### PR TITLE
Picked commit from ruby/ruby@41e1670

### DIFF
--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -275,13 +275,14 @@ class Gem::Resolver
   end
 
   def sort_dependencies(dependencies, activated, conflicts)
-    dependencies.sort_by do |dependency|
+    dependencies.sort_by.with_index do |dependency, i|
       name = name_for(dependency)
       [
         activated.vertex_named(name).payload ? 0 : 1,
         amount_constrained(dependency),
         conflicts[name] ? 0 : 1,
         activated.vertex_named(name).payload ? 0 : search_for(dependency).count,
+        i # for stable sort
       ]
     end
   end


### PR DESCRIPTION
# Description:

Picked commit from ruby/ruby@41e1670

This is patch for https://github.com/rubygems/rubygems/issues/1980

```
* lib/rubygems/resolver.rb (sort_dependencies): use stable sort.
  TestGemRequestSetLockfile#test_to_s_gem_dependency_non_default
  fails because this method return unstable results.
  Note that Enumerable#sort_by is unstable.

  I'm not sure the "stable" nature is required for RubyGems.
  The fact is that using stable sort, the test passed on
  mswin64+VS2017 where the sort results was reverse (unstable) order.
  Also using `-i` instead of `i` (it means forcing unstable sort)
  this test fails on other platform where the test successed before.
```

______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
