### PR TITLE
Restore gem build behavior and introduce the "-C" flag to gem build

### DIFF
--- a/lib/rubygems/commands/build_command.rb
+++ b/lib/rubygems/commands/build_command.rb
@@ -18,6 +18,10 @@ class Gem::Commands::BuildCommand < Gem::Command
     add_option '-o', '--output FILE', 'output gem with the given filename' do |value, options|
       options[:output] = value
     end
+
+    add_option '-C PATH', '', 'Run as if gem build was started in <PATH> instead of the current working directory.' do |value, options|
+      options[:build_path] = value
+    end
   end
 
   def arguments # :nodoc:
@@ -60,25 +64,36 @@ Gems can be saved to a specified filename with the output option:
     end
 
     if File.exist? gemspec
-      Dir.chdir(File.dirname(gemspec)) do
-        spec = Gem::Specification.load File.basename(gemspec)
+      spec = Gem::Specification.load(gemspec)
 
-        if spec
-          Gem::Package.build(
-            spec,
-            options[:force],
-            options[:strict],
-            options[:output]
-          )
-        else
-          alert_error "Error loading gemspec. Aborting."
-          terminate_interaction 1
+      if options[:build_path]
+        Dir.chdir(File.dirname(gemspec)) do
+          spec = Gem::Specification.load File.basename(gemspec)
+          build_package(spec)
         end
+      else
+        build_package(spec)
       end
+
     else
       alert_error "Gemspec file not found: #{gemspec}"
       terminate_interaction 1
     end
   end
 
+  private
+
+  def build_package(spec)
+    if spec
+      Gem::Package.build(
+        spec,
+        options[:force],
+        options[:strict],
+        options[:output]
+      )
+    else
+      alert_error "Error loading gemspec. Aborting."
+      terminate_interaction 1
+    end
+  end
 end

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -207,6 +207,7 @@ class TestGemCommandsBuildCommand < Gem::TestCase
       gs.write @gem.to_ruby
     end
 
+    @cmd.options[:build_path] = gemspec_dir
     @cmd.options[:args] = [gemspec_file]
 
     use_ui @ui do


### PR DESCRIPTION
# Description:
closes https://github.com/rubygems/rubygems/issues/2587

This PR restores gem build behavior, which is: do not change to the gemspec directory when building.
Also, this PR is introducing the `-C` flag, this flag will allow a user to specify the directory in which the gempsec is desired to be build.
______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
