### PR TITLE
Show which gem referenced a missing gem

### DIFF
--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -152,14 +152,25 @@ class Gem::Command
   #--
   # TODO: replace +domain+ with a parameter to suppress suggestions
 
-  def show_lookup_failure(gem_name, version, errors, domain)
+  def show_lookup_failure(gem_name, version, errors, domain, required_by = nil)
+    gem = "'#{gem_name}' (#{version})"
+
+    msg = StringIO.new "Could not find a valid gem #{gem}".dup, "a+"
+
     if errors and !errors.empty?
-      msg = "Could not find a valid gem '#{gem_name}' (#{version}), here is why:\n".dup
+      msg << ", here is why:\n"
       errors.each { |x| msg << "          #{x.wordy}\n" }
-      alert_error msg
     else
-      alert_error "Could not find a valid gem '#{gem_name}' (#{version}) in any repository"
+      if required_by && gem != required_by then
+        msg << " (required by #{required_by}) in any repository"
+      else
+        msg << " in any repository"
+      end
     end
+
+    msg.close
+
+    alert_error msg.string
 
     unless domain == :local then # HACK
       suggestions = Gem::SpecFetcher.fetcher.suggest_gems_from_name gem_name

--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -154,23 +154,20 @@ class Gem::Command
 
   def show_lookup_failure(gem_name, version, errors, domain, required_by = nil)
     gem = "'#{gem_name}' (#{version})"
-
-    msg = StringIO.new "Could not find a valid gem #{gem}".dup, "a+"
+    msg = String.new "Could not find a valid gem #{gem}"
 
     if errors and !errors.empty?
       msg << ", here is why:\n"
       errors.each { |x| msg << "          #{x.wordy}\n" }
     else
-      if required_by && gem != required_by then
+      if required_by and gem != required_by then
         msg << " (required by #{required_by}) in any repository"
       else
         msg << " in any repository"
       end
     end
 
-    msg.close
-
-    alert_error msg.string
+    alert_error msg
 
     unless domain == :local then # HACK
       suggestions = Gem::SpecFetcher.fetcher.suggest_gems_from_name gem_name

--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -250,16 +250,21 @@ to write the specification by hand.  For example:
 
     get_all_gem_names_and_versions.each do |gem_name, gem_version|
       gem_version ||= options[:version]
+      domain = options[:domain]
+      domain = :local unless options[:suggest_alternate]
 
       begin
         install_gem gem_name, gem_version
       rescue Gem::InstallError => e
         alert_error "Error installing #{gem_name}:\n\t#{e.message}"
         exit_code |= 1
-      rescue Gem::GemNotFoundException, Gem::UnsatisfiableDependencyError => e
-        domain = options[:domain]
-        domain = :local unless options[:suggest_alternate]
+      rescue Gem::GemNotFoundException => e
         show_lookup_failure e.name, e.version, e.errors, domain
+
+        exit_code |= 2
+      rescue Gem::UnsatisfiableDependencyError => e
+        show_lookup_failure e.name, e.version, e.errors, domain,
+                            "'#{gem_name}' (#{gem_version})"
 
         exit_code |= 2
       end
@@ -300,4 +305,3 @@ to write the specification by hand.  For example:
   end
 
 end
-

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -691,6 +691,29 @@ ERROR:  Possible alternatives: non_existent_with_hint
     assert_match %r!Could not find a valid gem 'a' \(= 10.0\)!, @ui.error
   end
 
+  def test_show_dependent_gem
+    spec_fetcher do |fetcher|
+      fetcher.spec 'foo', 2, 'bar' => '0.5'
+    end
+
+    @cmd.options[:args] = ['foo']
+    @cmd.options[:suggest_alternate] = false
+
+    use_ui @ui do
+      e = assert_raises Gem::MockGemUi::TermError do
+        @cmd.execute
+      end
+
+      assert_equal 2, e.exit_code
+    end
+
+    expected = <<-EXPECTED
+ERROR:  Could not find a valid gem 'bar' (= 0.5) (required by 'foo' (>= 0)) in any repository
+    EXPECTED
+
+    assert_equal expected, @ui.error
+  end
+
   def test_show_errors_on_failure
     Gem.sources.replace ["http://not-there.nothing"]
 

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -200,6 +200,28 @@ class TestGemCommandsInstallCommand < Gem::TestCase
     assert_match(/ould not find a valid gem 'nonexistent'/, @ui.error)
   end
 
+  def test_execute_dependency_nonexistent
+    spec_fetcher do |fetcher|
+      fetcher.spec 'foo', 2, 'bar' => '0.5'
+    end
+
+    @cmd.options[:args] = ['foo']
+
+    use_ui @ui do
+      e = assert_raises Gem::MockGemUi::TermError do
+        @cmd.execute
+      end
+
+      assert_equal 2, e.exit_code
+    end
+
+    expected = <<-EXPECTED
+ERROR:  Could not find a valid gem 'bar' (= 0.5) (required by 'foo' (>= 0)) in any repository
+    EXPECTED
+
+    assert_equal expected, @ui.error
+  end
+
   def test_execute_bad_source
     spec_fetcher
 
@@ -689,29 +711,6 @@ ERROR:  Possible alternatives: non_existent_with_hint
 
     assert_equal 2, e.exit_code
     assert_match %r!Could not find a valid gem 'a' \(= 10.0\)!, @ui.error
-  end
-
-  def test_show_dependent_gem
-    spec_fetcher do |fetcher|
-      fetcher.spec 'foo', 2, 'bar' => '0.5'
-    end
-
-    @cmd.options[:args] = ['foo']
-    @cmd.options[:suggest_alternate] = false
-
-    use_ui @ui do
-      e = assert_raises Gem::MockGemUi::TermError do
-        @cmd.execute
-      end
-
-      assert_equal 2, e.exit_code
-    end
-
-    expected = <<-EXPECTED
-ERROR:  Could not find a valid gem 'bar' (= 0.5) (required by 'foo' (>= 0)) in any repository
-    EXPECTED
-
-    assert_equal expected, @ui.error
   end
 
   def test_show_errors_on_failure


### PR DESCRIPTION
# Description:
If gem's dependency is missing, the output just shows the missing gem,
leaving the dependent gem obscure. (#2039)

This change adds the dependent gem to the output message.
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
