### PR TITLE
Enable Style/EmptyLinesAroundClassBody rubocop cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,6 +31,10 @@ Layout/EndOfLine:
   Enabled: true
   EnforcedStyle: lf
 
+Layout/EmptyLinesAroundClassBody:
+  Enabled: true
+  EnforcedStyle: empty_lines_except_namespace
+
 Layout/EmptyLinesAroundMethodBody:
   Enabled: true
 

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -593,8 +593,10 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   end
 
   class << self
+
     extend Gem::Deprecate
     deprecate :gunzip, "Gem::Util.gunzip", 2018, 12
+
   end
 
   ##
@@ -605,8 +607,10 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   end
 
   class << self
+
     extend Gem::Deprecate
     deprecate :gzip, "Gem::Util.gzip", 2018, 12
+
   end
 
   ##
@@ -617,8 +621,10 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   end
 
   class << self
+
     extend Gem::Deprecate
     deprecate :inflate, "Gem::Util.inflate", 2018, 12
+
   end
 
   ##
@@ -1211,6 +1217,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   end
 
   class << self
+
     ##
     # TODO remove with RubyGems 4.0
 
@@ -1218,6 +1225,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
     extend Gem::Deprecate
     deprecate :detect_gemdeps, "Gem.use_gemdeps", 2018, 12
+
   end
 
   # FIX: Almost everywhere else we use the `def self.` way of defining class
@@ -1337,6 +1345,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     # work
 
     attr_reader :pre_uninstall_hooks
+
   end
 
   ##

--- a/lib/rubygems/available_set.rb
+++ b/lib/rubygems/available_set.rb
@@ -162,4 +162,5 @@ class Gem::AvailableSet
   def inject_into_list(dep_list)
     @set.each { |t| dep_list.add t.spec }
   end
+
 end

--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -329,4 +329,5 @@ class Gem::BasicSpecification
       false
     end
   end
+
 end

--- a/lib/rubygems/commands/build_command.rb
+++ b/lib/rubygems/commands/build_command.rb
@@ -96,4 +96,5 @@ Gems can be saved to a specified filename with the output option:
       terminate_interaction 1
     end
   end
+
 end

--- a/lib/rubygems/commands/dependency_command.rb
+++ b/lib/rubygems/commands/dependency_command.rb
@@ -215,4 +215,5 @@ use with other commands.
       /\A#{Regexp.union(*args)}/
     end
   end
+
 end

--- a/lib/rubygems/commands/info_command.rb
+++ b/lib/rubygems/commands/info_command.rb
@@ -4,6 +4,7 @@ require 'rubygems/command'
 require 'rubygems/commands/query_command'
 
 class Gem::Commands::InfoCommand < Gem::Commands::QueryCommand
+
   def initialize
     super "info", "Show information for the given gem"
 
@@ -30,4 +31,5 @@ class Gem::Commands::InfoCommand < Gem::Commands::QueryCommand
   def defaults_str
     "--local"
   end
+
 end

--- a/lib/rubygems/commands/mirror_command.rb
+++ b/lib/rubygems/commands/mirror_command.rb
@@ -3,6 +3,7 @@ require 'rubygems/command'
 
 unless defined? Gem::Commands::MirrorCommand
   class Gem::Commands::MirrorCommand < Gem::Command
+
     def initialize
       super('mirror', 'Mirror all gem files (requires rubygems-mirror)')
       begin

--- a/lib/rubygems/commands/open_command.rb
+++ b/lib/rubygems/commands/open_command.rb
@@ -84,4 +84,5 @@ class Gem::Commands::OpenCommand < Gem::Command
 
     say "Unable to find gem '#{name}'"
   end
+
 end

--- a/lib/rubygems/commands/outdated_command.rb
+++ b/lib/rubygems/commands/outdated_command.rb
@@ -30,4 +30,5 @@ update the gems with the update or install commands.
       say "#{spec.name} (#{spec.version} < #{remote_version})"
     end
   end
+
 end

--- a/lib/rubygems/commands/owner_command.rb
+++ b/lib/rubygems/commands/owner_command.rb
@@ -4,6 +4,7 @@ require 'rubygems/local_remote_options'
 require 'rubygems/gemcutter_utilities'
 
 class Gem::Commands::OwnerCommand < Gem::Command
+
   include Gem::LocalRemoteOptions
   include Gem::GemcutterUtilities
 

--- a/lib/rubygems/commands/pristine_command.rb
+++ b/lib/rubygems/commands/pristine_command.rb
@@ -183,4 +183,5 @@ extensions will be restored.
       say "Restored #{spec.full_name}"
     end
   end
+
 end

--- a/lib/rubygems/commands/push_command.rb
+++ b/lib/rubygems/commands/push_command.rb
@@ -5,6 +5,7 @@ require 'rubygems/gemcutter_utilities'
 require 'rubygems/package'
 
 class Gem::Commands::PushCommand < Gem::Command
+
   include Gem::LocalRemoteOptions
   include Gem::GemcutterUtilities
 
@@ -145,4 +146,5 @@ You can upgrade or downgrade to the latest release version with:
       gem_metadata["allowed_push_host"]
     ]
   end
+
 end

--- a/lib/rubygems/commands/rdoc_command.rb
+++ b/lib/rubygems/commands/rdoc_command.rb
@@ -5,6 +5,7 @@ require 'rubygems/rdoc'
 require 'fileutils'
 
 class Gem::Commands::RdocCommand < Gem::Command
+
   include Gem::VersionOption
 
   def initialize

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -6,6 +6,7 @@ require 'rubygems/command'
 # RubyGems checkout or tarball.
 
 class Gem::Commands::SetupCommand < Gem::Command
+
   HISTORY_HEADER = /^===\s*[\d.a-zA-Z]+\s*\/\s*\d{4}-\d{2}-\d{2}\s*$/.freeze
   VERSION_MATCHER = /^===\s*([\d.a-zA-Z]+)\s*\/\s*\d{4}-\d{2}-\d{2}\s*$/.freeze
 

--- a/lib/rubygems/commands/signin_command.rb
+++ b/lib/rubygems/commands/signin_command.rb
@@ -3,6 +3,7 @@ require 'rubygems/command'
 require 'rubygems/gemcutter_utilities'
 
 class Gem::Commands::SigninCommand < Gem::Command
