### PR TITLE
[Version] Make hash based upon canonical segments

### DIFF
--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -237,7 +237,7 @@ class Gem::Version
   end
 
   def hash # :nodoc:
-    @version.hash
+    canonical_segments.hash
   end
 
   def init_with coder # :nodoc:
@@ -331,7 +331,7 @@ class Gem::Version
 
   def <=> other
     return unless Gem::Version === other
-    return 0 if @version == other._version
+    return 0 if @version == other._version || canonical_segments == other.canonical_segments
 
     lhsegments = _segments
     rhsegments = other._segments
@@ -356,6 +356,13 @@ class Gem::Version
     return 0
   end
 
+  def canonical_segments
+    @canonical_segments ||=
+      _split_segments.map! do |segments|
+        segments.reverse_each.drop_while {|s| s == 0 }.reverse
+      end.reduce(&:concat)
+  end
+
   protected
 
   def _version
@@ -370,5 +377,12 @@ class Gem::Version
     @segments ||= @version.scan(/[0-9]+|[a-z]+/i).map do |s|
       /^\d+$/ =~ s ? s.to_i : s
     end.freeze
+  end
+
+  def _split_segments
+    string_start = _segments.index {|s| s.is_a?(String) }
+    string_segments  = segments
+    numeric_segments = string_segments.slice!(0, string_start || string_segments.size)
+    return numeric_segments, string_segments
   end
 end

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -65,7 +65,8 @@ class TestGemVersion < Gem::TestCase
   def test_hash
     assert_equal v("1.2").hash, v("1.2").hash
     refute_equal v("1.2").hash, v("1.3").hash
-    refute_equal v("1.2").hash, v("1.2.0").hash
+    assert_equal v("1.2").hash, v("1.2.0").hash
+    assert_equal v("1.2.pre.1").hash, v("1.2.0.pre.1.0").hash
   end
 
   def test_initialize
@@ -98,6 +99,9 @@ class TestGemVersion < Gem::TestCase
     assert_prerelease "1.2.d.42"
 
     assert_prerelease '1.A'
+
+    assert_prerelease '1-1'
+    assert_prerelease '1-a'
 
     refute_prerelease "1.2.0"
     refute_prerelease "2.9"
@@ -154,6 +158,12 @@ class TestGemVersion < Gem::TestCase
     assert_equal         [9,8,7], v("9.8.7").segments
   end
 
+  def test_canonical_segments
+    assert_equal [1], v("1.0.0").canonical_segments
+    assert_equal [1, "a", 1], v("1.0.0.a.1.0").canonical_segments
+    assert_equal [1, 2, 3, "pre", 1], v("1.2.3-1").canonical_segments
+  end
+
   # Asserts that +version+ is a prerelease.
 
   def assert_prerelease version
@@ -183,6 +193,7 @@ class TestGemVersion < Gem::TestCase
 
   def assert_version_equal expected, actual
     assert_equal v(expected), v(actual)
+    assert_equal v(expected).hash, v(actual).hash, "since #{actual} == #{expected}, they must have the same hash"
   end
 
   # Assert that two versions are eql?. Checks both directions.


### PR DESCRIPTION
# Description:

Closes https://github.com/rubygems/rubygems/issues/1617.
This makes sure the hash reflects a `canonical_segments` property, which just removes trailing 0s from the numeric and pre-release segments as `<=>` does

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends
- [ ] [Squash commits](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html)

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
