### PR TITLE
Drop tests for legacy RDoc

### DIFF
--- a/test/rubygems/test_gem_rdoc.rb
+++ b/test/rubygems/test_gem_rdoc.rb
@@ -5,7 +5,6 @@ require 'rubygems/rdoc'
 
 class TestGemRDoc < Gem::TestCase
   Gem::RDoc.load_rdoc
-  rdoc_4 = Gem::Requirement.new('> 3').satisfied_by?(Gem::RDoc.rdoc_version)
 
   def setup
     super
@@ -31,29 +30,8 @@ class TestGemRDoc < Gem::TestCase
     Gem.configuration[:rdoc] = nil
   end
 
-  ##
-  # RDoc 4 ships with its own Gem::RDoc which overrides this one which is
-  # shipped for backwards compatibility.
-
-  def rdoc_4?
-    Gem::Requirement.new('>= 4.0.0.preview2').satisfied_by? \
-      @hook.class.rdoc_version
-  end
-
-  def rdoc_3?
-    Gem::Requirement.new('~> 3.0').satisfied_by? @hook.class.rdoc_version
-  end
-
-  def rdoc_3_8_or_better?
-    Gem::Requirement.new('>= 3.8').satisfied_by? @hook.class.rdoc_version
-  end
-
   def test_initialize
-    if rdoc_4?
-      refute @hook.generate_rdoc
-    else
-      assert @hook.generate_rdoc
-    end
+    refute @hook.generate_rdoc
     assert @hook.generate_ri
 
     rdoc = Gem::RDoc.new @a, false, false
@@ -75,67 +53,6 @@ class TestGemRDoc < Gem::TestCase
     assert_empty args
   end
 
-  def test_document
-    skip 'RDoc 3 required' unless rdoc_3?
-
-    options = RDoc::Options.new
-    options.files = []
-
-    rdoc = @hook.new_rdoc
-    @hook.instance_variable_set :@rdoc, rdoc
-    @hook.instance_variable_set :@file_info, []
-
-    @hook.document 'darkfish', options, @a.doc_dir('rdoc')
-
-    assert @hook.rdoc_installed?
-  end unless rdoc_4
-
-  def test_generate
-    skip 'RDoc 3 required' unless rdoc_3?
-
-    FileUtils.mkdir_p @a.doc_dir
-    FileUtils.mkdir_p File.join(@a.gem_dir, 'lib')
-
-    @hook.generate
-
-    assert @hook.rdoc_installed?
-    assert @hook.ri_installed?
-
-    rdoc = @hook.instance_variable_get :@rdoc
-
-    refute rdoc.options.hyperlink_all
-  end unless rdoc_4
-
-  def test_generate_configuration_rdoc_array
-    skip 'RDoc 3 required' unless rdoc_3?
-
-    Gem.configuration[:rdoc] = %w[-A]
-
-    FileUtils.mkdir_p @a.doc_dir
-    FileUtils.mkdir_p File.join(@a.gem_dir, 'lib')
-
-    @hook.generate
-
-    rdoc = @hook.instance_variable_get :@rdoc
-
-    assert rdoc.options.hyperlink_all
-  end unless rdoc_4
-
-  def test_generate_configuration_rdoc_string
-    skip 'RDoc 3 required' unless rdoc_3?
-
-    Gem.configuration[:rdoc] = '-A'
-
-    FileUtils.mkdir_p @a.doc_dir
-    FileUtils.mkdir_p File.join(@a.gem_dir, 'lib')
-
-    @hook.generate
-
-    rdoc = @hook.instance_variable_get :@rdoc
-
-    assert rdoc.options.hyperlink_all
-  end unless rdoc_4
-
   def test_generate_disabled
     @hook.generate_rdoc = false
     @hook.generate_ri   = false
@@ -145,57 +62,6 @@ class TestGemRDoc < Gem::TestCase
     refute @hook.rdoc_installed?
     refute @hook.ri_installed?
   end
-
-  def test_generate_force
-    skip 'RDoc 3 required' unless rdoc_3?
-
-    FileUtils.mkdir_p @a.doc_dir 'ri'
-    FileUtils.mkdir_p @a.doc_dir 'rdoc'
-    FileUtils.mkdir_p File.join(@a.gem_dir, 'lib')
-
-    @hook.force = true
-
-    @hook.generate
-
-    assert_path_exists File.join(@a.doc_dir('rdoc'), 'index.html')
-    assert_path_exists File.join(@a.doc_dir('ri'),   'cache.ri')
-  end unless rdoc_4
-
-  def test_generate_no_overwrite
-    skip 'RDoc 3 required' unless rdoc_3?
-
-    FileUtils.mkdir_p @a.doc_dir 'ri'
-    FileUtils.mkdir_p @a.doc_dir 'rdoc'
-    FileUtils.mkdir_p File.join(@a.gem_dir, 'lib')
-
-    @hook.generate
-
-    refute_path_exists File.join(@a.doc_dir('rdoc'), 'index.html')
-    refute_path_exists File.join(@a.doc_dir('ri'),   'cache.ri')
-  end unless rdoc_4
-
-  def test_generate_legacy
-    skip 'RDoc < 3.8 required' if rdoc_3_8_or_better?
-
-    FileUtils.mkdir_p @a.doc_dir
-    FileUtils.mkdir_p File.join(@a.gem_dir, 'lib')
-
-    @hook.generate_legacy
-
-    assert @hook.rdoc_installed?
-    assert @hook.ri_installed?
-  end unless rdoc_4
-
-  def test_legacy_rdoc
-    skip 'RDoc < 3.8 required' if rdoc_3_8_or_better?
-
-    FileUtils.mkdir_p @a.doc_dir
-    FileUtils.mkdir_p File.join(@a.gem_dir, 'lib')
-
-    @hook.legacy_rdoc '--op', @a.doc_dir('rdoc')
-
-    assert @hook.rdoc_installed?
-  end unless rdoc_4
 
   def test_new_rdoc
     assert_kind_of RDoc::RDoc, @hook.new_rdoc


### PR DESCRIPTION
# Description:

RDoc 4 or earlier are not supported now.
______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
