### PR TITLE
Enable Style/BlockDelimiters rubocop cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -71,3 +71,6 @@ Style/MethodDefParentheses:
 
 Style/MutableConstant:
   Enabled: true
+
+Style/BlockDelimiters:
+  Enabled: true

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -271,9 +271,9 @@ module Gem
 
     specs = dep.matching_specs(true)
 
-    specs = specs.find_all { |spec|
+    specs = specs.find_all do |spec|
       spec.executables.include? exec_name
-    } if exec_name
+    end if exec_name
 
     unless spec = specs.first
       msg = "can't find gem #{dep} with executable #{exec_name}"
@@ -521,9 +521,9 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
   def self.find_files_from_load_path(glob) # :nodoc:
     glob_with_suffixes = "#{glob}#{Gem.suffix_pattern}"
-    $LOAD_PATH.map { |load_path|
+    $LOAD_PATH.map do |load_path|
       Gem::Util.glob_files_in_dir(glob_with_suffixes, load_path)
-    }.flatten.select { |file| File.file? file.untaint }
+    end.flatten.select { |file| File.file? file.untaint }
   end
 
   ##
@@ -1021,11 +1021,11 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   def self.suffixes
     @suffixes ||= ['',
                    '.rb',
-                   *%w(DLEXT DLEXT2).map { |key|
+                   *%w(DLEXT DLEXT2).map do |key|
                      val = RbConfig::CONFIG[key]
                      next unless val and not val.empty?
                      ".#{val}"
-                   }
+                   end
                   ].compact.uniq
   end
 

--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -393,7 +393,7 @@ class Gem::Command
 
   def merge_options(new_options)
     @options = @defaults.clone
-    new_options.each do |k,v| @options[k] = v end
+    new_options.each { |k,v| @options[k] = v }
   end
 
   ##

--- a/lib/rubygems/commands/cleanup_command.rb
+++ b/lib/rubygems/commands/cleanup_command.rb
@@ -99,7 +99,7 @@ If no gems are named all gems in GEM_HOME are cleaned.
     @full = Gem::DependencyList.from_specs
 
     deplist = Gem::DependencyList.new
-    @gems_to_cleanup.each do |spec| deplist.add spec end
+    @gems_to_cleanup.each { |spec| deplist.add spec }
 
     deps = deplist.strongly_connected_components.flatten
 
@@ -121,19 +121,19 @@ If no gems are named all gems in GEM_HOME are cleaned.
   end
 
   def get_gems_to_cleanup
-    gems_to_cleanup = @candidate_gems.select { |spec|
+    gems_to_cleanup = @candidate_gems.select do |spec|
       @primary_gems[spec.name].version != spec.version
-    }
+    end
 
-    default_gems, gems_to_cleanup = gems_to_cleanup.partition { |spec|
+    default_gems, gems_to_cleanup = gems_to_cleanup.partition do |spec|
       spec.default_gem?
-    }
+    end
 
     uninstall_from = options[:user_install] ? Gem.user_dir : @original_home
 
-    gems_to_cleanup = gems_to_cleanup.select { |spec|
+    gems_to_cleanup = gems_to_cleanup.select do |spec|
       spec.base_dir == uninstall_from
-    }
+    end
 
     @default_gems += default_gems
     @default_gems.uniq!

--- a/lib/rubygems/commands/dependency_command.rb
+++ b/lib/rubygems/commands/dependency_command.rb
@@ -80,9 +80,9 @@ use with other commands.
   end
 
   def gem_dependency(pattern, version, prerelease) # :nodoc:
-    dependency = Gem::Deprecate.skip_during {
+    dependency = Gem::Deprecate.skip_during do
       Gem::Dependency.new pattern, version
-    }
+    end
 
     dependency.prerelease = prerelease
 

--- a/lib/rubygems/commands/lock_command.rb
+++ b/lib/rubygems/commands/lock_command.rb
@@ -100,9 +100,9 @@ lock it down to the exact version.
   end
 
   def spec_path(gem_full_name)
-    gemspecs = Gem.path.map { |path|
+    gemspecs = Gem.path.map do |path|
       File.join path, "specifications", "#{gem_full_name}.gemspec"
-    }
+    end
 
     gemspecs.find { |path| File.exist? path }
   end

--- a/lib/rubygems/commands/query_command.rb
+++ b/lib/rubygems/commands/query_command.rb
@@ -141,9 +141,9 @@ is too hard to use.
 
       display_header 'LOCAL'
 
-      specs = Gem::Specification.find_all { |s|
+      specs = Gem::Specification.find_all do |s|
         s.name =~ name and req =~ s.version
-      }
+      end
 
       spec_tuples = specs.map do |spec|
         [spec.name_tuple, spec]

--- a/lib/rubygems/core_ext/kernel_gem.rb
+++ b/lib/rubygems/core_ext/kernel_gem.rb
@@ -64,9 +64,9 @@ module Kernel
 
     spec = dep.to_spec
 
-    Gem::LOADED_SPECS_MUTEX.synchronize {
+    Gem::LOADED_SPECS_MUTEX.synchronize do
       spec.activate
-    } if spec
+    end if spec
   end
 
   private :gem

--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -277,16 +277,16 @@ class Gem::Dependency
 
   def matching_specs(platform_only = false)
     env_req = Gem.env_requirement(name)
-    matches = Gem::Specification.stubs_for(name).find_all { |spec|
+    matches = Gem::Specification.stubs_for(name).find_all do |spec|
       requirement.satisfied_by?(spec.version) && env_req.satisfied_by?(spec.version)
-    }.map(&:to_spec)
+    end.map(&:to_spec)
 
     Gem::BundlerVersionFinder.filter!(matches) if name == "bundler".freeze
 
     if platform_only
-      matches.reject! { |spec|
+      matches.reject! do |spec|
         spec.nil? || !Gem::Platform.match(spec.platform)
-      }
+      end
     end
 
     matches

--- a/lib/rubygems/dependency_installer.rb
+++ b/lib/rubygems/dependency_installer.rb
@@ -336,15 +336,15 @@ class Gem::DependencyInstaller
 
     # REFACTOR maybe abstract away using Gem::Specification.include? so
     # that this isn't dependent only on the currently installed gems
-    dependency_list.specs.reject! { |spec|
+    dependency_list.specs.reject! do |spec|
       not keep_names.include?(spec.full_name) and
       Gem::Specification.include?(spec)
-    }
+    end
 
     unless dependency_list.ok? or @ignore_dependencies or @force
-      reason = dependency_list.why_not_ok?.map { |k,v|
+      reason = dependency_list.why_not_ok?.map do |k,v|
         "#{k} requires #{v.join(", ")}"
-      }.join("; ")
+      end.join("; ")
       raise Gem::DependencyError, "Unable to resolve dependencies: #{reason}"
     end
 

--- a/lib/rubygems/dependency_list.rb
+++ b/lib/rubygems/dependency_list.rb
@@ -119,10 +119,10 @@ class Gem::DependencyList
     unsatisfied = Hash.new { |h,k| h[k] = [] }
     each do |spec|
       spec.runtime_dependencies.each do |dep|
-        inst = Gem::Specification.any? { |installed_spec|
+        inst = Gem::Specification.any? do |installed_spec|
           dep.name == installed_spec.name and
             dep.requirement.satisfied_by? installed_spec.version
-        }
+        end
 
         unless inst or @specs.find { |s| s.satisfies_requirement? dep }
           unsatisfied[spec.name] << dep
@@ -146,10 +146,10 @@ class Gem::DependencyList
     # If the state is inconsistent, at least don't crash
     return true unless gem_to_remove
 
-    siblings = @specs.find_all { |s|
+    siblings = @specs.find_all do |s|
       s.name == gem_to_remove.name &&
         s.full_name != gem_to_remove.full_name
-    }
+    end
 
     deps = []
 
@@ -161,11 +161,11 @@ class Gem::DependencyList
       end
     end
 
-    deps.all? { |dep|
-      siblings.any? { |s|
+    deps.all? do |dep|
+      siblings.any? do |s|
         s.satisfies_requirement? dep
-      }
-    }
+      end
+    end
   end
 
   ##
@@ -174,10 +174,10 @@ class Gem::DependencyList
   # dependencies).
 
   def remove_specs_unsatisfied_by(dependencies)
-    specs.reject! { |spec|
+    specs.reject! do |spec|
       dep = dependencies[spec.name]
       dep and not dep.requirement.satisfied_by? spec.version
-    }
+    end
   end
 
   ##

--- a/lib/rubygems/deprecate.rb
+++ b/lib/rubygems/deprecate.rb
@@ -48,7 +48,7 @@ module Gem::Deprecate
   # year/month that it is planned to go away.
 
   def deprecate(name, repl, year, month)
-    class_eval {
+    class_eval do
       old = "_deprecated_#{name}"
       alias_method old, name
       define_method name do |*args, &block|
@@ -62,7 +62,7 @@ module Gem::Deprecate
         warn "#{msg.join}." unless Gem::Deprecate.skip
         send old, *args, &block
       end
-    }
+    end
   end
 
   module_function :deprecate, :skip_during

--- a/lib/rubygems/errors.rb
+++ b/lib/rubygems/errors.rb
@@ -92,9 +92,9 @@ module Gem
       @conflicts = conflicts
       @name      = target.name
 
-      reason = conflicts.map { |act, dependencies|
+      reason = conflicts.map do |act, dependencies|
         "#{act.full_name} conflicts with #{dependencies.join(", ")}"
-      }.join ", "
+      end.join ", "
 
       # TODO: improve message by saying who activated `con`
 

--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -240,7 +240,9 @@ EOF
 
     FileUtils.mkdir_p @spec.extension_dir
 
