### PR TITLE
Fix method_missing for 'this' error

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -306,7 +306,9 @@ class Gem::BasicSpecification
     raise NotImplementedError
   end
 
-  def this; self; end
+  def this
+    self || Proc.new { }
+  end
 
   private
 


### PR DESCRIPTION
# Description:

______________

# Tasks:

- [x] Describe the problem / feature

When running a Sinatra app with Shotgun, `this` keyword in basic_specification.rb threw a `method_missing` error. This fixed it.

ERROR:
```
NoMethodError: undefined method `this' for #<Gem::Specification:0x3fc7648f1914 sinatra-1.4.7>
```
- [ ] Write tests
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends


I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

