### PR TITLE
Fix typo in specs warning.

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1285,7 +1285,7 @@ class Gem::Specification < Gem::BasicSpecification
     unresolved = unresolved_deps
     unless unresolved.empty?
       w = "W" + "ARN"
-      warn "#{w}: Unresolved or ambigious specs during Gem::Specification.reset:"
+      warn "#{w}: Unresolved or ambiguous specs during Gem::Specification.reset:"
       unresolved.values.each do |dep|
         warn "      #{dep}"
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2936,7 +2936,7 @@ duplicate dependency on c (>= 1.2.3, development), (~> 1.2) use:
     end
 
     expected = <<-EXPECTED
-WARN: Unresolved or ambigious specs during Gem::Specification.reset:
+WARN: Unresolved or ambiguous specs during Gem::Specification.reset:
       x (= 1)
 WARN: Clearing out unresolved specs. Try 'gem cleanup <gem>'
 Please report a bug if this causes problems.
@@ -2964,7 +2964,7 @@ Please report a bug if this causes problems.
     end
 
     expected = <<-EXPECTED
-WARN: Unresolved or ambigious specs during Gem::Specification.reset:
+WARN: Unresolved or ambiguous specs during Gem::Specification.reset:
       x (= 1)
       Available/installed versions of this gem:
       - 1


### PR DESCRIPTION
# Description:

Fixes typos in unresolved specification warning (s/ambigious/ambiguous).

______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
