### PR TITLE
Turn off ri and rdoc generation by default

### DIFF
--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -19,8 +19,8 @@ class Gem::Commands::InstallCommand < Gem::Command
 
   def initialize
     defaults = Gem::DependencyInstaller::DEFAULT_OPTIONS.merge({
-      :generate_rdoc     => true,
-      :generate_ri       => true,
+      :generate_rdoc     => false,
+      :generate_ri       => false,
       :format_executable => false,
       :version           => Gem::Requirement.default,
     })
@@ -39,7 +39,7 @@ class Gem::Commands::InstallCommand < Gem::Command
   end
 
   def defaults_str # :nodoc:
-    "--both --version '#{Gem::Requirement.default}' --rdoc --ri --no-force\n" \
+    "--both --version '#{Gem::Requirement.default}' --no-rdoc --no-ri --no-force\n" \
     "--install-dir #{Gem.dir}"
   end
 

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -15,8 +15,8 @@ class Gem::Commands::UpdateCommand < Gem::Command
   def initialize
     super 'update',
           'Update the named gems (or all installed gems) in the local repository',
-      :generate_rdoc => true,
-      :generate_ri   => true,
+      :generate_rdoc => false,
+      :generate_ri   => false,
       :force         => false
 
     add_install_update_options
@@ -44,7 +44,7 @@ class Gem::Commands::UpdateCommand < Gem::Command
   end
 
   def defaults_str # :nodoc:
-    "--rdoc --ri --no-force --install-dir #{Gem.dir}"
+    "--no-rdoc --no-ri --no-force --install-dir #{Gem.dir}"
   end
 
   def usage # :nodoc:

--- a/lib/rubygems/install_update_options.rb
+++ b/lib/rubygems/install_update_options.rb
@@ -121,7 +121,7 @@ module Gem::InstallUpdateOptions
   # Default options for the gem install command.
 
   def install_update_defaults_str
-    '--rdoc --no-force --wrappers'
+    '--no-rdoc --no-force --wrappers'
   end
 
 end


### PR DESCRIPTION
Hi guys,

It seems like everyone and their mother has --no-ri and --no-rdoc in their .gemrc file. Any objections to pulling that convention upstream?
