### PR TITLE
Make sure rubygems never leaks to another installation

### DIFF
--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -168,12 +168,8 @@ command to remove old versions.
     Dir.chdir update_dir do
       say "Installing RubyGems #{version}"
 
-      # Make sure old rubygems isn't loaded
-      old = ENV["RUBYOPT"]
-      ENV.delete("RUBYOPT") if old
-      installed = system Gem.ruby, 'setup.rb', *args
+      installed = system Gem.ruby, '--disable-gems', 'setup.rb', *args
       say "RubyGems system software updated" if installed
-      ENV["RUBYOPT"] = old if old
     end
   end
 

--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -38,7 +38,7 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
       destdir = ENV["DESTDIR"]
 
       begin
-        cmd = [Gem.ruby, "-r", get_relative_path(siteconf.path), File.basename(extension), *args].join ' '
+        cmd = [Gem.ruby, "-I", File.expand_path("../../..", __FILE__), "-r", get_relative_path(siteconf.path), File.basename(extension), *args].join ' '
 
         begin
           run cmd, results

--- a/test/rubygems/test_gem_util.rb
+++ b/test/rubygems/test_gem_util.rb
@@ -6,7 +6,7 @@ class TestGemUtil < Gem::TestCase
 
   def test_class_popen
     skip "MJIT executes process and it's caught by Process.wait(-1)" if defined?(RubyVM::MJIT) && RubyVM::MJIT.enabled?
-    assert_equal "0\n", Gem::Util.popen(Gem.ruby, '-e', 'p 0')
+    assert_equal "0\n", Gem::Util.popen(Gem.ruby, '-I', File.expand_path('../../../lib', __FILE__), '-e', 'p 0')
 
     assert_raises Errno::ECHILD do
       Process.wait(-1)
@@ -15,7 +15,7 @@ class TestGemUtil < Gem::TestCase
 
   def test_silent_system
     assert_silent do
-      Gem::Util.silent_system Gem.ruby, '-e', 'puts "hello"; warn "hello"'
+      Gem::Util.silent_system Gem.ruby, '-I', File.expand_path('../../../lib', __FILE__), '-e', 'puts "hello"; warn "hello"'
     end
   end
 


### PR DESCRIPTION
# Description:

So... Today I was debugging some rubygems weirdness, and I started filling my rubygems installation with debugging puts all around. Later in the day, I went to my rubygems development copy, I run the tests... and I got all those prints all around in the middle of the tests. I don't think we ever want rubygems to ever "leak" to another copy of "rubygems". These changes should fix that, at least all the debugging prints went away. Hopefully I'm not doing anything really bad here.
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
