### PR TITLE
Propagate env-shebang to "pristine" command if set for install.

### DIFF
--- a/lib/rubygems/commands/pristine_command.rb
+++ b/lib/rubygems/commands/pristine_command.rb
@@ -94,10 +94,14 @@ extensions.
       end
 
       # TODO use installer options
+      install_defaults = Gem::ConfigFile::PLATFORM_DEFAULTS['install']
+      installer_env_shebang = install_defaults.to_s['--env-shebang']
+      
       installer = Gem::Installer.new(gem,
                                      :wrappers => true,
                                      :force => true,
-                                     :install_dir => spec.base_dir)
+                                     :install_dir => spec.base_dir,
+                                     :env_shebang => installer_env_shebang)
       installer.install
 
       say "Restored #{spec.full_name}"


### PR DESCRIPTION
This is a partial fix for #119 that we've been shipping with JRuby.

Under many installs of JRuby, binstubs must be installed using an env shebang since the `jruby` command is a bash script. For that, we have set install's defaults to --env-shebang. However, the `pristine` command, which just reinstalls gems, does not observe install's defaults (as reported in #119). This patch propagates the env-shebang flag, since it's the important one for us.

This is by no means a complete fix for #119, but it's what we've been shipping for years.
