### PR TITLE
Raise errors in `gem uninstall` when a file in a gem could not be removed 

### DIFF
--- a/lib/rubygems/exceptions.rb
+++ b/lib/rubygems/exceptions.rb
@@ -52,6 +52,11 @@ class Gem::GemNotInHomeException < Gem::Exception
   attr_accessor :spec
 end
 
+###
+# Raised when removing a gem with the uninstall command fails
+
+class Gem::UninstallError < Gem::Exception; end
+
 class Gem::DocumentError < Gem::Exception; end
 
 ##

--- a/lib/rubygems/exceptions.rb
+++ b/lib/rubygems/exceptions.rb
@@ -55,7 +55,9 @@ end
 ###
 # Raised when removing a gem with the uninstall command fails
 
-class Gem::UninstallError < Gem::Exception; end
+class Gem::UninstallError < Gem::Exception
+  attr_accessor :spec
+end
 
 class Gem::DocumentError < Gem::Exception; end
 

--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -349,6 +349,9 @@ class Gem::Uninstaller
   rescue Errno::ENOENT
     nil
   rescue Errno::EPERM
-    raise Gem::UninstallError
+    e = Gem::UninstallError.new
+    e.spec = @spec
+
+    raise e
   end
 end

--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -253,6 +253,8 @@ class Gem::Uninstaller
     safe_delete { FileUtils.rm_r spec.full_gem_path }
     safe_delete { FileUtils.rm_r spec.extension_dir }
 
+    old_platform_name = spec.original_name
+
     gem = spec.cache_file
     gem = File.join(spec.cache_dir, "#{old_platform_name}.gem") unless
       File.exist? gem
@@ -261,8 +263,7 @@ class Gem::Uninstaller
 
     Gem::RDoc.new(spec).remove
 
-    old_platform_name = spec.original_name
-    gemspec           = spec.spec_file
+    gemspec = spec.spec_file
 
     unless File.exist? gemspec then
       gemspec = File.join(File.dirname(gemspec), "#{old_platform_name}.gemspec")

--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -253,15 +253,6 @@ class Gem::Uninstaller
     safe_delete { FileUtils.rm_r spec.full_gem_path }
     safe_delete { FileUtils.rm_r spec.extension_dir }
 
-    old_platform_name = spec.original_name
-    gemspec           = spec.spec_file
-
-    unless File.exist? gemspec then
-      gemspec = File.join(File.dirname(gemspec), "#{old_platform_name}.gemspec")
-    end
-
-    safe_delete { FileUtils.rm_r gemspec }
-
     gem = spec.cache_file
     gem = File.join(spec.cache_dir, "#{old_platform_name}.gem") unless
       File.exist? gem
@@ -270,6 +261,14 @@ class Gem::Uninstaller
 
     Gem::RDoc.new(spec).remove
 
+    old_platform_name = spec.original_name
+    gemspec           = spec.spec_file
+
+    unless File.exist? gemspec then
+      gemspec = File.join(File.dirname(gemspec), "#{old_platform_name}.gemspec")
+    end
+
+    safe_delete { FileUtils.rm_r gemspec }
     say "Successfully uninstalled #{spec.full_name}"
 
     Gem::Specification.reset

--- a/test/rubygems/test_gem_commands_uninstall_command.rb
+++ b/test/rubygems/test_gem_commands_uninstall_command.rb
@@ -291,5 +291,31 @@ WARNING:  Use your OS package manager to uninstall vendor gems
     assert_equal output.first, "Gem 'd' is not installed"
   end
 
+  def test_execute_with_gem_uninstall_error
+    util_make_gems
+
+    @cmd.options[:args] = %w[a]
+
+    uninstall_exception =  ->(_a) do
+      ex = Gem::UninstallError.new
+      ex.spec = @spec
+
+      raise ex
+    end
+
+    e = nil
+    @cmd.stub :uninstall, uninstall_exception do
+      use_ui @ui do
+        e = assert_raises Gem::MockGemUi::TermError do
+          @cmd.execute
+        end
+      end
+
+      assert_equal 1, e.exit_code
+    end
+
+    assert_empty @ui.output
+    assert_match %r!Error: unable to successfully uninstall '#{@spec.name}'!, @ui.error
+  end
 end
 

--- a/test/rubygems/test_gem_commands_uninstall_command.rb
+++ b/test/rubygems/test_gem_commands_uninstall_command.rb
@@ -296,7 +296,7 @@ WARNING:  Use your OS package manager to uninstall vendor gems
 
     @cmd.options[:args] = %w[a]
 
-    uninstall_exception =  ->(_a) do
+    uninstall_exception = lambda do |_a|
       ex = Gem::UninstallError.new
       ex.spec = @spec
 

--- a/test/rubygems/test_gem_uninstaller.rb
+++ b/test/rubygems/test_gem_uninstaller.rb
@@ -488,7 +488,9 @@ create_makefile '#{@spec.name}'
   def test_uninstall_no_permission
     uninstaller = Gem::Uninstaller.new @spec.name, :executables => true
 
-    stub_rm_r = -> (_a, options = {}) do
+    stub_rm_r = lambda do |*args|
+      _path = args.shift
+      options = args.shift || Hash.new
       # Uninstaller calls a method in RDoc which also calls FileUtils.rm_rf which
       # is an alias for FileUtils#rm_r, so skip if we're using the force option
       raise Errno::EPERM unless options[:force]
@@ -499,10 +501,5 @@ create_makefile '#{@spec.name}'
         uninstaller.uninstall
       end
     end
-
-    # lines = ui.output.split("\n")
-    # lines.shift
-
-    # assert_match %r!Error: unable to succesfully uninstall '#{@spec.name}'!, lines.shift
   end
 end


### PR DESCRIPTION
A problem that i've encountered a few times and that has also been reported at #1967 is that `gem uninstall` does not report any errors if it was unable to remove any files/executables or gemspec. 

Not successfully removing all the gem's files can introduce unexpected behavior for the user, especially when the files that could not be removed are the gem's executable or gemspec. A gem could be reported as still being installed and available to execute even though the rest of the gem has been removed.

This is happening because `gem uninstall` uses `rm_f` and `rm_rf` in the FileUtils library which suppresses any errors when attempting to delete the file.

This PR changes this behavior to instead capture any errors when removing a gem's files and raise an error to the user of the problem that has been encounted.

Example error when a gem could not be successfully removed:

```
Error: unable to successfully uninstall 'a' which is located at '/private/var/folders/vg/0528djbx3r9fb1d7qlpxwzq40000gn/T/test_rubygems_633/gemhome/gems/a-2'. This is most likely because the current user does not have the appropriate permissions
```

## A Few Notes

I've changed the Gem's `gemspec` to be the last thing that is removed, as that is the point which RubyGems says if a gem is installed or not, so it should only be removed when everything else was successfully removed.

I've opted to use mocks to test this behavior. Trying to create a env that could setup the conditions for a file to be prevented from being removed using only the current user proved to be quite difficult. I'm certainly open for suggestion in testing this behavior without using mocks.
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
