### PR TITLE
Doc Change: Command Manager example code should look like example gem

### DIFF
--- a/lib/rubygems/command_manager.rb
+++ b/lib/rubygems/command_manager.rb
@@ -18,11 +18,14 @@ require 'rubygems/user_interaction'
 #   # file rubygems_plugin.rb
 #   require 'rubygems/command_manager'
 #
+#   Gem::CommandManager.instance.register_command :edit
+#
+# You should put the implementation of your command in rubygems/commands.
+#
+#   # file rubygems/commands/edit_command.rb
 #   class Gem::Commands::EditCommand < Gem::Command
 #     # ...
 #   end
-#
-#   Gem::CommandManager.instance.register_command :edit
 #
 # See Gem::Command for instructions on writing gem commands.
 


### PR DESCRIPTION
the graph gem plugin puts it's command in `lib/rubygems/commands/graph_command.rb`, which makes it safe to load repeatedly if multiple versions of the gem are installed. This patch changes the example plugin command code to reflect that structure.
