### PR TITLE
S3 source

### DIFF
--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -397,12 +397,12 @@ class Gem::RemoteFetcher
 
   def s3_source_auth(host)
     s3_source = Gem.configuration[:s3_source] || Gem.configuration['s3_source']
-    raise FetchError.new('no s3_source key exists in .gemrc') unless s3_source
+    raise FetchError.new('no s3_source key exists in .gemrc', "s3://#{host}") unless s3_source
     auth = s3_source[host] || s3_source[host.to_sym]
-    raise FetchError.new("no key for host #{host} in s3_source in .gemrc") unless auth
+    raise FetchError.new("no key for host #{host} in s3_source in .gemrc", "s3://#{host}") unless auth
     id = auth[:id] || auth['id']
     secret = auth[:secret] || auth['secret']
-    raise FetchError.new("s3_source for #{host} missing id or secret") unless id and secret
+    raise FetchError.new("s3_source for #{host} missing id or secret", "s3://#{host}") unless id and secret
     [id, secret]
   end
 

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -384,7 +384,7 @@ class Gem::RemoteFetcher
     require 'base64'
     require 'openssl'
 
-    id, secret = s3_source_auth uri.host
+    id, secret = s3_source_auth uri
 
     expiration ||= s3_expiration
     canonical_path = "/#{uri.host}#{uri.path}"
@@ -393,17 +393,6 @@ class Gem::RemoteFetcher
     # URI.escape is deprecated, and there isn't yet a replacement that does quite what we want
     signature = Base64.encode64(digest).gsub("\n", '').gsub(/[\+\/=]/) { |c| BASE64_URI_TRANSLATE[c] }
     URI.parse("https://#{uri.host}.s3.amazonaws.com#{uri.path}?AWSAccessKeyId=#{id}&Expires=#{expiration}&Signature=#{signature}")
-  end
-
-  def s3_source_auth(host)
-    s3_source = Gem.configuration[:s3_source] || Gem.configuration['s3_source']
-    raise FetchError.new('no s3_source key exists in .gemrc', "s3://#{host}") unless s3_source
-    auth = s3_source[host] || s3_source[host.to_sym]
-    raise FetchError.new("no key for host #{host} in s3_source in .gemrc", "s3://#{host}") unless auth
-    id = auth[:id] || auth['id']
-    secret = auth[:secret] || auth['secret']
-    raise FetchError.new("s3_source for #{host} missing id or secret", "s3://#{host}") unless id and secret
-    [id, secret]
   end
 
   def s3_expiration
@@ -422,5 +411,22 @@ class Gem::RemoteFetcher
     @pool_lock.synchronize do
       @pools[proxy] ||= Gem::Request::ConnectionPools.new proxy, @cert_files
     end
+  end
+
+  def s3_source_auth(uri)
+    return [uri.user, uri.password] if uri.user && uri.password
+
+    s3_source = Gem.configuration[:s3_source] || Gem.configuration['s3_source']
+    host = uri.host
+    raise FetchError.new("no s3_source key exists in .gemrc", "s3://#{host}") unless s3_source
+
+    auth = s3_source[host] || s3_source[host.to_sym]
+    raise FetchError.new("no key for host #{host} in s3_source in .gemrc", "s3://#{host}") unless auth
+
+    id = auth[:id] || auth['id']
+    secret = auth[:secret] || auth['secret']
+    raise FetchError.new("s3_source for #{host} missing id or secret", "s3://#{host}") unless id and secret
+
+    [id, secret]
   end
 end

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -384,17 +384,26 @@ class Gem::RemoteFetcher
     require 'base64'
     require 'openssl'
 
-    unless uri.user && uri.password
-      raise FetchError.new("credentials needed in s3 source, like s3://key:secret@bucket-name/", uri.to_s)
-    end
+    id, secret = s3_source_auth uri.host
 
     expiration ||= s3_expiration
     canonical_path = "/#{uri.host}#{uri.path}"
     payload = "GET\n\n\n#{expiration}\n#{canonical_path}"
-    digest = OpenSSL::HMAC.digest('sha1', uri.password, payload)
+    digest = OpenSSL::HMAC.digest('sha1', secret, payload)
     # URI.escape is deprecated, and there isn't yet a replacement that does quite what we want
     signature = Base64.encode64(digest).gsub("\n", '').gsub(/[\+\/=]/) { |c| BASE64_URI_TRANSLATE[c] }
