### PR TITLE
Use file locks to ensure safety when being installed in parallel

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -764,7 +764,10 @@ module Gem
   # Safely read a file in binary mode on all platforms.
 
   def self.read_binary(path)
-    File.open path, binary_mode do |f| f.read end
+    File.open path, binary_mode do |f| 
+      f.flock(File::LOCK_EX)
+      f.read 
+    end
   end
 
   ##

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -292,6 +292,7 @@ class Gem::RemoteFetcher
 
       if update and path then
         open(path, 'wb') do |io|
+          io.flock(File::LOCK_EX)
           io.write data
         end
       end


### PR DESCRIPTION
Hey folks,

I have used file locks in remote fetcher to ensure that no two process or threads can write/read the same file at the same time.  Looking at the remote fetcher code, it's designed to be used as a singleton, thus its better to take this precaution.

The performance impact should be minimal because the file locks are local to that specific file, so the gems(different names/versions) can still be downloaded and installed in parallel. Just that in case two gems with the same name/version and same path are downloaded for some reason. This lock will prevent such situation. 

Also, after checking missing/flock.c in ruby even Windows implements File::LOCK_EX and File::LOCK_UN. so this should be good to go on multiple platforms.
