### PR TITLE
Get master's CI fixed

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -24,7 +24,7 @@ status = [
   "ubuntu_rvm (jruby-9.2.9.0)",
 ]
 
-timeout-sec = 3600
+timeout_sec = 3600
 delete_merged_branches = true
 
 [committer]

--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -25,6 +25,7 @@ status = [
 ]
 
 timeout_sec = 3600
+prerun_timeout_sec = 3600
 delete_merged_branches = true
 
 [committer]

--- a/.github/workflows/ubuntu-rvm.yml
+++ b/.github/workflows/ubuntu-rvm.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   ubuntu_rvm:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     env:
       CLASSPATH: ""
     strategy:

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -56,6 +56,7 @@ bundler/lib/bundler/cli/update.rb
 bundler/lib/bundler/cli/viz.rb
 bundler/lib/bundler/compact_index_client.rb
 bundler/lib/bundler/compact_index_client/cache.rb
+bundler/lib/bundler/compact_index_client/gem_parser.rb
 bundler/lib/bundler/compact_index_client/updater.rb
 bundler/lib/bundler/constants.rb
 bundler/lib/bundler/current_ruby.rb
@@ -158,8 +159,10 @@ bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
 bundler/lib/bundler/templates/newgem/rspec.tt
 bundler/lib/bundler/templates/newgem/spec/newgem_spec.rb.tt
 bundler/lib/bundler/templates/newgem/spec/spec_helper.rb.tt
-bundler/lib/bundler/templates/newgem/test/newgem_test.rb.tt
-bundler/lib/bundler/templates/newgem/test/test_helper.rb.tt
+bundler/lib/bundler/templates/newgem/test/minitest/newgem_test.rb.tt
+bundler/lib/bundler/templates/newgem/test/minitest/test_helper.rb.tt
+bundler/lib/bundler/templates/newgem/test/test-unit/newgem_test.rb.tt
+bundler/lib/bundler/templates/newgem/test/test-unit/test_helper.rb.tt
 bundler/lib/bundler/templates/newgem/travis.yml.tt
 bundler/lib/bundler/ui.rb
 bundler/lib/bundler/ui/rg_proxy.rb


### PR DESCRIPTION
# Description:

CI is broken at the moment. This PR tries to fix it.

In particular,

* TravisCI has stopped providing precompiled ruby-head rubies for ubuntu 18.04, so switch to 16.04 in that particular workflow temporarily.
* Bundler CI was broken by a bad rack release. We locked the rack version in bundler, so pick up that fix in here too by vendoring bundler's current master.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
