### PR TITLE
Prefer require_relative

### DIFF
--- a/lib/rubygems/bundler_version_finder.rb
+++ b/lib/rubygems/bundler_version_finder.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "rubygems/util"
+require_relative "util"
 
 module Gem::BundlerVersionFinder
   @without_filtering = false

--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -6,8 +6,8 @@
 #++
 
 require 'optparse'
-require 'rubygems/requirement'
-require 'rubygems/user_interaction'
+require_relative 'requirement'
+require_relative 'user_interaction'
 
 ##
 # Base class for all Gem commands.  When creating a new gem command, define

--- a/lib/rubygems/command_manager.rb
+++ b/lib/rubygems/command_manager.rb
@@ -5,8 +5,8 @@
 # See LICENSE.txt for permissions.
 #++
 
-require 'rubygems/command'
-require 'rubygems/user_interaction'
+require_relative 'command'
+require_relative 'user_interaction'
 
 ##
 # The command manager registers and installs all the individual sub-commands

--- a/lib/rubygems/commands/build_command.rb
+++ b/lib/rubygems/commands/build_command.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'rubygems/command'
-require 'rubygems/package'
+require_relative '../command'
+require_relative '../package'
 
 class Gem::Commands::BuildCommand < Gem::Command
 

--- a/lib/rubygems/commands/cert_command.rb
+++ b/lib/rubygems/commands/cert_command.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'rubygems/command'
-require 'rubygems/security'
+require_relative '../command'
+require_relative '../security'
 begin
   require 'openssl'
 rescue LoadError => e

--- a/lib/rubygems/commands/check_command.rb
+++ b/lib/rubygems/commands/check_command.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
-require 'rubygems/command'
-require 'rubygems/version_option'
-require 'rubygems/validator'
-require 'rubygems/doctor'
+require_relative '../command'
+require_relative '../version_option'
+require_relative '../validator'
+require_relative '../doctor'
 
 class Gem::Commands::CheckCommand < Gem::Command
 

--- a/lib/rubygems/commands/cleanup_command.rb
+++ b/lib/rubygems/commands/cleanup_command.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
-require 'rubygems/command'
-require 'rubygems/dependency_list'
-require 'rubygems/uninstaller'
+require_relative '../command'
+require_relative '../dependency_list'
+require_relative '../uninstaller'
 
 class Gem::Commands::CleanupCommand < Gem::Command
 

--- a/lib/rubygems/commands/contents_command.rb
+++ b/lib/rubygems/commands/contents_command.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'English'
-require 'rubygems/command'
-require 'rubygems/version_option'
+require_relative '../command'
+require_relative '../version_option'
 
 class Gem::Commands::ContentsCommand < Gem::Command
 

--- a/lib/rubygems/commands/dependency_command.rb
+++ b/lib/rubygems/commands/dependency_command.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
-require 'rubygems/command'
-require 'rubygems/local_remote_options'
-require 'rubygems/version_option'
+require_relative '../command'
+require_relative '../local_remote_options'
+require_relative '../version_option'
 
 class Gem::Commands::DependencyCommand < Gem::Command
 

--- a/lib/rubygems/commands/environment_command.rb
+++ b/lib/rubygems/commands/environment_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rubygems/command'
+require_relative '../command'
 
 class Gem::Commands::EnvironmentCommand < Gem::Command
 

--- a/lib/rubygems/commands/fetch_command.rb
+++ b/lib/rubygems/commands/fetch_command.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
-require 'rubygems/command'
-require 'rubygems/local_remote_options'
-require 'rubygems/version_option'
+require_relative '../command'
+require_relative '../local_remote_options'
+require_relative '../version_option'
 
 class Gem::Commands::FetchCommand < Gem::Command
 

--- a/lib/rubygems/commands/generate_index_command.rb
+++ b/lib/rubygems/commands/generate_index_command.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'rubygems/command'
-require 'rubygems/indexer'
+require_relative '../command'
+require_relative '../indexer'
 
 ##
 # Generates a index files for use as a gem server.

--- a/lib/rubygems/commands/help_command.rb
+++ b/lib/rubygems/commands/help_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rubygems/command'
+require_relative '../command'
 
 class Gem::Commands::HelpCommand < Gem::Command
 

--- a/lib/rubygems/commands/info_command.rb
+++ b/lib/rubygems/commands/info_command.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'rubygems/command'
-require 'rubygems/commands/query_command'
+require_relative '../command'
+require_relative 'query_command'
 
 class Gem::Commands::InfoCommand < Gem::Commands::QueryCommand
   def initialize

--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
-require 'rubygems/command'
-require 'rubygems/install_update_options'
-require 'rubygems/dependency_installer'
-require 'rubygems/local_remote_options'
-require 'rubygems/validator'
-require 'rubygems/version_option'
+require_relative '../command'
+require_relative '../install_update_options'
+require_relative '../dependency_installer'
+require_relative '../local_remote_options'
+require_relative '../validator'
+require_relative '../version_option'
 
 ##
 # Gem installer command line tool
@@ -171,7 +171,7 @@ You can use `i` command instead of `install`.
   end
 
   def install_from_gemdeps # :nodoc:
-    require 'rubygems/request_set'
+    require_relative '../request_set'
     rs = Gem::RequestSet.new
 
     specs = rs.install_from_gemdeps options do |req, inst|
@@ -242,7 +242,7 @@ You can use `i` command instead of `install`.
     inst = Gem::Installer.at gem, options
     inst.install
 
-    require 'rubygems/dependency_installer'
+    require_relative '../dependency_installer'
     dinst = Gem::DependencyInstaller.new options
     dinst.installed_gems.replace [inst.spec]
 
@@ -286,11 +286,11 @@ You can use `i` command instead of `install`.
 
   def load_hooks # :nodoc:
     if options[:install_as_default]
-      require 'rubygems/install_default_message'
+      require_relative '../install_default_message'
     else
-      require 'rubygems/install_message'
+      require_relative '../install_message'
     end
-    require 'rubygems/rdoc'
+    require_relative '../rdoc'
   end
 
   def show_install_errors errors # :nodoc:

