### PR TITLE
Revamp appveyor.yml file.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,38 +1,42 @@
----
-version: "{build}"
+version: '{build}'
 branches:
   only:
-    - master
-    - auto
-    - /[\d.]+/
+  - master
+  - auto
+  - /[\d.]+/
+skip_tags: true
 clone_depth: 10
-install:
-  - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
-  - SET GEM_HOME=%APPDATA%\.gem
-  - ruby --version
-  - gem --version
-  - gem install rake -v "~> 10.5" --no-rdoc --no-ri
-  - gem install hoe-travis --no-rdoc --no-ri
-  - gem install minitest -v "~> 4.7" --no-rdoc --no-ri
-  - rake travis:before --trace
-  - gem list --details
-  - gem env
-
-build: off
-test_script:
-  - rake -rdevkit travis
-after_test:
-  # FIXME: missing `diff` to check manifest differences
-  #- rake -rdevkit travis:after --trace
-
 environment:
   matrix:
-    # FIXME: Tests don't even run on Ruby 1.9.3 on Windows on Appveyor.
-    # See: https://github.com/rubygems/rubygems/issues/1270
-    #- ruby_version: "193"
-    - ruby_version: "200"
-    - ruby_version: "200-x64"
-    - ruby_version: "21"
-    - ruby_version: "21-x64"
-    - ruby_version: "22"
-    - ruby_version: "22-x64"
+  - ruby_version: 193
+  - ruby_version: 200
+  - ruby_version: 200-x64
+  - ruby_version: 21
+  - ruby_version: 21-x64
+  - ruby_version: 22
+  - ruby_version: 22-x64
+install:
+- ps: >-
+    $env:path = 'C:\Ruby' + $env:ruby_version + '\bin;' + $env:path
+
+    $env:TRAVIS = $TRUE
+
+    if ((gem query -i rake) -eq $False){ gem install rake --no-document }
+
+    if ((gem query -i hoe) -eq $False){ gem install hoe --no-document }
+
+    gem install minitest -v "~> 4.7" --no-document
+
+    ruby -v
+cache:
+- C:\Ruby193\lib\ruby\gems\1.9.1
+- C:\Ruby200\lib\ruby\gems\2.0.0
+- C:\Ruby200-x64\lib\ruby\gems\2.0.0
+- C:\Ruby21\lib\ruby\gems\2.1.0
+- C:\Ruby21-x64\lib\ruby\gems\2.1.0
+- C:\Ruby22\lib\ruby\gems\2.2.0
+- C:\Ruby22-x64\lib\ruby\gems\2.2.0
+build: off
+test_script:
+- cmd: rake -rdevkit test
+deploy: off


### PR DESCRIPTION
This is an update to the appveyor.yml file. A bit about the changes:

* Only tests the master branch. I'm not sure why we care about other branches but I can add them if you feel it's necessary.
* Uses Powershell in the "install" portion instead of cmd.exe. This makes it easier to skip gem installation if the dependencies we need are already installed. PS is just better in general.
* Removes all that Travis stuff. I have no idea what that's about. This ain't Travis.
* Caches the gem directories for each distribution. We don't need to re-provision gems every time we build, so this speeds up the build process.
* No after-test task. No idea why we care about that.

I tried it with local settings on my own fork and it worked fine. All the builds, including 1.9.3, were green.



