### PR TITLE
Implementation of cache for the RemoteFetcher

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -328,7 +328,8 @@ module Gem
 
   # Initialize the filesystem paths to use from +env+.
   # +env+ is a hash-like object (typically ENV) that
-  # is queried for 'GEM_HOME', 'GEM_PATH', and 'GEM_SPEC_CACHE'
+  # is queried for 'GEM_HOME', 'GEM_PATH', 'GEM_SPEC_CACHE', and
+  # 'GEM_FETCH_CACHE'
 
   def self.paths=(env)
     clear_paths
@@ -351,6 +352,10 @@ module Gem
 
   def self.spec_cache_dir
     paths.spec_cache_dir
+  end
+
+  def self.fetch_cache_dir
+    paths.fetch_cache_dir
   end
 
   ##

--- a/lib/rubygems/commands/environment_command.rb
+++ b/lib/rubygems/commands/environment_command.rb
@@ -121,6 +121,8 @@ lib/rubygems/defaults/operating_system.rb
 
     out << "  - SPEC CACHE DIRECTORY: #{Gem.spec_cache_dir}\n"
 
+    out << "  - FETCH CACHE DIRECTORY: #{Gem.fetch_cache_dir}\n"
+
     out << "  - SYSTEM CONFIGURATION DIRECTORY: #{Gem::ConfigFile::SYSTEM_CONFIG_PATH}\n"
 
     out << "  - RUBYGEMS PLATFORMS:\n"

--- a/lib/rubygems/defaults.rb
+++ b/lib/rubygems/defaults.rb
@@ -27,7 +27,7 @@ module Gem
   # specified in the environment
 
   def self.default_fetch_cache_dir
-    File.join Gem.user_home, 'gem', 'fetch_cache'
+    File.join Gem.user_home, '.gem', 'fetch_cache'
   end
 
   ##

--- a/lib/rubygems/defaults.rb
+++ b/lib/rubygems/defaults.rb
@@ -19,7 +19,15 @@ module Gem
   # specified in the environment
 
   def self.default_spec_cache_dir
-    File.join Gem.user_home, '.gem', 'specs'
+    default_fetch_cache_dir
+  end
+
+  ##
+  # Default fetch cache directory path to be used if an alternate value is not
+  # specified in the environment
+
+  def self.default_fetch_cache_dir
+    File.join Gem.user_home, 'gem', 'fetch_cache'
   end
 
   ##

--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -1,7 +1,12 @@
 ##
 #
-# Gem::PathSupport facilitates the GEM_HOME and GEM_PATH environment settings
+# Gem::PathSupport facilitates the GEM_* environment environment settings
 # to the rest of RubyGems.
+#
+# * GEM_HOME - path for managing gems
+# * GEM_PATH - search path for finding gems
+# * GEM_SPEC_CACHE - local file cache for /latest_specs.4.8
+# * GEM_FETCH_CACHE - local file cache for remote .gem files
 #
 class Gem::PathSupport
   ##
@@ -13,8 +18,8 @@ class Gem::PathSupport
   attr_reader :path
 
   ##
-  # Directory with spec cache
-  attr_reader :spec_cache_dir # :nodoc:
+  # Directory with fetch cache
+  attr_reader :fetch_cache_dir # :nodoc:
 
   ##
   #
@@ -30,14 +35,13 @@ class Gem::PathSupport
     if File::ALT_SEPARATOR then
       @home   = @home.gsub(File::ALT_SEPARATOR, File::SEPARATOR)
     end
+    @fetch_cache_dir = compute_fetch_cache_dir( @env, @home )
 
     self.path = env["GEM_PATH"] || ENV["GEM_PATH"]
+  end
 
-    @spec_cache_dir =
-      env["GEM_SPEC_CACHE"] || ENV["GEM_SPEC_CACHE"] ||
-        Gem.default_spec_cache_dir
-
-    @spec_cache_dir = @spec_cache_dir.dup.untaint
+  def spec_cache_dir
+    @fetch_cache_dir
   end
 
   private
@@ -47,6 +51,7 @@ class Gem::PathSupport
 
   def home=(home)
     @home = home.to_s
