### PR TITLE
[#28806] Re-install of a gem can leave prior gem files remaining

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -300,8 +300,10 @@ class Gem::Installer
     @spec.executables.each do |filename|
       filename.untaint
       bin_path = File.expand_path "#{@spec.bindir}/#{filename}", @gem_dir
-      mode = File.stat(bin_path).mode | 0111
-      File.chmod mode, bin_path
+      if File.exist?(bin_path)
+        mode = File.stat(bin_path).mode | 0111
+        File.chmod mode, bin_path
+      end
 
       if @wrappers then
         generate_bin_script filename, bindir


### PR DESCRIPTION
This patch addresses the issue described in tracker [#28806](http://rubyforge.org/tracker/index.php?func=detail&aid=28806&group_id=126&atid=575) on rubyforge. In summary,
it assures that older same-version gem files are removed before a gem is installed.
