### PR TITLE
Bundler issue

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,18 +28,6 @@ init:
       }
 
 install:
-# Temporary fix until Appveyor installs RubyGems 2.7.7
-- ps: >-
-    if ($env:ruby_version -lt '25') {
-      gem uninstall bundler -x
-      Push-Location C:\
-      gem fetch  rubygems-update -v 2.7.7
-      gem unpack rubygems-update-2.7.7.gem
-      Push-Location C:\rubygems-update-2.7.7
-      ruby setup.rb
-      Pop-Location
-      Pop-Location
-    }
 - ps: >-
     git submodule update --init --recursive
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -820,7 +820,7 @@ class Gem::Specification < Gem::BasicSpecification
   def self.stubs
     @@stubs ||= begin
       pattern = "*.gemspec"
-      stubs = default_stubs(pattern).concat installed_stubs(dirs, pattern)
+      stubs = Gem.loaded_specs.values + default_stubs(pattern) + installed_stubs(dirs, pattern)
       stubs = uniq_by(stubs) { |stub| stub.full_name }
 
       _resort!(stubs)
@@ -839,7 +839,7 @@ class Gem::Specification < Gem::BasicSpecification
       @@stubs_by_name[name] || []
     else
       pattern = "#{name}-*.gemspec"
-      stubs = default_stubs(pattern) + installed_stubs(dirs, pattern)
+      stubs = Gem.loaded_specs.values + default_stubs(pattern) + installed_stubs(dirs, pattern)
       stubs = uniq_by(stubs) { |stub| stub.full_name }.group_by(&:name)
       stubs.each_value { |v| _resort!(v) }
 

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -13,6 +13,15 @@ else
   require 'rubygems'
 end
 
+# If bundler gemspec exists, add to stubs
+bundler_gemspec = File.expand_path("../../../bundler/bundler.gemspec", __FILE__)
+if File.exist?(bundler_gemspec)
+  Gem::Specification.dirs.unshift File.dirname(bundler_gemspec)
+  Gem::Specification.class_variable_set :@@stubs, nil
+  Gem::Specification.stubs
+  Gem::Specification.dirs.shift
+end
+
 begin
   gem 'minitest'
 rescue Gem::LoadError


### PR DESCRIPTION
# Description:

First of all, I don't pretend to have great knowledge of RubyGems, so, this might be totally wrong...

Testing on Appveyor seemed to be broken after a rubygems-update to 2.7.6.

Investigating locally, it seemed that `Gem::Specification.stubs` &  `Gem::Specification.stubs_for` only load gemspecs from standard locations, but don't include currently loaded gems (`Gem.loaded_specs.values`).

So, I loaded bundler in the `Rake::Testtask` (only if it's included in the repo), and added the loaded gemspecs to `stubs` and `stubs_for`.  This PR also includes a commit removing the 'temp fix' for Appveyor.

Note that in my fork I had a 'false fail' due to a leftover file artifact.

# Tasks:

- [X] Describe the problem / feature
- [ ] Write tests
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).