### PR TITLE
Add raw spec method to gem package

### DIFF
--- a/lib/rubygems/commands/unpack_command.rb
+++ b/lib/rubygems/commands/unpack_command.rb
@@ -84,7 +84,7 @@ command help for an example.
       end
 
       if @options[:spec]
-        spec, metadata = get_metadata path, security_policy
+        spec, metadata = Gem::Package.metadata(path, security_policy)
 
         if metadata.nil?
           alert_error "--spec is unsupported on '#{name}' (old format gem)"
@@ -172,32 +172,4 @@ command help for an example.
 
     path
   end
-
-  ##
-  # Extracts the Gem::Specification and raw metadata from the .gem file at
-  # +path+.
-  #--
-  # TODO move to Gem::Package as #raw_spec or something
-
-  def get_metadata(path, security_policy = nil)
-    format = Gem::Package.new path, security_policy
-    spec = format.spec
-
-    metadata = nil
-
-    File.open path, Gem.binary_mode do |io|
-      tar = Gem::Package::TarReader.new io
-      tar.each_entry do |entry|
-        case entry.full_name
-        when 'metadata' then
-          metadata = entry.read
-        when 'metadata.gz' then
-          metadata = Gem::Util.gunzip entry.read
-        end
-      end
-    end
-
-    return spec, metadata
-  end
-
 end

--- a/lib/rubygems/commands/unpack_command.rb
+++ b/lib/rubygems/commands/unpack_command.rb
@@ -84,7 +84,7 @@ command help for an example.
       end
 
       if @options[:spec]
-        spec, metadata = Gem::Package.metadata(path, security_policy)
+        spec, metadata = Gem::Package.raw_spec(path, security_policy)
 
         if metadata.nil?
           alert_error "--spec is unsupported on '#{name}' (old format gem)"
@@ -172,4 +172,5 @@ command help for an example.
 
     path
   end
+
 end

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -161,7 +161,7 @@ class Gem::Package
   # +path+.
   #--
 
-  def self.metadata(path, security_policy = nil)
+  def self.raw_spec(path, security_policy = nil)
     format = new(path, security_policy)
     spec = format.spec
 
@@ -716,6 +716,7 @@ EOM
   rescue Zlib::GzipFile::Error => e
     raise Gem::Package::FormatError.new(e.message, entry.full_name)
   end
+
 end
 
 require 'rubygems/package/digest_io'

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -420,7 +420,7 @@ class TestGemPackage < Gem::Package::TarTestCase
     assert_equal %w[lib/code.rb], reader.contents
   end
 
-  def test_metadata
+  def test_raw_spec
     data_tgz = util_tar_gz { }
 
     gem = util_tar do |tar|
@@ -441,7 +441,7 @@ class TestGemPackage < Gem::Package::TarTestCase
       io.write gem.string
     end
 
-    spec, metadata = Gem::Package.metadata(gem_path)
+    spec, metadata = Gem::Package.raw_spec(gem_path)
 
     assert_equal @spec, spec
     assert_match @spec.to_yaml, metadata.force_encoding("UTF-8")


### PR DESCRIPTION
# Description:
Move `get_metadata` method in `unpack_command.rb` to `Gem::Package`
Then rename it to `raw_spec`, since the old `get_metadata` method returned more than metadata...
______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
