### PR TITLE
Allow `cleanup` command to take comma-separated gem_names

### DIFF
--- a/lib/rubygems/commands/cleanup_command.rb
+++ b/lib/rubygems/commands/cleanup_command.rb
@@ -45,7 +45,7 @@ installed elsewhere in GEM_PATH the cleanup command won't touch it.
     end
 
     gems_to_cleanup = unless options[:args].empty? then
-                        options[:args].map do |gem_name|
+                        options[:args].map {|arg| arg.split(',')}.compact.flatten.map do |gem_name|
                           Gem::Specification.find_all_by_name gem_name
                         end.flatten
                       else

--- a/test/rubygems/test_gem_commands_cleanup_command.rb
+++ b/test/rubygems/test_gem_commands_cleanup_command.rb
@@ -23,6 +23,20 @@ class TestGemCommandsCleanupCommand < Gem::TestCase
     refute_path_exists @a_1.gem_dir
   end
 
+  def test_execute_comma_separated
+    @b_1 = quick_spec 'b', 1
+    @b_2 = quick_spec 'b', 2
+    install_gem @b_1
+    install_gem @b_2
+
+    @cmd.options[:args] = %w[a,b]
+
+    @cmd.execute
+
+    refute_path_exists @a_1.gem_dir
+    refute_path_exists @b_1.gem_dir
+  end
+
   def test_execute_all
     @b_1 = quick_spec 'b', 1
     @b_2 = quick_spec 'b', 2
@@ -86,4 +100,3 @@ class TestGemCommandsCleanupCommand < Gem::TestCase
   end
 
 end
-


### PR DESCRIPTION
When we run `gem up`, it outputs something like this:

```
Gems updated: RedCloth, bson, childprocess, columnize, everywhere, factory_girl...
```

What I usually do next is to check what's updated, then cleanup the outdated installations.
Apparently the easiest way for doing this is to copy the updated gem_names from STDOUT above and pass it to the `cleanup` command, but that doesn't work as expected.
So, here's a patch for `cleanup` command to accept comma-separated gem_names for realizing this operation.
