### PR TITLE
Fix broken --exact parameter to gem command

### DIFF
--- a/lib/rubygems/commands/query_command.rb
+++ b/lib/rubygems/commands/query_command.rb
@@ -86,7 +86,7 @@ is too hard to use.
       name = Array(options[:name])
     else
       args = options[:args].to_a
-      name = options[:exact] ? args : args.map{|arg| /#{arg}/i }
+      name = options[:exact] ? args.map{|arg| /\A#{Regexp.escape(arg)}\Z/ } : args.map{|arg| /#{arg}/i }
     end
 
     prerelease = options[:prerelease]

--- a/test/rubygems/test_gem_commands_query_command.rb
+++ b/test/rubygems/test_gem_commands_query_command.rb
@@ -661,7 +661,7 @@ pl (1)
     assert_equal expected, @ui.output
   end
 
-  def test_execute_exact
+  def test_execute_exact_remote
     spec_fetcher do |fetcher|
       fetcher.spec 'coolgem-omg', 3
       fetcher.spec 'coolgem', '4.2.1'
@@ -679,6 +679,60 @@ pl (1)
 *** REMOTE GEMS ***
 
 coolgem (4.2.1)
+    EOF
+
+    assert_equal expected, @ui.output
+  end
+
+  def test_execute_exact_local
+    spec_fetcher do |fetcher|
+      fetcher.spec 'coolgem-omg', 3
+      fetcher.spec 'coolgem', '4.2.1'
+      fetcher.spec 'wow_coolgem', 1
+    end
+
+    @cmd.handle_options %w[--exact coolgem]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    expected = <<-EOF
+
+*** LOCAL GEMS ***
+
+coolgem (4.2.1)
+    EOF
+
+    assert_equal expected, @ui.output
+  end
+
+  def test_execute_exact_multiple
+    spec_fetcher do |fetcher|
+      fetcher.spec 'coolgem-omg', 3
+      fetcher.spec 'coolgem', '4.2.1'
+      fetcher.spec 'wow_coolgem', 1
+
+      fetcher.spec 'othergem-omg', 3
+      fetcher.spec 'othergem', '1.2.3'
+      fetcher.spec 'wow_othergem', 1
+    end
+
+    @cmd.handle_options %w[--exact coolgem othergem]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    expected = <<-EOF
+
+*** LOCAL GEMS ***
+
+coolgem (4.2.1)
+
+*** LOCAL GEMS ***
+
+othergem (1.2.3)
     EOF
 
     assert_equal expected, @ui.output


### PR DESCRIPTION
# Description:

Before this patch `gem list --exact` fails with the following error:

    > gem list --exact aws-sdk

    *** LOCAL GEMS ***

    ERROR:  While executing gem ... (TypeError)
        type mismatch: String given

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
