### PR TITLE
[TarHeader] Extract the empty header into a constant

### DIFF
--- a/lib/rubygems/package/tar_header.rb
+++ b/lib/rubygems/package/tar_header.rb
@@ -94,12 +94,14 @@ class Gem::Package::TarHeader
 
   attr_reader(*FIELDS)
 
+  EMPTY_HEADER = ("\0" * 512).freeze # :nodoc:
+
   ##
   # Creates a tar header from IO +stream+
 
   def self.from(stream)
     header = stream.read 512
-    empty = (header == "\0" * 512)
+    empty = (EMPTY_HEADER == header)
 
     fields = header.unpack UNPACK_FORMAT
 

--- a/lib/rubygems/package/tar_writer.rb
+++ b/lib/rubygems/package/tar_writer.rb
@@ -111,7 +111,7 @@ class Gem::Package::TarWriter
     name, prefix = split_name name
 
     init_pos = @io.pos
-    @io.write "\0" * 512 # placeholder for the header
+    @io.write Gem::Package::TarHeader::EMPTY_HEADER # placeholder for the header
 
     yield RestrictedStream.new(@io) if block_given?
 


### PR DESCRIPTION
# Description:

This way, we don't need to allocate new strings (and then do `String#*`) each time

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
