### PR TITLE
Remove useless directory parameter from builders .build methods.

### DIFF
--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -145,7 +145,7 @@ EOF
 
       CHDIR_MUTEX.synchronize do
         Dir.chdir extension_dir do
-          results = builder.build(extension, @gem_dir, dest_path,
+          results = builder.build(extension, dest_path,
                                   results, @build_args)
 
           say results.join("\n") if Gem.configuration.really_verbose

--- a/lib/rubygems/ext/cmake_builder.rb
+++ b/lib/rubygems/ext/cmake_builder.rb
@@ -1,5 +1,5 @@
 class Gem::Ext::CmakeBuilder < Gem::Ext::Builder
-  def self.build(extension, directory, dest_path, results)
+  def self.build(extension, dest_path, results)
     unless File.exist?('Makefile') then
       cmd = "cmake . -DCMAKE_INSTALL_PREFIX=#{dest_path}"
       cmd << " #{Gem::Command.build_args.join ' '}" unless Gem::Command.build_args.empty?

--- a/lib/rubygems/ext/configure_builder.rb
+++ b/lib/rubygems/ext/configure_builder.rb
@@ -8,7 +8,7 @@ require 'rubygems/ext/builder'
 
 class Gem::Ext::ConfigureBuilder < Gem::Ext::Builder
 
-  def self.build(extension, directory, dest_path, results, args=[])
+  def self.build(extension, dest_path, results, args=[])
     unless File.exist?('Makefile') then
       cmd = "sh ./configure --prefix=#{dest_path}"
       cmd << " #{args.join ' '}" unless args.empty?

--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -12,7 +12,7 @@ require 'tempfile'
 class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
   FileEntry = FileUtils::Entry_ # :nodoc:
 
-  def self.build(extension, directory, dest_path, results, args=[])
+  def self.build(extension, dest_path, results, args=[])
     tmp_dest = Dir.mktmpdir(".gem.", ".")
 
     t = nil

--- a/lib/rubygems/ext/rake_builder.rb
+++ b/lib/rubygems/ext/rake_builder.rb
@@ -9,7 +9,7 @@ require 'rubygems/command'
 
 class Gem::Ext::RakeBuilder < Gem::Ext::Builder
 
-  def self.build(extension, directory, dest_path, results, args=[])
+  def self.build(extension, dest_path, results, args=[])
     if File.basename(extension) =~ /mkrf_conf/i then
       cmd = "#{Gem.ruby} #{File.basename extension}"
       cmd << " #{args.join " "}" unless args.empty?

--- a/test/rubygems/test_gem_ext_configure_builder.rb
+++ b/test/rubygems/test_gem_ext_configure_builder.rb
@@ -25,7 +25,7 @@ class TestGemExtConfigureBuilder < Gem::TestCase
     output = []
 
     Dir.chdir @ext do
-      Gem::Ext::ConfigureBuilder.build nil, nil, @dest_path, output
+      Gem::Ext::ConfigureBuilder.build nil, @dest_path, output
     end
 
     assert_equal "sh ./configure --prefix=#{@dest_path}", output.shift
@@ -42,7 +42,7 @@ class TestGemExtConfigureBuilder < Gem::TestCase
 
     error = assert_raises Gem::InstallError do
       Dir.chdir @ext do
-        Gem::Ext::ConfigureBuilder.build nil, nil, @dest_path, output
+        Gem::Ext::ConfigureBuilder.build nil, @dest_path, output
       end
     end
 
@@ -73,7 +73,7 @@ class TestGemExtConfigureBuilder < Gem::TestCase
 
     output = []
     Dir.chdir @ext do
-      Gem::Ext::ConfigureBuilder.build nil, nil, @dest_path, output
+      Gem::Ext::ConfigureBuilder.build nil, @dest_path, output
     end
 
     assert_contains_make_command '', output[0]

--- a/test/rubygems/test_gem_ext_ext_conf_builder.rb
+++ b/test/rubygems/test_gem_ext_ext_conf_builder.rb
@@ -28,7 +28,7 @@ class TestGemExtExtConfBuilder < Gem::TestCase
 
     Dir.chdir @ext do
       result =
-        Gem::Ext::ExtConfBuilder.build 'extconf.rb', nil, @dest_path, output
+        Gem::Ext::ExtConfBuilder.build 'extconf.rb', @dest_path, output
 
       assert_same result, output
     end
@@ -50,7 +50,7 @@ class TestGemExtExtConfBuilder < Gem::TestCase
     output = []
 
     Dir.chdir @ext do
-      Gem::Ext::ExtConfBuilder.build 'extconf.rb', nil, @dest_path, output
+      Gem::Ext::ExtConfBuilder.build 'extconf.rb', @dest_path, output
     end
 
     assert_equal "creating Makefile\n", output[1]
@@ -73,7 +73,7 @@ class TestGemExtExtConfBuilder < Gem::TestCase
 
     assert_raises Gem::InstallError do
       Dir.chdir @ext do
-        Gem::Ext::ExtConfBuilder.build 'extconf.rb', nil, @dest_path, output
+        Gem::Ext::ExtConfBuilder.build 'extconf.rb', @dest_path, output
       end
     end
 
@@ -99,7 +99,7 @@ class TestGemExtExtConfBuilder < Gem::TestCase
 
     error = assert_raises Gem::InstallError do
       Dir.chdir @ext do
-        Gem::Ext::ExtConfBuilder.build 'extconf.rb', nil, @dest_path, output
+        Gem::Ext::ExtConfBuilder.build 'extconf.rb', @dest_path, output
       end
     end
 
@@ -144,7 +144,7 @@ end
     output = []
 
     Dir.chdir @ext do
-      Gem::Ext::ExtConfBuilder.build 'extconf.rb', nil, @dest_path, output
+      Gem::Ext::ExtConfBuilder.build 'extconf.rb', @dest_path, output
     end
 
     assert_contains_make_command '', output[2]

--- a/test/rubygems/test_gem_ext_rake_builder.rb
+++ b/test/rubygems/test_gem_ext_rake_builder.rb
@@ -27,7 +27,7 @@ class TestGemExtRakeBuilder < Gem::TestCase
     build_rake_in do |rake|
       Dir.chdir @ext do
         realdir = Dir.pwd
-        Gem::Ext::RakeBuilder.build 'mkrf_conf.rb', nil, @dest_path, output
+        Gem::Ext::RakeBuilder.build 'mkrf_conf.rb', @dest_path, output
       end
 
       output = output.join "\n"
@@ -52,7 +52,7 @@ class TestGemExtRakeBuilder < Gem::TestCase
     build_rake_in(false) do |rake|
       error = assert_raises Gem::InstallError do
         Dir.chdir @ext do
-          Gem::Ext::RakeBuilder.build "mkrf_conf.rb", nil, @dest_path, output
+          Gem::Ext::RakeBuilder.build "mkrf_conf.rb", @dest_path, output
         end
       end
 


### PR DESCRIPTION
This parameter was introduced 8 years ago (5834d2775a91bde5ff1374551fb7ab1755b7d6e8), but was never used. Although it might break some RubyGems plugin, it doesn't seems there exist any alternative RubyGems builder in the wild.