### PR TITLE
Remove rubyforge_page functionality

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -156,7 +156,6 @@ class Gem::Specification < Gem::BasicSpecification
     :required_ruby_version     => Gem::Requirement.default,
     :required_rubygems_version => Gem::Requirement.default,
     :requirements              => [],
-    :rubyforge_project         => nil,
     :rubygems_version          => Gem::VERSION,
     :signing_key               => nil,
     :specification_version     => CURRENT_SPECIFICATION_VERSION,
@@ -730,14 +729,6 @@ class Gem::Specification < Gem::BasicSpecification
   # Allows deinstallation of gems with legacy platforms.
 
   attr_writer :original_platform # :nodoc:
-
-  ##
-  # The rubyforge project this gem lives under.  i.e. RubyGems'
-  # rubyforge_project is "rubygems".
-  #
-  # This option is deprecated.
-
-  attr_accessor :rubyforge_project
 
   ##
   # The Gem::Specification version of this gemspec.
@@ -1349,16 +1340,15 @@ class Gem::Specification < Gem::BasicSpecification
     spec.instance_variable_set :@required_rubygems_version, array[7]
     spec.instance_variable_set :@original_platform,         array[8]
     spec.instance_variable_set :@dependencies,              array[9]
-    spec.instance_variable_set :@rubyforge_project,         array[10]
-    spec.instance_variable_set :@email,                     array[11]
-    spec.instance_variable_set :@authors,                   array[12]
-    spec.instance_variable_set :@description,               array[13]
-    spec.instance_variable_set :@homepage,                  array[14]
-    spec.instance_variable_set :@has_rdoc,                  array[15]
-    spec.instance_variable_set :@new_platform,              array[16]
-    spec.instance_variable_set :@platform,                  array[16].to_s
-    spec.instance_variable_set :@license,                   array[17]
-    spec.instance_variable_set :@metadata,                  array[18]
+    spec.instance_variable_set :@email,                     array[10]
+    spec.instance_variable_set :@authors,                   array[11]
+    spec.instance_variable_set :@description,               array[12]
+    spec.instance_variable_set :@homepage,                  array[13]
+    spec.instance_variable_set :@has_rdoc,                  array[14]
+    spec.instance_variable_set :@new_platform,              array[15]
+    spec.instance_variable_set :@platform,                  array[15].to_s
+    spec.instance_variable_set :@license,                   array[16]
+    spec.instance_variable_set :@metadata,                  array[17]
     spec.instance_variable_set :@loaded,                    false
     spec.instance_variable_set :@activated,                 false
 
@@ -1394,7 +1384,6 @@ class Gem::Specification < Gem::BasicSpecification
       @required_rubygems_version,
       @original_platform,
       @dependencies,
-      @rubyforge_project,
       @email,
       @authors,
       @description,

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -730,8 +730,17 @@ class Gem::Specification < Gem::BasicSpecification
 
   attr_writer :original_platform # :nodoc
 
-  attr_writer :rubyforge_project # :nodoc
-  deprecate :rubyforge_project, :none, 2020, 4
+  ##
+  # Deprecated and ignored.
+  #
+  # Formerly used to set rubyforge project.
+
+  def rubyforge_project= ignored # :nodoc:
+  end
+  deprecate :rubyforge_project=,           :none,       2020, 12
+
+  alias :rubyforge_project # :nodoc:
+  deprecate :rubyforge_project,           :none,       2020, 12
 
   ##
   # The Gem::Specification version of this gemspec.

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -736,7 +736,6 @@ class Gem::Specification < Gem::BasicSpecification
   # Formerly used to set rubyforge project.
 
   attr_writer :rubyforge_project
-  deprecate :rubyforge_project=, :none,        2020, 12
 
   ##
   # The Gem::Specification version of this gemspec.
@@ -1348,15 +1347,16 @@ class Gem::Specification < Gem::BasicSpecification
     spec.instance_variable_set :@required_rubygems_version, array[7]
     spec.instance_variable_set :@original_platform,         array[8]
     spec.instance_variable_set :@dependencies,              array[9]
-    spec.instance_variable_set :@email,                     array[10]
-    spec.instance_variable_set :@authors,                   array[11]
-    spec.instance_variable_set :@description,               array[12]
-    spec.instance_variable_set :@homepage,                  array[13]
-    spec.instance_variable_set :@has_rdoc,                  array[14]
-    spec.instance_variable_set :@new_platform,              array[15]
-    spec.instance_variable_set :@platform,                  array[15].to_s
-    spec.instance_variable_set :@license,                   array[16]
-    spec.instance_variable_set :@metadata,                  array[17]
+    # offset due to rubyforge_project removal
+    spec.instance_variable_set :@email,                     array[11]
+    spec.instance_variable_set :@authors,                   array[12]
+    spec.instance_variable_set :@description,               array[13]
+    spec.instance_variable_set :@homepage,                  array[14]
+    spec.instance_variable_set :@has_rdoc,                  array[15]
+    spec.instance_variable_set :@new_platform,              array[16]
+    spec.instance_variable_set :@platform,                  array[16].to_s
+    spec.instance_variable_set :@license,                   array[17]
+    spec.instance_variable_set :@metadata,                  array[18]
     spec.instance_variable_set :@loaded,                    false
     spec.instance_variable_set :@activated,                 false
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -735,12 +735,8 @@ class Gem::Specification < Gem::BasicSpecification
   #
   # Formerly used to set rubyforge project.
 
