### PR TITLE
sort installed versions to make sure we install the latest version

### DIFF
--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -241,7 +241,7 @@ command to remove old versions.
     update_gem 'rubygems-update', version
 
     installed_gems = Gem::Specification.find_all_by_name 'rubygems-update', requirement
-    version        = installed_gems.last.version
+    version        = installed_gems.sort.last.version
 
     install_rubygems version
   end

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -241,7 +241,7 @@ command to remove old versions.
     update_gem 'rubygems-update', version
 
     installed_gems = Gem::Specification.find_all_by_name 'rubygems-update', requirement
-    version        = installed_gems.sort.last.version
+    version        = installed_gems.first.version
 
     install_rubygems version
   end


### PR DESCRIPTION
This will fix the problem where the previous version is installed when you try to upgrade RubyGems.

@segiddins @drbrain 

If you have previous versions installed, the `installed_gems` returns an array:
`[#<Gem::Specification:0x3fc1595adde0 rubygems-update-2.6.4>, #<Gem::Specification:0x3fc1595a477c rubygems-update-2.6.3>]`

We want to sort this so we get the latest version last.