### PR TITLE
Syck compatibility with Ruby 1.9.2

### DIFF
--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -130,7 +130,6 @@ end
   end
 
   def test_self_from_yaml_syck_default_key_bug
-    skip 'syck default_key bug is only for ruby 1.8' unless RUBY_VERSION < '1.9'
     # This is equivalent to (and totally valid) psych 1.0 output and
     # causes parse errors on syck.
     yaml = <<-YAML


### PR DESCRIPTION
@laserlemon and I have updated Delayed Job to support/be compatible with Psych so that we could help get Rubygems.org updated to use Psych as its YAML parser and prevent these DefaultKeys.

We've submitted a pull request to rubygems.org containing an update, but when testing against Ruby 1.9.2 using Syck, we ran into `uninitialized constant Syck::Syck` errors which appear to be originating from `#fix_syck_default_key_in_requirements`.

Changing the conditional in `#fix_syck_default_key_in_requirements` allows for the Ruby 1.9 & Syck combination (or anomaly).

Hope this helps!
