### PR TITLE
config_file.rb - update path separator in ENV['GEMRC'] logic

### DIFF
--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -197,9 +197,10 @@ class Gem::ConfigFile
     platform_config = Marshal.load Marshal.dump(PLATFORM_DEFAULTS)
     system_config = load_file SYSTEM_WIDE_CONFIG_FILE
     user_config = load_file config_file_name.dup.untaint
-    environment_config = (ENV['GEMRC'] || '').split(/[:;]/).inject({}) do |result, file|
-      result.merge load_file file
-    end
+    environment_config = (ENV['GEMRC'] || '')
+      .split(File::PATH_SEPARATOR).inject({}) do |result, file|
+        result.merge load_file file
+      end
 
     @hash = operating_system_config.merge platform_config
     unless arg_list.index '--norc'

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -157,8 +157,8 @@ class TestGemConfigFile < Gem::TestCase
     File.open conf3, 'w' do |fp|
       fp.puts ':verbose: :loud'
     end
-
-    ENV['GEMRC'] = conf1 + ':' + conf2 + ';' + conf3
+    ps = File::PATH_SEPARATOR
+    ENV['GEMRC'] = conf1 + ps + conf2 + ps + conf3
 
     util_config_file
 


### PR DESCRIPTION
When `ENV['GEMRC']` is used in Windows, variable is parsed incorrectly.

Fixed by updating `cofig_file.rb` & test.

### Tasks:

- [x] Describe the problem / feature
- [x] Fix tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
