### PR TITLE
Remove conflict.rb code that was supposed to be removed in Rubygems 3

### DIFF
--- a/lib/rubygems/resolver/conflict.rb
+++ b/lib/rubygems/resolver/conflict.rb
@@ -153,8 +153,3 @@ class Gem::Resolver::Conflict
   end
 
 end
-
-##
-# TODO: Remove in RubyGems 3
-
-Gem::Resolver::DependencyConflict = Gem::Resolver::Conflict # :nodoc:

--- a/test/rubygems/test_gem_resolver_conflict.rb
+++ b/test/rubygems/test_gem_resolver_conflict.rb
@@ -3,10 +3,6 @@ require 'rubygems/test_case'
 
 class TestGemResolverConflict < Gem::TestCase
 
-  def test_self_compatibility
-    assert_same Gem::Resolver::Conflict, Gem::Resolver::DependencyConflict
-  end
-
   def test_explanation
     root  =
       dependency_request dep('net-ssh', '>= 2.0.13'), 'rye', '0.9.8'


### PR DESCRIPTION
# Description:

Remove `conflict.rb` code that was supposed to be removed in Rubygems 3

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
