### PR TITLE
Check for rubygems.org typo squatting sources

### DIFF
--- a/lib/rubygems/commands/sources_command.rb
+++ b/lib/rubygems/commands/sources_command.rb
@@ -43,6 +43,8 @@ class Gem::Commands::SourcesCommand < Gem::Command
 
     source = Gem::Source.new source_uri
 
+    check_typo_squatting(source)
+
     begin
       if Gem.sources.include? source
         say "source #{source_uri} already present in the cache"
@@ -59,6 +61,18 @@ class Gem::Commands::SourcesCommand < Gem::Command
     rescue Gem::RemoteFetcher::FetchError => e
       say "Error fetching #{source_uri}:\n\t#{e.message}"
       terminate_interaction 1
+    end
+  end
+
+  def check_typo_squatting(source)
+    if source.typo_squatting?("rubygems.org")
+      question = <<-QUESTION.chomp
+#{source.uri.to_s} is too similar to https://rubygems.org
+
+Do you want to add this source?
+      QUESTION
+
+      terminate_interaction 1 unless ask_yes_no question
     end
   end
 

--- a/lib/rubygems/source.rb
+++ b/lib/rubygems/source.rb
@@ -222,6 +222,7 @@ class Gem::Source
   end
 
   def typo_squatting?(host, distance_threshold=4)
+    return if @uri.host.nil?
     levenshtein_distance(@uri.host, host) <= distance_threshold
   end
 

--- a/lib/rubygems/source.rb
+++ b/lib/rubygems/source.rb
@@ -2,6 +2,7 @@
 autoload :FileUtils, 'fileutils'
 autoload :URI, 'uri'
 
+require "rubygems/text"
 ##
 # A Source knows how to list and fetch gems from a RubyGems marshal index.
 #
@@ -11,6 +12,7 @@ autoload :URI, 'uri'
 class Gem::Source
 
   include Comparable
+  include Gem::Text
 
   FILES = { # :nodoc:
     :released   => 'specs',
@@ -217,6 +219,10 @@ class Gem::Source
         q.text api.to_s
       end
     end
+  end
+
+  def typo_squatting?(host, distance_threshold=4)
+    levenshtein_distance(@uri.host, host) <= distance_threshold
   end
 
 end

--- a/test/rubygems/test_gem_source.rb
+++ b/test/rubygems/test_gem_source.rb
@@ -235,4 +235,18 @@ class TestGemSource < Gem::TestCase
     refute @source.update_cache?
   end
 
+  def test_typo_squatting
+    rubygems_source = Gem::Source.new("https://rubgems.org")
+    assert rubygems_source.typo_squatting?("rubygems.org")
+    assert rubygems_source.typo_squatting?("rubyagems.org")
+    assert rubygems_source.typo_squatting?("rubyasgems.org")
+    refute rubygems_source.typo_squatting?("rubysertgems.org")
+  end
+
+  def test_typo_squatting_custom_distance_threshold
+    rubygems_source = Gem::Source.new("https://rubgems.org")
+    distance_threshold = 5
+    assert rubygems_source.typo_squatting?("rubysertgems.org", distance_threshold)
+  end
+
 end


### PR DESCRIPTION
# Description:
closes https://github.com/rubygems/rubygems/issues/2952

Check for`rubygems.org` typo squatting sources before adding them

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
