### PR TITLE
nil guard on `Gem::Specification`

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -740,7 +740,7 @@ class Gem::Specification < Gem::BasicSpecification
     unless defined?(@@all) && @@all then
       @@all = stubs.map(&:to_spec)
       if @@all.any?(&:nil?) # TODO: remove once we're happy
-        raise "nil spec! included in #{stubs.inspect}"
+        raise "pid: #{$$} nil spec! included in #{stubs.inspect}"
       end
 
       # After a reset, make sure already loaded specs

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -959,6 +959,7 @@ class Gem::Specification < Gem::BasicSpecification
   # -- wilsonb
 
   def self.all= specs
+    raise "nil spec!" if specs.any?(&:nil?) # TODO: remove once we're happy
     @@stubs_by_name = specs.group_by(&:name)
     @@all = @@stubs = specs
   end

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -739,6 +739,9 @@ class Gem::Specification < Gem::BasicSpecification
   def self._all # :nodoc:
     unless defined?(@@all) && @@all then
       @@all = stubs.map(&:to_spec)
+      if @@all.any?(&:nil?) # TODO: remove once we're happy
+        raise "nil spec! included in #{stubs.inspect}"
+      end
 
       # After a reset, make sure already loaded specs
       # are still marked as activated.


### PR DESCRIPTION
# Description:

the ruby core has an issue of race condition for the concurrent environment. We already added extra nil guard to `Gem::Specification`. 

I will backport its code.

______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
