### PR TITLE
Do not squash commits

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,5 @@ ______________
 - [ ] Write tests
 - [ ] Write code to solve the problem
 - [ ] Get code review from coworkers / friends
-- [ ] [Squash commits](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html)
 
 I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
# Description:

Squashing commits may be helpful for small pull requests where the total
change is around 10—20 lines or two or three hunks.  With such a small
patch it's easy to infer intent in the future.

For larger patches it becomes increasingly difficult to determine why
the change was made when a single commit contains dozens of hunks where
none of them are related.

This is especially important after either:
* Enough time has passed that you don't remember why you made the patch
* The patch was made by a maintainer that is no longer active
* The patch was made by a contributor that is no longer interested

In these situations, when an issue is found related to the patch the
person working in the area has to infer the purpose of the patch from
the context they have.  The new work won't necessarily be a bug in the
original patch.  It may add functionality that incidentally became an
important feature for some of our users, and the new work wishes to
change something related to that change.

The new work may be a bug fix that has a subtle interaction, so
determining if the first patch was a buggy (even if unintentionally so)
change, or more importantly how the change is buggy, will be difficult
to determine the less context we have.

By aggressively squashing commits we remove the commit messages that
contain that very important context.  I see no reason to forbid
squashing commits in a way that makes the intent of the patch more
clear.  On the other hand, encouraging it via a check-box on our PR form
may cause the loss of this important context when we need it.

______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
