### PR TITLE
Remove reference to 'sources' gem in docs.

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -783,9 +783,8 @@ module Gem
   end
 
   ##
-  # Returns an Array of sources to fetch remote gems from.  If the sources
-  # list is empty, attempts to load the "sources" gem, then uses
-  # default_sources if it is not installed.
+  # Returns an Array of sources to fetch remote gems from. Uses
+  # default_sources if the sources list is empty.
 
   def self.sources
     @sources ||= Gem::SourceList.from(default_sources)


### PR DESCRIPTION
The 'sources' gem is no longer used (see commit
e72e92fc996b8590a5361b62159f3603f92152e0).

Delete reference to it in docs for Gem.sources.
