### PR TITLE
Fix fuzzy search for long strings

### DIFF
--- a/lib/rubygems/text.rb
+++ b/lib/rubygems/text.rb
@@ -43,11 +43,9 @@ module Gem::Text
     t = str2
     n = s.length
     m = t.length
-    max = n/2
 
     return m if (0 == n)
     return n if (0 == m)
-    return n if (n - m).abs > max
 
     d = (0..m).to_a
     x = nil

--- a/test/rubygems/test_gem_text.rb
+++ b/test/rubygems/test_gem_text.rb
@@ -71,4 +71,9 @@ Without the wrapping, the text might not look good in the RSS feed.
     assert_equal 7, levenshtein_distance("xxxxxxx", "ZenTest")
     assert_equal 7, levenshtein_distance("zentest", "xxxxxxx")
   end
+
+  def test_levenshtein_distance_long
+    assert_equal 13, levenshtein_distance("cat", "thundercatsarego")
+    assert_equal 13, levenshtein_distance("thundercatsarego", "cat")
+  end
 end


### PR DESCRIPTION
When strings being compared are drastically different in length, the shortcut in the existing levenshtein_distance method is incorrect. 

Currently it will report `levenshtein_distance("cat", "thundercatsarego")` as 3 since it will return n which is the number of characters in "cat". This is incorrect. It should return 13 (16 characters minus 3). 

To fix we remove the shortcut.