### PR TITLE
Enable Style/MethodDefParentheses in Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,5 +56,8 @@ Layout/TrailingBlankLines:
 Layout/TrailingWhitespace:
   Enabled: true
 
+Style/MethodDefParentheses:
+  Enabled: true
+
 Style/MutableConstant:
   Enabled: true

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -202,7 +202,7 @@ module Gem
   # activation succeeded or wasn't needed because it was already
   # activated. Returns false if it can't find the path in a gem.
 
-  def self.try_activate path
+  def self.try_activate(path)
     # finds the _latest_ version... regardless of loaded specs and their deps
     # if another gem had a requirement that would mean we shouldn't
     # activate the latest version, then either it would already be activated
@@ -262,7 +262,7 @@ module Gem
     find_spec_for_exe(name, exec_name, requirements).bin_file exec_name
   end
 
-  def self.find_spec_for_exe name, exec_name, requirements
+  def self.find_spec_for_exe(name, exec_name, requirements)
     dep = Gem::Dependency.new name, requirements
 
     loaded = Gem.loaded_specs[name]
@@ -298,7 +298,7 @@ module Gem
   #
   # This method should *only* be used in bin stub files.
 
-  def self.activate_bin_path name, exec_name, requirement # :nodoc:
+  def self.activate_bin_path(name, exec_name, requirement) # :nodoc:
     spec = find_spec_for_exe name, exec_name, [requirement]
     Gem::LOADED_SPECS_MUTEX.synchronize do
       spec.activate
@@ -441,7 +441,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   #
   # World-writable directories will never be created.
 
-  def self.ensure_gem_subdirectories dir = Gem.dir, mode = nil
+  def self.ensure_gem_subdirectories(dir = Gem.dir, mode = nil)
     ensure_subdirectories(dir, mode, REPOSITORY_SUBDIRECTORIES)
   end
 
@@ -454,11 +454,11 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   #
   # World-writable directories will never be created.
 
-  def self.ensure_default_gem_subdirectories dir = Gem.dir, mode = nil
+  def self.ensure_default_gem_subdirectories(dir = Gem.dir, mode = nil)
     ensure_subdirectories(dir, mode, REPOSITORY_DEFAULT_GEM_SUBDIRECTORIES)
   end
 
-  def self.ensure_subdirectories dir, mode, subdirs # :nodoc:
+  def self.ensure_subdirectories(dir, mode, subdirs) # :nodoc:
     old_umask = File.umask
     File.umask old_umask | 002
 
@@ -519,7 +519,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     return files
   end
 
