### PR TITLE
Support s3 sources without hacking the URL format

### DIFF
--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -377,12 +377,12 @@ class Gem::RemoteFetcher
 
   def s3_source_auth(host)
     s3_source = Gem.configuration[:s3_source] || Gem.configuration['s3_source']
-    raise FetchError.new('no s3_source key exists in .gemrc') unless s3_source
+    raise FetchError.new('no s3_source key exists in .gemrc', "s3://#{host}") unless s3_source
     auth = s3_source[host] || s3_source[host.to_sym]
-    raise FetchError.new("no key for host #{host} in s3_source in .gemrc") unless auth
+    raise FetchError.new("no key for host #{host} in s3_source in .gemrc", "s3://#{host}") unless auth
     id = auth[:id] || auth['id']
     secret = auth[:secret] || auth['secret']
-    raise FetchError.new("s3_source for #{host} missing id or secret") unless id and secret
+    raise FetchError.new("s3_source for #{host} missing id or secret", "s3://#{host}") unless id and secret
     [id, secret]
   end
 

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -364,17 +364,26 @@ class Gem::RemoteFetcher
     require 'base64'
     require 'openssl'
 
-    unless uri.user && uri.password
-      raise FetchError.new("credentials needed in s3 source, like s3://key:secret@bucket-name/", uri.to_s)
-    end
+    id, secret = s3_source_auth uri.host
 
     expiration ||= s3_expiration
     canonical_path = "/#{uri.host}#{uri.path}"
     payload = "GET\n\n\n#{expiration}\n#{canonical_path}"
-    digest = OpenSSL::HMAC.digest('sha1', uri.password, payload)
+    digest = OpenSSL::HMAC.digest('sha1', secret, payload)
     # URI.escape is deprecated, and there isn't yet a replacement that does quite what we want
     signature = Base64.encode64(digest).gsub("\n", '').gsub(/[\+\/=]/) { |c| BASE64_URI_TRANSLATE[c] }
-    URI.parse("https://#{uri.host}.s3.amazonaws.com#{uri.path}?AWSAccessKeyId=#{uri.user}&Expires=#{expiration}&Signature=#{signature}")
+    URI.parse("https://#{uri.host}.s3.amazonaws.com#{uri.path}?AWSAccessKeyId=#{id}&Expires=#{expiration}&Signature=#{signature}")
+  end
+
+  def s3_source_auth(host)
+    s3_source = Gem.configuration[:s3_source] || Gem.configuration['s3_source']
+    raise FetchError.new('no s3_source key exists in .gemrc') unless s3_source
+    auth = s3_source[host] || s3_source[host.to_sym]
+    raise FetchError.new("no key for host #{host} in s3_source in .gemrc") unless auth
+    id = auth[:id] || auth['id']
+    secret = auth[:secret] || auth['secret']
+    raise FetchError.new("s3_source for #{host} missing id or secret") unless id and secret
+    [id, secret]
   end
 
   def s3_expiration

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -610,7 +610,7 @@ gems:
     $fetched_uri = nil
 
     Gem.configuration[:s3_source] = {
-      'my-bucket' => {id: 'testuser', secret: 'testpass' }
+      'my-bucket' => {:id => 'testuser', :secret => 'testpass'}
     }
 
     def fetcher.request(uri, request_class, last_modified = nil)

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -606,8 +606,12 @@ gems:
   def test_fetch_s3
     fetcher = Gem::RemoteFetcher.new nil
     @fetcher = fetcher
-    url = 's3://testuser:testpass@my-bucket/gems/specs.4.8.gz'
+    url = 's3://my-bucket/gems/specs.4.8.gz'
     $fetched_uri = nil
+
+    Gem.configuration[:s3_source] = {
+      'my-bucket' => {id: 'testuser', secret: 'testpass' }
+    }
 
     def fetcher.request(uri, request_class, last_modified = nil)
       $fetched_uri = uri
@@ -625,6 +629,7 @@ gems:
     assert_equal 'https://my-bucket.s3.amazonaws.com/gems/specs.4.8.gz?AWSAccessKeyId=testuser&Expires=1395098371&Signature=eUTr7NkpZEet%2BJySE%2BfH6qukroI%3D', $fetched_uri.to_s
     assert_equal 'success', data
   ensure
+    Gem.configuration[:s3_source] = nil
     $fetched_uri = nil
   end
 
@@ -636,7 +641,7 @@ gems:
       fetcher.fetch_s3 URI.parse(url)
     end
 
-    assert_match "credentials needed", e.message
+    assert_match 'no s3_source key exists in .gemrc', e.message
   end
 
   def test_observe_no_proxy_env_single_host


### PR DESCRIPTION
Currently s3 sources are _almost_ supported in rubygems, but it will only work if you are lucky enough that your AWS secret key has no special characters in it. This patch fixes that by moving the config into the .gemrc.

Instead of encoding the id and secret into the url, edit the .gemrc file with the authentication needed for each source. You must add the s3 bucket to the regular `sources`, then add the `s3_source` key with a set of credentials for each s3 hostname.

```
:sources:
- s3://bucket1/path
- s3://bucket2/
- https://rubygems.org/
s3_source: {
  bucket1: {
    id: "AOUEAOEU123123AOEUAO",
    secret: "aodnuhtdao/saeuhto+19283oaehu/asoeu+123h"
  },
  bucket2: {
    id: "AOUEAOEU123123AOEUAO",
    secret: "aodnuhtdao/saeuhto+19283oaehu/asoeu+123h"
  }
}
```
