### PR TITLE
Remove superfluous thens

### DIFF
--- a/.autotest
+++ b/.autotest
@@ -39,7 +39,7 @@ Autotest.add_hook :initialize do |at|
 
     completed = results[self.completed_re]
 
-    if completed then
+    if completed
       completed = completed.scan(/(\d+) (\w+)/).map { |v, k| [k, v.to_i] }
 
       self.latest_results = Hash[*completed.flatten]

--- a/Rakefile
+++ b/Rakefile
@@ -217,10 +217,10 @@ namespace 'blog' do
 
     while line = lines.shift do
       case line
-      when /(^[A-Z].*)/ then
+      when /(^[A-Z].*)/
         change_types << $1
         change_log << "_#{$1}_\n"
-      when /^\*/ then
+      when /^\*/
         entry = [line.strip]
 
         while /^  \S/ =~ lines.first do
@@ -241,7 +241,7 @@ namespace 'blog' do
 
     last_change_type = change_types.pop
 
-    if change_types.empty? then
+    if change_types.empty?
       change_types = ''
     else
       change_types = change_types.join(', ') << ' and '
@@ -427,7 +427,7 @@ task "git:newchangelog" do
   codes_re = Regexp.escape codes.keys.join
 
   changes.each do |change|
-    if change =~ /^\s*([#{codes_re}])\s*(.*)/ then
+    if change =~ /^\s*([#{codes_re}])\s*(.*)/
       code, line = codes[$1], $2
     else
       code, line = codes["?"], change.chomp

--- a/bin/gem
+++ b/bin/gem
@@ -11,7 +11,7 @@ require 'rubygems/exceptions'
 
 required_version = Gem::Requirement.new ">= 1.8.7"
 
-unless required_version.satisfied_by? Gem.ruby_version then
+unless required_version.satisfied_by? Gem.ruby_version
   abort "Expected Ruby Version #{required_version}, is #{Gem.ruby_version}"
 end
 

--- a/bin/update_rubygems
+++ b/bin/update_rubygems
@@ -7,7 +7,7 @@
 
 require 'rubygems'
 
-if ARGV.include? '-h' or ARGV.include? '--help' then
+if ARGV.include? '-h' or ARGV.include? '--help'
   $stderr.puts "rubygems_update [options]"
   $stderr.puts
   $stderr.puts "This will install the latest version of RubyGems."
@@ -16,7 +16,7 @@ if ARGV.include? '-h' or ARGV.include? '--help' then
   exit
 end
 
-unless ARGV.grep(/--version=([\d\.]*)/).empty? then
+unless ARGV.grep(/--version=([\d\.]*)/).empty?
   exec Gem.ruby, '-S', $PROGRAM_NAME, "_#{$1}_"
 end
 

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -401,7 +401,7 @@ module Gem
   # distinction as extensions cannot be shared between the two.
 
   def self.extension_api_version # :nodoc:
-    if 'no' == RbConfig::CONFIG['ENABLE_SHARED'] then
+    if 'no' == RbConfig::CONFIG['ENABLE_SHARED']
       "#{ruby_api_version}-static"
     else
       ruby_api_version
@@ -489,19 +489,19 @@ module Gem
 
   def self.find_home
     windows = File::ALT_SEPARATOR
-    if not windows or RUBY_VERSION >= '1.9' then
+    if not windows or RUBY_VERSION >= '1.9'
       File.expand_path "~"
     else
       ['HOME', 'USERPROFILE'].each do |key|
         return File.expand_path ENV[key] if ENV[key]
       end
 
-      if ENV['HOMEDRIVE'] && ENV['HOMEPATH'] then
+      if ENV['HOMEDRIVE'] && ENV['HOMEPATH']
         File.expand_path "#{ENV['HOMEDRIVE']}#{ENV['HOMEPATH']}"
       end
     end
   rescue
-    if windows then
+    if windows
       File.expand_path File.join(ENV['HOMEDRIVE'] || ENV['SystemDrive'], '/')
     else
       File.expand_path "/"
@@ -745,7 +745,7 @@ module Gem
 
     if prefix != File.expand_path(RbConfig::CONFIG['sitelibdir']) and
        prefix != File.expand_path(RbConfig::CONFIG['libdir']) and
-       'lib' == File.basename(RUBYGEMS_DIR) then
+       'lib' == File.basename(RUBYGEMS_DIR)
       prefix
     end
   end
@@ -775,7 +775,7 @@ module Gem
   # The path to the running Ruby interpreter.
 
   def self.ruby
-    if @ruby.nil? then
+    if @ruby.nil?
       @ruby = File.join(RbConfig::CONFIG['bindir'],
                         "#{RbConfig::CONFIG['ruby_install_name']}#{RbConfig::CONFIG['EXEEXT']}")
 
@@ -828,9 +828,9 @@ module Gem
     return @ruby_version if defined? @ruby_version
     version = RUBY_VERSION.dup
 
-    if defined?(RUBY_PATCHLEVEL) && RUBY_PATCHLEVEL != -1 then
+    if defined?(RUBY_PATCHLEVEL) && RUBY_PATCHLEVEL != -1
       version << ".#{RUBY_PATCHLEVEL}"
-    elsif defined?(RUBY_REVISION) then
+    elsif defined?(RUBY_REVISION)
       version << ".dev.#{RUBY_REVISION}"
     end
 
@@ -935,7 +935,7 @@ module Gem
   # Is this a windows platform?
 
   def self.win_platform?
-    if @@win_platform.nil? then
+    if @@win_platform.nil?
       ruby_platform = RbConfig::CONFIG['host_os']
       @@win_platform = !!WIN_PATTERNS.find { |r| ruby_platform =~ r }
     end
@@ -1010,7 +1010,7 @@ module Gem
     return unless path = ENV['RUBYGEMS_GEMDEPS']
     path = path.dup
 
-    if path == "-" then
+    if path == "-"
       require 'rubygems/util'
 
       Gem::Util.traverse_parents Dir.pwd do |directory|
@@ -1186,7 +1186,7 @@ require 'rubygems/exceptions'
 
 # REFACTOR: This should be pulled out into some kind of hacks file.
 gem_preluded = Gem::GEM_PRELUDE_SUCKAGE and defined? Gem
-unless gem_preluded then # TODO: remove guard after 1.9.2 dropped
+unless gem_preluded # TODO: remove guard after 1.9.2 dropped
   begin
     ##
     # Defaults the operating system (or packager) wants to provide for RubyGems.
@@ -1195,7 +1195,7 @@ unless gem_preluded then # TODO: remove guard after 1.9.2 dropped
   rescue LoadError
   end
 
-  if defined?(RUBY_ENGINE) then
+  if defined?(RUBY_ENGINE)
     begin
       ##
       # Defaults the Ruby implementation wants to provide for RubyGems

--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -42,7 +42,7 @@ class Gem::BasicSpecification
 
   def base_dir
     return Gem.dir unless loaded_from
-    @base_dir ||= if default_gem? then
+    @base_dir ||= if default_gem?
                     File.dirname File.dirname File.dirname loaded_from
                   else
                     File.dirname File.dirname loaded_from
@@ -108,7 +108,7 @@ class Gem::BasicSpecification
   # default Ruby platform.
 
   def full_name
-    if platform == Gem::Platform::RUBY or platform.nil? then
+    if platform == Gem::Platform::RUBY or platform.nil?
       "#{name}-#{version}".untaint
     else
       "#{name}-#{version}-#{platform}".untaint
@@ -213,7 +213,7 @@ class Gem::BasicSpecification
   def source_paths
     paths = raw_require_paths.dup
 
-    if @extensions then
+    if @extensions
       ext_dirs = @extensions.map do |extension|
         extension.split(File::SEPARATOR, 2).first
       end.uniq

--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -158,7 +158,7 @@ class Gem::Command
       alert_error "Could not find a valid gem '#{gem_name}' (#{version}) in any repository"
     end
 
-    unless domain == :local then # HACK
+    unless domain == :local # HACK
       suggestions = Gem::SpecFetcher.fetcher.suggest_gems_from_name gem_name
 
       unless suggestions.empty?
@@ -173,7 +173,7 @@ class Gem::Command
   def get_all_gem_names
     args = options[:args]
 
-    if args.nil? or args.empty? then
+    if args.nil? or args.empty?
       raise Gem::CommandLineError,
             "Please specify at least one gem name (e.g. gem build GEMNAME)"
     end
@@ -203,12 +203,12 @@ class Gem::Command
   def get_one_gem_name
     args = options[:args]
 
-    if args.nil? or args.empty? then
+    if args.nil? or args.empty?
       raise Gem::CommandLineError,
             "Please specify a gem name on the command line (e.g. gem build GEMNAME)"
     end
 
-    if args.size > 1 then
+    if args.size > 1
       raise Gem::CommandLineError,
             "Too many gem names (#{args.join(', ')}); please specify only one"
     end
@@ -297,9 +297,9 @@ class Gem::Command
 
     options[:build_args] = build_args
 
-    if options[:help] then
+    if options[:help]
       show_help
-    elsif @when_invoked then
+    elsif @when_invoked
       @when_invoked.call options
     else
       execute
@@ -510,7 +510,7 @@ class Gem::Command
   add_common_option('-V', '--[no-]verbose',
                     'Set the verbose level of output') do |value, options|
     # Set us to "really verbose" so the progress meter works
-    if Gem.configuration.verbose and value then
+    if Gem.configuration.verbose and value
       Gem.configuration.verbose = 1
     else
       Gem.configuration.verbose = value

--- a/lib/rubygems/command_manager.rb
+++ b/lib/rubygems/command_manager.rb
@@ -146,19 +146,19 @@ class Gem::CommandManager
   end
 
   def process_args(args, build_args=nil)
-    if args.empty? then
+    if args.empty?
       say Gem::Command::HELP
       terminate_interaction 1
     end
 
     case args.first
-    when '-h', '--help' then
+    when '-h', '--help'
       say Gem::Command::HELP
       terminate_interaction 0
-    when '-v', '--version' then
+    when '-v', '--version'
       say Gem::VERSION
       terminate_interaction 0
-    when /^-/ then
+    when /^-/
       alert_error "Invalid option: #{args.first}.  See 'gem --help'."
       terminate_interaction 1
     else
@@ -171,10 +171,10 @@ class Gem::CommandManager
   def find_command(cmd_name)
     possibilities = find_command_possibilities cmd_name
 
-    if possibilities.size > 1 then
+    if possibilities.size > 1
       raise Gem::CommandLineError,
             "Ambiguous command #{cmd_name} matches [#{possibilities.join(', ')}]"
-    elsif possibilities.empty? then
+    elsif possibilities.empty?
       raise Gem::CommandLineError, "Unknown command #{cmd_name}"
     end
 

--- a/lib/rubygems/commands/build_command.rb
+++ b/lib/rubygems/commands/build_command.rb
@@ -41,10 +41,10 @@ with gem spec:
   def execute
     gemspec = get_one_gem_name
 
-    if File.exist? gemspec then
+    if File.exist? gemspec
       spec = Gem::Specification.load gemspec
 
-      if spec then
+      if spec
         Gem::Package.build spec, options[:force]
       else
         alert_error "Error loading gemspec. Aborting."

--- a/lib/rubygems/commands/cert_command.rb
+++ b/lib/rubygems/commands/cert_command.rb
@@ -129,7 +129,7 @@ class Gem::Commands::CertCommand < Gem::Command
   end
 
   def build_key # :nodoc:
-    if options[:key] then
+    if options[:key]
       options[:key]
     else
       passphrase = ask_for_password 'Passphrase for your Private Key:'

--- a/lib/rubygems/commands/check_command.rb
+++ b/lib/rubygems/commands/check_command.rb
@@ -43,7 +43,7 @@ class Gem::Commands::CheckCommand < Gem::Command
     gems = get_all_gem_names rescue []
 
     Gem::Validator.new.alien(gems).sort.each do |key, val|
-      unless val.empty? then
+      unless val.empty?
         say "#{key} has #{val.size} problems"
         val.each do |error_entry|
           say "  #{error_entry.path}:"

--- a/lib/rubygems/commands/cleanup_command.rb
+++ b/lib/rubygems/commands/cleanup_command.rb
@@ -48,7 +48,7 @@ If no gems are named all gems in GEM_HOME are cleaned.
   def execute
     say "Cleaning up installed gems..."
 
-    if options[:args].empty? then
+    if options[:args].empty?
       done     = false
       last_set = nil
 
@@ -67,7 +67,7 @@ If no gems are named all gems in GEM_HOME are cleaned.
 
     say "Clean Up Complete"
 
-    if Gem.configuration.really_verbose then
+    if Gem.configuration.really_verbose
       skipped = @default_gems.map { |spec| spec.full_name }
 
       say "Skipped default gems: #{skipped.join ', '}"
@@ -97,7 +97,7 @@ If no gems are named all gems in GEM_HOME are cleaned.
   end
 
   def get_candidate_gems
-    @candidate_gems = unless options[:args].empty? then
+    @candidate_gems = unless options[:args].empty?
                         options[:args].map do |gem_name|
                           Gem::Specification.find_all_by_name gem_name
                         end.flatten
@@ -125,7 +125,7 @@ If no gems are named all gems in GEM_HOME are cleaned.
 
     Gem::Specification.each do |spec|
       if @primary_gems[spec.name].nil? or
-         @primary_gems[spec.name].version < spec.version then
+         @primary_gems[spec.name].version < spec.version
         @primary_gems[spec.name] = spec
       end
     end
@@ -134,7 +134,7 @@ If no gems are named all gems in GEM_HOME are cleaned.
   def uninstall_dep spec
     return unless @full.ok_to_remove?(spec.full_name)
 
-    if options[:dryrun] then
+    if options[:dryrun]
       say "Dry Run Mode: Would uninstall #{spec.full_name}"
       return
     end

--- a/lib/rubygems/commands/contents_command.rb
+++ b/lib/rubygems/commands/contents_command.rb
@@ -72,7 +72,7 @@ prefix or only the files that are requireable.
   end
 
   def files_in spec
-    if spec.default_gem? then
+    if spec.default_gem?
       files_in_default_gem spec
     else
       files_in_gem spec
@@ -116,7 +116,7 @@ prefix or only the files that are requireable.
   end
 
   def gem_names # :nodoc:
-    if options[:all] then
+    if options[:all]
       Gem::Specification.map(&:name)
     else
       get_all_gem_names
@@ -124,7 +124,7 @@ prefix or only the files that are requireable.
   end
 
   def path_description spec_dirs # :nodoc:
-    if spec_dirs.empty? then
+    if spec_dirs.empty?
       spec_dirs = Gem::Specification.dirs
       "default gem paths"
     else
@@ -137,7 +137,7 @@ prefix or only the files that are requireable.
       absolute_path = File.join(prefix, basename)
       next if File.directory? absolute_path
 
-      if options[:prefix] then
+      if options[:prefix]
         say absolute_path
       else
         say basename
@@ -152,7 +152,7 @@ prefix or only the files that are requireable.
 
     say "Unable to find gem '#{name}' in #{@path_kind}"
 
-    if Gem.configuration.verbose then
+    if Gem.configuration.verbose
       say "\nDirectories searched:"
       @spec_dirs.sort.each { |dir| say dir }
     end

--- a/lib/rubygems/commands/dependency_command.rb
+++ b/lib/rubygems/commands/dependency_command.rb
@@ -75,7 +75,7 @@ use with other commands.
   def gem_dependency args, version, prerelease # :nodoc:
     args << '' if args.empty?
 
-    pattern = if args.length == 1 and args.first =~ /\A\/(.*)\/(i)?\z/m then
+    pattern = if args.length == 1 and args.first =~ /\A\/(.*)\/(i)?\z/m
                 flags = $2 ? Regexp::IGNORECASE : nil
                 Regexp.new $1, flags
               else
@@ -93,7 +93,7 @@ use with other commands.
 
   def display_pipe specs # :nodoc:
     specs.each do |spec|
-      unless spec.dependencies.empty? then
+      unless spec.dependencies.empty?
         spec.dependencies.sort_by { |dep| dep.name }.each do |dep|
           say "#{dep.name} --version '#{dep.requirement}'"
         end
@@ -106,7 +106,7 @@ use with other commands.
 
     specs.each do |spec|
       response << print_dependencies(spec)
-      unless reverse[spec.full_name].empty? then
+      unless reverse[spec.full_name].empty?
         response << "  Used by\n"
         reverse[spec.full_name].each do |sp, dep|
           response << "    #{sp} (#{dep})\n"
@@ -128,7 +128,7 @@ use with other commands.
 
     reverse = reverse_dependencies specs
 
-    if options[:pipe_format] then
+    if options[:pipe_format]
       display_pipe specs
     else
       display_readable specs, reverse
@@ -136,7 +136,7 @@ use with other commands.
   end
 
   def ensure_local_only_reverse_dependencies # :nodoc:
-    if options[:reverse_dependencies] and remote? and not local? then
+    if options[:reverse_dependencies] and remote? and not local?
       alert_error 'Only reverse dependencies for local gems are supported.'
       terminate_interaction 1
     end
@@ -155,7 +155,7 @@ use with other commands.
   def print_dependencies(spec, level = 0) # :nodoc:
     response = ''
     response << '  ' * level + "Gem #{spec.full_name}\n"
-    unless spec.dependencies.empty? then
+    unless spec.dependencies.empty?
       spec.dependencies.sort_by { |dep| dep.name }.each do |dep|
         response << '  ' * level + "  #{dep}\n"
       end
@@ -194,7 +194,7 @@ use with other commands.
         dep = Gem::Dependency.new(*dep) unless Gem::Dependency === dep
 
         if spec.name == dep.name and
-           dep.requirement.satisfied_by?(spec.version) then
+           dep.requirement.satisfied_by?(spec.version)
           result << [sp.full_name, dep]
         end
       end

--- a/lib/rubygems/commands/environment_command.rb
+++ b/lib/rubygems/commands/environment_command.rb
@@ -74,19 +74,19 @@ lib/rubygems/defaults/operating_system.rb
     arg = options[:args][0]
     out <<
       case arg
-      when /^packageversion/ then
+      when /^packageversion/
         Gem::RubyGemsPackageVersion
-      when /^version/ then
+      when /^version/
         Gem::VERSION
-      when /^gemdir/, /^gemhome/, /^home/, /^GEM_HOME/ then
+      when /^gemdir/, /^gemhome/, /^home/, /^GEM_HOME/
         Gem.dir
-      when /^gempath/, /^path/, /^GEM_PATH/ then
+      when /^gempath/, /^path/, /^GEM_PATH/
         Gem.path.join(File::PATH_SEPARATOR)
-      when /^remotesources/ then
+      when /^remotesources/
         Gem.sources.to_a.join("\n")
-      when /^platform/ then
+      when /^platform/
         Gem.platforms.join(File::PATH_SEPARATOR)
-      when nil then
+      when nil
         show_environment
       else
         raise Gem::CommandLineError, "Unknown environment option [#{arg}]"

--- a/lib/rubygems/commands/fetch_command.rb
+++ b/lib/rubygems/commands/fetch_command.rb
@@ -55,14 +55,14 @@ then repackaging it.
       specs_and_sources, errors =
         Gem::SpecFetcher.fetcher.spec_for_dependency dep
 
-      if platform then
+      if platform
         filtered = specs_and_sources.select { |s,| s.platform == platform }
         specs_and_sources = filtered unless filtered.empty?
       end
 
       spec, source = specs_and_sources.max_by { |s,| s.version }
 
-      if spec.nil? then
+      if spec.nil?
         show_lookup_failure gem_name, version, errors, options[:domain]
         next
       end

--- a/lib/rubygems/commands/generate_index_command.rb
+++ b/lib/rubygems/commands/generate_index_command.rb
@@ -66,13 +66,13 @@ Marshal::MINOR_VERSION constants.  It is used to ensure compatibility.
     options[:build_modern] = true
 
     if not File.exist?(options[:directory]) or
-       not File.directory?(options[:directory]) then
+       not File.directory?(options[:directory])
       alert_error "unknown directory name #{directory}."
       terminate_interaction 1
     else
       indexer = Gem::Indexer.new options.delete(:directory), options
 
-      if options[:update] then
+      if options[:update]
         indexer.update_index
       else
         indexer.generate_index

--- a/lib/rubygems/commands/help_command.rb
+++ b/lib/rubygems/commands/help_command.rb
@@ -114,22 +114,22 @@ platform.
   def execute
     arg = options[:args][0]
 
-    if begins? "commands", arg then
+    if begins? "commands", arg
       show_commands
 
-    elsif begins? "options", arg then
+    elsif begins? "options", arg
       say Gem::Command::HELP
 
-    elsif begins? "examples", arg then
+    elsif begins? "examples", arg
       say EXAMPLES
 
-    elsif begins? "platforms", arg then
+    elsif begins? "platforms", arg
       say PLATFORMS
 
-    elsif options[:help] then
+    elsif options[:help]
       show_help
 
-    elsif arg then
+    elsif arg
       show_command_help arg
 
     else
@@ -154,7 +154,7 @@ platform.
       command = @command_manager[cmd_name]
 
       summary =
-        if command then
+        if command
           command.summary
         else
           "[No command found for #{cmd_name}]"
@@ -181,10 +181,10 @@ platform.
 
     possibilities = @command_manager.find_command_possibilities command_name
 
-    if possibilities.size == 1 then
+    if possibilities.size == 1
       command = @command_manager[possibilities.first]
       command.invoke("--help")
-    elsif possibilities.size > 1 then
+    elsif possibilities.size > 1
       alert_warning "Ambiguous command #{command_name} (#{possibilities.join(', ')})"
     else
       alert_warning "Unknown command #{command_name}.  Try: gem help commands"
@@ -193,7 +193,7 @@ platform.
 
   def show_help # :nodoc:
     command = @command_manager[options[:help]]
-    if command then
+    if command
       # help with provided command
       command.invoke("--help")
     else

--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -40,7 +40,7 @@ class Gem::Commands::InstallCommand < Gem::Command
         File.exist? file
       end unless v
 
-      unless v then
+      unless v
         message = v ? v : "(tried #{Gem::GEM_DEP_FILES.join ', '})"
 
         raise OptionParser::InvalidArgument,
@@ -139,7 +139,7 @@ to write the specification by hand.  For example:
   end
 
   def check_install_dir # :nodoc:
-    if options[:install_dir] and options[:user_install] then
+    if options[:install_dir] and options[:user_install]
       alert_error "Use --install-dir or --user-install but not both"
       terminate_interaction 1
     end
@@ -147,14 +147,14 @@ to write the specification by hand.  For example:
 
   def check_version # :nodoc:
     if options[:version] != Gem::Requirement.default and
-         get_all_gem_names.size > 1 then
+         get_all_gem_names.size > 1
       alert_error "Can't use --version w/ multiple gems. Use name:ver instead."
       terminate_interaction 1
     end
   end
 
   def execute
-    if options.include? :gemdeps then
+    if options.include? :gemdeps
       install_from_gemdeps
       return # not reached
     end
@@ -200,7 +200,7 @@ to write the specification by hand.  For example:
 
     req = Gem::Requirement.create(version)
 
-    if options[:ignore_dependencies] then
+    if options[:ignore_dependencies]
       install_gem_without_dependencies name, req
     else
       inst = Gem::DependencyInstaller.new options
@@ -228,8 +228,8 @@ to write the specification by hand.  For example:
   def install_gem_without_dependencies name, req # :nodoc:
     gem = nil
 
-    if local? then
-      if name =~ /\.gem$/ and File.file? name then
+    if local?
+      if name =~ /\.gem$/ and File.file? name
         source = Gem::Source::SpecificFile.new name
         spec = source.spec
       else
@@ -239,7 +239,7 @@ to write the specification by hand.  For example:
       gem = source.download spec if spec
     end
 
-    if remote? and not gem then
+    if remote? and not gem
       dependency = Gem::Dependency.new name, req
       dependency.prerelease = options[:prerelease]
 

--- a/lib/rubygems/commands/lock_command.rb
+++ b/lib/rubygems/commands/lock_command.rb
@@ -58,7 +58,7 @@ lock it down to the exact version.
   end
 
   def complain(message)
-    if options[:strict] then
+    if options[:strict]
       raise Gem::Exception, message
     else
       say "# #{message}"
@@ -77,7 +77,7 @@ lock it down to the exact version.
 
       spec = Gem::Specification.load spec_path(full_name)
 
-      if spec.nil? then
+      if spec.nil?
         complain "Could not find gem #{full_name}, try using the full name"
         next
       end
@@ -89,7 +89,7 @@ lock it down to the exact version.
         next if locked[dep.name]
         candidates = dep.matching_specs
 
-        if candidates.empty? then
+        if candidates.empty?
           complain "Unable to satisfy '#{dep}' from currently installed gems"
         else
           pending << candidates.last.full_name

--- a/lib/rubygems/commands/pristine_command.rb
+++ b/lib/rubygems/commands/pristine_command.rb
@@ -75,13 +75,13 @@ extensions will be restored.
   end
 
   def execute
-    specs = if options[:all] then
+    specs = if options[:all]
               Gem::Specification.map
 
             # `--extensions` must be explicitly given to pristine only gems
             # with extensions.
             elsif options[:extensions_set] and
-                  options[:extensions] and options[:args].empty? then
+                  options[:extensions] and options[:args].empty?
               Gem::Specification.select do |spec|
                 spec.extensions and not spec.extensions.empty?
               end
@@ -91,7 +91,7 @@ extensions will be restored.
               end.flatten
             end
 
-    if specs.to_a.empty? then
+    if specs.to_a.empty?
       raise Gem::Exception,
             "Failed to find gems #{options[:args]} #{options[:version]}"
     end
@@ -109,14 +109,14 @@ extensions will be restored.
         next
       end
 
-      unless spec.extensions.empty? or options[:extensions] then
+      unless spec.extensions.empty? or options[:extensions]
         say "Skipped #{spec.full_name}, it needs to compile an extension"
         next
       end
 
       gem = spec.cache_file
 
-      unless File.exist? gem then
+      unless File.exist? gem
         require 'rubygems/remote_fetcher'
 
         say "Cached gem for #{spec.full_name} not found, attempting to fetch..."
@@ -125,7 +125,7 @@ extensions will be restored.
       end
 
       env_shebang =
-        if options.include? :env_shebang then
+        if options.include? :env_shebang
           options[:env_shebang]
         else
           install_defaults = Gem::ConfigFile::PLATFORM_DEFAULTS['install']
@@ -139,7 +139,7 @@ extensions will be restored.
                                      :env_shebang => env_shebang,
                                      :build_args => spec.build_args)
 
-      if options[:only_executables] then
+      if options[:only_executables]
         installer.generate_bin
       else
         installer.install

--- a/lib/rubygems/commands/push_command.rb
+++ b/lib/rubygems/commands/push_command.rb
@@ -54,7 +54,7 @@ command.  For further discussion see the help for the yank command.
 
     if latest_rubygems_version < Gem.rubygems_version and
          Gem.rubygems_version.prerelease? and
-         Gem::Version.new('2.0.0.rc.2') != Gem.rubygems_version then
+         Gem::Version.new('2.0.0.rc.2') != Gem.rubygems_version
       alert_error <<-ERROR
 You are using a beta release of RubyGems (#{Gem::VERSION}) which is not
 allowed to push gems.  Please downgrade or upgrade to a release version.

--- a/lib/rubygems/commands/query_command.rb
+++ b/lib/rubygems/commands/query_command.rb
@@ -83,8 +83,8 @@ is too hard to use.
 
     prerelease = options[:prerelease]
 
-    unless options[:installed].nil? then
-      if no_name then
+    unless options[:installed].nil?
+      if no_name
         alert_error "You must specify a gem name"
         exit_code |= 4
       elsif name.count > 1
@@ -94,7 +94,7 @@ is too hard to use.
         installed = installed? name.first, options[:version]
         installed = !installed unless options[:installed]
 
-        if installed then
+        if installed
           say "true"
         else
           say "false"
@@ -112,7 +112,7 @@ is too hard to use.
   private
 
   def display_header type
-    if (ui.outs.tty? and Gem.configuration.verbose) or both? then
+    if (ui.outs.tty? and Gem.configuration.verbose) or both?
       say
       say "*** #{type} GEMS ***"
       say
@@ -126,8 +126,8 @@ is too hard to use.
     dep = Gem::Deprecate.skip_during { Gem::Dependency.new name, req }
     dep.prerelease = prerelease
 
-    if local? then
-      if prerelease and not both? then
+    if local?
+      if prerelease and not both?
         alert_warning "prereleases are always shown locally"
       end
 
@@ -144,7 +144,7 @@ is too hard to use.
       output_query_results spec_tuples
     end
 
-    if remote? then
+    if remote?
       display_header 'REMOTE'
 
       fetcher = Gem::SpecFetcher.fetcher
@@ -210,7 +210,7 @@ is too hard to use.
       seen = {}
 
       matching_tuples.delete_if do |n,_|
-        if seen[n.version] then
+        if seen[n.version]
           true
         else
           seen[n.version] = true
@@ -243,11 +243,11 @@ is too hard to use.
     return unless options[:versions]
 
     list =
-      if platforms.empty? or options[:details] then
+      if platforms.empty? or options[:details]
         name_tuples.map { |n| n.version }.uniq
       else
         platforms.sort.reverse.map do |version, pls|
-          if pls == [Gem::Platform::RUBY] then
+          if pls == [Gem::Platform::RUBY]
             version
           else
             ruby = pls.delete Gem::Platform::RUBY
@@ -298,7 +298,7 @@ is too hard to use.
   def spec_loaded_from entry, spec, specs
     return unless spec.loaded_from
 
-    if specs.length == 1 then
+    if specs.length == 1
       default = spec.default_gem? ? ' (default)' : nil
       entry << "\n" << "    Installed at#{default}: #{spec.base_dir}"
     else
@@ -319,7 +319,7 @@ is too hard to use.
 
     return unless non_ruby
 
-    if platforms.length == 1 then
+    if platforms.length == 1
       title = platforms.values.length == 1 ? 'Platform' : 'Platforms'
       entry << "    #{title}: #{platforms.values.sort.join ', '}\n"
     else

--- a/lib/rubygems/commands/rdoc_command.rb
+++ b/lib/rubygems/commands/rdoc_command.rb
@@ -59,7 +59,7 @@ Use --overwrite to force rebuilding of documentation.
   end
 
   def execute
-    specs = if options[:all] then
+    specs = if options[:all]
               Gem::Specification.to_a
             else
               get_all_gem_names.map do |name|
@@ -67,7 +67,7 @@ Use --overwrite to force rebuilding of documentation.
               end.flatten.uniq
             end
 
-    if specs.empty? then
+    if specs.empty?
       alert_error 'No matching gems found'
       terminate_interaction 1
     end
@@ -77,7 +77,7 @@ Use --overwrite to force rebuilding of documentation.
 
       doc.force = options[:overwrite]
 
-      if options[:overwrite] then
+      if options[:overwrite]
         FileUtils.rm_rf File.join(spec.doc_dir, 'ri')
         FileUtils.rm_rf File.join(spec.doc_dir, 'rdoc')
       end

--- a/lib/rubygems/commands/server_command.rb
+++ b/lib/rubygems/commands/server_command.rb
@@ -8,7 +8,7 @@ class Gem::Commands::ServerCommand < Gem::Command
           :port => 8808, :gemdir => [], :daemon => false
 
     OptionParser.accept :Port do |port|
-      if port =~ /\A\d+\z/ then
+      if port =~ /\A\d+\z/
         port = Integer port
         raise OptionParser::InvalidArgument, "#{port}: not a port number" if
           port > 65535

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -58,7 +58,7 @@ class Gem::Commands::SetupCommand < Gem::Command
 
     add_option '--[no-]rdoc',
                'Generate RDoc documentation for RubyGems' do |value, options|
-      if value then
+      if value
         options[:document] << 'rdoc'
       else
         options[:document].delete 'rdoc'
@@ -69,7 +69,7 @@ class Gem::Commands::SetupCommand < Gem::Command
 
     add_option '--[no-]ri',
                'Generate RI documentation for RubyGems' do |value, options|
-      if value then
+      if value
         options[:document] << 'ri'
       else
         options[:document].delete 'ri'
@@ -84,7 +84,7 @@ class Gem::Commands::SetupCommand < Gem::Command
   def check_ruby_version
     required_version = Gem::Requirement.new '>= 1.8.7'
 
-    unless required_version.satisfied_by? Gem.ruby_version then
+    unless required_version.satisfied_by? Gem.ruby_version
       alert_error "Expected Ruby version #{required_version}, is #{Gem.ruby_version}"
       terminate_interaction 1
     end
@@ -117,7 +117,7 @@ By default, this RubyGems will install gem as:
 
     install_destdir = options[:destdir]
 
-    unless install_destdir.empty? then
+    unless install_destdir.empty?
       ENV['GEM_HOME'] ||= File.join(install_destdir,
                                     Gem.default_dir.gsub(/^[a-zA-Z]:/, ''))
     end
@@ -125,7 +125,7 @@ By default, this RubyGems will install gem as:
     check_ruby_version
 
     require 'fileutils'
-    if Gem.configuration.really_verbose then
+    if Gem.configuration.really_verbose
       extend FileUtils::Verbose
     else
       extend FileUtils
@@ -148,7 +148,7 @@ By default, this RubyGems will install gem as:
     documentation_success = install_rdoc
 
     say
-    if @verbose then
+    if @verbose
       say "-" * 78
       say
     end
@@ -169,14 +169,14 @@ By default, this RubyGems will install gem as:
     say @bin_file_names.map { |name| "\t#{name}\n" }
     say
 
-    unless @bin_file_names.grep(/#{File::SEPARATOR}gem$/) then
+    unless @bin_file_names.grep(/#{File::SEPARATOR}gem$/)
       say "If `gem` was installed by a previous RubyGems installation, you may need"
       say "to remove it by hand."
       say
     end
 
     if documentation_success
-      if options[:document].include? 'rdoc' then
+      if options[:document].include? 'rdoc'
         say "Rdoc documentation was installed. You may now invoke:"
         say "  gem server"
         say "and then peruse beautifully formatted documentation for your gems"
@@ -187,7 +187,7 @@ By default, this RubyGems will install gem as:
         say
       end
 
-      if options[:document].include? 'ri' then
+      if options[:document].include? 'ri'
         say "Ruby Interactive (ri) documentation was installed. ri is kind of like man "
         say "pages for ruby libraries. You may access it like this:"
         say "  ri Classname"
@@ -212,7 +212,7 @@ By default, this RubyGems will install gem as:
       bin_files.delete 'update_rubygems'
 
       bin_files.each do |bin_file|
-        bin_file_formatted = if options[:format_executable] then
+        bin_file_formatted = if options[:format_executable]
                                Gem.default_exec_format % bin_file
                              else
                                bin_file
@@ -297,7 +297,7 @@ TEXT
 
     if File.writable? gem_doc_dir and
        (not File.exist? rubygems_doc_dir or
-        File.writable? rubygems_doc_dir) then
+        File.writable? rubygems_doc_dir)
       say "Removing old RubyGems RDoc and ri" if @verbose
       Dir[File.join(Gem.dir, 'doc', 'rubygems-[0-9]*')].each do |dir|
         rm_rf dir
@@ -317,7 +317,7 @@ TEXT
       rdoc.generate
 
       return true
-    elsif @verbose then
+    elsif @verbose
       say "Skipping RDoc generation, #{gem_doc_dir} not writable"
       say "Set the GEM_HOME environment variable if you want RDoc generated"
     end
@@ -342,7 +342,7 @@ TEXT
     prefix = options[:prefix]
     site_or_vendor = options[:site_or_vendor]
 
-    if prefix.empty? then
+    if prefix.empty?
       lib_dir = RbConfig::CONFIG[site_or_vendor]
       bin_dir = RbConfig::CONFIG['bindir']
     else
@@ -353,7 +353,7 @@ TEXT
         # just in case Apple and RubyGems don't get this patched up proper.
         (prefix == RbConfig::CONFIG['libdir'] or
          # this one is important
-         prefix == File.join(RbConfig::CONFIG['libdir'], 'ruby')) then
+         prefix == File.join(RbConfig::CONFIG['libdir'], 'ruby'))
          lib_dir = RbConfig::CONFIG[site_or_vendor]
          bin_dir = RbConfig::CONFIG['bindir']
       else
@@ -362,7 +362,7 @@ TEXT
       end
     end
 
-    unless install_destdir.empty? then
+    unless install_destdir.empty?
       lib_dir = File.join install_destdir, lib_dir.gsub(/^[a-zA-Z]:/, '')
       bin_dir = File.join install_destdir, bin_dir.gsub(/^[a-zA-Z]:/, '')
     end
@@ -440,7 +440,7 @@ abort "#{deprecation_message}"
     release_notes = File.join Dir.pwd, 'History.txt'
 
     release_notes =
-      if File.exist? release_notes then
+      if File.exist? release_notes
         history = File.read release_notes
 
         history.force_encoding Encoding::UTF_8 if

--- a/lib/rubygems/commands/sources_command.rb
+++ b/lib/rubygems/commands/sources_command.rb
@@ -43,7 +43,7 @@ class Gem::Commands::SourcesCommand < Gem::Command
     source = Gem::Source.new source_uri
 
     begin
-      if Gem.sources.include? source_uri then
+      if Gem.sources.include? source_uri
         say "source #{source_uri} already present in the cache"
       else
         source.load_specs :released
@@ -65,7 +65,7 @@ class Gem::Commands::SourcesCommand < Gem::Command
     uri = URI source_uri
 
     if uri.scheme and uri.scheme.downcase == 'http' and
-       uri.host.downcase == 'rubygems.org' then
+       uri.host.downcase == 'rubygems.org'
       question = <<-QUESTION.chomp
 https://rubygems.org is recommended for security over #{uri}
 
@@ -80,10 +80,10 @@ Do you want to add this insecure source?
     path = Gem.spec_cache_dir
     FileUtils.rm_rf path
 
-    unless File.exist? path then
+    unless File.exist? path
       say "*** Removed specs cache ***"
     else
-      unless File.writable? path then
+      unless File.writable? path
         say "*** Unable to remove source cache (write protected) ***"
       else
         say "*** Unable to remove source cache ***"
@@ -175,7 +175,7 @@ To remove a source use the --remove argument:
   end
 
   def remove_source source_uri # :nodoc:
-    unless Gem.sources.include? source_uri then
+    unless Gem.sources.include? source_uri
       say "source #{source_uri} not present in cache"
     else
       Gem.sources.delete source_uri
@@ -197,9 +197,9 @@ To remove a source use the --remove argument:
   def remove_cache_file desc, path # :nodoc:
     FileUtils.rm_rf path
 
-    if not File.exist?(path) then
+    if not File.exist?(path)
       say "*** Removed #{desc} source cache ***"
-    elsif not File.writable?(path) then
+    elsif not File.writable?(path)
       say "*** Unable to remove #{desc} source cache (write protected) ***"
     else
       say "*** Unable to remove #{desc} source cache ***"

--- a/lib/rubygems/commands/specification_command.rb
+++ b/lib/rubygems/commands/specification_command.rb
@@ -74,7 +74,7 @@ Specific fields in the specification can be extracted in YAML format:
     specs = []
     gem = options[:args].shift
 
-    unless gem then
+    unless gem
       raise Gem::CommandLineError,
             "Please specify a gem name or file on the command line"
     end
@@ -104,29 +104,29 @@ Specific fields in the specification can be extracted in YAML format:
     raise Gem::CommandLineError, "--ruby and FIELD are mutually exclusive" if
       field and options[:format] == :ruby
 
-    if local? then
-      if File.exist? gem then
+    if local?
+      if File.exist? gem
         specs << Gem::Package.new(gem).spec rescue nil
       end
 
-      if specs.empty? then
+      if specs.empty?
         specs.push(*dep.matching_specs)
       end
     end
 
-    if remote? then
+    if remote?
       dep.prerelease = options[:prerelease]
       found, _ = Gem::SpecFetcher.fetcher.spec_for_dependency dep
 
       specs.push(*found.map { |spec,| spec })
     end
 
-    if specs.empty? then
+    if specs.empty?
       alert_error "No gem matching '#{dep}' found"
       terminate_interaction 1
     end
 
-    unless options[:all] then
+    unless options[:all]
       specs = [specs.max_by { |s| s.version }]
     end
 

--- a/lib/rubygems/commands/uninstall_command.rb
+++ b/lib/rubygems/commands/uninstall_command.rb
@@ -102,9 +102,9 @@ that is a dependency of an existing gem.  You can use the
   end
 
   def execute
-    if options[:all] and not options[:args].empty? then
+    if options[:all] and not options[:args].empty?
       uninstall_specific
-    elsif options[:all] then
+    elsif options[:all]
       uninstall_all
     else
       uninstall_specific

--- a/lib/rubygems/commands/unpack_command.rb
+++ b/lib/rubygems/commands/unpack_command.rb
@@ -66,15 +66,15 @@ command help for an example.
       dependency = Gem::Dependency.new name, options[:version]
       path = get_path dependency
 
-      unless path then
+      unless path
         alert_error "Gem '#{name}' not installed nor fetchable."
         next
       end
 
-      if @options[:spec] then
+      if @options[:spec]
         spec, metadata = get_metadata path
 
-        if metadata.nil? then
+        if metadata.nil?
           alert_error "--spec is unsupported on '#{name}' (old format gem)"
           next
         end
@@ -167,9 +167,9 @@ command help for an example.
       tar = Gem::Package::TarReader.new io
       tar.each_entry do |entry|
         case entry.full_name
-        when 'metadata' then
+        when 'metadata'
           metadata = entry.read
-        when 'metadata.gz' then
+        when 'metadata.gz'
           metadata = Gem.gunzip entry.read
         end
       end

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -66,7 +66,7 @@ command to remove old versions.
   end
 
   def check_latest_rubygems version # :nodoc:
-    if Gem.rubygems_version == version then
+    if Gem.rubygems_version == version
       say "Latest version currently installed. Aborting."
       terminate_interaction
     end
@@ -75,7 +75,7 @@ command to remove old versions.
   end
 
   def check_update_arguments # :nodoc:
-    unless options[:args].empty? then
+    unless options[:args].empty?
       alert_error "Gem names are not allowed with the --system option"
       terminate_interaction 1
     end
@@ -84,7 +84,7 @@ command to remove old versions.
   def execute
     hig = {}
 
-    if options[:system] then
+    if options[:system]
       update_rubygems
       return
     end
@@ -97,7 +97,7 @@ command to remove old versions.
 
     updated = update_gems gems_to_update
 
-    if updated.empty? then
+    if updated.empty?
       say "Nothing to update"
     else
       say "Gems updated: #{updated.map { |spec| spec.name }.join ' '}"
@@ -123,7 +123,7 @@ command to remove old versions.
     hig = {} # highest installed gems
 
     Gem::Specification.each do |spec|
-      if hig[spec.name].nil? or hig[spec.name].version < spec.version then
+      if hig[spec.name].nil? or hig[spec.name].version < spec.version
         hig[spec.name] = spec
       end
     end
@@ -166,7 +166,7 @@ command to remove old versions.
     version = options[:system]
     update_latest = version == true
 
-    if update_latest then
+    if update_latest
       version     = Gem::Version.new     Gem::VERSION
       requirement = Gem::Requirement.new ">= #{Gem::VERSION}"
     else
@@ -185,7 +185,7 @@ command to remove old versions.
     gems_to_update = which_to_update hig, options[:args], :system
     _, up_ver   = gems_to_update.first
 
-    target = if update_latest then
+    target = if update_latest
                up_ver
              else
                version
@@ -263,7 +263,7 @@ command to remove old versions.
 
       highest_remote_ver = highest_remote_version l_spec
 
-      if system or (l_spec.version < highest_remote_ver) then
+      if system or (l_spec.version < highest_remote_ver)
         result << [l_spec.name, [l_spec.version, highest_remote_ver].max]
       end
     end

--- a/lib/rubygems/commands/which_command.rb
+++ b/lib/rubygems/commands/which_command.rb
@@ -43,8 +43,8 @@ requiring to see why it does not behave as you expect.
 
       spec = Gem::Specification.find_by_path arg
 
-      if spec then
-        if options[:search_gems_first] then
+      if spec
+        if options[:search_gems_first]
           dirs = spec.full_require_paths + $LOAD_PATH
         else
           dirs = $LOAD_PATH + spec.full_require_paths
@@ -54,7 +54,7 @@ requiring to see why it does not behave as you expect.
       # TODO: this is totally redundant and stupid
       paths = find_paths arg, dirs
 
-      if paths.empty? then
+      if paths.empty?
         alert_error "Can't find ruby library file or shared library #{arg}"
 
         found &&= false
@@ -72,7 +72,7 @@ requiring to see why it does not behave as you expect.
     dirs.each do |dir|
       Gem.suffixes.each do |ext|
         full_path = File.join dir, "#{package_name}#{ext}"
-        if File.exist? full_path and not File.directory? full_path then
+        if File.exist? full_path and not File.directory? full_path
           result << full_path
           return result unless options[:show_all]
         end

--- a/lib/rubygems/commands/yank_command.rb
+++ b/lib/rubygems/commands/yank_command.rb
@@ -58,8 +58,8 @@ as the reason for the removal request.
     api_key   = Gem.configuration.rubygems_api_key
     api_key   = Gem.configuration.api_keys[options[:key].to_sym] if options[:key]
 
-    if version then
-      if options[:undo] then
+    if version
+      if options[:undo]
         unyank_gem(version, platform, api_key)
       else
         yank_gem(version, platform, api_key)

--- a/lib/rubygems/compatibility.rb
+++ b/lib/rubygems/compatibility.rb
@@ -15,12 +15,12 @@ end
 
 # Gem::QuickLoader exists in the gem prelude code in ruby 1.9.2 itself.
 # We gotta get rid of it if it's there, before we do anything else.
-if Gem::GEM_PRELUDE_SUCKAGE and defined?(Gem::QuickLoader) then
+if Gem::GEM_PRELUDE_SUCKAGE and defined?(Gem::QuickLoader)
   Gem::QuickLoader.remove
 
   $LOADED_FEATURES.delete Gem::QuickLoader.path_to_full_rubygems_library
 
-  if $LOADED_FEATURES.any? do |path| path.end_with? '/rubygems.rb' end then
+  if $LOADED_FEATURES.any? { |path| path.end_with? '/rubygems.rb' }
     # TODO path does not exist here
     raise LoadError, "another rubygems is already loaded from #{path}"
   end

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -68,7 +68,7 @@ class Gem::ConfigFile
 
         CSIDL_COMMON_APPDATA = 0x0023
         path = 0.chr * 260
-        if RUBY_VERSION > '1.9' then
+        if RUBY_VERSION > '1.9'
           SHGetFolderPath = Win32API.new 'shell32', 'SHGetFolderPath', 'PLPLP',
           'L', :stdcall
           SHGetFolderPath.call nil, CSIDL_COMMON_APPDATA, nil, 1, path
@@ -174,12 +174,12 @@ class Gem::ConfigFile
     arg_list = []
 
     args.each do |arg|
-      if need_config_file_name then
+      if need_config_file_name
         @config_file_name = arg
         need_config_file_name = false
-      elsif arg =~ /^--config-file=(.*)/ then
+      elsif arg =~ /^--config-file=(.*)/
         @config_file_name = $1
-      elsif arg =~ /^--config-file$/ then
+      elsif arg =~ /^--config-file$/
         need_config_file_name = true
       else
         arg_list << arg
@@ -277,13 +277,13 @@ if you believe they were disclosed to a third party.
   def load_api_keys
     check_credentials_permissions
 
-    @api_keys = if File.exist? credentials_path then
+    @api_keys = if File.exist? credentials_path
                   load_file(credentials_path)
                 else
                   @hash
                 end
 
-    if @api_keys.key? :rubygems_api_key then
+    if @api_keys.key? :rubygems_api_key
       @rubygems_api_key    = @api_keys[:rubygems_api_key]
       @api_keys[:rubygems] = @api_keys.delete :rubygems_api_key unless
         @api_keys.key? :rubygems
@@ -378,9 +378,9 @@ if you believe they were disclosed to a third party.
 
     arg_list.each do |arg|
       case arg
-      when /^--(backtrace|traceback)$/ then
+      when /^--(backtrace|traceback)$/
         @backtrace = true
-      when /^--debug$/ then
+      when /^--debug$/
         $DEBUG = true
       else
         @args << arg
@@ -391,7 +391,7 @@ if you believe they were disclosed to a third party.
   # Really verbose mode gives you extra output.
   def really_verbose
     case verbose
-    when true, false, nil then
+    when true, false, nil
       false
     else
       true

--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -10,7 +10,7 @@ module Kernel
 
   RUBYGEMS_ACTIVATION_MONITOR = Monitor.new # :nodoc:
 
-  if defined?(gem_original_require) then
+  if defined?(gem_original_require)
     # Ruby ships with a custom_require, override its require
     remove_method :require
   else
@@ -49,7 +49,7 @@ module Kernel
     # If there are no unresolved deps, then we can use just try
     # normal require handle loading a gem from the rescue below.
 
-    if Gem::Specification.unresolved_deps.empty? then
+    if Gem::Specification.unresolved_deps.empty?
       begin
         RUBYGEMS_ACTIVATION_MONITOR.exit
         return gem_original_require(path)
@@ -89,7 +89,7 @@ module Kernel
     # requested, then find_in_unresolved_tree will find d.rb in d because
     # it's a dependency of c.
     #
-    if found_specs.empty? then
+    if found_specs.empty?
       found_specs = Gem::Specification.find_in_unresolved_tree path
 
       found_specs.each do |found_spec|
@@ -104,7 +104,7 @@ module Kernel
       # versions of the same gem
       names = found_specs.map(&:name).uniq
 
-      if names.size > 1 then
+      if names.size > 1
         raise Gem::LoadError, "#{path} found in multiple gems: #{names.join ', '}"
       end
 
@@ -112,7 +112,7 @@ module Kernel
       # at the highest version.
       valid = found_specs.select { |s| s.conflicts.empty? }.last
 
-      unless valid then
+      unless valid
         le = Gem::LoadError.new "unable to find a version of '#{names.first}' to activate"
         le.name = names.first
         raise le
@@ -129,7 +129,7 @@ module Kernel
     end
   rescue LoadError => load_error
     if load_error.message.start_with?("Could not find") or
-        (load_error.message.end_with?(path) and Gem.try_activate(path)) then
+        (load_error.message.end_with?(path) and Gem.try_activate(path))
       begin
         RUBYGEMS_ACTIVATION_MONITOR.exit
         return gem_original_require(path)

--- a/lib/rubygems/defaults.rb
+++ b/lib/rubygems/defaults.rb
@@ -27,13 +27,13 @@ module Gem
   # specified in the environment
 
   def self.default_dir
-    path = if defined? RUBY_FRAMEWORK_VERSION then
+    path = if defined? RUBY_FRAMEWORK_VERSION
              [
                File.dirname(RbConfig::CONFIG['sitedir']),
                'Gems',
                RbConfig::CONFIG['ruby_version']
              ]
-           elsif RbConfig::CONFIG['rubylibprefix'] then
+           elsif RbConfig::CONFIG['rubylibprefix']
              [
               RbConfig::CONFIG['rubylibprefix'],
               'gems',
@@ -89,7 +89,7 @@ module Gem
   # Default gem load path
 
   def self.default_path
-    if Gem.user_home && File.exist?(Gem.user_home) then
+    if Gem.user_home && File.exist?(Gem.user_home)
       [user_dir, default_dir]
     else
       [default_dir]
@@ -102,7 +102,7 @@ module Gem
   def self.default_exec_format
     exec_format = RbConfig::CONFIG['ruby_install_name'].sub('ruby', '%s') rescue '%s'
 
-    unless exec_format =~ /%s/ then
+    unless exec_format =~ /%s/
       raise Gem::Exception,
         "[BUG] invalid exec_format #{exec_format.inspect}, no %s"
     end
@@ -114,7 +114,7 @@ module Gem
   # The default directory for binaries
 
   def self.default_bindir
-    if defined? RUBY_FRAMEWORK_VERSION then # mac framework support
+    if defined? RUBY_FRAMEWORK_VERSION # mac framework support
       '/usr/bin'
     else # generic install
       RbConfig::CONFIG['bindir']
@@ -125,7 +125,7 @@ module Gem
   # A wrapper around RUBY_ENGINE const that may not be defined
 
   def self.ruby_engine
-    if defined? RUBY_ENGINE then
+    if defined? RUBY_ENGINE
       RUBY_ENGINE
     else
       'ruby'

--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -36,8 +36,8 @@ class Gem::Dependency
 
   def initialize name, *requirements
     case name
-    when String then # ok
-    when Regexp then
+    when String # ok
+    when Regexp
       msg = ["NOTE: Dependency.new w/ a regexp is deprecated.",
              "Dependency.new called from #{Gem.location_of_caller.join(":")}"]
       warn msg.join("\n") unless Gem::Deprecate.skip
@@ -151,7 +151,7 @@ class Gem::Dependency
   end
 
   def to_s # :nodoc:
-    if type != :runtime then
+    if type != :runtime
       "#{name} (#{requirement}, #{type})"
     else
       "#{name} (#{requirement})"
@@ -234,7 +234,7 @@ class Gem::Dependency
   # Merges the requirements of +other+ into this dependency
 
   def merge other
-    unless name == other.name then
+    unless name == other.name
       raise ArgumentError,
             "#{self} and #{other} have different names"
     end
@@ -280,7 +280,7 @@ class Gem::Dependency
 
     # TODO: check Gem.activated_spec[self.name] in case matches falls outside
 
-    if matches.empty? then
+    if matches.empty?
       specs = Gem::Specification.find_all { |s|
                 s.name == name
               }.map { |x| x.full_name }

--- a/lib/rubygems/dependency_installer.rb
+++ b/lib/rubygems/dependency_installer.rb
@@ -162,7 +162,7 @@ class Gem::DependencyInstaller
   # +version+
 
   def available_set_for dep_or_name, version # :nodoc:
-    if String === dep_or_name then
+    if String === dep_or_name
       find_spec_by_name_and_version dep_or_name, version, @prerelease
     else
       dep = dep_or_name.dup
@@ -243,7 +243,7 @@ class Gem::DependencyInstaller
         # FIX if there is a problem talking to the network, we either need to always tell
         # the user (no really_verbose) or fail hard, not silently tell them that we just
         # couldn't find their requested gem.
-        if Gem.configuration.really_verbose then
+        if Gem.configuration.really_verbose
           say "Error fetching remote data:\t\t#{e.message}"
           say "Falling back to local-only install"
         end
@@ -265,10 +265,10 @@ class Gem::DependencyInstaller
     set = Gem::AvailableSet.new
 
     if consider_local?
-      if gem_name =~ /\.gem$/ and File.file? gem_name then
+      if gem_name =~ /\.gem$/ and File.file? gem_name
         src = Gem::Source::SpecificFile.new(gem_name)
         set.add src.spec, src
-      elsif gem_name =~ /\.gem$/ then
+      elsif gem_name =~ /\.gem$/
         Dir[gem_name].each do |name|
           begin
             src = Gem::Source::SpecificFile.new name
@@ -328,7 +328,7 @@ class Gem::DependencyInstaller
       Gem::Specification.include?(spec)
     }
 
-    unless dependency_list.ok? or @ignore_dependencies or @force then
+    unless dependency_list.ok? or @ignore_dependencies or @force
       reason = dependency_list.why_not_ok?.map { |k,v|
         "#{k} requires #{v.join(", ")}"
       }.join("; ")
@@ -405,9 +405,9 @@ class Gem::DependencyInstaller
   end
 
   def install_development_deps # :nodoc:
-    if @development and @dev_shallow then
+    if @development and @dev_shallow
       :shallow
-    elsif @development then
+    elsif @development
       :all
     else
       :none
@@ -424,7 +424,7 @@ class Gem::DependencyInstaller
     installer_set.always_install.concat request_set.always_install
     installer_set.ignore_installed = @only_install_dir
 
-    if @ignore_dependencies then
+    if @ignore_dependencies
       installer_set.ignore_dependencies = true
       request_set.ignore_dependencies   = true
       request_set.soft_missing          = true

--- a/lib/rubygems/dependency_list.rb
+++ b/lib/rubygems/dependency_list.rb
@@ -78,8 +78,8 @@ class Gem::DependencyList
     seen = {}
 
     sorted.each do |spec|
-      if index = seen[spec.name] then
-        if result[index].version < spec.version then
+      if index = seen[spec.name]
+        if result[index].version < spec.version
           result[index] = spec
         end
       else
@@ -122,7 +122,7 @@ class Gem::DependencyList
             dep.requirement.satisfied_by? installed_spec.version
         }
 
-        unless inst or @specs.find { |s| s.satisfies_requirement? dep } then
+        unless inst or @specs.find { |s| s.satisfies_requirement? dep }
           unsatisfied[spec.name] << dep
           return unsatisfied if quick
         end
@@ -196,7 +196,7 @@ class Gem::DependencyList
         next if spec == other
 
         other.dependencies.each do |dep|
-          if spec.satisfies_requirement? dep then
+          if spec.satisfies_requirement? dep
             result[spec] << other
           end
         end
@@ -218,7 +218,7 @@ class Gem::DependencyList
 
     dependencies.each do |dep|
       specs.each do |spec|
-        if spec.satisfies_requirement? dep then
+        if spec.satisfies_requirement? dep
           begin
             yield spec
           rescue TSort::Cyclic

--- a/lib/rubygems/doctor.rb
+++ b/lib/rubygems/doctor.rb
@@ -72,7 +72,7 @@ class Gem::Doctor
 
     Gem.use_paths @gem_repository.to_s
 
-    unless gem_repository? then
+    unless gem_repository?
       say 'This directory does not appear to be a RubyGems repository, ' +
           'skipping'
       say
@@ -114,7 +114,7 @@ class Gem::Doctor
 
       type = File.directory?(child) ? 'directory' : 'file'
 
-      action = if @dry_run then
+      action = if @dry_run
                  'Extra'
                else
                  FileUtils.rm_r(child)

--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -27,14 +27,14 @@ class Gem::Ext::Builder
   end
 
   def self.make(dest_path, results)
-    unless File.exist? 'Makefile' then
+    unless File.exist? 'Makefile'
       raise Gem::InstallError, 'Makefile not found'
     end
 
     # try to find make program from Ruby configure arguments first
     RbConfig::CONFIG['configure_args'] =~ /with-make-prog\=(\w+)/
     make_program = ENV['MAKE'] || ENV['make'] || $1
-    unless make_program then
+    unless make_program
       make_program = (/mswin/ =~ RUBY_PLATFORM) ? 'nmake' : 'make'
     end
 
@@ -76,13 +76,13 @@ class Gem::Ext::Builder
       ENV['RUBYGEMS_GEMDEPS'] = rubygems_gemdeps
     end
 
-    unless $?.success? then
+    unless $?.success?
       results << "Building has failed. See above output for more information on the failure." if verbose
 
       exit_reason =
-        if $?.exited? then
+        if $?.exited?
           ", exit code #{$?.exitstatus}"
-        elsif $?.signaled? then
+        elsif $?.signaled?
           ", uncaught signal #{$?.termsig}"
         end
 
@@ -108,14 +108,14 @@ class Gem::Ext::Builder
 
   def builder_for extension # :nodoc:
     case extension
-    when /extconf/ then
+    when /extconf/
       Gem::Ext::ExtConfBuilder
-    when /configure/ then
+    when /configure/
       Gem::Ext::ConfigureBuilder
-    when /rakefile/i, /mkrf_conf/i then
+    when /rakefile/i, /mkrf_conf/i
       @ran_rake = true
       Gem::Ext::RakeBuilder
-    when /CMakeLists.txt/ then
+    when /CMakeLists.txt/
       Gem::Ext::CmakeBuilder
     else
       extension_dir = File.join @gem_dir, File.dirname(extension)

--- a/lib/rubygems/ext/cmake_builder.rb
+++ b/lib/rubygems/ext/cmake_builder.rb
@@ -2,7 +2,7 @@ require 'rubygems/command'
 
 class Gem::Ext::CmakeBuilder < Gem::Ext::Builder
   def self.build(extension, directory, dest_path, results, args=[], lib_dir=nil)
-    unless File.exist?('Makefile') then
+    unless File.exist?('Makefile')
       cmd = "cmake . -DCMAKE_INSTALL_PREFIX=#{dest_path}"
       cmd << " #{Gem::Command.build_args.join ' '}" unless Gem::Command.build_args.empty?
 

--- a/lib/rubygems/ext/configure_builder.rb
+++ b/lib/rubygems/ext/configure_builder.rb
@@ -7,7 +7,7 @@
 class Gem::Ext::ConfigureBuilder < Gem::Ext::Builder
 
   def self.build(extension, directory, dest_path, results, args=[], lib_dir=nil)
-    unless File.exist?('Makefile') then
+    unless File.exist?('Makefile')
       cmd = "sh ./configure --prefix=#{dest_path}"
       cmd << " #{args.join ' '}" unless args.empty?
 

--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -44,7 +44,7 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
 
         if tmp_dest
           # TODO remove in RubyGems 3
-          if Gem.install_extension_in_lib and lib_dir then
+          if Gem.install_extension_in_lib and lib_dir
             FileUtils.mkdir_p lib_dir
             entries = Dir.entries(tmp_dest) - %w[. ..]
             entries = entries.map { |entry| File.join tmp_dest, entry }

--- a/lib/rubygems/ext/rake_builder.rb
+++ b/lib/rubygems/ext/rake_builder.rb
@@ -7,7 +7,7 @@
 class Gem::Ext::RakeBuilder < Gem::Ext::Builder
 
   def self.build(extension, directory, dest_path, results, args=[], lib_dir=nil)
-    if File.basename(extension) =~ /mkrf_conf/i then
+    if File.basename(extension) =~ /mkrf_conf/i
       cmd = "#{Gem.ruby} #{File.basename extension}"
       cmd << " #{args.join " "}" unless args.empty?
       run cmd, results

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -27,7 +27,7 @@ module Gem::GemcutterUtilities
   # The API key from the command options or from the user's configuration.
 
   def api_key
-    if options[:key] then
+    if options[:key]
       verify_api_key options[:key]
     elsif Gem.configuration.api_keys.key?(host)
       Gem.configuration.api_keys[host]
@@ -88,7 +88,7 @@ module Gem::GemcutterUtilities
     sign_in_host ||= self.host
     return if Gem.configuration.rubygems_api_key
 
-    pretty_host = if Gem::DEFAULT_HOST == sign_in_host then
+    pretty_host = if Gem::DEFAULT_HOST == sign_in_host
                     'RubyGems.org'
                   else
                     sign_in_host
@@ -118,7 +118,7 @@ module Gem::GemcutterUtilities
   # an error.
 
   def verify_api_key(key)
-    if Gem.configuration.api_keys.key? key then
+    if Gem.configuration.api_keys.key? key
       Gem.configuration.api_keys[key]
     else
       alert_error "No such API key. Please add it to your configuration (done automatically on initial `gem push`)."
@@ -135,8 +135,8 @@ module Gem::GemcutterUtilities
 
   def with_response response, error_prefix = nil
     case response
-    when Net::HTTPSuccess then
-      if block_given? then
+    when Net::HTTPSuccess
+      if block_given?
         yield response
       else
         say response.body

--- a/lib/rubygems/indexer.rb
+++ b/lib/rubygems/indexer.rb
@@ -53,7 +53,7 @@ class Gem::Indexer
     require 'tmpdir'
     require 'zlib'
 
-    unless defined?(Builder::XChar) then
+    unless defined?(Builder::XChar)
       raise "Gem::Indexer requires that the XML Builder library be installed:" +
             "\n\tgem install builder"
     end
@@ -170,7 +170,7 @@ class Gem::Indexer
           platform = spec.original_platform
 
           # win32-api-1.0.4-x86-mswin32-60
-          unless String === platform then
+          unless String === platform
             alert_warning "Skipping invalid platform in gem: #{spec.full_name}"
             next
           end
@@ -212,7 +212,7 @@ class Gem::Indexer
 
   def map_gems_to_specs gems
     gems.map { |gemfile|
-      if File.size(gemfile) == 0 then
+      if File.size(gemfile) == 0
         alert_warning "Skipping zero-length gem: #{gemfile}"
         next
       end
@@ -256,7 +256,7 @@ class Gem::Indexer
     say "Compressing indicies"
 
     Gem.time 'Compressed indicies' do
-      if @build_modern then
+      if @build_modern
         gzip @specs_index
         gzip @latest_specs_index
         gzip @prerelease_specs_index
@@ -334,7 +334,7 @@ class Gem::Indexer
     files = @files
     files.delete @quick_marshal_dir if files.include? @quick_dir
 
-    if files.include? @quick_marshal_dir and not files.include? @quick_dir then
+    if files.include? @quick_marshal_dir and not files.include? @quick_dir
       files.delete @quick_marshal_dir
 
       dst_name = File.join(@dest_directory, @quick_marshal_dir_base)
@@ -375,7 +375,7 @@ class Gem::Indexer
     data = Gem.read_binary path
     compressed_data = Gem.read_binary "#{path}.#{extension}"
 
-    unless data == Gem.inflate(compressed_data) then
+    unless data == Gem.inflate(compressed_data)
       raise "Compressed file #{compressed_path} does not match uncompressed file #{path}"
     end
   end
@@ -427,7 +427,7 @@ class Gem::Indexer
       gem_mtime >= specs_mtime
     end
 
-    if updated_gems.empty? then
+    if updated_gems.empty?
       say 'No new gems'
       terminate_interaction 0
     end

--- a/lib/rubygems/install_update_options.rb
+++ b/lib/rubygems/install_update_options.rb
@@ -67,7 +67,7 @@ module Gem::InstallUpdateOptions
     add_option(:Deprecated, '--[no-]rdoc',
                'Generate RDoc for installed gems',
                'Use --document instead') do |value, options|
-      if value then
+      if value
         options[:document] << 'rdoc'
       else
         options[:document].delete 'rdoc'
@@ -79,7 +79,7 @@ module Gem::InstallUpdateOptions
     add_option(:Deprecated, '--[no-]ri',
                'Generate ri data for installed gems.',
                'Use --document instead') do |value, options|
-      if value then
+      if value
         options[:document] << 'ri'
       else
         options[:document].delete 'ri'

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -115,7 +115,7 @@ class Gem::Installer
 
     @package.security_policy = @security_policy
 
-    if options[:user_install] and not options[:unpack] then
+    if options[:user_install] and not options[:unpack]
       @gem_home = Gem.user_dir
       @bin_dir = Gem.bindir gem_home unless options[:bin_dir]
       check_that_user_bin_dir_is_in_path
@@ -164,7 +164,7 @@ class Gem::Installer
 
     question = "#{spec.name}'s executable \"#{filename}\" conflicts with "
 
-    if ruby_executable then
+    if ruby_executable
       question << existing
 
       return if ask_yes_no "#{question}\nOverwrite the executable?", false
@@ -254,7 +254,7 @@ class Gem::Installer
 
   def run_pre_install_hooks # :nodoc:
     Gem.pre_install_hooks.each do |hook|
-      if hook.call(self) == false then
+      if hook.call(self) == false
         location = " at #{$1}" if hook.inspect =~ /@(.*:\d+)/
 
         message = "pre-install hook#{location} failed for #{spec.full_name}"
@@ -265,7 +265,7 @@ class Gem::Installer
 
   def run_post_build_hooks # :nodoc:
     Gem.post_build_hooks.each do |hook|
-      if hook.call(self) == false then
+      if hook.call(self) == false
         FileUtils.rm_rf gem_dir
 
         location = " at #{$1}" if hook.inspect =~ /@(.*:\d+)/
@@ -308,7 +308,7 @@ class Gem::Installer
   # dependency :: Gem::Dependency
 
   def ensure_dependency(spec, dependency)
-    unless installation_satisfies_dependency? dependency then
+    unless installation_satisfies_dependency? dependency
       raise Gem::InstallError, "#{spec.name} requires #{dependency}"
     end
     true
@@ -375,7 +375,7 @@ class Gem::Installer
   # Creates windows .bat files for easy running of commands
 
   def generate_windows_script(filename, bindir)
-    if Gem.win_platform? then
+    if Gem.win_platform?
       script_name = filename + ".bat"
       script_path = File.join bindir, File.basename(script_name)
       File.open script_path, 'w' do |file|
@@ -397,7 +397,7 @@ class Gem::Installer
       filename.untaint
       bin_path = File.join gem_dir, spec.bindir, filename
 
-      unless File.exist? bin_path then
+      unless File.exist? bin_path
         # TODO change this to a more useful warning
         warn "#{bin_path} maybe `gem pristine #{spec.name}` will fix it?"
         next
@@ -408,7 +408,7 @@ class Gem::Installer
 
       check_executable_overwrite filename
 
-      if @wrappers then
+      if @wrappers
         generate_bin_script filename, @bin_dir
       else
         generate_bin_symlink filename, @bin_dir
@@ -443,7 +443,7 @@ class Gem::Installer
   # the symlink if the gem being installed has a newer version.
 
   def generate_bin_symlink(filename, bindir)
-    if Gem.win_platform? then
+    if Gem.win_platform?
       alert_warning "Unable to use symlinks on Windows, installing wrapper"
       generate_bin_script filename, bindir
       return
@@ -452,8 +452,8 @@ class Gem::Installer
     src = File.join gem_dir, spec.bindir, filename
     dst = File.join bindir, formatted_program_filename(filename)
 
-    if File.exist? dst then
-      if File.symlink? dst then
+    if File.exist? dst
+      if File.symlink? dst
         link = File.readlink(dst).split File::SEPARATOR
         cur_version = Gem::Version.create(link[-3].sub(/^.*-/, ''))
         return if spec.version < cur_version
@@ -484,7 +484,7 @@ class Gem::Installer
     path = File.join gem_dir, spec.bindir, bin_file_name
     first_line = File.open(path, "rb") {|file| file.gets}
 
-    if /\A#!/ =~ first_line then
+    if /\A#!/ =~ first_line
       # Preserve extra words on shebang line, like "-w".  Thanks RPA.
       shebang = first_line.sub(/\A\#!.*?ruby\S*((\s+\S+)+)/, "#!#{Gem.ruby}")
       opts = $1
@@ -509,9 +509,9 @@ class Gem::Installer
       end
 
       "#!#{which}"
-    elsif not ruby_name then
+    elsif not ruby_name
       "#!#{Gem.ruby}#{opts}"
-    elsif opts then
+    elsif opts
       "#!/bin/sh\n'exec' #{ruby_name.dump} '-x' \"$0\" \"$@\"\n#{shebang}"
     else
       # Create a plain shebang line.
@@ -538,8 +538,8 @@ class Gem::Installer
 
   # DOC: Missing docs or :nodoc:.
   def ensure_required_ruby_version_met
-    if rrv = spec.required_ruby_version then
-      unless rrv.satisfied_by? Gem.ruby_version then
+    if rrv = spec.required_ruby_version
+      unless rrv.satisfied_by? Gem.ruby_version
         raise Gem::InstallError, "#{spec.name} requires Ruby version #{rrv}."
       end
     end
@@ -547,8 +547,8 @@ class Gem::Installer
 
   # DOC: Missing docs or :nodoc:.
   def ensure_required_rubygems_version_met
-    if rrgv = spec.required_rubygems_version then
-      unless rrgv.satisfied_by? Gem.rubygems_version then
+    if rrgv = spec.required_rubygems_version
+      unless rrgv.satisfied_by? Gem.rubygems_version
         raise Gem::InstallError,
           "#{spec.name} requires RubyGems version #{rrgv}. " +
           "Try 'gem update --system' to update RubyGems itself."
@@ -601,13 +601,13 @@ class Gem::Installer
       File::ALT_SEPARATOR
 
     path = ENV['PATH']
-    if Gem.win_platform? then
+    if Gem.win_platform?
       path = path.downcase
       user_bin_dir = user_bin_dir.downcase
     end
 
-    unless path.split(File::PATH_SEPARATOR).include? user_bin_dir then
-      unless self.class.path_warning then
+    unless path.split(File::PATH_SEPARATOR).include? user_bin_dir
+      unless self.class.path_warning
         alert_warning "You don't have #{user_bin_dir} in your PATH,\n\t  gem executables will not run."
         self.class.path_warning = true
       end
@@ -710,7 +710,7 @@ TEXT
   # Prefix and suffix the program filename the same as ruby.
 
   def formatted_program_filename(filename)
-    if @format_executable then
+    if @format_executable
       self.class.exec_format % File.basename(filename)
     else
       filename

--- a/lib/rubygems/local_remote_options.rb
+++ b/lib/rubygems/local_remote_options.rb
@@ -105,7 +105,7 @@ module Gem::LocalRemoteOptions
 
       source << '/' if source !~ /\/\z/
 
-      if options.delete :sources_cleared then
+      if options.delete :sources_cleared
         Gem.sources = [source]
       else
         Gem.sources << source unless Gem.sources.include?(source)

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -277,7 +277,7 @@ EOM
   # the security policy.
 
   def digest entry # :nodoc:
-    algorithms = if @checksums then
+    algorithms = if @checksums
                    @checksums.keys
                  else
                    [Gem::Security::DIGEST_NAME].compact
@@ -285,7 +285,7 @@ EOM
 
     algorithms.each do |algorithm|
       digester =
-        if defined?(OpenSSL::Digest) then
+        if defined?(OpenSSL::Digest)
           OpenSSL::Digest.new algorithm
         else
           Digest.const_get(algorithm).new
@@ -348,7 +348,7 @@ EOM
         mkdir_options = {}
         mkdir_options[:mode] = entry.header.mode if entry.directory?
         mkdir =
-          if entry.directory? then
+          if entry.directory?
             destination
           else
             File.dirname destination
@@ -408,9 +408,9 @@ EOM
 
   def load_spec entry # :nodoc:
     case entry.full_name
-    when 'metadata' then
+    when 'metadata'
       @spec = Gem::Specification.from_yaml entry.read
-    when 'metadata.gz' then
+    when 'metadata.gz'
       args = [entry]
       args << { :external_encoding => Encoding::UTF_8 } if
         Object.const_defined?(:Encoding) &&
@@ -452,7 +452,7 @@ EOM
 
   def setup_signer
     passphrase = ENV['GEM_PRIVATE_KEY_PASSPHRASE']
-    if @spec.signing_key then
+    if @spec.signing_key
       @signer = Gem::Security::Signer.new @spec.signing_key, @spec.cert_chain, passphrase
       @spec.signing_key = nil
       @spec.cert_chain = @signer.cert_chain.map { |cert| cert.to_s }
@@ -525,7 +525,7 @@ EOM
       gem_digests.sort.each do |file_name, gem_hexdigest|
         computed_digest = digests[algorithm][file_name]
 
-        unless computed_digest.hexdigest == gem_hexdigest then
+        unless computed_digest.hexdigest == gem_hexdigest
           raise Gem::Package::FormatError.new \
             "#{algorithm} checksum mismatch for #{file_name}", @gem
         end
@@ -541,7 +541,7 @@ EOM
     @files << file_name
 
     case file_name
-    when /\.sig$/ then
+    when /\.sig$/
       @signatures[$`] = entry.read if @security_policy
       return
     else
@@ -549,9 +549,9 @@ EOM
     end
 
     case file_name
-    when /^metadata(.gz)?$/ then
+    when /^metadata(.gz)?$/
       load_spec entry
-    when 'data.tar.gz' then
+    when 'data.tar.gz'
       verify_gz entry
     end
   rescue => e
@@ -568,11 +568,11 @@ EOM
       verify_entry entry
     end
 
-    unless @spec then
+    unless @spec
       raise Gem::Package::FormatError.new 'package metadata is missing', @gem
     end
 
-    unless @files.include? 'data.tar.gz' then
+    unless @files.include? 'data.tar.gz'
       raise Gem::Package::FormatError.new \
               'package content (data.tar.gz) is missing', @gem
     end

--- a/lib/rubygems/package/old.rb
+++ b/lib/rubygems/package/old.rb
@@ -143,9 +143,9 @@ class Gem::Package::Old < Gem::Package
       end
     end
 
-    yaml_error = if RUBY_VERSION < '1.9' then
+    yaml_error = if RUBY_VERSION < '1.9'
                    YAML::ParseError
-                 elsif YAML::ENGINE.yamler == 'syck' then
+                 elsif YAML::ENGINE.yamler == 'syck'
                    YAML::ParseError
                  else
                    YAML::SyntaxError

--- a/lib/rubygems/package/tar_header.rb
+++ b/lib/rubygems/package/tar_header.rb
@@ -126,7 +126,7 @@ class Gem::Package::TarHeader
   # Creates a new TarHeader using +vals+
 
   def initialize(vals)
-    unless vals[:name] && vals[:size] && vals[:prefix] && vals[:mode] then
+    unless vals[:name] && vals[:size] && vals[:prefix] && vals[:mode]
       raise ArgumentError, ":name, :size, :prefix and :mode required"
     end
 

--- a/lib/rubygems/package/tar_reader.rb
+++ b/lib/rubygems/package/tar_reader.rb
@@ -91,7 +91,7 @@ class Gem::Package::TarReader
   # NOTE: Do not call #rewind during #each
 
   def rewind
-    if @init_pos == 0 then
+    if @init_pos == 0
       raise Gem::Package::NonSeekableIO unless @io.respond_to? :rewind
       @io.rewind
     else

--- a/lib/rubygems/package/tar_reader/entry.rb
+++ b/lib/rubygems/package/tar_reader/entry.rb
@@ -63,7 +63,7 @@ class Gem::Package::TarReader::Entry
   # Full name of the tar entry
 
   def full_name
-    if @header.prefix != "" then
+    if @header.prefix != ""
       File.join @header.prefix, @header.name
     else
       @header.name

--- a/lib/rubygems/package/tar_test_case.rb
+++ b/lib/rubygems/package/tar_test_case.rb
@@ -51,7 +51,7 @@ class Gem::Package::TarTestCase < Gem::TestCase
       name = fields.shift
       length = fields.shift.to_i
 
-      if name == "checksum" then
+      if name == "checksum"
         chksum_off = offset
         offset += length
         next
@@ -94,7 +94,7 @@ class Gem::Package::TarTestCase < Gem::TestCase
     ]
 
     format = "C100C8C8C8C12C12C8CC100C6C2C32C32C8C8C155"
-    h = if RUBY_VERSION >= "1.9" then
+    h = if RUBY_VERSION >= "1.9"
           arr.join
         else
           arr = arr.join("").split(//).map{|x| x[0]}

--- a/lib/rubygems/package/tar_writer.rb
+++ b/lib/rubygems/package/tar_writer.rb
@@ -144,7 +144,7 @@ class Gem::Package::TarWriter
     digests = digest_algorithms.map do |digest_algorithm|
       digest = digest_algorithm.new
       digest_name =
-        if digest.respond_to? :name then
+        if digest.respond_to? :name
           digest.name
         else
           /::([^:]+)$/ =~ digest_algorithm.name
@@ -185,7 +185,7 @@ class Gem::Package::TarWriter
 
     signature_digest = digests.values.compact.find do |digest|
       digest_name =
-        if digest.respond_to? :name then
+        if digest.respond_to? :name
           digest.name
         else
           /::([^:]+)$/ =~ digest.class.name
@@ -195,7 +195,7 @@ class Gem::Package::TarWriter
       digest_name == signer.digest_name
     end
 
-    if signer.key then
+    if signer.key
       signature = signer.sign signature_digest.digest
 
       add_file_simple "#{name}.sig", 0444, signature.length do |io|
@@ -292,7 +292,7 @@ class Gem::Package::TarWriter
   def split_name(name) # :nodoc:
     raise Gem::Package::TooLongFileName if name.bytesize > 256
 
-    if name.bytesize <= 100 then
+    if name.bytesize <= 100
       prefix = ""
     else
       parts = name.split(/\//)
@@ -308,7 +308,7 @@ class Gem::Package::TarWriter
       prefix = (parts + [nxt]).join "/"
       name = newname
 
-      if name.bytesize > 100 or prefix.bytesize > 155 then
+      if name.bytesize > 100 or prefix.bytesize > 155
         raise Gem::Package::TooLongFileName
       end
     end

--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -27,7 +27,7 @@ class Gem::PathSupport
     # note 'env' vs 'ENV'...
     @home     = env["GEM_HOME"] || ENV["GEM_HOME"] || Gem.default_dir
 
-    if File::ALT_SEPARATOR then
+    if File::ALT_SEPARATOR
       @home   = @home.gsub(File::ALT_SEPARATOR, File::SEPARATOR)
     end
 
@@ -67,7 +67,7 @@ class Gem::PathSupport
         gem_path = gpaths.split(Gem.path_separator)
       end
 
-      if File::ALT_SEPARATOR then
+      if File::ALT_SEPARATOR
         gem_path.map! do |this_path|
           this_path.gsub File::ALT_SEPARATOR, File::SEPARATOR
         end

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -39,9 +39,9 @@ class Gem::Platform
 
   def self.new(arch) # :nodoc:
     case arch
-    when Gem::Platform::CURRENT then
+    when Gem::Platform::CURRENT
       Gem::Platform.local
-    when Gem::Platform::RUBY, nil, '' then
+    when Gem::Platform::RUBY, nil, ''
       Gem::Platform::RUBY
     else
       super
@@ -50,12 +50,12 @@ class Gem::Platform
 
   def initialize(arch)
     case arch
-    when Array then
+    when Array
       @cpu, @os, @version = arch
-    when String then
+    when String
       arch = arch.split '-'
 
-      if arch.length > 2 and arch.last !~ /\d/ then # reassemble x86-linux-gnu
+      if arch.length > 2 and arch.last !~ /\d/ # reassemble x86-linux-gnu
         extra = arch.pop
         arch.last << "-#{extra}"
       end
@@ -67,7 +67,7 @@ class Gem::Platform
              else cpu
              end
 
-      if arch.length == 2 and arch.last =~ /^\d+(\.\d+)?$/ then # for command-line
+      if arch.length == 2 and arch.last =~ /^\d+(\.\d+)?$/ # for command-line
         @os, @version = arch
         return
       end
@@ -163,8 +163,8 @@ class Gem::Platform
 
   def =~(other)
     case other
-    when Gem::Platform then # nop
-    when String then
+    when Gem::Platform # nop
+    when String
       # This data is from http://gems.rubyforge.org/gems/yaml on 19 Aug 2007
       other = case other
               when /^i686-darwin(\d)/     then ['x86',       'darwin',  $1    ]

--- a/lib/rubygems/rdoc.rb
+++ b/lib/rubygems/rdoc.rb
@@ -97,7 +97,7 @@ class Gem::RDoc # :nodoc: all
 
     require 'rdoc/rdoc'
 
-    @rdoc_version = if ::RDoc.const_defined? :VERSION then
+    @rdoc_version = if ::RDoc.const_defined? :VERSION
                       Gem::Version.new ::RDoc::VERSION
                     else
                       Gem::Version.new '1.0.1'
@@ -184,7 +184,7 @@ class Gem::RDoc # :nodoc: all
 
     options = nil
 
-    if Gem::Requirement.new('< 3').satisfied_by? self.class.rdoc_version then
+    if Gem::Requirement.new('< 3').satisfied_by? self.class.rdoc_version
       generate_legacy
       return
     end
@@ -197,9 +197,9 @@ class Gem::RDoc # :nodoc: all
     args.concat @spec.extra_rdoc_files
 
     case config_args = Gem.configuration[:rdoc]
-    when String then
+    when String
       args = args.concat config_args.split
-    when Array then
+    when Array
       args = args.concat config_args
     end
 
@@ -234,13 +234,13 @@ class Gem::RDoc # :nodoc: all
   # exist in future versions.
 
   def generate_legacy
-    if @generate_rdoc then
+    if @generate_rdoc
       FileUtils.rm_rf @rdoc_dir
       say "Installing RDoc documentation for #{@spec.full_name}"
       legacy_rdoc '--op', @rdoc_dir
     end
 
-    if @generate_ri then
+    if @generate_ri
       FileUtils.rm_rf @ri_dir
       say "Installing ri documentation for #{@spec.full_name}"
       legacy_rdoc '--ri', '--op', @ri_dir

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -118,9 +118,9 @@ class Gem::RemoteFetcher
 
   def download(spec, source_uri, install_dir = Gem.dir)
     cache_dir =
-      if Dir.pwd == install_dir then # see fetch_command
+      if Dir.pwd == install_dir # see fetch_command
         install_dir
-      elsif File.writable? install_dir then
+      elsif File.writable? install_dir
         File.join install_dir, "cache"
       else
         File.join Gem.user_dir, "cache"
@@ -146,8 +146,8 @@ class Gem::RemoteFetcher
     # REFACTOR: split this up and dispatch on scheme (eg download_http)
     # REFACTOR: be sure to clean up fake fetcher when you do this... cleaner
     case scheme
-    when 'http', 'https' then
-      unless File.exist? local_gem_path then
+    when 'http', 'https'
+      unless File.exist? local_gem_path
         begin
           say "Downloading gem #{gem_file_name}" if
             Gem.configuration.really_verbose
@@ -168,7 +168,7 @@ class Gem::RemoteFetcher
           self.cache_update_path remote_gem_path, local_gem_path
         end
       end
-    when 'file' then
+    when 'file'
       begin
         path = source_uri.path
         path = File.dirname(path) if File.extname(path) == '.gem'
@@ -182,9 +182,9 @@ class Gem::RemoteFetcher
 
       say "Using local gem #{local_gem_path}" if
         Gem.configuration.really_verbose
-    when nil then # TODO test for local overriding cache
+    when nil # TODO test for local overriding cache
       source_path = if Gem.win_platform? && source_uri.scheme &&
-                       !source_uri.path.include?(':') then
+                       !source_uri.path.include?(':')
                       "#{source_uri.scheme}:#{source_uri.path}"
                     else
                       source_uri.path
@@ -223,10 +223,10 @@ class Gem::RemoteFetcher
     response   = request uri, fetch_type, last_modified
 
     case response
-    when Net::HTTPOK, Net::HTTPNotModified then
+    when Net::HTTPOK, Net::HTTPNotModified
       head ? response : response.body
     when Net::HTTPMovedPermanently, Net::HTTPFound, Net::HTTPSeeOther,
-         Net::HTTPTemporaryRedirect then
+         Net::HTTPTemporaryRedirect
       raise FetchError.new('too many redirects', uri) if depth > 10
 
       location = URI.parse response['Location']

--- a/lib/rubygems/request.rb
+++ b/lib/rubygems/request.rb
@@ -42,7 +42,7 @@ class Gem::Request
       Gem.configuration.ssl_verify_mode || OpenSSL::SSL::VERIFY_PEER
     store = OpenSSL::X509::Store.new
 
-    if Gem.configuration.ssl_client_cert then
+    if Gem.configuration.ssl_client_cert
       pem = File.read Gem.configuration.ssl_client_cert
       connection.cert = OpenSSL::X509::Certificate.new pem
       connection.key = OpenSSL::PKey::RSA.new pem
@@ -74,7 +74,7 @@ class Gem::Request
   def connection_for(uri)
     net_http_args = [uri.host, uri.port]
 
-    if @proxy_uri and not no_proxy?(uri.host) then
+    if @proxy_uri and not no_proxy?(uri.host)
       net_http_args += [
         @proxy_uri.host,
         @proxy_uri.port,
@@ -90,7 +90,7 @@ class Gem::Request
       @connections[connection_id]
     end
 
-    if https?(uri) and not connection.started? then
+    if https?(uri) and not connection.started?
       configure_connection_for_https(connection)
     end
 
@@ -105,7 +105,7 @@ class Gem::Request
   def fetch
     request = @request_class.new @uri.request_uri
 
-    unless @uri.nil? || @uri.user.nil? || @uri.user.empty? then
+    unless @uri.nil? || @uri.user.nil? || @uri.user.empty?
       request.basic_auth @uri.user, @uri.password
     end
 
@@ -113,7 +113,7 @@ class Gem::Request
     request.add_field 'Connection', 'keep-alive'
     request.add_field 'Keep-Alive', '30'
 
-    if @last_modified then
+    if @last_modified
       request.add_field 'If-Modified-Since', @last_modified.httpdate
     end
 
@@ -217,7 +217,7 @@ class Gem::Request
 
     uri = URI(Gem::UriFormatter.new(env_proxy).normalize)
 
-    if uri and uri.user.nil? and uri.password.nil? then
+    if uri and uri.user.nil? and uri.password.nil?
       user     = ENV["#{_scheme}_proxy_user"] || ENV["#{_SCHEME}_PROXY_USER"]
       password = ENV["#{_scheme}_proxy_pass"] || ENV["#{_SCHEME}_PROXY_PASS"]
 
@@ -258,9 +258,9 @@ class Gem::Request
     ruby_version += 'dev' if RUBY_PATCHLEVEL == -1
 
     ua << " Ruby/#{ruby_version} (#{RUBY_RELEASE_DATE}"
-    if RUBY_PATCHLEVEL >= 0 then
+    if RUBY_PATCHLEVEL >= 0
       ua << " patchlevel #{RUBY_PATCHLEVEL}"
-    elsif defined?(RUBY_REVISION) then
+    elsif defined?(RUBY_REVISION)
       ua << " revision #{RUBY_REVISION}"
     end
     ua << ")"

--- a/lib/rubygems/request_set.rb
+++ b/lib/rubygems/request_set.rb
@@ -85,7 +85,7 @@ class Gem::RequestSet
   # Declare that a gem of name +name+ with +reqs+ requirements is needed.
 
   def gem name, *reqs
-    if dep = @dependency_names[name] then
+    if dep = @dependency_names[name]
       dep.requirement.concat reqs
     else
       dep = Gem::Dependency.new name, reqs
@@ -118,10 +118,10 @@ class Gem::RequestSet
     specs = []
 
     sorted_requests.each do |req|
-      if req.installed? then
+      if req.installed?
         req.spec.spec.build_extensions
 
-        if @always_install.none? { |spec| spec == req.spec.spec } then
+        if @always_install.none? { |spec| spec == req.spec.spec }
           yield req, nil if block_given?
           next
         end
@@ -191,7 +191,7 @@ class Gem::RequestSet
     sorted_requests.each do |request|
       spec = request.spec
 
-      if existing.find { |s| s.full_name == spec.full_name } then
+      if existing.find { |s| s.full_name == spec.full_name }
         yield request, nil if block_given?
         next
       end

--- a/lib/rubygems/request_set/gem_dependency_api.rb
+++ b/lib/rubygems/request_set/gem_dependency_api.rb
@@ -169,7 +169,7 @@ class Gem::RequestSet::GemDependencyAPI
     spec_files = Dir[glob]
 
     case spec_files.length
-    when 1 then
+    when 1
       spec_file = spec_files.first
 
       spec = Gem::Specification.load spec_file
@@ -177,7 +177,7 @@ class Gem::RequestSet::GemDependencyAPI
       return spec if spec
 
       raise ArgumentError, "invalid gemspec #{spec_file}"
-    when 0 then
+    when 0
       raise ArgumentError, "no gemspecs found at #{Dir.pwd}"
     else
       raise ArgumentError,
@@ -234,7 +234,7 @@ class Gem::RequestSet::GemDependencyAPI
   # Returns +true+ if the path option was handled.
 
   def gem_git name, options # :nodoc:
-    if gist = options.delete(:gist) then
+    if gist = options.delete(:gist)
       options[:git] = "https://gist.github.com/#{gist}.git"
     end
 
@@ -325,14 +325,14 @@ class Gem::RequestSet::GemDependencyAPI
 
       next false unless Gem::Platform.match platform
 
-      if engines = ENGINE_MAP[platform_name] then
+      if engines = ENGINE_MAP[platform_name]
         next false unless engines.include? Gem.ruby_engine
       end
 
       case WINDOWS[platform_name]
-      when :only then
+      when :only
         next false unless Gem.win_platform?
-      when :never then
+      when :never
         next false if Gem.win_platform?
       end
 
@@ -347,8 +347,8 @@ class Gem::RequestSet::GemDependencyAPI
   # default file to the require list for +name+.
 
   def gem_requires name, options # :nodoc:
-    if options.include? :require then
-      if requires = options.delete(:require) then
+    if options.include? :require
+      if requires = options.delete(:require)
         @requires[name].concat Array requires
       end
     else
@@ -471,24 +471,24 @@ class Gem::RequestSet::GemDependencyAPI
           'you must specify engine_version along with the ruby engine' if
             engine and not engine_version
 
-    unless RUBY_VERSION == version then
+    unless RUBY_VERSION == version
       message = "Your Ruby version is #{RUBY_VERSION}, " +
                 "but your #{gem_deps_file} requires #{version}"
 
       raise Gem::RubyVersionMismatch, message
     end
 
-    if engine and engine != Gem.ruby_engine then
+    if engine and engine != Gem.ruby_engine
       message = "Your ruby engine is #{Gem.ruby_engine}, " +
                 "but your #{gem_deps_file} requires #{engine}"
 
       raise Gem::RubyVersionMismatch, message
     end
 
-    if engine_version then
+    if engine_version
       my_engine_version = Object.const_get "#{Gem.ruby_engine.upcase}_VERSION"
 
-      if engine_version != my_engine_version then
+      if engine_version != my_engine_version
         message =
           "Your ruby engine version is #{Gem.ruby_engine} #{my_engine_version}, " +
           "but your #{gem_deps_file} requires #{engine} #{engine_version}"

--- a/lib/rubygems/request_set/lockfile.rb
+++ b/lib/rubygems/request_set/lockfile.rb
@@ -68,7 +68,7 @@ class Gem::RequestSet::Lockfile
       spec = request.spec
 
       if [Gem::Resolver::VendorSpecification,
-          Gem::Resolver::GitSpecification].include? spec.class then
+          Gem::Resolver::GitSpecification].include? spec.class
         out << "  #{request.name}!"
       else
         requirement = request.request.dependency.requirement
@@ -183,7 +183,7 @@ class Gem::RequestSet::Lockfile
 
     type, value, column, line = @current_token
 
-    if expected_types and not Array(expected_types).include? type then
+    if expected_types and not Array(expected_types).include? type
       unget
 
       message = "unexpected token [#{type.inspect}, #{value.inspect}], " +
@@ -192,7 +192,7 @@ class Gem::RequestSet::Lockfile
       raise ParseError.new message, column, line, "#{@gem_deps_file}.lock"
     end
 
-    if expected_value and expected_value != value then
+    if expected_value and expected_value != value
       unget
 
       message = "unexpected token [#{type.inspect}, #{value.inspect}], " +
@@ -212,19 +212,19 @@ class Gem::RequestSet::Lockfile
       type, data, column, line = get
 
       case type
-      when :section then
+      when :section
         skip :newline
 
         case data
-        when 'DEPENDENCIES' then
+        when 'DEPENDENCIES'
           parse_DEPENDENCIES
-        when 'GIT' then
+        when 'GIT'
           parse_GIT
-        when 'GEM' then
+        when 'GEM'
           parse_GEM
-        when 'PATH' then
+        when 'PATH'
           parse_PATH
-        when 'PLATFORMS' then
+        when 'PLATFORMS'
           parse_PLATFORMS
         else
           type, = get until @tokens.empty? or peek.first == :section
@@ -242,7 +242,7 @@ class Gem::RequestSet::Lockfile
       requirements = []
 
       case peek[0]
-      when :bang then
+      when :bang
         get :bang
 
         spec = @set.sets.select { |set|
@@ -253,7 +253,7 @@ class Gem::RequestSet::Lockfile
         }.first
 
         requirements << spec.version
-      when :l_paren then
+      when :l_paren
         get :l_paren
 
         loop do
@@ -295,14 +295,14 @@ class Gem::RequestSet::Lockfile
       _, name, column, = get :text
 
       case peek[0]
-      when :newline then
+      when :newline
         last_spec.add_dependency Gem::Dependency.new name if column == 6
-      when :l_paren then
+      when :l_paren
         get :l_paren
 
         type, data, = get [:text, :requirement]
 
-        if type == :text and column == 4 then
+        if type == :text and column == 4
           version, platform = data.split '-', 2
 
           platform =
@@ -348,14 +348,14 @@ class Gem::RequestSet::Lockfile
       _, name, column, = get :text
 
       case peek[0]
-      when :newline then
+      when :newline
         last_spec.add_dependency Gem::Dependency.new name if column == 6
-      when :l_paren then
+      when :l_paren
         get :l_paren
 
         type, data, = get [:text, :requirement]
 
-        if type == :text and column == 4 then
+        if type == :text and column == 4
           last_spec = set.add_git_spec name, data, repository, revision, true
         else
           dependency = parse_dependency name, data
@@ -391,14 +391,14 @@ class Gem::RequestSet::Lockfile
       _, name, column, = get :text
 
       case peek[0]
-      when :newline then
+      when :newline
         last_spec.add_dependency Gem::Dependency.new name if column == 6
-      when :l_paren then
+      when :l_paren
         get :l_paren
 
         type, data, = get [:text, :requirement]
 
-        if type == :text and column == 4 then
+        if type == :text and column == 4
           last_spec = set.add_vendor_gem name, directory
         else
           dependency = parse_dependency name, data
@@ -517,7 +517,7 @@ class Gem::RequestSet::Lockfile
 
       pos = s.pos if leading_whitespace = s.scan(/ +/)
 
-      if s.scan(/[<|=>]{7}/) then
+      if s.scan(/[<|=>]{7}/)
         message = "your #{lock_file} contains merge conflict markers"
         column, line = token_pos pos
 
@@ -526,33 +526,33 @@ class Gem::RequestSet::Lockfile
 
       @tokens <<
         case
-        when s.scan(/\r?\n/) then
+        when s.scan(/\r?\n/)
           token = [:newline, nil, *token_pos(pos)]
           @line_pos = s.pos
           @line += 1
           token
-        when s.scan(/[A-Z]+/) then
-          if leading_whitespace then
+        when s.scan(/[A-Z]+/)
+          if leading_whitespace
             text = s.matched
             text += s.scan(/[^\s)]*/).to_s # in case of no match
             [:text, text, *token_pos(pos)]
           else
             [:section, s.matched, *token_pos(pos)]
           end
-        when s.scan(/([a-z]+):\s/) then
+        when s.scan(/([a-z]+):\s/)
           s.pos -= 1 # rewind for possible newline
           [:entry, s[1], *token_pos(pos)]
-        when s.scan(/\(/) then
+        when s.scan(/\(/)
           [:l_paren, nil, *token_pos(pos)]
-        when s.scan(/\)/) then
+        when s.scan(/\)/)
           [:r_paren, nil, *token_pos(pos)]
-        when s.scan(/<=|>=|=|~>|<|>|!=/) then
+        when s.scan(/<=|>=|=|~>|<|>|!=/)
           [:requirement, s.matched, *token_pos(pos)]
-        when s.scan(/,/) then
+        when s.scan(/,/)
           [:comma, nil, *token_pos(pos)]
-        when s.scan(/!/) then
+        when s.scan(/!/)
           [:bang, nil, *token_pos(pos)]
-        when s.scan(/[^\s),!]*/) then
+        when s.scan(/[^\s),!]*/)
           [:text, s.matched, *token_pos(pos)]
         else
           raise "BUG: can't create token for: #{s.string[s.pos..-1].inspect}"

--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -47,12 +47,12 @@ class Gem::Requirement
 
   def self.create input
     case input
-    when Gem::Requirement then
+    when Gem::Requirement
       input
-    when Gem::Version, Array then
+    when Gem::Version, Array
       new input
     else
-      if input.respond_to? :to_str then
+      if input.respond_to? :to_str
         new [input.to_str]
       else
         default

--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -59,7 +59,7 @@ class Gem::Resolver
 
     sets = sets.map do |set|
       case set
-      when Gem::Resolver::ComposedSet then
+      when Gem::Resolver::ComposedSet
         set.sets
       else
         set
@@ -67,9 +67,9 @@ class Gem::Resolver
     end.flatten
 
     case sets.length
-    when 0 then
+    when 0
       raise ArgumentError, 'one set in the composition must be non-nil'
-    when 1 then
+    when 1
       sets.first
     else
       Gem::Resolver::ComposedSet.new(*sets)
@@ -234,7 +234,7 @@ class Gem::Resolver
     def summary # :nodoc:
       nd = needed.map { |s| s.to_s }.sort if nd
 
-      if specs then
+      if specs
         ss = specs.map { |s| s.full_name }.sort
         ss.unshift ss.length
       end

--- a/lib/rubygems/resolver/activation_request.rb
+++ b/lib/rubygems/resolver/activation_request.rb
@@ -70,12 +70,12 @@ class Gem::Resolver::ActivationRequest
   def inspect # :nodoc:
     others =
       case @others_possible
-      when true then # TODO remove at RubyGems 3
+      when true # TODO remove at RubyGems 3
         ' (others possible)'
-      when false then # TODO remove at RubyGems 3
+      when false # TODO remove at RubyGems 3
         nil
       else
-        unless @others_possible.empty? then
+        unless @others_possible.empty?
           others = @others_possible.map { |s| s.full_name }
           " (others possible: #{others.join ', '})"
         end
@@ -91,7 +91,7 @@ class Gem::Resolver::ActivationRequest
 
   def installed?
     case @spec
-    when Gem::Resolver::VendorSpecification then
+    when Gem::Resolver::VendorSpecification
       true
     else
       this_spec = full_spec
@@ -115,7 +115,7 @@ class Gem::Resolver::ActivationRequest
 
   def others_possible?
     case @others_possible
-    when true, false then
+    when true, false
       @others_possible
     else
       not @others_possible.empty?
@@ -140,12 +140,12 @@ class Gem::Resolver::ActivationRequest
       q.pp @request
 
       case @others_possible
-      when false then
-      when true then
+      when false
+      when true
         q.breakable
         q.text 'others possible'
       else
-        unless @others_possible.empty? then
+        unless @others_possible.empty?
           q.breakable
           q.text 'others '
           q.pp @others_possible.map { |s| s.full_name }

--- a/lib/rubygems/resolver/conflict.rb
+++ b/lib/rubygems/resolver/conflict.rb
@@ -79,7 +79,7 @@ class Gem::Resolver::Conflict
       q.pp @dependency
 
       q.breakable
-      if @dependency == @failed_dep then
+      if @dependency == @failed_dep
         q.text ' failed'
       else
         q.text ' failed dependency '

--- a/lib/rubygems/resolver/index_set.rb
+++ b/lib/rubygems/resolver/index_set.rb
@@ -6,7 +6,7 @@ class Gem::Resolver::IndexSet < Gem::Resolver::Set
 
   def initialize source = nil # :nodoc:
     @f =
-      if source then
+      if source
         sources = Gem::SourceList.from [source]
 
         Gem::SpecFetcher.new sources
@@ -37,7 +37,7 @@ class Gem::Resolver::IndexSet < Gem::Resolver::Set
     name = req.dependency.name
 
     @all[name].each do |uri, n|
-      if req.dependency.match? n then
+      if req.dependency.match? n
         res << Gem::Resolver::IndexSpecification.new(
           self, n.name, n.version, uri, n.platform)
       end

--- a/lib/rubygems/resolver/index_specification.rb
+++ b/lib/rubygems/resolver/index_specification.rb
@@ -42,7 +42,7 @@ class Gem::Resolver::IndexSpecification < Gem::Resolver::Specification
       q.breakable
       q.text full_name
 
-      unless Gem::Platform::RUBY == @platform then
+      unless Gem::Platform::RUBY == @platform
         q.breakable
         q.text @platform.to_s
       end

--- a/lib/rubygems/resolver/installer_set.rb
+++ b/lib/rubygems/resolver/installer_set.rb
@@ -69,10 +69,10 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
       res << Gem::Resolver::InstalledSpecification.new(self, gemspec)
     end unless @ignore_installed
 
-    if consider_local? then
+    if consider_local?
       local_source = Gem::Source::Local.new
 
-      if spec = local_source.find_gem(name, dep.requirement) then
+      if spec = local_source.find_gem(name, dep.requirement)
         res << Gem::Resolver::IndexSpecification.new(
           self, spec.name, spec.version, local_source, spec.platform)
       end

--- a/lib/rubygems/resolver/lock_specification.rb
+++ b/lib/rubygems/resolver/lock_specification.rb
@@ -26,7 +26,7 @@ class Gem::Resolver::LockSpecification < Gem::Resolver::Specification
   def install options
     destination = options[:install_dir] || Gem.dir
 
-    if File.exist? File.join(destination, 'specifications', spec.spec_name) then
+    if File.exist? File.join(destination, 'specifications', spec.spec_name)
       yield nil
       return
     end

--- a/lib/rubygems/security.rb
+++ b/lib/rubygems/security.rb
@@ -339,7 +339,7 @@ module Gem::Security
   # Digest algorithm used to sign gems
 
   DIGEST_ALGORITHM =
-    if defined?(OpenSSL::Digest) then
+    if defined?(OpenSSL::Digest)
       OpenSSL::Digest::SHA1
     end
 
@@ -347,7 +347,7 @@ module Gem::Security
   # Used internally to select the signing digest from all computed digests
 
   DIGEST_NAME = # :nodoc:
-    if DIGEST_ALGORITHM then
+    if DIGEST_ALGORITHM
       DIGEST_ALGORITHM.new.name
     end
 
@@ -355,7 +355,7 @@ module Gem::Security
   # Algorithm for creating the key pair used to sign gems
 
   KEY_ALGORITHM =
-    if defined?(OpenSSL::PKey) then
+    if defined?(OpenSSL::PKey)
       OpenSSL::PKey::RSA
     end
 
@@ -489,7 +489,7 @@ module Gem::Security
       expired_certificate.public_key.to_pem == private_key.public_key.to_pem
 
     unless expired_certificate.subject.to_s ==
-           expired_certificate.issuer.to_s then
+           expired_certificate.issuer.to_s
       subject = alt_name_or_x509_entry expired_certificate, :subject
       issuer  = alt_name_or_x509_entry expired_certificate, :issuer
 
@@ -585,7 +585,7 @@ module Gem::Security
 
 end
 
-if defined?(OpenSSL::SSL) then
+if defined?(OpenSSL::SSL)
   require 'rubygems/security/policy'
   require 'rubygems/security/policies'
   require 'rubygems/security/trust_dir'

--- a/lib/rubygems/security/policy.rb
+++ b/lib/rubygems/security/policy.rb
@@ -90,16 +90,16 @@ class Gem::Security::Policy
 
     message = "certificate #{signer.subject}"
 
-    if not_before = signer.not_before and not_before > time then
+    if not_before = signer.not_before and not_before > time
       raise Gem::Security::Exception,
             "#{message} not valid before #{not_before}"
     end
 
-    if not_after = signer.not_after and not_after < time then
+    if not_after = signer.not_after and not_after < time
       raise Gem::Security::Exception, "#{message} not valid after #{not_after}"
     end
 
-    if issuer and not signer.verify issuer.public_key then
+    if issuer and not signer.verify issuer.public_key
       raise Gem::Security::Exception,
             "#{message} was not issued by #{issuer.subject}"
     end
@@ -111,7 +111,7 @@ class Gem::Security::Policy
   # Ensures the public key of +key+ matches the public key in +signer+
 
   def check_key signer, key
-    unless signer and key then
+    unless signer and key
       return true unless @only_signed
 
       raise Gem::Security::Exception, 'missing key or signature'
@@ -156,7 +156,7 @@ class Gem::Security::Policy
 
     path = Gem::Security.trust_dir.cert_path root
 
-    unless File.exist? path then
+    unless File.exist? path
       message = "root cert #{root.subject} is not trusted"
 
       message << " (root of signing cert #{chain.last.subject})" if
@@ -209,11 +209,11 @@ class Gem::Security::Policy
 
   def verify chain, key = nil, digests = {}, signatures = {},
              full_name = '(unknown)'
-    if signatures.empty? then
-      if @only_signed then
+    if signatures.empty?
+      if @only_signed
         raise Gem::Security::Exception,
           "unsigned gems are not allowed by the #{name} policy"
-      elsif digests.empty? then
+      elsif digests.empty?
         # lack of signatures is irrelevant if there is nothing to check
         # against
       else
@@ -230,7 +230,7 @@ class Gem::Security::Policy
       file_digests.values.first.name == Gem::Security::DIGEST_NAME
     end
 
-    if @verify_data then
+    if @verify_data
       raise Gem::Security::Exception, 'no digests provided (probable bug)' if
         signer_digests.nil? or signer_digests.empty?
     else
@@ -247,9 +247,9 @@ class Gem::Security::Policy
 
     check_root chain, time if @verify_root
 
-    if @only_trusted then
+    if @only_trusted
       check_trust chain, digester, trust_dir
-    elsif signatures.empty? and digests.empty? then
+    elsif signatures.empty? and digests.empty?
       # trust is irrelevant if there's no signatures to verify
     else
       alert_warning "#{subject signer} is not trusted for #{full_name}"

--- a/lib/rubygems/security/signer.rb
+++ b/lib/rubygems/security/signer.rb
@@ -33,12 +33,12 @@ class Gem::Security::Signer
     @cert_chain = cert_chain
     @key        = key
 
-    unless @key then
+    unless @key
       default_key  = File.join Gem.default_key_path
       @key = default_key if File.exist? default_key
     end
 
-    unless @cert_chain then
+    unless @cert_chain
       default_cert = File.join Gem.default_cert_path
       @cert_chain = [default_cert] if File.exist? default_cert
     end
@@ -49,7 +49,7 @@ class Gem::Security::Signer
     @key = OpenSSL::PKey::RSA.new File.read(@key), passphrase if
       @key and not OpenSSL::PKey::RSA === @key
 
-    if @cert_chain then
+    if @cert_chain
       @cert_chain = @cert_chain.compact.map do |cert|
         next cert if OpenSSL::X509::Certificate === cert
 
@@ -69,7 +69,7 @@ class Gem::Security::Signer
   def extract_name cert # :nodoc:
     subject_alt_name = cert.extensions.find { |e| 'subjectAltName' == e.oid }
 
-    if subject_alt_name then
+    if subject_alt_name
       /\Aemail:/ =~ subject_alt_name.value
 
       $' || subject_alt_name.value
@@ -101,7 +101,7 @@ class Gem::Security::Signer
   def sign data
     return unless @key
 
-    if @cert_chain.length == 1 and @cert_chain.last.not_after < Time.now then
+    if @cert_chain.length == 1 and @cert_chain.last.not_after < Time.now
       re_sign_key
     end
 
@@ -133,12 +133,12 @@ class Gem::Security::Signer
     disk_key  =
       File.read File.join(Gem.default_key_path) rescue nil
 
-    if disk_key == @key.to_pem and disk_cert == old_cert.to_pem then
+    if disk_key == @key.to_pem and disk_cert == old_cert.to_pem
       expiry = old_cert.not_after.strftime '%Y%m%d%H%M%S'
       old_cert_file = "gem-public_cert.pem.expired.#{expiry}"
       old_cert_path = File.join Gem.user_home, ".gem", old_cert_file
 
-      unless File.exist? old_cert_path then
+      unless File.exist? old_cert_path
         Gem::Security.write old_cert, old_cert_path
 
         cert = Gem::Security.re_sign old_cert, @key

--- a/lib/rubygems/security/trust_dir.rb
+++ b/lib/rubygems/security/trust_dir.rb
@@ -103,7 +103,7 @@ class Gem::Security::TrustDir
   # permissions.
 
   def verify
-    if File.exist? @dir then
+    if File.exist? @dir
       raise Gem::Security::Exception,
         "trust directory #{@dir} is not a directory" unless
           File.directory? @dir

--- a/lib/rubygems/server.rb
+++ b/lib/rubygems/server.rb
@@ -73,37 +73,37 @@ class Gem::Server
   <dl>
   <% values["specs"].each do |spec| %>
     <dt>
-    <% if spec["first_name_entry"] then %>
+    <% if spec["first_name_entry"] %>
       <a name="<%=spec["name"]%>"></a>
     <% end %>
 
     <b><%=spec["name"]%> <%=spec["version"]%></b>
 
-    <% if spec["ri_installed"] then %>
+    <% if spec["ri_installed"] %>
       <a href="<%=spec["doc_path"]%>">[rdoc]</a>
-    <% elsif spec["rdoc_installed"] then %>
+    <% elsif spec["rdoc_installed"] %>
       <a href="<%=spec["doc_path"]%>">[rdoc]</a>
     <% else %>
       <span title="rdoc not installed">[rdoc]</span>
     <% end %>
 
-    <% if spec["homepage"] then %>
+    <% if spec["homepage"] %>
       <a href="<%=spec["homepage"]%>" title="<%=spec["homepage"]%>">[www]</a>
     <% else %>
       <span title="no homepage available">[www]</span>
     <% end %>
 
-    <% if spec["has_deps"] then %>
+    <% if spec["has_deps"] %>
      - depends on
       <%= spec["dependencies"].map { |v| "<a href=\"##{v["name"]}\">#{v["name"]}</a>" }.join ', ' %>.
     <% end %>
     </dt>
     <dd>
     <%=spec["summary"]%>
-    <% if spec["executables"] then %>
+    <% if spec["executables"] %>
       <br/>
 
-      <% if spec["only_one_executable"] then %>
+      <% if spec["only_one_executable"] %>
           Executable is
       <% else %>
           Executables are
@@ -457,7 +457,7 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
   end
 
   def doc_root gem_name
-    if have_rdoc_4_plus? then
+    if have_rdoc_4_plus?
       "/doc_root/#{gem_name}/"
     else
       "/doc_root/#{gem_name}/rdoc/index.html"
@@ -485,14 +485,14 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
 
     specs = Marshal.dump specs
 
-    if req.path =~ /\.gz$/ then
+    if req.path =~ /\.gz$/
       specs = Gem.gzip specs
       res['content-type'] = 'application/x-gzip'
     else
       res['content-type'] = 'application/octet-stream'
     end
 
-    if req.request_method == 'HEAD' then
+    if req.request_method == 'HEAD'
       res['content-length'] = specs.length
     else
       res.body << specs
@@ -523,7 +523,7 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
       end
     end
 
-    if @server.listeners.empty? then
+    if @server.listeners.empty?
       say "Unable to start a server."
       say "Check for running servers or your --bind and --port arguments"
       terminate_interaction 1
@@ -537,13 +537,13 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
     add_date res
 
     case req.request_uri.path
-    when %r|^/quick/(Marshal.#{Regexp.escape Gem.marshal_version}/)?(.*?)-([0-9.]+)(-.*?)?\.gemspec\.rz$| then
+    when %r|^/quick/(Marshal.#{Regexp.escape Gem.marshal_version}/)?(.*?)-([0-9.]+)(-.*?)?\.gemspec\.rz$|
       marshal_format, name, version, platform = $1, $2, $3, $4
       specs = Gem::Specification.find_all_by_name name, version
 
       selector = [name, version, platform].map(&:inspect).join ' '
 
-      platform = if platform then
+      platform = if platform
                    Gem::Platform.new platform.sub(/^-/, '')
                  else
                    Gem::Platform::RUBY
@@ -551,13 +551,13 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
 
       specs = specs.select { |s| s.platform == platform }
 
-      if specs.empty? then
+      if specs.empty?
         res.status = 404
         res.body = "No gems found matching #{selector}"
-      elsif specs.length > 1 then
+      elsif specs.length > 1
         res.status = 500
         res.body = "Multiple gems found matching #{selector}"
-      elsif marshal_format then
+      elsif marshal_format
         res['content-type'] = 'application/x-deflate'
         res.body << Gem.deflate(Marshal.dump(specs.first))
       end
@@ -773,7 +773,7 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
       '/gems' => '/cache/',
     }
 
-    if have_rdoc_4_plus? then
+    if have_rdoc_4_plus?
       @server.mount '/doc_root', RDoc::Servlet, '/doc_root'
     else
       file_handlers['/doc_root'] = '/doc/'
@@ -806,14 +806,14 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
 
     specs = Marshal.dump specs
 
-    if req.path =~ /\.gz$/ then
+    if req.path =~ /\.gz$/
       specs = Gem.gzip specs
       res['content-type'] = 'application/x-gzip'
     else
       res['content-type'] = 'application/octet-stream'
     end
 
-    if req.request_method == 'HEAD' then
+    if req.request_method == 'HEAD'
       res['content-length'] = specs.length
     else
       res.body << specs

--- a/lib/rubygems/source.rb
+++ b/lib/rubygems/source.rb
@@ -52,9 +52,9 @@ class Gem::Source
          Gem::Source::Lock,
          Gem::Source::SpecificFile,
          Gem::Source::Git,
-         Gem::Source::Vendor then
+         Gem::Source::Vendor
       -1
-    when Gem::Source then
+    when Gem::Source
       if !@uri
         return 0 unless other.uri
         return 1
@@ -129,7 +129,7 @@ class Gem::Source
 
     local_spec = File.join cache_dir, spec_file_name
 
-    if File.exist? local_spec then
+    if File.exist? local_spec
       spec = Gem.read_binary local_spec
       spec = Marshal.load(spec) rescue nil
       return spec if spec
@@ -140,7 +140,7 @@ class Gem::Source
     spec = fetcher.fetch_path uri
     spec = Gem.inflate spec
 
-    if update_cache? then
+    if update_cache?
       FileUtils.mkdir_p cache_dir
 
       open local_spec, 'wb' do |io|

--- a/lib/rubygems/source/git.rb
+++ b/lib/rubygems/source/git.rb
@@ -59,12 +59,12 @@ class Gem::Source::Git < Gem::Source
 
   def <=> other
     case other
-    when Gem::Source::Git then
+    when Gem::Source::Git
       0
     when Gem::Source::Installed,
-         Gem::Source::Lock then
+         Gem::Source::Lock
       -1
-    when Gem::Source then
+    when Gem::Source
       1
     else
       nil
@@ -85,7 +85,7 @@ class Gem::Source::Git < Gem::Source
   def checkout # :nodoc:
     cache
 
-    unless File.exist? install_dir then
+    unless File.exist? install_dir
       system @git, 'clone', '--quiet', '--no-checkout',
              repo_cache_dir, install_dir
     end
@@ -107,7 +107,7 @@ class Gem::Source::Git < Gem::Source
   # Creates a local cache repository for the git gem.
 
   def cache # :nodoc:
-    if File.exist? repo_cache_dir then
+    if File.exist? repo_cache_dir
       Dir.chdir repo_cache_dir do
         system @git, 'fetch', '--quiet', '--force', '--tags',
                @repository, 'refs/heads/*:refs/heads/*'
@@ -184,7 +184,7 @@ class Gem::Source::Git < Gem::Source
 
         Dir.chdir directory do
           spec = Gem::Specification.load file
-          if spec then
+          if spec
             spec.base_dir = base_dir
 
             spec.extension_dir =
@@ -204,7 +204,7 @@ class Gem::Source::Git < Gem::Source
 
   def uri_hash # :nodoc:
     normalized =
-      if @repository =~ %r%^\w+://(\w+@)?% then
+      if @repository =~ %r%^\w+://(\w+@)?%
         uri = URI(@repository).normalize.to_s.sub %r%/$%,''
         uri.sub(/\A(\w+)/) { $1.downcase }
       else

--- a/lib/rubygems/source/installed.rb
+++ b/lib/rubygems/source/installed.rb
@@ -13,11 +13,11 @@ class Gem::Source::Installed < Gem::Source
   def <=> other
     case other
     when Gem::Source::Lock,
-         Gem::Source::Vendor then
+         Gem::Source::Vendor
       -1
-    when Gem::Source::Installed then
+    when Gem::Source::Installed
       0
-    when Gem::Source then
+    when Gem::Source
       1
     else
       nil

--- a/lib/rubygems/source/local.rb
+++ b/lib/rubygems/source/local.rb
@@ -16,11 +16,11 @@ class Gem::Source::Local < Gem::Source
   def <=> other
     case other
     when Gem::Source::Installed,
-         Gem::Source::Lock then
+         Gem::Source::Lock
       -1
-    when Gem::Source::Local then
+    when Gem::Source::Local
       0
-    when Gem::Source then
+    when Gem::Source
       1
     else
       nil

--- a/lib/rubygems/source/lock.rb
+++ b/lib/rubygems/source/lock.rb
@@ -20,9 +20,9 @@ class Gem::Source::Lock < Gem::Source
 
   def <=> other # :nodoc:
     case other
-    when Gem::Source::Lock then
+    when Gem::Source::Lock
       @wrapped <=> other.wrapped
-    when Gem::Source then
+    when Gem::Source
       1
     else
       nil

--- a/lib/rubygems/source/specific_file.rb
+++ b/lib/rubygems/source/specific_file.rb
@@ -55,7 +55,7 @@ class Gem::Source::SpecificFile < Gem::Source
 
   def <=> other
     case other
-    when Gem::Source::SpecificFile then
+    when Gem::Source::SpecificFile
       return nil if @spec.name != other.spec.name
 
       @spec.version <=> other.spec.version

--- a/lib/rubygems/source/vendor.rb
+++ b/lib/rubygems/source/vendor.rb
@@ -12,11 +12,11 @@ class Gem::Source::Vendor < Gem::Source::Installed
 
   def <=> other
     case other
-    when Gem::Source::Lock then
+    when Gem::Source::Lock
       -1
-    when Gem::Source::Vendor then
+    when Gem::Source::Vendor
       0
-    when Gem::Source then
+    when Gem::Source
       1
     else
       nil

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -265,26 +265,26 @@ class Gem::Specification < Gem::BasicSpecification
 
   def platform= platform
     if @original_platform.nil? or
-       @original_platform == Gem::Platform::RUBY then
+       @original_platform == Gem::Platform::RUBY
       @original_platform = platform
     end
 
     case platform
-    when Gem::Platform::CURRENT then
+    when Gem::Platform::CURRENT
       @new_platform = Gem::Platform.local
       @original_platform = @new_platform.to_s
 
-    when Gem::Platform then
+    when Gem::Platform
       @new_platform = platform
 
     # legacy constants
-    when nil, Gem::Platform::RUBY then
+    when nil, Gem::Platform::RUBY
       @new_platform = Gem::Platform::RUBY
-    when 'mswin32' then # was Gem::Platform::WIN32
+    when 'mswin32' # was Gem::Platform::WIN32
       @new_platform = Gem::Platform.new 'x86-mswin32'
-    when 'i586-linux' then # was Gem::Platform::LINUX_586
+    when 'i586-linux' # was Gem::Platform::LINUX_586
       @new_platform = Gem::Platform.new 'x86-linux'
-    when 'powerpc-darwin' then # was Gem::Platform::DARWIN
+    when 'powerpc-darwin' # was Gem::Platform::DARWIN
       @new_platform = Gem::Platform.new 'ppc-darwin'
     else
       @new_platform = Gem::Platform.new platform
@@ -687,7 +687,7 @@ class Gem::Specification < Gem::BasicSpecification
   attr_accessor :specification_version
 
   def self._all # :nodoc:
-    unless defined?(@@all) && @@all then
+    unless defined?(@@all) && @@all
       @@all = stubs.map(&:to_spec)
 
       # After a reset, make sure already loaded specs
@@ -973,11 +973,11 @@ class Gem::Specification < Gem::BasicSpecification
     input = normalize_yaml_input input
     spec = YAML.load input
 
-    if spec && spec.class == FalseClass then
+    if spec && spec.class == FalseClass
       raise Gem::EndOfYAMLException
     end
 
-    unless Gem::Specification === spec then
+    unless Gem::Specification === spec
       raise Gem::Exception, "YAML data doesn't evaluate to gem specification"
     end
 
@@ -1139,7 +1139,7 @@ class Gem::Specification < Gem::BasicSpecification
     @@stubs = nil
     _clear_load_cache
     unresolved = unresolved_deps
-    unless unresolved.empty? then
+    unless unresolved.empty?
       w = "W" + "ARN"
       warn "#{w}: Unresolved specs during Gem::Specification.reset:"
       unresolved.values.each do |dep|
@@ -1168,7 +1168,7 @@ class Gem::Specification < Gem::BasicSpecification
 
     current_version = CURRENT_SPECIFICATION_VERSION
 
-    field_count = if spec.specification_version > current_version then
+    field_count = if spec.specification_version > current_version
                     spec.instance_variable_set :@specification_version,
                                                current_version
                     MARSHAL_FIELDS[current_version]
@@ -1176,7 +1176,7 @@ class Gem::Specification < Gem::BasicSpecification
                     MARSHAL_FIELDS[spec.specification_version]
                   end
 
-    if array.size < field_count then
+    if array.size < field_count
       raise TypeError, "invalid Gem::Specification format #{array.inspect}"
     end
 
@@ -1294,7 +1294,7 @@ class Gem::Specification < Gem::BasicSpecification
 
       specs = spec_dep.to_specs
 
-      if specs.size == 1 then
+      if specs.size == 1
         specs.first.activate
       else
         name = spec_dep.name
@@ -1312,7 +1312,7 @@ class Gem::Specification < Gem::BasicSpecification
   def add_bindir(executables)
     return nil if executables.nil?
 
-    if @bindir then
+    if @bindir
       Array(executables).map { |e| File.join(@bindir, e) }
     else
       executables
@@ -1327,7 +1327,7 @@ class Gem::Specification < Gem::BasicSpecification
   # <tt>:development</tt>.
 
   def add_dependency_with_type(dependency, type, *requirements)
-    requirements = if requirements.empty? then
+    requirements = if requirements.empty?
                      Gem::Requirement.default
                    else
                      requirements.flatten
@@ -1356,7 +1356,7 @@ class Gem::Specification < Gem::BasicSpecification
     # gem directories must come after -I and ENV['RUBYLIB']
     insert_index = Gem.load_path_insert_index
 
-    if insert_index then
+    if insert_index
       # gem directories must come after -I and ENV['RUBYLIB']
       $LOAD_PATH.insert(insert_index, *paths)
     else
@@ -1510,20 +1510,20 @@ class Gem::Specification < Gem::BasicSpecification
     # This is the cleanest, most-readable, faster-than-using-Date
     # way to do it.
     @date = case date
-            when String then
-              if DateTimeFormat =~ date then
+            when String
+              if DateTimeFormat =~ date
                 Time.utc($1.to_i, $2.to_i, $3.to_i)
 
               # Workaround for where the date format output from psych isn't
               # parsed as a Time object by syck and thus comes through as a
               # string.
-              elsif /\A(\d{4})-(\d{2})-(\d{2}) \d{2}:\d{2}:\d{2}\.\d+?Z\z/ =~ date then
+              elsif /\A(\d{4})-(\d{2})-(\d{2}) \d{2}:\d{2}:\d{2}\.\d+?Z\z/ =~ date
                 Time.utc($1.to_i, $2.to_i, $3.to_i)
               else
                 raise(Gem::InvalidSpecificationException,
                       "invalid date format in specification: #{date.inspect}")
               end
-            when Time, Date then
+            when Time, Date
               Time.utc(date.year, date.month, date.day)
             else
               TODAY
@@ -1574,7 +1574,7 @@ class Gem::Specification < Gem::BasicSpecification
     out = []
     Gem::Specification.each do |spec|
       spec.dependencies.each do |dep|
-        if self.satisfies_requirement?(dep) then
+        if self.satisfies_requirement?(dep)
           sats = []
           find_all_satisfiers(dep) do |sat|
             sats << sat
@@ -1618,7 +1618,7 @@ class Gem::Specification < Gem::BasicSpecification
   def doc_dir type = nil
     @doc_dir ||= File.join base_dir, 'doc', full_name
 
-    if type then
+    if type
       File.join @doc_dir, type
     else
       @doc_dir
@@ -1631,9 +1631,9 @@ class Gem::Specification < Gem::BasicSpecification
     coder.add 'name', @name
     coder.add 'version', @version
     platform = case @original_platform
-               when nil, '' then
+               when nil, ''
                  'ruby'
-               when String then
+               when String
                  @original_platform
                else
                  @original_platform.to_s
@@ -1834,7 +1834,7 @@ class Gem::Specification < Gem::BasicSpecification
 
       begin
         val = other_spec.instance_variable_get(name)
-        if val then
+        if val
           instance_variable_set name, val.dup
         elsif Gem.configuration.really_verbose
           warn "WARNING: #{full_name} has an invalid nil value for #{name}"
@@ -1873,7 +1873,7 @@ class Gem::Specification < Gem::BasicSpecification
   # for this spec.
 
   def lib_dirs_glob
-    dirs = if self.require_paths.size > 1 then
+    dirs = if self.require_paths.size > 1
              "{#{self.require_paths.join(',')}}"
            else
              self.require_paths.first
@@ -1943,7 +1943,7 @@ class Gem::Specification < Gem::BasicSpecification
 
   def method_missing(sym, *a, &b) # :nodoc:
     if @specification_version > CURRENT_SPECIFICATION_VERSION and
-      sym.to_s =~ /=$/ then
+      sym.to_s =~ /=$/
       warn "ignoring #{sym} loading #{full_name}" if $DEBUG
     else
       super
@@ -1957,7 +1957,7 @@ class Gem::Specification < Gem::BasicSpecification
   #   file list.
 
   def normalize
-    if defined?(@extra_rdoc_files) and @extra_rdoc_files then
+    if defined?(@extra_rdoc_files) and @extra_rdoc_files
       @extra_rdoc_files.uniq!
       @files ||= []
       @files.concat(@extra_rdoc_files)
@@ -1982,7 +1982,7 @@ class Gem::Specification < Gem::BasicSpecification
   # platform.  For use with legacy gems.
 
   def original_name # :nodoc:
-    if platform == Gem::Platform::RUBY or platform.nil? then
+    if platform == Gem::Platform::RUBY or platform.nil?
       "#{@name}-#{@version}"
     else
       "#{@name}-#{@version}-#{@original_platform}"
@@ -2015,11 +2015,11 @@ class Gem::Specification < Gem::BasicSpecification
       attributes.each do |attr_name|
         current_value = self.send attr_name
         if current_value != default_value(attr_name) or
-           self.class.required_attribute? attr_name then
+           self.class.required_attribute? attr_name
 
           q.text "s.#{attr_name} = "
 
-          if attr_name == :date then
+          if attr_name == :date
             current_value = current_value.utc
 
             q.text "Time.utc(#{current_value.year}, #{current_value.month}, #{current_value.day})"
@@ -2039,7 +2039,7 @@ class Gem::Specification < Gem::BasicSpecification
   def raise_if_conflicts
     other = Gem.loaded_specs[self.name]
 
-    if other and self.version != other.version then
+    if other and self.version != other.version
       # This gem is already loaded.  If the currently loaded gem is not in the
       # list of candidate gems, then we have a version conflict.
 
@@ -2054,7 +2054,7 @@ class Gem::Specification < Gem::BasicSpecification
 
     conf = self.conflicts
 
-    unless conf.empty? then
+    unless conf.empty?
       y = conf.map { |act,con|
         "#{act.full_name} conflicts with #{con.join(", ")}"
       }.join ", "
@@ -2234,11 +2234,11 @@ class Gem::Specification < Gem::BasicSpecification
     # Handle the possibility that we have @test_suite_file but not
     # @test_files.  This will happen when an old gem is loaded via
     # YAML.
-    if defined? @test_suite_file then
+    if defined? @test_suite_file
       @test_files = [@test_suite_file].flatten
       @test_suite_file = nil
     end
-    if defined?(@test_files) and @test_files then
+    if defined?(@test_files) and @test_files
       @test_files
     else
       @test_files = []
@@ -2262,7 +2262,7 @@ class Gem::Specification < Gem::BasicSpecification
 
     result << "  s.name = #{ruby_code name}"
     result << "  s.version = #{ruby_code version}"
-    unless platform.nil? or platform == Gem::Platform::RUBY then
+    unless platform.nil? or platform == Gem::Platform::RUBY
       result << "  s.platform = #{ruby_code original_platform}"
     end
     result << ""
@@ -2290,23 +2290,23 @@ class Gem::Specification < Gem::BasicSpecification
       next if handled.include? attr_name
       current_value = self.send(attr_name)
       if current_value != default_value(attr_name) or
-         self.class.required_attribute? attr_name then
+         self.class.required_attribute? attr_name
         result << "  s.#{attr_name} = #{ruby_code current_value}"
       end
     end
 
-    if @installed_by_version then
+    if @installed_by_version
       result << nil
       result << "  s.installed_by_version = \"#{Gem::VERSION}\" if s.respond_to? :installed_by_version"
     end
 
-    unless dependencies.empty? then
+    unless dependencies.empty?
       result << nil
-      result << "  if s.respond_to? :specification_version then"
+      result << "  if s.respond_to? :specification_version"
       result << "    s.specification_version = #{specification_version}"
       result << nil
 
-      result << "    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then"
+      result << "    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0')"
 
       dependencies.each do |dep|
         req = dep.requirements_list.inspect
@@ -2359,7 +2359,7 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   def to_yaml(opts = {}) # :nodoc:
-    if YAML.const_defined?(:ENGINE) && !YAML::ENGINE.syck? then
+    if YAML.const_defined?(:ENGINE) && !YAML::ENGINE.syck?
       # Because the user can switch the YAML engine behind our
       # back, we have to check again here to make sure that our
       # psych code was properly loaded, and load it if not.
@@ -2418,29 +2418,29 @@ class Gem::Specification < Gem::BasicSpecification
       instance_variable_get("@#{name}").nil?
     end
 
-    unless nil_attributes.empty? then
+    unless nil_attributes.empty?
       raise Gem::InvalidSpecificationException,
         "#{nil_attributes.join ', '} must not be nil"
     end
 
-    if packaging and rubygems_version != Gem::VERSION then
+    if packaging and rubygems_version != Gem::VERSION
       raise Gem::InvalidSpecificationException,
             "expected RubyGems version #{Gem::VERSION}, was #{rubygems_version}"
     end
 
     @@required_attributes.each do |symbol|
-      unless self.send symbol then
+      unless self.send symbol
         raise Gem::InvalidSpecificationException,
               "missing value for attribute #{symbol}"
       end
     end
 
-    unless String === name then
+    unless String === name
       raise Gem::InvalidSpecificationException,
             "invalid value for attribute name: \"#{name.inspect}\""
     end
 
-    if @require_paths.empty? then
+    if @require_paths.empty?
       raise Gem::InvalidSpecificationException,
             'specification must have at least one require_path'
     end
@@ -2453,12 +2453,12 @@ class Gem::Specification < Gem::BasicSpecification
 
     non_files = files.reject { |x| File.file?(x) }
 
-    unless not packaging or non_files.empty? then
+    unless not packaging or non_files.empty?
       raise Gem::InvalidSpecificationException,
             "[\"#{non_files.join "\", \""}\"] are not files"
     end
 
-    if files.include? file_name then
+    if files.include? file_name
       raise Gem::InvalidSpecificationException,
             "#{full_name} contains itself (#{file_name}), check your files list"
     end
@@ -2469,7 +2469,7 @@ class Gem::Specification < Gem::BasicSpecification
     end
 
     case platform
-    when Gem::Platform, Gem::Platform::RUBY then # ok
+    when Gem::Platform, Gem::Platform::RUBY # ok
     else
       raise Gem::InvalidSpecificationException,
             "invalid platform #{platform.inspect}, see Gem::Platform"
@@ -2484,7 +2484,7 @@ class Gem::Specification < Gem::BasicSpecification
                 String
               end
 
-      unless Array === val and val.all? { |x| x.kind_of?(klass) } then
+      unless Array === val and val.all? { |x| x.kind_of?(klass) }
         raise(Gem::InvalidSpecificationException,
               "#{field} must be an Array of #{klass}")
       end
@@ -2543,24 +2543,24 @@ http://opensource.org/licenses/alphabetical
 
     lazy = '"FIxxxXME" or "TOxxxDO"'.gsub(/xxx/, '')
 
-    unless authors.grep(/FI XME|TO DO/x).empty? then
+    unless authors.grep(/FI XME|TO DO/x).empty?
       raise Gem::InvalidSpecificationException, "#{lazy} is not an author"
     end
 
-    unless Array(email).grep(/FI XME|TO DO/x).empty? then
+    unless Array(email).grep(/FI XME|TO DO/x).empty?
       raise Gem::InvalidSpecificationException, "#{lazy} is not an email"
     end
 
-    if description =~ /FI XME|TO DO/x then
+    if description =~ /FI XME|TO DO/x
       raise Gem::InvalidSpecificationException, "#{lazy} is not a description"
     end
 
-    if summary =~ /FI XME|TO DO/x then
+    if summary =~ /FI XME|TO DO/x
       raise Gem::InvalidSpecificationException, "#{lazy} is not a summary"
     end
 
     if homepage and not homepage.empty? and
-       homepage !~ /\A[a-z][a-z\d+.-]*:/i then
+       homepage !~ /\A[a-z][a-z\d+.-]*:/i
       raise Gem::InvalidSpecificationException,
             "\"#{homepage}\" is not a URI"
     end
@@ -2572,7 +2572,7 @@ http://opensource.org/licenses/alphabetical
       warning "no #{attribute} specified" if value.nil? or value.empty?
     end
 
-    if description == summary then
+    if description == summary
       warning 'description and summary are identical'
     end
 
@@ -2590,7 +2590,7 @@ http://opensource.org/licenses/alphabetical
 
     true
   ensure
-    if $! or @warnings > 0 then
+    if $! or @warnings > 0
       alert_warning "See http://guides.rubygems.org/specification-reference/ for help"
     end
   end
@@ -2604,7 +2604,7 @@ http://opensource.org/licenses/alphabetical
     seen = {}
 
     dependencies.each do |dep|
-      if prev = seen[dep.name] then
+      if prev = seen[dep.name]
         raise Gem::InvalidSpecificationException, <<-MESSAGE
 duplicate dependency on #{dep}, (#{prev.requirement}) use:
     add_runtime_dependency '#{dep.name}', '#{dep.requirement}', '#{prev.requirement}'
@@ -2627,7 +2627,7 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
             version.segments.length > 2
         end
 
-      if overly_strict then
+      if overly_strict
         _, dep_version = dep.requirement.requirements.first
 
         base = dep_version.segments.first 2
@@ -2643,14 +2643,14 @@ pessimistic dependency on #{dep} may be overly strict
         not version.prerelease? and (op == '>' or op == '>=')
       end
 
-      if open_ended then
+      if open_ended
         op, dep_version = dep.requirement.requirements.first
 
         base = dep_version.segments.first 2
 
-        bugfix = if op == '>' then
+        bugfix = if op == '>'
                    ", '> #{dep_version}'"
-                 elsif op == '>=' and base != dep_version.segments then
+                 elsif op == '>=' and base != dep_version.segments
                    ", '>= #{dep_version}'"
                  end
 

--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -8,7 +8,7 @@ class Gem::StubSpecification < Gem::BasicSpecification
   PREFIX = "# stub: "
 
   OPEN_MODE = # :nodoc:
-    if Object.const_defined? :Encoding then
+    if Object.const_defined? :Encoding
       'r:UTF-8:-'
     else
       'r'
@@ -72,7 +72,7 @@ class Gem::StubSpecification < Gem::BasicSpecification
         begin
           file.readline # discard encoding line
           stubline = file.readline.chomp
-          if stubline.start_with?(PREFIX) then
+          if stubline.start_with?(PREFIX)
             @data = StubLine.new stubline
 
             @extensions = $'.split "\0" if

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -95,9 +95,9 @@ class Gem::TestCase < MiniTest::Unit::TestCase
   def assert_activate expected, *specs
     specs.each do |spec|
       case spec
-      when String then
+      when String
         Gem::Specification.find_by_name(spec).activate
-      when Gem::Specification then
+      when Gem::Specification
         spec.activate
       else
         flunk spec.inspect
@@ -211,7 +211,7 @@ class Gem::TestCase < MiniTest::Unit::TestCase
     tmpdir = File.expand_path Dir.tmpdir
     tmpdir.untaint
 
-    if ENV['KEEP_FILES'] then
+    if ENV['KEEP_FILES']
       @tempdir = File.join(tmpdir, "test_rubygems_#{$$}.#{Time.now.to_i}")
     else
       @tempdir = File.join(tmpdir, "test_rubygems_#{$$}")
@@ -234,7 +234,7 @@ class Gem::TestCase < MiniTest::Unit::TestCase
     @userhome = File.join @tempdir, 'userhome'
     ENV["GEM_SPEC_CACHE"] = File.join @tempdir, 'spec_cache'
 
-    @orig_ruby = if ENV['RUBY'] then
+    @orig_ruby = if ENV['RUBY']
                    ruby = Gem.ruby
                    Gem.ruby = ENV['RUBY']
                    ruby
@@ -322,7 +322,7 @@ class Gem::TestCase < MiniTest::Unit::TestCase
     end
     RbConfig::CONFIG['arch'] = @orig_arch
 
-    if defined? Gem::RemoteFetcher then
+    if defined? Gem::RemoteFetcher
       Gem::RemoteFetcher.fetcher = nil
     end
 
@@ -335,7 +335,7 @@ class Gem::TestCase < MiniTest::Unit::TestCase
 
     Gem.ruby = @orig_ruby if @orig_ruby
 
-    if @orig_ENV_HOME then
+    if @orig_ENV_HOME
       ENV['HOME'] = @orig_ENV_HOME
     else
       ENV.delete 'HOME'
@@ -412,7 +412,7 @@ class Gem::TestCase < MiniTest::Unit::TestCase
     head = nil
 
     Dir.chdir directory do
-      unless File.exist? '.git' then
+      unless File.exist? '.git'
         system @git, 'init', '--quiet'
         system @git, 'config', 'user.name',  'RubyGems Tests'
         system @git, 'config', 'user.email', 'rubygems@example'
@@ -451,7 +451,7 @@ class Gem::TestCase < MiniTest::Unit::TestCase
 
     gem = File.join @tempdir, "gems", "#{spec.full_name}.gem"
 
-    unless File.exist? gem then
+    unless File.exist? gem
       use_ui Gem::MockGemUi.new do
         Dir.chdir @tempdir do
           Gem::Package.build spec
@@ -698,7 +698,7 @@ class Gem::TestCase < MiniTest::Unit::TestCase
 
     spec.loaded_from = spec.spec_file
 
-    unless files.empty? then
+    unless files.empty?
       write_file spec.spec_file do |io|
         io.write spec.to_ruby_for_cache
       end
@@ -753,7 +753,7 @@ class Gem::TestCase < MiniTest::Unit::TestCase
       yield s if block_given?
     end
 
-    if deps then
+    if deps
       # Since Hash#each is unordered in 1.8, sort the keys and iterate that
       # way so the tests are deterministic on all implementations.
       deps.keys.sort.each do |n|
@@ -778,7 +778,7 @@ class Gem::TestCase < MiniTest::Unit::TestCase
     # TODO: deprecate
     raise "deps or block, not both" if deps and block
 
-    if deps then
+    if deps
       block = proc do |s|
         # Since Hash#each is unordered in 1.8, sort
         # the keys and iterate that way so the tests are
@@ -975,7 +975,7 @@ Also, a list:
     end
 
     # HACK for test_download_to_cache
-    unless Gem::RemoteFetcher === @fetcher then
+    unless Gem::RemoteFetcher === @fetcher
       v = Gem.marshal_version
 
       specs = all.map { |spec| spec.name_tuple }
@@ -1160,7 +1160,7 @@ Also, a list:
   def dependency_request dep, from_name, from_version, parent = nil
     remote = Gem::Source.new @uri
 
-    unless parent then
+    unless parent
       parent_dep = dep from_name, from_version
       parent = Gem::Resolver::DependencyRequest.new parent_dep, nil
     end
@@ -1311,7 +1311,7 @@ Also, a list:
   # <tt>test/rubygems/</tt>.
 
   def self.cert_path cert_name
-    if 32 == (Time.at(2**32) rescue 32) then
+    if 32 == (Time.at(2**32) rescue 32)
       cert_file =
         File.expand_path "../../../test/rubygems/#{cert_name}_cert_32.pem",
                          __FILE__

--- a/lib/rubygems/test_utilities.rb
+++ b/lib/rubygems/test_utilities.rb
@@ -38,7 +38,7 @@ class Gem::FakeFetcher
   end
 
   def find_data(path)
-    if URI === path and "URI::#{path.scheme.upcase}" != path.class.name then
+    if URI === path and "URI::#{path.scheme.upcase}" != path.class.name
       raise ArgumentError,
         "mismatch for scheme #{path.scheme} and class #{path.class}"
     end
@@ -47,7 +47,7 @@ class Gem::FakeFetcher
     @paths << path
     raise ArgumentError, 'need full URI' unless path =~ %r'^https?://'
 
-    unless @data.key? path then
+    unless @data.key? path
       raise Gem::RemoteFetcher::FetchError.new("no data for #{path}", path)
     end
 
@@ -57,10 +57,10 @@ class Gem::FakeFetcher
   def fetch_path path, mtime = nil, head = false
     data = find_data(path)
 
-    if data.respond_to?(:call) then
+    if data.respond_to?(:call)
       data.call
     else
-      if path.to_s =~ /gz$/ and not data.nil? and not data.empty? then
+      if path.to_s =~ /gz$/ and not data.nil? and not data.empty?
         data = Gem.gunzip data
       end
 
@@ -109,7 +109,7 @@ class Gem::FakeFetcher
       q.breakable
       q.pp @data.keys
 
-      unless @api_endpoints.empty? then
+      unless @api_endpoints.empty?
         q.breakable
         q.text 'API endpoints:'
 
@@ -125,7 +125,7 @@ class Gem::FakeFetcher
 
     raise ArgumentError, 'need full URI' unless path =~ %r'^http://'
 
-    unless @data.key? path then
+    unless @data.key? path
       raise Gem::RemoteFetcher::FetchError.new("no data for #{path}", path)
     end
 
@@ -136,7 +136,7 @@ class Gem::FakeFetcher
 
   def download spec, source_uri, install_dir = Gem.dir
     name = File.basename spec.cache_file
-    path = if Dir.pwd == install_dir then # see fetch_command
+    path = if Dir.pwd == install_dir # see fetch_command
              install_dir
            else
              File.join install_dir, "cache"
@@ -144,7 +144,7 @@ class Gem::FakeFetcher
 
     path = File.join path, name
 
-    if source_uri =~ /^http/ then
+    if source_uri =~ /^http/
       File.open(path, "wb") do |f|
         f.write fetch_path(File.join(source_uri, "gems", name))
       end
@@ -252,17 +252,17 @@ class Gem::TestCase::SpecFetcherSetup
   def execute_operations # :nodoc:
     @operations.each do |operation, *arguments|
       case operation
-      when :clear then
+      when :clear
         @test.util_clear_gems
         @installed.clear
-      when :gem then
+      when :gem
         spec, gem = @test.util_gem(*arguments, &arguments.pop)
 
         write_spec spec
 
         @gems[spec] = gem
         @installed << spec
-      when :spec then
+      when :spec
         spec = @test.util_spec(*arguments, &arguments.pop)
 
         write_spec spec
@@ -299,7 +299,7 @@ class Gem::TestCase::SpecFetcherSetup
     require 'socket'
     require 'rubygems/remote_fetcher'
 
-    unless @test.fetcher then
+    unless @test.fetcher
       @test.fetcher = Gem::FakeFetcher.new
       Gem::RemoteFetcher.fetcher = @test.fetcher
     end

--- a/lib/rubygems/text.rb
+++ b/lib/rubygems/text.rb
@@ -14,7 +14,7 @@ module Gem::Text
     work = text.dup
 
     while work.length > wrap do
-      if work =~ /^(.{0,#{wrap}})[ \n]/ then
+      if work =~ /^(.{0,#{wrap}})[ \n]/
         result << $1.rstrip
         work.slice!(0, $&.length)
       else

--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -96,7 +96,7 @@ class Gem::Uninstaller
         (@user_install and spec.base_dir == Gem.user_dir)
     end
 
-    if list.empty? then
+    if list.empty?
       if other_repo_specs.empty?
         if default_specs.empty?
           raise Gem::InstallError, "gem #{@gem.inspect} is not installed"
@@ -116,18 +116,18 @@ class Gem::Uninstaller
       }
 
       raise Gem::InstallError, message.join("\n")
-    elsif @force_all then
+    elsif @force_all
       remove_all list
 
-    elsif list.size > 1 then
+    elsif list.size > 1
       gem_names = list.collect {|gem| gem.full_name} + ["All versions"]
 
       say
       _, index = choose_from_list "Select gem to uninstall:", gem_names
 
-      if index == list.size then
+      if index == list.size
         remove_all list
-      elsif index >= 0 && index < list.size then
+      elsif index >= 0 && index < list.size
         uninstall_gem list[index]
       else
         say "Error: must enter a number [1-#{list.size+1}]"
@@ -190,7 +190,7 @@ class Gem::Uninstaller
 
     executables = executables.map { |exec| formatted_program_filename exec }
 
-    remove = if @force_executables.nil? then
+    remove = if @force_executables.nil?
                ask_yes_no("Remove executables:\n" +
                           "\t#{executables.join ', '}\n\n" +
                           "in addition to the gem?",
@@ -199,7 +199,7 @@ class Gem::Uninstaller
                @force_executables
              end
 
-    if remove then
+    if remove
       bin_dir = @bin_dir || Gem.bindir(spec.base_dir)
 
       raise Gem::FilePermissionError, bin_dir unless File.writable? bin_dir
@@ -235,7 +235,7 @@ class Gem::Uninstaller
 
   def remove(spec)
     unless path_ok?(@gem_home, spec) or
-           (@user_install and path_ok?(Gem.user_dir, spec)) then
+           (@user_install and path_ok?(Gem.user_dir, spec))
       e = Gem::GemNotInHomeException.new \
             "Gem '#{spec.full_name}' is not installed in directory #{@gem_home}"
       e.spec = spec
@@ -252,7 +252,7 @@ class Gem::Uninstaller
     old_platform_name = spec.original_name
     gemspec           = spec.spec_file
 
-    unless File.exist? gemspec then
+    unless File.exist? gemspec
       gemspec = File.join(File.dirname(gemspec), "#{old_platform_name}.gemspec")
     end
 
@@ -332,7 +332,7 @@ class Gem::Uninstaller
     # TODO perhaps the installer should leave a small manifest
     # of what it did for us to find rather than trying to recreate
     # it again.
-    if @format_executable then
+    if @format_executable
       require 'rubygems/installer'
       Gem::Installer.exec_format % File.basename(filename)
     else

--- a/lib/rubygems/user_interaction.rb
+++ b/lib/rubygems/user_interaction.rb
@@ -196,7 +196,7 @@ class Gem::StreamUI
   # Returns true if TTY methods should be used on this StreamUI.
 
   def tty?
-    if RUBY_VERSION < '1.9.3' and RUBY_PLATFORM =~ /mingw|mswin/ then
+    if RUBY_VERSION < '1.9.3' and RUBY_PLATFORM =~ /mingw|mswin/
       @usetty
     else
       @usetty && @ins.tty?
@@ -242,8 +242,8 @@ class Gem::StreamUI
   # default.
 
   def ask_yes_no(question, default=nil)
-    unless tty? then
-      if default.nil? then
+    unless tty?
+      if default.nil?
         raise Gem::OperationNotSupportedError,
               "Not connected to a tty and no default specified"
       else
@@ -303,7 +303,7 @@ class Gem::StreamUI
     password
   end
 
-  if IO.method_defined?(:noecho) then
+  if IO.method_defined?(:noecho)
     def _gets_noecho
       @ins.noecho {@ins.gets}
     end
@@ -611,7 +611,7 @@ class Gem::StreamUI
     # Updates the verbose download reporter for the given number of +bytes+.
 
     def update(bytes)
-      new_progress = if @units == 'B' then
+      new_progress = if @units == 'B'
                        bytes
                      else
                        ((bytes.to_f * 100) / total_bytes.to_f).ceil
@@ -636,7 +636,7 @@ class Gem::StreamUI
     def update_display(show_progress = true, new_line = false) # :nodoc:
       return unless @out.tty?
 
-      if show_progress then
+      if show_progress
         @out.print "\rFetching: %s (%3d%s)" % [@file_name, @progress, @units]
       else
         @out.print "Fetching: %s" % @file_name

--- a/lib/rubygems/validator.rb
+++ b/lib/rubygems/validator.rb
@@ -93,13 +93,13 @@ class Gem::Validator
       spec_path     = spec.spec_file
       gem_directory = spec.full_gem_path
 
-      unless File.directory? gem_directory then
+      unless File.directory? gem_directory
         errors[gem_name][spec.full_name] =
           "Gem registered but doesn't exist at #{gem_directory}"
         next
       end
 
-      unless File.exist? spec_path then
+      unless File.exist? spec_path
         errors[gem_name][spec_path] = "Spec file missing for installed gem"
       end
 
@@ -134,7 +134,7 @@ class Gem::Validator
               source = File.join gem_directory, entry['path']
 
               open source, Gem.binary_mode do |f|
-                unless f.read == data then
+                unless f.read == data
                   errors[gem_name][entry['path']] = "Modified from original"
                 end
               end

--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -173,9 +173,9 @@ class Gem::Version
   #   ver3 = Version.create(nil)        # -> nil
 
   def self.create input
-    if self === input then # check yourself before you wreck yourself
+    if self === input # check yourself before you wreck yourself
       input
-    elsif input.nil? then
+    elsif input.nil?
       nil
     else
       new input

--- a/lib/rubygems/version_option.rb
+++ b/lib/rubygems/version_option.rb
@@ -16,7 +16,7 @@ module Gem::VersionOption
 
   def add_platform_option(task = command, *wrap)
     OptionParser.accept Gem::Platform do |value|
-      if value == Gem::Platform::RUBY then
+      if value == Gem::Platform::RUBY
         value
       else
         Gem::Platform.new value
@@ -26,7 +26,7 @@ module Gem::VersionOption
     add_option('--platform PLATFORM', Gem::Platform,
                "Specify the platform of gem to #{task}", *wrap) do
                  |value, options|
-      unless options[:added_platform] then
+      unless options[:added_platform]
         Gem.platforms = [Gem::Platform::RUBY]
         options[:added_platform] = true
       end

--- a/setup.rb
+++ b/setup.rb
@@ -11,7 +11,7 @@ if RUBY_VERSION < "1.8.7"
 end
 
 # Make sure rubygems isn't already loaded.
-if ENV['RUBYOPT'] or defined? Gem then
+if ENV['RUBYOPT'] or defined? Gem
   ENV.delete 'RUBYOPT'
 
   require 'rbconfig'

--- a/test/rubygems/fix_openssl_warnings.rb
+++ b/test/rubygems/fix_openssl_warnings.rb
@@ -1,7 +1,7 @@
 ##
 # HACK: this drives me BONKERS
 
-if defined? OpenSSL then
+if defined? OpenSSL
   class OpenSSL::X509::ExtensionFactory
     alias :old_create_ext :create_ext
     def create_ext(*args)

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -305,7 +305,7 @@ class TestGem < Gem::TestCase
     assert File.directory?(util_cache_dir)
   end
 
-  unless win_platform? then # only for FS that support write protection
+  unless win_platform? # only for FS that support write protection
     def test_self_ensure_gem_directories_write_protected
       gemdir = File.join @tempdir, "egd"
       FileUtils.rm_r gemdir rescue nil
@@ -848,7 +848,7 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_user_home
-    if ENV['HOME'] then
+    if ENV['HOME']
       assert_equal ENV['HOME'], Gem.user_home
     else
       assert true, 'count this test'
@@ -1240,7 +1240,7 @@ class TestGem < Gem::TestCase
 
   def test_default_gems_use_full_paths
     begin
-      if defined?(RUBY_ENGINE) then
+      if defined?(RUBY_ENGINE)
         engine = RUBY_ENGINE
         Object.send :remove_const, :RUBY_ENGINE
       end
@@ -1253,7 +1253,7 @@ class TestGem < Gem::TestCase
     end
 
     begin
-      if defined?(RUBY_ENGINE) then
+      if defined?(RUBY_ENGINE)
         engine = RUBY_ENGINE
         Object.send :remove_const, :RUBY_ENGINE
       end
@@ -1377,7 +1377,7 @@ class TestGem < Gem::TestCase
 
   def util_set_RUBY_VERSION(version, patchlevel = nil, revision = nil)
     if Gem.instance_variables.include? :@ruby_version or
-       Gem.instance_variables.include? '@ruby_version' then
+       Gem.instance_variables.include? '@ruby_version'
       Gem.send :remove_instance_variable, :@ruby_version
     end
 

--- a/test/rubygems/test_gem_commands_cert_command.rb
+++ b/test/rubygems/test_gem_commands_cert_command.rb
@@ -2,7 +2,7 @@ require 'rubygems/test_case'
 require 'rubygems/commands/cert_command'
 require 'rubygems/fix_openssl_warnings' if RUBY_VERSION < "1.9"
 
-unless defined?(OpenSSL::SSL) then
+unless defined?(OpenSSL::SSL)
   warn 'Skipping `gem cert` tests.  openssl not found.'
 end
 

--- a/test/rubygems/test_gem_commands_help_command.rb
+++ b/test/rubygems/test_gem_commands_help_command.rb
@@ -37,7 +37,7 @@ class TestGemCommandsHelpCommand < Gem::TestCase
         assert_match(/\s+#{cmd}\s+\S+/, out)
       end
 
-      if defined?(OpenSSL::SSL) then
+      if defined?(OpenSSL::SSL)
         assert_empty err
 
         refute_match 'No command found for ', out

--- a/test/rubygems/test_gem_commands_uninstall_command.rb
+++ b/test/rubygems/test_gem_commands_uninstall_command.rb
@@ -81,7 +81,7 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
       end
     end
 
-    if win_platform? then
+    if win_platform?
       assert File.exist?(@executable)
     else
       assert File.symlink?(@executable)

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -315,7 +315,7 @@ if you believe they were disclosed to a third party.
 
     assert_equal expected, YAML.load_file(@cfg.credentials_path)
 
-    unless win_platform? then
+    unless win_platform?
       stat = File.stat @cfg.credentials_path
 
       assert_equal 0600, stat.mode & 0600

--- a/test/rubygems/test_gem_dependency_installer.rb
+++ b/test/rubygems/test_gem_dependency_installer.rb
@@ -830,7 +830,7 @@ class TestGemDependencyInstaller < Gem::TestCase
     assert_equal %w[a-1-cpu-other_platform-1], inst.installed_gems.map { |s| s.full_name }
   end
 
-  if defined? OpenSSL then
+  if defined? OpenSSL
     def test_install_security_policy
       util_setup_gems
 

--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -49,7 +49,7 @@ install:
 
     results = results.join "\n"
 
-    if RUBY_VERSION > '2.0' then
+    if RUBY_VERSION > '2.0'
       assert_match %r%"DESTDIR=#{ENV['DESTDIR']}" clean$%,   results
       assert_match %r%"DESTDIR=#{ENV['DESTDIR']}"$%,         results
       assert_match %r%"DESTDIR=#{ENV['DESTDIR']}" install$%, results
@@ -86,7 +86,7 @@ install:
 
     results = results.join "\n"
 
-    if RUBY_VERSION > '2.0' then
+    if RUBY_VERSION > '2.0'
       assert_match %r%"DESTDIR=#{ENV['DESTDIR']}" clean$%,   results
       assert_match %r%"DESTDIR=#{ENV['DESTDIR']}"$%,         results
       assert_match %r%"DESTDIR=#{ENV['DESTDIR']}" install$%, results

--- a/test/rubygems/test_gem_ext_ext_conf_builder.rb
+++ b/test/rubygems/test_gem_ext_ext_conf_builder.rb
@@ -120,7 +120,7 @@ class TestGemExtExtConfBuilder < Gem::TestCase
 include RbConfig
 
 ruby =
-  if ENV['RUBY'] then
+  if ENV['RUBY']
     ENV['RUBY']
   else
     ruby_exe = "#{CONFIG['RUBY_INSTALL_NAME']}#{CONFIG['EXEEXT']}"

--- a/test/rubygems/test_gem_gemcutter_utilities.rb
+++ b/test/rubygems/test_gem_gemcutter_utilities.rb
@@ -196,7 +196,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
     @sign_in_ui = Gem::MockGemUi.new "#{email}\n#{password}\n"
 
     use_ui @sign_in_ui do
-      if args.length > 0 then
+      if args.length > 0
         @cmd.sign_in(*args)
       else
         @cmd.sign_in

--- a/test/rubygems/test_gem_indexer.rb
+++ b/test/rubygems/test_gem_indexer.rb
@@ -1,7 +1,7 @@
 require 'rubygems/test_case'
 require 'rubygems/indexer'
 
-unless defined?(Builder::XChar) then
+unless defined?(Builder::XChar)
   warn "Gem::Indexer tests are being skipped.  Install builder gem." if $VERBOSE
 end
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -6,7 +6,7 @@ class TestGemInstaller < Gem::InstallerTestCase
     super
     common_installer_setup
 
-    if __name__ =~ /^test_install(_|$)/ then
+    if __name__ =~ /^test_install(_|$)/
       FileUtils.rm_r @spec.gem_dir
       FileUtils.rm_r @user_spec.gem_dir
     end

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -68,11 +68,11 @@ class TestGemPackage < Gem::Package::TarTestCase
 
     reader.each_entry do |entry|
       case entry.full_name
-      when 'checksums.yaml.gz' then
+      when 'checksums.yaml.gz'
         Zlib::GzipReader.wrap entry do |io|
           checksums = io.read
         end
-      when 'data.tar.gz' then
+      when 'data.tar.gz'
         tar = entry.read
       end
     end
@@ -93,7 +93,7 @@ class TestGemPackage < Gem::Package::TarTestCase
       }
     }
 
-    if defined?(OpenSSL::Digest) then
+    if defined?(OpenSSL::Digest)
       expected['SHA1'] = {
         'metadata.gz' => metadata_sha1,
         'data.tar.gz' => Digest::SHA1.hexdigest(tar),

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -140,7 +140,7 @@ class TestGemPlatform < Gem::TestCase
   end
 
   def test_to_s
-    if win_platform? then
+    if win_platform?
       assert_equal 'x86-mswin32-60', Gem::Platform.local.to_s
     else
       assert_equal 'x86-darwin-8', Gem::Platform.local.to_s

--- a/test/rubygems/test_gem_rdoc.rb
+++ b/test/rubygems/test_gem_rdoc.rb
@@ -48,7 +48,7 @@ class TestGemRDoc < Gem::TestCase
   end
 
   def test_initialize
-    if rdoc_4? then
+    if rdoc_4?
       refute @hook.generate_rdoc
     else
       assert @hook.generate_rdoc

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -207,7 +207,7 @@ gems:
     fetcher = Gem::RemoteFetcher.fetcher
     fetcher.instance_variable_set :@test_data, data
 
-    unless blow then
+    unless blow
       def fetcher.fetch_path arg, *rest
         @test_arg = arg
         @test_data
@@ -388,9 +388,9 @@ gems:
     @fetcher.instance_variable_set :@a2, @a2
     def @fetcher.fetch_path uri, mtime = nil, head = false
       case uri.request_uri
-      when /#{@a1.spec_name}/ then
+      when /#{@a1.spec_name}/
         Gem.deflate Marshal.dump @a1
-      when /#{@a2.spec_name}/ then
+      when /#{@a2.spec_name}/
         Gem.deflate Marshal.dump @a2
       else
         uri.to_s
@@ -521,7 +521,7 @@ gems:
 
     def fetcher.request(uri, request_class, last_modified = nil)
       url = 'http://gems.example.com/redirect'
-      unless defined? @requested then
+      unless defined? @requested
         @requested = true
         res = Net::HTTPMovedPermanently.new nil, 301, nil
         res.add_field 'Location', url

--- a/test/rubygems/test_gem_security.rb
+++ b/test/rubygems/test_gem_security.rb
@@ -2,7 +2,7 @@ require 'rubygems/test_case'
 require 'rubygems/security'
 require 'rubygems/fix_openssl_warnings' if RUBY_VERSION < "1.9"
 
-unless defined?(OpenSSL::SSL) then
+unless defined?(OpenSSL::SSL)
   warn 'Skipping Gem::Security tests.  openssl not found.'
 end
 

--- a/test/rubygems/test_gem_security_policy.rb
+++ b/test/rubygems/test_gem_security_policy.rb
@@ -2,7 +2,7 @@
 
 require 'rubygems/test_case'
 
-unless defined?(OpenSSL::SSL) then
+unless defined?(OpenSSL::SSL)
   warn 'Skipping Gem::Security::Policy tests.  openssl not found.'
 end
 

--- a/test/rubygems/test_gem_security_signer.rb
+++ b/test/rubygems/test_gem_security_signer.rb
@@ -1,6 +1,6 @@
 require 'rubygems/test_case'
 
-unless defined?(OpenSSL::SSL) then
+unless defined?(OpenSSL::SSL)
   warn 'Skipping Gem::Security::Signer tests.  openssl not found.'
 end
 

--- a/test/rubygems/test_gem_security_trust_dir.rb
+++ b/test/rubygems/test_gem_security_trust_dir.rb
@@ -1,6 +1,6 @@
 require 'rubygems/test_case'
 
-unless defined?(OpenSSL::SSL) then
+unless defined?(OpenSSL::SSL)
   warn 'Skipping Gem::Security::TrustDir tests.  openssl not found.'
 end
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1236,7 +1236,7 @@ dependencies: []
       @ext.build_extensions
     end
   ensure
-    unless Gem.win_platform? then
+    unless Gem.win_platform?
       FileUtils.chmod 0755, File.join(@ext.base_dir, 'extensions')
       FileUtils.chmod 0755, @ext.base_dir
     end
@@ -1973,10 +1973,10 @@ Gem::Specification.new do |s|
   s.rubygems_version = "#{Gem::VERSION}"
   s.summary = "this is a summary"
 
-  if s.respond_to? :specification_version then
+  if s.respond_to? :specification_version
     s.specification_version = #{Gem::Specification::CURRENT_SPECIFICATION_VERSION}
 
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0')
       s.add_runtime_dependency(%q<b>, [\"= 1\"])
     else
       s.add_dependency(%q<b>, [\"= 1\"])
@@ -2023,10 +2023,10 @@ Gem::Specification.new do |s|
 
   s.installed_by_version = "#{Gem::VERSION}" if s.respond_to? :installed_by_version
 
-  if s.respond_to? :specification_version then
+  if s.respond_to? :specification_version
     s.specification_version = #{Gem::Specification::CURRENT_SPECIFICATION_VERSION}
 
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0')
       s.add_runtime_dependency(%q<b>, [\"= 1\"])
     else
       s.add_dependency(%q<b>, [\"= 1\"])
@@ -2085,10 +2085,10 @@ Gem::Specification.new do |s|
   s.summary = "this is a summary"
   s.test_files = ["test/suite.rb"]
 
-  if s.respond_to? :specification_version then
+  if s.respond_to? :specification_version
     s.specification_version = 4
 
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0')
       s.add_runtime_dependency(%q<rake>, [\"> 0.4\"])
       s.add_runtime_dependency(%q<jabber4r>, [\"> 0.0.0\"])
       s.add_runtime_dependency(%q<pqa>, [\"<= 0.6\", \"> 0.4\"])
@@ -2443,7 +2443,7 @@ duplicate dependency on b (>= 1.2.3), (~> 1.2) use:
   end
 
   def test_validate_empty_require_paths
-    if win_platform? then
+    if win_platform?
       skip 'test_validate_empty_require_paths skipped on MS Windows (symlink)'
     else
       util_setup_validate

--- a/util/CL2notes
+++ b/util/CL2notes
@@ -9,7 +9,7 @@ def format_text(text, wrap, indent=0)
   work = text.dup
 
   while work.length > wrap
-    if work =~ /^(.{0,#{wrap}})[ \n]/o then
+    if work =~ /^(.{0,#{wrap}})[ \n]/o
       result << $1
       work.slice!(0, $&.length)
     else
@@ -31,16 +31,16 @@ IO.foreach 'ChangeLog' do |line|
   case line
   when /^\s*$/,
        /^#/,
-       /^\d{4}-\d{2}-\d{2}/ then
+       /^\d{4}-\d{2}-\d{2}/
     next
-  when /^\s+\*\s+([^:]+?):\s+#{version}/ then
+  when /^\s+\*\s+([^:]+?):\s+#{version}/
     entries[file] << entry.join(' ') unless entry.empty?
     break
-  when /^\s+\*\s+([^:]+?):\s+/ then
+  when /^\s+\*\s+([^:]+?):\s+/
     entries[file] << entry.join(' ') unless entry.empty?
     file = $1
     entry = [$'.strip]
-  when /^\s+/ then
+  when /^\s+/
     entry << $'.strip
   end
 end

--- a/util/create_certs.rb
+++ b/util/create_certs.rb
@@ -82,7 +82,7 @@ class CertificateBuilder
   end
 
   def validity_for time
-    if time == :end_of_time then
+    if time == :end_of_time
       validity    = @end_of_time
       validity_32 = @end_of_time_32
     else

--- a/util/update_bundled_ca_certificates.rb
+++ b/util/update_bundled_ca_certificates.rb
@@ -52,7 +52,7 @@ def test_certificates certificates, uri
     certificates.combination(n).each do |combination|
       match = test_uri uri, combination
 
-      if match then
+      if match
         $needed_combinations << match
         puts
         return
@@ -87,7 +87,7 @@ def write_certificates certificates
 end
 
 io =
-  if ARGV.empty? then
+  if ARGV.empty?
     open OpenSSL::X509::DEFAULT_CERT_FILE
   else
     ARGF


### PR DESCRIPTION
`then` is only needed on single-line `if/then` or `when` statements

The only other change is in lib/rubygems/compatibility.rb line 23 where I replaced an inline do/end with {}
