### PR TITLE
Backport a fix for concurrent requires

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -4,6 +4,8 @@
 
 Bug fixes:
 
+* Restore concurrent requires following the fix for ruby bug #8374.  Pull
+  request #637 and issue #640 by Charles Nutter.
 * Gem::Specification::remove_spec no longer checks for existence of the spec
   to be removed.  Issue #698 by Tiago Macedo.
 * Restored wildcard handling when installing gems.  Issue #697 by Chuck Remes.

--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -50,7 +50,12 @@ module Kernel
     # normal require handle loading a gem from the rescue below.
 
     if Gem::Specification.unresolved_deps.empty? then
-      return gem_original_require(path)
+      begin
+        RUBYGEMS_ACTIVATION_MONITOR.exit
+        return gem_original_require(path)
+      ensure
+        RUBYGEMS_ACTIVATION_MONITOR.enter
+      end
     end
 
     # If +path+ is for a gem that has already been loaded, don't
@@ -63,7 +68,12 @@ module Kernel
       s.activated? and s.contains_requirable_file? path
     }
 
-    return gem_original_require(path) if spec
+    begin
+      RUBYGEMS_ACTIVATION_MONITOR.exit
+      return gem_original_require(path)
+    ensure
+      RUBYGEMS_ACTIVATION_MONITOR.enter
+    end if spec
 
     # Attempt to find +path+ in any unresolved gems...
 
@@ -111,11 +121,21 @@ module Kernel
       valid.activate
     end
 
-    gem_original_require path
+    begin
+      RUBYGEMS_ACTIVATION_MONITOR.exit
+      return gem_original_require(path)
+    ensure
+      RUBYGEMS_ACTIVATION_MONITOR.enter
+    end
   rescue LoadError => load_error
     if load_error.message.start_with?("Could not find") or
         (load_error.message.end_with?(path) and Gem.try_activate(path)) then
-      return gem_original_require(path)
+      begin
+        RUBYGEMS_ACTIVATION_MONITOR.exit
+        return gem_original_require(path)
+      ensure
+        RUBYGEMS_ACTIVATION_MONITOR.enter
+      end
     end
 
     raise load_error


### PR DESCRIPTION
Backport 16fc8e8 to 2.0 branch.
see #640 and https://bugs.ruby-lang.org/issues/9224
