### PR TITLE
add info command to print information about an installed gem

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -267,6 +267,7 @@ lib/rubygems/commands/environment_command.rb
 lib/rubygems/commands/fetch_command.rb
 lib/rubygems/commands/generate_index_command.rb
 lib/rubygems/commands/help_command.rb
+lib/rubygems/commands/info_command.rb
 lib/rubygems/commands/install_command.rb
 lib/rubygems/commands/list_command.rb
 lib/rubygems/commands/lock_command.rb
@@ -503,6 +504,7 @@ test/rubygems/test_gem_commands_environment_command.rb
 test/rubygems/test_gem_commands_fetch_command.rb
 test/rubygems/test_gem_commands_generate_index_command.rb
 test/rubygems/test_gem_commands_help_command.rb
+test/rubygems/test_gem_commands_info_command.rb
 test/rubygems/test_gem_commands_install_command.rb
 test/rubygems/test_gem_commands_list_command.rb
 test/rubygems/test_gem_commands_lock_command.rb

--- a/lib/rubygems/command_manager.rb
+++ b/lib/rubygems/command_manager.rb
@@ -45,6 +45,7 @@ class Gem::CommandManager
     :fetch,
     :generate_index,
     :help,
+    :info,
     :install,
     :list,
     :lock,

--- a/lib/rubygems/commands/info_command.rb
+++ b/lib/rubygems/commands/info_command.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rubygems/command'
+require 'rubygems/commands/query_command'
+
+class Gem::Commands::InfoCommand < Gem::Commands::QueryCommand
+  def initialize
+    super "info", "Show information for the given gem"
+
+    remove_option('--name-matches')
+    remove_option('-d')
+
+    defaults[:details] = true
+    defaults[:exact] = true
+  end
+
+  def description # :nodoc:
+    "Info prints information about the gem such as name,"\
+    " description, website, license and installed paths"
+  end
+
+  def usage # :nodoc:
+    "#{program_name} GEMNAME"
+  end
+
+  def arguments # :nodoc:
+    "GEMNAME        name of the gem to print information about"
+  end
+
+  def defaults_str
+    "--local"
+  end
+end

--- a/test/rubygems/test_gem_commands_info_command.rb
+++ b/test/rubygems/test_gem_commands_info_command.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+require 'rubygems/test_case'
+require 'rubygems/commands/info_command'
+
+class TestGemCommandsInfoCommand < Gem::TestCase
+
+  def setup
+    super
+
+    @cmd = Gem::Commands::InfoCommand.new
+  end
+
+  def gem(name, version = "1.0")
+    spec = quick_gem name do |gem|
+      gem.summary = "test gem"
+      gem.homepage = "https://github.com/rubygems/rubygems"
+      gem.files = %W[lib/#{name}.rb Rakefile]
+      gem.authors = ["Colby", "Jack"]
+      gem.license = "MIT"
+      gem.version = version
+    end
+    write_file File.join(*%W[gems #{spec.full_name} lib #{name}.rb])
+    write_file File.join(*%W[gems #{spec.full_name} Rakefile])
+    spec
+  end
+
+  def test_execute
+    @gem = gem "foo", "1.0.0"
+
+    @cmd.handle_options %w[foo]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    assert_match %r%#{@gem.name} \(#{@gem.version}\)\n%, @ui.output
+    assert_match %r%Authors: #{@gem.authors.join(', ')}\n%, @ui.output
+    assert_match %r%Homepage: #{@gem.homepage}\n%, @ui.output
+    assert_match %r%License: #{@gem.license}\n%, @ui.output
+    assert_match %r%Installed at: #{@gem.base_dir}\n%, @ui.output
+    assert_match %r%#{@gem.summary}\n%, @ui.output
+    assert_match "", @ui.error
+  end
+end


### PR DESCRIPTION
# Description:

Quiet often i want to know some information about a gem installed in my ruby environment such as what the gem does and a link to get more information. Currently i need to find this information via RubyGems.org which is both is taxing and unnecessary for the the user.

There is currently a `specification` command which prints the specification in YAML to the user but i find this as not very user friendly.

This PR introduces the `info` command which prints a set of basic information about the given gem, such as the homepage, path and the summary in a simple and UI friendly manner:

```
$ gem info rack
  * rack (2.0.3)
        Summary: a modular Ruby webserver interface
        Homepage: http://rack.github.io/
        Path: /Users/c/.gem/ruby/2.3.1/gems/rack-2.0.3
```
This allows me to get a quick sense of what the gem does and a link that i can follow for more information if i wanted to.

Note: This command is nearly the same thing as `bundle info` that i also implemented

The `info` command also allows specifying a version, such as:

```
$ gem info rack -v 1.6.8
  * rack (1.6.8)
        Summary: a modular Ruby webserver interface
        Homepage: http://rack.github.io/
        Path: /Users/c/.gem/ruby/2.3.1/gems/rack-1.6.8
```

It will also note if the gem is a default gem as well

```
› gem info json
  * json (1.8.3)
        Summary: This json is bundled with Ruby
        Path: /Users/c/.rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/json-1.8.3
        Default Gem: yes
```
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
