### PR TITLE
Rename stub object like @stub_ui from @ui.

### DIFF
--- a/test/rubygems/test_gem_commands_dependency_command.rb
+++ b/test/rubygems/test_gem_commands_dependency_command.rb
@@ -6,7 +6,7 @@ class TestGemCommandsDependencyCommand < Gem::TestCase
 
   def setup
     super
-
+    @stub_ui = Gem::MockGemUi.new
     @cmd = Gem::Commands::DependencyCommand.new
     @cmd.options[:domain] = :local
   end
@@ -19,13 +19,13 @@ class TestGemCommandsDependencyCommand < Gem::TestCase
 
     @cmd.options[:args] = %w[foo]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
     assert_equal "Gem foo-2\n  bar (> 1)\n  baz (> 1)\n\n",
-                 @ui.output
-    assert_equal '', @ui.error
+                 @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_no_args
@@ -40,7 +40,7 @@ class TestGemCommandsDependencyCommand < Gem::TestCase
 
     @cmd.options[:args] = []
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -58,21 +58,21 @@ Gem x-2
 
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_no_match
     @cmd.options[:args] = %w[foo]
 
     assert_raises Gem::MockGemUi::TermError do
-      use_ui @ui do
+      use_ui @stub_ui do
         @cmd.execute
       end
     end
 
-    assert_equal "No gems found matching foo (>= 0)\n", @ui.output
-    assert_equal '', @ui.error
+    assert_equal "No gems found matching foo (>= 0)\n", @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_pipe_format
@@ -85,12 +85,12 @@ Gem x-2
     @cmd.options[:args] = %w[foo]
     @cmd.options[:pipe_format] = true
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
-    assert_equal "bar --version '> 1'\n", @ui.output
-    assert_equal '', @ui.error
+    assert_equal "bar --version '> 1'\n", @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_regexp
@@ -103,7 +103,7 @@ Gem x-2
 
     @cmd.options[:args] = %w[/[ab]/]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -118,8 +118,8 @@ Gem b-2
 
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_reverse
@@ -135,7 +135,7 @@ Gem b-2
     @cmd.options[:args] = %w[foo]
     @cmd.options[:reverse_dependencies] = true
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -147,8 +147,8 @@ Gem foo-2
 
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_reverse_remote
@@ -157,7 +157,7 @@ Gem foo-2
     @cmd.options[:domain] = :remote
 
     assert_raises Gem::MockGemUi::TermError do
-      use_ui @ui do
+      use_ui @stub_ui do
         @cmd.execute
       end
     end
@@ -166,8 +166,8 @@ Gem foo-2
 ERROR:  Only reverse dependencies for local gems are supported.
     EOF
 
-    assert_equal '', @ui.output
-    assert_equal expected, @ui.error
+    assert_equal '', @stub_ui.output
+    assert_equal expected, @stub_ui.error
   end
 
   def test_execute_remote
@@ -180,12 +180,12 @@ ERROR:  Only reverse dependencies for local gems are supported.
     @cmd.options[:args] = %w[foo]
     @cmd.options[:domain] = :remote
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
-    assert_equal "Gem foo-2\n  bar (> 1)\n\n", @ui.output
-    assert_equal '', @ui.error
+    assert_equal "Gem foo-2\n  bar (> 1)\n\n", @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_remote_version
@@ -201,12 +201,12 @@ ERROR:  Only reverse dependencies for local gems are supported.
     @cmd.options[:domain] = :remote
     @cmd.options[:version] = req '= 1'
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
-    assert_equal "Gem a-1\n\n", @ui.output
-    assert_equal '', @ui.error
+    assert_equal "Gem a-1\n\n", @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_prerelease
@@ -218,12 +218,12 @@ ERROR:  Only reverse dependencies for local gems are supported.
     @cmd.options[:domain] = :remote
     @cmd.options[:prerelease] = true
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
-    assert_equal "Gem a-2.a\n\n", @ui.output
-    assert_equal '', @ui.error
+    assert_equal "Gem a-2.a\n\n", @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
 end

--- a/test/rubygems/test_gem_commands_query_command.rb
+++ b/test/rubygems/test_gem_commands_query_command.rb
@@ -9,8 +9,10 @@ module TestGemCommandsQueryCommandSetup
     @cmd = Gem::Commands::QueryCommand.new
 
     @specs = add_gems_to_fetcher
