### PR TITLE
Use `File.open` instead of `open`.

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -871,19 +871,19 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   # Safely read a file in binary mode on all platforms.
 
   def self.read_binary(path)
-    open path, 'rb+' do |f|
+    File.open path, 'rb+' do |f|
       f.flock(File::LOCK_EX)
       f.read
     end
   rescue *READ_BINARY_ERRORS
-    open path, 'rb' do |f|
+    File.open path, 'rb' do |f|
       f.read
     end
   rescue Errno::ENOLCK # NFS
     if Thread.main != Thread.current
       raise
     else
-      open path, 'rb' do |f|
+      File.open path, 'rb' do |f|
         f.read
       end
     end

--- a/lib/rubygems/commands/unpack_command.rb
+++ b/lib/rubygems/commands/unpack_command.rb
@@ -94,7 +94,7 @@ command help for an example.
 
         spec_file = File.basename spec.spec_file
 
-        open spec_file, 'w' do |io|
+        File.open spec_file, 'w' do |io|
           io.write metadata
         end
       else
@@ -176,7 +176,7 @@ command help for an example.
 
     metadata = nil
 
-    open path, Gem.binary_mode do |io|
+    File.open path, Gem.binary_mode do |io|
       tar = Gem::Package::TarReader.new io
       tar.each_entry do |entry|
         case entry.full_name

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -458,7 +458,7 @@ if you believe they were disclosed to a third party.
 
   # Writes out this config file, replacing its source.
   def write
-    open config_file_name, 'w' do |io|
+    File.open config_file_name, 'w' do |io|
       io.write to_yaml
     end
   end

--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -212,7 +212,7 @@ EOF
 
     FileUtils.mkdir_p @spec.extension_dir
 
-    open destination, 'wb' do |io| io.puts output end
+    File.open destination, 'wb' do |io| io.puts output end
 
     destination
   end

--- a/lib/rubygems/indexer.rb
+++ b/lib/rubygems/indexer.rb
@@ -123,7 +123,7 @@ class Gem::Indexer
         marshal_name = File.join @quick_marshal_dir, spec_file_name
 
         marshal_zipped = Gem.deflate Marshal.dump(spec)
-        open marshal_name, 'wb' do |io| io.write marshal_zipped end
+        File.open marshal_name, 'wb' do |io| io.write marshal_zipped end
 
         files << marshal_name
 
@@ -261,7 +261,7 @@ class Gem::Indexer
 
     zipped = Gem.deflate data
 
-    open "#{filename}.#{extension}", 'wb' do |io|
+    File.open "#{filename}.#{extension}", 'wb' do |io|
       io.write zipped
     end
   end
@@ -427,7 +427,7 @@ class Gem::Indexer
 
     specs_index = compact_specs specs_index.uniq.sort
 
-    open dest, 'wb' do |io|
+    File.open dest, 'wb' do |io|
       Marshal.dump specs_index, io
     end
   end

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -206,7 +206,7 @@ class Gem::Installer
     ruby_executable = false
     existing = nil
 
-    open generated_bin, 'rb' do |io|
+    File.open generated_bin, 'rb' do |io|
       next unless io.gets =~ /^#!/ # shebang
       io.gets # blankline
 
@@ -427,7 +427,7 @@ class Gem::Installer
   # specifications directory.
 
   def write_spec
-    open spec_file, 'w' do |file|
+    File.open spec_file, 'w' do |file|
       spec.installed_by_version = Gem.rubygems_version
 
       file.puts spec.to_ruby_for_cache
@@ -863,7 +863,7 @@ TEXT
 
     build_info_file = File.join build_info_dir, "#{spec.full_name}.info"
 
-    open build_info_file, 'w' do |io|
+    File.open build_info_file, 'w' do |io|
       @build_args.each do |arg|
         io.puts arg
       end

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -219,7 +219,7 @@ class Gem::Package
       next unless stat.file?
 
       tar.add_file_simple file, stat.mode, stat.size do |dst_io|
-        open file, 'rb' do |src_io|
+        File.open file, 'rb' do |src_io|
           dst_io.write src_io.read 16384 until src_io.eof?
         end
       end
@@ -380,7 +380,7 @@ EOM
 
         FileUtils.mkdir_p mkdir, mkdir_options
 
-        open destination, 'wb' do |out|
+        File.open destination, 'wb' do |out|
           out.write entry.read
           FileUtils.chmod entry.header.mode, destination
         end if entry.file?

--- a/lib/rubygems/package/file_source.rb
+++ b/lib/rubygems/package/file_source.rb
@@ -23,11 +23,11 @@ class Gem::Package::FileSource < Gem::Package::Source # :nodoc: all
   end
 
   def with_write_io &block
-    open path, 'wb', &block
+    File.open path, 'wb', &block
   end
 
   def with_read_io &block
-    open path, 'rb', &block
+    File.open path, 'rb', &block
   end
 
 end

--- a/lib/rubygems/package/old.rb
+++ b/lib/rubygems/package/old.rb
@@ -80,7 +80,7 @@ class Gem::Package::Old < Gem::Package
 
         FileUtils.mkdir_p File.dirname destination
 
-        open destination, 'wb', entry['mode'] do |out|
+        File.open destination, 'wb', entry['mode'] do |out|
           out.write file_data
         end
 

--- a/lib/rubygems/request_set/lockfile.rb
+++ b/lib/rubygems/request_set/lockfile.rb
@@ -223,7 +223,7 @@ class Gem::RequestSet::Lockfile
   def write
     content = to_s
 
-    open "#{@gem_deps_file}.lock", 'w' do |io|
+    File.open "#{@gem_deps_file}.lock", 'w' do |io|
       io.write content
     end
   end

