### PR TITLE
Update windows.yml - GIT, DevKit, cmd -> ps

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,8 +15,13 @@ jobs:
         uses: actions/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+      - name: DevKit, ENV['PATH']
+        uses: MSP-Greg/msys2-action@master
       - name: Install Dependencies
-        run: gem install "rake:>=10.4.2" "minitest:>=5.4.3" --conservative --no-document
+        run: gem --% install "rake:>=12.0.0" "minitest:>=5.10.1" --conservative --no-document
       - name: Run Test
-        run: rake test
+        run: |
+          New-Item -Path "C:\git" -ItemType Junction -Value "C:\Program Files\Git" 1> $null
+          $env:GIT = "C:\git\cmd\git.exe"
+          rake test
     timeout-minutes: 15


### PR DESCRIPTION
# Description:

1. GitHub Actions changed the Windows default script engine on Actions from cmd to ps. Updated.

2. Add action to adjust path for DevKit and removal of other builds tools, which cause conflicts.

3. I use `git` commands daily in Ruby code.  But, the test suite has always required a git path without a space.  I think this was previously on Appveyor.

4. 2 & 3 from above cause test skips to decrease from 67 to 30. 

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
