### PR TITLE
Remove needless define/respond_to condition

### DIFF
--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -63,21 +63,7 @@ class Gem::ConfigFile
       require "etc"
       Etc.sysconfdir
     rescue LoadError, NoMethodError
-      begin
-        # TODO: remove after we drop 1.8.7 and 1.9.1
-        require 'Win32API'
-
-        CSIDL_COMMON_APPDATA = 0x0023
-        path = 0.chr * 260
-
-        SHGetFolderPath = Win32API.new 'shell32', 'SHGetFolderPath', 'PLPLP',
-        'L', :stdcall
-        SHGetFolderPath.call nil, CSIDL_COMMON_APPDATA, nil, 1, path
-
-        path.strip
-      rescue LoadError
-        RbConfig::CONFIG["sysconfdir"] || "/etc"
-      end
+      RbConfig::CONFIG["sysconfdir"] || "/etc"
     end
 
   # :startdoc:

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -665,14 +665,8 @@ EOM
     raise Gem::Package::FormatError.new(e.message, entry.full_name)
   end
 
-  if File.respond_to? :realpath
-    def realpath file
-      File.realpath file
-    end
-  else
-    def realpath file
-      file
-    end
+  def realpath file
+    File.realpath file
   end
 
 end

--- a/lib/rubygems/package/tar_reader.rb
+++ b/lib/rubygems/package/tar_reader.rb
@@ -93,10 +93,8 @@ class Gem::Package::TarReader
 
   def rewind
     if @init_pos == 0 then
-      raise Gem::Package::NonSeekableIO unless @io.respond_to? :rewind
       @io.rewind
     else
-      raise Gem::Package::NonSeekableIO unless @io.respond_to? :pos=
       @io.pos = @init_pos
     end
   end

--- a/lib/rubygems/package/tar_reader/entry.rb
+++ b/lib/rubygems/package/tar_reader/entry.rb
@@ -145,8 +145,6 @@ class Gem::Package::TarReader::Entry
   def rewind
     check_closed
 
-    raise Gem::Package::NonSeekableIO unless @io.respond_to? :pos=
-
     @io.pos = @orig_pos
     @read = 0
   end

--- a/lib/rubygems/package/tar_writer.rb
+++ b/lib/rubygems/package/tar_writer.rb
@@ -106,8 +106,6 @@ class Gem::Package::TarWriter
   def add_file(name, mode) # :yields: io
     check_closed
 
-    raise Gem::Package::NonSeekableIO unless @io.respond_to? :pos=
-
     name, prefix = split_name name
 
     init_pos = @io.pos

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -164,9 +164,7 @@ class Gem::RemoteFetcher
       begin
         source_uri = URI.parse(source_uri)
       rescue
-        source_uri = URI.parse(URI.const_defined?(:DEFAULT_PARSER) ?
-                               URI::DEFAULT_PARSER.escape(source_uri.to_s) :
-                               URI.escape(source_uri.to_s))
+        source_uri = URI.parse(URI::DEFAULT_PARSER.escape(source_uri.to_s))
       end
     end
 

--- a/lib/rubygems/request_set/lockfile/parser.rb
+++ b/lib/rubygems/request_set/lockfile/parser.rb
@@ -325,24 +325,13 @@ class Gem::RequestSet::Lockfile::Parser
     @tokens.peek
   end
 
-  if [].respond_to? :flat_map
-    def pinned_requirement name # :nodoc:
-      requirement = Gem::Dependency.new name
-      specification = @set.sets.flat_map { |set|
-        set.find_all(requirement)
-      }.compact.first
+  def pinned_requirement name # :nodoc:
+    requirement = Gem::Dependency.new name
+    specification = @set.sets.flat_map { |set|
+      set.find_all(requirement)
+    }.compact.first
 
-      specification && specification.version
-    end
-  else # FIXME: remove when 1.8 is dropped
-    def pinned_requirement name # :nodoc:
-      requirement = Gem::Dependency.new name
-      specification = @set.sets.map { |set|
-        set.find_all(requirement)
-      }.flatten(1).compact.first
-
-      specification && specification.version
-    end
+    specification && specification.version
   end
 
   ##

--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -171,7 +171,7 @@ class Gem::Resolver
   include Molinillo::UI
 
   def output
