### PR TITLE
Rename `-rubygems` option. 

### DIFF
--- a/lib/rubygems/ext/rake_builder.rb
+++ b/lib/rubygems/ext/rake_builder.rb
@@ -20,7 +20,7 @@ class Gem::Ext::RakeBuilder < Gem::Ext::Builder
     rake = ENV['rake']
 
     rake ||= begin
-               "#{Gem.ruby} -rubygems #{Gem.bin_path('rake', 'rake')}"
+               "#{Gem.ruby} -rrubygems #{Gem.bin_path('rake', 'rake')}"
              rescue Gem::Exception
              end
 


### PR DESCRIPTION
This option only needs Ruby 1.8. and It will remove at Ruby 2.5.

This commit was picked r60125 from ruby/ruby:  https://github.com/ruby/ruby/commit/9de6c712b66aad77df40661c1fc6d37e9a5c251a