### PR TITLE
Raise an explicit error if Signer#sign is called with no certs

### DIFF
--- a/lib/rubygems/security/signer.rb
+++ b/lib/rubygems/security/signer.rb
@@ -102,6 +102,8 @@ class Gem::Security::Signer
   def sign data
     return unless @key
 
+    raise Gem::Security::Exception, 'no certs provided' if @cert_chain.empty?
+
     if @cert_chain.length == 1 and @cert_chain.last.not_after < Time.now then
       re_sign_key
     end

--- a/test/rubygems/test_gem_security_signer.rb
+++ b/test/rubygems/test_gem_security_signer.rb
@@ -205,5 +205,13 @@ c7NM7KZZjj7G++SXjYTEI1PHSA7aFQ/i/+qSUvx+Pg==
     end
   end
 
+  def test_sign_no_certs
+    signer = Gem::Security::Signer.new ALTERNATE_KEY, []
+
+    assert_raises Gem::Security::Exception do
+      signer.sign 'hello'
+    end
+  end
+
 end if defined?(OpenSSL::SSL)
 


### PR DESCRIPTION
# Description:

This PR addresses an unfriendly error message that I brought up in https://github.com/rubygems/rubygems/issues/1413. It now explicitly raises an error if no certs are found. I also added a test for it.
______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

