### PR TITLE
Removed guard condition with USE_BUNDLER_FOR_GEMDEPS.

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -174,8 +174,6 @@ module Gem
     write_binary_errors
   end.freeze
 
-  USE_BUNDLER_FOR_GEMDEPS = !ENV['DONT_USE_BUNDLER_FOR_GEMDEPS'] # :nodoc:
-
   @@win_platform = nil
 
   @configuration = nil
@@ -1183,27 +1181,15 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
       raise ArgumentError, "Unable to find gem dependencies file at #{path}"
     end
 
-    if USE_BUNDLER_FOR_GEMDEPS
-
-      ENV["BUNDLE_GEMFILE"] ||= File.expand_path(path)
-      require 'rubygems/user_interaction'
-      Gem::DefaultUserInteraction.use_ui(ui) do
-        require "bundler"
-        @gemdeps = Bundler.setup
-        Bundler.ui = nil
-        @gemdeps.requested_specs.map(&:to_spec).sort_by(&:name)
-      end
-
-    else
-
-      rs = Gem::RequestSet.new
-      @gemdeps = rs.load_gemdeps path
-
-      rs.resolve_current.map do |s|
-        s.full_spec.tap(&:activate)
-      end
-
+    ENV["BUNDLE_GEMFILE"] ||= File.expand_path(path)
+    require 'rubygems/user_interaction'
+    Gem::DefaultUserInteraction.use_ui(ui) do
+      require "bundler"
+      @gemdeps = Bundler.setup
+      Bundler.ui = nil
+      @gemdeps.requested_specs.map(&:to_spec).sort_by(&:name)
     end
+
   rescue => e
     case e
     when Gem::LoadError, Gem::UnsatisfiableDependencyError, (defined?(Bundler::GemNotFound) ? Bundler::GemNotFound : Gem::LoadError)

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -319,7 +319,7 @@ By default, this RubyGems will install gem as:
 
   def install_lib(lib_dir)
     libs = { 'RubyGems' => 'lib' }
-    libs['Bundler'] = 'bundler/lib' if Gem::USE_BUNDLER_FOR_GEMDEPS
+    libs['Bundler'] = 'bundler/lib'
     libs.each do |tool, path|
       say "Installing #{tool}" if @verbose
 
@@ -382,7 +382,6 @@ By default, this RubyGems will install gem as:
   end
 
   def install_default_bundler_gem(bin_dir)
-    return unless Gem::USE_BUNDLER_FOR_GEMDEPS
 
     specs_dir = Gem::Specification.default_specifications_dir
     specs_dir = File.join(options[:destdir], specs_dir) unless Gem.win_platform?
@@ -544,7 +543,7 @@ abort "#{deprecation_message}"
 
   def remove_old_lib_files(lib_dir)
     lib_dirs = { File.join(lib_dir, 'rubygems') => 'lib/rubygems' }
-    lib_dirs[File.join(lib_dir, 'bundler')] = 'bundler/lib/bundler' if Gem::USE_BUNDLER_FOR_GEMDEPS
+    lib_dirs[File.join(lib_dir, 'bundler')] = 'bundler/lib/bundler'
     lib_dirs.each do |old_lib_dir, new_lib_dir|
       lib_files = rb_files_in(new_lib_dir)
       lib_files.concat(template_files_in(new_lib_dir)) if new_lib_dir =~ /bundler/

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -382,7 +382,6 @@ By default, this RubyGems will install gem as:
   end
 
   def install_default_bundler_gem(bin_dir)
-
     specs_dir = Gem::Specification.default_specifications_dir
     specs_dir = File.join(options[:destdir], specs_dir) unless Gem.win_platform?
     mkdir_p specs_dir, :mode => 0755

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -38,9 +38,8 @@ unless Gem::Dependency.new('rdoc', '>= 3.10').matching_specs.empty?
   gem 'json'
 end
 
