### PR TITLE
Better folder assertions

### DIFF
--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -134,6 +134,11 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
     assert File.exist?(path), msg
   end
 
+  def assert_directory_exists(path, msg = nil)
+    msg = message(msg) { "Expected path '#{path}' to be a directory" }
+    assert File.directory?(path), msg
+  end
+
   ##
   # Sets the ENABLE_SHARED entry in RbConfig::CONFIG to +value+ and restores
   # the original value when the block ends

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -136,6 +136,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
 
   def assert_directory_exists(path, msg = nil)
     msg = message(msg) { "Expected path '#{path}' to be a directory" }
+    assert_path_exists path
     assert File.directory?(path), msg
   end
 

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -553,7 +553,7 @@ class TestGem < Gem::TestCase
 
     Gem.ensure_gem_subdirectories @gemhome, 0750
 
-    assert File.directory? File.join(@gemhome, "cache")
+    assert_directory_exists File.join(@gemhome, "cache")
 
     assert_equal 0750, File::Stat.new(@gemhome).mode & 0777
     assert_equal 0750, File::Stat.new(File.join(@gemhome, "cache")).mode & 0777
@@ -582,7 +582,7 @@ class TestGem < Gem::TestCase
 
     Gem.ensure_gem_subdirectories gemdir
 
-    assert File.directory?(util_cache_dir)
+    assert_directory_exists util_cache_dir
   end
 
   unless win_platform? || Process.uid.zero?  # only for FS that support write protection

--- a/test/rubygems/test_gem_indexer.rb
+++ b/test/rubygems/test_gem_indexer.rb
@@ -103,8 +103,8 @@ class TestGemIndexer < Gem::TestCase
     quickdir = File.join @tempdir, 'quick'
     marshal_quickdir = File.join quickdir, "Marshal.#{@marshal_version}"
 
-    assert File.directory?(quickdir)
-    assert File.directory?(marshal_quickdir)
+    assert_directory_exists quickdir
+    assert_directory_exists marshal_quickdir
 
     assert_indexed marshal_quickdir, "#{File.basename(@a1.spec_file)}.rz"
     assert_indexed marshal_quickdir, "#{File.basename(@a2.spec_file)}.rz"
@@ -133,8 +133,8 @@ class TestGemIndexer < Gem::TestCase
     quickdir = File.join @tempdir, 'quick'
     marshal_quickdir = File.join quickdir, "Marshal.#{@marshal_version}"
 
-    assert File.directory?(quickdir), 'quickdir should be directory'
-    assert File.directory?(marshal_quickdir)
+    assert_directory_exists quickdir, 'quickdir should be directory'
+    assert_directory_exists marshal_quickdir
 
     refute_indexed quickdir, "index"
     refute_indexed quickdir, "index.rz"
@@ -179,8 +179,8 @@ class TestGemIndexer < Gem::TestCase
     quickdir = File.join @tempdir, 'quick'
     marshal_quickdir = File.join quickdir, "Marshal.#{@marshal_version}"
 
-    assert File.directory?(quickdir)
-    assert File.directory?(marshal_quickdir)
+    assert_directory_exists quickdir
+    assert_directory_exists marshal_quickdir
 
     assert_indexed marshal_quickdir, "#{File.basename(@a1.spec_file)}.rz"
     assert_indexed marshal_quickdir, "#{File.basename(@a2.spec_file)}.rz"
@@ -315,8 +315,8 @@ class TestGemIndexer < Gem::TestCase
     quickdir = File.join @tempdir, 'quick'
     marshal_quickdir = File.join quickdir, "Marshal.#{@marshal_version}"
 
-    assert File.directory?(quickdir)
-    assert File.directory?(marshal_quickdir)
+    assert_directory_exists quickdir
+    assert_directory_exists marshal_quickdir
 
     @d2_1 = util_spec 'd', '2.1'
     util_build_gem @d2_1

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -326,7 +326,7 @@ gem 'other', version
 
     @installer.generate_bin
 
-    assert_equal true, File.directory?(util_inst_bindir)
+    assert_directory_exists (util_inst_bindir)
     installed_exec = File.join(util_inst_bindir, 'executable')
     assert_path_exists installed_exec
     assert_equal mask, File.stat(installed_exec).mode unless win_platform?
@@ -367,7 +367,7 @@ gem 'other', version
     @installer.gem_dir = @spec.gem_dir
 
     @installer.generate_bin
-    assert File.directory? util_inst_bindir
+    assert_directory_exists util_inst_bindir
     installed_exec = File.join util_inst_bindir, 'executable'
     assert_path_exists installed_exec
     assert_equal mask, File.stat(installed_exec).mode unless win_platform?
@@ -384,7 +384,7 @@ gem 'other', version
 
     Gem::Installer.exec_format = 'foo-%s-bar'
     @installer.generate_bin
