### PR TITLE
Gem::Version should handle nil like it used to before

### DIFF
--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -170,7 +170,6 @@ class Gem::Version
   # True if the +version+ string matches RubyGems' requirements.
 
   def self.correct? version
-    return false if version.nil?
     !!(version.to_s =~ ANCHORED_VERSION_PATTERN)
   end
 

--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -170,7 +170,9 @@ class Gem::Version
   # True if the +version+ string matches RubyGems' requirements.
 
   def self.correct? version
-    warn "nil versions are discouraged and will be deprecated in Rubygems 4" if version.nil?
+    unless Gem::Deprecate.skip
+      warn "nil versions are discouraged and will be deprecated in Rubygems 4" if version.nil?
+    end
 
     !!(version.to_s =~ ANCHORED_VERSION_PATTERN)
   end

--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -172,7 +172,6 @@ class Gem::Version
   def self.correct? version
     warn "nil versions are discouraged and will be deprecated in Rubygems 4" if version.nil?
 
-    return false if version.nil?
     !!(version.to_s =~ ANCHORED_VERSION_PATTERN)
   end
 

--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -170,6 +170,9 @@ class Gem::Version
   # True if the +version+ string matches RubyGems' requirements.
 
   def self.correct? version
+    warn "nil versions are discouraged and will be deprecated in Rubygems 4" if version.nil?
+
+    return false if version.nil?
     !!(version.to_s =~ ANCHORED_VERSION_PATTERN)
   end
 

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -46,7 +46,6 @@ class TestGemVersion < Gem::TestCase
   def test_class_correct
     assert_equal true,  Gem::Version.correct?("5.1")
     assert_equal false, Gem::Version.correct?("an incorrect version")
-    assert_equal false, Gem::Version.correct?(nil)
   end
 
   def test_class_new_subclass

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -46,6 +46,11 @@ class TestGemVersion < Gem::TestCase
   def test_class_correct
     assert_equal true,  Gem::Version.correct?("5.1")
     assert_equal false, Gem::Version.correct?("an incorrect version")
+
+    expected = "nil versions are discouraged and will be deprecated in Rubygems 4\n"
+    assert_output nil, expected do
+      assert_equal false, Gem::Version.correct?(nil)
+    end
   end
 
   def test_class_new_subclass

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -49,7 +49,7 @@ class TestGemVersion < Gem::TestCase
 
     expected = "nil versions are discouraged and will be deprecated in Rubygems 4\n"
     assert_output nil, expected do
-      assert_equal false, Gem::Version.correct?(nil)
+      Gem::Version.correct?(nil)
     end
   end
 


### PR DESCRIPTION
# Description:
closes https://github.com/rubygems/rubygems/issues/2359
reverts https://github.com/rubygems/rubygems/pull/2203

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
