### PR TITLE
Remove PID from gem index directory.

### DIFF
--- a/lib/rubygems/indexer.rb
+++ b/lib/rubygems/indexer.rb
@@ -2,6 +2,7 @@
 require 'rubygems'
 require 'rubygems/package'
 require 'time'
+require 'tmpdir'
 
 begin
   gem 'builder'
@@ -64,7 +65,7 @@ class Gem::Indexer
     @build_modern = options[:build_modern]
 
     @dest_directory = directory
-    @directory = File.join(Dir.tmpdir, "gem_generate_index_#{$$}")
+    @directory = Dir.mktmpdir 'gem_generate_index'
 
     marshal_name = "Marshal.#{Gem.marshal_version}"
 

--- a/test/rubygems/test_gem_indexer.rb
+++ b/test/rubygems/test_gem_indexer.rb
@@ -39,8 +39,7 @@ class TestGemIndexer < Gem::TestCase
 
   def test_initialize
     assert_equal @tempdir, @indexer.dest_directory
-    assert_equal File.join(Dir.tmpdir, "gem_generate_index_#{$$}"),
-                 @indexer.directory
+    assert_match %r{#{Dir.mktmpdir('gem_generate_index').match(/.*-/)}}, @indexer.directory
 
     indexer = Gem::Indexer.new @tempdir
     assert indexer.build_modern


### PR DESCRIPTION
# Description:

`gem generate_index` allows creating sequential directory used PID. It's possible to guess the directory name by other local users. It's better to use `Dir.mktmpdir` instead of PID.

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
