### PR TITLE
Fix for Windows style file:/// uris

### DIFF
--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -134,7 +134,7 @@ class Gem::RemoteFetcher
         path = source_uri.path
         path = File.dirname(path) if File.extname(path) == '.gem'
 
-        remote_gem_path = File.join(path, 'gems', gem_file_name)
+        remote_gem_path = correct_for_windows_path(File.join(path, 'gems', gem_file_name))
 
         FileUtils.cp(remote_gem_path, local_gem_path)
       rescue Errno::EACCES
@@ -270,6 +270,14 @@ class Gem::RemoteFetcher
     raise FetchError.new(e.message, uri)
   end
 
+  def correct_for_windows_path(path)
+    if path[0].chr == '/' && path[1].chr =~ /[a-zA-Z]/ && path[2].chr == ':'
+      path = path[1..-1]
+    else
+      path
+    end
+  end
+
   ##
   # Read the data from the (source based) URI, but if it is a file:// URI,
   # read from the filesystem instead.
@@ -287,13 +295,7 @@ class Gem::RemoteFetcher
     end
 
     if uri.scheme == 'file'
-      path = uri.path
-
-      # Deal with leading slash on Windows paths
-      if path[0].chr == '/' && path[1].chr =~ /[a-zA-Z]/ && path[2].chr == ':'
-         path = path[1..-1]
-      end
-
+      path = correct_for_windows_path(uri.path)
       return Gem.read_binary(path)
     end
 

--- a/lib/rubygems/spec_fetcher.rb
+++ b/lib/rubygems/spec_fetcher.rb
@@ -70,7 +70,8 @@ class Gem::SpecFetcher
   # Returns the local directory to write +uri+ to.
 
   def cache_dir(uri)
-    File.join @dir, "#{uri.host}%#{uri.port}", File.dirname(uri.path)
+    escaped_path = uri.path.sub(%r[^/([a-zA-z]):/], '/\\1-/') # Correct for windows paths
+    File.join @dir, "#{uri.host}%#{uri.port}", File.dirname(escaped_path)
   end
 
   ##

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -738,5 +738,13 @@ gems:
     end
   end
 
+  def test_correct_for_windows_path
+    path = "/C:/WINDOWS/Temp/gems"
+    assert_equal "C:/WINDOWS/Temp/gems", @fetcher.correct_for_windows_path(path)
+
+    path = "/home/skillet"
+    assert_equal "/home/skillet", @fetcher.correct_for_windows_path(path)
+  end
+
 end
 

--- a/test/rubygems/test_gem_spec_fetcher.rb
+++ b/test/rubygems/test_gem_spec_fetcher.rb
@@ -406,5 +406,10 @@ class TestGemSpecFetcher < Gem::TestCase
     assert_equal @latest_specs, latest_specs
   end
 
+  def test_cache_dir_escapes_windows_paths
+    uri = URI.parse("file:///C:/WINDOWS/Temp/gem_repo")
+    cache_dir = @sf.cache_dir(uri)
+    assert cache_dir !~ /:/, "#{cache_dir} should not contain a :"
+  end
 end
 


### PR DESCRIPTION
Hey everyone,

I've patched some erroneous handling of Window style file uris, and added what seem to be 'ok' tests. If you can think of a better test strategy for the stuff in remote_fetcher.rb, it'd be much appreciated.

I have tested these changes manually on a Windows box, and they do work properly there.

Trotter
