### PR TITLE
stubs are already sorted, so we don't have to resort

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -709,8 +709,6 @@ class Gem::Specification < Gem::BasicSpecification
       specs = {}
       Gem.loaded_specs.each_value{|s| specs[s] = true}
       @@all.each{|s| s.activated = true if specs[s]}
-
-      _resort!(@@all)
     end
     @@all
   end


### PR DESCRIPTION
The stub specifications and the regular specifications are sorted in the
same way.  Since the list of full specifications is based on the list of
already sorted stub specifications, there is no need to sort the full
specs.
