### PR TITLE
Update tests to MiniTest 5

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -61,7 +61,7 @@ hoe = Hoe.spec 'rubygems-update' do
   dependency 'rdoc',          '~> 3.0',   :dev
   dependency 'ZenTest',       '~> 4.5',   :dev
   dependency 'rake',          '~> 10.5',  :dev
-  dependency 'minitest',      '~> 4.0',   :dev
+  dependency 'minitest',      '~> 5.0',   :dev
 
   self.extra_rdoc_files = Dir["*.rdoc"] + %w[
     CVE-2013-4287.txt
@@ -93,7 +93,7 @@ Hoe::DEFAULT_CONFIG["exclude"] = %r[#{Hoe::DEFAULT_CONFIG["exclude"]}|\./bundler
 v = hoe.version
 
 hoe.testlib      = :minitest
-hoe.test_prelude = 'gem "minitest", "~> 4.0"'
+hoe.test_prelude = 'gem "minitest", "~> 5.0"'
 
 Rake::Task['docs'].clear
 Rake::Task['clobber_docs'].clear

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -2,7 +2,7 @@
 # TODO: $SAFE = 1
 
 begin
-  gem 'minitest', '~> 4.0'
+  gem 'minitest', '~> 5.0'
 rescue NoMethodError, Gem::LoadError
   # for ruby tests
 end
@@ -83,7 +83,7 @@ end
 #
 # Tests are always run at a safe level of 1.
 
-class Gem::TestCase < MiniTest::Unit::TestCase
+class Gem::TestCase < MiniTest::Test
 
   attr_accessor :fetcher # :nodoc:
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -21,7 +21,7 @@ class TestGemInstaller < Gem::InstallerTestCase
     super
     common_installer_setup
 
-    if __name__ =~ /^test_install(_|$)/ then
+    if name =~ /^test_install(_|$)/ then
       FileUtils.rm_r @spec.gem_dir
       FileUtils.rm_r @user_spec.gem_dir
     end


### PR DESCRIPTION
@drbrain I couldn't really find a rational for why the tests were pinned to minitest 4. Would love to update them to 5 if possible, but obviously no rush!