### PR TITLE
Fix remote fetcher tests

### DIFF
--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -818,11 +818,16 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
 
   def test_do_not_follow_insecure_redirect
     ssl_server = self.class.start_ssl_server
-    temp_ca_cert = File.join(DIR, 'ca_cert.pem'),
+    temp_ca_cert = File.join(DIR, 'ca_cert.pem')
+    expected_error_message =
+      "redirecting to non-https resource: #{@server_uri} (https://localhost:#{ssl_server.config[:Port]}/insecure_redirect?to=#{@server_uri})"
+
     with_configured_fetcher(":ssl_ca_cert: #{temp_ca_cert}") do |fetcher|
-      assert_raises Gem::RemoteFetcher::FetchError do
+      err = assert_raises Gem::RemoteFetcher::FetchError do
         fetcher.fetch_path("https://localhost:#{ssl_server.config[:Port]}/insecure_redirect?to=#{@server_uri}")
       end
+
+      assert_equal(err.message, expected_error_message)
     end
   end
 

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -831,6 +831,17 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     end
   end
 
+  def test_nil_ca_cert
+    ssl_server = self.class.start_ssl_server
+    temp_ca_cert = nil
+
+    with_configured_fetcher(":ssl_ca_cert: #{temp_ca_cert}") do |fetcher|
+      assert_raises Gem::RemoteFetcher::FetchError do
+        fetcher.fetch_path("https://localhost:#{ssl_server.config[:Port]}")
+      end
+    end
+  end
+
   def with_configured_fetcher(config_str = nil, &block)
     if config_str
       temp_conf = File.join @tempdir, '.gemrc'


### PR DESCRIPTION
Closes https://github.com/rubygems/rubygems/issues/2437

This fix an erroneous test when testing insecure redirects...

What we wanted to test was `Gem::RemoteFetcher::FetchError` being raised by an insecure redirect, but instead we were testing for a `Gem::RemoteFetcher::FetchError` raised by a `nil` ca_cert raised in 
https://github.com/rubygems/rubygems/blob/cfa1d68962fa46cfbef624362813127a4a98a9f8/lib/rubygems/request/http_pool.rb#L38
which bubbles up to:
https://github.com/rubygems/rubygems/blob/cfa1d68962fa46cfbef624362813127a4a98a9f8/lib/rubygems/request.rb#L132

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
