### PR TITLE
Fix gem pristine not accounting for user installed gems

### DIFF
--- a/lib/rubygems/commands/pristine_command.rb
+++ b/lib/rubygems/commands/pristine_command.rb
@@ -111,11 +111,6 @@ extensions will be restored.
             "Failed to find gems #{options[:args]} #{options[:version]}"
     end
 
-    install_dir = Gem.dir # TODO use installer option
-
-    raise Gem::FilePermissionError.new(install_dir) unless
-      File.writable?(install_dir)
-
     say "Restoring gems to pristine condition..."
 
     specs.each do |spec|


### PR DESCRIPTION
# Description:
closes https://github.com/rubygems/rubygems/issues/1968

The problem is gem pristine is always checking for the `INSTALLATION DIRECTORY` instead of the `USER INSTALLATION DIRECTORY` even if a gem is installed using the `--user-install` flag.

If a `INSTALLATION DIRECTORY` is not writable it would cause an error like:

```
ERROR:  While executing gem ... (Gem::FilePermissionError)
    You don't have write permissions for the /var/lib/gems/2.3.0 directory.
```

This check is not needed in the pristine command, writable gem_home directory is already being checked at installation time by `Gem::Installer#pre_install_checks`
______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
