### PR TITLE
Extend YAML::Syck::DefaultKey fixing to `marshal_dump` as well.

### DIFF
--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -129,18 +129,15 @@ class Gem::Requirement
   end
 
   def marshal_dump # :nodoc:
+    fix_syck_default_key_in_requirements!
+
     [@requirements]
   end
 
   def marshal_load array # :nodoc:
     @requirements = array[0]
 
-    # Fixup the Syck DefaultKey bug
-    @requirements.each do |r|
-      if r[0].kind_of? YAML::Syck::DefaultKey
-        r[0] = "="
-      end
-    end
+    fix_syck_default_key_in_requirements!
   end
 
   def prerelease?
@@ -179,6 +176,17 @@ class Gem::Requirement
 
   def <=> other # :nodoc:
     to_s <=> other.to_s
+  end
+
+  private
+
+  def fix_syck_default_key_in_requirements!
+    # Fixup the Syck DefaultKey bug
+    @requirements.each do |r|
+      if r[0].kind_of? YAML::Syck::DefaultKey
+        r[0] = "="
+      end
+    end
   end
 end
 


### PR DESCRIPTION
I'm running into a problem on our internal gems repo where built-gem
metadata is being uploaded with unquoted `=`'s. When `gem
generate_index` is run, the metadata is loaded which turns the
`=` into DefaultKey. That's then marshaled out as part of the quick
specs which breaks clients that try to load them.

Applying the same fix to `marshal_dump` let quick specs be generated
that didn't have DefaultKey refs in them even though the incoming
gem specs were broken.
