### PR TITLE
Move abbreviate and sanitize to Gem::Specification

### DIFF
--- a/lib/rubygems/indexer.rb
+++ b/lib/rubygems/indexer.rb
@@ -93,23 +93,6 @@ class Gem::Indexer
   end
 
   ##
-  # Abbreviate the spec for downloading.  Abbreviated specs are only used for
-  # searching, downloading and related activities and do not need deployment
-  # specific information (e.g. list of files).  So we abbreviate the spec,
-  # making it much smaller for quicker downloads.
-  #--
-  # TODO move to Gem::Specification
-
-  def abbreviate(spec)
-    spec.files = []
-    spec.test_files = []
-    spec.rdoc_options = []
-    spec.extra_rdoc_files = []
-    spec.cert_chain = []
-    spec
-  end
-
-  ##
   # Build various indicies
 
   def build_indicies
@@ -231,8 +214,8 @@ class Gem::Indexer
         #   next
         # end
 
-        abbreviate spec
-        sanitize spec
+        spec.abbreviate
+        spec.sanitize
 
         spec
       rescue SignalException
@@ -377,38 +360,6 @@ class Gem::Indexer
 
     unless data == Gem.inflate(compressed_data) then
       raise "Compressed file #{compressed_path} does not match uncompressed file #{path}"
-    end
-  end
-
-  ##
-  # Sanitize the descriptive fields in the spec.  Sometimes non-ASCII
-  # characters will garble the site index.  Non-ASCII characters will
-  # be replaced by their XML entity equivalent.
-
-  def sanitize(spec)
-    spec.summary              = sanitize_string(spec.summary)
-    spec.description          = sanitize_string(spec.description)
-    spec.post_install_message = sanitize_string(spec.post_install_message)
-    spec.authors              = spec.authors.collect { |a| sanitize_string(a) }
-
-    spec
-  end
-
-  ##
-  # Sanitize a single string.
-
-  def sanitize_string(string)
-    return string unless string
-
-    # HACK the #to_s is in here because RSpec has an Array of Arrays of
-    # Strings for authors.  Need a way to disallow bad values on gemspec
-    # generation.  (Probably won't happen.)
-    string = string.to_s
-
-    begin
-      Builder::XChar.encode string
-    rescue NameError, NoMethodError
-      string.to_xs
     end
   end
 

--- a/lib/rubygems/indexer.rb
+++ b/lib/rubygems/indexer.rb
@@ -204,16 +204,6 @@ class Gem::Indexer
         spec = Gem::Package.new(gemfile).spec
         spec.loaded_from = gemfile
 
-        # HACK: fuck this shit - borks all tests that use pl1
-        # if File.basename(gemfile, ".gem") != spec.original_name then
-        #   exp = spec.full_name
-        #   exp << " (#{spec.original_name})" if
-        #     spec.original_name != spec.full_name
-        #   msg = "Skipping misnamed gem: #{gemfile} should be named #{exp}"
-        #   alert_warning msg
-        #   next
-        # end
-
         spec.abbreviate
         spec.sanitize
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1322,6 +1322,50 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   ##
+  # Abbreviate the spec for downloading.  Abbreviated specs are only used for
+  # searching, downloading and related activities and do not need deployment
+  # specific information (e.g. list of files).  So we abbreviate the spec,
+  # making it much smaller for quicker downloads.
+
+  def abbreviate
+    self.files = []
+    self.test_files = []
+    self.rdoc_options = []
+    self.extra_rdoc_files = []
+    self.cert_chain = []
+  end
+
+  ##
+  # Sanitize the descriptive fields in the spec.  Sometimes non-ASCII
+  # characters will garble the site index.  Non-ASCII characters will
+  # be replaced by their XML entity equivalent.
+
+  def sanitize
+    self.summary              = sanitize_string(summary)
+    self.description          = sanitize_string(description)
+    self.post_install_message = sanitize_string(post_install_message)
+    self.authors              = authors.collect { |a| sanitize_string(a) }
+  end
+
+  ##
+  # Sanitize a single string.
+
+  def sanitize_string(string)
+    return string unless string
+
+    # HACK the #to_s is in here because RSpec has an Array of Arrays of
+    # Strings for authors.  Need a way to disallow bad values on gemspec
+    # generation.  (Probably won't happen.)
+    string = string.to_s
+
+    begin
+      Builder::XChar.encode string
+    rescue NameError, NoMethodError
+      string.to_xs
+    end
+  end
+
+  ##
   # Returns an array with bindir attached to each executable in the
   # +executables+ list
 


### PR DESCRIPTION
`abbreviate` and  `sanitize` methods are a `Gem::Specification` concern. There was even a TODO there saying `TODO move to Gem::Specification`.
Also this will make rubygems.org not have to create a indexer only to call those methods.
see:
https://github.com/rubygems/rubygems.org/blob/master/app/jobs/indexer.rb#L95-L101

review @sferik @zzak @drbrain 

I am not sure if I should create a smoother deprecation path for this? or add a changelog, please let me know.

