### PR TITLE
Don't set `bin_dir` twice.

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -196,8 +196,6 @@ class Gem::Installer
     @package.prog_mode = options[:prog_mode]
     @package.data_mode = options[:data_mode]
 
-    @bin_dir = options[:bin_dir] if options[:bin_dir]
-
     if options[:user_install]
       @gem_home = Gem.user_dir
       @bin_dir = Gem.bindir gem_home unless options[:bin_dir]


### PR DESCRIPTION
Since PR #2361, the `@bin_dir` is set in `Gem::Installer#initialize` [[1]], while it was already properly set via preceding `process_options` call [[2]].


[1]: https://github.com/rubygems/rubygems/blob/6b2b09ac0ddf41c0824e1244aaa9c8120c3081c4/lib/rubygems/installer.rb#L199
[2]: https://github.com/rubygems/rubygems/blob/6b2b09ac0ddf41c0824e1244aaa9c8120c3081c4/lib/rubygems/installer.rb#L697