### PR TITLE
Allow uninstall from symlinked GEM_HOME

### DIFF
--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -46,7 +46,7 @@ class Gem::Uninstaller
     # TODO document the valid options
     @gem                = gem
     @version            = options[:version] || Gem::Requirement.default
-    @gem_home           = File.expand_path(options[:install_dir] || Gem.dir)
+    @gem_home           = File.realpath(options[:install_dir] || Gem.dir)
     @force_executables  = options[:executables]
     @force_all          = options[:all]
     @force_ignore       = options[:ignore]

--- a/test/rubygems/test_gem_uninstaller.rb
+++ b/test/rubygems/test_gem_uninstaller.rb
@@ -22,9 +22,10 @@ class TestGemUninstaller < Gem::InstallerTestCase
   end
 
   def test_initialize_expand_path
-    uninstaller = Gem::Uninstaller.new nil, :install_dir => '/foo//bar'
+    FileUtils.mkdir_p 'foo/bar'
+    uninstaller = Gem::Uninstaller.new nil, :install_dir => 'foo//bar'
 
-    assert_match %r|/foo/bar$|, uninstaller.instance_variable_get(:@gem_home)
+    assert_match %r|foo/bar$|, uninstaller.instance_variable_get(:@gem_home)
   end
 
   def test_ask_if_ok
@@ -133,6 +134,7 @@ class TestGemUninstaller < Gem::InstallerTestCase
   end
 
   def test_remove_not_in_home
+    Dir.mkdir "#{@gemhome}2"
     uninstaller = Gem::Uninstaller.new nil, :install_dir => "#{@gemhome}2"
 
     e = assert_raises Gem::GemNotInHomeException do
@@ -147,6 +149,22 @@ class TestGemUninstaller < Gem::InstallerTestCase
     assert_equal expected, e.message
 
     assert_path_exists @spec.gem_dir
+  end
+
+  def test_remove_symlinked_gem_home
+    Dir.mktmpdir("gem_home") do |dir|
+      symlinked_gem_home = "#{dir}/#{File.basename(@gemhome)}"
+
+      FileUtils.ln_s(@gemhome, dir)
+
+      uninstaller = Gem::Uninstaller.new nil, :install_dir => symlinked_gem_home
+
+      use_ui ui do
+        uninstaller.remove @spec
+      end
+
+      refute_path_exists @spec.gem_dir
+    end
   end
 
   def test_path_ok_eh
@@ -313,6 +331,7 @@ create_makefile '#{@spec.name}'
   end
 
   def test_uninstall_wrong_repo
+    Dir.mkdir "#{@gemhome}2"
     Gem.use_paths "#{@gemhome}2", [@gemhome]
 
     uninstaller = Gem::Uninstaller.new @spec.name, :executables => true


### PR DESCRIPTION
# Description:

Currently, if GEM_HOME is a symlink (for example, in rvm's ruby-head), `gem uninstall` fails. I hope to fix that in this PR.

Fixes #2705.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
