### PR TITLE
Fix some path quoting issues in the test suite

### DIFF
--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -1222,8 +1222,8 @@ Also, a list:
   end
 
   @@ruby = rubybin
-  @@good_rake = "#{rubybin} #{File.expand_path('../../../test/rubygems/good_rake.rb', __FILE__)}"
-  @@bad_rake = "#{rubybin} #{File.expand_path('../../../test/rubygems/bad_rake.rb', __FILE__)}"
+  @@good_rake = "#{rubybin} \"#{File.expand_path('../../../test/rubygems/good_rake.rb', __FILE__)}\""
+  @@bad_rake = "#{rubybin} \"#{File.expand_path('../../../test/rubygems/bad_rake.rb', __FILE__)}\""
 
   ##
   # Construct a new Gem::Dependency.

--- a/test/rubygems/test_config.rb
+++ b/test/rubygems/test_config.rb
@@ -10,5 +10,15 @@ class TestConfig < Gem::TestCase
     assert_equal "#{spec.full_gem_path}/data/a", Gem.datadir('a')
   end
 
+  def test_good_rake_path_is_escaped
+    path = Gem::TestCase.class_eval('@@good_rake')
+    assert_match(/ruby "[^"]*good_rake.rb"/, path)
+  end
+
+  def test_bad_rake_path_is_escaped
+    path = Gem::TestCase.class_eval('@@bad_rake')
+    assert_match(/ruby "[^"]*bad_rake.rb"/, path)
+  end
+
 end
 

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1311,7 +1311,7 @@ class TestGem < Gem::TestCase
     ENV['GEM_PATH'] = path
     ENV['RUBYGEMS_GEMDEPS'] = "-"
 
-    out = `#{Gem.ruby.dup.untaint} -I #{LIB_PATH.untaint} -rubygems -e "p Gem.loaded_specs.values.map(&:full_name).sort"`
+    out = `#{Gem.ruby.dup.untaint} -I "#{LIB_PATH.untaint}" -rubygems -e "p Gem.loaded_specs.values.map(&:full_name).sort"`
 
     assert_equal '["a-1", "b-1", "c-1"]', out.strip
   end
@@ -1343,7 +1343,7 @@ class TestGem < Gem::TestCase
 
     Dir.mkdir "sub1"
     out = Dir.chdir "sub1" do
-      `#{Gem.ruby.dup.untaint} -I #{LIB_PATH.untaint} -rubygems -e "p Gem.loaded_specs.values.map(&:full_name).sort"`
+      `#{Gem.ruby.dup.untaint} -I "#{LIB_PATH.untaint}" -rubygems -e "p Gem.loaded_specs.values.map(&:full_name).sort"`
     end
 
     Dir.rmdir "sub1"


### PR DESCRIPTION
Running the test suite with a directory structure that includes brackets `()` would cause multiple tests to fail. This PR resolves those issues. 