### PR TITLE
Fix installing gem from file without dependencies.

### DIFF
--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -228,19 +228,23 @@ to write the specification by hand.  For example:
   def install_gem_without_dependencies name, req # :nodoc:
     gem = nil
 
-    if remote? then
+    if local? then
+      if name =~ /\.gem$/ and File.file? name then
+        source = Gem::Source::SpecificFile.new name
+        spec = source.spec
+      else
+        source = Gem::Source::Local.new
+        spec = source.find_gem name, req
+      end
+      gem = source.download spec if spec
+    end
+
+    if remote? and not gem then
       dependency = Gem::Dependency.new name, req
       dependency.prerelease = options[:prerelease]
 
       fetcher = Gem::RemoteFetcher.fetcher
       gem = fetcher.download_to_cache dependency
-    end
-
-    if local? and not gem then
-      source = Gem::Source::Local.new
-      spec = source.find_gem name, req
-
-      gem = source.download spec
     end
 
     inst = Gem::Installer.new gem, options

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -560,6 +560,20 @@ ERROR:  Possible alternatives: non_existent_with_hint
     assert_equal %w[a-2], @cmd.installed_specs.map { |spec| spec.full_name }
   end
 
+  def test_install_gem_ignore_dependencies_specific_file
+    spec = quick_spec 'a', 2
+
+    util_build_gem spec
+
+    FileUtils.mv spec.cache_file, @tempdir
+
+    @cmd.options[:ignore_dependencies] = true
+
+    @cmd.install_gem File.join(@tempdir, spec.file_name), nil
+
+    assert_equal %w[a-2], @cmd.installed_specs.map { |spec| spec.full_name }
+  end
+
   def test_parses_requirement_from_gemname
     spec_fetcher do |fetcher|
       fetcher.gem 'a', 2


### PR DESCRIPTION
Commit 9437ccc fixed the ability to install remote gems that was accidentally broken by d97fba1, but in the process accidentally broke installing from local files.

This also changes the order to check for local first, to avoid unnecessary network requests in the case where the gem is local.

Closes #760.