+    @fetch_cache_dir = compute_fetch_cache_dir( @env, @home )
   end
 
   ##
@@ -83,5 +88,20 @@ class Gem::PathSupport
     end
 
     @path = gem_path.uniq
+  end
+
+  ##
+  # Update the Gem Fetcher cache directory (as reported by Gem.fetch_cache_dir)
+  def compute_fetch_cache_dir( env = @env, home = @home )
+    cache_dir = env["GEM_FETCH_CACHE"] || ENV["GEM_FETCH_CACHE"] ||
+                env["GEM_SPEC_CACHE"] || ENV["GEM_SPEC_CACHE"]
+    unless cache_dir then
+      cache_dir = if File.writable? home then
+        File.join home, 'fetch_cache'
+      else
+        File.join Gem.user_dir, 'fetch_cache'
+      end
+    end
+    cache_dir = cache_dir.dup.untaint
   end
 end

--- a/lib/rubygems/remote_fetcher_cache.rb
+++ b/lib/rubygems/remote_fetcher_cache.rb
@@ -75,14 +75,11 @@ class Gem::RemoteFetcherCache
   # Returns the local path to write +uri+ to.
 
   def cache_path_for(uri)
+    uri = URI.parse uri unless URI::Generic === uri
     File.join fetch_cache_dir, "#{uri.host}%#{uri.port}", escape_path(uri)
   end
 
-  ##
-  # Returns the local directory to write +uri+ to.
-  def cache_dir(uri)
-    File.dirname cache_path_for( uri )
-  end
+  private
 
   ##
   # escape_path
@@ -92,7 +89,6 @@ class Gem::RemoteFetcherCache
     escaped_path.untaint
   end
 
-  private
 
   ##
   # Creates the cache dir if it doesn't exist.

