### PR TITLE
Remove regular 2.3 testing

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,7 +1,5 @@
 status = [
   "ubuntu_lint",
-  "ubuntu (2.3.x, rubygems)",
-  "ubuntu (2.3.x, bundler)",
   "macos (2.4.x)",
   "ubuntu (2.4.x, rubygems)",
   "ubuntu (2.4.x, bundler)",
@@ -16,6 +14,7 @@ status = [
   "windows (2.6.x)",
   "ubuntu_bundler_master (2.6.x)",
   "ruby_master",
+  "ubuntu_rvm (2.3.8)",
   "ubuntu_rvm (ruby-head)",
   "ubuntu_rvm (jruby-9.2.9.0)",
 ]

--- a/.github/workflows/ubuntu-rvm.yml
+++ b/.github/workflows/ubuntu-rvm.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ 'ruby-head', 'jruby-9.2.9.0' ]
+        ruby: [ '2.3.8', 'ruby-head', 'jruby-9.2.9.0' ]
     steps:
       - uses: actions/checkout@v1
       - run: git submodule update -i
@@ -37,7 +37,7 @@ jobs:
           util/ci.sh script
         env:
           TEST_TOOL: rubygems
-        if: matrix.ruby == 'jruby-9.2.9.0'
+        if: matrix.ruby == 'jruby-9.2.9.0' || matrix.ruby == '2.3.8'
       - name: Test bundler
         run: |
           source $HOME/.rvm/scripts/rvm

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.3.x', '2.4.x', '2.5.x', '2.6.x' ]
+        ruby: [ '2.4.x', '2.5.x', '2.6.x' ]
         test_tool: [ "rubygems", "bundler" ]
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
# Description:

From the failures at #3017, it seems that `actions/setup-ruby` dropped support for testing against ruby 2.3.

So, I'm removing 2.3.x from our matrix. To ensure support until we actually drop it, I replaced it with an entry in the `rvm` file.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
