### PR TITLE
Pin `actions/checkout` version

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         ruby: [ '2.4.x', '2.5.x', '2.6.x' ]
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v1
       - run: git submodule update -i
       - name: Setup ruby
         uses: actions/setup-ruby@v1

--- a/.github/workflows/ruby-master.yml
+++ b/.github/workflows/ruby-master.yml
@@ -21,7 +21,7 @@ jobs:
           apt update -qy
           apt install zip -qy
           gem install rake --no-document
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v1
       - run: git submodule update -i
       - name: ruby -v
         run: ruby -v

--- a/.github/workflows/ubuntu-bundler-master.yml
+++ b/.github/workflows/ubuntu-bundler-master.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         ruby: [ '2.6.x' ]
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v1
       - run: git submodule update -i
       - name: Fixed world writable dirs
         run: |

--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -12,7 +12,7 @@ jobs:
   ubuntu_lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v1
       - run: git submodule update -i
       - name: Setup ruby
         uses: actions/setup-ruby@v1

--- a/.github/workflows/ubuntu-rvm.yml
+++ b/.github/workflows/ubuntu-rvm.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         ruby: [ 'ruby-head', 'jruby-9.2.9.0' ]
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v1
       - run: git submodule update -i
       - name: Fixed world writable dirs
         run: |

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -16,7 +16,7 @@ jobs:
         ruby: [ '2.3.x', '2.4.x', '2.5.x', '2.6.x' ]
         test_tool: [ "rubygems", "bundler" ]
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v1
       - run: git submodule update -i
       - name: Fixed world writable dirs
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         ruby: [ '2.4.x', '2.5.x', '2.6.x' ]
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v1
       - run: git submodule update -i
       - name: Setup ruby
         uses: actions/setup-ruby@v1


### PR DESCRIPTION
# Description:

According to https://github.com/rubygems/rubygems/runs/332239254, current `actions/checkout` master requires git 2.18.0, but our base docker image has 2.17.1.

Pinning to v1, since having a deterministic CI environment prevents this kind of issues.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
