### PR TITLE
Add --host sample to help

### DIFF
--- a/lib/rubygems/commands/owner_command.rb
+++ b/lib/rubygems/commands/owner_command.rb
@@ -40,7 +40,9 @@ permission to.
       options[:remove] << value
     end
 
-    add_option '-h', '--host HOST', 'Use another gemcutter-compatible host' do |value, options|
+    add_option '-h', '--host HOST',
+               'Use another gemcutter-compatible host',
+               '  (e.g. https://rubygems.org)' do |value, options|
       options[:host] = value
     end
   end

--- a/lib/rubygems/commands/push_command.rb
+++ b/lib/rubygems/commands/push_command.rb
@@ -33,7 +33,8 @@ command.  For further discussion see the help for the yank command.
     add_key_option
 
     add_option('--host HOST',
-               'Push to another gemcutter-compatible host') do |value, options|
+               'Push to another gemcutter-compatible host',
+               '  (e.g. https://rubygems.org)') do |value, options|
       options[:host] = value
     end
 

--- a/lib/rubygems/commands/yank_command.rb
+++ b/lib/rubygems/commands/yank_command.rb
@@ -42,7 +42,8 @@ as the reason for the removal request.
     add_platform_option("remove")
 
     add_option('--host HOST',
-               'Yank from another gemcutter-compatible host') do |value, options|
+               'Yank from another gemcutter-compatible host',
+               '  (e.g. https://rubygems.org)') do |value, options|
       options[:host] = value
     end
 


### PR DESCRIPTION
# Description:

`push`, `yank` and `owner` subcommands have `--host` option. This needs URI scheme. For example, `--host rubygems.org` is not valid, `--host https://rubygems.org` is valid. So I added sample to help.

before:

        --host HOST                  Use another gemcutter-compatible host

after:

        --host HOST                  Use another gemcutter-compatible host
                                       (e.g. https://rubygems.org)

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests **(no need)**
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends
- [x] [Squash commits](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html)

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

