### PR TITLE
[Specification] Prefer user-installed gems to default gems

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -812,7 +812,7 @@ class Gem::Specification < Gem::BasicSpecification
   def self.stubs
     @@stubs ||= begin
       pattern = "*.gemspec"
-      stubs = Gem.loaded_specs.values + default_stubs(pattern) + installed_stubs(dirs, pattern)
+      stubs = Gem.loaded_specs.values + installed_stubs(dirs, pattern) + default_stubs(pattern)
       stubs = uniq_by(stubs) { |stub| stub.full_name }
 
       _resort!(stubs)
@@ -843,8 +843,9 @@ class Gem::Specification < Gem::BasicSpecification
       @@stubs_by_name[name] || []
     else
       pattern = "#{name}-*.gemspec"
-      stubs = Gem.loaded_specs.values + default_stubs(pattern) +
-        installed_stubs(dirs, pattern).select { |s| Gem::Platform.match s.platform }
+      stubs = Gem.loaded_specs.values +
+        installed_stubs(dirs, pattern).select { |s| Gem::Platform.match s.platform } +
+        default_stubs(pattern)
       stubs = uniq_by(stubs) { |stub| stub.full_name }.group_by(&:name)
       stubs.each_value { |v| _resort!(v) }
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -901,6 +901,36 @@ gem 'other', version
     assert_includes(e.message, "can't find gem a (= 3.0)")
   end
 
+  def test_install_creates_binstub_that_prefers_user_installed_gem_to_default
+    Dir.mkdir util_inst_bindir
+
+    install_default_gems new_default_spec('default', '2')
+
+    util_setup_gem do |spec|
+      spec.name = 'default'
+      spec.version = '2'
+    end
+
+    util_clear_gems
+
+    @installer.wrappers = true
+
+    @newspec = nil
+    build_rake_in do
+      use_ui @ui do
+        @newspec = @installer.install
+      end
+    end
+
+    exe = File.join @gemhome, 'bin', 'executable'
+
+    e = assert_raises RuntimeError do
+      instance_eval File.read(exe)
+    end
+
+    assert_equal(e.message, "ran executable")
+  end
+
   def test_install_creates_binstub_that_dont_trust_encoding
     Dir.mkdir util_inst_bindir
     util_setup_gem


### PR DESCRIPTION
# Description:

@BanzaiMan I believe this will fix the issue we were discussing earlier today.

This PR will make RubyGems, when the same gem is installed both by the user and as a default gem, prefer to activate the user-installed gem. This is desirable, for example, with the default bundler gem, as it has fewer executables than the user-installed gem (i.e. the `bundler` executable).