### PR TITLE
Fix gem install from a gemdeps file with complex dependencies

### DIFF
--- a/lib/rubygems/request_set/gem_dependency_api.rb
+++ b/lib/rubygems/request_set/gem_dependency_api.rb
@@ -235,7 +235,7 @@ class Gem::RequestSet::GemDependencyAPI
     return unless (groups & @without_groups).empty?
 
     dependencies.each do |dep|
-      @set.gem dep.name, *dep.requirement
+      @set.gem dep.name, *dep.requirement.as_list
     end
   end
 


### PR DESCRIPTION
# Description:
closes https://github.com/rubygems/rubygems/issues/2997

Fix gem `install -g` bug when gemspec has complex version requirements and Gemfile.lock is present.

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
