### PR TITLE
Use the standard RUBY_ENGINE_VERSION instead of JRUBY_VERSION

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1395,14 +1395,12 @@ begin
 rescue LoadError
 end
 
-if defined?(RUBY_ENGINE)
-  begin
-    ##
-    # Defaults the Ruby implementation wants to provide for RubyGems
+begin
+  ##
+  # Defaults the Ruby implementation wants to provide for RubyGems
 
-    require "rubygems/defaults/#{RUBY_ENGINE}"
-  rescue LoadError
-  end
+  require "rubygems/defaults/#{RUBY_ENGINE}"
+rescue LoadError
 end
 
 ##

--- a/lib/rubygems/defaults.rb
+++ b/lib/rubygems/defaults.rb
@@ -129,15 +129,8 @@ module Gem
     end
   end
 
-  ##
-  # A wrapper around RUBY_ENGINE const that may not be defined
-
   def self.ruby_engine
-    if defined? RUBY_ENGINE
-      RUBY_ENGINE
-    else
-      'ruby'
-    end
+    RUBY_ENGINE
   end
 
   ##

--- a/lib/rubygems/request.rb
+++ b/lib/rubygems/request.rb
@@ -285,7 +285,7 @@ class Gem::Request
     end
     ua << ")"
 
-    ua << " #{RUBY_ENGINE}" if defined?(RUBY_ENGINE) and RUBY_ENGINE != 'ruby'
+    ua << " #{RUBY_ENGINE}" if RUBY_ENGINE != 'ruby'
 
     ua
   end

--- a/lib/rubygems/request_set/gem_dependency_api.rb
+++ b/lib/rubygems/request_set/gem_dependency_api.rb
@@ -782,7 +782,7 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
   # You may also provide +engine:+ and +engine_version:+ options to restrict
   # this gem dependencies file to a particular ruby engine and its engine
   # version.  This matching is performed by using the RUBY_ENGINE and
-  # engine_specific VERSION constants.  (For JRuby, JRUBY_VERSION).
+  # RUBY_ENGINE_VERSION constants.
 
   def ruby(version, options = {})
     engine         = options[:engine]
@@ -809,11 +809,9 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
     end
 
     if engine_version
-      my_engine_version = Object.const_get "#{Gem.ruby_engine.upcase}_VERSION"
-
-      if engine_version != my_engine_version
+      if engine_version != RUBY_ENGINE_VERSION
         message =
-          "Your Ruby engine version is #{Gem.ruby_engine} #{my_engine_version}, " +
+          "Your Ruby engine version is #{Gem.ruby_engine} #{RUBY_ENGINE_VERSION}, " +
           "but your #{gem_deps_file} requires #{engine} #{engine_version}"
 
         raise Gem::RubyVersionMismatch, message

--- a/test/rubygems/test_gem_request.rb
+++ b/test/rubygems/test_gem_request.rb
@@ -261,7 +261,7 @@ class TestGemRequest < Gem::TestCase
   def test_user_agent_engine
     util_save_version
 
-    Object.send :remove_const, :RUBY_ENGINE if defined?(RUBY_ENGINE)
+    Object.send :remove_const, :RUBY_ENGINE
     Object.send :const_set,    :RUBY_ENGINE, 'vroom'
 
     ua = make_request(@uri, nil, nil, nil).user_agent
@@ -274,7 +274,7 @@ class TestGemRequest < Gem::TestCase
   def test_user_agent_engine_ruby
     util_save_version
 
-    Object.send :remove_const, :RUBY_ENGINE if defined?(RUBY_ENGINE)
+    Object.send :remove_const, :RUBY_ENGINE
     Object.send :const_set,    :RUBY_ENGINE, 'ruby'
 
     ua = make_request(@uri, nil, nil, nil).user_agent
@@ -460,7 +460,7 @@ ERROR:  Certificate  is an invalid CA certificate
   end
 
   def util_restore_version
-    Object.send :remove_const, :RUBY_ENGINE if defined?(RUBY_ENGINE)
+    Object.send :remove_const, :RUBY_ENGINE
     Object.send :const_set,    :RUBY_ENGINE, @orig_RUBY_ENGINE if
       defined?(@orig_RUBY_ENGINE)
 
@@ -473,7 +473,7 @@ ERROR:  Certificate  is an invalid CA certificate
   end
 
   def util_save_version
-    @orig_RUBY_ENGINE     = RUBY_ENGINE if defined? RUBY_ENGINE
+    @orig_RUBY_ENGINE     = RUBY_ENGINE
     @orig_RUBY_PATCHLEVEL = RUBY_PATCHLEVEL
     @orig_RUBY_REVISION   = RUBY_REVISION if defined? RUBY_REVISION
   end

--- a/test/rubygems/test_gem_request_set_gem_dependency_api.rb
+++ b/test/rubygems/test_gem_request_set_gem_dependency_api.rb
@@ -34,21 +34,22 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
 
     Gem.instance_variable_set :@ruby_version, Gem::Version.new(version)
 
