### PR TITLE
Update Specification.all= to work with stubs.

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -786,7 +786,7 @@ class Gem::Specification < Gem::BasicSpecification
   # -- wilsonb
 
   def self.all= specs
-    @@all = specs
+    @@all = @@stubs = specs
   end
 
   ##


### PR DESCRIPTION
When @jonleighton added stubs support, many methods were changed to search the `@@stubs` cvar (for example by gem name) instead of the `@@all` cvar. This makes many methods continue to work the same way they did in Rubygems 2.0 after `all=` has been called.
