### PR TITLE
Fix metadata description docs

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -17,7 +17,7 @@ require 'rubygems/util/list'
 require 'stringio'
 
 ##
-# The Specification class contains the information for a Gem.  Typically
+# The Specification class contains the information for a gem.  Typically
 # defined in a .gemspec file or a Rakefile, and looks like this:
 #
 #   Gem::Specification.new do |s|
@@ -363,8 +363,7 @@ class Gem::Specification < Gem::BasicSpecification
 
   ##
   # The metadata holds extra data for this gem that may be useful to other
-  # consumers and is settable by gem authors without requiring an update to
-  # the rubygems software.
+  # consumers and is settable by gem authors.
   #
   # Metadata items have the following restrictions:
   #


### PR DESCRIPTION


# Description:

> settable by gem authors without requiring an update to the rubygems software.

this has never been true. Not sure why it said that.
Using G in the gem is converting it to link on using `rake spec_guide` ([broken here](https://github.com/rubygems/guides/commit/2ca58b0a29791567d3e997bf3c5c7ebb73b54364#diff-a0ed24268b853e4412f766326125de00L12)).

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
