### PR TITLE
double space fix for native extension build output

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -479,7 +479,7 @@ TEXT
 
   def build_extensions
     return if @spec.extensions.empty?
-    say "Building native extensions.  This could take a while..."
+    say "Building native extensions. This could take a while..."
     dest_path = File.join @gem_dir, @spec.require_paths.first
     ran_rake = false # only run rake once
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -54,7 +54,7 @@ load Gem.bin_path('a', 'executable', version)
 
     assert_match(/\AERROR: Failed to build gem native extension.$/, e.message)
 
-    assert_equal "Building native extensions.  This could take a while...\n",
+    assert_equal "Building native extensions. This could take a while...\n",
                  @ui.output
     assert_equal '', @ui.error
 
@@ -78,7 +78,7 @@ load Gem.bin_path('a', 'executable', version)
 
     assert_match(/^\s*No builder for extension ''$/, e.message)
 
-    assert_equal "Building native extensions.  This could take a while...\n",
+    assert_equal "Building native extensions. This could take a while...\n",
                  @ui.output
     assert_equal '', @ui.error
 


### PR DESCRIPTION
I removed a space from the native extension build output. This looks strange to me. If it was intended, just forget about this pull request.
