### PR TITLE
Deprecate passing options to Gem::GemRunner

### DIFF
--- a/lib/rubygems/gem_runner.rb
+++ b/lib/rubygems/gem_runner.rb
@@ -8,6 +8,7 @@
 require 'rubygems'
 require 'rubygems/command_manager'
 require 'rubygems/config_file'
+require 'rubygems/deprecate'
 
 ##
 # Load additional plugins from $LOAD_PATH
@@ -26,7 +27,10 @@ Gem.load_env_plugins rescue nil
 class Gem::GemRunner
 
   def initialize(options={})
-    # TODO: nuke these options
+    if !options.empty? && !Gem::Deprecate.skip
+      Kernel.warn "NOTE: passing options to Gem::GemRunner.new is deprecated with no replacement. It will be removed on or after 2016-10-01."
+    end
+
     @command_manager_class = options[:command_manager] || Gem::CommandManager
     @config_file_class = options[:config_file] || Gem::ConfigFile
   end


### PR DESCRIPTION
# Description:

Would use `Gem::Deprecate` but we're not deprecating a method here 😢 
______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

