### PR TITLE
Switch from docs to guides reference

### DIFF
--- a/lib/rubygems/server.rb
+++ b/lib/rubygems/server.rb
@@ -657,7 +657,7 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
       "only_one_executable" => true,
       "full_name" => "rubygems-#{Gem::VERSION}",
       "has_deps" => false,
-      "homepage" => "http://docs.rubygems.org/",
+      "homepage" => "http://guides.rubygems.org//",
       "name" => 'rubygems',
       "ri_installed" => true,
       "summary" => "RubyGems itself",

--- a/lib/rubygems/server.rb
+++ b/lib/rubygems/server.rb
@@ -657,7 +657,7 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
       "only_one_executable" => true,
       "full_name" => "rubygems-#{Gem::VERSION}",
       "has_deps" => false,
-      "homepage" => "http://guides.rubygems.org//",
+      "homepage" => "http://guides.rubygems.org/",
       "name" => 'rubygems',
       "ri_installed" => true,
       "summary" => "RubyGems itself",


### PR DESCRIPTION
# Description:

docs.rubygems.org is no longer a publicly resolvable DNS name, but there is code in RubyGems that still references this code.  It appears that guides.rubygems.org is it's successor, so I'm trading docs. for guides. in this PR.
______________

# Tasks:

- [X] Describe the problem / feature
- [x] Write tests (N/A)
- [X] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
