### PR TITLE
Ensure `to_spec` falls back on prerelease specs

### DIFF
--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -317,13 +317,16 @@ class Gem::Dependency
   end
 
   def to_spec
-    matches = self.to_specs
+    matches = self.to_specs.compact
 
-    active = matches.find { |spec| spec && spec.activated? }
-
+    active = matches.find { |spec| spec.activated? }
     return active if active
 
-    matches.delete_if { |spec| spec.nil? || spec.version.prerelease? } unless prerelease?
+    return matches.first if prerelease?
+
+    # Move prereleases to the end of the list for >= 0 requirements
+    pre, matches = matches.partition { |spec| spec.version.prerelease? }
+    matches += pre if requirement == Gem::Requirement.default
 
     matches.first
   end

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3389,6 +3389,13 @@ end
     end
   end
 
+  def test_find_by_name_with_only_prereleases
+    q = util_spec "q", "2.a"
+    install_specs q
+
+    assert Gem::Specification.find_by_name "q"
+  end
+
   def test_find_by_name_prerelease
     b = util_spec "b", "2.a"
 


### PR DESCRIPTION
The `Gem::Dependency#to_spec` method is documented to never return nil, and raise `Gem::MissingSpecError` if there are no gems that meet the dependency. However, if the only gem that meets the dependency is a prerelease gem, then `to_spec` would return `nil` instead of raising.

I've written a test that explicitly checks this case, and modified `to_spec` to fall back on the first prerelease spec if there are no full-release specs available.