### PR TITLE
Fixed benchmark lib require without inclusion in $LOADED_FEATURES

### DIFF
--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -57,9 +57,8 @@ class TestGemRequire < Gem::TestCase
   end
 
   def test_activate_via_require_respects_loaded_files
+    require 'benchmark' # stdlib
     save_loaded_features do
-      require 'benchmark' # stdlib
-
       a1 = new_spec "a", "1", {"b" => ">= 1"}, "lib/a.rb"
       b1 = new_spec "b", "1", nil, "lib/benchmark.rb"
       b2 = new_spec "b", "2", nil, "lib/benchmark.rb"


### PR DESCRIPTION
Hello,

`TestGemRequire#test_activate_via_require_respects_loaded_files` requires the benchmark library but removes the path from `$LOADED_FEATURES`, therefore making it possible to be required twice (and so causing redefined constants warnings and such).

This patch requires `'benchmark'` before the `save_loaded_features` block to avoid such problem. An easy way to see the problem is to add `require 'benchmark'` in a test executed after this one.
