### PR TITLE
Add validate_cert_chain to specification policy

### DIFF
--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -73,6 +73,8 @@ class Gem::SpecificationPolicy < SimpleDelegator
 
     validate_dependencies
 
+    validate_cert_chain
+
     if @warnings > 0
       if strict
         error "specification has warnings"
@@ -348,6 +350,15 @@ http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard li
       rescue URI::InvalidURIError
         error "\"#{homepage}\" is not a valid HTTP URI"
       end
+    end
+  end
+
+  def validate_cert_chain
+    if cert_chain.empty?
+      warning <<-warning
+No cert chain found. Please consider signing your gem to improve security.
+See https://guides.rubygems.org/security for more information.
+      warning
     end
   end
 

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -25,6 +25,7 @@ class TestGemCommandsBuildCommand < Gem::TestCase
       s.rubyforge_project = 'example'
       s.license = 'AGPL-3.0'
       s.files = ['README.md']
+      s.cert_chain = [PUBLIC_CERT_PATH]
     end
 
     @cmd = Gem::Commands::BuildCommand.new
@@ -121,7 +122,10 @@ class TestGemCommandsBuildCommand < Gem::TestCase
     error = @ui.error.split "\n"
     assert_equal "WARNING:  licenses is empty, but is recommended.  Use a license identifier from", error.shift
     assert_equal "http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.", error.shift
+    assert_equal "WARNING:  No cert chain found. Please consider signing your gem to improve security.", error.shift
+    assert_equal "See https://guides.rubygems.org/security for more information.", error.shift
     assert_equal "WARNING:  See http://guides.rubygems.org/specification-reference/ for help", error.shift
+
     assert_equal [], error
 
     gem_file = File.join @tempdir, File.basename(@gem.cache_file)

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -82,6 +82,7 @@ end
       s.requirements << 'A working computer'
       s.rubyforge_project = 'example'
       s.license = 'MIT'
+      s.cert_chain = [PUBLIC_CERT_PATH]
 
       s.mark_version
       s.files = %w[lib/code.rb]


### PR DESCRIPTION
# Description:
closes https://github.com/rubygems/rubygems/issues/2498

Warn if no cert chain is provided and link the user to the guides on how to set up a cert chain and signing key in their gemspec
______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
