### PR TITLE
Remove configuration that contained a typo

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,7 +23,6 @@ Rake::TestTask.new do |t|
   t.ruby_opts = %w[-w]
   t.ruby_opts << '-rdevkit' if Gem.win_platform?
 
-  t.libs << "libs"
   t.libs << "test"
   t.libs << "bundler/lib"
 


### PR DESCRIPTION
# Description:

A small follow up to #2981. This configuration must not be necessary since a folder named like that doesn't exist.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
