### PR TITLE
Added missing APPLE_GEM_HOME in paths.

### DIFF
--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -67,8 +67,8 @@ class Gem::PathSupport
     else
       gem_path = Gem.default_path + [@home]
 
-      if defined?(Gem::APPLE_GEM_HOME)
-        gem_path << Gem::APPLE_GEM_HOME
+      if defined?(APPLE_GEM_HOME)
+        gem_path << APPLE_GEM_HOME
       end
     end
 


### PR DESCRIPTION
On a Mac, using the system Ruby, `gem env` gives:

```
RubyGems Environment:
  - RUBYGEMS VERSION: 1.8.5
  - RUBY VERSION: 1.8.7 (2009-06-12 patchlevel 174) [universal-darwin10.0]
  - INSTALLATION DIRECTORY: /Library/Ruby/Gems/1.8
  - RUBY EXECUTABLE: /System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby
  - EXECUTABLE DIRECTORY: /usr/bin
  - RUBYGEMS PLATFORMS:
    - ruby
    - universal-darwin-10
  - GEM PATHS:
     - /Library/Ruby/Gems/1.8
     - /Users/emanuele/.gem/ruby/1.8
  - GEM CONFIGURATION:
     - :update_sources => true
     - :verbose => true
     - :benchmark => false
     - :backtrace => false
     - :bulk_threshold => 1000
  - REMOTE SOURCES:
     - http://rubygems.org/
```

Note that the Apple's system directory is missing from GEM PATHS section and pre-installed gems are not available. With the proposed fix, `gem env` gives:

```
RubyGems Environment:
  - RUBYGEMS VERSION: 1.8.5
  - RUBY VERSION: 1.8.7 (2009-06-12 patchlevel 174) [universal-darwin10.0]
  - INSTALLATION DIRECTORY: /Library/Ruby/Gems/1.8
  - RUBY EXECUTABLE: /System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby
  - EXECUTABLE DIRECTORY: /usr/bin
  - RUBYGEMS PLATFORMS:
    - ruby
    - universal-darwin-10
  - GEM PATHS:
     - /Library/Ruby/Gems/1.8
     - /Users/emanuele/.gem/ruby/1.8
     - /System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/gems/1.8
  - GEM CONFIGURATION:
     - :update_sources => true
     - :verbose => true
     - :benchmark => false
     - :backtrace => false
     - :bulk_threshold => 1000
  - REMOTE SOURCES:
     - http://rubygems.org/
```

Apple's system directory is back and pre-installed gems are available again.
