### PR TITLE
Fix cryptic error on local and ignore-dependencies combination

### DIFF
--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -204,17 +204,7 @@ You can use `i` command instead of `install`.
   end
 
   def install_gem_without_dependencies(dinst, name, req) # :nodoc:
-    gem = nil
-
-    if local?
-      gem = fetch_local_gem name, req
-    end
-
-    installed_spec_set = if remote? and not gem
-                           dinst.install name, req
-                         else
-                           install_fetched_gem dinst, gem
-                         end
+    installed_spec_set = dinst.install name, req
 
     Gem.done_installing_hooks.each do |hook|
       hook.call dinst, installed_spec_set
@@ -267,26 +257,6 @@ You can use `i` command instead of `install`.
     end
 
     show_install_errors dinst.errors
-  end
-
-  def fetch_local_gem(name, req) # :nodoc:
-    if name =~ /\.gem$/ and File.file? name
-      source = Gem::Source::SpecificFile.new name
-      spec = source.spec
-    else
-      source = Gem::Source::Local.new
-      spec = source.find_gem name, req
-    end
-    source.download spec if spec
-  end
-
-  def install_fetched_gem(dinst, gem) # :nodoc:
-    inst = Gem::Installer.at gem, options
-    inst.install
-
-    dinst.installed_gems.replace [inst.spec]
-
-    [inst.spec]
   end
 
   ##

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -236,6 +236,25 @@ ERROR:  Could not find a valid gem 'bar' (= 0.5) (required by 'foo' (>= 0)) in a
     assert_match(/ould not find a valid gem 'no_such_gem'/, @ui.error)
   end
 
+  def test_execute_local_missing_ignore_dependencies
+    spec_fetcher
+
+    @cmd.options[:domain] = :local
+    @cmd.options[:ignore_dependencies] = true
+
+    @cmd.options[:args] = %w[no_such_gem]
+
+    use_ui @ui do
+      e = assert_raises Gem::MockGemUi::TermError do
+        @cmd.execute
+      end
+      assert_equal 2, e.exit_code
+    end
+
+    # HACK no repository was checked
+    assert_match(/ould not find a valid gem 'no_such_gem'/, @ui.error)
+  end
+
   def test_execute_no_gem
     @cmd.options[:args] = %w[]
 

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -96,6 +96,64 @@ class TestGemCommandsInstallCommand < Gem::TestCase
     assert_match "1 gem installed", @ui.output
   end
 
+  def test_execute_local_dependency_nonexistent
+    specs = spec_fetcher do |fetcher|
+      fetcher.gem 'foo', 2, 'bar' => '0.5'
+    end
+
+    @cmd.options[:domain] = :local
+
+    FileUtils.mv specs['foo-2'].cache_file, @tempdir
+
+    @cmd.options[:args] = ['foo']
+
+    use_ui @ui do
+      orig_dir = Dir.pwd
+      begin
+        Dir.chdir @tempdir
+        e = assert_raises Gem::MockGemUi::TermError do
+          @cmd.execute
+        end
+        assert_equal 2, e.exit_code
+      ensure
+        Dir.chdir orig_dir
+      end
+    end
+
+    expected = <<-EXPECTED
+ERROR:  Could not find a valid gem 'bar' (= 0.5) (required by 'foo' (>= 0)) in any repository
+    EXPECTED
+
+    assert_equal expected, @ui.error
+  end
+
+  def test_execute_local_dependency_nonexistent_ignore_dependencies
+    specs = spec_fetcher do |fetcher|
+      fetcher.gem 'foo', 2, 'bar' => '0.5'
+    end
+
+    @cmd.options[:domain] = :local
+    @cmd.options[:ignore_dependencies] = true
+
+    FileUtils.mv specs['foo-2'].cache_file, @tempdir
+
+    @cmd.options[:args] = ['foo']
+
+    use_ui @ui do
+      orig_dir = Dir.pwd
+      begin
+        Dir.chdir orig_dir
+        assert_raises Gem::MockGemUi::SystemExitException, @ui.error do
+          @cmd.execute
+        end
+      ensure
+        Dir.chdir orig_dir
+      end
+    end
+
+    assert_match "1 gem installed", @ui.output
+  end
+
   def test_execute_local_transitive_prerelease
     specs = spec_fetcher do |fetcher|
       fetcher.download 'a', 2, 'b' => "2.a", 'c' => '3'


### PR DESCRIPTION
# Description:

Addresses https://github.com/rubygems/rubygems/pull/2647#discussion_r257277738 and successive comments by removing code. It feels great! :smile:

When combining the `--local` and the `--ignore-dependencies` flags, and specifying a nonexistent local gem, we would get the error

```
ERROR:  While executing gem ... (TypeError)
    no implicit conversion of nil into String
```

Now we get a nicer

```
ERROR:  Could not find a valid gem '<gem_name>' (>= 0) in any repository
```

I also added a bit of extra coverage to make sure that removing all this stuff does not really break anything.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).