### PR TITLE
Small reliability improvements to pristine command

### DIFF
--- a/lib/rubygems/commands/pristine_command.rb
+++ b/lib/rubygems/commands/pristine_command.rb
@@ -109,6 +109,11 @@ extensions will be restored.
         next
       end
 
+      if spec.bundled_gem_in_old_ruby?
+        say "Skipped #{spec.full_name}, it is bundled with old Ruby"
+        next
+      end
+
       unless spec.extensions.empty? or options[:extensions] then
         say "Skipped #{spec.full_name}, it needs to compile an extension"
         next

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1477,6 +1477,16 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   ##
+  # Used to detect if the gem is bundled in older version of Ruby, but not
+  # detectable as default gem (see BasicSpecification#default_gem?).
+
+  def bundled_gem_in_old_ruby?
+    !default_gem? &&
+      RUBY_VERSION < "2.0.0" &&
+      summary == "This #{name} is bundled with Ruby"
+  end
+
+  ##
   # Returns the full path to the cache directory containing this
   # spec's cached gem.
 

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -1035,6 +1035,37 @@ Also, a list:
     Zlib::Deflate.deflate data
   end
 
+  def util_set_RUBY_VERSION(version, patchlevel = nil, revision = nil)
+    if Gem.instance_variables.include? :@ruby_version or
+       Gem.instance_variables.include? '@ruby_version' then
+      Gem.send :remove_instance_variable, :@ruby_version
+    end
+
+    @RUBY_VERSION    = RUBY_VERSION
+    @RUBY_PATCHLEVEL = RUBY_PATCHLEVEL if defined?(RUBY_PATCHLEVEL)
+    @RUBY_REVISION   = RUBY_REVISION   if defined?(RUBY_REVISION)
+
+    Object.send :remove_const, :RUBY_VERSION
+    Object.send :remove_const, :RUBY_PATCHLEVEL if defined?(RUBY_PATCHLEVEL)
+    Object.send :remove_const, :RUBY_REVISION   if defined?(RUBY_REVISION)
+
+    Object.const_set :RUBY_VERSION,    version
+    Object.const_set :RUBY_PATCHLEVEL, patchlevel if patchlevel
+    Object.const_set :RUBY_REVISION,   revision   if revision
+  end
+
+  def util_restore_RUBY_VERSION
+    Object.send :remove_const, :RUBY_VERSION
+    Object.send :remove_const, :RUBY_PATCHLEVEL if defined?(RUBY_PATCHLEVEL)
+    Object.send :remove_const, :RUBY_REVISION   if defined?(RUBY_REVISION)
+
+    Object.const_set :RUBY_VERSION,    @RUBY_VERSION
+    Object.const_set :RUBY_PATCHLEVEL, @RUBY_PATCHLEVEL if
+      defined?(@RUBY_PATCHLEVEL)
+    Object.const_set :RUBY_REVISION,   @RUBY_REVISION   if
+      defined?(@RUBY_REVISION)
+  end
+
   ##
   # Is this test being run on a Windows platform?
 

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1551,37 +1551,6 @@ You may need to `gem install -g` to install missing gems
     @abin_path = File.join spec.full_gem_path, spec.bindir, 'abin'
   end
 
-  def util_set_RUBY_VERSION(version, patchlevel = nil, revision = nil)
-    if Gem.instance_variables.include? :@ruby_version or
-       Gem.instance_variables.include? '@ruby_version' then
-      Gem.send :remove_instance_variable, :@ruby_version
-    end
-
-    @RUBY_VERSION    = RUBY_VERSION
-    @RUBY_PATCHLEVEL = RUBY_PATCHLEVEL if defined?(RUBY_PATCHLEVEL)
-    @RUBY_REVISION   = RUBY_REVISION   if defined?(RUBY_REVISION)
-
-    Object.send :remove_const, :RUBY_VERSION
-    Object.send :remove_const, :RUBY_PATCHLEVEL if defined?(RUBY_PATCHLEVEL)
-    Object.send :remove_const, :RUBY_REVISION   if defined?(RUBY_REVISION)
-
-    Object.const_set :RUBY_VERSION,    version
-    Object.const_set :RUBY_PATCHLEVEL, patchlevel if patchlevel
-    Object.const_set :RUBY_REVISION,   revision   if revision
-  end
-
-  def util_restore_RUBY_VERSION
-    Object.send :remove_const, :RUBY_VERSION
-    Object.send :remove_const, :RUBY_PATCHLEVEL if defined?(RUBY_PATCHLEVEL)
-    Object.send :remove_const, :RUBY_REVISION   if defined?(RUBY_REVISION)
-
-    Object.const_set :RUBY_VERSION,    @RUBY_VERSION
-    Object.const_set :RUBY_PATCHLEVEL, @RUBY_PATCHLEVEL if
-      defined?(@RUBY_PATCHLEVEL)
-    Object.const_set :RUBY_REVISION,   @RUBY_REVISION   if
-      defined?(@RUBY_REVISION)
-  end
-
   def util_remove_interrupt_command
     Gem::Commands.send :remove_const, :InterruptCommand if
       Gem::Commands.const_defined? :InterruptCommand

--- a/test/rubygems/test_gem_commands_pristine_command.rb
+++ b/test/rubygems/test_gem_commands_pristine_command.rb
@@ -417,6 +417,29 @@ class TestGemCommandsPristineCommand < Gem::TestCase
     assert_empty(@ui.error)
   end
 
+  def test_execute_bundled_gem_on_old_rubies
+    util_set_RUBY_VERSION '1.9.3', 551
+
+    util_spec 'bigdecimal', '1.1.0' do |s|
+      s.summary = "This bigdecimal is bundled with Ruby"
+    end
+
+    @cmd.options[:args] = %w[bigdecimal]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    assert_equal([
+      "Restoring gems to pristine condition...",
+      "Skipped bigdecimal-1.1.0, it is bundled with old Ruby"
+    ], @ui.output.split("\n"))
+
+    assert_empty @ui.error
+  ensure
+    util_restore_RUBY_VERSION
+  end
+
   def test_handle_options
     @cmd.handle_options %w[]
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3010,6 +3010,18 @@ end
     assert_equal ["default-2.0.0.0"], Gem::Specification.map(&:full_name)
   end
 
+  def test_detect_bundled_gem_in_old_ruby
+    util_set_RUBY_VERSION '1.9.3', 551
+
+    spec = new_spec 'bigdecimal', '1.1.0' do |s|
+      s.summary = "This bigdecimal is bundled with Ruby"
+    end
+
+    assert spec.bundled_gem_in_old_ruby?
+  ensure
+    util_restore_RUBY_VERSION
+  end
+
   def util_setup_deps
     @gem = util_spec "awesome", "1.0" do |awesome|
       awesome.add_runtime_dependency "bonobo", []


### PR DESCRIPTION
Three small improvements in three commits, of which the first two are bug fixes and the third is an improvement:
1. skip pristine install for non-cached gem unknown at remote source
2. fetch gem to proper cache dir when gem path is not gem home
3. skip pristine install for old Ruby bundled gems

Details and motivation are in the commit messages.

I'm unsure if the 3rd change should be made available to other gem commands as well. I don't know if that would cause unexpected effects.
