### PR TITLE
Attempt to activate psych before requiring it

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -644,7 +644,7 @@ module Gem
 
   def self.load_yaml
     begin
-      gem 'psych' unless ENV['TEST_SYCK']
+      gem 'psych', '~> 1.2.0' unless ENV['TEST_SYCK']
     rescue Gem::LoadError
       # It's OK if the user does not have the psych gem installed.  We will
       # attempt to require the stdlib version


### PR DESCRIPTION
Rubygems should attempt to activate the psych gem before requiring psych.  That way people can install the psych gem and rubygems will use it.
