### PR TITLE
[Rakefile] Set bundler build metadata when doing a release

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -83,9 +83,9 @@ end
 # --------------------------------------------------------------------
 # Creating a release
 
-task :prerelease => [:clobber, :check_manifest, :test]
+task :prerelease => %w[clobber check_manifest test bundler:build_metadata]
 
-task :postrelease => %w[upload guides:publish blog:publish]
+task :postrelease => %w[bundler:build_metadata:clean upload guides:publish blog:publish]
 
 Gem::PackageTask.new(spec) {}
 
@@ -356,5 +356,15 @@ namespace :bundler do
   desc "Initialize bundler submodule"
   task :checkout do
     sh "git submodule update --init"
+  end
+
+  task :build_metadata do
+    chdir('bundler') { sh "rake build_metadata" }
+  end
+
+  namespace :build_metadata do
+    task :clean do
+      chdir('bundler') { sh "rake build_metadata:clean" }
+    end
   end
 end


### PR DESCRIPTION
# Description:

Should fix #2300 by invoking the bundler task to set the git version and data in the generate `BuildMetadata` file before releasing, and then reset the changes after release