### PR TITLE
Use setup command --regenerate-binstubs option flag

### DIFF
--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -82,11 +82,7 @@ class Gem::Commands::SetupCommand < Gem::Command
 
     add_option '--[no-]regenerate-binstubs',
                'Regenerate gem binstubs' do |value, options|
-      if value then
-        options[:regenerate_binstubs] = true
-      else
-        options.delete(:regenerate_binstubs)
-      end
+      options[:regenerate_binstubs] = value
    end
 
     @verbose = nil
@@ -156,7 +152,7 @@ By default, this RubyGems will install gem as:
 
     say "RubyGems #{Gem::VERSION} installed"
 
-    regenerate_binstubs
+    regenerate_binstubs if options[:regenerate_binstubs]
 
     uninstall_old_gemcutter
 

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -77,6 +77,19 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     assert_match %r{\A#!}, File.read(gem_bin_path)
   end
 
+  def test_execute_no_regenerate_binstubs
+    gem_bin_path = gem_install 'a'
+    write_file gem_bin_path do |io|
+      io.puts 'I changed it!'
+    end
+
+    @cmd.options[:document] = []
+    @cmd.options[:regenerate_binstubs] = false
+    @cmd.execute
+
+    assert_equal "I changed it!\n", File.read(gem_bin_path)
+  end
+
   def test_pem_files_in
     assert_equal %w[rubygems/ssl_certs/rubygems.org/foo.pem],
                  @cmd.pem_files_in('lib').sort


### PR DESCRIPTION
Test setup command binstubs regeneration
----------------------------------------

  Since 909b5fb, executable wrappers are regenerated using pristine
command if any gem are installed. New test is inspired by those for
`Gem::Commands::PristineCommand`.


Fix setup command --regenerate-binstubs option flag
---------------------------------------------------

  `--[no-]regenerate-binstubs` option flag was added in 909b5fb but is
not used yet. This change tests if the option was set before calling
`Gem::Commands::SetupCommand#regenerate_binstubs`.

  We also simplify how the option is set, since it's more similar to
`format_executable` for example (simple option flag), rather than
`document` where we use the same hash key for multiple options. This
way we can just test the value being either true or false, instead of
testing key presence (`Hash#key?`) or relying on `nil` being returned
for nonexistent hash keys with `Hash#[]`.
