### PR TITLE
Allow File::ALT_SEPARATOR to be nil when generating windows binary stub

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -673,10 +673,11 @@ TEXT
 
   def windows_stub_script(bindir, bin_file_name)
     ruby = File.basename(Gem.ruby).chomp('"')
+    alt_separator = File::ALT_SEPARATOR || File::SEPARATOR
     return <<-TEXT
 @ECHO OFF
 IF NOT "%~f0" == "~f0" GOTO :WinNT
-@"#{bindir.tr(File::SEPARATOR, File::ALT_SEPARATOR)}\\#{ruby}" "#{File.join(bindir, bin_file_name)}" %1 %2 %3 %4 %5 %6 %7 %8 %9
+@"#{bindir.tr(File::SEPARATOR, alt_separator)}\\#{ruby}" "#{File.join(bindir, bin_file_name)}" %1 %2 %3 %4 %5 %6 %7 %8 %9
 GOTO :EOF
 :WinNT
 @"%~dp0#{ruby}" "%~dpn0" %*


### PR DESCRIPTION
Under Cygwin, I was repeatedly getting the following error when installing any gem with a `bin` subdirectory:

```
ERROR:  While executing gem ... (TypeError)
    no implicit conversion of nil into String
```

After examining the `gem install --backtrace ...` output, it appears to be due to `File::ALT_SEPARATOR` being `nil`.  This is a quick work-around for that issue.
