### PR TITLE
Add an attr_reader to Gem::Installer for the package instance variable

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -65,6 +65,11 @@ class Gem::Installer
 
   attr_reader :options
 
+  ##
+  # The gem package instance.
+
+  attr_reader :package
+
   @path_warning = false
 
   @install_lock = Mutex.new

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1944,6 +1944,16 @@ gem 'other', version
     assert_equal ['exe/executable'], default_spec.files
   end
 
+  def test_package_attribute
+    spec = quick_gem 'c' do |spec|
+      util_make_exec spec, '#!/usr/bin/ruby', 'exe'
+    end
+
+    installer = util_installer(spec, @gemhome)
+    assert_respond_to(installer, :package)
+    assert_kind_of(Gem::Package, installer.package)
+  end
+
   def old_ruby_required(requirement)
     spec = util_spec 'old_ruby_required', '1' do |s|
       s.required_ruby_version = requirement


### PR DESCRIPTION
A simple PR that adds an attr_reader to the `@package` attribute. I wanted this recently for a rubygems plugin where I wanted to get at the underlying package. I can do it currently via `instance_variable_get`, but this is nicer.
