### PR TITLE
decrease probability of stub spec loading the full spec

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -38,6 +38,14 @@ class Gem::BasicSpecification
   end
 
   ##
+  # The path to the gem.build_complete file within the extension install
+  # directory.
+
+  def gem_build_complete_path # :nodoc:
+    File.join extension_dir, 'gem.build_complete'
+  end
+
+  ##
   # True when the gem has been activated
 
   def activated?

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1934,14 +1934,6 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   ##
-  # The path to the gem.build_complete file within the extension install
-  # directory.
-
-  def gem_build_complete_path # :nodoc:
-    File.join extension_dir, 'gem.build_complete'
-  end
-
-  ##
   # Work around bundler removing my methods
 
   def gem_dir # :nodoc:

--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -135,6 +135,7 @@ class Gem::StubSpecification < Gem::BasicSpecification
   def missing_extensions?
     return false if default_gem?
     return false if extensions.empty?
+    return false if File.exist? gem_build_complete_path
 
     to_spec.missing_extensions?
   end


### PR DESCRIPTION
Ruby trunk is loading the `did_you_mean` gem in the gem prelude.  Since
the gem doesn't ship with stdlib, we're getting cache misses in RubyGems
and all stub specifications are being turned in to full specifications.

You can see this by looking at the heap size of allocated strings.

Before this commit:

```
[aaron@TC rubygems (no_spec)]$ ruby -robjspace -e'GC.start; GC.start; p ObjectSpace.memsize_of_all String'
1028333
```

With this commit:

```
[aaron@TC rubygems (no_spec)]$ ruby -robjspace -Ilib -e'GC.start; GC.start; p ObjectSpace.memsize_of_all String'
934630
```

Of course loading the specs also slows startup.

This change pushes `gem_build_complete_path` in to the basic
specification because that method does not depend on anything that is
defined in `Gem::Specification`.  Pushing that method to the basic
specification makes it available to the stub specification.

Since that method is now available in the stub specification, we can add
this line to the `missing_extensions?` method:

```ruby
  return false if File.exist? gem_build_complete_path
```

It's very likely that extension gems will be fully built, so putting
this conditional in the stub spec saves us from loading specs.