### PR TITLE
Clean up the PathSupport object

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -941,7 +941,7 @@ module Gem
   def self.use_paths(home, *paths)
     paths = nil if paths == [nil]
     paths = paths.first if Array === Array(paths).first
-    self.paths = { "GEM_HOME" => home, "GEM_PATH" => paths }
+    self.paths = { "GEM_HOME" => home, "GEM_PATH" => paths.join(Gem.path_separator) }
   end
 
   ##

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -326,7 +326,7 @@ module Gem
   # lookup files.
 
   def self.paths
-    @paths ||= Gem::PathSupport.new
+    @paths ||= Gem::PathSupport.new(ENV)
   end
 
   # Initialize the filesystem paths to use from +env+.
@@ -335,7 +335,7 @@ module Gem
 
   def self.paths=(env)
     clear_paths
-    @paths = Gem::PathSupport.new env
+    @paths = Gem::PathSupport.new ENV.to_hash.merge(env)
     Gem::Specification.dirs = @paths.path
   end
 

--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -50,9 +50,6 @@ class Gem::PathSupport
 
     gem_path = []
 
-    # FIX: I can't tell wtf this is doing.
-    gpaths ||= (gpaths || "").empty? ? nil : gpaths
-
     if gpaths
       gem_path = gpaths.split(Gem.path_separator)
       # Handle the path_separator being set to a regexp, which will cause

--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -23,8 +23,6 @@ class Gem::PathSupport
   # hashtable, or defaults to ENV, the system environment.
   #
   def initialize(env)
-    @env = env
-
     @home     = env["GEM_HOME"] || Gem.default_dir
 
     if File::ALT_SEPARATOR then

--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -25,7 +25,6 @@ class Gem::PathSupport
   def initialize(env)
     @env = env
 
-    # note 'env' vs 'ENV'...
     @home     = env["GEM_HOME"] || Gem.default_dir
 
     if File::ALT_SEPARATOR then
@@ -52,7 +51,7 @@ class Gem::PathSupport
     gem_path = []
 
     # FIX: I can't tell wtf this is doing.
-    gpaths ||= (ENV['GEM_PATH'] || "").empty? ? nil : ENV["GEM_PATH"]
+    gpaths ||= (gpaths || "").empty? ? nil : gpaths
 
     if gpaths
       gem_path = gpaths.split(Gem.path_separator)

--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -29,7 +29,7 @@ class Gem::PathSupport
       @home   = @home.gsub(File::ALT_SEPARATOR, File::SEPARATOR)
     end
 
-    @path = split_gem_path env["GEM_PATH"]
+    @path = split_gem_path env["GEM_PATH"], @home
 
     @spec_cache_dir = env["GEM_SPEC_CACHE"] || Gem.default_spec_cache_dir
 
@@ -41,7 +41,7 @@ class Gem::PathSupport
   ##
   # Split the Gem search path (as reported by Gem.path).
 
-  def split_gem_path gpaths
+  def split_gem_path gpaths, home
     # FIX: it should be [home, *path], not [*path, home]
 
     gem_path = []
@@ -60,7 +60,7 @@ class Gem::PathSupport
         end
       end
 
-      gem_path << @home
+      gem_path << home
     else
       gem_path = default_path
     end

--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -22,20 +22,20 @@ class Gem::PathSupport
   # Constructor. Takes a single argument which is to be treated like a
   # hashtable, or defaults to ENV, the system environment.
   #
-  def initialize(env=ENV)
+  def initialize(env)
     @env = env
 
     # note 'env' vs 'ENV'...
-    @home     = env["GEM_HOME"] || ENV["GEM_HOME"] || Gem.default_dir
+    @home     = env["GEM_HOME"] || Gem.default_dir
 
     if File::ALT_SEPARATOR then
       @home   = @home.gsub(File::ALT_SEPARATOR, File::SEPARATOR)
     end
 
