### PR TITLE
rescue EROFS

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -163,7 +163,7 @@ module Gem
   # these are defined in Ruby 1.8.7, hence the need for this convoluted setup.
 
   READ_BINARY_ERRORS = begin
-    read_binary_errors = [Errno::EACCES]
+    read_binary_errors = [Errno::EACCES, Errno::EROFS]
     read_binary_errors << Errno::ENOTSUP if Errno.const_defined?(:ENOTSUP)
     read_binary_errors
   end.freeze


### PR DESCRIPTION
When the source directory is placed on a read-only filesystem,
EROFS is raised but not EACCES.
