### PR TITLE
Initialize StubSpecification’s @name to make RubyGems warning-free

### DIFF
--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -42,6 +42,7 @@ class Gem::StubSpecification < Gem::BasicSpecification
     self.loaded_from = filename
     @data            = nil
     @extensions      = nil
+    @name            = nil
     @spec            = nil
   end
 


### PR DESCRIPTION
RubyGems 2.4.1 – which ships with Ruby 2.2.0-preview1 – is not warning-free:

`/home/chastell/.rubies/ruby-2.2.0-preview1/lib/ruby/2.2.0/rubygems/stub_specification.rb:158: warning: instance variable @name not initialized`

This makes the current master warning-free again.
