### PR TITLE
Don't fsync every file when installing gems

### DIFF
--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -336,7 +336,6 @@ EOM
 
         open destination, 'wb', entry.header.mode do |out|
           out.write entry.read
-          out.fsync rescue nil # for filesystems without fsync(2)
         end
 
         say destination if Gem.configuration.really_verbose


### PR DESCRIPTION
d84090b introduced "similar sync behavior from old tar code". It looks like the old code was fsyncing directories, but the commit was fsyncing every single file.

This fixes a severe performance degradation in our virtualized environment. Gem install takes ~40 seconds on rubygems 2.0 compared to ~1 second on rubygems 1.8.

I looked through the last version that didn't have those performance issues - 1.8.25 - and the  Gem::Package::FSyncDir module is dead code there. 

I don't know rubygems well enough to say if its absolutely safe to remove this code, but from my limited testing it seems that it is. I installed a few gems with checking if any TarReader::Entry is a directory, and none of them is.
