### PR TITLE
test_gem.rb fixups & installer.rb one liner 

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -467,7 +467,7 @@ class Gem::Installer
 
   def generate_windows_script(filename, bindir)
     if Gem.win_platform?
-      script_name = filename + ".bat"
+      script_name = formatted_program_filename(filename) + ".bat"
       script_path = File.join bindir, File.basename(script_name)
       File.open script_path, 'w' do |file|
         file.puts windows_stub_script(bindir, filename)


### PR DESCRIPTION
# Description:

Test failure was due to random testing.  See PR #2613  d6b61c6, PR #2605  e7ab095, PR #2568  aeb353f

Failure involved setting the `format_executable` install option.  This option is uses `Gem::Installer.exec_format`, which is modified by other tests, but not reset.  Handling it correctly appears to have stopped the intermittent failures.

While debugging, the Gem::Installer issue appeared.  Windows installs have two scripts for every 'CLI gem'.  One is a cmd/bat file, which is considered an 'exe' by Windows, the other is a 'bash' style script.  From a pure Windows perspective, only the cmd/bat file is needed.  But, many Windows users have MSYS2/MinGW tools installed, and probably 'Git for Windows'.  Both have 'bash shells' available.  Also, I've seen more than a few CI bash scripts used in Appveyor testing, which allows repo's to use the same scripts for testing both on Appveyor & Travis.

Long story short, the issue with Gem::Installer is that it was using the file suffix added by `format_executable` in the bash script file name, but not the cmd/bat file name.  Fixed that and also added it to `test_self_install_permissions_with_format_executable` in `test_gem.rb`...

# Tasks:

- [ ] Describe the problem / feature
- [X] Update tests
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
