### PR TITLE
fix link to bundlerbot command documentation

### DIFF
--- a/POLICIES.md
+++ b/POLICIES.md
@@ -10,7 +10,7 @@ merge commit passes the tests.
 This process guarantees that our release branches always have passing tests,
 and reduces siloing of information to a single contributor. For a full list of
 possible commands, see [the Bundlerbot
-documentation](https://bundlerbot-homu.herokuapp.com/).
+documentation](https://bors.tech/documentation/).
 
 ## Long-Term Support
 


### PR DESCRIPTION
# Description:

Just updating the link for the bundlerbot commands to bors

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
