### PR TITLE
Gets rid of overly strict warning for versions below 1.0.0

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2658,7 +2658,8 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
         dep.requirement.requirements.any? do |op, version|
           op == '~>' and
             not version.prerelease? and
-            version.segments.length > 2
+            version.segments.length > 2 and
+            version.segments.first != 0
         end
 
       if overly_strict then

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2297,6 +2297,7 @@ end
       @a1.add_runtime_dependency     'k', '> 1.2'
       @a1.add_runtime_dependency     'l', '> 1.2.3'
       @a1.add_runtime_dependency     'm', '~> 2.1.0'
+      @a1.add_runtime_dependency     'n', '~> 0.1.0'
 
       use_ui @ui do
         @a1.validate


### PR DESCRIPTION
Fixes #987
