### PR TITLE
Fix 2.6.1 build against vendored bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,6 @@ script:
   - util/ci script
 matrix:
   allow_failures:
-    - rvm: 2.6.1
-      env: "TEST_TOOL=bundler RGV=master"
     - rvm: ruby-head
       env: "TEST_TOOL=rubygems YAML=psych"
     - rvm: ruby-head

--- a/util/ci
+++ b/util/ci
@@ -57,6 +57,11 @@ when %w(before_script)
     run('gem', %w(list --details))
     run('gem', %w(env))
   else
+    # Fix incorrect default gem specifications on ruby 2.6.1. Can be removed
+    # when 2.6.2 is released and we start testing against it. See
+    # https://bugs.ruby-lang.org/issues/15582 for more information
+    run('gem', %w(install etc:1.0.1 --default)) if RUBY_VERSION == "2.6.1"
+
     with_retries { run('rake', %w(spec:travis:deps)) }
   end
 when %w(rubocop)


### PR DESCRIPTION
# Description:

We're currently allowing failures when testing against bundler with MRI 2.6.1. This PR tries to get that green.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
