### PR TITLE
Should use default_path if GEM_PATH is empty.

### DIFF
--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -29,7 +29,7 @@ class Gem::PathSupport
       @home   = @home.gsub(File::ALT_SEPARATOR, File::SEPARATOR)
     end
 
-    @path = split_gem_path env["GEM_PATH"], @home
+    @path = split_gem_path env["GEM_PATH"] || '', @home
 
     @spec_cache_dir = env["GEM_SPEC_CACHE"] || Gem.default_spec_cache_dir
 
@@ -46,7 +46,9 @@ class Gem::PathSupport
 
     gem_path = []
 
-    if gpaths
+    if gpaths.empty?
+      gem_path = default_path
+    else
       gem_path = gpaths.split(Gem.path_separator)
       # Handle the path_separator being set to a regexp, which will cause
       # end_with? to error
@@ -61,8 +63,6 @@ class Gem::PathSupport
       end
 
       gem_path << home
-    else
-      gem_path = default_path
     end
 
     gem_path.uniq


### PR DESCRIPTION
Should use default_path if GEM_PATH is empty.

This follows the commit from:
27a436e91f1d83dc4a23168851d4d29a73fde752

We're still using `Gem::PathSupport.new(ENV)`
which GEM_PATH might be `nil`, therefore we should
still guard here and then we could use `empty?` to
check whether we should use `default_path` or not.

Fixes #1510.