### PR TITLE
Fixes #1623. Unpacking of gems with symlinks broken on windows

### DIFF
--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -385,7 +385,13 @@ EOM
           FileUtils.chmod entry.header.mode, destination
         end if entry.file?
 
-        File.symlink(entry.header.linkname, destination) if entry.symlink?
+        if entry.symlink?
+          begin 
+            File.symlink(entry.header.linkname, destination)
+          rescue NotImplementedError
+            # Not all Rubies support symlinks
+          end
+        end
 
         verbose destination
       end


### PR DESCRIPTION
# Description:

---
# Tasks:
-  Describe the problem / feature
  Explained in #1623 

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

All MRI Ruby versions before Ruby 2.3 had no symlink support.
JRuby currently has no symlink support on any version (although
it is planned in a later release of JRuby 9.1.x.x).

This fix just catches NotImplmentedError and ignores handling
the symlink entry.  I believe this is what Rubygems did before
symlink suport was added.
