### PR TITLE
JRuby's 'Syck' is 'Yecht'

### DIFF
--- a/lib/rubygems/syck_hack.rb
+++ b/lib/rubygems/syck_hack.rb
@@ -17,6 +17,10 @@ module YAML
   if defined? ::Syck
     Syck = ::Syck
 
+  # JRuby's "Syck" is called "Yecht"
+  elsif defined? YAML::Yecht
+    Syck = YAML::Yecht
+
   # Otherwise, if there is no YAML::Syck, then we've got just psych
   # loaded, so lets define a stub for DefaultKey.
   elsif !defined? YAML::Syck


### PR DESCRIPTION
So `Syck` should be equal to `YAML::Yecht`. This solves the problem described in http://stackoverflow.com/questions/8674480/rails-3-2-on-jruby-gemspec-errors, where JRuby fails to install Rails 3.2.0.rc1.
