### PR TITLE
Allow --host for yank/unyank command

### DIFF
--- a/lib/rubygems/commands/yank_command.rb
+++ b/lib/rubygems/commands/yank_command.rb
@@ -74,7 +74,7 @@ as the reason for the removal request.
 
   def yank_api_request(method, version, platform, api)
     name = get_one_gem_name
-    response = rubygems_api_request(method, api) do |request|
+    response = rubygems_api_request(method, api, host) do |request|
       request.add_field("Authorization", api_key)
 
       data = {

--- a/lib/rubygems/commands/yank_command.rb
+++ b/lib/rubygems/commands/yank_command.rb
@@ -31,7 +31,7 @@ as the reason for the removal request.
   end
 
   def usage # :nodoc:
-    "#{program_name} GEM -v VERSION [-p PLATFORM] [--key KEY_NAME]"
+    "#{program_name} GEM -v VERSION [-p PLATFORM] [--key KEY_NAME] [--host HOST]"
   end
 
   def initialize
@@ -40,11 +40,19 @@ as the reason for the removal request.
     add_version_option("remove")
     add_platform_option("remove")
 
+    add_option('--host HOST',
+               'Yank from another gemcutter-compatible host') do |value, options|
+      options[:host] = value
+    end
+
     add_key_option
+    @host = nil
   end
 
   def execute
-    sign_in
+    @host = options[:host]
+
+    sign_in @host
 
     version   = get_version_from_requirements(options[:version])
     platform  = get_platform_from_requirements(options)

--- a/test/rubygems/test_gem_commands_yank_command.rb
+++ b/test/rubygems/test_gem_commands_yank_command.rb
@@ -5,20 +5,13 @@ class TestGemCommandsYankCommand < Gem::TestCase
   def setup
     super
 
-    ENV["RUBYGEMS_HOST"] = nil
-    Gem.host = 'http://example'
     @cmd = Gem::Commands::YankCommand.new
+    @cmd.options[:host] = 'http://example'
 
     @fetcher = Gem::RemoteFetcher.fetcher
 
     Gem.configuration.rubygems_api_key = 'key'
     Gem.configuration.api_keys[:KEY]  = 'other'
-  end
-
-  def teardown
-    super
-
-    Gem.host = Gem::DEFAULT_HOST
   end
 
   def test_handle_options


### PR DESCRIPTION
I noticed that `yank`/`unyank` doesn't have a `--host` option like `push` does.

It would be convenient to have such an option so someone running a private gem server can easily yank or unyank a gem using RubyGems.

It is already possible to do this via the `RUBYGEMS_HOST` environment variable, however I didn't even know this was possible until I saw it in the code.

I tried to keep my change minimal, and the style as consistent as possible, but please let me know if I missed something, or you would like any additional changes or tests.