### PR TITLE
support SOURCE_DATE_EPOCH to make gem tar reproducible

### DIFF
--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -160,7 +160,7 @@ class Gem::Package
   def initialize gem, security_policy # :notnew:
     @gem = gem
 
-    @build_time      = Time.now
+    @build_time      = ENV["SOURCE_DATE_EPOCH"] ? Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc : Time.now
     @checksums       = {}
     @contents        = nil
     @digests         = Hash.new { |h, algorithm| h[algorithm] = {} }

--- a/lib/rubygems/package/tar_writer.rb
+++ b/lib/rubygems/package/tar_writer.rb
@@ -123,7 +123,7 @@ class Gem::Package::TarWriter
 
     header = Gem::Package::TarHeader.new :name => name, :mode => mode,
                                          :size => size, :prefix => prefix,
-                                         :mtime => Time.now
+                                         :mtime => ENV["SOURCE_DATE_EPOCH"] ? Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc : Time.now
 
     @io.write header
     @io.pos = final_pos
@@ -218,7 +218,7 @@ class Gem::Package::TarWriter
 
     header = Gem::Package::TarHeader.new(:name => name, :mode => mode,
                                          :size => size, :prefix => prefix,
-                                         :mtime => Time.now).to_s
+                                         :mtime => ENV["SOURCE_DATE_EPOCH"] ? Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc : Time.now).to_s
 
     @io.write header
     os = BoundedStream.new @io, size
@@ -246,7 +246,7 @@ class Gem::Package::TarWriter
                                          :size => 0, :typeflag => "2",
                                          :linkname => target,
                                          :prefix => prefix,
-                                         :mtime => Time.now).to_s
+                                         :mtime => ENV["SOURCE_DATE_EPOCH"] ? Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc : Time.now).to_s
 
     @io.write header
 
@@ -299,7 +299,7 @@ class Gem::Package::TarWriter
     header = Gem::Package::TarHeader.new :name => name, :mode => mode,
                                          :typeflag => "5", :size => 0,
                                          :prefix => prefix,
-                                         :mtime => Time.now
+                                         :mtime => ENV["SOURCE_DATE_EPOCH"] ? Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc : Time.now
 
     @io.write header
 

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -104,6 +104,22 @@ class TestGemPackage < Gem::Package::TarTestCase
     assert_equal expected, YAML.load(checksums)
   end
 
+  def test_build_time_source_date_epoch
+    ENV["SOURCE_DATE_EPOCH"] = "123456789"
+
+    spec = Gem::Specification.new 'build', '1'
+    spec.summary = 'build'
+    spec.authors = 'build'
+    spec.files = ['lib/code.rb']
+    spec.date = Time.at 0
+    spec.rubygems_version = Gem::Version.new '0'
+
+
+    package = Gem::Package.new spec.file_name
+
+    assert_equal Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc, package.build_time
+  end
+
   def test_add_files
     spec = Gem::Specification.new
     spec.files = %w[lib/code.rb lib/empty]

--- a/test/rubygems/test_gem_package_tar_writer.rb
+++ b/test/rubygems/test_gem_package_tar_writer.rb
@@ -31,6 +31,16 @@ class TestGemPackageTarWriter < Gem::Package::TarTestCase
     assert_equal 1024, @io.pos
   end
 
+  def test_add_file_source_date_epoch
+    ENV["SOURCE_DATE_EPOCH"] = "123456789"
+    Time.stub :now, Time.at(1458518157) do
+      @tar_writer.mkdir 'foo', 0644
+
+      assert_headers_equal tar_dir_header('foo', '', 0644, Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc),
+                           @io.string[0, 512]
+    end
+  end
+
   def test_add_symlink
     Time.stub :now, Time.at(1458518157) do
       @tar_writer.add_symlink 'x', 'y', 0644
@@ -39,6 +49,16 @@ class TestGemPackageTarWriter < Gem::Package::TarTestCase
                          @io.string[0, 512])
     end
     assert_equal 512, @io.pos
+  end
+
+  def test_add_symlink_source_date_epoch
+    ENV["SOURCE_DATE_EPOCH"] = "123456789"
+    Time.stub :now, Time.at(1458518157) do
+      @tar_writer.add_symlink 'x', 'y', 0644
+
+      assert_headers_equal(tar_symlink_header('x', '', 0644, Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc, 'y'),
+                         @io.string[0, 512])
+    end
   end
 
   def test_add_file_digest
@@ -148,6 +168,16 @@ class TestGemPackageTarWriter < Gem::Package::TarTestCase
     assert_equal 1024, @io.pos
   end
 
+  def test_add_file_simple_source_date_epoch
+    ENV["SOURCE_DATE_EPOCH"] = "123456789"
+    Time.stub :now, Time.at(1458518157) do
+      @tar_writer.add_file_simple 'x', 0644, 10 do |io| io.write "a" * 10 end
+
+      assert_headers_equal(tar_file_header('x', '', 0644, 10, Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc),
+                         @io.string[0, 512])
+    end
+  end
+
   def test_add_file_simple_padding
     Time.stub :now, Time.at(1458518157) do
       @tar_writer.add_file_simple 'x', 0, 100
@@ -214,6 +244,16 @@ class TestGemPackageTarWriter < Gem::Package::TarTestCase
                            @io.string[0, 512]
 
       assert_equal 512, @io.pos
+    end
+  end
+
+  def test_mkdir_source_date_epoch
+    ENV["SOURCE_DATE_EPOCH"] = "123456789"
+    Time.stub :now, Time.at(1458518157) do
+      @tar_writer.mkdir 'foo', 0644
+
+      assert_headers_equal tar_dir_header('foo', '', 0644, Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc),
+                           @io.string[0, 512]
     end
   end
 


### PR DESCRIPTION
Optionally respect the SOURCE_DATE_EPOCH environment variable to be used
instead of Time.now to allow reproducible builds of created gem tarballs.

In case none is specified, fall back to the current time.

# Description:

The problem is that using Time.now will change during time which makes created gem tarballs not reproducible (bit by bit identical).

This is related to making the .gemspec file's itself reproducible: #2278 

Spec:
https://reproducible-builds.org/specs/source-date-epoch/

Buy-in:
https://reproducible-builds.org/docs/buy-in/
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
