### PR TITLE
Set TEST_SSL instead of TRAVIS.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,8 +19,6 @@ install:
 - ps: >-
     $env:path = 'C:\Ruby' + $env:ruby_version + '\bin;' + $env:path
 
-    $env:TRAVIS = $TRUE
-
     if ((gem query -i rake) -eq $False){ gem install rake --no-document }
 
     if ((gem query -i hoe) -eq $False){ gem install hoe --no-document }

--- a/test/rubygems/test_bundled_ca.rb
+++ b/test/rubygems/test_bundled_ca.rb
@@ -8,7 +8,7 @@ require 'rubygems/request'
 # The tested hosts are explained in detail here: https://github.com/rubygems/rubygems/commit/5e16a5428f973667cabfa07e94ff939e7a83ebd9
 #
 
-if ENV["TRAVIS"] || ENV["TEST_SSL"]
+if ENV["CI"] || ENV["TEST_SSL"]
   class TestBundledCA < Gem::TestCase
 
     THIS_FILE = File.expand_path __FILE__


### PR DESCRIPTION
# Description:

This replaces the TRAVIS env settiing with TEST_SSL in the appveyor.yml file, since earlier discussion indicated that TRAVIS might go away.

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