--- a/lib/rubygems/security.rb
+++ b/lib/rubygems/security.rb
@@ -578,7 +578,7 @@ module Gem::Security
   def self.write pemmable, path, permissions = 0600, passphrase = nil, cipher = KEY_CIPHER
     path = File.expand_path path
 
-    open path, 'wb', permissions do |io|
+    File.open path, 'wb', permissions do |io|
       if passphrase and cipher
         io.write pemmable.to_pem cipher, passphrase
       else

--- a/lib/rubygems/security/trust_dir.rb
+++ b/lib/rubygems/security/trust_dir.rb
@@ -93,7 +93,7 @@ class Gem::Security::TrustDir
 
     destination = cert_path certificate
 
-    open destination, 'wb', @permissions[:trusted_cert] do |io|
+    File.open destination, 'wb', @permissions[:trusted_cert] do |io|
       io.write certificate.to_pem
     end
   end

--- a/lib/rubygems/source.rb
+++ b/lib/rubygems/source.rb
@@ -160,7 +160,7 @@ class Gem::Source
     if update_cache? then
       FileUtils.mkdir_p cache_dir
 
-      open local_spec, 'wb' do |io|
+      File.open local_spec, 'wb' do |io|
         io.write spec
       end
     end

--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -113,7 +113,9 @@ class Gem::StubSpecification < Gem::BasicSpecification
     unless @data
       begin
         saved_lineno = $.
-        File.open loaded_from, OPEN_MODE do |file|
+
+        # TODO It should be use `File.open`, but bundler-1.16.1 example expects Kernel#open.
+        open loaded_from, OPEN_MODE do |file|
           begin
             file.readline # discard encoding line
             stubline = file.readline.chomp

--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -113,7 +113,7 @@ class Gem::StubSpecification < Gem::BasicSpecification
     unless @data
       begin
         saved_lineno = $.
-        open loaded_from, OPEN_MODE do |file|
+        File.open loaded_from, OPEN_MODE do |file|
           begin
             file.readline # discard encoding line
             stubline = file.readline.chomp

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -488,7 +488,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
 
     gemspec = "#{name}.gemspec"
 
-    open File.join(directory, gemspec), 'w' do |io|
+    File.open File.join(directory, gemspec), 'w' do |io|
       io.write git_spec.to_ruby
     end
 
@@ -592,7 +592,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
   # Reads a Marshal file at +path+
 
   def read_cache(path)
-    open path.dup.untaint, 'rb' do |io|
+    File.open path.dup.untaint, 'rb' do |io|
       Marshal.load io.read
     end
   end
@@ -612,7 +612,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
     dir = File.dirname path
     FileUtils.mkdir_p dir unless File.directory? dir
 
-    open path, 'wb' do |io|
+    File.open path, 'wb' do |io|
       yield io if block_given?
     end
 
@@ -727,7 +727,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
     install_default_specs(*specs)
 
     specs.each do |spec|
-      open spec.loaded_from, 'w' do |io|
+      File.open spec.loaded_from, 'w' do |io|
         io.write spec.to_ruby_for_cache
       end
     end
@@ -1363,7 +1363,7 @@ Also, a list:
       yield specification if block_given?
     end
 
-    open File.join(directory, "#{name}.gemspec"), 'w' do |io|
+    File.open File.join(directory, "#{name}.gemspec"), 'w' do |io|
       io.write vendor_spec.to_ruby
     end
 

--- a/lib/rubygems/test_utilities.rb
+++ b/lib/rubygems/test_utilities.rb
@@ -346,7 +346,7 @@ class Gem::TestCase::SpecFetcherSetup
   end
 
   def write_spec spec # :nodoc:
-    open spec.spec_file, 'w' do |io|
+    File.open spec.spec_file, 'w' do |io|
       io.write spec.to_ruby_for_cache
     end
   end

--- a/lib/rubygems/validator.rb
+++ b/lib/rubygems/validator.rb
@@ -34,7 +34,7 @@ class Gem::Validator
   # gem_path:: [String] Path to gem file
 
   def verify_gem_file(gem_path)
-    open gem_path, Gem.binary_mode do |file|
+    File.open gem_path, Gem.binary_mode do |file|
       gem_data = file.read
       verify_gem gem_data
     end
@@ -109,7 +109,7 @@ class Gem::Validator
 
         good, gone, unreadable = nil, nil, nil, nil
 
