### PR TITLE
chdir back to original directory when building an extension fails

### DIFF
--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -162,14 +162,17 @@ EOF
       CHDIR_MUTEX.synchronize do
         pwd = Dir.getwd
         Dir.chdir extension_dir
-        results = builder.build(extension, dest_path,
-                                results, @build_args, lib_dir)
-
-        verbose { results.join("\n") }
         begin
-          Dir.chdir pwd
-        rescue SystemCallError
-          Dir.chdir dest_path
+          results = builder.build(extension, dest_path,
+                                  results, @build_args, lib_dir)
+
+          verbose { results.join("\n") }
+        ensure
+          begin
+            Dir.chdir pwd
+          rescue SystemCallError
+            Dir.chdir dest_path
+          end
         end
       end
 

--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -210,6 +210,8 @@ install:
   end
 
   def test_build_extensions_extconf_bad
+    cwd = Dir.pwd
+
     @spec.extensions << 'extconf.rb'
 
     FileUtils.mkdir_p @spec.gem_dir
@@ -240,6 +242,8 @@ install:
 
     assert_match %r%#{Regexp.escape Gem.ruby}: No such file%,
                  File.read(gem_make_out)
+
+    assert_equal cwd, Dir.pwd
   end
 
   def test_build_extensions_unsupported


### PR DESCRIPTION
# Description:

Fixes a regression caused by https://github.com/rubygems/rubygems/pull/1135, in which the directory wouldn't be restored when building an extension failed, causing any error handlers (such as Bundler's) to be run in an unexpected directory

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).