### PR TITLE
Ensure that RUBYGEMS_HOST is defined  

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -4,6 +4,8 @@
 
 Minor enhancements:
 
+* Ensure that RUBYGEMS_HOST isn't empty so some displayed messages don't refer
+  to a bad URL
 * `gem clean` now allows `-n` as an alias for `--dryrun`.  Pull Request #517
   by Gastón Ramos
 * Added `gem update --system` to `gem help`.  Pull Request #514 by Vince

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -60,7 +60,11 @@ module Gem::GemcutterUtilities
     configured_host = Gem.host unless
       Gem.configuration.disable_default_gem_server
 
-    @host ||= ENV['RUBYGEMS_HOST'] || configured_host
+    if ENV['RUBYGEMS_HOST'].empty?
+      ENV['RUBYGEMS_HOST'] = configured_host
+    end
+
+    @host ||=  ENV['RUBYGEMS_HOST']
   end
 
   def rubygems_api_request(method, path, host = nil, &block)


### PR DESCRIPTION
Hello, 

Empty string are evaluated to true so this patch avoid this

```
Enter your  credentials. 
Don't have an account yet? Create one at https:///sign_up
```

I don't know how I could add a test for this but let me know if I should add it.

I've added an entry in the `History.txt` file, I don't know if it's the good place for it.

Have a nice day.
