### PR TITLE
Validate SPDX license exceptions

### DIFF
--- a/lib/rubygems/util/licenses.rb
+++ b/lib/rubygems/util/licenses.rb
@@ -8,7 +8,7 @@ class Gem::Licenses
 
   # Software Package Data Exchange (SPDX) standard open-source software
   # license identifiers
-  IDENTIFIERS = %w(
+  LICENSE_IDENTIFIERS = %w(
       0BSD
       AAL
       ADSL
@@ -380,12 +380,43 @@ class Gem::Licenses
       zlib-acknowledgement
   ).freeze
 
+  # exception identifiers
+  EXCEPTION_IDENTIFIERS = %w(
+      389-exception
+      Autoconf-exception-2.0
+      Autoconf-exception-3.0
+      Bison-exception-2.2
+      Bootloader-exception
+      CLISP-exception-2.0
+      Classpath-exception-2.0
+      DigiRule-FOSS-exception
+      FLTK-exception
+      Fawkes-Runtime-exception
+      Font-exception-2.0
+      GCC-exception-2.0
+      GCC-exception-3.1
+      LZMA-exception
+      Libtool-exception
+      Linux-syscall-note
+      Nokia-Qt-exception-1.1
+      OCCT-exception-1.0
+      Qwt-exception-1.0
+      WxWindows-exception-3.1
+      eCos-exception-2.0
+      freertos-exception-2.0
+      gnu-javamail-exception
+      i2p-gpl-java-exception
+      mif-exception
+      openvpn-openssl-exception
+      u-boot-exception-2.0
+  ).freeze
+
   REGEXP = %r{
     \A
     (
-      #{Regexp.union(IDENTIFIERS)}
+      #{Regexp.union(LICENSE_IDENTIFIERS)}
       \+?
-      (\s WITH \s .+)?
+      (\s WITH \s #{Regexp.union(EXCEPTION_IDENTIFIERS)})?
       | #{NONSTANDARD}
     )
     \Z
@@ -396,7 +427,7 @@ class Gem::Licenses
   end
 
   def self.suggestions(license)
-    by_distance = IDENTIFIERS.group_by do |identifier|
+    by_distance = LICENSE_IDENTIFIERS.group_by do |identifier|
       levenshtein_distance(identifier, license)
     end
     lowest = by_distance.keys.min

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2979,6 +2979,20 @@ http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
     warning
   end
 
+  def test_validate_license_with_invalid_exception
+    util_setup_validate
+
+    use_ui @ui do
+      @a1.licenses = ['GPL-2.0+ WITH Autocofn-exception-2.0']
+      @a1.validate
+    end
+
+    assert_match <<-warning, @ui.error
+WARNING:  license value 'GPL-2.0+ WITH Autocofn-exception-2.0' is invalid.  Use a license identifier from
+http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
+    warning
+  end
+
   def test_validate_license_gives_suggestions
     util_setup_validate
 

--- a/util/generate_spdx_license_list.rb
+++ b/util/generate_spdx_license_list.rb
@@ -3,9 +3,13 @@ require 'json'
 require 'net/http'
 require 'uri'
 
-json = Net::HTTP.get(URI('https://spdx.org/licenses/licenses.json'))
-licenses = JSON.parse(json)['licenses'].map do |licenseObject|
+licenses_json = Net::HTTP.get(URI('https://spdx.org/licenses/licenses.json'))
+licenses = JSON.parse(licenses_json)['licenses'].map do |licenseObject|
   licenseObject['licenseId']
+end
+exceptions_json = Net::HTTP.get(URI('https://spdx.org/licenses/exceptions.json'))
+exceptions = JSON.parse(exceptions_json)['exceptions'].map do |exceptionObject|
+  exceptionObject['licenseExceptionId']
 end
 
 open 'lib/rubygems/util/licenses.rb', 'w' do |io|
@@ -20,16 +24,21 @@ class Gem::Licenses
 
   # Software Package Data Exchange (SPDX) standard open-source software
   # license identifiers
-  IDENTIFIERS = %w(
+  LICENSE_IDENTIFIERS = %w(
       #{licenses.sort.join "\n      "}
+  ).freeze
+
+  # exception identifiers
+  EXCEPTION_IDENTIFIERS = %w(
+      #{exceptions.sort.join "\n      "}
   ).freeze
 
   REGEXP = %r{
     \\A
     (
-      \#{Regexp.union(IDENTIFIERS)}
+      \#{Regexp.union(LICENSE_IDENTIFIERS)}
       \\+?
-      (\\s WITH \\s .+)?
+      (\\s WITH \\s \#{Regexp.union(EXCEPTION_IDENTIFIERS)})?
       | \#{NONSTANDARD}
     )
     \\Z
@@ -40,7 +49,7 @@ class Gem::Licenses
   end
 
   def self.suggestions(license)
-    by_distance = IDENTIFIERS.group_by do |identifier|
+    by_distance = LICENSE_IDENTIFIERS.group_by do |identifier|
       levenshtein_distance(identifier, license)
     end
     lowest = by_distance.keys.min


### PR DESCRIPTION
# Description:
[Current SPDX license expression regex](https://github.com/rubygems/rubygems/blob/master/lib/rubygems/util/licenses.rb#L388) does not validate [SPDX license exception identifiers](https://spdx.org/licenses/exceptions-index.html). I added an exception identifier list and its generator.
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
