### PR TITLE
Fix gem open to open highest version number rather than lowest

### DIFF
--- a/lib/rubygems/commands/open_command.rb
+++ b/lib/rubygems/commands/open_command.rb
@@ -72,7 +72,7 @@ class Gem::Commands::OpenCommand < Gem::Command
   end
 
   def spec_for name
-    spec = Gem::Specification.find_all_by_name(name, @version).last
+    spec = Gem::Specification.find_all_by_name(name, @version).first
 
     return spec if spec
 

--- a/test/rubygems/test_gem_commands_open_command.rb
+++ b/test/rubygems/test_gem_commands_open_command.rb
@@ -24,7 +24,8 @@ class TestGemCommandsOpenCommand < Gem::TestCase
     @cmd.options[:args] = %w[foo]
     @cmd.options[:editor] = "#{Gem.ruby} -e0 --"
 
-    spec = gem 'foo'
+    gem 'foo', '1.0.0'
+    spec = gem 'foo', '1.0.1'
     mock = MiniTest::Mock.new
     mock.expect(:call, true, [spec.full_gem_path])
 


### PR DESCRIPTION
I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
