### PR TITLE
Fix Gem::Requirement#hash to always compute same hash values

### DIFF
--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -171,7 +171,7 @@ class Gem::Requirement
   end
 
   def hash # :nodoc:
-    requirements.hash
+    requirements.sort.hash
   end
 
   def marshal_dump # :nodoc:

--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -347,6 +347,16 @@ class TestGemRequirement < Gem::TestCase
     refute_satisfied_by "1.0.0.1",     "= 1.0"
   end
 
+  def test_hash_with_multiple_versions
+    r1 = req('1.0', '2.0')
+    r2 = req('2.0', '1.0')
+    assert_equal r1.hash, r2.hash
+
+    r1 = req('1.0', '2.0').tap { |r| r.concat(['3.0']) }
+    r2 = req('3.0', '1.0').tap { |r| r.concat(['2.0']) }
+    assert_equal r1.hash, r2.hash
+  end
+
   # Assert that two requirements are equal. Handles Gem::Requirements,
   # strings, arrays, numbers, and versions.
 


### PR DESCRIPTION
When you have:

```
  r1 = Gem::Requirement.new('1.0', '2.0')
  r2 = Gem::Requirement.new('2.0', '1.0')
```

Since `r1 == r2` is `true`, I expect `[r1] - [r2]` returns empty. But, it does not because `r1.hash` and `r2.hash` are different. I think that those hash values should be same.

`Gem#Requirement#==` returns `true` because `Gem::Requirement#as_list` calls `Array#sort` to sort requirements. I think that `Gem::Requirement#hash` should call `Array#sort` before computing hash value.