### PR TITLE
Query command: Default to show prerelease gems for a remote domain

### DIFF
--- a/lib/rubygems/commands/query_command.rb
+++ b/lib/rubygems/commands/query_command.rb
@@ -190,7 +190,7 @@ is too hard to use.
     elsif options[:prerelease]
       :prerelease
     else
-      :latest
+      :abs_latest
     end
   end
 

--- a/test/rubygems/test_gem_commands_query_command.rb
+++ b/test/rubygems/test_gem_commands_query_command.rb
@@ -37,7 +37,7 @@ class TestGemCommandsQueryCommandWithInstalledGems < Gem::TestCase
 
 *** REMOTE GEMS ***
 
-a (2)
+a (3.a, 2)
 pl (1 i386-linux)
     EOF
 

--- a/test/rubygems/test_gem_commands_query_command.rb
+++ b/test/rubygems/test_gem_commands_query_command.rb
@@ -93,7 +93,9 @@ pl (1 i386-linux)
 
   def test_execute_details
     spec_fetcher do |fetcher|
-      fetcher.spec 'a', 2 do |s|
+      fetcher.spec 'a', 2
+
+      fetcher.spec 'a', '3.a' do |s|
         s.summary = 'This is a lot of text. ' * 4
         s.authors = ['Abraham Lincoln', 'Hirohito']
         s.homepage = 'http://a.example.com/'
@@ -112,7 +114,7 @@ pl (1 i386-linux)
 
 *** REMOTE GEMS ***
 
-a (2)
+a (3.a, 2)
     Authors: Abraham Lincoln, Hirohito
     Homepage: http://a.example.com/
 

--- a/test/rubygems/test_gem_commands_query_command.rb
+++ b/test/rubygems/test_gem_commands_query_command.rb
@@ -545,7 +545,7 @@ pl (1 i386-linux)
     end
 
     expected = <<-EOF
-a (2)
+a (3.a, 2)
 pl (1 i386-linux)
     EOF
 

--- a/test/rubygems/test_gem_commands_query_command.rb
+++ b/test/rubygems/test_gem_commands_query_command.rb
@@ -135,7 +135,9 @@ pl (1)
 
   def test_execute_details_cleans_text
     spec_fetcher do |fetcher|
-      fetcher.spec 'a', 2 do |s|
+      fetcher.spec 'a', 2
+
+      fetcher.spec 'a', '3.a' do |s|
         s.summary = 'This is a lot of text. ' * 4
         s.authors = ["Abraham Lincoln \x01", "\x02 Hirohito"]
         s.homepage = "http://a.example.com/\x03"
@@ -154,7 +156,7 @@ pl (1)
 
 *** REMOTE GEMS ***
 
-a (2)
+a (3.a, 2)
     Authors: Abraham Lincoln ., . Hirohito
     Homepage: http://a.example.com/.
 

--- a/test/rubygems/test_gem_commands_query_command.rb
+++ b/test/rubygems/test_gem_commands_query_command.rb
@@ -502,7 +502,7 @@ pl (1 i386-linux)
 
 *** REMOTE GEMS ***
 
-a (2)
+a (3.a, 2)
 pl (1 i386-linux)
     EOF
 

--- a/test/rubygems/test_gem_commands_query_command.rb
+++ b/test/rubygems/test_gem_commands_query_command.rb
@@ -177,7 +177,9 @@ pl (1)
 
   def test_execute_details_truncates_summary
     spec_fetcher do |fetcher|
-      fetcher.spec 'a', 2 do |s|
+      fetcher.spec 'a', 2
+
+      fetcher.spec 'a', '3.a' do |s|
         s.summary = 'This is a lot of text. ' * 10_000
         s.authors = ["Abraham Lincoln \x01", "\x02 Hirohito"]
         s.homepage = "http://a.example.com/\x03"
@@ -196,11 +198,11 @@ pl (1)
 
 *** REMOTE GEMS ***
 
-a (2)
+a (3.a, 2)
     Authors: Abraham Lincoln ., . Hirohito
     Homepage: http://a.example.com/.
 
-    Truncating the summary for a-2 to 100,000 characters:
+    Truncating the summary for a-3.a to 100,000 characters:
 #{"    This is a lot of text. This is a lot of text. This is a lot of text.\n" * 1449}    This is a lot of te
 
 pl (1)

--- a/test/rubygems/test_gem_commands_query_command.rb
+++ b/test/rubygems/test_gem_commands_query_command.rb
@@ -413,7 +413,7 @@ pl
     end
 
     expected = <<-EOF
-a (2)
+a (3.a, 2)
 pl (1 i386-linux)
     EOF
 


### PR DESCRIPTION
# Description:
Following up with: https://github.com/rubygems/rubygems/pull/2739#issuecomment-487142764

This PR will make whenever we query for a gem in a remote domain show the prereleases of that gem as default, this is to  make the output consistent with querying a gem in a local domain.

______________
I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
