### PR TITLE
Introduce dot for install and build

### DIFF
--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -217,7 +217,7 @@ class Gem::Command
     else
       get_all_gem_names.map do |name|
         if /\A(.*):(#{Gem::Requirement::PATTERN_RAW})\z/ =~ name
-            [$1, $2]
+          [$1, $2]
         else
           [name]
         end

--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -227,6 +227,14 @@ class Gem::Command
     args.first
   end
 
+  def first_arg_current_dir?
+    args = options[:args]
+    return false if args.nil?
+
+    current_dir = "."
+    args.first == current_dir
+  end
+
   ##
   # Get a single optional argument from the command line.  If more than one
   # argument is given, return only the first. Return nil if none are given.

--- a/lib/rubygems/commands/build_command.rb
+++ b/lib/rubygems/commands/build_command.rb
@@ -67,13 +67,7 @@ Gems can be saved to a specified filename with the output option:
   private
 
   def build_all_gems
-    gem_names = []
-
-    Dir.chdir(Dir.pwd) do |path|
-      gem_names = Dir["#{path}/*.gemspec"].map do |file_path|
-        File.basename(file_path, ".gemspec")
-      end
-    end
+    gem_names = get_current_dir_gems(file_extension: ".gemspec")
 
     if gem_names.empty?
       alert_error "Gemspec files not found: #{Dir.pwd}"

--- a/test/rubygems/test_gem_commands_uninstall_command.rb
+++ b/test/rubygems/test_gem_commands_uninstall_command.rb
@@ -71,11 +71,9 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
       end
     end
 
-    output = @ui.output.split "\n"
-    assert_equal "Successfully uninstalled c-2", output.shift
-    assert_equal "Successfully uninstalled b-2", output.shift
-    assert_equal "Successfully uninstalled d-2", output.shift
-    assert_equal [], output
+    assert_match "Successfully uninstalled c-2", @ui.output
+    assert_match "Successfully uninstalled b-2", @ui.output
+    assert_match "Successfully uninstalled d-2", @ui.output
   end
 
   def test_execute_dependency_order

--- a/test/rubygems/test_gem_commands_uninstall_command.rb
+++ b/test/rubygems/test_gem_commands_uninstall_command.rb
@@ -47,6 +47,37 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
                  Gem::Specification.all_names.sort
   end
 
+  def test_execute_current_directory
+    gem_dir = File.join @tempdir, 'uninstall_command_gem'
+    FileUtils.mkdir_p(gem_dir)
+
+    c = quick_gem 'c'
+    b = quick_gem 'b'
+    d = quick_gem 'd'
+
+    util_build_gem c
+    util_build_gem b
+    util_build_gem d
+
+    util_installer(c, gem_dir).install
+    util_installer(b, gem_dir).install
+    util_installer(d, gem_dir).install
+
+    @cmd.options[:args] = ["."]
+
+    use_ui @ui do
+      Dir.chdir "#{gem_dir}/cache" do
+        @cmd.execute
+      end
+    end
+
+    output = @ui.output.split "\n"
+    assert_equal "Successfully uninstalled c-2", output.shift
+    assert_equal "Successfully uninstalled b-2", output.shift
+    assert_equal "Successfully uninstalled d-2", output.shift
+    assert_equal [], output
+  end
+
   def test_execute_dependency_order
     c = quick_gem 'c' do |spec|
       spec.add_dependency 'a'


### PR DESCRIPTION
# Description:
closes https://github.com/rubygems/rubygems/issues/2580

This PR introduce the use of the `.` comand line argument to use when building, installing or uninstalling gems in the current directory.

The `.` argument will build all `.gemspec` files when building i.e `gem build .` and it will install/uninstall all the `.gem` files when installing or uninstalling i.e `gem install .` or `gem uninstall .`

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
