### PR TITLE
match host and scheme on allowed_push_host

### DIFF
--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -68,9 +68,14 @@ module Gem::GemcutterUtilities
       terminate_interaction 1 # TODO: question this
     end
 
-    if allowed_push_host and self.host != allowed_push_host
-      alert_error "#{self.host.inspect} is not allowed by the gemspec, which only allows #{allowed_push_host.inspect}"
-      terminate_interaction 1
+    if allowed_push_host
+      allowed_host_uri = URI.parse(allowed_push_host)
+      host_uri         = URI.parse(self.host)
+
+      unless (host_uri.scheme == allowed_host_uri.scheme) && (host_uri.host == allowed_host_uri.host)
+        alert_error "#{self.host.inspect} is not allowed by the gemspec, which only allows #{allowed_push_host.inspect}"
+        terminate_interaction 1
+      end
     end
 
     uri = URI.parse "#{self.host}/#{path}"

--- a/test/rubygems/test_gem_commands_push_command.rb
+++ b/test/rubygems/test_gem_commands_push_command.rb
@@ -177,6 +177,33 @@ class TestGemCommandsPushCommand < Gem::TestCase
     send_battery
   end
 
+  def test_sending_gem_to_allowed_push_host_with_basic_credentials
+    @sanitized_host = "http://privategemserver.com"
+    @host           = "http://user:password@privategemserver.com"
+
+    @spec, @path = util_gem "freebird", "1.0.1" do |spec|
+      spec.metadata['allowed_push_host'] = @sanitized_host
+    end
+
+    @api_key = "DOESNTMATTER"
+
+    keys = {
+      :rubygems_api_key => @api_key,
+    }
+
+    FileUtils.mkdir_p File.dirname Gem.configuration.credentials_path
+    open Gem.configuration.credentials_path, 'w' do |f|
+      f.write keys.to_yaml
+    end
+    Gem.configuration.load_api_keys
+
+    FileUtils.rm Gem.configuration.credentials_path
+
+    @response = "Successfully registered gem: freebird (1.0.1)"
+    @fetcher.data["#{@host}/api/v1/gems"]  = [@response, 200, 'OK']
+    send_battery
+  end
+
   def test_sending_gem_to_disallowed_default_host
     @spec, @path = util_gem "freebird", "1.0.1" do |spec|
       spec.metadata['allowed_push_host'] = "https://privategemserver.com"


### PR DESCRIPTION
allows for host restrictions in the gemspec without leaking credentials
in the repository

specific usecase is geminabox private gem server that uses basic
authentication instead of tokens