### PR TITLE
Backport "Escape strings in ruby-format..." security fix to 1.7 branch

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -998,11 +998,11 @@ class Gem::Specification
 
   def ruby_code(obj)
     case obj
-    when String            then '%q{' + obj + '}'
-    when Array             then obj.inspect
-    when Gem::Version      then obj.to_s.inspect
-    when Date              then '%q{' + obj.strftime('%Y-%m-%d') + '}'
-    when Time              then '%q{' + obj.strftime('%Y-%m-%d') + '}'
+    when String            then obj.dump
+    when Array             then '[' + obj.map { |x| ruby_code x }.join(", ") + ']'
+    when Gem::Version      then obj.to_s.dump
+    when Date              then obj.strftime('%Y-%m-%d').dump
+    when Time              then obj.strftime('%Y-%m-%d').dump
     when Numeric           then obj.inspect
     when true, false, nil  then obj.inspect
     when Gem::Platform     then "Gem::Platform.new(#{obj.to_a.inspect})"

--- a/test/rubygems/test_gem_commands_specification_command.rb
+++ b/test/rubygems/test_gem_commands_specification_command.rb
@@ -131,7 +131,7 @@ class TestGemCommandsSpecificationCommand < Gem::TestCase
     end
 
     assert_match %r|Gem::Specification.new|, @ui.output
-    assert_match %r|s.name = %q\{foo\}|, @ui.output
+    assert_match %r|s.name = "foo"|, @ui.output
     assert_equal '', @ui.error
   end
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -128,6 +128,54 @@ end
     assert_equal @a2, spec
   end
 
+  def test_self_load_escape_curly
+    @a2.name = 'a};raise "improper escaping";%q{'
+
+    full_path = File.join @gemhome, 'specifications', @a2.spec_name
+    path      = File.join "specifications", @a2.spec_name
+    write_file path do |io|
+      io.write @a2.to_ruby_for_cache
+    end
+
+    spec = Gem::Specification.load full_path
+
+    @a2.files.clear
+
+    assert_equal @a2, spec
+  end
+
+  def test_self_load_escape_interpolation
+    @a2.name = 'a#{raise %<improper escaping>}'
+
+    full_path = File.join @gemhome, 'specifications', @a2.spec_name
+    path      = File.join "specifications", @a2.spec_name
+    write_file path do |io|
+      io.write @a2.to_ruby_for_cache
+    end
+
+    spec = Gem::Specification.load full_path
+
+    @a2.files.clear
+
+    assert_equal @a2, spec
+  end
+
+  def test_self_load_escape_quote
+    @a2.name = 'a";raise "improper escaping";"'
+
+    full_path = File.join @gemhome, 'specifications', @a2.spec_name
+    path      = File.join "specifications", @a2.spec_name
+    write_file path do |io|
+      io.write @a2.to_ruby_for_cache
+    end
+
+    spec = Gem::Specification.load full_path
+
+    @a2.files.clear
+
+    assert_equal @a2, spec
+  end
+
   def test_self_load_legacy_ruby
     spec = Deprecate.skip_during do
       eval LEGACY_RUBY_SPEC
@@ -763,19 +811,19 @@ end
 # -*- encoding: utf-8 -*-
 
 Gem::Specification.new do |s|
