### PR TITLE
Don't output mkmf.log message if compilation didn't fail

### DIFF
--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -48,9 +48,11 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
           run cmd, results
         ensure
           if File.exist? 'mkmf.log'
-            results << "To see why this extension failed to compile, please check" \
-              " the mkmf.log which can be found here:\n"
-            results << "  " + File.join(dest_path, 'mkmf.log') + "\n"
+            unless $?.success? then
+              results << "To see why this extension failed to compile, please check" \
+                " the mkmf.log which can be found here:\n"
+              results << "  " + File.join(dest_path, 'mkmf.log') + "\n"
+            end
             FileUtils.mv 'mkmf.log', dest_path
           end
           siteconf.unlink

--- a/test/rubygems/test_gem_ext_ext_conf_builder.rb
+++ b/test/rubygems/test_gem_ext_ext_conf_builder.rb
@@ -111,6 +111,29 @@ class TestGemExtExtConfBuilder < Gem::TestCase
 
     assert_match(/^#{Gem.ruby}.* extconf.rb/, output[1])
     assert_match(File.join(@dest_path, 'mkmf.log'), output[4])
+    assert_includes(output, "To see why this extension failed to compile, please check the mkmf.log which can be found here:\n")
+
+    assert_path_exists File.join @dest_path, 'mkmf.log'
+  end
+
+  def test_class_build_extconf_success_without_warning
+    if vc_windows? && !nmake_found?
+      skip("test_class_build_extconf_fail skipped - nmake not found")
+    end
+
+    File.open File.join(@ext, 'extconf.rb'), 'w' do |extconf|
+      extconf.puts "require 'mkmf'"
+      extconf.puts "File.open('mkmf.log', 'w'){|f| f.write('a')}"
+      extconf.puts "create_makefile 'foo'"
+    end
+
+    output = []
+
+    Dir.chdir @ext do
+      Gem::Ext::ExtConfBuilder.build 'extconf.rb', nil, @dest_path, output
+    end
+
+    refute_includes(output, "To see why this extension failed to compile, please check the mkmf.log which can be found here:\n")
 
     assert_path_exists File.join @dest_path, 'mkmf.log'
   end


### PR DESCRIPTION
# Description:

The presence of mkmf.log does not signal failure, the return code
does.  Before this commit, if compilation succeeded but produced
a mkmf.log, the output indicates that compilation failed, which is
quite confusing.

# Tasks:

- [X] Describe the problem / feature
- [X] Write tests
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
