### PR TITLE
add support for Gemfile gem sources

### DIFF
--- a/lib/rubygems/request_set.rb
+++ b/lib/rubygems/request_set.rb
@@ -77,6 +77,11 @@ class Gem::RequestSet
   attr_reader :vendor_set # :nodoc:
 
   ##
+  # The set of source gems imported via load_gemdeps.
+
+  attr_reader :source_set
+
+  ##
   # Creates a RequestSet for a list of Gem::Dependency objects, +deps+.  You
   # can then #resolve and #install the resolved list of dependencies.
   #
@@ -105,6 +110,7 @@ class Gem::RequestSet
     @sorted              = nil
     @specs               = nil
     @vendor_set          = nil
+    @source_set          = nil
 
     yield self if block_given?
   end
@@ -271,6 +277,7 @@ class Gem::RequestSet
   def load_gemdeps path, without_groups = [], installing = false
     @git_set    = Gem::Resolver::GitSet.new
     @vendor_set = Gem::Resolver::VendorSet.new
+    @source_set = Gem::Resolver::SourceSet.new
 
     @git_set.root_dir = @install_dir
 
@@ -338,6 +345,7 @@ class Gem::RequestSet
     @sets << set
     @sets << @git_set
     @sets << @vendor_set
+    @sets << @source_set
 
     set = Gem::Resolver.compose_sets(*@sets)
     set.remote = @remote

--- a/lib/rubygems/request_set.rb
+++ b/lib/rubygems/request_set.rb
@@ -148,7 +148,6 @@ class Gem::RequestSet
       return requests
     end
 
-    cache_dir = options[:cache_dir] || Gem.dir
     @prerelease = options[:prerelease]
 
     requests = []
@@ -163,13 +162,11 @@ class Gem::RequestSet
         end
       end
 
-      path = req.download cache_dir
+      spec = req.spec.install options do |installer|
+        yield req, installer if block_given?
+      end
 
-      inst = Gem::Installer.at path, options
-
-      yield req, inst if block_given?
-
-      requests << inst.install
+      requests << spec
     end
 
     return requests if options[:gemdeps]

--- a/lib/rubygems/request_set/gem_dependency_api.rb
+++ b/lib/rubygems/request_set/gem_dependency_api.rb
@@ -407,17 +407,43 @@ Gem dependencies file #{@path} requires #{name} more than once.
 
     pin_gem_source name, :git, repository
 
-    reference = nil
-    reference ||= options.delete :ref
-    reference ||= options.delete :branch
-    reference ||= options.delete :tag
-    reference ||= 'master'
+    reference = gem_git_reference options
 
     submodules = options.delete :submodules
 
     @git_set.add_git_gem name, repository, reference, submodules
 
     true
+  end
+
+  ##
+  # Handles the git options from +options+ for git gem.
+  #
+  # Returns reference for the git gem.
+
+  def gem_git_reference options # :nodoc:
+    ref    = options.delete :ref
+    branch = options.delete :branch
+    tag    = options.delete :tag
+
+    reference = nil
+    reference ||= ref
+    reference ||= branch
+    reference ||= tag
+    reference ||= 'master'
+
+    if ref && branch
+      warn <<-WARNING
+Gem dependencies file #{@path} includes git reference for both ref and branch but only ref is used.
+      WARNING
+    end
+    if (ref||branch) && tag
+      warn <<-WARNING
+Gem dependencies file #{@path} includes git reference for both ref/branch and tag but only ref/branch is used.
+      WARNING
+    end
+
+    reference
   end
 
   private :gem_git
@@ -526,6 +552,7 @@ Gem dependencies file #{@path} requires #{name} more than once.
     else
       @requires[name] << name
     end
+    raise "Unhandled gem options #{options.inspect}" unless options.empty?
   end
 
   private :gem_requires

--- a/lib/rubygems/request_set/gem_dependency_api.rb
+++ b/lib/rubygems/request_set/gem_dependency_api.rb
@@ -362,6 +362,7 @@ class Gem::RequestSet::GemDependencyAPI
     source_set ||= gem_path       name, options
     source_set ||= gem_git        name, options
     source_set ||= gem_git_source name, options
+    source_set ||= gem_source     name, options
 
     duplicate = @dependencies.include? name
 
