### PR TITLE
generate_spdx_license_list.rb: Use HTTPS URI to SPDX JSON

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2774,27 +2774,11 @@ class Gem::Specification < Gem::BasicSpecification
 
     validate_metadata
 
-    licenses.each { |license|
-      if license.length > 64
-        raise Gem::InvalidSpecificationException,
-          "each license must be 64 characters or less"
-      end
-
-      if !Gem::Licenses.match?(license)
-        suggestions = Gem::Licenses.suggestions(license)
-        message = <<-warning
-license value '#{license}' is invalid.  Use a license identifier from
-http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard license.
-        warning
-        message += "Did you mean #{suggestions.map { |s| "'#{s}'"}.join(', ')}?\n" unless suggestions.nil?
-        warning(message)
-      end
+    licenses.reject { |l| Gem::Licenses.valid?(l) }.each { |invalid_license|
+      warning(Gem::Licenses.warning_for(invalid_license))
     }
 
-    warning <<-warning if licenses.empty?
-licenses is empty, but is recommended.  Use a license identifier from
-http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard license.
-    warning
+    warning(Gem::Licenses.warning_about_empty_licenses) if licenses.empty?
 
     validate_permissions
 

--- a/lib/rubygems/util/licenses.rb
+++ b/lib/rubygems/util/licenses.rb
@@ -48,9 +48,13 @@ class Gem::Licenses
       BSD-3-Clause-Attribution
       BSD-3-Clause-Clear
       BSD-3-Clause-LBNL
+      BSD-3-Clause-No-Nuclear-License
+      BSD-3-Clause-No-Nuclear-License-2014
+      BSD-3-Clause-No-Nuclear-Warranty
       BSD-4-Clause
       BSD-4-Clause-UC
       BSD-Protection
+      BSD-Source-Code
       BSL-1.0
       Bahyph
       Barr
@@ -126,6 +130,7 @@ class Gem::Licenses
       Entessa
       ErlPL-1.1
       Eurosym
+      FSFAP
       FSFUL
       FSFULLR
       FTL
@@ -137,8 +142,18 @@ class Gem::Licenses
       GFDL-1.3
       GL2PS
       GPL-1.0
+      GPL-1.0+
       GPL-2.0
+      GPL-2.0+
+      GPL-2.0-with-GCC-exception
+      GPL-2.0-with-autoconf-exception
+      GPL-2.0-with-bison-exception
+      GPL-2.0-with-classpath-exception
+      GPL-2.0-with-font-exception
       GPL-3.0
+      GPL-3.0+
+      GPL-3.0-with-GCC-exception
+      GPL-3.0-with-autoconf-exception
       Giftware
       Glide
       Glulxe
@@ -152,14 +167,20 @@ class Gem::Licenses
       ISC
       ImageMagick
       Imlib2
+      Info-ZIP
       Intel
       Intel-ACPI
       Interbase-1.0
       JSON
       JasPer-2.0
+      LAL-1.2
+      LAL-1.3
       LGPL-2.0
+      LGPL-2.0+
       LGPL-2.1
+      LGPL-2.1+
       LGPL-3.0
+      LGPL-3.0+
       LGPLLR
       LPL-1.0
       LPL-1.02
@@ -170,6 +191,9 @@ class Gem::Licenses
       LPPL-1.3c
       Latex2e
       Leptonica
+      LiLiQ-P-1.1
+      LiLiQ-R-1.1
+      LiLiQ-Rplus-1.1
       Libpng
       MIT
       MIT-CMU
@@ -193,6 +217,7 @@ class Gem::Licenses
       NBPL-1.0
       NCSA
       NGPL
+      NLOD-1.0
       NLPL
       NOSL
       NPL-1.0
@@ -201,11 +226,13 @@ class Gem::Licenses
       NRL
       NTP
       Naumen
+      Net-SNMP
       NetCDF
       Newsletr
       Nokia
       Noweb
       Nunit
+      OCCT-PL
       OCLC-2.0
       ODbL-1.0
       OFL-1.0
@@ -229,6 +256,7 @@ class Gem::Licenses
       OLDAP-2.8
       OML
       OPL-1.0
+      OSET-PL-2.1
       OSL-1.0
       OSL-1.1
       OSL-2.0
@@ -259,6 +287,7 @@ class Gem::Licenses
       SISSL
       SISSL-1.2
       SMLNJ
+      SMPPL
       SNIA
       SPL-1.0
       SWL
@@ -269,12 +298,16 @@ class Gem::Licenses
       Spencer-86
       Spencer-94
       Spencer-99
+      StandardML-NJ
       SugarCRM-1.1.3
       TCL
+      TCP-wrappers
       TMate
       TORQUE-1.1
       TOSL
       UPL-1.0
+      Unicode-DFS-2015
+      Unicode-DFS-2016
       Unicode-TOU
       Unlicense
       VOSTROM
@@ -282,7 +315,9 @@ class Gem::Licenses
       Vim
       W3C
       W3C-19980720
+      W3C-20150513
       WTFPL
+      WXwindows
       Watcom-1.0
       Wsuipa
       X11
@@ -302,8 +337,10 @@ class Gem::Licenses
       Zlib
       bzip2-1.0.5
       bzip2-1.0.6
+      curl
       diffmark
       dvipdfm
+      eCos-2.0
       eGenix
       gSOAP-1.3b
       gnuplot
@@ -328,8 +365,27 @@ class Gem::Licenses
     \Z
   }ox.freeze
 
