### PR TITLE
Clearer wording for --source option

### DIFF
--- a/lib/rubygems/local_remote_options.rb
+++ b/lib/rubygems/local_remote_options.rb
@@ -101,7 +101,7 @@ module Gem::LocalRemoteOptions
     accept_uri_http
 
     add_option(:"Local/Remote", '-s', '--source URL', URI::HTTP,
-               'Add URL as a remote source for gems') do |source, options|
+               'Append URL to list of remote gem sources') do |source, options|
 
       source << '/' if source !~ /\/\z/
 


### PR DESCRIPTION
When trying to use the gem command against a private rubygems server, I was
surprised when --source seemed to have no effect. My gem (which exists on both
rubygems.org and the private server) was always found on rubygems.org first,
and the source I added seemed ignored.

This led me into the code where I discovered --clear-sources and realized that
my source was there, but just at _end_ of the list instead of replacing and/or
taking precedence.

After talking with @drbrain it's clear this behavior can't change, but slightly
different wording in the help would have led me to understand what was
happening without requiring digging into the code.

I'm also intending to write up a Rubygems Guide page about using sources.
