### PR TITLE
Fix `--ignore-dependencies` flag not installing platform specific gems

### DIFF
--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -241,7 +241,6 @@ You can use `i` command instead of `install`.
     inst = Gem::Installer.at gem, options
     inst.install
 
-    require 'rubygems/dependency_installer'
     dinst = Gem::DependencyInstaller.new options
     dinst.installed_gems.replace [inst.spec]
 

--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -194,12 +194,12 @@ You can use `i` command instead of `install`.
 
     req = Gem::Requirement.create(version)
 
-    inst = Gem::DependencyInstaller.new options
+    dinst = Gem::DependencyInstaller.new options
 
     if options[:ignore_dependencies]
-      install_gem_without_dependencies inst, name, req
+      install_gem_without_dependencies dinst, name, req
     else
-      request_set = inst.resolve_dependencies name, req
+      request_set = dinst.resolve_dependencies name, req
 
       if options[:explain]
         say "Gems to install:"
@@ -213,7 +213,7 @@ You can use `i` command instead of `install`.
         @installed_specs.concat request_set.install options
       end
 
-      show_install_errors inst.errors
+      show_install_errors dinst.errors
     end
   end
 

--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -207,22 +207,11 @@ You can use `i` command instead of `install`.
     gem = nil
 
     if local?
-      if name =~ /\.gem$/ and File.file? name
-        source = Gem::Source::SpecificFile.new name
-        spec = source.spec
-      else
-        source = Gem::Source::Local.new
-        spec = source.find_gem name, req
-      end
-      gem = source.download spec if spec
+      gem = fetch_local_gem name, req
     end
 
     if remote? and not gem
-      dependency = Gem::Dependency.new name, req
-      dependency.prerelease = options[:prerelease]
-
-      fetcher = Gem::RemoteFetcher.fetcher
-      gem = fetcher.download_to_cache dependency
+      gem = fetch_remote_gem name, req
     end
 
     inst = Gem::Installer.at gem, options
@@ -281,6 +270,25 @@ You can use `i` command instead of `install`.
     end
 
     show_install_errors dinst.errors
+  end
+
+  def fetch_local_gem(name, req) # :nodoc:
+    if name =~ /\.gem$/ and File.file? name
+      source = Gem::Source::SpecificFile.new name
+      spec = source.spec
+    else
+      source = Gem::Source::Local.new
+      spec = source.find_gem name, req
+    end
+    source.download spec if spec
+  end
+
+  def fetch_remote_gem(name, req) # :nodoc:
+    dependency = Gem::Dependency.new name, req
+    dependency.prerelease = options[:prerelease]
+
+    fetcher = Gem::RemoteFetcher.fetcher
+    fetcher.download_to_cache dependency
   end
 
   ##

--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -210,11 +210,11 @@ You can use `i` command instead of `install`.
       gem = fetch_local_gem name, req
     end
 
-    if remote? and not gem
-      gem = fetch_remote_gem name, req
-    end
-
-    installed_spec_set = install_fetched_gem dinst, gem
+    installed_spec_set = if remote? and not gem
+                           dinst.install name, req
+                         else
+                           install_fetched_gem dinst, gem
+                         end
 
     Gem.done_installing_hooks.each do |hook|
       hook.call dinst, installed_spec_set
@@ -278,14 +278,6 @@ You can use `i` command instead of `install`.
       spec = source.find_gem name, req
     end
     source.download spec if spec
-  end
-
-  def fetch_remote_gem(name, req) # :nodoc:
-    dependency = Gem::Dependency.new name, req
-    dependency.prerelease = options[:prerelease]
-
-    fetcher = Gem::RemoteFetcher.fetcher
-    fetcher.download_to_cache dependency
   end
 
   def install_fetched_gem(dinst, gem) # :nodoc:

--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -214,16 +214,13 @@ You can use `i` command instead of `install`.
       gem = fetch_remote_gem name, req
     end
 
-    inst = Gem::Installer.at gem, options
-    inst.install
-
-    dinst.installed_gems.replace [inst.spec]
+    installed_spec_set = install_fetched_gem dinst, gem
 
     Gem.done_installing_hooks.each do |hook|
-      hook.call dinst, [inst.spec]
+      hook.call dinst, installed_spec_set
     end unless Gem.done_installing_hooks.empty?
 
-    @installed_specs.push(inst.spec)
+    @installed_specs.push(*installed_spec_set)
   end
 
   def install_gems # :nodoc:
