### PR TITLE
Set Platform#cpu to 'universal' by default

### DIFF
--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -148,8 +148,8 @@ class Gem::Platform
     return nil unless Gem::Platform === other
 
     # cpu
-    (@cpu == 'universal' or other.cpu == 'universal' or @cpu == other.cpu or
-     (@cpu == 'arm' and other.cpu =~ /\Aarm/)) and
+    ([nil,'universal'].include?(@cpu) or [nil, 'universal'].include?(other.cpu) or @cpu == other.cpu or
+    (@cpu == 'arm' and other.cpu =~ /\Aarm/)) and
 
     # os
     @os == other.os and

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -190,6 +190,17 @@ class TestGemPlatform < Gem::TestCase
     assert((x86_darwin8 === Gem::Platform.local), 'universal =~ x86')
   end
 
+  def test_nil_cpu_arch_is_treated_as_universal
+    with_nil_arch = Gem::Platform.new [nil, 'mingw32']
+    with_uni_arch = Gem::Platform.new ['universal', 'mingw32']
+    with_x86_arch = Gem::Platform.new ['x86', 'mingw32']
+
+    assert((with_nil_arch === with_uni_arch), 'nil =~ universal')
+    assert((with_uni_arch === with_nil_arch), 'universal =~ nil')
+    assert((with_nil_arch === with_x86_arch), 'nil =~ x86')
+    assert((with_x86_arch === with_nil_arch), 'x86 =~ nil')
+  end
+
   def test_equals3_cpu_arm
     arm   = Gem::Platform.new 'arm-linux'
     armv5 = Gem::Platform.new 'armv5-linux'


### PR DESCRIPTION
This patch will automatically set the @cpu within platform.rb to 'universal' if it is otherwise nil. This, to me, is intuitive to both authors and consumers, and is in line with the platform documentation. It's also a lot easier than figuring out how to handle nil cpu's in terms of how the matching should work.

This indirectly addresses an issue brought up in #1120. While it will not fix the issue with current gems, any newly created gems (using the latest version of Rubygems) will have the cpu set, and will match for any architecture.

In fact, I explicitly set the cpu to 'universal' for a couple of my own platform-specific pure Ruby gems and it works just fine.