### PR TITLE
Enable use of gem open with command line editors

### DIFF
--- a/lib/rubygems/commands/open_command.rb
+++ b/lib/rubygems/commands/open_command.rb
@@ -61,14 +61,7 @@ class Gem::Commands::OpenCommand < Gem::Command
   end
 
   def open_editor path
-    Dir.chdir(path) do
-      pid = fork do
-        args = (@editor.split(/\s+/) + [path]).join(' ')
-        exec(args)
-      end
-
-      Process.detach pid
-    end
+    system(*@editor.split(/\s+/) + [path])
   end
 
   def spec_for name


### PR DESCRIPTION
The current implementation forks the editor into the background, breaking it for all terminal editors. I assume this was an oversight. (I certainly missed it reviewing the initial pull request.)
