### PR TITLE
Fix ruby warnings in test suite

### DIFF
--- a/test/rubygems/test_gem_package_tar_header.rb
+++ b/test/rubygems/test_gem_package_tar_header.rb
@@ -158,7 +158,7 @@ group\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000
       header_s[124, 12] = val
       io = TempIO.new header_s
       assert_raises ArgumentError do
-        new_header = Gem::Package::TarHeader.from io
+        Gem::Package::TarHeader.from io
       end
       io.close! if io.respond_to? :close!
     end

--- a/test/rubygems/test_gem_server.rb
+++ b/test/rubygems/test_gem_server.rb
@@ -405,7 +405,7 @@ class TestGemServer < Gem::TestCase
     #
     #
     #  <a href="." title=".">[www]</a>
-    regex_match = /xsshomepagegem 1<\/b>[\n\s]+(<span title="rdoc not installed">\[rdoc\]<\/span>|<a href="\/doc_root\/xsshomepagegem-1\/">\[rdoc\]<\/a>)[\n\s]+<a href="\." title="\.">\[www\]<\/a>/
+    regex_match = /xsshomepagegem 1<\/b>[\s]+(<span title="rdoc not installed">\[rdoc\]<\/span>|<a href="\/doc_root\/xsshomepagegem-1\/">\[rdoc\]<\/a>)[\s]+<a href="\." title="\.">\[www\]<\/a>/
     assert_match regex_match, @res.body
   end
 
@@ -460,7 +460,7 @@ class TestGemServer < Gem::TestCase
     #
     #
     #  <a href="." title=".">[www]</a>
-    regex_match = /invalidhomepagegem 1<\/b>[\n\s]+(<span title="rdoc not installed">\[rdoc\]<\/span>|<a href="\/doc_root\/invalidhomepagegem-1\/">\[rdoc\]<\/a>)[\n\s]+<a href="\." title="\.">\[www\]<\/a>/
+    regex_match = /invalidhomepagegem 1<\/b>[\s]+(<span title="rdoc not installed">\[rdoc\]<\/span>|<a href="\/doc_root\/invalidhomepagegem-1\/">\[rdoc\]<\/a>)[\s]+<a href="\." title="\.">\[www\]<\/a>/
     assert_match regex_match, @res.body
   end
 
@@ -487,7 +487,7 @@ class TestGemServer < Gem::TestCase
     assert_equal 200, @res.status
     assert_match 'validhomepagegemhttp 1', @res.body
 
-    regex_match = /validhomepagegemhttp 1<\/b>[\n\s]+(<span title="rdoc not installed">\[rdoc\]<\/span>|<a href="\/doc_root\/validhomepagegemhttp-1\/">\[rdoc\]<\/a>)[\n\s]+<a href="http:\/\/rubygems\.org" title="http:\/\/rubygems\.org">\[www\]<\/a>/
+    regex_match = /validhomepagegemhttp 1<\/b>[\s]+(<span title="rdoc not installed">\[rdoc\]<\/span>|<a href="\/doc_root\/validhomepagegemhttp-1\/">\[rdoc\]<\/a>)[\s]+<a href="http:\/\/rubygems\.org" title="http:\/\/rubygems\.org">\[www\]<\/a>/
     assert_match regex_match, @res.body
   end
 
@@ -514,7 +514,7 @@ class TestGemServer < Gem::TestCase
     assert_equal 200, @res.status
     assert_match 'validhomepagegemhttps 1', @res.body
 
-    regex_match = /validhomepagegemhttps 1<\/b>[\n\s]+(<span title="rdoc not installed">\[rdoc\]<\/span>|<a href="\/doc_root\/validhomepagegemhttps-1\/">\[rdoc\]<\/a>)[\n\s]+<a href="https:\/\/rubygems\.org" title="https:\/\/rubygems\.org">\[www\]<\/a>/
+    regex_match = /validhomepagegemhttps 1<\/b>[\s]+(<span title="rdoc not installed">\[rdoc\]<\/span>|<a href="\/doc_root\/validhomepagegemhttps-1\/">\[rdoc\]<\/a>)[\s]+<a href="https:\/\/rubygems\.org" title="https:\/\/rubygems\.org">\[www\]<\/a>/
     assert_match regex_match, @res.body
   end
 


### PR DESCRIPTION
# Description:

Running the rubygems test will print a couple of warnings, this PR fixes these warnings so we can have cleaner test output.

```
/Users/c/Projects/rubygems/test/rubygems/test_gem_package_tar_header.rb:161: warning: assigned but unused variable - new_header
/Users/c/Projects/rubygems/test/rubygems/test_gem_server.rb:408: warning: character class has duplicated range
/Users/c/Projects/rubygems/test/rubygems/test_gem_server.rb:463: warning: character class has duplicated range
/Users/c/Projects/rubygems/test/rubygems/test_gem_server.rb:490: warning: character class has duplicated range
/Users/c/Projects/rubygems/test/rubygems/test_gem_server.rb:517: warning: character class has duplicated range
```

The `\n` in `[\n\s]` is redundant because `\s` already includes `\n`

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
