### PR TITLE
Removing \Z on Specification#date= method

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1301,7 +1301,7 @@ class Gem::Specification
     # way to do it.
     @date = case date
             when String then
-              if /\A(\d{4})-(\d{2})-(\d{2})\Z/ =~ date then
+              if /\A(\d{4})-(\d{2})-(\d{2})/ =~ date then
                 Time.utc($1.to_i, $2.to_i, $3.to_i)
               else
                 raise(Gem::InvalidSpecificationException,


### PR DESCRIPTION
Does the date regex have to strictly matched at the end of string? Eliminating \Z will solve the 'invalid date format in specification: "2011-08-25 00:00:00.000000000Z"' problem.
