### PR TITLE
Always pass an encoding option to Zlib::GzipReader.wrap

### DIFF
--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -534,11 +534,7 @@ EOM
     when 'metadata' then
       @spec = Gem::Specification.from_yaml entry.read
     when 'metadata.gz' then
-      args = [entry]
-      args << { :external_encoding => Encoding::UTF_8 } if
-        Zlib::GzipReader.method(:wrap).arity != 1
-
-      Zlib::GzipReader.wrap(*args) do |gzio|
+      Zlib::GzipReader.wrap(entry, external_encoding: Encoding::UTF_8) do |gzio|
         @spec = Gem::Specification.from_yaml gzio.read
       end
     end


### PR DESCRIPTION
# Description:

The arity of this method has been -1 since the import, so the
option has been passed always, even if `Zlib::GzipReader#initialize`
does not take the option.  Actually it takes the option since 1.9.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
