### PR TITLE
Use IAM role to extract security-credentials for EC2 instance

### DIFF
--- a/lib/rubygems/s3_uri_signer.rb
+++ b/lib/rubygems/s3_uri_signer.rb
@@ -152,7 +152,7 @@ class Gem::S3URISigner
 
     iam_info = ec2_metadata_request(EC2_IAM_INFO)
     # Expected format: arn:aws:iam::<id>:instance-profile/<role_name>
-    role_name = iam_info['InstanceProfileArn'].split('/')[1]
+    role_name = iam_info['InstanceProfileArn'].split('/').last
     ec2_metadata_request(EC2_IAM_SECURITY_CREDENTIALS + role_name)
   end
 


### PR DESCRIPTION
# Description:
Accidentally used the wrong metadata endpoint that is reserved for the internal use. If we want to use proper EC2 instance-profile credentials we need to extract the role-name first by calling `iam/info` and use it to construct `iam/security-credentials/role-name`.

If `iam_role` is not attached to the instance it will raise an exception `ec2_metadata_request` since `iam/info` will return 404.

See metadata documentation for more details: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html

Is there a chance we can have a new release for this? (I've been waiting for `3.0.5`/`3.0.6`, but unfortunately notice this issue just now).

Thank you!

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).