### PR TITLE
Fix for `--enable-load-relative`

### DIFF
--- a/test/rubygems/test_gem_commands_pristine_command.rb
+++ b/test/rubygems/test_gem_commands_pristine_command.rb
@@ -110,6 +110,8 @@ class TestGemCommandsPristineCommand < Gem::TestCase
 
     if win_platform?
       assert_match %r%\A#!\s*#{ruby_exec}%, File.read(gem_exec)
+    elsif RbConfig::CONFIG['LIBRUBY_RELATIVE'] == 'yes'
+      assert_match %r%\A#!\s*/bin/sh\n.*/#{ruby_exec}%, File.read(gem_exec)
     else
       assert_match %r%\A#!\s*/usr/bin/env #{ruby_exec}%, File.read(gem_exec)
     end

--- a/test/rubygems/test_gem_dependency_installer.rb
+++ b/test/rubygems/test_gem_dependency_installer.rb
@@ -602,6 +602,8 @@ class TestGemDependencyInstaller < Gem::TestCase
   end
 
   def test_install_env_shebang
+    return if RbConfig::CONFIG['LIBRUBY_RELATIVE'] == 'yes'
+
     util_setup_gems
 
     FileUtils.mv @a1_gem, @tempdir

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -17,6 +17,16 @@ class TestGemInstaller < Gem::InstallerTestCase
     @@symlink_supported
   end
 
+  @@libruby_relative = nil
+
+  def libruby_relative?
+    if @@libruby_relative.nil?
+      @@libruby_relative = RbConfig::CONFIG['LIBRUBY_RELATIVE'] == 'yes'
+    else
+      @@libruby_relative
+    end
+  end
+
   def setup
     super
     common_installer_setup
@@ -66,6 +76,7 @@ load Gem.activate_bin_path('a', 'executable', version)
     EOF
 
     wrapper = @installer.app_script_text 'executable'
+    wrapper = wrapper.sub(%r(\A#!/bin/sh\n(?:[^#\n].*\n)+), '')
     assert_equal expected, wrapper
   end
 
@@ -678,8 +689,14 @@ gem 'other', version
     @installer.generate_bin
 
     default_shebang = Gem.ruby
-    shebang_line = open("#{@gemhome}/bin/executable") { |f| f.readlines.first }
-    assert_match(/\A#!/, shebang_line)
+    lines = File.readlines("#{@gemhome}/bin/executable")
+    lines.first
+    assert_match(/\A#!/, lines.first)
+    if /\A#!\/bin\/sh(?!\S)/ =~ lines.first
+      begin lines.shift end until lines.empty? or /'exec'/ =~ lines.first
+      default_shebang = File.basename(default_shebang)
+    end
+    shebang_line = lines.first
     assert_match(/#{default_shebang}/, shebang_line)
   end
 
@@ -1450,7 +1467,7 @@ gem 'other', version
 
     shebang = @installer.shebang 'executable'
 
-    assert_equal "#!#{Gem.ruby}", shebang
+    assert_shebang %W"#{Gem.ruby}", shebang
   end
 
   def test_process_options
@@ -1474,14 +1491,14 @@ gem 'other', version
 
     shebang = @installer.shebang 'executable'
 
-    assert_equal "#!#{Gem.ruby} -ws", shebang
+    assert_shebang %W"#{Gem.ruby} -ws", shebang
   end
 
   def test_shebang_empty
     util_make_exec @spec, ''
 
     shebang = @installer.shebang 'executable'
-    assert_equal "#!#{Gem.ruby}", shebang
+    assert_shebang %W"#{Gem.ruby}", shebang
   end
 
   def test_shebang_env
@@ -1489,7 +1506,7 @@ gem 'other', version
 
     shebang = @installer.shebang 'executable'
 
-    assert_equal "#!#{Gem.ruby}", shebang
+    assert_shebang %W"#{Gem.ruby}", shebang
   end
 
   def test_shebang_env_arguments
@@ -1497,7 +1514,7 @@ gem 'other', version
 
     shebang = @installer.shebang 'executable'
 
-    assert_equal "#!#{Gem.ruby} -ws", shebang
+    assert_shebang %W"#{Gem.ruby} -ws", shebang
   end
 
   def test_shebang_env_shebang
@@ -1508,8 +1525,8 @@ gem 'other', version
 
     env_shebang = "/usr/bin/env" unless Gem.win_platform?
 
-    assert_equal("#!#{env_shebang} #{RbConfig::CONFIG['ruby_install_name']}",
-                 shebang)
+    assert_shebang(%W"#{env_shebang} #{RbConfig::CONFIG['ruby_install_name']}",
+                   shebang)
   end
 
   def test_shebang_nested
@@ -1517,7 +1534,7 @@ gem 'other', version
 
     shebang = @installer.shebang 'executable'
 
-    assert_equal "#!#{Gem.ruby}", shebang
+    assert_shebang %W"#{Gem.ruby}", shebang
   end
 
   def test_shebang_nested_arguments
@@ -1525,7 +1542,7 @@ gem 'other', version
 
     shebang = @installer.shebang 'executable'
 
-    assert_equal "#!#{Gem.ruby} -ws", shebang
+    assert_shebang %W"#{Gem.ruby} -ws", shebang
   end
 
   def test_shebang_version
@@ -1533,7 +1550,7 @@ gem 'other', version
 
     shebang = @installer.shebang 'executable'
 
-    assert_equal "#!#{Gem.ruby}", shebang
+    assert_shebang %W"#{Gem.ruby}", shebang
   end
 
   def test_shebang_version_arguments
@@ -1541,7 +1558,7 @@ gem 'other', version
 
     shebang = @installer.shebang 'executable'
 
-    assert_equal "#!#{Gem.ruby} -ws", shebang
+    assert_shebang %W"#{Gem.ruby} -ws", shebang
   end
 
   def test_shebang_version_env
@@ -1549,7 +1566,7 @@ gem 'other', version
 
     shebang = @installer.shebang 'executable'
 
-    assert_equal "#!#{Gem.ruby}", shebang
+    assert_shebang %W"#{Gem.ruby}", shebang
   end
 
   def test_shebang_version_env_arguments
@@ -1557,7 +1574,7 @@ gem 'other', version
 
     shebang = @installer.shebang 'executable'
 
-    assert_equal "#!#{Gem.ruby} -ws", shebang
+    assert_shebang %W"#{Gem.ruby} -ws", shebang
   end
 
   def test_shebang_custom
@@ -1766,5 +1783,23 @@ gem 'other', version
 
   def mask
     0100755 & (~File.umask)
+  end
+
+  def assert_shebang(expected, line)
+    line = line.sub(/\A#!\/bin\/sh(?:[ \t].*)?\n([^#\n].*\n|\n)+#!.*ruby\S*(\s.*)?/) do
+      opt = $2
+      bin = $1[/^'exec' "(\$\{0%\/\*\}\/)?(.*?)"/, 2]
+      if $1
+        ex = File.basename(expected[0])
+        if ex == "env"
+          ex = "#{expected[0]} "
+        else
+          expected[0] = ex
+          ex = ""
+        end
+      end
+      "#!#{ex}#{bin}#{opt}"
+    end
+    assert_equal("#!#{expected.join(' ')}", line)
   end
 end


### PR DESCRIPTION
# Description:

When configured with `--enable-load-relative`, the result ruby and libraries can be placed anywhere and the executable path is not known until running.

This behavior depends on the OS and the configuration, I leave it without a test.

______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
