### PR TITLE
Install files starting with '.' (Fixes #680)

### DIFF
--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -339,13 +339,9 @@ EOM
   def extract_tar_gz io, destination_dir, pattern = "*" # :nodoc:
     open_tar_gz io do |tar|
       tar.each do |entry|
-        # Some entries start with "./" which fnmatch does not like, see github
-        # issue #644
-        full_name = entry.full_name.sub %r%\A\./%, ''
+        next unless File.fnmatch pattern, entry.full_name, File::FNM_DOTMATCH
 
-        next unless File.fnmatch pattern, full_name
-
-        destination = install_location full_name, destination_dir
+        destination = install_location entry.full_name, destination_dir
 
         FileUtils.rm_rf destination
 

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -427,6 +427,19 @@ class TestGemPackage < Gem::Package::TarTestCase
     assert_path_exists extracted
   end
 
+  def test_extract_tar_gz_dot_file
+    package = Gem::Package.new @gem
+
+    tgz_io = util_tar_gz do |tar|
+      tar.add_file '.dot_file.rb', 0644 do |io| io.write 'hi' end
+    end
+
+    package.extract_tar_gz tgz_io, @destination
+
+    extracted = File.join @destination, '.dot_file.rb'
+    assert_path_exists extracted
+  end
+
   def test_install_location
     package = Gem::Package.new @gem
 


### PR DESCRIPTION
The '*' pattern doesn't match files starting with '.' unless you
use File::FNM_DOTMATCH.  Some gems depend on files starting with
'.' being installed.  Excluding files starting with '.' was not
the intention of the author that added the fnmatch code.
