### PR TITLE
support urls in the GEM_PATH environment variable

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -9,6 +9,12 @@
 require 'rbconfig'
 require 'thread'
 
+begin
+  require 'cgi/util'
+rescue LoadError
+  require 'cgi' # 1.8 support
+end
+
 module Gem
   VERSION = '2.6.1'
 end
@@ -386,7 +392,7 @@ Array values in the parameter are deprecated. Please use a String or nil.
 An Array was passed in from #{caller[3]}
             eowarn
           end
-          target[k] = v.join File::PATH_SEPARATOR
+          target[k] = v.map { |path| CGI.escape path }.join File::PATH_SEPARATOR
         end
       else
         target[k] = v
@@ -1000,7 +1006,12 @@ An Array was passed in from #{caller[3]}
   def self.use_paths(home, *paths)
     paths.flatten!
     paths.compact!
-    hash = { "GEM_HOME" => home, "GEM_PATH" => paths.empty? ? home : paths.join(File::PATH_SEPARATOR) }
+    path = if paths.empty?
+             home
+           else
+             paths.map { |p| CGI.escape p }.join File::PATH_SEPARATOR
+           end
+    hash = { "GEM_HOME" => home, "GEM_PATH" => path }
     hash.delete_if { |_, v| v.nil? }
     self.paths = hash
   end

--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -47,7 +47,7 @@ class Gem::PathSupport
     gem_path = []
 
     if gpaths
-      gem_path = gpaths.split(Gem.path_separator)
+      gem_path = gpaths.split(Gem.path_separator).map { |p| CGI.unescape(p) }
       # Handle the path_separator being set to a regexp, which will cause
       # end_with? to error
       if gpaths =~ /#{Gem.path_separator}\z/

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1033,6 +1033,21 @@ class TestGem < Gem::TestCase
     assert_equal '', stdout
   end
 
+  def test_url_support_for_paths
+    Gem.use_paths Gem.paths.home, 'http://example.com'
+    assert_equal ['http://example.com', Gem.paths.home], Gem.paths.path
+  end
+
+  def test_url_support_for_paths_via_deprecated_interface
+    stdout, stderr = capture_io do
+      Gem.paths = { 'GEM_HOME' => Gem.paths.home,
+                    'GEM_PATH' => [Gem.paths.home, 'http://example.com'] }
+    end
+    assert_equal [Gem.paths.home, 'http://example.com'], Gem.paths.path
+    assert_match(/Array values in the parameter are deprecated. Please use a String or nil/, stderr)
+    assert_equal '', stdout
+  end
+
   def test_setting_paths_does_not_mutate_parameter_object
     Gem.paths = { 'GEM_HOME' => Gem.paths.home,
                   'GEM_PATH' => 'foo' }.freeze


### PR DESCRIPTION
# Description:

---
# Tasks:
- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends
- [x] [Squash commits](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html)

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

This adds support for URLs in the GEM_PATH environment variable by
escaping / unescaping paths that are passed in the `use_paths` method.
The benefits of this patch are:
- People can specify a URL on the command line via an environment variable
- JRuby can remove this method: https://github.com/jruby/jruby/blob/ab7b0a06e1c93e35ac18693abade730a4558e55b/lib/ruby/stdlib/rubygems/defaults/jruby.rb#L73-L76

/cc @headius 
