### PR TITLE
Lazily load `rubygems/gem_runner` during tests

### DIFF
--- a/test/rubygems/test_gem_gem_runner.rb
+++ b/test/rubygems/test_gem_gem_runner.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
-require 'rubygems/gem_runner'
 
 class TestGemGemRunner < Gem::TestCase
 
@@ -8,6 +7,8 @@ class TestGemGemRunner < Gem::TestCase
     super
 
     @orig_args = Gem::Command.build_args
+
+    require 'rubygems/gem_runner'
     @runner = Gem::GemRunner.new
   end
 


### PR DESCRIPTION
# Description:

If you have a gem register a rubygems plugin globally installed, for example `gem-compìler`, and run `rake TESTOPTS="--name=test_gem_help_commands`, you'll get the following test failure:

```
F

Failure:
TestGemCommandsHelpCommand#test_gem_help_commands [/home/deivid/Code/rubygems/test/rubygems/test_gem_commands_help_command.rb:48]:
Expected "ERROR:  Loading command: compile (LoadError)\n" +
"\tcannot load such file -- rubygems/commands/compile_command\n" to be empty.
```

This is because requiring `rubygems/gem_runner` automatically loads all available plugins, and before this commit that was happening before `Gem::TestCase#setup` had run, which sets up a specific GEM_HOME for our rubygems tests. So, it was loading all plugins available in the developer's system, which is not expected.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).