### PR TITLE
This removes support for dynamic API backend lookup via DNS SRV records

### DIFF
--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -74,7 +74,7 @@ class Gem::RemoteFetcher
   # +headers+: A set of additional HTTP headers to be sent to the server when
   #            fetching the gem.
 
-  def initialize(proxy=nil, headers={})
+  def initialize(proxy=nil, dns=nil, headers={})
     require 'net/http'
     require 'stringio'
     require 'time'

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -71,13 +71,10 @@ class Gem::RemoteFetcher
   #        HTTP_PROXY_PASS)
   # * <tt>:no_proxy</tt>: ignore environment variables and _don't_ use a proxy
   #
-  # +dns+: An object to use for DNS resolution of the API endpoint.
-  #        By default, use Resolv::DNS.
-  #
   # +headers+: A set of additional HTTP headers to be sent to the server when
   #            fetching the gem.
 
-  def initialize(proxy=nil, dns=Resolv::DNS.new, headers={})
+  def initialize(proxy=nil, headers={})
     require 'net/http'
     require 'stringio'
     require 'time'
@@ -90,32 +87,7 @@ class Gem::RemoteFetcher
     @pool_lock = Mutex.new
     @cert_files = Gem::Request.get_cert_files
 
-    @dns = dns
     @headers = headers
-  end
-
-  ##
-  # Given a source at +uri+, calculate what hostname to actually
-  # connect to query the data for it.
-
-  def api_endpoint(uri)
-    host = uri.host
-
-    begin
-      res = @dns.getresource "_rubygems._tcp.#{host}",
-                             Resolv::DNS::Resource::IN::SRV
-    rescue Resolv::ResolvError => e
-      verbose "Getting SRV record failed: #{e}"
-      uri
-    else
-      target = res.target.to_s.strip
-
-      if URI("http://" + target).host.end_with?(".#{host}")
-        return URI.parse "#{uri.scheme}://#{target}#{uri.path}"
-      end
-
-      uri
-    end
   end
 
   ##

--- a/lib/rubygems/source.rb
+++ b/lib/rubygems/source.rb
@@ -36,15 +36,6 @@ class Gem::Source
     end
 
     @uri = uri
-    @api_uri = nil
-  end
-
-  ##
-  # Use an SRV record on the host to look up the true endpoint for the index.
-
-  def api_uri # :nodoc:
-    require 'rubygems/remote_fetcher'
-    @api_uri ||= Gem::RemoteFetcher.fetcher.api_endpoint uri
   end
 
   ##
@@ -87,9 +78,9 @@ class Gem::Source
   # Returns a Set that can fetch specifications from this source.
 
   def dependency_resolver_set # :nodoc:
-    return Gem::Resolver::IndexSet.new self if 'file' == api_uri.scheme
+    return Gem::Resolver::IndexSet.new self if 'file' == uri.scheme
 
-    bundler_api_uri = api_uri + './api/v1/dependencies'
+    bundler_api_uri = uri + './api/v1/dependencies'
 
     begin
       fetcher = Gem::RemoteFetcher.fetcher
@@ -140,9 +131,9 @@ class Gem::Source
 
     spec_file_name = name_tuple.spec_name
 
-    uri = api_uri + "#{Gem::MARSHAL_SPEC_DIR}#{spec_file_name}"
+    source_uri = uri + "#{Gem::MARSHAL_SPEC_DIR}#{spec_file_name}"
 
-    cache_dir = cache_dir uri
+    cache_dir = cache_dir source_uri
 
     local_spec = File.join cache_dir, spec_file_name
 
@@ -152,9 +143,9 @@ class Gem::Source
       return spec if spec
     end
 
-    uri.path << '.rz'
+    source_uri.path << '.rz'
 
-    spec = fetcher.fetch_path uri
+    spec = fetcher.fetch_path source_uri
     spec = Gem::Util.inflate spec
 
     if update_cache? then
