### PR TITLE
Handle when the gem home and gem path arent set in the config file

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -941,7 +941,9 @@ module Gem
   def self.use_paths(home, *paths)
     paths.flatten!
     paths.compact!
-    self.paths = { "GEM_HOME" => home, "GEM_PATH" => paths.join(File::PATH_SEPARATOR) }
+    hash = { "GEM_HOME" => home, "GEM_PATH" => paths.join(File::PATH_SEPARATOR) }
+    hash.delete_if { |_, v| v.nil? }
+    self.paths = hash
   end
 
   ##


### PR DESCRIPTION
This fixes failures with the bundler unit tests

(Required because of https://github.com/rubygems/rubygems/blob/master/lib/rubygems/gem_runner.rb#L76)