### PR TITLE
Don't define MirrorCommand if already defined.

### DIFF
--- a/lib/rubygems/commands/mirror_command.rb
+++ b/lib/rubygems/commands/mirror_command.rb
@@ -1,23 +1,25 @@
 require 'rubygems/command'
 
-class Gem::Commands::MirrorCommand < Gem::Command
-  def initialize
-    super('mirror', 'Mirror all gem files (requires rubygems-mirror)')
-    begin
-      Gem::Specification.find_by_name('rubygems-mirror').activate
-    rescue Gem::LoadError
-      # no-op
+unless defined? Gem::Commands::MirrorCommand
+  class Gem::Commands::MirrorCommand < Gem::Command
+    def initialize
+      super('mirror', 'Mirror all gem files (requires rubygems-mirror)')
+      begin
+        Gem::Specification.find_by_name('rubygems-mirror').activate
+      rescue Gem::LoadError
+        # no-op
+      end
     end
-  end
 
-  def description # :nodoc:
-    <<-EOF
+    def description # :nodoc:
+      <<-EOF
 The mirror command has been moved to the rubygems-mirror gem.
-    EOF
-  end
+      EOF
+    end
 
-  def execute
-    alert_error "Install the rubygems-mirror gem for the mirror command"
-  end
+    def execute
+      alert_error "Install the rubygems-mirror gem for the mirror command"
+    end
 
+  end
 end


### PR DESCRIPTION
Hi.  I found that "gem mirror" subcommand doesn't work.

```
% bin/ruby -v
ruby 2.2.0dev (2014-10-10 trunk 47863) [x86_64-linux]
% bin/gem mirror
ERROR:  Install the rubygems-mirror gem for the mirror command
```

gem mirror subcommand needs rubygems-mirror gem.
So I installed it but the error still occur.

```
% bin/gem install rubygems-mirror
Fetching: net-http-persistent-2.9.4.gem (100%)
Successfully installed net-http-persistent-2.9.4
Fetching: rubygems-mirror-1.0.1.gem (100%)
Successfully installed rubygems-mirror-1.0.1
Parsing documentation for net-http-persistent-2.9.4
Installing ri documentation for net-http-persistent-2.9.4
Parsing documentation for rubygems-mirror-1.0.1
Installing ri documentation for rubygems-mirror-1.0.1
Done installing documentation for net-http-persistent, rubygems-mirror after 0 seconds
2 gems installed
% bin/gem mirror
ERROR:  Install the rubygems-mirror gem for the mirror command
```

Gem::Commands::MirrorCommand#execute shows the error message.
It seems that this method is defined by rubygems-mirror gem but
redefined by rubygems/commands/mirror_command.rb.

```
% bin/ruby -v bin/gem mirror
ruby 2.2.0dev (2014-10-10 trunk 47863) [x86_64-linux]
/home/ruby/tst1/lib/ruby/2.2.0/rubygems/commands/mirror_command.rb:4: warning: method redefined; discarding old initialize
/home/ruby/tst1/lib/ruby/gems/2.2.0/gems/rubygems-mirror-1.0.1/lib/rubygems/mirror/command.rb:8: warning: previous definition of initialize was here
/home/ruby/tst1/lib/ruby/2.2.0/rubygems/commands/mirror_command.rb:13: warning: method redefined; discarding old description
/home/ruby/tst1/lib/ruby/gems/2.2.0/gems/rubygems-mirror-1.0.1/lib/rubygems/mirror/command.rb:12: warning: previous definition of description was here
/home/ruby/tst1/lib/ruby/2.2.0/rubygems/commands/mirror_command.rb:19: warning: method redefined; discarding old execute
/home/ruby/tst1/lib/ruby/gems/2.2.0/gems/rubygems-mirror-1.0.1/lib/rubygems/mirror/command.rb:26: warning: previous definition of execute was here
...
ERROR:  Install the rubygems-mirror gem for the mirror command
```

So it can be fixed by rubygems/commands/mirror_command.rb doesn't redefine the class if it is already defined.

After the fix applied, the error gone.

```
% bin/gem mirror
ERROR:  While executing gem ... (RuntimeError)
    Config file /home/akr/.gem/.mirrorrc not found
```
