### PR TITLE
Clarify reason for change in History.txt [ci skip]

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -18,7 +18,7 @@ Minor enhancements:
   Pull request #1131 by Matijs van Zuijlen
 * Fix edge case in `levenshtein_distance` for comparing longer strings.
   Pull request #1173 by Richard Schneeman
-* Remove duplication from List#to_a as it now includes Enumberable.
+* Remove duplication from List#to_a, improving from O(n^2) to O(n) time.
   Pull request #1200 by Marc Siegel.
 
 Bug fixes:


### PR DESCRIPTION
Just to clarify the reason for the change, in addition to reducing duplication, is also that the old version was quadratic in the number of elements, due to calling `Array#unshift` in a loop.