-    @output ||= debug? ? $stdout : File.open(Gem::Util::NULL_DEVICE, 'w')
+    @output ||= debug? ? $stdout : File.open(IO::NULL, 'w')
   end
 
   def debug?

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -797,33 +797,13 @@ class Gem::Specification < Gem::BasicSpecification
   end
   private_class_method :map_stubs
 
-  uniq_takes_a_block = false
-  [1,2].uniq { uniq_takes_a_block = true }
-
-  if uniq_takes_a_block
-    def self.uniq_by(list, &block) # :nodoc:
-      list.uniq(&block)
-    end
-  else # FIXME: remove when 1.8 is dropped
-    def self.uniq_by(list) # :nodoc:
-      values = {}
-      list.each { |item|
-        value = yield item
-        values[value] ||= item
-      }
-      values.values
-    end
+  def self.uniq_by(list, &block) # :nodoc:
+    list.uniq(&block)
   end
   private_class_method :uniq_by
 
-  if [].respond_to? :sort_by!
-    def self.sort_by! list, &block
-      list.sort_by!(&block)
-    end
-  else # FIXME: remove when 1.8 is dropped
-    def self.sort_by! list, &block
-      list.replace list.sort_by(&block)
-    end
+  def self.sort_by! list, &block
+    list.sort_by!(&block)
   end
   private_class_method :sort_by!
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -788,22 +788,12 @@ class Gem::Specification < Gem::BasicSpecification
   end
   private_class_method :installed_stubs
 
-  if [].respond_to? :flat_map
-    def self.map_stubs(dirs, pattern) # :nodoc:
-      dirs.flat_map { |dir|
-        base_dir = File.dirname dir
-        gems_dir = File.join base_dir, "gems"
-        gemspec_stubs_in(dir, pattern) { |path| yield path, base_dir, gems_dir }
-      }
-    end
-  else # FIXME: remove when 1.8 is dropped
-    def self.map_stubs(dirs, pattern) # :nodoc:
-      dirs.map { |dir|
-        base_dir = File.dirname dir
-        gems_dir = File.join base_dir, "gems"
-        gemspec_stubs_in(dir, pattern) { |path| yield path, base_dir, gems_dir }
-      }.flatten 1
-    end
+  def self.map_stubs(dirs, pattern) # :nodoc:
+    dirs.flat_map { |dir|
+      base_dir = File.dirname dir
+      gems_dir = File.join base_dir, "gems"
+      gemspec_stubs_in(dir, pattern) { |path| yield path, base_dir, gems_dir }
+    }
   end
   private_class_method :map_stubs
 

--- a/lib/rubygems/user_interaction.rb
+++ b/lib/rubygems/user_interaction.rb
@@ -320,22 +320,7 @@ class Gem::StreamUI
 
   def _gets_noecho
     require_io_console
-    if Gem.win_platform?
-      require "Win32API"
-      password = ''
-
-      while char = Win32API.new("crtdll", "_getch", [ ], "L").Call do
-        break if char == 10 || char == 13 # received carriage return or newline
-        if char == 127 || char == 8 # backspace and delete
-          password.slice!(-1, 1)
-        else
-          password << char.chr
-        end
-      end
-      password
-    else
-      @ins.noecho {@ins.gets}
-    end
+    @ins.noecho {@ins.gets}
   end
 
   ##

--- a/lib/rubygems/user_interaction.rb
+++ b/lib/rubygems/user_interaction.rb
@@ -320,9 +320,7 @@ class Gem::StreamUI
 
   def _gets_noecho
     require_io_console
-    if IO.method_defined?(:noecho) then
-      @ins.noecho {@ins.gets}
-    elsif Gem.win_platform?
+    if Gem.win_platform?
       require "Win32API"
       password = ''
 
@@ -336,12 +334,7 @@ class Gem::StreamUI
       end
       password
     else
-      system "stty -echo"
-      begin
-        @ins.gets
-      ensure
-        system "stty echo"
-      end
+      @ins.noecho {@ins.gets}
     end
   end
 

--- a/lib/rubygems/user_interaction.rb
+++ b/lib/rubygems/user_interaction.rb
@@ -673,8 +673,8 @@ class Gem::SilentUI < Gem::StreamUI
   def initialize
     reader, writer = nil, nil
 
