### PR TITLE
Error when loading YAML config file should show the file which failed

### DIFF
--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -317,14 +317,14 @@ if you believe they were disclosed to a third party.
     begin
       content = YAML.load(File.read(filename))
       unless content.kind_of? Hash
-        warn "Failed to load #{config_file_name} because it doesn't contain valid YAML hash"
+        warn "Failed to load #{filename} because it doesn't contain valid YAML hash"
         return {}
       end
       return content
     rescue ArgumentError
-      warn "Failed to load #{config_file_name}"
+      warn "Failed to load #{filename}"
     rescue Errno::EACCES
-      warn "Failed to load #{config_file_name} due to permissions problem."
+      warn "Failed to load #{filename} due to permissions problem."
     end
 
     {}


### PR DESCRIPTION
Just spent ages trying to figure out what was wrong with my .gemrc, turns out it was fine and my .gem/credentials file was at fault but the error was incorrectly mentioning .gemrc