@@ -505,6 +506,23 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
   end
 
   private :gem_path
+
+  ##
+  # Handles the source: option from +options+ for gem +name+.
+  #
+  # Returns +true+ if the source option was handled.
+
+  def gem_source name, options # :nodoc:
+    return unless source = options.delete(:source)
+
+    pin_gem_source name, :source, source
+
+    Gem.sources << source
+
+    true
+  end
+
+  private :gem_source
 
   ##
   # Handles the platforms: option from +options+.  Returns true if the
@@ -678,6 +696,7 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
       when :default then '(default)'
       when :path    then "path: #{source}"
       when :git     then "git: #{source}"
+      when :source  then "source: #{source}"
       else               '(unknown)'
       end
 

--- a/lib/rubygems/request_set/gem_dependency_api.rb
+++ b/lib/rubygems/request_set/gem_dependency_api.rb
@@ -204,6 +204,7 @@ class Gem::RequestSet::GemDependencyAPI
     @installing         = false
     @requires           = Hash.new { |h, name| h[name] = [] }
     @vendor_set         = @set.vendor_set
+    @source_set         = @set.source_set
     @gem_sources        = {}
     @without_groups     = []
 
@@ -517,7 +518,7 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
 
     pin_gem_source name, :source, source
 
-    Gem.sources << source
+    @source_set.add_source_gem name, source
 
     true
   end

--- a/lib/rubygems/request_set/gem_dependency_api.rb
+++ b/lib/rubygems/request_set/gem_dependency_api.rb
@@ -571,7 +571,7 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
     else
       @requires[name] << name
     end
-    raise "Unhandled gem options #{options.inspect}" unless options.empty?
+    raise ArgumentError, "Unhandled gem options #{options.inspect}" unless options.empty?
   end
 
   private :gem_requires
@@ -846,4 +846,3 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
   Gem::RequestSet::GemDepedencyAPI = self # :nodoc:
 
 end
-

--- a/lib/rubygems/request_set/lockfile.rb
+++ b/lib/rubygems/request_set/lockfile.rb
@@ -129,8 +129,8 @@ class Gem::RequestSet::Lockfile
       [source.repository, source.rev_parse]
     end
 
-    out << "GIT"
     by_repository_revision.each do |(repository, revision), requests|
+      out << "GIT"
       out << "  remote: #{repository}"
       out << "  revision: #{revision}"
       out << "  specs:"
@@ -143,9 +143,8 @@ class Gem::RequestSet::Lockfile
           out << "      #{dep.name}#{dep.requirement.for_lockfile}"
         end
       end
+      out << nil
     end
-
-    out << nil
   end
 
   def relative_path_from dest, base # :nodoc:

--- a/lib/rubygems/request_set/lockfile/parser.rb
+++ b/lib/rubygems/request_set/lockfile/parser.rb
@@ -326,9 +326,9 @@ class Gem::RequestSet::Lockfile::Parser
 
   def pinned_requirement name # :nodoc:
     requirement = Gem::Dependency.new name
-    specification = @set.sets.map { |set|
+    specification = @set.sets.flat_map { |set|
       set.find_all(requirement)
-    }.flatten.compact.first
+    }.compact.first
 
     specification.version
   end

--- a/lib/rubygems/request_set/lockfile/parser.rb
+++ b/lib/rubygems/request_set/lockfile/parser.rb
@@ -330,7 +330,7 @@ class Gem::RequestSet::Lockfile::Parser
       set.find_all(requirement)
     }.compact.first
 
-    specification.version
+    specification && specification.version
   end
 
   ##
@@ -340,4 +340,3 @@ class Gem::RequestSet::Lockfile::Parser
     @tokens.unshift token
   end
 end
-

--- a/lib/rubygems/request_set/lockfile/parser.rb
+++ b/lib/rubygems/request_set/lockfile/parser.rb
@@ -324,13 +324,24 @@ class Gem::RequestSet::Lockfile::Parser
     @tokens.peek
   end
 
-  def pinned_requirement name # :nodoc:
-    requirement = Gem::Dependency.new name
-    specification = @set.sets.flat_map { |set|
-      set.find_all(requirement)
-    }.compact.first
+  if [].respond_to? :flat_map
+    def pinned_requirement name # :nodoc:
+      requirement = Gem::Dependency.new name
+      specification = @set.sets.flat_map { |set|
+        set.find_all(requirement)
+      }.compact.first
 
