### PR TITLE
Build the first gemspec we found if no arguments are passed to gem build

### DIFF
--- a/lib/rubygems/commands/build_command.rb
+++ b/lib/rubygems/commands/build_command.rb
@@ -62,7 +62,7 @@ Gems can be saved to a specified filename with the output option:
 
   private
 
-  def build_gem(gemspec = get_one_gem_name)
+  def build_gem(gemspec = get_one_optional_argument)
     unless File.exist?(gemspec)
       gemspec += ".gemspec" if File.exist?(gemspec + ".gemspec")
     end

--- a/lib/rubygems/commands/build_command.rb
+++ b/lib/rubygems/commands/build_command.rb
@@ -82,7 +82,7 @@ Gems can be saved to a specified filename with the output option:
 
       if options[:build_path]
         Dir.chdir(File.dirname(gemspec)) do
-          spec = Gem::Specification.load File.basename(gemspec)
+          spec = Gem::Specification.load(File.basename(gemspec))
           build_package(spec)
         end
       else

--- a/lib/rubygems/commands/build_command.rb
+++ b/lib/rubygems/commands/build_command.rb
@@ -57,10 +57,18 @@ Gems can be saved to a specified filename with the output option:
   end
 
   def execute
-    build_gem
+    build_gem(gem_name)
   end
 
   private
+
+  def gem_name
+    get_one_optional_argument || find_gemspecs.first
+  end
+
+  def find_gemspecs
+    Dir.glob("*.gemspec").sort
+  end
 
   def build_gem(gem_name = get_one_optional_argument)
     gemspec = File.exist?(gem_name) ? gem_name : "#{gem_name}.gemspec"

--- a/lib/rubygems/commands/build_command.rb
+++ b/lib/rubygems/commands/build_command.rb
@@ -57,14 +57,11 @@ Gems can be saved to a specified filename with the output option:
   end
 
   def execute
+    gem_name = get_one_optional_argument || find_gemspec
     build_gem(gem_name)
   end
 
   private
-
-  def gem_name
-    get_one_optional_argument || find_gemspec
-  end
 
   def find_gemspec
     gemspecs = Dir.glob("*.gemspec").sort
@@ -77,7 +74,7 @@ Gems can be saved to a specified filename with the output option:
     gemspecs.first
   end
 
-  def build_gem(gem_name = get_one_optional_argument)
+  def build_gem(gem_name)
     gemspec = File.exist?(gem_name) ? gem_name : "#{gem_name}.gemspec"
 
     if File.exist?(gemspec)

--- a/lib/rubygems/commands/build_command.rb
+++ b/lib/rubygems/commands/build_command.rb
@@ -62,10 +62,8 @@ Gems can be saved to a specified filename with the output option:
 
   private
 
-  def build_gem(gemspec = get_one_optional_argument)
-    unless File.exist?(gemspec)
-      gemspec += ".gemspec" if File.exist?(gemspec + ".gemspec")
-    end
+  def build_gem(gem_name = get_one_optional_argument)
+    gemspec = File.exist?(gem_name) ? gem_name : "#{gem_name}.gemspec"
 
     if File.exist?(gemspec)
       spec = Gem::Specification.load(gemspec)

--- a/lib/rubygems/commands/build_command.rb
+++ b/lib/rubygems/commands/build_command.rb
@@ -57,13 +57,17 @@ Gems can be saved to a specified filename with the output option:
   end
 
   def execute
-    gemspec = get_one_gem_name
+    build_gem
+  end
 
-    unless File.exist? gemspec
-      gemspec += '.gemspec' if File.exist? gemspec + '.gemspec'
+  private
+
+  def build_gem(gemspec = get_one_gem_name)
+    unless File.exist?(gemspec)
+      gemspec += ".gemspec" if File.exist?(gemspec + ".gemspec")
     end
 
-    if File.exist? gemspec
+    if File.exist?(gemspec)
       spec = Gem::Specification.load(gemspec)
 
       if options[:build_path]
@@ -77,11 +81,9 @@ Gems can be saved to a specified filename with the output option:
 
     else
       alert_error "Gemspec file not found: #{gemspec}"
-      terminate_interaction 1
+      terminate_interaction(1)
     end
   end
-
-  private
 
   def build_package(spec)
     if spec

--- a/lib/rubygems/commands/build_command.rb
+++ b/lib/rubygems/commands/build_command.rb
@@ -63,11 +63,18 @@ Gems can be saved to a specified filename with the output option:
   private
 
   def gem_name
-    get_one_optional_argument || find_gemspecs.first
+    get_one_optional_argument || find_gemspec
   end
 
-  def find_gemspecs
-    Dir.glob("*.gemspec").sort
+  def find_gemspec
+    gemspecs = Dir.glob("*.gemspec").sort
+
+    if gemspecs.size > 1
+      alert_error "Multiple gemspecs found: #{gemspecs}, please specify one"
+      terminate_interaction(1)
+    end
+
+    gemspecs.first
   end
 
   def build_gem(gem_name = get_one_optional_argument)

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -244,7 +244,7 @@ class TestGemCommandsBuildCommand < Gem::TestCase
 
   def test_execute_without_gem_name
     some_gem = util_spec "some_gem"
