### PR TITLE
only check conflicts for specs that can actually be activated

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1259,9 +1259,13 @@ class Gem::Specification < Gem::BasicSpecification
   # there are conflicts upon activation.
 
   def activate
-    raise_if_conflicts
+    other = Gem.loaded_specs[self.name]
+    if other
+      conflicting_version_check! other
+      return false
+    end
 
-    return false if Gem.loaded_specs[self.name]
+    raise_if_conflicts
 
     activate_dependencies
     add_self_to_load_path
@@ -2047,12 +2051,11 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   ##
-  # Check the spec for possible conflicts and freak out if there are any.
+  # Raise an exception if the version of this spec conflicts with the one
+  # that is already loaded (+other+)
 
-  def raise_if_conflicts
-    other = Gem.loaded_specs[self.name]
-
-    if other and self.version != other.version then
+  def conflicting_version_check! other
+    if self.version != other.version then
       # This gem is already loaded.  If the currently loaded gem is not in the
       # list of candidate gems, then we have a version conflict.
 
@@ -2064,7 +2067,14 @@ class Gem::Specification < Gem::BasicSpecification
 
       raise e
     end
+  end
 
+  private :conflicting_version_check!
+
+  ##
+  # Check the spec for possible conflicts and freak out if there are any.
+
+  def raise_if_conflicts
     conf = self.conflicts
 
     unless conf.empty? then


### PR DESCRIPTION
This commit separates the "a different version of this gem has already
been loaded" check from the "this gem has conflicts" check.

Merits:
- We only have to look up the spec once rather than twice:
  
  https://github.com/rubygems/rubygems/blob/f235c4a5f1e27369f9cf800b01092adc68216a53/lib/rubygems/specification.rb#L1264
  https://github.com/rubygems/rubygems/blob/f235c4a5f1e27369f9cf800b01092adc68216a53/lib/rubygems/specification.rb#L2053
- We only have to check existence of the spec once rather than twice:
  
  https://github.com/rubygems/rubygems/blob/f235c4a5f1e27369f9cf800b01092adc68216a53/lib/rubygems/specification.rb#L2055
  https://github.com/rubygems/rubygems/blob/f235c4a5f1e27369f9cf800b01092adc68216a53/lib/rubygems/specification.rb#L1264
- We don't need to check for conflicts on this gem because we aren't
  going to load it anyway.

Demerits:
- It seems that basically all methods in Gem::Specification are public,
  so its impossible to tell what is safe to refactor.  This technically
  changes the behavior of `raise_if_conflicts`, so if people are manually
  instantiating specs and calling that method then it will not behave the
  same.  If this method were private, we wouldn't have to worry so much.
