### PR TITLE
Allow ruby-head + bundler master failures

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -16,8 +16,8 @@ status = [
   "windows (2.6.x)",
   "ubuntu_bundler_master (2.6.x)",
   "ruby_master",
-  "ubuntu_rvm (ruby-head, bundler)",
-  "ubuntu_rvm (jruby-9.2.9.0, rubygems)",
+  "ubuntu_rvm (ruby-head)",
+  "ubuntu_rvm (jruby-9.2.9.0)",
 ]
 
 timeout-sec = 14400

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,12 @@
 name: macos
 
-on: [push]
+on:
+  pull_request:
+
+  push:
+    branches:
+      - staging
+      - trying
 
 jobs:
   macos:

--- a/.github/workflows/ruby-master.yml
+++ b/.github/workflows/ruby-master.yml
@@ -1,6 +1,12 @@
 name: ruby-master
 
-on: [push]
+on:
+  pull_request:
+
+  push:
+    branches:
+      - staging
+      - trying
 
 jobs:
   ruby_master:

--- a/.github/workflows/ubuntu-bundler-master.yml
+++ b/.github/workflows/ubuntu-bundler-master.yml
@@ -1,6 +1,12 @@
 name: ubuntu-bundler-master
 
-on: [push]
+on:
+  pull_request:
+
+  push:
+    branches:
+      - staging
+      - trying
 
 jobs:
   ubuntu_bundler_master:

--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -1,6 +1,12 @@
 name: ubuntu-lint
 
-on: [push]
+on:
+  pull_request:
+
+  push:
+    branches:
+      - staging
+      - trying
 
 jobs:
   ubuntu_lint:

--- a/.github/workflows/ubuntu-rvm.yml
+++ b/.github/workflows/ubuntu-rvm.yml
@@ -8,16 +8,6 @@ jobs:
     strategy:
       matrix:
         ruby: [ 'ruby-head', 'jruby-9.2.9.0' ]
-        test_tool: [ "rubygems", "bundler" ]
-        include:
-          - ruby: ruby-head
-            test_tool: bundler
-            bdv: master
-        exclude:
-          - ruby: ruby-head
-            test_tool: rubygems
-          - ruby: jruby-9.2.9.0
-            test_tool: bundler
     steps:
       - uses: actions/checkout@master
       - run: git submodule update -i
@@ -34,17 +24,20 @@ jobs:
           source $HOME/.rvm/scripts/rvm
           rvm install ${{ matrix.ruby }} --binary
           rvm --default use ${{ matrix.ruby }}
-      - name: Install dependencies
+      - name: Test rubygems
         run: |
           source $HOME/.rvm/scripts/rvm
           util/ci.sh before_script
-        env:
-          TEST_TOOL: ${{ matrix.test_tool }}
-          BDV: ${{ matrix.bdv }}
-      - name: Run test
-        run: |
-          source $HOME/.rvm/scripts/rvm
           util/ci.sh script
         env:
-          TEST_TOOL: ${{ matrix.test_tool }}
+          TEST_TOOL: rubygems
+        if: matrix.ruby == 'jruby-9.2.9.0'
+      - name: Test bundler
+        run: |
+          source $HOME/.rvm/scripts/rvm
+          BDV=master util/ci.sh before_script
+          util/ci.sh script
+        env:
+          TEST_TOOL: bundler
+        if: matrix.ruby == 'ruby-head'
     timeout-minutes: 60

--- a/.github/workflows/ubuntu-rvm.yml
+++ b/.github/workflows/ubuntu-rvm.yml
@@ -37,6 +37,7 @@ jobs:
           source $HOME/.rvm/scripts/rvm
           BDV=master util/ci.sh before_script
           util/ci.sh script
+        continue-on-error: true
         env:
           TEST_TOOL: bundler
         if: matrix.ruby == 'ruby-head'

--- a/.github/workflows/ubuntu-rvm.yml
+++ b/.github/workflows/ubuntu-rvm.yml
@@ -1,6 +1,12 @@
 name: ubuntu-rvm
 
-on: [push]
+on:
+  pull_request:
+
+  push:
+    branches:
+      - staging
+      - trying
 
 jobs:
   ubuntu_rvm:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,6 +1,12 @@
 name: ubuntu
 
-on: [push]
+on:
+  pull_request:
+
+  push:
+    branches:
+      - staging
+      - trying
 
 jobs:
   ubuntu:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,12 @@
 name: windows
 
-on: [push]
+on:
+  pull_request:
+
+  push:
+    branches:
+      - staging
+      - trying
 
 jobs:
   windows:


### PR DESCRIPTION
# Description:

Currently the ruby-head + bundler's master build is failing. While I fix it, I'm going to allow failures to not block other PRs.

Actually, this is the way it was setup on TravisCI. On our initial setup of Github Actions, the `continue-on-error` setting was there, but affected all jobs in this workflow, including the `jruby` + `rubygems` entry, which was not an allowed failure on TravisCI.

So, while we might want to revisit this, this setup should exactly match what we had on TravisCI.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
