### PR TITLE
add PATH to gem env

### DIFF
--- a/lib/rubygems/commands/environment_command.rb
+++ b/lib/rubygems/commands/environment_command.rb
@@ -104,6 +104,7 @@ lib/rubygems/defaults/operating_system.rb
         out << "    - #{platform}\n"
       end
 
+      out << "  - PATH: #{ENV['PATH']}\n"
       out << "  - GEM PATHS:\n"
       out << "     - #{Gem.dir}\n"
 


### PR DESCRIPTION
although PATH is not part of rubygems, but it is very important to the functionality of rubygems, especially when it does not match `GEM_PATH` - so adding it to `gem env` would make it a lot easier to debug different problems
