### PR TITLE
Behaviour changes with default gems installer

### DIFF
--- a/bundler/spec/support/hax.rb
+++ b/bundler/spec/support/hax.rb
@@ -50,4 +50,9 @@ module Gem
       end
     end
   end
+
+  class Specification < BasicSpecification
+    remove_const :DEFAULT_GEMS_LIST
+    DEFAULT_GEMS_LIST = %w[irb foo bar].freeze
+  end
 end

--- a/bundler/spec/support/hax.rb
+++ b/bundler/spec/support/hax.rb
@@ -52,7 +52,9 @@ module Gem
   end
 
   class Specification < BasicSpecification
-    remove_const :DEFAULT_GEMS_LIST
-    DEFAULT_GEMS_LIST = %w[irb foo bar].freeze
+    if defined?(DEFAULT_GEMS_LIST)
+      remove_const :DEFAULT_GEMS_LIST
+      DEFAULT_GEMS_LIST = %w[irb foo bar].freeze
+    end
   end
 end

--- a/bundler/spec/support/hax.rb
+++ b/bundler/spec/support/hax.rb
@@ -54,7 +54,7 @@ module Gem
   class Specification < BasicSpecification
     if defined?(DEFAULT_GEMS_LIST)
       remove_const :DEFAULT_GEMS_LIST
-      DEFAULT_GEMS_LIST = %w[irb foo bar].freeze
+      DEFAULT_GEMS_LIST = %w[irb json foo bar].freeze
     end
   end
 end

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -764,7 +764,7 @@ class Gem::Installer
   def verify_default_gems
     return unless options[:install_as_default]
     return if Gem::Specification::DEFAULT_GEMS_LIST.include?(spec.name)
-    raise Gem::InstallError, "#{spec} is not a default gems"
+    raise Gem::InstallError, "#{spec} is not a default gem."
   end
 
   ##

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -321,14 +321,15 @@ class Gem::Installer
     dir_mode = options[:dir_mode]
     FileUtils.mkdir_p gem_dir, :mode => dir_mode && 0o755
 
+    extract_files
+
+    build_extensions
+    write_build_info_file
+
     if @options[:install_as_default]
       extract_bin
       write_default_spec
     else
-      extract_files
-
-      build_extensions
-      write_build_info_file
       run_post_build_hooks
     end
 

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -760,6 +760,12 @@ class Gem::Installer
     end
   end
 
+  def verify_default_gems
+    return unless options[:install_as_default]
+    return if Gem::Specification::DEFAULT_GEMS_LIST.include?(spec.name)
+    raise Gem::InstallError, "#{spec} is not a default gems"
+  end
+
   ##
   # Return the text for an application file.
 
@@ -924,6 +930,10 @@ TEXT
     verify_spec
 
     ensure_loadable_spec
+
+    verify_spec
+
+    verify_default_gems
 
     if options[:install_as_default]
       Gem.ensure_default_gem_subdirectories gem_home

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -110,6 +110,31 @@ class Gem::Specification < Gem::BasicSpecification
 
   VALID_NAME_PATTERN = /\A[a-zA-Z0-9\.\-\_]+\z/ # :nodoc:
 
+  DEFAULT_GEMS_LIST = %w[
+    bigdecimal
+    cmath
+    csv
+    date
+    dbm
+    etc
+    fcntl
+    fiddle
+    fileutils
+    gdbm
+    io-console
+    ipaddr
+    json
+    openssl
+    psych
+    rdoc
+    scanf
+    sdbm
+    stringio
+    strscan
+    webrick
+    zlib
+  ] #:nodoc:
+
   # :startdoc:
 
   ##

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -112,6 +112,7 @@ class Gem::Specification < Gem::BasicSpecification
 
   DEFAULT_GEMS_LIST = %w[
     bigdecimal
+    bundler
     cmath
     csv
     date

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -134,7 +134,7 @@ class Gem::Specification < Gem::BasicSpecification
     strscan
     webrick
     zlib
-  ].freeze #:nodoc:
+  ].freeze # :nodoc:
 
   # :startdoc:
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -134,7 +134,7 @@ class Gem::Specification < Gem::BasicSpecification
     strscan
     webrick
     zlib
-  ] #:nodoc:
+  ].freeze #:nodoc:
 
   # :startdoc:
 

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -65,7 +65,7 @@ end
 
 class Gem::Specification < Gem::BasicSpecification
   remove_const :DEFAULT_GEMS_LIST
-  DEFAULT_GEMS_LIST = %w[systemgem default a b]
+  DEFAULT_GEMS_LIST = %w[systemgem default bundler a b c z]
 end
 
 ##

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -63,6 +63,11 @@ class Gem::Command
   end
 end
 
+class Gem::Specification < Gem::BasicSpecification
+  remove_const :DEFAULT_GEMS_LIST
+  DEFAULT_GEMS_LIST = %w[systemgem default a b]
+end
+
 ##
 # RubyGemTestCase provides a variety of methods for testing rubygems and
 # gem-related behavior in a sandbox.  Through RubyGemTestCase you can install

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -65,7 +65,7 @@ end
 
 class Gem::Specification < Gem::BasicSpecification
   remove_const :DEFAULT_GEMS_LIST
-  DEFAULT_GEMS_LIST = %w[systemgem default bundler a b c z]
+  DEFAULT_GEMS_LIST = %w[systemgem default bundler a b c z].freeze
 end
 
 ##


### PR DESCRIPTION
# Description:

A current installer of default gems only installs executable file and `gemspec`. It didn't resolve the real world problem.

Default gems provide to upgrade standard libraries like `gem update openssl`. But current installer used by `gem install openssl --default` is inconsistency behavior with `gem update`.

I change its behavior to install gem files and build native extensions. It can upgrade instructions for the old version of Ruby like 2.3 or 2.4.


______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
