### PR TITLE
consolidate `contains_requirable_file?` cache

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -65,22 +65,17 @@ class Gem::BasicSpecification
   # Return true if this spec can require +file+.
 
   def contains_requirable_file? file
-    @contains_requirable_file ||= {}
-    @contains_requirable_file[file] ||=
-    begin
-      if @ignored then
-        return false
-      elsif missing_extensions? then
-        @ignored = true
+    if @ignored then
+      return false
+    elsif missing_extensions? then
+      @ignored = true
 
-        warn "Ignoring #{full_name} because its extensions are not built.  " +
-             "Try: gem pristine #{name} --version #{version}"
-        return false
-      end
+      warn "Ignoring #{full_name} because its extensions are not built.  " +
+        "Try: gem pristine #{name} --version #{version}"
+      return false
+    end
 
-      have_file? file, Gem.suffixes
-    end ? :yes : :no
-    @contains_requirable_file[file] == :yes
+    have_file? file, Gem.suffixes
   end
 
   def default_gem?

--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -60,9 +60,7 @@ module Kernel
     #--
     # TODO request access to the C implementation of this to speed up RubyGems
 
-    spec = Gem::Specification.stubs.find { |s|
-      s.activated? and s.contains_requirable_file? path
-    }
+    spec = Gem::Specification.find_active_stub_by_path path
 
     begin
       RUBYGEMS_ACTIVATION_MONITOR.exit

--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -88,6 +88,8 @@ class Gem::StubSpecification < Gem::BasicSpecification
     end
   end
 
+  def this; self; end
+
   def default_gem?
     @default_gem
   end


### PR DESCRIPTION
This commit consolidates the `contains_requirable_file?` cache in to one
cache, which should speed up require failures and decrease memory usage.
This commit moves the `contains_requirable_file?` off  the spec and on
to the `Gem::Specification` class.  That way data about which spec has
which file can be centrally located, and we don't have to repeat data
through each cache.

Memory Usage Improvements
=========================

Here is what the memory usage looked like before this change:

```
[aaron@TC rubygems (master)]$ ruby --disable-gems -robjspace -Ilib -e"require 'rubygems';(ENV['N']||10).to_i.times {|x| begin;require(x.to_s);rescue LoadError;end}; GC.start; GC.start; p ObjectSpace.memsize_of_all"
2965374
[aaron@TC rubygems (master)]$ N=100 ruby --disable-gems -robjspace -Ilib -e"require 'rubygems';(ENV['N']||10).to_i.times {|x| begin;require(x.to_s);rescue LoadError;end}; GC.start; GC.start; p ObjectSpace.memsize_of_all"
6273878
[aaron@TC rubygems (master)]$ N=1000 ruby --disable-gems -robjspace -Ilib -e"require 'rubygems';(ENV['N']||10).to_i.times {|x| begin;require(x.to_s);rescue LoadError;end}; GC.start; GC.start; p ObjectSpace.memsize_of_all"
39738934
```

and here it is after this change:

```
[aaron@TC rubygems (file_req_cache)]$ ruby --disable-gems -robjspace -Ilib -e"require 'rubygems';(ENV['N']||10).to_i.times {|x| begin;require(x.to_s);rescue LoadError;end}; GC.start; GC.start; p ObjectSpace.memsize_of_all"
2444798
[aaron@TC rubygems (file_req_cache)]$ N=100 ruby --disable-gems -robjspace -Ilib -e"require 'rubygems';(ENV['N']||10).to_i.times {|x| begin;require(x.to_s);rescue LoadError;end}; GC.start; GC.start; p ObjectSpace.memsize_of_all"
2452886
[aaron@TC rubygems (file_req_cache)]$ N=1000 ruby --disable-gems -robjspace -Ilib -e"require 'rubygems';(ENV['N']||10).to_i.times {|x| begin;require(x.to_s);rescue LoadError;end}; GC.start; GC.start; p ObjectSpace.memsize_of_all"
2533878
```

Here is a graph to compare the two:

