### PR TITLE
cache dup logic to speed up Gem::Specification#initialize

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -160,6 +160,17 @@ class Gem::Specification < Gem::BasicSpecification
     :version                   => nil,
   }
 
+  Dupable = { }
+
+  @@default_value.each do |k,v|
+    case v
+    when Time, Numeric, Symbol, true, false, nil
+      Dupable[k] = false
+    else
+      Dupable[k] = true
+    end
+  end
+
   @@attributes = @@default_value.keys.sort_by { |s| s.to_s }
   @@array_attributes = @@default_value.reject { |k,v| v != [] }.keys
   @@nil_attributes, @@non_nil_attributes = @@default_value.keys.partition { |k|
@@ -1682,11 +1693,7 @@ class Gem::Specification < Gem::BasicSpecification
 
     @@non_nil_attributes.each do |key|
       default = default_value(key)
-      value = case default
-              when Time, Numeric, Symbol, true, false, nil then default
-              else default.dup
-              end
-
+      value = Dupable[key] ? default.dup : default
       instance_variable_set "@#{key}", value
     end
 


### PR DESCRIPTION
Gem::Specification#initialize is a hotspot when booting Rails.  This PR caches the "dup" logic in the initialize method for a speed bump on init.  This diff speeds up initialization by about 20% (depending on if GC is on or off).

Here's my benchmark:

``` ruby
require 'benchmark/ips'

class AaronSpec < Gem::Specification
  @@default_value_init = {}

  @@default_value.each_with_object({}) { |(k,v), h|
    lookup = case v
             when Time, Numeric, Symbol, true, false, nil
               lambda { v }
             else
               lambda { v.dup }
             end
    @@default_value_init[k] = lookup
  }

  def default_value_init name
    @@default_value_init[name].call
  end

  def initialize name = nil, version = nil
    @loaded = false
    @activated = false
    self.loaded_from = nil
    @original_platform = nil

    @@nil_attributes.each do |key|
      instance_variable_set "@#{key}", nil
    end

    @@non_nil_attributes.each do |key|
      value = default_value_init(key)
      instance_variable_set "@#{key}", value
    end

    @new_platform = Gem::Platform::RUBY

    self.name = name if name
    self.version = version if version

    yield self if block_given?
  end
end

GC.disable

Benchmark.ips do |x|
  x.report("aaron")    { AaronSpec.new }
  x.report("original") { Gem::Specification.new }
end

__END__
Calculating -------------------------------------
               aaron      2195 i/100ms
            original      1746 i/100ms
-------------------------------------------------
               aaron    22236.2 (±7.3%) i/s -     111945 in   5.068976s
            original    16947.0 (±7.8%) i/s -      85554 in   5.085530s

```
