### PR TITLE
Don't run Ruby 1.9.3 tests on Appveyor.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,9 @@ after_test:
 
 environment:
   matrix:
-    - ruby_version: "193"
+    # FIXME: Tests don't even run on Ruby 1.9.3 on Windows on Appveyor.
+    # See: https://github.com/rubygems/rubygems/issues/1270
+    #- ruby_version: "193"
     - ruby_version: "200"
     - ruby_version: "200-x64"
     - ruby_version: "21"


### PR DESCRIPTION
Since 1.9.3 is lower priority (as I discussed with @indirect), I'm
leaving fixing 1.9.3 tests on Appveyor until after 2.x tests work.

The specs pass in 1.9.3 Windows, but they don't even run on Appveyor.

For more information, see:
  https://github.com/rubygems/rubygems/issues/1270#issuecomment-174247494