### PR TITLE
re-enable has_rdoc for YARD and to allow gems to opt-out of documentation generation.

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1393,17 +1393,15 @@ class Gem::Specification
   attribute_alias_singular :test_file, :test_files
 
   ##
-  # has_rdoc is now ignored
-
-  overwrite_accessor :has_rdoc do
-    true
-  end
-
-  ##
-  # has_rdoc is now ignored
+  # Allow has_rdoc to specify the type of documentation.
 
   overwrite_accessor :has_rdoc= do |value|
-    @has_rdoc = true
+    case value
+    when String, Symbol
+      @has_rdoc = value.to_s
+    else
+      @has_rdoc = value ? true : false
+    end
   end
 
   overwrite_accessor :version= do |version|


### PR DESCRIPTION
Re-enable `has_rdoc` accessor for projects such as [YARD](http://github.com/lsegal/yard#readme), which use `has_rdoc` to specify the documentation format. This patch also allows meta-gems (gems which contain no code) to opt-out of documentation generation.

I wasn't able to update the tests, as I could not even get the tests to run out-of-the-box:

<pre>
$ rake test --trace
(in /home/hal/src/ruby/rubygems)
rake aborted!
undefined method `_unresolved' for Gem:Module
/home/hal/src/ruby/rubygems/lib/rubygems/gem_path_searcher.rb:48:in `find'
/home/hal/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems.rb:213:in `try_activate'
<internal:lib/rubygems/custom_require>:32:in `rescue in require'
<internal:lib/rubygems/custom_require>:29:in `require'
/home/hal/src/ruby/rubygems/Rakefile:12:in `<top (required)>'
</pre>
