### PR TITLE
Fix flaky

### DIFF
--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -383,8 +383,6 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
 
     Gem.searcher = nil
     Gem::SpecFetcher.fetcher = nil
-    @orig_BASERUBY = RbConfig::CONFIG['BASERUBY']
-    RbConfig::CONFIG['BASERUBY'] = RbConfig::CONFIG['ruby_install_name']
 
     @orig_arch = RbConfig::CONFIG['arch']
 
@@ -422,11 +420,6 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
       end
     end
 
-    if @orig_BASERUBY
-      RbConfig::CONFIG['BASERUBY'] = @orig_BASERUBY
-    else
-      RbConfig::CONFIG.delete('BASERUBY')
-    end
     RbConfig::CONFIG['arch'] = @orig_arch
 
     if defined? Gem::RemoteFetcher

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1908,7 +1908,7 @@ You may need to `gem install -g` to install missing gems
 
     yield
   ensure
-    Gem.instance_variable_set("@ruby", orig_ruby)
+    Gem.instance_variable_set :@ruby, orig_ruby
   end
 
   def with_plugin(path)

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -954,9 +954,9 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_ruby_escaping_spaces_in_path
-    with_bindir_and_exeext("C:/Ruby 1.8/bin", ".exe") do
-      ruby_install_name "ruby" do
-        with_clean_path_to_ruby do
+    with_clean_path_to_ruby do
+      with_bindir_and_exeext("C:/Ruby 1.8/bin", ".exe") do
+        ruby_install_name "ruby" do
           assert_equal "\"C:/Ruby 1.8/bin/ruby.exe\"", Gem.ruby
         end
       end
@@ -964,9 +964,9 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_ruby_path_without_spaces
-    with_bindir_and_exeext("C:/Ruby18/bin", ".exe") do
-      ruby_install_name "ruby" do
-        with_clean_path_to_ruby do
+    with_clean_path_to_ruby do
+      with_bindir_and_exeext("C:/Ruby18/bin", ".exe") do
+        ruby_install_name "ruby" do
           assert_equal "C:/Ruby18/bin/ruby.exe", Gem.ruby
         end
       end

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -954,37 +954,23 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_ruby_escaping_spaces_in_path
-    orig_bindir = RbConfig::CONFIG['bindir']
-    orig_exe_ext = RbConfig::CONFIG['EXEEXT']
-
-    RbConfig::CONFIG['bindir'] = "C:/Ruby 1.8/bin"
-    RbConfig::CONFIG['EXEEXT'] = ".exe"
-
-    ruby_install_name "ruby" do
-      with_clean_path_to_ruby do
-        assert_equal "\"C:/Ruby 1.8/bin/ruby.exe\"", Gem.ruby
+    with_bindir_and_exeext("C:/Ruby 1.8/bin", ".exe") do
+      ruby_install_name "ruby" do
+        with_clean_path_to_ruby do
+          assert_equal "\"C:/Ruby 1.8/bin/ruby.exe\"", Gem.ruby
+        end
       end
     end
-  ensure
-    RbConfig::CONFIG['bindir'] = orig_bindir
-    RbConfig::CONFIG['EXEEXT'] = orig_exe_ext
   end
 
   def test_self_ruby_path_without_spaces
-    orig_bindir = RbConfig::CONFIG['bindir']
-    orig_exe_ext = RbConfig::CONFIG['EXEEXT']
-
-    RbConfig::CONFIG['bindir'] = "C:/Ruby18/bin"
-    RbConfig::CONFIG['EXEEXT'] = ".exe"
-
-    ruby_install_name "ruby" do
-      with_clean_path_to_ruby do
-        assert_equal "C:/Ruby18/bin/ruby.exe", Gem.ruby
+    with_bindir_and_exeext("C:/Ruby18/bin", ".exe") do
+      ruby_install_name "ruby" do
+        with_clean_path_to_ruby do
+          assert_equal "C:/Ruby18/bin/ruby.exe", Gem.ruby
+        end
       end
     end
-  ensure
-    RbConfig::CONFIG['bindir'] = orig_bindir
-    RbConfig::CONFIG['EXEEXT'] = orig_exe_ext
   end
 
   def test_self_ruby_api_version
@@ -1900,6 +1886,19 @@ You may need to `gem install -g` to install missing gems
     else
       RbConfig::CONFIG.delete 'ruby_install_name'
     end
+  end
+
+  def with_bindir_and_exeext(bindir, exeext)
+    orig_bindir = RbConfig::CONFIG['bindir']
+    orig_exe_ext = RbConfig::CONFIG['EXEEXT']
+
+    RbConfig::CONFIG['bindir'] = bindir
+    RbConfig::CONFIG['EXEEXT'] = exeext
+
+    yield
+  ensure
+    RbConfig::CONFIG['bindir'] = orig_bindir
+    RbConfig::CONFIG['EXEEXT'] = orig_exe_ext
   end
 
   def with_clean_path_to_ruby


### PR DESCRIPTION
# Description:

Fixes #2708.

The problem was that `Gem.ruby` was trying to be reset by saving its original value before the test, but that was happening after it had already been changed. So the leaked value would stay.

The failure is reproducible with

` rake TESTOPTS="--name=/self_ruby_path_without\|looks_for_gemdeps_files_automatically_on_start_in/"`

The PR includes other cleanups that I introduced while debugging.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
