### PR TITLE
 [Requirement] Treat requirements with == versions as equal

### DIFF
--- a/lib/rubygems/package/tar_test_case.rb
+++ b/lib/rubygems/package/tar_test_case.rb
@@ -94,7 +94,6 @@ class Gem::Package::TarTestCase < Gem::TestCase
       ASCIIZ(dname, 155)     # char prefix[155];   ASCII + (Z unless filled)
     ]
 
-    format = "C100C8C8C8C12C12C8CC100C6C2C32C32C8C8C155"
     h = arr.join
     ret = h + "\0" * (512 - h.size)
     assert_equal(512, ret.size)

--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -133,6 +133,7 @@ class Gem::Requirement
       @requirements = [DefaultRequirement]
     else
       @requirements = requirements.map! { |r| self.class.parse r }
+      sort_requirements!
     end
   end
 
@@ -146,6 +147,7 @@ class Gem::Requirement
     new = new.map { |r| self.class.parse r }
 
     @requirements.concat new
+    sort_requirements!
   end
 
   ##
@@ -183,11 +185,11 @@ class Gem::Requirement
   end
 
   def as_list # :nodoc:
-    requirements.map { |op, version| "#{op} #{version}" }.sort
+    requirements.map { |op, version| "#{op} #{version}" }
   end
 
   def hash # :nodoc:
-    requirements.sort.hash
+    requirements.hash
   end
 
   def marshal_dump # :nodoc:
@@ -264,7 +266,8 @@ class Gem::Requirement
   end
 
   def == other # :nodoc:
-    Gem::Requirement === other and to_s == other.to_s
+    return unless Gem::Requirement === other
+    requirements == other.requirements
   end
 
   private
@@ -277,6 +280,14 @@ class Gem::Requirement
       if r[0].kind_of? Gem::SyckDefaultKey
         r[0] = "="
       end
+    end
+  end
+
+  def sort_requirements! # :nodoc:
+    @requirements.sort! do |l, r| 
+      comp = l.last <=> r.last # first, sort by the requirement's version
+      next comp unless comp == 0
+      l.first <=> r.first # then, sort by the operator (for stability)
     end
   end
 end

--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -28,6 +28,8 @@ class TestGemRequirement < Gem::TestCase
     assert_requirement_equal "= 2", "2"
     assert_requirement_equal "= 2", ["2"]
     assert_requirement_equal "= 2", v(2)
+    assert_requirement_equal "2.0", "2"
+    assert_requirement_equal ["= 2", ">= 2"], [">= 2", "= 2"]
   end
 
   def test_create
@@ -69,6 +71,7 @@ class TestGemRequirement < Gem::TestCase
     assert_equal ['=', Gem::Version.new(1)], Gem::Requirement.parse('= 1')
     assert_equal ['>', Gem::Version.new(1)], Gem::Requirement.parse('> 1')
     assert_equal ['=', Gem::Version.new(1)], Gem::Requirement.parse("=\n1")
+    assert_equal ['=', Gem::Version.new(1)], Gem::Requirement.parse('1.0')
 
     assert_equal ['=', Gem::Version.new(2)],
       Gem::Requirement.parse(Gem::Version.new('2'))
@@ -226,6 +229,8 @@ class TestGemRequirement < Gem::TestCase
     assert_satisfied_by "0.2.33",      "= 0.2.33"
     assert_satisfied_by "0.2.34",      "> 0.2.33"
     assert_satisfied_by "1.0",         "= 1.0"
+    assert_satisfied_by "1.0.0",       "= 1.0"
+    assert_satisfied_by "1.0",         "= 1.0.0"
     assert_satisfied_by "1.0",         "1.0"
     assert_satisfied_by "1.8.2",       "> 1.8.0"
     assert_satisfied_by "1.112",       "> 1.111"
@@ -313,6 +318,7 @@ class TestGemRequirement < Gem::TestCase
   def test_satisfied_by_boxed
     refute_satisfied_by "1.3",   "~> 1.4"
     assert_satisfied_by "1.4",   "~> 1.4"
+    assert_satisfied_by "1.4.0", "~> 1.4"
     assert_satisfied_by "1.5",   "~> 1.4"
     refute_satisfied_by "2.0",   "~> 1.4"
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2429,16 +2429,16 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<rake>.freeze, [\"> 0.4\"])
       s.add_runtime_dependency(%q<jabber4r>.freeze, [\"> 0.0.0\"])
-      s.add_runtime_dependency(%q<pqa>.freeze, [\"<= 0.6\", \"> 0.4\"])
+      s.add_runtime_dependency(%q<pqa>.freeze, [\"> 0.4\", \"<= 0.6\"])
     else
       s.add_dependency(%q<rake>.freeze, [\"> 0.4\"])
       s.add_dependency(%q<jabber4r>.freeze, [\"> 0.0.0\"])
-      s.add_dependency(%q<pqa>.freeze, [\"<= 0.6\", \"> 0.4\"])
+      s.add_dependency(%q<pqa>.freeze, [\"> 0.4\", \"<= 0.6\"])
     end
   else
     s.add_dependency(%q<rake>.freeze, [\"> 0.4\"])
     s.add_dependency(%q<jabber4r>.freeze, [\"> 0.0.0\"])
-    s.add_dependency(%q<pqa>.freeze, [\"<= 0.6\", \"> 0.4\"])
+    s.add_dependency(%q<pqa>.freeze, [\"> 0.4\", \"<= 0.6\"])
   end
 end
     SPEC


### PR DESCRIPTION
# Description:

Fixes https://github.com/bundler/bundler/issues/6295

Previously, Gem::Requirement.new(“= 1) != Gem::Requirement.new(“= 1.0)
We fix that by comparing equality by the (op, version) tuples, rather than string equality on the versions

Internally, we now keep requirements sorted by version, so we don’t need to re-sort each time any method that uses a sorted list of requirements is called (such as == or to_s)

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).