### PR TITLE
Remove unnecessary code

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -61,8 +61,7 @@ class Gem::BasicSpecification
     @contains_requirable_file ||= {}
     @contains_requirable_file[file] ||=
     begin
-      if instance_variable_defined?(:@ignored) or
-         instance_variable_defined?('@ignored') then
+      if instance_variable_defined?(:@ignored) then
         return false
       elsif missing_extensions? then
         @ignored = true


### PR DESCRIPTION
`Kernel#instance_variable_defined?` accepts a `Symbol` as well as a `String` from the beginning.
Instance variable names are stored as `ID`s, not `String`s.

~~~ruby
class A
  def initialize
   @x = true
  end
end
p RUBY_DESCRIPTION, A.new.instance_variable_defined?("@x")
~~~
~~~
"ruby 1.8.7 (2013-06-27 patchlevel 374) [i686-darwin11.4.0]"
true
~~~
