### PR TITLE
Hundreds of repeated instances of "Gem::SourceIndex#add_spec is deprecated"

### DIFF
--- a/lib/rubygems/deprecate.rb
+++ b/lib/rubygems/deprecate.rb
@@ -31,6 +31,15 @@ module Gem
       @skip = v
     end
 
+    def self.did_warn_about(name, for_caller)
+      @did_warn_about ||= Hash.new { |h,k| h[k] = 0 }
+
+      warning_count =
+        @did_warn_about[[ name, for_caller ]] += 1
+
+      warning_count > 1
+    end
+
     ##
     # Temporarily turn off warnings. Intended for tests only.
 
@@ -59,7 +68,9 @@ module Gem
             ". It will be removed on or after %4d-%02d-01." % [year, month],
             "\n#{target}#{name} called from #{Gem.location_of_caller.join(":")}",
           ]
-          warn "#{msg.join}." unless Gem::Deprecate.skip
+          unless (Deprecate.skip or Deprecate.did_warn_about(name, caller[0]))
+            warn "#{msg.join}." 
+          end
           send old, *args, &block
         end
       }


### PR DESCRIPTION
This small patch tracks what callers triggered what deprecation warnings and will warn once only per instance.

One of the problems here is that `add_spec` is inside a loop in the `add_specs` implementation. You will get hit with a heap of warnings that appear to originate from rubygems, but actually come from outside, such as `bundler-1.0.14`.

Sample output from before:

```
Gem::SourceIndex#add_specs called from /opt/local/rvm/gems/ruby-1.9.2-p180/gems/bundler-1.0.14/lib/bundler/rubygems_integration.rb:176.
NOTE: Gem::SourceIndex#add_spec is deprecated, use Specification.add_spec. It will be removed on or after 2011-11-01.
Gem::SourceIndex#add_spec called from /opt/local/rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/source_index.rb:197.
NOTE: Gem::SourceIndex#add_spec is deprecated, use Specification.add_spec. It will be removed on or after 2011-11-01.
Gem::SourceIndex#add_spec called from /opt/local/rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/source_index.rb:197.
NOTE: Gem::SourceIndex#add_spec is deprecated, use Specification.add_spec. It will be removed on or after 2011-11-01.
Gem::SourceIndex#add_spec called from /opt/local/rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/source_index.rb:197.
NOTE: Gem::SourceIndex#add_spec is deprecated, use Specification.add_spec. It will be removed on or after 2011-11-01.
Gem::SourceIndex#add_spec called from /opt/local/rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/source_index.rb:197.
NOTE: Gem::SourceIndex#add_spec is deprecated, use Specification.add_spec. It will be removed on or after 2011-11-01.
Gem::SourceIndex#add_spec called from /opt/local/rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/source_index.rb:197.
NOTE: Gem::SourceIndex#add_spec is deprecated, use Specification.add_spec. It will be removed on or after 2011-11-01.
Gem::SourceIndex#add_spec called from /opt/local/rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/source_index.rb:197.
NOTE: Gem::SourceIndex#add_spec is deprecated, use Specification.add_spec. It will be removed on or after 2011-11-01.
Gem::SourceIndex#add_spec called from /opt/local/rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/source_index.rb:197.
NOTE: Gem::SourceIndex#add_spec is deprecated, use Specification.add_spec. It will be removed on or after 2011-11-01.
Gem::SourceIndex#add_spec called from /opt/local/rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/source_index.rb:197.
NOTE: Gem::SourceIndex#add_spec is deprecated, use Specification.add_spec. It will be removed on or after 2011-11-01.
Gem::SourceIndex#add_spec called from /opt/local/rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/source_index.rb:197.
NOTE: Gem::SourceIndex#add_spec is deprecated, use Specification.add_spec. It will be removed on or after 2011-11-01.
Gem::SourceIndex#add_spec called from /opt/local/rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/source_index.rb:197.
NOTE: Gem::SourceIndex#add_spec is deprecated, use Specification.add_spec. It will be removed on or after 2011-11-01.
Gem::SourceIndex#add_spec called from /opt/local/rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/source_index.rb:197.
NOTE: Gem::SourceIndex#add_spec is deprecated, use Specification.add_spec. It will be removed on or after 2011-11-01.
Gem::SourceIndex#add_spec called from /opt/local/rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/source_index.rb:197.
NOTE: Gem::SourceIndex#add_spec is deprecated, use Specification.add_spec. It will be removed on or after 2011-11-01.
```

This actually continues.

Sample output after:

```
NOTE: Gem::SourceIndex#add_specs is deprecated with no replacement. It will be removed on or after 2011-11-01.
Gem::SourceIndex#add_specs called from /opt/local/rvm/gems/ruby-1.9.2-p180/gems/bundler-1.0.14/lib/bundler/rubygems_integration.rb:176.
NOTE: Gem::SourceIndex#add_spec is deprecated, use Specification.add_spec. It will be removed on or after 2011-11-01.
Gem::SourceIndex#add_spec called from /opt/local/rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/source_index.rb:197.
```
