### PR TITLE
Fix invalid config file handling with Psych

### DIFF
--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -321,11 +321,11 @@ if you believe they were disclosed to a third party.
     @rubygems_api_key = api_key
   end
 
-  YAMLErrors = [ArgumentError]
-  YAMLErrors << Psych::SyntaxError if defined?(Psych::SyntaxError)
-
   def load_file(filename)
     Gem.load_yaml
+
+    yaml_errors = [ArgumentError]
+    yaml_errors << Psych::SyntaxError if defined?(Psych::SyntaxError)
 
     return {} unless filename and File.exist? filename
 
@@ -336,7 +336,7 @@ if you believe they were disclosed to a third party.
         return {}
       end
       return content
-    rescue *YAMLErrors => e
+    rescue *yaml_errors => e
       warn "Failed to load #{filename}, #{e}"
     rescue Errno::EACCES
       warn "Failed to load #{filename} due to permissions problem."

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -37,9 +37,6 @@ require 'tmpdir'
 require 'uri'
 require 'zlib'
 require 'benchmark' # stdlib
-
-Gem.load_yaml
-
 require 'rubygems/mock_gem_ui'
 
 module Gem

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -416,7 +416,7 @@ if you believe they were disclosed to a third party.
 
   def test_ignore_invalid_config_file
     File.open @temp_conf, 'w' do |fp|
-      fp.puts "some-non-yaml-hash-string"
+      fp.puts "invalid: yaml:"
     end
 
     begin


### PR DESCRIPTION
This is a series of changes that:

1) fix the relevant test to actually test that we properly handle config files with invalid YAML, and therefore fail (since we don't)
2) fix RubyGems to actually handle such files