### PR TITLE
Speed up `loaded_path?` by compiling regexp once

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -980,9 +980,8 @@ module Gem
 
   def self.loaded_path? path
     # TODO: ruby needs a feature to let us query what's loaded in 1.8 and 1.9
-    $LOADED_FEATURES.find { |s|
-      s =~ /(^|\/)#{Regexp.escape path}#{Regexp.union(*Gem.suffixes)}$/
-    }
+    re = /(^|\/)#{Regexp.escape path}#{Regexp.union(*Gem.suffixes)}$/
+    $LOADED_FEATURES.any? { |s| s =~ re }
   end
 
   ##


### PR DESCRIPTION
Create the regular expression once in order to speed up the `loaded_path?` method.

Here is benchmark code:

``` ruby

require 'benchmark'
require 'rubygems'

def old_loaded_path? path
  $LOADED_FEATURES.find { |s|
    s =~ /(^|\/)#{Regexp.escape path}#{Regexp.union(*Gem.suffixes)}$/
  }
end

def loaded_path? path
  re = /(^|\/)#{Regexp.escape path}#{Regexp.union(*Gem.suffixes)}$/
  $LOADED_FEATURES.any? { |s| s =~ re }
end

n = 50000
Benchmark.bm do |x|
  x.report('old') do
    n.times { old_loaded_path? 'hi mom' }
  end

  x.report('new') do
    n.times { loaded_path? 'hi mom' }
  end
end
```

Results on my machine:

```
[aaron@mobile-166-187-251-251 rubygems (1.8)]$ ruby -I lib test.rb
       user     system      total        real
old 23.080000   0.060000  23.140000 ( 23.412055)
new  3.680000   0.010000   3.690000 (  3.742817)
[aaron@mobile-166-187-251-251 rubygems (1.8)]$
```
