### PR TITLE
Simplify deprecate command method

### DIFF
--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -444,6 +444,10 @@ class Gem::Command
     result
   end
 
+  def deprecated?
+    false
+  end
+
   private
 
   def option_is_deprecated?(option)

--- a/lib/rubygems/command_manager.rb
+++ b/lib/rubygems/command_manager.rb
@@ -176,6 +176,7 @@ class Gem::CommandManager
       cmd_name = args.shift.downcase
       cmd = find_command cmd_name
       cmd.invoke_with_build_args args, build_args
+      cmd.deprecation_warning if cmd.deprecated?
     end
   end
 

--- a/test/rubygems/test_deprecate.rb
+++ b/test/rubygems/test_deprecate.rb
@@ -95,13 +95,13 @@ class TestDeprecate < Gem::TestCase
   end
 
   def test_deprecate_command
+    foo = FooCommand.new
+
     out, err = capture_io do
-      foo = FooCommand.new
       foo.execute
     end
 
-    assert_equal "pew pew!\n", out
-    assert_match(/NOTE: foo command is deprecated. It will be removed on or after 2099-04-01.\n/, err)
+    assert foo.deprecated?
   end
 
 end

--- a/test/rubygems/test_deprecate.rb
+++ b/test/rubygems/test_deprecate.rb
@@ -77,31 +77,22 @@ class TestDeprecate < Gem::TestCase
     assert_match(/on or after 2099-03-01/, err)
   end
 
-  require 'rubygems/command'
-  class FooCommand < Gem::Command
-
-    extend Gem::Deprecate
-
-    deprecate_command(2099, 4)
-
-    def initialize
-      super("foo", "foo command does pew pew")
-    end
-
-    def execute
-      puts "pew pew!"
-    end
-
-  end
-
   def test_deprecate_command
-    foo = FooCommand.new
+    require 'rubygems/command'
+    foo_command = Class.new(Gem::Command) do
+      extend Gem::Deprecate
 
-    out, err = capture_io do
-      foo.execute
+      deprecate_command(2099, 4)
+
+      def execute
+        puts "pew pew!"
+      end
     end
 
-    assert foo.deprecated?
+    Gem::Commands.send(:const_set, :FooCommand, foo_command)
+    assert Gem::Commands::FooCommand.new("foo").deprecated?
+  ensure
+    Gem::Commands.send(:remove_const, :FooCommand)
   end
 
 end


### PR DESCRIPTION
# Description:
 
Simplify `Gem::Deprecate#deprecate_command` that was introduced here https://github.com/rubygems/rubygems/pull/2935
______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
