### PR TITLE
Add support for TruffleRuby

### DIFF
--- a/lib/rubygems/commands/owner_command.rb
+++ b/lib/rubygems/commands/owner_command.rb
@@ -60,6 +60,8 @@ permission to.
   end
 
   def show_owners(name)
+    Gem.load_yaml
+
     response = rubygems_api_request :get, "api/v1/gems/#{name}/owners.yaml" do |request|
       request.add_field "Authorization", api_key
     end

--- a/lib/rubygems/request_set/gem_dependency_api.rb
+++ b/lib/rubygems/request_set/gem_dependency_api.rb
@@ -43,11 +43,12 @@ class Gem::RequestSet::GemDependencyAPI
     :mri_20       => %w[ruby],
     :mri_21       => %w[ruby],
     :rbx          => %w[rbx],
-    :ruby         => %w[ruby rbx maglev],
-    :ruby_18      => %w[ruby rbx maglev],
-    :ruby_19      => %w[ruby rbx maglev],
-    :ruby_20      => %w[ruby rbx maglev],
-    :ruby_21      => %w[ruby rbx maglev],
+    :truffleruby  => %w[truffleruby],
+    :ruby         => %w[ruby rbx maglev truffleruby],
+    :ruby_18      => %w[ruby rbx maglev truffleruby],
+    :ruby_19      => %w[ruby rbx maglev truffleruby],
+    :ruby_20      => %w[ruby rbx maglev truffleruby],
+    :ruby_21      => %w[ruby rbx maglev truffleruby],
   }.freeze
 
   mswin     = Gem::Platform.new 'x86-mswin32'
@@ -85,6 +86,7 @@ class Gem::RequestSet::GemDependencyAPI
     :ruby_19      => Gem::Platform::RUBY,
     :ruby_20      => Gem::Platform::RUBY,
     :ruby_21      => Gem::Platform::RUBY,
+    :truffleruby  => Gem::Platform::RUBY,
     :x64_mingw    => x64_mingw,
     :x64_mingw_20 => x64_mingw,
     :x64_mingw_21 => x64_mingw
@@ -126,6 +128,7 @@ class Gem::RequestSet::GemDependencyAPI
     :ruby_19      => tilde_gt_1_9_0,
     :ruby_20      => tilde_gt_2_0_0,
     :ruby_21      => tilde_gt_2_1_0,
+    :truffleruby  => gt_eq_0,
     :x64_mingw    => gt_eq_0,
     :x64_mingw_20 => tilde_gt_2_0_0,
     :x64_mingw_21 => tilde_gt_2_1_0,

--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -2,10 +2,6 @@
 require "rubygems/version"
 require "rubygems/deprecate"
 
-# If we're being loaded after yaml was already required, then
-# load our yaml + workarounds now.
-Gem.load_yaml if defined? ::YAML
-
 ##
 # A Requirement is a set of one or more version restrictions. It supports a
 # few (<tt>=, !=, >, <, >=, <=, ~></tt>) different restriction operators.

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1311,6 +1311,8 @@ class Gem::Specification < Gem::BasicSpecification
   # Load custom marshal format, re-initializing defaults as needed
 
   def self._load(str)
+    Gem.load_yaml
+
     array = Marshal.load str
 
     spec = Gem::Specification.new
@@ -2591,6 +2593,8 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   def to_yaml(opts = {}) # :nodoc:
+    Gem.load_yaml
+
     # Because the user can switch the YAML engine behind our
     # back, we have to check again here to make sure that our
     # psych code was properly loaded, and load it if not.

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -115,7 +115,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
 
   attr_accessor :uri # :nodoc:
 
-  TEST_PATH = File.expand_path('../../../test/rubygems', __FILE__)
+  TEST_PATH = ENV.fetch('RUBYGEMS_TEST_PATH', File.expand_path('../../../test/rubygems', __FILE__))
 
   def assert_activate(expected, *specs)
     specs.each do |spec|

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -115,6 +115,8 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
 
   attr_accessor :uri # :nodoc:
 
+  TEST_PATH = File.expand_path('../../../test/rubygems', __FILE__)
+
   def assert_activate(expected, *specs)
     specs.each do |spec|
       case spec
@@ -1355,9 +1357,8 @@ Also, a list:
   end
 
   @@ruby = rubybin
