### PR TITLE
ignore .DS_Store files in the update_manifest task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -378,7 +378,7 @@ desc "Update the manifest to reflect what's on disk"
 task :update_manifest do
   files = []
   require 'find'
-  exclude = %r[/\/tmp\/|pkg|CVS|\.svn|\.git|TAGS|extconf.h|\.bundle$|\.o$|\.log$/|\./bundler/(?!lib|man|exe|[^/]+\.md|bundler.gemspec)|doc/]ox
+  exclude = %r[/\/tmp\/|pkg|CVS|\.DS_Store|\.svn|\.git|TAGS|extconf.h|\.bundle$|\.o$|\.log$/|\./bundler/(?!lib|man|exe|[^/]+\.md|bundler.gemspec)|doc/]ox
   Find.find(".") do |path|
     next unless File.file?(path)
     next if path =~ exclude


### PR DESCRIPTION
# Description:

This PR adds `.DS_Store` to the ignore list in the `update_manifest` rake task so that it doesn't show up in `Manifest.txt`. It's fairly easy for this file to be generated by MacOS and has caught me a few times already.

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
