### PR TITLE
Feature/add norc flag

### DIFF
--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -539,6 +539,11 @@ class Gem::Command
                     'Turn on Ruby debugging') do
   end
 
+  add_common_option('--norc',
+                    'Avoid loading any .gemrc file') do
+  end
+
+
   # :stopdoc:
 
   HELP = <<-HELP

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -200,11 +200,12 @@ class Gem::ConfigFile
       result.merge load_file file
     end
 
-
     @hash = operating_system_config.merge platform_config
-    @hash = @hash.merge system_config
-    @hash = @hash.merge user_config
-    @hash = @hash.merge environment_config
+    unless arg_list.index '--norc'
+      @hash = @hash.merge system_config
+      @hash = @hash.merge user_config
+      @hash = @hash.merge environment_config
+    end
 
     # HACK these override command-line args, which is bad
     @backtrace                  = @hash[:backtrace]                  if @hash.key? :backtrace

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -269,6 +269,29 @@ if you believe they were disclosed to a third party.
     assert_equal true, @cfg.backtrace
   end
 
+  def test_handle_arguments_norc
+    assert_equal @temp_conf, @cfg.config_file_name
+
+    File.open @temp_conf, 'w' do |fp|
+      fp.puts ":backtrace: true"
+      fp.puts ":update_sources: false"
+      fp.puts ":bulk_threshold: 10"
+      fp.puts ":verbose: false"
+      fp.puts ":sources:"
+      fp.puts "  - http://more-gems.example.com"
+    end
+
+    args = %W[--norc]
+
+    util_config_file args
+
+    assert_equal false, @cfg.backtrace
+    assert_equal true, @cfg.update_sources
+    assert_equal Gem::ConfigFile::DEFAULT_BULK_THRESHOLD, @cfg.bulk_threshold
+    assert_equal true, @cfg.verbose
+    assert_equal [@gem_repo], Gem.sources
+  end
+
   def test_load_api_keys
     temp_cred = File.join Gem.user_home, '.gem', 'credentials'
     FileUtils.mkdir File.dirname(temp_cred)


### PR DESCRIPTION
This pull request adds  the --norc flag to rubygems, this feature will avoid the loading of any .gemrc file in the config file setup.