### PR TITLE
Analyze staged files except deleted files for rubocop pre-commit-hook

### DIFF
--- a/.githooks/pre-commit-rubocop
+++ b/.githooks/pre-commit-rubocop
@@ -1,3 +1,11 @@
 #!/usr/bin/env bash
 
-./util/rubocop $(git diff --cached --name-only)
+files=$(git diff --name-only --cached --diff-filter=d)
+length=${#files}
+
+# Run rubocop hook only when analyzable files are present
+if [[ $length -ne 0 ]]; then
+  ./util/rubocop $files
+else
+  echo "No files to analyze"
+fi


### PR DESCRIPTION
# Description:
Currently if we try to delete ruby file and commit, the rubcop-precommit-hook fails as it will not be able to find the file.
This patch excludes deleted files with git diff-filter.

```
❱ git status
On branch update_rubocop_precommit_hook
Changes to be committed:
  (use "git reset HEAD <file>..." to unstage)

	deleted:    lib/rubygems/request.rb
```
Before:
```
❱ git commit
Running pre-commit hooks...
  > pre-commit-rubocop
Inspecting 1 file


0 files inspected, no offenses detected
Error: No such file or directory: /home/akshay/rubygems/lib/rubygems/request.rb
```

## After:
```
❱ git commit
Running pre-commit hooks...
  > pre-commit-rubocop
No files to analyze
```

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
