### PR TITLE
Improve error message when Gem::RuntimeRequirementNotMetError is raised

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -608,8 +608,9 @@ class Gem::Installer
   def ensure_required_ruby_version_met # :nodoc:
     if rrv = spec.required_ruby_version then
       unless rrv.satisfied_by? Gem.ruby_version then
+        ruby_version = Gem.ruby_api_version
         raise Gem::RuntimeRequirementNotMetError,
-          "#{spec.name} requires Ruby version #{rrv}."
+          "#{spec.name} requires Ruby version #{rrv}. The current ruby version is #{ruby_version}."
       end
     end
   end
@@ -617,8 +618,9 @@ class Gem::Installer
   def ensure_required_rubygems_version_met # :nodoc:
     if rrgv = spec.required_rubygems_version then
       unless rrgv.satisfied_by? Gem.rubygems_version then
+        rg_version = Gem::VERSION
         raise Gem::RuntimeRequirementNotMetError,
-          "#{spec.name} requires RubyGems version #{rrgv}. " +
+          "#{spec.name} requires RubyGems version #{rrgv}. The current RubyGems version is #{rg_version}. " +
           "Try 'gem update --system' to update RubyGems itself."
       end
     end

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1419,7 +1419,8 @@ gem 'other', version
       e = assert_raises Gem::RuntimeRequirementNotMetError do
         installer.pre_install_checks
       end
-      assert_equal 'old_ruby_required requires Ruby version = 1.4.6.',
+      rv = Gem.ruby_api_version
+      assert_equal "old_ruby_required requires Ruby version = 1.4.6. The current ruby version is #{rv}.",
                    e.message
     end
   end
@@ -1438,7 +1439,8 @@ gem 'other', version
       e = assert_raises Gem::RuntimeRequirementNotMetError do
         @installer.pre_install_checks
       end
-      assert_equal 'old_rubygems_required requires RubyGems version < 0. ' +
+      rgv = Gem::VERSION
+      assert_equal "old_rubygems_required requires RubyGems version < 0. The current RubyGems version is #{rgv}. " +
         "Try 'gem update --system' to update RubyGems itself.", e.message
     end
   end


### PR DESCRIPTION
# Description:

This will show the current Ruby version and RubyGems version accordingly when a `Gem::RuntimeRequirementNotMetError` is raised.

closes https://github.com/rubygems/rubygems/issues/1786
