### PR TITLE
Fixes for find_in_unresolved_tree

### DIFF
--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1,3 +1,4 @@
+require 'benchmark'
 require 'rubygems/test_case'
 require 'pathname'
 require 'stringio'
@@ -141,7 +142,6 @@ end
       install_specs base,*packages.flatten
       base.activate
 
-      require 'benchmark'
       tms = Benchmark.measure {
         assert_raises(LoadError) { require 'no_such_file_foo' }
       }
@@ -211,6 +211,155 @@ end
 
       assert_equal %w(a-1 d-1), loaded_spec_names
       assert_equal ["b (> 0)"], unresolved_names
+    end
+  end
+
+  def test_require_should_prefer_latest_gem_level1
+    save_loaded_features do
+      a1 = new_spec "a", "1", "b" => "> 0"
+      b1 = new_spec "b", "1", "c" => ">= 0" # unresolved
+      b2 = new_spec "b", "2", "c" => ">= 0"
+      c1 = new_spec "c", "1", nil, "lib/c.rb"  # 1st level
+      c2 = new_spec "c", "2", nil, "lib/c.rb"
+
+      install_specs a1, b1, b2, c1, c2
+
+      a1.activate
+
+      require "c"
+
+      assert_equal %w(a-1 b-2 c-2), loaded_spec_names
+    end
+  end
+
+  def test_require_should_prefer_latest_gem_level2
+    save_loaded_features do
+      a1 = new_spec "a", "1", "b" => "> 0"
+      b1 = new_spec "b", "1", "c" => ">= 0" # unresolved
+      b2 = new_spec "b", "2", "c" => ">= 0"
+      c1 = new_spec "c", "1", "d" => ">= 0"  # 1st level
+      c2 = new_spec "c", "2", "d" => ">= 0"
+      d1 = new_spec "d", "1", nil, "lib/d.rb" # 2nd level
+      d2 = new_spec "d", "2", nil, "lib/d.rb"
+
+      install_specs a1, b1, b2, c1, c2, d1, d2
+
+      a1.activate
+
+      require "d"
+
+      assert_equal %w(a-1 b-2 c-2 d-2), loaded_spec_names
+    end
+  end
+
+  def test_require_finds_in_2nd_level_indirect
+    save_loaded_features do
+      a1 = new_spec "a", "1", "b" => "> 0"
+      b1 = new_spec "b", "1", "c" => ">= 0" # unresolved
+      b2 = new_spec "b", "2", "c" => ">= 0"
+      c1 = new_spec "c", "1", "d" => "<= 2" # 1st level
+      c2 = new_spec "c", "2", "d" => "<= 2"
+      d1 = new_spec "d", "1", nil, "lib/d.rb" # 2nd level
+      d2 = new_spec "d", "2", nil, "lib/d.rb"
+      d3 = new_spec "d", "3", nil, "lib/d.rb"
+
+      install_specs a1, b1, b2, c1, c2, d1, d2, d3
+
+      a1.activate
+
+      require "d"
+
+      assert_equal %w(a-1 b-2 c-2 d-2), loaded_spec_names
+    end
+  end
+
+  def test_require_should_prefer_reachable_gems
+    save_loaded_features do
+      a1 = new_spec "a", "1", "b" => "> 0"
+      b1 = new_spec "b", "1", "c" => ">= 0" # unresolved
+      b2 = new_spec "b", "2", "c" => ">= 0"
+      c1 = new_spec "c", "1", "d" => "<= 2" # 1st level
+      c2 = new_spec "c", "2", "d" => "<= 2"
+      d1 = new_spec "d", "1", nil, "lib/d.rb" # 2nd level
+      d2 = new_spec "d", "2", nil, "lib/d.rb"
+      d3 = new_spec "d", "3", nil, "lib/d.rb"
+      e  = new_spec "anti_d", "1", nil, "lib/d.rb"
+
+      install_specs a1, b1, b2, c1, c2, d1, d2, d3, e
+
+      a1.activate
+
+      require "d"
+
+      assert_equal %w(a-1 b-2 c-2 d-2), loaded_spec_names
+    end
+  end
+
+  def test_require_should_not_conflict
+    save_loaded_features do
+      base = new_spec "0", "1", "A" => ">= 1"
+      a1 = new_spec "A", "1", {"c" => ">= 2", "b" => "> 0"}, "lib/a.rb"
+      a2 = new_spec "A", "2", {"c" => ">= 2", "b" => "> 0"}, "lib/a.rb"
+      b1 = new_spec "b", "1", {"c" => "= 1"}, "lib/d.rb"
+      b2 = new_spec "b", "2", {"c" => "= 2"}, "lib/d.rb"
+      c1 = new_spec "c", "1", {}, "lib/c.rb"
+      c2 = new_spec "c", "2", {}, "lib/c.rb"
+      c3 = new_spec "c", "3", {}, "lib/c.rb"
+
+      install_specs base, a1, a2, b1, b2, c1, c2, c3
+
+      base.activate
+      assert_equal %w(0-1), loaded_spec_names
+      assert_equal ["A (>= 1)"], unresolved_names
+
+      require "d"
+
+      assert_equal %w(0-1 A-2 b-2 c-2), loaded_spec_names
+      assert_equal [], unresolved_names
+    end
+  end
+
+  def test_inner_clonflict_in_indirect_gems
+    save_loaded_features do
+      a1 = new_spec "a", "1", "b" => "> 0"
+      b1 = new_spec "b", "1", "c" => ">= 1" # unresolved
+      b2 = new_spec "b", "2", "c" => ">= 1", "d" => "< 3"
+      c1 = new_spec "c", "1", "d" => "<= 2" # 1st level
+      c2 = new_spec "c", "2", "d" => "<= 2"
+      c3 = new_spec "c", "3", "d" => "<= 3"
+      d1 = new_spec "d", "1", nil, "lib/d.rb" # 2nd level
+      d2 = new_spec "d", "2", nil, "lib/d.rb"
+      d3 = new_spec "d", "3", nil, "lib/d.rb"
+
+      install_specs a1, b1, b2, c1, c2, c3, d1, d2, d3
+
+      a1.activate
+
+      require "d"
+
+      assert_equal %w(a-1 b-2 c-3 d-2), loaded_spec_names
+    end
+  end
+
+  def test_inner_clonflict_in_indirect_gems_reversed
+    save_loaded_features do
+      a1 = new_spec "a", "1", "b" => "> 0"
+      b1 = new_spec "b", "1", "xc" => ">= 1" # unresolved
+      b2 = new_spec "b", "2", "xc" => ">= 1", "d" => "< 3"
+      c1 = new_spec "xc", "1", "d" => "<= 3" # 1st level
+      c2 = new_spec "xc", "2", "d" => "<= 2"
+      c3 = new_spec "xc", "3", "d" => "<= 3"
+      d1 = new_spec "d", "1", nil, "lib/d.rb" # 2nd level
+      d2 = new_spec "d", "2", nil, "lib/d.rb"
+      d3 = new_spec "d", "3", nil, "lib/d.rb"
+
+      install_specs a1, b1, b2, c1, c2, c3, d1, d2, d3
+
+      a1.activate
+
+      require "d"
+
+      assert_equal %w(a-1 b-2 d-2 xc-3), loaded_spec_names
     end
   end
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -337,7 +337,7 @@ end
 
       require "d"
 
