### PR TITLE
Move gemcutter utilities code to Gem::Command

### DIFF
--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -20,6 +20,10 @@ class Gem::Command
 
   include Gem::UserInteraction
 
+  OptionParser.accept Symbol do |value|
+    value.to_sym
+  end
+
   ##
   # The name of the command.
 

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -9,11 +9,6 @@ module Gem::GemcutterUtilities
 
   include Gem::Text
 
-  # TODO: move to Gem::Command
-  OptionParser.accept Symbol do |value|
-    value.to_sym
-  end
-
   attr_writer :host
 
   ##


### PR DESCRIPTION
# Description:
Moves 
```ruby
OptionParser.accept Symbol do |value|
    value.to_sym
end
```
to `Gem::Command`
______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
