### PR TITLE
Eagerly resolve in activate_bin_path

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -296,7 +296,10 @@ module Gem
 
   def self.activate_bin_path name, exec_name, requirement # :nodoc:
     spec = find_spec_for_exe name, exec_name, [requirement]
-    Gem::LOADED_SPECS_MUTEX.synchronize { spec.activate }
+    Gem::LOADED_SPECS_MUTEX.synchronize do
+      spec.activate
+      finish_resolve
+    end
     spec.bin_file exec_name
   end
 


### PR DESCRIPTION
# Description:

This means we can avoid raising conflicts later on when transitive dependencies are activated before the things that depend upon them

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends
- [ ] [Squash commits](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html)

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
