### PR TITLE
Modify the return value of Gem::Version.correct?

### DIFF
--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -170,7 +170,7 @@ class Gem::Version
   # True if the +version+ string matches RubyGems' requirements.
 
   def self.correct? version
-    version.to_s =~ ANCHORED_VERSION_PATTERN
+    ANCHORED_VERSION_PATTERN.match?(version.to_s)
   end
 
   ##

--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -170,7 +170,7 @@ class Gem::Version
   # True if the +version+ string matches RubyGems' requirements.
 
   def self.correct? version
-    ANCHORED_VERSION_PATTERN.match?(version.to_s)
+    !!(version.to_s =~ ANCHORED_VERSION_PATTERN)
   end
 
   ##

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -41,6 +41,11 @@ class TestGemVersion < Gem::TestCase
     assert_equal v('1.1'), Gem::Version.create(ver)
   end
 
+  def test_class_correct
+    assert Gem::Version.correct?("5.1")
+    refute Gem::Version.correct?("an incorrect version")
+  end
+
   def test_class_new_subclass
     v1 = Gem::Version.new '1'
     v2 = V.new '1'

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -42,8 +42,8 @@ class TestGemVersion < Gem::TestCase
   end
 
   def test_class_correct
-    assert Gem::Version.correct?("5.1")
-    refute Gem::Version.correct?("an incorrect version")
+    assert_equal true,  Gem::Version.correct?("5.1")
+    assert_equal false, Gem::Version.correct?("an incorrect version")
   end
 
   def test_class_new_subclass


### PR DESCRIPTION
Comes from https://github.com/ruby/ruby/pull/1605

# Description:

Before:

```ruby
Gem::Version.correct?("5.1") # => 0
Gem::Version.correct?("an incorrect version") # => nil
```

After:

```ruby
Gem::Version.correct?("5.1") # => true
Gem::Version.correct?("an incorrect version") # => false
```
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
