### PR TITLE
Support the environment without OpenSSL

### DIFF
--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -274,7 +274,8 @@ class Gem::RemoteFetcher
     raise
   rescue Timeout::Error
     raise UnknownHostError.new('timed out', uri.to_s)
-  rescue IOError, SocketError, SystemCallError, OpenSSL::SSL::SSLError => e
+  rescue IOError, SocketError, SystemCallError,
+    *(OpenSSL::SSL::SSLError if defined?(OpenSSL)) => e
     if e.message =~ /getaddrinfo/
       raise UnknownHostError.new('no such name', uri.to_s)
     else

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -516,6 +516,24 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     assert_equal url, e.uri
   end
 
+  def test_fetch_path_openssl_ssl_sslerror
+    fetcher = Gem::RemoteFetcher.new nil
+    @fetcher = fetcher
+
+    def fetcher.fetch_http(uri, mtime = nil, head = nil)
+      raise OpenSSL::SSL::SSLError
+    end
+
+    url = 'http://example.com/uri'
+
+    e = assert_raises Gem::RemoteFetcher::FetchError do
+      fetcher.fetch_path url
+    end
+
+    assert_equal "OpenSSL::SSL::SSLError: OpenSSL::SSL::SSLError (#{url})", e.message
+    assert_equal url, e.uri
+  end
+
   def test_fetch_path_unmodified
     fetcher = Gem::RemoteFetcher.new nil
     @fetcher = fetcher


### PR DESCRIPTION
# Description:

Fixup https://github.com/rubygems/rubygems/commit/d9ed00405697f05d683b5d27a8417d207048996f

```
fix r66163

OpenSSL maybe aren't loaded in rubygems.

git-svn-id: svn+ssh://ci.ruby-lang.org/ruby/trunk@66400 b2dd03c8-39d4-4d8f-98ff-823fe69b080e
```

______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