-    File.open destination, 'wb' do |io| io.puts output end
+    File.open destination, 'wb' do |io|
+      io.puts output
+    end
 
     destination
   end

--- a/lib/rubygems/indexer.rb
+++ b/lib/rubygems/indexer.rb
@@ -180,9 +180,9 @@ class Gem::Indexer
   # Builds indices for RubyGems 1.2 and newer. Handles full, latest, prerelease
 
   def build_modern_indices(specs)
-    prerelease, released = specs.partition { |s|
+    prerelease, released = specs.partition do |s|
       s.version.prerelease?
-    }
+    end
     latest_specs =
       Gem::Specification._latest_specs specs
 
@@ -200,7 +200,7 @@ class Gem::Indexer
   end
 
   def map_gems_to_specs(gems)
-    gems.map { |gemfile|
+    gems.map do |gemfile|
       if File.size(gemfile) == 0
         alert_warning "Skipping zero-length gem: #{gemfile}"
         next
@@ -223,7 +223,7 @@ class Gem::Indexer
                "\t#{e.backtrace.join "\n\t"}"].join("\n")
         alert_error msg
       end
-    }.compact
+    end.compact
   end
 
   ##

--- a/lib/rubygems/indexer.rb
+++ b/lib/rubygems/indexer.rb
@@ -131,7 +131,10 @@ class Gem::Indexer
         marshal_name = File.join @quick_marshal_dir, spec_file_name
 
         marshal_zipped = Gem.deflate Marshal.dump(spec)
-        File.open marshal_name, 'wb' do |io| io.write marshal_zipped end
+
+        File.open marshal_name, 'wb' do |io|
+          io.write marshal_zipped
+        end
 
         files << marshal_name
 

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -126,7 +126,9 @@ class Gem::Installer
         file = File.join destination_dir, file
         next if File.exist? file
         FileUtils.mkdir_p File.dirname(file)
-        File.open file, 'w' do |fp| fp.puts "# #{file}" end
+        File.open file, 'w' do |fp|
+          fp.puts "# #{file}"
+        end
       end
     end
 

--- a/lib/rubygems/installer_test_case.rb
+++ b/lib/rubygems/installer_test_case.rb
@@ -156,7 +156,10 @@ class Gem::InstallerTestCase < Gem::TestCase
         f.puts "raise 'ran executable'"
       end
 
-      File.open File.join('lib', 'code.rb'), 'w' do |f| f.puts '1' end
+      File.open File.join('lib', 'code.rb'), 'w' do |f|
+        f.puts '1'
+      end
+
       File.open File.join('ext', 'a', 'mkrf_conf.rb'), 'w' do |f|
         f << <<-EOF
           File.open 'Rakefile', 'w' do |rf| rf.puts "task :default" end

--- a/lib/rubygems/installer_test_case.rb
+++ b/lib/rubygems/installer_test_case.rb
@@ -151,9 +151,11 @@ class Gem::InstallerTestCase < Gem::TestCase
       FileUtils.mkdir_p 'bin'
       FileUtils.mkdir_p 'lib'
       FileUtils.mkdir_p File.join('ext', 'a')
+
       File.open File.join('bin', 'executable'), 'w' do |f|
         f.puts "raise 'ran executable'"
       end
+
       File.open File.join('lib', 'code.rb'), 'w' do |f| f.puts '1' end
       File.open File.join('ext', 'a', 'mkrf_conf.rb'), 'w' do |f|
         f << <<-EOF

--- a/lib/rubygems/request_set.rb
+++ b/lib/rubygems/request_set.rb
@@ -457,9 +457,9 @@ class Gem::RequestSet
     node.spec.dependencies.each do |dep|
       next if dep.type == :development and not @development
 
-      match = @requests.find { |r|
+      match = @requests.find do |r|
         dep.match? r.spec.name, r.spec.version, @prerelease
-      }
+      end
 
       unless match
         next if dep.type == :development and @development_shallow

--- a/lib/rubygems/request_set/lockfile/parser.rb
+++ b/lib/rubygems/request_set/lockfile/parser.rb
@@ -328,9 +328,9 @@ class Gem::RequestSet::Lockfile::Parser
 
   def pinned_requirement(name) # :nodoc:
     requirement = Gem::Dependency.new name
-    specification = @set.sets.flat_map { |set|
+    specification = @set.sets.flat_map do |set|
       set.find_all(requirement)
-    }.compact.first
+    end.compact.first
 
     specification && specification.version
   end

--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -153,11 +153,11 @@ class Gem::Requirement
   def for_lockfile # :nodoc:
     return if [DefaultRequirement] == @requirements
 
-    list = requirements.sort_by { |_, version|
+    list = requirements.sort_by do |_, version|
       version
-    }.map { |op, version|
+    end.map do |op, version|
       "#{op} #{version}"
-    }.uniq
+    end.uniq
 
     " (#{list.join ', '})"
   end

--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -235,11 +235,11 @@ class Gem::Resolver
     groups = Hash.new { |hash, key| hash[key] = [] }
 
     # create groups & sources in the same loop
-    sources = possibles.map { |spec|
+    sources = possibles.map do |spec|
       source = spec.source
       groups[source] << spec
       source
-    }.uniq.reverse
+    end.uniq.reverse
 
     activation_requests = []
 

--- a/lib/rubygems/resolver/activation_request.rb
+++ b/lib/rubygems/resolver/activation_request.rb
@@ -54,12 +54,12 @@ class Gem::Resolver::ActivationRequest
 
     if @spec.respond_to? :sources
       exception = nil
-      path = @spec.sources.find{ |source|
+      path = @spec.sources.find do |source|
         begin
           source.download full_spec, path
         rescue exception
         end
-      }
+      end
       return path      if path
       raise  exception if exception
 

--- a/lib/rubygems/resolver/best_set.rb
+++ b/lib/rubygems/resolver/best_set.rb
@@ -63,9 +63,9 @@ class Gem::Resolver::BestSet < Gem::Resolver::ComposedSet
     uri = URI uri unless URI === uri
     uri.query = nil
 
-    raise error unless api_set = @sets.find { |set|
+    raise error unless api_set = @sets.find do |set|
       Gem::Resolver::APISet === set and set.dep_uri == uri
-    }
+    end
 
     index_set = Gem::Resolver::IndexSet.new api_set.source
 

--- a/lib/rubygems/resolver/installer_set.rb
+++ b/lib/rubygems/resolver/installer_set.rb
@@ -55,9 +55,9 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
 
     found = find_all request
 
-    found.delete_if { |s|
+    found.delete_if do |s|
       s.version.prerelease? and not s.local?
-    } unless dependency.prerelease?
+    end unless dependency.prerelease?
 
     found = found.select do |s|
       Gem::Source::SpecificFile === s.source or

--- a/lib/rubygems/resolver/lock_specification.rb
+++ b/lib/rubygems/resolver/lock_specification.rb
@@ -71,9 +71,9 @@ class Gem::Resolver::LockSpecification < Gem::Resolver::Specification
   # A specification constructed from the lockfile is returned
 
   def spec
-    @spec ||= Gem::Specification.find { |spec|
+    @spec ||= Gem::Specification.find do |spec|
       spec.name == @name and spec.version == @version
-    }
+    end
 
     @spec ||= Gem::Specification.new do |s|
       s.name     = @name

--- a/lib/rubygems/server.rb
+++ b/lib/rubygems/server.rb
@@ -607,13 +607,13 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
 
     Gem::Specification.each do |spec|
       total_file_count += spec.files.size
-      deps = spec.dependencies.map { |dep|
+      deps = spec.dependencies.map do |dep|
         {
           "name"    => dep.name,
           "type"    => dep.type,
           "version" => dep.requirement.to_s,
         }
-      }
+      end
 
       deps = deps.sort_by { |dep| [dep["name"].downcase, dep["version"]] }
       deps.last["is_last"] = true unless deps.empty?
@@ -754,9 +754,9 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
   # documentation - just put it underneath the main doc folder.
 
   def show_rdoc_for_pattern(pattern, res)
-    found_gems = Dir.glob("{#{@gem_dirs.join ','}}/doc/#{pattern}").select {|path|
+    found_gems = Dir.glob("{#{@gem_dirs.join ','}}/doc/#{pattern}").select do |path|
       File.exist? File.join(path, 'rdoc/index.html')
-    }
+    end
     case found_gems.length
     when 0
       return false

--- a/lib/rubygems/spec_fetcher.rb
+++ b/lib/rubygems/spec_fetcher.rb
@@ -189,7 +189,7 @@ class Gem::SpecFetcher
     max             = gem_name.size / 2
     names           = available_specs(type).first.values.flatten(1)
 
-    matches = names.map { |n|
+    matches = names.map do |n|
       next unless n.match_platform?
 
       distance = levenshtein_distance gem_name, n.name.downcase.tr('_-', '')
@@ -199,7 +199,7 @@ class Gem::SpecFetcher
       return [n.name] if distance == 0
 
       [n.name, distance]
-    }.compact
+    end.compact
 
     matches = if matches.empty? && type != :prerelease
                 suggest_gems_from_name gem_name, :prerelease

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -183,9 +183,9 @@ class Gem::Specification < Gem::BasicSpecification
 
   @@attributes = @@default_value.keys.sort_by { |s| s.to_s }
   @@array_attributes = @@default_value.reject { |k,v| v != [] }.keys
-  @@nil_attributes, @@non_nil_attributes = @@default_value.keys.partition { |k|
+  @@nil_attributes, @@non_nil_attributes = @@default_value.keys.partition do |k|
     @@default_value[k].nil?
-  }
+  end
 
   @@stubs_by_name = {}
 
@@ -792,11 +792,11 @@ class Gem::Specification < Gem::BasicSpecification
   private_class_method :installed_stubs
 
   def self.map_stubs(dirs, pattern) # :nodoc:
