### PR TITLE
require `uri` in source.rb

### DIFF
--- a/lib/rubygems/source.rb
+++ b/lib/rubygems/source.rb
@@ -28,6 +28,7 @@ class Gem::Source
   # Creates a new Source which will use the index located at +uri+.
 
   def initialize(uri)
+    require "uri"
     begin
       unless uri.kind_of? URI
         uri = URI.parse(uri.to_s)


### PR DESCRIPTION
# Description:

The following commit: https://github.com/rubygems/rubygems/commit/0f55f337b174f9f70a213c078ae2a1c2bfd07e75  removed the autoload for `uri` causing calls made to source_list to raise `uninitialized constant Gem::SourceList::URI` error.

eg:
```
root@82cc6a0bdd6d:/# gem env --debug
NOTE:  Debugging mode prints all exceptions even when rescued
Exception `NameError' at /usr/local/lib/ruby/site_ruby/2.3.0/rubygems/source_list.rb:54 - uninitialized constant Gem::SourceList::URI
ERROR:  While executing gem ... (NameError)
    uninitialized constant Gem::SourceList::URI
	/usr/local/lib/ruby/site_ruby/2.3.0/rubygems/source_list.rb:54:in `<<'
	/usr/local/lib/ruby/site_ruby/2.3.0/rubygems/source_list.rb:74:in `block in replace'
	/usr/local/lib/ruby/site_ruby/2.3.0/rubygems/source_list.rb:73:in `each'
	/usr/local/lib/ruby/site_ruby/2.3.0/rubygems/source_list.rb:73:in `replace'
	/usr/local/lib/ruby/site_ruby/2.3.0/rubygems/source_list.rb:39:in `from'
	/usr/local/lib/ruby/site_ruby/2.3.0/rubygems.rb:996:in `sources'
	/usr/local/lib/ruby/site_ruby/2.3.0/rubygems/commands/environment_command.rb:147:in `show_environment'
	/usr/local/lib/ruby/site_ruby/2.3.0/rubygems/commands/environment_command.rb:89:in `execute'
	/usr/local/lib/ruby/site_ruby/2.3.0/rubygems/command.rb:325:in `invoke_with_build_args'
	/usr/local/lib/ruby/site_ruby/2.3.0/rubygems/command_manager.rb:178:in `process_args'
	/usr/local/lib/ruby/site_ruby/2.3.0/rubygems/command_manager.rb:148:in `run'
	/usr/local/lib/ruby/site_ruby/2.3.0/rubygems/gem_runner.rb:59:in `run'
	/usr/local/bin/gem:15:in `<main>'
```

This PR attempts to fix this by adding a require "uri" to the source.rb.

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
