### PR TITLE
Remove warning `no email specified` when no email.

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -396,8 +396,6 @@ class Gem::Specification < Gem::BasicSpecification
   attr_reader :description
 
   ##
-  # :category: Recommended gemspec attributes
-  #
   # A contact email address (or addresses) for this gem
   #
   # Usage:
@@ -2821,7 +2819,7 @@ http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard li
 
     # Warnings
 
-    %w[author email homepage summary].each do |attribute|
+    %w[author homepage summary].each do |attribute|
       value = self.send attribute
       warning "no #{attribute} specified" if value.nil? or value.empty?
     end

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2748,14 +2748,6 @@ duplicate dependency on c (>= 1.2.3, development), (~> 1.2) use:
     util_setup_validate
 
     Dir.chdir @tempdir do
-      @a1.email = ""
-
-      use_ui @ui do
-        @a1.validate
-      end
-
-      assert_match "#{w}:  no email specified\n", @ui.error, "error"
-
       @a1.email = "FIxxxXME (your e-mail)".sub(/xxx/, "")
 
       e = assert_raises Gem::InvalidSpecificationException do


### PR DESCRIPTION
What
===
Remove warning `no email specified` when no email.

Why
===
Many projects are hosted on version control like Github and BitBucket,
and they provide other more appropriate ways to contact the author (e.g.
Issues, Pull Requests).

Some people are sensitive to including their email address in public
databases. These people have three options:
* Resign to including their email.
* Leave it out and ignore the warning.
* Use a dummy email they don't check often.

Requiring the user to provide email, when there are other more
appropriate methods for contact, seems unnecessary.