### PR TITLE
Require digest when it is used

### DIFF
--- a/lib/rubygems/source/git.rb
+++ b/lib/rubygems/source/git.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'digest'
 require 'rubygems/util'
 
 ##
@@ -226,6 +225,8 @@ class Gem::Source::Git < Gem::Source
   # A hash for the git gem based on the git repository URI.
 
   def uri_hash # :nodoc:
+    require 'digest' # required here to avoid deadlocking in Gem.activate_bin_path (because digest is a gem on 2.5+)
+
     normalized =
       if @repository =~ %r%^\w+://(\w+@)?% then
         uri = URI(@repository).normalize.to_s.sub %r%/$%,''


### PR DESCRIPTION
This avoids a potential issue where Gem.activate_bin_path could deadlock, since we'd attempt to activate the digest gem in the middle of activating other gems

This fixes 8 of the ten issues surfaced at https://travis-ci.org/bundler/bundler/jobs/271910850#L3531