### PR TITLE
Extract a SpecificationPolicy validation class

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -703,7 +703,7 @@ class Gem::Installer
   end
 
   def verify_spec_name
-    return if spec.name =~ Gem::Specification::VALID_NAME_PATTERN
+    return if spec.name =~ Gem::SpecificationPolicy::VALID_NAME_PATTERN
     raise Gem::InstallError, "#{spec} has an invalid name"
   end
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -13,6 +13,7 @@ require 'rubygems/platform'
 require 'rubygems/deprecate'
 require 'rubygems/basic_specification'
 require 'rubygems/stub_specification'
+require 'rubygems/specification_policy'
 require 'rubygems/util/list'
 require 'stringio'
 
@@ -108,8 +109,6 @@ class Gem::Specification < Gem::BasicSpecification
   LOAD_CACHE = {} # :nodoc:
 
   private_constant :LOAD_CACHE if defined? private_constant
-
-  VALID_NAME_PATTERN = /\A[a-zA-Z0-9\.\-\_]+\z/ # :nodoc:
 
   # :startdoc:
 
@@ -2679,256 +2678,21 @@ class Gem::Specification < Gem::BasicSpecification
     extend Gem::UserInteraction
     normalize
 
-    nil_attributes = self.class.non_nil_attributes.find_all do |attrname|
-      instance_variable_get("@#{attrname}").nil?
-    end
-
-    unless nil_attributes.empty? then
-      raise Gem::InvalidSpecificationException,
-        "#{nil_attributes.join ', '} must not be nil"
-    end
-
-    if packaging and rubygems_version != Gem::VERSION then
-      raise Gem::InvalidSpecificationException,
-            "expected RubyGems version #{Gem::VERSION}, was #{rubygems_version}"
-    end
-
-    @@required_attributes.each do |symbol|
-      unless self.send symbol then
-        raise Gem::InvalidSpecificationException,
-              "missing value for attribute #{symbol}"
-      end
-    end
-
-    if !name.is_a?(String) then
-      raise Gem::InvalidSpecificationException,
-            "invalid value for attribute name: \"#{name.inspect}\" must be a string"
-    elsif name !~ /[a-zA-Z]/ then
-      raise Gem::InvalidSpecificationException,
-            "invalid value for attribute name: #{name.dump} must include at least one letter"
-    elsif name !~ VALID_NAME_PATTERN then
-      raise Gem::InvalidSpecificationException,
-            "invalid value for attribute name: #{name.dump} can only include letters, numbers, dashes, and underscores"
-    end
-
-    if raw_require_paths.empty? then
-      raise Gem::InvalidSpecificationException,
-            'specification must have at least one require_path'
-    end
-
-    @files.delete_if            { |x| File.directory?(x) && !File.symlink?(x) }
-    @test_files.delete_if       { |x| File.directory?(x) && !File.symlink?(x) }
-    @executables.delete_if      { |x| File.directory?(File.join(@bindir, x)) }
-    @extra_rdoc_files.delete_if { |x| File.directory?(x) && !File.symlink?(x) }
-    @extensions.delete_if       { |x| File.directory?(x) && !File.symlink?(x) }
-
-    non_files = files.reject { |x| File.file?(x) || File.symlink?(x) }
-
-    unless not packaging or non_files.empty? then
-      raise Gem::InvalidSpecificationException,
-            "[\"#{non_files.join "\", \""}\"] are not files"
-    end
-
-    if files.include? file_name then
-      raise Gem::InvalidSpecificationException,
-            "#{full_name} contains itself (#{file_name}), check your files list"
-    end
-
-    unless specification_version.is_a?(Integer)
-      raise Gem::InvalidSpecificationException,
-            'specification_version must be an Integer (did you mean version?)'
-    end
-
-    case platform
-    when Gem::Platform, Gem::Platform::RUBY then # ok
-    else
-      raise Gem::InvalidSpecificationException,
-            "invalid platform #{platform.inspect}, see Gem::Platform"
-    end
-
-    self.class.array_attributes.each do |field|
-      val = self.send field
-      klass = case field
-              when :dependencies
-                Gem::Dependency
-              else
-                String
-              end
-
-      unless Array === val and val.all? { |x| x.kind_of?(klass) } then
-        raise(Gem::InvalidSpecificationException,
-              "#{field} must be an Array of #{klass}")
-      end
-    end
-
-    [:authors].each do |field|
-      val = self.send field
-      raise Gem::InvalidSpecificationException, "#{field} may not be empty" if
-        val.empty?
-    end
-
-    unless Hash === metadata
-      raise Gem::InvalidSpecificationException,
-              'metadata must be a hash'
-    end
-
-    validate_metadata
-
-    validate_licenses
-
-    validate_permissions
-
-    validate_lazy_metadata
-
-    validate_values
-
-    validate_dependencies
-
-    true
+    validation_policy = Gem::SpecificationPolicy.new(self)
+    validation_policy.packaging = packaging
+    validation_policy.call
   ensure
     if $! or @warnings > 0 then
       alert_warning "See http://guides.rubygems.org/specification-reference/ for help"
     end
   end
 
