### PR TITLE
Unbreak gem specification loading if Encoding.default_internal = 'ISO-8859-1'

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -900,7 +900,7 @@ class Gem::Specification
     return unless File.file?(file)
 
     code = if defined? Encoding
-             File.read file, :encoding => "UTF-8"
+             File.read file, :mode => 'r:UTF-8:-'
            else
              File.read file
            end

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -308,6 +308,29 @@ bindir:
     assert_equal @a2, spec
   end
 
+  if defined?(Encoding)
+  def test_self_load_utf8_with_ascii_encoding
+    int_enc = Encoding.default_internal
+    Encoding.default_internal = 'US-ASCII'
+    
+    spec2 = @a2.dup
+    bin = "\u5678"
+    spec2.authors = [bin]
+    full_path = spec2.spec_file
+    write_file full_path do |io|
+      io.write spec2.to_ruby_for_cache.force_encoding('BINARY').sub("\\u{5678}", bin.force_encoding('BINARY'))
+    end
+
+    spec = Gem::Specification.load full_path
+
+    spec2.files.clear
+
+    assert_equal spec2, spec
+  ensure
+    Encoding.default_internal = int_enc
+  end
+  end
+
   def test_self_load_legacy_ruby
     spec = Gem::Deprecate.skip_during do
       eval LEGACY_RUBY_SPEC


### PR DESCRIPTION
Unbreak gem specification loading if Encoding.default_internal = 'ISO-8859-1' (or other encoding) and there are characters in the gem specification that aren't supported by that encoding.  If you just use the :encoding option, that sets the external encoding, and ruby will automatically attempt to convert it to the default internal encoding if it is set and different from the external encoding.  Using the :mode option with both encodings set means that no conversion is attempted, allowing you to load gems that contain characters that aren't supported by the default internal encoding.
