### PR TITLE
Add add_test_dependency method to Specification

### DIFF
--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -16,6 +16,7 @@ class Gem::Dependency
 
   TYPES = [
     :development,
+    :test,
     :runtime,
   ]
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -464,6 +464,21 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   ##
+  # Adds a test dependency named +gem+ with +requirements+ to this
+  # gem.
+  #
+  # Usage:
+  #
+  #   spec.add_test_dependency 'example', '~> 1.1', '>= 1.1.4'
+  #
+  # Test dependencies aren't installed by default and aren't
+  # activated when a gem is required.
+
+  def add_test_dependency(gem, *requirements)
+    add_dependency_with_type(gem, :test, *requirements)
+  end
+
+  ##
   # Adds a runtime dependency named +gem+ with +requirements+ to this gem.
   #
   # Usage:

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1081,13 +1081,22 @@ dependencies: []
     assert_equal %w[true gem_name], gem.dependencies.map { |dep| dep.name }
   end
 
-  def test_add_dependency_with_type_explicit
+  def test_add_development_dependency
     gem = util_spec "awesome", "1.0" do |awesome|
       awesome.add_development_dependency "monkey"
     end
 
     monkey = gem.dependencies.detect { |d| d.name == "monkey" }
     assert_equal(:development, monkey.type)
+  end
+
+  def test_add_test_dependency
+    gem = util_spec "awesome", "1.0" do |awesome|
+      awesome.add_test_dependency "monkey"
+    end
+
+    monkey = gem.dependencies.detect { |d| d.name == "monkey" }
+    assert_equal(:test, monkey.type)
   end
 
   def test_author


### PR DESCRIPTION
While updating a gem of ours, we needed to add gems to the test group for bundler, but that functionality does not exist in the gemspec. So we added it the Gemfile but we get the following warnings while running `bundle install`:

```
Your Gemfile lists the gem rake (>= 0) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of just one of them later.
Your Gemfile lists the gem rspec (>= 0) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of just one of them later.
```

We added the `add_test_dependency` method (with tests) to make it possible to add test-related gems to the gemspec. 

How do we test this pull request with bundler locally?

Thanks, 
Alex and Roy
