### PR TITLE
Move .rb to the beginning of the suffixes list.

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -995,8 +995,8 @@ module Gem
   # Suffixes for require-able paths.
 
   def self.suffixes
-    @suffixes ||= ['',
-                   '.rb',
+    @suffixes ||= ['.rb',
+                   '',
                    *%w(DLEXT DLEXT2).map { |key|
                      val = RbConfig::CONFIG[key]
                      next unless val and not val.empty?


### PR DESCRIPTION
Move .rb to the beginning of the suffixes list.  require without rb extension is more common, so this should reduce the iterations in `contains_requirable_file?`.