![require graph](http://i.imgur.com/Fq8Etsh.png)

Before this patch, each call to `require` that produced a load error
would increase memory usage by ~37000.  Since the cache is on each spec,
and I have 743 specs on my machine, that means growth is about 50 per
spec.  So memory growth before this patch is roughly:

```
  first_time_failed_requires.count * spec_stubs.count * 50
```

(note that before 41585b7a127a6227c6040647acbcc319aa6f5a65, it's likely
more than that because the caches didn't share string keys)

After this patch, memory grows by about 90 per failed require.  Since
the cache is moved off the spec object, you can calculate memory
requirements like this:

```
  first_time_failed_requires.count * 90
```

Speed Improvements
==================

This change also improves the speed at which files are required.  Here
is some test code to demonstrate:

```ruby
require 'rubygems'
require 'benchmark/ips'

Benchmark.ips do |x|
  x.report('can require') do
    require 'nokogiri'
  end

  x.report('cannot require') do
    begin
      require 'omglolwut'
    rescue LoadError
    end
  end
end
```

The first test requires a file, and it is successful.  The second test
requires a file and it fails.

Here are the results before this patch:

```
[aaron@TC rubygems (master)]$ N=1000 ruby --disable-gems -Ilib test.rb
Calculating -------------------------------------
         can require     8.347k i/100ms
      cannot require    87.000  i/100ms
-------------------------------------------------
         can require    116.658k (±12.4%) i/s -    575.943k
      cannot require    860.013  (±10.1%) i/s -      4.263k
```

And after the patch:

```
[aaron@TC rubygems (file_req_cache)]$ ruby --disable-gems -Ilib test.rb
Calculating -------------------------------------
         can require     8.502k i/100ms
      cannot require   383.000  i/100ms
-------------------------------------------------
         can require    123.928k (± 3.2%) i/s -    620.646k
      cannot require      3.689k (±15.7%) i/s -     18.001k
```

The speed of a successful require stays the same (this is essentially
just a base-line check), but the speed of a failing require dramatically
improves.  Since the cache has been pushed up away from the specs, it's
gone from an O(n) check (n = stubs.count) to an O(1) check (just look in
the hash).

The previous test was just for requiring the same file over and over, so
lets look at the time to require a different file every time (always a
cache miss).

Before the patch:

```
[aaron@TC rubygems (master)]$ time N=1000 ruby --disable-gems -robjspace -Ilib -e"require 'rubygems';(ENV['N']||10).to_i.times {|x| begin;require(x.to_s);rescue LoadError;end};"

real	0m58.232s
user	0m47.826s
sys	0m9.571s
[aaron@TC rubygems (master)]$ time N=100 ruby --disable-gems -robjspace -Ilib -e"require 'rubygems';(ENV['N']||10).to_i.times {|x| begin;require(x.to_s);rescue LoadError;end};"

real	0m3.570s
user	0m2.303s
sys	0m1.046s
[aaron@TC rubygems (master)]$ time ruby --disable-gems -robjspace -Ilib -e"require 'rubygems';(ENV['N']||10).to_i.times {|x| begin;require(x.to_s);rescue LoadError;end};"

real	0m0.522s
user	0m0.359s
sys	0m0.151s
```

After:

```
[aaron@TC rubygems (file_req_cache)]$ time N=1000 ruby --disable-gems -robjspace -Ilib -e"require 'rubygems';(ENV['N']||10).to_i.times {|x| begin;require(x.to_s);rescue LoadError;end};"

real	0m26.101s
user	0m16.264s
sys	0m9.347s
[aaron@TC rubygems (file_req_cache)]$ time N=100 ruby --disable-gems -robjspace -Ilib -e"require 'rubygems';(ENV['N']||10).to_i.times {|x| begin;require(x.to_s);rescue LoadError;end};"

real	0m3.055s
user	0m1.830s
sys	0m1.034s
[aaron@TC rubygems (file_req_cache)]$ time ruby --disable-gems -robjspace -Ilib -e"require 'rubygems';(ENV['N']||10).to_i.times {|x| begin;require(x.to_s);rescue LoadError;end};"

real	0m0.503s
user	0m0.339s
sys	0m0.154s
```

Time is cut nearly in half when N reaches 1000.

Demerits of this patch
======================

Since this patch removes the cache from inside
`contains_requirable_file?`, then clearly calls to
`contains_requirable_file?` may get slower.  We still have calls to this
method in `find_inactive_by_path`, `find_in_unresolved`, and
`find_in_unresolved_tree`.

`find_inactive_by_path` seems to only ever be used in tests, so I don't
think it's a hotspot.  The other two seem to only query specs that are
in the "unresolved tree" which should be a small subset of the overall
set of specs.  If we find that those are a bottleneck, I think we can
add a cache in those places too.

Finally, since this patch is a slightly dangerous change (it's API
compatible, but is not kind to the internals), I don't think it should
go in a bugfix release.

Conclusion
==========

I think the value of this patch, low memory, high speed, outweigh the
possible downside I listed above.  I think this patch is important,
especially for scripters because it drops **over all** memory usage
(*not* just memory used by RG, but total heap size) by 17% on my
machine:

Before:

```
$ ruby --disable-gems -robjspace -Ilib -e"require 'rubygems';(ENV['N']||10).to_i.times {|x| begin;require(x.to_s);rescue LoadError;end}; GC.start; GC.start; p ObjectSpace.memsize_of_all"
2965374
```

After:

```
$ ruby --disable-gems -robjspace -Ilib -e"require 'rubygems';(ENV['N']||10).to_i.times {|x| begin;require(x.to_s);rescue LoadError;end}; GC.start; GC.start; p ObjectSpace.memsize_of_all"
2444798
```

I think this is important for Ruby 2.3 because the new gem prelude will
immediately require the "did you mean" gem, and that immediately
activates Ruby Gems. (Previous versions of Ruby did not do that).