### PR TITLE
Vendorize latest bundler

### DIFF
--- a/util/ci
+++ b/util/ci
@@ -59,14 +59,6 @@ when %w(before_script)
   else
     if ENV["BDV"]
       run('git', %W(reset --hard origin/#{ENV["BDV"]}))
-    elsif RUBY_VERSION == "2.6.2" || RUBY_VERSION == "2.5.5"
-      # Manually cherry-pick changes needed so that bundler does not load
-      # default gems by default, and thus its specs pass.
-      # TODO: Remove when the commits are included in a bundler release and
-      # vendored in rubygems.
-      run('git', %w(cherry-pick facdf8e6a450d60a05546b62e23bd9c0d7de2c02))
-      run('git', %w(cherry-pick 7f1ec3d02f62ddea6dac75513e320c607ac3ed93))
-      run('git', %w(cherry-pick c7ac5b38012051379fb87d40e31e0887833dca98))
     end
 
     with_retries { run('rake', %w(spec:travis:deps)) }


### PR DESCRIPTION
# Description:

I'd like to propose that we start vendorizing the latest bundler master.

The prerequisite for this would be that we cut a bundler release _before_ cutting a rubygems release, so that we can get the submodule back to a released version before releasing rubygems.

The motivation is that it is simpler to keep CI green if we do this. For example, fixing #1868 made surface some issues in bundler's specs that are only fixed in bundler's master. This has happened before, as can be seen by the list of cherry-pick we already need for the build to be green. Cherry-picking is not always easy, and not very clear why it's for the reader of the CI config, so I think I would prefer to do this?

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
