### PR TITLE
DRY up Gem::List in utils

### DIFF
--- a/lib/rubygems/util/list.rb
+++ b/lib/rubygems/util/list.rb
@@ -1,8 +1,12 @@
 module Gem
-  List = Struct.new(:value, :tail)
-
   class List
     include Enumerable
+    attr_accessor :value, :tail
+
+    def initialize(value = nil, tail = nil)
+      @value = value
+      @tail = tail
+    end
 
     def each
       n = self
@@ -13,14 +17,7 @@ module Gem
     end
 
     def to_a
-      ary = []
-      n = self
-      while n
-        ary.unshift n.value
-        n = n.tail
-      end
-
-      ary
+      super.reverse
     end
 
     def prepend(value)


### PR DESCRIPTION
1. Methods `#find` and `#to_a` use the implementations
defined in Enumerable rather than repeating themselves.

2. The inclusion of Enumerable in Struct was the obstacle,
so remove the Struct and define a constructor instead.

3. Avoid potential N^2 behavior in previous `to_a` implementation.
Why? `Array#unshift` has linear performance, so iteratively
building a reversed array by unshifting risks N^2 performance.
Instead, do a single `#reverse` for linear at worst.

(Note: I head about this code from #1188 via Ruby Weekly news, don't
know if conversion rate to PR is counted anywhere)