### PR TITLE
Set SOURCE_DATE_EPOCH env var if not provided.

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1242,6 +1242,23 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
   end
 
+  ##
+  # The SOURCE_DATE_EPOCH environment variable (or, if that's not set, the current time), converted to Time object.
+  # This is used throughout RubyGems for enabling reproducible builds.
+  #
+  # If it is not set as an environment variable already, this also sets it.
+  #
+  # Details on SOURCE_DATE_EPOCH:
+  # https://reproducible-builds.org/specs/source-date-epoch/
+
+  def self.source_date_epoch
+    if ENV["SOURCE_DATE_EPOCH"].nil? || ENV["SOURCE_DATE_EPOCH"].empty?
+      ENV["SOURCE_DATE_EPOCH"] = Time.now.to_i.to_s
+    end
+
+    Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc.freeze
+  end
+
   # FIX: Almost everywhere else we use the `def self.` way of defining class
   # methods, and then we switch over to `class << self` here. Pick one or the
   # other.

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -188,7 +188,7 @@ class Gem::Package
   def initialize(gem, security_policy) # :notnew:
     @gem = gem
 
-    @build_time      = ENV["SOURCE_DATE_EPOCH"] ? Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc : Time.now
+    @build_time      = Gem.source_date_epoch
     @checksums       = {}
     @contents        = nil
     @digests         = Hash.new { |h, algorithm| h[algorithm] = {} }

--- a/lib/rubygems/package/tar_writer.rb
+++ b/lib/rubygems/package/tar_writer.rb
@@ -123,7 +123,7 @@ class Gem::Package::TarWriter
 
     header = Gem::Package::TarHeader.new :name => name, :mode => mode,
                                          :size => size, :prefix => prefix,
-                                         :mtime => ENV["SOURCE_DATE_EPOCH"] ? Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc : Time.now
+                                         :mtime => Gem.source_date_epoch
 
     @io.write header
     @io.pos = final_pos
@@ -217,7 +217,7 @@ class Gem::Package::TarWriter
 
     header = Gem::Package::TarHeader.new(:name => name, :mode => mode,
                                          :size => size, :prefix => prefix,
-                                         :mtime => ENV["SOURCE_DATE_EPOCH"] ? Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc : Time.now).to_s
+                                         :mtime => Gem.source_date_epoch).to_s
 
     @io.write header
     os = BoundedStream.new @io, size
@@ -245,7 +245,7 @@ class Gem::Package::TarWriter
                                          :size => 0, :typeflag => "2",
                                          :linkname => target,
                                          :prefix => prefix,
-                                         :mtime => ENV["SOURCE_DATE_EPOCH"] ? Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc : Time.now).to_s
+                                         :mtime => Gem.source_date_epoch).to_s
 
     @io.write header
 
@@ -298,7 +298,7 @@ class Gem::Package::TarWriter
     header = Gem::Package::TarHeader.new :name => name, :mode => mode,
                                          :typeflag => "5", :size => 0,
                                          :prefix => prefix,
-                                         :mtime => ENV["SOURCE_DATE_EPOCH"] ? Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc : Time.now
+                                         :mtime => Gem.source_date_epoch
 
     @io.write header
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1667,7 +1667,7 @@ class Gem::Specification < Gem::BasicSpecification
   # https://reproducible-builds.org/specs/source-date-epoch/
 
   def date
-    @date ||= ENV["SOURCE_DATE_EPOCH"] ? Time.utc(*Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc.to_a[3..5].reverse) : TODAY
+    @date ||= Time.utc(*Gem.source_date_epoch.utc.to_a[3..5].reverse)
   end
 
   DateLike = Object.new # :nodoc:

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require 'rubygems/package/tar_test_case'
+require 'digest'
 
 class TestGemPackage < Gem::Package::TarTestCase
 
@@ -119,6 +120,32 @@ class TestGemPackage < Gem::Package::TarTestCase
     package = Gem::Package.new spec.file_name
 
     assert_equal Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc, package.build_time
+  ensure
+    ENV["SOURCE_DATE_EPOCH"] = epoch
+  end
+
+  def test_build_time_source_date_epoch_automatically_set
+    epoch = ENV["SOURCE_DATE_EPOCH"]
+    ENV["SOURCE_DATE_EPOCH"] = nil
+
+    start_time = Time.now.utc.to_i
+
+    spec = Gem::Specification.new 'build', '1'
+    spec.summary = 'build'
+    spec.authors = 'build'
+    spec.files = ['lib/code.rb']
+    spec.rubygems_version = Gem::Version.new '0'
+
+    package = Gem::Package.new spec.file_name
+
+    end_time = Time.now.utc.to_i
+
+    assert package.build_time.is_a?(Time)
+
+    build_time = package.build_time.to_i
+
+    assert(start_time <= build_time)
+    assert(build_time <= end_time)
   ensure
     ENV["SOURCE_DATE_EPOCH"] = epoch
   end


### PR DESCRIPTION
# Description:

Set SOURCE_DATE_EPOCH env var if not provided.

Fixes #2290.

1. `Gem::Specification.date` returns SOURCE_DATE_EPOCH when defined,
2. this commit makes RubyGems set it _persistently_ when not provided.

This combination means that you can build a gem, check the build time,
and use that value to generate a new build -- and then verify they're
the same.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
