### PR TITLE
Creating Sign In Command

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -49,6 +49,7 @@ lib/rubygems/commands/rdoc_command.rb
 lib/rubygems/commands/search_command.rb
 lib/rubygems/commands/server_command.rb
 lib/rubygems/commands/setup_command.rb
+lib/rubygems/commands/signin_command.rb
 lib/rubygems/commands/sources_command.rb
 lib/rubygems/commands/specification_command.rb
 lib/rubygems/commands/stale_command.rb
@@ -267,6 +268,7 @@ test/rubygems/test_gem_commands_query_command.rb
 test/rubygems/test_gem_commands_search_command.rb
 test/rubygems/test_gem_commands_server_command.rb
 test/rubygems/test_gem_commands_setup_command.rb
+test/rubygems/test_gem_commands_signin_command.rb
 test/rubygems/test_gem_commands_sources_command.rb
 test/rubygems/test_gem_commands_specification_command.rb
 test/rubygems/test_gem_commands_stale_command.rb

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -21,6 +21,7 @@ bin/update_rubygems
 hide_lib_for_update/note.txt
 lib/gauntlet_rubygems.rb
 lib/rubygems.rb
+lib/rubygems/authorization_utilities.rb
 lib/rubygems/available_set.rb
 lib/rubygems/basic_specification.rb
 lib/rubygems/command.rb
@@ -78,7 +79,6 @@ lib/rubygems/ext/configure_builder.rb
 lib/rubygems/ext/ext_conf_builder.rb
 lib/rubygems/ext/rake_builder.rb
 lib/rubygems/gem_runner.rb
-lib/rubygems/gemcutter_utilities.rb
 lib/rubygems/indexer.rb
 lib/rubygems/install_default_message.rb
 lib/rubygems/install_message.rb
@@ -242,6 +242,7 @@ test/rubygems/test_bundled_ca.rb
 test/rubygems/test_config.rb
 test/rubygems/test_deprecate.rb
 test/rubygems/test_gem.rb
+test/rubygems/test_gem_authorization_utilities.rb
 test/rubygems/test_gem_available_set.rb
 test/rubygems/test_gem_command.rb
 test/rubygems/test_gem_command_manager.rb
@@ -289,7 +290,6 @@ test/rubygems/test_gem_ext_configure_builder.rb
 test/rubygems/test_gem_ext_ext_conf_builder.rb
 test/rubygems/test_gem_ext_rake_builder.rb
 test/rubygems/test_gem_gem_runner.rb
-test/rubygems/test_gem_gemcutter_utilities.rb
 test/rubygems/test_gem_impossible_dependencies_error.rb
 test/rubygems/test_gem_indexer.rb
 test/rubygems/test_gem_install_update_options.rb

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -967,6 +967,14 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   end
 
   ##
+  # Is the current rubygems version a beta?
+
+  def self.beta_version?
+    self.latest_rubygems_version < self.rubygems_version and
+      self.rubygems_version.prerelease?
+  end
+
+  ##
   # Returns an Array of sources to fetch remote gems from. Uses
   # default_sources if the sources list is empty.
 

--- a/lib/rubygems/authorization_utilities.rb
+++ b/lib/rubygems/authorization_utilities.rb
@@ -4,7 +4,7 @@ require 'rubygems/remote_fetcher'
 ##
 # Utility methods for using the RubyGems API.
 
-module Gem::GemcutterUtilities
+module Gem::AuthorizationUtilities
 
   # TODO: move to Gem::Command
   OptionParser.accept Symbol do |value|

--- a/lib/rubygems/command_manager.rb
+++ b/lib/rubygems/command_manager.rb
@@ -58,6 +58,7 @@ class Gem::CommandManager
     :rdoc,
     :search,
     :server,
+    :signin,
     :sources,
     :specification,
     :stale,

--- a/lib/rubygems/commands/owner_command.rb
+++ b/lib/rubygems/commands/owner_command.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 require 'rubygems/command'
 require 'rubygems/local_remote_options'
-require 'rubygems/gemcutter_utilities'
+require 'rubygems/authorization_utilities'
 
 class Gem::Commands::OwnerCommand < Gem::Command
   include Gem::LocalRemoteOptions
