### PR TITLE
Fix memoization for Gem::Version#prerelease?

### DIFF
--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -279,7 +279,10 @@ class Gem::Version
   # A version is considered a prerelease if it contains a letter.
 
   def prerelease?
-    @prerelease ||= !!(@version =~ /[a-zA-Z]/)
+    unless defined?(@prerelease)
+      @prerelease = !!(@version =~ /[a-zA-Z]/)
+    end
+    @prerelease
   end
 
   def pretty_print q # :nodoc:

--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -279,7 +279,7 @@ class Gem::Version
   # A version is considered a prerelease if it contains a letter.
 
   def prerelease?
-    unless defined?(@prerelease)
+    unless instance_variable_defined? :@prerelease
       @prerelease = !!(@version =~ /[a-zA-Z]/)
     end
     @prerelease


### PR DESCRIPTION
The `||=` trick does not work with booleans.