### PR TITLE
Don't output mkmf.log result if file doesn't exist

### DIFF
--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -35,10 +35,12 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
         begin
           run cmd, results
         ensure
-          results << "To see why this extension failed to compile, please check" \
-            " the mkmf.log which can be found here:\n"
-          results << "  " + File.join(dest_path, 'mkmf.log') + "\n"
-          FileUtils.mv 'mkmf.log', dest_path if File.exist? 'mkmf.log'
+          if File.exist? 'mkmf.log'
+            results << "To see why this extension failed to compile, please check" \
+              " the mkmf.log which can be found here:\n"
+            results << "  " + File.join(dest_path, 'mkmf.log') + "\n"
+            FileUtils.mv 'mkmf.log', dest_path
+          end
           siteconf.unlink
         end
 


### PR DESCRIPTION
@tenderlove just a little tweak, given that we were checking for the file to exist before moving it, it doesn't make sense to output the result if the file doesn't exist. 