### PR TITLE
Cleanup after testing `rake package`

### DIFF
--- a/test/rubygems/test_rake_package.rb
+++ b/test/rubygems/test_rake_package.rb
@@ -19,6 +19,8 @@ class TestRakePackage < Minitest::Test
 
       If you have added or removed files, make sure you run `rake update_manifest` to update the `Manifest.txt` accordingly
     MSG
+
+    FileUtils.rm_f "pkg"
   end
 
 end


### PR DESCRIPTION
# Description:

Sometimes it happens to me that my local tests start failing because I pull some file removals or renames into my local copy, and those are still present on my last copy of pkg/. In those cases, the test about `rake package` will fail with something like the following:

````

Failure:
TestRakePackage#test_builds_ok [/home/deivid/Code/rubygems/test/rubygems/test_rake_package.rb:13]:
Expected `rake package` to work, but got errors:

```
cd pkg/rubygems-update-3.1.0.pre1
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
rake aborted!
Gem::InvalidSpecificationException: ["test/rubygems/test_rake_package.rb"] are not files

Tasks: TOP => package => gem => pkg/rubygems-update-3.1.0.pre1.gem
(See full trace by running task with --trace)

 ```

If you have added or removed files, make sure you run `rake update_manifest` to update the `Manifest.txt` accordingly.
Expected: true
  Actual: false
````

So, make sure, package is always built from scratch.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