+
   include Gem::GemcutterUtilities
 
   def initialize

--- a/lib/rubygems/commands/specification_command.rb
+++ b/lib/rubygems/commands/specification_command.rb
@@ -143,4 +143,5 @@ Specific fields in the specification can be extracted in YAML format:
       say "\n"
     end
   end
+
 end

--- a/lib/rubygems/commands/stale_command.rb
+++ b/lib/rubygems/commands/stale_command.rb
@@ -2,6 +2,7 @@
 require 'rubygems/command'
 
 class Gem::Commands::StaleCommand < Gem::Command
+
   def initialize
     super('stale', 'List gems along with access times')
   end
@@ -36,4 +37,5 @@ longer using.
       say "#{name} at #{atime.strftime '%c'}"
     end
   end
+
 end

--- a/lib/rubygems/commands/uninstall_command.rb
+++ b/lib/rubygems/commands/uninstall_command.rb
@@ -185,4 +185,5 @@ that is a dependency of an existing gem.  You can use the
   def uninstall(gem_name)
     Gem::Uninstaller.new(gem_name, options).uninstall
   end
+
 end

--- a/lib/rubygems/commands/which_command.rb
+++ b/lib/rubygems/commands/which_command.rb
@@ -2,6 +2,7 @@
 require 'rubygems/command'
 
 class Gem::Commands::WhichCommand < Gem::Command
+
   def initialize
     super 'which', 'Find the location of a library file you can require',
           :search_gems_first => false, :show_all => false

--- a/lib/rubygems/commands/yank_command.rb
+++ b/lib/rubygems/commands/yank_command.rb
@@ -5,6 +5,7 @@ require 'rubygems/version_option'
 require 'rubygems/gemcutter_utilities'
 
 class Gem::Commands::YankCommand < Gem::Command
+
   include Gem::LocalRemoteOptions
   include Gem::VersionOption
   include Gem::GemcutterUtilities

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -484,4 +484,5 @@ if you believe they were disclosed to a third party.
 
   attr_reader :hash
   protected :hash
+
 end

--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -333,4 +333,5 @@ class Gem::Dependency
 
     matches.first
   end
+
 end

--- a/lib/rubygems/dependency_list.rb
+++ b/lib/rubygems/dependency_list.rb
@@ -17,6 +17,7 @@ require 'rubygems/deprecate'
 # this class necessary anymore?  Especially #ok?, #why_not_ok?
 
 class Gem::DependencyList
+
   attr_reader :specs
 
   include Enumerable

--- a/lib/rubygems/errors.rb
+++ b/lib/rubygems/errors.rb
@@ -13,11 +13,13 @@ module Gem
   # already activated gems or that RubyGems is otherwise unable to activate.
 
   class LoadError < ::LoadError
+
     # Name of gem
     attr_accessor :name
 
     # Version requirement of gem
     attr_accessor :requirement
+
   end
 
   ##
@@ -25,6 +27,7 @@ module Gem
   # system.  Instead of rescuing from this class, make sure to rescue from the
   # superclass Gem::LoadError to catch all types of load errors.
   class MissingSpecError < Gem::LoadError
+
     def initialize(name, requirement)
       @name        = name
       @requirement = requirement
@@ -41,6 +44,7 @@ module Gem
       total = Gem::Specification.stubs.size
       "Could not find '#{name}' (#{requirement}) among #{total} total gem(s)\n"
     end
+
   end
 
   ##
@@ -48,6 +52,7 @@ module Gem
   # not the requested version. Instead of rescuing from this class, make sure to
   # rescue from the superclass Gem::LoadError to catch all types of load errors.
   class MissingSpecVersionError < MissingSpecError
+
     attr_reader :specs
 
     def initialize(name, requirement, specs)
@@ -64,6 +69,7 @@ module Gem
       names = specs.map(&:full_name)
       "Could not find '#{name}' (#{requirement}) - did find: [#{names.join ','}]\n"
     end
+
   end
 
   # Raised when there are conflicting gem specs loaded
@@ -94,6 +100,7 @@ module Gem
 
       super("Unable to activate #{target.full_name}, because #{reason}")
     end
+
   end
 
   class ErrorReason; end
@@ -143,6 +150,7 @@ module Gem
          @platforms.size == 1 ? '' : 's',
          @platforms.join(' ,')]
     end
+
   end
 
   ##
@@ -181,5 +189,6 @@ module Gem
     # The "exception" alias allows you to call raise on a SourceFetchProblem.
 
     alias exception error
+
   end
 end

--- a/lib/rubygems/exceptions.rb
+++ b/lib/rubygems/exceptions.rb
@@ -19,6 +19,7 @@ class Gem::Exception < RuntimeError
 
   extend Gem::Deprecate
   deprecate :source_exception, :none, 2018, 12
+
 end
 
 class Gem::CommandLineError < Gem::Exception; end
@@ -53,14 +54,18 @@ end
 # Raised when attempting to uninstall a gem that isn't in GEM_HOME.
 
 class Gem::GemNotInHomeException < Gem::Exception
+
   attr_accessor :spec
+
 end
 
 ###
 # Raised when removing a gem with the uninstall command fails
 
 class Gem::UninstallError < Gem::Exception
+
   attr_accessor :spec
+
 end
 
 class Gem::DocumentError < Gem::Exception; end
@@ -88,7 +93,9 @@ end
 ##
 # Used to raise parsing and loading errors
 class Gem::FormatException < Gem::Exception
+
   attr_accessor :file_path
+
 end
 
 class Gem::GemNotFoundException < Gem::Exception; end
@@ -166,10 +173,12 @@ end
 
 class Gem::InstallError < Gem::Exception; end
 class Gem::RuntimeRequirementNotMetError < Gem::InstallError
+
   attr_accessor :suggestion
   def message
     [suggestion, super].compact.join("\n\t")
   end
+
 end
 
 ##

--- a/lib/rubygems/ext/cmake_builder.rb
+++ b/lib/rubygems/ext/cmake_builder.rb
@@ -2,6 +2,7 @@
 require 'rubygems/command'
 
 class Gem::Ext::CmakeBuilder < Gem::Ext::Builder
