### PR TITLE
Move `require uri` to source_list

### DIFF
--- a/lib/rubygems/source.rb
+++ b/lib/rubygems/source.rb
@@ -28,7 +28,6 @@ class Gem::Source
   # Creates a new Source which will use the index located at +uri+.
 
   def initialize(uri)
-    require "uri"
     begin
       unless uri.kind_of? URI
         uri = URI.parse(uri.to_s)

--- a/lib/rubygems/source_list.rb
+++ b/lib/rubygems/source_list.rb
@@ -50,6 +50,8 @@ class Gem::SourceList
   # String.
 
   def <<(obj)
+    require "uri"
+
     src = case obj
           when URI
             Gem::Source.new(obj)


### PR DESCRIPTION
# Description:

It seems like the change in the following commit: https://github.com/rubygems/rubygems/pull/3034/commits/8de4d0272ed1d9ff395087e0b8ec3cf77a797d99 is not enough as sources_list.rb uses uri before Gem::Source is initialized.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
