### PR TITLE
Add a gem attr to the Gem::Package class

### DIFF
--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -100,6 +100,11 @@ class Gem::Package
   attr_reader :files
 
   ##
+  # Reference to the gem being packaged.
+
+  attr_reader :gem
+
+  ##
   # The security policy used for verifying the contents of this package.
 
   attr_accessor :security_policy

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -1093,10 +1093,10 @@ class TestGemPackage < Gem::Package::TarTestCase
     assert_equal @spec, package.spec
   end
 
-  def test_gem_attr
-    package = Gem::Package.new(@gem)
-    assert_equal(package.gem, @gem)
-  end
+ def test_gem_attr
+   package = Gem::Package.new(@gem)
+   assert_equal(package.gem.path, @gem)
+ end
 
   def test_spec_from_io
     # This functionality is used by rubygems.org to extract spec data from an

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -1093,6 +1093,11 @@ class TestGemPackage < Gem::Package::TarTestCase
     assert_equal @spec, package.spec
   end
 
+  def test_gem_attr
+    package = Gem::Package.new(@gem)
+    assert_equal(package.gem, @gem)
+  end
+
   def test_spec_from_io
     # This functionality is used by rubygems.org to extract spec data from an
     # uploaded gem before it is written to storage.


### PR DESCRIPTION
This PR just adds a simple attr reader to the `Gem::Package` class that lets you access the gem object passed to the constructor. Potentially useful in plugins so that you don't have to use `instance_variable_get`.

This is part 2 of https://github.com/rubygems/rubygems/issues/2750.