### PR TITLE
Fix SecurityError: Insecure operation - file? when calling Gem::Specification.load under $SAFE >= 1

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -518,9 +518,9 @@ class Gem::Specification
   # Loads Ruby format gemspec from +file+.
 
   def self.load file
-    return unless file && File.file?(file)
-
+    return unless file
     file = file.dup.untaint
+    return unless File.file?(file)
 
     code = if defined? Encoding
              File.read file, :encoding => "UTF-8"

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -141,6 +141,21 @@ end
     assert_equal @a2, spec
   end
 
+  def test_self_load_tainted
+    full_path = @a2.spec_file
+    write_file full_path do |io|
+      io.write @a2.to_ruby_for_cache
+    end
+
+    full_path.taint
+    loader = Thread.new { $SAFE = 1; Gem::Specification.load full_path }
+    spec = loader.value
+
+    @a2.files.clear
+
+    assert_equal @a2, spec
+  end
+
   def test_self_load_legacy_ruby
     spec = Deprecate.skip_during do
       eval LEGACY_RUBY_SPEC


### PR DESCRIPTION
`Gem::Specification.load` calls `File.file?` with its argument before untainting it, causing it to raise a `SecurityError` under `$SAFE >= 1` if the argument is tainted. 

This patch adds a test for the condition, and fixes it by moving the `File.file?` test after the argument is duped and untainted.
