### PR TITLE
Pass DESTDIR via command line to override what's in MAKEFLAGS.

### DIFF
--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -23,9 +23,14 @@ class Gem::Ext::Builder
       make_program = (/mswin/ =~ RUBY_PLATFORM) ? 'nmake' : 'make'
     end
 
-    ['', ' install'].each do |target|
-      cmd = "#{make_program}#{target}"
-      run(cmd, results, "make#{target}")
+    ['', 'install'].each do |target|
+      # Pass DESTDIR via command line to override what's in MAKEFLAGS
+      cmd = [
+        make_program,
+        '"DESTDIR=%s"' % ENV['DESTDIR'],
+        target
+      ].join(' ').rstrip
+      run(cmd, results, "make #{target}".rstrip)
     end
   end
 

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -28,6 +28,7 @@ require 'rubygems/test_utilities'
 require 'pp'
 require 'zlib'
 require 'pathname'
+require 'shellwords'
 Gem.load_yaml
 
 require 'rubygems/mock_gem_ui'
@@ -104,6 +105,63 @@ class Gem::TestCase < Minitest::Test
   def refute_path_exists path, msg = nil
     msg = message(msg) { "Expected path '#{path}' to not exist" }
     refute File.exist?(path), msg
+  end
+
+  def scan_make_command_lines(output)
+    output.scan(/^#{Regexp.escape make_command}(?:[[:blank:]].*)?$/)
+  end
+
+  def parse_make_command_line(line)
+    command, *args = line.shellsplit
+
+    targets = []
+    macros = {}
+
+    args.each do |arg|
+      case arg
+      when /\A(\w+)=/
+        macros[$1] = $'
+      else
+        targets << arg
+      end
+    end
+
+    targets << '' if targets.empty?
+
+    {
+      :command => command,
+      :targets => targets,
+      :macros => macros,
+    }
+  end
+
+  def assert_contains_make_command(target, output, msg = nil)
+    if output.match(/\n/)
+      msg = message(msg) {
+        'Expected output containing make command "%s": %s' % [
+          ('%s %s' % [make_command, target]).rstrip,
+          output.inspect
+        ]
+      }
+    else
+      msg = message(msg) {
+        'Expected make command "%s": %s' % [
+          ('%s %s' % [make_command, target]).rstrip,
+          output.inspect
+        ]
+      }
+    end
+
+    assert scan_make_command_lines(output).any? { |line|
+      make = parse_make_command_line(line)
+
+      if make[:targets].include?(target)
+        yield make, line if block_given?
+        true
+      else
+        false
+      end
+    }, msg
   end
 
   include Gem::DefaultUserInteraction

--- a/test/rubygems/test_gem_ext_cmake_builder.rb
+++ b/test/rubygems/test_gem_ext_cmake_builder.rb
@@ -38,8 +38,8 @@ install (FILES test.txt DESTINATION bin)
     assert_match \
       %r%^cmake \. -DCMAKE_INSTALL_PREFIX=#{Regexp.escape @dest_path}%, output
     assert_match %r%#{Regexp.escape @ext}%, output
-    assert_match %r%^#{Regexp.escape make_command}$%, output
-    assert_match %r%^#{Regexp.escape make_command} install$%, output
+    assert_contains_make_command '', output
+    assert_contains_make_command 'install', output
     assert_match %r%test\.txt%, output
   end
 
@@ -82,8 +82,8 @@ install (FILES test.txt DESTINATION bin)
 
     output = output.join "\n"
 
-    assert_match %r%^#{make_command}%,         output
-    assert_match %r%^#{make_command} install%, output
+    assert_contains_make_command '', output
+    assert_contains_make_command 'install', output
   end
 
 end

--- a/test/rubygems/test_gem_ext_configure_builder.rb
+++ b/test/rubygems/test_gem_ext_configure_builder.rb
@@ -30,9 +30,9 @@ class TestGemExtConfigureBuilder < Gem::TestCase
 
     assert_equal "sh ./configure --prefix=#{@dest_path}", output.shift
     assert_equal "", output.shift
-    assert_equal make_command, output.shift
+    assert_contains_make_command '', output.shift
     assert_match(/^ok$/m, output.shift)
-    assert_equal make_command + " install", output.shift
+    assert_contains_make_command 'install', output.shift
     assert_match(/^ok$/m, output.shift)
   end
 
@@ -76,8 +76,8 @@ class TestGemExtConfigureBuilder < Gem::TestCase
       Gem::Ext::ConfigureBuilder.build nil, nil, @dest_path, output
     end
 
-    assert_equal make_command, output[0]
-    assert_equal "#{make_command} install", output[2]
+    assert_contains_make_command '', output[0]
+    assert_contains_make_command 'install', output[2]
   end
 
 end

--- a/test/rubygems/test_gem_ext_ext_conf_builder.rb
+++ b/test/rubygems/test_gem_ext_ext_conf_builder.rb
@@ -32,14 +32,8 @@ class TestGemExtExtConfBuilder < Gem::TestCase
 
     assert_match(/^#{Gem.ruby} extconf.rb/, output[0])
     assert_equal "creating Makefile\n", output[1]
-    case RUBY_PLATFORM
-    when /mswin/ then
-      assert_equal "nmake", output[2]
-      assert_equal "nmake install", output[4]
-    else
-      assert_equal "make", output[2]
-      assert_equal "make install", output[4]
-    end
+    assert_contains_make_command '', output[2]
+    assert_contains_make_command 'install', output[4]
   end
 
   def test_class_build_rbconfig_make_prog
@@ -56,8 +50,8 @@ class TestGemExtExtConfBuilder < Gem::TestCase
     end
 
     assert_equal "creating Makefile\n", output[1]
-    assert_equal make_command, output[2]
-    assert_equal "#{make_command} install", output[4]
+    assert_contains_make_command '', output[2]
+    assert_contains_make_command 'install', output[4]
   ensure
     RbConfig::CONFIG['configure_args'] = configure_args
   end
@@ -80,7 +74,7 @@ class TestGemExtExtConfBuilder < Gem::TestCase
     end
 
     assert_equal "creating Makefile\n", output[1]
-    assert_equal "anothermake", output[2]
+    assert_contains_make_command '', output[2]
   ensure
     RbConfig::CONFIG['configure_args'] = configure_args
     ENV['make'] = env_make
@@ -132,8 +126,8 @@ checking for main\(\) in .*?nonexistent/m, error.message)
       Gem::Ext::ExtConfBuilder.make @ext, output
     end
 
-    assert_equal make_command, output[0]
-    assert_equal "#{make_command} install", output[2]
+    assert_contains_make_command '', output[0]
+    assert_contains_make_command 'install', output[2]
   end
 
   def test_class_make_no_Makefile


### PR DESCRIPTION
This fixes an installation problem under a package building
environment where DESTDIR is specified in the (parent) command line.

Related bug reports:
- https://bugzilla.redhat.com/show_bug.cgi?id=921650
- https://github.com/ruby/ruby/pull/327
