### PR TITLE
Replace a blockless map with to_a.

### DIFF
--- a/lib/rubygems/dependency_list.rb
+++ b/lib/rubygems/dependency_list.rb
@@ -31,7 +31,7 @@ class Gem::DependencyList
 
   def self.from_specs
     list = new
-    list.add(*Gem::Specification.map)
+    list.add(*Gem::Specification.to_a)
     list
   end
 


### PR DESCRIPTION
This is just a minor nit, but `*to_a` is more readable and about 2x faster than `*map` which creates an intermediate enumerator to finally get an array.
