### PR TITLE
remove unneeded Windows skips, TestGemRequire#test_realworld_default_gem

### DIFF
--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -130,8 +130,8 @@ class TestGemCommandsInstallCommand < Gem::TestCase
   end
 
   def test_execute_no_user_install
-    skip 'skipped on MS Windows (chmod has no effect)' if win_platform?
-    skip 'skipped in root privilege' if Process.uid.zero?
+    skip 'skipped on mwsin (chmod has no effect)' if vc_windows?
+    skip 'skipped in root privilege' if Process.uid.zero? && !win_platform?
 
     specs = spec_fetcher do |fetcher|
       fetcher.gem 'a', 2

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -183,7 +183,7 @@ class TestGemConfigFile < Gem::TestCase
   end
 
   def test_check_credentials_permissions
-    skip 'chmod not supported' if win_platform?
+    skip 'chmod 0644 not supported' if win_platform?
 
     @cfg.rubygems_api_key = 'x'
 
@@ -310,7 +310,7 @@ if you believe they were disclosed to a third party.
   end
 
   def test_load_api_keys_bad_permission
-    skip 'chmod not supported' if win_platform?
+    skip 'chmod 0644 not supported' if win_platform?
 
     @cfg.rubygems_api_key = 'x'
 
@@ -352,7 +352,7 @@ if you believe they were disclosed to a third party.
   end
 
   def test_rubygems_api_key_equals_bad_permission
-    skip 'chmod not supported' if win_platform?
+    skip 'chmod 0644 not supported' if win_platform?
 
     @cfg.rubygems_api_key = 'x'
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -441,19 +441,19 @@ gem 'other', version
 
     Dir.mkdir util_inst_bindir
 
-    if win_platform?
-      skip('test_generate_bin_script_no_perms skipped on MS Windows')
-    elsif Process.uid.zero?
+    if vc_windows?
+      skip('test_generate_bin_script_no_perms skipped on mswin')
+    elsif Process.uid.zero? && !win_platform?
       skip('test_generate_bin_script_no_perms skipped in root privilege')
-    else
-      FileUtils.chmod 0000, util_inst_bindir
+    end
 
-      assert_raises Gem::FilePermissionError do
-        @installer.generate_bin
-      end
+    FileUtils.chmod 0000, util_inst_bindir
+
+    assert_raises Gem::FilePermissionError do
+      @installer.generate_bin
     end
   ensure
-    FileUtils.chmod 0755, util_inst_bindir unless ($DEBUG or win_platform?)
+    FileUtils.chmod 0755, util_inst_bindir unless ($DEBUG or vc_windows?)
   end
 
   def test_generate_bin_script_no_shebang

--- a/test/rubygems/test_gem_rdoc.rb
+++ b/test/rubygems/test_gem_rdoc.rb
@@ -222,8 +222,8 @@ class TestGemRDoc < Gem::TestCase
   end
 
   def test_remove_unwritable
-    skip 'chmod not supported' if Gem.win_platform?
-    skip 'skipped in root privilege' if Process.uid.zero?
+    skip 'chmod not supported' if vc_windows?
+    skip 'skipped in root privilege' if Process.uid.zero? && !win_platform?
     FileUtils.mkdir_p @a.base_dir
     FileUtils.chmod 0, @a.base_dir
 
@@ -251,8 +251,8 @@ class TestGemRDoc < Gem::TestCase
   end
 
   def test_setup_unwritable
-    skip 'chmod not supported' if Gem.win_platform?
-    skip 'skipped in root privilege' if Process.uid.zero?
+    skip 'chmod not supported' if vc_windows?
+    skip 'skipped in root privilege' if Process.uid.zero? && !win_platform?
     FileUtils.mkdir_p @a.doc_dir
     FileUtils.chmod 0, @a.doc_dir
 

--- a/test/rubygems/test_gem_spec_fetcher.rb
+++ b/test/rubygems/test_gem_spec_fetcher.rb
@@ -39,7 +39,8 @@ class TestGemSpecFetcher < Gem::TestCase
   end
 
   def test_initialize_unwritable_home_dir
-    skip 'chmod not supported' if Gem.win_platform?
+    skip 'skipped on mwsin (chmod has no effect)' if vc_windows?
+    skip 'skipped in root privilege' if Process.uid.zero? && !win_platform?
 
     FileUtils.chmod 0000, Gem.user_home
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1534,8 +1534,8 @@ dependencies: []
   end
 
   def test_build_extensions_extensions_dir_unwritable
-    skip 'chmod not supported' if Gem.win_platform?
-    skip 'skipped in root privilege' if Process.uid.zero?
+    skip 'chmod not supported' if vc_windows?
+    skip 'skipped in root privilege' if Process.uid.zero? && !win_platform?
 
     ext_spec
 
@@ -1568,7 +1568,7 @@ dependencies: []
   end
 
   def test_build_extensions_no_extensions_dir_unwritable
-    skip 'chmod not supported' if Gem.win_platform?
+    skip 'chmod not supported' if vc_windows?
 
     ext_spec
 
@@ -3260,7 +3260,7 @@ Did you mean 'Ruby'?
   end
 
   def test_validate_permissions_of_missing_file_non_packaging
-    skip 'chmod not supported' if Gem.win_platform?
+    skip 'chmod not supported' if vc_windows?
 
     util_setup_validate
 

--- a/test/rubygems/test_gem_util.rb
+++ b/test/rubygems/test_gem_util.rb
@@ -30,7 +30,7 @@ class TestGemUtil < Gem::TestCase
   end
 
   def test_traverse_parents_does_not_crash_on_permissions_error
-    skip 'skipped on MS Windows (chmod has no effect)' if win_platform?
+    skip 'skipped on MS Windows (chmod 0666 has no effect)' if win_platform?
 
     FileUtils.mkdir_p 'd/e/f'
     # remove 'execute' permission from "e" directory and make it

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -297,7 +297,10 @@ class TestGemRequire < Gem::TestCase
     begin
       gem 'json'
     rescue Gem::MissingSpecError
-      skip "default gems are only available after ruby installation"
+      unless File.expand_path("../..", __dir__).end_with? "rubygems"
+        # running tests in ruby/ruby testing
+        skip "default gems are only available after ruby installation"
+      end
     end
 
     cmd = <<-RUBY
@@ -305,7 +308,7 @@ class TestGemRequire < Gem::TestCase
       require "json"
       puts Gem.loaded_specs["json"].default_gem?
     RUBY
-    output = Gem::Util.popen(Gem.ruby, "-e", cmd).strip
+    output = IO.popen([Gem.ruby, "-e", cmd], &:read).strip
     assert_equal "true", output
   end
 


### PR DESCRIPTION
# Description:

Current MinGW Ruby builds support some `chmod` calls.  Fixes tests that pass but are currently skipped.

[`TestGemRequire#test_realworld_default_gem`](https://github.com/rubygems/rubygems/blob/efe0c45e39e4d809c3f046a31a3fb99e9aef086f/test/rubygems/test_require.rb#L296-L310) seems to be skipped for ruby/ruby testing, but works for testing here.

# Tasks:

- [X] Describe the problem / feature
- [ ] Write tests
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
