### PR TITLE
Ignored to publish rdoc documentation of rubygems for docs.seattlerb.org

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -168,7 +168,7 @@ end
 
 task :prerelease => [:clobber, :check_manifest, :test]
 
-task :postrelease => %w[upload guides:publish blog:publish publish_docs]
+task :postrelease => %w[upload guides:publish blog:publish]
 
 file "pkg/rubygems-#{v}" => "pkg/rubygems-update-#{v}" do |t|
   require 'find'
@@ -219,10 +219,8 @@ end
 desc "Upload release to rubygems.org"
 task :upload => %w[upload_to_s3]
 
-on_master = `git branch --list master`.strip == '* master'
-on_master = true if ENV['FORCE']
-
-Rake::Task['publish_docs'].clear unless on_master
+# Ignonre to publish rdoc to docs.seattlerb.org
+Rake::Task['publish_docs'].clear
 
 directory '../guides.rubygems.org' do
   sh 'git', 'clone',

--- a/Rakefile
+++ b/Rakefile
@@ -264,6 +264,9 @@ namespace 'guides' do
   desc 'Updates and publishes the guides for the just-released RubyGems'
   task 'publish'
 
+  on_master = `git branch --list master`.strip == '* master'
+  on_master = true if ENV['FORCE']
+
   task 'publish' => %w[
     guides:pull
     guides:update


### PR DESCRIPTION
http://docs.seattlerb.org/rubygems seems to an obsoleted site. I removed uploading task from postrelease tasks.

We need to move GitHub pages like "https://rubygems.github.com/documentation/". 