### PR TITLE
Dup the Dir.home string before passing it on.

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -572,7 +572,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   #++
 
   def self.find_home
-    Dir.home
+    Dir.home.dup
   rescue
     if Gem.win_platform?
       File.expand_path File.join(ENV['HOMEDRIVE'] || ENV['SystemDrive'], '/')


### PR DESCRIPTION
# Description:

Whether it's appropriate for this string to be frozen or mutable it will always be safe and very little cost to just make a copy of the string before attempting to mutate it.

The rough equivalent, `ENV['HOME']`, always returns a frozen String, and the same logic is used by `Dir.home`.

Fixes #2542.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
