### PR TITLE
Allow installing a gem inside a rescue block

### DIFF
--- a/lib/rubygems/request_set.rb
+++ b/lib/rubygems/request_set.rb
@@ -166,9 +166,6 @@ class Gem::RequestSet
       requests << inst.install
     end
 
-    requests
-  ensure
-    raise if $!
     return requests if options[:gemdeps]
 
     specs = requests.map do |request|
@@ -187,6 +184,8 @@ class Gem::RequestSet
     Gem.done_installing_hooks.each do |hook|
       hook.call inst, specs
     end unless Gem.done_installing_hooks.empty?
+
+    requests
   end
 
   ##

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -90,6 +90,23 @@ class TestGem < Gem::TestCase
     assert_path_exists File.join(gemhome2, 'gems', 'a-1')
   end
 
+  def test_self_install_in_rescue
+    spec_fetcher do |f|
+      f.gem  'a', 1
+      f.spec 'a', 2
+    end
+
+    gemhome2 = "#{@gemhome}2"
+
+    installed =
+      begin
+        raise 'Error'
+      rescue StandardError
+        Gem.install 'a', '= 1', :install_dir => gemhome2
+      end
+    assert_equal %w[a-1], installed.map { |spec| spec.full_name }
+  end
+
   def test_require_missing
     save_loaded_features do
       assert_raises ::LoadError do


### PR DESCRIPTION
Closes #1281

That `raise if $!` meant that anytime you were in a rescue block,
you'd get a non-sensical exception raised.