### PR TITLE
Sort files *after* compacting them to avoid problem in Ruby 1.8.7

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -327,7 +327,7 @@ class Gem::Specification < Gem::BasicSpecification
               add_bindir(@executables),
               @extra_rdoc_files,
               @extensions,
-             ].flatten.sort.uniq.compact
+             ].flatten.uniq.compact.sort
   end
 
   ######################################################################


### PR DESCRIPTION
Pull request #612 introduced sorting of `Gem::Specification#files`.

However, as @pixeltrix pointed out in [1,2], `nil#<=>` is not defined in Ruby
versions before v1.9.3. By doing the `#sort` _after_ the `#compact`, we can
avoid this problem without changing the behaviour.

This was causing a fatal Bundler error in my Ruby v1.8.7 builds on Travis CI.
See [3] for an example of the fatal error.

See also my initial issue on Travis CI [4] and subsequent issue on Bundler [5].

[1] https://twitter.com/pixeltrix/status/416950629786189824
[2] https://twitter.com/pixeltrix/status/416950640242622465
[3] https://travis-ci.org/freerange/mocha/jobs/16068647#L50
[4] https://github.com/travis-ci/travis-ci/issues/1793
[5] https://github.com/bundler/bundler/issues/2784
