### PR TITLE
Using the presence or absence of a constant called "Encoding" is brittle

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -505,7 +505,7 @@ class Gem::Specification
 
     file = file.dup.untaint
 
-    code = if defined? Encoding
+    code = if Config::CONFIG['MAJOR'] == '1' && Config::CONFIG['MINOR'] == '9'
              File.read file, :encoding => "UTF-8"
            else
              File.read file


### PR DESCRIPTION
Instead of checking for the presence of a constant called "Encoding" which anyone can define (and the gem character-encodings in fact does), this should really check for Ruby 1.9, since that is the only place that using encodings with IO::read really makes sense.

I discovered this by doing (in Ruby 1.8):

```
irb(main):001:0> require 'rubygems'
false
irb(main):002:0> require 'encoding/character/utf-8'
true
irb(main):003:0> require 'uuid'
TypeError: can't convert Hash into Integer
        from /Users/ballancopatch/.rvm/rubies/ree-1.8.7-2010.02/lib/ruby/site_ruby/1.8/rubygems/specification.rb:509:in `read'
        from /Users/ballancopatch/.rvm/rubies/ree-1.8.7-2010.02/lib/ruby/site_ruby/1.8/rubygems/specification.rb:509:in `load'
        from /Users/ballancopatch/.rvm/gems/ree-1.8.7-2011.01/gems/uuid-2.3.1/lib/uuid.rb:63
        from /Users/ballancopatch/.rvm/rubies/ree-1.8.7-2010.02/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:32:in `gem_original_require'
        from /Users/ballancopatch/.rvm/rubies/ree-1.8.7-2010.02/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:32:in `require'
        from (irb):3
```

This is because the uuid gem calls, rather unwisely, Gem::Specification#load on it's own gemspec to get the gem version at runtime. (BTW, I have also filed a pull request against the uuid gem.)
