### PR TITLE
Use current checkout in CI to uninstall RVM related gems

### DIFF
--- a/util/ci
+++ b/util/ci
@@ -49,7 +49,7 @@ end
 case ARGV
 when %w(before_script)
   if TOOL.rubygems?
-    run('gem', %W(uninstall executable-hooks gem-wrappers bundler-unload -x --force -i #{`gem env home`.strip}@global))
+    run('ruby', %W(-I lib bin/gem uninstall executable-hooks gem-wrappers bundler-unload -x --force -i #{`gem env home`.strip}@global))
 
     # shipped gems in 2.3.8
     run('rake', 'setup')


### PR DESCRIPTION
# Description:

Using the latest rubygems is better because we can pickup the latest bug
fixes present in master, but non on whatever rubygems version Travis is
using.

For example, once we merge #2720, this change will allow to get the `ruby-head` build fixed.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
