### PR TITLE
Redact uri password from error output when gem fetch fails

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -365,6 +365,7 @@ test/rubygems/test_gem_validator.rb
 test/rubygems/test_gem_version.rb
 test/rubygems/test_gem_version_option.rb
 test/rubygems/test_kernel.rb
+test/rubygems/test_remote_fetch_error.rb
 test/rubygems/test_require.rb
 test/rubygems/wrong_key_cert.pem
 test/rubygems/wrong_key_cert_32.pem

--- a/lib/rubygems/errors.rb
+++ b/lib/rubygems/errors.rb
@@ -170,6 +170,7 @@ module Gem
     # An English description of the error.
 
     def wordy
+      @source.uri.password = 'REDACTED' unless @source.uri.password.nil?
       "Unable to download data from #{@source.uri} - #{@error.message}"
     end
 

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -27,7 +27,13 @@ class Gem::RemoteFetcher
 
     def initialize(message, uri)
       super message
-      @uri = uri
+      begin
+        uri = URI(uri)
+        uri.password = 'REDACTED' if uri.password
+        @uri = uri.to_s
+      rescue URI::InvalidURIError, ArgumentError
+        @uri = uri
+      end
     end
 
     def to_s # :nodoc:

--- a/test/rubygems/test_gem_source_fetch_problem.rb
+++ b/test/rubygems/test_gem_source_fetch_problem.rb
@@ -16,5 +16,13 @@ class TestGemSourceFetchProblem < Gem::TestCase
     assert_equal 'test', e.message
   end
 
+  def test_password_redacted
+    source = Gem::Source.new 'https://username:secret@gemsource.com'
+    error  = RuntimeError.new 'test'
+
+    sf = Gem::SourceFetchProblem.new source, error
+
+    refute_match sf.wordy, 'secret'
+  end
 end
 

--- a/test/rubygems/test_remote_fetch_error.rb
+++ b/test/rubygems/test_remote_fetch_error.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require 'rubygems/test_case'
+
+class TestRemoteFetchError < Gem::TestCase
+
+  def test_password_redacted
+    error = Gem::RemoteFetcher::FetchError.new('There was an error fetching', 'https://user:secret@gemsource.org')
+    refute_match error.to_s, 'secret'
+  end
+
+  def test_invalid_url
+    error = Gem::RemoteFetcher::FetchError.new('There was an error fetching', 'https://::gemsource.org')
+    assert_equal error.to_s, 'There was an error fetching (https://::gemsource.org)'
+  end
+
+  def test_to_s
+    error = Gem::RemoteFetcher::FetchError.new('There was an error fetching', 'https://gemsource.org')
+    assert_equal error.to_s, 'There was an error fetching (https://gemsource.org)'
+  end
+end
+


### PR DESCRIPTION
# Description:
Previously when a gem install from an authenticated source failed the error message showed the password in plain text. This change ensures that the message has the password redacted.
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends
- [x] [Squash commits](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html)

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

