### PR TITLE
Remove useless directory parameter from builders .build methods. [rebased]

### DIFF
--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -162,7 +162,7 @@ EOF
       CHDIR_MUTEX.synchronize do
         pwd = Dir.getwd
         Dir.chdir extension_dir
-        results = builder.build(extension, @gem_dir, dest_path,
+        results = builder.build(extension, dest_path,
                                 results, @build_args, lib_dir)
 
         verbose { results.join("\n") }
@@ -223,4 +223,3 @@ EOF
   end
 
 end
-

--- a/lib/rubygems/ext/cmake_builder.rb
+++ b/lib/rubygems/ext/cmake_builder.rb
@@ -2,7 +2,7 @@
 require 'rubygems/command'
 
 class Gem::Ext::CmakeBuilder < Gem::Ext::Builder
-  def self.build(extension, directory, dest_path, results, args=[], lib_dir=nil)
+  def self.build(extension, dest_path, results, args=[], lib_dir=nil)
     unless File.exist?('Makefile') then
       cmd = "cmake . -DCMAKE_INSTALL_PREFIX=#{dest_path}"
       cmd << " #{Gem::Command.build_args.join ' '}" unless Gem::Command.build_args.empty?

--- a/lib/rubygems/ext/configure_builder.rb
+++ b/lib/rubygems/ext/configure_builder.rb
@@ -7,7 +7,7 @@
 
 class Gem::Ext::ConfigureBuilder < Gem::Ext::Builder
 
-  def self.build(extension, directory, dest_path, results, args=[], lib_dir=nil)
+  def self.build(extension, dest_path, results, args=[], lib_dir=nil)
     unless File.exist?('Makefile') then
       cmd = "sh ./configure --prefix=#{dest_path}"
       cmd << " #{args.join ' '}" unless args.empty?
@@ -21,4 +21,3 @@ class Gem::Ext::ConfigureBuilder < Gem::Ext::Builder
   end
 
 end
-

--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -11,7 +11,7 @@ require 'tempfile'
 class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
   FileEntry = FileUtils::Entry_ # :nodoc:
 
-  def self.build(extension, directory, dest_path, results, args=[], lib_dir=nil)
+  def self.build(extension, dest_path, results, args=[], lib_dir=nil)
     tmp_dest = Dir.mktmpdir(".gem.", ".")
 
     # Some versions of `mktmpdir` return absolute paths, which will break make

--- a/lib/rubygems/ext/rake_builder.rb
+++ b/lib/rubygems/ext/rake_builder.rb
@@ -7,7 +7,7 @@
 
 class Gem::Ext::RakeBuilder < Gem::Ext::Builder
 
-  def self.build(extension, directory, dest_path, results, args=[], lib_dir=nil)
+  def self.build(extension, dest_path, results, args=[], lib_dir=nil)
     if File.basename(extension) =~ /mkrf_conf/i then
       cmd = "#{Gem.ruby} #{File.basename extension}".dup
       cmd << " #{args.join " "}" unless args.empty?
@@ -34,4 +34,3 @@ class Gem::Ext::RakeBuilder < Gem::Ext::Builder
   end
 
 end
-

--- a/test/rubygems/test_gem_ext_cmake_builder.rb
+++ b/test/rubygems/test_gem_ext_cmake_builder.rb
@@ -34,7 +34,7 @@ install (FILES test.txt DESTINATION bin)
     output = []
 
     Dir.chdir @ext do
-      Gem::Ext::CmakeBuilder.build nil, nil, @dest_path, output
+      Gem::Ext::CmakeBuilder.build nil, @dest_path, output
     end
 
     output = output.join "\n"
@@ -52,7 +52,7 @@ install (FILES test.txt DESTINATION bin)
 
     error = assert_raises Gem::InstallError do
       Dir.chdir @ext do
-        Gem::Ext::CmakeBuilder.build nil, nil, @dest_path, output
+        Gem::Ext::CmakeBuilder.build nil, @dest_path, output
       end
     end
 
@@ -75,7 +75,7 @@ install (FILES test.txt DESTINATION bin)
     output = []
 
     Dir.chdir @ext do
-      Gem::Ext::CmakeBuilder.build nil, nil, @dest_path, output
+      Gem::Ext::CmakeBuilder.build nil, @dest_path, output
     end
 
     output = output.join "\n"

--- a/test/rubygems/test_gem_ext_configure_builder.rb
+++ b/test/rubygems/test_gem_ext_configure_builder.rb
@@ -27,7 +27,7 @@ class TestGemExtConfigureBuilder < Gem::TestCase
     output = []
 
     Dir.chdir @ext do
-      Gem::Ext::ConfigureBuilder.build nil, nil, @dest_path, output
+      Gem::Ext::ConfigureBuilder.build nil, @dest_path, output
     end
 
     assert_match(/^current directory:/, output.shift)
@@ -50,7 +50,7 @@ class TestGemExtConfigureBuilder < Gem::TestCase
 
     error = assert_raises Gem::InstallError do
       Dir.chdir @ext do
-        Gem::Ext::ConfigureBuilder.build nil, nil, @dest_path, output
+        Gem::Ext::ConfigureBuilder.build nil, @dest_path, output
       end
     end
 
@@ -76,7 +76,7 @@ class TestGemExtConfigureBuilder < Gem::TestCase
 
     output = []
     Dir.chdir @ext do
-      Gem::Ext::ConfigureBuilder.build nil, nil, @dest_path, output
+      Gem::Ext::ConfigureBuilder.build nil, @dest_path, output
     end
 
     assert_contains_make_command 'clean', output[1]

--- a/test/rubygems/test_gem_ext_ext_conf_builder.rb
+++ b/test/rubygems/test_gem_ext_ext_conf_builder.rb
@@ -29,7 +29,7 @@ class TestGemExtExtConfBuilder < Gem::TestCase
 
     Dir.chdir @ext do
       result =
-        Gem::Ext::ExtConfBuilder.build 'extconf.rb', nil, @dest_path, output
+        Gem::Ext::ExtConfBuilder.build 'extconf.rb', @dest_path, output
 
       assert_same result, output
     end
@@ -54,7 +54,7 @@ class TestGemExtExtConfBuilder < Gem::TestCase
       output = []
 
       Dir.chdir @ext do
-        Gem::Ext::ExtConfBuilder.build 'extconf.rb', nil, @dest_path, output
+        Gem::Ext::ExtConfBuilder.build 'extconf.rb', @dest_path, output
       end
 
       assert_equal "creating Makefile\n", output[2]
@@ -77,7 +77,7 @@ class TestGemExtExtConfBuilder < Gem::TestCase
 
       assert_raises Gem::InstallError do
         Dir.chdir @ext do
-          Gem::Ext::ExtConfBuilder.build 'extconf.rb', nil, @dest_path, output
+          Gem::Ext::ExtConfBuilder.build 'extconf.rb', @dest_path, output
         end
       end
 
@@ -103,7 +103,7 @@ class TestGemExtExtConfBuilder < Gem::TestCase
 
     error = assert_raises Gem::InstallError do
       Dir.chdir @ext do
-        Gem::Ext::ExtConfBuilder.build 'extconf.rb', nil, @dest_path, output
+        Gem::Ext::ExtConfBuilder.build 'extconf.rb', @dest_path, output
       end
     end
 
@@ -172,7 +172,7 @@ end
     output = []
 
     Dir.chdir @ext do
-      Gem::Ext::ExtConfBuilder.build 'extconf.rb', nil, @dest_path, output
+      Gem::Ext::ExtConfBuilder.build 'extconf.rb', @dest_path, output
     end
 
     assert_contains_make_command 'clean', output[4]
@@ -231,4 +231,3 @@ end
   end
 
 end
-

--- a/test/rubygems/test_gem_ext_ext_conf_builder.rb
+++ b/test/rubygems/test_gem_ext_ext_conf_builder.rb
@@ -130,7 +130,7 @@ class TestGemExtExtConfBuilder < Gem::TestCase
     output = []
 
     Dir.chdir @ext do
-      Gem::Ext::ExtConfBuilder.build 'extconf.rb', nil, @dest_path, output
+      Gem::Ext::ExtConfBuilder.build 'extconf.rb', @dest_path, output
     end
 
     refute_includes(output, "To see why this extension failed to compile, please check the mkmf.log which can be found here:\n")

--- a/test/rubygems/test_gem_ext_rake_builder.rb
+++ b/test/rubygems/test_gem_ext_rake_builder.rb
@@ -19,7 +19,7 @@ class TestGemExtRakeBuilder < Gem::TestCase
 
     build_rake_in do |rake|
       Dir.chdir @ext do
-        Gem::Ext::RakeBuilder.build 'mkrf_conf.rb', nil, @dest_path, output
+        Gem::Ext::RakeBuilder.build 'mkrf_conf.rb', @dest_path, output
       end
 
       output = output.join "\n"
@@ -58,7 +58,7 @@ class TestGemExtRakeBuilder < Gem::TestCase
     build_rake_in(false) do |rake|
       error = assert_raises Gem::InstallError do
         Dir.chdir @ext do
-          Gem::Ext::RakeBuilder.build "mkrf_conf.rb", nil, @dest_path, output
+          Gem::Ext::RakeBuilder.build "mkrf_conf.rb", @dest_path, output
         end
       end
 

--- a/test/rubygems/test_gem_ext_rake_builder.rb
+++ b/test/rubygems/test_gem_ext_rake_builder.rb
@@ -40,7 +40,7 @@ class TestGemExtRakeBuilder < Gem::TestCase
     build_rake_in do |rake|
       Dir.chdir @ext do
         non_empty_args_list = ['']
-        Gem::Ext::RakeBuilder.build 'mkrf_conf.rb', nil, @dest_path, output, non_empty_args_list
+        Gem::Ext::RakeBuilder.build 'mkrf_conf.rb', @dest_path, output, non_empty_args_list
       end
 
       output = output.join "\n"


### PR DESCRIPTION
This is a rebase of #669

This parameter was introduced 8 years ago, but was never used. Although
it might break some RubyGems plugin, it doesn't seems there exist any
alternative RubyGems builder in the wild.
