### PR TITLE
Add Gem::Specification#required_engine_version

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -919,6 +919,12 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   end
 
   ##
+  # A Gem::Version for the current Ruby engine.
+  def self.ruby_engine_version
+    @engine_version ||= Gem::Version.new RUBY_ENGINE_VERSION
+  end
+
+  ##
   # A Gem::Version for the currently running RubyGems
 
   def self.rubygems_version

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -614,8 +614,10 @@ class Gem::Installer
     rev = spec.required_engine_version
 
     rev.each do |engine, requirement|
-      unless requirement.satisfied_by? Gem.ruby_engine then
-        raise Gem::InstallError, "#{engine} requires Ruby version #{requirement}."
+      if engine.downcase.to_s == Gem.ruby_engine then
+        unless requirement.satisfied_by?(Gem.ruby_engine_version) then
+          raise Gem::InstallError, "#{engine} requires Ruby engine version #{requirement}."
+        end
       end
     end
   end
@@ -833,6 +835,7 @@ TEXT
 
     ensure_required_ruby_version_met
     ensure_required_rubygems_version_met
+    ensure_required_engine_version_met
     ensure_dependencies_met unless @ignore_dependencies
 
     true

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -610,6 +610,16 @@ class Gem::Installer
     end
   end
 
+  def ensure_required_engine_version_met # :nodoc:
+    rev = spec.required_engine_version
+
+    rev.each do |engine, requirement|
+      unless requirement.satisfied_by? Gem.ruby_engine then
+        raise Gem::InstallError, "#{engine} requires Ruby version #{requirement}."
+      end
+    end
+  end
+
   def ensure_required_rubygems_version_met # :nodoc:
     if rrgv = spec.required_rubygems_version then
       unless rrgv.satisfied_by? Gem.rubygems_version then

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -147,6 +147,7 @@ class Gem::Specification < Gem::BasicSpecification
     :require_paths             => ['lib'],
     :required_ruby_version     => Gem::Requirement.default,
     :required_rubygems_version => Gem::Requirement.default,
+    :required_engine_version   => {},
     :requirements              => [],
     :rubyforge_project         => nil,
     :rubygems_version          => Gem::VERSION,
@@ -429,6 +430,11 @@ class Gem::Specification < Gem::BasicSpecification
   attr_reader :required_ruby_version
 
   ##
+  # The Ruby engine required by this gem
+
+  attr_reader :required_engine_version
+
+  ##
   # The RubyGems version required by this gem
 
   attr_reader :required_rubygems_version
@@ -649,6 +655,28 @@ class Gem::Specification < Gem::BasicSpecification
 
   def required_rubygems_version= req
     @required_rubygems_version = Gem::Requirement.create req
+  end
+
+  ##
+  # The Ruby engine required by this gem, e.g. 'ruby', 'jruby', 'rubinius', and
+  # the version required for that engine.
+  #
+  # Usage:
+  #
+  #  spec.required_engine_version = {
+  #    :ruby     => '>= 1.9.3',
+  #    :jruby    => '>= 1.7.24',
+  #    :rubinius => '~> 3.0'
+  #  }
+  #
+  def required_engine_version= req
+    @required_engine_version = {}
+
+    req.each do |engine, value|
+      @required_engine_version[engine] = Gem::Requirement.create value
+    end
+
+    @required_engine_version
   end
 
   ##
@@ -1333,18 +1361,19 @@ class Gem::Specification < Gem::BasicSpecification
     spec.instance_variable_set :@summary,                   array[5]
     spec.instance_variable_set :@required_ruby_version,     array[6]
     spec.instance_variable_set :@required_rubygems_version, array[7]
