### PR TITLE
Reduce bors timeout to one hour

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -24,7 +24,7 @@ status = [
   "ubuntu_rvm (jruby-9.2.9.0)",
 ]
 
-timeout-sec = 14400
+timeout-sec = 3600
 delete_merged_branches = true
 
 [committer]


### PR DESCRIPTION
# Description:

The timeout for bors to report a timeout is excessive in my opinion. For example, #3066 has already failed due to a flaky test issue, but bors won't notify until three hours from now.