### PR TITLE
Do not modify global Specification.dirs during installation.

### DIFF
--- a/lib/rubygems/dependency_installer.rb
+++ b/lib/rubygems/dependency_installer.rb
@@ -58,12 +58,7 @@ class Gem::DependencyInstaller
 
   def initialize(options = {})
     if options[:install_dir] then
-      @gem_home = options[:install_dir]
-
-      # HACK shouldn't change the global settings
-      Gem::Specification.dirs = @gem_home
-      Gem.ensure_gem_subdirectories @gem_home
-      options[:install_dir] = @gem_home # FIX: because we suck and reuse below
+      Gem.ensure_gem_subdirectories options[:install_dir]
     end
 
     options = DEFAULT_OPTIONS.merge options


### PR DESCRIPTION
While gems are installed into --install-dir just fine even without
modifications of Specification.dirs, change in it makes inaccessible
gems already present on the system.
