### PR TITLE
Detect libc version, closes #2918

### DIFF
--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -88,7 +88,7 @@ class Gem::Platform
                       when /^dalvik(\d+)?$/ then        [ 'dalvik',    $1  ]
                       when /^dotnet$/ then              [ 'dotnet',    nil ]
                       when /^dotnet([\d.]*)/ then       [ 'dotnet',    $1  ]
-                      when /linux-?(\w+)?/ then         [ 'linux',     $1  ]
+                      when /linux-?((?!gnu)\w+)?/ then  [ 'linux',     $1  ]
                       when /mingw32/ then               [ 'mingw32',   nil ]
                       when /(mswin\d+)(\_(\d+))?/ then
                         os, version = $1, $3

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -88,7 +88,7 @@ class Gem::Platform
                       when /^dalvik(\d+)?$/ then        [ 'dalvik',    $1  ]
                       when /^dotnet$/ then              [ 'dotnet',    nil ]
                       when /^dotnet([\d.]*)/ then       [ 'dotnet',    $1  ]
-                      when /linux/ then                 [ 'linux',     $1  ]
+                      when /linux-?(\w+)?/ then         [ 'linux',     $1  ]
                       when /mingw32/ then               [ 'mingw32',   nil ]
                       when /(mswin\d+)(\_(\d+))?/ then
                         os, version = $1, $3

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -76,6 +76,7 @@ class TestGemPlatform < Gem::TestCase
       'i386-solaris2.8'        => ['x86',       'solaris',   '2.8'],
       'mswin32'                => ['x86',       'mswin32',   nil],
       'x86_64-linux'           => ['x86_64',    'linux',     nil],
+      'x86_64-linux-musl'      => ['x86_64',    'linux',     'musl'],
       'x86_64-openbsd3.9'      => ['x86_64',    'openbsd',   '3.9'],
       'x86_64-openbsd4.0'      => ['x86_64',    'openbsd',   '4.0'],
       'x86_64-openbsd'         => ['x86_64',    'openbsd',   nil],


### PR DESCRIPTION
# Description:

Detect libc version on Linux, makes it possible to distinguish between distributions compiled with alternative libc

# Tasks:

- [ ] Describe the problem / feature
- [x] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
