### PR TITLE
Ensure that an appropriate version of Bundler is always activated

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -254,6 +254,7 @@ hide_lib_for_update/note.txt
 lib/rubygems.rb
 lib/rubygems/available_set.rb
 lib/rubygems/basic_specification.rb
+lib/rubygems/bundler_version_finder.rb
 lib/rubygems/command.rb
 lib/rubygems/command_manager.rb
 lib/rubygems/commands/build_command.rb
@@ -489,6 +490,7 @@ test/rubygems/test_config.rb
 test/rubygems/test_deprecate.rb
 test/rubygems/test_gem.rb
 test/rubygems/test_gem_available_set.rb
+test/rubygems/test_gem_bundler_version_finder.rb
 test/rubygems/test_gem_command.rb
 test/rubygems/test_gem_command_manager.rb
 test/rubygems/test_gem_commands_build_command.rb

--- a/Rakefile
+++ b/Rakefile
@@ -46,6 +46,7 @@ hoe = Hoe.spec 'rubygems-update' do
   spec_extras[:required_rubygems_version] = Gem::Requirement.default
   spec_extras[:required_ruby_version]     = Gem::Requirement.new '>= 1.8.7'
   spec_extras[:executables]               = ['update_rubygems']
+  spec_extras[:homepage]                  = 'https://rubygems.org'
 
   rdoc_locations <<
     'docs-push.seattlerb.org:/data/www/docs.seattlerb.org/rubygems/'

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -271,15 +271,15 @@ module Gem
 
     specs = dep.matching_specs(true)
 
-    raise Gem::GemNotFoundException,
-          "can't find gem #{dep}" if specs.empty?
-
     specs = specs.find_all { |spec|
       spec.executables.include? exec_name
     } if exec_name
 
     unless spec = specs.first
-      msg = "can't find gem #{name} (#{requirements}) with executable #{exec_name}"
+      msg = "can't find gem #{dep} with executable #{exec_name}"
+      if name == "bundler" && bundler_message = Gem::BundlerVersionFinder.missing_version_message
+        msg = bundler_message
+      end
       raise Gem::GemNotFoundException, msg
     end
 
@@ -1334,6 +1334,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
   MARSHAL_SPEC_DIR = "quick/Marshal.#{Gem.marshal_version}/"
 
+  autoload :BundlerVersionFinder, 'rubygems/bundler_version_finder'
   autoload :ConfigFile,         'rubygems/config_file'
   autoload :Dependency,         'rubygems/dependency'
   autoload :DependencyList,     'rubygems/dependency_list'

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -133,6 +133,7 @@ module Gem
 
   GEM_DEP_FILES = %w[
     gem.deps.rb
+    gems.rb
     Gemfile
     Isolate
   ]

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -270,7 +270,12 @@ module Gem
 
     return loaded if loaded && dep.matches_spec?(loaded)
 
