### PR TITLE
Allow the user to omit .gemspec when doing gem build

### DIFF
--- a/lib/rubygems/commands/build_command.rb
+++ b/lib/rubygems/commands/build_command.rb
@@ -41,6 +41,10 @@ with gem spec:
   def execute
     gemspec = get_one_gem_name
 
+    unless File.exist? gemspec
+      gemspec += '.gemspec' if File.exist? gemspec + '.gemspec'
+    end
+
     if File.exist? gemspec then
       spec = Gem::Specification.load gemspec
 

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -61,6 +61,16 @@ class TestGemCommandsBuildCommand < Gem::TestCase
     assert_equal '', @ui.output
     assert_equal "ERROR:  Gemspec file not found: some_gem\n", @ui.error
   end
+  
+  def test_can_find_gemspecs_without_dot_gemspec
+    gemspec_file = File.join(@tempdir, @gem.spec_name)
+
+    File.open gemspec_file + ".gemspec", 'w' do |gs|
+      gs.write @gem.to_ruby
+    end
+
+    util_test_build_gem @gem, gemspec_file
+  end
 
   def util_test_build_gem(gem, gemspec_file, check_licenses=true)
     @cmd.options[:args] = [gemspec_file]


### PR DESCRIPTION
When in the directory of a gem and using bash autocomplete, you often have directories which match the name of the gem as well as your gemspec file - so "gem build *someprefix* *tab*" then makes you stop and type .g *tab* in order to autocomplete the name.

This patch changes this so if you omit .gemspec and the file isn't found, it will try attaching .gemspec before giving up.
