### PR TITLE
Move `coding` location to first line

### DIFF
--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -1,5 +1,5 @@
-# frozen_string_literal: true
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 #--
 # Copyright (C) 2004 Mauricio Julio Fernández Pradier
 # See LICENSE.txt for additional licensing information.

--- a/lib/rubygems/package/tar_header.rb
+++ b/lib/rubygems/package/tar_header.rb
@@ -1,5 +1,5 @@
-# frozen_string_literal: true
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 #--
 # Copyright (C) 2004 Mauricio Julio Fernández Pradier
 # See LICENSE.txt for additional licensing information.
@@ -227,4 +227,3 @@ class Gem::Package::TarHeader
   end
 
 end
-

--- a/lib/rubygems/package/tar_reader.rb
+++ b/lib/rubygems/package/tar_reader.rb
@@ -1,5 +1,5 @@
-# frozen_string_literal: true
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 #--
 # Copyright (C) 2004 Mauricio Julio Fernández Pradier
 # See LICENSE.txt for additional licensing information.
@@ -121,4 +121,3 @@ class Gem::Package::TarReader
 end
 
 require 'rubygems/package/tar_reader/entry'
-

--- a/lib/rubygems/package/tar_reader/entry.rb
+++ b/lib/rubygems/package/tar_reader/entry.rb
@@ -1,5 +1,5 @@
-# frozen_string_literal: true
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 #++
 # Copyright (C) 2004 Mauricio Julio Fernández Pradier
 # See LICENSE.txt for additional licensing information.

--- a/lib/rubygems/package/tar_writer.rb
+++ b/lib/rubygems/package/tar_writer.rb
@@ -1,5 +1,5 @@
-# frozen_string_literal: true
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 #--
 # Copyright (C) 2004 Mauricio Julio Fernández Pradier
 # See LICENSE.txt for additional licensing information.

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1,5 +1,5 @@
-# frozen_string_literal: true
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 #--
 # Copyright 2006 by Chad Fowler, Rich Kilmer, Jim Weirich and others.
 # All rights reserved.


### PR DESCRIPTION
Fixes https://github.com/rubygems/rubygems/commit/45966be372d85520630143090b82b455d287cec6#commitcomment-15800471