### PR TITLE
Check deprecated methods on release

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
   Exclude:
     - 'bundler/**/*'
     - 'lib/rubygems/resolver/molinillo/**/*'
+    - 'pkg/**/*'
   TargetRubyVersion: 2.3
 
 Layout/AccessModifierIndentation:

--- a/Rakefile
+++ b/Rakefile
@@ -86,8 +86,17 @@ end
 # --------------------------------------------------------------------
 # Creating a release
 
-task :prerelease => %w[clobber test bundler:build_metadata]
+task :prerelease => %w[clobber test bundler:build_metadata check_deprecations]
 task :postrelease => %w[bundler:build_metadata:clean upload guides:publish blog:publish]
+
+desc "Check for deprecated methods with expired deprecation horizon"
+task :check_deprecations do
+  if v.segments[1] == 0 && v.segments[2] == 0
+    sh("util/rubocop -r ./util/cops/deprecations --only Rubygems/Deprecations")
+  else
+    puts "Skipping deprecation checks since not releasing a major version."
+  end
+end
 
 desc "Release rubygems-#{v}"
 task :release => :prerelease do

--- a/util/cops/deprecations.rb
+++ b/util/cops/deprecations.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Rubygems
+      # This cop enforces that no outdated deprecations are present on RubyGems
+      # code base.
+      #
+      # @example
+      #
+      #   As of March, 2019
+      #
+      #   # bad
+      #   deprecate :safdfa, nil, 2018, 12
+      #   deprecate :safdfa, nil, 2019, 03
+      #
+      #   # good
+      #   deprecate :safdfa, nil, 2019, 04
+      #
+      class Deprecations < Cop
+
+        MSG = "Remove `deprecate` calls with dates in the past, along with " \
+          "the methods they deprecate, or expand the deprecation horizons to " \
+          "a future date"
+
+        def on_send(node)
+          _receiver, method_name, *args = *node
+          return unless method_name == :deprecate
+
+          scheduled_year = args[2].children.last
+          scheduled_month = args[3].children.last
+
+          current_time = Time.now
+
+          current_year = current_time.year
+          current_month = current_time.month
+
+          if current_year >= scheduled_year || (current_year == scheduled_year && current_month >= scheduled_month)
+            add_offense(node)
+          end
+        end
+
+        private
+
+        def message(node)
+          format(MSG, method: node.method_name)
+        end
+
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Description:

I noticed that we have a bunch of methods in the code base that were supposed to have been deprecated in December 2018, when rubygems 3 was released, but that didn't happen?

I'm not sure if it was intentional or not, but I figured we could have a release check that makes sure we either definitively remove the methods, or expand the deprecation horizon.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
