### PR TITLE
gem install/update, --explain, --ignore-dependencies, platform 

### DIFF
--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -201,10 +201,14 @@ You can use `i` command instead of `install`.
       request_set = inst.resolve_dependencies name, req
 
       if options[:explain]
-        puts "Gems to install:"
+        say "Gems to install:"
 
         request_set.sorted_requests.each do |s|
-          puts "  #{s.full_name}"
+          # shows platform specific gems if used
+          say (plat = s.spec.platform) == Gem::Platform::RUBY ?
+            "  #{s.full_name}" :
+            "  #{s.full_name}-#{plat}"
+
         end
 
         return
@@ -234,6 +238,20 @@ You can use `i` command instead of `install`.
       dependency = Gem::Dependency.new name, req
       dependency.prerelease = options[:prerelease]
 
+      if options[:explain]
+        say "Gems to install:"
+        ary = Gem::SpecFetcher.fetcher.search_for_dependency dependency
+        if ary.is_a?(Array) && ary[0].is_a?(Array)
+          tuples = ary[0].map { |i| i[0] }
+          tuple = tuples.max_by { |s|
+            [s.version, Gem::Platform.rank(s.platform)]
+          }
+          say "  #{tuple.full_name}"
+        else
+          say "  no matching gems found"
+        end
+        return
+      end
       fetcher = Gem::RemoteFetcher.fetcher
       gem = fetcher.download_to_cache dependency
     end

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -30,6 +30,20 @@ class Gem::Platform
     end
   end
 
+  def self.rank(platform)
+    if Gem.platforms == [RUBY]     # --platform=ruby
+      if RUBY == platform then     0
+      else                        -1
+      end
+    else
+      if    local == platform then 2
+      elsif local =~ platform then 1
+      elsif RUBY  == platform then 0
+      else                        -1
+      end
+    end
+  end
+
   def self.installable?(spec)
     if spec.respond_to? :installable_platform?
       spec.installable_platform?

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -99,10 +99,11 @@ class Gem::RemoteFetcher
 
   def download_to_cache(dependency)
     found, _ = Gem::SpecFetcher.fetcher.spec_for_dependency dependency
-
     return if found.empty?
 
-    spec, source = found.max_by { |(s,_)| s.version }
+    spec, source = found.max_by { |(s,_)|
+      [s.version, Gem::Platform.rank(s.platform)]
+    }
 
     download spec, source.uri.to_s
   end

--- a/lib/rubygems/source/local.rb
+++ b/lib/rubygems/source/local.rb
@@ -97,8 +97,7 @@ class Gem::Source::Local < Gem::Source
         end
       end
     end
-
-    found.max_by { |s| s.version }
+    found.max_by { |s| [s.version, Gem::Platform.rank(s.platform)] }
   end
 
   def fetch_spec(name) # :nodoc:

--- a/lib/rubygems/test_utilities.rb
+++ b/lib/rubygems/test_utilities.rb
@@ -149,7 +149,9 @@ class Gem::FakeFetcher
 
     return if found.empty?
 
-    spec, source = found.first
+    spec, source = Gem.platforms.length == 1 ?
+      found.first :
+      found.max_by { |(s,_)| [s.version, Gem::Platform.rank(s.platform)] }
 
     download spec, source.uri.to_s
   end

--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -522,4 +522,52 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
     assert_equal "  a-2", out.shift
     assert_empty out
   end
+
+  def test_explain_platform_local
+    local = Gem::Platform.local
+    spec_fetcher do |fetcher|
+      fetcher.download 'a', 2
+      fetcher.download 'a', 2 do |s| s.platform = local end
+      fetcher.spec 'a', 1
+    end
+
+    @cmd.options[:explain] = true
+    @cmd.options[:args] = %w[a]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    out = @ui.output.split "\n"
+
+    assert_equal "Gems to update:", out.shift
+    assert_equal "  a-2-#{local}", out.shift
+    assert_empty out
+  end
+
+  def test_explain_platform_ruby
+    local = Gem::Platform.local
+    spec_fetcher do |fetcher|
+      fetcher.download 'a', 2
+      fetcher.download 'a', 2 do |s| s.platform = local end
+      fetcher.spec 'a', 1
+    end
+
+    # equivalent to --platform=ruby
+    Gem.platforms = [Gem::Platform::RUBY]
+
+    @cmd.options[:explain] = true
+    @cmd.options[:args] = %w[a]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    out = @ui.output.split "\n"
+
+    assert_equal "Gems to update:", out.shift
+    assert_equal "  a-2", out.shift
+    assert_empty out
+  end
+
 end

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -440,6 +440,36 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     assert_equal @a2.file_name, File.basename(gem)
   end
 
