### PR TITLE
Remove shared libraries before copying them into place

### DIFF
--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -49,7 +49,7 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
             FileUtils.mkdir_p lib_dir
             entries = Dir.entries(tmp_dest) - %w[. ..]
             entries = entries.map { |entry| File.join tmp_dest, entry }
-            FileUtils.cp_r entries, lib_dir
+            FileUtils.cp_r entries, lib_dir, :remove_destination => true
           end
 
           FileEntry.new(tmp_dest).traverse do |ent|


### PR DESCRIPTION
Fixes issue #1037

When building an extension that's still loaded into memory, cp_r replaces the file contents of the same inode. Since Linux mmaps shared libs, they will get reloaded but not relocated, leading to corruption of the GOT/PLT.

The fix is to unlink the destination before copying, which creates a new inode and prevents the file from being reloaded.

A test for this would be fairly complicated, but if necessary I can add one.

@dylanahsmith @camilo @csfrancis
