### PR TITLE
Change extensions dir order.

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -70,8 +70,8 @@ class Gem::BasicSpecification
         Gem.ruby_api_version
       end
 
-    File.join base_dir, 'extensions', full_name,
-              ruby_api_version, Gem::Platform.local.to_s
+    File.join base_dir, 'extensions', Gem::Platform.local.to_s,
+              ruby_api_version, full_name
   end
 
   def find_full_gem_path # :nodoc:
@@ -183,8 +183,8 @@ class Gem::BasicSpecification
     return @require_paths if @extensions.empty?
 
     relative_extension_install_dir =
-      File.join '..', '..', '..', 'extensions', full_name,
-                Gem.ruby_api_version, Gem::Platform.local.to_s
+      File.join '..', '..', '..', 'extensions', Gem::Platform.local.to_s,
+                Gem.ruby_api_version, full_name
 
     @require_paths + [relative_extension_install_dir]
   end

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1366,8 +1366,8 @@ dependencies: []
     refute_empty @ext.extensions
 
     expected =
-      File.join(@ext.base_dir, 'extensions', @ext.full_name,
-                Gem.ruby_api_version, Gem::Platform.local.to_s)
+      File.join(@ext.base_dir, 'extensions', Gem::Platform.local.to_s,
+                Gem.ruby_api_version,@ext.full_name)
 
     assert_equal expected, @ext.extension_install_dir
   ensure
@@ -1383,8 +1383,8 @@ dependencies: []
     refute_empty @ext.extensions
 
     expected =
-      File.join(@ext.base_dir, 'extensions', @ext.full_name,
-                "#{Gem.ruby_api_version}-static", Gem::Platform.local.to_s)
+      File.join(@ext.base_dir, 'extensions', Gem::Platform.local.to_s,
+                "#{Gem.ruby_api_version}-static", @ext.full_name)
 
     assert_equal expected, @ext.extension_install_dir
   ensure


### PR DESCRIPTION
There are several reasons to do that:
- It will preserve the current state, i.e. there is folder with
  full_name and under that folder, there is the extension, without any
  addition clutter.
- If we consider other alternative Ruby implementations such as Rubinius,
  it speaks in favor of this proposal as well. It means I could go into
  Rubinius folder and rebuild every gem extension I'll found. The opposite
  way, such as go into each gem folder is less favourable (although
  possible). Additionally, if I remove Rubinius, I can simple delete whole
  directory branch instead of iterating through the folders.
- It will ease packaging. I.e. the RubyGems package owns the platform
  specific folders, the gem package owns just its own sub-directory with
  its content. In current state, the platform specific of the gem would
  need to share ownership of the gem directory, which is repetitive.
- It follows the principle of mutliarch Linux distributions. E.g. there
  is arch specific folder and in this folder resided library, not the
  opposite.
