### PR TITLE
Deprecate for rubygems3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,6 @@ before_script:
   - util/ci before_script
 script:
   - util/ci script
+matrix:
+  allow_failures:
+    - env: TEST_TOOL=bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ script:
   - util/ci script
 matrix:
   allow_failures:
-    - env: TEST_TOOL=bundler
+    - env: "TEST_TOOL=bundler RGV=master"

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -615,7 +615,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
   class << self
     extend Gem::Deprecate
-    deprecate :gunzip, :none, 2018, 12
+    deprecate :gunzip, "Gem::Util.gunzip", 2018, 12
   end
 
   ##
@@ -627,7 +627,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
   class << self
     extend Gem::Deprecate
-    deprecate :gzip, :none, 2018, 12
+    deprecate :gzip, "Gem::Util.gzip", 2018, 12
   end
 
   ##
@@ -639,7 +639,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
   class << self
     extend Gem::Deprecate
-    deprecate :inflate, :none, 2018, 12
+    deprecate :inflate, "Gem::Util.inflate", 2018, 12
   end
 
   ##

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -604,13 +604,18 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
   private_class_method :find_home
 
-  # FIXME deprecate these in 3.0
+  # TODO:  remove in RubyGems 4.0
 
   ##
   # Zlib::GzipReader wrapper that unzips +data+.
 
   def self.gunzip(data)
     Gem::Util.gunzip data
+  end
+
+  class << self
+    extend Gem::Deprecate
+    deprecate :gunzip, :none, 2018, 12
   end
 
   ##
@@ -620,11 +625,21 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     Gem::Util.gzip data
   end
 
+  class << self
+    extend Gem::Deprecate
+    deprecate :gzip, :none, 2018, 12
+  end
+
   ##
   # A Zlib::Inflate#inflate wrapper
 
   def self.inflate(data)
     Gem::Util.inflate data
+  end
+
+  class << self
+    extend Gem::Deprecate
+    deprecate :inflate, :none, 2018, 12
   end
 
   ##
@@ -1225,9 +1240,12 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
   class << self
     ##
-    # TODO remove with RubyGems 3.0
+    # TODO remove with RubyGems 4.0
 
     alias detect_gemdeps use_gemdeps # :nodoc:
+
+    extend Gem::Deprecate
+    deprecate :detect_gemdeps, "Gem.use_gemdeps", 2018, 12
   end
 
   # FIX: Almost everywhere else we use the `def self.` way of defining class

--- a/lib/rubygems/commands/unpack_command.rb
+++ b/lib/rubygems/commands/unpack_command.rb
@@ -193,7 +193,7 @@ command help for an example.
         when 'metadata' then
           metadata = entry.read
         when 'metadata.gz' then
-          metadata = Gem.gunzip entry.read
+          metadata = Gem::Util.gunzip entry.read
         end
       end
     end

--- a/lib/rubygems/dependency_installer.rb
+++ b/lib/rubygems/dependency_installer.rb
@@ -113,7 +113,7 @@ class Gem::DependencyInstaller
 
   ##
   #--
-  # TODO remove, no longer used
+  # TODO remove at RubyGems 4, no longer used
 
   def add_found_dependencies to_do, dependency_list # :nodoc:
     seen = {}
@@ -322,7 +322,7 @@ class Gem::DependencyInstaller
   # Gathers all dependencies necessary for the installation from local and
   # remote sources unless the ignore_dependencies was given.
   #--
-  # TODO remove at RubyGems 3
+  # TODO remove at RubyGems 4
 
   def gather_dependencies # :nodoc:
     specs = @available.all_specs

--- a/lib/rubygems/exceptions.rb
+++ b/lib/rubygems/exceptions.rb
@@ -16,6 +16,8 @@ class Gem::Exception < RuntimeError
   # TODO: remove in RubyGems 4, nobody sets this
 
   attr_accessor :source_exception # :nodoc:
+
+  extend Gem::Deprecate
   deprecate :source_exception, :none, 2018, 12
 end
 

