### PR TITLE
Allow writing gemspecs from gem unpack to location specified by target option

### DIFF
--- a/lib/rubygems/commands/unpack_command.rb
+++ b/lib/rubygems/commands/unpack_command.rb
@@ -94,7 +94,17 @@ command help for an example.
 
         spec_file = File.basename spec.spec_file
 
-        File.open spec_file, 'w' do |io|
+        FileUtils.mkdir_p @options[:target] if @options[:target]
+
+        destination = begin
+          if @options[:target]
+            File.join @options[:target], spec_file
+          else
+            spec_file
+          end
+        end
+
+        File.open destination, 'w' do |io|
           io.write metadata
         end
       else

--- a/test/rubygems/test_gem_commands_unpack_command.rb
+++ b/test/rubygems/test_gem_commands_unpack_command.rb
@@ -134,6 +134,23 @@ class TestGemCommandsUnpackCommand < Gem::TestCase
     assert File.exist?(File.join(@tempdir, 'b-2.gemspec'))
   end
 
+  def test_execute_spec_target
+    util_make_gems
+
+    @cmd.options[:args] = %w[a b]
+    @cmd.options[:target] = 'specs'
+    @cmd.options[:spec] = true
+
+    use_ui @ui do
+      Dir.chdir @tempdir do
+        @cmd.execute
+      end
+    end
+
+    assert File.exist?(File.join(@tempdir, 'specs/a-3.a.gemspec'))
+    assert File.exist?(File.join(@tempdir, 'specs/b-2.gemspec'))
+  end
+
   def test_execute_sudo
     skip 'Cannot perform this test on windows (chmod)' if win_platform?
 


### PR DESCRIPTION
# Description:

`gem unpack` has a `--target` option which allows specifying a location to unpack the gem.

```
› gem unpack bundler-1.16.1.gem --target gems
Unpacked gem: '/Users/c/Desktop/gems/bundler-1.16.1'
› ls gems
bundler-1.16.1/
```

`gem unpack` also has a `--spec` option which only extracts the `gemspec` but does write to a given location if i specify a `--target` directory (which does not raise an error)

```
› gem unpack bundler-1.16.1.gem --target gems --spec
› ls
bundler-1.16.1.gem      bundler-1.16.1.gemspec
```
This PR updates `gem unpack` to write the gemspec to the given directory when the `--target` option is specified along with the `--spec` option.

Fixes #2149 

______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
