### PR TITLE
Enable `Layout/SpaceInsideParens` rubocop cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,6 +53,9 @@ Layout/IndentationConsistency:
 Layout/IndentationWidth:
   Enabled: true
 
+Layout/SpaceInsideParens:
+  Enabled: true
+
 Layout/TrailingBlankLines:
   Enabled: true
 

--- a/lib/rubygems/commands/contents_command.rb
+++ b/lib/rubygems/commands/contents_command.rb
@@ -14,7 +14,7 @@ class Gem::Commands::ContentsCommand < Gem::Command
 
     add_version_option
 
-    add_option(      '--all',
+    add_option('--all',
                "Contents for all gems") do |all, options|
       options[:all] = all
     end
@@ -29,12 +29,12 @@ class Gem::Commands::ContentsCommand < Gem::Command
       options[:lib_only] = lib_only
     end
 
-    add_option(      '--[no-]prefix',
+    add_option('--[no-]prefix',
                "Don't include installed path prefix") do |prefix, options|
       options[:prefix] = prefix
     end
 
-    add_option(      '--[no-]show-install-dir',
+    add_option('--[no-]show-install-dir',
                'Show only the gem install dir') do |show, options|
       options[:show_install_dir] = show
     end

--- a/lib/rubygems/commands/query_command.rb
+++ b/lib/rubygems/commands/query_command.rb
@@ -39,7 +39,7 @@ class Gem::Commands::QueryCommand < Gem::Command
       options[:details] = value
     end
 
-    add_option(      '--[no-]versions',
+    add_option('--[no-]versions',
                'Display only gem names') do |value, options|
       options[:versions] = value
       options[:details] = false unless value
@@ -56,7 +56,7 @@ class Gem::Commands::QueryCommand < Gem::Command
       options[:exact] = value
     end
 
-    add_option(      '--[no-]prerelease',
+    add_option('--[no-]prerelease',
                'Display prerelease versions') do |value, options|
       options[:prerelease] = value
     end

--- a/lib/rubygems/request.rb
+++ b/lib/rubygems/request.rb
@@ -169,7 +169,7 @@ class Gem::Request
     no_env_proxy = env_proxy.nil? || env_proxy.empty?
 
     if no_env_proxy
-      return ( _scheme == 'https' || _scheme == 'http' ) ?
+      return (_scheme == 'https' || _scheme == 'http') ?
         :no_proxy : get_proxy_from_env('http')
     end
 

--- a/test/rubygems/test_gem_source.rb
+++ b/test/rubygems/test_gem_source.rb
@@ -199,16 +199,16 @@ class TestGemSource < Gem::TestCase
     installed = Gem::Source::Installed.new
     local     = Gem::Source::Local.new
 
-    assert_equal( 0, remote.   <=>(remote),    'remote    <=> remote')
+    assert_equal(0, remote.   <=>(remote),    'remote    <=> remote')
 
     assert_equal(-1, remote.   <=>(specific),  'remote    <=> specific')
-    assert_equal( 1, specific. <=>(remote),    'specific  <=> remote')
+    assert_equal(1, specific. <=>(remote),    'specific  <=> remote')
 
     assert_equal(-1, remote.   <=>(local),     'remote    <=> local')
-    assert_equal( 1, local.    <=>(remote),    'local     <=> remote')
+    assert_equal(1, local.    <=>(remote),    'local     <=> remote')
 
     assert_equal(-1, remote.   <=>(installed), 'remote    <=> installed')
-    assert_equal( 1, installed.<=>(remote),    'installed <=> remote')
+    assert_equal(1, installed.<=>(remote),    'installed <=> remote')
 
     no_uri = @source.dup
     no_uri.instance_variable_set :@uri, nil
@@ -220,9 +220,9 @@ class TestGemSource < Gem::TestCase
     sourceA = Gem::Source.new "http://example.com/a"
     sourceB = Gem::Source.new "http://example.com/b"
 
-    assert_equal( 0, sourceA. <=>(sourceA), 'sourceA <=> sourceA')
-    assert_equal( 1, sourceA. <=>(sourceB), 'sourceA <=> sourceB')
-    assert_equal( 1, sourceB. <=>(sourceA), 'sourceB <=> sourceA')
+    assert_equal(0, sourceA. <=>(sourceA), 'sourceA <=> sourceA')
+    assert_equal(1, sourceA. <=>(sourceB), 'sourceA <=> sourceB')
+    assert_equal(1, sourceB. <=>(sourceA), 'sourceB <=> sourceA')
   end
 
   def test_update_cache_eh

--- a/test/rubygems/test_gem_source_git.rb
+++ b/test/rubygems/test_gem_source_git.rb
@@ -208,16 +208,16 @@ class TestGemSourceGit < Gem::TestCase
     installed = Gem::Source::Installed.new
     vendor    = Gem::Source::Vendor.new 'vendor/foo'
 
-    assert_equal( 0, git.      <=>(git),       'git    <=> git')
+    assert_equal(0, git.      <=>(git),       'git    <=> git')
 
-    assert_equal( 1, git.      <=>(remote),    'git    <=> remote')
+    assert_equal(1, git.      <=>(remote),    'git    <=> remote')
     assert_equal(-1, remote.   <=>(git),       'remote <=> git')
 
-    assert_equal( 1, git.      <=>(installed), 'git       <=> installed')
+    assert_equal(1, git.      <=>(installed), 'git       <=> installed')
     assert_equal(-1, installed.<=>(git),       'installed <=> git')
 
     assert_equal(-1, git.      <=>(vendor),    'git       <=> vendor')
-    assert_equal( 1, vendor.   <=>(git),       'vendor    <=> git')
+    assert_equal(1, vendor.   <=>(git),       'vendor    <=> git')
   end
 
   def test_specs

--- a/test/rubygems/test_gem_source_installed.rb
+++ b/test/rubygems/test_gem_source_installed.rb
@@ -15,21 +15,21 @@ class TestGemSourceInstalled < Gem::TestCase
     git       = Gem::Source::Git.new 'a', 'a', 'master'
     vendor    = Gem::Source::Vendor.new 'a'
 
-    assert_equal( 0, installed.<=>(installed), 'installed <=> installed')
+    assert_equal(0, installed.<=>(installed), 'installed <=> installed')
 
     assert_equal(-1, remote.   <=>(installed), 'remote    <=> installed')
-    assert_equal( 1, installed.<=>(remote),    'installed <=> remote')
+    assert_equal(1, installed.<=>(remote),    'installed <=> remote')
 
-    assert_equal( 1, installed.<=>(local),     'installed <=> local')
+    assert_equal(1, installed.<=>(local),     'installed <=> local')
     assert_equal(-1, local.    <=>(installed), 'local     <=> installed')
 
     assert_equal(-1, specific. <=>(installed), 'specific  <=> installed')
-    assert_equal( 1, installed.<=>(specific),  'installed <=> specific')
+    assert_equal(1, installed.<=>(specific),  'installed <=> specific')
 
-    assert_equal( 1, git.      <=>(installed), 'git       <=> installed')
+    assert_equal(1, git.      <=>(installed), 'git       <=> installed')
     assert_equal(-1, installed.<=>(git),       'installed <=> git')
 
-    assert_equal( 1, vendor.   <=>(installed), 'vendor    <=> installed')
+    assert_equal(1, vendor.   <=>(installed), 'vendor    <=> installed')
     assert_equal(-1, installed.<=>(vendor),    'installed <=> vendor')
   end
 

--- a/test/rubygems/test_gem_source_local.rb
+++ b/test/rubygems/test_gem_source_local.rb
@@ -92,16 +92,16 @@ class TestGemSourceLocal < Gem::TestCase
     installed = Gem::Source::Installed.new
     local     = Gem::Source::Local.new
 
-    assert_equal( 0, local.    <=>(local),     'local     <=> local')
+    assert_equal(0, local.    <=>(local),     'local     <=> local')
 
     assert_equal(-1, remote.   <=>(local),     'remote    <=> local')
-    assert_equal( 1, local.    <=>(remote),    'local     <=> remote')
+    assert_equal(1, local.    <=>(remote),    'local     <=> remote')
 
-    assert_equal( 1, installed.<=>(local),     'installed <=> local')
+    assert_equal(1, installed.<=>(local),     'installed <=> local')
     assert_equal(-1, local.    <=>(installed), 'local     <=> installed')
 
     assert_equal(-1, specific. <=>(local),     'specific  <=> local')
-    assert_equal( 1, local.    <=>(specific),  'local     <=> specific')
+    assert_equal(1, local.    <=>(specific),  'local     <=> specific')
   end
 
 end

--- a/test/rubygems/test_gem_source_lock.rb
+++ b/test/rubygems/test_gem_source_lock.rb
@@ -40,25 +40,25 @@ class TestGemSourceLock < Gem::TestCase
     vendor = Gem::Source::Vendor.new 'vendor/a'
     v_lock = Gem::Source::Lock.new vendor
 
-    assert_equal( 0, g_lock.<=>(g_lock), 'g_lock <=> g_lock')
-    assert_equal( 0, i_lock.<=>(i_lock), 'i_lock <=> i_lock')
-    assert_equal( 0, v_lock.<=>(v_lock), 'v_lock <=> v_lock')
+    assert_equal(0, g_lock.<=>(g_lock), 'g_lock <=> g_lock')
+    assert_equal(0, i_lock.<=>(i_lock), 'i_lock <=> i_lock')
+    assert_equal(0, v_lock.<=>(v_lock), 'v_lock <=> v_lock')
 
-    assert_equal( 1, g_lock.<=>(i_lock), 'g_lock <=> i_lock')
+    assert_equal(1, g_lock.<=>(i_lock), 'g_lock <=> i_lock')
     assert_equal(-1, i_lock.<=>(g_lock), 'i_lock <=> g_lock')
 
     assert_equal(-1, g_lock.<=>(v_lock), 'g_lock <=> v_lock')
-    assert_equal( 1, v_lock.<=>(g_lock), 'v_lock <=> g_lock')
+    assert_equal(1, v_lock.<=>(g_lock), 'v_lock <=> g_lock')
 
     assert_equal(-1, i_lock.<=>(v_lock), 'i_lock <=> v_lock')
-    assert_equal( 1, v_lock.<=>(i_lock), 'i_lock <=> v_lock')
+    assert_equal(1, v_lock.<=>(i_lock), 'i_lock <=> v_lock')
   end
 
   def test_spaceship_git
     git  = Gem::Source::Git.new 'a', 'git/a', 'master', false
     lock = Gem::Source::Lock.new git
 
-    assert_equal( 1, lock.<=>(git),  'lock <=> git')
+    assert_equal(1, lock.<=>(git),  'lock <=> git')
     assert_equal(-1, git .<=>(lock), 'git  <=> lock')
   end
 
@@ -66,7 +66,7 @@ class TestGemSourceLock < Gem::TestCase
     installed = Gem::Source::Installed.new
     lock      = Gem::Source::Lock.new installed
 
-    assert_equal( 1, lock.     <=>(installed),  'lock      <=> installed')
+    assert_equal(1, lock.     <=>(installed),  'lock      <=> installed')
     assert_equal(-1, installed.<=>(lock),       'installed <=> lock')
   end
 
@@ -74,7 +74,7 @@ class TestGemSourceLock < Gem::TestCase
     local = Gem::Source::Local.new
     lock  = Gem::Source::Lock.new local # nonsense
 
-    assert_equal( 1, lock. <=>(local), 'lock  <=> local')
+    assert_equal(1, lock. <=>(local), 'lock  <=> local')
     assert_equal(-1, local.<=>(lock),  'local <=> lock')
   end
 
@@ -82,7 +82,7 @@ class TestGemSourceLock < Gem::TestCase
     remote = Gem::Source.new @gem_repo
     lock   = Gem::Source::Lock.new remote
 
-    assert_equal( 1, lock.  <=>(remote), 'lock   <=> remote')
+    assert_equal(1, lock.  <=>(remote), 'lock   <=> remote')
     assert_equal(-1, remote.<=>(lock),   'remote <=> lock')
   end
 
@@ -92,7 +92,7 @@ class TestGemSourceLock < Gem::TestCase
     specific = Gem::Source::SpecificFile.new gem
     lock     = Gem::Source::Lock.new specific # nonsense
 
-    assert_equal( 1, lock    .<=>(specific),  'lock     <=> specific')
+    assert_equal(1, lock    .<=>(specific),  'lock     <=> specific')
     assert_equal(-1, specific.<=>(lock),      'specific <=> lock')
   end
 
@@ -100,7 +100,7 @@ class TestGemSourceLock < Gem::TestCase
     vendor = Gem::Source::Vendor.new 'vendor/a'
     lock   = Gem::Source::Lock.new vendor
 
-    assert_equal( 1, lock.  <=>(vendor), 'lock   <=>    vendor')
+    assert_equal(1, lock.  <=>(vendor), 'lock   <=>    vendor')
     assert_equal(-1, vendor.<=>(lock),   'vendor <=> lock')
   end
 

--- a/test/rubygems/test_gem_source_specific_file.rb
+++ b/test/rubygems/test_gem_source_specific_file.rb
@@ -45,16 +45,16 @@ class TestGemSourceSpecificFile < Gem::TestCase
     installed = Gem::Source::Installed.new
     local     = Gem::Source::Local.new
 
-    assert_equal( 0, specific. <=>(specific),  'specific  <=> specific')
+    assert_equal(0, specific. <=>(specific),  'specific  <=> specific')
 
     assert_equal(-1, remote.   <=>(specific),  'remote    <=> specific')
-    assert_equal( 1, specific. <=>(remote),    'specific  <=> remote')
+    assert_equal(1, specific. <=>(remote),    'specific  <=> remote')
 
     assert_equal(-1, specific. <=>(local),     'specific  <=> local')
-    assert_equal( 1, local.    <=>(specific),  'local     <=> specific')
+    assert_equal(1, local.    <=>(specific),  'local     <=> specific')
 
     assert_equal(-1, specific. <=>(installed), 'specific  <=> installed')
-    assert_equal( 1, installed.<=>(specific),  'installed <=> specific')
+    assert_equal(1, installed.<=>(specific),  'installed <=> specific')
 
     a2 = quick_gem 'a', '2'
     util_build_gem a2
@@ -69,8 +69,8 @@ class TestGemSourceSpecificFile < Gem::TestCase
     assert_nil       a1_source.<=>(b1_source), 'a1_source <=> b1_source'
 
     assert_equal(-1, a1_source.<=>(a2_source), 'a1_source <=> a2_source')
-    assert_equal( 0, a1_source.<=>(a1_source), 'a1_source <=> a1_source')
-    assert_equal( 1, a2_source.<=>(a1_source), 'a2_source <=> a1_source')
+    assert_equal(0, a1_source.<=>(a1_source), 'a1_source <=> a1_source')
+    assert_equal(1, a2_source.<=>(a1_source), 'a2_source <=> a1_source')
   end
 
 end

--- a/test/rubygems/test_gem_source_vendor.rb
+++ b/test/rubygems/test_gem_source_vendor.rb
@@ -16,15 +16,15 @@ class TestGemSourceVendor < Gem::TestCase
     git       = Gem::Source::Git.new 'a', 'a', 'master'
     installed = Gem::Source::Installed.new
 
-    assert_equal( 0, vendor.   <=>(vendor),    'vendor    <=> vendor')
+    assert_equal(0, vendor.   <=>(vendor),    'vendor    <=> vendor')
 
-    assert_equal( 1, vendor.   <=>(remote),    'vendor    <=> remote')
+    assert_equal(1, vendor.   <=>(remote),    'vendor    <=> remote')
     assert_equal(-1, remote.   <=>(vendor),    'remote    <=> vendor')
 
-    assert_equal( 1, vendor.   <=>(git),       'vendor    <=> git')
+    assert_equal(1, vendor.   <=>(git),       'vendor    <=> git')
     assert_equal(-1, git.      <=>(vendor),    'git       <=> vendor')
 
-    assert_equal( 1, vendor.   <=>(installed), 'vendor    <=> installed')
+    assert_equal(1, vendor.   <=>(installed), 'vendor    <=> installed')
     assert_equal(-1, installed.<=>(vendor),    'installed <=> vendor')
   end
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2316,8 +2316,8 @@ dependencies: []
     s2 = util_spec 'b', '1'
 
     assert_equal(-1, (s1 <=> s2))
-    assert_equal( 0, (s1 <=> s1))
-    assert_equal( 1, (s2 <=> s1))
+    assert_equal(0, (s1 <=> s1))
+    assert_equal(1, (s2 <=> s1))
   end
 
   def test_spaceship_platform
@@ -2326,18 +2326,18 @@ dependencies: []
       s.platform = Gem::Platform.new 'x86-my_platform1'
     end
 
-    assert_equal( -1, (s1 <=> s2))
-    assert_equal(  0, (s1 <=> s1))
-    assert_equal(  1, (s2 <=> s1))
+    assert_equal(-1, (s1 <=> s2))
+    assert_equal(0, (s1 <=> s1))
+    assert_equal(1, (s2 <=> s1))
   end
 
   def test_spaceship_version
     s1 = util_spec 'a', '1'
     s2 = util_spec 'a', '2'
 
-    assert_equal( -1, (s1 <=> s2))
-    assert_equal(  0, (s1 <=> s1))
-    assert_equal(  1, (s2 <=> s1))
+    assert_equal(-1, (s1 <=> s2))
+    assert_equal(0, (s1 <=> s1))
+    assert_equal(1, (s2 <=> s1))
   end
 
   def test_spec_file

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -148,14 +148,14 @@ class TestGemVersion < Gem::TestCase
   end
 
   def test_spaceship
-    assert_equal( 0, v("1.0")       <=> v("1.0.0"))
-    assert_equal( 1, v("1.0")       <=> v("1.0.a"))
-    assert_equal( 1, v("1.8.2")     <=> v("0.0.0"))
-    assert_equal( 1, v("1.8.2")     <=> v("1.8.2.a"))
-    assert_equal( 1, v("1.8.2.b")   <=> v("1.8.2.a"))
+    assert_equal(0, v("1.0")       <=> v("1.0.0"))
+    assert_equal(1, v("1.0")       <=> v("1.0.a"))
+    assert_equal(1, v("1.8.2")     <=> v("0.0.0"))
+    assert_equal(1, v("1.8.2")     <=> v("1.8.2.a"))
+    assert_equal(1, v("1.8.2.b")   <=> v("1.8.2.a"))
     assert_equal(-1, v("1.8.2.a")   <=> v("1.8.2"))
-    assert_equal( 1, v("1.8.2.a10") <=> v("1.8.2.a9"))
-    assert_equal( 0, v("")          <=> v("0"))
+    assert_equal(1, v("1.8.2.a10") <=> v("1.8.2.a9"))
+    assert_equal(0, v("")          <=> v("0"))
 
     assert_nil v("1.0") <=> "whatever"
   end


### PR DESCRIPTION
# Description:

One more `rubocop` cop enabled. We were pretty much consistent here already.

I can see the "alignment" argument to avoid this cop, although I don't like it since all those "pretty alignments" take effort to maintain, and maintaining them tends to obscure the real point of changes. So, if some devs doesn't like this I'll just happily close :)

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
