### PR TITLE
Freeze version to avoid dup

### DIFF
--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -160,12 +160,10 @@ class Gem::Version
   # A string representation of this Version.
 
   def version
-    @version
-  end
-
-  def to_s
     @version.dup
   end
+
+  alias to_s version
 
   ##
   # True if the +version+ string matches RubyGems' requirements.
@@ -331,7 +329,7 @@ class Gem::Version
 
   def <=> other
     return unless Gem::Version === other
-    return 0 if @version == other.version
+    return 0 if @version == other.version_string
 
     lhsegments = segments
     rhsegments = other.segments
@@ -354,5 +352,11 @@ class Gem::Version
     end
 
     return 0
+  end
+
+  protected
+
+  def version_string
+    @version
   end
 end

--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -160,10 +160,12 @@ class Gem::Version
   # A string representation of this Version.
 
   def version
-    @version.dup
+    @version
   end
 
-  alias to_s version
+  def to_s
+    @version.dup
+  end
 
   ##
   # True if the +version+ string matches RubyGems' requirements.
@@ -206,7 +208,7 @@ class Gem::Version
     raise ArgumentError, "Malformed version number string #{version}" unless
       self.class.correct?(version)
 
-    @version = version.to_s.strip.gsub("-",".pre.")
+    @version = version.to_s.strip.gsub("-",".pre.").freeze
     @segments = nil
   end
 


### PR DESCRIPTION
Avoiding the creation of a new string speeds up `Gem::Version#<=>`.

Benchmark:

```ruby
require 'benchmark'
n = 500000

orig = Gem::Version.new('1.4-b-4')
same = Gem::Version.new('1.4-b-4')
other = Gem::Version.new('1.4-b-5')
Benchmark.bm(7) do |x|
  x.report('self') { n.times { orig <=> same } }
  x.report('other') { n.times { orig <=> other } }
end
```

Original result:
```
              user     system      total        real
self      0.270000   0.000000   0.270000 (  0.271262)
other     0.880000   0.000000   0.880000 (  0.886234)
```

With this change applied:
```
              user     system      total        real
self      0.120000   0.000000   0.120000 (  0.111093)
other     0.680000   0.000000   0.680000 (  0.688053)
```