### PR TITLE
Require UserInteraction before including it

### DIFF
--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -4,6 +4,8 @@
 # See LICENSE.txt for permissions.
 #++
 
+require 'rubygems/user_interaction'
+
 ##
 # Gem::ConfigFile RubyGems options and gem command options from gemrc.
 #


### PR DESCRIPTION
Commit 5db04b1c07fcd9ae9e38313e371dfa2e708ca3b4 started including
Gem::UserInteraction into Gem::ConfigFile, but didn't add a require.
The Bundler tests against rubygems master started failing as a result.
If this should be done a different way, just let me know.
