### PR TITLE
Improve certificate expiration defaults

### DIFF
--- a/lib/rubygems/commands/build_command.rb
+++ b/lib/rubygems/commands/build_command.rb
@@ -55,7 +55,16 @@ with gem spec:
         spec = Gem::Specification.load File.basename(gemspec)
 
         if spec then
-          Gem::Package.build spec, options[:force], options[:strict]
+          signer_options = {
+            expiration_length_days: Gem.configuration.cert_expiration_length_days
+          }
+
+          Gem::Package.build(
+            spec,
+            options[:force],
+            options[:strict],
+            signer_options
+          )
         else
           alert_error "Error loading gemspec. Aborting."
           terminate_interaction 1

--- a/lib/rubygems/commands/build_command.rb
+++ b/lib/rubygems/commands/build_command.rb
@@ -55,15 +55,10 @@ with gem spec:
         spec = Gem::Specification.load File.basename(gemspec)
 
         if spec then
-          signer_options = {
-            expiration_length_days: Gem.configuration.cert_expiration_length_days
-          }
-
           Gem::Package.build(
             spec,
             options[:force],
-            options[:strict],
-            signer_options
+            options[:strict]
           )
         else
           alert_error "Error loading gemspec. Aborting."

--- a/lib/rubygems/commands/cert_command.rb
+++ b/lib/rubygems/commands/cert_command.rb
@@ -149,15 +149,15 @@ class Gem::Commands::CertCommand < Gem::Command
   end
 
   def build_cert email, key # :nodoc:
-    expiration_length_days = options[:expiration_length_days]
-    age =
-      if expiration_length_days.nil? || expiration_length_days == 0
-        Gem::Security::ONE_YEAR
-      else
-        Gem::Security::ONE_DAY * expiration_length_days
-      end
+    expiration_length_days = options[:expiration_length_days] ||
+      Gem.configuration.cert_expiration_length_days
 
-    cert = Gem::Security.create_cert_email email, key, age
+    cert = Gem::Security.create_cert_email(
+      email,
+      key,
+      (Gem::Security::ONE_DAY * expiration_length_days)
+    )
+
     Gem::Security.write cert, "gem-public_cert.pem"
   end
 

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -45,6 +45,7 @@ class Gem::ConfigFile
   DEFAULT_VERBOSITY = true
   DEFAULT_UPDATE_SOURCES = true
   DEFAULT_CONCURRENT_DOWNLOADS = 8
+  DEFAULT_CERT_EXPIRATION_LENGTH_DAYS = 365
 
   ##
   # For Ruby packagers to set configuration defaults.  Set in
@@ -136,6 +137,11 @@ class Gem::ConfigFile
   attr_accessor :sources
 
   ##
+  # Expiration length to sign a certificate
+
+  attr_accessor :cert_expiration_length_days
+
+  ##
   # Path name of directory or file of openssl client certificate, used for remote https connection with client authentication
 
   attr_reader :ssl_client_cert
@@ -185,6 +191,7 @@ class Gem::ConfigFile
     @verbose = DEFAULT_VERBOSITY
     @update_sources = DEFAULT_UPDATE_SOURCES
     @concurrent_downloads = DEFAULT_CONCURRENT_DOWNLOADS
+    @cert_expiration_length_days = CERT_EXPIRATION_LENGTH_DAYS
 
     operating_system_config = Marshal.load Marshal.dump(OPERATING_SYSTEM_DEFAULTS)
     platform_config = Marshal.load Marshal.dump(PLATFORM_DEFAULTS)

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -191,7 +191,7 @@ class Gem::ConfigFile
     @verbose = DEFAULT_VERBOSITY
     @update_sources = DEFAULT_UPDATE_SOURCES
     @concurrent_downloads = DEFAULT_CONCURRENT_DOWNLOADS
-    @cert_expiration_length_days = CERT_EXPIRATION_LENGTH_DAYS
+    @cert_expiration_length_days = DEFAULT_CERT_EXPIRATION_LENGTH_DAYS
 
     operating_system_config = Marshal.load Marshal.dump(OPERATING_SYSTEM_DEFAULTS)
     platform_config = Marshal.load Marshal.dump(PLATFORM_DEFAULTS)

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -209,15 +209,15 @@ class Gem::ConfigFile
     end
 
     # HACK these override command-line args, which is bad
