### PR TITLE
matches_for_glob - remove root path

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -275,10 +275,10 @@ class Gem::BasicSpecification
   # for this spec.
 
   def lib_dirs_glob
-    dirs = if self.require_paths.size > 1 then
-             "{#{self.require_paths.join(',')}}"
+    dirs = if self.raw_require_paths.size > 1 then
+             "{#{self.raw_require_paths.join(',')}}"
            else
-             self.require_paths.first
+             self.raw_require_paths.first
            end
 
     "#{self.full_gem_path}/#{dirs}".dup.untaint

--- a/test/rubygems/test_gem_stub_specification.rb
+++ b/test/rubygems/test_gem_stub_specification.rb
@@ -95,6 +95,12 @@ class TestStubSpecification < Gem::TestCase
     assert_equal File.join(stub.full_gem_path, 'lib'), stub.lib_dirs_glob
   end
 
+  def test_lib_dirs_glob_with_extension
+    stub = stub_with_extension
+
+    assert_equal File.join(stub.full_gem_path, 'lib'), stub.lib_dirs_glob
+  end
+
   def test_matches_for_glob
     stub = stub_without_extension
     code_rb = File.join stub.gem_dir, 'lib', 'code.rb'


### PR DESCRIPTION
# Description:
Hi,
during my testing I found out that this method uses a wierd glob pattern.

```
  def matches_for_glob glob # TODO: rename?
    # TODO: do we need these?? Kill it
    glob = File.join(self.lib_dirs_glob, glob)

    Dir[glob].map { |f| f.untaint } # FIX our tests are broken, run w/ SAFE=1
  end
```

example:
c:/rubyinstaller/sandbox/ruby25_mingw/lib/ruby/gems/2.5.0/gems/bigdecimal-1.3.2/{**c:/rubyinstaller/sandbox/ruby25_mingw/lib/ruby/gems/2.5.0/extensions/x64-mingw32/2.5.0/bigdecimal-1.3.2**,lib}

I think it's a bug because the absolute path in the pattern will never be matched.

I attached a PR that removes absolute paths from the pattern. What do you think?
______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
