### PR TITLE
If `credentials` file has permissions other than 0600, abort with warning.

### DIFF
--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -255,6 +255,11 @@ class Gem::ConfigFile
     File.open(credentials_path, 'w', permissions) do |f|
       f.write config.to_yaml
     end
+    
+    existing_permissions = File.stat(credentials_path).mode.to_s(8)[2..5]
+    unless existing_permissions == '0600'
+      abort "Your gem `credentials` file located at #{credentials_path} has file permissions of #{existing_permissions} but 0600 is required."
+    end
 
     @rubygems_api_key = api_key
   end


### PR DESCRIPTION
I don't know if a warning to $stderr with exitstatus of 1 is the desired behavior if `credentials` file has permissions other than 0600? I'm also uncertain how this should be properly tested?

I initially was thinking fixing the permissions was appropriate, but Whitequark pointed out that "if they were insecure and the user was unaware of that, the credentials might have already been compromised and by automatically changing the perms, you'd hide that fact.... I'd suggest checking permissions and if they're wrong, doing nothing."
