### PR TITLE
Fix rubyforge deprecated warnings

### DIFF
--- a/lib/rubygems/command_manager.rb
+++ b/lib/rubygems/command_manager.rb
@@ -78,6 +78,11 @@ class Gem::CommandManager
   }.freeze
 
   ##
+  # The current command name as a symbol
+
+  attr_reader :current_command
+
+  ##
   # Return the authoritative instance of the command manager.
 
   def self.instance
@@ -175,6 +180,7 @@ class Gem::CommandManager
     else
       cmd_name = args.shift.downcase
       cmd = find_command cmd_name
+      @current_command = cmd.command.to_sym
       cmd.invoke_with_build_args args, build_args
       cmd.deprecation_warning if cmd.deprecated?
     end

--- a/lib/rubygems/deprecate.rb
+++ b/lib/rubygems/deprecate.rb
@@ -52,14 +52,16 @@ module Gem::Deprecate
       old = "_deprecated_#{name}"
       alias_method old, name
       define_method name do |*args, &block|
-        klass = self.kind_of? Module
-        target = klass ? "#{self}." : "#{self.class}#"
-        msg = [ "NOTE: #{target}#{name} is deprecated",
-                repl == :none ? " with no replacement" : "; use #{repl} instead",
-                ". It will be removed on or after %4d-%02d-01." % [year, month],
-                "\n#{target}#{name} called from #{Gem.location_of_caller.join(":")}",
-        ]
-        warn "#{msg.join}." unless Gem::Deprecate.skip
+        unless Gem::Deprecate.skip
+          klass = self.kind_of? Module
+          target = klass ? "#{self}." : "#{self.class}#"
+          msg = [ "NOTE: #{target}#{name} is deprecated",
+                  repl == :none ? " with no replacement" : "; use #{repl} instead",
+                  ". It will be removed on or after %4d-%02d-01." % [year, month],
+                  "\n#{target}#{name} called from #{Gem.location_of_caller.join(":")}",
+          ]
+          warn "#{msg.join}."
+        end
         send old, *args, &block
       end
     end

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -732,7 +732,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Formerly used to set rubyforge project.
 
   attr_writer :rubyforge_project
-  deprecate :rubyforge_project=, :none,       2019, 12
+  deprecate_spec :rubyforge_project=, :none, 2019, 12
 
   ##
   # The Gem::Specification version of this gemspec.


### PR DESCRIPTION
# Description:

`Specification#rubyforge_project=` is deprecated, and issues warning when loading any specs containing it.  Hence, the warning is shown when many gem commands are used.

See https://github.com/rubygems/rubygems/issues/2984

Add a `deprecate_spec` method that only warns when `gem build` is used.

I haven't looked at RG tests for quite a while, so considering this a draft.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
