### PR TITLE
Allow local installs with transitive prerelease requirements

### DIFF
--- a/lib/rubygems/source/local.rb
+++ b/lib/rubygems/source/local.rb
@@ -91,7 +91,7 @@ class Gem::Source::Local < Gem::Source
         if version.satisfied_by?(s.version)
           if prerelease
             found << s
-          elsif !s.version.prerelease?
+          elsif !s.version.prerelease? || version.prerelease?
             found << s
           end
         end

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -96,6 +96,39 @@ class TestGemCommandsInstallCommand < Gem::TestCase
     assert_match "1 gem installed", @ui.output
   end
 
+  def test_execute_local_transitive_prerelease
+    specs = spec_fetcher do |fetcher|
+      fetcher.download 'a', 2, 'b' => "2.a", 'c' => '3'
+      fetcher.download 'b', '2.a'
+      fetcher.download 'c', '3'
+    end
+
+    @cmd.options[:domain] = :local
+
+    FileUtils.mv specs['a-2'].cache_file, @tempdir
+    FileUtils.mv specs['b-2.a'].cache_file, @tempdir
+    FileUtils.mv specs['c-3'].cache_file, @tempdir
+
+    @cmd.options[:args] = %w[a]
+
+    use_ui @ui do
+      orig_dir = Dir.pwd
+      begin
+        Dir.chdir @tempdir
+        FileUtils.rm_r [@gemhome, "gems"]
+        assert_raises Gem::MockGemUi::SystemExitException, @ui.error do
+          @cmd.execute
+        end
+      ensure
+        Dir.chdir orig_dir
+      end
+    end
+
+    assert_equal %w[a-2 b-2.a c-3], @cmd.installed_specs.map { |spec| spec.full_name }.sort
+
+    assert_match "3 gems installed", @ui.output
+  end
+
   def test_execute_no_user_install
     skip 'skipped on MS Windows (chmod has no effect)' if win_platform?
 


### PR DESCRIPTION
# Description:

This closes https://github.com/rubygems/rubygems/issues/1988 by considering local prerelease gems when the requirement is a prerelease requirement.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).