### PR TITLE
Dont generate a gem's documentation by default any more

### DIFF
--- a/lib/rubygems/install_update_options.rb
+++ b/lib/rubygems/install_update_options.rb
@@ -35,9 +35,8 @@ module Gem::InstallUpdateOptions
                'List the documentation types you wish to',
                'generate.  For example: rdoc,ri') do |value, options|
       options[:document] = case value
-                           when nil   then %w[ri]
-                           when false then []
-                           else            value
+                           when nil, false then []
+                           else                 value
                            end
     end
 
@@ -209,7 +208,7 @@ module Gem::InstallUpdateOptions
   # Default options for the gem install command.
 
   def install_update_defaults_str
-    '--document=rdoc,ri --wrappers'
+    '--wrappers'
   end
 
 end

--- a/test/rubygems/test_gem_install_update_options.rb
+++ b/test/rubygems/test_gem_install_update_options.rb
@@ -45,7 +45,7 @@ class TestGemInstallUpdateOptions < Gem::InstallerTestCase
   def test_doc
     @cmd.handle_options %w[--doc]
 
-    assert_equal %w[ri], @cmd.options[:document].sort
+    assert_equal %w[], @cmd.options[:document].sort
   end
 
   def test_doc_rdoc
@@ -73,7 +73,7 @@ class TestGemInstallUpdateOptions < Gem::InstallerTestCase
   def test_document
     @cmd.handle_options %w[--document]
 
-    assert_equal %w[ri], @cmd.options[:document].sort
+    assert_equal %w[], @cmd.options[:document].sort
   end
 
   def test_document_no


### PR DESCRIPTION
# Description:

This PR changes the default flags when installing/updating gems to not generate the documentation with `rdoc` or `ri`. The documentation being generated is very rarely used by developers today and installing gems is a lot quicker when not generating these docs.

See #1965 
______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
