### PR TITLE
Fix malformed version number error

### DIFF
--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -39,7 +39,12 @@ class Gem::StubSpecification < Gem::BasicSpecification
     def initialize data, extensions
       parts          = data[PREFIX.length..-1].split(" ".freeze, 4)
       @name          = parts[0].freeze
-      @version       = Gem::Version.new parts[1]
+      @version       = if Gem::Version.correct?(parts[1])
+                         Gem::Version.new(parts[1])
+                       else
+                         Gem::Version.new(0)
+                       end
+
       @platform      = Gem::Platform.new parts[2]
       @extensions    = extensions
       @full_name     = if platform == Gem::Platform::RUBY

--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -204,8 +204,12 @@ class Gem::Version
   # series of digits or ASCII letters separated by dots.
 
   def initialize version
-    raise ArgumentError, "Malformed version number string #{version}" unless
-      self.class.correct?(version)
+    unless self.class.correct?(version)
+      raise ArgumentError, "Malformed version number string #{version}"
+    end
+
+    # If version is an empty string convert it to 0
+    version = 0 if version =~ /\A\s*\Z/
 
     @version = version.to_s.strip.gsub("-",".pre.")
     @segments = nil

--- a/test/rubygems/test_gem_stub_specification.rb
+++ b/test/rubygems/test_gem_stub_specification.rb
@@ -33,6 +33,20 @@ class TestStubSpecification < Gem::TestCase
     assert_equal %w[ext/stub_e/extconf.rb],   stub.extensions
   end
 
+  def test_initialize_version
+    stub = stub_with_version
+
+    assert_equal 'stub_v',                    stub.name
+    assert_equal v(2),                        stub.version
+  end
+
+  def test_initialize_with_empty_version
+    stub = stub_without_version
+
+    assert_equal 'stub_v',                    stub.name
+    assert_equal v(0),                        stub.version
+  end
+
   def test_initialize_missing_stubline
     stub = Gem::StubSpecification.gemspec_stub(BAR, @base_dir, @gems_dir)
     assert_equal "bar", stub.name
@@ -162,6 +176,53 @@ class TestStubSpecification < Gem::TestCase
     end
 
     assert stub.to_spec.instance_variable_get :@ignored
+  end
+
+  def stub_with_version
+    spec = File.join @gemhome, 'specifications', 'stub_e-2.gemspec'
+    open spec, 'w' do |io|
+      io.write <<-STUB
+# -*- encoding: utf-8 -*-
+# stub: stub_v 2 ruby lib
+
+Gem::Specification.new do |s|
+  s.name = 'stub_v'
+  s.version = Gem::Version.new '2'
+end
+      STUB
+
+      io.flush
+
+      stub = Gem::StubSpecification.gemspec_stub io.path, @gemhome, File.join(@gemhome, 'gems')
+
+      yield stub if block_given?
+
+      return stub
+    end
+  end
+
+  def stub_without_version
+    spec = File.join @gemhome, 'specifications', 'stub-2.gemspec'
+    open spec, 'w' do |io|
+      io.write <<-STUB
+# -*- encoding: utf-8 -*-
+# stub: stub_v ruby lib
+
+Gem::Specification.new do |s|
+  s.name = 'stub_v'
+  s.version = ""
+end
+      STUB
+
+      io.flush
+
+      stub = Gem::StubSpecification.gemspec_stub io.path, @gemhome, File.join(@gemhome, 'gems')
+
+      yield stub if block_given?
+
+      return stub
+    end
+
   end
 
   def stub_with_extension

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -92,6 +92,12 @@ class TestGemVersion < Gem::TestCase
     end
   end
 
+  def test_empty_version
+    ["", "   ", " "].each do |empty|
+      assert_equal "0", Gem::Version.new(empty).version
+    end
+  end
+
   def test_prerelease
     assert_prerelease "1.2.0.a"
     assert_prerelease "2.9.b"


### PR DESCRIPTION
closes https://github.com/rubygems/rubygems/issues/1628 

This PR will convert a gem version that is set to an empty string to "0" 

