### PR TITLE
Add documentation section to README and fix a few documentation related issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ For more details and other options, see:
   ruby setup.rb --help
 ```
 
+## Documentation
+
+RubyGems uses [rdoc](https://github.com/rdoc/rdoc) for documentation. A compiled set of the docs
+can be viewed online at http://www.rubydoc.info/github/rubygems/rubygems
+
+RubyGems also provides a comprehensive set of guides which covers numerous topics such as
+creating a new gem, security practices and other resources at http://guides.rubygems.org
+
 ## GETTING HELP
 
 ### Support Requests

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -39,7 +39,7 @@ require 'rubygems/errors'
 # Further RubyGems documentation can be found at:
 #
 # * {RubyGems Guides}[http://guides.rubygems.org]
-# * {RubyGems API}[http://rubygems.rubyforge.org/rdoc] (also available from
+# * {RubyGems API}[http://www.rubydoc.info/github/rubygems/rubygems] (also available from
 #   <tt>gem server</tt>)
 #
 # == RubyGems Plugins
@@ -47,15 +47,16 @@ require 'rubygems/errors'
 # As of RubyGems 1.3.2, RubyGems will load plugins installed in gems or
 # $LOAD_PATH.  Plugins must be named 'rubygems_plugin' (.rb, .so, etc) and
 # placed at the root of your gem's #require_path.  Plugins are discovered via
-# Gem::find_files then loaded.  Take care when implementing a plugin as your
+# Gem::find_files and then loaded.  Take care when implementing a plugin as your
 # plugin file may be loaded multiple times if multiple versions of your gem
 # are installed.
 #
-# For an example plugin, see the graph gem which adds a `gem graph` command.
+# For an example plugin, see the {Graph gem}[https://github.com/seattlerb/graph]
+# which adds a `gem graph` command.
 #
 # == RubyGems Defaults, Packaging
 #
-# RubyGems defaults are stored in rubygems/defaults.rb.  If you're packaging
+# RubyGems defaults are stored in lib/rubygems/defaults.rb.  If you're packaging
 # RubyGems or implementing Ruby you can change RubyGems' defaults.
 #
 # For RubyGems packagers, provide lib/rubygems/defaults/operating_system.rb
@@ -65,7 +66,7 @@ require 'rubygems/errors'
 # override any defaults from lib/rubygems/defaults.rb.
 #
 # If you need RubyGems to perform extra work on install or uninstall, your
-# defaults override file can set pre and post install and uninstall hooks.
+# defaults override file can set pre/post install and uninstall hooks.
 # See Gem::pre_install, Gem::pre_uninstall, Gem::post_install,
 # Gem::post_uninstall.
 #
@@ -105,6 +106,8 @@ require 'rubygems/errors'
 # * Steve Klabnik      -- steve(at)steveklabnik.com
 #
 # (If your name is missing, PLEASE let us know!)
+#
+# == License
 #
 # See {LICENSE.txt}[rdoc-ref:lib/rubygems/LICENSE.txt] for permissions.
 #


### PR DESCRIPTION
# Description:

* Add a new section in the README covering the RubyGems documentation and
RubyGems guides.
* Update link to the RubyGems API to rubydoc.info since rubyforce.org
has been shutdown
* Add link to homepage of the referenced graph gem
* fix few small syntax issues

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
