### PR TITLE
Fix bundler rubygems binstub not properly looking for bundler

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -269,12 +269,7 @@ module Gem
 
     return loaded if loaded && dep.matches_spec?(loaded)
 
-    find_specs = proc { dep.matching_specs(true) }
-    if dep.to_s == "bundler (>= 0.a)"
-      specs = Gem::BundlerVersionFinder.without_filtering(&find_specs)
-    else
-      specs = find_specs.call
-    end
+    specs = dep.matching_specs(true)
 
     specs = specs.find_all { |spec|
       spec.executables.include? exec_name

--- a/lib/rubygems/bundler_version_finder.rb
+++ b/lib/rubygems/bundler_version_finder.rb
@@ -29,7 +29,7 @@ module Gem::BundlerVersionFinder
     return unless vr = bundler_version_with_reason
     <<-EOS
 Could not find 'bundler' (#{vr.first}) required by #{vr.last}.
-To update to the lastest version installed on your system, run `bundle update --bundler`.
+To update to the latest version installed on your system, run `bundle update --bundler`.
 To install the missing version, run `gem install bundler:#{vr.first}`
     EOS
   end

--- a/lib/rubygems/bundler_version_finder.rb
+++ b/lib/rubygems/bundler_version_finder.rb
@@ -3,15 +3,6 @@
 require "rubygems/util"
 
 module Gem::BundlerVersionFinder
-  @without_filtering = false
-
-  def self.without_filtering
-    without_filtering, @without_filtering = true, @without_filtering
-    yield
-  ensure
-    @without_filtering = without_filtering
-  end
-
   def self.bundler_version
     version, _ = bundler_version_with_reason
 
@@ -21,8 +12,6 @@ module Gem::BundlerVersionFinder
   end
 
   def self.bundler_version_with_reason
-    return if @without_filtering
-
     if v = ENV["BUNDLER_VERSION"]
       return [v, "`$BUNDLER_VERSION`"]
     end

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -308,7 +308,7 @@ class TestGem < Gem::TestCase
     end
 
     assert_includes e.message, "Could not find 'bundler' (9999) required by your #{File.expand_path("Gemfile.lock")}."
-    assert_includes e.message, "To update to the lastest version installed on your system, run `bundle update --bundler`."
+    assert_includes e.message, "To update to the latest version installed on your system, run `bundle update --bundler`."
     assert_includes e.message, "To install the missing version, run `gem install bundler:9999`"
     refute_includes e.message, "can't find gem bundler (>= 0.a) with executable bundle"
   end

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -278,6 +278,41 @@ class TestGem < Gem::TestCase
     assert_equal %w(a-1 b-2 c-1), loaded_spec_names
   end
 
+  def test_activate_bin_path_gives_proper_error_for_bundler
+    bundler = util_spec 'bundler', '2' do |s|
+      s.executables = ['bundle']
+    end
+
+    install_specs bundler
+
+    File.open("Gemfile.lock", "w") do |f|
+      f.write <<-L.gsub(/ {8}/, "")
+        GEM
+          remote: https://rubygems.org/
+          specs:
+
+        PLATFORMS
+          ruby
+
+        DEPENDENCIES
+
+        BUNDLED WITH
+          9999
+      L
+    end
+
+    File.open("Gemfile", "w") { |f| f.puts('source "https://rubygems.org"') }
+
+    e = assert_raises Gem::GemNotFoundException do
+      load Gem.activate_bin_path("bundler", "bundle", ">= 0.a")
+    end
+
+    assert_includes e.message, "Could not find 'bundler' (9999) required by your #{File.expand_path("Gemfile.lock")}."
+    assert_includes e.message, "To update to the lastest version installed on your system, run `bundle update --bundler`."
+    assert_includes e.message, "To install the missing version, run `gem install bundler:9999`"
+    refute_includes e.message, "can't find gem bundler (>= 0.a) with executable bundle"
+  end
+
   def test_self_bin_path_no_exec_name
     e = assert_raises ArgumentError do
       Gem.bin_path 'a'

--- a/test/rubygems/test_gem_dependency.rb
+++ b/test/rubygems/test_gem_dependency.rb
@@ -358,7 +358,7 @@ class TestGemDependency < Gem::TestCase
         dep.to_specs
       end
 
-      assert_match "Could not find 'bundler' (3.5) required by reason.\nTo update to the lastest version installed on your system, run `bundle update --bundler`.\nTo install the missing version, run `gem install bundler:3.5`\n", e.message
+      assert_match "Could not find 'bundler' (3.5) required by reason.\nTo update to the latest version installed on your system, run `bundle update --bundler`.\nTo install the missing version, run `gem install bundler:3.5`\n", e.message
     end
 
     Gem::BundlerVersionFinder.stub(:bundler_version_with_reason, ["2.0.0.pre.1", "reason"]) do


### PR DESCRIPTION
# Description:

The problem is that when running a rubygems bundler binstub with a lock file locked to a non-installed bundler version, one would get the cryptic error message:

```
can't find gem bundler (>= 0.a) with executable bundle (Gem::GemNotFoundException)
```

where one tends to think... What? How is it not found if I just run it?!

Partially closes bundler/bundler#6595. Now the message is way more clear, but I guess it'd be better to actually run the command. Not sure if that's possible from a rubygems binstub, though.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] ~Write~ Delete code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
