### PR TITLE
Raise error if the email is invalid when building cert

### DIFF
--- a/lib/rubygems/commands/cert_command.rb
+++ b/lib/rubygems/commands/cert_command.rb
@@ -110,16 +110,20 @@ class Gem::Commands::CertCommand < Gem::Command
       list_certificates_matching filter
     end
 
-    options[:build].each do |name|
-      build name
+    options[:build].each do |email|
+      build email
     end
 
     sign_certificates unless options[:sign].empty?
   end
 
-  def build name
+  def build email
+    if !valid_email?(email)
+      raise Gem::CommandLineError, "Invalid email address #{email}"
+    end
+
     key, key_path = build_key
-    cert_path = build_cert name, key
+    cert_path = build_cert email, key
 
     say "Certificate: #{cert_path}"
 
@@ -129,7 +133,7 @@ class Gem::Commands::CertCommand < Gem::Command
     end
   end
 
-  def build_cert name, key # :nodoc:
+  def build_cert email, key # :nodoc:
     expiration_length_days = options[:expiration_length_days]
     age =
       if expiration_length_days.nil? || expiration_length_days == 0
@@ -138,7 +142,7 @@ class Gem::Commands::CertCommand < Gem::Command
         Gem::Security::ONE_DAY * expiration_length_days
       end
 
-    cert = Gem::Security.create_cert_email name, key, age
+    cert = Gem::Security.create_cert_email email, key, age
     Gem::Security.write cert, "gem-public_cert.pem"
   end
 
@@ -285,6 +289,14 @@ For further reading on signing gems see `ri Gem::Security`.
       sign cert_file
     end
   end
+
+  private
+
+  def valid_email? email
+    # It's simple, but is all we need
+    email =~ /\A.+@.+\z/
+  end
+
 
 end if defined?(OpenSSL::SSL)
 

--- a/test/rubygems/test_gem_commands_cert_command.rb
+++ b/test/rubygems/test_gem_commands_cert_command.rb
@@ -130,6 +130,28 @@ Added '/CN=alternate/DC=example'
     assert_path_exists File.join(@tempdir, 'gem-public_cert.pem')
   end
 
+  def test_execute_build_bad_email_address
+    passphrase = 'Foo bar'
+    email = "nobody@"
+
+    @cmd.handle_options %W[--build #{email}]
+
+    @build_ui = Gem::MockGemUi.new "#{passphrase}\n#{passphrase}"
+
+    use_ui @build_ui do
+
+      e = assert_raises Gem::CommandLineError do
+        @cmd.execute
+      end
+
+      assert_equal "Invalid email address #{email}",
+        e.message
+
+      refute_path_exists File.join(@tempdir, 'gem-private_key.pem')
+      refute_path_exists File.join(@tempdir, 'gem-public_cert.pem')
+    end
+  end
+
   def test_execute_build_expiration_days
     passphrase = 'Foo bar'
 


### PR DESCRIPTION
closes https://github.com/rubygems/rubygems/issues/1777
