### PR TITLE
Upgrading S3 source signature to AWS SigV4

### DIFF
--- a/lib/rubygems/s3_uri_signer.rb
+++ b/lib/rubygems/s3_uri_signer.rb
@@ -1,8 +1,6 @@
 require 'base64'
 require 'digest'
 require 'openssl'
-require 'rubygems/request'
-require 'rubygems/request/connection_pools'
 
 ##
 # S3URISigner implements AWS SigV4 for S3 Source to avoid a dependency on the aws-sdk-* gems
@@ -139,6 +137,8 @@ class Gem::S3URISigner
 
   def ec2_metadata
     require 'net/http'
+    require 'rubygems/request'
+    require 'rubygems/request/connection_pools'
 
     metadata_uri = URI(EC2_METADATA_CREDENTIALS)
 

--- a/lib/rubygems/s3_uri_signer.rb
+++ b/lib/rubygems/s3_uri_signer.rb
@@ -39,9 +39,7 @@ class Gem::S3URISigner
 
   ##
   # Signs S3 URI using query-params according to the reference: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
-  def sign(expiration = nil)
-    expiration ||= 86400
-
+  def sign(expiration = 86400)
     s3_config = fetch_s3_config
 
     current_time = Time.now.utc

--- a/lib/rubygems/s3_uri_signer.rb
+++ b/lib/rubygems/s3_uri_signer.rb
@@ -1,0 +1,166 @@
+require 'base64'
+require 'digest'
+require 'openssl'
+require 'rubygems/request'
+require 'rubygems/request/connection_pools'
+
+##
+# S3URISigner implements AWS SigV4 for S3 Source to avoid a dependency on the aws-sdk-* gems
+# More on AWS SigV4: https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html
+class Gem::S3URISigner
+
+  class ConfigurationError < Gem::Exception
+
+    def initialize(message)
+      super message
+    end
+
+    def to_s # :nodoc:
+      "#{super}"
+    end
+
+  end
+
+  class InstanceProfileError < Gem::Exception
+
+    def initialize(message)
+      super message
+    end
+
+    def to_s # :nodoc:
+      "#{super}"
+    end
+
+  end
+
+  attr_accessor :uri
+
+  def initialize(uri)
+    @uri = uri
+  end
+
+  ##
+  # Signs S3 URI using query-params according to the reference: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
+  def sign(expiration = nil)
+    expiration ||= 86400
+
+    s3_config = fetch_s3_config
+
+    current_time = Time.now.utc
+    date_time = current_time.strftime("%Y%m%dT%H%m%SZ")
+    date = date_time[0,8]
+
+    credential_info = "#{date}/#{s3_config.region}/s3/aws4_request"
+    canonical_host = "#{uri.host}.s3.#{s3_config.region}.amazonaws.com"
+
+    canonical_params = {}
+    canonical_params["X-Amz-Algorithm"] = "AWS4-HMAC-SHA256"
+    canonical_params["X-Amz-Credential"] = "#{s3_config.access_key_id}/#{credential_info}"
+    canonical_params["X-Amz-Date"] = date_time
+    canonical_params["X-Amz-Expires"] = expiration.to_s
+    canonical_params["X-Amz-SignedHeaders"] = "host"
+    canonical_params["X-Amz-Security-Token"] = s3_config.security_token if s3_config.security_token
+
+    # Sorting is required to generate proper signature
+    query_params = canonical_params.sort.to_h.map do |key, value|
+      "#{base64_uri_escape(key)}=#{base64_uri_escape(value)}"
+    end.join("&")
+
+    canonical_request = [
+      "GET",
+      uri.path,
+      query_params,
+      "host:#{canonical_host}",
+      "", # empty params
+      "host",
+      "UNSIGNED-PAYLOAD",
+    ].join("\n")
+
+    string_to_sign = [
+      "AWS4-HMAC-SHA256",
+      date_time,
+      credential_info,
+      Digest::SHA256.hexdigest(canonical_request)
+    ].join("\n")
+
+    date_key = OpenSSL::HMAC.digest("sha256", "AWS4" + s3_config.secret_access_key, date)
+    date_region_key = OpenSSL::HMAC.digest("sha256", date_key, s3_config.region)
+    date_region_service_key = OpenSSL::HMAC.digest("sha256", date_region_key, "s3")
+    signing_key = OpenSSL::HMAC.digest("sha256", date_region_service_key, "aws4_request")
+    signature = OpenSSL::HMAC.hexdigest("sha256", signing_key, string_to_sign)
+
+    URI.parse("https://#{canonical_host}#{uri.path}?#{query_params}&X-Amz-Signature=#{signature}")
+  end
+
+  private
+
+  S3Config = Struct.new :access_key_id, :secret_access_key, :security_token, :region
+
+  ##
+  # Extracts S3 configuration for S3 bucket
+  def fetch_s3_config
+    return S3Config.new(uri.user, uri.password, nil, "us-east-1") if uri.user && uri.password
+
+    s3_source = Gem.configuration[:s3_source] || Gem.configuration["s3_source"]
+    host = uri.host
+    raise ConfigurationError.new("no s3_source key exists in .gemrc") unless s3_source
+
+    auth = s3_source[host] || s3_source[host.to_sym]
+    raise ConfigurationError.new("no key for host #{host} in s3_source in .gemrc") unless auth
+
+    provider = auth[:provider] || auth["provider"]
+    case provider
+    when "env"
+      id = ENV["AWS_ACCESS_KEY_ID"]
+      secret = ENV["AWS_SECRET_ACCESS_KEY"]
+      security_token = ENV["AWS_SESSION_TOKEN"]
+    when "instance_profile"
+      require "json"
+      credentials_response = ec2_metadata
+      credentials = JSON.parse(credentials_response)
+      id = credentials["AccessKeyId"]
+      secret = credentials["SecretAccessKey"]
+      security_token = credentials["Token"]
+    else
+      id = auth[:id] || auth["id"]
+      secret = auth[:secret] || auth["secret"]
+      raise ConfigurationError.new("s3_source for #{host} missing id or secret") unless id && secret
+
+      security_token = auth[:security_token] || auth["security_token"]
+    end
+
+    region = auth[:region] || auth["region"] || "us-east-1"
+    S3Config.new(id, secret, security_token, region)
+  end
+
+  def base64_uri_escape(str)
+    str.gsub("\n", "").gsub(/[\+\/=]/) { |c| BASE64_URI_TRANSLATE[c] }
+  end
+
+  def ec2_metadata
+    require 'net/http'
+
+    metadata_uri = URI(EC2_METADATA_CREDENTIALS)
+
+    @request_pool ||= create_request_pool(metadata_uri)
+    request = Gem::Request.new(metadata_uri, Net::HTTP::Get, nil, @request_pool)
+    response = request.fetch
+
+    case response
+    when Net::HTTPOK then
+      response.body
+    else
+      raise InstanceProfileError.new("Unable to fetch AWS credentials from #{metadata_uri}: #{response.message} #{response.code}")
+    end
+  end
+
+  def create_request_pool(uri)
+    proxy_uri = Gem::Request.proxy_uri(Gem::Request.get_proxy_from_env(uri.scheme))
+    certs = Gem::Request.get_cert_files
+    Gem::Request::ConnectionPools.new(proxy_uri, certs).pool_for(uri)
+  end
+
+  BASE64_URI_TRANSLATE = { "+" => "%2B", "/" => "%2F", "=" => "%3D" }.freeze
+  EC2_METADATA_CREDENTIALS = "http://169.254.169.254/latest/meta-data/identity-credentials/ec2/security-credentials/ec2-instance".freeze
+
+end

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -670,7 +670,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
 
     data = fetcher.fetch_s3 URI.parse(url)
 
