### PR TITLE
Fix `gem update --system --force`

### DIFF
--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -17,6 +17,7 @@ class Gem::Commands::SetupCommand < Gem::Command
 
     super 'setup', 'Install RubyGems',
           :format_executable => true, :document => %w[ri],
+          :force => false,
           :site_or_vendor => 'sitelibdir',
           :destdir => '', :prefix => '', :previous_version => '',
           :regenerate_binstubs => true
@@ -86,6 +87,11 @@ class Gem::Commands::SetupCommand < Gem::Command
     add_option '--[no-]regenerate-binstubs',
                'Regenerate gem binstubs' do |value, options|
       options[:regenerate_binstubs] = value
+    end
+
+    add_option '-f', '--[no-]force',
+               'Forcefully overwrite binstubs' do |value, options|
+      options[:force] = value
     end
 
     add_option('-E', '--[no-]env-shebang',
@@ -429,7 +435,7 @@ By default, this RubyGems will install gem as:
     Dir.chdir("bundler") do
       built_gem = Gem::Package.build(bundler_spec)
       begin
-        installer = Gem::Installer.at(built_gem, env_shebang: options[:env_shebang], format_executable: options[:format_executable], install_as_default: true, bin_dir: bin_dir, wrappers: true)
+        installer = Gem::Installer.at(built_gem, env_shebang: options[:env_shebang], format_executable: options[:format_executable], force: options[:force], install_as_default: true, bin_dir: bin_dir, wrappers: true)
         installer.install
       ensure
         FileUtils.rm_f built_gem

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -164,6 +164,50 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
     end
   end
 
+  ##
+  # Sets the bindir entry in RbConfig::CONFIG to +value+ and restores the
+  # original value when the block ends
+  #
+  def bindir(value)
+    bindir = RbConfig::CONFIG['bindir']
+
+    if value
+      RbConfig::CONFIG['bindir'] = value
+    else
+      RbConfig::CONFIG.delete 'bindir'
+    end
+
+    yield
+  ensure
+    if bindir
+      RbConfig::CONFIG['bindir'] = bindir
+    else
+      RbConfig::CONFIG.delete 'bindir'
+    end
+  end
+
+  ##
+  # Sets the EXEEXT entry in RbConfig::CONFIG to +value+ and restores the
+  # original value when the block ends
+  #
+  def exeext(value)
+    exeext = RbConfig::CONFIG['EXEEXT']
+
+    if value
+      RbConfig::CONFIG['EXEEXT'] = value
+    else
+      RbConfig::CONFIG.delete 'EXEEXT'
+    end
+
+    yield
+  ensure
+    if exeext
+      RbConfig::CONFIG['EXEEXT'] = exeext
+    else
+      RbConfig::CONFIG.delete 'EXEEXT'
+    end
+  end
+
   # TODO: move to minitest
   def refute_path_exists(path, msg = nil)
     msg = message(msg) { "Expected path '#{path}' to not exist" }

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1917,16 +1917,11 @@ You may need to `gem install -g` to install missing gems
   end
 
   def with_bindir_and_exeext(bindir, exeext)
-    orig_bindir = RbConfig::CONFIG['bindir']
-    orig_exe_ext = RbConfig::CONFIG['EXEEXT']
-
-    RbConfig::CONFIG['bindir'] = bindir
-    RbConfig::CONFIG['EXEEXT'] = exeext
-
-    yield
-  ensure
-    RbConfig::CONFIG['bindir'] = orig_bindir
-    RbConfig::CONFIG['EXEEXT'] = orig_exe_ext
+    bindir(bindir) do
+      exeext(exeext) do
+        yield
+      end
+    end
   end
 
   def with_clean_path_to_ruby

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -212,7 +212,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
 
     # TODO: We need to assert to remove same version of bundler on gem_dir directory(It's not site_ruby dir)
 
-    # expect to not remove bundler-* direcotyr.
+    # expect to not remove bundler-* directory.
     assert_path_exists 'default/gems/bundler-audit-1.0.0'
   end
 

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -216,6 +216,37 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     assert_path_exists 'default/gems/bundler-audit-1.0.0'
   end
 
+  def test_install_default_bundler_gem_with_force_flag
+    @cmd.extend FileUtils
+
+    bin_dir = File.join(@gemhome, 'bin')
+    bundle_bin = File.join(bin_dir, 'bundle')
+
+    write_file bundle_bin do |f|
+      f.puts '#!/usr/bin/ruby'
+      f.puts ''
+      f.puts 'echo "hello"'
+    end
+
+    bindir(bin_dir) do
+      @cmd.options[:force] = true
+
+      @cmd.install_default_bundler_gem bin_dir
+
+      bundler_spec = Gem::Specification.load("bundler/bundler.gemspec")
+      default_spec_path = File.join(Gem.default_specifications_dir, "#{bundler_spec.full_name}.gemspec")
+      spec = Gem::Specification.load(default_spec_path)
+
+      spec.executables.each do |e|
+        if Gem.win_platform?
+          assert_path_exists File.join(bin_dir, "#{e}.bat")
+        end
+
+        assert_path_exists File.join bin_dir, Gem.default_exec_format % e
+      end
+    end
+  end
+
   def test_remove_old_lib_files
     lib                   = File.join @install_dir, 'lib'
     lib_rubygems          = File.join lib, 'rubygems'

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -104,10 +104,6 @@ end
   def test_check_executable_overwrite_default_bin_dir
     installer = setup_base_installer
 
-    if defined?(RUBY_FRAMEWORK_VERSION)
-      orig_RUBY_FRAMEWORK_VERSION = RUBY_FRAMEWORK_VERSION
-      Object.send :remove_const, :RUBY_FRAMEWORK_VERSION
-    end
     orig_bindir = RbConfig::CONFIG['bindir']
     RbConfig::CONFIG['bindir'] = Gem.bindir
 
@@ -118,14 +114,11 @@ end
       e = assert_raises Gem::InstallError do
         installer.generate_bin
       end
-
       conflicted = File.join @gemhome, 'bin', 'executable'
       assert_match %r%\A"executable" from a conflicts with (?:#{Regexp.quote(conflicted)}|installed executable from conflict)\z%,
                    e.message
     end
   ensure
-    Object.const_set :RUBY_FRAMEWORK_VERSION, orig_RUBY_FRAMEWORK_VERSION if
-      orig_RUBY_FRAMEWORK_VERSION
     if orig_bindir
       RbConfig::CONFIG['bindir'] = orig_bindir
     else

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -104,25 +104,19 @@ end
   def test_check_executable_overwrite_default_bin_dir
     installer = setup_base_installer
 
-    orig_bindir = RbConfig::CONFIG['bindir']
-    RbConfig::CONFIG['bindir'] = Gem.bindir
+    bindir(Gem.bindir) do
+      util_conflict_executable false
 
-    util_conflict_executable false
+      ui = Gem::MockGemUi.new "n\n"
+      use_ui ui do
+        e = assert_raises Gem::InstallError do
+          installer.generate_bin
+        end
 
-    ui = Gem::MockGemUi.new "n\n"
-    use_ui ui do
-      e = assert_raises Gem::InstallError do
-        installer.generate_bin
+        conflicted = File.join @gemhome, 'bin', 'executable'
+        assert_match %r%\A"executable" from a conflicts with (?:#{Regexp.quote(conflicted)}|installed executable from conflict)\z%,
+                     e.message
       end
-      conflicted = File.join @gemhome, 'bin', 'executable'
-      assert_match %r%\A"executable" from a conflicts with (?:#{Regexp.quote(conflicted)}|installed executable from conflict)\z%,
-                   e.message
-    end
-  ensure
-    if orig_bindir
-      RbConfig::CONFIG['bindir'] = orig_bindir
-    else
-      RbConfig::CONFIG.delete 'bindir'
     end
   end
 


### PR DESCRIPTION
# Description:

The `--force` option is not implemented by `gem update --system`, but it should because `gem update --system` also installs binstubs (`bundler` and `gem` at the least)

Note that in the case of https://github.com/rubygems/rubygems/issues/3030, `rubygems` is prompting the user even though the `bundler` binstub has actually been generated by `rubygems`. The reason is that the `ruby.2.5` docker image ships with rubygems 3.0.3 which has [this bug](https://github.com/rubygems/rubygems/issues/2686). That means it generates an incorrect bundler binstub, and when you try to update it, user gets prompted because rubygems sees the binstub as "modified".

The `--force` option is useful here, since it's a good way for `rubygems` to be able to "auto-heal" its own installation in cases like this one.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

Closes #3030.