### PR TITLE
Synchronize access to the Gem::Specification::LOAD_CACHE Hash

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1124,7 +1124,12 @@ class Gem::Specification < Gem::BasicSpecification
       if Gem::Specification === _spec
         _spec.loaded_from = File.expand_path file.to_s
         LOAD_CACHE_MUTEX.synchronize do
-          LOAD_CACHE[file] = _spec
+          prev = LOAD_CACHE[file]
+          if prev
+            _spec = prev
+          else
+            LOAD_CACHE[file] = _spec
+          end
         end
         return _spec
       end


### PR DESCRIPTION
The `Gem::Specification::LOAD_CACHE` Hash is accessed concurrently, notably when installing a gem with C extensions but does not use synchronization. This PR adds synchronization so that it works fine on implementations which do not (yet) have a thread-safe `Hash`, such as TruffleRuby and JRuby.

Furthermore, it ensures the cached `Gem::Specification` object is always the same for a given path, which was not guaranteed before. That seems a good guaranty to have.

This code is already applied in TruffleRuby's copy of RubyGems in the stdlib, but it needs to be upstreamed for updating RubyGems to keep working with TruffleRuby.

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
