### PR TITLE
Better unrestricted warning

### DIFF
--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -158,11 +158,10 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
                    ", '>= #{dep_version}'"
                  end
 
-        warning_messages << <<-WARNING
-open-ended dependency on #{dep} is not recommended
-  if #{dep.name} is semantically versioned, use:
-    add_#{dep.type}_dependency '#{dep.name}', '~> #{base.join '.'}'#{bugfix}
-        WARNING
+        recommendation = "  if #{dep.name} is semantically versioned, use:\n" \
+                         "    add_#{dep.type}_dependency '#{dep.name}', '~> #{base.join '.'}'#{bugfix}"
+
+        warning_messages << ["open-ended dependency on #{dep} is not recommended", recommendation].join("\n") + "\n"
       end
     end
     if error_messages.any?

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -154,14 +154,18 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
 
         base = segments.first 2
 
-        bugfix = if op == '>'
-                   ", '> #{dep_version}'"
-                 elsif op == '>=' and base != segments
-                   ", '>= #{dep_version}'"
-                 end
+        recommendation = if (op == '>' || op == '>=') && segments == [0]
+                           "  use a bounded requirement, such as '~> x.y'"
+                         else
+                           bugfix = if op == '>'
+                                      ", '> #{dep_version}'"
+                                    elsif op == '>=' and base != segments
+                                      ", '>= #{dep_version}'"
+                                    end
 
-        recommendation = "  if #{dep.name} is semantically versioned, use:\n" \
-                         "    add_#{dep.type}_dependency '#{dep.name}', '~> #{base.join '.'}'#{bugfix}"
+                           "  if #{dep.name} is semantically versioned, use:\n" \
+                           "    add_#{dep.type}_dependency '#{dep.name}', '~> #{base.join '.'}'#{bugfix}"
+                         end
 
         warning_messages << ["open-ended dependency on #{dep} is not recommended", recommendation].join("\n") + "\n"
       end

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -150,11 +150,13 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
       if open_ended
         op, dep_version = dep.requirement.requirements.first
 
-        base = dep_version.segments.first 2
+        segments = dep_version.segments
+
+        base = segments.first 2
 
         bugfix = if op == '>'
                    ", '> #{dep_version}'"
-                 elsif op == '>=' and base != dep_version.segments
+                 elsif op == '>=' and base != segments
                    ", '>= #{dep_version}'"
                  end
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2699,6 +2699,7 @@ end
       @a1.add_runtime_dependency     'l', '> 1.2.3'
       @a1.add_runtime_dependency     'm', '~> 2.1.0'
       @a1.add_runtime_dependency     'n', '~> 0.1.0'
+      @a1.add_runtime_dependency     'o'
 
       use_ui @ui do
         @a1.validate
@@ -2719,6 +2720,8 @@ end
 #{w}:  open-ended dependency on l (> 1.2.3) is not recommended
   if l is semantically versioned, use:
     add_runtime_dependency 'l', '~> 1.2', '> 1.2.3'
+#{w}:  open-ended dependency on o (>= 0) is not recommended
+  use a bounded requirement, such as '~> x.y'
 #{w}:  See http://guides.rubygems.org/specification-reference/ for help
       EXPECTED
 


### PR DESCRIPTION
# Description:

This is a possible fix for #2508. If the dependency is fully unrestricted, give a generic message instead of guessing what the user wants, since we cannot really know it.
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
