### PR TITLE
Improve test compatibility with CMake 2.8.

### DIFF
--- a/test/rubygems/test_gem_ext_cmake_builder.rb
+++ b/test/rubygems/test_gem_ext_cmake_builder.rb
@@ -25,7 +25,7 @@ class TestGemExtCmakeBuilder < Gem::TestCase
     File.open File.join(@ext, 'CMakeLists.txt'), 'w' do |cmakelists|
       cmakelists.write <<-eo_cmake
 cmake_minimum_required(VERSION 2.6)
-project(self_build LANGUAGES NONE)
+project(self_build NONE)
 install (FILES test.txt DESTINATION bin)
       eo_cmake
     end


### PR DESCRIPTION
I previously submitted #2367 removing the need for C++ compiler on the system to pass the CMake test cases. Now testing on RHEL7 with CMake 2.8, it turns out, that CMake 2.8 does not support the "LANGUAGES" keyword yet. OTOH, it seems it is not needed at all to achieve the same goal, therefore this PR drops the "LANGUAGES" keyword.
I tested this patch on Fedora Rawhide:

~~~
$ rpm -q cmake
cmake-3.13.2-1.fc30.x86_64
~~~

and RHEL7:

~~~
$ rpm -q cmake
cmake-2.8.12.2-2.el7.x86_64
~~~