### PR TITLE
Do not mutate uri.query during s3 signature creation

### DIFF
--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -675,6 +675,9 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
       def s3_uri_signer.ec2_metadata_credentials_json
         JSON.parse($instance_profile)
       end
+      # Running sign operation to make sure uri.query is not mutated
+      s3_uri_signer.sign
+      raise "URI query is not empty: #{uri.query}" unless uri.query.nil?
       s3_uri_signer
     end
 


### PR DESCRIPTION
# Description:
My previous PR https://github.com/rubygems/rubygems/pull/2807 introduced a small regression. 

When it fetches a new file using `Gem::RemoteFetcher.fetch_path` it unpacks it if an URI ends with `.gz`: https://github.com/rubygems/rubygems/blob/master/lib/rubygems/remote_fetcher.rb#L267:L273

In my PR above I mutated `uri` object and added params to the `uri.query`. As a result of that `uri` no longer ends with`.gz` and breaks `gem install` with s3 source.

- It fetches `prerelease_specs.4.8.gz` and stores as `prerelease_specs.4.8` on the file system. Keeping it unzipped.
- During `gem install` it will fail because of incompatible file-format:
```
ERROR:  While executing gem ... (TypeError)
    incompatible marshal file format (can't be read)
	format version 4.8 required; 31.139 given
```

The reason it didn't fail in previous iterations, because it relied on already cached file on a disk that was properly unzipped.

P.S. I also moved `ConfigurationError` message to cover all mechanism of fetching credentials.
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
