### PR TITLE
Fix C extensions in Ruby 1.9.x on Windows

### DIFF
--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -24,8 +24,7 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
     # Details: https://github.com/rubygems/rubygems/issues/977#issuecomment-171544940
     #
     # TODO: Make this unconditional when rubygems no longer supports Ruby 1.9.x.
-    windows = !!File::ALT_SEPARATOR
-    tmp_dest = get_relative_path(tmp_dest) unless windows && RUBY_VERSION <= '2.0'
+    tmp_dest = get_relative_path(tmp_dest) unless Gem.win_platform? && RUBY_VERSION <= '2.0'
 
     t = nil
     Tempfile.open %w"siteconf .rb", "." do |siteconf|

--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -11,9 +11,21 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
   FileEntry = FileUtils::Entry_ # :nodoc:
 
   def self.build(extension, directory, dest_path, results, args=[], lib_dir=nil)
-    # relative path required as some versions of mktmpdir return an absolute
-    # path which breaks make if it includes a space in the name
-    tmp_dest = get_relative_path(Dir.mktmpdir(".gem.", "."))
+    tmp_dest = Dir.mktmpdir(".gem.", ".")
+
+    # Some versions of `mktmpdir` return absolute paths, which will break make
+    # if the paths contain spaces. However, on Ruby 1.9.x on Windows, relative
+    # paths cause all C extension builds to fail.
+    #
+    # As such, we convert to a relative path unless we are using Ruby 1.9.x on
+    # Windows. This means that when using Ruby 1.9.x on Windows, paths with
+    # spaces do not work.
+    #
+    # Details: https://github.com/rubygems/rubygems/issues/977#issuecomment-171544940
+    #
+    # TODO: Make this unconditional when rubygems no longer supports Ruby 1.9.x.
+    windows = !!File::ALT_SEPARATOR
+    tmp_dest = get_relative_path(tmp_dest) unless windows && RUBY_VERSION <= '2.0'
 
     t = nil
     Tempfile.open %w"siteconf .rb", "." do |siteconf|
@@ -80,4 +92,3 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
   end
 
 end
-

--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -133,6 +133,11 @@ install:
   end
 
   def test_build_extensions_with_gemhome_with_space
+    # Details: https://github.com/rubygems/rubygems/issues/977#issuecomment-171544940
+    if win_platform? && RUBY_VERSION <= '2.0'
+      skip 'gemhome with spaces does not work with Ruby 1.9.x on Windows'
+    end
+
     new_gemhome = File.join @tempdir, 'gem home'
     File.rename(@gemhome, new_gemhome)
     @gemhome = new_gemhome
@@ -333,4 +338,3 @@ install:
   end
 
 end
-


### PR DESCRIPTION
This fixes C extensions failing to build when using Ruby 1.9 on Windows (#977), _unless_ `mktmpdir` returns a path with a space. Later Ruby versions and all other operating systems are unaffected.

See https://github.com/rubygems/rubygems/issues/977#issuecomment-171544940 for a more detailed discussion.