### PR TITLE
Fix test failure on Alpine Linux.

### DIFF
--- a/test/rubygems/test_gem_ext_configure_builder.rb
+++ b/test/rubygems/test_gem_ext_configure_builder.rb
@@ -54,7 +54,7 @@ class TestGemExtConfigureBuilder < Gem::TestCase
       end
     end
 
-    shell_error_msg = %r{(\./configure: .*)|((?:Can't|cannot) open \./configure(?:: No such file or directory)?)}
+    shell_error_msg = %r{(\./configure: .*)|((?:[Cc]an't|cannot) open '?\./configure'?(?:: No such file or directory)?)}
     sh_prefix_configure = "sh ./configure --prefix="
 
     assert_match 'configure failed', error.message


### PR DESCRIPTION
# Description:

Fixes a test failure on Alpine Linux. The test failure was due to a regular expression that didn't match the output of `sh` on Alpine.

Fixes #2075.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
