### PR TITLE
Make gem -g Gemfile respect --conservative (Fixes #929)

### DIFF
--- a/lib/rubygems/request_set.rb
+++ b/lib/rubygems/request_set.rb
@@ -82,6 +82,7 @@ class Gem::RequestSet
     @dependencies = deps
 
     @always_install      = []
+    @conservative        = false
     @dependency_names    = {}
     @development         = false
     @development_shallow = false
@@ -191,6 +192,7 @@ class Gem::RequestSet
 
     @install_dir = options[:install_dir] || Gem.dir
     @remote      = options[:domain] != :local
+    @conservative = true if options[:conservative]
 
     gem_deps_api = load_gemdeps gemdeps, options[:without_groups], true
 
@@ -288,6 +290,14 @@ class Gem::RequestSet
     resolver.development_shallow = @development_shallow
     resolver.ignore_dependencies = @ignore_dependencies
     resolver.soft_missing        = @soft_missing
+
+    if @conservative
+      installed_gems = {}
+      Gem::Specification.find_all do |spec|
+        (installed_gems[spec.name] ||= []) << spec
+      end
+      resolver.skip_gems = installed_gems
+    end
 
     @resolver = resolver
 

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -729,6 +729,31 @@ ERROR:  Possible alternatives: non_existent_with_hint
     assert !File.exist?("#{@gemdeps}.lock")
   end
 
+  def test_execute_installs_from_a_gemdeps_with_conservative
+    spec_fetcher do |fetcher|
+      fetcher.gem 'a', 2
+      fetcher.clear
+      fetcher.gem 'a', 1
+    end
+
+    File.open @gemdeps, "w" do |f|
+      f << "gem 'a'"
+    end
+
+    @cmd.handle_options %w[--conservative]
+    @cmd.options[:gemdeps] = @gemdeps
+
+    use_ui @ui do
+      assert_raises Gem::MockGemUi::SystemExitException, @ui.error do
+        @cmd.execute
+      end
+    end
+
+    assert_equal %w[], @cmd.installed_specs.map { |spec| spec.full_name }
+
+    assert_match "Using a (1)", @ui.output
+  end
+
   def test_execute_installs_from_a_gemdeps
     spec_fetcher do |fetcher|
       fetcher.gem 'a', 2


### PR DESCRIPTION
This is the least intrusive way I could think to support the
combination of -g and --conservative.  This took a while to
figure out, but it should correctly handle dependencies and
make sure that currently installed gems are used instead of
installing new gems, as long as the currently installed gems
meet the version requirements.

Implmentation wise, this adds a hash attribute to the Resolver
for gems that should be skipped instead of new installations
made if the versions match.  The RequestSet sets this variable
with the specifications of all of the currently installed gems
if --conservative is used.

When finding possible dependencies in the resolver, we still query
the rubygems.org API, but then we restrict the returned results
to only gems that match the currently installed gems, if any
do.  The reason for this choice of implementation is parts of
rubygems expect Gem::Resolver::APISpecification instances,
and I couldn't think of a good way to create them otherwise.
