### PR TITLE
Deprecate `gem generate_index --modern` and `gem generate_index --no-modern`

### DIFF
--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -397,9 +397,9 @@ class Gem::Command
         version_to_expire = @deprecated_options[command][option]["rg_version_to_expire"]
 
         deprecate_option_msg = if version_to_expire
-                                 "The \"#{option}\" option has been deprecated and will be removed in Rubygems #{version_to_expire}, its use is discouraged."
+                                 "The \"#{option}\" option has been deprecated and will be removed in Rubygems #{version_to_expire}."
                                else
-                                 "The \"#{option}\" option has been deprecated and will be removed in future versions of Rubygems, its use is discouraged."
+                                 "The \"#{option}\" option has been deprecated and will be removed in future versions of Rubygems."
                                end
 
         alert_warning(deprecate_option_msg)

--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -387,20 +387,25 @@ class Gem::Command
   #   deprecate_option('--test')
   #   deprecate_option('--no-test')
 
-  def deprecate_option(name, version: nil)
-    @deprecated_options[command].merge!({ name => { "rg_version_to_expire" => version } })
+  def deprecate_option(name, version: nil, extra_msg: nil)
+    @deprecated_options[command].merge!({ name => { "rg_version_to_expire" => version, "extra_msg" => extra_msg } })
   end
 
   def check_deprecated_options(options)
     options.each do |option|
       if option_is_deprecated?(option)
-        version_to_expire = @deprecated_options[command][option]["rg_version_to_expire"]
+        deprecation = @deprecated_options[command][option]
+        version_to_expire = deprecation["rg_version_to_expire"]
 
         deprecate_option_msg = if version_to_expire
                                  "The \"#{option}\" option has been deprecated and will be removed in Rubygems #{version_to_expire}."
                                else
                                  "The \"#{option}\" option has been deprecated and will be removed in future versions of Rubygems."
                                end
+
+        extra_msg = deprecation["extra_msg"]
+
+        deprecate_option_msg += " #{extra_msg}" if extra_msg
 
         alert_warning(deprecate_option_msg)
       end

--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -369,6 +369,24 @@ class Gem::Command
     end
   end
 
+  ##
+  # Mark a command-line option as deprecated, and optionally specify a
+  # deprecation horizon.
+  #
+  # Note that with the current implementation, every version of the option needs
+  # to be explicitly deprecated, so to deprecate an option defined as
+  #
+  #   add_option('-t', '--[no-]test', 'Set test mode') do |value, options|
+  #     # ... stuff ...
+  #   end
+  #
+  # you would need to explicitly add a call to `deprecate_option` for every
+  # version of the option you want to deprecate, like
+  #
+  #   deprecate_option('-t')
+  #   deprecate_option('--test')
+  #   deprecate_option('--no-test')
+
   def deprecate_option(name, version: nil)
     @deprecated_options[command].merge!({ name => { "rg_version_to_expire" => version } })
   end

--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -369,9 +369,8 @@ class Gem::Command
     end
   end
 
-  def deprecate_option(short_name: nil, long_name: nil, version: nil)
-    @deprecated_options[command].merge!({ short_name => { "rg_version_to_expire" => version } }) if short_name
-    @deprecated_options[command].merge!({ long_name  => { "rg_version_to_expire" => version } }) if long_name
+  def deprecate_option(name, version: nil)
+    @deprecated_options[command].merge!({ name => { "rg_version_to_expire" => version } })
   end
 
   def check_deprecated_options(options)

--- a/lib/rubygems/commands/generate_index_command.rb
+++ b/lib/rubygems/commands/generate_index_command.rb
@@ -25,6 +25,9 @@ class Gem::Commands::GenerateIndexCommand < Gem::Command
       options[:build_modern] = value
     end
 
+    deprecate_option('--modern', version: '4.0', extra_msg: 'Modern indexes (specs, latest_specs, and prerelease_specs) are always generated, so this option is not needed.')
+    deprecate_option('--no-modern', version: '4.0', extra_msg: 'The `--no-modern` option is currently ignored. Modern indexes (specs, latest_specs, and prerelease_specs) are always generated.')
+
     add_option '--update',
                'Update modern indexes with gems added',
                'since the last update' do |value, options|

