### PR TITLE
Bug/kernel#warn uplevel

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1392,5 +1392,6 @@ Gem::Specification.load_defaults
 
 require 'rubygems/core_ext/kernel_gem'
 require 'rubygems/core_ext/kernel_require'
+require 'rubygems/core_ext/kernel_warn'
 
 Gem.use_gemdeps

--- a/lib/rubygems/core_ext/kernel_warn.rb
+++ b/lib/rubygems/core_ext/kernel_warn.rb
@@ -1,28 +1,45 @@
 # frozen_string_literal: true
 
+# `uplevel` keyword argument of Kernel#warn is available since ruby 2.5.
 if RUBY_VERSION >= "2.5"
+
   module Kernel
-    path = "#{__dir__}/"
+    path = "#{__dir__}/" # Frames to be skipped start with this path.
+
+    # Suppress "method redefined" warning
     original_warn = instance_method(:warn)
     Module.new {define_method(:warn, original_warn)}
+
     original_warn = method(:warn)
 
     module_function define_method(:warn) {|*messages, uplevel: nil|
-      if uplevel
-        uplevel, = [uplevel].pack("l!").unpack("l!")
-        if uplevel >= 0
-          start = 0
-          begin
-            loc, = caller_locations(start, 1)
-            break start += uplevel unless loc
-            start += 1
-          end while (loc.path.start_with?(path) or (uplevel -= 1) >= 0)
-          uplevel = start
-        end
-        original_warn.call(*messages, uplevel: uplevel)
-      else
-        original_warn.call(*messages)
+      unless uplevel
+        return original_warn.call(*messages)
       end
+
+      # Ensure `uplevel` fits a `long`
+      uplevel, = [uplevel].pack("l!").unpack("l!")
+
+      if uplevel >= 0
+        start = 0
+        while uplevel >= 0
+          loc, = caller_locations(start, 1)
+          unless loc
+            # No more backtrace
+            start += uplevel
+            break
+          end
+
+          start += 1
+
+          unless loc.path.start_with?(path)
+            # Non-rubygems frames
+            uplevel -= 1
+          end
+        end
+        uplevel = start
+      end
+      original_warn.call(*messages, uplevel: uplevel)
     }
   end
 end

--- a/lib/rubygems/core_ext/kernel_warn.rb
+++ b/lib/rubygems/core_ext/kernel_warn.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+if RUBY_VERSION >= "2.5"
+  module Kernel
+    path = "#{__dir__}/"
+    original_warn = instance_method(:warn)
+    Module.new {define_method(:warn, original_warn)}
+    original_warn = method(:warn)
+
+    module_function define_method(:warn) {|*messages, uplevel: nil|
+      if uplevel
+        uplevel, = [uplevel].pack("l!").unpack("l!")
+        if uplevel >= 0
+          start = 0
+          begin
+            loc, = caller_locations(start, 1)
+            break start += uplevel unless loc
+            start += 1
+          end while (loc.path.start_with?(path) or (uplevel -= 1) >= 0)
+          uplevel = start
+        end
+        original_warn.call(*messages, uplevel: uplevel)
+      else
+        original_warn.call(*messages)
+      end
+    }
+  end
+end


### PR DESCRIPTION
# Description:

With this script `w.rb`:
```ruby
require "Win32API"
```

The expected line is shown when rubygems is disabled.
```
$ ruby -w --disable=gems -I./lib -I./ext/win32/lib w.rb 
w.rb:1: warning: Win32API is deprecated after Ruby 1.9.1; use fiddle directly instead
```

But `kernel_require.rb` is shown when rubygems is enabled.
```
$ ruby -w --enable=gems -I./lib -I./ext/win32/lib w.rb 
/opt/local/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54: warning: Win32API is deprecated after Ruby 1.9.1; use fiddle directly instead
```

______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).