### PR TITLE
Handle cases when the @@stubs variable contains non-stubs.

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -306,6 +306,8 @@ class Gem::BasicSpecification
     raise NotImplementedError
   end
 
+  def this; self; end
+
   private
 
   def have_extensions?; !extensions.empty?; end
@@ -323,5 +325,4 @@ class Gem::BasicSpecification
       false
     end
   end
-
 end

--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -89,8 +89,6 @@ class Gem::StubSpecification < Gem::BasicSpecification
     end
   end
 
-  def this; self; end
-
   def default_gem?
     @default_gem
   end
@@ -212,4 +210,3 @@ class Gem::StubSpecification < Gem::BasicSpecification
   end
 
 end
-

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -100,6 +100,17 @@ end
     load 'rubygems/syck_hack.rb'
   end
 
+  def test_self_find_active_stub_by_path
+    spec = new_spec('a', '1', nil, 'lib/foo.rb')
+    spec.activated = true
+
+    # There used to be a bug (introduced in a9c1aaf) when Gem::Specification
+    # objects are present in the @stubs collection. This test verifies that
+    # this scenario works correctly.
+    Gem::Specification.all = [spec]
+    Gem::Specification.find_active_stub_by_path('foo')
+  end
+
   def test_self_activate
     foo = util_spec 'foo', '1'
 


### PR DESCRIPTION
This fixes the regression introduced in a9c1aaffec0095081fd405ce78cfd689e937c1d7 related to non-stubs being present in the list of stubs. This can happen e.g. when the `all` method is being used. We discovered this while using the `github_changelog_generator` in projects using Bundler (because rvm does some special tricks to "unload" bundler files when ruby gets run from a Bundler project without bundler... https://github.com/rvm/bundler-unload/blob/master/lib/bundler-unload.rb#L28)

Credits to @orenf for fixing this in https://github.com/orenf/rubygems/commit/4a4b4758bd454b4f7525635aca5e8a00e47cab42. This commit builds on top of that, based on discussions in https://github.com/rubygems/rubygems/pull/1556.

Since the `this` method is needed from different kind of `Specification` objects, moving it up one step in the class hierarchy (i.e. to `BasicSpecification`) seemed like the reasonable thing to do. An accompanying test has also been added, to ensure that we have properly fixed the issue.