### PR TITLE
Cherry-picked from master changes(typofix)

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2698,7 +2698,7 @@ class Gem::Specification < Gem::BasicSpecification
 
     unless specification_version.is_a?(Integer)
       raise Gem::InvalidSpecificationException,
-            'specification_version must be a Integer (did you mean version?)'
+            'specification_version must be an Integer (did you mean version?)'
     end
 
     case platform

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3080,7 +3080,7 @@ Did you mean 'Ruby'?
         end
       end
 
-      err = 'specification_version must be a Integer (did you mean version?)'
+      err = 'specification_version must be an Integer (did you mean version?)'
       assert_equal err, e.message
     end
   end


### PR DESCRIPTION
# Description:

I picked https://github.com/rubygems/rubygems/commit/e18caa808350f477b6f04ea6d586ba0693c4c73d from master branch for rubygems-2.6.x

I merged rubygems-2.6.8 to ruby core repository and got regression of this typofix . I'm happy to backport this fix into 2.6 branch. so We leave from same regression in the future.

ref. https://github.com/ruby/ruby/commit/6ce158ba870eb815ba9775ac8380b32fd81be040
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

