### PR TITLE
Gem::Package::TarReader::Entry: use correct string size

### DIFF
--- a/lib/rubygems/package/tar_reader/entry.rb
+++ b/lib/rubygems/package/tar_reader/entry.rb
@@ -83,7 +83,7 @@ class Gem::Package::TarReader::Entry
     return nil if @read >= @header.size
 
     ret = @io.getc
-    @read += 1 if ret
+    @read += char_bytesize(ret) if ret
 
     ret
   end
@@ -131,7 +131,7 @@ class Gem::Package::TarReader::Entry
     max_read = [len, @header.size - @read].min
 
     ret = @io.read max_read
-    @read += ret.size
+    @read += string_bytesize(ret)
 
     ret
   end
@@ -148,6 +148,30 @@ class Gem::Package::TarReader::Entry
 
     @io.pos = @orig_pos
     @read = 0
+  end
+
+private
+
+  ##
+  # Returns the number of bytes in +str+
+  def string_bytesize( str )
+    if str.respond_to? :bytesize then
+      str.bytesize
+    else
+      str.size
+    end
+  end
+
+  ##
+  # Returns the number of bytes in +char+
+  def char_bytesize( char )
+    if char.kind_of? Fixnum
+      # Ruby < 1.9 uses a Fixnum to represent a single char
+      1
+    else
+      # Ruby >= 1.9 uses a String
+      string_bytesize( char )
+    end
   end
 
 end

--- a/test/rubygems/test_gem_package_tar_reader_entry_multibyte.rb
+++ b/test/rubygems/test_gem_package_tar_reader_entry_multibyte.rb
@@ -1,0 +1,53 @@
+require 'rubygems/package/tar_test_case'
+require 'rubygems/package'
+
+class TestGemPackageTarReaderEntryMultibyte < Gem::Package::TarTestCase
+
+  def setup
+    super
+
+    @contents = "öäü"
+    @content_size = 6
+
+    @tar = ''
+    @tar << tar_file_header("lib/foo", "", 0, @content_size, Time.now)
+    @tar << @contents
+    @tar << "\0" * (512 - (@tar.size % 512))
+
+    @entry = util_entry @tar
+    io = @entry.instance_variable_get(:@io)
+    io.set_encoding "utf-8" if io.respond_to? :set_encoding
+  end
+
+  def teardown
+    close_util_entry(@entry)
+    super
+  end
+
+  def close_util_entry(entry)
+    entry.instance_variable_get(:@io).close!
+  end
+
+  def test_bytes_read_getc
+    assert_equal 0, @entry.bytes_read
+
+    c = @entry.getc
+
+    if c.kind_of? Fixnum then
+      # Ruby < 1.9 behaviour
+      assert_equal 1, @entry.bytes_read
+    else
+      # Ruby >= 1.9 behaviour
+      assert_equal 2, @entry.bytes_read
+    end
+  end
+
+  def test_bytes_read_read
+    assert_equal 0, @entry.bytes_read
+
+    @entry.read
+
+    assert_equal 6, @entry.bytes_read
+  end
+
+end


### PR DESCRIPTION
`Gem::Package::TarReader::Entry.getc` and `.read` don't update `@read` correctly when a multibyte encoding is used. I guess this didn't cause any problems so far because most code just reads an entire tar entry in one go.

I'm not sure about the implementation of `char_bytesize` adn `string_bytesize` because they do type detection at runtime. I tried to solve this by wrapping the method defs in if-blocks but that looked very odd. I guess this is the most maintainable version.
