### PR TITLE
Restrict special chars from prefixing new gem names

### DIFF
--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -4,6 +4,8 @@ require 'uri'
 class Gem::SpecificationPolicy < SimpleDelegator
   VALID_NAME_PATTERN = /\A[a-zA-Z0-9\.\-\_]+\z/ # :nodoc:
 
+  SPECIAL_CHARACTERS = /\A[#{Regexp.escape('.-_')}]+/ # :nodoc:
+
   VALID_URI_PATTERN = %r{\Ahttps?:\/\/([^\s:@]+:[^\s:@]*@)?[A-Za-z\d\-]+(\.[A-Za-z\d\-]+)+\.?(:\d{1,5})?([\/?]\S*)?\z}  # :nodoc:
 
   METADATA_LINK_KEYS = %w[
@@ -225,6 +227,8 @@ open-ended dependency on #{dep} is not recommended
       error "invalid value for attribute name: #{name.dump} must include at least one letter"
     elsif name !~ VALID_NAME_PATTERN then
       error "invalid value for attribute name: #{name.dump} can only include letters, numbers, dashes, and underscores"
+    elsif name =~ SPECIAL_CHARACTERS
+      error "invalid value for attribute name: #{name.dump} can not begin with a period, dash, or underscore"
     end
   end
 

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -221,11 +221,11 @@ open-ended dependency on #{dep} is not recommended
   end
 
   def validate_name
-    if !name.is_a?(String) then
+    if !name.is_a?(String)
       error "invalid value for attribute name: \"#{name.inspect}\" must be a string"
-    elsif name !~ /[a-zA-Z]/ then
+    elsif name !~ /[a-zA-Z]/
       error "invalid value for attribute name: #{name.dump} must include at least one letter"
-    elsif name !~ VALID_NAME_PATTERN then
+    elsif name !~ VALID_NAME_PATTERN
       error "invalid value for attribute name: #{name.dump} can only include letters, numbers, dashes, and underscores"
     elsif name =~ SPECIAL_CHARACTERS
       error "invalid value for attribute name: #{name.dump} can not begin with a period, dash, or underscore"

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -56,6 +56,32 @@ class TestGemCommandsBuildCommand < Gem::TestCase
     util_test_build_gem @gem
   end
 
+  def test_execute_bad_name
+    [".", "-", "_"].each do |special_char|
+      gem = util_spec 'some_gem_with_bad_name' do |s|
+        s.name = "#{special_char}bad_gem_name"
+        s.license = 'AGPL-3.0'
+        s.files = ['README.md']
+      end
+
+      gemspec_file = File.join(@tempdir, gem.spec_name)
+
+      File.open gemspec_file, 'w' do |gs|
+        gs.write gem.to_ruby
+      end
+
+      @cmd.options[:args] = [gemspec_file]
+
+      use_ui @ui do
+        Dir.chdir @tempdir do
+          assert_raises Gem::InvalidSpecificationException do
+            @cmd.execute
+          end
+        end
+      end
+    end
+  end
+
   def test_execute_strict_without_warnings
     gemspec_file = File.join(@tempdir, @gem.spec_name)
 


### PR DESCRIPTION
# Description:
closes https://github.com/rubygems/rubygems/issues/2430

A user should not be able to create a gem with a `.`, `-` or `_` as a prefix in a gem name
______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