-    self.path = env["GEM_PATH"] || ENV["GEM_PATH"]
+    self.path = env["GEM_PATH"]
 
     @spec_cache_dir =
-      env["GEM_SPEC_CACHE"] || ENV["GEM_SPEC_CACHE"] ||
+      env["GEM_SPEC_CACHE"] ||
         Gem.default_spec_cache_dir
 
     @spec_cache_dir = @spec_cache_dir.dup.untaint

--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -55,15 +55,11 @@ class Gem::PathSupport
     gpaths ||= (ENV['GEM_PATH'] || "").empty? ? nil : ENV["GEM_PATH"]
 
     if gpaths
-      if gpaths.kind_of?(Array)
-        gem_path = gpaths.dup
-      else
-        gem_path = gpaths.split(Gem.path_separator)
-        # Handle the path_separator being set to a regexp, which will cause
-        # end_with? to error
-        if gpaths =~ /#{Gem.path_separator}\z/
-          gem_path += default_path
-        end
+      gem_path = gpaths.split(Gem.path_separator)
+      # Handle the path_separator being set to a regexp, which will cause
+      # end_with? to error
+      if gpaths =~ /#{Gem.path_separator}\z/
+        gem_path += default_path
       end
 
       if File::ALT_SEPARATOR then

--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -31,11 +31,9 @@ class Gem::PathSupport
       @home   = @home.gsub(File::ALT_SEPARATOR, File::SEPARATOR)
     end
 
-    self.path = env["GEM_PATH"]
+    @path = split_gem_path env["GEM_PATH"]
 
-    @spec_cache_dir =
-      env["GEM_SPEC_CACHE"] ||
-        Gem.default_spec_cache_dir
+    @spec_cache_dir = env["GEM_SPEC_CACHE"] || Gem.default_spec_cache_dir
 
     @spec_cache_dir = @spec_cache_dir.dup.untaint
   end
@@ -43,9 +41,9 @@ class Gem::PathSupport
   private
 
   ##
-  # Set the Gem search path (as reported by Gem.path).
+  # Split the Gem search path (as reported by Gem.path).
 
-  def path=(gpaths)
+  def split_gem_path gpaths
     # FIX: it should be [home, *path], not [*path, home]
 
     gem_path = []
@@ -69,7 +67,7 @@ class Gem::PathSupport
       gem_path = default_path
     end
 
-    @path = gem_path.uniq
+    gem_path.uniq
   end
 
   # Return the default Gem path

--- a/test/rubygems/test_gem_path_support.rb
+++ b/test/rubygems/test_gem_path_support.rb
@@ -21,7 +21,7 @@ class TestGemPathSupport < Gem::TestCase
   end
 
   def test_initialize_home
-    ps = Gem::PathSupport.new "GEM_HOME" => "#{@tempdir}/foo"
+    ps = Gem::PathSupport.new ENV.to_hash.merge("GEM_HOME" => "#{@tempdir}/foo")
 
     assert_equal File.join(@tempdir, "foo"), ps.home
 

--- a/test/rubygems/test_gem_path_support.rb
+++ b/test/rubygems/test_gem_path_support.rb
@@ -39,7 +39,7 @@ class TestGemPathSupport < Gem::TestCase
   end
 
   def test_initialize_path
