### PR TITLE
ubygems.rb is unavailable on Ruby 2.5

### DIFF
--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1509,7 +1509,7 @@ class TestGem < Gem::TestCase
 
     path = File.join @tempdir, "gem.deps.rb"
     cmd = [Gem.ruby.dup.untaint, "-I#{LIB_PATH.untaint}",
-           "-I#{BUNDLER_LIB_PATH.untaint}", "-rubygems"]
+           "-I#{BUNDLER_LIB_PATH.untaint}", "-rrubygems"]
     if RUBY_VERSION < '1.9'
       cmd << "-e 'puts Gem.loaded_specs.values.map(&:full_name).sort'"
       cmd = cmd.join(' ')


### PR DESCRIPTION
Follow up with https://github.com/rubygems/rubygems/pull/2027