### PR TITLE
Update doc for required_ruby_version=

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -619,6 +619,10 @@ class Gem::Specification < Gem::BasicSpecification
   #   ruby 2.0.0p247 (2013-06-27 revision 41674) [x86_64-darwin12.4.0]
   #   #<Gem::Version "2.0.0.247">
   #
+  # Because patch-level is taken into account, be very careful specifying using
+  # `<=`: `<= 2.2.2` will not match any patch-level of 2.2.2 after the `p0`
+  # release. It is much safer to specify `< 2.2.3` instead
+  #
   # Usage:
   #
   #  # This gem will work with 1.8.6 or greater...
@@ -626,6 +630,9 @@ class Gem::Specification < Gem::BasicSpecification
   #
   #  # Only with ruby 2.0.x
   #  spec.required_ruby_version = '~> 2.0'
+  #
+  #  # Only with ruby between 2.2.0 and 2.2.2
+  #  spec.required_ruby_version = ['>= 2.2.0', '< 2.2.3']
 
   def required_ruby_version= req
     @required_ruby_version = Gem::Requirement.create req


### PR DESCRIPTION
Update doc for `required_ruby_version=` with a note about the dangers of
using `<=` with tiny versions, a recommendation to use `<` instead, and
an example showing restricting a gem between two versions of ruby.