### PR TITLE
Add `funding_uri ` metadata field to gemspec

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -384,6 +384,7 @@ class Gem::Specification < Gem::BasicSpecification
   #     "mailing_list_uri"  => "https://groups.example.com/bestgemever",
   #     "source_code_uri"   => "https://example.com/user/bestgemever",
   #     "wiki_uri"          => "https://example.com/user/bestgemever/wiki"
+  #     "donation_uri"      => "https://example.com/donation"
   #   }
   #
   # These links will be used on your gem's page on rubygems.org and must pass

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -384,7 +384,7 @@ class Gem::Specification < Gem::BasicSpecification
   #     "mailing_list_uri"  => "https://groups.example.com/bestgemever",
   #     "source_code_uri"   => "https://example.com/user/bestgemever",
   #     "wiki_uri"          => "https://example.com/user/bestgemever/wiki"
-  #     "donation_uri"      => "https://example.com/donation"
+  #     "funding_uri"       => "https://example.com/donate"
   #   }
   #
   # These links will be used on your gem's page on rubygems.org and must pass

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -18,7 +18,7 @@ class Gem::SpecificationPolicy
     mailing_list_uri
     source_code_uri
     wiki_uri
-    donation_uri
+    funding_uri
   ].freeze # :nodoc:
 
   def initialize(specification)

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -18,6 +18,7 @@ class Gem::SpecificationPolicy
     mailing_list_uri
     source_code_uri
     wiki_uri
+    donation_uri
   ].freeze # :nodoc:
 
   def initialize(specification)

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3533,7 +3533,7 @@ Did you mean 'Ruby'?
           "one"          => "two",
           "home"         => "three",
           "homepage_uri" => "https://example.com/user/repo",
-          "donation_uri" => "https://example.com/donation"
+          "funding_uri"  => "https://example.com/donate"
         }
       end
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3532,7 +3532,8 @@ Did you mean 'Ruby'?
         s.metadata = {
           "one"          => "two",
           "home"         => "three",
-          "homepage_uri" => "https://example.com/user/repo"
+          "homepage_uri" => "https://example.com/user/repo",
+          "donation_uri" => "https://example.com/donation"
         }
       end
 


### PR DESCRIPTION
# Description:

I want to add a new metadata field to the gemspec called `funding_uri` for the purpose of linking a page which users can view on how to donate to/sponsor gem authors.

With the introduction of [Github Sponsors](https://github.com/sponsors), [Tidlelift](https://tidelift.com/), [Open Collective](https://opencollective.com) & [Patreon](https://www.patreon.com/), donating or sponsoring a developer is now super easy and streamlined. I hope by adding this field to accomplish a number of goals:

* Similar to npmjs.org, we add a button/ui element to the gem page on rubygems.org to link visitors to the given donation uri.
* Encourage tooling to be built to list information about how to donate to gem authors for a given Gemfile, Gemfile.lock. (similar to the new `npm fund` command https://github.com/npm/cli/pull/273)
* Encourage more maintainers to signup and receive sponsorship for their work

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
