### PR TITLE
add raising exception on unhandled gem options

### DIFF
--- a/lib/rubygems/request_set/gem_dependency_api.rb
+++ b/lib/rubygems/request_set/gem_dependency_api.rb
@@ -407,17 +407,43 @@ Gem dependencies file #{@path} requires #{name} more than once.
 
     pin_gem_source name, :git, repository
 
-    reference = nil
-    reference ||= options.delete :ref
-    reference ||= options.delete :branch
-    reference ||= options.delete :tag
-    reference ||= 'master'
+    reference = gem_git_reference options
 
     submodules = options.delete :submodules
 
     @git_set.add_git_gem name, repository, reference, submodules
 
     true
+  end
+
+  ##
+  # Handles the git options from +options+ for git gem.
+  #
+  # Returns reference for the git gem.
+
+  def gem_git_reference options # :nodoc:
+    ref    = options.delete :ref
+    branch = options.delete :branch
+    tag    = options.delete :tag
+
+    reference = nil
+    reference ||= ref
+    reference ||= branch
+    reference ||= tag
+    reference ||= 'master'
+
+    if ref && branch
+      warn <<-WARNING
+Gem dependencies file #{@path} includes git reference for both ref and branch but only ref is used.
+      WARNING
+    end
+    if (ref||branch) && tag
+      warn <<-WARNING
+Gem dependencies file #{@path} includes git reference for both ref/branch and tag but only ref/branch is used.
+      WARNING
+    end
+
+    reference
   end
 
   private :gem_git
@@ -526,6 +552,7 @@ Gem dependencies file #{@path} requires #{name} more than once.
     else
       @requires[name] << name
     end
+    raise "Unhandled gem options #{options.inspect}" unless options.empty?
   end
 
   private :gem_requires

--- a/test/rubygems/test_gem_request_set_gem_dependency_api.rb
+++ b/test/rubygems/test_gem_request_set_gem_dependency_api.rb
@@ -144,7 +144,11 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
   end
 
   def test_gem_git_branch
-    @gda.gem 'a', :git => 'git/a', :branch => 'other', :tag => 'v1'
+    _, err = capture_io do
+      @gda.gem 'a', :git => 'git/a', :branch => 'other', :tag => 'v1'
+    end
+    expected = "Gem dependencies file gem.deps.rb includes git reference for both ref/branch and tag but only ref/branch is used."
+    assert_match expected, err
 
     assert_equal [dep('a')], @set.dependencies
 
@@ -161,7 +165,11 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
   end
 
   def test_gem_git_ref
-    @gda.gem 'a', :git => 'git/a', :ref => 'abcd123', :branch => 'other'
+    _, err = capture_io do
+      @gda.gem 'a', :git => 'git/a', :ref => 'abcd123', :branch => 'other'
+    end
+    expected = "Gem dependencies file gem.deps.rb includes git reference for both ref and branch but only ref is used."
+    assert_match expected, err
 
     assert_equal [dep('a')], @set.dependencies
 


### PR DESCRIPTION
help in debugging unimplemented code for #1286, when user specifies options that are not handled an exception will be raised, optionally this could be a warning, so far:

- add raising exception on unhandled gem options
- add handling of all git options
- raise warnings on unhandled git options
- handle the warnings in tests
