### PR TITLE
gem cleanup is trying to uninstall gems outside GEM_HOME and reporting an error after it tries

### DIFF
--- a/lib/rubygems/commands/cleanup_command.rb
+++ b/lib/rubygems/commands/cleanup_command.rb
@@ -75,6 +75,9 @@ If no gems are named all gems in GEM_HOME are cleaned.
   end
 
   def clean_gems
+    @original_home = Gem.dir
+    @original_path = Gem.path
+
     get_primary_gems
     get_candidate_gems
     get_gems_to_cleanup
@@ -85,9 +88,6 @@ If no gems are named all gems in GEM_HOME are cleaned.
     @gems_to_cleanup.each do |spec| deplist.add spec end
 
     deps = deplist.strongly_connected_components.flatten
-
-    @original_home = Gem.dir
-    @original_path = Gem.path
 
     deps.reverse_each do |spec|
       uninstall_dep spec
@@ -107,12 +107,17 @@ If no gems are named all gems in GEM_HOME are cleaned.
   end
 
   def get_gems_to_cleanup
+
     gems_to_cleanup = @candidate_gems.select { |spec|
       @primary_gems[spec.name].version != spec.version
     }
 
     default_gems, gems_to_cleanup = gems_to_cleanup.partition { |spec|
       spec.default_gem?
+    }
+
+    gems_to_cleanup = gems_to_cleanup.select { |spec|
+      spec.base_dir == @original_home
     }
 
     @default_gems += default_gems

--- a/test/rubygems/test_gem_commands_cleanup_command.rb
+++ b/test/rubygems/test_gem_commands_cleanup_command.rb
@@ -111,7 +111,7 @@ class TestGemCommandsCleanupCommand < Gem::TestCase
     @cmd.execute
 
     assert_path_exists @a_1.gem_dir
-    refute_path_exists @a_1_1.gem_dir
+    assert_path_exists @a_1_1.gem_dir
   ensure
     FileUtils.chmod 0755, @gemhome
   end unless win_platform?

--- a/test/rubygems/test_gem_commands_cleanup_command.rb
+++ b/test/rubygems/test_gem_commands_cleanup_command.rb
@@ -164,5 +164,33 @@ class TestGemCommandsCleanupCommand < Gem::TestCase
     assert_match %r%^Skipped default gems: b-2%, @ui.output
     assert_empty @ui.error
   end
+
+  def test_execute_remove_gem_home_only
+    c_1, = util_gem 'c', '1'
+    c_2, = util_gem 'c', '2'
+    d_1, = util_gem 'd', '1'
+    d_2, = util_gem 'd', '2'
+    e_1, = util_gem 'e', '1'
+    e_2, = util_gem 'e', '2'
+
+    c_1 = install_gem c_1, :user_install => true # pick up user install path
+    c_2 = install_gem c_2
+
+    d_1 = install_gem d_1
+    d_2 = install_gem d_2, :user_install => true # pick up user install path
+
+    e_1 = install_gem e_1
+    e_2 = install_gem e_2
+
+    Gem::Specification.dirs = [Gem.dir, Gem.user_dir]
+
+    @cmd.options[:args] = []
+
+    @cmd.execute
+
+    assert_path_exists c_1.gem_dir
+    refute_path_exists d_1.gem_dir
+    refute_path_exists e_1.gem_dir
+  end
 end
 


### PR DESCRIPTION
This error happens when there's the same gem in any path of the GEM_PATH and one in the GEM_HOME, but the GEM_HOME one has a newer version than the one found in a path of GEM_PATH, so cleanup tries to remove the GEM_PATH one and fails.

This closes https://github.com/rubygems/rubygems/issues/1119, let me know if this is the right path for fixing this, or if i'm missing something, thanks.

@djberg96 