### PR TITLE
No TypeError on dup

### DIFF
--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1260,7 +1260,7 @@ dependencies: []
       s.version = '1'
     end
 
-    spec.instance_variable_set :@licenses, Object.new.singleton_class
+    spec.instance_variable_set :@licenses, (class << (Object.new);self;end)
     spec.loaded_from = '/path/to/file'
 
     e = assert_raises Gem::FormatException do

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1260,7 +1260,7 @@ dependencies: []
       s.version = '1'
     end
 
-    spec.instance_variable_set :@licenses, :blah
+    spec.instance_variable_set :@licenses, Object.new.singleton_class
     spec.loaded_from = '/path/to/file'
 
     e = assert_raises Gem::FormatException do


### PR DESCRIPTION
# Description:

Special constants (`Integer`, `Symbol`, `true`, `false`, `nil`, etc) no longer raises a `TypeError` at `dup` since 2.4.
https://bugs.ruby-lang.org/issues/12979
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
