### PR TITLE
Drop macos ruby 2.3.x job on Github Actions

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,6 +1,5 @@
 status = [
   "ubuntu_lint",
-  "macos (2.3.x)",
   "ubuntu (2.3.x, rubygems)",
   "ubuntu (2.3.x, bundler)",
   "macos (2.4.x)",

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        ruby: [ '2.3.x', '2.4.x', '2.5.x', '2.6.x' ]
+        ruby: [ '2.4.x', '2.5.x', '2.6.x' ]
     steps:
       - uses: actions/checkout@master
       - run: git submodule update -i


### PR DESCRIPTION
# Description:

Similarly to the Windows base image, it seems to have dropped support
for ruby 2.3

See failures at #2979.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
