### PR TITLE
Remove semver gem build warning

### DIFF
--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -132,30 +132,6 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
       warning_messages << "prerelease dependency on #{dep} is not recommended" if
           prerelease_dep && !version.prerelease?
 
-      overly_strict = dep.requirement.requirements.length == 1 &&
-          dep.requirement.requirements.any? do |op, version|
-            op == '~>' and
-                not version.prerelease? and
-                version.segments.length > 2 and
-                version.segments.first != 0
-          end
-
-      if overly_strict then
-        _, dep_version = dep.requirement.requirements.first
-
-        base = dep_version.segments.first 2
-        upper_bound = dep_version.segments.first(dep_version.segments.length - 1)
-        upper_bound[-1] += 1
-
-        warning_messages << <<-WARNING
-pessimistic dependency on #{dep} may be overly strict
-  if #{dep.name} is semantically versioned, use:
-    add_#{dep.type}_dependency '#{dep.name}', '~> #{base.join '.'}', '>= #{dep_version}'
-  if #{dep.name} is not semantically versioned, you can bypass this warning with:
-    add_#{dep.type}_dependency '#{dep.name}', '>= #{dep_version}', '< #{upper_bound.join '.'}.a'
-        WARNING
-      end
-
       open_ended = dep.requirement.requirements.all? do |op, version|
         not version.prerelease? and (op == '>' or op == '>=')
       end

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2697,16 +2697,6 @@ end
       expected = <<-EXPECTED
 #{w}:  prerelease dependency on b (>= 1.0.rc1) is not recommended
 #{w}:  prerelease dependency on c (>= 2.0.rc2, development) is not recommended
-#{w}:  pessimistic dependency on d (~> 1.2.3) may be overly strict
-  if d is semantically versioned, use:
-    add_runtime_dependency 'd', '~> 1.2', '>= 1.2.3'
-  if d is not semantically versioned, you can bypass this warning with:
-    add_runtime_dependency 'd', '>= 1.2.3', '< 1.3.a'
-#{w}:  pessimistic dependency on e (~> 1.2.3.4) may be overly strict
-  if e is semantically versioned, use:
-    add_runtime_dependency 'e', '~> 1.2', '>= 1.2.3.4'
-  if e is not semantically versioned, you can bypass this warning with:
-    add_runtime_dependency 'e', '>= 1.2.3.4', '< 1.2.4.a'
 #{w}:  open-ended dependency on i (>= 1.2) is not recommended
   if i is semantically versioned, use:
     add_runtime_dependency 'i', '~> 1.2'
@@ -2719,11 +2709,6 @@ end
 #{w}:  open-ended dependency on l (> 1.2.3) is not recommended
   if l is semantically versioned, use:
     add_runtime_dependency 'l', '~> 1.2', '> 1.2.3'
-#{w}:  pessimistic dependency on m (~> 2.1.0) may be overly strict
-  if m is semantically versioned, use:
-    add_runtime_dependency 'm', '~> 2.1', '>= 2.1.0'
-  if m is not semantically versioned, you can bypass this warning with:
-    add_runtime_dependency 'm', '>= 2.1.0', '< 2.2.a'
 #{w}:  See http://guides.rubygems.org/specification-reference/ for help
       EXPECTED
 


### PR DESCRIPTION
# Description:

This is an alternative to #2323.

I think this warning is too brittle at the moment because `rubygems` has no way of knowing if a dependency is semantically versioned. If a dependency is not semantically versioned, I don't see the problem with using something like `~> 1.2.3` so suggesting a constraint that does the same thing in a more complicated way just because it does not warn seems no good.

In the future maybe rubygems could provide a `spec.versioning_policy =` accessor where gems can inform of their own versioning (`:semver`, or others) but currently I think this warning should just go.
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).