### PR TITLE
fix using sysconfdir for 1.8.x rubies

### DIFF
--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -46,7 +46,28 @@ class Gem::ConfigFile
   PLATFORM_DEFAULTS = {}
 
   require "rbconfig"
-  system_config_path = RbConfig::CONFIG['sysconfdir'] || "/etc"
+  system_config_path = RbConfig::CONFIG['sysconfdir'] || 
+    begin
+      # TODO: remove after we drop 1.8.7 and 1.9.1 - Etc.sysconfdir
+      require 'Win32API'
+
+      CSIDL_COMMON_APPDATA = 0x0023
+      path = 0.chr * 260
+      if RUBY_VERSION > '1.9' then
+        SHGetFolderPath = Win32API.new 'shell32', 'SHGetFolderPath', 'PLPLP',
+        'L', :stdcall
+        SHGetFolderPath.call nil, CSIDL_COMMON_APPDATA, nil, 1, path
+      else
+        SHGetFolderPath = Win32API.new 'shell32', 'SHGetFolderPath', 'LLLLP',
+        'L'
+        SHGetFolderPath.call 0, CSIDL_COMMON_APPDATA, 0, 1, path
+      end
+
+      path.strip
+    rescue LoadError
+      "/etc"
+    end
+
 
   SYSTEM_WIDE_CONFIG_FILE = File.join system_config_path, 'gemrc'
 


### PR DESCRIPTION
for the line of rubies 1.8 rubygems did not load sysconfdir and defaulted back to /etc which lead to problems like this: https://gist.github.com/1981223
