### PR TITLE
Revert "Validate that symlinks cannot cause dirs outside of the gem t…

### DIFF
--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -458,16 +458,6 @@ EOM
     raise Gem::Package::PathError.new(destination, destination_dir) unless
       destination.start_with? destination_dir + '/'
 
-    begin
-      real_destination = File.expand_path(File.realpath(destination))
-    rescue
-      # it's fine if the destination doesn't exist, because rm -rf'ing it can't cause any damage
-      nil
-    else
-      raise Gem::Package::PathError.new(real_destination, destination_dir) unless
-        real_destination.start_with? destination_dir + '/'
-    end
-
     destination.untaint
     destination
   end

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -543,40 +543,6 @@ class TestGemPackage < Gem::Package::TarTestCase
     end
   end
 
-  def test_extract_symlink_parent_doesnt_delete_user_dir
-    package = Gem::Package.new @gem
-
-    # Extract into a subdirectory of @destination; if this test fails it writes
-    # a file outside destination_subdir, but we want the file to remain inside
-    # @destination so it will be cleaned up.
-    destination_subdir = File.join @destination, 'subdir'
-    FileUtils.mkdir_p destination_subdir
-
-    destination_user_dir = File.join @destination, 'user'
-    destination_user_subdir = File.join destination_user_dir, 'dir'
-    FileUtils.mkdir_p destination_user_subdir
-
-    tgz_io = util_tar_gz do |tar|
-      tar.add_symlink 'link', destination_user_dir, 16877
-      tar.add_symlink 'link/dir', '.', 16877
-    end
-
-    e = assert_raises(Gem::Package::PathError, Errno::EACCES) do
-      package.extract_tar_gz tgz_io, destination_subdir
-    end
-
-    assert_path_exists destination_user_subdir
-
-    if Gem::Package::PathError === e
-      assert_equal("installing into parent path #{destination_user_subdir} of " +
-                  "#{destination_subdir} is not allowed", e.message)
-    elsif win_platform?
-      skip "symlink - must be admin with no UAC on Windows"
-    else
-      raise e
-    end
-  end
-
   def test_extract_tar_gz_directory
     package = Gem::Package.new @gem
 


### PR DESCRIPTION
…o be deleted"

This reverts commit e2b5c58de49b83381d7971f5bb1d901721ed5818.

The original commit does not explain the mechanism of attack carefully enough, but the test case definitely does not test the added code.

E.g. I did the following modification:

~~~
diff --git a/test/rubygems/test_gem_package.rb b/test/rubygems/test_gem_package.rb
index 03accc9d..5a5142a0 100644
--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -533,6 +533,9 @@ class TestGemPackage < Gem::Package::TarTestCase
       package.extract_tar_gz tgz_io, destination_subdir
     end

+    p '================='
+    puts e.backtrace
+
     if Gem::Package::PathError === e
       assert_equal("installing into parent path lib/link/outside.txt of " +
                   "#{destination_subdir} is not allowed", e.message)
~~~

This shows:

~~~
"================="
/builddir/rubygems/lib/rubygems/package.rb:492:in `block in mkdir_p_safe'
/builddir/rubygems/lib/rubygems/package.rb:486:in `each'
/builddir/rubygems/lib/rubygems/package.rb:486:in `reduce'
/builddir/rubygems/lib/rubygems/package.rb:486:in `mkdir_p_safe'
/builddir/rubygems/lib/rubygems/package.rb:408:in `block (2 levels) in extract_tar_gz'
/builddir/rubygems/lib/rubygems/package/tar_reader.rb:65:in `each'
/builddir/rubygems/lib/rubygems/package.rb:391:in `block in extract_tar_gz'
/builddir/rubygems/lib/rubygems/package.rb:524:in `block in open_tar_gz'
/builddir/rubygems/lib/rubygems/package.rb:521:in `wrap'
/builddir/rubygems/lib/rubygems/package.rb:521:in `open_tar_gz'
/builddir/rubygems/lib/rubygems/package.rb:390:in `extract_tar_gz'
/builddir/rubygems/test/rubygems/test_gem_package.rb:533:in `block in test_extract_symlink_parent'
/usr/share/gems/gems/minitest-5.11.3/lib/minitest/assertions.rb:326:in `assert_raises'
/builddir/rubygems/test/rubygems/test_gem_package.rb:532:in `test_extract_symlink_parent'
/usr/share/gems/gems/minitest-5.11.3/lib/minitest/test.rb:98:in `block (3 levels) in run'
/usr/share/gems/gems/minitest-5.11.3/lib/minitest/test.rb:195:in `capture_exceptions'
/usr/share/gems/gems/minitest-5.11.3/lib/minitest/test.rb:95:in `block (2 levels) in run'
/usr/share/gems/gems/minitest-5.11.3/lib/minitest.rb:265:in `time_it'
/usr/share/gems/gems/minitest-5.11.3/lib/minitest/test.rb:94:in `block in run'
/usr/share/gems/gems/minitest-5.11.3/lib/minitest.rb:360:in `on_signal'
/usr/share/gems/gems/minitest-5.11.3/lib/minitest/test.rb:211:in `with_info_handler'
/usr/share/gems/gems/minitest-5.11.3/lib/minitest/test.rb:93:in `run'
/usr/share/gems/gems/minitest-5.11.3/lib/minitest.rb:960:in `run_one_method'
/usr/share/gems/gems/minitest-5.11.3/lib/minitest.rb:334:in `run_one_method'
/usr/share/gems/gems/minitest-5.11.3/lib/minitest.rb:321:in `block (2 levels) in run'
/usr/share/gems/gems/minitest-5.11.3/lib/minitest.rb:320:in `each'
/usr/share/gems/gems/minitest-5.11.3/lib/minitest.rb:320:in `block in run'
/usr/share/gems/gems/minitest-5.11.3/lib/minitest.rb:360:in `on_signal'
/usr/share/gems/gems/minitest-5.11.3/lib/minitest.rb:347:in `with_info_handler'
/usr/share/gems/gems/minitest-5.11.3/lib/minitest.rb:319:in `run'
/usr/share/gems/gems/minitest-5.11.3/lib/minitest.rb:159:in `block in __run'
/usr/share/gems/gems/minitest-5.11.3/lib/minitest.rb:159:in `map'
/usr/share/gems/gems/minitest-5.11.3/lib/minitest.rb:159:in `__run'
/usr/share/gems/gems/minitest-5.11.3/lib/minitest.rb:136:in `run'
/usr/share/gems/gems/minitest-5.11.3/lib/minitest.rb:63:in `block in autorun'
~~~

So clearly the exception is comming from different place then from the `Gem::Package#install_location`.

I also tried to create the vulnerable gem, but the installation failed with similar error from similar place, with or without this patch and without triggering at the newly introduced check.

Because I don't see how this vulnerability could be triggered and the check does not check the newly introduced code, I propose to revert the commit.

Also, it would be nice if the original H1 report was disclosed.