-    @backtrace                  = @hash[:backtrace]                  if @hash.key? :backtrace
-    @bulk_threshold             = @hash[:bulk_threshold]             if @hash.key? :bulk_threshold
-    @home                       = @hash[:gemhome]                    if @hash.key? :gemhome
-    @path                       = @hash[:gempath]                    if @hash.key? :gempath
-    @update_sources             = @hash[:update_sources]             if @hash.key? :update_sources
-    @verbose                    = @hash[:verbose]                    if @hash.key? :verbose
-    @concurrent_downloads       = @hash[:concurrent_downloads]       if @hash.key? :concurrent_downloads
-    @disable_default_gem_server = @hash[:disable_default_gem_server] if @hash.key? :disable_default_gem_server
-    @sources                    = @hash[:sources]                    if @hash.key? :sources
+    @backtrace                   = @hash[:backtrace]                   if @hash.key? :backtrace
+    @bulk_threshold              = @hash[:bulk_threshold]              if @hash.key? :bulk_threshold
+    @home                        = @hash[:gemhome]                     if @hash.key? :gemhome
+    @path                        = @hash[:gempath]                     if @hash.key? :gempath
+    @update_sources              = @hash[:update_sources]              if @hash.key? :update_sources
+    @verbose                     = @hash[:verbose]                     if @hash.key? :verbose
+    @disable_default_gem_server  = @hash[:disable_default_gem_server]  if @hash.key? :disable_default_gem_server
+    @sources                     = @hash[:sources]                     if @hash.key? :sources
+    @cert_expiration_length_days = @hash[:cert_expiration_length_days] if @hash.key? :cert_expiration_length_days
 
     @ssl_verify_mode  = @hash[:ssl_verify_mode]  if @hash.key? :ssl_verify_mode
     @ssl_ca_cert      = @hash[:ssl_ca_cert]      if @hash.key? :ssl_ca_cert

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -119,12 +119,12 @@ class Gem::Package
   # Permission for other files
   attr_accessor :data_mode
 
-  def self.build spec, skip_validation=false, strict_validation=false
+  def self.build spec, skip_validation = false, strict_validation = false, signer_options = {}
     gem_file = spec.file_name
 
     package = new gem_file
     package.spec = spec
-    package.build skip_validation, strict_validation
+    package.build skip_validation, strict_validation, signer_options
 
     gem_file
   end
@@ -254,7 +254,7 @@ class Gem::Package
   ##
   # Builds this package based on the specification set by #spec=
 
-  def build skip_validation = false, strict_validation = false, signer_options
+  def build skip_validation = false, strict_validation = false, signer_options = {}
     raise ArgumentError, "skip_validation = true and strict_validation = true are incompatible" if skip_validation && strict_validation
 
     Gem.load_yaml
@@ -521,7 +521,7 @@ EOM
   # Prepares the gem for signing and checksum generation.  If a signing
   # certificate and key are not present only checksum generation is set up.
 
-  def setup_signer(signer_options)
+  def setup_signer(signer_options = {})
     passphrase = ENV['GEM_PRIVATE_KEY_PASSPHRASE']
     if @spec.signing_key then
       @signer =

--- a/lib/rubygems/security/signer.rb
+++ b/lib/rubygems/security/signer.rb
@@ -49,7 +49,11 @@ class Gem::Security::Signer
 
     Gem::Security.write(expired_cert, new_expired_cert_path)
 
-    re_signed_cert = Gem::Security.re_sign(expired_cert, private_key)
+    re_signed_cert = Gem::Security.re_sign(
+      expired_cert,
+      private_key,
+      (Gem::Security::ONE_DAY * Gem.configuration.cert_expiration_length_days)
+    )
 
     Gem::Security.write(re_signed_cert, expired_cert_path)
 

--- a/lib/rubygems/security/signer.rb
+++ b/lib/rubygems/security/signer.rb
@@ -69,8 +69,7 @@ class Gem::Security::Signer
     @cert_chain = cert_chain
     @key        = key
     @passphrase = passphrase
-    @options = options
-    @options.merge!(DEFAULT_OPTIONS)
+    @options = DEFAULT_OPTIONS.merge(options)
 
     unless @key then
       default_key  = File.join Gem.default_key_path

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -44,6 +44,7 @@ class TestGemConfigFile < Gem::TestCase
     assert_equal Gem::ConfigFile::DEFAULT_BULK_THRESHOLD, @cfg.bulk_threshold
     assert_equal true, @cfg.verbose
     assert_equal [@gem_repo], Gem.sources
+    assert_equal 365, @cfg.cert_expiration_length_days
 
     File.open @temp_conf, 'w' do |fp|
       fp.puts ":backtrace: true"
@@ -58,6 +59,7 @@ class TestGemConfigFile < Gem::TestCase
       fp.puts "- /var/ruby/1.8/gem_home"
       fp.puts ":ssl_verify_mode: 0"
       fp.puts ":ssl_ca_cert: /etc/ssl/certs"
+      fp.puts ":cert_expiration_length_days: 28"
     end
 
     util_config_file
@@ -71,6 +73,7 @@ class TestGemConfigFile < Gem::TestCase
                  @cfg.path)
     assert_equal 0, @cfg.ssl_verify_mode
     assert_equal '/etc/ssl/certs', @cfg.ssl_ca_cert
+    assert_equal 28, @cfg.cert_expiration_length_days
   end
 
   def test_initialize_handle_arguments_config_file


### PR DESCRIPTION
# Description:

closes https://github.com/rubygems/rubygems/issues/2397

This introduce a new configuration option `cert_expiration_length_days`, this option will allow a user to set the default expiration length in days of a certificate when is created or being re-signed.

`.gemrc` example:
```yaml
:verbose: true
:update_sources: true
:backtrace: true
:cert_expiration_length_days: 30
```

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
