### PR TITLE
Rakefile - Rake::TestTask - devkit is mingw, not windows

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ end
 
 Rake::TestTask.new do |t|
   t.ruby_opts = %w[-w]
-  t.ruby_opts << '-rdevkit' if Gem.win_platform?
+  t.ruby_opts << '-rdevkit' if RbConfig::CONFIG['host_os'].include?('mingw')
 
   t.libs << "test"
   t.libs << "bundler/lib"


### PR DESCRIPTION
# Description:

Currently Rake::TestTask adds `-rdevkit` to `ruby_opts` for all Windows platforms using `Gem.win_platform?`.  `devkit` is only part of publicly facing `mingw` builds, and does not exist in other Windows builds.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
