### PR TITLE
Extract bin file for rake

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -623,5 +623,7 @@ util/create_certs.rb
 util/create_encrypted_key.rb
 util/generate_spdx_license_list.rb
 util/patch_with_prs.rb
+util/rake
 util/update_bundled_ca_certificates.rb
 util/update_changelog.rb
+util/with_gemspec.rb

--- a/Rakefile
+++ b/Rakefile
@@ -29,64 +29,15 @@ $ [sudo] gem install hoe
   ERR
 end
 
+load File.expand_path("../util/with_gemspec.rb", __FILE__)
+
 Hoe::RUBY_FLAGS << " --disable-gems" if RUBY_VERSION > "1.9"
 
 Hoe.plugin :git
 Hoe.plugin :travis
 Hoe.plugin :newb
 
-hoe = Hoe.spec 'rubygems-update' do
-  self.author         = ['Jim Weirich', 'Chad Fowler', 'Eric Hodel']
-  self.email          = %w[rubygems-developers@rubyforge.org]
-  self.readme_file    = 'README.md'
-
-  license 'Ruby'
-  license 'MIT'
-
-  spec_extras[:required_rubygems_version] = Gem::Requirement.default
-  spec_extras[:required_ruby_version]     = Gem::Requirement.new '>= 1.8.7'
-  spec_extras[:executables]               = ['update_rubygems']
-  spec_extras[:homepage]                  = 'https://rubygems.org'
-
-  rdoc_locations <<
-    'docs-push.seattlerb.org:/data/www/docs.seattlerb.org/rubygems/'
-
-  clean_globs.push('**/debug.log',
-                   '*.out',
-                   '.config',
-                   'data__',
-                   'html',
-                   'logs',
-                   'graph.dot',
-                   'pkgs/sources/sources*.gem',
-                   'scripts/*.hieraki')
-
-  extra_dev_deps.clear
-
-  dependency 'builder',       '~> 2.1',   :dev
-  dependency 'hoe-seattlerb', '~> 1.2',   :dev
-  dependency 'rdoc',          '~> 4.0',   :dev
-  dependency 'ZenTest',       '~> 4.5',   :dev
-  dependency 'rake',          '~> 10.5',  :dev
-  dependency 'minitest',      '~> 4.0',   :dev
-
-  self.extra_rdoc_files = Dir["*.rdoc"] + %w[
-    CVE-2013-4287.txt
-    CVE-2013-4363.txt
-  ]
-
-  spec_extras['rdoc_options'] = proc do |rdoc_options|
-    rdoc_options << "--title=RubyGems Update Documentation"
-  end
-
-  self.rsync_args += " --no-p -O"
-
-  self.version = File.open('lib/rubygems.rb', 'r:utf-8') do |f|
-    f.read[/VERSION\s+=\s+(['"])(#{Gem::Version::VERSION_PATTERN})\1/, 2]
-  end
-
-  spec_extras['require_paths'] = %w[hide_lib_for_update]
-end
+hoe = rubygems_spec
 
 # Monkey-patch to ensure newly-installed gems are visible
 Hoe::Package.instance_method(:install_gem).tap do |existing_install_gem|

--- a/util/rake
+++ b/util/rake
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.path('../lib')
+require "rubygems"
+
+load File.expand_path("../with_gemspec.rb", __FILE__)
+
+rubygems_spec.spec.dependencies do |dep|
+  begin
+    gem dep.name, dep.requirement
+  rescue Gem::LoadError => e
+    $stderr.puts "#{e.message} (#{e.class})"
+  end
+end
+
+Gem.finish_resolve if Gem.respond_to?(:finish_resolve)
+
+load Gem.bin_path("rake", "rake")

--- a/util/with_gemspec.rb
+++ b/util/with_gemspec.rb
@@ -1,0 +1,67 @@
+require 'rubygems'
+
+begin
+  require 'hoe'
+rescue ::LoadError
+  abort <<-ERR
+Error while loading the hoe gem.
+Please install it by running the following:
+
+$ [sudo] gem install hoe
+  ERR
+end
+
+def rubygems_spec
+  Hoe.spec 'rubygems-update' do
+    self.author         = ['Jim Weirich', 'Chad Fowler', 'Eric Hodel']
+    self.email          = %w[rubygems-developers@rubyforge.org]
+    self.readme_file    = 'README.md'
+
+    license 'Ruby'
+    license 'MIT'
+
+    spec_extras[:required_rubygems_version] = Gem::Requirement.default
+    spec_extras[:required_ruby_version]     = Gem::Requirement.new '>= 1.8.7'
+    spec_extras[:executables]               = ['update_rubygems']
+    spec_extras[:homepage]                  = 'https://rubygems.org'
+
+    rdoc_locations <<
+      'docs-push.seattlerb.org:/data/www/docs.seattlerb.org/rubygems/'
+
+    clean_globs.push('**/debug.log',
+                     '*.out',
+                     '.config',
+                     'data__',
+                     'html',
+                     'logs',
+                     'graph.dot',
+                     'pkgs/sources/sources*.gem',
+                     'scripts/*.hieraki')
+
+    extra_dev_deps.clear
+
+    dependency 'builder',       '~> 2.1',   :dev
+    dependency 'hoe-seattlerb', '~> 1.2',   :dev
+    dependency 'rdoc',          '~> 4.0',   :dev
+    dependency 'ZenTest',       '~> 4.5',   :dev
+    dependency 'rake',          '~> 10.5',  :dev
+    dependency 'minitest',      '~> 4.0',   :dev
+
+    self.extra_rdoc_files = Dir["*.rdoc"] + %w[
+      CVE-2013-4287.txt
+      CVE-2013-4363.txt
+    ]
+
+    spec_extras['rdoc_options'] = proc do |rdoc_options|
+      rdoc_options << "--title=RubyGems Update Documentation"
+    end
+
+    self.rsync_args += " --no-p -O"
+
+    self.version = File.open('lib/rubygems.rb', 'r:utf-8') do |f|
+      f.read[/VERSION\s+=\s+(['"])(#{Gem::Version::VERSION_PATTERN})\1/, 2]
+    end
+
+    spec_extras['require_paths'] = %w[hide_lib_for_update]
+  end
+end


### PR DESCRIPTION
This PR is fixing #1754 by creating a ruby executable script for the rake command, so that we can avoid running into the gem activation issues like:

```
› rake newb
git submodule update --init
To override your default rake version, run: `rake _x.y.z_ task_name`:
Gem::LoadError: can't activate rake-10.5.0, already activated rake-12.1.0
```

To fix this issue i have extracted out the Hoe gemspec generator that lived in the `Rakefile` and created a ruby executable in the `util` directory. This means that going forward developers would need to run rake tasks as `util/rake <task>` instead of just `<rake>`.
______________

# Tasks:

- [x ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
