### PR TITLE
Removed explicitly declaration of thread library.

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -7,7 +7,6 @@
 #++
 
 require 'rbconfig'
-require 'thread'
 
 module Gem
   VERSION = "3.0.0.beta1"

--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -6,7 +6,6 @@
 #++
 
 require 'rubygems/user_interaction'
-require 'thread'
 
 class Gem::Ext::Builder
 

--- a/lib/rubygems/request.rb
+++ b/lib/rubygems/request.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'net/http'
-require 'thread'
 require 'time'
 require 'rubygems/user_interaction'
 

--- a/lib/rubygems/request/connection_pools.rb
+++ b/lib/rubygems/request/connection_pools.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'thread'
 
 class Gem::Request::ConnectionPools # :nodoc:
 

--- a/lib/rubygems/util.rb
+++ b/lib/rubygems/util.rb
@@ -80,8 +80,6 @@ module Gem::Util
     end
     return system(*(cmds << opt))
   rescue TypeError
-    require 'thread'
-
     @silent_mutex ||= Mutex.new
 
     @silent_mutex.synchronize do


### PR DESCRIPTION
# Description:

`require 'thread'` is obsoleted with current support version.
______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
