### PR TITLE
Autoswitch to exact bundler version if present

### DIFF
--- a/lib/rubygems/bundler_version_finder.rb
+++ b/lib/rubygems/bundler_version_finder.rb
@@ -45,6 +45,11 @@ To install the missing version, run `gem install bundler:#{vr.first}`
     return unless bundler_version = self.bundler_version
 
     specs.reject! { |spec| spec.version.segments.first != bundler_version.segments.first }
+
+    exact_match_index = specs.find_index { |spec| spec.version == bundler_version }
+    return specs unless exact_match_index
+
+    specs.unshift(specs.delete_at(exact_match_index))
   end
 
   def self.bundle_update_bundler_version

--- a/lib/rubygems/bundler_version_finder.rb
+++ b/lib/rubygems/bundler_version_finder.rb
@@ -47,7 +47,7 @@ To install the missing version, run `gem install bundler:#{vr.first}`
     specs.reject! { |spec| spec.version.segments.first != bundler_version.segments.first }
 
     exact_match_index = specs.find_index { |spec| spec.version == bundler_version }
-    return specs unless exact_match_index
+    return unless exact_match_index
 
     specs.unshift(specs.delete_at(exact_match_index))
   end

--- a/test/rubygems/test_gem_bundler_version_finder.rb
+++ b/test/rubygems/test_gem_bundler_version_finder.rb
@@ -116,7 +116,7 @@ class TestGemBundlerVersionFinder < Gem::TestCase
       assert_equal %w[1 1.0 1.0.1.1], util_filter_specs(specs).map(&:version).map(&:to_s)
     end
     bvf.stub(:bundler_version, v("2.a")) do
-      assert_equal %w[2 2.a 2.0 2.1.1], util_filter_specs(specs).map(&:version).map(&:to_s)
+      assert_equal %w[2.a 2 2.0 2.1.1], util_filter_specs(specs).map(&:version).map(&:to_s)
     end
     bvf.stub(:bundler_version, v("3")) do
       assert_equal %w[3 3.a 3.0 3.1.1], util_filter_specs(specs).map(&:version).map(&:to_s)


### PR DESCRIPTION
# Description:

Currently we filter out bundler versions not matching the major version of the bundler version in the `BUNDLED WITH` section of the lock file. But we do not choose the exact bundler version matching the one in the lock file if present. This PR implements that feature. 

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).