### PR TITLE
Allow building gems without having to be in the gem folder 

### DIFF
--- a/lib/rubygems/commands/build_command.rb
+++ b/lib/rubygems/commands/build_command.rb
@@ -47,13 +47,15 @@ with gem spec:
     end
 
     if File.exist? gemspec then
-      spec = Gem::Specification.load gemspec
+      Dir.chdir(File.dirname(gemspec)) do
+        spec = Gem::Specification.load File.basename(gemspec)
 
-      if spec then
-        Gem::Package.build spec, options[:force]
-      else
-        alert_error "Error loading gemspec. Aborting."
-        terminate_interaction 1
+        if spec then
+          Gem::Package.build spec, options[:force]
+        else
+          alert_error "Error loading gemspec. Aborting."
+          terminate_interaction 1
+        end
       end
     else
       alert_error "Gemspec file not found: #{gemspec}"

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -64,6 +64,38 @@ class TestGemCommandsBuildCommand < Gem::TestCase
     assert_equal "ERROR:  Gemspec file not found: some_gem\n", @ui.error
   end
 
+  def test_execute_outside_dir
+    gemspec_dir = File.join @tempdir, 'build_command_gem'
+    gemspec_file = File.join gemspec_dir, @gem.spec_name
+
+    FileUtils.mkdir_p gemspec_dir
+
+    File.open gemspec_file, 'w' do |gs|
+      gs.write @gem.to_ruby
+    end
+
+    @cmd.options[:args] = [gemspec_file]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    output = @ui.output.split "\n"
+    assert_equal "  Successfully built RubyGem", output.shift
+    assert_equal "  Name: some_gem", output.shift
+    assert_equal "  Version: 2", output.shift
+    assert_equal "  File: some_gem-2.gem", output.shift
+    assert_equal [], output
+
+    gem_file = File.join gemspec_dir, File.basename(@gem.cache_file)
+    assert File.exist?(gem_file)
+
+    spec = Gem::Package.new(gem_file).spec
+
+    assert_equal "some_gem", spec.name
+    assert_equal "this is a summary", spec.summary
+  end
+
   def test_can_find_gemspecs_without_dot_gemspec
     gemspec_file = File.join(@tempdir, @gem.spec_name)
 


### PR DESCRIPTION
# Description:

The `gem build` command does not change into the working directory when building gems. This leads to issues when building a gem when you're not inside the same directory as the gemspec.

Here is an example of the trying to build the Bundler gem when i'm not inside the project directory.

```
› gem build bundler/bundler.gemspec
/Users/c/Projects
fatal: Not a git repository (or any of the parent directories): .git
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
    ["CHANGELOG.md", "LICENSE.md", "README.md", "bundler.gemspec", "exe/bundle", "exe/bundler"] are not files
```

This PR changes the `build` command to change into the same directory that the `gemspec` is located in. This makes it possible to build a gem without having to be inside it.

```
› gem build bundler/bundler.gemspec
/Users/c/Projects/bundler
  Successfully built RubyGem
  Name: bundler
  Version: 1.16.2
  File: bundler-1.16.2.gem
```

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
