### PR TITLE
Should respect Gem.path rather than using Gem.dir

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2079,7 +2079,7 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   def base_dir
-    return Gem.dir unless loaded_from
+    return Gem.path.first unless loaded_from
     @base_dir ||= if default_gem? then
                     File.dirname File.dirname File.dirname loaded_from
                   else


### PR DESCRIPTION
Closes #1680 

Should respect Gem.path rather than using Gem.dir

This fixes installing gems with native extensions with `--user`.

```
gem install --user json
```

Would install to the wrong place without this patch.
