### PR TITLE
Deprecate Gem::InstallerTestCase#util_gem_bindir and Gem::InstallerTestCase#util_gem_dir

### DIFF
--- a/lib/rubygems/installer_test_case.rb
+++ b/lib/rubygems/installer_test_case.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
 require 'rubygems/installer'
+require 'rubygems/deprecate'
 
 class Gem::Installer
 
@@ -107,14 +108,16 @@ class Gem::InstallerTestCase < Gem::TestCase
   end
 
   def util_gem_bindir spec = @spec # :nodoc:
-    # TODO: deprecate
     spec.bin_dir
   end
 
   def util_gem_dir spec = @spec # :nodoc:
-    # TODO: deprecate
     spec.gem_dir
   end
+
+  extend Gem::Deprecate
+  deprecate :util_gem_bindir, "@spec.bin_dir", 2016, 10
+  deprecate :util_gem_dir, "@spec.gem_dir", 2016, 10
 
   ##
   # The path where installed executables live

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -82,7 +82,7 @@ load Gem.activate_bin_path('a', 'executable', version)
     end
 
     util_make_exec
-    @installer.gem_dir = util_gem_dir @spec
+    @installer.gem_dir = @spec.gem_dir
     @installer.wrappers = true
     @installer.generate_bin
 
@@ -299,7 +299,7 @@ gem 'other', version
   def test_extract_files
     @installer.extract_files
 
-    assert_path_exists File.join util_gem_dir, 'bin/executable'
+    assert_path_exists File.join @spec.gem_dir, 'bin/executable'
   end
 
   def test_generate_bin_bindir
@@ -309,12 +309,12 @@ gem 'other', version
     @spec.bindir = '.'
 
     exec_file = @installer.formatted_program_filename 'executable'
-    exec_path = File.join util_gem_dir(@spec), exec_file
+    exec_path = File.join @spec.gem_dir, exec_file
     File.open exec_path, 'w' do |f|
       f.puts '#!/usr/bin/ruby'
     end
 
-    @installer.gem_dir = util_gem_dir
+    @installer.gem_dir = @spec.gem_dir
 
     @installer.generate_bin
 
@@ -350,7 +350,7 @@ gem 'other', version
   def test_generate_bin_script
     @installer.wrappers = true
     util_make_exec
-    @installer.gem_dir = util_gem_dir
+    @installer.gem_dir = @spec.gem_dir
 
     @installer.generate_bin
     assert File.directory? util_inst_bindir
@@ -366,7 +366,7 @@ gem 'other', version
     @installer.format_executable = true
     @installer.wrappers = true
     util_make_exec
-    @installer.gem_dir = util_gem_dir
+    @installer.gem_dir = @spec.gem_dir
 
     Gem::Installer.exec_format = 'foo-%s-bar'
     @installer.generate_bin
@@ -380,7 +380,7 @@ gem 'other', version
   def test_generate_bin_script_format_disabled
     @installer.wrappers = true
     util_make_exec
-    @installer.gem_dir = util_gem_dir
+    @installer.gem_dir = @spec.gem_dir
 
     Gem::Installer.exec_format = 'foo-%s-bar'
     @installer.generate_bin
@@ -469,10 +469,10 @@ gem 'other', version
   def test_generate_bin_script_wrappers
     @installer.wrappers = true
     util_make_exec
-    @installer.gem_dir = util_gem_dir
+    @installer.gem_dir = @spec.gem_dir
     installed_exec = File.join(util_inst_bindir, 'executable')
 
-    real_exec = File.join util_gem_dir, 'bin', 'executable'
+    real_exec = File.join @spec.gem_dir, 'bin', 'executable'
 
     # fake --no-wrappers for previous install
     unless Gem.win_platform? then
@@ -496,13 +496,13 @@ gem 'other', version
 
     @installer.wrappers = false
     util_make_exec
-    @installer.gem_dir = util_gem_dir
+    @installer.gem_dir = @spec.gem_dir
 
     @installer.generate_bin
     assert_equal true, File.directory?(util_inst_bindir)
     installed_exec = File.join util_inst_bindir, 'executable'
     assert_equal true, File.symlink?(installed_exec)
