### PR TITLE
Allow the require bundler specs to pass when bundler is installed as a default gem

### DIFF
--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -385,20 +385,20 @@ class TestGemRequire < Gem::TestCase
 
 
   def test_require_bundler
-    $:.reject! {|lp| File.expand_path(lp).end_with?("bundler/lib") }
     b1 = new_spec('bundler', '1', nil, "lib/bundler/setup.rb")
     b2a = new_spec('bundler', '2.a', nil, "lib/bundler/setup.rb")
     install_specs b1, b2a
 
+    require "rubygems/bundler_version_finder"
+    $:.clear
     assert_require 'bundler/setup'
     assert_equal %w[bundler-2.a], loaded_spec_names
     assert_empty unresolved_names
   end
 
   def test_require_bundler_missing_bundler_version
-    $:.reject! {|lp| File.expand_path(lp).end_with?("bundler/lib") }
     Gem::BundlerVersionFinder.stub(:bundler_version_with_reason, ["55", "reason"]) do
-      b1 = new_spec('bundler', '1', nil, "lib/bundler/setup.rb")
+      b1 = new_spec('bundler', '1.999999999', nil, "lib/bundler/setup.rb")
       b2a = new_spec('bundler', '2.a', nil, "lib/bundler/setup.rb")
       install_specs b1, b2a
 
@@ -410,14 +410,14 @@ class TestGemRequire < Gem::TestCase
   end
 
   def test_require_bundler_with_bundler_version
-    $:.reject! {|lp| File.expand_path(lp).end_with?("bundler/lib") }
     Gem::BundlerVersionFinder.stub(:bundler_version_with_reason, ["1", "reason"]) do
-      b1 = new_spec('bundler', '1', nil, "lib/bundler/setup.rb")
+      b1 = new_spec('bundler', '1.999999999', nil, "lib/bundler/setup.rb")
       b2 = new_spec('bundler', '2', nil, "lib/bundler/setup.rb")
       install_specs b1, b2
 
+      $:.clear
       assert_require 'bundler/setup'
-      assert_equal %w[bundler-1], loaded_spec_names
+      assert_equal %w[bundler-1.999999999], loaded_spec_names
     end
   end
 


### PR DESCRIPTION
This should fix the specs when running against ruby trunk, as the load path that contains bundler no longer ends in `bundler/lib`, as it did when running with `-I bundler/lib` (e.g. its in with the ruby stdlib)