-    specification && specification.version
+      specification && specification.version
+    end
+  else # FIXME: remove when 1.8 is dropped
+    def pinned_requirement name # :nodoc:
+      requirement = Gem::Dependency.new name
+      specification = @set.sets.map { |set|
+        set.find_all(requirement)
+      }.flatten(1).compact.first
+
+      specification && specification.version
+    end
   end
 
   ##

--- a/lib/rubygems/request_set/lockfile/parser.rb
+++ b/lib/rubygems/request_set/lockfile/parser.rb
@@ -325,14 +325,12 @@ class Gem::RequestSet::Lockfile::Parser
   end
 
   def pinned_requirement name # :nodoc:
-    spec = @set.sets.select { |set|
-      Gem::Resolver::GitSet    === set or
-        Gem::Resolver::VendorSet === set
-    }.map { |set|
-      set.specs[name]
-    }.compact.first
+    requirement = Gem::Dependency.new name
+    specification = @set.sets.map { |set|
+      set.find_all(requirement)
+    }.flatten.compact.first
 
-    spec.version
+    specification.version
   end
 
   ##

--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -278,6 +278,7 @@ require 'rubygems/resolver/index_set'
 require 'rubygems/resolver/installer_set'
 require 'rubygems/resolver/lock_set'
 require 'rubygems/resolver/vendor_set'
+require 'rubygems/resolver/source_set'
 
 require 'rubygems/resolver/specification'
 require 'rubygems/resolver/spec_specification'

--- a/lib/rubygems/resolver/activation_request.rb
+++ b/lib/rubygems/resolver/activation_request.rb
@@ -49,15 +49,28 @@ class Gem::Resolver::ActivationRequest
   # Downloads a gem at +path+ and returns the file path.
 
   def download path
-    if @spec.respond_to? :source
-      source = @spec.source
-    else
-      source = Gem.sources.first
-    end
-
     Gem.ensure_gem_subdirectories path
 
-    source.download full_spec, path
+    if @spec.respond_to? :sources
+      exception = nil
+      path = nil
+      @spec.sources.each{ |source|
+        begin
+          path = source.download full_spec, path
+        rescue exception
+          nil
+        end
+      }
+      raise exception if exception
+      path
+    elsif @spec.respond_to? :source
+      source = @spec.source
+      source.download full_spec, path
+    else
+      source = Gem.sources.first
+      source.download full_spec, path
+    end
+
   end
 
   ##

--- a/lib/rubygems/resolver/activation_request.rb
+++ b/lib/rubygems/resolver/activation_request.rb
@@ -53,24 +53,23 @@ class Gem::Resolver::ActivationRequest
 
     if @spec.respond_to? :sources
       exception = nil
