### PR TITLE
gem sources --list doesn't print anything to the terminal

### DIFF
--- a/lib/rubygems/commands/sources_command.rb
+++ b/lib/rubygems/commands/sources_command.rb
@@ -154,8 +154,7 @@ To remove a source use the --remove argument:
   end
 
   def list? # :nodoc:
-    !(options[:list] ||
-      options[:add] ||
+    !(options[:add] ||
       options[:clear_all] ||
       options[:remove] ||
       options[:update])


### PR DESCRIPTION
Commit d58c5b2abda70c6819950e0174d61f05e1a3d3d1 introduces a bug in the "gem sources" command.

When "--list" or "-l" is passed to "gem sources", the command is currently ignoring it (nothing is printed to terminal).

Currently, when options[:list] is set (by passing -l or --list), the list() method is never reached.
