### PR TITLE
Deprecate Gem::RemoteFetcher#fetch_size

### DIFF
--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -6,6 +6,7 @@ require 'rubygems/s3_uri_signer'
 require 'rubygems/uri_formatter'
 require 'rubygems/user_interaction'
 require 'resolv'
+require 'rubygems/deprecate'
 
 ##
 # RemoteFetcher handles the details of fetching gems and gem information from
@@ -14,6 +15,7 @@ require 'resolv'
 class Gem::RemoteFetcher
 
   include Gem::UserInteraction
+  extend Gem::Deprecate
 
   ##
   # A FetchError exception wraps up the various possible IO and HTTP failures
@@ -321,11 +323,13 @@ class Gem::RemoteFetcher
   ##
   # Returns the size of +uri+ in bytes.
 
-  def fetch_size(uri) # TODO: phase this out
+  def fetch_size(uri)
     response = fetch_path(uri, nil, true)
 
     response['content-length'].to_i
   end
+
+  deprecate :fetch_size, :none, 2019, 12
 
   ##
   # Performs a Net::HTTP request of type +request_class+ on +uri+ returning


### PR DESCRIPTION
# Description:
I don't see `Gem::RemoteFetcher#fetch_size` being used anywhere? and has a TODO about to `phase out`. Marking it as deprecated for now. 

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
