### PR TITLE
fix Gem::Specification#files to always return files in a predictably sorted order

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -321,7 +321,7 @@ class Gem::Specification < Gem::BasicSpecification
               add_bindir(@executables),
               @extra_rdoc_files,
               @extensions,
-             ].flatten.uniq.compact
+             ].flatten.sort.uniq.compact
   end
 
   ######################################################################

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -938,7 +938,7 @@ dependencies: []
     assert_same spec.summary, new_spec.summary
 
     assert_equal %w[lib/file.rb test/file.rb bin/exec README.txt
-                    ext/extconf.rb],
+                    ext/extconf.rb].sort,
                  spec.files
     refute_same spec.files, new_spec.files, 'files'
 
@@ -1047,7 +1047,7 @@ dependencies: []
     @a2.executable = 'app'
 
     assert_equal nil, @a2.bindir
-    assert_equal %w[lib/code.rb app], @a2.files
+    assert_equal %w[lib/code.rb app].sort, @a2.files
   end
 
   def test_date
@@ -1147,7 +1147,7 @@ dependencies: []
   def test_executable_equals
     @a2.executable = 'app'
     assert_equal 'app', @a2.executable
-    assert_equal %w[lib/code.rb bin/app], @a2.files
+    assert_equal %w[lib/code.rb bin/app].sort, @a2.files
   end
 
   def test_extensions
@@ -1169,7 +1169,7 @@ dependencies: []
       files
       test_files
     ]
-    assert_equal expected, @a1.files.sort
+    assert_equal expected, @a1.files
   end
 
   def test_files_append
@@ -1187,14 +1187,14 @@ dependencies: []
       files
       test_files
     ]
-    assert_equal expected, @a1.files.sort
+    assert_equal expected, @a1.files
 
     @a1.files << "generated_file.c"
 
     expected << "generated_file.c"
     expected.sort!
 
-    assert_equal expected, @a1.files.sort
+    assert_equal expected, @a1.files
   end
 
   def test_files_duplicate
@@ -1220,7 +1220,7 @@ dependencies: []
     @a1.extra_rdoc_files = "ERF"
     @a1.extensions = "E"
 
-    assert_equal %w[E ERF F TF bin/X], @a1.files.sort
+    assert_equal %w[E ERF F TF bin/X], @a1.files
   end
 
   def test_files_non_array_pathological
@@ -1230,7 +1230,7 @@ dependencies: []
     @a1.instance_variable_set :@extensions, "E"
     @a1.instance_variable_set :@executables, "X"
 
-    assert_equal %w[E ERF F TF bin/X], @a1.files.sort
+    assert_equal %w[E ERF F TF bin/X], @a1.files
     assert_kind_of Integer, @a1.hash
   end
 
@@ -1645,7 +1645,7 @@ Gem::Specification.new do |s|
   s.email = "example@example.com"
   s.executables = ["exec"]
   s.extensions = ["ext/a/extconf.rb"]
-  s.files = ["lib/code.rb", "test/suite.rb", "bin/exec", "ext/a/extconf.rb"]
+  s.files = ["bin/exec", "ext/a/extconf.rb", "lib/code.rb", "test/suite.rb"]
   s.homepage = "http://example.com"
   s.licenses = ["MIT"]
   s.require_paths = ["lib"]
@@ -1977,7 +1977,7 @@ end
       assert_equal '["lib2"] are not files', e.message
     end
 
-    assert_equal %w[lib/code.rb test/suite.rb bin/exec ext/a/extconf.rb lib2],
+    assert_equal %w[lib/code.rb test/suite.rb bin/exec ext/a/extconf.rb lib2].sort,
                  @a1.files
   end
 


### PR DESCRIPTION
Ref http://bugs.ruby-lang.org/issues/8623

This patch causes specifications to always return files in a sorted order, rather than in the order declared.

Tests will fail until #611 is applied due to a bug in register_default_specs
