### PR TITLE
Ignore vendored molinillo from code coverage

### DIFF
--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -23,6 +23,7 @@ begin
   SimpleCov.start do
     add_filter "/test/"
     add_filter "/bundler/"
+    add_filter "/lib/rubygems/resolver/molinillo"
   end
 rescue LoadError
 end


### PR DESCRIPTION
# Description:

molinillo is not controlled for code coverage on rubygems repo.
______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
