### PR TITLE
Use env var to configure api key on push

### DIFF
--- a/lib/rubygems/commands/push_command.rb
+++ b/lib/rubygems/commands/push_command.rb
@@ -15,6 +15,8 @@ https://rubygems.org) and adds it to the index.
 
 The gem can be removed from the index and deleted from the server using the yank
 command.  For further discussion see the help for the yank command.
+
+The push command will use ~/.gem/credentials to authenticate to a server, but you can use the RubyGems environment variable GEM_HOST_API_KEY to set the api key to authenticate.
     EOF
   end
 

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -38,7 +38,9 @@ module Gem::GemcutterUtilities
   # The API key from the command options or from the user's configuration.
 
   def api_key
-    if options[:key]
+    if ENV["GEM_HOST_API_KEY"]
+      ENV["GEM_HOST_API_KEY"]
+    elsif options[:key]
       verify_api_key options[:key]
     elsif Gem.configuration.api_keys.key?(host)
       Gem.configuration.api_keys[host]

--- a/test/rubygems/test_gem_commands_push_command.rb
+++ b/test/rubygems/test_gem_commands_push_command.rb
@@ -199,6 +199,21 @@ class TestGemCommandsPushCommand < Gem::TestCase
     send_battery
   end
 
+  def test_sending_gem_with_env_var_api_key
+    @host = "http://privategemserver.example"
+
+    @spec, @path = util_gem "freebird", "1.0.1" do |spec|
+      spec.metadata['allowed_push_host'] = @host
+    end
+
+    @api_key = "PRIVKEY"
+    ENV["GEM_HOST_API_KEY"] = "PRIVKEY"
+
+    @response = "Successfully registered gem: freebird (1.0.1)"
+    @fetcher.data["#{@host}/api/v1/gems"]  = [@response, 200, 'OK']
+    send_battery
+  end
+
   def test_sending_gem_to_allowed_push_host_with_basic_credentials
     @sanitized_host = "http://privategemserver.example"
     @host           = "http://user:password@privategemserver.example"


### PR DESCRIPTION
# Description:

closes https://github.com/rubygems/rubygems/issues/2522

This PR will allow a user to set an environment var called `HOST_API_KEY` to an `api_key` that would have precedence over the `--key` flag

How differs of the current current `--key` flag of the push command is that this env var will be set to the api token value itself instead of the a key associated to an api token configured in `~/.gem/credentials` 

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
