### PR TITLE
String#basename doesn't exist.

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -421,7 +421,7 @@ module Gem
 
   def self.each_load_path(partials)
     partials.each do |gp|
-      base = gp.basename
+      base = File.basename(gp)
       specfn = dir.specifications.add(base + ".gemspec")
       if specfn.exist?
         spec = eval(specfn.read)
@@ -598,7 +598,7 @@ module Gem
   def self.latest_partials(gemdir)
     latest = {}
     all_partials(gemdir).each do |gp|
-      base = gp.basename
+      base = File.basename(gp)
 
       if base.to_s =~ /(.*)-((\d+\.)*\d+)/ then
         name, version = $1, $2


### PR DESCRIPTION
I got the "undefined method `basename' for #String:0x000001011927b8 (NoMethodError)" error, so I started to dig the code and now I believe this was forgotten in this commit: https://github.com/rubygems/rubygems/commit/f33345d6e62af339299d873d03cd3cfd14f9c989
