### PR TITLE
Fix for Gem.loaded_path? with a Pathname instance.

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -943,7 +943,7 @@ module Gem
   def self.loaded_path? path
     # TODO: ruby needs a feature to let us query what's loaded in 1.8 and 1.9
     $LOADED_FEATURES.find { |s|
-      s =~ /(^|\/)#{Regexp.escape path}#{Regexp.union(*Gem.suffixes)}$/
+      s =~ /(^|\/)#{Regexp.escape path.to_s}#{Regexp.union(*Gem.suffixes)}$/
     }
   end
 


### PR DESCRIPTION
Handle the case where Gem.loaded_path? receives a non string argument such as an instance of Pathname.
