### PR TITLE
Forbid `find_spec_for_exe` without an `exec_name`

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -253,8 +253,6 @@ module Gem
     # TODO: fails test_self_bin_path_bin_file_gone_in_latest
     # Gem::Specification.find_by_name(name, *requirements).bin_file exec_name
 
-    raise ArgumentError, "you must supply exec_name" unless exec_name
-
     requirements = Gem::Requirement.default if
       requirements.empty?
 
@@ -262,6 +260,8 @@ module Gem
   end
 
   def self.find_spec_for_exe(name, exec_name, requirements)
+    raise ArgumentError, "you must supply exec_name" unless exec_name
+
     dep = Gem::Dependency.new name, requirements
 
     loaded = Gem.loaded_specs[name]
@@ -297,8 +297,8 @@ module Gem
   #
   # This method should *only* be used in bin stub files.
 
-  def self.activate_bin_path(name, exec_name, requirement) # :nodoc:
-    spec = find_spec_for_exe name, exec_name, [requirement]
+  def self.activate_bin_path(name, exec_name = nil, *requirements) # :nodoc:
+    spec = find_spec_for_exe name, exec_name, requirements
     Gem::LOADED_SPECS_MUTEX.synchronize do
       spec.activate
       finish_resolve

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -267,6 +267,14 @@ class TestGem < Gem::TestCase
     assert_match 'a-2/bin/exec', Gem.bin_path('a', 'exec', '>= 0')
   end
 
+  def test_self_activate_bin_path_no_exec_name
+    e = assert_raises ArgumentError do
+      Gem.activate_bin_path 'a'
+    end
+
+    assert_equal 'you must supply exec_name', e.message
+  end
+
   def test_activate_bin_path_resolves_eagerly
     a1 = util_spec 'a', '1' do |s|
       s.executables = ['exec']

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -53,7 +53,6 @@ gems:
     homepage: http://rake.rubyforge.org
     description: Rake is a Make-like program implemented in Ruby. Tasks and dependencies are specified in standard Ruby syntax.
     autorequire:
-    default_executable: rake
     bindir: bin
     has_rdoc: true
     required_ruby_version: !ruby/object:Gem::Version::Requirement


### PR DESCRIPTION
# Description:

With this we can make `Gem.bin_path` and `Gem.activate_bin_path` behave exactly the same regarding this parameter, and it allows us to simplify bundler's integration since the current version handles the case where no executable is passed, defaulting to `Gem::Specification.default_executable` in that case, which is a deprecated rubygems method anyways.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
