### PR TITLE
Sort files and test_files in specifications

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2254,6 +2254,7 @@ class Gem::Specification < Gem::BasicSpecification
 
       attributes.each do |attr_name|
         current_value = self.send attr_name
+        current_value = current_value.sort if %i(files test_files).include? attr_name
         if current_value != default_value(attr_name) or
            self.class.required_attribute? attr_name
 


### PR DESCRIPTION
# Description:

Currently, when writing out specifications, the order of the elements
in files and test_files can differ. Even if the set of files (in the
mathematical sense) is the same, the different order causes the files
or test_files to look different.

This causes problems with the reproducibility of working with
specifications. You can install a gem on different machines, and get
gemspecs that differ.

This change sorts the files and test_files, to protect against the
specifications differing unnecessarily.

______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