-
-    @fetcher.data["#{@gem_repo}Marshal.#{Gem.marshal_version}"] = proc do
+    @stub_ui = Gem::MockGemUi.new
+    @stub_fetcher = Gem::FakeFetcher.new
+    
+    @stub_fetcher.data["#{@gem_repo}Marshal.#{Gem.marshal_version}"] = proc do
       raise Gem::RemoteFetcher::FetchError
     end
   end
@@ -26,7 +28,7 @@ class TestGemCommandsQueryCommandWithInstalledGems < Gem::TestCase
 
     @cmd.handle_options %w[-r]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -38,8 +40,8 @@ a (2)
 pl (1 i386-linux)
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_all
@@ -49,7 +51,7 @@ pl (1 i386-linux)
 
     @cmd.handle_options %w[-r --all]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -61,8 +63,8 @@ a (2, 1)
 pl (1 i386-linux)
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_all_prerelease
@@ -72,7 +74,7 @@ pl (1 i386-linux)
 
     @cmd.handle_options %w[-r --all --prerelease]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -84,8 +86,8 @@ a (3.a, 2, 1)
 pl (1 i386-linux)
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_details
@@ -101,7 +103,7 @@ pl (1 i386-linux)
 
     @cmd.handle_options %w[-r -d]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -124,8 +126,8 @@ pl (1)
     this is a summary
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_details_cleans_text
@@ -141,7 +143,7 @@ pl (1)
 
     @cmd.handle_options %w[-r -d]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -164,8 +166,8 @@ pl (1)
     this is a summary
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_details_truncates_summary
@@ -181,7 +183,7 @@ pl (1)
 
     @cmd.handle_options %w[-r -d]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -204,34 +206,34 @@ pl (1)
     this is a summary
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_installed
     @cmd.handle_options %w[-n a --installed]
 
     assert_raises Gem::MockGemUi::SystemExitException do
-      use_ui @ui do
+      use_ui @stub_ui do
         @cmd.execute
       end
     end
 
-    assert_equal "true\n", @ui.output
-    assert_equal '', @ui.error
+    assert_equal "true\n", @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_installed_inverse
     @cmd.handle_options %w[-n a --no-installed]
 
     e = assert_raises Gem::MockGemUi::TermError do
-      use_ui @ui do
+      use_ui @stub_ui do
         @cmd.execute
       end
     end
 
-    assert_equal "false\n", @ui.output
-    assert_equal '', @ui.error
+    assert_equal "false\n", @stub_ui.output
+    assert_equal '', @stub_ui.error
 
     assert_equal 1, e.exit_code
   end
@@ -240,26 +242,26 @@ pl (1)
     @cmd.handle_options %w[-n not_installed --no-installed]
 
     assert_raises Gem::MockGemUi::SystemExitException do
-      use_ui @ui do
+      use_ui @stub_ui do
         @cmd.execute
       end
     end
 
-    assert_equal "true\n", @ui.output
-    assert_equal '', @ui.error
+    assert_equal "true\n", @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_installed_no_name
     @cmd.handle_options %w[--installed]
 
     e = assert_raises Gem::MockGemUi::TermError do
-      use_ui @ui do
+      use_ui @stub_ui do
         @cmd.execute
       end
     end
 
-    assert_equal '', @ui.output
-    assert_equal "ERROR:  You must specify a gem name\n", @ui.error
+    assert_equal '', @stub_ui.output
+    assert_equal "ERROR:  You must specify a gem name\n", @stub_ui.error
 
     assert_equal 4, e.exit_code
   end
@@ -268,13 +270,13 @@ pl (1)
     @cmd.handle_options %w[-n not_installed --installed]
 
     e = assert_raises Gem::MockGemUi::TermError do
-      use_ui @ui do
+      use_ui @stub_ui do
         @cmd.execute
       end
     end
 
-    assert_equal "false\n", @ui.output
-    assert_equal '', @ui.error
+    assert_equal "false\n", @stub_ui.output
+    assert_equal '', @stub_ui.error
 
     assert_equal 1, e.exit_code
   end
@@ -283,26 +285,26 @@ pl (1)
     @cmd.handle_options %w[-n a --installed --version 2]
 
     assert_raises Gem::MockGemUi::SystemExitException do
-      use_ui @ui do
+      use_ui @stub_ui do
         @cmd.execute
       end
     end
 
-    assert_equal "true\n", @ui.output
-    assert_equal '', @ui.error
+    assert_equal "true\n", @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_installed_version_not_installed
     @cmd.handle_options %w[-n c --installed --version 2]
 
     e = assert_raises Gem::MockGemUi::TermError do
-      use_ui @ui do
+      use_ui @stub_ui do
         @cmd.execute
       end
     end
 
