### PR TITLE
Fix missing load_yaml in YAML-related requirement.rb code.

### DIFF
--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -135,6 +135,7 @@ class Gem::Requirement
       instance_variable_set "@#{ivar}", val
     end
 
+    Gem.load_yaml
     fix_syck_default_key_in_requirements
   end
 


### PR DESCRIPTION
First of two PRs for differences in JRuby's copy of RubyGems.

Add Gem.load_yaml to yaml_initialize in requirement.rb. This avoids nearby code attempting to work with YAML classes/modules before they've been loaded.

This change has already been made on master (a PR from me committed in e2977afa), but was never backported to the 1.8 branch. Since RubyGems is still on 1.8 releases, we'd like to see this backported so we don't have to maintain it in our fork.