-      assert_equal %w(a-1 b-2 c-3 d-2), loaded_spec_names
+      assert_includes [%w(a-1 b-2 c-3 d-2),%w(a-1 b-2 d-2)], loaded_spec_names
     end
   end
 
@@ -359,7 +359,7 @@ end
 
       require "d"
 
-      assert_equal %w(a-1 b-2 d-2 xc-3), loaded_spec_names
+      assert_includes [%w(a-1 b-2 d-2 xc-3), %w(a-1 b-2 d-2)], loaded_spec_names
     end
   end
 


### PR DESCRIPTION
Added a new implementation of find_in_unresolved_tree
Bugs fixed in original one:
- next was not skipping rest of walk, so now returns :next so caller knows there is a conflict so no need to walk this branch
- we prevent visiting the same spec twice, using visited set. While this means we dont process all paths processing all path is exponential and we dont want that
- we do walk in a greedy way taking the latest versions of specs first and we return as soon as we find something rather than processing all paths and soring it to return the latest (also original was used wrong number of reserve so it did not actually returned the latest)
- we need to check conflict in all the to be activated gems and not only in the last elem of the path(trail)

find_in_unresolved is called when we have some gems already activated and the required file is not found in any of them. It has the following requirements:
- should prefer gems in direct/indirect dependencies (vs gems outside the dependency tree)
- should prefer latest versions
- should avoid conflicts but we also want it to be performant