### PR TITLE
 Fix shadowing outer local variable warning

### DIFF
--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -801,13 +801,13 @@ gem 'other', version
     rakefile   = File.join gemdir, 'ext', 'a', 'Rakefile'
     spec_file  = File.join @gemhome, 'specifications', @spec.spec_name
 
-    Gem.pre_install do |installer|
+    Gem.pre_install do
       refute_path_exists cache_file, 'cache file must not exist yet'
       refute_path_exists spec_file,  'spec file must not exist yet'
       true
     end
 
-    Gem.post_build do |installer|
+    Gem.post_build do
       assert_path_exists gemdir, 'gem install dir must exist'
       assert_path_exists rakefile, 'gem executable must exist'
       refute_path_exists stub_exe, 'gem executable must not exist'
@@ -815,7 +815,7 @@ gem 'other', version
       true
     end
 
-    Gem.post_install do |installer|
+    Gem.post_install do
       assert_path_exists cache_file, 'cache file must exist'
       assert_path_exists spec_file,  'spec file must exist'
     end


### PR DESCRIPTION
# Description:

Remove warning about `shadowing outer local variable`
```
/Users/bronzdoc/projects/ruby/rubygems/test/rubygems/test_gem_installer.rb:804: warning: shadowing outer local variable - installer
/Users/bronzdoc/projects/ruby/rubygems/test/rubygems/test_gem_installer.rb:810: warning: shadowing outer local variable - installer
/Users/bronzdoc/projects/ruby/rubygems/test/rubygems/test_gem_installer.rb:818: warning: shadowing outer local variable - installer
Run options: --seed 1209
```
______________
I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).