### PR TITLE
Allow s3 scheme in --source cli arguments

### DIFF
--- a/lib/rubygems/local_remote_options.rb
+++ b/lib/rubygems/local_remote_options.rb
@@ -23,7 +23,7 @@ module Gem::LocalRemoteOptions
         raise OptionParser::InvalidArgument, value
       end
 
-      unless ['http', 'https', 'file'].include?(uri.scheme)
+      unless ['http', 'https', 'file', 's3'].include?(uri.scheme)
          raise OptionParser::InvalidArgument, value
       end
 


### PR DESCRIPTION
The `s3://` URL scheme has been supported as a source in `.gemrc` config since #856, but it is not allowed in `gem query --source s3://xxx` or `gem install --source s3:xxx` commands.

This patch allows the `s3` scheme through the initial validation filter.