### PR TITLE
Cherry-pick shushing deprecation warnings from ruby-core

### DIFF
--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -158,7 +158,9 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     @fetcher = fetcher
 
     e = assert_raises ArgumentError do
-      fetcher.fetch_size 'gems.example.com/yaml'
+      Gem::Deprecate.skip_during do
+        fetcher.fetch_size 'gems.example.com/yaml'
+      end
     end
 
     assert_equal 'uri scheme is invalid: nil', e.message
@@ -173,7 +175,9 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
 
     uri = 'http://gems.example.com/yaml'
     e = assert_raises Gem::RemoteFetcher::FetchError do
-      fetcher.fetch_size uri
+      Gem::Deprecate.skip_during do
+        fetcher.fetch_size uri
+      end
     end
 
     assert_equal "SocketError: oops (#{uri})", e.message
@@ -182,7 +186,9 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
   def test_no_proxy
     use_ui @stub_ui do
       assert_data_from_server @fetcher.fetch_path(@server_uri)
-      assert_equal SERVER_DATA.size, @fetcher.fetch_size(@server_uri)
+      Gem::Deprecate.skip_during do
+        assert_equal SERVER_DATA.size, @fetcher.fetch_size(@server_uri)
+      end
     end
   end
 


### PR DESCRIPTION
# Description:

This PR picks up a commit from ruby-core that removes deprecation warnings from our test suite.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] ~Write~ Cherry-pick code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
