### PR TITLE
Remove unused 'raise' from test_case

### DIFF
--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -807,9 +807,6 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
   # location are returned.
 
   def util_gem(name, version, deps = nil, &block)
-    # TODO: deprecate
-    raise "deps or block, not both" if deps and block
-
     if deps
       block = proc do |s|
         # Since Hash#each is unordered in 1.8, sort


### PR DESCRIPTION
# Description:
Seems like this `raise` is useless now?

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
