### PR TITLE
Improve user-facing messages by consistent casing of Ruby/RubyGems

### DIFF
--- a/bin/gem
+++ b/bin/gem
@@ -12,7 +12,7 @@ require 'rubygems/exceptions'
 required_version = Gem::Requirement.new ">= 1.8.7"
 
 unless required_version.satisfied_by? Gem.ruby_version then
-  abort "Expected Ruby Version #{required_version}, is #{Gem.ruby_version}"
+  abort "Expected Ruby version #{required_version}, is #{Gem.ruby_version}"
 end
 
 args = ARGV.clone

--- a/bin/update_rubygems
+++ b/bin/update_rubygems
@@ -12,7 +12,7 @@ if ARGV.include? '-h' or ARGV.include? '--help' then
   $stderr.puts
   $stderr.puts "This will install the latest version of RubyGems."
   $stderr.puts
-  $stderr.puts "\t--version=X.Y\tUpdate rubygems from the X.Y version."
+  $stderr.puts "\t--version=X.Y\tUpdate RubyGems from the X.Y version."
   exit
 end
 
@@ -23,7 +23,7 @@ end
 update_dir = $LOAD_PATH.find { |dir| dir =~ /rubygems-update/ }
 
 if update_dir.nil?
-  puts "Error: Cannot find RubyGems Update Path!"
+  puts "Error: Cannot find RubyGems update path!"
   puts
   puts "RubyGems has already been updated."
   puts "The rubygems-update gem may now be uninstalled."

--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -71,7 +71,7 @@ class Gem::BasicSpecification
     elsif missing_extensions? then
       @ignored = true
 
-      warn "Ignoring #{full_name} because its extensions are not built.  " +
+      warn "Ignoring #{full_name} because its extensions are not built. " +
         "Try: gem pristine #{name} --version #{version}"
       return false
     end

--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -527,7 +527,7 @@ class Gem::Command
   end
 
   add_common_option("--silent",
-                    "Silence rubygems output") do |value, options|
+                    "Silence RubyGems output") do |value, options|
     options[:silent] = true
   end
 

--- a/lib/rubygems/command_manager.rb
+++ b/lib/rubygems/command_manager.rb
@@ -161,7 +161,7 @@ class Gem::CommandManager
       say Gem::VERSION
       terminate_interaction 0
     when /^-/ then
-      alert_error "Invalid option: #{args.first}.  See 'gem --help'."
+      alert_error "Invalid option: #{args.first}. See 'gem --help'."
       terminate_interaction 1
     else
       cmd_name = args.shift.downcase

--- a/lib/rubygems/commands/cert_command.rb
+++ b/lib/rubygems/commands/cert_command.rb
@@ -124,7 +124,7 @@ class Gem::Commands::CertCommand < Gem::Command
     say "Certificate: #{cert_path}"
 
     if key_path
-      say "Private Key: #{key_path}"
+      say "Private key: #{key_path}"
       say "Don't forget to move the key file to somewhere private!"
     end
   end

--- a/lib/rubygems/commands/cert_command.rb
+++ b/lib/rubygems/commands/cert_command.rb
@@ -124,7 +124,7 @@ class Gem::Commands::CertCommand < Gem::Command
     say "Certificate: #{cert_path}"
 
     if key_path
-      say "Private key: #{key_path}"
+      say "Private Key: #{key_path}"
       say "Don't forget to move the key file to somewhere private!"
     end
   end

--- a/lib/rubygems/commands/cleanup_command.rb
+++ b/lib/rubygems/commands/cleanup_command.rb
@@ -66,7 +66,7 @@ If no gems are named all gems in GEM_HOME are cleaned.
       clean_gems
     end
 
-    say "Clean Up Complete"
+    say "Clean up complete"
 
     verbose do
       skipped = @default_gems.map { |spec| spec.full_name }

--- a/lib/rubygems/commands/help_command.rb
+++ b/lib/rubygems/commands/help_command.rb
@@ -367,7 +367,7 @@ platform.
     elsif possibilities.size > 1 then
       alert_warning "Ambiguous command #{command_name} (#{possibilities.join(', ')})"
     else
-      alert_warning "Unknown command #{command_name}.  Try: gem help commands"
+      alert_warning "Unknown command #{command_name}. Try: gem help commands"
     end
   end
 

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -18,7 +18,7 @@ class Gem::Commands::SetupCommand < Gem::Command
           :destdir => '', :prefix => '', :previous_version => ''
 
     add_option '--previous-version=VERSION',
-               'Previous version of rubygems',
+               'Previous version of RubyGems',
                'Used for changelog processing' do |version, options|
       options[:previous_version] = version
     end
