### PR TITLE
Switch Gem::StubSpecification to be a delegate object

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -39,13 +39,6 @@ module Gem::BasicSpecification
   end
 
   ##
-  # True when the gem has been activated
-
-  def activated?
-    raise NotImplementedError
-  end
-
-  ##
   # Returns the full path to the base gem directory.
   #
   # eg: /usr/local/lib/ruby/gems/1.8
@@ -201,6 +194,7 @@ module Gem::BasicSpecification
     @gem_dir               = nil
     @gems_dir              = nil
     @base_dir              = nil
+    @activated             = false
   end
 
   ##

--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -269,11 +269,19 @@ module Gem::BasicSpecification
     raise NotImplementedError
   end
 
+  def spec; self; end
+
   ##
   # Version of the gem
 
   def version
     raise NotImplementedError
+  end
+
+  def == other # :nodoc:
+    name == other.name &&
+      version == other.version &&
+      platform == other.platform
   end
 
   ##

--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -2,7 +2,12 @@
 # BasicSpecification is an abstract class which implements some common code
 # used by both Specification and StubSpecification.
 
-class Gem::BasicSpecification
+module Gem::BasicSpecification
+  module ClassMethods
+    def default_specifications_dir
+      File.join(Gem.default_dir, "specifications", "default")
+    end
+  end
 
   ##
   # Allows installation of extensions for git: gems.
@@ -31,10 +36,6 @@ class Gem::BasicSpecification
 
   def initialize
     internal_init
-  end
-
-  def self.default_specifications_dir
-    File.join(Gem.default_dir, "specifications", "default")
   end
 
   ##

--- a/lib/rubygems/commands/dependency_command.rb
+++ b/lib/rubygems/commands/dependency_command.rb
@@ -65,7 +65,7 @@ use with other commands.
     specs = []
 
     if local?
