### PR TITLE
if MAKE or make are in the environment, use those instead of rbconfig's make.

### DIFF
--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -25,7 +25,7 @@ class Gem::Ext::Builder
 
     # try to find make program from Ruby configure arguments first
     RbConfig::CONFIG['configure_args'] =~ /with-make-prog\=(\w+)/
-    make_program = $1 || ENV['MAKE'] || ENV['make']
+    make_program = ENV['MAKE'] || ENV['make'] || $1
     unless make_program then
       make_program = (/mswin/ =~ RUBY_PLATFORM) ? 'nmake' : 'make'
     end


### PR DESCRIPTION
This is a solution for #426. I don't think there's an easy way to test it but am willing to write them if anyone has a good idea of how to.

It's very easy to get into this situation for non-linux, non-osx users, so I'm hoping this can make it in ASAP. The current situation is "rebuild ruby" for these situations, the converse (where someone has make in their environment and that breaks things because of this change) is much easier to resolve for the end-user, which is why I think this change is pretty safe.
