### PR TITLE
URI::Generic#hostname isn't needed here since the URIs aren't IPv6.

### DIFF
--- a/util/update_bundled_ca_certificates.rb
+++ b/util/update_bundled_ca_certificates.rb
@@ -10,7 +10,8 @@ URIS = [
 ]
 
 def connect_to uri, store
-  http = Net::HTTP.new uri.hostname, uri.port
+  # None of the URIs are IPv6, so URI::Generic#hostname(ruby 1.9.3+) isn't needed
+  http = Net::HTTP.new uri.host, uri.port
 
   http.use_ssl = uri.scheme.downcase == 'https'
   http.ssl_version = :TLSv1_2


### PR DESCRIPTION
I don't see a need to break pre-1.9.3 rubies for this.

On ruby 1.9.2, this script fails:
```
util/update_bundled_ca_certificates.rb:13:in `connect_to': undefined method `hostname' for #<URI::HTTPS:0x007fc6d5885ec0 URL:https://rubygems.org> (NoMethodError)
```

This tool was added here: 82ed63eb599e0854

cc @drbrain 