### PR TITLE
Set loaded_from before using extension_dir to ensure it is correct for --user or other alternate install path modes

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -282,18 +282,23 @@ class Gem::Installer
 
     run_pre_install_hooks
 
+    # Set loaded_from to ensure extension_dir is correct
+    if @options[:install_as_default] then
+      spec.loaded_from = default_spec_file
+    else
+      spec.loaded_from = spec_file
+    end
+
     # Completely remove any previous gem files
     FileUtils.rm_rf gem_dir
     FileUtils.rm_rf spec.extension_dir
 
     FileUtils.mkdir_p gem_dir
 
-    if @options[:install_as_default]
-      spec.loaded_from = default_spec_file
+    if @options[:install_as_default] then
       extract_bin
       write_default_spec
     else
-      spec.loaded_from = spec_file
       extract_files
 
       build_extensions


### PR DESCRIPTION
Fixes https://github.com/rubygems/rubygems/issues/1680

Not 100% sure the best way to write a test for this.

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
