### PR TITLE
Removed unused method find_conflict_state

### DIFF
--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -179,27 +179,6 @@ class Gem::Resolver
   end
 
   ##
-  # Finds the State in +states+ that matches the +conflict+ so that we can try
-  # other possible sets.
-  #
-  # If no good candidate is found, the first state is tried.
-
-  def find_conflict_state conflict, states # :nodoc:
-    until states.empty? do
-      state = states.pop
-
-      explain :consider, state.dep, conflict.failed_dep
-
-      if conflict.for_spec? state.spec
-        state.conflicts << [state.spec, conflict]
-        return state
-      end
-    end
-
-    nil
-  end
-
-  ##
   # Extracts the specifications that may be able to fulfill +dependency+ and
   # returns those that match the local platform and all those that match.
 


### PR DESCRIPTION
Hey @evanphx ,

While reading through the resolver code I found out that find_conflict_state method was not being used anywhere after https://github.com/rubygems/rubygems/commit/c3811c183521d65092d5924fc9e807f98a58bdfb, so I am just raising this PR to remove the uneeded method. 
