### PR TITLE
Remove --all from `gem pristine -h` list of defaults to reflect existing behavior.

### DIFF
--- a/lib/rubygems/commands/pristine_command.rb
+++ b/lib/rubygems/commands/pristine_command.rb
@@ -37,7 +37,7 @@ class Gem::Commands::PristineCommand < Gem::Command
   end
 
   def defaults_str # :nodoc:
-    "--all --extensions"
+    "--extensions"
   end
 
   def description # :nodoc:


### PR DESCRIPTION
Current `gem pristine -h` default claim --all flag, which contradicts actual behavior and tests. Removed --all from defaults.
