### PR TITLE
Failing test cases for requirements range expressions and prereleases

### DIFF
--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -251,7 +251,7 @@ class TestGemRequirement < Gem::TestCase
     assert_satisfied_by "1.4.beta.1",  "~> 1.4.beta.0"
 
     refute_satisfied_by "1.4",         "~> 1.4.beta.0"
-    retute_satisfied_by "1.4.0",       "~> 1.4.beta.0"
+    refute_satisfied_by "1.4.0",       "~> 1.4.beta.0"
     refute_satisfied_by "1.4.1",       "~> 1.4.beta.0"
 
     refute_satisfied_by "1.5.alpha.0", "~> 1.4.beta.0"

--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -226,7 +226,6 @@ class TestGemRequirement < Gem::TestCase
   end
 
   def test_satisfied_by_spermy_inplace_pre
-    skip "Spermy won't match as expected with inplace prerelease versions"
     req = "~> 1.4.beta"
 
     refute_satisfied_by "1.3.beta.0",  req
@@ -242,9 +241,15 @@ class TestGemRequirement < Gem::TestCase
     assert_satisfied_by "1.4.0",       req
     assert_satisfied_by "1.4.1",       req
 
+    # See more delicate versions compared below
+
     refute_satisfied_by "2.0",         req
     refute_satisfied_by "2.0.0",       req
+  end
 
+  def test_satisfied_by_spermy_inplace_pre_next_minor
+    skip "Spermy won't match as expected with inplace prerelease versions"
+    req = "~> 1.4.beta"
     refute_satisfied_by "1.5.alpha",   req
     refute_satisfied_by "1.5.beta.0",  req
     refute_satisfied_by "1.5",         req

--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -226,6 +226,7 @@ class TestGemRequirement < Gem::TestCase
   end
 
   def test_satisfied_by_spermy_inplace_pre
+    skip "Spermy won't match as expected with inplace prerelease versions"
     req = "~> 1.4.beta"
 
     refute_satisfied_by "1.3.beta.0",  req

--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -225,40 +225,197 @@ class TestGemRequirement < Gem::TestCase
     refute_satisfied_by "2.0.a",   "~> 2.0"
   end
 
-  def test_satisfied_by_boxed_pre
-    refute_satisfied_by "1.3.beta.0",  "~> 1.4.beta"
-    refute_satisfied_by "1.3",         "~> 1.4.beta"
-    refute_satisfied_by "1.3.0",       "~> 1.4.beta"
-    refute_satisfied_by "1.3.alpha.0", "~> 1.4.beta"
+  def test_satisfied_by_spermy_inplace_pre
+    req = "~> 1.4.beta"
 
-    refute_satisfied_by "1.4.alpha",   "~> 1.4.beta"
-    refute_satisfied_by "1.4.alpha.0", "~> 1.4.beta"
+    refute_satisfied_by "1.3.beta.0",  req
+    refute_satisfied_by "1.3",         req
+    refute_satisfied_by "1.3.0",       req
 
-    assert_satisfied_by "1.4.beta.0",  "~> 1.4.beta"
-    assert_satisfied_by "1.4",         "~> 1.4.beta"
-    assert_satisfied_by "1.4.0",       "~> 1.4.beta"
-    assert_satisfied_by "1.4.1",       "~> 1.4.beta"
+    refute_satisfied_by "1.4.alpha",   req
+    refute_satisfied_by "1.4.alpha.0", req
 
-    refute_satisfied_by "1.5.alpha.0", "~> 1.4.beta"
-    refute_satisfied_by "1.5.beta.0",  "~> 1.4.beta"
-    refute_satisfied_by "1.5",         "~> 1.4.beta"
-    refute_satisfied_by "1.5.0",       "~> 1.4.beta"
-    refute_satisfied_by "1.5.1",       "~> 1.4.beta"
+    assert_satisfied_by "1.4.beta",    req
+    assert_satisfied_by "1.4.beta.0",  req
+    assert_satisfied_by "1.4",         req
+    assert_satisfied_by "1.4.0",       req
+    assert_satisfied_by "1.4.1",       req
+
+    refute_satisfied_by "2.0",         req
+    refute_satisfied_by "2.0.0",       req
+
+    refute_satisfied_by "1.5.alpha",   req
+    refute_satisfied_by "1.5.beta.0",  req
+    refute_satisfied_by "1.5",         req
+    refute_satisfied_by "1.5.0",       req
+    refute_satisfied_by "1.5.1",       req
   end
 
