### PR TITLE
Fix handling path's started with '~/' in environment variable PATH.

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -609,7 +609,7 @@ class Gem::Installer
     path = path.split(File::PATH_SEPARATOR)
 
     unless path.include? user_bin_dir then
-      unless !Gem.win_platform? && path.include? user_bin_dir.sub(ENV['HOME'], '~')
+      unless !Gem.win_platform? && (path.include? user_bin_dir.sub(ENV['HOME'], '~'))
         unless self.class.path_warning then
           alert_warning "You don't have #{user_bin_dir} in your PATH,\n\t  gem executables will not run."
           self.class.path_warning = true


### PR DESCRIPTION
Fix handling path's like '~/.gem/ruby/2.1.0/bin' in PATH variable.
