### PR TITLE
Fix a typo in uninstall_command.rb

### DIFF
--- a/lib/rubygems/commands/uninstall_command.rb
+++ b/lib/rubygems/commands/uninstall_command.rb
@@ -30,7 +30,7 @@ class Gem::Commands::UninstallCommand < Gem::Command
       options[:ignore] = value
     end
 
-    add_option('-D', '--[no-]-check-development',
+    add_option('-D', '--[no-]check-development',
                'Check development dependencies while uninstalling',
                '(default: false)') do |value, options|
       options[:check_dev] = value


### PR DESCRIPTION
# Description:
I modified `-check-development` to `check-development`.
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