-  include Gem::GemcutterUtilities
+  include Gem::AuthorizationUtilities
 
   def description # :nodoc:
     <<-EOF

--- a/lib/rubygems/commands/push_command.rb
+++ b/lib/rubygems/commands/push_command.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 require 'rubygems/command'
 require 'rubygems/local_remote_options'
-require 'rubygems/gemcutter_utilities'
+require 'rubygems/authorization_utilities'
 require 'rubygems/package'
 
 class Gem::Commands::PushCommand < Gem::Command
   include Gem::LocalRemoteOptions
-  include Gem::GemcutterUtilities
+  include Gem::AuthorizationUtilities
 
   def description # :nodoc:
     <<-EOF

--- a/lib/rubygems/commands/signin_command.rb
+++ b/lib/rubygems/commands/signin_command.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require 'rubygems/command'
+require 'rubygems/gemcutter_utilities'
+require 'rubygems/package'
+
+class Gem::Commands::SigninCommand < Gem::Command
+  include Gem::GemcutterUtilities
+
+  def description # :nodoc:
+    <<-EOF
+        The signin command executes host sign in.
+    EOF
+  end
+
+  def arguments # :nodoc:
+    "GEM        gem that you are logging in to push"
+  end
+
+  def usage # :nodoc:
+    "#{program_name} GEM"
+  end
+
+  def initialize
+    super 'signin', 'Signin to a gem server'
+
+    add_option('--host HOST',
+               'Push to another gemcutter-compatible host') do |value, options|
+      options[:host] = value
+    end
+  end
+
+  def execute
+    sign_in sign_in_host
+  end
+
+  def sign_in_host
+    options[:host] || default_host
+  end
+
+  def default_host
+    gem_data = Gem::Package.new(get_one_gem_name)
+    gem_data.spec.metadata['default_gem_server']
+  end
+
+end

--- a/lib/rubygems/commands/signin_command.rb
+++ b/lib/rubygems/commands/signin_command.rb
@@ -8,12 +8,12 @@ class Gem::Commands::SigninCommand < Gem::Command
 
   def description # :nodoc:
     <<-EOF
