### PR TITLE
Gem::Util.traverse_parents should not crash on permissions error

### DIFF
--- a/lib/rubygems/util.rb
+++ b/lib/rubygems/util.rb
@@ -114,7 +114,8 @@ module Gem::Util
 
     here = File.expand_path directory
     loop do
-      Dir.chdir here, &block
+      Dir.chdir here, &block rescue Errno::EACCES
+
       new_here = File.expand_path('..', here)
       return if new_here == here # toplevel
       here = new_here

--- a/test/rubygems/test_gem_util.rb
+++ b/test/rubygems/test_gem_util.rb
@@ -29,6 +29,25 @@ class TestGemUtil < Gem::TestCase
     loop { break if enum.next.nil? } # exhaust the enumerator
   end
 
+  def test_traverse_parents_does_not_crash_on_permissions_error
+    skip 'skipped on MS Windows (chmod has no effect)' if win_platform?
+
+    FileUtils.mkdir_p 'd/e/f'
+    # remove 'execute' permission from "e" directory and make it
+    # impossible to cd into it and its children
+    FileUtils.chmod(0666, 'd/e')
+
+    paths = Gem::Util.traverse_parents('d/e/f').to_a
+
+    assert_equal File.join(@tempdir, 'd'), paths[0]
+    assert_equal @tempdir, paths[1]
+    assert_equal Dir.tmpdir, paths[2]
+    assert_equal '/', paths[3]
+  ensure
+    # restore default permissions, allow the directory to be removed
+    FileUtils.chmod(0775, 'd/e') unless win_platform?
+  end
+
   def test_linked_list_find
     list = [1,2,3,4,5].inject(Gem::List.new(0)) { |m,o|
       Gem::List.new o, m


### PR DESCRIPTION
This change makes `traverse_parents` to skip directories it can't
read.

There are edge cases where program working directory (and parents)
is not "readable". If such a program includes `require 'some-gem'`
and environment variable BUNDLER_VERSION is not set then
`BundlerVersionFinder` will attempt to determine bundler version
by traversing all parent directories to find Gemfile.lock and determine
the bundler version from it. The program will then crash.

A real-world example is described here:

https://github.com/rubygems/rubygems/issues/2144

With this patch unreadable directories will be skipped and the
program won't crash.

Resolves #2144 


I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
