### PR TITLE
Remove Gem::UserInteraction#debug method

### DIFF
--- a/lib/rubygems/user_interaction.rb
+++ b/lib/rubygems/user_interaction.rb
@@ -359,14 +359,6 @@ class Gem::StreamUI
   end
 
   ##
-  # Display a debug message on the same location as error messages.
-
-  def debug(statement)
-    @errs.puts statement
-  end
-  deprecate :debug, :none, 2018, 12
-
-  ##
   # Terminate the application with exit code +status+, running any exit
   # handlers that might have been defined.
 


### PR DESCRIPTION
# Description:
Removes deprecated `Remove Gem::UserInteraction#debug`
______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
