### PR TITLE
support SOURCE_DATE_EPOCH to make gem spec reproducible

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -135,7 +135,7 @@ class Gem::Specification < Gem::BasicSpecification
     :autorequire               => nil,
     :bindir                    => 'bin',
     :cert_chain                => [],
-    :date                      => TODAY,
+    :date                      => nil,
     :dependencies              => [],
     :description               => nil,
     :email                     => nil,
@@ -1713,13 +1713,16 @@ class Gem::Specification < Gem::BasicSpecification
     }
   end
 
-  ##
-  # The date this gem was created.  Lazily defaults to the current UTC date.
+  # The date this gem was created.
   #
-  # There is no need to set this in your gem specification.
+  # If SOURCE_DATE_EPOCH is set as an environment variable, use that to support
+  # reproducible builds; otherwise, default to the current UTC date.
+  #
+  # Details on SOURCE_DATE_EPOCH:
+  # https://reproducible-builds.org/specs/source-date-epoch/
 
   def date
-    @date ||= TODAY
+    @date ||= ENV["SOURCE_DATE_EPOCH"] ? Time.utc(*Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc.to_a[3..5].reverse) : TODAY
   end
 
   DateLike = Object.new # :nodoc:

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1630,6 +1630,11 @@ dependencies: []
     assert_equal Time.utc(2012,01,12,0,0,0), @a1.date
   end
 
+  def test_date_use_env_source_date_epoch
+    ENV["SOURCE_DATE_EPOCH"] = "123456789"
+    assert_equal Time.utc(1973,11,29,0,0,0), @a1.date
+  end
+
   def test_dependencies
     util_setup_deps
     assert_equal [@bonobo, @monkey], @gem.dependencies


### PR DESCRIPTION
Optionally respect the SOURCE_DATE_EPOCH environment variable to be used
instead of TODAY to allow reproducible builds of created gem specs.

In case none is specified, fall back to the current time.
______________

The problem is that using TODAY will change during time which makes created artifacts not reproducible (bit by bit identical).

Spec:
https://reproducible-builds.org/specs/source-date-epoch/

Buy-in:
https://reproducible-builds.org/docs/buy-in/

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
