### PR TITLE
fix request.rb for intermittently raised error using TLS 1.3

### DIFF
--- a/lib/rubygems/request.rb
+++ b/lib/rubygems/request.rb
@@ -237,6 +237,14 @@ class Gem::Request
       verbose "fatal error"
 
       raise Gem::RemoteFetcher::FetchError.new('fatal error', @uri)
+    rescue (defined?(OpenSSL::SSL) ? OpenSSL::SSL::SSLError : nil) => e
+      # As of 2018-11, error is intermittently raised when using TLS 1.3 with
+      # improper client authentication
+      if OpenSSL::SSL.const_defined? :TLS1_3_VERSION
+        raise Gem::RemoteFetcher::FetchError.new("OpenSSL error: #{e.message}", @uri)
+      else
+        raise e
+      end
     # HACK work around EOFError bug in Net::HTTP
     # NOTE Errno::ECONNABORTED raised a lot on Windows, and make impossible
     # to install gems.


### PR DESCRIPTION
# Description:

When running tests with a Ruby built with OpenSSL 1.1.1 or later, one test has intermittently failed both here and in Ruby trunk testing.  With trunk, sometimes the failure occurs when testing parallel, but passes on retry.  The test is:
```
TestGemRemoteFetcher#test_do_not_allow_invalid_client_cert_auth_connection
```

An error should be raised in the test, but this one starts with OpenSSL, passes thru net/http, and should be caught in `request.rb`.  Since it seems to only occur with OpenSSL 1.1.1/TLSv1_3, code somewhat accounts for that...

Two examples of test failure:
https://ci.appveyor.com/project/rubygems/rubygems/builds/20388929/job/lk27qkfajexyciuj#L30
https://ci.appveyor.com/project/MSP-Greg/ruby-loco/builds/20465475#L2933

# Tasks:

- [X] Describe the problem / feature
- [ ] Write tests
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
