### PR TITLE
Restore transitiveness of version comparison

### DIFF
--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -344,8 +344,8 @@ class Gem::Version
     return unless Gem::Version === other
     return 0 if @version == other._version || canonical_segments == other.canonical_segments
 
-    lhsegments = _segments
-    rhsegments = other._segments
+    lhsegments = canonical_segments
+    rhsegments = other.canonical_segments
 
     lhsize = lhsegments.size
     rhsize = rhsegments.size

--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -265,6 +265,12 @@ class TestGemRequirement < Gem::TestCase
     assert_satisfied_by "3.0.rc2",     "< 3.0.1"
 
     assert_satisfied_by "3.0.rc2",     "> 0"
+
+    assert_satisfied_by "5.0.0.rc2",   "~> 5.a"
+    refute_satisfied_by "5.0.0.rc2",   "~> 5.x"
+
+    assert_satisfied_by "5.0.0",       "~> 5.a"
+    assert_satisfied_by "5.0.0",       "~> 5.x"
   end
 
   def test_illformed_requirements

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -157,6 +157,13 @@ class TestGemVersion < Gem::TestCase
     assert_equal(1, v("1.8.2.a10") <=> v("1.8.2.a9"))
     assert_equal(0, v("")          <=> v("0"))
 
+    assert_equal(0, v("0.beta.1")  <=> v("0.0.beta.1"))
+    assert_equal(-1, v("0.0.beta")  <=> v("0.0.beta.1"))
+    assert_equal(-1, v("0.0.beta")  <=> v("0.beta.1"))
+
+    assert_equal(-1, v("5.a") <=> v("5.0.0.rc2"))
+    assert_equal(1, v("5.x") <=> v("5.0.0.rc2"))
+
     assert_nil v("1.0") <=> "whatever"
   end
 


### PR DESCRIPTION
# Description:

This is an alternative to #2597 fix to #2595.

I strongly think this is the best way to fix this, even if it _could_ create some incompatibility with some gems relying on things like "~> 5.x" being lower than _all_ 5.0.0 prereleases.

As explained in that discussion, the official way that's recommended in the docs to match all prereleases is "~> 5.a", because "a" is the first string in lexicographical order.

I created PRs to the two gems I found relying on this:

* https://github.com/rails/activemodel-serializers-xml/pull/17
* https://github.com/rails/rails-controller-testing/pull/45

I would consider this a bug fix and ship it normally on a bug fix release, but I can understand if others prefer a more conservative approach.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).