-    URI.parse("https://#{uri.host}.s3.amazonaws.com#{uri.path}?AWSAccessKeyId=#{uri.user}&Expires=#{expiration}&Signature=#{signature}")
+    URI.parse("https://#{uri.host}.s3.amazonaws.com#{uri.path}?AWSAccessKeyId=#{id}&Expires=#{expiration}&Signature=#{signature}")
+  end
+
+  def s3_source_auth(host)
+    s3_source = Gem.configuration[:s3_source] || Gem.configuration['s3_source']
+    raise FetchError.new('no s3_source key exists in .gemrc') unless s3_source
+    auth = s3_source[host] || s3_source[host.to_sym]
+    raise FetchError.new("no key for host #{host} in s3_source in .gemrc") unless auth
+    id = auth[:id] || auth['id']
+    secret = auth[:secret] || auth['secret']
+    raise FetchError.new("s3_source for #{host} missing id or secret") unless id and secret
+    [id, secret]
   end
 
   def s3_expiration

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -727,15 +727,10 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     assert_equal "murphy", fetcher.fetch_path(@server_uri)
   end
 
-  def test_fetch_s3
+  def assert_fetch_s3(url)
     fetcher = Gem::RemoteFetcher.new nil
     @fetcher = fetcher
-    url = 's3://my-bucket/gems/specs.4.8.gz'
     $fetched_uri = nil
-
-    Gem.configuration[:s3_source] = {
-      'my-bucket' => {:id => 'testuser', :secret => 'testpass'}
-    }
 
     def fetcher.request(uri, request_class, last_modified = nil)
       $fetched_uri = uri
@@ -753,8 +748,22 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     assert_equal 'https://my-bucket.s3.amazonaws.com/gems/specs.4.8.gz?AWSAccessKeyId=testuser&Expires=1395098371&Signature=eUTr7NkpZEet%2BJySE%2BfH6qukroI%3D', $fetched_uri.to_s
     assert_equal 'success', data
   ensure
-    Gem.configuration[:s3_source] = nil
     $fetched_uri = nil
+  end
+
+  def test_fetch_s3_config_creds
+    Gem.configuration[:s3_source] = {
+      'my-bucket' => {:id => 'testuser', :secret => 'testpass'}
+    }
+    url = 's3://my-bucket/gems/specs.4.8.gz'
+    assert_fetch_s3 url
+  ensure
+    Gem.configuration[:s3_source] = nil
+  end
+
+  def test_fetch_s3_url_creds
+    url = 's3://testuser:testpass@my-bucket/gems/specs.4.8.gz'
+    assert_fetch_s3 url
   end
 
   def test_fetch_s3_no_creds

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -730,8 +730,12 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
   def test_fetch_s3
     fetcher = Gem::RemoteFetcher.new nil
     @fetcher = fetcher
-    url = 's3://testuser:testpass@my-bucket/gems/specs.4.8.gz'
+    url = 's3://my-bucket/gems/specs.4.8.gz'
     $fetched_uri = nil
+
+    Gem.configuration[:s3_source] = {
+      'my-bucket' => {id: 'testuser', secret: 'testpass' }
+    }
 
     def fetcher.request(uri, request_class, last_modified = nil)
       $fetched_uri = uri
@@ -749,6 +753,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     assert_equal 'https://my-bucket.s3.amazonaws.com/gems/specs.4.8.gz?AWSAccessKeyId=testuser&Expires=1395098371&Signature=eUTr7NkpZEet%2BJySE%2BfH6qukroI%3D', $fetched_uri.to_s
     assert_equal 'success', data
   ensure
+    Gem.configuration[:s3_source] = nil
     $fetched_uri = nil
   end
 
@@ -760,7 +765,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
       fetcher.fetch_s3 URI.parse(url)
     end
 
-    assert_match "credentials needed", e.message
+    assert_match 'no s3_source key exists in .gemrc', e.message
   end
 
   def test_observe_no_proxy_env_single_host

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -734,7 +734,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     $fetched_uri = nil
 
     Gem.configuration[:s3_source] = {
-      'my-bucket' => {id: 'testuser', secret: 'testpass' }
+      'my-bucket' => {:id => 'testuser', :secret => 'testpass'}
     }
 
     def fetcher.request(uri, request_class, last_modified = nil)


### PR DESCRIPTION
# Description:

Supersedes: #1134 

> Currently s3 sources are almost supported in rubygems, but it will only work if you are lucky enough that your AWS secret key has no special characters in it. This patch fixes that by moving the config into the .gemrc.
> Instead of encoding the id and secret into the url, edit the .gemrc file with the authentication needed for each source. You must add the s3 bucket to the regular sources, then add the s3_source key with a set of credentials for each s3 hostname.
> 
> ```
> :sources:
> - s3://bucket1/path
> - s3://bucket2/
> - https://rubygems.org/
> s3_source: {
>   bucket1: {
>     id: "AOUEAOEU123123AOEUAO",
>     secret: "aodnuhtdao/saeuhto+19283oaehu/asoeu+123h"
>   },
>   bucket2: {
>     id: "AOUEAOEU123123AOEUAO",
>     secret: "aodnuhtdao/saeuhto+19283oaehu/asoeu+123h"
>   }
> }
> ```
# Tasks:
- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends
- [ ] [Squash commits](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html)

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
