### PR TITLE
Removed needless version lock

### DIFF
--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -2,12 +2,6 @@
 require 'rubygems/test_case'
 require 'rubygems/commands/update_command'
 
-begin
-  gem "rdoc"
-rescue Gem::LoadError
-  # ignore
-end
-
 class TestGemCommandsUpdateCommand < Gem::TestCase
 
   def setup


### PR DESCRIPTION
`gem "rdoc"` on test_gem_commands_update_command.rb sometimes fails parallel tests on ruby core ci environment. This code was added for removing warning message on test runner at 7 years ago. ( https://github.com/rubygems/rubygems/commit/674eae6a7074a81aee60f7a74a6576fe6006be99 )



