### PR TITLE
Gem command doesn't crash if config file content is invalid

### DIFF
--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -242,7 +242,12 @@ class Gem::ConfigFile
     return {} unless filename and File.exist? filename
 
     begin
-      return YAML.load(File.read(filename))
+      content = YAML.load(File.read(filename))
+      unless content.kind_of? Hash
+        warn "Failed to load #{config_file_name} because it doesn't contain valid YAML hash"
+        return {}
+      end
+      return content
     rescue ArgumentError
       warn "Failed to load #{config_file_name}"
     rescue Errno::EACCES


### PR DESCRIPTION
If gem config file (for example `~/.gemrc`) doesn't contain valid YAML hash, `gem` command crashes with error which is not very obvious:

```
......./rubygems/config_file.rb:187:in 'merge': can't convert String into Hash (TypeError)
```

I suggest adding warning about invalid gem config file content
