### PR TITLE
Validate metadata link keys

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -455,9 +455,22 @@ class Gem::Specification < Gem::BasicSpecification
   #   bytes
   # * All strings must be UTF-8, no binary data is allowed
   #
-  # To add metadata for the location of a issue tracker:
+  # You can use metadata to specify links to your gem's homepage, codebase,
+  # documentation, wiki, mailing list and issue tracker.
   #
-  #   s.metadata = { "issue_tracker" => "https://example/issues" }
+  #   s.metadata = {
+  #     "home" => "https://bestgemever.example.io",
+  #     "code" => "https://example.com/user/bestgemever",
+  #     "docs" => "https://www.example.info/gems/bestgemever/0.0.1",
+  #     "wiki" => "https://example.com/user/bestgemever/wiki",
+  #     "mail" => "https://groups.example.com/bestgemever",
+  #     "bugs" => "https://example.com/user/bestgemever/issues"
+  #   }
+  #
+  # These links will be used on your gem's page on rubygems.org and must pass
+  # validation against following regex.
+  #
+  #   %r{\Ahttps?:\/\/([^\s:@]+:[^\s:@]*@)?[A-Za-z\d\-]+(\.[A-Za-z\d\-]+)+\.?(:\d{1,5})?([\/?]\S*)?\z}
 
   attr_accessor :metadata
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2756,29 +2756,7 @@ class Gem::Specification < Gem::BasicSpecification
               'metadata must be a hash'
     end
 
-    metadata.keys.each do |k|
-      if !k.kind_of?(String)
-        raise Gem::InvalidSpecificationException,
-                'metadata keys must be a String'
-      end
-
-      if k.size > 128
-        raise Gem::InvalidSpecificationException,
-                "metadata key too large (#{k.size} > 128)"
-      end
-    end
-
-    metadata.values.each do |k|
-      if !k.kind_of?(String)
-        raise Gem::InvalidSpecificationException,
-                'metadata values must be a String'
-      end
-
-      if k.size > 1024
-        raise Gem::InvalidSpecificationException,
-                "metadata value too large (#{k.size} > 1024)"
-      end
-    end
+    validate_metadata
 
     licenses.each { |license|
       if license.length > 64
@@ -2862,6 +2840,40 @@ http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard li
   ensure
     if $! or @warnings > 0 then
       alert_warning "See http://guides.rubygems.org/specification-reference/ for help"
+    end
+  end
+
+  def validate_metadata
+    url_validation_regex = %r{\Ahttps?:\/\/([^\s:@]+:[^\s:@]*@)?[A-Za-z\d\-]+(\.[A-Za-z\d\-]+)+\.?(:\d{1,5})?([\/?]\S*)?\z}
+    link_keys = ["home", "code", "docs", "wiki", "mail", "bugs"]
+
+    metadata.each do|key, value|
+      if !key.kind_of?(String)
+        raise Gem::InvalidSpecificationException,
+                "metadata keys must be a String"
+      end
+
+      if key.size > 128
+        raise Gem::InvalidSpecificationException,
+                "metadata key too large (#{key.size} > 128)"
+      end
+
+      if !value.kind_of?(String)
+        raise Gem::InvalidSpecificationException,
+                "metadata values must be a String"
+      end
+
+      if value.size > 1024
+        raise Gem::InvalidSpecificationException,
+                "metadata value too large (#{value.size} > 1024)"
+      end
+
+      if link_keys.include? key
+        if value !~ url_validation_regex
+          raise Gem::InvalidSpecificationException,
+                 "metadata['#{key}'] has invalid link: #{value.inspect}"
+        end
+      end
     end
   end
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3251,7 +3251,7 @@ Did you mean 'Ruby'?
     Dir.chdir @tempdir do
       @m1 = quick_gem 'm', '1' do |s|
         s.files = %w[lib/code.rb]
-        s.metadata = { 'one' => "two", 'two' => "three" }
+        s.metadata = { "one" => "two", "home" => "https://example.com/user/repo"  }
       end
 
       use_ui @ui do
@@ -3325,6 +3325,23 @@ Did you mean 'Ruby'?
       end
 
       assert_equal "metadata value too large (1025 > 1024)", e.message
+    end
+  end
+
+  def test_metadata_link_validation_fails
+    util_setup_validate
+
+    Dir.chdir @tempdir do
+      @m2 = quick_gem 'm', '2' do |s|
+        s.files = %w[lib/code.rb]
+        s.metadata = { 'home' => 'http:/example.com' }
+      end
+
+      e = assert_raises Gem::InvalidSpecificationException do
+        @m2.validate
+      end
+
+      assert_equal "metadata['home'] has invalid link: \"http:/example.com\"", e.message
     end
   end
 


### PR DESCRIPTION
# Description:

We intend to deprecate form used to edit linkset of gems. Metadata will be the only way to specify homepage, codebase, documentation, wiki, mailing list and issue tracker urls.

Related: https://github.com/rubygems/rubygems.org/pull/1234
https://github.com/rubygems/rubygems.org/pull/1557
# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
