### PR TITLE
[GSoC] Multi-factor feature for RubyGems.

### DIFF
--- a/lib/rubygems/commands/push_command.rb
+++ b/lib/rubygems/commands/push_command.rb
@@ -33,6 +33,7 @@ command.  For further discussion see the help for the yank command.
 
     add_proxy_option
     add_key_option
+    add_otp_option
 
     add_option('--host HOST',
                'Push to another gemcutter-compatible host',
@@ -113,17 +114,26 @@ You can upgrade or downgrade to the latest release version with:
 
     say "Pushing gem to #{@host || Gem.host}..."
 
-    response = rubygems_api_request(*args) do |request|
-      request.body = Gem.read_binary name
-      request.add_field "Content-Length", request.body.size
-      request.add_field "Content-Type",   "application/octet-stream"
-      request.add_field "Authorization",  api_key
+    response = send_push_request(name, args)
+
+    if need_otp? response
+      response = send_push_request(name, args, true)
     end
 
     with_response response
   end
 
   private
+
+  def send_push_request(name, args, use_otp = false)
+    rubygems_api_request(*args) do |request|
+      request.body = Gem.read_binary name
+      request.add_field "Content-Length", request.body.size
+      request.add_field "Content-Type",   "application/octet-stream"
+      request.add_field "Authorization",  api_key
+      request.add_field "OTP", options[:otp] if use_otp
+    end
+  end
 
   def get_hosts_for(name)
     gem_metadata = Gem::Package.new(name).spec.metadata

--- a/lib/rubygems/commands/signin_command.rb
+++ b/lib/rubygems/commands/signin_command.rb
@@ -14,7 +14,6 @@ class Gem::Commands::SigninCommand < Gem::Command
     end
 
     add_otp_option
-
   end
 
   def description # :nodoc:

--- a/lib/rubygems/commands/signin_command.rb
+++ b/lib/rubygems/commands/signin_command.rb
@@ -12,6 +12,9 @@ class Gem::Commands::SigninCommand < Gem::Command
     add_option('--host HOST', 'Push to another gemcutter-compatible host') do |value, options|
       options[:host] = value
     end
+
+    add_otp_option
+
   end
 
   def description # :nodoc:

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -177,7 +177,7 @@ module Gem::GemcutterUtilities
   # Returns true when the user has enabled multifactor authentication from
   # +response+ text.
 
-  def need_otp? response
+  def need_otp?(response)
     return unless response.kind_of?(Net::HTTPUnauthorized) &&
         response.body.start_with?('You have enabled multifactor authentication')
     return true if options[:otp]

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -25,6 +25,16 @@ module Gem::GemcutterUtilities
   end
 
   ##
+  # Add the --otp option
+
+  def add_otp_option
+    add_option('--otp CODE',
+               'Digit code for multifactor authentication') do |value, options|
+      options[:otp] = value
+    end
+  end
+
+  ##
   # The API key from the command options or from the user's configuration.
 
   def api_key
@@ -113,6 +123,13 @@ module Gem::GemcutterUtilities
       request.basic_auth email, password
     end
 
+    if need_otp? response
+      response = rubygems_api_request(:get, "api/v1/api_key", sign_in_host) do |request|
+        request.basic_auth email, password
+        request.add_field "OTP", options[:otp]
+      end
+    end
+
     with_response response do |resp|
       say "Signed in."
       set_api_key host, resp.body
@@ -154,6 +171,20 @@ module Gem::GemcutterUtilities
       say message
       terminate_interaction 1 # TODO: question this
     end
+  end
+
+  ##
+  # Returns true when the user has enabled multifactor authentication from
+  # +response+ text.
+
+  def need_otp? response
+    return unless response.kind_of?(Net::HTTPUnauthorized) &&
+        response.body.start_with?('You have enabled multifactor authentication')
+    return true if options[:otp]
+
+    say 'You have enabled multi-factor authentication. Please enter OTP code.'
+    options[:otp] = ask 'Code: '
+    true
   end
 
   def set_api_key(host, key)

--- a/lib/rubygems/test_utilities.rb
+++ b/lib/rubygems/test_utilities.rb
@@ -87,7 +87,7 @@ class Gem::FakeFetcher
 
   def request(uri, request_class, last_modified = nil)
     data = find_data(uri)
-    body, code, msg = data
+    body, code, msg = (data.respond_to?(:call) ? data.call : data)
 
     @last_request = request_class.new uri.request_uri
     yield @last_request if block_given?

--- a/test/rubygems/test_gem_commands_owner_command.rb
+++ b/test/rubygems/test_gem_commands_owner_command.rb
@@ -235,4 +235,39 @@ EOF
     assert_equal "Removing missing@example: #{response}\n", @stub_ui.output
   end
 
+  def test_otp_verified_success
+    response_fail = "You have enabled multifactor authentication but your request doesn't have the correct OTP code. Please check it and retry."
+    response_success = "Owner added successfully."
+
+    @stub_fetcher.data["#{Gem.host}/api/v1/gems/freewill/owners"] = proc do
+      @call_count ||= 0
+      (@call_count += 1).odd? ? [response_fail, 401, 'Unauthorized'] : [response_success, 200, 'OK']
+    end
+
+    @otp_ui = Gem::MockGemUi.new "111111\n"
+    use_ui @otp_ui do
+      @cmd.add_owners("freewill", ["user-new1@example.com"])
+    end
+
+    assert_match 'You have enabled multi-factor authentication. Please enter OTP code.', @otp_ui.output
+    assert_match 'Code: ', @otp_ui.output
+    assert_match response_success, @otp_ui.output
+    assert_equal '111111', @stub_fetcher.last_request['OTP']
+  end
+
+  def test_otp_verified_failure
+    response = "You have enabled multifactor authentication but your request doesn't have the correct OTP code. Please check it and retry."
+    @stub_fetcher.data["#{Gem.host}/api/v1/gems/freewill/owners"] = [response, 401, 'Unauthorized']
+
+    @otp_ui = Gem::MockGemUi.new "111111\n"
+    use_ui @otp_ui do
+      @cmd.add_owners("freewill", ["user-new1@example.com"])
+    end
+
+    assert_match response, @otp_ui.output
+    assert_match 'You have enabled multi-factor authentication. Please enter OTP code.', @otp_ui.output
+    assert_match 'Code: ', @otp_ui.output
+    assert_equal '111111', @stub_fetcher.last_request['OTP']
+  end
+
 end

--- a/test/rubygems/test_gem_commands_push_command.rb
+++ b/test/rubygems/test_gem_commands_push_command.rb
@@ -161,6 +161,7 @@ class TestGemCommandsPushCommand < Gem::TestCase
 
     @response = "Successfully registered gem: freebird (1.0.1)"
     @fetcher.data["#{@host}/api/v1/gems"]  = [@response, 200, 'OK']
+
     send_battery
   end
 
@@ -229,6 +230,7 @@ class TestGemCommandsPushCommand < Gem::TestCase
     @spec, @path = util_gem "freebird", "1.0.1" do |spec|
       spec.metadata['allowed_push_host'] = "https://privategemserver.example"
     end
+
 
     response = %{ERROR:  "#{@host}" is not allowed by the gemspec, which only allows "https://privategemserver.example"}
 
@@ -345,6 +347,43 @@ class TestGemCommandsPushCommand < Gem::TestCase
 
     assert_equal Gem.configuration.api_keys[:other],
                  @fetcher.last_request["Authorization"]
+  end
+
+  def test_otp_verified_success
+    response_fail = "You have enabled multifactor authentication but your request doesn't have the correct OTP code. Please check it and retry."
+    response_success = 'Successfully registered gem: freewill (1.0.0)'
+
+    @fetcher.data["#{Gem.host}/api/v1/gems"] = proc do
+      @call_count ||= 0
+      (@call_count += 1).odd? ? [response_fail, 401, 'Unauthorized'] : [response_success, 200, 'OK']
+    end
+
+    @otp_ui = Gem::MockGemUi.new "111111\n"
+    use_ui @otp_ui do
+      @cmd.send_gem(@path)
+    end
+
+    assert_match 'You have enabled multi-factor authentication. Please enter OTP code.', @otp_ui.output
+    assert_match 'Code: ', @otp_ui.output
+    assert_match response_success, @otp_ui.output
+    assert_equal '111111', @fetcher.last_request['OTP']
+  end
+
+  def test_otp_verified_failure
+    response = "You have enabled multifactor authentication but your request doesn't have the correct OTP code. Please check it and retry."
+    @fetcher.data["#{Gem.host}/api/v1/gems"] = [response, 401, 'Unauthorized']
+
+    @otp_ui = Gem::MockGemUi.new "111111\n"
+    assert_raises Gem::MockGemUi::TermError do
+      use_ui @otp_ui do
+        @cmd.send_gem(@path)
+      end
+    end
+
+    assert_match response, @otp_ui.output
+    assert_match 'You have enabled multi-factor authentication. Please enter OTP code.', @otp_ui.output
+    assert_match 'Code: ', @otp_ui.output
+    assert_equal '111111', @fetcher.last_request['OTP']
   end
 
 end

--- a/test/rubygems/test_gem_gemcutter_utilities.rb
+++ b/test/rubygems/test_gem_gemcutter_utilities.rb
@@ -187,7 +187,35 @@ class TestGemGemcutterUtilities < Gem::TestCase
     assert_match %r{Access Denied.}, @sign_in_ui.output
   end
 
-  def util_sign_in(response, host = nil, args = [])
+  def test_sign_in_with_correct_otp_code
+    api_key       = 'a5fdbb6ba150cbb83aad2bb2fede64cf040453903'
+    response_fail = "You have enabled multifactor authentication but your request doesn't have the correct OTP code. Please check it and retry."
+
+    util_sign_in(proc do
+      @call_count ||= 0
+      (@call_count += 1).odd? ? [response_fail, 401, 'Unauthorized'] : [api_key, 200, 'OK']
+    end, nil, [], "111111\n")
+
+    assert_match 'You have enabled multi-factor authentication. Please enter OTP code.', @sign_in_ui.output
+    assert_match 'Code: ', @sign_in_ui.output
+    assert_match 'Signed in.', @sign_in_ui.output
+    assert_equal '111111', @fetcher.last_request['OTP']
+  end
+
+  def test_sign_in_with_incorrect_otp_code
+    response = "You have enabled multifactor authentication but your request doesn't have the correct OTP code. Please check it and retry."
+
+    assert_raises Gem::MockGemUi::TermError do
+      util_sign_in [response, 401, 'Unauthorized'], nil, [], "111111\n"
+    end
+
+    assert_match 'You have enabled multi-factor authentication. Please enter OTP code.', @sign_in_ui.output
+    assert_match 'Code: ', @sign_in_ui.output
+    assert_match response, @sign_in_ui.output
+    assert_equal '111111', @fetcher.last_request['OTP']
+  end
+
+  def util_sign_in(response, host = nil, args = [], extra_input = '')
     email    = 'you@example.com'
     password = 'secret'
 
@@ -201,7 +229,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
     @fetcher.data["#{host}/api/v1/api_key"] = response
     Gem::RemoteFetcher.fetcher = @fetcher
 
-    @sign_in_ui = Gem::MockGemUi.new "#{email}\n#{password}\n"
+    @sign_in_ui = Gem::MockGemUi.new("#{email}\n#{password}\n" + extra_input)
 
     use_ui @sign_in_ui do
       if args.length > 0


### PR DESCRIPTION
# Description:

Hello. This is my GSoC project, dedicated to add multifactor authentication to both RubyGems command program and Gemcutter ([RubyGems.org](https://rubygems.org)).

Work for the Gemcutter part has almost been finished (see [PR #1753](https://github.com/rubygems/rubygems.org/pull/1753), [PR #1729](https://github.com/rubygems/rubygems.org/pull/1729) and a series of [my progress reports](https://ecnelises.github.io/)).

## Content:

This PR will contain my changes to RubyGems client, adding multifactor auth for `gem push`, `gem signin` and `gem owner` commands. Since no command for editing profile, adding command for changing multifactor auth settings seems unnecessary.

## Workflow:

- User set up multifactor auth well in the site. (into `mfa_login_and_write` level)
- When user does the actions requiring MFA, an OTP prompt is shown. Or user can add `--otp` option into command, like `gem push mygem-0.0.0.gem --otp 123456`.
- If the OTP is incorrect, operation fails with failure text.
______________

# Tasks:

- [x] Add OTP requirement to `push_command`.
- [x] Add OTP requirement to `owner_command`.
- [x] Add OTP prompt to `sign_in`.
- [ ] Support for `yank_command`.
- [x] Write related tests.

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
