### PR TITLE
Fix undefined method `contains_requirable_file?' for nil:NilClass which occurs in running ruby processes when gems are uninstalled.

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1007,7 +1007,7 @@ class Gem::Specification < Gem::BasicSpecification
 
   def self.find_by_path path
     stub = stubs.find { |spec|
-      spec.contains_requirable_file? path
+      spec.contains_requirable_file? path if spec
     }
     stub && stub.to_spec
   end
@@ -1018,7 +1018,7 @@ class Gem::Specification < Gem::BasicSpecification
 
   def self.find_inactive_by_path path
     stub = stubs.find { |s|
-      s.contains_requirable_file? path unless s.activated?
+      s.contains_requirable_file? path unless s.nil? || s.activated?
     }
     stub && stub.to_spec
   end
@@ -1030,7 +1030,7 @@ class Gem::Specification < Gem::BasicSpecification
     # TODO: do we need these?? Kill it
     specs = unresolved_deps.values.map { |dep| dep.to_specs }.flatten
 
-    specs.find_all { |spec| spec.contains_requirable_file? path }
+    specs.find_all { |spec| spec.contains_requirable_file? path if spec }
   end
 
   ##


### PR DESCRIPTION
In order to reproduce the bug I was hitting, install multiple versions of a gem, run the gist below and then execute gem cleanup while the script is running.  I was unable to create a test that reproduces the bug so I did not include any kind of regression test for this.

https://gist.github.com/pdrakeweb/61d4f89fbdf22b4566b0