### PR TITLE
update util/ci (travis)

### DIFF
--- a/util/ci
+++ b/util/ci
@@ -49,14 +49,8 @@ when %w(before_script)
   if TOOL.rubygems?
     run('gem', %W(uninstall executable-hooks gem-wrappers bundler-unload -x --force -i #{`gem env home`.strip}@global))
 
-    if RUBY_VERSION >= "2.6.0"
-      run('gem', %w(install minitest -v 5.4.3))
-    end
-
-    # 2.5 images of Travis was broken about bundler installation.
-    if RUBY_VERSION >= "2.5.0" && RUBY_VERSION < "2.6.0"
-      run('gem', %w(install bundler -v 1.16.2))
-    end
+    # shipped gems in 2.3.8
+    run('gem', %w(install rake:>=10.4.2 minitest:>=5.8.5 --conservative --no-document))
 
     run('gem', %w(list --details))
     run('gem', %w(env))


### PR DESCRIPTION
# Description:

Update script used on Travis for current Travis setup.  Change rake & minitest to use whatever Travis wants to use today, hopefully shipped gems.  Similar to code used for Appveyor.  Previous code forced old versions, which (normally) shouldn't be needed for default or bundled gems.

JFYI, tried Ruby 2.6.0, needs updates committed to Bundler, but after 2.6.0 release...

# Tasks:

- [X] Describe the problem / feature
- [ ] Write tests
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
