### PR TITLE
Avoid need of C++ compiler to pass the test suite.

### DIFF
--- a/test/rubygems/test_gem_ext_cmake_builder.rb
+++ b/test/rubygems/test_gem_ext_cmake_builder.rb
@@ -25,6 +25,7 @@ class TestGemExtCmakeBuilder < Gem::TestCase
     File.open File.join(@ext, 'CMakeLists.txt'), 'w' do |cmakelists|
       cmakelists.write <<-eo_cmake
 cmake_minimum_required(VERSION 2.6)
+project(self_build LANGUAGES NONE)
 install (FILES test.txt DESTINATION bin)
       eo_cmake
     end


### PR DESCRIPTION
The test suite fails when C++ compiler is not available on the system:

~~~
TestGemExtCmakeBuilder#test_self_build:
Gem::InstallError: cmake failed, exit code 1
    /builddir/build/BUILD/ruby-2.5.1/lib/rubygems/ext/builder.rb:92:in `run'
    /builddir/build/BUILD/ruby-2.5.1/lib/rubygems/ext/cmake_builder.rb:10:in `build'
    /builddir/build/BUILD/ruby-2.5.1/test/rubygems/test_gem_ext_cmake_builder.rb:37:in `block in test_self_build'
    /builddir/build/BUILD/ruby-2.5.1/test/rubygems/test_gem_ext_cmake_builder.rb:36:in `chdir'
    /builddir/build/BUILD/ruby-2.5.1/test/rubygems/test_gem_ext_cmake_builder.rb:36:in `test_self_build'
~~~

and this is the plumbing of the test case:

~~~
$ cat CMakeLists.txt 
cmake_minimum_required(VERSION 2.6)
install (FILES test.txt DESTINATION bin)

$ cmake . -DCMAKE_INSTALL_PREFIX=/tmp/test_rubygems_15764/prefix
-- The C compiler identification is GNU 8.1.1
-- The CXX compiler identification is unknown
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
CMake Error in CMakeLists.txt:
  No CMAKE_CXX_COMPILER could be found.

  Tell CMake where to find the compiler by setting either the environment
  variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.


-- Configuring incomplete, errors occurred!
See also "/tmp/test_rubygems_15764/ext/CMakeFiles/CMakeOutput.log".
See also "/tmp/test_rubygems_15764/ext/CMakeFiles/CMakeError.log".
~~~

But there is nothing which would really require C++. It is just CMake
default to check for C++.