@@ -184,7 +175,7 @@ class Gem::Source
     file       = FILES[type]
     fetcher    = Gem::RemoteFetcher.fetcher
     file_name  = "#{file}.#{Gem.marshal_version}"
-    spec_path  = api_uri + "#{file_name}.gz"
+    spec_path  = uri + "#{file_name}.gz"
     cache_dir  = cache_dir spec_path
     local_file = File.join(cache_dir, file_name)
     retried    = false
@@ -212,7 +203,7 @@ class Gem::Source
 
   def download(spec, dir=Dir.pwd)
     fetcher = Gem::RemoteFetcher.fetcher
-    fetcher.download spec, api_uri.to_s, dir
+    fetcher.download spec, uri.to_s, dir
   end
 
   def pretty_print q # :nodoc:
@@ -220,7 +211,7 @@ class Gem::Source
       q.breakable
       q.text @uri.to_s
 
-      if api = api_uri
+      if api = uri
         q.breakable
         q.text 'API URI: '
         q.text api.to_s

--- a/lib/rubygems/test_utilities.rb
+++ b/lib/rubygems/test_utilities.rb
@@ -25,17 +25,11 @@ class Gem::FakeFetcher
 
   attr_reader :data
   attr_reader :last_request
-  attr_reader :api_endpoints
   attr_accessor :paths
 
   def initialize
     @data = {}
     @paths = []
-    @api_endpoints = {}
-  end
-
-  def api_endpoint(uri)
-    @api_endpoints[uri] || uri
   end
 
   def find_data(path)
@@ -111,14 +105,6 @@ class Gem::FakeFetcher
 
       q.breakable
       q.pp @data.keys
-
-      unless @api_endpoints.empty? then
-        q.breakable
-        q.text 'API endpoints:'
-
-        q.breakable
-        q.pp @api_endpoints.keys
-      end
     end
   end
 

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -626,7 +626,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
   def test_fetch_http_with_additional_headers
     ENV["http_proxy"] = @proxy_uri
     ENV["no_proxy"] = URI::parse(@server_uri).host
-    fetcher = Gem::RemoteFetcher.new nil, {"X-Captain" => "murphy"}
+    fetcher = Gem::RemoteFetcher.new nil, nil, {"X-Captain" => "murphy"}
     @fetcher = fetcher
     assert_equal "murphy", fetcher.fetch_path(@server_uri)
   end

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -185,106 +185,6 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     end
   end
 
