### PR TITLE
Fix gem installer test for ruby trunk

### DIFF
--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1150,6 +1150,8 @@ gem 'other', version
       RUBY
     end
 
+    write_file File.join(@tempdir, "depend")
+
     write_file File.join(@tempdir, "a.c") do |io|
       io.write <<-C
       #include <ruby.h>
@@ -1162,7 +1164,7 @@ gem 'other', version
       io.write "# b.rb"
     end
 
-    @spec.files += %w[extconf.rb lib/b.rb a.c]
+    @spec.files += %w[extconf.rb lib/b.rb depend a.c]
 
     use_ui @ui do
       path = Gem::Package.build @spec

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1146,6 +1146,11 @@ gem 'other', version
     write_file File.join(@tempdir, "extconf.rb") do |io|
       io.write <<-RUBY
         require "mkmf"
+
+        CONFIG['CC'] = '$(TOUCH) $@ ||'
+        CONFIG['LDSHARED'] = '$(TOUCH) $@ ||'
+        $ruby = '#{Gem.ruby}'
+
         create_makefile("#{@spec.name}")
       RUBY
     end

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1156,8 +1156,8 @@ gem 'other', version
 
       write_file File.join(@tempdir, "a.c") do |io|
         io.write <<-C
-        #include <ruby.h>
-        void Init_a() { }
+          #include <ruby.h>
+          void Init_a() { }
         C
       end
 
@@ -1182,17 +1182,16 @@ gem 'other', version
     end
   else
     def test_find_lib_file_after_install
-
       @spec.extensions << "extconf.rb"
       write_file File.join(@tempdir, "extconf.rb") do |io|
         io.write <<-RUBY
-        require "mkmf"
+          require "mkmf"
 
-        CONFIG['CC'] = '$(TOUCH) $@ ||'
-        CONFIG['LDSHARED'] = '$(TOUCH) $@ ||'
-        $ruby = '#{Gem.ruby}'
+          CONFIG['CC'] = '$(TOUCH) $@ ||'
+          CONFIG['LDSHARED'] = '$(TOUCH) $@ ||'
+          $ruby = '#{Gem.ruby}'
 
-        create_makefile("#{@spec.name}")
+          create_makefile("#{@spec.name}")
         RUBY
       end
 
@@ -1200,8 +1199,8 @@ gem 'other', version
 
       write_file File.join(@tempdir, "a.c") do |io|
         io.write <<-C
-        #include <ruby.h>
-        void Init_a() { }
+          #include <ruby.h>
+          void Init_a() { }
         C
       end
 
@@ -1221,9 +1220,8 @@ gem 'other', version
 
       expected = File.join @spec.full_require_paths.find { |path|
         File.exist? File.join path, 'b.rb'
-        }, 'b.rb'
-        assert_equal expected, @spec.matches_for_glob('b.rb').first
-      end
+      }, 'b.rb'
+      assert_equal expected, @spec.matches_for_glob('b.rb').first
     end
   end
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1141,13 +1141,51 @@ gem 'other', version
     refute_path_exists should_be_removed
   end
 
-  def test_find_lib_file_after_install
-    skip '1.9.2 and earlier mkmf.rb does not create TOUCH' if
-      RUBY_VERSION < '1.9.3'
+  # ruby core repository needs to `depend` file for extension build.
+  # but 1.9.2 and earlier mkmf.rb does not create TOUCH file like depend.
+  if RUBY_VERSION < '1.9.3'
+    def test_find_lib_file_after_install
 
