### PR TITLE
Hide spec var from gemspecs to silence warnings

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1028,8 +1028,8 @@ class Gem::Specification < Gem::BasicSpecification
     file = file.dup.untaint
     return unless File.file?(file)
 
-    spec = LOAD_CACHE[file]
-    return spec if spec
+    _spec = LOAD_CACHE[file]
+    return _spec if _spec
 
     code = if defined? Encoding
              File.read file, :mode => 'r:UTF-8:-'
@@ -1040,15 +1040,15 @@ class Gem::Specification < Gem::BasicSpecification
     code.untaint
 
     begin
-      spec = eval code, binding, file
+      _spec = eval code, binding, file
 
-      if Gem::Specification === spec
-        spec.loaded_from = File.expand_path file.to_s
-        LOAD_CACHE[file] = spec
-        return spec
+      if Gem::Specification === _spec
+        _spec.loaded_from = File.expand_path file.to_s
+        LOAD_CACHE[file] = _spec
+        return _spec
       end
 
-      warn "[#{file}] isn't a Gem::Specification (#{spec.class} instead)."
+      warn "[#{file}] isn't a Gem::Specification (#{_spec.class} instead)."
     rescue SignalException, SystemExit
       raise
     rescue SyntaxError, Exception => e


### PR DESCRIPTION
This change prevents warnings to be emitted like:

```
bundler.gemspec:6: warning: shadowing outer local variable - spec
```

The gemspec's that emit the above warning is of the form:

```ruby
Gem::Specification.new do |spec| do
   # the actual spec
end
```

I think all of rubygems docs use examples where in the block var for a specification is `s`. This change will allow the use of the more natural `spec`.

Note that Bundler no longer uses `spec` as the block var to prevent that warning but IMHO gem authors should be able to use `spec` as the block var without getting a mysterious warning. :smile: