### PR TITLE
fixup #2441: `make` arguments as an array too

### DIFF
--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -33,19 +33,20 @@ class Gem::Ext::Builder
     # try to find make program from Ruby configure arguments first
     RbConfig::CONFIG['configure_args'] =~ /with-make-prog\=(\w+)/
     make_program = ENV['MAKE'] || ENV['make'] || $1
-    unless make_program
-      make_program = (/mswin/ =~ RUBY_PLATFORM) ? 'nmake' : 'make'
+    if make_program
+      make_program = make_program.shellsplit
+    else
+      make_program = [(/mswin/ =~ RUBY_PLATFORM) ? 'nmake' : 'make']
     end
 
-    destdir = '"DESTDIR=%s"' % ENV['DESTDIR']
+    destdir = 'DESTDIR=%s' % ENV['DESTDIR']
 
-    ['clean', '', 'install'].each do |target|
+    ['clean', nil, 'install'].each do |target|
       # Pass DESTDIR via command line to override what's in MAKEFLAGS
-      cmd = [
-        make_program,
+      cmd = make_program + [
         destdir,
-        target
-      ].join(' ').rstrip
+        target,
+      ].compact
       begin
         run(cmd, results, "make #{target}".rstrip)
       rescue Gem::InstallError

--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -49,9 +49,9 @@ install:
 
     results = results.join "\n"
 
-    assert_match %r{"DESTDIR=#{ENV['DESTDIR']}" clean$},   results
-    assert_match %r{"DESTDIR=#{ENV['DESTDIR']}"$},         results
-    assert_match %r{"DESTDIR=#{ENV['DESTDIR']}" install$}, results
+    assert_match %r{DESTDIR\\=#{ENV['DESTDIR']} clean$},   results
+    assert_match %r{DESTDIR\\=#{ENV['DESTDIR']}$},         results
+    assert_match %r{DESTDIR\\=#{ENV['DESTDIR']} install$}, results
 
     if /nmake/ !~ results
       assert_match %r{^clean: destination$},   results
@@ -80,9 +80,9 @@ install:
 
     results = results.join "\n"
 
-    assert_match %r{"DESTDIR=#{ENV['DESTDIR']}" clean$},   results
-    assert_match %r{"DESTDIR=#{ENV['DESTDIR']}"$},         results
-    assert_match %r{"DESTDIR=#{ENV['DESTDIR']}" install$}, results
+    assert_match %r{DESTDIR\\=#{ENV['DESTDIR']} clean$},   results
+    assert_match %r{DESTDIR\\=#{ENV['DESTDIR']}$},         results
+    assert_match %r{DESTDIR\\=#{ENV['DESTDIR']} install$}, results
   end
 
   def test_build_extensions


### PR DESCRIPTION
# Description:

I forgot to modify `Gem::Ext::Builder.make` to call `run` with a command array at #2441.
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).