### PR TITLE
Fix #1470: generate documentation when --install-dir is present.

### DIFF
--- a/lib/rubygems/request_set.rb
+++ b/lib/rubygems/request_set.rb
@@ -261,7 +261,7 @@ class Gem::RequestSet
         next
       end
 
-      a = spec.install options do |installer|
+      spec.install options do |installer|
         yield request, installer if block_given?
       end
 

--- a/lib/rubygems/request_set.rb
+++ b/lib/rubygems/request_set.rb
@@ -288,7 +288,7 @@ class Gem::RequestSet
       end
     end
 
-    require 'rubygems/dependency_installer'
+    require "rubygems/dependency_installer"
     inst = Gem::DependencyInstaller.new options
     inst.installed_gems.replace specs
 

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -448,6 +448,43 @@ ERROR:  Possible alternatives: non_existent_with_hint
     assert_path_exists File.join(a2.doc_dir, 'rdoc')
   end
 
+  def test_execute_rdoc_with_path
+    skip if RUBY_VERSION <= "1.8.7"
+    specs = spec_fetcher do |fetcher|
+      fetcher.gem 'a', 2
+    end
+  
+    Gem.done_installing(&Gem::RDoc.method(:generation_hook))
+  
+    @cmd.options[:document] = %w[rdoc ri]
+    @cmd.options[:domain] = :local
+    @cmd.options[:install_dir] = 'whatever'
+  
+    a2 = specs['a-2']
+    FileUtils.mv a2.cache_file, @tempdir
+  
+    @cmd.options[:args] = %w[a]
+  
+    use_ui @ui do
+      # Don't use Dir.chdir with a block, it warnings a lot because
+      # of a downstream Dir.chdir with a block
+      old = Dir.getwd
+  
+      begin
+        Dir.chdir @tempdir
+        assert_raises Gem::MockGemUi::SystemExitException, @ui.error do
+          @cmd.execute
+        end
+      ensure
+        Dir.chdir old
+      end
+    end
+  
+    wait_for_child_process_to_exit
+  
+    assert_path_exists 'whatever/doc/a-2', 'documentation not installed'
+  end
+
   def test_execute_saves_build_args
     specs = spec_fetcher do |fetcher|
       fetcher.gem 'a', 2


### PR DESCRIPTION
# Description:
Fixes a problem (#1470) where documentation would not be generated when selecting a directory for installation using `--install-dir`. The code for calling hooks was moved onto a separate function (`install_hooks`) which is now called from both `install` and `install_into` (in `request_set.rb`).

___________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends: **comments are very appreciated!**

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).