### PR TITLE
Increase timeout for ruby core testing with --jit-wait

### DIFF
--- a/test/rubygems/test_gem_stream_ui.rb
+++ b/test/rubygems/test_gem_stream_ui.rb
@@ -4,6 +4,7 @@ require 'rubygems/user_interaction'
 require 'timeout'
 
 class TestGemStreamUI < Gem::TestCase
+  SHORT_TIMEOUT = (defined?(RubyVM::MJIT) && RubyVM::MJIT.enabled?) ? 1.0 : 0.1 # increase timeout with MJIT for --jit-wait testing
 
   module IsTty
     attr_accessor :tty
@@ -47,7 +48,7 @@ class TestGemStreamUI < Gem::TestCase
   def test_ask_no_tty
     @in.tty = false
 
-    Timeout.timeout(0.1) do
+    Timeout.timeout(SHORT_TIMEOUT) do
       answer = @sui.ask("what is your favorite color?")
       assert_nil answer
     end
@@ -65,7 +66,7 @@ class TestGemStreamUI < Gem::TestCase
   def test_ask_for_password_no_tty
     @in.tty = false
 
-    Timeout.timeout(0.1) do
+    Timeout.timeout(SHORT_TIMEOUT) do
       answer = @sui.ask_for_password("what is the airspeed velocity of an unladen swallow?")
       assert_nil answer
     end
@@ -74,7 +75,7 @@ class TestGemStreamUI < Gem::TestCase
   def test_ask_yes_no_no_tty_with_default
     @in.tty = false
 
-    Timeout.timeout(0.1) do
+    Timeout.timeout(SHORT_TIMEOUT) do
       answer = @sui.ask_yes_no("do coconuts migrate?", false)
       assert_equal false, answer
 
@@ -86,7 +87,7 @@ class TestGemStreamUI < Gem::TestCase
   def test_ask_yes_no_no_tty_without_default
     @in.tty = false
 
-    Timeout.timeout(0.1) do
+    Timeout.timeout(SHORT_TIMEOUT) do
       assert_raises(Gem::OperationNotSupportedError) do
         @sui.ask_yes_no("do coconuts migrate?")
       end


### PR DESCRIPTION
# Description:
0.1s timeout is too short for testing ruby's MJIT with synchronous compilation of all methods enabled.
This enables to test that on ruby core CI with --jit-wait. This backports https://github.com/ruby/ruby/commit/70a385a4f655465e6f65c07a91150c61b34aea2e.
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
