### PR TITLE
Use jruby-9.2.8.0 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
       rvm: 2.6.3
       env: "TEST_TOOL=bundler RGV=.. BDV=master"
     - stage: test
-      rvm: jruby-9.2.7.0
+      rvm: jruby-9.2.8.0
       env: "TEST_TOOL=rubygems"
     - stage: test
       rvm: ruby-head


### PR DESCRIPTION
# Description:

Bumps the jruby version used in our CI to the latest jruby release.

Hopefully it will be a bit more stable and CI will no longer fail randomly :)

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
