### PR TITLE
Don't set 1.9.2 suckage constant when on JRuby. JRuby don't suck.

### DIFF
--- a/lib/rubygems/compatibility.rb
+++ b/lib/rubygems/compatibility.rb
@@ -6,7 +6,7 @@
 # support them, so we define some constants to use later.
 module Gem
   QUICKLOADER_SUCKAGE = RUBY_VERSION =~ /^1\.9\.1/
-  GEM_PRELUDE_SUCKAGE = RUBY_VERSION =~ /^1\.9\.2/
+  GEM_PRELUDE_SUCKAGE = RUBY_VERSION =~ /^1\.9\.2/ && !defined(JRUBY_VERSION)
 end
 
 # Gem::QuickLoader exists in the gem prelude code in ruby 1.9.2 itself.


### PR DESCRIPTION
I opted to just do a hard defined?(JRUBY_VERSION) check since the suckage flag should never be set on JRuby.

I also respectfully request this be ported to 1.8 branch, since that's what we're running off for 1.6.x and master.

Fixes #268.