-    assert_equal "false\n", @ui.output
-    assert_equal '', @ui.error
+    assert_equal "false\n", @stub_ui.output
+    assert_equal '', @stub_ui.error
 
     assert_equal 1, e.exit_code
   end
@@ -314,7 +316,7 @@ pl (1)
 
     @cmd.options[:domain] = :local
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -326,8 +328,8 @@ a (3.a, 2, 1)
 pl (1 i386-linux)
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_local_notty
@@ -337,9 +339,9 @@ pl (1 i386-linux)
 
     @cmd.handle_options %w[]
 
-    @ui.outs.tty = false
+    @stub_ui.outs.tty = false
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -348,8 +350,8 @@ a (3.a, 2, 1)
 pl (1 i386-linux)
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_local_quiet
@@ -360,7 +362,7 @@ pl (1 i386-linux)
     @cmd.options[:domain] = :local
     Gem.configuration.verbose = false
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -369,8 +371,8 @@ a (3.a, 2, 1)
 pl (1 i386-linux)
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_no_versions
@@ -380,7 +382,7 @@ pl (1 i386-linux)
 
     @cmd.handle_options %w[-r --no-versions]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -392,8 +394,8 @@ a
 pl
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_notty
@@ -403,9 +405,9 @@ pl
 
     @cmd.handle_options %w[-r]
 
-    @ui.outs.tty = false
+    @stub_ui.outs.tty = false
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -414,14 +416,14 @@ a (2)
 pl (1 i386-linux)
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_prerelease
     @cmd.handle_options %w[-r --prerelease]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -432,8 +434,8 @@ pl (1 i386-linux)
 a (3.a)
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_prerelease_local
@@ -443,7 +445,7 @@ a (3.a)
 
     @cmd.handle_options %w[-l --prerelease]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -455,8 +457,8 @@ a (3.a, 2, 1)
 pl (1 i386-linux)
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal "WARNING:  prereleases are always shown locally\n", @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal "WARNING:  prereleases are always shown locally\n", @stub_ui.error
   end
 
   def test_execute_remote
@@ -466,7 +468,7 @@ pl (1 i386-linux)
 
     @cmd.options[:domain] = :remote
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -478,8 +480,8 @@ a (2)
 pl (1 i386-linux)
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_remote_notty
@@ -489,9 +491,9 @@ pl (1 i386-linux)
 
     @cmd.handle_options %w[]
 
-    @ui.outs.tty = false
+    @stub_ui.outs.tty = false
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -500,8 +502,8 @@ a (3.a, 2, 1)
 pl (1 i386-linux)
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_remote_quiet
@@ -512,7 +514,7 @@ pl (1 i386-linux)
     @cmd.options[:domain] = :remote
     Gem.configuration.verbose = false
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -521,14 +523,14 @@ a (2)
 pl (1 i386-linux)
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_make_entry
     a_2_name = @specs['a-2'].original_name
 
-    @fetcher.data.delete \
+    @stub_fetcher.data.delete \
       "#{@gem_repo}quick/Marshal.#{Gem.marshal_version}/#{a_2_name}.gemspec.rz"
 
     a2 = @specs['a-2']
@@ -552,26 +554,26 @@ pl (1 i386-linux)
 
     @cmd.handle_options %w[a pl]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
-    assert_match %r%^a %, @ui.output
-    assert_match %r%^pl %, @ui.output
-    assert_equal '', @ui.error
+    assert_match %r%^a %, @stub_ui.output
+    assert_match %r%^pl %, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_show_gems
     @cmd.options[:name] = //
     @cmd.options[:domain] = :remote
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.send :show_gems, /a/i, false
     end
 
-    assert_match %r%^a %,  @ui.output
-    refute_match %r%^pl %, @ui.output
-    assert_empty @ui.error
+    assert_match %r%^a %,  @stub_ui.output
+    refute_match %r%^pl %, @stub_ui.output
+    assert_empty @stub_ui.error
   end
 
   private
@@ -602,7 +604,7 @@ class TestGemCommandsQueryCommandWithoutInstalledGems < Gem::TestCase
 
     @cmd.handle_options %w[-r -a]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -613,8 +615,8 @@ class TestGemCommandsQueryCommandWithoutInstalledGems < Gem::TestCase
 a (2 universal-darwin, 1 ruby x86-linux)
     EOF
 
-    assert_equal expected, @ui.output
-    assert_equal '', @ui.error
+    assert_equal expected, @stub_ui.output
+    assert_equal '', @stub_ui.error
   end
 
   def test_execute_show_default_gems
