### PR TITLE
Remove unused block arguments to avoid creating Proc objects.

### DIFF
--- a/lib/rubygems/dependency_list.rb
+++ b/lib/rubygems/dependency_list.rb
@@ -213,7 +213,7 @@ class Gem::DependencyList
     @specs.each(&block)
   end
 
-  def tsort_each_child(node, &block)
+  def tsort_each_child(node)
     specs = @specs.sort.reverse
 
     dependencies = node.runtime_dependencies

--- a/lib/rubygems/package/tar_input.rb
+++ b/lib/rubygems/package/tar_input.rb
@@ -16,7 +16,7 @@ class Gem::Package::TarInput
 
   private_class_method :new
 
-  def self.open(io, security_policy = nil,  &block)
+  def self.open(io, security_policy = nil)
     is = new io, security_policy
 
     yield is


### PR DESCRIPTION
I propose that unused block arguments should be removed. 
It creates unnecessary Proc objects.

I applied similar patches to standard libraries in ruby-trunk(r33638).

Thanks
