### PR TITLE
Ignore to handle the different platform

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -71,8 +71,11 @@ class Gem::BasicSpecification
     elsif missing_extensions?
       @ignored = true
 
-      warn "Ignoring #{full_name} because its extensions are not built. " +
-        "Try: gem pristine #{name} --version #{version}"
+      if platform == RUBY_ENGINE
+        warn "Ignoring #{full_name} because its extensions are not built. " +
+          "Try: gem pristine #{name} --version #{version}"
+      end
+
       return false
     end
 

--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -71,7 +71,7 @@ class Gem::BasicSpecification
     elsif missing_extensions?
       @ignored = true
 
-      if platform == RUBY_ENGINE
+      if RUBY_ENGINE == platform || Gem::Platform.local === platform
         warn "Ignoring #{full_name} because its extensions are not built. " +
           "Try: gem pristine #{name} --version #{version}"
       end

--- a/lib/rubygems/commands/pristine_command.rb
+++ b/lib/rubygems/commands/pristine_command.rb
@@ -104,7 +104,7 @@ extensions will be restored.
               end.flatten
             end
 
-    specs = specs.select{|spec| spec.platform == RUBY_ENGINE }
+    specs = specs.select{|spec| RUBY_ENGINE == spec.platform || Gem::Platform.local === spec.platform }
 
     if specs.to_a.empty?
       raise Gem::Exception,

--- a/lib/rubygems/commands/pristine_command.rb
+++ b/lib/rubygems/commands/pristine_command.rb
@@ -104,6 +104,8 @@ extensions will be restored.
               end.flatten
             end
 
+    specs = specs.select{|spec| spec.platform == RUBY_ENGINE }
+
     if specs.to_a.empty?
       raise Gem::Exception,
             "Failed to find gems #{options[:args]} #{options[:version]}"

--- a/test/rubygems/test_gem_commands_pristine_command.rb
+++ b/test/rubygems/test_gem_commands_pristine_command.rb
@@ -542,8 +542,10 @@ class TestGemCommandsPristineCommand < Gem::TestCase
     @cmd.options[:extensions_set] = true
     @cmd.options[:args] = []
 
-    use_ui @ui do
-      @cmd.execute
+    util_set_arch "x86_64-darwin" do
+      use_ui @ui do
+        @cmd.execute
+      end
     end
 
     out = @ui.output.split "\n"

--- a/test/rubygems/test_gem_commands_pristine_command.rb
+++ b/test/rubygems/test_gem_commands_pristine_command.rb
@@ -514,6 +514,47 @@ class TestGemCommandsPristineCommand < Gem::TestCase
     assert_empty(@ui.error)
   end
 
+  def test_execute_multi_platform
+    a = util_spec 'a' do |s|
+      s.extensions << 'ext/a/extconf.rb'
+    end
+
+    b = util_spec 'b' do |s|
+      s.extensions << 'ext/a/extconf.rb'
+      s.platform = Gem::Platform.new("java")
+    end
+
+    ext_path = File.join @tempdir, 'ext', 'a', 'extconf.rb'
+    write_file ext_path do |io|
+      io.write <<-'RUBY'
+      File.open "Makefile", "w" do |f|
+        f.puts "clean:\n\techo cleaned\n"
+        f.puts "all:\n\techo built\n"
+        f.puts "install:\n\techo installed\n"
+      end
+      RUBY
+    end
+
+    install_gem a
+    install_gem b
+
+    @cmd.options[:extensions]     = true
+    @cmd.options[:extensions_set] = true
+    @cmd.options[:args] = []
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    out = @ui.output.split "\n"
+
+    assert_equal 'Restoring gems to pristine condition...', out.shift
+    assert_equal 'Building native extensions. This could take a while...',
+                 out.shift
+    assert_equal "Restored #{a.full_name}", out.shift
+    assert_empty out, out.inspect
+  end
+
   def test_handle_options
     @cmd.handle_options %w[]
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -6,6 +6,7 @@ require 'stringio'
 require 'rubygems/ext'
 require 'rubygems/specification'
 require 'rubygems/installer'
+require 'rubygems/platform'
 
 class TestGemSpecification < Gem::TestCase
 
@@ -59,12 +60,13 @@ end
     end
   end
 
-  def ext_spec
+  def ext_spec(platform: Gem::Platform::RUBY)
     @ext = util_spec 'ext', '1' do |s|
       s.executable = 'exec'
       s.test_file = 'test/suite.rb'
       s.extensions = %w[ext/extconf.rb]
       s.license = 'MIT'
+      s.platform = platform
 
       s.mark_version
       s.files = %w[lib/code.rb]
@@ -1671,6 +1673,16 @@ dependencies: []
                "Try: gem pristine ext --version 1\n"
 
     assert_equal expected, err
+  end
+
+  def test_contains_requirable_file_eh_extension
+    ext_spec(platform: Gem::Platform.new("java"))
+
+    _, err = capture_io do
+      refute @ext.contains_requirable_file? 'nonexistent'
+    end
+
+    assert_empty err
   end
 
   def test_date


### PR DESCRIPTION
# Description:

I set `GEM_HOME` to `~/.gem` and invoke `gem i jruby-launcher` with JRuby. After that, I swicthed CRuby and invoke `gem -v` or `gem pristine --extension`, I got the warnings and error message about `jruby-launcher`.

The current RubyGems do handle the extensions of different platform. It should be ignore or skip.
______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
