### PR TITLE
Ignore erd.pdf generated by rails-erd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /notes.txt
 /pkg
 /tmp
+/erd.pdf


### PR DESCRIPTION
# Description:

`rake erd` would generate the `erd.pdf` file (thanks to `rails-erd` gem). This should be ignored by the version control.
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

