### PR TITLE
Don't use regex delimiters when searching for a dependency

### DIFF
--- a/lib/rubygems/commands/dependency_command.rb
+++ b/lib/rubygems/commands/dependency_command.rb
@@ -208,7 +208,7 @@ use with other commands.
   def name_pattern(args)
     args << '' if args.empty?
 
-    if args.length == 1 and args.first =~ /\A\/(.*)\/(i)?\z/m
+    if args.length == 1 and args.first =~ /\A(.*)(i)?\z/m
       flags = $2 ? Regexp::IGNORECASE : nil
       Regexp.new $1, flags
     else

--- a/test/rubygems/test_gem_commands_dependency_command.rb
+++ b/test/rubygems/test_gem_commands_dependency_command.rb
@@ -101,7 +101,7 @@ Gem x-2
       fetcher.spec 'b',      2
     end
 
-    @cmd.options[:args] = %w[/[ab]/]
+    @cmd.options[:args] = %w[[ab]]
 
     use_ui @stub_ui do
       @cmd.execute


### PR DESCRIPTION
# Description:

closes https://github.com/rubygems/rubygems/issues/2692

This PR will make `gem search [REGEXP]` and `gem dependency [REGEXP]` use the same [REGEXP] pattern for consistency.

so now you can do `gem dependency ^rails$` instead of `gem dependency /^rails$/` 

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
