### PR TITLE
initial executable hooks

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -160,6 +160,7 @@ module Gem
   @ruby = nil
   @sources = nil
 
+  @executables_hooks    ||= []
   @post_build_hooks     ||= []
   @post_install_hooks   ||= []
   @post_uninstall_hooks ||= []
@@ -709,6 +710,13 @@ module Gem
   end
 
   ##
+  # Adds a execute hook that will be called before gem executable is ran.
+
+  def self.execute(&hook)
+    @executables_hooks << hook
+  end
+
+  ##
   # Adds a post-build hook that will be passed an Gem::Installer instance
   # when Gem::Installer#install is called.  The hook is called after the gem
   # has been extracted and extensions have been built but before the
@@ -995,6 +1003,19 @@ module Gem
   end
 
   ##
+  # Find the 'rubygems_executable_plugin' files in the latest installed gems
+  # and load them
+
+  def self.load_executable_plugins
+    # Remove this env var by at least 3.0
+    if ENV['RUBYGEMS_LOAD_ALL_PLUGINS']
+      load_plugin_files find_files('rubygems_executable_plugin', false)
+    else
+      load_plugin_files find_latest_files('rubygems_executable_plugin', false)
+    end
+  end
+
+  ##
   # Find the 'rubygems_plugin' files in the latest installed gems and load
   # them
 
@@ -1094,6 +1115,11 @@ module Gem
     def clear_default_specs
       @path_to_default_spec_map.clear
     end
+
+    ##
+    # The list of hooks to be run before gem executable is ran
+
+    attr_reader :executables_hooks
 
     ##
     # The list of hooks to be run after Gem::Installer#install extracts files

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -636,6 +636,14 @@ if ARGV.first
   end
 end
 
+begin
+  Gem.load_executable_plugins
+  Gem.executables_hooks.each do |hook|
+    hook.call('#{bin_file_name}')
+  end
+rescue
+end
+
 gem '#{spec.name}', version
 load Gem.bin_path('#{spec.name}', '#{bin_file_name}', version)
 TEXT

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -47,6 +47,14 @@ if ARGV.first
   end
 end
 
+begin
+  Gem.load_executable_plugins
+  Gem.executables_hooks.each do |hook|
+    hook.call('executable')
+  end
+rescue
+end
+
 gem 'a', version
 load Gem.bin_path('a', 'executable', version)
     EOF


### PR DESCRIPTION
Allow a gem to include `lib/rubygems_executable_plugin.rb` with:

``` ruby
Gem.execute do |original_file|
  warn("Executing: #{original_file}")
end
```

which will be called before gem executable is ran

This code would eliminate the need for https://github.com/mpapis/executable-hooks - which is a huge hack to do the same thing.