-  s.name = %q{a}
-  s.version = \"2\"
+  s.name = "a"
+  s.version = "2"
 
   s.required_rubygems_version = Gem::Requirement.new(\"> 0\") if s.respond_to? :required_rubygems_version=
-  s.authors = [\"A User\"]
-  s.date = %q{#{Gem::Specification::TODAY.strftime "%Y-%m-%d"}}
-  s.description = %q{This is a test description}
-  s.email = %q{example@example.com}
-  s.files = [\"lib/code.rb\"]
-  s.homepage = %q{http://example.com}
-  s.require_paths = [\"lib\"]
-  s.rubygems_version = %q{#{Gem::VERSION}}
-  s.summary = %q{this is a summary}
+  s.authors = ["A User"]
+  s.date = "#{Gem::Specification::TODAY.strftime "%Y-%m-%d"}"
+  s.description = "This is a test description"
+  s.email = "example@example.com"
+  s.files = ["lib/code.rb"]
+  s.homepage = "http://example.com"
+  s.require_paths = ["lib"]
+  s.rubygems_version = "#{Gem::VERSION}"
+  s.summary = "this is a summary"
 
   if s.respond_to? :specification_version then
     s.specification_version = #{Gem::Specification::CURRENT_SPECIFICATION_VERSION}
@@ -810,18 +858,18 @@ end
 # -*- encoding: utf-8 -*-
 
 Gem::Specification.new do |s|
-  s.name = %q{a}
-  s.version = \"2\"
+  s.name = "a"
+  s.version = "2"
 
   s.required_rubygems_version = Gem::Requirement.new(\"> 0\") if s.respond_to? :required_rubygems_version=
-  s.authors = [\"A User\"]
-  s.date = %q{#{Gem::Specification::TODAY.strftime "%Y-%m-%d"}}
-  s.description = %q{This is a test description}
-  s.email = %q{example@example.com}
-  s.homepage = %q{http://example.com}
-  s.require_paths = [\"lib\"]
-  s.rubygems_version = %q{#{Gem::VERSION}}
-  s.summary = %q{this is a summary}
+  s.authors = ["A User"]
+  s.date = "#{Gem::Specification::TODAY.strftime "%Y-%m-%d"}"
+  s.description = "This is a test description"
+  s.email = "example@example.com"
+  s.homepage = "http://example.com"
+  s.require_paths = ["lib"]
+  s.rubygems_version = "#{Gem::VERSION}"
+  s.summary = "this is a summary"
 
   if s.respond_to? :specification_version then
     s.specification_version = #{Gem::Specification::CURRENT_SPECIFICATION_VERSION}
@@ -857,26 +905,26 @@ end
 # -*- encoding: utf-8 -*-
 
 Gem::Specification.new do |s|
-  s.name = %q{a}
-  s.version = \"1\"
+  s.name = "a"
+  s.version = "1"
   s.platform = Gem::Platform.new(#{expected_platform})
 
   s.required_rubygems_version = Gem::Requirement.new(\">= 0\") if s.respond_to? :required_rubygems_version=
-  s.authors = [\"A User\"]
-  s.date = %q{#{Gem::Specification::TODAY.strftime "%Y-%m-%d"}}
-  s.description = %q{This is a test description}
-  s.email = %q{example@example.com}
-  s.executables = [\"exec\"]
-  s.extensions = [\"ext/a/extconf.rb\"]
-  s.files = [\"lib/code.rb\", \"test/suite.rb\", \"bin/exec\", \"ext/a/extconf.rb\"]
-  s.homepage = %q{http://example.com}
-  s.licenses = [\"MIT\"]
-  s.require_paths = [\"lib\"]
-  s.requirements = [\"A working computer\"]
-  s.rubyforge_project = %q{example}
-  s.rubygems_version = %q{#{Gem::VERSION}}
-  s.summary = %q{this is a summary}
-  s.test_files = [\"test/suite.rb\"]
+  s.authors = ["A User"]
+  s.date = "#{Gem::Specification::TODAY.strftime "%Y-%m-%d"}"
+  s.description = "This is a test description"
+  s.email = "example@example.com"
+  s.executables = ["exec"]
+  s.extensions = ["ext/a/extconf.rb"]
+  s.files = ["lib/code.rb", "test/suite.rb", "bin/exec", "ext/a/extconf.rb"]
+  s.homepage = "http://example.com"
+  s.licenses = ["MIT"]
+  s.require_paths = ["lib"]
+  s.requirements = ["A working computer"]
+  s.rubyforge_project = "example"
+  s.rubygems_version = "#{Gem::VERSION}"
+  s.summary = "this is a summary"
+  s.test_files = ["test/suite.rb"]
 
   if s.respond_to? :specification_version then
     s.specification_version = 3


### PR DESCRIPTION
Original commit made to 'master' branch:
https://github.com/rubygems/rubygems/commit/81a6f40374fd7339cd124023d266ce9e2ae34c37

**Alterations to original commit:**
- Array case in lib/rubygems/specification.rb was updated in 1.8.x branch before the vulnerability was discovered.  The change, however removed the call to inspect which fixed part of the vulnerability without anyone noticing.  Had to address this vulnerability separately.
- The 1.8.x branch introduced metadata into Gem::Specification.  Removed tests against the metadata attribute.
- `write_file` method in test_case.rb behaves differently in 1.7 branch.  Changed tests to reflect.
- `spec_file` method doesn't exist in 1.7 branch.  Changed tests to use conventioned used in similar tests.

Please consider making another minor release to the 1.7 branch for people who are using rails 2.3 and are being encouraged to downgrade back to 1.7.2 when they encounter the wall of deprecation warnings and are afraid to upgrade rails at this point in time:
https://github.com/rubygems/rubygems/issues/84#issuecomment-1904557

Buy everyone a bit more time to upgrade rails?
