### PR TITLE
Recommend license attribute in gemspec

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -180,7 +180,6 @@ class Gem::Specification < Gem::BasicSpecification
 
   ######################################################################
   # :section: Required gemspec attributes
-  # :category:
 
   ##
   # This gem's name.
@@ -333,7 +332,6 @@ class Gem::Specification < Gem::BasicSpecification
 
   ######################################################################
   # :section: Optional gemspec attributes
-  # :category:
 
   ##
   # The path in the gem for executable scripts.  Usually 'bin'
@@ -2536,8 +2534,8 @@ class Gem::Specification < Gem::BasicSpecification
     }
 
     warning <<-warning if licenses.empty?
-licenses is empty, but is recommended.  Use a license
-abbreviation from:  http://opensource.org/licenses/alphabetical
+licenses is empty, but is recommended.  Use a license abbreviation from:
+http://opensource.org/licenses/alphabetical
     warning
 
     validate_permissions

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2447,8 +2447,8 @@ duplicate dependency on b (>= 1.2.3), (~> 1.2) use:
     end
 
     assert_match <<-warning, @ui.error
-WARNING:  licenses is empty, but is recommended.  Use a license
-abbreviation from:  http://opensource.org/licenses/alphabetical
+WARNING:  licenses is empty, but is recommended.  Use a license abbreviation from:
+http://opensource.org/licenses/alphabetical
     warning
   end
 


### PR DESCRIPTION
Per discussion in https://github.com/rubygems/guides/pull/67
1. Adds a license attribute to the example gemspec
2. Adds categories for Required and Optional gemspec attributes sections
3. Add 'Recommended' category for license/licenses within the Optional section
4. Add documentation to license, re: github chooser and legal importance
5. Add recommendation to warning (and test)

@drbrain I built the spec guide and it looked fine. `RUBYGEMS_DIR=$HOME/repos/forked/rubygems rake spec_guide --trace`
