### PR TITLE
Use absolute paths with autoload

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1366,23 +1366,23 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
   MARSHAL_SPEC_DIR = "quick/Marshal.#{Gem.marshal_version}/".freeze
 
-  autoload :BundlerVersionFinder, 'rubygems/bundler_version_finder'
-  autoload :ConfigFile,         'rubygems/config_file'
-  autoload :Dependency,         'rubygems/dependency'
-  autoload :DependencyList,     'rubygems/dependency_list'
-  autoload :Installer,          'rubygems/installer'
-  autoload :Licenses,           'rubygems/util/licenses'
-  autoload :PathSupport,        'rubygems/path_support'
-  autoload :Platform,           'rubygems/platform'
-  autoload :RequestSet,         'rubygems/request_set'
-  autoload :Requirement,        'rubygems/requirement'
-  autoload :Resolver,           'rubygems/resolver'
-  autoload :Source,             'rubygems/source'
-  autoload :SourceList,         'rubygems/source_list'
-  autoload :SpecFetcher,        'rubygems/spec_fetcher'
-  autoload :Specification,      'rubygems/specification'
-  autoload :Util,               'rubygems/util'
-  autoload :Version,            'rubygems/version'
+  autoload :BundlerVersionFinder, File.expand_path('rubygems/bundler_version_finder', __dir__)
+  autoload :ConfigFile,         File.expand_path('rubygems/config_file', __dir__)
+  autoload :Dependency,         File.expand_path('rubygems/dependency', __dir__)
+  autoload :DependencyList,     File.expand_path('rubygems/dependency_list', __dir__)
+  autoload :Installer,          File.expand_path('rubygems/installer', __dir__)
+  autoload :Licenses,           File.expand_path('rubygems/util/licenses', __dir__)
+  autoload :PathSupport,        File.expand_path('rubygems/path_support', __dir__)
+  autoload :Platform,           File.expand_path('rubygems/platform', __dir__)
+  autoload :RequestSet,         File.expand_path('rubygems/request_set', __dir__)
+  autoload :Requirement,        File.expand_path('rubygems/requirement', __dir__)
+  autoload :Resolver,           File.expand_path('rubygems/resolver', __dir__)
+  autoload :Source,             File.expand_path('rubygems/source', __dir__)
+  autoload :SourceList,         File.expand_path('rubygems/source_list', __dir__)
+  autoload :SpecFetcher,        File.expand_path('rubygems/spec_fetcher', __dir__)
+  autoload :Specification,      File.expand_path('rubygems/specification', __dir__)
+  autoload :Util,               File.expand_path('rubygems/util', __dir__)
+  autoload :Version,            File.expand_path('rubygems/version', __dir__)
 
   require "rubygems/specification"
 end

--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -151,7 +151,7 @@
 
 class Gem::Version
 
-  autoload :Requirement, 'rubygems/requirement'
+  autoload :Requirement, File.expand_path('requirement', __dir__)
 
   include Comparable
 


### PR DESCRIPTION
# Description:

Fixes the following flaky test failure under ruby 2.4:

```
$ rake TESTOPTS="--name=/\(test_activate_via_require_respects_loaded_files\|test_validate_license_values_or_later\)/ --seed=16773"
Run options: "--name=/(test_activate_via_require_respects_loaded_files|test_validate_license_values_or_later)/" --seed=16773

# Running:

.F

Finished in 0.110757s, 18.0575 runs/s, 63.2012 assertions/s.

  1) Failure:
TestGemSpecification#test_validate_license_values_or_later [/home/deivid/Code/rubygems/test/rubygems/test_gem_specification.rb:3159]:
Expected "WARNING:  license value 'GPL-2.0-or-later' is invalid.  Use a license identifier from\n" +
"http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.\n" +
"Did you mean 'GPL-2.0', 'GPL-2.0+'?\n" +
"WARNING:  See https://guides.rubygems.org/specification-reference/ for help\n" to be empty.

2 runs, 7 assertions, 1 failures, 0 errors, 0 skips
rake aborted!
Command failed with status (1)

Tasks: TOP => default => test
(See full trace by running task with --trace)
```

The first test removes `lib/` from the $LOAD_PATH for the duration of the test. During the test, `Gem::Licenses` is autoloaded, but since `lib` is not in the $LOAD_PATH, it's autoloaded from the rubygems version that comes with the ruby installation (rubygems 2.6). In that rubygems version, `GPL-2.0-or-later` was not part of the list of licenses, so the following spec about licenses validation fails.

To fix it, we stop relying on the $LOAD_PATH for the `Gem::Licenses` autoload. For consistency, I also migrated the rest of the autoload's.

Closes #3095.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
