### PR TITLE
RubyGems does not accept '+' suffix as allowed by spdx for "or later" clause.

### DIFF
--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2895,6 +2895,17 @@ http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
     warning
   end
 
+  def test_validate_license_values_plus
+    util_setup_validate
+
+    use_ui @ui do
+      @a1.licenses = ['GPL-2.0+']
+      @a1.validate
+    end
+
+    assert_empty @ui.error
+  end
+
   def test_validate_name
     util_setup_validate
 


### PR DESCRIPTION
I got issue related with spdx validation from Eric Wong as Ruby core team.

If we set "GPL-2.0+" to licenses fields at gem specification, We got invalid error. but http://spdx.org/licenses accepts "GPL-2.0+" indentifier.

I added failure testcase for this.