### PR TITLE
Add a rubocop binstub

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -71,15 +71,6 @@ rescue LoadError
   end
 end
 
-begin
-  gem "rubocop", "~> 0.60.0"
-  require "rubocop/rake_task"
-
-  RuboCop::RakeTask.new
-rescue LoadError
-  task(:rubocop) { abort "Install the rubocop gem (~> 0.60.0) to run a static analysis" }
-end
-
 # --------------------------------------------------------------------
 # Creating a release
 

--- a/util/ci
+++ b/util/ci
@@ -65,7 +65,7 @@ when %w(before_script)
     with_retries { run('rake', %w(spec:travis:deps)) }
   end
 when %w(script)
-  run('rake rubocop')
+  run('util/rubocop')
   if TOOL.rubygems?
     run('rake test')
   else

--- a/util/ci
+++ b/util/ci
@@ -65,8 +65,8 @@ when %w(before_script)
     with_retries { run('rake', %w(spec:travis:deps)) }
   end
 when %w(script)
-  run('util/rubocop')
   if TOOL.rubygems?
+    run('util/rubocop')
     run('rake test')
   else
     run('rake', %w(spec:travis -t))

--- a/util/rubocop
+++ b/util/rubocop
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+begin
+  load Gem.bin_path("rubocop", "rubocop", "~> 0.60.0")
+rescue Gem::GemNotFoundException
+  abort "Install the rubocop gem (~> 0.60.0) to run a static analysis"
+end


### PR DESCRIPTION
# Description:

Currently there's no easy way to run the proper version of rubocop againt the rubygems repo. One can do `rake rubocop`, but that does not allow any rubocop options, like `--auto-correct`. One can also do, `rubocop _0.60.0_`, but it's not very handy. So I propose to replace the `rubocop` rake task with a binstub, because it's more flexible.
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
