### PR TITLE
Fix TestCase#have_git? on Windows - test_case.rb

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,10 +25,7 @@ jobs:
         run: TEST_TOOL=rubygems util/ci.sh before_script
         shell: bash
       - name: Run Test
-        # create a symlink for git to a folder without a space, needed for CI only
         run: |
-          New-Item -Path "C:\git" -ItemType Junction -Value "C:\Program Files\Git" 1> $null
-          $env:GIT = "C:\git\cmd\git.exe"
           ridk enable
           rake test
     timeout-minutes: 15

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -340,7 +340,7 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
                    ruby
                  end
 
-    @git = ENV['GIT'] || 'git'
+    @git = ENV['GIT'] || (win_platform? ? 'git.exe' : 'git')
 
     Gem.ensure_gem_subdirectories @gemhome
 


### PR DESCRIPTION
# Description:

RG determines if 'git' exists by file existence. Fix that on Windows. Supersedes #3064.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
