### PR TITLE
Show Dir.pwd on building

### DIFF
--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -66,9 +66,11 @@ class Gem::Ext::Builder
       # TODO use Process.spawn when ruby 1.8 support is dropped.
       rubygems_gemdeps, ENV['RUBYGEMS_GEMDEPS'] = ENV['RUBYGEMS_GEMDEPS'], nil
       if verbose
+        puts("current directory: #{Dir.pwd}")
         puts(command)
         system(command)
       else
+        results << "current directory: #{Dir.pwd}"
         results << command
         results << `#{command} #{redirector}`
       end

--- a/test/rubygems/test_gem_ext_configure_builder.rb
+++ b/test/rubygems/test_gem_ext_configure_builder.rb
@@ -29,6 +29,7 @@ class TestGemExtConfigureBuilder < Gem::TestCase
       Gem::Ext::ConfigureBuilder.build nil, nil, @dest_path, output
     end
 
+    assert_match /^current directory:/, output.shift
     assert_equal "sh ./configure --prefix=#{@dest_path}", output.shift
     assert_equal "", output.shift
     assert_contains_make_command 'clean', output.shift
@@ -54,6 +55,7 @@ class TestGemExtConfigureBuilder < Gem::TestCase
 
     assert_match 'configure failed', error.message
 
+    assert_match /^current directory:/, output.shift
     assert_equal "#{sh_prefix_configure}#{@dest_path}", output.shift
     assert_match %r(#{shell_error_msg}), output.shift
     assert_equal true, output.empty?
@@ -73,9 +75,9 @@ class TestGemExtConfigureBuilder < Gem::TestCase
       Gem::Ext::ConfigureBuilder.build nil, nil, @dest_path, output
     end
 
-    assert_contains_make_command 'clean', output[0]
-    assert_contains_make_command '', output[2]
-    assert_contains_make_command 'install', output[4]
+    assert_contains_make_command 'clean', output[1]
+    assert_contains_make_command '', output[4]
+    assert_contains_make_command 'install', output[7]
   end
 
 end

--- a/test/rubygems/test_gem_ext_ext_conf_builder.rb
+++ b/test/rubygems/test_gem_ext_ext_conf_builder.rb
@@ -33,11 +33,13 @@ class TestGemExtExtConfBuilder < Gem::TestCase
       assert_same result, output
     end
 
-    assert_match(/^#{Gem.ruby}.* extconf.rb/, output[0])
-    assert_equal "creating Makefile\n", output[1]
-    assert_contains_make_command 'clean', output[2]
-    assert_contains_make_command '', output[4]
-    assert_contains_make_command 'install', output[6]
+    assert_match(/^current directory:/, output[0])
+    assert_match(/^#{Gem.ruby}.* extconf.rb/, output[1])
+    assert_equal "creating Makefile\n", output[2]
+    assert_match(/^current directory:/, output[3])
+    assert_contains_make_command 'clean', output[4]
+    assert_contains_make_command '', output[7]
+    assert_contains_make_command 'install', output[10]
     assert_empty Dir.glob(File.join(@ext, 'siteconf*.rb'))
   end
 
@@ -54,10 +56,10 @@ class TestGemExtExtConfBuilder < Gem::TestCase
         Gem::Ext::ExtConfBuilder.build 'extconf.rb', nil, @dest_path, output
       end
 
-      assert_equal "creating Makefile\n", output[1]
-      assert_contains_make_command 'clean', output[2]
-      assert_contains_make_command '', output[4]
-      assert_contains_make_command 'install', output[6]
+      assert_equal "creating Makefile\n", output[2]
+      assert_contains_make_command 'clean', output[4]
+      assert_contains_make_command '', output[7]
+      assert_contains_make_command 'install', output[10]
     end
   end
 
@@ -78,8 +80,8 @@ class TestGemExtExtConfBuilder < Gem::TestCase
         end
       end
 
-      assert_equal "creating Makefile\n",   output[1]
-      assert_contains_make_command 'clean', output[2]
+      assert_equal "creating Makefile\n",   output[2]
+      assert_contains_make_command 'clean', output[4]
     end
   ensure
     ENV['make'] = env_make
@@ -106,8 +108,8 @@ class TestGemExtExtConfBuilder < Gem::TestCase
 
     assert_equal 'extconf failed, exit code 1', error.message
 
-    assert_match(/^#{Gem.ruby}.* extconf.rb/, output[0])
-    assert_match(File.join(@dest_path, 'mkmf.log'), output[3])
+    assert_match(/^#{Gem.ruby}.* extconf.rb/, output[1])
+    assert_match(File.join(@dest_path, 'mkmf.log'), output[4])
 
     assert_path_exists File.join @dest_path, 'mkmf.log'
   end
@@ -149,9 +151,9 @@ end
       Gem::Ext::ExtConfBuilder.build 'extconf.rb', nil, @dest_path, output
     end
 
-    assert_contains_make_command 'clean', output[2]
-    assert_contains_make_command '', output[4]
-    assert_contains_make_command 'install', output[6]
+    assert_contains_make_command 'clean', output[4]
+    assert_contains_make_command '', output[7]
+    assert_contains_make_command 'install', output[10]
     assert_empty Dir.glob(File.join(@ext, 'siteconf*.rb'))
   end
 
@@ -175,9 +177,9 @@ end
       Gem::Ext::ExtConfBuilder.make @ext, output
     end
 
-    assert_contains_make_command 'clean', output[0]
-    assert_contains_make_command '', output[2]
-    assert_contains_make_command 'install', output[4]
+    assert_contains_make_command 'clean', output[1]
+    assert_contains_make_command '', output[4]
+    assert_contains_make_command 'install', output[7]
   end
 
   def test_class_make_no_Makefile


### PR DESCRIPTION
When some error occurs, rubygems reports the address of gem_make.out.
I think it's great.
But, we can never find the information of the Makefile which is the cause of the error.
Showing the current directory of running command (such as make) on gem_make.out is very useful to debug.