### PR TITLE
Allow usage of multiple `--version` operators

### DIFF
--- a/lib/rubygems/version_option.rb
+++ b/lib/rubygems/version_option.rb
@@ -58,7 +58,12 @@ module Gem::VersionOption
     add_option('-v', '--version VERSION', Gem::Requirement,
                "Specify version of gem to #{task}", *wrap) do
                  |value, options|
-      options[:version] = value
+      # Allow handling for multiple --version operators
+      if options[:version] && !options[:version].none?
+        options[:version].concat([value])
+      else
+        options[:version] = value
+      end
 
       explicit_prerelease_set = !options[:explicit_prerelease].nil?
       options[:explicit_prerelease] = false unless explicit_prerelease_set

--- a/test/rubygems/test_gem_version_option.rb
+++ b/test/rubygems/test_gem_version_option.rb
@@ -106,6 +106,21 @@ class TestGemVersionOption < Gem::TestCase
     assert_equal expected, @cmd.options
   end
 
+  def test_multiple_version_operator_option_compound
+    @cmd.add_version_option
+
+    @cmd.handle_options ['--version', '< 1', '--version', '> 0.9']
+
+    expected = {
+      :args => [],
+      :explicit_prerelease => false,
+      :prerelease => false,
+      :version => Gem::Requirement.new('< 1', '> 0.9'),
+    }
+
+    assert_equal expected, @cmd.options
+  end
+
   def test_version_option_explicit_prerelease
     @cmd.add_prerelease_option
     @cmd.add_version_option


### PR DESCRIPTION
Allows for specifying multiple version requirements via multiple `--version` operators.
- Closes #207
