### PR TITLE
Fix crash on certain gemspecs

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2693,7 +2693,7 @@ class Gem::Specification < Gem::BasicSpecification
     @version = Gem::Version.create(version)
     # skip to set required_ruby_version when pre-released rubygems.
     # It caused to raise CircularDependencyError
-    if @version.prerelease? && @name.strip != "rubygems"
+    if @version.prerelease? && (@name.nil? || @name.strip != "rubygems")
       self.required_rubygems_version = '> 1.3.1'
     end
     invalidate_memoized_attributes

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1345,6 +1345,16 @@ dependencies: []
     assert_equal '/path/to/file', e.file_path
   end
 
+  def test_initialize_prerelease_version_before_name
+    spec = Gem::Specification.new do |s|
+      s.version = '1.0.0.dev'
+      s.name = 'a'
+    end
+
+    assert_equal "a", spec.name
+    assert_equal "1.0.0.dev", spec.version.to_s
+  end
+
   def test__dump
     @a2.platform = Gem::Platform.local
     @a2.instance_variable_set :@original_platform, 'old_platform'


### PR DESCRIPTION
# Description:

If `version` was a prerelease, and was defined before `name` in the gemspec, rubygems would crash.

This commit fixes that.

This regression was introduced in https://github.com/rubygems/rubygems/pull/2128.
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
