### PR TITLE
Fix warning from check_that_user_bin_dir_is_in_path on Windows

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -703,9 +703,10 @@ class Gem::Installer
     if Gem.win_platform? then
       path = path.downcase
       user_bin_dir = user_bin_dir.downcase
+      path = path.split(File::PATH_SEPARATOR).map(&:downcase)
+    else
+      path = path.split(File::PATH_SEPARATOR)
     end
-
-    path = path.split(File::PATH_SEPARATOR)
 
     unless path.include? user_bin_dir then
       unless !Gem.win_platform? && (path.include? user_bin_dir.sub(ENV['HOME'], '~'))


### PR DESCRIPTION
Windows standard is that all user folders begin with a base directory of `Users`, and `PATH` is often correctly capitalized.

`Gem::Installer#check_that_user_bin_dir_is_in_path` fails with a PATH that is correctly capitazlized.  PR fixes.

Thanks, Greg

# Tasks:

- [X] Describe the problem / feature
- [ ] Write tests
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