-if Gem::USE_BUNDLER_FOR_GEMDEPS
-  require 'bundler'
-end
+require 'bundler'
+
 require 'minitest/autorun'
 
 require 'rubygems/deprecate'
@@ -261,9 +260,8 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
     @current_dir = Dir.pwd
     @fetcher     = nil
 
-    if Gem::USE_BUNDLER_FOR_GEMDEPS
-      Bundler.ui = Bundler::UI::Silent.new
-    end
+    Bundler.ui = Bundler::UI::Silent.new
+
     @back_ui                       = Gem::DefaultUserInteraction.ui
     @ui                            = Gem::MockGemUi.new
     # This needs to be a new instance since we call use_ui(@ui) when we want to
@@ -368,9 +366,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
     Gem.loaded_specs.clear
     Gem.clear_default_specs
     Gem::Specification.unresolved_deps.clear
-    if Gem::USE_BUNDLER_FOR_GEMDEPS
-      Bundler.reset!
-    end
+    Bundler.reset!
 
     Gem.configuration.verbose = true
     Gem.configuration.update_sources = true

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1548,19 +1548,15 @@ class TestGem < Gem::TestCase
 
     ENV['RUBYGEMS_GEMDEPS'] = "-"
 
-    expected_specs = [a, b, (Gem::USE_BUNDLER_FOR_GEMDEPS || nil) && util_spec("bundler", Bundler::VERSION), c].compact
+    expected_specs = [a, b, util_spec("bundler", Bundler::VERSION), c].compact
     assert_equal expected_specs, Gem.use_gemdeps.sort_by { |s| s.name }
   end
 
   LIB_PATH = File.expand_path "../../../lib".dup.untaint, __FILE__.dup.untaint
-
-  if Gem::USE_BUNDLER_FOR_GEMDEPS
-    BUNDLER_LIB_PATH = File.expand_path $LOAD_PATH.find {|lp| File.file?(File.join(lp, "bundler.rb")) }.dup.untaint
-    BUNDLER_FULL_NAME = "bundler-#{Bundler::VERSION}".freeze
-  end
+  BUNDLER_LIB_PATH = File.expand_path $LOAD_PATH.find {|lp| File.file?(File.join(lp, "bundler.rb")) }.dup.untaint
+  BUNDLER_FULL_NAME = "bundler-#{Bundler::VERSION}".freeze
 
   def add_bundler_full_name(names)
-    return names unless Gem::USE_BUNDLER_FOR_GEMDEPS
     names << BUNDLER_FULL_NAME
     names.sort!
     names
@@ -1600,7 +1596,7 @@ class TestGem < Gem::TestCase
     out = IO.popen(cmd, &:read).split(/\n/)
 
     assert_equal ["b-1", "c-1"], out - out0
-  end if Gem::USE_BUNDLER_FOR_GEMDEPS
+  end
 
   def test_looks_for_gemdeps_files_automatically_on_start_in_parent_dir
     util_clear_gems
@@ -1640,7 +1636,7 @@ class TestGem < Gem::TestCase
     Dir.rmdir "sub1"
 
     assert_equal ["b-1", "c-1"], out - out0
-  end if Gem::USE_BUNDLER_FOR_GEMDEPS
+  end
 
   def test_register_default_spec
     Gem.clear_default_specs
@@ -1819,27 +1815,19 @@ class TestGem < Gem::TestCase
     else
       platform = " #{platform}"
     end
-    expected =
-      if Gem::USE_BUNDLER_FOR_GEMDEPS
-        <<-EXPECTED
+
+    expected = <<-EXPECTED
 Could not find gem 'a#{platform}' in any of the gem sources listed in your Gemfile.
 You may need to `gem install -g` to install missing gems
 
