### PR TITLE
fix test warnings

### DIFF
--- a/lib/rubygems/user_interaction.rb
+++ b/lib/rubygems/user_interaction.rb
@@ -568,6 +568,7 @@ class Gem::StreamUI
     # +out_stream+.  The other arguments are ignored.
 
     def initialize(out_stream, *args)
+      @file_name = nil
       @out = out_stream
     end
 

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -286,7 +286,7 @@ class TestGemCommandsBuildCommand < Gem::TestCase
     gem_path = File.join Gem.user_home, ".gem"
     Dir.mkdir gem_path
 
-    trust_dir = Gem::Security.trust_dir
+    Gem::Security.trust_dir
 
     tmp_expired_cert_file = File.join gem_path, "gem-public_cert.pem"
     File.write(tmp_expired_cert_file, File.read(EXPIRED_CERT_FILE))

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2914,6 +2914,8 @@ duplicate dependency on c (>= 1.2.3, development), (~> 1.2) use:
   def test_unresolved_specs
     specification = Gem::Specification.clone
 
+    set_orig specification
+
     specification.define_singleton_method(:unresolved_deps) do
       { b: Gem::Dependency.new("x","1") }
     end
@@ -2936,6 +2938,8 @@ Please report a bug if this causes problems.
 
   def test_unresolved_specs_with_versions
     specification = Gem::Specification.clone
+
+    set_orig specification
 
     specification.define_singleton_method(:unresolved_deps) do
       { b: Gem::Dependency.new("x","1") }
@@ -2961,6 +2965,12 @@ Please report a bug if this causes problems.
     assert_output nil, expected do
       specification.reset
     end
+  end
+
+  def set_orig(cls)
+    s_cls = cls.singleton_class
+    s_cls.send :alias_method, :orig_unresolved_deps , :unresolved_deps
+    s_cls.send :alias_method, :orig_find_all_by_name, :find_all_by_name
   end
 
   def test_validate_files_recursive


### PR DESCRIPTION
# Description:

Fix test warnings.

```
test/rubygems/test_gem_commands_build_command.rb:289: warning: assigned but unused variable - trust_dir

test/rubygems/test_gem_specification.rb:2917: warning: method redefined; discarding old unresolved_deps
lib/rubygems/specification.rb:1310: warning: previous definition of unresolved_deps was here

test/rubygems/test_gem_specification.rb:2921: warning: method redefined; discarding old find_all_by_name
lib/rubygems/specification.rb:1013: warning: previous definition of find_all_by_name was here

test/rubygems/test_gem_specification.rb:2940: warning: method redefined; discarding old unresolved_deps
lib/rubygems/specification.rb:1310: warning: previous definition of unresolved_deps was here

test/rubygems/test_gem_specification.rb:2944: warning: method redefined; discarding old find_all_by_name
lib/rubygems/specification.rb:1013: warning: previous definition of find_all_by_name was here

Below x3

lib/rubygems/user_interaction.rb:579: warning: instance variable @file_name not initialized
lib/rubygems/user_interaction.rb:579: warning: instance variable @file_name not initialized
```

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
