### PR TITLE
Fix required_ruby_version with prereleases and improve error message

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -959,7 +959,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     if defined?(RUBY_PATCHLEVEL) && RUBY_PATCHLEVEL != -1 then
       version << ".#{RUBY_PATCHLEVEL}"
     elsif defined?(RUBY_REVISION) then
-      version << ".dev.#{RUBY_REVISION}"
+      version << ".#{RUBY_DESCRIPTION.match(/\Aruby #{RUBY_VERSION}([^ ]+) /)[1]}.#{RUBY_REVISION}"
     end
 
     @ruby_version = Gem::Version.new version

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -960,9 +960,9 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
       version << ".#{RUBY_PATCHLEVEL}"
     elsif defined?(RUBY_DESCRIPTION) then
       if RUBY_ENGINE == "ruby" then
-        version << ".#{RUBY_DESCRIPTION.match(/\Aruby #{RUBY_VERSION}([^ ]+) /)[1]}"
+        version << ".#{RUBY_DESCRIPTION[/\Aruby #{RUBY_VERSION}([^ ]+) /, 1]}"
       else
-        version << ".#{RUBY_DESCRIPTION.match(/\A#{RUBY_ENGINE} #{RUBY_ENGINE_VERSION} \(#{RUBY_VERSION}([^ ]+)\) /)[1]}"
+        version << ".#{RUBY_DESCRIPTION[/\A#{RUBY_ENGINE} #{RUBY_ENGINE_VERSION} \(#{RUBY_VERSION}([^ ]+)\) /, 1]}"
       end
     end
 

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -959,7 +959,11 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     if defined?(RUBY_PATCHLEVEL) && RUBY_PATCHLEVEL != -1 then
       version << ".#{RUBY_PATCHLEVEL}"
     elsif defined?(RUBY_DESCRIPTION) then
-      version << ".#{RUBY_DESCRIPTION.match(/\Aruby #{RUBY_VERSION}([^ ]+) /)[1]}"
+      if RUBY_ENGINE == "ruby" then
+        version << ".#{RUBY_DESCRIPTION.match(/\Aruby #{RUBY_VERSION}([^ ]+) /)[1]}"
+      else
+        version << ".#{RUBY_DESCRIPTION.match(/\A#{RUBY_ENGINE} #{RUBY_ENGINE_VERSION} \(#{RUBY_VERSION}([^ ]+)\) /)[1]}"
+      end
     end
 
     @ruby_version = Gem::Version.new version

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -960,9 +960,9 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
       version << ".#{RUBY_PATCHLEVEL}"
     elsif defined?(RUBY_DESCRIPTION) then
       if RUBY_ENGINE == "ruby" then
-        version << ".#{RUBY_DESCRIPTION[/\Aruby #{RUBY_VERSION}([^ ]+) /, 1]}"
+        version << ".#{RUBY_DESCRIPTION[/\Aruby #{Regexp.quote(RUBY_VERSION)}([^ ]+) /, 1]}"
       else
-        version << ".#{RUBY_DESCRIPTION[/\A#{RUBY_ENGINE} #{RUBY_ENGINE_VERSION} \(#{RUBY_VERSION}([^ ]+)\) /, 1]}"
+        version << ".#{RUBY_DESCRIPTION[/\A#{RUBY_ENGINE} #{Regexp.quote(RUBY_ENGINE_VERSION)} \(#{RUBY_VERSION}([^ ]+)\) /, 1]}"
       end
     end
 

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -958,8 +958,8 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
     if defined?(RUBY_PATCHLEVEL) && RUBY_PATCHLEVEL != -1 then
       version << ".#{RUBY_PATCHLEVEL}"
-    elsif defined?(RUBY_REVISION) then
-      version << ".#{RUBY_DESCRIPTION.match(/\Aruby #{RUBY_VERSION}([^ ]+) /)[1]}.#{RUBY_REVISION}"
+    elsif defined?(RUBY_DESCRIPTION) then
+      version << ".#{RUBY_DESCRIPTION.match(/\Aruby #{RUBY_VERSION}([^ ]+) /)[1]}"
     end
 
     @ruby_version = Gem::Version.new version

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -632,8 +632,8 @@ class Gem::Installer
 
   def ensure_required_ruby_version_met # :nodoc:
     if rrv = spec.required_ruby_version then
