### PR TITLE
rework exception management for JRuby compatibility

### DIFF
--- a/lib/rubygems/dependency_installer.rb
+++ b/lib/rubygems/dependency_installer.rb
@@ -387,14 +387,17 @@ class Gem::DependencyInstaller
   end
 
   def in_background what
+    fork_happened = false
     if @build_docs_in_background and Process.respond_to?(:fork)
-      say "#{what} in a background process."
-      Process.fork do
-        yield
+      begin
+        Process.fork do
+          yield
+        end
+        fork_happened = true
+        say "#{what} in a background process."
+      rescue NotImplementedError
       end
-    else
-      yield
     end
+    yield unless fork_happened
   end
-
 end


### PR DESCRIPTION
Once more into the breach! This patch should work with JRuby. Unfortunately I can't get "rvm jruby do rake test" to run since RubyKernel.java seems to be preferring its own version of rubygems but I tested the code itself in "rvm jruby irb".

"rake test" passes under MRI 1.9.3 and 1.8.7. Any other Ruby versions I need to worry about?
