### PR TITLE
raise error if find_by_name returns with nil

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -200,8 +200,13 @@ module Gem
 
     begin
       spec.activate
-    rescue Gem::LoadError # this could fail due to gem dep collisions, go lax
-      Gem::Specification.find_by_name(spec.name).activate
+    rescue Gem::LoadError => e # this could fail due to gem dep collisions, go lax
+      spec_by_name = Gem::Specification.find_by_name(spec.name)
+      if spec_by_name.nil?
+        raise e
+      else
+        spec_by_name.activate
+      end
     end
 
     return true

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -929,6 +929,26 @@ class TestGem < Gem::TestCase
     assert_match %r%Could not find 'b' %, e.message
   end
 
+  def test_self_try_activate_missing_prerelease
+    b = util_spec 'b', '1.0rc1'
+    a = util_spec 'a', '1.0rc1', 'b' => '1.0rc1'
+
+    install_specs b, a
+    uninstall_gem b
+
+    a_file = File.join a.gem_dir, 'lib', 'a_file.rb'
+
+    write_file a_file do |io|
+      io.puts '# a_file.rb'
+    end
+
+    e = assert_raises Gem::LoadError do
+      Gem.try_activate 'a_file'
+    end
+
+    assert_match %r%Could not find 'b' \(= 1.0rc1\)%, e.message
+  end
+
   def test_self_try_activate_missing_extensions
     spec = util_spec 'ext', '1' do |s|
       s.extensions = %w[ext/extconf.rb]


### PR DESCRIPTION
We encountered a dependency collision where meaningful error message got lost because of an unhandled nil-check.