### PR TITLE
added possibility of suppressing deprecation warnings

### DIFF
--- a/lib/rubygems/deprecate.rb
+++ b/lib/rubygems/deprecate.rb
@@ -58,7 +58,12 @@ module Deprecate
                 ". It will be removed on or after %4d-%02d-01." % [year, month],
                 "\n#{target}#{name} called from #{Gem.location_of_caller.join(":")}",
               ]
-        warn "#{msg.join}." unless Deprecate.skip
+        # Having "NOTE: Gem::Specification#default_executable= is deprecated with no replacement. It will be removed on or after 2011-10-01."
+        # on servers is really useless. My development environment will tell me which gems use deprecated stuff. I would like my tasks
+        # run in crontabs to be quiet. Even if a task completes succesfully, I still get an email now, because of all that deprecation
+        # cruft.
+        warn "#{msg.join}." unless Deprecate.skip ||
+                                   (ENV['RUBYGEMS_SUPPRESS_DEPRECATION_WARNINGS'] || '') =~ /(^|,)(#{target}#{name}|\*)(,|$)/
         send old, *args, &block
       end
     }

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1039,6 +1039,29 @@ end
     end
   end
 
+  def test_default_executable_deprecation_warning
+    ENV["RUBYGEMS_SUPPRESS_DEPRECATION_WARNINGS"] = "*"
+    output = util_catch_stderr do
+      Gem::Specification.new.default_executable = 'dummy'
+    end
+    
+    assert output.split("\n").grep(/Gem::Specification#default_executable= is deprecated/).empty?
+
+    ENV["RUBYGEMS_SUPPRESS_DEPRECATION_WARNINGS"] = "Gem::Specification#default_executable="
+    output = util_catch_stderr do
+      Gem::Specification.new.default_executable = 'dummy'
+    end
+    
+    assert output.split("\n").grep(/Gem::Specification#default_executable= is deprecated/).empty?
+
+    ENV.delete("RUBYGEMS_SUPPRESS_DEPRECATION_WARNINGS")
+    output = util_catch_stderr do
+      Gem::Specification.new.default_executable = 'dummy'
+    end
+
+    assert !output.split("\n").grep(/Gem::Specification#default_executable= is deprecated/).empty?
+  end
+
   def test_validate_description
     util_setup_validate
 
@@ -1418,6 +1441,18 @@ end
         fp.puts "#!#{Gem.ruby}"
       end
     end
+  end
+  
+  def util_catch_stderr
+    old_stderr = $stderr
+    output = String.new
+    $stderr = StringIO.new(output, "w+")
+    
+    yield
+    
+    $stderr.close
+    $stderr = old_stderr
+    output
   end
 
   def with_syck


### PR DESCRIPTION
Hi, I didn't see any option for suppressing deprecation warnings, so I thought I'd add the option.

Two reasons:
- I run rails rake tasks from cron using whenever. Cron emails non-empty output, so in most cases I shouldn't get any. With these deprecation warnings, I now get emails for every task that gets run, amounting to 1310 emails since 11 am CET.
- My apache/passenger logs are clogged up with these messages as well, but in my role as sysadmin I don't really care about a gem using a deprecated field in its specification. Only in my role as developer it will have my interest.
