### PR TITLE
Unset SOURCE_DATE_EPOCH in the test cases

### DIFF
--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -254,6 +254,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
     @orig_gem_env_requirements = ENV.to_hash
 
     ENV['GEM_VENDOR'] = nil
+    ENV['SOURCE_DATE_EPOCH'] = nil
 
     @current_dir = Dir.pwd
     @fetcher     = nil


### PR DESCRIPTION
When test suites run with SOURCE_DATE_EPOCH, several tests would fail.  The environment variables are already kept with this setup & teardown phase.

Porting https://github.com/ruby/ruby/commit/6b861342b9ef41daf3a4c55d5a50a09f023a2180

----

Relates to https://github.com/rubygems/rubygems/issues/2551 & https://github.com/rubygems/rubygems/pull/2552 but I believe this is a better & shorter fix to mitigate the issue. `SOURCE_DATE_EPOCH` support have its test case, so basically test should run without `SOURCE_DATE_EPOCH`.