### PR TITLE
use File.exist? instead of File.exists?

### DIFF
--- a/lib/rubygems/doctor.rb
+++ b/lib/rubygems/doctor.rb
@@ -105,7 +105,7 @@ class Gem::Doctor
       next if ent == "." || ent == ".."
 
       child = File.join(directory, ent)
-      next unless File.exists?(child)
+      next unless File.exist?(child)
 
       basename = File.basename(child, extension)
       next if installed_specs.include? basename

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1053,7 +1053,7 @@ gem 'other', version
 
     path = File.join(@gemhome, 'gems', 'a-2', 'gem_make.out')
 
-    if File.exists?(path)
+    if File.exist?(path)
       puts File.read(path)
       puts '-' * 78
     end


### PR DESCRIPTION
Running under Ruby 2.1 or higher with -w option. I got deprecated warnings. This patch fixed it.