-    assert_equal "https://my-bucket.s3.#{region}.amazonaws.com/gems/specs.4.8.gz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=testuser%2F20190624%2F#{region}%2Fs3%2Faws4_request&X-Amz-Date=20190624T050641Z&X-Amz-Expires=3600#{token ? "&X-Amz-Security-Token=" + token : ""}&X-Amz-SignedHeaders=host&X-Amz-Signature=#{signature}", $fetched_uri.to_s
+    assert_equal "https://my-bucket.s3.#{region}.amazonaws.com/gems/specs.4.8.gz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=testuser%2F20190624%2F#{region}%2Fs3%2Faws4_request&X-Amz-Date=20190624T050641Z&X-Amz-Expires=86400#{token ? "&X-Amz-Security-Token=" + token : ""}&X-Amz-SignedHeaders=host&X-Amz-Signature=#{signature}", $fetched_uri.to_s
     assert_equal 'success', data
   ensure
     $fetched_uri = nil
@@ -682,7 +682,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     }
     url = 's3://my-bucket/gems/specs.4.8.gz'
     Time.stub :now, Time.at(1561353581) do
-      assert_fetch_s3 url, '8464fcf293454689ec1d3399463c9eeafe2a5b22f2cbd948cba28175a34b073d'
+      assert_fetch_s3 url, '20f974027db2f3cd6193565327a7c73457a138efb1a63ea248d185ce6827d41b'
     end
   ensure
     Gem.configuration[:s3_source] = nil
