### PR TITLE
Code Improvement: Inheritance corrected

### DIFF
--- a/lib/rubygems/commands/signout_command.rb
+++ b/lib/rubygems/commands/signout_command.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 require 'rubygems/command'
-require 'rubygems/commands/query_command'
 
-class Gem::Commands::SignoutCommand < Gem::Commands::QueryCommand
+class Gem::Commands::SignoutCommand < Gem::Command
 
   def initialize
     super 'signout', 'Sign out from all the current sessions.'
-
-    remove_option('--name-matches')
   end
 
   def description # :nodoc:


### PR DESCRIPTION
# Description: 
Class inherited from `Gem::Commands::QueryCommand` here instead of `Gem::Command`. 

## Reason: 
I have copied code from another command file but forgot to change this portion of code. 

Thanks for point this out @simi.
______________

# Tasks:

- [x] Describe the problem / feature
- [] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