-    gemspec_dir  = File.join(@tempdir, "build_command_gem")
+    gemspec_dir = File.join(@tempdir, "build_command_gem")
     gemspec_file = File.join(gemspec_dir, some_gem.spec_name)
 
     FileUtils.mkdir_p(gemspec_dir)

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -243,20 +243,11 @@ class TestGemCommandsBuildCommand < Gem::TestCase
   end
 
   def test_execute_without_gem_name
-    some_gem = util_spec "some_gem" do |s|
-      s.license = "AGPL-3.0"
-      s.files = ["README.md"]
-    end
-
+    some_gem = util_spec "some_gem"
     gemspec_dir  = File.join(@tempdir, "build_command_gem")
     gemspec_file = File.join(gemspec_dir, some_gem.spec_name)
-    readme_file  = File.join(gemspec_dir, 'README.md')
 
     FileUtils.mkdir_p(gemspec_dir)
-
-    File.open(readme_file, "w") do |f|
-      f.write("My awesome gem")
-    end
 
     File.open(gemspec_file, "w") do |gs|
       gs.write(some_gem.to_ruby)

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -189,7 +189,7 @@ class TestGemCommandsBuildCommand < Gem::TestCase
     end
 
     assert_equal '', @ui.output
-    assert_equal "ERROR:  Gemspec file not found: some_gem\n", @ui.error
+    assert_equal "ERROR:  Gemspec file not found: some_gem.gemspec\n", @ui.error
   end
 
   def test_execute_outside_dir

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -293,19 +293,18 @@ class TestGemCommandsBuildCommand < Gem::TestCase
 
     use_ui @ui do
       Dir.chdir(gemspec_dir) do
-        @cmd.execute
+        assert_raises Gem::MockGemUi::TermError do
+          @cmd.execute
+        end
       end
     end
 
-    output = @ui.output.split("\n")
-    assert_equal "  Successfully built RubyGem", output.shift
-    assert_equal "  Name: another_gem", output.shift
-    assert_equal "  Version: 2", output.shift
-    assert_equal "  File: another_gem-2.gem", output.shift
-    assert_equal [], output
+    gemspecs = ["another_gem-2.gemspec", "some_gem-2.gemspec"]
+    assert_equal "", @ui.output
+    assert_equal @ui.error, "ERROR:  Multiple gemspecs found: #{gemspecs}, please specify one\n"
 
     expected_gem = File.join(gemspec_dir, File.basename(another_gem.cache_file))
-    assert File.exist?(expected_gem)
+    refute File.exist?(expected_gem)
   end
 
   def util_test_build_gem(gem)
@@ -323,29 +322,6 @@ class TestGemCommandsBuildCommand < Gem::TestCase
     assert_equal [], output
 
     gem_file = File.join(@tempdir, File.basename(gem.cache_file))
-    assert File.exist?(gem_file)
-
-    spec = Gem::Package.new(gem_file).spec
-
-    assert_equal "some_gem", spec.name
-    assert_equal "this is a summary", spec.summary
-  end
-
-  def util_test_build_gem(gem)
-    use_ui @ui do
-      Dir.chdir @tempdir do
-        @cmd.execute
-      end
-    end
-
-    output = @ui.output.split "\n"
-    assert_equal "  Successfully built RubyGem", output.shift
-    assert_equal "  Name: some_gem", output.shift
-    assert_equal "  Version: 2", output.shift
-    assert_equal "  File: some_gem-2.gem", output.shift
-    assert_equal [], output
-
-    gem_file = File.join @tempdir, File.basename(gem.cache_file)
     assert File.exist?(gem_file)
 
     spec = Gem::Package.new(gem_file).spec


### PR DESCRIPTION
# Description:
closes https://github.com/rubygems/rubygems/issues/2859

Build the first gemspec we found if no arguments are passed to `gem build`.

```shell
 $ ls
total 72
-rw-r--r--  1 bronzdoc  staff    93 Aug 18 14:52 Gemfile
-rw-r--r--  1 bronzdoc  staff  1167 Aug 18 14:52 README.md
-rw-r--r--  1 bronzdoc  staff    51 Aug 18 14:52 Rakefile
drwxr-xr-x  4 bronzdoc  staff   128 Aug 18 14:52 bin
drwxr-xr-x  4 bronzdoc  staff   128 Aug 18 14:52 lib
-rw-r--r--  1 bronzdoc  staff  1206 Aug 18 14:53 test_gem.gemspec
```

```shell
$ gem build
  Successfully built RubyGem
  Name: test_gem
  Version: 0.1.0
  File: test_gem-0.1.0.gem
```
______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
