### PR TITLE
Remove taint usage on Ruby 2.7+

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -116,6 +116,11 @@ require 'rubygems/path_support'
 module Gem
   RUBYGEMS_DIR = File.dirname File.expand_path(__FILE__)
 
+  # Taint support is deprecated in Ruby 2.7.
+  # This allows switching ".untaint" to ".tap(&Gem::UNTAINT)",
+  # to avoid deprecation warnings in Ruby 2.7.
+  UNTAINT = RUBY_VERSION < '2.7' ? :untaint.to_sym : proc{}
+
   ##
   # An Array of Regexps that match windows Ruby platforms.
 
@@ -521,7 +526,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     glob_with_suffixes = "#{glob}#{Gem.suffix_pattern}"
     $LOAD_PATH.map do |load_path|
       Gem::Util.glob_files_in_dir(glob_with_suffixes, load_path)
-    end.flatten.select { |file| File.file? file.untaint }
+    end.flatten.select { |file| File.file? file.tap(&Gem::UNTAINT) }
   end
 
   ##
@@ -1083,7 +1088,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   # The home directory for the user.
 
   def self.user_home
-    @user_home ||= find_home.untaint
+    @user_home ||= find_home.tap(&Gem::UNTAINT)
   end
 
   ##
@@ -1150,7 +1155,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
       globbed = Gem::Util.glob_files_in_dir(glob, load_path)
 
       globbed.each do |load_path_file|
-        files << load_path_file if File.file?(load_path_file.untaint)
+        files << load_path_file if File.file?(load_path_file.tap(&Gem::UNTAINT))
       end
     end
 
@@ -1196,7 +1201,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
       end
     end
 
-    path.untaint
+    path.tap(&Gem::UNTAINT)
 
     unless File.file? path
       return unless raise_exception

--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -98,7 +98,7 @@ class Gem::BasicSpecification
   # Returns full path to the directory where gem's extensions are installed.
 
   def extension_dir
-    @extension_dir ||= File.expand_path(File.join(extensions_dir, full_name)).untaint
+    @extension_dir ||= File.expand_path(File.join(extensions_dir, full_name)).tap(&Gem::UNTAINT)
   end
 
   ##
@@ -113,7 +113,7 @@ class Gem::BasicSpecification
   def find_full_gem_path # :nodoc:
     # TODO: also, shouldn't it default to full_name if it hasn't been written?
     path = File.expand_path File.join(gems_dir, full_name)
-    path.untaint
+    path.tap(&Gem::UNTAINT)
     path
   end
 
@@ -135,9 +135,9 @@ class Gem::BasicSpecification
 
   def full_name
     if platform == Gem::Platform::RUBY or platform.nil?
-      "#{name}-#{version}".dup.untaint
+      "#{name}-#{version}".dup.tap(&Gem::UNTAINT)
     else
-      "#{name}-#{version}-#{platform}".dup.untaint
+      "#{name}-#{version}-#{platform}".dup.tap(&Gem::UNTAINT)
     end
   end
 
@@ -149,7 +149,7 @@ class Gem::BasicSpecification
     @full_require_paths ||=
     begin
       full_paths = raw_require_paths.map do |path|
-        File.join full_gem_path, path.untaint
+        File.join full_gem_path, path.tap(&Gem::UNTAINT)
       end
 
       full_paths << extension_dir if have_extensions?
@@ -163,7 +163,7 @@ class Gem::BasicSpecification
 
   def datadir
     # TODO: drop the extra ", gem_name" which is uselessly redundant
-    File.expand_path(File.join(gems_dir, full_name, "data", name)).untaint
+    File.expand_path(File.join(gems_dir, full_name, "data", name)).tap(&Gem::UNTAINT)
   end
 
   ##
@@ -277,7 +277,7 @@ class Gem::BasicSpecification
     # TODO: do we need these?? Kill it
     glob = File.join(self.lib_dirs_glob, glob)
 
-    Dir[glob].map { |f| f.untaint } # FIX our tests are broken, run w/ SAFE=1
+    Dir[glob].map { |f| f.tap(&Gem::UNTAINT) } # FIX our tests are broken, run w/ SAFE=1
   end
 
   ##
@@ -295,7 +295,7 @@ class Gem::BasicSpecification
              "lib" # default value for require_paths for bundler/inline
            end
 
-    "#{self.full_gem_path}/#{dirs}".dup.untaint
+    "#{self.full_gem_path}/#{dirs}".dup.tap(&Gem::UNTAINT)
   end
 
   ##
