### PR TITLE
stop calling `sort_obj` to sort the gem specs

### DIFF
--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -286,7 +286,9 @@ class Gem::Dependency
       }
     end
 
-    matches.sort_by { |s| s.sort_obj } # HACK: shouldn't be needed
+    # `stubs_for` returns oldest first, but `matching_specs` is supposed to
+    # return newest first, so just reverse the list
+    matches.reverse
   end
 
   ##
@@ -334,6 +336,6 @@ class Gem::Dependency
 
     matches.delete_if { |spec| spec.nil? || spec.version.prerelease? } unless prerelease?
 
-    matches.last
+    matches.first
   end
 end


### PR DESCRIPTION
Eventually I'd like to eliminate the `sort_obj` method (if possible).
The order that `stubs_for` returns gem specifications is predictable.
It returns specs ordered oldest first.  `matching_specs` wants to return
them as newest first.  Rather than redoing an expensive sort, we can
just reverse the list.