### PR TITLE
include test for v0.X.X versions

### DIFF
--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -207,6 +207,14 @@ class TestGemRequirement < Gem::TestCase
     end
   end
 
+  def test_satisfied_by_eh_tilde_gt_v0
+    r = req "~> 0.0.1"
+
+    refute_satisfied_by "0.1.1", r
+    assert_satisfied_by "0.0.2", r
+    assert_satisfied_by "0.0.1", r
+  end
+
   def test_satisfied_by_eh_good
     assert_satisfied_by "0.2.33",      "= 0.2.33"
     assert_satisfied_by "0.2.34",      "> 0.2.33"


### PR DESCRIPTION
For semantic versioning I had expected only exact matches to satisfy the pessimistic operator, because breaking change can occur at even the patch level.  

RubyGems does not have any special `satisfied_by?` logic for v0.X.X gems, this patch documents that.
