### PR TITLE
Upgrade TravisCI to use bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-dist: xenial
+dist: bionic
 branches:
   only:
     - master


### PR DESCRIPTION
# Description:

Not sure if we'll change our CI to use github actions or something, but for now I need to upgrade to bionic, because I did that in the bundler repo, and now bundler CI fails because it fails to install a `groff` version only present in bionic.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
