### PR TITLE
Add deprecate command method

### DIFF
--- a/lib/rubygems/deprecate.rb
+++ b/lib/rubygems/deprecate.rb
@@ -65,37 +65,72 @@ module Gem::Deprecate
     end
   end
 
+  # Deprecation method to deprecate Rubygems commands
   def deprecate_command(year, month)
     class_eval do
-      @@deprecation_year  = year
+      # Year we want the command to be deprecated
+      @@deprecation_year = year
+
+      # Month we want the command to be deprecated
       @@deprecation_month = month
-      @@command_method    = :execute
-      @@command_found     = false
+
+      # We will be calling the deprecation warning whenever the "execute" method is called
+      @@command_method = :execute
+
+      # state variable to avoid infinite loop
+      @@command_found = false
+
+      # Original command name where this method is called.
+      # e.g if we call this method inside the Gem::Commands::QueryCommand class, this variable will be "query"
+      @@command = "#{self}".split("::").last.split(/(?=[A-Z])/).first.downcase
 
       def self.method_added(method_name)
+        # Look only when @@command_method is added/loaded
         if method_name == @@command_method
+          # If we don't return early this will be called recursively forerver.
+          # method_added will be called everytime we "define_method"
           return if @@command_found
 
           @@command_found = true
 
+          # Alias "execute" to "_deprecated_execute"
           old = "_deprecated_#{method_name}"
           alias_method old, method_name
 
+          # Overwrite execute method with our custom method that will display the deprecation message
           define_method method_name do |*args, &block|
-            send old, *args, &block
+            send(old, *args, &block)
 
-            klass = self.kind_of? Module
-            msg = [ "\nNOTE: #{self.command} command is deprecated",
-                    ". It will be removed on or after %4d-%02d-01.\n" % [@@deprecation_year, @@deprecation_month],
-            ]
+            # We will call the deprecation warning only on the class in which we are calling "deprecate_command"
+            # This is to avoid calling the deprecation warning on classes which inherits from the class we are calling "deprecate_command"
 
-            warn "#{msg.join}" unless Gem::Deprecate.skip
+            # Example:
+            #
+            #class Gem::Commands::QueryCommand
+            #    deprecate_command(2019, 12)
+            #
+            #    def execute
+            #      do_something
+            #    end
+            # end
+            #
+            # class Gem::Commands::InfoCommand < Gem::Commands::QueryCommand; end
+
+            # This check will prevent the deprecation warning happening when we execute "gem info" and display it
+            # only when we call "gem query" as expected
+            if "#{self.command}" == @@command
+              msg = [ "\nNOTE: #{self.command} command is deprecated",
+                      ". It will be removed on or after %4d-%02d-01.\n" % [@@deprecation_year, @@deprecation_month],
+              ]
+
+              warn "#{msg.join}" unless Gem::Deprecate.skip
+            end
           end
         end
       end
     end
   end
 
-  module_function :deprecate, :skip_during
+  module_function :deprecate, :deprecate_command, :skip_during
 
 end

--- a/lib/rubygems/deprecate.rb
+++ b/lib/rubygems/deprecate.rb
@@ -75,6 +75,7 @@ module Gem::Deprecate
       def self.method_added(method_name)
         if method_name == @@command_method
           return if @@command_found
+
           @@command_found = true
 
           old = "_deprecated_#{method_name}"
@@ -84,7 +85,6 @@ module Gem::Deprecate
             send old, *args, &block
 
             klass = self.kind_of? Module
-            target = klass ? "#{self}." : "#{self.class}#"
             msg = [ "\nNOTE: #{self.command} command is deprecated",
                     ". It will be removed on or after %4d-%02d-01.\n" % [@@deprecation_year, @@deprecation_month],
             ]

--- a/test/rubygems/test_deprecate.rb
+++ b/test/rubygems/test_deprecate.rb
@@ -77,4 +77,31 @@ class TestDeprecate < Gem::TestCase
     assert_match(/on or after 2099-03-01/, err)
   end
 
+  require 'rubygems/command'
+  class FooCommand < Gem::Command
+
+    extend Gem::Deprecate
+
+    deprecate_command(2099, 4)
+
+    def initialize
+      super("foo", "foo command does pew pew")
+    end
+
+    def execute
+      puts "pew pew!"
+    end
+
+  end
+
+  def test_deprecate_command
+    out, err = capture_io do
+      foo = FooCommand.new
+      foo.execute
+    end
+
+    assert_equal "pew pew!\n", out
+    assert_match(/NOTE: foo command is deprecated. It will be removed on or after 2099-04-01.\n/, err)
+  end
+
 end


### PR DESCRIPTION
# Description:

This PR adds a `deprecate_command` method to deprecate RubyGems commands.

### Example
```ruby            
class Gem::Commands::QueryCommand
  extend Gem::Deprecate

  deprecate_command(2019, 12)

  def execute
    gem_names = Array(options[:name])

    if !args.empty?
      gem_names = options[:exact] ? args.map{|arg| /\A#{Regexp.escape(arg)}\Z/ } : args.map{|arg| /#{arg}/i }
    end

    terminate_interaction(check_installed_gems(gem_names)) if check_installed_gems?

    gem_names.each { |n| show_gems(n) }
  end
 ...
end
```

```shell
$ gem query
ebsocket-driver (0.7.1, 0.7.0, 0.6.5)
websocket-extensions (0.1.4, 0.1.3)
will_paginate (3.0.12)
xml-simple (1.1.5)
xmlrpc (0.3.0)
xpath (3.2.0, 2.1.0)
yajl-ruby (1.4.1)
yard (0.9.20, 0.8.7.6)
yell (2.2.0)
zeitwerk (2.1.10, 2.1.9, 2.1.8, 2.1.6, 2.1.2)
zlib (default: 1.0.0)

NOTE: query command is deprecated. It will be removed on or after 2019-12-01.
```

______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
