### PR TITLE
Make checking for existing executable respect format_executable 

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -132,7 +132,7 @@ class Gem::Installer
   def check_executable_overwrite filename # :nodoc:
     return if @force
 
-    generated_bin = File.join @bin_dir, filename
+    generated_bin = File.join @bin_dir, formatted_program_filename(filename)
 
     return unless File.exist? generated_bin
 


### PR DESCRIPTION
With the current code, it checks against the unformatted name instead of the formatted name, which is definitely a bug.

Sorry for the lack of tests on this. I couldn't figure out a simple way to add tests for this behavior that didn't involve a copy/pasting a large chunk of code or refactoring the test suite.
