### PR TITLE
Fix wrong version of gem activation for bin stub.

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -216,7 +216,8 @@ class Gem::Installer
       existing = io.read.slice(%r{
           ^(
             gem \s |
-            load \s Gem\.bin_path\(
+            load \s Gem\.bin_path\( |
+            load \s Gem\.activate_bin_path\(
           )
           (['"])(.*?)(\2),
         }x, 3)
@@ -719,7 +720,7 @@ if ARGV.first
   end
 end
 
-load Gem.bin_path('#{spec.name}', '#{bin_file_name}', version)
+load Gem.activate_bin_path('#{spec.name}', '#{bin_file_name}', version)
 TEXT
   end
 

--- a/lib/rubygems/installer_test_case.rb
+++ b/lib/rubygems/installer_test_case.rb
@@ -170,6 +170,8 @@ class Gem::InstallerTestCase < Gem::TestCase
         EOF
       end
 
+      yield @spec if block_given?
+
       use_ui ui do
         FileUtils.rm_f @gem
 


### PR DESCRIPTION
# Description:

______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends
- [x] [Squash commits](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html)

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

Gem FOO version 1 is installed with a bin file.  The bin file requires
"FOO.rb"

Gem FOO version 2 is installed, no longer has the bin file, but still
contains "FOO.rb"

If the user has FOO gem version 1 and 2 installed, the bin file for
version 1 will erroneously require "FOO.rb" from version 2.

This commit changes the bin file to find the executable and activate the
gem spec that contains that executable.  To do this, I introduced a new
function called `activate_bin_path` which should only be used in bin
stubs.  This function is exactly the same as `bin_path`, but as a side
effect activates the gemspec that contains the binfile.

`bin_path` is public and documented, so I didn't want to change it to
activate gem specifications.