### PR TITLE
Move rubocop into a separate stage in travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,16 @@ rvm:
 env:
   - "TEST_TOOL=rubygems YAML=psych"
   - "TEST_TOOL=bundler RGV=master"
+jobs:
+  include:
+    - stage: rubocop
+      rvm: 2.5
+      env:
+        - "TEST_TOOL=rubygems YAML=psych"
+      script: util/ci rubocop
+stages:
+  - rubocop
+  - test
 before_script:
   - util/ci before_script
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,13 @@ env:
   - "TEST_TOOL=bundler RGV=master"
 jobs:
   include:
-    - stage: rubocop
+    - stage: linting
       rvm: 2.5
       env:
         - "TEST_TOOL=rubygems YAML=psych"
       script: util/ci rubocop
 stages:
-  - rubocop
+  - linting
   - test
 before_script:
   - util/ci before_script

--- a/util/ci
+++ b/util/ci
@@ -58,16 +58,16 @@ when %w(before_script)
       run('gem', %w(install bundler -v 1.16.2))
     end
 
-    run('gem', %w(install rubocop -v ~>0.60.0))
-
     run('gem', %w(list --details))
     run('gem', %w(env))
   else
     with_retries { run('rake', %w(spec:travis:deps)) }
   end
+when %w(rubocop)
+  run('gem', %w(install rubocop -v ~>0.60.0))
+  run('util/rubocop')
 when %w(script)
   if TOOL.rubygems?
-    run('util/rubocop')
     run('rake test')
   else
     run('rake', %w(spec:travis -t))


### PR DESCRIPTION
# Description:

TIL it's now possible to use multiple stages in Travis-CI while using the `rvm` matrix. With that, this PR moves rubocop into it's own stage - before any tests are executed. This should provide faster feedback to contributors and make a clear separation between linting and tests.

Here's an [example build](https://travis-ci.org/rubygems/rubygems/builds/463775265) (this failed because it was a custom build that didn't have the changes to run rubocop by itself). The build for this PR should use the separate stages as well.
______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
