### PR TITLE
Make warning in Gem::Spec.reset more informative

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1153,11 +1153,17 @@ class Gem::Specification < Gem::BasicSpecification
     unresolved = unresolved_deps
     unless unresolved.empty? then
       w = "W" + "ARN"
-      warn "#{w}: Unresolved specs during Gem::Specification.reset:"
+      warn "#{w}: Unresolved or ambigious specs during Gem::Specification.reset:"
       unresolved.values.each do |dep|
         warn "      #{dep}"
+        
+        versions = Gem::Specification.find_all_by_name(dep.name)
+        unless versions.empty?
+          warn "      Available/installed versions of this gem:"
+          versions.each { |s| warn "      - #{s.version}" }
+        end
       end
-      warn "#{w}: Clearing out unresolved specs."
+      warn "#{w}: Clearing out unresolved specs. Try 'gem cleanup <gem>'"
       warn "Please report a bug if this causes problems."
       unresolved.clear
     end


### PR DESCRIPTION
According to http://stackoverflow.com/questions/17936340/unresolved-specs-during-gemspecification-reset this warning is (also?) shown when gem doesn't know what version of a gem it should use if multiple are available. The message however does not say that.

This change finds all installed versions and displays them alongside the original dependency and its version. It also proposes a `gem cleanup`.
