### PR TITLE
make licenses a required field for new gems

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -120,6 +120,7 @@ class Gem::Specification
                            :version,
                            :date,
                            :summary,
+                           :licenses,
                            :require_paths]
 
   ##


### PR DESCRIPTION
Software should have a license. Most gems do have one but it is not
specified in the gemspec. Let's make it required so that it can be
automatically retrieved.
