### PR TITLE
use '|' to preserve line breaks in welcome message

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,4 +1,4 @@
-newPRWelcomeComment: >
+newPRWelcomeComment: |
   Thanks for opening a pull request and helping make RubyGems better! Someone from the RubyGems team will take a look at your pull request shortly and leave any feedback. Please make sure that your pull request has tests for any changes or added functionality.
 
   We use Travis CI to test and make sure your change works functionally and uses acceptable conventions, you can review the current progress of Travis CI in the PR status window below.


### PR DESCRIPTION
# Description:

I used the wrong block in the welcome message YAML. `>` strips the new line breaks, we want to use `|` instead.

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
