### PR TITLE
Set whether bundler is used for gemdeps with an environmental variable

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -176,7 +176,7 @@ module Gem
     write_binary_errors
   end.freeze
 
-  USE_BUNDLER_FOR_GEMDEPS = ENV['USE_BUNDLER_FOR_GEMDEPS'] || true # :nodoc:
+  USE_BUNDLER_FOR_GEMDEPS = !ENV['DONT_USE_BUNDLER_FOR_GEMDEPS'] # :nodoc:
 
   @@win_platform = nil
 

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -176,7 +176,7 @@ module Gem
     write_binary_errors
   end.freeze
 
-  USE_BUNDLER_FOR_GEMDEPS = true # :nodoc:
+  USE_BUNDLER_FOR_GEMDEPS = ENV['USE_BUNDLER_FOR_GEMDEPS'] || true # :nodoc:
 
   @@win_platform = nil
 

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -25,7 +25,9 @@ unless Gem::Dependency.new('rdoc', '>= 3.10').matching_specs.empty?
   gem 'json'
 end
 
-require 'bundler'
+if Gem::USE_BUNDLER_FOR_GEMDEPS
+  require 'bundler'
+end
 require 'minitest/autorun'
 
 require 'rubygems/deprecate'
@@ -235,7 +237,9 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
     @current_dir = Dir.pwd
     @fetcher     = nil
 
-    Bundler.ui                     = Bundler::UI::Silent.new
+    if Gem::USE_BUNDLER_FOR_GEMDEPS
+      Bundler.ui                     = Bundler::UI::Silent.new
+    end
     @back_ui                       = Gem::DefaultUserInteraction.ui
     @ui                            = Gem::MockGemUi.new
     # This needs to be a new instance since we call use_ui(@ui) when we want to
@@ -331,7 +335,9 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
     Gem.loaded_specs.clear
     Gem.clear_default_specs
     Gem::Specification.unresolved_deps.clear
-    Bundler.reset!
+    if Gem::USE_BUNDLER_FOR_GEMDEPS
+      Bundler.reset!
+    end
 
     Gem.configuration.verbose = true
     Gem.configuration.update_sources = true

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1480,8 +1480,11 @@ class TestGem < Gem::TestCase
   end
 
   LIB_PATH = File.expand_path "../../../lib".dup.untaint, __FILE__.dup.untaint
-  BUNDLER_LIB_PATH = File.expand_path $LOAD_PATH.find {|lp| File.file?(File.join(lp, "bundler.rb")) }.dup.untaint
-  BUNDLER_FULL_NAME = "bundler-#{Bundler::VERSION}"
+
+  if Gem::USE_BUNDLER_FOR_GEMDEPS
+    BUNDLER_LIB_PATH = File.expand_path $LOAD_PATH.find {|lp| File.file?(File.join(lp, "bundler.rb")) }.dup.untaint
+    BUNDLER_FULL_NAME = "bundler-#{Bundler::VERSION}"
+  end
 
   def add_bundler_full_name(names)
     return names unless Gem::USE_BUNDLER_FOR_GEMDEPS
@@ -1529,7 +1532,7 @@ class TestGem < Gem::TestCase
     out = IO.popen(cmd, &:read).split(/\n/)
 
     assert_equal ["b-1", "c-1"], out - out0
-  end
+  end if Gem::USE_BUNDLER_FOR_GEMDEPS
 
   def test_looks_for_gemdeps_files_automatically_on_start_in_parent_dir
     util_clear_gems
@@ -1574,7 +1577,7 @@ class TestGem < Gem::TestCase
     Dir.rmdir "sub1"
 
     assert_equal ["b-1", "c-1"], out - out0
-  end
+  end if Gem::USE_BUNDLER_FOR_GEMDEPS
 
   def test_register_default_spec
     Gem.clear_default_specs
@@ -1775,7 +1778,7 @@ You may need to `gem install -g` to install missing gems
     end
   ensure
     ENV['RUBYGEMS_GEMDEPS'] = rubygems_gemdeps
-  end
+  end if Gem::USE_BUNDLER_FOR_GEMDEPS
 
   def test_use_gemdeps_specific
     skip 'Insecure operation - read' if RUBY_VERSION <= "1.8.7"


### PR DESCRIPTION
If we confirm to work test suite without vendored bundler and `Gem::USE_BUNDLER_FOR_GEMDEPS = false`, We got a `LoadError` of bundler files and `uninitialized constant Bundler` error. 

It's better to separate test environment until completely merging bundler.