### PR TITLE
Fix broken builds using the correct rubocop version

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -72,12 +72,12 @@ rescue LoadError
 end
 
 begin
-  gem "rubocop", "~> 0.58.1"
+  gem "rubocop", "~> 0.58"
   require "rubocop/rake_task"
 
   RuboCop::RakeTask.new
 rescue LoadError
-  task(:rubocop) { abort "Install the rubocop gem (~> 0.58.1) to run a static analysis" }
+  task(:rubocop) { abort "Install the rubocop gem (~> 0.58) to run a static analysis" }
 end
 
 # --------------------------------------------------------------------


### PR DESCRIPTION
Rubocop version to install was changed on https://github.com/rubygems/rubygems/pull/2394/files#diff-dcc988a27020494812a8376f558858a7L60

so the rake task doesn't find the correct version to use, this PR changes that.

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
