### PR TITLE
Use Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ after_script:
 before_script:
 - util/ci before_script
 language: ruby
+dist: trusty
+sudo: required
 branches:
   only:
     - master


### PR DESCRIPTION
And explicitly require `sudo`.

# Description:

Move CI to Trusty.

# Tasks:

- [x] Describe the problem / feature

Due to a recent build image update of Precise image, 1.9.2 builds are currently broken. (https://github.com/travis-ci/travis-ci/issues/7743)
This PR aims to fix it.

- [x] Write tests

N/A

- [x] Write code to solve the problem

N/A

- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
