### PR TITLE
Prevent TarHeader.typeflags from being set to '', use '0' (file) instead...

### DIFF
--- a/lib/rubygems/package/tar_header.rb
+++ b/lib/rubygems/package/tar_header.rb
@@ -134,7 +134,7 @@ class Gem::Package::TarHeader
     vals[:gid] ||= 0
     vals[:mtime] ||= 0
     vals[:checksum] ||= ""
-    vals[:typeflag] ||= "0"
+    vals[:typeflag] = "0" if vals[:typeflag].nil? || vals[:typeflag].empty?
     vals[:magic] ||= "ustar"
     vals[:version] ||= "00"
     vals[:uname] ||= "wheel"


### PR DESCRIPTION
I'm trying to extract a .tar.gz file (http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz) using Ruby and I'm noticing that it's missing a lot of files from the tar file. Peeking in, it seems that the tar header's `typeflags` is being set to `""` in some places where I would expect it to be set to `0`.

It looks like this member should be set to some non-empty value according to here: http://www.gnu.org/software/tar/manual/html_node/Standard.html

It looks like `||= '0'`, as it does now, may not be sufficient.

Here's a test program based upon this post: http://dracoater.blogspot.com/2013/10/extracting-files-from-targz-with-ruby.html

``` ruby
require 'rubygems/package'
require 'zlib'

TAR_LONGLINK = '././@LongLink'
tar_gz_archive = './autoconf-2.69.tar.gz'
destination = './foo'

Gem::Package::TarReader.new( Zlib::GzipReader.open tar_gz_archive ) do |tar|
  dest = nil
  tar.each do |entry|
    if entry.full_name == TAR_LONGLINK
      dest = File.join destination, entry.read.strip
      next
    end
    dest ||= File.join destination, entry.full_name
    if entry.directory?
      FileUtils.rm_rf dest unless File.directory? dest
      FileUtils.mkdir_p dest, :mode => entry.header.mode, :verbose => false
    elsif entry.file?
      FileUtils.rm_rf dest unless File.file? dest
      File.open dest, "wb" do |f|
        f.print entry.read
      end
      FileUtils.chmod entry.header.mode, dest, :verbose => false
    elsif entry.header.typeflag == '2' #Symlink!
      File.symlink entry.header.linkname, dest
    end
    dest = nil
  end
end
```
