### PR TITLE
Fix test warning

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ task :setup => ["bundler:checkout"] do
 end
 
 Rake::TestTask.new do |t|
-  t.ruby_opts = %w[--disable-gems]
+  t.ruby_opts = %w[--disable-gems -w]
   t.ruby_opts << '-rdevkit' if Gem.win_platform?
 
   t.libs << "test"

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -389,7 +389,7 @@ class TestGemCommandsBuildCommand < Gem::TestCase
     output = @ui.output.split "\n"
     assert_equal "INFO:  Your certificate has expired, trying to re-sign it...", output.shift
     assert_equal "INFO:  Your cert: #{tmp_expired_cert_file } has been auto re-signed with the key: #{tmp_private_key_file}", output.shift
-    assert_match /INFO:  Your expired cert will be located at: .+\Wgem-public_cert\.pem\.expired\.[0-9]+/, output.shift
+    assert_match(/INFO:  Your expired cert will be located at: .+\Wgem-public_cert\.pem\.expired\.[0-9]+/, output.shift)
   end
 
 end


### PR DESCRIPTION
# Description:

Fixes one test warning

```
/path/to/test/rubygems/test_gem_commands_build_command.rb:392: warning: ambiguous first argument; put parentheses or a space even after `/' operator
```

And turns warnings on for our tests.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
