### PR TITLE
Fix canonical_segments/equality to match <=> and pre-2.7.0 behaviour

### DIFF
--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -368,9 +368,7 @@ class Gem::Version
 
   def canonical_segments
     @canonical_segments ||=
-      _split_segments.map! do |segments|
-        segments.reverse_each.drop_while {|s| s == 0 }.reverse
-      end.reduce(&:concat)
+      _segments.reverse_each.drop_while {|s| s == 0 }.reverse
   end
 
   protected

--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -341,7 +341,7 @@ class Gem::Version
 
   def <=>(other)
     return unless Gem::Version === other
-    return 0 if @version == other._version || canonical_segments == other.canonical_segments
+    return 0 if @version == other._version
 
     lhsegments = _segments
     rhsegments = other._segments

--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -341,7 +341,7 @@ class Gem::Version
 
   def <=>(other)
     return unless Gem::Version === other
-    return 0 if @version == other._version
+    return 0 if @version == other._version || canonical_segments == other.canonical_segments
 
     lhsegments = _segments
     rhsegments = other._segments

--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -404,7 +404,7 @@ class TestGemRequirement < Gem::TestCase
 
   def assert_satisfied_by(version, requirement)
     assert req(requirement).satisfied_by?(v(version)),
-      "#{requirement} is satisfied by #{version}"
+      "Expected #{version} to satisfy #{requirement}"
   end
 
   # Refute the assumption that two requirements are equal.
@@ -417,6 +417,6 @@ class TestGemRequirement < Gem::TestCase
 
   def refute_satisfied_by(version, requirement)
     refute req(requirement).satisfied_by?(v(version)),
-      "#{requirement} is not satisfied by #{version}"
+      "Expected #{version} not to satisfy #{requirement}"
   end
 end

--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -266,6 +266,9 @@ class TestGemRequirement < Gem::TestCase
     assert_satisfied_by "3.0.rc2",     "< 3.0.1"
 
     assert_satisfied_by "3.0.rc2",     "> 0"
+
+    assert_satisfied_by "5.0.0.rc2",   "~> 5.x"
+    assert_satisfied_by "5.0.0",       "~> 5.x"
   end
 
   def test_illformed_requirements

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -157,6 +157,10 @@ class TestGemVersion < Gem::TestCase
     assert_equal( 1, v("1.8.2.a10") <=> v("1.8.2.a9"))
     assert_equal( 0, v("")          <=> v("0"))
 
+    assert_equal( 0, v("0.beta.1")  <=> v("0.0.beta.1"))
+    assert_equal(-1, v("0.0.beta")  <=> v("0.0.beta.1"))
+    assert_equal( 1, v("0.0.beta")  <=> v("0.beta.1"))
+
     assert_nil v("1.0") <=> "whatever"
   end
 

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -78,7 +78,7 @@ class TestGemVersion < Gem::TestCase
     assert_equal v("1.2").hash, v("1.2").hash
     refute_equal v("1.2").hash, v("1.3").hash
     assert_equal v("1.2").hash, v("1.2.0").hash
-    assert_equal v("1.2.pre.1").hash, v("1.2.0.pre.1.0").hash
+    assert_equal v("1.2.0.pre.1").hash, v("1.2.0.pre.1.0").hash
   end
 
   def test_initialize
@@ -210,7 +210,7 @@ class TestGemVersion < Gem::TestCase
 
   def test_canonical_segments
     assert_equal [1], v("1.0.0").canonical_segments
-    assert_equal [1, "a", 1], v("1.0.0.a.1.0").canonical_segments
+    assert_equal [1, 0, 0, "a", 1], v("1.0.0.a.1.0").canonical_segments
     assert_equal [1, 2, 3, "pre", 1], v("1.2.3-1").canonical_segments
   end
 

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -157,7 +157,7 @@ class TestGemVersion < Gem::TestCase
     assert_equal( 1, v("1.8.2.a10") <=> v("1.8.2.a9"))
     assert_equal( 0, v("")          <=> v("0"))
 
-    assert_equal( 0, v("0.beta.1")  <=> v("0.0.beta.1"))
+    assert_equal(-1, v("0.beta.1")  <=> v("0.0.beta.1"))
     assert_equal(-1, v("0.0.beta")  <=> v("0.0.beta.1"))
     assert_equal( 1, v("0.0.beta")  <=> v("0.beta.1"))
 

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -161,6 +161,8 @@ class TestGemVersion < Gem::TestCase
     assert_equal(-1, v("0.0.beta")  <=> v("0.0.beta.1"))
     assert_equal( 1, v("0.0.beta")  <=> v("0.beta.1"))
 
+    assert_equal(-1, v("5.x")  <=> v("5.0.0.rc2"))
+
     assert_nil v("1.0") <=> "whatever"
   end
 


### PR DESCRIPTION
# Description:

This fixes #2595 by not removing 0's which precede a prerelease segment. I've split this into 4 commits, each of which should pass tests to "show my work", but they could all be squashed.

The final commit re-adds `canonical_segments == other.canonical_segments`, which probably isn't necessary since `canonical_segments` now match the later logic in this method, but I left it in to make the change as small as possible.

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
