### PR TITLE
Update Contributing.rdoc with new label usage

### DIFF
--- a/CONTRIBUTING.rdoc
+++ b/CONTRIBUTING.rdoc
@@ -38,6 +38,18 @@ RubyGems uses labels to track all issues and pull requests. In order to provide
 guidance to the community this is documentation of how labels are used in the
 rubygems repository.
 
+=== Contribution
+
+These labels are made to guide contributors to issue/pull requests that they
+can help with. That are marked with <tt>contribution: *</tt>
+
+* *small* - The issue described here will take a small amount of work to resolve,
+  and is a good option for a new contributor
+* *unclaimed* - The issue has not been claimed for work, and is awaiting willing
+  volunteers!
+
+All the contribution labels are in the same light gray color.
+
 === Type
 
 Most Issues or pull requests will have a <tt>type: *</tt> label, which describes the
@@ -75,7 +87,6 @@ progression order from submitted to closed.
 * <b>working / ready</b> - An issue that is available for collaboration. This issue
   should have existing discussion on the problem, and a description of how to go
   about solving it.
-* *unclaimed* - An issue that needs someone to volunteer to work on it
 * <b>user feedback required</b> - The issue/pull request is blocked pending more
   feedback from an end user
 * <b>blocked / backlog</b> - the issue/pull request is currently unable to move forward
@@ -84,8 +95,6 @@ progression order from submitted to closed.
   be a while before something it is resolved.
 
 All the workflow <tt>status: *</tt> reason labels are the same light yellow color.
-Most of these labels represent a particular state in a linear progression,
-with the exception of <tt>satus: unclaimed</tt>.
 
 === Closed Reason
 

--- a/CONTRIBUTING.rdoc
+++ b/CONTRIBUTING.rdoc
@@ -124,9 +124,5 @@ issues have a blue <tt>category: *</tt> label.
 === Platforms
 
 If an issue or pull request pertains to only one platform, then it should have
-an appropriate purle <tt>platform: *</tt> label.
-
-* *windows*
-* *java*
-* *osx*
-* *linux*
+an appropriate purle <tt>platform: *</tt> label. Current platform labels:
+*windows*, *java*, *osx*, *linux*

--- a/CONTRIBUTING.rdoc
+++ b/CONTRIBUTING.rdoc
@@ -40,12 +40,12 @@ rubygems repository.
 
 === Type
 
-Most Issues or pull requests will have one of these labels, which describes the
+Most Issues or pull requests will have a `type: *` label, which describes the
 type of the issue or pull request.
 
 * <b>bug report</b> - An issue describing a bug in rubygems. This would be something
   that is broken, confusing, unexpected behavior etc.
-* <b>bugfix</b> - A pull request that fixes a bug report.
+* <b>bug fix</b> - A pull request that fixes a bug report.
 * <b>feature request</b> - An issue describing a request for a new feature or
   enhancement.
 * <b>feature implementation</b> - A pull request implementing a feature request.
@@ -56,15 +56,17 @@ type of the issue or pull request.
 * <b>major bump</b> - This issue or pull request requires a major version bump
 * <b>administrative</b> - This issue relates to adminstrative tasks that need to
   take place as it relates to rubygems
+* <b>documentation</b> - This issue relates to improving the documenation for
+  in this repo. Note that much of the rubygems documentation is here:
+  https://github.com/rubygems/guides
 
-Bug report and Bugfix have the same color. And feature implementation and
-feature request have the same color since they are related labels.
+All the `type: *` reason labels are the same light green color.
 
-=== Workflow
+=== Workflow / Status
 
-These are labels that indicate the state of an issue, where it is in the process
-from being submitted to being closed. These are listed in rough progression
-order from submitted to closed.
+The `status: *` labels that indicate the state of an issue, where it is in the
+process from being submitted to being closed. These are listed in rough 
+progression order from submitted to closed.
 
 * <b>triage</b> - This is an issue or pull request that needs to be properly
   labeled by by a maintainer.
@@ -84,10 +86,9 @@ order from submitted to closed.
   RubyGems or needs feedback from some specific individual or group, and it may
   be a while before something it is resolved.
 
-Feedback and blocked all have the same color since they are all waiting on
-someone in particular to do something.
+All the workflow `status: *` reason labels are the same light yellow color.
 
-=== Inactive Reason
+=== Closed Reason
 
 Reasons are why an issue / pull request was closed without being worked on or
 accepted. There should also be more detailed information in the comments.
