### PR TITLE
Mark see also require_path as internal comment

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -209,9 +209,9 @@ class Gem::Specification < Gem::BasicSpecification
   ##
   # Paths in the gem to add to <code>$LOAD_PATH</code> when this gem is
   # activated.
-  #
+  #--
   # See also #require_paths
-  #
+  #++
   # If you have an extension you do not need to add <code>"ext"</code> to the
   # require path, the extension build process will copy the extension files
   # into "lib" for you.


### PR DESCRIPTION
### Description:

It was showing up in guides http://guides.rubygems.org/specification-reference/#require_paths=
Syntax of internal comment taken from: [Documenting Source Code](http://docs.ruby-lang.org/en/2.2.0/RDoc/Markup.html#class-RDoc::Markup-label-Documenting+Source+Code)

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).