+
   def self.build(extension, dest_path, results, args=[], lib_dir=nil)
     unless File.exist?('Makefile')
       cmd = "cmake . -DCMAKE_INSTALL_PREFIX=#{dest_path}"
@@ -14,4 +15,5 @@ class Gem::Ext::CmakeBuilder < Gem::Ext::Builder
 
     results
   end
+
 end

--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -10,6 +10,7 @@ require 'tempfile'
 require 'shellwords'
 
 class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
+
   FileEntry = FileUtils::Entry_ # :nodoc:
 
   def self.build(extension, dest_path, results, args=[], lib_dir=nil)

--- a/lib/rubygems/indexer.rb
+++ b/lib/rubygems/indexer.rb
@@ -439,4 +439,5 @@ class Gem::Indexer
       Marshal.dump specs_index, io
     end
   end
+
 end

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -108,6 +108,7 @@ class Gem::Installer
   end
 
   class FakePackage
+
     attr_accessor :spec
 
     attr_accessor :dir_mode
@@ -131,6 +132,7 @@ class Gem::Installer
 
     def copy_to(path)
     end
+
   end
 
   ##

--- a/lib/rubygems/installer_test_case.rb
+++ b/lib/rubygems/installer_test_case.rb
@@ -58,6 +58,7 @@ class Gem::Installer
   # Available through requiring rubygems/installer_test_case
 
   attr_writer :wrappers
+
 end
 
 ##

--- a/lib/rubygems/mock_gem_ui.rb
+++ b/lib/rubygems/mock_gem_ui.rb
@@ -7,6 +7,7 @@ require 'rubygems/user_interaction'
 # retrieval during tests.
 
 class Gem::MockGemUi < Gem::StreamUI
+
   ##
   # Raised when you haven't provided enough input to your MockGemUi
 
@@ -19,12 +20,14 @@ class Gem::MockGemUi < Gem::StreamUI
   end
 
   class TermError < RuntimeError
+
     attr_reader :exit_code
 
     def initialize(exit_code)
       super
       @exit_code = exit_code
     end
+
   end
   class SystemExitException < RuntimeError; end
 

--- a/lib/rubygems/name_tuple.rb
+++ b/lib/rubygems/name_tuple.rb
@@ -7,6 +7,7 @@
 require 'rubygems/platform'
 
 class Gem::NameTuple
+
   def initialize(name, version, platform="ruby")
     @name = name
     @version = version

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -53,6 +53,7 @@ class Gem::Package
   class Error < Gem::Exception; end
 
   class FormatError < Error
+
     attr_reader :path
 
     def initialize(message, source = nil)
@@ -68,10 +69,12 @@ class Gem::Package
   end
 
   class PathError < Error
+
     def initialize(destination, destination_dir)
       super "installing into parent path %s of %s is not allowed" %
               [destination, destination_dir]
     end
+
   end
 
   class NonSeekableIO < Error; end

--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -5,6 +5,7 @@
 # to the rest of RubyGems.
 #
 class Gem::PathSupport
+
   ##
   # The default system path for managing Gems.
   attr_reader :home
@@ -87,4 +88,5 @@ class Gem::PathSupport
       path
     end
   end
+
 end

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -202,4 +202,5 @@ class Gem::Platform
   # This will be replaced with Gem::Platform::local.
 
   CURRENT = 'current'.freeze
+
 end

--- a/lib/rubygems/psych_tree.rb
+++ b/lib/rubygems/psych_tree.rb
@@ -2,6 +2,7 @@
 module Gem
   if defined? ::Psych::Visitors
     class NoAliasYAMLTree < Psych::Visitors::YAMLTree
+
       def self.create
         new({})
       end unless respond_to? :create
@@ -27,6 +28,7 @@ module Gem
       end
 
       private :format_time
+
     end
   end
 end

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -402,4 +402,5 @@ class Gem::RemoteFetcher
 
     [id, secret]
   end
+
 end

--- a/lib/rubygems/request/connection_pools.rb
+++ b/lib/rubygems/request/connection_pools.rb
@@ -5,7 +5,9 @@ class Gem::Request::ConnectionPools # :nodoc:
   @client = Net::HTTP
 
   class << self
+
     attr_accessor :client
+
   end
 
   def initialize(proxy_uri, cert_files)

--- a/lib/rubygems/request/http_pool.rb
+++ b/lib/rubygems/request/http_pool.rb
@@ -6,6 +6,7 @@
 # use it.
 
 class Gem::Request::HTTPPool # :nodoc:
+
   attr_reader :cert_files, :proxy_uri
 
   def initialize(http_args, cert_files, proxy_uri)

--- a/lib/rubygems/request/https_pool.rb
+++ b/lib/rubygems/request/https_pool.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 class Gem::Request::HTTPSPool < Gem::Request::HTTPPool # :nodoc:
+
   private
 
   def setup_connection(connection)
     Gem::Request.configure_connection_for_https(connection, @cert_files)
     super
   end
+
 end

--- a/lib/rubygems/request_set/lockfile.rb
+++ b/lib/rubygems/request_set/lockfile.rb
@@ -5,6 +5,7 @@
 # constructed.
 
 class Gem::RequestSet::Lockfile
+
   ##
   # Raised when a lockfile cannot be parsed
 
@@ -35,6 +36,7 @@ class Gem::RequestSet::Lockfile
       @path   = path
       super "#{message} (at line #{line} column #{column})"
     end
+
   end
 
   ##
@@ -233,6 +235,7 @@ class Gem::RequestSet::Lockfile
   def requests
     @set.sorted_requests
   end
+
 end
 
 require 'rubygems/request_set/lockfile/tokenizer'

--- a/lib/rubygems/request_set/lockfile/parser.rb
+++ b/lib/rubygems/request_set/lockfile/parser.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 class Gem::RequestSet::Lockfile::Parser
+
   ###
   # Parses lockfiles
 
@@ -340,4 +341,5 @@ class Gem::RequestSet::Lockfile::Parser
   def unget(token) # :nodoc:
     @tokens.unshift token
   end
+
 end

--- a/lib/rubygems/request_set/lockfile/tokenizer.rb
+++ b/lib/rubygems/request_set/lockfile/tokenizer.rb
@@ -2,6 +2,7 @@
 require 'rubygems/request_set/lockfile/parser'
 
 class Gem::RequestSet::Lockfile::Tokenizer
