### PR TITLE
Fix exception error message in Dependency#new

### DIFF
--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -54,7 +54,7 @@ class Gem::Dependency
 
     unless TYPES.include? type
       raise ArgumentError, "Valid types are #{TYPES.inspect}, "
-        + "not #{@type.inspect}"
+        + "not #{type.inspect}"
     end
 
     @name        = name


### PR DESCRIPTION
Gem::Dependency#new when given an invalid dependency type, was always printing 'nil' for the dependency type as it was attempting to display @type before it had been initialized.  Use the type parameter (which was the thing being checked) instead.

-Sam.
