### PR TITLE
Add overwrite-exec option to Install/Update

### DIFF
--- a/lib/rubygems/install_update_options.rb
+++ b/lib/rubygems/install_update_options.rb
@@ -203,6 +203,11 @@ module Gem::InstallUpdateOptions
       options[:suggest_alternate] = v
     end
 
+    add_option(:"Install/Update", '--overwrite-exec',
+               'Overwrite execs without prompt, use only in scripting') do |v,o|
+      options[:overwrite_exec] = true
+    end
+
   end
 
   ##

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -241,6 +241,11 @@ class Gem::Installer
     # somebody has written to RubyGems' directory, overwrite, too bad
     return if Gem.default_bindir != @bin_dir and not ruby_executable
 
+    if options[:overwrite_exec]
+      say "Overwriting executable"
+      return true
+    end
+
     question = "#{spec.name}'s executable \"#{filename}\" conflicts with ".dup
 
     if ruby_executable then

--- a/test/rubygems/test_gem_install_update_options.rb
+++ b/test/rubygems/test_gem_install_update_options.rb
@@ -29,6 +29,7 @@ class TestGemInstallUpdateOptions < Gem::InstallerTestCase
       -w
       --vendor
       --post-install-message
+      --overwrite-exec
     ]
 
     args.concat %w[-P HighSecurity] if defined?(OpenSSL::SSL)
@@ -196,5 +197,11 @@ class TestGemInstallUpdateOptions < Gem::InstallerTestCase
     @cmd.handle_options %w[--post-install-message]
 
     assert_equal true, @cmd.options[:post_install_message]
+  end
+
+  def test_overwrite_exec
+    @cmd.handle_options %w[--overwrite-exec]
+
+    assert_equal true, @cmd.options[:overwrite_exec]
   end
 end


### PR DESCRIPTION
# Description:

Add `--overwrite-exec` option to gem install/update, allowing use from scripts without UI prompt

# Tasks:

- [X] Describe the problem / feature
- [X] Write tests
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
