### PR TITLE
don't remove always_install requests for local gems

### DIFF
--- a/lib/rubygems/resolver/installer_set.rb
+++ b/lib/rubygems/resolver/installer_set.rb
@@ -53,7 +53,9 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
 
     found = find_all request
 
-    found.delete_if { |s| s.version.prerelease? } unless dependency.prerelease?
+    found.delete_if { |s|
+      s.version.prerelease? and not s.local?
+    } unless dependency.prerelease?
 
     found = found.select do |s|
       Gem::Source::SpecificFile === s.source or

--- a/lib/rubygems/resolver/local_specification.rb
+++ b/lib/rubygems/resolver/local_specification.rb
@@ -12,5 +12,9 @@ class Gem::Resolver::LocalSpecification < Gem::Resolver::SpecSpecification
     super
   end
 
+  def local? # :nodoc:
+    true
+  end
+
 end
 

--- a/lib/rubygems/resolver/specification.rb
+++ b/lib/rubygems/resolver/specification.rb
@@ -85,5 +85,8 @@ class Gem::Resolver::Specification
     Gem::Platform.match spec.platform
   end
 
+  def local? # :nodoc:
+    false
+  end
 end
 

--- a/test/rubygems/test_gem_dependency_installer.rb
+++ b/test/rubygems/test_gem_dependency_installer.rb
@@ -457,6 +457,20 @@ class TestGemDependencyInstaller < Gem::TestCase
     assert_equal %w[a-1], inst.installed_gems.map { |s| s.full_name }
   end
 
+  def test_install_local_prerelease
+    util_setup_gems
+
+    FileUtils.mv @a1_pre_gem, @tempdir
+    inst = nil
+
+    Dir.chdir @tempdir do
+      inst = Gem::DependencyInstaller.new :domain => :local
+      inst.install 'a-1.a.gem'
+    end
+
+    assert_equal %w[a-1.a], inst.installed_gems.map { |s| s.full_name }
+  end
+
   def test_install_local_dependency
     util_setup_gems
 


### PR DESCRIPTION
If the gem was specified on the commandline, we should not remove it
from the `found` list even if it is a prerelease gem.

Fixes #828
