### PR TITLE
Raise a more specific error for illformed requirements

### DIFF
--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -46,9 +46,9 @@ class Gem::Requirement
 
   quoted  = OPS.keys.map { |k| Regexp.quote k }.join "|"
   PATTERN = /\A\s*(#{quoted})?\s*(#{Gem::Version::VERSION_PATTERN})\s*\z/
-  
+
   class IllformedRequirementError < ArgumentError; end
-  
+
   ##
   # Factory method to create a Gem::Requirement object.  Input may be
   # a Version, a String, or nil.  Intended to simplify client code.

--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -48,7 +48,7 @@ class TestGemRequirement < Gem::TestCase
     end
 
     assert_equal 'Illformed requirement [""]', e.message
-    
+
     assert_equal Gem::Requirement::IllformedRequirementError.superclass, ArgumentError
   end
 


### PR DESCRIPTION
I recently ran into the following error after making a typo in my Gemfile:

```
Unfortunately, a fatal error has occurred. Please report this error to the Bundler issue tracker at https://github.com/carlhuda/bundler/issues so that we can fix it. Thanks!
/Users/ahkoppel2/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/site_ruby/1.9.1/rubygems/requirement.rb:98:in `parse': Illformed requirement [">~ 3.0"] (ArgumentError)
```

Bundler ought to be giving a clearer message here -- Rubygems has identified the problem, and no amount of Github issues will fix it.  Unfortunately, there's currently no way for Bundler to distinguish illformed requirements from any other ArgumentError without parsing the text of the error message, which isn't an ideal approach.

This is a pretty small commit (with tests) that creates a IllformedRequirementError < ArgumentError class, and raises that as appropriate.  I'll submit a pull request to Bundler either way (using the error message initially) and if this gets accepted, I'll update that to use the new error class.

Thanks for the great work!

Best,

Alex
