### PR TITLE
Refactor tests

### DIFF
--- a/lib/rubygems/installer_test_case.rb
+++ b/lib/rubygems/installer_test_case.rb
@@ -188,7 +188,7 @@ class Gem::InstallerTestCase < Gem::TestCase
       end
     end
 
-    @installer = Gem::Installer.at @gem
+    Gem::Installer.at @gem
   end
 
   ##

--- a/lib/rubygems/installer_test_case.rb
+++ b/lib/rubygems/installer_test_case.rb
@@ -66,43 +66,8 @@ end
 
 class Gem::InstallerTestCase < Gem::TestCase
 
-  ##
-  # Creates the following instance variables:
-  #
-  # @spec::
-  #   a spec named 'a', intended for regular installs
-  # @user_spec::
-  #   a spec named 'b', intended for user installs
-  #
-  # @gem::
-  #   the path to a built gem from @spec
-  # @user_spec::
-  #   the path to a built gem from @user_spec
-  #
-  # @installer::
-  #   a Gem::Installer for the @spec that installs into @gemhome
-  # @user_installer::
-  #   a Gem::Installer for the @user_spec that installs into Gem.user_dir
-
   def setup
     super
-
-    @spec = quick_gem 'a' do |spec|
-      util_make_exec spec
-    end
-
-    @user_spec = quick_gem 'b' do |spec|
-      util_make_exec spec
-    end
-
-    util_build_gem @spec
-    util_build_gem @user_spec
-
-    @gem = @spec.cache_file
-    @user_gem = @user_spec.cache_file
-
-    @installer      = util_installer @spec, @gemhome
-    @user_installer = util_installer @user_spec, Gem.user_dir, :user
 
     Gem::Installer.path_warning = false
   end
@@ -133,6 +98,54 @@ class Gem::InstallerTestCase < Gem::TestCase
     write_file bin_path do |io|
       io.puts shebang
     end
+  end
+
+  ##
+  # Creates the following instance variables:
+  #
+  # @spec::
+  #   a spec named 'a', intended for regular installs
+  #
+  # @gem::
+  #   the path to a built gem from @spec
+  #
+  # And returns a Gem::Installer for the @spec that installs into @gemhome
+
+  def setup_base_installer
+    @spec = quick_gem 'a' do |spec|
+      util_make_exec spec
+    end
+
+    util_build_gem @spec
+    @gem = @spec.cache_file
+    util_installer @spec, @gemhome
+  end
+
+  ##
+  # Creates the following instance variables:
+  #
+  # @spec::
+  #   a spec named 'a', intended for regular installs
+  # @user_spec::
+  #   a spec named 'b', intended for user installs
+  #
+  # @gem::
+  #   the path to a built gem from @spec
+  # @user_gem::
+  #   the path to a built gem from @user_spec
+  #
+  # And returns a Gem::Installer for the @user_spec that installs into Gem.user_dir
+
+  def setup_base_user_installer
+    @user_spec = quick_gem 'b' do |spec|
+      util_make_exec spec
+    end
+
+    util_build_gem @user_spec
+
+    @user_gem = @user_spec.cache_file
+
+    util_installer @user_spec, Gem.user_dir, :user
   end
 
   ##

--- a/lib/rubygems/installer_test_case.rb
+++ b/lib/rubygems/installer_test_case.rb
@@ -143,7 +143,7 @@ class Gem::InstallerTestCase < Gem::TestCase
   #   lib/code.rb
   #   ext/a/mkrf_conf.rb
 
-  def util_setup_gem(ui = @ui) # HACK fix use_ui to make this automatic
+  def util_setup_gem(ui = @ui)
     @spec.files << File.join('lib', 'code.rb')
     @spec.extensions << File.join('ext', 'a', 'mkrf_conf.rb')
 

--- a/lib/rubygems/installer_test_case.rb
+++ b/lib/rubygems/installer_test_case.rb
@@ -112,13 +112,33 @@ class Gem::InstallerTestCase < Gem::TestCase
   # And returns a Gem::Installer for the @spec that installs into @gemhome
 
   def setup_base_installer
-    @spec = quick_gem 'a' do |spec|
+    @gem = setup_base_gem
+    util_installer @spec, @gemhome
+  end
+
+  ##
+  # Creates the following instance variables:
+  #
+  # @spec::
+  #   a spec named 'a', intended for regular installs
+  #
+  # And returns a gem built for the @spec
+
+  def setup_base_gem
+    @spec = setup_base_spec
+    util_build_gem @spec
+    @spec.cache_file
+  end
+
+  ##
+  # Sets up a generic specification for testing the rubygems installer
+  #
+  # And returns it
+
+  def setup_base_spec
+    quick_gem 'a' do |spec|
       util_make_exec spec
     end
-
-    util_build_gem @spec
-    @gem = @spec.cache_file
-    util_installer @spec, @gemhome
   end
 
   ##
@@ -146,6 +166,15 @@ class Gem::InstallerTestCase < Gem::TestCase
     @user_gem = @user_spec.cache_file
 
     util_installer @user_spec, Gem.user_dir, :user
+  end
+
+  ##
+  # Sets up the base @gem, builds it and returns an installer for it.
+  #
+  def util_setup_installer
+    @gem = setup_base_gem
+
+    util_setup_gem
   end
 
   ##

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -682,11 +682,6 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
     Gem::Specification.reset
   end
 
-  def util_clear_default_gems
-    FileUtils.rm_rf @default_spec_dir
-    FileUtils.mkdir @default_spec_dir
-  end
-
   ##
   # Install the provided specs
 

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -632,7 +632,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
       io.write spec.to_ruby_for_cache
     end
 
-    spec.loaded_from = spec.loaded_from = written_path
+    spec.loaded_from = written_path
 
     Gem::Specification.reset
 

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1295,7 +1295,6 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_needs
-    util_clear_gems
     a = util_spec "a", "1"
     b = util_spec "b", "1", "c" => nil
     c = util_spec "c", "2"
@@ -1314,7 +1313,6 @@ class TestGem < Gem::TestCase
 
   def test_self_needs_picks_up_unresolved_deps
     save_loaded_features do
-      util_clear_gems
       a = util_spec "a", "1"
       b = util_spec "b", "1", "c" => nil
       c = util_spec "c", "2"
@@ -1506,7 +1504,6 @@ class TestGem < Gem::TestCase
 
   def test_auto_activation_of_specific_gemdeps_file
     skip "Requiring bundler messes things up" if Gem.java_platform?
-    util_clear_gems
 
     a = util_spec "a", "1", nil, "lib/a.rb"
     b = util_spec "b", "1", nil, "lib/b.rb"
@@ -1531,7 +1528,6 @@ class TestGem < Gem::TestCase
 
   def test_auto_activation_of_used_gemdeps_file
     skip "Requiring bundler messes things up" if Gem.java_platform?
-    util_clear_gems
 
     a = util_spec "a", "1", nil, "lib/a.rb"
     b = util_spec "b", "1", nil, "lib/b.rb"
@@ -1565,7 +1561,6 @@ class TestGem < Gem::TestCase
 
   def test_looks_for_gemdeps_files_automatically_on_start
     skip "Requiring bundler messes things up" if Gem.java_platform?
-    util_clear_gems
 
     a = util_spec "a", "1", nil, "lib/a.rb"
     b = util_spec "b", "1", nil, "lib/b.rb"
@@ -1602,7 +1597,6 @@ class TestGem < Gem::TestCase
 
   def test_looks_for_gemdeps_files_automatically_on_start_in_parent_dir
     skip "Requiring bundler messes things up" if Gem.java_platform?
-    util_clear_gems
 
     a = util_spec "a", "1", nil, "lib/a.rb"
     b = util_spec "b", "1", nil, "lib/b.rb"

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -509,7 +509,6 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_use_gemdeps
-    skip "Requiring bundler messes things up" if Gem.java_platform?
     rubygems_gemdeps, ENV['RUBYGEMS_GEMDEPS'] = ENV['RUBYGEMS_GEMDEPS'], '-'
 
     FileUtils.mkdir_p 'detect/a/b'
@@ -663,7 +662,6 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_find_files_with_gemfile
-    skip "Requiring bundler messes things up" if Gem.java_platform?
     cwd = File.expand_path("test/rubygems", @@project_dir)
     actual_load_path = $LOAD_PATH.unshift(cwd).dup
 
@@ -1503,8 +1501,6 @@ class TestGem < Gem::TestCase
   end
 
   def test_auto_activation_of_specific_gemdeps_file
-    skip "Requiring bundler messes things up" if Gem.java_platform?
-
     a = util_spec "a", "1", nil, "lib/a.rb"
     b = util_spec "b", "1", nil, "lib/b.rb"
     c = util_spec "c", "1", nil, "lib/c.rb"
@@ -1527,8 +1523,6 @@ class TestGem < Gem::TestCase
   end
 
   def test_auto_activation_of_used_gemdeps_file
-    skip "Requiring bundler messes things up" if Gem.java_platform?
-
     a = util_spec "a", "1", nil, "lib/a.rb"
     b = util_spec "b", "1", nil, "lib/b.rb"
     c = util_spec "c", "1", nil, "lib/c.rb"
@@ -1664,7 +1658,6 @@ class TestGem < Gem::TestCase
   end
 
   def test_use_gemdeps
-    skip "Requiring bundler messes things up" if Gem.java_platform?
     gem_deps_file = 'gem.deps.rb'.untaint
     spec = util_spec 'a', 1
     install_specs spec
@@ -1726,7 +1719,6 @@ class TestGem < Gem::TestCase
   end
 
   def test_use_gemdeps_automatic
-    skip "Requiring bundler messes things up" if Gem.java_platform?
     rubygems_gemdeps, ENV['RUBYGEMS_GEMDEPS'] = ENV['RUBYGEMS_GEMDEPS'], '-'
 
     spec = util_spec 'a', 1
@@ -1775,7 +1767,6 @@ class TestGem < Gem::TestCase
   end
 
   def test_use_gemdeps_missing_gem
-    skip "Requiring bundler messes things up" if Gem.java_platform?
     rubygems_gemdeps, ENV['RUBYGEMS_GEMDEPS'] = ENV['RUBYGEMS_GEMDEPS'], 'x'
 
     File.open 'x', 'w' do |io|
@@ -1803,7 +1794,6 @@ You may need to `gem install -g` to install missing gems
   end
 
   def test_use_gemdeps_specific
-    skip "Requiring bundler messes things up" if Gem.java_platform?
     rubygems_gemdeps, ENV['RUBYGEMS_GEMDEPS'] = ENV['RUBYGEMS_GEMDEPS'], 'x'
 
     spec = util_spec 'a', 1

--- a/test/rubygems/test_gem_commands_uninstall_command.rb
+++ b/test/rubygems/test_gem_commands_uninstall_command.rb
@@ -73,15 +73,6 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
 
   def test_execute_removes_executable
     initial_install
-    ui = Gem::MockGemUi.new
-
-    installer = util_setup_gem ui
-
-    build_rake_in do
-      use_ui ui do
-        installer.install
-      end
-    end
 
     if win_platform?
       assert File.exist?(@executable)
@@ -132,7 +123,6 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
   end
 
   def test_execute_prerelease
-    initial_install
     @spec = util_spec "pre", "2.b"
     @gem = File.join @tempdir, @spec.file_name
     FileUtils.touch @gem
@@ -162,7 +152,6 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
     ui = Gem::MockGemUi.new
 
     util_make_gems
-    @installer = util_setup_gem ui
 
     assert_equal 3, Gem::Specification.find_all_by_name('a').length
 
@@ -185,7 +174,6 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
     ui = Gem::MockGemUi.new "y\n"
 
     util_make_gems
-    @installer = util_setup_gem ui
 
     assert_equal 3, Gem::Specification.find_all_by_name('a').length
 
@@ -268,8 +256,6 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
     a_3a, = util_gem 'a', '3.a'
     install_gem a_3a
 
-    @installer = util_setup_gem ui
-
     assert_equal 3, Gem::Specification.find_all_by_name('a').length
 
     @cmd.options[:force] = true
@@ -290,7 +276,6 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
     ui = Gem::MockGemUi.new
 
     util_make_gems
-    @installer = util_setup_gem ui
 
     assert Gem::Specification.find_all_by_name('dep_x').length > 0
     assert Gem::Specification.find_all_by_name('x').length > 0

--- a/test/rubygems/test_gem_commands_uninstall_command.rb
+++ b/test/rubygems/test_gem_commands_uninstall_command.rb
@@ -6,20 +6,13 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
 
   def setup
     super
-    @installer = setup_base_installer
-    common_installer_setup
-
-    build_rake_in do
-      use_ui @ui do
-        @installer.install
-      end
-    end
-
     @cmd = Gem::Commands::UninstallCommand.new
     @executable = File.join(@gemhome, 'bin', 'executable')
   end
 
   def test_execute_all_named
+    initial_install
+
     util_make_gems
 
     default = new_default_spec 'default', '1'
@@ -49,6 +42,8 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
   end
 
   def test_execute_dependency_order
+    initial_install
+
     c = quick_gem 'c' do |spec|
       spec.add_dependency 'a'
     end
