### PR TITLE
Feature/show user installation directory when calling 'gem env'

### DIFF
--- a/lib/rubygems/commands/environment_command.rb
+++ b/lib/rubygems/commands/environment_command.rb
@@ -113,6 +113,8 @@ lib/rubygems/defaults/operating_system.rb
 
     out << "  - INSTALLATION DIRECTORY: #{Gem.dir}\n"
 
+    out << "  - USER INSTALLATION DIRECTORY: #{Gem.user_dir}\n"
+
     out << "  - RUBYGEMS PREFIX: #{Gem.prefix}\n" unless Gem.prefix.nil?
 
     out << "  - RUBY EXECUTABLE: #{Gem.ruby}\n"


### PR DESCRIPTION
When using <code>gem env</code> show where things will be installed when using <code>--user-install</code>.

This was requested in: https://github.com/rubygems/rubygems/issues/1310