### PR TITLE
Fix incorrect dir globs when have_extensions? is true

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -276,13 +276,15 @@ class Gem::BasicSpecification
   # for this spec.
 
   def lib_dirs_glob
-    dirs = if self.require_paths.size > 1 then
-             "{#{self.require_paths.join(',')}}"
-           else
-             self.require_paths.first
-           end
+    dirs = self.require_paths.join(',')
 
-    "#{self.full_gem_path}/#{dirs}".dup.untaint
+    paths = if self.require_paths.size > 1 then
+      "{#{dirs}}"
+    else
+      "#{self.full_gem_path}/#{dirs}"
+    end
+
+    paths.dup.untaint
   end
 
   ##


### PR DESCRIPTION
Before this change `lib_dirs_glob` would return this for the glob if `have_extensions?` was true:

```
"/private/var/folders/fy/rml6_y9x3b392jpmpy160g7r0000gn/T/test_rubygems_64679/gemhome/gems/a-2/{/private/var/folders/fy/rml6_y9x3b392jpmpy160g7r0000gn/T/test_rubygems_64679/gemhome/extensions/x86-darwin-8/2.3.0-static/a-2,lib}"
```

As you can see the extensions directory ends up inside the curly braces so the glob will never actually find anything in the extensions directory.

This commit changes the glob to look like this:

```
{/private/var/folders/fy/rml6_y9x3b392jpmpy160g7r0000gn/T/test_rubygems_64904/gemhome/extensions/x86-darwin-8/2.3.0-static/a-2,lib}"
```

It looks like when extensions are built the shared object is copied to the lib dir as well as the extensions dir. When we're searching for a shared object which one do we want? The lib dir or the extension dir? If we want the extensions dir then we need this patch to fix. If we want the lib dir then there's no point in adding the extensions dir to the lib dir glob.

cc/ @drbrain 
