### PR TITLE
Rename #extension_install_dir to #extension_dir.

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -12,7 +12,7 @@ class Gem::BasicSpecification
   ##
   # Sets the directory where extensions for this gem will be installed.
 
-  attr_writer :extension_install_dir # :nodoc:
+  attr_writer :extension_dir # :nodoc:
 
   ##
   # The path this gemspec was loaded from.  This attribute is not persisted.
@@ -74,11 +74,11 @@ class Gem::BasicSpecification
   # Usage:
   #
   #   spec.extensions.each do |ext|
-  #     puts spec.extension_install_dir ext
+  #     puts spec.extension_dir ext
   #   end
 
-  def extension_install_dir
-    @extension_install_dir ||=
+  def extension_dir
+    @extension_dir ||=
       File.join base_dir, 'extensions', Gem::Platform.local.to_s,
                 Gem.extension_api_version, full_name
   end
@@ -123,7 +123,7 @@ class Gem::BasicSpecification
       File.join full_gem_path, path
     end
 
-    full_paths.unshift extension_install_dir unless @extensions.empty?
+    full_paths.unshift extension_dir unless @extensions.empty?
 
     full_paths
   end
@@ -152,7 +152,7 @@ class Gem::BasicSpecification
   def loaded_from= path
     @loaded_from   = path && path.to_s
 
-    @extension_install_dir = nil
+    @extension_dir = nil
     @full_gem_path         = nil
     @gems_dir              = nil
     @base_dir              = nil
@@ -196,11 +196,11 @@ class Gem::BasicSpecification
   def require_paths
     return @require_paths if @extensions.empty?
 
-    relative_extension_install_dir =
+    relative_extension_dir =
       File.join '..', '..', 'extensions', Gem::Platform.local.to_s,
                 Gem.extension_api_version, full_name
 
-    [relative_extension_install_dir].concat @require_paths
+    [relative_extension_dir].concat @require_paths
   end
 
   ##

--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -186,7 +186,7 @@ EOF
       say "This could take a while..."
     end
 
-    dest_path = @spec.extension_install_dir
+    dest_path = @spec.extension_dir
 
     FileUtils.rm_f @spec.gem_build_complete_path
 
@@ -205,9 +205,9 @@ EOF
   # Writes +output+ to gem_make.out in the extension install directory.
 
   def write_gem_make_out output # :nodoc:
-    destination = File.join @spec.extension_install_dir, 'gem_make.out'
+    destination = File.join @spec.extension_dir, 'gem_make.out'
 
-    FileUtils.mkdir_p @spec.extension_install_dir
+    FileUtils.mkdir_p @spec.extension_dir
 
     open destination, 'wb' do |io| io.puts output end
 

--- a/lib/rubygems/source/git.rb
+++ b/lib/rubygems/source/git.rb
@@ -191,7 +191,7 @@ class Gem::Source::Git < Gem::Source
             spec.loaded_from = loaded_from
             spec.base_dir = base_dir
 
-            spec.extension_install_dir =
+            spec.extension_dir =
               File.join base_dir, 'extensions', Gem::Platform.local.to_s,
                 Gem.extension_api_version, "#{name}-#{dir_shortref}"
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1744,7 +1744,7 @@ class Gem::Specification < Gem::BasicSpecification
   # directory.
 
   def gem_build_complete_path # :nodoc:
-    File.join extension_install_dir, 'gem.build_complete'
+    File.join extension_dir, 'gem.build_complete'
   end
 
   ##

--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -247,7 +247,7 @@ class Gem::Uninstaller
       File.writable?(spec.base_dir)
 
     FileUtils.rm_rf spec.full_gem_path
-    FileUtils.rm_rf spec.extension_install_dir
+    FileUtils.rm_rf spec.extension_dir
 
     old_platform_name = spec.original_name
     gemspec           = spec.spec_file

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -338,7 +338,7 @@ class TestGem < Gem::TestCase
     end
   end
 
-  def test_self_extension_install_dir_shared
+  def test_self_extension_dir_shared
     enable_shared, RbConfig::CONFIG['ENABLE_SHARED'] =
       RbConfig::CONFIG['ENABLE_SHARED'], 'yes'
 