+  def test_download_to_cache_local
+    local = Gem::Platform.local
+    @a2, @a2_gem = util_gem 'a', '2'
+    @a2loc, @a2loc_gem = util_gem 'a', '2' do |s| s.platform = local end
+
+    Gem.platforms = ['ruby', local]
+
+    util_setup_spec_fetcher @a1, @a2, @a2loc
+    @fetcher.instance_variable_set :@a1, @a1
+    @fetcher.instance_variable_set :@a2, @a2
+    @fetcher.instance_variable_set :@a2loc, @a2loc
+
+    def @fetcher.fetch_path(uri, mtime = nil, head = false)
+      case uri.request_uri
+      when /#{@a1.spec_name}/
+        Gem.deflate Marshal.dump @a1
+      when /#{@a2.spec_name}/
+        Gem.deflate Marshal.dump @a2
+      when /#{@a2loc.spec_name}/
+        Gem.deflate Marshal.dump @a2loc
+      else
+        uri.to_s
+      end
+    end
+
+    gem = Gem::RemoteFetcher.fetcher.download_to_cache dep 'a'
+
+    assert_equal @a2loc.file_name, File.basename(gem)
+  end
+
   def test_fetch_path_gzip
     fetcher = Gem::RemoteFetcher.new nil
     @fetcher = fetcher

--- a/test/rubygems/test_gem_source_local.rb
+++ b/test/rubygems/test_gem_source_local.rb
@@ -41,6 +41,32 @@ class TestGemSourceLocal < Gem::TestCase
     assert_equal "a-1", @sl.find_gem("a").full_name
   end
 
+  def test_find_gem_platform_local
+    local = Gem::Platform.local
+    _, al_gem = util_gem "a", '1' do |s| s.platform = local end
+    FileUtils.mv al_gem, @tempdir
+
+    assert_equal "a-1-#{local}", @sl.find_gem("a").full_name
+  end
+
+  def test_find_gem_platform_ruby
+    # equivalent to --platform=ruby
+    Gem.platforms = [Gem::Platform::RUBY]
+
+    local = Gem::Platform.local
+    _, al_gem = util_gem "a", '1' do |s| s.platform = local end
+    FileUtils.mv al_gem, @tempdir
+
+    # equivalent to --platform=ruby
+    Gem.platforms = [Gem::Platform::RUBY]
+
+    assert_equal "a-1", @sl.find_gem("a").full_name
+  end
+
+  def test_find_gem_platform
+    assert_equal "a-1", @sl.find_gem("a").full_name
+  end
+
   def test_find_gem_highest_version
     _, a2_gem = util_gem "a", "2"
     FileUtils.mv a2_gem, @tempdir


### PR DESCRIPTION
`gem install` & `gem update` behavior when used with the `--explain` and/or `--ignore-dependencies` options is not consistent, along with their handling of pre-compiled or platform specific gems and the
`--platform=ruby` option..

Below are three examples of the changes from the PR.  generated on a `x64-mingw32` windows build

```
———————————— Not patched ————————————      —————————————— Patched ——————————————

C:\> gem install eventmachine --explain

Gems to install:                           Gems to install:
  eventmachine-1.2.7                         eventmachine-1.2.7-x64-mingw32


C:\> gem install eventmachine --explain --ignore-dependencies
  
** Installs                                Gems to install:
   eventmachine-1.2.7.gem                    eventmachine-1.2.7-x64-mingw32
                                             
                                             
C:\> gem install eventmachine --ignore-dependencies

** Installs                                ** Installs
   eventmachine-1.2.7.gem                     eventmachine-1.2.7-x64-mingw32.gem
```

Below is a summary of the news tests, 'F' indicates that it fails currently (before the 2nd code commit):
```
TestGemCommandsInstallCommand              test_gem_commands_install_command.rb
   test_install_gem_remote_platform_local
   test_install_gem_ignore_dependencies_local (previously both)
F  test_install_gem_ignore_dependencies_remote_platform_local
F  test_explain_platform_local
F  test_explain_platform_local_ignore_deps
F  test_explain_platform_ruby
F  test_explain_platform_ruby_ignore_deps

TestGemCommandsUpdateCommand               test_gem_commands_update_command.rb
F  test_explain_platform_local
   test_explain_platform_ruby

TestGemRemoteFetcher                       test_gem_remote_fetcher.rb
F  test_download_to_cache_local

TestGemSourceLocal                         test_gem_source_local.rb
   test_find_gem_platform_local
F  test_find_gem_platform_ruby
```

Two commits, the first changes/adds tests, the second fixes the code.  Additional discussion in PR #2446 & #2449.

**EDIT:** 2018-10-31 22:00 UTC - refactored and added `Gem::Platform.rank` method.

# Tasks:

- [X] Describe the problem / feature
- [X] Write tests
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
