### PR TITLE
Don't touch the binary when not needed.

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -421,8 +421,8 @@ class Gem::Installer
         next
       end
 
-      mode = File.stat(bin_path).mode | 0111
-      FileUtils.chmod mode, bin_path
+      mode = File.stat(bin_path).mode
+      FileUtils.chmod mode | 0111, bin_path unless (mode | 0111) == mode
 
       check_executable_overwrite filename
 


### PR DESCRIPTION
This might cause issues, when Bundler uses the git repository, but the
repository is read-only. In such case, although everything is in correct
state, the execution fails with 'Errno::EPERM: Operation not permitted @
chmod_internal' error.
