### PR TITLE
Add version command

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -303,6 +303,7 @@ lib/rubygems/commands/stale_command.rb
 lib/rubygems/commands/uninstall_command.rb
 lib/rubygems/commands/unpack_command.rb
 lib/rubygems/commands/update_command.rb
+lib/rubygems/commands/version_command.rb
 lib/rubygems/commands/which_command.rb
 lib/rubygems/commands/yank_command.rb
 lib/rubygems/compatibility.rb
@@ -541,6 +542,7 @@ test/rubygems/test_gem_commands_stale_command.rb
 test/rubygems/test_gem_commands_uninstall_command.rb
 test/rubygems/test_gem_commands_unpack_command.rb
 test/rubygems/test_gem_commands_update_command.rb
+test/rubygems/test_gem_commands_version_command.rb
 test/rubygems/test_gem_commands_which_command.rb
 test/rubygems/test_gem_commands_yank_command.rb
 test/rubygems/test_gem_config_file.rb

--- a/lib/rubygems/command_manager.rb
+++ b/lib/rubygems/command_manager.rb
@@ -67,6 +67,7 @@ class Gem::CommandManager
     :uninstall,
     :unpack,
     :update,
+    :version,
     :which,
     :yank,
   ]

--- a/lib/rubygems/commands/version_command.rb
+++ b/lib/rubygems/commands/version_command.rb
@@ -1,0 +1,19 @@
+require 'rubygems/command'
+
+class Gem::Commands::VersionCommand < Gem::Command
+  def initialize
+    super "version", "Print the version of RubyGems"
+  end
+
+  def description # :nodoc:
+    "Print the version of RubyGems"
+  end
+
+  def usage # :nodoc:
+    "#{program_name}"
+  end
+
+  def execute
+    say Gem::VERSION
+  end
+end

--- a/test/rubygems/test_gem_commands_version_command.rb
+++ b/test/rubygems/test_gem_commands_version_command.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require 'rubygems/test_case'
+require 'rubygems/commands/version_command'
+
+class TestGemCommandsVersionCommand < Gem::TestCase
+
+  def setup
+    super
+
+    @cmd = Gem::Commands::VersionCommand.new
+  end
+
+  def test_execute
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    assert_match "#{Gem::VERSION}", @ui.output
+  end
+end
+


### PR DESCRIPTION
# Description:

I find myself often using `gem version` to check for the current version of RubyGems, but it's actually `gem --version` to get the version string.

I think it would be good to support both ways. So this PR adds the `version` command that will just print out the version string the same way that `gem --version` does.

______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