-        open gem_path, Gem.binary_mode do |file|
+        File.open gem_path, Gem.binary_mode do |file|
           package = Gem::Package.new gem_path
 
           good, gone = package.contents.partition { |file_name|
@@ -134,7 +134,7 @@ class Gem::Validator
 
               source = File.join gem_directory, entry['path']
 
-              open source, Gem.binary_mode do |f|
+              File.open source, Gem.binary_mode do |f|
                 unless f.read == data then
                   errors[gem_name][entry['path']] = "Modified from original"
                 end

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -775,7 +775,7 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_read_binary
-    open 'test', 'w' do |io|
+    File.open 'test', 'w' do |io|
       io.write "\xCF\x80"
     end
 
@@ -1642,7 +1642,7 @@ class TestGem < Gem::TestCase
     spec = Gem::Specification.find { |s| s == spec }
     refute spec.activated?
 
-    open gem_deps_file, 'w' do |io|
+    File.open gem_deps_file, 'w' do |io|
       io.write 'gem "a"'
     end
 
@@ -1661,7 +1661,7 @@ class TestGem < Gem::TestCase
 
     refute spec.activated?
 
-    open 'gem.deps.rb', 'w' do |io|
+    File.open 'gem.deps.rb', 'w' do |io|
       io.write 'gem "a"'
     end
 
@@ -1705,7 +1705,7 @@ class TestGem < Gem::TestCase
 
     refute spec.activated?
 
-    open 'Gemfile', 'w' do |io|
+    File.open 'Gemfile', 'w' do |io|
       io.write 'gem "a"'
     end
 
@@ -1734,7 +1734,7 @@ class TestGem < Gem::TestCase
 
     refute spec.activated?
 
-    open 'gem.deps.rb', 'w' do |io|
+    File.open 'gem.deps.rb', 'w' do |io|
       io.write 'gem "a"'
     end
 
@@ -1749,7 +1749,7 @@ class TestGem < Gem::TestCase
     skip 'Insecure operation - read' if RUBY_VERSION <= "1.8.7"
     rubygems_gemdeps, ENV['RUBYGEMS_GEMDEPS'] = ENV['RUBYGEMS_GEMDEPS'], 'x'
 
-    open 'x', 'w' do |io|
+    File.open 'x', 'w' do |io|
       io.write 'gem "a"'
     end
 
@@ -1790,7 +1790,7 @@ You may need to `gem install -g` to install missing gems
     spec = Gem::Specification.find { |s| s == spec }
     refute spec.activated?
 
-    open 'x', 'w' do |io|
+    File.open 'x', 'w' do |io|
       io.write 'gem "a"'
     end
 

--- a/test/rubygems/test_gem_commands_push_command.rb
+++ b/test/rubygems/test_gem_commands_push_command.rb
@@ -132,7 +132,7 @@ class TestGemCommandsPushCommand < Gem::TestCase
     }
 
     FileUtils.mkdir_p File.dirname Gem.configuration.credentials_path
-    open Gem.configuration.credentials_path, 'w' do |f|
+    File.open Gem.configuration.credentials_path, 'w' do |f|
       f.write keys.to_yaml
     end
     Gem.configuration.load_api_keys
@@ -166,7 +166,7 @@ class TestGemCommandsPushCommand < Gem::TestCase
     }
 
     FileUtils.mkdir_p File.dirname Gem.configuration.credentials_path
-    open Gem.configuration.credentials_path, 'w' do |f|
+    File.open Gem.configuration.credentials_path, 'w' do |f|
       f.write keys.to_yaml
     end
     Gem.configuration.load_api_keys
@@ -193,7 +193,7 @@ class TestGemCommandsPushCommand < Gem::TestCase
     }
 
     FileUtils.mkdir_p File.dirname Gem.configuration.credentials_path
-    open Gem.configuration.credentials_path, 'w' do |f|
+    File.open Gem.configuration.credentials_path, 'w' do |f|
       f.write keys.to_yaml
     end
     Gem.configuration.load_api_keys
@@ -235,7 +235,7 @@ class TestGemCommandsPushCommand < Gem::TestCase
     }
 
     FileUtils.mkdir_p File.dirname Gem.configuration.credentials_path
-    open Gem.configuration.credentials_path, 'w' do |f|
+    File.open Gem.configuration.credentials_path, 'w' do |f|
       f.write keys.to_yaml
     end
     Gem.configuration.load_api_keys
@@ -266,7 +266,7 @@ class TestGemCommandsPushCommand < Gem::TestCase
     }
 
     FileUtils.mkdir_p File.dirname Gem.configuration.credentials_path
-    open Gem.configuration.credentials_path, 'w' do |f|
+    File.open Gem.configuration.credentials_path, 'w' do |f|
       f.write keys.to_yaml
     end
     Gem.configuration.load_api_keys

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -18,17 +18,17 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     FileUtils.mkdir_p 'bin'
     FileUtils.mkdir_p 'lib/rubygems/ssl_certs/rubygems.org'
 
-    open 'bin/gem',                   'w' do |io| io.puts '# gem'          end
-    open 'lib/rubygems.rb',           'w' do |io| io.puts '# rubygems.rb'  end
-    open 'lib/rubygems/test_case.rb', 'w' do |io| io.puts '# test_case.rb' end
-    open 'lib/rubygems/ssl_certs/rubygems.org/foo.pem', 'w' do |io| io.puts 'PEM'       end
+    File.open 'bin/gem',                   'w' do |io| io.puts '# gem'          end
+    File.open 'lib/rubygems.rb',           'w' do |io| io.puts '# rubygems.rb'  end
+    File.open 'lib/rubygems/test_case.rb', 'w' do |io| io.puts '# test_case.rb' end
+    File.open 'lib/rubygems/ssl_certs/rubygems.org/foo.pem', 'w' do |io| io.puts 'PEM'       end
 
     FileUtils.mkdir_p 'bundler/exe'
     FileUtils.mkdir_p 'bundler/lib/bundler'
 
-    open 'bundler/exe/bundle',        'w' do |io| io.puts '# bundle'       end
-    open 'bundler/lib/bundler.rb',    'w' do |io| io.puts '# bundler.rb'   end
-    open 'bundler/lib/bundler/b.rb',  'w' do |io| io.puts '# b.rb'         end
+    File.open 'bundler/exe/bundle',        'w' do |io| io.puts '# bundle'       end
+    File.open 'bundler/lib/bundler.rb',    'w' do |io| io.puts '# bundler.rb'   end
+    File.open 'bundler/lib/bundler/b.rb',  'w' do |io| io.puts '# b.rb'         end
 
     FileUtils.mkdir_p 'default/gems'
 
@@ -38,7 +38,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     gemspec.bindir = "exe"
     gemspec.executables = ["bundle"]
 
