### PR TITLE
fix for calculating none in requirement initialize

### DIFF
--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -112,8 +112,10 @@ class Gem::Requirement
     requirements.compact!
     requirements.uniq!
 
-    requirements << ">= 0" if requirements.empty?
-    @none = (requirements == ">= 0")
+    if requirements.empty?
+      requirements << ">= 0"
+      @none = true
+    end
     @requirements = requirements.map! { |r| self.class.parse r }
   end
 


### PR DESCRIPTION
Was digging around to get a better idea of the code base and ran across this.  I believe `@none` is intended to be memoized here to save the calculation later, but since `requirements` ought to be an array it will always evaluate to false.  This should fix it to set none if the requirements are empty, which I believe is the intention, in a manner that is hopefully a bit clearer and explicit.

Note, since `@none` is memoized this worked regardless of always being false.  It would simply replace the false with the calculated version.  This should prevent the extra lookup by setting the value up front.  I'm sure its only a pretty minuscule performance difference, but it makes things less confusing (for me at least).

Thanks!
