### PR TITLE
Configure Appveyor.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ branches:
 clone_depth: 10
 install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
+  - SET GEM_HOME=%APPDATA%\.gem
   - ruby --version
   - gem --version
   - gem install rake --no-rdoc --no-ri

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,3 +30,5 @@ environment:
     - ruby_version: "200-x64"
     - ruby_version: "21"
     - ruby_version: "21-x64"
+    - ruby_version: "22"
+    - ruby_version: "22-x64"


### PR DESCRIPTION
This pull request updates appveyor.yml.

I was testing it on my fork of this repo, and it works: https://ci.appveyor.com/project/duckinator/rubygems.

It's safe to merge this _but Appveyor should *not* be enabled for this repository yet, since there are failures for every single version of Ruby._ Enabling Appveyor now would cause every PR to be blocked regardless of if they're actually broken or not. (It operates the same way as Travis-CI.)

This PR is a prerequisite for #1270.