### PR TITLE
Performance: only match first character for gem suggestions

### DIFF
--- a/lib/rubygems/spec_fetcher.rb
+++ b/lib/rubygems/spec_fetcher.rb
@@ -191,13 +191,17 @@ class Gem::SpecFetcher
 
   def suggest_gems_from_name gem_name
     gem_name        = gem_name.downcase
+    gem_starts_with = gem_name[0]
     max             = gem_name.size / 2
     specs           = list.values.flatten(1) # flatten(1) is 1.8.7 and up
 
     matches = specs.map { |name, version, platform|
       next unless Gem::Platform.match platform
 
-      distance = levenshtein_distance gem_name, name.downcase
+      name.downcase!
+      next unless name[0] == gem_starts_with
+
+      distance = levenshtein_distance gem_name, name
 
       next if distance >= max
 


### PR DESCRIPTION
First, thanks for accepting my patch. I like the changes made to it. However, the performance constraint which only considered gems that matched the first character didn't survive the change.

I originally introduced this because there is a noticeable delay generating the list of suggestions. Matching the first character seemed like a reasonable constraint as I figured most mistakes will not be in the first character.

Perhaps gem users won't dislike the lookup time, or perhaps there is a different idea on how to make this code faster.

Happy New Year, and thanks again for accepting my original patch.
