### PR TITLE
Skip permissions-dependent test when root

### DIFF
--- a/test/rubygems/test_gem_util.rb
+++ b/test/rubygems/test_gem_util.rb
@@ -38,6 +38,8 @@ class TestGemUtil < Gem::TestCase
     # impossible to cd into it and its children
     FileUtils.chmod(0666, 'd/e')
 
+    skip 'skipped in root privilege' if Process.uid.zero?
+
     paths = Gem::Util.traverse_parents('d/e/f').to_a
 
     assert_equal File.join(@tempdir, 'd'), paths[0]


### PR DESCRIPTION
Root can cd to non-executable directories, which would cause this test to fail.

______________


- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).