-    spec.instance_variable_set :@original_platform,         array[8]
-    spec.instance_variable_set :@dependencies,              array[9]
-    spec.instance_variable_set :@rubyforge_project,         array[10]
-    spec.instance_variable_set :@email,                     array[11]
-    spec.instance_variable_set :@authors,                   array[12]
-    spec.instance_variable_set :@description,               array[13]
-    spec.instance_variable_set :@homepage,                  array[14]
-    spec.instance_variable_set :@has_rdoc,                  array[15]
-    spec.instance_variable_set :@new_platform,              array[16]
-    spec.instance_variable_set :@platform,                  array[16].to_s
-    spec.instance_variable_set :@license,                   array[17]
-    spec.instance_variable_set :@metadata,                  array[18]
+    spec.instance_variable_set :@required_engine_version,   array[8]
+    spec.instance_variable_set :@original_platform,         array[9]
+    spec.instance_variable_set :@dependencies,              array[10]
+    spec.instance_variable_set :@rubyforge_project,         array[11]
+    spec.instance_variable_set :@email,                     array[12]
+    spec.instance_variable_set :@authors,                   array[13]
+    spec.instance_variable_set :@description,               array[14]
+    spec.instance_variable_set :@homepage,                  array[15]
+    spec.instance_variable_set :@has_rdoc,                  array[16]
+    spec.instance_variable_set :@new_platform,              array[17]
+    spec.instance_variable_set :@platform,                  array[18].to_s
+    spec.instance_variable_set :@license,                   array[19]
+    spec.instance_variable_set :@metadata,                  array[20]
     spec.instance_variable_set :@loaded,                    false
     spec.instance_variable_set :@activated,                 false
 
@@ -1378,6 +1407,7 @@ class Gem::Specification < Gem::BasicSpecification
       @summary,
       @required_ruby_version,
       @required_rubygems_version,
+      @required_engine_version,
       @original_platform,
       @dependencies,
       @rubyforge_project,

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -64,12 +64,13 @@ class Gem::Specification < Gem::BasicSpecification
   #                          Now forward-compatible with future versions
   #      3  1.3.2 2009-01-03 Added Fixnum validation to specification_version
   #      4  1.9.0 2011-06-07 Added metadata
+  #      5  2.3.0 2016-02-10 Added required_engine_version
   #--
   # When updating this number, be sure to also update #to_ruby.
   #
   # NOTE RubyGems < 1.2 cannot load specification versions > 2.
 
-  CURRENT_SPECIFICATION_VERSION = 4 # :nodoc:
+  CURRENT_SPECIFICATION_VERSION = 5 # :nodoc:
 
   ##
   # An informal list of changes to the specification.  The highest-valued
@@ -90,6 +91,9 @@ class Gem::Specification < Gem::BasicSpecification
     ],
     4 => [
       'Added sandboxed freeform metadata to the specification version.'
+    ],
+    5 => [
+      'Added required_engine_version to the specification version.'
     ]
   }
 
@@ -99,6 +103,7 @@ class Gem::Specification < Gem::BasicSpecification
      2 => 16,
      3 => 17,
      4 => 18,
+     5 => 19
   }
 
   today = Time.now.utc
@@ -147,7 +152,6 @@ class Gem::Specification < Gem::BasicSpecification
     :require_paths             => ['lib'],
     :required_ruby_version     => Gem::Requirement.default,
     :required_rubygems_version => Gem::Requirement.default,
-    :required_engine_version   => {},
     :requirements              => [],
     :rubyforge_project         => nil,
     :rubygems_version          => Gem::VERSION,
@@ -156,6 +160,7 @@ class Gem::Specification < Gem::BasicSpecification
     :summary                   => nil,
     :test_files                => [],
     :version                   => nil,
+    :required_engine_version   => {},
   }
 
   Dupable = { } # :nodoc:
@@ -1361,21 +1366,21 @@ class Gem::Specification < Gem::BasicSpecification
     spec.instance_variable_set :@summary,                   array[5]
     spec.instance_variable_set :@required_ruby_version,     array[6]
     spec.instance_variable_set :@required_rubygems_version, array[7]
