### PR TITLE
Gem::Requirement.create treat arguments as variable-length

### DIFF
--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -51,7 +51,11 @@ class Gem::Requirement
   # If the input is "weird", the default version requirement is
   # returned.
 
-  def self.create input
+  def self.create *inputs
+    return create inputs if inputs.length > 1
+
+    input = inputs.shift
+
     case input
     when Gem::Requirement then
       input

--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -52,7 +52,7 @@ class Gem::Requirement
   # returned.
 
   def self.create *inputs
-    return create inputs if inputs.length > 1
+    return new inputs if inputs.length > 1
 
     input = inputs.shift
 

--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -33,6 +33,7 @@ class TestGemRequirement < Gem::TestCase
   def test_create
     assert_equal req("= 1"), Gem::Requirement.create("= 1")
     assert_equal req(">= 1.2", "<= 1.3"), Gem::Requirement.create([">= 1.2", "<= 1.3"])
+    assert_equal req(">= 1.2", "<= 1.3"), Gem::Requirement.create(">= 1.2", "<= 1.3")
   end
 
   def test_empty_requirements_is_none

--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -30,6 +30,11 @@ class TestGemRequirement < Gem::TestCase
     assert_requirement_equal "= 2", v(2)
   end
 
+  def test_create
+    assert_equal req("= 1"), Gem::Requirement.create("= 1")
+    assert_equal req(">= 1.2", "<= 1.3"), Gem::Requirement.create([">= 1.2", "<= 1.3"])
+  end
+
   def test_empty_requirements_is_none
     r = Gem::Requirement.new
     assert_equal true, r.none?


### PR DESCRIPTION
# Description:

This PR enables `Gem::Requirement.create` to treat arguments as variable-length.

Now, we can write only
```ruby
Gem::Requirement.create([">= 1.2", "<= 1.3"])
```

New style will be supported
```ruby
Gem::Requirement.create(">= 1.2", "<= 1.3")
```
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
