### PR TITLE
5x speed anyone ?

### DIFF
--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -245,9 +245,10 @@ class Gem::Dependency
   # DOC: this method needs either documented or :nodoc'd
 
   def matching_specs platform_only = false
-    matches = Gem::Specification.find_all { |spec|
-      self.name === spec.name and # TODO: == instead of ===
-        requirement.satisfied_by? spec.version
+    matches = []
+    Gem::Specification.stubs.each { |name, version, file|
+      next unless self.name == name and requirement.satisfied_by? version
+      matches << Gem::Specification.load(file)
     }
 
     if platform_only
@@ -256,7 +257,7 @@ class Gem::Dependency
       }
     end
 
-    matches = matches.sort_by { |s| s.sort_obj } # HACK: shouldn't be needed
+    matches.sort_by { |s| s.sort_obj } # HACK: shouldn't be needed
   end
 
   ##

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1861,6 +1861,17 @@ end
     assert_equal nil, Gem::Specification.find_inactive_by_path('foo')
   end
 
+  def test_extract_basic_info
+    path = "xxx/yyy/a-1.gemspec"
+    assert_equal ["a", Gem::Version.new("1"), path], Gem::Specification.extract_basic_info(path)
+
+    path = "xxx/yyy/foo-1.2.3.gemspec"
+    assert_equal ["foo", Gem::Version.new("1.2.3"), path], Gem::Specification.extract_basic_info(path)
+
+    path = "xxx/yyy/foo-bar-1.2.3.gemspec"
+    assert_equal ["foo-bar", Gem::Version.new("1.2.3"), path], Gem::Specification.extract_basic_info(path)
+  end
+
   def util_setup_deps
     @gem = quick_spec "awesome", "1.0" do |awesome|
       awesome.add_runtime_dependency "bonobo", []


### PR DESCRIPTION
startup speed for `time ruby -r active_record/version -e ''`
and would equally affect any other simple ruby program that needs to load only a few other gems,
and should be neutral to bigger apps.

before:

```
real    0m0.808s
user    0m0.375s
sys 0m0.067s
```

after:

```
real    0m0.167s
user    0m0.132s
sys 0m0.033s
```

It's definitely not perfect, e.g. 1.2.3-rc2 would not be supported, but e.g. tweaking the filenames of stored gems to replace - in versions with -- and maybe adding the platform could solve those edge-cases.
Also making the spec itself aware of being a stub and replacing itself when more info is needed could make it less disrupting for other users of specifications. But for now just a small idea to see if you like it / want to hack on it :)