-  def rubyforge_project= ignored # :nodoc:
-  end
-  deprecate :rubyforge_project=,           :none,       2020, 12
-
-  alias :rubyforge_project # :nodoc:
-  deprecate :rubyforge_project,           :none,       2020, 12
+  attr_writer :rubyforge_project
+  deprecate :rubyforge_project=, :none,        2020, 12
 
   ##
   # The Gem::Specification version of this gemspec.

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -728,7 +728,7 @@ class Gem::Specification < Gem::BasicSpecification
   ##
   # Allows deinstallation of gems with legacy platforms.
 
-  attr_writer :original_platform # :nodoc
+  attr_writer :original_platform # :nodoc:
 
   ##
   # Deprecated and ignored.

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1392,6 +1392,7 @@ class Gem::Specification < Gem::BasicSpecification
       @required_rubygems_version,
       @original_platform,
       @dependencies,
+      '', # rubyforge_project
       @email,
       @authors,
       @description,

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -22,7 +22,6 @@ class TestGemCommandsBuildCommand < Gem::TestCase
     end
 
     @gem = util_spec 'some_gem' do |s|
-      s.rubyforge_project = 'example'
       s.license = 'AGPL-3.0'
       s.files = ['README.md']
     end
@@ -97,7 +96,6 @@ class TestGemCommandsBuildCommand < Gem::TestCase
 
   def test_execute_strict_with_warnings
     bad_gem = util_spec 'some_bad_gem' do |s|
-      s.rubyforge_project = 'example'
       s.files = ['README.md']
     end
 

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -51,7 +51,6 @@ gems:
     author: Jim Weirich
     email: jim@weirichhouse.org
     homepage: http://rake.rubyforge.org
-    rubyforge_project: rake
     description: Rake is a Make-like program implemented in Ruby. Tasks and dependencies are specified in standard Ruby syntax.
     autorequire:
     default_executable: rake

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1206,6 +1206,14 @@ dependencies: []
 
   DATA_PATH = File.expand_path "../data", __FILE__
 
+  def test_handles_private_null_type
+    path = File.join DATA_PATH, "null-type.gemspec.rz"
+
+    data = Marshal.load Gem::Util.inflate(Gem.read_binary(path))
+
+    assert_nil data.description
+  end
+
   def test_initialize
     spec = Gem::Specification.new do |s|
       s.name = "blah"

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -48,7 +48,6 @@ end
       s.extensions << 'ext/a/extconf.rb'
       s.test_file = 'test/suite.rb'
       s.requirements << 'A working computer'
-      s.rubyforge_project = 'example'
       s.license = 'MIT'
 
       s.add_dependency 'rake', '> 0.4'
@@ -80,7 +79,6 @@ end
       s.executable = 'exec'
       s.test_file = 'test/suite.rb'
       s.requirements << 'A working computer'
-      s.rubyforge_project = 'example'
       s.license = 'MIT'
 
       s.mark_version
@@ -701,7 +699,6 @@ end
       required_ruby_version
       required_rubygems_version
       requirements
-      rubyforge_project
       rubygems_version
       signing_key
       specification_version
@@ -871,7 +868,6 @@ require_paths:
 author: Austin Ziegler
 email: diff-lcs@halostatue.ca
 homepage: http://rubyforge.org/projects/ruwiki/
-rubyforge_project: ruwiki
 description: "Test"
 bindir: bin
 has_rdoc: true
@@ -1209,14 +1205,6 @@ dependencies: []
   end
 
   DATA_PATH = File.expand_path "../data", __FILE__
-
-  def test_handles_private_null_type
-    path = File.join DATA_PATH, "null-type.gemspec.rz"
-
-    data = Marshal.load Gem::Util.inflate(Gem.read_binary(path))
-
-    assert_nil data.rubyforge_project
-  end
 
   def test_initialize
     spec = Gem::Specification.new do |s|
@@ -2496,7 +2484,6 @@ Gem::Specification.new do |s|
   s.homepage = "http://example.com".freeze
   s.licenses = ["MIT".freeze]
   s.requirements = ["A working computer".freeze]
-  s.rubyforge_project = "example".freeze
   s.rubygems_version = "#{Gem::VERSION}".freeze
   s.summary = "this is a summary".freeze
   s.test_files = ["test/suite.rb".freeze]

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1211,7 +1211,7 @@ dependencies: []
 
     data = Marshal.load Gem::Util.inflate(Gem.read_binary(path))
 
-    assert_nil data.description
+    assert_nil data.default_executable
   end
 
   def test_initialize


### PR DESCRIPTION
# Description:

Type: Cleanup

RubyForge was [sunsetted in 2013](https://twitter.com/evanphx/status/399552820380053505) . There are still mentions of it in the code base. For this PR, instead of looking for dead links I aimed to clear out the `rubyforge_project` attr_accessor from the rubygems specification and the places that reference it. 

Perhaps there could be a conversation here whether something could 'replace', `rubyforge_project` (`github_project`?) but to start here is the 'lite' approach that simply removes it. 

Looking forward to thoughts and feedback! :) 
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests __(n/a)__
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
