### PR TITLE
Test ruby-head against bundler's master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,18 +15,21 @@ rvm:
   - 2.4.5
   - 2.5.5
   - 2.6.2
-  - ruby-head
 jobs:
   include:
     - stage: linting
       rvm: 2.6.2
-      env:
-        - "TEST_TOOL=rubygems"
+      env: "TEST_TOOL=rubygems"
       script: util/ci rubocop
     - stage: test
       rvm: 2.6.2
-      env:
-        - "TEST_TOOL=bundler RGV=.. BDV=master"
+      env: "TEST_TOOL=bundler RGV=.. BDV=master"
+    - stage: test
+      rvm: ruby-head
+      env: "TEST_TOOL=rubygems"
+    - stage: test
+      rvm: ruby-head
+      env: "TEST_TOOL=bundler RGV=.. BDV=master"
 stages:
   - linting
   - test
@@ -39,4 +42,4 @@ matrix:
     - rvm: ruby-head
       env: "TEST_TOOL=rubygems"
     - rvm: ruby-head
-      env: "TEST_TOOL=bundler RGV=master"
+      env: "TEST_TOOL=bundler RGV=.. BDV=master"


### PR DESCRIPTION
# Description:

I'd like to get our ruby-head build green. The current failure of bundler's build is fixed on bundler's master. To pick up this fix, I'd like to change ruby-head's build to test bundler's master instead of the currently vendored one.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
