### PR TITLE
Do not index the doc folder in the `update_manifest` task.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -95,7 +95,7 @@ Hoe::Package.instance_method(:install_gem).tap do |existing_install_gem|
   end
 end
 
-Hoe::DEFAULT_CONFIG["exclude"] = %r[#{Hoe::DEFAULT_CONFIG["exclude"]}|\./bundler/(?!lib|man|exe|[^/]+\.md)]ox
+Hoe::DEFAULT_CONFIG["exclude"] = %r[#{Hoe::DEFAULT_CONFIG["exclude"]}|\./bundler/(?!lib|man|exe|[^/]+\.md)|doc/]ox
 
 v = hoe.version
 


### PR DESCRIPTION
# Description:

A small problem I have come across while doing work on RubyGems is when I need to update the Manifest.

When running the `rake newb` - the task generates the RubyGems docs which is an entry in `.gitignore` but is not ignored in the `rake update_manifest` task. This means that everyone has to remember to either remove the `doc` folder beforehand or remove the entries in `Manifest.txt`. We should just be ignoring the `doc` folder entirely.

______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).