### PR TITLE
Fix a test failure on Windows

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -569,8 +569,13 @@ class Gem::Installer
   def check_that_user_bin_dir_is_in_path
     user_bin_dir = @bin_dir || Gem.bindir(gem_home)
     user_bin_dir.gsub!(File::SEPARATOR, File::ALT_SEPARATOR) if File::ALT_SEPARATOR
+    path = ENV['PATH']
+    if Gem.win_platform? then
+      path = path.downcase
+      user_bin_dir = user_bin_dir.downcase
+    end
 
-    unless ENV['PATH'].split(File::PATH_SEPARATOR).include? user_bin_dir then
+    unless path.split(File::PATH_SEPARATOR).include? user_bin_dir then
       unless self.class.path_warning then
         alert_warning "You don't have #{user_bin_dir} in your PATH,\n\t  gem executables will not run."
         self.class.path_warning = true


### PR DESCRIPTION
test_generate_bin_bindir_with_user_install_warning(TestGemInstaller) fails
on Windows with msys bash. It makes comparing paths case-insensitive.
It would be better to fix this.

See:
https://github.com/rubygems/rubygems/issues/299#issuecomment-4524401

```
 16) Failure:
test_generate_bin_bindir_with_user_install_warning(TestGemInstaller) [C:/work/ru
bygems/test/rubygems/test_gem_installer.rb:291]:
--- expected
+++ actual
@@ -1 +1,3 @@
-""
+"WARNING:  You don't have C:\\WINDOWS in your PATH,
+\t  gem executables will not run.
+"
```
