### PR TITLE
Improve version pattern

### DIFF
--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -153,7 +153,7 @@ class Gem::Version
 
   include Comparable
 
-  VERSION_PATTERN = '[0-9]+(?>\.[0-9a-zA-Z]+)*(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?' # :nodoc:
+  VERSION_PATTERN = '[0-9]+([-.][0-9a-zA-Z]+)*' # :nodoc:
   ANCHORED_VERSION_PATTERN = /\A\s*(#{VERSION_PATTERN})?\s*\z/ # :nodoc:
 
   ##

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -145,6 +145,19 @@ class TestGemVersion < Gem::TestCase
     assert_less_than "1.0.0-1", "1"
   end
 
+  def test_invalid_versions
+    assert Gem::Version.correct? '1.4'
+    assert Gem::Version.correct? '1.a'
+    assert Gem::Version.correct? '1.4-b-a'
+    assert Gem::Version.correct? '1.4-b.a'
+    assert Gem::Version.correct? '1-4-b.a'
+
+    refute Gem::Version.correct? 'a.4'
+    refute Gem::Version.correct? '1.4-.a'
+    refute Gem::Version.correct? '1.4-a.-'
+    refute Gem::Version.correct? '1.4-b.a--b'
+  end
+
   # Asserts that +version+ is a prerelease.
 
   def assert_prerelease version


### PR DESCRIPTION
This pattern is simpler and rejects all versions where . and - occur side by side.
