### PR TITLE
update rubocop and also use correct pessimistic version

### DIFF
--- a/rubygems-update.gemspec
+++ b/rubygems-update.gemspec
@@ -37,5 +37,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency(%q<rake>.freeze, ["~> 12.0"])
   s.add_development_dependency(%q<minitest>.freeze, ["~> 5.0"])
   s.add_development_dependency(%q<simplecov>.freeze, ["~> 0"])
-  s.add_development_dependency(%q<rubocop>.freeze, ["~> 0.58"])
+  s.add_development_dependency(%q<rubocop>.freeze, ["~> 0.59.0"])
 end

--- a/util/ci
+++ b/util/ci
@@ -57,7 +57,7 @@ when %w(before_script)
       run('gem', %w(install bundler -v 1.16.2))
     end
 
-    run('gem', %w(install rubocop -v ~>0.58))
+    run('gem', %w(install rubocop -v ~>0.59.0))
 
     run('gem', %w(list --details))
     run('gem', %w(env))


### PR DESCRIPTION
# Description:

This PR has 2 parts. Firstly is just updating Rubocop to the latest version. The second part is that the constraint that is specified in the `util/ci` and the `rubygems-update.gemspec` files are not correct. 

Currently, any version that is less then '1.0' would be installed. This is bad because Rubocop could release a new version which changes a cop that will result in our CI breaking. We want to restrict the version of Rubocop to only patch releases within the given pessimistic version constraint.

______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
