### PR TITLE
Update to SPDX license list 3.0

### DIFF
--- a/lib/rubygems/util/licenses.rb
+++ b/lib/rubygems/util/licenses.rb
@@ -19,6 +19,8 @@ class Gem::Licenses
       AFL-3.0
       AGPL-1.0
       AGPL-3.0
+      AGPL-3.0-only
+      AGPL-3.0-or-later
       AMDPLPA
       AML
       AMPAS
@@ -41,9 +43,11 @@ class Gem::Licenses
       Artistic-1.0-Perl
       Artistic-1.0-cl8
       Artistic-2.0
+      BSD-1-Clause
       BSD-2-Clause
       BSD-2-Clause-FreeBSD
       BSD-2-Clause-NetBSD
+      BSD-2-Clause-Patent
       BSD-3-Clause
       BSD-3-Clause-Attribution
       BSD-3-Clause-Clear
@@ -96,6 +100,8 @@ class Gem::Licenses
       CC0-1.0
       CDDL-1.0
       CDDL-1.1
+      CDLA-Permissive-1.0
+      CDLA-Sharing-1.0
       CECILL-1.0
       CECILL-1.1
       CECILL-2.0
@@ -124,9 +130,11 @@ class Gem::Licenses
       EFL-1.0
       EFL-2.0
       EPL-1.0
+      EPL-2.0
       EUDatagrid
       EUPL-1.0
       EUPL-1.1
+      EUPL-1.2
       Entessa
       ErlPL-1.1
       Eurosym
@@ -138,13 +146,23 @@ class Gem::Licenses
       Frameworx-1.0
       FreeImage
       GFDL-1.1
+      GFDL-1.1-only
+      GFDL-1.1-or-later
       GFDL-1.2
+      GFDL-1.2-only
+      GFDL-1.2-or-later
       GFDL-1.3
+      GFDL-1.3-only
+      GFDL-1.3-or-later
       GL2PS
       GPL-1.0
       GPL-1.0+
+      GPL-1.0-only
+      GPL-1.0-or-later
       GPL-2.0
       GPL-2.0+
+      GPL-2.0-only
+      GPL-2.0-or-later
       GPL-2.0-with-GCC-exception
       GPL-2.0-with-autoconf-exception
       GPL-2.0-with-bison-exception
@@ -152,6 +170,8 @@ class Gem::Licenses
       GPL-2.0-with-font-exception
       GPL-3.0
       GPL-3.0+
+      GPL-3.0-only
+      GPL-3.0-or-later
       GPL-3.0-with-GCC-exception
       GPL-3.0-with-autoconf-exception
       Giftware
@@ -177,10 +197,16 @@ class Gem::Licenses
       LAL-1.3
       LGPL-2.0
       LGPL-2.0+
+      LGPL-2.0-only
+      LGPL-2.0-or-later
       LGPL-2.1
       LGPL-2.1+
+      LGPL-2.1-only
+      LGPL-2.1-or-later
       LGPL-3.0
       LGPL-3.0+
+      LGPL-3.0-only
+      LGPL-3.0-or-later
       LGPLLR
       LPL-1.0
       LPL-1.02
@@ -317,7 +343,6 @@ class Gem::Licenses
       W3C-19980720
       W3C-20150513
       WTFPL
-      WXwindows
       Watcom-1.0
       Wsuipa
       X11
@@ -349,6 +374,7 @@ class Gem::Licenses
       mpich2
       psfrag
       psutils
+      wxWindows
       xinetd
       xpp
       zlib-acknowledgement

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2928,6 +2928,17 @@ http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
     assert_empty @ui.error
   end
 
+  def test_validate_license_values_or_later
+    util_setup_validate
+
+    use_ui @ui do
+      @a1.licenses = ['GPL-2.0-or-later']
+      @a1.validate
+    end
+
+    assert_empty @ui.error
+  end
+
   def test_validate_license_values_with
     util_setup_validate
 


### PR DESCRIPTION
# Description:

Update to SPDX license list 3.0 simply by running

  ruby util/generate_spdx_license_list.rb

3.0 was released 2017-12-28 https://spdx.org/news/news/2018/01/license-list-30-released

It includes some new license identifiers that rubygems should be aware of.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

Yes, I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).