### PR TITLE
Fix @ran_rake assignment in builder.rb

### DIFF
--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -110,7 +110,7 @@ class Gem::Ext::Builder
     @build_args = build_args
     @gem_dir    = spec.full_gem_path
 
-    @ran_rake   = nil
+    @ran_rake   = false
   end
 
   ##
@@ -219,9 +219,6 @@ EOF
     dest_path = @spec.extension_dir
 
     FileUtils.rm_f @spec.gem_build_complete_path
-
-    # FIXME: action at a distance: @ran_rake modified deep in build_extension(). - @duckinator
-    @ran_rake = false # only run rake once
 
     @spec.extensions.each do |extension|
       break if @ran_rake


### PR DESCRIPTION
# Description:
Initialize `@ran_rake` correctly, so we don't have to set it up later and cause confusion
______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
