### PR TITLE
Make sure our local rubygems loads before `rake`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ task :git_hooks do
 end
 
 Rake::TestTask.new do |t|
-  t.ruby_opts = %w[--disable-gems -w]
+  t.ruby_opts = %w[--disable-gems -w -rrubygems]
   t.ruby_opts << '-rdevkit' if Gem.win_platform?
 
   t.libs << "test"


### PR DESCRIPTION
# Description:

Without this early require, the rake test loader will load first, and then require our copy of `rubygems`.

The rake test loader will in turn load the default `fileutils` version, but since we haven't yet required `rubygems`, our `Kernel.require` monkeypatches have not yet been loaded and the version of `fileutils` being required will not be activated as a gem.

That will cause a bunch of redefinition warnings if you have a higher version of `fileutils` installed on your system, such as:

```
/home/deivid/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/fileutils-1.3.0/lib/fileutils/version.rb:5: warning: already initialized constant FileUtils::VERSION
/home/deivid/.rbenv/versions/2.6.5/lib/ruby/2.6.0/fileutils/version.rb:5: warning: previous definition of VERSION was here
/home/deivid/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/fileutils-1.3.0/lib/fileutils.rb:108: warning: method redefined; discarding old private_module_function
/home/deivid/.rbenv/versions/2.6.5/lib/ruby/2.6.0/fileutils.rb:98: warning: previous definition of private_module_function was here
/home/deivid/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/fileutils-1.3.0/lib/fileutils.rb:1170: warning: method redefined; discarding old fu_windows?
/home/deivid/.rbenv/versions/2.6.5/lib/ruby/2.6.0/fileutils.rb:1152: warning: previous definition of fu_windows? was here
/home/deivid/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/fileutils-1.3.0/lib/fileutils.rb:1173: warning: method redefined; discarding old fu_copy_stream0
/home/deivid/.rbenv/versions/2.6.5/lib/ruby/2.6.0/fileutils.rb:1155: warning: previous definition of fu_copy_stream0 was here
/home/deivid/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/fileutils-1.3.0/lib/fileutils.rb:1177: warning: method redefined; discarding old fu_stream_blksize
/home/deivid/.rbenv/versions/2.6.5/lib/ruby/2.6.0/fileutils.rb:1159: warning: previous definition of fu_stream_blksize was here
/home/deivid/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/fileutils-1.3.0/lib/fileutils.rb:1186: warning: method redefined; discarding old fu_blksize
/home/deivid/.rbenv/versions/2.6.5/lib/ruby/2.6.0/fileutils.rb:1168: warning: previous definition of fu_blksize was here
```

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
