### PR TITLE
[require] try to defer to the load path even when there are unresolve…

### DIFF
--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -49,9 +49,12 @@ module Kernel
     # If there are no unresolved deps, then we can use just try
     # normal require handle loading a gem from the rescue below.
 
-    if Gem::Specification.unresolved_deps.empty? then
+    begin
       RUBYGEMS_ACTIVATION_MONITOR.exit
-      return gem_original_require(path)
+      original = gem_original_require(path)
+      return original
+    rescue LoadError
+      RUBYGEMS_ACTIVATION_MONITOR.enter
     end
 
     # If +path+ is for a gem that has already been loaded, don't
@@ -136,4 +139,3 @@ module Kernel
   private :require
 
 end
-

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -143,12 +143,12 @@ class TestGemRequire < Gem::TestCase
 
     refute require('benchmark'), "benchmark should have already been loaded"
 
-    # We detected that we should activate b-2, so we did so, but
-    # then original_require decided "I've already got benchmark.rb" loaded.
-    # This case is fine because our lazy loading is provided exactly
-    # the same behavior as eager loading would have.
+    # We dont activate any version of `b` yet, since we found a `benchmark` to
+    # require in the load path (or already required, as is the case here)
+    # before we got to checking the unresolved specs
 
-    assert_equal %w(a-1 b-2), loaded_spec_names
+    assert_equal %w(a-1), loaded_spec_names
+    assert_equal unresolved_names, ["b (>= 1)"]
   end
 
   def test_already_activated_direct_conflict


### PR DESCRIPTION
…d specs

This fixes issues I've been having all day with Ruby shipping with rake in the stdlib