### PR TITLE
Add Gem::Dependency identity

### DIFF
--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -334,4 +334,18 @@ class Gem::Dependency
     matches.first
   end
 
+  def identity
+    if prerelease?
+      if specific?
+        :complete
+      else
+        :abs_latest
+      end
+    elsif latest_version?
+      :latest
+    else
+      :released
+    end
+  end
+
 end

--- a/lib/rubygems/spec_fetcher.rb
+++ b/lib/rubygems/spec_fetcher.rb
@@ -88,19 +88,8 @@ class Gem::SpecFetcher
 
     rejected_specs = {}
 
-    if dependency.prerelease?
-      if dependency.specific?
-        type = :complete
-      else
-        type = :abs_latest
-      end
-    elsif dependency.latest_version?
-      type = :latest
-    else
-      type = :released
-    end
+    list, errors = available_specs(dependency.identity)
 
-    list, errors = available_specs(type)
     list.each do |source, specs|
       if dependency.name.is_a?(String) && specs.respond_to?(:bsearch)
         start_index = (0 ... specs.length).bsearch{ |i| specs[i].name >= dependency.name }

--- a/test/rubygems/test_gem_dependency.rb
+++ b/test/rubygems/test_gem_dependency.rb
@@ -385,4 +385,11 @@ class TestGemDependency < Gem::TestCase
     assert_match "Could not find 'b' (= 2.0) among 1 total gem(s)", e.message
   end
 
+  def test_identity
+    assert_equal dep("a", "= 1").identity, :released
+    assert_equal dep("a", "= 1.a").identity, :complete
+    assert_equal dep("a", " >= 1.a").identity, :abs_latest
+    assert_equal dep("a").identity, :latest
+  end
+
 end


### PR DESCRIPTION
# Description:

Move `Gem::Dependency` logic from `Gem::SpecFetcher` to it's own method in `Gem::Dependency`

______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
