### PR TITLE
lock around spec activation so that `gem` is threadsafe.

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -156,6 +156,7 @@ module Gem
 
   @configuration = nil
   @loaded_specs = {}
+  LOADED_SPECS_MUTEX = Mutex.new
   @path_to_default_spec_map = {}
   @platforms = []
   @ruby = nil

--- a/lib/rubygems/core_ext/kernel_gem.rb
+++ b/lib/rubygems/core_ext/kernel_gem.rb
@@ -56,7 +56,9 @@ module Kernel
     end
 
     spec = Gem::Dependency.new(gem_name, *requirements).to_spec
-    spec.activate if spec
+    Gem::LOADED_SPECS_MUTEX.synchronize {
+      spec.activate
+    } if spec
   end
 
   private :gem


### PR DESCRIPTION
This program demonstrates the thread unsafetyness before this commit:

``` ruby
require 'rubygems'

lp           = $LOAD_PATH.dup

10.times.map {
  Thread.new {
    gem 'minitest'
  }
}.each(&:join)

p $LOAD_PATH - lp
```

if you run this with JRuby, you will sometimes see multiple entries for
minitest on the load path.  This commit fixes the `gem` method so that
you can call `gem` in parallel and the load path is updated safely.
