### PR TITLE
Show default gems for all platforms

### DIFF
--- a/lib/rubygems/commands/query_command.rb
+++ b/lib/rubygems/commands/query_command.rb
@@ -255,22 +255,21 @@ is too hard to use.
         name_tuples.map { |n| n.version }.uniq
       else
         platforms.sort.reverse.map do |version, pls|
-          if pls == [Gem::Platform::RUBY] then
-            if options[:domain] == :remote || specs.all? { |spec| spec.is_a? Gem::Source }
-              version
-            else
-              spec = specs.select { |s| s.version == version }
-              if spec.first.default_gem?
-                "default: #{version}"
-              else
-                version
-              end
+          out = version.to_s
+
+          if options[:domain] == :local
+            default = specs.any? do |s|
+              !s.is_a?(Gem::Source) && s.version == version && s.default_gem?
             end
-          else
-            ruby = pls.delete Gem::Platform::RUBY
-            platform_list = [ruby, *pls.sort].compact
-            "#{version} #{platform_list.join ' '}"
+            out = "default: #{out}" if default
           end
+
+          if pls != [Gem::Platform::RUBY] then
+            platform_list = [pls.delete(Gem::Platform::RUBY), *pls.sort].compact
+            out = platform_list.unshift(out).join(' ')
+          end
+
+          out
         end
       end
 

--- a/test/rubygems/test_gem_commands_query_command.rb
+++ b/test/rubygems/test_gem_commands_query_command.rb
@@ -557,6 +557,25 @@ EOF
     assert_equal expected, @ui.output
   end
 
+  def test_execute_show_default_gems_with_platform
+    a1 = new_default_spec 'a', 1
+    a1.platform = 'java'
+    install_default_specs a1
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    expected = <<-EOF
+
+*** LOCAL GEMS ***
+
+a (default: 1 java)
+EOF
+
+    assert_equal expected, @ui.output
+  end
+
   def test_execute_default_details
     spec_fetcher do |fetcher|
       fetcher.spec 'a', 2


### PR DESCRIPTION
# Description:
Before:

On JRuby 9k:

```sh
gem list
*** LOCAL GEMS ***

did_you_mean (default: 1.0.1)
ffi (1.9.14 java)
jar-dependencies (default: 0.3.5, default: 0.3.2)
jruby-openssl (0.9.17 java) # <----
json (1.8.3 java) # <----
minitest (default: 5.4.1)
net-telnet (default: 0.1.1)
power_assert (default: 0.2.3)
psych (2.0.17 java) # <----
racc (1.4.14 java, 1.4.13 java) # <----
rake (default: 10.4.2)
rdoc (default: 4.2.0)
test-unit (default: 3.1.1)
```

After:

```sh

*** LOCAL GEMS ***

did_you_mean (default: 1.0.1)
ffi (1.9.14 java)
jar-dependencies (default: 0.3.5, default: 0.3.2)
jruby-openssl (default: 0.9.17 java) # <----
json (default: 1.8.3 java) # <----
minitest (default: 5.4.1)
net-telnet (default: 0.1.1)
power_assert (default: 0.2.3)
psych (default: 2.0.17 java) # <----
racc (default: 1.4.14 java, default: 1.4.13 java) # <----
rake (default: 10.4.2)
rdoc (default: 4.2.0)
test-unit (default: 3.1.1)
```

Original issue: https://github.com/jruby/jruby/issues/4019