### PR TITLE
Fix windows specific executables generated by `gem install`

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -467,7 +467,7 @@ class Gem::Installer
 
   def generate_windows_script(filename, bindir)
     if Gem.win_platform?
-      script_name = filename + ".bat"
+      script_name = formatted_program_filename(filename) + ".bat"
       script_path = File.join bindir, File.basename(script_name)
       File.open script_path, 'w' do |file|
         file.puts windows_stub_script(bindir, filename)

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -14,7 +14,7 @@ $LOAD_PATH.map! do |path|
 end
 
 class TestGem < Gem::TestCase
-  RUBY_INSTALL_NAME = RbConfig::CONFIG['RUBY_INSTALL_NAME']
+  RUBY_INSTALL_NAME = RbConfig::CONFIG['ruby_install_name']
 
   PLUGINS_LOADED = [] # rubocop:disable Style/MutableConstant
 

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -152,6 +152,15 @@ class TestGem < Gem::TestCase
     assert_self_install_permissions(format_executable: true)
   end
 
+  def test_self_install_permissions_with_format_executable_and_non_standard_ruby_install_name
+    Gem::Installer.exec_format = nil
+    ruby_install_name 'ruby27' do
+      assert_self_install_permissions(format_executable: true)
+    end
+  ensure
+    Gem::Installer.exec_format = nil
+  end
+
   def assert_self_install_permissions(format_executable: false)
     mask = win_platform? ? 0700 : 0777
     options = {

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -14,8 +14,6 @@ $LOAD_PATH.map! do |path|
 end
 
 class TestGem < Gem::TestCase
-  RUBY_INSTALL_NAME = RbConfig::CONFIG['ruby_install_name']
-
   PLUGINS_LOADED = [] # rubocop:disable Style/MutableConstant
 
   def setup
@@ -185,7 +183,7 @@ class TestGem < Gem::TestCase
     dir_mode = (options[:dir_mode] & mask).to_s(8)
     data_mode = (options[:data_mode] & mask).to_s(8)
     prog_name = 'foo'
-    prog_name = RUBY_INSTALL_NAME.sub('ruby', 'foo') if options[:format_executable]
+    prog_name = RbConfig::CONFIG['ruby_install_name'].sub('ruby', 'foo') if options[:format_executable]
     expected = {
       "bin/#{prog_name}" => prog_mode,
       'gems/foo-1' => dir_mode,

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -151,18 +151,17 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_install_permissions_with_format_executable
-    @format_executable = true
-    assert_self_install_permissions
+    assert_self_install_permissions(format_executable: true)
   end
 
-  def assert_self_install_permissions
+  def assert_self_install_permissions(format_executable: false)
     mask = win_platform? ? 0700 : 0777
     options = {
       :dir_mode => 0500,
       :prog_mode => win_platform? ? 0410 : 0510,
       :data_mode => 0640,
       :wrappers => true,
-      :format_executable => !!(@format_executable if defined?(@format_executable))
+      :format_executable => format_executable
     }
     Dir.chdir @tempdir do
       Dir.mkdir 'bin'

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -168,7 +168,7 @@ class TestGem < Gem::TestCase
       Dir.mkdir 'bin'
       Dir.mkdir 'data'
 
-      File.write 'bin/foo', "p\n"
+      File.write 'bin/foo', "#!/usr/bin/env ruby\n"
       File.chmod 0755, 'bin/foo'
 
       File.write 'data/foo.txt', "blah\n"

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -195,9 +195,6 @@ class TestGem < Gem::TestCase
       'gems/foo-1/bin/foo.cmd' => prog_mode,
       'gems/foo-1/data/foo.txt' => data_mode,
     }
-    # below is for intermittent errors on Appveyor & Travis 2019-01,
-    # see https://github.com/rubygems/rubygems/pull/2568
-    sleep 0.2
     result = {}
     Dir.chdir @gemhome do
       expected.each_key do |n|


### PR DESCRIPTION
# Description:

This is a rework of #2615. While reviewing that PR I took care of splitting each change into its own commit, and added some comments in the commit messages to explain why I think the change is useful / needed / correct.

First commits are just simplifications and refactorings; the last commit, 961b514, is a bug fix.

Stuff I didn't include from #2615 are stylistic changes, inconsistent stuff, and DRY ups that I consider that harm readability instead of adding to it (for example, moving the umask stuff inside the already complicated method `assert_self_install_permissions`).

I didn't push directly to #2615 because I don't have permissions, but I did keep @MSP-Greg's authorship.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
