### PR TITLE
Use net/http, not net/https.

### DIFF
--- a/lib/rubygems/request.rb
+++ b/lib/rubygems/request.rb
@@ -45,7 +45,6 @@ class Gem::Request
   end
 
   def self.configure_connection_for_https(connection, cert_files)
-    require 'net/https'
     connection.use_ssl = true
     connection.verify_mode =
       Gem.configuration.ssl_verify_mode || OpenSSL::SSL::VERIFY_PEER

--- a/test/rubygems/test_bundled_ca.rb
+++ b/test/rubygems/test_bundled_ca.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
-require 'net/https'
+require 'net/http'
 require 'rubygems/request'
 
 # = Testing Bundled CA


### PR DESCRIPTION
# Description:

`net/https` has been merged into `net/http` since at least 1.9.3.

The [ruby-doc.org page for net/http in Ruby 1.9.3](https://ruby-doc.org/stdlib-1.9.3/libdoc/net/http/rdoc/Net/HTTP.html#class-Net::HTTPSession-label-HTTPS) says `In previous versions of ruby you would need to require 'net/https' to use HTTPS. This is no longer true.`

As far as I know, we are no longer supporting Ruby <2.0, so there is no point in differentiating.

Note that `lib/rubygems/request.rb` unconditionally requires `net/http` earlier in the file, which is why I just removed the `require 'net/https'` instead of changing it.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
