### PR TITLE
Use latest rubies on CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ rvm:
 - 1.9.2
 - 1.9.3
 - 2.0.0
-- 2.1.7
-- 2.2.3
+- 2.1.10
+- 2.2.5
 - 2.3.1
 - ruby-head
 env:
@@ -33,9 +33,9 @@ matrix:
       env: "TEST_TOOL=bundler RGV=master"
     - rvm: 2.0.0
       env: "TEST_TOOL=rubygems YAML=syck"
-    - rvm: 2.1.7
+    - rvm: 2.1.10
       env: "TEST_TOOL=rubygems YAML=syck"
-    - rvm: 2.2.3
+    - rvm: 2.2.5
       env: "TEST_TOOL=rubygems YAML=syck"
     - rvm: 2.3.1
       env: "TEST_TOOL=rubygems YAML=syck"


### PR DESCRIPTION
NOTICE: *I was about to use shortcuts (2.1, 2.2, 2.3) in `.travis.yml`, but it wasn't using latest versions.*