### PR TITLE
Fix setup command if format_executable is true by default

### DIFF
--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -429,7 +429,7 @@ By default, this RubyGems will install gem as:
     Dir.chdir("bundler") do
       built_gem = Gem::Package.build(bundler_spec)
       begin
-        installer = Gem::Installer.at(built_gem, env_shebang: options[:env_shebang], install_as_default: true, bin_dir: bin_dir, wrappers: true)
+        installer = Gem::Installer.at(built_gem, env_shebang: options[:env_shebang], format_executable: options[:format_executable], install_as_default: true, bin_dir: bin_dir, wrappers: true)
         installer.install
       ensure
         FileUtils.rm_f built_gem


### PR DESCRIPTION
# Description:

Some operating systems that support multiple versions of
ruby set `:format_executable` by default.  Previously, the
setup command handled things for `gem` but not for `bundle`,
resulting in the following test failure:

```
TestGemCommandsSetupCommand#test_env_shebang_flag:
Errno::ENOENT: No such file or directory @ rb_sysopen - /tmp/test_rubygems_30662/install/bin/bundle26
    test/rubygems/test_gem_commands_setup_command.rb:149:in `read'
    test/rubygems/test_gem_commands_setup_command.rb:149:in `test_env_shebang_flag'
```

This patch fixes the issue by passing the `:format_executable`
option when installing the bundler gem during setup.

# Tasks:

- [X] Describe the problem / feature
- [X] Write tests (fixes existing test failure)
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
