### PR TITLE
Drop to support Ruby < 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ branches:
     - /^[\d.]+$/
     - /.+-stable$/
 rvm:
-- 1.8.7
-- 1.9.2
-- 1.9.3
 - 2.0.0
 - 2.1.10
 - 2.2.9
@@ -31,12 +28,6 @@ script:
 - util/ci script
 matrix:
   exclude:
-    - rvm: 1.8.7
-      env: "TEST_TOOL=rubygems YAML=psych"
-    - rvm: 1.9.2
-      env: "TEST_TOOL=bundler RGV=master"
-    - rvm: 2.0.0
-      env: "TEST_TOOL=rubygems YAML=syck"
     - rvm: 2.1.10
       env: "TEST_TOOL=rubygems YAML=syck"
     - rvm: 2.2.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,33 +13,17 @@ branches:
     - /^[\d.]+$/
     - /.+-stable$/
 rvm:
-- 2.0.0
-- 2.1.10
 - 2.2.9
 - 2.3.6
 - 2.4.3
 - 2.5.0
 - ruby-head
 env:
-  - "TEST_TOOL=rubygems YAML=syck"
   - "TEST_TOOL=rubygems YAML=psych"
   - "TEST_TOOL=bundler RGV=master"
 script:
 - util/ci script
 matrix:
-  exclude:
-    - rvm: 2.1.10
-      env: "TEST_TOOL=rubygems YAML=syck"
-    - rvm: 2.2.9
-      env: "TEST_TOOL=rubygems YAML=syck"
-    - rvm: 2.3.6
-      env: "TEST_TOOL=rubygems YAML=syck"
-    - rvm: 2.4.3
-      env: "TEST_TOOL=rubygems YAML=syck"
-    - rvm: 2.5.0
-      env: "TEST_TOOL=rubygems YAML=syck"
-    - rvm: ruby-head
-      env: "TEST_TOOL=rubygems YAML=syck"
   allow_failures:
     # TODO: Remove 1.8.7-2.1.10 jobs after releasing bundler 1.16.2
     - rvm: 1.8.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,11 +9,6 @@ clone_depth: 10
 
 environment:
   matrix:
-  - ruby_version: 193
-  - ruby_version: 200
-  - ruby_version: 200-x64
-  - ruby_version: 21
-  - ruby_version: 21-x64
   - ruby_version: 22
   - ruby_version: 22-x64
     GIT:  C:/git/cmd/git.exe
@@ -32,7 +27,6 @@ init:
       7z x C:\ruby_trunk.7z -oC:\ruby_trunk )
 
 install:
-- if %ruby_version%==193 ( gem update minitest --no-document )
 - ps: >-
     git submodule update --init --recursive
 

--- a/rubygems-update.gemspec
+++ b/rubygems-update.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://rubygems.org".freeze
   s.licenses = ["Ruby".freeze, "MIT".freeze]
   s.rdoc_options = ["--main".freeze, "README.md".freeze, "--title=RubyGems Update Documentation".freeze]
-  s.required_ruby_version = Gem::Requirement.new(">= 1.8.7".freeze)
+  s.required_ruby_version = Gem::Requirement.new(">= 2.0.0".freeze)
   s.rubygems_version = "2.7.3".freeze
   s.summary = "".freeze
 

--- a/rubygems-update.gemspec
+++ b/rubygems-update.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://rubygems.org".freeze
   s.licenses = ["Ruby".freeze, "MIT".freeze]
   s.rdoc_options = ["--main".freeze, "README.md".freeze, "--title=RubyGems Update Documentation".freeze]
-  s.required_ruby_version = Gem::Requirement.new(">= 2.0.0".freeze)
+  s.required_ruby_version = Gem::Requirement.new(">= 2.2.2".freeze)
   s.rubygems_version = "2.7.3".freeze
   s.summary = "".freeze
 


### PR DESCRIPTION
# Description:

I know that this violates SemVer policy(But I didn't find the RubyGems adopts SemVer policy officially).

To support Ruby 1.8 and 1.9 reduces maintainers productivity. I always fix or added deprecated code like `defined?` or `respond_to?`, fix failing tests of too old ruby and preparing its environment to my box. I was burned out by its works.

# solution

Remove to support 1.8.7, 1.9.2 and 1.9.3 at RubyGems 2.8.