### PR TITLE
Replace domain parameter with a parameter to suppress suggestions

### DIFF
--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -155,9 +155,8 @@ class Gem::Command
   ##
   # Display to the user that a gem couldn't be found and reasons why
   #--
-  # TODO: replace +domain+ with a parameter to suppress suggestions
 
-  def show_lookup_failure(gem_name, version, errors, domain, required_by = nil)
+  def show_lookup_failure(gem_name, version, errors, suppress_suggestions = false, required_by = nil)
     gem = "'#{gem_name}' (#{version})"
     msg = String.new "Could not find a valid gem #{gem}"
 
@@ -174,7 +173,7 @@ class Gem::Command
 
     alert_error msg
 
-    unless domain == :local  # HACK
+    unless suppress_suggestions
       suggestions = Gem::SpecFetcher.fetcher.suggest_gems_from_name gem_name
 
       unless suggestions.empty?

--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -218,6 +218,7 @@ You can use `i` command instead of `install`.
       gem_version ||= options[:version]
       domain = options[:domain]
       domain = :local unless options[:suggest_alternate]
+      supress_suggestions = (domain == :local)
 
       begin
         install_gem gem_name, gem_version
@@ -225,11 +226,11 @@ You can use `i` command instead of `install`.
         alert_error "Error installing #{gem_name}:\n\t#{e.message}"
         exit_code |= 1
       rescue Gem::GemNotFoundException => e
-        show_lookup_failure e.name, e.version, e.errors, domain
+        show_lookup_failure e.name, e.version, e.errors, supress_suggestions
 
         exit_code |= 2
       rescue Gem::UnsatisfiableDependencyError => e
-        show_lookup_failure e.name, e.version, e.errors, domain,
+        show_lookup_failure e.name, e.version, e.errors, supress_suggestions,
                             "'#{gem_name}' (#{gem_version})"
 
         exit_code |= 2

--- a/test/rubygems/test_gem_command.rb
+++ b/test/rubygems/test_gem_command.rb
@@ -328,7 +328,7 @@ ERROR:  Could not find a valid gem 'other' (>= 0) in any repository
     end
 
     use_ui @ui do
-      @cmd.show_lookup_failure misspelled, Gem::Requirement.default, [], :remote
+      @cmd.show_lookup_failure misspelled, Gem::Requirement.default, []
     end
 
     expected = <<-EXPECTED


### PR DESCRIPTION
# Description:
Replace domain parameter in Gem::Command#show_lookup_failure with a parameter to suppress suggestions

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
