### PR TITLE
Remove TODO comment about warning on setting instead of pushing

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1847,29 +1847,23 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   ##
-  # Sets executables to +value+, ensuring it is an array. Don't
-  # use this, push onto the array instead.
+  # Sets executables to +value+, ensuring it is an array.
 
   def executables=(value)
-    # TODO: warn about setting instead of pushing
     @executables = Array(value)
   end
 
   ##
-  # Sets extensions to +extensions+, ensuring it is an array. Don't
-  # use this, push onto the array instead.
+  # Sets extensions to +extensions+, ensuring it is an array.
 
   def extensions=(extensions)
-    # TODO: warn about setting instead of pushing
     @extensions = Array extensions
   end
 
   ##
-  # Sets extra_rdoc_files to +files+, ensuring it is an array. Don't
-  # use this, push onto the array instead.
+  # Sets extra_rdoc_files to +files+, ensuring it is an array.
 
   def extra_rdoc_files=(files)
-    # TODO: warn about setting instead of pushing
     @extra_rdoc_files = Array files
   end
 
@@ -2245,11 +2239,9 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   ##
-  # Sets rdoc_options to +value+, ensuring it is an array. Don't
-  # use this, push onto the array instead.
+  # Sets rdoc_options to +value+, ensuring it is an array.
 
   def rdoc_options=(options)
-    # TODO: warn about setting instead of pushing
     @rdoc_options = Array options
   end
 
@@ -2268,11 +2260,9 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   ##
-  # Set requirements to +req+, ensuring it is an array. Don't
-  # use this, push onto the array instead.
+  # Set requirements to +req+, ensuring it is an array.
 
   def requirements=(req)
-    # TODO: warn about setting instead of pushing
     @requirements = Array req
   end
 


### PR DESCRIPTION
# Description:
Remove TODO comment about warning on setting instead of pushing.

This methods are heavily used across specs and i personally think those warning at this point will not add much value, thoughts?
______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
