### PR TITLE
Fix pre-existing source recognition on add action

### DIFF
--- a/lib/rubygems/commands/sources_command.rb
+++ b/lib/rubygems/commands/sources_command.rb
@@ -44,7 +44,7 @@ class Gem::Commands::SourcesCommand < Gem::Command
     source = Gem::Source.new source_uri
 
     begin
-      if Gem.sources.include? source_uri then
+      if Gem.sources.include? source then
         say "source #{source_uri} already present in the cache"
       else
         source.load_specs :released

--- a/test/rubygems/test_gem_commands_sources_command.rb
+++ b/test/rubygems/test_gem_commands_sources_command.rb
@@ -109,29 +109,29 @@ source #{@gem_repo} already present in the cache
   end
 
   def test_execute_add_redundant_source_trailing_slash
-    # Remove pre-existing gem source
-    gem_repo1 = "http://gems.example.com/"
-    @cmd.handle_options %W[--remove #{gem_repo1}]
+    # Remove pre-existing gem source (w/ slash)
+    repo_with_slash = "http://gems.example.com/"
+    @cmd.handle_options %W[--remove #{repo_with_slash}]
     use_ui @ui do
       @cmd.execute
     end
-    source = Gem::Source.new gem_repo1
+    source = Gem::Source.new repo_with_slash
     assert_equal false, Gem.sources.include?(source)
 
     expected = <<-EOF
-#{gem_repo1} removed from sources
+#{repo_with_slash} removed from sources
     EOF
 
     assert_equal expected, @ui.output
     assert_equal '', @ui.error
 
     # Re-add pre-existing gem source (w/o slash)
-    gem_repo1 = "http://gems.example.com"
-    @cmd.handle_options %W[--add #{gem_repo1}]
+    repo_without_slash = "http://gems.example.com"
+    @cmd.handle_options %W[--add #{repo_without_slash}]
     use_ui @ui do
       @cmd.execute
     end
-    source = Gem::Source.new gem_repo1
+    source = Gem::Source.new repo_without_slash
     assert_equal true, Gem.sources.include?(source)
 
     expected = <<-EOF
@@ -142,13 +142,12 @@ http://gems.example.com added to sources
     assert_equal expected, @ui.output
     assert_equal '', @ui.error
 
-    # Re-add pre-existing gem source (w/ slash)
-    gem_repo1 = "http://gems.example.com/"
-    @cmd.handle_options %W[--add #{gem_repo1}]
+    # Re-add original gem source (w/ slash)
+    @cmd.handle_options %W[--add #{repo_with_slash}]
     use_ui @ui do
       @cmd.execute
     end
-    source = Gem::Source.new gem_repo1
+    source = Gem::Source.new repo_with_slash
     assert_equal true, Gem.sources.include?(source)
 
     expected = <<-EOF

--- a/test/rubygems/test_gem_commands_sources_command.rb
+++ b/test/rubygems/test_gem_commands_sources_command.rb
@@ -108,6 +108,59 @@ source #{@gem_repo} already present in the cache
     assert_equal '', @ui.error
   end
 
+  def test_execute_add_redundant_source_trailing_slash
+    # Remove pre-existing gem source
+    gem_repo1 = "http://gems.example.com/"
+    @cmd.handle_options %W[--remove #{gem_repo1}]
+    use_ui @ui do
+      @cmd.execute
+    end
+    source = Gem::Source.new gem_repo1
+    assert_equal false, Gem.sources.include?(source)
+
+    expected = <<-EOF
+#{gem_repo1} removed from sources
+    EOF
+
+    assert_equal expected, @ui.output
+    assert_equal '', @ui.error
+
+    # Re-add pre-existing gem source (w/o slash)
+    gem_repo1 = "http://gems.example.com"
+    @cmd.handle_options %W[--add #{gem_repo1}]
+    use_ui @ui do
+      @cmd.execute
+    end
+    source = Gem::Source.new gem_repo1
+    assert_equal true, Gem.sources.include?(source)
+
+    expected = <<-EOF
+http://gems.example.com/ removed from sources
+http://gems.example.com added to sources
+    EOF
+
+    assert_equal expected, @ui.output
+    assert_equal '', @ui.error
+
+    # Re-add pre-existing gem source (w/ slash)
+    gem_repo1 = "http://gems.example.com/"
+    @cmd.handle_options %W[--add #{gem_repo1}]
+    use_ui @ui do
+      @cmd.execute
+    end
+    source = Gem::Source.new gem_repo1
+    assert_equal true, Gem.sources.include?(source)
+
+    expected = <<-EOF
+http://gems.example.com/ removed from sources
+http://gems.example.com added to sources
+source http://gems.example.com/ already present in the cache
+    EOF
+
+    assert_equal expected, @ui.output
+    assert_equal '', @ui.error 
+  end
+
   def test_execute_add_http_rubygems_org
     http_rubygems_org = 'http://rubygems.org'
 


### PR DESCRIPTION
# Description:

I believe there is a bug in the sources command that prevents it from recognizing pre-existing sources when it's not an exact string match (trailing slash vs. non-trailing slash).

    $ gem sources
    *** CURRENT SOURCES ***
    https://rubygems.org/

**Current Behavior:**

    $ ruby -I lib ./bin/gem sources --add 'https://rubygems.org'
    https://rubygems.org added to sources

**Desired Behavior:**

    $ ruby -I lib ./bin/gem sources --add 'https://rubygems.org'
    source https://rubygems.org already present in the cache

I also believe the unit-tests which verify this functionality is broken, incomplete or mis-representing reality.  I looked at it briefly, but it might be worth having someone a little more familiar with the unit-tests to also take a peek at it.
______________

# Tasks:

- [X] Describe the problem / feature
- [x] Write tests
- [X] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
