### PR TITLE
Do not modify global Specification.dirs during installation.

### DIFF
--- a/lib/rubygems/dependency_installer.rb
+++ b/lib/rubygems/dependency_installer.rb
@@ -74,12 +74,6 @@ class Gem::DependencyInstaller
     @only_install_dir = !!options[:install_dir]
     @install_dir = options[:install_dir] || Gem.dir
 
-    if options[:install_dir] then
-      # HACK shouldn't change the global settings, needed for -i behavior
-      # maybe move to the install command?  See also github #442
-      Gem::Specification.dirs = @install_dir
-    end
-
     options = DEFAULT_OPTIONS.merge options
 
     @bin_dir             = options[:bin_dir]


### PR DESCRIPTION
This was originally proposed as #442. In that time, it doesn't worked, just test case exercising this behavior was added. Later, I submitted #452, which included this patch again, but was accepted just partially, since it was not mergeable at that time. So this is my 3rd attempt to propose this patch. The testsuite passed and it works according to my testing (note that we are using similar patch in Fedora since February without any issues).