-    yield
+    begin
+      yield
+    ensure
+      Object.send :remove_const, :RUBY_ENGINE             if name
+      Object.send :remove_const, new_engine_version_const if version
 
-  ensure
-    Object.send :remove_const, :RUBY_ENGINE             if name
-    Object.send :remove_const, new_engine_version_const if version
+      Object.send :remove_const, engine_version_const     if name == 'ruby' and
+        Object.const_defined? engine_version_const
 
-    Object.send :remove_const, engine_version_const     if name == 'ruby' and
-      Object.const_defined? engine_version_const
+      Object.const_set :RUBY_ENGINE,         engine         if engine
+      Object.const_set engine_version_const, engine_version unless
+        Object.const_defined? engine_version_const
 
-    Object.const_set :RUBY_ENGINE,         engine         if engine
-    Object.const_set engine_version_const, engine_version unless
-      Object.const_defined? engine_version_const
-
-    Gem.send :remove_instance_variable, :@ruby_version if
-      Gem.instance_variables.include? :@ruby_version
+      Gem.send :remove_instance_variable, :@ruby_version if
+        Gem.instance_variables.include? :@ruby_version
+    end
   end
 
   def test_gempspec_with_multiple_runtime_deps

--- a/test/rubygems/test_gem_request_set_gem_dependency_api.rb
+++ b/test/rubygems/test_gem_request_set_gem_dependency_api.rb
@@ -20,35 +20,27 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
   end
 
   def with_engine_version(name, version)
-    engine               = RUBY_ENGINE if Object.const_defined? :RUBY_ENGINE
-    engine_version_const = "#{Gem.ruby_engine.upcase}_VERSION"
-    engine_version       = Object.const_get engine_version_const
+    engine = RUBY_ENGINE
+    engine_version = RUBY_ENGINE_VERSION
 
-    Object.send :remove_const, :RUBY_ENGINE         if engine
-    Object.send :remove_const, engine_version_const if name == 'ruby' and
-      Object.const_defined? engine_version_const
+    Object.send :remove_const, :RUBY_ENGINE
+    Object.send :remove_const, :RUBY_ENGINE_VERSION
 
-    new_engine_version_const = "#{name.upcase}_VERSION"
-    Object.const_set :RUBY_ENGINE,             name    if name
-    Object.const_set new_engine_version_const, version if version
+    Object.const_set :RUBY_ENGINE, name if name
+    Object.const_set :RUBY_ENGINE_VERSION, version if version
 
     Gem.instance_variable_set :@ruby_version, Gem::Version.new(version)
 
     begin
       yield
     ensure
-      Object.send :remove_const, :RUBY_ENGINE             if name
-      Object.send :remove_const, new_engine_version_const if version
+      Object.send :remove_const, :RUBY_ENGINE if name
+      Object.send :remove_const, :RUBY_ENGINE_VERSION if version
 
-      Object.send :remove_const, engine_version_const     if name == 'ruby' and
-        Object.const_defined? engine_version_const
+      Object.const_set :RUBY_ENGINE, engine
+      Object.const_set :RUBY_ENGINE_VERSION, engine_version
 
-      Object.const_set :RUBY_ENGINE,         engine         if engine
-      Object.const_set engine_version_const, engine_version unless
-        Object.const_defined? engine_version_const
-
-      Gem.send :remove_instance_variable, :@ruby_version if
-        Gem.instance_variables.include? :@ruby_version
+      Gem.send :remove_instance_variable, :@ruby_version
     end
   end
 
@@ -838,23 +830,20 @@ end
 
   def test_with_engine_version
     version = RUBY_VERSION
-    engine  = Gem.ruby_engine
-
-    engine_version_const = "#{Gem.ruby_engine.upcase}_VERSION"
-    engine_version       = Object.const_get engine_version_const
+    engine = Gem.ruby_engine
+    engine_version = RUBY_ENGINE_VERSION
 
     with_engine_version 'other', '1.2.3' do
       assert_equal 'other', Gem.ruby_engine
-      assert_equal '1.2.3', OTHER_VERSION
+      assert_equal '1.2.3', RUBY_ENGINE_VERSION
 
-      assert_equal version, RUBY_VERSION if engine
+      assert_equal version, RUBY_VERSION
     end
 
     assert_equal version, RUBY_VERSION
     assert_equal engine,  Gem.ruby_engine
 
-    assert_equal engine_version, Object.const_get(engine_version_const) if
-      engine
+    assert_equal engine_version, RUBY_ENGINE_VERSION if engine
   end
 
 end unless Gem.java_platform?


### PR DESCRIPTION
* RUBY_ENGINE and RUBY_ENGINE_VERSION are defined on every modern Ruby.
* There is no such constant as TRUFFLERUBY_VERSION or RBX_VERSION.

This blocks https://github.com/rubygems/rubygems/pull/2797.
Also see https://github.com/bundler/bundler/pull/7275

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
