### PR TITLE
Refactoring install and update explanations

### DIFF
--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -203,8 +203,8 @@ You can use `i` command instead of `install`.
       if options[:explain]
         say "Gems to install:"
 
-        request_set.sorted_requests.each do |s|
-          say "  #{s.full_name}"
+        request_set.sorted_requests.each do |activation_request|
+          say "  #{activation_request.full_name}"
         end
 
         return

--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -204,10 +204,7 @@ You can use `i` command instead of `install`.
         say "Gems to install:"
 
         request_set.sorted_requests.each do |s|
-          # shows platform specific gems if used
-          say (plat = s.spec.platform) == Gem::Platform::RUBY ?
-            "  #{s.full_name}" :
-            "  #{s.full_name}-#{plat}"
+          say "  #{s.full_name}"
         end
 
         return

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -146,7 +146,7 @@ command to remove old versions.
     hig
   end
 
-  def highest_remote_tuple(spec) # :nodoc:
+  def highest_remote_name_tuple(spec) # :nodoc:
     spec_tuples = fetch_remote_gems spec
 
     matching_gems = spec_tuples.select do |g,_|
@@ -271,7 +271,7 @@ command to remove old versions.
       next if not gem_names.empty? and
               gem_names.none? { |name| name == l_spec.name }
 
-      highest_remote_tup = highest_remote_tuple l_spec
+      highest_remote_tup = highest_remote_name_tuple l_spec
       highest_remote_ver = highest_remote_tup.version
       highest_installed_ver = l_spec.version
 

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -97,10 +97,8 @@ command to remove old versions.
     if options[:explain]
       say "Gems to update:"
 
-      gems_to_update.each do |(name, version, platform)|
-        say platform == "ruby" ?
-          "  #{name}-#{version}" :
-          "  #{name}-#{version}-#{platform}"
+      gems_to_update.each do |name_tuple|
+        say "  #{name_tuple.full_name}"
       end
 
       return
@@ -196,7 +194,7 @@ command to remove old versions.
     }
 
     gems_to_update = which_to_update hig, options[:args], :system
-    _, up_ver = gems_to_update.first
+    up_ver = gems_to_update.first.version
 
     target = if update_latest
                up_ver
@@ -228,8 +226,8 @@ command to remove old versions.
   end
 
   def update_gems(gems_to_update)
-    gems_to_update.uniq.sort.each do |(name, version)|
-      update_gem name, version
+    gems_to_update.uniq.sort.each do |name_tuple|
+      update_gem name_tuple.name, name_tuple.version
     end
 
     @updated
@@ -278,7 +276,7 @@ command to remove old versions.
       highest_installed_ver = l_spec.version
 
       if system or (highest_installed_ver < highest_remote_ver)
-        result << [l_spec.name, [highest_installed_ver, highest_remote_ver].max, highest_remote_tup.platform]
+        result << Gem::NameTuple.new(l_spec.name, [highest_installed_ver, highest_remote_ver].max, highest_remote_tup.platform)
       end
     end
 

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -275,9 +275,10 @@ command to remove old versions.
 
       highest_remote_tup = highest_remote_tuple l_spec
       highest_remote_ver = highest_remote_tup.version
+      highest_installed_ver = l_spec.version
 
-      if system or (l_spec.version < highest_remote_ver)
-        result << [l_spec.name, [l_spec.version, highest_remote_ver].max, highest_remote_tup.platform]
+      if system or (highest_installed_ver < highest_remote_ver)
+        result << [l_spec.name, [highest_installed_ver, highest_remote_ver].max, highest_remote_tup.platform]
       end
     end
 

--- a/lib/rubygems/resolver/activation_request.rb
+++ b/lib/rubygems/resolver/activation_request.rb
@@ -77,7 +77,9 @@ class Gem::Resolver::ActivationRequest
   # The full name of the specification to be activated.
 
   def full_name
-    @spec.full_name
+    (plat = @spec.platform) == Gem::Platform::RUBY ?
+      @spec.full_name :
+      "#{@spec.full_name}-#{plat}"
   end
 
   alias_method :to_s, :full_name

--- a/lib/rubygems/resolver/activation_request.rb
+++ b/lib/rubygems/resolver/activation_request.rb
@@ -77,9 +77,9 @@ class Gem::Resolver::ActivationRequest
   # The full name of the specification to be activated.
 
   def full_name
-    (plat = @spec.platform) == Gem::Platform::RUBY ?
+    (platform = @spec.platform) == Gem::Platform::RUBY ?
       @spec.full_name :
-      "#{@spec.full_name}-#{plat}"
+      "#{@spec.full_name}-#{platform}"
   end
 
   alias_method :to_s, :full_name

--- a/lib/rubygems/resolver/activation_request.rb
+++ b/lib/rubygems/resolver/activation_request.rb
@@ -77,7 +77,7 @@ class Gem::Resolver::ActivationRequest
   # The full name of the specification to be activated.
 
   def full_name
-    (platform = @spec.platform) == Gem::Platform::RUBY ?
+    platform == Gem::Platform::RUBY ?
       @spec.full_name :
       "#{@spec.full_name}-#{platform}"
   end
@@ -183,6 +183,13 @@ class Gem::Resolver::ActivationRequest
 
   def version
     @spec.version
+  end
+
+  ##
+  # The platform of this activation request's specification
+
+  def platform
+    @spec.platform
   end
 
 end

--- a/lib/rubygems/resolver/activation_request.rb
+++ b/lib/rubygems/resolver/activation_request.rb
@@ -77,9 +77,7 @@ class Gem::Resolver::ActivationRequest
   # The full name of the specification to be activated.
 
   def full_name
-    platform == Gem::Platform::RUBY ?
-      @spec.full_name :
-      "#{@spec.full_name}-#{platform}"
+    name_tuple.full_name
   end
 
   alias_method :to_s, :full_name
@@ -190,6 +188,12 @@ class Gem::Resolver::ActivationRequest
 
   def platform
     @spec.platform
+  end
+
+  private
+
+  def name_tuple
+    @name_tuple ||= Gem::NameTuple.new(name, version, platform)
   end
 
 end


### PR DESCRIPTION
# Description:

When formatting gem versions to be displayed by the `--explain` option of the install and update commands, we have very similar logic that lives in different places. This PR tries to unify that under the `NameTuple` class.

It tries to address https://github.com/rubygems/rubygems/pull/2635#discussion_r256501917.

@bronzdoc Is something like this what you meant by your comment?

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
