### PR TITLE
Unifying Fixnum and Bignum into Integer at Ruby 2.4

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2696,9 +2696,9 @@ class Gem::Specification < Gem::BasicSpecification
             "#{full_name} contains itself (#{file_name}), check your files list"
     end
 
-    unless specification_version.is_a?(Fixnum)
+    unless specification_version.is_a?(Integer)
       raise Gem::InvalidSpecificationException,
-            'specification_version must be a Fixnum (did you mean version?)'
+            'specification_version must be a Integer (did you mean version?)'
     end
 
     case platform

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3080,7 +3080,7 @@ Did you mean 'Ruby'?
         end
       end
 
-      err = 'specification_version must be a Fixnum (did you mean version?)'
+      err = 'specification_version must be a Integer (did you mean version?)'
       assert_equal err, e.message
     end
   end


### PR DESCRIPTION
# Description:

ruby core team unified `Fixnum` and `Bignum` into Integer on current master.  I backport these code from our repository.

ref. https://github.com/ruby/ruby/commit/f9727c12cc8fbc5f752f5983be1f14bb976e5a13
______________

# Tasks:

- [*] Describe the problem / feature
- [*] Write tests
- [*] Write code to solve the problem

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).