### PR TITLE
Bump tested jruby to 9.2.9.0

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -17,7 +17,7 @@ status = [
   "ubuntu_bundler_master (2.6.x)",
   "ruby_master",
   "ubuntu_rvm (ruby-head, bundler)",
-  "ubuntu_rvm (jruby-9.2.8.0, rubygems)",
+  "ubuntu_rvm (jruby-9.2.9.0, rubygems)",
 ]
 
 timeout-sec = 14400

--- a/.github/workflows/ubuntu-rvm.yml
+++ b/.github/workflows/ubuntu-rvm.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ 'ruby-head', 'jruby-9.2.8.0' ]
+        ruby: [ 'ruby-head', 'jruby-9.2.9.0' ]
         test_tool: [ "rubygems", "bundler" ]
         include:
           - ruby: ruby-head
@@ -17,7 +17,7 @@ jobs:
         exclude:
           - ruby: ruby-head
             test_tool: rubygems
-          - ruby: jruby-9.2.8.0
+          - ruby: jruby-9.2.9.0
             test_tool: bundler
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
# Description:
Last master CI build failed on jruby with an unclear error:

```
/home/runner/.rvm/rubies/jruby-9.2.8.0/lib/ruby/stdlib/jars/installer.rb:48: warning: Ambiguous first argument; make sure.
jar-dependencies: No such file or directory - /tmp/test_rubygems_7382/default/gems/default-2
jar-dependencies: No such file or directory - /tmp/test_rubygems_7382/default/gems/default-2.0.0.0
Bad file descriptor - No message available
rake aborted!
Command failed with status (1)

Tasks: TOP => test
(See full trace by running task with --trace)
.........................................................................................................................S...S...........................................................S...........S..........................................................S..S.....S...........S..............S..............S...............................................................................................................................................................S.....................................
##[error]Process completed with exit code 1.
```

See https://github.com/rubygems/rubygems/runs/294753712.

Just trying out the latest version to see if this is something that's no longer an issue there.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
