### PR TITLE
Allow Gem.finish_resolve to respect already-activated specs

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -234,6 +234,7 @@ module Gem
 
   def self.finish_resolve(request_set=Gem::RequestSet.new)
     request_set.import Gem::Specification.unresolved_deps.values
+    request_set.import Gem.loaded_specs.values.map {|s| Gem::Dependency.new(s.name, s.version) }
 
     request_set.resolve_current.each do |s|
       s.full_spec.activate

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -1510,6 +1510,8 @@ end
 begin
   gem 'rdoc'
   require 'rdoc'
+
+  require 'rubygems/rdoc'
 rescue LoadError, Gem::LoadError
 end
 
@@ -1526,3 +1528,4 @@ tmpdirs << (ENV['GEM_PATH'] = Dir.mktmpdir("path"))
 pid = $$
 END {tmpdirs.each {|dir| Dir.rmdir(dir)} if $$ == pid}
 Gem.clear_paths
+Gem.loaded_specs.clear

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -75,6 +75,29 @@ class TestGem < Gem::TestCase
     end
   end
 
+  def test_self_finish_resolve_respects_loaded_specs
+    save_loaded_features do
+      a1 = new_spec "a", "1", "b" => "> 0"
+      b1 = new_spec "b", "1", "c" => ">= 1"
+      b2 = new_spec "b", "2", "c" => ">= 2"
+      c1 = new_spec "c", "1"
+      c2 = new_spec "c", "2"
+
+      install_specs c1, c2, b1, b2, a1
+
+      a1.activate
+      c1.activate
+
+      assert_equal %w(a-1 c-1), loaded_spec_names
+      assert_equal ["b (> 0)"], unresolved_names
+
+      Gem.finish_resolve
+
+      assert_equal %w(a-1 b-1 c-1), loaded_spec_names
+      assert_equal [], unresolved_names
+    end
+  end
+
   def test_self_install
     spec_fetcher do |f|
       f.gem  'a', 1


### PR DESCRIPTION
# Description:

Previously, if a gem was already activated, `finish_resolve` wouldn't consider the activated dependency as a requirement, always leading to a hard error.
This makes finish_resolve work as you'd respect.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).