### PR TITLE
fixed minor typo in History.txt ("1.8.5 / 2011-05-31" item)

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,9 +1,8 @@
-<<<<<<< HEAD
 === 1.8.5 / 2011-05-31
 
 * 2 minor enhancement:
 
-  * The -u option to 'update local source cache' is official deprecated.
+  * The -u option to 'update local source cache' is officially deprecated.
   * Remove has_rdoc deprecations from Specification.
 
 * 2 bug fixes:


### PR DESCRIPTION
Fixed minor typo in History.txt ("1.8.5 / 2011-05-31" item) and removed orphaned merge conflict delimiter.

Thanks for your work.

/g
## 

George Anderson

BenevolentCode LLC
george@benevolentcode.com
