### PR TITLE
Add stubbed? method to Gem::BasicSpecification and Gem::Specification

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -196,5 +196,13 @@ class Gem::BasicSpecification
     raise NotImplementedError
   end
 
+  ##
+  # Whether this specification is stubbed - i.e. we have information
+  # about the gem from a stub line, without having to evaluate the
+  # entire gemspec file.
+  def stubbed?
+    raise NotImplementedError
+  end
+
 end
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2646,6 +2646,10 @@ pessimistic dependency on #{dep} may be overly strict
     return @version
   end
 
+  def stubbed?
+    false
+  end
+
   # FIX: have this handle the platform/new_platform/original_platform bullshit
   def yaml_initialize(tag, vals) # :nodoc:
     vals.each do |ivar, val|


### PR DESCRIPTION
I originally thought this did not make sense to do, since a question
about whether the spec is stubbed or not only exists if the stub is a
Gem::StubSpecification.

However, I have discovered that Bundler overwrite
Gem::Specification.stubs, so that it returns Gem::Specification
instances. Therefore I think it is useful to define this method on
Gem::Specification for the purpose of duck typing.
