### PR TITLE
Don't use a proxy if https_proxy env var is empty

### DIFF
--- a/lib/rubygems/request.rb
+++ b/lib/rubygems/request.rb
@@ -168,6 +168,7 @@ class Gem::Request
 
     no_env_proxy = env_proxy.nil? || env_proxy.empty?
 
+    return :no_proxy if scheme == 'https' && no_env_proxy
     return get_proxy_from_env 'http' if no_env_proxy and _scheme != 'http'
     return :no_proxy                 if no_env_proxy
 

--- a/test/rubygems/test_gem_request.rb
+++ b/test/rubygems/test_gem_request.rb
@@ -79,6 +79,17 @@ class TestGemRequest < Gem::TestCase
     assert_equal URI(@proxy_uri), proxy
   end
 
+  def test_proxy_ENV
+    ENV['http_proxy'] = "http://proxy"
+    ENV['https_proxy'] = ""
+
+    request = make_request URI('https://example'), nil, nil, nil
+
+    proxy = request.proxy_uri
+
+    assert_nil proxy
+  end
+
   def test_configure_connection_for_https
     connection = Net::HTTP.new 'localhost', 443
 


### PR DESCRIPTION
# Description:

Closes https://github.com/rubygems/rubygems/issues/1706

Do no use a proxy if `https_proxy` env var is set to empty

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
