### PR TITLE
Support case insensitve file systems other than Windows when checking that user bin dir is in PATH

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -695,7 +695,19 @@ class Gem::Installer
     path = ENV['PATH']
     path = path.tr(File::ALT_SEPARATOR, File::SEPARATOR) if File::ALT_SEPARATOR
 
-    if Gem.win_platform?
+    # Windows file system is case insensitive, but other OS's may also be,
+    # so we need to check
+    # test_dir folder needs to exist, try a few...
+    test_dir = if    Dir.exist? user_bin_dir  then user_bin_dir
+               elsif Dir.exist? Gem.user_home then Gem.user_home
+               else  __dir__
+               end
+
+    # fs_case_insens is true for case insensitive file systems
+    fs_case_insens =
+      test_dir != test_dir.swapcase && File.identical?(test_dir, test_dir.swapcase)
+
+    if fs_case_insens
       path = path.downcase
       user_bin_dir = user_bin_dir.downcase
     end

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -219,6 +219,15 @@ gem 'other', version
     end
 
     assert_empty @ui.error
+
+    ENV['PATH'] = [orig_PATH, bin_dir.swapcase].join(File::PATH_SEPARATOR)
+
+    use_ui @ui do
+      installer.check_that_user_bin_dir_is_in_path
+    end
+
+    assert_empty @ui.error
+
   ensure
     ENV['PATH'] = orig_PATH
   end


### PR DESCRIPTION
# Fixes:

test_gem_ext_builder.rb - fix test skip, test now passes on Windows

test/rubygems/test_gem_installer.rb - add test `test_check_that_user_bin_dir_is_in_path_case_insens`

installer.rb - allow for ALT_SEPARATOR or SEPARATOR in Windows ENV items, update case handling

# Description:

1.  Properly handle casing issues.
2. Newer versions of Windows allows File::SEPARATOR in paths, so ENV['PATH'] & ENV['HOME'] can contain either slashes or backslashes.

# Tasks:

- [X] Describe the problem / feature
- [X] Write tests
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