-    assert_equal(File.join(util_gem_dir, 'bin', 'executable'),
+    assert_equal(File.join(@spec.gem_dir, 'bin', 'executable'),
                  File.readlink(installed_exec))
   end
 
@@ -518,7 +518,7 @@ gem 'other', version
   def test_generate_bin_symlink_no_perms
     @installer.wrappers = false
     util_make_exec
-    @installer.gem_dir = util_gem_dir
+    @installer.gem_dir = @spec.gem_dir
 
     Dir.mkdir util_inst_bindir
 
@@ -540,11 +540,11 @@ gem 'other', version
 
     @installer.wrappers = false
     util_make_exec
-    @installer.gem_dir = util_gem_dir
+    @installer.gem_dir = @spec.gem_dir
 
     @installer.generate_bin
     installed_exec = File.join(util_inst_bindir, 'executable')
-    assert_equal(File.join(util_gem_dir, 'bin', 'executable'),
+    assert_equal(File.join(@spec.gem_dir, 'bin', 'executable'),
                  File.readlink(installed_exec))
 
     @spec = Gem::Specification.new do |s|
@@ -557,7 +557,7 @@ gem 'other', version
     end
 
     util_make_exec
-    @installer.gem_dir = util_gem_dir @spec
+    @installer.gem_dir = @spec.gem_dir
     @installer.generate_bin
     installed_exec = File.join(util_inst_bindir, 'executable')
     assert_equal(@spec.bin_file('executable'),
@@ -570,11 +570,11 @@ gem 'other', version
 
     @installer.wrappers = false
     util_make_exec
-    @installer.gem_dir = util_gem_dir
+    @installer.gem_dir = @spec.gem_dir
 
     @installer.generate_bin
     installed_exec = File.join(util_inst_bindir, 'executable')
-    assert_equal(File.join(util_gem_dir, 'bin', 'executable'),
+    assert_equal(File.join(@spec.gem_dir, 'bin', 'executable'),
                  File.readlink(installed_exec))
 
     spec = Gem::Specification.new do |s|
@@ -590,12 +590,12 @@ gem 'other', version
     one = @spec.dup
     one.version = 1
     @installer = Gem::Installer.for_spec spec
-    @installer.gem_dir = util_gem_dir one
+    @installer.gem_dir = one.gem_dir
 
     @installer.generate_bin
 
     installed_exec = File.join util_inst_bindir, 'executable'
-    expected = File.join util_gem_dir, 'bin', 'executable'
+    expected = File.join @spec.gem_dir, 'bin', 'executable'
     assert_equal(expected,
                  File.readlink(installed_exec),
                  "Ensure symlink not moved")
@@ -606,7 +606,7 @@ gem 'other', version
 
     @installer.wrappers = true
     util_make_exec
-    @installer.gem_dir = util_gem_dir
+    @installer.gem_dir = @spec.gem_dir
 
     @installer.generate_bin
 
@@ -625,7 +625,7 @@ gem 'other', version
 
     util_installer @spec, @gemhome
     @installer.wrappers = false
-    @installer.gem_dir = util_gem_dir
+    @installer.gem_dir = @spec.gem_dir
 
     @installer.generate_bin
 
@@ -643,7 +643,7 @@ gem 'other', version
     File.const_set(:ALT_SEPARATOR, '\\')
     @installer.wrappers = false
     util_make_exec
-    @installer.gem_dir = util_gem_dir
+    @installer.gem_dir = @spec.gem_dir
 
     use_ui @ui do
       @installer.generate_bin
@@ -1714,7 +1714,7 @@ gem 'other', version
 
     @installer.wrappers = true
     @installer.options[:install_as_default] = true
-    @installer.gem_dir = util_gem_dir @spec
+    @installer.gem_dir = @spec.gem_dir
     @installer.generate_bin
 
     use_ui @ui do


### PR DESCRIPTION
# Description:

Both of these methods are deprecated, so we should warn users if they are using them, since they will be removed in a future version of Rubygems.
______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).