### PR TITLE
Remove get_relative_path(). Fixes #977.

### DIFF
--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -11,9 +11,7 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
   FileEntry = FileUtils::Entry_ # :nodoc:
 
   def self.build(extension, directory, dest_path, results, args=[], lib_dir=nil)
-    # relative path required as some versions of mktmpdir return an absolute
-    # path which breaks make if it includes a space in the name
-    tmp_dest = get_relative_path(Dir.mktmpdir(".gem.", "."))
+    tmp_dest = Dir.mktmpdir(".gem.", ".")
 
     t = nil
     Tempfile.open %w"siteconf .rb", "." do |siteconf|
@@ -30,7 +28,7 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
       destdir = ENV["DESTDIR"]
 
       begin
-        cmd = [Gem.ruby, "-r", get_relative_path(siteconf.path), File.basename(extension), *args].join ' '
+        cmd = [Gem.ruby, "-r", siteconf.path, File.basename(extension), *args].join ' '
 
         begin
           run cmd, results
@@ -72,12 +70,4 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
   ensure
     FileUtils.rm_rf tmp_dest if tmp_dest
   end
-
-  private
-  def self.get_relative_path(path)
-    path[0..Dir.pwd.length-1] = '.' if path.start_with?(Dir.pwd)
-    path
-  end
-
 end
-

--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -6,6 +6,7 @@
 
 require 'fileutils'
 require 'tempfile'
+require 'shellwords'
 
 class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
   FileEntry = FileUtils::Entry_ # :nodoc:
@@ -28,7 +29,7 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
       destdir = ENV["DESTDIR"]
 
       begin
-        cmd = [Gem.ruby, "-r", siteconf.path, File.basename(extension), *args].join ' '
+        cmd = [Gem.ruby, "-r", Shellwords.escape(siteconf.path), File.basename(extension), *args].join ' '
 
         begin
           run cmd, results

--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -18,7 +18,9 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
     Tempfile.open %w"siteconf .rb", "." do |siteconf|
       t = siteconf
       siteconf.puts "require 'rbconfig'"
-      siteconf.puts "dest_path = #{tmp_dest.dump}"
+      siteconf.puts "# Calling .dump twice quotes it in the Makefile,"
+      siteconf.puts "# allowing paths with spaces in them."
+      siteconf.puts "dest_path = #{tmp_dest.dump.dump}"
       %w[sitearchdir sitelibdir].each do |dir|
         siteconf.puts "RbConfig::MAKEFILE_CONFIG['#{dir}'] = dest_path"
         siteconf.puts "RbConfig::CONFIG['#{dir}'] = dest_path"


### PR DESCRIPTION
Because it breaks literally everything related to C extensions on Windows.