### PR TITLE
Show git path in gem env

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -847,6 +847,21 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   end
 
   ##
+  # Git binary path
+
+  def self.git_path
+    exts = ENV["PATHEXT"] ? ENV["PATHEXT"].split(";") : [""]
+    ENV["PATH"].split(File::PATH_SEPARATOR).each do |path|
+      exts.each do |ext|
+        exe = File.join(path, "git#{ext}")
+        return exe if File.executable?(exe) && !File.directory?(exe)
+      end
+    end
+
+    return nil
+  end
+
+  ##
   # Refresh available gems from disk.
 
   def self.refresh

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -847,21 +847,6 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   end
 
   ##
-  # Git binary path
-
-  def self.git_path
-    exts = ENV["PATHEXT"] ? ENV["PATHEXT"].split(";") : [""]
-    ENV["PATH"].split(File::PATH_SEPARATOR).each do |path|
-      exts.each do |ext|
-        exe = File.join(path, "git#{ext}")
-        return exe if File.executable?(exe) && !File.directory?(exe)
-      end
-    end
-
-    return nil
-  end
-
-  ##
   # Refresh available gems from disk.
 
   def self.refresh

--- a/lib/rubygems/commands/environment_command.rb
+++ b/lib/rubygems/commands/environment_command.rb
@@ -120,7 +120,7 @@ lib/rubygems/defaults/operating_system.rb
 
     out << "  - RUBY EXECUTABLE: #{Gem.ruby}\n"
 
-    out << "  - GIT EXECUTABLE: #{Gem.git_path}\n"
+    out << "  - GIT EXECUTABLE: #{git_path}\n"
 
     out << "  - EXECUTABLE DIRECTORY: #{Gem.bindir}\n"
 
@@ -157,6 +157,23 @@ lib/rubygems/defaults/operating_system.rb
     add_path out, shell_path
 
     out
+  end
+
+  private
+
+  ##
+  # Git binary path
+
+  def git_path
+    exts = ENV["PATHEXT"] ? ENV["PATHEXT"].split(";") : [""]
+    ENV["PATH"].split(File::PATH_SEPARATOR).each do |path|
+      exts.each do |ext|
+        exe = File.join(path, "git#{ext}")
+        return exe if File.executable?(exe) && !File.directory?(exe)
+      end
+    end
+
+    return nil
   end
 
 end

--- a/lib/rubygems/commands/environment_command.rb
+++ b/lib/rubygems/commands/environment_command.rb
@@ -120,6 +120,8 @@ lib/rubygems/defaults/operating_system.rb
 
     out << "  - RUBY EXECUTABLE: #{Gem.ruby}\n"
 
+    out << "  - GIT EXECUTABLE: #{Gem.git_path}\n"
+
     out << "  - EXECUTABLE DIRECTORY: #{Gem.bindir}\n"
 
     out << "  - SPEC CACHE DIRECTORY: #{Gem.spec_cache_dir}\n"

--- a/test/rubygems/test_gem_commands_environment_command.rb
+++ b/test/rubygems/test_gem_commands_environment_command.rb
@@ -29,7 +29,7 @@ class TestGemCommandsEnvironmentCommand < Gem::TestCase
     assert_match %r|RUBYGEMS PREFIX: |, @ui.output
     assert_match %r|RUBY EXECUTABLE:.*#{RbConfig::CONFIG['ruby_install_name']}|,
                  @ui.output
-    assert_match %r|GIT EXECUTABLE: #{Gem.git_path}|, @ui.output
+    assert_match %r|GIT EXECUTABLE: #{@cmd.send(:git_path)}|, @ui.output
     assert_match %r|SYSTEM CONFIGURATION DIRECTORY:|, @ui.output
     assert_match %r|EXECUTABLE DIRECTORY:|, @ui.output
     assert_match %r|RUBYGEMS PLATFORMS:|, @ui.output

--- a/test/rubygems/test_gem_commands_environment_command.rb
+++ b/test/rubygems/test_gem_commands_environment_command.rb
@@ -29,6 +29,7 @@ class TestGemCommandsEnvironmentCommand < Gem::TestCase
     assert_match %r|RUBYGEMS PREFIX: |, @ui.output
     assert_match %r|RUBY EXECUTABLE:.*#{RbConfig::CONFIG['ruby_install_name']}|,
                  @ui.output
+    assert_match %r|GIT EXECUTABLE: #{Gem.git_path}|, @ui.output
     assert_match %r|SYSTEM CONFIGURATION DIRECTORY:|, @ui.output
     assert_match %r|EXECUTABLE DIRECTORY:|, @ui.output
     assert_match %r|RUBYGEMS PLATFORMS:|, @ui.output


### PR DESCRIPTION
# Description:
closes https://github.com/rubygems/rubygems/issues/2021

Adds Git path to `gem env`
```
RubyGems Environment:
  ...
  - GIT EXECUTABLE: /usr/bin/git
  ...
```

still need to add a test for this...

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