-    specs = dep.matching_specs(true)
+    find_specs = proc { dep.matching_specs(true) }
+    if dep.to_s == "bundler (>= 0.a)"
+      specs = Gem::BundlerVersionFinder.without_filtering(&find_specs)
+    else
+      specs = find_specs.call
+    end
 
     specs = specs.find_all { |spec|
       spec.executables.include? exec_name

--- a/lib/rubygems/bundler_version_finder.rb
+++ b/lib/rubygems/bundler_version_finder.rb
@@ -66,7 +66,7 @@ To install the missing version, run `gem install bundler:#{vr.first}`
     gemfile = ENV["BUNDLE_GEMFILE"]
     gemfile = nil if gemfile && gemfile.empty?
     Gem::Util.traverse_parents Dir.pwd do |directory|
-      next unless gemfile = %w[gems.rb Gemfile].find { |f| File.file?(f) }
+      next unless gemfile = Gem::GEM_DEP_FILES.find { |f| File.file?(f.untaint) }
 
       gemfile = File.join directory, gemfile
       break
@@ -77,7 +77,7 @@ To install the missing version, run `gem install bundler:#{vr.first}`
     lockfile = case gemfile
     when "gems.rb" then "gems.locked"
     else "#{gemfile}.lock"
-    end
+    end.untaint
 
     return unless File.file?(lockfile)
 

--- a/lib/rubygems/bundler_version_finder.rb
+++ b/lib/rubygems/bundler_version_finder.rb
@@ -1,0 +1,87 @@
+module Gem::BundlerVersionFinder
+  def self.bundler_version
+    version, _reason = bundler_version_with_reason
+
+    return unless version
+
+    Gem::Version.new(version)
+  end
+
+  def self.bundler_version_with_reason
+    if v = ENV["BUNDLER_VERSION"]
+      return [v, "`$BUNDLER_VERSION`"]
+    end
+    if v = bundle_update_bundler_version
+      return if v == true
+      return [v, "`bundle update --bundler`"]
+    end
+    v, lockfile = lockfile_version
+    if v
+      return [v, "your #{lockfile}"]
+    end
+  end
+
+  def self.missing_version_message
+    return unless vr = bundler_version_with_reason
+    <<-EOS
+Could not find 'bundler' (#{vr.first}) required by #{vr.last}.
+To update to the lastest version installed on your system, run `bundle update --bundler`.
+To install the missing version, run `gem install bundler:#{vr.first}`
+    EOS
+  end
+
+  def self.compatible?(spec)
+    return true unless spec.name == "bundler".freeze
+    return true unless bundler_version = self.bundler_version
+    spec.version == bundler_version
+  end
+
+  def self.filter!(specs)
+    return unless bundler_version = self.bundler_version
+    specs.reject! { |spec| spec.version != bundler_version }
+  end
+
+  def self.bundle_update_bundler_version
+    return unless File.basename($0) == "bundle".freeze
+    return unless "update".start_with?(ARGV.first || " ")
+    ARGV.each do |a|
+      next unless a =~ /\A--bundler(?:=(#{Gem::Version::VERSION_PATTERN}))?\z/
+      return $1 || true
+    end
+    nil
+  end
+  private_class_method :bundle_update_bundler_version
+
+  def self.lockfile_version
+    return unless lockfile = lockfile_contents
+    lockfile, contents = lockfile
+    lockfile ||= "lockfile"
+    regexp = /\n\nBUNDLED WITH\n\s{2,}(#{Gem::Version::VERSION_PATTERN})\n/
+    return unless contents =~ regexp
+    [$1, lockfile]
+  end
+  private_class_method :lockfile_version
+
+  def self.lockfile_contents
+    gemfile = ENV["BUNDLE_GEMFILE"]
+    gemfile = nil if gemfile && gemfile.empty?
+    Gem::Util.traverse_parents Dir.pwd do |directory|
+      next unless gemfile = %w[gems.rb Gemfile].find { |f| File.file?(f) }
+
+      gemfile = File.join directory, gemfile
+      break
+    end unless gemfile
+
+    return unless gemfile
+
+    lockfile = case gemfile
+    when "gems.rb" then "gems.locked"
+    else "#{gemfile}.lock"
+    end
+
+    return unless File.file?(lockfile)
+
+    [lockfile, File.read(lockfile)]
+  end
+  private_class_method :lockfile_contents
+end

--- a/lib/rubygems/bundler_version_finder.rb
+++ b/lib/rubygems/bundler_version_finder.rb
@@ -44,11 +44,17 @@ To install the missing version, run `gem install bundler:#{vr.first}`
   def self.bundle_update_bundler_version
     return unless File.basename($0) == "bundle".freeze
     return unless "update".start_with?(ARGV.first || " ")
-    ARGV.each do |a|
-      next unless a =~ /\A--bundler(?:=(#{Gem::Version::VERSION_PATTERN}))?\z/
-      return $1 || true
+    bundler_version = nil
+    update_index = nil
+    ARGV.each_with_index do |a, i|
+      if update_index && update_index.succ == i && a =~ Gem::Version::ANCHORED_VERSION_PATTERN
+        bundler_version = a
+      end
+      next unless a =~ /\A--bundler(?:[= ](#{Gem::Version::VERSION_PATTERN}))?\z/
+      bundler_version = $1 || true
+      update_index = i
     end
-    nil
+    bundler_version
   end
   private_class_method :bundle_update_bundler_version
 

--- a/lib/rubygems/bundler_version_finder.rb
+++ b/lib/rubygems/bundler_version_finder.rb
@@ -9,7 +9,7 @@ module Gem::BundlerVersionFinder
   end
 
   def self.bundler_version
-    version, _reason = bundler_version_with_reason
+    version, _ = bundler_version_with_reason
 
     return unless version
 

--- a/lib/rubygems/bundler_version_finder.rb
+++ b/lib/rubygems/bundler_version_finder.rb
@@ -1,4 +1,11 @@
 module Gem::BundlerVersionFinder
+  def self.without_filtering
+    without_filtering, @without_filtering = true, @without_filtering
+    yield
+  ensure
+    @without_filtering = without_filtering
+  end
+
   def self.bundler_version
     version, _reason = bundler_version_with_reason
 
@@ -8,6 +15,8 @@ module Gem::BundlerVersionFinder
   end
 
   def self.bundler_version_with_reason
+    return if @without_filtering
+
     if v = ENV["BUNDLER_VERSION"]
       return [v, "`$BUNDLER_VERSION`"]
     end

--- a/lib/rubygems/bundler_version_finder.rb
+++ b/lib/rubygems/bundler_version_finder.rb
@@ -1,4 +1,6 @@
 module Gem::BundlerVersionFinder
+  @without_filtering = false
+
   def self.without_filtering
     without_filtering, @without_filtering = true, @without_filtering
     yield

--- a/lib/rubygems/bundler_version_finder.rb
+++ b/lib/rubygems/bundler_version_finder.rb
@@ -33,12 +33,20 @@ To install the missing version, run `gem install bundler:#{vr.first}`
   def self.compatible?(spec)
     return true unless spec.name == "bundler".freeze
     return true unless bundler_version = self.bundler_version
-    spec.version == bundler_version
+    if bundler_version.segments.first >= 2
+      spec.version == bundler_version
+    else # 1.x
+      spec.version.segments.first < 2
+    end
   end
 
   def self.filter!(specs)
     return unless bundler_version = self.bundler_version
-    specs.reject! { |spec| spec.version != bundler_version }
+    if bundler_version.segments.first >= 2
+      specs.reject! { |spec| spec.version != bundler_version }
+    else # 1.x
+      specs.reject! { |spec| spec.version.segments.first >= 2}
+    end
   end
 
   def self.bundle_update_bundler_version

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -15,7 +15,8 @@ class Gem::Commands::SetupCommand < Gem::Command
     super 'setup', 'Install RubyGems',
           :format_executable => true, :document => %w[ri],
           :site_or_vendor => 'sitelibdir',
-          :destdir => '', :prefix => '', :previous_version => ''
+          :destdir => '', :prefix => '', :previous_version => '',
+          :regenerate_binstubs => true
 
     add_option '--previous-version=VERSION',
                'Previous version of RubyGems',
@@ -79,6 +80,15 @@ class Gem::Commands::SetupCommand < Gem::Command
       options[:document].uniq!
     end
 
+    add_option '--[no-]regenerate-binstubs',
+               'Regenerate gem binstubs' do |value, options|
+      if value then
+        options[:regenerate_binstubs] = true
+      else
+        options.delete(:regenerate_binstubs)
+      end
+   end
+
     @verbose = nil
   end
 
@@ -92,7 +102,7 @@ class Gem::Commands::SetupCommand < Gem::Command
   end
 
   def defaults_str # :nodoc:
-    "--format-executable --document ri"
+    "--format-executable --document ri --regenerate-binstubs"
   end
 
   def description # :nodoc:
@@ -145,6 +155,8 @@ By default, this RubyGems will install gem as:
     install_default_bundler_gem
 
     say "RubyGems #{Gem::VERSION} installed"
+
+    regenerate_binstubs
 
     uninstall_old_gemcutter
 
@@ -518,6 +530,12 @@ abort "#{deprecation_message}"
                               :version => '< 0.4')
     ui.uninstall
   rescue Gem::InstallError
+  end
+
+  def regenerate_binstubs
+    command = Gem::Commands::PristineCommand.new
+    command.handle_options %w[--all --only-executables]
+    command.execute
   end
 
 end

--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -280,6 +280,8 @@ class Gem::Dependency
       requirement.satisfied_by?(spec.version) && env_req.satisfied_by?(spec.version)
     }.map(&:to_spec)
 
+    Gem::BundlerVersionFinder.filter!(matches) if name == "bundler".freeze
+
     if platform_only
       matches.reject! { |spec|
         spec.nil? || !Gem::Platform.match(spec.platform)

--- a/lib/rubygems/errors.rb
+++ b/lib/rubygems/errors.rb
@@ -58,6 +58,9 @@ module Gem
     private
 
     def build_message
+      if name == "bundler" && message = Gem::BundlerVersionFinder.missing_version_message
+        return message
+      end
       names = specs.map(&:full_name)
       "Could not find '#{name}' (#{requirement}) - did find: [#{names.join ','}]\n"
     end

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1057,6 +1057,7 @@ class Gem::Specification < Gem::BasicSpecification
   def self.find_by_path path
     path = path.dup.freeze
     spec = @@spec_with_requirable_file[path] ||= (stubs.find { |s|
+      next unless Gem::BundlerVersionFinder.compatible?(s)
       s.contains_requirable_file? path
     } || NOT_FOUND)
     spec.to_spec
@@ -1068,7 +1069,9 @@ class Gem::Specification < Gem::BasicSpecification
 
   def self.find_inactive_by_path path
     stub = stubs.find { |s|
-      s.contains_requirable_file? path unless s.activated?
+      next if s.activated?
+      next unless Gem::BundlerVersionFinder.compatible?(s)
+      s.contains_requirable_file? path
     }
     stub && stub.to_spec
   end

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1110,7 +1110,8 @@ class TestGem < Gem::TestCase
     orig_path = ENV.delete 'GEM_PATH'
     Gem.use_paths nil, nil
     assert_equal Gem.default_dir, Gem.paths.home
-    assert_equal (Gem.default_path + [Gem.paths.home]).uniq, Gem.paths.path
+    path = (Gem.default_path + [Gem.paths.home]).uniq
+    assert_equal path, Gem.paths.path
   ensure
     ENV['GEM_HOME'] = orig_home
     ENV['GEM_PATH'] = orig_path

--- a/test/rubygems/test_gem_bundler_version_finder.rb
+++ b/test/rubygems/test_gem_bundler_version_finder.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+require 'rubygems/test_case'
+
+class TestGemBundlerVersionFinder < Gem::TestCase
+  def setup
+    @argv = ARGV.dup
+    @env = ENV.to_hash.clone
+    ENV.delete("BUNDLER_VERSION")
+    @dollar_0 = $0
+  end
+
+  def teardown
+    ARGV.replace @argv
+    ENV.replace @env
+    $0 = @dollar_0
+  end
+
+  def bvf
+    Gem::BundlerVersionFinder
+  end
+
+  def test_bundler_version_defaults_to_nil
+    assert_nil bvf.bundler_version
+  end
+
+  def test_bundler_version_with_env_var
+    ENV["BUNDLER_VERSION"] = "1.1.1.1"
+    assert_equal v("1.1.1.1"), bvf.bundler_version
+  end
+
+  def test_bundler_version_with_bundle_update_bundler
+    ARGV.replace %w[update --bundler]
+    assert_nil bvf.bundler_version
+    $0 = "/foo/bar/bundle"
+    assert_nil bvf.bundler_version
+    ARGV.replace %w[update --bundler=1.1.1.1]
+    assert_equal v("1.1.1.1"), bvf.bundler_version
+    $0 = "other"
+    assert_nil bvf.bundler_version
+  end
+
+  def test_bundler_version_with_lockfile
+    bvf.stub(:lockfile_contents, [nil, ""]) do
+      assert_nil bvf.bundler_version
+    end
+    bvf.stub(:lockfile_contents, [nil, "\n\nBUNDLED WITH\n   1.1.1.1\n"]) do
+      assert_equal v("1.1.1.1"), bvf.bundler_version
+    end
+    bvf.stub(:lockfile_contents, [nil, "\n\nBUNDLED WITH\n   fjdkslfjdkslfjsldk\n"]) do
+      assert_nil bvf.bundler_version
+    end
+  end
+
+  def test_bundler_version_with_reason
+    assert_nil bvf.bundler_version_with_reason
+    bvf.stub(:lockfile_contents, [nil, "\n\nBUNDLED WITH\n   1.1.1.1\n"]) do
+      assert_equal ["1.1.1.1", "your lockfile"], bvf.bundler_version_with_reason
+
+      $0 = "bundle"
+      ARGV.replace %w[update --bundler]
+      assert_nil bvf.bundler_version_with_reason
+      ARGV.replace %w[update --bundler=1.1.1.2]
+      assert_equal ["1.1.1.2", "`bundle update --bundler`"], bvf.bundler_version_with_reason
+
+      ENV["BUNDLER_VERSION"] = "1.1.1.3"
+      assert_equal ["1.1.1.3", "`$BUNDLER_VERSION`"], bvf.bundler_version_with_reason
+    end
+  end
+
+  def test_compatible
+    assert bvf.compatible?(util_spec("foo"))
+    assert bvf.compatible?(util_spec("bundler", 1.1))
+
+    bvf.stub(:bundler_version, v("1.1.1.1")) do
+      assert bvf.compatible?(util_spec("foo"))
+      assert bvf.compatible?(util_spec("bundler", "1.1.1.1"))
+      refute bvf.compatible?(util_spec("bundler", "1.1.1.a"))
+    end
+  end
+
+  def test_filter
+    specs = [util_spec("bundler", "1"), util_spec("bundler", "1.0"), util_spec("bundler", "1.0.1.1"), util_spec("bundler", "2.a")]
+
+    assert_equal %w[1 1.0 1.0.1.1 2.a], util_filter_specs(specs).map(&:version).map(&:to_s)
+
+    bvf.stub(:bundler_version, v("1.1.1.1")) do
+      assert_empty util_filter_specs(specs)
+    end
+    bvf.stub(:bundler_version, v("1")) do
+      assert_equal %w[1 1.0], util_filter_specs(specs).map(&:version).map(&:to_s)
+    end
+    bvf.stub(:bundler_version, v("2.a")) do
+      assert_equal %w[2.a], util_filter_specs(specs).map(&:version).map(&:to_s)
+    end
+  end
+
+  def util_filter_specs(specs)
+    specs = specs.dup
+    bvf.filter!(specs)
+    specs
+  end
+end

--- a/test/rubygems/test_gem_bundler_version_finder.rb
+++ b/test/rubygems/test_gem_bundler_version_finder.rb
@@ -33,7 +33,13 @@ class TestGemBundlerVersionFinder < Gem::TestCase
     assert_nil bvf.bundler_version
     $0 = "/foo/bar/bundle"
     assert_nil bvf.bundler_version
-    ARGV.replace %w[update --bundler=1.1.1.1]
+    ARGV.replace %w[update --bundler=1.1.1.1 gem_name]
+    assert_equal v("1.1.1.1"), bvf.bundler_version
+    ARGV.replace %w[update --bundler 1.1.1.1 gem_name]
+    assert_equal v("1.1.1.1"), bvf.bundler_version
+    ARGV.replace %w[update --bundler\ 1.1.1.1 gem_name]
+    assert_equal v("1.1.1.1"), bvf.bundler_version
+    ARGV.replace %w[update --bundler\ 1.1.1.2 --bundler --bundler 1.1.1.1 gem_name]
     assert_equal v("1.1.1.1"), bvf.bundler_version
     $0 = "other"
     assert_nil bvf.bundler_version

--- a/test/rubygems/test_gem_dependency.rb
+++ b/test/rubygems/test_gem_dependency.rb
@@ -338,6 +338,34 @@ class TestGemDependency < Gem::TestCase
     assert_match "Could not find 'a' (= 2.0) - did find: [a-1.0]", e.message
   end
 
+  def test_to_specs_respects_bundler_version
+    b = util_spec 'bundler', '2.0.0.pre.1'
+    b_1 = util_spec 'bundler', '1'
+    install_specs b, b_1
+
+    b_file = File.join b.gem_dir, 'lib', 'bundler', 'setup.rb'
+
+    write_file b_file do |io|
+      io.puts '# setup.rb'
+    end
+
+    dep = Gem::Dependency.new "bundler", ">= 0.a"
+
+    assert_equal [b, b_1], dep.to_specs
+
+    Gem::BundlerVersionFinder.stub(:bundler_version_with_reason, ["1.5", "reason"]) do
+      e = assert_raises Gem::MissingSpecVersionError do
+        dep.to_specs
+      end
+
+      assert_match "Could not find 'bundler' (1.5) required by reason.\nTo update to the lastest version installed on your system, run `bundle update --bundler`.\nTo install the missing version, run `gem install bundler:1.5`\n", e.message
+    end
+
+    Gem::BundlerVersionFinder.stub(:bundler_version_with_reason, ["1.0", "reason"]) do
+      assert_equal [b_1], dep.to_specs
+    end
+  end
+
   def test_to_specs_indicates_total_gem_set_size
     a = util_spec 'a', '1.0'
     install_specs a

--- a/test/rubygems/test_gem_dependency.rb
+++ b/test/rubygems/test_gem_dependency.rb
@@ -353,16 +353,16 @@ class TestGemDependency < Gem::TestCase
 
     assert_equal [b, b_1], dep.to_specs
 
-    Gem::BundlerVersionFinder.stub(:bundler_version_with_reason, ["1.5", "reason"]) do
+    Gem::BundlerVersionFinder.stub(:bundler_version_with_reason, ["3.5", "reason"]) do
       e = assert_raises Gem::MissingSpecVersionError do
         dep.to_specs
       end
 
-      assert_match "Could not find 'bundler' (1.5) required by reason.\nTo update to the lastest version installed on your system, run `bundle update --bundler`.\nTo install the missing version, run `gem install bundler:1.5`\n", e.message
+      assert_match "Could not find 'bundler' (3.5) required by reason.\nTo update to the lastest version installed on your system, run `bundle update --bundler`.\nTo install the missing version, run `gem install bundler:3.5`\n", e.message
     end
 
-    Gem::BundlerVersionFinder.stub(:bundler_version_with_reason, ["1.0", "reason"]) do
-      assert_equal [b_1], dep.to_specs
+    Gem::BundlerVersionFinder.stub(:bundler_version_with_reason, ["2.0.0.pre.1", "reason"]) do
+      assert_equal [b], dep.to_specs
     end
   end
 

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -540,7 +540,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
       nil
     end
 
-    assert_equal nil, fetcher.fetch_path(@uri + 'foo.gz', Time.at(0))
+    assert_nil fetcher.fetch_path(@uri + 'foo.gz', Time.at(0))
   end
 
   def test_fetch_path_io_error
@@ -606,7 +606,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
       nil
     end
 
-    assert_equal nil, fetcher.fetch_path(URI.parse(@gem_repo), Time.at(0))
+    assert_nil fetcher.fetch_path(URI.parse(@gem_repo), Time.at(0))
   end
 
   def test_implicit_no_proxy

--- a/test/rubygems/test_kernel.rb
+++ b/test/rubygems/test_kernel.rb
@@ -90,4 +90,34 @@ class TestKernel < Gem::TestCase
     assert gem('a', '= 1'), "Should load"
     refute $:.any? { |p| %r{a-1/bin} =~ p }
   end
+
+  def test_gem_bundler
+    quick_gem 'bundler', '1'
+    quick_gem 'bundler', '2.a'
+
+    assert gem('bundler')
+    assert $:.any? { |p| %r{bundler-1/lib} =~ p }
+  end
+
+  def test_gem_bundler_missing_bundler_version
+    Gem::BundlerVersionFinder.stub(:bundler_version_with_reason, ["55", "reason"]) do
+      quick_gem 'bundler', '1'
+      quick_gem 'bundler', '2.a'
+
+      e = assert_raises Gem::MissingSpecVersionError do
+        gem('bundler')
+      end
+      assert_match "Could not find 'bundler' (55) required by reason.", e.message
+    end
+  end
+
+  def test_gem_bundler_inferred_bundler_version
+    Gem::BundlerVersionFinder.stub(:bundler_version_with_reason, ["1", "reason"]) do
+      quick_gem 'bundler', '1'
+      quick_gem 'bundler', '2.a'
+
+      assert gem('bundler', '>= 0.a')
+      assert $:.any? { |p| %r{bundler-1/lib} =~ p }
+    end
+  end
 end

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -383,6 +383,44 @@ class TestGemRequire < Gem::TestCase
     assert_equal %w(a-1), loaded_spec_names
   end
 
+
+  def test_require_bundler
+    $:.reject! {|lp| File.expand_path(lp).end_with?("bundler/lib") }
+    b1 = new_spec('bundler', '1', nil, "lib/bundler/setup.rb")
+    b2a = new_spec('bundler', '2.a', nil, "lib/bundler/setup.rb")
+    install_specs b1, b2a
+
+    assert_require 'bundler/setup'
+    assert_equal %w[bundler-2.a], loaded_spec_names
+    assert_empty unresolved_names
+  end
+
+  def test_require_bundler_missing_bundler_version
+    $:.reject! {|lp| File.expand_path(lp).end_with?("bundler/lib") }
+    Gem::BundlerVersionFinder.stub(:bundler_version_with_reason, ["55", "reason"]) do
+      b1 = new_spec('bundler', '1', nil, "lib/bundler/setup.rb")
+      b2a = new_spec('bundler', '2.a', nil, "lib/bundler/setup.rb")
+      install_specs b1, b2a
+
+      e = assert_raises Gem::MissingSpecVersionError do
+        gem('bundler')
+      end
+      assert_match "Could not find 'bundler' (55) required by reason.", e.message
+    end
+  end
+
+  def test_require_bundler_with_bundler_version
+    $:.reject! {|lp| File.expand_path(lp).end_with?("bundler/lib") }
+    Gem::BundlerVersionFinder.stub(:bundler_version_with_reason, ["1", "reason"]) do
+      b1 = new_spec('bundler', '1', nil, "lib/bundler/setup.rb")
+      b2 = new_spec('bundler', '2', nil, "lib/bundler/setup.rb")
+      install_specs b1, b2
+
+      assert_require 'bundler/setup'
+      assert_equal %w[bundler-1], loaded_spec_names
+    end
+  end
+
   def silence_warnings
     old_verbose, $VERBOSE = $VERBOSE, false
     yield


### PR DESCRIPTION
# Description:

Closes https://github.com/rubygems/rubygems/issues/1974.
This ensures that the `bundle` binstub, along with anything running `require "bundler/setup"` will respect, in order:

1. `ENV["BUNDLER_VERSION"]`
2. `bundle update --bundler`
3. The bundler version in the nearest `Gemfile.lock`

See https://github.com/bundler/bundler/issues/5876 for further context, and https://github.com/bundler/bundler/issues/5878 for a related change to Bundler.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).