### PR TITLE
Set deprecation warning on query command

### DIFF
--- a/lib/rubygems/commands/query_command.rb
+++ b/lib/rubygems/commands/query_command.rb
@@ -4,8 +4,12 @@ require 'rubygems/local_remote_options'
 require 'rubygems/spec_fetcher'
 require 'rubygems/version_option'
 require 'rubygems/text'
+require 'rubygems/deprecate'
 
 class Gem::Commands::QueryCommand < Gem::Command
+
+  extend Gem::Deprecate
+  deprecate_command(2019, 12)
 
   include Gem::Text
   include Gem::LocalRemoteOptions

--- a/test/rubygems/test_gem_commands_query_command.rb
+++ b/test/rubygems/test_gem_commands_query_command.rb
@@ -844,6 +844,10 @@ othergem (1.2.3)
     assert_equal expected, @stub_ui.output
   end
 
+  def test_depprecated
+    assert @cmd.deprecated?
+  end
+
   private
 
   def add_gems_to_fetcher


### PR DESCRIPTION
# Description:
We have been discouraging user for the use of the query command for a long time.
```
Summary:
    Query gem information in local or remote repositories

  Description:
    The query command is the basis for the list and search commands.

    You should really use the list and search commands instead.  This command
    is too hard to use.
```

 It's time to deprecate it.

This will setup a deprecation warning whenever is used.

______________
I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
