### PR TITLE
Gem::Specification#to_ruby needs OpenSSL

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2423,6 +2423,7 @@ class Gem::Specification < Gem::BasicSpecification
   # still have their default values are omitted.
 
   def to_ruby
+    require 'openssl'
     mark_version
     result = []
     result << "# -*- encoding: utf-8 -*-"


### PR DESCRIPTION
# Description:

Since b1d825ab3a25a12e2602c13555b22809c93bc12e, lib/rubygems/specification.rb should require openssl.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
