### PR TITLE
Show only release notes for new code installed

### DIFF
--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -598,7 +598,7 @@ abort "#{deprecation_message}"
         history_string = ""
 
         until versions.length == 0 or
-              versions.shift < options[:previous_version] do
+              versions.shift <= options[:previous_version] do
           history_string += version_lines.shift + text.shift
         end
 

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -339,11 +339,6 @@ class TestGemCommandsSetupCommand < Gem::TestCase
   * Fixed release note display for LANG=C when installing rubygems
   * π is tasty
 
-=== 2.0.2 / 2013-03-06
-
-* Bug fixes:
-  * Other bugs fixed
-
     EXPECTED
 
     output = @ui.output


### PR DESCRIPTION
# Description:

While working on #3040, I noticed a small bug when showing the release notes after `gem update --system`.

If, for example, I upgrade rubygems from 3.0.4 to 3.0.6, I only want to see the release notes for 3.0.5 and 3.0.6, I don't want to see the release notes for 3.0.4 since I'm already using that code.

# Tasks:

- [x] Describe the problem / feature
- [x] ~Write~Change tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
