### PR TITLE
remove old version support

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -749,11 +749,12 @@ require 'rubygems'
 
 version = "#{Gem::Requirement.default}.a"
 
-if ARGV.first
-  str = ARGV.first
+str = ARGV.first
+if str
   str = str.dup.force_encoding("BINARY")
-  if str =~ /\\A_(.*)_\\z/ and Gem::Version.correct?($1)
-    version = $1
+  str = str[/\\A_(.*)_\\z/, 1]
+  if str and Gem::Version.correct?(str)
+    version = str
     ARGV.shift
   end
 end

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -751,8 +751,7 @@ version = "#{Gem::Requirement.default}.a"
 
 str = ARGV.first
 if str
-  str = str.dup.force_encoding("BINARY")
-  str = str[/\\A_(.*)_\\z/, 1]
+  str = str.b[/\\A_(.*)_\\z/, 1]
   if str and Gem::Version.correct?(str)
     version = str
     ARGV.shift

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -55,8 +55,7 @@ version = \">= 0.a\"
 
 str = ARGV.first
 if str
-  str = str.dup.force_encoding("BINARY")
-  str = str[/\\A_(.*)_\\z/, 1]
+  str = str.b[/\\A_(.*)_\\z/, 1]
   if str and Gem::Version.correct?(str)
     version = str
     ARGV.shift

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -53,11 +53,12 @@ require 'rubygems'
 
 version = \">= 0.a\"
 
-if ARGV.first
-  str = ARGV.first
+str = ARGV.first
+if str
   str = str.dup.force_encoding("BINARY")
-  if str =~ /\\A_(.*)_\\z/ and Gem::Version.correct?($1)
-    version = $1
+  str = str[/\\A_(.*)_\\z/, 1]
+  if str and Gem::Version.correct?(str)
+    version = str
     ARGV.shift
   end
 end


### PR DESCRIPTION
# Description:

`String#b` is simpler than `dup` then `force_encoding`, and has been available since ruby 2.0.

This patch does not change behaviors, so no new tests but modified an old test depending on the internal.

______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
