### PR TITLE
[Require] Call #gem explicitly on Kernel

### DIFF
--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -43,7 +43,7 @@ module Kernel
 
     if spec = Gem.find_unresolved_default_spec(path)
       Gem.remove_unresolved_default_spec(spec)
-      gem(spec.name)
+      Kernel.send(:gem, spec.name)
     end
 
     # If there are no unresolved deps, then we can use just try

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -341,6 +341,31 @@ class TestGemRequire < Gem::TestCase
     Kernel::RUBYGEMS_ACTIVATION_MONITOR.exit
   end
 
+  def test_require_when_gem_defined
+    default_gem_spec = new_default_spec("default", "2.0.0.0",
+                                        nil, "default/gem.rb")
+    install_default_specs(default_gem_spec)
+    c = Class.new do
+      def self.gem(*args)
+        raise "received #gem with #{args.inspect}"
+      end
+    end
+    assert c.send(:require, "default/gem")
+    assert_equal %w(default-2.0.0.0), loaded_spec_names
+  end
+
+  def test_require_default_when_gem_defined
+    a = new_spec("a", "1", nil, "lib/a.rb")
+    install_specs a
+    c = Class.new do
+      def self.gem(*args)
+        raise "received #gem with #{args.inspect}"
+      end
+    end
+    assert c.send(:require, "a")
+    assert_equal %w(a-1), loaded_spec_names
+  end
+
   def silence_warnings
     old_verbose, $VERBOSE = $VERBOSE, false
     yield


### PR DESCRIPTION
# Description:

This avoids conflicts if #gem happens to be defined on self
Inspired by https://github.com/bundler/bundler/issues/5346

My one concern is that this _could_ be considered a breaking change if anyone is relying on overriding our `gem` method

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).