### PR TITLE
Improved thread safety in remote fetcher

### DIFF
--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -243,7 +243,7 @@ class Gem::RemoteFetcher
       ]
     end
 
-    connection_id = net_http_args.join ':'
+    connection_id = [Thread.current.object_id, *net_http_args].join ':'
     @connections[connection_id] ||= Net::HTTP.new(*net_http_args)
     connection = @connections[connection_id]
 

--- a/test/test_gem_remote_fetcher.rb
+++ b/test/test_gem_remote_fetcher.rb
@@ -562,7 +562,7 @@ gems:
       end
     end
 
-    conn = { 'gems.example.com:80' => conn }
+    conn = { "#{Thread.current.object_id}:gems.example.com:80" => conn }
     fetcher.instance_variable_set :@connections, conn
 
     data = fetcher.open_uri_or_path 'http://gems.example.com/redirect'
@@ -581,7 +581,7 @@ gems:
       res
     end
 
-    conn = { 'gems.example.com:80' => conn }
+    conn = { "#{Thread.current.object_id}:gems.example.com:80" => conn }
     fetcher.instance_variable_set :@connections, conn
 
     e = assert_raises Gem::RemoteFetcher::FetchError do


### PR DESCRIPTION
The current process of caching connections in `@connections` causes problems across multiple threads, due to unexpected socket closing. By adding the current thread's ID to cache keys this problem may be avoided without affecting single-threaded applications.
