### PR TITLE
Replace usage of the term "spermy" with "approximate".

### DIFF
--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -129,8 +129,8 @@
 # specify your dependency as ">= 2.0.0" then, you're good, right? What
 # happens if fnord 3.0 comes out and it isn't backwards compatible
 # with 2.y.z? Your stuff will break as a result of using ">=". The
-# better route is to specify your dependency with a "spermy" version
-# specifier. They're a tad confusing, so here is how the dependency
+# better route is to specify your dependency with an "approximate" version
+# specifier ("~>"). They're a tad confusing, so here is how the dependency
 # specifiers work:
 #
 #   Specification From  ... To (exclusive)
@@ -273,7 +273,7 @@ class Gem::Version
   ##
   # A recommended version for use with a ~> Requirement.
 
-  def spermy_recommendation
+  def approximate_recommendation
     segments = self.segments.dup
 
     segments.pop    while segments.any? { |s| String === s }

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -106,13 +106,13 @@ class TestGemVersion < Gem::TestCase
     assert_nil v("1.0") <=> "whatever"
   end
 
-  def test_spermy_recommendation
-    assert_spermy_equal "~> 1.0", "1"
-    assert_spermy_equal "~> 1.0", "1.0"
-    assert_spermy_equal "~> 1.2", "1.2"
-    assert_spermy_equal "~> 1.2", "1.2.0"
-    assert_spermy_equal "~> 1.2", "1.2.3"
-    assert_spermy_equal "~> 1.2", "1.2.3.a.4"
+  def test_approximate_recommendation
+    assert_approximate_equal "~> 1.0", "1"
+    assert_approximate_equal "~> 1.0", "1.0"
+    assert_approximate_equal "~> 1.2", "1.2"
+    assert_approximate_equal "~> 1.2", "1.2.0"
+    assert_approximate_equal "~> 1.2", "1.2.3"
+    assert_approximate_equal "~> 1.2", "1.2.3.a.4"
   end
 
   def test_to_s
@@ -125,10 +125,10 @@ class TestGemVersion < Gem::TestCase
     assert v(version).prerelease?, "#{version} is a prerelease"
   end
 
-  # Assert that +expected+ is the "spermy" recommendation for +version".
+  # Assert that +expected+ is the "approximate" recommendation for +version".
 
-  def assert_spermy_equal expected, version
-    assert_equal expected, v(version).spermy_recommendation
+  def assert_approximate_equal expected, version
+    assert_equal expected, v(version).approximate_recommendation
   end
 
   # Assert that bumping the +unbumped+ version yields the +expected+.


### PR DESCRIPTION
- The "spermy" or "twiddle wakka" operator (~>) is similar to the
  greater-equal-then (>=) version operator, except that it matches
  families of versions. This version operator also uses a Tilde character,
  which is commonly used to denote approximate values
  (See definition 2.b http://www.merriam-webster.com/dictionary/tilde).
