### PR TITLE
Patch to stop using + inside Gem::Specification#hash

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -672,8 +672,7 @@ class Gem::Specification
 
   def hash # :nodoc:
     @@attributes.inject(0) { |hash_code, (name, default_value)|
-      n = self.send(name).hash
-      hash_code + n
+      hash_code ^ self.send(name).hash
     }
   end
 


### PR DESCRIPTION
This is a [pretty old bug](http://rubyforge.org/tracker/index.php?func=detail&aid=27154&group_id=126&atid=575) that seems to have been half-fixed. This is the other half of the patch in that bug report. Hopefully this will finally kill the overflow errors that some people using bundler [have been seeing](http://github.com/carlhuda/bundler/issues/issue/610). Thanks!
