### PR TITLE
Fix gem update --user-install

### DIFF
--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -136,6 +136,9 @@ command to remove old versions.
   def highest_installed_gems # :nodoc:
     hig = {} # highest installed gems
 
+    # Get only gem specifications installed as --user-install
+    Gem::Specification.dirs = Gem.user_dir if options[:user_install]
+
     Gem::Specification.each do |spec|
       if hig[spec.name].nil? or hig[spec.name].version < spec.version
         hig[spec.name] = spec

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -73,8 +73,6 @@ command to remove old versions.
       say "Latest version already installed. Done."
       terminate_interaction
     end
-
-    options[:user_install] = false
   end
 
   def check_update_arguments # :nodoc:

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -90,9 +90,10 @@ command to remove old versions.
       return
     end
 
-    hig = highest_installed_gems
-
-    gems_to_update = which_to_update hig, options[:args].uniq
+    gems_to_update = which_to_update(
+      highest_installed_gems,
+      options[:args].uniq
+    )
 
     if options[:explain]
       say "Gems to update:"

--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -359,10 +359,10 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
   end
 
   def test_execute_user_install
-    spec_fetcher do |fetcher|
-      fetcher.download 'a', 2
-      fetcher.spec 'a', 1
-    end
+    a = util_spec "a", 1
+    b = util_spec "b", 1
+    install_gem_user(a)
+    install_gem(b)
 
     @cmd.handle_options %w[--user-install]
 
@@ -373,7 +373,13 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
     installer = @cmd.installer
     user_install = installer.instance_variable_get :@user_install
 
-    assert user_install, 'user_install must be set on the installer'
+    assert user_install, "user_install must be set on the installer"
+
+    out = @ui.output.split "\n"
+    assert_equal "Updating installed gems", out.shift
+    assert_equal "Updating a", out.shift
+    assert_equal "Gems updated: a", out.shift
+    assert_empty out
   end
 
   def test_fetch_remote_gems


### PR DESCRIPTION
# Description:

Closes https://github.com/rubygems/rubygems/issues/2886

Update only user insatalled gems when the `--user-install` flag is passed to `gem update`

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