-    dirs.flat_map { |dir|
+    dirs.flat_map do |dir|
       base_dir = File.dirname dir
       gems_dir = File.join base_dir, "gems"
       gemspec_stubs_in(dir, pattern) { |path| yield path, base_dir, gems_dir }
-    }
+    end
   end
   private_class_method :map_stubs
 
@@ -854,11 +854,11 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   def self._resort!(specs) # :nodoc:
-    specs.sort! { |a, b|
+    specs.sort! do |a, b|
       names = a.name <=> b.name
       next names if names.nonzero?
       b.version <=> a.version
-    }
+    end
   end
 
   ##
@@ -974,9 +974,9 @@ class Gem::Specification < Gem::BasicSpecification
   # Return the directories that Specification uses to find specs.
 
   def self.dirs
-    @@dirs ||= Gem.path.collect { |dir|
+    @@dirs ||= Gem.path.collect do |dir|
       File.join dir.dup.untaint, "specifications"
-    }
+    end
   end
 
   ##
@@ -1038,10 +1038,10 @@ class Gem::Specification < Gem::BasicSpecification
 
   def self.find_by_path(path)
     path = path.dup.freeze
-    spec = @@spec_with_requirable_file[path] ||= (stubs.find { |s|
+    spec = @@spec_with_requirable_file[path] ||= (stubs.find do |s|
       next unless Gem::BundlerVersionFinder.compatible?(s)
       s.contains_requirable_file? path
-    } || NOT_FOUND)
+    end || NOT_FOUND)
     spec.to_spec
   end
 
@@ -1050,18 +1050,18 @@ class Gem::Specification < Gem::BasicSpecification
   # amongst the specs that are not activated.
 
   def self.find_inactive_by_path(path)
-    stub = stubs.find { |s|
+    stub = stubs.find do |s|
       next if s.activated?
       next unless Gem::BundlerVersionFinder.compatible?(s)
       s.contains_requirable_file? path
-    }
+    end
     stub && stub.to_spec
   end
 
   def self.find_active_stub_by_path(path)
-    stub = @@active_stub_with_requirable_file[path] ||= (stubs.find { |s|
+    stub = @@active_stub_with_requirable_file[path] ||= (stubs.find do |s|
       s.activated? and s.contains_requirable_file? path
-    } || NOT_FOUND)
+    end || NOT_FOUND)
     stub.this
   end
 
@@ -1142,10 +1142,10 @@ class Gem::Specification < Gem::BasicSpecification
       result[spec.name][spec.platform] = spec
     end
 
-    result.map(&:last).map(&:values).flatten.reject { |spec|
+    result.map(&:last).map(&:values).flatten.reject do |spec|
       minimum = native[spec.name]
       minimum && spec.version < minimum
-    }.sort_by{ |tup| tup.name }
+    end.sort_by{ |tup| tup.name }
   end
 
   ##
@@ -1680,12 +1680,12 @@ class Gem::Specification < Gem::BasicSpecification
 
   def conflicts
     conflicts = {}
-    self.runtime_dependencies.each { |dep|
+    self.runtime_dependencies.each do |dep|
       spec = Gem.loaded_specs[dep.name]
       if spec and not spec.satisfies_requirement? dep
         (conflicts[spec] ||= []) << dep
       end
-    }
+    end
     env_req = Gem.env_requirement(name)
     (conflicts[self] ||= []) << env_req unless env_req.satisfied_by? version
     conflicts
@@ -1695,9 +1695,9 @@ class Gem::Specification < Gem::BasicSpecification
   # return true if there will be conflict when spec if loaded together with the list of specs.
 
   def conficts_when_loaded_with?(list_of_specs) # :nodoc:
-    result = list_of_specs.any? { |spec|
+    result = list_of_specs.any? do |spec|
       spec.dependencies.any? { |dep| dep.runtime? && (dep.name == name) && !satisfies_requirement?(dep) }
-    }
+    end
     result
   end
 
@@ -1706,14 +1706,14 @@ class Gem::Specification < Gem::BasicSpecification
 
   def has_conflicts?
     return true unless Gem.env_requirement(name).satisfied_by?(version)
-    self.dependencies.any? { |dep|
+    self.dependencies.any? do |dep|
       if dep.runtime?
         spec = Gem.loaded_specs[dep.name]
         spec and not spec.satisfies_requirement? dep
       else
         false
       end
-    }
+    end
   end
 
   # The date this gem was created.

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -301,7 +301,7 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
   end
 
   def validate_licenses
-    licenses.each { |license|
+    licenses.each do |license|
       if license.length > 64
         error "each license must be 64 characters or less"
       end
@@ -315,7 +315,7 @@ http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard li
         message += "Did you mean #{suggestions.map { |s| "'#{s}'"}.join(', ')}?\n" unless suggestions.nil?
         warning(message)
       end
-    }
+    end
 
     warning <<-warning if licenses.empty?
 licenses is empty, but is recommended.  Use a license identifier from

--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -52,9 +52,9 @@ class Gem::StubSpecification < Gem::BasicSpecification
                        end
 
       path_list = parts.last
-      @require_paths = REQUIRE_PATH_LIST[path_list] || path_list.split("\0".freeze).map! { |x|
+      @require_paths = REQUIRE_PATH_LIST[path_list] || path_list.split("\0".freeze).map! do |x|
         REQUIRE_PATHS[x] || x
-      }
+      end
     end
 
   end

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -193,19 +193,19 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
 
   def assert_contains_make_command(target, output, msg = nil)
     if output.match(/\n/)
-      msg = message(msg) {
+      msg = message(msg) do
         'Expected output containing make command "%s": %s' % [
           ('%s %s' % [make_command, target]).rstrip,
           output.inspect
         ]
-      }
+      end
     else
