### PR TITLE
Disable the generation of RDoc upon Gem install/update, but leave RI generation enabled.

### DIFF
--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -19,7 +19,7 @@ class Gem::Commands::InstallCommand < Gem::Command
 
   def initialize
     defaults = Gem::DependencyInstaller::DEFAULT_OPTIONS.merge({
-      :generate_rdoc     => true,
+      :generate_rdoc     => false,
       :generate_ri       => true,
       :format_executable => false,
       :version           => Gem::Requirement.default,
@@ -39,7 +39,7 @@ class Gem::Commands::InstallCommand < Gem::Command
   end
 
   def defaults_str # :nodoc:
-    "--both --version '#{Gem::Requirement.default}' --rdoc --ri --no-force\n" \
+    "--both --version '#{Gem::Requirement.default}' --ri --no-rdoc --no-force\n" \
     "--install-dir #{Gem.dir}"
   end
 

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -15,7 +15,7 @@ class Gem::Commands::UpdateCommand < Gem::Command
   def initialize
     super 'update',
           'Update the named gems (or all installed gems) in the local repository',
-      :generate_rdoc => true,
+      :generate_rdoc => false,
       :generate_ri   => true,
       :force         => false
 
@@ -44,7 +44,7 @@ class Gem::Commands::UpdateCommand < Gem::Command
   end
 
   def defaults_str # :nodoc:
-    "--rdoc --ri --no-force --install-dir #{Gem.dir}"
+    "--ri --no-rdoc --no-force --install-dir #{Gem.dir}"
   end
 
   def usage # :nodoc:

--- a/lib/rubygems/install_update_options.rb
+++ b/lib/rubygems/install_update_options.rb
@@ -121,7 +121,7 @@ module Gem::InstallUpdateOptions
   # Default options for the gem install command.
 
   def install_update_defaults_str
-    '--rdoc --no-force --wrappers'
+    '--no-rdoc --no-force --wrappers'
   end
 
 end


### PR DESCRIPTION
While I agree with @drbrain and @raggi that the disabling of documentation generation for installed/updated RubyGems is a rash one, I recognize it is motivated by the time/CPU usage incurred by RDoc. However, I still believe that the generation of RI indexes should be left enabled. RI is much faster than RDoc and is very useful to developers who need to quickly lookup the documentation for an installed Class/Module.
