### PR TITLE
Install the previous default bundler version as a regular gem when upgrading rubygems

### DIFF
--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -383,6 +383,13 @@ By default, this RubyGems will install gem as:
 
       gem = spec.cache_file
 
+      unless File.exist?(gem)
+        require 'rubygems/remote_fetcher'
+
+        dep = Gem::Dependency.new(spec.name, spec.version)
+        Gem::RemoteFetcher.fetcher.download_to_cache(dep, spec.base_dir)
+      end
+
       installer = Gem::Installer.at(gem, env_shebang: options[:env_shebang], format_executable: options[:format_executable], force: options[:force], bin_dir: bin_dir, wrappers: true)
       installer.install
 

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -377,10 +377,17 @@ By default, this RubyGems will install gem as:
 
     bundler_spec = Dir.chdir("bundler") { Gem::Specification.load("bundler.gemspec") }
 
-    # Remove bundler-*.gemspec in default specification directory.
-    Dir.entries(specs_dir).
-      select {|gs| gs.start_with?("bundler-") }.
-      each {|gs| File.delete(File.join(specs_dir, gs)) }
+    Dir.entries(specs_dir).select {|gs| gs.start_with?("bundler-") }.each do |gs|
+      spec = Gem::Specification.load(File.join(specs_dir, gs))
+      spec.loaded_from = nil
+
+      gem = spec.cache_file
+
+      installer = Gem::Installer.at(gem, env_shebang: options[:env_shebang], format_executable: options[:format_executable], force: options[:force], bin_dir: bin_dir, wrappers: true)
+      installer.install
+
+      File.delete(File.join(specs_dir, gs))
+    end
 
     default_spec_path = File.join(specs_dir, "#{bundler_spec.full_name}.gemspec")
     Gem.write_binary(default_spec_path, bundler_spec.to_ruby)

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -101,14 +101,14 @@ class Gem::RemoteFetcher
   # Should probably be integrated with #download below, but that will be a
   # larger, more encompassing effort. -erikh
 
-  def download_to_cache(dependency)
+  def download_to_cache(dependency, install_dir = Gem.dir)
     found, _ = Gem::SpecFetcher.fetcher.spec_for_dependency dependency
 
     return if found.empty?
 
     spec, source = found.max_by {|(s,_)| s.version }
 
-    download spec, source.uri
+    download spec, source.uri, install_dir
   end
 
   ##

--- a/lib/rubygems/test_utilities.rb
+++ b/lib/rubygems/test_utilities.rb
@@ -153,14 +153,14 @@ class Gem::FakeFetcher
     path
   end
 
-  def download_to_cache(dependency)
+  def download_to_cache(dependency, install_dir = Gem.dir)
     found, _ = Gem::SpecFetcher.fetcher.spec_for_dependency dependency
 
     return if found.empty?
 
     spec, source = found.first
 
-    download spec, source.uri.to_s
+    download spec, source.uri.to_s, install_dir
   end
 end
 

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -249,6 +249,19 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     end
   end
 
+  def test_install_default_bundler_gem_when_previous_version_not_in_cache
+    @cmd.extend FileUtils
+
+    File.delete File.join(Gem.dir, "cache", "bundler-1.15.4.gem")
+
+    bin_dir = File.join(@gemhome, 'bin')
+    @cmd.install_default_bundler_gem bin_dir
+
+    refute_path_exists File.join(Gem.default_specifications_dir, "bundler-1.15.4.gemspec")
+    assert_path_exists File.join(Gem.dir, "specifications", "bundler-1.15.4.gemspec")
+    assert_path_exists File.join(Gem.dir, "gems", "bundler-1.15.4")
+  end
+
   def test_remove_old_lib_files
     lib                   = File.join @install_dir, 'lib'
     lib_rubygems          = File.join lib, 'rubygems'

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -210,6 +210,9 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     # expect to remove normal gem that was same version. because it's promoted default gems.
     refute_path_exists File.join(Gem.dir, "specifications", "bundler-#{BUNDLER_VERS}.gemspec")
 
+    # expect to add normal gem that was same version. because it's demoted from a default gem.
+    assert_path_exists File.join(Gem.dir, "specifications", "bundler-1.15.4.gemspec")
+
     assert_path_exists "#{Gem.dir}/gems/bundler-#{BUNDLER_VERS}"
     assert_path_exists "#{Gem.dir}/gems/bundler-1.15.4"
     assert_path_exists "#{Gem.dir}/gems/bundler-audit-1.0.0"


### PR DESCRIPTION
# Description:

The problem is that running `gem update --system` currently wipes out the previous default bundler version from the system. That means applications locked to that previous default bundler version will fail because they will no longer find the bundler version that they need.

`gem update --system` should install the previous bundler version as a regular gem, instead of just overwriting it.

Fixes #2671.
Closes #3044 

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).