### PR TITLE
Increase DH key size (fixes #1289).

### DIFF
--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -898,7 +898,7 @@ gems:
       server.mount_proc("/insecure_redirect") { |req, res|
         res.set_redirect(WEBrick::HTTPStatus::MovedPermanently, req.query['to'])
       }
-      server.ssl_context.tmp_dh_callback = proc { OpenSSL::PKey::DH.new 128 }
+      server.ssl_context.tmp_dh_callback = proc { OpenSSL::PKey::DH.new 2048 }
       t = Thread.new do
         begin
           server.start


### PR DESCRIPTION
This fixes compatibility with OpenSLL 1.0.2c+:

https://www.openssl.org/blog/blog/2015/05/20/logjam-freak-upcoming-changes/

Unfortunately, the tests feels slower now, but there is probably no other way to fix this.