### PR TITLE
Use URI::Generic#hostname for ipv6 friendly host passed to Net::HTTP

### DIFF
--- a/lib/rubygems/request/connection_pools.rb
+++ b/lib/rubygems/request/connection_pools.rb
@@ -61,18 +61,22 @@ class Gem::Request::ConnectionPools # :nodoc:
   end
 
   def net_http_args uri, proxy_uri
-    net_http_args = [uri.host, uri.port]
+    # URI::Generic#hostname was added in ruby 1.9.3, use it if exists, otherwise
+    # don't support IPv6 literals and use host.
+    hostname = uri.respond_to?(:hostname) ? uri.hostname : uri.host
+    net_http_args = [hostname, uri.port]
 
     no_proxy = get_no_proxy_from_env
 
-    if proxy_uri and not no_proxy?(uri.host, no_proxy) then
+    if proxy_uri and not no_proxy?(hostname, no_proxy) then
+      proxy_hostname = proxy_uri.respond_to?(:hostname) ? proxy_uri.hostname : proxy_uri.host
       net_http_args + [
-        proxy_uri.host,
+        proxy_hostname,
         proxy_uri.port,
         Gem::UriFormatter.new(proxy_uri.user).unescape,
         Gem::UriFormatter.new(proxy_uri.password).unescape,
       ]
-    elsif no_proxy? uri.host, no_proxy then
+    elsif no_proxy? hostname, no_proxy then
       net_http_args + [nil, nil]
     else
       net_http_args

--- a/test/rubygems/test_gem_request_connection_pools.rb
+++ b/test/rubygems/test_gem_request_connection_pools.rb
@@ -80,6 +80,15 @@ class TestGemRequestConnectionPool < Gem::TestCase
     assert_equal ['example', 80], net_http_args
   end
 
+  def test_net_http_args_ipv6
+    pools = Gem::Request::ConnectionPools.new nil, []
+
+    net_http_args = pools.send :net_http_args, URI('http://[::1]'), nil
+
+    expected_host = RUBY_VERSION >= "1.9.3" ? "::1" : "[::1]"
+    assert_equal [expected_host, 80], net_http_args
+  end
+
   def test_net_http_args_proxy
     pools = Gem::Request::ConnectionPools.new nil, []
 


### PR DESCRIPTION
Fixes 'SocketError: getaddrinfo: Name or service not known' when IPv6
literal such as '[::1]' is passed to the Socket layer in Net::HTTP.

Ruby versions less than 1.9.3 do not have this hostname method, so it
will gracefully use the existing host method which is not IPv6 friendly.

Fixes #1269