### PR TITLE
Revert "Remove dummy empty block"

### DIFF
--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2906,7 +2906,9 @@ duplicate dependency on c (>= 1.2.3, development), (~> 1.2) use:
     util_setup_validate
 
     FileUtils.mkdir_p File.join(@tempdir, 'bin')
-    File.open File.join(@tempdir, 'bin', 'exec'), 'w' do end
+    File.open File.join(@tempdir, 'bin', 'exec'), 'w' do
+      # necessary block to close the fd to `bin/exec` file
+    end
     FileUtils.mkdir_p File.join(@tempdir, 'exec')
 
     use_ui @ui do

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2906,7 +2906,7 @@ duplicate dependency on c (>= 1.2.3, development), (~> 1.2) use:
     util_setup_validate
 
     FileUtils.mkdir_p File.join(@tempdir, 'bin')
-    File.open File.join(@tempdir, 'bin', 'exec'), 'w'
+    File.open File.join(@tempdir, 'bin', 'exec'), 'w' do end
     FileUtils.mkdir_p File.join(@tempdir, 'exec')
 
     use_ui @ui do

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2906,9 +2906,7 @@ duplicate dependency on c (>= 1.2.3, development), (~> 1.2) use:
     util_setup_validate
 
     FileUtils.mkdir_p File.join(@tempdir, 'bin')
-    File.open File.join(@tempdir, 'bin', 'exec'), 'w' do
-      # necessary block to close the fd to `bin/exec` file
-    end
+    File.write File.join(@tempdir, 'bin', 'exec'), ''
     FileUtils.mkdir_p File.join(@tempdir, 'exec')
 
     use_ui @ui do


### PR DESCRIPTION
# Description:

This reverts commit 1713044008c42694e23aa6fb2d415157d906c79c.

This block is not a dummy, but necessary to close the fd to the created `bin/exec` file.
By removal of this block, ruby's test now complains that this fd leaks.

______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
