### PR TITLE
extensions isn't initialized, so it could be nil

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -138,7 +138,7 @@ class Gem::BasicSpecification
       File.join full_gem_path, path
     end
 
-    full_paths.unshift extension_dir unless @extensions.empty?
+    full_paths.unshift extension_dir unless @extensions.nil? || @extensions.empty?
 
     full_paths
   end
@@ -211,7 +211,7 @@ class Gem::BasicSpecification
   #   spec.require_path = '.'
 
   def require_paths
-    return @require_paths if @extensions.empty?
+    return @require_paths if @extensions.nil? || @extensions.empty?
 
     relative_extension_dir =
       File.join '..', '..', 'extensions', Gem::Platform.local.to_s,


### PR DESCRIPTION
The BasicSpecification class checks if `@extensions` is empty, but never sets it to anything in the first place. That means it could be nil, and that would cause a `NoMethodError`. (I've run into that error myself while running Bundler tests). This pull checks if `@extensions` is nil or empty to avoid the exception.
