### PR TITLE
improve performance of find_files_from_load_path

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -439,8 +439,11 @@ module Gem
   end
 
   def self.find_files_from_load_path glob # :nodoc:
+    search = glob + Gem.suffix_pattern
     $LOAD_PATH.map { |load_path|
-      Dir["#{File.expand_path glob, load_path}#{Gem.suffix_pattern}"]
+      Dir.chdir(load_path) {
+        Dir[search].map! { |f| File.join load_path, f }
+      }
     }.flatten.select { |file| File.file? file.untaint }
   end
 


### PR DESCRIPTION
In order to support case-insensitive file systems, Dir#[] is slower in
trunk Ruby:

  https://bugs.ruby-lang.org/issues/10015

This patch speeds up `find_files_from_load_path` a little on 2.1.2
(about 10%) and a lot on Ruby trunk (10x faster).  Here is my benchmark:

``` ruby
require 'benchmark/ips'

class Hello
  def self.old_find_files_from_load_path glob # :nodoc:
    $LOAD_PATH.map { |load_path|
      Dir["#{File.expand_path glob, load_path}#{Gem.suffix_pattern}"]
    }.flatten.select { |file| File.file? file.untaint }
  end

  def self.new_find_files_from_load_path glob # :nodoc:
    search = "#{glob}#{Gem.suffix_pattern}"
    $LOAD_PATH.map { |load_path|
      Dir.chdir(load_path) {
        Dir[search].map! { |f| File.join load_path, f }
      }
    }.flatten.select { |file| File.file? file.untaint }
  end
end

search = "minitest/*_plugin.rb"

Benchmark.ips do |x|
  x.report('old') do
    Hello.old_find_files_from_load_path search
  end

  x.report('new') do
    Hello.new_find_files_from_load_path search
  end
end
```

Results on 2.1.2:

```
[aaron@higgins rubygems (master)]$ ruby -v -I lib flp.rb
ruby 2.1.2p95 (2014-05-08 revision 45877) [x86_64-darwin13.0]
Calculating -------------------------------------
                 old       283 i/100ms
                 new       304 i/100ms
-------------------------------------------------
                 old     2903.8 (±4.3%) i/s -      14716 in   5.078291s
                 new     3180.5 (±4.7%) i/s -      16112 in   5.078193s
```

Results against trunk:

```
[aaron@higgins rubygems (master)]$ ruby -v -I lib flp.rb
ruby 2.2.0dev (2014-07-09 trunk 46759) [x86_64-darwin13]
Calculating -------------------------------------
                 old         8 i/100ms
                 new        85 i/100ms
-------------------------------------------------
                 old       84.6 (±7.1%) i/s -        424 in   5.046520s
                 new      858.7 (±3.3%) i/s -       4335 in   5.053763s
```
