### PR TITLE
Relax test if Gem.ruby is not the name of the binary being run in the end

### DIFF
--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -228,10 +228,16 @@ install:
 
     assert_match %r%#{Regexp.escape Gem.ruby} extconf\.rb%,
                  File.read(gem_make_out)
-    assert_match %r%#{Regexp.escape Gem.ruby}: No such file%,
+    assert_match /: No such file/,
                  File.read(gem_make_out)
 
     refute_path_exists @spec.gem_build_complete_path
+
+    skip "Gem.ruby is not the name of the binary being run in the end" \
+      unless File.read(gem_make_out).include? "#{Regexp.escape Gem.ruby}:"
+
+    assert_match %r%#{Regexp.escape Gem.ruby}: No such file%,
+                 File.read(gem_make_out)
   end
 
   def test_build_extensions_unsupported


### PR DESCRIPTION
The test suite fails for Ruby in Fedora due to the expectation that Gem.ruby as the path for running Ruby is also an actual binary file running it, which is not the case in recent Fedoras (and might not be true for other environments as well).

This resolves https://github.com/rubygems/rubygems/issues/703. Please look there for the details.
