### PR TITLE
Fix script generation on Windows

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -292,7 +292,7 @@ class Gem::Installer
 
     FileUtils.rm_f bin_script_path # prior install may have been --no-wrappers
 
-    File.open bin_script_path, 'w', 0755 do |file|
+    File.open bin_script_path, 'wb', 0755 do |file|
       file.print app_script_text(filename)
     end
 


### PR DESCRIPTION
If we write out the script in non-binary mode, newlines will be generated as \r\n on Windows.  This causes /bin/sh to add \r to the command line run with exec, which you don’t want it to do.  So don’t do that.
