### PR TITLE
Fix Gem::Requirement equality comparison when ~> operator is used

### DIFF
--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -267,7 +267,17 @@ class Gem::Requirement
 
   def ==(other) # :nodoc:
     return unless Gem::Requirement === other
-    requirements == other.requirements
+
+    # An == check is always necessary
+    return false unless requirements == other.requirements
+
+    # An == check is sufficient unless any requirements use ~>
+    return true unless requirements.any? { |r| r.first == "~>" }
+
+    # If any requirements use ~> then we also need to compare the version
+    # strings for those requirements only (to check their precision is equal)
+    requirements.select { |r| r.first == "~>" }.
+      eql?(other.requirements.select { |r| r.first == "~>" })
   end
 
   private

--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -272,12 +272,17 @@ class Gem::Requirement
     return false unless requirements == other.requirements
 
     # An == check is sufficient unless any requirements use ~>
-    return true unless requirements.any? { |r| r.first == "~>" }
+    return true unless _tilde_requirements.any?
 
-    # If any requirements use ~> then we also need to compare the version
-    # strings for those requirements only (to check their precision is equal)
-    requirements.select { |r| r.first == "~>" }.
-      eql?(other.requirements.select { |r| r.first == "~>" })
+    # If any requirements use ~> we use the stricter `#eql?` that also checks
+    # that version precision is the same
+    _tilde_requirements.eql?(other._tilde_requirements)
+  end
+
+  protected
+
+  def _tilde_requirements
+    requirements.select { |r| r.first == "~>" }
   end
 
   private

--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -20,6 +20,12 @@ class TestGemRequirement < Gem::TestCase
     refute_requirement_equal "= 1.2", "= 1.3"
     refute_requirement_equal "= 1.3", "= 1.2"
 
+    refute_requirement_equal "~> 1.3", "~> 1.3.0"
+    refute_requirement_equal "~> 1.3.0", "~> 1.3"
+
+    assert_requirement_equal ["> 2", "~> 1.3"], ["> 2.0", "~> 1.3"]
+    assert_requirement_equal ["> 2.0", "~> 1.3"], ["> 2", "~> 1.3"]
+
     refute_equal Object.new, req("= 1.2")
     refute_equal req("= 1.2"), Object.new
   end


### PR DESCRIPTION
# Description:

The logic to compare versions included in a requirement needs to consider precision when a `~>` operator is used, and ignore it when one isn't.

Before this patch we had the following bug:
```ruby
Gem::Requirement.new("~> 5.2.0") == Gem::Requirement.new("~> 5.2")  # => true
```

Fixes https://github.com/bundler/bundler/issues/6858.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
