### PR TITLE
Fix error message Gem::Security::Policy

### DIFF
--- a/lib/rubygems/install_update_options.rb
+++ b/lib/rubygems/install_update_options.rb
@@ -30,11 +30,12 @@ module Gem::InstallUpdateOptions
       raise OptionParser::InvalidArgument, 'OpenSSL not installed' unless
         defined?(Gem::Security::HighSecurity)
 
-      value = Gem::Security::Policies[value]
-      valid = Gem::Security::Policies.keys.sort
-      message = "#{value} (#{valid.join ', '} are valid)"
-      raise OptionParser::InvalidArgument, message if value.nil?
-      value
+      policy = Gem::Security::Policies[value]
+      unless policy
+        valid = Gem::Security::Policies.keys.sort
+        raise OptionParser::InvalidArgument, "#{value} (#{valid.join ', '} are valid)"
+      end
+      policy
     end
 
     add_option(:"Install/Update", '-i', '--install-dir DIR',

--- a/test/rubygems/test_gem_install_update_options.rb
+++ b/test/rubygems/test_gem_install_update_options.rb
@@ -121,9 +121,10 @@ class TestGemInstallUpdateOptions < Gem::InstallerTestCase
   def test_security_policy_unknown
     @cmd.add_install_update_options
 
-    assert_raises OptionParser::InvalidArgument do
+    e = assert_raises OptionParser::InvalidArgument do
       @cmd.handle_options %w[-P UnknownSecurity]
     end
+    assert_includes e.message, "UnknownSecurity"
   end
 
   def test_user_install_enabled


### PR DESCRIPTION
# Description:

With invalid security policy, an error raises but the message does not show that policy name:

```
$ gem install --trust-policy Unknown foo
ERROR:  While executing gem ... (OptionParser::InvalidArgument)
    invalid argument: --trust-policy  (AlmostNoSecurity, HighSecurity, LowSecurity, MediumSecurity, NoSecurity are valid)
```

This is because `value` is clobbered before building the error message and always `nil` at that time.