@@ -347,7 +347,7 @@ class TestGem < Gem::TestCase
     RbConfig::CONFIG['ENABLE_SHARED'] = enable_shared
   end
 
-  def test_self_extension_install_dir_static
+  def test_self_extension_dir_static
     enable_shared, RbConfig::CONFIG['ENABLE_SHARED'] =
       RbConfig::CONFIG['ENABLE_SHARED'], 'no'
 

--- a/test/rubygems/test_gem_dependency_installer.rb
+++ b/test/rubygems/test_gem_dependency_installer.rb
@@ -407,7 +407,7 @@ class TestGemDependencyInstaller < Gem::TestCase
     _, f1_gem = util_gem 'f', '1', 'e' => nil
 
     Gem::Installer.new(e1_gem).install
-    FileUtils.rm_r e1.extension_install_dir
+    FileUtils.rm_r e1.extension_dir
 
     FileUtils.mv e1_gem, @tempdir
     FileUtils.mv f1_gem, @tempdir
@@ -420,7 +420,7 @@ class TestGemDependencyInstaller < Gem::TestCase
 
     assert_equal %w[f-1], inst.installed_gems.map { |s| s.full_name }
 
-    assert_path_exists e1.extension_install_dir
+    assert_path_exists e1.extension_dir
   end
 
   def test_install_dependency_old

--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -124,10 +124,10 @@ install:
       @builder.build_extensions
     end
 
-    assert_path_exists @spec.extension_install_dir
+    assert_path_exists @spec.extension_dir
     assert_path_exists @spec.gem_build_complete_path
-    assert_path_exists File.join @spec.extension_install_dir, 'gem_make.out'
-    assert_path_exists File.join @spec.extension_install_dir, 'a.rb'
+    assert_path_exists File.join @spec.extension_dir, 'gem_make.out'
+    assert_path_exists File.join @spec.extension_dir, 'a.rb'
     assert_path_exists File.join @spec.gem_dir, 'lib', 'a.rb'
     assert_path_exists File.join @spec.gem_dir, 'lib', 'a', 'b.rb'
   end
@@ -140,11 +140,11 @@ install:
     assert_equal '', @ui.output
     assert_equal '', @ui.error
 
-    refute_path_exists File.join @spec.extension_install_dir, 'gem_make.out'
+    refute_path_exists File.join @spec.extension_dir, 'gem_make.out'
   end
 
   def test_build_extensions_rebuild_failure
-    FileUtils.mkdir_p @spec.extension_install_dir
+    FileUtils.mkdir_p @spec.extension_dir
     FileUtils.touch @spec.gem_build_complete_path
 
     @spec.extensions << nil
@@ -175,7 +175,7 @@ install:
                  @ui.output
     assert_equal '', @ui.error
 
-    gem_make_out = File.join @spec.extension_install_dir, 'gem_make.out'
+    gem_make_out = File.join @spec.extension_dir, 'gem_make.out'
 
     assert_match %r%#{Regexp.escape Gem.ruby} extconf\.rb%,
                  File.read(gem_make_out)
@@ -187,7 +187,7 @@ install:
 
   def test_build_extensions_unsupported
     FileUtils.mkdir_p @spec.gem_dir
-    gem_make_out = File.join @spec.extension_install_dir, 'gem_make.out'
+    gem_make_out = File.join @spec.extension_dir, 'gem_make.out'
     @spec.extensions << nil
 
     e = assert_raises Gem::Ext::BuildError do
@@ -239,7 +239,7 @@ install:
     path = File.join @spec.gem_dir, "extconf_args"
 
     assert_equal args.inspect, File.read(path).strip
-    assert_path_exists @spec.extension_install_dir
+    assert_path_exists @spec.extension_dir
   end
 
   def test_initialize

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -937,7 +937,7 @@ gem 'other', version
     assert_match %r|I am a shiny gem!|, @ui.output
   end
 
-  def test_install_extension_install_dir
+  def test_install_extension_dir
     gemhome2 = "#{@gemhome}2"
 
     @spec.extensions << "extconf.rb"

--- a/test/rubygems/test_gem_resolver_git_specification.rb
+++ b/test/rubygems/test_gem_resolver_git_specification.rb
@@ -77,7 +77,7 @@ class TestGemResolverGitSpecification < Gem::TestCase
 
     git_spec.install({})
 
