### PR TITLE
Add command `signin` to `gem` CLI

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -274,6 +274,7 @@ lib/rubygems/commands/rdoc_command.rb
 lib/rubygems/commands/search_command.rb
 lib/rubygems/commands/server_command.rb
 lib/rubygems/commands/setup_command.rb
+lib/rubygems/commands/signin_command.rb
 lib/rubygems/commands/signout_command.rb
 lib/rubygems/commands/sources_command.rb
 lib/rubygems/commands/specification_command.rb
@@ -507,6 +508,7 @@ test/rubygems/test_gem_commands_query_command.rb
 test/rubygems/test_gem_commands_search_command.rb
 test/rubygems/test_gem_commands_server_command.rb
 test/rubygems/test_gem_commands_setup_command.rb
+test/rubygems/test_gem_commands_signin_command.rb
 test/rubygems/test_gem_commands_signout_command.rb
 test/rubygems/test_gem_commands_sources_command.rb
 test/rubygems/test_gem_commands_specification_command.rb

--- a/lib/rubygems/command_manager.rb
+++ b/lib/rubygems/command_manager.rb
@@ -58,6 +58,7 @@ class Gem::CommandManager
     :rdoc,
     :search,
     :server,
+    :signin,
     :signout,
     :sources,
     :specification,

--- a/lib/rubygems/commands/signin_command.rb
+++ b/lib/rubygems/commands/signin_command.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require 'rubygems/command'
+require 'rubygems/gemcutter_utilities'
+
+class Gem::Commands::SigninCommand < Gem::Command
+  include Gem::GemcutterUtilities
+
+  def initialize
+    super 'signin', 'Sign in to any gemcutter-compatible host. '\
+          'It defaults to https://rubygems.org'
+
+    add_option('--host HOST', 'Push to another gemcutter-compatible host') do |value, options|
+       options[:host] = value
+    end
+
+  end
+
+  def description # :nodoc:
+    'The signin command executes host sign in for a push server (the default is'\
+    ' https://rubygems.org). The host can be provided with the host flag or can'\
+    ' be inferred from the provided gem. Host resolution matches the resolution'\
+    ' strategy for the push command.'
+  end
+
+  def usage # :nodoc:
+    program_name
+  end
+
+  def execute
+    sign_in options[:host]
+  end
+
+end

--- a/test/rubygems/test_gem_commands_signin_command.rb
+++ b/test/rubygems/test_gem_commands_signin_command.rb
@@ -19,28 +19,61 @@ class TestGemCommandsSigninCommand < Gem::TestCase
     File.delete(credentials_path)  if File.exist?(credentials_path)
     super
   end
-
+  
   def test_execute_when_not_already_signed_in
     sign_in_ui = util_capture() { @cmd.execute }
     assert_match %r{Signed in.}, sign_in_ui.output
   end
 
+  def test_execute_when_already_signed_in_with_same_host
+    host            = 'http://some-gemcutter-compatible-host.org'
+    sign_in_ui      = util_capture(nil, host) { @cmd.execute }
+    old_credentials = YAML.load_file Gem.configuration.credentials_path
+    
+    sign_in_ui      = util_capture(nil, host) { @cmd.execute }
+    new_credentials = YAML.load_file Gem.configuration.credentials_path
+    
+    assert_equal old_credentials[host], new_credentials[host]    
+  end
+
+  def test_execute_when_already_signed_in_with_different_host
+    api_key     = 'a5fdbb6ba150cbb83aad2bb2fede64cf04045xxxx'
+    sign_in_ui  = util_capture(nil, nil, api_key) { @cmd.execute }
+    host        = 'http://some-gemcutter-compatible-host.org'
+    sign_in_ui  = util_capture(nil, host, api_key) { @cmd.execute }
+    credentials = YAML.load_file Gem.configuration.credentials_path
+
+    assert_equal credentials[:rubygems_api_key], api_key
+
+    assert_equal credentials[host], nil
+  end
+
   def test_execute_with_host_supplied
     host = 'http://some-gemcutter-compatible-host.org'
