### PR TITLE
Dont add coverage reports to Manifest.txt

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -343,7 +343,7 @@ desc "Update the manifest to reflect what's on disk"
 task :update_manifest do
   files = []
   require 'find'
-  exclude = %r[/\/tmp\/|pkg|CVS|\.DS_Store|\.svn|\.git|TAGS|extconf.h|\.bundle$|\.o$|\.log$/|\./bundler/(?!lib|man|exe|[^/]+\.md|bundler.gemspec)|doc/]ox
+  exclude = %r[/\/tmp\/|pkg|CVS|\.DS_Store|\.svn|\.git|TAGS|extconf.h|\.bundle$|\.o$|\.log$/|\./bundler/(?!lib|man|exe|[^/]+\.md|bundler.gemspec)|doc|coverage/]ox
   Find.find(".") do |path|
     next unless File.file?(path)
     next if path =~ exclude


### PR DESCRIPTION
# Description:

When we run RubyGems' test suite, it will generate a coverage report. But the `update_manifest` Rake task is not filtering the `coverage/` folder. This PR just appends the `coverage/` folder to the exclude regex.

______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
