### PR TITLE
Backport ruby core changes for test fixes.

### DIFF
--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -7,7 +7,7 @@ require 'pathname'
 require 'tmpdir'
 
 # TODO: push this up to test_case.rb once battle tested
-$SAFE=1
+
 $LOAD_PATH.map! do |path|
   path.dup.untaint
 end

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -948,6 +948,9 @@ dependencies: []
     @a2.files.clear
 
     assert_equal @a2, spec
+
+  ensure
+    $SAFE = 0
   end
 
   def test_self_load_escape_curly

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -102,8 +102,8 @@ class TestGemRequire < Gem::TestCase
     assert t1.join, "thread 1 should exit"
     assert t2.join, "thread 2 should exit"
   ensure
-    Object.send :remove_const, :FILE_ENTERED_LATCH
-    Object.send :remove_const, :FILE_EXIT_LATCH
+    Object.send :remove_const, :FILE_ENTERED_LATCH if Object.const_defined? :FILE_ENTERED_LATCH
+    Object.send :remove_const, :FILE_EXIT_LATCH if Object.const_defined? :FILE_EXIT_LATCH
   end
 
   def test_require_is_not_lazy_with_exact_req

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -70,10 +70,12 @@ class TestGemRequire < Gem::TestCase
 
   def create_sync_thread
     Thread.new do
-      yield
-    ensure
-      FILE_ENTERED_LATCH.release
-      FILE_EXIT_LATCH.await
+      begin
+        yield
+      ensure
+        FILE_ENTERED_LATCH.release
+        FILE_EXIT_LATCH.await
+      end
     end
   end
 


### PR DESCRIPTION
Ruby 2.6 will change the behavior of `$SAFE` variable. 

It's part of test fixes by @MSP-Greg like https://github.com/rubygems/rubygems/pull/2139