### PR TITLE
Make rake test suite runnable on rvm based environment again.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -95,17 +95,10 @@ rescue LoadError, RuntimeError # rake 10.1 on rdoc from ruby 1.9.2 and earlier
   end
 end
 
-task :clean_env do
-  ENV.delete "GEM_HOME"
-  ENV.delete "GEM_PATH"
-end
-
 desc "Install gems needed to run the tests"
 task :install_test_deps => :clean_env do
   sh "gem install minitest -v '~> 4.0'"
 end
-
-task :test => :clean_env
 
 # --------------------------------------------------------------------
 # Creating a release


### PR DESCRIPTION
clean_env task makes rake forget about gems that have been installed in general GEM_HOME, preventing the test suite to run.