@@ -42,7 +42,7 @@ class Gem::Commands::SetupCommand < Gem::Command
 
     add_option '--[no-]format-executable',
                'Makes `gem` match ruby',
-               'If ruby is ruby18, gem will be gem18' do |value, options|
+               'If Ruby is ruby18, gem will be gem18' do |value, options|
       options[:format_executable] = value
     end
 
@@ -192,7 +192,7 @@ By default, this RubyGems will install gem as:
 
       if options[:document].include? 'ri' then
         say "Ruby Interactive (ri) documentation was installed. ri is kind of like man "
-        say "pages for ruby libraries. You may access it like this:"
+        say "pages for Ruby libraries. You may access it like this:"
         say "  ri Classname"
         say "  ri Classname.class_method"
         say "  ri Classname#instance_method"
@@ -423,7 +423,7 @@ By default, this RubyGems will install gem as:
       old_bin_path = File.join bin_dir, old_bin_file
       next unless File.exist? old_bin_path
 
-      deprecation_message = "`#{old_bin_file}` has been deprecated.  Use `#{new_name}` instead."
+      deprecation_message = "`#{old_bin_file}` has been deprecated. Use `#{new_name}` instead."
 
       File.open old_bin_path, 'w' do |fp|
         fp.write <<-EOF

--- a/lib/rubygems/commands/which_command.rb
+++ b/lib/rubygems/commands/which_command.rb
@@ -56,7 +56,7 @@ requiring to see why it does not behave as you expect.
       paths = find_paths arg, dirs
 
       if paths.empty? then
-        alert_error "Can't find ruby library file or shared library #{arg}"
+        alert_error "Can't find Ruby library file or shared library #{arg}"
 
         found &&= false
       else

--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -183,7 +183,7 @@ EOF
     return if @spec.extensions.empty?
 
     if @build_args.empty?
-      say "Building native extensions.  This could take a while..."
+      say "Building native extensions. This could take a while..."
     else
       say "Building native extensions with: '#{@build_args.join ' '}'"
       say "This could take a while..."

--- a/lib/rubygems/install_update_options.rb
+++ b/lib/rubygems/install_update_options.rb
@@ -137,8 +137,8 @@ module Gem::InstallUpdateOptions
     end
 
     add_option(:"Install/Update",       '--[no-]format-executable',
-               'Make installed executable names match ruby.',
-               'If ruby is ruby18, foo_exec will be',
+               'Make installed executable names match Ruby.',
+               'If Ruby is ruby18, foo_exec will be',
                'foo_exec18') do |value, options|
       options[:format_executable] = value
     end

--- a/lib/rubygems/package/old.rb
+++ b/lib/rubygems/package/old.rb
@@ -124,7 +124,7 @@ class Gem::Package::Old < Gem::Package
       break unless line
     end
 
-    raise Gem::Exception, "Failed to find end of ruby script while reading gem"
+    raise Gem::Exception, "Failed to find end of Ruby script while reading gem"
   end
 
   ##

--- a/lib/rubygems/request.rb
+++ b/lib/rubygems/request.rb
@@ -83,7 +83,7 @@ class Gem::Request
                  e.message =~ / -- openssl$/
 
     raise Gem::Exception.new(
-            'Unable to require openssl, install OpenSSL and rebuild ruby (preferred) or use non-HTTPS sources')
+            'Unable to require openssl, install OpenSSL and rebuild Ruby (preferred) or use non-HTTPS sources')
   end
 
   def self.verify_certificate store_context

--- a/lib/rubygems/request_set.rb
+++ b/lib/rubygems/request_set.rb
@@ -174,10 +174,10 @@ class Gem::RequestSet
             s.required_ruby_version.satisfied_by?(Gem.ruby_version) && s.required_rubygems_version.satisfied_by?(Gem.rubygems_version)
           end
           if recent_match
-            suggestion = "The last version of #{req.request} to support your ruby & rubygems was #{recent_match.version}. Try installing it with `gem install #{recent_match.name} -v #{recent_match.version}`"
+            suggestion = "The last version of #{req.request} to support your Ruby & RubyGems was #{recent_match.version}. Try installing it with `gem install #{recent_match.name} -v #{recent_match.version}`"
             suggestion += " and then running the current command again" unless @always_install.include?(req.spec.spec)
           else
-            suggestion = "There are no versions of #{req.request} compatible with your ruby & rubygems"
+            suggestion = "There are no versions of #{req.request} compatible with your Ruby & RubyGems"
             suggestion += ". Maybe try installing an older version of the gem you're looking for?" unless @always_install.include?(req.spec.spec)
           end
           e.suggestion = suggestion