@@ -289,6 +286,15 @@ You can use `i` command instead of `install`.
 
     fetcher = Gem::RemoteFetcher.fetcher
     fetcher.download_to_cache dependency
+  end
+
+  def install_fetched_gem(dinst, gem) # :nodoc:
+    inst = Gem::Installer.at gem, options
+    inst.install
+
+    dinst.installed_gems.replace [inst.spec]
+
+    [inst.spec]
   end
 
   ##

--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -194,10 +194,11 @@ You can use `i` command instead of `install`.
 
     req = Gem::Requirement.create(version)
 
+    inst = Gem::DependencyInstaller.new options
+
     if options[:ignore_dependencies]
-      install_gem_without_dependencies name, req
+      install_gem_without_dependencies inst, name, req
     else
-      inst = Gem::DependencyInstaller.new options
       request_set = inst.resolve_dependencies name, req
 
       if options[:explain]
@@ -216,9 +217,7 @@ You can use `i` command instead of `install`.
     end
   end
 
-  def install_gem_without_dependencies(name, req) # :nodoc:
-    dinst = Gem::DependencyInstaller.new options
-
+  def install_gem_without_dependencies(dinst, name, req) # :nodoc:
     gem = nil
 
     if local?

--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -217,6 +217,8 @@ You can use `i` command instead of `install`.
   end
 
   def install_gem_without_dependencies(name, req) # :nodoc:
+    dinst = Gem::DependencyInstaller.new options
+
     gem = nil
 
     if local?
@@ -241,7 +243,6 @@ You can use `i` command instead of `install`.
     inst = Gem::Installer.at gem, options
     inst.install
 
-    dinst = Gem::DependencyInstaller.new options
     dinst.installed_gems.replace [inst.spec]
 
     Gem.done_installing_hooks.each do |hook|

--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -199,21 +199,7 @@ You can use `i` command instead of `install`.
     if options[:ignore_dependencies]
       install_gem_without_dependencies dinst, name, req
     else
-      request_set = dinst.resolve_dependencies name, req
-
-      if options[:explain]
-        say "Gems to install:"
-
-        request_set.sorted_requests.each do |activation_request|
-          say "  #{activation_request.full_name}"
-        end
-
-        return
-      else
-        @installed_specs.concat request_set.install options
-      end
-
-      show_install_errors dinst.errors
+      install_gem_with_dependencies dinst, name, req
     end
   end
 
@@ -277,6 +263,24 @@ You can use `i` command instead of `install`.
     end
 
     exit_code
+  end
+
+  def install_gem_with_dependencies(dinst, name, req) # :nodoc:
+    request_set = dinst.resolve_dependencies name, req
+
+    if options[:explain]
+      say "Gems to install:"
+
+      request_set.sorted_requests.each do |activation_request|
+        say "  #{activation_request.full_name}"
+      end
+
+      return
+    else
+      @installed_specs.concat request_set.install options
+    end
+
+    show_install_errors dinst.errors
   end
 
   ##

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -753,6 +753,23 @@ ERROR:  Possible alternatives: non_existent_with_hint
     assert_equal %w[a-2], @cmd.installed_specs.map { |spec| spec.full_name }
   end
 
+  def test_install_gem_ignore_dependencies_remote_platform_local
+    local = Gem::Platform.local
+    spec_fetcher do |fetcher|
+      fetcher.gem 'a', 3
+
+      fetcher.gem 'a', 3 do |s|
+        s.platform = local
+      end
+    end
+
+    @cmd.options[:ignore_dependencies] = true
+
+    @cmd.install_gem 'a', '>= 0'
+
+    assert_equal %W[a-3-#{local}], @cmd.installed_specs.map { |spec| spec.full_name }
+  end
+
   def test_install_gem_ignore_dependencies_specific_file
     spec = util_spec 'a', 2
 


### PR DESCRIPTION
# Description:

The problem is that Rubygems won't install platform-specific gems when the `--ignore-dependencies` option is passed.

This is a rework of #2446. It's essentially the same fix proposed by @camertron in #2446 using the same approach, but I split it into an incremental refactoring divided in small commits that always keep tests passing. So, even if the final diff can be hard to understand, a commit per commit review should be pretty straightforward.

Last commit fixes the bug by replacing the raw usage of `Gem::RemoteFetcher` with `Gem::DependencyInstaller#install` which does the proper platform filtering while also respecting the `--ignore-dependencies` flag. It also adds a regression test (borrowed from @MSP-Greg).

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
