### PR TITLE
Fix Kernel#warn override

### DIFF
--- a/lib/rubygems/core_ext/kernel_warn.rb
+++ b/lib/rubygems/core_ext/kernel_warn.rb
@@ -14,7 +14,11 @@ if RUBY_VERSION >= "2.5"
 
     module_function define_method(:warn) {|*messages, **kw|
       unless uplevel = kw[:uplevel]
-        return original_warn.call(*messages, **kw)
+        if Gem.java_platform?
+          return original_warn.call(*messages)
+        else
+          return original_warn.call(*messages, **kw)
+        end
       end
 
       # Ensure `uplevel` fits a `long`

--- a/lib/rubygems/core_ext/kernel_warn.rb
+++ b/lib/rubygems/core_ext/kernel_warn.rb
@@ -39,7 +39,9 @@ if RUBY_VERSION >= "2.5"
         end
         uplevel = start
       end
-      original_warn.call(*messages, uplevel: uplevel, **kw)
+
+      kw[:uplevel] = uplevel
+      original_warn.call(*messages, **kw)
     }
   end
 end

--- a/lib/rubygems/core_ext/kernel_warn.rb
+++ b/lib/rubygems/core_ext/kernel_warn.rb
@@ -12,9 +12,9 @@ if RUBY_VERSION >= "2.5"
 
     original_warn = method(:warn)
 
-    module_function define_method(:warn) {|*messages, uplevel: nil|
-      unless uplevel
-        return original_warn.call(*messages)
+    module_function define_method(:warn) {|*messages, **kw|
+      unless uplevel = kw[:uplevel]
+        return original_warn.call(*messages, **kw)
       end
 
       # Ensure `uplevel` fits a `long`
@@ -39,7 +39,7 @@ if RUBY_VERSION >= "2.5"
         end
         uplevel = start
       end
-      original_warn.call(*messages, uplevel: uplevel)
+      original_warn.call(*messages, uplevel: uplevel, **kw)
     }
   end
 end

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -516,6 +516,21 @@ class TestGemRequire < Gem::TestCase
         assert_equal "main.rb:1: warning: uplevel\ntest\n", err
       end
     end
+
+    def test_no_other_behavioral_changes_with_kernel_warn
+      lib = File.realpath("../../../lib", __FILE__)
+      Dir.mktmpdir("warn_test") do |dir|
+        File.write(dir + "/main.rb", "warn({x:1}, {y:2}, {})\n")
+        _, err = capture_subprocess_io do
+          system(@@ruby, "-w", "-rpp", "--disable=gems", "-I", lib, "-C", dir, "-I.", "main.rb")
+        end
+        assert_equal "{:x=>1}\n{:y=>2}\n", err
+        _, err = capture_subprocess_io do
+          system(@@ruby, "-w", "-rpp", "--enable=gems", "-I", lib, "-C", dir, "-I.", "main.rb")
+        end
+        assert_equal "{:x=>1}\n{:y=>2}\n", err
+      end
+    end
   end
 
   def silence_warnings


### PR DESCRIPTION
# Description:

This makes the Kernel#warn override behave the same as the default
Kernel#warn.  Previously, behavior could be different, because an
empty hash or empty keyword arguments would be swallowed by the
override, and the second to last argument could be treated as the
keyword argument by the default Kernel#warn.

For example:

    warn({x:1}, {y:2}, {})

    # C version outputs:
    {:x=>1}
    {:y=>2}

    # Rubygems version raises:
    unknown keyword: y (ArgumentError)

By using a keyword splat, and passing the keyword splat to the
default version, we can make behavior the same.

This issue was originally reported on the Ruby bug tracker:
https://bugs.ruby-lang.org/issues/16157#note-8

# Tasks:

- [X] Describe the problem / feature
- [ ] Write tests
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).