### PR TITLE
Restore non prompting `gem update --system` behavior

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,5 +1,10 @@
 status = [
   "ubuntu_lint",
+  "install (2.3.8)",
+  "install (2.4.9)",
+  "install (2.5.7)",
+  "install (2.6.5)",
+  "install (jruby-9.2.9.0)",
   "macos (2.4.x)",
   "ubuntu (2.4.x, rubygems)",
   "ubuntu (2.4.x, bundler)",

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,0 +1,44 @@
+name: install
+
+on:
+  pull_request:
+
+  push:
+    branches:
+      - staging
+      - trying
+
+jobs:
+  install:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ruby: [ '2.3.8', '2.4.9', '2.5.7', '2.6.5', 'jruby-9.2.9.0' ]
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - run: git submodule update -i
+
+      - name: Fix world writable dirs
+        run: |
+          chmod go-w $HOME
+          sudo chmod -R go-w /usr/share
+          sudo chmod -R go-w /opt
+
+      - name: Set up RVM
+        run: curl -sSL https://get.rvm.io | bash
+
+      - name: Set up Ruby
+        run: |
+          source $HOME/.rvm/scripts/rvm
+          rvm install ${{ matrix.ruby }} --binary --autolibs=disable
+          rvm --default use ${{ matrix.ruby }}
+
+      - name: Install rubygems
+        run: |
+          source $HOME/.rvm/scripts/rvm
+          ruby -Ilib -S rake install
+
+    timeout-minutes: 10

--- a/Rakefile
+++ b/Rakefile
@@ -97,7 +97,7 @@ end
 
 desc "Install rubygems to local system"
 task :install => :package do
-  sh "gem install pkg/rubygems-update-#{v}.gem && update_rubygems"
+  sh "ruby -Ilib bin/gem install pkg/rubygems-update-#{v}.gem && update_rubygems"
 end
 
 desc "Release rubygems-#{v}"

--- a/bin/update_rubygems
+++ b/bin/update_rubygems
@@ -32,5 +32,5 @@ else
   update_dir = File.dirname(update_dir)
   Dir.chdir update_dir
   ENV["GEM_PREV_VER"] = Gem::VERSION
-  system(Gem.ruby, 'setup.rb', *ARGV)
+  abort unless system(Gem.ruby, 'setup.rb', *ARGV)
 end

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -17,7 +17,7 @@ class Gem::Commands::SetupCommand < Gem::Command
 
     super 'setup', 'Install RubyGems',
           :format_executable => true, :document => %w[ri],
-          :force => false,
+          :force => true,
           :site_or_vendor => 'sitelibdir',
           :destdir => '', :prefix => '', :previous_version => '',
           :regenerate_binstubs => true


### PR DESCRIPTION
# Description:

After the upgrade to rubygems 3.1, CIs of people who had `gem update --system` in their CI scripts broke, because `gem update --system` would prompt the user for confirmation to overwrite the `bundler` binstub that had apparently been changed. However, these are pristine installations, nobody has edited this file other than rubygems, so this is a bug.

This wrong binstub used to get created by ruby (through `make install`, prior to version 2.6) or by rubygems (through `gem update --system`, prior to version 3.1). Those bugs are now fixed, but fixing them sadly made this issue appear because the correct binstub that the newest rubygems wants to create no longer matches the old one (that might have been generated by previous versions of rubygems or ruby), and rubygems refuses to overwrite it.

The problem with the fix to the wrong binstub is that it changed rubygems behavior, because whereas in rubygems 3.0 bundler binstubs were overwritten manually without confirmation, in the new version they are not, since we use the default gem installer, which uses `--force=false` by default.

So, to fix the issue and preserve rubygems 3.0 behavior, we default to `--force=true` in this particular case.

To protect ourselves from future similar breakage, I added some integration tests to check that the current version of rubygems can always upgrade older installations of all supported rubies.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