-    open 'bundler/bundler.gemspec',   'w' do |io|
+    File.open 'bundler/bundler.gemspec',   'w' do |io|
       io.puts gemspec.to_ruby
     end
 
@@ -181,14 +181,14 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     FileUtils.mkdir_p lib_rubygems_defaults
     FileUtils.mkdir_p lib_bundler
 
-    open securerandom_rb,    'w' do |io| io.puts '# securerandom.rb'     end
+    File.open securerandom_rb,    'w' do |io| io.puts '# securerandom.rb'     end
 
-    open old_builder_rb,     'w' do |io| io.puts '# builder.rb'          end
-    open old_format_rb,      'w' do |io| io.puts '# format.rb'           end
-    open old_bundler_c_rb,   'w' do |io| io.puts '# c.rb'                end
+    File.open old_builder_rb,     'w' do |io| io.puts '# builder.rb'          end
+    File.open old_format_rb,      'w' do |io| io.puts '# format.rb'           end
+    File.open old_bundler_c_rb,   'w' do |io| io.puts '# c.rb'                end
 
-    open engine_defaults_rb, 'w' do |io| io.puts '# jruby.rb'            end
-    open os_defaults_rb,     'w' do |io| io.puts '# operating_system.rb' end
+    File.open engine_defaults_rb, 'w' do |io| io.puts '# jruby.rb'            end
+    File.open os_defaults_rb,     'w' do |io| io.puts '# operating_system.rb' end
 
     @cmd.remove_old_lib_files lib
 
@@ -210,7 +210,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
 
     @cmd.options[:previous_version] = Gem::Version.new '2.0.2'
 
-    open 'History.txt', 'w' do |io|
+    File.open 'History.txt', 'w' do |io|
       io.puts <<-History_txt
 # coding: UTF-8
 

--- a/test/rubygems/test_gem_commands_uninstall_command.rb
+++ b/test/rubygems/test_gem_commands_uninstall_command.rb
@@ -92,7 +92,7 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
     # Evil hack to prevent false removal success
     FileUtils.rm_f @executable
 
-    open @executable, "wb+" do |f| f.puts "binary" end
+    File.open @executable, "wb+" do |f| f.puts "binary" end
 
     @cmd.options[:executables] = true
     @cmd.options[:args] = [@spec.name]

--- a/test/rubygems/test_gem_dependency_installer.rb
+++ b/test/rubygems/test_gem_dependency_installer.rb
@@ -424,7 +424,7 @@ class TestGemDependencyInstaller < Gem::TestCase
     extconf_rb = File.join @gemhome, 'gems', 'e-1', 'extconf.rb'
     FileUtils.mkdir_p File.dirname extconf_rb
 
-    open extconf_rb, 'w' do |io|
+    File.open extconf_rb, 'w' do |io|
       io.write <<-EXTCONF_RB
         require 'mkmf'
         create_makefile 'e'

--- a/test/rubygems/test_gem_doctor.rb
+++ b/test/rubygems/test_gem_doctor.rb
@@ -24,7 +24,7 @@ class TestGemDoctor < Gem::TestCase
 
     FileUtils.rm b.spec_file
 
-    open c.spec_file, 'w' do |io|
+    File.open c.spec_file, 'w' do |io|
       io.write 'this will raise an exception when evaluated.'
     end
 
@@ -77,7 +77,7 @@ Removed directory gems/c-2
 
     FileUtils.rm b.spec_file
 
-    open c.spec_file, 'w' do |io|
+    File.open c.spec_file, 'w' do |io|
       io.write 'this will raise an exception when evaluated.'
     end
 

--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -32,7 +32,7 @@ class TestGemExtBuilder < Gem::TestCase
     results = []
 
     Dir.chdir @ext do
-      open 'Makefile', 'w' do |io|
+      File.open 'Makefile', 'w' do |io|
         io.puts <<-MAKEFILE
 all:
 \t@#{Gem.ruby} -e "puts %Q{all: \#{ENV['DESTDIR']}}"
@@ -72,7 +72,7 @@ install:
     results = []
 
     Dir.chdir @ext do
-      open 'Makefile', 'w' do |io|
+      File.open 'Makefile', 'w' do |io|
         io.puts <<-MAKEFILE
 all:
 \t@#{Gem.ruby} -e "puts %Q{all: \#{ENV['DESTDIR']}}"
@@ -107,7 +107,7 @@ install:
 
     extconf_rb = File.join ext_dir, 'extconf.rb'
 
-    open extconf_rb, 'w' do |f|
+    File.open extconf_rb, 'w' do |f|
       f.write <<-'RUBY'
         require 'mkmf'
 
@@ -168,7 +168,7 @@ install:
 
     extconf_rb = File.join ext_dir, 'extconf.rb'
 
-    open extconf_rb, 'w' do |f|
+    File.open extconf_rb, 'w' do |f|
       f.write <<-'RUBY'
         require 'mkmf'
 
@@ -290,7 +290,7 @@ install:
 
     FileUtils.mkdir_p @spec.gem_dir
 
-    open File.join(@spec.gem_dir, "extconf.rb"), "w" do |f|
+    File.open File.join(@spec.gem_dir, "extconf.rb"), "w" do |f|
       f.write <<-'RUBY'
         puts "IN EXTCONF"
         extconf_args = File.join File.dirname(__FILE__), 'extconf_args'
@@ -323,7 +323,7 @@ install:
 
     build_info_file = File.join build_info_dir, "#{@spec.full_name}.info"
 
-    open build_info_file, 'w' do |io|
+    File.open build_info_file, 'w' do |io|
       io.puts '--with-foo-dir=/nonexistent'
     end
 

