### PR TITLE
Update contributing guide

### DIFF
--- a/CONTRIBUTING.rdoc
+++ b/CONTRIBUTING.rdoc
@@ -25,6 +25,7 @@ here: http://guides.rubygems.org/contributing/
 
 == Getting Started
 
+    $ git submodule update —-init
     $ gem install hoe
     $ rake newb
 


### PR DESCRIPTION
This add `git submodule update --init` to the instructions since it's needed now that bundler is part of rubygems.