-    @cmd.options[:host] = host
 
     sign_in_ui = util_capture(nil, host) { @cmd.execute }
     assert_match %r{Enter your #{host} credentials.}, sign_in_ui.output
     assert_match %r{Signed in.}, sign_in_ui.output
+
+    api_key     = 'a5fdbb6ba150cbb83aad2bb2fede64cf040453903'
+    credentials = YAML.load_file Gem.configuration.credentials_path
+    assert_equal api_key, credentials[host]    
+  end
+  
+  def test_execute_with_valid_creds_set_for_default_host
+    util_capture {@cmd.execute}
+    api_key  = 'a5fdbb6ba150cbb83aad2bb2fede64cf040453903'
+    credentials = YAML.load_file Gem.configuration.credentials_path
+    assert_equal api_key, credentials[:rubygems_api_key]
   end
 
   # Utility method to capture IO/UI within the block passed
 
-  def util_capture ui_stub = nil, host = nil
-    api_key  = 'a5fdbb6ba150cbb83aad2bb2fede64cf040453903'
-    response = [api_key, 200, 'OK']
-    email    = 'you@example.com'
-    password = 'secret'
+  def util_capture ui_stub = nil, host = nil, api_key = nil
+    api_key ||= 'a5fdbb6ba150cbb83aad2bb2fede64cf040453903'
+    response  = [api_key, 200, 'OK']
+    email     = 'you@example.com'
+    password  = 'secret'
 
     ENV['RUBYGEMS_HOST'] = host || Gem::DEFAULT_HOST
 

--- a/test/rubygems/test_gem_commands_signin_command.rb
+++ b/test/rubygems/test_gem_commands_signin_command.rb
@@ -62,8 +62,10 @@ class TestGemCommandsSigninCommand < Gem::TestCase
   
   def test_execute_with_valid_creds_set_for_default_host
     util_capture {@cmd.execute}
-    api_key  = 'a5fdbb6ba150cbb83aad2bb2fede64cf040453903'
+    
+    api_key     = 'a5fdbb6ba150cbb83aad2bb2fede64cf040453903'
     credentials = YAML.load_file Gem.configuration.credentials_path
+    
     assert_equal api_key, credentials[:rubygems_api_key]
   end
 
@@ -74,15 +76,15 @@ class TestGemCommandsSigninCommand < Gem::TestCase
     response  = [api_key, 200, 'OK']
     email     = 'you@example.com'
     password  = 'secret'
+    fetcher   = Gem::FakeFetcher.new
 
-    ENV['RUBYGEMS_HOST'] = host || Gem::DEFAULT_HOST
-
-    fetcher = Gem::FakeFetcher.new
     # Set the expected response for the Web-API supplied
-    fetcher.data["#{ENV['RUBYGEMS_HOST']}/api/v1/api_key"] = response
+    ENV['RUBYGEMS_HOST']       = host || Gem::DEFAULT_HOST
+    data_key                   = "#{ENV['RUBYGEMS_HOST']}/api/v1/api_key"
+    fetcher.data[data_key]     = response
     Gem::RemoteFetcher.fetcher = fetcher
 
-    sign_in_ui = ui_stub || Gem::MockGemUi.new("#{email}\n#{password}\n")
+    sign_in_ui                 = ui_stub || Gem::MockGemUi.new("#{email}\n#{password}\n")
 
     use_ui sign_in_ui do
       yield

--- a/test/rubygems/test_gem_commands_signin_command.rb
+++ b/test/rubygems/test_gem_commands_signin_command.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+require 'rubygems/test_case'
+require 'rubygems/commands/signin_command'
+require 'rubygems/installer'
+
+class TestGemCommandsSigninCommand < Gem::TestCase
+
+  def setup
+    super
+    
+    Gem.configuration.rubygems_api_key = nil
+    Gem.configuration.api_keys.clear
+    
+    @cmd = Gem::Commands::SigninCommand.new
+  end
+
+  def teardown
+    credentials_path = Gem.configuration.credentials_path
+    File.delete(credentials_path)  if File.exist?(credentials_path)
+    super
+  end
+
+  def test_execute_when_not_already_signed_in
+    sign_in_ui = util_capture() { @cmd.execute }
+    assert_match %r{Signed in.}, sign_in_ui.output
+  end
+
+  def test_execute_with_host_supplied
+    host = 'http://some-gemcutter-compatible-host.org'
+    @cmd.options[:host] = host
+
+    sign_in_ui = util_capture(nil, host) { @cmd.execute }
+    assert_match %r{Enter your #{host} credentials.}, sign_in_ui.output
+    assert_match %r{Signed in.}, sign_in_ui.output
+  end
+
+  # Utility method to capture IO/UI within the block passed
+
+  def util_capture ui_stub = nil, host = nil
+    api_key  = 'a5fdbb6ba150cbb83aad2bb2fede64cf040453903'
+    response = [api_key, 200, 'OK']
+    email    = 'you@example.com'
+    password = 'secret'
+
+    ENV['RUBYGEMS_HOST'] = host || Gem::DEFAULT_HOST
+
+    fetcher = Gem::FakeFetcher.new
+    # Set the expected response for the Web-API supplied
+    fetcher.data["#{ENV['RUBYGEMS_HOST']}/api/v1/api_key"] = response
+    Gem::RemoteFetcher.fetcher = fetcher
+
+    sign_in_ui = ui_stub || Gem::MockGemUi.new("#{email}\n#{password}\n")
+
+    use_ui sign_in_ui do
+      yield
+    end
+
+    sign_in_ui
+  end
+end


### PR DESCRIPTION
# Description:
 Lets user to login to any `gem-cutter` compatible package hosts. But, the default would be `rubygems.org`

 The command will take `--host` as a switch to let use pass the host URL

closes #1634 

**Note**: There's already PR for this - https://github.com/rubygems/rubygems/pull/1635/files.
I thought this would be much simpler. What do you guys think? 

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
