### PR TITLE
Fixup #2844

### DIFF
--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -87,7 +87,7 @@ module Gem::GemcutterUtilities
 
       unless (host_uri.scheme == allowed_host_uri.scheme) && (host_uri.host == allowed_host_uri.host)
         alert_error "#{self.host.inspect} is not allowed by the gemspec, which only allows #{allowed_push_host.inspect}"
-        terminate_interaction 1
+        terminate_interaction(ERROR_CODE)
       end
     end
 


### PR DESCRIPTION
# Description:

`lib/rubygems/gemcutter_utilities.rb` is still remained hard-coded number as `ERROR_CODE`

______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
