### PR TITLE
Fix sort stability

### DIFF
--- a/lib/rubygems/resolver/molinillo/lib/molinillo/modules/specification_provider.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/modules/specification_provider.rb
@@ -79,11 +79,12 @@ module Gem::Resolver::Molinillo
     # @param [{String => Array<Conflict>}] conflicts
     # @return [Array<Object>] a sorted copy of `dependencies`.
     def sort_dependencies(dependencies, activated, conflicts)
-      dependencies.sort_by do |dependency|
+      dependencies.sort_by.with_index do |dependency, index|
         name = name_for(dependency)
         [
           activated.vertex_named(name).payload ? 0 : 1,
           conflicts[name] ? 0 : 1,
+          index,
         ]
       end
     end


### PR DESCRIPTION
# Description:

Sort stably.
`Array#sort` and `Array#sort_by` are not guaranteed as stable, and, in fact, `qsort_s` of Microsoft Visual C sorts elements with same keys in different order.

This is reported at https://bugs.ruby-lang.org/issues/12509.

I'm not sure if stable sort is expected here or other keys will be expected, please correct properly.

______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