--- a/test/rubygems/test_gem_gemcutter_utilities.rb
+++ b/test/rubygems/test_gem_gemcutter_utilities.rb
@@ -33,7 +33,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
 
     FileUtils.mkdir_p File.dirname Gem.configuration.credentials_path
 
-    open Gem.configuration.credentials_path, 'w' do |f|
+    File.open Gem.configuration.credentials_path, 'w' do |f|
       f.write keys.to_yaml
     end
 
@@ -48,7 +48,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
     keys = { :rubygems_api_key => 'KEY' }
     FileUtils.mkdir_p File.dirname Gem.configuration.credentials_path
 
-    open Gem.configuration.credentials_path, 'w' do |f|
+    File.open Gem.configuration.credentials_path, 'w' do |f|
       f.write keys.to_yaml
     end
 
@@ -61,7 +61,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
     keys = { :rubygems_api_key => 'KEY', :other => 'OTHER' }
     FileUtils.mkdir_p File.dirname Gem.configuration.credentials_path
 
-    open Gem.configuration.credentials_path, 'w' do |f|
+    File.open Gem.configuration.credentials_path, 'w' do |f|
       f.write keys.to_yaml
     end
 
@@ -165,7 +165,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
     other_api_key = 'f46dbb18bb6a9c97cdc61b5b85c186a17403cdcbf'
 
     FileUtils.mkdir_p File.dirname(Gem.configuration.credentials_path)
-    open Gem.configuration.credentials_path, 'w' do |f|
+    File.open Gem.configuration.credentials_path, 'w' do |f|
       f.write Hash[:other_api_key, other_api_key].to_yaml
     end
     util_sign_in [api_key, 200, 'OK']

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -140,7 +140,7 @@ end
       s.require_path = 'lib'
     end
 
-    open File.join(util_inst_bindir, 'executable'), 'w' do |io|
+    File.open File.join(util_inst_bindir, 'executable'), 'w' do |io|
      io.write <<-EXEC
 #!/usr/local/bin/ruby
 #

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -24,7 +24,7 @@ class TestGemPackage < Gem::Package::TarTestCase
   end
 
   def test_class_new_old_format
-    open 'old_format.gem', 'wb' do |io|
+    File.open 'old_format.gem', 'wb' do |io|
       io.write SIMPLE_GEM
     end
 
@@ -45,7 +45,7 @@ class TestGemPackage < Gem::Package::TarTestCase
 
     FileUtils.mkdir 'lib'
 
-    open 'lib/code.rb', 'w' do |io|
+    File.open 'lib/code.rb', 'w' do |io|
       io.write '# lib/code.rb'
     end
 
@@ -110,8 +110,8 @@ class TestGemPackage < Gem::Package::TarTestCase
 
     FileUtils.mkdir_p 'lib/empty'
 
-    open 'lib/code.rb',  'w' do |io| io.write '# lib/code.rb'  end
-    open 'lib/extra.rb', 'w' do |io| io.write '# lib/extra.rb' end
+    File.open 'lib/code.rb',  'w' do |io| io.write '# lib/code.rb'  end
+    File.open 'lib/extra.rb', 'w' do |io| io.write '# lib/extra.rb' end
 
     package = Gem::Package.new 'bogus.gem'
     package.spec = spec
@@ -140,7 +140,7 @@ class TestGemPackage < Gem::Package::TarTestCase
     spec.files = %w[lib/code.rb lib/code_sym.rb]
 
     FileUtils.mkdir_p 'lib'
-    open 'lib/code.rb',  'w' do |io| io.write '# lib/code.rb'  end
+    File.open 'lib/code.rb',  'w' do |io| io.write '# lib/code.rb'  end
 
     # NOTE: 'code.rb' is correct, because it's relative to lib/code_sym.rb
     File.symlink('code.rb', 'lib/code_sym.rb')
@@ -179,7 +179,7 @@ class TestGemPackage < Gem::Package::TarTestCase
 
     FileUtils.mkdir 'lib'
 
-    open 'lib/code.rb', 'w' do |io|
+    File.open 'lib/code.rb', 'w' do |io|
       io.write '# lib/code.rb'
     end
 
@@ -218,7 +218,7 @@ class TestGemPackage < Gem::Package::TarTestCase
 
     FileUtils.mkdir 'lib'
 
-    open 'lib/code.rb', 'w' do |io|
+    File.open 'lib/code.rb', 'w' do |io|
       io.write '# lib/code.rb'
     end
 
@@ -261,7 +261,7 @@ class TestGemPackage < Gem::Package::TarTestCase
 
     FileUtils.mkdir 'lib'
 
-    open 'lib/code.rb', 'w' do |io|
+    File.open 'lib/code.rb', 'w' do |io|
       io.write '# lib/code.rb'
     end
 
@@ -311,7 +311,7 @@ class TestGemPackage < Gem::Package::TarTestCase
 
     FileUtils.mkdir 'lib'
 
-    open 'lib/code.rb', 'w' do |io|
+    File.open 'lib/code.rb', 'w' do |io|
       io.write '# lib/code.rb'
     end
 
@@ -348,7 +348,7 @@ class TestGemPackage < Gem::Package::TarTestCase
 
     FileUtils.mkdir 'lib'
 
-    open 'lib/code.rb', 'w' do |io|
+    File.open 'lib/code.rb', 'w' do |io|
       io.write '# lib/code.rb'
     end
 
@@ -408,7 +408,7 @@ class TestGemPackage < Gem::Package::TarTestCase
       end
     end
 
-    open 'empty.gem', 'wb' do |io|
+    File.open 'empty.gem', 'wb' do |io|
       io.write gem.string
     end
 
