### PR TITLE
Remove dead code in Gem::Validator.

### DIFF
--- a/lib/rubygems/validator.rb
+++ b/lib/rubygems/validator.rb
@@ -19,19 +19,6 @@ class Gem::Validator
     require 'find'
   end
 
-  ##
-  # Given the path to a gem file, validates against its own MD5 checksum
-  #
-  # gem_path:: [String] Path to gem file
-
-  def verify_gem_file(gem_path)
-    File.open gem_path, Gem.binary_mode do |file|
-      gem_data = file.read
-    end
-  rescue Errno::ENOENT, Errno::EINVAL
-    raise Gem::VerificationError, "missing gem file #{gem_path}"
-  end
-
   private
 
   def find_files_for_gem(gem_directory)
@@ -95,7 +82,9 @@ class Gem::Validator
       end
 
       begin
-        verify_gem_file(gem_path)
+        unless File.readable?(gem_path)
+          raise Gem::VerificationError, "missing gem file #{gem_path}"
+        end
 
         good, gone, unreadable = nil, nil, nil, nil
 

--- a/lib/rubygems/validator.rb
+++ b/lib/rubygems/validator.rb
@@ -20,15 +20,6 @@ class Gem::Validator
   end
 
   ##
-  # Given a gem file's contents, validates against its own MD5 checksum
-  # gem_data:: [String] Contents of the gem file
-
-  def verify_gem(gem_data)
-    # TODO remove me? The code here only validate an MD5SUM that was
-    # in some old formatted gems, but hasn't been for a long time.
-  end
-
-  ##
   # Given the path to a gem file, validates against its own MD5 checksum
   #
   # gem_path:: [String] Path to gem file
@@ -36,7 +27,6 @@ class Gem::Validator
   def verify_gem_file(gem_path)
     File.open gem_path, Gem.binary_mode do |file|
       gem_data = file.read
-      verify_gem gem_data
     end
   rescue Errno::ENOENT, Errno::EINVAL
     raise Gem::VerificationError, "missing gem file #{gem_path}"


### PR DESCRIPTION
# Description:

In `Gem::Validator`, `verify_gem` was a function that did nothing and has had a comment saying "remove me?" since 2011. This function was only called once, in a private function.

After removing the only call to that function, I was able to refactor away `Gem::Validator#verify_gem_file` entirely.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
