### PR TITLE
Don't remove default spec files from mapping after require

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1303,6 +1303,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     def remove_unresolved_default_spec(spec)
       spec.files.each do |file|
         @path_to_default_spec_map.delete(file)
+        @path_to_default_spec_map.delete(file.sub(suffix_regexp, ""))
       end
     end
 

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1293,18 +1293,8 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     # Find a Gem::Specification of default gem from +path+
 
     def find_unresolved_default_spec(path)
-      @path_to_default_spec_map[path]
-    end
-
-    ##
-    # Remove needless Gem::Specification of default gem from
-    # unresolved default gem list
-
-    def remove_unresolved_default_spec(spec)
-      spec.files.each do |file|
-        @path_to_default_spec_map.delete(file)
-        @path_to_default_spec_map.delete(file.sub(suffix_regexp, ""))
-      end
+      default_spec = @path_to_default_spec_map[path]
+      return default_spec if default_spec && loaded_specs[default_spec.name] != default_spec
     end
 
     ##

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1024,6 +1024,10 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     @suffix_pattern ||= "{#{suffixes.join(',')}}"
   end
 
+  def self.suffix_regexp
+    @suffix_regexp ||= /#{Regexp.union(suffixes)}\z/
+  end
+
   ##
   # Suffixes for require-able paths.
 
@@ -1274,8 +1278,6 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
         prefix_pattern = /^(#{prefix_group})/
       end
 
-      suffix_pattern = /#{Regexp.union(Gem.suffixes)}\z/
-
       spec.files.each do |file|
         if new_format
           file = file.sub(prefix_pattern, "")
@@ -1283,7 +1285,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
         end
 
         @path_to_default_spec_map[file] = spec
-        @path_to_default_spec_map[file.sub(suffix_pattern, "")] = spec
+        @path_to_default_spec_map[file.sub(suffix_regexp, "")] = spec
       end
     end
 

--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -37,7 +37,6 @@ module Kernel
     path = path.to_path if path.respond_to? :to_path
 
     if spec = Gem.find_unresolved_default_spec(path)
-      Gem.remove_unresolved_default_spec(spec)
       begin
         Kernel.send(:gem, spec.name, "#{Gem::Requirement.default}.a")
       rescue Exception

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -41,6 +41,10 @@ class TestGemRequire < Gem::TestCase
     assert require(path), "'#{path}' was already required"
   end
 
+  def refute_require(path)
+    refute require(path), "'#{path}' was not yet required"
+  end
+
   # Providing -I on the commandline should always beat gems
   def test_dash_i_beats_gems
     a1 = util_spec "a", "1", {"b" => "= 1"}, "lib/test_gem_require_a.rb"
@@ -298,6 +302,22 @@ class TestGemRequire < Gem::TestCase
     install_default_specs(default_gem_spec)
     assert_require "default/gem"
     assert_equal %w(default-2.0.0.0), loaded_spec_names
+  end
+
+  def test_default_gem_require_activates_just_once
+    default_gem_spec = new_default_spec("default", "2.0.0.0",
+                                        nil, "default/gem.rb")
+    install_default_specs(default_gem_spec)
+
+    assert_require "default/gem"
+
+    times_called = 0
+
+    Kernel.stub(:gem, ->(name, requirement) { times_called += 1 }) do
+      refute_require "default/gem"
+    end
+
+    assert_equal 0, times_called
   end
 
   def test_realworld_default_gem


### PR DESCRIPTION
# Description:

I discovered a bug in our monkey patched `require` where default gems would not be properly removed from our "default spec file mapping" after being required the first time. This doesn't have any effect at the correctness level because `Kernel.gem` will detect that the gem has already been activated and return `false` in that case.

However, it results in `require` doing more work than it's supposed since it will loop through all files in the default gem and unsuccessfully try to remove its default mappings, _every_ time a default gem is required.

This patch fixes that bug.

As per the explanation of the fix, the previous method to remove the default spec mappings would only try to remove keys like `logger.rb`, but not `logger`. And the `logger` form is what's actually used with `require` most of the times.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
