### PR TITLE
fix for obtaining api key from rubygems.org during sign in (issue #172)

### DIFF
--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -37,10 +37,14 @@ module Gem::GemcutterUtilities
     response = rubygems_api_request :get, "api/v1/api_key" do |request|
       request.basic_auth email, password
     end
-
+    
     with_response response do |resp|
-      say "Signed in."
-      Gem.configuration.rubygems_api_key = resp.body
+      if resp.body =~ /"rubygems_api_key"\s*:\s*"([a-z0-9]+)"/
+        say "Signed in."
+        Gem.configuration.rubygems_api_key = $1
+      else
+        say "Unable to parse api response."
+      end
     end
   end
 


### PR DESCRIPTION
Since it doesn't seem there is any JSON support in rubygems, to avoid adding an additional dependency, this is a simple patch that will parse the API key from the response using RegExp. It should be solid enough in the sense that it should still work even if you add more keys to the response hash.
