### PR TITLE
Use File#open instead of Kernel#open in stub_specification.rb

### DIFF
--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -113,8 +113,7 @@ class Gem::StubSpecification < Gem::BasicSpecification
       begin
         saved_lineno = $.
 
-        # TODO It should be use `File.open`, but bundler-1.16.1 example expects Kernel#open.
-        open loaded_from, OPEN_MODE do |file|
+        File.open loaded_from, OPEN_MODE do |file|
           begin
             file.readline # discard encoding line
             stubline = file.readline.chomp


### PR DESCRIPTION
# Description:
Use `File#open` instead of `Kernel#open`

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
