### PR TITLE
Add a buildroot option to gem install.

### DIFF
--- a/lib/rubygems/dependency_installer.rb
+++ b/lib/rubygems/dependency_installer.rb
@@ -72,6 +72,7 @@ class Gem::DependencyInstaller
   def initialize options = {}
     @only_install_dir = !!options[:install_dir]
     @install_dir = options[:install_dir] || Gem.dir
+    @build_root = options[:build_root]
 
     options = DEFAULT_OPTIONS.merge options
 
@@ -384,6 +385,7 @@ class Gem::DependencyInstaller
       :security_policy     => @security_policy,
       :user_install        => @user_install,
       :wrappers            => @wrappers,
+      :build_root          => @build_root,
       :install_as_default  => @install_as_default
     }
     options[:install_dir] = @install_dir if @only_install_dir

--- a/lib/rubygems/install_update_options.rb
+++ b/lib/rubygems/install_update_options.rb
@@ -59,6 +59,12 @@ module Gem::InstallUpdateOptions
                            end
     end
 
+    add_option(:"Install/Update", '--build-root DIR',
+               'Temporary installation root. Useful for building',
+               'packages. Do not use this when installing remote gems.') do |value, options|
+    options[:build_root] = File.expand_path(value)
+    end
+
     add_option(:"Install/Update", '-N', '--no-document',
                'Disable documentation generation') do |value, options|
       options[:document] = []

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -593,8 +593,17 @@ class Gem::Installer
     # (or use) a new bin dir under the gem_home.
     @bin_dir             = options[:bin_dir] || Gem.bindir(gem_home)
     @development         = options[:development]
+    @build_root          = options[:build_root]
 
     @build_args          = options[:build_args] || Gem::Command.build_args
+
+    unless @build_root.nil?
+      require 'pathname'
+      @build_root = Pathname.new(@build_root).expand_path
+      @bin_dir = File.join(@build_root, options[:bin_dir] || Gem.bindir(@gem_home))
+      @gem_home = File.join(@build_root,@gem_home)
+      alert_warning "You build with buildroot.\n  Build root: #{@build_root}\n  Bin dir: #{@bin_dir}\n  Gem home: #{@gem_home}"
+    end
   end
 
   def check_that_user_bin_dir_is_in_path # :nodoc:


### PR DESCRIPTION
This option helps packagers, who want to repackage gems in deb/rpm.
It is also needed to make tools/rbinstall.rb work in ruby 2.2.
Without this patch and another small patch for rbinstall.rb, "make
install" ignores DESTDIR when installing the stdlib gems.
