### PR TITLE
Add a test for requiring a default spec as installed by the ruby installer

### DIFF
--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -301,6 +301,17 @@ class TestGemRequire < Gem::TestCase
     assert_equal %w(default-2.0.0.0), loaded_spec_names
   end
 
+  def test_realworld_default_gem
+    skip "no default gems on ruby < 2.0" unless RUBY_VERSION >= "2"
+    cmd = <<-RUBY
+      $stderr = $stdout
+      require "json"
+      puts Gem.loaded_specs["json"].default_gem?
+    RUBY
+    output = Gem::Util.popen(Gem.ruby, "-e", cmd).strip
+    assert_equal "true", output
+  end
+
   def test_default_gem_and_normal_gem
     default_gem_spec = new_default_spec("default", "2.0.0.0",
                                         nil, "default/gem.rb")


### PR DESCRIPTION
# Description:

This tests the regression discussed in https://github.com/bundler/bundler/pull/5588, whereby default gems created by the ruby installer have no files and thus when required, the gem is not activated.

\c @hsbt 