### PR TITLE
Fixed tempfile leak for RubyGems 2.7.6

### DIFF
--- a/test/rubygems/test_gem_package_tar_header.rb
+++ b/test/rubygems/test_gem_package_tar_header.rb
@@ -160,6 +160,7 @@ group\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000
       assert_raises ArgumentError do
         new_header = Gem::Package::TarHeader.from io
       end
+      io.close! if io.respond_to? :close!
     end
   end
 


### PR DESCRIPTION
It's found by ruby core test suite.