### PR TITLE
[WIP] Configure Code Climate.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,49 @@
+version: "2"
+
+# This config isn't meant to encode the state we want the codebase in.
+# It aims to highlight the most complicated or redundant parts of the
+# codebase. My aim is to make the number of issues be small enough to be
+# actionable, by making it to be more forgiving of less-urgent problems.
+#
+# We started with Code Climate flagging 379 potential issues, and a lot of
+# them are ultimately pretty low priority. Feel free to adjust these, or
+# ask me to do so, if you think it'd be useful. - @duckinator
+checks:
+  argument-count:
+    config:
+      threshold: 4
+  complex-logic:
+    config:
+      threshold: 4
+  file-lines:
+    config:
+      threshold: 750 # default=250
+  method-complexity:
+    config:
+      threshold: 20 # default=5
+  method-count:
+    config:
+      threshold: 50 # default=20
+  method-lines:
+    config:
+      threshold: 60 # default=25
+  nested-control-flow:
+    config:
+      threshold: 4
+  return-statements:
+    config:
+      threshold: 4
+  similar-code:
+    config:
+      threshold: # language-specific defaults. an override will affect all languages.
+  identical-code:
+    config:
+      threshold: # language-specific defaults. an override will affect all languages.
+
+# Disallowing all duplication often causes more trouble than it's worth.
+# Allow a few instances of similar code before Code Climate gets grumpy.
+plugins:
+  duplication:
+    enabled: true
+    config:
+      count_threshold: 3

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -1,4 +1,5 @@
 .bundle/config
+.codeclimate.yml
 .rubocop.yml
 CODE_OF_CONDUCT.md
 CONTRIBUTING.md


### PR DESCRIPTION
# Description:

Code Climate's default configuration generates a lot of low-priority
issues for the RubyGems codebase. I configured it to be a lot more relaxed,
so it focuses on the worst problems. Hopefully this will make it more
useful for focusing refactoring efforts.

NOTE: I know we don't tend to use it right now. My hope is that this will reduce the noise so we _can_ use it. :slightly_smiling_face: 
 
EDIT: Copy/pasting a clarification I made on Slack:

> my goal with 3069 isn't to make it a required check or anything. my goal is to use it as a way for people who are interested in refactoring can go to https://codeclimate.com/github/rubygems/rubygems/issues and find areas that may be worth focusing on. which is why i deliberately made the restrictions extremely loose, and have no intent to make it required. in fact, i'd love if i could find a way to view the details on individual PRs without even having it show up in the list of checks, so only the people who are interested have to worry about it.
>
> but, as you'll see if you click that link, it's so strict that it's pretty much entirely things that are relatively unimportant, but there are some useful ones scattered throughout the 379 "issues" it mentions.
>
> e.g., the default "cognitive complexity of 5" check is a tad silly [for this codebase], but if most things are <=50 and you find some that are 75+, that's worth being aware of even if you don't actually refactor it purely to deal with that problem.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
