### PR TITLE
Allow build options to be passed to Rake

### DIFF
--- a/lib/rubygems/ext/rake_builder.rb
+++ b/lib/rubygems/ext/rake_builder.rb
@@ -5,6 +5,8 @@
 # See LICENSE.txt for permissions.
 #++
 
+require "shellwords"
+
 class Gem::Ext::RakeBuilder < Gem::Ext::Builder
 
   def self.build(extension, dest_path, results, args=[], lib_dir=nil)
@@ -13,9 +15,6 @@ class Gem::Ext::RakeBuilder < Gem::Ext::Builder
       cmd << " #{args.join " "}" unless args.empty?
       run cmd, results
     end
-
-    # Deal with possible spaces in the path, e.g. C:/Program Files
-    dest_path = '"' + dest_path.to_s + '"' if dest_path.to_s.include?(' ')
 
     rake = ENV['rake']
 
@@ -26,9 +25,8 @@ class Gem::Ext::RakeBuilder < Gem::Ext::Builder
 
     rake ||= Gem.default_exec_format % 'rake'
 
-    cmd = "#{rake} RUBYARCHDIR=#{dest_path} RUBYLIBDIR=#{dest_path}".dup # ENV is frozen
-    cmd << " #{args.join " "}" unless args.empty?
-    run cmd, results
+    rake_args = ["RUBYARCHDIR=#{dest_path}", "RUBYLIBDIR=#{dest_path}", *args]
+    run "#{rake} #{rake_args.shelljoin}", results
 
     results
   end

--- a/lib/rubygems/ext/rake_builder.rb
+++ b/lib/rubygems/ext/rake_builder.rb
@@ -26,8 +26,8 @@ class Gem::Ext::RakeBuilder < Gem::Ext::Builder
 
     rake ||= Gem.default_exec_format % 'rake'
 
-    cmd = "#{rake} RUBYARCHDIR=#{dest_path} RUBYLIBDIR=#{dest_path}" # ENV is frozen
-
+    cmd = "#{rake} RUBYARCHDIR=#{dest_path} RUBYLIBDIR=#{dest_path}".dup # ENV is frozen
+    cmd << " #{args.join " "}" unless args.empty?
     run cmd, results
 
     results

--- a/test/rubygems/test_gem_ext_rake_builder.rb
+++ b/test/rubygems/test_gem_ext_rake_builder.rb
@@ -51,6 +51,21 @@ class TestGemExtRakeBuilder < Gem::TestCase
     end
   end
 
+  def test_class_build_no_mkrf_passes_args
+    output = []
+
+    build_rake_in do |rake|
+      Dir.chdir @ext do
+        Gem::Ext::RakeBuilder.build "ext/Rakefile", @dest_path, output, ["test1", "test2"]
+      end
+
+      output = output.join "\n"
+
+      refute_match %r%^rake failed:%, output
+      assert_match %r%^#{Regexp.escape rake} RUBYARCHDIR=#{Regexp.escape @dest_path} RUBYLIBDIR=#{Regexp.escape @dest_path} test1 test2%, output
+    end
+  end
+
   def test_class_build_fail
     create_temp_mkrf_file("task :default do abort 'fail' end")
     output = []

--- a/test/rubygems/test_gem_ext_rake_builder.rb
+++ b/test/rubygems/test_gem_ext_rake_builder.rb
@@ -26,7 +26,7 @@ class TestGemExtRakeBuilder < Gem::TestCase
 
       refute_match %r%^rake failed:%, output
       assert_match %r%^#{Regexp.escape @@ruby} mkrf_conf\.rb%, output
-      assert_match %r%^#{Regexp.escape rake} RUBYARCHDIR=#{Regexp.escape @dest_path} RUBYLIBDIR=#{Regexp.escape @dest_path}%, output
+      assert_match %r%^#{Regexp.escape rake} RUBYARCHDIR\\=#{Regexp.escape @dest_path} RUBYLIBDIR\\=#{Regexp.escape @dest_path}%, output
     end
   end
 
@@ -47,7 +47,7 @@ class TestGemExtRakeBuilder < Gem::TestCase
 
       refute_match %r%^rake failed:%, output
       assert_match %r%^#{Regexp.escape @@ruby} mkrf_conf\.rb%, output
-      assert_match %r%^#{Regexp.escape rake} RUBYARCHDIR=#{Regexp.escape @dest_path} RUBYLIBDIR=#{Regexp.escape @dest_path}%, output
+      assert_match %r%^#{Regexp.escape rake} RUBYARCHDIR\\=#{Regexp.escape @dest_path} RUBYLIBDIR\\=#{Regexp.escape @dest_path}%, output
     end
   end
 
@@ -62,7 +62,7 @@ class TestGemExtRakeBuilder < Gem::TestCase
       output = output.join "\n"
 
       refute_match %r%^rake failed:%, output
-      assert_match %r%^#{Regexp.escape rake} RUBYARCHDIR=#{Regexp.escape @dest_path} RUBYLIBDIR=#{Regexp.escape @dest_path} test1 test2%, output
+      assert_match %r%^#{Regexp.escape rake} RUBYARCHDIR\\=#{Regexp.escape @dest_path} RUBYLIBDIR\\=#{Regexp.escape @dest_path} test1 test2%, output
     end
   end
 


### PR DESCRIPTION
Rake tasks can take arguments, but unlike other extension builders, arguments were not passed through from `gem install` to Rake.

I haven't managed to write any tests because the current Rake builder tests ran neither on my machine, nor in a clean container.

This does solve the problem I was having, though.
______________


- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).