### PR TITLE
revisit more MJIT test skips

### DIFF
--- a/test/rubygems/test_gem_util.rb
+++ b/test/rubygems/test_gem_util.rb
@@ -5,7 +5,6 @@ require 'rubygems/util'
 class TestGemUtil < Gem::TestCase
 
   def test_class_popen
-    skip "MJIT executes process and it's caught by Process.wait(-1)" if defined?(RubyVM::MJIT) && RubyVM::MJIT.enabled?
     assert_equal "0\n", Gem::Util.popen(Gem.ruby, '-I', File.expand_path('../../../lib', __FILE__), '-e', 'p 0')
 
     assert_raises Errno::ECHILD do


### PR DESCRIPTION
The original commit was https://github.com/ruby/ruby/commit/e38a0b46067fd261a88be608787927ccdf5b7877

```
r65308 passed both trunk-mjit and trunk-mjit-wait CIs. MJIT copy job
looks working fine. Then this commit skips 5 more tests. Some of them
were skipped in a very early stage and may still need to be skipped, but
I want to confirm them since they haven't been changed for a long time.

And this prefers having inline information on `RubyVM::MJIT.enabled?`.
This commit makes it easier to confirm whether there's suspicious test
skip by RubyVM::MJIT.enabled? or not.

After this commit, tentatively we're not skipping tests for MJIT other
than `assert_no_memory_leak` ones.

git-svn-id: svn+ssh://ci.ruby-lang.org/ruby/trunk@65311 b2dd03c8-39d4-4d8f-98ff-823fe69b080e
```
