### PR TITLE
Fixed test fails with the newer version of OpenSSL

### DIFF
--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -274,7 +274,7 @@ class Gem::RemoteFetcher
     raise
   rescue Timeout::Error
     raise UnknownHostError.new('timed out', uri.to_s)
-  rescue IOError, SocketError, SystemCallError => e
+  rescue IOError, SocketError, SystemCallError, OpenSSL::SSL::SSLError => e
     if e.message =~ /getaddrinfo/
       raise UnknownHostError.new('no such name', uri.to_s)
     else


### PR DESCRIPTION
# Description:

This backport fixes https://github.com/rubygems/rubygems/pull/2486 .

I already fixed at https://github.com/ruby/ruby/commit/edbac1b986d6cbacf191bd1fde15e5de801a4935
______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
