### PR TITLE
Only chmod files if necessary

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -412,8 +412,15 @@ class Gem::Installer
         next
       end
 
-      mode = File.stat(bin_path).mode | 0111
-      FileUtils.chmod mode, bin_path
+      mode = File.stat(bin_path).mode
+      new_mode = mode | 0111
+      if mode != new_mode
+        # We can't assume we own the file, only that it will be writeable
+        tmp_path = bin_path + '.tmp'
+        FileUtils.cp bin_path, tmp_path
+        FileUtils.chmod new_mode, tmp_path
+        FileUtils.mv tmp_path, bin_path
+      end
 
       check_executable_overwrite filename
 


### PR DESCRIPTION
This helps with some permissions problems.

The particular use case is where you have a shared set of gems being
administered by multiple users. Think a PCI environment where you can't
have a deploy account and need an account per user.

You place all the users in the deploy group and set permissions on your
application as follows.

``` bash
sudo chown -R root.deploy .
sudo chmod -R g+rw .
sudo find . -type d -exec chmod g+s {} \;
```

When the first user deploys them gems, any executables will look like.

```
-rwxrwxr-x 1 user_a deploy 128 Aug 30 03:48 vendor/bundle/ruby/2.0.0/bundler/gems/henson-b725e8b71582/bin/henson
```

The permissions are correct and the file is owned by ```user_a```

When user_b comes along and runs bundle, they will see the following
error.

```
Errno::EPERM: Operation not permitted - vendor/bundle/ruby/2.0.0/bundler/gems/henson-b725e8b71582/bin/henson
```

This is because even though the permissions are correct we always try to
chmod the file. A chmod will only succeed if you are the owner of the
file, not if you have write permissions.

While we can assume we have write permissions, I don't think we should
assume we are the owner of the files.

The simple fix is to copy the file, fix the permissions and then put it
back into place.