### PR TITLE
Trivial patch to avoid issues with custom require being called with a Pathname instance.

### DIFF
--- a/lib/rubygems/custom_require.rb
+++ b/lib/rubygems/custom_require.rb
@@ -32,6 +32,9 @@ module Kernel
   # that file has already been loaded is preserved.
 
   def require path
+    # Convert the passed object into a string in case the path is a Pathname 
+    # for instance.
+    path = path.to_s
     if Gem.unresolved_deps.empty? or Gem.loaded_path? path then
       gem_original_require path
     else


### PR DESCRIPTION
Gem.loaded_path? tries to use Regexp.escape to escape the passed path, but that fails if a Pathname instance is being passed. This patch avoids this problem by converting the passed path into a string before processing it.

"fixed custom require to handle Pathname instance properly and not fail when checking against the loaded_path? regexp"
