### PR TITLE
Remove useless comment in exceptions.rb

### DIFF
--- a/lib/rubygems/exceptions.rb
+++ b/lib/rubygems/exceptions.rb
@@ -1,8 +1,4 @@
 # frozen_string_literal: true
-# TODO: the documentation in here is terrible.
-#
-# Each exception needs a brief description and the scenarios where it is
-# likely to be raised
 
 require 'rubygems/deprecate'
 


### PR DESCRIPTION
# Description:

Remove useless comment in exceptions.rb
______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
