### PR TITLE
Dont warn on prerelease dependencies with less than ("<")

### DIFF
--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -125,6 +125,8 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
 
       seen[dep.type][dep.name] = dep
 
+      dep_requirements = dep.requirement.requirements
+
       prerelease_dep = dep.requirements_list.any? do |req|
         Gem::Requirement.new(req).prerelease?
       end
@@ -132,8 +134,8 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
       warning_messages << "prerelease dependency on #{dep} is not recommended" if
           prerelease_dep && !version.prerelease?
 
-      overly_strict = dep.requirement.requirements.length == 1 &&
-          dep.requirement.requirements.any? do |op, version|
+      overly_strict = dep_requirements.length == 1 &&
+          dep_requirements.any? do |op, version|
             op == '~>' and
                 not version.prerelease? and
                 version.segments.length > 2 and
@@ -141,7 +143,7 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
           end
 
       if overly_strict then
-        _, dep_version = dep.requirement.requirements.first
+        _, dep_version = dep_requirements.first
 
         base = dep_version.segments.first 2
         upper_bound = dep_version.segments.first(dep_version.segments.length - 1)
@@ -156,12 +158,12 @@ pessimistic dependency on #{dep} may be overly strict
         WARNING
       end
 
-      open_ended = dep.requirement.requirements.all? do |op, version|
+      open_ended = dep_requirements.all? do |op, version|
         not version.prerelease? and (op == '>' or op == '>=')
       end
 
       if open_ended then
-        op, dep_version = dep.requirement.requirements.first
+        op, dep_version = dep_requirements.first
 
         base = dep_version.segments.first 2
 

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -127,8 +127,8 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
 
       dep_requirements = dep.requirement.requirements
 
-      prerelease_dep = dep.requirements_list.any? do |req|
-        Gem::Requirement.new(req).prerelease?
+      prerelease_dep = dep_requirements.any? do |op, version|
+        version.prerelease? and op != '<'
       end
 
       warning_messages << "prerelease dependency on #{dep} is not recommended" if

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2650,6 +2650,7 @@ end
       @a1.add_runtime_dependency     'l', '> 1.2.3'
       @a1.add_runtime_dependency     'm', '~> 2.1.0'
       @a1.add_runtime_dependency     'n', '~> 0.1.0'
+      @a1.add_runtime_dependency     'o', '< 1.0.x'
 
       use_ui @ui do
         @a1.validate


### PR DESCRIPTION
# Description:

I just saw this warning when installing my gem:

```
WARNING:  prerelease dependency on rails (< 6.0.x, >= 5.2) is not recommended
```

I can see the rationale for the "prerelease warning" but doesn't look reasonable when the requirement is using "<", since in that case we're filtering out prereleases. Right?
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