+
   Token = Struct.new :type, :value, :column, :line
   EOF   = Token.new :EOF
 
@@ -109,4 +110,5 @@ class Gem::RequestSet::Lockfile::Tokenizer
 
     @tokens
   end
+
 end

--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -10,6 +10,7 @@ require "rubygems/deprecate"
 # together in RubyGems.
 
 class Gem::Requirement
+
   OPS = { #:nodoc:
     "="  =>  lambda { |v, r| v == r },
     "!=" =>  lambda { |v, r| v != r },
@@ -301,11 +302,14 @@ class Gem::Requirement
       l.first <=> r.first # then, sort by the operator (for stability)
     end
   end
+
 end
 
 class Gem::Version
+
   # This is needed for compatibility with older yaml
   # gemspecs.
 
   Requirement = Gem::Requirement # :nodoc:
+
 end

--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -11,6 +11,7 @@ require 'rubygems/util/list'
 # all the requirements.
 
 class Gem::Resolver
+
   require 'rubygems/resolver/molinillo'
 
   ##

--- a/lib/rubygems/resolver/requirement_list.rb
+++ b/lib/rubygems/resolver/requirement_list.rb
@@ -79,4 +79,5 @@ class Gem::Resolver::RequirementList
     x = @exact[0,5]
     x + @list[0,5 - x.size]
   end
+
 end

--- a/lib/rubygems/resolver/specification.rb
+++ b/lib/rubygems/resolver/specification.rb
@@ -111,4 +111,5 @@ class Gem::Resolver::Specification
   def local? # :nodoc:
     false
   end
+
 end

--- a/lib/rubygems/resolver/stats.rb
+++ b/lib/rubygems/resolver/stats.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 class Gem::Resolver::Stats
+
   def initialize
     @max_depth = 0
     @max_requirements = 0
@@ -42,4 +43,5 @@ class Gem::Resolver::Stats
     $stdout.printf PATTERN, "Backtracking #", @backtracking
     $stdout.printf PATTERN, "Iteration #", @iterations
   end
+
 end

--- a/lib/rubygems/server.rb
+++ b/lib/rubygems/server.rb
@@ -875,4 +875,5 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
 
     system("#{@launch} http://#{host}:#{@port}")
   end
+
 end

--- a/lib/rubygems/source_list.rb
+++ b/lib/rubygems/source_list.rb
@@ -147,4 +147,5 @@ class Gem::SourceList
       @sources.delete_if { |x| x.uri.to_s == source.to_s }
     end
   end
+
 end

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -2,6 +2,7 @@ require 'delegate'
 require 'uri'
 
 class Gem::SpecificationPolicy < SimpleDelegator
+
   VALID_NAME_PATTERN = /\A[a-zA-Z0-9\.\-\_]+\z/.freeze # :nodoc:
 
   SPECIAL_CHARACTERS = /\A[#{Regexp.escape('.-_')}]+/.freeze # :nodoc:
@@ -404,4 +405,5 @@ http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard li
   def help_text # :nodoc:
     "See http://guides.rubygems.org/specification-reference/ for help"
   end
+
 end

--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -5,6 +5,7 @@
 # information.
 
 class Gem::StubSpecification < Gem::BasicSpecification
+
   # :nodoc:
   PREFIX = "# stub: ".freeze
 
@@ -12,6 +13,7 @@ class Gem::StubSpecification < Gem::BasicSpecification
   OPEN_MODE = 'r:UTF-8:-'.freeze
 
   class StubLine # :nodoc: all
+
     attr_reader :name, :version, :platform, :require_paths, :extensions,
                 :full_name
 
@@ -54,6 +56,7 @@ class Gem::StubSpecification < Gem::BasicSpecification
         REQUIRE_PATHS[x] || x
       }
     end
+
   end
 
   def self.default_gemspec_stub(filename, base_dir, gems_dir)

--- a/lib/rubygems/syck_hack.rb
+++ b/lib/rubygems/syck_hack.rb
@@ -40,11 +40,13 @@ module YAML # :nodoc:
   # should.
   module Syck
     class DefaultKey
+
       remove_method :to_s rescue nil
 
       def to_s
         '='
       end
+
     end
   end
 

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -1341,6 +1341,7 @@ Also, a list:
   end
 
   class << self
+
     # :nodoc:
     ##
     # Return the join path, with escaping backticks, dollars, and
@@ -1354,6 +1355,7 @@ Also, a list:
         "\"#{path.gsub(/[`$"]/, '\\&')}\""
       end
     end
+
   end
 
   @@ruby = rubybin
@@ -1527,6 +1529,7 @@ Also, a list:
 
     def prefetch(reqs) # :nodoc:
     end
+
   end
 
   ##

--- a/lib/rubygems/test_utilities.rb
+++ b/lib/rubygems/test_utilities.rb
@@ -366,4 +366,5 @@ class TempIO < Tempfile
     flush
     Gem.read_binary path
   end
+
 end

--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -354,4 +354,5 @@ class Gem::Uninstaller
 
     raise e
   end
+
 end

--- a/lib/rubygems/user_interaction.rb
+++ b/lib/rubygems/user_interaction.rb
@@ -418,6 +418,7 @@ class Gem::StreamUI
 
     def done
     end
+
   end
 
   ##
@@ -506,6 +507,7 @@ class Gem::StreamUI
     def done
       @out.puts @terminal_message
     end
+
   end
 
   ##
@@ -549,6 +551,7 @@ class Gem::StreamUI
 
     def done
     end
+
   end
 
   ##
@@ -603,7 +606,9 @@ class Gem::StreamUI
         @out.puts message
       end
     end
+
   end
+
 end
 
 ##
@@ -619,6 +624,7 @@ class Gem::ConsoleUI < Gem::StreamUI
   def initialize
     super STDIN, STDOUT, STDERR, true
   end
+
 end
 
 ##
@@ -651,4 +657,5 @@ class Gem::SilentUI < Gem::StreamUI
   def progress_reporter(*args) # :nodoc:
     SilentProgressReporter.new(@outs, *args)
   end
+
 end