@@ -620,7 +620,7 @@ class TestGemPackage < Gem::Package::TarTestCase
       end
     end
 
-    open 'mismatch.gem', 'wb' do |io|
+    File.open 'mismatch.gem', 'wb' do |io|
       io.write gem.string
     end
 
@@ -670,7 +670,7 @@ class TestGemPackage < Gem::Package::TarTestCase
       end
     end
 
-    open 'data_checksum_missing.gem', 'wb' do |io|
+    File.open 'data_checksum_missing.gem', 'wb' do |io|
       io.write gem.string
     end
 
@@ -773,7 +773,7 @@ class TestGemPackage < Gem::Package::TarTestCase
     FileUtils.mkdir 'lib'
     FileUtils.touch 'lib/code.rb'
 
-    open @gem, 'wb' do |gem_io|
+    File.open @gem, 'wb' do |gem_io|
       Gem::Package::TarWriter.new gem_io do |gem|
         build.add_metadata gem
         build.add_contents gem
@@ -804,7 +804,7 @@ class TestGemPackage < Gem::Package::TarTestCase
   end
 
   def test_verify_truncate
-    open 'bad.gem', 'wb' do |io|
+    File.open 'bad.gem', 'wb' do |io|
       io.write File.read(@gem, 1024) # don't care about newlines
     end
 

--- a/test/rubygems/test_gem_package_old.rb
+++ b/test/rubygems/test_gem_package_old.rb
@@ -7,7 +7,7 @@ class TestGemPackageOld < Gem::TestCase
   def setup
     super
 
-    open 'old_format.gem', 'wb' do |io|
+    File.open 'old_format.gem', 'wb' do |io|
       io.write SIMPLE_GEM
     end
 

--- a/test/rubygems/test_gem_request_set.rb
+++ b/test/rubygems/test_gem_request_set.rb
@@ -52,7 +52,7 @@ class TestGemRequestSet < Gem::TestCase
     rs = Gem::RequestSet.new
     installed = []
 
-    open 'gem.deps.rb', 'w' do |io|
+    File.open 'gem.deps.rb', 'w' do |io|
       io.puts 'gem "a"'
       io.flush
 
@@ -78,7 +78,7 @@ class TestGemRequestSet < Gem::TestCase
 
     rs = Gem::RequestSet.new
 
-    open 'gem.deps.rb', 'w' do |io|
+    File.open 'gem.deps.rb', 'w' do |io|
       io.puts 'gem "a"'
       io.flush
 
@@ -104,7 +104,7 @@ Gems to install:
     rs = Gem::RequestSet.new
     installed = []
 
-    open 'gem.deps.rb', 'w' do |io|
+    File.open 'gem.deps.rb', 'w' do |io|
       io.puts 'gem "a"'
     end
 
@@ -128,7 +128,7 @@ Gems to install:
 
     rs = Gem::RequestSet.new
 
-    open 'gem.deps.rb', 'w' do |io|
+    File.open 'gem.deps.rb', 'w' do |io|
       io.puts 'gem "a"'
       io.flush
 
@@ -150,7 +150,7 @@ Gems to install:
     rs = Gem::RequestSet.new
     installed = []
 
-    open 'gem.deps.rb.lock', 'w' do |io|
+    File.open 'gem.deps.rb.lock', 'w' do |io|
       io.puts <<-LOCKFILE
 GEM
   remote: #{@gem_repo}
@@ -167,7 +167,7 @@ DEPENDENCIES
       LOCKFILE
     end
 
-    open 'gem.deps.rb', 'w' do |io|
+    File.open 'gem.deps.rb', 'w' do |io|
       io.puts 'gem "b"'
     end
 
@@ -190,7 +190,7 @@ DEPENDENCIES
     rs = Gem::RequestSet.new
     installed = []
 
-    open 'gem.deps.rb', 'w' do |io|
+    File.open 'gem.deps.rb', 'w' do |io|
       io.puts <<-GEM_DEPS
 gem "a"
 ruby "0"

--- a/test/rubygems/test_gem_request_set_lockfile.rb
+++ b/test/rubygems/test_gem_request_set_lockfile.rb
@@ -31,7 +31,7 @@ class TestGemRequestSetLockfile < Gem::TestCase
   def write_lockfile lockfile
     @lock_file = File.expand_path "#{@gem_deps_file}.lock"
 
-    open @lock_file, 'w' do |io|
+    File.open @lock_file, 'w' do |io|
       io.write lockfile
     end
   end
@@ -387,7 +387,7 @@ DEPENDENCIES
           s.add_dependency 'c', '~> 1.0'
         end
 
-        open 'b.gemspec', 'w' do |io|
+        File.open 'b.gemspec', 'w' do |io|
           io.write b.to_ruby
         end
 
@@ -400,7 +400,7 @@ DEPENDENCIES
       Dir.chdir 'c' do
         c = Gem::Specification.new 'c', 1
 
-        open 'c.gemspec', 'w' do |io|
+        File.open 'c.gemspec', 'w' do |io|
           io.write c.to_ruby
         end
 
@@ -455,7 +455,7 @@ DEPENDENCIES
 
     gem_deps_lock_file = "#{@gem_deps_file}.lock"
 
-    open gem_deps_lock_file, 'w' do |io|
+    File.open gem_deps_lock_file, 'w' do |io|
       io.write 'hello'
     end
 

--- a/test/rubygems/test_gem_request_set_lockfile_parser.rb
+++ b/test/rubygems/test_gem_request_set_lockfile_parser.rb
@@ -536,7 +536,7 @@ DEPENDENCIES
   end
 
   def write_lockfile lockfile
-    open @lock_file, 'w' do |io|
+    File.open @lock_file, 'w' do |io|
       io.write lockfile
     end
   end

