### PR TITLE
Test TruffleRuby in CI

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -22,8 +22,8 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler: none
+      - name: Install Dependencies
+        run: rake setup
       - name: Run Test
-        run: |
-          rake setup
-          rake test
+        run: rake test
     timeout-minutes: 60

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -12,7 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ 2.3.8, 2.4.10, 2.5.8, 2.6.6, 2.7.1, jruby-9.2.11.1 ]
+        ruby: [ 2.3.8, 2.4.10, 2.5.8, 2.6.6, 2.7.1, jruby-9.2.11.1, truffleruby-head ]
+    env:
+      TRUFFLERUBYOPT: "--experimental-options --testing-rubygems"
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby

--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -233,15 +233,11 @@ install:
     gem_make_out = File.join @spec.extension_dir, 'gem_make.out'
     cmd_make_out = File.read(gem_make_out)
 
-    assert_match %r{#{Regexp.escape Gem.ruby}.* extconf\.rb}, cmd_make_out
+    assert_match %r{#{Regexp.escape Gem.ruby} .* extconf\.rb}, cmd_make_out
     assert_match %r{: No such file}, cmd_make_out
 
     refute_path_exists @spec.gem_build_complete_path
 
-    skip "Gem.ruby is not the name of the binary being run in the end" \
-      unless cmd_make_out.include? "#{Gem.ruby}:"
-
-    assert_match %r{#{Regexp.escape Gem.ruby}: No such file}, cmd_make_out
     assert_equal cwd, Dir.pwd
   end
 

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -522,11 +522,11 @@ class TestGemRequire < Gem::TestCase
           File.write(dir + "/sub.rb", "#{prefix}warn 'uplevel', 'test', uplevel: 1\n")
           File.write(dir + "/main.rb", "require 'sub'\n")
           _, err = capture_subprocess_io do
-            system(*ruby_with_rubygems_in_load_path, "-w", "--disable=gems", "-C", dir, "-I.", "main.rb")
+            system(*ruby_with_rubygems_in_load_path, "-w", "--disable=gems", "-C", dir, "-I", dir, "main.rb")
           end
           assert_match(/main\.rb:1: warning: uplevel\ntest\n$/, err)
           _, err = capture_subprocess_io do
-            system(*ruby_with_rubygems_in_load_path, "-w", "--enable=gems", "-C", dir, "-I.", "main.rb")
+            system(*ruby_with_rubygems_in_load_path, "-w", "--enable=gems", "-C", dir, "-I", dir, "main.rb")
           end
           assert_match(/main\.rb:1: warning: uplevel\ntest\n$/, err)
         end

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -230,20 +230,33 @@ class TestGemRequire < Gem::TestCase
       $LOAD_PATH.push lib_dir
     end
 
+    require 'benchmark' # the stdlib
+
     a1 = util_spec "a", "1", {"b" => ">= 1"}, "lib/test_gem_require_a.rb"
     b1 = util_spec "b", "1", nil, "lib/benchmark.rb"
     b2 = util_spec "b", "2", nil, "lib/benchmark.rb"
 
     install_specs b1, b2, a1
 
+    # Activates a-1, but not b-1 and b-2
     assert_require 'test_gem_require_a'
+    assert $LOAD_PATH.include? a1.load_paths[0]
+    refute $LOAD_PATH.include? b1.load_paths[0]
+    refute $LOAD_PATH.include? b2.load_paths[0]
+
     assert_equal unresolved_names, ["b (>= 1)"]
 
-    refute require('benchmark'), "benchmark should have already been loaded"
+    # The require('benchmark') below will activate b-2. However, its
+    # lib/benchmark.rb won't ever be loaded. The reason is MRI sees that even
+    # though b-2 is earlier in $LOAD_PATH it already loaded a benchmark.rb file
+    # and that still exists in $LOAD_PATH (further down),
+    # and as a result #gem_original_require returns false.
+    refute require('benchmark'), "the benchmark stdlib should be recognized as already loaded"
+    assert $LOAD_PATH.include? b2.load_paths[0]
 
     # We detected that we should activate b-2, so we did so, but
-    # then original_require decided "I've already got benchmark.rb" loaded.
-    # This case is fine because our lazy loading is provided exactly
+    # then #gem_original_require decided "I've already got some benchmark.rb" loaded.
+    # This case is fine because our lazy loading provided exactly
     # the same behavior as eager loading would have.
 
     assert_equal %w[a-1 b-2], loaded_spec_names

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -223,11 +223,14 @@ class TestGemRequire < Gem::TestCase
       stdlib one is already in $LOADED_FEATURES?. Reproducible by running the
       spaceship_specific_file test before this one" if java_platform?
 
-    lp = $LOAD_PATH.dup
-    lib_dir = File.expand_path(File.join(File.dirname(__FILE__), "../../lib"))
-    if File.exist?(lib_dir)
+    lib_dir = File.expand_path("../../lib", File.dirname(__FILE__))
+    if RbConfig::CONFIG["rubylibdir"] == lib_dir
+      # testing in the ruby repository where RubyGems' lib/ == stdlib lib/
+      # In that case we want to move the stdlib lib/ to still be after b-2 in $LOAD_PATH
+      lp = $LOAD_PATH.dup
       $LOAD_PATH.delete lib_dir
       $LOAD_PATH.push lib_dir
+      load_path_changed = true
     end
 
     require 'benchmark' # the stdlib
@@ -240,6 +243,7 @@ class TestGemRequire < Gem::TestCase
 
     # Activates a-1, but not b-1 and b-2
     assert_require 'test_gem_require_a'
+    assert_equal %w[a-1], loaded_spec_names
     assert $LOAD_PATH.include? a1.load_paths[0]
     refute $LOAD_PATH.include? b1.load_paths[0]
     refute $LOAD_PATH.include? b2.load_paths[0]
@@ -252,7 +256,10 @@ class TestGemRequire < Gem::TestCase
     # and that still exists in $LOAD_PATH (further down),
     # and as a result #gem_original_require returns false.
     refute require('benchmark'), "the benchmark stdlib should be recognized as already loaded"
+
     assert $LOAD_PATH.include? b2.load_paths[0]
+    assert $LOAD_PATH.index(b2.load_paths[0]) < $LOAD_PATH.index(RbConfig::CONFIG["rubylibdir"]),
+      "this test relies on the b-2 gem lib/ to be before stdlib to make sense"
 
     # We detected that we should activate b-2, so we did so, but
     # then #gem_original_require decided "I've already got some benchmark.rb" loaded.
@@ -261,7 +268,7 @@ class TestGemRequire < Gem::TestCase
 
     assert_equal %w[a-1 b-2], loaded_spec_names
   ensure
-    $LOAD_PATH.replace lp unless java_platform?
+    $LOAD_PATH.replace lp if load_path_changed
   end
 
   def test_already_activated_direct_conflict

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -412,7 +412,29 @@ class TestGemRequire < Gem::TestCase
       puts Gem.loaded_specs["json"]
     RUBY
     output = Gem::Util.popen(*ruby_with_rubygems_in_load_path, "-e", cmd).strip
+    assert $?.success?
     refute_empty output
+  end
+
+  def test_realworld_upgraded_default_gem
+    testing_ruby_repo = !ENV["GEM_COMMAND"].nil?
+    skip "this test can't work under ruby-core setup" if testing_ruby_repo
+
+    newer_json = util_spec("json", "999.99.9", nil, ["lib/json.rb"])
+    install_gem newer_json
+
+    cmd = <<-RUBY
+      $stderr = $stdout
+      require "json"
+      puts Gem.loaded_specs["json"].version
+      puts $LOADED_FEATURES
+    RUBY
+    output = Gem::Util.popen({ 'GEM_HOME' => @gemhome }, *ruby_with_rubygems_in_load_path, "-e", cmd).strip
+    assert $?.success?
+    refute_empty output
+    assert_equal "999.99.9", output.lines[0].chomp
+    # Make sure only files from the newer json gem are loaded, and no files from the default json gem
+    assert_equal ["#{@gemhome}/gems/json-999.99.9/lib/json.rb"], output.lines.grep(%r{/gems/json-}).map(&:chomp)
   end
 
   def test_default_gem_and_normal_gem

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -423,13 +423,16 @@ class TestGemRequire < Gem::TestCase
     newer_json = util_spec("json", "999.99.9", nil, ["lib/json.rb"])
     install_gem newer_json
 
-    cmd = <<-RUBY
+    path = "#{@tempdir}/test_realworld_upgraded_default_gem.rb"
+    code = <<-RUBY
       $stderr = $stdout
       require "json"
       puts Gem.loaded_specs["json"].version
       puts $LOADED_FEATURES
     RUBY
-    output = Gem::Util.popen({ 'GEM_HOME' => @gemhome }, *ruby_with_rubygems_in_load_path, "-e", cmd).strip
+    File.write(path, code)
+
+    output = Gem::Util.popen({ 'GEM_HOME' => @gemhome }, *ruby_with_rubygems_in_load_path, path).strip
     assert $?.success?
     refute_empty output
     assert_equal "999.99.9", output.lines[0].chomp


### PR DESCRIPTION
# Description:

We'd like to test TruffleRuby in RubyGems' CI, but it's not working yet.
This is related to #2700, but with additional fixes to run tests.

cc @hsbt 

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
