### PR TITLE
Add cert expiration length flag

### DIFF
--- a/lib/rubygems/commands/cert_command.rb
+++ b/lib/rubygems/commands/cert_command.rb
@@ -84,6 +84,11 @@ class Gem::Commands::CertCommand < Gem::Command
 
       options[:sign] << cert_file
     end
+
+    add_option('-d', '--days NUMBER_OF_DAYS',
+               'Days for the certificate to expire') do |days, options|
+                options[:expiration_length_days] = days.to_i
+    end
   end
 
   def add_certificate certificate # :nodoc:
@@ -125,7 +130,15 @@ class Gem::Commands::CertCommand < Gem::Command
   end
 
   def build_cert name, key # :nodoc:
-    cert = Gem::Security.create_cert_email name, key
+    expiration_length_days = options[:expiration_length_days]
+    age =
+      if expiration_length_days.nil? || expiration_length_days == 0
+        Gem::Security::ONE_YEAR
+      else
+        Gem::Security::ONE_DAY * expiration_length_days
+      end
+
+    cert = Gem::Security.create_cert_email name, key, age
     Gem::Security.write cert, "gem-public_cert.pem"
   end
 

--- a/lib/rubygems/commands/cert_command.rb
+++ b/lib/rubygems/commands/cert_command.rb
@@ -86,7 +86,7 @@ class Gem::Commands::CertCommand < Gem::Command
     end
 
     add_option('-d', '--days NUMBER_OF_DAYS',
-               'Days for the certificate to expire') do |days, options|
+               'Days before the certificate expires') do |days, options|
                 options[:expiration_length_days] = days.to_i
     end
   end

--- a/lib/rubygems/security.rb
+++ b/lib/rubygems/security.rb
@@ -377,6 +377,11 @@ module Gem::Security
   ONE_YEAR = 86400 * 365
 
   ##
+  # One day in seconds
+
+  ONE_DAY = 86400
+
+  ##
   # The default set of extensions are:
   #
   # * The certificate is not a certificate authority

--- a/lib/rubygems/security.rb
+++ b/lib/rubygems/security.rb
@@ -372,14 +372,14 @@ module Gem::Security
   KEY_CIPHER = OpenSSL::Cipher.new('AES-256-CBC') if defined?(OpenSSL::Cipher)
 
   ##
-  # One year in seconds
-
-  ONE_YEAR = 86400 * 365
-
-  ##
   # One day in seconds
 
   ONE_DAY = 86400
+
+  ##
+  # One year in seconds
+
+  ONE_YEAR = ONE_DAY * 365
 
   ##
   # The default set of extensions are:

--- a/test/rubygems/test_gem_commands_cert_command.rb
+++ b/test/rubygems/test_gem_commands_cert_command.rb
@@ -130,6 +130,48 @@ Added '/CN=alternate/DC=example'
     assert_path_exists File.join(@tempdir, 'gem-public_cert.pem')
   end
 
+  def test_execute_build_expiration_days
+    passphrase = 'Foo bar'
+
+    @cmd.handle_options %W[
+      --build nobody@example.com
+      --days 26
+      ]
+
+    @build_ui = Gem::MockGemUi.new "#{passphrase}\n#{passphrase}"
+
+    use_ui @build_ui do
+      @cmd.execute
+    end
+
+    output = @build_ui.output.squeeze("\n").split "\n"
+
+    assert_equal "Passphrase for your Private Key:  ",
+                 output.shift
+    assert_equal "Please repeat the passphrase for your Private Key:  ",
+                 output.shift
+    assert_equal "Certificate: #{File.join @tempdir, 'gem-public_cert.pem'}",
+                 output.shift
+    assert_equal "Private Key: #{File.join @tempdir, 'gem-private_key.pem'}",
+                 output.shift
+
+    assert_equal "Don't forget to move the key file to somewhere private!",
+                 output.shift
+
+    assert_empty output
+    assert_empty @build_ui.error
+
+    assert_path_exists File.join(@tempdir, 'gem-private_key.pem')
+    assert_path_exists File.join(@tempdir, 'gem-public_cert.pem')
+
+    pem = File.read("#{@tempdir}/gem-public_cert.pem")
+    cert = OpenSSL::X509::Certificate.new(pem)
+
+    test = (cert.not_after - cert.not_before).to_i / (24 * 60 * 60)
+    assert_equal(test, 26)
+
+  end
+
   def test_execute_build_bad_passphrase_confirmation
     passphrase = 'Foo bar'
     passphrase_confirmation = 'Fu bar'


### PR DESCRIPTION
# Description:
This PR adds the ability to specify an expiration length with the gem cert command using the `-d/--days` flag

closes https://github.com/rubygems/rubygems/issues/1719

cc @djberg96 
______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
