### PR TITLE
Fix typo in uninstall message

### DIFF
--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -255,7 +255,7 @@ class Gem::Uninstaller
          "[#{dep.name} (#{dep.requirement})]")
     end
 
-    msg << 'If you remove this gems, one or more dependencies will not be met.'
+    msg << 'If you remove this gem, one or more dependencies will not be met.'
     msg << 'Continue with Uninstall?'
     return ask_yes_no(msg.join("\n"), true)
   end


### PR DESCRIPTION
This is the same patch as https://github.com/rubygems/rubygems/pull/52, minus the asshattery.
