### PR TITLE
Add a helpful suggestion when `gem install` fails due to required_rub…

### DIFF
--- a/lib/rubygems/exceptions.rb
+++ b/lib/rubygems/exceptions.rb
@@ -154,6 +154,12 @@ class Gem::ImpossibleDependenciesError < Gem::Exception
 end
 
 class Gem::InstallError < Gem::Exception; end
+class Gem::RuntimeRequirementNotMetError < Gem::InstallError
+  attr_accessor :suggestion
+  def message
+    [suggestion, super].compact.join("\n\t")
+  end
+end
 
 ##
 # Potentially raised when a specification is validated.

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -608,7 +608,8 @@ class Gem::Installer
   def ensure_required_ruby_version_met # :nodoc:
     if rrv = spec.required_ruby_version then
       unless rrv.satisfied_by? Gem.ruby_version then
-        raise Gem::InstallError, "#{spec.name} requires Ruby version #{rrv}."
+        raise Gem::RuntimeRequirementNotMetError,
+          "#{spec.name} requires Ruby version #{rrv}."
       end
     end
   end
@@ -616,7 +617,7 @@ class Gem::Installer
   def ensure_required_rubygems_version_met # :nodoc:
     if rrgv = spec.required_rubygems_version then
       unless rrgv.satisfied_by? Gem.rubygems_version then
-        raise Gem::InstallError,
+        raise Gem::RuntimeRequirementNotMetError,
           "#{spec.name} requires RubyGems version #{rrgv}. " +
           "Try 'gem update --system' to update RubyGems itself."
       end

--- a/lib/rubygems/request_set.rb
+++ b/lib/rubygems/request_set.rb
@@ -163,9 +163,26 @@ class Gem::RequestSet
         end
       end
 
-      spec = req.spec.install options do |installer|
-        yield req, installer if block_given?
-      end
+      spec =
+        begin
+          req.spec.install options do |installer|
+            yield req, installer if block_given?
+          end
+        rescue Gem::RuntimeRequirementNotMetError => e
+          recent_match = req.spec.set.find_all(req.request).sort_by(&:version).reverse_each.find do |s|
+            s = s.spec
+            s.required_ruby_version.satisfied_by?(Gem.ruby_version) && s.required_rubygems_version.satisfied_by?(Gem.rubygems_version)
+          end
+          if recent_match
+            suggestion = "The last version of #{req.request} to support your ruby & rubygems was #{recent_match.version}. Try installing it with `gem install #{recent_match.name} -v #{recent_match.version}`"
+            suggestion += " and then running the current command again" unless @always_install.any? { |spec| spec == req.spec.spec }
+          else
+            suggestion = "There are no versions of #{req.request} compatible with your ruby & rubygems"
+            suggestion += ". Maybe try installing an older version of the gem you're looking for?" unless @always_install.any? { |spec| spec == req.spec.spec }
+          end
+          e.suggestion = suggestion
+          raise
+        end
 
       requests << spec
     end

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1416,7 +1416,7 @@ gem 'other', version
   def test_pre_install_checks_ruby_version
     use_ui @ui do
       installer = Gem::Installer.at old_ruby_required
-      e = assert_raises Gem::InstallError do
+      e = assert_raises Gem::RuntimeRequirementNotMetError do
         installer.pre_install_checks
       end
       assert_equal 'old_ruby_required requires Ruby version = 1.4.6.',
@@ -1435,7 +1435,7 @@ gem 'other', version
 
     use_ui @ui do
       @installer = Gem::Installer.at gem
-      e = assert_raises Gem::InstallError do
+      e = assert_raises Gem::RuntimeRequirementNotMetError do
         @installer.pre_install_checks
       end
       assert_equal 'old_rubygems_required requires RubyGems version < 0. ' +


### PR DESCRIPTION
# Description:

This should help make it clearer what users (especially those not familiar with rubygems) can do to make installation succeed on an unsupported ruby/rubygems.

I can add tests if others think this feature is worthwhile.

Examples from 1.8.7:

```
ERROR:  Error installing cocoapods:
	There are no versions of cocoapods-core (= 1.0.1) compatible with your ruby & rubygems. Maybe try installing an older version of the gem you're looking for?
	cocoapods-core requires Ruby version >= 2.0.0.
```

```
ERROR:  Error installing cocoapods-downloader:
	The last version of cocoapods-downloader (>= 0) to support your ruby & rubygems was 0.7.2. Try installing it with `gem install cocoapods-downloader -v 0.7.2`
	cocoapods-downloader requires Ruby version >= 2.0.0.
```

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends
- [ ] [Squash commits](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html)

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

…y{gems,}_version