### PR TITLE
Allow group writable if umask allows it already.

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -446,7 +446,7 @@ module Gem
     require 'fileutils'
 
     old_umask = File.umask
-    File.umask old_umask | 022
+    File.umask old_umask | 002
 
     %w[cache doc gems specifications].each do |name|
       subdir = File.join dir, name

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -614,8 +614,8 @@ class TestGem < Gem::TestCase
     File.umask 0
     Gem.ensure_gem_subdirectories @gemhome
 
-    assert_equal 0, File::Stat.new(@gemhome).mode & 022
-    assert_equal 0, File::Stat.new(File.join(@gemhome, "cache")).mode & 022
+    assert_equal 0, File::Stat.new(@gemhome).mode & 002
+    assert_equal 0, File::Stat.new(File.join(@gemhome, "cache")).mode & 002
   ensure
     File.umask old_umask
   end unless win_platform?


### PR DESCRIPTION
Commit 38c534187819528ea132320cdaf9533b545e47b7 mentions removing world-writable permission, which is a great idea. However, it also removes group-writable permissions which is a problem for a shared environment. This patch leaves the group permissions of the umask alone.