--- a/lib/rubygems/util/licenses.rb
+++ b/lib/rubygems/util/licenses.rb
@@ -2,6 +2,7 @@
 require 'rubygems/text'
 
 class Gem::Licenses
+
   extend Gem::Text
 
   NONSTANDARD = 'Nonstandard'.freeze
@@ -434,4 +435,5 @@ class Gem::Licenses
     return unless lowest < license.size
     by_distance[lowest]
   end
+
 end

--- a/lib/rubygems/util/list.rb
+++ b/lib/rubygems/util/list.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 module Gem
   class List
+
     include Enumerable
     attr_accessor :value, :tail
 
@@ -33,5 +34,6 @@ module Gem
       return List.new(value) unless list
       List.new value, list
     end
+
   end
 end

--- a/lib/rubygems/validator.rb
+++ b/lib/rubygems/validator.rb
@@ -141,4 +141,5 @@ class Gem::Validator
 
     errors
   end
+
 end

--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -150,6 +150,7 @@
 # a zero to give a sensible result.
 
 class Gem::Version
+
   autoload :Requirement, 'rubygems/requirement'
 
   include Comparable
@@ -395,4 +396,5 @@ class Gem::Version
     numeric_segments = string_segments.slice!(0, string_start || string_segments.size)
     return numeric_segments, string_segments
   end
+
 end

--- a/test/rubygems/plugin/load/rubygems_plugin.rb
+++ b/test/rubygems/plugin/load/rubygems_plugin.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 class TestGem
+
   TEST_PLUGIN_LOAD = :loaded
+
 end

--- a/test/rubygems/test_deprecate.rb
+++ b/test/rubygems/test_deprecate.rb
@@ -45,6 +45,7 @@ class TestDeprecate < Gem::TestCase
   end
 
   class Thing
+
     extend Gem::Deprecate
     attr_accessor :message
     def foo
@@ -54,6 +55,7 @@ class TestDeprecate < Gem::TestCase
       @message = "bar"
     end
     deprecate :foo, :bar, 2099, 3
+
   end
 
   def test_deprecated_method_calls_the_old_method
