### PR TITLE
Pass nil to net_http as proxy parameter not to use environment variables

### DIFF
--- a/lib/rubygems/request.rb
+++ b/lib/rubygems/request.rb
@@ -80,7 +80,7 @@ class Gem::Request
         Gem::UriFormatter.new(@proxy_uri.user).unescape,
         Gem::UriFormatter.new(@proxy_uri.password).unescape,
       ]
-    else
+    elsif no_proxy?(uri.host) then
       net_http_args += [nil, nil]
     end
 


### PR DESCRIPTION
ENV['http_proxy'] is used even if ENV['no_proxy'] is set because Net/HTTP uses environment variables if arguments of proxy is not passed.
