### PR TITLE
update gem install for better platform specific support, --explain, --ignore-dependencies

### DIFF
--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -205,7 +205,12 @@ You can use `i` command instead of `install`.
         puts "Gems to install:"
 
         request_set.sorted_requests.each do |s|
-          puts "  #{s.full_name}"
+          # shows platform specific gems if used
+          if (plat = s.spec.platform) == "ruby"
+            puts "  #{s.full_name}"
+          else
+            puts "  #{s.full_name}-#{plat}"
+          end
         end
 
         return
@@ -235,6 +240,22 @@ You can use `i` command instead of `install`.
       dependency = Gem::Dependency.new name, req
       dependency.prerelease = options[:prerelease]
 
+      if options[:explain]
+        puts "Gems to install:"
+        ary = Gem::SpecFetcher.fetcher.search_for_dependency dependency
+        if Array === ary && Array === ary[0]
+          tuples = ary[0].map { |i| i[0] }
+          if p_tuple = tuples.find { |t| Gem::Platform.local.to_s == t.platform }
+            puts "  #{p_tuple.full_name}"
+          else
+            r_tuple = tuples.find { |t| 'ruby' == t.platform }
+            puts "  #{r_tuple.full_name}"
+          end
+        else
+          puts "  no matching gems found"
+        end
+        return
+      end
       fetcher = Gem::RemoteFetcher.fetcher
       gem = fetcher.download_to_cache dependency
     end

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -102,7 +102,19 @@ class Gem::RemoteFetcher
 
     return if found.empty?
 
-    spec, source = found.max_by { |(s,_)| s.version }
+    # platform Ruby spec
+    r_spec, r_source = found.max_by { |(s,_)| s.version }
+
+    # platform local spec
+    p_found = found.select { |(s,_)| s.platform != 'ruby' && Gem::Platform.match(s.platform) }
+    p_spec, p_source = p_found.max_by { |(s,_)| s.version }
+
+    # use platform specific gem if version at least equal to ruby gem
+    if p_spec && p_spec.version >= r_spec.version
+      spec = p_spec ; source = p_source
+    else
+      spec = r_spec ; source = r_source
+    end
 
     download spec, source.uri.to_s
   end


### PR DESCRIPTION
All pertain to `gem install`:

1. As noted in PR #2446, `--ignore-dependencies` does not work correctly with platform specific gems
2. `--explain` option is ignored when combined with `--ignore-dependencies`
3.  `--explain` option shows only gem name and version, platform information is missing

PR fixes the above.

Notes:

4. When using `--ignore-dependencies` with `--explain`, `Gem::NameTuple`'s are used instead of specs.
5. Tests passed before and after.
6. The fix for `--ignore-dependencies` is in `Gem::RemoteFetcher#download_to_cache`.  If a platform specific gem exists, but it's version is less than the generic (platform=ruby) gem, the generic gem is used.
7. Not a complicated PR, but since I can only check it on Windows, more testing would certainly be appreciated...

______________

# Tasks:

- [X] Describe the problem / feature
- [ ] Write tests
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md)
