### PR TITLE
only look at latest specs to suggest name

### DIFF
--- a/lib/rubygems/spec_fetcher.rb
+++ b/lib/rubygems/spec_fetcher.rb
@@ -186,7 +186,7 @@ class Gem::SpecFetcher
   def suggest_gems_from_name gem_name
     gem_name        = gem_name.downcase.tr('_-', '')
     max             = gem_name.size / 2
-    names           = available_specs(:complete).first.values.flatten(1)
+    names           = available_specs(:latest).first.values.flatten(1)
 
     matches = names.map { |n|
       next unless n.match_platform?


### PR DESCRIPTION
This reduced HTTP requests. Reviewed by @zenspider.

There are too many HTTP requests when someone misspells a gem name and that makes the command very slow.  Here is the output _before_ my change:

```
[aaron@higgins rubygems (master)]$ time ruby -I lib bin/gem install minitist -V
HEAD https://api.rubygems.org/api/v1/dependencies
302 Moved Temporarily
HEAD https://bundler.rubygems.org/api/v1/dependencies
200 OK
GET https://api.rubygems.org/api/v1/dependencies?gems=minitist
302 Moved Temporarily
GET https://bundler.rubygems.org/api/v1/dependencies?gems=minitist
200 OK
ERROR:  Could not find a valid gem 'minitist' (>= 0) in any repository
GET https://api.rubygems.org/prerelease_specs.4.8.gz
302 Moved Temporarily
GET https://s3.amazonaws.com/production.s3.rubygems.org/prerelease_specs.4.8.gz
304 Not Modified
GET https://api.rubygems.org/specs.4.8.gz
302 Moved Temporarily
GET https://s3.amazonaws.com/production.s3.rubygems.org/specs.4.8.gz
304 Not Modified
ERROR:  Possible alternatives: minitest, minigit, minilisp, ministat, linguist

real    0m32.252s
user    0m25.878s
sys 0m0.156s
[aaron@higgins rubygems (master)]$
```

Here it is after my changes:

```
[aaron@higgins rubygems (faster_error)]$ time ruby -I lib bin/gem install minitist -V
HEAD https://api.rubygems.org/api/v1/dependencies
302 Moved Temporarily
HEAD https://bundler.rubygems.org/api/v1/dependencies
200 OK
GET https://api.rubygems.org/api/v1/dependencies?gems=minitist
302 Moved Temporarily
GET https://bundler.rubygems.org/api/v1/dependencies?gems=minitist
200 OK
ERROR:  Could not find a valid gem 'minitist' (>= 0) in any repository
GET https://api.rubygems.org/latest_specs.4.8.gz
302 Moved Temporarily
GET https://s3.amazonaws.com/production.s3.rubygems.org/latest_specs.4.8.gz
304 Not Modified
ERROR:  Possible alternatives: minitest, minigit, minilisp, minit, linguist

real    0m10.148s
user    0m3.594s
sys 0m0.094s
[aaron@higgins rubygems (faster_error)]$
```

Both runs have a heated spec cache, but the new version is ~20 seconds faster.
