### PR TITLE
Serve documentation for gems in all gem paths.

### DIFF
--- a/lib/rubygems/commands/server_command.rb
+++ b/lib/rubygems/commands/server_command.rb
@@ -78,7 +78,7 @@ You can set up a shortcut to gem server documentation using the URL:
   end
 
   def execute
-    options[:gemdir] << Gem.dir if options[:gemdir].empty?
+    options[:gemdir] = Gem.path if options[:gemdir].empty?
     Gem::Server.run options
   end
 


### PR DESCRIPTION
Hi,

I found that gem server has issues, when running

```
$ GEM_HOME=foo gem server
ERROR:  While executing gem ... (ArgumentError)
    foo does not appear to be a gem repository
```

This pull request fixes this issue and on top of that, it allows to serve documentation for all gem paths.
