### PR TITLE
filter dependency type and name strictly.

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -754,7 +754,11 @@ class Gem::Installer
       raise Gem::InstallError, "#{spec} has an invalid specification_version"
     end
 
-    if spec.dependencies.any? {|dep| dep.type =~ /\R/ || dep.name =~ /\R/ }
+    if spec.dependencies.any? {|dep| dep.type != :runtime && dep.type != :development }
+      raise Gem::InstallError, "#{spec} has an invalid dependencies"
+    end
+
+    if spec.dependencies.any? {|dep| dep.name =~ /(?:\R|[<>])/ }
       raise Gem::InstallError, "#{spec} has an invalid dependencies"
     end
   end

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -1120,10 +1120,10 @@ class TestGemPackage < Gem::Package::TarTestCase
     assert_equal @spec, package.spec
   end
 
- def test_gem_attr
-   package = Gem::Package.new(@gem)
-   assert_equal(package.gem.path, @gem)
- end
+  def test_gem_attr
+    package = Gem::Package.new(@gem)
+    assert_equal(package.gem.path, @gem)
+  end
 
   def test_spec_from_io
     # This functionality is used by rubygems.org to extract spec data from an


### PR DESCRIPTION
# Description:

`Gem::Specification#type` has only `:runtime` and `:development` and Also `Gem::Specification#name` is only one-word. 

We should filter them

Co-authored-by: Yusuke Endoh <mame@ruby-lang.org>
______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
