### PR TITLE
Temporarily disable Bundler integration

### DIFF
--- a/lib/rubygems/commands/pristine_command.rb
+++ b/lib/rubygems/commands/pristine_command.rb
@@ -125,14 +125,14 @@ extensions will be restored.
         next
       end
 
-      unless spec.extensions.empty? or options[:extensions] then
+      unless spec.extensions.empty? or options[:extensions] or options[:only_executables] then
         say "Skipped #{spec.full_name}, it needs to compile an extension"
         next
       end
 
       gem = spec.cache_file
 
-      unless File.exist? gem then
+      unless File.exist? gem or options[:only_executables] then
         require 'rubygems/remote_fetcher'
 
         say "Cached gem for #{spec.full_name} not found, attempting to fetch..."
@@ -157,16 +157,19 @@ extensions will be restored.
           install_defaults.to_s['--env-shebang']
         end
 
-      installer = Gem::Installer.at(gem,
-                                     :wrappers => true,
-                                     :force => true,
-                                     :install_dir => spec.base_dir,
-                                     :env_shebang => env_shebang,
-                                     :build_args => spec.build_args)
-
+      installer_options = { 
+        :wrappers => true,
+        :force => true,
+        :install_dir => spec.base_dir,
+        :env_shebang => env_shebang,
+        :build_args => spec.build_args,
+      }
+      
       if options[:only_executables] then
+        installer = Gem::Installer.for_spec(spec, installer_options)
         installer.generate_bin
       else
+        installer = Gem::Installer.at(gem, installer_options)
         installer.install
       end
 

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -220,10 +220,9 @@ By default, this RubyGems will install gem as:
   def install_executables(bin_dir)
     @bin_file_names = []
 
-    {
-      'gem' => 'bin',
-      'bundler' => 'bundler/exe',
-    }.each do |tool, path|
+    executables = { 'gem' => 'bin' }
+    executables['bundler'] = 'bundler/exe' if Gem::USE_BUNDLER_FOR_GEMDEPS
+    executables.each do |tool, path|
       say "Installing #{tool} executable" if @verbose
 
       Dir.chdir path do
@@ -289,10 +288,9 @@ By default, this RubyGems will install gem as:
   end
 
   def install_lib(lib_dir)
-    {
-      'RubyGems' => 'lib',
-      'Bundler' => 'bundler/lib'
-    }.each do |tool, path|
+    libs = { 'RubyGems' => 'lib' }
+    libs['Bundler'] = 'bundler/lib' if Gem::USE_BUNDLER_FOR_GEMDEPS
+    libs.each do |tool, path|
       say "Installing #{tool}" if @verbose
 
       lib_files = rb_files_in path
@@ -352,26 +350,26 @@ By default, this RubyGems will install gem as:
   end
 
   def install_default_bundler_gem
-    Dir.chdir("bundler") do
-      bundler_spec = Gem::Specification.load("bundler.gemspec")
-      bundler_spec.files = Dir["{*.md,{lib,exe,man}/**/*}"]
-      bundler_spec.executables -= %w[bundler bundle_ruby]
-      Dir.entries(Gem::Specification.default_specifications_dir).
-        select {|gs| gs.start_with?("bundler-") }.
-        each {|gs| File.delete(File.join(Gem::Specification.default_specifications_dir, gs)) }
+    return unless Gem::USE_BUNDLER_FOR_GEMDEPS
 
-      default_spec_path = File.join(Gem::Specification.default_specifications_dir, "#{bundler_spec.full_name}.gemspec")
-      Gem.write_binary(default_spec_path, bundler_spec.to_ruby)
+    bundler_spec = Gem::Specification.load("bundler/bundler.gemspec")
+    bundler_spec.files = Dir["bundler/{*.md,{lib,exe,man}/**/*}"]
+    bundler_spec.executables -= %w[bundler bundle_ruby]
+    Dir.entries(Gem::Specification.default_specifications_dir).
+      select {|gs| gs.start_with?("bundler-") }.
+      each {|gs| File.delete(File.join(Gem::Specification.default_specifications_dir, gs)) }
 
-      bundler_spec = Gem::Specification.load(default_spec_path)
+    default_spec_path = File.join(Gem::Specification.default_specifications_dir, "#{bundler_spec.full_name}.gemspec")
+    Gem.write_binary(default_spec_path, bundler_spec.to_ruby)
 
-      Dir.entries(bundler_spec.gems_dir).
-        select {|default_gem| default_gem.start_with?("bundler-") }.
-        each {|default_gem| rm_r File.join(bundler_spec.gems_dir, default_gem) }
+    bundler_spec = Gem::Specification.load(default_spec_path)
 
