### PR TITLE
Don't assume ruby.exe is in gem bindir on Windows

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -656,14 +656,14 @@ TEXT
   # return the stub script text used to launch the true Ruby script
 
   def windows_stub_script(bindir, bin_file_name)
-    ruby = File.basename(Gem.ruby).chomp('"')
+    ruby = Gem.ruby.chomp('"').tr(File::SEPARATOR, File::ALT_SEPARATOR)
     return <<-TEXT
 @ECHO OFF
 IF NOT "%~f0" == "~f0" GOTO :WinNT
-@"#{bindir.tr(File::SEPARATOR, File::ALT_SEPARATOR)}\\#{ruby}" "#{File.join(bindir, bin_file_name)}" %1 %2 %3 %4 %5 %6 %7 %8 %9
+@"#{ruby}" "#{File.join(bindir, bin_file_name)}" %1 %2 %3 %4 %5 %6 %7 %8 %9
 GOTO :EOF
 :WinNT
-@"%~dp0#{ruby}" "%~dpn0" %*
+@"#{ruby}" "%~dpn0" %*
 TEXT
   end
 


### PR DESCRIPTION
Normally gem "binaries" install to the same place as ruby.exe. Under normal conditions, this is a safe assumption, and causes no problems. However when using bundler with the --deployment switch your gem binaries end up in project/vendor/bundle/ruby/VERSION/bin and your exe is somewhere else. Because of the way the Windows wrapper .bat files are written bundle exec tries to execute ruby.exe from your vendor/bundle directory and can't.
I am a little torn on whether this is a Rubygems problem or a Bundler problem. If I owned both systems I'd rather fix the wrapper batch files, which are build by Rubygems. So that's the solution I'm proposing.
All I can report is that this "works for me", I have not tested extensively (on different Windows versions, with PIK or other Ruby switchers, etc).
Final note, I'm unsure of under what circumstances quotes would show up in your Gem.ruby variable, so I am not sure why we are chomping them off on line 659. Because of that, I'm not sure if I re-implemented it correctly (calling it directly on Gem.ruby instead of the result of running File.basename on samesuch).
