### PR TITLE
Add Rake task to install dev dependencies.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,16 @@ rescue ::LoadError
   require 'yaml'
 end
 
+task :setup do
+  # TODO: I am sorry for this abomination, and it needs to be replaced. -@duckinator
+  gemspec = eval(File.read(File.expand_path("../rubygems-update.gemspec", __FILE__)))
+  deps = gemspec.dependencies.map { |dep| [dep.name, dep.requirement.to_s] }
+
+  deps.each do |(name, version)|
+    sh "gem install #{name} -v '#{version}'"
+  end
+end
+
 Rake::TestTask.new do |t|
   # For old rubygems with default bundler gemspec
   if "1.8" < RUBY_VERSION && RUBY_VERSION < "2.2"

--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,6 @@ task :setup do
 
   gemspec.dependencies.each do |dep|
     sh "gem install '#{dep.name}:#{dep.requirement.to_s}'"
-    #Gem.install(dep.name, dep.requirement)
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -15,13 +15,12 @@ rescue ::LoadError
 end
 
 task :setup do
-  # TODO: I am sorry for this abomination, and it needs to be replaced. -@duckinator
-  gemspec = eval(File.read(File.expand_path("../rubygems-update.gemspec", __FILE__)))
-  deps = gemspec.dependencies.map { |dep|
-    "'#{dep.name}:#{dep.requirement.to_s}'"
-  }
+  gemspec = Gem::Specification.load(File.expand_path("../rubygems-update.gemspec", __FILE__))
 
-  sh "gem install #{deps.join(" ")}"
+  gemspec.dependencies.each do |dep|
+    sh "gem install '#{dep.name}:#{dep.requirement.to_s}'"
+    #Gem.install(dep.name, dep.requirement)
+  end
 end
 
 Rake::TestTask.new do |t|

--- a/Rakefile
+++ b/Rakefile
@@ -17,11 +17,11 @@ end
 task :setup do
   # TODO: I am sorry for this abomination, and it needs to be replaced. -@duckinator
   gemspec = eval(File.read(File.expand_path("../rubygems-update.gemspec", __FILE__)))
-  deps = gemspec.dependencies.map { |dep| [dep.name, dep.requirement.to_s] }
+  deps = gemspec.dependencies.map { |dep|
+    "'#{dep.name}:#{dep.requirement.to_s}'"
+  }
 
-  deps.each do |(name, version)|
-    sh "gem install #{name} -v '#{version}'"
-  end
+  sh "gem install #{deps.join(" ")}"
 end
 
 Rake::TestTask.new do |t|


### PR DESCRIPTION
# Description:

This adds a `rake setup` which installs the ependencies required for working on RubyGems.

It's basically a replacement for `rake newb`.

Usage:

    $ gem install rake
    $ rake setup
    $ rake test

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
