### PR TITLE
Fix for installing both 32 & 64 bit mingw binary gems in --user-install

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -782,8 +782,18 @@ class Gem::Specification < Gem::BasicSpecification
   private_class_method :default_stubs
 
   def self.installed_stubs dirs, pattern
-    map_stubs(dirs, pattern) do |path, base_dir, gems_dir|
-      Gem::StubSpecification.gemspec_stub(path, base_dir, gems_dir)
+    # if mingw, derive platform from file name (loaded_from)
+    if RUBY_PLATFORM.match('mingw')
+      map_stubs(dirs, pattern) do |path, base_dir, gems_dir|
+        Gem::StubSpecification.gemspec_stub(path, base_dir, gems_dir)
+      end.select do |s|
+        (plat = s.loaded_from[/(x\d{2}-mingw32)\.gemspec/,1]) ?
+          Gem::Platform.match(plat) : true
+      end
+    else
+      map_stubs(dirs, pattern) do |path, base_dir, gems_dir|
+        Gem::StubSpecification.gemspec_stub(path, base_dir, gems_dir)
+      end
     end
   end
   private_class_method :installed_stubs


### PR DESCRIPTION
## Description:

At present, if a Windows user (mingw) installs both 32 and 64 bit binary gems in `--user-install` (assuming the same ABI version), the following occurs:

1. `gem list` shows both 32 & 64 bit gems regardless of ruby build being used.
2. `require` fails one build or the other.  I think 32 bit fails because 'x86' sorts after `x64`.

This PR fixes both issues.  Rather than using StubSpec data, platform info is derived from a regex of the `loaded_from` filename.  Fully tested locally.

See issue #2301.  Also, PR #2119 affects this (and allows it to work), as, although 32 & 64 bit binary gems have separate gem folders and spec names, they share a common bin stub.  If a bin stub has a hard coded path, it will override PATH and possibly choose the wrong ruby version...

Thanks, Greg

# Tasks:

- [X] Describe the problem / feature
- [ ] Write tests
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).