@@ -328,7 +328,7 @@ class Gem::BasicSpecification
 
   def have_file?(file, suffixes)
     return true if raw_require_paths.any? do |path|
-      base = File.join(gems_dir, full_name, path.untaint, file).untaint
+      base = File.join(gems_dir, full_name, path.tap(&Gem::UNTAINT), file).tap(&Gem::UNTAINT)
       suffixes.any? { |suf| File.file? base + suf }
     end
 

--- a/lib/rubygems/bundler_version_finder.rb
+++ b/lib/rubygems/bundler_version_finder.rb
@@ -83,7 +83,7 @@ To install the missing version, run `gem install bundler:#{vr.first}`
     gemfile = ENV["BUNDLE_GEMFILE"]
     gemfile = nil if gemfile && gemfile.empty?
     Gem::Util.traverse_parents Dir.pwd do |directory|
-      next unless gemfile = Gem::GEM_DEP_FILES.find { |f| File.file?(f.untaint) }
+      next unless gemfile = Gem::GEM_DEP_FILES.find { |f| File.file?(f.tap(&Gem::UNTAINT)) }
 
       gemfile = File.join directory, gemfile
       break
@@ -94,7 +94,7 @@ To install the missing version, run `gem install bundler:#{vr.first}`
     lockfile = case gemfile
                when "gems.rb" then "gems.locked"
                else "#{gemfile}.lock"
-               end.dup.untaint
+               end.dup.tap(&Gem::UNTAINT)
 
     return unless File.file?(lockfile)
 

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -180,7 +180,7 @@ class Gem::ConfigFile
     operating_system_config = Marshal.load Marshal.dump(OPERATING_SYSTEM_DEFAULTS)
     platform_config = Marshal.load Marshal.dump(PLATFORM_DEFAULTS)
     system_config = load_file SYSTEM_WIDE_CONFIG_FILE
-    user_config = load_file config_file_name.dup.untaint
+    user_config = load_file config_file_name.dup.tap(&Gem::UNTAINT)
 
     environment_config = (ENV['GEMRC'] || '')
       .split(File::PATH_SEPARATOR).inject({}) do |result, file|

--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -41,7 +41,7 @@ module Kernel
     resolved_path = begin
       rp = nil
       $LOAD_PATH[0...Gem.load_path_insert_index || -1].each do |lp|
-        safe_lp = lp.dup.untaint
+        safe_lp = lp.dup.tap(&Gem::UNTAINT)
         next if File.symlink? safe_lp # for backword compatibility
         Gem.suffixes.each do |s|
           full_path = File.expand_path(File.join(safe_lp, "#{path}#{s}"))

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -392,7 +392,7 @@ class Gem::Installer
       specs = []
 
       Gem::Util.glob_files_in_dir("*.gemspec", File.join(gem_home, "specifications")).each do |path|
-        spec = Gem::Specification.load path.untaint
+        spec = Gem::Specification.load path.tap(&Gem::UNTAINT)
         specs << spec if spec
       end
 
@@ -500,7 +500,7 @@ class Gem::Installer
     raise Gem::FilePermissionError.new(@bin_dir) unless File.writable? @bin_dir
 
     spec.executables.each do |filename|
-      filename.untaint
+      filename.tap(&Gem::UNTAINT)
       bin_path = File.join gem_dir, spec.bindir, filename
 
       unless File.exist? bin_path
@@ -631,7 +631,7 @@ class Gem::Installer
 
   def ensure_loadable_spec
     ruby = spec.to_ruby_for_cache
-    ruby.untaint
+    ruby.tap(&Gem::UNTAINT)
 
     begin
       eval ruby

--- a/lib/rubygems/name_tuple.rb
+++ b/lib/rubygems/name_tuple.rb
@@ -55,7 +55,7 @@ class Gem::NameTuple
       "#{@name}-#{@version}"
     else
       "#{@name}-#{@version}-#{@platform}"
-    end.dup.untaint
+    end.dup.tap(&Gem::UNTAINT)
   end
 
   ##

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -498,7 +498,7 @@ EOM
         real_destination.start_with? destination_dir + '/'
     end
 
-    destination.untaint
+    destination.tap(&Gem::UNTAINT)
     destination
   end
 

--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -36,7 +36,7 @@ class Gem::PathSupport
 
     @spec_cache_dir = env["GEM_SPEC_CACHE"] || Gem.default_spec_cache_dir
 
