### PR TITLE
Renamed test fixture name on TestRequire

### DIFF
--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -386,11 +386,11 @@ class TestGemRequire < Gem::TestCase
 
   def test_require_bundler
     $:.reject! {|lp| File.expand_path(lp).end_with?("bundler/lib") }
-    b1 = new_spec('bundler', '1', nil, "lib/bundler/setup.rb")
-    b2a = new_spec('bundler', '2.a', nil, "lib/bundler/setup.rb")
+    b1 = new_spec('bundler', '1', nil, "lib/bundler/a.rb")
+    b2a = new_spec('bundler', '2.a', nil, "lib/bundler/a.rb")
     install_specs b1, b2a
 
-    assert_require 'bundler/setup'
+    assert_require 'bundler/a'
     assert_equal %w[bundler-2.a], loaded_spec_names
     assert_empty unresolved_names
   end
@@ -398,8 +398,8 @@ class TestGemRequire < Gem::TestCase
   def test_require_bundler_missing_bundler_version
     $:.reject! {|lp| File.expand_path(lp).end_with?("bundler/lib") }
     Gem::BundlerVersionFinder.stub(:bundler_version_with_reason, ["55", "reason"]) do
-      b1 = new_spec('bundler', '1', nil, "lib/bundler/setup.rb")
-      b2a = new_spec('bundler', '2.a', nil, "lib/bundler/setup.rb")
+      b1 = new_spec('bundler', '1', nil, "lib/bundler/a.rb")
+      b2a = new_spec('bundler', '2.a', nil, "lib/bundler/a.rb")
       install_specs b1, b2a
 
       e = assert_raises Gem::MissingSpecVersionError do
@@ -412,11 +412,11 @@ class TestGemRequire < Gem::TestCase
   def test_require_bundler_with_bundler_version
     $:.reject! {|lp| File.expand_path(lp).end_with?("bundler/lib") }
     Gem::BundlerVersionFinder.stub(:bundler_version_with_reason, ["1", "reason"]) do
-      b1 = new_spec('bundler', '1', nil, "lib/bundler/setup.rb")
-      b2 = new_spec('bundler', '2', nil, "lib/bundler/setup.rb")
+      b1 = new_spec('bundler', '1', nil, "lib/bundler/a.rb")
+      b2 = new_spec('bundler', '2', nil, "lib/bundler/a.rb")
       install_specs b1, b2
 
-      assert_require 'bundler/setup'
+      assert_require 'bundler/a'
       assert_equal %w[bundler-1], loaded_spec_names
     end
   end


### PR DESCRIPTION
# Description:

@segiddins 

I renamed fixture name to `a.rb` from `setup.rb`.  Because Ruby 2.5 contains "lib/bundler/setup.rb" with real code of bundler. I think that it name is enough to test case.

Related with https://github.com/rubygems/rubygems/pull/2012

______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
