### PR TITLE
show gem name when throwing GemNotInHomeException

### DIFF
--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -237,7 +237,7 @@ class Gem::Uninstaller
     unless path_ok?(@gem_home, spec) or
            (@user_install and path_ok?(Gem.user_dir, spec)) then
       e = Gem::GemNotInHomeException.new \
-            "Gem is not installed in directory #{@gem_home}"
+            "Gem '#{spec.full_name}' is not installed in directory #{@gem_home}"
       e.spec = spec
 
       raise e


### PR DESCRIPTION
The original error is not very useful:

``` bash
ERROR:  Gem::GemNotInHomeException: Gem is not installed in directory /home/mpapis/.rvm/gems/ruby-2.1.0-preview2
```

after fix:

``` bash
ERROR:  Gem::GemNotInHomeException: Gem 'rake-10.1.0' is not installed in directory /home/mpapis/.rvm/gems/ruby-2.1.0-preview2
```
