### PR TITLE
fixes: 'method_missing': undefined method `this'

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -3005,6 +3005,8 @@ open-ended dependency on #{dep} is not recommended
     @require_paths
   end
 
+  def this; self; end
+
   extend Gem::Deprecate
 
   # TODO:


### PR DESCRIPTION
Description: Certain things (like `github_changelog_generator`) are broken with recent versions of Ruby and Rubygems. This patch works around that.

More details in https://github.com/skywinder/github-changelog-generator/issues/325.