### PR TITLE
Fix pre-release version comparison across versions with different non-canonical segments

### DIFF
--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -344,8 +344,8 @@ class Gem::Version
     return unless Gem::Version === other
     return 0 if @version == other._version || canonical_segments == other.canonical_segments
 
-    lhsegments = _segments
-    rhsegments = other._segments
+    lhsegments = canonical_segments
+    rhsegments = other.canonical_segments
 
     lhsize = lhsegments.size
     rhsize = rhsegments.size

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -149,12 +149,14 @@ class TestGemVersion < Gem::TestCase
 
   def test_spaceship
     assert_equal(0, v("1.0")       <=> v("1.0.0"))
+    assert_equal(0, v("1.0.0.a")   <=> v("1.0.a"))
     assert_equal(1, v("1.0")       <=> v("1.0.a"))
     assert_equal(1, v("1.8.2")     <=> v("0.0.0"))
     assert_equal(1, v("1.8.2")     <=> v("1.8.2.a"))
     assert_equal(1, v("1.8.2.b")   <=> v("1.8.2.a"))
-    assert_equal(-1, v("1.8.2.a") <=> v("1.8.2"))
+    assert_equal(-1, v("1.8.2.a")  <=> v("1.8.2"))
     assert_equal(1, v("1.8.2.a10") <=> v("1.8.2.a9"))
+    assert_equal(1, v("2.0.b")     <=> v("2.0.0.a"))
     assert_equal(0, v("")          <=> v("0"))
 
     assert_nil v("1.0") <=> "whatever"


### PR DESCRIPTION
# Description:

Currently, the following happens:

```
Gem::Version.new("1.0.beta") >= Gem::Version.new("1.0.0.beta")
# => true
Gem::Version.new("1.0.beta") >= Gem::Version.new("1.0.0.alpha")
# => false
```

That is inconsistent. I propose that the second statement should be true. (Alternatively we could make the first statement false, but that is arguably a breaking change.)

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
