### PR TITLE
Add a "whereis" command.

### DIFF
--- a/lib/rubygems/command_manager.rb
+++ b/lib/rubygems/command_manager.rb
@@ -63,6 +63,7 @@ class Gem::CommandManager
     :uninstall,
     :unpack,
     :update,
+    :whereis,
     :which,
     :yank,
   ]

--- a/lib/rubygems/commands/whereis_command.rb
+++ b/lib/rubygems/commands/whereis_command.rb
@@ -1,0 +1,63 @@
+require 'rubygems/command'
+
+class Gem::Commands::WhereisCommand < Gem::Command
+  def initialize
+    super 'whereis', 'Find the location of a named gem',
+          show_all: false
+
+    add_option '-a', '--[no-]all', 'show all versions' do |show_all, options|
+      options[:show_all] = show_all
+    end
+  end
+
+  def usage # :nodoc:
+    "#{program_name} GEMNAME [REQUIREMENT ...]"
+  end
+
+  def arguments # :nodoc:
+    <<-ARGS
+GEMNAME       name of gem to find
+REQUIREMENT   optional version specifier(s)
+    ARGS
+  end
+
+  def defaults_str # :nodoc:
+    " --no-all"
+  end
+
+  def description # :nodoc:
+    <<-EOF
+The whereis command shows the base directory where a specified gem is
+installed.
+
+If -a/--all is given, it shows the base directories of all installed
+versions of a gem that matches a given query.
+    EOF
+  end
+
+  def execute
+    name, *requirements = options[:args]
+
+    if !name
+      alert_error "Please specify a gem name"
+      terminate_interaction 1
+    end
+
+    begin
+      if options[:show_all]
+        specs = Gem::Specification.find_all_by_name(name, *requirements)
+      else
+        specs = [Gem::Specification.find_by_name(name, *requirements)]
+      end
+    rescue Gem::LoadError
+      if requirements.empty?
+        alert_error "Can't find installed gem(s) named #{name}"
+      else
+        alert_error "Can't find installed gem(s) named #{name} [#{requirements.join(', ')}]"
+      end
+      terminate_interaction 1
+    end
+
+    say specs.map(&:gem_dir)
+  end
+end


### PR DESCRIPTION
"gem whereis GEMNAME [REQUIREMENT ...]" shows the base directory where a
specified gem is installed.  This is considered useful for use in
scripts and editor plugins, or when one simply wants to browse a gem's
installed directory.

"gem which" does a similar job, but it is focused on locating a library
file and does not work for gems that do not provide a user loadable
library.
