### PR TITLE
prefer to use util_spec in `Gem::TestCase`

### DIFF
--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -31,11 +31,11 @@ class TestGem < Gem::TestCase
 
   def test_self_finish_resolve
     save_loaded_features do
-      a1 = new_spec "a", "1", "b" => "> 0"
-      b1 = new_spec "b", "1", "c" => ">= 1"
-      b2 = new_spec "b", "2", "c" => ">= 2"
-      c1 = new_spec "c", "1"
-      c2 = new_spec "c", "2"
+      a1 = util_spec "a", "1", "b" => "> 0"
+      b1 = util_spec "b", "1", "c" => ">= 1"
+      b2 = util_spec "b", "2", "c" => ">= 2"
+      c1 = util_spec "c", "1"
+      c2 = util_spec "c", "2"
 
       install_specs c1, c2, b1, b2, a1
 
@@ -53,13 +53,13 @@ class TestGem < Gem::TestCase
 
   def test_self_finish_resolve_wtf
     save_loaded_features do
-      a1 = new_spec "a", "1", "b" => "> 0", "d" => "> 0"    # this
-      b1 = new_spec "b", "1", { "c" => ">= 1" }, "lib/b.rb" # this
-      b2 = new_spec "b", "2", { "c" => ">= 2" }, "lib/b.rb"
-      c1 = new_spec "c", "1"                                # this
-      c2 = new_spec "c", "2"
-      d1 = new_spec "d", "1", { "c" => "< 2" },  "lib/d.rb"
-      d2 = new_spec "d", "2", { "c" => "< 2" },  "lib/d.rb" # this
+      a1 = util_spec "a", "1", "b" => "> 0", "d" => "> 0"    # this
+      b1 = util_spec "b", "1", { "c" => ">= 1" }, "lib/b.rb" # this
+      b2 = util_spec "b", "2", { "c" => ">= 2" }, "lib/b.rb"
+      c1 = util_spec "c", "1"                                # this
+      c2 = util_spec "c", "2"
+      d1 = util_spec "d", "1", { "c" => "< 2" },  "lib/d.rb"
+      d2 = util_spec "d", "2", { "c" => "< 2" },  "lib/d.rb" # this
 
       install_specs c1, c2, b1, b2, d1, d2, a1
 
@@ -77,11 +77,11 @@ class TestGem < Gem::TestCase
 
   def test_self_finish_resolve_respects_loaded_specs
     save_loaded_features do
-      a1 = new_spec "a", "1", "b" => "> 0"
-      b1 = new_spec "b", "1", "c" => ">= 1"
-      b2 = new_spec "b", "2", "c" => ">= 2"
-      c1 = new_spec "c", "1"
-      c2 = new_spec "c", "2"
+      a1 = util_spec "a", "1", "b" => "> 0"
+      b1 = util_spec "b", "1", "c" => ">= 1"
+      b2 = util_spec "b", "2", "c" => ">= 2"
+      c1 = util_spec "c", "1"
+      c2 = util_spec "c", "2"
 
       install_specs c1, c2, b1, b2, a1
 
@@ -209,7 +209,7 @@ class TestGem < Gem::TestCase
 
   def test_require_does_not_glob
     save_loaded_features do
-      a1 = new_spec "a", "1", nil, "lib/a1.rb"
+      a1 = util_spec "a", "1", nil, "lib/a1.rb"
 
       install_specs a1
 
@@ -1263,7 +1263,7 @@ class TestGem < Gem::TestCase
       a = util_spec "a", "1"
       b = util_spec "b", "1", "c" => nil
       c = util_spec "c", "2"
-      d =  new_spec "d", "1", {'e' => '= 1'}, "lib/d.rb"
+      d =  util_spec "d", "1", {'e' => '= 1'}, "lib/d.rb"
       e = util_spec "e", "1"
 
       install_specs a, c, b, e, d
@@ -1423,8 +1423,8 @@ class TestGem < Gem::TestCase
     write_file File.join(@tempdir, 'lib', "g.rb") { |fp| fp.puts "" }
     write_file File.join(@tempdir, 'lib', 'm.rb') { |fp| fp.puts "" }
 
-    g = new_spec 'g', '1', nil, "lib/g.rb"
-    m = new_spec 'm', '1', nil, "lib/m.rb"
+    g = util_spec 'g', '1', nil, "lib/g.rb"
+    m = util_spec 'm', '1', nil, "lib/m.rb"
 
     install_gem g, :install_dir => Gem.dir
     m0 = install_gem m, :install_dir => Gem.dir
@@ -1479,8 +1479,8 @@ class TestGem < Gem::TestCase
     write_file File.join(@tempdir, 'lib', "g.rb") { |fp| fp.puts "" }
     write_file File.join(@tempdir, 'lib', 'm.rb') { |fp| fp.puts "" }
 
-    g = new_spec 'g', '1', nil, "lib/g.rb"
-    m = new_spec 'm', '1', nil, "lib/m.rb"
+    g = util_spec 'g', '1', nil, "lib/g.rb"
+    m = util_spec 'm', '1', nil, "lib/m.rb"
 
     install_gem g, :install_dir => Gem.dir
     install_gem m, :install_dir => Gem.dir
@@ -1497,9 +1497,9 @@ class TestGem < Gem::TestCase
   def test_auto_activation_of_specific_gemdeps_file
     util_clear_gems
 
-    a = new_spec "a", "1", nil, "lib/a.rb"
-    b = new_spec "b", "1", nil, "lib/b.rb"
-    c = new_spec "c", "1", nil, "lib/c.rb"
+    a = util_spec "a", "1", nil, "lib/a.rb"
+    b = util_spec "b", "1", nil, "lib/b.rb"
+    c = util_spec "c", "1", nil, "lib/c.rb"
 
     install_specs a, b, c
 
@@ -1522,9 +1522,9 @@ class TestGem < Gem::TestCase
     skip 'Insecure operation - chdir' if RUBY_VERSION <= "1.8.7"
     util_clear_gems
 
-    a = new_spec "a", "1", nil, "lib/a.rb"
-    b = new_spec "b", "1", nil, "lib/b.rb"
-    c = new_spec "c", "1", nil, "lib/c.rb"
+    a = util_spec "a", "1", nil, "lib/a.rb"
+    b = util_spec "b", "1", nil, "lib/b.rb"
+    c = util_spec "c", "1", nil, "lib/c.rb"
 
     install_specs a, b, c
 
@@ -1559,9 +1559,9 @@ class TestGem < Gem::TestCase
   def test_looks_for_gemdeps_files_automatically_on_start
     util_clear_gems
 
-    a = new_spec "a", "1", nil, "lib/a.rb"
-    b = new_spec "b", "1", nil, "lib/b.rb"
-    c = new_spec "c", "1", nil, "lib/c.rb"
+    a = util_spec "a", "1", nil, "lib/a.rb"
+    b = util_spec "b", "1", nil, "lib/b.rb"
+    c = util_spec "c", "1", nil, "lib/c.rb"
 
     install_specs a, b, c
 
@@ -1600,9 +1600,9 @@ class TestGem < Gem::TestCase
   def test_looks_for_gemdeps_files_automatically_on_start_in_parent_dir
     util_clear_gems
 
-    a = new_spec "a", "1", nil, "lib/a.rb"
-    b = new_spec "b", "1", nil, "lib/b.rb"
-    c = new_spec "c", "1", nil, "lib/c.rb"
+    a = util_spec "a", "1", nil, "lib/a.rb"
+    b = util_spec "b", "1", nil, "lib/b.rb"
+    c = util_spec "c", "1", nil, "lib/c.rb"
 
     install_specs a, b, c
 

