### PR TITLE
Removing yaml require

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,12 +3,7 @@
 require 'rubygems'
 require 'rubygems/package_task'
 require "rake/testtask"
-
-begin
-  require 'psych'
-rescue ::LoadError
-  require 'yaml'
-end
+require 'psych'
 
 desc "Setup Rubygems dev environment"
 task :setup => ["bundler:checkout"] do


### PR DESCRIPTION
# Description:
Removing dead ruby 1.x code.
Since rubygems only support Ruby 2.3 and higher versions there is no need for this anymore
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