@@ -77,6 +72,7 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
   end
 
   def test_execute_removes_executable
+    initial_install
     ui = Gem::MockGemUi.new
 
     installer = util_setup_gem ui
@@ -114,6 +110,8 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
   end
 
   def test_execute_removes_formatted_executable
+    @installer = setup_base_installer
+
     FileUtils.rm_f @executable # Wish this didn't happen in #setup
 
     Gem::Installer.exec_format = 'foo-%s-bar'
@@ -134,6 +132,7 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
   end
 
   def test_execute_prerelease
+    initial_install
     @spec = util_spec "pre", "2.b"
     @gem = File.join @tempdir, @spec.file_name
     FileUtils.touch @gem
@@ -158,6 +157,8 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
   end
 
   def test_execute_with_version_leaves_non_matching_versions
+    initial_install
+
     ui = Gem::MockGemUi.new
 
     util_make_gems
@@ -179,6 +180,8 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
   end
 
   def test_execute_with_version_specified_as_colon
+    initial_install
+
     ui = Gem::MockGemUi.new "y\n"
 
     util_make_gems
@@ -255,6 +258,8 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
   end
 
   def test_execute_with_force_and_without_version_uninstalls_everything
+    initial_install
+
     ui = Gem::MockGemUi.new "y\n"
 
     a_1, = util_gem 'a', 1
@@ -280,6 +285,8 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
   end
 
   def test_execute_with_force_ignores_dependencies
+    initial_install
+
     ui = Gem::MockGemUi.new
 
     util_make_gems
@@ -424,6 +431,8 @@ WARNING:  Use your OS package manager to uninstall vendor gems
   end
 
   def test_execute_with_gem_uninstall_error
+    initial_install
+
     util_make_gems
 
     @cmd.options[:args] = %w[a]
@@ -448,6 +457,19 @@ WARNING:  Use your OS package manager to uninstall vendor gems
 
     assert_empty @ui.output
     assert_match %r!Error: unable to successfully uninstall '#{@spec.name}'!, @ui.error
+  end
+
+  private
+
+  def initial_install
+    installer = setup_base_installer
+    common_installer_setup
+
+    build_rake_in do
+      use_ui @ui do
+        installer.install
+      end
+    end
   end
 
 end

--- a/test/rubygems/test_gem_commands_uninstall_command.rb
+++ b/test/rubygems/test_gem_commands_uninstall_command.rb
@@ -101,14 +101,14 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
   end
 
   def test_execute_removes_formatted_executable
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     FileUtils.rm_f @executable # Wish this didn't happen in #setup
 
     Gem::Installer.exec_format = 'foo-%s-bar'
 
-    @installer.format_executable = true
-    @installer.install
+    installer.format_executable = true
+    installer.install
 
     formatted_executable = File.join @gemhome, 'bin', 'foo-executable-bar'
     assert_equal true, File.exist?(formatted_executable)
@@ -127,11 +127,11 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
     @gem = File.join @tempdir, @spec.file_name
     FileUtils.touch @gem
 
-    @installer = util_setup_gem
+    installer = util_setup_gem
 
     build_rake_in do
       use_ui @ui do
-        @installer.install
+        installer.install
       end
     end
 

--- a/test/rubygems/test_gem_commands_uninstall_command.rb
+++ b/test/rubygems/test_gem_commands_uninstall_command.rb
@@ -6,6 +6,7 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
 
   def setup
     super
+    @installer = setup_base_installer
     common_installer_setup
 
     build_rake_in do

--- a/test/rubygems/test_gem_commands_uninstall_command.rb
+++ b/test/rubygems/test_gem_commands_uninstall_command.rb
@@ -79,7 +79,7 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
   def test_execute_removes_executable
     ui = Gem::MockGemUi.new
 
-    util_setup_gem ui
+    @installer = util_setup_gem ui
 
     build_rake_in do
       use_ui ui do
@@ -138,7 +138,7 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
     @gem = File.join @tempdir, @spec.file_name
     FileUtils.touch @gem
 
-    util_setup_gem
+    @installer = util_setup_gem
 
     build_rake_in do
       use_ui @ui do
@@ -161,7 +161,7 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
     ui = Gem::MockGemUi.new
 
     util_make_gems
-    util_setup_gem ui
+    @installer = util_setup_gem ui
 
     assert_equal 3, Gem::Specification.find_all_by_name('a').length
 
@@ -182,7 +182,7 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
     ui = Gem::MockGemUi.new "y\n"
 
     util_make_gems
-    util_setup_gem ui
+    @installer = util_setup_gem ui
 
     assert_equal 3, Gem::Specification.find_all_by_name('a').length
 
@@ -263,7 +263,7 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
     a_3a, = util_gem 'a', '3.a'
     install_gem a_3a
 
-    util_setup_gem ui
+    @installer = util_setup_gem ui
 
     assert_equal 3, Gem::Specification.find_all_by_name('a').length
 
@@ -283,7 +283,7 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
     ui = Gem::MockGemUi.new
 
     util_make_gems
-    util_setup_gem ui
+    @installer = util_setup_gem ui
 
     assert Gem::Specification.find_all_by_name('dep_x').length > 0
     assert Gem::Specification.find_all_by_name('x').length > 0

--- a/test/rubygems/test_gem_commands_uninstall_command.rb
+++ b/test/rubygems/test_gem_commands_uninstall_command.rb
@@ -79,11 +79,11 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
   def test_execute_removes_executable
     ui = Gem::MockGemUi.new
 
-    @installer = util_setup_gem ui
+    installer = util_setup_gem ui
 
     build_rake_in do
       use_ui ui do
-        @installer.install
+        installer.install
       end
     end
 

--- a/test/rubygems/test_gem_dependency_installer.rb
+++ b/test/rubygems/test_gem_dependency_installer.rb
@@ -45,7 +45,6 @@ class TestGemDependencyInstaller < Gem::TestCase
       s.add_development_dependency 'c'
     end
 
-    util_clear_gems
     util_reset_gems
   end
 
@@ -133,7 +132,6 @@ class TestGemDependencyInstaller < Gem::TestCase
     p1a, gem = util_gem 'a', '10.a'
 
     util_setup_spec_fetcher(p1a, @a1, @a1_pre)
-    util_clear_gems
 
     p1a_data = Gem.read_binary(gem)
 
@@ -172,7 +170,6 @@ class TestGemDependencyInstaller < Gem::TestCase
     p1a, gem = util_gem 'p', '1.a'
 
     util_setup_spec_fetcher(p1a)
-    util_clear_gems
 
     p1a_data = Gem.read_binary(gem)
 
@@ -192,7 +189,6 @@ class TestGemDependencyInstaller < Gem::TestCase
     util_setup_gems
 
     util_setup_spec_fetcher(@a1, @a1_pre)
-    util_clear_gems
 
     p1a_data = Gem.read_binary(@a1_gem)
 
@@ -212,8 +208,6 @@ class TestGemDependencyInstaller < Gem::TestCase
     _, e1_gem = util_gem 'e', '1' do |s|
       s.add_dependency 'b'
     end
-
-    util_clear_gems
 
     FileUtils.mv @a1_gem, @tempdir
     FileUtils.mv @b1_gem, @tempdir
@@ -575,8 +569,6 @@ class TestGemDependencyInstaller < Gem::TestCase
       s.add_dependency 'a'
     end
 
-    util_clear_gems
-
     FileUtils.mv @a1_gem, @tempdir
     FileUtils.mv @b1_gem, @tempdir
     FileUtils.mv  b2_gem, @tempdir
@@ -876,8 +868,6 @@ class TestGemDependencyInstaller < Gem::TestCase
     end
 
     si = util_setup_spec_fetcher @a1, a2_o
-
-    util_clear_gems
 
     @fetcher.data['http://gems.example.com/gems/yaml'] = si.to_yaml
 
@@ -1274,8 +1264,6 @@ class TestGemDependencyInstaller < Gem::TestCase
     util_setup_spec_fetcher(*[@a1, @a1_pre, @b1, @c1_pre,
                               @d1, @d2, @x1_m, @x1_o, @w1, @y1,
                               @y1_1_p, @z1].compact)
-
-    util_clear_gems
   end
 
 end

--- a/test/rubygems/test_gem_dependency_list.rb
+++ b/test/rubygems/test_gem_dependency_list.rb
@@ -7,8 +7,6 @@ class TestGemDependencyList < Gem::TestCase
   def setup
     super
 
-    util_clear_gems
-
     @deplist = Gem::DependencyList.new
 
     # TODO: switch to util_spec
@@ -124,8 +122,6 @@ class TestGemDependencyList < Gem::TestCase
   end
 
   def test_ok_eh
-    util_clear_gems
-
     assert @deplist.ok?, 'no dependencies'
 
     @deplist.add @b2
@@ -138,8 +134,6 @@ class TestGemDependencyList < Gem::TestCase
   end
 
   def test_why_not_ok_eh
-    util_clear_gems
-
     assert_equal({},  @deplist.why_not_ok?)
 
     @deplist.add @b2
@@ -229,8 +223,6 @@ class TestGemDependencyList < Gem::TestCase
   end
 
   def test_remove_by_name
-    util_clear_gems
-
     @deplist.add @a1, @b2
 
     @deplist.remove_by_name "a-1"

--- a/test/rubygems/test_gem_indexer.rb
+++ b/test/rubygems/test_gem_indexer.rb
@@ -11,7 +11,6 @@ class TestGemIndexer < Gem::TestCase
   def setup
     super
 
-    util_clear_gems
     util_make_gems
 
     @d2_0 = util_spec 'd', '2.0' do |s|
@@ -40,7 +39,6 @@ class TestGemIndexer < Gem::TestCase
   def teardown
     super
 
-    util_clear_gems
     util_clear_default_gems
   end
 

--- a/test/rubygems/test_gem_indexer.rb
+++ b/test/rubygems/test_gem_indexer.rb
@@ -27,29 +27,23 @@ class TestGemIndexer < Gem::TestCase
     @default = new_default_spec 'default', 2
     install_default_gems @default
 
-    @tempdir = File.join(@tempdir, 'indexer')
+    @indexerdir = File.join(@tempdir, 'indexer')
 
-    gems = File.join(@tempdir, 'gems')
+    gems = File.join(@indexerdir, 'gems')
     FileUtils.mkdir_p gems
     FileUtils.mv Dir[File.join(@gemhome, "cache", '*.gem')], gems
 
-    @indexer = Gem::Indexer.new(@tempdir)
-  end
-
-  def teardown
-    super
-
-    util_clear_default_gems
+    @indexer = Gem::Indexer.new(@indexerdir)
   end
 
   def test_initialize
