### PR TITLE
Remove dependency installer deprecated code

### DIFF
--- a/lib/rubygems/dependency_installer.rb
+++ b/lib/rubygems/dependency_installer.rb
@@ -107,62 +107,6 @@ class Gem::DependencyInstaller
   end
 
   ##
-  #--
-  # TODO remove at RubyGems 4, no longer used
-
-  def add_found_dependencies(to_do, dependency_list) # :nodoc:
-    seen = {}
-    dependencies = Hash.new { |h, name| h[name] = Gem::Dependency.new name }
-
-    until to_do.empty? do
-      spec = to_do.shift
-
-      # HACK why is spec nil?
-      next if spec.nil? or seen[spec.name]
-      seen[spec.name] = true
-
-      deps = spec.runtime_dependencies
-
-      if @development
-        if @dev_shallow
-          if @toplevel_specs.include? spec.full_name
-            deps |= spec.development_dependencies
-          end
-        else
-          deps |= spec.development_dependencies
-        end
-      end
-
-      deps.each do |dep|
-        dependencies[dep.name] = dependencies[dep.name].merge dep
-
-        if @minimal_deps
-          next if Gem::Specification.any? do |installed_spec|
-                    dep.name == installed_spec.name and
-                      dep.requirement.satisfied_by? installed_spec.version
-                  end
-        end
-
-        results = Gem::Deprecate.skip_during do
-          find_gems_with_sources(dep)
-        end
-
-        results.sorted.each do |t|
-          to_do.push t.spec
-        end
-
-        results.remove_installed! dep
-
-        @available << results
-        results.inject_into_list dependency_list
-      end
-    end
-
-    dependency_list.remove_specs_unsatisfied_by dependencies
-  end
-  deprecate :add_found_dependencies, :none, 2018, 12
-
-  ##
   # Creates an AvailableSet to install from based on +dep_or_name+ and
   # +version+
 
@@ -343,11 +287,6 @@ class Gem::DependencyInstaller
 
     dependency_list = Gem::DependencyList.new @development
     dependency_list.add(*specs)
-    to_do = specs.dup
-
-    Gem::Deprecate.skip_during do
-      add_found_dependencies to_do, dependency_list unless @ignore_dependencies
-    end
 
     # REFACTOR maybe abstract away using Gem::Specification.include? so
     # that this isn't dependent only on the currently installed gems

--- a/lib/rubygems/dependency_installer.rb
+++ b/lib/rubygems/dependency_installer.rb
@@ -269,43 +269,6 @@ class Gem::DependencyInstaller
   end
   deprecate :find_spec_by_name_and_version, :none, 2019, 12
 
-  ##
-  # Gathers all dependencies necessary for the installation from local and
-  # remote sources unless the ignore_dependencies was given.
-  #--
-  # TODO remove at RubyGems 4
-
-  def gather_dependencies # :nodoc:
-    specs = @available.all_specs
-
-    # these gems were listed by the user, always install them
-    keep_names = specs.map { |spec| spec.full_name }
-
-    if @dev_shallow
-      @toplevel_specs = keep_names
-    end
-
-    dependency_list = Gem::DependencyList.new @development
-    dependency_list.add(*specs)
-
-    # REFACTOR maybe abstract away using Gem::Specification.include? so
-    # that this isn't dependent only on the currently installed gems
-    dependency_list.specs.reject! do |spec|
-      not keep_names.include?(spec.full_name) and
-      Gem::Specification.include?(spec)
-    end
-
-    unless dependency_list.ok? or @ignore_dependencies or @force
-      reason = dependency_list.why_not_ok?.map do |k,v|
-        "#{k} requires #{v.join(", ")}"
-      end.join("; ")
-      raise Gem::DependencyError, "Unable to resolve dependencies: #{reason}"
-    end
-
-    @gems_to_install = dependency_list.dependency_order.reverse
-  end
-  deprecate :gather_dependencies, :none, 2018, 12
-
   def in_background(what) # :nodoc:
     fork_happened = false
     if @build_docs_in_background and Process.respond_to?(:fork)


### PR DESCRIPTION
# Description:

This methods should have gone away 12, 2018 

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