--- a/test/rubygems/test_gem_command.rb
+++ b/test/rubygems/test_gem_command.rb
@@ -197,7 +197,7 @@ class TestGemCommand < Gem::TestCase
     assert_equal ['-h', 'command'], args
   end
 
-  def test_deprecate_option_long_name
+  def test_deprecate_option
     deprecate_msg = <<-EXPECTED
 WARNING:  The \"--test\" option has been deprecated and will be removed in Rubygems 3.1, its use is discouraged.
     EXPECTED
@@ -210,7 +210,7 @@ WARNING:  The \"--test\" option has been deprecated and will be removed in Rubyg
           options[:test] = true
         end
 
-        deprecate_option(long_name: '--test', version: '3.1')
+        deprecate_option('--test', version: '3.1')
       end
 
       def execute
@@ -239,7 +239,7 @@ WARNING:  The \"--test\" option has been deprecated and will be removed in futur
           options[:test] = true
         end
 
-        deprecate_option(long_name: '--test')
+        deprecate_option('--test')
       end
 
       def execute
@@ -251,35 +251,6 @@ WARNING:  The \"--test\" option has been deprecated and will be removed in futur
 
     use_ui @ui do
       cmd.invoke("--test")
-      assert_equal deprecate_msg, @ui.error
-    end
-  end
-
-  def test_deprecate_option_short_name
-    deprecate_msg = <<-EXPECTED
-WARNING:  The \"-t\" option has been deprecated and will be removed in Rubygems 3.5, its use is discouraged.
-    EXPECTED
-
-    testCommand = Class.new(Gem::Command) do
-      def initialize
-        super('test', 'Gem::Command instance for testing')
-
-        add_option('-t', '--test', 'Test command') do |value, options|
-          options[:test] = true
-        end
-
-        deprecate_option(short_name: '-t', version: '3.5')
-      end
-
-      def execute
-        true
-      end
-    end
-
-    cmd = testCommand.new
-
-    use_ui @ui do
-      cmd.invoke("-t")
       assert_equal deprecate_msg, @ui.error
     end
   end

--- a/test/rubygems/test_gem_command.rb
+++ b/test/rubygems/test_gem_command.rb
@@ -199,7 +199,7 @@ class TestGemCommand < Gem::TestCase
 
   def test_deprecate_option
     deprecate_msg = <<-EXPECTED
-WARNING:  The \"--test\" option has been deprecated and will be removed in Rubygems 3.1, its use is discouraged.
+WARNING:  The \"--test\" option has been deprecated and will be removed in Rubygems 3.1.
     EXPECTED
 
     testCommand = Class.new(Gem::Command) do
@@ -228,7 +228,7 @@ WARNING:  The \"--test\" option has been deprecated and will be removed in Rubyg
 
   def test_deprecate_option_no_version
     deprecate_msg = <<-EXPECTED
-WARNING:  The \"--test\" option has been deprecated and will be removed in future versions of Rubygems, its use is discouraged.
+WARNING:  The \"--test\" option has been deprecated and will be removed in future versions of Rubygems.
     EXPECTED
 
     testCommand = Class.new(Gem::Command) do
@@ -240,6 +240,64 @@ WARNING:  The \"--test\" option has been deprecated and will be removed in futur
         end
 
         deprecate_option('--test')
+      end
+
+      def execute
+        true
+      end
+    end
+
+    cmd = testCommand.new
+
+    use_ui @ui do
+      cmd.invoke("--test")
+      assert_equal deprecate_msg, @ui.error
+    end
+  end
+
+  def test_deprecate_option_extra_message
+    deprecate_msg = <<-EXPECTED
+WARNING:  The \"--test\" option has been deprecated and will be removed in Rubygems 3.1. Whether you set `--test` mode or not, this dummy app always runs in test mode.
+    EXPECTED
+
+    testCommand = Class.new(Gem::Command) do
+      def initialize
+        super('test', 'Gem::Command instance for testing')
+
+        add_option('-t', '--test', 'Test command') do |value, options|
+          options[:test] = true
+        end
+
+        deprecate_option('--test', version: '3.1', extra_msg: 'Whether you set `--test` mode or not, this dummy app always runs in test mode.')
+      end
+
+      def execute
+        true
+      end
+    end
+
+    cmd = testCommand.new
+
+    use_ui @ui do
+      cmd.invoke("--test")
+      assert_equal deprecate_msg, @ui.error
+    end
+  end
+
+  def test_deprecate_option_extra_message_and_no_version
+    deprecate_msg = <<-EXPECTED
+WARNING:  The \"--test\" option has been deprecated and will be removed in future versions of Rubygems. Whether you set `--test` mode or not, this dummy app always runs in test mode.
+    EXPECTED
+
+    testCommand = Class.new(Gem::Command) do
+      def initialize
+        super('test', 'Gem::Command instance for testing')
+
+        add_option('-t', '--test', 'Test command') do |value, options|
+          options[:test] = true
+        end
+
+        deprecate_option('--test', extra_msg: 'Whether you set `--test` mode or not, this dummy app always runs in test mode.')
       end
 
       def execute

