### PR TITLE
Don't treat inaccessible working directories as build failures.

### DIFF
--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -157,11 +157,16 @@ EOF
       FileUtils.mkdir_p dest_path
 
       CHDIR_MUTEX.synchronize do
-        Dir.chdir extension_dir do
-          results = builder.build(extension, @gem_dir, dest_path,
-                                  results, @build_args, lib_dir)
+        pwd = Dir.getwd
+        Dir.chdir extension_dir
+        results = builder.build(extension, @gem_dir, dest_path,
+                                results, @build_args, lib_dir)
 
-          verbose { results.join("\n") }
+        verbose { results.join("\n") }
+        begin
+          Dir.chdir pwd
+        rescue
+          Dir.chdir dest_path
         end
       end
 

--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -165,7 +165,7 @@ EOF
         verbose { results.join("\n") }
         begin
           Dir.chdir pwd
-        rescue
+        rescue SystemCallError
           Dir.chdir dest_path
         end
       end


### PR DESCRIPTION
If the user installing the gem does not have access to the directory
where the `gem install` command is run (which is common for sudo(1),
for example) then extensions will build correctly, but will then report
a build failure when trying to return to the previous working directory
raises an exception.  This fixes the bug by returning to a fallback
directory if we can't return to the original one.

An example is probably clearer:

``` sh
mkdir /tmp/test
chmod 700 /tmp/test
cd /tmp/test
sudo -u $a_non_root_user gem install sqlite3
```

(Although a non-root user is easier to demonstrate, this happened to me
while installing a gem as root from a working directory that happed to
be inside a FUSE filesystem that root couldn't see.)

In this case, rubygems will compile sqlite3's extensions correctly, and
then try to return to the previous working directory, which will raise
an Errno::EACCES, which will trigger the rescue block that is intended
to report build failures.  This patch bounces back to dest_dir in that
case, which allows installation to proceed as normal.
