### PR TITLE
Add --[no-]check-development option to cleanup command

### DIFF
--- a/lib/rubygems/commands/cleanup_command.rb
+++ b/lib/rubygems/commands/cleanup_command.rb
@@ -8,11 +8,18 @@ class Gem::Commands::CleanupCommand < Gem::Command
   def initialize
     super 'cleanup',
           'Clean up old versions of installed gems',
-          :force => false, :install_dir => Gem.dir
+          :force => false, :install_dir => Gem.dir,
+          :check_dev => true
 
     add_option('-n', '-d', '--dryrun',
                'Do not uninstall gems') do |value, options|
       options[:dryrun] = true
+    end
+
+    add_option('-D', '--[no-]check-development',
+               'Check development dependencies while uninstalling',
+               '(default: true)') do |value, options|
+      options[:check_dev] = value
     end
 
     @candidate_gems  = nil
@@ -138,7 +145,7 @@ If no gems are named all gems in GEM_HOME are cleaned.
   end
 
   def uninstall_dep spec
-    return unless @full.ok_to_remove?(spec.full_name)
+    return unless @full.ok_to_remove?(spec.full_name, options[:check_dev])
 
     if options[:dryrun] then
       say "Dry Run Mode: Would uninstall #{spec.full_name}"


### PR DESCRIPTION
Default to check so it keeps backward compatibility.

# Description:

I just realized that there's no way to force cleaning up gems without checking development dependency. I wish at least we have an option:

```
gem cleanup --no-check-development
```

This is a bit too verbose to my taste, but to make it backward compatible and consistent with the uninstall command, this is probably the way to do it.

Thanks for reviewing.
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
