### PR TITLE
Allow to easily bisect flaky failures

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -638,6 +638,7 @@ test/rubygems/test_require.rb
 test/rubygems/wrong_key_cert.pem
 test/rubygems/wrong_key_cert_32.pem
 util/CL2notes
+util/bisect
 util/ci
 util/create_certs.rb
 util/create_encrypted_key.rb

--- a/Rakefile
+++ b/Rakefile
@@ -71,6 +71,17 @@ task(:rubocop) do
   sh "util/rubocop"
 end
 
+desc "Run a test suite bisection"
+task(:bisect) do
+  seed = begin
+           Integer(ENV["SEED"])
+         rescue
+           abort "Specify the failing seed as the SEED environment variable"
+         end
+
+  sh "SEED=#{seed} MTB_VERBOSE=2 util/bisect -Ilib:bundler/lib:test test"
+end
+
 # --------------------------------------------------------------------
 # Creating a release
 

--- a/Rakefile
+++ b/Rakefile
@@ -79,7 +79,8 @@ task(:bisect) do
            abort "Specify the failing seed as the SEED environment variable"
          end
 
-  sh "SEED=#{seed} MTB_VERBOSE=2 util/bisect -Ilib:bundler/lib:test test"
+  gemdir = `gem env gemdir`.chomp
+  sh "SEED=#{seed} MTB_VERBOSE=2 util/bisect -Ilib:bundler/lib:test:#{gemdir}/gems/minitest-server-1.0.5/lib test"
 end
 
 # --------------------------------------------------------------------

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 # TODO: $SAFE = 1
 
-begin
-  gem 'minitest', '~> 5.0'
-rescue NoMethodError, Gem::LoadError
-  # for ruby tests
-end
-
 if defined? Gem::QuickLoader
   Gem::QuickLoader.load_full_rubygems_library
 else
@@ -23,7 +17,7 @@ if File.exist?(bundler_gemspec)
 end
 
 begin
-  gem 'minitest'
+  gem 'minitest', '~> 5.0'
 rescue Gem::LoadError
 end
 

--- a/util/bisect
+++ b/util/bisect
@@ -2,7 +2,30 @@
 # frozen_string_literal: true
 
 begin
-  load Gem.bin_path("minitest-bisect", "minitest_bisect")
+  minitest_bisect = Gem.bin_path("minitest-bisect", "minitest_bisect")
 rescue Gem::GemNotFoundException
   abort "Install minitest-bisect gem to run a rubygems test suite bisection"
 end
+
+#
+# Need to monkeypatch the `path_expander` gem to make sure it uses the same
+# sorted set of files as `rake`. Otherwise `rake test` failures are
+# irreproducible. Can be removed once
+# https://github.com/seattlerb/path_expander/pull/4 is released.
+#
+
+module RefinedPathExpander
+  def expand_dirs_to_files(*dirs)
+    super.sort
+  end
+end
+
+require 'path_expander'
+
+class PathExpander
+
+  prepend RefinedPathExpander
+
+end
+
+load minitest_bisect

--- a/util/bisect
+++ b/util/bisect
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+begin
+  load Gem.bin_path("minitest-bisect", "minitest_bisect")
+rescue Gem::GemNotFoundException
+  abort "Install minitest-bisect gem to run a rubygems test suite bisection"
+end


### PR DESCRIPTION
# Description:

I used this today to bisect some flaky test failures. I thought I should share it in case other rubygems devs find it useful.

For example,

```
SEED=26796 rake
```

currently fails with the error described in #2625.

Running

```
SEED=26796 rake bisect
```

should give you the minimal reproduction for it after a bit of investigation, namely,

```
SEED=26796 rake TESTOPTS="--name=/test_generate_index_modern_back_to_back\|test_doctor_dry_run/"
```

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
