### PR TITLE
Allow to override default extension_dir using operating_system.rb

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -72,9 +72,16 @@ class Gem::BasicSpecification
   # Returns full path to the directory where gem's extensions are installed.
 
   def extension_dir
-    @extension_dir ||=
-      File.join base_dir, 'extensions', Gem::Platform.local.to_s,
-                Gem.extension_api_version, full_name
+    @extension_dir ||= File.expand_path File.join(extensions_dir, full_name)
+  end
+
+  ##
+  # Returns path to the extensions directory.
+
+  def extensions_dir
+    @extensions_dir ||= Gem.default_ext_dir_for(base_dir) ||
+      File.join(base_dir, 'extensions', Gem::Platform.local.to_s,
+                Gem.extension_api_version)
   end
 
   def find_full_gem_path # :nodoc:
@@ -147,6 +154,7 @@ class Gem::BasicSpecification
     @loaded_from   = path && path.to_s
 
     @extension_dir = nil
+    @extensions_dir = nil
     @full_gem_path         = nil
     @gems_dir              = nil
     @base_dir              = nil

--- a/lib/rubygems/defaults.rb
+++ b/lib/rubygems/defaults.rb
@@ -52,6 +52,17 @@ module Gem
   end
 
   ##
+  # Returns binary extensions dir for specified RubyGems base dir or nil
+  # if such directory cannot be determined.
+  #
+  # By default, the binary extensions are located side by side with their
+  # Ruby counterparts, therefore nil is returned
+
+  def self.default_ext_dir_for base_dir
+    nil
+  end
+
+  ##
   # Paths where RubyGems' .rb files and bin files are installed
 
   def self.default_rubygems_dirs


### PR DESCRIPTION
This follows the same logic as gem_dir overrides, although
default_ext_dir_for requires base_dir parameter. This allows to install
gems for example into /usr/share, but their extensions into /usr/lib64.