-      msg = message(msg) {
+      msg = message(msg) do
         'Expected make command "%s": %s' % [
           ('%s %s' % [make_command, target]).rstrip,
           output.inspect
         ]
-      }
+      end
     end
 
     assert scan_make_command_lines(output).any? { |line|
@@ -318,7 +318,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
     Gem.ensure_gem_subdirectories @gemhome
 
     @orig_LOAD_PATH = $LOAD_PATH.dup
-    $LOAD_PATH.map! { |s|
+    $LOAD_PATH.map! do |s|
       expand_path = File.expand_path(s)
       if expand_path != s
         expand_path.untaint
@@ -329,7 +329,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
         s = expand_path
       end
       s
-    }
+    end
 
     Dir.chdir @tempdir
 
@@ -601,11 +601,11 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
   def uninstall_gem(spec)
     require 'rubygems/uninstaller'
 
-    Class.new(Gem::Uninstaller) {
+    Class.new(Gem::Uninstaller) do
       def ask_if_ok(spec)
         true
       end
-    }.new(spec.name, :executables => true, :user_install => true).uninstall
+    end.new(spec.name, :executables => true, :user_install => true).uninstall
   end
 
   ##

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -614,7 +614,11 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
 
   def create_tmpdir
     tmpdir = nil
-    Dir.chdir Dir.tmpdir do tmpdir = Dir.pwd end # HACK OSX /private/tmp
+
+    Dir.chdir Dir.tmpdir do
+      tmpdir = Dir.pwd
+    end # HACK OSX /private/tmp
+
     tmpdir = File.join tmpdir, "test_rubygems_#{$$}"
     FileUtils.mkdir_p tmpdir
     return tmpdir
@@ -725,7 +729,10 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
       spec.files.each do |file|
         next if File.exist? file
         FileUtils.mkdir_p File.dirname(file)
-        File.open file, 'w' do |fp| fp.puts "# #{file}" end
+
+        File.open file, 'w' do |fp|
+          fp.puts "# #{file}"
+        end
       end
 
       use_ui Gem::MockGemUi.new do

--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -180,9 +180,9 @@ class Gem::Uninstaller
     # Leave any executables created by other installed versions
     # of this gem installed.
 
-    list = Gem::Specification.find_all { |s|
+    list = Gem::Specification.find_all do |s|
       s.name == spec.name && s.version != spec.version
-    }
+    end
 
     list.each do |s|
       s.executables.each do |exe_name|

--- a/lib/rubygems/util.rb
+++ b/lib/rubygems/util.rb
@@ -28,7 +28,9 @@ module Gem::Util
     zipped = StringIO.new(String.new, 'w')
     zipped.set_encoding Encoding::BINARY
 
-    Zlib::GzipWriter.wrap zipped do |io| io.write data end
+    Zlib::GzipWriter.wrap zipped do |io|
+      io.write data
+    end
 
     zipped.string
   end

--- a/lib/rubygems/validator.rb
+++ b/lib/rubygems/validator.rb
@@ -91,17 +91,17 @@ class Gem::Validator
         File.open gem_path, Gem.binary_mode do |file|
           package = Gem::Package.new gem_path
 
-          good, gone = package.contents.partition { |file_name|
+          good, gone = package.contents.partition do |file_name|
             File.exist? File.join(gem_directory, file_name)
-          }
+          end
 
           gone.sort.each do |path|
             errors[gem_name][path] = "Missing file"
           end
 
-          good, unreadable = good.partition { |file_name|
+          good, unreadable = good.partition do |file_name|
             File.readable? File.join(gem_directory, file_name)
-          }
+          end
 
           unreadable.sort.each do |path|
             errors[gem_name][path] = "Unreadable file"

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -416,7 +416,10 @@ class TestGem < Gem::TestCase
         fp.puts 'blah'
       end
 
-      foo = util_spec 'foo' do |s| s.files = %w[data/foo.txt] end
+      foo = util_spec 'foo' do |s|
+        s.files = %w[data/foo.txt]
+      end
+
       install_gem foo
     end
 

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -634,7 +634,7 @@ class TestGem < Gem::TestCase
 
     discover_path = File.join 'lib', 'sff', 'discover.rb'
 
-    foo1, foo2 = %w(1 2).map { |version|
+    foo1, foo2 = %w(1 2).map do |version|
       spec = quick_gem 'sff', version do |s|
         s.files << discover_path
       end
@@ -644,7 +644,7 @@ class TestGem < Gem::TestCase
       end
 
       spec
-    }
+    end
 
     Gem.refresh
 
@@ -666,7 +666,7 @@ class TestGem < Gem::TestCase
 
     discover_path = File.join 'lib', 'sff', 'discover.rb'
 
-    foo1, _ = %w(1 2).map { |version|
+    foo1, _ = %w(1 2).map do |version|
       spec = quick_gem 'sff', version do |s|
         s.files << discover_path
       end
@@ -676,7 +676,7 @@ class TestGem < Gem::TestCase
       end
 
       spec
-    }
+    end
     Gem.refresh
 
     write_file(File.join Dir.pwd, 'Gemfile') do |fp|
@@ -702,7 +702,7 @@ class TestGem < Gem::TestCase
 
     discover_path = File.join 'lib', 'sff', 'discover.rb'
 
-    _, foo2 = %w(1 2).map { |version|
+    _, foo2 = %w(1 2).map do |version|
       spec = quick_gem 'sff', version do |s|
         s.files << discover_path
       end
@@ -712,7 +712,7 @@ class TestGem < Gem::TestCase
       end
 
       spec
-    }
+    end
 
     Gem.refresh
 
@@ -1090,7 +1090,7 @@ class TestGem < Gem::TestCase
   def test_self_post_build
     assert_equal 1, Gem.post_build_hooks.length
 
-    Gem.post_build do |installer| end
+    Gem.post_build { |installer| }
 
     assert_equal 2, Gem.post_build_hooks.length
   end
@@ -1098,7 +1098,7 @@ class TestGem < Gem::TestCase
   def test_self_post_install
     assert_equal 1, Gem.post_install_hooks.length
 
-    Gem.post_install do |installer| end
+    Gem.post_install { |installer| }
 
     assert_equal 2, Gem.post_install_hooks.length
   end
@@ -1106,7 +1106,7 @@ class TestGem < Gem::TestCase
   def test_self_done_installing
     assert_empty Gem.done_installing_hooks
 
-    Gem.done_installing do |gems| end
+    Gem.done_installing { |gems| }
 
     assert_equal 1, Gem.done_installing_hooks.length
   end
@@ -1122,7 +1122,7 @@ class TestGem < Gem::TestCase
   def test_self_post_uninstall
     assert_equal 1, Gem.post_uninstall_hooks.length
 
-    Gem.post_uninstall do |installer| end
+    Gem.post_uninstall { |installer| }
 
     assert_equal 2, Gem.post_uninstall_hooks.length
   end
@@ -1130,7 +1130,7 @@ class TestGem < Gem::TestCase
   def test_self_pre_install
     assert_equal 1, Gem.pre_install_hooks.length
 
-    Gem.pre_install do |installer| end
+    Gem.pre_install { |installer| }
 
     assert_equal 2, Gem.pre_install_hooks.length
   end
@@ -1146,7 +1146,7 @@ class TestGem < Gem::TestCase
   def test_self_pre_uninstall
     assert_equal 1, Gem.pre_uninstall_hooks.length
 
-    Gem.pre_uninstall do |installer| end
+    Gem.pre_uninstall { |installer| }
 
     assert_equal 2, Gem.pre_uninstall_hooks.length
   end

--- a/test/rubygems/test_gem_command.rb
+++ b/test/rubygems/test_gem_command.rb
@@ -98,7 +98,7 @@ class TestGemCommand < Gem::TestCase
 
   def test_invoke_with_bad_options
     use_ui @ui do
-      @cmd.when_invoked do true end
+      @cmd.when_invoked { true }
 
       ex = assert_raises OptionParser::InvalidOption do
         @cmd.invoke('-zzz')
@@ -109,7 +109,7 @@ class TestGemCommand < Gem::TestCase
   end
 
   def test_invoke_with_common_options
-    @cmd.when_invoked do true end
+    @cmd.when_invoked { true }
 
     use_ui @ui do
       @cmd.invoke "-x"

--- a/test/rubygems/test_gem_command.rb
+++ b/test/rubygems/test_gem_command.rb
@@ -34,7 +34,7 @@ class TestGemCommand < Gem::TestCase
 
   def test_self_add_specific_extra_args
     added_args = %w[--all]
-    @cmd.add_option '--all' do |v,o| end
+    @cmd.add_option('--all') { |v,o| }
 
     Gem::Command.add_specific_extra_args @cmd_name, added_args
 

--- a/test/rubygems/test_gem_commands_cleanup_command.rb
+++ b/test/rubygems/test_gem_commands_cleanup_command.rb
@@ -56,8 +56,13 @@ class TestGemCommandsCleanupCommand < Gem::TestCase
   end
 
   def test_execute_all_dependencies
-    @b_1 = util_spec 'b', 1 do |s| s.add_dependency 'a', '1' end
-    @b_2 = util_spec 'b', 2 do |s| s.add_dependency 'a', '2' end
+    @b_1 = util_spec 'b', 1 do |s|
+      s.add_dependency 'a', '1'
+    end
+
+    @b_2 = util_spec 'b', 2 do |s|
+      s.add_dependency 'a', '2'
+    end
 
     install_gem @b_1
     install_gem @b_2
@@ -71,8 +76,13 @@ class TestGemCommandsCleanupCommand < Gem::TestCase
   end
 
   def test_execute_dev_dependencies
-    @b_1 = util_spec 'b', 1 do |s| s.add_development_dependency 'a', '1' end
-    @c_1 = util_spec 'c', 1 do |s| s.add_development_dependency 'a', '2' end
+    @b_1 = util_spec 'b', 1 do |s|
+      s.add_development_dependency 'a', '1'
+    end
+
+    @c_1 = util_spec 'c', 1 do |s|
+      s.add_development_dependency 'a', '2'
+    end
 
     install_gem @b_1
     install_gem @c_1
@@ -85,8 +95,13 @@ class TestGemCommandsCleanupCommand < Gem::TestCase
   end
 
   def test_execute_without_dev_dependencies
-    @b_1 = util_spec 'b', 1 do |s| s.add_development_dependency 'a', '1' end
-    @c_1 = util_spec 'c', 1 do |s| s.add_development_dependency 'a', '2' end
+    @b_1 = util_spec 'b', 1 do |s|
+      s.add_development_dependency 'a', '1'
+    end
+
+    @c_1 = util_spec 'c', 1 do |s|
+      s.add_development_dependency 'a', '2'
+    end
 
     install_gem @b_1
     install_gem @c_1

--- a/test/rubygems/test_gem_commands_pristine_command.rb
+++ b/test/rubygems/test_gem_commands_pristine_command.rb
@@ -54,7 +54,10 @@ class TestGemCommandsPristineCommand < Gem::TestCase
   end
 
   def test_execute_all
-    a = util_spec 'a' do |s| s.executables = %w[foo] end
+    a = util_spec 'a' do |s|
+      s.executables = %w[foo]
+    end
+
     write_file File.join(@tempdir, 'bin', 'foo') do |fp|
       fp.puts "#!/usr/bin/ruby"
     end
@@ -116,7 +119,9 @@ class TestGemCommandsPristineCommand < Gem::TestCase
   end
 
   def test_execute_extensions_explicit
-    a = util_spec 'a' do |s| s.extensions << 'ext/a/extconf.rb' end
+    a = util_spec 'a' do |s|
+      s.extensions << 'ext/a/extconf.rb'
+    end
 
     ext_path = File.join @tempdir, 'ext', 'a', 'extconf.rb'
     write_file ext_path do |io|
@@ -152,7 +157,9 @@ class TestGemCommandsPristineCommand < Gem::TestCase
   end
 
   def test_execute_no_extension
-    a = util_spec 'a' do |s| s.extensions << 'ext/a/extconf.rb' end
+    a = util_spec 'a' do |s|
+      s.extensions << 'ext/a/extconf.rb'
+    end
 
     ext_path = File.join @tempdir, 'ext', 'a', 'extconf.rb'
     write_file ext_path do |io|
@@ -178,7 +185,9 @@ class TestGemCommandsPristineCommand < Gem::TestCase
   end
 
   def test_execute_with_extension_with_build_args
-    a = util_spec 'a' do |s| s.extensions << 'ext/a/extconf.rb' end
+    a = util_spec 'a' do |s|
+      s.extensions << 'ext/a/extconf.rb'
+    end
 
     ext_path = File.join @tempdir, 'ext', 'a', 'extconf.rb'
     write_file ext_path do |io|

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -23,17 +23,36 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     FileUtils.mkdir_p 'bin'
     FileUtils.mkdir_p 'lib/rubygems/ssl_certs/rubygems.org'
 
-    File.open 'bin/gem',                   'w' do |io| io.puts '# gem'          end
-    File.open 'lib/rubygems.rb',           'w' do |io| io.puts '# rubygems.rb'  end
-    File.open 'lib/rubygems/test_case.rb', 'w' do |io| io.puts '# test_case.rb' end
-    File.open 'lib/rubygems/ssl_certs/rubygems.org/foo.pem', 'w' do |io| io.puts 'PEM'       end
+    File.open 'bin/gem',                   'w' do
+      |io| io.puts '# gem'
+    end
+
+    File.open 'lib/rubygems.rb',           'w' do |io|
+      io.puts '# rubygems.rb'
+    end
+
+    File.open 'lib/rubygems/test_case.rb', 'w' do |io|
+      io.puts '# test_case.rb'
+    end
+
+    File.open 'lib/rubygems/ssl_certs/rubygems.org/foo.pem', 'w' do |io|
+      io.puts 'PEM'
+    end
 
     FileUtils.mkdir_p 'bundler/exe'
     FileUtils.mkdir_p 'bundler/lib/bundler'
 
-    File.open 'bundler/exe/bundle',        'w' do |io| io.puts '# bundle'       end
-    File.open 'bundler/lib/bundler.rb',    'w' do |io| io.puts '# bundler.rb'   end
-    File.open 'bundler/lib/bundler/b.rb',  'w' do |io| io.puts '# b.rb'         end
+    File.open 'bundler/exe/bundle',        'w' do |io|
+      io.puts '# bundle'
+    end
+
+    File.open 'bundler/lib/bundler.rb',    'w' do |io|
+      io.puts '# bundler.rb'
+    end
+
+    File.open 'bundler/lib/bundler/b.rb',  'w' do |io|
+      io.puts '# b.rb'
+    end
 
     FileUtils.mkdir_p 'default/gems'
 
@@ -220,14 +239,29 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     FileUtils.mkdir_p lib_rubygems_defaults
     FileUtils.mkdir_p lib_bundler
 
-    File.open securerandom_rb,    'w' do |io| io.puts '# securerandom.rb'     end
+    File.open securerandom_rb,    'w' do |io|
+      io.puts '# securerandom.rb'
+    end
 
-    File.open old_builder_rb,     'w' do |io| io.puts '# builder.rb'          end
-    File.open old_format_rb,      'w' do |io| io.puts '# format.rb'           end
-    File.open old_bundler_c_rb,   'w' do |io| io.puts '# c.rb'                end
+    File.open old_builder_rb,     'w' do |io|
+      io.puts '# builder.rb'
+    end
 
-    File.open engine_defaults_rb, 'w' do |io| io.puts '# jruby.rb'            end
-    File.open os_defaults_rb,     'w' do |io| io.puts '# operating_system.rb' end
+    File.open old_format_rb,      'w' do |io|
+      io.puts '# format.rb'
+    end
+
+    File.open old_bundler_c_rb,   'w' do |io|
+      io.puts '# c.rb'
+    end
+
+    File.open engine_defaults_rb, 'w' do |io|
+      io.puts '# jruby.rb'
+    end
+
+    File.open os_defaults_rb,     'w' do |io|
+      io.puts '# operating_system.rb'
+    end
 
     @cmd.remove_old_lib_files lib
 

--- a/test/rubygems/test_gem_commands_sources_command.rb
+++ b/test/rubygems/test_gem_commands_sources_command.rb
@@ -40,9 +40,9 @@ class TestGemCommandsSourcesCommand < Gem::TestCase
       fetcher.spec 'a', 1
     end
 
-    specs = Gem::Specification.map { |spec|
+    specs = Gem::Specification.map do |spec|
       [spec.name, spec.version, spec.original_platform]
-    }
+    end
 
     specs_dump_gz = StringIO.new
     Zlib::GzipWriter.wrap specs_dump_gz do |io|
@@ -167,9 +167,9 @@ source http://gems.example.com/ already present in the cache
       fetcher.spec 'a', 1
     end
 
-    specs = Gem::Specification.map { |spec|
+    specs = Gem::Specification.map do |spec|
       [spec.name, spec.version, spec.original_platform]
-    }
+    end
 
     specs_dump_gz = StringIO.new
     Zlib::GzipWriter.wrap specs_dump_gz do |io|

--- a/test/rubygems/test_gem_commands_uninstall_command.rb
+++ b/test/rubygems/test_gem_commands_uninstall_command.rb
@@ -54,7 +54,10 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
 
     util_build_gem c
     installer = util_installer c, @gemhome
-    use_ui @ui do installer.install end
+
+    use_ui @ui do
+      installer.install
+    end
 
     ui = Gem::MockGemUi.new
 
@@ -92,7 +95,9 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
     # Evil hack to prevent false removal success
     FileUtils.rm_f @executable
 
-    File.open @executable, "wb+" do |f| f.puts "binary" end
+    File.open @executable, "wb+" do |f|
+      f.puts "binary"
+    end
 
     @cmd.options[:executables] = true
     @cmd.options[:args] = [@spec.name]

--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -66,7 +66,9 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
 
   def test_execute_system
     spec_fetcher do |fetcher|
-      fetcher.download 'rubygems-update', 9 do |s| s.files = %w[setup.rb] end
+      fetcher.download 'rubygems-update', 9 do |s|
+        s.files = %w[setup.rb]
+      end
     end
 
     @cmd.options[:args]          = []
@@ -107,8 +109,13 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
 
   def test_execute_system_multiple
     spec_fetcher do |fetcher|
-      fetcher.download 'rubygems-update', 8 do |s| s.files = %w[setup.rb] end
-      fetcher.download 'rubygems-update', 9 do |s| s.files = %w[setup.rb] end
+      fetcher.download 'rubygems-update', 8 do |s|
+        s.files = %w[setup.rb]
+      end
+
+      fetcher.download 'rubygems-update', 9 do |s|
+        s.files = %w[setup.rb]
+      end
     end
 
     @cmd.options[:args]          = []
@@ -128,8 +135,13 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
 
   def test_execute_system_specific
     spec_fetcher do |fetcher|
-      fetcher.download 'rubygems-update', 8 do |s| s.files = %w[setup.rb] end
-      fetcher.download 'rubygems-update', 9 do |s| s.files = %w[setup.rb] end
+      fetcher.download 'rubygems-update', 8 do |s|
+        s.files = %w[setup.rb]
+      end
+
+      fetcher.download 'rubygems-update', 9 do |s|
+        s.files = %w[setup.rb]
+      end
     end
 
     @cmd.options[:args]          = []
@@ -149,8 +161,13 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
 
   def test_execute_system_specifically_to_latest_version
     spec_fetcher do |fetcher|
-      fetcher.download 'rubygems-update', 8 do |s| s.files = %w[setup.rb] end
-      fetcher.download 'rubygems-update', 9 do |s| s.files = %w[setup.rb] end
+      fetcher.download 'rubygems-update', 8 do |s|
+        s.files = %w[setup.rb]
+      end
+
+      fetcher.download 'rubygems-update', 9 do |s|
+        s.files = %w[setup.rb]
+      end
     end
 
     @cmd.options[:args]          = []
@@ -387,7 +404,10 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
     specs = spec_fetcher do |fetcher|
       fetcher.spec 'a', 1
       fetcher.spec 'a', 2
-      fetcher.spec 'a', 2 do |s| s.platform = platform end
+
+      fetcher.spec 'a', 2 do |s|
+        s.platform = platform
+      end
     end
 
     expected = [

--- a/test/rubygems/test_gem_dependency_installer.rb
+++ b/test/rubygems/test_gem_dependency_installer.rb
@@ -26,7 +26,10 @@ class TestGemDependencyInstaller < Gem::TestCase
   end
 
   def util_setup_gems
-    @a1, @a1_gem         = util_gem 'a', '1' do |s| s.executables << 'a_bin' end
+    @a1, @a1_gem         = util_gem 'a', '1' do |s|
+      s.executables << 'a_bin'
+    end
+
     @a1_pre, @a1_pre_gem = util_gem 'a', '1.a'
 
     @b1, @b1_gem         = util_gem 'b', '1' do |s|
@@ -873,8 +876,13 @@ class TestGemDependencyInstaller < Gem::TestCase
     a1_data = nil
     a2_o_data = nil
 
-    File.open @a1_gem, 'rb' do |fp| a1_data = fp.read end
-    File.open a2_o_gem, 'rb' do |fp| a2_o_data = fp.read end
+    File.open @a1_gem, 'rb' do |fp|
+      a1_data = fp.read
+    end
+
+    File.open a2_o_gem, 'rb' do |fp|
+      a2_o_data = fp.read
+    end
 
     @fetcher.data["http://gems.example.com/gems/#{@a1.file_name}"] =
       a1_data

--- a/test/rubygems/test_gem_dependency_installer.rb
+++ b/test/rubygems/test_gem_dependency_installer.rb
@@ -28,6 +28,7 @@ class TestGemDependencyInstaller < Gem::TestCase
   def util_setup_gems
     @a1, @a1_gem         = util_gem 'a', '1' do |s| s.executables << 'a_bin' end
     @a1_pre, @a1_pre_gem = util_gem 'a', '1.a'
+
     @b1, @b1_gem         = util_gem 'b', '1' do |s|
       s.add_dependency 'a'
       s.add_development_dependency 'aa'

--- a/test/rubygems/test_gem_dependency_list.rb
+++ b/test/rubygems/test_gem_dependency_list.rb
@@ -16,13 +16,23 @@ class TestGemDependencyList < Gem::TestCase
     @a2 = util_spec 'a', '2'
     @a3 = util_spec 'a', '3'
 
-    @b1 = util_spec 'b', '1' do |s| s.add_dependency 'a', '>= 1' end
-    @b2 = util_spec 'b', '2' do |s| s.add_dependency 'a', '>= 1' end
+    @b1 = util_spec 'b', '1' do |s|
+      s.add_dependency 'a', '>= 1'
+    end
 
-    @c1 = util_spec 'c', '1' do |s| s.add_dependency 'b', '>= 1' end
+    @b2 = util_spec 'b', '2' do |s|
+      s.add_dependency 'a', '>= 1'
+    end
+
+    @c1 = util_spec 'c', '1' do |s|
+      s.add_dependency 'b', '>= 1'
+    end
+
     @c2 = util_spec 'c', '2'
 
-    @d1 = util_spec 'd', '1' do |s| s.add_dependency 'c', '>= 1' end
+    @d1 = util_spec 'd', '1' do |s|
+      s.add_dependency 'c', '>= 1'
+    end
   end
 
   def test_active_count
@@ -165,8 +175,13 @@ class TestGemDependencyList < Gem::TestCase
     a1 = util_spec 'a', '1'
     a2 = util_spec 'a', '2'
 
-    b = util_spec 'b', '1' do |s| s.add_dependency 'a', '= 1' end
-    c = util_spec 'c', '1' do |s| s.add_dependency 'a', '= 2' end
+    b = util_spec 'b', '1' do |s|
+      s.add_dependency 'a', '= 1'
+    end
+
+    c = util_spec 'c', '1' do |s|
+      s.add_dependency 'a', '= 2'
+    end
 
     d = util_spec 'd', '1' do |s|
       s.add_dependency 'b'

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -702,7 +702,10 @@ gem 'other', version
   end
 
   def test_initialize
-    spec = util_spec 'a' do |s| s.platform = Gem::Platform.new 'mswin32' end
+    spec = util_spec 'a' do |s|
+      s.platform = Gem::Platform.new 'mswin32'
+    end
+
     gem = File.join @tempdir, spec.file_name
 
     Dir.mkdir util_inst_bindir
@@ -948,7 +951,10 @@ gem 'other', version
     # Morph spec to have lib/other.rb instead of code.rb and recreate
     @spec.files = File.join('lib', 'other.rb')
     Dir.chdir @tempdir do
-      File.open File.join('lib', 'other.rb'), 'w' do |f| f.puts '1' end
+      File.open File.join('lib', 'other.rb'), 'w' do |f|
+        f.puts '1'
+      end
+
       use_ui ui do
         FileUtils.rm @gem
         Gem::Package.build @spec

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1285,9 +1285,9 @@ gem 'other', version
     end
 
     # empty depend file for no auto dependencies
-    @spec.files += %W"depend #{@spec.name}.c".each {|file|
+    @spec.files += %W"depend #{@spec.name}.c".each do |file|
       write_file File.join(@tempdir, file)
-    }
+    end
 
     so = File.join(@spec.gem_dir, "#{@spec.name}.#{RbConfig::CONFIG["DLEXT"]}")
     refute_path_exists so

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -129,8 +129,13 @@ class TestGemPackage < Gem::Package::TarTestCase
 
     FileUtils.mkdir_p 'lib/empty'
 
-    File.open 'lib/code.rb',  'w' do |io| io.write '# lib/code.rb'  end
-    File.open 'lib/extra.rb', 'w' do |io| io.write '# lib/extra.rb' end
+    File.open 'lib/code.rb',  'w' do |io|
+      io.write '# lib/code.rb'
+    end
+
+    File.open 'lib/extra.rb', 'w' do |io|
+      io.write '# lib/extra.rb'
+    end
 
     package = Gem::Package.new 'bogus.gem'
     package.spec = spec
@@ -157,7 +162,10 @@ class TestGemPackage < Gem::Package::TarTestCase
     spec.files = %w[lib/code.rb lib/code_sym.rb lib/code_sym2.rb]
 
     FileUtils.mkdir_p 'lib'
-    File.open 'lib/code.rb',  'w' do |io| io.write '# lib/code.rb'  end
+
+    File.open 'lib/code.rb',  'w' do |io|
+      io.write '# lib/code.rb'
+    end
 
     # NOTE: 'code.rb' is correct, because it's relative to lib/code_sym.rb
     begin
@@ -462,7 +470,9 @@ class TestGemPackage < Gem::Package::TarTestCase
     package = Gem::Package.new @gem
 
     tgz_io = util_tar_gz do |tar|
-      tar.add_file '/absolute.rb', 0644 do |io| io.write 'hi' end
+      tar.add_file '/absolute.rb', 0644 do |io|
+        io.write 'hi'
+      end
     end
 
     e = assert_raises Gem::Package::PathError do
@@ -477,7 +487,10 @@ class TestGemPackage < Gem::Package::TarTestCase
     package = Gem::Package.new @gem
 
     tgz_io = util_tar_gz do |tar|
-      tar.add_file    'relative.rb', 0644 do |io| io.write 'hi' end
+      tar.add_file    'relative.rb', 0644 do |io|
+        io.write 'hi'
+      end
+
       tar.mkdir       'lib',         0755
       tar.add_symlink 'lib/foo.rb', '../relative.rb', 0644
     end
@@ -506,7 +519,9 @@ class TestGemPackage < Gem::Package::TarTestCase
     tgz_io = util_tar_gz do |tar|
       tar.mkdir       'lib',               0755
       tar.add_symlink 'lib/link', '../..', 0644
-      tar.add_file    'lib/link/outside.txt', 0644 do |io| io.write 'hi' end
+      tar.add_file    'lib/link/outside.txt', 0644 do |io|
+        io.write 'hi'
+      end
     end
 
     # Extract into a subdirectory of @destination; if this test fails it writes
@@ -534,7 +549,9 @@ class TestGemPackage < Gem::Package::TarTestCase
 
     tgz_io = util_tar_gz do |tar|
       tar.mkdir    'lib',        0755
-      tar.add_file 'lib/foo.rb', 0644 do |io| io.write 'hi' end
+      tar.add_file 'lib/foo.rb', 0644 do |io|
+        io.write 'hi'
+      end
       tar.mkdir    'lib/foo',    0755
     end
 
@@ -551,7 +568,9 @@ class TestGemPackage < Gem::Package::TarTestCase
     package = Gem::Package.new @gem
 
     tgz_io = util_tar_gz do |tar|
-      tar.add_file './dot_slash.rb', 0644 do |io| io.write 'hi' end
+      tar.add_file './dot_slash.rb', 0644 do |io|
+        io.write 'hi'
+      end
     end
 
     package.extract_tar_gz tgz_io, @destination
@@ -564,7 +583,9 @@ class TestGemPackage < Gem::Package::TarTestCase
     package = Gem::Package.new @gem
 
     tgz_io = util_tar_gz do |tar|
-      tar.add_file '.dot_file.rb', 0644 do |io| io.write 'hi' end
+      tar.add_file '.dot_file.rb', 0644 do |io|
+        io.write 'hi'
+      end
     end
 
     package.extract_tar_gz tgz_io, @destination
@@ -578,7 +599,9 @@ class TestGemPackage < Gem::Package::TarTestCase
       package = Gem::Package.new @gem
 
       tgz_io = util_tar_gz do |tar|
-        tar.add_file 'foo/file.rb', 0644 do |io| io.write 'hi' end
+        tar.add_file 'foo/file.rb', 0644 do |io|
+          io.write 'hi'
+        end
       end
 
       package.extract_tar_gz tgz_io, @destination.upcase
@@ -1043,7 +1066,9 @@ class TestGemPackage < Gem::Package::TarTestCase
     tgz_io = StringIO.new
 
     # can't wrap TarWriter because it seeks
-    Zlib::GzipWriter.wrap tgz_io do |io| io.write tar_io.string end
+    Zlib::GzipWriter.wrap tgz_io do |io|
+      io.write tar_io.string
+    end
 
     StringIO.new tgz_io.string
   end

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -433,7 +433,7 @@ class TestGemPackage < Gem::Package::TarTestCase
   end
 
   def test_extract_files_empty
-    data_tgz = util_tar_gz do end
+    data_tgz = util_tar_gz { }
 
     gem = util_tar do |tar|
       tar.add_file 'data.tar.gz', 0644 do |io|

--- a/test/rubygems/test_gem_package_tar_reader_entry.rb
+++ b/test/rubygems/test_gem_package_tar_reader_entry.rb
@@ -43,19 +43,19 @@ class TestGemPackageTarReaderEntry < Gem::Package::TarTestCase
 
     assert @entry.bytes_read
 
-    e = assert_raises IOError do @entry.eof? end
+    e = assert_raises(IOError) { @entry.eof? }
     assert_equal 'closed Gem::Package::TarReader::Entry', e.message
 
-    e = assert_raises IOError do @entry.getc end
+    e = assert_raises(IOError) { @entry.getc }
     assert_equal 'closed Gem::Package::TarReader::Entry', e.message
 
-    e = assert_raises IOError do @entry.pos end
+    e = assert_raises(IOError) { @entry.pos }
     assert_equal 'closed Gem::Package::TarReader::Entry', e.message
 
-    e = assert_raises IOError do @entry.read end
+    e = assert_raises(IOError) { @entry.read }
     assert_equal 'closed Gem::Package::TarReader::Entry', e.message
 
-    e = assert_raises IOError do @entry.rewind end
+    e = assert_raises(IOError) { @entry.rewind }
     assert_equal 'closed Gem::Package::TarReader::Entry', e.message
   end
 

--- a/test/rubygems/test_gem_package_tar_writer.rb
+++ b/test/rubygems/test_gem_package_tar_writer.rb
@@ -25,7 +25,9 @@ class TestGemPackageTarWriter < Gem::Package::TarTestCase
 
   def test_add_file
     Time.stub :now, Time.at(1458518157) do
-      @tar_writer.add_file 'x', 0644 do |f| f.write 'a' * 10 end
+      @tar_writer.add_file 'x', 0644 do |f|
+        f.write 'a' * 10
+      end
 
       assert_headers_equal(tar_file_header('x', '', 0644, 10, Time.now),
                          @io.string[0, 512])
@@ -160,7 +162,9 @@ class TestGemPackageTarWriter < Gem::Package::TarTestCase
 
   def test_add_file_simple
     Time.stub :now, Time.at(1458518157) do
-      @tar_writer.add_file_simple 'x', 0644, 10 do |io| io.write "a" * 10 end
+      @tar_writer.add_file_simple 'x', 0644, 10 do |io|
+        io.write "a" * 10
+      end
 
       assert_headers_equal(tar_file_header('x', '', 0644, 10, Time.now),
                          @io.string[0, 512])
@@ -173,7 +177,9 @@ class TestGemPackageTarWriter < Gem::Package::TarTestCase
   def test_add_file_simple_source_date_epoch
     ENV["SOURCE_DATE_EPOCH"] = "123456789"
     Time.stub :now, Time.at(1458518157) do
-      @tar_writer.add_file_simple 'x', 0644, 10 do |io| io.write "a" * 10 end
+      @tar_writer.add_file_simple 'x', 0644, 10 do |io|
+        io.write "a" * 10
+      end
 
       assert_headers_equal(tar_file_header('x', '', 0644, 10, Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc),
                          @io.string[0, 512])

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -962,12 +962,12 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
         :SSLVerifyClient => nil,
         :SSLCertName => nil
       }.merge(config))
