### PR TITLE
Fallback to IPv4 when IPv6 is unreachable

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -354,6 +354,7 @@ lib/rubygems/config_file.rb
 lib/rubygems/core_ext/kernel_gem.rb
 lib/rubygems/core_ext/kernel_require.rb
 lib/rubygems/core_ext/kernel_warn.rb
+lib/rubygems/core_ext/tcpsocket_init.rb
 lib/rubygems/defaults.rb
 lib/rubygems/dependency.rb
 lib/rubygems/dependency_installer.rb

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -45,6 +45,7 @@ class Gem::ConfigFile
   DEFAULT_UPDATE_SOURCES = true
   DEFAULT_CONCURRENT_DOWNLOADS = 8
   DEFAULT_CERT_EXPIRATION_LENGTH_DAYS = 365
+  DEFAULT_IPv4_FALLBACK_ENABLED = false
 
   ##
   # For Ruby packagers to set configuration defaults.  Set in
@@ -141,6 +142,11 @@ class Gem::ConfigFile
   attr_accessor :cert_expiration_length_days
 
   ##
+  # Fallback to IPv4 when IPv6 is not reachable or slow (default: false)
+
+  attr_accessor :ipv4_fallback_enabled
+
+  ##
   # Path name of directory or file of openssl client certificate, used for remote https connection with client authentication
 
   attr_reader :ssl_client_cert
@@ -175,6 +181,7 @@ class Gem::ConfigFile
     @update_sources = DEFAULT_UPDATE_SOURCES
     @concurrent_downloads = DEFAULT_CONCURRENT_DOWNLOADS
     @cert_expiration_length_days = DEFAULT_CERT_EXPIRATION_LENGTH_DAYS
+    @ipv4_fallback_enabled = DEFAULT_IPv4_FALLBACK_ENABLED
 
     operating_system_config = Marshal.load Marshal.dump(OPERATING_SYSTEM_DEFAULTS)
     platform_config = Marshal.load Marshal.dump(PLATFORM_DEFAULTS)
@@ -203,6 +210,7 @@ class Gem::ConfigFile
     @disable_default_gem_server  = @hash[:disable_default_gem_server]  if @hash.key? :disable_default_gem_server
     @sources                     = @hash[:sources]                     if @hash.key? :sources
     @cert_expiration_length_days = @hash[:cert_expiration_length_days] if @hash.key? :cert_expiration_length_days
+    @ipv4_fallback_enabled       = @hash[:ipv4_fallback_enabled]       if @hash.key? :ipv4_fallback_enabled
 
     @ssl_verify_mode  = @hash[:ssl_verify_mode]  if @hash.key? :ssl_verify_mode
     @ssl_ca_cert      = @hash[:ssl_ca_cert]      if @hash.key? :ssl_ca_cert

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -45,7 +45,7 @@ class Gem::ConfigFile
   DEFAULT_UPDATE_SOURCES = true
   DEFAULT_CONCURRENT_DOWNLOADS = 8
   DEFAULT_CERT_EXPIRATION_LENGTH_DAYS = 365
-  DEFAULT_IPv4_FALLBACK_ENABLED = false
+  DEFAULT_IPV4_FALLBACK_ENABLED = false
 
   ##
   # For Ruby packagers to set configuration defaults.  Set in
@@ -142,6 +142,7 @@ class Gem::ConfigFile
   attr_accessor :cert_expiration_length_days
 
   ##
+  # == Experimental ==
   # Fallback to IPv4 when IPv6 is not reachable or slow (default: false)
 
   attr_accessor :ipv4_fallback_enabled
@@ -181,7 +182,7 @@ class Gem::ConfigFile
     @update_sources = DEFAULT_UPDATE_SOURCES
     @concurrent_downloads = DEFAULT_CONCURRENT_DOWNLOADS
     @cert_expiration_length_days = DEFAULT_CERT_EXPIRATION_LENGTH_DAYS
