### PR TITLE
cut monitor entry / exits in half on "happy path" requires

### DIFF
--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -99,6 +99,7 @@ module Kernel
       names = found_specs.map(&:name).uniq
 
       if names.size > 1 then
+        RUBYGEMS_ACTIVATION_MONITOR.exit
         raise Gem::LoadError, "#{path} found in multiple gems: #{names.join ', '}"
       end
 
@@ -109,6 +110,7 @@ module Kernel
       unless valid then
         le = Gem::LoadError.new "unable to find a version of '#{names.first}' to activate"
         le.name = names.first
+        RUBYGEMS_ACTIVATION_MONITOR.exit
         raise le
       end
 

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -61,7 +61,6 @@ class TestGemRequire < Gem::TestCase
     append_latch a1
     append_latch b1
 
-    Thread.abort_on_exception = true
     t1 = Thread.new { assert_require 'a' }
     t2 = Thread.new { assert_require 'b' }
 


### PR DESCRIPTION
Before this change RUBYGEMS_ACTIVATION_MONITOR would enter and exit
twice for every call to require.  This commit pushes the "exit" call
outside of the `ensure` block to the `rescue` and unlocks in the
appropriate place.  Eliminating the effectively "global" unlock in then
`ensure` block allows us to lock and unlock once during happy path
requires, and only lock / unlock twice when `gem_original_require` fails
and we need to attempt to activate the gem.

Here is a test to demonstrate the problem:

``` ruby
require 'rubygems'
require 'tempfile'

moncalls = []
trace = TracePoint.new(:c_call, :call) do |tp|
  if tp.method_id == :mon_enter
    moncalls << [tp.defined_class, tp.method_id, tp.path]
  end
end

f = Tempfile.open(['foo', '.rb'])
f.write "true"
f.close

$: << File.dirname(f.path)
file = File.basename f.path, '.rb'

trace.enable
require file
trace.disable

p moncalls.length
```

Before this change `moncalls.length` will return 2, after this commit,
it returns 1.