-      unless rrv.satisfied_by? Gem.ruby_version then
-        ruby_version = Gem.ruby_api_version
+      ruby_version = Gem.ruby_version
+      unless rrv.satisfied_by? ruby_version then
         raise Gem::RuntimeRequirementNotMetError,
           "#{spec.name} requires Ruby version #{rrv}. The current ruby version is #{ruby_version}."
       end

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -650,10 +650,6 @@ class Gem::Specification < Gem::BasicSpecification
   #   ruby 2.0.0p247 (2013-06-27 revision 41674) [x86_64-darwin12.4.0]
   #   #<Gem::Version "2.0.0.247">
   #
-  # Because patch-level is taken into account, be very careful specifying using
-  # `<=`: `<= 2.2.2` will not match any patch-level of 2.2.2 after the `p0`
-  # release. It is much safer to specify `< 2.2.3` instead
-  #
   # Usage:
   #
   #  # This gem will work with 1.8.6 or greater...
@@ -661,9 +657,6 @@ class Gem::Specification < Gem::BasicSpecification
   #
   #  # Only with ruby 2.0.x
   #  spec.required_ruby_version = '~> 2.0'
-  #
-  #  # Only with ruby between 2.2.0 and 2.2.2
-  #  spec.required_ruby_version = ['>= 2.2.0', '< 2.2.3']
 
   def required_ruby_version= req
     @required_ruby_version = Gem::Requirement.create req

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -650,6 +650,8 @@ class Gem::Specification < Gem::BasicSpecification
   #   ruby 2.0.0p247 (2013-06-27 revision 41674) [x86_64-darwin12.4.0]
   #   #<Gem::Version "2.0.0.247">
   #
+  # Prereleases can also be specified.
+  #
   # Usage:
   #
   #  # This gem will work with 1.8.6 or greater...
@@ -657,6 +659,9 @@ class Gem::Specification < Gem::BasicSpecification
   #
   #  # Only with ruby 2.0.x
   #  spec.required_ruby_version = '~> 2.0'
+  #
+  #  # Only prereleases or final releases after 2.6.0.preview2
+  #  spec.required_ruby_version = '> 2.6.0.preview2'
 
   def required_ruby_version= req
     @required_ruby_version = Gem::Requirement.create req

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -1161,42 +1161,51 @@ Also, a list:
     Zlib::Deflate.deflate data
   end
 
-  def util_set_RUBY_VERSION(version, patchlevel = nil, revision = nil, description = nil)
+  def util_set_RUBY_VERSION(version, patchlevel = nil, revision = nil, description = nil, engine = "ruby", engine_version = nil)
     if Gem.instance_variables.include? :@ruby_version or
        Gem.instance_variables.include? '@ruby_version' then
       Gem.send :remove_instance_variable, :@ruby_version
     end
 
-    @RUBY_VERSION     = RUBY_VERSION
-    @RUBY_PATCHLEVEL  = RUBY_PATCHLEVEL  if defined?(RUBY_PATCHLEVEL)
-    @RUBY_REVISION    = RUBY_REVISION    if defined?(RUBY_REVISION)
-    @RUBY_DESCRIPTION = RUBY_DESCRIPTION if defined?(RUBY_DESCRIPTION)
+    @RUBY_VERSION        = RUBY_VERSION
+    @RUBY_PATCHLEVEL     = RUBY_PATCHLEVEL     if defined?(RUBY_PATCHLEVEL)
+    @RUBY_REVISION       = RUBY_REVISION       if defined?(RUBY_REVISION)
+    @RUBY_DESCRIPTION    = RUBY_DESCRIPTION    if defined?(RUBY_DESCRIPTION)
+    @RUBY_ENGINE         = RUBY_ENGINE
+    @RUBY_ENGINE_VERSION = RUBY_ENGINE_VERSION if defined?(RUBY_ENGINE_VERSION)
 
     util_clear_RUBY_VERSION
 
