### PR TITLE
Specification - add REMOVED_METHODS, remove rubyforge_project=

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -734,14 +734,6 @@ class Gem::Specification < Gem::BasicSpecification
   attr_writer :original_platform # :nodoc:
 
   ##
-  # Deprecated and ignored.
-  #
-  # Formerly used to set rubyforge project.
-
-  attr_writer :rubyforge_project
-  deprecate :rubyforge_project=, :none,       2019, 12
-
-  ##
   # The Gem::Specification version of this gemspec.
   #
   # Do not set this, it is set automatically when the gem is packaged.

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -103,6 +103,13 @@ class Gem::Specification < Gem::BasicSpecification
      4 => 18,
   }.freeze
 
+  ##
+  # Some Specification methods/properties are deprecated and then removed.
+  # Gems installed with older RubyGems versions may have these items
+  # in their .gemspec files.  Used in #method_missing to ignore them.
+
+  REMOVED_METHODS = [:rubyforge_project=].freeze
+
   today = Time.now.utc
   TODAY = Time.utc(today.year, today.month, today.day) # :nodoc:
 
@@ -2105,6 +2112,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Warn about unknown attributes while loading a spec.
 
   def method_missing(sym, *a, &b) # :nodoc:
+    return if REMOVED_METHODS.include? sym
     if @specification_version > CURRENT_SPECIFICATION_VERSION and
       sym.to_s =~ /=$/
       warn "ignoring #{sym} loading #{full_name}" if $DEBUG


### PR DESCRIPTION
# Description:

Currently, `rubyforge_project=` is a deprecated Specification property/method.  Also, if a repo has the property in its *.gemspec file, it will not be added to a built gem's metadata.

But, if an older version of RubyGems is used to install a gem with the property in its metadata, and then a `gem update --system` is performed, almost all gem operations will emit a warning about the deprecated property.

This PR adds an array constant that contains the names of removed Specification properties/methods.   The array is then used in `Specification#method_missing` to ignore the method call.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
