### PR TITLE
Change trunk build from BinTray to Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,8 +10,8 @@ clone_depth: 10
 init:
   - mklink /d C:\git "C:\Program Files\Git"
   - if %ruby_version%==_trunk (
-      appveyor DownloadFile https://dl.bintray.com/msp-greg/ruby_windows/ruby_trunk.7z -FileName C:\ruby_trunk.7z &
-      7z x C:\ruby_trunk.7z -oC:\ruby_trunk & C:\ruby_trunk\trunk_install.cmd )
+      appveyor DownloadFile https://ci.appveyor.com/api/projects/MSP-Greg/ruby-loco/artifacts/ruby_trunk.7z -FileName C:\ruby_trunk.7z &
+      7z x C:\ruby_trunk.7z -oC:\ruby_trunk )
 
 environment:
   PATH: C:/ruby%ruby_version%/bin;C:/Program Files/7-Zip;C:/Program Files/AppVeyor/BuildAgent;C:/git/cmd;C:/Program Files (x86)/GNU/GnuPG/pub;C:/Windows/system32;C:\Windows;


### PR DESCRIPTION
# Description:

Previously added trunk build to appveyor.yml.  At the time, build was done locally and pushed to BinTray.  Rolling trunk build (twice daily) is now done on Appveyor.  Changed download URI in appveyor.yml to account for the change.

Also, since nothing is compiled with OpenSSL or GDBM, removed package download.

Tests passed on my fork.
______________

# Tasks:

- [X] Describe the problem / feature
- [ ] Write tests
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
