### PR TITLE
Fix gem indexer tests leaking utility gems

### DIFF
--- a/test/rubygems/test_gem_indexer.rb
+++ b/test/rubygems/test_gem_indexer.rb
@@ -37,6 +37,12 @@ class TestGemIndexer < Gem::TestCase
     @indexer = Gem::Indexer.new(@tempdir)
   end
 
+  def teardown
+    super
+
+    util_clear_gems
+  end
+
   def test_initialize
     assert_equal @tempdir, @indexer.dest_directory
     assert_match %r{#{Dir.mktmpdir('gem_generate_index').match(/.*-/)}}, @indexer.directory


### PR DESCRIPTION
# Description:

The problem is that `SEED=26796 rake TESTOPTS="--name=/test_generate_index_modern_back_to_back\|test_doctor_dry_run/"` fails on master with

```
$ SEED=26796 rake TESTOPTS="--name=/test_generate_index_modern_back_to_back\|test_doctor_dry_run/"
Run options: "--name=/test_generate_index_modern_back_to_back|test_doctor_dry_run/" --seed 26796

# Running:

.F

Finished in 0.163319s, 12.2460 runs/s, 128.5826 assertions/s.

  1) Failure:
TestGemDoctor#test_doctor_dry_run [/home/deivid/Code/rubygems/test/rubygems/test_gem_doctor.rb:118]:
--- expected
+++ actual
@@ -6,5 +6,11 @@
 " +
 "Extra directory gems/c-2
 " +
+"Extra directory gems/d-2.0
+" +
+"Extra directory gems/d-2.0.a
+" +
+"Extra directory gems/d-2.0.b
+" +
 "
 "


2 runs, 21 assertions, 1 failures, 0 errors, 0 skips
rake aborted!
Command failed with status (1)

Tasks: TOP => default => test
(See full trace by running task with --trace)
```

This PR fixes that.

Fixes #2623.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
