### PR TITLE
Prevent negative IDs in output of #inspect.

### DIFF
--- a/lib/rubygems/dependency_list.rb
+++ b/lib/rubygems/dependency_list.rb
@@ -104,7 +104,7 @@ class Gem::DependencyList
   end
 
   def inspect # :nodoc:
-    "#<%s:0x%x %p>" % [self.class, object_id, map { |s| s.full_name }]
+    "%s %p>" % [super[0..-2], map { |s| s.full_name }]
   end
 
   ##

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -112,7 +112,7 @@ class Gem::Platform
   end
 
   def inspect
-    "#<%s:0x%x @cpu=%p, @os=%p, @version=%p>" % [self.class, object_id, *to_a]
+    "%s @cpu=%p, @os=%p, @version=%p>" % [super[0..-2], *to_a]
   end
 
   def to_a

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2125,7 +2125,7 @@ class Gem::Specification < Gem::BasicSpecification
     if $DEBUG
       super
     else
-      "#<#{self.class}:0x#{__id__.to_s(16)} #{full_name}>"
+      "#{super[0..-2]} #{full_name}>"
     end
   end
 


### PR DESCRIPTION
# Description:

object_id might be negative, since Ruby tries to avoid Bignums:

https://bugs.ruby-lang.org/issues/13397

