### PR TITLE
[Resolver] Ensure platform sorting only uses strings

### DIFF
--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -232,7 +232,7 @@ class Gem::Resolver
       exc.errors = @set.errors
       raise exc
     end
-    possibles.sort_by { |s| [s.source, s.version, s.platform == Gem::Platform.local.to_s ? 1 : 0] }.
+    possibles.sort_by { |s| [s.source, s.version, s.platform.to_s == Gem::Platform.local.to_s ? 1 : 0] }.
       map { |s| ActivationRequest.new s, dependency, [] }
   end
 


### PR DESCRIPTION
This fixes a bug where some objects that masquerade as specifications return
a `Gem::Platform` in `#platform` instead of a `String`, as `Gem::Specification`
does. This causes the sorting to fail on, e.g. `Gem::Resolver::APISpecification`
objects.

Closes https://github.com/rubygems/rubygems/issues/1369.

I'm unsure how to test this, since all the test helpers create `Gem::Specification` objects.