### PR TITLE
Extract an `add_to_load_path` method

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -669,6 +669,21 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     index
   end
 
+  ##
+  # Add a list of paths to the $LOAD_PATH at the proper place.
+
+  def self.add_to_load_path(*paths)
+    insert_index = load_path_insert_index
+
+    if insert_index
+      # gem directories must come after -I and ENV['RUBYLIB']
+      $LOAD_PATH.insert(insert_index, *paths)
+    else
+      # we are probably testing in core, -I and RUBYLIB don't apply
+      $LOAD_PATH.unshift(*paths)
+    end
+  end
+
   @yaml_loaded = false
 
   ##

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1498,7 +1498,6 @@ class Gem::Specification < Gem::BasicSpecification
 
     paths = full_require_paths
 
-    # gem directories must come after -I and ENV['RUBYLIB']
     insert_index = Gem.load_path_insert_index
 
     if insert_index

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1498,15 +1498,7 @@ class Gem::Specification < Gem::BasicSpecification
 
     paths = full_require_paths
 
-    insert_index = Gem.load_path_insert_index
-
-    if insert_index
-      # gem directories must come after -I and ENV['RUBYLIB']
-      $LOAD_PATH.insert(insert_index, *paths)
-    else
-      # we are probably testing in core, -I and RUBYLIB don't apply
-      $LOAD_PATH.unshift(*paths)
-    end
+    Gem.add_to_load_path(*paths)
   end
 
   ##


### PR DESCRIPTION
# Description:

This logic is duplicated in several places in bundler, so I'd like to extract it to a public method, so that `bundler` can reuse it. 

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
