### PR TITLE
tests - remove unneeded requires, add frozen string code

### DIFF
--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -6,7 +6,6 @@
 #++
 
 require 'optparse'
-require 'rubygems/requirement'
 require 'rubygems/user_interaction'
 
 ##

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -2,16 +2,13 @@
 # TODO: $SAFE = 1
 
 begin
-  gem 'minitest', '~> 5.0'
+  # minitest 5.4.3 included with Ruby 2.2.0
+  gem 'minitest', '~> 5.4'
 rescue NoMethodError, Gem::LoadError
   # for ruby tests
 end
 
-if defined? Gem::QuickLoader
-  Gem::QuickLoader.load_full_rubygems_library
-else
-  require 'rubygems'
-end
+require 'rubygems'
 
 # If bundler gemspec exists, add to stubs
 bundler_gemspec = File.expand_path("../../../bundler/bundler.gemspec", __FILE__)

--- a/test/rubygems/test_config.rb
+++ b/test/rubygems/test_config.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
-require 'rubygems'
 require 'shellwords'
 
 class TestConfig < Gem::TestCase

--- a/test/rubygems/test_deprecate.rb
+++ b/test/rubygems/test_deprecate.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
-# require 'rubygems/builder'
-# require 'rubygems/package'
 require 'rubygems/deprecate'
 
 class TestDeprecate < Gem::TestCase

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1,8 +1,7 @@
 # coding: US-ASCII
+# frozen_string_literal: true
 require 'rubygems/test_case'
-require 'rubygems'
 require 'rubygems/command'
-require 'rubygems/installer'
 require 'pathname'
 require 'tmpdir'
 require 'rbconfig'
@@ -889,14 +888,16 @@ class TestGem < Gem::TestCase
       io.write "\xCF\x80"
     end
 
-    assert_equal ["\xCF", "\x80"], Gem.read_binary('test').chars.to_a
+    file_str = "\xCF\x80".dup.force_encoding('ASCII-8BIT')
+
+    assert_equal file_str, Gem.read_binary('test')
 
     skip 'chmod not supported' if Gem.win_platform?
 
     begin
       File.chmod 0444, 'test'
 
-      assert_equal ["\xCF", "\x80"], Gem.read_binary('test').chars.to_a
+      assert_equal file_str, Gem.read_binary('test')
     ensure
       File.chmod 0644, 'test'
     end

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 require 'rubygems/test_case'
 require 'rubygems/commands/build_command'

--- a/test/rubygems/test_gem_commands_help_command.rb
+++ b/test/rubygems/test_gem_commands_help_command.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "rubygems"
 require "rubygems/test_case"
 require "rubygems/commands/help_command"
 require "rubygems/package"

--- a/test/rubygems/test_gem_commands_signout_command.rb
+++ b/test/rubygems/test_gem_commands_signout_command.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 require 'rubygems/test_case'
 require 'rubygems/commands/signout_command'
 require 'rubygems/installer'

--- a/test/rubygems/test_gem_dependency.rb
+++ b/test/rubygems/test_gem_dependency.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
-require 'rubygems/dependency'
 
 class TestGemDependency < Gem::TestCase
 

--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
 require 'rubygems/ext'
-require 'rubygems/installer'
 
 class TestGemExtBuilder < Gem::TestCase
 

--- a/test/rubygems/test_gem_ext_ext_conf_builder.rb
+++ b/test/rubygems/test_gem_ext_ext_conf_builder.rb
@@ -1,6 +1,5 @@
 # coding: UTF-8
 # frozen_string_literal: true
-
 require 'rubygems/test_case'
 require 'rubygems/ext'
 

--- a/test/rubygems/test_gem_gemcutter_utilities.rb
+++ b/test/rubygems/test_gem_gemcutter_utilities.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
-require 'rubygems'
 require 'rubygems/command'
 require 'rubygems/gemcutter_utilities'
 

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -1,6 +1,5 @@
 # coding: utf-8
 # frozen_string_literal: true
-
 require 'rubygems/package/tar_test_case'
 require 'rubygems/simple_gem'
 

--- a/test/rubygems/test_gem_package_task.rb
+++ b/test/rubygems/test_gem_package_task.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
-require 'rubygems'
 require 'bundler/errors'
 begin
   require 'rubygems/package_task'

--- a/test/rubygems/test_gem_path_support.rb
+++ b/test/rubygems/test_gem_path_support.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
-require 'rubygems'
 require 'fileutils'
 
 class TestGemPathSupport < Gem::TestCase

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
-require 'rubygems/platform'
 require 'rbconfig'
 
 class TestGemPlatform < Gem::TestCase

--- a/test/rubygems/test_gem_rdoc.rb
+++ b/test/rubygems/test_gem_rdoc.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'rubygems'
 require 'rubygems/test_case'
 require 'rubygems/rdoc'
 

--- a/test/rubygems/test_gem_request_set_lockfile_parser.rb
+++ b/test/rubygems/test_gem_request_set_lockfile_parser.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
-require 'rubygems/request_set'
 require 'rubygems/request_set/lockfile'
 require 'rubygems/request_set/lockfile/tokenizer'
 require 'rubygems/request_set/lockfile/parser'

