### PR TITLE
Check Fastly instead of S3 CA cert

### DIFF
--- a/test/rubygems/test_bundled_ca.rb
+++ b/test/rubygems/test_bundled_ca.rb
@@ -52,8 +52,8 @@ class TestBundledCA < Gem::TestCase
     assert_https('d2chzxaqi4y7f8.cloudfront.net')
   end
 
-  def test_accessing_s3
-    assert_https('s3.amazonaws.com')
+  def test_accessing_fastly
+    assert_https('rubygems.global.ssl.fastly.net')
   end
 
 end if ENV['TRAVIS']


### PR DESCRIPTION
We only serve gems over Fastly now, so remove S3 cert check (which fails
for undiagnosed reasons).