### PR TITLE
Fix verify_entry regex for metadata

### DIFF
--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -591,7 +591,7 @@ EOM
     end
 
     case file_name
-    when /^metadata(.gz)?$/ then
+    when "metadata", "metadata.gz" then
       load_spec entry
     when 'data.tar.gz' then
       verify_gz entry


### PR DESCRIPTION
# Description:
closes https://github.com/rubygems/rubygems/issues/2209 

I'm still figuring out how should i test this...

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
