### PR TITLE
Restore the `rubocop` task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -71,6 +71,11 @@ rescue LoadError
   end
 end
 
+desc "Run rubocop"
+task(:rubocop) do
+  sh "util/rubocop"
+end
+
 # --------------------------------------------------------------------
 # Creating a release
 


### PR DESCRIPTION
# Description:

Follow up to #2468, as per https://github.com/rubygems/rubygems/pull/2468#issuecomment-438439125. In case some rubygems developer was relying on this task for her workflow, here it is again!
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