@@ -74,4 +76,5 @@ class TestDeprecate < Gem::TestCase
     assert_match(/Thing#foo is deprecated; use bar instead\./, err)
     assert_match(/on or after 2099-03-01/, err)
   end
+
 end

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -14,6 +14,7 @@ $LOAD_PATH.map! do |path|
 end
 
 class TestGem < Gem::TestCase
+
   PLUGINS_LOADED = [] # rubocop:disable Style/MutableConstant
 
   def setup
@@ -1945,4 +1946,5 @@ You may need to `gem install -g` to install missing gems
   def util_cache_dir
     File.join Gem.dir, "cache"
   end
+
 end

--- a/test/rubygems/test_gem_available_set.rb
+++ b/test/rubygems/test_gem_available_set.rb
@@ -127,4 +127,5 @@ class TestGemAvailableSet < Gem::TestCase
 
     assert_equal [a3a, a2, a2a, a1, a1a], g
   end
+
 end

--- a/test/rubygems/test_gem_bundler_version_finder.rb
+++ b/test/rubygems/test_gem_bundler_version_finder.rb
@@ -2,6 +2,7 @@
 require 'rubygems/test_case'
 
 class TestGemBundlerVersionFinder < Gem::TestCase
+
   def setup
     super
 
@@ -127,4 +128,5 @@ class TestGemBundlerVersionFinder < Gem::TestCase
     bvf.filter!(specs)
     specs
   end
+
 end

--- a/test/rubygems/test_gem_command.rb
+++ b/test/rubygems/test_gem_command.rb
@@ -3,7 +3,9 @@ require 'rubygems/test_case'
 require 'rubygems/command'
 
 class Gem::Command
+
   public :parser
+
 end
 
 class TestGemCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_cleanup_command.rb
+++ b/test/rubygems/test_gem_commands_cleanup_command.rb
@@ -263,4 +263,5 @@ class TestGemCommandsCleanupCommand < Gem::TestCase
     assert_path_exists d_1.gem_dir
     assert_path_exists d_2.gem_dir
   end
+
 end

--- a/test/rubygems/test_gem_commands_environment_command.rb
+++ b/test/rubygems/test_gem_commands_environment_command.rb
@@ -152,4 +152,5 @@ class TestGemCommandsEnvironmentCommand < Gem::TestCase
     assert_equal "#{Gem.platforms.join File::PATH_SEPARATOR}\n", @ui.output
     assert_equal '', @ui.error
   end
+
 end

--- a/test/rubygems/test_gem_commands_help_command.rb
+++ b/test/rubygems/test_gem_commands_help_command.rb
@@ -7,6 +7,7 @@ require "rubygems/command_manager"
 require File.expand_path('../rubygems_plugin', __FILE__)
 
 class TestGemCommandsHelpCommand < Gem::TestCase
+
   # previously this was calc'd in setup, but 1.8.7 had
   # intermittent failures, but no issues with above require
   PLUGIN = File.expand_path('../rubygems_plugin.rb', __FILE__)
@@ -75,4 +76,5 @@ class TestGemCommandsHelpCommand < Gem::TestCase
 
     yield @ui.output, @ui.error
   end
+
 end

--- a/test/rubygems/test_gem_commands_info_command.rb
+++ b/test/rubygems/test_gem_commands_info_command.rb
@@ -41,4 +41,5 @@ class TestGemCommandsInfoCommand < Gem::TestCase
     assert_match %r%#{@gem.summary}\n%, @ui.output
     assert_match "", @ui.error
   end
+
 end

--- a/test/rubygems/test_gem_commands_mirror.rb
+++ b/test/rubygems/test_gem_commands_mirror.rb
@@ -3,6 +3,7 @@ require 'rubygems/test_case'
 require 'rubygems/commands/mirror_command'
 
 class TestGemCommandsMirrorCommand < Gem::TestCase
+
   def setup
     super
 

--- a/test/rubygems/test_gem_commands_outdated_command.rb
+++ b/test/rubygems/test_gem_commands_outdated_command.rb
@@ -29,4 +29,5 @@ class TestGemCommandsOutdatedCommand < Gem::TestCase
     assert_equal "foo (0.2 < 2.0)\n", @ui.output
     assert_equal "", @ui.error
   end
+
 end

--- a/test/rubygems/test_gem_commands_push_command.rb
+++ b/test/rubygems/test_gem_commands_push_command.rb
@@ -28,11 +28,13 @@ class TestGemCommandsPushCommand < Gem::TestCase
     @cmd = Gem::Commands::PushCommand.new
 
     class << Gem
+
       alias_method :orig_latest_rubygems_version, :latest_rubygems_version
 
       def latest_rubygems_version
         Gem.rubygems_version
       end
+
     end
   end
 
@@ -40,8 +42,10 @@ class TestGemCommandsPushCommand < Gem::TestCase
     super
 
     class << Gem
+
       remove_method :latest_rubygems_version
       alias_method :latest_rubygems_version, :orig_latest_rubygems_version
+
     end
   end
 

--- a/test/rubygems/test_gem_commands_query_command.rb
+++ b/test/rubygems/test_gem_commands_query_command.rb
@@ -19,6 +19,7 @@ module TestGemCommandsQueryCommandSetup
 end
 
 class TestGemCommandsQueryCommandWithInstalledGems < Gem::TestCase
+
   include TestGemCommandsQueryCommandSetup
 
   def test_execute
@@ -585,9 +586,11 @@ pl (1 i386-linux)
       fetcher.spec 'a', '3.a'
     end
   end
+
 end
 
 class TestGemCommandsQueryCommandWithoutInstalledGems < Gem::TestCase
+
   include TestGemCommandsQueryCommandSetup
 
   def test_execute_platform
@@ -829,4 +832,5 @@ othergem (1.2.3)
       fetcher.download 'a', '3.a'
     end
   end
+
 end

--- a/test/rubygems/test_gem_commands_signin_command.rb
+++ b/test/rubygems/test_gem_commands_signin_command.rb
@@ -95,4 +95,5 @@ class TestGemCommandsSigninCommand < Gem::TestCase
 
     sign_in_ui
   end
+
 end

--- a/test/rubygems/test_gem_commands_uninstall_command.rb
+++ b/test/rubygems/test_gem_commands_uninstall_command.rb
@@ -366,4 +366,5 @@ WARNING:  Use your OS package manager to uninstall vendor gems
     assert_empty @ui.output
     assert_match %r!Error: unable to successfully uninstall '#{@spec.name}'!, @ui.error
   end
+
 end

--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -522,4 +522,5 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
     assert_equal "  a-2", out.shift
     assert_empty out
   end
+
 end

--- a/test/rubygems/test_gem_commands_yank_command.rb
+++ b/test/rubygems/test_gem_commands_yank_command.rb
@@ -3,6 +3,7 @@ require 'rubygems/test_case'
 require 'rubygems/commands/yank_command'
 
 class TestGemCommandsYankCommand < Gem::TestCase
+
   def setup
     super
 

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -489,4 +489,5 @@ if you believe they were disclosed to a third party.
     util_config_file
     assert_equal(true, @cfg.disable_default_gem_server)
   end
+
 end

--- a/test/rubygems/test_gem_dependency_installer.rb
+++ b/test/rubygems/test_gem_dependency_installer.rb
@@ -1235,4 +1235,5 @@ class TestGemDependencyInstaller < Gem::TestCase
 
     util_clear_gems
   end
+
 end

--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -134,6 +134,7 @@ install:
 
   def test_build_extensions_install_ext_only
     class << Gem
+
       alias orig_install_extension_in_lib install_extension_in_lib
 
       remove_method :install_extension_in_lib
@@ -141,6 +142,7 @@ install:
       def Gem.install_extension_in_lib
         false
       end
+
     end
 
     @spec.extensions << 'ext/extconf.rb'
@@ -177,9 +179,11 @@ install:
     refute_path_exists File.join @spec.gem_dir, 'lib', 'a', 'b.rb'
   ensure
     class << Gem
+
       remove_method :install_extension_in_lib
 
       alias install_extension_in_lib orig_install_extension_in_lib
+
     end
   end
 

--- a/test/rubygems/test_gem_ext_rake_builder.rb
+++ b/test/rubygems/test_gem_ext_rake_builder.rb
@@ -3,6 +3,7 @@ require 'rubygems/test_case'
 require 'rubygems/ext'
 
 class TestGemExtRakeBuilder < Gem::TestCase
+
   def setup
     super
 
@@ -90,4 +91,5 @@ class TestGemExtRakeBuilder < Gem::TestCase
       EO_MKRF
     end
   end
+
 end

--- a/test/rubygems/test_gem_install_update_options.rb
+++ b/test/rubygems/test_gem_install_update_options.rb
@@ -180,4 +180,5 @@ class TestGemInstallUpdateOptions < Gem::InstallerTestCase
 
     assert_equal true, @cmd.options[:post_install_message]
   end
+
 end

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -2,6 +2,7 @@
 require 'rubygems/installer_test_case'
 
 class TestGemInstaller < Gem::InstallerTestCase
+
   @@symlink_supported = nil
 
   def symlink_supported?
@@ -1770,4 +1771,5 @@ gem 'other', version
   def mask
     0100755 & (~File.umask)
   end
+
 end

--- a/test/rubygems/test_gem_path_support.rb
+++ b/test/rubygems/test_gem_path_support.rb
@@ -4,6 +4,7 @@ require 'rubygems'
 require 'fileutils'
 
 class TestGemPathSupport < Gem::TestCase
+
   def setup
     super
 
@@ -135,4 +136,5 @@ class TestGemPathSupport < Gem::TestCase
     assert_equal dir, ps.home
     assert_equal [dir, not_existing], ps.path
   end
+
 end

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -304,4 +304,5 @@ class TestGemPlatform < Gem::TestCase
   def refute_local_match(name)
     refute_match Gem::Platform.local, name
   end
+
 end

--- a/test/rubygems/test_gem_rdoc.rb
+++ b/test/rubygems/test_gem_rdoc.rb
@@ -4,6 +4,7 @@ require 'rubygems/test_case'
 require 'rubygems/rdoc'
 
 class TestGemRDoc < Gem::TestCase
+
   Gem::RDoc.load_rdoc
 
   def setup

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -895,11 +895,14 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
   end
 
   class NilLog < WEBrick::Log
+
     def log(level, data) #Do nothing
     end
+
   end
 
   class << self
+
     attr_reader :normal_server, :proxy_server
     attr_accessor :enable_zip, :enable_yaml
 
@@ -1042,6 +1045,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     def key(filename)
       OpenSSL::PKey::RSA.new(File.read(File.join(DIR, filename)))
     end
+
   end
 
   def test_correct_for_windows_path

--- a/test/rubygems/test_gem_request.rb
+++ b/test/rubygems/test_gem_request.rb
@@ -486,6 +486,7 @@ ERROR:  Certificate  is an invalid CA certificate
   end
 
   class Conn
+
     attr_accessor :payload
 
     def new(*args); self; end
@@ -504,6 +505,7 @@ ERROR:  Certificate  is an invalid CA certificate
       self.payload = req
       @response
     end
+
   end
 
 end if defined?(OpenSSL::SSL)

--- a/test/rubygems/test_gem_request_connection_pools.rb
+++ b/test/rubygems/test_gem_request_connection_pools.rb
@@ -4,12 +4,15 @@ require 'rubygems/request'
 require 'timeout'
 
 class TestGemRequestConnectionPool < Gem::TestCase
+
   class FakeHttp
+
     def initialize(*args)
     end
 
     def start
     end
+
   end
 
   def setup
@@ -147,4 +150,5 @@ class TestGemRequestConnectionPool < Gem::TestCase
       end
     }.join
   end