-  gempath = File.expand_path('../../../test/rubygems', __FILE__)
-  @@good_rake = "#{rubybin} #{escape_path(gempath, 'good_rake.rb')}"
-  @@bad_rake = "#{rubybin} #{escape_path(gempath, 'bad_rake.rb')}"
+  @@good_rake = "#{rubybin} #{escape_path(TEST_PATH, 'good_rake.rb')}"
+  @@bad_rake = "#{rubybin} #{escape_path(TEST_PATH, 'bad_rake.rb')}"
 
   ##
   # Construct a new Gem::Dependency.
@@ -1545,14 +1546,12 @@ Also, a list:
 
   def self.cert_path(cert_name)
     if 32 == (Time.at(2**32) rescue 32)
-      cert_file =
-        File.expand_path "../../../test/rubygems/#{cert_name}_cert_32.pem",
-                         __FILE__
+      cert_file = "#{TEST_PATH}/#{cert_name}_cert_32.pem"
 
       return cert_file if File.exist? cert_file
     end
 
-    File.expand_path "../../../test/rubygems/#{cert_name}_cert.pem", __FILE__
+    "#{TEST_PATH}/#{cert_name}_cert.pem"
   end
 
   ##
@@ -1570,7 +1569,7 @@ Also, a list:
   # Returns the path to the key named +key_name+ from <tt>test/rubygems</tt>
 
   def self.key_path(key_name)
-    File.expand_path "../../../test/rubygems/#{key_name}_key.pem", __FILE__
+    "#{TEST_PATH}/#{key_name}_key.pem"
   end
 
   # :stopdoc:

--- a/test/rubygems/test_gem_request_set_gem_dependency_api.rb
+++ b/test/rubygems/test_gem_request_set_gem_dependency_api.rb
@@ -283,6 +283,14 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
       refute_empty set.dependencies
     end
 
+    with_engine_version 'truffleruby', '2.0.0' do
+      set = Gem::RequestSet.new
+      gda = @GDA.new set, 'gem.deps.rb'
+      gda.gem 'a', :platforms => :ruby
+
+      refute_empty set.dependencies
+    end
+
     with_engine_version 'jruby', '1.7.6' do
       set = Gem::RequestSet.new
       gda = @GDA.new set, 'gem.deps.rb'
@@ -310,6 +318,12 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
 
       assert_empty @set.dependencies
     end
+
+    with_engine_version 'truffleruby', '1.2.3' do
+      @gda.gem 'a', :platforms => :mri
+
+      assert_empty @set.dependencies
+    end
   end
 
   def test_gem_platforms_maglev
@@ -330,6 +344,22 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
     end
   ensure
     Gem.win_platform = win_platform
+  end
+
+  def test_gem_platforms_truffleruby
+    with_engine_version 'truffleruby', '1.0.0' do
+      set = Gem::RequestSet.new
+      gda = @GDA.new set, 'gem.deps.rb'
+      gda.gem 'a', :platforms => :truffleruby
+
+      refute_empty set.dependencies
+
+      set = Gem::RequestSet.new
+      gda = @GDA.new set, 'gem.deps.rb'
+      gda.gem 'a', :platforms => :maglev
+
+      assert_empty set.dependencies
+    end
   end
 
   def test_gem_platforms_multiple
@@ -736,6 +766,12 @@ end
     with_engine_version 'jruby', '1.7.6' do
       assert @gda.ruby RUBY_VERSION,
                :engine => 'jruby', :engine_version => '1.7.6'
+
+    end
+
+    with_engine_version 'truffleruby', '1.0.0-rc11' do
+      assert @gda.ruby RUBY_VERSION,
+               :engine => 'truffleruby', :engine_version => '1.0.0-rc11'
 
     end
   end

--- a/util/create_encrypted_key.rb
+++ b/util/create_encrypted_key.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 require 'openssl'
 
-private_key_path = '../../test/rubygems/private_key.pem'
-private_key_path = File.expand_path private_key_path, __FILE__
+test_path = File.expand_path('../../test/rubygems', __FILE__)
+
+private_key_path = "#{test_path}/private_key.pem"
 
 key = OpenSSL::PKey::RSA.new File.read private_key_path
 
 cipher = OpenSSL::Cipher.new 'DES-CBC'
 
-encrypted_key_path = '../../test/rubygems/encrypted_private_key.pem'
-encrypted_key_path = File.expand_path encrypted_key_path, __FILE__
+encrypted_key_path = "#{test_path}/encrypted_private_key.pem"
 
 open encrypted_key_path, 'w' do |io|
   io.write key.to_pem cipher, 'Foo bar'


### PR DESCRIPTION
# Description:

This PR adds support for TruffleRuby.
So far, the code was patched in the truffleruby repository, but this obviously does not work very well when updating RubyGems (e.g., https://github.com/oracle/truffleruby/issues/1558).

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
