### PR TITLE
Warn if getting SRV record fails, part of #1017

### DIFF
--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -91,7 +91,8 @@ class Gem::RemoteFetcher
     begin
       res = @dns.getresource "_rubygems._tcp.#{host}",
                              Resolv::DNS::Resource::IN::SRV
-    rescue Resolv::ResolvError
+    rescue Resolv::ResolvError => e
+      verbose "Getting SRV record failed: #{e}"
       uri
     else
       URI.parse "#{uri.scheme}://#{res.target}#{uri.path}"

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -182,6 +182,31 @@ gems:
     dns.verify
   end
 
+  def test_api_endpoint_timeout_warning
+    uri = URI.parse "http://gems.example.com/foo"
+
+    dns = MiniTest::Mock.new
+    def dns.getresource arg, *rest
+      raise Resolv::ResolvError.new('timeout!')
+    end
+
+    fetch = Gem::RemoteFetcher.new nil, dns
+    begin
+      old_verbose, Gem.configuration.verbose = Gem.configuration.verbose, 1
+      endpoint = use_ui @ui do
+        fetch.api_endpoint(uri)
+      end
+    ensure
+      Gem.configuration.verbose = old_verbose
+    end
+
+    assert_equal uri, endpoint
+
+    assert_equal "Getting SRV record failed: timeout!\n", @ui.output
+
+    dns.verify
+  end
+
   def test_cache_update_path
     uri = URI 'http://example/file'
     path = File.join @tempdir, 'file'


### PR DESCRIPTION
Feedback in case of problems with DNS configuration which can cause long timeout