### PR TITLE
Add support for long file names and paths in tar writer

### DIFF
--- a/lib/rubygems/package/tar_header.rb
+++ b/lib/rubygems/package/tar_header.rb
@@ -189,6 +189,13 @@ class Gem::Package::TarHeader
     @checksum = oct calculate_checksum(header), 6
   end
 
+  ##
+  # Returns true if the local default tar format has no file/path name length or size limits
+
+  def self.sizes_limited?
+    @sizes_limited ||= !%w(gnu posix oldgnu).include?(default_tar_format)
+  end
+
   private
 
   def calculate_checksum(header)
@@ -223,6 +230,10 @@ class Gem::Package::TarHeader
 
   def oct(num, len)
     "%0#{len}o" % num
+  end
+
+  def self.default_tar_format
+    @default_tar_format ||= `tar --show-defaults`[/--format=(\w*)/,1]
   end
 
 end

--- a/lib/rubygems/package/tar_writer.rb
+++ b/lib/rubygems/package/tar_writer.rb
@@ -267,9 +267,9 @@ class Gem::Package::TarWriter
   # Splits +name+ into a name and prefix that can fit in the TarHeader
 
   def split_name(name) # :nodoc:
-    raise Gem::Package::TooLongFileName if name.bytesize > 256
+    raise Gem::Package::TooLongFileName if Gem::Package::TarHeader.sizes_limited? && name.bytesize > 256
 
-    if name.bytesize <= 100 then
+    if !Gem::Package::TarHeader.sizes_limited? || name.bytesize <= 100 then
       prefix = ""
     else
       parts = name.split(/\//)

--- a/test/rubygems/test_gem_package_tar_header.rb
+++ b/test/rubygems/test_gem_package_tar_header.rb
@@ -126,5 +126,15 @@ group\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000
     assert_equal '012467', @tar_header.checksum
   end
 
+  def test_sizes_limited
+    Gem::Package::TarHeader.instance_variable_set(:"@default_tar_format", "gnu")
+    assert_equal "gnu", Gem::Package::TarHeader.send(:default_tar_format)
+    assert !Gem::Package::TarHeader.sizes_limited?
+
+    Gem::Package::TarHeader.instance_variable_set(:"@default_tar_format", "v7")
+    assert_equal "v7", Gem::Package::TarHeader.send(:default_tar_format)
+    assert Gem::Package::TarHeader.sizes_limited?
+  end
+
 end
 


### PR DESCRIPTION
Tar writer limits the file name size to 99 characters and the path to 155 chars. This is not necessary for tar versions that support formats other than V7 and ustar. i.e. formats. 

This patch detects the default tar format that is used locally and decides wether the format supports longer filenames.

Works properly with gnutar and defaults to legacy mode for bsdtar.

Tests included.
