### PR TITLE
Fix Gem::Version.correct?

### DIFF
--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -170,6 +170,7 @@ class Gem::Version
   # True if the +version+ string matches RubyGems' requirements.
 
   def self.correct? version
+    return false if version.nil?
     !!(version.to_s =~ ANCHORED_VERSION_PATTERN)
   end
 

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -46,6 +46,7 @@ class TestGemVersion < Gem::TestCase
   def test_class_correct
     assert_equal true,  Gem::Version.correct?("5.1")
     assert_equal false, Gem::Version.correct?("an incorrect version")
+    assert_equal false, Gem::Version.correct?(nil)
   end
 
   def test_class_new_subclass


### PR DESCRIPTION
# Description:

in ruby 2.5.0. 
```
irb(main):001:0> Gem::Version.correct?(nil)
=> true
```

I think that it was wrong.  I think that I should behave as follows.
```
irb(main):001:0> Gem::Version.correct?(nil)
=> false
```
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
