### PR TITLE
Revert cadb66 and deprecate specification autorequire 

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -133,6 +133,7 @@ class Gem::Specification < Gem::BasicSpecification
 
   @@default_value = {
     :authors                   => [],
+    :autorequire               => nil,
     :bindir                    => 'bin',
     :cert_chain                => [],
     :date                      => nil,
@@ -704,6 +705,13 @@ class Gem::Specification < Gem::BasicSpecification
   attr_accessor :activated
 
   alias :activated? :activated
+
+  ##
+  # Autorequire was used by old RubyGems to automatically require a file.
+  #
+  # Deprecated: It is neither supported nor functional.
+
+  attr_accessor :autorequire # :nodoc:
 
   ##
   # Sets the default executable for this gem.

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -369,6 +369,9 @@ http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard li
       warning "description and summary are identical"
     end
 
+    # TODO: raise at some given date
+    warning "deprecated autorequire specified" if autorequire
+
     executables.each do |executable|
       validate_shebang_line_in(executable)
     end

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -23,6 +23,7 @@ require_paths:
   - lib
 files:
   - lib/keyedlist.rb
+autorequire: keyedlist
 author: Florian Gross
 email: flgr@ccan.de
 has_rdoc: true
@@ -36,6 +37,7 @@ Gem::Specification.new do |s|
   s.summary = %q{A Hash which automatically computes keys.}
   s.files = [%q{lib/keyedlist.rb}]
   s.require_paths = [%q{lib}]
+  s.autorequire = %q{keyedlist}
   s.author = %q{Florian Gross}
   s.email = %q{flgr@ccan.de}
 end
@@ -677,6 +679,7 @@ end
   def test_self_attribute_names
     expected_value = %w[
       authors
+      autorequire
       bindir
       cert_chain
       date
@@ -2688,6 +2691,21 @@ end
       end
 
       assert_equal %{"#{f}" or "#{t}" is not an author}, e.message
+    end
+  end
+
+  def test_validate_autorequire
+    util_setup_validate
+
+    Dir.chdir @tempdir do
+      @a1.autorequire = 'code'
+
+      use_ui @ui do
+        @a1.validate
+      end
+
+      assert_match "#{w}:  deprecated autorequire specified\n",
+                   @ui.error, 'error'
     end
   end
 


### PR DESCRIPTION
# Description:
See: https://github.com/rubygems/rubygems/pull/2832
______________
I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