-  def validate_metadata
-    url_validation_regex = %r{\Ahttps?:\/\/([^\s:@]+:[^\s:@]*@)?[A-Za-z\d\-]+(\.[A-Za-z\d\-]+)+\.?(:\d{1,5})?([\/?]\S*)?\z}
-    link_keys = %w(
-      bug_tracker_uri
-      changelog_uri
-      documentation_uri
-      homepage_uri
-      mailing_list_uri
-      source_code_uri
-      wiki_uri
-    )
-
-    metadata.each do|key, value|
-      if !key.kind_of?(String)
-        raise Gem::InvalidSpecificationException,
-                "metadata keys must be a String"
-      end
-
-      if key.size > 128
-        raise Gem::InvalidSpecificationException,
-                "metadata key too large (#{key.size} > 128)"
-      end
-
-      if !value.kind_of?(String)
-        raise Gem::InvalidSpecificationException,
-                "metadata values must be a String"
-      end
-
-      if value.size > 1024
-        raise Gem::InvalidSpecificationException,
-                "metadata value too large (#{value.size} > 1024)"
-      end
-
-      if link_keys.include? key
-        if value !~ url_validation_regex
-          raise Gem::InvalidSpecificationException,
-                 "metadata['#{key}'] has invalid link: #{value.inspect}"
-        end
-      end
-    end
-  end
-
-  ##
-  # Checks that dependencies use requirements as we recommend.  Warnings are
-  # issued when dependencies are open-ended or overly strict for semantic
-  # versioning.
-
-  def validate_dependencies # :nodoc:
-    # NOTE: see REFACTOR note in Gem::Dependency about types - this might be brittle
-    seen = Gem::Dependency::TYPES.inject({}) { |types, type| types.merge({ type => {}}) }
-
-    error_messages = []
-    warning_messages = []
-    dependencies.each do |dep|
-      if prev = seen[dep.type][dep.name] then
-        error_messages << <<-MESSAGE
-duplicate dependency on #{dep}, (#{prev.requirement}) use:
-    add_#{dep.type}_dependency '#{dep.name}', '#{dep.requirement}', '#{prev.requirement}'
-        MESSAGE
-      end
-
-      seen[dep.type][dep.name] = dep
-
-      prerelease_dep = dep.requirements_list.any? do |req|
-        Gem::Requirement.new(req).prerelease?
-      end
-
-      warning_messages << "prerelease dependency on #{dep} is not recommended" if
-        prerelease_dep && !version.prerelease?
-
-      overly_strict = dep.requirement.requirements.length == 1 &&
-        dep.requirement.requirements.any? do |op, version|
-          op == '~>' and
-            not version.prerelease? and
-            version.segments.length > 2 and
-            version.segments.first != 0
-        end
-
-      if overly_strict then
-        _, dep_version = dep.requirement.requirements.first
-
-        base = dep_version.segments.first 2
-
-        warning_messages << <<-WARNING
-pessimistic dependency on #{dep} may be overly strict
-  if #{dep.name} is semantically versioned, use:
-    add_#{dep.type}_dependency '#{dep.name}', '~> #{base.join '.'}', '>= #{dep_version}'
-        WARNING
-      end
-
-      open_ended = dep.requirement.requirements.all? do |op, version|
-        not version.prerelease? and (op == '>' or op == '>=')
-      end
-
-      if open_ended then
-        op, dep_version = dep.requirement.requirements.first
-
-        base = dep_version.segments.first 2
-
-        bugfix = if op == '>' then
-                   ", '> #{dep_version}'"
-                 elsif op == '>=' and base != dep_version.segments then
-                   ", '>= #{dep_version}'"
-                 end
-
-        warning_messages << <<-WARNING
-open-ended dependency on #{dep} is not recommended
-  if #{dep.name} is semantically versioned, use:
-    add_#{dep.type}_dependency '#{dep.name}', '~> #{base.join '.'}'#{bugfix}
-        WARNING
-      end
-    end
-    if error_messages.any?
-      raise Gem::InvalidSpecificationException, error_messages.join
-    end
-    if warning_messages.any?
-      warning_messages.each { |warning_message| warning warning_message }
-    end
-  end
-
-  ##
-  # Checks to see if the files to be packaged are world-readable.
-
-  def validate_permissions
-    return if Gem.win_platform?
-
-    files.each do |file|
-      next unless File.file?(file)
-      next if File.stat(file).mode & 0444 == 0444
-      warning "#{file} is not world-readable"
-    end
-
-    executables.each do |name|
-      exec = File.join @bindir, name
-      next unless File.file?(exec)
-      next if File.stat(exec).executable?
-      warning "#{exec} is not executable"
-    end
+  def normalize_files
+    @files.delete_if            { |x| File.directory?(x) && !File.symlink?(x) }
+    @test_files.delete_if       { |x| File.directory?(x) && !File.symlink?(x) }
+    @executables.delete_if      { |x| File.directory?(File.join(@bindir, x)) }
+    @extra_rdoc_files.delete_if { |x| File.directory?(x) && !File.symlink?(x) }
+    @extensions.delete_if       { |x| File.directory?(x) && !File.symlink?(x) }
   end
 
   ##
