### PR TITLE
Add .bundle/gems to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.rbc
 *.swp
 .DS_Store
+/.bundle/gems
 /.idea
 /.rdoc
 /.rvmrc


### PR DESCRIPTION
# Description:

Since we can use bundler for at least some RubyGems-related stuff now, it seems useful to ignore things installed using it.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
