### PR TITLE
Only perform a single request in cache_update_path

### DIFF
--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -285,20 +285,20 @@ class Gem::RemoteFetcher
   def cache_update_path uri, path = nil, update = true
     mtime = path && File.stat(path).mtime rescue nil
 
-    if mtime && Net::HTTPNotModified === fetch_path(uri, mtime, true)
-      Gem.read_binary(path)
-    else
-      data = fetch_path(uri)
+    data = fetch_path(uri, mtime)
 
-      if update and path then
-        open(path, 'wb') do |io|
-          io.flock(File::LOCK_EX)
-          io.write data
-        end
-      end
-
-      data
+    if data == nil # indicates the server returned 304 Not Modified
+      return Gem.read_binary(path)
     end
+
+    if update and path
+      open(path, 'wb') do |io|
+        io.flock(File::LOCK_EX)
+        io.write data
+      end
+    end
+
+    data
   end
 
   ##


### PR DESCRIPTION
This fixes a double request in the case that the locally cached specs
are out of date. What RubyGems did before this commit was perform a
request to determine that the cache was out of date, then perform
another request to download the latest specs.

Now we only perform one request which returns 304 Not Modified and no
data if the local cache is up to date, or 200 OK and the new specs data
otherwise.

This shaves off about a second of install time on my connection.
