### PR TITLE
Fix `generate_index` ignoring default gems

### DIFF
--- a/lib/rubygems/indexer.rb
+++ b/lib/rubygems/indexer.rb
@@ -117,7 +117,6 @@ class Gem::Indexer
 
     Gem.time 'Generated Marshal quick index gemspecs' do
       specs.each do |spec|
-        next if spec.default_gem?
         spec_file_name = "#{spec.original_name}.gemspec.rz"
         marshal_name = File.join @quick_marshal_dir, spec_file_name
 


### PR DESCRIPTION
`gem generate_index` should not ignore default gems if they are present in the directory containing the gems you want to index (the path pointed by the param --directory).

```
$ ruby -v && gem -v
ruby 2.1.2p95 (2014-05-08 revision 45877) [x86_64-darwin13.0]
2.4.5

$ tree .
.
└── gems
    ├── json-1.8.0.gem
    ├── json-1.8.1.gem
    └── sdoc-0.4.1.gem

1 directory, 3 files
$ gem generate_index -V
Generating Marshal quick index gemspecs for 2 gems
1/2: json-1.8.0
2/2: sdoc-0.4.1
Complete
Generated Marshal quick index gemspecs: 0.001s
Generating specs index
Generated specs index: 0.000s
Generating latest specs index
Generated latest specs index: 0.000s
Generating prerelease specs index
Generated prerelease specs index: 0.000s
Compressing indicies
Compressed indicies: 0.001s
Moving index into production dir .
mkdir -p ./quick
rm -rf ./quick/Marshal.4.8
mv -f /var/folders/gp/2qhc4gmx08s3twkvzm9jbmdh0000gn/T/gem_generate_index_88548/quick/Marshal.4.8 ./quick/Marshal.4.8
rm -rf ./specs.4.8
mv -f /var/folders/gp/2qhc4gmx08s3twkvzm9jbmdh0000gn/T/gem_generate_index_88548/specs.4.8 .
rm -rf ./specs.4.8.gz
mv -f /var/folders/gp/2qhc4gmx08s3twkvzm9jbmdh0000gn/T/gem_generate_index_88548/specs.4.8.gz .
rm -rf ./latest_specs.4.8
mv -f /var/folders/gp/2qhc4gmx08s3twkvzm9jbmdh0000gn/T/gem_generate_index_88548/latest_specs.4.8 .
rm -rf ./latest_specs.4.8.gz
mv -f /var/folders/gp/2qhc4gmx08s3twkvzm9jbmdh0000gn/T/gem_generate_index_88548/latest_specs.4.8.gz .
rm -rf ./prerelease_specs.4.8
mv -f /var/folders/gp/2qhc4gmx08s3twkvzm9jbmdh0000gn/T/gem_generate_index_88548/prerelease_specs.4.8 .
rm -rf ./prerelease_specs.4.8.gz
mv -f /var/folders/gp/2qhc4gmx08s3twkvzm9jbmdh0000gn/T/gem_generate_index_88548/prerelease_specs.4.8.gz .
```

**The problem:** `json-1.8.1.gem` is included in the `gems` directory but is simply ignored.
**The reason:** lib/rubygems/indexer.rb simply ignores every `default_gem?` regardless of its presence in the `gems` directory.

See https://github.com/rubygems/rubygems/issues/661#issuecomment-70561849 for more details.
