### PR TITLE
Avoid changing $SOURCE_DATE_EPOCH.

### DIFF
--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -68,7 +68,9 @@ class Gem::Ext::Builder
       results << (command.respond_to?(:shelljoin) ? command.shelljoin : command)
 
       require "open3"
-      output, status = Open3.capture2e(*command)
+      # Set $SOURCE_DATE_EPOCH for the subprocess.
+      env = {'SOURCE_DATE_EPOCH' => Gem.source_date_epoch_string}
+      output, status = Open3.capture2e(env, *command)
       if verbose
         puts output
       else

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1906,6 +1906,24 @@ You may need to `gem install -g` to install missing gems
     assert platform_defaults.is_a? Hash
   end
 
+  # Ensure that `Gem.source_date_epoch` is consistent even if
+  # $SOURCE_DATE_EPOCH has not been set.
+  def test_default_source_date_epoch_doesnt_change
+    old_epoch = ENV['SOURCE_DATE_EPOCH']
+    ENV['SOURCE_DATE_EPOCH'] = nil
+
+    # Unfortunately, there is no real way to test this aside from waiting
+    # enough for `Time.now.to_i` to change -- which is a whole second.
+    #
+    # Fortunately, we only need to do this once.
+    a = Gem.source_date_epoch
+    sleep 1
+    b = Gem.source_date_epoch
+    assert_equal a, b
+  ensure
+    ENV['SOURCE_DATE_EPOCH'] = old_epoch
+  end
+
   def ruby_install_name(name)
     with_clean_path_to_ruby do
       orig_RUBY_INSTALL_NAME = RbConfig::CONFIG['ruby_install_name']

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -106,7 +106,7 @@ class TestGemPackage < Gem::Package::TarTestCase
     assert_equal expected, YAML.load(checksums)
   end
 
-  def test_build_time_source_date_epoch
+  def test_build_time_uses_source_date_epoch
     epoch = ENV["SOURCE_DATE_EPOCH"]
     ENV["SOURCE_DATE_EPOCH"] = "123456789"
 
@@ -124,11 +124,9 @@ class TestGemPackage < Gem::Package::TarTestCase
     ENV["SOURCE_DATE_EPOCH"] = epoch
   end
 
-  def test_build_time_source_date_epoch_automatically_set
+  def test_build_time_without_source_date_epoch
     epoch = ENV["SOURCE_DATE_EPOCH"]
     ENV["SOURCE_DATE_EPOCH"] = nil
-
-    start_time = Time.now.utc.to_i
 
     spec = Gem::Specification.new 'build', '1'
     spec.summary = 'build'
@@ -138,14 +136,11 @@ class TestGemPackage < Gem::Package::TarTestCase
 
     package = Gem::Package.new spec.file_name
 
-    end_time = Time.now.utc.to_i
-
     assert_kind_of Time, package.build_time
 
     build_time = package.build_time.to_i
 
-    assert_operator(start_time, :<=, build_time)
-    assert_operator(build_time, :<=, end_time)
+    assert_equal Gem.source_date_epoch.to_i, build_time
   ensure
     ENV["SOURCE_DATE_EPOCH"] = epoch
   end

--- a/test/rubygems/test_gem_package_tar_writer.rb
+++ b/test/rubygems/test_gem_package_tar_writer.rb
@@ -8,6 +8,11 @@ class TestGemPackageTarWriter < Gem::Package::TarTestCase
   def setup
     super
 
+    # Setting `@default_source_date_epoch` to `nil` effectively resets the
+    # value used for `Gem.source_date_epoch` whenever `$SOURCE_DATE_EPOCH`
+    # is not set.
+    Gem.instance_variable_set(:'@default_source_date_epoch', nil)
+
     @data = 'abcde12345'
     @io = TempIO.new
     @tar_writer = Gem::Package::TarWriter.new @io

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -83,6 +83,11 @@ end
   def setup
     super
 
+    # Setting `@default_source_date_epoch` to `nil` effectively resets the
+    # value used for `Gem.source_date_epoch` whenever `$SOURCE_DATE_EPOCH`
+    # is not set.
+    Gem.instance_variable_set(:'@default_source_date_epoch', nil)
+
     @a1 = util_spec 'a', '1' do |s|
       s.executable = 'exec'
       s.test_file = 'test/suite.rb'


### PR DESCRIPTION
# Description:

Avoid changing $SOURCE_DATE_EPOCH.

- Gem.source_date_epoch no longer sets any environment variables.
- Gem::Ext::Builder sets $SOURCE_DATE_EPOCH for subprocesses.
- If $SOURCE_DATE_EPOCH is unset while the program is running, it reverts
  to using the time when `Gem.source_date_epoch_string` was first called.
- Added test to confirm that `Gem.source_date_epoch` stays stable over time,
  even when $SOURCE_DATE_EPOCH is not set.
- Updated tests that made now-invalid assumptions.
- Add slight kludge to part of the test suite so `Gem.source_date_epoch`
  is regenerated for each test.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