-    Object.const_set :RUBY_VERSION,     version
-    Object.const_set :RUBY_PATCHLEVEL,  patchlevel  if patchlevel
-    Object.const_set :RUBY_REVISION,    revision    if revision
-    Object.const_set :RUBY_DESCRIPTION, description if description
+    Object.const_set :RUBY_VERSION,        version
+    Object.const_set :RUBY_PATCHLEVEL,     patchlevel     if patchlevel
+    Object.const_set :RUBY_REVISION,       revision       if revision
+    Object.const_set :RUBY_DESCRIPTION,    description    if description
+    Object.const_set :RUBY_ENGINE,         engine
+    Object.const_set :RUBY_ENGINE_VERSION, engine_version if engine_version
   end
 
   def util_restore_RUBY_VERSION
     util_clear_RUBY_VERSION
 
-    Object.const_set :RUBY_VERSION,     @RUBY_VERSION
-    Object.const_set :RUBY_PATCHLEVEL,  @RUBY_PATCHLEVEL  if
+    Object.const_set :RUBY_VERSION,        @RUBY_VERSION
+    Object.const_set :RUBY_PATCHLEVEL,     @RUBY_PATCHLEVEL  if
       defined?(@RUBY_PATCHLEVEL)
-    Object.const_set :RUBY_REVISION,    @RUBY_REVISION    if
+    Object.const_set :RUBY_REVISION,       @RUBY_REVISION    if
       defined?(@RUBY_REVISION)
-    Object.const_set :RUBY_DESCRIPTION, @RUBY_DESCRIPTION if
+    Object.const_set :RUBY_DESCRIPTION,    @RUBY_DESCRIPTION if
       defined?(@RUBY_DESCRIPTION)
+    Object.const_set :RUBY_ENGINE,         @RUBY_ENGINE
+    Object.const_set :RUBY_ENGINE_VERSION, @RUBY_ENGINE_VERSION if
+      defined?(@RUBY_ENGINE_VERSION)
   end
 
   def util_clear_RUBY_VERSION
     Object.send :remove_const, :RUBY_VERSION
-    Object.send :remove_const, :RUBY_PATCHLEVEL  if defined?(RUBY_PATCHLEVEL)
-    Object.send :remove_const, :RUBY_REVISION    if defined?(RUBY_REVISION)
-    Object.send :remove_const, :RUBY_DESCRIPTION if defined?(RUBY_DESCRIPTION)
+    Object.send :remove_const, :RUBY_PATCHLEVEL     if defined?(RUBY_PATCHLEVEL)
+    Object.send :remove_const, :RUBY_REVISION       if defined?(RUBY_REVISION)
+    Object.send :remove_const, :RUBY_DESCRIPTION    if defined?(RUBY_DESCRIPTION)
+    Object.send :remove_const, :RUBY_ENGINE
+    Object.send :remove_const, :RUBY_ENGINE_VERSION if defined?(RUBY_ENGINE_VERSION)
   end
 
   ##

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -1172,10 +1172,7 @@ Also, a list:
     @RUBY_REVISION    = RUBY_REVISION    if defined?(RUBY_REVISION)
     @RUBY_DESCRIPTION = RUBY_DESCRIPTION if defined?(RUBY_DESCRIPTION)
 
-    Object.send :remove_const, :RUBY_VERSION
-    Object.send :remove_const, :RUBY_PATCHLEVEL  if defined?(RUBY_PATCHLEVEL)
-    Object.send :remove_const, :RUBY_REVISION    if defined?(RUBY_REVISION)
-    Object.send :remove_const, :RUBY_DESCRIPTION if defined?(RUBY_DESCRIPTION)
+    util_clear_RUBY_VERSION
 
     Object.const_set :RUBY_VERSION,     version
     Object.const_set :RUBY_PATCHLEVEL,  patchlevel  if patchlevel
@@ -1184,10 +1181,7 @@ Also, a list:
   end
 
   def util_restore_RUBY_VERSION
-    Object.send :remove_const, :RUBY_VERSION
-    Object.send :remove_const, :RUBY_PATCHLEVEL  if defined?(RUBY_PATCHLEVEL)
-    Object.send :remove_const, :RUBY_REVISION    if defined?(RUBY_REVISION)
-    Object.send :remove_const, :RUBY_DESCRIPTION if defined?(RUBY_DESCRIPTION)
+    util_clear_RUBY_VERSION
 
     Object.const_set :RUBY_VERSION,     @RUBY_VERSION
     Object.const_set :RUBY_PATCHLEVEL,  @RUBY_PATCHLEVEL  if
