### PR TITLE
Load config in Gem.sources

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -971,7 +971,8 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   # default_sources if the sources list is empty.
 
   def self.sources
-    @sources ||= Gem::SourceList.from(default_sources)
+    source_list = configuration.sources || default_sources
+    @sources ||= Gem::SourceList.from(source_list)
   end
 
   ##

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -144,6 +144,10 @@ class Gem::ConfigFile
   attr_accessor :ssl_ca_cert
 
   ##
+  # sources to look for gems
+  attr_accessor :sources
+
+  ##
   # Path name of directory or file of openssl client certificate, used for remote https connection with client authentication
 
   attr_reader :ssl_client_cert
@@ -216,6 +220,7 @@ class Gem::ConfigFile
     @update_sources             = @hash[:update_sources]             if @hash.key? :update_sources
     @verbose                    = @hash[:verbose]                    if @hash.key? :verbose
     @disable_default_gem_server = @hash[:disable_default_gem_server] if @hash.key? :disable_default_gem_server
+    @sources                    = @hash[:sources]                    if @hash.key? :sources
 
     @ssl_verify_mode  = @hash[:ssl_verify_mode]  if @hash.key? :ssl_verify_mode
     @ssl_ca_cert      = @hash[:ssl_ca_cert]      if @hash.key? :ssl_ca_cert
@@ -224,7 +229,6 @@ class Gem::ConfigFile
     @api_keys         = nil
     @rubygems_api_key = nil
 
-    Gem.sources = @hash[:sources] if @hash.key? :sources
     handle_arguments arg_list
   end
 

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -990,6 +990,9 @@ class TestGem < Gem::TestCase
 
   def test_self_sources
     assert_equal %w[http://gems.example.com/], Gem.sources
+    Gem.sources = nil
+    Gem.configuration.sources = %w[http://test.example.com/]
+    assert_equal %w[http://test.example.com/], Gem.sources
   end
 
   def test_try_activate_returns_true_for_activated_specs

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -61,12 +61,11 @@ class TestGemConfigFile < Gem::TestCase
     end
 
     util_config_file
-
     assert_equal true, @cfg.backtrace
     assert_equal 10, @cfg.bulk_threshold
     assert_equal false, @cfg.verbose
     assert_equal false, @cfg.update_sources
-    assert_equal %w[http://more-gems.example.com], Gem.sources
+    assert_equal %w[http://more-gems.example.com], @cfg.sources
     assert_equal '--wrappers', @cfg[:install]
     assert_equal(['/usr/ruby/1.8/lib/ruby/gems/1.8', '/var/ruby/1.8/gem_home'],
                  @cfg.path)


### PR DESCRIPTION
# Description:
When calling `Gem.sources` load sources from configuration if present, else use default sources. 

closes https://github.com/rubygems/rubygems/issues/1613
# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends
- [ ] [Squash commits](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html)

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
