### PR TITLE
handle the explain option in gem update

### DIFF
--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -85,17 +85,26 @@ command to remove old versions.
   end
 
   def execute
-
     if options[:system] then
       update_rubygems
       return
     end
 
-    say "Updating installed gems"
-
     hig = highest_installed_gems
 
     gems_to_update = which_to_update hig, options[:args].uniq
+
+    if options[:explain]
+      say "Gems to update:"
+
+      gems_to_update.each do |(name, version)|
+        say "  #{name}-#{version}"
+      end
+
+      return
+    end
+
+    say "Updating installed gems"
 
     updated = update_gems gems_to_update
 

--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -504,5 +504,23 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
     assert_empty arguments
   end
 
-end
+  def test_explain
+    spec_fetcher do |fetcher|
+      fetcher.download 'a', 2
+      fetcher.spec 'a', 1
+    end
 
+    @cmd.options[:explain] = true
+    @cmd.options[:args] = %w[a]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    out = @ui.output.split "\n"
+
+    assert_equal "Gems to update:", out.shift
+    assert_equal "  a-2", out.shift
+    assert_empty out
+  end
+end


### PR DESCRIPTION
… and versions of gems that can be updated

# Description:

This PR fixes #2068 by updating the `gem update` command to handle the explain option.

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
