### PR TITLE
Remove `delegate` dependency

### DIFF
--- a/lib/rubygems/core_ext/kernel_warn.rb
+++ b/lib/rubygems/core_ext/kernel_warn.rb
@@ -12,7 +12,13 @@ if RUBY_VERSION >= "2.5"
 
     original_warn = method(:warn)
 
-    module_function define_method(:warn) {|*messages, **kw|
+    class << self
+
+      remove_method :warn
+
+    end
+
+    define_method(:warn) do |*messages, **kw|
       unless uplevel = kw[:uplevel]
         if Gem.java_platform?
           return original_warn.call(*messages)
@@ -46,6 +52,6 @@ if RUBY_VERSION >= "2.5"
 
       kw[:uplevel] = uplevel
       original_warn.call(*messages, **kw)
-    }
+    end
   end
 end

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -26,6 +26,7 @@ class Gem::SpecificationPolicy < SimpleDelegator
     @warnings = 0
 
     super(specification)
+    @specification = specification
   end
 
   ##
@@ -51,7 +52,7 @@ class Gem::SpecificationPolicy < SimpleDelegator
 
     validate_require_paths
 
-    keep_only_files_and_directories
+    @specification.keep_only_files_and_directories
 
     validate_non_files
 
@@ -92,6 +93,8 @@ class Gem::SpecificationPolicy < SimpleDelegator
   # Implementation for Specification#validate_metadata
 
   def validate_metadata
+    metadata = @specification.metadata
+
     unless Hash === metadata
       error 'metadata must be a hash'
     end
@@ -130,7 +133,7 @@ class Gem::SpecificationPolicy < SimpleDelegator
 
     error_messages = []
     warning_messages = []
-    dependencies.each do |dep|
+    @specification.dependencies.each do |dep|
       if prev = seen[dep.type][dep.name]
         error_messages << <<-MESSAGE
 duplicate dependency on #{dep}, (#{prev.requirement}) use:
@@ -145,7 +148,7 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
       end
 
       warning_messages << "prerelease dependency on #{dep} is not recommended" if
-          prerelease_dep && !version.prerelease?
+          prerelease_dep && !@specification.version.prerelease?
 
       open_ended = dep.requirement.requirements.all? do |op, version|
         not version.prerelease? and (op == '>' or op == '>=')
@@ -190,14 +193,14 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
   def validate_permissions
     return if Gem.win_platform?
 
-    files.each do |file|
+    @specification.files.each do |file|
       next unless File.file?(file)
       next if File.stat(file).mode & 0444 == 0444
       warning "#{file} is not world-readable"
     end
 
-    executables.each do |name|
-      exec = File.join bindir, name
+    @specification.executables.each do |name|
+      exec = File.join @specification.bindir, name
       next unless File.file?(exec)
       next if File.stat(exec).executable?
       warning "#{exec} is not executable"
@@ -208,7 +211,7 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
 
   def validate_nil_attributes
     nil_attributes = Gem::Specification.non_nil_attributes.select do |attrname|
-      __getobj__.instance_variable_get("@#{attrname}").nil?
+      @specification.instance_variable_get("@#{attrname}").nil?
     end
     return if nil_attributes.empty?
     error "#{nil_attributes.join ', '} must not be nil"
@@ -216,6 +219,9 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
 
   def validate_rubygems_version
     return unless packaging
+
+    rubygems_version = @specification.rubygems_version
+
     return if rubygems_version == Gem::VERSION
 
     error "expected RubyGems version #{Gem::VERSION}, was #{rubygems_version}"
@@ -223,13 +229,15 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
 
   def validate_required_attributes
     Gem::Specification.required_attributes.each do |symbol|
-      unless send symbol
+      unless @specification.send symbol
         error "missing value for attribute #{symbol}"
       end
     end
   end
 
   def validate_name
+    name = @specification.name
+
     if !name.is_a?(String)
       error "invalid value for attribute name: \"#{name.inspect}\" must be a string"
     elsif name !~ /[a-zA-Z]/
@@ -242,14 +250,15 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
   end
 
   def validate_require_paths
-    return unless raw_require_paths.empty?
+    return unless @specification.raw_require_paths.empty?
 
     error 'specification must have at least one require_path'
   end
 
   def validate_non_files
     return unless packaging
-    non_files = files.reject {|x| File.file?(x) || File.symlink?(x)}
+
+    non_files = @specification.files.reject {|x| File.file?(x) || File.symlink?(x)}
 
     unless non_files.empty?
       error "[\"#{non_files.join "\", \""}\"] are not files"
