### PR TITLE
Added message to uninstall command for gem that is not installed.

### DIFF
--- a/lib/rubygems/commands/uninstall_command.rb
+++ b/lib/rubygems/commands/uninstall_command.rb
@@ -143,7 +143,9 @@ that is a dependency of an existing gem.  You can use the
     deplist = Gem::DependencyList.new
 
     get_all_gem_names.uniq.each do |name|
-      Gem::Specification.find_all_by_name(name).each do |spec|
+      gem_specs = Gem::Specification.find_all_by_name(name)
+      say("Gem '#{name}' is not installed") if gem_specs.empty?
+      gem_specs.each do |spec|
         deplist.add spec
       end
     end
@@ -162,4 +164,3 @@ that is a dependency of an existing gem.  You can use the
   end
 
 end
-

--- a/test/rubygems/test_gem_commands_uninstall_command.rb
+++ b/test/rubygems/test_gem_commands_uninstall_command.rb
@@ -279,5 +279,17 @@ WARNING:  Use your OS package manager to uninstall vendor gems
     RbConfig::CONFIG['vendordir'] = orig_vendordir
   end
 
+  def test_execute_with_gem_not_installed
+    @cmd.options[:args] = ['d']
+
+    use_ui ui do
+      @cmd.execute
+    end
+
+    output = ui.output.split "\n"
+    
+    assert_equal output.first, "Gem 'd' is not installed"
+  end
+
 end
 


### PR DESCRIPTION
When we try to uninstall a gem that's not installed, we don't get any message.

Assuming I don't have `day_greeter` gem installed in my machine.
> [anant@localhost ~]# gem uninstall day_greeter
> [anant@localhost ~]# 

with below changes it will be like this
> [anant@localhost ~]# gem uninstall day_greeter
> Gem 'day_greeter' is not installed
> [anant@localhost ~]#  
