### PR TITLE
Keep feature names loaded in the block

### DIFF
--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -769,6 +769,9 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
     old_loaded_features = $LOADED_FEATURES.dup
     yield
   ensure
+    prefix = File.dirname(__FILE__) + "/"
+    new_features = ($LOADED_FEATURES - old_loaded_features)
+    old_loaded_features.concat(new_features.select {|f| f.rindex(prefix, 0)})
     $LOADED_FEATURES.replace old_loaded_features
   end
 


### PR DESCRIPTION
# Description:

The test shows constant redefinition warnings sometimes.

```
# Running tests:

$BUILD/trunk/src/lib/rubygems/request_set/gem_dependency_api.rb:41: warning: already initialized constant Gem::RequestSet::GemDependencyAPI::ENGINE_MAPem_requ
$BUILD/trunk/src/lib/rubygems/request_set/gem_dependency_api.rb:41: warning: previous definition of ENGINE_MAP was here
$BUILD/trunk/src/lib/rubygems/request_set/gem_dependency_api.rb:64: warning: already initialized constant Gem::RequestSet::GemDependencyAPI::PLATFORM_MAP
$BUILD/trunk/src/lib/rubygems/request_set/gem_dependency_api.rb:64: warning: previous definition of PLATFORM_MAP was here
$BUILD/trunk/src/lib/rubygems/request_set/gem_dependency_api.rb:105: warning: already initialized constant Gem::RequestSet::GemDependencyAPI::VERSION_MAP
$BUILD/trunk/src/lib/rubygems/request_set/gem_dependency_api.rb:105: warning: previous definition of VERSION_MAP was here
$BUILD/trunk/src/lib/rubygems/request_set/gem_dependency_api.rb:140: warning: already initialized constant Gem::RequestSet::GemDependencyAPI::WINDOWS
$BUILD/trunk/src/lib/rubygems/request_set/gem_dependency_api.rb:140: warning: previous definition of WINDOWS was here
$BUILD/trunk/src/lib/rubygems/request_set/gem_dependency_api.rb:853: warning: already initialized constant Gem::RequestSet::GemDepedencyAPI
$BUILD/trunk/src/lib/rubygems/request_set/gem_dependency_api.rb:853: warning: previous definition of GemDepedencyAPI was here
$BUILD/trunk/src/lib/rubygems/request_set/lockfile/tokenizer.rb:5: warning: already initialized constant Gem::RequestSet::Lockfile::Tokenizer::Tokent_gem_requ
$BUILD/trunk/src/lib/rubygems/request_set/lockfile/tokenizer.rb:5: warning: previous definition of Token was here
$BUILD/trunk/src/lib/rubygems/request_set/lockfile/tokenizer.rb:6: warning: already initialized constant Gem::RequestSet::Lockfile::Tokenizer::EOF
$BUILD/trunk/src/lib/rubygems/request_set/lockfile/tokenizer.rb:6: warning: previous definition of EOF was here
Finished tests in 21.531344s, 92.2376 tests/s, 274.2513 assertions/s.                                                                                                       
1986 tests, 5905 assertions, 0 failures, 0 errors, 4 skips
```

This is because `Gem::TestCase#save_loaded_features` restores old `$LOADED_FEATURES` and removes new features loaded in the block.
Then another test or library loads the feature later, it will be loaded again.

This patch makes the rubygems libraries kept in the list.
It is not complete, but is fine for ruby's test at least.
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
