### PR TITLE
the `debug` method is never used

### DIFF
--- a/lib/rubygems/user_interaction.rb
+++ b/lib/rubygems/user_interaction.rb
@@ -367,13 +367,6 @@ class Gem::StreamUI
   end
 
   ##
-  # Display a debug message on the same location as error messages.
-
-  def debug(statement)
-    @errs.puts statement
-  end
-
-  ##
   # Terminate the application with exit code +status+, running any exit
   # handlers that might have been defined.
 


### PR DESCRIPTION
I'm not sure what this method is for (other than the comment). It's
never used in the tests, and it doesn't seem like anything in RubyGems
is calling it.
