### PR TITLE
match RUBYGEMS_HOST env variable with credential key

### DIFF
--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -19,6 +19,8 @@ module Gem::GemcutterUtilities
   def api_key
     if options[:key] then
       verify_api_key options[:key]
+    elsif (host = ENV['RUBYGEMS_HOST']) && Gem.configuration.api_keys.key?(host)
+      Gem.configuration.api_keys[host]
     else
       Gem.configuration.rubygems_api_key
     end

--- a/test/rubygems/test_gem_gemcutter_utilities.rb
+++ b/test/rubygems/test_gem_gemcutter_utilities.rb
@@ -15,6 +15,25 @@ class TestGemGemcutterUtilities < Gem::TestCase
     @cmd.extend Gem::GemcutterUtilities
   end
 
+  def test_alternate_key_alternate_host
+    keys = {
+      :rubygems_api_key => 'KEY',
+      "http://rubygems.engineyard.com" => "EYKEY"
+    }
+
+    FileUtils.mkdir_p File.dirname Gem.configuration.credentials_path
+
+    open Gem.configuration.credentials_path, 'w' do |f|
+      f.write keys.to_yaml
+    end
+
+    ENV["RUBYGEMS_HOST"] = "http://rubygems.engineyard.com"
+
+    Gem.configuration.load_api_keys
+
+    assert_equal 'EYKEY', @cmd.api_key
+  end
+
   def test_api_key
     keys = { :rubygems_api_key => 'KEY' }
     FileUtils.mkdir_p File.dirname Gem.configuration.credentials_path


### PR DESCRIPTION
This prevents having to specify a --key argument with every push by checking the credential file for a key matching the provided host name.