--- a/test/rubygems/test_gem_request_set_lockfile_tokenizer.rb
+++ b/test/rubygems/test_gem_request_set_lockfile_tokenizer.rb
@@ -295,7 +295,7 @@ GEM
   end
 
   def write_lockfile lockfile
-    open @lock_file, 'w' do |io|
+    File.open @lock_file, 'w' do |io|
       io.write lockfile
     end
   end

--- a/test/rubygems/test_gem_resolver_git_specification.rb
+++ b/test/rubygems/test_gem_resolver_git_specification.rb
@@ -70,7 +70,7 @@ class TestGemResolverGitSpecification < Gem::TestCase
     Dir.chdir 'git/a' do
       FileUtils.mkdir_p 'ext/lib'
 
-      open 'ext/extconf.rb', 'w' do |io|
+      File.open 'ext/extconf.rb', 'w' do |io|
         io.puts 'require "mkmf"'
         io.puts 'create_makefile "a"'
       end

--- a/test/rubygems/test_gem_server.rb
+++ b/test/rubygems/test_gem_server.rb
@@ -100,7 +100,7 @@ class TestGemServer < Gem::TestCase
     specs_dir = File.join dir, 'specifications'
     FileUtils.mkdir_p specs_dir
 
-    open File.join(specs_dir, spec.spec_name), 'w' do |io|
+    File.open File.join(specs_dir, spec.spec_name), 'w' do |io|
       io.write spec.to_ruby
     end
 
@@ -198,7 +198,7 @@ class TestGemServer < Gem::TestCase
 
     FileUtils.mkdir_p specs_dir
 
-    open File.join(specs_dir, spec.spec_name), 'w' do |io|
+    File.open File.join(specs_dir, spec.spec_name), 'w' do |io|
       io.write spec.to_ruby
     end
 
@@ -339,7 +339,7 @@ class TestGemServer < Gem::TestCase
     specs_dir = File.join dir, 'specifications'
     FileUtils.mkdir_p specs_dir
 
-    open File.join(specs_dir, spec.spec_name), 'w' do |io|
+    File.open File.join(specs_dir, spec.spec_name), 'w' do |io|
       io.write spec.to_ruby
     end
 
@@ -378,7 +378,7 @@ class TestGemServer < Gem::TestCase
     specs_dir = File.join dir, 'specifications'
     FileUtils.mkdir_p specs_dir
 
-    open File.join(specs_dir, spec.spec_name), 'w' do |io|
+    File.open File.join(specs_dir, spec.spec_name), 'w' do |io|
       io.write spec.to_ruby
     end
 

--- a/test/rubygems/test_gem_source.rb
+++ b/test/rubygems/test_gem_source.rb
@@ -110,7 +110,7 @@ class TestGemSource < Gem::TestCase
 
     cache_file = File.join cache_dir, a1.spec_name
 
-    open cache_file, 'wb' do |io|
+    File.open cache_file, 'wb' do |io|
       Marshal.dump a1, io
     end
 
@@ -163,7 +163,7 @@ class TestGemSource < Gem::TestCase
 
     cache_file = File.join cache_dir, "latest_specs.#{Gem.marshal_version}"
 
-    open cache_file, 'wb' do |io|
+    File.open cache_file, 'wb' do |io|
       Marshal.dump latest_specs, io
     end
 
@@ -187,7 +187,7 @@ class TestGemSource < Gem::TestCase
 
     cache_file = File.join cache_dir, "latest_specs.#{Gem.marshal_version}"
 
-    open cache_file, 'wb' do |io|
+    File.open cache_file, 'wb' do |io|
       # Setup invalid data in the cache:
       io.write Marshal.dump(latest_specs)[0, 10]
     end

--- a/test/rubygems/test_gem_source_git.rb
+++ b/test/rubygems/test_gem_source_git.rb
@@ -229,7 +229,7 @@ class TestGemSourceGit < Gem::TestCase
       Dir.chdir 'b' do
         b = Gem::Specification.new 'b', 1
 
-        open 'b.gemspec', 'w' do |io|
+        File.open 'b.gemspec', 'w' do |io|
           io.write b.to_ruby
         end
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -922,7 +922,7 @@ dependencies: []
   end
 
   def test_self_load_relative
-    open 'a-2.gemspec', 'w' do |io|
+    File.open 'a-2.gemspec', 'w' do |io|
       io.write @a2.to_ruby_for_cache
     end
 
@@ -1111,7 +1111,7 @@ dependencies: []
   end
 
   def test_self_remove_spec_removed
-    open @a1.spec_file, 'w' do |io|
+    File.open @a1.spec_file, 'w' do |io|
       io.write @a1.to_ruby
     end
 
@@ -1363,13 +1363,13 @@ dependencies: []
 
     assert_empty @ext.build_args
 
-    open @ext.build_info_file, 'w' do |io|
+    File.open @ext.build_info_file, 'w' do |io|
       io.puts
     end
 
     assert_empty @ext.build_args
 
-    open @ext.build_info_file, 'w' do |io|
+    File.open @ext.build_info_file, 'w' do |io|
       io.puts '--with-foo-dir=wherever'
     end
 
@@ -1385,9 +1385,9 @@ dependencies: []
     extconf_rb = File.join @ext.gem_dir, @ext.extensions.first
     FileUtils.mkdir_p File.dirname extconf_rb
 
-    open extconf_rb, 'w' do |f|
+    File.open extconf_rb, 'w' do |f|
       f.write <<-'RUBY'
-        open 'Makefile', 'w' do |f|
+        File.open 'Makefile', 'w' do |f|
           f.puts "clean:\n\techo clean"
           f.puts "default:\n\techo built"
           f.puts "install:\n\techo installed"
