### PR TITLE
Exception: NameError: uninitialized constant Gem::SyckDefaultKey

### DIFF
--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -10,6 +10,7 @@
 
 require "rubygems/version"
 require "rubygems/deprecate"
+require "rubygems/syck_hack"
 
 class Gem::Requirement
   include Comparable


### PR DESCRIPTION
fixed the Exception: NameError: uninitialized constant Gem::SyckDefaultKey error
by requiring the syck_hack file.
