### PR TITLE
backport r48265 without to using refinements

### DIFF
--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -352,6 +352,10 @@ class Gem::RemoteFetcher
     uri.scheme.downcase == 'https'
   end
 
+  def close_all
+    @pools.each_value {|pool| pool.close_all}
+  end
+
   protected
 
   # we have our own signing code here to avoid a dependency on the aws-sdk gem

--- a/lib/rubygems/request/connection_pools.rb
+++ b/lib/rubygems/request/connection_pools.rb
@@ -28,6 +28,10 @@ class Gem::Request::ConnectionPools # :nodoc:
     end
   end
 
+  def close_all
+    @pools.each_value {|pool| pool.close_all}
+  end
+
   private
 
   ##

--- a/lib/rubygems/request/http_pool.rb
+++ b/lib/rubygems/request/http_pool.rb
@@ -23,6 +23,15 @@ class Gem::Request::HTTPPool # :nodoc:
     @queue.push connection
   end
 
+  def close_all
+    until @queue.empty?
+      if connection = @queue.pop(true) and connection.started?
+        connection.finish
+      end
+    end
+    @queue.push(nil)
+  end
+
   private
 
   def make_connection


### PR DESCRIPTION
I extracted patch for connection leak from https://github.com/ruby/ruby/commit/f6616071dc4089b772d3dcb6c1031653fb4d2054 . original patch used `refinements`. but rubygems still support Ruby 1.8 and 1.9.

this pull request fixes connection leak on all versions of Ruby.
