### PR TITLE
when using #sign_in, store the api key under the correct host

### DIFF
--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -306,9 +306,18 @@ if you believe they were disclosed to a third party.
   # Sets the RubyGems.org API key to +api_key+
 
   def rubygems_api_key= api_key
+    set_api_key :rubygems_api_key, api_key
+
+    @rubygems_api_key = api_key
+  end
+
+  ##
+  # Set a specific host's API key to +api_key+
+
+  def set_api_key host, api_key
     check_credentials_permissions
 
-    config = load_file(credentials_path).merge(:rubygems_api_key => api_key)
+    config = load_file(credentials_path).merge(host => api_key)
 
     dirname = File.dirname credentials_path
     Dir.mkdir(dirname) unless File.exist? dirname
@@ -320,7 +329,7 @@ if you believe they were disclosed to a third party.
       f.write config.to_yaml
     end
 
-    @rubygems_api_key = api_key
+    load_api_keys # reload
   end
 
   def load_file(filename)

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -115,7 +115,7 @@ module Gem::GemcutterUtilities
 
     with_response response do |resp|
       say "Signed in."
-      Gem.configuration.rubygems_api_key = resp.body
+      set_api_key host, resp.body
     end
   end
 
@@ -153,6 +153,14 @@ module Gem::GemcutterUtilities
 
       say message
       terminate_interaction 1 # TODO: question this
+    end
+  end
+
+  def set_api_key host, key
+    if host == Gem::DEFAULT_HOST
+      Gem.configuration.rubygems_api_key = key
+    else
+      Gem.configuration.set_api_key host, key
     end
   end
 

--- a/test/rubygems/test_gem_gemcutter_utilities.rb
+++ b/test/rubygems/test_gem_gemcutter_utilities.rb
@@ -110,7 +110,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
     assert_match %r{Signed in.}, @sign_in_ui.output
 
     credentials = YAML.load_file Gem.configuration.credentials_path
-    assert_equal api_key, credentials[:rubygems_api_key]
+    assert_equal api_key, credentials['http://example.com']
   end
 
   def test_sign_in_with_host_nil
@@ -137,7 +137,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
     assert_match %r{Signed in.}, @sign_in_ui.output
 
     credentials = YAML.load_file Gem.configuration.credentials_path
-    assert_equal api_key, credentials[:rubygems_api_key]
+    assert_equal api_key, credentials['http://example.com']
   end
 
   def test_sign_in_skips_with_existing_credentials


### PR DESCRIPTION
* currently every #sign_in overrides the :rubygems_api_key: key