### PR TITLE
Implement Gem::Specification#hash more efficiently

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1705,9 +1705,7 @@ class Gem::Specification
   # :startdoc:
 
   def hash # :nodoc:
-    @@attributes.inject(0) { |hash_code, (name, _)|
-      hash_code ^ self.send(name).hash
-    }
+    name.hash ^ version.hash
   end
 
   def init_with coder # :nodoc:


### PR DESCRIPTION
I found that 7% of the startup time of a vanilla Rails app is spent in `Gem::Specification#hash`:

![](http://i.imgur.com/7rF4qOC.png)

I've reimplemented this method so that it only takes into account the specification's name and version. This should be adequate for hashing purposes.

With this benchmark script:

``` ruby
require "rubygems"
require "benchmark"

specs = Gem::Specification._all

puts "#{specs.count} specs, #{specs.map(&:hash).uniq.count} unique hashes"

puts Benchmark.measure { 100.times { specs.each(&:hash) } }
```

I've found that just `name.hash ^ version.hash` is over 100x faster than the current hash, and does just as good a job at generating unique hash values:

**Current hash:**

```
λ ruby test_script.rb
421 specs, 421 unique hashes
  2.680000   0.000000   2.680000 (  2.678905)
```

**New hash:**

```
λ ruby --disable-gem -I./lib test_script.rb
421 specs, 421 unique hashes
  0.020000   0.000000   0.020000 (  0.017726)
```