-    @spec_cache_dir = @spec_cache_dir.dup.untaint
+    @spec_cache_dir = @spec_cache_dir.dup.tap(&Gem::UNTAINT)
   end
 
   private

--- a/lib/rubygems/request_set.rb
+++ b/lib/rubygems/request_set.rb
@@ -334,7 +334,7 @@ class Gem::RequestSet
 
     @git_set.root_dir = @install_dir
 
-    lock_file = "#{File.expand_path(path)}.lock".dup.untaint
+    lock_file = "#{File.expand_path(path)}.lock".dup.tap(&Gem::UNTAINT)
     begin
       tokenizer = Gem::RequestSet::Lockfile::Tokenizer.from_file lock_file
       parser = tokenizer.make_parser self, []

--- a/lib/rubygems/request_set/gem_dependency_api.rb
+++ b/lib/rubygems/request_set/gem_dependency_api.rb
@@ -280,7 +280,7 @@ class Gem::RequestSet::GemDependencyAPI
   # Loads the gem dependency file and returns self.
 
   def load
-    instance_eval File.read(@path).untaint, @path, 1
+    instance_eval File.read(@path).tap(&Gem::UNTAINT), @path, 1
 
     self
   end

--- a/lib/rubygems/request_set/lockfile.rb
+++ b/lib/rubygems/request_set/lockfile.rb
@@ -79,7 +79,9 @@ class Gem::RequestSet::Lockfile
     @gem_deps_file = File.expand_path(gem_deps_file)
     @gem_deps_dir  = File.dirname(@gem_deps_file)
 
-    @gem_deps_file.untaint unless gem_deps_file.tainted?
+    if RUBY_VERSION < '2.7'
+      @gem_deps_file.untaint unless gem_deps_file.tainted?
+    end
 
     @platforms = []
   end

