### PR TITLE
drop millions of allocations by using a linked list

### DIFF
--- a/lib/rubygems/util/list.rb
+++ b/lib/rubygems/util/list.rb
@@ -2,6 +2,8 @@ module Gem
   List = Struct.new(:value, :tail)
 
   class List
+    include Enumerable
+
     def each
       n = self
       while n


### PR DESCRIPTION
I'm sending a PR because the reduction in allocations is so surprising to me that I'm afraid it's wrong.  All tests pass on my machine, and I *think* it's backwards compatible, but I need review.  /cc @evanphx @drbrain 

Use a linked list to drop array allocations.  The previous
implementation would dup arrays on every call to `traverse`.  This patch
uses a linked list so that any block that is interested in keeping a
reference to `trail` can just keep the trail node around (the trail node
points at it's parents).

This approach reduces allocations from 11173668, to 2940.

Here is the test I used:

```ruby
require 'stackprof'
require 'allocation_tracer'
require 'rubygems/test_case'
require 'rubygems/ext'
require 'rubygems/specification'
require 'benchmark'

class TestGemSpecification < Gem::TestCase
  def test_runtime
    make_gems do
      StackProf.run(mode: :wall, out: '/tmp/out.dump') do
        assert_raises(LoadError) { require 'no_such_file_foo' }
      end
    end
  end

  def test_alone
    make_gems do
      tms = Benchmark.measure {
        assert_raises(LoadError) { require 'no_such_file_foo' }
      }
      p tms.total
      assert_operator tms.total, :<=, 10
    end
  end

  def test_memory
    make_gems do
      ObjectSpace::AllocationTracer.setup(%i{path line type})
      r = ObjectSpace::AllocationTracer.trace do
        assert_raises(LoadError) { require 'no_such_file_foo' }
      end

      r.sort_by { |k,v| v.first }.each do |k,v|
        p k => v
      end
      p hash_alloc: ObjectSpace::AllocationTracer.allocated_count_table[:T_HASH]
      p array_alloc: ObjectSpace::AllocationTracer.allocated_count_table[:T_ARRAY]
      p :TOTAL => ObjectSpace::AllocationTracer.allocated_count_table.values.inject(:+)
    end
  end

  def make_gems
    save_loaded_features do
      num_of_pkg = 7
      num_of_version_per_pkg = 3
      packages = (0..num_of_pkg).map do |pkgi|
        (0..num_of_version_per_pkg).map do |pkg_version|
          deps = Hash[(pkgi..num_of_pkg).map { |deppkgi| ["pkg#{deppkgi}", ">= 0"] }]
          new_spec "pkg#{pkgi}", pkg_version.to_s, deps
        end
      end
      base = new_spec "pkg_base", "1", {"pkg0" => ">= 0"}

      Gem::Specification.reset
      install_specs base,*packages.flatten
      base.activate

      yield
    end
  end
end
```

Before:

{:TOTAL=>11173668}

After:

{:TOTAL=>2940}
