### PR TITLE
Fix `ruby setup.rb` warnings

### DIFF
--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -428,8 +428,12 @@ By default, this RubyGems will install gem as:
 
     Dir.chdir("bundler") do
       built_gem = Gem::Package.build(bundler_spec)
-      installer = Gem::Installer.at(built_gem, env_shebang: options[:env_shebang], install_as_default: true, bin_dir: bin_dir, wrappers: true)
-      installer.install
+      begin
+        installer = Gem::Installer.at(built_gem, env_shebang: options[:env_shebang], install_as_default: true, bin_dir: bin_dir, wrappers: true)
+        installer.install
+      ensure
+        FileUtils.rm_f built_gem
+      end
     end
 
     say "Bundler #{bundler_spec.version} installed"

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -265,7 +265,6 @@ class Gem::Package
     raise ArgumentError, "skip_validation = true and strict_validation = true are incompatible" if skip_validation && strict_validation
 
     Gem.load_yaml
-    require 'rubygems/security'
 
     @spec.mark_version
     @spec.validate true, strict_validation unless skip_validation

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2595,8 +2595,6 @@ class Gem::Specification < Gem::BasicSpecification
   # checks..
 
   def validate(packaging = true, strict = false)
-    require 'rubygems/user_interaction'
-    extend Gem::UserInteraction
     normalize
 
     validation_policy = Gem::SpecificationPolicy.new(self)

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -1,7 +1,10 @@
 require 'delegate'
 require 'uri'
+require 'rubygems/user_interaction'
 
 class Gem::SpecificationPolicy < SimpleDelegator
+
+  include Gem::UserInteraction
 
   VALID_NAME_PATTERN = /\A[a-zA-Z0-9\.\-\_]+\z/.freeze # :nodoc:
 


### PR DESCRIPTION
# Description:

Currently, installing rubygems from a development copy through `ruby setup.rb` prints a lot of redefinition warnings:

```
$ ruby setup.rb
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/exceptions.rb:296: warning: already initialized constant Gem::UnsatisfiableDepedencyError
/home/deivid/Code/rubygems/lib/rubygems/exceptions.rb:296: warning: previous definition of UnsatisfiableDepedencyError was here
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/security.rb:342: warning: already initialized constant Gem::Security::DIGEST_ALGORITHM
/home/deivid/Code/rubygems/lib/rubygems/security.rb:342: warning: previous definition of DIGEST_ALGORITHM was here
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/security.rb:355: warning: already initialized constant Gem::Security::DIGEST_NAME
/home/deivid/Code/rubygems/lib/rubygems/security.rb:355: warning: previous definition of DIGEST_NAME was here
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/security.rb:365: warning: already initialized constant Gem::Security::KEY_ALGORITHM
/home/deivid/Code/rubygems/lib/rubygems/security.rb:365: warning: previous definition of KEY_ALGORITHM was here
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/security.rb:373: warning: already initialized constant Gem::Security::KEY_LENGTH
/home/deivid/Code/rubygems/lib/rubygems/security.rb:373: warning: previous definition of KEY_LENGTH was here
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/security.rb:379: warning: already initialized constant Gem::Security::KEY_CIPHER
/home/deivid/Code/rubygems/lib/rubygems/security.rb:379: warning: previous definition of KEY_CIPHER was here
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/security.rb:384: warning: already initialized constant Gem::Security::ONE_DAY
/home/deivid/Code/rubygems/lib/rubygems/security.rb:384: warning: previous definition of ONE_DAY was here
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/security.rb:389: warning: already initialized constant Gem::Security::ONE_YEAR
/home/deivid/Code/rubygems/lib/rubygems/security.rb:389: warning: previous definition of ONE_YEAR was here
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/security.rb:399: warning: already initialized constant Gem::Security::EXTENSIONS
/home/deivid/Code/rubygems/lib/rubygems/security.rb:399: warning: previous definition of EXTENSIONS was here
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/user_interaction.rb:565: warning: already initialized constant Gem::StreamUI::ThreadedDownloadReporter::MUTEX
/home/deivid/Code/rubygems/lib/rubygems/user_interaction.rb:565: warning: previous definition of MUTEX was here
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/security/policies.rb:7: warning: already initialized constant Gem::Security::NoSecurity
/home/deivid/Code/rubygems/lib/rubygems/security/policies.rb:7: warning: previous definition of NoSecurity was here
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/security/policies.rb:25: warning: already initialized constant Gem::Security::AlmostNoSecurity
/home/deivid/Code/rubygems/lib/rubygems/security/policies.rb:25: warning: previous definition of AlmostNoSecurity was here
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/security/policies.rb:42: warning: already initialized constant Gem::Security::LowSecurity
/home/deivid/Code/rubygems/lib/rubygems/security/policies.rb:42: warning: previous definition of LowSecurity was here
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/security/policies.rb:61: warning: already initialized constant Gem::Security::MediumSecurity
/home/deivid/Code/rubygems/lib/rubygems/security/policies.rb:61: warning: previous definition of MediumSecurity was here
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/security/policies.rb:80: warning: already initialized constant Gem::Security::HighSecurity
/home/deivid/Code/rubygems/lib/rubygems/security/policies.rb:80: warning: previous definition of HighSecurity was here
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/security/policies.rb:93: warning: already initialized constant Gem::Security::SigningPolicy
/home/deivid/Code/rubygems/lib/rubygems/security/policies.rb:93: warning: previous definition of SigningPolicy was here
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/security/policies.rb:106: warning: already initialized constant Gem::Security::Policies
/home/deivid/Code/rubygems/lib/rubygems/security/policies.rb:106: warning: previous definition of Policies was here
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/security/trust_dir.rb:11: warning: already initialized constant Gem::Security::TrustDir::DEFAULT_PERMISSIONS
/home/deivid/Code/rubygems/lib/rubygems/security/trust_dir.rb:11: warning: previous definition of DEFAULT_PERMISSIONS was here
/home/deivid/.rbenv/versions/2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/security/signer.rb:37: warning: already initialized constant Gem::Security::Signer::DEFAULT_OPTIONS
/home/deivid/Code/rubygems/lib/rubygems/security/signer.rb:37: warning: previous definition of DEFAULT_OPTIONS was here
  Successfully built RubyGem
  Name: bundler
  Version: 2.0.1
  File: bundler-2.0.1.gem
Bundler 2.0.1 installed
RubyGems 3.1.0.pre1 installed
Regenerating binstubs



------------------------------------------------------------------------------

RubyGems installed the following executables:
	/home/deivid/.rbenv/versions/2.6.3/bin/gem
```

This PR removes all those warnings.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
