### PR TITLE
Workaround for non-git environment.

### DIFF
--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -354,6 +354,10 @@ By default, this RubyGems will install gem as:
 
     mkdir_p Gem::Specification.default_specifications_dir
 
+    # Workaround for non-git environment.
+    gemspec = File.read('bundler/bundler.gemspec').gsub(/`git ls-files -z`/, "''")
+    File.open('bundler/bundler.gemspec', 'w'){|f| f.write gemspec }
+
     bundler_spec = Gem::Specification.load("bundler/bundler.gemspec")
     bundler_spec.files = Dir.chdir("bundler") { Dir["{*.md,{lib,exe,man}/**/*}"] }
     bundler_spec.executables -= %w[bundler bundle_ruby]


### PR DESCRIPTION
Fixes #2064

Ignored `git` command. It's no effects for installation of vendored bundler.

Because we overwrite file list when invoking `update_rubygems`.
