### PR TITLE
Defer API prefetch until it's required

### DIFF
--- a/lib/rubygems/resolver/api_set.rb
+++ b/lib/rubygems/resolver/api_set.rb
@@ -34,6 +34,8 @@ class Gem::Resolver::APISet < Gem::Resolver::Set
 
     @data   = Hash.new { |h,k| h[k] = [] }
     @source = Gem::Source.new @uri
+
+    @to_fetch = []
   end
 
   ##
@@ -44,6 +46,10 @@ class Gem::Resolver::APISet < Gem::Resolver::Set
     res = []
 
     return res unless @remote
+
+    if @to_fetch.include?(req.name)
+      prefetch_now
+    end
 
     versions(req.name).each do |ver|
       if req.dependency.match? req.name, ver[:number]
@@ -61,9 +67,13 @@ class Gem::Resolver::APISet < Gem::Resolver::Set
   def prefetch reqs
     return unless @remote
     names = reqs.map { |r| r.dependency.name }
-    needed = names - @data.keys
+    needed = names - @data.keys - @to_fetch
 
-    return if needed.empty?
+    @to_fetch += needed
+  end
+
+  def prefetch_now
+    needed, @to_fetch = @to_fetch, []
 
     uri = @dep_uri + "?gems=#{needed.sort.join ','}"
     str = Gem::RemoteFetcher.fetcher.fetch_path uri


### PR DESCRIPTION
In normal operation, after we get the first level dependencies, we'll
make several prefetch calls before we need one of those results. Waiting
until then means we can make fewer HTTP requests.

Before:

```
delta:src/rubygems[master]% time ruby -I lib bin/gem install rails --no-ri --no-rdoc   
Successfully installed rails-4.0.4
1 gem installed
ruby -I lib bin/gem install rails --no-ri --no-rdoc  0.98s user 0.18s system 5% cpu 21.170 total
```

After:

```
delta:src/rubygems[defer_fetch]% time ruby -I lib bin/gem install rails --no-ri --no-rdoc
Successfully installed rails-4.0.4
1 gem installed
ruby -I lib bin/gem install rails --no-ri --no-rdoc  0.83s user 0.17s system 10% cpu 9.732 total
```

When applied on top of #869, this only gives a more modest 30% improvement:

master + #869:

```
delta:src/rubygems[persistent]% time ruby -I lib bin/gem install rails --no-ri --no-rdoc
Successfully installed rails-4.0.4
1 gem installed
ruby -I lib bin/gem install rails --no-ri --no-rdoc  0.75s user 0.17s system 12% cpu 7.612 total
```

master + #869 + defer_fetch:

```
delta:src/rubygems[combined]% time ruby -I lib bin/gem install rails --no-ri --no-rdoc
Successfully installed rails-4.0.4
1 gem installed
ruby -I lib bin/gem install rails --no-ri --no-rdoc  0.75s user 0.17s system 17% cpu 5.288 total
```
