### PR TITLE
Fix typos with misspell

### DIFF
--- a/CONTRIBUTING.rdoc
+++ b/CONTRIBUTING.rdoc
@@ -64,9 +64,9 @@ which describes the type of the issue or pull request.
 * *cleanup* - Generally for a pull request that improves the code base without
   fixing a bug or implementing a feature.
 * <b>major bump</b> - This issue or pull request requires a major version bump
-* *administrative* - This issue relates to adminstrative tasks that need to
+* *administrative* - This issue relates to administrative tasks that need to
   take place as it relates to rubygems
-* *documentation* - This issue relates to improving the documenation for
+* *documentation* - This issue relates to improving the documentation for
   in this repo. Note that much of the rubygems documentation is here:
   https://github.com/rubygems/guides
 

--- a/History.txt
+++ b/History.txt
@@ -2370,7 +2370,7 @@ http://rubygems.org is now the default source for downloading gems.
 You may have sources set via ~/.gemrc, so you should replace
 http://gems.rubyforge.org with http://rubygems.org
 
-http://gems.rubyforge.org will continue to work for the forseeable future.
+http://gems.rubyforge.org will continue to work for the foreseeable future.
 
 New features:
 
@@ -2415,12 +2415,12 @@ New features:
   * `gem server` now supports --bind.  Patch #27357 by Bruno Michel.
   * `gem rdoc` no longer overwrites built documentation.  Use --overwrite
     force rebuilding.  Patch #25982 by Akinori MUSHA.
-* Captial letters are now allowed in prerelease versions.
+* Capital letters are now allowed in prerelease versions.
 
 Bug fixes:
 
 * Development deps are no longer added to rubygems-update gem so older
-  versions can update sucessfully.
+  versions can update successfully.
 * Installer bugs:
   * Prerelease gems can now depend on non-prerelease gems.
   * Development dependencies are ignored unless explicitly needed.  Bug #27608
@@ -2840,7 +2840,7 @@ Major New Features Include:
 * Bulk update threshold can be specified (-B, --bulk-threshold)
 * New `gem fetch` command
 * `gem` now has "really verbose" output when you specify -v
-* Improved stubs and `gem.bat` on mswin, including better compatiblity
+* Improved stubs and `gem.bat` on mswin, including better compatibility
   with the One-Click Installer.
 
 Other Changes Include:
@@ -2903,7 +2903,7 @@ Bug Fixes Include:
 * The source cache files may now be dropped with the "gem sources
   --clear-all" command.  (This command may require root is the system
   source cache is in a root protected area).
-* Several sub-commands were accidently dropped from the "gem" command.
+* Several sub-commands were accidentally dropped from the "gem" command.
   These commands have been restored.
 
 === 0.9.3 / 2007-05-10
@@ -2913,7 +2913,7 @@ Bug Fixes Include:
 The ZLib library on Windows will occasionally complains about a buffer error
 when unpacking gems.  The Gems software has a workaround for that problem, but
 the workaround was only enabled for versions of ZLib 1.2.1 or earlier.  We
-have received several reports of the error occuring with ZLib 1.2.3, so we
+have received several reports of the error occurring with ZLib 1.2.3, so we
 have permanently enabled the work around on all versions.
 
 === 0.9.2 / 2007-02-05
@@ -2954,7 +2954,7 @@ Major Enhancments include:
 
 Minor enhancements include:
 
-* Verison 0.0.0 is now a valid gem version.
+* Version 0.0.0 is now a valid gem version.
 * Better detection of missing SSL functionality.
 * SSL is not required if the security policy does not require
   signature checking.
@@ -2973,7 +2973,7 @@ Bug Fixes:
 * Fixed bug where the wrong executables could be uninstalled (Eric
   Hodel).
 * Fixed bug where gem unpack occasionally unpacked the wrong gem.
-* Fixed bug where a fatal error occured when permissions on .gemrc
+* Fixed bug where a fatal error occurred when permissions on .gemrc
   were too restrictive (reported by Luca Pireddu).
 * Fixed prefix handling for native expressions (patch by Aaron Patterson).
 * Fixed several Upgrade => Update typos.
@@ -2999,7 +2999,7 @@ Bug Fixes:
 
 === 0.8.10 / 2005-03-27
 
-* In multi-user environments, it is common to supply mulitple versions of gems
+* In multi-user environments, it is common to supply multiple versions of gems
   (for example Rails), allowing individual users to select the version of the
   gem they desire.  This allows a user to be insulated from updates to that
   gem.  RubyGems 0.8.10 fixes a problem where gems could occasionally become
@@ -3221,7 +3221,7 @@ See ChangeLog
 
 === 0.4.0 / 2004-05-30
 
-* Minor bug fixes including Windows compatability issues
+* Minor bug fixes including Windows compatibility issues
 
 === 0.3.0 / 2004-04-30
 

--- a/POLICIES.rdoc
+++ b/POLICIES.rdoc
@@ -32,7 +32,7 @@ receive any updates.
 Security releases will be made for RubyGems version series that were included
 in a Ruby release.
 
-For example, RubyGems 2.0.x will recieve security fixes until Ruby 2.0.0
+For example, RubyGems 2.0.x will receive security fixes until Ruby 2.0.0
 reaches end-of-life.
 
 == Release Policies

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -1346,7 +1346,7 @@ Also, a list:
   end
 
   ##
-  # create_gemspec creates gem specification in given +direcotry+ or '.'
+  # create_gemspec creates gem specification in given +directory+ or '.'
   # for the given +name+ and +version+.
   #
   # Yields the +specification+ to the block, if given


### PR DESCRIPTION
# Description:

Fixed typo used [misspell](https://github.com/client9/misspell/)

I found another typo in `lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/vertex.rb`. It should be fixed upstream repo. I send pull request.

https://github.com/CocoaPods/Molinillo/pull/61

______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
