### PR TITLE
Removed compatibility code for Ruby 1.9.2.

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1367,24 +1367,21 @@ end
 require 'rubygems/exceptions'
 
 # REFACTOR: This should be pulled out into some kind of hacks file.
-gem_preluded = Gem::GEM_PRELUDE_SUCKAGE and defined? Gem
-unless gem_preluded then # TODO: remove guard after 1.9.2 dropped
+begin
+  ##
+  # Defaults the operating system (or packager) wants to provide for RubyGems.
+
+  require 'rubygems/defaults/operating_system'
+rescue LoadError
+end
+
+if defined?(RUBY_ENGINE) then
   begin
     ##
-    # Defaults the operating system (or packager) wants to provide for RubyGems.
+    # Defaults the Ruby implementation wants to provide for RubyGems
 
-    require 'rubygems/defaults/operating_system'
+    require "rubygems/defaults/#{RUBY_ENGINE}"
   rescue LoadError
-  end
-
-  if defined?(RUBY_ENGINE) then
-    begin
-      ##
-      # Defaults the Ruby implementation wants to provide for RubyGems
-
-      require "rubygems/defaults/#{RUBY_ENGINE}"
-    rescue LoadError
-    end
   end
 end
 

--- a/lib/rubygems/compatibility.rb
+++ b/lib/rubygems/compatibility.rb
@@ -9,26 +9,6 @@
 # Ruby 1.9.x has introduced some things that are awkward, and we need to
 # support them, so we define some constants to use later.
 #++
-module Gem
-  # Only MRI 1.9.2 has the custom prelude.
-  GEM_PRELUDE_SUCKAGE = RUBY_VERSION =~ /^1\.9\.2/ and RUBY_ENGINE == "ruby"
-end
-
-# Gem::QuickLoader exists in the gem prelude code in ruby 1.9.2 itself.
-# We gotta get rid of it if it's there, before we do anything else.
-if Gem::GEM_PRELUDE_SUCKAGE and defined?(Gem::QuickLoader) then
-  Gem::QuickLoader.remove
-
-  $LOADED_FEATURES.delete Gem::QuickLoader.path_to_full_rubygems_library
-
-  if path = $LOADED_FEATURES.find {|n| n.end_with? '/rubygems.rb'} then
-    raise LoadError, "another rubygems is already loaded from #{path}"
-  end
-
-  class << Gem
-    remove_method :try_activate if Gem.respond_to?(:try_activate, true)
-  end
-end
 
 module Gem
   RubyGemsVersion = VERSION


### PR DESCRIPTION
# Description:

`Gem::GEM_PRELUDE_SUCKAGE` was no longer used in the master branch.

______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
