### PR TITLE
[InstallerSet] Avoid reloading _all_ local gems multiple times during dependency resolution

### DIFF
--- a/lib/rubygems/resolver/installer_set.rb
+++ b/lib/rubygems/resolver/installer_set.rb
@@ -41,6 +41,7 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
     @ignore_dependencies = false
     @ignore_installed    = false
     @local               = {}
+    @local_source        = Gem::Source::Local.new
     @remote_set          = Gem::Resolver::BestSet.new
     @specs               = {}
   end
@@ -136,13 +137,11 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
 
       res.concat matching_local
 
-      local_source = Gem::Source::Local.new
-
       begin
-        if local_spec = local_source.find_gem(name, dep.requirement) then
+        if local_spec = @local_source.find_gem(name, dep.requirement) then
           res << Gem::Resolver::IndexSpecification.new(
             self, local_spec.name, local_spec.version,
-            local_source, local_spec.platform)
+            @local_source, local_spec.platform)
         end
       rescue Gem::Package::FormatError
         # ignore
@@ -226,4 +225,3 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
   end
 
 end
-

--- a/lib/rubygems/source/local.rb
+++ b/lib/rubygems/source/local.rb
@@ -9,6 +9,7 @@ class Gem::Source::Local < Gem::Source
     @specs   = nil
     @api_uri = nil
     @uri     = nil
+    @load_specs_names = {}
   end
 
   ##
@@ -34,45 +35,47 @@ class Gem::Source::Local < Gem::Source
   end
 
   def load_specs type # :nodoc:
-    names = []
+    @load_specs_names[type] ||= begin
+      names = []
 
-    @specs = {}
+      @specs = {}
 
-    Dir["*.gem"].each do |file|
-      begin
-        pkg = Gem::Package.new(file)
-      rescue SystemCallError, Gem::Package::FormatError
-        # ignore
-      else
-        tup = pkg.spec.name_tuple
-        @specs[tup] = [File.expand_path(file), pkg]
-
-        case type
-        when :released
-          unless pkg.spec.version.prerelease?
-            names << pkg.spec.name_tuple
-          end
-        when :prerelease
-          if pkg.spec.version.prerelease?
-            names << pkg.spec.name_tuple
-          end
-        when :latest
-          tup = pkg.spec.name_tuple
-
-          cur = names.find { |x| x.name == tup.name }
-          if !cur
-            names << tup
-          elsif cur.version < tup.version
-            names.delete cur
-            names << tup
-          end
+      Dir["*.gem"].each do |file|
+        begin
+          pkg = Gem::Package.new(file)
+        rescue SystemCallError, Gem::Package::FormatError
+          # ignore
         else
-          names << pkg.spec.name_tuple
+          tup = pkg.spec.name_tuple
+          @specs[tup] = [File.expand_path(file), pkg]
+
+          case type
+          when :released
+            unless pkg.spec.version.prerelease?
+              names << pkg.spec.name_tuple
+            end
+          when :prerelease
+            if pkg.spec.version.prerelease?
+              names << pkg.spec.name_tuple
+            end
+          when :latest
+            tup = pkg.spec.name_tuple
+
+            cur = names.find { |x| x.name == tup.name }
+            if !cur
+              names << tup
+            elsif cur.version < tup.version
+              names.delete cur
+              names << tup
+            end
+          else
+            names << pkg.spec.name_tuple
+          end
         end
       end
-    end
 
-    names
+      names
+    end
   end
 
   def find_gem gem_name, version = Gem::Requirement.default, # :nodoc:


### PR DESCRIPTION
# Description:

Closes #1923. We now cache the local source in the installer set, and inside the local source cache the loaded specs. This allows us to avoid re-opening ever. single. `.gem` file. Every time we access a gem.



# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).