### PR TITLE
Use RFC 2616 compatible time

### DIFF
--- a/lib/rubygems/request.rb
+++ b/lib/rubygems/request.rb
@@ -114,8 +114,7 @@ class Gem::Request
     request.add_field 'Keep-Alive', '30'
 
     if @last_modified then
-      @last_modified = @last_modified.utc
-      request.add_field 'If-Modified-Since', @last_modified.rfc2822
+      request.add_field 'If-Modified-Since', @last_modified.httpdate
     end
 
     yield request if block_given?

--- a/test/rubygems/test_gem_request.rb
+++ b/test/rubygems/test_gem_request.rb
@@ -126,7 +126,7 @@ class TestGemRequest < Gem::TestCase
 
   def test_fetch_unmodified
     uri = URI.parse "#{@gem_repo}/specs.#{Gem.marshal_version}"
-    t = Time.now
+    t = Time.utc(2013, 1, 2, 3, 4, 5)
     @request = Gem::Request.new(uri, Net::HTTP::Get, t, nil)
     conn = util_stub_connection_for :body => '', :code => 304
 
@@ -135,7 +135,9 @@ class TestGemRequest < Gem::TestCase
     assert_equal 304, response.code
     assert_equal '', response.body
 
-    assert_equal t.rfc2822, conn.payload['if-modified-since']
+    modified_header = conn.payload['if-modified-since']
+
+    assert_equal 'Wed, 02 Jan 2013 03:04:05 GMT', modified_header
   end
 
   def test_user_agent


### PR DESCRIPTION
RFC 2616 states that the time in the [If-Modified-Since header must be in GMT](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.25). `Time#rfc2822` returns a time with time zone offset whereas `Time#httpdate` always returns a time in GMT.
