### PR TITLE
fix SystemStackError occurring with "gem list -r -a" on 1.9

### DIFF
--- a/lib/rubygems/spec_fetcher.rb
+++ b/lib/rubygems/spec_fetcher.rb
@@ -169,7 +169,7 @@ class Gem::SpecFetcher
 
     found.each do |source_uri, specs|
       uri_str = source_uri.to_s
-      specs_and_sources.push(*specs.map { |spec| [spec, uri_str] })
+      specs_and_sources.concat(specs.map { |spec| [spec, uri_str] })
     end
 
     [specs_and_sources, errors]


### PR DESCRIPTION
A [number of users](https://github.com/rubygems/gemcutter/issues/319) have been getting this error when trying to list all the remote gemspecs from gemcutter (~ 131,600). I've confirmed this happens on ruby 1.9.2 and rubygems 1.6.2 and 1.8.5. I debugged the offending line and found that only after 130,000 specs would this error get thrown. The concat fixes this issue as it's functionally equivalent and seemingly more performant.
