### PR TITLE
Expand symlinks in gem path

### DIFF
--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -23,10 +23,10 @@ class Gem::PathSupport
   # hashtable, or defaults to ENV, the system environment.
   #
   def initialize(env)
-    @home     = env["GEM_HOME"] || Gem.default_dir
+    @home = env["GEM_HOME"] || Gem.default_dir
 
     if File::ALT_SEPARATOR then
-      @home   = @home.gsub(File::ALT_SEPARATOR, File::SEPARATOR)
+      @home = @home.gsub(File::ALT_SEPARATOR, File::SEPARATOR)
     end
 
     @path = split_gem_path env["GEM_PATH"], @home

--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -29,6 +29,8 @@ class Gem::PathSupport
       @home = @home.gsub(File::ALT_SEPARATOR, File::SEPARATOR)
     end
 
+    @home = expand(@home)
+
     @path = split_gem_path env["GEM_PATH"], @home
 
     @spec_cache_dir = env["GEM_SPEC_CACHE"] || Gem.default_spec_cache_dir
@@ -65,7 +67,7 @@ class Gem::PathSupport
       gem_path = default_path
     end
 
-    gem_path.uniq
+    gem_path.map { |path| expand(path) }.uniq
   end
 
   # Return the default Gem path
@@ -76,5 +78,13 @@ class Gem::PathSupport
       gem_path << APPLE_GEM_HOME
     end
     gem_path
+  end
+
+  def expand(path)
+    if File.directory?(path)
+      File.realpath(path)
+    else
+      path
+    end
   end
 end

--- a/test/rubygems/test_gem_path_support.rb
+++ b/test/rubygems/test_gem_path_support.rb
@@ -118,4 +118,21 @@ class TestGemPathSupport < Gem::TestCase
     ps = Gem::PathSupport.new "GEM_SPEC_CACHE" => "foo"
     assert_equal "foo", ps.spec_cache_dir
   end
+
+  def test_gem_paths_do_not_contain_symlinks
+    dir = "#{@tempdir}/realgemdir"
+    symlink = "#{@tempdir}/symdir"
+    Dir.mkdir dir
+    begin
+      File.symlink(dir, symlink)
+    rescue NotImplementedError, SystemCallError
+      skip 'symlinks not supported'
+    end
+    not_existing = "#{@tempdir}/does_not_exist"
+    path = "#{symlink}#{File::PATH_SEPARATOR}#{not_existing}"
+
+    ps = Gem::PathSupport.new "GEM_PATH" => path, "GEM_HOME" => symlink
+    assert_equal dir, ps.home
+    assert_equal [dir, not_existing], ps.path
+  end
 end


### PR DESCRIPTION
# Description:

The environment variable `GEM_PATH` can contain symlinks.
This is notably the case on RVM, with a typical `GEM_PATH` being
`GEM_PATH=/home/eregon/.rvm/gems/ruby-2.5.1:/home/eregon/.rvm/gems/ruby-2.5.1@global` (the `...@global` is a symlink to `/home/eregon/.rvm/rubies/ruby-2.5.1/lib/ruby/gems/2.5.0`).

Currently, RubyGems just takes the paths from `GEM_HOME` and `GEM_PATH` and store them in `Gem.dir` and `Gem.path`, without resolving symlinks.
Similarly those paths might end up in `$LOAD_PATH` and still contain symlinks.

This makes all code relying on `__FILE__`, `caller`, `$LOADED_FEATURES` or `$LOAD_PATH`, etc more brittle for paths comparisons, by having to expand paths with e.g. `File.realpath` before any path comparison involving those paths.
As an example, Bundler has a recent bug due to this, where it fails to detect its own `bundler-1.16.2/lib` directory in `$LOAD_PATH` due to the presence of symlinks in GEM_PATH: https://github.com/bundler/bundler/pull/6502 https://github.com/bundler/bundler/issues/6465

While this specific case of course should be fixed in Bundler, it's not hard to imagine many other places might have similar assumptions.
So I think it's just more robust for all gems to have RubyGems expands symlinks from the environment `GEM_HOME` and `GEM_PATH`.

Ruby implementations since Ruby 2.4.4 [resolve symlinks from `$LOAD_PATH`](https://github.com/oracle/truffleruby/commit/9a76df4287ce212fd7513baa23eefe6dfa4034a2#diff-7346c44420f7a2c1d276e7f67dcee8f8R369).
Therefore, having symlinks in `$LOAD_PATH` means an extra cost during `require` to expand each `$LOAD_PATH` with symlinks.
So it's more efficient if there are already realpaths in `$LOAD_PATH`, and less surprising for everybody (e.g., paths in `$LOADED_FEATURES` are actual concatenation of one of the `$LOAD_PATH` + `/` + required feature).
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
