### PR TITLE
Do not prompt for passphrase when key can be loaded without it

### DIFF
--- a/lib/rubygems/security/signer.rb
+++ b/lib/rubygems/security/signer.rb
@@ -143,6 +143,8 @@ class Gem::Security::Signer
     raise Gem::Security::Exception, 'no certs provided' if @cert_chain.empty?
 
     if @cert_chain.length == 1 and @cert_chain.last.not_after < Time.now
+      alert("Your certificate has expired, trying to re-sign it...")
+
       re_sign_key(
         expiration_length: (Gem::Security::ONE_DAY * options[:expiration_length_days])
       )

--- a/lib/rubygems/security/signer.rb
+++ b/lib/rubygems/security/signer.rb
@@ -85,7 +85,6 @@ class Gem::Security::Signer
     @digest_name      = Gem::Security::DIGEST_NAME
 
     if @key && !@key.is_a?(OpenSSL::PKey::RSA)
-      @passphrase ||= ask_for_password("Enter PEM pass phrase:")
       @key = OpenSSL::PKey::RSA.new(File.read(@key), @passphrase)
     end
 


### PR DESCRIPTION
# Description:
closes https://github.com/rubygems/rubygems/issues/2660

in https://github.com/rubygems/rubygems/pull/2380/files#diff-b1c96c3380adfe196cce915be6689f16R56 i introduced a custom prompt for a key passphrase to avoid  asking the passphrase twice when auto re-signing a cert in https://github.com/rubygems/rubygems/pull/2380/files#diff-b1c96c3380adfe196cce915be6689f16R147 
but that leads to the prompt being triggered even if a key has no passphrase as  https://github.com/rubygems/rubygems/issues/2660 described.

This PR reverts that... now if a key doesn't need a passphrase it will not be triggered as it used before, but at the cost of asking for the passphrase twice if a key needs to be re-signed.

I added another alert message in between prompts to try to make things clear and not confuse the user when asked for passphrase twice if the key needs to be resigned when building a gem re-signed

______________
I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
