### PR TITLE
Fix invalid specs resulting from incorrect syck time parsing

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1447,7 +1447,7 @@ class Gem::Specification
     # way to do it.
     @date = case date
             when String then
-              if /\A(\d{4})-(\d{2})-(\d{2})\Z/ =~ date then
+              if /\A(\d{4})-(\d{2})-(\d{2})(\s|\Z)/ =~ date then
                 Time.utc($1.to_i, $2.to_i, $3.to_i)
               else
                 raise(Gem::InvalidSpecificationException,


### PR DESCRIPTION
Fix for a bug where invalid gemspecs are being generated when a gem is built with psych but read using syck.

To reproduce the issue:
- Ensure psych is available in your ruby installation.
- Build a gem. The gem's manifest should have a date of a format similar to "`2011-04-26 00:00:00.000000000Z`". If the date in the manifest has a format similar to "`2011-04-26 00:00:00 Z`", it means psych wasn't available and syck was used to generate the manifest.
- Switch to a ruby installation that lacks psych (or manually remove psych from your ruby installation by removing both psych.rb and psych.{so,bundle}).
- Install the gem you just built.
- Check the generated gemspec for the installed gem. The date will appear formatted like "`%q{2011-04-26 00:00:00.000000000Z}`". This is incorrect; it should be formatted like "`%q{2011-04-26}`".
- Now, any operation that reads the generated gemspec (for example, gem list) will fail. Indeed, it will not be possible to uninstall the gem until you manually fix the generated gemspec.

(These steps were reproduced on Snow Leopard, ruby 1.9.2-p180, with the built-in psych atop libyaml 0.1.3.)

The reason for this behavior is that syck is incapable of parsing certain timestamp formats, and unfortunately, among those is the format that psych outputs by default. Thus, a ruby using syck will fail to properly read the manifest of a gem built by a ruby using psych.

The fix involves two commits:
- Commit e886aa4d11951753c97eb031b4768b153b2bf912 fixes the problem at the source, preventing the generation of further bad gemspec files. It modifies the code that parses the manifest, and checks the @date field to see if it failed to parse properly into a timestamp (in which case it will appear as a string instead). In this case, it manually converts it to the proper Time object.
- Commit c3ac5a8a6ab4255c511e703e1e467727e681a7a8 implements some damage control for bad gemspecs already written. It loosens the format restrictions for the gemspec date field, hence restoring operation for users already bitten by the bug.

I believe this is a critical issue to fix because it can put a user's gem installation in an inconsistent state that they cannot fix otherwise without manual edits to the generated gemspec files.
