### PR TITLE
Fix grouped expression warning

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -164,7 +164,7 @@ class Gem::BasicSpecification
         suffixes = Gem.suffixes
         full_require_paths.find do |dir|
           suffixes.find do |suf|
-            File.file? (fullpath = "#{dir}/#{path}#{suf}")
+            File.file?(fullpath = "#{dir}/#{path}#{suf}")
           end
         end ? fullpath : nil
       end


### PR DESCRIPTION
ruby -w printed "rubygems/lib/rubygems/basic_specification.rb:167:
warning: (...) interpreted as grouped expression"
