### PR TITLE
Gem metadata URLs don't support subdomains with underscore

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -389,7 +389,7 @@ class Gem::Specification < Gem::BasicSpecification
   # These links will be used on your gem's page on rubygems.org and must pass
   # validation against following regex.
   #
-  #   %r{\Ahttps?:\/\/([^\s:@]+:[^\s:@]*@)?[A-Za-z\d\-]+(\.[A-Za-z\d\-]+)+\.?(:\d{1,5})?([\/?]\S*)?\z}
+  #   %r{\Ahttps?:\/\/([^\s:@]+:[^\s:@]*@)?[A-Za-z\d\-\_]+(\.[A-Za-z\d\-\_]+)+\.?(:\d{1,5})?([\/?]\S*)?\z}
 
   attr_accessor :metadata
 

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -8,7 +8,7 @@ class Gem::SpecificationPolicy
 
   SPECIAL_CHARACTERS = /\A[#{Regexp.escape('.-_')}]+/.freeze # :nodoc:
 
-  VALID_URI_PATTERN = %r{\Ahttps?:\/\/([^\s:@]+:[^\s:@]*@)?[A-Za-z\d\-]+(\.[A-Za-z\d\-]+)+\.?(:\d{1,5})?([\/?]\S*)?\z}.freeze  # :nodoc:
+  VALID_URI_PATTERN = %r{\Ahttps?:\/\/([^\s:@]+:[^\s:@]*@)?[A-Za-z\d\-\_]+(\.[A-Za-z\d\-\_]+)+\.?(:\d{1,5})?([\/?]\S*)?\z}.freeze  # :nodoc:
 
   METADATA_LINK_KEYS = %w[
     bug_tracker_uri


### PR DESCRIPTION
A metadata URL with underscores in the subdomain in `*.gemspec` is considered invalid by `rubygems`:

```ruby
spec.metadata = {'documentation_uri' => 'https://example_workspace.gitlab.io/my_example' }
```
is rejected with:
```
The gemspec at ~/projects/my_example.gemspec is not valid. Please fix this gemspec. (Gem::InvalidSpecificationException)
The validation error was 'metadata['documentation_uri'] has invalid link: "https://example_workspace.gitlab.io/my_example"'
```
A slightly different subdomain like `example-workspace` would be accepted by the regex:

```ruby
%r{\Ahttps?:\/\/([^\s:@]+:[^\s:@]*@)?[A-Za-z\d\-]+(\.[A-Za-z\d\-]+)+\.?(:\d{1,5})?([\/?]\S*)?\z}
```

I therefore propose to change the validation regex into:

```ruby
%r{\Ahttps?:\/\/([^\s:@]+:[^\s:@]*@)?[A-Za-z\d\-\_]+(\.[A-Za-z\d\-\_]+)+\.?(:\d{1,5})?([\/?]\S*)?\z}
```
To allow for underscores in subdomains/domains.