### PR TITLE
[BudlerVersionFinder] set .filter! and .compatible? to match only on major versions

### DIFF
--- a/lib/rubygems/bundler_version_finder.rb
+++ b/lib/rubygems/bundler_version_finder.rb
@@ -37,20 +37,14 @@ To install the missing version, run `gem install bundler:#{vr.first}`
   def self.compatible?(spec)
     return true unless spec.name == "bundler".freeze
     return true unless bundler_version = self.bundler_version
-    if bundler_version.segments.first >= 2
-      spec.version == bundler_version
-    else # 1.x
-      spec.version.segments.first < 2
-    end
+
+    spec.version.segments.first == bundler_version.segments.first
   end
 
   def self.filter!(specs)
     return unless bundler_version = self.bundler_version
-    if bundler_version.segments.first >= 2
-      specs.reject! { |spec| spec.version != bundler_version }
-    else # 1.x
-      specs.reject! { |spec| spec.version.segments.first >= 2}
-    end
+
+    specs.reject! { |spec| spec.version.segments.first != bundler_version.segments.first }
   end
 
   def self.bundle_update_bundler_version

--- a/test/rubygems/test_gem_bundler_version_finder.rb
+++ b/test/rubygems/test_gem_bundler_version_finder.rb
@@ -88,20 +88,21 @@ class TestGemBundlerVersionFinder < Gem::TestCase
     bvf.stub(:bundler_version, v("2.1.1.1")) do
       assert bvf.compatible?(util_spec("foo"))
       assert bvf.compatible?(util_spec("bundler", "2.1.1.1"))
-      refute bvf.compatible?(util_spec("bundler", "2.1.1.a"))
+      assert bvf.compatible?(util_spec("bundler", "2.1.1.a"))
+      assert bvf.compatible?(util_spec("bundler", "2.999"))
       refute bvf.compatible?(util_spec("bundler", "1.999"))
-      refute bvf.compatible?(util_spec("bundler", "2.999"))
+      refute bvf.compatible?(util_spec("bundler", "3.0.0"))
     end
   end
 
   def test_filter
-    versions = %w[1 1.0 1.0.1.1 2.a 3 3.0]
+    versions = %w[1 1.0 1.0.1.1 2 2.a 2.0 2.1.1 3 3.a 3.0 3.1.1]
     specs = versions.map { |v| util_spec("bundler", v) }
 
-    assert_equal %w[1 1.0 1.0.1.1 2.a 3 3.0], util_filter_specs(specs).map(&:version).map(&:to_s)
+    assert_equal %w[1 1.0 1.0.1.1 2 2.a 2.0 2.1.1 3 3.a 3.0 3.1.1], util_filter_specs(specs).map(&:version).map(&:to_s)
 
     bvf.stub(:bundler_version, v("2.1.1.1")) do
-      assert_empty util_filter_specs(specs).map(&:version).map(&:to_s)
+      assert_equal %w[2 2.a 2.0 2.1.1], util_filter_specs(specs).map(&:version).map(&:to_s)
     end
     bvf.stub(:bundler_version, v("1.1.1.1")) do
       assert_equal %w[1 1.0 1.0.1.1], util_filter_specs(specs).map(&:version).map(&:to_s)
@@ -110,10 +111,10 @@ class TestGemBundlerVersionFinder < Gem::TestCase
       assert_equal %w[1 1.0 1.0.1.1], util_filter_specs(specs).map(&:version).map(&:to_s)
     end
     bvf.stub(:bundler_version, v("2.a")) do
-      assert_equal %w[2.a], util_filter_specs(specs).map(&:version).map(&:to_s)
+      assert_equal %w[2 2.a 2.0 2.1.1], util_filter_specs(specs).map(&:version).map(&:to_s)
     end
     bvf.stub(:bundler_version, v("3")) do
-      assert_equal %w[3 3.0], util_filter_specs(specs).map(&:version).map(&:to_s)
+      assert_equal %w[3 3.a 3.0 3.1.1], util_filter_specs(specs).map(&:version).map(&:to_s)
     end
   end
 


### PR DESCRIPTION
# Description:

This is a complicated problem so I will do my best to explain it well. When people use Bundler, there is a bit of functionality in RubyGems called the `BundlerVersionFinder`, that filters the available Bundler specs that RubyGems could activate - depending on the Gemfile.lock.

For a `Gemfile.lock` that is `BUNDLED WITH` 1.17.1, the `BundlerVersionFinder` allows for any version of Bundler 1. But for Bundler 2, only the exact same version is allowed.

https://github.com/rubygems/rubygems/blob/fa9c3b6cc8e8d20b0486524c5eec851768e594fe/lib/rubygems/bundler_version_finder.rb#L40-L43

This functionality was built to support Bundler's postit/trampoline functionality which was removed about a year ago that would automatically install the locked version of Bundler in the `Gemfile.lock`

This code is an issue now because after Bundler 2 is released, everyone would have to manually install the exact version of Bundler for each `Gemfile` a person is working on. Going forward, I want to keep the functionality the same as Bundler 1. A `Gemfile.lock` that that was bundled with `2.0.0` is compatible with `2.1.0`, `2.1.1.0`, `2.9999`, but not `3.0.0`. And a `Gemfile.lock` that that was bundled with `3.0.0` Is compatible with `3.1.0`, `3.999` and so on.

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).