--- a/test/rubygems/test_gem_request_set_lockfile_tokenizer.rb
+++ b/test/rubygems/test_gem_request_set_lockfile_tokenizer.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
-require 'rubygems/request_set'
 require 'rubygems/request_set/lockfile'
 require 'rubygems/request_set/lockfile/tokenizer'
 require 'rubygems/request_set/lockfile/parser'

--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
-require "rubygems/requirement"
 
 class TestGemRequirement < Gem::TestCase
 

--- a/test/rubygems/test_gem_resolver_git_specification.rb
+++ b/test/rubygems/test_gem_resolver_git_specification.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
-require 'rubygems/installer'
 
 class TestGemResolverGitSpecification < Gem::TestCase
 

--- a/test/rubygems/test_gem_resolver_lock_specification.rb
+++ b/test/rubygems/test_gem_resolver_lock_specification.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
-require 'rubygems/installer'
-require 'rubygems/resolver'
 
 class TestGemResolverLockSpecification < Gem::TestCase
 

--- a/test/rubygems/test_gem_security_policy.rb
+++ b/test/rubygems/test_gem_security_policy.rb
@@ -1,6 +1,5 @@
 # coding: utf-8
 # frozen_string_literal: true
-
 require 'rubygems/test_case'
 
 unless defined?(OpenSSL::SSL)

--- a/test/rubygems/test_gem_source.rb
+++ b/test/rubygems/test_gem_source.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
-require 'rubygems/source'
 require 'rubygems/indexer'
 
 class TestGemSource < Gem::TestCase

--- a/test/rubygems/test_gem_source_git.rb
+++ b/test/rubygems/test_gem_source_git.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
-require 'rubygems/source'
 
 class TestGemSourceGit < Gem::TestCase
 

--- a/test/rubygems/test_gem_source_installed.rb
+++ b/test/rubygems/test_gem_source_installed.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
-require 'rubygems/source'
 
 class TestGemSourceInstalled < Gem::TestCase
 

--- a/test/rubygems/test_gem_source_list.rb
+++ b/test/rubygems/test_gem_source_list.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'rubygems/source_list'
 require 'rubygems/test_case'
+require 'rubygems/source_list'
 
 class TestGemSourceList < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_source_local.rb
+++ b/test/rubygems/test_gem_source_local.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
-require 'rubygems/source'
-
 require 'fileutils'
 
 class TestGemSourceLocal < Gem::TestCase

--- a/test/rubygems/test_gem_source_specific_file.rb
+++ b/test/rubygems/test_gem_source_specific_file.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
-require 'rubygems/source'
 
 class TestGemSourceSpecificFile < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_source_vendor.rb
+++ b/test/rubygems/test_gem_source_vendor.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
-require 'rubygems/source'
 
 class TestGemSourceVendor < Gem::TestCase
 

--- a/test/rubygems/test_gem_spec_fetcher.rb
+++ b/test/rubygems/test_gem_spec_fetcher.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
-require 'rubygems/spec_fetcher'
 
 class TestGemSpecFetcher < Gem::TestCase
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -4,7 +4,6 @@ require 'rubygems/test_case'
 require 'pathname'
 require 'stringio'
 require 'rubygems/ext'
-require 'rubygems/specification'
 require 'rubygems/installer'
 
 class TestGemSpecification < Gem::TestCase

--- a/test/rubygems/test_gem_stub_specification.rb
+++ b/test/rubygems/test_gem_stub_specification.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "rubygems/test_case"
-require "rubygems/stub_specification"
 
 class TestStubSpecification < Gem::TestCase
   SPECIFICATIONS = File.expand_path(File.join("..", "specifications"), __FILE__)

--- a/test/rubygems/test_gem_util.rb
+++ b/test/rubygems/test_gem_util.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
-require 'rubygems/util'
 
 class TestGemUtil < Gem::TestCase
 

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
-require "rubygems/version"
-
 require "minitest/benchmark"
 
 class TestGemVersion < Gem::TestCase

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
-require 'rubygems'
 
 class TestGemRequire < Gem::TestCase
   class Latch


### PR DESCRIPTION
# Description:

While working on PR #2568, I noticed that [test_gem.rb](https://github.com/rubygems/rubygems/blob/dbf4fbe50f9898e7c6cb93af6c5cf1a9b084e032/test/rubygems/test_gem.rb) did not have a 'frozen-string' comment.  Also, was wondering about unneeded require statements.  Hence:

1. Updated `test_gem.rb` to work with frozen strings.
2. Removed unneeded require statements from tests, as many autoload in `rubygems.rb`, which is required by `test_case.rb`.
3. Removed code for `Gem::QuickLoader`, which seems to be an eight year old gem with few downloads.
4. Updated minitest requirement to 5.4 from 5.0.

After this update, and using `--enable=frozen-string-literal`, there were only three test errors, all due to rdoc...

# Tasks:

- [X] Describe the problem / feature
- [ ] Write tests
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
