### PR TITLE
remove leading double quote on windows script.

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -681,7 +681,7 @@ TEXT
   # return the stub script text used to launch the true Ruby script
 
   def windows_stub_script(bindir, bin_file_name)
-    ruby = Gem.ruby.chomp('"').tr(File::SEPARATOR, "\\")
+    ruby = Gem.ruby.gsub(/^\"|\"$/, "").tr(File::SEPARATOR, "\\")
     return <<-TEXT
 @ECHO OFF
 IF NOT "%~f0" == "~f0" GOTO :WinNT


### PR DESCRIPTION
Gem.ruby has leading and tailing double quote. but previous code only removed tailing double quote.