-      mkdir_p bundler_spec.bin_dir
-      bundler_spec.executables.each {|e| cp File.join(bundler_spec.bindir, e), File.join(bundler_spec.bin_dir, e) }
-    end
+    Dir.entries(bundler_spec.gems_dir).
+      select {|default_gem| default_gem.start_with?("bundler-") }.
+      each {|default_gem| rm_r File.join(bundler_spec.gems_dir, default_gem) }
+
+    mkdir_p bundler_spec.bin_dir
+    bundler_spec.executables.each {|e| cp File.join("bundler", bundler_spec.bindir, e), File.join(bundler_spec.bin_dir, e) }
   end
 
   def make_destination_dirs(install_destdir)
@@ -464,10 +462,9 @@ abort "#{deprecation_message}"
   end
 
   def remove_old_lib_files lib_dir
-    {
-      File.join(lib_dir, 'rubygems') => 'lib/rubygems',
-      File.join(lib_dir, 'bundler') => 'bundler/lib/bundler',
-    }.each do |old_lib_dir, new_lib_dir|
+    lib_dirs = { File.join(lib_dir, 'rubygems') => 'lib/rubygems' }
+    lib_dirs[File.join(lib_dir, 'bundler')] = 'bundler/lib/bundler' if Gem::USE_BUNDLER_FOR_GEMDEPS
+    lib_dirs.each do |old_lib_dir, new_lib_dir|
       lib_files = rb_files_in(new_lib_dir)
 
       old_lib_files = rb_files_in(old_lib_dir)

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -533,9 +533,10 @@ abort "#{deprecation_message}"
   end
 
   def regenerate_binstubs
+    require "rubygems/commands/pristine_command"
+    say "Regenerating binstubs"
     command = Gem::Commands::PristineCommand.new
-    command.handle_options %w[--all --only-executables]
-    command.execute
+    command.invoke(*%w[--all --only-executables --silent])
   end
 
 end

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -473,7 +473,7 @@ class Gem::Installer
 
       unless File.exist? bin_path then
         # TODO change this to a more useful warning
-        warn "#{bin_path} maybe `gem pristine #{spec.name}` will fix it?"
+        warn "`#{bin_path}` does not exist, maybe `gem pristine #{spec.name}` will fix it?"
         next
       end
 

--- a/lib/rubygems/util.rb
+++ b/lib/rubygems/util.rb
@@ -109,26 +109,15 @@ module Gem::Util
   ##
   # Enumerates the parents of +directory+.
 
-  def self.traverse_parents directory
+  def self.traverse_parents directory, &block
     return enum_for __method__, directory unless block_given?
 
     here = File.expand_path directory
-    start = here
-
-    Dir.chdir start
-
-    begin
-      loop do
-        yield here
-
-        Dir.chdir '..'
-
-        return if Dir.pwd == here # toplevel
-
-        here = Dir.pwd
-      end
-    ensure
-      Dir.chdir start
+    loop do
+      Dir.chdir here, &block
+      new_here = File.expand_path('..', here)
+      return if new_here == here # toplevel
+      here = new_here
     end
   end
 

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -48,8 +48,10 @@ class TestGemCommandsSetupCommand < Gem::TestCase
       assert_path_exists File.join(dir, 'rubygems.rb')
       assert_path_exists File.join(dir, 'rubygems/ssl_certs/rubygems.org/foo.pem')
 
-      assert_path_exists File.join(dir, 'bundler.rb')
-      assert_path_exists File.join(dir, 'bundler/b.rb')
+      if Gem::USE_BUNDLER_FOR_GEMDEPS
+        assert_path_exists File.join(dir, 'bundler.rb')
+        assert_path_exists File.join(dir, 'bundler/b.rb')
+      end
     end
   end
 
@@ -84,7 +86,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
 
     refute_path_exists old_builder_rb
     refute_path_exists old_format_rb
-    refute_path_exists old_bundler_c_rb
+    refute_path_exists old_bundler_c_rb if Gem::USE_BUNDLER_FOR_GEMDEPS
 
     assert_path_exists securerandom_rb
     assert_path_exists engine_defaults_rb

--- a/test/rubygems/test_gem_util.rb
+++ b/test/rubygems/test_gem_util.rb
@@ -26,6 +26,7 @@ class TestGemUtil < Gem::TestCase
     assert_equal File.join(@tempdir, 'a/b/c'), enum.next
     assert_equal File.join(@tempdir, 'a/b'),   enum.next
     assert_equal File.join(@tempdir, 'a'),     enum.next
+    loop { break if enum.next.nil? } # exhaust the enumerator
   end
 
   def test_linked_list_find


### PR DESCRIPTION
Right now, I've been avoiding shipping `master` as RubyGems 2.7 for almost a year because (1) it relies on Bundler for `use_gemdeps` functionality (purposefully, as a part of the Bundler/RubyGems merger plan) and (2) Ruby core is not yet able to vendor a version of RubyGems that depends upon Bundler because they do not yet have they infrastructure in place to test Bundler (with rspec, etc) along with core.

This PR temporarily disables the Bundler integration, unblocking the release of 2.7. Once @hsbt gets Ruby core ready for a RubyGems that uses Bundler, we can flip the constant and ship a new minor version.