### PR TITLE
Fix a bug that "gem install" use "ruby" platform rather than specific platform

### DIFF
--- a/lib/rubygems/dependency_installer.rb
+++ b/lib/rubygems/dependency_installer.rb
@@ -218,7 +218,17 @@ class Gem::DependencyInstaller
         tuples, errors = Gem::SpecFetcher.fetcher.search_for_dependency dep
 
         if best_only && !tuples.empty?
-          tuples.sort! { |a,b| b[0].version <=> a[0].version }
+          tuples.sort! do |a,b|
+            if b[0].version == a[0].version
+              if b[0].platform != Gem::Platform::RUBY
+                1
+              else
+                -1
+              end
+            else
+              b[0].version <=> a[0].version
+            end
+          end
           tuples = [tuples.first]
         end
 


### PR DESCRIPTION
"gem install" with "--platform" option should install the specified
platform gem rather than "ruby" platform.

For example, "gem install --platform=x86-mingw32 gtk2" should install
"gtk2-X.Y.Z-x86-mingw32" not "gtk2-X.Y.Z".

How to confirm the problem:

```
% sudo gem install --platform=x86-mingw32 gtk2 --verbose
...
Downloading gem gtk2-2.2.3.gem
GET https://api.rubygems.org/gems/gtk2-2.2.3.gem
```

The command should download "gtk2-2.2.3-x86-mingw32.gem".
