### PR TITLE
Fix getting started instructions

### DIFF
--- a/CONTRIBUTING.rdoc
+++ b/CONTRIBUTING.rdoc
@@ -25,8 +25,8 @@ here: http://guides.rubygems.org/contributing/
 
 == Getting Started
 
-    $ gem install hoe
-    $ rake newb
+    $ rake setup
+    $ rake test
 
 To run commands like <tt>gem install</tt> from the repo:
 


### PR DESCRIPTION
# Description:
Fix the `Getting started` part of the documentation since we are not using the `hoe gem` anymore

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
