### PR TITLE
Remove redundant cache

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -95,7 +95,7 @@ class Gem::BasicSpecification
   # Returns path to the extensions directory.
 
   def extensions_dir
-    @extensions_dir ||= Gem.default_ext_dir_for(base_dir) ||
+    Gem.default_ext_dir_for(base_dir) ||
       File.join(base_dir, 'extensions', Gem::Platform.local.to_s,
                 Gem.extension_api_version)
   end
@@ -196,7 +196,6 @@ class Gem::BasicSpecification
 
   def internal_init # :nodoc:
     @extension_dir = nil
-    @extensions_dir = nil
     @full_gem_path         = nil
     @gem_dir               = nil
     @ignored = nil


### PR DESCRIPTION
`extension_dir` caches the result of `extensions_dir` so there's no
reason to cache both.