### PR TITLE
restore but deprecate support for Array values on `Gem.paths=`

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -345,10 +345,32 @@ module Gem
   # Initialize the filesystem paths to use from +env+.
   # +env+ is a hash-like object (typically ENV) that
   # is queried for 'GEM_HOME', 'GEM_PATH', and 'GEM_SPEC_CACHE'
+  # Keys for the +env+ hash should be Strings, and values of the hash should
+  # be Strings or +nil+.
 
   def self.paths=(env)
     clear_paths
-    @paths = Gem::PathSupport.new ENV.to_hash.merge(env)
+    target = {}
+    env.each_pair do |k,v|
+      case k
+      when 'GEM_HOME', 'GEM_PATH', 'GEM_SPEC_CACHE'
+        case v
+        when nil, String
+          target[k] = v
+        when Array
+          unless Gem::Deprecate.skip
+            warn <<-eowarn
+Array values in the parameter are deprecated. Please use a String or nil.
+An Array was passed in from #{caller[3]}
+            eowarn
+          end
+          target[k] = v.join File::PATH_SEPARATOR
+        end
+      else
+        target[k] = v
+      end
+    end
+    @paths = Gem::PathSupport.new ENV.to_hash.merge(target)
     Gem::Specification.dirs = @paths.path
   end
 

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1021,6 +1021,34 @@ class TestGem < Gem::TestCase
     ENV['GEM_PATH'] = orig_path
   end
 
+  def test_setting_paths_does_not_warn_about_unknown_keys
+    stdout, stderr = capture_io do
+      Gem.paths = { 'foo'      => [],
+                    'bar'      => Object.new,
+                    'GEM_HOME' => Gem.paths.home,
+                    'GEM_PATH' => 'foo' }
+    end
+    assert_equal ['foo', Gem.paths.home], Gem.paths.path
+    assert_equal '', stderr
+    assert_equal '', stdout
+  end
+
+  def test_setting_paths_does_not_mutate_parameter_object
+    Gem.paths = { 'GEM_HOME' => Gem.paths.home,
+                  'GEM_PATH' => 'foo' }.freeze
+    assert_equal ['foo', Gem.paths.home], Gem.paths.path
+  end
+
+  def test_deprecated_paths=
+    stdout, stderr = capture_io do
+      Gem.paths = { 'GEM_HOME' => Gem.paths.home,
+                    'GEM_PATH' => [Gem.paths.home, 'foo'] }
+    end
+    assert_equal [Gem.paths.home, 'foo'], Gem.paths.path
+    assert_match(/Array values in the parameter are deprecated. Please use a String or nil/, stderr)
+    assert_equal '', stdout
+  end
+
   def test_self_use_paths
     util_ensure_gem_dirs
 


### PR DESCRIPTION
Some users (most notably Spring users with generated bin files) are
passing Arrays as values in the hash to `Gem.paths=`.  This commit
restores support for Array values but issues a deprecation warning.  The
point is to warn people about their broken code, but allow RubyGems to
continue to work, thus reducing "upgrade friction".

@drbrain I'm not sure about the deprecation cycle, so I just added a deprecation message.  In what version should we drop support for this?

/cc @jonleighton 