--- a/lib/rubygems/request_set/gem_dependency_api.rb
+++ b/lib/rubygems/request_set/gem_dependency_api.rb
@@ -786,7 +786,7 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
     engine_version = options[:engine_version]
 
     raise ArgumentError,
-          'you must specify engine_version along with the ruby engine' if
+          'You must specify engine_version along with the Ruby engine' if
             engine and not engine_version
 
     return true if @installing
@@ -799,7 +799,7 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
     end
 
     if engine and engine != Gem.ruby_engine then
-      message = "Your ruby engine is #{Gem.ruby_engine}, " +
+      message = "Your Ruby engine is #{Gem.ruby_engine}, " +
                 "but your #{gem_deps_file} requires #{engine}"
 
       raise Gem::RubyVersionMismatch, message
@@ -810,7 +810,7 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
 
       if engine_version != my_engine_version then
         message =
-          "Your ruby engine version is #{Gem.ruby_engine} #{my_engine_version}, " +
+          "Your Ruby engine version is #{Gem.ruby_engine} #{my_engine_version}, " +
           "but your #{gem_deps_file} requires #{engine} #{engine_version}"
 
         raise Gem::RubyVersionMismatch, message

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -882,7 +882,7 @@ class Gem::Specification < Gem::BasicSpecification
   # properly sorted.
 
   def self.add_spec spec
-    warn "Gem::Specification.add_spec is deprecated and will be removed in Rubygems 3.0" unless Gem::Deprecate.skip
+    warn "Gem::Specification.add_spec is deprecated and will be removed in RubyGems 3.0" unless Gem::Deprecate.skip
     # TODO: find all extraneous adds
     # puts
     # p :add_spec => [spec.full_name, caller.reject { |s| s =~ /minitest/ }]
@@ -907,7 +907,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Adds multiple specs to the known specifications.
 
   def self.add_specs *specs
-    warn "Gem::Specification.add_specs is deprecated and will be removed in Rubygems 3.0" unless Gem::Deprecate.skip
+    warn "Gem::Specification.add_specs is deprecated and will be removed in RubyGems 3.0" unless Gem::Deprecate.skip
 
     raise "nil spec!" if specs.any?(&:nil?) # TODO: remove once we're happy
 
@@ -1246,7 +1246,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Removes +spec+ from the known specs.
 
   def self.remove_spec spec
-    warn "Gem::Specification.remove_spec is deprecated and will be removed in Rubygems 3.0" unless Gem::Deprecate.skip
+    warn "Gem::Specification.remove_spec is deprecated and will be removed in RubyGems 3.0" unless Gem::Deprecate.skip
     _all.delete spec
     stubs.delete_if { |s| s.full_name == spec.full_name }
     (@@stubs_by_name[spec.name] || []).delete_if { |s| s.full_name == spec.full_name }

--- a/setup.rb
+++ b/setup.rb
@@ -7,7 +7,7 @@
 #++
 
 if RUBY_VERSION < "1.8.7"
-  $stderr.puts "Rubygems now requires Ruby 1.8.7 or later"
+  $stderr.puts "RubyGems now requires Ruby 1.8.7 or later"
   exit 1
 end
 

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1076,7 +1076,7 @@ class TestGem < Gem::TestCase
       refute Gem.try_activate 'nonexistent'
     end
 
-    expected = "Ignoring ext-1 because its extensions are not built.  " +
+    expected = "Ignoring ext-1 because its extensions are not built. " +
                "Try: gem pristine ext --version 1\n"
 
     assert_equal expected, err

--- a/test/rubygems/test_gem_command.rb
+++ b/test/rubygems/test_gem_command.rb
@@ -170,7 +170,7 @@ class TestGemCommand < Gem::TestCase
     @cmd.add_option('-f', '--file FILE', 'File option') do |value, options|
       options[:help] = true
     end
-    @cmd.add_option('--silent', 'Silence rubygems output') do |value, options|
+    @cmd.add_option('--silent', 'Silence RubyGems output') do |value, options|
       options[:silent] = true
     end
     assert @cmd.handles?(['-x'])

--- a/test/rubygems/test_gem_commands_pristine_command.rb
+++ b/test/rubygems/test_gem_commands_pristine_command.rb
@@ -145,7 +145,7 @@ class TestGemCommandsPristineCommand < Gem::TestCase
     out = @ui.output.split "\n"
 
     assert_equal 'Restoring gems to pristine condition...', out.shift