-    spec.instance_variable_set :@required_engine_version,   array[8]
-    spec.instance_variable_set :@original_platform,         array[9]
-    spec.instance_variable_set :@dependencies,              array[10]
-    spec.instance_variable_set :@rubyforge_project,         array[11]
-    spec.instance_variable_set :@email,                     array[12]
-    spec.instance_variable_set :@authors,                   array[13]
-    spec.instance_variable_set :@description,               array[14]
-    spec.instance_variable_set :@homepage,                  array[15]
-    spec.instance_variable_set :@has_rdoc,                  array[16]
-    spec.instance_variable_set :@new_platform,              array[17]
-    spec.instance_variable_set :@platform,                  array[18].to_s
-    spec.instance_variable_set :@license,                   array[19]
-    spec.instance_variable_set :@metadata,                  array[20]
+    spec.instance_variable_set :@original_platform,         array[8]
+    spec.instance_variable_set :@dependencies,              array[9]
+    spec.instance_variable_set :@rubyforge_project,         array[10]
+    spec.instance_variable_set :@email,                     array[11]
+    spec.instance_variable_set :@authors,                   array[12]
+    spec.instance_variable_set :@description,               array[13]
+    spec.instance_variable_set :@homepage,                  array[14]
+    spec.instance_variable_set :@has_rdoc,                  array[15]
+    spec.instance_variable_set :@new_platform,              array[16]
+    spec.instance_variable_set :@platform,                  array[17].to_s
+    spec.instance_variable_set :@license,                   array[18]
+    spec.instance_variable_set :@metadata,                  array[19]
     spec.instance_variable_set :@loaded,                    false
     spec.instance_variable_set :@activated,                 false
+    spec.instance_variable_set :@required_engine_version,   array[20]
 
     spec
   end
@@ -1407,7 +1412,6 @@ class Gem::Specification < Gem::BasicSpecification
       @summary,
       @required_ruby_version,
       @required_rubygems_version,
-      @required_engine_version,
       @original_platform,
       @dependencies,
       @rubyforge_project,
@@ -1418,7 +1422,8 @@ class Gem::Specification < Gem::BasicSpecification
       true, # has_rdoc
       @new_platform,
       @licenses,
-      @metadata
+      @metadata,
+      @required_engine_version
     ]
   end
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2429,7 +2429,7 @@ Gem::Specification.new do |s|
   s.test_files = ["test/suite.rb".freeze]
 
   if s.respond_to? :specification_version then
-    s.specification_version = 4
+    s.specification_version = 5
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<rake>.freeze, [\"> 0.4\"])

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -698,6 +698,7 @@ end
       post_install_message
       rdoc_options
       require_paths
+      required_engine_version
       required_ruby_version
       required_rubygems_version
       requirements
@@ -1166,6 +1167,7 @@ dependencies: []
     assert_equal 'bin', spec.bindir
     assert_equal '>= 0', spec.required_ruby_version.to_s
     assert_equal '>= 0', spec.required_rubygems_version.to_s
+    assert_equal({}, spec.required_engine_version)
   end
 
   def test_initialize_future
@@ -1199,6 +1201,7 @@ dependencies: []
       s.extensions = 'ext/extconf.rb'
       s.requirements = 'requirement'
       s.add_dependency 'some_gem'
+      s.required_engine_version = {:ruby => '>= 1.9.3', :jruby => '>= 1.7.24'}
     end
 
     new_spec = spec.dup
@@ -1252,6 +1255,10 @@ dependencies: []
     assert_equal '>= 0', spec.required_rubygems_version.to_s
     assert_same spec.required_rubygems_version,
                 new_spec.required_rubygems_version
+
+    engines = [Gem::Requirement.new('>= 1.9.3'), Gem::Requirement.new('>= 1.7.24')]
+    assert_equal({:ruby => engines[0], :jruby => engines[1]}, spec.required_engine_version)
+    assert_same spec.required_engine_version, new_spec.required_engine_version
   end
 
   def test_initialize_copy_broken


### PR DESCRIPTION
This is a followup to issue #1263.

This PR adds the Gem::Specification#required_engine_version member to deal with the limitations of the required_ruby_version, which was originally put in place when there was only one implementation. With multiple Ruby implementations now in the wild, it's necessary to not only specify a Ruby version, but an engine version as well in some cases.

I've also added a Gem.ruby_engine_version singleton method. There's already a Gem.ruby_engine singleton, so it makes sense to add it, and I use it internally in the installer code.

<del>
There is one test failure:

```
1) Failure:
TestGemSpecification#test_handles_private_null_type [test/rubygems/test_gem_specification.rb:1124]:
Expected: nil
  Actual: "developers@soundcloud.com"
```

Which is coming from this test:

```
def test_handles_private_null_type
  path = File.join DATA_PATH, "null-type.gemspec.rz"

  data = Marshal.load Gem.inflate(Gem.read_binary(path))

  assert_equal nil, data.rubyforge_project
end
```
Perhaps the null-type.gemspec.rz file needs to be regenerated? I'm not sure what the proper thing to do is.
</del>