### PR TITLE
s/2048/3072

### DIFF
--- a/lib/rubygems/security.rb
+++ b/lib/rubygems/security.rb
@@ -462,7 +462,7 @@ module Gem::Security
 
   ##
   # Creates a new key pair of the specified +length+ and +algorithm+.  The
-  # default is a 2048 bit RSA key.
+  # default is a 3072 bit RSA key.
 
   def self.create_key length = KEY_LENGTH, algorithm = KEY_ALGORITHM
     algorithm.new length


### PR DESCRIPTION
# Description:

The default key is size is 3072 and not 2048 bits: https://github.com/rubygems/rubygems/commit/beee528b4f2387149b91bc14acbd499eca41aba4

______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
