### PR TITLE
Fix and lock rubocop

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -72,12 +72,12 @@ rescue LoadError
 end
 
 begin
-  gem "rubocop", "~> 0.58"
+  gem "rubocop", "~> 0.59.0"
   require "rubocop/rake_task"
 
   RuboCop::RakeTask.new
 rescue LoadError
-  task(:rubocop) { abort "Install the rubocop gem (~> 0.58) to run a static analysis" }
+  task(:rubocop) { abort "Install the rubocop gem (~> 0.59.0) to run a static analysis" }
 end
 
 # --------------------------------------------------------------------

--- a/Rakefile
+++ b/Rakefile
@@ -72,12 +72,12 @@ rescue LoadError
 end
 
 begin
-  gem "rubocop", "~> 0.59.0"
+  gem "rubocop", "~> 0.60.0"
   require "rubocop/rake_task"
 
   RuboCop::RakeTask.new
 rescue LoadError
-  task(:rubocop) { abort "Install the rubocop gem (~> 0.59.0) to run a static analysis" }
+  task(:rubocop) { abort "Install the rubocop gem (~> 0.60.0) to run a static analysis" }
 end
 
 # --------------------------------------------------------------------

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -6,8 +6,8 @@ require 'rubygems/command'
 # RubyGems checkout or tarball.
 
 class Gem::Commands::SetupCommand < Gem::Command
-  HISTORY_HEADER = /^===\s*[\d.a-zA-Z]+\s*\/\s*\d{4}-\d{2}-\d{2}\s*$/
-  VERSION_MATCHER = /^===\s*([\d.a-zA-Z]+)\s*\/\s*\d{4}-\d{2}-\d{2}\s*$/
+  HISTORY_HEADER = /^===\s*[\d.a-zA-Z]+\s*\/\s*\d{4}-\d{2}-\d{2}\s*$/.freeze
+  VERSION_MATCHER = /^===\s*([\d.a-zA-Z]+)\s*\/\s*\d{4}-\d{2}-\d{2}\s*$/.freeze
 
   ENV_PATHS = %w[/usr/bin/env /bin/env].freeze
 

--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -32,7 +32,7 @@ class Gem::Requirement
   ##
   # A regular expression that matches a requirement
 
-  PATTERN = /\A#{PATTERN_RAW}\z/
+  PATTERN = /\A#{PATTERN_RAW}\z/.freeze
 
   ##
   # The default requirement matches any version

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -114,7 +114,7 @@ class Gem::Specification < Gem::BasicSpecification
 
   private_constant :LOAD_CACHE if defined? private_constant
 
-  VALID_NAME_PATTERN = /\A[a-zA-Z0-9\.\-\_]+\z/ # :nodoc:
+  VALID_NAME_PATTERN = /\A[a-zA-Z0-9\.\-\_]+\z/.freeze # :nodoc:
 
   # :startdoc:
 
@@ -1749,7 +1749,7 @@ class Gem::Specification < Gem::BasicSpecification
     /\A
      (\d{4})-(\d{2})-(\d{2})
      (\s+ \d{2}:\d{2}:\d{2}\.\d+ \s* (Z | [-+]\d\d:\d\d) )?
-     \Z/x
+     \Z/x.freeze
 
   ##
   # The date this gem was created

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -2,11 +2,11 @@ require 'delegate'
 require 'uri'
 
 class Gem::SpecificationPolicy < SimpleDelegator
-  VALID_NAME_PATTERN = /\A[a-zA-Z0-9\.\-\_]+\z/ # :nodoc:
+  VALID_NAME_PATTERN = /\A[a-zA-Z0-9\.\-\_]+\z/.freeze # :nodoc:
 
-  SPECIAL_CHARACTERS = /\A[#{Regexp.escape('.-_')}]+/ # :nodoc:
+  SPECIAL_CHARACTERS = /\A[#{Regexp.escape('.-_')}]+/.freeze # :nodoc:
 
-  VALID_URI_PATTERN = %r{\Ahttps?:\/\/([^\s:@]+:[^\s:@]*@)?[A-Za-z\d\-]+(\.[A-Za-z\d\-]+)+\.?(:\d{1,5})?([\/?]\S*)?\z}  # :nodoc:
+  VALID_URI_PATTERN = %r{\Ahttps?:\/\/([^\s:@]+:[^\s:@]*@)?[A-Za-z\d\-]+(\.[A-Za-z\d\-]+)+\.?(:\d{1,5})?([\/?]\S*)?\z}.freeze  # :nodoc:
 
   METADATA_LINK_KEYS = %w[
     bug_tracker_uri
@@ -318,8 +318,8 @@ http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard li
   end
 
   LAZY = '"FIxxxXME" or "TOxxxDO"'.gsub(/xxx/, '')
-  LAZY_PATTERN = /FI XME|TO DO/x
-  HOMEPAGE_URI_PATTERN = /\A[a-z][a-z\d+.-]*:/i
+  LAZY_PATTERN = /FI XME|TO DO/x.freeze
+  HOMEPAGE_URI_PATTERN = /\A[a-z][a-z\d+.-]*:/i.freeze
 
   def validate_lazy_metadata
     unless authors.grep(LAZY_PATTERN).empty? then

--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -155,7 +155,7 @@ class Gem::Version
   include Comparable
 
   VERSION_PATTERN = '[0-9]+(?>\.[0-9a-zA-Z]+)*(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?'.freeze # :nodoc:
-  ANCHORED_VERSION_PATTERN = /\A\s*(#{VERSION_PATTERN})?\s*\z/ # :nodoc:
+  ANCHORED_VERSION_PATTERN = /\A\s*(#{VERSION_PATTERN})?\s*\z/.freeze # :nodoc:
 
   ##
   # A string representation of this Version.

--- a/rubygems-update.gemspec
+++ b/rubygems-update.gemspec
@@ -39,5 +39,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency(%q<rake>, ["~> 12.0"])
   s.add_development_dependency(%q<minitest>, ["~> 5.0"])
   s.add_development_dependency(%q<simplecov>, ["~> 0"])
-  s.add_development_dependency(%q<rubocop>, ["~> 0.59.0"])
+  s.add_development_dependency(%q<rubocop>, ["~> 0.60.0"])
 end

--- a/util/ci
+++ b/util/ci
@@ -57,7 +57,7 @@ when %w(before_script)
       run('gem', %w(install bundler -v 1.16.2))
     end
 
-    run('gem', %w(install rubocop -v ~>0.59.0))
+    run('gem', %w(install rubocop -v ~>0.60.0))
 
     run('gem', %w(list --details))
     run('gem', %w(env))


### PR DESCRIPTION
# Description:

I was getting rubocop offenses against latest master. This is because I had `0.60.0` installed and that version was allowed by the previous requirement (`~> 0.58`), so the rake task was picking that version. 
`0.60.0` added [a bug fix](https://github.com/rubocop-hq/rubocop/pull/6333) around `Style/MutableConstant` that detects new offenses, so that's why it was failing.
 
This PR bumps the version of rubocop in use to `0.60.0`, and consistently sets the requirement to include the patch version (`~> 0.60.0`).

I would actually go as far as fully locking the dependency, because right now if the same thing happens with a patch level release (for example, `0.60.1`), the same problem will be introduced and get in the middle for contributors. But I haven't done it in this PR. 
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
