### PR TITLE
check when building for non-world-writable files

### DIFF
--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -196,6 +196,28 @@ class TestGemPackage < Gem::Package::TarTestCase
     assert_equal %w[lib/code.rb], reader.contents
   end
 
+  def test_build_bad_permissions
+    bad_file = "./gemhome/cache/a-2.gem"
+
+    spec = Gem::Specification.new 'build', '1'
+    spec.summary = 'build'
+    spec.authors = 'build'
+    spec.files = [bad_file]
+
+    package = Gem::Package.new spec.file_name
+    package.spec = spec
+
+    # make the file non-world-readable
+    File.chmod(00640, bad_file)
+
+    use_ui @ui do
+      package.build
+    end
+
+    assert_match(
+        "files found with non-world-readable permissions", @ui.error)
+  end
+
   def test_build_invalid
     spec = Gem::Specification.new 'build', '1'
 


### PR DESCRIPTION
Warn users at 'gem build' time if the gem's files 
are not world readable.

//

Please let me know if you'd like this in the spec verification code or if you would like an accompanying test.

Originally requested by myself in https://github.com/rubygems/rubygems/issues/191.

Thanks,
Andy
