### PR TITLE
Fix undefined method error when printing alert

### DIFF
--- a/lib/rubygems/commands/generate_index_command.rb
+++ b/lib/rubygems/commands/generate_index_command.rb
@@ -68,7 +68,7 @@ Marshal::MINOR_VERSION constants.  It is used to ensure compatibility.
 
     if not File.exist?(options[:directory]) or
        not File.directory?(options[:directory]) then
-      alert_error "unknown directory name #{directory}."
+      alert_error "unknown directory name #{options[:directory]}."
       terminate_interaction 1
     else
       indexer = Gem::Indexer.new options.delete(:directory), options


### PR DESCRIPTION
In the case a directory does not exist, this code would attempt to print an error but would fail because `directory` isn't a defined method or variable.

# Description:

When attempting to generate an index for a directory that doesn't exist, you'd get an exception like so:

```
$ gem generate_index --directory s3
ERROR:  While executing gem ... (NameError)
    undefined local variable or method `directory' for #<Gem::Commands::GenerateIndexCommand:0x007ff1b114eda8>
```

This makes the error alerting use the options hash to print the name instead of just failing
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
