### PR TITLE
Inform about installed `bundle` executable after `gem update --system`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -96,8 +96,13 @@ task :check_deprecations do
 end
 
 desc "Install rubygems to local system"
-task :install => :package do
+task :install => [:clear_package, :package] do
   sh "ruby -Ilib bin/gem install pkg/rubygems-update-#{v}.gem && update_rubygems"
+end
+
+desc "Clears previously built package"
+task :clear_package do
+  rm_rf "pkg"
 end
 
 desc "Release rubygems-#{v}"

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -123,6 +123,18 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     assert_equal "I changed it!\n", File.read(gem_bin_path)
   end
 
+  def test_execute_informs_about_installed_executables
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    out = @ui.output.split "\n"
+
+    exec_line = out.shift until exec_line == "RubyGems installed the following executables:"
+    assert_equal "\t#{default_gem_bin_path}", out.shift
+    assert_equal "\t#{default_bundle_bin_path}", out.shift
+  end
+
   def test_env_shebang_flag
     gem_bin_path = gem_install 'a'
     write_file gem_bin_path do |io|
@@ -133,10 +145,6 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     @cmd.options[:env_shebang] = true
     @cmd.execute
 
-    gem_exec = sprintf Gem.default_exec_format, 'gem'
-    default_gem_bin_path = File.join @install_dir, 'bin', gem_exec
-    bundle_exec = sprintf Gem.default_exec_format, 'bundle'
-    default_bundle_bin_path = File.join @install_dir, 'bin', bundle_exec
     ruby_exec = sprintf Gem.default_exec_format, 'ruby'
 
     if Gem.win_platform?
@@ -347,6 +355,18 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     assert_equal expected, output
   ensure
     @ui.outs.set_encoding @default_external if @default_external
+  end
+
+  private
+
+  def default_gem_bin_path
+    gem_exec = sprintf Gem.default_exec_format, 'gem'
+    File.join @install_dir, 'bin', gem_exec
+  end
+
+  def default_bundle_bin_path
+    bundle_exec = sprintf Gem.default_exec_format, 'bundle'
+    File.join @install_dir, 'bin', bundle_exec
   end
 
 end unless Gem.java_platform?


### PR DESCRIPTION
# Description:

In rubygems 3.0, after running `gem update --system`, you would get the following informational message:

```
RubyGems installed the following executables:
    /tmp/test_rubygems_4566/install/bin/gem
    /tmp/test_rubygems_4566/install/bin/bundle
```

In rubygems 3.1, the message about the `bundle` executable has been lost, and it only shows:

```
RubyGems installed the following executables:
    /tmp/test_rubygems_4566/install/bin/gem
```

This PR restores the previous message.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).