### PR TITLE
use frozen strings in serialized specs

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2295,7 +2295,7 @@ class Gem::Specification < Gem::BasicSpecification
 
   def ruby_code(obj)
     case obj
-    when String            then obj.dump
+    when String            then obj.dump + ".freeze"
     when Array             then '[' + obj.map { |x| ruby_code x }.join(", ") + ']'
     when Hash              then
       seg = obj.keys.sort.map { |k| "#{k.to_s.dump} => #{obj[k].to_s.dump}" }
@@ -2485,14 +2485,14 @@ class Gem::Specification < Gem::BasicSpecification
       dependencies.each do |dep|
         req = dep.requirements_list.inspect
         dep.instance_variable_set :@type, :runtime if dep.type.nil? # HACK
-        result << "      s.add_#{dep.type}_dependency(%q<#{dep.name}>, #{req})"
+        result << "      s.add_#{dep.type}_dependency(%q<#{dep.name}>.freeze, #{req})"
       end
 
       result << "    else"
 
       dependencies.each do |dep|
         version_reqs_param = dep.requirements_list.inspect
-        result << "      s.add_dependency(%q<#{dep.name}>, #{version_reqs_param})"
+        result << "      s.add_dependency(%q<#{dep.name}>.freeze, #{version_reqs_param})"
       end
 
       result << '    end'
@@ -2500,7 +2500,7 @@ class Gem::Specification < Gem::BasicSpecification
       result << "  else"
       dependencies.each do |dep|
         version_reqs_param = dep.requirements_list.inspect
-        result << "    s.add_dependency(%q<#{dep.name}>, #{version_reqs_param})"
+        result << "    s.add_dependency(%q<#{dep.name}>.freeze, #{version_reqs_param})"
       end
       result << "  end"
     end

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2262,30 +2262,30 @@ dependencies: []
 # stub: a 2 ruby lib\0other
 
 Gem::Specification.new do |s|
-  s.name = "a"
+  s.name = "a".freeze
   s.version = "2"
 
