### PR TITLE
Ensure we unlock the monitor even if try_activate throws.

### DIFF
--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -121,13 +121,16 @@ module Kernel
   rescue LoadError => load_error
     RUBYGEMS_ACTIVATION_MONITOR.enter
 
-    if load_error.message.start_with?("Could not find") or
-        (load_error.message.end_with?(path) and Gem.try_activate(path)) then
-      RUBYGEMS_ACTIVATION_MONITOR.exit
-      return gem_original_require(path)
-    else
+    begin
+      if load_error.message.start_with?("Could not find") or
+          (load_error.message.end_with?(path) and Gem.try_activate(path)) then
+        require_again = true
+      end
+    ensure
       RUBYGEMS_ACTIVATION_MONITOR.exit
     end
+
+    return gem_original_require(path) if require_again
 
     raise load_error
   end


### PR DESCRIPTION
# Description:

Not all paths ensured the monitor was unlocked. Specifically `try_activat`e could throw here (possibly exposing an internal bug, but still) and leave the monitor locked, preventing any future requires from entering the Gem require. This patch modifies the `try_activate` logic to always unlock the monitor, success or fail.

See jruby/jruby#3652.

I'm not sure how best to test this; the original report has a
rather complicated env setup not suitable for RG test suite.

There may be locking required around the iteration of
Gem.loaded_specs, in case parallel gem activation is attempting to
mutate that structure concurrently.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests

I'm not sure how to write a test for this. We'd have to get `try_activate` to raise.

- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends
- [x] [Squash commits](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html)

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

