### PR TITLE
Fixed leaked FDs

### DIFF
--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -308,7 +308,10 @@ class Gem::Command
 
     options[:build_args] = build_args
 
-    self.ui = Gem::SilentUI.new if options[:silent]
+    if options[:silent]
+      old_ui = self.ui
+      self.ui = ui = Gem::SilentUI.new
+    end
 
     if options[:help] then
       show_help
@@ -316,6 +319,11 @@ class Gem::Command
       @when_invoked.call options
     else
       execute
+    end
+  ensure
+    if ui
+      self.ui = old_ui
+      ui.close
     end
   end
 


### PR DESCRIPTION
# Description:

Ruby CIs have shown leaked FDs messages for a long time, because `Gem::Command#invoke_with_build_args` creates `SilentUI` and leaves it unclosed.
The global states should be restored.
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