--- a/lib/rubygems/exceptions.rb
+++ b/lib/rubygems/exceptions.rb
@@ -4,6 +4,8 @@
 # Each exception needs a brief description and the scenarios where it is
 # likely to be raised
 
+require 'rubygems/deprecate'
+
 ##
 # Base exception class for RubyGems.  All exception raised by RubyGems are a
 # subclass of this one.
@@ -11,10 +13,10 @@ class Gem::Exception < RuntimeError
 
   ##
   #--
-  # TODO: remove in RubyGems 3, nobody sets this
+  # TODO: remove in RubyGems 4, nobody sets this
 
   attr_accessor :source_exception # :nodoc:
-
+  deprecate :source_exception, :none, 2018, 12
 end
 
 class Gem::CommandLineError < Gem::Exception; end

--- a/lib/rubygems/indexer.rb
+++ b/lib/rubygems/indexer.rb
@@ -347,7 +347,7 @@ class Gem::Indexer
     data = Gem.read_binary path
     compressed_data = Gem.read_binary "#{path}.#{extension}"
 
-    unless data == Gem.inflate(compressed_data) then
+    unless data == Gem::Util.inflate(compressed_data) then
       raise "Compressed file #{compressed_path} does not match uncompressed file #{path}"
     end
   end

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -28,6 +28,8 @@ require 'fileutils'
 
 class Gem::Installer
 
+  extend Gem::Deprecate
+
   ##
   # Paths where env(1) might live.  Some systems are broken and have it in
   # /bin

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -7,6 +7,7 @@
 
 require 'rubygems/command'
 require 'rubygems/exceptions'
+require 'rubygems/deprecate'
 require 'rubygems/package'
 require 'rubygems/ext'
 require 'rubygems/user_interaction'
@@ -777,13 +778,14 @@ TEXT
   ##
   # Logs the build +output+ in +build_dir+, then raises Gem::Ext::BuildError.
   #
-  # TODO:  Delete this for RubyGems 3.  It remains for API compatibility
+  # TODO:  Delete this for RubyGems 4.  It remains for API compatibility
 
   def extension_build_error(build_dir, output, backtrace = nil) # :nodoc:
     builder = Gem::Ext::Builder.new spec, @build_args
 
     builder.build_error build_dir, output, backtrace
   end
+  deprecate :extension_build_error, :none, 2018, 12
 
   ##
   # Reads the file index and extracts each file into the gem directory.

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -293,7 +293,7 @@ class Gem::RemoteFetcher
 
     if data and !head and uri.to_s =~ /\.gz$/
       begin
-        data = Gem.gunzip data
+        data = Gem::Util.gunzip data
       rescue Zlib::GzipFile::Error
         raise FetchError.new("server did not return a valid file", uri.to_s)
       end

--- a/lib/rubygems/server.rb
+++ b/lib/rubygems/server.rb
@@ -492,7 +492,7 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
     specs = Marshal.dump specs
 
     if req.path =~ /\.gz$/ then
-      specs = Gem.gzip specs
+      specs = Gem::Util.gzip specs
       res['content-type'] = 'application/x-gzip'
     else
       res['content-type'] = 'application/octet-stream'
@@ -553,7 +553,7 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
     specs = Marshal.dump specs
 
     if req.path =~ /\.gz$/ then
-      specs = Gem.gzip specs
+      specs = Gem::Util.gzip specs
       res['content-type'] = 'application/x-gzip'
     else
       res['content-type'] = 'application/octet-stream'
@@ -852,7 +852,7 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
     specs = Marshal.dump specs
 
     if req.path =~ /\.gz$/ then
-      specs = Gem.gzip specs
+      specs = Gem::Util.gzip specs
       res['content-type'] = 'application/x-gzip'
     else
       res['content-type'] = 'application/octet-stream'

--- a/lib/rubygems/source.rb
+++ b/lib/rubygems/source.rb
@@ -155,7 +155,7 @@ class Gem::Source
     uri.path << '.rz'
 
     spec = fetcher.fetch_path uri
