### PR TITLE
add option -n for cleanup command to automatically skip gems having dependants

### DIFF
--- a/lib/rubygems/commands/cleanup_command.rb
+++ b/lib/rubygems/commands/cleanup_command.rb
@@ -13,6 +13,14 @@ class Gem::Commands::CleanupCommand < Gem::Command
     add_option('-d', '--dryrun', "") do |value, options|
       options[:dryrun] = true
     end
+
+    # add_option('-y', '--yes', "Force to uninstall gems having dependants") do |value, options|
+    #  options[:pre_opted] = true
+    # end
+
+    add_option('-n', '--no', "Do not uninstall gems having dependants") do |value, options|
+      options[:pre_opted] = false
+    end
   end
 
   def arguments # :nodoc:
@@ -82,6 +90,9 @@ installed elsewhere in GEM_PATH the cleanup command won't touch it.
           :executables => false,
           :version => "= #{spec.version}",
         }
+
+        pre_opted = options[:pre_opted]
+        uninstall_options[:pre_opted] = pre_opted unless pre_opted.nil?
 
         if Gem.user_dir == spec.installation_path then
           uninstall_options[:install_dir] = spec.installation_path

--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -50,6 +50,7 @@ class Gem::Uninstaller
     @force_all = options[:all]
     @force_ignore = options[:ignore]
     @bin_dir = options[:bin_dir]
+    @pre_opted = options[:pre_opted]
 
     # only add user directory if install_dir is not set
     @user_install = false
@@ -244,6 +245,7 @@ class Gem::Uninstaller
   end
 
   def ask_if_ok(spec)
+    return @pre_opted unless @pre_opted.nil?
     msg = ['']
     msg << 'You have requested to uninstall the gem:'
     msg << "\t#{spec.full_name}"


### PR DESCRIPTION
This is to rescue the accidentally died pull-request [#36](https://github.com/rubygems/rubygems/pull/36)

> I'm just tired of keeping pushing the `N` key to prevent gems from being removed if they still have dependants. Using the new option `-n` will make `gem cleanup` automatically skip them. 
> 
> The bug was previously reported as [ticket #28919 on rubyforge](http://rubyforge.org/tracker/index.php?func=detail&aid=28919&group_id=126&atid=577).
> 
> BTW, I commented off the option '-y', thinking it's too risky, not sure if it's possible to make it a hidden option.