--- a/test/rubygems/test_gem_commands_dependency_command.rb
+++ b/test/rubygems/test_gem_commands_dependency_command.rb
@@ -29,7 +29,7 @@ class TestGemCommandsDependencyCommand < Gem::TestCase
   end
 
   def test_execute_no_args
-    install_specs new_spec 'x', '2'
+    install_specs util_spec 'x', '2'
 
     spec_fetcher do |fetcher|
       fetcher.spec 'a', 1
@@ -171,7 +171,7 @@ ERROR:  Only reverse dependencies for local gems are supported.
   end
 
   def test_execute_remote
-    install_specs new_spec 'bar', '2'
+    install_specs util_spec 'bar', '2'
 
     spec_fetcher do |fetcher|
       fetcher.spec 'foo', 2, 'bar' => '> 1'

--- a/test/rubygems/test_gem_commands_specification_command.rb
+++ b/test/rubygems/test_gem_commands_specification_command.rb
@@ -105,7 +105,7 @@ class TestGemCommandsSpecificationCommand < Gem::TestCase
   end
 
   def test_execute_field
-    foo = new_spec 'foo', '2'
+    foo = util_spec 'foo', '2'
 
     install_specs foo
 
@@ -137,7 +137,7 @@ class TestGemCommandsSpecificationCommand < Gem::TestCase
   end
 
   def test_execute_marshal
-    foo = new_spec 'foo', '2'
+    foo = util_spec 'foo', '2'
 
     install_specs foo
 

--- a/test/rubygems/test_gem_dependency_installer.rb
+++ b/test/rubygems/test_gem_dependency_installer.rb
@@ -431,7 +431,7 @@ class TestGemDependencyInstaller < Gem::TestCase
       EXTCONF_RB
     end
 
-    e1 = new_spec 'e', '1', nil, 'extconf.rb' do |s|
+    e1 = util_spec 'e', '1', nil, 'extconf.rb' do |s|
       s.extensions << 'extconf.rb'
     end
     e1_gem = File.join @tempdir, 'gems', "#{e1.full_name}.gem"

--- a/test/rubygems/test_gem_dependency_list.rb
+++ b/test/rubygems/test_gem_dependency_list.rb
@@ -11,7 +11,7 @@ class TestGemDependencyList < Gem::TestCase
 
     @deplist = Gem::DependencyList.new
 
-    # TODO: switch to new_spec
+    # TODO: switch to util_spec
     @a1 = util_spec 'a', '1'
     @a2 = util_spec 'a', '2'
     @a3 = util_spec 'a', '3'
@@ -144,13 +144,13 @@ class TestGemDependencyList < Gem::TestCase
   end
 
   def test_why_not_ok_eh_old_dependency
-    a  = new_spec 'a', '1',
+    a  = util_spec 'a', '1',
                   'b' => '~> 1.0'
 
-    b0 = new_spec 'b', '1.0',
+    b0 = util_spec 'b', '1.0',
                   'd' => '>= 0'
 
-    b1 = new_spec 'b', '1.1'
+    b1 = util_spec 'b', '1.1'
 
     util_clear_gems
 

--- a/test/rubygems/test_gem_resolver.rb
+++ b/test/rubygems/test_gem_resolver.rb
@@ -662,12 +662,12 @@ class TestGemResolver < Gem::TestCase
   end
 
   def test_second_level_backout
-    b1 = new_spec "b", "1", { "c" => ">= 1" }, "lib/b.rb"
-    b2 = new_spec "b", "2", { "c" => ">= 2" }, "lib/b.rb"
-    c1 = new_spec "c", "1"
-    c2 = new_spec "c", "2"
-    d1 = new_spec "d", "1", { "c" => "< 2" },  "lib/d.rb"
-    d2 = new_spec "d", "2", { "c" => "< 2" },  "lib/d.rb"
+    b1 = util_spec "b", "1", { "c" => ">= 1" }, "lib/b.rb"
+    b2 = util_spec "b", "2", { "c" => ">= 2" }, "lib/b.rb"
+    c1 = util_spec "c", "1"
+    c2 = util_spec "c", "2"
+    d1 = util_spec "d", "1", { "c" => "< 2" },  "lib/d.rb"
+    d2 = util_spec "d", "2", { "c" => "< 2" },  "lib/d.rb"
 
     s = set(b1, b2, c1, c2, d1, d2)
 
@@ -684,11 +684,11 @@ class TestGemResolver < Gem::TestCase
     sourceB = Gem::Source.new 'http://example.com/b'
     sourceC = Gem::Source.new 'http://example.com/c'
 