@@ -257,18 +266,22 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
   end
 
   def validate_self_inclusion_in_files_list
-    return unless files.include?(file_name)
+    file_name = @specification.file_name
 
-    error "#{full_name} contains itself (#{file_name}), check your files list"
+    return unless @specification.files.include?(file_name)
+
+    error "#{@specification.full_name} contains itself (#{file_name}), check your files list"
   end
 
   def validate_specification_version
-    return if specification_version.is_a?(Integer)
+    return if @specification.specification_version.is_a?(Integer)
 
     error 'specification_version must be an Integer (did you mean version?)'
   end
 
   def validate_platform
+    platform = @specification.platform
+
     case platform
     when Gem::Platform, Gem::Platform::RUBY  # ok
     else
@@ -283,7 +296,7 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
   end
 
   def validate_array_attribute(field)
-    val = self.send(field)
+    val = @specification.send(field)
     klass = case field
             when :dependencies then
               Gem::Dependency
@@ -298,12 +311,14 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
   end
 
   def validate_authors_field
-    return unless authors.empty?
+    return unless @specification.authors.empty?
 
     error "authors may not be empty"
   end
 
   def validate_licenses
+    licenses = @specification.licenses
+
     licenses.each do |license|
       if license.length > 64
         error "each license must be 64 characters or less"
@@ -331,21 +346,23 @@ http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard li
   HOMEPAGE_URI_PATTERN = /\A[a-z][a-z\d+.-]*:/i.freeze
 
   def validate_lazy_metadata
-    unless authors.grep(LAZY_PATTERN).empty?
+    unless @specification.authors.grep(LAZY_PATTERN).empty?
       error "#{LAZY} is not an author"
     end
 
-    unless Array(email).grep(LAZY_PATTERN).empty?
+    unless Array(@specification.email).grep(LAZY_PATTERN).empty?
       error "#{LAZY} is not an email"
     end
 
-    if description =~ LAZY_PATTERN
+    if @specification.description =~ LAZY_PATTERN
       error "#{LAZY} is not a description"
     end
 
-    if summary =~ LAZY_PATTERN
+    if @specification.summary =~ LAZY_PATTERN
       error "#{LAZY} is not a summary"
     end
+
+    homepage = @specification.homepage
 
     # Make sure a homepage is valid HTTP/HTTPS URI
     if homepage and not homepage.empty?
@@ -365,29 +382,29 @@ http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard li
       validate_attribute_present(attribute)
     end
 
-    if description == summary
+    if @specification.description == @specification.summary
       warning "description and summary are identical"
     end
 
     # TODO: raise at some given date
-    warning "deprecated autorequire specified" if autorequire
+    warning "deprecated autorequire specified" if @specification.autorequire
 
-    executables.each do |executable|
+    @specification.executables.each do |executable|
       validate_shebang_line_in(executable)
     end
 
-    files.select { |f| File.symlink?(f) }.each do |file|
+    @specification.files.select { |f| File.symlink?(f) }.each do |file|
       warning "#{file} is a symlink, which is not supported on all platforms"
     end
   end
 
   def validate_attribute_present(attribute)
-    value = self.send attribute
+    value = @specification.send attribute
     warning("no #{attribute} specified") if value.nil? || value.empty?
   end
 
   def validate_shebang_line_in(executable)
-    executable_path = File.join(bindir, executable)
+    executable_path = File.join(@specification.bindir, executable)
     return if File.read(executable_path, 2) == '#!'
 
     warning "#{executable_path} is missing #! line"

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -1,8 +1,7 @@
-require 'delegate'
 require 'uri'
 require 'rubygems/user_interaction'
 
-class Gem::SpecificationPolicy < SimpleDelegator
+class Gem::SpecificationPolicy
 
   include Gem::UserInteraction
 
@@ -25,7 +24,6 @@ class Gem::SpecificationPolicy < SimpleDelegator
   def initialize(specification)
     @warnings = 0
 
-    super(specification)
     @specification = specification
   end
 

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -522,11 +522,11 @@ class TestGemRequire < Gem::TestCase
       Dir.mktmpdir("warn_test") do |dir|
         File.write(dir + "/main.rb", "warn({x:1}, {y:2}, [])\n")
         _, err = capture_subprocess_io do
