### PR TITLE
Fix host on gem push, when not passing a --host

### DIFF
--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -77,7 +77,8 @@ module Gem::GemcutterUtilities
   # Signs in with the RubyGems API at +sign_in_host+ and sets the rubygems API
   # key.
 
-  def sign_in sign_in_host = self.host
+  def sign_in sign_in_host = nil
+    sign_in_host ||= self.host
     return if Gem.configuration.rubygems_api_key
 
     pretty_host = if Gem::DEFAULT_HOST == sign_in_host then

--- a/test/rubygems/test_gem_gemcutter_utilities.rb
+++ b/test/rubygems/test_gem_gemcutter_utilities.rb
@@ -101,9 +101,23 @@ class TestGemGemcutterUtilities < Gem::TestCase
   def test_sign_in_with_host
     api_key     = 'a5fdbb6ba150cbb83aad2bb2fede64cf040453903'
 
-    util_sign_in [api_key, 200, 'OK'], 'http://example.com', :param
+    util_sign_in [api_key, 200, 'OK'], 'http://example.com', ['http://example.com']
 
     assert_match "Enter your http://example.com credentials.",
+                 @sign_in_ui.output
+    assert @fetcher.last_request["authorization"]
+    assert_match %r{Signed in.}, @sign_in_ui.output
+
+    credentials = YAML.load_file Gem.configuration.credentials_path
+    assert_equal api_key, credentials[:rubygems_api_key]
+  end
+
+  def test_sign_in_with_host_nil
+    api_key     = 'a5fdbb6ba150cbb83aad2bb2fede64cf040453903'
+
+    util_sign_in [api_key, 200, 'OK'], nil, [nil]
+
+    assert_match "Enter your RubyGems.org credentials.",
                  @sign_in_ui.output
     assert @fetcher.last_request["authorization"]
     assert_match %r{Signed in.}, @sign_in_ui.output
@@ -163,14 +177,14 @@ class TestGemGemcutterUtilities < Gem::TestCase
     assert_match %r{Access Denied.}, @sign_in_ui.output
   end
 
-  def util_sign_in response, host = nil, style = :ENV
+  def util_sign_in response, host = nil, args = []
     skip 'Always uses $stdin on windows' if Gem.win_platform?
 
     email    = 'you@example.com'
     password = 'secret'
 
     if host
-      ENV['RUBYGEMS_HOST'] = host if style == :ENV
+      ENV['RUBYGEMS_HOST'] = host
     else
       host = Gem.host
     end
@@ -182,8 +196,8 @@ class TestGemGemcutterUtilities < Gem::TestCase
     @sign_in_ui = Gem::MockGemUi.new "#{email}\n#{password}\n"
 
     use_ui @sign_in_ui do
-      if style == :param then
-        @cmd.sign_in host
+      if args.length > 0 then
+        @cmd.sign_in *args
       else
         @cmd.sign_in
       end
@@ -209,4 +223,3 @@ class TestGemGemcutterUtilities < Gem::TestCase
   end
 
 end
-


### PR DESCRIPTION
After d3f91a011705020c4f1e601d8ddab1c924e5eb99 we start accepting the option --host on the push command.
However when the --host is not provided, it is set as nil, and this was causing the following output:

```
Enter your  credentials.
Dont have an account yet? Create one at https:///sign_up
```

With the patch, on `sign_in`, we get the host even if a nil one is provided.
