### PR TITLE
Cache Gem::Specification.load

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -960,6 +960,10 @@ class Gem::Specification < Gem::BasicSpecification
     LOAD_CACHE[file] ||= load_without_cache file
   end
 
+  def self._clear_load_cache!
+    LOAD_CACHE.clear
+  end
+
   def self.load_without_cache file
     return unless file
     file = file.dup.untaint

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -280,6 +280,8 @@ class Gem::TestCase < MiniTest::Unit::TestCase
     Gem.instance_variable_set :@default_dir, nil
 
     ENV['GEM_PRIVATE_KEY_PASSPHRASE'] = @orig_gem_private_key_passphrase
+
+    Gem::Specification._clear_load_cache!
   end
 
   ##


### PR DESCRIPTION
This pull request caches the result of `Gem::Specification#load`. For some reason, Rubygems will try to load the same gemspec multiple times, so this speeds things up a little bit there.

```
master λ time ruby --disable-gem -Ilib -rubygems ~/.gem/ruby/2.0.0/bin/pry -e exit

real    0m0.495s
user    0m0.446s
sys     0m0.046s
master λ gco cache-gem-specification-load
Switched to branch 'cache-gem-specification-load'
cache-gem-specification-load λ time ruby --disable-gem -Ilib -rubygems ~/.gem/ruby/2.0.0/bin/pry -e exit

real    0m0.347s
user    0m0.306s
sys     0m0.039s
```
