### PR TITLE
Fixes issue where cannot override Gem::ConfigFile attributes.

### DIFF
--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -461,12 +461,12 @@ if you believe they were disclosed to a third party.
 
   # Return the configuration information for +key+.
   def [](key)
-    @hash[key.to_s]
+    @hash[key.to_sym]
   end
 
   # Set configuration option +key+ to +value+.
   def []=(key, value)
-    @hash[key.to_s] = value
+    @hash[key.to_sym] = value
   end
 
   def ==(other) # :nodoc:


### PR DESCRIPTION
This actually makes these two methods work correctly. Because this whole
class uses symbols instead of strings on @hash it doesn't make any sense
here why it would coerce the keys into strings.