### PR TITLE
Remove unnecessary CI step

### DIFF
--- a/.github/workflows/ruby-master.yml
+++ b/.github/workflows/ruby-master.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - name: Setup Requirements
         run: |
-          apt update -qy
-          apt install zip -qy
           gem install rake --no-document
       - uses: actions/checkout@v1
       - run: git submodule update -i

--- a/.github/workflows/ubuntu-rvm.yml
+++ b/.github/workflows/ubuntu-rvm.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Ruby
         run: |
           source $HOME/.rvm/scripts/rvm
-          rvm install ${{ matrix.ruby }} --binary
+          rvm install ${{ matrix.ruby }} --binary --autolibs=disable
           rvm --default use ${{ matrix.ruby }}
       - name: Test rubygems
         run: |

--- a/test/rubygems/test_project_sanity.rb
+++ b/test/rubygems/test_project_sanity.rb
@@ -1,27 +1,8 @@
 # frozen_string_literal: true
 
-require "rubygems/test_case"
 require "open3"
 
 class TestProjectSanity < Minitest::Test
-
-  def test_rake_package_builds_ok
-    skip unless File.exist?(File.expand_path("../../../Rakefile", __FILE__))
-
-    with_empty_pkg_folder do
-      output, status = Open3.capture2e("rake package")
-
-      assert_equal true, status.success?, <<~MSG.chomp
-        Expected `rake package` to work, but got errors:
-
-        ```
-        #{output}
-        ```
-
-        If you have added or removed files, make sure you run `rake update_manifest` to update the `Manifest.txt` accordingly
-      MSG
-    end
-  end
 
   def test_manifest_is_up_to_date
     skip unless File.exist?(File.expand_path("../../../Rakefile", __FILE__))
@@ -29,30 +10,6 @@ class TestProjectSanity < Minitest::Test
     _, status = Open3.capture2e("rake check_manifest")
 
     assert status.success?, "Expected Manifest.txt to be up to date, but it's not. Run `rake update_manifest` to sync it."
-  end
-
-  private
-
-  def with_empty_pkg_folder
-    if File.exist?("pkg")
-      FileUtils.cp_r("pkg", "tmp")
-
-      begin
-        FileUtils.rm_rf("pkg")
-        yield
-      ensure
-        FileUtils.rm_rf("pkg")
-        FileUtils.cp_r("tmp/pkg", ".")
-      end
-    else
-      Dir.mkdir("pkg")
-
-      begin
-        yield
-      ensure
-        FileUtils.rm_rf("pkg")
-      end
-    end
   end
 
 end

--- a/util/ci.sh
+++ b/util/ci.sh
@@ -30,7 +30,7 @@ case $1 in
       fi
 
       gem install rake -v "~>12.0"
-      exec bin/rake spec:travis:deps
+      exec bin/rake spec:deps
     fi
 
     ;;


### PR DESCRIPTION

# Description:

Currently, the `apt install` step in our CI causes some stability some times. However, only a single test relies on the `zip` package being present. That test was added on https://github.com/rubygems/rubygems/pull/2787 and essentially checked that the `Manifest.txt` file was in sync. However, in https://github.com/rubygems/rubygems/pull/2953 a more robust check for that was added, so I think we can remove the original test and thus remove the `apt install` step too.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
