### PR TITLE
Extend timeout on assert_self_install_permissions

### DIFF
--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -200,7 +200,7 @@ class TestGem < Gem::TestCase
     }
     # below is for intermittent errors on Appveyor & Travis 2019-01,
     # see https://github.com/rubygems/rubygems/pull/2568
-    sleep 0.1
+    sleep 0.2
     result = {}
     Dir.chdir @gemhome do
       expected.each_key do |n|


### PR DESCRIPTION
# Description:

It's caused by random failures.
______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
