### PR TITLE
Add instruction to `CONTRIBUTING.rdoc` specifying when to update `Manifest.txt`

### DIFF
--- a/CONTRIBUTING.rdoc
+++ b/CONTRIBUTING.rdoc
@@ -13,9 +13,11 @@ contributors to follow to reduce the time it takes to get changes merged in.
    * Match indentation (two spaces)
    * Match coding style (`if`, `elsif`, `when` need trailing `then`)
 
-3. Don't modify the history file or version number.
+3. If any new files are added or existing files removed in a commit or PR, please update the `Manifest.txt` accordingly.
 
-4. If you have any questions, just ask on IRC in #rubygems on Freenode or file
+4. Don't modify the history file or version number.
+
+5. If you have any questions, just ask on IRC in #rubygems on Freenode or file
    an issue here: http://github.com/rubygems/rubygems/issues
 
 For more information and ideas on how to contribute to RubyGems ecosystem, see


### PR DESCRIPTION
- It was not evident from the `CONTRIBUTING.rdoc` guidelines that an update to the `Manifest.txt` file was required when I had previously submitted a PR that added and removed some files. This PR updates to `CONTRIBUTING.rdoc` guidelines to include this caveat.