### PR TITLE
TestGemRequrement cases for spermy pre-release matching

### DIFF
--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -251,7 +251,7 @@ class TestGemRequirement < Gem::TestCase
     assert_satisfied_by "1.4.beta.1",  "~> 1.4.beta.0"
 
     refute_satisfied_by "1.4",         "~> 1.4.beta.0"
-    retute_satisfied_by "1.4.0",       "~> 1.4.beta.0"
+    refute_satisfied_by "1.4.0",       "~> 1.4.beta.0"
     refute_satisfied_by "1.4.1",       "~> 1.4.beta.0"
 
     refute_satisfied_by "1.5.alpha.0", "~> 1.4.beta.0"


### PR DESCRIPTION
I was recently bitten and surprised by the matching behavior of spermy/pessimetic requirements that contain pre-release alpha segments.  Issue #198 identifies a subcase of this problem. Here is a more concerning example.

If I specify a requirement of `~> 1.4.beta`,  what I believe I'm saying is that I will take anything from 1.4.beta.0, to 1.4.rc.1 to release versions 1.4.0, 1.4.1, etc.   This works, however I'm surprised to find that `~> 1.4.beta` _also_ matches 1.5.  By comparison, `~> 1.4.0` drops both the earlier pre-releases and also avoids matching 1.5.

It appears the current logic is that a `~> 1.4.beta` is effectively equivalent to `~> 1.4` which is both surprising and limits my ability to constrain the dependency in the way I would like. 

Here is a simple demonstration, where I'd expect the matching version would be `1.1.3`:

```
% gem list bundler

*** LOCAL GEMS ***
bundler (1.2.0.pre.1, 1.1.3, 1.1.0, 1.1.rc.8)

% ruby -rubygems -e "gem 'bundler', '~> 1.1.rc'; require 'bundler'; puts Bundler::VERSION"
1.2.0.pre.1
```

The current commit provides two test cases which show the behavior that I would have expected, but fail as shown below. If you could let me know if these tests cases are valid, then I could attempt to fix the Requirement handling to make this pull request mergeable. 

```
  1) Failure:
test_satisfied_by_boxed_pre_plus(TestGemRequirement) [./test/rubygems/test_gem_requirement.rb:253]:
~> 1.4.beta.0 is not satisfied by 1.4

  2) Failure:
test_satisfied_by_boxed_pre(TestGemRequirement) [./test/rubygems/test_gem_requirement.rb:242]:
~> 1.4.beta is not satisfied by 1.5.alpha.0
```