--- a/lib/rubygems/commands/list_command.rb
+++ b/lib/rubygems/commands/list_command.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'rubygems/command'
-require 'rubygems/commands/query_command'
+require_relative '../command'
+require_relative 'query_command'
 
 ##
 # An alternate to Gem::Commands::QueryCommand that searches for gems starting

--- a/lib/rubygems/commands/lock_command.rb
+++ b/lib/rubygems/commands/lock_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rubygems/command'
+require_relative '../command'
 
 class Gem::Commands::LockCommand < Gem::Command
 

--- a/lib/rubygems/commands/mirror_command.rb
+++ b/lib/rubygems/commands/mirror_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rubygems/command'
+require_relative '../command'
 
 unless defined? Gem::Commands::MirrorCommand
   class Gem::Commands::MirrorCommand < Gem::Command

--- a/lib/rubygems/commands/open_command.rb
+++ b/lib/rubygems/commands/open_command.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 require 'English'
-require 'rubygems/command'
-require 'rubygems/version_option'
-require 'rubygems/util'
+require_relative '../command'
+require_relative '../version_option'
+require_relative '../util'
 
 class Gem::Commands::OpenCommand < Gem::Command
 

--- a/lib/rubygems/commands/outdated_command.rb
+++ b/lib/rubygems/commands/outdated_command.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
-require 'rubygems/command'
-require 'rubygems/local_remote_options'
-require 'rubygems/spec_fetcher'
-require 'rubygems/version_option'
+require_relative '../command'
+require_relative '../local_remote_options'
+require_relative '../spec_fetcher'
+require_relative '../version_option'
 
 class Gem::Commands::OutdatedCommand < Gem::Command
 

--- a/lib/rubygems/commands/owner_command.rb
+++ b/lib/rubygems/commands/owner_command.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
-require 'rubygems/command'
-require 'rubygems/local_remote_options'
-require 'rubygems/gemcutter_utilities'
+require_relative '../command'
+require_relative '../local_remote_options'
+require_relative '../gemcutter_utilities'
 
 class Gem::Commands::OwnerCommand < Gem::Command
   include Gem::LocalRemoteOptions

--- a/lib/rubygems/commands/pristine_command.rb
+++ b/lib/rubygems/commands/pristine_command.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
-require 'rubygems/command'
-require 'rubygems/package'
-require 'rubygems/installer'
-require 'rubygems/version_option'
+require_relative '../command'
+require_relative '../package'
+require_relative '../installer'
+require_relative '../version_option'
 
 class Gem::Commands::PristineCommand < Gem::Command
 
@@ -142,7 +142,7 @@ extensions will be restored.
       gem = spec.cache_file
 
       unless File.exist? gem or options[:only_executables] then
-        require 'rubygems/remote_fetcher'
+        require_relative '../remote_fetcher'
 
         say "Cached gem for #{spec.full_name} not found, attempting to fetch..."
 

--- a/lib/rubygems/commands/push_command.rb
+++ b/lib/rubygems/commands/push_command.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
-require 'rubygems/command'
-require 'rubygems/local_remote_options'
-require 'rubygems/gemcutter_utilities'
-require 'rubygems/package'
+require_relative '../command'
+require_relative '../local_remote_options'
+require_relative '../gemcutter_utilities'
+require_relative '../package'
 
 class Gem::Commands::PushCommand < Gem::Command
   include Gem::LocalRemoteOptions

--- a/lib/rubygems/commands/query_command.rb
+++ b/lib/rubygems/commands/query_command.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
-require 'rubygems/command'
-require 'rubygems/local_remote_options'
-require 'rubygems/spec_fetcher'
-require 'rubygems/version_option'
-require 'rubygems/text'
+require_relative '../command'
+require_relative '../local_remote_options'
+require_relative '../spec_fetcher'
+require_relative '../version_option'
+require_relative '../text'
 
 class Gem::Commands::QueryCommand < Gem::Command
 

--- a/lib/rubygems/commands/rdoc_command.rb
+++ b/lib/rubygems/commands/rdoc_command.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
-require 'rubygems/command'
-require 'rubygems/version_option'
-require 'rubygems/rdoc'
+require_relative '../command'
+require_relative '../version_option'
+require_relative '../rdoc'
 require 'fileutils'
 
 class Gem::Commands::RdocCommand < Gem::Command

--- a/lib/rubygems/commands/search_command.rb
+++ b/lib/rubygems/commands/search_command.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'rubygems/command'
-require 'rubygems/commands/query_command'
+require_relative '../command'
+require_relative 'query_command'
 
 class Gem::Commands::SearchCommand < Gem::Commands::QueryCommand
 

--- a/lib/rubygems/commands/server_command.rb
+++ b/lib/rubygems/commands/server_command.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'rubygems/command'
-require 'rubygems/server'
+require_relative '../command'
+require_relative '../server'
 
 class Gem::Commands::ServerCommand < Gem::Command
 

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rubygems/command'
+require_relative '../command'
 
 ##
 # Installs RubyGems itself.  This command is ordinarily only available from a
@@ -360,7 +360,7 @@ By default, this RubyGems will install gem as:
         rm_rf dir
       end
 
-      require 'rubygems/rdoc'
+      require_relative '../rdoc'
 
       fake_spec = Gem::Specification.new 'rubygems', Gem::VERSION
       def fake_spec.full_gem_path
@@ -428,7 +428,7 @@ By default, this RubyGems will install gem as:
     end
 
     if Gem.win_platform?
-      require 'rubygems/installer'
+      require_relative '../installer'
 
       installer = Gem::Installer.for_spec bundler_spec
       bundler_spec.executables.each do |e|
@@ -605,7 +605,7 @@ abort "#{deprecation_message}"
   end
 
   def uninstall_old_gemcutter
-    require 'rubygems/uninstaller'
+    require_relative '../uninstaller'
 
     ui = Gem::Uninstaller.new('gemcutter', :all => true, :ignore => true,
                               :version => '< 0.4')
@@ -614,7 +614,7 @@ abort "#{deprecation_message}"
   end
 
   def regenerate_binstubs
-    require "rubygems/commands/pristine_command"
+    require_relative "pristine_command"
     say "Regenerating binstubs"
 
     args = %w[--all --only-executables --silent]

