### PR TITLE
[SafeYAML] Avoid warning when Gem::Deprecate.skip is set

### DIFF
--- a/lib/rubygems/safe_yaml.rb
+++ b/lib/rubygems/safe_yaml.rb
@@ -35,7 +35,10 @@ module Gem
         ::YAML.safe_load(input, [::Symbol])
       end
     else
-      warn "YAML safe loading is not available. Please upgrade psych to a version that supports safe loading (>= 2.0)."
+      unless Gem::Deprecate.skip
+        warn "YAML safe loading is not available. Please upgrade psych to a version that supports safe loading (>= 2.0)."
+      end
+
       def self.safe_load input, *args
         ::YAML.load input
       end


### PR DESCRIPTION
# Description:

This will allow Bundler to suppress the warnings, so we can get the tests passing again

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).