### PR TITLE
Remove raise on specification removal

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1082,9 +1082,6 @@ class Gem::Specification < Gem::BasicSpecification
   # Removes +spec+ from the known specs.
 
   def self.remove_spec spec
-    # TODO: beat on the tests
-    raise "wtf: #{spec.full_name} not in #{all_names.inspect}" unless
-      _all.include? spec
     _all.delete spec
     stubs.delete_if { |s| s.full_name == spec.full_name }
   end


### PR DESCRIPTION
The gemspec is removed from the filesystem prior to removing from the
Specification list, so there is an order dependence here.

This causes issues in vagrant:

https://github.com/mitchellh/vagrant/pull/2420/files#diff-f6bf52fb33f7f429df40149aa99c126dR131

and can be reproduced by the following code:

```
require 'rubygems'
require 'rubygems/uninstaller'

name = 'vcr'
version = '2.6.0'
`gem install #{name} -v #{version}`

Gem::Uninstaller.new(name, {
  :all         => true,
  :executables => true,
  :force       => true,
  :ignore      => true,
  :version     => version
}).uninstall
```
