### PR TITLE
suppress list source header if only one type requested with --quiet

### DIFF
--- a/lib/rubygems/commands/query_command.rb
+++ b/lib/rubygems/commands/query_command.rb
@@ -96,7 +96,7 @@ class Gem::Commands::QueryCommand < Gem::Command
         alert_warning "prereleases are always shown locally"
       end
 
-      if ui.outs.tty? or both? then
+      if (ui.outs.tty? and Gem.configuration.verbose) or both? then
         say
         say "*** LOCAL GEMS ***"
         say
@@ -114,7 +114,7 @@ class Gem::Commands::QueryCommand < Gem::Command
     end
 
     if remote? then
-      if ui.outs.tty? or both? then
+      if (ui.outs.tty? and Gem.configuration.verbose) or both? then
         say
         say "*** REMOTE GEMS ***"
         say


### PR DESCRIPTION
## Before

`gem list --quiet --no-versions`:

``` bash

*** LOCAL GEMS ***

bundler
bundler-unload
fattr
rake
rubygems-bundler
rvm
session
tf
```
## After

`gem list --quiet --no-versions`:

``` bash
bundler
bundler-unload
fattr
rake
rubygems-bundler
rvm
session
tf
```

I decided not to apply the change for `both?` as it would lead to confusion and does not seems as expected behavior.
