### PR TITLE
Fixed crash if a .gemspec has a string for require_paths variable.

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -134,7 +134,7 @@ class Gem::BasicSpecification
   # activated.
 
   def full_require_paths
-    full_paths = [@require_paths].flatten.map do |path|
+    full_paths = Array(@require_paths).map do |path|
       File.join full_gem_path, path
     end
 
@@ -211,13 +211,13 @@ class Gem::BasicSpecification
   #   spec.require_path = '.'
 
   def require_paths
-    return @require_paths if @extensions.nil? || @extensions.empty?
+    return Array(@require_paths) if @extensions.nil? || @extensions.empty?
 
     relative_extension_dir =
       File.join '..', '..', 'extensions', Gem::Platform.local.to_s,
                 Gem.extension_api_version, full_name
 
-    [relative_extension_dir].concat @require_paths
+    [relative_extension_dir].concat Array(@require_paths)
   end
 
   ##

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1784,7 +1784,7 @@ dependencies: []
     enable_shared 'no' do
       ext_spec
 
-      @ext.require_path = 'lib'
+      @ext.require_paths = 'lib'
 
       ext_install_dir = Pathname(@ext.extension_dir)
       full_gem_path = Pathname(@ext.full_gem_path)
@@ -1817,7 +1817,7 @@ dependencies: []
   def test_full_require_paths
     ext_spec
 
-    @ext.require_path = 'lib'
+    @ext.require_paths = 'lib'
 
     expected = [
       @ext.extension_dir,


### PR DESCRIPTION
Addresses open issue "require_path from gemspec is type sensitive. #890".