-    spec = Gem.inflate spec
+    spec = Gem::Util.inflate spec
 
     if update_cache? then
       FileUtils.mkdir_p cache_dir

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -40,6 +40,8 @@ require 'stringio'
 
 class Gem::Specification < Gem::BasicSpecification
 
+  extend Gem::Deprecate
+
   # REFACTOR: Consider breaking out this version stuff into a separate
   # module. There's enough special stuff around it that it may justify
   # a separate class.
@@ -715,6 +717,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Deprecated: You must now specify the executable name to  Gem.bin_path.
 
   attr_writer :default_executable
+  deprecate :default_executable=, :none,       2018, 12
 
   ##
   # Allows deinstallation of gems with legacy platforms.
@@ -1810,6 +1813,7 @@ class Gem::Specification < Gem::BasicSpecification
     end
     result
   end
+  deprecate :default_executable,  :none,       2018, 12
 
   ##
   # The default value for specification attribute +name+
@@ -2018,6 +2022,7 @@ class Gem::Specification < Gem::BasicSpecification
   def has_rdoc # :nodoc:
     true
   end
+  deprecate :has_rdoc,            :none,       2018, 12
 
   ##
   # Deprecated and ignored.
@@ -2027,8 +2032,10 @@ class Gem::Specification < Gem::BasicSpecification
   def has_rdoc= ignored # :nodoc:
     @has_rdoc = true
   end
+  deprecate :has_rdoc=,           :none,       2018, 12
 
   alias :has_rdoc? :has_rdoc # :nodoc:
+  deprecate :has_rdoc?,           :none,       2018, 12
 
   ##
   # True if this gem has files in test_files
@@ -2783,16 +2790,6 @@ class Gem::Specification < Gem::BasicSpecification
     @require_paths
   end
 
-  extend Gem::Deprecate
-
-  # TODO:
-  # deprecate :has_rdoc,            :none,       2011, 10
-  # deprecate :has_rdoc?,           :none,       2011, 10
-  # deprecate :has_rdoc=,           :none,       2011, 10
-  # deprecate :default_executable,  :none,       2011, 10
-  # deprecate :default_executable=, :none,       2011, 10
-  # deprecate :file_name,           :cache_file, 2011, 10
-  # deprecate :full_gem_path,     :cache_file, 2011, 10
 end
 
 # DOC: What is this and why is it here, randomly, at the end of this file?

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -816,7 +816,8 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
 
     spec
   end
-  deprecate :new_spec, :none, 2018, 12
+  # TODO: mark deprecate after replacing util_spec from new_spec
+  # deprecate :new_spec, :none, 2018, 12
 
   def new_default_spec(name, version, deps = nil, *files)
     spec = util_spec name, version, deps

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -97,6 +97,8 @@ end
 
 class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Unit::TestCase)
 
+  extend Gem::Deprecate
+
   attr_accessor :fetcher # :nodoc:
 
   attr_accessor :gem_repo # :nodoc:

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -672,11 +672,13 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
   end
 
   ##
-  # TODO:  remove in RubyGems 3.0
+  # TODO:  remove in RubyGems 4.0
 
   def quick_spec name, version = '2' # :nodoc:
     util_spec name, version
   end
+  deprecate :quick_spec, :util_spec, 2018, 12
+
 
   ##
   # Builds a gem from +spec+ and places it in <tt>File.join @gemhome,
@@ -771,7 +773,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
   ##
   # new_spec is deprecated as it is never used.
   #
-  # TODO:  remove in RubyGems 3.0
+  # TODO:  remove in RubyGems 4.0
 
   def new_spec name, version, deps = nil, *files # :nodoc:
     require 'rubygems/specification'
@@ -812,6 +814,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
 
     spec
   end
+  deprecate :new_spec, :none, 2018, 12
 
   def new_default_spec(name, version, deps = nil, *files)
     spec = util_spec name, version, deps

--- a/lib/rubygems/test_utilities.rb
+++ b/lib/rubygems/test_utilities.rb
@@ -64,7 +64,7 @@ class Gem::FakeFetcher
       data.call
     else
       if path.to_s =~ /gz$/ and not data.nil? and not data.empty? then
