### PR TITLE
Getting ready for lgtm.co

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,3 +1,4 @@
 André Arko <andre@arko.net> (@indirect)
 Jeremy Hinegardner <jeremy@copiousfreetime.org> (@copiousfreetime)
 Kurtis Rainbolt-Greene <me@kurtisrainboltgreene.name> (@krainboltgreene)
+Samuel Giddins <segiddins@segiddins.me> (@segiddins)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,3 @@
+André Arko <andre@arko.net> (@indirect)
+Jeremy Hinegardner <jeremy@copiousfreetime.org> (@copiousfreetime)
+Kurtis Rainbolt-Greene <me@kurtisrainboltgreene.name> (@krainboltgreene)


### PR DESCRIPTION
So [one service I would like to use](#1429) is https://lgtm.co, which gives us the ability to easily :+1: PRs before they get merged. It would cutdown on some of the communication load now that there are more developers.

Either way, it's nice to have a list of all the active maintainers and their contact. If you're not in this list because I've forgotten you, add yourself!