### PR TITLE
terminate TimeoutHandler

### DIFF
--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -924,6 +924,8 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
         @ssl_server_thread.kill.join
         @ssl_server_thread = nil
       end
+      timeout = WEBrick::Utils::TimeoutHandler
+      timeout.terminate if defined?(timeout.terminate)
     end
 
     def normal_server_port

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -924,8 +924,8 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
         @ssl_server_thread.kill.join
         @ssl_server_thread = nil
       end
-      timeout = WEBrick::Utils::TimeoutHandler
-      timeout.terminate if defined?(timeout.terminate)
+      utils = WEBrick::Utils    # TimeoutHandler is since 1.9
+      utils::TimeoutHandler.terminate if defined?(utils::TimeoutHandler.terminate)
     end
 
     def normal_server_port


### PR DESCRIPTION
Terminate WEBrick::Utils::TimeoutHandler watcher thread to fix
thread leak.

Import from ruby/ruby@d47534799034576131644967d65e5f380fe1de85