### PR TITLE
Add output option to build command

### DIFF
--- a/lib/rubygems/commands/build_command.rb
+++ b/lib/rubygems/commands/build_command.rb
@@ -14,6 +14,10 @@ class Gem::Commands::BuildCommand < Gem::Command
     add_option '--strict', 'consider warnings as errors when validating the spec' do |value, options|
       options[:strict] = true
     end
+
+    add_option '-o', '--output FILE', 'output gem with the given filename' do |value, options|
+      options[:output] = value
+    end
   end
 
   def arguments # :nodoc:
@@ -36,6 +40,11 @@ with gem spec:
   $ cd my_gem-1.0
   [edit gem contents]
   $ gem build my_gem-1.0.gemspec
+
+Gems can be saved to a specified filename with the output option:
+
+  $ gem build my_gem-1.0.gemspec --output=release.gem
+
     EOF
   end
 
@@ -58,7 +67,8 @@ with gem spec:
           Gem::Package.build(
             spec,
             options[:force],
-            options[:strict]
+            options[:strict],
+            options[:output]
           )
         else
           alert_error "Error loading gemspec. Aborting."

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -119,8 +119,8 @@ class Gem::Package
   # Permission for other files
   attr_accessor :data_mode
 
-  def self.build(spec, skip_validation = false, strict_validation = false)
-    gem_file = spec.file_name
+  def self.build(spec, skip_validation = false, strict_validation = false, file_name = nil)
+    gem_file = file_name || spec.file_name
 
     package = new gem_file
     package.spec = spec
@@ -281,7 +281,7 @@ class Gem::Package
   Successfully built RubyGem
   Name: #{@spec.name}
   Version: #{@spec.version}
-  File: #{File.basename @spec.cache_file}
+  File: #{File.basename @gem.path}
 EOM
   ensure
     @signer = nil

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -37,11 +37,39 @@ class TestGemCommandsBuildCommand < Gem::TestCase
     assert @cmd.options[:strict]
   end
 
+  def test_options_filename
+    gemspec_file = File.join(@tempdir, @gem.spec_name)
+
+    File.open gemspec_file, 'w' do |gs|
+      gs.write @gem.to_ruby
+    end
+
+    @cmd.options[:args] = [gemspec_file]
+    @cmd.options[:output] = "test.gem"
+
+    use_ui @ui do
+      Dir.chdir @tempdir do
+        @cmd.execute
+      end
+    end
+
+    file = File.join(@tempdir, File::SEPARATOR, "test.gem")
+    assert File.exist?(file)
+
+    output = @ui.output.split "\n"
+    assert_equal "  Successfully built RubyGem", output.shift
+    assert_equal "  Name: some_gem", output.shift
+    assert_equal "  Version: 2", output.shift
+    assert_equal "  File: test.gem", output.shift
+    assert_equal [], output
+  end
+
   def test_handle_options_defaults
     @cmd.handle_options []
 
     refute @cmd.options[:force]
     refute @cmd.options[:strict]
+    assert_nil @cmd.options[:output]
   end
 
   def test_execute


### PR DESCRIPTION
# Description:

I've come across a few situations when i'm trying to automate a gem build process and found that i always have to add code to find the gem's filename, instead of just setting the filename myself.

To solve this, this PR adds an `--output` option to the `gem build` command that allows the user to specify a filename to save the gem to.

```
$ gem build bundler.gemspec --output release.gem
  Successfully built RubyGem
  Name: bundler
  Version: 2.0.0.dev
  File: release.gem
```
______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
