### PR TITLE
Fix error when trying to find bundler with a deleted "working directo…

### DIFF
--- a/lib/rubygems/bundler_version_finder.rb
+++ b/lib/rubygems/bundler_version_finder.rb
@@ -82,7 +82,15 @@ To install the missing version, run `gem install bundler:#{vr.first}`
   def self.lockfile_contents
     gemfile = ENV["BUNDLE_GEMFILE"]
     gemfile = nil if gemfile && gemfile.empty?
-    Gem::Util.traverse_parents Dir.pwd do |directory|
+
+    pwd = begin
+            Dir.pwd
+          rescue Errno::ENOENT
+            Dir.chdir
+            Dir.pwd
+          end
+
+    Gem::Util.traverse_parents(pwd) do |directory|
       next unless gemfile = Gem::GEM_DEP_FILES.find { |f| File.file?(f.tap(&Gem::UNTAINT)) }
 
       gemfile = File.join directory, gemfile

--- a/test/rubygems/test_gem_bundler_version_finder.rb
+++ b/test/rubygems/test_gem_bundler_version_finder.rb
@@ -80,11 +80,16 @@ class TestGemBundlerVersionFinder < Gem::TestCase
 
   def test_deleted_directory
     skip "Cannot perform this test on windows" if win_platform?
-
     require "tmpdir"
 
-    Dir.mktmpdir("some_dir") do |dir|
-      Dir.chdir(dir)
+    orig_dir = Dir.pwd
+
+    begin
+      Dir.mktmpdir("some_dir") do |dir|
+        Dir.chdir(dir)
+      end
+    ensure
+      Dir.chdir(orig_dir)
     end
 
     assert_nil bvf.bundler_version_with_reason

--- a/test/rubygems/test_gem_bundler_version_finder.rb
+++ b/test/rubygems/test_gem_bundler_version_finder.rb
@@ -78,6 +78,16 @@ class TestGemBundlerVersionFinder < Gem::TestCase
     end
   end
 
+  def test_deleted_directory
+    require "tmpdir"
+
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir)
+    end
+
+    assert_nil bvf.bundler_version_with_reason
+  end
+
   def test_compatible
     assert bvf.compatible?(util_spec("foo"))
     assert bvf.compatible?(util_spec("bundler", 1.1))

--- a/test/rubygems/test_gem_bundler_version_finder.rb
+++ b/test/rubygems/test_gem_bundler_version_finder.rb
@@ -79,9 +79,11 @@ class TestGemBundlerVersionFinder < Gem::TestCase
   end
 
   def test_deleted_directory
+    skip "Cannot perform this test on windows" if win_platform?
+
     require "tmpdir"
 
-    Dir.mktmpdir do |dir|
+    Dir.mktmpdir("some_dir") do |dir|
       Dir.chdir(dir)
     end
 


### PR DESCRIPTION
closes https://github.com/rubygems/rubygems/issues/3087

# Description:
Fix and error in the Bundler version finder when run in a deleted `current working directory` 
______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