-          system(@@ruby, "-w", "--disable=gems", "-I", lib, "-C", dir, "-I.", "main.rb")
+          system(@@ruby, "-w", "--disable=gems", "-I", lib, "-C", dir, "main.rb")
         end
         assert_equal "{:x=>1}\n{:y=>2}\n", err
         _, err = capture_subprocess_io do
-          system(@@ruby, "-w", "--enable=gems", "-I", lib, "-C", dir, "-I.", "main.rb")
+          system(@@ruby, "-w", "--enable=gems", "-I", lib, "-C", dir, "main.rb")
         end
         assert_equal "{:x=>1}\n{:y=>2}\n", err
       end

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -499,8 +499,8 @@ class TestGemRequire < Gem::TestCase
     end
   end
 
-  # uplevel is 2.5+ only and jruby has some issues with it
-  if RUBY_VERSION >= "2.5" && !java_platform?
+  # uplevel is 2.5+ only
+  if RUBY_VERSION >= "2.5"
     ["", "Kernel."].each do |prefix|
       define_method "test_no_kernel_require_in_#{prefix.tr(".", "_")}warn_with_uplevel" do
         lib = File.realpath("../../../lib", __FILE__)
@@ -510,11 +510,11 @@ class TestGemRequire < Gem::TestCase
           _, err = capture_subprocess_io do
             system(@@ruby, "-w", "--disable=gems", "-I", lib, "-C", dir, "-I.", "main.rb")
           end
-          assert_equal "main.rb:1: warning: uplevel\ntest\n", err
+          assert_match(/main\.rb:1: warning: uplevel\ntest\n$/, err)
           _, err = capture_subprocess_io do
             system(@@ruby, "-w", "--enable=gems", "-I", lib, "-C", dir, "-I.", "main.rb")
           end
-          assert_equal "main.rb:1: warning: uplevel\ntest\n", err
+          assert_match(/main\.rb:1: warning: uplevel\ntest\n$/, err)
         end
       end
 
@@ -525,11 +525,11 @@ class TestGemRequire < Gem::TestCase
           _, err = capture_subprocess_io do
             system(@@ruby, "-w", "--disable=gems", "-I", lib, "-C", dir, "main.rb")
           end
-          assert_equal "{:x=>1}\n{:y=>2}\n", err
+          assert_match(/{:x=>1}\n{:y=>2}\n$/, err)
           _, err = capture_subprocess_io do
             system(@@ruby, "-w", "--enable=gems", "-I", lib, "-C", dir, "main.rb")
           end
-          assert_equal "{:x=>1}\n{:y=>2}\n", err
+          assert_match(/{:x=>1}\n{:y=>2}\n$/, err)
         end
       end
     end

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -507,11 +507,11 @@ class TestGemRequire < Gem::TestCase
         File.write(dir + "/sub.rb", "warn 'uplevel', 'test', uplevel: 1\n")
         File.write(dir + "/main.rb", "require 'sub'\n")
         _, err = capture_subprocess_io do
-          system(@@ruby, "-w", "-rpp", "--disable=gems", "-I", lib, "-C", dir, "-I.", "main.rb")
+          system(@@ruby, "-w", "--disable=gems", "-I", lib, "-C", dir, "-I.", "main.rb")
         end
         assert_equal "main.rb:1: warning: uplevel\ntest\n", err
         _, err = capture_subprocess_io do
-          system(@@ruby, "-w", "-rpp", "--enable=gems", "-I", lib, "-C", dir, "-I.", "main.rb")
+          system(@@ruby, "-w", "--enable=gems", "-I", lib, "-C", dir, "-I.", "main.rb")
         end
         assert_equal "main.rb:1: warning: uplevel\ntest\n", err
       end
@@ -522,11 +522,11 @@ class TestGemRequire < Gem::TestCase
       Dir.mktmpdir("warn_test") do |dir|
         File.write(dir + "/main.rb", "warn({x:1}, {y:2}, [])\n")
         _, err = capture_subprocess_io do
-          system(@@ruby, "-w", "-rpp", "--disable=gems", "-I", lib, "-C", dir, "-I.", "main.rb")
+          system(@@ruby, "-w", "--disable=gems", "-I", lib, "-C", dir, "-I.", "main.rb")
         end
         assert_equal "{:x=>1}\n{:y=>2}\n", err
         _, err = capture_subprocess_io do
