### PR TITLE
Relax psych require

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -598,7 +598,7 @@ module Gem
 
     unless test_syck
       begin
-        gem 'psych', '~> 1.2', '>= 1.2.1'
+        gem 'psych', '>= 1.2.1'
       rescue Gem::LoadError
         # It's OK if the user does not have the psych gem installed.  We will
         # attempt to require the stdlib version


### PR DESCRIPTION
I am not sure why only Psych ~> 1.2 should be used, since Ruby ships with Psych 2.0.8 now, so relax the dependency.