### PR TITLE
api_specification should use the platform name it was supplied

### DIFF
--- a/lib/rubygems/resolver/api_specification.rb
+++ b/lib/rubygems/resolver/api_specification.rb
@@ -19,6 +19,7 @@ class Gem::Resolver::APISpecification < Gem::Resolver::Specification
     @set = set
     @name = api_data[:name]
     @version = Gem::Version.new api_data[:number]
+    @original_platform = api_data[:platform]
     @platform = Gem::Platform.new api_data[:platform]
     @dependencies = api_data[:dependencies].map do |name, ver|
       Gem::Dependency.new name, ver.split(/\s*,\s*/)
@@ -35,7 +36,7 @@ class Gem::Resolver::APISpecification < Gem::Resolver::Specification
   end
 
   def fetch_development_dependencies # :nodoc:
-    spec = source.fetch_spec Gem::NameTuple.new @name, @version, @platform
+    spec = source.fetch_spec name_tuple
 
     @dependencies = spec.dependencies
   end
@@ -69,16 +70,15 @@ class Gem::Resolver::APISpecification < Gem::Resolver::Specification
   # Fetches a Gem::Specification for this APISpecification.
 
   def spec # :nodoc:
-    @spec ||=
-      begin
-        tuple = Gem::NameTuple.new @name, @version, @platform
-
-        source.fetch_spec tuple
-      end
+    @spec ||= source.fetch_spec name_tuple
   end
 
   def source # :nodoc:
     @set.source
+  end
+
+  def name_tuple
+    @name_tuple ||= Gem::NameTuple.new @name, @version, @original_platform
   end
 
 end

--- a/test/rubygems/test_gem_resolver_api_specification.rb
+++ b/test/rubygems/test_gem_resolver_api_specification.rb
@@ -31,13 +31,14 @@ class TestGemResolverAPISpecification < Gem::TestCase
   def test_fetch_development_dependencies
     specs = spec_fetcher do |fetcher|
       fetcher.spec 'rails', '3.0.3' do |s|
+        s.platform = 'i386-mingw32'
         s.add_runtime_dependency 'bundler',  '~> 1.0'
         s.add_runtime_dependency 'railties', '= 3.0.3'
         s.add_development_dependency 'a',    '= 1'
       end
     end
 
-    rails = specs['rails-3.0.3']
+    rails = specs['rails-3.0.3-x86-mingw32']
 
     repo = @gem_repo + 'api/v1/dependencies'
 
@@ -46,7 +47,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
     data = {
       :name     => 'rails',
       :number   => '3.0.3',
-      :platform => 'ruby',
+      :platform => 'i386-mingw32',
       :dependencies => [
         ['bundler',  '~> 1.0'],
         ['railties', '= 3.0.3'],


### PR DESCRIPTION
Without this patch, `gem install pry` fails because it wants to download pry-0.10.1-x86-mingw32 
instead of pry-0.10.1-i386-mingw32. This is because a Platform object is created from the 
`i386-mingw32` string, which gets normalized into `x86-mingw32`. This behavior was
introduced in d96c57ce3c69dbaf3c9bb43e65eaa2c5e2601718.

This fixes #1120.