### PR TITLE
Make GemDependencyAPI available after .use_gemdeps

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -156,6 +156,7 @@ module Gem
   @@win_platform = nil
 
   @configuration = nil
+  @gemdeps = nil
   @loaded_specs = {}
   LOADED_SPECS_MUTEX = Mutex.new
   @path_to_default_spec_map = {}
@@ -1052,7 +1053,7 @@ module Gem
     end
 
     rs = Gem::RequestSet.new
-    rs.load_gemdeps path
+    @gemdeps = rs.load_gemdeps path
 
     rs.resolve_current.map do |s|
       sp = s.full_spec
@@ -1081,6 +1082,12 @@ module Gem
     # Hash of loaded Gem::Specification keyed by name
 
     attr_reader :loaded_specs
+
+    ##
+    # GemDependencyAPI object, which is set when .use_gemdeps is called.
+    # This contains all the information from the Gemfile.
+
+    attr_reader :gemdeps
 
     ##
     # Register a Gem::Specification for default gem.

--- a/lib/rubygems/request_set/gem_dependency_api.rb
+++ b/lib/rubygems/request_set/gem_dependency_api.rb
@@ -174,7 +174,7 @@ class Gem::RequestSet::GemDependencyAPI
   ##
   # A Hash containing gem names and files to require from those gems.
 
-  attr_reader :requires # :nodoc:
+  attr_reader :requires
 
   ##
   # A set of gems that are loaded via the +:path+ option to #gem

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -275,6 +275,7 @@ class Gem::TestCase < MiniTest::Unit::TestCase
     @orig_ENV_HOME = ENV['HOME']
     ENV['HOME'] = @userhome
     Gem.instance_variable_set :@user_home, nil
+    Gem.instance_variable_set :@gemdeps, nil
     Gem.send :remove_instance_variable, :@ruby_version if
       Gem.instance_variables.include? :@ruby_version
 

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1379,9 +1379,12 @@ class TestGem < Gem::TestCase
       io.write 'gem "a"'
     end
 
+    assert_nil Gem.gemdeps
+
     Gem.use_gemdeps gem_deps_file
 
     assert spec.activated?
+    refute_nil Gem.gemdeps
   end
 
   def test_use_gemdeps_ENV


### PR DESCRIPTION
Previously, the files specified with the `:require` option in a Gemfile
were not accesible to plugin authors. Now, the GemDependencyAPI object
provides access to them via `Gem.gemdeps.requires`.

Fixes #1213