### PR TITLE
Check gems dir existence before removing bundler

### DIFF
--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -372,9 +372,11 @@ By default, this RubyGems will install gem as:
 
     bundler_spec = Gem::Specification.load(default_spec_path)
 
-    Dir.entries(bundler_spec.gems_dir).
-      select {|default_gem| File.basename(default_gem).match(/^bundler-#{Gem::Version::VERSION_PATTERN}$/) }.
-      each {|default_gem| rm_r File.join(bundler_spec.gems_dir, default_gem) }
+    if File.directory? bundler_spec.gems_dir
+      Dir.entries(bundler_spec.gems_dir).
+        select {|default_gem| File.basename(default_gem).match(/^bundler-#{Gem::Version::VERSION_PATTERN}$/) }.
+        each {|default_gem| rm_r File.join(bundler_spec.gems_dir, default_gem) }
+    end
 
     mkdir_p bundler_spec.bin_dir
     bundler_spec.executables.each {|e| cp File.join("bundler", bundler_spec.bindir, e), File.join(bundler_spec.bin_dir, e) }


### PR DESCRIPTION
  In `Gem::Commands::SetupCommand#install_default_bundler_gem`, check if
gems directory exists before attempting to uninstall potential bundler
gems, else `Dir.entries` might fail:

    env \
      GEM_HOME=/wrkdirs/usr/ports/devel/ruby-gems/work/stage/usr/local/lib/ruby/gems/2.4 \
      /usr/local/bin/ruby24 setup.rb \
      --destdir=/wrkdirs/usr/ports/devel/ruby-gems/work/stage \
      --backtrace
    ERROR:  While executing gem ... (Errno::ENOENT)
      No such file or directory @ dir_initialize - /usr/local/lib/ruby/gems/2.4/gems
      /wrkdirs/usr/ports/devel/ruby-gems/work/rubygems-2.7.2/lib/rubygems/commands/setup_command.rb:371:in `open'
      /wrkdirs/usr/ports/devel/ruby-gems/work/rubygems-2.7.2/lib/rubygems/commands/setup_command.rb:371:in `entries'
      /wrkdirs/usr/ports/devel/ruby-gems/work/rubygems-2.7.2/lib/rubygems/commands/setup_command.rb:371:in `install_default_bundler_gem'
      /wrkdirs/usr/ports/devel/ruby-gems/work/rubygems-2.7.2/lib/rubygems/commands/setup_command.rb:151:in `execute'
      /wrkdirs/usr/ports/devel/ruby-gems/work/rubygems-2.7.2/lib/rubygems/command.rb:310:in `invoke_with_build_args'
      /wrkdirs/usr/ports/devel/ruby-gems/work/rubygems-2.7.2/lib/rubygems/command_manager.rb:171:in `process_args'
      /wrkdirs/usr/ports/devel/ruby-gems/work/rubygems-2.7.2/lib/rubygems/command_manager.rb:141:in `run'
      /wrkdirs/usr/ports/devel/ruby-gems/work/rubygems-2.7.2/lib/rubygems/gem_runner.rb:59:in `run'
      setup.rb:46:in `<main>'
