### PR TITLE
Ensure globbed files paths are expanded

### DIFF
--- a/lib/rubygems/util.rb
+++ b/lib/rubygems/util.rb
@@ -122,7 +122,7 @@ module Gem::Util
 
   def self.glob_files_in_dir(glob, base_path)
     if RUBY_VERSION >= "2.5"
-      Dir.glob(glob, base: base_path).map! {|f| File.join(base_path, f) }
+      Dir.glob(glob, base: base_path).map! {|f| File.expand_path(f, base_path) }
     else
       Dir.glob(File.expand_path(glob, base_path))
     end

--- a/test/rubygems/test_gem_util.rb
+++ b/test/rubygems/test_gem_util.rb
@@ -58,4 +58,21 @@ class TestGemUtil < Gem::TestCase
     assert_equal 4, list.find { |x| x == 4 }
   end
 
+  def test_glob_files_in_dir
+    FileUtils.mkdir_p 'g'
+    FileUtils.touch File.join('g', 'h.rb')
+    FileUtils.touch File.join('g', 'i.rb')
+
+    expected_paths = [
+      File.join(@tempdir, 'g/h.rb'),
+      File.join(@tempdir, 'g/i.rb'),
+    ]
+
+    files_with_absolute_base = Gem::Util.glob_files_in_dir('*.rb', File.join(@tempdir, 'g'))
+    assert_equal expected_paths.to_set, files_with_absolute_base.to_set
+
+    files_with_relative_base = Gem::Util.glob_files_in_dir('*.rb', 'g')
+    assert_equal expected_paths.to_set, files_with_relative_base.to_set
+  end
+
 end


### PR DESCRIPTION
# Description:

The implementation of `Gem::Util.glob_files_in_dir` method introduced in https://github.com/rubygems/rubygems/pull/2336 will unexpectedly return _relative_ paths, instead of _absolute_ paths. This causes `Gem.find_files` to return filepaths will raise an error when passed to `Kernel#require`.  Expanding the paths when globbing ensures that these will always be absolute paths.

This issue can be demonstrated here: https://github.com/tonyta/rubygems-glob-bug-repro

## Minimum Repro

```ruby
require "fileutils"
FileUtils.mkdir_p "foo"
FileUtils.touch "foo/bar.rb"
$LOAD_PATH.unshift "foo"

# Before
files = Gem.find_files("bar.rb")  # => ["foo/bar.rb"]
files.map { |path| require path } # !> LoadError: cannot load such file -- foo/bar.rb

# After
files = Gem.find_files("bar.rb")  # => ["/Users/tonyta/Reflektive/rubygems/foo/bar.rb"]
files.map { |path| require path } # => [true]
```

## Realistic Repro

This problem can manifest when using the following:
- RubyGems 3.0 (since it contains a change introduced in [rubygems PR#2336](https://github.com/rubygems/rubygems/pull/2336))
- Ruby 2.5 or above (since the behavior [switches on `RUBY_VERSION`](https://github.com/rubygems/rubygems/blob/v3.0.0/lib/rubygems/util.rb#L124-L128))
- Minitest testing framework and its default behavior to `load_plugins`
- Test Rake task (`Rails::TestTask`) provided by Rails 4.2 as defined in the `railties` gem
- User-defined Minitest plugin in the project's `test/` directory

Below is an explanation of how it works (or, er... doesn't work):

1. `Rails::TestTask` will [add the relative path `test`](https://github.com/rails/rails/blob/v4.2.11/railties/lib/rails/test_unit/sub_test_task.rb#L103) to the [$LOAD_PATH without expanding it](https://github.com/rails/rails/blob/v4.2.11/railties/lib/rails/test_unit/sub_test_task.rb#L112). This causes `$LOAD_PATH` to contain relative paths.

2. When Minitest is invoked, it will attempt to [find all minitest plugins and require them](https://github.com/seattlerb/minitest/blob/master/lib/minitest.rb#L92-L100) via `Gem.find_files`.

3. If the user has defined a Minitest plugin from within directory in `$LOAD_PATH` that is a relative path (e.g. the `test/` directory in a Rails project), its non-expanded path will be returned by `Gem.find_files`.

4. Minitest will attempt to `require` all found plugins, but will fail since the relative path for the user-defined plugin is prepended with its parent directory, making it unrequireable.

## Benchmark

This improvement does _not_ discernibly affect the performance of the implementation—it does not take away from performance gained in https://github.com/rubygems/rubygems/pull/2336.

```ruby
require "benchmark/ips"

class Hello
  def self.old_find_files_from_load_path glob # :nodoc:
    $LOAD_PATH.map { |load_path|
      Dir["#{File.expand_path glob, load_path}#{Gem.suffix_pattern}"]
    }.flatten.select { |file| File.file? file.untaint }
  end

  def self.aaron_find_files_from_load_path glob # :nodoc:
    search = "#{glob}#{Gem.suffix_pattern}"
    $LOAD_PATH.map { |load_path|
      Dir.chdir(load_path) {
        Dir[search].map! { |f| File.join load_path, f }
      }
    }.flatten.select { |file| File.file? file.untaint }
  end

  def self.new_find_files_from_load_path glob # :nodoc:
    glob_with_suffixes = "#{glob}#{Gem.suffix_pattern}"
    $LOAD_PATH.map { |load_path|
      Dir.glob(glob_with_suffixes, base: load_path).map! {|f| File.join(load_path, f) }
    }.flatten.select { |file| File.file? file.untaint }
  end

  def self.expanded_find_files_from_load_path glob # :nodoc:
    glob_with_suffixes = "#{glob}#{Gem.suffix_pattern}"
    $LOAD_PATH.map { |load_path|
      Dir.glob(glob_with_suffixes, base: load_path).map! {|f| File.expand_path(f, load_path) }
    }.flatten.select { |file| File.file? file.untaint }
  end
end

search = "minitest/*_plugin.rb"

Benchmark.ips do |x|
  x.report('old') do
    Hello.old_find_files_from_load_path search
  end

  x.report('aaron') do
    Hello.aaron_find_files_from_load_path search
  end

  x.report('new') do
    Hello.new_find_files_from_load_path search
  end

  x.report('expanded') do
    Hello.expanded_find_files_from_load_path search
  end

  x.compare!
end

# Warming up --------------------------------------
#                  old    66.000  i/100ms
#                aaron   245.000  i/100ms
#                  new   577.000  i/100ms
#             expanded   575.000  i/100ms
# Calculating -------------------------------------
#                  old    678.640  (± 2.7%) i/s -      3.432k in   5.061071s
#                aaron      2.446k (± 3.1%) i/s -     12.250k in   5.014307s
#                  new      5.709k (± 3.6%) i/s -     28.850k in   5.060754s
#             expanded      5.791k (± 1.4%) i/s -     29.325k in   5.064898s
#
# Comparison:
#             expanded:     5791.0 i/s
#                  new:     5709.2 i/s - same-ish: difference falls within error
#                aaron:     2445.7 i/s - 2.37x  slower
#                  old:      678.6 i/s - 8.53x  slower
```

## Tests

I tried to write a test similar to `test_self_find_files` but with a relative path in the `$LOAD_PATH`, but could not trigger the error. I couldn't figure out how the tests were setup with the temp directory (`@@project_dir`).

Instead, I was able to prove that the fix worked using this repro project: https://github.com/tonyta/rubygems-glob-bug-repro
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).