@@ -100,8 +101,10 @@ accepted. There should also be more detailed information in the comments.
   is not accepted.
 * *deprecated* - An issue/pull request that no longer applies to the actively
   maintained codebase.
+* *discussion* - An issue/pull that is no longer about a concrete change, and
+  is instead being used for discussion.
 
-All the reason labels are the same maroon color.
+All the `closed: *` reason labels are the same maroon color.
 
 === Categories
 
@@ -116,7 +119,7 @@ request pertains too. Not all issues will have a category.
 * <b>documentation</b> - related to updating / fixing / clarifying documentation or
   guides
 
-All category labels are the same blue color.
+All `category - *` labels are the same blue color.
 
 === Platforms
 
@@ -128,4 +131,4 @@ an appropriate platform tag.
 * *osx*
 * *linux*
 
-All platform tags are the same purple color.
+All `platform: *` tags are the same purple color.

--- a/CONTRIBUTING.rdoc
+++ b/CONTRIBUTING.rdoc
@@ -43,20 +43,20 @@ rubygems repository.
 Most Issues or pull requests will have a `type: *` label, which describes the
 type of the issue or pull request.
 
-* <b>bug report</b> - An issue describing a bug in rubygems. This would be something
+* *bug report* - An issue describing a bug in rubygems. This would be something
   that is broken, confusing, unexpected behavior etc.
-* <b>bug fix</b> - A pull request that fixes a bug report.
-* <b>feature request</b> - An issue describing a request for a new feature or
+* *bug fix* - A pull request that fixes a bug report.
+* *feature request* - An issue describing a request for a new feature or
   enhancement.
-* <b>feature implementation</b> - A pull request implementing a feature request.
-* <b>question</b> - An issue that is a more of a question than a call for specific
+* *feature implementation* - A pull request implementing a feature request.
+* *question* - An issue that is a more of a question than a call for specific
   changes in the codebase.
-* <b>cleanup</b> - Generally for a pull request that improves the code base without
+* *cleanup* - Generally for a pull request that improves the code base without
   fixing a bug or implementing a feature.
-* <b>major bump</b> - This issue or pull request requires a major version bump
-* <b>administrative</b> - This issue relates to adminstrative tasks that need to
+* *major bump* - This issue or pull request requires a major version bump
+* *administrative* - This issue relates to adminstrative tasks that need to
   take place as it relates to rubygems
-* <b>documentation</b> - This issue relates to improving the documenation for
+* *documentation* - This issue relates to improving the documenation for
   in this repo. Note that much of the rubygems documentation is here:
   https://github.com/rubygems/guides
 
@@ -68,25 +68,24 @@ The `status: *` labels that indicate the state of an issue, where it is in the
 process from being submitted to being closed. These are listed in rough 
 progression order from submitted to closed.
 
-* <b>triage</b> - This is an issue or pull request that needs to be properly
+* *triage* - This is an issue or pull request that needs to be properly
   labeled by by a maintainer.
-* <b>accepted</b> - This issue / pull request has been accepted as valid and
-  will be worked on by someone.
-* <b>ready for work</b> - An issue that is available for collaboration. This issue
+* *confirmed* - This issue/pull request has been accepted as valid, but
+  is not yet immediately ready for work.
+* *working / ready* - An issue that is available for collaboration. This issue
   should have existing discussion on the problem, and a description of how to go
-  about solving it. This label should be removed once someone has said they are
-  going to work on it.
-* <b>claimed</b> - An issue that is claimed by a member of the community and is
-  working on it. If the member can be assigned to the issue, they should be.
-* <b>feedback</b>- This issue/pull request is waiting on feedback from
-  one ore more of the folks involved in the issue. Generally their should be an
-  <tt>@username/team</tt> in the issue indicating who should respond.
-* <b>blocked</b> - the issue/pull request is currently unable to move forward because
-  of some specific reason, generally this will be a reason that is outside
+  about solving it.
+* *unclaimed* - An issue that needs someone to volunteer to work on it
+* *user feedback required* - The issue/pull request is blocked pending more
+  feedback from an end user
+* *blocked / backlog* - the issue/pull request is currently unable to move forward
+  because of some specific reason, generally this will be a reason that is outside
   RubyGems or needs feedback from some specific individual or group, and it may
   be a while before something it is resolved.
 
 All the workflow `status: *` reason labels are the same light yellow color.
