### PR TITLE
Remove Trailing whitespace with rubocop.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,3 +13,6 @@ Layout/IndentationConsistency:
 
 Layout/IndentationWidth:
   Enabled: true
+
+Layout/TrailingWhitespace:
+  Enabled: true

--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -284,7 +284,7 @@ class Gem::Requirement
   end
 
   def sort_requirements! # :nodoc:
-    @requirements.sort! do |l, r| 
+    @requirements.sort! do |l, r|
       comp = l.last <=> r.last # first, sort by the requirement's version
       next comp unless comp == 0
       l.first <=> r.first # then, sort by the operator (for stability)

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -245,13 +245,13 @@ open-ended dependency on #{dep} is not recommended
 
   def validate_self_inclusion_in_files_list
     return unless files.include?(file_name)
-    
+
     error "#{full_name} contains itself (#{file_name}), check your files list"
   end
 
   def validate_specification_version
     return if specification_version.is_a?(Integer)
-    
+
     error 'specification_version must be an Integer (did you mean version?)'
   end
 

--- a/rubygems-update.gemspec
+++ b/rubygems-update.gemspec
@@ -37,5 +37,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency(%q<rake>.freeze, ["~> 12.0"])
   s.add_development_dependency(%q<minitest>.freeze, ["~> 5.0"])
   s.add_development_dependency(%q<simplecov>.freeze, ["~> 0"])
-  s.add_development_dependency(%q<rubocop>.freeze, ["~> 0.54.0"])
+  s.add_development_dependency(%q<rubocop>.freeze, ["~> 0.58"])
 end

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -451,23 +451,23 @@ ERROR:  Possible alternatives: non_existent_with_hint
     specs = spec_fetcher do |fetcher|
       fetcher.gem 'a', 2
     end
-  
+
     Gem.done_installing(&Gem::RDoc.method(:generation_hook))
-  
+
     @cmd.options[:document] = %w[rdoc ri]
     @cmd.options[:domain] = :local
     @cmd.options[:install_dir] = 'whatever'
-  
+
     a2 = specs['a-2']
     FileUtils.mv a2.cache_file, @tempdir
-  
+
     @cmd.options[:args] = %w[a]
-  
+
     use_ui @ui do
       # Don't use Dir.chdir with a block, it warnings a lot because
       # of a downstream Dir.chdir with a block
       old = Dir.getwd
-  
+
       begin
         Dir.chdir @tempdir
         assert_raises Gem::MockGemUi::SystemExitException, @ui.error do
@@ -477,9 +477,9 @@ ERROR:  Possible alternatives: non_existent_with_hint
         Dir.chdir old
       end
     end
-  
+
     wait_for_child_process_to_exit
-  
+
     assert_path_exists 'whatever/doc/a-2', 'documentation not installed'
   end
 

--- a/test/rubygems/test_gem_commands_query_command.rb
+++ b/test/rubygems/test_gem_commands_query_command.rb
@@ -11,7 +11,7 @@ module TestGemCommandsQueryCommandSetup
     @specs = add_gems_to_fetcher
     @stub_ui = Gem::MockGemUi.new
     @stub_fetcher = Gem::FakeFetcher.new
-    
+
     @stub_fetcher.data["#{@gem_repo}Marshal.#{Gem.marshal_version}"] = proc do
       raise Gem::RemoteFetcher::FetchError
     end

--- a/test/rubygems/test_gem_server.rb
+++ b/test/rubygems/test_gem_server.rb
@@ -377,9 +377,9 @@ class TestGemServer < Gem::TestCase
     assert_equal 200, @res.status
     assert_match 'xsshomepagegem 1', @res.body
 
-    # This verifies that the homepage for this spec is not displayed and is set to ".", because it's not a 
+    # This verifies that the homepage for this spec is not displayed and is set to ".", because it's not a
     # valid HTTP/HTTPS URL and could be unsafe in an HTML context.  We would prefer to throw an exception here,
-    # but spec.homepage is currently free form and not currently required to be a URL, this behavior may be 
+    # but spec.homepage is currently free form and not currently required to be a URL, this behavior may be
     # validated in future versions of Gem::Specification.
     #
     # There are two variant we're checking here, one where rdoc is not present, and one where rdoc is present in the same regex:
@@ -432,9 +432,9 @@ class TestGemServer < Gem::TestCase
     assert_equal 200, @res.status
     assert_match 'invalidhomepagegem 1', @res.body
 
-    # This verifies that the homepage for this spec is not displayed and is set to ".", because it's not a 
+    # This verifies that the homepage for this spec is not displayed and is set to ".", because it's not a
     # valid HTTP/HTTPS URL and could be unsafe in an HTML context.  We would prefer to throw an exception here,
-    # but spec.homepage is currently free form and not currently required to be a URL, this behavior may be 
+    # but spec.homepage is currently free form and not currently required to be a URL, this behavior may be
     # validated in future versions of Gem::Specification.
     #
     # There are two variant we're checking here, one where rdoc is not present, and one where rdoc is present in the same regex:

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1184,7 +1184,7 @@ dependencies: []
     gem = 'mingw'
     v   = '1.1.1'
     platforms = ['x86-mingw32', 'x64-mingw32']
-    
+
     #create specs
     platforms.each do |plat|
       spec = Gem::Specification.new(gem, v) { |s| s.platform = plat }

--- a/util/ci
+++ b/util/ci
@@ -57,7 +57,7 @@ when %w(before_script)
       run('gem', %w(install bundler -v 1.16.2))
     end
 
-    run('gem', %w(install rubocop -v 0.58.1))
+    run('gem', %w(install rubocop -v ~>0.58))
 
     run('gem', %w(list --details))
     run('gem', %w(env))


### PR DESCRIPTION
# Description:

I always faced removing trailing white-space comimts on ruby core repository with our dev bot.

https://github.com/ruby/ruby/commit/73c8b1ea296ca9631f684609d62e908fd5f5d10c

I hope to detect them before merging into ruby core repository.
______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
