### PR TITLE
Fix help for list and search commands

### DIFF
--- a/lib/rubygems/commands/list_command.rb
+++ b/lib/rubygems/commands/list_command.rb
@@ -8,13 +8,13 @@ require 'rubygems/commands/query_command'
 class Gem::Commands::ListCommand < Gem::Commands::QueryCommand
 
   def initialize
-    super 'list', 'Display local gems whose name starts with STRING'
+    super 'list', 'Display local gems whose name matches REGEXP'
 
     remove_option('--name-matches')
   end
 
   def arguments # :nodoc:
-    "STRING        start of gem name to look for"
+    "REGEXP        regexp to look for in gem name"
   end
 
   def defaults_str # :nodoc:

--- a/lib/rubygems/commands/search_command.rb
+++ b/lib/rubygems/commands/search_command.rb
@@ -4,7 +4,7 @@ require 'rubygems/commands/query_command'
 class Gem::Commands::SearchCommand < Gem::Commands::QueryCommand
 
   def initialize
-    super 'search', 'Display remote gems whose name contains STRING'
+    super 'search', 'Display remote gems whose name matches REGEXP'
 
     remove_option '--name-matches'
 
@@ -12,7 +12,7 @@ class Gem::Commands::SearchCommand < Gem::Commands::QueryCommand
   end
 
   def arguments # :nodoc:
-    "STRING        fragment of gem name to search for"
+    "REGEXP        regexp to search for in gem name"
   end
 
   def defaults_str # :nodoc:
@@ -21,8 +21,8 @@ class Gem::Commands::SearchCommand < Gem::Commands::QueryCommand
 
   def description # :nodoc:
     <<-EOF
-The search command displays remote gems whose name contains the given
-string.
+The search command displays remote gems whose name matches the given
+regexp.
 
 The --details option displays additional details from the gem but will
 take a little longer to complete as it must download the information
@@ -33,7 +33,7 @@ To list local gems use the list command.
   end
 
   def usage # :nodoc:
-    "#{program_name} [STRING]"
+    "#{program_name} [REGEXP]"
   end
 
 end


### PR DESCRIPTION
Reflect that they take a regexp rather than a string.