-    reader = File.open(Gem::Util::NULL_DEVICE, 'r')
-    writer = File.open(Gem::Util::NULL_DEVICE, 'w')
+    reader = File.open(IO::NULL, 'r')
+    writer = File.open(IO::NULL, 'w')
 
     super reader, writer, writer, false
   end

--- a/lib/rubygems/util.rb
+++ b/lib/rubygems/util.rb
@@ -67,13 +67,11 @@ module Gem::Util
     end
   end
 
-  NULL_DEVICE = defined?(IO::NULL) ? IO::NULL : Gem.win_platform? ? 'NUL' : '/dev/null'
-
   ##
   # Invokes system, but silences all output.
 
   def self.silent_system *command
-    opt = {:out => NULL_DEVICE, :err => [:child, :out]}
+    opt = {:out => IO::NULL, :err => [:child, :out]}
     if Hash === command.last
       opt.update(command.last)
       cmds = command[0...-1]
@@ -86,15 +84,13 @@ module Gem::Util
 
     @silent_mutex ||= Mutex.new
 
-    null_device = NULL_DEVICE
-
     @silent_mutex.synchronize do
       begin
         stdout = STDOUT.dup
         stderr = STDERR.dup
 
-        STDOUT.reopen null_device, 'w'
-        STDERR.reopen null_device, 'w'
+        STDOUT.reopen IO::NULL, 'w'
+        STDERR.reopen IO::NULL, 'w'
 
         return system(*command)
       ensure

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -751,7 +751,7 @@ class TestGemPackage < Gem::Package::TarTestCase
                    e.message
       io
     end
-    tf.close! if tf.respond_to? :close!
+    tf.close!
   end
 
   def test_verify_empty

--- a/test/rubygems/test_gem_package_tar_header.rb
+++ b/test/rubygems/test_gem_package_tar_header.rb
@@ -160,7 +160,7 @@ group\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000
       assert_raises ArgumentError do
         Gem::Package::TarHeader.from io
       end
-      io.close! if io.respond_to? :close!
+      io.close!
     end
   end
 

--- a/test/rubygems/test_gem_package_tar_writer.rb
+++ b/test/rubygems/test_gem_package_tar_writer.rb
@@ -175,12 +175,6 @@ class TestGemPackageTarWriter < Gem::Package::TarTestCase
     end
   end
 
-  def test_add_file_unseekable
-    assert_raises Gem::Package::NonSeekableIO do
-      Gem::Package::TarWriter.new(Object.new).add_file 'x', 0
-    end
-  end
-
   def test_close
     @tar_writer.close
 

--- a/test/rubygems/test_gem_path_support.rb
+++ b/test/rubygems/test_gem_path_support.rb
@@ -29,13 +29,11 @@ class TestGemPathSupport < Gem::TestCase
     assert_equal expected, ps.path
   end
 
-  if defined?(File::ALT_SEPARATOR) and File::ALT_SEPARATOR
-    def test_initialize_home_normalize
-      alternate = @tempdir.gsub(File::SEPARATOR, File::ALT_SEPARATOR)
-      ps = Gem::PathSupport.new "GEM_HOME" => alternate
+  def test_initialize_home_normalize
+    alternate = @tempdir.gsub(File::SEPARATOR, File::ALT_SEPARATOR)
+    ps = Gem::PathSupport.new "GEM_HOME" => alternate
 
-      assert_equal @tempdir, ps.home, "normalize values"
-    end
+    assert_equal @tempdir, ps.home, "normalize values"
   end
 
   def test_initialize_path

--- a/test/rubygems/test_gem_path_support.rb
+++ b/test/rubygems/test_gem_path_support.rb
@@ -29,11 +29,13 @@ class TestGemPathSupport < Gem::TestCase
     assert_equal expected, ps.path
   end
 
-  def test_initialize_home_normalize
-    alternate = @tempdir.gsub(File::SEPARATOR, File::ALT_SEPARATOR)
-    ps = Gem::PathSupport.new "GEM_HOME" => alternate
+  if File::ALT_SEPARATOR
+    def test_initialize_home_normalize
+      alternate = @tempdir.gsub(File::SEPARATOR, File::ALT_SEPARATOR)
+      ps = Gem::PathSupport.new "GEM_HOME" => alternate
 