--- a/lib/rubygems/commands/signin_command.rb
+++ b/lib/rubygems/commands/signin_command.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'rubygems/command'
-require 'rubygems/gemcutter_utilities'
+require_relative '../command'
+require_relative '../gemcutter_utilities'
 
 class Gem::Commands::SigninCommand < Gem::Command
   include Gem::GemcutterUtilities

--- a/lib/rubygems/commands/signout_command.rb
+++ b/lib/rubygems/commands/signout_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rubygems/command'
+require_relative '../command'
 
 class Gem::Commands::SignoutCommand < Gem::Command
 

--- a/lib/rubygems/commands/sources_command.rb
+++ b/lib/rubygems/commands/sources_command.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
-require 'rubygems/command'
-require 'rubygems/remote_fetcher'
-require 'rubygems/spec_fetcher'
-require 'rubygems/local_remote_options'
+require_relative '../command'
+require_relative '../remote_fetcher'
+require_relative '../spec_fetcher'
+require_relative '../local_remote_options'
 
 class Gem::Commands::SourcesCommand < Gem::Command
 

--- a/lib/rubygems/commands/specification_command.rb
+++ b/lib/rubygems/commands/specification_command.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
-require 'rubygems/command'
-require 'rubygems/local_remote_options'
-require 'rubygems/version_option'
-require 'rubygems/package'
+require_relative '../command'
+require_relative '../local_remote_options'
+require_relative '../version_option'
+require_relative '../package'
 
 class Gem::Commands::SpecificationCommand < Gem::Command
 

--- a/lib/rubygems/commands/stale_command.rb
+++ b/lib/rubygems/commands/stale_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rubygems/command'
+require_relative '../command'
 
 class Gem::Commands::StaleCommand < Gem::Command
   def initialize

--- a/lib/rubygems/commands/uninstall_command.rb
+++ b/lib/rubygems/commands/uninstall_command.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
-require 'rubygems/command'
-require 'rubygems/version_option'
-require 'rubygems/uninstaller'
+require_relative '../command'
+require_relative '../version_option'
+require_relative '../uninstaller'
 require 'fileutils'
 
 ##

--- a/lib/rubygems/commands/unpack_command.rb
+++ b/lib/rubygems/commands/unpack_command.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
-require 'rubygems/command'
-require 'rubygems/installer'
-require 'rubygems/version_option'
-require 'rubygems/security_option'
-require 'rubygems/remote_fetcher'
+require_relative '../command'
+require_relative '../installer'
+require_relative '../version_option'
+require_relative '../security_option'
+require_relative '../remote_fetcher'
 
 # forward-declare
 

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
-require 'rubygems/command'
-require 'rubygems/command_manager'
-require 'rubygems/dependency_installer'
-require 'rubygems/install_update_options'
-require 'rubygems/local_remote_options'
-require 'rubygems/spec_fetcher'
-require 'rubygems/version_option'
-require 'rubygems/install_message' # must come before rdoc for messaging
-require 'rubygems/rdoc'
+require_relative '../command'
+require_relative '../command_manager'
+require_relative '../dependency_installer'
+require_relative '../install_update_options'
+require_relative '../local_remote_options'
+require_relative '../spec_fetcher'
+require_relative '../version_option'
+require_relative '../install_message' # must come before rdoc for messaging
+require_relative '../rdoc'
 
 class Gem::Commands::UpdateCommand < Gem::Command
 

--- a/lib/rubygems/commands/which_command.rb
+++ b/lib/rubygems/commands/which_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rubygems/command'
+require_relative '../command'
 
 class Gem::Commands::WhichCommand < Gem::Command
   def initialize

--- a/lib/rubygems/commands/yank_command.rb
+++ b/lib/rubygems/commands/yank_command.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
-require 'rubygems/command'
-require 'rubygems/local_remote_options'
-require 'rubygems/version_option'
-require 'rubygems/gemcutter_utilities'
+require_relative '../command'
+require_relative '../local_remote_options'
+require_relative '../version_option'
+require_relative '../gemcutter_utilities'
 
 class Gem::Commands::YankCommand < Gem::Command
   include Gem::LocalRemoteOptions

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -5,7 +5,7 @@
 # See LICENSE.txt for permissions.
 #++
 
-require 'rubygems/user_interaction'
+require_relative 'user_interaction'
 require 'rbconfig'
 
 ##

--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -2,8 +2,8 @@
 ##
 # The Dependency class holds a Gem name and a Gem::Requirement.
 
-require "rubygems/bundler_version_finder"
-require "rubygems/requirement"
+require_relative "bundler_version_finder"
+require_relative "requirement"
 
 class Gem::Dependency
 

--- a/lib/rubygems/dependency_installer.rb
+++ b/lib/rubygems/dependency_installer.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 require 'rubygems'
-require 'rubygems/dependency_list'
-require 'rubygems/package'
-require 'rubygems/installer'
-require 'rubygems/spec_fetcher'
-require 'rubygems/user_interaction'
-require 'rubygems/source'
-require 'rubygems/available_set'
-require 'rubygems/deprecate'
+require_relative 'dependency_list'
+require_relative 'package'
+require_relative 'installer'
+require_relative 'spec_fetcher'
+require_relative 'user_interaction'
+require_relative 'source'
+require_relative 'available_set'
+require_relative 'deprecate'
 
 ##
 # Installs a gem along with all its dependencies from local and remote gems.

--- a/lib/rubygems/dependency_list.rb
+++ b/lib/rubygems/dependency_list.rb
@@ -6,7 +6,7 @@
 #++
 
 require 'tsort'
-require 'rubygems/deprecate'
+require_relative 'deprecate'
 
 ##
 # Gem::DependencyList is used for installing and uninstalling gems in the

--- a/lib/rubygems/doctor.rb
+++ b/lib/rubygems/doctor.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require 'rubygems'
-require 'rubygems/user_interaction'
+require_relative 'user_interaction'
 
 ##
 # Cleans up after a partially-failed uninstall or for an invalid

--- a/lib/rubygems/exceptions.rb
+++ b/lib/rubygems/exceptions.rb
@@ -4,7 +4,7 @@
 # Each exception needs a brief description and the scenarios where it is
 # likely to be raised
 
