### PR TITLE
Fix test that depended on /usr/bin being in PATH

### DIFF
--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -336,6 +336,9 @@ gem 'other', version
     bin_dir = Gem.win_platform? ? File.expand_path(ENV["WINDIR"]).upcase :
                                   "/usr/bin"
 
+    old_path = ENV["PATH"]
+    ENV["PATH"] = [ENV["PATH"], bin_dir].compact.join(File::PATH_SEPARATOR)
+
     options = {
       :bin_dir => bin_dir,
       :install_dir => "/non/existent"
@@ -350,6 +353,9 @@ gem 'other', version
     end
 
     assert_equal "", @ui.error
+
+  ensure
+    ENV["PATH"] = old_path
   end
 
   def test_generate_bin_script


### PR DESCRIPTION
This isn't always going to be true. For example, /usr/bin isn't in the PATH on my NixOS system. Work around this by ensuring the test `bin_dir` is always in the PATH.

______________


- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).