### PR TITLE
Skip failing test with mjit

### DIFF
--- a/test/rubygems/test_gem_util.rb
+++ b/test/rubygems/test_gem_util.rb
@@ -5,6 +5,7 @@ require 'rubygems/util'
 class TestGemUtil < Gem::TestCase
 
   def test_class_popen
+    skip "MJIT executes process and it's caught by Process.wait(-1)" if RubyVM::MJIT.enabled?
     assert_equal "0\n", Gem::Util.popen(Gem.ruby, '-e', 'p 0')
 
     assert_raises Errno::ECHILD do

--- a/test/rubygems/test_gem_util.rb
+++ b/test/rubygems/test_gem_util.rb
@@ -5,7 +5,7 @@ require 'rubygems/util'
 class TestGemUtil < Gem::TestCase
 
   def test_class_popen
-    skip "MJIT executes process and it's caught by Process.wait(-1)" if RubyVM::MJIT.enabled?
+    skip "MJIT executes process and it's caught by Process.wait(-1)" if defined?(RubyVM::MJIT) && RubyVM::MJIT.enabled?
     assert_equal "0\n", Gem::Util.popen(Gem.ruby, '-e', 'p 0')
 
     assert_raises Errno::ECHILD do


### PR DESCRIPTION
# Description:

MJIT has been merged with Ruby 2.6. it added to skip failing a test in rubygems. I backport and modify it.
______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
