### PR TITLE
Fix error on creating a Version object with a frozen string.

### DIFF
--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -187,7 +187,7 @@ class Gem::Version
     raise ArgumentError, "Malformed version number string #{version}" unless
       self.class.correct?(version)
 
-    @version = version.to_s
+    @version = version.to_s.dup
     @version.strip!
   end
 

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -33,6 +33,9 @@ class TestGemVersion < Gem::TestCase
     assert_same  fake, Gem::Version.create(fake)
     assert_nil   Gem::Version.create(nil)
     assert_equal v("5.1"), Gem::Version.create("5.1")
+    
+    ver = '1.1'.freeze
+    assert_equal v('1.1'), Gem::Version.create(ver)
   end
 
   def test_eql_eh


### PR DESCRIPTION
The logic for Version#initialize stores the to_s of the incoming value and then attempts to strip! that value in-place. This is broken for two reasons:
- It cannot accept frozen strings; an error results.
- It modifies the original string.

Note that String#to_s returns the same string, not a copy, so the dup is necessary to ensure we have our own copy of the string.
