### PR TITLE
disable_default_gem_server does not work when set in the config file

### DIFF
--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -201,14 +201,14 @@ class Gem::ConfigFile
     @hash = @hash.merge environment_config
 
     # HACK these override command-line args, which is bad
-    @backtrace                  = @hash[:backtrace]      if @hash.key? :backtrace
-    @benchmark                  = @hash[:benchmark]      if @hash.key? :benchmark
-    @bulk_threshold             = @hash[:bulk_threshold] if @hash.key? :bulk_threshold
-    @home                       = @hash[:gemhome]        if @hash.key? :gemhome
-    @path                       = @hash[:gempath]        if @hash.key? :gempath
-    @update_sources             = @hash[:update_sources] if @hash.key? :update_sources
-    @verbose                    = @hash[:verbose]        if @hash.key? :verbose
-    @disable_default_gem_server = @hash[:verbose]        if @hash.key? :disable_default_gem_server
+    @backtrace                  = @hash[:backtrace]                  if @hash.key? :backtrace
+    @benchmark                  = @hash[:benchmark]                  if @hash.key? :benchmark
+    @bulk_threshold             = @hash[:bulk_threshold]             if @hash.key? :bulk_threshold
+    @home                       = @hash[:gemhome]                    if @hash.key? :gemhome
+    @path                       = @hash[:gempath]                    if @hash.key? :gempath
+    @update_sources             = @hash[:update_sources]             if @hash.key? :update_sources
+    @verbose                    = @hash[:verbose]                    if @hash.key? :verbose
+    @disable_default_gem_server = @hash[:disable_default_gem_server] if @hash.key? :disable_default_gem_server
 
     load_api_keys
 

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -334,5 +334,12 @@ class TestGemConfigFile < Gem::TestCase
     @cfg = Gem::ConfigFile.new args
   end
 
+  def test_disable_default_gem_server
+    File.open @temp_conf, 'w' do |fp|
+      fp.puts ":disable_default_gem_server: true"
+    end
+    util_config_file
+    assert_equal(true, @cfg.disable_default_gem_server)
+  end
 end
 


### PR DESCRIPTION
Setting :disable_default_gem_server: true in the config file would wrongly use the :verbose flag instead.
