### PR TITLE
Add tests to check if Gem.ruby_version works with ruby git master

### DIFF
--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1090,10 +1090,18 @@ class TestGem < Gem::TestCase
     util_restore_RUBY_VERSION
   end
 
-  def test_self_ruby_version_with_prerelease
+  def test_self_ruby_version_with_svn_prerelease
     util_set_RUBY_VERSION '2.6.0', -1, 63539, 'ruby 2.6.0preview2 (2018-05-31 trunk 63539) [x86_64-linux]'
 
     assert_equal Gem::Version.new('2.6.0.preview2'), Gem.ruby_version
+  ensure
+    util_restore_RUBY_VERSION
+  end
+
+  def test_self_ruby_version_with_git_prerelease
+    util_set_RUBY_VERSION '2.7.0', -1, 'b563439274a402e33541f5695b1bfd4ac1085638', 'ruby 2.7.0preview3 (2019-11-23 master b563439274) [x86_64-linux]'
+
+    assert_equal Gem::Version.new('2.7.0.preview3'), Gem.ruby_version
   ensure
     util_restore_RUBY_VERSION
   end
@@ -1106,10 +1114,18 @@ class TestGem < Gem::TestCase
     util_restore_RUBY_VERSION
   end
 
-  def test_self_ruby_version_with_trunk
+  def test_self_ruby_version_with_svn_trunk
     util_set_RUBY_VERSION '1.9.2', -1, 23493, 'ruby 1.9.2dev (2009-05-20 trunk 23493) [x86_64-linux]'
 
     assert_equal Gem::Version.new('1.9.2.dev'), Gem.ruby_version
+  ensure
+    util_restore_RUBY_VERSION
+  end
+
+  def test_self_ruby_version_with_git_master
+    util_set_RUBY_VERSION '2.7.0', -1, '5de284ec78220e75643f89b454ce999da0c1c195', 'ruby 2.7.0dev (2019-12-23T01:37:30Z master 5de284ec78) [x86_64-linux]'
+
+    assert_equal Gem::Version.new('2.7.0.dev'), Gem.ruby_version
   ensure
     util_restore_RUBY_VERSION
   end


### PR DESCRIPTION
# Description:

Now Ruby source code is managed under git, and `ruby -v` was slightly changed.
This PR adds two tests to check if Gem.ruby_version works with the new format of RUBY_VERSION.

https://bugs.ruby-lang.org/issues/14632
https://bugs.ruby-lang.org/issues/15843
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
