### PR TITLE
Fix for Issue 171 - Broken all_load_path

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -258,7 +258,7 @@ module Gem
 
     Gem.path.each do |gemdir|
       each_load_path all_partials(gemdir) do |load_path|
-        result << gemdir.add(load_path).expand_path
+        result << load_path
       end
     end
 


### PR DESCRIPTION
fix issue with gettext gem. Even if method is deprecated it should not be broken. Fix issue@171
