### PR TITLE
Ignored failing matrix with bundler tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,5 +47,12 @@ matrix:
     - rvm: ruby-head
       env: "TEST_TOOL=rubygems YAML=syck"
   allow_failures:
+    - rvm: 1.8.7
+      env: "TEST_TOOL=bundler RGV=master"
+    - rvm: 1.9.3
+      env: "TEST_TOOL=bundler RGV=master"
+    - rvm: 2.0.0
+      env: "TEST_TOOL=bundler RGV=master"
+    - rvm: 2.1.10
+      env: "TEST_TOOL=bundler RGV=master"
     - rvm: ruby-head
-


### PR DESCRIPTION
Temporary ignored for releasing RG 2.7.2.