### PR TITLE
Assume ruby.exe to be available as defined by the environment

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -718,11 +718,12 @@ TEXT
 
   ##
   # return the stub script text used to launch the true Ruby script
-
   def windows_stub_script(bindir, bin_file_name)
-    ruby = Gem.ruby.chomp('"').tr(File::SEPARATOR, File::ALT_SEPARATOR)
-    ENV.select {|k,v| k.end_with?('RUBY_HOME') && ruby.downcase.start_with?(v.tr(File::SEPARATOR, File::ALT_SEPARATOR).downcase)}.each do |k, v|
-      ruby = "%#{k}%#{ruby[v.length..-1]}"
+    ruby = Gem.ruby.gsub(/^\"|\"$/, "").tr(File::SEPARATOR, "\\")
+    # Use the ruby_home environment variable if set and matching to the current 
+    # runtime to be more flexibility when changing the ruby runtime
+    ENV.select {|k, v| k.end_with?('RUBY_HOME') && ruby.downcase.start_with?(v.tr(File::SEPARATOR, "\\").downcase)}.each do |k, v|
+      ruby = "%#{k}%\\#{ruby[v.length..-1]}"
     end
     return <<-TEXT
 @ECHO OFF

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -720,7 +720,10 @@ TEXT
   # return the stub script text used to launch the true Ruby script
 
   def windows_stub_script(bindir, bin_file_name)
-    ruby = Gem.ruby.gsub(/^\"|\"$/, "").tr(File::SEPARATOR, "\\")
+    ruby = Gem.ruby.chomp('"').tr(File::SEPARATOR, File::ALT_SEPARATOR)
+    ENV.select {|k,v| k.end_with?('RUBY_HOME') && ruby.downcase.start_with?(v.tr(File::SEPARATOR, File::ALT_SEPARATOR).downcase)}.each do |k, v|
+      ruby = "%#{k}%#{ruby[v.length..-1]}"
+    end
     return <<-TEXT
 @ECHO OFF
 IF NOT "%~f0" == "~f0" GOTO :WinNT

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -724,6 +724,7 @@ TEXT
     # runtime to be more flexibility when changing the ruby runtime
     ENV.select {|k, v| k.end_with?('RUBY_HOME') && ruby.downcase.start_with?(v.tr(File::SEPARATOR, "\\").downcase)}.each do |k, v|
       ruby = "%#{k}%\\#{ruby[v.length..-1]}"
+      break
     end
     return <<-TEXT
 @ECHO OFF

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1389,13 +1389,14 @@ gem 'other', version
     begin
       env_with_ruby_home = ENV.to_hash.delete_if {|key, value| key.end_with?('RUBY_HOME') }
       env_with_ruby_home['RUBY_HOME'] = File.expand_path('../..', Gem.ruby)
+      executable = File.basename(Gem.ruby)
       expected =<<-TEXT
 @ECHO OFF
 IF NOT "%~f0" == "~f0" GOTO :WinNT
-@"%RUBY_HOME%\\\\bin\\ruby.exe" "#{@installer.gem_home}/bin/bar" %1 %2 %3 %4 %5 %6 %7 %8 %9
+@"%RUBY_HOME%\\\\bin\\#{executable}" "#{@installer.gem_home}/bin/bar" %1 %2 %3 %4 %5 %6 %7 %8 %9
 GOTO :EOF
 :WinNT
-@"%RUBY_HOME%\\\\bin\\ruby.exe" "%~dpn0" %*
+@"%RUBY_HOME%\\\\bin\\#{executable}" "%~dpn0" %*
       TEXT
 
       if (defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby') || RUBY_PLATFORM == "java"
@@ -1404,10 +1405,10 @@ GOTO :EOF
         expected =<<-TEXT
 @ECHO OFF
 IF NOT "%~f0" == "~f0" GOTO :WinNT
-@"%JRUBY_HOME%\\\\bin\\jruby.exe" "#{@installer.gem_home}/bin/bar" %1 %2 %3 %4 %5 %6 %7 %8 %9
+@"%JRUBY_HOME%\\\\bin\\#{executable}" "#{@installer.gem_home}/bin/bar" %1 %2 %3 %4 %5 %6 %7 %8 %9
 GOTO :EOF
 :WinNT
-@"%JRUBY_HOME%\\\\bin\\jruby.exe" "%~dpn0" %*
+@"%JRUBY_HOME%\\\\bin\\#{executable}" "%~dpn0" %*
         TEXT
       end
       ENV.clear


### PR DESCRIPTION
The behavior introduced with pull request #942 when creating the windows
batch file of a ruby gem has the downside that it is no longer easy
possible to use a different (J)Ruby installation but the same %GEM_HOME%
directory.  This is for example needed when distributing all gems
available in a %GEM_HOME% directory accross various installations which
may have different Ruby installations.

The proposed changes tries to fix the mentioned flaws by utilizing set
environment variables. It keeps the existing behavior if no environment
variable is set but uses the environment variables if set.
