### PR TITLE
[UserInteraction] Require gem/util since it is used by SilentUI

### DIFF
--- a/lib/rubygems/user_interaction.rb
+++ b/lib/rubygems/user_interaction.rb
@@ -5,6 +5,8 @@
 # See LICENSE.txt for permissions.
 #++
 
+require 'rubygems/util'
+
 begin
   require 'io/console'
 rescue LoadError
@@ -696,4 +698,3 @@ class Gem::SilentUI < Gem::StreamUI
     SilentProgressReporter.new(@outs, *args)
   end
 end
-


### PR DESCRIPTION
# Description:

Likely fixes an error with the bundler specs introduced by https://github.com/rubygems/rubygems/pull/1588.
