### PR TITLE
Remove underscores and dashes when finding suggestions

### DIFF
--- a/lib/rubygems/spec_fetcher.rb
+++ b/lib/rubygems/spec_fetcher.rb
@@ -187,14 +187,14 @@ class Gem::SpecFetcher
   # Suggests gems based on the supplied +gem_name+. Returns an array of
 	# alternative gem names.
   def suggest_gems_from_name gem_name
-    gem_name        = gem_name.downcase
+    gem_name        = gem_name.downcase.tr("_-", "")
     max             = gem_name.size / 2
     specs           = list.values.flatten(1) # flatten(1) is 1.8.7 and up
 
     matches = specs.map { |name, version, platform|
       next unless Gem::Platform.match platform
 
-      distance = levenshtein_distance gem_name, name.downcase
+      distance = levenshtein_distance gem_name, name.downcase.tr("_-", "")
 
       next if distance >= max
 


### PR DESCRIPTION
As documented in the [earlier pull request](https://github.com/rubygems/rubygems/pull/1#issuecomment-606410), this can sometimes provide faster and more accurate suggestions. In other cases, it can be slower.

I also took the liberty of correcting the method description and removing unused variables.

With this change:

```
$ time -p gem install rubydebug
ERROR:  Could not find a valid gem 'rubydebug' (>= 0) in any repository
ERROR:  Possible alternatives: ruby-debug
real 6.22  user 5.71  sys 0.11

$ time -p gem install active_support
ERROR:  Could not find a valid gem 'active_support' (>= 0) in any repository
ERROR:  Possible alternatives: activesupport
real 1.48  user 1.01  sys 0.08

$ time -p gem install RubyParser
ERROR:  Could not find a valid gem 'RubyParser' (>= 0) in any repository
ERROR:  Possible alternatives: ruby_parser
real 7.79  user 7.18  sys 0.06

$ time -p gem install ruby-purser
ERROR:  Could not find a valid gem 'ruby-purser' (>= 0) in any repository
ERROR:  Possible alternatives: ruby_parser, rubypulse, ruby-poker, rubypodder, rb-ruby_parser
real 10.24  user 9.67  sys 0.09
```

Without this change:

```
$ time -p gem install rubydebug
ERROR:  Could not find a valid gem 'rubydebug' (>= 0) in any repository
ERROR:  Possible alternatives: ruby-debug, rudebug, ruby-dbus, rubydbc, ruby-debug19
real 7.18  user 6.68  sys 0.10

$ time -p gem install active_support
ERROR:  Could not find a valid gem 'active_support' (>= 0) in any repository
ERROR:  Possible alternatives: activesupport, active_form, redis_support, bcms_support, active_wrapper
real 14.80  user 14.21  sys 0.11

$ time -p gem install RubyParser
ERROR:  Could not find a valid gem 'RubyParser' (>= 0) in any repository
ERROR:  Possible alternatives: ruby_parser, queryparser, rubypodder, rubypulse, rubylogparser
real 9.39  user 8.81  sys 0.13

$ time -p gem install ruby-purser
ERROR:  Could not find a valid gem 'ruby-purser' (>= 0) in any repository
ERROR:  Possible alternatives: ruby_parser, rubypulse, ruby-poker, rubypodder, ruby-beamer
real 10.39  user 9.67  sys 0.08
```
