### PR TITLE
Support IO.copy_stream

### DIFF
--- a/lib/rubygems/package/tar_reader/entry.rb
+++ b/lib/rubygems/package/tar_reader/entry.rb
@@ -129,7 +129,7 @@ class Gem::Package::TarReader::Entry
   # Reads +len+ bytes from the tar file entry, or the rest of the entry if
   # nil
 
-  def read(len = nil, outbuf = "".b)
+  def read(len = nil)
     check_closed
 
     return nil if @read >= @header.size
@@ -137,11 +137,10 @@ class Gem::Package::TarReader::Entry
     len ||= @header.size - @read
     max_read = [len, @header.size - @read].min
 
-    _size = outbuf.size
-    @io.read(max_read, outbuf)
-    @read += max_read
+    ret = @io.read max_read
+    @read += ret.size
 
-    outbuf
+    ret
   end
 
   def readpartial(maxlen = nil, outbuf = "".b)

--- a/lib/rubygems/package/tar_reader/entry.rb
+++ b/lib/rubygems/package/tar_reader/entry.rb
@@ -153,7 +153,7 @@ class Gem::Package::TarReader::Entry
     max_read = [maxlen, @header.size - @read].min
 
     _size = outbuf.size
-    @io.read(max_read, outbuf)
+    @io.readpartial(max_read, outbuf)
     @read += max_read
 
     outbuf

--- a/lib/rubygems/package/tar_reader/entry.rb
+++ b/lib/rubygems/package/tar_reader/entry.rb
@@ -144,13 +144,13 @@ class Gem::Package::TarReader::Entry
     outbuf
   end
 
-  def readpartial(maxlen, outbuf = "".b)
+  def readpartial(maxlen = nil, outbuf = "".b)
     check_closed
 
     raise EOFError if @read >= @header.size
 
-    len ||= @header.size - @read
-    max_read = [len, @header.size - @read].min
+    maxlen ||= @header.size - @read
+    max_read = [maxlen, @header.size - @read].min
 
     _size = outbuf.size
     @io.read(max_read, outbuf)

--- a/lib/rubygems/package/tar_reader/entry.rb
+++ b/lib/rubygems/package/tar_reader/entry.rb
@@ -152,7 +152,7 @@ class Gem::Package::TarReader::Entry
     max_read = [maxlen, @header.size - @read].min
 
     @io.readpartial(max_read, outbuf)
-    @read += max_read
+    @read += outbuf.size
 
     outbuf
   end

--- a/lib/rubygems/package/tar_reader/entry.rb
+++ b/lib/rubygems/package/tar_reader/entry.rb
@@ -151,7 +151,6 @@ class Gem::Package::TarReader::Entry
     maxlen ||= @header.size - @read
     max_read = [maxlen, @header.size - @read].min
 
-    _size = outbuf.size
     @io.readpartial(max_read, outbuf)
     @read += max_read
 

--- a/test/rubygems/test_gem_package_tar_reader_entry.rb
+++ b/test/rubygems/test_gem_package_tar_reader_entry.rb
@@ -34,6 +34,10 @@ class TestGemPackageTarReaderEntry < Gem::Package::TarTestCase
     assert_equal 1, @entry.bytes_read
   end
 
+  def test_size
+    assert_equal @contents.size, @entry.size
+  end
+
   def test_close
     @entry.close
 
@@ -127,6 +131,13 @@ class TestGemPackageTarReaderEntry < Gem::Package::TarTestCase
 
   def test_read_small
     assert_equal @contents[0...100], @entry.read(100)
+  end
+
+  def test_readpartial
+    assert_raises(EOFError) do
+      @entry.read(@contents.size)
+      @entry.readpartial(1)
+    end
   end
 
   def test_rewind


### PR DESCRIPTION
Implement Gem::Package::TarReader::Entry#readpartial.
It raises EOFError when call readpartial after reach EOF.

In previous version, Gem::Package::TarReader::Entry#read does not
support 2nd argument. So we cannot run following sample code.

Sample code:

```ruby
File.open(target, "rb+") do |tar|
  Gem::Package::TarReader.new(tar) do |reader|
    reader.each do |entry|
      case
      when entry.file?
        File.open(entry.full_name, "w+") do |file|
          IO.copy_stream(entry, file)
        end
      when entry.directory?
        FileUtils.mkdir_p(entry.full_name)
      else
        # do nothing
      end
    end
  end
end
```