### PR TITLE
Fix metadata link key names

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -459,13 +459,13 @@ class Gem::Specification < Gem::BasicSpecification
   # documentation, wiki, mailing list, issue tracker and changelog.
   #
   #   s.metadata = {
-  #     "home"      => "https://bestgemever.example.io",
-  #     "code"      => "https://example.com/user/bestgemever",
-  #     "docs"      => "https://www.example.info/gems/bestgemever/0.0.1",
-  #     "wiki"      => "https://example.com/user/bestgemever/wiki",
-  #     "mail"      => "https://groups.example.com/bestgemever",
-  #     "bugs"      => "https://example.com/user/bestgemever/issues",
-  #     "changelog" => "https://example.com/user/bestgemever/CHANGELOG.md"
+  #     "bug_tracker_uri"   => "https://example.com/user/bestgemever/issues",
+  #     "changelog_uri"     => "https://example.com/user/bestgemever/CHANGELOG.md",
+  #     "documentation_uri" => "https://www.example.info/gems/bestgemever/0.0.1",
+  #     "homepage_uri"      => "https://bestgemever.example.io",
+  #     "mailing_list_uri"  => "https://groups.example.com/bestgemever",
+  #     "source_code_uri"   => "https://example.com/user/bestgemever",
+  #     "wiki_uri"          => "https://example.com/user/bestgemever/wiki"
   #   }
   #
   # These links will be used on your gem's page on rubygems.org and must pass
@@ -2846,7 +2846,15 @@ http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard li
 
   def validate_metadata
     url_validation_regex = %r{\Ahttps?:\/\/([^\s:@]+:[^\s:@]*@)?[A-Za-z\d\-]+(\.[A-Za-z\d\-]+)+\.?(:\d{1,5})?([\/?]\S*)?\z}
-    link_keys = ["home", "code", "docs", "wiki", "mail", "bugs", "changelog"]
+    link_keys = %w(
+      bug_tracker_uri
+      changelog_uri
+      documentation_uri
+      homepage_uri
+      mailing_list_uri
+      source_code_uri
+      wiki_uri
+    )
 
     metadata.each do|key, value|
       if !key.kind_of?(String)

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3251,7 +3251,11 @@ Did you mean 'Ruby'?
     Dir.chdir @tempdir do
       @m1 = quick_gem 'm', '1' do |s|
         s.files = %w[lib/code.rb]
-        s.metadata = { "one" => "two", "home" => "https://example.com/user/repo"  }
+        s.metadata = {
+          "one"          => "two",
+          "home"         => "three",
+          "homepage_uri" => "https://example.com/user/repo"
+        }
       end
 
       use_ui @ui do
@@ -3334,14 +3338,14 @@ Did you mean 'Ruby'?
     Dir.chdir @tempdir do
       @m2 = quick_gem 'm', '2' do |s|
         s.files = %w[lib/code.rb]
-        s.metadata = { 'home' => 'http:/example.com' }
+        s.metadata = { 'homepage_uri' => 'http:/example.com' }
       end
 
       e = assert_raises Gem::InvalidSpecificationException do
         @m2.validate
       end
 
-      assert_equal "metadata['home'] has invalid link: \"http:/example.com\"", e.message
+      assert_equal "metadata['homepage_uri'] has invalid link: \"http:/example.com\"", e.message
     end
   end
 


### PR DESCRIPTION
# Description:

I had used incorrect names for metadata link keys. Related: https://github.com/rubygems/rubygems.org/pull/1234#issuecomment-294440420

Good thing it wasn't released with 2.6.11. Is there anything I can do to make sure that my commits are in next release? I need to update guides.
# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
