### PR TITLE
Fix flaky bundler version finder tests

### DIFF
--- a/test/rubygems/test_gem_bundler_version_finder.rb
+++ b/test/rubygems/test_gem_bundler_version_finder.rb
@@ -3,6 +3,8 @@ require 'rubygems/test_case'
 
 class TestGemBundlerVersionFinder < Gem::TestCase
   def setup
+    super
+
     @argv = ARGV.dup
     @env = ENV.to_hash.clone
     ENV.delete("BUNDLER_VERSION")
@@ -13,6 +15,8 @@ class TestGemBundlerVersionFinder < Gem::TestCase
     ARGV.replace @argv
     ENV.replace @env
     $0 = @dollar_0
+
+    super
   end
 
   def bvf


### PR DESCRIPTION
# Description:

Running bundler version finder tests in isolation would fail. For example,

```
rake TESTOPTS=--name=test_bundler_version_defaults_to_nil
```

This PR fixes that.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).