### PR TITLE
ensure `default_path` and `home` are set for paths

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -956,7 +956,7 @@ module Gem
   def self.use_paths(home, *paths)
     paths.flatten!
     paths.compact!
-    hash = { "GEM_HOME" => home, "GEM_PATH" => paths.join(File::PATH_SEPARATOR) }
+    hash = { "GEM_HOME" => home, "GEM_PATH" => paths.empty? ? home : paths.join(File::PATH_SEPARATOR) }
     hash.delete_if { |_, v| v.nil? }
     self.paths = hash
   end

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1010,6 +1010,17 @@ class TestGem < Gem::TestCase
     assert_equal expected, err
   end
 
+  def test_self_use_paths_with_nils
+    orig_home = ENV.delete 'GEM_HOME'
+    orig_path = ENV.delete 'GEM_PATH'
+    Gem.use_paths nil, nil
+    assert_equal Gem.default_dir, Gem.paths.home
+    assert_equal (Gem.default_path + [Gem.paths.home]).uniq, Gem.paths.path
+  ensure
+    ENV['GEM_HOME'] = orig_home
+    ENV['GEM_PATH'] = orig_path
+  end
+
   def test_self_use_paths
     util_ensure_gem_dirs
 


### PR DESCRIPTION
When calling `use_paths` with nil values, `home` should be set to
`Gem.default_dir`, and `path` should be the default dir *plus* the home
dir.

Fixes #1510