-    @ipv4_fallback_enabled = DEFAULT_IPv4_FALLBACK_ENABLED
+    @ipv4_fallback_enabled = ENV['IPV4_FALLBACK_ENABLED'] == 'true' || DEFAULT_IPV4_FALLBACK_ENABLED
 
     operating_system_config = Marshal.load Marshal.dump(OPERATING_SYSTEM_DEFAULTS)
     platform_config = Marshal.load Marshal.dump(PLATFORM_DEFAULTS)

--- a/lib/rubygems/core_ext/tcpsocket_init.rb
+++ b/lib/rubygems/core_ext/tcpsocket_init.rb
@@ -1,0 +1,49 @@
+require 'socket'
+
+module CoreExtensions
+  module TCPSocketExt
+    def self.prepended(base)
+      base.prepend Initializer
+    end
+
+    module Initializer
+      CONNECTION_TIMEOUT = 5
+      IPV4_DELAY_SECONDS = 0.3
+
+      def initialize(host, serv, *rest)
+        mutex = Mutex.new
+        addrs = []
+        cond_var = ConditionVariable.new
+
+        Addrinfo.foreach(host, serv, nil, :STREAM) do |addr|
+          Thread.report_on_exception = false if defined? Thread.report_on_exception = ()
+
+          Thread.new(addr) do
+            # give head start to ipv6 addresses
+            sleep IPV4_DELAY_SECONDS if addr.ipv4?
+
+            # raises Errno::ECONNREFUSED when ip:port is unreachable
+            Socket.tcp(addr.ip_address, serv, connect_timeout: CONNECTION_TIMEOUT).close
+            mutex.synchronize do
+              addrs << addr.ip_address
+              cond_var.signal
+            end
+          end
+        end
+
+        mutex.synchronize do
+          timeout_time = CONNECTION_TIMEOUT + Time.now.to_f
+          while addrs.empty? && (remaining_time = timeout_time - Time.now.to_f) > 0
+            cond_var.wait(mutex, remaining_time)
+          end
+
+          host = addrs.shift unless addrs.empty?
+        end
+
+        super(host, serv, *rest)
+      end
+    end
+  end
+end
+
+TCPSocket.prepend CoreExtensions::TCPSocketExt

--- a/lib/rubygems/core_ext/tcpsocket_init.rb
+++ b/lib/rubygems/core_ext/tcpsocket_init.rb
@@ -8,7 +8,7 @@ module CoreExtensions
 
     module Initializer
       CONNECTION_TIMEOUT = 5
-      IPV4_DELAY_SECONDS = 0.3
+      IPV4_DELAY_SECONDS = 0.1
 
       def initialize(host, serv, *rest)
         mutex = Mutex.new

--- a/lib/rubygems/install_update_options.rb
+++ b/lib/rubygems/install_update_options.rb
@@ -18,12 +18,6 @@ module Gem::InstallUpdateOptions
   # Add the install/update options to the option parser.
 
   def add_install_update_options
-    add_option(:"Install/Update", '--ipv4-fallback-enabled',
-          'Gem repository directory to get installed',
-          'gems') do |value, options|
-      Gem.configuration.ipv4_fallback_enabled = value
-    end
-
     add_option(:"Install/Update", '-i', '--install-dir DIR',
                'Gem repository directory to get installed',
                'gems') do |value, options|

--- a/lib/rubygems/install_update_options.rb
+++ b/lib/rubygems/install_update_options.rb
@@ -18,6 +18,12 @@ module Gem::InstallUpdateOptions
   # Add the install/update options to the option parser.
 
   def add_install_update_options
+    add_option(:"Install/Update", '--ipv4-fallback-enabled',
+          'Gem repository directory to get installed',
+          'gems') do |value, options|
+      Gem.configuration.ipv4_fallback_enabled = value
+    end
+
     add_option(:"Install/Update", '-i', '--install-dir DIR',
                'Gem repository directory to get installed',
                'gems') do |value, options|

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -6,7 +6,6 @@ require 'rubygems/s3_uri_signer'
 require 'rubygems/uri_formatter'
 require 'rubygems/uri_parsing'
 require 'rubygems/user_interaction'
-require 'rubygems/core_ext/tcpsocket_init'
 require 'resolv'
 
 ##