+
 end

--- a/test/rubygems/test_gem_request_set.rb
+++ b/test/rubygems/test_gem_request_set.rb
@@ -3,6 +3,7 @@ require 'rubygems/test_case'
 require 'rubygems/request_set'
 
 class TestGemRequestSet < Gem::TestCase
+
   def setup
     super
 

--- a/test/rubygems/test_gem_request_set_lockfile.rb
+++ b/test/rubygems/test_gem_request_set_lockfile.rb
@@ -466,4 +466,5 @@ DEPENDENCIES
 
     assert_equal 'hello', File.read(gem_deps_lock_file)
   end
+
 end

--- a/test/rubygems/test_gem_request_set_lockfile_parser.rb
+++ b/test/rubygems/test_gem_request_set_lockfile_parser.rb
@@ -6,6 +6,7 @@ require 'rubygems/request_set/lockfile/tokenizer'
 require 'rubygems/request_set/lockfile/parser'
 
 class TestGemRequestSetLockfileParser < Gem::TestCase
+
   def setup
     super
     @gem_deps_file = 'gem.deps.rb'
@@ -541,4 +542,5 @@ DEPENDENCIES
     parser = tokenizer.make_parser set, platforms
     parser.parse
   end
+
 end

--- a/test/rubygems/test_gem_request_set_lockfile_tokenizer.rb
+++ b/test/rubygems/test_gem_request_set_lockfile_tokenizer.rb
@@ -6,6 +6,7 @@ require 'rubygems/request_set/lockfile/tokenizer'
 require 'rubygems/request_set/lockfile/parser'
 
 class TestGemRequestSetLockfileTokenizer < Gem::TestCase
+
   def setup
     super
 
@@ -303,4 +304,5 @@ GEM
   def tokenize_lockfile
     Gem::RequestSet::Lockfile::Tokenizer.from_file(@lock_file).to_a
   end
+
 end

--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -416,4 +416,5 @@ class TestGemRequirement < Gem::TestCase
     refute req(requirement).satisfied_by?(v(version)),
       "#{requirement} is not satisfied by #{version}"
   end
+
 end

--- a/test/rubygems/test_gem_resolver_specification.rb
+++ b/test/rubygems/test_gem_resolver_specification.rb
@@ -4,6 +4,7 @@ require 'rubygems/test_case'
 class TestGemResolverSpecification < Gem::TestCase
 
   class TestSpec < Gem::Resolver::Specification
+
     attr_writer :source
     attr_reader :spec
 
@@ -12,6 +13,7 @@ class TestGemResolverSpecification < Gem::TestCase
 
       @spec = spec
     end
+
   end
 
   def test_install

--- a/test/rubygems/test_gem_server.rb
+++ b/test/rubygems/test_gem_server.rb
@@ -4,10 +4,13 @@ require 'rubygems/server'
 require 'stringio'
 
 class Gem::Server
+
   attr_reader :server
+
 end
 
 class TestGemServer < Gem::TestCase
+
   def process_based_port
     0
   end
@@ -604,4 +607,5 @@ class TestGemServer < Gem::TestCase
 
     @server.instance_variable_set :@server, webrick
   end
+
 end

--- a/test/rubygems/test_gem_silent_ui.rb
+++ b/test/rubygems/test_gem_silent_ui.rb
@@ -114,4 +114,5 @@ class TestGemSilentUI < Gem::TestCase
     assert_empty out, 'No output'
     assert_empty err, 'No output'
   end
+
 end

--- a/test/rubygems/test_gem_source_fetch_problem.rb
+++ b/test/rubygems/test_gem_source_fetch_problem.rb
@@ -24,4 +24,5 @@ class TestGemSourceFetchProblem < Gem::TestCase
 
     refute_match sf.wordy, 'secret'
   end
+
 end

--- a/test/rubygems/test_gem_source_list.rb
+++ b/test/rubygems/test_gem_source_list.rb
@@ -3,6 +3,7 @@ require 'rubygems/source_list'
 require 'rubygems/test_case'
 
 class TestGemSourceList < Gem::TestCase
+
   def setup
     super
 

--- a/test/rubygems/test_gem_source_local.rb
+++ b/test/rubygems/test_gem_source_local.rb
@@ -5,6 +5,7 @@ require 'rubygems/source'
 require 'fileutils'
 
 class TestGemSourceLocal < Gem::TestCase
+
   def setup
     super
 

--- a/test/rubygems/test_gem_source_specific_file.rb
+++ b/test/rubygems/test_gem_source_specific_file.rb
@@ -3,6 +3,7 @@ require 'rubygems/test_case'
 require 'rubygems/source'
 
 class TestGemSourceSpecificFile < Gem::TestCase
+
   def setup
     super
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1823,6 +1823,7 @@ dependencies: []
       RbConfig::CONFIG['ENABLE_SHARED'], 'no'
 
     class << Gem
