### PR TITLE
Introduce default prerelease requirement

### DIFF
--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -66,7 +66,7 @@ module Kernel
 
     if spec = Gem.find_unresolved_default_spec(path)
       begin
-        Kernel.send(:gem, spec.name, "#{Gem::Requirement.default}.a")
+        Kernel.send(:gem, spec.name, Gem::Requirement.default_prerelease)
       rescue Exception
         RUBYGEMS_ACTIVATION_MONITOR.exit
         raise

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -776,7 +776,7 @@ class Gem::Installer
 
 require 'rubygems'
 
-version = "#{Gem::Requirement.default}.a"
+version = "#{Gem::Requirement.default_prerelease}"
 
 str = ARGV.first
 if str

--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -32,9 +32,14 @@ class Gem::Requirement
   PATTERN = /\A#{PATTERN_RAW}\z/.freeze
 
   ##
-  # The default requirement matches any version
+  # The default requirement matches any non-prerelease version
 
   DefaultRequirement = [">=", Gem::Version.new(0)].freeze
+
+  ##
+  # The default requirement matches any version
+
+  DefaultPrereleaseRequirement = [">=", Gem::Version.new("0.a")].freeze
 
   ##
   # Raised when a bad requirement is encountered
@@ -73,6 +78,10 @@ class Gem::Requirement
     new '>= 0'
   end
 
+  def self.default_prerelease
+    new '>= 0.a'
+  end
+
   ###
   # A source set requirement, used for Gemfiles and lockfiles
 
@@ -101,6 +110,8 @@ class Gem::Requirement
 
     if $1 == ">=" && $2 == "0"
       DefaultRequirement
+    elsif $1 == ">=" && $2 == "0.a"
+      DefaultPrereleaseRequirement
     else
       [$1 || "=", Gem::Version.new($2)]
     end

--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -69,9 +69,6 @@ class Gem::Requirement
     end
   end
 
-  ##
-  # A default "version requirement" can surely _only_ be '>= 0'.
-
   def self.default
     new '>= 0'
   end


### PR DESCRIPTION
# Description:

This PR unifies a bit of logic by introducing a `Gem::Requirement.default_prerelease` analogous to `Gem::Requirement.default`, the difference between them being that the latter satisfies any non-prerelease version while the former allows any version.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
