### PR TITLE
Remove kou from notification list for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ notifications:
   email:
   - drbrain@segment7.net
   - evan+notify@phx.io
-  - kou@cozmixng.org
 rvm:
 - 1.8.7
 - 1.9.2


### PR DESCRIPTION
I'm not active for RubyGems development in this year.