-      server.mount_proc("/yaml") { |req, res|
+      server.mount_proc("/yaml") do |req, res|
         res.body = "--- true\n"
-      }
-      server.mount_proc("/insecure_redirect") { |req, res|
+      end
+      server.mount_proc("/insecure_redirect") do |req, res|
         res.set_redirect(WEBrick::HTTPStatus::MovedPermanently, req.query['to'])
-      }
+      end
       server.ssl_context.tmp_dh_callback = proc { TEST_KEY_DH2048 }
       t = Thread.new do
         begin
@@ -1002,7 +1002,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
         :AccessLog       => null_logger
       )
       s.mount_proc("/kill") { |req, res| s.shutdown }
-      s.mount_proc("/yaml") { |req, res|
+      s.mount_proc("/yaml") do |req, res|
         if req["X-Captain"]
           res.body = req["X-Captain"]
         elsif @enable_yaml
@@ -1014,8 +1014,8 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
           res.body = "<h1>NOT FOUND</h1>"
           res['Content-Type'] = 'text/html'
         end
-      }
-      s.mount_proc("/yaml.Z") { |req, res|
+      end
+      s.mount_proc("/yaml.Z") do |req, res|
         if @enable_zip
           res.body = Zlib::Deflate.deflate(data)
           res['Content-Type'] = 'text/plain'
@@ -1024,7 +1024,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
           res.body = "<h1>NOT FOUND</h1>"
           res['Content-Type'] = 'text/html'
         end
-      }
+      end
       th = Thread.new do
         begin
           s.start

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -117,7 +117,10 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     FileUtils.mkdir @gems_dir
 
     # TODO: why does the remote fetcher need it written to disk?
