### PR TITLE
Fix underscore version selection for bundler

### DIFF
--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -281,7 +281,7 @@ class Gem::Dependency
       requirement.satisfied_by?(spec.version) && env_req.satisfied_by?(spec.version)
     end.map(&:to_spec)
 
-    Gem::BundlerVersionFinder.filter!(matches) if name == "bundler".freeze
+    Gem::BundlerVersionFinder.filter!(matches) if name == "bundler".freeze && !requirement.specific?
 
     if platform_only
       matches.reject! do |spec|

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -375,6 +375,40 @@ class TestGem < Gem::TestCase
     assert_equal %w(bundler-2.0.0), loaded_spec_names
   end
 
+  def test_activate_bin_path_respects_underscore_selection_if_given
+    bundler_latest = util_spec 'bundler', '2.0.1' do |s|
+      s.executables = ['bundle']
+    end
+
+    bundler_previous = util_spec 'bundler', '1.17.3' do |s|
+      s.executables = ['bundle']
+    end
+
+    install_specs bundler_latest, bundler_previous
+
+    File.open("Gemfile.lock", "w") do |f|
+      f.write <<-L.gsub(/ {8}/, "")
+        GEM
+          remote: https://rubygems.org/
+          specs:
+
+        PLATFORMS
+          ruby
+
+        DEPENDENCIES
+
+        BUNDLED WITH
+          2.0.1
+      L
+    end
+
+    File.open("Gemfile", "w") { |f| f.puts('source "https://rubygems.org"') }
+
+    load Gem.activate_bin_path("bundler", "bundle", "= 1.17.3")
+
+    assert_equal %w(bundler-1.17.3), loaded_spec_names
+  end
+
   def test_self_bin_path_no_exec_name
     e = assert_raises ArgumentError do
       Gem.bin_path 'a'


### PR DESCRIPTION
# Description:

When rubygems' underscore version selection is used with bundler itself, it doesn't work. This PR should fix it.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

Fixes bundler/bundler#7345.
Closes bundler/bundler#7349.