### PR TITLE
Gem command doesn't crash if config file content is invalid

### DIFF
--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -242,7 +242,12 @@ class Gem::ConfigFile
     return {} unless filename and File.exist? filename
 
     begin
-      return YAML.load(File.read(filename))
+      content = YAML.load(File.read(filename))
+      unless content.kind_of? Hash
+        warn "Failed to load #{config_file_name} because it doesn't contain valid YAML hash"
+        return {}
+      end
+      return content
     rescue ArgumentError
       warn "Failed to load #{config_file_name}"
     rescue Errno::EACCES

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -291,6 +291,18 @@ class TestGemConfigFile < Gem::TestCase
                   :other => 'a5fdbb6ba150cbb83aad2bb2fede64c'}, @cfg.api_keys)
   end
 
+  def test_ignore_invalid_config_file
+    File.open @temp_conf, 'w' do |fp|
+      fp.puts "some-non-yaml-hash-string"
+    end
+
+    # Avoid writing stuff to output when running tests
+    Gem::ConfigFile.class_eval { def warn(args); end } 
+
+    # This should not raise exception
+    util_config_file
+  end
+
   def util_config_file(args = @cfg_args)
     @cfg = Gem::ConfigFile.new args
   end


### PR DESCRIPTION
If gem config file (for example `~/.gemrc`) doesn't contain valid YAML hash, gem command crashes with error which is not very obvious:

```
.../rubygems/config_file.rb:187:in 'merge': can't convert String into Hash (TypeError)
```

I suggest adding warning about invalid gem config file content

This is a tiny change, but I believe it can save few hours for those users who blindly copy-pasted their `.gemrc` from some web-site

P.S. Test-case included
