### PR TITLE
Add --format-executable support to gem uninstall

### DIFF
--- a/lib/rubygems/commands/uninstall_command.rb
+++ b/lib/rubygems/commands/uninstall_command.rb
@@ -49,6 +49,11 @@ class Gem::Commands::UninstallCommand < Gem::Command
       options[:user_install] = value
     end
 
+    add_option('--[no-]format-executable',
+               'Assume executable names match Ruby\'s prefix and suffix.') do |value, options|
+      options[:format_executable] = value
+    end
+
     add_version_option
     add_platform_option
   end

--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -38,6 +38,17 @@ class Gem::Uninstaller
 
   attr_reader :spec
 
+  class << self
+
+    attr_writer :exec_format
+
+    # Defaults to use Ruby's program prefix and suffix.
+    def exec_format
+      @exec_format ||= Gem.default_exec_format
+    end
+
+  end
+
   ##
   # Constructs an uninstaller that will uninstall +gem+
 
@@ -50,6 +61,7 @@ class Gem::Uninstaller
     @force_all = options[:all]
     @force_ignore = options[:ignore]
     @bin_dir = options[:bin_dir]
+    @format_executable = options[:format_executable]
 
     # only add user directory if install_dir is not set
     @user_install = false
@@ -155,8 +167,8 @@ class Gem::Uninstaller
 
       spec.executables.each do |exe_name|
         say "Removing #{exe_name}"
-        FileUtils.rm_f File.join(bindir, exe_name)
-        FileUtils.rm_f File.join(bindir, "#{exe_name}.bat")
+        FileUtils.rm_f File.join(bindir, formatted_program_filename(exe_name))
+        FileUtils.rm_f File.join(bindir, "#{formatted_program_filename(exe_name)}.bat")
       end
     end
   end
@@ -256,6 +268,15 @@ class Gem::Uninstaller
     msg << 'Continue with Uninstall?'
     return ask_yes_no(msg.join("\n"), true)
   end
+
+  def formatted_program_filename(filename)
+    if @format_executable then
+      self.class.exec_format % File.basename(filename)
+    else
+      filename
+    end
+  end
+
 
 end
 

--- a/test/rubygems/test_gem_commands_uninstall_command.rb
+++ b/test/rubygems/test_gem_commands_uninstall_command.rb
@@ -49,6 +49,26 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
     assert_equal false, File.exist?(@executable)
     assert_nil output.shift, "UI output should have contained only two lines"
   end
+  
+  def test_execute_removes_formatted_executable
+    FileUtils.rm_f @executable # Wish this didn't happen in #setup
+    
+    Gem::Installer.exec_format = 'foo-%s-bar'
+
+    @installer.format_executable = true
+    @installer.install
+
+    formatted_executable = File.join(@gemhome, 'bin', 'foo-executable-bar')
+    assert_equal true, File.exist?(@formatted_executable)
+    
+    @cmd.options[:format_executable] = true
+    @cmd.execute
+    
+    assert_equal false, File.exist?(@formatted_executable)
+    
+  rescue
+    Gem::Installer.exec_format = nil
+  end
 
   def test_execute_not_installed
     @cmd.options[:args] = ["foo"]

--- a/test/rubygems/test_gem_uninstaller.rb
+++ b/test/rubygems/test_gem_uninstaller.rb
@@ -81,6 +81,41 @@ class TestGemUninstaller < Gem::InstallerTestCase
     assert_equal "Removing my_exec\n", @ui.output
   end
 
+  def test_remove_executables_user_format
+    Gem::Uninstaller.exec_format = 'foo-%s-bar'
+
+    uninstaller = Gem::Uninstaller.new nil, :executables => true, :format_executable => true
+
+    use_ui @ui do
+      uninstaller.remove_executables @user_spec
+    end
+
+    exec_path = File.join Gem.user_dir, 'bin', 'foo-my_exec-bar'
+    assert_equal false, File.exist?(exec_path), 'removed exec from bin dir'
+
+    assert_equal "Removing my_exec\n", @ui.output
+  ensure
+    Gem::Uninstaller.exec_format = nil
+  end
+
+  def test_remove_executables_user_format_disabled
+    Gem::Uninstaller.exec_format = 'foo-%s-bar'
+
+    uninstaller = Gem::Uninstaller.new nil, :executables => true
+
+    use_ui @ui do
+      uninstaller.remove_executables @user_spec
+    end
+
+    exec_path = File.join Gem.user_dir, 'bin', 'my_exec'
+    assert_equal false, File.exist?(exec_path), 'removed exec from bin dir'
+
+    assert_equal "Removing my_exec\n", @ui.output
+  ensure
+    Gem::Uninstaller.exec_format = nil
+  end
+
+
   def test_path_ok_eh
     uninstaller = Gem::Uninstaller.new nil
 


### PR DESCRIPTION
Originally reported here:
http://rubyforge.org/tracker/index.php?func=detail&aid=25826&group_id=126&atid=575

As per that original ticket:

```
gem install --format-executable rake
==> Installs executable "rake18".

ln -s rake18 rake
==> This step is performed by most Linux distros.

gem uninstall rake
==> Asks whether to uninstall "rake", but not "rake18".
```

This patch fixes this.
