### PR TITLE
Add full_require_paths.

### DIFF
--- a/lib/rubygems/commands/which_command.rb
+++ b/lib/rubygems/commands/which_command.rb
@@ -45,9 +45,9 @@ requiring to see why it does not behave as you expect.
 
       if spec then
         if options[:search_gems_first] then
-          dirs = gem_paths(spec) + $LOAD_PATH
+          dirs = spec.full_require_paths + $LOAD_PATH
         else
-          dirs = $LOAD_PATH + gem_paths(spec)
+          dirs = $LOAD_PATH + spec.full_require_paths
         end
       end
 
@@ -79,10 +79,6 @@ requiring to see why it does not behave as you expect.
     end
 
     result
-  end
-
-  def gem_paths(spec)
-    spec.require_paths.collect { |d| File.join spec.full_gem_path, d }
   end
 
   def usage # :nodoc:

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1321,9 +1321,7 @@ class Gem::Specification < Gem::BasicSpecification
   def add_self_to_load_path
     return if default_gem?
 
-    paths = require_paths.map do |path|
-      File.join full_gem_path, path
-    end
+    paths = full_require_paths
 
     # gem directories must come after -I and ENV['RUBYLIB']
     insert_index = Gem.load_path_insert_index
@@ -2014,6 +2012,17 @@ class Gem::Specification < Gem::BasicSpecification
 
   def require_path= path
     self.require_paths = [path]
+  end
+
+  ##
+  # Full paths in the gem to add to <code>$LOAD_PATH</code> when this gem is
+  # activated.
+  #
+
+  def full_require_paths
+    require_paths.map do |path|
+      File.join full_gem_path, path
+    end
   end
 
   ##

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1428,6 +1428,12 @@ dependencies: []
     assert_equal %w[lib], @a1.require_paths
   end
 
+  def test_full_require_paths
+    @a1.require_path = 'lib'
+    assert_equal [File.join(@gemhome, 'gems', @a1.original_name, 'lib')],
+                 @a1.full_require_paths
+  end
+
   def test_require_already_activated
     save_loaded_features do
       a1 = new_spec "a", "1", nil, "lib/d.rb"


### PR DESCRIPTION
Add convenient method, which returns expanded version of
require_paths. This removes code duplication and may helps #210 a bit.
