### PR TITLE
Remove syck support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,10 +4,6 @@ require 'rubygems'
 require 'rubygems/package_task'
 require "rake/testtask"
 
-if ENV['YAML'] == "syck"
-  ENV['TEST_SYCK'] = "1"
-end
-
 begin
   require 'psych'
 rescue ::LoadError

--- a/lib/rubygems/package/old.rb
+++ b/lib/rubygems/package/old.rb
@@ -144,15 +144,9 @@ class Gem::Package::Old < Gem::Package
       end
     end
 
-    yaml_error = if YAML.const_defined?(:ENGINE) && YAML::ENGINE.yamler == 'syck' then
-                   YAML::ParseError
-                 else
-                   YAML::SyntaxError
-                 end
-
     begin
       @spec = Gem::Specification.from_yaml yaml
-    rescue yaml_error
+    rescue YAML::SyntaxError
       raise Gem::Exception, "Failed to parse gem specification out of gem file"
     end
   rescue ArgumentError

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2620,32 +2620,23 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   def to_yaml(opts = {}) # :nodoc:
-    if (YAML.const_defined?(:ENGINE) && !YAML::ENGINE.syck?) ||
-        (defined?(Psych) && YAML == Psych) then
-      # Because the user can switch the YAML engine behind our
-      # back, we have to check again here to make sure that our
-      # psych code was properly loaded, and load it if not.
-      unless Gem.const_defined?(:NoAliasYAMLTree)
-        require 'rubygems/psych_tree'
-      end
-
-      builder = Gem::NoAliasYAMLTree.create
-      builder << self
-      ast = builder.tree
-
-      io = StringIO.new
-      io.set_encoding Encoding::UTF_8 if Object.const_defined? :Encoding
-
-      Psych::Visitors::Emitter.new(io).accept(ast)
-
-      io.string.gsub(/ !!null \n/, " \n")
-    else
-      YAML.quick_emit object_id, opts do |out|
-        out.map taguri, to_yaml_style do |map|
-          encode_with map
-        end
-      end
+    # Because the user can switch the YAML engine behind our
+    # back, we have to check again here to make sure that our
+    # psych code was properly loaded, and load it if not.
+    unless Gem.const_defined?(:NoAliasYAMLTree)
+      require 'rubygems/psych_tree'
     end
+
+    builder = Gem::NoAliasYAMLTree.create
+    builder << self
+    ast = builder.tree
+
+    io = StringIO.new
+    io.set_encoding Encoding::UTF_8 if Object.const_defined? :Encoding
+
+    Psych::Visitors::Emitter.new(io).accept(ast)
+
+    io.string.gsub(/ !!null \n/, " \n")
   end
 
   ##


### PR DESCRIPTION
# Description:

Removed code related the Syck support. Because RubyGems 3 support > Ruby 2.1. We don't need to care the Syck engine.

______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
