### PR TITLE
Fixes #1503 link from CoC to project maintainers list.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -32,8 +32,8 @@ This code of conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by opening an issue or contacting one or more of the project
-maintainers.
+reported by opening an issue or contacting one or more of the [project
+maintainers](MAINTAINERS.txt).
 
 This Code of Conduct is adapted from the [Contributor
 Covenant](http://contributor-covenant.org), version 1.2.0, available at


### PR DESCRIPTION
# Description:
This solves #1503 including a link to project maintainers list in the CODE_OF_CONDUCT.md.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests (not needed)
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends
- [x] [Squash commits](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html) (only one commit)

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

