### PR TITLE
Make Gem::Specification work even if openssl is unavailable

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2414,7 +2414,10 @@ class Gem::Specification < Gem::BasicSpecification
   # still have their default values are omitted.
 
   def to_ruby
-    require 'openssl'
+    begin
+      require 'openssl'
+    rescue LoadError
+    end
     mark_version
     result = []
     result << "# -*- encoding: utf-8 -*-"
@@ -2454,7 +2457,7 @@ class Gem::Specification < Gem::BasicSpecification
       next if handled.include? attr_name
       current_value = self.send(attr_name)
       if current_value != default_value(attr_name) || self.class.required_attribute?(attr_name)
-        result << "  s.#{attr_name} = #{ruby_code current_value}" unless current_value.is_a?(OpenSSL::PKey::RSA)
+        result << "  s.#{attr_name} = #{ruby_code current_value}" unless defined?(OpenSSL) && current_value.is_a?(OpenSSL::PKey::RSA)
       end
     end
 


### PR DESCRIPTION
# Description:

Currently, to_ruby always require OpenSSL, which makes "make install" of
ruby fail.

See https://bugs.ruby-lang.org/issues/16475

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
