### PR TITLE
Change condition of YAML engine for Psych

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2386,7 +2386,7 @@ class Gem::Specification < Gem::BasicSpecification
 
   def to_yaml(opts = {}) # :nodoc:
     if (YAML.const_defined?(:ENGINE) && !YAML::ENGINE.syck?) ||
-        !defined?(Syck) && defined?(Psych) then
+        (defined?(Psych) && YAML == Psych) then
       # Because the user can switch the YAML engine behind our
       # back, we have to check again here to make sure that our
       # psych code was properly loaded, and load it if not.


### PR DESCRIPTION
rubygems is broken on defined Syck environment. I fixed this on ruby trunk. ref. https://github.com/ruby/ruby/commit/b0bc5635504faa851742ec056a9875fadf2fdcbc

@drbrain if you have more better code, Please fixed this and backport ruby trunk.

/cc @zzak @tenderlove

Thanks!
