### PR TITLE
Let `@@stubs_by_name` to be incrementally populated again.

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -830,8 +830,8 @@ class Gem::Specification < Gem::BasicSpecification
   # only returns stubs that match Gem.platforms
 
   def self.stubs_for(name)
-    if @@stubs
-      @@stubs_by_name[name] || []
+    if @@stubs_by_name[name]
+      @@stubs_by_name[name]
     else
       pattern = "#{name}-*.gemspec"
       stubs = Gem.loaded_specs.values +

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1193,6 +1193,11 @@ dependencies: []
     assert_equal ['b-1'], Gem::Specification.stubs_for('b').map { |s| s.full_name }
     assert_equal 2, Gem::Specification.class_variable_get(:@@stubs_by_name).length
 
+    assert_equal(
+      Gem::Specification.stubs_for('a').map { |s| s.object_id },
+      Gem::Specification.stubs_for('a').map { |s| s.object_id }
+    )
+
     Gem.loaded_specs.delete 'a'
     Gem.loaded_specs.delete 'b'
     Gem::Specification.class_variable_set(:@@stubs, nil)

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1179,6 +1179,25 @@ dependencies: []
     Gem::Specification.class_variable_set(:@@stubs, nil)
   end
 
+  def test_self_stubs_for_lazy_loading
+    Gem.loaded_specs.clear
+    Gem::Specification.class_variable_set(:@@stubs, nil)
+
+    dir_standard_specs = File.join Gem.dir, 'specifications'
+
+    save_gemspec('a-1', '1', dir_standard_specs){|s| s.name = 'a' }
+    save_gemspec('b-1', '1', dir_standard_specs){|s| s.name = 'b' }
+
+    assert_equal ['a-1'], Gem::Specification.stubs_for('a').map { |s| s.full_name }
+    assert_equal 1, Gem::Specification.class_variable_get(:@@stubs_by_name).length
+    assert_equal ['b-1'], Gem::Specification.stubs_for('b').map { |s| s.full_name }
+    assert_equal 2, Gem::Specification.class_variable_get(:@@stubs_by_name).length
+
+    Gem.loaded_specs.delete 'a'
+    Gem.loaded_specs.delete 'b'
+    Gem::Specification.class_variable_set(:@@stubs, nil)
+  end
+
   def test_self_stubs_for_mult_platforms
     # gems for two different platforms are installed with --user-install
     # the correct one should be returned in the array


### PR DESCRIPTION
Originally, the call to `.stubs_for` allowed to incrementally populate the `@@stubs_by_name` (especially see the `"#{name}-*.gemspec"` pattern in 4fa03bb7aac9f25f44394e818433fdda9962ae8d). Now it looks like it expects that all stubs are loaded, but the `.stubs_for` still matches the .gemspec files by the `name` pattern:

https://github.com/rubygems/rubygems/blob/6d45e0f7ac1caca22900e39f703e226c4cfdebf7/lib/rubygems/specification.rb#L845

I think this was done by mistake incrementally by PR #1239 and 4cee8ca9199ac7b3ab8647e0b78615f55d3eb02b. I think the best option is to get back to the original implementation, to let RubyGems incrementally populate the array. Other option would be to replace the logic in `.stub_for` by call to `.stubs`, but the means the performance improvement from the original commit was lost.

@tenderlove @segiddins WDYT?

BTW it would be nice if the PRs and commit messages gave more explanation why they were done. Now it is just guesswork what was the intention.