### PR TITLE
Make license/licenses field mandatory in gemspec during the build

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2295,6 +2295,11 @@ class Gem::Specification
       end
     end
 
+    if licenses.empty? then
+      raise Gem::InvalidSpecificationException,
+            'specification must define at least one license'
+    end
+
     licenses.each { |license|
       if license.length > 64
         raise Gem::InvalidSpecificationException,


### PR DESCRIPTION
as discussed in this thread:
http://rubyforge.org/pipermail/rubygems-developers/2011-October/006828.html
