### PR TITLE
remove .document from src

### DIFF
--- a/.document
+++ b/.document
@@ -1,5 +1,0 @@
-README
-LICENSE.txt
-GPL.txt
-lib
-release_notes

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -1,4 +1,3 @@
-.document
 .rubocop.yml
 .travis.yml
 CODE_OF_CONDUCT.md


### PR DESCRIPTION
# Description:

I'm fairly certain that `.document` is no longer being used and can be removed safely

______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
