### PR TITLE
Backport ruby core r65992

### DIFF
--- a/lib/rubygems/indexer.rb
+++ b/lib/rubygems/indexer.rb
@@ -4,10 +4,17 @@ require 'rubygems/package'
 require 'time'
 require 'tmpdir'
 
+rescue_exceptions = [LoadError]
+begin
+  require 'bundler/errors'
+rescue LoadError # this rubygems + old ruby
+else # this rubygems + ruby trunk with bundler
+  rescue_exceptions << Bundler::GemfileNotFound
+end
 begin
   gem 'builder'
   require 'builder/xchar'
-rescue LoadError
+rescue *rescue_exceptions
 end
 
 ##


### PR DESCRIPTION
# Description:

Backport https://github.com/ruby/ruby/commit/af6adb9982b93d3e960bc6fe6fa37d01b8f9f130

This resolves an random error depending on load order, which is caused by Ruby 2.6's Bundler integration http://ci.rvm.jp/results/trunk-no-mjit@silicon-docker/1479769

We assume this happens in some load order between rubygems and bundler, but TBH we haven't figured it out yet.
______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
