### PR TITLE
Allow failure with Ruby 2.5.0 for rubygems test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,4 +51,5 @@ matrix:
       env: "TEST_TOOL=rubygems YAML=syck"
   allow_failures:
     - rvm: ruby-head
-
+    - rvm: 2.5.0
+      env: "TEST_TOOL=rubygems YAML=psych"


### PR DESCRIPTION
# Description:

It caused by travis environment.

see https://travis-ci.org/rubygems/rubygems/jobs/333599954

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
