### PR TITLE
Explicitly deprecate `rubyforge_project`

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -732,6 +732,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Formerly used to set rubyforge project.
 
   attr_writer :rubyforge_project
+  deprecate :rubyforge_project=, :none,       2019, 12
 
   ##
   # The Gem::Specification version of this gemspec.

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1786,8 +1786,10 @@ You may need to `gem install -g` to install missing gems
 
     EXPECTED
 
-    assert_output nil, expected do
-      Gem.use_gemdeps
+    Gem::Deprecate.skip_during do
+      assert_output nil, expected do
+        Gem.use_gemdeps
+      end
     end
   ensure
     ENV['RUBYGEMS_GEMDEPS'] = rubygems_gemdeps


### PR DESCRIPTION
# Description:

In https://github.com/rubygems/rubygems/pull/2436, we removed all the `rubyforge_project` functionality, but kept the gemspec writer as a noop, so that people's gemspecs won't break. However, we didn't deprecate the writer. We should do it, so that we can actually remove it in the future.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