-    assert_equal @tempdir, @indexer.dest_directory
+    assert_equal @indexerdir, @indexer.dest_directory
     assert_match %r{#{Dir.mktmpdir('gem_generate_index').match(/.*-/)}}, @indexer.directory
 
-    indexer = Gem::Indexer.new @tempdir
+    indexer = Gem::Indexer.new @indexerdir
     assert indexer.build_modern
 
-    indexer = Gem::Indexer.new @tempdir, :build_modern => true
+    indexer = Gem::Indexer.new @indexerdir, :build_modern => true
     assert indexer.build_modern
   end
 
@@ -98,7 +92,7 @@ class TestGemIndexer < Gem::TestCase
       @indexer.generate_index
     end
 
-    quickdir = File.join @tempdir, 'quick'
+    quickdir = File.join @indexerdir, 'quick'
     marshal_quickdir = File.join quickdir, "Marshal.#{@marshal_version}"
 
     assert_directory_exists quickdir
@@ -109,11 +103,11 @@ class TestGemIndexer < Gem::TestCase
 
     refute_indexed marshal_quickdir, File.basename(@c1_2.spec_file)
 
-    assert_indexed @tempdir, "specs.#{@marshal_version}"
-    assert_indexed @tempdir, "specs.#{@marshal_version}.gz"
+    assert_indexed @indexerdir, "specs.#{@marshal_version}"
+    assert_indexed @indexerdir, "specs.#{@marshal_version}.gz"
 
-    assert_indexed @tempdir, "latest_specs.#{@marshal_version}"
-    assert_indexed @tempdir, "latest_specs.#{@marshal_version}.gz"
+    assert_indexed @indexerdir, "latest_specs.#{@marshal_version}"
+    assert_indexed @indexerdir, "latest_specs.#{@marshal_version}.gz"
   end
 
   def test_generate_index_modern
@@ -123,12 +117,12 @@ class TestGemIndexer < Gem::TestCase
       @indexer.generate_index
     end
 
-    refute_indexed @tempdir, 'yaml'
-    refute_indexed @tempdir, 'yaml.Z'
-    refute_indexed @tempdir, "Marshal.#{@marshal_version}"
-    refute_indexed @tempdir, "Marshal.#{@marshal_version}.Z"
+    refute_indexed @indexerdir, 'yaml'
+    refute_indexed @indexerdir, 'yaml.Z'
+    refute_indexed @indexerdir, "Marshal.#{@marshal_version}"
+    refute_indexed @indexerdir, "Marshal.#{@marshal_version}.Z"
 
-    quickdir = File.join @tempdir, 'quick'
+    quickdir = File.join @indexerdir, 'quick'
     marshal_quickdir = File.join quickdir, "Marshal.#{@marshal_version}"
 
     assert_directory_exists quickdir, 'quickdir should be directory'
@@ -154,11 +148,11 @@ class TestGemIndexer < Gem::TestCase
     refute_indexed quickdir, "#{File.basename(@c1_2.spec_file)}"
     refute_indexed marshal_quickdir, "#{File.basename(@c1_2.spec_file)}"
 
-    assert_indexed @tempdir, "specs.#{@marshal_version}"
-    assert_indexed @tempdir, "specs.#{@marshal_version}.gz"
+    assert_indexed @indexerdir, "specs.#{@marshal_version}"
+    assert_indexed @indexerdir, "specs.#{@marshal_version}.gz"
 
-    assert_indexed @tempdir, "latest_specs.#{@marshal_version}"
-    assert_indexed @tempdir, "latest_specs.#{@marshal_version}.gz"
+    assert_indexed @indexerdir, "latest_specs.#{@marshal_version}"
+    assert_indexed @indexerdir, "latest_specs.#{@marshal_version}.gz"
   end
 
   def test_generate_index_modern_back_to_back
@@ -168,13 +162,13 @@ class TestGemIndexer < Gem::TestCase
       @indexer.generate_index
     end
 
-    @indexer = Gem::Indexer.new @tempdir
+    @indexer = Gem::Indexer.new @indexerdir
     @indexer.build_modern = true
 
     use_ui @ui do
       @indexer.generate_index
     end
-    quickdir = File.join @tempdir, 'quick'
+    quickdir = File.join @indexerdir, 'quick'
     marshal_quickdir = File.join quickdir, "Marshal.#{@marshal_version}"
 
     assert_directory_exists quickdir
@@ -183,11 +177,11 @@ class TestGemIndexer < Gem::TestCase
     assert_indexed marshal_quickdir, "#{File.basename(@a1.spec_file)}.rz"
     assert_indexed marshal_quickdir, "#{File.basename(@a2.spec_file)}.rz"
 
-    assert_indexed @tempdir, "specs.#{@marshal_version}"
-    assert_indexed @tempdir, "specs.#{@marshal_version}.gz"
+    assert_indexed @indexerdir, "specs.#{@marshal_version}"
+    assert_indexed @indexerdir, "specs.#{@marshal_version}.gz"
 
-    assert_indexed @tempdir, "latest_specs.#{@marshal_version}"
-    assert_indexed @tempdir, "latest_specs.#{@marshal_version}.gz"
+    assert_indexed @indexerdir, "latest_specs.#{@marshal_version}"
+    assert_indexed @indexerdir, "latest_specs.#{@marshal_version}.gz"
   end
 
   def test_generate_index_ui
@@ -213,7 +207,7 @@ class TestGemIndexer < Gem::TestCase
       @indexer.generate_index
     end
 
-    specs_path = File.join @tempdir, "specs.#{@marshal_version}"
+    specs_path = File.join @indexerdir, "specs.#{@marshal_version}"
 
     specs_dump = Gem.read_binary specs_path
     specs = Marshal.load specs_dump
@@ -250,7 +244,7 @@ class TestGemIndexer < Gem::TestCase
       @indexer.generate_index
     end
 
-    latest_specs_path = File.join @tempdir, "latest_specs.#{@marshal_version}"
+    latest_specs_path = File.join @indexerdir, "latest_specs.#{@marshal_version}"
 
     latest_specs_dump = Gem.read_binary latest_specs_path
     latest_specs = Marshal.load latest_specs_dump
@@ -280,7 +274,7 @@ class TestGemIndexer < Gem::TestCase
       @indexer.generate_index
     end
 
-    prerelease_specs_path = File.join @tempdir, "prerelease_specs.#{@marshal_version}"
+    prerelease_specs_path = File.join @indexerdir, "prerelease_specs.#{@marshal_version}"
 
     prerelease_specs_dump = Gem.read_binary prerelease_specs_path
     prerelease_specs = Marshal.load prerelease_specs_dump
@@ -309,7 +303,7 @@ class TestGemIndexer < Gem::TestCase
       @indexer.generate_index
     end
 
-    quickdir = File.join @tempdir, 'quick'
+    quickdir = File.join @indexerdir, 'quick'
     marshal_quickdir = File.join quickdir, "Marshal.#{@marshal_version}"
 
     assert_directory_exists quickdir
@@ -323,7 +317,7 @@ class TestGemIndexer < Gem::TestCase
     util_build_gem @d2_1_a
     @d2_1_a_tuple = [@d2_1_a.name, @d2_1_a.version, @d2_1_a.original_platform]
 
-    gems = File.join @tempdir, 'gems'
+    gems = File.join @indexerdir, 'gems'
 
     FileUtils.mv @d2_1.cache_file, gems
     FileUtils.mv @d2_1_a.cache_file, gems

--- a/test/rubygems/test_gem_install_update_options.rb
+++ b/test/rubygems/test_gem_install_update_options.rb
@@ -112,6 +112,13 @@ class TestGemInstallUpdateOptions < Gem::InstallerTestCase
   end
 
   def test_user_install_enabled
+    @spec = quick_gem 'a' do |spec|
+      util_make_exec spec
+    end
+
+    util_build_gem @spec
+    @gem = @spec.cache_file
+
     @cmd.handle_options %w[--user-install]
 
     assert @cmd.options[:user_install]
@@ -123,6 +130,13 @@ class TestGemInstallUpdateOptions < Gem::InstallerTestCase
   end
 
   def test_user_install_disabled_read_only
+    @spec = quick_gem 'a' do |spec|
+      util_make_exec spec
+    end
+
+    util_build_gem @spec
+    @gem = @spec.cache_file
+
     if win_platform?
       skip('test_user_install_disabled_read_only test skipped on MS Windows')
     elsif Process.uid.zero?

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -460,7 +460,7 @@ gem 'other', version
   def test_generate_bin_script_no_execs
     @installer = setup_base_installer
 
-    util_execless
+    @installer = util_execless
 
     @installer.wrappers = true
     @installer.generate_bin
@@ -563,7 +563,7 @@ gem 'other', version
   def test_generate_bin_symlink_no_execs
     @installer = setup_base_installer
 
-    util_execless
+    @installer = util_execless
 
     @installer.wrappers = false
     @installer.generate_bin
@@ -2068,7 +2068,7 @@ gem 'other', version
     @spec = util_spec 'z'
     util_build_gem @spec
 
-    @installer = util_installer @spec, @gemhome
+    util_installer @spec, @gemhome
   end
 
   def util_conflict_executable(wrappers)

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -841,8 +841,6 @@ gem 'other', version
 
     assert_path_exists rakefile
 
-    spec_file = File.join(@gemhome, 'specifications', @spec.spec_name)
-
     assert_equal spec_file, @newspec.loaded_from
     assert_path_exists spec_file
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -34,7 +34,7 @@ class TestGemInstaller < Gem::InstallerTestCase
   end
 
   def test_app_script_text
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     util_make_exec @spec, ''
 
@@ -68,14 +68,14 @@ load Gem.bin_path("a", "executable", version)
 end
     EOF
 
-    wrapper = @installer.app_script_text 'executable'
+    wrapper = installer.app_script_text 'executable'
     assert_equal expected, wrapper
   end
 
   def test_check_executable_overwrite
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
-    @installer.generate_bin
+    installer.generate_bin
 
     @spec = Gem::Specification.new do |s|
       s.files = ['lib/code.rb']
@@ -87,9 +87,9 @@ end
     end
 
     util_make_exec
-    @installer.gem_dir = @spec.gem_dir
-    @installer.wrappers = true
-    @installer.generate_bin
+    installer.gem_dir = @spec.gem_dir
+    installer.wrappers = true
+    installer.generate_bin
 
     installed_exec = File.join util_inst_bindir, 'executable'
     assert_path_exists installed_exec
@@ -99,7 +99,7 @@ end
   end
 
   def test_check_executable_overwrite_default_bin_dir
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     if defined?(RUBY_FRAMEWORK_VERSION)
       orig_RUBY_FRAMEWORK_VERSION = RUBY_FRAMEWORK_VERSION
@@ -113,7 +113,7 @@ end
     ui = Gem::MockGemUi.new "n\n"
     use_ui ui do
       e = assert_raises Gem::InstallError do
-        @installer.generate_bin
+        installer.generate_bin
       end
 
       conflicted = File.join @gemhome, 'bin', 'executable'
@@ -131,9 +131,9 @@ end
   end
 
   def test_check_executable_overwrite_format_executable
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
-    @installer.generate_bin
+    installer.generate_bin
 
     @spec = Gem::Specification.new do |s|
       s.files = ['lib/code.rb']
@@ -156,11 +156,11 @@ gem 'other', version
 
     util_make_exec
     Gem::Installer.exec_format = 'foo-%s-bar'
-    @installer.gem_dir = @spec.gem_dir
-    @installer.wrappers = true
-    @installer.format_executable = true
+    installer.gem_dir = @spec.gem_dir
+    installer.wrappers = true
+    installer.format_executable = true
 
-    @installer.generate_bin # should not raise
+    installer.generate_bin # should not raise
 
     installed_exec = File.join util_inst_bindir, 'foo-executable-bar'
     assert_path_exists installed_exec
@@ -172,7 +172,7 @@ gem 'other', version
   end
 
   def test_check_executable_overwrite_other_gem
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     util_conflict_executable true
 
@@ -180,7 +180,7 @@ gem 'other', version
 
     use_ui ui do
       e = assert_raises Gem::InstallError do
-        @installer.generate_bin
+        installer.generate_bin
       end
 
       assert_equal '"executable" from a conflicts with installed executable from conflict',
@@ -189,13 +189,13 @@ gem 'other', version
   end
 
   def test_check_executable_overwrite_other_gem_force
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     util_conflict_executable true
-    @installer.wrappers = true
-    @installer.force = true
+    installer.wrappers = true
+    installer.force = true
 
-    @installer.generate_bin
+    installer.generate_bin
 
     installed_exec = File.join util_inst_bindir, 'executable'
     assert_path_exists installed_exec
@@ -205,12 +205,12 @@ gem 'other', version
   end
 
   def test_check_executable_overwrite_other_non_gem
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     util_conflict_executable false
-    @installer.wrappers = true
+    installer.wrappers = true
 
-    @installer.generate_bin
+    installer.generate_bin
 
     installed_exec = File.join util_inst_bindir, 'executable'
     assert_path_exists installed_exec
@@ -220,9 +220,9 @@ gem 'other', version
   end unless Gem.win_platform?
 
   def test_check_that_user_bin_dir_is_in_path
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
-    bin_dir = @installer.bin_dir
+    bin_dir = installer.bin_dir
 
     if Gem.win_platform?
       bin_dir = bin_dir.downcase.gsub(File::SEPARATOR, File::ALT_SEPARATOR)
@@ -232,7 +232,7 @@ gem 'other', version
       ENV['PATH'], [ENV['PATH'], bin_dir].join(File::PATH_SEPARATOR)
 
     use_ui @ui do
-      @installer.check_that_user_bin_dir_is_in_path
+      installer.check_that_user_bin_dir_is_in_path
     end
 
     assert_empty @ui.error
@@ -246,11 +246,11 @@ gem 'other', version
     orig_PATH, ENV['PATH'] =
       ENV['PATH'], [ENV['PATH'], '~/bin'].join(File::PATH_SEPARATOR)
 
-    @installer = setup_base_installer
-    @installer.bin_dir.replace File.join @userhome, 'bin'
+    installer = setup_base_installer
+    installer.bin_dir.replace File.join @userhome, 'bin'
 
     use_ui @ui do
-      @installer.check_that_user_bin_dir_is_in_path
+      installer.check_that_user_bin_dir_is_in_path
     end
 
     assert_empty @ui.error
@@ -259,13 +259,13 @@ gem 'other', version
   end
 
   def test_check_that_user_bin_dir_is_in_path_not_in_path
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     use_ui @ui do
-      @installer.check_that_user_bin_dir_is_in_path
+      installer.check_that_user_bin_dir_is_in_path
     end
 
-    expected = @installer.bin_dir
+    expected = installer.bin_dir
 
     if Gem.win_platform?
       expected = expected.downcase.gsub(File::SEPARATOR, File::ALT_SEPARATOR)
@@ -275,16 +275,16 @@ gem 'other', version
   end
 
   def test_ensure_dependency
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     util_spec 'a'
 
     dep = Gem::Dependency.new 'a', '>= 2'
-    assert @installer.ensure_dependency(@spec, dep)
+    assert installer.ensure_dependency(@spec, dep)
 
     dep = Gem::Dependency.new 'b', '> 2'
     e = assert_raises Gem::InstallError do
-      @installer.ensure_dependency @spec, dep
+      installer.ensure_dependency @spec, dep
     end
 
     assert_equal 'a requires b (> 2)', e.message
@@ -321,30 +321,30 @@ gem 'other', version
   end
 
   def test_extract_files
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
-    @installer.extract_files
+    installer.extract_files
 
     assert_path_exists File.join @spec.gem_dir, 'bin/executable'
   end
 
   def test_generate_bin_bindir
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
-    @installer.wrappers = true
+    installer.wrappers = true
 
     @spec.executables = %w[executable]
     @spec.bindir = 'bin'
 
-    exec_file = @installer.formatted_program_filename 'executable'
+    exec_file = installer.formatted_program_filename 'executable'
     exec_path = File.join @spec.gem_dir, exec_file
     File.open exec_path, 'w' do |f|
       f.puts '#!/usr/bin/ruby'
     end
 
-    @installer.gem_dir = @spec.gem_dir
+    installer.gem_dir = @spec.gem_dir
 
-    @installer.generate_bin
+    installer.generate_bin
 
     assert_directory_exists util_inst_bindir
     installed_exec = File.join(util_inst_bindir, 'executable')
@@ -382,13 +382,13 @@ gem 'other', version
   end
 
   def test_generate_bin_script
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
-    @installer.wrappers = true
+    installer.wrappers = true
     util_make_exec
-    @installer.gem_dir = @spec.gem_dir
+    installer.gem_dir = @spec.gem_dir
 
-    @installer.generate_bin
+    installer.generate_bin
     assert_directory_exists util_inst_bindir
     installed_exec = File.join util_inst_bindir, 'executable'
     assert_path_exists installed_exec
@@ -399,15 +399,15 @@ gem 'other', version
   end
 
   def test_generate_bin_script_format
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
-    @installer.format_executable = true
-    @installer.wrappers = true
+    installer.format_executable = true
+    installer.wrappers = true
     util_make_exec
-    @installer.gem_dir = @spec.gem_dir
+    installer.gem_dir = @spec.gem_dir
 
     Gem::Installer.exec_format = 'foo-%s-bar'
-    @installer.generate_bin
+    installer.generate_bin
     assert_directory_exists util_inst_bindir
     installed_exec = File.join util_inst_bindir, 'foo-executable-bar'
     assert_path_exists installed_exec
@@ -416,14 +416,14 @@ gem 'other', version
   end
 
   def test_generate_bin_script_format_disabled
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
-    @installer.wrappers = true
+    installer.wrappers = true
     util_make_exec
-    @installer.gem_dir = @spec.gem_dir
+    installer.gem_dir = @spec.gem_dir
 
     Gem::Installer.exec_format = 'foo-%s-bar'
-    @installer.generate_bin
+    installer.generate_bin
     assert_directory_exists util_inst_bindir
     installed_exec = File.join util_inst_bindir, 'executable'
     assert_path_exists installed_exec
@@ -432,9 +432,9 @@ gem 'other', version
   end
 
   def test_generate_bin_script_install_dir
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
-    @installer.wrappers = true
+    installer.wrappers = true
 
     gem_dir = File.join("#{@gemhome}2", "gems", @spec.full_name)
     gem_bindir = File.join gem_dir, 'bin'
@@ -443,11 +443,11 @@ gem 'other', version
       f.puts "#!/bin/ruby"
     end
 
-    @installer.gem_home = "#{@gemhome}2"
-    @installer.gem_dir = gem_dir
-    @installer.bin_dir = File.join "#{@gemhome}2", 'bin'
+    installer.gem_home = "#{@gemhome}2"
+    installer.gem_dir = gem_dir
+    installer.bin_dir = File.join "#{@gemhome}2", 'bin'
 
-    @installer.generate_bin
+    installer.generate_bin
 
     installed_exec = File.join("#{@gemhome}2", "bin", 'executable')
     assert_path_exists installed_exec
@@ -458,20 +458,20 @@ gem 'other', version
   end
 
   def test_generate_bin_script_no_execs
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
-    @installer = util_execless
+    installer = util_execless
 
-    @installer.wrappers = true
-    @installer.generate_bin
+    installer.wrappers = true
+    installer.generate_bin
 
     refute_path_exists util_inst_bindir, 'bin dir was created when not needed'
   end
 
   def test_generate_bin_script_no_perms
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
-    @installer.wrappers = true
+    installer.wrappers = true
     util_make_exec
 
     Dir.mkdir util_inst_bindir
@@ -484,7 +484,7 @@ gem 'other', version
       FileUtils.chmod 0000, util_inst_bindir
 
       assert_raises Gem::FilePermissionError do
-        @installer.generate_bin
+        installer.generate_bin
       end
     end
   ensure
@@ -492,9 +492,9 @@ gem 'other', version
   end
 
   def test_generate_bin_script_no_shebang
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
-    @installer.wrappers = true
+    installer.wrappers = true
     @spec.executables = %w[executable]
 
     gem_dir = File.join @gemhome, 'gems', @spec.full_name
@@ -504,7 +504,7 @@ gem 'other', version
       f.puts "blah blah blah"
     end
 
-    @installer.generate_bin
+    installer.generate_bin
 
     installed_exec = File.join @gemhome, 'bin', 'executable'
     assert_path_exists installed_exec
@@ -517,11 +517,11 @@ gem 'other', version
   end
 
   def test_generate_bin_script_wrappers
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
-    @installer.wrappers = true
+    installer.wrappers = true
     util_make_exec
-    @installer.gem_dir = @spec.gem_dir
+    installer.gem_dir = @spec.gem_dir
     installed_exec = File.join(util_inst_bindir, 'executable')
 
     real_exec = File.join @spec.gem_dir, 'bin', 'executable'
@@ -532,7 +532,7 @@ gem 'other', version
       FileUtils.ln_s real_exec, installed_exec
     end
 
-    @installer.generate_bin
+    installer.generate_bin
     assert_directory_exists util_inst_bindir
     assert_path_exists installed_exec
     assert_equal mask, File.stat(installed_exec).mode unless win_platform?
@@ -546,13 +546,13 @@ gem 'other', version
   def test_generate_bin_symlink
     return if win_platform? #Windows FS do not support symlinks
 
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
-    @installer.wrappers = false
+    installer.wrappers = false
     util_make_exec
-    @installer.gem_dir = @spec.gem_dir
+    installer.gem_dir = @spec.gem_dir
 
-    @installer.generate_bin
+    installer.generate_bin
     assert_directory_exists util_inst_bindir
     installed_exec = File.join util_inst_bindir, 'executable'
     assert_equal true, File.symlink?(installed_exec)
@@ -561,22 +561,22 @@ gem 'other', version
   end
 
   def test_generate_bin_symlink_no_execs
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
-    @installer = util_execless
+    installer = util_execless
 
-    @installer.wrappers = false
-    @installer.generate_bin
+    installer.wrappers = false
+    installer.generate_bin
 
     refute_path_exists util_inst_bindir
   end
 
   def test_generate_bin_symlink_no_perms
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
-    @installer.wrappers = false
+    installer.wrappers = false
     util_make_exec
-    @installer.gem_dir = @spec.gem_dir
+    installer.gem_dir = @spec.gem_dir
 
     Dir.mkdir util_inst_bindir
 
@@ -588,7 +588,7 @@ gem 'other', version
       FileUtils.chmod 0000, util_inst_bindir
 
       assert_raises Gem::FilePermissionError do
-        @installer.generate_bin
+        installer.generate_bin
       end
     end
   ensure
@@ -598,13 +598,13 @@ gem 'other', version
   def test_generate_bin_symlink_update_newer
     return if win_platform? #Windows FS do not support symlinks
 
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
-    @installer.wrappers = false
+    installer.wrappers = false
     util_make_exec
-    @installer.gem_dir = @spec.gem_dir
+    installer.gem_dir = @spec.gem_dir
 
-    @installer.generate_bin
+    installer.generate_bin
     installed_exec = File.join(util_inst_bindir, 'executable')
     assert_equal(File.join(@spec.gem_dir, 'bin', 'executable'),
                  File.readlink(installed_exec))
@@ -619,8 +619,8 @@ gem 'other', version
     end
 
     util_make_exec
-    @installer.gem_dir = @spec.gem_dir
-    @installer.generate_bin
+    installer.gem_dir = @spec.gem_dir
+    installer.generate_bin
     installed_exec = File.join(util_inst_bindir, 'executable')
     assert_equal(@spec.bin_file('executable'),
                  File.readlink(installed_exec),
@@ -630,13 +630,13 @@ gem 'other', version
   def test_generate_bin_symlink_update_older
     return if !symlink_supported?
 
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
-    @installer.wrappers = false
+    installer.wrappers = false
     util_make_exec
-    @installer.gem_dir = @spec.gem_dir
+    installer.gem_dir = @spec.gem_dir
 
-    @installer.generate_bin
+    installer.generate_bin
     installed_exec = File.join(util_inst_bindir, 'executable')
     assert_equal(File.join(@spec.gem_dir, 'bin', 'executable'),
                  File.readlink(installed_exec))
@@ -653,10 +653,10 @@ gem 'other', version
     util_make_exec
     one = @spec.dup
     one.version = 1
-    @installer = Gem::Installer.for_spec spec
-    @installer.gem_dir = one.gem_dir
+    installer = Gem::Installer.for_spec spec
+    installer.gem_dir = one.gem_dir
 
-    @installer.generate_bin
+    installer.generate_bin
 
     installed_exec = File.join util_inst_bindir, 'executable'
     expected = File.join @spec.gem_dir, 'bin', 'executable'
@@ -668,13 +668,13 @@ gem 'other', version
   def test_generate_bin_symlink_update_remove_wrapper
     return if !symlink_supported?
 
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
-    @installer.wrappers = true
+    installer.wrappers = true
     util_make_exec
-    @installer.gem_dir = @spec.gem_dir
+    installer.gem_dir = @spec.gem_dir
 
-    @installer.generate_bin
+    installer.generate_bin
 
     installed_exec = File.join util_inst_bindir, 'executable'
     assert_path_exists installed_exec
@@ -690,10 +690,10 @@ gem 'other', version
     util_make_exec
 
     util_installer @spec, @gemhome
-    @installer.wrappers = false
-    @installer.gem_dir = @spec.gem_dir
+    installer.wrappers = false
+    installer.gem_dir = @spec.gem_dir
 
-    @installer.generate_bin
+    installer.generate_bin
 
     installed_exec = File.join util_inst_bindir, 'executable'
     assert_equal(@spec.bin_file('executable'),
@@ -708,14 +708,14 @@ gem 'other', version
     File.__send__(:remove_const, :ALT_SEPARATOR)
     File.const_set(:ALT_SEPARATOR, '\\')
 
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
-    @installer.wrappers = false
+    installer.wrappers = false
     util_make_exec
-    @installer.gem_dir = @spec.gem_dir
+    installer.gem_dir = @spec.gem_dir
 
     use_ui @ui do
-      @installer.generate_bin
+      installer.generate_bin
     end
 
     assert_directory_exists util_inst_bindir
@@ -741,12 +741,12 @@ gem 'other', version
   def test_generate_bin_uses_default_shebang
     return if !symlink_supported?
 
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
-    @installer.wrappers = true
+    installer.wrappers = true
     util_make_exec
 
-    @installer.generate_bin
+    installer.generate_bin
 
     default_shebang = Gem.ruby
     shebang_line = open("#{@gemhome}/bin/executable") { |f| f.readlines.first }
@@ -793,7 +793,7 @@ gem 'other', version
   end
 
   def test_install
-    @installer = util_setup_installer
+    installer = util_setup_installer
 
     gemdir     = File.join @gemhome, 'gems', @spec.full_name
     cache_file = File.join @gemhome, 'cache', @spec.file_name
@@ -823,7 +823,7 @@ gem 'other', version
     @newspec = nil
     build_rake_in do
       use_ui @ui do
-        @newspec = @installer.install
+        @newspec = installer.install
       end
     end
 
@@ -844,22 +844,22 @@ gem 'other', version
     assert_equal spec_file, @newspec.loaded_from
     assert_path_exists spec_file
 
-    assert_same @installer, @post_build_hook_arg
-    assert_same @installer, @post_install_hook_arg
-    assert_same @installer, @pre_install_hook_arg
+    assert_same installer, @post_build_hook_arg
+    assert_same installer, @post_install_hook_arg
+    assert_same installer, @pre_install_hook_arg
   end
 
   def test_install_creates_working_binstub
-    @installer = util_setup_installer
+    installer = util_setup_installer
 
-    @installer.wrappers = true
+    installer.wrappers = true
 
     gemdir = File.join @gemhome, 'gems', @spec.full_name
 
     @newspec = nil
     build_rake_in do
       use_ui @ui do
-        @newspec = @installer.install
+        @newspec = installer.install
       end
     end
 
@@ -876,7 +876,7 @@ gem 'other', version
     @gem = setup_base_gem
 
     # build old version that has a bin file
-    @installer = util_setup_gem do |spec|
+    installer = util_setup_gem do |spec|
       File.open File.join('bin', 'executable'), 'w' do |f|
         f.puts "require 'code'"
       end
@@ -885,17 +885,17 @@ gem 'other', version
       end
     end
 
-    @installer.wrappers = true
+    installer.wrappers = true
     build_rake_in do
       use_ui @ui do
-        @newspec = @installer.install
+        @newspec = installer.install
       end
     end
 
-    old_bin_file = File.join @installer.bin_dir, 'executable'
+    old_bin_file = File.join installer.bin_dir, 'executable'
 
     # build new version that doesn't have a bin file
-    @installer = util_setup_gem do |spec|
+    installer = util_setup_gem do |spec|
       FileUtils.rm File.join('bin', 'executable')
       spec.files.delete File.join('bin', 'executable')
       spec.executables.delete 'executable'
@@ -907,7 +907,7 @@ gem 'other', version
 
     build_rake_in do
       use_ui @ui do
-        @newspec = @installer.install
+        @newspec = installer.install
       end
     end
 
@@ -921,14 +921,14 @@ gem 'other', version
   end
 
   def test_install_creates_binstub_that_understand_version
-    @installer = util_setup_installer
+    installer = util_setup_installer
 
-    @installer.wrappers = true
+    installer.wrappers = true
 
     @newspec = nil
     build_rake_in do
       use_ui @ui do
-        @newspec = @installer.install
+        @newspec = installer.install
       end
     end
 
@@ -952,19 +952,19 @@ gem 'other', version
   def test_install_creates_binstub_that_prefers_user_installed_gem_to_default
     install_default_gems new_default_spec('default', '2')
 
-    @installer = util_setup_installer do |spec|
+    installer = util_setup_installer do |spec|
       spec.name = 'default'
       spec.version = '2'
     end
 
     util_clear_gems
 
-    @installer.wrappers = true
+    installer.wrappers = true
 
     @newspec = nil
     build_rake_in do
       use_ui @ui do
-        @newspec = @installer.install
+        @newspec = installer.install
       end
     end
 
@@ -978,14 +978,14 @@ gem 'other', version
   end
 
   def test_install_creates_binstub_that_dont_trust_encoding
-    @installer = util_setup_installer
+    installer = util_setup_installer
 
-    @installer.wrappers = true
+    installer.wrappers = true
 
     @newspec = nil
     build_rake_in do
       use_ui @ui do
-        @newspec = @installer.install
+        @newspec = installer.install
       end
     end
 
@@ -1008,18 +1008,18 @@ gem 'other', version
   end
 
   def test_install_with_no_prior_files
-    @installer = util_setup_installer
+    installer = util_setup_installer
 
     build_rake_in do
       use_ui @ui do
-        assert_equal @spec, @installer.install
+        assert_equal @spec, installer.install
       end
     end
 
     gemdir = File.join(@gemhome, 'gems', @spec.full_name)
     assert_path_exists File.join gemdir, 'lib', 'code.rb'
 
-    @installer = util_setup_installer
+    installer = util_setup_installer
 
     # Morph spec to have lib/other.rb instead of code.rb and recreate
     @spec.files = File.join('lib', 'other.rb')
@@ -1033,10 +1033,10 @@ gem 'other', version
         Gem::Package.build @spec
       end
     end
-    @installer = Gem::Installer.at @gem
+    installer = Gem::Installer.at @gem
     build_rake_in do
       use_ui @ui do
-        assert_equal @spec, @installer.install
+        assert_equal @spec, installer.install
       end
     end
 
@@ -1056,14 +1056,14 @@ gem 'other', version
   end
 
   def test_install_missing_dirs
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     FileUtils.rm_f File.join(Gem.dir, 'cache')
     FileUtils.rm_f File.join(Gem.dir, 'doc')
     FileUtils.rm_f File.join(Gem.dir, 'specifications')
 
     use_ui @ui do
-      @installer.install
+      installer.install
     end
 
     assert_directory_exists File.join(Gem.dir, 'cache')
@@ -1075,7 +1075,7 @@ gem 'other', version
   end
 
   def test_install_post_build_false
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     Gem.post_build do
       false
@@ -1083,7 +1083,7 @@ gem 'other', version
 
     use_ui @ui do
       e = assert_raises Gem::InstallError do
-        @installer.install
+        installer.install
       end
 
       location = "#{__FILE__}:#{__LINE__ - 9}"
@@ -1099,14 +1099,14 @@ gem 'other', version
   end
 
   def test_install_post_build_nil
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     Gem.post_build do
       nil
     end
 
     use_ui @ui do
-      @installer.install
+      installer.install
     end
 
     spec_file = File.join @gemhome, 'specifications', @spec.spec_name
@@ -1117,7 +1117,7 @@ gem 'other', version
   end
 
   def test_install_pre_install_false
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     Gem.pre_install do
       false
@@ -1125,7 +1125,7 @@ gem 'other', version
 
     use_ui @ui do
       e = assert_raises Gem::InstallError do
-        @installer.install
+        installer.install
       end
 
       location = "#{__FILE__}:#{__LINE__ - 9}"
@@ -1138,14 +1138,14 @@ gem 'other', version
   end
 
   def test_install_pre_install_nil
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     Gem.pre_install do
       nil
     end
 
     use_ui @ui do
-      @installer.install
+      installer.install
     end
 
     spec_file = File.join @gemhome, 'specifications', @spec.spec_name
@@ -1159,8 +1159,8 @@ gem 'other', version
     use_ui @ui do
       path = Gem::Package.build @spec
 
-      @installer = Gem::Installer.at path
-      @installer.install
+      installer = Gem::Installer.at path
+      installer.install
     end
 
     assert_match %r|I am a shiny gem!|, @ui.output
@@ -1173,8 +1173,8 @@ gem 'other', version
     use_ui @ui do
       path = Gem::Package.build @spec
 
-      @installer = Gem::Installer.at path, :post_install_message => false
-      @installer.install
+      installer = Gem::Installer.at path, :post_install_message => false
+      installer.install
     end
 
     refute_match %r|I am a shiny gem!|, @ui.output
@@ -1353,8 +1353,8 @@ gem 'other', version
     use_ui @ui do
       path = Gem::Package.build @spec
 
-      @installer = Gem::Installer.at path
-      @installer.install
+      installer = Gem::Installer.at path
+      installer.install
     end
     assert_path_exists File.join @spec.gem_dir, rb
     assert_path_exists File.join @spec.gem_dir, rb2
@@ -1390,8 +1390,8 @@ gem 'other', version
     use_ui @ui do
       path = Gem::Package.build @spec
 
-      @installer = Gem::Installer.at path
-      @installer.install
+      installer = Gem::Installer.at path
+      installer.install
     end
     assert_path_exists so
   rescue
@@ -1410,48 +1410,48 @@ gem 'other', version
   end
 
   def test_installation_satisfies_dependency_eh
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     util_spec 'a'
 
     dep = Gem::Dependency.new 'a', '>= 2'
-    assert @installer.installation_satisfies_dependency?(dep)
+    assert installer.installation_satisfies_dependency?(dep)
 
     dep = Gem::Dependency.new 'a', '> 2'
-    refute @installer.installation_satisfies_dependency?(dep)
+    refute installer.installation_satisfies_dependency?(dep)
   end
 
   def test_installation_satisfies_dependency_eh_development
-    @installer = setup_base_installer
-    @installer.options[:development] = true
-    @installer.options[:dev_shallow] = true
+    installer = setup_base_installer
+    installer.options[:development] = true
+    installer.options[:dev_shallow] = true
 
     util_spec 'a'
 
     dep = Gem::Dependency.new 'a', :development
-    assert @installer.installation_satisfies_dependency?(dep)
+    assert installer.installation_satisfies_dependency?(dep)
   end
 
   def test_pre_install_checks_dependencies
-    @installer = setup_base_installer
+    installer = setup_base_installer
     @spec.add_dependency 'b', '> 5'
-    @installer = util_setup_gem
+    installer = util_setup_gem
 
     use_ui @ui do
       assert_raises Gem::InstallError do
-        @installer.install
+        installer.install
       end
     end
   end
 
   def test_pre_install_checks_dependencies_ignore
-    @installer = util_setup_installer
+    installer = util_setup_installer
     @spec.add_dependency 'b', '> 5'
-    @installer.ignore_dependencies = true
+    installer.ignore_dependencies = true
 
     build_rake_in do
       use_ui @ui do
-        assert @installer.pre_install_checks
+        assert installer.pre_install_checks
       end
     end
   end
@@ -1522,9 +1522,9 @@ gem 'other', version
     gem = File.join(@gemhome, 'cache', spec.file_name)
 
     use_ui @ui do
-      @installer = Gem::Installer.at gem
+      installer = Gem::Installer.at gem
       e = assert_raises Gem::RuntimeRequirementNotMetError do
-        @installer.pre_install_checks
+        installer.pre_install_checks
       end
       rgv = Gem::VERSION
       assert_equal "old_rubygems_required requires RubyGems version < 0. The current RubyGems version is #{rgv}. " +
@@ -1544,9 +1544,9 @@ gem 'other', version
     gem = File.join(@gemhome, 'cache', spec.file_name)
 
     use_ui @ui do
-      @installer = Gem::Installer.at gem
+      installer = Gem::Installer.at gem
       e = assert_raises Gem::InstallError do
-        @installer.pre_install_checks
+        installer.pre_install_checks
       end
       assert_equal '#<Gem::Specification name=../malicious version=1> has an invalid name', e.message
     end
@@ -1564,9 +1564,9 @@ gem 'other', version
     gem = File.join(@gemhome, 'cache', spec.file_name)
 
     use_ui @ui do
-      @installer = Gem::Installer.at gem
+      installer = Gem::Installer.at gem
       e = assert_raises Gem::InstallError do
-        @installer.pre_install_checks
+        installer.pre_install_checks
       end
       assert_equal "#<Gem::Specification name=malicious\n::Object.const_set(:FROM_EVAL, true)# version=1> has an invalid name", e.message
     end
@@ -1586,9 +1586,9 @@ gem 'other', version
     gem = File.join(@gemhome, 'cache', spec.file_name)
 
     use_ui @ui do
-      @installer = Gem::Installer.at gem
+      installer = Gem::Installer.at gem
       e = assert_raises Gem::InstallError do
-        @installer.pre_install_checks
+        installer.pre_install_checks
       end
       assert_equal "#<Gem::Specification name=malicious version=1> has an invalid require_paths", e.message
     end
@@ -1609,9 +1609,9 @@ gem 'other', version
     gem = File.join(@gemhome, 'cache', spec.file_name)
 
     use_ui @ui do
-      @installer = Gem::Installer.at gem
+      installer = Gem::Installer.at gem
       e = assert_raises Gem::InstallError do
-        @installer.pre_install_checks
+        installer.pre_install_checks
       end
       assert_equal "#<Gem::Specification name=malicious version=1> has an invalid extensions", e.message
     end
@@ -1630,9 +1630,9 @@ gem 'other', version
     gem = File.join(@gemhome, 'cache', spec.file_name)
 
     use_ui @ui do
-      @installer = Gem::Installer.at gem
+      installer = Gem::Installer.at gem
       e = assert_raises Gem::InstallError do
-        @installer.pre_install_checks
+        installer.pre_install_checks
       end
       assert_equal "#<Gem::Specification name=malicious version=1> has an invalid specification_version", e.message
     end
@@ -1651,90 +1651,90 @@ gem 'other', version
     gem = File.join(@gemhome, 'cache', spec.file_name)
 
     use_ui @ui do
-      @installer = Gem::Installer.at gem
-      @installer.ignore_dependencies = true
+      installer = Gem::Installer.at gem
+      installer.ignore_dependencies = true
       e = assert_raises Gem::InstallError do
-        @installer.pre_install_checks
+        installer.pre_install_checks
       end
       assert_equal "#<Gem::Specification name=malicious version=1> has an invalid dependencies", e.message
     end
   end
 
   def test_shebang
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     util_make_exec @spec, "#!/usr/bin/ruby"
 
-    shebang = @installer.shebang 'executable'
+    shebang = installer.shebang 'executable'
 
     assert_equal "#!#{Gem.ruby}", shebang
   end
 
   def test_process_options
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
-    assert_nil @installer.build_root
-    assert_equal File.join(@gemhome, 'bin'), @installer.bin_dir
-    assert_equal @gemhome, @installer.gem_home
+    assert_nil installer.build_root
+    assert_equal File.join(@gemhome, 'bin'), installer.bin_dir
+    assert_equal @gemhome, installer.gem_home
   end
 
   def test_process_options_build_root
     build_root = File.join @tempdir, 'build_root'
 
     @gem = setup_base_gem
-    @installer = Gem::Installer.at @gem, :build_root => build_root
+    installer = Gem::Installer.at @gem, :build_root => build_root
 
-    assert_equal Pathname(build_root), @installer.build_root
-    assert_equal File.join(build_root, @gemhome, 'bin'), @installer.bin_dir
-    assert_equal File.join(build_root, @gemhome), @installer.gem_home
+    assert_equal Pathname(build_root), installer.build_root
+    assert_equal File.join(build_root, @gemhome, 'bin'), installer.bin_dir
+    assert_equal File.join(build_root, @gemhome), installer.gem_home
   end
 
   def test_shebang_arguments
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     util_make_exec @spec, "#!/usr/bin/ruby -ws"
 
-    shebang = @installer.shebang 'executable'
+    shebang = installer.shebang 'executable'
 
     assert_equal "#!#{Gem.ruby} -ws", shebang
   end
 
   def test_shebang_empty
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     util_make_exec @spec, ''
 
-    shebang = @installer.shebang 'executable'
+    shebang = installer.shebang 'executable'
     assert_equal "#!#{Gem.ruby}", shebang
   end
 
   def test_shebang_env
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     util_make_exec @spec, "#!/usr/bin/env ruby"
 
-    shebang = @installer.shebang 'executable'
+    shebang = installer.shebang 'executable'
 
     assert_equal "#!#{Gem.ruby}", shebang
   end
 
   def test_shebang_env_arguments
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     util_make_exec @spec, "#!/usr/bin/env ruby -ws"
 
-    shebang = @installer.shebang 'executable'
+    shebang = installer.shebang 'executable'
 
     assert_equal "#!#{Gem.ruby} -ws", shebang
   end
 
   def test_shebang_env_shebang
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     util_make_exec @spec, ''
-    @installer.env_shebang = true
+    installer.env_shebang = true
 
-    shebang = @installer.shebang 'executable'
+    shebang = installer.shebang 'executable'
 
     env_shebang = "/usr/bin/env" unless Gem.win_platform?
 
@@ -1743,67 +1743,67 @@ gem 'other', version
   end
 
   def test_shebang_nested
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     util_make_exec @spec, "#!/opt/local/ruby/bin/ruby"
 
-    shebang = @installer.shebang 'executable'
+    shebang = installer.shebang 'executable'
 
     assert_equal "#!#{Gem.ruby}", shebang
   end
 
   def test_shebang_nested_arguments
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     util_make_exec @spec, "#!/opt/local/ruby/bin/ruby -ws"
 
-    shebang = @installer.shebang 'executable'
+    shebang = installer.shebang 'executable'
 
     assert_equal "#!#{Gem.ruby} -ws", shebang
   end
 
   def test_shebang_version
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     util_make_exec @spec, "#!/usr/bin/ruby18"
 
-    shebang = @installer.shebang 'executable'
+    shebang = installer.shebang 'executable'
 
     assert_equal "#!#{Gem.ruby}", shebang
   end
 
   def test_shebang_version_arguments
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     util_make_exec @spec, "#!/usr/bin/ruby18 -ws"
 
-    shebang = @installer.shebang 'executable'
+    shebang = installer.shebang 'executable'
 
     assert_equal "#!#{Gem.ruby} -ws", shebang
   end
 
   def test_shebang_version_env
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     util_make_exec @spec, "#!/usr/bin/env ruby18"
 
-    shebang = @installer.shebang 'executable'
+    shebang = installer.shebang 'executable'
 
     assert_equal "#!#{Gem.ruby}", shebang
   end
 
   def test_shebang_version_env_arguments
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     util_make_exec @spec, "#!/usr/bin/env ruby18 -ws"
 
-    shebang = @installer.shebang 'executable'
+    shebang = installer.shebang 'executable'
 
     assert_equal "#!#{Gem.ruby} -ws", shebang
   end
 
   def test_shebang_custom
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     conf = Gem::ConfigFile.new []
     conf[:custom_shebang] = 'test'
@@ -1812,13 +1812,13 @@ gem 'other', version
 
     util_make_exec @spec, "#!/usr/bin/ruby"
 
-    shebang = @installer.shebang 'executable'
+    shebang = installer.shebang 'executable'
 
     assert_equal "#!test", shebang
   end
 
   def test_shebang_custom_with_expands
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     bin_env = win_platform? ? '' : '/usr/bin/env'
     conf = Gem::ConfigFile.new []
@@ -1828,13 +1828,13 @@ gem 'other', version
 
     util_make_exec @spec, "#!/usr/bin/ruby"
 
-    shebang = @installer.shebang 'executable'
+    shebang = installer.shebang 'executable'
 
     assert_equal "#!1 #{bin_env} 2 #{Gem.ruby} 3 executable 4 a", shebang
   end
 
   def test_shebang_custom_with_expands_and_arguments
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     bin_env = win_platform? ? '' : '/usr/bin/env'
     conf = Gem::ConfigFile.new []
@@ -1844,18 +1844,18 @@ gem 'other', version
 
     util_make_exec @spec, "#!/usr/bin/ruby -ws"
 
-    shebang = @installer.shebang 'executable'
+    shebang = installer.shebang 'executable'
 
     assert_equal "#!1 #{bin_env} 2 #{Gem.ruby} -ws 3 executable", shebang
   end
 
   def test_unpack
-    @installer = util_setup_installer
+    installer = util_setup_installer
 
     dest = File.join @gemhome, 'gems', @spec.full_name
 
     Gem::Deprecate.skip_during do
-      @installer.unpack dest
+      installer.unpack dest
     end
 
     assert_path_exists File.join dest, 'lib', 'code.rb'
@@ -1863,15 +1863,15 @@ gem 'other', version
   end
 
   def test_write_build_info_file
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     refute_path_exists @spec.build_info_file
 
-    @installer.build_args = %w[
+    installer.build_args = %w[
       --with-libyaml-dir /usr/local/Cellar/libyaml/0.1.4
     ]
 
-    @installer.write_build_info_file
+    installer.write_build_info_file
 
     assert_path_exists @spec.build_info_file
 
@@ -1881,11 +1881,11 @@ gem 'other', version
   end
 
   def test_write_build_info_file_empty
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     refute_path_exists @spec.build_info_file
 
-    @installer.write_build_info_file
+    installer.write_build_info_file
 
     refute_path_exists @spec.build_info_file
   end
@@ -1926,10 +1926,10 @@ gem 'other', version
     FileUtils.rm @spec.spec_file
     refute_path_exists @spec.spec_file
 
-    @installer = Gem::Installer.for_spec @spec
-    @installer.gem_home = @gemhome
+    installer = Gem::Installer.for_spec @spec
+    installer.gem_home = @gemhome
 
-    @installer.write_spec
+    installer.write_spec
 
     assert_path_exists @spec.spec_file
 
@@ -1947,10 +1947,10 @@ gem 'other', version
 
     @spec.files = %w[a.rb b.rb c.rb]
 
-    @installer = Gem::Installer.for_spec @spec
-    @installer.gem_home = @gemhome
+    installer = Gem::Installer.for_spec @spec
+    installer.gem_home = @gemhome
 
-    @installer.write_spec
+    installer.write_spec
 
     # cached specs have no file manifest:
     @spec.files = []
@@ -1959,9 +1959,9 @@ gem 'other', version
   end
 
   def test_dir
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
-    assert_match %r!/gemhome/gems/a-2$!, @installer.dir
+    assert_match %r!/gemhome/gems/a-2$!, installer.dir
   end
 
   def test_default_gem_loaded_from
@@ -1972,16 +1972,16 @@ gem 'other', version
   end
 
   def test_default_gem_without_wrappers
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
     FileUtils.rm_f File.join(Gem.dir, 'specifications')
 
-    @installer.wrappers = false
-    @installer.options[:install_as_default] = true
-    @installer.gem_dir = @spec.gem_dir
+    installer.wrappers = false
+    installer.options[:install_as_default] = true
+    installer.gem_dir = @spec.gem_dir
 
     use_ui @ui do
-      @installer.install
+      installer.install
     end
 
     assert_directory_exists File.join(@spec.gem_dir, 'bin')
@@ -2005,14 +2005,14 @@ gem 'other', version
   end
 
   def test_default_gem_with_wrappers
-    @installer = setup_base_installer
+    installer = setup_base_installer
 
-    @installer.wrappers = true
-    @installer.options[:install_as_default] = true
-    @installer.gem_dir = @spec.gem_dir
+    installer.wrappers = true
+    installer.options[:install_as_default] = true
+    installer.gem_dir = @spec.gem_dir
 
     use_ui @ui do
-      @installer.install
+      installer.install
     end
 
     assert_directory_exists util_inst_bindir

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -20,7 +20,6 @@ class TestGemInstaller < Gem::InstallerTestCase
 
   def setup
     super
-    @installer = setup_base_installer
     common_installer_setup
 
     @config = Gem.configuration
@@ -35,6 +34,8 @@ class TestGemInstaller < Gem::InstallerTestCase
   end
 
   def test_app_script_text
+    @installer = setup_base_installer
+
     util_make_exec @spec, ''
 
     expected = <<-EOF
@@ -72,6 +73,8 @@ end
   end
 
   def test_check_executable_overwrite
+    @installer = setup_base_installer
+
     @installer.generate_bin
 
     @spec = Gem::Specification.new do |s|
@@ -96,6 +99,8 @@ end
   end
 
   def test_check_executable_overwrite_default_bin_dir
+    @installer = setup_base_installer
+
     if defined?(RUBY_FRAMEWORK_VERSION)
       orig_RUBY_FRAMEWORK_VERSION = RUBY_FRAMEWORK_VERSION
       Object.send :remove_const, :RUBY_FRAMEWORK_VERSION
@@ -126,6 +131,8 @@ end
   end
 
   def test_check_executable_overwrite_format_executable
+    @installer = setup_base_installer
+
     @installer.generate_bin
 
     @spec = Gem::Specification.new do |s|
@@ -165,6 +172,8 @@ gem 'other', version
   end
 
   def test_check_executable_overwrite_other_gem
+    @installer = setup_base_installer
+
     util_conflict_executable true
 
     ui = Gem::MockGemUi.new "n\n"
@@ -180,6 +189,8 @@ gem 'other', version
   end
 
   def test_check_executable_overwrite_other_gem_force
+    @installer = setup_base_installer
+
     util_conflict_executable true
     @installer.wrappers = true
     @installer.force = true
@@ -194,6 +205,8 @@ gem 'other', version
   end
 
   def test_check_executable_overwrite_other_non_gem
+    @installer = setup_base_installer
+
     util_conflict_executable false
     @installer.wrappers = true
 
@@ -207,6 +220,8 @@ gem 'other', version
   end unless Gem.win_platform?
 
   def test_check_that_user_bin_dir_is_in_path
+    @installer = setup_base_installer
+
     bin_dir = @installer.bin_dir
 
     if Gem.win_platform?
@@ -231,6 +246,7 @@ gem 'other', version
     orig_PATH, ENV['PATH'] =
       ENV['PATH'], [ENV['PATH'], '~/bin'].join(File::PATH_SEPARATOR)
 
+    @installer = setup_base_installer
     @installer.bin_dir.replace File.join @userhome, 'bin'
 
     use_ui @ui do
@@ -243,6 +259,8 @@ gem 'other', version
   end
 
   def test_check_that_user_bin_dir_is_in_path_not_in_path
+    @installer = setup_base_installer
+
     use_ui @ui do
       @installer.check_that_user_bin_dir_is_in_path
     end
@@ -257,6 +275,8 @@ gem 'other', version
   end
 
   def test_ensure_dependency
+    @installer = setup_base_installer
+
     util_spec 'a'
 
     dep = Gem::Dependency.new 'a', '>= 2'
@@ -301,12 +321,16 @@ gem 'other', version
   end
 
   def test_extract_files
+    @installer = setup_base_installer
+
     @installer.extract_files
 
     assert_path_exists File.join @spec.gem_dir, 'bin/executable'
   end
 
   def test_generate_bin_bindir
+    @installer = setup_base_installer
+
     @installer.wrappers = true
 
     @spec.executables = %w[executable]
@@ -358,6 +382,8 @@ gem 'other', version
   end
 
   def test_generate_bin_script
+    @installer = setup_base_installer
+
     @installer.wrappers = true
     util_make_exec
     @installer.gem_dir = @spec.gem_dir
@@ -373,6 +399,8 @@ gem 'other', version
   end
 
   def test_generate_bin_script_format
+    @installer = setup_base_installer
+
     @installer.format_executable = true
     @installer.wrappers = true
     util_make_exec
@@ -388,6 +416,8 @@ gem 'other', version
   end
 
   def test_generate_bin_script_format_disabled
+    @installer = setup_base_installer
+
     @installer.wrappers = true
     util_make_exec
     @installer.gem_dir = @spec.gem_dir
@@ -402,6 +432,8 @@ gem 'other', version
   end
 
   def test_generate_bin_script_install_dir
+    @installer = setup_base_installer
+
     @installer.wrappers = true
 
     gem_dir = File.join("#{@gemhome}2", "gems", @spec.full_name)
@@ -426,6 +458,8 @@ gem 'other', version
   end
 
   def test_generate_bin_script_no_execs
+    @installer = setup_base_installer
+
     util_execless
 
     @installer.wrappers = true
@@ -435,6 +469,8 @@ gem 'other', version
   end
 
   def test_generate_bin_script_no_perms
+    @installer = setup_base_installer
+
     @installer.wrappers = true
     util_make_exec
 
@@ -456,6 +492,8 @@ gem 'other', version
   end
 
   def test_generate_bin_script_no_shebang
+    @installer = setup_base_installer
+
     @installer.wrappers = true
     @spec.executables = %w[executable]
 
@@ -479,6 +517,8 @@ gem 'other', version
   end
 
   def test_generate_bin_script_wrappers
+    @installer = setup_base_installer
+
     @installer.wrappers = true
     util_make_exec
     @installer.gem_dir = @spec.gem_dir
@@ -506,6 +546,8 @@ gem 'other', version
   def test_generate_bin_symlink
     return if win_platform? #Windows FS do not support symlinks
 
+    @installer = setup_base_installer
+
     @installer.wrappers = false
     util_make_exec
     @installer.gem_dir = @spec.gem_dir
@@ -519,6 +561,8 @@ gem 'other', version
   end
 
   def test_generate_bin_symlink_no_execs
+    @installer = setup_base_installer
+
     util_execless
 
     @installer.wrappers = false
@@ -528,6 +572,8 @@ gem 'other', version
   end
 
   def test_generate_bin_symlink_no_perms
+    @installer = setup_base_installer
+
     @installer.wrappers = false
     util_make_exec
     @installer.gem_dir = @spec.gem_dir
@@ -551,6 +597,8 @@ gem 'other', version
 
   def test_generate_bin_symlink_update_newer
     return if win_platform? #Windows FS do not support symlinks
+
+    @installer = setup_base_installer
 
     @installer.wrappers = false
     util_make_exec
@@ -581,6 +629,8 @@ gem 'other', version
 
   def test_generate_bin_symlink_update_older
     return if !symlink_supported?
+
+    @installer = setup_base_installer
 
     @installer.wrappers = false
     util_make_exec
@@ -617,6 +667,8 @@ gem 'other', version
 
   def test_generate_bin_symlink_update_remove_wrapper
     return if !symlink_supported?
+
+    @installer = setup_base_installer
 
     @installer.wrappers = true
     util_make_exec
@@ -655,6 +707,9 @@ gem 'other', version
     old_alt_separator = File::ALT_SEPARATOR
     File.__send__(:remove_const, :ALT_SEPARATOR)
     File.const_set(:ALT_SEPARATOR, '\\')
+
+    @installer = setup_base_installer
+
     @installer.wrappers = false
     util_make_exec
     @installer.gem_dir = @spec.gem_dir
@@ -686,6 +741,8 @@ gem 'other', version
   def test_generate_bin_uses_default_shebang
     return if !symlink_supported?
 
+    @installer = setup_base_installer
+
     @installer.wrappers = true
     util_make_exec
 
@@ -715,6 +772,8 @@ gem 'other', version
   end
 
   def test_initialize_user_install
+    @gem = setup_base_gem
+
     installer = Gem::Installer.at @gem, :user_install => true
 
     assert_equal File.join(Gem.user_dir, 'gems', @spec.full_name),
@@ -723,6 +782,8 @@ gem 'other', version
   end
 
   def test_initialize_user_install_bin_dir
+    @gem = setup_base_gem
+
     installer =
       Gem::Installer.at @gem, :user_install => true, :bin_dir => @tempdir
 
@@ -733,7 +794,8 @@ gem 'other', version
 
   def test_install
     Dir.mkdir util_inst_bindir
-    @installer = util_setup_gem
+
+    @installer = util_setup_installer
 
     gemdir     = File.join @gemhome, 'gems', @spec.full_name
     cache_file = File.join @gemhome, 'cache', @spec.file_name
@@ -793,7 +855,8 @@ gem 'other', version
 
   def test_install_creates_working_binstub
     Dir.mkdir util_inst_bindir
-    @installer = util_setup_gem
+
+    @installer = util_setup_installer
 
     @installer.wrappers = true
 
@@ -817,6 +880,8 @@ gem 'other', version
 
   def test_conflicting_binstubs
     Dir.mkdir util_inst_bindir
+
+    @gem = setup_base_gem
 
     # build old version that has a bin file
     @installer = util_setup_gem do |spec|
@@ -865,7 +930,8 @@ gem 'other', version
 
   def test_install_creates_binstub_that_understand_version
     Dir.mkdir util_inst_bindir
-    @installer = util_setup_gem
+
+    @installer = util_setup_installer
 
     @installer.wrappers = true
 
@@ -898,7 +964,7 @@ gem 'other', version
 
     install_default_gems new_default_spec('default', '2')
 
-    @installer = util_setup_gem do |spec|
+    @installer = util_setup_installer do |spec|
       spec.name = 'default'
       spec.version = '2'
     end
@@ -925,7 +991,8 @@ gem 'other', version
 
   def test_install_creates_binstub_that_dont_trust_encoding
     Dir.mkdir util_inst_bindir
-    @installer = util_setup_gem
+
+    @installer = util_setup_installer
 
     @installer.wrappers = true
 
@@ -957,7 +1024,8 @@ gem 'other', version
   def test_install_with_no_prior_files
     Dir.mkdir util_inst_bindir
 
-    @installer = util_setup_gem
+    @installer = util_setup_installer
+
     build_rake_in do
       use_ui @ui do
         assert_equal @spec, @installer.install
@@ -967,7 +1035,8 @@ gem 'other', version
     gemdir = File.join(@gemhome, 'gems', @spec.full_name)
     assert_path_exists File.join gemdir, 'lib', 'code.rb'
 
-    @installer = util_setup_gem
+    @installer = util_setup_installer
+
     # Morph spec to have lib/other.rb instead of code.rb and recreate
     @spec.files = File.join('lib', 'other.rb')
     Dir.chdir @tempdir do
@@ -1003,6 +1072,8 @@ gem 'other', version
   end
 
   def test_install_missing_dirs
+    @installer = setup_base_installer
+
     FileUtils.rm_f File.join(Gem.dir, 'cache')
     FileUtils.rm_f File.join(Gem.dir, 'doc')
     FileUtils.rm_f File.join(Gem.dir, 'specifications')
@@ -1020,6 +1091,8 @@ gem 'other', version
   end
 
   def test_install_post_build_false
+    @installer = setup_base_installer
+
     Gem.post_build do
       false
     end
@@ -1042,6 +1115,8 @@ gem 'other', version
   end
 
   def test_install_post_build_nil
+    @installer = setup_base_installer
+
     Gem.post_build do
       nil
     end
@@ -1058,6 +1133,8 @@ gem 'other', version
   end
 
   def test_install_pre_install_false
+    @installer = setup_base_installer
+
     Gem.pre_install do
       false
     end
@@ -1077,6 +1154,8 @@ gem 'other', version
   end
 
   def test_install_pre_install_nil
+    @installer = setup_base_installer
+
     Gem.pre_install do
       nil
     end
@@ -1090,6 +1169,7 @@ gem 'other', version
   end
 
   def test_install_with_message
+    @spec = setup_base_spec
     @spec.post_install_message = 'I am a shiny gem!'
 
     use_ui @ui do
@@ -1103,6 +1183,7 @@ gem 'other', version
   end
 
   def test_install_with_skipped_message
+    @spec = setup_base_spec
     @spec.post_install_message = 'I am a shiny gem!'
 
     use_ui @ui do
@@ -1118,6 +1199,7 @@ gem 'other', version
   def test_install_extension_dir
     gemhome2 = "#{@gemhome}2"
 
+    @spec = setup_base_spec
     @spec.extensions << "extconf.rb"
     write_file File.join(@tempdir, "extconf.rb") do |io|
       io.write <<-RUBY
@@ -1141,6 +1223,8 @@ gem 'other', version
   end
 
   def test_install_extension_dir_is_removed_on_reinstall
+    @spec = setup_base_spec
+
     @spec.extensions << "extconf.rb"
     write_file File.join(@tempdir, "extconf.rb") do |io|
       io.write <<-RUBY
@@ -1176,6 +1260,7 @@ gem 'other', version
   end
 
   def test_install_user_extension_dir
+    @spec = setup_base_spec
     @spec.extensions << "extconf.rb"
     write_file File.join(@tempdir, "extconf.rb") do |io|
       io.write <<-RUBY
@@ -1206,6 +1291,8 @@ gem 'other', version
 
   def test_find_lib_file_after_install
     skip "extensions don't quite work on jruby" if Gem.java_platform?
+
+    @spec = setup_base_spec
     @spec.extensions << "extconf.rb"
     write_file File.join(@tempdir, "extconf.rb") do |io|
       io.write <<-RUBY
@@ -1250,6 +1337,8 @@ gem 'other', version
 
   def test_install_extension_and_script
     skip "Makefile creation crashes on jruby" if Gem.java_platform?
+
+    @spec = setup_base_spec
     @spec.extensions << "extconf.rb"
     write_file File.join(@tempdir, "extconf.rb") do |io|
       io.write <<-RUBY
@@ -1289,6 +1378,8 @@ gem 'other', version
 
   def test_install_extension_flat
     skip "extensions don't quite work on jruby" if Gem.java_platform?
+
+    @spec = setup_base_spec
     @spec.require_paths = ["."]
 
     @spec.extensions << "extconf.rb"
@@ -1335,6 +1426,8 @@ gem 'other', version
   end
 
   def test_installation_satisfies_dependency_eh
+    @installer = setup_base_installer
+
     util_spec 'a'
 
     dep = Gem::Dependency.new 'a', '>= 2'
@@ -1345,6 +1438,7 @@ gem 'other', version
   end
 
   def test_installation_satisfies_dependency_eh_development
+    @installer = setup_base_installer
     @installer.options[:development] = true
     @installer.options[:dev_shallow] = true
 
@@ -1355,6 +1449,7 @@ gem 'other', version
   end
 
   def test_pre_install_checks_dependencies
+    @installer = setup_base_installer
     @spec.add_dependency 'b', '> 5'
     @installer = util_setup_gem
 
@@ -1366,6 +1461,7 @@ gem 'other', version
   end
 
   def test_pre_install_checks_dependencies_ignore
+    @installer = util_setup_installer
     @spec.add_dependency 'b', '> 5'
     @installer.ignore_dependencies = true
 
@@ -1378,6 +1474,8 @@ gem 'other', version
 
   def test_pre_install_checks_dependencies_install_dir
     gemhome2 = "#{@gemhome}2"
+
+    @gem = setup_base_gem
     @spec.add_dependency 'd'
 
     quick_gem 'd', 2
@@ -1579,6 +1677,8 @@ gem 'other', version
   end
 
   def test_shebang
+    @installer = setup_base_installer
+
     util_make_exec @spec, "#!/usr/bin/ruby"
 
     shebang = @installer.shebang 'executable'
@@ -1587,6 +1687,8 @@ gem 'other', version
   end
 
   def test_process_options
+    @installer = setup_base_installer
+
     assert_nil @installer.build_root
     assert_equal File.join(@gemhome, 'bin'), @installer.bin_dir
     assert_equal @gemhome, @installer.gem_home
@@ -1595,6 +1697,7 @@ gem 'other', version
   def test_process_options_build_root
     build_root = File.join @tempdir, 'build_root'
 
+    @gem = setup_base_gem
     @installer = Gem::Installer.at @gem, :build_root => build_root
 
     assert_equal Pathname(build_root), @installer.build_root
@@ -1603,6 +1706,8 @@ gem 'other', version
   end
 
   def test_shebang_arguments
+    @installer = setup_base_installer
+
     util_make_exec @spec, "#!/usr/bin/ruby -ws"
 
     shebang = @installer.shebang 'executable'
@@ -1611,6 +1716,8 @@ gem 'other', version
   end
 
   def test_shebang_empty
+    @installer = setup_base_installer
+
     util_make_exec @spec, ''
 
     shebang = @installer.shebang 'executable'
@@ -1618,6 +1725,8 @@ gem 'other', version
   end
 
   def test_shebang_env
+    @installer = setup_base_installer
+
     util_make_exec @spec, "#!/usr/bin/env ruby"
 
     shebang = @installer.shebang 'executable'
@@ -1626,6 +1735,8 @@ gem 'other', version
   end
 
   def test_shebang_env_arguments
+    @installer = setup_base_installer
+
     util_make_exec @spec, "#!/usr/bin/env ruby -ws"
 
     shebang = @installer.shebang 'executable'
@@ -1634,6 +1745,8 @@ gem 'other', version
   end
 
   def test_shebang_env_shebang
+    @installer = setup_base_installer
+
     util_make_exec @spec, ''
     @installer.env_shebang = true
 
@@ -1646,6 +1759,8 @@ gem 'other', version
   end
 
   def test_shebang_nested
+    @installer = setup_base_installer
+
     util_make_exec @spec, "#!/opt/local/ruby/bin/ruby"
 
     shebang = @installer.shebang 'executable'
@@ -1654,6 +1769,8 @@ gem 'other', version
   end
 
   def test_shebang_nested_arguments
+    @installer = setup_base_installer
+
     util_make_exec @spec, "#!/opt/local/ruby/bin/ruby -ws"
 
     shebang = @installer.shebang 'executable'
@@ -1662,6 +1779,8 @@ gem 'other', version
   end
 
   def test_shebang_version
+    @installer = setup_base_installer
+
     util_make_exec @spec, "#!/usr/bin/ruby18"
 
     shebang = @installer.shebang 'executable'
@@ -1670,6 +1789,8 @@ gem 'other', version
   end
 
   def test_shebang_version_arguments
+    @installer = setup_base_installer
+
     util_make_exec @spec, "#!/usr/bin/ruby18 -ws"
 
     shebang = @installer.shebang 'executable'
@@ -1678,6 +1799,8 @@ gem 'other', version
   end
 
   def test_shebang_version_env
+    @installer = setup_base_installer
+
     util_make_exec @spec, "#!/usr/bin/env ruby18"
 
     shebang = @installer.shebang 'executable'
@@ -1686,6 +1809,8 @@ gem 'other', version
   end
 
   def test_shebang_version_env_arguments
+    @installer = setup_base_installer
+
     util_make_exec @spec, "#!/usr/bin/env ruby18 -ws"
 
     shebang = @installer.shebang 'executable'
@@ -1694,6 +1819,8 @@ gem 'other', version
   end
 
   def test_shebang_custom
+    @installer = setup_base_installer
+
     conf = Gem::ConfigFile.new []
     conf[:custom_shebang] = 'test'
 
@@ -1707,6 +1834,8 @@ gem 'other', version
   end
 
   def test_shebang_custom_with_expands
+    @installer = setup_base_installer
+
     bin_env = win_platform? ? '' : '/usr/bin/env'
     conf = Gem::ConfigFile.new []
     conf[:custom_shebang] = '1 $env 2 $ruby 3 $exec 4 $name'
@@ -1721,6 +1850,8 @@ gem 'other', version
   end
 
   def test_shebang_custom_with_expands_and_arguments
+    @installer = setup_base_installer
+
     bin_env = win_platform? ? '' : '/usr/bin/env'
     conf = Gem::ConfigFile.new []
     conf[:custom_shebang] = '1 $env 2 $ruby 3 $exec'
@@ -1735,7 +1866,7 @@ gem 'other', version
   end
 
   def test_unpack
-    @installer = util_setup_gem
+    @installer = util_setup_installer
 
     dest = File.join @gemhome, 'gems', @spec.full_name
 
@@ -1748,6 +1879,8 @@ gem 'other', version
   end
 
   def test_write_build_info_file
+    @installer = setup_base_installer
+
     refute_path_exists @spec.build_info_file
 
     @installer.build_args = %w[
@@ -1764,6 +1897,8 @@ gem 'other', version
   end
 
   def test_write_build_info_file_empty
+    @installer = setup_base_installer
+
     refute_path_exists @spec.build_info_file
 
     @installer.write_build_info_file
@@ -1772,6 +1907,7 @@ gem 'other', version
   end
 
   def test_write_build_info_file_install_dir
+    @gem = setup_base_gem
     installer = Gem::Installer.at @gem, :install_dir => "#{@gemhome}2"
 
     installer.build_args = %w[
@@ -1786,6 +1922,7 @@ gem 'other', version
   end
 
   def test_write_cache_file
+    @gem = setup_base_gem
     cache_file = File.join @gemhome, 'cache', @spec.file_name
     gem = File.join @gemhome, @spec.file_name
 
@@ -1801,6 +1938,7 @@ gem 'other', version
   end
 
   def test_write_spec
+    @spec = setup_base_spec
     FileUtils.rm @spec.spec_file
     refute_path_exists @spec.spec_file
 
@@ -1819,6 +1957,7 @@ gem 'other', version
   end
 
   def test_write_spec_writes_cached_spec
+    @spec = setup_base_spec
     FileUtils.rm @spec.spec_file
     refute_path_exists @spec.spec_file
 
@@ -1836,6 +1975,8 @@ gem 'other', version
   end
 
   def test_dir
+    @installer = setup_base_installer
+
     assert_match %r!/gemhome/gems/a-2$!, @installer.dir
   end
 
@@ -1847,6 +1988,8 @@ gem 'other', version
   end
 
   def test_default_gem_without_wrappers
+    @installer = setup_base_installer
+
     FileUtils.rm_f File.join(Gem.dir, 'specifications')
 
     @installer.wrappers = false
@@ -1878,6 +2021,8 @@ gem 'other', version
   end
 
   def test_default_gem_with_wrappers
+    @installer = setup_base_installer
+
     @installer.wrappers = true
     @installer.options[:install_as_default] = true
     @installer.gem_dir = @spec.gem_dir

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -734,7 +734,6 @@ gem 'other', version
   def test_install
     Dir.mkdir util_inst_bindir
     util_setup_gem
-    util_clear_gems
 
     gemdir     = File.join @gemhome, 'gems', @spec.full_name
     cache_file = File.join @gemhome, 'cache', @spec.file_name
@@ -795,7 +794,6 @@ gem 'other', version
   def test_install_creates_working_binstub
     Dir.mkdir util_inst_bindir
     util_setup_gem
-    util_clear_gems
 
     @installer.wrappers = true
 
@@ -819,7 +817,6 @@ gem 'other', version
 
   def test_conflicting_binstubs
     Dir.mkdir util_inst_bindir
-    util_clear_gems
 
     # build old version that has a bin file
     util_setup_gem do |spec|
@@ -869,7 +866,6 @@ gem 'other', version
   def test_install_creates_binstub_that_understand_version
     Dir.mkdir util_inst_bindir
     util_setup_gem
-    util_clear_gems
 
     @installer.wrappers = true
 
@@ -930,7 +926,6 @@ gem 'other', version
   def test_install_creates_binstub_that_dont_trust_encoding
     Dir.mkdir util_inst_bindir
     util_setup_gem
-    util_clear_gems
 
     @installer.wrappers = true
 
@@ -961,7 +956,6 @@ gem 'other', version
 
   def test_install_with_no_prior_files
     Dir.mkdir util_inst_bindir
-    util_clear_gems
 
     util_setup_gem
     build_rake_in do
@@ -1026,8 +1020,6 @@ gem 'other', version
   end
 
   def test_install_post_build_false
-    util_clear_gems
-
     Gem.post_build do
       false
     end
@@ -1050,8 +1042,6 @@ gem 'other', version
   end
 
   def test_install_post_build_nil
-    util_clear_gems
-
     Gem.post_build do
       nil
     end
@@ -1068,8 +1058,6 @@ gem 'other', version
   end
 
   def test_install_pre_install_false
-    util_clear_gems
-
     Gem.pre_install do
       false
     end
@@ -1089,8 +1077,6 @@ gem 'other', version
   end
 
   def test_install_pre_install_nil
-    util_clear_gems
-
     Gem.pre_install do
       nil
     end

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -793,8 +793,6 @@ gem 'other', version
   end
 
   def test_install
-    Dir.mkdir util_inst_bindir
-
     @installer = util_setup_installer
 
     gemdir     = File.join @gemhome, 'gems', @spec.full_name
@@ -854,8 +852,6 @@ gem 'other', version
   end
 
   def test_install_creates_working_binstub
-    Dir.mkdir util_inst_bindir
-
     @installer = util_setup_installer
 
     @installer.wrappers = true
@@ -879,8 +875,6 @@ gem 'other', version
   end
 
   def test_conflicting_binstubs
-    Dir.mkdir util_inst_bindir
-
     @gem = setup_base_gem
 
     # build old version that has a bin file
@@ -929,8 +923,6 @@ gem 'other', version
   end
 
   def test_install_creates_binstub_that_understand_version
-    Dir.mkdir util_inst_bindir
-
     @installer = util_setup_installer
 
     @installer.wrappers = true
@@ -960,8 +952,6 @@ gem 'other', version
   end
 
   def test_install_creates_binstub_that_prefers_user_installed_gem_to_default
-    Dir.mkdir util_inst_bindir
-
     install_default_gems new_default_spec('default', '2')
 
     @installer = util_setup_installer do |spec|
@@ -990,8 +980,6 @@ gem 'other', version
   end
 
   def test_install_creates_binstub_that_dont_trust_encoding
-    Dir.mkdir util_inst_bindir
-
     @installer = util_setup_installer
 
     @installer.wrappers = true
@@ -1022,8 +1010,6 @@ gem 'other', version
   end
 
   def test_install_with_no_prior_files
-    Dir.mkdir util_inst_bindir
-
     @installer = util_setup_installer
 
     build_rake_in do

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -20,6 +20,7 @@ class TestGemInstaller < Gem::InstallerTestCase
 
   def setup
     super
+    @installer = setup_base_installer
     common_installer_setup
 
     @config = Gem.configuration

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -22,11 +22,6 @@ class TestGemInstaller < Gem::InstallerTestCase
     super
     common_installer_setup
 
-    if (self.class.method_defined?(:__name__) ? __name__ : name) =~ /\Atest_install(_|\Z)/
-      FileUtils.rm_r @spec.gem_dir
-      FileUtils.rm_r @user_spec.gem_dir
-    end
-
     @config = Gem.configuration
   end
 
@@ -1896,8 +1891,6 @@ gem 'other', version
   end
 
   def test_default_gem_with_wrappers
-    FileUtils.rm_f File.join(Gem.dir, 'specifications')
-
     @installer.wrappers = true
     @installer.options[:install_as_default] = true
     @installer.gem_dir = @spec.gem_dir
@@ -1916,8 +1909,6 @@ gem 'other', version
   end
 
   def test_default_gem_with_exe_as_bindir
-    FileUtils.rm_f File.join(Gem.dir, 'specifications')
-
     @spec = quick_gem 'c' do |spec|
       util_make_exec spec, '#!/usr/bin/ruby', 'exe'
     end

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -733,7 +733,7 @@ gem 'other', version
 
   def test_install
     Dir.mkdir util_inst_bindir
-    util_setup_gem
+    @installer = util_setup_gem
 
     gemdir     = File.join @gemhome, 'gems', @spec.full_name
     cache_file = File.join @gemhome, 'cache', @spec.file_name
@@ -793,7 +793,7 @@ gem 'other', version
 
   def test_install_creates_working_binstub
     Dir.mkdir util_inst_bindir
-    util_setup_gem
+    @installer = util_setup_gem
 
     @installer.wrappers = true
 
@@ -819,7 +819,7 @@ gem 'other', version
     Dir.mkdir util_inst_bindir
 
     # build old version that has a bin file
-    util_setup_gem do |spec|
+    @installer = util_setup_gem do |spec|
       File.open File.join('bin', 'executable'), 'w' do |f|
         f.puts "require 'code'"
       end
@@ -838,7 +838,7 @@ gem 'other', version
     old_bin_file = File.join @installer.bin_dir, 'executable'
 
     # build new version that doesn't have a bin file
-    util_setup_gem do |spec|
+    @installer = util_setup_gem do |spec|
       FileUtils.rm File.join('bin', 'executable')
       spec.files.delete File.join('bin', 'executable')
       spec.executables.delete 'executable'
@@ -865,7 +865,7 @@ gem 'other', version
 
   def test_install_creates_binstub_that_understand_version
     Dir.mkdir util_inst_bindir
-    util_setup_gem
+    @installer = util_setup_gem
 
     @installer.wrappers = true
 
@@ -898,7 +898,7 @@ gem 'other', version
 
     install_default_gems new_default_spec('default', '2')
 
-    util_setup_gem do |spec|
+    @installer = util_setup_gem do |spec|
       spec.name = 'default'
       spec.version = '2'
     end
@@ -925,7 +925,7 @@ gem 'other', version
 
   def test_install_creates_binstub_that_dont_trust_encoding
     Dir.mkdir util_inst_bindir
-    util_setup_gem
+    @installer = util_setup_gem
 
     @installer.wrappers = true
 
@@ -957,7 +957,7 @@ gem 'other', version
   def test_install_with_no_prior_files
     Dir.mkdir util_inst_bindir
 
-    util_setup_gem
+    @installer = util_setup_gem
     build_rake_in do
       use_ui @ui do
         assert_equal @spec, @installer.install
@@ -967,7 +967,7 @@ gem 'other', version
     gemdir = File.join(@gemhome, 'gems', @spec.full_name)
     assert_path_exists File.join gemdir, 'lib', 'code.rb'
 
-    util_setup_gem
+    @installer = util_setup_gem
     # Morph spec to have lib/other.rb instead of code.rb and recreate
     @spec.files = File.join('lib', 'other.rb')
     Dir.chdir @tempdir do
@@ -1356,7 +1356,7 @@ gem 'other', version
 
   def test_pre_install_checks_dependencies
     @spec.add_dependency 'b', '> 5'
-    util_setup_gem
+    @installer = util_setup_gem
 
     use_ui @ui do
       assert_raises Gem::InstallError do
@@ -1735,7 +1735,7 @@ gem 'other', version
   end
 
   def test_unpack
-    util_setup_gem
+    @installer = util_setup_gem
 
     dest = File.join @gemhome, 'gems', @spec.full_name
 

--- a/test/rubygems/test_gem_uninstaller.rb
+++ b/test/rubygems/test_gem_uninstaller.rb
@@ -6,6 +6,8 @@ class TestGemUninstaller < Gem::InstallerTestCase
 
   def setup
     super
+    @installer = setup_base_installer
+    @user_installer = setup_base_user_installer
     common_installer_setup
 
     build_rake_in do


### PR DESCRIPTION
# Description:

I was working on adding some tests for installing defafult gems, and I noticed that it's pretty hard to work with installer tests, because the base setup does too much, so sometimes you need to reset state at the beginning of each test to go back to a clean slate.

Instead, I've removed all the common setup, and make each test explicitly do only the stuff it needs to do.

This allows to remove a lot of state resetting from many tests. 

I also included a little follow up to the addition of jruby in https://github.com/rubygems/rubygems/pull/2757/commits/309de0ed2376c8efb248e030c9847e0feaf18cfa by undoing some skips that are not really necessary.
 
# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
