### PR TITLE
Backport r58736 from ruby/ruby repository(to master branch)

### DIFF
--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -422,6 +422,7 @@ class Gem::TestCase < MiniTest::Unit::TestCase
 
     Gem::Specification._clear_load_cache
     Gem::Specification.unresolved_deps.clear
+    Gem::refresh
   end
 
   def common_installer_setup


### PR DESCRIPTION
# Description:

This is same as https://github.com/rubygems/rubygems/pull/1952. 

----

This is backport request from ruby core repository. We already committed this. Therefore, We will ship next version of the ruby language contained this fixes.

 * https://github.com/rubygems/rubygems/issues/1928
 * https://svn.ruby-lang.org/cgi-bin/viewvc.cgi?view=revision&revision=58736

```
refresh Gem at the end of `teardown`.

* lib/rubygems/test_case.rb (teardown): call `Gem::refresh()` at the
  end of `teardown`.
  On parallel test sometimes fails test process. The reason
  is:
  (1) previous tests remains `Gem::Specification@@stubs` value
      which points to temporary directories and the directories
      are removed by `teardown` method of previous test.
  (2) `require 'rubygems/gem_runner'` in `test_gem_gem_runner.rb`
      tries to require test utility file. However, with strange `@@stubs`
      RubyGems tries to load specification from removed directory.
      `StubSpecification#to_spec` returns `nil` and error will occur.
  The solution this patch employs is to refresh all of parameters
  includes `Gem::Specification@@stubs` by `Gem::refresh()`.
```

______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
