### PR TITLE
Fix a wrong type check in self.new

### DIFF
--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -189,7 +189,7 @@ class Gem::Version
   @@all = {}
 
   def self.new version # :nodoc:
-    return super unless Gem::VERSION == self.class
+    return super unless Gem::Version == self
 
     @@all[version] ||= super
   end


### PR DESCRIPTION
The change introduced by https://github.com/rubygems/rubygems/commit/81d806d818baeb5dcb6398ca631d772a003d078e is wrong.  It compares a String instance to Class.  So that the condition is always evaluated to false.