-  def test_satisfied_by_boxed_pre_plus
-    assert_satisfied_by "1.4.beta.0",  "~> 1.4.beta.0"
-    assert_satisfied_by "1.4.beta.1",  "~> 1.4.beta.0"
+  def test_satisfied_by_spermy_postfix_pre
+    req = "~> 1.4.0.beta"
 
-    refute_satisfied_by "1.4",         "~> 1.4.beta.0"
-    refute_satisfied_by "1.4.0",       "~> 1.4.beta.0"
-    refute_satisfied_by "1.4.1",       "~> 1.4.beta.0"
+    refute_satisfied_by "1.3.0.beta.0",  req
+    refute_satisfied_by "1.3",           req
+    refute_satisfied_by "1.3.0",         req
 
-    refute_satisfied_by "1.5.alpha.0", "~> 1.4.beta.0"
-    refute_satisfied_by "1.5.beta.0",  "~> 1.4.beta.0"
-    refute_satisfied_by "1.5",         "~> 1.4.beta.0"
-    refute_satisfied_by "1.5.0",       "~> 1.4.beta.0"
-    refute_satisfied_by "1.5.1",       "~> 1.4.beta.0"
+    refute_satisfied_by "1.4.alpha",     req
+    refute_satisfied_by "1.4.alpha.0",   req
+    refute_satisfied_by "1.4.0.alpha",   req
+    refute_satisfied_by "1.4.0.alpha.0", req
+
+    assert_satisfied_by "1.4.0.beta",    req
+    assert_satisfied_by "1.4.0.beta.0",  req
+    assert_satisfied_by "1.4",           req
+    assert_satisfied_by "1.4.0",         req
+    assert_satisfied_by "1.4.1",         req
+
+    refute_satisfied_by "2.0",           req
+    refute_satisfied_by "2.0.0",         req
+
+    refute_satisfied_by "1.5",           req
+    refute_satisfied_by "1.5.0.alpha",   req
+    refute_satisfied_by "1.5.0.beta.0",  req
+    refute_satisfied_by "1.5.0",         req
+    refute_satisfied_by "1.5.1",         req
+  end
+
+  def test_satisfied_by_spermy_postfix_pre_sub
+    req = "~> 1.4.0.beta.1"
+
+    refute_satisfied_by "1.3.0.beta.0",  req
+    refute_satisfied_by "1.3",           req
+    refute_satisfied_by "1.3.0",         req
+
+    refute_satisfied_by "1.4.alpha",     req
+    refute_satisfied_by "1.4.alpha.0",   req
+    refute_satisfied_by "1.4.0.alpha",   req
+    refute_satisfied_by "1.4.0.alpha.0", req
+
+    refute_satisfied_by "1.4.0.beta",    req
+    refute_satisfied_by "1.4.0.beta.0",  req
+
+    assert_satisfied_by "1.4.0.beta.1",  req
+    assert_satisfied_by "1.4",           req
+    assert_satisfied_by "1.4.0",         req
+    assert_satisfied_by "1.4.1",         req
+
+    refute_satisfied_by "2.0",           req
+    refute_satisfied_by "2.0.0",         req
+
+    refute_satisfied_by "1.5",           req
+    refute_satisfied_by "1.5.0.alpha",   req
+    refute_satisfied_by "1.5.0.beta.0",  req
+    refute_satisfied_by "1.5.0",         req
+    refute_satisfied_by "1.5.1",         req
+  end
+
+  def test_satisfied_by_spermy_release
+    req = "~> 1.4.0"
+
+    refute_satisfied_by "1.3.beta.0",  req
+    refute_satisfied_by "1.3",         req
+    refute_satisfied_by "1.3.0",       req
+    refute_satisfied_by "1.3.alpha.0", req
+
+    refute_satisfied_by "1.4.beta.0",  req
+    assert_satisfied_by "1.4",         req
+    assert_satisfied_by "1.4.0",       req
+    assert_satisfied_by "1.4.1",       req
+
+    refute_satisfied_by "1.5.alpha.0", req
+    refute_satisfied_by "1.5.beta.0",  req
+    refute_satisfied_by "1.5",         req
+    refute_satisfied_by "1.5.0",       req
+    refute_satisfied_by "1.5.1",       req
+  end
+
+  def test_satisfied_by_range_pre_inplace
+    req = [ ">= 1.4.beta", "< 1.5" ]
+
+    refute_satisfied_by "1.3.alpha.0", req
+    refute_satisfied_by "1.4.alpha.0", req
+
+    assert_satisfied_by "1.4.beta.0",  req
+    assert_satisfied_by "1.4.beta.1",  req
+
+    assert_satisfied_by "1.4",         req
+    assert_satisfied_by "1.4.0",       req
+    assert_satisfied_by "1.4.1",       req
+
+    refute_satisfied_by "1.5.alpha.0", req
+    refute_satisfied_by "1.5.beta.0",  req
+    refute_satisfied_by "1.5",         req
+    refute_satisfied_by "1.5.0",       req
+    refute_satisfied_by "1.5.1",       req
+  end
+
+  def test_satisfied_by_range_inplace
+    req = [ ">= 1.4", "< 1.5" ]
+
+    refute_satisfied_by "1.3.alpha.0", req
+    refute_satisfied_by "1.4.alpha.0", req
+
+    refute_satisfied_by "1.4.beta.0",  req
+    refute_satisfied_by "1.4.beta.1",  req
+
+    assert_satisfied_by "1.4",         req
+    assert_satisfied_by "1.4.0",       req
+    assert_satisfied_by "1.4.1",       req
+
+    refute_satisfied_by "1.5.alpha.0", req
+    refute_satisfied_by "1.5.beta.0",  req
+    refute_satisfied_by "1.5",         req
+    refute_satisfied_by "1.5.0",       req
+    refute_satisfied_by "1.5.1",       req
+  end
+
+  def test_satisfied_by_range_postfix
+    req = [ ">= 1.4", "< 1.5" ]
+
+    refute_satisfied_by "1.4.0.beta.0",  req
+
+    assert_satisfied_by "1.4",           req
+    assert_satisfied_by "1.4.0",         req
+    assert_satisfied_by "1.4.1",         req
+
+    refute_satisfied_by "1.5.0.beta.0",  req
+    refute_satisfied_by "1.5",           req
+    refute_satisfied_by "1.5.0",         req
+    refute_satisfied_by "1.5.1",         req
+  end
+
+  def test_satisfied_by_range_3_postfix
+    req = [ ">= 1.4.0", "< 1.5.0" ]
+
+    refute_satisfied_by "1.4.0.beta.0",  req
+
+    assert_satisfied_by "1.4",           req
+    assert_satisfied_by "1.4.0",         req
+    assert_satisfied_by "1.4.1",         req
+
+    refute_satisfied_by "1.5.0.beta.0",  req
+    refute_satisfied_by "1.5",           req
+    refute_satisfied_by "1.5.0",         req
+    refute_satisfied_by "1.5.1",         req
+  end
+
+  def test_satisfied_by_range_with_pre_postfix
+    req = [ ">= 1.4.0.beta", "< 1.5" ]
+
+    refute_satisfied_by "1.3.0.alpha.0", req
+    refute_satisfied_by "1.4.0.alpha.0", req
+
+    assert_satisfied_by "1.4.0.beta.0",  req
+    assert_satisfied_by "1.4.0.beta.1",  req
+
+    assert_satisfied_by "1.4.0",         req
+    assert_satisfied_by "1.4.1",         req
+
+    refute_satisfied_by "1.5.0.alpha.0", req
+    refute_satisfied_by "1.5.0.beta.0",  req
+    refute_satisfied_by "1.5",           req
+    refute_satisfied_by "1.5.0",         req
+    refute_satisfied_by "1.5.1",         req
   end
 
   def test_satisfied_by_eh_multiple

