### PR TITLE
Remove test suite warnings

### DIFF
--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -2055,11 +2055,11 @@ gem 'other', version
   end
 
   def test_package_attribute
-    spec = quick_gem 'c' do |spec|
+    gem = quick_gem 'c' do |spec|
       util_make_exec spec, '#!/usr/bin/ruby', 'exe'
     end
 
-    installer = util_installer(spec, @gemhome)
+    installer = util_installer(gem, @gemhome)
     assert_respond_to(installer, :package)
     assert_kind_of(Gem::Package, installer.package)
   end


### PR DESCRIPTION
# Description:
Remove warning when running the test suite -  ` warning: shadowing outer local variable - spec`
______________
I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
