### PR TITLE
Fix broken rubocop task by upgrading to 0.58.1

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -72,12 +72,12 @@ rescue LoadError
 end
 
 begin
-  gem "rubocop", "~> 0.54.0"
+  gem "rubocop", "~> 0.58.1"
   require "rubocop/rake_task"
 
   RuboCop::RakeTask.new
 rescue LoadError
-  task(:rubocop) { abort "Install the rubocop gem (~> 0.54.0) to run a static analysis" }
+  task(:rubocop) { abort "Install the rubocop gem (~> 0.58.1) to run a static analysis" }
 end
 
 # --------------------------------------------------------------------

--- a/util/ci
+++ b/util/ci
@@ -57,7 +57,7 @@ when %w(before_script)
       run('gem', %w(install bundler -v 1.16.2))
     end
 
-    run('gem', %w(install rubocop -v 0.54.0))
+    run('gem', %w(install rubocop -v 0.58.1))
 
     run('gem', %w(list --details))
     run('gem', %w(env))


### PR DESCRIPTION
# Description:

The problem is a broken parser release (2.5.1.1). Rubocop 0.58.1 skips
this bad release so upgrading fixes the problem. An alternative is to
explicitly install the previous version of parser, but I see no harm in
upgrading.

See https://github.com/rubocop-hq/rubocop/issues/6092.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).