### PR TITLE
Fix requiring default gems to consider prereleases

### DIFF
--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -39,7 +39,7 @@ module Kernel
     if spec = Gem.find_unresolved_default_spec(path)
       Gem.remove_unresolved_default_spec(spec)
       begin
-        Kernel.send(:gem, spec.name)
+        Kernel.send(:gem, spec.name, "#{Gem::Requirement.default}.a")
       rescue Exception
         RUBYGEMS_ACTIVATION_MONITOR.exit
         raise

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -323,6 +323,19 @@ class TestGemRequire < Gem::TestCase
     assert_equal %w(default-3.0), loaded_spec_names
   end
 
+  def test_default_gem_prerelease
+    default_gem_spec = new_default_spec("default", "2.0.0",
+                                        nil, "default/gem.rb")
+    install_default_specs(default_gem_spec)
+
+    normal_gem_higher_prerelease_spec = util_spec("default", "3.0.0.rc2", nil,
+                                                  "lib/default/gem.rb")
+    install_default_specs(normal_gem_higher_prerelease_spec)
+
+    assert_require "default/gem"
+    assert_equal %w(default-3.0.0.rc2), loaded_spec_names
+  end
+
   def loaded_spec_names
     Gem.loaded_specs.values.map(&:full_name).sort
   end


### PR DESCRIPTION
# Description:

Currently default gem activation does not consider pre-releases, and that causes causes several unexpected behavior. For example:

* Requiring a regular gem activates the highest version installed, including prereleases, whereas requiring a default gem activates the highest version installed, not including prereleases.

    ```
    $ gem list ^activesupport

    *** LOCAL GEMS ***

    activesupport (6.0.0.beta3, 5.2.3, 5.2.2)

    $ ruby -e "require 'active_support'; puts ActiveSupport.gem_version"
    6.0.0.beta3

    $ gem list ^bundler

    *** LOCAL GEMS ***

    bundler (2.1.0.pre.1, 2.0.1, default: 1.17.3)

    $ ruby -e "require 'bundler'; puts Bundler::VERSION"
    2.0.1
    ```

* Running an executable of a default gem from a rubygems binstub activates the highest version installed [including prereleases](https://github.com/rubygems/rubygems/blob/01e701dc7d3ec72c14dc79d7af5b5f5fb6ffbb25/lib/rubygems/installer.rb#L774), whereas just requiring it activates the highest version not including pre-releases.

    ```
    $ gem list ^bundler

    *** LOCAL GEMS ***

    bundler (2.1.0.pre.1, default: 2.0.1)

    $ touch Gemfile

    $ bundle -v
    Bundler version 2.1.0.pre.1

    $ ruby -e "require 'bundler'; puts Bundler::VERSION"
    2.0.1
    ```

This PR wants to fix these issues.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
