### PR TITLE
Remove `others_possible` activation request param

### DIFF
--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -246,7 +246,7 @@ class Gem::Resolver
     sources.each do |source|
       groups[source].
         sort_by { |spec| [spec.version, Gem::Platform.local =~ spec.platform ? 1 : 0] }.
-        map { |spec| ActivationRequest.new spec, dependency, [] }.
+        map { |spec| ActivationRequest.new spec, dependency }.
         each { |activation_request| activation_requests << activation_request }
     end
 

--- a/lib/rubygems/resolver/activation_request.rb
+++ b/lib/rubygems/resolver/activation_request.rb
@@ -18,14 +18,10 @@ class Gem::Resolver::ActivationRequest
   ##
   # Creates a new ActivationRequest that will activate +spec+.  The parent
   # +request+ is used to provide diagnostics in case of conflicts.
-  #
-  # +others_possible+ indicates that other specifications may also match this
-  # activation request.
 
-  def initialize(spec, request, others_possible = true)
+  def initialize(spec, request)
     @spec = spec
     @request = request
-    @others_possible = others_possible
   end
 
   def ==(other) # :nodoc:
@@ -90,21 +86,8 @@ class Gem::Resolver::ActivationRequest
   end
 
   def inspect # :nodoc:
-    others =
-      case @others_possible
-      when true then # TODO remove at RubyGems 3
-        ' (others possible)'
-      when false then # TODO remove at RubyGems 3
-        nil
-      else
-        unless @others_possible.empty?
-          others = @others_possible.map { |s| s.full_name }
-          " (others possible: #{others.join ', '})"
-        end
-      end
-
-    '#<%s for %p from %s%s>' % [
-      self.class, @spec, @request, others
+    '#<%s for %p from %s>' % [
+      self.class, @spec, @request
     ]
   end
 
@@ -132,19 +115,6 @@ class Gem::Resolver::ActivationRequest
   end
 
   ##
-  # Indicate if this activation is one of a set of possible
-  # requests for the same Dependency request.
-
-  def others_possible?
-    case @others_possible
-    when true, false then
-      @others_possible
-    else
-      not @others_possible.empty?
-    end
-  end
-
-  ##
   # Return the ActivationRequest that contained the dependency
   # that we were activated for.
 
@@ -160,19 +130,6 @@ class Gem::Resolver::ActivationRequest
       q.breakable
       q.text ' for '
       q.pp @request
-
-      case @others_possible
-      when false then
-      when true then
-        q.breakable
-        q.text 'others possible'
-      else
-        unless @others_possible.empty?
-          q.breakable
-          q.text 'others '
-          q.pp @others_possible.map { |s| s.full_name }
-        end
-      end
     end
   end
 

--- a/test/rubygems/test_gem_resolver.rb
+++ b/test/rubygems/test_gem_resolver.rb
@@ -97,7 +97,7 @@ class TestGemResolver < Gem::TestCase
 
     r1 = Gem::Resolver::DependencyRequest.new dep('a', '= 1'), nil
 
-    act = Gem::Resolver::ActivationRequest.new a1, r1, false
+    act = Gem::Resolver::ActivationRequest.new a1, r1
 
     res = Gem::Resolver.new [a1]
 
@@ -118,7 +118,7 @@ class TestGemResolver < Gem::TestCase
 
     r1 = Gem::Resolver::DependencyRequest.new dep('a', '= 1'), nil
 
-    act = Gem::Resolver::ActivationRequest.new spec, r1, false
+    act = Gem::Resolver::ActivationRequest.new spec, r1
 
     res = Gem::Resolver.new [act]
     res.development = true
@@ -137,7 +137,7 @@ class TestGemResolver < Gem::TestCase
 
     r1 = Gem::Resolver::DependencyRequest.new dep('a', '= 1'), nil
 
-    act = Gem::Resolver::ActivationRequest.new a1, r1, false
+    act = Gem::Resolver::ActivationRequest.new a1, r1
 
     res = Gem::Resolver.new [a1]
     res.ignore_dependencies = true

--- a/test/rubygems/test_gem_resolver_activation_request.rb
+++ b/test/rubygems/test_gem_resolver_activation_request.rb
@@ -13,11 +13,9 @@ class TestGemResolverActivationRequest < Gem::TestCase
     source   = Gem::Source::Local.new
     platform = Gem::Platform::RUBY
 
-    @a1 = @DR::IndexSpecification.new nil, 'a', v(1), source, platform
-    @a2 = @DR::IndexSpecification.new nil, 'a', v(2), source, platform
     @a3 = @DR::IndexSpecification.new nil, 'a', v(3), source, platform
 
-    @req = @DR::ActivationRequest.new @a3, @dep, [@a1, @a2]
+    @req = @DR::ActivationRequest.new @a3, @dep
   end
 
   def test_development_eh
@@ -25,7 +23,7 @@ class TestGemResolverActivationRequest < Gem::TestCase
 
     dep_req = @DR::DependencyRequest.new dep('a', '>= 0', :development), nil
 
-    act_req = @DR::ActivationRequest.new @a3, dep_req, [@a1, @a2]
+    act_req = @DR::ActivationRequest.new @a3, dep_req
 
     assert act_req.development?
   end
@@ -33,41 +31,14 @@ class TestGemResolverActivationRequest < Gem::TestCase
   def test_inspect
     assert_match 'a-3',                         @req.inspect
     assert_match 'from a (>= 0)',               @req.inspect
-    assert_match '(others possible: a-1, a-2)', @req.inspect
-  end
-
-  def test_inspect_legacy
-    req = @DR::ActivationRequest.new @a3, @dep, true
-
-    assert_match '(others possible)', req.inspect
-
-    req = @DR::ActivationRequest.new @a3, @dep, false
-
-    refute_match '(others possible)', req.inspect
   end
 
   def test_installed_eh
     v_spec = Gem::Resolver::VendorSpecification.new nil, @a3
 
-    @req = @DR::ActivationRequest.new v_spec, @dep, [@a1, @a2]
+    @req = @DR::ActivationRequest.new v_spec, @dep
 
     assert @req.installed?
-  end
-
-  def test_others_possible_eh
-    assert @req.others_possible?
-
-    req = @DR::ActivationRequest.new @a3, @dep, []
-
-    refute req.others_possible?
-
-    req = @DR::ActivationRequest.new @a3, @dep, true
-
-    assert req.others_possible?
-
-    req = @DR::ActivationRequest.new @a3, @dep, false
-
-    refute req.others_possible?
   end
 
 end


### PR DESCRIPTION
# Description:

I don't think this is used for anything, and there was a TODO note to remove it in Rubygems 3, so I did it.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
