### PR TITLE
Fix "interpreted as grouped expression" warning

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -779,7 +779,7 @@ TEXT
 @ECHO OFF
 @"%~dp0ruby.exe" "%~dpn0" %*
       TEXT
-    elsif bindir.downcase.start_with? (RbConfig::TOPDIR || File.dirname(rb_bindir)).downcase
+    elsif bindir.downcase.start_with?((RbConfig::TOPDIR || File.dirname(rb_bindir)).downcase)
       # stub within ruby folder, but not standard bin.  Not portable
       require 'pathname'
       from = Pathname.new bindir


### PR DESCRIPTION
# Description:

This PR resolves a warning which was introduced in #2390. In older versions of Ruby (1.9.3), Ruby will print a warning

    lib/rubygems/installer.rb:782: warning: (...) interpreted as grouped expression

As a result, this is breaking a spec in Bundler's test suite: https://travis-ci.org/bundler/bundler/jobs/428597922
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
