### PR TITLE
Unswallow uninstall error

### DIFF
--- a/lib/rubygems/commands/uninstall_command.rb
+++ b/lib/rubygems/commands/uninstall_command.rb
@@ -180,8 +180,6 @@ that is a dependency of an existing gem.  You can use the
 
   def uninstall_gem(gem_name)
     uninstall(gem_name)
-  rescue Gem::InstallError
-    nil
   rescue Gem::GemNotInHomeException => e
     spec = e.spec
     alert("In order to remove #{spec.name}, please execute:\n" +

--- a/test/rubygems/test_gem_commands_uninstall_command.rb
+++ b/test/rubygems/test_gem_commands_uninstall_command.rb
@@ -307,7 +307,7 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
     gemhome2 = "#{@gemhome}2"
 
     a_4, = util_gem 'a', 4
-    install_gem a_4, :install_dir => gemhome2
+    install_gem a_4
 
     Gem::Specification.dirs = [@gemhome, gemhome2]
 
@@ -323,6 +323,29 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
     end
 
     assert_equal %w[default-1], Gem::Specification.all_names.sort
+  end
+
+  def test_execute_outside_gem_home
+    ui = Gem::MockGemUi.new "y\n"
+
+    gemhome2 = "#{@gemhome}2"
+
+    a_4, = util_gem 'a', 4
+    install_gem a_4 , :install_dir => gemhome2
+
+    Gem::Specification.dirs = [@gemhome, gemhome2]
+
+    assert_includes Gem::Specification.all_names, 'a-4'
+
+    @cmd.options[:args] = ['a:4']
+
+    e = assert_raises Gem::InstallError do
+      use_ui ui do
+        @cmd.execute
+      end
+    end
+
+    assert_includes e.message, "a is not installed in GEM_HOME"
   end
 
   def test_handle_options


### PR DESCRIPTION
# Description:

Sometimes `gem uninstall <gem_name>` fails to uninstall the gem, but does not give any errors. See #2701.

This error swallowing seems intentionally introduced specifically for the `--all` option in https://github.com/rubygems/rubygems/commit/564ffe277b7604304794b1eb008fe6e6d107743b, but I don't think this is good. In that case, `--all` is leaving gems around so the user should be informed too?

Maybe `gem uninstall` should try all paths in `GEM_PATH` instead?

Not sure, but the current behavior is no good.


# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
