### PR TITLE
Use metadata['allowed_push_host'] to restrict gem pushing to that host only

### DIFF
--- a/lib/rubygems/commands/push_command.rb
+++ b/lib/rubygems/commands/push_command.rb
@@ -63,13 +63,18 @@ You can upgrade or downgrade to the latest release version with:
       terminate_interaction 1
     end
 
+    gem_data = Gem::Package.new(name)
+
     unless @host then
-      if gem_data = Gem::Package.new(name) then
-        @host = gem_data.spec.metadata['default_gem_server']
-      end
+      @host = gem_data.spec.metadata['default_gem_server']
     end
 
-    args << @host if @host
+    # Always include this, even if it's nil
+    args << @host
+
+    if gem_data.spec.metadata.has_key?('allowed_push_host')
+      args << gem_data.spec.metadata['allowed_push_host']
+    end
 
     say "Pushing gem to #{@host || Gem.host}..."
 

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -56,14 +56,21 @@ module Gem::GemcutterUtilities
 
   ##
   # Creates an RubyGems API to +host+ and +path+ with the given HTTP +method+.
+  #
+  # If +allowed_push_host+ metadata is present, then it will only allow that host.
 
-  def rubygems_api_request(method, path, host = nil, &block)
+  def rubygems_api_request(method, path, host = nil, allowed_push_host = nil, &block)
     require 'net/http'
 
     self.host = host if host
     unless self.host
       alert_error "You must specify a gem server"
       terminate_interaction 1 # TODO: question this
+    end
+
+    if allowed_push_host and self.host != allowed_push_host
+      alert_error "#{self.host.inspect} is not allowed by the gemspec, which only allows #{allowed_push_host.inspect}"
+      terminate_interaction 1
     end
 
     uri = URI.parse "#{self.host}/#{path}"

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -75,6 +75,10 @@ end
       s.files = %w[lib/code.rb]
     end
 
+    @a3 = quick_spec 'a', '3' do |s|
+      s.metadata['allowed_push_host'] = "https://privategemserver.com"
+    end
+
     @current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
 
     load 'rubygems/syck_hack.rb'
@@ -1443,6 +1447,11 @@ dependencies: []
 
   def test_requirements
     assert_equal ['A working computer'], @a1.requirements
+  end
+
+  def test_allowed_push_host
+    assert_equal nil, @a1.metadata['allowed_push_host']
+    assert_equal 'https://privategemserver.com', @a3.metadata['allowed_push_host']
   end
 
   def test_runtime_dependencies_legacy


### PR DESCRIPTION
Defaults to nil, meaning any host is allowed. Includes tests.

Note that I had to change 2 tests in test_gem_commands_push_command.rb, namely test_execute and test_execute_host; they exploited the fact that gem push previously did not always attempt to load a gem's specification (it only loaded the gemspec if no host was specified). I used existing test helpers to fix those 2 tests.

I figure @rykov of @gemfury will appreciate this.
