### PR TITLE
Add --trust-policy option to unpack command

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -389,6 +389,7 @@ lib/rubygems/security/policies.rb
 lib/rubygems/security/policy.rb
 lib/rubygems/security/signer.rb
 lib/rubygems/security/trust_dir.rb
+lib/rubygems/security_option.rb
 lib/rubygems/server.rb
 lib/rubygems/source.rb
 lib/rubygems/source/git.rb

--- a/lib/rubygems/install_update_options.rb
+++ b/lib/rubygems/install_update_options.rb
@@ -6,38 +6,18 @@
 #++
 
 require 'rubygems'
-
-# forward-declare
-
-module Gem::Security # :nodoc:
-  class Policy # :nodoc:
-  end
-end
+require 'rubygems/security_option'
 
 ##
 # Mixin methods for install and update options for Gem::Commands
 
 module Gem::InstallUpdateOptions
+  include Gem::SecurityOption
 
   ##
   # Add the install/update options to the option parser.
 
   def add_install_update_options
-    # TODO: use @parser.accept
-    OptionParser.accept Gem::Security::Policy do |value|
-      require 'rubygems/security'
-
-      raise OptionParser::InvalidArgument, 'OpenSSL not installed' unless
-        defined?(Gem::Security::HighSecurity)
-
-      policy = Gem::Security::Policies[value]
-      unless policy
-        valid = Gem::Security::Policies.keys.sort
-        raise OptionParser::InvalidArgument, "#{value} (#{valid.join ', '} are valid)"
-      end
-      policy
-    end
-
     add_option(:"Install/Update", '-i', '--install-dir DIR',
                'Gem repository directory to get installed',
                'gems') do |value, options|
@@ -125,11 +105,7 @@ module Gem::InstallUpdateOptions
       options[:wrappers] = value
     end
 
-    add_option(:"Install/Update", '-P', '--trust-policy POLICY',
-               Gem::Security::Policy,
-               'Specify gem trust policy') do |value, options|
-      options[:security_policy] = value
-    end
+    add_security_option
 
     add_option(:"Install/Update", '--ignore-dependencies',
                'Do not install any required dependent gems') do |value, options|

--- a/lib/rubygems/security_option.rb
+++ b/lib/rubygems/security_option.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+#--
+# Copyright 2006 by Chad Fowler, Rich Kilmer, Jim Weirich and others.
+# All rights reserved.
+# See LICENSE.txt for permissions.
+#++
+
+require 'rubygems'
+
+# forward-declare
+
+module Gem::Security # :nodoc:
+  class Policy # :nodoc:
+  end
+end
+
+##
+# Mixin methods for security option for Gem::Commands
+
+module Gem::SecurityOption
+  def add_security_option
+    # TODO: use @parser.accept
+    OptionParser.accept Gem::Security::Policy do |value|
+      require 'rubygems/security'
+
+      raise OptionParser::InvalidArgument, 'OpenSSL not installed' unless
+        defined?(Gem::Security::HighSecurity)
+
+      policy = Gem::Security::Policies[value]
+      unless policy
+        valid = Gem::Security::Policies.keys.sort
+        raise OptionParser::InvalidArgument, "#{value} (#{valid.join ', '} are valid)"
+      end
+      policy
+    end
+
+    add_option(:"Install/Update", '-P', '--trust-policy POLICY',
+               Gem::Security::Policy,
+               'Specify gem trust policy') do |value, options|
+      options[:security_policy] = value
+    end
+  end
+end


### PR DESCRIPTION
# Description:

Add `--trust-policy` option to verify gem files to `unpack` command as well as `install` and `update` commands.

The latter commands do not have tests for this option too.
---
# Tasks:
- [x] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends
- [ ] [Squash commits](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html)

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
