### PR TITLE
Fix a test failure on Windows

### DIFF
--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1074,6 +1074,7 @@ gem 'other', version
 
         CONFIG['CC'] = '$(TOUCH) $@ ||'
         CONFIG['LDSHARED'] = '$(TOUCH) $@ ||'
+        $ruby = '#{Gem.ruby}'
 
         create_makefile("#{@spec.name}")
       RUBY


### PR DESCRIPTION
This patch fixes a test failure on on RubyInstaller CI.
The test requires ruby only on Windows, but ruby is not available if
ruby is not installed. Instead we use Gem.ruby.
https://bugs.ruby-lang.org/issues/8058