@@ -694,7 +694,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     }
     url = 's3://my-bucket/gems/specs.4.8.gz'
     Time.stub :now, Time.at(1561353581) do
-      assert_fetch_s3 url, '800419b6efb5eacabef2c13c7e493f093df417afc10961f6dcc7e085c9c89e93', nil, 'us-west-2'
+      assert_fetch_s3 url, '4afc3010757f1fd143e769f1d1dabd406476a4fc7c120e9884fd02acbb8f26c9', nil, 'us-west-2'
     end
   ensure
     Gem.configuration[:s3_source] = nil
@@ -706,7 +706,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     }
     url = 's3://my-bucket/gems/specs.4.8.gz'
     Time.stub :now, Time.at(1561353581) do
-      assert_fetch_s3 url, '9686a7b85d29b983f0ee723fd444536258ae1d3a7afa7f8599b3852aef3c8c11', 'testtoken'
+      assert_fetch_s3 url, '935160a427ef97e7630f799232b8f208c4a4e49aad07d0540572a2ad5fe9f93c', 'testtoken'
     end
   ensure
     Gem.configuration[:s3_source] = nil
@@ -721,7 +721,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     }
     url = 's3://my-bucket/gems/specs.4.8.gz'
     Time.stub :now, Time.at(1561353581) do
-      assert_fetch_s3 url, '8464fcf293454689ec1d3399463c9eeafe2a5b22f2cbd948cba28175a34b073d'
+      assert_fetch_s3 url, '20f974027db2f3cd6193565327a7c73457a138efb1a63ea248d185ce6827d41b'
     end
   ensure
     ENV.each_key {|key| ENV.delete(key) if key.start_with?('AWS')}
@@ -737,7 +737,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     }
     url = 's3://my-bucket/gems/specs.4.8.gz'
     Time.stub :now, Time.at(1561353581) do
-      assert_fetch_s3 url, '800419b6efb5eacabef2c13c7e493f093df417afc10961f6dcc7e085c9c89e93', nil, 'us-west-2'
+      assert_fetch_s3 url, '4afc3010757f1fd143e769f1d1dabd406476a4fc7c120e9884fd02acbb8f26c9', nil, 'us-west-2'
     end
   ensure
     ENV.each_key {|key| ENV.delete(key) if key.start_with?('AWS')}
@@ -753,7 +753,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     }
     url = 's3://my-bucket/gems/specs.4.8.gz'
     Time.stub :now, Time.at(1561353581) do
-      assert_fetch_s3 url, '9686a7b85d29b983f0ee723fd444536258ae1d3a7afa7f8599b3852aef3c8c11', 'testtoken'
+      assert_fetch_s3 url, '935160a427ef97e7630f799232b8f208c4a4e49aad07d0540572a2ad5fe9f93c', 'testtoken'
     end
   ensure
     ENV.each_key {|key| ENV.delete(key) if key.start_with?('AWS')}
@@ -763,7 +763,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
   def test_fetch_s3_url_creds
     url = 's3://testuser:testpass@my-bucket/gems/specs.4.8.gz'
     Time.stub :now, Time.at(1561353581) do
-      assert_fetch_s3 url, '8464fcf293454689ec1d3399463c9eeafe2a5b22f2cbd948cba28175a34b073d'
+      assert_fetch_s3 url, '20f974027db2f3cd6193565327a7c73457a138efb1a63ea248d185ce6827d41b'
     end
   end
 
@@ -774,7 +774,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
 
     url = 's3://my-bucket/gems/specs.4.8.gz'
     Time.stub :now, Time.at(1561353581) do