+Most of these labels represent a particular state in a linear progression,
+with the exception of `satus: unclaimed`.
 
 === Closed Reason
 
@@ -111,15 +110,15 @@ All the `closed: *` reason labels are the same maroon color.
 These are aspects of the codebase, or what general area the issue or pull
 request pertains too. Not all issues will have a category.
 
-* <b>gemspec</b> - related to the gem specification itself
-* <b>API</b> - related to the public supported rubygems API. This is the code api,
+* *gemspec* - related to the gem specification itself
+* *API* - related to the public supported rubygems API. This is the code api,
   not a network related API.
-* <b>command</b> - related to something in <tt>Gem::Commands</tt>
-* <b>install</b> - related to gem installations
-* <b>documentation</b> - related to updating / fixing / clarifying documentation or
+* *command* - related to something in <tt>Gem::Commands</tt>
+* *install* - related to gem installations
+* *documentation* - related to updating / fixing / clarifying documentation or
   guides
 
-All `category - *` labels are the same blue color.
+All `category: *` labels are the same blue color.
 
 === Platforms
 

--- a/CONTRIBUTING.rdoc
+++ b/CONTRIBUTING.rdoc
@@ -11,9 +11,9 @@ contributors to follow to reduce the time it takes to get changes merged in.
 2. Ensure that your code blends well with ours:
    * No trailing whitespace
    * Match indentation (two spaces)
-   * Match coding style (`if`, `elsif`, `when` need trailing `then`)
+   * Match coding style (+if+, +elsif+, +when+ need trailing +then+)
 
-3. If any new files are added or existing files removed in a commit or PR, please update the `Manifest.txt` accordingly.
+3. If any new files are added or existing files removed in a commit or PR, please update the +Manifest.txt+ accordingly.
 
 4. Don't modify the history file or version number.
 
@@ -28,7 +28,7 @@ here: http://guides.rubygems.org/contributing/
     $ gem install hoe
     $ rake newb
 
-To run commands like `gem install` from the repo:
+To run commands like +gem install+ from the repo:
 
     $ ruby -Ilib bin/gem install
 
@@ -40,31 +40,31 @@ rubygems repository.
 
 === Type
 
-Most Issues or pull requests will have a `type: *` label, which describes the
+Most Issues or pull requests will have a +type: *+ label, which describes the
 type of the issue or pull request.
 
-* *bug report* - An issue describing a bug in rubygems. This would be something
+* <b>bug report</b> - An issue describing a bug in rubygems. This would be something
   that is broken, confusing, unexpected behavior etc.
-* *bug fix* - A pull request that fixes a bug report.
-* *feature request* - An issue describing a request for a new feature or
+* <b>bug fix</b> - A pull request that fixes a bug report.
+* <b>feature request</b> - An issue describing a request for a new feature or
   enhancement.
-* *feature implementation* - A pull request implementing a feature request.
+* <b>feature implementation</b> - A pull request implementing a feature request.
 * *question* - An issue that is a more of a question than a call for specific
   changes in the codebase.
 * *cleanup* - Generally for a pull request that improves the code base without
   fixing a bug or implementing a feature.
-* *major bump* - This issue or pull request requires a major version bump
+* <b>major bump</b> - This issue or pull request requires a major version bump
 * *administrative* - This issue relates to adminstrative tasks that need to
   take place as it relates to rubygems
 * *documentation* - This issue relates to improving the documenation for
   in this repo. Note that much of the rubygems documentation is here:
   https://github.com/rubygems/guides
 
-All the `type: *` reason labels are the same light green color.
+All the +type: *+ reason labels are the same light green color.
 
 === Workflow / Status
 
-The `status: *` labels that indicate the state of an issue, where it is in the
+The +status: *+ labels that indicate the state of an issue, where it is in the
 process from being submitted to being closed. These are listed in rough 
 progression order from submitted to closed.
 
@@ -72,20 +72,20 @@ progression order from submitted to closed.
   labeled by by a maintainer.
 * *confirmed* - This issue/pull request has been accepted as valid, but
   is not yet immediately ready for work.
-* *working / ready* - An issue that is available for collaboration. This issue
+* <b>working / ready</b> - An issue that is available for collaboration. This issue
   should have existing discussion on the problem, and a description of how to go
   about solving it.
 * *unclaimed* - An issue that needs someone to volunteer to work on it
-* *user feedback required* - The issue/pull request is blocked pending more
+* <b>user feedback required</b> - The issue/pull request is blocked pending more
   feedback from an end user
