### PR TITLE
add host variable to gem spec

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -120,6 +120,7 @@ require "rubygems/deprecate"
 
 module Gem
   VERSION = '1.8.10'
+  DEFAULT_HOST = "https://rubygems.org"
 
   ##
   # Raised when RubyGems is unable to load or activate a gem.  Contains the
@@ -570,7 +571,7 @@ module Gem
 
   def self.host
     # TODO: move to utils
-    @host ||= "https://rubygems.org"
+    @host ||= Gem::DEFAULT_HOST
   end
 
   ## Set the default RubyGems API host.

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -19,7 +19,7 @@ module Gem::GemcutterUtilities
   def api_key
     if options[:key] then
       verify_api_key options[:key]
-    elsif (host = ENV['RUBYGEMS_HOST']) && Gem.configuration.api_keys.key?(host)
+    elsif Gem.configuration.api_keys.key?(host)
       Gem.configuration.api_keys[host]
     else
       Gem.configuration.rubygems_api_key
@@ -46,10 +46,15 @@ module Gem::GemcutterUtilities
     end
   end
 
-  def rubygems_api_request(method, path, host = Gem.host, &block)
+  attr_writer :host
+  def host
+    @host ||= ENV['RUBYGEMS_HOST'] || Gem.host
+  end
+
+  def rubygems_api_request(method, path, host = nil, &block)
     require 'net/http'
-    host = ENV['RUBYGEMS_HOST'] if ENV['RUBYGEMS_HOST']
-    uri = URI.parse "#{host}/#{path}"
+    self.host = host if host
+    uri = URI.parse "#{self.host}/#{path}"
 
     request_method = Net::HTTP.const_get method.to_s.capitalize
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -67,6 +67,7 @@ class Gem::Specification
   #                          Now forward-compatible with future versions
   #      3  1.3.2 2009-01-03 Added Fixnum validation to specification_version
   #      4  1.9.0 2011-06-07 Added metadata
+  #      5  1.9.0 2011-11-18 Added host
   #--
   # When updating this number, be sure to also update #to_ruby.
   #
@@ -148,6 +149,7 @@ class Gem::Specification
     :summary                   => nil,
     :test_files                => [],
     :version                   => nil,
+    :host                      => Gem::DEFAULT_HOST
   }
 
   @@attributes = @@default_value.keys.sort_by { |s| s.to_s }
@@ -373,6 +375,20 @@ class Gem::Specification
   # data that could be useful to other consumers.
 
   attr_accessor :metadata
+
+  ##
+  # :attr_accessor: host
+  #
+  # Specify the default host to push this gem to.
+  #
+  # This specifies the host for pushing gems to. It defaults to Gem::DEFAULT_HOST
+  # and can be overridden by the RUBYGEMS_HOST environment variable.
+  #
+  # Usage:
+  #
+  #   spec.host = "rubygems.engineyard.com"
+
+  attr_accessor :host
 
   ##
   # Adds a development dependency named +gem+ with +requirements+ to this

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -78,6 +78,7 @@ end
       extra_rdoc_files
       files
       homepage
+      host
       licenses
       metadata
       name


### PR DESCRIPTION
Making it possible to set a default host in the gemspec that gem push will pick up on.

Also aligned that host with an API key set in credentials file. (As made possible by 02c83001d6d7027c807e2a3fb3d44a1d515ce52e)
