### PR TITLE
Fix double word typo

### DIFF
--- a/lib/rubygems/commands/list_command.rb
+++ b/lib/rubygems/commands/list_command.rb
@@ -3,7 +3,7 @@ require 'rubygems/commands/query_command'
 
 ##
 # An alternate to Gem::Commands::QueryCommand that searches for gems starting
-# with the the supplied argument.
+# with the supplied argument.
 
 class Gem::Commands::ListCommand < Gem::Commands::QueryCommand
 


### PR DESCRIPTION
This fixes a double word typo, 'the'.