### PR TITLE
RakeBuilder: avoid frozen string issue

### DIFF
--- a/lib/rubygems/ext/rake_builder.rb
+++ b/lib/rubygems/ext/rake_builder.rb
@@ -9,7 +9,7 @@ class Gem::Ext::RakeBuilder < Gem::Ext::Builder
 
   def self.build(extension, directory, dest_path, results, args=[], lib_dir=nil)
     if File.basename(extension) =~ /mkrf_conf/i then
-      cmd = "#{Gem.ruby} #{File.basename extension}"
+      cmd = "#{Gem.ruby} #{File.basename extension}".dup
       cmd << " #{args.join " "}" unless args.empty?
       run cmd, results
     end

--- a/test/rubygems/test_gem_ext_rake_builder.rb
+++ b/test/rubygems/test_gem_ext_rake_builder.rb
@@ -12,9 +12,9 @@ class TestGemExtRakeBuilder < Gem::TestCase
     FileUtils.mkdir_p @ext
     FileUtils.mkdir_p @dest_path
   end
-  
+
   def test_class_build
-    create_temp_mkrf_file!('task :default')
+    create_temp_mkrf_file('task :default')
     output = []
     realdir = nil # HACK /tmp vs. /private/tmp
 
@@ -36,7 +36,7 @@ class TestGemExtRakeBuilder < Gem::TestCase
   #
   # It should not fail with a non-empty args list either
   def test_class_build_with_args
-    create_temp_mkrf_file!('task :default')
+    create_temp_mkrf_file('task :default')
     output = []
     realdir = nil # HACK /tmp vs. /private/tmp
 
@@ -56,7 +56,7 @@ class TestGemExtRakeBuilder < Gem::TestCase
   end  
 
   def test_class_build_fail
-    create_temp_mkrf_file!("task :default do abort 'fail' end")
+    create_temp_mkrf_file("task :default do abort 'fail' end")
     output = []
 
     build_rake_in(false) do |rake|
@@ -70,7 +70,7 @@ class TestGemExtRakeBuilder < Gem::TestCase
     end
   end
   
-  def create_temp_mkrf_file!(rakefile_content)
+  def create_temp_mkrf_file(rakefile_content)
     File.open File.join(@ext, 'mkrf_conf.rb'), 'w' do |mkrf_conf|
       mkrf_conf.puts <<-EO_MKRF
         File.open("Rakefile","w") do |f|

--- a/test/rubygems/test_gem_ext_rake_builder.rb
+++ b/test/rubygems/test_gem_ext_rake_builder.rb
@@ -12,16 +12,9 @@ class TestGemExtRakeBuilder < Gem::TestCase
     FileUtils.mkdir_p @ext
     FileUtils.mkdir_p @dest_path
   end
-
+  
   def test_class_build
-    File.open File.join(@ext, 'mkrf_conf.rb'), 'w' do |mkrf_conf|
-      mkrf_conf.puts <<-EO_MKRF
-        File.open("Rakefile","w") do |f|
-          f.puts "task :default"
-        end
-      EO_MKRF
-    end
-
+    create_temp_mkrf_file!('task :default')
     output = []
     realdir = nil # HACK /tmp vs. /private/tmp
 
@@ -43,14 +36,7 @@ class TestGemExtRakeBuilder < Gem::TestCase
   #
   # It should not fail with a non-empty args list either
   def test_class_build_with_args
-    File.open File.join(@ext, 'mkrf_conf.rb'), 'w' do |mkrf_conf|
-      mkrf_conf.puts <<-EO_MKRF
-        File.open("Rakefile","w") do |f|
-          f.puts "task :default"
-        end
-      EO_MKRF
-    end
-
+    create_temp_mkrf_file!('task :default')
     output = []
     realdir = nil # HACK /tmp vs. /private/tmp
 
@@ -70,14 +56,7 @@ class TestGemExtRakeBuilder < Gem::TestCase
   end  
 
   def test_class_build_fail
-    File.open File.join(@ext, 'mkrf_conf.rb'), 'w' do |mkrf_conf|
-      mkrf_conf.puts <<-EO_MKRF
-        File.open("Rakefile","w") do |f|
-          f.puts "task :default do abort 'fail' end"
-        end
-      EO_MKRF
-    end
-
+    create_temp_mkrf_file!("task :default do abort 'fail' end")
     output = []
 
     build_rake_in(false) do |rake|
@@ -90,6 +69,14 @@ class TestGemExtRakeBuilder < Gem::TestCase
       assert_match %r%^rake failed%, error.message
     end
   end
-
+  
+  def create_temp_mkrf_file!(rakefile_content)
+    File.open File.join(@ext, 'mkrf_conf.rb'), 'w' do |mkrf_conf|
+      mkrf_conf.puts <<-EO_MKRF
+        File.open("Rakefile","w") do |f|
+          f.puts "#{rakefile_content}"
+        end
+      EO_MKRF
+    end
+  end
 end
-

--- a/test/rubygems/test_gem_ext_rake_builder.rb
+++ b/test/rubygems/test_gem_ext_rake_builder.rb
@@ -39,6 +39,36 @@ class TestGemExtRakeBuilder < Gem::TestCase
     end
   end
 
+  # https://github.com/rubygems/rubygems/pull/1819
+  #
+  # It should not fail with a non-empty args list either
+  def test_class_build_with_args
+    File.open File.join(@ext, 'mkrf_conf.rb'), 'w' do |mkrf_conf|
+      mkrf_conf.puts <<-EO_MKRF
+        File.open("Rakefile","w") do |f|
+          f.puts "task :default"
+        end
+      EO_MKRF
+    end
+
+    output = []
+    realdir = nil # HACK /tmp vs. /private/tmp
+
+    build_rake_in do |rake|
+      Dir.chdir @ext do
+        realdir = Dir.pwd
+        non_empty_args_list = ['']
+        Gem::Ext::RakeBuilder.build 'mkrf_conf.rb', nil, @dest_path, output, non_empty_args_list
+      end
+
+      output = output.join "\n"
+
+      refute_match %r%^rake failed:%, output
+      assert_match %r%^#{Regexp.escape @@ruby} mkrf_conf\.rb%, output
+      assert_match %r%^#{Regexp.escape rake} RUBYARCHDIR=#{Regexp.escape @dest_path} RUBYLIBDIR=#{Regexp.escape @dest_path}%, output
+    end
+  end  
+
   def test_class_build_fail
     File.open File.join(@ext, 'mkrf_conf.rb'), 'w' do |mkrf_conf|
       mkrf_conf.puts <<-EO_MKRF


### PR DESCRIPTION
# Description:

This PR adds a missing `#dup` ("convert frozen string literal to a mutable String object instance") in the same way that https://github.com/rubygems/rubygems/commit/45966be372d85520630143090b82b455d287cec6 did. 

The problem only appears when there're `args` to `.build`. To trigger this behavior, I duplicated a test and added a variable with a non-empty array of an empty string (to have benign test data).

**What it looks like without the fix**

Without this change, the user's failure will look like this:

```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
can't modify frozen String, created at
/home/travis/.rvm/rubies/jruby-9.1.7.0/lib/ruby/stdlib/rubygems/ext/rake_builder.rb:11
```

**Reproduce**

To reproduce the issue, write a `mkrf_conf.rb` which calls `build`. Here is an example `ext/mkrf_conf.rb` with a failing build: https://github.com/sickill/rainbow/blob/master/ext/mkrf_conf.rb

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
