### PR TITLE
Handle trailing colon in GEM_PATH

### DIFF
--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -58,6 +58,9 @@ class Gem::PathSupport
         gem_path = gpaths.dup
       else
         gem_path = gpaths.split(Gem.path_separator)
+        if gpaths.end_with?(Gem.path_separator)
+          gem_path += default_path
+        end
       end
 
       if File::ALT_SEPARATOR then
@@ -68,13 +71,19 @@ class Gem::PathSupport
 
       gem_path << @home
     else
-      gem_path = Gem.default_path + [@home]
-
-      if defined?(APPLE_GEM_HOME)
-        gem_path << APPLE_GEM_HOME
-      end
+      gem_path = default_path
     end
 
     @path = gem_path.uniq
+  end
+
+  # Return the default Gem path
+  def default_path
+    gem_path = Gem.default_path + [@home]
+
+    if defined?(APPLE_GEM_HOME)
+      gem_path << APPLE_GEM_HOME
+    end
+    gem_path
   end
 end


### PR DESCRIPTION
A trailing colon in GEM_PATH will add the default path to the current path.

Rationale:
Using `gem env` (with an empty GEM_PATH), I get that
~~~
  - GEM PATHS:
     - /home/dams/opt/pkgmgr/gems #<- my GEM_HOME
     - /home/dams/.gem/ruby/2.2.0
     - /usr/lib/ruby/gems/2.2.0
~~~

Sometime it is nice to be able to specify extra gem directory. This is
exactly what GEM_PATH is for, but it overwrites the default path:
`GEM_PATH=$HOME/local_gems gem env`
~~~
  - GEM PATHS:
     - /home/dams/opt/pkgmgr/gems
     - /home/dams/local_gems
~~~

With this patch, one can keep the default path by letting a trailing colon:
`GEM_PATH=$HOME/local_gems: gem env`
~~~
  - GEM PATHS:
     - /home/dams/opt/pkgmgr/gems
     - /home/dams/local_gems
     - /home/dams/.gem/ruby/2.2.0
     - /usr/lib/ruby/gems/2.2.0
~~~