### PR TITLE
Fix links in Policies document

### DIFF
--- a/POLICIES.rdoc
+++ b/POLICIES.rdoc
@@ -3,13 +3,13 @@
 Contributions to RubyGems are made via GitHub pull requests, which must be
 approved by a project committer other than the author. To approve a PR, a
 maintainer can leave a comment including the text "@homu r+", indicating that
-they have reviewed the PR and approve it. [Homu](http://homu.io) will then
+they have reviewed the PR and approve it. {Homu}[http://homu.io] will then
 automatically create a merge commit, test the merge, and land the PR if the
 merge commit passes the tests.
 
 This process guarantees that our release branches always have passing tests,
 and reduces siloing of information to a single contributor. For a full list of
-possible commands, see [the Homu documentation](http://homu.io).
+possible commands, see {the Homu documentation}[http://homu.io].
 
 == Long-Term Support
 


### PR DESCRIPTION
# Description:

This is an RDoc document, but these links were in Markdown syntax.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).