-    spec_A_1 = new_spec 'some-dep', '0.0.1'
-    spec_A_2 = new_spec 'some-dep', '1.0.0'
-    spec_B_1 = new_spec 'some-dep', '0.0.1'
-    spec_B_2 = new_spec 'some-dep', '0.0.2'
-    spec_C_1 = new_spec 'some-dep', '0.1.0'
+    spec_A_1 = util_spec 'some-dep', '0.0.1'
+    spec_A_2 = util_spec 'some-dep', '1.0.0'
+    spec_B_1 = util_spec 'some-dep', '0.0.1'
+    spec_B_2 = util_spec 'some-dep', '0.0.2'
+    spec_C_1 = util_spec 'some-dep', '0.1.0'
 
     set = StaticSet.new [
       Gem::Resolver::SpecSpecification.new(nil, spec_B_1, sourceB),

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -721,11 +721,11 @@ end
     spec.version = '1'
     spec.specification_version = @current_version + 1
 
-    util_spec = Marshal.load Marshal.dump(spec)
+    load_spec = Marshal.load Marshal.dump(spec)
 
-    assert_equal 'a', util_spec.name
-    assert_equal Gem::Version.new(1), util_spec.version
-    assert_equal @current_version, util_spec.specification_version
+    assert_equal 'a', load_spec.name
+    assert_equal Gem::Version.new(1), load_spec.version
+    assert_equal @current_version, load_spec.specification_version
   end
 
   def test_self_from_yaml
@@ -743,12 +743,12 @@ end
     yaml = @a1.to_yaml
     yaml.sub!(/^date:.*/, "date: 2011-04-26 00:00:00.000000000Z")
 
-    util_spec = with_syck do
+    spec = with_syck do
       Gem::Specification.from_yaml yaml
     end
 
     assert_kind_of Time, @a1.date
-    assert_kind_of Time, util_spec.date
+    assert_kind_of Time, spec.date
   end
 
   def test_self_from_yaml_syck_default_key_bug
@@ -778,14 +778,14 @@ test_files: []
 bindir:
     YAML
 
-    util_spec = with_syck do
+    spec = with_syck do
       Gem::Specification.from_yaml yaml
     end
 
-    op = util_spec.dependencies.first.requirement.requirements.first.first
+    op = spec.dependencies.first.requirement.requirements.first.first
     refute_kind_of YAML::Syck::DefaultKey, op
 
-    refute_match %r%DefaultKey%, util_spec.to_ruby
+    refute_match %r%DefaultKey%, spec.to_ruby
   end
 
   def test_self_from_yaml_cleans_up_defaultkey
@@ -814,12 +814,12 @@ test_files: []
 bindir:
     YAML
 
-    util_spec = Gem::Specification.from_yaml yaml
+    spec = Gem::Specification.from_yaml yaml
 
-    op = util_spec.dependencies.first.requirement.requirements.first.first
+    op = spec.dependencies.first.requirement.requirements.first.first
     refute_kind_of YAML::Syck::DefaultKey, op
 
-    refute_match %r%DefaultKey%, util_spec.to_ruby
+    refute_match %r%DefaultKey%, spec.to_ruby
   end
 
   def test_self_from_yaml_cleans_up_defaultkey_from_newer_192
@@ -848,12 +848,12 @@ test_files: []
 bindir:
     YAML
 
-    util_spec = Gem::Specification.from_yaml yaml
+    spec = Gem::Specification.from_yaml yaml
 
-    op = util_spec.dependencies.first.requirement.requirements.first.first
+    op = spec.dependencies.first.requirement.requirements.first.first
     refute_kind_of YAML::Syck::DefaultKey, op
 
-    refute_match %r%DefaultKey%, util_spec.to_ruby
+    refute_match %r%DefaultKey%, spec.to_ruby
   end
 
   def test_self_from_yaml_cleans_up_Date_objects
@@ -903,9 +903,9 @@ requirements: []
 dependencies: []
     YAML
 
-    util_spec = Gem::Specification.from_yaml yaml
+    spec = Gem::Specification.from_yaml yaml
 
-    assert_kind_of Time, util_spec.date
+    assert_kind_of Time, spec.date
   end
 
   def test_self_load
@@ -1202,57 +1202,57 @@ dependencies: []
       s.add_dependency 'some_gem'
     end
 
-    util_spec = spec.dup
+    dup_spec = spec.dup
 
     assert_equal "blah", spec.name
-    assert_same  spec.name, util_spec.name
+    assert_same  spec.name, dup_spec.name
 
     assert_equal "1.3.5", spec.version.to_s
-    assert_same spec.version, util_spec.version
+    assert_same spec.version, dup_spec.version
 
     assert_equal Gem::Platform::RUBY, spec.platform
-    assert_same spec.platform, util_spec.platform
+    assert_same spec.platform, dup_spec.platform
 
     assert_equal 'summary', spec.summary
-    assert_same spec.summary, util_spec.summary
+    assert_same spec.summary, dup_spec.summary
 
     assert_equal %w[README.txt bin/exec ext/extconf.rb lib/file.rb
                     test/file.rb].sort,
                  spec.files
-    refute_same spec.files, util_spec.files, 'files'
+    refute_same spec.files, dup_spec.files, 'files'
 
     assert_equal %w[test/file.rb], spec.test_files
-    refute_same spec.test_files, util_spec.test_files, 'test_files'
+    refute_same spec.test_files, dup_spec.test_files, 'test_files'
 
     assert_equal %w[--foo], spec.rdoc_options
-    refute_same spec.rdoc_options, util_spec.rdoc_options, 'rdoc_options'
+    refute_same spec.rdoc_options, dup_spec.rdoc_options, 'rdoc_options'
 
     assert_equal %w[README.txt], spec.extra_rdoc_files
-    refute_same spec.extra_rdoc_files, util_spec.extra_rdoc_files,
+    refute_same spec.extra_rdoc_files, dup_spec.extra_rdoc_files,
                 'extra_rdoc_files'
 
     assert_equal %w[exec], spec.executables
-    refute_same spec.executables, util_spec.executables, 'executables'
+    refute_same spec.executables, dup_spec.executables, 'executables'
 
     assert_equal %w[ext/extconf.rb], spec.extensions
-    refute_same spec.extensions, util_spec.extensions, 'extensions'
+    refute_same spec.extensions, dup_spec.extensions, 'extensions'
 
     assert_equal %w[requirement], spec.requirements
-    refute_same spec.requirements, util_spec.requirements, 'requirements'
+    refute_same spec.requirements, dup_spec.requirements, 'requirements'
 
     assert_equal [Gem::Dependency.new('some_gem', Gem::Requirement.default)],
                  spec.dependencies
-    refute_same spec.dependencies, util_spec.dependencies, 'dependencies'
+    refute_same spec.dependencies, dup_spec.dependencies, 'dependencies'
 
     assert_equal 'bin', spec.bindir
-    assert_same spec.bindir, util_spec.bindir
+    assert_same spec.bindir, dup_spec.bindir
 
     assert_equal '>= 0', spec.required_ruby_version.to_s
-    assert_same spec.required_ruby_version, util_spec.required_ruby_version
+    assert_same spec.required_ruby_version, dup_spec.required_ruby_version
 
     assert_equal '>= 0', spec.required_rubygems_version.to_s
     assert_same spec.required_rubygems_version,
-                util_spec.required_rubygems_version
+                dup_spec.required_rubygems_version
   end
 
   def test_initialize_copy_broken

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -101,7 +101,7 @@ end
   end
 
   def test_self_find_active_stub_by_path
-    spec = new_spec('a', '1', nil, 'lib/foo.rb')
+    spec = util_spec('a', '1', nil, 'lib/foo.rb')
     spec.activated = true
 
     # There used to be a bug (introduced in a9c1aaf) when Gem::Specification
@@ -119,11 +119,11 @@ end
 
   def test_self_activate_ambiguous_direct
     save_loaded_features do
-      a1 = new_spec "a", "1", "b" => "> 0"
-      b1 = new_spec("b", "1", { "c" => ">= 1" }, "lib/d.rb")
-      b2 = new_spec("b", "2", { "c" => ">= 2" }, "lib/d.rb")
-      c1 = new_spec "c", "1"
-      c2 = new_spec "c", "2"
+      a1 = util_spec "a", "1", "b" => "> 0"
+      b1 = util_spec("b", "1", { "c" => ">= 1" }, "lib/d.rb")
+      b2 = util_spec("b", "2", { "c" => ">= 2" }, "lib/d.rb")
+      c1 = util_spec "c", "1"
+      c2 = util_spec "c", "2"
 
       Gem::Specification.reset
       install_specs c1, c2, b1, b2, a1
@@ -148,10 +148,10 @@ end
           deps = Hash[((pkgi + 1)..num_of_pkg).map { |deppkgi|
             ["pkg#{deppkgi}", ">= 0"]
           }]
-          new_spec "pkg#{pkgi}", pkg_version.to_s, deps
+          util_spec "pkg#{pkgi}", pkg_version.to_s, deps
         end
       end
-      base = new_spec "pkg_base", "1", {"pkg0" => ">= 0"}
+      base = util_spec "pkg_base", "1", {"pkg0" => ">= 0"}
 
       Gem::Specification.reset
       install_specs(*packages.flatten.reverse)
@@ -167,11 +167,11 @@ end
 
   def test_self_activate_ambiguous_indirect
     save_loaded_features do
-      a1 = new_spec "a", "1", "b" => "> 0"
-      b1 = new_spec "b", "1", "c" => ">= 1"
-      b2 = new_spec "b", "2", "c" => ">= 2"
-      c1 = new_spec "c", "1", nil, "lib/d.rb"
-      c2 = new_spec "c", "2", nil, "lib/d.rb"
+      a1 = util_spec "a", "1", "b" => "> 0"
+      b1 = util_spec "b", "1", "c" => ">= 1"
+      b2 = util_spec "b", "2", "c" => ">= 2"
+      c1 = util_spec "c", "1", nil, "lib/d.rb"
+      c2 = util_spec "c", "2", nil, "lib/d.rb"
 
       install_specs c1, c2, b1, b2, a1
 
@@ -188,12 +188,12 @@ end
 
   def test_self_activate_ambiguous_indirect_conflict
     save_loaded_features do
-      a1 = new_spec "a", "1", "b" => "> 0"
-      a2 = new_spec "a", "2", "b" => "> 0"
-      b1 = new_spec "b", "1", "c" => ">= 1"
-      b2 = new_spec "b", "2", "c" => ">= 2"
-      c1 = new_spec "c", "1", nil, "lib/d.rb"
-      c2 = new_spec("c", "2", { "a" => "1" }, "lib/d.rb") # conflicts with a-2
+      a1 = util_spec "a", "1", "b" => "> 0"
+      a2 = util_spec "a", "2", "b" => "> 0"
+      b1 = util_spec "b", "1", "c" => ">= 1"
+      b2 = util_spec "b", "2", "c" => ">= 2"
+      c1 = util_spec "c", "1", nil, "lib/d.rb"
+      c2 = util_spec("c", "2", { "a" => "1" }, "lib/d.rb") # conflicts with a-2
 
       install_specs c1, b1, a1, a2, c2, b2
 
@@ -210,12 +210,12 @@ end
 
   def test_self_activate_ambiguous_unrelated
     save_loaded_features do
-      a1 = new_spec "a", "1", "b" => "> 0"
-      b1 = new_spec "b", "1", "c" => ">= 1"
-      b2 = new_spec "b", "2", "c" => ">= 2"
-      c1 = new_spec "c", "1"
-      c2 = new_spec "c", "2"
-      d1 = new_spec "d", "1", nil, "lib/d.rb"
+      a1 = util_spec "a", "1", "b" => "> 0"
+      b1 = util_spec "b", "1", "c" => ">= 1"
+      b2 = util_spec "b", "2", "c" => ">= 2"
+      c1 = util_spec "c", "1"
+      c2 = util_spec "c", "2"
+      d1 = util_spec "d", "1", nil, "lib/d.rb"
 
       install_specs d1, c1, c2, b1, b2, a1
 
@@ -232,11 +232,11 @@ end
 
   def test_require_should_prefer_latest_gem_level1
     save_loaded_features do
-      a1 = new_spec "a", "1", "b" => "> 0"
-      b1 = new_spec "b", "1", "c" => ">= 0" # unresolved
-      b2 = new_spec "b", "2", "c" => ">= 0"
-      c1 = new_spec "c", "1", nil, "lib/c.rb"  # 1st level
-      c2 = new_spec "c", "2", nil, "lib/c.rb"
+      a1 = util_spec "a", "1", "b" => "> 0"
+      b1 = util_spec "b", "1", "c" => ">= 0" # unresolved
+      b2 = util_spec "b", "2", "c" => ">= 0"
+      c1 = util_spec "c", "1", nil, "lib/c.rb"  # 1st level
+      c2 = util_spec "c", "2", nil, "lib/c.rb"
 
       install_specs c1, c2, b1, b2, a1
 
@@ -250,13 +250,13 @@ end
 
   def test_require_should_prefer_latest_gem_level2
     save_loaded_features do
-      a1 = new_spec "a", "1", "b" => "> 0"
-      b1 = new_spec "b", "1", "c" => ">= 0" # unresolved
-      b2 = new_spec "b", "2", "c" => ">= 0"
-      c1 = new_spec "c", "1", "d" => ">= 0"  # 1st level
-      c2 = new_spec "c", "2", "d" => ">= 0"
-      d1 = new_spec "d", "1", nil, "lib/d.rb" # 2nd level
-      d2 = new_spec "d", "2", nil, "lib/d.rb"
+      a1 = util_spec "a", "1", "b" => "> 0"
+      b1 = util_spec "b", "1", "c" => ">= 0" # unresolved
+      b2 = util_spec "b", "2", "c" => ">= 0"
+      c1 = util_spec "c", "1", "d" => ">= 0"  # 1st level
+      c2 = util_spec "c", "2", "d" => ">= 0"
+      d1 = util_spec "d", "1", nil, "lib/d.rb" # 2nd level
+      d2 = util_spec "d", "2", nil, "lib/d.rb"
 
       install_specs d1, d2, c1, c2, b1, b2, a1
 
@@ -270,14 +270,14 @@ end
 
   def test_require_finds_in_2nd_level_indirect
     save_loaded_features do
-      a1 = new_spec "a", "1", "b" => "> 0"
-      b1 = new_spec "b", "1", "c" => ">= 0" # unresolved
-      b2 = new_spec "b", "2", "c" => ">= 0"
-      c1 = new_spec "c", "1", "d" => "<= 2" # 1st level
-      c2 = new_spec "c", "2", "d" => "<= 2"
-      d1 = new_spec "d", "1", nil, "lib/d.rb" # 2nd level
-      d2 = new_spec "d", "2", nil, "lib/d.rb"
-      d3 = new_spec "d", "3", nil, "lib/d.rb"
+      a1 = util_spec "a", "1", "b" => "> 0"
+      b1 = util_spec "b", "1", "c" => ">= 0" # unresolved
+      b2 = util_spec "b", "2", "c" => ">= 0"
+      c1 = util_spec "c", "1", "d" => "<= 2" # 1st level
+      c2 = util_spec "c", "2", "d" => "<= 2"
+      d1 = util_spec "d", "1", nil, "lib/d.rb" # 2nd level
+      d2 = util_spec "d", "2", nil, "lib/d.rb"
+      d3 = util_spec "d", "3", nil, "lib/d.rb"
 
       install_specs d1, d2, d3, c1, c2, b1, b2, a1
 
@@ -291,15 +291,15 @@ end
 
   def test_require_should_prefer_reachable_gems
     save_loaded_features do
-      a1 = new_spec "a", "1", "b" => "> 0"
-      b1 = new_spec "b", "1", "c" => ">= 0" # unresolved
-      b2 = new_spec "b", "2", "c" => ">= 0"
-      c1 = new_spec "c", "1", "d" => "<= 2" # 1st level
-      c2 = new_spec "c", "2", "d" => "<= 2"
-      d1 = new_spec "d", "1", nil, "lib/d.rb" # 2nd level
-      d2 = new_spec "d", "2", nil, "lib/d.rb"
-      d3 = new_spec "d", "3", nil, "lib/d.rb"
-      e  = new_spec "anti_d", "1", nil, "lib/d.rb"
+      a1 = util_spec "a", "1", "b" => "> 0"
+      b1 = util_spec "b", "1", "c" => ">= 0" # unresolved
+      b2 = util_spec "b", "2", "c" => ">= 0"
+      c1 = util_spec "c", "1", "d" => "<= 2" # 1st level
+      c2 = util_spec "c", "2", "d" => "<= 2"
+      d1 = util_spec "d", "1", nil, "lib/d.rb" # 2nd level
+      d2 = util_spec "d", "2", nil, "lib/d.rb"
+      d3 = util_spec "d", "3", nil, "lib/d.rb"
+      e  = util_spec "anti_d", "1", nil, "lib/d.rb"
 
       install_specs d1, d2, d3, e, c1, c2, b1, b2, a1
 
@@ -313,14 +313,14 @@ end
 
   def test_require_should_not_conflict
     save_loaded_features do
-      base = new_spec "0", "1", "A" => ">= 1"
-      a1 = new_spec "A", "1", {"c" => ">= 2", "b" => "> 0"}, "lib/a.rb"
-      a2 = new_spec "A", "2", {"c" => ">= 2", "b" => "> 0"}, "lib/a.rb"
-      b1 = new_spec "b", "1", {"c" => "= 1"}, "lib/d.rb"
-      b2 = new_spec "b", "2", {"c" => "= 2"}, "lib/d.rb"
-      c1 = new_spec "c", "1", {}, "lib/c.rb"
-      c2 = new_spec "c", "2", {}, "lib/c.rb"
-      c3 = new_spec "c", "3", {}, "lib/c.rb"
+      base = util_spec "0", "1", "A" => ">= 1"
+      a1 = util_spec "A", "1", {"c" => ">= 2", "b" => "> 0"}, "lib/a.rb"
+      a2 = util_spec "A", "2", {"c" => ">= 2", "b" => "> 0"}, "lib/a.rb"
+      b1 = util_spec "b", "1", {"c" => "= 1"}, "lib/d.rb"
+      b2 = util_spec "b", "2", {"c" => "= 2"}, "lib/d.rb"
+      c1 = util_spec "c", "1", {}, "lib/c.rb"
+      c2 = util_spec "c", "2", {}, "lib/c.rb"
+      c3 = util_spec "c", "3", {}, "lib/c.rb"
 
       install_specs c1, c2, c3, b1, b2, a1, a2, base
 
@@ -337,15 +337,15 @@ end
 
   def test_inner_clonflict_in_indirect_gems
     save_loaded_features do
-      a1 = new_spec "a", "1", "b" => "> 0"
-      b1 = new_spec "b", "1", "c" => ">= 1" # unresolved
-      b2 = new_spec "b", "2", "c" => ">= 1", "d" => "< 3"
-      c1 = new_spec "c", "1", "d" => "<= 2" # 1st level
-      c2 = new_spec "c", "2", "d" => "<= 2"
-      c3 = new_spec "c", "3", "d" => "<= 3"
-      d1 = new_spec "d", "1", nil, "lib/d.rb" # 2nd level
-      d2 = new_spec "d", "2", nil, "lib/d.rb"
-      d3 = new_spec "d", "3", nil, "lib/d.rb"
+      a1 = util_spec "a", "1", "b" => "> 0"
+      b1 = util_spec "b", "1", "c" => ">= 1" # unresolved
+      b2 = util_spec "b", "2", "c" => ">= 1", "d" => "< 3"
+      c1 = util_spec "c", "1", "d" => "<= 2" # 1st level
+      c2 = util_spec "c", "2", "d" => "<= 2"
+      c3 = util_spec "c", "3", "d" => "<= 3"
+      d1 = util_spec "d", "1", nil, "lib/d.rb" # 2nd level
+      d2 = util_spec "d", "2", nil, "lib/d.rb"
+      d3 = util_spec "d", "3", nil, "lib/d.rb"
 
       install_specs d1, d2, d3, c1, c2, c3, b1, b2, a1
 
@@ -359,15 +359,15 @@ end
 
   def test_inner_clonflict_in_indirect_gems_reversed
     save_loaded_features do
-      a1 = new_spec "a", "1", "b" => "> 0"
-      b1 = new_spec "b", "1", "xc" => ">= 1" # unresolved
-      b2 = new_spec "b", "2", "xc" => ">= 1", "d" => "< 3"
-      c1 = new_spec "xc", "1", "d" => "<= 3" # 1st level
-      c2 = new_spec "xc", "2", "d" => "<= 2"
-      c3 = new_spec "xc", "3", "d" => "<= 3"
-      d1 = new_spec "d", "1", nil, "lib/d.rb" # 2nd level
-      d2 = new_spec "d", "2", nil, "lib/d.rb"
-      d3 = new_spec "d", "3", nil, "lib/d.rb"
+      a1 = util_spec "a", "1", "b" => "> 0"
+      b1 = util_spec "b", "1", "xc" => ">= 1" # unresolved
+      b2 = util_spec "b", "2", "xc" => ">= 1", "d" => "< 3"
+      c1 = util_spec "xc", "1", "d" => "<= 3" # 1st level
+      c2 = util_spec "xc", "2", "d" => "<= 2"
+      c3 = util_spec "xc", "3", "d" => "<= 3"
+      d1 = util_spec "d", "1", nil, "lib/d.rb" # 2nd level
+      d2 = util_spec "d", "2", nil, "lib/d.rb"
+      d3 = util_spec "d", "3", nil, "lib/d.rb"
 
       install_specs d1, d2, d3, c1, c2, c3, b1, b2, a1
 
@@ -493,9 +493,9 @@ end
   end
 
   def test_self_activate_via_require
-    a1 = new_spec "a", "1", "b" => "= 1"
-    b1 = new_spec "b", "1", nil, "lib/b/c.rb"
-    b2 = new_spec "b", "2", nil, "lib/b/c.rb"
+    a1 = util_spec "a", "1", "b" => "= 1"
+    b1 = util_spec "b", "1", nil, "lib/b/c.rb"
+    b2 = util_spec "b", "2", nil, "lib/b/c.rb"
 
     install_specs b1, b2, a1
 
@@ -509,13 +509,13 @@ end
 
   def test_self_activate_via_require_wtf
     save_loaded_features do
-      a1 = new_spec "a", "1", "b" => "> 0", "d" => "> 0"    # this
-      b1 = new_spec "b", "1", { "c" => ">= 1" }, "lib/b.rb"
-      b2 = new_spec "b", "2", { "c" => ">= 2" }, "lib/b.rb" # this
-      c1 = new_spec "c", "1"
-      c2 = new_spec "c", "2"                                # this
-      d1 = new_spec "d", "1", { "c" => "< 2" },  "lib/d.rb"
-      d2 = new_spec "d", "2", { "c" => "< 2" },  "lib/d.rb" # this
+      a1 = util_spec "a", "1", "b" => "> 0", "d" => "> 0"    # this
+      b1 = util_spec "b", "1", { "c" => ">= 1" }, "lib/b.rb"
+      b2 = util_spec "b", "2", { "c" => ">= 2" }, "lib/b.rb" # this
+      c1 = util_spec "c", "1"
+      c2 = util_spec "c", "2"                                # this
+      d1 = util_spec "d", "1", { "c" => "< 2" },  "lib/d.rb"
+      d2 = util_spec "d", "2", { "c" => "< 2" },  "lib/d.rb" # this
 
       install_specs c1, c2, b1, b2, d1, d2, a1
 
@@ -538,11 +538,11 @@ end
   end
 
   def test_self_activate_deep_unambiguous
-    a1 = new_spec "a", "1", "b" => "= 1"
-    b1 = new_spec "b", "1", "c" => "= 1"
-    b2 = new_spec "b", "2", "c" => "= 2"
-    c1 = new_spec "c", "1"
-    c2 = new_spec "c", "2"
+    a1 = util_spec "a", "1", "b" => "= 1"
+    b1 = util_spec "b", "1", "c" => "= 1"
+    b2 = util_spec "b", "2", "c" => "= 2"
+    c1 = util_spec "c", "1"
+    c2 = util_spec "c", "2"
 
     install_specs c1, c2, b1, b2, a1
 
@@ -668,7 +668,7 @@ end
   end
 
   def test_self_all_equals
-    a = new_spec "foo", "1", nil, "lib/foo.rb"
+    a = util_spec "foo", "1", nil, "lib/foo.rb"
 
     install_specs a
     Gem::Specification.all = [a]
@@ -721,11 +721,11 @@ end
     spec.version = '1'
     spec.specification_version = @current_version + 1
 
-    new_spec = Marshal.load Marshal.dump(spec)
+    util_spec = Marshal.load Marshal.dump(spec)
 
-    assert_equal 'a', new_spec.name
-    assert_equal Gem::Version.new(1), new_spec.version
-    assert_equal @current_version, new_spec.specification_version
+    assert_equal 'a', util_spec.name
+    assert_equal Gem::Version.new(1), util_spec.version
+    assert_equal @current_version, util_spec.specification_version
   end
 
   def test_self_from_yaml
@@ -743,12 +743,12 @@ end
     yaml = @a1.to_yaml
     yaml.sub!(/^date:.*/, "date: 2011-04-26 00:00:00.000000000Z")
 
-    new_spec = with_syck do
+    util_spec = with_syck do
       Gem::Specification.from_yaml yaml
     end
 
     assert_kind_of Time, @a1.date
-    assert_kind_of Time, new_spec.date
+    assert_kind_of Time, util_spec.date
   end
 
   def test_self_from_yaml_syck_default_key_bug
@@ -778,14 +778,14 @@ test_files: []
 bindir:
     YAML
 
-    new_spec = with_syck do
+    util_spec = with_syck do
       Gem::Specification.from_yaml yaml
     end
 
-    op = new_spec.dependencies.first.requirement.requirements.first.first
+    op = util_spec.dependencies.first.requirement.requirements.first.first
     refute_kind_of YAML::Syck::DefaultKey, op
 
-    refute_match %r%DefaultKey%, new_spec.to_ruby
+    refute_match %r%DefaultKey%, util_spec.to_ruby
   end
 
   def test_self_from_yaml_cleans_up_defaultkey
@@ -814,12 +814,12 @@ test_files: []
 bindir:
     YAML
 
-    new_spec = Gem::Specification.from_yaml yaml
+    util_spec = Gem::Specification.from_yaml yaml
 
-    op = new_spec.dependencies.first.requirement.requirements.first.first
+    op = util_spec.dependencies.first.requirement.requirements.first.first
     refute_kind_of YAML::Syck::DefaultKey, op
 
-    refute_match %r%DefaultKey%, new_spec.to_ruby
+    refute_match %r%DefaultKey%, util_spec.to_ruby
   end
 
   def test_self_from_yaml_cleans_up_defaultkey_from_newer_192
@@ -848,12 +848,12 @@ test_files: []
 bindir:
     YAML
 
-    new_spec = Gem::Specification.from_yaml yaml
+    util_spec = Gem::Specification.from_yaml yaml
 
-    op = new_spec.dependencies.first.requirement.requirements.first.first
+    op = util_spec.dependencies.first.requirement.requirements.first.first
     refute_kind_of YAML::Syck::DefaultKey, op
 
-    refute_match %r%DefaultKey%, new_spec.to_ruby
+    refute_match %r%DefaultKey%, util_spec.to_ruby
   end
 
   def test_self_from_yaml_cleans_up_Date_objects
@@ -903,9 +903,9 @@ requirements: []
 dependencies: []
     YAML
 
-    new_spec = Gem::Specification.from_yaml yaml
+    util_spec = Gem::Specification.from_yaml yaml
 
-    assert_kind_of Time, new_spec.date
+    assert_kind_of Time, util_spec.date
   end
 
   def test_self_load
@@ -1202,57 +1202,57 @@ dependencies: []
       s.add_dependency 'some_gem'
     end
 
-    new_spec = spec.dup
+    util_spec = spec.dup
 
     assert_equal "blah", spec.name
-    assert_same  spec.name, new_spec.name
+    assert_same  spec.name, util_spec.name
 
     assert_equal "1.3.5", spec.version.to_s
-    assert_same spec.version, new_spec.version
+    assert_same spec.version, util_spec.version
 
     assert_equal Gem::Platform::RUBY, spec.platform
-    assert_same spec.platform, new_spec.platform
+    assert_same spec.platform, util_spec.platform
 
     assert_equal 'summary', spec.summary
-    assert_same spec.summary, new_spec.summary
+    assert_same spec.summary, util_spec.summary
 
     assert_equal %w[README.txt bin/exec ext/extconf.rb lib/file.rb
                     test/file.rb].sort,
                  spec.files
-    refute_same spec.files, new_spec.files, 'files'
+    refute_same spec.files, util_spec.files, 'files'
 
     assert_equal %w[test/file.rb], spec.test_files
-    refute_same spec.test_files, new_spec.test_files, 'test_files'
+    refute_same spec.test_files, util_spec.test_files, 'test_files'
 
     assert_equal %w[--foo], spec.rdoc_options
-    refute_same spec.rdoc_options, new_spec.rdoc_options, 'rdoc_options'
+    refute_same spec.rdoc_options, util_spec.rdoc_options, 'rdoc_options'
 
     assert_equal %w[README.txt], spec.extra_rdoc_files
-    refute_same spec.extra_rdoc_files, new_spec.extra_rdoc_files,
+    refute_same spec.extra_rdoc_files, util_spec.extra_rdoc_files,
                 'extra_rdoc_files'
 
     assert_equal %w[exec], spec.executables
-    refute_same spec.executables, new_spec.executables, 'executables'
+    refute_same spec.executables, util_spec.executables, 'executables'
 
     assert_equal %w[ext/extconf.rb], spec.extensions
-    refute_same spec.extensions, new_spec.extensions, 'extensions'
+    refute_same spec.extensions, util_spec.extensions, 'extensions'
 
     assert_equal %w[requirement], spec.requirements
-    refute_same spec.requirements, new_spec.requirements, 'requirements'
+    refute_same spec.requirements, util_spec.requirements, 'requirements'
 
     assert_equal [Gem::Dependency.new('some_gem', Gem::Requirement.default)],
                  spec.dependencies
-    refute_same spec.dependencies, new_spec.dependencies, 'dependencies'
+    refute_same spec.dependencies, util_spec.dependencies, 'dependencies'
 
     assert_equal 'bin', spec.bindir
-    assert_same spec.bindir, new_spec.bindir
+    assert_same spec.bindir, util_spec.bindir
 
     assert_equal '>= 0', spec.required_ruby_version.to_s
-    assert_same spec.required_ruby_version, new_spec.required_ruby_version
+    assert_same spec.required_ruby_version, util_spec.required_ruby_version
 
     assert_equal '>= 0', spec.required_rubygems_version.to_s
     assert_same spec.required_rubygems_version,
-                new_spec.required_rubygems_version
+                util_spec.required_rubygems_version
   end
 
   def test_initialize_copy_broken
@@ -1683,8 +1683,8 @@ dependencies: []
   end
 
   def test_eql_eh
-    g1 = new_spec 'gem', 1
-    g2 = new_spec 'gem', 1
+    g1 = util_spec 'gem', 1
+    g2 = util_spec 'gem', 1
 
     assert_equal g1, g2
     assert_equal g1.hash, g2.hash
@@ -2165,7 +2165,7 @@ dependencies: []
 
   def test_require_already_activated
     save_loaded_features do
-      a1 = new_spec "a", "1", nil, "lib/d.rb"
+      a1 = util_spec "a", "1", nil, "lib/d.rb"
 
       install_specs a1 # , a2, b1, b2, c1, c2
 
@@ -2182,12 +2182,12 @@ dependencies: []
 
   def test_require_already_activated_indirect_conflict
     save_loaded_features do
-      a1 = new_spec "a", "1", "b" => "> 0"
-      a2 = new_spec "a", "2", "b" => "> 0"
-      b1 = new_spec "b", "1", "c" => ">= 1"
-      b2 = new_spec "b", "2", "c" => ">= 2"
-      c1 = new_spec "c", "1", nil, "lib/d.rb"
-      c2 = new_spec("c", "2", { "a" => "1" }, "lib/d.rb") # conflicts with a-2
+      a1 = util_spec "a", "1", "b" => "> 0"
+      a2 = util_spec "a", "2", "b" => "> 0"
+      b1 = util_spec "b", "1", "c" => ">= 1"
+      b2 = util_spec "b", "2", "c" => ">= 2"
+      c1 = util_spec "c", "1", nil, "lib/d.rb"
+      c2 = util_spec("c", "2", { "a" => "1" }, "lib/d.rb") # conflicts with a-2
 
       install_specs c1, b1, a1, a2, c2, b2
 
@@ -2225,8 +2225,8 @@ dependencies: []
   end
 
   def test_spaceship_name
-    s1 = new_spec 'a', '1'
-    s2 = new_spec 'b', '1'
+    s1 = util_spec 'a', '1'
+    s2 = util_spec 'b', '1'
 
     assert_equal(-1, (s1 <=> s2))
     assert_equal( 0, (s1 <=> s1))
@@ -2234,8 +2234,8 @@ dependencies: []
   end
 
   def test_spaceship_platform
-    s1 = new_spec 'a', '1'
-    s2 = new_spec 'a', '1' do |s|
+    s1 = util_spec 'a', '1'
+    s2 = util_spec 'a', '1' do |s|
       s.platform = Gem::Platform.new 'x86-my_platform1'
     end
 
@@ -2245,8 +2245,8 @@ dependencies: []
   end
 
   def test_spaceship_version
-    s1 = new_spec 'a', '1'
-    s2 = new_spec 'a', '2'
+    s1 = util_spec 'a', '1'
+    s2 = util_spec 'a', '2'
 
     assert_equal( -1, (s1 <=> s2))
     assert_equal(  0, (s1 <=> s1))
@@ -3234,7 +3234,7 @@ Did you mean 'Ruby'?
   end
 
   def test__load_fixes_Date_objects
-    spec = new_spec "a", 1
+    spec = util_spec "a", 1
     spec.instance_variable_set :@date, Date.today
 
     spec = Marshal.load Marshal.dump(spec)
@@ -3546,7 +3546,7 @@ end
   end
 
   def test_find_by_path
-    a = new_spec "foo", "1", nil, "lib/foo.rb"
+    a = util_spec "foo", "1", nil, "lib/foo.rb"
 
     install_specs a
 
@@ -3556,7 +3556,7 @@ end
   end
 
   def test_find_inactive_by_path
-    a = new_spec "foo", "1", nil, "lib/foo.rb"
+    a = util_spec "foo", "1", nil, "lib/foo.rb"
 
     install_specs a
 
@@ -3582,7 +3582,7 @@ end
   def test_detect_bundled_gem_in_old_ruby
     util_set_RUBY_VERSION '1.9.3', 551
 
-    spec = new_spec 'bigdecimal', '1.1.0' do |s|
+    spec = util_spec 'bigdecimal', '1.1.0' do |s|
       s.summary = "This bigdecimal is bundled with Ruby"
     end
 

--- a/test/rubygems/test_gem_uninstaller.rb
+++ b/test/rubygems/test_gem_uninstaller.rb
@@ -214,7 +214,7 @@ class TestGemUninstaller < Gem::InstallerTestCase
     default_spec = new_default_spec 'default', '2'
     install_default_gems default_spec
 
-    spec = new_spec 'default', '2'
+    spec = util_spec 'default', '2'
     install_gem spec
 
     Gem::Specification.reset

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -40,10 +40,10 @@ class TestGemRequire < Gem::TestCase
 
   # Providing -I on the commandline should always beat gems
   def test_dash_i_beats_gems
-    a1 = new_spec "a", "1", {"b" => "= 1"}, "lib/test_gem_require_a.rb"
-    b1 = new_spec "b", "1", {"c" => "> 0"}, "lib/b/c.rb"
-    c1 = new_spec "c", "1", nil, "lib/c/c.rb"
-    c2 = new_spec "c", "2", nil, "lib/c/c.rb"
+    a1 = util_spec "a", "1", {"b" => "= 1"}, "lib/test_gem_require_a.rb"
+    b1 = util_spec "b", "1", {"c" => "> 0"}, "lib/b/c.rb"
+    c1 = util_spec "c", "1", nil, "lib/c/c.rb"
+    c2 = util_spec "c", "2", nil, "lib/c/c.rb"
 
     install_specs c1, c2, b1, a1
 
@@ -85,8 +85,8 @@ class TestGemRequire < Gem::TestCase
     Object.const_set :FILE_ENTERED_LATCH, Latch.new(2)
     Object.const_set :FILE_EXIT_LATCH, Latch.new(1)
 
-    a1 = new_spec "a", "1", nil, "lib/a.rb"
-    b1 = new_spec "b", "1", nil, "lib/b.rb"
+    a1 = util_spec "a", "1", nil, "lib/a.rb"
+    b1 = util_spec "b", "1", nil, "lib/b.rb"
 
     install_specs a1, b1
 
@@ -107,9 +107,9 @@ class TestGemRequire < Gem::TestCase
   end
 
   def test_require_is_not_lazy_with_exact_req
-    a1 = new_spec "a", "1", {"b" => "= 1"}, "lib/test_gem_require_a.rb"
-    b1 = new_spec "b", "1", nil, "lib/b/c.rb"
-    b2 = new_spec "b", "2", nil, "lib/b/c.rb"
+    a1 = util_spec "a", "1", {"b" => "= 1"}, "lib/test_gem_require_a.rb"
+    b1 = util_spec "b", "1", nil, "lib/b/c.rb"
+    b2 = util_spec "b", "2", nil, "lib/b/c.rb"
 
     install_specs b1, b2, a1
 
@@ -122,9 +122,9 @@ class TestGemRequire < Gem::TestCase
   end
 
   def test_require_is_lazy_with_inexact_req
-    a1 = new_spec "a", "1", {"b" => ">= 1"}, "lib/test_gem_require_a.rb"
-    b1 = new_spec "b", "1", nil, "lib/b/c.rb"
-    b2 = new_spec "b", "2", nil, "lib/b/c.rb"
+    a1 = util_spec "a", "1", {"b" => ">= 1"}, "lib/test_gem_require_a.rb"
+    b1 = util_spec "b", "1", nil, "lib/b/c.rb"
+    b2 = util_spec "b", "2", nil, "lib/b/c.rb"
 
     install_specs b1, b2, a1
 
@@ -137,8 +137,8 @@ class TestGemRequire < Gem::TestCase
   end
 
   def test_require_is_not_lazy_with_one_possible
-    a1 = new_spec "a", "1", {"b" => ">= 1"}, "lib/test_gem_require_a.rb"
-    b1 = new_spec "b", "1", nil, "lib/b/c.rb"
+    a1 = util_spec "a", "1", {"b" => ">= 1"}, "lib/test_gem_require_a.rb"
+    b1 = util_spec "b", "1", nil, "lib/b/c.rb"
 
     install_specs b1, a1
 
@@ -151,7 +151,7 @@ class TestGemRequire < Gem::TestCase
   end
 
   def test_require_can_use_a_pathname_object
-    a1 = new_spec "a", "1", nil, "lib/test_gem_require_a.rb"
+    a1 = util_spec "a", "1", nil, "lib/test_gem_require_a.rb"
 
     install_specs a1
 
@@ -161,9 +161,9 @@ class TestGemRequire < Gem::TestCase
   end
 
   def test_activate_via_require_respects_loaded_files
-    a1 = new_spec "a", "1", {"b" => ">= 1"}, "lib/test_gem_require_a.rb"
-    b1 = new_spec "b", "1", nil, "lib/benchmark.rb"
-    b2 = new_spec "b", "2", nil, "lib/benchmark.rb"
+    a1 = util_spec "a", "1", {"b" => ">= 1"}, "lib/test_gem_require_a.rb"
+    b1 = util_spec "b", "1", nil, "lib/benchmark.rb"
+    b2 = util_spec "b", "2", nil, "lib/benchmark.rb"
 
     install_specs b1, b2, a1
 
@@ -181,11 +181,11 @@ class TestGemRequire < Gem::TestCase
   end
 
   def test_already_activated_direct_conflict
-    a1 = new_spec "a", "1", { "b" => "> 0" }
-    b1 = new_spec "b", "1", { "c" => ">= 1" }, "lib/ib.rb"
-    b2 = new_spec "b", "2", { "c" => ">= 2" }, "lib/ib.rb"
-    c1 = new_spec "c", "1", nil, "lib/d.rb"
-    c2 = new_spec("c", "2", nil, "lib/d.rb")
+    a1 = util_spec "a", "1", { "b" => "> 0" }
+    b1 = util_spec "b", "1", { "c" => ">= 1" }, "lib/ib.rb"
+    b2 = util_spec "b", "2", { "c" => ">= 2" }, "lib/ib.rb"
+    c1 = util_spec "c", "1", nil, "lib/d.rb"
+    c2 = util_spec("c", "2", nil, "lib/d.rb")
 
     install_specs c1, c2, b1, b2, a1
 
@@ -201,13 +201,13 @@ class TestGemRequire < Gem::TestCase
   end
 
   def test_multiple_gems_with_the_same_path
-    a1 = new_spec "a", "1", { "b" => "> 0", "x" => "> 0" }
-    b1 = new_spec "b", "1", { "c" => ">= 1" }, "lib/ib.rb"
-    b2 = new_spec "b", "2", { "c" => ">= 2" }, "lib/ib.rb"
-    x1 = new_spec "x", "1", nil, "lib/ib.rb"
-    x2 = new_spec "x", "2", nil, "lib/ib.rb"
-    c1 = new_spec "c", "1", nil, "lib/d.rb"
-    c2 = new_spec("c", "2", nil, "lib/d.rb")
+    a1 = util_spec "a", "1", { "b" => "> 0", "x" => "> 0" }
+    b1 = util_spec "b", "1", { "c" => ">= 1" }, "lib/ib.rb"
+    b2 = util_spec "b", "2", { "c" => ">= 2" }, "lib/ib.rb"
+    x1 = util_spec "x", "1", nil, "lib/ib.rb"
+    x2 = util_spec "x", "2", nil, "lib/ib.rb"
+    c1 = util_spec "c", "1", nil, "lib/d.rb"
+    c2 = util_spec("c", "2", nil, "lib/d.rb")
 
     install_specs c1, c2, x1, x2, b1, b2, a1
 
@@ -224,13 +224,13 @@ class TestGemRequire < Gem::TestCase
   end
 
   def test_unable_to_find_good_unresolved_version
-    a1 = new_spec "a", "1", { "b" => "> 0" }
-    b1 = new_spec "b", "1", { "c" => ">= 2" }, "lib/ib.rb"
-    b2 = new_spec "b", "2", { "c" => ">= 3" }, "lib/ib.rb"
+    a1 = util_spec "a", "1", { "b" => "> 0" }
+    b1 = util_spec "b", "1", { "c" => ">= 2" }, "lib/ib.rb"
+    b2 = util_spec "b", "2", { "c" => ">= 3" }, "lib/ib.rb"
 
-    c1 = new_spec "c", "1", nil, "lib/d.rb"
-    c2 = new_spec "c", "2", nil, "lib/d.rb"
-    c3 = new_spec "c", "3", nil, "lib/d.rb"
+    c1 = util_spec "c", "1", nil, "lib/d.rb"
+    c2 = util_spec "c", "2", nil, "lib/d.rb"
+    c3 = util_spec "c", "3", nil, "lib/d.rb"
 
     install_specs c1, c2, c3, b1, b2, a1
 
@@ -273,10 +273,10 @@ class TestGemRequire < Gem::TestCase
   end
 
   def test_require_doesnt_traverse_development_dependencies
-    a = new_spec("a", "1", nil, "lib/a.rb")
-    z = new_spec("z", "1", "w" => "> 0")
-    w1 = new_spec("w", "1") { |s| s.add_development_dependency "non-existent" }
-    w2 = new_spec("w", "2") { |s| s.add_development_dependency "non-existent" }
+    a = util_spec("a", "1", nil, "lib/a.rb")
+    z = util_spec("z", "1", "w" => "> 0")
+    w1 = util_spec("w", "1") { |s| s.add_development_dependency "non-existent" }
+    w2 = util_spec("w", "2") { |s| s.add_development_dependency "non-existent" }
 
     install_specs a, w1, w2, z
 
@@ -316,7 +316,7 @@ class TestGemRequire < Gem::TestCase
     default_gem_spec = new_default_spec("default", "2.0.0.0",
                                         nil, "default/gem.rb")
     install_default_specs(default_gem_spec)
-    normal_gem_spec = new_spec("default", "3.0", nil,
+    normal_gem_spec = util_spec("default", "3.0", nil,
                                "lib/default/gem.rb")
     install_specs(normal_gem_spec)
     assert_require "default/gem"
@@ -366,7 +366,7 @@ class TestGemRequire < Gem::TestCase
   end
 
   def test_require_default_when_gem_defined
-    a = new_spec("a", "1", nil, "lib/a.rb")
+    a = util_spec("a", "1", nil, "lib/a.rb")
     install_specs a
     c = Class.new do
       def self.gem(*args)
@@ -379,8 +379,8 @@ class TestGemRequire < Gem::TestCase
 
 
   def test_require_bundler
-    b1 = new_spec('bundler', '1', nil, "lib/bundler/setup.rb")
-    b2a = new_spec('bundler', '2.a', nil, "lib/bundler/setup.rb")
+    b1 = util_spec('bundler', '1', nil, "lib/bundler/setup.rb")
+    b2a = util_spec('bundler', '2.a', nil, "lib/bundler/setup.rb")
     install_specs b1, b2a
 
     require "rubygems/bundler_version_finder"
@@ -392,8 +392,8 @@ class TestGemRequire < Gem::TestCase
 
   def test_require_bundler_missing_bundler_version
     Gem::BundlerVersionFinder.stub(:bundler_version_with_reason, ["55", "reason"]) do
-      b1 = new_spec('bundler', '1.999999999', nil, "lib/bundler/setup.rb")
-      b2a = new_spec('bundler', '2.a', nil, "lib/bundler/setup.rb")
+      b1 = util_spec('bundler', '1.999999999', nil, "lib/bundler/setup.rb")
+      b2a = util_spec('bundler', '2.a', nil, "lib/bundler/setup.rb")
       install_specs b1, b2a
 
       e = assert_raises Gem::MissingSpecVersionError do
@@ -405,8 +405,8 @@ class TestGemRequire < Gem::TestCase
 
   def test_require_bundler_with_bundler_version
     Gem::BundlerVersionFinder.stub(:bundler_version_with_reason, ["1", "reason"]) do
-      b1 = new_spec('bundler', '1.999999999', nil, "lib/bundler/setup.rb")
-      b2 = new_spec('bundler', '2', nil, "lib/bundler/setup.rb")
+      b1 = util_spec('bundler', '1.999999999', nil, "lib/bundler/setup.rb")
+      b2 = util_spec('bundler', '2', nil, "lib/bundler/setup.rb")
       install_specs b1, b2
 
       $:.clear


### PR DESCRIPTION
# Description:

`Gem::Testcase` has `new_spec` and `util_spec` for building stub specification. I migrated them to util_spec and marked new_spec to deprecated.

______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