@@ -623,7 +625,7 @@ a (2 universal-darwin, 1 ruby x86-linux)
     a1 = new_default_spec 'a', 1
     install_default_specs a1
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -634,7 +636,7 @@ a (2 universal-darwin, 1 ruby x86-linux)
 a (2, default: 1)
 EOF
 
-    assert_equal expected, @ui.output
+    assert_equal expected, @stub_ui.output
   end
 
   def test_execute_show_default_gems_with_platform
@@ -642,7 +644,7 @@ EOF
     a1.platform = 'java'
     install_default_specs a1
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -653,7 +655,7 @@ EOF
 a (default: 1 java)
 EOF
 
-    assert_equal expected, @ui.output
+    assert_equal expected, @stub_ui.output
   end
 
   def test_execute_default_details
@@ -666,7 +668,7 @@ EOF
 
     @cmd.handle_options %w[-l -d]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -683,7 +685,7 @@ a (2, 1)
     this is a summary
     EOF
 
-    assert_equal expected, @ui.output
+    assert_equal expected, @stub_ui.output
   end
 
   def test_execute_local_details
@@ -704,11 +706,11 @@ a (2, 1)
 
     @cmd.handle_options %w[-l -d]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
-    str = @ui.output
+    str = @stub_ui.output
 
     str.gsub!(/\(\d\): [^\n]*/, "-")
     str.gsub!(/at: [^\n]*/, "at: -")
@@ -738,7 +740,7 @@ pl (1)
     this is a summary
     EOF
 
-    assert_equal expected, @ui.output
+    assert_equal expected, @stub_ui.output
   end
 
   def test_execute_exact_remote
@@ -750,7 +752,7 @@ pl (1)
 
     @cmd.handle_options %w[--remote --exact coolgem]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -761,7 +763,7 @@ pl (1)
 coolgem (4.2.1)
     EOF
 
-    assert_equal expected, @ui.output
+    assert_equal expected, @stub_ui.output
   end
 
   def test_execute_exact_local
@@ -773,7 +775,7 @@ coolgem (4.2.1)
 
     @cmd.handle_options %w[--exact coolgem]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -784,7 +786,7 @@ coolgem (4.2.1)
 coolgem (4.2.1)
     EOF
 
-    assert_equal expected, @ui.output
+    assert_equal expected, @stub_ui.output
   end
 
   def test_execute_exact_multiple
@@ -800,7 +802,7 @@ coolgem (4.2.1)
 
     @cmd.handle_options %w[--exact coolgem othergem]
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
@@ -815,7 +817,7 @@ coolgem (4.2.1)
 othergem (1.2.3)
     EOF
 
-    assert_equal expected, @ui.output
+    assert_equal expected, @stub_ui.output
   end
 
   private

--- a/test/rubygems/test_gem_commands_stale_command.rb
+++ b/test/rubygems/test_gem_commands_stale_command.rb
@@ -6,6 +6,7 @@ class TestGemCommandsStaleCommand < Gem::TestCase
 
   def setup
     super
+    @stub_ui = Gem::MockGemUi.new
     @cmd = Gem::Commands::StaleCommand.new
   end
 
@@ -31,11 +32,11 @@ class TestGemCommandsStaleCommand < Gem::TestCase
       FileUtils.touch(filename, :mtime => Time.now - 86400)
     end
 
-    use_ui @ui do
+    use_ui @stub_ui do
       @cmd.execute
     end
 
-    lines = @ui.output.split("\n")
+    lines = @stub_ui.output.split("\n")
     assert_equal("#{foo_bar.name}-#{foo_bar.version}", lines[0].split.first)
     assert_equal("#{bar_baz.name}-#{bar_baz.version}", lines[1].split.first)
   end

--- a/test/rubygems/test_gem_resolver_installer_set.rb
+++ b/test/rubygems/test_gem_resolver_installer_set.rb
@@ -25,8 +25,8 @@ class TestGemResolverInstallerSet < Gem::TestCase
   end
 
   def test_add_always_install_errors
-    @fetcher = Gem::FakeFetcher.new
-    Gem::RemoteFetcher.fetcher = @fetcher
+    @stub_fetcher = Gem::FakeFetcher.new
+    Gem::RemoteFetcher.fetcher = @stub_fetcher
 
     set = Gem::Resolver::InstallerSet.new :both
 


### PR DESCRIPTION
# Description:

This patch is part of #2139 by @MSP-Greg. I hope to merge it incrementally.

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
