### PR TITLE
remove temporary library directory

### DIFF
--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -58,7 +58,7 @@ class TestGemRequire < Gem::TestCase
 
     install_specs c1, c2, b1, a1
 
-    dir = Dir.mktmpdir
+    dir = Dir.mktmpdir("test_require", @tempdir)
     dash_i_arg = File.join dir, 'lib'
 
     c_rb = File.join dash_i_arg, 'b', 'c.rb'


### PR DESCRIPTION
Create temporary library directory under the temporary directory
created by `Gem::TestCase#setup`, not to leave garbage in the
default temporary directory.
[Fix #1461]