### PR TITLE
yank command accepts opt option

### DIFF
--- a/lib/rubygems/commands/yank_command.rb
+++ b/lib/rubygems/commands/yank_command.rb
@@ -42,6 +42,7 @@ data you will need to change them immediately and yank your gem.
     end
 
     add_key_option
+    add_otp_option
     @host = nil
   end
 


### PR DESCRIPTION
# Description:

At the version 3.0.3 or later, `gem yank` does not accept OTP option even it says 'invalid option: --otp' when executing yank command with `--otp` option. 

This pull-request provides a patch to enable yank command accept `otp` option. 
This PR would resolve #2790 . 
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
