### PR TITLE
Refactor: replace `partition` with `reject` as selected elements are not used

### DIFF
--- a/lib/rubygems/commands/uninstall_command.rb
+++ b/lib/rubygems/commands/uninstall_command.rb
@@ -124,7 +124,7 @@ that is a dependency of an existing gem.  You can use the
   end
 
   def uninstall_all
-    _, specs = Gem::Specification.partition { |spec| spec.default_gem? }
+    specs = Gem::Specification.reject { |spec| spec.default_gem? }
 
     specs.each do |spec|
       options[:version] = spec.version


### PR DESCRIPTION
It's unnecessary to use `Enumerable#partition` when you're only using the elements where the predicate is false.
