### PR TITLE
Suggest a runnable gem pristine command

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -65,7 +65,7 @@ class Gem::BasicSpecification
       @ignored = true
 
       warn "Ignoring #{full_name} because its extensions are not built.  " +
-           "Try: gem pristine #{full_name}"
+           "Try: gem pristine #{name} --version #{version}"
       return false
     end
 

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -895,7 +895,7 @@ class TestGem < Gem::TestCase
     end
 
     expected = "Ignoring ext-1 because its extensions are not built.  " +
-               "Try: gem pristine ext-1\n"
+               "Try: gem pristine ext --version 1\n"
 
     assert_equal expected, err
   end

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1353,7 +1353,7 @@ dependencies: []
     end
 
     expected = "Ignoring ext-1 because its extensions are not built.  " +
-               "Try: gem pristine ext-1\n"
+               "Try: gem pristine ext --version 1\n"
 
     assert_equal expected, err
   end

--- a/test/rubygems/test_gem_stub_specification.rb
+++ b/test/rubygems/test_gem_stub_specification.rb
@@ -55,7 +55,7 @@ class TestStubSpecification < Gem::TestCase
       end
 
       expected = "Ignoring stub_e-2 because its extensions are not built.  " +
-                 "Try: gem pristine stub_e-2\n"
+                 "Try: gem pristine stub_e --version 2\n"
 
       assert_equal expected, err
     end


### PR DESCRIPTION
When warning about missing extensions, suggest a `gem pristine` command that is ready to be run. For example, the missing extensions warning for puma v2.9.1 was `Try: gem pristine puma-2.9.1`, which failed. This changes the suggestion to `Try: gem pristine puma --version 2.9.1`, which succeeds.
