### PR TITLE
Add Gem.operating_system_defaults to allow packagers to override defaults.

### DIFF
--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -48,7 +48,7 @@ class Gem::ConfigFile
   # For Ruby packagers to set configuration defaults.  Set in
   # rubygems/defaults/operating_system.rb
 
-  OPERATING_SYSTEM_DEFAULTS = {}
+  OPERATING_SYSTEM_DEFAULTS = Gem.operating_system_defaults
 
   ##
   # For Ruby implementers to set configuration defaults.  Set in

--- a/lib/rubygems/defaults.rb
+++ b/lib/rubygems/defaults.rb
@@ -176,7 +176,26 @@ module Gem
   end
 
   ##
-  # Default options for gem commands.
+  # Default options for gem commands for Ruby packagers.
+  #
+  # The options here should be structured as an array of string "gem"
+  # command names as keys and a string of the default options as values.
+  #
+  # Example:
+  #
+  # def self.operating_system_defaults
+  #   {
+  #       'install' => '--no-rdoc --no-ri --env-shebang',
+  #       'update' => '--no-rdoc --no-ri --env-shebang'
+  #   }
+  # end
+
+  def self.operating_system_defaults
+    {}
+  end
+
+  ##
+  # Default options for gem commands for Ruby implementers.
   #
   # The options here should be structured as an array of string "gem"
   # command names as keys and a string of the default options as values.

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1798,6 +1798,13 @@ You may need to `gem install -g` to install missing gems
     ENV['RUBYGEMS_GEMDEPS'] = rubygems_gemdeps
   end
 
+  def test_operating_system_defaults
+    operating_system_defaults = Gem.operating_system_defaults
+
+    assert operating_system_defaults != nil
+    assert operating_system_defaults.is_a? Hash
+  end
+
   def test_platform_defaults
     platform_defaults = Gem.platform_defaults
 


### PR DESCRIPTION
# Description:

This change allows Ruby packagers to override defaults and lazily query
them.

This is very much the same change as #1644 to treat the
operating_system defaults the same way as platform defaults.


# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
