### PR TITLE
Fixing Gem.clear_paths to work in an environment with a Security Constan...

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -315,7 +315,7 @@ module Gem
     @paths         = nil
     @user_home     = nil
     Gem::Specification.reset
-    Gem::Security.reset if const_defined? :Security
+    Gem::Security.reset if defined?(Gem::Security)
   end
 
   ##


### PR DESCRIPTION
I recently upgraded to Rubygems 2.0.3 (and quickly 2.0.7) and started receiving this error when trying to run tests:

/Users/username/.rbenv/versions/2.0.0-p247/lib/ruby/site_ruby/2.0.0/rubygems.rb:310:in `clear_paths': uninitialized constant Gem::Security (NameError)

After about an hour of debugging, I found that when you have bundler configured to use local copies of some gems, it will load those gems before calling Gem.clear_paths. One of our gems defines a Security constant at the top level. This confused rubygems into thinking Gem::Security was defined (which it wasn't).

Trivially you can reproduce this error with the following script:
# !/usr/bin/env ruby

Security = 4 #Chosen by a fair die roll
Gem.clear_paths
