### PR TITLE
Fix setup command test for bundler with program_suffix

### DIFF
--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -189,7 +189,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
         assert_path_exists File.join(bin_dir, "#{e}.bat")
       end
 
-      assert_path_exists File.join bin_dir, e
+      assert_path_exists File.join bin_dir, Gem.default_exec_format % e
     end
 
     default_dir = Gem::Specification.default_specifications_dir


### PR DESCRIPTION
This test fails with ruby built with --program-suffix.

This is an additional fix for #2766,
commit ec3c64a3de4048bec588896819df647c616cc6a8


# Description:

______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).