### PR TITLE
Fix broken symlink support in tar writer (+ fix broken test)

### DIFF
--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -211,7 +211,9 @@ class Gem::Package
       stat = File.lstat file
 
       if stat.symlink?
-        tar.add_symlink file, File.readlink(file), stat.mode
+        relative_dir = File.dirname(file).sub("#{Dir.pwd}/", '')
+        target_path = File.join(relative_dir, File.readlink(file))
+        tar.add_symlink file, target_path, stat.mode
       end
 
       next unless stat.file?

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -141,7 +141,9 @@ class TestGemPackage < Gem::Package::TarTestCase
 
     FileUtils.mkdir_p 'lib'
     open 'lib/code.rb',  'w' do |io| io.write '# lib/code.rb'  end
-    File.symlink('lib/code.rb', 'lib/code_sym.rb')
+
+    # NOTE: 'code.rb' is correct, because it's relative to lib/code_sym.rb
+    File.symlink('code.rb', 'lib/code_sym.rb')
 
     package = Gem::Package.new 'bogus.gem'
     package.spec = spec
@@ -156,12 +158,16 @@ class TestGemPackage < Gem::Package::TarTestCase
 
     Gem::Package::TarReader.new tar do |tar_io|
       tar_io.each_entry do |entry|
-        (entry.symlink? ? symlinks : files) << entry.full_name
+        if entry.symlink?
+          symlinks << { entry.full_name => entry.header.linkname }
+        else
+          files << entry.full_name
+        end
       end
     end
 
     assert_equal %w[lib/code.rb], files
-    assert_equal %w[lib/code_sym.rb], symlinks
+    assert_equal [{'lib/code_sym.rb' => 'lib/code.rb'}], symlinks
   end
 
   def test_build


### PR DESCRIPTION
# Description:

Fix for: https://github.com/rubygems/rubygems/issues/1577

(Avoids installing symlinks before symlink targets have been copied).

# Tasks:

- [X] Describe the problem / feature
- [ ] Write tests
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends
- [ ] [Squash commits](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html)

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

