### PR TITLE
Backport r58419 from ruby/ruby repository(to master branch)

### DIFF
--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -43,7 +43,12 @@ module Kernel
 
     if spec = Gem.find_unresolved_default_spec(path)
       Gem.remove_unresolved_default_spec(spec)
-      Kernel.send(:gem, spec.name)
+      begin
+        Kernel.send(:gem, spec.name)
+      rescue Exception
+        RUBYGEMS_ACTIVATION_MONITOR.exit
+        raise
+      end
     end
 
     # If there are no unresolved deps, then we can use just try


### PR DESCRIPTION
# Description:

It is patch file for https://github.com/rubygems/rubygems/issues/1901

* https://github.com/ruby/ruby/commit/1721dfa0ea963a85d4ac1e3415eb18ef427d4d36
* https://svn.ruby-lang.org/cgi-bin/viewvc.cgi?view=revision&revision=58419
```
release monitor correctly.

* lib/rubygems/core_ext/kernel_require.rb: sometimes
  `Kernel.send(:gem, spec.name)` can raise some errors
  (Gem::MissingSpecError I observed) and this method
  doesn't release RUBYGEMS_ACTIVATION_MONITOR correctly.
  This patch fix this problem.
```

______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
