### PR TITLE
When gem uninstall would break dependencies, default to [yN] instead of [Yn].

### DIFF
--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -296,7 +296,7 @@ class Gem::Uninstaller
 
     msg << 'If you remove this gem, these dependencies will not be met.'
     msg << 'Continue with Uninstall?'
-    return ask_yes_no(msg.join("\n"), true)
+    return ask_yes_no(msg.join("\n"), false)
   end
 
   def formatted_program_filename(filename)


### PR DESCRIPTION
When gem cleanup is run and removing a gem would result in dependencies not being met, the user is prompted with "Continue with Uninstall? [Yn]". It seems the preferred query would be [yN], so users can quickly hit return to decline to break dependencies but still cleanup old gems.
