### PR TITLE
URL path logic in path_support

### DIFF
--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -52,6 +52,17 @@ class Gem::PathSupport
         gem_path.push(*gpaths)
       else
         gem_path.push(*gpaths.split(File::PATH_SEPARATOR))
+
+        0.upto(gem_path.size - 1) do |i|
+          # Rejoin incorrectly split URLs. Push proto + ':' onto following item
+          if gem_path[i] =~ /^(jar(:file)?|file|classpath)$/ || # recognize commonly encountered protocols
+              (gem_path[i] =~ /^[a-z]+$/ && # some other protocol and following element begins with '//'
+               gem_path[i+1] && gem_path[i+1] =~ %r{^//})
+            gem_path[i+1] = gem_path[i] + ':' + gem_path[i+1]
+            gem_path[i] = nil
+          end
+        end if File::PATH_SEPARATOR == ':'
+        gem_path.compact!
       end
 
       if File::ALT_SEPARATOR then


### PR DESCRIPTION
I will admit this change is a bit cumbersome, but I'm looking for help coming up with something better.

This code exists in JRuby's copy of RubyGems to allow loading specs, etc from URL locations like file:, jar:, and classpath:. This feature is used extensively by JRuby to allow gems to load from within package applications that may not be expanded on the filesystem (in other words, this allows us to run gem contents from within a JRuby application archive of some sort).

The code here fixes up previously-split paths back into URLs and then continues. It's not the prettiest thing, but it was written this way to avoid functionally changing any of the path-splitting logic that already existed and only doing this when there's a file: or jar:file: or classpath: URL that gets broken into pieces.

Suggestions? Thoughts?
