### PR TITLE
Add Gem.platform_defaults to allow impls to override defaults.

### DIFF
--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -54,7 +54,7 @@ class Gem::ConfigFile
   # For Ruby implementers to set configuration defaults.  Set in
   # rubygems/defaults/#{RUBY_ENGINE}.rb
 
-  PLATFORM_DEFAULTS = {}
+  PLATFORM_DEFAULTS = Gem.platform_defaults
 
   # :stopdoc:
 

--- a/lib/rubygems/defaults.rb
+++ b/lib/rubygems/defaults.rb
@@ -175,4 +175,22 @@ module Gem
               RbConfig::CONFIG['ruby_version']
   end
 
+  ##
+  # Default options for gem commands.
+  #
+  # The options here should be structured as an array of string "gem"
+  # command names as keys and a string of the default options as values.
+  #
+  # Example:
+  #
+  # def self.platform_defaults
+  #   {
+  #       'install' => '--no-rdoc --no-ri --env-shebang',
+  #       'update' => '--no-rdoc --no-ri --env-shebang'
+  #   }
+  # end
+
+  def self.platform_defaults
+    {}
+  end
 end

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1695,6 +1695,13 @@ You may need to `gem install -g` to install missing gems
     ENV['RUBYGEMS_GEMDEPS'] = rubygems_gemdeps
   end
 
+  def test_platform_defaults
+    platform_defaults = Gem.platform_defaults
+
+    assert platform_defaults != nil
+    assert platform_defaults.is_a? Hash
+  end
+
   def ruby_install_name name
     orig_RUBY_INSTALL_NAME = RbConfig::CONFIG['ruby_install_name']
     RbConfig::CONFIG['ruby_install_name'] = name


### PR DESCRIPTION
# Description:

In order for implementations like JRuby to provide custom defaults for `gem` commands, we have to load `rubygems/config_file.rb` in order to patch the default value for `Gem::ConfigFile::PLATFORM_DEFAULTS. This file is not normally loaded at runtime, since it is not needed to activate gems, and the load in JRuby adds a few hundred milliseconds to our base startup. With this change, the override of `PLATFORM_DEFAULTS` is done lazily, without loading additional files or overwriting a constant.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends
- [x] [Squash commits](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html)

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).