### PR TITLE
Properly fetch `Gem#latest_spec_for` with multiple sources

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -854,7 +854,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     fetcher      = Gem::SpecFetcher.fetcher
     spec_tuples, = fetcher.spec_for_dependency dependency
 
-    spec, = spec_tuples.first
+    spec, = spec_tuples.last
 
     spec
   end

--- a/lib/rubygems/spec_fetcher.rb
+++ b/lib/rubygems/spec_fetcher.rb
@@ -121,7 +121,7 @@ class Gem::SpecFetcher
       end
     end
 
-    tuples = tuples.sort_by {|x| x[0] }
+    tuples = tuples.sort_by {|x| x[0].version }
 
     return [tuples, errors]
   end

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -888,6 +888,27 @@ class TestGem < Gem::TestCase
     assert_equal gems['a-2'], spec
   end
 
+  def test_self_latest_spec_for_multiple_sources
+    uri = 'https://example.sample.com/'
+    source = Gem::Source.new(uri)
+    source_list = Gem::SourceList.new
+    source_list << Gem::Source.new(@uri)
+    source_list << source
+    Gem.sources.replace source_list
+
+    spec_fetcher(uri) do |fetcher|
+      fetcher.spec 'a', 1.1
+    end
+
+    gems = spec_fetcher do |fetcher|
+      fetcher.spec 'a', 1
+      fetcher.spec 'a', '3.a'
+      fetcher.spec 'a', 2
+    end
+    spec = Gem.latest_spec_for 'a'
+    assert_equal gems['a-2'], spec
+  end
+
   def test_self_latest_rubygems_version
     spec_fetcher do |fetcher|
       fetcher.spec 'rubygems-update', '1.8.23'
@@ -901,6 +922,29 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_latest_version_for
+    spec_fetcher do |fetcher|
+      fetcher.spec 'a', 1
+      fetcher.spec 'a', 2
+      fetcher.spec 'a', '3.a'
+    end
+
+    version = Gem.latest_version_for 'a'
+
+    assert_equal Gem::Version.new(2), version
+  end
+
+  def test_self_latest_version_for_multiple_sources
+    uri = 'https://example.sample.com/'
+    source = Gem::Source.new(uri)
+    source_list = Gem::SourceList.new
+    source_list << Gem::Source.new(@uri)
+    source_list << source
+    Gem.sources.replace source_list
+
+    spec_fetcher(uri) do |fetcher|
+      fetcher.spec 'a', 1.1
+    end
+
     spec_fetcher do |fetcher|
       fetcher.spec 'a', 1
       fetcher.spec 'a', 2


### PR DESCRIPTION
# Description:
There are times when getting the latest spec for a gem is returning the wrong result. If multiple sources are used, and a gem exists in both, then [spec_fetcher](https://github.com/rubygems/rubygems/blob/master/lib/rubygems/spec_fetcher.rb#L86) will return a spec for each source the gem is found in and [sort it by oldest to newest](https://github.com/rubygems/rubygems/blob/master/lib/rubygems/spec_fetcher.rb#L136).

 Returning the last item from the list of specs resolves this issue.
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
