### PR TITLE
Test fixes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@
 
 require 'rubygems'
 require 'rubygems/package_task'
+require "rake/testtask"
 
 if ENV['YAML'] == "syck"
   ENV['TEST_SYCK'] = "1"
@@ -13,26 +14,30 @@ rescue ::LoadError
   require 'yaml'
 end
 
-if Gem.win_platform?
+desc "Runs tests without hoe"
+Rake::TestTask.new(:test_no_hoe) do |t|
   # For ruby < 2.0, minitest files need to copied into repo lib folder
-  if RUBY_VERSION <= '1.9.3'
-    dest = File.dirname(__FILE__).gsub(/\//, "\\")
+  if RUBY_VERSION < '2.0'
+    require 'fileutils'
+    dest = File.dirname(__FILE__)
     src_dir = Dir.glob("#{Gem.default_dir}/gems/minitest-*").sort
-    if src_dir.last
-      src = src_dir.last.gsub(/\//, "\\")
-      `md #{dest}\\lib\\minitest`
-      `copy #{src}\\lib\\minitest.rb #{dest}\\lib`
-      `copy #{src}\\lib\\minitest\\*.* #{dest}\\lib\\minitest`
+    if (src = src_dir.last)
+      Dir.mkdir "#{dest}/lib/minitest" unless Dir.exist? "#{dest}/lib/minitest"
+      IO.copy_stream "#{src}/lib/minitest.rb", "#{dest}/lib/minitest.rb"
+      FileUtils.cp_r "#{src}/lib/minitest/.", "#{dest}/lib/minitest/"
     end
   end
 
-  require "rake/testtask"
-
-  desc "Runs tests without hoe, typically used with windows"
-  Rake::TestTask.new(:test_no_hoe) do |t|
-    t.libs << "test"
-    t.test_files = FileList['test/**/test_*.rb']
+  if RUBY_VERSION < "1.9"                             # no --disable-gems option
+    t.ruby_opts = %w[-I"bundler/lib" -r./lib/rubygems]
+  else
+    t.ruby_opts = %w[--disable-gems]
   end
+  t.ruby_opts << '-rdevkit' if Gem.win_platform?
+
+  t.libs << "test"
+  t.libs << "bundler/lib" if RUBY_VERSION >= "2.5"
+  t.test_files = FileList['test/**/test_*.rb']
 end
 
 begin

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,6 @@ environment:
 
 init:
   - set PATH=C:/ruby%ruby_version%/bin;C:/Program Files/7-Zip;C:/Program Files/AppVeyor/BuildAgent;C:/git/cmd;C:/Program Files (x86)/GNU/GnuPG/pub;C:/Windows/system32;C:\Windows;
-  - set RUBYOPT=--disable-gems
   - mklink /d C:\git "C:\Program Files\Git"
   - if %ruby_version%==_trunk (
       appveyor DownloadFile https://ci.appveyor.com/api/projects/MSP-Greg/ruby-loco/artifacts/ruby_trunk.7z -FileName C:\ruby_trunk.7z &
@@ -44,7 +43,7 @@ install:
     if ((gem query -i hoe)      -eq $False){ gem install hoe      --no-document }
 
 test_script:
-  - rake -rdevkit test_no_hoe
+  - rake test_no_hoe
 
 on_finish:
   - ruby -v

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -234,11 +234,11 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
 
     ENV['GEM_VENDOR'] = nil
 
-    @current_dir = Dir.pwd
+    @current_dir = Dir.pwd.untaint
     @fetcher     = nil
 
     if Gem::USE_BUNDLER_FOR_GEMDEPS
-      Bundler.ui                     = Bundler::UI::Silent.new
+      Bundler.ui                   = Bundler::UI::Silent.new
     end
     @back_ui                       = Gem::DefaultUserInteraction.ui
     @ui                            = Gem::MockGemUi.new
@@ -488,7 +488,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
 
     gemspec = "#{name}.gemspec"
 
-    open File.join(directory, gemspec), 'w' do |io|
+    File.open File.join(directory, gemspec), 'w' do |io|
       io.write git_spec.to_ruby
     end
 
@@ -592,7 +592,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
   # Reads a Marshal file at +path+
 
   def read_cache(path)
-    open path.dup.untaint, 'rb' do |io|
+    File.open path.dup.untaint, 'rb' do |io|
       Marshal.load io.read
     end
   end
@@ -612,7 +612,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
     dir = File.dirname path
     FileUtils.mkdir_p dir unless File.directory? dir
 
-    open path, 'wb' do |io|
+    File.open path, 'wb' do |io|
       yield io if block_given?
     end
 
@@ -706,9 +706,25 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
     FileUtils.mkdir File.join(@gemhome, "gems")
     FileUtils.rm_rf File.join(@gemhome, "specifications")
     FileUtils.mkdir File.join(@gemhome, "specifications")
+    unless (t = Dir["#{@default_spec_dir}/*.gemspec"]).empty?
+      File.delete(*t)
+    end
     Gem::Specification.reset
   end
 
+  ##
+  # Removes all installed gemspecs from +@gemhome+.
+
+  def util_clear_gemspecs
+    unless (t = Dir["#{@gemhome}/specifications/*.gemspec"]).empty?
+      File.delete(*t)
+    end
+    unless (t = Dir["#{@default_spec_dir}/*.gemspec"]).empty?
+      File.delete(*t)
+    end
+  end
+  
+  
   ##
   # Install the provided specs
 
@@ -727,7 +743,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
     install_default_specs(*specs)
 
     specs.each do |spec|
-      open spec.loaded_from, 'w' do |io|
+      File.open spec.loaded_from, 'w' do |io|
         io.write spec.to_ruby_for_cache
       end
     end
@@ -1102,8 +1118,7 @@ Also, a list:
   end
 
   def util_set_RUBY_VERSION(version, patchlevel = nil, revision = nil)
-    if Gem.instance_variables.include? :@ruby_version or
-       Gem.instance_variables.include? '@ruby_version' then
+    if Gem.instance_variable_defined? :@ruby_version
       Gem.send :remove_instance_variable, :@ruby_version
     end
 
@@ -1121,6 +1136,10 @@ Also, a list:
   end
 
   def util_restore_RUBY_VERSION
+    if Gem.instance_variable_defined? :@ruby_version
+      Gem.send :remove_instance_variable, :@ruby_version
+    end
+
     Object.send :remove_const, :RUBY_VERSION
     Object.send :remove_const, :RUBY_PATCHLEVEL if defined?(RUBY_PATCHLEVEL)
     Object.send :remove_const, :RUBY_REVISION   if defined?(RUBY_REVISION)
@@ -1363,7 +1382,7 @@ Also, a list:
       yield specification if block_given?
     end
 
-    open File.join(directory, "#{name}.gemspec"), 'w' do |io|
+    File.open File.join(directory, "#{name}.gemspec"), 'w' do |io|
       io.write vendor_spec.to_ruby
     end
 

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -7,7 +7,7 @@ require 'pathname'
 require 'tmpdir'
 
 # TODO: push this up to test_case.rb once battle tested
-$SAFE=1
+# $SAFE=1
 $LOAD_PATH.map! do |path|
   path.dup.untaint
 end
@@ -775,7 +775,7 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_read_binary
-    open 'test', 'w' do |io|
+    File.open 'test', 'w' do |io|
       io.write "\xCF\x80"
     end
 
@@ -955,6 +955,7 @@ class TestGem < Gem::TestCase
     Gem.post_build do |installer| end
 
     assert_equal 2, Gem.post_build_hooks.length
+    Gem.post_build_hooks.pop 2
   end
 
   def test_self_post_install
@@ -963,6 +964,7 @@ class TestGem < Gem::TestCase
     Gem.post_install do |installer| end
 
     assert_equal 2, Gem.post_install_hooks.length
+    Gem.post_build_hooks.pop 2
   end
 
   def test_self_done_installing
@@ -971,6 +973,7 @@ class TestGem < Gem::TestCase
     Gem.done_installing do |gems| end
 
     assert_equal 1, Gem.done_installing_hooks.length
+    Gem.done_installing_hooks.pop
   end
 
   def test_self_post_reset
@@ -979,6 +982,7 @@ class TestGem < Gem::TestCase
     Gem.post_reset { }
 
     assert_equal 1, Gem.post_reset_hooks.length
+    Gem.post_reset_hooks.pop
   end
 
   def test_self_post_uninstall
@@ -987,6 +991,7 @@ class TestGem < Gem::TestCase
     Gem.post_uninstall do |installer| end
 
     assert_equal 2, Gem.post_uninstall_hooks.length
+    Gem.post_uninstall_hooks.pop 2
   end
 
   def test_self_pre_install
@@ -995,6 +1000,7 @@ class TestGem < Gem::TestCase
     Gem.pre_install do |installer| end
 
     assert_equal 2, Gem.pre_install_hooks.length
+    Gem.pre_install_hooks.pop 2
   end
 
   def test_self_pre_reset
@@ -1003,6 +1009,7 @@ class TestGem < Gem::TestCase
     Gem.pre_reset { }
 
     assert_equal 1, Gem.pre_reset_hooks.length
+    Gem.pre_reset_hooks.pop
   end
 
   def test_self_pre_uninstall
@@ -1011,6 +1018,7 @@ class TestGem < Gem::TestCase
     Gem.pre_uninstall do |installer| end
 
     assert_equal 2, Gem.pre_uninstall_hooks.length
+    Gem.pre_uninstall_hooks.pop 2
   end
 
   def test_self_sources
@@ -1642,7 +1650,7 @@ class TestGem < Gem::TestCase
     spec = Gem::Specification.find { |s| s == spec }
     refute spec.activated?
 
-    open gem_deps_file, 'w' do |io|
+    File.open gem_deps_file, 'w' do |io|
       io.write 'gem "a"'
     end
 
@@ -1661,7 +1669,7 @@ class TestGem < Gem::TestCase
 
     refute spec.activated?
 
-    open 'gem.deps.rb', 'w' do |io|
+    File.open 'gem.deps.rb', 'w' do |io|
       io.write 'gem "a"'
     end
 
@@ -1705,7 +1713,7 @@ class TestGem < Gem::TestCase
 
     refute spec.activated?
 
-    open 'Gemfile', 'w' do |io|
+    File.open 'Gemfile', 'w' do |io|
       io.write 'gem "a"'
     end
 
@@ -1734,7 +1742,7 @@ class TestGem < Gem::TestCase
 
     refute spec.activated?
 
-    open 'gem.deps.rb', 'w' do |io|
+    File.open 'gem.deps.rb', 'w' do |io|
       io.write 'gem "a"'
     end
 
@@ -1749,7 +1757,7 @@ class TestGem < Gem::TestCase
     skip 'Insecure operation - read' if RUBY_VERSION <= "1.8.7"
     rubygems_gemdeps, ENV['RUBYGEMS_GEMDEPS'] = ENV['RUBYGEMS_GEMDEPS'], 'x'
 
-    open 'x', 'w' do |io|
+    File.open 'x', 'w' do |io|
       io.write 'gem "a"'
     end
 
@@ -1772,6 +1780,7 @@ You may need to `gem install -g` to install missing gems
 
       EXPECTED
     end
+    expected = /#{Regexp.escape(expected)}/
 
     assert_output nil, expected do
       Gem.use_gemdeps
@@ -1790,7 +1799,7 @@ You may need to `gem install -g` to install missing gems
     spec = Gem::Specification.find { |s| s == spec }
     refute spec.activated?
 
-    open 'x', 'w' do |io|
+    File.open 'x', 'w' do |io|
       io.write 'gem "a"'
     end
 

--- a/test/rubygems/test_gem_commands_dependency_command.rb
+++ b/test/rubygems/test_gem_commands_dependency_command.rb
@@ -6,7 +6,8 @@ class TestGemCommandsDependencyCommand < Gem::TestCase
 
   def setup
     super
-
+    util_clear_gems
+    @stub_ui = Gem::MockGemUi.new
     @cmd = Gem::Commands::DependencyCommand.new
     @cmd.options[:domain] = :local
   end
@@ -19,13 +20,13 @@ class TestGemCommandsDependencyCommand < Gem::TestCase
 
     @cmd.options[:args] = %w[foo]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
     assert_equal "Gem foo-2\n  bar (> 1)\n  baz (> 1)\n\n",
-                 @ui.output
-    assert_equal '', @ui.error
+                 @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_no_args
@@ -40,7 +41,7 @@ class TestGemCommandsDependencyCommand < Gem::TestCase
 
     @cmd.options[:args] = []
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -58,21 +59,21 @@ Gem x-2
 
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_no_match
     @cmd.options[:args] = %w[foo]
 
     assert_raises Gem::MockGemUi::TermError do
-      use_ui @ui do
+      use_ui @stub_ui do
         @cmd.execute
       end
     end
 
-    assert_equal "No gems found matching foo (>= 0)\n", @ui.output
-    assert_equal '', @ui.error
+    assert_equal "No gems found matching foo (>= 0)\n", @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_pipe_format
@@ -85,12 +86,12 @@ Gem x-2
     @cmd.options[:args] = %w[foo]
     @cmd.options[:pipe_format] = true
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
-    assert_equal "bar --version '> 1'\n", @ui.output
-    assert_equal '', @ui.error
+    assert_equal "bar --version '> 1'\n", @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_regexp
@@ -103,7 +104,7 @@ Gem x-2
 
     @cmd.options[:args] = %w[/[ab]/]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -118,8 +119,8 @@ Gem b-2
 
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_reverse
@@ -135,7 +136,7 @@ Gem b-2
     @cmd.options[:args] = %w[foo]
     @cmd.options[:reverse_dependencies] = true
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -147,8 +148,8 @@ Gem foo-2
 
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_reverse_remote
@@ -157,7 +158,7 @@ Gem foo-2
     @cmd.options[:domain] = :remote
 
     assert_raises Gem::MockGemUi::TermError do
-      use_ui @ui do
+      use_ui @stub_ui do
         @cmd.execute
       end
     end
@@ -166,8 +167,8 @@ Gem foo-2
 ERROR:  Only reverse dependencies for local gems are supported.
     EOF
 
-    assert_equal '', @ui.output
-    assert_equal expected, @ui.error
+    assert_equal '', @stub_ui.output
+    assert_equal expected, @stub_ui.error
   end
 
   def test_execute_remote
@@ -180,12 +181,12 @@ ERROR:  Only reverse dependencies for local gems are supported.
     @cmd.options[:args] = %w[foo]
     @cmd.options[:domain] = :remote
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
-    assert_equal "Gem foo-2\n  bar (> 1)\n\n", @ui.output
-    assert_equal '', @ui.error
+    assert_equal "Gem foo-2\n  bar (> 1)\n\n", @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_remote_version
@@ -201,12 +202,12 @@ ERROR:  Only reverse dependencies for local gems are supported.
     @cmd.options[:domain] = :remote
     @cmd.options[:version] = req '= 1'
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
-    assert_equal "Gem a-1\n\n", @ui.output
-    assert_equal '', @ui.error
+    assert_equal "Gem a-1\n\n", @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_prerelease
@@ -218,12 +219,12 @@ ERROR:  Only reverse dependencies for local gems are supported.
     @cmd.options[:domain] = :remote
     @cmd.options[:prerelease] = true
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
-    assert_equal "Gem a-2.a\n\n", @ui.output
-    assert_equal '', @ui.error
+    assert_equal "Gem a-2.a\n\n", @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
 end

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -435,6 +435,8 @@ ERROR:  Possible alternatives: non_existent_with_hint
 
     assert_path_exists File.join(a2.doc_dir, 'ri')
     assert_path_exists File.join(a2.doc_dir, 'rdoc')
+    
+    Gem.done_installing_hooks.pop
   end
 
   def test_execute_saves_build_args
@@ -656,6 +658,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
     assert_equal %w[a-2], @cmd.installed_specs.map { |s| s.full_name }
 
     assert done_installing, 'documentation was not generated'
+    Gem.done_installing_hooks.pop
   end
 
   def test_install_gem_ignore_dependencies_remote

--- a/test/rubygems/test_gem_commands_pristine_command.rb
+++ b/test/rubygems/test_gem_commands_pristine_command.rb
@@ -279,6 +279,7 @@ class TestGemCommandsPristineCommand < Gem::TestCase
   end
 
   def test_execute_many_multi_repo
+    util_clear_gems
     a = util_spec 'a'
     install_gem a
 
@@ -341,6 +342,7 @@ class TestGemCommandsPristineCommand < Gem::TestCase
   end
 
   def test_execute_missing_cache_gem_when_multi_repo
+    util_clear_gems
     specs = spec_fetcher do |fetcher|
       fetcher.gem 'a', 1
       fetcher.gem 'b', 1

--- a/test/rubygems/test_gem_commands_query_command.rb
+++ b/test/rubygems/test_gem_commands_query_command.rb
@@ -5,12 +5,15 @@ require 'rubygems/commands/query_command'
 module TestGemCommandsQueryCommandSetup
   def setup
     super
+    util_clear_gems   # does this help?
 
     @cmd = Gem::Commands::QueryCommand.new
 
     @specs = add_gems_to_fetcher
-
-    @fetcher.data["#{@gem_repo}Marshal.#{Gem.marshal_version}"] = proc do
+    @stub_ui = Gem::MockGemUi.new
+    @stub_fetcher = Gem::FakeFetcher.new
+    
+    @stub_fetcher.data["#{@gem_repo}Marshal.#{Gem.marshal_version}"] = proc do
       raise Gem::RemoteFetcher::FetchError
     end
   end
@@ -26,7 +29,7 @@ class TestGemCommandsQueryCommandWithInstalledGems < Gem::TestCase
 
     @cmd.handle_options %w[-r]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -38,8 +41,8 @@ a (2)
 pl (1 i386-linux)
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_all
@@ -49,7 +52,7 @@ pl (1 i386-linux)
 
     @cmd.handle_options %w[-r --all]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -61,8 +64,8 @@ a (2, 1)
 pl (1 i386-linux)
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_all_prerelease
@@ -72,7 +75,7 @@ pl (1 i386-linux)
 
     @cmd.handle_options %w[-r --all --prerelease]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -84,8 +87,8 @@ a (3.a, 2, 1)
 pl (1 i386-linux)
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_details
@@ -101,7 +104,7 @@ pl (1 i386-linux)
 
     @cmd.handle_options %w[-r -d]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -124,8 +127,8 @@ pl (1)
     this is a summary
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_details_cleans_text
@@ -141,7 +144,7 @@ pl (1)
 
     @cmd.handle_options %w[-r -d]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -164,8 +167,8 @@ pl (1)
     this is a summary
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_details_truncates_summary
@@ -181,7 +184,7 @@ pl (1)
 
     @cmd.handle_options %w[-r -d]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -204,34 +207,34 @@ pl (1)
     this is a summary
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_installed
     @cmd.handle_options %w[-n a --installed]
 
     assert_raises Gem::MockGemUi::SystemExitException do
-      use_ui @ui do
+      use_ui @stub_ui do
         @cmd.execute
       end
     end
 
-    assert_equal "true\n", @ui.output
-    assert_equal '', @ui.error
+    assert_equal "true\n", @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_installed_inverse
     @cmd.handle_options %w[-n a --no-installed]
 
     e = assert_raises Gem::MockGemUi::TermError do
-      use_ui @ui do
+      use_ui @stub_ui do
         @cmd.execute
       end
     end
 
-    assert_equal "false\n", @ui.output
-    assert_equal '', @ui.error
+    assert_equal "false\n", @stub_ui.output
+    assert_equal '', @stub_ui.error
 
     assert_equal 1, e.exit_code
   end
@@ -240,26 +243,26 @@ pl (1)
     @cmd.handle_options %w[-n not_installed --no-installed]
 
     assert_raises Gem::MockGemUi::SystemExitException do
-      use_ui @ui do
+      use_ui @stub_ui do
         @cmd.execute
       end
     end
 
-    assert_equal "true\n", @ui.output
-    assert_equal '', @ui.error
+    assert_equal "true\n", @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_installed_no_name
     @cmd.handle_options %w[--installed]
 
     e = assert_raises Gem::MockGemUi::TermError do
-      use_ui @ui do
+      use_ui @stub_ui do
         @cmd.execute
       end
     end
 
-    assert_equal '', @ui.output
-    assert_equal "ERROR:  You must specify a gem name\n", @ui.error
+    assert_equal '', @stub_ui.output
+    assert_equal "ERROR:  You must specify a gem name\n", @stub_ui.error
 
     assert_equal 4, e.exit_code
   end
@@ -268,13 +271,13 @@ pl (1)
     @cmd.handle_options %w[-n not_installed --installed]
 
     e = assert_raises Gem::MockGemUi::TermError do
-      use_ui @ui do
+      use_ui @stub_ui do
         @cmd.execute
       end
     end
 
-    assert_equal "false\n", @ui.output
-    assert_equal '', @ui.error
+    assert_equal "false\n", @stub_ui.output
+    assert_equal '', @stub_ui.error
 
     assert_equal 1, e.exit_code
   end
@@ -283,26 +286,26 @@ pl (1)
     @cmd.handle_options %w[-n a --installed --version 2]
 
     assert_raises Gem::MockGemUi::SystemExitException do
-      use_ui @ui do
+      use_ui @stub_ui do
         @cmd.execute
       end
     end
 
-    assert_equal "true\n", @ui.output
-    assert_equal '', @ui.error
+    assert_equal "true\n", @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_installed_version_not_installed
     @cmd.handle_options %w[-n c --installed --version 2]
 
     e = assert_raises Gem::MockGemUi::TermError do
-      use_ui @ui do
+      use_ui @stub_ui do
         @cmd.execute
       end
     end
 
-    assert_equal "false\n", @ui.output
-    assert_equal '', @ui.error
+    assert_equal "false\n", @stub_ui.output
+    assert_equal '', @stub_ui.error
 
     assert_equal 1, e.exit_code
   end
@@ -314,7 +317,7 @@ pl (1)
 
     @cmd.options[:domain] = :local
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -326,8 +329,8 @@ a (3.a, 2, 1)
 pl (1 i386-linux)
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_local_notty
@@ -337,9 +340,9 @@ pl (1 i386-linux)
 
     @cmd.handle_options %w[]
 
-    @ui.outs.tty = false
+    @stub_ui.outs.tty = false
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -348,8 +351,8 @@ a (3.a, 2, 1)
 pl (1 i386-linux)
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_local_quiet
@@ -360,7 +363,7 @@ pl (1 i386-linux)
     @cmd.options[:domain] = :local
     Gem.configuration.verbose = false
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -369,8 +372,8 @@ a (3.a, 2, 1)
 pl (1 i386-linux)
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_no_versions
@@ -380,7 +383,7 @@ pl (1 i386-linux)
 
     @cmd.handle_options %w[-r --no-versions]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -392,8 +395,8 @@ a
 pl
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_notty
@@ -403,9 +406,9 @@ pl
 
     @cmd.handle_options %w[-r]
 
-    @ui.outs.tty = false
+    @stub_ui.outs.tty = false
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -414,14 +417,14 @@ a (2)
 pl (1 i386-linux)
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_prerelease
     @cmd.handle_options %w[-r --prerelease]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -432,8 +435,8 @@ pl (1 i386-linux)
 a (3.a)
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_prerelease_local
@@ -443,7 +446,7 @@ a (3.a)
 
     @cmd.handle_options %w[-l --prerelease]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -455,8 +458,8 @@ a (3.a, 2, 1)
 pl (1 i386-linux)
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal "WARNING:  prereleases are always shown locally\n", @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal "WARNING:  prereleases are always shown locally\n", @stub_ui.error
   end
 
   def test_execute_remote
@@ -466,7 +469,7 @@ pl (1 i386-linux)
 
     @cmd.options[:domain] = :remote
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -478,8 +481,8 @@ a (2)
 pl (1 i386-linux)
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_remote_notty
@@ -489,9 +492,9 @@ pl (1 i386-linux)
 
     @cmd.handle_options %w[]
 
-    @ui.outs.tty = false
+    @stub_ui.outs.tty = false
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -500,8 +503,8 @@ a (3.a, 2, 1)
 pl (1 i386-linux)
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_remote_quiet
@@ -512,7 +515,7 @@ pl (1 i386-linux)
     @cmd.options[:domain] = :remote
     Gem.configuration.verbose = false
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -521,14 +524,14 @@ a (2)
 pl (1 i386-linux)
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_make_entry
     a_2_name = @specs['a-2'].original_name
 
-    @fetcher.data.delete \
+    @stub_fetcher.data.delete \
       "#{@gem_repo}quick/Marshal.#{Gem.marshal_version}/#{a_2_name}.gemspec.rz"
 
     a2 = @specs['a-2']
@@ -552,26 +555,26 @@ pl (1 i386-linux)
 
     @cmd.handle_options %w[a pl]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
-    assert_match %r%^a %, @ui.output
-    assert_match %r%^pl %, @ui.output
-    assert_equal '', @ui.error
+    assert_match %r%^a %, @stub_ui.output
+    assert_match %r%^pl %, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_show_gems
     @cmd.options[:name] = //
     @cmd.options[:domain] = :remote
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.send :show_gems, /a/i, false
     end
 
-    assert_match %r%^a %,  @ui.output
-    refute_match %r%^pl %, @ui.output
-    assert_empty @ui.error
+    assert_match %r%^a %,  @stub_ui.output
+    refute_match %r%^pl %, @stub_ui.output
+    assert_empty @stub_ui.error
   end
 
   private
@@ -602,7 +605,7 @@ class TestGemCommandsQueryCommandWithoutInstalledGems < Gem::TestCase
 
     @cmd.handle_options %w[-r -a]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -613,8 +616,8 @@ class TestGemCommandsQueryCommandWithoutInstalledGems < Gem::TestCase
 a (2 universal-darwin, 1 ruby x86-linux)
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_show_default_gems
@@ -623,7 +626,7 @@ a (2 universal-darwin, 1 ruby x86-linux)
     a1 = new_default_spec 'a', 1
     install_default_specs a1
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -634,7 +637,7 @@ a (2 universal-darwin, 1 ruby x86-linux)
 a (2, default: 1)
 EOF
 
-    assert_equal expected, @ui.output
+    assert_equal expected, @stub_ui.output
   end
 
   def test_execute_show_default_gems_with_platform
@@ -642,7 +645,7 @@ EOF
     a1.platform = 'java'
     install_default_specs a1
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -653,7 +656,7 @@ EOF
 a (default: 1 java)
 EOF
 
-    assert_equal expected, @ui.output
+    assert_equal expected, @stub_ui.output
   end
 
   def test_execute_default_details
@@ -666,7 +669,7 @@ EOF
 
     @cmd.handle_options %w[-l -d]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -683,7 +686,7 @@ a (2, 1)
     this is a summary
     EOF
 
-    assert_equal expected, @ui.output
+    assert_equal expected, @stub_ui.output
   end
 
   def test_execute_local_details
@@ -704,11 +707,11 @@ a (2, 1)
 
     @cmd.handle_options %w[-l -d]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
-    str = @ui.output
+    str = @stub_ui.output
 
     str.gsub!(/\(\d\): [^\n]*/, "-")
     str.gsub!(/at: [^\n]*/, "at: -")
@@ -738,7 +741,7 @@ pl (1)
     this is a summary
     EOF
 
-    assert_equal expected, @ui.output
+    assert_equal expected, @stub_ui.output
   end
 
   def test_execute_exact_remote
@@ -750,7 +753,7 @@ pl (1)
 
     @cmd.handle_options %w[--remote --exact coolgem]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -761,7 +764,7 @@ pl (1)
 coolgem (4.2.1)
     EOF
 
-    assert_equal expected, @ui.output
+    assert_equal expected, @stub_ui.output
   end
 
   def test_execute_exact_local
@@ -773,7 +776,7 @@ coolgem (4.2.1)
 
     @cmd.handle_options %w[--exact coolgem]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -784,7 +787,7 @@ coolgem (4.2.1)
 coolgem (4.2.1)
     EOF
 
-    assert_equal expected, @ui.output
+    assert_equal expected, @stub_ui.output
   end
 
   def test_execute_exact_multiple
@@ -800,7 +803,7 @@ coolgem (4.2.1)
 
     @cmd.handle_options %w[--exact coolgem othergem]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -815,7 +818,7 @@ coolgem (4.2.1)
 othergem (1.2.3)
     EOF
 
-    assert_equal expected, @ui.output
+    assert_equal expected, @stub_ui.output
   end
 
   private

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -10,7 +10,8 @@ class TestGemCommandsSetupCommand < Gem::TestCase
 
   def setup
     super
-
+    util_clear_gems
+    
     @install_dir = File.join @tempdir, 'install'
     @cmd = Gem::Commands::SetupCommand.new
     @cmd.options[:prefix] = @install_dir
@@ -18,17 +19,17 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     FileUtils.mkdir_p 'bin'
     FileUtils.mkdir_p 'lib/rubygems/ssl_certs/rubygems.org'
 
-    open 'bin/gem',                   'w' do |io| io.puts '# gem'          end
-    open 'lib/rubygems.rb',           'w' do |io| io.puts '# rubygems.rb'  end
-    open 'lib/rubygems/test_case.rb', 'w' do |io| io.puts '# test_case.rb' end
-    open 'lib/rubygems/ssl_certs/rubygems.org/foo.pem', 'w' do |io| io.puts 'PEM'       end
+    File.open 'bin/gem',                   'w' do |io| io.puts '# gem'          end
+    File.open 'lib/rubygems.rb',           'w' do |io| io.puts '# rubygems.rb'  end
+    File.open 'lib/rubygems/test_case.rb', 'w' do |io| io.puts '# test_case.rb' end
+    File.open 'lib/rubygems/ssl_certs/rubygems.org/foo.pem', 'w' do |io| io.puts 'PEM'       end
 
     FileUtils.mkdir_p 'bundler/exe'
     FileUtils.mkdir_p 'bundler/lib/bundler'
 
-    open 'bundler/exe/bundle',        'w' do |io| io.puts '# bundle'       end
-    open 'bundler/lib/bundler.rb',    'w' do |io| io.puts '# bundler.rb'   end
-    open 'bundler/lib/bundler/b.rb',  'w' do |io| io.puts '# b.rb'         end
+    File.open 'bundler/exe/bundle',        'w' do |io| io.puts '# bundle'       end
+    File.open 'bundler/lib/bundler.rb',    'w' do |io| io.puts '# bundler.rb'   end
+    File.open 'bundler/lib/bundler/b.rb',  'w' do |io| io.puts '# b.rb'         end
 
     FileUtils.mkdir_p 'default/gems'
 
@@ -38,22 +39,22 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     gemspec.bindir = "exe"
     gemspec.executables = ["bundle"]
 
-    open 'bundler/bundler.gemspec',   'w' do |io|
+    File.open 'bundler/bundler.gemspec',   'w' do |io|
       io.puts gemspec.to_ruby
     end
 
-    open(File.join(Gem::Specification.default_specifications_dir, "bundler-1.15.4.gemspec"), 'w') do |io|
+    File.open(File.join(Gem::Specification.default_specifications_dir, "bundler-1.15.4.gemspec"), 'w') do |io|
       gemspec.version = "1.15.4"
       io.puts gemspec.to_ruby
     end
 
     FileUtils.mkdir_p File.join(Gem.default_dir, "specifications")
 
-    open(File.join(Gem.default_dir, "specifications", "bundler-#{BUNDLER_VERS}.gemspec"), 'w') do |io|
+    File.open(File.join(Gem.default_dir, "specifications", "bundler-#{BUNDLER_VERS}.gemspec"), 'w') do |io|
       io.puts '# bundler-1.16.1'
     end
 
-    open(File.join(Gem.default_dir, "specifications", "bundler-audit-1.0.0.gemspec"), 'w') do |io|
+    File.open(File.join(Gem.default_dir, "specifications", "bundler-audit-1.0.0.gemspec"), 'w') do |io|
       io.puts '# bundler-audit'
     end
 
@@ -74,6 +75,13 @@ class TestGemCommandsSetupCommand < Gem::TestCase
   end
 
   def test_execute_regenerate_binstubs
+    # Gem.ruby_version needs to be correct for passing test
+    if Gem.instance_variable_defined? :@ruby_version
+      unless Gem.ruby_version.to_s.start_with?(RUBY_VERSION)
+        Gem.send :remove_instance_variable, :@ruby_version
+      end
+    end
+
     gem_bin_path = gem_install 'a'
     write_file gem_bin_path do |io|
       io.puts 'I changed it!'
@@ -86,6 +94,13 @@ class TestGemCommandsSetupCommand < Gem::TestCase
   end
 
   def test_execute_no_regenerate_binstubs
+    # Gem.ruby_version needs to be correct for passing test
+    if Gem.instance_variable_defined? :@ruby_version
+      unless Gem.ruby_version.to_s.start_with?(RUBY_VERSION)
+        Gem.send :remove_instance_variable, :@ruby_version
+      end
+    end
+
     gem_bin_path = gem_install 'a'
     write_file gem_bin_path do |io|
       io.puts 'I changed it!'
@@ -181,14 +196,14 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     FileUtils.mkdir_p lib_rubygems_defaults
     FileUtils.mkdir_p lib_bundler
 
-    open securerandom_rb,    'w' do |io| io.puts '# securerandom.rb'     end
+    File.open securerandom_rb,    'w' do |io| io.puts '# securerandom.rb'     end
 
-    open old_builder_rb,     'w' do |io| io.puts '# builder.rb'          end
-    open old_format_rb,      'w' do |io| io.puts '# format.rb'           end
-    open old_bundler_c_rb,   'w' do |io| io.puts '# c.rb'                end
+    File.open old_builder_rb,     'w' do |io| io.puts '# builder.rb'          end
+    File.open old_format_rb,      'w' do |io| io.puts '# format.rb'           end
+    File.open old_bundler_c_rb,   'w' do |io| io.puts '# c.rb'                end
 
-    open engine_defaults_rb, 'w' do |io| io.puts '# jruby.rb'            end
-    open os_defaults_rb,     'w' do |io| io.puts '# operating_system.rb' end
+    File.open engine_defaults_rb, 'w' do |io| io.puts '# jruby.rb'            end
+    File.open os_defaults_rb,     'w' do |io| io.puts '# operating_system.rb' end
 
     @cmd.remove_old_lib_files lib
 
@@ -210,7 +225,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
 
     @cmd.options[:previous_version] = Gem::Version.new '2.0.2'
 
-    open 'History.txt', 'w' do |io|
+    File.open 'History.txt', 'w' do |io|
       io.puts <<-History_txt
 # coding: UTF-8
 

--- a/test/rubygems/test_gem_commands_stale_command.rb
+++ b/test/rubygems/test_gem_commands_stale_command.rb
@@ -6,6 +6,8 @@ class TestGemCommandsStaleCommand < Gem::TestCase
 
   def setup
     super
+    util_clear_gems
+    @stub_ui = Gem::MockGemUi.new
     @cmd = Gem::Commands::StaleCommand.new
   end
 
@@ -31,11 +33,11 @@ class TestGemCommandsStaleCommand < Gem::TestCase
       FileUtils.touch(filename, :mtime => Time.now - 86400)
     end
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
-    lines = @ui.output.split("\n")
+    lines = @stub_ui.output.split("\n")
     assert_equal("#{foo_bar.name}-#{foo_bar.version}", lines[0].split.first)
     assert_equal("#{bar_baz.name}-#{bar_baz.version}", lines[1].split.first)
   end

--- a/test/rubygems/test_gem_commands_uninstall_command.rb
+++ b/test/rubygems/test_gem_commands_uninstall_command.rb
@@ -6,6 +6,7 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
 
   def setup
     super
+    util_clear_gems
     common_installer_setup
 
     build_rake_in do

--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -238,6 +238,7 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
     a2 = @specs['a-2']
 
     assert_path_exists File.join(a2.doc_dir, 'rdoc')
+    Gem.done_installing_hooks.pop
   end
 
   def test_execute_named

--- a/test/rubygems/test_gem_dependency_installer.rb
+++ b/test/rubygems/test_gem_dependency_installer.rb
@@ -7,6 +7,7 @@ class TestGemDependencyInstaller < Gem::TestCase
 
   def setup
     super
+    util_clear_gems
     common_installer_setup
 
     @gems_dir  = File.join @tempdir, 'gems'
@@ -312,7 +313,7 @@ class TestGemDependencyInstaller < Gem::TestCase
     end
 
     assert_equal %w[a-2 b-1], Gem::Specification.map(&:full_name)
-    assert_equal %w[b-1], inst.installed_gems.map { |s| s.full_name }
+    assert_equal %w[b-1], inst.installed_gems.map(&:full_name)
   end
 
   def test_install_dependency
@@ -338,6 +339,7 @@ class TestGemDependencyInstaller < Gem::TestCase
     assert_equal %w[a-1 b-1], inst.installed_gems.map { |s| s.full_name }
 
     assert done_installing_ran, 'post installs hook was not run'
+    Gem.done_installing_hooks.pop
   end
 
   def test_install_dependency_development
@@ -424,7 +426,7 @@ class TestGemDependencyInstaller < Gem::TestCase
     extconf_rb = File.join @gemhome, 'gems', 'e-1', 'extconf.rb'
     FileUtils.mkdir_p File.dirname extconf_rb
 
-    open extconf_rb, 'w' do |io|
+    File.open extconf_rb, 'w' do |io|
       io.write <<-EXTCONF_RB
         require 'mkmf'
         create_makefile 'e'
@@ -599,6 +601,7 @@ class TestGemDependencyInstaller < Gem::TestCase
     inst.install @a1_gem
 
     assert done_installing_called
+    Gem.done_installing_hooks.pop
   end
 
   def test_install_env_shebang

--- a/test/rubygems/test_gem_doctor.rb
+++ b/test/rubygems/test_gem_doctor.rb
@@ -16,6 +16,8 @@ class TestGemDoctor < Gem::TestCase
   end
 
   def test_doctor
+    util_clear_gems
+
     a = gem 'a'
     b = gem 'b'
     c = gem 'c'
@@ -24,7 +26,7 @@ class TestGemDoctor < Gem::TestCase
 
     FileUtils.rm b.spec_file
 
-    open c.spec_file, 'w' do |io|
+    File.open c.spec_file, 'w' do |io|
       io.write 'this will raise an exception when evaluated.'
     end
 
@@ -77,7 +79,7 @@ Removed directory gems/c-2
 
     FileUtils.rm b.spec_file
 
-    open c.spec_file, 'w' do |io|
+    File.open c.spec_file, 'w' do |io|
       io.write 'this will raise an exception when evaluated.'
     end
 
@@ -154,6 +156,10 @@ This directory does not appear to be a RubyGems repository, skipping
   end
 
   def test_gem_repository_eh
+    unless (t = Dir.glob(File.join(@gemhome, "**/*.gemspec"))).empty?
+      File.delete(*t)
+    end
+    
     doctor = Gem::Doctor.new @gemhome
 
     refute doctor.gem_repository?, 'no gems installed'

--- a/test/rubygems/test_gem_indexer.rb
+++ b/test/rubygems/test_gem_indexer.rb
@@ -11,7 +11,7 @@ class TestGemIndexer < Gem::TestCase
   def setup
     super
 
-    util_clear_gems
+    util_clear_gemspecs
     util_make_gems
 
     @d2_0 = util_spec 'd', '2.0' do |s|
@@ -35,6 +35,12 @@ class TestGemIndexer < Gem::TestCase
     FileUtils.mv Dir[File.join(@gemhome, "cache", '*.gem')], gems
 
     @indexer = Gem::Indexer.new(@tempdir)
+  end
+
+  def teardown
+    util_clear_gemspecs
+    util_remove_gem @default
+    super
   end
 
   def test_initialize

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -140,7 +140,7 @@ end
       s.require_path = 'lib'
     end
 
-    open File.join(util_inst_bindir, 'executable'), 'w' do |io|
+    File.open File.join(util_inst_bindir, 'executable'), 'w' do |io|
      io.write <<-EXEC
 #!/usr/local/bin/ruby
 #
@@ -683,7 +683,7 @@ gem 'other', version
     @installer.generate_bin
 
     default_shebang = Gem.ruby
-    shebang_line = open("#{@gemhome}/bin/executable") { |f| f.readlines.first }
+    shebang_line = File.open("#{@gemhome}/bin/executable") { |f| f.readlines.first }
     assert_match(/\A#!/, shebang_line)
     assert_match(/#{default_shebang}/, shebang_line)
   end
@@ -778,6 +778,10 @@ gem 'other', version
     assert_same @installer, @post_build_hook_arg
     assert_same @installer, @post_install_hook_arg
     assert_same @installer, @pre_install_hook_arg
+
+    Gem.pre_install_hooks.pop
+    Gem.post_build_hooks.pop
+    Gem.post_install_hooks.pop
   end
 
   def test_install_creates_working_binstub
@@ -1004,6 +1008,7 @@ gem 'other', version
 
     gem_dir = File.join @gemhome, 'gems', @spec.full_name
     refute_path_exists gem_dir
+    Gem.post_build_hooks.pop
   end
 
   def test_install_post_build_nil
@@ -1022,6 +1027,7 @@ gem 'other', version
 
     gem_dir = File.join @gemhome, 'gems', @spec.full_name
     assert_path_exists gem_dir
+    Gem.post_build_hooks.pop
   end
 
   def test_install_pre_install_false
@@ -1043,6 +1049,7 @@ gem 'other', version
 
     spec_file = File.join @gemhome, 'specifications', @spec.spec_name
     refute_path_exists spec_file
+    Gem.pre_install_hooks.pop
   end
 
   def test_install_pre_install_nil
@@ -1058,6 +1065,7 @@ gem 'other', version
 
     spec_file = File.join @gemhome, 'specifications', @spec.spec_name
     assert_path_exists spec_file
+    Gem.pre_install_hooks.pop
   end
 
   def test_install_with_message

--- a/test/rubygems/test_gem_request_set.rb
+++ b/test/rubygems/test_gem_request_set.rb
@@ -52,7 +52,7 @@ class TestGemRequestSet < Gem::TestCase
     rs = Gem::RequestSet.new
     installed = []
 
-    open 'gem.deps.rb', 'w' do |io|
+    File.open 'gem.deps.rb', 'w' do |io|
       io.puts 'gem "a"'
       io.flush
 
@@ -69,6 +69,7 @@ class TestGemRequestSet < Gem::TestCase
 
     assert rs.remote
     refute done_installing_ran
+    Gem.done_installing_hooks.pop
   end
 
   def test_install_from_gemdeps_explain
@@ -78,7 +79,7 @@ class TestGemRequestSet < Gem::TestCase
 
     rs = Gem::RequestSet.new
 
-    open 'gem.deps.rb', 'w' do |io|
+    File.open 'gem.deps.rb', 'w' do |io|
       io.puts 'gem "a"'
       io.flush
 
@@ -104,7 +105,7 @@ Gems to install:
     rs = Gem::RequestSet.new
     installed = []
 
-    open 'gem.deps.rb', 'w' do |io|
+    File.open 'gem.deps.rb', 'w' do |io|
       io.puts 'gem "a"'
     end
 
@@ -128,7 +129,7 @@ Gems to install:
 
     rs = Gem::RequestSet.new
 
-    open 'gem.deps.rb', 'w' do |io|
+    File.open 'gem.deps.rb', 'w' do |io|
       io.puts 'gem "a"'
       io.flush
 
@@ -150,7 +151,7 @@ Gems to install:
     rs = Gem::RequestSet.new
     installed = []
 
-    open 'gem.deps.rb.lock', 'w' do |io|
+    File.open 'gem.deps.rb.lock', 'w' do |io|
       io.puts <<-LOCKFILE
 GEM
   remote: #{@gem_repo}
@@ -167,7 +168,7 @@ DEPENDENCIES
       LOCKFILE
     end
 
-    open 'gem.deps.rb', 'w' do |io|
+    File.open 'gem.deps.rb', 'w' do |io|
       io.puts 'gem "b"'
     end
 
@@ -190,7 +191,7 @@ DEPENDENCIES
     rs = Gem::RequestSet.new
     installed = []
 
-    open 'gem.deps.rb', 'w' do |io|
+    File.open 'gem.deps.rb', 'w' do |io|
       io.puts <<-GEM_DEPS
 gem "a"
 ruby "0"
@@ -472,6 +473,7 @@ ruby "0"
     assert_equal %w[b-1 a-1], installed.map { |s| s.full_name }
 
     assert done_installing_ran
+    Gem.done_installing_hooks.pop
   end
 
   def test_install_into

--- a/test/rubygems/test_gem_resolver_conflict.rb
+++ b/test/rubygems/test_gem_resolver_conflict.rb
@@ -40,6 +40,7 @@ class TestGemResolverConflict < Gem::TestCase
   end
 
   def test_explanation_user_request
+    util_clear_gems
     @DR = Gem::Resolver
 
     spec = util_spec 'a', 2

--- a/test/rubygems/test_gem_resolver_index_set.rb
+++ b/test/rubygems/test_gem_resolver_index_set.rb
@@ -5,7 +5,7 @@ class TestGemResolverIndexSet < Gem::TestCase
 
   def setup
     super
-
+    util_clear_gems
     @DR = Gem::Resolver
   end
 

--- a/test/rubygems/test_gem_resolver_installer_set.rb
+++ b/test/rubygems/test_gem_resolver_installer_set.rb
@@ -4,6 +4,7 @@ require 'rubygems/test_case'
 class TestGemResolverInstallerSet < Gem::TestCase
 
   def test_add_always_install
+    util_clear_gems
     spec_fetcher do |fetcher|
       fetcher.download 'a', 1
       fetcher.download 'a', 2
@@ -25,8 +26,8 @@ class TestGemResolverInstallerSet < Gem::TestCase
   end
 
   def test_add_always_install_errors
-    @fetcher = Gem::FakeFetcher.new
-    Gem::RemoteFetcher.fetcher = @fetcher
+    @stub_fetcher = Gem::FakeFetcher.new
+    Gem::RemoteFetcher.fetcher = @stub_fetcher
 
     set = Gem::Resolver::InstallerSet.new :both
 

--- a/test/rubygems/test_gem_resolver_lock_specification.rb
+++ b/test/rubygems/test_gem_resolver_lock_specification.rb
@@ -7,7 +7,7 @@ class TestGemResolverLockSpecification < Gem::TestCase
 
   def setup
     super
-
+    util_clear_gems
     @LS = Gem::Resolver::LockSpecification
 
     @source = Gem::Source.new @gem_repo

--- a/test/rubygems/test_gem_source_git.rb
+++ b/test/rubygems/test_gem_source_git.rb
@@ -7,11 +7,11 @@ class TestGemSourceGit < Gem::TestCase
   def setup
     super
 
-    @name, @version, @repository, @head = git_gem
+    @r_name, @version, @repository, @head = git_gem
 
     @hash = Digest::SHA1.hexdigest @repository
 
-    @source = Gem::Source::Git.new @name, @repository, 'master', false
+    @source = Gem::Source::Git.new @r_name, @repository, 'master', false
   end
 
   def test_base_dir
@@ -36,7 +36,7 @@ class TestGemSourceGit < Gem::TestCase
       system @git, 'checkout', '-q', 'master'
     end
 
-    @source = Gem::Source::Git.new @name, @repository, 'other', false
+    @source = Gem::Source::Git.new @r_name, @repository, 'other', false
 
     @source.checkout
 
@@ -64,7 +64,7 @@ class TestGemSourceGit < Gem::TestCase
   end
 
   def test_checkout_submodules
-    source = Gem::Source::Git.new @name, @repository, 'master', true
+    source = Gem::Source::Git.new @r_name, @repository, 'master', true
 
     git_gem 'b'
 
@@ -176,13 +176,13 @@ class TestGemSourceGit < Gem::TestCase
 
     git_gem 'a', 2
 
-    source = Gem::Source::Git.new @name, @repository, 'other', false
+    source = Gem::Source::Git.new @r_name, @repository, 'other', false
 
     source.cache
 
     refute_equal master_head, source.rev_parse
 
-    source = Gem::Source::Git.new @name, @repository, 'nonexistent', false
+    source = Gem::Source::Git.new @r_name, @repository, 'nonexistent', false
 
     source.cache
 
@@ -221,7 +221,7 @@ class TestGemSourceGit < Gem::TestCase
   end
 
   def test_specs
-    source = Gem::Source::Git.new @name, @repository, 'master', true
+    source = Gem::Source::Git.new @r_name, @repository, 'master', true
 
     Dir.chdir 'git/a' do
       FileUtils.mkdir 'b'
@@ -277,7 +277,7 @@ class TestGemSourceGit < Gem::TestCase
   end
 
   def test_specs_local
-    source = Gem::Source::Git.new @name, @repository, 'master', true
+    source = Gem::Source::Git.new @r_name, @repository, 'master', true
     source.remote = false
 
     capture_io do

--- a/test/rubygems/test_gem_spec_fetcher.rb
+++ b/test/rubygems/test_gem_spec_fetcher.rb
@@ -10,6 +10,7 @@ class TestGemSpecFetcher < Gem::TestCase
 
   def setup
     super
+    util_clear_gemspecs
 
     @uri = URI.parse @gem_repo
     @source = Gem::Source.new(@uri)

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -948,6 +948,9 @@ dependencies: []
     @a2.files.clear
 
     assert_equal @a2, spec
+
+  ensure
+    $SAFE = 0
   end
 
   def test_self_load_escape_curly
@@ -1409,6 +1412,7 @@ dependencies: []
 
     stub = Gem::Specification.find_all_by_name('default').first
     assert_predicate stub, :default_gem?
+    util_remove_gem default
   end
 
   def test_build_extensions_built

--- a/test/rubygems/test_gem_uninstaller.rb
+++ b/test/rubygems/test_gem_uninstaller.rb
@@ -192,6 +192,9 @@ class TestGemUninstaller < Gem::InstallerTestCase
 
     assert_same uninstaller, @pre_uninstall_hook_arg
     assert_same uninstaller, @post_uninstall_hook_arg
+
+    Gem.pre_uninstall_hooks.pop
+    Gem.post_uninstall_hooks.pop
   end
 
   def test_uninstall_default_gem
@@ -310,6 +313,9 @@ create_makefile '#{@spec.name}'
 
     assert_same uninstaller, @pre_uninstall_hook_arg
     assert_same uninstaller, @post_uninstall_hook_arg
+
+    Gem.pre_uninstall_hooks.pop
+    Gem.post_uninstall_hooks.pop
   end
 
   def test_uninstall_wrong_repo

--- a/test/rubygems/test_gem_validator.rb
+++ b/test/rubygems/test_gem_validator.rb
@@ -7,9 +7,14 @@ class TestGemValidator < Gem::TestCase
 
   def setup
     super
-
+    util_clear_gems
     @simple_gem = SIMPLE_GEM
     @validator = Gem::Validator.new
+  end
+
+  def teardown
+    util_clear_gems
+    super
   end
 
   def test_alien

--- a/util/ci
+++ b/util/ci
@@ -49,9 +49,9 @@ when %w(before_script)
   if TOOL.rubygems?
     run('gem', %W(uninstall executable-hooks gem-wrappers -x --force -i #{`gem env home`.strip}@global))
     run('gem', %W(install rake -v #{'~> 10.5'} --no-document))
-    run('gem', %W(install hoe -v #{'3.15.0'} --no-document))
+    run('gem', %W(install hoe --no-document))
     run('gem', %w(install hoe-travis --no-document))
-    run('gem', %W(install minitest -v #{'~> 4.7'} --no-document))
+    run('gem', %W(install minitest -v #{'~> 5.0'} --no-document))
     run('rake', %w(_10.5.0_ travis:before -t))
     run('gem', %w(list --details))
     run('gem', %w(env))
@@ -64,7 +64,7 @@ when %w(after_script)
   end
 when %w(script)
   if TOOL.rubygems?
-    run('rake', %w(_10.5.0_ travis))
+    run('rake test_no_hoe')
   else
     run('rake', %w(spec:travis -t))
   end


### PR DESCRIPTION
# Description:
I recently closed [PR 2135](https://github.com/rubygems/rubygems/pull/2135) for test updates, since I knew I was missing something.

I was incorrectly assuming that default spec files were being loaded into `File.join(@gemhome, "specifications", "default")`, but they are loaded into another directory.  So, after realizing that, I proceeded with changes & testing.

I've tested it quite a few times, found one additional issue, along with the update to Minitest 5.11.

This PR does the following:

1. Seems to remove/fix all intermittent failures.  I assume most are due to test leaks, but I didn't set a goal of making sure I found the source of **all leaks**.    IOW, should test leaks be fixed in the source or the tests affected by them?  Some might say only the source, other more pragmatic types might say both.  Regardless, I believe I've run the tests often enough to know that a combination of cleaning leaking tests and cleaning affected tests has been done.

2. Removes hoe from Travis RG testing, matching Appveyor and ruby/ruby.

3. test_case.rb - Adds a method `util_clear_gemspecs`, which clears standard and default gemspec files.  Also, added clearing of default gemspec files to ``util_clear_gems`.

4. Cleans up some `$SAFE` issues, reset for now in `test_gem.rb`.

5. `@name` - Minitest v5.11 had a naming clash with `test_gem_source_git.rb`, so `@name` is renamed `@r_name`.

6. `Binding.source_location` warnings in head/trunk are fixed by [bundler PR #6237](https://github.com/bundler/bundler/pull/6237).  On my fork, I added a patch for this to my Appveyor testing, and all warnings disappeared.

7. For example results, see my fork's [Travis builds](https://travis-ci.org/MSP-Greg/rubygems/builds), note that I bypassed the bundler testing.

# Tasks:

- [X] Describe the problem / feature
- [ ] Write tests
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).