### PR TITLE
set rubocop to ignore Molinillo and set target ruby version to 2.2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,8 @@ AllCops:
   DisabledByDefault: true
   Exclude:
     - 'bundler/**/*'
+    - 'lib/rubygems/resolver/molinillo/**/*'
+  TargetRubyVersion: 2.2
 
 Layout/IndentationConsistency:
   Enabled: true


### PR DESCRIPTION
# Description:

This PR is fixing a couple of issues in Rubocop that is preventing PRs from being merged.

______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
