### PR TITLE
Use StringIO in specification.rb

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -12,8 +12,8 @@ require 'rubygems/platform'
 require 'rubygems/deprecate'
 require 'rubygems/basic_specification'
 require 'rubygems/stub_specification'
-require 'rubygems/util/stringio'
 require 'rubygems/util/list'
+require 'stringio'
 
 ##
 # The Specification class contains the information for a Gem.  Typically
@@ -2538,7 +2538,7 @@ class Gem::Specification < Gem::BasicSpecification
       builder << self
       ast = builder.tree
 
-      io = Gem::StringSink.new
+      io = StringIO.new
       io.set_encoding Encoding::UTF_8 if Object.const_defined? :Encoding
 
       Psych::Visitors::Emitter.new(io).accept(ast)


### PR DESCRIPTION
Use ``` StringIO ``` instead of ``` Gem::StringSink ``` because util/stringio.rb was removed in #1250