### PR TITLE
Fix one typo in CONTRIBUTING.rdoc

### DIFF
--- a/CONTRIBUTING.rdoc
+++ b/CONTRIBUTING.rdoc
@@ -113,7 +113,7 @@ request pertains too. Not all issues will have a category.
   not a network related API.
 * <b>command</b> - related to something in <tt>Gem::Commands</tt>
 * <b>install</b> - related to gem installations
-* <b>documentation</b> - related to updating / fixing / clarifiying documentation or
+* <b>documentation</b> - related to updating / fixing / clarifying documentation or
   guides
 
 All category labels are the same blue color.


### PR DESCRIPTION
# Description:
Fix one typo in the CONTRIBUTING.rdoc:

  `clarifiying => clarifying`
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends
- [ ] [Squash commits](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html)

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

