### PR TITLE
Add missing requires

### DIFF
--- a/lib/rubygems/bundler_version_finder.rb
+++ b/lib/rubygems/bundler_version_finder.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rubygems/util"
+
 module Gem::BundlerVersionFinder
   @without_filtering = false
 

--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -2,6 +2,7 @@
 ##
 # The Dependency class holds a Gem name and a Gem::Requirement.
 
+require "rubygems/bundler_version_finder"
 require "rubygems/requirement"
 
 class Gem::Dependency


### PR DESCRIPTION
# Description:

I'm getting some crashes when running tests for my gem: https://circleci.com/gh/decidim/decidim/54469.
Adding the missing requires that the error points to seems to fix them. The require in `dependency.rb` comes from the error message, the second require comes from the error message that still appears after adding the first require.

I tried to isolate this, but I couldn't. So the minimal reproduction would be:

```
git clone https://github.com/decidim/decidim
cd decidim
git checkout rails-5.1.5-and-pg-1.0
bundle install
bundle exec rspec spec/generator_spec.rb[1:1:1:1]
```

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