-require 'rubygems/deprecate'
+require_relative 'deprecate'
 
 ##
 # Base exception class for RubyGems.  All exception raised by RubyGems are a

--- a/lib/rubygems/ext.rb
+++ b/lib/rubygems/ext.rb
@@ -10,10 +10,10 @@
 
 module Gem::Ext; end
 
-require 'rubygems/ext/build_error'
-require 'rubygems/ext/builder'
-require 'rubygems/ext/configure_builder'
-require 'rubygems/ext/ext_conf_builder'
-require 'rubygems/ext/rake_builder'
-require 'rubygems/ext/cmake_builder'
+require_relative 'ext/build_error'
+require_relative 'ext/builder'
+require_relative 'ext/configure_builder'
+require_relative 'ext/ext_conf_builder'
+require_relative 'ext/rake_builder'
+require_relative 'ext/cmake_builder'
 

--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -5,7 +5,7 @@
 # See LICENSE.txt for permissions.
 #++
 
-require 'rubygems/user_interaction'
+require_relative '../user_interaction'
 
 class Gem::Ext::Builder
 

--- a/lib/rubygems/ext/cmake_builder.rb
+++ b/lib/rubygems/ext/cmake_builder.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rubygems/command'
+require_relative '../command'
 
 class Gem::Ext::CmakeBuilder < Gem::Ext::Builder
   def self.build(extension, dest_path, results, args=[], lib_dir=nil)

--- a/lib/rubygems/gem_runner.rb
+++ b/lib/rubygems/gem_runner.rb
@@ -6,9 +6,9 @@
 #++
 
 require 'rubygems'
-require 'rubygems/command_manager'
-require 'rubygems/config_file'
-require 'rubygems/deprecate'
+require_relative 'command_manager'
+require_relative 'config_file'
+require_relative 'deprecate'
 
 ##
 # Load additional plugins from $LOAD_PATH

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rubygems/remote_fetcher'
+require_relative 'remote_fetcher'
 
 ##
 # Utility methods for using the RubyGems API.

--- a/lib/rubygems/indexer.rb
+++ b/lib/rubygems/indexer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require 'rubygems'
-require 'rubygems/package'
+require_relative 'package'
 require 'time'
 require 'tmpdir'
 

--- a/lib/rubygems/install_default_message.rb
+++ b/lib/rubygems/install_default_message.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require 'rubygems'
-require 'rubygems/user_interaction'
+require_relative 'user_interaction'
 
 ##
 # A post-install hook that displays "Successfully installed

--- a/lib/rubygems/install_message.rb
+++ b/lib/rubygems/install_message.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require 'rubygems'
-require 'rubygems/user_interaction'
+require_relative 'user_interaction'
 
 ##
 # A default post-install hook that displays "Successfully installed

--- a/lib/rubygems/install_update_options.rb
+++ b/lib/rubygems/install_update_options.rb
@@ -6,7 +6,7 @@
 #++
 
 require 'rubygems'
-require 'rubygems/security_option'
+require_relative 'security_option'
 
 ##
 # Mixin methods for install and update options for Gem::Commands

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -5,12 +5,12 @@
 # See LICENSE.txt for permissions.
 #++
 
-require 'rubygems/command'
-require 'rubygems/exceptions'
-require 'rubygems/deprecate'
-require 'rubygems/package'
-require 'rubygems/ext'
-require 'rubygems/user_interaction'
+require_relative 'command'
+require_relative 'exceptions'
+require_relative 'deprecate'
+require_relative 'package'
+require_relative 'ext'
+require_relative 'user_interaction'
 require 'fileutils'
 
 ##

--- a/lib/rubygems/installer_test_case.rb
+++ b/lib/rubygems/installer_test_case.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'rubygems/test_case'
-require 'rubygems/installer'
+require_relative 'test_case'
+require_relative 'installer'
 
 class Gem::Installer
 

--- a/lib/rubygems/mock_gem_ui.rb
+++ b/lib/rubygems/mock_gem_ui.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require 'stringio'
-require 'rubygems/user_interaction'
+require_relative 'user_interaction'
 
 ##
 # This Gem::StreamUI subclass records input and output to StringIO for

--- a/lib/rubygems/name_tuple.rb
+++ b/lib/rubygems/name_tuple.rb
@@ -4,7 +4,7 @@
 # Represents a gem of name +name+ at +version+ of +platform+. These
 # wrap the data returned from the indexes.
 
-require 'rubygems/platform'
+require_relative 'platform'
 
 class Gem::NameTuple
   def initialize(name, version, platform="ruby")

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -41,9 +41,9 @@
 # #files are the files in the .gem tar file, not the Ruby files in the gem
 # #extract_files and #contents automatically call #verify
 
-require 'rubygems/security'
-require 'rubygems/specification'
-require 'rubygems/user_interaction'
+require_relative 'security'
+require_relative 'specification'
+require_relative 'user_interaction'
 require 'zlib'
 
 class Gem::Package
@@ -258,7 +258,7 @@ class Gem::Package
     raise ArgumentError, "skip_validation = true and strict_validation = true are incompatible" if skip_validation && strict_validation
 
     Gem.load_yaml
-    require 'rubygems/security'
+    require_relative 'security'
 
     @spec.mark_version
     @spec.validate true, strict_validation unless skip_validation
@@ -677,12 +677,12 @@ EOM
 
 end
 
-require 'rubygems/package/digest_io'
-require 'rubygems/package/source'
-require 'rubygems/package/file_source'
-require 'rubygems/package/io_source'
-require 'rubygems/package/old'
-require 'rubygems/package/tar_header'
-require 'rubygems/package/tar_reader'
-require 'rubygems/package/tar_reader/entry'
-require 'rubygems/package/tar_writer'
+require_relative 'package/digest_io'
+require_relative 'package/source'
+require_relative 'package/file_source'
+require_relative 'package/io_source'
+require_relative 'package/old'
+require_relative 'package/tar_header'
+require_relative 'package/tar_reader'
+require_relative 'package/tar_reader/entry'
+require_relative 'package/tar_writer'