-* *blocked / backlog* - the issue/pull request is currently unable to move forward
+* <b>blocked / backlog</b> - the issue/pull request is currently unable to move forward
   because of some specific reason, generally this will be a reason that is outside
   RubyGems or needs feedback from some specific individual or group, and it may
   be a while before something it is resolved.
 
-All the workflow `status: *` reason labels are the same light yellow color.
+All the workflow +status: *+ reason labels are the same light yellow color.
 Most of these labels represent a particular state in a linear progression,
-with the exception of `satus: unclaimed`.
+with the exception of +satus: unclaimed+.
 
 === Closed Reason
 
@@ -103,7 +103,7 @@ accepted. There should also be more detailed information in the comments.
 * *discussion* - An issue/pull that is no longer about a concrete change, and
   is instead being used for discussion.
 
-All the `closed: *` reason labels are the same maroon color.
+All the +closed: *+ reason labels are the same maroon color.
 
 === Categories
 
@@ -118,7 +118,7 @@ request pertains too. Not all issues will have a category.
 * *documentation* - related to updating / fixing / clarifying documentation or
   guides
 
-All `category: *` labels are the same blue color.
+All +category: *+ labels are the same blue color.
 
 === Platforms
 
@@ -130,4 +130,4 @@ an appropriate platform tag.
 * *osx*
 * *linux*
 
-All `platform: *` tags are the same purple color.
+All +platform: *+ tags are the same purple color.

--- a/CONTRIBUTING.rdoc
+++ b/CONTRIBUTING.rdoc
@@ -28,7 +28,7 @@ here: http://guides.rubygems.org/contributing/
     $ gem install hoe
     $ rake newb
 
-To run commands like +gem install+ from the repo:
+To run commands like <tt>gem install</tt> from the repo:
 
     $ ruby -Ilib bin/gem install
 
@@ -40,7 +40,7 @@ rubygems repository.
 
 === Type
 
-Most Issues or pull requests will have a +type: *+ label, which describes the
+Most Issues or pull requests will have a <tt>type: *</tt> label, which describes the
 type of the issue or pull request.
 
 * <b>bug report</b> - An issue describing a bug in rubygems. This would be something
@@ -60,11 +60,11 @@ type of the issue or pull request.
   in this repo. Note that much of the rubygems documentation is here:
   https://github.com/rubygems/guides
 
-All the +type: *+ reason labels are the same light green color.
+All the <tt>type: *</tt> reason labels are the same light green color.
 
 === Workflow / Status
 
-The +status: *+ labels that indicate the state of an issue, where it is in the
+The <tt>status: *</tt> labels that indicate the state of an issue, where it is in the
 process from being submitted to being closed. These are listed in rough 
 progression order from submitted to closed.
 
@@ -83,9 +83,9 @@ progression order from submitted to closed.
   RubyGems or needs feedback from some specific individual or group, and it may
   be a while before something it is resolved.
 
-All the workflow +status: *+ reason labels are the same light yellow color.
+All the workflow <tt>status: *</tt> reason labels are the same light yellow color.
 Most of these labels represent a particular state in a linear progression,
-with the exception of +satus: unclaimed+.
+with the exception of <tt>satus: unclaimed</tt>.
 
 === Closed Reason
 
@@ -103,7 +103,7 @@ accepted. There should also be more detailed information in the comments.
 * *discussion* - An issue/pull that is no longer about a concrete change, and
   is instead being used for discussion.
 
-All the +closed: *+ reason labels are the same maroon color.
+All the <tt>closed: *</tt> reason labels are the same maroon color.
 
 === Categories
 
@@ -118,7 +118,7 @@ request pertains too. Not all issues will have a category.
 * *documentation* - related to updating / fixing / clarifying documentation or
   guides
 
-All +category: *+ labels are the same blue color.
+All <tt>category: *</tt> labels are the same blue color.
 
 === Platforms
 
@@ -130,4 +130,4 @@ an appropriate platform tag.
 * *osx*
 * *linux*
 
-All +platform: *+ tags are the same purple color.
+All <tt>platform: *</tt> tags are the same purple color.

--- a/CONTRIBUTING.rdoc
+++ b/CONTRIBUTING.rdoc
@@ -41,19 +41,17 @@ rubygems repository.
 === Contribution
 
 These labels are made to guide contributors to issue/pull requests that they
