### PR TITLE
Refactor remote fetcher

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -493,6 +493,7 @@ lib/rubygems/test_utilities.rb
 lib/rubygems/text.rb
 lib/rubygems/uninstaller.rb
 lib/rubygems/uri_formatter.rb
+lib/rubygems/uri_parser.rb
 lib/rubygems/user_interaction.rb
 lib/rubygems/util.rb
 lib/rubygems/util/licenses.rb

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -494,6 +494,7 @@ lib/rubygems/text.rb
 lib/rubygems/uninstaller.rb
 lib/rubygems/uri_formatter.rb
 lib/rubygems/uri_parser.rb
+lib/rubygems/uri_parsing.rb
 lib/rubygems/user_interaction.rb
 lib/rubygems/util.rb
 lib/rubygems/util/licenses.rb

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -254,7 +254,7 @@ class Gem::RemoteFetcher
   # Downloads +uri+ and returns it as a String.
 
   def fetch_path(uri, mtime = nil, head = false)
-    uri = URI.parse uri unless URI::Generic === uri
+    uri = URI.parse uri unless uri.is_a?(URI::Generic)
 
     unless uri.scheme
       raise ArgumentError, "uri scheme is invalid: #{uri.scheme.inspect}"

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -130,12 +130,12 @@ class Gem::RemoteFetcher
 
     FileUtils.mkdir_p cache_dir rescue nil unless File.exist? cache_dir
 
-    # Always escape URI's to deal with potential spaces and such
-    # It should also be considered that source_uri may already be
-    # a valid URI with escaped characters. e.g. "{DESede}" is encoded
-    # as "%7BDESede%7D". If this is escaped again the percentage
-    # symbols will be escaped.
     if source_uri.is_a?(String)
+      # Always escape URI's to deal with potential spaces and such
+      # It should also be considered that source_uri may already be
+      # a valid URI with escaped characters. e.g. "{DESede}" is encoded
+      # as "%7BDESede%7D". If this is escaped again the percentage
+      # symbols will be escaped.
       begin
         source_uri = URI.parse(source_uri)
       rescue

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -135,7 +135,7 @@ class Gem::RemoteFetcher
     # a valid URI with escaped characters. e.g. "{DESede}" is encoded
     # as "%7BDESede%7D". If this is escaped again the percentage
     # symbols will be escaped.
-    unless source_uri.is_a?(URI::Generic)
+    if source_uri.is_a?(String)
       begin
         source_uri = URI.parse(source_uri)
       rescue
@@ -254,7 +254,7 @@ class Gem::RemoteFetcher
   # Downloads +uri+ and returns it as a String.
 
   def fetch_path(uri, mtime = nil, head = false)
-    uri = URI.parse uri unless uri.is_a?(URI::Generic)
+    uri = URI.parse uri if uri.is_a?(String)
 
     unless uri.scheme
       raise ArgumentError, "uri scheme is invalid: #{uri.scheme.inspect}"

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -31,10 +31,10 @@ class Gem::RemoteFetcher
     def initialize(message, uri)
       super message
       begin
-        uri = URI(uri)
+        uri = URI.parse(uri)
         uri.password = 'REDACTED' if uri.password
         @uri = uri.to_s
-      rescue URI::InvalidURIError, ArgumentError
+      rescue URI::InvalidURIError
         @uri = uri
       end
     end

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -153,7 +153,7 @@ class Gem::RemoteFetcher
           remote_gem_path = source_uri + "gems/#{gem_file_name}"
 
           self.cache_update_path remote_gem_path, local_gem_path
-        rescue Gem::RemoteFetcher::FetchError
+        rescue FetchError
           raise if spec.original_platform == spec.platform
 
           alternate_name = "#{spec.original_name}.gem"

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -4,6 +4,7 @@ require 'rubygems/request'
 require 'rubygems/request/connection_pools'
 require 'rubygems/s3_uri_signer'
 require 'rubygems/uri_formatter'
+require 'rubygems/uri_parser'
 require 'rubygems/user_interaction'
 require 'resolv'
 require 'rubygems/deprecate'
@@ -31,21 +32,29 @@ class Gem::RemoteFetcher
     def initialize(message, uri)
       super message
 
-      if uri.is_a?(String)
-        begin
-          uri = URI.parse(uri)
-        rescue URI::InvalidURIError
-          @uri = uri
-          return
-        end
-      end
+      uri = parse_uri(uri)
 
-      uri.password = 'REDACTED' if uri.password
+      uri.password = 'REDACTED' if uri.respond_to?(:password) && uri.password
+
       @uri = uri.to_s
     end
 
     def to_s # :nodoc:
       "#{super} (#{uri})"
+    end
+
+    private
+
+    def parse_uri(source_uri)
+      return source_uri unless source_uri.is_a?(String)
+
+      uri_parser.parse(source_uri)
+    end
+
+    def uri_parser
+      require "uri"
+
+      Gem::UriParser.new
     end
 
   end
@@ -350,15 +359,13 @@ class Gem::RemoteFetcher
   def parse_uri(source_uri)
     return source_uri unless source_uri.is_a?(String)
 
