### PR TITLE
Suppress Ruby 2.7's real kwargs warning

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -469,7 +469,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     subdirs.each do |name|
       subdir = File.join dir, name
       next if File.exist? subdir
-      FileUtils.mkdir_p subdir, options rescue nil
+      FileUtils.mkdir_p subdir, **options rescue nil
     end
   ensure
     File.umask old_umask

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -513,7 +513,7 @@ EOM
       path = File.expand_path(path + File::SEPARATOR + basename)
       lstat = File.lstat path rescue nil
       if !lstat || !lstat.directory?
-        unless normalize_path(path).start_with? normalize_path(destination_dir) and (FileUtils.mkdir path, mkdir_options rescue false)
+        unless normalize_path(path).start_with? normalize_path(destination_dir) and (FileUtils.mkdir path, **mkdir_options rescue false)
           raise Gem::Package::PathError.new(file_name, destination_dir)
         end
       end


### PR DESCRIPTION
# Description:

Follow ruby/ruby#2395.

This PR suppress the following Ruby 2.7's real kwargs warning.

```console% ruby -v
% ruby -v
ruby 2.7.0dev (2019-09-11T21:58:51Z master 515b1989b1) [x86_64-darwin17]

% gem i bundler
(snip)
/Users/koic/.rbenv/versions/2.7.0-dev/lib/ruby/site_ruby/2.7.0/rubygems/package.rb:489:
warning: The last argument is used as the keyword parameter
/Users/koic/.rbenv/versions/2.7.0-dev/lib/ruby/2.7.0/fileutils.rb:171:
warning: for `mkdir' defined here

% cd path/to/rubygems
% rake test
(snip)
./Users/koic/src/github.com/rubygems/rubygems/lib/rubygems.rb:472:
warning: The last argument is used as the keyword parameter
/Users/koic/.rbenv/versions/2.7.0-dev/lib/ruby/2.7.0/fileutils.rb:197:
warning: for `mkdir_p' defined here
```

______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