--- a/lib/rubygems/package/tar_reader.rb
+++ b/lib/rubygems/package/tar_reader.rb
@@ -118,4 +118,4 @@ class Gem::Package::TarReader
 
 end
 
-require 'rubygems/package/tar_reader/entry'
+require_relative 'tar_reader/entry'

--- a/lib/rubygems/package/tar_test_case.rb
+++ b/lib/rubygems/package/tar_test_case.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'rubygems/test_case'
-require 'rubygems/package'
+require_relative '../test_case'
+require_relative '../package'
 
 ##
 # A test case for Gem::Package::Tar* classes

--- a/lib/rubygems/package_task.rb
+++ b/lib/rubygems/package_task.rb
@@ -21,7 +21,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 require 'rubygems'
-require 'rubygems/package'
+require_relative 'package'
 begin
   gem 'rake'
 rescue Gem::LoadError

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require "rubygems/deprecate"
+require_relative "deprecate"
 
 ##
 # Available list of platforms for targeting Gem installations.

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 require 'rubygems'
-require 'rubygems/request'
-require 'rubygems/uri_formatter'
-require 'rubygems/user_interaction'
-require 'rubygems/request/connection_pools'
+require_relative 'request'
+require_relative 'uri_formatter'
+require_relative 'user_interaction'
+require_relative 'request/connection_pools'
 require 'resolv'
 
 ##

--- a/lib/rubygems/request.rb
+++ b/lib/rubygems/request.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'net/http'
 require 'time'
-require 'rubygems/user_interaction'
+require_relative 'user_interaction'
 
 class Gem::Request
 
@@ -288,6 +288,6 @@ class Gem::Request
 
 end
 
-require 'rubygems/request/http_pool'
-require 'rubygems/request/https_pool'
-require 'rubygems/request/connection_pools'
+require_relative 'request/http_pool'
+require_relative 'request/https_pool'
+require_relative 'request/connection_pools'

--- a/lib/rubygems/request_set.rb
+++ b/lib/rubygems/request_set.rb
@@ -315,7 +315,7 @@ class Gem::RequestSet
       end
     end
 
-    require "rubygems/dependency_installer"
+    require_relative "dependency_installer"
     inst = Gem::DependencyInstaller.new options
     inst.installed_gems.replace specs
 
@@ -474,6 +474,6 @@ class Gem::RequestSet
 
 end
 
-require 'rubygems/request_set/gem_dependency_api'
-require 'rubygems/request_set/lockfile'
-require 'rubygems/request_set/lockfile/tokenizer'
+require_relative 'request_set/gem_dependency_api'
+require_relative 'request_set/lockfile'
+require_relative 'request_set/lockfile/tokenizer'

--- a/lib/rubygems/request_set/lockfile.rb
+++ b/lib/rubygems/request_set/lockfile.rb
@@ -235,4 +235,4 @@ class Gem::RequestSet::Lockfile
   end
 end
 
-require 'rubygems/request_set/lockfile/tokenizer'
+require_relative 'lockfile/tokenizer'

--- a/lib/rubygems/request_set/lockfile/tokenizer.rb
+++ b/lib/rubygems/request_set/lockfile/tokenizer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rubygems/request_set/lockfile/parser'
+require_relative 'parser'
 
 class Gem::RequestSet::Lockfile::Tokenizer
   Token = Struct.new :type, :value, :column, :line

--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require "rubygems/version"
-require "rubygems/deprecate"
+require_relative "version"
+require_relative "deprecate"
 
 # If we're being loaded after yaml was already required, then
 # load our yaml + workarounds now.

--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
-require 'rubygems/dependency'
-require 'rubygems/exceptions'
-require 'rubygems/util'
-require 'rubygems/util/list'
+require_relative 'dependency'
+require_relative 'exceptions'
+require_relative 'util'
+require_relative 'util/list'
 
 ##
 # Given a set of Gem::Dependency objects as +needed+ and a way to query the
@@ -11,7 +11,7 @@ require 'rubygems/util/list'
 # all the requirements.
 
 class Gem::Resolver
-  require 'rubygems/resolver/molinillo'
+  require_relative 'resolver/molinillo'
 
   ##
   # If the DEBUG_RESOLVER environment variable is set then debugging mode is
@@ -314,30 +314,30 @@ class Gem::Resolver
 
 end
 
-require 'rubygems/resolver/activation_request'
-require 'rubygems/resolver/conflict'
-require 'rubygems/resolver/dependency_request'
-require 'rubygems/resolver/requirement_list'
-require 'rubygems/resolver/stats'
+require_relative 'resolver/activation_request'
+require_relative 'resolver/conflict'
+require_relative 'resolver/dependency_request'
+require_relative 'resolver/requirement_list'
+require_relative 'resolver/stats'
 
-require 'rubygems/resolver/set'
-require 'rubygems/resolver/api_set'
-require 'rubygems/resolver/composed_set'
-require 'rubygems/resolver/best_set'
-require 'rubygems/resolver/current_set'
-require 'rubygems/resolver/git_set'
-require 'rubygems/resolver/index_set'
-require 'rubygems/resolver/installer_set'
-require 'rubygems/resolver/lock_set'
-require 'rubygems/resolver/vendor_set'
-require 'rubygems/resolver/source_set'
+require_relative 'resolver/set'
+require_relative 'resolver/api_set'
+require_relative 'resolver/composed_set'
+require_relative 'resolver/best_set'
+require_relative 'resolver/current_set'
+require_relative 'resolver/git_set'
+require_relative 'resolver/index_set'
+require_relative 'resolver/installer_set'
+require_relative 'resolver/lock_set'
+require_relative 'resolver/vendor_set'
+require_relative 'resolver/source_set'
 
-require 'rubygems/resolver/specification'
-require 'rubygems/resolver/spec_specification'
-require 'rubygems/resolver/api_specification'
-require 'rubygems/resolver/git_specification'
-require 'rubygems/resolver/index_specification'
-require 'rubygems/resolver/installed_specification'
-require 'rubygems/resolver/local_specification'
-require 'rubygems/resolver/lock_specification'
-require 'rubygems/resolver/vendor_specification'
+require_relative 'resolver/specification'
+require_relative 'resolver/spec_specification'
+require_relative 'resolver/api_specification'
+require_relative 'resolver/git_specification'
+require_relative 'resolver/index_specification'
+require_relative 'resolver/installed_specification'
+require_relative 'resolver/local_specification'
+require_relative 'resolver/lock_specification'
+require_relative 'resolver/vendor_specification'

