### PR TITLE
Fix Gem::LOADED_SPECS_MUTEX handling for recursive locking

### DIFF
--- a/lib/rubygems/core_ext/kernel_gem.rb
+++ b/lib/rubygems/core_ext/kernel_gem.rb
@@ -61,9 +61,13 @@ module Kernel
 
     spec = dep.to_spec
 
-    Gem::LOADED_SPECS_MUTEX.synchronize do
-      spec.activate
-    end if spec
+    if spec
+      if Gem::LOADED_SPECS_MUTEX.owned?
+        spec.activate
+      else
+        Gem::LOADED_SPECS_MUTEX.synchronize { spec.activate }
+      end
+    end
   end
 
   private :gem


### PR DESCRIPTION
# Description:

See:

https://bugs.ruby-lang.org/issues/16337

RubyGems https://github.com/rubygems/rubygems/commit/bb082f7043e7e7c35799c0fe9d765f59e032be63

Tested several ways locally, cannot test against JRuby.

What is or is not a default gem should not depend on whether it's used here...

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
