### PR TITLE
DRYer and more self-documenting tests of background rdoc generation

### DIFF
--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -796,6 +796,14 @@ Also, a list:
     system('nmake /? 1>NUL 2>&1')
   end
 
+  # In case we're building docs in a background process, this method waits for
+  # that process to exit (or if it's already been reaped, or never happened,
+  # swallows the Errno::ECHILD error).
+  def wait_for_child_process_to_exit
+    Process.wait if Process.respond_to?(:fork)
+  rescue Errno::ECHILD
+  end
+
   ##
   # Allows tests to use a random (but controlled) port number instead of
   # a hardcoded one. This helps CI tools when running parallels builds on

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -304,7 +304,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
       assert_equal 0, e.exit_code
     end
 
-    Process.wait rescue Errno::ECHILD if Process.respond_to?(:fork)
+    wait_for_child_process_to_exit
 
     assert_path_exists File.join(@a2.doc_dir, 'ri')
     assert_path_exists File.join(@a2.doc_dir, 'rdoc')

--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -274,7 +274,7 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
       @cmd.execute
     end
 
-    Process.wait rescue Errno::ECHILD if Process.respond_to?(:fork)
+    wait_for_child_process_to_exit
 
     assert_path_exists File.join(@a2.doc_dir, 'ri')
     assert_path_exists File.join(@a2.doc_dir, 'rdoc')


### PR DESCRIPTION
following up on @bhenderson's comments on https://github.com/rubygems/rubygems/pull/352
