### PR TITLE
Remove missleading comment, no reason to move Gem.host to Gem::Util

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -645,14 +645,12 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   # <tt>https://rubygems.org</tt>.
 
   def self.host
-    # TODO: move to utils
     @host ||= Gem::DEFAULT_HOST
   end
 
   ## Set the default RubyGems API host.
 
   def self.host=(host)
-    # TODO: move to utils
     @host = host
   end
 


### PR DESCRIPTION
# Description:
The comment suggests moving `Gem.host` and `Gem.host=` but i don't see a good reason to do it, since the logic behind both methods is simple enough
______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
