### PR TITLE
Remove extension directory before installing

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -284,6 +284,7 @@ class Gem::Installer
 
     # Completely remove any previous gem files
     FileUtils.rm_rf gem_dir
+    FileUtils.rm_rf spec.extension_dir
 
     FileUtils.mkdir_p gem_dir
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1087,6 +1087,41 @@ gem 'other', version
     assert_path_exists expected_makefile
   end
 
+  def test_install_extension_dir_is_removed_on_reinstall
+    @spec.extensions << "extconf.rb"
+    write_file File.join(@tempdir, "extconf.rb") do |io|
+      io.write <<-RUBY
+        require "mkmf"
+        create_makefile("#{@spec.name}")
+      RUBY
+    end
+
+    @spec.files += %w[extconf.rb]
+
+    path = Gem::Package.build @spec
+
+    # Install a gem with an extension
+    use_ui @ui do
+      installer = Gem::Installer.at path
+      installer.install
+    end
+
+    # pretend that a binary file was created as part of the build
+    should_be_removed = File.join(@spec.extension_dir, "#{@spec.name}.so")
+    write_file should_be_removed do |io|
+      io.write "DELETE ME ON REINSTALL"
+    end
+    assert_path_exists should_be_removed
+
+    # reinstall the gem, this is also the same as pristine
+    use_ui @ui do
+      installer = Gem::Installer.at path
+      installer.install
+    end
+
+    refute_path_exists should_be_removed
+  end
+
   def test_install_extension_and_script
     @spec.extensions << "extconf.rb"
     write_file File.join(@tempdir, "extconf.rb") do |io|


### PR DESCRIPTION
# Description:

This is a fix for #1192. 

When a gem is installed, before installing, rubyge currently removes the the files from the `gems` and `specifications` but fails to remove the files from `extensions`. This fixes that.
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends
- [x] [Squash commits](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html)

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

