### PR TITLE
Restore ARGV to fix test falure on ruby test-all

### DIFF
--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -766,7 +766,8 @@ load Gem.bin_path('a', 'executable', version)
 
     exe = File.join @gemhome, 'bin', 'executable'
 
-    ARGV.unshift "\xE4pfel".force_encoding("UTF-8")
+    extra_arg = "\xE4pfel".force_encoding("UTF-8")
+    ARGV.unshift extra_arg
 
     begin
       Gem::Specification.reset
@@ -775,7 +776,7 @@ load Gem.bin_path('a', 'executable', version)
         instance_eval File.read(exe)
       end
     ensure
-      ARGV.shift if ARGV.first == "\xE4pfel"
+      ARGV.shift if ARGV.first == extra_arg
     end
 
     assert_match(/ran executable/, e.message)


### PR DESCRIPTION
This was fixed in ruby repository at r37032.
I think upstream also should be fixed.

Restore ARGV properly, non-ascii strings in different encodings are not equal.
This should fix parallel test failure on ruby repository.

http://bugs.ruby-lang.org/issues/6673
[ruby-core:45975]
