### PR TITLE
Fix for issue 522 and communication security improvement. 

### DIFF
--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -409,6 +409,7 @@ class Gem::RemoteFetcher
   def configure_connection_for_https(connection)
     require 'net/https'
     connection.use_ssl = true
+    connection.ssl_version = :TLSv1
     connection.verify_mode =
       Gem.configuration.ssl_verify_mode || OpenSSL::SSL::VERIFY_PEER
     store = OpenSSL::X509::Store.new


### PR DESCRIPTION
I noticed the issue described in 522 was being discussed elsewhere over the last few weeks. If you Google the issue title in 522 you will see several examples. Ruby uses the OpenSSL SSLv23 client method by default. The problem with that is that in many cases the server will not understand SSLv2 client hello messages which will cause problems. This is a difficult issue to replicate because of several client and server side host level variables that can impact cipher suite support. 

Also, running a client like this leaves you open to ssl degradation attacks. It's not 1995 so I don't think we have to worry about pulling gems from someone who can only support SSL 2.0. 

Some more background.
http://www.openssl.org/docs/ssl/SSL_CTX_new.html#NOTES
