### PR TITLE
Drop `rescue TSort::Cyclic` from `Gem::{DependencyList,RequestSet}#tsort_each_child`.

### DIFF
--- a/lib/rubygems/dependency_list.rb
+++ b/lib/rubygems/dependency_list.rb
@@ -219,11 +219,7 @@ class Gem::DependencyList
     dependencies.each do |dep|
       specs.each do |spec|
         if spec.satisfies_requirement? dep then
-          begin
-            yield spec
-          rescue TSort::Cyclic
-            # do nothing
-          end
+          yield spec
           break
         end
       end

--- a/lib/rubygems/request_set.rb
+++ b/lib/rubygems/request_set.rb
@@ -403,10 +403,7 @@ class Gem::RequestSet
               "Unresolved dependency found during sorting - #{dep} (requested by #{node.spec.full_name})"
       end
 
-      begin
-        yield match
-      rescue TSort::Cyclic
-      end
+      yield match
     end
   end
 


### PR DESCRIPTION
`TSort::Cyclic` is only raised from `TSort.tsort_each`, not from `TSort#strongly_connected_components` which is used here. Even then, the exception is raised outside the child iterator and thus cannot be rescued in `#tsort_each_child`.

This is only a cosmetic change that doesn't affect compatibility.

Originally introduced in f554bc5 and a1d35cd, respectively.
