### PR TITLE
Temporary removed TOOLS=bundler from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,17 @@ matrix:
     - rvm: ruby-head
       env: "TEST_TOOL=rubygems YAML=syck"
   allow_failures:
-    - rvm: ruby-head
+    # TODO: Remove 1.8.7-2.1.10 jobs after releasing bundler 1.16.2
+    - rvm: 1.8.7
+      env: "TEST_TOOL=bundler RGV=master"
+    - rvm: 1.9.2
+      env: "TEST_TOOL=bundler RGV=master"
+    - rvm: 1.9.3
+      env: "TEST_TOOL=bundler RGV=master"
+    - rvm: 2.0.0
+      env: "TEST_TOOL=bundler RGV=master"
+    - rvm: 2.1.10
+      env: "TEST_TOOL=bundler RGV=master"
     - rvm: 2.5.0
       env: "TEST_TOOL=rubygems YAML=psych"
+    - rvm: ruby-head


### PR DESCRIPTION
# Description:

Because it needs to fix bundler test case and release 1.16.2.

refs:

* https://github.com/bundler/bundler/pull/6291
* https://travis-ci.org/rubygems/rubygems/jobs/339325369

______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