-        EXPECTED
-      else
-        <<-EXPECTED
-Unable to resolve dependency: user requested 'a (>= 0)'
-You may need to `gem install -g` to install missing gems
-
-        EXPECTED
-      end
+    EXPECTED
 
     assert_output nil, expected do
       Gem.use_gemdeps
     end
   ensure
     ENV['RUBYGEMS_GEMDEPS'] = rubygems_gemdeps
-  end if Gem::USE_BUNDLER_FOR_GEMDEPS
+  end
 
   def test_use_gemdeps_specific
     rubygems_gemdeps, ENV['RUBYGEMS_GEMDEPS'] = ENV['RUBYGEMS_GEMDEPS'], 'x'

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -135,24 +135,17 @@ class TestGemCommandsSetupCommand < Gem::TestCase
 
     gem_exec = sprintf Gem.default_exec_format, 'gem'
     default_gem_bin_path = File.join @install_dir, 'bin', gem_exec
-    if Gem::USE_BUNDLER_FOR_GEMDEPS
-      bundle_exec = sprintf Gem.default_exec_format, 'bundle'
-      default_bundle_bin_path = File.join @install_dir, 'bin', bundle_exec
-    end
-
+    bundle_exec = sprintf Gem.default_exec_format, 'bundle'
+    default_bundle_bin_path = File.join @install_dir, 'bin', bundle_exec
     ruby_exec = sprintf Gem.default_exec_format, 'ruby'
 
     if Gem.win_platform?
       assert_match %r%\A#!\s*#{ruby_exec}%, File.read(default_gem_bin_path)
-      if Gem::USE_BUNDLER_FOR_GEMDEPS
-        assert_match %r%\A#!\s*#{ruby_exec}%, File.read(default_bundle_bin_path)
-      end
+      assert_match %r%\A#!\s*#{ruby_exec}%, File.read(default_bundle_bin_path)
       assert_match %r%\A#!\s*#{ruby_exec}%, File.read(gem_bin_path)
     else
       assert_match %r%\A#!/usr/bin/env #{ruby_exec}%, File.read(default_gem_bin_path)
-      if Gem::USE_BUNDLER_FOR_GEMDEPS
-        assert_match %r%\A#!/usr/bin/env #{ruby_exec}%, File.read(default_bundle_bin_path)
-      end
+      assert_match %r%\A#!/usr/bin/env #{ruby_exec}%, File.read(default_bundle_bin_path)
       assert_match %r%\A#!/usr/bin/env #{ruby_exec}%, File.read(gem_bin_path)
     end
   end
@@ -176,10 +169,8 @@ class TestGemCommandsSetupCommand < Gem::TestCase
       assert_path_exists File.join(dir, 'rubygems.rb')
       assert_path_exists File.join(dir, 'rubygems/ssl_certs/rubygems.org/foo.pem')
 
-      if Gem::USE_BUNDLER_FOR_GEMDEPS
-        assert_path_exists File.join(dir, 'bundler.rb')
-        assert_path_exists File.join(dir, 'bundler/b.rb')
-      end
+      assert_path_exists File.join(dir, 'bundler.rb')
+      assert_path_exists File.join(dir, 'bundler/b.rb')
     end
   end
 
@@ -223,7 +214,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
 
     # expect to not remove bundler-* direcotyr.
     assert_path_exists 'default/gems/bundler-audit-1.0.0'
-  end if Gem::USE_BUNDLER_FOR_GEMDEPS
+  end
 
   def test_remove_old_lib_files
     lib                   = File.join @install_dir, 'lib'
@@ -271,7 +262,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
 
     refute_path_exists old_builder_rb
     refute_path_exists old_format_rb
-    refute_path_exists old_bundler_c_rb if Gem::USE_BUNDLER_FOR_GEMDEPS
+    refute_path_exists old_bundler_c_rb
 
     assert_path_exists securerandom_rb
     assert_path_exists engine_defaults_rb


### PR DESCRIPTION
# Description:

Ruby 2.6+ has RubyGems and Bundler with the standard libraries. We can always activate Bundler in RubyGems now.

______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
