### PR TITLE
Lazily load `open3`

### DIFF
--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -6,7 +6,6 @@
 #++
 
 require 'rubygems/user_interaction'
-require "open3"
 
 class Gem::Ext::Builder
 
@@ -68,6 +67,7 @@ class Gem::Ext::Builder
       results << "current directory: #{Dir.pwd}"
       results << (command.respond_to?(:shelljoin) ? command.shelljoin : command)
 
+      require "open3"
       output, status = Open3.capture2e(*command)
       if verbose
         puts output


### PR DESCRIPTION
# Description:

Since open3 will be gemified in ruby 2.7, it's better to load it as late as possible to avoid version conflicts with user chosen versions.

This should get us closer to a green CI against ruby-head.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