-    assert_equal 'Building native extensions.  This could take a while...',
+    assert_equal 'Building native extensions. This could take a while...',
                  out.shift
     assert_equal "Restored #{a.full_name}", out.shift
     assert_empty out, out.inspect

--- a/test/rubygems/test_gem_commands_which_command.rb
+++ b/test/rubygems/test_gem_commands_which_command.rb
@@ -33,7 +33,7 @@ class TestGemCommandsWhichCommand < Gem::TestCase
     end
 
     assert_equal '', @ui.output
-    assert_match %r%Can.t find ruby library file or shared library directory\n%,
+    assert_match %r%Can.t find Ruby library file or shared library directory\n%,
                  @ui.error
   end
 
@@ -51,7 +51,7 @@ class TestGemCommandsWhichCommand < Gem::TestCase
     end
 
     assert_equal "#{@foo_bar.full_gem_path}/lib/foo_bar.rb\n", @ui.output
-    assert_match %r%Can.t find ruby library file or shared library missinglib\n%,
+    assert_match %r%Can.t find Ruby library file or shared library missinglib\n%,
                  @ui.error
   end
 
@@ -65,7 +65,7 @@ class TestGemCommandsWhichCommand < Gem::TestCase
     end
 
     assert_equal '', @ui.output
-    assert_match %r%Can.t find ruby library file or shared library missinglib\n%,
+    assert_match %r%Can.t find Ruby library file or shared library missinglib\n%,
                  @ui.error
   end
 

--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -239,7 +239,7 @@ install:
 
     assert_match(/\AERROR: Failed to build gem native extension.$/, e.message)
 
-    assert_equal "Building native extensions.  This could take a while...\n",
+    assert_equal "Building native extensions. This could take a while...\n",
                  @ui.output
     assert_equal '', @ui.error
 
@@ -272,7 +272,7 @@ install:
 
     assert_match(/^\s*No builder for extension ''$/, e.message)
 
-    assert_equal "Building native extensions.  This could take a while...\n",
+    assert_equal "Building native extensions. This could take a while...\n",
                  @ui.output
     assert_equal '', @ui.error
 

--- a/test/rubygems/test_gem_request_set_gem_dependency_api.rb
+++ b/test/rubygems/test_gem_request_set_gem_dependency_api.rb
@@ -753,7 +753,7 @@ end
         @gda.ruby RUBY_VERSION, :engine => 'jruby', :engine_version => '1.7.4'
       end
 
-      assert_equal 'Your ruby engine is ruby, but your gem.deps.rb requires jruby',
+      assert_equal 'Your Ruby engine is ruby, but your gem.deps.rb requires jruby',
                    e.message
     end
   end
@@ -764,7 +764,7 @@ end
         @gda.ruby RUBY_VERSION, :engine => 'jruby', :engine_version => '1.7.4'
       end
 
-      assert_equal 'Your ruby engine version is jruby 1.7.6, but your gem.deps.rb requires jruby 1.7.4',
+      assert_equal 'Your Ruby engine version is jruby 1.7.6, but your gem.deps.rb requires jruby 1.7.4',
                    e.message
     end
   end
@@ -774,7 +774,7 @@ end
       @gda.ruby RUBY_VERSION, :engine => 'jruby'
     end
 
-    assert_equal 'you must specify engine_version along with the ruby engine',
+    assert_equal 'You must specify engine_version along with the Ruby engine',
                  e.message
   end
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1586,7 +1586,7 @@ dependencies: []
       refute @ext.contains_requirable_file? 'nonexistent'
     end
 
-    expected = "Ignoring ext-1 because its extensions are not built.  " +
+    expected = "Ignoring ext-1 because its extensions are not built. " +
                "Try: gem pristine ext --version 1\n"
 
     assert_equal expected, err

--- a/test/rubygems/test_gem_stub_specification.rb
+++ b/test/rubygems/test_gem_stub_specification.rb
@@ -57,7 +57,7 @@ class TestStubSpecification < Gem::TestCase
         refute stub.contains_requirable_file? 'nonexistent'
       end
 
-      expected = "Ignoring stub_e-2 because its extensions are not built.  " +
+      expected = "Ignoring stub_e-2 because its extensions are not built. " +
                  "Try: gem pristine stub_e --version 2\n"
 
       assert_equal expected, err


### PR DESCRIPTION
# Description:

It was bothering me to see the message "Clean Up Complete" capitalized like that, which was inconsistent from most other RubyGems messages. So I fixed that issue, and also found a few handfuls of other instances where either case or spacing was inconsistent. Note this is all in user-facing messages -- I tried hard to avoid touching anything that generated code, or tests.