### PR TITLE
File.rename won't work across partitions, snd return EXDEV

### DIFF
--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -57,7 +57,7 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
 
           FileEntry.new(tmp_dest).traverse do |ent|
             destent = ent.class.new(dest_path, ent.rel)
-            destent.exist? or File.rename(ent.path, destent.path)
+            destent.exist? or FileUtils.mv(ent.path, destent.path)
           end
         end
       ensure


### PR DESCRIPTION
This errors poped up as I was trying to have /usr/local/share/gems shared
accross docker container for persistence.

To reproduce, try this ( with a docker container with ruby and all that is needed to build atomic ):

```
docker run -d  -v $(pwd)/.gemcaches:/usr/local/share/gems fedora gem install rubygem
```
