### PR TITLE
Added --abort-on-dependent which prevents uninstalling gems that are depended on

### DIFF
--- a/lib/rubygems/commands/uninstall_command.rb
+++ b/lib/rubygems/commands/uninstall_command.rb
@@ -67,6 +67,11 @@ class Gem::Commands::UninstallCommand < Gem::Command
       options[:force] = value
     end
 
+    add_option('--abort-on-dependent',
+               'Prevent uninstalling gems that are depended on by other gems.') do |value, options|
+      options[:abort_on_dependent] = value
+    end
+
     add_version_option
     add_platform_option
   end

--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -43,14 +43,15 @@ class Gem::Uninstaller
 
   def initialize(gem, options = {})
     # TODO document the valid options
-    @gem               = gem
-    @version           = options[:version] || Gem::Requirement.default
-    @gem_home          = File.expand_path(options[:install_dir] || Gem.dir)
-    @force_executables = options[:executables]
-    @force_all         = options[:all]
-    @force_ignore      = options[:ignore]
-    @bin_dir           = options[:bin_dir]
-    @format_executable = options[:format_executable]
+    @gem                = gem
+    @version            = options[:version] || Gem::Requirement.default
+    @gem_home           = File.expand_path(options[:install_dir] || Gem.dir)
+    @force_executables  = options[:executables]
+    @force_all          = options[:all]
+    @force_ignore       = options[:ignore]
+    @bin_dir            = options[:bin_dir]
+    @format_executable  = options[:format_executable]
+    @abort_on_dependent = options[:abort_on_dependent]
 
     # Indicate if development dependencies should be checked when
     # uninstalling. (default: false)
@@ -143,7 +144,7 @@ class Gem::Uninstaller
     @spec = spec
 
     unless dependencies_ok? spec
-      unless ask_if_ok(spec)
+      if abort_on_dependent? || !ask_if_ok(spec)
         raise Gem::DependencyRemovalException,
           "Uninstallation aborted due to dependent gem(s)"
       end
@@ -288,6 +289,10 @@ class Gem::Uninstaller
 
     deplist = Gem::DependencyList.from_specs
     deplist.ok_to_remove?(spec.full_name, @check_dev)
+  end
+
+  def abort_on_dependent?
+    !!@abort_on_dependent
   end
 
   def ask_if_ok(spec)

--- a/test/rubygems/test_gem_uninstaller.rb
+++ b/test/rubygems/test_gem_uninstaller.rb
@@ -375,6 +375,19 @@ class TestGemUninstaller < Gem::InstallerTestCase
     assert_equal "Successfully uninstalled q-1.0", lines.shift
   end
 
+  def test_uninstall_doesnt_prompt_and_raises_when_abort_on_dependent_set
+    quick_gem 'r', '1' do |s| s.add_dependency 'q', '= 1' end
+    quick_gem 'q', '1'
+
+    un = Gem::Uninstaller.new('q', :abort_on_dependent => true)
+    ui = Gem::MockGemUi.new("y\n")
+
+    assert_raises Gem::DependencyRemovalException do
+      use_ui ui do
+        un.uninstall
+      end
+    end
+  end
 
   def test_uninstall_prompt_includes_dep_type
     quick_gem 'r', '1' do |s|


### PR DESCRIPTION
If there's anything wrong with this PR please let me know.

My primary use case is when running `gem clean` I want it to keep all of the gems that prompt for dependencies without prompting.  As I'm new to contributing to rubygems I may not have covered this use case properly in `gem clean`. Is that the case?

Thanks!
