### PR TITLE
Add Ruby Together CTA, rearrange README a bit

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -12,7 +12,7 @@ MAINTAINERS.txt
 MIT.txt
 Manifest.txt
 POLICIES.rdoc
-README.rdoc
+README.md
 Rakefile
 UPGRADING.rdoc
 appveyor.yml

--- a/README.md
+++ b/README.md
@@ -1,13 +1,4 @@
-= RubyGems
-
-Homepage:      :: https://rubygems.org
-Announcements: :: http://blog.rubygems.org
-Documentation: :: http://guides.rubygems.org
-Support:       :: http://help.rubygems.org
-Source:        :: https://github.com/rubygems/rubygems
-Bugtracker:    :: https://github.com/rubygems/rubygems/issues
-
-== DESCRIPTION
+# RubyGems
 
 RubyGems is a package management framework for Ruby.
 
@@ -18,7 +9,9 @@ See Gem for information on RubyGems (or `ri Gem`)
 
 To upgrade to the latest RubyGems, run:
 
+```
   $ gem update --system  # you might need to be an administrator or root
+```
 
 See UPGRADING.rdoc for more details and alternative instructions.
 
@@ -32,23 +25,30 @@ If you don't have RubyGems installed, you can still do it manually:
 
 For more details and other options, see:
 
+```
   ruby setup.rb --help
+```
 
-== GETTING HELP
+## SUPPORTING
 
-=== Support Requests
+<a href="https://rubytogether.org/"><img src="https://rubytogether.org/images/rubies.svg" width=200></a><br/>
+  RubyGems is maintained by <a href="https://rubytogether.org/">Ruby Together</a>, a grassroots initiative committed to supporting the critical Ruby infrastructure you rely on. Contribute today <a href="https://rubytogether.org/developers">as an individual</a> or even better, <a href="https://rubytogether.org/companies">as a company</a>, and ensure that Bundler, RubyGems, and other shared tooling is around for years to come.
+
+## GETTING HELP
+
+### Support Requests
 
 Are you unsure of how to use RubyGems?  Do you think you've found a bug and
 you're not sure?  If that is the case, the best place for you is to file a
 support request at {help.rubygems.org}[http://help.rubygems.org].
 
-=== Filing Tickets
+### Filing Tickets
 
 Got a bug and you're not sure?  You're sure you have a bug, but don't know
 what to do next?  In any case, let us know about it!  The best place
 for letting the RubyGems team know about bugs or problems you're having is
 {on the RubyGems issues page at GitHub}[http://github.com/rubygems/rubygems/issues].
 
-=== Bundler Compatibility
+### Bundler Compatibility
 
 See http://bundler.io/compatibility for known issues.

--- a/Rakefile
+++ b/Rakefile
@@ -32,7 +32,7 @@ Hoe.plugin :travis
 hoe = Hoe.spec 'rubygems-update' do
   self.author         = ['Jim Weirich', 'Chad Fowler', 'Eric Hodel']
   self.email          = %w[rubygems-developers@rubyforge.org]
-  self.readme_file    = 'README.rdoc'
+  self.readme_file    = 'README.md'
 
   license 'Ruby'
   license 'MIT'


### PR DESCRIPTION
# Description:

Adds a CTA to the Ruby Together site. /c @indirect 

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

