### PR TITLE
Removed trailing-whitespaces

### DIFF
--- a/test/rubygems/test_gem_commands_sources_command.rb
+++ b/test/rubygems/test_gem_commands_sources_command.rb
@@ -157,7 +157,7 @@ source http://gems.example.com/ already present in the cache
     EOF
 
     assert_equal expected, @ui.output
-    assert_equal '', @ui.error 
+    assert_equal '', @ui.error
   end
 
   def test_execute_add_http_rubygems_org

--- a/test/rubygems/test_gem_ext_rake_builder.rb
+++ b/test/rubygems/test_gem_ext_rake_builder.rb
@@ -53,7 +53,7 @@ class TestGemExtRakeBuilder < Gem::TestCase
       assert_match %r%^#{Regexp.escape @@ruby} mkrf_conf\.rb%, output
       assert_match %r%^#{Regexp.escape rake} RUBYARCHDIR=#{Regexp.escape @dest_path} RUBYLIBDIR=#{Regexp.escape @dest_path}%, output
     end
-  end  
+  end
 
   def test_class_build_fail
     create_temp_mkrf_file("task :default do abort 'fail' end")
@@ -69,7 +69,7 @@ class TestGemExtRakeBuilder < Gem::TestCase
       assert_match %r%^rake failed%, error.message
     end
   end
-  
+
   def create_temp_mkrf_file(rakefile_content)
     File.open File.join(@ext, 'mkrf_conf.rb'), 'w' do |mkrf_conf|
       mkrf_conf.puts <<-EO_MKRF


### PR DESCRIPTION
I always faced this issue when merging ruby core repository.