### PR TITLE
Correct conflict list when uninstallation is prevented

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1752,10 +1752,11 @@ class Gem::Specification < Gem::BasicSpecification
   #
   #   [depending_gem, dependency, [list_of_gems_that_satisfy_dependency]]
 
-  def dependent_gems
+  def dependent_gems(check_dev=true)
     out = []
     Gem::Specification.each do |spec|
-      spec.dependencies.each do |dep|
+      deps = check_dev ? spec.dependencies : spec.runtime_dependencies
+      deps.each do |dep|
         if self.satisfies_requirement?(dep)
           sats = []
           find_all_satisfiers(dep) do |sat|

--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -317,7 +317,7 @@ class Gem::Uninstaller
       s.name == spec.name && s.full_name != spec.full_name
     end
 
-    spec.dependent_gems.each do |dep_spec, dep, satlist|
+    spec.dependent_gems(@check_dev).each do |dep_spec, dep, satlist|
       unless siblings.any? { |s| s.satisfies_requirement? dep }
         msg << "#{dep_spec.name}-#{dep_spec.version} depends on #{dep}"
       end

--- a/test/rubygems/test_gem_uninstaller.rb
+++ b/test/rubygems/test_gem_uninstaller.rb
@@ -524,6 +524,35 @@ create_makefile '#{@spec.name}'
     assert_match %r!Successfully uninstalled q-1!, lines.last
   end
 
+  def test_uninstall_prompt_only_lists_the_dependents_that_prevented_uninstallation
+    quick_gem 'r', '1' do |s|
+      s.add_development_dependency 'q', '= 1'
+    end
+
+    quick_gem 's', '1' do |s|
+      s.add_dependency 'q', '= 1'
+    end
+
+    quick_gem 'q', '1'
+
+    un = Gem::Uninstaller.new('q', :check_dev => false)
+    ui = Gem::MockGemUi.new("y\n")
+
+    use_ui ui do
+      un.uninstall
+    end
+
+    lines = ui.output.split("\n")
+    lines.shift
+
+    assert_match %r!You have requested to uninstall the gem:!, lines.shift
+    lines.shift
+    lines.shift
+
+    assert_match %r!s-1 depends on q \(= 1\)!, lines.shift
+    assert_match %r!Successfully uninstalled q-1!, lines.last
+  end
+
   def test_uninstall_no_permission
     uninstaller = Gem::Uninstaller.new @spec.name, :executables => true
 


### PR DESCRIPTION
# Description:

The default rubygems behavior is to prompt for confirmation if there are any gems in the user's system that have the target gem as a _runtime_ dependency. However, when listing all the conflicts that led to prompting the user, gems having the target gem as a _development_
dependency are also listed.

That behavior is a bug, and this commit fixes it. Those gems should only be listed if I explicitly pass the `--check-development` flag.

For example, this is what I currently get if I try to uninstall `rake` from my system:

