### PR TITLE
Add a note for the non-semantically versioned case

### DIFF
--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -144,11 +144,15 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
         _, dep_version = dep.requirement.requirements.first
 
         base = dep_version.segments.first 2
+        upper_bound = dep_version.segments.first(dep_version.segments.length - 1)
+        upper_bound[-1] += 1
 
         warning_messages << <<-WARNING
 pessimistic dependency on #{dep} may be overly strict
   if #{dep.name} is semantically versioned, use:
     add_#{dep.type}_dependency '#{dep.name}', '~> #{base.join '.'}', '>= #{dep_version}'
+  if #{dep.name} is not semantically versioned, you can bypass this warning with:
+    add_#{dep.type}_dependency '#{dep.name}', '>= #{dep_version}', '< #{upper_bound.join '.'}'
         WARNING
       end
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2622,9 +2622,13 @@ end
 #{w}:  pessimistic dependency on d (~> 1.2.3) may be overly strict
   if d is semantically versioned, use:
     add_runtime_dependency 'd', '~> 1.2', '>= 1.2.3'
+  if d is not semantically versioned, you can bypass this warning with:
+    add_runtime_dependency 'd', '>= 1.2.3', '< 1.3'
 #{w}:  pessimistic dependency on e (~> 1.2.3.4) may be overly strict
   if e is semantically versioned, use:
     add_runtime_dependency 'e', '~> 1.2', '>= 1.2.3.4'
+  if e is not semantically versioned, you can bypass this warning with:
+    add_runtime_dependency 'e', '>= 1.2.3.4', '< 1.2.4'
 #{w}:  open-ended dependency on i (>= 1.2) is not recommended
   if i is semantically versioned, use:
     add_runtime_dependency 'i', '~> 1.2'
@@ -2640,6 +2644,8 @@ end
 #{w}:  pessimistic dependency on m (~> 2.1.0) may be overly strict
   if m is semantically versioned, use:
     add_runtime_dependency 'm', '~> 2.1', '>= 2.1.0'
+  if m is not semantically versioned, you can bypass this warning with:
+    add_runtime_dependency 'm', '>= 2.1.0', '< 2.2'
 #{w}:  See http://guides.rubygems.org/specification-reference/ for help
       EXPECTED
 


### PR DESCRIPTION
# Description:

Fixes #2228 by recommending another form of version specification when the overly strict dependency is not actually semantically versioned.
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
