### PR TITLE
Avoid crashing when gem is "half-uninstalled"

### DIFF
--- a/lib/rubygems/dependency_list.rb
+++ b/lib/rubygems/dependency_list.rb
@@ -141,6 +141,9 @@ class Gem::DependencyList
   def ok_to_remove?(full_name, check_dev=true)
     gem_to_remove = find_name full_name
 
+    # If the state is inconsistent, at least don't crash
+    return true unless gem_to_remove
+
     siblings = @specs.find_all { |s|
       s.name == gem_to_remove.name &&
         s.full_name != gem_to_remove.full_name


### PR DESCRIPTION
Due to maybe another problem, somehow, `gem uninstall` showed available gems
for uninstalling, but failed to uninstall.

This helps avoid the crash of calling :name on a nil.

Logically, it should be "ok to remove" (`ok_to_remove?`) a gem if it actually
"was removed" (i.e. doesn't seem to be listed).

At the very least this patch makes uninstalling possible and the actual problem
is handed off to where things can be handled/repared.