--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -225,6 +225,42 @@ class TestGemRequirement < Gem::TestCase
     refute_satisfied_by "2.0.a",   "~> 2.0"
   end
 
+  def test_satisfied_by_boxed_pre
+    refute_satisfied_by "1.3.beta.0",  "~> 1.4.beta"
+    refute_satisfied_by "1.3",         "~> 1.4.beta"
+    refute_satisfied_by "1.3.0",       "~> 1.4.beta"
+    refute_satisfied_by "1.3.alpha.0", "~> 1.4.beta"
+
+    refute_satisfied_by "1.4.alpha",   "~> 1.4.beta"
+    refute_satisfied_by "1.4.alpha.0", "~> 1.4.beta"
+
+    assert_satisfied_by "1.4.beta.0",  "~> 1.4.beta"
+    assert_satisfied_by "1.4",         "~> 1.4.beta"
+    assert_satisfied_by "1.4.0",       "~> 1.4.beta"
+    assert_satisfied_by "1.4.1",       "~> 1.4.beta"
+
+    refute_satisfied_by "1.5.alpha.0", "~> 1.4.beta"
+    refute_satisfied_by "1.5.beta.0",  "~> 1.4.beta"
+    refute_satisfied_by "1.5",         "~> 1.4.beta"
+    refute_satisfied_by "1.5.0",       "~> 1.4.beta"
+    refute_satisfied_by "1.5.1",       "~> 1.4.beta"
+  end
+
+  def test_satisfied_by_boxed_pre_plus
+    assert_satisfied_by "1.4.beta.0",  "~> 1.4.beta.0"
+    assert_satisfied_by "1.4.beta.1",  "~> 1.4.beta.0"
+
+    refute_satisfied_by "1.4",         "~> 1.4.beta.0"
+    retute_satisfied_by "1.4.0",       "~> 1.4.beta.0"
+    refute_satisfied_by "1.4.1",       "~> 1.4.beta.0"
+
+    refute_satisfied_by "1.5.alpha.0", "~> 1.4.beta.0"
+    refute_satisfied_by "1.5.beta.0",  "~> 1.4.beta.0"
+    refute_satisfied_by "1.5",         "~> 1.4.beta.0"
+    refute_satisfied_by "1.5.0",       "~> 1.4.beta.0"
+    refute_satisfied_by "1.5.1",       "~> 1.4.beta.0"
+  end
+
   def test_satisfied_by_eh_multiple
     req = [">= 1.4", "<= 1.6", "!= 1.5"]
 

