### PR TITLE
Move default specifications dir definition out of BasicSpecification.

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -35,7 +35,14 @@ class Gem::BasicSpecification
   end
 
   def self.default_specifications_dir
-    File.join(Gem.default_dir, "specifications", "default")
+    Gem.default_specifications_dir
+  end
+
+  class << self
+
+    extend Gem::Deprecate
+    deprecate :default_specifications_dir, "Gem::BasicSpecification.default_specifications_dir", 2020, 02
+
   end
 
   ##
@@ -84,7 +91,7 @@ class Gem::BasicSpecification
 
   def default_gem?
     loaded_from &&
-      File.dirname(loaded_from) == self.class.default_specifications_dir
+      File.dirname(loaded_from) == Gem.default_specifications_dir
   end
 
   ##

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -382,7 +382,7 @@ By default, this RubyGems will install gem as:
   end
 
   def install_default_bundler_gem(bin_dir)
-    specs_dir = Gem::Specification.default_specifications_dir
+    specs_dir = Gem.default_specifications_dir
     specs_dir = File.join(options[:destdir], specs_dir) unless Gem.win_platform?
     mkdir_p specs_dir, :mode => 0755
 

--- a/lib/rubygems/defaults.rb
+++ b/lib/rubygems/defaults.rb
@@ -71,6 +71,13 @@ module Gem
   end
 
   ##
+  # Path to specification files of default gems.
+
+  def self.default_specifications_dir
+    File.join(Gem.default_dir, "specifications", "default")
+  end
+
+  ##
   # Path for gems in the user's home directory
 
   def self.user_dir

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -448,7 +448,7 @@ class Gem::Installer
   #
 
   def default_spec_file
-    File.join Gem::Specification.default_specifications_dir, "#{spec.full_name}.gemspec"
+    File.join Gem.default_specifications_dir, "#{spec.full_name}.gemspec"
   end
 
   ##

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -827,7 +827,7 @@ class Gem::Specification < Gem::BasicSpecification
   def self.default_stubs(pattern = "*.gemspec")
     base_dir = Gem.default_dir
     gems_dir = File.join base_dir, "gems"
-    gemspec_stubs_in(default_specifications_dir, pattern) do |path|
+    gemspec_stubs_in(Gem.default_specifications_dir, pattern) do |path|
       Gem::StubSpecification.default_gemspec_stub(path, base_dir, gems_dir)
     end
   end
@@ -866,7 +866,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Loads the default specifications. It should be called only once.
 
   def self.load_defaults
-    each_spec([default_specifications_dir]) do |spec|
+    each_spec([Gem.default_specifications_dir]) do |spec|
       # #load returns nil if the spec is bad, so we just ignore
       # it at this stage
       Gem.register_default_spec(spec)

--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -80,7 +80,7 @@ class Gem::Uninstaller
 
     dirs =
       Gem::Specification.dirs +
-      [Gem::Specification.default_specifications_dir]
+      [Gem.default_specifications_dir]
 
     Gem::Specification.each_spec dirs do |spec|
       next unless dependency.matches_spec? spec

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -67,7 +67,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
       io.puts gemspec.to_ruby
     end
 
-    open(File.join(Gem::Specification.default_specifications_dir, "bundler-1.15.4.gemspec"), 'w') do |io|
+    open(File.join(Gem.default_specifications_dir, "bundler-1.15.4.gemspec"), 'w') do |io|
       gemspec.version = "1.15.4"
       io.puts gemspec.to_ruby
     end
@@ -181,7 +181,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     @cmd.install_default_bundler_gem bin_dir
 
     bundler_spec = Gem::Specification.load("bundler/bundler.gemspec")
-    default_spec_path = File.join(Gem::Specification.default_specifications_dir, "#{bundler_spec.full_name}.gemspec")
+    default_spec_path = File.join(Gem.default_specifications_dir, "#{bundler_spec.full_name}.gemspec")
     spec = Gem::Specification.load(default_spec_path)
 
     spec.executables.each do |e|
@@ -192,7 +192,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
       assert_path_exists File.join bin_dir, Gem.default_exec_format % e
     end
 
-    default_dir = Gem::Specification.default_specifications_dir
+    default_dir = Gem.default_specifications_dir
 
     # expect to remove other versions of bundler gemspecs on default specification directory.
     refute_path_exists File.join(default_dir, "bundler-1.15.4.gemspec")

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1129,7 +1129,7 @@ dependencies: []
     Gem::Specification.class_variable_set(:@@stubs, nil)
 
     dir_standard_specs = File.join Gem.dir, 'specifications'
-    dir_default_specs = Gem::BasicSpecification.default_specifications_dir
+    dir_default_specs = Gem.default_specifications_dir
 
     # Create gemspecs in three locations used in stubs
     loaded_spec = Gem::Specification.new 'a', '3'
@@ -1149,7 +1149,7 @@ dependencies: []
     Gem::Specification.class_variable_set(:@@stubs, nil)
 
     dir_standard_specs = File.join Gem.dir, 'specifications'
-    dir_default_specs = Gem::BasicSpecification.default_specifications_dir
+    dir_default_specs = Gem.default_specifications_dir
 
     # Create gemspecs in three locations used in stubs
     loaded_spec = Gem::Specification.new 'a', '3'
@@ -2052,7 +2052,7 @@ dependencies: []
 
   def test_base_dir_default
     default_dir =
-      File.join Gem::Specification.default_specifications_dir, @a1.spec_name
+      File.join Gem.default_specifications_dir, @a1.spec_name
 
     @a1.instance_variable_set :@loaded_from, default_dir
 


### PR DESCRIPTION
This was never the right place. The method got there just by evolution, not by design. Move it within default methods, where it suits better.

Since this method is presumably used just internally, it should be safe to deprecate it and remove later.