### PR TITLE
Add --[no-]post-install-message argument to gem install/update.

### DIFF
--- a/lib/rubygems/install_update_options.rb
+++ b/lib/rubygems/install_update_options.rb
@@ -173,6 +173,11 @@ module Gem::InstallUpdateOptions
                 "meet version requirements") do |value, options|
       options[:minimal_deps] = true
     end
+
+    add_option(:"Install/Update", "--[no-]post-install-message",
+                "Print post install message") do |value, options|
+      options[:post_install_message] = value
+    end
   end
 
   ##

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -302,7 +302,7 @@ class Gem::Installer
       write_cache_file
     end
 
-    say spec.post_install_message unless spec.post_install_message.nil?
+    say spec.post_install_message if options[:post_install_message] && !spec.post_install_message.nil?
 
     Gem::Installer.install_lock.synchronize { Gem::Specification.reset }
 
@@ -632,7 +632,8 @@ class Gem::Installer
       :bin_dir      => nil,
       :env_shebang  => false,
       :force        => false,
-      :only_install_dir => false
+      :only_install_dir => false,
+      :post_install_message => true
     }.merge options
 
     @env_shebang         = options[:env_shebang]

--- a/test/rubygems/test_gem_install_update_options.rb
+++ b/test/rubygems/test_gem_install_update_options.rb
@@ -27,6 +27,7 @@ class TestGemInstallUpdateOptions < Gem::InstallerTestCase
       -i /install_to
       -w
       --vendor
+      --post-install-message
     ]
 
     args.concat %w[-P HighSecurity] if defined?(OpenSSL::SSL)
@@ -181,4 +182,15 @@ class TestGemInstallUpdateOptions < Gem::InstallerTestCase
     RbConfig::CONFIG['vendordir'] = orig_vendordir
   end
 
+  def test_post_install_message_no
+    @cmd.handle_options %w[--no-post-install-message]
+
+    assert_equal false, @cmd.options[:post_install_message]
+  end
+
+  def test_post_install_message
+    @cmd.handle_options %w[--post-install-message]
+
+    assert_equal true, @cmd.options[:post_install_message]
+  end
 end

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -999,6 +999,19 @@ gem 'other', version
     assert_match %r|I am a shiny gem!|, @ui.output
   end
 
+  def test_install_with_skipped_message
+    @spec.post_install_message = 'I am a shiny gem!'
+
+    use_ui @ui do
+      path = Gem::Package.build @spec
+
+      @installer = Gem::Installer.new path, :post_install_message => false
+      @installer.install
+    end
+
+    refute_match %r|I am a shiny gem!|, @ui.output
+  end
+
   def test_install_extension_dir
     gemhome2 = "#{@gemhome}2"
 


### PR DESCRIPTION
Hello!

Often I don't need to read post install messages (and they are really long some times). I've added option to skip them in install/update process.

It is really naive implementation.

Feel free to ping me if this change makes sense at all and if some improvements are needed.

*idea by https://github.com/tpope/gem-shut-the-fuck-up*