### PR TITLE
raise a ConflictError when there are conflicting specs loaded

### DIFF
--- a/lib/rubygems/errors.rb
+++ b/lib/rubygems/errors.rb
@@ -19,6 +19,20 @@ module Gem
     attr_accessor :requirement
   end
 
+  # Raised when there are conflicting gem specs loaded
+
+  class ConflictError < LoadError
+    def initialize target, conf
+      y = conf.map { |act,con|
+        "#{act.full_name} conflicts with #{con.join(", ")}"
+      }.join ", "
+
+      # TODO: improve message by saying who activated `con`
+
+      super("Unable to activate #{target.full_name}, because #{y}")
+    end
+  end
+
   class ErrorReason; end
 
   # Generated when trying to lookup a gem to indicate that the gem

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2068,13 +2068,7 @@ class Gem::Specification < Gem::BasicSpecification
     conf = self.conflicts
 
     unless conf.empty? then
-      y = conf.map { |act,con|
-        "#{act.full_name} conflicts with #{con.join(", ")}"
-      }.join ", "
-
-      # TODO: improve message by saying who activated `con`
-
-      raise Gem::LoadError, "Unable to activate #{self.full_name}, because #{y}"
+      raise Gem::ConflictError.new self, conf
     end
   end
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -226,7 +226,7 @@ end
             util_spec 'b', '2.0'
     c,  _ = util_spec 'c', '1.0', 'b' => '= 2.0'
 
-    e = assert_raises Gem::LoadError do
+    e = assert_raises Gem::ConflictError do
       assert_activate nil, a, c, "b"
     end
 


### PR DESCRIPTION
Hi,

I think it would be nice if we start raising exceptions that relate to the type of exception being raised rather than relying on inspecting the exception message to differentiate types of errors.  I've introduced a `ConflictError` that gets raised when conflicting gemspecs are loaded.
## Merits:
- It separates the "message creation" logic from the logic that raises the exception
- You can differentiate a ConflictError from just a normal `LoadError`

The ConflictError inherits from LoadError, so it should be backwards compatible with `rescue` blocks.  If this type of change is acceptable, I'll look at the other exceptions too.