-      specs.concat Gem::Specification.stubs.find_all { |spec|
+      specs.concat Gem::Specification.find_all { |spec|
         name_pattern =~ spec.name and
           dependency.requirement.satisfied_by? spec.version
       }.map(&:to_spec)

--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -60,7 +60,7 @@ module Kernel
     #--
     # TODO request access to the C implementation of this to speed up RubyGems
 
-    spec = Gem::Specification.stubs.find { |s|
+    spec = Gem::Specification.find { |s|
       s.activated? and s.contains_requirable_file? path
     }
 

--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -276,7 +276,7 @@ class Gem::Dependency
   def matching_specs platform_only = false
     matches = Gem::Specification.stubs_for(name).find_all { |spec|
       requirement.satisfied_by? spec.version
-    }.map(&:to_spec)
+    }
 
     if platform_only
       matches.reject! { |spec|

--- a/lib/rubygems/resolver/activation_request.rb
+++ b/lib/rubygems/resolver/activation_request.rb
@@ -71,7 +71,7 @@ class Gem::Resolver::ActivationRequest
   # The Gem::Specification for this activation request.
 
   def full_spec
-    Gem::Specification === @spec ? @spec : @spec.spec
+    @spec.spec
   end
 
   def inspect # :nodoc:

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -35,7 +35,9 @@ require 'rubygems/util/list'
 # metadata.  See #metadata for restrictions on the format and size of metadata
 # items you may add to a specification.
 
-class Gem::Specification < Gem::BasicSpecification
+class Gem::Specification
+  include Gem::BasicSpecification
+  extend Gem::BasicSpecification::ClassMethods
 
   # REFACTOR: Consider breaking out this version stuff into a separate
   # module. There's enough special stuff around it that it may justify

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -857,11 +857,9 @@ class Gem::Specification
     return if _all.include? spec
 
     _all << spec
-    stubs << spec
     (@@stubs_by_name[spec.name] ||= []) << spec
     sort_by!(@@stubs_by_name[spec.name]) { |s| s.version }
     _resort!(_all)
-    _resort!(stubs)
   end
 
   ##
@@ -995,7 +993,7 @@ class Gem::Specification
   # Return the best specification that contains the file matching +path+.
 
   def self.find_by_path path
-    stubs.find { |spec| spec.contains_requirable_file? path }
+    find { |spec| spec.contains_requirable_file? path }
   end
 
   ##
@@ -1003,9 +1001,7 @@ class Gem::Specification
   # amongst the specs that are not activated.
 
   def self.find_inactive_by_path path
-    stubs.find { |s|
-      s.contains_requirable_file? path unless s.activated?
-    }
+    find { |s| s.contains_requirable_file? path unless s.activated?  }
   end
 
   ##
@@ -1194,8 +1190,7 @@ class Gem::Specification
 
   def self.remove_spec spec
     warn "Gem::Specification.remove_spec is deprecated and will be removed in Rubygems 3.0" unless Gem::Deprecate.skip
-    _all.delete spec
-    stubs.delete_if { |s| s.full_name == spec.full_name }
+    _all.delete_if { |s| s.full_name == spec.full_name }
     (@@stubs_by_name[spec.name] || []).delete_if { |s| s.full_name == spec.full_name }
     reset
   end

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -11,7 +11,6 @@ require 'rubygems/requirement'
 require 'rubygems/platform'
 require 'rubygems/deprecate'
 require 'rubygems/basic_specification'
-require 'rubygems/stub_specification'
 require 'rubygems/util/stringio'
 require 'rubygems/util/list'
 
@@ -1310,13 +1309,6 @@ class Gem::Specification
 
   def <=>(other) # :nodoc:
     sort_obj <=> other.sort_obj
-  end
-
-  def == other # :nodoc:
-    self.class === other &&
-      name == other.name &&
-      version == other.version &&
-      platform == other.platform
   end
 
   ##
@@ -2965,6 +2957,8 @@ open-ended dependency on #{dep} is not recommended
   # deprecate :file_name,           :cache_file, 2011, 10
   # deprecate :full_gem_path,     :cache_file, 2011, 10
 end
+
+require 'rubygems/stub_specification'
 
 # DOC: What is this and why is it here, randomly, at the end of this file?
 Gem.clear_paths

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -710,7 +710,7 @@ class Gem::Specification
 
   def self._all # :nodoc:
     unless defined?(@@all) && @@all then
-      @@all = stubs.map(&:to_spec)
+      @@all = stubs
 
       # After a reset, make sure already loaded specs
       # are still marked as activated.
@@ -1011,10 +1011,9 @@ class Gem::Specification
   # amongst the specs that are not activated.
 
   def self.find_inactive_by_path path
-    stub = stubs.find { |s|
+    stubs.find { |s|
       s.contains_requirable_file? path unless s.activated?
     }
-    stub && stub.to_spec
   end
 
   ##

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -995,10 +995,7 @@ class Gem::Specification
   # Return the best specification that contains the file matching +path+.
 
   def self.find_by_path path
-    stub = stubs.find { |spec|
-      spec.contains_requirable_file? path
-    }
-    stub && stub.to_spec
+    stubs.find { |spec| spec.contains_requirable_file? path }
   end
 
   ##

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1967,7 +1967,6 @@ class Gem::Specification
   def initialize name = nil, version = nil
     super()
     @loaded = false
-    @activated = false
     @loaded_from = nil
     @original_platform = nil
     @installed_by_version = nil

--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -170,7 +170,7 @@ class Gem::StubSpecification < DelegateClass(Gem::Specification)
   end
 
   def __getobj__
-    spec = super { load_gemspec! }
+    spec = super { __setobj__ load_gemspec! }
     # FIXME: apparently the stub specification can be mutated, then mutate
     # the real specification after it's loaded.  We should stop doing that
     # so that we can remove this check.
@@ -203,13 +203,12 @@ class Gem::StubSpecification < DelegateClass(Gem::Specification)
   private
 
   def load_gemspec!
-    @spec ||= if @data then
-                Gem.loaded_specs.values.find { |spec|
-                  spec.name == name and spec.version == version
-                }
-              end
-
-    @spec ||= Gem::Specification.load(loaded_from)
-    __setobj__ @spec
+    if @data then
+      Gem.loaded_specs.values.find { |spec|
+        spec.name == name and spec.version == version
+      } || Gem::Specification.load(loaded_from)
+    else
+      Gem::Specification.load(loaded_from)
+    end
   end
 end

--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -3,7 +3,10 @@
 # us having to eval the entire gemspec in order to find out certain
 # information.
 
-class Gem::StubSpecification < Gem::BasicSpecification
+class Gem::StubSpecification
+  include Gem::BasicSpecification
+  extend Gem::BasicSpecification::ClassMethods
+
   # :nodoc:
   PREFIX = "# stub: "
 

--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -169,6 +169,19 @@ class Gem::StubSpecification < DelegateClass(Gem::Specification)
     __getobj__
   end
 
+  if RUBY_VERSION <= '2.0.0'
+    module DelegateComat
+      def __getobj__  # :nodoc:
+        unless defined?(@delegate_dc_obj)
+          return yield if block_given?
+          __raise__ ::ArgumentError, "not delegated"
+        end
+        @delegate_dc_obj
+      end
+    end
+    include DelegateComat
+  end
+
   def __getobj__
     spec = super { __setobj__ load_gemspec! }
     # FIXME: apparently the stub specification can be mutated, then mutate

--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -95,10 +95,7 @@ class Gem::StubSpecification < DelegateClass(Gem::Specification)
       end
     end
 
-    unless @data
-      @data = __getobj__
-    end
-    @data
+    @data ||= __getobj__
   end
 
   private :data

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -987,7 +987,7 @@ Also, a list:
   # Best used with +@all_gems+ from #util_setup_fake_fetcher.
 
   def util_setup_spec_fetcher(*specs)
-    all_specs = Gem::Specification.to_a + specs
+    all_specs = Gem::Specification.to_a.map(&:to_spec) + specs
     Gem::Specification._resort! all_specs
 
     spec_fetcher = Gem::SpecFetcher.fetcher

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -194,7 +194,7 @@ class TestGem < Gem::TestCase
 
     Gem.clear_paths
 
-    assert_nil Gem::Specification.send(:class_variable_get, :@@all)
+    assert_nil Gem::Specification.send(:class_variable_get, :@@stubs)
   end
 
   def test_self_configuration

--- a/test/rubygems/test_gem_resolver_lock_specification.rb
+++ b/test/rubygems/test_gem_resolver_lock_specification.rb
@@ -92,7 +92,7 @@ class TestGemResolverLockSpecification < Gem::TestCase
 
     l_spec = @LS.new @set, 'a', version, @source, Gem::Platform::RUBY
 
-    assert_same real_spec, l_spec.spec
+    assert_same real_spec, l_spec.spec.to_spec
   end
 
 end

--- a/test/rubygems/test_gem_stub_specification.rb
+++ b/test/rubygems/test_gem_stub_specification.rb
@@ -113,7 +113,9 @@ class TestStubSpecification < Gem::TestCase
   end
 
   def test_to_spec
-    real_foo = util_spec @foo.name, @foo.version
+    real_foo = util_spec @foo.name, @foo.version do |spec|
+      spec.platform = @foo.platform
+    end
     real_foo.activate
 
     assert_equal @foo.version, Gem.loaded_specs[@foo.name].version,
@@ -131,7 +133,6 @@ class TestStubSpecification < Gem::TestCase
   end
 
   def test_to_spec_activated
-    assert @foo.to_spec.is_a?(Gem::Specification)
     assert_equal "foo", @foo.to_spec.name
     refute @foo.to_spec.instance_variable_defined? :@ignored
   end


### PR DESCRIPTION
This pull request changes `Gem::StubSpecification` to be a delegate object that delegates to a lazily loaded `Gem::Specification`.
### Advantages
- `Gem::Specification._all` and `stubs` are synonyms, so you can use the `Enumerable` methods on `Gem::Specification` without accidentally actually loading all specifications
- Since `Gem::StubSpecification` will delegate to a real specification, we can stop calling `to_spec` on the stubs and just return the stub object itself
- Cache invalidation is easier since we only have to manage a list of stubs (not `@@stubs` **and** `@@all`)
### Disadvantages
- Since we only deal with stubs specification objects, it can break `is_a?` checks.  I had to remove an is_a check [here](https://github.com/rubygems/rubygems/compare/rubygems:master...tenderlove:spec_delegate?expand=1#diff-85fbee5acd2a7ba48fabb0e047a8c463L74) and [here](https://github.com/rubygems/rubygems/compare/rubygems:master...tenderlove:spec_delegate?expand=1#diff-c4bc5f3d440d5a8e5ebae6c4e16782a4L134), and I know for sure that bundler does is_a checks [here](https://github.com/bundler/bundler/blob/94be4481dd55c7c0a562edcdc72d28b7bba3b500/lib/bundler/index.rb#L76).

I left [`to_spec` in tact](https://github.com/rubygems/rubygems/compare/rubygems:master...tenderlove:spec_delegate?expand=1#diff-6e383fc55f842a23cc890109a802d609R168) so if you really really need the underlying spec object, you can get it (though I don't advise it because that's slow).
### Further work

Since `_all` and `stubs` can be synonyms, and `_all` is nodoc'd, I think we could rm `_all` and back the `Enumerable` methods by `stubs`.

It seems like there may be some other places in bundler that are doing is_a? checks, but I need to find them.  If this seems like an OK path forward, I will fix bundler specs before merging.
