### PR TITLE
FEATURE: cleanup command add --no and --yes to auto confirm [Yn]

### DIFF
--- a/lib/rubygems/commands/cleanup_command.rb
+++ b/lib/rubygems/commands/cleanup_command.rb
@@ -12,6 +12,15 @@ class Gem::Commands::CleanupCommand < Gem::Command
     add_option('-d', '--dryrun', "") do |value, options|
       options[:dryrun] = true
     end
+
+    add_option('-y', '--yes', 'Confirm all questions with yes') do
+      options[:confirm_yes] = true
+    end
+
+    add_option('-n', '--no', 'Confirm all questions with no') do
+      options[:confirm_no] = true
+    end
+
   end
 
   def arguments # :nodoc:
@@ -74,6 +83,8 @@ installed elsewhere in GEM_PATH the cleanup command won't touch it.
         uninstall_options = {
           :executables => false,
           :version => "= #{spec.version}",
+          :confirm_no => options[:confirm_no],
+          :confirm_yes => options[:confirm_yes],
         }
 
         uninstall_options[:user_install] = Gem.user_dir == spec.base_dir
@@ -84,8 +95,12 @@ installed elsewhere in GEM_PATH the cleanup command won't touch it.
           uninstaller.uninstall
         rescue Gem::DependencyRemovalException, Gem::InstallError,
                Gem::GemNotInHomeException, Gem::FilePermissionError => e
-          say "Unable to uninstall #{spec.full_name}:"
-          say "\t#{e.class}: #{e.message}"
+          if options[:confirm_no]
+            say "ignored to uninstall #{spec.full_name}"
+          else
+            say "Unable to uninstall #{spec.full_name}:"
+            say "\t#{e.class}: #{e.message}"
+          end
         end
       end
 

--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -51,6 +51,8 @@ class Gem::Uninstaller
     @force_ignore      = options[:ignore]
     @bin_dir           = options[:bin_dir]
     @format_executable = options[:format_executable]
+    @confirm_no        = true || options[:confirm_no]
+    @confirm_yes       = options[:confirm_yes]
 
     if options[:force]
       @force_all = true
@@ -265,6 +267,9 @@ class Gem::Uninstaller
     msg = ['']
     msg << 'You have requested to uninstall the gem:'
     msg << "\t#{spec.full_name}"
+
+    return true if @confirm_yes
+    return false if @confirm_no
 
     spec.dependent_gems.each do |dep_spec, dep, satlist|
       msg << "#{dep_spec.name}-#{dep_spec.version} depends on #{dep}"


### PR DESCRIPTION
In order to use the gem utility within shell scripts it would be nice to have options --no and --yes for automatically confirm all questions asked by ask_\* methods.
This patch adds --no and --yes for the cleanup command, which I want to use within shell scripts.
