### PR TITLE
Make Gem::SilentUI use silent download and progress reporters.

### DIFF
--- a/lib/rubygems/user_interaction.rb
+++ b/lib/rubygems/user_interaction.rb
@@ -525,9 +525,7 @@ end
 # SilentUI is a UI choice that is absolutely silent.
 
 class Gem::SilentUI < Gem::StreamUI
-
   def initialize
-
     reader, writer = nil, nil
 
     begin
@@ -541,5 +539,12 @@ class Gem::SilentUI < Gem::StreamUI
     super reader, writer, writer
   end
 
+  def download_reporter(*args)
+    SilentDownloadReporter.new(@outs, *args)
+  end
+
+  def progress_reporter(*args)
+    SilentProgressReporter.new(@outs, *args)
+  end
 end
 


### PR DESCRIPTION
Bundler::UI::RGProxy extends Gem::SilentUI but does not call super, so its streams are not initialized, resulting in the error below. Bundler has already fixed this for 1.0.10, but it also seems good to be more explicit about silent reporters in the silent UI.

```
/Users/nicksieger/Projects/ruby/jruby/lib/ruby/site_ruby/1.8/rubygems/user_interaction.rb:503:in `update_display': undefined method `tty?' for nil:NilClass (NoMethodError)
    from /Users/nicksieger/Projects/ruby/jruby/lib/ruby/site_ruby/1.8/rubygems/user_interaction.rb:478:in `fetch'
    from /Users/nicksieger/Projects/ruby/jruby/lib/ruby/site_ruby/1.8/rubygems/remote_fetcher.rb:366:in `request'
    from /Users/nicksieger/Projects/ruby/jruby/lib/ruby/1.8/net/http.rb:1054:in `request'
    from /Users/nicksieger/Projects/ruby/jruby/lib/ruby/1.8/net/http.rb:2142:in `reading_body'
    from /Users/nicksieger/Projects/ruby/jruby/lib/ruby/1.8/net/http.rb:1053:in `request'
    from /Users/nicksieger/Projects/ruby/jruby/lib/ruby/site_ruby/1.8/rubygems/remote_fetcher.rb:364:in `request'
    from /Users/nicksieger/Projects/ruby/jruby/lib/ruby/site_ruby/1.8/rubygems/remote_fetcher.rb:306:in `open_uri_or_path'
    from /Users/nicksieger/Projects/ruby/jruby/lib/ruby/site_ruby/1.8/rubygems/remote_fetcher.rb:315:in `open_uri_or_path'
    from /Users/nicksieger/Projects/ruby/jruby/lib/ruby/site_ruby/1.8/rubygems/remote_fetcher.rb:181:in `fetch_path'
    from /Users/nicksieger/Projects/ruby/jruby/lib/ruby/site_ruby/1.8/rubygems/remote_fetcher.rb:119:in `download'
    from /Users/nicksieger/.rvm/gems/jruby-head@rails-test/gems/bundler-1.0.7/lib/bundler/source.rb:254:in `download_gem_from_uri'
    from /Users/nicksieger/.rvm/gems/jruby-head@rails-test/gems/bundler-1.0.7/lib/bundler/source.rb:71:in `fetch'
    from /Users/nicksieger/.rvm/gems/jruby-head@rails-test/gems/bundler-1.0.7/lib/bundler/installer.rb:45:in `run'
    from /Users/nicksieger/.rvm/gems/jruby-head@rails-test/gems/bundler-1.0.7/lib/bundler/spec_set.rb:12:in `each'
    from org/jruby/RubyArray.java:1676:in `each'
    from /Users/nicksieger/.rvm/gems/jruby-head@rails-test/gems/bundler-1.0.7/lib/bundler/spec_set.rb:12:in `each'
    from /Users/nicksieger/.rvm/gems/jruby-head@rails-test/gems/bundler-1.0.7/lib/bundler/installer.rb:44:in `run'
    from /Users/nicksieger/.rvm/gems/jruby-head@rails-test/gems/bundler-1.0.7/lib/bundler/installer.rb:8:in `install'
    from /Users/nicksieger/.rvm/gems/jruby-head@rails-test/gems/bundler-1.0.7/lib/bundler/cli.rb:271:in `update'
    from org/jruby/RubyKernel.java:2039:in `send'
    from /Users/nicksieger/.rvm/gems/jruby-head@rails-test/gems/bundler-1.0.7/lib/bundler/vendor/thor/task.rb:21:in `run'
    from /Users/nicksieger/.rvm/gems/jruby-head@rails-test/gems/bundler-1.0.7/lib/bundler/vendor/thor/invocation.rb:118:in `invoke_task'
    from /Users/nicksieger/.rvm/gems/jruby-head@rails-test/gems/bundler-1.0.7/lib/bundler/vendor/thor.rb:246:in `dispatch'
    from /Users/nicksieger/.rvm/gems/jruby-head@rails-test/gems/bundler-1.0.7/lib/bundler/vendor/thor/base.rb:389:in `start'
    from /Users/nicksieger/.rvm/gems/jruby-head@rails-test/gems/bundler-1.0.7/bin/bundle:13:in `(root)'
```