--- a/lib/rubygems/resolver/git_specification.rb
+++ b/lib/rubygems/resolver/git_specification.rb
@@ -22,7 +22,7 @@ class Gem::Resolver::GitSpecification < Gem::Resolver::SpecSpecification
   # the executables.
 
   def install options = {}
-    require 'rubygems/installer'
+    require_relative '../installer'
 
     installer = Gem::Installer.for_spec spec, options
 

--- a/lib/rubygems/resolver/molinillo.rb
+++ b/lib/rubygems/resolver/molinillo.rb
@@ -1,2 +1,2 @@
 # frozen_string_literal: true
-require 'rubygems/resolver/molinillo/lib/molinillo'
+require_relative 'molinillo/lib/molinillo'

--- a/lib/rubygems/resolver/molinillo/lib/molinillo.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
-require 'rubygems/resolver/molinillo/lib/molinillo/gem_metadata'
-require 'rubygems/resolver/molinillo/lib/molinillo/errors'
-require 'rubygems/resolver/molinillo/lib/molinillo/resolver'
-require 'rubygems/resolver/molinillo/lib/molinillo/modules/ui'
-require 'rubygems/resolver/molinillo/lib/molinillo/modules/specification_provider'
+require_relative 'molinillo/gem_metadata'
+require_relative 'molinillo/errors'
+require_relative 'molinillo/resolver'
+require_relative 'molinillo/modules/ui'
+require_relative 'molinillo/modules/specification_provider'
 
 # Gem::Resolver::Molinillo is a generic dependency resolution algorithm.
 module Gem::Resolver::Molinillo

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph.rb
@@ -2,8 +2,8 @@
 require 'set'
 require 'tsort'
 
-require 'rubygems/resolver/molinillo/lib/molinillo/dependency_graph/log'
-require 'rubygems/resolver/molinillo/lib/molinillo/dependency_graph/vertex'
+require_relative 'dependency_graph/log'
+require_relative 'dependency_graph/vertex'
 
 module Gem::Resolver::Molinillo
   # A directed acyclic graph that is tuned to hold named dependencies

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/add_edge_no_circular.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/add_edge_no_circular.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rubygems/resolver/molinillo/lib/molinillo/dependency_graph/action'
+require_relative 'action'
 module Gem::Resolver::Molinillo
   class DependencyGraph
     # @!visibility private

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/add_vertex.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/add_vertex.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rubygems/resolver/molinillo/lib/molinillo/dependency_graph/action'
+require_relative 'action'
 module Gem::Resolver::Molinillo
   class DependencyGraph
     # @!visibility private

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/delete_edge.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/delete_edge.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rubygems/resolver/molinillo/lib/molinillo/dependency_graph/action'
+require_relative 'action'
 module Gem::Resolver::Molinillo
   class DependencyGraph
     # @!visibility private

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/detach_vertex_named.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/detach_vertex_named.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rubygems/resolver/molinillo/lib/molinillo/dependency_graph/action'
+require_relative 'action'
 module Gem::Resolver::Molinillo
   class DependencyGraph
     # @!visibility private

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/log.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/log.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
-require 'rubygems/resolver/molinillo/lib/molinillo/dependency_graph/add_edge_no_circular'
-require 'rubygems/resolver/molinillo/lib/molinillo/dependency_graph/add_vertex'
-require 'rubygems/resolver/molinillo/lib/molinillo/dependency_graph/delete_edge'
-require 'rubygems/resolver/molinillo/lib/molinillo/dependency_graph/detach_vertex_named'
-require 'rubygems/resolver/molinillo/lib/molinillo/dependency_graph/set_payload'
-require 'rubygems/resolver/molinillo/lib/molinillo/dependency_graph/tag'
+require_relative 'add_edge_no_circular'
+require_relative 'add_vertex'
+require_relative 'delete_edge'
+require_relative 'detach_vertex_named'
+require_relative 'set_payload'
+require_relative 'tag'
 
 module Gem::Resolver::Molinillo
   class DependencyGraph

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/set_payload.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/set_payload.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rubygems/resolver/molinillo/lib/molinillo/dependency_graph/action'
+require_relative 'action'
 module Gem::Resolver::Molinillo
   class DependencyGraph
     # @!visibility private

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/tag.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/tag.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rubygems/resolver/molinillo/lib/molinillo/dependency_graph/action'
+require_relative 'action'
 module Gem::Resolver::Molinillo
   class DependencyGraph
     # @!visibility private

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/resolution.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/resolution.rb
@@ -121,11 +121,11 @@ module Gem::Resolver::Molinillo
         debug { 'Activated: ' + Hash[activated.vertices.select { |_n, v| v.payload }].keys.join(', ') } if state
       end
 
-      require 'rubygems/resolver/molinillo/lib/molinillo/state'
-      require 'rubygems/resolver/molinillo/lib/molinillo/modules/specification_provider'
+      require_relative 'state'
+      require_relative 'modules/specification_provider'
 
-      require 'rubygems/resolver/molinillo/lib/molinillo/delegates/resolution_state'
-      require 'rubygems/resolver/molinillo/lib/molinillo/delegates/specification_provider'
+      require_relative 'delegates/resolution_state'
+      require_relative 'delegates/specification_provider'
 
       include Gem::Resolver::Molinillo::Delegates::ResolutionState
       include Gem::Resolver::Molinillo::Delegates::SpecificationProvider

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/resolver.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/resolver.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rubygems/resolver/molinillo/lib/molinillo/dependency_graph'
+require_relative 'dependency_graph'
 
 module Gem::Resolver::Molinillo
   # This class encapsulates a dependency resolver.
@@ -8,7 +8,7 @@ module Gem::Resolver::Molinillo
   #
   #
   class Resolver
-    require 'rubygems/resolver/molinillo/lib/molinillo/resolution'
+    require_relative 'resolution'
 
     # @return [SpecificationProvider] the specification provider used
     #   in the resolution process