+  def self.valid?(license)
+    if license.length > 64
+      raise Gem::InvalidSpecificationException,
+        "each license must be 64 characters or less"
+    end
+    match?(license)
+  end
+
   def self.match?(license)
     !REGEXP.match(license).nil?
+  end
+
+  def self.warning_for(license)
+    message = <<-warning
+license value '#{license}' is invalid.  Use a license identifier from
+http://spdx.org/licenses or '#{NONSTANDARD}' for a nonstandard license.
+    warning
+    suggestions = suggestions(license)
+    message += "Did you mean #{suggestions.map { |s| "'#{s}'"}.join(', ')}?
+" if suggestions
+    message
   end
 
   def self.suggestions(license)
@@ -340,4 +396,12 @@ class Gem::Licenses
     return unless lowest < license.size
     by_distance[lowest]
   end
+
+  def self.warning_about_empty_licenses
+    <<-warning
+licenses is empty, but is recommended.  Use a license identifier from
+http://spdx.org/licenses or '#{NONSTANDARD}' for a nonstandard license.
+    warning
+  end
+
 end

--- a/util/generate_spdx_license_list.rb
+++ b/util/generate_spdx_license_list.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 require 'json'
+require 'uri'
 require 'net/http'
 
-json = Net::HTTP.get('spdx.org', '/licenses/licenses.json')
-licenses = JSON.parse(json)['licenses'].map do |licenseObject|
-  licenseObject['licenseId']
+uri = URI('https://spdx.org/licenses/licenses.json')
+json = Net::HTTP.get(uri)
+licenses = JSON.parse(json)['licenses'].map do |license_object|
+  license_object['licenseId']
 end
 
 open 'lib/rubygems/util/licenses.rb', 'w' do |io|
@@ -34,8 +36,26 @@ class Gem::Licenses
     \\Z
   }ox.freeze
 
+  def self.valid?(license)
+    if license.length > 64
+      raise Gem::InvalidSpecificationException,
+        "each license must be 64 characters or less"
+    end
+    match?(license)
+  end
+
   def self.match?(license)
     !REGEXP.match(license).nil?
+  end
+
+  def self.warning_for(license)
+    message = <<-warning
+license value '\#{license}' is invalid.  Use a license identifier from
+http://spdx.org/licenses or '\#{NONSTANDARD}' for a nonstandard license.
+    warning
+    suggestions = suggestions(license)
+    message += "Did you mean \#{suggestions.map { |s| "'\#{s}'"}.join(', ')}?\n" if suggestions
+    message
   end
 
   def self.suggestions(license)
@@ -46,6 +66,14 @@ class Gem::Licenses
     return unless lowest < license.size
     by_distance[lowest]
   end
+
+  def self.warning_about_empty_licenses
+    <<-warning
+licenses is empty, but is recommended.  Use a license identifier from
+http://spdx.org/licenses or '\#{NONSTANDARD}' for a nonstandard license.
+    warning
+  end
+
 end
   RUBY
 end


### PR DESCRIPTION
This PR fixes the license-fetching script.

  - makes the supporting script to create `licenses.rb` run again by using the **updated HTTPS URI**
  - **has run** that supporting script, which meant creating some **new license names**
  - extracted some code to create warning messages about licenses (into `licenses.rb` out of `specification.rb`)