### PR TITLE
Speed up dependency matching

### DIFF
--- a/lib/rubygems/spec_fetcher.rb
+++ b/lib/rubygems/spec_fetcher.rb
@@ -74,6 +74,12 @@ class Gem::SpecFetcher
 
     list, errors = available_specs(type)
     list.each do |source, specs|
+      if dependency.name.is_a?(String) && specs.respond_to?(:bsearch)
+        start_index = (0 ... specs.length).bsearch{ |i| specs[i].name >= dependency.name }
+        end_index   = (0 ... specs.length).bsearch{ |i| specs[i].name > dependency.name }
+        specs = specs[start_index ... end_index] if start_index && end_index
+      end
+
       found[source] = specs.select do |tup|
         if dependency.match?(tup)
           if matching_platform and !Gem::Platform.match(tup.platform)
@@ -216,12 +222,12 @@ class Gem::SpecFetcher
 
     if gracefully_ignore
       begin
-        cache[source.uri] ||= source.load_specs(type)
+        cache[source.uri] ||= source.load_specs(type).sort_by{ |tup| tup.name }.freeze
       rescue Gem::RemoteFetcher::FetchError
-        []
+        [].freeze
       end
     else
-      cache[source.uri] ||= source.load_specs(type)
+      cache[source.uri] ||= source.load_specs(type).sort_by{ |tup| tup.name }.freeze
     end
   end
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -954,7 +954,7 @@ class Gem::Specification < Gem::BasicSpecification
     result.map(&:last).map(&:values).flatten.reject { |spec|
       minimum = native[spec.name]
       minimum && spec.version < minimum
-    }
+    }.sort_by{ |tup| tup.name }.freeze
   end
 
   ##


### PR DESCRIPTION
When searching for a specific name, we can just do a binary search to find the gems by their name, instead of iterating thru all the gems (which takes a long time, since there are over 320,000 gem versions).
To do this, we need to sort the tuples by name, which is just a little overhead.

Motivation:
Gem update took 32 seconds on my machine, when there was nothing to update, only to check if there is a newer version.
With the optimized version, it dropped down to 2 seconds.