-        data = Gem.gunzip data
+        data = Gem::Util.gunzip data
       end
 
       data

--- a/lib/rubygems/user_interaction.rb
+++ b/lib/rubygems/user_interaction.rb
@@ -6,12 +6,15 @@
 #++
 
 require 'rubygems/util'
+require 'rubygems/deprecate'
 
 ##
 # Module that defines the default UserInteraction.  Any class including this
 # module will have access to the +ui+ method that returns the default UI.
 
 module Gem::DefaultUserInteraction
+
+  extend Gem::Deprecate
 
   ##
   # The default UI is a class variable of the singleton class for this
@@ -384,6 +387,7 @@ class Gem::StreamUI
   def debug(statement)
     @errs.puts statement
   end
+  deprecate :debug, :none, 2018, 12
 
   ##
   # Terminate the application with exit code +status+, running any exit

--- a/lib/rubygems/user_interaction.rb
+++ b/lib/rubygems/user_interaction.rb
@@ -14,8 +14,6 @@ require 'rubygems/deprecate'
 
 module Gem::DefaultUserInteraction
 
-  extend Gem::Deprecate
-
   ##
   # The default UI is a class variable of the singleton class for this
   # module.
@@ -172,6 +170,8 @@ end
 # Gem::StreamUI implements a simple stream based user interface.
 
 class Gem::StreamUI
