### PR TITLE
Fix default gem executable installation when folder is not `bin/`

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -844,7 +844,7 @@ TEXT
   # without the full gem installed.
 
   def extract_bin
-    @package.extract_files gem_dir, "bin/*"
+    @package.extract_files gem_dir, "#{spec.bindir}/*"
   end
 
   ##

--- a/lib/rubygems/installer_test_case.rb
+++ b/lib/rubygems/installer_test_case.rb
@@ -122,7 +122,7 @@ class Gem::InstallerTestCase < Gem::TestCase
 
   def util_make_exec(spec = @spec, shebang = "#!/usr/bin/ruby")
     spec.executables = %w[executable]
-    spec.files << 'bin/executable'
+    spec.bindir = 'bin'
 
     exec_path = spec.bin_file "executable"
     write_file exec_path do |io|

--- a/lib/rubygems/installer_test_case.rb
+++ b/lib/rubygems/installer_test_case.rb
@@ -120,9 +120,9 @@ class Gem::InstallerTestCase < Gem::TestCase
   # The executable is also written to the bin dir in @tmpdir and the installed
   # gem directory for +spec+.
 
-  def util_make_exec(spec = @spec, shebang = "#!/usr/bin/ruby")
+  def util_make_exec(spec = @spec, shebang = "#!/usr/bin/ruby", bindir = "bin")
     spec.executables = %w[executable]
-    spec.bindir = 'bin'
+    spec.bindir = bindir
 
     exec_path = spec.bin_file "executable"
     write_file exec_path do |io|

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1744,6 +1744,38 @@ gem 'other', version
     assert_equal ['bin/executable'], default_spec.files
   end
 
+  def test_default_gem_with_exe_as_bindir
+    FileUtils.rm_f File.join(Gem.dir, 'specifications')
+
+    @spec = quick_gem 'c' do |spec|
+      util_make_exec spec, '#!/usr/bin/ruby', 'exe'
+    end
+
+    util_build_gem @spec
+
+    @spec.cache_file
+
+    installer = util_installer @spec, @gemhome
+
+    installer.options[:install_as_default] = true
+    installer.gem_dir = @spec.gem_dir
+
+    use_ui @ui do
+      installer.install
+    end
+
+    assert_directory_exists File.join(@spec.gem_dir, 'exe')
+    installed_exec = File.join @spec.gem_dir, 'exe', 'executable'
+    assert_path_exists installed_exec
+
+    assert_directory_exists File.join(Gem.default_dir, 'specifications')
+    assert_directory_exists File.join(Gem.default_dir, 'specifications', 'default')
+
+    default_spec = eval File.read File.join(Gem.default_dir, 'specifications', 'default', 'c-2.gemspec')
+    assert_equal Gem::Version.new("2"), default_spec.version
+    assert_equal ['exe/executable'], default_spec.files
+  end
+
   def old_ruby_required(requirement)
     spec = util_spec 'old_ruby_required', '1' do |s|
       s.required_ruby_version = requirement

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1727,14 +1727,13 @@ gem 'other', version
     @installer.wrappers = true
     @installer.options[:install_as_default] = true
     @installer.gem_dir = @spec.gem_dir
-    @installer.generate_bin
 
     use_ui @ui do
       @installer.install
     end
 
-    assert_directory_exists util_inst_bindir
-    installed_exec = File.join util_inst_bindir, 'executable'
+    assert_directory_exists File.join(@spec.gem_dir, 'bin')
+    installed_exec = File.join @spec.gem_dir, 'bin', 'executable'
     assert_path_exists installed_exec
 
     assert_directory_exists File.join(Gem.default_dir, 'specifications')

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -314,7 +314,7 @@ gem 'other', version
     @installer.wrappers = true
 
     @spec.executables = %w[executable]
-    @spec.bindir = '.'
+    @spec.bindir = 'bin'
 
     exec_file = @installer.formatted_program_filename 'executable'
     exec_path = File.join @spec.gem_dir, exec_file


### PR DESCRIPTION
# Description:

Fixes #2646 by making sure executables are extracted to the proper folder.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
