### PR TITLE
Support using the GEM_VERSION env variable in addition to the _VERSION_ argument

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -647,6 +647,10 @@ if ARGV.first
   end
 end
 
+if ENV['GEM_VERSION']
+  version = ENV.delete('GEM_VERSION')
+end
+
 gem '#{spec.name}', version
 load Gem.bin_path('#{spec.name}', '#{bin_file_name}', version)
 TEXT

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -47,6 +47,10 @@ if ARGV.first
   end
 end
 
+if ENV['GEM_VERSION']
+  version = ENV.delete('GEM_VERSION')
+end
+
 gem 'a', version
 load Gem.bin_path('a', 'executable', version)
     EOF


### PR DESCRIPTION
* If GEM_VERSION is specified, it is deleted from ENV so it is not
  passed to sub-processes.
* Use of an env variable is preferrable, as non-rubygem binstubs do not
  support the _VERSION_ argument (ex: Bundler's binstubs).