--- a/lib/rubygems/resolver/specification.rb
+++ b/lib/rubygems/resolver/specification.rb
@@ -82,7 +82,7 @@ class Gem::Resolver::Specification
   # specification.
 
   def install options = {}
-    require 'rubygems/installer'
+    require_relative '../installer'
 
     gem = download options
 

--- a/lib/rubygems/security.rb
+++ b/lib/rubygems/security.rb
@@ -5,7 +5,7 @@
 # See LICENSE.txt for permissions.
 #++
 
-require 'rubygems/exceptions'
+require_relative 'exceptions'
 require 'fileutils'
 
 begin
@@ -599,10 +599,10 @@ module Gem::Security
 end
 
 if defined?(OpenSSL::SSL) then
-  require 'rubygems/security/policy'
-  require 'rubygems/security/policies'
-  require 'rubygems/security/trust_dir'
+  require_relative 'security/policy'
+  require_relative 'security/policies'
+  require_relative 'security/trust_dir'
 end
 
-require 'rubygems/security/signer'
+require_relative 'security/signer'
 

--- a/lib/rubygems/security/policy.rb
+++ b/lib/rubygems/security/policy.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rubygems/user_interaction'
+require_relative '../user_interaction'
 
 ##
 # A Gem::Security::Policy object encapsulates the settings for verifying

--- a/lib/rubygems/security/signer.rb
+++ b/lib/rubygems/security/signer.rb
@@ -2,7 +2,7 @@
 ##
 # Basic OpenSSL-based package signing class.
 
-require "rubygems/user_interaction"
+require_relative "../user_interaction"
 
 class Gem::Security::Signer
 

--- a/lib/rubygems/security_option.rb
+++ b/lib/rubygems/security_option.rb
@@ -21,7 +21,7 @@ module Gem::SecurityOption
   def add_security_option
     # TODO: use @parser.accept
     OptionParser.accept Gem::Security::Policy do |value|
-      require 'rubygems/security'
+      require_relative 'security'
 
       raise OptionParser::InvalidArgument, 'OpenSSL not installed' unless
         defined?(Gem::Security::HighSecurity)

--- a/lib/rubygems/server.rb
+++ b/lib/rubygems/server.rb
@@ -5,7 +5,7 @@ require 'erb'
 require 'uri'
 
 require 'rubygems'
-require 'rubygems/rdoc'
+require_relative 'rdoc'
 
 ##
 # Gem::Server and allows users to serve gems for consumption by

--- a/lib/rubygems/source.rb
+++ b/lib/rubygems/source.rb
@@ -43,7 +43,7 @@ class Gem::Source
   # Use an SRV record on the host to look up the true endpoint for the index.
 
   def api_uri # :nodoc:
-    require 'rubygems/remote_fetcher'
+    require_relative 'remote_fetcher'
     @api_uri ||= Gem::RemoteFetcher.fetcher.api_endpoint uri
   end
 
@@ -230,9 +230,9 @@ class Gem::Source
 
 end
 
-require 'rubygems/source/git'
-require 'rubygems/source/installed'
-require 'rubygems/source/specific_file'
-require 'rubygems/source/local'
-require 'rubygems/source/lock'
-require 'rubygems/source/vendor'
+require_relative 'source/git'
+require_relative 'source/installed'
+require_relative 'source/specific_file'
+require_relative 'source/local'
+require_relative 'source/lock'
+require_relative 'source/vendor'

--- a/lib/rubygems/source/git.rb
+++ b/lib/rubygems/source/git.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rubygems/util'
+require_relative '../util'
 
 ##
 # A git gem for use in a gem dependencies file.

--- a/lib/rubygems/source_list.rb
+++ b/lib/rubygems/source_list.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rubygems/source'
+require_relative 'source'
 
 ##
 # The SourceList represents the sources rubygems has been configured to use.

--- a/lib/rubygems/source_local.rb
+++ b/lib/rubygems/source_local.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'rubygems/source'
-require 'rubygems/source_local'
+require_relative 'source'
+require_relative 'source_local'
 
 unless Gem::Deprecate.skip
   Kernel.warn "#{Gem.location_of_caller(3).join(':')}: Warning: Requiring rubygems/source_local is deprecated; please use rubygems/source/local instead."

--- a/lib/rubygems/source_specific_file.rb
+++ b/lib/rubygems/source_specific_file.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rubygems/source/specific_file'
+require_relative 'source/specific_file'
 
 unless Gem::Deprecate.skip
   Kernel.warn "#{Gem.location_of_caller(3).join(':')}: Warning: Requiring rubygems/source_specific_file is deprecated; please use rubygems/source/specific_file instead."

--- a/lib/rubygems/spec_fetcher.rb
+++ b/lib/rubygems/spec_fetcher.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
-require 'rubygems/remote_fetcher'
-require 'rubygems/user_interaction'
-require 'rubygems/errors'
-require 'rubygems/text'
-require 'rubygems/name_tuple'
+require_relative 'remote_fetcher'
+require_relative 'user_interaction'
+require_relative 'errors'
+require_relative 'text'
+require_relative 'name_tuple'
 
 ##
 # SpecFetcher handles metadata updates from remote gem repositories.

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -7,14 +7,14 @@
 #++
 
 
-require 'rubygems/version'
-require 'rubygems/requirement'
-require 'rubygems/platform'
-require 'rubygems/deprecate'
-require 'rubygems/basic_specification'
-require 'rubygems/stub_specification'
-require 'rubygems/specification_policy'
-require 'rubygems/util/list'
+require_relative 'version'
+require_relative 'requirement'
+require_relative 'platform'
+require_relative 'deprecate'
+require_relative 'basic_specification'
+require_relative 'stub_specification'
+require_relative 'specification_policy'
+require_relative 'util/list'
 require 'stringio'
 
 ##
@@ -1628,9 +1628,9 @@ class Gem::Specification < Gem::BasicSpecification
       unresolved_deps = Gem::Specification.unresolved_deps.dup
       Gem::Specification.unresolved_deps.clear
 
