### PR TITLE
Add git hooks to Rubygems - Rubocop pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+HOOKS="pre-commit-rubocop"
+
+for hook in $HOOKS; do
+  if [ -f "$PWD/.githooks/$hook" ]; then
+    echo  "Running pre-commit hooks..."
+    echo  "  > $hook"
+
+    # Execute hook
+    "$PWD/.githooks/$hook"
+
+    if [ $? != 0 ]; then
+      exit 1
+    fi
+  else
+    echo "Error: file $hook not found."
+    exit 1
+  fi
+done
+

--- a/.githooks/pre-commit-rubocop
+++ b/.githooks/pre-commit-rubocop
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+./util/rubocop $(git diff --cached --name-only)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,8 @@ here: http://guides.rubygems.org/contributing/
     $ rake setup
     $ rake test
 
+> Optional you can configure git hooks with: rake git_hooks
+
 To run commands like `gem install` from the repo:
 
     $ ruby -Ilib bin/gem install

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ require "rake/testtask"
 require 'psych'
 
 desc "Setup Rubygems dev environment"
-task :setup => ["git_hooks", "bundler:checkout"] do
+task :setup => ["bundler:checkout"] do
   gemspec = Gem::Specification.load(File.expand_path("../rubygems-update.gemspec", __FILE__))
 
   gemspec.dependencies.each do |dep|

--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,11 @@ task :setup => ["bundler:checkout"] do
   end
 end
 
+desc "Setup git hooks"
+task :git_hooks do
+  sh "git config core.hooksPath .githooks"
+end
+
 Rake::TestTask.new do |t|
   t.ruby_opts = %w[--disable-gems -w]
   t.ruby_opts << '-rdevkit' if Gem.win_platform?

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ require "rake/testtask"
 require 'psych'
 
 desc "Setup Rubygems dev environment"
-task :setup => ["bundler:checkout"] do
+task :setup => ["git_hooks", "bundler:checkout"] do
   gemspec = Gem::Specification.load(File.expand_path("../rubygems-update.gemspec", __FILE__))
 
   gemspec.dependencies.each do |dep|


### PR DESCRIPTION
# Description:

I often find myself submitting PR's just to find out later that my PR's is failing due to rubocop.

This PR will make easier to avoid that issue, since is configuring rubocop as a git pre-commit hook 
______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
