### PR TITLE
Fix platform matching

### DIFF
--- a/lib/rubygems/resolver/installer_set.rb
+++ b/lib/rubygems/resolver/installer_set.rb
@@ -60,7 +60,7 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
     found = found.select do |s|
       Gem::Source::SpecificFile === s.source or
         Gem::Platform::RUBY == s.platform or
-        Gem::Platform.local === s.platform
+        Gem::Platform.local =~ s.platform
     end
 
     if found.empty? then


### PR DESCRIPTION
`s.platform` is a String, so the method `Gem::Platform#=~` should be used instead of `Gem::Platform#===`.

in my case:

```
Gem::Platform.local: #<Gem::Platform:0xdbda70 @cpu="arm", @os="linux", @version=nil>
s.platform.class: String
s.platform: arm-linux
Gem::Platform::RUBY: ruby
```
