### PR TITLE
Warn if GEM_HOME contains spaces

### DIFF
--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -31,6 +31,11 @@ class Gem::PathSupport
       @home   = @home.gsub(File::ALT_SEPARATOR, File::SEPARATOR)
     end
 
+    if @home.include? ' ' then
+      warn "RubyGems does not support GEM_HOME with spaces " \
+           "and some gems may fail to install"
+    end
+
     self.path = env["GEM_PATH"] || ENV["GEM_PATH"]
 
     @spec_cache_dir =


### PR DESCRIPTION
Since this is known to be broken and hard to fix. https://github.com/rubygems/rubygems/issues/523

Unfortunately, this adds an ugly warning into the test output but I'm not sure how best to suppress this. I'm also happy to have the syntax or wording of the multi-line `warn` improved.