--- a/test/rubygems/test_gem_commands_generate_index_command.rb
+++ b/test/rubygems/test_gem_commands_generate_index_command.rb
@@ -3,6 +3,10 @@ require 'rubygems/test_case'
 require 'rubygems/indexer'
 require 'rubygems/commands/generate_index_command'
 
+unless defined?(Builder::XChar)
+  warn "generate_index tests are being skipped.  Install builder gem."
+end
+
 class TestGemCommandsGenerateIndexCommand < Gem::TestCase
 
   def setup
@@ -47,4 +51,4 @@ class TestGemCommandsGenerateIndexCommand < Gem::TestCase
     assert @cmd.options[:update]
   end
 
-end if ''.respond_to? :to_xs
+end if defined?(Builder::XChar)

--- a/test/rubygems/test_gem_commands_generate_index_command.rb
+++ b/test/rubygems/test_gem_commands_generate_index_command.rb
@@ -26,6 +26,18 @@ class TestGemCommandsGenerateIndexCommand < Gem::TestCase
     assert File.exist?(specs), specs
   end
 
+  def test_execute_no_modern
+    @cmd.options[:modern] = false
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    specs = File.join @gemhome, "specs.4.8.gz"
+
+    assert File.exist?(specs), specs
+  end
+
   def test_handle_options_directory
     return if win_platform?
     refute_equal '/nonexistent', @cmd.options[:directory]
@@ -49,6 +61,26 @@ class TestGemCommandsGenerateIndexCommand < Gem::TestCase
     @cmd.handle_options %w[--update]
 
     assert @cmd.options[:update]
+  end
+
+  def test_handle_options_modern
+    use_ui @ui do
+      @cmd.handle_options %w[--modern]
+    end
+
+    assert_equal \
+      "WARNING:  The \"--modern\" option has been deprecated and will be removed in Rubygems 4.0. Modern indexes (specs, latest_specs, and prerelease_specs) are always generated, so this option is not needed.\n",
+      @ui.error
+  end
+
+  def test_handle_options_no_modern
+    use_ui @ui do
+      @cmd.handle_options %w[--no-modern]
+    end
+
+    assert_equal \
+      "WARNING:  The \"--no-modern\" option has been deprecated and will be removed in Rubygems 4.0. The `--no-modern` option is currently ignored. Modern indexes (specs, latest_specs, and prerelease_specs) are always generated.\n",
+      @ui.error
   end
 
 end if defined?(Builder::XChar)

--- a/test/rubygems/test_gem_indexer.rb
+++ b/test/rubygems/test_gem_indexer.rb
@@ -3,7 +3,7 @@ require 'rubygems/test_case'
 require 'rubygems/indexer'
 
 unless defined?(Builder::XChar)
-  warn "Gem::Indexer tests are being skipped.  Install builder gem." if $VERBOSE
+  warn "Gem::Indexer tests are being skipped.  Install builder gem."
 end
 
 class TestGemIndexer < Gem::TestCase


### PR DESCRIPTION
# Description:

In https://github.com/rubygems/rubygems/pull/2607 we added an API to deprecate option switches to rubygems commands. The original motivation was to prevent abrupt removals like we did for `--no-ri` and `--no-rdoc`, but since the removal of those options was not reverted, we never started using `deprecate_option`.

This PR officially deprecates `gem generate_index --modern` and `gem generate_index --no-modern`, that have been "noops" for a long time, since rubygems generates only "modern" indexes.

While implementing this, I noticed that the previous definition of `deprecate_option` was overly complicated, and also that it could use the possibility of an extra message to further explain each deprecation. So I removed the unnecessary options, and added the extra feature.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
