### PR TITLE
Add error message when trying to open a default gem

### DIFF
--- a/lib/rubygems/commands/open_command.rb
+++ b/lib/rubygems/commands/open_command.rb
@@ -60,7 +60,13 @@ class Gem::Commands::OpenCommand < Gem::Command
 
   def open_gem name
     spec = spec_for name
+
     return false unless spec
+
+    if spec.default_gem?
+      say "'#{name}' is a default gem and can't be opened."
+      return false
+    end
 
     open_editor(spec.full_gem_path)
   end


### PR DESCRIPTION
# Description:

closes https://github.com/rubygems/rubygems/issues/2281

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