+
       alias orig_default_ext_dir_for default_ext_dir_for
 
       remove_method :default_ext_dir_for
@@ -1830,6 +1831,7 @@ dependencies: []
       def Gem.default_ext_dir_for(base_dir)
         'elsewhere'
       end
+
     end
 
     ext_spec
@@ -1843,9 +1845,11 @@ dependencies: []
     RbConfig::CONFIG['ENABLE_SHARED'] = enable_shared
 
     class << Gem
+
       remove_method :default_ext_dir_for
 
       alias default_ext_dir_for orig_default_ext_dir_for
+
     end
   end
 
@@ -2135,9 +2139,11 @@ dependencies: []
 
   def test_require_paths_default_ext_dir_for
     class << Gem
+
       send :alias_method, :orig_default_ext_dir_for, :default_ext_dir_for
 
       remove_method :default_ext_dir_for
+
     end
 
     def Gem.default_ext_dir_for(base_dir)
@@ -2153,9 +2159,11 @@ dependencies: []
     end
   ensure
     class << Gem
+
       send :remove_method, :default_ext_dir_for
       send :alias_method,  :default_ext_dir_for, :orig_default_ext_dir_for
       send :remove_method, :orig_default_ext_dir_for
+
     end
   end
 
@@ -3811,4 +3819,5 @@ end
   ensure
     $VERBOSE = old_verbose
   end
+
 end

--- a/test/rubygems/test_gem_stream_ui.rb
+++ b/test/rubygems/test_gem_stream_ui.rb
@@ -4,6 +4,7 @@ require 'rubygems/user_interaction'
 require 'timeout'
 
 class TestGemStreamUI < Gem::TestCase
+
   SHORT_TIMEOUT = (defined?(RubyVM::MJIT) && RubyVM::MJIT.enabled?) ? 1.0 : 0.1 # increase timeout with MJIT for --jit-wait testing
 
   module IsTty
@@ -219,4 +220,5 @@ class TestGemStreamUI < Gem::TestCase
     reporter.fetch 'a.gem', 1024
     assert_equal "", @out.string
   end
+
 end

--- a/test/rubygems/test_gem_stub_specification.rb
+++ b/test/rubygems/test_gem_stub_specification.rb
@@ -3,6 +3,7 @@ require "rubygems/test_case"
 require "rubygems/stub_specification"
 
 class TestStubSpecification < Gem::TestCase
+
   SPECIFICATIONS = File.expand_path(File.join("..", "specifications"), __FILE__)
   FOO = File.join SPECIFICATIONS, "foo-0.0.1-x86-mswin32.gemspec"
   BAR = File.join SPECIFICATIONS, "bar-0.0.2.gemspec"

--- a/test/rubygems/test_gem_text.rb
+++ b/test/rubygems/test_gem_text.rb
@@ -3,6 +3,7 @@ require 'rubygems/test_case'
 require "rubygems/text"
 
 class TestGemText < Gem::TestCase
+
   include Gem::Text
 
   def test_format_text
@@ -89,4 +90,5 @@ Without the wrapping, the text might not look good in the RSS feed.
     s = "ab" * 500_001
     assert_equal "Truncating desc to 1,000,000 characters:\n#{s[0, 1_000_000]}", truncate_text(s, "desc", 1_000_000)
   end
+
 end

--- a/test/rubygems/test_gem_uninstaller.rb
+++ b/test/rubygems/test_gem_uninstaller.rb
@@ -502,4 +502,5 @@ create_makefile '#{@spec.name}'
       end
     end
   end
+
 end

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -284,4 +284,5 @@ class TestGemVersion < Gem::TestCase
   def refute_version_equal(unexpected, actual)
     refute_equal v(unexpected), v(actual)
   end
+
 end

--- a/test/rubygems/test_kernel.rb
+++ b/test/rubygems/test_kernel.rb
@@ -120,4 +120,5 @@ class TestKernel < Gem::TestCase
       assert $:.any? { |p| %r{bundler-1/lib} =~ p }
     end
   end
+
 end

--- a/test/rubygems/test_remote_fetch_error.rb
+++ b/test/rubygems/test_remote_fetch_error.rb
@@ -17,4 +17,5 @@ class TestRemoteFetchError < Gem::TestCase
     error = Gem::RemoteFetcher::FetchError.new('There was an error fetching', 'https://gemsource.org')
     assert_equal error.to_s, 'There was an error fetching (https://gemsource.org)'
   end
+
 end

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -3,7 +3,9 @@ require 'rubygems/test_case'
 require 'rubygems'
 
 class TestGemRequire < Gem::TestCase
+
   class Latch
+
     def initialize(count = 1)
       @count = count
       @lock  = Monitor.new
@@ -22,6 +24,7 @@ class TestGemRequire < Gem::TestCase
         @cv.wait_while { @count > 0 }
       end
     end
+
   end
 
   def setup
@@ -331,8 +334,10 @@ class TestGemRequire < Gem::TestCase
   def test_try_activate_error_unlocks_require_monitor
     silence_warnings do
       class << ::Gem
+
         alias old_try_activate try_activate
         def try_activate(*); raise 'raised from try_activate'; end
+
       end
     end
 
@@ -343,7 +348,9 @@ class TestGemRequire < Gem::TestCase
   ensure
     silence_warnings do
       class << ::Gem
+
         alias try_activate old_try_activate
+
       end
     end
     Kernel::RUBYGEMS_ACTIVATION_MONITOR.exit
@@ -436,4 +443,5 @@ class TestGemRequire < Gem::TestCase
   ensure
     $VERBOSE = old_verbose
   end
+
 end

--- a/util/ci
+++ b/util/ci
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
 class Tool
+
   def initialize(name)
     @name = name
   end
@@ -20,6 +21,7 @@ class Tool
       File.expand_path('../../bundler', __FILE__)
     end
   end
+
 end
 
 TOOL = Tool.new(ENV.fetch("TEST_TOOL") { abort "must specify a TEST_TOOL" })


### PR DESCRIPTION
# Description:

A bit of extra rubocop formatting. Style inconsistencies distract me when I review PRs, so I want to enable some basic cops :). My preferred style is the opposite, but `rubygems` majoritary style (~400 offenses vs ~200 offenses) is this one, so I'm respecting it.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
