### PR TITLE
Update the CONTRIBUTING guide with instructions on signing up with Slack

### DIFF
--- a/CONTRIBUTING.rdoc
+++ b/CONTRIBUTING.rdoc
@@ -14,11 +14,12 @@ contributors to follow to reduce the time it takes to get changes merged in.
    * Match coding style (+if+, +elsif+, +when+ need trailing +then+)
 
 3. If any new files are added or existing files removed in a commit or PR, please update the +Manifest.txt+ accordingly.
+   This can be done by running <tt>rake update_manifest</tt>
 
 4. Don't modify the history file or version number.
 
-5. If you have any questions, just ask on IRC in #rubygems on Freenode or file
-   an issue here: http://github.com/rubygems/rubygems/issues
+5. If you have any questions, Feel free to join us on Slack, you can register by signing up at http://slack.bundler.io
+   or file an issue here: http://github.com/rubygems/rubygems/issues
 
 For more information and ideas on how to contribute to RubyGems ecosystem, see
 here: http://guides.rubygems.org/contributing/


### PR DESCRIPTION
# Description:

Most of the rubygems maintainer team now communicate over Slack rather then IRC, so we should update the docs to reflect on the best way to reach us.

I've also updated the clause on updating the `Manifest.txt` to include the rake task that can be used to generate it automatically.

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
