### PR TITLE
speed up require by skipping non-activated specs

### DIFF
--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -60,8 +60,8 @@ module Kernel
     #--
     # TODO request access to the C implementation of this to speed up RubyGems
 
-    spec = Gem::Specification.stubs.find { |s|
-      s.activated? and s.contains_requirable_file? path
+    spec = Gem.loaded_specs.each_value.find { |s|
+      s.contains_requirable_file? path
     }
 
     begin


### PR DESCRIPTION
spec activation always adds the spec to the `loaded_specs` hash.  rather
than looping over every spec on the system and testing whether or not
that spec is activated, just loop over the list of activated specs.
The list of activated specs should be much smaller and we can remove the
`activated?` test because we know they are activated from the fact that
they're in the list.

@fishermanchips can you try this out?