### PR TITLE
Keep consistency for the second option for add_option

### DIFF
--- a/lib/rubygems/install_update_options.rb
+++ b/lib/rubygems/install_update_options.rb
@@ -101,34 +101,34 @@ module Gem::InstallUpdateOptions
       options[:user_install] = value
     end
 
-    add_option(:"Install/Update", "--development",
+    add_option(:"Install/Update", '--development',
                 "Install additional development",
                 "dependencies") do |value, options|
       options[:development] = true
       options[:dev_shallow] = true
     end
 
-    add_option(:"Install/Update", "--development-all",
+    add_option(:"Install/Update", '--development-all',
                 "Install development dependencies for all",
                 "gems (including dev deps themselves)") do |value, options|
       options[:development] = true
       options[:dev_shallow] = false
     end
 
-    add_option(:"Install/Update", "--conservative",
+    add_option(:"Install/Update", '--conservative',
                 "Don't attempt to upgrade gems already",
                 "meeting version requirement") do |value, options|
       options[:conservative] = true
       options[:minimal_deps] = true
     end
 
-    add_option(:"Install/Update", "--minimal-deps",
+    add_option(:"Install/Update", '--minimal-deps',
                 "Don't upgrade any dependencies that already",
                 "meet version requirements") do |value, options|
       options[:minimal_deps] = true
     end
 
-    add_option(:"Install/Update", "--[no-]post-install-message",
+    add_option(:"Install/Update", '--[no-]post-install-message',
                 "Print post install message") do |value, options|
       options[:post_install_message] = value
     end


### PR DESCRIPTION
# Description:

Keep consistency for the second option for add_option.

`git grep 'add_option.*, "'` (the targets the PR fixes) vs. `git grep "add_option.*, '"` (the dominant notation)

______________

# Tasks:

- [x] Describe the problem / feature
- [n/a] Write tests
- [x] Write code to solve the problem
- [n/a] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
