### PR TITLE
Tweak warning recommendation

### DIFF
--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -152,7 +152,7 @@ pessimistic dependency on #{dep} may be overly strict
   if #{dep.name} is semantically versioned, use:
     add_#{dep.type}_dependency '#{dep.name}', '~> #{base.join '.'}', '>= #{dep_version}'
   if #{dep.name} is not semantically versioned, you can bypass this warning with:
-    add_#{dep.type}_dependency '#{dep.name}', '>= #{dep_version}', '< #{upper_bound.join '.'}'
+    add_#{dep.type}_dependency '#{dep.name}', '>= #{dep_version}', '< #{upper_bound.join '.'}.x'
         WARNING
       end
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2614,12 +2614,12 @@ end
   if d is semantically versioned, use:
     add_runtime_dependency 'd', '~> 1.2', '>= 1.2.3'
   if d is not semantically versioned, you can bypass this warning with:
-    add_runtime_dependency 'd', '>= 1.2.3', '< 1.3'
+    add_runtime_dependency 'd', '>= 1.2.3', '< 1.3.x'
 #{w}:  pessimistic dependency on e (~> 1.2.3.4) may be overly strict
   if e is semantically versioned, use:
     add_runtime_dependency 'e', '~> 1.2', '>= 1.2.3.4'
   if e is not semantically versioned, you can bypass this warning with:
-    add_runtime_dependency 'e', '>= 1.2.3.4', '< 1.2.4'
+    add_runtime_dependency 'e', '>= 1.2.3.4', '< 1.2.4.x'
 #{w}:  open-ended dependency on i (>= 1.2) is not recommended
   if i is semantically versioned, use:
     add_runtime_dependency 'i', '~> 1.2'
@@ -2636,7 +2636,7 @@ end
   if m is semantically versioned, use:
     add_runtime_dependency 'm', '~> 2.1', '>= 2.1.0'
   if m is not semantically versioned, you can bypass this warning with:
-    add_runtime_dependency 'm', '>= 2.1.0', '< 2.2'
+    add_runtime_dependency 'm', '>= 2.1.0', '< 2.2.x'
 #{w}:  See http://guides.rubygems.org/specification-reference/ for help
       EXPECTED
 


### PR DESCRIPTION
# Description:

In #2242 I introduced a recommendation to fix the semver warning in the case where the dependency is not semantically version. However, I think the recommendation was incorrect since, for example, `< 5.2` still allows `5.2.0.rc1`, whereas something like `~> 5.1.5` does not.

I was bitten by this when I updated my dependencies according to the recommendation and the `rails-5.2.0.rc1` gem installed on my system was unintentionally activated.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
