### PR TITLE
Serve a more descriptive error when --no-ri or --no-rdoc are used

### DIFF
--- a/lib/rubygems/command_manager.rb
+++ b/lib/rubygems/command_manager.rb
@@ -167,6 +167,12 @@ class Gem::CommandManager
     when '-v', '--version' then
       say Gem::VERSION
       terminate_interaction 0
+    when '--no-ri', '--no-rdoc' then
+      # This was added to compensate for a deprecation warning not being shown
+      # in Rubygems 2.x.x.
+      # TODO: Remove when Rubygems 4.0.0 is released.
+      alert_error "Invalid option: #{args.first}. Use --no-document instead."
+      terminate_interaction 1
     when /^-/ then
       alert_error "Invalid option: #{args.first}. See 'gem --help'."
       terminate_interaction 1

--- a/test/rubygems/test_gem_command_manager.rb
+++ b/test/rubygems/test_gem_command_manager.rb
@@ -103,6 +103,16 @@ class TestGemCommandManager < Gem::TestCase
     assert_match(/invalid option: --bad-arg/i, @ui.error)
   end
 
+  def test_process_args_bad_no_ri
+    use_ui @ui do
+      assert_raises Gem::MockGemUi::TermError do
+        @command_manager.process_args %w[--no-ri]
+      end
+    end
+
+    assert_match(/invalid option: --no-ri. Use --no-document instead./i, @ui.error)
+  end
+
   # HACK move to install command test
   def test_process_args_install
     #capture all install options


### PR DESCRIPTION
# Description:

Rubygems 3.0.0 removed support for the `--no-ri` and `--no-rdoc` install arguments, replacing them with `--no-document`. However, this deprecation wasn't clearly shown to users.

To compensate and save the Ruby community some googling, I propose serving a more instructive error for these common arguments (which exist in tutorials all over the web).

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
