### PR TITLE
Correct the help for the update command

### DIFF
--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -47,7 +47,7 @@ class Gem::Commands::UpdateCommand < Gem::Command
   end
 
   def arguments # :nodoc:
-    "REGEXP        regexp to search for in gem name"
+    "GEMNAME       name of gem to update"
   end
 
   def defaults_str # :nodoc:
@@ -64,7 +64,7 @@ command to remove old versions.
   end
 
   def usage # :nodoc:
-    "#{program_name} REGEXP [REGEXP ...]"
+    "#{program_name} GEMNAME [GEMNAME ...]"
   end
 
   def check_latest_rubygems version # :nodoc:


### PR DESCRIPTION
The update command used to use a regular expression to match gem names for updating, but this was changed to exact matching in 6054db76.  It appears that that change crossed over with a6360ce2, which was an attempt to correct the previously-incorrect documentation.

This change effectively reverts the change from a6360ce2 and means that both functionality and documentation now match.