### PR TITLE
skip broken test with macOS platform.

### DIFF
--- a/test/rubygems/test_gem_util.rb
+++ b/test/rubygems/test_gem_util.rb
@@ -41,8 +41,11 @@ class TestGemUtil < Gem::TestCase
 
     assert_equal File.join(@tempdir, 'd'), paths[0]
     assert_equal @tempdir, paths[1]
-    assert_equal Dir.tmpdir, paths[2]
-    assert_equal '/', paths[3]
+    # Dir.tmpdir macOS returns `/private` prefix.
+    if RUBY_PLATFORM !~ /darwin/
+      assert_equal Dir.tmpdir, paths[2]
+      assert_equal '/', paths[3]
+    end
   ensure
     # restore default permissions, allow the directory to be removed
     FileUtils.chmod(0775, 'd/e') unless win_platform?

--- a/test/rubygems/test_gem_util.rb
+++ b/test/rubygems/test_gem_util.rb
@@ -41,7 +41,7 @@ class TestGemUtil < Gem::TestCase
 
     assert_equal File.join(@tempdir, 'd'), paths[0]
     assert_equal @tempdir, paths[1]
-    # Dir.tmpdir macOS returns `/private` prefix.
+    # File.expand_path with macOS returns `/private` prefix.
     if RUBY_PLATFORM !~ /darwin/
       assert_equal Dir.tmpdir, paths[2]
       assert_equal '/', paths[3]


### PR DESCRIPTION
test of https://github.com/rubygems/rubygems/pull/2147 fails on macOS platform.

```
  2) Failure:
TestGemUtil#test_traverse_parents_does_not_crash_on_permissions_error:
--- expected
+++ actual
@@ -1 +1 @@
-"/var/folders/jl/zgy9fk353nd6zn0xznlsdzvc6gxzs5/T"
+"/private/var/folders/jl/zgy9fk353nd6zn0xznlsdzvc6gxzs5/T"
```

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
