### PR TITLE
Make documentation template for add_*_dependency consistent with code

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -417,12 +417,12 @@ class Gem::Specification < Gem::BasicSpecification
   attr_accessor :metadata
 
   ##
-  # Adds a development dependency named +gem+ with +requirements+ to this
-  # gem.
+  # Adds a development dependency named +gem+ with version +requirements+ 
+  # of '~> 1.1' and '>= 1.1.4'to this gem.
   #
   # Usage:
   #
-  #   spec.add_development_dependency 'example', '~> 1.1', '>= 1.1.4'
+  #   spec.add_development_dependency 'gem', '~> 1.1', '>= 1.1.4'
   #
   # Development dependencies aren't installed by default and aren't
   # activated when a gem is required.
@@ -432,11 +432,12 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   ##
-  # Adds a runtime dependency named +gem+ with +requirements+ to this gem.
+  # Adds a runtime dependency named +gem+ with version +requirements+ 
+  # of '~> 1.1' and '>= 1.1.4'to this gem.
   #
   # Usage:
   #
-  #   spec.add_runtime_dependency 'example', '~> 1.1', '>= 1.1.4'
+  #   spec.add_runtime_dependency 'gem', '~> 1.1', '>= 1.1.4'
 
   def add_runtime_dependency(gem, *requirements)
     add_dependency_with_type(gem, :runtime, *requirements)


### PR DESCRIPTION
Originally I made a similar change directly to the RubyGems Guides repository, but [the comment from @drbrain said it would be better to make it here](https://github.com/rubygems/guides/pull/75#issuecomment-32131480).

@drbrain, does this look good, or still need work?