-  s.required_rubygems_version = Gem::Requirement.new(\"> 0\") if s.respond_to? :required_rubygems_version=
-  s.require_paths = ["lib", "other"]
-  s.authors = ["A User"]
+  s.required_rubygems_version = Gem::Requirement.new(\"> 0\".freeze) if s.respond_to? :required_rubygems_version=
+  s.require_paths = ["lib".freeze, "other".freeze]
+  s.authors = ["A User".freeze]
   s.date = "#{Gem::Specification::TODAY.strftime "%Y-%m-%d"}"
-  s.description = "This is a test description"
-  s.email = "example@example.com"
-  s.files = ["lib/code.rb"]
-  s.homepage = "http://example.com"
-  s.rubygems_version = "#{Gem::VERSION}"
-  s.summary = "this is a summary"
+  s.description = "This is a test description".freeze
+  s.email = "example@example.com".freeze
+  s.files = ["lib/code.rb".freeze]
+  s.homepage = "http://example.com".freeze
+  s.rubygems_version = "#{Gem::VERSION}".freeze
+  s.summary = "this is a summary".freeze
 
   if s.respond_to? :specification_version then
     s.specification_version = #{Gem::Specification::CURRENT_SPECIFICATION_VERSION}
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<b>, [\"= 1\"])
+      s.add_runtime_dependency(%q<b>.freeze, [\"= 1\"])
     else
-      s.add_dependency(%q<b>, [\"= 1\"])
+      s.add_dependency(%q<b>.freeze, [\"= 1\"])
     end
   else
-    s.add_dependency(%q<b>, [\"= 1\"])
+    s.add_dependency(%q<b>.freeze, [\"= 1\"])
   end
 end
     SPEC
@@ -2311,18 +2311,18 @@ end
 # stub: a 2 ruby lib
 
 Gem::Specification.new do |s|
-  s.name = "a"
+  s.name = "a".freeze
   s.version = "2"
 
-  s.required_rubygems_version = Gem::Requirement.new(\"> 0\") if s.respond_to? :required_rubygems_version=
-  s.require_paths = ["lib"]
-  s.authors = ["A User"]
+  s.required_rubygems_version = Gem::Requirement.new(\"> 0\".freeze) if s.respond_to? :required_rubygems_version=
+  s.require_paths = ["lib".freeze]
+  s.authors = ["A User".freeze]
   s.date = "#{Gem::Specification::TODAY.strftime "%Y-%m-%d"}"
-  s.description = "This is a test description"
-  s.email = "example@example.com"
-  s.homepage = "http://example.com"
-  s.rubygems_version = "#{Gem::VERSION}"
-  s.summary = "this is a summary"
+  s.description = "This is a test description".freeze
+  s.email = "example@example.com".freeze
+  s.homepage = "http://example.com".freeze
+  s.rubygems_version = "#{Gem::VERSION}".freeze
+  s.summary = "this is a summary".freeze
 
   s.installed_by_version = "#{Gem::VERSION}" if s.respond_to? :installed_by_version
 
@@ -2330,12 +2330,12 @@ Gem::Specification.new do |s|
     s.specification_version = #{Gem::Specification::CURRENT_SPECIFICATION_VERSION}
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<b>, [\"= 1\"])
+      s.add_runtime_dependency(%q<b>.freeze, [\"= 1\"])
     else
-      s.add_dependency(%q<b>, [\"= 1\"])
+      s.add_dependency(%q<b>.freeze, [\"= 1\"])
     end
   else
-    s.add_dependency(%q<b>, [\"= 1\"])
+    s.add_dependency(%q<b>.freeze, [\"= 1\"])
   end
 end
     SPEC
@@ -2367,43 +2367,43 @@ end
 # stub: #{extensions}
 
 Gem::Specification.new do |s|
-  s.name = "a"
+  s.name = "a".freeze
   s.version = "1"
   s.platform = Gem::Platform.new(#{expected_platform})
 
-  s.required_rubygems_version = Gem::Requirement.new(\">= 0\") if s.respond_to? :required_rubygems_version=
-  s.require_paths = ["lib"]
-  s.authors = ["A User"]
+  s.required_rubygems_version = Gem::Requirement.new(\">= 0\".freeze) if s.respond_to? :required_rubygems_version=
+  s.require_paths = ["lib".freeze]
+  s.authors = ["A User".freeze]
   s.date = "#{Gem::Specification::TODAY.strftime "%Y-%m-%d"}"
-  s.description = "This is a test description"
-  s.email = "example@example.com"
-  s.executables = ["exec"]
-  s.extensions = ["ext/a/extconf.rb"]
-  s.files = ["bin/exec", "ext/a/extconf.rb", "lib/code.rb", "test/suite.rb"]
-  s.homepage = "http://example.com"
-  s.licenses = ["MIT"]
-  s.requirements = ["A working computer"]
-  s.rubyforge_project = "example"
-  s.rubygems_version = "#{Gem::VERSION}"
-  s.summary = "this is a summary"
-  s.test_files = ["test/suite.rb"]
+  s.description = "This is a test description".freeze
+  s.email = "example@example.com".freeze
+  s.executables = ["exec".freeze]
+  s.extensions = ["ext/a/extconf.rb".freeze]
+  s.files = ["bin/exec".freeze, "ext/a/extconf.rb".freeze, "lib/code.rb".freeze, "test/suite.rb".freeze]
+  s.homepage = "http://example.com".freeze
+  s.licenses = ["MIT".freeze]
+  s.requirements = ["A working computer".freeze]
+  s.rubyforge_project = "example".freeze
+  s.rubygems_version = "#{Gem::VERSION}".freeze
+  s.summary = "this is a summary".freeze
+  s.test_files = ["test/suite.rb".freeze]
 
   if s.respond_to? :specification_version then
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<rake>, [\"> 0.4\"])
-      s.add_runtime_dependency(%q<jabber4r>, [\"> 0.0.0\"])
-      s.add_runtime_dependency(%q<pqa>, [\"<= 0.6\", \"> 0.4\"])
+      s.add_runtime_dependency(%q<rake>.freeze, [\"> 0.4\"])
+      s.add_runtime_dependency(%q<jabber4r>.freeze, [\"> 0.0.0\"])
+      s.add_runtime_dependency(%q<pqa>.freeze, [\"<= 0.6\", \"> 0.4\"])
     else
-      s.add_dependency(%q<rake>, [\"> 0.4\"])
-      s.add_dependency(%q<jabber4r>, [\"> 0.0.0\"])
-      s.add_dependency(%q<pqa>, [\"<= 0.6\", \"> 0.4\"])
+      s.add_dependency(%q<rake>.freeze, [\"> 0.4\"])
+      s.add_dependency(%q<jabber4r>.freeze, [\"> 0.0.0\"])
+      s.add_dependency(%q<pqa>.freeze, [\"<= 0.6\", \"> 0.4\"])
     end
   else
-    s.add_dependency(%q<rake>, [\"> 0.4\"])
-    s.add_dependency(%q<jabber4r>, [\"> 0.0.0\"])
-    s.add_dependency(%q<pqa>, [\"<= 0.6\", \"> 0.4\"])
+    s.add_dependency(%q<rake>.freeze, [\"> 0.4\"])
+    s.add_dependency(%q<jabber4r>.freeze, [\"> 0.0.0\"])
+    s.add_dependency(%q<pqa>.freeze, [\"<= 0.6\", \"> 0.4\"])
   end
 end
     SPEC
@@ -3202,20 +3202,20 @@ http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
 # stub: m 1 ruby lib
 
 Gem::Specification.new do |s|
-  s.name = "m"
+  s.name = "m".freeze
   s.version = "1"
 
-  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
+  s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.metadata = { "one" => "two", "two" => "three" } if s.respond_to? :metadata=
-  s.require_paths = ["lib"]
-  s.authors = ["A User"]
+  s.require_paths = ["lib".freeze]
+  s.authors = ["A User".freeze]
   s.date = "#{Gem::Specification::TODAY.strftime("%Y-%m-%d")}"
-  s.description = "This is a test description"
-  s.email = "example@example.com"
-  s.files = ["lib/code.rb"]
-  s.homepage = "http://example.com"
-  s.rubygems_version = "#{Gem::VERSION}"
-  s.summary = "this is a summary"
+  s.description = "This is a test description".freeze
+  s.email = "example@example.com".freeze
+  s.files = ["lib/code.rb".freeze]
+  s.homepage = "http://example.com".freeze
+  s.rubygems_version = "#{Gem::VERSION}".freeze
+  s.summary = "this is a summary".freeze
 end
     EOF
 


### PR DESCRIPTION
This drops the number of strings allocated overall since there are
repeated strings between specifications.

Before this change:

```
$ ruby -I~/git/allocation_tracer -rallocation_tracer -e'ObjectSpace::AllocationTracer.setup(%i{type}); p ObjectSpace::AllocationTracer.trace { Gem::Specification._all }'
{[:T_NODE]=>[179644, 0, 155062, 0, 4, 6186344], [:T_IMEMO]=>[10779, 0, 9384, 0, 3, 383760], [:T_ARRAY]=>[69988, 13749, 141533, 0, 14, 3233056], [:T_STRING]=>[185102, 19060, 263879, 0, 14, 9104273], [:T_OBJECT]=>[9587, 7940, 54460, 0, 14, 30960], [:T_MATCH]=>[5159, 0, 4503, 0, 3, 1279880], [:T_HASH]=>[2232, 618, 5656, 0, 14, 322248], [:T_FILE]=>[682, 0, 591, 0, 2, 146400], [:T_DATA]=>[2728, 0, 6102, 0, 14, 557048]}
```

My system would allocate 185k strings when loading the gemspecs.  After:

```
ruby -I~/git/allocation_tracer -rallocation_tracer -e'ObjectSpace::AllocationTracer.setup(%i{type}); p ObjectSpace::AllocationTracer.trace { Gem::Specification._all }'
{[:T_NODE]=>[200765, 0, 187789, 0, 3, 7337840], [:T_STRING]=>[166409, 8512, 203300, 0, 15, 9634644], [:T_ARRAY]=>[69988, 14789, 151028, 0, 15, 3601192], [:T_HASH]=>[2232, 668, 6023, 0, 15, 335936], [:T_MATCH]=>[5159, 0, 4794, 0, 3, 1346800], [:T_IMEMO]=>[10779, 0, 9982, 0, 3, 402040], [:T_FILE]=>[682, 0, 629, 0, 2, 152880], [:T_DATA]=>[2728, 0, 6500, 0, 15, 575900], [:T_OBJECT]=>[9587, 8530, 58054, 0, 15, 32400]}
```

About 166k allocated.  This is total allocations though, not heap space.
If I look at memsize consumed by strings on the heap, this is before:

```
[aaron@TC rubygems (alloc)]$ ruby -robjspace -e'Gem::Specification._all; GC.start; GC.start; p ObjectSpace.memsize_of_all String'
2168333
[aaron@TC rubygems (alloc)]$
```

After this change:

```
[aaron@TC rubygems (alloc)]$ ruby -robjspace -e'Gem::Specification._all; GC.start; GC.start; p ObjectSpace.memsize_of_all String'
1593616
[aaron@TC rubygems (alloc)]$
```

Heap size of strings without loading anything is this:

```
[aaron@TC rubygems (alloc)]$ ruby -robjspace -e'GC.start; GC.start; p ObjectSpace.memsize_of_all String'
1028333
[aaron@TC rubygems (alloc)]$
```

So before the change, heap size grew by 1140000, after this change, the
heap grew by 565283.  So this commit drops string heap allocations made
by loading gem specs by ~50% (on my machine).

A few caveats:

1. I have 741 unique gems installed on my machine
2. Hopefully nobody is actually calling the `_all` method. I know it's
   called by bundler, but I think that only happens at `gem install` time.
3. I had to `gem pristine` to get the benefits.