### PR TITLE
custom_shebang should not be used on binaries used in it - prevent loop

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -478,6 +478,9 @@ class Gem::Installer
     end
 
     if which = Gem.configuration[:custom_shebang]
+      # replace bin_file_name with "ruby" to avoid endless loops
+      which = which.gsub(/ #{bin_file_name}$/," #{Gem::ConfigMap[:ruby_install_name]}")
+
       which = which.gsub(/\$(\w+)/) do
         case $1
         when "env"


### PR DESCRIPTION
The basic example is a `awesome.gemspec`:

```
...
spec.executables = %w( ruby_awesome_launcher )
...
```

and a `~/gemrc`:

```
custom_shebang: "$env ruby_awesome_launcher"
```

this would generate a loop where `ruby_awesome_launcher` will be using itself in shebang if the gem is installed multiple times.