+
+  extend Gem::Deprecate
 
   ##
   # The input stream

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -387,7 +387,7 @@ class TestGem < Gem::TestCase
     assert_equal %w[https://rubygems.org/], Gem.default_sources
   end
 
-  def test_self_detect_gemdeps
+  def test_self_use_gemdeps
     skip 'Insecure operation - chdir' if RUBY_VERSION <= "1.8.7"
     rubygems_gemdeps, ENV['RUBYGEMS_GEMDEPS'] = ENV['RUBYGEMS_GEMDEPS'], '-'
 
@@ -399,7 +399,7 @@ class TestGem < Gem::TestCase
     begin
       Dir.chdir 'detect/a/b'
 
-      assert_equal add_bundler_full_name([]), Gem.detect_gemdeps.map(&:full_name)
+      assert_equal add_bundler_full_name([]), Gem.use_gemdeps.map(&:full_name)
     ensure
       Dir.chdir @tempdir
     end
@@ -1450,12 +1450,12 @@ class TestGem < Gem::TestCase
 
     ENV['RUBYGEMS_GEMDEPS'] = path
 
-    Gem.detect_gemdeps
+    Gem.use_gemdeps
 
     assert_equal add_bundler_full_name(%W(a-1 b-1 c-1)), loaded_spec_names
   end
 
-  def test_auto_activation_of_detected_gemdeps_file
+  def test_auto_activation_of_used_gemdeps_file
     skip 'Insecure operation - chdir' if RUBY_VERSION <= "1.8.7"
     util_clear_gems
 
@@ -1476,7 +1476,7 @@ class TestGem < Gem::TestCase
     ENV['RUBYGEMS_GEMDEPS'] = "-"
 
     expected_specs = [a, b, (Gem::USE_BUNDLER_FOR_GEMDEPS || nil) && util_spec("bundler", Bundler::VERSION), c].compact
-    assert_equal expected_specs, Gem.detect_gemdeps.sort_by { |s| s.name }
+    assert_equal expected_specs, Gem.use_gemdeps.sort_by { |s| s.name }
   end
 
   LIB_PATH = File.expand_path "../../../lib".dup.untaint, __FILE__.dup.untaint

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1214,7 +1214,7 @@ class TestGem < Gem::TestCase
     input = "\x1F\x8B\b\0\xED\xA3\x1AQ\0\x03\xCBH" +
             "\xCD\xC9\xC9\a\0\x86\xA6\x106\x05\0\0\0"
 
-    output = Gem.gunzip input
+    output = Gem::Util.gunzip input
 
     assert_equal 'hello', output
 
@@ -1226,7 +1226,7 @@ class TestGem < Gem::TestCase
   def test_self_gzip
     input = 'hello'
 
-    output = Gem.gzip input
+    output = Gem::Util.gzip input
 
     zipped = StringIO.new output
 

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -607,7 +607,7 @@ class TestGemPackage < Gem::Package::TarTestCase
   end
 
   def test_load_spec
-    entry = StringIO.new Gem.gzip @spec.to_yaml
+    entry = StringIO.new Gem::Util.gzip @spec.to_yaml
     def entry.full_name() 'metadata.gz' end
 
     package = Gem::Package.new 'nonexistent.gem'
@@ -637,7 +637,7 @@ class TestGemPackage < Gem::Package::TarTestCase
     data_tgz = data_tgz.string
 
     gem = util_tar do |tar|
-      metadata_gz = Gem.gzip @spec.to_yaml
+      metadata_gz = Gem::Util.gzip @spec.to_yaml
 
       tar.add_file 'metadata.gz', 0444 do |io|
         io.write metadata_gz
@@ -684,7 +684,7 @@ class TestGemPackage < Gem::Package::TarTestCase
     data_tgz = data_tgz.string
 
     gem = util_tar do |tar|
-      metadata_gz = Gem.gzip @spec.to_yaml
+      metadata_gz = Gem::Util.gzip @spec.to_yaml
 
       tar.add_file 'metadata.gz', 0444 do |io|
         io.write metadata_gz
@@ -721,7 +721,7 @@ class TestGemPackage < Gem::Package::TarTestCase
 
   def test_verify_corrupt
     tf = Tempfile.open 'corrupt' do |io|
-      data = Gem.gzip 'a' * 10
+      data = Gem::Util.gzip 'a' * 10
       io.write \
         tar_file_header('metadata.gz', "\000x", 0644, data.length, Time.now)
       io.write data
@@ -845,7 +845,7 @@ class TestGemPackage < Gem::Package::TarTestCase
         build.add_contents gem
 
         # write bogus data.tar.gz to foil signature
-        bogus_data = Gem.gzip 'hello'
+        bogus_data = Gem::Util.gzip 'hello'
         fake_signer = Class.new do
           def digest_name; 'SHA512'; end
           def digest_algorithm; Digest(:SHA512); end

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -541,7 +541,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     @fetcher = fetcher
 
     def fetcher.fetch_http(uri, mtime, head = nil)
-      Gem.gzip 'foo'
+      Gem::Util.gzip 'foo'
     end
 
     assert_equal 'foo', fetcher.fetch_path(@uri + 'foo.gz')

--- a/test/rubygems/test_gem_security_policy.rb
+++ b/test/rubygems/test_gem_security_policy.rb
@@ -450,7 +450,7 @@ class TestGemSecurityPolicy < Gem::TestCase
 
     @spec.cert_chain = [PUBLIC_CERT.to_s]
 
-    metadata_gz = Gem.gzip @spec.to_yaml
+    metadata_gz = Gem::Util.gzip @spec.to_yaml
 
     package = Gem::Package.new 'nonexistent.gem'
     package.checksums[Gem::Security::DIGEST_NAME] = {}
@@ -473,7 +473,7 @@ class TestGemSecurityPolicy < Gem::TestCase
 
     @spec.cert_chain = [PUBLIC_CERT.to_s]
 
-    metadata_gz = Gem.gzip @spec.to_yaml
+    metadata_gz = Gem::Util.gzip @spec.to_yaml
 
     package = Gem::Package.new 'nonexistent.gem'
     package.checksums[Gem::Security::DIGEST_NAME] = {}
@@ -502,7 +502,7 @@ class TestGemSecurityPolicy < Gem::TestCase
 
     @spec.cert_chain = [PUBLIC_CERT.to_s]
 
-    metadata_gz = Gem.gzip @spec.to_yaml
+    metadata_gz = Gem::Util.gzip @spec.to_yaml
 
     package = Gem::Package.new 'nonexistent.gem'
     package.checksums[Gem::Security::DIGEST_NAME] = {}

--- a/test/rubygems/test_gem_server.rb
+++ b/test/rubygems/test_gem_server.rb
@@ -127,7 +127,7 @@ class TestGemServer < Gem::TestCase
     assert_match %r| \d\d:\d\d:\d\d |, @res['date']
     assert_equal 'application/x-gzip', @res['content-type']
     assert_equal [['a', Gem::Version.new(2), Gem::Platform::RUBY]],
-                 Marshal.load(Gem.gunzip(@res.body))
+                 Marshal.load(Gem::Util.gunzip(@res.body))
   end
 
   def test_listen
@@ -177,7 +177,7 @@ class TestGemServer < Gem::TestCase
     assert_match %r| \d\d:\d\d:\d\d |, @res['date']
     assert_equal 'application/x-gzip', @res['content-type']
     assert_equal [['a', v('3.a'), Gem::Platform::RUBY]],
-                 Marshal.load(Gem.gunzip(@res.body))
+                 Marshal.load(Gem::Util.gunzip(@res.body))
   end
 
   def test_quick_gemdirs
@@ -236,7 +236,7 @@ class TestGemServer < Gem::TestCase
     assert @res['date']
     assert_equal 'application/x-deflate', @res['content-type']
 
-    spec = Marshal.load Gem.inflate(@res.body)
+    spec = Marshal.load Gem::Util.inflate(@res.body)
     assert_equal 'a', spec.name
     assert_equal Gem::Version.new(1), spec.version
   end
@@ -253,7 +253,7 @@ class TestGemServer < Gem::TestCase
     assert @res['date']
     assert_equal 'application/x-deflate', @res['content-type']
 
-    spec = Marshal.load Gem.inflate(@res.body)
+    spec = Marshal.load Gem::Util.inflate(@res.body)
     assert_equal 'a', spec.name
     assert_equal Gem::Version.new(1), spec.version
     assert_equal Gem::Platform.local, spec.platform
@@ -269,7 +269,7 @@ class TestGemServer < Gem::TestCase
     assert @res['date']
     assert_equal 'application/x-deflate', @res['content-type']
 
-    spec = Marshal.load Gem.inflate(@res.body)
+    spec = Marshal.load Gem::Util.inflate(@res.body)
     assert_equal 'a', spec.name
     assert_equal v('3.a'), spec.version
   end
@@ -286,7 +286,7 @@ class TestGemServer < Gem::TestCase
     assert @res['date']
     assert_equal 'application/x-deflate', @res['content-type']
 
-    spec = Marshal.load Gem.inflate(@res.body)
+    spec = Marshal.load Gem::Util.inflate(@res.body)
     assert_equal 'a-b', spec.name
     assert_equal v('3.a'), spec.version
   end
@@ -303,7 +303,7 @@ class TestGemServer < Gem::TestCase
     assert @res['date']
     assert_equal 'application/x-deflate', @res['content-type']
 
-    spec = Marshal.load Gem.inflate(@res.body)
+    spec = Marshal.load Gem::Util.inflate(@res.body)
     assert_equal 'a-b-1', spec.name
     assert_equal v('3.a'), spec.version
   end
@@ -571,7 +571,7 @@ class TestGemServer < Gem::TestCase
     assert_equal [['a', Gem::Version.new(1), Gem::Platform::RUBY],
                   ['a', Gem::Version.new(2), Gem::Platform::RUBY],
                   ['a', v('3.a'), Gem::Platform::RUBY]],
-                 Marshal.load(Gem.gunzip(@res.body))
+                 Marshal.load(Gem::Util.gunzip(@res.body))
   end
 
   def test_uri_encode

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1133,7 +1133,7 @@ dependencies: []
   def test_handles_private_null_type
     path = File.join DATA_PATH, "null-type.gemspec.rz"
 
-    data = Marshal.load Gem.inflate(Gem.read_binary(path))
+    data = Marshal.load Gem::Util.inflate(Gem.read_binary(path))
 
     assert_nil data.rubyforge_project
   end


### PR DESCRIPTION
# Description:

I've marked deprecated methods without `Gem::Deprecate#deprecate`. We're going to remove it in RubyGems 4(not 3)
______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
