### PR TITLE
Ignored `test_realworld_default_gem` with ruby-head

### DIFF
--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -303,6 +303,12 @@ class TestGemRequire < Gem::TestCase
 
   def test_realworld_default_gem
     skip "no default gems on ruby < 2.0" unless RUBY_VERSION >= "2"
+    begin
+      gem 'json'
+    rescue Gem::MissingSpecError
+      skip "default gems is only available after ruby installation"
+    end
+
     cmd = <<-RUBY
       $stderr = $stdout
       require "json"

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -306,7 +306,7 @@ class TestGemRequire < Gem::TestCase
     begin
       gem 'json'
     rescue Gem::MissingSpecError
-      skip "default gems is only available after ruby installation"
+      skip "default gems are only available after ruby installation"
     end
 
     cmd = <<-RUBY


### PR DESCRIPTION
# Description:

I ignored `test_realworld_default_gem`. Because default gem was enabled after ruby installation that is `make install`. It test always fail with ruby core test suite.

see also failing results: https://travis-ci.org/ruby/ruby/builds/257589943#L6992

______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
