### PR TITLE
Add Travis and Appveyor build status to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RubyGems
+# RubyGems [![Travis Build Status](https://secure.travis-ci.org/rubygems/rubygems.svg?branch=master)](http://travis-ci.org/rubygems/rubygems) [![Appveyor Build Status](https://ci.appveyor.com/api/projects/status/github/rubygems/rubygems?branch=master&svg=true)](https://ci.appveyor.com/project/rubygems/rubygems?branch=master)
 
 RubyGems is a package management framework for Ruby.
 


### PR DESCRIPTION
# Description:

I added Travis and Appveyor build status to README.
Seeing those easily must be better to maintain `rubygems`.

I referred below gem packages for the README.
https://github.com/rspec/rspec-core/blob/master/README.md
https://github.com/sparklemotion/nokogiri/blob/master/README.md

You can check modified README here.
https://github.com/junaruga/rubygems/blob/feature/add-travis-badge/README.md

______________

# Tasks:

- [X] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
