### PR TITLE
[Installer] Avoid a #mkdir race condition

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -464,7 +464,12 @@ class Gem::Installer
   def generate_bin # :nodoc:
     return if spec.executables.nil? or spec.executables.empty?
 
-    Dir.mkdir @bin_dir unless File.exist? @bin_dir
+    begin
+      Dir.mkdir @bin_dir
+    rescue SystemCallError
+      raise unless File.directory? @bin_dir
+    end
+
     raise Gem::FilePermissionError.new(@bin_dir) unless File.writable? @bin_dir
 
     spec.executables.each do |filename|


### PR DESCRIPTION
When attempting to install multiple gems with binstubs,
it would be possible to have the directory created after checking
for its existence.

It's safer instead to attempt to create the directory, and then handle
any errors.

This should fix some spurious errors seen in the Bundler test suite.