### PR TITLE
Add install --no-lock option for not writing the dependency lock file

### DIFF
--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -69,6 +69,11 @@ class Gem::Commands::InstallCommand < Gem::Command
       o[:explain] = v
     end
 
+    add_option(:"Install/Update", '--no-lock',
+               'Do not create a lock file (when used with -g/--file)') do |v,o|
+      o[:without_lock] = true
+    end
+
     @installed_specs = []
   end
 

--- a/lib/rubygems/request_set.rb
+++ b/lib/rubygems/request_set.rb
@@ -168,8 +168,10 @@ class Gem::RequestSet
     else
       installed = install options, &block
 
-      lockfile = Gem::RequestSet::Lockfile.new self, gemdeps
-      lockfile.write
+      unless options[:without_lock]
+        lockfile = Gem::RequestSet::Lockfile.new self, gemdeps
+        lockfile.write
+      end
 
       installed
     end


### PR DESCRIPTION
If a user does not care about locking dependencies (as they don't
want to force users to use specific versions of them), it makes
sense to not write a dependency lock file.  Previously there was
not an option to do this.