-    @a1, @a1_gem = util_gem 'a', '1' do |s| s.executables << 'a_bin' end
+    @a1, @a1_gem = util_gem 'a', '1' do |s|
+      s.executables << 'a_bin'
+    end
+
     @a1.loaded_from = File.join(@gemhome, 'specifications', @a1.full_name)
 
     Gem::RemoteFetcher.fetcher = nil

--- a/test/rubygems/test_gem_request.rb
+++ b/test/rubygems/test_gem_request.rb
@@ -93,11 +93,11 @@ class TestGemRequest < Gem::TestCase
   def test_configure_connection_for_https
     connection = Net::HTTP.new 'localhost', 443
 
-    request = Class.new(Gem::Request) {
+    request = Class.new(Gem::Request) do
       def self.get_cert_files
         [TestGemRequest::PUBLIC_CERT_FILE]
       end
-    }.create_with_proxy URI('https://example'), nil, nil, nil
+    end.create_with_proxy URI('https://example'), nil, nil, nil
 
     Gem::Request.configure_connection_for_https connection, request.cert_files
 
@@ -112,11 +112,11 @@ class TestGemRequest < Gem::TestCase
 
     connection = Net::HTTP.new 'localhost', 443
 
-    request = Class.new(Gem::Request) {
+    request = Class.new(Gem::Request) do
       def self.get_cert_files
         [TestGemRequest::PUBLIC_CERT_FILE]
       end
-    }.create_with_proxy URI('https://example'), nil, nil, nil
+    end.create_with_proxy URI('https://example'), nil, nil, nil
 
     Gem::Request.configure_connection_for_https connection, request.cert_files
 

