### PR TITLE
Happier message when latest version is already installed

### DIFF
--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -70,7 +70,7 @@ command to remove old versions.
 
   def check_latest_rubygems version # :nodoc:
     if Gem.rubygems_version == version then
-      say "Latest version currently installed. Aborting."
+      say "Latest version already installed. Done."
       terminate_interaction
     end
 

--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -107,7 +107,7 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
     end
 
     out = @ui.output.split "\n"
-    assert_equal "Latest version currently installed. Aborting.", out.shift
+    assert_equal "Latest version already installed. Done.", out.shift
     assert_empty out
   end
 


### PR DESCRIPTION
# Description

Changes wording of the success message of `gem update --system`.

## "Done" is happier than "Aborting"

Every day I check for a new version of `gem`, and usually I see this message:

```
Latest version currently installed. Aborting.
```

This message could be happier, and that would make people's days better. :sunny: 🌈 

The word "done" is happier than the word "aborting".

## "already" is more descriptive than "currently"

It does a better job of explaining what happened.