### PR TITLE
Revert #2517

### DIFF
--- a/lib/rubygems/request.rb
+++ b/lib/rubygems/request.rb
@@ -45,6 +45,7 @@ class Gem::Request
   end
 
   def self.configure_connection_for_https(connection, cert_files)
+    require 'net/https'
     connection.use_ssl = true
     connection.verify_mode =
       Gem.configuration.ssl_verify_mode || OpenSSL::SSL::VERIFY_PEER

--- a/test/rubygems/test_bundled_ca.rb
+++ b/test/rubygems/test_bundled_ca.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
-require 'net/http'
+require 'net/https'
 require 'rubygems/request'
 
 # = Testing Bundled CA


### PR DESCRIPTION
# Description:

```
Revert "Use net/http, not net/https. They have both been merged into net/http since at least 1.9.3."

This reverts commit 3933b2b7302f7d2753ad0f28ea79bb855de0b5be.
```

It commits break the environment without OpenSSL like https://github.com/rubygems/rubygems/issues/2526
______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
