### PR TITLE
Remove the --rdoc and --ri options from install/update

### DIFF
--- a/lib/rubygems/install_update_options.rb
+++ b/lib/rubygems/install_update_options.rb
@@ -63,30 +63,6 @@ module Gem::InstallUpdateOptions
       options[:document] = []
     end
 
-    add_option(:Deprecated, '--[no-]rdoc',
-               'Generate RDoc for installed gems',
-               'Use --document instead') do |value, options|
-      if value then
-        options[:document] << 'rdoc'
-      else
-        options[:document].delete 'rdoc'
-      end
-
-      options[:document].uniq!
-    end
-
-    add_option(:Deprecated, '--[no-]ri',
-               'Generate ri data for installed gems.',
-               'Use --document instead') do |value, options|
-      if value then
-        options[:document] << 'ri'
-      else
-        options[:document].delete 'ri'
-      end
-
-      options[:document].uniq!
-    end
-
     add_option(:"Install/Update", '-E', '--[no-]env-shebang',
                "Rewrite the shebang line on installed",
                "scripts to use /usr/bin/env") do |value, options|

--- a/test/rubygems/test_gem_command_manager.rb
+++ b/test/rubygems/test_gem_command_manager.rb
@@ -126,7 +126,7 @@ class TestGemCommandManager < Gem::TestCase
       #check settings
       check_options = nil
       @command_manager.process_args %w[
-        install --force --local --rdoc --install-dir .
+        install --force --local --document=ri,rdoc --install-dir .
                 --version 3.0 --no-wrapper --bindir .
       ]
       assert_equal %w[rdoc ri], check_options[:document].sort
@@ -260,7 +260,7 @@ class TestGemCommandManager < Gem::TestCase
 
     #check settings
     check_options = nil
-    @command_manager.process_args %w[update --force --rdoc --install-dir .]
+    @command_manager.process_args %w[update --force --document=ri --install-dir .]
     assert_includes check_options[:document], 'ri'
     assert_equal true, check_options[:force]
     assert_equal Dir.pwd, check_options[:install_dir]

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -55,7 +55,7 @@ class TestGemCommandsInstallCommand < Gem::TestCase
     a2_pre = specs['a-2.a']
 
     @cmd.handle_options [a2_pre.name, '--version', a2_pre.version.to_s,
-                         "--no-ri", "--no-rdoc"]
+                         "--no-document"]
     assert @cmd.options[:prerelease]
     assert @cmd.options[:version].satisfied_by?(a2_pre.version)
 

--- a/test/rubygems/test_gem_install_update_options.rb
+++ b/test/rubygems/test_gem_install_update_options.rb
@@ -21,8 +21,7 @@ class TestGemInstallUpdateOptions < Gem::InstallerTestCase
       --build-root build_root
       --format-exec
       --ignore-dependencies
-      --rdoc
-      --ri
+      --document
       -E
       -f
       -i /install_to
@@ -90,24 +89,6 @@ class TestGemInstallUpdateOptions < Gem::InstallerTestCase
     @cmd.handle_options %w[--document ri]
 
     assert_equal %w[ri], @cmd.options[:document]
-  end
-
-  def test_rdoc
-    @cmd.handle_options %w[--rdoc]
-
-    assert_equal %w[rdoc ri], @cmd.options[:document].sort
-  end
-
-  def test_rdoc_no
-    @cmd.handle_options %w[--no-rdoc]
-
-    assert_equal %w[ri], @cmd.options[:document]
-  end
-
-  def test_ri
-    @cmd.handle_options %w[--no-ri]
-
-    assert_equal %w[], @cmd.options[:document]
   end
 
   def test_security_policy


### PR DESCRIPTION
The `--rdoc` and `--ri` options have been marked as deprecated for a while now and with the release of RubyGems 3 looming - it seems like a good idea to get rid of them now.
______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
