### PR TITLE
Add alias command 'i' for 'install' command

### DIFF
--- a/lib/rubygems/command_manager.rb
+++ b/lib/rubygems/command_manager.rb
@@ -71,7 +71,7 @@ class Gem::CommandManager
     :yank,
   ]
 
-  ARIAS_COMMANDS = {
+  ALIAS_COMMANDS = {
     'i' => 'install'
   }
 
@@ -193,7 +193,7 @@ class Gem::CommandManager
   end
 
   def find_alias_command(cmd_name)
-    alias_name = ARIAS_COMMANDS[cmd_name]
+    alias_name = ALIAS_COMMANDS[cmd_name]
     alias_name ? alias_name : cmd_name
   end
 

--- a/lib/rubygems/command_manager.rb
+++ b/lib/rubygems/command_manager.rb
@@ -71,6 +71,10 @@ class Gem::CommandManager
     :yank,
   ]
 
+  ARIAS_COMMANDS = {
+    'i' => 'install'
+  }
+
   ##
   # Return the authoritative instance of the command manager.
 
@@ -174,6 +178,8 @@ class Gem::CommandManager
   end
 
   def find_command(cmd_name)
+    cmd_name = find_alias_command cmd_name
+
     possibilities = find_command_possibilities cmd_name
 
     if possibilities.size > 1 then
@@ -184,6 +190,11 @@ class Gem::CommandManager
     end
 
     self[possibilities.first]
+  end
+
+  def find_alias_command(cmd_name)
+    alias_name = ARIAS_COMMANDS[cmd_name]
+    alias_name ? alias_name : cmd_name
   end
 
   def find_command_possibilities(cmd_name)

--- a/test/rubygems/test_gem_command_manager.rb
+++ b/test/rubygems/test_gem_command_manager.rb
@@ -29,6 +29,12 @@ class TestGemCommandManager < Gem::TestCase
                  e.message
   end
 
+  def test_find_alias_command
+    command = @command_manager.find_command 'i'
+
+    assert_kind_of Gem::Commands::InstallCommand, command
+  end
+
   def test_find_command_ambiguous_exact
     ins_command = Class.new
     Gem::Commands.send :const_set, :InsCommand, ins_command


### PR DESCRIPTION
# Description:

In rubygems 2.x, the command that started with `i` was `install` command only.  
So we can install gem by following command like [npm](https://docs.npmjs.com/cli/install).  
`gem i bundler`

But rubygems 3.x have `info` command.  
https://github.com/rubygems/rubygems/pull/2023  

So this command doesn't work

```bash
% gem i bundler
ERROR:  While executing gem ... (Gem::CommandLineError)
    Ambiguous command i matches [info, install]
```

The `i` command work well in 2.x and this command is very useful as we install lots of gem.  
So it would be nice to set an alias for this command.

______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