-      assert_fetch_s3 url, '8464fcf293454689ec1d3399463c9eeafe2a5b22f2cbd948cba28175a34b073d', nil, 'us-east-1',
+      assert_fetch_s3 url, '20f974027db2f3cd6193565327a7c73457a138efb1a63ea248d185ce6827d41b', nil, 'us-east-1',
                       '{"AccessKeyId": "testuser", "SecretAccessKey": "testpass"}'
     end
   ensure
@@ -788,7 +788,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
 
     url = 's3://my-bucket/gems/specs.4.8.gz'
     Time.stub :now, Time.at(1561353581) do
-      assert_fetch_s3 url, '800419b6efb5eacabef2c13c7e493f093df417afc10961f6dcc7e085c9c89e93', nil, 'us-west-2',
+      assert_fetch_s3 url, '4afc3010757f1fd143e769f1d1dabd406476a4fc7c120e9884fd02acbb8f26c9', nil, 'us-west-2',
                       '{"AccessKeyId": "testuser", "SecretAccessKey": "testpass"}'
     end
   ensure
@@ -802,7 +802,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
 
     url = 's3://my-bucket/gems/specs.4.8.gz'
     Time.stub :now, Time.at(1561353581) do
-      assert_fetch_s3 url, '9686a7b85d29b983f0ee723fd444536258ae1d3a7afa7f8599b3852aef3c8c11', 'testtoken', 'us-east-1',
+      assert_fetch_s3 url, '935160a427ef97e7630f799232b8f208c4a4e49aad07d0540572a2ad5fe9f93c', 'testtoken', 'us-east-1',
                       '{"AccessKeyId": "testuser", "SecretAccessKey": "testpass", "Token": "testtoken"}'
     end
   ensure

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -659,13 +659,16 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     def fetcher.request(uri, request_class, last_modified = nil)
       $fetched_uri = uri
       res = Net::HTTPOK.new nil, 200, nil
-      case uri.to_s
-      when /^http:\/\/169\.254\.169\.254.*/
-        def res.body() $instance_profile end
-      else
-        def res.body() 'success' end
-      end
+      def res.body() 'success' end
       res
+    end
+
+    def fetcher.s3_uri_signer(uri)
+      s3_uri_signer = Gem::S3URISigner.new(uri)
+      def s3_uri_signer.ec2_metadata
+        $instance_profile
+      end
+      s3_uri_signer
     end
 
     data = fetcher.fetch_s3 URI.parse(url)

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -665,8 +665,8 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
 
     def fetcher.s3_uri_signer(uri)
       s3_uri_signer = Gem::S3URISigner.new(uri)
-      def s3_uri_signer.ec2_metadata
-        $instance_profile
+      def s3_uri_signer.ec2_metadata_credentials_json
+        JSON.parse($instance_profile)
       end
       s3_uri_signer
     end

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -664,6 +664,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     end
 
     def fetcher.s3_uri_signer(uri)
+      require 'json'
       s3_uri_signer = Gem::S3URISigner.new(uri)
       def s3_uri_signer.ec2_metadata_credentials_json
         JSON.parse($instance_profile)


### PR DESCRIPTION
# Description:
Initial problem description can be found in https://github.com/rubygems/rubygems/issues/2793

The following PR adopts AWS SigV4 implementation with query params according this spec: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html

As a part this PR I also added the following functionality:
- Explicitly define a region in `.gemrc` for a give S3 bucket.
- Session-Token support for [temporary credentials](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html).
- Added an option to define a `provider` in `.gemrc` to extract S3 credentials from different sources:
  - `env` extracts credentials from environment variable according to the AWS [env-vars ](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) naming convention
  - `instance_profile` uses EC2 metadata endpoint to extract unique EC2 instance credentials.

Supported `s3_source` options:
```
s3_source: {
  bucket-default: {
    id: "...",
    secret: "..."
  },
  bucket-with-region: {
    id: "...",
    secret: "...",
    region: "us-east-1"
  },
  bucket-with-region-and-token: {
    id: "...",
    secret: "...",
    security_token: "...",
    region: "us-west-2"
  },
  bucket-with-env-provider-and-region: {
    provider: "env",
    region: "us-west-2"
  },
  bucket-with-env-instance-profile-and-region: {
    provider: "instance_profile",
    region: "us-west-2"
  }
}
```
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