--- a/lib/rubygems/remote_fetcher_cache.rb
+++ b/lib/rubygems/remote_fetcher_cache.rb
@@ -1,0 +1,74 @@
+require 'uri'
+require 'fileutils'
+require 'rubygems/path_support'
+
+##
+# A RemoteFetcherCache keeps track of remote uris and their local cached
+# versions.
+
+class Gem::RemoteFetcherCache
+  def initialize(paths = Gem.paths)
+    @paths = paths
+    @update_cache = nil
+  end
+
+  def fetch_cache_dir
+    @paths.fetch_cache_dir
+  end
+
+  def fetch(uri, mtime = Time.now.to_i)
+    cache_path = cache_path_for uri
+    return nil unless File.exist? cache_path
+    Gem.read_binary cache_path
+  end
+
+  def store(uri, data, mtime = Time.now.to_i)
+    return nil unless update_cache?
+    cache_path = cache_path_for(uri)
+    dirname = File.basename(cache_path)
+    File.mkdir_p(dirname) unless File.directory? dirname
+    File.open(cache_path, 'wb') do |io|
+      io.flock(File::LOCK_EX)
+      io.write data
+    end
+    File.utime(mtime,mtime,cache_path)
+  end
+
+  def include?(uri)
+    File.exist? cache_path_for(uri)
+  end
+
+  ##
+  # Returns the local path to write +uri+ to.
+
+  def cache_path_for(uri)
+    File.join fetch_cache_dir, "#{uri.host}%#{uri.port}", escape_path(uri)
+  end
+
+  ##
+  # Returns the local directory to write +uri+ to.
+  def cache_dir(uri)
+    File.dirname cache_path_for( uri )
+  end
+
+  ##
+  # escape_path
+  def escape_path(uri)
+    # Correct for windows paths
+    escaped_path = uri.path.sub(/^\/([a-z]):\//i, '/\\1-/')
+    escaped_path.untaint
+  end
+
+  ##
+  # Returns true when it is possible and safe to update the cache directory.
+
+  def update_cache?
+    @update_cache ||=
+      begin
+        File.stat(fetch_cache_dir).uid == Process.uid
+      rescue Errno::ENOENT
+        false
+      end
+  end
+
+end

--- a/lib/rubygems/remote_fetcher_cache.rb
+++ b/lib/rubygems/remote_fetcher_cache.rb
@@ -10,6 +10,7 @@ class Gem::RemoteFetcherCache
   def initialize(paths = Gem.paths)
     @paths = paths
     @update_cache = nil
+    FileUtils.mkdir_p @paths.fetch_cache_dir unless update_cache?
   end
 
   def fetch_cache_dir

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -252,7 +252,7 @@ class Gem::TestCase < MiniTest::Unit::TestCase
 
     @gemhome  = File.join @tempdir, 'gemhome'
     @userhome = File.join @tempdir, 'userhome'
-    ENV["GEM_SPEC_CACHE"] = File.join @tempdir, 'spec_cache'
+    ENV["GEM_FETCH_CACHE"] = File.join @tempdir, 'fetch_cache'
 
     @orig_ruby = if ENV['RUBY'] then
                    ruby = Gem.ruby

--- a/lib/rubygems/test_utilities.rb
+++ b/lib/rubygems/test_utilities.rb
@@ -31,6 +31,7 @@ class Gem::FakeFetcher
     @data = {}
     @paths = []
     @api_endpoints = {}
+    @cache = Gem::RemoteFetcherCache.new
   end
 
   def api_endpoint(uri)
@@ -57,7 +58,9 @@ class Gem::FakeFetcher
   end
 
   def fetch_path path, mtime = nil, head = false
-    data = find_data(path)
+    data = @cache.fetch(path, mtime) {
+      find_data(path)
+    }
 
     if data.respond_to?(:call) then
       data.call

--- a/test/rubygems/test_gem_commands_environment_command.rb
+++ b/test/rubygems/test_gem_commands_environment_command.rb
@@ -38,6 +38,7 @@ class TestGemCommandsEnvironmentCommand < Gem::TestCase
     assert_match %r|"gemcutter_key" => "\*\*\*\*"|, @ui.output
     assert_match %r|:verbose => |, @ui.output
     assert_match %r|REMOTE SOURCES:|, @ui.output
+    assert_match %r|SPEC CACHE DIRECTORY:|, @ui.output
 
     assert_match %r|- SHELL PATH:|,     @ui.output
     assert_match %r|- /usr/local/bin$|, @ui.output

--- a/test/rubygems/test_gem_commands_environment_command.rb
+++ b/test/rubygems/test_gem_commands_environment_command.rb
@@ -38,6 +38,7 @@ class TestGemCommandsEnvironmentCommand < Gem::TestCase
     assert_match %r|"gemcutter_key" => "\*\*\*\*"|, @ui.output
     assert_match %r|:verbose => |, @ui.output
     assert_match %r|REMOTE SOURCES:|, @ui.output
+    assert_match %r|FETCH CACHE DIRECTORY:|, @ui.output
     assert_match %r|SPEC CACHE DIRECTORY:|, @ui.output
 
     assert_match %r|- SHELL PATH:|,     @ui.output

--- a/test/rubygems/test_gem_path_support.rb
+++ b/test/rubygems/test_gem_path_support.rb
@@ -65,8 +65,9 @@ class TestGemPathSupport < Gem::TestCase
     ENV["GEM_PATH"].split(File::PATH_SEPARATOR)
   end
 
-  def test_initialize_spec
+  def test_initialize_spec_cache
     ENV["GEM_SPEC_CACHE"] = nil
+    ENV["GEM_FETCH_CACHE"] = nil
 
     ps = Gem::PathSupport.new
     assert_equal Gem.default_spec_cache_dir, ps.spec_cache_dir
@@ -81,4 +82,23 @@ class TestGemPathSupport < Gem::TestCase
     ps = Gem::PathSupport.new "GEM_SPEC_CACHE" => "foo"
     assert_equal "foo", ps.spec_cache_dir
   end
+
+  def test_initialize_fetch_cache
+    ENV["GEM_SPEC_CACHE"] = nil
+    ENV["GEM_FETCH_CACHE"] = nil
+
+    ps = Gem::PathSupport.new
+    assert_equal Gem.default_fetch_cache_dir, ps.fetch_cache_dir
+
+    ENV["GEM_FETCH_CACHE"] = 'bar'
+
+    ps = Gem::PathSupport.new
+    assert_equal ENV["GEM_FETCH_CACHE"], ps.fetch_cache_dir
+
+    ENV["GEM_FETCH_CACHE"] = File.join @tempdir, 'fetch_cache'
+
+    ps = Gem::PathSupport.new "GEM_FETCH_CACHE" => "foo"
+    assert_equal "foo", ps.fetch_cache_dir
+  end
+
 end

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -96,6 +96,8 @@ gems:
     # REFACTOR: copied from test_gem_dependency_installer.rb
     @gems_dir = File.join @tempdir, 'gems'
     @cache_dir = File.join @gemhome, "cache"
+    @fetch_cache_dir = File.join @tempdir, 'fetch_cache'
+    ENV["GEM_FETCH_CACHE"] = @fetch_cache_dir
     FileUtils.mkdir @gems_dir
 
     # TODO: why does the remote fetcher need it written to disk?

--- a/test/rubygems/test_gem_remote_fetcher_cache.rb
+++ b/test/rubygems/test_gem_remote_fetcher_cache.rb
@@ -1,0 +1,29 @@
+require 'rubygems/test_case'
+require 'rubygems/remote_fetcher_cache'
+require 'fileutils'
+
+class TestGemRemoteFetcherCache < Gem::TestCase
+
+  def setup
+    super
+    @fetcher = Gem::RemoteFetcherCache.new
+  end
+
+  def test_escapes_windows_paths
+    uri = URI.parse("file:///C:/WINDOWS/Temp/gem_repo")
+    root = @fetcher.fetch_cache_dir
+    cache_path = @fetcher.cache_path_for(uri).gsub(root, '')
+    assert cache_path !~ /:/, "#{cache_path} should not contain a :"
+  end
+
+  def test_update_cache_eh
+    assert @fetcher.update_cache?
+  end
+
+  def test_update_cache_eh_home_nonexistent
+    FileUtils.rmdir Gem.fetch_cache_dir
+
+    refute @fetcher.update_cache?
+  end
+
+end

--- a/test/rubygems/test_gem_remote_fetcher_cache.rb
+++ b/test/rubygems/test_gem_remote_fetcher_cache.rb
@@ -16,14 +16,4 @@ class TestGemRemoteFetcherCache < Gem::TestCase
     assert cache_path !~ /:/, "#{cache_path} should not contain a :"
   end
 
-  def test_update_cache_eh
-    assert @fetcher.update_cache?, "#{@fetcher.fetch_cache_dir} does not exist"
-  end
-
-  def test_update_cache_eh_home_nonexistent
-    FileUtils.rmdir Gem.fetch_cache_dir
-
-    refute @fetcher.update_cache?
-  end
-
 end

--- a/test/rubygems/test_gem_remote_fetcher_cache.rb
+++ b/test/rubygems/test_gem_remote_fetcher_cache.rb
@@ -17,7 +17,7 @@ class TestGemRemoteFetcherCache < Gem::TestCase
   end
 
   def test_update_cache_eh
-    assert @fetcher.update_cache?
+    assert @fetcher.update_cache?, "#{@fetcher.fetch_cache_dir} does not exist"
   end
 
   def test_update_cache_eh_home_nonexistent


### PR DESCRIPTION
## Implementation of Cache for RemoteFetcher

In short, it allows the `RemoteFetcher` to cache all of its requests in the location that was originally used to only by `Gem::Source` to cache the specs to disk.

## Detail list of changes

* creates a new class `RemoteFetcherCache` which is used by the `RemoteFetcher`
* adds a new top level directory in `PathSupport` of `fetch_cache_dir` which is then exposed at the `Gem` level in the same manner as `spec_cache_dir`
* uses an new environment variable `GEM_FETCH_CACHE` which is used to configure `fetch_cache_dir`.
* replaces the spec caching that was done in `Source` and allows `Source` to take advantage of the cache that is now built in to `RemoteFetcher`.
* the existing `spec_cache_dir` methods delegate to the new `fetch_cache_dir` methods
* the existing `GEM_SPEC_CACHE` environment is kept for backwards compatibility and is used to configure `fetch_cache_dir`

##  Todo

* [ ] update guides / external documentation to demonstrate `GEM_FETCH_CACHE`
* [ ] additional testing, please let me of gaps in tests you see.
* [ ] testing against rubygems.org itself.