### PR TITLE
fix detecting yaml parsing errors for psych, add the parsing message

### DIFF
--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -314,6 +314,8 @@ if you believe they were disclosed to a third party.
 
     return {} unless filename and File.exist? filename
 
+    syntax_errors = [ArgumentError]
+    syntax_errors << Psych::SyntaxError if Kernel.const_defined?('Psych')
     begin
       content = YAML.load(File.read(filename))
       unless content.kind_of? Hash
@@ -321,8 +323,8 @@ if you believe they were disclosed to a third party.
         return {}
       end
       return content
-    rescue ArgumentError
-      warn "Failed to load #{filename}"
+    rescue *syntax_errors => e
+      warn "Failed to load #{filename}, #{e.to_s}"
     rescue Errno::EACCES
       warn "Failed to load #{filename} due to permissions problem."
     end


### PR DESCRIPTION
follow up from https://github.com/wayneeseguin/rvm/issues/1955
- fixes detecting parsing errors when `Psych` is used
- adds the parsing error to the warning so it's easier to locate the problem

please also port this to `rubygems` 2.0
