### PR TITLE
Add a section to the CONTRIBUTING.md file on signing commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,3 +148,13 @@ issues have a blue `category: *` label.
 If an issue or pull request pertains to only one platform, then it should have
 an appropriate purple `platform: *` label. Current platform labels:
 **windows**, **java**, **osx**, **linux**
+
+### Git
+
+Please sign your commits. Although not required in order for you to contribute,
+it does ensures that any code submitted by you wasn't altered while you were
+transferring it, and proves that it was you who submitted it and not someone
+else.
+
+Please see https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work for
+details on how to generate a signature and automatically sign your commits.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,5 +156,6 @@ it does ensures that any code submitted by you wasn't altered while you were
 transferring it, and proves that it was you who submitted it and not someone
 else.
 
-Please see https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work for
-details on how to generate a signature and automatically sign your commits.
+Please see https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work or
+https://help.github.com/en/articles/signing-commits for details on how to
+to generate a signature and automatically sign your commits.


### PR DESCRIPTION
This adds a small section to the contributing guide that suggests signing your commits, as well as a link to instructions on how to set that up.

Followup to https://github.com/rubygems/rubygems/issues/2880