### PR TITLE
allow failures for ruby trunk in appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,6 +31,10 @@ environment:
   - ruby_version: _trunk
     GIT:  C:/git/cmd/git.exe
 
+matrix:
+  allow_failures:
+    - ruby_version: _trunk
+
 install:
 - ps: >-
     git submodule update --init --recursive


### PR DESCRIPTION
 Description:

We should allow build failures for trunk ruby in appveyor. This will let PRs that pass all released & supported versions of ruby to have green status builds and be merged more easily.

See #2009, #2010 

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
