### PR TITLE
Add support for setting headers in RemoteFetcher

### DIFF
--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -51,6 +51,8 @@ class Gem::RemoteFetcher
     @fetcher ||= self.new Gem.configuration[:http_proxy]
   end
 
+  attr_accessor :headers
+
   ##
   # Initialize a remote fetcher using the source URI and possible proxy
   # information.
@@ -64,8 +66,11 @@ class Gem::RemoteFetcher
   #
   # +dns+: An object to use for DNS resolution of the API endpoint.
   #        By default, use Resolv::DNS.
+  #
+  # +headers+: A set of additional HTTP headers to be sent to the server when
+  #            fetching the gem.
 
-  def initialize(proxy=nil, dns=Resolv::DNS.new)
+  def initialize(proxy=nil, dns=Resolv::DNS.new, headers={})
     require 'net/http'
     require 'stringio'
     require 'time'
@@ -79,6 +84,7 @@ class Gem::RemoteFetcher
     @cert_files = Gem::Request.get_cert_files
 
     @dns = dns
+    @headers = headers
   end
 
   ##
@@ -235,7 +241,9 @@ class Gem::RemoteFetcher
 
   def fetch_http uri, last_modified = nil, head = false, depth = 0
     fetch_type = head ? Net::HTTP::Head : Net::HTTP::Get
-    response   = request uri, fetch_type, last_modified
+    response   = request uri, fetch_type, last_modified do |req|
+      headers.each { |k,v| req.add_field(k,v) }
+    end
 
     case response
     when Net::HTTPOK, Net::HTTPNotModified then

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -698,6 +698,14 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     assert_equal "too many redirects (#{url})", e.message
   end
 
+  def test_fetch_http_with_additional_headers
+    ENV["http_proxy"] = @proxy_uri
+    ENV["no_proxy"] = URI::parse(@server_uri).host
+    fetcher = Gem::RemoteFetcher.new nil, nil, {"X-Captain" => "murphy"}
+    @fetcher = fetcher
+    assert_equal "murphy", fetcher.fetch_path(@server_uri)
+  end
+
   def test_fetch_s3
     fetcher = Gem::RemoteFetcher.new nil
     @fetcher = fetcher
@@ -984,7 +992,9 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
         )
       s.mount_proc("/kill") { |req, res| s.shutdown }
       s.mount_proc("/yaml") { |req, res|
-        if @enable_yaml
+        if req["X-Captain"]
+          res.body = req["X-Captain"]
+        elsif @enable_yaml
           res.body = data
           res['Content-Type'] = 'text/plain'
           res['content-length'] = data.size


### PR DESCRIPTION
A use case for this is discussed at https://github.com/bundler/bundler/pull/4040 & https://trello.com/c/iysZYwlD/118-send-x-gemfile-source-header-to-mirrored-sources.