### PR TITLE
Fix Gem::Specification#to_ruby without OpenSSL

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2414,7 +2414,10 @@ class Gem::Specification < Gem::BasicSpecification
   # still have their default values are omitted.
 
   def to_ruby
-    require 'openssl'
+    begin
+      require 'openssl'
+    rescue LoadError
+    end
     mark_version
     result = []
     result << "# -*- encoding: utf-8 -*-"
@@ -2454,7 +2457,9 @@ class Gem::Specification < Gem::BasicSpecification
       next if handled.include? attr_name
       current_value = self.send(attr_name)
       if current_value != default_value(attr_name) || self.class.required_attribute?(attr_name)
-        result << "  s.#{attr_name} = #{ruby_code current_value}" unless current_value.is_a?(OpenSSL::PKey::RSA)
+        unless defined?(OpenSSL) && current_value.is_a?(OpenSSL::PKey::RSA)
+          result << "  s.#{attr_name} = #{ruby_code current_value}"
+        end
       end
     end
 


### PR DESCRIPTION
# Description:

OpenSSL is an optional dependency of Ruby.  Requiring openssl
unconditionally means that Rubies that don't have the OpenSSL library
won't be able to use RubyGems at all.

In such a Ruby, an OpenSSL::PKey::RSA object can't exist, so we can
just skip the check for those objects if there is no OpenSSL.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
