### PR TITLE
Properly test `Gem::Specifications.stub_for`

### DIFF
--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1162,12 +1162,11 @@ dependencies: []
     # Create gemspecs in three locations used in stubs
     loaded_spec = Gem::Specification.new 'a', '3'
     Gem.loaded_specs['a'] = loaded_spec
-    save_gemspec 'a', '2', dir_default_specs
-    save_gemspec 'a', '1', dir_standard_specs
+    save_gemspec('a-2', '2', dir_default_specs) { |s| s.name = 'a' }
+    save_gemspec('a-1', '1', dir_standard_specs) { |s| s.name = 'a' }
 
     full_names = ['a-3', 'a-2', 'a-1']
 
-    full_names = Gem::Specification.stubs_for('a').map { |s| s.full_name }
     assert_equal full_names, Gem::Specification.stubs_for('a').map { |s| s.full_name }
     assert_equal 1, Gem::Specification.class_variable_get(:@@stubs_by_name).length
 


### PR DESCRIPTION
I extracted this change from #2711, to try increase the chance of getting a review by making smaller PRs. This is the exact same original commit by @voxik, I only changed the commit message to explain both changes being made.

# Description:

This test was faulty, because the assert condition was initialized by the same content as later used by the assertion.

After fixing the assertion, we also get another problem where `save_gemspec` is saving gemspecs with naming `foo.gemspec`, but `stubs_for` looks for the `foo-1.0.gemspec` pattern. Include a workaround for this issue as well.

Fixes #2827.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
