### PR TITLE
Gem::Resolver#search_for update for reliable searching/sorting

### DIFF
--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -235,17 +235,16 @@ class Gem::Resolver
 
     groups = Hash.new { |hash, key| hash[key] = [] }
 
-    possibles.each do |spec|
+    # create groups & sources in the same loop
+    sources = possibles.map { |spec|
       source = spec.source
-
-      sources << source unless sources.include? source
-
       groups[source] << spec
-    end
+      source
+    }.uniq.reverse
 
     activation_requests = []
 
-    sources.sort.each do |source|
+    sources.each do |source|
       groups[source].
         sort_by { |spec| [spec.version, Gem::Platform.local =~ spec.platform ? 1 : 0] }.
         map { |spec| ActivationRequest.new spec, dependency, [] }.


### PR DESCRIPTION
# Description:

Recently a [commit](https://github.com/ruby/ruby/commit/41e1670a64405133e3d25b73e5cab9456ccb364e) on ruby/ruby addressed stable sort issues.   Currently, `Gem::Resolver#search_for` in [ruby](https://github.com/ruby/ruby/blob/a2f5275e0b0a79ad804eae3f6c817f8bf9979661/lib/rubygems/resolver.rb#L225-L235) is different from the same method [here](https://github.com/rubygems/rubygems/blob/0cfc24cbe742736648d3ab599598be656a9a1be1/lib/rubygems/resolver.rb#L225-L256).  The test for it [TestGemResolver#test_sorts_by_source_then_version](https://github.com/rubygems/rubygems/blob/0cfc24cbe742736648d3ab599598be656a9a1be1/test/rubygems/test_gem_resolver.rb#L686-L710) is not used at ruby/ruby.  Hence, unlike the commit, this issue wouldn't be visible in ruby/ruby testing.

The test fails against MinGW 2.4 & trunk.  This corrects that, and passes all the other versions in the Appveyor matrix.  It's also a more reliable sort algorithm, assuming that ruby continues to vary the stability of sorting and filtering.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
