### PR TITLE
Fix the problem Gem::Version#initialize modifies parameter object 

### DIFF
--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -187,8 +187,7 @@ class Gem::Version
     raise ArgumentError, "Malformed version number string #{version}" unless
       self.class.correct?(version)
 
-    @version = version.to_s
-    @version.strip!
+    @version = version.to_s.strip
   end
 
   ##

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -56,7 +56,7 @@ class TestGemVersion < Gem::TestCase
   end
 
   def test_initialize
-    ["1.0", "1.0 ", " 1.0 ", "1.0\n", "\n1.0\n"].each do |good|
+    ["1.0", "1.0 ", " 1.0 ", "1.0\n", "\n1.0\n", "1.0".freeze].each do |good|
       assert_version_equal "1.0", good
     end
 


### PR DESCRIPTION
In Gem::Version#initialization: 
When `version` is `String`, #to_s returns the original string and #strip! modifies that.
This causes two problems:
- When `version` is a frozen string, a exception will be thrown.
- The string will be modified while it's unexcepted for caller.

Fixed that and added a test case. 
