### PR TITLE
Ignore GEMRC variable for test suite

### DIFF
--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -248,6 +248,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
     @orig_env = ENV.to_hash
 
     ENV['GEM_VENDOR'] = nil
+    ENV['GEMRC'] = nil
     ENV['SOURCE_DATE_EPOCH'] = nil
 
     @current_dir = Dir.pwd


### PR DESCRIPTION
# Description:

It affects some test case. When I use `GEMRC` with the test suite, I got the following error:

```
 1) Failure:
TestGemGemRunner#test_do_configuration [/Users/hsbt/Documents/github.com/ruby/ruby/test/rubygems/test_gem_gem_runner.rb:43]:
Expected: ["--commands"]
  Actual: ["--no-document"]
```
______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
