### PR TITLE
improved required/recommended attributes

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -383,6 +383,8 @@ class Gem::Specification < Gem::BasicSpecification
   attr_reader :description
 
   ##
+  # :category: Recommended gemspec attributes
+  #
   # A contact email address (or addresses) for this gem
   #
   # Usage:
@@ -393,6 +395,8 @@ class Gem::Specification < Gem::BasicSpecification
   attr_accessor :email
 
   ##
+  # :category: Recommended gemspec attributes
+  #
   # The URL of this gem's home page
   #
   # Usage:

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2601,7 +2601,7 @@ http://opensource.org/licenses/alphabetical
 
     # Warnings
 
-    %w[author description email homepage summary].each do |attribute|
+    %w[author email homepage summary].each do |attribute|
       value = self.send attribute
       warning "no #{attribute} specified" if value.nil? or value.empty?
     end

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2370,8 +2370,6 @@ duplicate dependency on b (>= 1.2.3), (~> 1.2) use:
         @a1.validate
       end
 
-      assert_match "#{w}:  no description specified\n", @ui.error, "error"
-
       @ui = Gem::MockGemUi.new
       @a1.summary = "this is my summary"
       @a1.description = @a1.summary


### PR DESCRIPTION
according to http://guides.rubygems.org/specification-reference/#description `description` is not required - removed annoying warning