-  def test_api_endpoint
-    uri = URI.parse "http://example.com/foo"
-    target = MiniTest::Mock.new
-    target.expect :target, "gems.example.com"
-
-    dns = MiniTest::Mock.new
-    dns.expect :getresource, target, [String, Object]
-
-    fetch = Gem::RemoteFetcher.new nil, dns
-    assert_equal URI.parse("http://gems.example.com/foo"), fetch.api_endpoint(uri)
-
-    target.verify
-    dns.verify
-  end
-
-  def test_api_endpoint_ignores_trans_domain_values
-    uri = URI.parse "http://gems.example.com/foo"
-    target = MiniTest::Mock.new
-    target.expect :target, "blah.com"
-
-    dns = MiniTest::Mock.new
-    dns.expect :getresource, target, [String, Object]
-
-    fetch = Gem::RemoteFetcher.new nil, dns
-    assert_equal URI.parse("http://gems.example.com/foo"), fetch.api_endpoint(uri)
-
-    target.verify
-    dns.verify
-  end
-
-  def test_api_endpoint_ignores_trans_domain_values_that_starts_with_original
-    uri = URI.parse "http://example.com/foo"
-    target = MiniTest::Mock.new
-    target.expect :target, "example.combadguy.com"
-
-    dns = MiniTest::Mock.new
-    dns.expect :getresource, target, [String, Object]
-
-    fetch = Gem::RemoteFetcher.new nil, dns
-    assert_equal URI.parse("http://example.com/foo"), fetch.api_endpoint(uri)
-
-    target.verify
-    dns.verify
-  end
-
-  def test_api_endpoint_ignores_trans_domain_values_that_end_with_original
-    uri = URI.parse "http://example.com/foo"
-    target = MiniTest::Mock.new
-    target.expect :target, "badexample.com"
-
-    dns = MiniTest::Mock.new
-    dns.expect :getresource, target, [String, Object]
-
-    fetch = Gem::RemoteFetcher.new nil, dns
-    assert_equal URI.parse("http://example.com/foo"), fetch.api_endpoint(uri)
-
-    target.verify
-    dns.verify
-  end
-
-  def test_api_endpoint_ignores_trans_domain_values_that_end_with_original_in_path
-    uri = URI.parse "http://example.com/foo"
-    target = MiniTest::Mock.new
-    target.expect :target, "evil.com/a.example.com"
-
-    dns = MiniTest::Mock.new
-    dns.expect :getresource, target, [String, Object]
-
-    fetch = Gem::RemoteFetcher.new nil, dns
-    assert_equal URI.parse("http://example.com/foo"), fetch.api_endpoint(uri)
-
-    target.verify
-    dns.verify
-  end
-
-  def test_api_endpoint_timeout_warning
-    uri = URI.parse "http://gems.example.com/foo"
-
-    dns = MiniTest::Mock.new
-    def dns.getresource arg, *rest
-      raise Resolv::ResolvError.new('timeout!')
-    end
-
-    fetch = Gem::RemoteFetcher.new nil, dns
-    begin
-      old_verbose, Gem.configuration.verbose = Gem.configuration.verbose, 1
-      endpoint = use_ui @stub_ui do
-        fetch.api_endpoint(uri)
-      end
-    ensure
-      Gem.configuration.verbose = old_verbose
-    end
-
-    assert_equal uri, endpoint
-
-    assert_equal "Getting SRV record failed: timeout!\n", @stub_ui.output
-
-    dns.verify
-  end
-
   def test_cache_update_path
     uri = URI 'http://example/file'
     path = File.join @tempdir, 'file'
@@ -726,7 +626,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
   def test_fetch_http_with_additional_headers
     ENV["http_proxy"] = @proxy_uri
     ENV["no_proxy"] = URI::parse(@server_uri).host
-    fetcher = Gem::RemoteFetcher.new nil, nil, {"X-Captain" => "murphy"}
+    fetcher = Gem::RemoteFetcher.new nil, {"X-Captain" => "murphy"}
     @fetcher = fetcher
     assert_equal "murphy", fetcher.fetch_path(@server_uri)
   end

--- a/test/rubygems/test_gem_source.rb
+++ b/test/rubygems/test_gem_source.rb
@@ -36,18 +36,6 @@ class TestGemSource < Gem::TestCase
     assert_equal repository, source.uri
   end
 
-  def test_api_uri
-    assert_equal @source.api_uri, @source.uri
-  end
-
-  def test_api_uri_resolved_from_remote_fetcher
-    uri = URI.parse "http://gem.example/foo"
-    @fetcher.api_endpoints[uri] = URI.parse "http://api.blah"
-
-    src = Gem::Source.new uri
-    assert_equal URI.parse("http://api.blah"), src.api_uri
-  end
-
   def test_cache_dir_escapes_windows_paths
     uri = URI.parse("file:///C:/WINDOWS/Temp/gem_repo")
     root = Gem.spec_cache_dir


### PR DESCRIPTION
Per issue #2418, the DNS SRV record functionality was a headache to maintain because of security concerns and become moot since everything is fetched from rubygems.org.

# Description:
- Remove support for dynamic API backend lookup via DNS SRV records
- Remove related code in RemoteFetcher and Source
- Update broken link in CONTRIBUTING.md
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Remove tests
- [x] Remove code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

I went ahead and aggressively removed parts that seemed unnecessary now that the functionality is being removed. Let me know if I was *too* aggressive and should pare back a bit.
