### PR TITLE
Fix approximate recommendation with prereleases

### DIFF
--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -325,7 +325,9 @@ class Gem::Version
     segments.pop    while segments.size > 2
     segments.push 0 while segments.size < 2
 
-    "~> #{segments.join(".")}"
+    recommendation = "~> #{segments.join(".")}"
+    recommendation += ".a" if prerelease?
+    recommendation
   end
 
   ##

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -158,11 +158,25 @@ class TestGemVersion < Gem::TestCase
 
   def test_approximate_recommendation
     assert_approximate_equal "~> 1.0", "1"
+    assert_approximate_satisfies_itself "1"
+
     assert_approximate_equal "~> 1.0", "1.0"
+    assert_approximate_satisfies_itself "1.0"
+
     assert_approximate_equal "~> 1.2", "1.2"
+    assert_approximate_satisfies_itself "1.2"
+
     assert_approximate_equal "~> 1.2", "1.2.0"
+    assert_approximate_satisfies_itself "1.2.0"
+
     assert_approximate_equal "~> 1.2", "1.2.3"
-    assert_approximate_equal "~> 1.2", "1.2.3.a.4"
+    assert_approximate_satisfies_itself "1.2.3"
+
+    assert_approximate_equal "~> 1.2.a", "1.2.3.a.4"
+    assert_approximate_satisfies_itself "1.2.3.a.4"
+
+    assert_approximate_equal "~> 1.9.a", "1.9.0.dev"
+    assert_approximate_satisfies_itself "1.9.0.dev"
   end
 
   def test_to_s
@@ -202,6 +216,14 @@ class TestGemVersion < Gem::TestCase
 
   def assert_approximate_equal expected, version
     assert_equal expected, v(version).approximate_recommendation
+  end
+
+  # Assert that the "approximate" recommendation for +version+ satifies +version+.
+
+  def assert_approximate_satisfies_itself version
+    gem_version = v(version)
+
+    assert Gem::Requirement.new(gem_version.approximate_recommendation).satisfied_by?(gem_version)
   end
 
   # Assert that bumping the +unbumped+ version yields the +expected+.

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -198,7 +198,7 @@ class TestGemVersion < Gem::TestCase
     assert v(version).prerelease?, "#{version} is a prerelease"
   end
 
-  # Assert that +expected+ is the "approximate" recommendation for +version".
+  # Assert that +expected+ is the "approximate" recommendation for +version+.
 
   def assert_approximate_equal expected, version
     assert_equal expected, v(version).approximate_recommendation


### PR DESCRIPTION
# Description:

Fixes #1172. Not sure if this is fully correct but it at least seems to fix original @indirect's report.

Basically, when we want to find the approximate recomendation for a prerelease, we need to make sure the requirement allows prereleases so that it also satisfies the original prerelease. 
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
