### PR TITLE
Check ruby version by API version when requirements only use 2 digit version

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -607,7 +607,12 @@ class Gem::Installer
 
   def ensure_required_ruby_version_met # :nodoc:
     if rrv = spec.required_ruby_version then
-      unless rrv.satisfied_by? Gem.ruby_version then
+      if rrv.requirements.flatten.all?{|e| !e.is_a?(Gem::Version) || /^\d+\.\d+$/ =~ e.version}
+        ruby_version = Gem::Version.new(Gem.ruby_api_version)
+      else
+        ruby_version = Gem.ruby_version
+      end
+      unless rrv.satisfied_by? ruby_version then
         ruby_version = Gem.ruby_api_version
         raise Gem::RuntimeRequirementNotMetError,
           "#{spec.name} requires Ruby version #{rrv}. The current ruby version is #{ruby_version}."


### PR DESCRIPTION
# Description:

if `required_ruby_version` uses only 2 digit version numbers such as `[["<", "2.6"], [">=", "2.5"]]`, the numbers might means ruby API version.

This change fixes the problem that the development and/or pre-release versions of ruby cannot install any binary gems built with rake-compiler.
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
