### PR TITLE
Gem.load_yaml can be removed

### DIFF
--- a/lib/rubygems/package/tar_input.rb
+++ b/lib/rubygems/package/tar_input.rb
@@ -5,7 +5,6 @@
 #--
 
 require 'zlib'
-Gem.load_yaml
 
 class Gem::Package::TarInput
 


### PR DESCRIPTION
`Gem.load_yaml` is called from `Gem::Specification.from_yaml`, so we don't need to call it in the `tar_input.rb` file.