-      require 'rubygems/config_file'
-      require 'rubygems/ext'
-      require 'rubygems/user_interaction'
+      require_relative 'config_file'
+      require_relative 'ext'
+      require_relative 'user_interaction'
 
       ui = Gem::SilentUI.new
       Gem::DefaultUserInteraction.use_ui ui do
@@ -2604,7 +2604,7 @@ class Gem::Specification < Gem::BasicSpecification
     # back, we have to check again here to make sure that our
     # psych code was properly loaded, and load it if not.
     unless Gem.const_defined?(:NoAliasYAMLTree)
-      require 'rubygems/psych_tree'
+      require_relative 'psych_tree'
     end
 
     builder = Gem::NoAliasYAMLTree.create
@@ -2657,7 +2657,7 @@ class Gem::Specification < Gem::BasicSpecification
   # checks..
 
   def validate packaging = true, strict = false
-    require 'rubygems/user_interaction'
+    require_relative 'user_interaction'
     extend Gem::UserInteraction
     normalize
 

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -49,18 +49,18 @@ if Gem::USE_BUNDLER_FOR_GEMDEPS
 end
 require 'minitest/autorun'
 
-require 'rubygems/deprecate'
+require_relative 'deprecate'
 
 require 'fileutils'
 require 'pathname'
 require 'pp'
-require 'rubygems/package'
+require_relative 'package'
 require 'shellwords'
 require 'tmpdir'
 require 'uri'
 require 'zlib'
 require 'benchmark' # stdlib
-require 'rubygems/mock_gem_ui'
+require_relative 'mock_gem_ui'
 
 module Gem
 
@@ -569,7 +569,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
   # Builds and installs the Gem::Specification +spec+
 
   def install_gem spec, options = {}
-    require 'rubygems/installer'
+    require_relative 'installer'
 
     gem = File.join @tempdir, "gems", "#{spec.full_name}.gem"
 
@@ -596,7 +596,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
   ##
   # Uninstalls the Gem::Specification +spec+
   def uninstall_gem spec
-    require 'rubygems/uninstaller'
+    require_relative 'uninstaller'
 
     Class.new(Gem::Uninstaller) {
       def ask_if_ok spec
@@ -673,7 +673,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
   # Use this with #write_file to build an installed gem.
 
   def quick_gem(name, version='2')
-    require 'rubygems/specification'
+    require_relative 'specification'
 
     spec = Gem::Specification.new do |s|
       s.platform    = Gem::Platform::RUBY
@@ -809,7 +809,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
   # TODO:  remove in RubyGems 4.0
 
   def new_spec name, version, deps = nil, *files # :nodoc:
-    require 'rubygems/specification'
+    require_relative 'specification'
 
     spec = Gem::Specification.new do |s|
       s.platform    = Gem::Platform::RUBY
@@ -1068,7 +1068,7 @@ Also, a list:
   def util_setup_fake_fetcher(prerelease = false)
     require 'zlib'
     require 'socket'
-    require 'rubygems/remote_fetcher'
+    require_relative 'remote_fetcher'
 
     @fetcher = Gem::FakeFetcher.new
 
@@ -1578,7 +1578,7 @@ begin
   gem 'rdoc'
   require 'rdoc'
 
-  require 'rubygems/rdoc'
+  require_relative 'rdoc'
 rescue LoadError, Gem::LoadError
 end
 
@@ -1588,7 +1588,7 @@ begin
 rescue LoadError, Gem::LoadError
 end
 
-require 'rubygems/test_utilities'
+require_relative 'test_utilities'
 tmpdirs = []
 tmpdirs << (ENV['GEM_HOME'] = Dir.mktmpdir("home"))
 tmpdirs << (ENV['GEM_PATH'] = Dir.mktmpdir("path"))

--- a/lib/rubygems/test_utilities.rb
+++ b/lib/rubygems/test_utilities.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'tempfile'
 require 'rubygems'
-require 'rubygems/remote_fetcher'
+require_relative 'remote_fetcher'
 
 ##
 # A fake Gem::RemoteFetcher for use in tests or to avoid real live HTTP
@@ -305,7 +305,7 @@ class Gem::TestCase::SpecFetcherSetup
   def setup_fetcher # :nodoc:
     require 'zlib'
     require 'socket'
-    require 'rubygems/remote_fetcher'
+    require_relative 'remote_fetcher'
 
     unless @test.fetcher then
       @test.fetcher = Gem::FakeFetcher.new

--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -7,9 +7,9 @@
 
 require 'fileutils'
 require 'rubygems'
-require 'rubygems/dependency_list'
-require 'rubygems/rdoc'
-require 'rubygems/user_interaction'
+require_relative 'dependency_list'
+require_relative 'rdoc'
+require_relative 'user_interaction'
 
 ##
 # An Uninstaller.
@@ -337,7 +337,7 @@ class Gem::Uninstaller
     # of what it did for us to find rather than trying to recreate
     # it again.
     if @format_executable then
-      require 'rubygems/installer'
+      require_relative 'installer'
       Gem::Installer.exec_format % File.basename(filename)
     else
       filename

--- a/lib/rubygems/user_interaction.rb
+++ b/lib/rubygems/user_interaction.rb
@@ -5,8 +5,8 @@
 # See LICENSE.txt for permissions.
 #++
 
-require 'rubygems/util'
-require 'rubygems/deprecate'
+require_relative 'util'
+require_relative 'deprecate'
 
 ##
 # Module that defines the default UserInteraction.  Any class including this

--- a/lib/rubygems/util/licenses.rb
+++ b/lib/rubygems/util/licenses.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rubygems/text'
+require_relative '../text'
 
 class Gem::Licenses
   extend Gem::Text

--- a/lib/rubygems/validator.rb
+++ b/lib/rubygems/validator.rb
@@ -5,8 +5,8 @@
 # See LICENSE.txt for permissions.
 #++
 
-require 'rubygems/package'
-require 'rubygems/installer'
+require_relative 'package'
+require_relative 'installer'
 
 ##
 # Validator performs various gem file and gem database validation


### PR DESCRIPTION
There are over 300 calls to `require` that could be more efficient with `require_relative`. If I'm not mistaken, current `rubygems` supports only Ruby 2.2+, so this is a free speed gain.
