### PR TITLE
DRY: Use full_require_paths on yet another place.

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -38,11 +38,10 @@ class Gem::BasicSpecification
   # Return true if this spec can require +file+.
 
   def contains_requirable_file? file
-    root     = full_gem_path
     suffixes = Gem.suffixes
 
-    require_paths.any? do |lib|
-      base = "#{root}/#{lib}/#{file}"
+    full_require_paths.any? do |path|
+      base = "#{path}/#{file}"
       suffixes.any? { |suf| File.file? "#{base}#{suf}" }
     end
   end
@@ -80,6 +79,17 @@ class Gem::BasicSpecification
       "#{name}-#{version}".untaint
     else
       "#{name}-#{version}-#{platform}".untaint
+    end
+  end
+
+  ##
+  # Full paths in the gem to add to <code>$LOAD_PATH</code> when this gem is
+  # activated.
+  #
+
+  def full_require_paths
+    require_paths.map do |path|
+      File.join full_gem_path, path
     end
   end
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2013,17 +2013,6 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   ##
-  # Full paths in the gem to add to <code>$LOAD_PATH</code> when this gem is
-  # activated.
-  #
-
-  def full_require_paths
-    require_paths.map do |path|
-      File.join full_gem_path, path
-    end
-  end
-
-  ##
   # The RubyGems version required by this gem
 
   def required_rubygems_version= req


### PR DESCRIPTION
This is follow up of #632. It reuses full_require_paths method on yet another place, although it has to be moved into basic_specification.rb
