### PR TITLE
Fix `Gem.find_spec_for_exe` picks oldest gem

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -254,7 +254,7 @@ module Gem
       spec.executables.include? exec_name
     } if exec_name
 
-    unless spec = specs.last
+    unless spec = specs.first
       msg = "can't find gem #{name} (#{requirements}) with executable #{exec_name}"
       raise Gem::GemNotFoundException, msg
     end

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -143,6 +143,20 @@ class TestGem < Gem::TestCase
     assert_match 'a-1/bin/exec', Gem.bin_path('a', 'exec', '>= 0')
   end
 
+  def test_self_bin_path_picking_newest
+    a1 = util_spec 'a', '1' do |s|
+      s.executables = ['exec']
+    end
+
+    a2 = util_spec 'a', '2' do |s|
+      s.executables = ['exec']
+    end
+
+    install_specs a1, a2
+
+    assert_match 'a-2/bin/exec', Gem.bin_path('a', 'exec', '>= 0')
+  end
+
   def test_self_bin_path_no_exec_name
     e = assert_raises ArgumentError do
       Gem.bin_path 'a'


### PR DESCRIPTION
# Description:

This PR fixes #1563 :smiley: 

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends
- [x] [Squash commits](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html)

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

