### PR TITLE
Retry with :prerelease when no suggestions are found

### DIFF
--- a/lib/rubygems/spec_fetcher.rb
+++ b/lib/rubygems/spec_fetcher.rb
@@ -184,10 +184,10 @@ class Gem::SpecFetcher
   # Suggests gems based on the supplied +gem_name+. Returns an array of
   # alternative gem names.
 
-  def suggest_gems_from_name gem_name
+  def suggest_gems_from_name(gem_name, type = :latest)
     gem_name        = gem_name.downcase.tr('_-', '')
     max             = gem_name.size / 2
-    names           = available_specs(:latest).first.values.flatten(1)
+    names           = available_specs(type).first.values.flatten(1)
 
     matches = names.map { |n|
       next unless n.match_platform?
@@ -201,7 +201,11 @@ class Gem::SpecFetcher
       [n.name, distance]
     }.compact
 
-    matches = matches.uniq.sort_by { |name, dist| dist }
+    matches = if matches.empty? && type != :prerelease
+      suggest_gems_from_name gem_name, :prerelease
+    else
+      matches.uniq.sort_by { |name, dist| dist }
+    end
 
     matches.first(5).map { |name, dist| name }
   end

--- a/test/rubygems/test_gem_spec_fetcher.rb
+++ b/test/rubygems/test_gem_spec_fetcher.rb
@@ -169,6 +169,26 @@ class TestGemSpecFetcher < Gem::TestCase
     assert_equal "bad news from the internet (#{@gem_repo})", sfp.error.message
   end
 
+  def test_suggest_gems_from_name_latest
+    spec_fetcher do|fetcher|
+      fetcher.spec 'example', 1
+      fetcher.spec 'other-example', 1
+    end
+
+    suggestions = @sf.suggest_gems_from_name('examplw')
+    assert_equal ['example'], suggestions
+  end
+
+  def test_suggest_gems_from_name_prerelease
+    spec_fetcher do|fetcher|
+      fetcher.spec 'example', '1.a'
+      fetcher.spec 'other-example', 1
+    end
+
+    suggestions = @sf.suggest_gems_from_name('examplw')
+    assert_equal ['example'], suggestions
+  end
+
   def test_available_specs_latest
     spec_fetcher do |fetcher|
       fetcher.spec 'a', 1


### PR DESCRIPTION
# Description:
closes: #116
When no matches are found with latest specs, `suggest_gems_from_name` will retry with prerelease specs.
# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends
- [ ] [Squash commits](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html)

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