-    assert_equal @tempdir, ps.home, "normalize values"
+      assert_equal @tempdir, ps.home, "normalize values"
+    end
   end
 
   def test_initialize_path

--- a/test/rubygems/test_gem_request_set.rb
+++ b/test/rubygems/test_gem_request_set.rb
@@ -218,7 +218,7 @@ ruby "0"
       assert_kind_of Gem::RequestSet::GemDependencyAPI, gem_deps
       io
     end
-    tf.close! if tf.respond_to? :close!
+    tf.close!
 
     assert_equal [dep('a')], rs.dependencies
 
@@ -239,7 +239,7 @@ ruby "0"
       assert_kind_of Gem::RequestSet::GemDependencyAPI, gem_deps
       io
     end
-    tf.close! if tf.respond_to? :close!
+    tf.close!
 
     assert_equal [dep('a')], rs.dependencies
   end
@@ -254,7 +254,7 @@ ruby "0"
       rs.load_gemdeps io.path, [:test]
       io
     end
-    tf.close! if tf.respond_to? :close!
+    tf.close!
 
     assert_empty rs.dependencies
   end
@@ -346,7 +346,7 @@ ruby "0"
       rs.load_gemdeps io.path
       io
     end
-    tf.close! if tf.respond_to? :close!
+    tf.close!
 
     res = rs.resolve
     assert_equal 1, res.size
@@ -410,7 +410,7 @@ ruby "0"
       rs.load_gemdeps io.path
       io
     end
-    tf.close! if tf.respond_to? :close!
+    tf.close!
 
     res = rs.resolve
     assert_equal 2, res.size

--- a/test/rubygems/test_gem_request_set_gem_dependency_api.rb
+++ b/test/rubygems/test_gem_request_set_gem_dependency_api.rb
@@ -627,7 +627,7 @@ end
       assert_equal [dep('a'), dep('b')], @set.dependencies
       io
     end
-    tf.close! if tf.respond_to? :close!
+    tf.close!
   end
 
   def test_pin_gem_source

--- a/test/rubygems/test_gem_request_set_lockfile_parser.rb
+++ b/test/rubygems/test_gem_request_set_lockfile_parser.rb
@@ -248,13 +248,8 @@ DEPENDENCIES
 
     assert_equal %w[a-2], lockfile_set.specs.map { |s| s.full_name }
 
-    if [].respond_to? :flat_map
-      assert_equal %w[https://gems.example/ https://other.example/],
-                   lockfile_set.specs.flat_map { |s| s.sources.map{ |src| src.uri.to_s } }
-    else # FIXME: remove when 1.8 is dropped
-      assert_equal %w[https://gems.example/ https://other.example/],
-                   lockfile_set.specs.map { |s| s.sources.map{ |src| src.uri.to_s } }.flatten(1)
-    end
+    assert_equal %w[https://gems.example/ https://other.example/],
+                 lockfile_set.specs.flat_map { |s| s.sources.map{ |src| src.uri.to_s } }
   end
 
   def test_parse_GIT

--- a/test/rubygems/test_gem_util.rb
+++ b/test/rubygems/test_gem_util.rb
@@ -42,13 +42,8 @@ class TestGemUtil < Gem::TestCase
 
     assert_equal File.join(@tempdir, 'd'), paths[0]
     assert_equal @tempdir, paths[1]
-    if File.respond_to?(:realpath)
-      assert_equal File.realpath(Dir.tmpdir), paths[2]
-      assert_equal File.realpath("..", Dir.tmpdir), paths[3]
-    elsif RUBY_PLATFORM !~ /darwin/
-      assert_equal Dir.tmpdir, paths[2]
-      assert_equal '/', paths[3]
-    end
+    assert_equal File.realpath(Dir.tmpdir), paths[2]
+    assert_equal File.realpath("..", Dir.tmpdir), paths[3]
   ensure
     # restore default permissions, allow the directory to be removed
     FileUtils.chmod(0775, 'd/e') unless win_platform?


### PR DESCRIPTION
# Description:

RubyGems has many of condition for method definition about old Ruby like 1.8 or 1.9. I removed them.

______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
