### PR TITLE
Workaround for test failure related bundler in ruby core

### DIFF
--- a/test/rubygems/test_gem_package_task.rb
+++ b/test/rubygems/test_gem_package_task.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
 require 'rubygems'
+require 'bundler/errors'
 begin
   require 'rubygems/package_task'
-rescue LoadError
+rescue LoadError, Bundler::GemfileNotFound
 end
 
 class TestGemPackageTask < Gem::TestCase


### PR DESCRIPTION
# Description:


```
test_gem_package_task.rb: suppress random failure by Bundler.

http://ci.rvm.jp/results/trunk-vm-asserts@silicon-docker/1500762

git-svn-id: svn+ssh://ci.ruby-lang.org/ruby/trunk@66263 b2dd03c8-39d4-4d8f-98ff-823fe69b080e
```

______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