@@ -1196,6 +1190,13 @@ Also, a list:
       defined?(@RUBY_REVISION)
     Object.const_set :RUBY_DESCRIPTION, @RUBY_DESCRIPTION if
       defined?(@RUBY_DESCRIPTION)
+  end
+
+  def util_clear_RUBY_VERSION
+    Object.send :remove_const, :RUBY_VERSION
+    Object.send :remove_const, :RUBY_PATCHLEVEL  if defined?(RUBY_PATCHLEVEL)
+    Object.send :remove_const, :RUBY_REVISION    if defined?(RUBY_REVISION)
+    Object.send :remove_const, :RUBY_DESCRIPTION if defined?(RUBY_DESCRIPTION)
   end
 
   ##

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -1161,35 +1161,41 @@ Also, a list:
     Zlib::Deflate.deflate data
   end
 
-  def util_set_RUBY_VERSION(version, patchlevel = nil, revision = nil)
+  def util_set_RUBY_VERSION(version, patchlevel = nil, revision = nil, description = nil)
     if Gem.instance_variables.include? :@ruby_version or
        Gem.instance_variables.include? '@ruby_version' then
       Gem.send :remove_instance_variable, :@ruby_version
     end
 
-    @RUBY_VERSION    = RUBY_VERSION
-    @RUBY_PATCHLEVEL = RUBY_PATCHLEVEL if defined?(RUBY_PATCHLEVEL)
-    @RUBY_REVISION   = RUBY_REVISION   if defined?(RUBY_REVISION)
+    @RUBY_VERSION     = RUBY_VERSION
+    @RUBY_PATCHLEVEL  = RUBY_PATCHLEVEL  if defined?(RUBY_PATCHLEVEL)
+    @RUBY_REVISION    = RUBY_REVISION    if defined?(RUBY_REVISION)
+    @RUBY_DESCRIPTION = RUBY_DESCRIPTION if defined?(RUBY_DESCRIPTION)
 
     Object.send :remove_const, :RUBY_VERSION
-    Object.send :remove_const, :RUBY_PATCHLEVEL if defined?(RUBY_PATCHLEVEL)
-    Object.send :remove_const, :RUBY_REVISION   if defined?(RUBY_REVISION)
+    Object.send :remove_const, :RUBY_PATCHLEVEL  if defined?(RUBY_PATCHLEVEL)
+    Object.send :remove_const, :RUBY_REVISION    if defined?(RUBY_REVISION)
+    Object.send :remove_const, :RUBY_DESCRIPTION if defined?(RUBY_DESCRIPTION)
 
-    Object.const_set :RUBY_VERSION,    version
-    Object.const_set :RUBY_PATCHLEVEL, patchlevel if patchlevel
-    Object.const_set :RUBY_REVISION,   revision   if revision
+    Object.const_set :RUBY_VERSION,     version
+    Object.const_set :RUBY_PATCHLEVEL,  patchlevel  if patchlevel
+    Object.const_set :RUBY_REVISION,    revision    if revision
+    Object.const_set :RUBY_DESCRIPTION, description if description
   end
 
   def util_restore_RUBY_VERSION
     Object.send :remove_const, :RUBY_VERSION
-    Object.send :remove_const, :RUBY_PATCHLEVEL if defined?(RUBY_PATCHLEVEL)
-    Object.send :remove_const, :RUBY_REVISION   if defined?(RUBY_REVISION)
+    Object.send :remove_const, :RUBY_PATCHLEVEL  if defined?(RUBY_PATCHLEVEL)
+    Object.send :remove_const, :RUBY_REVISION    if defined?(RUBY_REVISION)
+    Object.send :remove_const, :RUBY_DESCRIPTION if defined?(RUBY_DESCRIPTION)
 
-    Object.const_set :RUBY_VERSION,    @RUBY_VERSION
-    Object.const_set :RUBY_PATCHLEVEL, @RUBY_PATCHLEVEL if
+    Object.const_set :RUBY_VERSION,     @RUBY_VERSION
+    Object.const_set :RUBY_PATCHLEVEL,  @RUBY_PATCHLEVEL  if
       defined?(@RUBY_PATCHLEVEL)
-    Object.const_set :RUBY_REVISION,   @RUBY_REVISION   if
+    Object.const_set :RUBY_REVISION,    @RUBY_REVISION    if
       defined?(@RUBY_REVISION)