@@ -2996,85 +2760,6 @@ open-ended dependency on #{dep} is not recommended
   end
 
   extend Gem::Deprecate
-
-  private
-
-  def validate_values
-    %w[author homepage summary files].each do |attribute|
-      value = self.send attribute
-      warning("no #{attribute} specified") if value.nil? || value.empty?
-    end
-
-    if description == summary
-      warning "description and summary are identical"
-    end
-
-    # TODO: raise at some given date
-    warning "deprecated autorequire specified" if autorequire
-
-    executables.each do |executable|
-      executable_path = File.join(bindir, executable)
-      shebang = File.read(executable_path, 2) == '#!'
-
-      warning "#{executable_path} is missing #! line" unless shebang
-    end
-
-    files.each do |file|
-      next unless File.symlink?(file)
-      warning "#{file} is a symlink, which is not supported on all platforms"
-    end
-  end
-
-  def validate_licenses
-    licenses.each { |license|
-      if license.length > 64
-        raise Gem::InvalidSpecificationException,
-              "each license must be 64 characters or less"
-      end
-
-      if !Gem::Licenses.match?(license)
-        suggestions = Gem::Licenses.suggestions(license)
-        message = <<-warning
-license value '#{license}' is invalid.  Use a license identifier from
-http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard license.
-        warning
-        message += "Did you mean #{suggestions.map { |s| "'#{s}'"}.join(', ')}?\n" unless suggestions.nil?
-        warning(message)
-      end
-    }
-
-    warning <<-warning if licenses.empty?
-licenses is empty, but is recommended.  Use a license identifier from
-http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard license.
-    warning
-  end
-
-  def validate_lazy_metadata
-    lazy = '"FIxxxXME" or "TOxxxDO"'.gsub(/xxx/, '')
-    lazy_pattern = /FI XME|TO DO/x
-
-    unless authors.grep(lazy_pattern).empty?
-      raise Gem::InvalidSpecificationException, "#{lazy} is not an author"
-    end
-
-    unless Array(email).grep(lazy_pattern).empty?
-      raise Gem::InvalidSpecificationException, "#{lazy} is not an email"
-    end
-
-    if description =~ lazy_pattern
-      raise Gem::InvalidSpecificationException, "#{lazy} is not a description"
-    end
-
-    if summary =~ lazy_pattern
-      raise Gem::InvalidSpecificationException, "#{lazy} is not a summary"
-    end
-
-    if homepage and not homepage.empty? and
-        homepage !~ /\A[a-z][a-z\d+.-]*:/i
-      raise Gem::InvalidSpecificationException,
-            "\"#{homepage}\" is not a URI"
-    end
-  end
 
   # TODO:
   # deprecate :has_rdoc,            :none,       2011, 10

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2695,6 +2695,24 @@ class Gem::Specification < Gem::BasicSpecification
     @extensions.delete_if       { |x| File.directory?(x) && !File.symlink?(x) }
   end
 
