### PR TITLE
Avoid to warnings about gemspec loadings in rubygems tests.

### DIFF
--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -43,7 +43,8 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     end
 
     open(File.join(Gem::Specification.default_specifications_dir, "bundler-1.15.4.gemspec"), 'w') do |io|
-      io.puts '# bundler-1.15.4'
+      gemspec.version = "1.15.4"
+      io.puts gemspec.to_ruby
     end
 
     FileUtils.mkdir_p File.join(Gem.default_dir, "specifications")


### PR DESCRIPTION
`bundler-1.15.4.gemspec` was evaluated `Gem::Specification.load`. It needs valid gemspec.