@@ -79,6 +78,7 @@ class Gem::RemoteFetcher
   #            fetching the gem.
 
   def initialize(proxy=nil, dns=nil, headers={})
+    require 'rubygems/core_ext/tcpsocket_init' if Gem.configuration.ipv4_fallback_enabled
     require 'net/http'
     require 'stringio'
     require 'uri'

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -6,6 +6,7 @@ require 'rubygems/s3_uri_signer'
 require 'rubygems/uri_formatter'
 require 'rubygems/uri_parsing'
 require 'rubygems/user_interaction'
+require 'rubygems/core_ext/tcpsocket_init'
 require 'resolv'
 
 ##

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -41,6 +41,7 @@ class TestGemConfigFile < Gem::TestCase
     assert_equal true, @cfg.verbose
     assert_equal [@gem_repo], Gem.sources
     assert_equal 365, @cfg.cert_expiration_length_days
+    assert_equal false, @cfg.ipv4_fallback_enabled
 
     File.open @temp_conf, 'w' do |fp|
       fp.puts ":backtrace: true"
@@ -56,6 +57,7 @@ class TestGemConfigFile < Gem::TestCase
       fp.puts ":ssl_verify_mode: 0"
       fp.puts ":ssl_ca_cert: /etc/ssl/certs"
       fp.puts ":cert_expiration_length_days: 28"
+      fp.puts ":ipv4_fallback_enabled: true"
     end
 
     util_config_file
@@ -70,6 +72,14 @@ class TestGemConfigFile < Gem::TestCase
     assert_equal 0, @cfg.ssl_verify_mode
     assert_equal '/etc/ssl/certs', @cfg.ssl_ca_cert
     assert_equal 28, @cfg.cert_expiration_length_days
+    assert_equal true, @cfg.ipv4_fallback_enabled
+  end
+
+  def test_initialize_ipv4_fallback_enabled_env
+    ENV['IPV4_FALLBACK_ENABLED'] = 'true'
+    util_config_file %W[--config-file #{@temp_conf}]
+
+    assert_equal true, @cfg.ipv4_fallback_enabled
   end
 
   def test_initialize_handle_arguments_config_file

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -962,6 +962,12 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     end
   end
 
+  def test_tcpsocketext_require
+    with_configured_fetcher(":ipv4_fallback_enabled: true") do |fetcher|
+      refute require('rubygems/core_ext/tcpsocket_init')
+    end
+  end
+
   def with_configured_fetcher(config_str = nil, &block)
     if config_str
       temp_conf = File.join @tempdir, '.gemrc'


### PR DESCRIPTION
# Description:

Multiple users have reported that IPv6 address of rubygems.org is
unreachable[[1](https://help.rubygems.org/discussions/problems/33671-suggestion-for-easy-solution-for-the-ipv6-related-timeout-problem)][[2](https://help.rubygems.org/discussions/problems/31074-timeout-error)]. We have verified using online tools[[3](https://www.ssllabs.com/ssltest/analyze.html?d=rubygems.org)][[4](https://ready.chair6.net/?url=rubygems.org)] as well
as all of aws regions with ipv6 support that there is no misconfig issue
on our part.
IPv6 route being broken is a bit expected and hence, RFC8305[[5](https://tools.ietf.org/html/rfc8305)]
recommends starting connection to both IPv4 and IPv6 address in parallel
and use whichever returns first (this is TLDR explanation, check RFC for
details). This patch of TCPSocket.initialize does something similar, as
in, it starts connection to all resolved IPs in parallel and uses first
successful connection's IP to initalize the TCPSocket. We use `Net:HTTP`
as our remote featcher and it internally uses TCPSocket.open[[6](https://github.com/ruby/ruby/blob/4444025d16ae1a586eee6a0ac9bdd09e33833f3c/lib/net/http.rb#L950)].

Even tho support of IPv6 fallback is spotty, I have open a ruby issue
for it[[7](https://bugs.ruby-lang.org/issues/15628)].

About test for this.. we would need to simulate a ipv6 broken route, only way I know of is using `ip6tables` and that needs `sudo`.

Fixes #3641.
Closes #3463.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