+    Object.const_set :RUBY_DESCRIPTION, @RUBY_DESCRIPTION if
+      defined?(@RUBY_DESCRIPTION)
   end
 
   ##

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1012,7 +1012,7 @@ class TestGem < Gem::TestCase
   def test_self_ruby_version_with_prerelease
     util_set_RUBY_VERSION '2.6.0', -1, 63539, 'ruby 2.6.0preview2 (2018-05-31 trunk 63539) [x86_64-linux]'
 
-    assert_equal Gem::Version.new('2.6.0.preview2.63539'), Gem.ruby_version
+    assert_equal Gem::Version.new('2.6.0.preview2'), Gem.ruby_version
   ensure
     util_restore_RUBY_VERSION
   end
@@ -1020,7 +1020,7 @@ class TestGem < Gem::TestCase
   def test_self_ruby_version_with_trunk
     util_set_RUBY_VERSION '1.9.2', -1, 23493, 'ruby 1.9.2dev (2009-05-20 trunk 23493) [x86_64-linux]'
 
-    assert_equal Gem::Version.new('1.9.2.dev.23493'), Gem.ruby_version
+    assert_equal Gem::Version.new('1.9.2.dev'), Gem.ruby_version
   ensure
     util_restore_RUBY_VERSION
   end

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1009,6 +1009,14 @@ class TestGem < Gem::TestCase
     util_restore_RUBY_VERSION
   end
 
+  def test_self_ruby_version_with_non_mri_implementations
+    util_set_RUBY_VERSION '2.5.0', 0, 60928, 'jruby 9.2.0.0 (2.5.0) 2018-05-24 81156a8 OpenJDK 64-Bit Server VM 25.171-b11 on 1.8.0_171-8u171-b11-0ubuntu0.16.04.1-b11 [linux-x86_64]'
+
+    assert_equal Gem::Version.new('2.5.0'), Gem.ruby_version
+  ensure
+    util_restore_RUBY_VERSION
+  end
+
   def test_self_ruby_version_with_prerelease
     util_set_RUBY_VERSION '2.6.0', -1, 63539, 'ruby 2.6.0preview2 (2018-05-31 trunk 63539) [x86_64-linux]'
 

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -993,7 +993,7 @@ class TestGem < Gem::TestCase
     assert_equal Gem::Requirement.default, Gem.env_requirement('qux')
   end
 
-  def test_self_ruby_version_1_8_5
+  def test_self_ruby_version_with_patchlevel_less_ancient_rubies
     util_set_RUBY_VERSION '1.8.5'
 
     assert_equal Gem::Version.new('1.8.5'), Gem.ruby_version
@@ -1001,7 +1001,7 @@ class TestGem < Gem::TestCase
     util_restore_RUBY_VERSION
   end
 
-  def test_self_ruby_version_1_8_6p287
+  def test_self_ruby_version_with_release
     util_set_RUBY_VERSION '1.8.6', 287
 
     assert_equal Gem::Version.new('1.8.6.287'), Gem.ruby_version
@@ -1009,7 +1009,7 @@ class TestGem < Gem::TestCase
     util_restore_RUBY_VERSION
   end
 
-  def test_self_ruby_version_1_9_2dev_r23493
+  def test_self_ruby_version_with_trunk
     util_set_RUBY_VERSION '1.9.2', -1, 23493
 
     assert_equal Gem::Version.new('1.9.2.dev.23493'), Gem.ruby_version

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1009,8 +1009,16 @@ class TestGem < Gem::TestCase
     util_restore_RUBY_VERSION
   end
 
+  def test_self_ruby_version_with_prerelease
+    util_set_RUBY_VERSION '2.6.0', -1, 63539, 'ruby 2.6.0preview2 (2018-05-31 trunk 63539) [x86_64-linux]'
+
+    assert_equal Gem::Version.new('2.6.0.preview2.63539'), Gem.ruby_version
+  ensure
+    util_restore_RUBY_VERSION
+  end
+
   def test_self_ruby_version_with_trunk
-    util_set_RUBY_VERSION '1.9.2', -1, 23493
+    util_set_RUBY_VERSION '1.9.2', -1, 23493, 'ruby 1.9.2dev (2009-05-20 trunk 23493) [x86_64-linux]'
 
     assert_equal Gem::Version.new('1.9.2.dev.23493'), Gem.ruby_version
   ensure

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1025,6 +1025,14 @@ class TestGem < Gem::TestCase
     util_restore_RUBY_VERSION
   end
 
