### PR TITLE
Fix `gem update --system` with RubyGems 2.7+

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -23,6 +23,7 @@ bundler/CODE_OF_CONDUCT.md
 bundler/CONTRIBUTING.md
 bundler/LICENSE.md
 bundler/README.md
+bundler/bundler.gemspec
 bundler/exe/bundle
 bundler/exe/bundle_ruby
 bundler/exe/bundler

--- a/Rakefile
+++ b/Rakefile
@@ -95,7 +95,7 @@ Hoe::Package.instance_method(:install_gem).tap do |existing_install_gem|
   end
 end
 
-Hoe::DEFAULT_CONFIG["exclude"] = %r[#{Hoe::DEFAULT_CONFIG["exclude"]}|\./bundler/(?!lib|man|exe|[^/]+\.md)|doc/]ox
+Hoe::DEFAULT_CONFIG["exclude"] = %r[#{Hoe::DEFAULT_CONFIG["exclude"]}|\./bundler/(?!lib|man|exe|[^/]+\.md|bundler.gemspec)|doc/]ox
 
 v = hoe.version
 

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -370,6 +370,8 @@ By default, this RubyGems will install gem as:
 
     mkdir_p bundler_spec.bin_dir
     bundler_spec.executables.each {|e| cp File.join("bundler", bundler_spec.bindir, e), File.join(bundler_spec.bin_dir, e) }
+
+    say "Bundler #{bundler_spec.version} installed"
   end
 
   def make_destination_dirs(install_destdir)

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -355,7 +355,7 @@ By default, this RubyGems will install gem as:
     mkdir_p Gem::Specification.default_specifications_dir
 
     bundler_spec = Gem::Specification.load("bundler/bundler.gemspec")
-    bundler_spec.files = Dir["bundler/{*.md,{lib,exe,man}/**/*}"]
+    bundler_spec.files = Dir.chdir("bundler") { Dir["{*.md,{lib,exe,man}/**/*}"] }
     bundler_spec.executables -= %w[bundler bundle_ruby]
     Dir.entries(Gem::Specification.default_specifications_dir).
       select {|gs| gs.start_with?("bundler-") }.

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -352,7 +352,7 @@ By default, this RubyGems will install gem as:
   def install_default_bundler_gem
     return unless Gem::USE_BUNDLER_FOR_GEMDEPS
 
-    return unless File.directory?(Gem::Specification.default_specifications_dir)
+    mkdir_p Gem::Specification.default_specifications_dir
 
     bundler_spec = Gem::Specification.load("bundler/bundler.gemspec")
     bundler_spec.files = Dir["bundler/{*.md,{lib,exe,man}/**/*}"]

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -352,6 +352,8 @@ By default, this RubyGems will install gem as:
   def install_default_bundler_gem
     return unless Gem::USE_BUNDLER_FOR_GEMDEPS
 
+    return unless File.directory?(Gem::Specification.default_specifications_dir)
+
     bundler_spec = Gem::Specification.load("bundler/bundler.gemspec")
     bundler_spec.files = Dir["bundler/{*.md,{lib,exe,man}/**/*}"]
     bundler_spec.executables -= %w[bundler bundle_ruby]


### PR DESCRIPTION
# Description:

Fixes #2052.

By including the bundler gemspec in the manifest, it should allow the setup task to succeed when run from the published rubygems-update gem, and not just from source.

When we merge this, I will release 2.7.1 ?
