### PR TITLE
Pass `--no-document` to `rake install`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -97,7 +97,7 @@ end
 
 desc "Install rubygems to local system"
 task :install => [:clear_package, :package] do
-  sh "ruby -Ilib bin/gem install pkg/rubygems-update-#{v}.gem && update_rubygems"
+  sh "ruby -Ilib bin/gem install pkg/rubygems-update-#{v}.gem && update_rubygems --no-document"
 end
 
 desc "Clears previously built package"


### PR DESCRIPTION
# Description:

Sometimes the CI workflow that tests local installation of the development copy of rubygems is hanging under jruby. The hang is happening on documentation generation. Since that's not the original focus of this test, I'll stop generating docs there to see if that fixes the flakyness. 

See https://github.com/rubygems/rubygems/runs/408668674?check_suite_focus=true for the last example.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
