### PR TITLE
fix typo in 5113945: avoid use of instance_variables.include?

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -488,7 +488,7 @@ class Gem::Specification
       raise Gem::Exception, "YAML data doesn't evaluate to gem specification"
     end
 
-    spec.instance_eval { @specification ||= NONEXISTENT_SPECIFICATION_VERSION }
+    spec.instance_eval { @specification_version ||= NONEXISTENT_SPECIFICATION_VERSION }
 
     spec
   end


### PR DESCRIPTION
My original patch in #50 had a typo. Sorry.

(I missed it because b3db1a6 in #50 passes all tests!)
