### PR TITLE
Update tests for 'newer' Windows builds

### DIFF
--- a/test/rubygems/test_gem_gemcutter_utilities.rb
+++ b/test/rubygems/test_gem_gemcutter_utilities.rb
@@ -179,8 +179,6 @@ class TestGemGemcutterUtilities < Gem::TestCase
   end
 
   def test_sign_in_with_bad_credentials
-    skip 'Always uses $stdin on windows' if Gem.win_platform?
-
     assert_raises Gem::MockGemUi::TermError do
       util_sign_in ['Access Denied.', 403, 'Forbidden']
     end
@@ -190,8 +188,6 @@ class TestGemGemcutterUtilities < Gem::TestCase
   end
 
   def util_sign_in response, host = nil, args = []
-    skip 'Always uses $stdin on windows' if Gem.win_platform?
-
     email    = 'you@example.com'
     password = 'secret'
 

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -150,7 +150,7 @@ class TestGemPackage < Gem::Package::TarTestCase
   end
 
   def test_add_files_symlink
-    skip 'symlink not supported' if Gem.win_platform?
+    skip 'symlink not supported' if Gem.win_platform? && RUBY_VERSION < '2.3'
 
     spec = Gem::Specification.new
     spec.files = %w[lib/code.rb lib/code_sym.rb]
@@ -159,7 +159,15 @@ class TestGemPackage < Gem::Package::TarTestCase
     File.open 'lib/code.rb',  'w' do |io| io.write '# lib/code.rb'  end
 
     # NOTE: 'code.rb' is correct, because it's relative to lib/code_sym.rb
-    File.symlink('code.rb', 'lib/code_sym.rb')
+    begin
+      File.symlink('code.rb', 'lib/code_sym.rb')
+    rescue Errno::EACCES => e
+      if win_platform?
+        skip "symlink - must be admin with no UAC on Windows"
+      else
+        raise e
+      end
+    end
 
     package = Gem::Package.new 'bogus.gem'
     package.spec = spec
@@ -451,7 +459,7 @@ class TestGemPackage < Gem::Package::TarTestCase
   end
 
   def test_extract_tar_gz_symlink_relative_path
-    skip 'symlink not supported' if Gem.win_platform?
+    skip 'symlink not supported' if Gem.win_platform? && RUBY_VERSION < '2.3'
 
     package = Gem::Package.new @gem
 
@@ -461,7 +469,15 @@ class TestGemPackage < Gem::Package::TarTestCase
       tar.add_symlink 'lib/foo.rb', '../relative.rb', 0644
     end
 
-    package.extract_tar_gz tgz_io, @destination
+    begin
+      package.extract_tar_gz tgz_io, @destination
+    rescue Errno::EACCES => e
+      if win_platform?
+        skip "symlink - must be admin with no UAC on Windows"
+      else
+        raise e
+      end
+    end
 
     extracted = File.join @destination, 'lib/foo.rb'
     assert_path_exists extracted
@@ -472,7 +488,7 @@ class TestGemPackage < Gem::Package::TarTestCase
   end
 
   def test_extract_symlink_parent
-    skip 'symlink not supported' if Gem.win_platform?
+    skip 'symlink not supported' if Gem.win_platform? && RUBY_VERSION < '2.3'
 
     package = Gem::Package.new @gem
 
@@ -482,18 +498,24 @@ class TestGemPackage < Gem::Package::TarTestCase
       tar.add_file    'lib/link/outside.txt', 0644 do |io| io.write 'hi' end
     end
 
-   # Extract into a subdirectory of @destination; if this test fails it writes
-   # a file outside destination_subdir, but we want the file to remain inside
-   # @destination so it will be cleaned up.
+    # Extract into a subdirectory of @destination; if this test fails it writes
+    # a file outside destination_subdir, but we want the file to remain inside
+    # @destination so it will be cleaned up.
     destination_subdir = File.join @destination, 'subdir'
     FileUtils.mkdir_p destination_subdir
 
-    e = assert_raises Gem::Package::PathError do
+    e = assert_raises(Gem::Package::PathError, Errno::EACCES) do
       package.extract_tar_gz tgz_io, destination_subdir
     end
 
-    assert_equal("installing into parent path lib/link/outside.txt of " +
+    if Gem::Package::PathError === e
+      assert_equal("installing into parent path lib/link/outside.txt of " +
                   "#{destination_subdir} is not allowed", e.message)
+    elsif win_platform?
+      skip "symlink - must be admin with no UAC on Windows"
+    else
+      raise e
+    end
   end
 
   def test_extract_tar_gz_directory


### PR DESCRIPTION
# Description:

Two test files have 'Windows' skips that are not required for newer versions of Ruby when Windows is run with full admin access (as is the case with Appveyor).

Updated the tests, and tested locally as a non-admin, tests then skip.

Note: one test (test_extract_symlink_parent) that was updated had a single space indent instead of two.  Corrected the indent for the whole test.

# Tasks:

- [X] Describe the problem / feature
- [X] Write tests
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).