-    # It should also be considered that source_uri may already be
-    # a valid URI with escaped characters. e.g. "{DESede}" is encoded
-    # as "%7BDESede%7D". If this is escaped again the percentage
-    # symbols will be escaped.
-    begin
-      URI.parse(source_uri)
-    rescue
-      URI.parse(URI::DEFAULT_PARSER.escape(source_uri))
-    end
+    uri_parser.parse!(source_uri)
+  end
+
+  def uri_parser
+    require "uri"
+
+    @uri_parser ||= Gem::UriParser.new
   end
 
   def proxy_for(proxy, uri)

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -236,7 +236,7 @@ class Gem::RemoteFetcher
       unless location = response['Location']
         raise FetchError.new("redirecting but no redirect location was given", uri)
       end
-      location = URI.parse response['Location']
+      location = URI.parse location
 
       if https?(uri) && !https?(location)
         raise FetchError.new("redirecting to non-https resource: #{location}", uri)

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -260,8 +260,6 @@ class Gem::RemoteFetcher
     end
 
     data
-  rescue FetchError
-    raise
   rescue Timeout::Error
     raise UnknownHostError.new('timed out', uri.to_s)
   rescue IOError, SocketError, SystemCallError,

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -139,7 +139,7 @@ class Gem::RemoteFetcher
       begin
         source_uri = URI.parse(source_uri)
       rescue
-        source_uri = URI.parse(URI::DEFAULT_PARSER.escape(source_uri.to_s))
+        source_uri = URI.parse(URI::DEFAULT_PARSER.escape(source_uri))
       end
     end
 

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -256,8 +256,6 @@ class Gem::RemoteFetcher
   def fetch_path(uri, mtime = nil, head = false)
     uri = URI.parse uri unless URI::Generic === uri
 
-    raise ArgumentError, "bad uri: #{uri}" unless uri
-
     unless uri.scheme
       raise ArgumentError, "uri scheme is invalid: #{uri.scheme.inspect}"
     end

--- a/lib/rubygems/request.rb
+++ b/lib/rubygems/request.rb
@@ -19,6 +19,7 @@ class Gem::Request
   end
 
   def self.proxy_uri(proxy) # :nodoc:
+    require "uri"
     case proxy
     when :no_proxy then nil
     when URI::HTTP then proxy
@@ -173,6 +174,7 @@ class Gem::Request
         :no_proxy : get_proxy_from_env('http')
     end
 
+    require "uri"
     uri = URI(Gem::UriFormatter.new(env_proxy).normalize)
 
     if uri and uri.user.nil? and uri.password.nil?

--- a/lib/rubygems/source.rb
+++ b/lib/rubygems/source.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 autoload :FileUtils, 'fileutils'
-autoload :URI, 'uri'
 
 require "rubygems/text"
 ##

--- a/lib/rubygems/uri_formatter.rb
+++ b/lib/rubygems/uri_formatter.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'cgi'
-require 'uri'
 
 ##
 # The UriFormatter handles URIs from user-input and escaping.

--- a/lib/rubygems/uri_parser.rb
+++ b/lib/rubygems/uri_parser.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+##
+# The UriParser handles parsing URIs.
+#
+
+class Gem::UriParser
+
+  ##
+  # Parses the #uri, raising if it's invalid
+
+  def parse!(uri)
+    raise URI::InvalidURIError unless uri
+
+    # Always escape URI's to deal with potential spaces and such
+    # It should also be considered that source_uri may already be
+    # a valid URI with escaped characters. e.g. "{DESede}" is encoded
+    # as "%7BDESede%7D". If this is escaped again the percentage
+    # symbols will be escaped.
+    begin
+      URI.parse(uri)
+    rescue URI::InvalidURIError
+      URI.parse(URI::DEFAULT_PARSER.escape(uri))
+    end
+  end
+
+  ##
+  # Parses the #uri, returning the original uri if it's invalid
+
+  def parse(uri)
+    parse!(uri)
+  rescue URI::InvalidURIError
+    uri
+  end
+
+end

--- a/lib/rubygems/uri_parsing.rb
+++ b/lib/rubygems/uri_parsing.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rubygems/uri_parser"
+
+module Gem::UriParsing
+
+  def parse_uri(source_uri)
+    return source_uri unless source_uri.is_a?(String)
+
+    uri_parser.parse(source_uri)
+  end
+
+  private :parse_uri
+
+  def uri_parser
+    require "uri"
+
+    Gem::UriParser.new
+  end
+
+  private :uri_parser
+
+end

--- a/test/rubygems/test_remote_fetch_error.rb
+++ b/test/rubygems/test_remote_fetch_error.rb
@@ -5,7 +5,7 @@ class TestRemoteFetchError < Gem::TestCase
 
   def test_password_redacted
     error = Gem::RemoteFetcher::FetchError.new('There was an error fetching', 'https://user:secret@gemsource.org')
-    refute_match error.to_s, 'secret'
+    refute_match 'secret', error.to_s
   end
 
   def test_invalid_url


### PR DESCRIPTION
# Description:

In bundler/bundler#7460 I'm vendoring the `uri` library inside `bundler` to add support for using the `uri` version inside Gemfile's just like any other gem. However, that was not the only thing needed since `bundler/setup` also touches some code from this class in rubygems.

So the initial approach I took was to duplicate all the code inside bundler, replacing all reference to `URI` with `Bundler::URI` (the vendored namespace). Like in https://github.com/bundler/bundler/pull/7460/commits/3bcc57980b27fc98a9cb44c7853261c206fdc109.

However, this is ugly and hard to maintain so in this PR I'm refactoring this class so that it is enough to override only one method in the `bundler` subclass, like this: https://github.com/bundler/bundler/blob/aa3a25d30383a16e002dd94c209a6078746204a7/lib/bundler/gem_remote_fetcher.rb 

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