--- a/lib/rubygems/source.rb
+++ b/lib/rubygems/source.rb
@@ -106,7 +106,7 @@ class Gem::Source
   def cache_dir(uri)
     # Correct for windows paths
     escaped_path = uri.path.sub(/^\/([a-z]):\//i, '/\\1-/')
-    escaped_path.untaint
+    escaped_path.tap(&Gem::UNTAINT)
 
     File.join Gem.spec_cache_dir, "#{uri.host}%#{uri.port}", File.dirname(escaped_path)
   end

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -763,7 +763,7 @@ class Gem::Specification < Gem::BasicSpecification
   def self.each_gemspec(dirs) # :nodoc:
     dirs.each do |dir|
       Gem::Util.glob_files_in_dir("*.gemspec", dir).each do |path|
-        yield path.untaint
+        yield path.tap(&Gem::UNTAINT)
       end
     end
   end
@@ -930,7 +930,7 @@ class Gem::Specification < Gem::BasicSpecification
 
   def self.dirs
     @@dirs ||= Gem.path.collect do |dir|
-      File.join dir.dup.untaint, "specifications"
+      File.join dir.dup.tap(&Gem::UNTAINT), "specifications"
     end
   end
 
@@ -1112,12 +1112,12 @@ class Gem::Specification < Gem::BasicSpecification
     _spec = LOAD_CACHE_MUTEX.synchronize { LOAD_CACHE[file] }
     return _spec if _spec
 
-    file = file.dup.untaint
+    file = file.dup.tap(&Gem::UNTAINT)
     return unless File.file?(file)
 
     code = File.read file, :mode => 'r:UTF-8:-'
 
-    code.untaint
+    code.tap(&Gem::UNTAINT)
 
     begin
       _spec = eval code, binding, file
@@ -2642,9 +2642,9 @@ class Gem::Specification < Gem::BasicSpecification
       case ivar
       when "date"
         # Force Date to go through the extra coerce logic in date=
-        self.date = val.untaint
+        self.date = val.tap(&Gem::UNTAINT)
       else
-        instance_variable_set "@#{ivar}", val.untaint
+        instance_variable_set "@#{ivar}", val.tap(&Gem::UNTAINT)
       end
     end
 

--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -71,7 +71,7 @@ class Gem::StubSpecification < Gem::BasicSpecification
 
   def initialize(filename, base_dir, gems_dir, default_gem)
     super()
-    filename.untaint
+    filename.tap(&Gem::UNTAINT)
 
     self.loaded_from = filename
     @data            = nil

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -259,10 +259,10 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
     Gem::DefaultUserInteraction.ui = Gem::MockGemUi.new
 
     tmpdir = File.realpath Dir.tmpdir
-    tmpdir.untaint
+    tmpdir.tap(&Gem::UNTAINT)
 
     @tempdir = File.join(tmpdir, "test_rubygems_#{$$}")
-    @tempdir.untaint
+    @tempdir.tap(&Gem::UNTAINT)
 
     FileUtils.mkdir_p @tempdir
 
@@ -274,7 +274,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
     # Short and long path name is specific to Windows filesystem.
     if win_platform?
       @tempdir = Dir[@tempdir][0]
-      @tempdir.untaint
+      @tempdir.tap(&Gem::UNTAINT)
     end
 
     @gemhome  = File.join @tempdir, 'gemhome'
@@ -295,7 +295,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
     $LOAD_PATH.map! do |s|
       expand_path = File.realpath(s) rescue File.expand_path(s)
       if expand_path != s
-        expand_path.untaint
+        expand_path.tap(&Gem::UNTAINT)
         if s.instance_variable_defined?(:@gem_prelude_index)
           expand_path.instance_variable_set(:@gem_prelude_index, expand_path)
         end
@@ -527,7 +527,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
         end
       end
 
-      gem = File.join(@tempdir, File.basename(spec.cache_file)).untaint
+      gem = File.join(@tempdir, File.basename(spec.cache_file)).tap(&Gem::UNTAINT)
     end
 
     Gem::Installer.at(gem, options.merge({:wrappers => true})).install
@@ -566,7 +566,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
   # Reads a Marshal file at +path+
 
   def read_cache(path)
-    File.open path.dup.untaint, 'rb' do |io|
+    File.open path.dup.tap(&Gem::UNTAINT), 'rb' do |io|
       Marshal.load io.read
     end
   end

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -10,14 +10,14 @@ require 'rbconfig'
 # TODO: push this up to test_case.rb once battle tested
 
 $LOAD_PATH.map! do |path|
-  path.dup.untaint
+  path.dup.tap(&Gem::UNTAINT)
 end
 
 class TestGem < Gem::TestCase
 
   PLUGINS_LOADED = [] # rubocop:disable Style/MutableConstant
 
-  PROJECT_DIR = File.expand_path('../../..', __FILE__).untaint
+  PROJECT_DIR = File.expand_path('../../..', __FILE__).tap(&Gem::UNTAINT)
 
   def setup
     super
@@ -216,7 +216,7 @@ class TestGem < Gem::TestCase
     end
     assert_equal(expected, result)
   ensure
-    File.chmod(0755, *Dir.glob(@gemhome + '/gems/**/').map {|path| path.untaint})
+    File.chmod(0755, *Dir.glob(@gemhome + '/gems/**/').map {|path| path.tap(&Gem::UNTAINT)})
   end
 
   def test_require_missing
@@ -1613,8 +1613,8 @@ class TestGem < Gem::TestCase
     assert_equal expected_specs, Gem.use_gemdeps.sort_by { |s| s.name }
   end
 
-  LIB_PATH = File.expand_path "../../../lib".dup.untaint, __FILE__.dup.untaint
-  BUNDLER_LIB_PATH = File.expand_path $LOAD_PATH.find {|lp| File.file?(File.join(lp, "bundler.rb")) }.dup.untaint
+  LIB_PATH = File.expand_path "../../../lib".dup.tap(&Gem::UNTAINT), __FILE__.dup.tap(&Gem::UNTAINT)
+  BUNDLER_LIB_PATH = File.expand_path $LOAD_PATH.find {|lp| File.file?(File.join(lp, "bundler.rb")) }.dup.tap(&Gem::UNTAINT)
   BUNDLER_FULL_NAME = "bundler-#{Bundler::VERSION}".freeze
 
   def add_bundler_full_name(names)
@@ -1641,8 +1641,8 @@ class TestGem < Gem::TestCase
     ENV['RUBYGEMS_GEMDEPS'] = "-"
 
     path = File.join @tempdir, "gem.deps.rb"
-    cmd = [Gem.ruby.dup.untaint, "-I#{LIB_PATH.untaint}",
-           "-I#{BUNDLER_LIB_PATH.untaint}", "-rrubygems"]
+    cmd = [Gem.ruby.dup.tap(&Gem::UNTAINT), "-I#{LIB_PATH.tap(&Gem::UNTAINT)}",
+           "-I#{BUNDLER_LIB_PATH.tap(&Gem::UNTAINT)}", "-rrubygems"]
     cmd << "-eputs Gem.loaded_specs.values.map(&:full_name).sort"
 
     File.open path, "w" do |f|
@@ -1679,8 +1679,8 @@ class TestGem < Gem::TestCase
     Dir.mkdir "sub1"
 
     path = File.join @tempdir, "gem.deps.rb"
-    cmd = [Gem.ruby.dup.untaint, "-Csub1", "-I#{LIB_PATH.untaint}",
-           "-I#{BUNDLER_LIB_PATH.untaint}", "-rrubygems"]
+    cmd = [Gem.ruby.dup.tap(&Gem::UNTAINT), "-Csub1", "-I#{LIB_PATH.tap(&Gem::UNTAINT)}",
+           "-I#{BUNDLER_LIB_PATH.tap(&Gem::UNTAINT)}", "-rrubygems"]
     cmd << "-eputs Gem.loaded_specs.values.map(&:full_name).sort"
 
     File.open path, "w" do |f|
@@ -1728,7 +1728,7 @@ class TestGem < Gem::TestCase
   end
 
   def test_use_gemdeps
-    gem_deps_file = 'gem.deps.rb'.untaint
+    gem_deps_file = 'gem.deps.rb'.tap(&Gem::UNTAINT)
     spec = util_spec 'a', 1
     install_specs spec
 

--- a/test/rubygems/test_gem_command_manager.rb
+++ b/test/rubygems/test_gem_command_manager.rb
@@ -4,7 +4,7 @@ require 'rubygems/command_manager'
 
 class TestGemCommandManager < Gem::TestCase
 
-  PROJECT_DIR = File.expand_path('../../..', __FILE__).untaint
+  PROJECT_DIR = File.expand_path('../../..', __FILE__).tap(&Gem::UNTAINT)
 
   def setup
     super

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -703,12 +703,12 @@ class TestGemPackage < Gem::Package::TarTestCase
     package = Gem::Package.new @gem
 
     file = 'file.rb'.dup
-    file.taint
+    file.taint if RUBY_VERSION < '2.7'
 
     destination = package.install_location file, @destination
 
     assert_equal File.join(@destination, 'file.rb'), destination
-    refute destination.tainted?
+    refute destination.tainted? if RUBY_VERSION < '2.7'
   end
 
   def test_install_location_absolute
@@ -742,14 +742,14 @@ class TestGemPackage < Gem::Package::TarTestCase
     package = Gem::Package.new @gem
 
     file = 'foo//file.rb'.dup
-    file.taint
+    file.taint if RUBY_VERSION < '2.7'
 
     destination = @destination.sub '/', '//'
 
     destination = package.install_location file, destination
 
     assert_equal File.join(@destination, 'foo', 'file.rb'), destination
-    refute destination.tainted?
+    refute destination.tainted? if RUBY_VERSION < '2.7'
   end
 
   def test_install_location_relative

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -939,22 +939,24 @@ dependencies: []
     assert_equal File.join(@tempdir, 'a-2.gemspec'), spec.loaded_from
   end
 
-  def test_self_load_tainted
-    full_path = @a2.spec_file
-    write_file full_path do |io|
-      io.write @a2.to_ruby_for_cache
+  if RUBY_VERSION < '2.7'
+    def test_self_load_tainted
+      full_path = @a2.spec_file
+      write_file full_path do |io|
+        io.write @a2.to_ruby_for_cache
+      end
+
+      full_path.taint
+      loader = Thread.new { $SAFE = 1; Gem::Specification.load full_path }
+      spec = loader.value
+
+      @a2.files.clear
+
+      assert_equal @a2, spec
+
+    ensure
+      $SAFE = 0
     end
-
-    full_path.taint
-    loader = Thread.new { $SAFE = 1; Gem::Specification.load full_path }
-    spec = loader.value
-
-    @a2.files.clear
-
-    assert_equal @a2, spec
-
-  ensure
-    $SAFE = 0
   end
 
   def test_self_load_escape_curly


### PR DESCRIPTION
# Description:

Ruby 2.7 deprecates taint and it no longer has an effect.
This attempts to leave the behavior the same on older
Ruby versions, but avoid the use of deprecated methods
related to taint on Ruby 2.7+.

See https://bugs.ruby-lang.org/issues/16131 for details.

# Tasks:

- [X] Describe the problem / feature
- [X] Update tests
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
