### PR TITLE
Write to the correct config file(.gemrc)

### DIFF
--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -472,6 +472,7 @@ if you believe they were disclosed to a third party.
   protected :hash
 
   private
+
   def set_config_file_name(args)
     @config_file_name = ENV["GEMRC"]
     need_config_file_name = false

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -473,7 +473,7 @@ if you believe they were disclosed to a third party.
 
   private
   def set_config_file_name(args)
-    @config_file_name = nil
+    @config_file_name = ENV["GEMRC"] || nil
     need_config_file_name = false
 
     args.each do |arg|

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -334,7 +334,7 @@ if you believe they were disclosed to a third party.
     yaml_errors = [ArgumentError]
     yaml_errors << Psych::SyntaxError if defined?(Psych::SyntaxError)
 
-    return {} unless filename and File.exist? filename
+    return {} unless filename && !filename.empty? && File.exist?(filename)
 
     begin
       content = Gem::SafeYAML.load(File.read(filename))

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -168,23 +168,7 @@ class Gem::ConfigFile
   # TODO: parse options upstream, pass in options directly
 
   def initialize(args)
-    @config_file_name = nil
-    need_config_file_name = false
-
-    arg_list = []
-
-    args.each do |arg|
-      if need_config_file_name
-        @config_file_name = arg
-        need_config_file_name = false
-      elsif arg =~ /^--config-file=(.*)/
-        @config_file_name = $1
-      elsif arg =~ /^--config-file$/
-        need_config_file_name = true
-      else
-        arg_list << arg
-      end
-    end
+    set_config_file_name(args)
 
     @backtrace = DEFAULT_BACKTRACE
     @bulk_threshold = DEFAULT_BULK_THRESHOLD
@@ -197,13 +181,14 @@ class Gem::ConfigFile
     platform_config = Marshal.load Marshal.dump(PLATFORM_DEFAULTS)
     system_config = load_file SYSTEM_WIDE_CONFIG_FILE
     user_config = load_file config_file_name.dup.untaint
+
     environment_config = (ENV['GEMRC'] || '')
       .split(File::PATH_SEPARATOR).inject({}) do |result, file|
         result.merge load_file file
       end
 
     @hash = operating_system_config.merge platform_config
-    unless arg_list.index '--norc'
+    unless args.index '--norc'
       @hash = @hash.merge system_config
       @hash = @hash.merge user_config
       @hash = @hash.merge environment_config
@@ -227,7 +212,7 @@ class Gem::ConfigFile
     @api_keys         = nil
     @rubygems_api_key = nil
 
-    handle_arguments arg_list
+    handle_arguments args
   end
 
   ##
@@ -485,5 +470,22 @@ if you believe they were disclosed to a third party.
 
   attr_reader :hash
   protected :hash
+
+  private
+  def set_config_file_name(args)
+    @config_file_name = nil
+    need_config_file_name = false
+
+    args.each do |arg|
+      if need_config_file_name
+        @config_file_name = arg
+        need_config_file_name = false
+      elsif arg =~ /^--config-file=(.*)/
+        @config_file_name = $1
+      elsif arg =~ /^--config-file$/
+        need_config_file_name = true
+      end
+    end
+  end
 
 end

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -473,7 +473,7 @@ if you believe they were disclosed to a third party.
 
   private
   def set_config_file_name(args)
-    @config_file_name = ENV["GEMRC"] || nil
+    @config_file_name = ENV["GEMRC"]
     need_config_file_name = false
 
     args.each do |arg|

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -19,7 +19,7 @@ class TestGemConfigFile < Gem::TestCase
     Gem::ConfigFile::PLATFORM_DEFAULTS.clear
 
     @env_gemrc = ENV['GEMRC']
-    ENV['GEMRC'] = nil
+    ENV['GEMRC'] = ''
 
     util_config_file
   end

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -19,7 +19,7 @@ class TestGemConfigFile < Gem::TestCase
     Gem::ConfigFile::PLATFORM_DEFAULTS.clear
 
     @env_gemrc = ENV['GEMRC']
-    ENV['GEMRC'] = ''
+    ENV['GEMRC'] = nil
 
     util_config_file
   end
@@ -165,6 +165,12 @@ class TestGemConfigFile < Gem::TestCase
     assert_equal true, @cfg.backtrace
     assert_equal :loud, @cfg.verbose
     assert_equal 2048, @cfg.bulk_threshold
+  end
+
+  def test_set_config_file_name_from_environment_variable
+    ENV['GEMRC'] = "/tmp/.gemrc"
+    cfg = Gem::ConfigFile.new([])
+    assert_equal cfg.config_file_name, "/tmp/.gemrc"
   end
 
   def test_api_keys


### PR DESCRIPTION
# Description:
Closes https://github.com/rubygems/rubygems/issues/2773

Currently Rubygems config file(`.gemrc`) is not set to the value of `GEMRC` environment variable if set, leading to unexpected behaviour as described in https://github.com/rubygems/rubygems/issues/2773 this PR will make the config file to be set to the value of `GEMRC` if provided.

______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
