### PR TITLE
Fix rake extensions builder to support jruby-complete.jar case

### DIFF
--- a/lib/rubygems/ext/rake_builder.rb
+++ b/lib/rubygems/ext/rake_builder.rb
@@ -19,7 +19,7 @@ class Gem::Ext::RakeBuilder < Gem::Ext::Builder
     rake = ENV['rake']
 
     rake ||= begin
-               "\"#{Gem.ruby}\" -rubygems #{Gem.bin_path('rake', 'rake')}"
+               "#{Gem.ruby} -rubygems #{Gem.bin_path('rake', 'rake')}"
              rescue Gem::Exception
              end
 


### PR DESCRIPTION
when using jruby from jruby-complete.jar, Gem.ruby returns "java -jar /path/to/jruby-complete.jar" and since it's in quotes, the builder blows up stating that file doesn't exist.

Unfortunately, reproducing this in tests is rather clunky, which is why there's no test fix.
