### PR TITLE
Provide public API for checking if a gemspec has a stubline

### DIFF
--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -165,5 +165,12 @@ class Gem::StubSpecification < Gem::BasicSpecification
     @version ||= data.version
   end
 
+  ##
+  # Is there a stub line present for this StubSpecification?
+
+  def stubbed?
+    data.is_a? StubLine
+  end
+
 end
 

--- a/test/rubygems/test_gem_stub_specification.rb
+++ b/test/rubygems/test_gem_stub_specification.rb
@@ -17,6 +17,7 @@ class TestStubSpecification < Gem::TestCase
     assert_equal Gem::Version.new("0.0.1"), @foo.version
     assert_equal Gem::Platform.new("mswin32"), @foo.platform
     assert_equal ["lib", "lib/f oo/ext"], @foo.require_paths
+    assert @foo.stubbed?
   end
 
   def test_initialize_extension
@@ -43,6 +44,7 @@ class TestStubSpecification < Gem::TestCase
     assert_equal Gem::Version.new("0.0.2"), stub.version
     assert_equal Gem::Platform.new("ruby"), stub.platform
     assert_equal ["lib"], stub.require_paths
+    assert !stub.stubbed?
   end
 
   def test_contains_requirable_file_eh


### PR DESCRIPTION
I'd like there to be a public API for checking if a gemspec is stubbed. I want this so that I can warn users of [spring](https://github.com/jonleighton/spring) when they have unstubbed gemspecs present, so that I can encourage them to run `gem pristine` and get the speed benefits.
