### PR TITLE
Use Hash#fetch instead of if/else in Gem::ConfigFile

### DIFF
--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -415,31 +415,11 @@ if you believe they were disclosed to a third party.
   # to_yaml only overwrites things you can't override on the command line.
   def to_yaml # :nodoc:
     yaml_hash = {}
-    yaml_hash[:backtrace] = if @hash.key?(:backtrace)
-                              @hash[:backtrace]
-                            else
-                              DEFAULT_BACKTRACE
-                            end
-
-    yaml_hash[:bulk_threshold] = if @hash.key?(:bulk_threshold)
-                                   @hash[:bulk_threshold]
-                                 else
-                                   DEFAULT_BULK_THRESHOLD
-                                 end
-
+    yaml_hash[:backtrace] = @hash.fetch(:backtrace, DEFAULT_BACKTRACE)
+    yaml_hash[:bulk_threshold] = @hash.fetch(:bulk_threshold, DEFAULT_BULK_THRESHOLD)
     yaml_hash[:sources] = Gem.sources.to_a
-
-    yaml_hash[:update_sources] = if @hash.key?(:update_sources)
-                                   @hash[:update_sources]
-                                 else
-                                   DEFAULT_UPDATE_SOURCES
-                                 end
-
-    yaml_hash[:verbose] = if @hash.key?(:verbose)
-                            @hash[:verbose]
-                          else
-                            DEFAULT_VERBOSITY
-                          end
+    yaml_hash[:update_sources] = @hash.fetch(:update_sources, DEFAULT_UPDATE_SOURCES)
+    yaml_hash[:verbose] = @hash.fetch(:verbose, DEFAULT_VERBOSITY)
 
     yaml_hash[:ssl_verify_mode] =
       @hash[:ssl_verify_mode] if @hash.key? :ssl_verify_mode


### PR DESCRIPTION
Minor refactoring to use Hash#fetch with default values instead of if/else blocks in the Gem::ConfigFile class.

Addresses https://github.com/rubygems/rubygems/issues/1813