### PR TITLE
Only print month & year in deprecation messages

### DIFF
--- a/lib/rubygems/deprecate.rb
+++ b/lib/rubygems/deprecate.rb
@@ -60,7 +60,7 @@ module Gem::Deprecate
         target = klass ? "#{self}." : "#{self.class}#"
         msg = [ "NOTE: #{target}#{name} is deprecated",
                 repl == :none ? " with no replacement" : "; use #{repl} instead",
-                ". It will be removed on or after %4d-%02d-01." % [year, month],
+                ". It will be removed on or after %4d-%02d." % [year, month],
                 "\n#{target}#{name} called from #{Gem.location_of_caller.join(":")}",
         ]
         warn "#{msg.join}." unless Gem::Deprecate.skip

--- a/test/rubygems/test_deprecate.rb
+++ b/test/rubygems/test_deprecate.rb
@@ -152,6 +152,6 @@ class TestDeprecate < Gem::TestCase
     assert_match(/OtherThing#foo is deprecated; use bar instead\./, err)
     assert_match(/OtherThing#foo_arg is deprecated; use bar_arg instead\./, err)
     assert_match(/OtherThing#foo_kwarg is deprecated; use bar_kwarg instead\./, err)
-    assert_match(/on or after 2099-03-01/, err)
+    assert_match(/on or after 2099-03/, err)
   end
 end


### PR DESCRIPTION
Currently `deprecate` only supports four arguments, allowing for deprecation year and month. Attempting to supply a 'day' fails. 

```
class MyClass
  extend Gem::Deprecate
  
  def the_dying_method
  end
  deprecate :the_dying_method, :the_new_method, 2020, 5, 10
  
  def the_new_method
  end
end

#=> ArgumentError (wrong number of arguments (given 5, expected 4))
```

This supports prior implementation (day is optional) but can support more specific deprecation dates:

`NOTE: MyClass#the_dying_method is deprecated; use the_new_method instead. It will be removed on or after 2020-05-10.`

# Description:

______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