-    ps = Gem::PathSupport.new ENV.to_hash.merge("GEM_PATH" => %W[#{@tempdir}/foo #{@tempdir}/bar])
+    ps = Gem::PathSupport.new ENV.to_hash.merge("GEM_PATH" => %W[#{@tempdir}/foo #{@tempdir}/bar].join(Gem.path_separator))
 
     assert_equal ENV["GEM_HOME"], ps.home
 
@@ -90,7 +90,7 @@ class TestGemPathSupport < Gem::TestCase
 
   def test_initialize_home_path
     ps = Gem::PathSupport.new("GEM_HOME" => "#{@tempdir}/foo",
-                              "GEM_PATH" => %W[#{@tempdir}/foo #{@tempdir}/bar])
+                              "GEM_PATH" => %W[#{@tempdir}/foo #{@tempdir}/bar].join(Gem.path_separator))
 
     assert_equal File.join(@tempdir, "foo"), ps.home
 

--- a/test/rubygems/test_gem_path_support.rb
+++ b/test/rubygems/test_gem_path_support.rb
@@ -58,7 +58,7 @@ class TestGemPathSupport < Gem::TestCase
                 #{File::PATH_SEPARATOR}
                 #{@tempdir}/bar
                 #{File::PATH_SEPARATOR}].join
-      ps = Gem::PathSupport.new "GEM_PATH" => path
+      ps = Gem::PathSupport.new "GEM_PATH" => path, "GEM_HOME" => ENV["GEM_HOME"]
 
       assert_equal ENV["GEM_HOME"], ps.home
 
@@ -76,7 +76,7 @@ class TestGemPathSupport < Gem::TestCase
               #{File::PATH_SEPARATOR}
               #{@tempdir}/bar
               #{File::PATH_SEPARATOR}].join
-    ps = Gem::PathSupport.new "GEM_PATH" => path
+    ps = Gem::PathSupport.new "GEM_PATH" => path, "GEM_HOME" => ENV["GEM_HOME"]
 
     assert_equal ENV["GEM_HOME"], ps.home
 

--- a/test/rubygems/test_gem_path_support.rb
+++ b/test/rubygems/test_gem_path_support.rb
@@ -12,7 +12,7 @@ class TestGemPathSupport < Gem::TestCase
   end
 
   def test_initialize
-    ps = Gem::PathSupport.new
+    ps = Gem::PathSupport.new ENV
 
     assert_equal ENV["GEM_HOME"], ps.home
 
@@ -39,7 +39,7 @@ class TestGemPathSupport < Gem::TestCase
   end
 
   def test_initialize_path
-    ps = Gem::PathSupport.new "GEM_PATH" => %W[#{@tempdir}/foo #{@tempdir}/bar]
+    ps = Gem::PathSupport.new ENV.to_hash.merge("GEM_PATH" => %W[#{@tempdir}/foo #{@tempdir}/bar])
 
     assert_equal ENV["GEM_HOME"], ps.home
 
@@ -105,12 +105,12 @@ class TestGemPathSupport < Gem::TestCase
   def test_initialize_spec
     ENV["GEM_SPEC_CACHE"] = nil
 
-    ps = Gem::PathSupport.new
+    ps = Gem::PathSupport.new ENV
     assert_equal Gem.default_spec_cache_dir, ps.spec_cache_dir
 
     ENV["GEM_SPEC_CACHE"] = 'bar'
 
-    ps = Gem::PathSupport.new
+    ps = Gem::PathSupport.new ENV
     assert_equal ENV["GEM_SPEC_CACHE"], ps.spec_cache_dir
 
     ENV["GEM_SPEC_CACHE"] = File.join @tempdir, 'spec_cache'


### PR DESCRIPTION
This pull request cleans up the PathSupport object.  It's technically not backwards compatible, but I think the change is extremely low risk.

### Required parameter to PathSupport constructor

First, I changed the constructor to require that something be passed in.  We'll usually pass `ENV` in, though we pass other stuff in the test cases.

### Stop using `ENV` in the object

Now that the constructor requires you to pass something in, I've removed references to `ENV` from inside the object.  It **was** pulling stuff from `ENV` if it couldn't find the info from `env`.  It was essentially doing a hash merge manually.  Since it now requires you to pass the env in, the caller is responsible for merging the hash.  I think this simplifies the implementation and should be less surprising from the user's side, but it is technically not backwards compatible

### Assume `ENV` values are always strings

The object had code to support `ENV` values that are arrays.  But `ENV` values will never be arrays unless someone mutates the `ENV` hash and specifically inserts arrays.  I don't think that's something we should support.