### PR TITLE
Refactor api_endpoint to be more explicit

### DIFF
--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -109,9 +109,12 @@ class Gem::RemoteFetcher
       uri
     else
       target = res.target.to_s.strip
+      target_host = URI("https://" + target).host
 
-      if URI("http://" + target).host.end_with?(".#{host}")
-        return URI.parse "#{uri.scheme}://#{target}#{uri.path}"
+      if target_host.end_with?(".#{host}")
+        uri = uri.dup
+        uri.host = target_host
+        return uri
       end
 
       uri

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -196,6 +196,21 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     dns.verify
   end
 
+  def test_api_endpoint_changes_host_only
+    uri = URI.parse "http://example.com/foo"
+    target = MiniTest::Mock.new
+    target.expect :target, "user:pass@gems.example.com:8000/path?query=value#fragment"
+
+    dns = MiniTest::Mock.new
+    dns.expect :getresource, target, [String, Object]
+
+    fetch = Gem::RemoteFetcher.new nil, dns
+    assert_equal URI.parse("http://gems.example.com/foo"), fetch.api_endpoint(uri)
+
+    target.verify
+    dns.verify
+  end
+
   def test_api_endpoint_ignores_trans_domain_values
     uri = URI.parse "http://gems.example.com/foo"
     target = MiniTest::Mock.new


### PR DESCRIPTION
# Description:

The input validation checks on SRV api endpoint discovery are sane, but it's usage afterwards could be better.  This PR incorporates feedback from david@bamsoftware.com, to make this even safer and more explicit how we're handling this potentially unsafe input that helps with API discovery.
______________

# Tasks:

- [X] Describe the problem / feature
- [X] Write tests
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
