### PR TITLE
Explicitly load Mutex class for older rubies

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -6,6 +6,7 @@
 #++
 
 require 'rbconfig'
+require 'thread'
 
 module Gem
   VERSION = '2.3.0'


### PR DESCRIPTION
Using ruby 1.8.7, `require 'rubygems'` will fail with the error `rubygems.rb:159: uninitialized constant Gem::Mutex (NameError)`

This can be seen in bundler's continuous integration tests: https://travis-ci.org/bundler/bundler/jobs/29373480#L151