-        The signin command executes host sign in.
+        The signin command executes host sign in for a push server (the default is https://rubygems.org). The host can be provided with the host flag or can be inferred from the provided gem. Host resolution matches the resolution strategy for the push command.
     EOF
   end
 
   def arguments # :nodoc:
-    "GEM        gem that you are logging in to push"
+    "GEM        built gem that you would like to use for resolving host. This is the qualified gem name to match the push command. example: pkg/foo-bar-1.0.0.gem"
   end
 
   def usage # :nodoc:

--- a/lib/rubygems/commands/signin_command.rb
+++ b/lib/rubygems/commands/signin_command.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 require 'rubygems/command'
-require 'rubygems/gemcutter_utilities'
+require 'rubygems/authorization_utilities'
 require 'rubygems/package'
 
 class Gem::Commands::SigninCommand < Gem::Command
-  include Gem::GemcutterUtilities
+  include Gem::AuthorizationUtilities
 
   def description # :nodoc:
     <<-EOF

--- a/lib/rubygems/commands/yank_command.rb
+++ b/lib/rubygems/commands/yank_command.rb
@@ -2,12 +2,12 @@
 require 'rubygems/command'
 require 'rubygems/local_remote_options'
 require 'rubygems/version_option'
-require 'rubygems/gemcutter_utilities'
+require 'rubygems/authorization_utilities'
 
 class Gem::Commands::YankCommand < Gem::Command
   include Gem::LocalRemoteOptions
   include Gem::VersionOption
-  include Gem::GemcutterUtilities
+  include Gem::AuthorizationUtilities
 
   def description # :nodoc:
     <<-EOF

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -29,6 +29,14 @@ class TestGem < Gem::TestCase
     util_remove_interrupt_command
   end
 
+  def before_teardown
+    change_version Gem::Version.new(Gem::VERSION)
+  end
+
+  def change_version new_version
+    Gem.instance_variable_set :@rubygems_version, new_version
+  end
+
   def test_self_finish_resolve
     save_loaded_features do
       a1 = new_spec "a", "1", "b" => "> 0"
@@ -579,6 +587,18 @@ class TestGem < Gem::TestCase
     version = Gem.latest_rubygems_version
 
     assert_equal Gem::Version.new('1.8.24'), version
+  end
+
+  def test_self_beta_version
+    change_version Gem::Version.new '2.6.4.beta'
+    spec_fetcher do |fetcher|
+      fetcher.spec 'rubygems-update', '2.6.3'
+    end
+
+    assert_equal Gem::Version.new('2.6.4.beta'), Gem.rubygems_version
+    assert_equal Gem::Version.new('2.6.3'), Gem.latest_rubygems_version
+    assert Gem.rubygems_version.prerelease?
+    assert Gem.beta_version?
   end
 
   def test_self_latest_version_for

--- a/test/rubygems/test_gem_authorization_utilities.rb
+++ b/test/rubygems/test_gem_authorization_utilities.rb
@@ -2,9 +2,9 @@
 require 'rubygems/test_case'
 require 'rubygems'
 require 'rubygems/command'
-require 'rubygems/gemcutter_utilities'
+require 'rubygems/authorization_utilities'
 
-class TestGemGemcutterUtilities < Gem::TestCase
+class TestAuthorizationUtilities < Gem::TestCase
 
   def setup
     super
@@ -13,7 +13,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
     Gem.configuration.rubygems_api_key = nil
 
     @cmd = Gem::Command.new '', 'summary'
-    @cmd.extend Gem::GemcutterUtilities
+    @cmd.extend Gem::AuthorizationUtilities
   end
 
   def teardown

--- a/test/rubygems/test_gem_commands_signin_command.rb
+++ b/test/rubygems/test_gem_commands_signin_command.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+require 'rubygems/test_case'
+require 'rubygems/commands/signin_command'
+
+class TestGemCommandsSigninCommand < Gem::TestCase
+  def setup
+    super
+
+    Gem.configuration.rubygems_api_key = nil
+    Gem.configuration.api_keys.clear
+
+    @api_key     = 'a5fdbb6ba150cbb83aad2bb2fede64cf040453903'
+    @email    = 'you@example.com'
+    @password = 'secret'
+
+    @cmd = Gem::Commands::SigninCommand.new
+    _spec, path = util_gem "freewill", "1.0.0" do |spec|
+      spec.metadata['default_gem_server'] = Gem::DEFAULT_HOST
+    end
+    @cmd.options[:args] = [path]
+  end
+
+  def teardown
+    Gem.configuration.rubygems_api_key = nil
+    Gem.configuration.api_keys.clear
+
+    super
+  end
+
+  def test_signin_to_default_host
+    host = Gem::DEFAULT_HOST
+    pretty_host = 'RubyGems.org'
+
+    sign_in host, pretty_host
+
+    credentials = YAML.load_file Gem.configuration.credentials_path
+    assert_equal @api_key, credentials[:rubygems_api_key]
+  end
+
+  def test_signin_to_options_host
+    host = "https://rubygems.example/"
+    
+    @cmd.options[:host] = host
+
+    sign_in host
+
+    credentials = YAML.load_file Gem.configuration.credentials_path
+    assert_equal @api_key, credentials[host]
+  end
+
+  def sign_in host, pretty_host=nil
+    skip 'Always uses $stdin on windows' if Gem.win_platform?
+
+    fetcher = Gem::FakeFetcher.new
+    fetcher.data["#{host}/api/v1/api_key"] = [@api_key, 200, 'OK']
+    Gem::RemoteFetcher.fetcher = fetcher
+
+    
+    sign_in_ui = Gem::MockGemUi.new "#{@email}\n#{@password}\n"
+    use_ui sign_in_ui do
+      @cmd.execute
+    end
+
+    assert_match %r{Enter your #{pretty_host || host} credentials.}, sign_in_ui.output
+    assert fetcher.last_request["authorization"]
+    assert_match %r{Signed in.}, sign_in_ui.output
+  end
+end
+
+


### PR DESCRIPTION
Closes rubygems/rubygems#1634

Sign in command signs the user into a gem's host prior to pushing a gem.
Uses the same sign in mechanism as `PushCommand`.
Can be used to sign into a gem's host prior to running automated tooling
to push gem.