-  def self.find_files_from_load_path glob # :nodoc:
+  def self.find_files_from_load_path(glob) # :nodoc:
     glob_with_suffixes = "#{glob}#{Gem.suffix_pattern}"
     $LOAD_PATH.map { |load_path|
       Gem::Util.glob_files_in_dir(glob_with_suffixes, load_path)
@@ -629,7 +629,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   #   Fetching: minitest-3.0.1.gem (100%)
   #   => [#<Gem::Specification:0x1013b4528 @name="minitest", ...>]
 
-  def self.install name, version = Gem::Requirement.default, *options
+  def self.install(name, version = Gem::Requirement.default, *options)
     require "rubygems/dependency_installer"
     inst = Gem::DependencyInstaller.new(*options)
     inst.install name, version
@@ -647,7 +647,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
   ## Set the default RubyGems API host.
 
-  def self.host= host
+  def self.host=(host)
     # TODO: move to utils
     @host = host
   end
@@ -923,7 +923,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   ##
   # Returns the latest release-version specification for the gem +name+.
 
-  def self.latest_spec_for name
+  def self.latest_spec_for(name)
     dependency   = Gem::Dependency.new name
     fetcher      = Gem::SpecFetcher.fetcher
     spec_tuples, = fetcher.spec_for_dependency dependency
@@ -944,7 +944,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   ##
   # Returns the version of the latest release-version of gem +name+
 
-  def self.latest_version_for name
+  def self.latest_version_for(name)
     spec = latest_spec_for name
     spec and spec.version
   end
@@ -993,7 +993,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   # DOC: This comment is not documentation about the method itself, it's
   # more of a code comment about the implementation.
 
-  def self.sources= new_sources
+  def self.sources=(new_sources)
     if !new_sources
       @sources = nil
     else
@@ -1081,7 +1081,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   ##
   # Load +plugins+ as Ruby files
 
-  def self.load_plugin_files plugins # :nodoc:
+  def self.load_plugin_files(plugins) # :nodoc:
     plugins.each do |plugin|
 
       # Skip older versions of the GemCutter plugin: Its commands are in
@@ -1150,7 +1150,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   # execution of arbitrary code when used from directories outside your
   # control.
 
-  def self.use_gemdeps path = nil
+  def self.use_gemdeps(path = nil)
     raise_exception = path
 
     path ||= ENV['RUBYGEMS_GEMDEPS']

--- a/lib/rubygems/available_set.rb
+++ b/lib/rubygems/available_set.rb
@@ -103,7 +103,7 @@ class Gem::AvailableSet
   # Other options are :shallow for only direct development dependencies of the
   # gems in this set or :all for all development dependencies.
 
-  def to_request_set development = :none
+  def to_request_set(development = :none)
     request_set = Gem::RequestSet.new
     request_set.development = :all == development
 

--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -65,7 +65,7 @@ class Gem::BasicSpecification
   ##
   # Return true if this spec can require +file+.
 
-  def contains_requirable_file? file
+  def contains_requirable_file?(file)
     if @ignored then
       return false
     elsif missing_extensions? then
@@ -160,7 +160,7 @@ class Gem::BasicSpecification
   # Full path of the target library file.
   # If the file is not in this gem, return nil.
 
-  def to_fullpath path
+  def to_fullpath(path)
     if activated? then
       @paths_map ||= {}
       @paths_map[path] ||=
@@ -263,7 +263,7 @@ class Gem::BasicSpecification
   ##
   # Return all files in this gem that match for +glob+.
 
-  def matches_for_glob glob # TODO: rename?
+  def matches_for_glob(glob) # TODO: rename?
     # TODO: do we need these?? Kill it
     glob = File.join(self.lib_dirs_glob, glob)
 
@@ -316,7 +316,7 @@ class Gem::BasicSpecification
 
   def have_extensions?; !extensions.empty?; end
 
-  def have_file? file, suffixes
+  def have_file?(file, suffixes)
     return true if raw_require_paths.any? do |path|
       base = File.join(gems_dir, full_name, path.untaint, file).untaint
       suffixes.any? { |suf| File.file? base + suf }

--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -451,7 +451,7 @@ class Gem::Command
   # Adds a section with +title+ and +content+ to the parser help view.  Used
   # for adding command arguments and default arguments.
 
-  def add_parser_run_info title, content
+  def add_parser_run_info(title, content)
     return if content.empty?
 
     @parser.separator nil

--- a/lib/rubygems/commands/cert_command.rb
+++ b/lib/rubygems/commands/cert_command.rb
@@ -98,7 +98,7 @@ class Gem::Commands::CertCommand < Gem::Command
     end
   end
 
-  def add_certificate certificate # :nodoc:
+  def add_certificate(certificate) # :nodoc:
     Gem::Security.trust_dir.trust_cert certificate
 
     say "Added '#{certificate.subject}'"
@@ -132,7 +132,7 @@ class Gem::Commands::CertCommand < Gem::Command
     sign_certificates unless options[:sign].empty?
   end
 
-  def build email
+  def build(email)
     if !valid_email?(email)
       raise Gem::CommandLineError, "Invalid email address #{email}"
     end
@@ -148,7 +148,7 @@ class Gem::Commands::CertCommand < Gem::Command
     end
   end
 
-  def build_cert email, key # :nodoc:
+  def build_cert(email, key) # :nodoc:
     expiration_length_days = options[:expiration_length_days] ||
       Gem.configuration.cert_expiration_length_days
 
@@ -179,7 +179,7 @@ class Gem::Commands::CertCommand < Gem::Command
     return key, key_path
   end
 
-  def certificates_matching filter
+  def certificates_matching(filter)
     return enum_for __method__, filter unless block_given?
 
     Gem::Security.trusted_certificates.select do |certificate, _|
@@ -231,7 +231,7 @@ For further reading on signing gems see `ri Gem::Security`.
     EOF
   end
 
-  def list_certificates_matching filter # :nodoc:
+  def list_certificates_matching(filter) # :nodoc:
     certificates_matching filter do |certificate, _|
       # this could probably be formatted more gracefully
       say certificate.subject.to_s
@@ -276,14 +276,14 @@ For further reading on signing gems see `ri Gem::Security`.
     load_default_key  unless options[:key]
   end
 
-  def remove_certificates_matching filter # :nodoc:
+  def remove_certificates_matching(filter) # :nodoc:
     certificates_matching filter do |certificate, path|
       FileUtils.rm path
       say "Removed '#{certificate.subject}'"
     end
   end
 
-  def sign cert_file
+  def sign(cert_file)
     cert = File.read cert_file
     cert = OpenSSL::X509::Certificate.new cert
 
@@ -314,7 +314,7 @@ For further reading on signing gems see `ri Gem::Security`.
 
   private
 
-  def valid_email? email
+  def valid_email?(email)
     # It's simple, but is all we need
     email =~ /\A.+@.+\z/
   end

--- a/lib/rubygems/commands/cleanup_command.rb
+++ b/lib/rubygems/commands/cleanup_command.rb
@@ -151,7 +151,7 @@ If no gems are named all gems in GEM_HOME are cleaned.
     end
   end
 
-  def uninstall_dep spec
+  def uninstall_dep(spec)
     return unless @full.ok_to_remove?(spec.full_name, options[:check_dev])
 
     if options[:dryrun] then

--- a/lib/rubygems/commands/contents_command.rb
+++ b/lib/rubygems/commands/contents_command.rb
@@ -83,7 +83,7 @@ prefix or only the files that are requireable.
     end
   end
 
-  def files_in spec
+  def files_in(spec)
     if spec.default_gem? then
       files_in_default_gem spec
     else
@@ -91,7 +91,7 @@ prefix or only the files that are requireable.
     end
   end
 
-  def files_in_gem spec
+  def files_in_gem(spec)
     gem_path  = spec.full_gem_path
     extra     = "/{#{spec.require_paths.join ','}}" if options[:lib_only]
     glob      = "#{gem_path}#{extra}/**/*"
@@ -102,7 +102,7 @@ prefix or only the files that are requireable.
     end
   end
 
-  def files_in_default_gem spec
+  def files_in_default_gem(spec)
     spec.files.map do |file|
       case file
       when /\A#{spec.bindir}\//
@@ -115,7 +115,7 @@ prefix or only the files that are requireable.
     end
   end
 
-  def gem_contents name
+  def gem_contents(name)
     spec = spec_for name
 
     return false unless spec
@@ -127,7 +127,7 @@ prefix or only the files that are requireable.
     true
   end
 
-  def gem_install_dir name
+  def gem_install_dir(name)
     spec = spec_for name
 
     return false unless spec
@@ -145,7 +145,7 @@ prefix or only the files that are requireable.
     end
   end
 
-  def path_description spec_dirs # :nodoc:
+  def path_description(spec_dirs) # :nodoc:
     if spec_dirs.empty? then
       "default gem paths"
     else
@@ -153,7 +153,7 @@ prefix or only the files that are requireable.
     end
   end
 
-  def show_files files
+  def show_files(files)
     files.sort.each do |prefix, basename|
       absolute_path = File.join(prefix, basename)
       next if File.directory? absolute_path
@@ -166,7 +166,7 @@ prefix or only the files that are requireable.
     end
   end
 
-  def spec_for name
+  def spec_for(name)
     spec = Gem::Specification.find_all_by_name(name, @version).last
 
     return spec if spec

--- a/lib/rubygems/commands/dependency_command.rb
+++ b/lib/rubygems/commands/dependency_command.rb
@@ -54,7 +54,7 @@ use with other commands.
     "#{program_name} REGEXP"
   end
 
-  def fetch_remote_specs dependency # :nodoc:
+  def fetch_remote_specs(dependency) # :nodoc:
     fetcher = Gem::SpecFetcher.fetcher
 
     ss, = fetcher.spec_for_dependency dependency
@@ -62,7 +62,7 @@ use with other commands.
     ss.map { |spec, _| spec }
   end
 
-  def fetch_specs name_pattern, dependency # :nodoc:
+  def fetch_specs(name_pattern, dependency) # :nodoc:
     specs = []
 
     if local?
@@ -79,7 +79,7 @@ use with other commands.
     specs.uniq.sort
   end
 
-  def gem_dependency pattern, version, prerelease # :nodoc:
+  def gem_dependency(pattern, version, prerelease) # :nodoc:
     dependency = Gem::Deprecate.skip_during {
       Gem::Dependency.new pattern, version
     }
@@ -89,7 +89,7 @@ use with other commands.
     dependency
   end
 
-  def display_pipe specs # :nodoc:
+  def display_pipe(specs) # :nodoc:
     specs.each do |spec|
       unless spec.dependencies.empty? then
         spec.dependencies.sort_by { |dep| dep.name }.each do |dep|
@@ -99,7 +99,7 @@ use with other commands.
     end
   end
 
-  def display_readable specs, reverse # :nodoc:
+  def display_readable(specs, reverse) # :nodoc:
     response = String.new
 
     specs.each do |spec|
@@ -142,7 +142,7 @@ use with other commands.
     end
   end
 
-  def ensure_specs specs # :nodoc:
+  def ensure_specs(specs) # :nodoc:
     return unless specs.empty?
 
     patterns = options[:args].join ','
@@ -163,7 +163,7 @@ use with other commands.
     response
   end
 
-  def remote_specs dependency # :nodoc:
+  def remote_specs(dependency) # :nodoc:
     fetcher = Gem::SpecFetcher.fetcher
 
     ss, _ = fetcher.spec_for_dependency dependency
@@ -171,7 +171,7 @@ use with other commands.
     ss.map { |s,o| s }
   end
 
-  def reverse_dependencies specs # :nodoc:
+  def reverse_dependencies(specs) # :nodoc:
     reverse = Hash.new { |h, k| h[k] = [] }
 
     return reverse unless options[:reverse_dependencies]
@@ -186,7 +186,7 @@ use with other commands.
   ##
   # Returns an Array of [specification, dep] that are satisfied by +spec+.
 
-  def find_reverse_dependencies spec # :nodoc:
+  def find_reverse_dependencies(spec) # :nodoc:
     result = []
 
     Gem::Specification.each do |sp|
@@ -205,7 +205,7 @@ use with other commands.
 
   private
 
-  def name_pattern args
+  def name_pattern(args)
     args << '' if args.empty?
 
     if args.length == 1 and args.first =~ /\A\/(.*)\/(i)?\z/m then

--- a/lib/rubygems/commands/environment_command.rb
+++ b/lib/rubygems/commands/environment_command.rb
@@ -97,7 +97,7 @@ lib/rubygems/defaults/operating_system.rb
     true
   end
 
-  def add_path out, path
+  def add_path(out, path)
     path.each do |component|
       out << "     - #{component}\n"
     end

--- a/lib/rubygems/commands/help_command.rb
+++ b/lib/rubygems/commands/help_command.rb
@@ -356,7 +356,7 @@ platform.
     say out.join("\n")
   end
 
-  def show_command_help command_name # :nodoc:
+  def show_command_help(command_name) # :nodoc:
     command_name = command_name.downcase
 
     possibilities = @command_manager.find_command_possibilities command_name

--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -188,7 +188,7 @@ You can use `i` command instead of `install`.
     terminate_interaction
   end
 
-  def install_gem name, version # :nodoc:
+  def install_gem(name, version) # :nodoc:
     return if options[:conservative] and
       not Gem::Dependency.new(name, version).matching_specs.empty?
 
@@ -216,7 +216,7 @@ You can use `i` command instead of `install`.
     end
   end
 
-  def install_gem_without_dependencies name, req # :nodoc:
+  def install_gem_without_dependencies(name, req) # :nodoc:
     gem = nil
 
     if local? then
@@ -292,7 +292,7 @@ You can use `i` command instead of `install`.
     require 'rubygems/rdoc'
   end
 
-  def show_install_errors errors # :nodoc:
+  def show_install_errors(errors) # :nodoc:
     return unless errors
 
     errors.each do |x|

--- a/lib/rubygems/commands/open_command.rb
+++ b/lib/rubygems/commands/open_command.rb
@@ -58,7 +58,7 @@ class Gem::Commands::OpenCommand < Gem::Command
     terminate_interaction 1 unless found
   end
 
-  def open_gem name
+  def open_gem(name)
     spec = spec_for name
 
     return false unless spec
@@ -71,13 +71,13 @@ class Gem::Commands::OpenCommand < Gem::Command
     open_editor(spec.full_gem_path)
   end
 
-  def open_editor path
+  def open_editor(path)
     Dir.chdir(path) do
       system(*@editor.split(/\s+/) + [path])
     end
   end
 
-  def spec_for name
+  def spec_for(name)
     spec = Gem::Specification.find_all_by_name(name, @version).first
 
     return spec if spec

--- a/lib/rubygems/commands/owner_command.rb
+++ b/lib/rubygems/commands/owner_command.rb
@@ -58,7 +58,7 @@ permission to.
     show_owners   name
   end
 
-  def show_owners name
+  def show_owners(name)
     response = rubygems_api_request :get, "api/v1/gems/#{name}/owners.yaml" do |request|
       request.add_field "Authorization", api_key
     end
@@ -73,15 +73,15 @@ permission to.
     end
   end
 
-  def add_owners name, owners
+  def add_owners(name, owners)
     manage_owners :post, name, owners
   end
 
-  def remove_owners name, owners
+  def remove_owners(name, owners)
     manage_owners :delete, name, owners
   end
 
-  def manage_owners method, name, owners
+  def manage_owners(method, name, owners)
     owners.each do |owner|
       begin
         response = rubygems_api_request method, "api/v1/gems/#{name}/owners" do |request|

--- a/lib/rubygems/commands/query_command.rb
+++ b/lib/rubygems/commands/query_command.rb
@@ -119,7 +119,7 @@ is too hard to use.
 
   private
 
-  def display_header type
+  def display_header(type)
     if (ui.outs.tty? and Gem.configuration.verbose) or both? then
       say
       say "*** #{type} GEMS ***"
@@ -128,7 +128,7 @@ is too hard to use.
   end
 
   #Guts of original execute
-  def show_gems name, prerelease
+  def show_gems(name, prerelease)
     req = Gem::Requirement.default
     # TODO: deprecate for real
     dep = Gem::Deprecate.skip_during { Gem::Dependency.new name, req }
@@ -205,7 +205,7 @@ is too hard to use.
     say output.join(options[:details] ? "\n\n" : "\n")
   end
 
-  def output_versions output, versions
+  def output_versions(output, versions)
     versions.each do |gem_name, matching_tuples|
       matching_tuples = matching_tuples.sort_by { |n,_| n.version }.reverse
 
@@ -230,7 +230,7 @@ is too hard to use.
     end
   end
 
-  def entry_details entry, detail_tuple, specs, platforms
+  def entry_details(entry, detail_tuple, specs, platforms)
     return unless options[:details]
 
     name_tuple, spec = detail_tuple
@@ -247,7 +247,7 @@ is too hard to use.
     spec_summary     entry, spec
   end
 
-  def entry_versions entry, name_tuples, platforms, specs
+  def entry_versions(entry, name_tuples, platforms, specs)
     return unless options[:versions]
 
     list =
@@ -276,7 +276,7 @@ is too hard to use.
     entry << " (#{list.join ', '})"
   end
 
-  def make_entry entry_tuples, platforms
+  def make_entry(entry_tuples, platforms)
     detail_tuple = entry_tuples.first
 
     name_tuples, specs = entry_tuples.flatten.partition do |item|
@@ -291,19 +291,19 @@ is too hard to use.
     entry.join
   end
 
-  def spec_authors entry, spec
+  def spec_authors(entry, spec)
     authors = "Author#{spec.authors.length > 1 ? 's' : ''}: ".dup
     authors << spec.authors.join(', ')
     entry << format_text(authors, 68, 4)
   end
 
-  def spec_homepage entry, spec
+  def spec_homepage(entry, spec)
     return if spec.homepage.nil? or spec.homepage.empty?
 
     entry << "\n" << format_text("Homepage: #{spec.homepage}", 68, 4)
   end
 
-  def spec_license entry, spec
+  def spec_license(entry, spec)
     return if spec.license.nil? or spec.license.empty?
 
     licenses = "License#{spec.licenses.length > 1 ? 's' : ''}: ".dup
@@ -311,7 +311,7 @@ is too hard to use.
     entry << "\n" << format_text(licenses, 68, 4)
   end
 
-  def spec_loaded_from entry, spec, specs
+  def spec_loaded_from(entry, spec, specs)
     return unless spec.loaded_from
 
     if specs.length == 1 then
@@ -328,7 +328,7 @@ is too hard to use.
     end
   end
 
-  def spec_platforms entry, platforms
+  def spec_platforms(entry, platforms)
     non_ruby = platforms.any? do |_, pls|
       pls.any? { |pl| pl != Gem::Platform::RUBY }
     end
@@ -351,7 +351,7 @@ is too hard to use.
     end
   end
 
-  def spec_summary entry, spec
+  def spec_summary(entry, spec)
     summary = truncate_text(spec.summary, "the summary for #{spec.full_name}")
     entry << "\n\n" << format_text(summary, 68, 4)
   end

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -308,7 +308,7 @@ By default, this RubyGems will install gem as:
     end
   end
 
-  def install_file file, dest_dir
+  def install_file(file, dest_dir)
     dest_file = File.join dest_dir, file
     dest_dir = File.dirname dest_file
     unless File.directory? dest_dir
@@ -484,13 +484,13 @@ By default, this RubyGems will install gem as:
     [lib_dir, bin_dir]
   end
 
-  def pem_files_in dir
+  def pem_files_in(dir)
     Dir.chdir dir do
       Dir[File.join('**', '*pem')]
     end
   end
 
-  def rb_files_in dir
+  def rb_files_in(dir)
     Dir.chdir dir do
       Dir[File.join('**', '*rb')]
     end
@@ -505,7 +505,7 @@ By default, this RubyGems will install gem as:
   end
 
   # for cleanup old bundler files
-  def template_files_in dir
+  def template_files_in(dir)
     Dir.chdir dir do
       (Dir[File.join('templates', '**', '{*,.*}')]).
         select{|f| !File.directory?(f)}
@@ -544,7 +544,7 @@ abort "#{deprecation_message}"
     end
   end
 
-  def remove_old_lib_files lib_dir
+  def remove_old_lib_files(lib_dir)
     lib_dirs = { File.join(lib_dir, 'rubygems') => 'lib/rubygems' }
     lib_dirs[File.join(lib_dir, 'bundler')] = 'bundler/lib/bundler' if Gem::USE_BUNDLER_FOR_GEMDEPS
     lib_dirs.each do |old_lib_dir, new_lib_dir|

--- a/lib/rubygems/commands/sources_command.rb
+++ b/lib/rubygems/commands/sources_command.rb
@@ -38,7 +38,7 @@ class Gem::Commands::SourcesCommand < Gem::Command
     add_proxy_option
   end
 
-  def add_source source_uri # :nodoc:
+  def add_source(source_uri) # :nodoc:
     check_rubygems_https source_uri
 
     source = Gem::Source.new source_uri
@@ -62,7 +62,7 @@ class Gem::Commands::SourcesCommand < Gem::Command
     end
   end
 
-  def check_rubygems_https source_uri # :nodoc:
+  def check_rubygems_https(source_uri) # :nodoc:
     uri = URI source_uri
 
     if uri.scheme and uri.scheme.downcase == 'http' and
@@ -175,7 +175,7 @@ To remove a source use the --remove argument:
     list if list?
   end
 
-  def remove_source source_uri # :nodoc:
+  def remove_source(source_uri) # :nodoc:
     unless Gem.sources.include? source_uri then
       say "source #{source_uri} not present in cache"
     else
@@ -195,7 +195,7 @@ To remove a source use the --remove argument:
     say "source cache successfully updated"
   end
 
-  def remove_cache_file desc, path # :nodoc:
+  def remove_cache_file(desc, path) # :nodoc:
     FileUtils.rm_rf path
 
     if not File.exist?(path) then

--- a/lib/rubygems/commands/unpack_command.rb
+++ b/lib/rubygems/commands/unpack_command.rb
@@ -152,7 +152,7 @@ command help for an example.
   # TODO: It just uses Gem.dir for now.  What's an easy way to get the list of
   # source directories?
 
-  def get_path dependency
+  def get_path(dependency)
     return dependency.name if dependency.name =~ /\.gem$/i
 
     specs = dependency.matching_specs
@@ -180,7 +180,7 @@ command help for an example.
   #--
   # TODO move to Gem::Package as #raw_spec or something
 
-  def get_metadata path, security_policy = nil
+  def get_metadata(path, security_policy = nil)
     format = Gem::Package.new path, security_policy
     spec = format.spec
 

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -68,7 +68,7 @@ command to remove old versions.
     "#{program_name} GEMNAME [GEMNAME ...]"
   end
 
-  def check_latest_rubygems version # :nodoc:
+  def check_latest_rubygems(version) # :nodoc:
     if Gem.rubygems_version == version then
       say "Latest version already installed. Done."
       terminate_interaction
@@ -119,7 +119,7 @@ command to remove old versions.
     end
   end
 
-  def fetch_remote_gems spec # :nodoc:
+  def fetch_remote_gems(spec) # :nodoc:
     dependency = Gem::Dependency.new spec.name, "> #{spec.version}"
     dependency.prerelease = options[:prerelease]
 
@@ -146,7 +146,7 @@ command to remove old versions.
     hig
   end
 
-  def highest_remote_version spec # :nodoc:
+  def highest_remote_version(spec) # :nodoc:
     spec_tuples = fetch_remote_gems spec
 
     matching_gems = spec_tuples.select do |g,_|
@@ -160,7 +160,7 @@ command to remove old versions.
     highest_remote_gem.first.version
   end
 
-  def install_rubygems version # :nodoc:
+  def install_rubygems(version) # :nodoc:
     args = update_rubygems_arguments
 
     update_dir = File.join Gem.dir, 'gems', "rubygems-update-#{version}"
@@ -205,7 +205,7 @@ command to remove old versions.
     return target, requirement
   end
 
-  def update_gem name, version = Gem::Requirement.default
+  def update_gem(name, version = Gem::Requirement.default)
     return if @updated.any? { |spec| spec.name == name }
 
     update_options = options.dup
@@ -225,7 +225,7 @@ command to remove old versions.
     end
   end
 
-  def update_gems gems_to_update
+  def update_gems(gems_to_update)
     gems_to_update.uniq.sort.each do |(name, version)|
       update_gem name, version
     end
@@ -264,7 +264,7 @@ command to remove old versions.
     args
   end
 
-  def which_to_update highest_installed_gems, gem_names, system = false
+  def which_to_update(highest_installed_gems, gem_names, system = false)
     result = []
 
     highest_installed_gems.each do |l_name, l_spec|

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -306,7 +306,7 @@ if you believe they were disclosed to a third party.
   ##
   # Sets the RubyGems.org API key to +api_key+
 
-  def rubygems_api_key= api_key
+  def rubygems_api_key=(api_key)
     set_api_key :rubygems_api_key, api_key
 
     @rubygems_api_key = api_key
@@ -315,7 +315,7 @@ if you believe they were disclosed to a third party.
   ##
   # Set a specific host's API key to +api_key+
 
-  def set_api_key host, api_key
+  def set_api_key(host, api_key)
     check_credentials_permissions
 
     config = load_file(credentials_path).merge(host => api_key)

--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -31,7 +31,7 @@ module Kernel
   # The normal <tt>require</tt> functionality of returning false if
   # that file has already been loaded is preserved.
 
-  def require path
+  def require(path)
     RUBYGEMS_ACTIVATION_MONITOR.enter
 
     path = path.to_path if path.respond_to? :to_path

--- a/lib/rubygems/defaults.rb
+++ b/lib/rubygems/defaults.rb
@@ -59,7 +59,7 @@ module Gem
   # By default, the binary extensions are located side by side with their
   # Ruby counterparts, therefore nil is returned
 
-  def self.default_ext_dir_for base_dir
+  def self.default_ext_dir_for(base_dir)
     nil
   end
 

--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -36,7 +36,7 @@ class Gem::Dependency
   # argument can optionally be the dependency type, which defaults to
   # <tt>:runtime</tt>.
 
-  def initialize name, *requirements
+  def initialize(name, *requirements)
     case name
     when String then # ok
     when Regexp then
@@ -100,7 +100,7 @@ class Gem::Dependency
     @requirement.none?
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 1, 'Gem::Dependency.new(', ')' do
       q.pp name
       q.text ','
@@ -170,7 +170,7 @@ class Gem::Dependency
     @type == :runtime || !@type
   end
 
-  def == other # :nodoc:
+  def ==(other) # :nodoc:
     Gem::Dependency === other &&
       self.name        == other.name &&
       self.type        == other.type &&
@@ -180,7 +180,7 @@ class Gem::Dependency
   ##
   # Dependencies are ordered by name.
 
-  def <=> other
+  def <=>(other)
     self.name <=> other.name
   end
 
@@ -190,7 +190,7 @@ class Gem::Dependency
   # other has only an equal version requirement that satisfies this
   # dependency.
 
-  def =~ other
+  def =~(other)
     unless Gem::Dependency === other
       return unless other.respond_to?(:name) && other.respond_to?(:version)
       other = Gem::Dependency.new other.name, other.version
@@ -222,7 +222,7 @@ class Gem::Dependency
   # NOTE:  Unlike #matches_spec? this method does not return true when the
   # version is a prerelease version unless this is a prerelease dependency.
 
-  def match? obj, version=nil, allow_prerelease=false
+  def match?(obj, version=nil, allow_prerelease=false)
     if !version
       name = obj.name
       version = obj.version
@@ -249,7 +249,7 @@ class Gem::Dependency
   # returns true when +spec+ is a prerelease version even if this dependency
   # is not a prerelease dependency.
 
-  def matches_spec? spec
+  def matches_spec?(spec)
     return false unless name === spec.name
     return true  if requirement.none?
 
@@ -259,7 +259,7 @@ class Gem::Dependency
   ##
   # Merges the requirements of +other+ into this dependency
 
-  def merge other
+  def merge(other)
     unless name == other.name then
       raise ArgumentError,
             "#{self} and #{other} have different names"
@@ -275,7 +275,7 @@ class Gem::Dependency
     self.class.new name, self_req.as_list.concat(other_req.as_list)
   end
 
-  def matching_specs platform_only = false
+  def matching_specs(platform_only = false)
     env_req = Gem.env_requirement(name)
     matches = Gem::Specification.stubs_for(name).find_all { |spec|
       requirement.satisfied_by?(spec.version) && env_req.satisfied_by?(spec.version)

--- a/lib/rubygems/dependency_installer.rb
+++ b/lib/rubygems/dependency_installer.rb
@@ -66,7 +66,7 @@ class Gem::DependencyInstaller
   # :wrappers:: See Gem::Installer::new
   # :build_args:: See Gem::Installer::new
 
-  def initialize options = {}
+  def initialize(options = {})
     @only_install_dir = !!options[:install_dir]
     @install_dir = options[:install_dir] || Gem.dir
     @build_root = options[:build_root]
@@ -110,7 +110,7 @@ class Gem::DependencyInstaller
   #--
   # TODO remove at RubyGems 4, no longer used
 
-  def add_found_dependencies to_do, dependency_list # :nodoc:
+  def add_found_dependencies(to_do, dependency_list) # :nodoc:
     seen = {}
     dependencies = Hash.new { |h, name| h[name] = Gem::Dependency.new name }
 
@@ -164,7 +164,7 @@ class Gem::DependencyInstaller
   # Creates an AvailableSet to install from based on +dep_or_name+ and
   # +version+
 
-  def available_set_for dep_or_name, version # :nodoc:
+  def available_set_for(dep_or_name, version) # :nodoc:
     if String === dep_or_name then
       find_spec_by_name_and_version dep_or_name, version, @prerelease
     else
@@ -198,7 +198,7 @@ class Gem::DependencyInstaller
   # sources.  Gems are sorted with newer gems preferred over older gems, and
   # local gems preferred over remote gems.
 
-  def find_gems_with_sources dep, best_only=false # :nodoc:
+  def find_gems_with_sources(dep, best_only=false) # :nodoc:
     set = Gem::AvailableSet.new
 
     if consider_local?
@@ -272,9 +272,9 @@ class Gem::DependencyInstaller
   # +version+.  Returns an Array of specs and sources required for
   # installation of the gem.
 
-  def find_spec_by_name_and_version gem_name,
+  def find_spec_by_name_and_version(gem_name,
                                     version = Gem::Requirement.default,
-                                    prerelease = false
+                                    prerelease = false)
     set = Gem::AvailableSet.new
 
     if consider_local?
@@ -352,7 +352,7 @@ class Gem::DependencyInstaller
   end
   deprecate :gather_dependencies, :none, 2018, 12
 
-  def in_background what # :nodoc:
+  def in_background(what) # :nodoc:
     fork_happened = false
     if @build_docs_in_background and Process.respond_to?(:fork)
       begin
@@ -381,7 +381,7 @@ class Gem::DependencyInstaller
   # c-1.a, b-1 and a-1.a will be installed.  b-1.a will need to be installed
   # separately.
 
-  def install dep_or_name, version = Gem::Requirement.default
+  def install(dep_or_name, version = Gem::Requirement.default)
     request_set = resolve_dependencies dep_or_name, version
 
     @installed_gems = []
@@ -434,7 +434,7 @@ class Gem::DependencyInstaller
     end
   end
 
-  def resolve_dependencies dep_or_name, version # :nodoc:
+  def resolve_dependencies(dep_or_name, version) # :nodoc:
     request_set = Gem::RequestSet.new
     request_set.development         = @development
     request_set.development_shallow = @dev_shallow

--- a/lib/rubygems/dependency_list.rb
+++ b/lib/rubygems/dependency_list.rb
@@ -40,7 +40,7 @@ class Gem::DependencyList
   # Creates a new DependencyList.  If +development+ is true, development
   # dependencies will be included.
 
-  def initialize development = false
+  def initialize(development = false)
     @specs = []
 
     @development = development
@@ -114,7 +114,7 @@ class Gem::DependencyList
     why_not_ok?(:quick).empty?
   end
 
-  def why_not_ok? quick = false
+  def why_not_ok?(quick = false)
     unsatisfied = Hash.new { |h,k| h[k] = [] }
     each do |spec|
       spec.runtime_dependencies.each do |dep|
@@ -172,7 +172,7 @@ class Gem::DependencyList
   # satisfy items in +dependencies+ (a hash of gem names to arrays of
   # dependencies).
 
-  def remove_specs_unsatisfied_by dependencies
+  def remove_specs_unsatisfied_by(dependencies)
     specs.reject! { |spec|
       dep = dependencies[spec.name]
       dep and not dep.requirement.satisfied_by? spec.version

--- a/lib/rubygems/deprecate.rb
+++ b/lib/rubygems/deprecate.rb
@@ -27,7 +27,7 @@ module Gem::Deprecate
     @skip ||= false
   end
 
-  def self.skip= v # :nodoc:
+  def self.skip=(v) # :nodoc:
     @skip = v
   end
 
@@ -47,7 +47,7 @@ module Gem::Deprecate
   # telling the user of +repl+ (unless +repl+ is :none) and the
   # year/month that it is planned to go away.
 
-  def deprecate name, repl, year, month
+  def deprecate(name, repl, year, month)
     class_eval {
       old = "_deprecated_#{name}"
       alias_method old, name

--- a/lib/rubygems/doctor.rb
+++ b/lib/rubygems/doctor.rb
@@ -41,7 +41,7 @@ class Gem::Doctor
   #
   # If +dry_run+ is true no files or directories will be removed.
 
-  def initialize gem_repository, dry_run = false
+  def initialize(gem_repository, dry_run = false)
     @gem_repository = gem_repository
     @dry_run        = dry_run
 
@@ -99,7 +99,7 @@ class Gem::Doctor
   ##
   # Removes files in +sub_directory+ with +extension+
 
-  def doctor_child sub_directory, extension # :nodoc:
+  def doctor_child(sub_directory, extension) # :nodoc:
     directory = File.join(@gem_repository, sub_directory)
 
     Dir.entries(directory).sort.each do |ent|

--- a/lib/rubygems/errors.rb
+++ b/lib/rubygems/errors.rb
@@ -25,7 +25,7 @@ module Gem
   # system.  Instead of rescuing from this class, make sure to rescue from the
   # superclass Gem::LoadError to catch all types of load errors.
   class MissingSpecError < Gem::LoadError
-    def initialize name, requirement
+    def initialize(name, requirement)
       @name        = name
       @requirement = requirement
     end
@@ -50,7 +50,7 @@ module Gem
   class MissingSpecVersionError < MissingSpecError
     attr_reader :specs
 
-    def initialize name, requirement, specs
+    def initialize(name, requirement, specs)
       super(name, requirement)
       @specs = specs
     end
@@ -81,7 +81,7 @@ module Gem
 
     attr_reader :target
 
-    def initialize target, conflicts
+    def initialize(target, conflicts)
       @target    = target
       @conflicts = conflicts
       @name      = target.name

--- a/lib/rubygems/exceptions.rb
+++ b/lib/rubygems/exceptions.rb
@@ -36,7 +36,7 @@ class Gem::DependencyResolutionError < Gem::DependencyError
 
   attr_reader :conflict
 
-  def initialize conflict
+  def initialize(conflict)
     @conflict = conflict
     a, b = conflicting_dependencies
 
@@ -77,7 +77,7 @@ class Gem::FilePermissionError < Gem::Exception
 
   attr_reader :directory
 
-  def initialize directory
+  def initialize(directory)
     @directory = directory
 
     super "You don't have write permissions for the #{directory} directory."
@@ -137,7 +137,7 @@ class Gem::ImpossibleDependenciesError < Gem::Exception
   attr_reader :conflicts
   attr_reader :request
 
-  def initialize request, conflicts
+  def initialize(request, conflicts)
     @request   = request
     @conflicts = conflicts
 
@@ -249,7 +249,7 @@ class Gem::UnsatisfiableDependencyError < Gem::DependencyError
   # Creates a new UnsatisfiableDependencyError for the unsatisfiable
   # Gem::Resolver::DependencyRequest +dep+
 
-  def initialize dep, platform_mismatch=nil
+  def initialize(dep, platform_mismatch=nil)
     if platform_mismatch and !platform_mismatch.empty?
       plats = platform_mismatch.map { |x| x.platform.to_s }.sort.uniq
       super "Unable to resolve dependency: No match for '#{dep}' on this platform. Found: #{plats.join(', ')}"

--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -105,7 +105,7 @@ class Gem::Ext::Builder
   # have build arguments, saved, set +build_args+ which is an ARGV-style
   # array.
 
-  def initialize spec, build_args = spec.build_args
+  def initialize(spec, build_args = spec.build_args)
     @spec       = spec
     @build_args = build_args
     @gem_dir    = spec.full_gem_path
@@ -116,7 +116,7 @@ class Gem::Ext::Builder
   ##
   # Chooses the extension builder class for +extension+
 
-  def builder_for extension # :nodoc:
+  def builder_for(extension) # :nodoc:
     case extension
     when /extconf/ then
       Gem::Ext::ExtConfBuilder
@@ -138,7 +138,7 @@ class Gem::Ext::Builder
   ##
   # Logs the build +output+ in +build_dir+, then raises Gem::Ext::BuildError.
 
-  def build_error build_dir, output, backtrace = nil # :nodoc:
+  def build_error(build_dir, output, backtrace = nil) # :nodoc:
     gem_make_out = write_gem_make_out output
 
     message = <<-EOF
@@ -153,7 +153,7 @@ EOF
     raise Gem::Ext::BuildError, message, backtrace
   end
 
-  def build_extension extension, dest_path # :nodoc:
+  def build_extension(extension, dest_path) # :nodoc:
     results = []
 
     # FIXME: Determine if this line is necessary and, if so, why.
@@ -235,7 +235,7 @@ EOF
   ##
   # Writes +output+ to gem_make.out in the extension install directory.
 
-  def write_gem_make_out output # :nodoc:
+  def write_gem_make_out(output) # :nodoc:
     destination = File.join @spec.extension_dir, 'gem_make.out'
 
     FileUtils.mkdir_p @spec.extension_dir

--- a/lib/rubygems/gem_runner.rb
+++ b/lib/rubygems/gem_runner.rb
@@ -38,7 +38,7 @@ class Gem::GemRunner
   ##
   # Run the gem command with the following arguments.
 
-  def run args
+  def run(args)
     build_args = extract_build_args args
 
     do_configuration args
@@ -63,7 +63,7 @@ class Gem::GemRunner
   # Separates the build arguments (those following <code>--</code>) from the
   # other arguments in the list.
 
-  def extract_build_args args # :nodoc:
+  def extract_build_args(args) # :nodoc:
     return [] unless offset = args.index('--')
 
     build_args = args.slice!(offset...args.length)

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -90,7 +90,7 @@ module Gem::GemcutterUtilities
   # Signs in with the RubyGems API at +sign_in_host+ and sets the rubygems API
   # key.
 
-  def sign_in sign_in_host = nil
+  def sign_in(sign_in_host = nil)
     sign_in_host ||= self.host
     return if api_key
 
@@ -139,7 +139,7 @@ module Gem::GemcutterUtilities
   # If the response was not successful, shows an error to the user including
   # the +error_prefix+ and the response body.
 
-  def with_response response, error_prefix = nil
+  def with_response(response, error_prefix = nil)
     case response
     when Net::HTTPSuccess then
       if block_given? then
@@ -156,7 +156,7 @@ module Gem::GemcutterUtilities
     end
   end
 
-  def set_api_key host, key
+  def set_api_key(host, key)
     if host == Gem::DEFAULT_HOST
       Gem.configuration.rubygems_api_key = key
     else

--- a/lib/rubygems/indexer.rb
+++ b/lib/rubygems/indexer.rb
@@ -109,7 +109,7 @@ class Gem::Indexer
   ##
   # Builds Marshal quick index gemspecs.
 
-  def build_marshal_gemspecs specs
+  def build_marshal_gemspecs(specs)
     count = specs.count
     progress = ui.progress_reporter count,
                                     "Generating Marshal quick index gemspecs for #{count} gems",
@@ -172,7 +172,7 @@ class Gem::Indexer
   ##
   # Builds indices for RubyGems 1.2 and newer. Handles full, latest, prerelease
 
-  def build_modern_indices specs
+  def build_modern_indices(specs)
     prerelease, released = specs.partition { |s|
       s.version.prerelease?
     }
@@ -192,7 +192,7 @@ class Gem::Indexer
                "#{@prerelease_specs_index}.gz"]
   end
 
-  def map_gems_to_specs gems
+  def map_gems_to_specs(gems)
     gems.map { |gemfile|
       if File.size(gemfile) == 0 then
         alert_warning "Skipping zero-length gem: #{gemfile}"

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -101,7 +101,7 @@ class Gem::Installer
   ##
   # Construct an installer object for the gem file located at +path+
 
-  def self.at path, options = {}
+  def self.at(path, options = {})
     security_policy = options[:security_policy]
     package = Gem::Package.new path, security_policy
     new package, options
@@ -118,7 +118,7 @@ class Gem::Installer
       @spec = spec
     end
 
-    def extract_files destination_dir, pattern = '*'
+    def extract_files(destination_dir, pattern = '*')
       FileUtils.mkdir_p destination_dir
 
       spec.files.each do |file|
@@ -129,7 +129,7 @@ class Gem::Installer
       end
     end
 
-    def copy_to path
+    def copy_to(path)
     end
   end
 
@@ -137,7 +137,7 @@ class Gem::Installer
   # Construct an installer object for an ephemeral gem (one where we don't
   # actually have a .gem file, just a spec)
 
-  def self.for_spec spec, options = {}
+  def self.for_spec(spec, options = {})
     # FIXME: we should have a real Package class for this
     new FakePackage.new(spec), options
   end
@@ -209,7 +209,7 @@ class Gem::Installer
   #
   # Otherwise +filename+ is overwritten.
 
-  def check_executable_overwrite filename # :nodoc:
+  def check_executable_overwrite(filename) # :nodoc:
     return if @force
 
     generated_bin = File.join @bin_dir, formatted_program_filename(filename)

--- a/lib/rubygems/mock_gem_ui.rb
+++ b/lib/rubygems/mock_gem_ui.rb
@@ -12,7 +12,7 @@ class Gem::MockGemUi < Gem::StreamUI
 
   class InputEOFError < RuntimeError
 
-    def initialize question
+    def initialize(question)
       super "Out of input for MockGemUi on #{question.inspect}"
     end
 
@@ -21,7 +21,7 @@ class Gem::MockGemUi < Gem::StreamUI
   class TermError < RuntimeError
     attr_reader :exit_code
 
-    def initialize exit_code
+    def initialize(exit_code)
       super
       @exit_code = exit_code
     end
@@ -56,7 +56,7 @@ class Gem::MockGemUi < Gem::StreamUI
     @terminated = false
   end
 
-  def ask question
+  def ask(question)
     raise InputEOFError, question if @ins.eof?
 
     super

--- a/lib/rubygems/name_tuple.rb
+++ b/lib/rubygems/name_tuple.rb
@@ -24,7 +24,7 @@ class Gem::NameTuple
   # Turn an array of [name, version, platform] into an array of
   # NameTuple objects.
 
-  def self.from_list list
+  def self.from_list(list)
     list.map { |t| new(*t) }
   end
 
@@ -32,7 +32,7 @@ class Gem::NameTuple
   # Turn an array of NameTuple objects back into an array of
   # [name, version, platform] tuples.
 
-  def self.to_basic list
+  def self.to_basic(list)
     list.map { |t| t.to_a }
   end
 
@@ -90,7 +90,7 @@ class Gem::NameTuple
 
   alias to_s inspect # :nodoc:
 
-  def <=> other
+  def <=>(other)
     [@name, @version, @platform == Gem::Platform::RUBY ? -1 : 1] <=>
       [other.name, other.version,
        other.platform == Gem::Platform::RUBY ? -1 : 1]
@@ -102,7 +102,7 @@ class Gem::NameTuple
   # Compare with +other+. Supports another NameTuple or an Array
   # in the [name, version, platform] format.
 
-  def == other
+  def ==(other)
     case other
     when self.class
       @name == other.name and

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -55,7 +55,7 @@ class Gem::Package
   class FormatError < Error
     attr_reader :path
 
-    def initialize message, source = nil
+    def initialize(message, source = nil)
       if source
         @path = source.path
 
@@ -68,7 +68,7 @@ class Gem::Package
   end
 
   class PathError < Error
-    def initialize destination, destination_dir
+    def initialize(destination, destination_dir)
       super "installing into parent path %s of %s is not allowed" %
               [destination, destination_dir]
     end
@@ -119,7 +119,7 @@ class Gem::Package
   # Permission for other files
   attr_accessor :data_mode
 
-  def self.build spec, skip_validation = false, strict_validation = false
+  def self.build(spec, skip_validation = false, strict_validation = false)
     gem_file = spec.file_name
 
     package = new gem_file
@@ -136,7 +136,7 @@ class Gem::Package
   # If +gem+ is an existing file in the old format a Gem::Package::Old will be
   # returned.
 
-  def self.new gem, security_policy = nil
+  def self.new(gem, security_policy = nil)
     gem = if gem.is_a?(Gem::Package::Source)
             gem
           elsif gem.respond_to? :read
@@ -157,7 +157,7 @@ class Gem::Package
   ##
   # Creates a new package that will read or write to the file +gem+.
 
-  def initialize gem, security_policy # :notnew:
+  def initialize(gem, security_policy) # :notnew:
     @gem = gem
 
     @build_time      = ENV["SOURCE_DATE_EPOCH"] ? Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc : Time.now
@@ -174,14 +174,14 @@ class Gem::Package
   ##
   # Copies this package to +path+ (if possible)
 
-  def copy_to path
+  def copy_to(path)
     FileUtils.cp @gem.path, path unless File.exist? path
   end
 
   ##
   # Adds a checksum for each entry in the gem to checksums.yaml.gz.
 
-  def add_checksums tar
+  def add_checksums(tar)
     Gem.load_yaml
 
     checksums_by_algorithm = Hash.new { |h, algorithm| h[algorithm] = {} }
@@ -203,7 +203,7 @@ class Gem::Package
   # Adds the files listed in the packages's Gem::Specification to data.tar.gz
   # and adds this file to the +tar+.
 
-  def add_contents tar # :nodoc:
+  def add_contents(tar) # :nodoc:
     digests = tar.add_file_signed 'data.tar.gz', 0444, @signer do |io|
       gzip_to io do |gz_io|
         Gem::Package::TarWriter.new gz_io do |data_tar|
@@ -218,7 +218,7 @@ class Gem::Package
   ##
   # Adds files included the package's Gem::Specification to the +tar+ file
 
-  def add_files tar # :nodoc:
+  def add_files(tar) # :nodoc:
     @spec.files.each do |file|
       stat = File.lstat file
 
@@ -241,7 +241,7 @@ class Gem::Package
   ##
   # Adds the package's Gem::Specification to the +tar+ file
 
-  def add_metadata tar # :nodoc:
+  def add_metadata(tar) # :nodoc:
     digests = tar.add_file_signed 'metadata.gz', 0444, @signer do |io|
       gzip_to io do |gz_io|
         gz_io.write @spec.to_yaml
@@ -254,7 +254,7 @@ class Gem::Package
   ##
   # Builds this package based on the specification set by #spec=
 
-  def build skip_validation = false, strict_validation = false
+  def build(skip_validation = false, strict_validation = false)
     raise ArgumentError, "skip_validation = true and strict_validation = true are incompatible" if skip_validation && strict_validation
 
     Gem.load_yaml
@@ -318,7 +318,7 @@ EOM
   # Creates a digest of the TarEntry +entry+ from the digest algorithm set by
   # the security policy.
 
-  def digest entry # :nodoc:
+  def digest(entry) # :nodoc:
     algorithms = if @checksums then
                    @checksums.keys
                  else
@@ -349,7 +349,7 @@ EOM
   # If +pattern+ is specified, only entries matching that glob will be
   # extracted.
 
-  def extract_files destination_dir, pattern = "*"
+  def extract_files(destination_dir, pattern = "*")
     verify unless @spec
 
     FileUtils.mkdir_p destination_dir, :mode => dir_mode && 0700
@@ -378,7 +378,7 @@ EOM
   # If +pattern+ is specified, only entries matching that glob will be
   # extracted.
 
-  def extract_tar_gz io, destination_dir, pattern = "*" # :nodoc:
+  def extract_tar_gz(io, destination_dir, pattern = "*") # :nodoc:
     directories = [] if dir_mode
     open_tar_gz io do |tar|
       tar.each do |entry|
@@ -427,7 +427,7 @@ EOM
   # Also sets the gzip modification time to the package build time to ease
   # testing.
 
-  def gzip_to io # :yields: gz_io
+  def gzip_to(io) # :yields: gz_io
     gz_io = Zlib::GzipWriter.new io, Zlib::BEST_COMPRESSION
     gz_io.mtime = @build_time
 
@@ -441,7 +441,7 @@ EOM
   #
   # If +filename+ is not inside +destination_dir+ an exception is raised.
 
-  def install_location filename, destination_dir # :nodoc:
+  def install_location(filename, destination_dir) # :nodoc:
     raise Gem::Package::PathError.new(filename, destination_dir) if
       filename.start_with? '/'
 
@@ -463,7 +463,7 @@ EOM
     end
   end
 
-  def mkdir_p_safe mkdir, mkdir_options, destination_dir, file_name
+  def mkdir_p_safe(mkdir, mkdir_options, destination_dir, file_name)
     destination_dir = File.realpath(File.expand_path(destination_dir))
     parts = mkdir.split(File::SEPARATOR)
     parts.reduce do |path, basename|
@@ -482,7 +482,7 @@ EOM
   ##
   # Loads a Gem::Specification from the TarEntry +entry+
 
-  def load_spec entry # :nodoc:
+  def load_spec(entry) # :nodoc:
     case entry.full_name
     when 'metadata' then
       @spec = Gem::Specification.from_yaml entry.read
@@ -500,7 +500,7 @@ EOM
   ##
   # Opens +io+ as a gzipped tar archive
 
-  def open_tar_gz io # :nodoc:
+  def open_tar_gz(io) # :nodoc:
     Zlib::GzipReader.wrap io do |gzio|
       tar = Gem::Package::TarReader.new gzio
 
@@ -511,7 +511,7 @@ EOM
   ##
   # Reads and loads checksums.yaml.gz from the tar file +gem+
 
-  def read_checksums gem
+  def read_checksums(gem)
     Gem.load_yaml
 
     @checksums = gem.seek 'checksums.yaml.gz' do |entry|
@@ -600,7 +600,7 @@ EOM
   # Verifies the +checksums+ against the +digests+.  This check is not
   # cryptographically secure.  Missing checksums are ignored.
 
-  def verify_checksums digests, checksums # :nodoc:
+  def verify_checksums(digests, checksums) # :nodoc:
     return unless checksums
 
     checksums.sort.each do |algorithm, gem_digests|
@@ -618,7 +618,7 @@ EOM
   ##
   # Verifies +entry+ in a .gem file.
 
-  def verify_entry entry
+  def verify_entry(entry)
     file_name = entry.full_name
     @files << file_name
 
@@ -645,7 +645,7 @@ EOM
   ##
   # Verifies the files of the +gem+
 
-  def verify_files gem
+  def verify_files(gem)
     gem.each do |entry|
       verify_entry entry
     end
@@ -667,7 +667,7 @@ EOM
   ##
   # Verifies that +entry+ is a valid gzipped file.
 
-  def verify_gz entry # :nodoc:
+  def verify_gz(entry) # :nodoc:
     Zlib::GzipReader.wrap entry do |gzio|
       gzio.read 16384 until gzio.eof? # gzip checksum verification
     end

--- a/lib/rubygems/package/digest_io.rb
+++ b/lib/rubygems/package/digest_io.rb
@@ -31,7 +31,7 @@ class Gem::Package::DigestIO
   #   digests['SHA1'].hexdigest   #=> "aaf4c61d[...]"
   #   digests['SHA512'].hexdigest #=> "9b71d224[...]"
 
-  def self.wrap io, digests
+  def self.wrap(io, digests)
     digest_io = new io, digests
 
     yield digest_io
@@ -43,7 +43,7 @@ class Gem::Package::DigestIO
   # Creates a new DigestIO instance.  Using ::wrap is recommended, see the
   # ::wrap documentation for documentation of +io+ and +digests+.
 
-  def initialize io, digests
+  def initialize(io, digests)
     @io = io
     @digests = digests
   end
@@ -51,7 +51,7 @@ class Gem::Package::DigestIO
   ##
   # Writes +data+ to the underlying IO and updates the digests
 
-  def write data
+  def write(data)
     result = @io.write data
 
     @digests.each do |_, digest|

--- a/lib/rubygems/package/file_source.rb
+++ b/lib/rubygems/package/file_source.rb
@@ -10,7 +10,7 @@ class Gem::Package::FileSource < Gem::Package::Source # :nodoc: all
 
   attr_reader :path
 
-  def initialize path
+  def initialize(path)
     @path = path
   end
 
@@ -22,11 +22,11 @@ class Gem::Package::FileSource < Gem::Package::Source # :nodoc: all
     File.exist? path
   end
 
-  def with_write_io &block
+  def with_write_io(&block)
     File.open path, 'wb', &block
   end
 
-  def with_read_io &block
+  def with_read_io(&block)
     File.open path, 'rb', &block
   end
 

--- a/lib/rubygems/package/io_source.rb
+++ b/lib/rubygems/package/io_source.rb
@@ -11,7 +11,7 @@ class Gem::Package::IOSource < Gem::Package::Source # :nodoc: all
 
   attr_reader :io
 
-  def initialize io
+  def initialize(io)
     @io = io
   end
 

--- a/lib/rubygems/package/old.rb
+++ b/lib/rubygems/package/old.rb
@@ -19,7 +19,7 @@ class Gem::Package::Old < Gem::Package
   # Creates a new old-format package reader for +gem+.  Old-format packages
   # cannot be written.
 
-  def initialize gem, security_policy
+  def initialize(gem, security_policy)
     require 'fileutils'
     require 'zlib'
     Gem.load_yaml
@@ -49,7 +49,7 @@ class Gem::Package::Old < Gem::Package
   ##
   # Extracts the files in this package into +destination_dir+
 
-  def extract_files destination_dir
+  def extract_files(destination_dir)
     verify
 
     errstr = "Error reading files from gem"
@@ -94,7 +94,7 @@ class Gem::Package::Old < Gem::Package
   ##
   # Reads the file list section from the old-format gem +io+
 
-  def file_list io # :nodoc:
+  def file_list(io) # :nodoc:
     header = String.new
 
     read_until_dashes io do |line|
@@ -107,7 +107,7 @@ class Gem::Package::Old < Gem::Package
   ##
   # Reads lines until a "---" separator is found
 
-  def read_until_dashes io # :nodoc:
+  def read_until_dashes(io) # :nodoc:
     while (line = io.gets) && line.chomp.strip != "---" do
       yield line if block_given?
     end
@@ -116,7 +116,7 @@ class Gem::Package::Old < Gem::Package
   ##
   # Skips the Ruby self-install header in +io+.
 
-  def skip_ruby io # :nodoc:
+  def skip_ruby(io) # :nodoc:
     loop do
       line = io.gets
 

--- a/lib/rubygems/package/tar_reader.rb
+++ b/lib/rubygems/package/tar_reader.rb
@@ -104,7 +104,7 @@ class Gem::Package::TarReader
   # yields it.  Rewinds the tar file to the beginning when the block
   # terminates.
 
-  def seek name # :yields: entry
+  def seek(name) # :yields: entry
     found = find do |entry|
       entry.full_name == name
     end

--- a/lib/rubygems/package/tar_writer.rb
+++ b/lib/rubygems/package/tar_writer.rb
@@ -139,7 +139,7 @@ class Gem::Package::TarWriter
   #
   # The created digest object is returned.
 
-  def add_file_digest name, mode, digest_algorithms # :yields: io
+  def add_file_digest(name, mode, digest_algorithms) # :yields: io
     digests = digest_algorithms.map do |digest_algorithm|
       digest = digest_algorithm.new
       digest_name =
@@ -172,7 +172,7 @@ class Gem::Package::TarWriter
   #
   # Returns the digest.
 
-  def add_file_signed name, mode, signer
+  def add_file_signed(name, mode, signer)
     digest_algorithms = [
       signer.digest_algorithm,
       Digest::SHA512,

--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -43,7 +43,7 @@ class Gem::PathSupport
   ##
   # Split the Gem search path (as reported by Gem.path).
 
-  def split_gem_path gpaths, home
+  def split_gem_path(gpaths, home)
     # FIX: it should be [home, *path], not [*path, home]
 
     gem_path = []

--- a/lib/rubygems/psych_tree.rb
+++ b/lib/rubygems/psych_tree.rb
@@ -18,7 +18,7 @@ module Gem
       end
 
       # This is ported over from the yaml_tree in 1.9.3
-      def format_time time
+      def format_time(time)
         if time.utc?
           time.strftime("%Y-%m-%d %H:%M:%S.%9N Z")
         else

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -97,7 +97,7 @@ class Gem::RemoteFetcher
   # Should probably be integrated with #download below, but that will be a
   # larger, more encompassing effort. -erikh
 
-  def download_to_cache dependency
+  def download_to_cache(dependency)
     found, _ = Gem::SpecFetcher.fetcher.spec_for_dependency dependency
 
     return if found.empty?
@@ -209,14 +209,14 @@ class Gem::RemoteFetcher
   ##
   # File Fetcher. Dispatched by +fetch_path+. Use it instead.
 
-  def fetch_file uri, *_
+  def fetch_file(uri, *_)
     Gem.read_binary correct_for_windows_path uri.path
   end
 
   ##
   # HTTP Fetcher. Dispatched by +fetch_path+. Use it instead.
 
-  def fetch_http uri, last_modified = nil, head = false, depth = 0
+  def fetch_http(uri, last_modified = nil, head = false, depth = 0)
     fetch_type = head ? Net::HTTP::Head : Net::HTTP::Get
     response   = request uri, fetch_type, last_modified do |req|
       headers.each { |k,v| req.add_field(k,v) }
@@ -291,7 +291,7 @@ class Gem::RemoteFetcher
   # Downloads +uri+ to +path+ if necessary. If no path is given, it just
   # passes the data.
 
-  def cache_update_path uri, path = nil, update = true
+  def cache_update_path(uri, path = nil, update = true)
     mtime = path && File.stat(path).mtime rescue nil
 
     data = fetch_path(uri, mtime)
@@ -375,11 +375,11 @@ class Gem::RemoteFetcher
 
   private
 
-  def proxy_for proxy, uri
+  def proxy_for(proxy, uri)
     Gem::Request.proxy_uri(proxy || Gem::Request.get_proxy_from_env(uri.scheme))
   end
 
-  def pools_for proxy
+  def pools_for(proxy)
     @pool_lock.synchronize do
       @pools[proxy] ||= Gem::Request::ConnectionPools.new proxy, @cert_files
     end

--- a/lib/rubygems/request.rb
+++ b/lib/rubygems/request.rb
@@ -10,7 +10,7 @@ class Gem::Request
 
   ###
   # Legacy.  This is used in tests.
-  def self.create_with_proxy uri, request_class, last_modified, proxy # :nodoc:
+  def self.create_with_proxy(uri, request_class, last_modified, proxy) # :nodoc:
     cert_files = get_cert_files
     proxy ||= get_proxy_from_env(uri.scheme)
     pool       = ConnectionPools.new proxy_uri(proxy), cert_files
@@ -18,7 +18,7 @@ class Gem::Request
     new(uri, request_class, last_modified, pool.pool_for(uri))
   end
 
-  def self.proxy_uri proxy # :nodoc:
+  def self.proxy_uri(proxy) # :nodoc:
     case proxy
     when :no_proxy then nil
     when URI::HTTP then proxy
@@ -85,7 +85,7 @@ class Gem::Request
             'Unable to require openssl, install OpenSSL and rebuild Ruby (preferred) or use non-HTTPS sources')
   end
 
-  def self.verify_certificate store_context
+  def self.verify_certificate(store_context)
     depth  = store_context.error_depth
     error  = store_context.error_string
     number = store_context.error
@@ -98,7 +98,7 @@ class Gem::Request
     ui.alert_error extra_message if extra_message
   end
 
-  def self.verify_certificate_message error_number, cert
+  def self.verify_certificate_message(error_number, cert)
     return unless cert
     case error_number
     when OpenSSL::X509::V_ERR_CERT_HAS_EXPIRED then
@@ -161,7 +161,7 @@ class Gem::Request
   # Returns a proxy URI for the given +scheme+ if one is set in the
   # environment variables.
 
-  def self.get_proxy_from_env scheme = 'http'
+  def self.get_proxy_from_env(scheme = 'http')
     _scheme = scheme.downcase
     _SCHEME = scheme.upcase
     env_proxy = ENV["#{_scheme}_proxy"] || ENV["#{_SCHEME}_PROXY"]
@@ -184,7 +184,7 @@ class Gem::Request
     uri
   end
 
-  def perform_request request # :nodoc:
+  def perform_request(request) # :nodoc:
     connection = connection_for @uri
 
     retried = false

--- a/lib/rubygems/request/connection_pools.rb
+++ b/lib/rubygems/request/connection_pools.rb
@@ -8,14 +8,14 @@ class Gem::Request::ConnectionPools # :nodoc:
     attr_accessor :client
   end
 
-  def initialize proxy_uri, cert_files
+  def initialize(proxy_uri, cert_files)
     @proxy_uri  = proxy_uri
     @cert_files = cert_files
     @pools      = {}
     @pool_mutex = Mutex.new
   end
 
-  def pool_for uri
+  def pool_for(uri)
     http_args = net_http_args(uri, @proxy_uri)
     key       = http_args + [https?(uri)]
     @pool_mutex.synchronize do
@@ -45,11 +45,11 @@ class Gem::Request::ConnectionPools # :nodoc:
     env_no_proxy.split(/\s*,\s*/)
   end
 
-  def https? uri
+  def https?(uri)
     uri.scheme.downcase == 'https'
   end
 
-  def no_proxy? host, env_no_proxy
+  def no_proxy?(host, env_no_proxy)
     host = host.downcase
 
     env_no_proxy.any? do |pattern|
@@ -73,7 +73,7 @@ class Gem::Request::ConnectionPools # :nodoc:
     end
   end
 
-  def net_http_args uri, proxy_uri
+  def net_http_args(uri, proxy_uri)
     # URI::Generic#hostname was added in ruby 1.9.3, use it if exists, otherwise
     # don't support IPv6 literals and use host.
     hostname = uri.respond_to?(:hostname) ? uri.hostname : uri.host

--- a/lib/rubygems/request/http_pool.rb
+++ b/lib/rubygems/request/http_pool.rb
@@ -8,7 +8,7 @@
 class Gem::Request::HTTPPool # :nodoc:
   attr_reader :cert_files, :proxy_uri
 
-  def initialize http_args, cert_files, proxy_uri
+  def initialize(http_args, cert_files, proxy_uri)
     @http_args  = http_args
     @cert_files = cert_files
     @proxy_uri  = proxy_uri
@@ -20,7 +20,7 @@ class Gem::Request::HTTPPool # :nodoc:
     @queue.pop || make_connection
   end
 
-  def checkin connection
+  def checkin(connection)
     @queue.push connection
   end
 
@@ -39,7 +39,7 @@ class Gem::Request::HTTPPool # :nodoc:
     setup_connection Gem::Request::ConnectionPools.client.new(*@http_args)
   end
 
-  def setup_connection connection
+  def setup_connection(connection)
     connection.start
     connection
   end

--- a/lib/rubygems/request/https_pool.rb
+++ b/lib/rubygems/request/https_pool.rb
@@ -2,7 +2,7 @@
 class Gem::Request::HTTPSPool < Gem::Request::HTTPPool # :nodoc:
   private
 
-  def setup_connection connection
+  def setup_connection(connection)
     Gem::Request.configure_connection_for_https(connection, @cert_files)
     super
   end

--- a/lib/rubygems/request_set.rb
+++ b/lib/rubygems/request_set.rb
@@ -91,7 +91,7 @@ class Gem::RequestSet
   #
   #   set = Gem::RequestSet.new nokogiri, pg
 
-  def initialize *deps
+  def initialize(*deps)
     @dependencies = deps
 
     @always_install      = []
@@ -119,7 +119,7 @@ class Gem::RequestSet
   ##
   # Declare that a gem of name +name+ with +reqs+ requirements is needed.
 
-  def gem name, *reqs
+  def gem(name, *reqs)
     if dep = @dependency_names[name] then
       dep.requirement.concat reqs
     else
@@ -132,7 +132,7 @@ class Gem::RequestSet
   ##
   # Add +deps+ Gem::Dependency objects to the set.
 
-  def import deps
+  def import(deps)
     @dependencies.concat deps
   end
 
@@ -143,7 +143,7 @@ class Gem::RequestSet
   # The +installer+ will be +nil+ if a gem matching the request was already
   # installed.
 
-  def install options, &block # :yields: request, installer
+  def install(options, &block) # :yields: request, installer
     if dir = options[:install_dir]
       requests = install_into dir, false, options, &block
       return requests
@@ -230,7 +230,7 @@ class Gem::RequestSet
   # If +:without_groups+ is given in the +options+, those groups in the gem
   # dependencies file are not used.  See Gem::Installer for other +options+.
 
-  def install_from_gemdeps options, &block
+  def install_from_gemdeps(options, &block)
     gemdeps = options[:gemdeps]
 
     @install_dir = options[:install_dir] || Gem.dir
@@ -265,7 +265,7 @@ class Gem::RequestSet
     end
   end
 
-  def install_into dir, force = true, options = {}
+  def install_into(dir, force = true, options = {})
     gem_home, ENV['GEM_HOME'] = ENV['GEM_HOME'], dir
 
     existing = force ? [] : specs_in(dir)
@@ -305,7 +305,7 @@ class Gem::RequestSet
   ##
   # Call hooks on installed gems
 
-  def install_hooks requests, options
+  def install_hooks(requests, options)
     specs = requests.map do |request|
       case request
       when Gem::Resolver::ActivationRequest then
@@ -327,7 +327,7 @@ class Gem::RequestSet
   ##
   # Load a dependency management file.
 
-  def load_gemdeps path, without_groups = [], installing = false
+  def load_gemdeps(path, without_groups = [], installing = false)
     @git_set    = Gem::Resolver::GitSet.new
     @vendor_set = Gem::Resolver::VendorSet.new
     @source_set = Gem::Resolver::SourceSet.new
@@ -348,7 +348,7 @@ class Gem::RequestSet
     gf.load
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, '[RequestSet:', ']' do
       q.breakable
 
@@ -394,7 +394,7 @@ class Gem::RequestSet
   # Resolve the requested dependencies and return an Array of Specification
   # objects to be activated.
 
-  def resolve set = Gem::Resolver::BestSet.new
+  def resolve(set = Gem::Resolver::BestSet.new)
     @sets << set
     @sets << @git_set
     @sets << @vendor_set
@@ -443,17 +443,17 @@ class Gem::RequestSet
     @specs ||= @requests.map { |r| r.full_spec }
   end
 
-  def specs_in dir
+  def specs_in(dir)
     Gem::Util.glob_files_in_dir("*.gemspec", File.join(dir, "specifications")).map do |g|
       Gem::Specification.load g
     end
   end
 
-  def tsort_each_node &block # :nodoc:
+  def tsort_each_node(&block) # :nodoc:
     @requests.each(&block)
   end
 
-  def tsort_each_child node # :nodoc:
+  def tsort_each_child(node) # :nodoc:
     node.spec.dependencies.each do |dep|
       next if dep.type == :development and not @development
 

--- a/lib/rubygems/request_set/gem_dependency_api.rb
+++ b/lib/rubygems/request_set/gem_dependency_api.rb
@@ -191,7 +191,7 @@ class Gem::RequestSet::GemDependencyAPI
   # Creates a new GemDependencyAPI that will add dependencies to the
   # Gem::RequestSet +set+ based on the dependency API description in +path+.
 
-  def initialize set, path
+  def initialize(set, path)
     @set = set
     @path = path
 
@@ -228,7 +228,7 @@ class Gem::RequestSet::GemDependencyAPI
   # Adds +dependencies+ to the request set if any of the +groups+ are allowed.
   # This is used for gemspec dependencies.
 
-  def add_dependencies groups, dependencies # :nodoc:
+  def add_dependencies(groups, dependencies) # :nodoc:
     return unless (groups & @without_groups).empty?
 
     dependencies.each do |dep|
@@ -241,7 +241,7 @@ class Gem::RequestSet::GemDependencyAPI
   ##
   # Finds a gemspec with the given +name+ that lives at +path+.
 
-  def find_gemspec name, path # :nodoc:
+  def find_gemspec(name, path) # :nodoc:
     glob = File.join path, "#{name}.gemspec"
 
     spec_files = Dir[glob]
@@ -269,7 +269,7 @@ class Gem::RequestSet::GemDependencyAPI
   # In installing mode certain restrictions are ignored such as ruby version
   # mismatch checks.
 
-  def installing= installing # :nodoc:
+  def installing=(installing) # :nodoc:
     @installing = installing
   end
 
@@ -353,7 +353,7 @@ class Gem::RequestSet::GemDependencyAPI
   # tag: ::
   #   Use the given tag for git:, gist: and github: dependencies.
 
-  def gem name, *requirements
+  def gem(name, *requirements)
     options = requirements.pop if requirements.last.kind_of?(Hash)
     options ||= {}
 
@@ -401,7 +401,7 @@ Gem dependencies file #{@path} requires #{name} more than once.
   #
   # Returns +true+ if the gist or git option was handled.
 
-  def gem_git name, options # :nodoc:
+  def gem_git(name, options) # :nodoc:
     if gist = options.delete(:gist) then
       options[:git] = "https://gist.github.com/#{gist}.git"
     end
@@ -424,7 +424,7 @@ Gem dependencies file #{@path} requires #{name} more than once.
   #
   # Returns reference for the git gem.
 
-  def gem_git_reference options # :nodoc:
+  def gem_git_reference(options) # :nodoc:
     ref    = options.delete :ref
     branch = options.delete :branch
     tag    = options.delete :tag
@@ -457,7 +457,7 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
   #
   # Returns +true+ if the custom source option was handled.
 
-  def gem_git_source name, options # :nodoc:
+  def gem_git_source(name, options) # :nodoc:
     return unless git_source = (@git_sources.keys & options.keys).last
 
     source_callback = @git_sources[git_source]
@@ -478,7 +478,7 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
   # Handles the :group and :groups +options+ for the gem with the given
   # +name+.
 
-  def gem_group name, options # :nodoc:
+  def gem_group(name, options) # :nodoc:
     g = options.delete :group
     all_groups  = g ? Array(g) : []
 
@@ -497,7 +497,7 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
   #
   # Returns +true+ if the path option was handled.
 
-  def gem_path name, options # :nodoc:
+  def gem_path(name, options) # :nodoc:
     return unless directory = options.delete(:path)
 
     pin_gem_source name, :path, directory
@@ -514,7 +514,7 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
   #
   # Returns +true+ if the source option was handled.
 
-  def gem_source name, options # :nodoc:
+  def gem_source(name, options) # :nodoc:
     return unless source = options.delete(:source)
 
     pin_gem_source name, :source, source
@@ -530,7 +530,7 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
   # Handles the platforms: option from +options+.  Returns true if the
   # platform matches the current platform.
 
-  def gem_platforms options # :nodoc:
+  def gem_platforms(options) # :nodoc:
     platform_names = Array(options.delete :platform)
     platform_names.concat Array(options.delete :platforms)
     platform_names.concat @current_platforms if @current_platforms
@@ -564,7 +564,7 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
   # Records the require: option from +options+ and adds those files, or the
   # default file to the require list for +name+.
 
-  def gem_requires name, options # :nodoc:
+  def gem_requires(name, options) # :nodoc:
     if options.include? :require then
       if requires = options.delete(:require) then
         @requires[name].concat Array requires
@@ -587,7 +587,7 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
   #     gem 'activerecord'
   #   end
 
-  def git repository
+  def git(repository)
     @current_repository = repository
 
     yield
@@ -601,7 +601,7 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
   # for use in gems built from git repositories.  You must provide a block
   # that accepts a git repository name for expansion.
 
-  def git_source name, &callback
+  def git_source(name, &callback)
     @git_sources[name] = callback
   end
 
@@ -634,7 +634,7 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
   #   The group to add development dependencies to.  By default this is
   #   :development.  Only one group may be specified.
 
-  def gemspec options = {}
+  def gemspec(options = {})
     name              = options.delete(:name) || '{,*}'
     path              = options.delete(:path) || '.'
     development_group = options.delete(:development_group) || :development
@@ -679,7 +679,7 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
   # development`.  See `gem help install` and `gem help gem_dependencies` for
   # further details.
 
-  def group *groups
+  def group(*groups)
     @current_groups = groups
 
     yield
@@ -692,7 +692,7 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
   # Pins the gem +name+ to the given +source+.  Adding a gem with the same
   # name from a different +source+ will raise an exception.
 
-  def pin_gem_source name, type = :default, source = nil
+  def pin_gem_source(name, type = :default, source = nil)
     source_description =
       case type
       when :default then '(default)'
@@ -754,7 +754,7 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
   # NOTE:  There is inconsistency in what environment a platform matches.  You
   # may need to read the source to know the exact details.
 
-  def platform *platforms
+  def platform(*platforms)
     @current_platforms = platforms
 
     yield
@@ -781,7 +781,7 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
   # version.  This matching is performed by using the RUBY_ENGINE and
   # engine_specific VERSION constants.  (For JRuby, JRUBY_VERSION).
 
-  def ruby version, options = {}
+  def ruby(version, options = {})
     engine         = options[:engine]
     engine_version = options[:engine_version]
 
@@ -834,7 +834,7 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
   # * The +prepend:+ option is not supported.  If you wish to order sources
   #   then list them in your preferred order.
 
-  def source url
+  def source(url)
     Gem.sources.clear if @default_sources
 
     @default_sources = false

--- a/lib/rubygems/request_set/lockfile.rb
+++ b/lib/rubygems/request_set/lockfile.rb
@@ -29,7 +29,7 @@ class Gem::RequestSet::Lockfile
     # Raises a ParseError with the given +message+ which was encountered at a
     # +line+ and +column+ while parsing.
 
-    def initialize message, column, line, path
+    def initialize(message, column, line, path)
       @line   = line
       @column = column
       @path   = path
@@ -41,13 +41,13 @@ class Gem::RequestSet::Lockfile
   # Creates a new Lockfile for the given +request_set+ and +gem_deps_file+
   # location.
 
-  def self.build request_set, gem_deps_file, dependencies = nil
+  def self.build(request_set, gem_deps_file, dependencies = nil)
     request_set.resolve
     dependencies ||= requests_to_deps request_set.sorted_requests
     new request_set, gem_deps_file, dependencies
   end
 
-  def self.requests_to_deps requests # :nodoc:
+  def self.requests_to_deps(requests) # :nodoc:
     deps = {}
 
     requests.each do |request|
@@ -71,7 +71,7 @@ class Gem::RequestSet::Lockfile
 
   attr_reader :platforms
 
-  def initialize request_set, gem_deps_file, dependencies
+  def initialize(request_set, gem_deps_file, dependencies)
     @set           = request_set
     @dependencies  = dependencies
     @gem_deps_file = File.expand_path(gem_deps_file)
@@ -82,7 +82,7 @@ class Gem::RequestSet::Lockfile
     @platforms      = []
   end
 
-  def add_DEPENDENCIES out # :nodoc:
+  def add_DEPENDENCIES(out) # :nodoc:
     out << "DEPENDENCIES"
 
     out.concat @dependencies.sort_by { |name,| name }.map { |name, requirement|
@@ -92,7 +92,7 @@ class Gem::RequestSet::Lockfile
     out << nil
   end
 
-  def add_GEM out, spec_groups # :nodoc:
+  def add_GEM(out, spec_groups) # :nodoc:
     return if spec_groups.empty?
 
     source_groups = spec_groups.values.flatten.group_by do |request|
@@ -122,7 +122,7 @@ class Gem::RequestSet::Lockfile
     end
   end
 
-  def add_GIT out, git_requests
+  def add_GIT(out, git_requests)
     return if git_requests.empty?
 
     by_repository_revision = git_requests.group_by do |request|
@@ -148,7 +148,7 @@ class Gem::RequestSet::Lockfile
     end
   end
 
-  def relative_path_from dest, base # :nodoc:
+  def relative_path_from(dest, base) # :nodoc:
     dest = File.expand_path(dest)
     base = File.expand_path(base)
 
@@ -163,7 +163,7 @@ class Gem::RequestSet::Lockfile
     end
   end
 
-  def add_PATH out, path_requests # :nodoc:
+  def add_PATH(out, path_requests) # :nodoc:
     return if path_requests.empty?
 
     out << "PATH"
@@ -178,7 +178,7 @@ class Gem::RequestSet::Lockfile
     out << nil
   end
 
-  def add_PLATFORMS out # :nodoc:
+  def add_PLATFORMS(out) # :nodoc:
     out << "PLATFORMS"
 
     platforms = requests.map { |request| request.spec.platform }.uniq

--- a/lib/rubygems/request_set/lockfile/parser.rb
+++ b/lib/rubygems/request_set/lockfile/parser.rb
@@ -3,7 +3,7 @@ class Gem::RequestSet::Lockfile::Parser
   ###
   # Parses lockfiles
 
-  def initialize tokenizer, set, platforms, filename = nil
+  def initialize(tokenizer, set, platforms, filename = nil)
     @tokens    = tokenizer
     @filename  = filename
     @set       = set
@@ -41,7 +41,7 @@ class Gem::RequestSet::Lockfile::Parser
   ##
   # Gets the next token for a Lockfile
 
-  def get expected_types = nil, expected_value = nil # :nodoc:
+  def get(expected_types = nil, expected_value = nil) # :nodoc:
     token = @tokens.shift
 
     if expected_types and not Array(expected_types).include? token.type then
@@ -294,7 +294,7 @@ class Gem::RequestSet::Lockfile::Parser
   # Parses the requirements following the dependency +name+ and the +op+ for
   # the first token of the requirements and returns a Gem::Dependency object.
 
-  def parse_dependency name, op # :nodoc:
+  def parse_dependency(name, op) # :nodoc:
     return Gem::Dependency.new name, op unless peek[0] == :text
 
     version = get(:text).value
@@ -314,7 +314,7 @@ class Gem::RequestSet::Lockfile::Parser
 
   private
 
-  def skip type # :nodoc:
+  def skip(type) # :nodoc:
     @tokens.skip type
   end
 
@@ -325,7 +325,7 @@ class Gem::RequestSet::Lockfile::Parser
     @tokens.peek
   end
 
-  def pinned_requirement name # :nodoc:
+  def pinned_requirement(name) # :nodoc:
     requirement = Gem::Dependency.new name
     specification = @set.sets.flat_map { |set|
       set.find_all(requirement)
@@ -337,7 +337,7 @@ class Gem::RequestSet::Lockfile::Parser
   ##
   # Ungets the last token retrieved by #get
 
-  def unget token # :nodoc:
+  def unget(token) # :nodoc:
     @tokens.unshift token
   end
 end

--- a/lib/rubygems/request_set/lockfile/tokenizer.rb
+++ b/lib/rubygems/request_set/lockfile/tokenizer.rb
@@ -5,11 +5,11 @@ class Gem::RequestSet::Lockfile::Tokenizer
   Token = Struct.new :type, :value, :column, :line
   EOF   = Token.new :EOF
 
-  def self.from_file file
+  def self.from_file(file)
     new File.read(file), file
   end
 
-  def initialize input, filename = nil, line = 0, pos = 0
+  def initialize(input, filename = nil, line = 0, pos = 0)
     @line     = line
     @line_pos = pos
     @tokens   = []
@@ -17,7 +17,7 @@ class Gem::RequestSet::Lockfile::Tokenizer
     tokenize input
   end
 
-  def make_parser set, platforms
+  def make_parser(set, platforms)
     Gem::RequestSet::Lockfile::Parser.new self, set, platforms, @filename
   end
 
@@ -25,7 +25,7 @@ class Gem::RequestSet::Lockfile::Tokenizer
     @tokens.map { |token| [token.type, token.value, token.column, token.line] }
   end
 
-  def skip type
+  def skip(type)
     @tokens.shift while not @tokens.empty? and peek.type == type
   end
 
@@ -33,7 +33,7 @@ class Gem::RequestSet::Lockfile::Tokenizer
   # Calculates the column (by byte) and the line of the current token based on
   # +byte_offset+.
 
-  def token_pos byte_offset # :nodoc:
+  def token_pos(byte_offset) # :nodoc:
     [byte_offset - @line_pos, @line]
   end
 
@@ -41,7 +41,7 @@ class Gem::RequestSet::Lockfile::Tokenizer
     @tokens.empty?
   end
 
-  def unshift token
+  def unshift(token)
     @tokens.unshift token
   end
 
@@ -56,7 +56,7 @@ class Gem::RequestSet::Lockfile::Tokenizer
 
   private
 
-  def tokenize input
+  def tokenize(input)
     require 'strscan'
     s = StringScanner.new input
 

--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -51,7 +51,7 @@ class Gem::Requirement
   # If the input is "weird", the default version requirement is
   # returned.
 
-  def self.create *inputs
+  def self.create(*inputs)
     return new inputs if inputs.length > 1
 
     input = inputs.shift
@@ -98,7 +98,7 @@ class Gem::Requirement
   #     parse("1.0")                   # => ["=", Gem::Version.new("1.0")]
   #     parse(Gem::Version.new("1.0")) # => ["=,  Gem::Version.new("1.0")]
 
-  def self.parse obj
+  def self.parse(obj)
     return ["=", obj] if Gem::Version === obj
 
     unless PATTERN =~ obj.to_s
@@ -124,7 +124,7 @@ class Gem::Requirement
   # requirements are ignored. An empty set of +requirements+ is the
   # same as <tt>">= 0"</tt>.
 
-  def initialize *requirements
+  def initialize(*requirements)
     requirements = requirements.flatten
     requirements.compact!
     requirements.uniq!
@@ -140,7 +140,7 @@ class Gem::Requirement
   ##
   # Concatenates the +new+ requirements onto this requirement.
 
-  def concat new
+  def concat(new)
     new = new.flatten
     new.compact!
     new.uniq!
@@ -198,7 +198,7 @@ class Gem::Requirement
     [@requirements]
   end
 
-  def marshal_load array # :nodoc:
+  def marshal_load(array) # :nodoc:
     @requirements = array[0]
 
     fix_syck_default_key_in_requirements
@@ -213,7 +213,7 @@ class Gem::Requirement
     fix_syck_default_key_in_requirements
   end
 
-  def init_with coder # :nodoc:
+  def init_with(coder) # :nodoc:
     yaml_initialize coder.tag, coder.map
   end
 
@@ -221,7 +221,7 @@ class Gem::Requirement
     ["@requirements"]
   end
 
-  def encode_with coder # :nodoc:
+  def encode_with(coder) # :nodoc:
     coder.add 'requirements', @requirements
   end
 
@@ -233,7 +233,7 @@ class Gem::Requirement
     requirements.any? { |r| r.last.prerelease? }
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 1, 'Gem::Requirement.new(', ')' do
       q.pp as_list
     end
@@ -242,7 +242,7 @@ class Gem::Requirement
   ##
   # True if +version+ satisfies this Requirement.
 
-  def satisfied_by? version
+  def satisfied_by?(version)
     raise ArgumentError, "Need a Gem::Version: #{version.inspect}" unless
       Gem::Version === version
     # #28965: syck has a bug with unquoted '=' YAML.loading as YAML::DefaultKey
@@ -265,7 +265,7 @@ class Gem::Requirement
     as_list.join ", "
   end
 
-  def == other # :nodoc:
+  def ==(other) # :nodoc:
     return unless Gem::Requirement === other
     requirements == other.requirements
   end

--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -59,7 +59,7 @@ class Gem::Resolver
   # uniform manner.  If one of the +sets+ is itself a ComposedSet its sets are
   # flattened into the result ComposedSet.
 
-  def self.compose_sets *sets
+  def self.compose_sets(*sets)
     sets.compact!
 
     sets = sets.map do |set|
@@ -87,7 +87,7 @@ class Gem::Resolver
   # Creates a Resolver that queries only against the already installed gems
   # for the +needed+ dependencies.
 
-  def self.for_current_gems needed
+  def self.for_current_gems(needed)
     new needed, Gem::Resolver::CurrentSet.new
   end
 
@@ -99,7 +99,7 @@ class Gem::Resolver
   # satisfy the Dependencies. This defaults to IndexSet, which will query
   # rubygems.org.
 
-  def initialize needed, set = nil
+  def initialize(needed, set = nil)
     @set = set || Gem::Resolver::IndexSet.new
     @needed = needed
 
@@ -112,14 +112,14 @@ class Gem::Resolver
     @stats               = Gem::Resolver::Stats.new
   end
 
-  def explain stage, *data # :nodoc:
+  def explain(stage, *data) # :nodoc:
     return unless DEBUG_RESOLVER
 
     d = data.map { |x| x.pretty_inspect }.join(", ")
     $stderr.printf "%10s %s\n", stage.to_s.upcase, d
   end
 
-  def explain_list stage # :nodoc:
+  def explain_list(stage) # :nodoc:
     return unless DEBUG_RESOLVER
 
     data = yield
@@ -133,7 +133,7 @@ class Gem::Resolver
   #
   # Returns the Specification and the ActivationRequest
 
-  def activation_request dep, possible # :nodoc:
+  def activation_request(dep, possible) # :nodoc:
     spec = possible.pop
 
     explain :activate, [spec.full_name, possible.size]
@@ -145,7 +145,7 @@ class Gem::Resolver
     return spec, activation_request
   end
 
-  def requests s, act, reqs=[] # :nodoc:
+  def requests(s, act, reqs=[]) # :nodoc:
     return reqs if @ignore_dependencies
 
     s.fetch_development_dependencies if @development
@@ -197,7 +197,7 @@ class Gem::Resolver
   # Extracts the specifications that may be able to fulfill +dependency+ and
   # returns those that match the local platform and all those that match.
 
-  def find_possible dependency # :nodoc:
+  def find_possible(dependency) # :nodoc:
     all = @set.find_all dependency
 
     if (skip_dep_gems = skip_gems[dependency.name]) && !skip_dep_gems.empty?
@@ -216,7 +216,7 @@ class Gem::Resolver
   ##
   # Returns the gems in +specs+ that match the local platform.
 
-  def select_local_platforms specs # :nodoc:
+  def select_local_platforms(specs) # :nodoc:
     specs.select do |spec|
       Gem::Platform.installable? spec
     end

--- a/lib/rubygems/resolver/activation_request.rb
+++ b/lib/rubygems/resolver/activation_request.rb
@@ -22,13 +22,13 @@ class Gem::Resolver::ActivationRequest
   # +others_possible+ indicates that other specifications may also match this
   # activation request.
 
-  def initialize spec, request, others_possible = true
+  def initialize(spec, request, others_possible = true)
     @spec = spec
     @request = request
     @others_possible = others_possible
   end
 
-  def == other # :nodoc:
+  def ==(other) # :nodoc:
     case other
     when Gem::Specification
       @spec == other
@@ -49,7 +49,7 @@ class Gem::Resolver::ActivationRequest
   ##
   # Downloads a gem at +path+ and returns the file path.
 
-  def download path
+  def download(path)
     Gem.ensure_gem_subdirectories path
 
     if @spec.respond_to? :sources
@@ -152,7 +152,7 @@ class Gem::Resolver::ActivationRequest
     @request.requester
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, '[Activation request', ']' do
       q.breakable
       q.pp @spec

--- a/lib/rubygems/resolver/api_set.rb
+++ b/lib/rubygems/resolver/api_set.rb
@@ -25,7 +25,7 @@ class Gem::Resolver::APISet < Gem::Resolver::Set
   # API URL +dep_uri+ which is described at
   # http://guides.rubygems.org/rubygems-org-api
 
-  def initialize dep_uri = 'https://rubygems.org/api/v1/dependencies'
+  def initialize(dep_uri = 'https://rubygems.org/api/v1/dependencies')
     super()
 
     dep_uri = URI dep_uri unless URI === dep_uri # for ruby 1.8
@@ -43,7 +43,7 @@ class Gem::Resolver::APISet < Gem::Resolver::Set
   # Return an array of APISpecification objects matching
   # DependencyRequest +req+.
 
-  def find_all req
+  def find_all(req)
     res = []
 
     return res unless @remote
@@ -65,7 +65,7 @@ class Gem::Resolver::APISet < Gem::Resolver::Set
   # A hint run by the resolver to allow the Set to fetch
   # data for DependencyRequests +reqs+.
 
-  def prefetch reqs
+  def prefetch(reqs)
     return unless @remote
     names = reqs.map { |r| r.dependency.name }
     needed = names - @data.keys - @to_fetch
@@ -93,7 +93,7 @@ class Gem::Resolver::APISet < Gem::Resolver::Set
     end
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, '[APISet', ']' do
       q.breakable
       q.text "URI: #{@dep_uri}"
@@ -107,7 +107,7 @@ class Gem::Resolver::APISet < Gem::Resolver::Set
   ##
   # Return data for all versions of the gem +name+.
 
-  def versions name # :nodoc:
+  def versions(name) # :nodoc:
     if @data.key?(name)
       return @data[name]
     end

--- a/lib/rubygems/resolver/api_specification.rb
+++ b/lib/rubygems/resolver/api_specification.rb
@@ -27,7 +27,7 @@ class Gem::Resolver::APISpecification < Gem::Resolver::Specification
     end
   end
 
-  def == other # :nodoc:
+  def ==(other) # :nodoc:
     self.class === other and
       @set          == other.set and
       @name         == other.name and
@@ -46,7 +46,7 @@ class Gem::Resolver::APISpecification < Gem::Resolver::Specification
     Gem::Platform.match @platform
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, '[APISpecification', ']' do
       q.breakable
       q.text "name: #{name}"

--- a/lib/rubygems/resolver/best_set.rb
+++ b/lib/rubygems/resolver/best_set.rb
@@ -10,7 +10,7 @@ class Gem::Resolver::BestSet < Gem::Resolver::ComposedSet
   # Creates a BestSet for the given +sources+ or Gem::sources if none are
   # specified.  +sources+ must be a Gem::SourceList.
 
-  def initialize sources = Gem.sources
+  def initialize(sources = Gem.sources)
     super()
 
     @sources = sources
@@ -25,7 +25,7 @@ class Gem::Resolver::BestSet < Gem::Resolver::ComposedSet
     end
   end
 
-  def find_all req # :nodoc:
+  def find_all(req) # :nodoc:
     pick_sets if @remote and @sets.empty?
 
     super
@@ -35,13 +35,13 @@ class Gem::Resolver::BestSet < Gem::Resolver::ComposedSet
     retry
   end
 
-  def prefetch reqs # :nodoc:
+  def prefetch(reqs) # :nodoc:
     pick_sets if @remote and @sets.empty?
 
     super
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, '[BestSet', ']' do
       q.breakable
       q.text 'sets:'
@@ -58,7 +58,7 @@ class Gem::Resolver::BestSet < Gem::Resolver::ComposedSet
   #
   # The calling method must retry the exception to repeat the lookup.
 
-  def replace_failed_api_set error # :nodoc:
+  def replace_failed_api_set(error) # :nodoc:
     uri = error.uri
     uri = URI uri unless URI === uri
     uri.query = nil

--- a/lib/rubygems/resolver/composed_set.rb
+++ b/lib/rubygems/resolver/composed_set.rb
@@ -16,7 +16,7 @@ class Gem::Resolver::ComposedSet < Gem::Resolver::Set
   # Creates a new ComposedSet containing +sets+.  Use
   # Gem::Resolver::compose_sets instead.
 
-  def initialize *sets
+  def initialize(*sets)
     super()
 
     @sets = sets
@@ -26,7 +26,7 @@ class Gem::Resolver::ComposedSet < Gem::Resolver::Set
   # When +allow_prerelease+ is set to +true+ prereleases gems are allowed to
   # match dependencies.
 
-  def prerelease= allow_prerelease
+  def prerelease=(allow_prerelease)
     super
 
     sets.each do |set|
@@ -37,7 +37,7 @@ class Gem::Resolver::ComposedSet < Gem::Resolver::Set
   ##
   # Sets the remote network access for all composed sets.
 
-  def remote= remote
+  def remote=(remote)
     super
 
     @sets.each { |set| set.remote = remote }
@@ -50,7 +50,7 @@ class Gem::Resolver::ComposedSet < Gem::Resolver::Set
   ##
   # Finds all specs matching +req+ in all sets.
 
-  def find_all req
+  def find_all(req)
     @sets.map do |s|
       s.find_all req
     end.flatten
@@ -59,7 +59,7 @@ class Gem::Resolver::ComposedSet < Gem::Resolver::Set
   ##
   # Prefetches +reqs+ in all sets.
 
-  def prefetch reqs
+  def prefetch(reqs)
     @sets.each { |s| s.prefetch(reqs) }
   end
 

--- a/lib/rubygems/resolver/conflict.rb
+++ b/lib/rubygems/resolver/conflict.rb
@@ -27,7 +27,7 @@ class Gem::Resolver::Conflict
     @failed_dep = failed_dep
   end
 
-  def == other # :nodoc:
+  def ==(other) # :nodoc:
     self.class === other and
       @dependency == other.dependency and
       @activated  == other.activated  and
@@ -97,7 +97,7 @@ class Gem::Resolver::Conflict
     @dependency.name == spec.name
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, '[Dependency conflict: ', ']' do
       q.breakable
 
@@ -121,7 +121,7 @@ class Gem::Resolver::Conflict
   ##
   # Path of activations from the +current+ list.
 
-  def request_path current
+  def request_path(current)
     path = []
 
     while current do

--- a/lib/rubygems/resolver/current_set.rb
+++ b/lib/rubygems/resolver/current_set.rb
@@ -6,7 +6,7 @@
 
 class Gem::Resolver::CurrentSet < Gem::Resolver::Set
 
-  def find_all req
+  def find_all(req)
     req.dependency.matching_specs
   end
 

--- a/lib/rubygems/resolver/dependency_request.rb
+++ b/lib/rubygems/resolver/dependency_request.rb
@@ -19,12 +19,12 @@ class Gem::Resolver::DependencyRequest
   # Creates a new DependencyRequest for +dependency+ from +requester+.
   # +requester may be nil if the request came from a user.
 
-  def initialize dependency, requester
+  def initialize(dependency, requester)
     @dependency = dependency
     @requester  = requester
   end
 
-  def == other # :nodoc:
+  def ==(other) # :nodoc:
     case other
     when Gem::Dependency
       @dependency == other
@@ -48,7 +48,7 @@ class Gem::Resolver::DependencyRequest
   # NOTE:  #match? only matches prerelease versions when #dependency is a
   # prerelease dependency.
 
-  def match? spec, allow_prerelease = false
+  def match?(spec, allow_prerelease = false)
     @dependency.match? spec, nil, allow_prerelease
   end
 
@@ -95,7 +95,7 @@ class Gem::Resolver::DependencyRequest
     @requester ? @requester.request : "(unknown)"
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, '[Dependency request ', ']' do
       q.breakable
       q.text @dependency.to_s

--- a/lib/rubygems/resolver/git_set.rb
+++ b/lib/rubygems/resolver/git_set.rb
@@ -43,7 +43,7 @@ class Gem::Resolver::GitSet < Gem::Resolver::Set
     @specs           = {}
   end
 
-  def add_git_gem name, repository, reference, submodules # :nodoc:
+  def add_git_gem(name, repository, reference, submodules) # :nodoc:
     @repositories[name] = [repository, reference]
     @need_submodules[repository] = submodules
   end
@@ -56,7 +56,7 @@ class Gem::Resolver::GitSet < Gem::Resolver::Set
   # This fills in the prefetch information as enough information about the gem
   # is present in the arguments.
 
-  def add_git_spec name, version, repository, reference, submodules # :nodoc:
+  def add_git_spec(name, version, repository, reference, submodules) # :nodoc:
     add_git_gem name, repository, reference, submodules
 
     source = Gem::Source::Git.new name, repository, reference
@@ -77,7 +77,7 @@ class Gem::Resolver::GitSet < Gem::Resolver::Set
   ##
   # Finds all git gems matching +req+
 
-  def find_all req
+  def find_all(req)
     prefetch nil
 
     specs.values.select do |spec|
@@ -88,7 +88,7 @@ class Gem::Resolver::GitSet < Gem::Resolver::Set
   ##
   # Prefetches specifications from the git repositories in this set.
 
-  def prefetch reqs
+  def prefetch(reqs)
     return unless @specs.empty?
 
     @repositories.each do |name, (repository, reference)|
@@ -104,7 +104,7 @@ class Gem::Resolver::GitSet < Gem::Resolver::Set
     end
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, '[GitSet', ']' do
       next if @repositories.empty?
       q.breakable

--- a/lib/rubygems/resolver/git_specification.rb
+++ b/lib/rubygems/resolver/git_specification.rb
@@ -6,14 +6,14 @@
 
 class Gem::Resolver::GitSpecification < Gem::Resolver::SpecSpecification
 
-  def == other # :nodoc:
+  def ==(other) # :nodoc:
     self.class === other and
       @set  == other.set and
       @spec == other.spec and
       @source == other.source
   end
 
-  def add_dependency dependency # :nodoc:
+  def add_dependency(dependency) # :nodoc:
     spec.dependencies << dependency
   end
 
@@ -21,7 +21,7 @@ class Gem::Resolver::GitSpecification < Gem::Resolver::SpecSpecification
   # Installing a git gem only involves building the extensions and generating
   # the executables.
 
-  def install options = {}
+  def install(options = {})
     require 'rubygems/installer'
 
     installer = Gem::Installer.for_spec spec, options
@@ -35,7 +35,7 @@ class Gem::Resolver::GitSpecification < Gem::Resolver::SpecSpecification
     installer.run_post_install_hooks
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, '[GitSpecification', ']' do
       q.breakable
       q.text "name: #{name}"

--- a/lib/rubygems/resolver/index_set.rb
+++ b/lib/rubygems/resolver/index_set.rb
@@ -5,7 +5,7 @@
 
 class Gem::Resolver::IndexSet < Gem::Resolver::Set
 
-  def initialize source = nil # :nodoc:
+  def initialize(source = nil) # :nodoc:
     super()
 
     @f =
@@ -36,7 +36,7 @@ class Gem::Resolver::IndexSet < Gem::Resolver::Set
   # Return an array of IndexSpecification objects matching
   # DependencyRequest +req+.
 
-  def find_all req
+  def find_all(req)
     res = []
 
     return res unless @remote
@@ -53,7 +53,7 @@ class Gem::Resolver::IndexSet < Gem::Resolver::Set
     res
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, '[IndexSet', ']' do
       q.breakable
       q.text 'sources:'

--- a/lib/rubygems/resolver/index_specification.rb
+++ b/lib/rubygems/resolver/index_specification.rb
@@ -15,7 +15,7 @@ class Gem::Resolver::IndexSpecification < Gem::Resolver::Specification
   # The +name+, +version+ and +platform+ are the name, version and platform of
   # the gem.
 
-  def initialize set, name, version, source, platform
+  def initialize(set, name, version, source, platform)
     super()
 
     @set = set
@@ -38,7 +38,7 @@ class Gem::Resolver::IndexSpecification < Gem::Resolver::Specification
     '#<%s %s source %s>' % [self.class, full_name, @source]
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, '[Index specification', ']' do
       q.breakable
       q.text full_name

--- a/lib/rubygems/resolver/installed_specification.rb
+++ b/lib/rubygems/resolver/installed_specification.rb
@@ -5,7 +5,7 @@
 
 class Gem::Resolver::InstalledSpecification < Gem::Resolver::SpecSpecification
 
-  def == other # :nodoc:
+  def ==(other) # :nodoc:
     self.class === other and
       @set  == other.set and
       @spec == other.spec
@@ -15,7 +15,7 @@ class Gem::Resolver::InstalledSpecification < Gem::Resolver::SpecSpecification
   # This is a null install as this specification is already installed.
   # +options+ are ignored.
 
-  def install options = {}
+  def install(options = {})
     yield nil
   end
 
@@ -30,7 +30,7 @@ class Gem::Resolver::InstalledSpecification < Gem::Resolver::SpecSpecification
     super
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, '[InstalledSpecification', ']' do
       q.breakable
       q.text "name: #{name}"

--- a/lib/rubygems/resolver/installer_set.rb
+++ b/lib/rubygems/resolver/installer_set.rb
@@ -29,7 +29,7 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
   ##
   # Creates a new InstallerSet that will look for gems in +domain+.
 
-  def initialize domain
+  def initialize(domain)
     super()
 
     @domain = domain
@@ -50,7 +50,7 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
   # Looks up the latest specification for +dependency+ and adds it to the
   # always_install list.
 
-  def add_always_install dependency
+  def add_always_install(dependency)
     request = Gem::Resolver::DependencyRequest.new dependency, nil
 
     found = find_all request
@@ -83,7 +83,7 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
   # Adds a local gem requested using +dep_name+ with the given +spec+ that can
   # be loaded and installed using the +source+.
 
-  def add_local dep_name, spec, source
+  def add_local(dep_name, spec, source)
     @local[dep_name] = [spec, source]
   end
 
@@ -112,7 +112,7 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
   # Returns an array of IndexSpecification objects matching DependencyRequest
   # +req+.
 
-  def find_all req
+  def find_all(req)
     res = []
 
     dep  = req.dependency
@@ -161,7 +161,7 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
     @remote_set.prefetch(reqs) if consider_remote?
   end
 
-  def prerelease= allow_prerelease
+  def prerelease=(allow_prerelease)
     super
 
     @remote_set.prerelease = allow_prerelease
@@ -179,7 +179,7 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
   # Called from IndexSpecification to get a true Specification
   # object.
 
-  def load_spec name, ver, platform, source # :nodoc:
+  def load_spec(name, ver, platform, source) # :nodoc:
     key = "#{name}-#{ver}-#{platform}"
 
     @specs.fetch key do
@@ -192,13 +192,13 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
   ##
   # Has a local gem for +dep_name+ been added to this set?
 
-  def local? dep_name # :nodoc:
+  def local?(dep_name) # :nodoc:
     spec, _ = @local[dep_name]
 
     spec
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, '[InstallerSet', ']' do
       q.breakable
       q.text "domain: #{@domain}"
@@ -213,7 +213,7 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
     end
   end
 
-  def remote= remote # :nodoc:
+  def remote=(remote) # :nodoc:
     case @domain
     when :local then
       @domain = :both if remote

--- a/lib/rubygems/resolver/local_specification.rb
+++ b/lib/rubygems/resolver/local_specification.rb
@@ -17,7 +17,7 @@ class Gem::Resolver::LocalSpecification < Gem::Resolver::SpecSpecification
     true
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, '[LocalSpecification', ']' do
       q.breakable
       q.text "name: #{name}"

--- a/lib/rubygems/resolver/lock_set.rb
+++ b/lib/rubygems/resolver/lock_set.rb
@@ -9,7 +9,7 @@ class Gem::Resolver::LockSet < Gem::Resolver::Set
   ##
   # Creates a new LockSet from the given +sources+
 
-  def initialize sources
+  def initialize(sources)
     super()
 
     @sources = sources.map do |source|
@@ -26,7 +26,7 @@ class Gem::Resolver::LockSet < Gem::Resolver::Set
   # The specification's set will be the current set, and the source will be
   # the current set's source.
 
-  def add name, version, platform # :nodoc:
+  def add(name, version, platform) # :nodoc:
     version = Gem::Version.new version
     specs = [
       Gem::Resolver::LockSpecification.new(self, name, version, @sources, platform)
@@ -41,7 +41,7 @@ class Gem::Resolver::LockSet < Gem::Resolver::Set
   # Returns an Array of IndexSpecification objects matching the
   # DependencyRequest +req+.
 
-  def find_all req
+  def find_all(req)
     @specs.select do |spec|
       req.match? spec
     end
@@ -51,7 +51,7 @@ class Gem::Resolver::LockSet < Gem::Resolver::Set
   # Loads a Gem::Specification with the given +name+, +version+ and
   # +platform+.  +source+ is ignored.
 
-  def load_spec name, version, platform, source # :nodoc:
+  def load_spec(name, version, platform, source) # :nodoc:
     dep = Gem::Dependency.new name, version
 
     found = @specs.find do |spec|
@@ -63,7 +63,7 @@ class Gem::Resolver::LockSet < Gem::Resolver::Set
     found.source.fetch_spec tuple
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, '[LockSet', ']' do
       q.breakable
       q.text 'source:'

--- a/lib/rubygems/resolver/lock_specification.rb
+++ b/lib/rubygems/resolver/lock_specification.rb
@@ -9,7 +9,7 @@ class Gem::Resolver::LockSpecification < Gem::Resolver::Specification
 
   attr_reader :sources
 
-  def initialize set, name, version, sources, platform
+  def initialize(set, name, version, sources, platform)
     super()
 
     @name     = name
@@ -27,7 +27,7 @@ class Gem::Resolver::LockSpecification < Gem::Resolver::Specification
   # This is a null install as a locked specification is considered installed.
   # +options+ are ignored.
 
-  def install options = {}
+  def install(options = {})
     destination = options[:install_dir] || Gem.dir
 
     if File.exist? File.join(destination, 'specifications', spec.spec_name) then
@@ -41,11 +41,11 @@ class Gem::Resolver::LockSpecification < Gem::Resolver::Specification
   ##
   # Adds +dependency+ from the lockfile to this specification
 
-  def add_dependency dependency # :nodoc:
+  def add_dependency(dependency) # :nodoc:
     @dependencies << dependency
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, '[LockSpecification', ']' do
       q.breakable
       q.text "name: #{@name}"

--- a/lib/rubygems/resolver/requirement_list.rb
+++ b/lib/rubygems/resolver/requirement_list.rb
@@ -18,7 +18,7 @@ class Gem::Resolver::RequirementList
     @list = []
   end
 
-  def initialize_copy other # :nodoc:
+  def initialize_copy(other) # :nodoc:
     @exact = @exact.dup
     @list = @list.dup
   end

--- a/lib/rubygems/resolver/set.rb
+++ b/lib/rubygems/resolver/set.rb
@@ -31,7 +31,7 @@ class Gem::Resolver::Set
   # The find_all method must be implemented.  It returns all Resolver
   # Specification objects matching the given DependencyRequest +req+.
 
-  def find_all req
+  def find_all(req)
     raise NotImplementedError
   end
 
@@ -43,7 +43,7 @@ class Gem::Resolver::Set
   # When overridden, the #prefetch method should look up specifications
   # matching +reqs+.
 
-  def prefetch reqs
+  def prefetch(reqs)
   end
 
   ##

--- a/lib/rubygems/resolver/source_set.rb
+++ b/lib/rubygems/resolver/source_set.rb
@@ -16,7 +16,7 @@ class Gem::Resolver::SourceSet < Gem::Resolver::Set
     @sets  = {}
   end
 
-  def find_all req # :nodoc:
+  def find_all(req) # :nodoc:
     if set = get_set(req.dependency.name)
       set.find_all req
     else
@@ -25,7 +25,7 @@ class Gem::Resolver::SourceSet < Gem::Resolver::Set
   end
 
   # potentially no-op
-  def prefetch reqs # :nodoc:
+  def prefetch(reqs) # :nodoc:
     reqs.each do |req|
       if set = get_set(req.dependency.name)
         set.prefetch reqs
@@ -33,7 +33,7 @@ class Gem::Resolver::SourceSet < Gem::Resolver::Set
     end
   end
 
-  def add_source_gem name, source
+  def add_source_gem(name, source)
     @links[name] = source
   end
 

--- a/lib/rubygems/resolver/spec_specification.rb
+++ b/lib/rubygems/resolver/spec_specification.rb
@@ -10,7 +10,7 @@ class Gem::Resolver::SpecSpecification < Gem::Resolver::Specification
   # +spec+.  The +source+ is either where the +spec+ came from, or should be
   # loaded from.
 
-  def initialize set, spec, source = nil
+  def initialize(set, spec, source = nil)
     @set    = set
     @source = source
     @spec   = spec

--- a/lib/rubygems/resolver/specification.rb
+++ b/lib/rubygems/resolver/specification.rb
@@ -81,7 +81,7 @@ class Gem::Resolver::Specification
   # After installation #spec is updated to point to the just-installed
   # specification.
 
-  def install options = {}
+  def install(options = {})
     require 'rubygems/installer'
 
     gem = download options
@@ -93,7 +93,7 @@ class Gem::Resolver::Specification
     @spec = installer.install
   end
 
-  def download options
+  def download(options)
     dir = options[:install_dir] || Gem.dir
 
     Gem.ensure_gem_subdirectories dir

--- a/lib/rubygems/resolver/vendor_set.rb
+++ b/lib/rubygems/resolver/vendor_set.rb
@@ -32,7 +32,7 @@ class Gem::Resolver::VendorSet < Gem::Resolver::Set
   # Adds a specification to the set with the given +name+ which has been
   # unpacked into the given +directory+.
 
-  def add_vendor_gem name, directory # :nodoc:
+  def add_vendor_gem(name, directory) # :nodoc:
     gemspec = File.join directory, "#{name}.gemspec"
 
     spec = Gem::Specification.load gemspec
@@ -52,7 +52,7 @@ class Gem::Resolver::VendorSet < Gem::Resolver::Set
   # Returns an Array of VendorSpecification objects matching the
   # DependencyRequest +req+.
 
-  def find_all req
+  def find_all(req)
     @specs.values.select do |spec|
       req.match? spec
     end.map do |spec|
@@ -65,11 +65,11 @@ class Gem::Resolver::VendorSet < Gem::Resolver::Set
   # Loads a spec with the given +name+. +version+, +platform+ and +source+ are
   # ignored.
 
-  def load_spec name, version, platform, source # :nodoc:
+  def load_spec(name, version, platform, source) # :nodoc:
     @specs.fetch name
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, '[VendorSet', ']' do
       next if @directories.empty?
       q.breakable

--- a/lib/rubygems/resolver/vendor_specification.rb
+++ b/lib/rubygems/resolver/vendor_specification.rb
@@ -6,7 +6,7 @@
 
 class Gem::Resolver::VendorSpecification < Gem::Resolver::SpecSpecification
 
-  def == other # :nodoc:
+  def ==(other) # :nodoc:
     self.class === other and
       @set  == other.set and
       @spec == other.spec and
@@ -17,7 +17,7 @@ class Gem::Resolver::VendorSpecification < Gem::Resolver::SpecSpecification
   # This is a null install as this gem was unpacked into a directory.
   # +options+ are ignored.
 
-  def install options = {}
+  def install(options = {})
     yield nil
   end
 

--- a/lib/rubygems/safe_yaml.rb
+++ b/lib/rubygems/safe_yaml.rb
@@ -27,7 +27,7 @@ module Gem
     ).freeze
 
     if ::YAML.respond_to? :safe_load
-      def self.safe_load input
+      def self.safe_load(input)
         if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0.pre1')
           ::YAML.safe_load(input, permitted_classes: PERMITTED_CLASSES, permitted_symbols: PERMITTED_SYMBOLS, aliases: true)
         else
@@ -35,7 +35,7 @@ module Gem
         end
       end
 
-      def self.load input
+      def self.load(input)
         if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0.pre1')
           ::YAML.safe_load(input, permitted_classes: [::Symbol])
         else
@@ -47,11 +47,11 @@ module Gem
         warn "YAML safe loading is not available. Please upgrade psych to a version that supports safe loading (>= 2.0)."
       end
 
-      def self.safe_load input, *args
+      def self.safe_load(input, *args)
         ::YAML.load input
       end
 
-      def self.load input
+      def self.load(input)
         ::YAML.load input
       end
     end

--- a/lib/rubygems/security.rb
+++ b/lib/rubygems/security.rb
@@ -403,7 +403,7 @@ module Gem::Security
     'subjectKeyIdentifier' => 'hash',
   }.freeze
 
-  def self.alt_name_or_x509_entry certificate, x509_entry
+  def self.alt_name_or_x509_entry(certificate, x509_entry)
     alt_name = certificate.extensions.find do |extension|
       extension.oid == "#{x509_entry}AltName"
     end
@@ -419,8 +419,8 @@ module Gem::Security
   #
   # The +extensions+ restrict the key to the indicated uses.
 
-  def self.create_cert subject, key, age = ONE_YEAR, extensions = EXTENSIONS,
-                       serial = 1
+  def self.create_cert(subject, key, age = ONE_YEAR, extensions = EXTENSIONS,
+                       serial = 1)
     cert = OpenSSL::X509::Certificate.new
 
     cert.public_key = key.public_key
@@ -446,7 +446,7 @@ module Gem::Security
   # a subject alternative name of +email+ and the given +extensions+ for the
   # +key+.
 
-  def self.create_cert_email email, key, age = ONE_YEAR, extensions = EXTENSIONS
+  def self.create_cert_email(email, key, age = ONE_YEAR, extensions = EXTENSIONS)
     subject = email_to_name email
 
     extensions = extensions.merge "subjectAltName" => "email:#{email}"
@@ -458,8 +458,8 @@ module Gem::Security
   # Creates a self-signed certificate with an issuer and subject of +subject+
   # and the given +extensions+ for the +key+.
 
-  def self.create_cert_self_signed subject, key, age = ONE_YEAR,
-                                   extensions = EXTENSIONS, serial = 1
+  def self.create_cert_self_signed(subject, key, age = ONE_YEAR,
+                                   extensions = EXTENSIONS, serial = 1)
     certificate = create_cert subject, key, age, extensions
 
     sign certificate, key, certificate, age, extensions, serial
@@ -469,14 +469,14 @@ module Gem::Security
   # Creates a new key pair of the specified +length+ and +algorithm+.  The
   # default is a 3072 bit RSA key.
 
-  def self.create_key length = KEY_LENGTH, algorithm = KEY_ALGORITHM
+  def self.create_key(length = KEY_LENGTH, algorithm = KEY_ALGORITHM)
     algorithm.new length
   end
 
   ##
   # Turns +email_address+ into an OpenSSL::X509::Name
 
-  def self.email_to_name email_address
+  def self.email_to_name(email_address)
     email_address = email_address.gsub(/[^\w@.-]+/i, '_')
 
     cn, dcs = email_address.split '@'
@@ -494,8 +494,8 @@ module Gem::Security
   #--
   # TODO increment serial
 
-  def self.re_sign expired_certificate, private_key, age = ONE_YEAR,
-                   extensions = EXTENSIONS
+  def self.re_sign(expired_certificate, private_key, age = ONE_YEAR,
+                   extensions = EXTENSIONS)
     raise Gem::Security::Exception,
           "incorrect signing key for re-signing " +
           "#{expired_certificate.subject}" unless
@@ -531,8 +531,8 @@ module Gem::Security
   #
   # Returns the newly signed certificate.
 
-  def self.sign certificate, signing_key, signing_cert,
-                age = ONE_YEAR, extensions = EXTENSIONS, serial = 1
+  def self.sign(certificate, signing_key, signing_cert,
+                age = ONE_YEAR, extensions = EXTENSIONS, serial = 1)
     signee_subject = certificate.subject
     signee_key     = certificate.public_key
 
@@ -571,7 +571,7 @@ module Gem::Security
   ##
   # Enumerates the trusted certificates via Gem::Security::TrustDir.
 
-  def self.trusted_certificates &block
+  def self.trusted_certificates(&block)
     trust_dir.each_certificate(&block)
   end
 
@@ -580,7 +580,7 @@ module Gem::Security
   # +permissions+. If passed +cipher+ and +passphrase+ those arguments will be
   # passed to +to_pem+.
 
-  def self.write pemmable, path, permissions = 0600, passphrase = nil, cipher = KEY_CIPHER
+  def self.write(pemmable, path, permissions = 0600, passphrase = nil, cipher = KEY_CIPHER)
     path = File.expand_path path
 
     File.open path, 'wb', permissions do |io|

--- a/lib/rubygems/security/policy.rb
+++ b/lib/rubygems/security/policy.rb
@@ -24,7 +24,7 @@ class Gem::Security::Policy
   # Create a new Gem::Security::Policy object with the given mode and
   # options.
 
-  def initialize name, policy = {}, opt = {}
+  def initialize(name, policy = {}, opt = {})
     require 'openssl'
 
     @name = name
@@ -55,7 +55,7 @@ class Gem::Security::Policy
   # Verifies each certificate in +chain+ has signed the following certificate
   # and is valid for the given +time+.
 
-  def check_chain chain, time
+  def check_chain(chain, time)
     raise Gem::Security::Exception, 'missing signing chain' unless chain
     raise Gem::Security::Exception, 'empty signing chain' if chain.empty?
 
@@ -74,7 +74,7 @@ class Gem::Security::Policy
   # Verifies that +data+ matches the +signature+ created by +public_key+ and
   # the +digest+ algorithm.
 
-  def check_data public_key, digest, signature, data
+  def check_data(public_key, digest, signature, data)
     raise Gem::Security::Exception, "invalid signature" unless
       public_key.verify digest.new, signature, data.digest
 
@@ -85,7 +85,7 @@ class Gem::Security::Policy
   # Ensures that +signer+ is valid for +time+ and was signed by the +issuer+.
   # If the +issuer+ is +nil+ no verification is performed.
 
-  def check_cert signer, issuer, time
+  def check_cert(signer, issuer, time)
     raise Gem::Security::Exception, 'missing signing certificate' unless
       signer
 
@@ -111,7 +111,7 @@ class Gem::Security::Policy
   ##
   # Ensures the public key of +key+ matches the public key in +signer+
 
-  def check_key signer, key
+  def check_key(signer, key)
     unless signer and key then
       return true unless @only_signed
 
@@ -129,7 +129,7 @@ class Gem::Security::Policy
   # Ensures the root certificate in +chain+ is self-signed and valid for
   # +time+.
 
-  def check_root chain, time
+  def check_root(chain, time)
     raise Gem::Security::Exception, 'missing signing chain' unless chain
 
     root = chain.first
@@ -148,7 +148,7 @@ class Gem::Security::Policy
   # Ensures the root of +chain+ has a trusted certificate in +trust_dir+ and
   # the digests of the two certificates match according to +digester+
 
-  def check_trust chain, digester, trust_dir
+  def check_trust(chain, digester, trust_dir)
     raise Gem::Security::Exception, 'missing signing chain' unless chain
 
     root = chain.first
@@ -183,7 +183,7 @@ class Gem::Security::Policy
   ##
   # Extracts the email or subject from +certificate+
 
-  def subject certificate # :nodoc:
+  def subject(certificate) # :nodoc:
     certificate.extensions.each do |extension|
       next unless extension.oid == 'subjectAltName'
 
@@ -208,8 +208,8 @@ class Gem::Security::Policy
   #
   # If +key+ is given it is used to validate the signing certificate.
 
-  def verify chain, key = nil, digests = {}, signatures = {},
-             full_name = '(unknown)'
+  def verify(chain, key = nil, digests = {}, signatures = {},
+             full_name = '(unknown)')
     if signatures.empty? then
       if @only_signed then
         raise Gem::Security::Exception,
@@ -280,7 +280,7 @@ class Gem::Security::Policy
   # Extracts the certificate chain from the +spec+ and calls #verify to ensure
   # the signatures and certificate chain is valid according to the policy..
 
-  def verify_signatures spec, digests, signatures
+  def verify_signatures(spec, digests, signatures)
     chain = spec.cert_chain.map do |cert_pem|
       OpenSSL::X509::Certificate.new cert_pem
     end

--- a/lib/rubygems/security/signer.rb
+++ b/lib/rubygems/security/signer.rb
@@ -65,7 +65,7 @@ class Gem::Security::Signer
   # +chain+ containing X509 certificates, encoding certificates or paths to
   # certificates.
 
-  def initialize key, cert_chain, passphrase = nil, options = {}
+  def initialize(key, cert_chain, passphrase = nil, options = {})
     @cert_chain = cert_chain
     @key        = key
     @passphrase = passphrase
@@ -106,7 +106,7 @@ class Gem::Security::Signer
   # Extracts the full name of +cert+.  If the certificate has a subjectAltName
   # this value is preferred, otherwise the subject is used.
 
-  def extract_name cert # :nodoc:
+  def extract_name(cert) # :nodoc:
     subject_alt_name = cert.extensions.find { |e| 'subjectAltName' == e.oid }
 
     if subject_alt_name then
@@ -138,7 +138,7 @@ class Gem::Security::Signer
   ##
   # Sign data with given digest algorithm
 
-  def sign data
+  def sign(data)
     return unless @key
 
     raise Gem::Security::Exception, 'no certs provided' if @cert_chain.empty?

--- a/lib/rubygems/security/trust_dir.rb
+++ b/lib/rubygems/security/trust_dir.rb
@@ -22,7 +22,7 @@ class Gem::Security::TrustDir
   # Creates a new TrustDir using +dir+ where the directory and file
   # permissions will be checked according to +permissions+
 
-  def initialize dir, permissions = DEFAULT_PERMISSIONS
+  def initialize(dir, permissions = DEFAULT_PERMISSIONS)
     @dir = dir
     @permissions = permissions
 
@@ -32,7 +32,7 @@ class Gem::Security::TrustDir
   ##
   # Returns the path to the trusted +certificate+
 
-  def cert_path certificate
+  def cert_path(certificate)
     name_path certificate.subject
   end
 
@@ -59,7 +59,7 @@ class Gem::Security::TrustDir
   # Returns the issuer certificate of the given +certificate+ if it exists in
   # the trust directory.
 
-  def issuer_of certificate
+  def issuer_of(certificate)
     path = name_path certificate.issuer
 
     return unless File.exist? path
@@ -70,7 +70,7 @@ class Gem::Security::TrustDir
   ##
   # Returns the path to the trusted certificate with the given ASN.1 +name+
 
-  def name_path name
+  def name_path(name)
     digest = @digester.hexdigest name.to_s
 
     File.join @dir, "cert-#{digest}.pem"
@@ -79,7 +79,7 @@ class Gem::Security::TrustDir
   ##
   # Loads the given +certificate_file+
 
-  def load_certificate certificate_file
+  def load_certificate(certificate_file)
     pem = File.read certificate_file
 
     OpenSSL::X509::Certificate.new pem
@@ -88,7 +88,7 @@ class Gem::Security::TrustDir
   ##
   # Add a certificate to trusted certificate list.
 
-  def trust_cert certificate
+  def trust_cert(certificate)
     verify
 
     destination = cert_path certificate

--- a/lib/rubygems/server.rb
+++ b/lib/rubygems/server.rb
@@ -450,7 +450,7 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
     @have_rdoc_4_plus = nil
   end
 
-  def add_date res
+  def add_date(res)
     res['date'] = @spec_dirs.map do |spec_dir|
       File.stat(spec_dir).mtime
     end.max
@@ -462,7 +462,7 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
     end
   end
 
-  def doc_root gem_name
+  def doc_root(gem_name)
     if have_rdoc_4_plus? then
       "/doc_root/#{u gem_name}/"
     else
@@ -509,7 +509,7 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
   # Creates server sockets based on the addresses option.  If no addresses
   # were given a server socket for all interfaces is created.
 
-  def listen addresses = @addresses
+  def listen(addresses = @addresses)
     addresses = [nil] unless addresses
 
     listeners = 0
@@ -536,7 +536,7 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
     end
   end
 
-  def prerelease_specs req, res
+  def prerelease_specs(req, res)
     reset_gems
 
     res['content-type'] = 'application/x-gzip'

--- a/lib/rubygems/source.rb
+++ b/lib/rubygems/source.rb
@@ -68,7 +68,7 @@ class Gem::Source
     end
   end
 
-  def == other # :nodoc:
+  def ==(other) # :nodoc:
     self.class === other and @uri == other.uri
   end
 
@@ -126,7 +126,7 @@ class Gem::Source
   ##
   # Fetches a specification for the given +name_tuple+.
 
-  def fetch_spec name_tuple
+  def fetch_spec(name_tuple)
     fetcher = Gem::RemoteFetcher.fetcher
 
     spec_file_name = name_tuple.spec_name
@@ -206,7 +206,7 @@ class Gem::Source
     fetcher.download spec, uri.to_s, dir
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, '[Remote:', ']' do
       q.breakable
       q.text @uri.to_s

--- a/lib/rubygems/source/git.rb
+++ b/lib/rubygems/source/git.rb
@@ -50,7 +50,7 @@ class Gem::Source::Git < Gem::Source
   # repository may contain multiple gems.  If +submodules+ is true, submodules
   # will be checked out when the gem is installed.
 
-  def initialize name, repository, reference, submodules = false
+  def initialize(name, repository, reference, submodules = false)
     super repository
 
     @name            = name
@@ -63,7 +63,7 @@ class Gem::Source::Git < Gem::Source
     @git      = ENV['git'] || 'git'
   end
 
-  def <=> other
+  def <=>(other)
     case other
     when Gem::Source::Git then
       0
@@ -77,7 +77,7 @@ class Gem::Source::Git < Gem::Source
     end
   end
 
-  def == other # :nodoc:
+  def ==(other) # :nodoc:
     super and
       @name            == other.name and
       @repository      == other.repository and
@@ -145,7 +145,7 @@ class Gem::Source::Git < Gem::Source
   ##
   # Nothing to download for git gems
 
-  def download full_spec, path # :nodoc:
+  def download(full_spec, path) # :nodoc:
   end
 
   ##
@@ -157,7 +157,7 @@ class Gem::Source::Git < Gem::Source
     File.join base_dir, 'gems', "#{@name}-#{dir_shortref}"
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, '[Git: ', ']' do
       q.breakable
       q.text @repository

--- a/lib/rubygems/source/installed.rb
+++ b/lib/rubygems/source/installed.rb
@@ -11,7 +11,7 @@ class Gem::Source::Installed < Gem::Source
   ##
   # Installed sources sort before all other sources
 
-  def <=> other
+  def <=>(other)
     case other
     when Gem::Source::Git,
          Gem::Source::Lock,
@@ -29,11 +29,11 @@ class Gem::Source::Installed < Gem::Source
   ##
   # We don't need to download an installed gem
 
-  def download spec, path
+  def download(spec, path)
     nil
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.text '[Installed]'
   end
 

--- a/lib/rubygems/source/local.rb
+++ b/lib/rubygems/source/local.rb
@@ -15,7 +15,7 @@ class Gem::Source::Local < Gem::Source
   ##
   # Local sorts before Gem::Source and after Gem::Source::Installed
 
-  def <=> other
+  def <=>(other)
     case other
     when Gem::Source::Installed,
          Gem::Source::Lock then
@@ -34,7 +34,7 @@ class Gem::Source::Local < Gem::Source
     "#<%s specs: %p>" % [self.class, keys]
   end
 
-  def load_specs type # :nodoc:
+  def load_specs(type) # :nodoc:
     @load_specs_names[type] ||= begin
       names = []
 
@@ -78,8 +78,8 @@ class Gem::Source::Local < Gem::Source
     end
   end
 
-  def find_gem gem_name, version = Gem::Requirement.default, # :nodoc:
-               prerelease = false
+  def find_gem(gem_name, version = Gem::Requirement.default, # :nodoc:
+               prerelease = false)
     load_specs :complete
 
     found = []
@@ -101,7 +101,7 @@ class Gem::Source::Local < Gem::Source
     found.max_by { |s| s.version }
   end
 
-  def fetch_spec name # :nodoc:
+  def fetch_spec(name) # :nodoc:
     load_specs :complete
 
     if data = @specs[name]
@@ -111,7 +111,7 @@ class Gem::Source::Local < Gem::Source
     end
   end
 
-  def download spec, cache_dir = nil # :nodoc:
+  def download(spec, cache_dir = nil) # :nodoc:
     load_specs :complete
 
     @specs.each do |name, data|
@@ -121,7 +121,7 @@ class Gem::Source::Local < Gem::Source
     raise Gem::Exception, "Unable to find file for '#{spec.full_name}'"
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, '[Local gems:', ']' do
       q.breakable
       q.seplist @specs.keys do |v|

--- a/lib/rubygems/source/lock.rb
+++ b/lib/rubygems/source/lock.rb
@@ -15,11 +15,11 @@ class Gem::Source::Lock < Gem::Source
   # Creates a new Lock source that wraps +source+ and moves it earlier in the
   # sort list.
 
-  def initialize source
+  def initialize(source)
     @wrapped = source
   end
 
-  def <=> other # :nodoc:
+  def <=>(other) # :nodoc:
     case other
     when Gem::Source::Lock then
       @wrapped <=> other.wrapped
@@ -30,7 +30,7 @@ class Gem::Source::Lock < Gem::Source
     end
   end
 
-  def == other # :nodoc:
+  def ==(other) # :nodoc:
     0 == (self <=> other)
   end
 
@@ -41,7 +41,7 @@ class Gem::Source::Lock < Gem::Source
   ##
   # Delegates to the wrapped source's fetch_spec method.
 
-  def fetch_spec name_tuple
+  def fetch_spec(name_tuple)
     @wrapped.fetch_spec name_tuple
   end
 

--- a/lib/rubygems/source/specific_file.rb
+++ b/lib/rubygems/source/specific_file.rb
@@ -27,22 +27,22 @@ class Gem::Source::SpecificFile < Gem::Source
 
   attr_reader :spec
 
-  def load_specs *a # :nodoc:
+  def load_specs(*a) # :nodoc:
     [@name]
   end
 
-  def fetch_spec name # :nodoc:
+  def fetch_spec(name) # :nodoc:
     return @spec if name == @name
     raise Gem::Exception, "Unable to find '#{name}'"
     @spec
   end
 
-  def download spec, dir = nil # :nodoc:
+  def download(spec, dir = nil) # :nodoc:
     return @path if spec == @spec
     raise Gem::Exception, "Unable to download '#{spec.full_name}'"
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, '[SpecificFile:', ']' do
       q.breakable
       q.text @path
@@ -59,7 +59,7 @@ class Gem::Source::SpecificFile < Gem::Source
   #
   # Otherwise Gem::Source#<=> is used.
 
-  def <=> other
+  def <=>(other)
     case other
     when Gem::Source::SpecificFile then
       return nil if @spec.name != other.spec.name

--- a/lib/rubygems/source/vendor.rb
+++ b/lib/rubygems/source/vendor.rb
@@ -7,11 +7,11 @@ class Gem::Source::Vendor < Gem::Source::Installed
   ##
   # Creates a new Vendor source for a gem that was unpacked at +path+.
 
-  def initialize path
+  def initialize(path)
     @uri = path
   end
 
-  def <=> other
+  def <=>(other)
     case other
     when Gem::Source::Lock then
       -1

--- a/lib/rubygems/source_list.rb
+++ b/lib/rubygems/source_list.rb
@@ -105,7 +105,7 @@ class Gem::SourceList
     @sources.empty?
   end
 
-  def == other # :nodoc:
+  def ==(other) # :nodoc:
     to_a == other
   end
 
@@ -140,7 +140,7 @@ class Gem::SourceList
   ##
   # Deletes +source+ from the source list which may be a Gem::Source or a URI.
 
-  def delete source
+  def delete(source)
     if source.kind_of? Gem::Source
       @sources.delete source
     else

--- a/lib/rubygems/spec_fetcher.rb
+++ b/lib/rubygems/spec_fetcher.rb
@@ -54,7 +54,7 @@ class Gem::SpecFetcher
   # If you need to retrieve specifications from a different +source+, you can
   # send it as an argument.
 
-  def initialize sources = nil
+  def initialize(sources = nil)
     @sources = sources || Gem.sources
 
     @update_cache =

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -274,7 +274,7 @@ class Gem::Specification < Gem::BasicSpecification
   #
   #   spec.authors = ['John Jones', 'Mary Smith']
 
-  def authors= value
+  def authors=(value)
     @authors = Array(value).flatten.grep(String)
   end
 
@@ -342,7 +342,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Usage:
   #   spec.license = 'MIT'
 
-  def license=o
+  def license=(o)
     self.licenses = [o]
   end
 
@@ -359,7 +359,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Usage:
   #   spec.licenses = ['MIT', 'GPL-2.0']
 
-  def licenses= licenses
+  def licenses=(licenses)
     @licenses = Array licenses
   end
 
@@ -406,7 +406,7 @@ class Gem::Specification < Gem::BasicSpecification
   #
   #   spec.author = 'John Jones'
 
-  def author= o
+  def author=(o)
     self.authors = [o]
   end
 
@@ -457,7 +457,7 @@ class Gem::Specification < Gem::BasicSpecification
   #
   #   spec.platform = Gem::Platform.local
 
-  def platform= platform
+  def platform=(platform)
     if @original_platform.nil? or
        @original_platform == Gem::Platform::RUBY then
       @original_platform = platform
@@ -625,7 +625,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Sets the version of RubyGems that installed this gem.  See also
   # #installed_by_version.
 
-  def installed_by_version= version # :nodoc:
+  def installed_by_version=(version) # :nodoc:
     @installed_by_version = Gem::Version.new version
   end
 
@@ -663,14 +663,14 @@ class Gem::Specification < Gem::BasicSpecification
   #  # Only prereleases or final releases after 2.6.0.preview2
   #  spec.required_ruby_version = '> 2.6.0.preview2'
 
-  def required_ruby_version= req
+  def required_ruby_version=(req)
     @required_ruby_version = Gem::Requirement.create req
   end
 
   ##
   # The RubyGems version required by this gem
 
-  def required_rubygems_version= req
+  def required_rubygems_version=(req)
     @required_rubygems_version = Gem::Requirement.create req
   end
 
@@ -695,7 +695,7 @@ class Gem::Specification < Gem::BasicSpecification
   #   spec.test_files = Dir.glob('test/tc_*.rb')
   #   spec.test_files = ['tests/test-suite.rb']
 
-  def test_files= files # :nodoc:
+  def test_files=(files) # :nodoc:
     @test_files = Array files
   end
 
@@ -772,12 +772,12 @@ class Gem::Specification < Gem::BasicSpecification
     end
   end
 
-  def self.gemspec_stubs_in dir, pattern
+  def self.gemspec_stubs_in(dir, pattern)
     Gem::Util.glob_files_in_dir(pattern, dir).map { |path| yield path }.select(&:valid?)
   end
   private_class_method :gemspec_stubs_in
 
-  def self.default_stubs pattern
+  def self.default_stubs(pattern)
     base_dir = Gem.default_dir
     gems_dir = File.join base_dir, "gems"
     gemspec_stubs_in(default_specifications_dir, pattern) do |path|
@@ -786,7 +786,7 @@ class Gem::Specification < Gem::BasicSpecification
   end
   private_class_method :default_stubs
 
-  def self.installed_stubs dirs, pattern
+  def self.installed_stubs(dirs, pattern)
     map_stubs(dirs, pattern) do |path, base_dir, gems_dir|
       Gem::StubSpecification.gemspec_stub(path, base_dir, gems_dir)
     end
@@ -807,7 +807,7 @@ class Gem::Specification < Gem::BasicSpecification
   end
   private_class_method :uniq_by
 
-  def self.sort_by! list, &block
+  def self.sort_by!(list, &block)
     list.sort_by!(&block)
   end
   private_class_method :sort_by!
@@ -840,7 +840,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Returns a Gem::StubSpecification for installed gem named +name+
   # only returns stubs that match Gem.platforms
 
-  def self.stubs_for name
+  def self.stubs_for(name)
     if @@stubs
       @@stubs_by_name[name] || []
     else
@@ -878,7 +878,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Adds +spec+ to the known specifications, keeping the collection
   # properly sorted.
 
-  def self.add_spec spec
+  def self.add_spec(spec)
     warn "Gem::Specification.add_spec is deprecated and will be removed in RubyGems 3.0" unless Gem::Deprecate.skip
     # TODO: find all extraneous adds
     # puts
@@ -903,7 +903,7 @@ class Gem::Specification < Gem::BasicSpecification
   ##
   # Adds multiple specs to the known specifications.
 
-  def self.add_specs *specs
+  def self.add_specs(*specs)
     warn "Gem::Specification.add_specs is deprecated and will be removed in RubyGems 3.0" unless Gem::Deprecate.skip
 
     raise "nil spec!" if specs.any?(&:nil?) # TODO: remove once we're happy
@@ -941,7 +941,7 @@ class Gem::Specification < Gem::BasicSpecification
   #
   # -- wilsonb
 
-  def self.all= specs
+  def self.all=(specs)
     raise "nil spec!" if specs.any?(&:nil?) # TODO: remove once we're happy
     @@stubs_by_name = specs.group_by(&:name)
     @@all = @@stubs = specs
@@ -985,7 +985,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Set the directories that Specification uses to find specs. Setting
   # this resets the list of known specs.
 
-  def self.dirs= dirs
+  def self.dirs=(dirs)
     self.reset
 
     @@dirs = Array(dirs).map { |dir| File.join dir, "specifications" }
@@ -1008,7 +1008,7 @@ class Gem::Specification < Gem::BasicSpecification
   ##
   # Returns every spec that matches +name+ and optional +requirements+.
 
-  def self.find_all_by_name name, *requirements
+  def self.find_all_by_name(name, *requirements)
     requirements = Gem::Requirement.default if requirements.empty?
 
     # TODO: maybe try: find_all { |s| spec === dep }
@@ -1027,7 +1027,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Find the best specification matching a +name+ and +requirements+. Raises
   # if the dependency doesn't resolve to a valid specification.
 
-  def self.find_by_name name, *requirements
+  def self.find_by_name(name, *requirements)
     requirements = Gem::Requirement.default if requirements.empty?
 
     # TODO: maybe try: find { |s| spec === dep }
@@ -1038,7 +1038,7 @@ class Gem::Specification < Gem::BasicSpecification
   ##
   # Return the best specification that contains the file matching +path+.
 
-  def self.find_by_path path
+  def self.find_by_path(path)
     path = path.dup.freeze
     spec = @@spec_with_requirable_file[path] ||= (stubs.find { |s|
       next unless Gem::BundlerVersionFinder.compatible?(s)
@@ -1051,7 +1051,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Return the best specification that contains the file matching +path+
   # amongst the specs that are not activated.
 
-  def self.find_inactive_by_path path
+  def self.find_inactive_by_path(path)
     stub = stubs.find { |s|
       next if s.activated?
       next unless Gem::BundlerVersionFinder.compatible?(s)
@@ -1060,7 +1060,7 @@ class Gem::Specification < Gem::BasicSpecification
     stub && stub.to_spec
   end
 
-  def self.find_active_stub_by_path path
+  def self.find_active_stub_by_path(path)
     stub = @@active_stub_with_requirable_file[path] ||= (stubs.find { |s|
       s.activated? and s.contains_requirable_file? path
     } || NOT_FOUND)
@@ -1070,7 +1070,7 @@ class Gem::Specification < Gem::BasicSpecification
   ##
   # Return currently unresolved specs that contain the file matching +path+.
 
-  def self.find_in_unresolved path
+  def self.find_in_unresolved(path)
     # TODO: do we need these?? Kill it
     specs = unresolved_deps.values.map { |dep| dep.to_specs }.flatten
 
@@ -1081,7 +1081,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Search through all unresolved deps and sub-dependencies and return
   # specs that contain the file matching +path+.
 
-  def self.find_in_unresolved_tree path
+  def self.find_in_unresolved_tree(path)
     specs = unresolved_deps.values.map { |dep| dep.to_specs }.flatten
 
     specs.each do |spec|
@@ -1129,11 +1129,11 @@ class Gem::Specification < Gem::BasicSpecification
   # Return the latest specs, optionally including prerelease specs if
   # +prerelease+ is true.
 
-  def self.latest_specs prerelease = false
+  def self.latest_specs(prerelease = false)
     _latest_specs Gem::Specification._all, prerelease
   end
 
-  def self._latest_specs specs, prerelease = false # :nodoc:
+  def self._latest_specs(specs, prerelease = false) # :nodoc:
     result = Hash.new { |h,k| h[k] = {} }
     native = {}
 
@@ -1153,7 +1153,7 @@ class Gem::Specification < Gem::BasicSpecification
   ##
   # Loads Ruby format gemspec from +file+.
 
-  def self.load file
+  def self.load(file)
     return unless file
 
     _spec = LOAD_CACHE[file]
@@ -1249,7 +1249,7 @@ class Gem::Specification < Gem::BasicSpecification
   ##
   # Removes +spec+ from the known specs.
 
-  def self.remove_spec spec
+  def self.remove_spec(spec)
     warn "Gem::Specification.remove_spec is deprecated and will be removed in RubyGems 3.0" unless Gem::Deprecate.skip
     _all.delete spec
     stubs.delete_if { |s| s.full_name == spec.full_name }
@@ -1367,7 +1367,7 @@ class Gem::Specification < Gem::BasicSpecification
     sort_obj <=> other.sort_obj
   end
 
-  def == other # :nodoc:
+  def ==(other) # :nodoc:
     self.class === other &&
       name == other.name &&
       version == other.version &&
@@ -1594,7 +1594,7 @@ class Gem::Specification < Gem::BasicSpecification
   ##
   # Returns the full path to an executable named +name+ in this gem.
 
-  def bin_file name
+  def bin_file(name)
     File.join bin_dir, name
   end
 
@@ -1754,7 +1754,7 @@ class Gem::Specification < Gem::BasicSpecification
   #
   # DO NOT set this, it is set automatically when the gem is packaged.
 
-  def date= date
+  def date=(date)
     # We want to end up with a Time object with one-day resolution.
     # This is the cleanest, most-readable, faster-than-using-Date
     # way to do it.
@@ -1800,7 +1800,7 @@ class Gem::Specification < Gem::BasicSpecification
   ##
   # The default value for specification attribute +name+
 
-  def default_value name
+  def default_value(name)
     @@default_value[name]
   end
 
@@ -1846,7 +1846,7 @@ class Gem::Specification < Gem::BasicSpecification
   ##
   # A detailed description of this gem.  See also #summary
 
-  def description= str
+  def description=(str)
     @description = str.to_s
   end
 
@@ -1865,7 +1865,7 @@ class Gem::Specification < Gem::BasicSpecification
   #
   #   spec.doc_dir 'ri' # => "/path/to/gem_repo/doc/a-1/ri"
 
-  def doc_dir type = nil
+  def doc_dir(type = nil)
     @doc_dir ||= File.join base_dir, 'doc', full_name
 
     if type then
@@ -1875,7 +1875,7 @@ class Gem::Specification < Gem::BasicSpecification
     end
   end
 
-  def encode_with coder # :nodoc:
+  def encode_with(coder) # :nodoc:
     mark_version
 
     coder.add 'name', @name
@@ -1896,7 +1896,7 @@ class Gem::Specification < Gem::BasicSpecification
     end
   end
 
-  def eql? other # :nodoc:
+  def eql?(other) # :nodoc:
     self.class === other && same_attributes?(other)
   end
 
@@ -1910,7 +1910,7 @@ class Gem::Specification < Gem::BasicSpecification
   ##
   # Singular accessor for #executables
 
-  def executable=o
+  def executable=(o)
     self.executables = [o]
   end
 
@@ -1918,7 +1918,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Sets executables to +value+, ensuring it is an array. Don't
   # use this, push onto the array instead.
 
-  def executables= value
+  def executables=(value)
     # TODO: warn about setting instead of pushing
     @executables = Array(value)
   end
@@ -1927,7 +1927,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Sets extensions to +extensions+, ensuring it is an array. Don't
   # use this, push onto the array instead.
 
-  def extensions= extensions
+  def extensions=(extensions)
     # TODO: warn about setting instead of pushing
     @extensions = Array extensions
   end
@@ -1936,7 +1936,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Sets extra_rdoc_files to +files+, ensuring it is an array. Don't
   # use this, push onto the array instead.
 
-  def extra_rdoc_files= files
+  def extra_rdoc_files=(files)
     # TODO: warn about setting instead of pushing
     @extra_rdoc_files = Array files
   end
@@ -1953,14 +1953,14 @@ class Gem::Specification < Gem::BasicSpecification
   ##
   # Sets files to +files+, ensuring it is an array.
 
-  def files= files
+  def files=(files)
     @files = Array files
   end
 
   ##
   # Finds all gems that satisfy +dep+
 
-  def find_all_satisfiers dep
+  def find_all_satisfiers(dep)
     Gem::Specification.each do |spec|
       yield spec if spec.satisfies_requirement? dep
     end
@@ -2011,7 +2011,7 @@ class Gem::Specification < Gem::BasicSpecification
   #
   # Formerly used to indicate this gem was RDoc-capable.
 
-  def has_rdoc= ignored # :nodoc:
+  def has_rdoc=(ignored) # :nodoc:
     @has_rdoc = true
   end
   deprecate :has_rdoc=,           :none,       2018, 12
@@ -2034,7 +2034,7 @@ class Gem::Specification < Gem::BasicSpecification
     name.hash ^ version.hash
   end
 
-  def init_with coder # :nodoc:
+  def init_with(coder) # :nodoc:
     @installed_by_version ||= nil
     yaml_initialize coder.tag, coder.map
   end
@@ -2058,7 +2058,7 @@ class Gem::Specification < Gem::BasicSpecification
   # and yields itself for further initialization.  Optionally takes +name+ and
   # +version+.
 
-  def initialize name = nil, version = nil
+  def initialize(name = nil, version = nil)
     super()
     @gems_dir              = nil
     @base_dir              = nil
@@ -2082,7 +2082,7 @@ class Gem::Specification < Gem::BasicSpecification
   ##
   # Duplicates array_attributes from +other_spec+ so state isn't shared.
 
-  def initialize_copy other_spec
+  def initialize_copy(other_spec)
     self.class.array_attributes.each do |name|
       name = :"@#{name}"
       next unless other_spec.instance_variable_defined? name
@@ -2289,7 +2289,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Raise an exception if the version of this spec conflicts with the one
   # that is already loaded (+other+)
 
-  def check_version_conflict other # :nodoc:
+  def check_version_conflict(other) # :nodoc:
     return if self.version == other.version
 
     # This gem is already loaded.  If the currently loaded gem is not in the
@@ -2319,7 +2319,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Sets rdoc_options to +value+, ensuring it is an array. Don't
   # use this, push onto the array instead.
 
-  def rdoc_options= options
+  def rdoc_options=(options)
     # TODO: warn about setting instead of pushing
     @rdoc_options = Array options
   end
@@ -2334,7 +2334,7 @@ class Gem::Specification < Gem::BasicSpecification
   ##
   # Singular accessor for #require_paths
 
-  def require_path= path
+  def require_path=(path)
     self.require_paths = Array(path)
   end
 
@@ -2342,12 +2342,12 @@ class Gem::Specification < Gem::BasicSpecification
   # Set requirements to +req+, ensuring it is an array. Don't
   # use this, push onto the array instead.
 
-  def requirements= req
+  def requirements=(req)
     # TODO: warn about setting instead of pushing
     @requirements = Array req
   end
 
-  def respond_to_missing? m, include_private = false # :nodoc:
+  def respond_to_missing?(m, include_private = false) # :nodoc:
     false
   end
 
@@ -2394,7 +2394,7 @@ class Gem::Specification < Gem::BasicSpecification
   ##
   # True if this gem has the same attributes as +other+.
 
-  def same_attributes? spec
+  def same_attributes?(spec)
     @@attributes.all? { |name, default| self.send(name) == spec.send(name) }
   end
 
@@ -2403,7 +2403,7 @@ class Gem::Specification < Gem::BasicSpecification
   ##
   # Checks if this specification meets the requirement of +dependency+.
 
-  def satisfies_requirement? dependency
+  def satisfies_requirement?(dependency)
     return @name == dependency.name &&
       dependency.requirement.satisfied_by?(@version)
   end
@@ -2450,7 +2450,7 @@ class Gem::Specification < Gem::BasicSpecification
   ##
   # A short summary of this gem's description.
 
-  def summary= str
+  def summary=(str)
     @summary = str.to_s.strip.
       gsub(/(\w-)\n[ \t]*(\w)/, '\1\2').gsub(/\n[ \t]*/, " ") # so. weird.
   end
@@ -2465,7 +2465,7 @@ class Gem::Specification < Gem::BasicSpecification
   ##
   # Singular mutator for #test_files
 
-  def test_file= file # :nodoc:
+  def test_file=(file) # :nodoc:
     self.test_files = [file]
   end
 
@@ -2625,7 +2625,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Recursively walk dependencies of this spec, executing the +block+ for each
   # hop.
 
-  def traverse trail = [], visited = {}, &block
+  def traverse(trail = [], visited = {}, &block)
     trail.push(self)
     begin
       dependencies.each do |dep|
@@ -2658,7 +2658,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Raises InvalidSpecificationException if the spec does not pass the
   # checks..
 
-  def validate packaging = true, strict = false
+  def validate(packaging = true, strict = false)
     require 'rubygems/user_interaction'
     extend Gem::UserInteraction
     normalize
@@ -2699,7 +2699,7 @@ class Gem::Specification < Gem::BasicSpecification
   # required_rubygems_version if +version+ indicates it is a
   # prerelease.
 
-  def version= version
+  def version=(version)
     @version = Gem::Version.create(version)
     # skip to set required_ruby_version when pre-released rubygems.
     # It caused to raise CircularDependencyError

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -384,13 +384,13 @@ http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard li
     warning "#{executable_path} is missing #! line"
   end
 
-  def warning statement # :nodoc:
+  def warning(statement) # :nodoc:
     @warnings += 1
 
     alert_warning statement
   end
 
-  def error statement # :nodoc:
+  def error(statement) # :nodoc:
     raise Gem::InvalidSpecificationException, statement
   ensure
     alert_warning help_text

--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -32,7 +32,7 @@ class Gem::StubSpecification < Gem::BasicSpecification
       'lib' => ['lib'].freeze
     }.freeze
 
-    def initialize data, extensions
+    def initialize(data, extensions)
       parts          = data[PREFIX.length..-1].split(" ".freeze, 4)
       @name          = parts[0].freeze
       @version       = if Gem::Version.correct?(parts[1])
@@ -56,17 +56,17 @@ class Gem::StubSpecification < Gem::BasicSpecification
     end
   end
 
-  def self.default_gemspec_stub filename, base_dir, gems_dir
+  def self.default_gemspec_stub(filename, base_dir, gems_dir)
     new filename, base_dir, gems_dir, true
   end
 
-  def self.gemspec_stub filename, base_dir, gems_dir
+  def self.gemspec_stub(filename, base_dir, gems_dir)
     new filename, base_dir, gems_dir, false
   end
 
   attr_reader :base_dir, :gems_dir
 
-  def initialize filename, base_dir, gems_dir, default_gem
+  def initialize(filename, base_dir, gems_dir, default_gem)
     super()
     filename.untaint
 

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -84,7 +84,7 @@ module Gem
   # Allows setting path to Ruby.  This method is available when requiring
   # 'rubygems/test_case'
 
-  def self.ruby= ruby
+  def self.ruby=(ruby)
     @ruby = ruby
   end
 
@@ -115,7 +115,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
 
   attr_accessor :uri # :nodoc:
 
-  def assert_activate expected, *specs
+  def assert_activate(expected, *specs)
     specs.each do |spec|
       case spec
       when String then
@@ -133,7 +133,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
   end
 
   # TODO: move to minitest
-  def assert_path_exists path, msg = nil
+  def assert_path_exists(path, msg = nil)
     msg = message(msg) { "Expected path '#{path}' to exist" }
     assert File.exist?(path), msg
   end
@@ -142,7 +142,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
   # Sets the ENABLE_SHARED entry in RbConfig::CONFIG to +value+ and restores
   # the original value when the block ends
 
-  def enable_shared value
+  def enable_shared(value)
     enable_shared = RbConfig::CONFIG['ENABLE_SHARED']
     RbConfig::CONFIG['ENABLE_SHARED'] = value
 
@@ -156,7 +156,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
   end
 
   # TODO: move to minitest
-  def refute_path_exists path, msg = nil
+  def refute_path_exists(path, msg = nil)
     msg = message(msg) { "Expected path '#{path}' to not exist" }
     refute File.exist?(path), msg
   end
@@ -513,7 +513,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
   #
   # Yields the +specification+ to the block, if given
 
-  def git_gem name = 'a', version = 1
+  def git_gem(name = 'a', version = 1)
     have_git?
 
     directory = File.join 'git', name
@@ -557,7 +557,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
     skip 'cannot find git executable, use GIT environment variable to set'
   end
 
-  def in_path? executable # :nodoc:
+  def in_path?(executable) # :nodoc:
     return true if %r%\A([A-Z]:|/)% =~ executable and File.exist? executable
 
     ENV['PATH'].split(File::PATH_SEPARATOR).any? do |directory|
@@ -568,7 +568,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
   ##
   # Builds and installs the Gem::Specification +spec+
 
-  def install_gem spec, options = {}
+  def install_gem(spec, options = {})
     require 'rubygems/installer'
 
     gem = File.join @tempdir, "gems", "#{spec.full_name}.gem"
@@ -589,17 +589,17 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
   ##
   # Builds and installs the Gem::Specification +spec+ into the user dir
 
-  def install_gem_user spec
+  def install_gem_user(spec)
     install_gem spec, :user_install => true
   end
 
   ##
   # Uninstalls the Gem::Specification +spec+
-  def uninstall_gem spec
+  def uninstall_gem(spec)
     require 'rubygems/uninstaller'
 
     Class.new(Gem::Uninstaller) {
-      def ask_if_ok spec
+      def ask_if_ok(spec)
         true
       end
     }.new(spec.name, :executables => true, :user_install => true).uninstall
@@ -704,7 +704,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
   ##
   # TODO:  remove in RubyGems 4.0
 
-  def quick_spec name, version = '2' # :nodoc:
+  def quick_spec(name, version = '2') # :nodoc:
     util_spec name, version
   end
   deprecate :quick_spec, :util_spec, 2018, 12
@@ -808,7 +808,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
   #
   # TODO:  remove in RubyGems 4.0
 
-  def new_spec name, version, deps = nil, *files # :nodoc:
+  def new_spec(name, version, deps = nil, *files) # :nodoc:
     require 'rubygems/specification'
 
     spec = Gem::Specification.new do |s|
@@ -872,7 +872,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
   # Creates a spec with +name+, +version+.  +deps+ can specify the dependency
   # or a +block+ can be given for full customization of the specification.
 
-  def util_spec name, version = 2, deps = nil, *files # :yields: specification
+  def util_spec(name, version = 2, deps = nil, *files) # :yields: specification
     raise "deps or block, not both" if deps and block_given?
 
     spec = Gem::Specification.new do |s|
@@ -1359,7 +1359,7 @@ Also, a list:
   ##
   # Construct a new Gem::Dependency.
 
-  def dep name, *requirements
+  def dep(name, *requirements)
     Gem::Dependency.new name, *requirements
   end
 
@@ -1368,7 +1368,7 @@ Also, a list:
   # Gem::Dependency +dep+, a +from_name+ and +from_version+ requesting the
   # dependency and a +parent+ DependencyRequest
 
-  def dependency_request dep, from_name, from_version, parent = nil
+  def dependency_request(dep, from_name, from_version, parent = nil)
     remote = Gem::Source.new @uri
 
     unless parent then
@@ -1386,7 +1386,7 @@ Also, a list:
   ##
   # Constructs a new Gem::Requirement.
 
-  def req *requirements
+  def req(*requirements)
     return requirements.first if Gem::Requirement === requirements.first
     Gem::Requirement.create requirements
   end
@@ -1394,7 +1394,7 @@ Also, a list:
   ##
   # Constructs a new Gem::Specification.
 
-  def spec name, version, &block
+  def spec(name, version, &block)
     Gem::Specification.new name, v(version), &block
   end
 
@@ -1418,7 +1418,7 @@ Also, a list:
   #     end
   #   end
 
-  def spec_fetcher repository = @gem_repo
+  def spec_fetcher(repository = @gem_repo)
     Gem::TestCase::SpecFetcherSetup.declare self, repository do |spec_fetcher_setup|
       yield spec_fetcher_setup if block_given?
     end
@@ -1427,7 +1427,7 @@ Also, a list:
   ##
   # Construct a new Gem::Version.
 
-  def v string
+  def v(string)
     Gem::Version.create string
   end
 
@@ -1437,7 +1437,7 @@ Also, a list:
   #
   # Yields the +specification+ to the block, if given
 
-  def vendor_gem name = 'a', version = 1
+  def vendor_gem(name = 'a', version = 1)
     directory = File.join 'vendor', name
 
     FileUtils.mkdir_p directory
@@ -1451,7 +1451,7 @@ Also, a list:
   #
   # Yields the +specification+ to the block, if given
 
-  def save_gemspec name = 'a', version = 1, directory = '.'
+  def save_gemspec(name = 'a', version = 1, directory = '.')
     vendor_spec = Gem::Specification.new name, version do |specification|
       yield specification if block_given?
     end
@@ -1488,7 +1488,7 @@ Also, a list:
     ##
     # Adds +spec+ to this set.
 
-    def add spec
+    def add(spec)
       @specs << spec
     end
 
@@ -1512,7 +1512,7 @@ Also, a list:
     # Loads a Gem::Specification from this set which has the given +name+,
     # version +ver+, +platform+.  The +source+ is ignored.
 
-    def load_spec name, ver, platform, source
+    def load_spec(name, ver, platform, source)
       dep = Gem::Dependency.new name, ver
       spec = find_spec dep
 
@@ -1521,14 +1521,14 @@ Also, a list:
       end
     end
 
-    def prefetch reqs # :nodoc:
+    def prefetch(reqs) # :nodoc:
     end
   end
 
   ##
   # Loads certificate named +cert_name+ from <tt>test/rubygems/</tt>.
 
-  def self.load_cert cert_name
+  def self.load_cert(cert_name)
     cert_file = cert_path cert_name
 
     cert = File.read cert_file
@@ -1540,7 +1540,7 @@ Also, a list:
   # Returns the path to the certificate named +cert_name+ from
   # <tt>test/rubygems/</tt>.
 
-  def self.cert_path cert_name
+  def self.cert_path(cert_name)
     if 32 == (Time.at(2**32) rescue 32) then
       cert_file =
         File.expand_path "../../../test/rubygems/#{cert_name}_cert_32.pem",
@@ -1555,7 +1555,7 @@ Also, a list:
   ##
   # Loads an RSA private key named +key_name+ with +passphrase+ in <tt>test/rubygems/</tt>
 
-  def self.load_key key_name, passphrase = nil
+  def self.load_key(key_name, passphrase = nil)
     key_file = key_path key_name
 
     key = File.read key_file
@@ -1566,7 +1566,7 @@ Also, a list:
   ##
   # Returns the path to the key named +key_name+ from <tt>test/rubygems</tt>
 
-  def self.key_path key_name
+  def self.key_path(key_name)
     File.expand_path "../../../test/rubygems/#{key_name}_key.pem", __FILE__
   end
 

--- a/lib/rubygems/test_utilities.rb
+++ b/lib/rubygems/test_utilities.rb
@@ -51,7 +51,7 @@ class Gem::FakeFetcher
     @data[path]
   end
 
-  def fetch_path path, mtime = nil, head = false
+  def fetch_path(path, mtime = nil, head = false)
     data = find_data(path)
 
     if data.respond_to?(:call) then
@@ -65,7 +65,7 @@ class Gem::FakeFetcher
     end
   end
 
-  def cache_update_path uri, path = nil, update = true
+  def cache_update_path(uri, path = nil, update = true)
     if data = fetch_path(uri)
       open(path, 'wb') { |io| io.write data } if path and update
       data
@@ -98,7 +98,7 @@ class Gem::FakeFetcher
     response
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.group 2, '[FakeFetcher', ']' do
       q.breakable
       q.text 'URIs:'
@@ -123,7 +123,7 @@ class Gem::FakeFetcher
     data.respond_to?(:call) ? data.call : data.length
   end
 
-  def download spec, source_uri, install_dir = Gem.dir
+  def download(spec, source_uri, install_dir = Gem.dir)
     name = File.basename spec.cache_file
     path = if Dir.pwd == install_dir then # see fetch_command
              install_dir
@@ -144,7 +144,7 @@ class Gem::FakeFetcher
     path
   end
 
-  def download_to_cache dependency
+  def download_to_cache(dependency)
     found, _ = Gem::SpecFetcher.fetcher.spec_for_dependency dependency
 
     return if found.empty?
@@ -187,7 +187,7 @@ class Gem::TestCase::SpecFetcherSetup
   # Executes a SpecFetcher setup block.  Yields an instance then creates the
   # gems and specifications defined in the instance.
 
-  def self.declare test, repository
+  def self.declare(test, repository)
     setup = new test, repository
 
     yield setup
@@ -195,7 +195,7 @@ class Gem::TestCase::SpecFetcherSetup
     setup.execute
   end
 
-  def initialize test, repository # :nodoc:
+  def initialize(test, repository) # :nodoc:
     @test       = test
     @repository = repository
 
@@ -263,7 +263,7 @@ class Gem::TestCase::SpecFetcherSetup
   # The specification will be yielded before gem creation for customization,
   # but only the block or the dependencies may be set, not both.
 
-  def gem name, version, dependencies = nil, &block
+  def gem(name, version, dependencies = nil, &block)
     @operations << [:gem, name, version, dependencies, block]
   end
 
@@ -274,7 +274,7 @@ class Gem::TestCase::SpecFetcherSetup
   # The specification will be yielded before gem creation for customization,
   # but only the block or the dependencies may be set, not both.
 
-  def download name, version, dependencies = nil, &block
+  def download(name, version, dependencies = nil, &block)
     @operations << [:download, name, version, dependencies, block]
   end
 
@@ -327,11 +327,11 @@ class Gem::TestCase::SpecFetcherSetup
   # The specification will be yielded before creation for customization,
   # but only the block or the dependencies may be set, not both.
 
-  def spec name, version, dependencies = nil, &block
+  def spec(name, version, dependencies = nil, &block)
     @operations << [:spec, name, version, dependencies, block]
   end
 
-  def write_spec spec # :nodoc:
+  def write_spec(spec) # :nodoc:
     File.open spec.spec_file, 'w' do |io|
       io.write spec.to_ruby_for_cache
     end

--- a/lib/rubygems/text.rb
+++ b/lib/rubygems/text.rb
@@ -40,7 +40,7 @@ module Gem::Text
     result.join("\n").gsub(/^/, " " * indent)
   end
 
-  def min3 a, b, c # :nodoc:
+  def min3(a, b, c) # :nodoc:
     if a < b && a < c then
       a
     elsif b < c then
@@ -52,7 +52,7 @@ module Gem::Text
 
   # This code is based directly on the Text gem implementation
   # Returns a value representing the "cost" of transforming str1 into str2
-  def levenshtein_distance str1, str2
+  def levenshtein_distance(str1, str2)
     s = str1
     t = str2
     n = s.length

--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -289,7 +289,7 @@ class Gem::Uninstaller
   # Returns true if it is OK to remove +spec+ or this is a forced
   # uninstallation.
 
-  def dependencies_ok? spec # :nodoc:
+  def dependencies_ok?(spec) # :nodoc:
     return true if @force_ignore
 
     deplist = Gem::DependencyList.from_specs
@@ -308,7 +308,7 @@ class Gem::Uninstaller
   ##
   # Asks if it is OK to remove +spec+.  Returns true if it is OK.
 
-  def ask_if_ok spec # :nodoc:
+  def ask_if_ok(spec) # :nodoc:
     msg = ['']
     msg << 'You have requested to uninstall the gem:'
     msg << "\t#{spec.full_name}"
@@ -332,7 +332,7 @@ class Gem::Uninstaller
   ##
   # Returns the formatted version of the executable +filename+
 
-  def formatted_program_filename filename # :nodoc:
+  def formatted_program_filename(filename) # :nodoc:
     # TODO perhaps the installer should leave a small manifest
     # of what it did for us to find rather than trying to recreate
     # it again.

--- a/lib/rubygems/uri_formatter.rb
+++ b/lib/rubygems/uri_formatter.rb
@@ -19,7 +19,7 @@ class Gem::UriFormatter
   ##
   # Creates a new URI formatter for +uri+.
 
-  def initialize uri
+  def initialize(uri)
     @uri = uri
   end
 

--- a/lib/rubygems/user_interaction.rb
+++ b/lib/rubygems/user_interaction.rb
@@ -95,7 +95,7 @@ module Gem::UserInteraction
   ##
   # Displays an alert +statement+.  Asks a +question+ if given.
 
-  def alert statement, question = nil
+  def alert(statement, question = nil)
     ui.alert statement, question
   end
 
@@ -103,7 +103,7 @@ module Gem::UserInteraction
   # Displays an error +statement+ to the error output location.  Asks a
   # +question+ if given.
 
-  def alert_error statement, question = nil
+  def alert_error(statement, question = nil)
     ui.alert_error statement, question
   end
 
@@ -111,49 +111,49 @@ module Gem::UserInteraction
   # Displays a warning +statement+ to the warning output location.  Asks a
   # +question+ if given.
 
-  def alert_warning statement, question = nil
+  def alert_warning(statement, question = nil)
     ui.alert_warning statement, question
   end
 
   ##
   # Asks a +question+ and returns the answer.
 
-  def ask question
+  def ask(question)
     ui.ask question
   end
 
   ##
   # Asks for a password with a +prompt+
 
-  def ask_for_password prompt
+  def ask_for_password(prompt)
     ui.ask_for_password prompt
   end
 
   ##
   # Asks a yes or no +question+.  Returns true for yes, false for no.
 
-  def ask_yes_no question, default = nil
+  def ask_yes_no(question, default = nil)
     ui.ask_yes_no question, default
   end
 
   ##
   # Asks the user to answer +question+ with an answer from the given +list+.
 
-  def choose_from_list question, list
+  def choose_from_list(question, list)
     ui.choose_from_list question, list
   end
 
   ##
   # Displays the given +statement+ on the standard output (or equivalent).
 
-  def say statement = ''
+  def say(statement = '')
     ui.say statement
   end
 
   ##
   # Terminates the RubyGems process with the given +exit_code+
 
-  def terminate_interaction exit_code = 0
+  def terminate_interaction(exit_code = 0)
     ui.terminate_interaction exit_code
   end
 
@@ -161,7 +161,7 @@ module Gem::UserInteraction
   # Calls +say+ with +msg+ or the results of the block if really_verbose
   # is true.
 
-  def verbose msg = nil
+  def verbose(msg = nil)
     say(msg || yield) if Gem.configuration.really_verbose
   end
 end
@@ -212,7 +212,7 @@ class Gem::StreamUI
   # Prints a formatted backtrace to the errors stream if backtraces are
   # enabled.
 
-  def backtrace exception
+  def backtrace(exception)
     return unless Gem.configuration.backtrace
 
     @errs.puts "\t#{exception.backtrace.join "\n\t"}"

--- a/lib/rubygems/util.rb
+++ b/lib/rubygems/util.rb
@@ -46,7 +46,7 @@ module Gem::Util
   # and implements an IO.popen-like behavior where it does not accept an array
   # for a command.
 
-  def self.popen *command
+  def self.popen(*command)
     IO.popen command, &:read
   rescue TypeError # ruby 1.8 only supports string command
     r, w = IO.pipe
@@ -70,7 +70,7 @@ module Gem::Util
   ##
   # Invokes system, but silences all output.
 
-  def self.silent_system *command
+  def self.silent_system(*command)
     opt = {:out => IO::NULL, :err => [:child, :out]}
     if Hash === command.last
       opt.update(command.last)
@@ -103,7 +103,7 @@ module Gem::Util
   ##
   # Enumerates the parents of +directory+.
 
-  def self.traverse_parents directory, &block
+  def self.traverse_parents(directory, &block)
     return enum_for __method__, directory unless block_given?
 
     here = File.expand_path directory

--- a/lib/rubygems/util/list.rb
+++ b/lib/rubygems/util/list.rb
@@ -25,7 +25,7 @@ module Gem
       List.new value, self
     end
 
-    def pretty_print q # :nodoc:
+    def pretty_print(q) # :nodoc:
       q.pp to_a
     end
 

--- a/lib/rubygems/validator.rb
+++ b/lib/rubygems/validator.rb
@@ -62,7 +62,7 @@ class Gem::Validator
   # Describes a problem with a file in a gem.
 
   ErrorData = Struct.new :path, :problem do
-    def <=> other # :nodoc:
+    def <=>(other) # :nodoc:
       return nil unless self.class === other
 
       [path, problem] <=> [other.path, other.problem]

--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -169,7 +169,7 @@ class Gem::Version
   ##
   # True if the +version+ string matches RubyGems' requirements.
 
-  def self.correct? version
+  def self.correct?(version)
     unless Gem::Deprecate.skip
       warn "nil versions are discouraged and will be deprecated in Rubygems 4" if version.nil?
     end
@@ -185,7 +185,7 @@ class Gem::Version
   #   ver2 = Version.create(ver1)       # -> (ver1)
   #   ver3 = Version.create(nil)        # -> nil
 
-  def self.create input
+  def self.create(input)
     if self === input then # check yourself before you wreck yourself
       input
     elsif input.nil? then
@@ -197,7 +197,7 @@ class Gem::Version
 
   @@all = {}
 
-  def self.new version # :nodoc:
+  def self.new(version) # :nodoc:
     return super unless Gem::Version == self
 
     @@all[version] ||= super
@@ -207,7 +207,7 @@ class Gem::Version
   # Constructs a Version from the +version+ string.  A version string is a
   # series of digits or ASCII letters separated by dots.
 
-  def initialize version
+  def initialize(version)
     unless self.class.correct?(version)
       raise ArgumentError, "Malformed version number string #{version}"
     end
@@ -240,7 +240,7 @@ class Gem::Version
   # A Version is only eql? to another version if it's specified to the
   # same precision. Version "1.0" is not the same as version "1".
 
-  def eql? other
+  def eql?(other)
     self.class === other and @version == other._version
   end
 
@@ -248,7 +248,7 @@ class Gem::Version
     canonical_segments.hash
   end
 
-  def init_with coder # :nodoc:
+  def init_with(coder) # :nodoc:
     yaml_initialize coder.tag, coder.map
   end
 
@@ -268,7 +268,7 @@ class Gem::Version
   # Load custom marshal format. It's a string for backwards (RubyGems
   # 1.3.5 and earlier) compatibility.
 
-  def marshal_load array
+  def marshal_load(array)
     initialize array[0]
   end
 
@@ -282,7 +282,7 @@ class Gem::Version
     ["@version"]
   end
 
-  def encode_with coder # :nodoc:
+  def encode_with(coder) # :nodoc:
     coder.add 'version', @version
   end
 
@@ -296,7 +296,7 @@ class Gem::Version
     @prerelease
   end
 
-  def pretty_print q # :nodoc:
+  def pretty_print(q) # :nodoc:
     q.text "Gem::Version.new(#{version.inspect})"
   end
 
@@ -339,7 +339,7 @@ class Gem::Version
   # one. Attempts to compare to something that's not a
   # <tt>Gem::Version</tt> return +nil+.
 
-  def <=> other
+  def <=>(other)
     return unless Gem::Version === other
     return 0 if @version == other._version || canonical_segments == other.canonical_segments
 

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1872,7 +1872,7 @@ You may need to `gem install -g` to install missing gems
     assert platform_defaults.is_a? Hash
   end
 
-  def ruby_install_name name
+  def ruby_install_name(name)
     orig_RUBY_INSTALL_NAME = RbConfig::CONFIG['ruby_install_name']
     RbConfig::CONFIG['ruby_install_name'] = name
 

--- a/test/rubygems/test_gem_commands_check_command.rb
+++ b/test/rubygems/test_gem_commands_check_command.rb
@@ -10,7 +10,7 @@ class TestGemCommandsCheckCommand < Gem::TestCase
     @cmd = Gem::Commands::CheckCommand.new
   end
 
-  def gem name
+  def gem(name)
     spec = quick_gem name do |gem|
       gem.files = %W[lib/#{name}.rb Rakefile]
     end

--- a/test/rubygems/test_gem_commands_contents_command.rb
+++ b/test/rubygems/test_gem_commands_contents_command.rb
@@ -10,7 +10,7 @@ class TestGemCommandsContentsCommand < Gem::TestCase
     @cmd = Gem::Commands::ContentsCommand.new
   end
 
-  def gem name, version = 2
+  def gem(name, version = 2)
     spec = quick_gem name, version do |gem|
       gem.files = %W[lib/#{name}.rb Rakefile]
     end

--- a/test/rubygems/test_gem_commands_help_command.rb
+++ b/test/rubygems/test_gem_commands_help_command.rb
@@ -64,7 +64,7 @@ class TestGemCommandsHelpCommand < Gem::TestCase
     end
   end
 
-  def util_gem *args
+  def util_gem(*args)
     @cmd.options[:args] = args
 
     use_ui @ui do

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -66,7 +66,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     FileUtils.mkdir_p 'default/gems/bundler-audit-1.0.0'
   end
 
-  def gem_install name
+  def gem_install(name)
     gem = util_spec name do |s|
       s.executables = [name]
       s.files = %W[bin/#{name}]

--- a/test/rubygems/test_gem_commands_signin_command.rb
+++ b/test/rubygems/test_gem_commands_signin_command.rb
@@ -74,7 +74,7 @@ class TestGemCommandsSigninCommand < Gem::TestCase
 
   # Utility method to capture IO/UI within the block passed
 
-  def util_capture ui_stub = nil, host = nil, api_key = nil
+  def util_capture(ui_stub = nil, host = nil, api_key = nil)
     api_key ||= 'a5fdbb6ba150cbb83aad2bb2fede64cf040453903'
     response  = [api_key, 200, 'OK']
     email     = 'you@example.com'

--- a/test/rubygems/test_gem_doctor.rb
+++ b/test/rubygems/test_gem_doctor.rb
@@ -4,7 +4,7 @@ require 'rubygems/doctor'
 
 class TestGemDoctor < Gem::TestCase
 
-  def gem name
+  def gem(name)
     spec = quick_gem name do |gem|
       gem.files = %W[lib/#{name}.rb Rakefile]
     end

--- a/test/rubygems/test_gem_ext_ext_conf_builder.rb
+++ b/test/rubygems/test_gem_ext_ext_conf_builder.rb
@@ -216,7 +216,7 @@ end
     assert_equal 'Makefile not found', error.message
   end
 
-  def configure_args args = nil
+  def configure_args(args = nil)
     configure_args = RbConfig::CONFIG['configure_args']
     RbConfig::CONFIG['configure_args'] = args if args
 

--- a/test/rubygems/test_gem_gemcutter_utilities.rb
+++ b/test/rubygems/test_gem_gemcutter_utilities.rb
@@ -187,7 +187,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
     assert_match %r{Access Denied.}, @sign_in_ui.output
   end
 
-  def util_sign_in response, host = nil, args = []
+  def util_sign_in(response, host = nil, args = [])
     email    = 'you@example.com'
     password = 'secret'
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1431,7 +1431,7 @@ gem 'other', version
     def spec.full_name # so the spec is buildable
       "malicious-1"
     end
-    def spec.validate packaging, strict; end
+    def spec.validate(packaging, strict); end
 
     util_build_gem spec
 
@@ -1753,7 +1753,7 @@ gem 'other', version
     @installer = util_installer @spec, @gemhome
   end
 
-  def util_conflict_executable wrappers
+  def util_conflict_executable(wrappers)
     conflict = quick_gem 'conflict' do |spec|
       util_make_exec spec
     end

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -297,11 +297,11 @@ class TestGemPlatform < Gem::TestCase
     assert_local_match 'sparc-solaris2.8-mq5.3'
   end
 
-  def assert_local_match name
+  def assert_local_match(name)
     assert_match Gem::Platform.local, name
   end
 
-  def refute_local_match name
+  def refute_local_match(name)
     refute_match Gem::Platform.local, name
   end
 end

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -211,20 +211,20 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     refute_path_exists path
   end
 
-  def util_fuck_with_fetcher data, blow = false
+  def util_fuck_with_fetcher(data, blow = false)
     fetcher = Gem::RemoteFetcher.fetcher
     fetcher.instance_variable_set :@test_data, data
 
     unless blow then
-      def fetcher.fetch_path arg, *rest
+      def fetcher.fetch_path(arg, *rest)
         @test_arg = arg
         @test_data
       end
     else
-      def fetcher.fetch_path arg, *rest
+      def fetcher.fetch_path(arg, *rest)
         # OMG I'm such an ass
         class << self; remove_method :fetch_path; end
-        def self.fetch_path arg, *rest
+        def self.fetch_path(arg, *rest)
           @test_arg = arg
           @test_data
         end
@@ -424,7 +424,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     util_setup_spec_fetcher @a1, @a2
     @fetcher.instance_variable_set :@a1, @a1
     @fetcher.instance_variable_set :@a2, @a2
-    def @fetcher.fetch_path uri, mtime = nil, head = false
+    def @fetcher.fetch_path(uri, mtime = nil, head = false)
       case uri.request_uri
       when /#{@a1.spec_name}/ then
         Gem.deflate Marshal.dump @a1

--- a/test/rubygems/test_gem_request.rb
+++ b/test/rubygems/test_gem_request.rb
@@ -17,7 +17,7 @@ class TestGemRequest < Gem::TestCase
   PUBLIC_CERT_FILE = cert_path 'public'
   SSL_CERT         = load_cert 'ssl'
 
-  def make_request uri, request_class, last_modified, proxy
+  def make_request(uri, request_class, last_modified, proxy)
     Gem::Request.create_with_proxy uri, request_class, last_modified, proxy
   end
 
@@ -465,7 +465,7 @@ ERROR:  Certificate  is an invalid CA certificate
     @orig_RUBY_REVISION   = RUBY_REVISION if defined? RUBY_REVISION
   end
 
-  def util_stub_net_http hash
+  def util_stub_net_http(hash)
     old_client = Gem::Request::ConnectionPools.client
     conn = Conn.new OpenStruct.new(hash)
     Gem::Request::ConnectionPools.client = conn
@@ -477,7 +477,7 @@ ERROR:  Certificate  is an invalid CA certificate
   class Conn
     attr_accessor :payload
 
-    def new *args; self; end
+    def new(*args); self; end
     def use_ssl=(bool); end
     def verify_callback=(setting); end
     def verify_mode=(setting); end

--- a/test/rubygems/test_gem_request_connection_pools.rb
+++ b/test/rubygems/test_gem_request_connection_pools.rb
@@ -5,7 +5,7 @@ require 'timeout'
 
 class TestGemRequestConnectionPool < Gem::TestCase
   class FakeHttp
-    def initialize *args
+    def initialize(*args)
     end
 
     def start

--- a/test/rubygems/test_gem_request_set_gem_dependency_api.rb
+++ b/test/rubygems/test_gem_request_set_gem_dependency_api.rb
@@ -19,7 +19,7 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
     @gda.instance_variable_set :@vendor_set, @vendor_set
   end
 
-  def with_engine_version name, version
+  def with_engine_version(name, version)
     engine               = RUBY_ENGINE if Object.const_defined? :RUBY_ENGINE
     engine_version_const = "#{Gem.ruby_engine.upcase}_VERSION"
     engine_version       = Object.const_get engine_version_const

--- a/test/rubygems/test_gem_request_set_lockfile.rb
+++ b/test/rubygems/test_gem_request_set_lockfile.rb
@@ -27,7 +27,7 @@ class TestGemRequestSetLockfile < Gem::TestCase
     Gem::RequestSet::Lockfile.build @set, @gem_deps_file
   end
 
-  def write_lockfile lockfile
+  def write_lockfile(lockfile)
     @lock_file = File.expand_path "#{@gem_deps_file}.lock"
 
     File.open @lock_file, 'w' do |io|

--- a/test/rubygems/test_gem_request_set_lockfile_parser.rb
+++ b/test/rubygems/test_gem_request_set_lockfile_parser.rb
@@ -530,13 +530,13 @@ DEPENDENCIES
     refute lockfile_set
   end
 
-  def write_lockfile lockfile
+  def write_lockfile(lockfile)
     File.open @lock_file, 'w' do |io|
       io.write lockfile
     end
   end
 
-  def parse_lockfile set, platforms
+  def parse_lockfile(set, platforms)
     tokenizer = Gem::RequestSet::Lockfile::Tokenizer.from_file @lock_file
     parser = tokenizer.make_parser set, platforms
     parser.parse

--- a/test/rubygems/test_gem_request_set_lockfile_tokenizer.rb
+++ b/test/rubygems/test_gem_request_set_lockfile_tokenizer.rb
@@ -294,7 +294,7 @@ GEM
     assert_equal :token, parser.get
   end
 
-  def write_lockfile lockfile
+  def write_lockfile(lockfile)
     File.open @lock_file, 'w' do |io|
       io.write lockfile
     end

--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -387,26 +387,26 @@ class TestGemRequirement < Gem::TestCase
   # Assert that two requirements are equal. Handles Gem::Requirements,
   # strings, arrays, numbers, and versions.
 
-  def assert_requirement_equal expected, actual
+  def assert_requirement_equal(expected, actual)
     assert_equal req(expected), req(actual)
   end
 
   # Assert that +version+ satisfies +requirement+.
 
-  def assert_satisfied_by version, requirement
+  def assert_satisfied_by(version, requirement)
     assert req(requirement).satisfied_by?(v(version)),
       "#{requirement} is satisfied by #{version}"
   end
 
   # Refute the assumption that two requirements are equal.
 
-  def refute_requirement_equal unexpected, actual
+  def refute_requirement_equal(unexpected, actual)
     refute_equal req(unexpected), req(actual)
   end
 
   # Refute the assumption that +version+ satisfies +requirement+.
 
-  def refute_satisfied_by version, requirement
+  def refute_satisfied_by(version, requirement)
     refute req(requirement).satisfied_by?(v(version)),
       "#{requirement} is not satisfied by #{version}"
   end

--- a/test/rubygems/test_gem_resolver.rb
+++ b/test/rubygems/test_gem_resolver.rb
@@ -23,7 +23,7 @@ class TestGemResolver < Gem::TestCase
     StaticSet.new(specs)
   end
 
-  def assert_resolves_to expected, resolver
+  def assert_resolves_to(expected, resolver)
     actual = resolver.resolve
 
     exp = expected.sort_by { |s| s.full_name }

--- a/test/rubygems/test_gem_resolver_specification.rb
+++ b/test/rubygems/test_gem_resolver_specification.rb
@@ -7,7 +7,7 @@ class TestGemResolverSpecification < Gem::TestCase
     attr_writer :source
     attr_reader :spec
 
-    def initialize spec
+    def initialize(spec)
       super()
 
       @spec = spec

--- a/test/rubygems/test_gem_security_policy.rb
+++ b/test/rubygems/test_gem_security_policy.rb
@@ -518,17 +518,17 @@ class TestGemSecurityPolicy < Gem::TestCase
     end
   end
 
-  def digest data
+  def digest(data)
     digester = @digest.new
     digester << data
     digester
   end
 
-  def sign data, key = PRIVATE_KEY
+  def sign(data, key = PRIVATE_KEY)
     key.sign @digest.new, data.digest
   end
 
-  def dummy_signatures key = PRIVATE_KEY
+  def dummy_signatures(key = PRIVATE_KEY)
     data = digest 'hello'
 
     digests    = { Gem::Security::DIGEST_NAME => { 0 => data } }

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2131,7 +2131,7 @@ dependencies: []
       remove_method :default_ext_dir_for
     end
 
-    def Gem.default_ext_dir_for base_dir
+    def Gem.default_ext_dir_for(base_dir)
       '/foo'
     end
 
@@ -2613,7 +2613,7 @@ end
     end
   end
 
-  def x s; s.gsub(/xxx/, ''); end
+  def x(s); s.gsub(/xxx/, ''); end
   def w; x "WARxxxNING"; end
   def t; x "TOxxxDO"; end
   def f; x "FxxxIXME"; end

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -212,19 +212,19 @@ class TestGemVersion < Gem::TestCase
 
   # Asserts that +version+ is a prerelease.
 
-  def assert_prerelease version
+  def assert_prerelease(version)
     assert v(version).prerelease?, "#{version} is a prerelease"
   end
 
   # Assert that +expected+ is the "approximate" recommendation for +version+.
 
-  def assert_approximate_equal expected, version
+  def assert_approximate_equal(expected, version)
     assert_equal expected, v(version).approximate_recommendation
   end
 
   # Assert that the "approximate" recommendation for +version+ satifies +version+.
 
-  def assert_approximate_satisfies_itself version
+  def assert_approximate_satisfies_itself(version)
     gem_version = v(version)
 
     assert Gem::Requirement.new(gem_version.approximate_recommendation).satisfied_by?(gem_version)
@@ -232,33 +232,33 @@ class TestGemVersion < Gem::TestCase
 
   # Assert that bumping the +unbumped+ version yields the +expected+.
 
-  def assert_bumped_version_equal expected, unbumped
+  def assert_bumped_version_equal(expected, unbumped)
     assert_version_equal expected, v(unbumped).bump
   end
 
   # Assert that +release+ is the correct non-prerelease +version+.
 
-  def assert_release_equal release, version
+  def assert_release_equal(release, version)
     assert_version_equal release, v(version).release
   end
 
   # Assert that two versions are equal. Handles strings or
   # Gem::Version instances.
 
-  def assert_version_equal expected, actual
+  def assert_version_equal(expected, actual)
     assert_equal v(expected), v(actual)
     assert_equal v(expected).hash, v(actual).hash, "since #{actual} == #{expected}, they must have the same hash"
   end
 
   # Assert that two versions are eql?. Checks both directions.
 
-  def assert_version_eql first, second
+  def assert_version_eql(first, second)
     first, second = v(first), v(second)
     assert first.eql?(second), "#{first} is eql? #{second}"
     assert second.eql?(first), "#{second} is eql? #{first}"
   end
 
-  def assert_less_than left, right
+  def assert_less_than(left, right)
     l = v(left)
     r = v(right)
     assert l < r, "#{left} not less than #{right}"
@@ -266,14 +266,14 @@ class TestGemVersion < Gem::TestCase
 
   # Refute the assumption that +version+ is a prerelease.
 
-  def refute_prerelease version
+  def refute_prerelease(version)
     refute v(version).prerelease?, "#{version} is NOT a prerelease"
   end
 
   # Refute the assumption that two versions are eql?. Checks both
   # directions.
 
-  def refute_version_eql first, second
+  def refute_version_eql(first, second)
     first, second = v(first), v(second)
     refute first.eql?(second), "#{first} is NOT eql? #{second}"
     refute second.eql?(first), "#{second} is NOT eql? #{first}"
@@ -281,7 +281,7 @@ class TestGemVersion < Gem::TestCase
 
   # Refute the assumption that the two versions are equal?.
 
-  def refute_version_equal unexpected, actual
+  def refute_version_equal(unexpected, actual)
     refute_equal v(unexpected), v(actual)
   end
 end

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -4,7 +4,7 @@ require 'rubygems'
 
 class TestGemRequire < Gem::TestCase
   class Latch
-    def initialize count = 1
+    def initialize(count = 1)
       @count = count
       @lock  = Monitor.new
       @cv    = @lock.new_cond

--- a/util/create_certs.rb
+++ b/util/create_certs.rb
@@ -6,7 +6,7 @@ class CertificateBuilder
 
   attr_reader :start
 
-  def initialize key_size = 2048
+  def initialize(key_size = 2048)
     @start          = Time.utc 2012, 01, 01, 00, 00, 00
     @end_of_time    = Time.utc 9999, 12, 31, 23, 59, 59
     @end_of_time_32 = Time.utc 2038, 01, 19, 03, 14, 07
@@ -79,7 +79,7 @@ class CertificateBuilder
     OpenSSL::PKey::RSA.new @key_size
   end
 
-  def create_keys names
+  def create_keys(names)
     keys = {}
 
     names.each do |name|
@@ -95,7 +95,7 @@ class CertificateBuilder
     serial
   end
 
-  def validity_for time
+  def validity_for(time)
     if time == :end_of_time then
       validity    = @end_of_time
       validity_32 = @end_of_time_32

--- a/util/update_bundled_ca_certificates.rb
+++ b/util/update_bundled_ca_certificates.rb
@@ -17,7 +17,7 @@ HOSTNAMES_TO_MAP = [
   'index.rubygems.org'
 ].freeze
 
-def connect_to uri, store
+def connect_to(uri, store)
   # None of the URIs are IPv6, so URI::Generic#hostname(ruby 1.9.3+) isn't needed
   http = Net::HTTP.new uri.host, uri.port
 
@@ -33,7 +33,7 @@ rescue OpenSSL::SSL::SSLError
   false
 end
 
-def load_certificates io
+def load_certificates(io)
   cert_texts =
     io.read.scan(/^-{5}BEGIN CERTIFICATE-{5}.*?^-{5}END CERTIFICATE-{5}/m)
 
@@ -42,13 +42,13 @@ def load_certificates io
   end
 end
 
-def show_certificates certificates
+def show_certificates(certificates)
   certificates.each do |certificate|
     p certificate.subject.to_a
   end
 end
 
-def store_for certificates
+def store_for(certificates)
   store = OpenSSL::X509::Store.new
   certificates.each do |certificate|
     store.add_cert certificate
@@ -57,7 +57,7 @@ def store_for certificates
   store
 end
 
-def test_certificates certificates, uri
+def test_certificates(certificates, uri)
   1.upto certificates.length do |n|
     puts "combinations of #{n} certificates"
     certificates.combination(n).each do |combination|
@@ -76,7 +76,7 @@ def test_certificates certificates, uri
   end
 end
 
-def test_uri uri, certificates
+def test_uri(uri, certificates)
   store = store_for certificates
 
   verified = connect_to uri, store
@@ -86,7 +86,7 @@ def test_uri uri, certificates
   nil
 end
 
-def hostname_certificate_mapping certificates
+def hostname_certificate_mapping(certificates)
   mapping = {}
   HOSTNAMES_TO_MAP.each do |hostname|
     uri = URI("https://#{hostname}")
@@ -98,7 +98,7 @@ def hostname_certificate_mapping certificates
   mapping
 end
 
-def write_certificates certificates
+def write_certificates(certificates)
   mapping = hostname_certificate_mapping(certificates)
   mapping.each do |hostname, certificate|
     subject = certificate.subject.to_a


### PR DESCRIPTION
# Description:

One of my biggest annoyances with the current style of Rubygems' codebase is the inconsistent use of parentheses on method definitions. Their use is very mixed and I want to set a single style (methods definitions *must* use parentheses) and enforce it with Rubocop.

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
