### PR TITLE
Added option to search command to output in JSON

### DIFF
--- a/test/rubygems/test_gem_commands_query_command.rb
+++ b/test/rubygems/test_gem_commands_query_command.rb
@@ -684,6 +684,20 @@ coolgem (4.2.1)
     assert_equal expected, @ui.output
   end
 
+  def test_execute_json
+    require 'json'
+
+    @cmd.handle_options %w[--remote --exact --json-output cocoapods]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    json_output = JSON.parse @ui.output
+
+    assert_equal json_output[:name], "cocoapods"
+  end
+
   private
 
   def add_gems_to_fetcher


### PR DESCRIPTION
# Description:
I added an option to query_command to output results as JSON.

Why?

I am spawning a child process in my code, and needed the output from `gem search` to stdout to be JSON parsable.

______________

# Tasks:

- [x ] Describe the problem / feature
- [ x] Write tests
- [ x] Write code to solve the problem
- [x ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
