### PR TITLE
Skip temporary "No such host is known" error

### DIFF
--- a/test/rubygems/test_bundled_ca.rb
+++ b/test/rubygems/test_bundled_ca.rb
@@ -37,7 +37,7 @@ if ENV["CI"] || ENV["TEST_SSL"]
       http.verify_mode = OpenSSL::SSL::VERIFY_PEER
       http.cert_store = bundled_certificate_store
       http.get('/')
-    rescue Errno::ENOENT, Errno::ETIMEDOUT
+    rescue Errno::ENOENT, Errno::ETIMEDOUT, SocketError
       skip "#{host} seems offline, I can't tell whether ssl would work."
     rescue OpenSSL::SSL::SSLError => e
       # Only fail for certificate verification errors


### PR DESCRIPTION
# Description:
I've seen fastly domains temporarily get "getaddrinfo: No such host is known" on Ruby's CI like https://ci.appveyor.com/project/ruby/ruby/builds/23089959/job/wjm0jgvqljn35pu3 many times. The `SocketError` is not detecting Ruby or RubyGems' bugs, so it's just harmful for productivity to make CI fail on `SocketError`.
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
