### PR TITLE
Add submodule instructions to manual install

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -27,7 +27,7 @@ See UPGRADING.rdoc for more details and alternative instructions.
 If you don't have RubyGems installed, you can still do it manually:
 
 * Download from: https://rubygems.org/pages/download, unpack, and cd there
-* OR clone this repository and cd there
+* OR clone this repository and cd there (make sure to run `git submodule update -\-init`)
 * Install with: ruby setup.rb  # you may need admin/root privilege
 
 For more details and other options, see:


### PR DESCRIPTION
# Description:

After cloning this repo, the bundler submodule must be initialized/updated before `ruby setup.rb` will work. Otherwise, the following error is shown:

```shell
ERROR:  While executing gem ... (Errno::ENOENT)
    No such file or directory @ dir_chdir - bundler/lib
```

# Tasks:

- [x] Describe the problem / feature
- [x] ~~Write tests~~
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).