### PR TITLE
lazily calculate Gem::LoadError exception messages

### DIFF
--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -307,18 +307,10 @@ class Gem::Dependency
       specs = Gem::Specification.stubs_for name
 
       if specs.empty?
-        total = Gem::Specification.stubs.size
-        msg   = "Could not find '#{name}' (#{requirement}) among #{total} total gem(s)\n".dup
+        raise Gem::MissingSpecError.new name, requirement
       else
-        specs = specs.map(&:full_name)
-        msg   = "Could not find '#{name}' (#{requirement}) - did find: [#{specs.join ','}]\n".dup
+        raise Gem::MissingSpecVersionError.new name, requirement, specs
       end
-      msg << "Checked in 'GEM_PATH=#{Gem.path.join(File::PATH_SEPARATOR)}', execute `gem env` for more information"
-
-      error = Gem::LoadError.new(msg)
-      error.name        = self.name
-      error.requirement = self.requirement
-      raise error
     end
 
     # TODO: any other resolver validations should go here

--- a/lib/rubygems/errors.rb
+++ b/lib/rubygems/errors.rb
@@ -20,6 +20,41 @@ module Gem
     attr_accessor :requirement
   end
 
+  class MissingSpecError < Gem::LoadError
+    def initialize name, requirement
+      @name        = name
+      @requirement = requirement
+    end
+
+    def message
+      build_message +
+        "Checked in 'GEM_PATH=#{Gem.path.join(File::PATH_SEPARATOR)}', execute `gem env` for more information"
+    end
+
+    private
+
+    def build_message
+      total = Gem::Specification.stubs.size
+      "Could not find '#{name}' (#{requirement}) among #{total} total gem(s)\n"
+    end
+  end
+
+  class MissingSpecVersionError < MissingSpecError
+    attr_reader :specs
+
+    def initialize name, requirement, specs
+      super(name, requirement)
+      @specs = specs
+    end
+
+    private
+
+    def build_message
+      names = specs.map(&:full_name)
+      "Could not find '#{name}' (#{requirement}) - did find: [#{names.join ','}]\n"
+    end
+  end
+
   # Raised when there are conflicting gem specs loaded
 
   class ConflictError < LoadError

--- a/lib/rubygems/errors.rb
+++ b/lib/rubygems/errors.rb
@@ -20,13 +20,17 @@ module Gem
     attr_accessor :requirement
   end
 
+  ##
+  # Raised when trying to activate a gem, and that gem does not exist on the
+  # system.  Instead of rescuing from this class, make sure to rescue from the
+  # superclass Gem::LoadError to catch all types of load errors.
   class MissingSpecError < Gem::LoadError
     def initialize name, requirement
       @name        = name
       @requirement = requirement
     end
 
-    def message
+    def message # :nodoc:
       build_message +
         "Checked in 'GEM_PATH=#{Gem.path.join(File::PATH_SEPARATOR)}', execute `gem env` for more information"
     end
@@ -39,6 +43,10 @@ module Gem
     end
   end
 
+  ##
+  # Raised when trying to activate a gem, and the gem exists on the system, but
+  # not the requested version. Instead of rescuing from this class, make sure to
+  # rescue from the superclass Gem::LoadError to catch all types of load errors.
   class MissingSpecVersionError < MissingSpecError
     attr_reader :specs
 

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -972,7 +972,7 @@ class TestGem < Gem::TestCase
       io.puts '# a_file.rb'
     end
 
-    e = assert_raises Gem::LoadError do
+    e = assert_raises Gem::MissingSpecError do
       Gem.try_activate 'a_file'
     end
 
@@ -992,7 +992,7 @@ class TestGem < Gem::TestCase
       io.puts '# a_file.rb'
     end
 
-    e = assert_raises Gem::LoadError do
+    e = assert_raises Gem::MissingSpecError do
       Gem.try_activate 'a_file'
     end
 

