### PR TITLE
Ignore warnings with test_gem_specification.rb

### DIFF
--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1211,7 +1211,7 @@ dependencies: []
 
     data = Marshal.load Gem::Util.inflate(Gem.read_binary(path))
 
-    assert_nil data.default_executable
+    assert_nil data.signing_key
   end
 
   def test_initialize


### PR DESCRIPTION
# Description:

Use signing_key, Because default_executables is deprecated now.

______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