-can help with. That are marked with <tt>contribution: *</tt>
+can help with. That are marked with a light gray <tt>contribution: *</tt>
 
 * *small* - The issue described here will take a small amount of work to resolve,
   and is a good option for a new contributor
 * *unclaimed* - The issue has not been claimed for work, and is awaiting willing
   volunteers!
 
-All the contribution labels are in the same light gray color.
-
 === Type
 
-Most Issues or pull requests will have a <tt>type: *</tt> label, which describes the
-type of the issue or pull request.
+Most Issues or pull requests will have a light green <tt>type: *</tt> label, 
+which describes the type of the issue or pull request.
 
 * <b>bug report</b> - An issue describing a bug in rubygems. This would be something
   that is broken, confusing, unexpected behavior etc.
@@ -72,13 +70,11 @@ type of the issue or pull request.
   in this repo. Note that much of the rubygems documentation is here:
   https://github.com/rubygems/guides
 
-All the <tt>type: *</tt> reason labels are the same light green color.
-
 === Workflow / Status
 
-The <tt>status: *</tt> labels that indicate the state of an issue, where it is in the
-process from being submitted to being closed. These are listed in rough 
-progression order from submitted to closed.
+The light yellow <tt>status: *</tt> labels that indicate the state of an 
+issue, where it is in the process from being submitted to being closed. 
+These are listed in rough  progression order from submitted to closed.
 
 * *triage* - This is an issue or pull request that needs to be properly
   labeled by by a maintainer.
@@ -94,12 +90,11 @@ progression order from submitted to closed.
   RubyGems or needs feedback from some specific individual or group, and it may
   be a while before something it is resolved.
 
-All the workflow <tt>status: *</tt> reason labels are the same light yellow color.
-
 === Closed Reason
 
 Reasons are why an issue / pull request was closed without being worked on or
-accepted. There should also be more detailed information in the comments.
+accepted. There should also be more detailed information in the comments. The
+closed reason labels are maroon <tt>closed: *</tt>.
 
 * *duplicate* - This is a duplicate of an existing bug. The comments must
   reference the existing issue.
@@ -112,12 +107,11 @@ accepted. There should also be more detailed information in the comments.
 * *discussion* - An issue/pull that is no longer about a concrete change, and
   is instead being used for discussion.
 
-All the <tt>closed: *</tt> reason labels are the same maroon color.
-
 === Categories
 
 These are aspects of the codebase, or what general area the issue or pull
-request pertains too. Not all issues will have a category.
+request pertains too. Not all issues will have a category. All categorized
+issues have a blue <tt>category: *</tt> label.
 
 * *gemspec* - related to the gem specification itself
 * *API* - related to the public supported rubygems API. This is the code api,
@@ -127,16 +121,12 @@ request pertains too. Not all issues will have a category.
 * *documentation* - related to updating / fixing / clarifying documentation or
   guides
 
-All <tt>category: *</tt> labels are the same blue color.
-
 === Platforms
 
 If an issue or pull request pertains to only one platform, then it should have
-an appropriate platform tag.
+an appropriate purle <tt>platform: *</tt> label.
 
 * *windows*
 * *java*
 * *osx*
 * *linux*
-
-All <tt>platform: *</tt> tags are the same purple color.

--- a/CONTRIBUTING.rdoc
+++ b/CONTRIBUTING.rdoc
@@ -80,9 +80,11 @@ These are listed in rough  progression order from submitted to closed.
   labeled by by a maintainer.
 * *confirmed* - This issue/pull request has been accepted as valid, but
   is not yet immediately ready for work.
-* <b>working / ready</b> - An issue that is available for collaboration. This issue
+* <b>ready</b> - An issue that is available for collaboration. This issue
   should have existing discussion on the problem, and a description of how to go
   about solving it.
+* <b>working</b> - An issue that has a specific invidual assigned to and planning
+  to do work on it.
 * <b>user feedback required</b> - The issue/pull request is blocked pending more
   feedback from an end user
 * <b>blocked / backlog</b> - the issue/pull request is currently unable to move forward


### PR DESCRIPTION
---

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

---

reference issue: #1715

Some labels were changed in https://github.com/rubygems/rubygems/labels to match this document

- Add the `closed: discussion` label
- Workflow labels are denoted by `status: *`
- All labels in the same broad category now share a color
- Adding a space to "bug fix" allows it to be sorted next to "bug report"
- Add type: documentation
- Minor syntax and wording changes
- A list of other changes are mentioned in the commit descriptions