-      path = nil
-      @spec.sources.each{ |source|
+      path = @spec.sources.find{ |source|
         begin
-          path = source.download full_spec, path
+          source.download full_spec, path
         rescue exception
-          nil
         end
       }
-      raise exception if exception
-      path
+      return path      if path
+      raise  exception if exception
+
     elsif @spec.respond_to? :source
       source = @spec.source
       source.download full_spec, path
+
     else
       source = Gem.sources.first
       source.download full_spec, path
     end
-
   end
 
   ##

--- a/lib/rubygems/resolver/lock_set.rb
+++ b/lib/rubygems/resolver/lock_set.rb
@@ -27,11 +27,9 @@ class Gem::Resolver::LockSet < Gem::Resolver::Set
 
   def add name, version, platform # :nodoc:
     version = Gem::Version.new version
-
-    specs = @sources.map do |source|
-      Gem::Resolver::LockSpecification.new self, name, version, source,
-                                           platform
-    end
+    specs = [
+      Gem::Resolver::LockSpecification.new(self, name, version, @sources, platform)
+    ]
 
     @specs.concat specs
 

--- a/lib/rubygems/resolver/lock_specification.rb
+++ b/lib/rubygems/resolver/lock_specification.rb
@@ -6,13 +6,16 @@
 
 class Gem::Resolver::LockSpecification < Gem::Resolver::Specification
 
-  def initialize set, name, version, source, platform
+  attr_reader :sources
+
+  def initialize set, name, version, sources, platform
     super()
 
     @name     = name
     @platform = platform
     @set      = set
-    @source   = source
+    @source   = sources.first
+    @sources  = sources
     @version  = version
 
     @dependencies = []

--- a/lib/rubygems/resolver/source_set.rb
+++ b/lib/rubygems/resolver/source_set.rb
@@ -1,0 +1,48 @@
+##
+# The SourceSet chooses the best available method to query a remote index.
+#
+# Kind off like BestSet but filters the sources for gems
+
+class Gem::Resolver::SourceSet < Gem::Resolver::Set
+
+  ##
+  # Creates a SourceSet for the given +sources+ or Gem::sources if none are
+  # specified.  +sources+ must be a Gem::SourceList.
+
+  def initialize
+    super()
+
+    @links = {}
+    @sets  = {}
+  end
+
+  def find_all req # :nodoc:
+    if set = get_set(req.dependency.name)
+      set.find_all req
+    else
+      []
+    end
+  end
+
+  # potentially no-op
+  def prefetch reqs # :nodoc:
+    reqs.each do |req|
+      if set = get_set(req.dependency.name)
+        set.prefetch reqs
+      end
+    end
+  end
+
+  def add_source_gem name, source
+    @links[name] = source
+  end
+
+private
+
+  def get_set(name)
+    link = @links[name]
+    @sets[link] ||= Gem::Source.new(link).dependency_resolver_set if link
+  end
+
+end
+

--- a/lib/rubygems/source_list.rb
+++ b/lib/rubygems/source_list.rb
@@ -9,7 +9,7 @@ require 'rubygems/source'
 # Or by adding them:
 #
 #   sources = Gem::SourceList.new
-#   sources.add 'https://rubygems.example'
+#   sources << 'https://rubygems.example'
 #
 # The most common way to get a SourceList is Gem.sources.
 

--- a/test/rubygems/test_gem_request_set.rb
+++ b/test/rubygems/test_gem_request_set.rb
@@ -354,7 +354,7 @@ ruby "0"
 
     assert_equal %w[a-1], names
 
-    assert_equal [@DR::BestSet, @DR::GitSet, @DR::VendorSet],
+    assert_equal [@DR::BestSet, @DR::GitSet, @DR::VendorSet, @DR::SourceSet],
                  rs.sets.map { |set| set.class }
   end
 
@@ -418,7 +418,7 @@ ruby "0"
 
     assert_equal ["a-1", "b-2"], names
 
-    assert_equal [@DR::BestSet, @DR::GitSet, @DR::VendorSet],
+    assert_equal [@DR::BestSet, @DR::GitSet, @DR::VendorSet, @DR::SourceSet],
                  rs.sets.map { |set| set.class }
   end
 

--- a/test/rubygems/test_gem_request_set_gem_dependency_api.rb
+++ b/test/rubygems/test_gem_request_set_gem_dependency_api.rb
@@ -136,7 +136,11 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
   end
 
   def test_gem_git_branch
-    @gda.gem 'a', :git => 'git/a', :branch => 'other', :tag => 'v1'
+    _, err = capture_io do
+      @gda.gem 'a', :git => 'git/a', :branch => 'other', :tag => 'v1'
+    end
+    expected = "Gem dependencies file gem.deps.rb includes git reference for both ref/branch and tag but only ref/branch is used."
+    assert_match expected, err
 
     assert_equal [dep('a')], @set.dependencies
 
@@ -153,7 +157,11 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
   end
 
   def test_gem_git_ref
-    @gda.gem 'a', :git => 'git/a', :ref => 'abcd123', :branch => 'other'
+    _, err = capture_io do
+      @gda.gem 'a', :git => 'git/a', :ref => 'abcd123', :branch => 'other'
+    end
+    expected = "Gem dependencies file gem.deps.rb includes git reference for both ref and branch but only ref is used."
+    assert_match expected, err
 
     assert_equal [dep('a')], @set.dependencies
 

--- a/test/rubygems/test_gem_request_set_lockfile_parser.rb
+++ b/test/rubygems/test_gem_request_set_lockfile_parser.rb
@@ -247,8 +247,13 @@ DEPENDENCIES
 
     assert_equal %w[a-2], lockfile_set.specs.map { |s| s.full_name }
 
-    assert_equal %w[https://gems.example/ https://other.example/],
-                 lockfile_set.specs.flat_map { |s| s.sources.map{ |src| src.uri.to_s } }
+    if [].respond_to? :flat_map
+      assert_equal %w[https://gems.example/ https://other.example/],
+                   lockfile_set.specs.flat_map { |s| s.sources.map{ |src| src.uri.to_s } }
+    else # FIXME: remove when 1.8 is dropped
+      assert_equal %w[https://gems.example/ https://other.example/],
+                   lockfile_set.specs.map { |s| s.sources.map{ |src| src.uri.to_s } }.flatten(1)
+    end
   end
 
   def test_parse_GIT

--- a/test/rubygems/test_gem_request_set_lockfile_parser.rb
+++ b/test/rubygems/test_gem_request_set_lockfile_parser.rb
@@ -245,10 +245,10 @@ DEPENDENCIES
 
     assert lockfile_set, 'found a LockSet'
 
-    assert_equal %w[a-2 a-2], lockfile_set.specs.map { |s| s.full_name }
+    assert_equal %w[a-2], lockfile_set.specs.map { |s| s.full_name }
 
     assert_equal %w[https://gems.example/ https://other.example/],
-                 lockfile_set.specs.map { |s| s.source.uri.to_s }
+                 lockfile_set.specs.flat_map { |s| s.sources.map{ |src| src.uri.to_s } }
   end
 
   def test_parse_GIT

--- a/test/rubygems/test_gem_resolver_lock_specification.rb
+++ b/test/rubygems/test_gem_resolver_lock_specification.rb
@@ -14,7 +14,7 @@ class TestGemResolverLockSpecification < Gem::TestCase
   end
 
   def test_initialize
-    spec = @LS.new @set, 'a', v(2), @source, Gem::Platform::RUBY
+    spec = @LS.new @set, 'a', v(2), [@source], Gem::Platform::RUBY
 
     assert_equal 'a',                 spec.name
     assert_equal v(2),                spec.version
@@ -24,7 +24,7 @@ class TestGemResolverLockSpecification < Gem::TestCase
   end
 
   def test_add_dependency
-    l_spec = @LS.new @set, 'a', v(2), @source, Gem::Platform::RUBY
+    l_spec = @LS.new @set, 'a', v(2), [@source], Gem::Platform::RUBY
 
     b_dep = dep('b', '>= 0')
 
@@ -38,7 +38,7 @@ class TestGemResolverLockSpecification < Gem::TestCase
       fetcher.download 'a', 2
     end
 
-    spec = @LS.new @set, 'a', v(2), @source, Gem::Platform::RUBY
+    spec = @LS.new @set, 'a', v(2), [@source], Gem::Platform::RUBY
 
     called = false
 
@@ -50,7 +50,7 @@ class TestGemResolverLockSpecification < Gem::TestCase
   end
 
   def test_install_installed
-    spec = @LS.new @set, 'a', v(2), @source, Gem::Platform::RUBY
+    spec = @LS.new @set, 'a', v(2), [@source], Gem::Platform::RUBY
 
     FileUtils.touch File.join(@gemhome, 'specifications', spec.spec.spec_name)
 
@@ -66,7 +66,7 @@ class TestGemResolverLockSpecification < Gem::TestCase
   def test_spec
     version = v(2)
 
-    l_spec = @LS.new @set, 'a', version, @source, Gem::Platform::RUBY
+    l_spec = @LS.new @set, 'a', version, [@source], Gem::Platform::RUBY
 
     b_dep = dep 'b', '>= 0'
     c_dep = dep 'c', '~> 1'
@@ -90,7 +90,7 @@ class TestGemResolverLockSpecification < Gem::TestCase
 
     version = v(2)
 
-    l_spec = @LS.new @set, 'a', version, @source, Gem::Platform::RUBY
+    l_spec = @LS.new @set, 'a', version, [@source], Gem::Platform::RUBY
 
     assert_same real_spec, l_spec.spec
   end


### PR DESCRIPTION
replaces #1348, extends on  #1305 to add support for `Gemfile`s:
```ruby
gem "name", source: "http://..."
```
based on http://bundler.io/v1.10/man/gemfile.5.html#SOURCE-source-

work in progress, @drbrain does it go in right direction?
