### PR TITLE
Lazily load `uri`

### DIFF
--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -1,4 +1,3 @@
-require 'uri'
 require 'rubygems/user_interaction'
 
 class Gem::SpecificationPolicy
@@ -364,6 +363,7 @@ http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard li
 
     # Make sure a homepage is valid HTTP/HTTPS URI
     if homepage and not homepage.empty?
+      require 'uri'
       begin
         homepage_uri = URI.parse(homepage)
         unless [URI::HTTP, URI::HTTPS].member? homepage_uri.class


### PR DESCRIPTION
# Description:

The `uri` library will be a default gem on ruby 2.7. Because of this, requiring `uri` at the top of this file will cause the default `uri` gem to be activated during `bundler/setup`, and that will result in gem activation conflicts.

So, it's better to lazily load `uri` here.

I'm using this patch in bundler/bundler#7460 to get bundler specs passing against ruby 2.7.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
