### PR TITLE
add support for Gemfile gem sources

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -56,6 +56,10 @@ Minor enhancements:
   Pull request #1328 by Gavin Miller.
 * Fix NoMethodError in running ruby processes when gems are uninstalled.
   Pull request #1332 by Peter Drake.
+* Emit a warning on SRV resolve failure.
+  Pull request #1023 by Ivan Kuchin.
+* Allow duplicate dependencies between runtime and development.
+  Pull request #1032 by Murray Steele.
 
 Bug fixes:
 

--- a/lib/rubygems/request_set.rb
+++ b/lib/rubygems/request_set.rb
@@ -77,6 +77,11 @@ class Gem::RequestSet
   attr_reader :vendor_set # :nodoc:
 
   ##
+  # The set of source gems imported via load_gemdeps.
+
+  attr_reader :source_set
+
+  ##
   # Creates a RequestSet for a list of Gem::Dependency objects, +deps+.  You
   # can then #resolve and #install the resolved list of dependencies.
   #
@@ -105,6 +110,7 @@ class Gem::RequestSet
     @sorted              = nil
     @specs               = nil
     @vendor_set          = nil
+    @source_set          = nil
 
     yield self if block_given?
   end
@@ -271,6 +277,7 @@ class Gem::RequestSet
   def load_gemdeps path, without_groups = [], installing = false
     @git_set    = Gem::Resolver::GitSet.new
     @vendor_set = Gem::Resolver::VendorSet.new
+    @source_set = Gem::Resolver::SourceSet.new
 
     @git_set.root_dir = @install_dir
 
@@ -338,6 +345,7 @@ class Gem::RequestSet
     @sets << set
     @sets << @git_set
     @sets << @vendor_set
+    @sets << @source_set
 
     set = Gem::Resolver.compose_sets(*@sets)
     set.remote = @remote

--- a/lib/rubygems/request_set/gem_dependency_api.rb
+++ b/lib/rubygems/request_set/gem_dependency_api.rb
@@ -204,6 +204,7 @@ class Gem::RequestSet::GemDependencyAPI
     @installing         = false
     @requires           = Hash.new { |h, name| h[name] = [] }
     @vendor_set         = @set.vendor_set
+    @source_set         = @set.source_set
     @gem_sources        = {}
     @without_groups     = []
 
@@ -517,7 +518,7 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
 
     pin_gem_source name, :source, source
 
-    Gem.sources << source
+    @source_set.add_source_gem name, source
 
     true
   end

--- a/lib/rubygems/request_set/gem_dependency_api.rb
+++ b/lib/rubygems/request_set/gem_dependency_api.rb
@@ -362,6 +362,7 @@ class Gem::RequestSet::GemDependencyAPI
     source_set ||= gem_path       name, options
     source_set ||= gem_git        name, options
     source_set ||= gem_git_source name, options
+    source_set ||= gem_source     name, options
 
     duplicate = @dependencies.include? name
 
@@ -505,6 +506,23 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
   end
 
   private :gem_path
+
+  ##
+  # Handles the source: option from +options+ for gem +name+.
+  #
+  # Returns +true+ if the source option was handled.
+
+  def gem_source name, options # :nodoc:
+    return unless source = options.delete(:source)
+
+    pin_gem_source name, :source, source
+
+    Gem.sources << source
+
+    true
+  end
+
+  private :gem_source
 
   ##
   # Handles the platforms: option from +options+.  Returns true if the
@@ -677,6 +695,7 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
       when :default then '(default)'
       when :path    then "path: #{source}"
       when :git     then "git: #{source}"
+      when :source  then "source: #{source}"
       else               '(unknown)'
       end
 

--- a/lib/rubygems/request_set/lockfile/parser.rb
+++ b/lib/rubygems/request_set/lockfile/parser.rb
@@ -326,9 +326,9 @@ class Gem::RequestSet::Lockfile::Parser
 
   def pinned_requirement name # :nodoc:
     requirement = Gem::Dependency.new name
-    specification = @set.sets.map { |set|
+    specification = @set.sets.flat_map { |set|
       set.find_all(requirement)
-    }.flatten.compact.first
+    }.compact.first
 
     specification.version
   end

--- a/lib/rubygems/request_set/lockfile/parser.rb
+++ b/lib/rubygems/request_set/lockfile/parser.rb
@@ -325,14 +325,12 @@ class Gem::RequestSet::Lockfile::Parser
   end
 
   def pinned_requirement name # :nodoc:
-    spec = @set.sets.select { |set|
-      Gem::Resolver::GitSet    === set or
-        Gem::Resolver::VendorSet === set
-    }.map { |set|
-      set.specs[name]
-    }.compact.first
+    requirement = Gem::Dependency.new name
+    specification = @set.sets.map { |set|
+      set.find_all(requirement)
+    }.flatten.compact.first
 
-    spec.version
+    specification.version
   end
 
   ##

--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -278,6 +278,7 @@ require 'rubygems/resolver/index_set'
 require 'rubygems/resolver/installer_set'
 require 'rubygems/resolver/lock_set'
 require 'rubygems/resolver/vendor_set'
+require 'rubygems/resolver/source_set'
 
 require 'rubygems/resolver/specification'
 require 'rubygems/resolver/spec_specification'

--- a/lib/rubygems/resolver/source_set.rb
+++ b/lib/rubygems/resolver/source_set.rb
@@ -1,0 +1,48 @@
+##
+# The SourceSet chooses the best available method to query a remote index.
+#
+# Kind off like BestSet but filters the sources for gems
+
+class Gem::Resolver::SourceSet < Gem::Resolver::Set
+
+  ##
+  # Creates a SourceSet for the given +sources+ or Gem::sources if none are
+  # specified.  +sources+ must be a Gem::SourceList.
+
+  def initialize
+    super()
+
+    @links = {}
+    @sets  = {}
+  end
+
+  def find_all req # :nodoc:
+    if set = get_set(req.dependency.name)
+      set.find_all req
+    else
+      []
+    end
+  end
+
+  # potentially no-op
+  def prefetch reqs # :nodoc:
+    reqs.each do |req|
+      if set = get_set(req.dependency.name)
+        set.prefetch reqs
+      end
+    end
+  end
+
+  def add_source_gem name, source
+    @links[name] = source
+  end
+
+private
+
+  def get_set(name)
+    link = @links[name]
+    @sets[link] ||= Gem::Source.new(link).dependency_resolver_set if link
+  end
+
+end
+

--- a/lib/rubygems/source_list.rb
+++ b/lib/rubygems/source_list.rb
@@ -9,7 +9,7 @@ require 'rubygems/source'
 # Or by adding them:
 #
 #   sources = Gem::SourceList.new
-#   sources.add 'https://rubygems.example'
+#   sources << 'https://rubygems.example'
 #
 # The most common way to get a SourceList is Gem.sources.
 


### PR DESCRIPTION
extends on  #1305 to add support for `Gemfile`s:
```ruby
gem "name", source: "http://..."
```
based on http://bundler.io/v1.10/man/gemfile.5.html#SOURCE-source-

work in progress, @drbrain does it go in right direction?
