### PR TITLE
Remove meaningless ensure

### DIFF
--- a/lib/rubygems/rdoc.rb
+++ b/lib/rubygems/rdoc.rb
@@ -279,7 +279,6 @@ class Gem::RDoc # :nodoc: all
         ui.errs.puts "... RDOC args: #{args.join(' ')}"
         ui.backtrace ex
         ui.errs.puts "(continuing with the rest of the installation)"
-      ensure
       end
     end
   end


### PR DESCRIPTION
I suppose 'empty ensure' like that ↓ has no meaning,

```
begin
  r.document args
rescue Errno::EACCES => e
  dirname = File.dirname e.message.split("-")[1].strip
  raise Gem::FilePermissionError, dirname
rescue Interrupt => e
  raise e
rescue Exception => ex
  alert_error "While generating documentation for #{@spec.full_name}"
  ui.errs.puts "... MESSAGE:   #{ex}"
  ui.errs.puts "... RDOC args: #{args.join(' ')}"
  ui.backtrace ex
  ui.errs.puts "(continuing with the rest of the installation)"
ensure
end
```

So I remove that.
