### PR TITLE
Hide custom_require in backtrace

### DIFF
--- a/lib/rubygems/custom_require.rb
+++ b/lib/rubygems/custom_require.rb
@@ -101,6 +101,7 @@ module Kernel
       return gem_original_require(path)
     end
 
+    load_error.set_backtrace caller(2)
     raise load_error
   end
 


### PR DESCRIPTION
This cleans up the 2 references to `custom_require.rb` in the backtrace that happens when you `require 'nonexistent/file'`. Seems like a cheap win to me.