```
 $ gem uninstall rake

You have requested to uninstall the gem:
	rake-13.0.0

apparition-0.4.0 depends on rake (>= 0, development)
arel-9.0.0 depends on rake (>= 0, development)
capybara-3.29.0 depends on rake (>= 0, development)
cmath-1.0.0 depends on rake (>= 0, development)
coffee-script-2.4.1 depends on rake (>= 0, development)
csv-3.1.2 depends on rake (>= 0, development)
csv-3.0.9 depends on rake (>= 0, development)
cucumber-3.1.2 depends on rake (>= 0.9.2, development)
cucumber-core-3.2.1 depends on rake (>= 0.9.2, development)
cucumber-rails-1.8.0 depends on rake (>= 12.0, development)
cucumber-wire-0.0.1 depends on rake (>= 0.9.2, development)
database_cleaner-1.7.0 depends on rake (>= 0, development)
did_you_mean-1.3.1 depends on rake (>= 0, development)
did_you_mean-1.3.0 depends on rake (>= 0, development)
draper-3.1.0 depends on rake (>= 0, development)
etc-1.0.1 depends on rake (>= 0, development)
execjs-2.7.0 depends on rake (>= 0, development)
fiddle-1.0.0 depends on rake (>= 0, development)
fileutils-1.1.0 depends on rake (>= 0, development)
forwardable-1.2.0 depends on rake (>= 0, development)
globalid-0.4.2 depends on rake (>= 0, development)
has_scope-0.7.2 depends on rake (>= 0, development)
highline-2.0.3 depends on rake (>= 0, development)
highline-2.0.2 depends on rake (>= 0, development)
i18n-tasks-0.9.29 depends on rake (>= 0, development)
irb-1.0.0 depends on rake (>= 0, development)
jasmine-2.99.0 depends on rake (>= 0)
jasmine-2.9.0 depends on rake (>= 0)
jasmine-core-2.99.2 depends on rake (>= 0, development)
jasmine-core-2.9.1 depends on rake (>= 0, development)
jekyll-coffeescript-1.1.1 depends on rake (>= 0, development)
jekyll-commonmark-ghpages-0.1.5 depends on rake (>= 0, development)
jekyll-gist-1.5.0 depends on rake (>= 0, development)
jekyll-github-metadata-2.9.4 depends on rake (>= 0, development)
jekyll-paginate-1.1.0 depends on rake (>= 0, development)
jekyll-sass-converter-1.5.2 depends on rake (>= 0, development)
jekyll-sitemap-1.2.0 depends on rake (>= 0, development)
jekyll-watch-2.0.0 depends on rake (>= 0, development)
json-2.2.0 depends on rake (>= 0, development)
json-2.1.0 depends on rake (>= 0, development)
kaminari-1.1.1 depends on rake (>= 0, development)
kaminari-actionview-1.1.1 depends on rake (>= 10.0, development)
kaminari-activerecord-1.1.1 depends on rake (>= 10.0, development)
kaminari-core-1.1.1 depends on rake (>= 10.0, development)
loofah-2.2.3 depends on rake (>= 0.8, development)
mail-2.7.1 depends on rake (> 0.8.7, development)
matrix-0.1.0 depends on rake (>= 0, development)
mdl-0.7.0 depends on rake (>= 11.2, < 14, development)
mercenary-0.3.6 depends on rake (>= 0, development)
mimemagic-0.3.3 depends on rake (>= 0, development)
mocha-1.9.0 depends on rake (>= 0, development)
multipart-post-2.1.1 depends on rake (>= 0, development)
mutex_m-0.1.0 depends on rake (>= 0, development)
net-telnet-0.2.0 depends on rake (>= 0, development)
nio4r-2.5.2 depends on rake (>= 0, development)
nio4r-2.5.1 depends on rake (>= 0, development)
nio4r-2.4.0 depends on rake (>= 0, development)
openssl-2.1.2 depends on rake (>= 0, development)
orm_adapter-0.5.0 depends on rake (>= 0.8.7, development)
ostruct-0.1.0 depends on rake (>= 0, development)
phantomjs-2.1.1.0 depends on rake (>= 0, development)
power_assert-1.1.3 depends on rake (>= 0, development)
powerpack-0.1.2 depends on rake (>= 0, development)
prime-0.1.0 depends on rake (>= 0, development)
public_suffix-4.0.1 depends on rake (>= 0, development)
public_suffix-3.1.1 depends on rake (>= 0, development)
public_suffix-3.0.3 depends on rake (>= 0, development)
public_suffix-2.0.5 depends on rake (>= 0, development)
pundit-2.1.0 depends on rake (>= 0, development)
rack-2.0.7 depends on rake (>= 0, development)
rails-dom-testing-2.0.3 depends on rake (>= 0, development)
rails-html-sanitizer-1.3.0 depends on rake (>= 0, development)
rails-html-sanitizer-1.2.0 depends on rake (>= 0, development)
railties-6.0.0 depends on rake (>= 0.8.7)
railties-5.2.3 depends on rake (>= 0.8.7)
rake-compiler-1.0.8 depends on rake (>= 0)
rdoc-6.1.2 depends on rake (>= 0, development)
rexml-3.2.3 depends on rake (>= 0, development)
rexml-3.1.9 depends on rake (>= 0, development)
rss-0.2.8 depends on rake (>= 0, development)
rss-0.2.7 depends on rake (>= 0, development)
rubocop-rspec-1.36.0 depends on rake (>= 0, development)
rubocop-rspec-1.35.0 depends on rake (>= 0, development)
sassc-2.2.1 depends on rake (>= 0, development)
shell-0.7 depends on rake (>= 0, development)
simplecov-0.17.1 depends on rake (>= 0, development)
sprockets-es6-0.9.2 depends on rake (>= 0, development)
sprockets-rails-3.2.1 depends on rake (>= 0, development)
sync-0.5.0 depends on rake (>= 0, development)
test-unit-3.2.9 depends on rake (>= 0, development)
tracer-0.1.0 depends on rake (>= 0, development)
webrick-1.5.0 depends on rake (>= 0, development)
webrick-1.4.2 depends on rake (>= 0, development)
xmlrpc-0.3.0 depends on rake (>= 0, development)
xpath-3.2.0 depends on rake (>= 0, development)
zlib-1.0.0 depends on rake (>= 0, development)
If you remove this gem, these dependencies will not be met.
Continue with Uninstall? [yN]  
```

This is what I get after this PR:

```shell
$ gem uninstall rake

You have requested to uninstall the gem:
	rake-13.0.0

jasmine-2.99.0 depends on rake (>= 0)
jasmine-2.9.0 depends on rake (>= 0)
railties-6.0.0 depends on rake (>= 0.8.7)
railties-5.2.3 depends on rake (>= 0.8.7)
rake-compiler-1.0.8 depends on rake (>= 0)
If you remove this gem, these dependencies will not be met.
Continue with Uninstall? [yN]  
```
# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
