### PR TITLE
Add `--all` flag to gem outdated

### DIFF
--- a/lib/rubygems/commands/outdated_command.rb
+++ b/lib/rubygems/commands/outdated_command.rb
@@ -26,7 +26,7 @@ update the gems with the update or install commands.
   end
 
   def execute
-    Gem::Specification.outdated_and_latest_version.each do |spec, remote_version|
+    Gem::Specification.outdated_and_latest_version do |spec, remote_version|
       say "#{spec.name} (#{spec.version} < #{remote_version})"
     end
   end

--- a/lib/rubygems/commands/outdated_command.rb
+++ b/lib/rubygems/commands/outdated_command.rb
@@ -14,6 +14,11 @@ class Gem::Commands::OutdatedCommand < Gem::Command
 
     add_local_remote_options
     add_platform_option
+
+    add_option('all', '--all',
+               'List all newer versions of each outdated gem') do |value, options|
+      options[:all_outdated] = value
+    end
   end
 
   def description # :nodoc:

--- a/lib/rubygems/commands/outdated_command.rb
+++ b/lib/rubygems/commands/outdated_command.rb
@@ -17,7 +17,7 @@ class Gem::Commands::OutdatedCommand < Gem::Command
 
     add_option('all', '--all',
                'List all newer versions of each outdated gem') do |value, options|
-      options[:all_outdated] = value
+      options[:all_newest] = value
     end
   end
 
@@ -31,7 +31,7 @@ update the gems with the update or install commands.
   end
 
   def execute
-    Gem::Specification.outdated_and_latest_version(options[:all_outdated]) do |spec, remote_versions|
+    Gem::Specification.outdated_and_latest_version(options[:all_newest]) do |spec, remote_versions|
       say "#{spec.name} (#{spec.version} < #{[remote_versions].flatten.join(", ")})"
     end
   end

--- a/lib/rubygems/commands/outdated_command.rb
+++ b/lib/rubygems/commands/outdated_command.rb
@@ -31,8 +31,8 @@ update the gems with the update or install commands.
   end
 
   def execute
-    Gem::Specification.outdated_and_latest_version do |spec, remote_version|
-      say "#{spec.name} (#{spec.version} < #{remote_version})"
+    Gem::Specification.outdated_and_latest_version(options[:all_outdated]) do |spec, remote_versions|
+      say "#{spec.name} (#{spec.version} < #{[remote_versions].flatten.join(", ")})"
     end
   end
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1202,8 +1202,6 @@ class Gem::Specification < Gem::BasicSpecification
       yield [local_spec, latest_remote] if
         latest_remote and local_spec.version < latest_remote
     end
-
-    nil
   end
 
   ##

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1200,6 +1200,8 @@ class Gem::Specification < Gem::BasicSpecification
       latest_remote = remotes.sort.last
 
       if show_all_versions
+        remotes.delete(local_spec.version)
+        next if remotes.empty?
         yield [local_spec, remotes]
       else
         if latest_remote && local_spec.version < latest_remote

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1184,7 +1184,7 @@ class Gem::Specification < Gem::BasicSpecification
   # This method may take some time to return as it must check each local gem
   # against the server's index.
 
-  def self.outdated_and_latest_version
+  def self.outdated_and_latest_version(show_all_versions=false)
     return enum_for __method__ unless block_given?
 
     # TODO: maybe we should switch to rubygems' version service?
@@ -1199,8 +1199,14 @@ class Gem::Specification < Gem::BasicSpecification
 
       latest_remote = remotes.sort.last
 
-      yield [local_spec, latest_remote] if
-        latest_remote and local_spec.version < latest_remote
+      if show_all_versions
+        yield [local_spec, remotes]
+      else
+        if latest_remote && local_spec.version < latest_remote
+          yield [local_spec, latest_remote]
+        end
+      end
+
     end
   end
 

--- a/test/rubygems/test_gem_commands_outdated_command.rb
+++ b/test/rubygems/test_gem_commands_outdated_command.rb
@@ -38,7 +38,7 @@ class TestGemCommandsOutdatedCommand < Gem::TestCase
       fetcher.gem 'foo', '0.2'
     end
 
-    @cmd.options[:all_outdated] = true
+    @cmd.options[:all_newest] = true
     use_ui @ui do
       @cmd.execute
     end

--- a/test/rubygems/test_gem_commands_outdated_command.rb
+++ b/test/rubygems/test_gem_commands_outdated_command.rb
@@ -30,4 +30,21 @@ class TestGemCommandsOutdatedCommand < Gem::TestCase
     assert_equal "", @ui.error
   end
 
+  def test_execute_all
+    spec_fetcher do |fetcher|
+      fetcher.download 'foo', '1.0'
+      fetcher.download 'foo', '2.0'
+      fetcher.gem 'foo', '0.1'
+      fetcher.gem 'foo', '0.2'
+    end
+
+    @cmd.options[:all_outdated] = true
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    assert_equal "foo (0.2 < 1.0, 2.0)\n", @ui.output
+    assert_equal "", @ui.error
+  end
+
 end


### PR DESCRIPTION
# Description:

Closes https://github.com/rubygems/rubygems/issues/2900

Add `--all` flag to show all the newer versions of a current installed gem when executing `gem outdated`
______________


I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
