### PR TITLE
Option on latest_specs to include prerelease gems

### DIFF
--- a/lib/rubygems/source_index.rb
+++ b/lib/rubygems/source_index.rb
@@ -125,7 +125,7 @@ class Gem::SourceIndex
   # Returns an Array specifications for the latest released versions
   # of each gem in this index.
 
-  def latest_specs
+  def latest_specs(include_prerelease=false)
     result = Hash.new { |h,k| h[k] = [] }
     latest = {}
 
@@ -134,7 +134,7 @@ class Gem::SourceIndex
       curr_ver = spec.version
       prev_ver = latest.key?(name) ? latest[name].version : nil
 
-      next if curr_ver.prerelease?
+      next if !include_prerelease && curr_ver.prerelease?
       next unless prev_ver.nil? or curr_ver >= prev_ver or
                   latest[name].platform != Gem::Platform::RUBY
 

--- a/test/rubygems/test_gem_source_index.rb
+++ b/test/rubygems/test_gem_source_index.rb
@@ -300,6 +300,7 @@ end
     @source_index.add_spec gem_a1_alpha
 
     refute @source_index.latest_specs.include?(gem_a1_alpha)
+    assert @source_index.latest_specs(true).include?(gem_a1_alpha)
     assert @source_index.find_name(gem_a1_alpha.full_name).empty?
     assert @source_index.prerelease_specs.include?(gem_a1_alpha)
   end


### PR DESCRIPTION
Does what the subject says. SourceIndex#latest_specs currently doesn't include pre gems and there is no trivial way to implement this outside of RubyGems without basically redoing the latest_specs code. This adds a simply boolean flag to do it.

Mitchell