--- a/test/rubygems/test_gem_request_connection_pools.rb
+++ b/test/rubygems/test_gem_request_connection_pools.rb
@@ -142,13 +142,13 @@ class TestGemRequestConnectionPool < Gem::TestCase
 
     pool.checkout
 
-    Thread.new {
+    Thread.new do
       assert_raises(Timeout::Error) do
         Timeout.timeout(1) do
           pool.checkout
         end
       end
-    }.join
+    end.join
   end
 
 end

--- a/test/rubygems/test_gem_request_set.rb
+++ b/test/rubygems/test_gem_request_set.rb
@@ -312,8 +312,14 @@ ruby "0"
   end
 
   def test_resolve_development_shallow
-    a = util_spec 'a', 1 do |s| s.add_development_dependency 'b' end
-    b = util_spec 'b', 1 do |s| s.add_development_dependency 'c' end
+    a = util_spec 'a', 1 do |s|
+      s.add_development_dependency 'b'
+    end
+
+    b = util_spec 'b', 1 do |s|
+      s.add_development_dependency 'c'
+    end
+
     c = util_spec 'c', 1
 
     a_spec = Gem::Resolver::SpecSpecification.new nil, a
@@ -529,8 +535,14 @@ ruby "0"
   end
 
   def test_sorted_requests_development_shallow
-    a = util_spec 'a', 1 do |s| s.add_development_dependency 'b' end
-    b = util_spec 'b', 1 do |s| s.add_development_dependency 'c' end
+    a = util_spec 'a', 1 do |s|
+      s.add_development_dependency 'b'
+    end
+
+    b = util_spec 'b', 1 do |s|
+      s.add_development_dependency 'c'
+    end
+
     c = util_spec 'c', 1
 
     rs = Gem::RequestSet.new
@@ -548,8 +560,14 @@ ruby "0"
   end
 
   def test_tsort_each_child_development
-    a = util_spec 'a', 1 do |s| s.add_development_dependency 'b' end
-    b = util_spec 'b', 1 do |s| s.add_development_dependency 'c' end
+    a = util_spec 'a', 1 do |s|
+      s.add_development_dependency 'b'
+    end
+
+    b = util_spec 'b', 1 do |s|
+      s.add_development_dependency 'c'
+    end
+
     c = util_spec 'c', 1
 
     rs = Gem::RequestSet.new
@@ -571,8 +589,14 @@ ruby "0"
   end
 
   def test_tsort_each_child_development_shallow
-    a = util_spec 'a', 1 do |s| s.add_development_dependency 'b' end
-    b = util_spec 'b', 1 do |s| s.add_development_dependency 'c' end
+    a = util_spec 'a', 1 do |s|
+      s.add_development_dependency 'b'
+    end
+
+    b = util_spec 'b', 1 do |s|
+      s.add_development_dependency 'c'
+    end
+
     c = util_spec 'c', 1
 
     rs = Gem::RequestSet.new

--- a/test/rubygems/test_gem_resolver.rb
+++ b/test/rubygems/test_gem_resolver.rb
@@ -159,10 +159,23 @@ class TestGemResolver < Gem::TestCase
 
     b1_spec = util_spec 'b', 1
     b2_spec = util_spec 'b', 2
-    c1_spec = util_spec 'c', 1 do |s| s.add_dependency 'd', 2 end
-    c2_spec = util_spec 'c', 2 do |s| s.add_dependency 'd', 2 end
-    d1_spec = util_spec 'd', 1 do |s| s.add_dependency 'e' end
-    d2_spec = util_spec 'd', 2 do |s| s.add_dependency 'e' end
+
+    c1_spec = util_spec 'c', 1 do |s|
+      s.add_dependency 'd', 2
+    end
+
+    c2_spec = util_spec 'c', 2 do |s|
+      s.add_dependency 'd', 2
+    end
+
+    d1_spec = util_spec 'd', 1 do |s|
+      s.add_dependency 'e'
+    end
+
+    d2_spec = util_spec 'd', 2 do |s|
+      s.add_dependency 'e'
+    end
+
     e1_spec = util_spec 'e', 1
     e2_spec = util_spec 'e', 2
 
@@ -191,8 +204,14 @@ class TestGemResolver < Gem::TestCase
   end
 
   def test_resolve_development
-    a_spec = util_spec 'a', 1 do |s| s.add_development_dependency 'b' end
-    b_spec = util_spec 'b', 1 do |s| s.add_development_dependency 'c' end
+    a_spec = util_spec 'a', 1 do |s|
+      s.add_development_dependency 'b'
+    end
+
+    b_spec = util_spec 'b', 1 do
+      |s| s.add_development_dependency 'c'
+    end
+
     c_spec = util_spec 'c', 1
 
     a_dep = make_dep 'a', '= 1'
@@ -214,10 +233,16 @@ class TestGemResolver < Gem::TestCase
       s.add_runtime_dependency 'd'
     end
 
-    b_spec = util_spec 'b', 1 do |s| s.add_development_dependency 'c' end
+    b_spec = util_spec 'b', 1 do |s|
+      s.add_development_dependency 'c'
+    end
+
     c_spec = util_spec 'c', 1
 
-    d_spec = util_spec 'd', 1 do |s| s.add_development_dependency 'e' end
+    d_spec = util_spec 'd', 1 do |s|
+      s.add_development_dependency 'e'
+    end
+
     e_spec = util_spec 'e', 1
 
     a_dep = make_dep 'a', '= 1'
@@ -302,8 +327,14 @@ class TestGemResolver < Gem::TestCase
 
     spec_fetcher do |fetcher|
       fetcher.spec 'a', 2
