### PR TITLE
Setup cmd: Avoid terminating option string w/ dot

### DIFF
--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -47,7 +47,7 @@ class Gem::Commands::SetupCommand < Gem::Command
     end
 
     add_option '--[no-]document [TYPES]', Array,
-               'Generate documentation for RubyGems.',
+               'Generate documentation for RubyGems',
                'List the documentation types you wish to',
                'generate.  For example: rdoc,ri' do |value, options|
       options[:document] = case value


### PR DESCRIPTION
# Description:

This PR formats the documentation string for the option `--[no-]document` of the not-so user-facing `SetupCommand`.

None of the other short option strings end in a dot.

______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
