### PR TITLE
test_gem.rb - fix intermittent test

### DIFF
--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -955,37 +955,35 @@ class TestGem < Gem::TestCase
 
   def test_self_ruby_escaping_spaces_in_path
     orig_bindir = RbConfig::CONFIG['bindir']
-    orig_ruby_install_name = RbConfig::CONFIG['ruby_install_name']
     orig_exe_ext = RbConfig::CONFIG['EXEEXT']
 
     RbConfig::CONFIG['bindir'] = "C:/Ruby 1.8/bin"
-    RbConfig::CONFIG['ruby_install_name'] = "ruby"
     RbConfig::CONFIG['EXEEXT'] = ".exe"
 
-    with_clean_path_to_ruby do
-      assert_equal "\"C:/Ruby 1.8/bin/ruby.exe\"", Gem.ruby
+    ruby_install_name "ruby" do
+      with_clean_path_to_ruby do
+        assert_equal "\"C:/Ruby 1.8/bin/ruby.exe\"", Gem.ruby
+      end
     end
   ensure
     RbConfig::CONFIG['bindir'] = orig_bindir
-    RbConfig::CONFIG['ruby_install_name'] = orig_ruby_install_name
     RbConfig::CONFIG['EXEEXT'] = orig_exe_ext
   end
 
   def test_self_ruby_path_without_spaces
     orig_bindir = RbConfig::CONFIG['bindir']
-    orig_ruby_install_name = RbConfig::CONFIG['ruby_install_name']
     orig_exe_ext = RbConfig::CONFIG['EXEEXT']
 
     RbConfig::CONFIG['bindir'] = "C:/Ruby18/bin"
-    RbConfig::CONFIG['ruby_install_name'] = "ruby"
     RbConfig::CONFIG['EXEEXT'] = ".exe"
 
-    with_clean_path_to_ruby do
-      assert_equal "C:/Ruby18/bin/ruby.exe", Gem.ruby
+    ruby_install_name "ruby" do
+      with_clean_path_to_ruby do
+        assert_equal "C:/Ruby18/bin/ruby.exe", Gem.ruby
+      end
     end
   ensure
     RbConfig::CONFIG['bindir'] = orig_bindir
-    RbConfig::CONFIG['ruby_install_name'] = orig_ruby_install_name
     RbConfig::CONFIG['EXEEXT'] = orig_exe_ext
   end
 

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -952,7 +952,6 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_ruby_escaping_spaces_in_path
-    orig_ruby = Gem.ruby
     orig_bindir = RbConfig::CONFIG['bindir']
     orig_ruby_install_name = RbConfig::CONFIG['ruby_install_name']
     orig_exe_ext = RbConfig::CONFIG['EXEEXT']
@@ -960,18 +959,17 @@ class TestGem < Gem::TestCase
     RbConfig::CONFIG['bindir'] = "C:/Ruby 1.8/bin"
     RbConfig::CONFIG['ruby_install_name'] = "ruby"
     RbConfig::CONFIG['EXEEXT'] = ".exe"
-    Gem.instance_variable_set("@ruby", nil)
 
-    assert_equal "\"C:/Ruby 1.8/bin/ruby.exe\"", Gem.ruby
+    with_clean_path_to_ruby do
+      assert_equal "\"C:/Ruby 1.8/bin/ruby.exe\"", Gem.ruby
+    end
   ensure
-    Gem.instance_variable_set("@ruby", orig_ruby)
     RbConfig::CONFIG['bindir'] = orig_bindir
     RbConfig::CONFIG['ruby_install_name'] = orig_ruby_install_name
     RbConfig::CONFIG['EXEEXT'] = orig_exe_ext
   end
 
   def test_self_ruby_path_without_spaces
-    orig_ruby = Gem.ruby
     orig_bindir = RbConfig::CONFIG['bindir']
     orig_ruby_install_name = RbConfig::CONFIG['ruby_install_name']
     orig_exe_ext = RbConfig::CONFIG['EXEEXT']
@@ -979,11 +977,11 @@ class TestGem < Gem::TestCase
     RbConfig::CONFIG['bindir'] = "C:/Ruby18/bin"
     RbConfig::CONFIG['ruby_install_name'] = "ruby"
     RbConfig::CONFIG['EXEEXT'] = ".exe"
-    Gem.instance_variable_set("@ruby", nil)
 
-    assert_equal "C:/Ruby18/bin/ruby.exe", Gem.ruby
+    with_clean_path_to_ruby do
+      assert_equal "C:/Ruby18/bin/ruby.exe", Gem.ruby
+    end
   ensure
-    Gem.instance_variable_set("@ruby", orig_ruby)
     RbConfig::CONFIG['bindir'] = orig_bindir
     RbConfig::CONFIG['ruby_install_name'] = orig_ruby_install_name
     RbConfig::CONFIG['EXEEXT'] = orig_exe_ext
@@ -1902,6 +1900,16 @@ You may need to `gem install -g` to install missing gems
     else
       RbConfig::CONFIG.delete 'ruby_install_name'
     end
+  end
+
+  def with_clean_path_to_ruby
+    orig_ruby = Gem.ruby
+
+    Gem.instance_variable_set :@ruby, nil
+
+    yield
+  ensure
+    Gem.instance_variable_set("@ruby", orig_ruby)
   end
 
   def with_plugin(path)

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -155,8 +155,10 @@ class TestGem < Gem::TestCase
 
   def test_self_install_permissions_with_format_executable_and_non_standard_ruby_install_name
     Gem::Installer.exec_format = nil
-    ruby_install_name 'ruby27' do
-      assert_self_install_permissions(format_executable: true)
+    with_clean_path_to_ruby do
+      ruby_install_name 'ruby27' do
+        assert_self_install_permissions(format_executable: true)
+      end
     end
   ensure
     Gem::Installer.exec_format = nil


### PR DESCRIPTION
`test_gem.rb` has the following code (note line 158):

https://github.com/rubygems/rubygems/blob/3d27eb01f8ab89a672915ebd56c7b70768739749/test/rubygems/test_gem.rb#L156-L163

Failures are caused by `Gem.ruby`, which matches the test setting, see:

https://ci.appveyor.com/project/MSP-Greg/rubygems/build/job/wudlxafxreyk3auy#L31

# Tasks:

- [ ] Describe the problem / feature
- [X] Fix tests
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).