### PR TITLE
Make sure Gem.refresh keeps already loaded gems activated

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -656,6 +656,12 @@ class Gem::Specification
 
       @@all = specs.values
 
+      # After a reset, make sure already loaded specs
+      # are still marked as activated.
+      specs = {}
+      Gem.loaded_specs.each_value{|s| specs[s] = true}
+      @@all.each{|s| s.activated = true if specs[s]}
+
       _resort!
     end
     @@all

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -959,6 +959,27 @@ class TestGem < Gem::TestCase
     assert_includes Gem::Specification.all_names, @a1.full_name
   end
 
+  def test_self_refresh_keeps_loaded_specs_activated
+    util_make_gems
+
+    a1_spec = @a1.spec_file
+    moved_path = File.join @tempdir, File.basename(a1_spec)
+
+    FileUtils.mv a1_spec, moved_path
+
+    Gem.refresh
+
+    s = Gem::Specification.first
+    s.activate
+
+    Gem.refresh
+
+    Gem::Specification.each{|spec| assert spec.activated? if spec == s}
+
+    Gem.loaded_specs.delete(s)
+    Gem.refresh
+  end
+
   def test_self_ruby_escaping_spaces_in_path
     orig_ruby = Gem.ruby
     orig_bindir = Gem::ConfigMap[:bindir]


### PR DESCRIPTION
Previously, calling Gem.refresh made it so all specifications
yielded by Gem::Specification.each had activated = false, even
if the same specs were in Gem.loaded_specs with activated = true.
For consistency, you can either clear Gem.loaded_specs when
refreshing the specifications, or make sure the refreshed
specifications reflect the already loaded gems.  I think the
latter behavior makes more sense.