--- a/test/rubygems/test_gem_dependency.rb
+++ b/test/rubygems/test_gem_dependency.rb
@@ -331,7 +331,7 @@ class TestGemDependency < Gem::TestCase
 
     dep = Gem::Dependency.new "a", "= 2.0"
 
-    e = assert_raises Gem::LoadError do
+    e = assert_raises Gem::MissingSpecVersionError do
       dep.to_specs
     end
 
@@ -350,7 +350,7 @@ class TestGemDependency < Gem::TestCase
 
     dep = Gem::Dependency.new "b", "= 2.0"
 
-    e = assert_raises Gem::LoadError do
+    e = assert_raises Gem::MissingSpecError do
       dep.to_specs
     end
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3373,7 +3373,7 @@ end
     assert Gem::Specification.find_by_name "a", "1"
     assert Gem::Specification.find_by_name "a", ">1"
 
-    assert_raises Gem::LoadError do
+    assert_raises Gem::MissingSpecError do
       Gem::Specification.find_by_name "monkeys"
     end
   end
@@ -3387,7 +3387,7 @@ end
 
     assert Gem::Specification.find_by_name "b"
 
-    assert_raises Gem::LoadError do
+    assert_raises Gem::MissingSpecVersionError do
       Gem::Specification.find_by_name "b", "1"
     end
 

--- a/test/rubygems/test_kernel.rb
+++ b/test/rubygems/test_kernel.rb
@@ -66,7 +66,7 @@ class TestKernel < Gem::TestCase
 
   def test_gem_env_req
     ENV["GEM_REQUIREMENT_A"] = '~> 2.0'
-    assert_raises(Gem::LoadError) { gem('a', '= 1') }
+    assert_raises(Gem::MissingSpecVersionError) { gem('a', '= 1') }
     assert gem('a', '> 1')
     assert_equal @a2, Gem.loaded_specs['a']
   end


### PR DESCRIPTION
`Gem::LoadError` exception messages are expensive to calculate.  The
more gems you have installed, the more expensive the message is to
calculate.  This commit lazily calculates the exception message so that
the only time the message is ever created is if it's accessed.  This
speeds up gem activation misses that look like this:

```ruby
begin
  gem 'missing_gem'
rescue Gem::LoadError
end
```

After this commit, the above pattern is nearly 2x faster:

```
[aaron@TC rubygems (master)]$ cat test.rb
require 'benchmark/ips'

Benchmark.ips do |x|
  x.report("fail") do
    begin
      gem "doesnotexist"
    rescue Gem::LoadError
    end
  end
end
[aaron@TC rubygems (master)]$ ruby -I lib test.rb
Warming up --------------------------------------
                fail     6.395k i/100ms
Calculating -------------------------------------
                fail     69.572k (± 4.4%) i/s -    351.725k
[aaron@TC rubygems (master)]$ git checkout -
Switched to branch 'faster_miss'
[aaron@TC rubygems (faster_miss)]$ ruby -I lib test.rb
Warming up --------------------------------------
                fail    11.654k i/100ms
Calculating -------------------------------------
                fail    128.400k (± 6.7%) i/s -    640.970k
```

The "did_you_mean" gem is loaded in the manner above, so this commit
will speed up environments (like mine) that don't have that gem
installed.  This cuts my boot time about 40%:

```
[aaron@TC rubygems (master)]$ time /Users/aaron/.rbenv/versions/ruby-trunk/bin/ruby -I lib -e' '

real  0m0.094s
user  0m0.064s
sys 0m0.021s
[aaron@TC rubygems (master)]$ git checkout -
Switched to branch 'faster_miss'
[aaron@TC rubygems (faster_miss)]$ time /Users/aaron/.rbenv/versions/ruby-trunk/bin/ruby -I lib -e' '

real  0m0.059s
user  0m0.039s
sys 0m0.011s
```

You can see a massive difference in syscalls on boot:

