### PR TITLE
Specification#add_runtime_dependency accepts instances of Dependency

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1350,7 +1350,7 @@ class Gem::Specification < Gem::BasicSpecification
                    end
 
     unless dependency.respond_to?(:name) &&
-           dependency.respond_to?(:version_requirements)
+           dependency.respond_to?(:requirement)
       dependency = Gem::Dependency.new(dependency.to_s, requirements, type)
     end
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1080,6 +1080,12 @@ dependencies: []
     assert_equal %w[true gem_name], gem.dependencies.map { |dep| dep.name }
   end
 
+  def test_add_dependency_from_existing_dependency
+    dep  = Gem::Dependency.new("existing_dep", Gem::Requirement.new('> 1'), :runtime)
+    spec = Gem::Specification.new { |s| s.add_dependency dep }
+    assert_equal dep, spec.dependencies.first
+  end
+
   def test_add_dependency_with_type_explicit
     gem = util_spec "awesome", "1.0" do |awesome|
       awesome.add_development_dependency "monkey"


### PR DESCRIPTION
Based on the unless block, it looks like I should be able to pass a `Gem::Dependency`, which has a name and an ivar `@version_requirements`, but no method for it.

It got [deprecated](41bc3129d3976c6ac415241181b902052878a9bd) and should now be `#requirements`

Test Failure without this patch:

```diff
-Gem::Dependency.new("existing_dep", Gem::Requirement.new(["> 1"]), :runtime)
+Gem::Dependency.new("existing_dep (> 1)", Gem::Requirement.new([">= 0"]), :runtime)
```