### PR TITLE
leave default requirement to dependency init

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -769,8 +769,6 @@ class Gem::Specification
   # Returns every spec that matches +name+ and optional +requirements+.
 
   def self.find_all_by_name name, *requirements
-    requirements = Gem::Requirement.default if requirements.empty?
-
     # TODO: maybe try: find_all { |s| spec === dep }
 
     Gem::Dependency.new(name, *requirements).matching_specs
@@ -781,8 +779,6 @@ class Gem::Specification
   # if the dependency doesn't resolve to a valid specification.
 
   def self.find_by_name name, *requirements
-    requirements = Gem::Requirement.default if requirements.empty?
-
     # TODO: maybe try: find { |s| spec === dep }
 
     Gem::Dependency.new(name, *requirements).to_spec
@@ -1158,11 +1154,7 @@ class Gem::Specification
   # <tt>:development</tt>.
 
   def add_dependency_with_type(dependency, type, *requirements)
-    requirements = if requirements.empty? then
-                     Gem::Requirement.default
-                   else
-                     requirements.flatten
-                   end
+    requirements = requirements.flatten
 
     unless dependency.respond_to?(:name) &&
       dependency.respond_to?(:version_requirements)


### PR DESCRIPTION
Rather than checking for empty requirements and replacing them with a
default requirement, we can instead just pass the empty requirement set.
By default a dependency with an empty requirements list will add the
default requirement anyway, so seems better to let it do its thing.
