### PR TITLE
Freeze `Gem::Version@segments` instance variable

### DIFF
--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -219,7 +219,7 @@ class Gem::Version
 
   def bump
     @bump ||= begin
-                segments = self.segments.dup
+                segments = self.segments
                 segments.pop while segments.any? { |s| String === s }
                 segments.pop if segments.size > 1
 
@@ -298,7 +298,7 @@ class Gem::Version
 
   def release
     @release ||= if prerelease?
-                   segments = self.segments.dup
+                   segments = self.segments
                    segments.pop while segments.any? { |s| String === s }
                    self.class.new segments.join('.')
                  else
@@ -307,20 +307,14 @@ class Gem::Version
   end
 
   def segments # :nodoc:
-
-    # segments is lazy so it can pick up version values that come from
-    # old marshaled versions, which don't go through marshal_load.
-
-    @segments ||= @version.scan(/[0-9]+|[a-z]+/i).map do |s|
-      /^\d+$/ =~ s ? s.to_i : s
-    end
+    _segments.dup
   end
 
   ##
   # A recommended version for use with a ~> Requirement.
 
   def approximate_recommendation
-    segments = self.segments.dup
+    segments = self.segments
 
     segments.pop    while segments.any? { |s| String === s }
     segments.pop    while segments.size > 2
@@ -339,8 +333,8 @@ class Gem::Version
     return unless Gem::Version === other
     return 0 if @version == other._version
 
-    lhsegments = segments
-    rhsegments = other.segments
+    lhsegments = _segments
+    rhsegments = other._segments
 
     lhsize = lhsegments.size
     rhsize = rhsegments.size
@@ -366,5 +360,15 @@ class Gem::Version
 
   def _version
     @version
+  end
+
+  def _segments
+    # segments is lazy so it can pick up version values that come from
+    # old marshaled versions, which don't go through marshal_load.
+    # since this version object is cached in @@all, its @segments should be frozen
+
+    @segments ||= @version.scan(/[0-9]+|[a-z]+/i).map do |s|
+      /^\d+$/ =~ s ? s.to_i : s
+    end.freeze
   end
 end

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -146,6 +146,14 @@ class TestGemVersion < Gem::TestCase
     assert_less_than "1.0.0-1", "1"
   end
 
+  # modifying the segments of a version should not affect the segments of the cached version object
+  def test_segments
+    v('9.8.7').segments[2] += 1
+
+    refute_version_equal "9.8.8", "9.8.7"
+    assert_equal         [9,8,7], v("9.8.7").segments
+  end
+
   # Asserts that +version+ is a prerelease.
 
   def assert_prerelease version


### PR DESCRIPTION
Moved the lazy loading to protetected method `Gem::Version#_segments`.
Now `Gem::Version#segments` always returns a dup of the segments array
so you cannot ruin the cached version objects for everyone.

```ruby
# This should *not* make all future '1.2.3' versions have their
# segments equal to [1,2,3,4,5,6]
v = Gem::Version.new('1.2.3')
v.segments += [4,5,6]
```

`Gem::Version` instances started being cached in changeset c4223a2145f07fad4d9383b545620fdd380c77bf (which was in v2.1.0). `@segments` started being lazily initialized in 12d7ca1d34b61115582cc757a3f2c569cbd026f3 and then really lazy in 73b7b5f1118c23240fcfb4f08b807f989118aba0 (both in v1.4.0). It didn't matter so much that they were lazy until the caching of instances by `@version` happened. Then someone could mess with the segments and they'd stay that way for every instance with that version string.

We ran into this with some method to that looked something more or less like this:

```ruby
def bump_patch(version)
  segments = version.segments
  segments[2] += 1
  Gem::Version.new(segments.join('.'))
end

# then this will happen
v1 = Gem::Version.new('1.2.3')
v2 = bump_patch(v1)
v3 = Gem::Version.new('1.2.4')
v4 = Gem::Version.new('1.2.3')
puts v1 == v2 # true
puts v2 == v3 # true
puts v3 == v4 # true
```
And of course since changes to segments doesn't affect the `@version` they all still seem to be the versions I thought they should be, but the comparisons are all wrong.

My solution is to do something like what @tenderlove did in 9fd7533e49661e5166e947567b5803fcbb605510, but for `@segments`