### PR TITLE
Allow date format where month and day can be without leading zero 

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1422,7 +1422,7 @@ class Gem::Specification
     # way to do it.
     @date = case date
             when String then
-              if /\A(\d{4})-(\d{2})-(\d{2})\Z/ =~ date then
+              if /\A(\d{4})-(\d{1,2})-(\d{1,2})\Z/ =~ date then
                 Time.utc($1.to_i, $2.to_i, $3.to_i)
               else
                 raise(Gem::InvalidSpecificationException,

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -351,6 +351,16 @@ end
     assert_equal Time.utc(2003, 9, 17, 0,0,0), @a1.date
   end
 
+  def test_date_equals_string_where_month_without_leading_zeroes
+    @a1.date = '2003-9-17'
+    assert_equal Time.utc(2003, 9, 17, 0,0,0), @a1.date
+  end
+
+  def test_date_equals_string_where_day_without_leading_zeroes
+    @a1.date = '2003-08-1'
+    assert_equal Time.utc(2003, 8, 1, 0,0,0), @a1.date
+  end
+
   def test_date_equals_string_bad
     assert_raises Gem::InvalidSpecificationException do
       @a1.date = '9/11/2003'


### PR DESCRIPTION
[9b37225be3b9eb7667cb](https://github.com/rubygems/rubygems/commit/9b37225be3b9eb7667cb2f9ad16ab62dbb06d0e9) - drops support for dates in time format. While this is certainly welcome, can we at least support dates without leading zero for month/day. I've already stumbled on it with jammit specification and I bet there are more examples.

![pull this, please](http://images1.memegenerator.net/ImageMacro/6905928/PULL-THIS-PRETTY-PLEASE.jpg?imageSize=Medium&generatorName=Hipster-Mermaid)
