### PR TITLE
Re-enable using Bundler for gemdeps

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -178,7 +178,7 @@ module Gem
     write_binary_errors
   end.freeze
 
-  USE_BUNDLER_FOR_GEMDEPS = false # :nodoc:
+  USE_BUNDLER_FOR_GEMDEPS = true # :nodoc:
 
   @@win_platform = nil
 


### PR DESCRIPTION
# Description:

Since @hsbt told us that we're ready to release v2.7 _including the use of Bundler_, we can safely re-enable using Bundler!