-      a2_p1 = fetcher.spec 'a', 2 do |s| s.platform = Gem::Platform.local end
-      a3_p2 = fetcher.spec 'a', 3 do |s| s.platform = unknown end
+
+      a2_p1 = fetcher.spec 'a', 2 do |s|
+        s.platform = Gem::Platform.local
+      end
+
+      a3_p2 = fetcher.spec 'a', 3 do |s|
+        s.platform = unknown
+      end
     end
 
     v2 = v(2)
@@ -711,8 +742,14 @@ class TestGemResolver < Gem::TestCase
     r = Gem::Resolver.new nil, nil
 
     a1    = util_spec 'a', 1
-    a1_p1 = util_spec 'a', 1 do |s| s.platform = Gem::Platform.local end
-    a1_p2 = util_spec 'a', 1 do |s| s.platform = 'unknown'           end
+
+    a1_p1 = util_spec 'a', 1 do |s|
+      s.platform = Gem::Platform.local
+    end
+
+    a1_p2 = util_spec 'a', 1 do |s|
+      s.platform = 'unknown'
+    end
 
     selected = r.select_local_platforms [a1, a1_p1, a1_p2]
 
@@ -721,8 +758,14 @@ class TestGemResolver < Gem::TestCase
 
   def test_search_for_local_platform_partial_string_match
     a1    = util_spec 'a', 1
-    a1_p1 = util_spec 'a', 1 do |s| s.platform = Gem::Platform.local.os end
-    a1_p2 = util_spec 'a', 1 do |s| s.platform = 'unknown'              end
+
+    a1_p1 = util_spec 'a', 1 do |s|
+      s.platform = Gem::Platform.local.os
+    end
+
+    a1_p2 = util_spec 'a', 1 do |s|
+      s.platform = 'unknown'
+    end
 
     s = set(a1_p1, a1_p2, a1)
     d = [make_dep('a')]

--- a/test/rubygems/test_gem_resolver.rb
+++ b/test/rubygems/test_gem_resolver.rb
@@ -151,10 +151,12 @@ class TestGemResolver < Gem::TestCase
 
   def test_resolve_conservative
     a1_spec = util_spec 'a', 1
+
     a2_spec = util_spec 'a', 2 do |s|
       s.add_dependency 'b', 2
       s.add_dependency 'c'
     end
+
     b1_spec = util_spec 'b', 1
     b2_spec = util_spec 'b', 2
     c1_spec = util_spec 'c', 1 do |s| s.add_dependency 'd', 2 end

--- a/test/rubygems/test_gem_resolver_index_specification.rb
+++ b/test/rubygems/test_gem_resolver_index_specification.rb
@@ -55,7 +55,9 @@ class TestGemResolverIndexSpecification < Gem::TestCase
   def test_spec
     specs = spec_fetcher do |fetcher|
       fetcher.spec 'a', 2
-      fetcher.spec 'a', 2 do |s| s.platform = Gem::Platform.local end
+      fetcher.spec 'a', 2 do |s|
+        s.platform = Gem::Platform.local
+      end
     end
 
     source = Gem::Source.new @gem_repo
@@ -71,7 +73,10 @@ class TestGemResolverIndexSpecification < Gem::TestCase
   end
 
   def test_spec_local
-    a_2_p = util_spec 'a', 2 do |s| s.platform = Gem::Platform.local end
+    a_2_p = util_spec 'a', 2 do |s|
+      s.platform = Gem::Platform.local
+    end
+
     Gem::Package.build a_2_p
 
     source = Gem::Source::Local.new

--- a/test/rubygems/test_gem_resolver_installer_set.rb
+++ b/test/rubygems/test_gem_resolver_installer_set.rb
@@ -173,7 +173,9 @@ class TestGemResolverInstallerSet < Gem::TestCase
   def test_load_spec
     specs = spec_fetcher do |fetcher|
       fetcher.spec 'a', 2
-      fetcher.spec 'a', 2 do |s| s.platform = Gem::Platform.local end
+      fetcher.spec 'a', 2 do |s|
+        s.platform = Gem::Platform.local
+      end
     end
 
     source = Gem::Source.new @gem_repo

--- a/test/rubygems/test_gem_server.rb
+++ b/test/rubygems/test_gem_server.rb
@@ -245,7 +245,9 @@ class TestGemServer < Gem::TestCase
   end
 
   def test_quick_marshal_a_1_mswin32_gemspec_rz
-    quick_gem 'a', '1' do |s| s.platform = Gem::Platform.local end
+    quick_gem 'a', '1' do |s|
+      s.platform = Gem::Platform.local
+    end
 
     data = StringIO.new "GET /quick/Marshal.#{Gem.marshal_version}/a-1-#{Gem::Platform.local}.gemspec.rz HTTP/1.0\r\n\r\n"
     @req.parse data

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2878,7 +2878,7 @@ duplicate dependency on c (>= 1.2.3, development), (~> 1.2) use:
     util_setup_validate
 
     FileUtils.mkdir_p File.join(@tempdir, 'bin')
-    File.open File.join(@tempdir, 'bin', 'exec'), 'w' do end
+    File.open File.join(@tempdir, 'bin', 'exec'), 'w'
     FileUtils.mkdir_p File.join(@tempdir, 'exec')
 
     use_ui @ui do

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -143,9 +143,9 @@ end
       num_of_version_per_pkg = 3
       packages = (0..num_of_pkg).map do |pkgi|
         (0..num_of_version_per_pkg).map do |pkg_version|
-          deps = Hash[((pkgi + 1)..num_of_pkg).map { |deppkgi|
+          deps = Hash[((pkgi + 1)..num_of_pkg).map do |deppkgi|
             ["pkg#{deppkgi}", ">= 0"]
-          }]
+          end]
           util_spec "pkg#{pkgi}", pkg_version.to_s, deps
         end
       end
@@ -156,9 +156,9 @@ end
       install_specs base
       base.activate
 
-      tms = Benchmark.measure {
+      tms = Benchmark.measure do
         assert_raises(LoadError) { require 'no_such_file_foo' }
-      }
+      end
       assert_operator tms.total, :<=, 10
     end
   end

--- a/test/rubygems/test_gem_uninstaller.rb
+++ b/test/rubygems/test_gem_uninstaller.rb
@@ -368,7 +368,10 @@ create_makefile '#{@spec.name}'
   end
 
   def test_uninstall_prompts_about_broken_deps
-    quick_gem 'r', '1' do |s| s.add_dependency 'q', '= 1' end
+    quick_gem 'r', '1' do |s|
+      s.add_dependency 'q', '= 1'
+    end
+
     quick_gem 'q', '1'
 
     un = Gem::Uninstaller.new('q')
@@ -390,8 +393,14 @@ create_makefile '#{@spec.name}'
   end
 
   def test_uninstall_only_lists_unsatisfied_deps
-    quick_gem 'r', '1' do |s| s.add_dependency 'q', '~> 1.0' end
-    quick_gem 'x', '1' do |s| s.add_dependency 'q', '= 1.0'  end
+    quick_gem 'r', '1' do |s|
+      s.add_dependency 'q', '~> 1.0'
+    end
+
+    quick_gem 'x', '1' do |s|
+      s.add_dependency 'q', '= 1.0'
+    end
+
     quick_gem 'q', '1.0'
     quick_gem 'q', '1.1'
 
@@ -414,7 +423,10 @@ create_makefile '#{@spec.name}'
   end
 
   def test_uninstall_doesnt_prompt_when_other_gem_satisfies_requirement
-    quick_gem 'r', '1' do |s| s.add_dependency 'q', '~> 1.0' end
+    quick_gem 'r', '1' do |s|
+      s.add_dependency 'q', '~> 1.0'
+    end
+
     quick_gem 'q', '1.0'
     quick_gem 'q', '1.1'
 
@@ -431,7 +443,10 @@ create_makefile '#{@spec.name}'
   end
 
   def test_uninstall_doesnt_prompt_when_removing_a_dev_dep
-    quick_gem 'r', '1' do |s| s.add_development_dependency 'q', '= 1.0' end
+    quick_gem 'r', '1' do |s|
+      s.add_development_dependency 'q', '= 1.0'
+    end
+
     quick_gem 'q', '1.0'
 
     un = Gem::Uninstaller.new('q', :version => "1.0")
@@ -447,7 +462,10 @@ create_makefile '#{@spec.name}'
   end
 
   def test_uninstall_doesnt_prompt_and_raises_when_abort_on_dependent_set
-    quick_gem 'r', '1' do |s| s.add_dependency 'q', '= 1' end
+    quick_gem 'r', '1' do |s|
+      s.add_dependency 'q', '= 1'
+    end
+
     quick_gem 'q', '1'
 
     un = Gem::Uninstaller.new('q', :abort_on_dependent => true)

--- a/test/rubygems/test_gem_util.rb
+++ b/test/rubygems/test_gem_util.rb
@@ -51,9 +51,9 @@ class TestGemUtil < Gem::TestCase
   end
 
   def test_linked_list_find
-    list = [1,2,3,4,5].inject(Gem::List.new(0)) { |m,o|
+    list = [1,2,3,4,5].inject(Gem::List.new(0)) do |m,o|
       Gem::List.new o, m
-    }
+    end
     assert_equal 5, list.find { |x| x == 5 }
     assert_equal 4, list.find { |x| x == 4 }
   end


### PR DESCRIPTION
# Description:

This PR enables the `Style/BlockDelimiters` rubocop cop. In many places I could've switched to curly braces, but decided to make the block multiline instead since I feel it affects less the style of the surrounding code. 

References: https://github.com/rubygems/rubygems/pull/2631#discussion_r255777867.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
