### PR TITLE
Skipping more than one gem in pristine

### DIFF
--- a/lib/rubygems/commands/pristine_command.rb
+++ b/lib/rubygems/commands/pristine_command.rb
@@ -24,7 +24,8 @@ class Gem::Commands::PristineCommand < Gem::Command
 
     add_option('--skip=gem_name',
                'used on --all, skip if name == gem_name') do |value, options|
-      options[:skip] = value
+      options[:skip] ||= []
+      options[:skip] << value
     end
 
     add_option('--[no-]extensions',
@@ -115,9 +116,11 @@ extensions will be restored.
         next
       end
 
-      if spec.name == options[:skip]
-        say "Skipped #{spec.full_name}, it was given through options"
-        next
+      if options.has_key? :skip
+        if options[:skip].include? spec.name
+          say "Skipped #{spec.full_name}, it was given through options"
+          next
+        end
       end
 
       if spec.bundled_gem_in_old_ruby?
@@ -157,14 +160,14 @@ extensions will be restored.
           install_defaults.to_s['--env-shebang']
         end
 
-      installer_options = { 
+      installer_options = {
         :wrappers => true,
         :force => true,
         :install_dir => spec.base_dir,
         :env_shebang => env_shebang,
         :build_args => spec.build_args,
       }
-      
+
       if options[:only_executables] then
         installer = Gem::Installer.for_spec(spec, installer_options)
         installer.generate_bin

--- a/test/rubygems/test_gem_commands_pristine_command.rb
+++ b/test/rubygems/test_gem_commands_pristine_command.rb
@@ -253,6 +253,31 @@ class TestGemCommandsPristineCommand < Gem::TestCase
     assert_empty out, out.inspect
   end
 
+  def test_skip_many_gems
+    a = util_spec 'a'
+    b = util_spec 'b'
+    c = util_spec 'c'
+
+    install_gem a
+    install_gem b
+    install_gem c
+
+    @cmd.options[:args] = %w[a b c]
+    @cmd.options[:skip] = ['a', 'c']
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    out = @ui.output.split "\n"
+
+    assert_equal "Restoring gems to pristine condition...", out.shift
+    assert_equal "Skipped #{a.full_name}, it was given through options", out.shift
+    assert_equal "Restored #{b.full_name}", out.shift
+    assert_equal "Skipped #{c.full_name}, it was given through options", out.shift
+    assert_empty out, out.inspect
+  end
+
   def test_execute_many_multi_repo
     a = util_spec 'a'
     install_gem a
@@ -488,4 +513,3 @@ class TestGemCommandsPristineCommand < Gem::TestCase
   end
 
 end
-


### PR DESCRIPTION
# Description:

Turn --skip into an array of values to make it possible
to skip more than one gem when running pristine.

---
# Tasks:
- [X] Describe the problem / feature
- [X] Write tests
- [X] Write code to solve the problem
- [X] Get code review from coworkers / friends
- [X] [Squash commits](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html)

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
