### PR TITLE
Add platform ranking method, fix --explain issue

### DIFF
--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -30,6 +30,20 @@ class Gem::Platform
     end
   end
 
+  def self.rank(platform)
+    if Gem.platforms == [RUBY]     # --platform=ruby
+      if RUBY == platform then     0
+      else                        -1
+      end
+    else
+      if    local == platform then 2
+      elsif local =~ platform then 1
+      elsif RUBY  == platform then 0
+      else                        -1
+      end
+    end
+  end
+
   def self.installable?(spec)
     if spec.respond_to? :installable_platform?
       spec.installable_platform?

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -102,7 +102,9 @@ class Gem::RemoteFetcher
 
     return if found.empty?
 
-    spec, source = found.max_by { |(s,_)| s.version }
+    spec, source = found.max_by { |(s,_)|
+      [s.version, Gem::Platform.rank(s.platform)]
+    }
 
     download spec, source.uri.to_s
   end

--- a/lib/rubygems/resolver/installer_set.rb
+++ b/lib/rubygems/resolver/installer_set.rb
@@ -59,11 +59,9 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
       s.version.prerelease? and not s.local?
     } unless dependency.prerelease?
 
-    found = found.select do |s|
-      Gem::Source::SpecificFile === s.source or
-        Gem::Platform::RUBY == s.platform or
-        Gem::Platform.local === s.platform
-    end
+    found = found.select { |s|
+      Gem::Source::SpecificFile === s.source or Gem::Platform.match s.platform
+    }
 
     if found.empty?
       exc = Gem::UnsatisfiableDependencyError.new request
@@ -73,7 +71,7 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
     end
 
     newest = found.max_by do |s|
-      [s.version, s.platform == Gem::Platform::RUBY ? -1 : 1]
+      [s.version, Gem::Platform.rank(s.platform)]
     end
 
     @always_install << newest.spec

--- a/lib/rubygems/source/local.rb
+++ b/lib/rubygems/source/local.rb
@@ -97,8 +97,7 @@ class Gem::Source::Local < Gem::Source
         end
       end
     end
-
-    found.max_by { |s| s.version }
+    found.max_by { |s| [s.version, Gem::Platform.rank(s.platform)] }
   end
 
   def fetch_spec(name) # :nodoc:

--- a/lib/rubygems/test_utilities.rb
+++ b/lib/rubygems/test_utilities.rb
@@ -149,7 +149,9 @@ class Gem::FakeFetcher
 
     return if found.empty?
 
-    spec, source = found.first
+    spec, source = Gem.platforms.length == 1 ?
+      found.first :
+      found.max_by { |(s,_)| [s.version, Gem::Platform.rank(s.platform)] }
 
     download spec, source.uri.to_s
   end

--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -522,4 +522,52 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
     assert_equal "  a-2", out.shift
     assert_empty out
   end
+
+  def test_explain_platform_local
+    local = Gem::Platform.local
+    spec_fetcher do |fetcher|
+      fetcher.download 'a', 2
+      fetcher.download 'a', 2 do |s| s.platform = local end
+      fetcher.spec 'a', 1
+    end
+
+    @cmd.options[:explain] = true
+    @cmd.options[:args] = %w[a]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    out = @ui.output.split "\n"
+
+    assert_equal "Gems to update:", out.shift
+    assert_equal "  a-2-#{local}", out.shift
+    assert_empty out
+  end
+
+  def test_explain_platform_ruby
+    local = Gem::Platform.local
+    spec_fetcher do |fetcher|
+      fetcher.download 'a', 2
+      fetcher.download 'a', 2 do |s| s.platform = local end
+      fetcher.spec 'a', 1
+    end
+
+    # equivalent to --platform=ruby
+    Gem.platforms = [Gem::Platform::RUBY]
+
+    @cmd.options[:explain] = true
+    @cmd.options[:args] = %w[a]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    out = @ui.output.split "\n"
+
+    assert_equal "Gems to update:", out.shift
+    assert_equal "  a-2", out.shift
+    assert_empty out
+  end
+
 end

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -297,6 +297,25 @@ class TestGemPlatform < Gem::TestCase
     assert_local_match 'sparc-solaris2.8-mq5.3'
   end
 
+  def test_rank
+    util_set_arch 'x64-mingw32'
+    assert_equal( 2, Gem::Platform.rank( Gem::Platform.new 'x64-mingw32'      ))
+    assert_equal( 1, Gem::Platform.rank( Gem::Platform.new 'universal-mingw32'))
+    assert_equal( 0, Gem::Platform.rank( Gem::Platform::RUBY ))
+    assert_equal(-1, Gem::Platform.rank( Gem::Platform.new 'x86_64-linux'     ))
+    assert_equal(-1, Gem::Platform.rank( Gem::Platform.new 'x86_64-darwin17'  ))
+  end
+
+  def test_rank_platform_ruby
+    # equivalent to --platform=ruby
+    Gem.platforms = [Gem::Platform::RUBY]
+    assert_equal(-1, Gem::Platform.rank( Gem::Platform.new 'x64-mingw32'      ))
+    assert_equal(-1, Gem::Platform.rank( Gem::Platform.new 'universal-mingw32'))
+    assert_equal( 0, Gem::Platform.rank( Gem::Platform::RUBY ))
+    assert_equal(-1, Gem::Platform.rank( Gem::Platform.new 'x86_64-linux'     ))
+    assert_equal(-1, Gem::Platform.rank( Gem::Platform.new 'x86_64-darwin17'  ))
+  end
+
   def assert_local_match(name)
     assert_match Gem::Platform.local, name
   end

--- a/test/rubygems/test_gem_source_local.rb
+++ b/test/rubygems/test_gem_source_local.rb
@@ -41,6 +41,28 @@ class TestGemSourceLocal < Gem::TestCase
     assert_equal "a-1", @sl.find_gem("a").full_name
   end
 
+  def test_find_gem_platform_local
+    local = Gem::Platform.local
+    _, al_gem = util_gem "a", '1' do |s| s.platform = local end
+    FileUtils.mv al_gem, @tempdir
+
+    assert_equal "a-1-#{local}", @sl.find_gem("a").full_name
+  end
+
+  def test_find_gem_platform_ruby
+    # equivalent to --platform=ruby
+    Gem.platforms = [Gem::Platform::RUBY]
+
+    local = Gem::Platform.local
+    _, al_gem = util_gem "a", '1' do |s| s.platform = local end
+    FileUtils.mv al_gem, @tempdir
+
+    # equivalent to --platform=ruby
+    Gem.platforms = [Gem::Platform::RUBY]
+
+    assert_equal "a-1", @sl.find_gem("a").full_name
+  end
+
   def test_find_gem_highest_version
     _, a2_gem = util_gem "a", "2"
     FileUtils.mv a2_gem, @tempdir


### PR DESCRIPTION
# Description:

Platform rankings is currently done in several places, and is a 'binary' rank.  Install/Update will not show selected platform specific gems correctly when used with the `--explain` option.

1. Add platform ranking method (`Gem::Platform.rank`), see 2nd commit, test_gem_platform.rb  additions.
2. Fix above --explain issues.

Two commits, the first changes/adds code and passes existing tests, the second adds tests. Additional discussion in PR #2446, #2449, and #2452.

# Tasks:

- [X] Describe the problem / feature
- [X] Write tests
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
