### PR TITLE
Updates to some old gem-signing docs.

### DIFF
--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -8,7 +8,8 @@
 # Example using a Gem::Package
 #
 # Builds a .gem file given a Gem::Specification. A .gem file is a tarball
-# which contains a data.tar.gz and metadata.gz, and possibly signatures.
+# which contains a data.tar.gz, metadata.gz, checksums.yaml.gz and possibly
+# signatures.
 #
 #   require 'rubygems'
 #   require 'rubygems/package'

--- a/lib/rubygems/security.rb
+++ b/lib/rubygems/security.rb
@@ -267,7 +267,7 @@ end
 # 2. Grab the public key from the gemspec
 #
 #      gem spec some_signed_gem-1.0.gem cert_chain | \
-#        ruby -ryaml -e 'puts YAML.load_documents($stdin)' > public_key.crt
+#        ruby -ryaml -e 'puts YAML.load($stdin)' > public_key.crt
 #
 # 3. Generate a SHA1 hash of the data.tar.gz
 #

--- a/lib/rubygems/security.rb
+++ b/lib/rubygems/security.rb
@@ -62,11 +62,11 @@ end
 #
 #   $ tar tf your-gem-1.0.gem
 #   metadata.gz
-#   metadata.gz.sum
 #   metadata.gz.sig # metadata signature
 #   data.tar.gz
-#   data.tar.gz.sum
 #   data.tar.gz.sig # data signature
+#   checksums.yaml.gz
+#   checksums.yaml.gz.sig # checksums signature
 #
 # === Manually signing gems
 #

--- a/lib/rubygems/security.rb
+++ b/lib/rubygems/security.rb
@@ -161,6 +161,8 @@ end
 #     -K, --private-key KEY            Key for --sign or --build
 #     -s, --sign CERT                  Signs CERT with the key from -K
 #                                      and the certificate from -C
+#     -d, --days NUMBER_OF_DAYS        Days before the certificate expires
+#     -R, --re-sign                    Re-signs the certificate from -C with the key from -K
 #
 # We've already covered the <code>--build</code> option, and the
 # <code>--add</code>, <code>--list</code>, and <code>--remove</code> commands


### PR DESCRIPTION
# Description:

Some of the gem-signing docs are out-of-date since most of them were updated in 2012:

* `gem build` includes a single checksum file now, relpacing the old *.sum files, as of 3f2e05972c85d4f4d9cd5e56e5b033bfb4d11b84
* updates the results of the `gem help cert` command in the docs with newer flags
* replaces an old YAML method that was removed from Psych

Additional question: I almost replaced ~/.gem in these docs with ~/.ssh for storing gem signing keys, since the [Rubygems guides use ~/.ssh](https://guides.rubygems.org/security/), for consistency between docs + guides. But then I wondered "why would you store gem signing keys in an ssh folder?" and couldn't find an explanation in https://github.com/rubygems/guides/pull/70 . Curious which one would be best. 

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
