### PR TITLE
Give more error information on dependency fails

### DIFF
--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -282,12 +282,13 @@ class Gem::Dependency
 
       if specs.empty?
         total = Gem::Specification.to_a.size
-        error = Gem::LoadError.new \
-          "Could not find '#{name}' (#{requirement}) among #{total} total gem(s)"
+        msg   = "Could not find '#{name}' (#{requirement}) among #{total} total gem(s)\n"
       else
-        error = Gem::LoadError.new \
-          "Could not find '#{name}' (#{requirement}) - did find: [#{specs.join ','}]"
+        msg   = "Could not find '#{name}' (#{requirement}) - did find: [#{specs.join ','}]\n"
       end
+      msg << "Checked in 'GEM_PATH=#{Gem.path.join(":")}', execute `$ gem env` for more information"
+
+      error = Gem::LoadError.new(msg)
       error.name        = self.name
       error.requirement = self.requirement
       raise error

--- a/test/rubygems/test_gem_dependency.rb
+++ b/test/rubygems/test_gem_dependency.rb
@@ -261,7 +261,7 @@ class TestGemDependency < Gem::TestCase
       dep.to_specs
     end
 
-    assert_equal "Could not find 'a' (= 2.0) - did find: [a-1.0]", e.message
+    assert_match "Could not find 'a' (= 2.0) - did find: [a-1.0]", e.message
   end
 
   def test_to_specs_indicates_total_gem_set_size
@@ -279,7 +279,7 @@ class TestGemDependency < Gem::TestCase
       dep.to_specs
     end
 
-    assert_equal "Could not find 'b' (= 2.0) among 1 total gem(s)", e.message
+    assert_match "Could not find 'b' (= 2.0) among 1 total gem(s)", e.message
   end
 
 


### PR DESCRIPTION
When rubygems cannot find your installed gems it will raise an error. It includes the name of the gem it was looking for and a count of the available gems in the available path, but it does not give any additional debugging information. 

This PR adds the path locations of where gems are stored so the developer could manually check to see if the gem exists in one of them. If there is not an issue with GEM_PATH then perhaps a quick check of `$ gem env` will at least prompt users to dig in more. 

When I first started developing in Ruby I had many gem problems, most of them were solved after posting to ruby-forum.com and them asking for my `gem env`. By prompting the user to look for that information proactively we can decrease the friction of debugging these errors.

Old error:

```
/Users/schneems/.rubies/ruby-2.1.1/lib/ruby/2.1.0/rubygems/dependency.rb:300:in `to_specs': Could not find 'bundler' (>= 0) among 8 total gem(s) (Gem::LoadError)
    from /Users/schneems/.rubies/ruby-2.1.1/lib/ruby/2.1.0/rubygems/dependency.rb:311:in `to_spec'
    from /Users/schneems/.rubies/ruby-2.1.1/lib/ruby/2.1.0/rubygems/core_ext/kernel_gem.rb:53:in `gem'
    from /tmp/bin/bundle:18:in `<main>'

```

New error:

```
/Users/schneems/.rubies/ruby-2.1.1/lib/ruby/2.1.0/rubygems/dependency.rb:300:in `to_specs': Could not find 'bundler' (>= 0) among 8 total gem(s) (Gem::LoadError)
Checked in 'GEM_PATH=foo:bar', execute `$ gem env` for more information
    from /Users/schneems/.rubies/ruby-2.1.1/lib/ruby/2.1.0/rubygems/dependency.rb:311:in `to_spec'
    from /Users/schneems/.rubies/ruby-2.1.1/lib/ruby/2.1.0/rubygems/core_ext/kernel_gem.rb:53:in `gem'
    from /tmp/bin/bundle:18:in `<main>'
```
