### PR TITLE
Fix rake install_test_deps once the rake clean_env does not exist

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -144,7 +144,7 @@ end
 task(:newb).prerequisites.unshift "bundler:checkout"
 
 desc "Install gems needed to run the tests"
-task :install_test_deps => :clean_env do
+task :install_test_deps => :clean do
   sh "gem install minitest -v '~> 4.0'"
 end
 


### PR DESCRIPTION
# Description:

Problem: running `rake install_test_deps` is raising an error:

![rake-with-error](https://user-images.githubusercontent.com/2293178/33078993-85de9ab0-cebb-11e7-93ff-8737fda7e9ac.png)

Solution: change the `rake install_test_deps` to run `clean` instead of  `clean_env` (I saw this on `rake --tasks`)

![rake-without-error](https://user-images.githubusercontent.com/2293178/33079224-356fe9a2-cebc-11e7-89fd-69205079b6ea.png)

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests (does not apply)
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

Thank you