### PR TITLE
fix garbled Gem.user_home on Windows with ruby 1.9

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -509,7 +509,7 @@ module Gem
 
   def self.find_home
     windows = File::ALT_SEPARATOR
-    if not windows or RUBY_VERSION >= '1.9' then
+    if not windows then
       File.expand_path "~"
     else
       ['HOME', 'USERPROFILE'].each do |key|


### PR DESCRIPTION
In `Gem.find_home`, with Ruby 1.9, even if it's on Windows, it still tries to return `File.expand_path '~'`.

This is wrong, the consequence is, in JRuby 1.9 mode, `jruby --1.9 -e 'puts Gem.user_home'` prints garbled result, like `C:/C:â‚©Usersâ‚©xxx`,

see JRuby bug [JRUBY-6267](https://jira.codehaus.org/browse/JRUBY-6267)
