### PR TITLE
Fix the test I broke in #871

### DIFF
--- a/test/rubygems/test_gem_resolver_api_set.rb
+++ b/test/rubygems/test_gem_resolver_api_set.rb
@@ -73,13 +73,13 @@ class TestGemResolverAPISet < Gem::TestCase
 
     set.prefetch [a_dep]
 
-    @fetcher.data.delete "#{@dep_uri}?gems=a"
-
     expected = [
       @DR::APISpecification.new(set, data.first)
     ]
 
     assert_equal expected, set.find_all(a_dep)
+
+    @fetcher.data.delete "#{@dep_uri}?gems=a"
   end
 
   def test_find_all_local


### PR DESCRIPTION
The fetch now doesn't happen until we call find_all, so the data must
remain available until then.
