### PR TITLE
To use constant instead of hard-coded version

### DIFF
--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -50,7 +50,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     FileUtils.mkdir_p File.join(Gem.default_dir, "specifications")
 
     open(File.join(Gem.default_dir, "specifications", "bundler-#{BUNDLER_VERS}.gemspec"), 'w') do |io|
-      io.puts '# bundler-1.16.1'
+      io.puts "# bundler-#{BUNDLER_VERS}"
     end
 
     open(File.join(Gem.default_dir, "specifications", "bundler-audit-1.0.0.gemspec"), 'w') do |io|


### PR DESCRIPTION
# Description:

This is a nitpick changes. stub parameter should use constant instead of hard-coded value.

______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
