### PR TITLE
Retry api specification spec with original platform

### DIFF
--- a/lib/rubygems/resolver/api_specification.rb
+++ b/lib/rubygems/resolver/api_specification.rb
@@ -21,6 +21,7 @@ class Gem::Resolver::APISpecification < Gem::Resolver::Specification
     @name = api_data[:name]
     @version = Gem::Version.new api_data[:number]
     @platform = Gem::Platform.new api_data[:platform]
+    @original_platform = api_data[:platform]
     @dependencies = api_data[:dependencies].map do |name, ver|
       Gem::Dependency.new name, ver.split(/\s*,\s*/)
     end
@@ -73,7 +74,11 @@ class Gem::Resolver::APISpecification < Gem::Resolver::Specification
     @spec ||=
       begin
         tuple = Gem::NameTuple.new @name, @version, @platform
+        source.fetch_spec tuple
+      rescue Gem::RemoteFetcher::FetchError
+        raise if @original_platform == @platform
 
+        tuple = Gem::NameTuple.new @name, @version, @original_platform
         source.fetch_spec tuple
       end
   end

--- a/test/rubygems/test_gem_resolver_api_specification.rb
+++ b/test/rubygems/test_gem_resolver_api_specification.rb
@@ -141,5 +141,29 @@ class TestGemResolverAPISpecification < Gem::TestCase
     assert_equal 'a-1', spec.full_name
   end
 
+  def test_spec_jruby_platform
+    spec_fetcher do |fetcher|
+      fetcher.gem 'j', 1 do |spec|
+        spec.platform = 'jruby'
+      end
+    end
+
+    dep_uri = URI(@gem_repo) + 'api/v1/dependencies'
+    set = Gem::Resolver::APISet.new dep_uri
+    data = {
+      :name         => 'j',
+      :number       => '1',
+      :platform     => 'jruby',
+      :dependencies => [],
+    }
+
+    api_spec = Gem::Resolver::APISpecification.new set, data
+
+    spec = api_spec.spec
+
+    assert_kind_of Gem::Specification, spec
+    assert_equal 'j-1-java', spec.full_name
+  end
+
 end
 


### PR DESCRIPTION
# Description:
closes https://github.com/rubygems/rubygems/issues/2140

Fallback to `original_platform` when no gem with `platform` is found

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
