### PR TITLE
Make `gem install --explain` list platforms

### DIFF
--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -201,10 +201,10 @@ You can use `i` command instead of `install`.
       request_set = inst.resolve_dependencies name, req
 
       if options[:explain]
-        puts "Gems to install:"
+        say "Gems to install:"
 
         request_set.sorted_requests.each do |s|
-          puts "  #{s.full_name}"
+          say "  #{s.full_name}"
         end
 
         return

--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -204,7 +204,10 @@ You can use `i` command instead of `install`.
         say "Gems to install:"
 
         request_set.sorted_requests.each do |s|
-          say "  #{s.full_name}"
+          # shows platform specific gems if used
+          say (plat = s.spec.platform) == Gem::Platform::RUBY ?
+            "  #{s.full_name}" :
+            "  #{s.full_name}-#{plat}"
         end
 
         return

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -1142,4 +1142,59 @@ ERROR:  Possible alternatives: non_existent_with_hint
     assert_equal [:test, :development], @cmd.options[:without_groups]
   end
 
+  def test_explain_platform_local
+    local = Gem::Platform.local
+    spec_fetcher do |fetcher|
+      fetcher.spec 'a', 2
+
+      fetcher.spec 'a', 2 do |s|
+        s.platform = local
+      end
+    end
+
+    @cmd.options[:explain] = true
+    @cmd.options[:args] = %w[a]
+
+    use_ui @ui do
+      assert_raises Gem::MockGemUi::SystemExitException, @ui.error do
+        @cmd.execute
+      end
+    end
+
+    out = @ui.output.split "\n"
+
+    assert_equal "Gems to install:", out.shift
+    assert_equal "  a-2-#{local}", out.shift
+    assert_empty out
+  end
+
+  def test_explain_platform_ruby
+    local = Gem::Platform.local
+    spec_fetcher do |fetcher|
+      fetcher.spec 'a', 2
+
+      fetcher.spec 'a', 2 do |s|
+        s.platform = local
+      end
+    end
+
+    # equivalent to --platform=ruby
+    Gem.platforms = [Gem::Platform::RUBY]
+
+    @cmd.options[:explain] = true
+    @cmd.options[:args] = %w[a]
+
+    use_ui @ui do
+      assert_raises Gem::MockGemUi::SystemExitException, @ui.error do
+        @cmd.execute
+      end
+    end
+
+    out = @ui.output.split "\n"
+
+    assert_equal "Gems to install:", out.shift
+    assert_equal "  a-2", out.shift
+    assert_empty out
+  end
+
 end


### PR DESCRIPTION
# Description:

Extracting more isolated changes from #2616. In this case, now `gem install --explain` informs about gem platforms.

As always full credit to @MSP-Greg for the fixes and the great tests, I'm only explaining them a bit better :)

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
