### PR TITLE
Fixed deprecation message

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -41,7 +41,7 @@ class Gem::BasicSpecification
   class << self
 
     extend Gem::Deprecate
-    deprecate :default_specifications_dir, "Gem::BasicSpecification.default_specifications_dir", 2020, 02
+    deprecate :default_specifications_dir, "Gem.default_specifications_dir", 2020, 02
 
   end
 


### PR DESCRIPTION
# Description:

Using `Gem::BasicSpecification.default_specifications_dir` yields the following message, which makes no sense.

```
NOTE: Gem::BasicSpecification.default_specifications_dir is deprecated; use Gem::BasicSpecification.default_specifications_dir instead. It will be removed on or after 2020-02-01.
```

Cherry-picked ruby/ruby@e6901cea74
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).