### PR TITLE
Removed circular require

### DIFF
--- a/lib/rubygems/text.rb
+++ b/lib/rubygems/text.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'rubygems'
 
 ##
 # A collection of text-wrangling methods


### PR DESCRIPTION
# Description:
rubygems/text.rb requires rubygems.rb but also is required by rubygems.rb via rubygems/user_interaction.rb.
It doesn't make sense to require rubygems/text.rb alone, `require` in it seems useless.
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).