### PR TITLE
Remove missleading TODO comment in security_option.rb

### DIFF
--- a/lib/rubygems/security_option.rb
+++ b/lib/rubygems/security_option.rb
@@ -19,7 +19,6 @@ end
 
 module Gem::SecurityOption
   def add_security_option
-    # TODO: use @parser.accept
     OptionParser.accept Gem::Security::Policy do |value|
       require 'rubygems/security'
 


### PR DESCRIPTION
# Description:
Remove missleading TODO comment. Can't use `@parser.accept` since not every class where this is used has a parser available. i.e `lib/rubygems/install_update_options.rb`
______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
