### PR TITLE
Verbose extension builder

### DIFF
--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -51,7 +51,7 @@ class Gem::Ext::Builder
     end
 
     unless $?.success? then
-      results << "Look above for error messages!" if verbose
+      results << "Building has failed. See above output for more information on the failure." if verbose
       raise Gem::InstallError, "#{command_name || class_name} failed:\n\n#{results.join "\n"}"
     end
   end


### PR DESCRIPTION
The Debian Ruby packaging helper, [gem2deb](http://anonscm.debian.org/gitweb/?p=pkg-ruby-extras/gem2deb.git;a=summary) uses Rubygems to build C extensions to make sure we are 100% compatible with Rubygems packages. When building Debian packages it's useful to follow the build as it goes, but currently Rubygems hides the compilation from the user -- what makes a lot of sente.

This branch makes the extension builder output terminal as the build proceeds upon request. `gem install --verbose` will enable this behavior, and gem2deb would enable it by setting `Gem.configuration.verbose` directly. The default is to behave as it does now, i.e. to not output anything unless something goes wrong.
