### PR TITLE
Fix Travis head, remove RG 2.7.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,15 @@ stages:
   - linting
   - test
 before_script:
+  # fix Travis trunk build as of 2019-01-05
+  - |
+    rv="$(ruby -e 'STDOUT.write RUBY_VERSION')";
+    if [ "$rv" = "2.7.0" ]; then
+      lib="$(ruby -e 'STDOUT.write RbConfig::CONFIG["sitelibdir"]')";
+      echo "Processing 2.7.0 - $lib";
+      rm -rf $lib/rubygems;
+      rm -f  $lib/rubygems.rb $lib/ubygems.rb;
+    fi
   - util/ci before_script
 script:
   - util/ci script


### PR DESCRIPTION
# Description:

Temporary fix for Travis installing RubyGems 2.7.7 in Ruby trunk

# Tasks:

- [X] Describe the problem / feature
- [ ] Write tests
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
