### PR TITLE
Do not use #quick_spec internally

### DIFF
--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -588,7 +588,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
       done_installing = true
     end
 
-    spec = quick_spec 'a', 2
+    spec = util_spec 'a', 2
 
     util_build_gem spec
 
@@ -616,7 +616,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
   end
 
   def test_install_gem_ignore_dependencies_specific_file
-    spec = quick_spec 'a', 2
+    spec = util_spec 'a', 2
 
     util_build_gem spec
 

--- a/test/rubygems/test_gem_resolver_conflict.rb
+++ b/test/rubygems/test_gem_resolver_conflict.rb
@@ -15,7 +15,7 @@ class TestGemResolverConflict < Gem::TestCase
 
     dep = Gem::Resolver::DependencyRequest.new dep('net-ssh', '>= 2.0.13'), nil
 
-    spec = quick_spec 'net-ssh', '2.2.2'
+    spec = util_spec 'net-ssh', '2.2.2'
     active =
       Gem::Resolver::ActivationRequest.new spec, dep
 


### PR DESCRIPTION
# Description:

The method is slated to be removed in RG 3.0, so we might as well use
the replacement now.
______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

The method is slated to be removed in RG 3.0, so we might as well use
the replacement now.