### PR TITLE
Set nil values of the spec to default in Gem::Specification#self.from_yaml

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -851,7 +851,8 @@ class Gem::Specification
     end
 
     spec.instance_eval { @specification_version ||= NONEXISTENT_SPECIFICATION_VERSION }
-
+    spec.reset_nil_attributes_to_default
+    
     spec
   end
 


### PR DESCRIPTION
This solves an issue that comes with extracting and repacking gems with Gem::Builder (in RubyGems 1.8) or Gem::Package if the spec has nil values that cannot be nil.

That is caused by metadata like the following:

``` ruby
# Excerpt from idn-0.0.2.gem metadata file
platform: ruby
signing_key: 
cert_chain: 
authors: 
  - Erik Abele
```

Gem::Specification#self.from_yaml would take cert_chain as a nil, but that makes this spec file incorrect and wouldn't pass Gem::Specification#validate method as showed below. Suggested commits prevent this to happen.

``` ruby
irb(main):001:0> require 'rubygems/package'
=> true
irb(main):002:0> package = Gem::Package.new 'idn-0.0.2.gem'
=> #<Gem::Package:0x00000001e394e0 @gem="idn-0.0.2.gem", @build_time=2012-09-24 13:35:56 +0200, @checksums={}, @contents=nil, @digests={}, @files=nil, @security_policy=nil, @signatures={}, @signer=nil, @spec=nil>
irb(main):008:0> package.extract_files '/home/strzibny/unpacked'
=> nil
irb(main):009:0> patched_gem = package.spec.file_name
=> "idn-0.0.2.gem"
irb(main):012:0> patched_package = Gem::Package.new patched_gem
=> #<Gem::Package:0x00000002aa0710 @gem="idn-0.0.2.gem", @build_time=2012-09-24 13:39:08 +0200, @checksums={}, @contents=nil, @digests={}, @files=nil, @security_policy=nil, @signatures={}, @signer=nil, @spec=nil>
irb(main):013:0> patched_package.spec = package.spec.clone
=> #<Gem::Specification:0x103c658 idn-0.0.2>
irb(main):014:0> patched_package.spec.rubygems_version = '2.0.a'
=> "2.0.a"
irb(main):015:0> Dir.chdir '/home/strzibny/unpacked' do
irb(main):016:1* patched_package.build
irb(main):017:1> end
Gem::InvalidSpecificationException: cert_chain, licenses, metadata, required_rubygems_version must not be nil
    from /usr/local/share/ruby/site_ruby/rubygems/specification.rb:2354:in `validate'
    from /usr/local/share/ruby/site_ruby/rubygems/package.rb:184:in `build'
    from (irb):16:in `block in irb_binding'
    from (irb):15:in `chdir'
    from (irb):15
    from /usr/bin/irb:12:in `<main>'
irb(main):018:0> 

```