-    assert_equal true, File.directory?(util_inst_bindir)
+    assert_directory_exists util_inst_bindir
     installed_exec = File.join util_inst_bindir, 'foo-executable-bar'
     assert_path_exists installed_exec
   ensure
@@ -398,7 +398,7 @@ gem 'other', version
 
     Gem::Installer.exec_format = 'foo-%s-bar'
     @installer.generate_bin
-    assert_equal true, File.directory?(util_inst_bindir)
+    assert_directory_exists util_inst_bindir
     installed_exec = File.join util_inst_bindir, 'executable'
     assert_path_exists installed_exec
   ensure
@@ -497,7 +497,7 @@ gem 'other', version
     end
 
     @installer.generate_bin
-    assert_equal true, File.directory?(util_inst_bindir)
+    assert_directory_exists util_inst_bindir
     assert_path_exists installed_exec
     assert_equal mask, File.stat(installed_exec).mode unless win_platform?
 
@@ -515,7 +515,7 @@ gem 'other', version
     @installer.gem_dir = @spec.gem_dir
 
     @installer.generate_bin
-    assert_equal true, File.directory?(util_inst_bindir)
+    assert_directory_exists util_inst_bindir
     installed_exec = File.join util_inst_bindir, 'executable'
     assert_equal true, File.symlink?(installed_exec)
     assert_equal(File.join(@spec.gem_dir, 'bin', 'executable'),
@@ -667,7 +667,7 @@ gem 'other', version
       @installer.generate_bin
     end
 
-    assert_equal true, File.directory?(util_inst_bindir)
+    assert_directory_exists util_inst_bindir
     installed_exec = File.join(util_inst_bindir, 'executable')
     assert_path_exists installed_exec
 
@@ -1733,12 +1733,12 @@ gem 'other', version
       @installer.install
     end
 
-    assert File.directory? util_inst_bindir
+    assert_directory_exists util_inst_bindir
     installed_exec = File.join util_inst_bindir, 'executable'
     assert_path_exists installed_exec
 
-    assert File.directory? File.join(Gem.default_dir, 'specifications')
-    assert File.directory? File.join(Gem.default_dir, 'specifications', 'default')
+    assert_directory_exists File.join(Gem.default_dir, 'specifications')
+    assert_directory_exists File.join(Gem.default_dir, 'specifications', 'default')
 
     default_spec = eval File.read File.join(Gem.default_dir, 'specifications', 'default', 'a-2.gemspec')
     assert_equal Gem::Version.new("2"), default_spec.version

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -984,7 +984,7 @@ gem 'other', version
 
   def test_install_missing_dirs
     FileUtils.rm_f File.join(Gem.dir, 'cache')
-    FileUtils.rm_f File.join(Gem.dir, 'docs')
+    FileUtils.rm_f File.join(Gem.dir, 'doc')
     FileUtils.rm_f File.join(Gem.dir, 'specifications')
 
     use_ui @ui do
@@ -992,7 +992,7 @@ gem 'other', version
     end
 
     assert_directory_exists File.join(Gem.dir, 'cache')
-    assert_directory_exists File.join(Gem.dir, 'docs')
+    assert_directory_exists File.join(Gem.dir, 'doc')
     assert_directory_exists File.join(Gem.dir, 'specifications')
 
     assert_path_exists File.join @gemhome, 'cache', @spec.file_name

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -991,9 +991,9 @@ gem 'other', version
       @installer.install
     end
 
-    File.directory? File.join(Gem.dir, 'cache')
-    File.directory? File.join(Gem.dir, 'docs')
-    File.directory? File.join(Gem.dir, 'specifications')
+    assert_directory_exists File.join(Gem.dir, 'cache')
+    assert_directory_exists File.join(Gem.dir, 'docs')
+    assert_directory_exists File.join(Gem.dir, 'specifications')
 
     assert_path_exists File.join @gemhome, 'cache', @spec.file_name
     assert_path_exists File.join @gemhome, 'specifications', @spec.spec_name


### PR DESCRIPTION
# Description:

Previously, when an assertion about the existance of a folder failed inside rubygems test suite, you would get something like

```
  1) Failure:
TestGemInstaller#test_default_gem_with_exe_as_bindir [/home/deivid/Code/rubygems/test/rubygems/test_gem_installer.rb:1767]:
Expected false to be truthy.
```

After this PR, you'll get a better message like

```
  1) Failure:
TestGemInstaller#test_default_gem_with_exe_as_bindir [/home/deivid/Code/rubygems/test/rubygems/test_gem_installer.rb:1767]:
Expected path '/tmp/test_rubygems_31460/gemhome/gems/c-2/exe' to exist.
```

if the folder does not exist, or like

```
  1) Failure:
TestGemInstaller#test_default_gem_with_exe_as_bindir [/home/deivid/Code/rubygems/test/rubygems/test_gem_installer.rb:1767]:
Expected path '/tmp/test_rubygems_31460/gemhome/gems/c-2/exe' to be a folder
```

if the file exists but it's not a folder.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
