### PR TITLE
check_version_conflict don't have a 'dep' variable available for use

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2229,7 +2229,6 @@ class Gem::Specification < Gem::BasicSpecification
 
     e = Gem::LoadError.new msg
     e.name = self.name
-    # TODO: e.requirement = dep.requirement
 
     raise e
   end


### PR DESCRIPTION
# Description:
Removes TODO comment about using of dep variable.

`check_version_conflict` don't have a 'dep' variable available for use
______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
