### PR TITLE
Don't apply `--destdir` twice when running `setup.rb`

### DIFF
--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -370,8 +370,7 @@ By default, this RubyGems will install gem as:
   end
 
   def install_default_bundler_gem(bin_dir)
-    specs_dir = Gem.default_specifications_dir
-    specs_dir = File.join(options[:destdir], specs_dir) unless Gem.win_platform?
+    specs_dir = prepend_destdir_if_present(Gem.default_specifications_dir)
     mkdir_p specs_dir, :mode => 0755
 
     bundler_spec = Dir.chdir("bundler") { Gem::Specification.load("bundler.gemspec") }

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -437,7 +437,6 @@ By default, this RubyGems will install gem as:
   end
 
   def generate_default_man_dir
-    install_destdir = options[:destdir]
     prefix = options[:prefix]
 
     if prefix.empty?
@@ -447,15 +446,10 @@ By default, this RubyGems will install gem as:
       man_dir = File.join prefix, 'man'
     end
 
-    unless install_destdir.empty?
-      man_dir = prepend_destdir(man_dir)
-    end
-
-    man_dir
+    prepend_destdir_if_present(man_dir)
   end
 
   def generate_default_dirs
-    install_destdir = options[:destdir]
     prefix = options[:prefix]
     site_or_vendor = options[:site_or_vendor]
 
@@ -467,12 +461,7 @@ By default, this RubyGems will install gem as:
       bin_dir = File.join prefix, 'bin'
     end
 
-    unless install_destdir.empty?
-      lib_dir = prepend_destdir(lib_dir)
-      bin_dir = prepend_destdir(bin_dir)
-    end
-
-    [lib_dir, bin_dir]
+    [prepend_destdir_if_present(lib_dir), prepend_destdir_if_present(bin_dir)]
   end
 
   def files_in(dir)
@@ -617,6 +606,13 @@ abort "#{deprecation_message}"
   end
 
   private
+
+  def prepend_destdir_if_present(path)
+    destdir = options[:destdir]
+    return path if destdir.empty?
+
+    prepend_destdir(path)
+  end
 
   def prepend_destdir(path)
     File.join(options[:destdir], path.gsub(/^[a-zA-Z]:/, ''))

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -152,8 +152,7 @@ By default, this RubyGems will install gem as:
     install_destdir = options[:destdir]
 
     unless install_destdir.empty?
-      ENV['GEM_HOME'] ||= File.join(install_destdir,
-                                    Gem.default_dir.gsub(/^[a-zA-Z]:/, ''))
+      ENV['GEM_HOME'] ||= prepend_destdir(Gem.default_dir)
     end
 
     check_ruby_version
@@ -166,8 +165,8 @@ By default, this RubyGems will install gem as:
     end
     extend MakeDirs
 
-    lib_dir, bin_dir = make_destination_dirs install_destdir
-    man_dir = generate_default_man_dir install_destdir
+    lib_dir, bin_dir = make_destination_dirs
+    man_dir = generate_default_man_dir
 
     install_lib lib_dir
 
@@ -424,11 +423,11 @@ By default, this RubyGems will install gem as:
     say "Bundler #{bundler_spec.version} installed"
   end
 
-  def make_destination_dirs(install_destdir)
+  def make_destination_dirs
     lib_dir, bin_dir = Gem.default_rubygems_dirs
 
     unless lib_dir
-      lib_dir, bin_dir = generate_default_dirs(install_destdir)
+      lib_dir, bin_dir = generate_default_dirs
     end
 
     mkdir_p lib_dir, :mode => 0755
@@ -437,7 +436,8 @@ By default, this RubyGems will install gem as:
     return lib_dir, bin_dir
   end
 
-  def generate_default_man_dir(install_destdir)
+  def generate_default_man_dir
+    install_destdir = options[:destdir]
     prefix = options[:prefix]
 
     if prefix.empty?
@@ -448,13 +448,14 @@ By default, this RubyGems will install gem as:
     end
 
     unless install_destdir.empty?
-      man_dir = File.join install_destdir, man_dir.gsub(/^[a-zA-Z]:/, '')
+      man_dir = prepend_destdir(man_dir)
     end
 
     man_dir
   end
 
-  def generate_default_dirs(install_destdir)
+  def generate_default_dirs
+    install_destdir = options[:destdir]
     prefix = options[:prefix]
     site_or_vendor = options[:site_or_vendor]
 
@@ -467,8 +468,8 @@ By default, this RubyGems will install gem as:
     end
 
     unless install_destdir.empty?
-      lib_dir = File.join install_destdir, lib_dir.gsub(/^[a-zA-Z]:/, '')
-      bin_dir = File.join install_destdir, bin_dir.gsub(/^[a-zA-Z]:/, '')
+      lib_dir = prepend_destdir(lib_dir)
+      bin_dir = prepend_destdir(bin_dir)
     end
 
     [lib_dir, bin_dir]
@@ -616,6 +617,10 @@ abort "#{deprecation_message}"
   end
 
   private
+
+  def prepend_destdir(path)
+    File.join(options[:destdir], path.gsub(/^[a-zA-Z]:/, ''))
+  end
 
   def install_file_list(files, dest_dir)
     files.each do |file|

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -246,6 +246,28 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     end
   end
 
+  def test_install_default_bundler_gem_with_destdir_flag
+    @cmd.extend FileUtils
+
+    bin_dir = File.join(@gemhome, 'bin')
+
+    bindir(bin_dir) do
+      destdir = File.join(@tempdir, 'foo')
+
+      @cmd.options[:destdir] = destdir
+
+      @cmd.install_default_bundler_gem bin_dir
+
+      bundler_spec = Gem::Specification.load("bundler/bundler.gemspec")
+      default_spec_path = File.join(Gem.default_specifications_dir, "#{bundler_spec.full_name}.gemspec")
+      spec = Gem::Specification.load(default_spec_path)
+
+      spec.executables.each do |e|
+        assert_path_exist File.join destdir, spec.bin_dir.gsub(/^[a-zA-Z]:/, ''), e
+      end
+    end
+  end
+
   def test_remove_old_lib_files
     lib                   = File.join @install_dir, 'lib'
     lib_rubygems          = File.join lib, 'rubygems'


### PR DESCRIPTION
# Description:

Prior to this patch, if I ran:

    ruby setup.rb --destdir /foo

Then Bundler files would be written into /foo/foo, because destdir was being prepended, even though bundler_spec.bin_dir already included destdir.
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).