### PR TITLE
Remove commented code from command.rb

### DIFF
--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -375,7 +375,6 @@ class Gem::Command
     options.each do |option|
       if option_is_deprecated?(option)
         version_to_expire = @deprecated_options[command][option]["rg_version_to_expire"]
-        #deprecate_option_msg = "The \"#{option}\" option has been deprecated and will be removed in future versions of Rubygems #{version_to_expire}, its use is discouraged."
 
         deprecate_option_msg = if version_to_expire
                                  "The \"#{option}\" option has been deprecated and will be removed in Rubygems #{version_to_expire}, its use is discouraged."


### PR DESCRIPTION
# Description:

Just removing comented code in `command.rb` that i introduced in https://github.com/rubygems/rubygems/pull/2607

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
