### PR TITLE
Removed needless condition for Encoding

### DIFF
--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -560,8 +560,7 @@ abort "#{deprecation_message}"
       if File.exist? release_notes then
         history = File.read release_notes
 
-        history.force_encoding Encoding::UTF_8 if
-          Object.const_defined? :Encoding
+        history.force_encoding Encoding::UTF_8
 
         history = history.sub(/^# coding:.*?(?=^=)/m, '')
 

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -486,8 +486,7 @@ EOM
     when 'metadata.gz' then
       args = [entry]
       args << { :external_encoding => Encoding::UTF_8 } if
-        Object.const_defined?(:Encoding) &&
-          Zlib::GzipReader.method(:wrap).arity != 1
+        Zlib::GzipReader.method(:wrap).arity != 1
 
       Zlib::GzipReader.wrap(*args) do |gzio|
         @spec = Gem::Specification.from_yaml gzio.read

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1185,11 +1185,7 @@ class Gem::Specification < Gem::BasicSpecification
     file = file.dup.untaint
     return unless File.file?(file)
 
-    code = if defined? Encoding
-             File.read file, :mode => 'r:UTF-8:-'
-           else
-             File.read file
-           end
+    code = File.read file, :mode => 'r:UTF-8:-'
 
     code.untaint
 
@@ -2634,7 +2630,7 @@ class Gem::Specification < Gem::BasicSpecification
       ast = builder.tree
 
       io = StringIO.new
-      io.set_encoding Encoding::UTF_8 if Object.const_defined? :Encoding
+      io.set_encoding Encoding::UTF_8
 
       Psych::Visitors::Emitter.new(io).accept(ast)
 

--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -8,12 +8,8 @@ class Gem::StubSpecification < Gem::BasicSpecification
   # :nodoc:
   PREFIX = "# stub: "
 
-  OPEN_MODE = # :nodoc:
-    if Object.const_defined? :Encoding then
-      'r:UTF-8:-'
-    else
-      'r'
-    end
+  # :nodoc:
+  OPEN_MODE = 'r:UTF-8:-'
 
   class StubLine # :nodoc: all
     attr_reader :name, :version, :platform, :require_paths, :extensions,

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -595,7 +595,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
   def mu_pp(obj)
     s = String.new
     s = PP.pp obj, s
-    s = s.force_encoding(Encoding.default_external) if defined? Encoding
+    s = s.force_encoding(Encoding.default_external)
     s.chomp
   end
 

--- a/lib/rubygems/util.rb
+++ b/lib/rubygems/util.rb
@@ -15,7 +15,7 @@ module Gem::Util
     data = StringIO.new(data, 'r')
 
     unzipped = Zlib::GzipReader.new(data).read
-    unzipped.force_encoding Encoding::BINARY if Object.const_defined? :Encoding
+    unzipped.force_encoding Encoding::BINARY
     unzipped
   end
 
@@ -26,7 +26,7 @@ module Gem::Util
     require 'zlib'
     require 'stringio'
     zipped = StringIO.new(String.new, 'w')
-    zipped.set_encoding Encoding::BINARY if Object.const_defined? :Encoding
+    zipped.set_encoding Encoding::BINARY
 
     Zlib::GzipWriter.wrap zipped do |io| io.write data end
 

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1286,9 +1286,6 @@ class TestGem < Gem::TestCase
     output = Gem::Util.gunzip input
 
     assert_equal 'hello', output
-
-    return unless Object.const_defined? :Encoding
-
     assert_equal Encoding::BINARY, output.encoding
   end
 
@@ -1300,9 +1297,6 @@ class TestGem < Gem::TestCase
     zipped = StringIO.new output
 
     assert_equal 'hello', Zlib::GzipReader.new(zipped).read
-
-    return unless Object.const_defined? :Encoding
-
     assert_equal Encoding::BINARY, output.encoding
   end
 

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -207,11 +207,8 @@ class TestGemCommandsSetupCommand < Gem::TestCase
   end
 
   def test_show_release_notes
-    @default_external = nil
-    if Object.const_defined? :Encoding
-      @default_external = @ui.outs.external_encoding
-      @ui.outs.set_encoding Encoding::US_ASCII
-    end
+    @default_external = @ui.outs.external_encoding
+    @ui.outs.set_encoding Encoding::US_ASCII
 
     @cmd.options[:previous_version] = Gem::Version.new '2.0.2'
 
@@ -256,7 +253,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     EXPECTED
 
     output = @ui.output
-    output.force_encoding Encoding::UTF_8 if Object.const_defined? :Encoding
+    output.force_encoding Encoding::UTF_8
 
     assert_equal expected, output
   ensure

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1010,7 +1010,6 @@ dependencies: []
     assert_equal @a2, spec
   end
 
-  if defined?(Encoding)
   def test_self_load_utf8_with_ascii_encoding
     int_enc = Encoding.default_internal
     silence_warnings { Encoding.default_internal = 'US-ASCII' }
@@ -1030,7 +1029,6 @@ dependencies: []
     assert_equal spec2, spec
   ensure
     silence_warnings { Encoding.default_internal = int_enc }
-  end
   end
 
   def test_self_load_legacy_ruby


### PR DESCRIPTION
# Description:

 It's always provided after Ruby 1.9+
______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
