### PR TITLE
Skip deprecation warning during specs

### DIFF
--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1724,7 +1724,9 @@ gem 'other', version
 
     dest = File.join @gemhome, 'gems', @spec.full_name
 
-    @installer.unpack dest
+    Gem::Deprecate.skip_during do
+      @installer.unpack dest
+    end
 
     assert_path_exists File.join dest, 'lib', 'code.rb'
     assert_path_exists File.join dest, 'bin', 'executable'


### PR DESCRIPTION
# Description:

Since #2715, specs print a deprecation warning "NOTE: Gem::Installer#unpack is deprecated with no replacement. It will be removed on or after 2020-04-01.
Gem::Installer#unpack called from /home/deivid/Code/rubygems/test/rubygems/test_gem_installer.rb:1727."

This PR skips that during the spec run.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
