### PR TITLE
Added permissions to installed files for non-owners

### DIFF
--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -312,7 +312,7 @@ By default, this RubyGems will install gem as:
     dest_file = File.join dest_dir, file
     dest_dir = File.dirname dest_file
     unless File.directory? dest_dir
-      mkdir_p dest_dir, :mode => 0700
+      mkdir_p dest_dir, :mode => 0755
     end
 
     install file, dest_file, :mode => options[:data_mode] || 0644
@@ -387,7 +387,7 @@ By default, this RubyGems will install gem as:
 
     specs_dir = Gem::Specification.default_specifications_dir
     specs_dir = File.join(options[:destdir], specs_dir) unless Gem.win_platform?
-    mkdir_p specs_dir, :mode => 0700
+    mkdir_p specs_dir, :mode => 0755
 
     # Workaround for non-git environment.
     gemspec = File.open('bundler/bundler.gemspec', 'rb'){|f| f.read.gsub(/`git ls-files -z`/, "''") }
@@ -422,7 +422,7 @@ By default, this RubyGems will install gem as:
 
     bundler_bin_dir = bundler_spec.bin_dir
     bundler_bin_dir = File.join(options[:destdir], bundler_bin_dir) unless Gem.win_platform?
-    mkdir_p bundler_bin_dir, :mode => 0700
+    mkdir_p bundler_bin_dir, :mode => 0755
     bundler_spec.executables.each do |e|
       cp File.join("bundler", bundler_spec.bindir, e), File.join(bundler_bin_dir, e)
     end
@@ -446,8 +446,8 @@ By default, this RubyGems will install gem as:
       lib_dir, bin_dir = generate_default_dirs(install_destdir)
     end
 
-    mkdir_p lib_dir, :mode => 0700
-    mkdir_p bin_dir, :mode => 0700
+    mkdir_p lib_dir, :mode => 0755
+    mkdir_p bin_dir, :mode => 0755
 
     return lib_dir, bin_dir
   end

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -309,7 +309,7 @@ class Gem::Installer
     FileUtils.rm_rf spec.extension_dir
 
     dir_mode = options[:dir_mode]
-    FileUtils.mkdir_p gem_dir, :mode => dir_mode && 0700
+    FileUtils.mkdir_p gem_dir, :mode => dir_mode && 0755
 
     if @options[:install_as_default]
       extract_bin
@@ -481,7 +481,7 @@ class Gem::Installer
     return if spec.executables.nil? or spec.executables.empty?
 
     begin
-      Dir.mkdir @bin_dir, *[options[:dir_mode] && 0700].compact
+      Dir.mkdir @bin_dir, *[options[:dir_mode] && 0755].compact
     rescue SystemCallError
       raise unless File.directory? @bin_dir
     end
@@ -525,7 +525,7 @@ class Gem::Installer
 
     FileUtils.rm_f bin_script_path # prior install may have been --no-wrappers
 
-    File.open bin_script_path, 'wb', 0700 do |file|
+    File.open bin_script_path, 'wb', 0755 do |file|
       file.print app_script_text(filename)
       file.chmod(options[:prog_mode] || 0755)
     end
@@ -720,7 +720,7 @@ class Gem::Installer
   end
 
   def verify_gem_home(unpack = false) # :nodoc:
-    FileUtils.mkdir_p gem_home, :mode => options[:dir_mode] && 0700
+    FileUtils.mkdir_p gem_home, :mode => options[:dir_mode] && 0755
     raise Gem::FilePermissionError, gem_home unless
       unpack or File.writable?(gem_home)
   end
@@ -905,7 +905,7 @@ TEXT
     build_info_dir = File.join gem_home, 'build_info'
 
     dir_mode = options[:dir_mode]
-    FileUtils.mkdir_p build_info_dir, :mode => dir_mode && 0700
+    FileUtils.mkdir_p build_info_dir, :mode => dir_mode && 0755
 
     build_info_file = File.join build_info_dir, "#{spec.full_name}.info"
 

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -357,7 +357,7 @@ EOM
   def extract_files(destination_dir, pattern = "*")
     verify unless @spec
 
-    FileUtils.mkdir_p destination_dir, :mode => dir_mode && 0700
+    FileUtils.mkdir_p destination_dir, :mode => dir_mode && 0755
 
     @gem.with_read_io do |io|
       reader = Gem::Package::TarReader.new io
@@ -394,7 +394,7 @@ EOM
         FileUtils.rm_rf destination
 
         mkdir_options = {}
-        mkdir_options[:mode] = dir_mode ? 0700 : (entry.header.mode if entry.directory?)
+        mkdir_options[:mode] = dir_mode ? 0755 : (entry.header.mode if entry.directory?)
         mkdir =
           if entry.directory?
             destination

--- a/lib/rubygems/package/old.rb
+++ b/lib/rubygems/package/old.rb
@@ -78,7 +78,7 @@ class Gem::Package::Old < Gem::Package
 
         FileUtils.rm_rf destination
 
-        FileUtils.mkdir_p File.dirname(destination), :mode => dir_mode && 0700
+        FileUtils.mkdir_p File.dirname(destination), :mode => dir_mode && 0755
 
         File.open destination, 'wb', file_mode(entry['mode']) do |out|
           out.write file_data

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -151,7 +151,7 @@ class TestGem < Gem::TestCase
   end
 
   def assert_self_install_permissions
-    mask = /mingw|mswin/ =~ RUBY_PLATFORM ? 0755 : 0777
+    mask = /mingw|mswin/ =~ RUBY_PLATFORM ? 0700 : 0777
     options = {
       :dir_mode => 0500,
       :prog_mode => 0510,

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -151,7 +151,7 @@ class TestGem < Gem::TestCase
   end
 
   def assert_self_install_permissions
-    mask = /mingw|mswin/ =~ RUBY_PLATFORM ? 0700 : 0777
+    mask = /mingw|mswin/ =~ RUBY_PLATFORM ? 0755 : 0777
     options = {
       :dir_mode => 0500,
       :prog_mode => 0510,
@@ -198,7 +198,7 @@ class TestGem < Gem::TestCase
     end
     assert_equal(expected, result)
   ensure
-    File.chmod(0700, *Dir.glob(@gemhome+'/gems/**/').map {|path| path.untaint})
+    File.chmod(0755, *Dir.glob(@gemhome+'/gems/**/').map {|path| path.untaint})
   end
 
   def test_require_missing


### PR DESCRIPTION
# Description:

https://github.com/rubygems/rubygems/pull/2219 introduced to deny to access files installed rubygems installer. I'm not sure why @nobu choose `700` permission instead of `755`.

I will merge this after discussion with @nobu.

  Fixes #2535
  Fixes #2541
  Fixes #2543

______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
