### PR TITLE
Nicer NFS handling in rubygems, remote fetcher

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -778,6 +778,14 @@ module Gem
     open path, 'rb' do |f|
       f.read
     end
+  rescue Errno::ENOLCK # NFS
+    if Thread.main != Thread.current
+      raise
+    else
+      open path, 'rb' do |f|
+        f.read
+      end
+    end
   end
 
   ##

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -312,9 +312,19 @@ class Gem::RemoteFetcher
     end
 
     if update and path
-      open(path, 'wb') do |io|
-        io.flock(File::LOCK_EX)
-        io.write data
+      begin
+        open(path, 'wb') do |io|
+          io.flock(File::LOCK_EX)
+          io.write data
+        end
+      rescue Errno::ENOLCK # NFS
+        if Thread.main != Thread.current
+          raise
+        else
+          open(path, 'wb') do |io|
+            io.write data
+          end
+        end
       end
     end
 


### PR DESCRIPTION
This is an attempt to deal with gem installation on NFS. The issue was originally caused by https://github.com/rubygems/rubygems/pull/737 and reported in https://github.com/rubygems/rubygems/issues/1176.

The problem is that NFS really doesn't support file locking. There are ways to deal with it, but none of them are pretty, and beyond the scope of this project IMO. See http://0pointer.de/blog/projects/locking.html on the joys of locking, for example.

There's no actual use case for #737 in the original PR, though we've speculated that there are issues that could theoretically occur, e.g. multiple bundlers installing the same gem at the same time in a cron job or something, so it's best to keep it in there if we can.

This PR is meant as a fallback for NFS. Basically, it will check for an Errno::ENOLCK and try again without the lock, assuming you aren't in a multithreaded environment.

@Who828 and @mooreryan, feedback welcome.

