### PR TITLE
Remove siteconf temp file once unused

### DIFF
--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -37,6 +37,7 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
         run cmd, results
 
         ENV["DESTDIR"] = nil
+        siteconf.unlink
 
         make dest_path, results
 

--- a/test/rubygems/test_gem_ext_ext_conf_builder.rb
+++ b/test/rubygems/test_gem_ext_ext_conf_builder.rb
@@ -34,6 +34,7 @@ class TestGemExtExtConfBuilder < Gem::TestCase
     assert_equal "creating Makefile\n", output[1]
     assert_contains_make_command '', output[2]
     assert_contains_make_command 'install', output[4]
+    assert_empty Dir.glob(File.join(@ext, 'siteconf*.rb'))
   end
 
   def test_class_build_rbconfig_make_prog


### PR DESCRIPTION
Clean up the sitearch temp file before running any make commands to prevent
the temp file being copied into the gem installation.

Doing an install of the 'mysql' gem leads to something like this being installed:

```
/usr/local/share/gems/gems/mysql-2.9.1/ext/mysql_api/siteconf20130708-4079-k7iv3m.rb
```
