### PR TITLE
Rescue of SocketError error in remote_fetcher.rb:api_endpoint

### DIFF
--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -107,6 +107,9 @@ class Gem::RemoteFetcher
     rescue Resolv::ResolvError => e
       verbose "Getting SRV record failed: #{e}"
       uri
+    rescue SocketError => e
+      verbose "Getting SRV record failed: #{e}"
+      uri
     else
       target = res.target.to_s.strip
 


### PR DESCRIPTION
# Description:

Sometimes a SocketError might occur during ruby's DNS lookup. This sould not crash gem same as ResolvError does not crash it.

---
# Tasks:
- [X] Describe the problem / feature
- [ ] Write tests
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends
- [X] [Squash commits](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html)

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
