### PR TITLE
[Specification] Only include runtime dependencies in #traverse

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2592,7 +2592,7 @@ class Gem::Specification < Gem::BasicSpecification
   def traverse trail = [], visited = {}, &block
     trail.push(self)
     begin
-      dependencies.each do |dep|
+      runtime_dependencies.each do |dep|
         dep.to_specs.reverse_each do |dep_spec|
           next if visited.has_key?(dep_spec)
           visited[dep_spec] = true

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2592,7 +2592,8 @@ class Gem::Specification < Gem::BasicSpecification
   def traverse trail = [], visited = {}, &block
     trail.push(self)
     begin
-      runtime_dependencies.each do |dep|
+      dependencies.each do |dep|
+        next unless dep.runtime?
         dep.to_specs.reverse_each do |dep_spec|
           next if visited.has_key?(dep_spec)
           visited[dep_spec] = true

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -277,6 +277,21 @@ class TestGemRequire < Gem::TestCase
     assert_equal %w(a-1.0 b-2.0), loaded_spec_names
   end
 
+  def test_require_doesnt_traverse_development_dependencies
+    a = new_spec("a", "1", nil, "lib/a.rb")
+    z = new_spec("z", "1", "w" => "> 0")
+    w1 = new_spec("w", "1") { |s| s.add_development_dependency "non-existent" }
+    w2 = new_spec("w", "2") { |s| s.add_development_dependency "non-existent" }
+
+    install_specs a, w1, w2, z
+
+    assert gem("z")
+    assert_equal %w(z-1), loaded_spec_names
+    assert_equal ["w (> 0)"], unresolved_names
+
+    assert require("a")
+  end
+
   def test_default_gem_only
     default_gem_spec = new_default_spec("default", "2.0.0.0",
                                         nil, "default/gem.rb")


### PR DESCRIPTION
Presumably fixes https://github.com/rubygems/rubygems/issues/1381