### PR TITLE
Use CI fix in bundler's master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
     - stage: test
       rvm: 2.6.1
       env:
-        - "TEST_TOOL=bundler RGV=master BDV=master"
+        - "TEST_TOOL=bundler RGV=.. BDV=master"
 stages:
   - linting
   - test


### PR DESCRIPTION
# Description:

So that PRs get tested against the checked out rubygems copy instead of rubygems master.

Note that we can only do this on the bundler master build, because the required changes are not available in the vendored copy of bundler. I think that's good enough for now.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