+  def validate_metadata
+    Gem::SpecificationPolicy.new(self).validate_metadata
+  end
+
+  ##
+  # Checks that dependencies use requirements as we recommend.  Warnings are
+  # issued when dependencies are open-ended or overly strict for semantic
+  # versioning.
+  def validate_dependencies
+    Gem::SpecificationPolicy.new(self).validate_dependencies
+  end
+
+  ##
+  # Checks to see if the files to be packaged are world-readable.
+  def validate_permissions
+    Gem::SpecificationPolicy.new(self).validate_permissions
+  end
+
   ##
   # Set the version to +version+, potentially also setting
   # required_rubygems_version if +version+ indicates it is a

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -1,0 +1,370 @@
+require 'delegate'
+class Gem::SpecificationPolicy < SimpleDelegator
+  VALID_NAME_PATTERN = /\A[a-zA-Z0-9\.\-\_]+\z/ # :nodoc:
+
+  attr_accessor :packaging
+
+  def call
+    validate_nil_attributes
+
+    validate_rubygems_version
+
+    validate_required_attributes
+
+    validate_name
+
+    validate_require_paths
+
+    normalize_files
+
+    validate_non_files
+
+    validate_self_inclusion_in_files_list
+
+    validate_specification_version
+
+    validate_platform
+
+    validate_array_attributes
+
+    validate_authors_field
+
+    validate_metadata
+
+    validate_licenses
+
+    validate_permissions
+
+    validate_lazy_metadata
+
+    validate_values
+
+    validate_dependencies
+    true
+  end
+
+  private
+
+  def validate_nil_attributes
+    nil_attributes = __getobj__.class.non_nil_attributes.select do |attrname|
+      __getobj__.instance_variable_get("@#{attrname}").nil?
+    end
+    return if nil_attributes.empty?
+    raise Gem::InvalidSpecificationException,
+          "#{nil_attributes.join ', '} must not be nil"
+  end
+
+  def validate_rubygems_version
+    if packaging && rubygems_version != Gem::VERSION
+      raise Gem::InvalidSpecificationException,
+            "expected RubyGems version #{Gem::VERSION}, was #{rubygems_version}"
+    end
+  end
+
+  def validate_required_attributes
+    __getobj__.class.required_attributes.each do |symbol|
+      unless send symbol
+        raise Gem::InvalidSpecificationException,
+              "missing value for attribute #{symbol}"
+      end
+    end
+  end
+
+  def validate_name
+    if !name.is_a?(String)
+      raise Gem::InvalidSpecificationException,
+            "invalid value for attribute name: \"#{name.inspect}\" must be a string"
+    elsif name !~ /[a-zA-Z]/
+      raise Gem::InvalidSpecificationException,
+            "invalid value for attribute name: #{name.dump} must include at least one letter"
+    elsif name !~ VALID_NAME_PATTERN
+      raise Gem::InvalidSpecificationException,
+            "invalid value for attribute name: #{name.dump} can only include letters, numbers, dashes, and underscores"
+    end
+  end
+
+  def validate_require_paths
+    if raw_require_paths.empty?
+      raise Gem::InvalidSpecificationException,
+            'specification must have at least one require_path'
+    end
+  end
+
+  def validate_non_files
+    non_files = files.reject {|x| File.file?(x) || File.symlink?(x)}
+
+    unless not packaging or non_files.empty?
+      raise Gem::InvalidSpecificationException,
+            "[\"#{non_files.join "\", \""}\"] are not files"
+    end
+  end
+
+  def validate_self_inclusion_in_files_list
+    if files.include?(file_name)
+      raise Gem::InvalidSpecificationException,
+            "#{full_name} contains itself (#{file_name}), check your files list"
+    end
+  end
+
+  def validate_specification_version
+    unless specification_version.is_a?(Integer)
+      raise Gem::InvalidSpecificationException,
+            'specification_version must be an Integer (did you mean version?)'
+    end
+  end
+
+  def validate_platform
+    case platform
+      when Gem::Platform, Gem::Platform::RUBY then # ok
+      else
+        raise Gem::InvalidSpecificationException,
+              "invalid platform #{platform.inspect}, see Gem::Platform"
+    end
+  end
+
+  def validate_array_attributes
+    __getobj__.class.array_attributes.each do |field|
+      val = self.send(field)
+      klass = case field
+                when :dependencies
+                  Gem::Dependency
+                else
+                  String
+              end
+
+      unless Array === val and val.all? {|x| x.kind_of?(klass)}
+        raise(Gem::InvalidSpecificationException,
+              "#{field} must be an Array of #{klass}")
+      end
+    end
+  end
+
+  def validate_authors_field
+    [:authors].each do |field|
+      val = self.send(field)
+      raise Gem::InvalidSpecificationException, "#{field} may not be empty" if val.empty?
+    end
+  end
+
+  def validate_metadata
+    unless Hash === metadata
+      raise Gem::InvalidSpecificationException,
+            'metadata must be a hash'
+    end
+
+    url_validation_regex = %r{\Ahttps?:\/\/([^\s:@]+:[^\s:@]*@)?[A-Za-z\d\-]+(\.[A-Za-z\d\-]+)+\.?(:\d{1,5})?([\/?]\S*)?\z}
+    link_keys = %w[
+      bug_tracker_uri
+      changelog_uri
+      documentation_uri
+      homepage_uri
+      mailing_list_uri
+      source_code_uri
+      wiki_uri
+    ]
+
+    metadata.each do|key, value|
+      if !key.kind_of?(String)
+        raise Gem::InvalidSpecificationException,
+              "metadata keys must be a String"
+      end
+
+      if key.size > 128
+        raise Gem::InvalidSpecificationException,
+              "metadata key too large (#{key.size} > 128)"
+      end
+
+      if !value.kind_of?(String)
+        raise Gem::InvalidSpecificationException,
+              "metadata values must be a String"
+      end
+
+      if value.size > 1024
+        raise Gem::InvalidSpecificationException,
+              "metadata value too large (#{value.size} > 1024)"
+      end
+
+      if link_keys.include? key
+        if value !~ url_validation_regex
+          raise Gem::InvalidSpecificationException,
+                "metadata['#{key}'] has invalid link: #{value.inspect}"
+        end
+      end
+    end
+  end
+
+
+  def validate_licenses
+    licenses.each { |license|
+      if license.length > 64
+        raise Gem::InvalidSpecificationException,
+              "each license must be 64 characters or less"
+      end
+
+      if !Gem::Licenses.match?(license)
+        suggestions = Gem::Licenses.suggestions(license)
+        message = <<-warning
+license value '#{license}' is invalid.  Use a license identifier from
+http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard license.
+        warning
+        message += "Did you mean #{suggestions.map { |s| "'#{s}'"}.join(', ')}?\n" unless suggestions.nil?
+        warning(message)
+      end
+    }
+
+    warning <<-warning if licenses.empty?
+licenses is empty, but is recommended.  Use a license identifier from
+http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard license.
+    warning
+  end
+
+  ##
+  # Checks to see if the files to be packaged are world-readable.
+  def validate_permissions
+    return if Gem.win_platform?
+
+    files.each do |file|
+      next unless File.file?(file)
+      next if File.stat(file).mode & 0444 == 0444
+      warning "#{file} is not world-readable"
+    end
+
+    executables.each do |name|
+      exec = File.join bindir, name
+      next unless File.file?(exec)
+      next if File.stat(exec).executable?
+      warning "#{exec} is not executable"
+    end
+  end
+
+  def validate_lazy_metadata
+    lazy = '"FIxxxXME" or "TOxxxDO"'.gsub(/xxx/, '')
+    lazy_pattern = /FI XME|TO DO/x
+
+    unless authors.grep(lazy_pattern).empty?
+      raise Gem::InvalidSpecificationException, "#{lazy} is not an author"
+    end
+
+    unless Array(email).grep(lazy_pattern).empty?
+      raise Gem::InvalidSpecificationException, "#{lazy} is not an email"
+    end
+
+    if description =~ lazy_pattern
+      raise Gem::InvalidSpecificationException, "#{lazy} is not a description"
+    end
+
+    if summary =~ lazy_pattern
+      raise Gem::InvalidSpecificationException, "#{lazy} is not a summary"
+    end
+
+    if homepage and not homepage.empty? and
+        homepage !~ /\A[a-z][a-z\d+.-]*:/i
+      raise Gem::InvalidSpecificationException,
+            "\"#{homepage}\" is not a URI"
+    end
+  end
+
+  def validate_values
+    %w[author homepage summary files].each do |attribute|
+      value = self.send attribute
+      warning("no #{attribute} specified") if value.nil? || value.empty?
+    end
+
+    if description == summary
+      warning "description and summary are identical"
+    end
+
+    # TODO: raise at some given date
+    warning "deprecated autorequire specified" if autorequire
+
+    executables.each do |executable|
+      executable_path = File.join(bindir, executable)
+      shebang = File.read(executable_path, 2) == '#!'
+
+      warning "#{executable_path} is missing #! line" unless shebang
+    end
+
+    files.each do |file|
+      next unless File.symlink?(file)
+      warning "#{file} is a symlink, which is not supported on all platforms"
+    end
+  end
+
+  ##
+  # Checks that dependencies use requirements as we recommend.  Warnings are
+  # issued when dependencies are open-ended or overly strict for semantic
+  # versioning.
+  def validate_dependencies # :nodoc:
+    # NOTE: see REFACTOR note in Gem::Dependency about types - this might be brittle
+    seen = Gem::Dependency::TYPES.inject({}) { |types, type| types.merge({ type => {}}) }
+
+    error_messages = []
+    warning_messages = []
+    dependencies.each do |dep|
+      if prev = seen[dep.type][dep.name] then
+        error_messages << <<-MESSAGE
+duplicate dependency on #{dep}, (#{prev.requirement}) use:
+    add_#{dep.type}_dependency '#{dep.name}', '#{dep.requirement}', '#{prev.requirement}'
+        MESSAGE
+      end
+
+      seen[dep.type][dep.name] = dep
+
+      prerelease_dep = dep.requirements_list.any? do |req|
+        Gem::Requirement.new(req).prerelease?
+      end
+
+      warning_messages << "prerelease dependency on #{dep} is not recommended" if
+          prerelease_dep && !version.prerelease?
+
+      overly_strict = dep.requirement.requirements.length == 1 &&
+          dep.requirement.requirements.any? do |op, version|
+            op == '~>' and
+                not version.prerelease? and
+                version.segments.length > 2 and
+                version.segments.first != 0
+          end
+
+      if overly_strict then
+        _, dep_version = dep.requirement.requirements.first
+
+        base = dep_version.segments.first 2
+
+        warning_messages << <<-WARNING
+pessimistic dependency on #{dep} may be overly strict
+  if #{dep.name} is semantically versioned, use:
+    add_#{dep.type}_dependency '#{dep.name}', '~> #{base.join '.'}', '>= #{dep_version}'
+        WARNING
+      end
+
+      open_ended = dep.requirement.requirements.all? do |op, version|
+        not version.prerelease? and (op == '>' or op == '>=')
+      end
+
+      if open_ended then
+        op, dep_version = dep.requirement.requirements.first
+
+        base = dep_version.segments.first 2
+
+        bugfix = if op == '>' then
+                   ", '> #{dep_version}'"
+                 elsif op == '>=' and base != dep_version.segments then
+                   ", '>= #{dep_version}'"
+                 end
+
+        warning_messages << <<-WARNING
+open-ended dependency on #{dep} is not recommended
+  if #{dep.name} is semantically versioned, use:
+    add_#{dep.type}_dependency '#{dep.name}', '~> #{base.join '.'}'#{bugfix}
+        WARNING
+      end
+    end
+    if error_messages.any?
+      raise Gem::InvalidSpecificationException, error_messages.join
+    end
+    if warning_messages.any?
+      warning_messages.each { |warning_message| warning warning_message }
+    end
+  end
+end
+


### PR DESCRIPTION
# Description:

The Specification class is 3000 lines long.

This speculative PR extracts a `SpecificationPolicy` delegate class. It does validation on Specification.

## Questions for reviewer

- `#normalize_files` - can you figure out a better name for what's going on there? And there already is a `#normalize`
- Existing Specification public interface is kept, except I moved `VALID_NAME_PATTERN` (used in `lib/rubygems/installer.rb`) into the policy class. Question: Should I revert that move?

______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