-    assert_path_exists File.join git_spec.spec.extension_install_dir, 'b.rb'
+    assert_path_exists File.join git_spec.spec.extension_dir, 'b.rb'
   end
 
   def test_install_installed

--- a/test/rubygems/test_gem_source_git.rb
+++ b/test/rubygems/test_gem_source_git.rb
@@ -194,12 +194,12 @@ class TestGemSourceGit < Gem::TestCase
     assert_equal File.join(source.install_dir, 'a.gemspec'), a_spec.loaded_from
     assert_equal base_dir, a_spec.base_dir
 
-    extension_install_dir =
+    extension_dir =
       File.join Gem.dir, 'bundler', 'extensions',
         Gem::Platform.local.to_s, Gem.extension_api_version,
         "a-#{source.dir_shortref}"
 
-    assert_equal extension_install_dir, a_spec.extension_install_dir
+    assert_equal extension_dir, a_spec.extension_dir
 
     b_spec = specs.shift
 
@@ -208,7 +208,7 @@ class TestGemSourceGit < Gem::TestCase
                  b_spec.loaded_from
     assert_equal base_dir, b_spec.base_dir
 
-    assert_equal extension_install_dir, b_spec.extension_install_dir
+    assert_equal extension_dir, b_spec.extension_dir
   end
 
   def test_uri_hash

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1115,7 +1115,7 @@ dependencies: []
   def test_build_extensions
     ext_spec
 
-    refute_path_exists @ext.extension_install_dir, 'sanity check'
+    refute_path_exists @ext.extension_dir, 'sanity check'
     refute_empty @ext.extensions, 'sanity check'
 
     extconf_rb = File.join @ext.gem_dir, @ext.extensions.first
@@ -1133,7 +1133,7 @@ dependencies: []
 
     @ext.build_extensions
 
-    assert_path_exists @ext.extension_install_dir
+    assert_path_exists @ext.extension_dir
   end
 
   def test_build_extensions_built
@@ -1142,14 +1142,14 @@ dependencies: []
     refute_empty @ext.extensions, 'sanity check'
 
     gem_build_complete =
-      File.join @ext.extension_install_dir, 'gem.build_complete'
+      File.join @ext.extension_dir, 'gem.build_complete'
 
-    FileUtils.mkdir_p @ext.extension_install_dir
+    FileUtils.mkdir_p @ext.extension_dir
     FileUtils.touch gem_build_complete
 
     @ext.build_extensions
 
-    gem_make_out = File.join @ext.extension_install_dir, 'gem_make.out'
+    gem_make_out = File.join @ext.extension_dir, 'gem_make.out'
     refute_path_exists gem_make_out
   end
 
@@ -1171,7 +1171,7 @@ dependencies: []
 
     spec.build_extensions
 
-    refute_path_exists spec.extension_install_dir
+    refute_path_exists spec.extension_dir
   end
 
   def test_build_extensions_error
@@ -1243,19 +1243,19 @@ dependencies: []
 
     @ext.build_extensions
 
-    gem_make_out = File.join @ext.extension_install_dir, 'gem_make.out'
+    gem_make_out = File.join @ext.extension_dir, 'gem_make.out'
     refute_path_exists gem_make_out
   ensure
     FileUtils.chmod 0755, @gemhome
   end
 
   def test_build_extensions_none
-    refute_path_exists @a1.extension_install_dir, 'sanity check'
+    refute_path_exists @a1.extension_dir, 'sanity check'
     assert_empty @a1.extensions, 'sanity check'
 
     @a1.build_extensions
 
-    refute_path_exists @a1.extension_install_dir
+    refute_path_exists @a1.extension_dir
   end
 
   def test_build_extensions_old
@@ -1267,7 +1267,7 @@ dependencies: []
 
     @ext.build_extensions
 
-    gem_make_out = File.join @ext.extension_install_dir, 'gem_make.out'
+    gem_make_out = File.join @ext.extension_dir, 'gem_make.out'
     refute_path_exists gem_make_out
   end
 
@@ -1293,7 +1293,7 @@ dependencies: []
 
     @ext.build_extensions
 
