### PR TITLE
Allow String gem path separator to be configurable

### DIFF
--- a/lib/rubygems/defaults.rb
+++ b/lib/rubygems/defaults.rb
@@ -58,6 +58,13 @@ module Gem
   end
 
   ##
+  # How String Gem paths should be split.  Overridable for esoteric platforms.
+
+  def self.path_separator
+    File::PATH_SEPARATOR
+  end
+
+  ##
   # Default gem load path
 
   def self.default_path

--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -54,7 +54,7 @@ class Gem::PathSupport
       if gpaths.kind_of?(Array)
         gem_path = gpaths.dup
       else
-        gem_path = gpaths.split(File::PATH_SEPARATOR)
+        gem_path = gpaths.split(Gem.path_separator)
       end
 
       if File::ALT_SEPARATOR then


### PR DESCRIPTION
This is an alternate solution to 'URL path logic in path_support (#371)' in which it depends on being able to specify a custom path separator.  By pulling this out we can specify the following in our defaults/jruby.rb:

``` ruby
  def self.path_separator
    return PATH_SEPARATOR if PATH_SEPARATOR != ':'
    /(?<!jar:file|jar|file|classpath):/
  end

```

which allows us to specify jar and classpath type gem path entries.  First and probably last time I will ever use negative backtracking in a regexp; but hey it keeps ugly JRuby logic out of Rubygems.
