### PR TITLE
Frozen string fix - lib/rubygems/bundler_version_finder.rb

### DIFF
--- a/lib/rubygems/bundler_version_finder.rb
+++ b/lib/rubygems/bundler_version_finder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Gem::BundlerVersionFinder
   @without_filtering = false
 
@@ -102,7 +104,7 @@ To install the missing version, run `gem install bundler:#{vr.first}`
     lockfile = case gemfile
     when "gems.rb" then "gems.locked"
     else "#{gemfile}.lock"
-    end.untaint
+    end.dup.untaint
 
     return unless File.file?(lockfile)
 


### PR DESCRIPTION
# Description:

When starting ruby with `RUBYOPT=--enable-frozen-string-literal`, there are a few issues in RubyGems.  This is the only issue I found in RubyGems, the others were in RDoc, which do cause RubyGems tests to fail.  Working on that.

I found this when I noticed a popluar gem was failing CI, turns out the owner had enabled the above setting.  Investigation found this...
______________

# Tasks:

- [X] Describe the problem / feature
- [ ] Write tests
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
