### PR TITLE
Replaced aws-sdk-s3 instead of s3cmd.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -150,7 +150,7 @@ task :upload_to_s3 do
 
   s3 = Aws::S3::Resource.new(region:'us-west-2')
   %w[zip tgz].each do |ext|
-    obj = s3.bucket('production').object("rubygems/rubygems-#{v}.#{ext}")
+    obj = s3.bucket('oregon.production.s3.rubygems.org').object("rubygems/rubygems-#{v}.#{ext}")
     obj.upload_file("pkg/rubygems-#{v}.#{ext}")
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -142,7 +142,17 @@ end
 
 desc "Upload release to S3"
 task :upload_to_s3 do
-  sh "s3cmd put -P pkg/rubygems-#{v}.zip pkg/rubygems-#{v}.tgz s3://oregon.production.s3.rubygems.org/rubygems/"
+  begin
+    require "aws-sdk-s3"
+  rescue LoadError
+    abort "Install the aws-sdk-s3 gem to be able to upload gems to rubygems.org."
+  end
+
+  s3 = Aws::S3::Resource.new(region:'us-west-2')
+  %w[zip tgz].each do |ext|
+    obj = s3.bucket('production').object("rubygems/rubygems-#{v}.#{ext}")
+    obj.upload_file("pkg/rubygems-#{v}.#{ext}")
+  end
 end
 
 desc "Upload release to rubygems.org"


### PR DESCRIPTION
# Description:

We should avoid to use external tool like `s3cmd`. I replaced it to pure ruby code with `aws-sdk-s3`.

@dwradcliffe Can you confirm bucket name and path of S3? I used `production` as bucket name and `rubygems` as full-path of S3. But I'm not sure they are correct variables. 
______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
