### PR TITLE
Drop ruby 1.8 support and use IO.popen

### DIFF
--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -74,6 +74,8 @@ class Gem::Ext::Builder
         results << (command.respond_to?(:shelljoin) ? command.shelljoin : command)
         results << IO.popen(command, "r", err: [:child, :out], &:read)
       end
+    rescue => error
+      raise Gem::InstallError, "#{command_name || class_name} failed#{error.message}"
     ensure
       ENV['RUBYGEMS_GEMDEPS'] = rubygems_gemdeps
     end

--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -56,6 +56,7 @@ class Gem::Ext::Builder
   end
 
   def self.redirector
+    warn "#{caller[0]}: Use IO.popen(..., err: [:child, :out])"
     '2>&1'
   end
 
@@ -63,7 +64,6 @@ class Gem::Ext::Builder
     verbose = Gem.configuration.really_verbose
 
     begin
-      # TODO use Process.spawn when ruby 1.8 support is dropped.
       rubygems_gemdeps, ENV['RUBYGEMS_GEMDEPS'] = ENV['RUBYGEMS_GEMDEPS'], nil
       if verbose
         puts("current directory: #{Dir.pwd}")
@@ -71,8 +71,8 @@ class Gem::Ext::Builder
         system(command)
       else
         results << "current directory: #{Dir.pwd}"
-        results << command
-        results << `#{command} #{redirector}`
+        results << (command.respond_to?(:shelljoin) ? command.shelljoin : command)
+        results << IO.popen(command, "r", err: [:child, :out], &:read)
       end
     ensure
       ENV['RUBYGEMS_GEMDEPS'] = rubygems_gemdeps

--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -7,6 +7,7 @@
 
 require 'fileutils'
 require 'tempfile'
+require 'shellwords'
 
 class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
   FileEntry = FileUtils::Entry_ # :nodoc:
@@ -38,7 +39,9 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
       destdir = ENV["DESTDIR"]
 
       begin
-        cmd = [Gem.ruby, "-I", File.expand_path("../../..", __FILE__), "-r", get_relative_path(siteconf.path), File.basename(extension), *args].join ' '
+        cmd = Gem.ruby.shellsplit << "-I" << File.expand_path("../../..", __FILE__) <<
+              "-r" << get_relative_path(siteconf.path) << File.basename(extension)
+        cmd.push(*args)
 
         begin
           run cmd, results

--- a/lib/rubygems/ext/rake_builder.rb
+++ b/lib/rubygems/ext/rake_builder.rb
@@ -11,22 +11,23 @@ class Gem::Ext::RakeBuilder < Gem::Ext::Builder
 
   def self.build(extension, dest_path, results, args=[], lib_dir=nil)
     if File.basename(extension) =~ /mkrf_conf/i then
-      cmd = "#{Gem.ruby} #{File.basename extension}".dup
-      cmd << " #{args.join " "}" unless args.empty?
-      run cmd, results
+      run([Gem.ruby, File.basename(extension), *args], results)
     end
 
     rake = ENV['rake']
 
-    rake ||= begin
-               "#{Gem.ruby} -rrubygems #{Gem.bin_path('rake', 'rake')}"
-             rescue Gem::Exception
-             end
-
-    rake ||= Gem.default_exec_format % 'rake'
+    if rake
+      rake = rake.shellsplit
+    else
+      begin
+        rake = [Gem.ruby, "-rrubygems", Gem.bin_path('rake', 'rake')]
+      rescue Gem::Exception
+        rake = [Gem.default_exec_format % 'rake']
+      end
+    end
 
     rake_args = ["RUBYARCHDIR=#{dest_path}", "RUBYLIBDIR=#{dest_path}", *args]
-    run "#{rake} #{rake_args.shelljoin}", results
+    run(rake + rake_args, results)
 
     results
   end

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -1319,9 +1319,26 @@ Also, a list:
     end
   end
 
+  class << self
+    # :nodoc:
+    ##
+    # Return the join path, with escaping backticks, dollars, and
+    # double-quotes.  Unlike `shellescape`, equal-sign is not escaped.
+    private
+    def escape_path(*path)
+      path = File.join(*path)
+      if %r'\A[-+:/=@,.\w]+\z' =~ path
+        path
+      else
+        "\"#{path.gsub(/[`$"]/, '\\&')}\""
+      end
+    end
+  end
+
   @@ruby = rubybin
-  @@good_rake = "#{rubybin} \"#{File.expand_path('../../../test/rubygems/good_rake.rb', __FILE__)}\""
-  @@bad_rake = "#{rubybin} \"#{File.expand_path('../../../test/rubygems/bad_rake.rb', __FILE__)}\""
+  gempath = File.expand_path('../../../test/rubygems', __FILE__)
+  @@good_rake = "#{rubybin} #{escape_path(gempath, 'good_rake.rb')}"
+  @@bad_rake = "#{rubybin} #{escape_path(gempath, 'bad_rake.rb')}"
 
   ##
   # Construct a new Gem::Dependency.

--- a/test/rubygems/test_config.rb
+++ b/test/rubygems/test_config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
 require 'rubygems'
+require 'shellwords'
 
 class TestConfig < Gem::TestCase
 
@@ -13,12 +14,16 @@ class TestConfig < Gem::TestCase
 
   def test_good_rake_path_is_escaped
     path = Gem::TestCase.class_eval('@@good_rake')
-    assert_match(/#{Gem.ruby} "[^"]*good_rake.rb"/, path)
+    ruby, rake = path.shellsplit
+    assert_equal(Gem.ruby, ruby)
+    assert_match(/\/good_rake.rb\z/, rake)
   end
 
   def test_bad_rake_path_is_escaped
     path = Gem::TestCase.class_eval('@@bad_rake')
-    assert_match(/#{Gem.ruby} "[^"]*bad_rake.rb"/, path)
+    ruby, rake = path.shellsplit
+    assert_equal(Gem.ruby, ruby)
+    assert_match(/\/bad_rake.rb\z/, rake)
   end
 
 end

--- a/test/rubygems/test_gem_ext_cmake_builder.rb
+++ b/test/rubygems/test_gem_ext_cmake_builder.rb
@@ -10,7 +10,7 @@ class TestGemExtCmakeBuilder < Gem::TestCase
     # Details: https://github.com/rubygems/rubygems/issues/1270#issuecomment-177368340
     skip "CmakeBuilder doesn't work on Windows." if Gem.win_platform?
 
-    `cmake #{Gem::Ext::Builder.redirector}`
+    system('cmake', out: IO::NULL, err: [:child, :out])
 
     skip 'cmake not present' unless $?.success?
 


### PR DESCRIPTION
IO.popen supports command line as an array since 1.9, as well as
system had done.  And both support redirection option since 1.9
too.  These prevents from excution by shell which could cause
unexpected expansions.

# Description:

______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
