### PR TITLE
Remove QuickLoader reference

### DIFF
--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 # TODO: $SAFE = 1
 
-if defined? Gem::QuickLoader
-  Gem::QuickLoader.load_full_rubygems_library
-else
-  require 'rubygems'
-end
+require 'rubygems'
 
 # If bundler gemspec exists, add to stubs
 bundler_gemspec = File.expand_path("../../../bundler/bundler.gemspec", __FILE__)


### PR DESCRIPTION

# Description:

This module was removed from ruby [before the Ruby 1.9.3 release](https://github.com/ruby/ruby/commit/f52c2cc24d1070f1997921c1d870cdd55327ba2a).

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