--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -327,7 +327,7 @@ class TestGemRequirement < Gem::TestCase
 
   def assert_satisfied_by version, requirement
     assert req(requirement).satisfied_by?(v(version)),
-      "#{requirement} is satisfied by #{version}"
+      "#{requirement} should be satisfied by #{version}"
   end
 
   # Refute the assumption that two requirements are equal.
@@ -340,6 +340,6 @@ class TestGemRequirement < Gem::TestCase
 
   def refute_satisfied_by version, requirement
     refute req(requirement).satisfied_by?(v(version)),
-      "#{requirement} is not satisfied by #{version}"
+      "#{requirement} should not be satisfied by #{version}"
   end
 end


### PR DESCRIPTION
Here is an oddity, continued from #349:

Prereleases are included in `>=`, `<` requirement ranges, even when they don't have prerelease segments.  But anyone specifying for example `< 1.5.0` is most certainly not expecting to use 1.5.0.beta.0 if they happen to have it installed.

Failed test output:

~~~~
 1) Failure:
test_satisfied_by_range_postfix(TestGemRequirement) [./test/rubygems/test_gem_requirement.rb:387]:
[">= 1.4", "< 1.5"] should not be satisfied by 1.5.0.beta.0

  2) Failure:
test_satisfied_by_range_pre_inplace(TestGemRequirement) [./test/rubygems/test_gem_requirement.rb:351]:
[">= 1.4.beta", "< 1.5"] should not be satisfied by 1.5.alpha.0

  3) Failure:
test_satisfied_by_range_3_postfix(TestGemRequirement) [./test/rubygems/test_gem_requirement.rb:402]:
[">= 1.4.0", "< 1.5.0"] should not be satisfied by 1.5.0.beta.0

  4) Failure:
test_satisfied_by_range_with_pre_postfix(TestGemRequirement) [./test/rubygems/test_gem_requirement.rb:420]:
[">= 1.4.0.beta", "< 1.5"] should not be satisfied by 1.5.0.alpha.0

  5) Failure:
test_satisfied_by_range_inplace(TestGemRequirement) [./test/rubygems/test_gem_requirement.rb:371]:
[">= 1.4", "< 1.5"] should not be satisfied by 1.5.alpha.0
~~~~

Also, a command line example:

~~~~
% gem list bundler
*** LOCAL GEMS ***
bundler (1.2.0.pre.1, 1.1.3, 1.1.0, 1.1.rc.8)

% ruby -rubygems -e "gem( 'bundler', [ '>= 1.1', '< 1.2' ] ); require 'bundler'; puts Bundler::VERSION"
1.2.0.pre.1
~~~~

Is this all expected behavior?