+  def test_self_ruby_version_with_non_mri_implementations_with_mri_prerelase_compatibility
+    util_set_RUBY_VERSION '2.6.0', -1, 63539, 'weirdjruby 9.2.0.0 (2.6.0preview2) 2018-05-24 81156a8 OpenJDK 64-Bit Server VM 25.171-b11 on 1.8.0_171-8u171-b11-0ubuntu0.16.04.1-b11 [linux-x86_64]', 'weirdjruby', '9.2.0.0'
+
+    assert_equal Gem::Version.new('2.6.0.preview2'), Gem.ruby_version
+  ensure
+    util_restore_RUBY_VERSION
+  end
+
   def test_self_ruby_version_with_trunk
     util_set_RUBY_VERSION '1.9.2', -1, 23493, 'ruby 1.9.2dev (2009-05-20 trunk 23493) [x86_64-linux]'
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -965,7 +965,7 @@ gem 'other', version
 
   def test_install_force
     use_ui @ui do
-      installer = Gem::Installer.at old_ruby_required, :force => true
+      installer = Gem::Installer.at old_ruby_required('= 1.4.6'), :force => true
       installer.install
     end
 
@@ -1380,7 +1380,7 @@ gem 'other', version
 
   def test_pre_install_checks_ruby_version
     use_ui @ui do
-      installer = Gem::Installer.at old_ruby_required
+      installer = Gem::Installer.at old_ruby_required('= 1.4.6')
       e = assert_raises Gem::RuntimeRequirementNotMetError do
         installer.pre_install_checks
       end
@@ -1388,6 +1388,16 @@ gem 'other', version
       assert_equal "old_ruby_required requires Ruby version = 1.4.6. The current ruby version is #{rv}.",
                    e.message
     end
+  end
+
+  def test_pre_install_checks_ruby_version_with_prereleases
+    util_set_RUBY_VERSION '2.6.0', -1, '63539', 'ruby 2.6.0preview2 (2018-05-31 trunk 63539) [x86_64-linux]'
+
+    installer = Gem::Installer.at old_ruby_required('>= 2.6.0.preview2')
+
+    assert installer.pre_install_checks
+  ensure
+    util_restore_RUBY_VERSION
   end
 
   def test_pre_install_checks_wrong_rubygems_version
@@ -1720,9 +1730,9 @@ gem 'other', version
     assert_equal ['bin/executable'], default_spec.files
   end
 
-  def old_ruby_required
+  def old_ruby_required(requirement)
     spec = util_spec 'old_ruby_required', '1' do |s|
-      s.required_ruby_version = '= 1.4.6'
+      s.required_ruby_version = requirement
     end
 
     util_build_gem spec

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1394,8 +1394,14 @@ gem 'other', version
     util_set_RUBY_VERSION '2.6.0', -1, '63539', 'ruby 2.6.0preview2 (2018-05-31 trunk 63539) [x86_64-linux]'
 
     installer = Gem::Installer.at old_ruby_required('>= 2.6.0.preview2')
-
     assert installer.pre_install_checks
+
+    installer = Gem::Installer.at old_ruby_required('> 2.6.0.preview2')
+    e = assert_raises Gem::RuntimeRequirementNotMetError do
+      assert installer.pre_install_checks
+    end
+    assert_equal "old_ruby_required requires Ruby version > 2.6.0.preview2. The current ruby version is 2.6.0.preview2.",
+                 e.message
   ensure
     util_restore_RUBY_VERSION
   end

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1384,7 +1384,7 @@ gem 'other', version
       e = assert_raises Gem::RuntimeRequirementNotMetError do
         installer.pre_install_checks
       end
-      rv = Gem.ruby_api_version
+      rv = Gem.ruby_version
       assert_equal "old_ruby_required requires Ruby version = 1.4.6. The current ruby version is #{rv}.",
                    e.message
     end


### PR DESCRIPTION
# Description:

Fixes #2343, by making the `required_ruby_version` gemspec setting work with prereleases and shows a better error message when the check does not pass.

Not sure how stable the `RUBY_DESCRIPTION` string is across ruby releases, maybe I can check the format is what we expect?

______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
