### PR TITLE
Improve SSL verification failure message

### DIFF
--- a/test/rubygems/test_gem_request.rb
+++ b/test/rubygems/test_gem_request.rb
@@ -8,6 +8,7 @@ class TestGemRequest < Gem::TestCase
 
   CA_CERT_FILE     = cert_path 'ca'
   CHILD_CERT       = load_cert 'child'
+  EXPIRED_CERT     = load_cert 'expired'
   PUBLIC_CERT      = load_cert 'public'
   PUBLIC_CERT_FILE = cert_path 'public'
   SSL_CERT         = load_cert 'ssl'
@@ -311,6 +312,136 @@ class TestGemRequest < Gem::TestCase
     util_restore_version
   end
 
+  def test_verify_certificate
+    store = OpenSSL::X509::Store.new
+    context = OpenSSL::X509::StoreContext.new store
+    context.error = OpenSSL::X509::V_ERR_OUT_OF_MEM
+
+    use_ui @ui do
+      Gem::Request.verify_certificate context
+    end
+
+    assert_equal "ERROR:  SSL verification error at depth 0: out of memory (17)\n",
+                 @ui.error
+  end
+
+  def test_verify_certificate_extra_message
+    store = OpenSSL::X509::Store.new
+    context = OpenSSL::X509::StoreContext.new store
+    context.error = OpenSSL::X509::V_ERR_INVALID_CA
+
+    use_ui @ui do
+      Gem::Request.verify_certificate context
+    end
+
+    expected = <<-ERROR
+ERROR:  SSL verification error at depth 0: invalid CA certificate (24)
+ERROR:  Certificate  is an invalid CA certificate
+    ERROR
+
+    assert_equal expected, @ui.error
+  end
+
+  def test_verify_certificate_message_CERT_HAS_EXPIRED
+    error_number = OpenSSL::X509::V_ERR_CERT_HAS_EXPIRED
+
+    message =
+      Gem::Request.verify_certificate_message error_number, EXPIRED_CERT
+
+    assert_equal "Certificate #{EXPIRED_CERT.subject} expired at #{EXPIRED_CERT.not_before.iso8601}",
+                 message
+  end
+
+  def test_verify_certificate_message_CERT_NOT_YET_VALID
+    error_number = OpenSSL::X509::V_ERR_CERT_NOT_YET_VALID
+
+    message =
+      Gem::Request.verify_certificate_message error_number, EXPIRED_CERT
+
+    assert_equal "Certificate #{EXPIRED_CERT.subject} not valid until #{EXPIRED_CERT.not_before.iso8601}",
+                 message
+  end
+
+  def test_verify_certificate_message_CERT_REJECTED
+    error_number = OpenSSL::X509::V_ERR_CERT_REJECTED
+
+    message =
+      Gem::Request.verify_certificate_message error_number, CHILD_CERT
+
+    assert_equal "Certificate #{CHILD_CERT.subject} is rejected",
+                 message
+  end
+
+  def test_verify_certificate_message_CERT_UNTRUSTED
+    error_number = OpenSSL::X509::V_ERR_CERT_UNTRUSTED
+
+    message =
+      Gem::Request.verify_certificate_message error_number, CHILD_CERT
+
+    assert_equal "Certificate #{CHILD_CERT.subject} is not trusted",
+                 message
+  end
+
+  def test_verify_certificate_message_DEPTH_ZERO_SELF_SIGNED_CERT
+    error_number = OpenSSL::X509::V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT
+
+    message =
+      Gem::Request.verify_certificate_message error_number, CHILD_CERT
+
+    assert_equal "Certificate #{CHILD_CERT.issuer} is not trusted",
+                 message
+  end
+
+  def test_verify_certificate_message_INVALID_CA
+    error_number = OpenSSL::X509::V_ERR_INVALID_CA
+
+    message =
+      Gem::Request.verify_certificate_message error_number, CHILD_CERT
+
+    assert_equal "Certificate #{CHILD_CERT.subject} is an invalid CA certificate",
+                 message
+  end
+
+  def test_verify_certificate_message_INVALID_PURPOSE
+    error_number = OpenSSL::X509::V_ERR_INVALID_PURPOSE
+
+    message =
+      Gem::Request.verify_certificate_message error_number, CHILD_CERT
+
+    assert_equal "Certificate #{CHILD_CERT.subject} has an invalid purpose",
+                 message
+  end
+
+  def test_verify_certificate_message_SELF_SIGNED_CERT_IN_CHAIN
+    error_number = OpenSSL::X509::V_ERR_SELF_SIGNED_CERT_IN_CHAIN
+
+    message =
+      Gem::Request.verify_certificate_message error_number, EXPIRED_CERT
+
+    assert_equal "Root certificate is not trusted (#{EXPIRED_CERT.subject})",
+                 message
+  end
+
+  def test_verify_certificate_message_UNABLE_TO_GET_ISSUER_CERT_LOCALLY
+    error_number = OpenSSL::X509::V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY
+
+    message =
+      Gem::Request.verify_certificate_message error_number, EXPIRED_CERT
+
+    assert_equal "You must add #{EXPIRED_CERT.issuer} to your local trusted store",
+                 message
+  end
+
+  def test_verify_certificate_message_UNABLE_TO_VERIFY_LEAF_SIGNATURE
+    error_number = OpenSSL::X509::V_ERR_UNABLE_TO_VERIFY_LEAF_SIGNATURE
+
+    message =
+      Gem::Request.verify_certificate_message error_number, EXPIRED_CERT
+
+    assert_equal "You must add #{EXPIRED_CERT.issuer} to your local trusted store",
+                 message
+  end
+
   def util_restore_version
     Object.send :remove_const, :RUBY_ENGINE if defined?(RUBY_ENGINE)
     Object.send :const_set,    :RUBY_ENGINE, @orig_RUBY_ENGINE if
@@ -344,6 +475,7 @@ class TestGemRequest < Gem::TestCase
 
     def new *args; self; end
     def use_ssl=(bool); end
+    def verify_callback=(setting); end
     def verify_mode=(setting); end
     def cert_store=(setting); end
     def start; end


### PR DESCRIPTION
# Description:

When a TLS connection fails for some known reason we now provide a better
description of the failure.  It's unfortunate that OpenSSL doesn't do
this by default.

The full list of possible error codes is here:

https://www.openssl.org/docs/manmaster/crypto/X509_STORE_CTX_get_error.html

I picked out a few of the more useful error types to provide extra
messages where this information would be most useful.  We can add extra
message types in the future if the rest of the errors are common.

______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
