### PR TITLE
Update vendored bundler to account for rack 2 release

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -76,6 +76,7 @@ bundler/lib/bundler/gem_helper.rb
 bundler/lib/bundler/gem_helpers.rb
 bundler/lib/bundler/gem_remote_fetcher.rb
 bundler/lib/bundler/gem_tasks.rb
+bundler/lib/bundler/gem_version_promoter.rb
 bundler/lib/bundler/graph.rb
 bundler/lib/bundler/index.rb
 bundler/lib/bundler/injector.rb
@@ -90,6 +91,7 @@ bundler/lib/bundler/match_platform.rb
 bundler/lib/bundler/mirror.rb
 bundler/lib/bundler/plugin.rb
 bundler/lib/bundler/plugin/api.rb
+bundler/lib/bundler/plugin/api/source.rb
 bundler/lib/bundler/plugin/dsl.rb
 bundler/lib/bundler/plugin/index.rb
 bundler/lib/bundler/plugin/installer.rb


### PR DESCRIPTION
Should fix CI failing on recent PRs