### PR TITLE
Support arbitrary `executables` with bin-wrappers.

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -648,7 +648,7 @@ if ARGV.first
 end
 
 gem '#{spec.name}', version
-load Gem.bin_path('#{spec.name}', '#{bin_file_name}', version)
+exec Gem.bin_path('#{spec.name}', '#{bin_file_name}', version), *ARGV
 TEXT
   end
 


### PR DESCRIPTION
This PR is a proposal to address issue #830.

@drbrain With due respect, I'd like to [question](https://github.com/rubygems/rubygems/issues/830#issuecomment-35340639):

> The documentation on guides.rubygems.org is incorrect here. Entries in a `Gem::Specification`'s executables list must be ruby scripts.

Unless this is an intentional change to implement a restriction, this definitely seems more likely implementation rather than documentation. I took some time and examined all the executables installed to `bin` from the ~350 gems I have installed, and there are more than a few that install linked binaries, not scripts. With the wording in the documentation, and the fact that this isn't an issue without bin-wrappers, I thought I'd look at the code, and it seems to me that the change I propose here would fix my issue without affecting the execution of ruby executables. I've `pristine`'d everything with this change, and tested with IO, args, etc., and there appears to be no difference in behavior -- so, is there some reason why `load` must be used that I'm missing?

If not, this would really be a great feature/patch for me -- while I can, of course, put scripts in other languages in heredocs and exec them myself, this basically means I have to write my own wrappers, just to support `wrappers`.
