### PR TITLE
Fix intermittent test error on Appveyor & Travis

### DIFF
--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -156,7 +156,7 @@ class TestGem < Gem::TestCase
   end
 
   def assert_self_install_permissions
-    mask = /mingw|mswin/ =~ RUBY_PLATFORM ? 0700 : 0777
+    mask = win_platform? ? 0700 : 0777
     options = {
       :dir_mode => 0500,
       :prog_mode => 0510,
@@ -198,6 +198,9 @@ class TestGem < Gem::TestCase
       'gems/foo-1/bin/foo.cmd' => prog_mode,
       'gems/foo-1/data/foo.txt' => data_mode,
     }
+    # below is for intermittent errors on Appveyor & Travis 2019-01,
+    # see https://github.com/rubygems/rubygems/pull/2568
+    sleep 0.1
     result = {}
     Dir.chdir @gemhome do
       expected.each_key do |n|


### PR DESCRIPTION
# Description:

Intermittent test error on Appveyor, which is not restricted to particular Ruby version:

```
  1) Error:
TestGem#test_self_install_permissions_with_format_executable:
Errno::ENOENT: No such file or directory @ rb_file_s_stat - bin/foo.cmd
    C:/projects/rubygems/test/rubygems/test_gem.rb:204:in `stat'
    C:/projects/rubygems/test/rubygems/test_gem.rb:204:in `block (2 levels) in assert_self_install_permissions'
    C:/projects/rubygems/test/rubygems/test_gem.rb:203:in `each_key'
    C:/projects/rubygems/test/rubygems/test_gem.rb:203:in `block in assert_self_install_permissions'
    C:/projects/rubygems/test/rubygems/test_gem.rb:202:in `chdir'
    C:/projects/rubygems/test/rubygems/test_gem.rb:202:in `assert_self_install_permissions'
    C:/projects/rubygems/test/rubygems/test_gem.rb:155:in `test_self_install_permissions_with_format_executable'
```

From being familiar with Appveyor test issues, many of the intermittent errors in trunk parallel testing (which pass on serial retry) occur when doing 'write' then immediate 'reads'.  Probably due to multiple VM's sharing drives.  JFYI, I cannot repo locally.

This may require a longer sleep, only time will tell...

# Tasks:

- [X] Describe the problem / feature
- [ ] Write tests
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
