### PR TITLE
Remove temporary directories

### DIFF
--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -1442,6 +1442,9 @@ rescue LoadError, Gem::LoadError
 end
 
 require 'rubygems/test_utilities'
-ENV['GEM_HOME'] = Dir.mktmpdir "home"
-ENV['GEM_PATH'] = Dir.mktmpdir "path"
+tmpdirs = []
+tmpdirs << (ENV['GEM_HOME'] = Dir.mktmpdir("home"))
+tmpdirs << (ENV['GEM_PATH'] = Dir.mktmpdir("path"))
+pid = $$
+END {tmpdirs.each {|dir| Dir.rmdir(dir)} if $$ == pid}
 Gem.clear_paths


### PR DESCRIPTION
Remove temporary directories for GEM_HOME and GEM_PATH at exit.
Entries under these directories are removed usually, but top
directories are left.

~~~
$ mkdir $HOME/tmp/rubygems-tmp && TMPDIR=$HOME/tmp/rubygems-tmp rake >& /dev/null && rmdir $HOME/tmp/rubygems-tmp/
rmdir: failed to remove '/Users/nobu/tmp/rubygems-tmp/': Directory not empty
bash: exit 1
$ ls -l $HOME/tmp/rubygems-tmp/
total 0
drwx------ 2 nobu staff 68 Mar  4 15:18 home20150304-26757-nqt4li/
drwx------ 2 nobu staff 68 Mar  4 15:18 path20150304-26757-hq5i0m/
~~~