### PR TITLE
Make spec reset more informative

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1280,11 +1280,17 @@ class Gem::Specification < Gem::BasicSpecification
     unresolved = unresolved_deps
     unless unresolved.empty? then
       w = "W" + "ARN"
-      warn "#{w}: Unresolved specs during Gem::Specification.reset:"
+      warn "#{w}: Unresolved or ambigious specs during Gem::Specification.reset:"
       unresolved.values.each do |dep|
         warn "      #{dep}"
+        
+        versions = Gem::Specification.find_all_by_name(dep.name)
+        unless versions.empty?
+          warn "      Available/installed versions of this gem:"
+          versions.each { |s| warn "      - #{s.version}" }
+        end
       end
-      warn "#{w}: Clearing out unresolved specs."
+      warn "#{w}: Clearing out unresolved specs. Try 'gem cleanup <gem>'"
       warn "Please report a bug if this causes problems."
       unresolved.clear
     end

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1283,8 +1283,8 @@ class Gem::Specification < Gem::BasicSpecification
       warn "#{w}: Unresolved or ambigious specs during Gem::Specification.reset:"
       unresolved.values.each do |dep|
         warn "      #{dep}"
-        
-        versions = Gem::Specification.find_all_by_name(dep.name)
+
+        versions = find_all_by_name(dep.name)
         unless versions.empty?
           warn "      Available/installed versions of this gem:"
           versions.each { |s| warn "      - #{s.version}" }

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2887,7 +2887,7 @@ duplicate dependency on c (>= 1.2.3, development), (~> 1.2) use:
                  @a1.files
   end
 
-  def test_unresolved_specs_warinings
+  def test_unresolved_specs_warnings
     specification = Gem::Specification.clone
 
     specification.define_singleton_method(:unresolved_deps) do

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2887,17 +2887,15 @@ duplicate dependency on c (>= 1.2.3, development), (~> 1.2) use:
                  @a1.files
   end
 
-  def test_unresolved_specs_warnings
+  def test_unresolved_specs
     specification = Gem::Specification.clone
 
     specification.define_singleton_method(:unresolved_deps) do
-      { b: Gem::Dependency.new('x','1') }
+      { b: Gem::Dependency.new("x","1") }
     end
 
     specification.define_singleton_method(:find_all_by_name) do |dep_name|
-      [
-        specification.new { |s| s.name = "z", s.version = Gem::Version.new("1") }
-      ]
+      []
     end
 
     expected = <<-EXPECTED
@@ -2907,6 +2905,34 @@ WARN: Clearing out unresolved specs. Try 'gem cleanup <gem>'
 Please report a bug if this causes problems.
     EXPECTED
 
+    assert_output nil, expected do
+     specification.reset
+    end
+  end
+
+  def test_unresolved_specs_with_versions
+    specification = Gem::Specification.clone
+
+    specification.define_singleton_method(:unresolved_deps) do
+      { b: Gem::Dependency.new("x","1") }
+    end
+
+    specification.define_singleton_method(:find_all_by_name) do |dep_name|
+      [
+        specification.new { |s| s.name = "z", s.version = Gem::Version.new("1") },
+        specification.new { |s| s.name = "z", s.version = Gem::Version.new("2") }
+      ]
+    end
+
+    expected = <<-EXPECTED
+WARN: Unresolved or ambigious specs during Gem::Specification.reset:
+      x (= 1)
+      Available/installed versions of this gem:
+      - 1
+      - 2
+WARN: Clearing out unresolved specs. Try 'gem cleanup <gem>'
+Please report a bug if this causes problems.
+    EXPECTED
 
     assert_output nil, expected do
      specification.reset


### PR DESCRIPTION
# Description:

By JimPanic
```
According to http://stackoverflow.com/questions/17936340/unresolved-specs-during-gemspecification-reset this warning is (also?) shown when gem doesn't know what version of a gem it should use if multiple are available. The message however does not say that.

This change finds all installed versions and displays them alongside the original dependency and its version. It also proposes a gem cleanup.
```

This add a test for it.

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
