### PR TITLE
use packaged gem files mode as hint only

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -482,9 +482,6 @@ class Gem::Installer
         next
       end
 
-      mode = File.stat(bin_path).mode
-      FileUtils.chmod mode | 0111, bin_path unless (mode | 0111) == mode
-
       check_executable_overwrite filename
 
       if @wrappers then

--- a/lib/rubygems/installer_test_case.rb
+++ b/lib/rubygems/installer_test_case.rb
@@ -158,6 +158,7 @@ class Gem::InstallerTestCase < Gem::TestCase
   def util_setup_gem(ui = @ui) # HACK fix use_ui to make this automatic
     @spec.files << File.join('lib', 'code.rb')
     @spec.extensions << File.join('ext', 'a', 'mkrf_conf.rb')
+    @spec.executables << File.join('executable')
 
     Dir.chdir @tempdir do
       FileUtils.mkdir_p 'bin'
@@ -196,4 +197,3 @@ class Gem::InstallerTestCase < Gem::TestCase
   end
 
 end
-

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -413,7 +413,11 @@ EOM
   def install_mode filename, mode
     if
       mode & 0111 > 0 ||
-      ( @spec && @spec.executables && @spec.executables.include?(filename) )
+      (
+        @spec &&
+        @spec.executables &&
+        @spec.executables.include?(filename.sub(/^#{@spec.bindir}\//,""))
+      )
     then
       0775
     else

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -370,7 +370,7 @@ EOM
         FileUtils.rm_rf destination
 
         mkdir_options = {}
-        mkdir_options[:mode] = entry.header.mode if entry.directory?
+        mkdir_options[:mode] = 0775
         mkdir =
           if entry.directory? then
             destination
@@ -380,7 +380,8 @@ EOM
 
         FileUtils.mkdir_p mkdir, mkdir_options
 
-        File.open destination, 'wb' do |out|
+        target_mode = entry.header.mode & 0111 > 0 ? 0775 : 0664
+        File.open destination, 'wb', target_mode do |out|
           out.write entry.read
           FileUtils.chmod entry.header.mode, destination
         end if entry.file?

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -428,8 +428,8 @@ EOM
     @spec &&
     @spec.bindir &&
     @spec.executables &&
-    filename.start_with?(@spec.bindir) &&
-    @spec.executables.map { |exe| File.join(@spec.bindir, exe) }.include?(filename)
+    filename.start_with?("#{@spec.bindir}\/") &&
+    @spec.executables.include?(filename.sub("#{@spec.bindir}\/",""))
   end
 
   ##

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -369,8 +369,6 @@ EOM
 
         FileUtils.rm_rf destination
 
-        mkdir_options = {}
-        mkdir_options[:mode] = 0775
         mkdir =
           if entry.directory? then
             destination
@@ -378,7 +376,7 @@ EOM
             File.dirname destination
           end
 
-        FileUtils.mkdir_p mkdir, mkdir_options
+        FileUtils.mkdir_p mkdir, :mode => 0775
 
         if entry.file?
           target_mode = install_mode entry.full_name, entry.header.mode

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -413,16 +413,23 @@ EOM
   def install_mode filename, mode
     if
       mode & 0111 > 0 ||
-      (
-        @spec &&
-        @spec.executables &&
-        @spec.executables.include?(filename.sub(/^#{@spec.bindir}\//,""))
-      )
+      file_is_executable(filename)
     then
       0775
     else
       0664
     end
+  end
+
+  ##
+  # Check if the given file is listed in specification executables list
+
+  def file_is_executable filename
+    @spec &&
+    @spec.bindir &&
+    @spec.executables &&
+    filename.start_with?(@spec.bindir) &&
+    @spec.executables.map { |exe| File.join(@spec.bindir, exe) }.include?(filename)
   end
 
   ##

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -410,7 +410,7 @@ EOM
   end
 
   ##
-  # Returns file mode for installating +filename+
+  # Returns file mode for installing +filename+
 
   def install_mode filename, mode
     if

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1637,8 +1637,12 @@ gem 'other', version
 
     @installer.unpack dest
 
-    assert_path_exists File.join dest, 'lib', 'code.rb'
-    assert_path_exists File.join dest, 'bin', 'executable'
+    lib_file = File.join dest, 'lib', 'code.rb'
+    bin_file = File.join dest, 'bin', 'executable'
+    assert_path_exists lib_file
+    assert_path_exists bin_file
+    refute File.executable?(lib_file), "Expected path '#{lib_file}' not to be executable"
+    assert File.executable?(bin_file), "Expected path '#{bin_file}' to be executable"
   end
 
   def test_write_build_info_file


### PR DESCRIPTION
proposal to fix one of the problems in #1040, this allows systems `umask` to be applied properly to extracted gem files

to fully avoid #1002 it would be required to know `spec.executables` so the `775` could be forced on those files