-          system(@@ruby, "-w", "-rpp", "--enable=gems", "-I", lib, "-C", dir, "-I.", "main.rb")
+          system(@@ruby, "-w", "--enable=gems", "-I", lib, "-C", dir, "-I.", "main.rb")
         end
         assert_equal "{:x=>1}\n{:y=>2}\n", err
       end

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -501,34 +501,36 @@ class TestGemRequire < Gem::TestCase
 
   # uplevel is 2.5+ only and jruby has some issues with it
   if RUBY_VERSION >= "2.5" && !java_platform?
-    def test_no_kernel_require_in_warn_with_uplevel
-      lib = File.realpath("../../../lib", __FILE__)
-      Dir.mktmpdir("warn_test") do |dir|
-        File.write(dir + "/sub.rb", "warn 'uplevel', 'test', uplevel: 1\n")
-        File.write(dir + "/main.rb", "require 'sub'\n")
-        _, err = capture_subprocess_io do
-          system(@@ruby, "-w", "--disable=gems", "-I", lib, "-C", dir, "-I.", "main.rb")
+    ["", "Kernel."].each do |prefix|
+      define_method "test_no_kernel_require_in_#{prefix.tr(".", "_")}warn_with_uplevel" do
+        lib = File.realpath("../../../lib", __FILE__)
+        Dir.mktmpdir("warn_test") do |dir|
+          File.write(dir + "/sub.rb", "#{prefix}warn 'uplevel', 'test', uplevel: 1\n")
+          File.write(dir + "/main.rb", "require 'sub'\n")
+          _, err = capture_subprocess_io do
+            system(@@ruby, "-w", "--disable=gems", "-I", lib, "-C", dir, "-I.", "main.rb")
+          end
+          assert_equal "main.rb:1: warning: uplevel\ntest\n", err
+          _, err = capture_subprocess_io do
+            system(@@ruby, "-w", "--enable=gems", "-I", lib, "-C", dir, "-I.", "main.rb")
+          end
+          assert_equal "main.rb:1: warning: uplevel\ntest\n", err
         end
-        assert_equal "main.rb:1: warning: uplevel\ntest\n", err
-        _, err = capture_subprocess_io do
-          system(@@ruby, "-w", "--enable=gems", "-I", lib, "-C", dir, "-I.", "main.rb")
-        end
-        assert_equal "main.rb:1: warning: uplevel\ntest\n", err
       end
-    end
 
-    def test_no_other_behavioral_changes_with_kernel_warn
-      lib = File.realpath("../../../lib", __FILE__)
-      Dir.mktmpdir("warn_test") do |dir|
-        File.write(dir + "/main.rb", "warn({x:1}, {y:2}, [])\n")
-        _, err = capture_subprocess_io do
-          system(@@ruby, "-w", "--disable=gems", "-I", lib, "-C", dir, "main.rb")
+      define_method "test_no_other_behavioral_changes_with_#{prefix.tr(".", "_")}warn" do
+        lib = File.realpath("../../../lib", __FILE__)
+        Dir.mktmpdir("warn_test") do |dir|
+          File.write(dir + "/main.rb", "#{prefix}warn({x:1}, {y:2}, [])\n")
+          _, err = capture_subprocess_io do
+            system(@@ruby, "-w", "--disable=gems", "-I", lib, "-C", dir, "main.rb")
+          end
+          assert_equal "{:x=>1}\n{:y=>2}\n", err
+          _, err = capture_subprocess_io do
+            system(@@ruby, "-w", "--enable=gems", "-I", lib, "-C", dir, "main.rb")
+          end
+          assert_equal "{:x=>1}\n{:y=>2}\n", err
         end
-        assert_equal "{:x=>1}\n{:y=>2}\n", err
-        _, err = capture_subprocess_io do
-          system(@@ruby, "-w", "--enable=gems", "-I", lib, "-C", dir, "main.rb")
-        end
-        assert_equal "{:x=>1}\n{:y=>2}\n", err
       end
     end
   end


### PR DESCRIPTION
# Description:

The `delegate` library will be gemified in ruby 2.7, so we should try to remove our dependency on it because otherwise we can run into gem activation conflicts with user chosen versions.

We were only depending on it in one place, but our `Kernel.warn` modification actually depended on this dependency because the `delegate` library [performs some customizations on `Kernel` methods](https://github.com/ruby/ruby/blob/cdcaf041127430b30ee4b32452762666495a732a/lib/delegate.rb#L40-L53) and that was accidentally making our customizations work. 

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
