### PR TITLE
Improve the error message given when using --version with multiple gems in the install command

### DIFF
--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -134,7 +134,8 @@ to write the specification by hand.  For example:
   def check_version # :nodoc:
     if options[:version] != Gem::Requirement.default and
          get_all_gem_names.size > 1 then
-      alert_error "Can't use --version w/ multiple gems. Use name:ver instead."
+      alert_error "Can't use --version with multiple gems. You can specify multiple gems with" \
+                  " version requirments using `gem install 'my_gem:1.0.0' 'my_other_gem:~>2.0.0'`"
       terminate_interaction 1
     end
   end

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -602,7 +602,8 @@ ERROR:  Possible alternatives: non_existent_with_hint
 
     assert_empty @cmd.installed_specs
 
-    msg = "ERROR:  Can't use --version w/ multiple gems. Use name:ver instead."
+    msg = "ERROR:  Can't use --version with multiple gems. You can specify multiple gems with" \
+      " version requirments using `gem install 'my_gem:1.0.0' 'my_other_gem:~>2.0.0'`"
 
     assert_empty @ui.output
     assert_equal msg, @ui.error.chomp


### PR DESCRIPTION
Set the error message to now be:

    Can't use --version with multiple gems. You can specify multiple gems with
    version requirements using `gem install 'my_gem:1.0.0' 'my_other_gem:~>2.0.0

This gives a more easily understood example of the argument format to
use in rubygems when installing multiple gems with versions constraints.

______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
