### PR TITLE
Improve `gem uninstall --all`

### DIFF
--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -88,6 +88,10 @@ class Gem::Uninstaller
       list << spec
     end
 
+    if list.empty?
+      raise Gem::InstallError, "gem #{@gem.inspect} is not installed"
+    end
+
     default_specs, list = list.partition do |spec|
       spec.default_gem?
     end
@@ -101,9 +105,7 @@ class Gem::Uninstaller
 
     if list.empty?
       if other_repo_specs.empty?
-        if default_specs.empty?
-          raise Gem::InstallError, "gem #{@gem.inspect} is not installed"
-        else
+        if default_specs.any?
           message =
             "gem #{@gem.inspect} cannot be uninstalled " +
             "because it is a default gem"

--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -96,6 +96,10 @@ class Gem::Uninstaller
       spec.default_gem?
     end
 
+    default_specs.each do |default_spec|
+      say "Gem #{default_spec.full_name} cannot be uninstalled because it is a default gem"
+    end
+
     list, other_repo_specs = list.partition do |spec|
       @gem_home == spec.base_dir or
         (@user_install and spec.base_dir == Gem.user_dir)
@@ -104,14 +108,7 @@ class Gem::Uninstaller
     list.sort!
 
     if list.empty?
-      if other_repo_specs.empty?
-        if default_specs.any?
-          message =
-            "gem #{@gem.inspect} cannot be uninstalled " +
-            "because it is a default gem"
-          raise Gem::InstallError, message
-        end
-      end
+      return unless other_repo_specs.any?
 
       other_repos = other_repo_specs.map { |spec| spec.base_dir }.uniq
 

--- a/test/rubygems/test_gem_commands_uninstall_command.rb
+++ b/test/rubygems/test_gem_commands_uninstall_command.rb
@@ -41,6 +41,51 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
                  Gem::Specification.all_names.sort
   end
 
+  def test_execute_all_named_default_single
+    z_1 = new_default_spec 'z', '1'
+    install_default_gems z_1
+
+    assert_includes Gem::Specification.all_names, 'z-1'
+
+    @cmd.options[:all] = true
+    @cmd.options[:args] = %w[z]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    assert_equal %w[z-1], Gem::Specification.all_names.sort
+
+    output = @ui.output.split "\n"
+
+    assert_equal 'Gem z-1 cannot be uninstalled because it is a default gem', output.shift
+  end
+
+  def test_execute_all_named_default_multiple
+    z_1 = new_default_spec 'z', '1'
+    install_default_gems z_1
+
+    z_2, = util_gem 'z', 2
+    install_gem z_2
+
+    assert_includes Gem::Specification.all_names, 'z-1'
+    assert_includes Gem::Specification.all_names, 'z-2'
+
+    @cmd.options[:all] = true
+    @cmd.options[:args] = %w[z]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    assert_equal %w[z-1], Gem::Specification.all_names.sort
+
+    output = @ui.output.split "\n"
+
+    assert_equal 'Gem z-1 cannot be uninstalled because it is a default gem', output.shift
+    assert_equal 'Successfully uninstalled z-2', output.shift
+  end
+
   def test_execute_dependency_order
     initial_install
 

--- a/test/rubygems/test_gem_uninstaller.rb
+++ b/test/rubygems/test_gem_uninstaller.rb
@@ -221,13 +221,13 @@ class TestGemUninstaller < Gem::InstallerTestCase
 
     uninstaller = Gem::Uninstaller.new spec.name, :executables => true
 
-    e = assert_raises Gem::InstallError do
+    use_ui @ui do
       uninstaller.uninstall
     end
 
-    assert_equal 'gem "default" cannot be uninstalled ' +
-                 'because it is a default gem',
-                 e.message
+    lines = @ui.output.split("\n")
+
+    assert_equal 'Gem default-2 cannot be uninstalled because it is a default gem', lines.shift
   end
 
   def test_uninstall_default_gem_with_same_version


### PR DESCRIPTION
# Description:

After we started unswallowing errors of `gem uninstall` in #2707, some people got failing CI runs because they were doing things like `gem uninstall <default_gem> --all --force`. Previously that would work just fine, because the error while trying to uninstall a default gem was being swallowed.

In my opinion, if you try to do `gem uninstall bundler:1.17.2` (on a ruby where this is the default bundler version), then it is fine to fail hard, but if you do `gem uninstall bundler --all`, then the command should uninstall all bundler versions that can be uninstalled (and skip the default version), but not fail just because bundler is a default gem.

It can be argued though that the command should indeed fail hard, because it didn't really succeeded on trying to do what the user asked for: the user tried to uninstall _all_versions, but that wasn't achieved because the default version was left around.

In order to find a compromise between these two visions, and maximize usability, I propose to not fail hard, but log a line for each default version that couldn't be removed.

Note that the current behavior is completely inconsistent (in my opinion), because it fails if the default copy is the single copy in the system, but succeeds if it's not:

```
$ gem uninstall rdoc --all --force 
ERROR:  While executing gem ... (Gem::InstallError)
    gem "rdoc" cannot be uninstalled because it is a default gem

$ gem install rdoc
Fetching rdoc-6.1.1.gem
Successfully installed rdoc-6.1.1
1 gem installed

$ gem uninstall rdoc --all --force 
Successfully uninstalled rdoc-6.1.1
```

After this PR, the messages are more consistent and informative, in my opinion, and the status code is always success (as it was before #2707).

```
$ ruby -Ilib bin/gem uninstall rdoc --all --force
Ignored rdoc-6.1.0 because it is a default gem

$ gem install rdoc
Fetching rdoc-6.1.1.gem
Successfully installed rdoc-6.1.1
1 gem installed

$ ruby -Ilib bin/gem uninstall rdoc --all --force
Ignored rdoc-6.1.0 because it is a default gem
Successfully uninstalled rdoc-6.1.1
```

Thoughts?

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

Closes #2892.