@@ -1435,9 +1435,9 @@ dependencies: []
     extconf_rb = File.join spec.gem_dir, spec.extensions.first
     FileUtils.mkdir_p File.dirname extconf_rb
 
-    open extconf_rb, 'w' do |f|
+    File.open extconf_rb, 'w' do |f|
       f.write <<-'RUBY'
-        open 'Makefile', 'w' do |f|
+        File.open 'Makefile', 'w' do |f|
           f.puts "default:\n\techo built"
           f.puts "install:\n\techo installed"
         end
@@ -1469,9 +1469,9 @@ dependencies: []
     extconf_rb = File.join @ext.gem_dir, @ext.extensions.first
     FileUtils.mkdir_p File.dirname extconf_rb
 
-    open extconf_rb, 'w' do |f|
+    File.open extconf_rb, 'w' do |f|
       f.write <<-'RUBY'
-        open 'Makefile', 'w' do |f|
+        File.open 'Makefile', 'w' do |f|
           f.puts "clean:\n\techo clean"
           f.puts "default:\n\techo built"
           f.puts "install:\n\techo installed"
@@ -1502,9 +1502,9 @@ dependencies: []
     extconf_rb = File.join @ext.gem_dir, @ext.extensions.first
     FileUtils.mkdir_p File.dirname extconf_rb
 
-    open extconf_rb, 'w' do |f|
+    File.open extconf_rb, 'w' do |f|
       f.write <<-'RUBY'
-        open 'Makefile', 'w' do |f|
+        File.open 'Makefile', 'w' do |f|
           f.puts "clean:\n\techo clean"
           f.puts "default:\n\techo built"
           f.puts "install:\n\techo installed"
@@ -1551,9 +1551,9 @@ dependencies: []
     extconf_rb = File.join @ext.gem_dir, @ext.extensions.first
     FileUtils.mkdir_p File.dirname extconf_rb
 
-    open extconf_rb, 'w' do |f|
+    File.open extconf_rb, 'w' do |f|
       f.write <<-'RUBY'
-        open 'Makefile', 'w' do |f|
+        File.open 'Makefile', 'w' do |f|
           f.puts "clean:\n\techo clean"
           f.puts "default:\n\techo built"
           f.puts "install:\n\techo installed"
@@ -3418,9 +3418,9 @@ end
     extconf_rb = File.join @ext.gem_dir, @ext.extensions.first
     FileUtils.mkdir_p File.dirname extconf_rb
 
-    open extconf_rb, 'w' do |f|
+    File.open extconf_rb, 'w' do |f|
       f.write <<-'RUBY'
-        open 'Makefile', 'w' do |f|
+        File.open 'Makefile', 'w' do |f|
           f.puts "clean:\n\techo clean"
           f.puts "default:\n\techo built"
           f.puts "install:\n\techo installed"

--- a/test/rubygems/test_gem_stub_specification.rb
+++ b/test/rubygems/test_gem_stub_specification.rb
@@ -127,9 +127,9 @@ class TestStubSpecification < Gem::TestCase
       extconf_rb = File.join s.gem_dir, s.extensions.first
       FileUtils.mkdir_p File.dirname extconf_rb
 
-      open extconf_rb, 'w' do |f|
+      File.open extconf_rb, 'w' do |f|
         f.write <<-'RUBY'
-        open 'Makefile', 'w' do |f|
+        File.open 'Makefile', 'w' do |f|
           f.puts "clean:\n\techo clean"
           f.puts "default:\n\techo built"
           f.puts "install:\n\techo installed"
@@ -149,7 +149,7 @@ class TestStubSpecification < Gem::TestCase
     spec = new_default_spec 'default', 1
     spec.extensions << 'extconf.rb'
 
-    open spec.loaded_from, 'w' do |io|
+    File.open spec.loaded_from, 'w' do |io|
       io.write spec.to_ruby_for_cache
     end
 
@@ -198,7 +198,7 @@ class TestStubSpecification < Gem::TestCase
 
   def stub_with_version
     spec = File.join @gemhome, 'specifications', 'stub_e-2.gemspec'
-    open spec, 'w' do |io|
+    File.open spec, 'w' do |io|
       io.write <<-STUB
 # -*- encoding: utf-8 -*-
 # stub: stub_v 2 ruby lib
@@ -221,7 +221,7 @@ end
 
   def stub_without_version
     spec = File.join @gemhome, 'specifications', 'stub-2.gemspec'
-    open spec, 'w' do |io|
+    File.open spec, 'w' do |io|
       io.write <<-STUB
 # -*- encoding: utf-8 -*-
 # stub: stub_v ruby lib
@@ -245,7 +245,7 @@ end
 
   def stub_with_extension
     spec = File.join @gemhome, 'specifications', 'stub_e-2.gemspec'
-    open spec, 'w' do |io|
+    File.open spec, 'w' do |io|
       io.write <<-STUB
 # -*- encoding: utf-8 -*-
 # stub: stub_e 2 ruby lib
@@ -271,7 +271,7 @@ end
 
   def stub_without_extension
     spec = File.join @gemhome, 'specifications', 'stub-2.gemspec'
-    open spec, 'w' do |io|
+    File.open spec, 'w' do |io|
       io.write <<-STUB
 # -*- encoding: utf-8 -*-
 # stub: stub 2 ruby lib


### PR DESCRIPTION
This change is not vulnerability fix. @hsbt and @shugo did audit this usage when CVE-2017-17405 was disclosed.

Because ruby core team will warn to use `Kernel#open` in standard libraries.

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
