### PR TITLE
Added `Gem.install gem` so that you can install gems from the REPL

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -142,6 +142,12 @@ module Gem
   @pre_reset_hooks      ||= []
   @post_reset_hooks     ||= []
 
+  def self.install gem
+    require 'rubygems/dependency_installer'
+    inst = Gem::DependencyInstaller.new
+    inst.install(gem).map { |gem| gem.name }
+  end
+
   ##
   # Try to activate a gem containing +path+. Returns true if
   # activation succeeded or wasn't needed because it was already


### PR DESCRIPTION
Hõla. I want `Gem.install gem` so that I can install gems from the REPL like in R.  I don't expect this PR to be merged since I added no tests, I just wanted to get a conversation started.

Also, I think @nahi may be interested in making this feature better.
