### PR TITLE
speed up gem activation failures

### DIFF
--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -304,14 +304,13 @@ class Gem::Dependency
     # TODO: check Gem.activated_spec[self.name] in case matches falls outside
 
     if matches.empty? then
-      specs = Gem::Specification.find_all { |s|
-                s.name == name
-              }.map { |x| x.full_name }
+      specs = Gem::Specification.stubs_for name
 
       if specs.empty?
-        total = Gem::Specification.to_a.size
+        total = Gem::Specification.stubs.size
         msg   = "Could not find '#{name}' (#{requirement}) among #{total} total gem(s)\n".dup
       else
+        specs = specs.map(&:full_name)
         msg   = "Could not find '#{name}' (#{requirement}) - did find: [#{specs.join ','}]\n".dup
       end
       msg << "Checked in 'GEM_PATH=#{Gem.path.join(File::PATH_SEPARATOR)}', execute `gem env` for more information"


### PR DESCRIPTION
# Description:

______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends
- [ ] [Squash commits](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html)

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

The cost of raising a Gem::LoadError is proportional to the number of
gems that are installed on the system.  We can speed this up a little by
only using stubs in the case of a miss (though we could remove the O(N)
nature of the exception by not putting the count in the error message,
or lazily calculating it).

Before this commit (on a machine with ~800 gems):

```
$ time ruby --disable-did-you-mean -Ilib -e'begin; gem "omglolwut"; rescue Gem::LoadError; end'

real	0m0.437s
user	0m0.341s
sys	0m0.082s
```

After:

```
$ time ruby --disable-did-you-mean -Ilib -e'begin; gem "omglolwut"; rescue Gem::LoadError; end'

real	0m0.181s
user	0m0.106s
sys	0m0.068s
```

This matters to me because I don't have the "did_you_mean" gem
installed, which means that Ruby startup time is proportional to the
number of gems installed.  My Ruby startup time before and after this
commit:

```
[aaron@TC rubygems (master)]$ time ruby -Ilib -e' '

real  0m0.412s
user  0m0.327s
sys 0m0.079s
[aaron@TC rubygems (master)]$ git checkout -
Switched to branch 'speed_up_gem_miss'
[aaron@TC rubygems (speed_up_gem_miss)]$ time ruby -Ilib -e' '

real  0m0.159s
user  0m0.092s
sys 0m0.059s
[aaron@TC rubygems (speed_up_gem_miss)]$
```