-    gem_make_out = File.join @ext.extension_install_dir, 'gem_make.out'
+    gem_make_out = File.join @ext.extension_dir, 'gem_make.out'
     assert_path_exists gem_make_out
   end
 
@@ -1323,7 +1323,7 @@ dependencies: []
 
     refute @ext.contains_requirable_file? 'nonexistent'
 
-    assert_path_exists @ext.extension_install_dir
+    assert_path_exists @ext.extension_dir
   end
 
   def test_date
@@ -1444,7 +1444,7 @@ dependencies: []
     assert_equal ['ext/extconf.rb'], ext_spec.extensions
   end
 
-  def test_extension_install_dir
+  def test_extension_dir
     enable_shared, RbConfig::CONFIG['ENABLE_SHARED'] =
       RbConfig::CONFIG['ENABLE_SHARED'], 'no'
 
@@ -1456,7 +1456,7 @@ dependencies: []
       File.join(@ext.base_dir, 'extensions', Gem::Platform.local.to_s,
                 "#{Gem.ruby_api_version}-static", @ext.full_name)
 
-    assert_equal expected, @ext.extension_install_dir
+    assert_equal expected, @ext.extension_dir
   ensure
     RbConfig::CONFIG['ENABLE_SHARED'] = enable_shared
   end
@@ -1610,7 +1610,7 @@ dependencies: []
   end
 
   def test_gem_build_complete_path
-    expected = File.join @a1.extension_install_dir, 'gem.build_complete'
+    expected = File.join @a1.extension_dir, 'gem.build_complete'
     assert_equal expected, @a1.gem_build_complete_path
   end
 
@@ -1743,7 +1743,7 @@ dependencies: []
 
     @ext.require_path = 'lib'
 
-    ext_install_dir = Pathname(@ext.extension_install_dir)
+    ext_install_dir = Pathname(@ext.extension_dir)
     full_gem_path = Pathname(@ext.full_gem_path)
     relative_install_dir = ext_install_dir.relative_path_from full_gem_path
 
@@ -1762,7 +1762,7 @@ dependencies: []
     @ext.require_path = 'lib'
 
     expected = [
-      @ext.extension_install_dir,
+      @ext.extension_dir,
       File.join(@gemhome, 'gems', @ext.original_name, 'lib'),
     ]
 

--- a/test/rubygems/test_gem_stub_specification.rb
+++ b/test/rubygems/test_gem_stub_specification.rb
@@ -23,7 +23,7 @@ class TestStubSpecification < Gem::TestCase
   def test_initialize_extension
     stub = stub_with_extension
 
-    ext_install_dir = Pathname(stub.extension_install_dir)
+    ext_install_dir = Pathname(stub.extension_dir)
     full_gem_path = Pathname(stub.full_gem_path)
     relative_install_dir = ext_install_dir.relative_path_from full_gem_path
     relative_install_dir = relative_install_dir.to_s
@@ -70,7 +70,7 @@ class TestStubSpecification < Gem::TestCase
 
       refute stub.contains_requirable_file? 'nonexistent'
 
-      assert_path_exists stub.extension_install_dir
+      assert_path_exists stub.extension_dir
     end
   end
 
@@ -78,7 +78,7 @@ class TestStubSpecification < Gem::TestCase
     stub = stub_with_extension
 
     expected = [
-      stub.extension_install_dir,
+      stub.extension_dir,
       File.join(stub.full_gem_path, 'lib'),
     ]
 

--- a/test/rubygems/test_gem_uninstaller.rb
+++ b/test/rubygems/test_gem_uninstaller.rb
@@ -223,12 +223,12 @@ create_makefile '#{@spec.name}'
       installer.install
     end
 
-    assert_path_exists @spec.extension_install_dir, 'sanity check'
+    assert_path_exists @spec.extension_dir, 'sanity check'
 
     uninstaller = Gem::Uninstaller.new @spec.name, :executables => true
     uninstaller.uninstall
 
-    refute_path_exists @spec.extension_install_dir
+    refute_path_exists @spec.extension_dir
   end
 
   def test_uninstall_nonexistent


### PR DESCRIPTION
The name is shorter and easier to type. It is the analogy to #gem_dir,
which does not contain the "install" word as well.

I hope it is not too late for such PR.
