### PR TITLE
Support processing of gems that have already been loaded into an IO object

### DIFF
--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -54,10 +54,12 @@ class Gem::Package
   class FormatError < Error
     attr_reader :path
 
-    def initialize message, path = nil
-      @path = path
+    def initialize message, source = nil
+      if source
+        @path = source.path
 
-      message << " in #{path}" if path
+        message << " in #{path}" if path
+      end
 
       super message
     end
@@ -79,6 +81,85 @@ class Gem::Package
   # Raised when a tar file is corrupt
 
   class TarInvalidError < Error; end
+
+
+  class GemSource; end # :nodoc:
+
+  ##
+  # The primary source of gems is a file on disk, including all usages
+  # internal to rubygems.
+  #
+  # This is a private class, do not depend on it directly. Instead, pass a path
+  # object to `Gem::Package.new`.
+  class FileSource < GemSource # :nodoc: all
+
+    def initialize path
+      @path = path
+    end
+
+    def start
+      @start ||= File.read path, 20
+    end
+
+    def present?
+      File.exists? path
+    end
+
+    def with_write_io(&block)
+      open path, 'wb', &block
+    end
+
+    def with_read_io(&block)
+      open path, 'rb', &block
+    end
+
+    attr_reader :path
+  end
+
+  ##
+  # Supports reading and writing gems from/to a generic IO object.  This is
+  # useful for other applications built on top of rubygems, such as
+  # rubygems.org.
+  #
+  # This is a private class, do not depend on it directly. Instead, pass an IO
+  # object to `Gem::Package.new`.
+  class IOSource < GemSource # :nodoc: all
+
+    def initialize io
+      @io = io
+    end
+
+    def start
+      @start ||= begin
+        if io.pos > 0
+          raise Gem::Package::Error, "Cannot read start unless IO is at start"
+        end
+
+        value = io.read 20
+        io.rewind
+        value
+      end
+    end
+
+    def present?
+      true
+    end
+
+    def with_read_io
+      yield io
+    end
+
+    def with_write_io
+      yield io
+    end
+
+    def path
+    end
+
+    private
+
+    attr_reader :io
+  end
 
   attr_accessor :build_time # :nodoc:
 
@@ -114,19 +195,26 @@ class Gem::Package
   end
 
   ##
-  # Creates a new Gem::Package for the file at +gem+.
+  # Creates a new Gem::Package for the file at +gem+. +gem+ can also be
+  # provided as an IO object.
   #
   # If +gem+ is an existing file in the old format a Gem::Package::Old will be
   # returned.
 
   def self.new gem
-    return super unless Gem::Package == self
-    return super unless File.exist? gem
+    gem = if gem.is_a?(GemSource)
+            gem
+          elsif gem.respond_to? :read
+            IOSource.new(gem)
+          else
+            FileSource.new(gem)
+          end
 
-    start = File.read gem, 20
+    return super(gem) unless Gem::Package == self
+    return super unless gem.present?
 
-    return super unless start
-    return super unless start.include? 'MD5SUM ='
+    return super unless gem.start
+    return super unless gem.start.include? 'MD5SUM ='
 
     Gem::Package::Old.new gem
   end
@@ -227,7 +315,7 @@ class Gem::Package
 
     setup_signer
 
-    open @gem, 'wb' do |gem_io|
+    @gem.with_write_io do |gem_io|
       Gem::Package::TarWriter.new gem_io do |gem|
         add_metadata gem
         add_contents gem
@@ -255,7 +343,7 @@ EOM
 
     @contents = []
 
-    open @gem, 'rb' do |io|
+    @gem.with_read_io do |io|
       gem_tar = Gem::Package::TarReader.new io
 
       gem_tar.each do |entry|
@@ -312,7 +400,7 @@ EOM
 
     FileUtils.mkdir_p destination_dir
 
-    open @gem, 'rb' do |io|
+    @gem.with_read_io do |io|
       reader = Gem::Package::TarReader.new io
 
       reader.each do |entry|
@@ -490,7 +578,7 @@ EOM
     @files     = []
     @spec      = nil
 
-    open @gem, 'rb' do |io|
+    @gem.with_read_io do |io|
       Gem::Package::TarReader.new io do |reader|
         read_checksums reader
 

--- a/lib/rubygems/package/old.rb
+++ b/lib/rubygems/package/old.rb
@@ -37,7 +37,7 @@ class Gem::Package::Old < Gem::Package
 
     return @contents if @contents
 
-    open @gem, 'rb' do |io|
+    @gem.with_read_io do |io|
       read_until_dashes io # spec
       header = file_list io
 
@@ -53,7 +53,7 @@ class Gem::Package::Old < Gem::Package
 
     errstr = "Error reading files from gem"
 
-    open @gem, 'rb' do |io|
+    @gem.with_read_io do |io|
       read_until_dashes io # spec
       header = file_list io
       raise Gem::Exception, errstr unless header
@@ -136,7 +136,7 @@ class Gem::Package::Old < Gem::Package
 
     yaml = ''
 
-    open @gem, 'rb' do |io|
+    @gem.with_read_io do |io|
       skip_ruby io
       read_until_dashes io do |line|
         yaml << line

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -778,6 +778,23 @@ class TestGemPackage < Gem::Package::TarTestCase
     assert_equal @spec, package.spec
   end
 
+  def test_spec_from_io
+    # This functionality is used by rubygems.org to extract spec data from an
+    # uploaded gem before it is written to storage.
+    io = StringIO.new(File.read(@gem))
+    package = Gem::Package.new io
+
+    assert_equal @spec, package.spec
+  end
+
+  def test_spec_from_io_raises_gem_error_for_io_not_at_start
+    io = StringIO.new(File.read(@gem))
+    io.read(1)
+    assert_raises(Gem::Package::Error) do
+      Gem::Package.new io
+    end
+  end
+
   def util_tar
     tar_io = StringIO.new
 


### PR DESCRIPTION
@drbrain as mentioned on IRC, this is required to fix https://github.com/rubygems/rubygems.org/issues/625

In particular, this feature is used by rubygems.org to extract metadata
from uploaded gems that have not yet been written to storage.

I was looking for a way to do this without introducing a new abstraction but wasn't seeing it.

Could potentially do this without changing `Gem::Package` (by adding a new class or method), but that would duplicate a lot of code.

Suggestions welcome!