```
[aaron@TC rubygems (master)]$ sudo dtrace -q -n 'syscall:::entry { @num[probefunc] = count(); }' -c`rbenv which ruby`" -Ilib -e'\ '"

  __semwait_signal                                                  1
  access                                                            1
  bsdthread_create                                                  1
  exit                                                              1
  fcntl_nocancel                                                    1
  getrlimit                                                         1
  getrusage                                                         1
  issetugid                                                         1
  poll                                                              1
  setitimer                                                         1
  shm_open                                                          1
  __disable_threadsignal                                            2
  __pthread_sigmask                                                 2
  bsdthread_terminate                                               2
  gettimeofday                                                      2
  madvise                                                           2
  pipe                                                              2
  select                                                            2
  __mac_syscall                                                     3
  pread                                                             3
  thread_selfid                                                     4
  proc_info                                                         5
  lseek                                                             7
  read_nocancel                                                     9
  fstatfs64                                                        10
  mmap                                                             10
  psynch_cvbroad                                                   10
  psynch_cvwait                                                    10
  sysctl                                                           13
  close_nocancel                                                   15
  open_nocancel                                                    15
  stat64                                                           15
  fgetattrlist                                                     20
  bsdthread_ctl                                                    21
  getgid                                                           21
  getegid                                                          22
  sigaction                                                        22
  geteuid                                                          24
  getuid                                                           24
  fcntl                                                            37
  getdirentries64                                                  47
  workq_kernreturn                                                 70
  fstat64                                                          78
  getattrlist                                                      82
  kevent_qos                                                      125
  close                                                           764
  read                                                            777
  open                                                            852
  lstat64                                                         866
  ioctl                                                          1478
  sigprocmask                                                    1485
  sigaltstack                                                    1486
[aaron@TC rubygems (master)]$ git checkout -
Switched to branch 'faster_miss'
[aaron@TC rubygems (faster_miss)]$ sudo dtrace -q -n 'syscall:::entry { @num[probefunc] = count(); }' -c`rbenv which ruby`" -Ilib -e'\ '"

  __semwait_signal                                                  1
  access                                                            1
  bsdthread_create                                                  1
  exit                                                              1
  fcntl_nocancel                                                    1
  getrlimit                                                         1
  getrusage                                                         1
  issetugid                                                         1
  madvise                                                           1
  poll                                                              1
  setitimer                                                         1
  shm_open                                                          1
  thread_selfid                                                     1
  __pthread_sigmask                                                 2
  pipe                                                              2
  __disable_threadsignal                                            3
  __mac_syscall                                                     3
  bsdthread_terminate                                               3
  pread                                                             3
  proc_info                                                         5
  sysctl                                                            6
  fstatfs64                                                         7
  lseek                                                             7
  psynch_cvwait                                                     8
  read_nocancel                                                     9
  mmap                                                             10
  psynch_cvbroad                                                   10
  open_nocancel                                                    11
  close_nocancel                                                   12
  bsdthread_ctl                                                    14
  fgetattrlist                                                     14
  stat64                                                           14
  getgid                                                           21
  getegid                                                          22
  sigaction                                                        22
  workq_kernreturn                                                 22
  geteuid                                                          23
  getuid                                                           24
  getdirentries64                                                  32
  kevent_qos                                                       35
  fcntl                                                            37
  ioctl                                                            56
  close                                                            57
  getattrlist                                                      58
  read                                                             70
  sigprocmask                                                      71
  sigaltstack                                                      72
  fstat64                                                          78
  open                                                            145
  lstat64                                                         159
```

The differences in system calls at boot time is due to the error message
processing all gem specs (in order to give you the "out of N gems"
message).

This patch introduces two new exception classes, both of which subclass
`Gem::LoadError`.  That means this patch should be backwards compatible
for code that rescues from `Gem::LoadError`, but not code that
specifically does "instance_of?" calls.  Unfortunately minitest 4 does
"instance_of" checks in `assert_raises` which is why I had to change the
tests.  I think the performance improvement is worth the trade-off,
especially since this is done at the boot of every Ruby 2.3+ process.