-    @spec.extensions << "extconf.rb"
-    write_file File.join(@tempdir, "extconf.rb") do |io|
-      io.write <<-RUBY
+      @spec.extensions << "extconf.rb"
+      write_file File.join(@tempdir, "extconf.rb") do |io|
+        io.write <<-RUBY
+          require "mkmf"
+          create_makefile("#{@spec.name}")
+        RUBY
+      end
+
+      write_file File.join(@tempdir, "a.c") do |io|
+        io.write <<-C
+        #include <ruby.h>
+        void Init_a() { }
+        C
+      end
+
+      Dir.mkdir File.join(@tempdir, "lib")
+      write_file File.join(@tempdir, 'lib', "b.rb") do |io|
+        io.write "# b.rb"
+      end
+
+      @spec.files += %w[extconf.rb lib/b.rb a.c]
+
+      use_ui @ui do
+        path = Gem::Package.build @spec
+
+        installer = Gem::Installer.at path
+        installer.install
+      end
+
+      expected = File.join @spec.full_require_paths.find { |path|
+        File.exist? File.join path, 'b.rb'
+      }, 'b.rb'
+      assert_equal expected, @spec.matches_for_glob('b.rb').first
+    end
+  else
+    def test_find_lib_file_after_install
+
+      @spec.extensions << "extconf.rb"
+      write_file File.join(@tempdir, "extconf.rb") do |io|
+        io.write <<-RUBY
         require "mkmf"
 
         CONFIG['CC'] = '$(TOUCH) $@ ||'
@@ -1155,36 +1193,38 @@ gem 'other', version
         $ruby = '#{Gem.ruby}'
 
         create_makefile("#{@spec.name}")
-      RUBY
+        RUBY
+      end
+
+      write_file File.join(@tempdir, "depend")
+
+      write_file File.join(@tempdir, "a.c") do |io|
+        io.write <<-C
+        #include <ruby.h>
+        void Init_a() { }
+        C
+      end
+
+      Dir.mkdir File.join(@tempdir, "lib")
+      write_file File.join(@tempdir, 'lib', "b.rb") do |io|
+        io.write "# b.rb"
+      end
+
+      @spec.files += %w[extconf.rb lib/b.rb depend a.c]
+
+      use_ui @ui do
+        path = Gem::Package.build @spec
+
+        installer = Gem::Installer.at path
+        installer.install
+      end
+
+      expected = File.join @spec.full_require_paths.find { |path|
+        File.exist? File.join path, 'b.rb'
+        }, 'b.rb'
+        assert_equal expected, @spec.matches_for_glob('b.rb').first
+      end
     end
-
-    write_file File.join(@tempdir, "depend")
-
-    write_file File.join(@tempdir, "a.c") do |io|
-      io.write <<-C
-      #include <ruby.h>
-      void Init_a() { }
-      C
-    end
-
-    Dir.mkdir File.join(@tempdir, "lib")
-    write_file File.join(@tempdir, 'lib', "b.rb") do |io|
-      io.write "# b.rb"
-    end
-
-    @spec.files += %w[extconf.rb lib/b.rb depend a.c]
-
-    use_ui @ui do
-      path = Gem::Package.build @spec
-
-      installer = Gem::Installer.at path
-      installer.install
-    end
-
-    expected = File.join @spec.full_require_paths.find { |path|
-      File.exist? File.join path, 'b.rb'
-    }, 'b.rb'
-    assert_equal expected, @spec.matches_for_glob('b.rb').first
   end
 
   def test_install_extension_and_script

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1142,6 +1142,9 @@ gem 'other', version
   end
 
   def test_find_lib_file_after_install
+    skip '1.9.2 and earlier mkmf.rb does not create TOUCH' if
+      RUBY_VERSION < '1.9.3'
+
     @spec.extensions << "extconf.rb"
     write_file File.join(@tempdir, "extconf.rb") do |io|
       io.write <<-RUBY


### PR DESCRIPTION
# Description:

I'm going to prepare to release Ruby 2.4.0preview1. ref. https://github.com/ruby/www.ruby-lang.org/pull/1409

I try to merge current master of rubygems into ruby core repository. but I found a test fail with `test_find_lib_file_after_install`. It caused by following reason.

1. Extension on Ruby core needs to `depend` file. Current test case is not build target on ruby core repository.
2. `#include <ruby.h>` is not found on ruby core repository. It needs to some configurations like `test_install_extension_flat`

@segiddins Can you review this? I hope to merge this until next monday.
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends
- [ ] [Squash commits](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html)

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
