### PR TITLE
Update Actions windows.yml - GIT, DevKit, cmd -> ps

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,7 +16,13 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: Install Dependencies
-        run: gem --% install "rake:>=10.4.2" "minitest:>=5.4.3" --conservative --no-document
+        # updated to match gems in oldest Actions Ruby version, currently 2.4
+        run: gem --% install "rake:>=12.0.0" "minitest:>=5.10.1" --conservative --no-document
       - name: Run Test
-        run: rake test
+        # create a symlink for git to a folder without a space, needed for CI only
+        run: |
+          New-Item -Path "C:\git" -ItemType Junction -Value "C:\Program Files\Git" 1> $null
+          $env:GIT = "C:\git\cmd\git.exe"
+          ridk enable
+          rake test
     timeout-minutes: 15


### PR DESCRIPTION
# Description:

1. GitHub Actions changed the Windows default script engine on Actions from cmd to ps. Updated.

2. I use `git` commands daily in Ruby code.  But, the test suite has always required a git path without a space.  I think this was previously in the Appveyor script.  This, along with adding DevKit, lowers the skip count from 67 to 30.

Currently, no updates to DevKit/MSYS2 are done.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
