### PR TITLE
Fix sorting of platforms

### DIFF
--- a/lib/rubygems/request_set/lockfile.rb
+++ b/lib/rubygems/request_set/lockfile.rb
@@ -185,7 +185,7 @@ class Gem::RequestSet::Lockfile
 
     platforms = platforms.sort_by { |platform| platform.to_s }
 
-    platforms.sort.each do |platform|
+    platforms.each do |platform|
       out << "  #{platform}"
     end
 


### PR DESCRIPTION
The double sorting of `platforms` is an obvious bug. Here's a fix.

**Details**
Env: Windows, Ruby 2.2.2p95, RubyGems 2.4.7.
Running `gem install -g --debug` on a simple Gemfile fails with

    Exception `ArgumentError' at c:/home/vendor/ruby-2.2/lib/ruby/site_ruby/2.2.0/rubygems/request_set/lockfile.rb:188 - comparison of String with Gem::Platform failed
    ERROR:  While executing gem ... (ArgumentError)
    comparison of String with Gem::Platform failed
    c:/home/vendor/ruby-2.2/lib/ruby/site_ruby/2.2.0/rubygems/request_set/lockfile.rb:188:in `sort'
    c:/home/vendor/ruby-2.2/lib/ruby/site_ruby/2.2.0/rubygems/request_set/lockfile.rb:188:in `add_PLATFORMS'

In my case, the `platforms` array contains a `String` and a `Gem::Platform`, which can't be compared.
The `sort_by(&:to_s)` in line 186 fixes this, but its result is never used.