### PR TITLE
Fix test on Windows for inconsistent temp path

### DIFF
--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -256,6 +256,17 @@ class Gem::TestCase < MiniTest::Unit::TestCase
       @tempdir.untaint
     end
 
+    # This makes the tempdir consistent on Windows.
+    # Dir.tmpdir may return short path name, but Dir[Dir.tmpdir] returns long
+    # path name. https://bugs.ruby-lang.org/issues/10819
+    # File.expand_path or File.realpath doesn't convert path name to long path
+    # name. Only Dir[] (= Dir.glob) works.
+    # Short and long path name is specific to Windows filesystem.
+    if win_platform?
+      @tempdir = Dir[@tempdir][0]
+      @tempdir.untaint
+    end
+
     @gemhome  = File.join @tempdir, 'gemhome'
     @userhome = File.join @tempdir, 'userhome'
     ENV["GEM_SPEC_CACHE"] = File.join @tempdir, 'spec_cache'


### PR DESCRIPTION
# Description:

Tests fail like the following on Windows.
Reported in https://bugs.ruby-lang.org/issues/12193

```
TestGem#test_self_bin_path_bin_name [C:/rubyinstaller/sandbox/ruby_2_3/test/rubygems/test_gem.rb:157]:
--- expected
+++ actual
@@ -1 +1 @@
-"C:/Users/ADMINI~1/AppData/Local/Temp/2/test_rubygems_4580/gemhome/gems/a-4/bin/abin"
+"C:/Users/Administrator/AppData/Local/Temp/2/test_rubygems_4580/gemhome/gems/a-4/bin/abin"
```

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends
- [x] [Squash commits](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html)

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

This makes the tempdir consistent on Windows.
Dir.tmpdir may return short path name, but Dir[Dir.tmpdir] returns long path name.
https://bugs.ruby-lang.org/issues/10819