### PR TITLE
Implement spec required_ruby_version constraint

### DIFF
--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -125,7 +125,7 @@ command to remove old versions.
 
     fetcher = Gem::SpecFetcher.fetcher
 
-    spec_tuples, errors = fetcher.search_for_dependency dependency
+    spec_tuples, errors = fetcher.search_for_dependency dependency, best_only: true
 
     error = errors.find { |e| e.respond_to? :exception }
 
@@ -147,17 +147,13 @@ command to remove old versions.
   end
 
   def highest_remote_name_tuple(spec) # :nodoc:
-    spec_tuples = fetch_remote_gems spec
+    dependency = Gem::Dependency.new spec.name, "> #{spec.version}"
+    dependency.prerelease = options[:prerelease]
 
-    matching_gems = spec_tuples.select do |g,_|
-      g.name == spec.name and g.match_platform?
-    end
+    fetcher = Gem::SpecFetcher.fetcher
+    specs, _ = fetcher.spec_for_dependency dependency, best_only: true
 
-    highest_remote_gem = matching_gems.max
-
-    highest_remote_gem ||= [Gem::NameTuple.null]
-
-    highest_remote_gem.first
+    specs.empty? ? Gem::NameTuple.null : specs[0][0].name_tuple
   end
 
   def install_rubygems(version) # :nodoc:

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -98,7 +98,7 @@ class Gem::RemoteFetcher
   # larger, more encompassing effort. -erikh
 
   def download_to_cache(dependency)
-    found, _ = Gem::SpecFetcher.fetcher.spec_for_dependency dependency
+    found, _ = Gem::SpecFetcher.fetcher.spec_for_dependency dependency, best_only: true
 
     return if found.empty?
 

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -428,6 +428,63 @@ ERROR:  Possible alternatives: non_existent_with_hint
     assert_equal %w[a-2], @cmd.installed_specs.map { |spec| spec.full_name }
   end
 
+  def test_execute_required_ruby_version
+    local = Gem::Platform.local
+    spec_fetcher do |fetcher|
+      fetcher.download 'a', 2
+      fetcher.download 'a', 2 do |s|
+        s.required_ruby_version = '< 2.5.0.a'
+        s.platform = local
+      end
+      fetcher.download 'a', 3 do |s|
+        s.required_ruby_version = '>= 2.6.0'
+      end
+      fetcher.download 'a', 3 do |s|
+        s.required_ruby_version = '>= 2.6.0'
+        s.platform = local
+      end
+    end
+
+    util_set_RUBY_VERSION '2.5.0'
+
+    @cmd.options[:args] = %w[a]
+
+    use_ui @ui do
+      assert_raises Gem::MockGemUi::SystemExitException, @ui.error do
+        @cmd.execute
+      end
+    end
+
+    assert_equal %w[a-2], @cmd.installed_specs.map { |spec| spec.full_name }
+  ensure
+    util_restore_RUBY_VERSION
+  end
+
+  def test_execute_required_ruby_version2
+    local = Gem::Platform.local
+    spec_fetcher do |fetcher|
+      fetcher.gem 'a', 2.0
+      fetcher.gem 'a', 2.0 do |s|
+        s.required_ruby_version = '< 2.6.a'
+        s.platform = local
+      end
+    end
+
+    util_set_RUBY_VERSION '2.6.0'
+
+    @cmd.options[:args] = %w[a]
+
+    use_ui @ui do
+      assert_raises Gem::MockGemUi::SystemExitException, @ui.error do
+        @cmd.execute
+      end
+    end
+
+    assert_equal %w[a-2.0], @cmd.installed_specs.map { |spec| spec.full_name }
+  ensure
+    util_restore_RUBY_VERSION
+  end
+
   def test_execute_rdoc
     specs = spec_fetcher do |fetcher|
       fetcher.gem 'a', 2

--- a/test/rubygems/test_gem_dependency_installer.rb
+++ b/test/rubygems/test_gem_dependency_installer.rb
@@ -1123,6 +1123,35 @@ class TestGemDependencyInstaller < Gem::TestCase
     assert_equal [a1_x86_mingw32], releases
   end
 
+  def test_find_gems_with_sources_with_best_only_plat_ruby_vers
+    a2,           = util_gem 'a', 2
+    a2_ruby_plat, = util_gem 'a', 2 do |s|
+      s.required_ruby_version = Gem::Requirement.new "< 2.5.0.a"
+      s.platform = Gem::Platform.local
+    end
+    a3_ruby, = util_gem 'a', 3 do |s|
+      s.required_ruby_version = Gem::Requirement.new ">= 2.6.0"
+    end
+    a3_ruby_plat, = util_gem 'a', 3 do |s|
+      s.required_ruby_version = Gem::Requirement.new ">= 2.6.0"
+      s.platform = Gem::Platform.local
+    end
+    util_setup_spec_fetcher a2, a2_ruby_plat, a3_ruby, a3_ruby_plat
+
+    util_set_RUBY_VERSION '2.5.0'
+
+    installer = Gem::DependencyInstaller.new
+
+    dependency = Gem::Dependency.new('a', Gem::Requirement.default)
+
+    releases =
+      installer.find_gems_with_sources(dependency, true).all_specs
+
+    assert_equal [a2], releases
+  ensure
+    util_restore_RUBY_VERSION
+  end
+
   def test_find_gems_with_sources_with_bad_source
     Gem.sources.replace ["http://not-there.nothing"]
 

--- a/test/rubygems/test_gem_resolver_installer_set.rb
+++ b/test/rubygems/test_gem_resolver_installer_set.rb
@@ -77,6 +77,34 @@ class TestGemResolverInstallerSet < Gem::TestCase
     end
   end
 
+  def test_add_always_install_required_ruby_version
+    spec_fetcher do |fetcher|
+      fetcher.spec 'a', 2
+      fetcher.spec 'a', 2 do |s|
+        s.required_ruby_version = Gem::Requirement.new "< 2.5.0.a"
+        s.platform = Gem::Platform.local
+      end
+      fetcher.spec 'a', 3 do |s|
+        s.required_ruby_version = Gem::Requirement.new ">= 2.6.0"
+      end
+      fetcher.spec 'a', 3 do |s|
+        s.required_ruby_version = Gem::Requirement.new ">= 2.6.0"
+        s.platform = Gem::Platform.local
+      end
+    end
+
+    util_set_RUBY_VERSION '2.5.0'
+
+    set = Gem::Resolver::InstallerSet.new :both
+
+    spec = set.add_always_install dep('a', '>= 0')
+
+    assert_equal 1, spec.length
+    assert_equal 'a-2', spec[0].full_name
+  ensure
+    util_restore_RUBY_VERSION
+  end
+
   def test_add_local
     a_1, a_1_gem = util_gem 'a', 1
 


### PR DESCRIPTION
## Description:

Currently the `required_ruby_version` constraint is ignored.  This causes issues as more & more gems are using it in new releases, along the normal use in pre-compiled gems.

Fixes the issue in several places.

### Notes:

Since the tuples stored in the local cache do not contain `required_ruby_version` info, specs must be downloaded and checked.  The algorithms should minimize that.

The specs/tuples contained in `latest_specs.4.8` are no longer of use, since one needs to check the other cache files, as the most recent gem that matches `required_ruby_version` may not be the most recent.

As mentioned previously, 'spec' sorting by platform has issues. See Issue #2653.  Another posted soon.

## Tasks:

- [ ] Describe the problem / feature
- [X] Write tests
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
