### PR TITLE
Rework plugins system and speed up rubygems

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -398,6 +398,7 @@ lib/rubygems/install_message.rb
 lib/rubygems/install_update_options.rb
 lib/rubygems/installer.rb
 lib/rubygems/installer_test_case.rb
+lib/rubygems/installer_uninstaller_utils.rb
 lib/rubygems/local_remote_options.rb
 lib/rubygems/mock_gem_ui.rb
 lib/rubygems/name_tuple.rb

--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -280,6 +280,13 @@ class Gem::BasicSpecification
   end
 
   ##
+  # Returns the list of plugins in this spec.
+
+  def plugins
+    matches_for_glob("rubygems#{Gem.plugin_suffix_pattern}")
+  end
+
+  ##
   # Returns a string usable in Dir.glob to match all requirable paths
   # for this spec.
 

--- a/lib/rubygems/commands/pristine_command.rb
+++ b/lib/rubygems/commands/pristine_command.rb
@@ -40,6 +40,11 @@ class Gem::Commands::PristineCommand < Gem::Command
       options[:only_executables] = value
     end
 
+    add_option('--only-plugins',
+               'Only restore plugins') do |value, options|
+      options[:only_plugins] = value
+    end
+
     add_option('-E', '--[no-]env-shebang',
                'Rewrite executables with a shebang',
                'of /usr/bin/env') do |value, options|
@@ -126,14 +131,14 @@ extensions will be restored.
         end
       end
 
-      unless spec.extensions.empty? or options[:extensions] or options[:only_executables]
+      unless spec.extensions.empty? or options[:extensions] or options[:only_executables] or options[:only_plugins]
         say "Skipped #{spec.full_name}, it needs to compile an extension"
         next
       end
 
       gem = spec.cache_file
 
-      unless File.exist? gem or options[:only_executables]
+      unless File.exist? gem or options[:only_executables] or options[:only_plugins]
         require 'rubygems/remote_fetcher'
 
         say "Cached gem for #{spec.full_name} not found, attempting to fetch..."
@@ -172,6 +177,9 @@ extensions will be restored.
       if options[:only_executables]
         installer = Gem::Installer.for_spec(spec, installer_options)
         installer.generate_bin
+      elsif options[:only_plugins]
+        installer = Gem::Installer.for_spec(spec)
+        installer.generate_plugins
       else
         installer = Gem::Installer.at(gem, installer_options)
         installer.install

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -20,7 +20,8 @@ class Gem::Commands::SetupCommand < Gem::Command
           :force => true,
           :site_or_vendor => 'sitelibdir',
           :destdir => '', :prefix => '', :previous_version => '',
-          :regenerate_binstubs => true
+          :regenerate_binstubs => true,
+          :regenerate_plugins => true
 
     add_option '--previous-version=VERSION',
                'Previous version of RubyGems',
@@ -87,6 +88,11 @@ class Gem::Commands::SetupCommand < Gem::Command
     add_option '--[no-]regenerate-binstubs',
                'Regenerate gem binstubs' do |value, options|
       options[:regenerate_binstubs] = value
+    end
+
+    add_option '--[no-]regenerate-plugins',
+               'Regenerate gem plugins' do |value, options|
+      options[:regenerate_plugins] = value
     end
 
     add_option '-f', '--[no-]force',
@@ -181,6 +187,7 @@ By default, this RubyGems will install gem as:
     say "RubyGems #{Gem::VERSION} installed"
 
     regenerate_binstubs if options[:regenerate_binstubs]
+    regenerate_plugins if options[:regenerate_plugins]
 
     uninstall_old_gemcutter
 
@@ -621,6 +628,16 @@ abort "#{deprecation_message}"
     if options[:env_shebang]
       args << "--env-shebang"
     end
+
+    command = Gem::Commands::PristineCommand.new
+    command.invoke(*args)
+  end
+
+  def regenerate_plugins
+    require "rubygems/commands/pristine_command"
+    say "Regenerating plugins"
+
+    args = %w[--all --only-plugins --silent]
 
     command = Gem::Commands::PristineCommand.new
     command.invoke(*args)

--- a/lib/rubygems/doctor.rb
+++ b/lib/rubygems/doctor.rb
@@ -26,6 +26,7 @@ class Gem::Doctor
     ['doc',            ''],
     ['extensions',     ''],
     ['gems',           ''],
+    ['plugins',        ''],
   ].freeze
 
   missing =
@@ -112,6 +113,7 @@ class Gem::Doctor
       next if installed_specs.include? basename
       next if /^rubygems-\d/ =~ basename
       next if 'specifications' == sub_directory and 'default' == basename
+      next if 'plugins' == sub_directory and Gem.plugin_suffix_regexp =~ basename
 
       type = File.directory?(child) ? 'directory' : 'file'
 

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -520,7 +520,7 @@ class Gem::Installer
   end
 
   def generate_plugins # :nodoc:
-    latest = Gem::Specification.latest_specs(true).find { |installed_spec| installed_spec.name == spec.name }
+    latest = Gem::Specification.latest_spec_for(spec.name)
     return if latest && latest.version > spec.version
 
     if spec.plugins.empty?

--- a/lib/rubygems/installer_uninstaller_utils.rb
+++ b/lib/rubygems/installer_uninstaller_utils.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+##
+# Helper methods for both Gem::Installer and Gem::Uninstaller
+
+module Gem::InstallerUninstallerUtils
+
+  def regenerate_plugins_for(spec)
+    spec.plugins.each do |plugin|
+      plugin_script_path = File.join Gem.plugins_dir, "#{spec.name}_plugin#{File.extname(plugin)}"
+
+      File.open plugin_script_path, 'wb' do |file|
+        file.puts "require '#{plugin}'"
+      end
+
+      verbose plugin_script_path
+    end
+  end
+
+  def remove_plugins_for(spec)
+    FileUtils.rm_f Gem::Util.glob_files_in_dir("#{spec.name}#{Gem.plugin_suffix_pattern}", Gem.plugins_dir)
+  end
+
+end

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1087,6 +1087,13 @@ class Gem::Specification < Gem::BasicSpecification
     _latest_specs Gem::Specification._all, prerelease
   end
 
+  ##
+  # Return the latest installed spec for gem +name+.
+
+  def self.latest_spec_for(name)
+    latest_specs(true).find { |installed_spec| installed_spec.name == name }
+  end
+
   def self._latest_specs(specs, prerelease = false) # :nodoc:
     result = Hash.new { |h,k| h[k] = {} }
     native = {}

--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -288,7 +288,7 @@ class Gem::Uninstaller
   # Regenerates plugin wrappers after removal.
 
   def regenerate_plugins
-    latest = Gem::Specification.latest_specs(true).find { |installed_spec| installed_spec.name == @spec.name }
+    latest = Gem::Specification.latest_spec_for(@spec.name)
     return if latest.nil?
 
     regenerate_plugins_for(latest)

--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -171,7 +171,7 @@ class Gem::Uninstaller
   # Removes installed executables and batch files (windows only) for +spec+.
 
   def remove_executables(spec)
-    return if spec.nil? or spec.executables.empty?
+    return if spec.executables.empty?
 
     executables = spec.executables.clone
 

--- a/test/rubygems/test_gem_commands_pristine_command.rb
+++ b/test/rubygems/test_gem_commands_pristine_command.rb
@@ -490,6 +490,42 @@ class TestGemCommandsPristineCommand < Gem::TestCase
     refute File.exist? gem_lib
   end
 
+  def test_execute_only_plugins
+    a = util_spec 'a' do |s|
+      s.executables = %w[foo]
+      s.files = %w[bin/foo lib/a.rb lib/rubygems_plugin.rb]
+    end
+    write_file File.join(@tempdir, 'lib', 'a.rb') do |fp|
+      fp.puts "puts __FILE__"
+    end
+    write_file File.join(@tempdir, 'lib', 'rubygems_plugin.rb') do |fp|
+      fp.puts "puts __FILE__"
+    end
+    write_file File.join(@tempdir, 'bin', 'foo') do |fp|
+      fp.puts "#!/usr/bin/ruby"
+    end
+
+    install_gem a
+
+    gem_lib = File.join @gemhome, 'gems', a.full_name, 'lib', 'a.rb'
+    gem_plugin = File.join @gemhome, 'plugins', 'a_plugin.rb'
+    gem_exec = File.join @gemhome, 'bin', 'foo'
+
+    FileUtils.rm gem_exec
+    FileUtils.rm gem_plugin
+    FileUtils.rm gem_lib
+
+    @cmd.handle_options %w[--all --only-plugins]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    refute File.exist? gem_exec
+    assert File.exist? gem_plugin
+    refute File.exist? gem_lib
+  end
+
   def test_execute_bindir
     a = util_spec 'a' do |s|
       s.name = "test_gem"

--- a/test/rubygems/test_gem_doctor.rb
+++ b/test/rubygems/test_gem_doctor.rb
@@ -153,6 +153,34 @@ This directory does not appear to be a RubyGems repository, skipping
     assert true # count
   end
 
+  def test_doctor_badly_named_plugins
+    gem 'a'
+
+    Gem.use_paths @gemhome.to_s
+
+    FileUtils.mkdir_p Gem.plugins_dir
+    bad_plugin = File.join(Gem.plugins_dir, "a_badly_named_file.rb")
+    write_file bad_plugin
+
+    doctor = Gem::Doctor.new @gemhome
+
+    capture_io do
+      use_ui @ui do
+        doctor.doctor
+      end
+    end
+
+    # refute_path_exists bad_plugin
+
+    expected = <<-OUTPUT
+Checking #{@gemhome}
+Removed file plugins/a_badly_named_file.rb
+
+    OUTPUT
+
+    assert_equal expected, @ui.output
+  end
+
   def test_gem_repository_eh
     doctor = Gem::Doctor.new @gemhome
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -744,6 +744,70 @@ gem 'other', version
     assert_match(/#{default_shebang}/, shebang_line)
   end
 
+  def test_generate_plugins
+    installer = util_setup_installer do |spec|
+      write_file File.join(@tempdir, 'lib', 'rubygems_plugin.rb') do |io|
+        io.write "puts __FILE__"
+      end
+
+      spec.files += %w[lib/rubygems_plugin.rb]
+    end
+
+    build_rake_in do
+      installer.install
+    end
+
+    plugin_path = File.join Gem.plugins_dir, 'a_plugin.rb'
+
+    FileUtils.rm plugin_path
+
+    installer.generate_plugins
+
+    assert File.exist?(plugin_path), 'plugin not written'
+  end
+
+  def test_keeps_plugins_up_to_date
+    # NOTE: version a-2 is already installed by setup hooks
+
+    write_file File.join(@tempdir, 'lib', 'rubygems_plugin.rb') do |io|
+      io.write "puts __FILE__"
+    end
+
+    build_rake_in do
+      util_setup_installer do |spec|
+        spec.version = '1'
+        spec.files += %w[lib/rubygems_plugin.rb]
+      end.install
+
+      plugin_path = File.join Gem.plugins_dir, 'a_plugin.rb'
+      refute File.exist?(plugin_path), 'old version installed while newer version without plugin also installed, but plugin written'
+
+      util_setup_installer do |spec|
+        spec.version = '2'
+        spec.files += %w[lib/rubygems_plugin.rb]
+      end.install
+
+      plugin_path = File.join Gem.plugins_dir, 'a_plugin.rb'
+      assert File.exist?(plugin_path), 'latest version reinstalled, but plugin not written'
+      assert_match %r{\Arequire.*a-2/lib/rubygems_plugin\.rb}, File.read(plugin_path), 'written plugin has incorrect content'
+
+      util_setup_installer do |spec|
+        spec.version = '3'
+        spec.files += %w[lib/rubygems_plugin.rb]
+      end.install
+
+      plugin_path = File.join Gem.plugins_dir, 'a_plugin.rb'
+      assert File.exist?(plugin_path), 'latest version installed, but plugin removed'
+      assert_match %r{\Arequire.*a-3/lib/rubygems_plugin\.rb}, File.read(plugin_path), 'written plugin has incorrect content'
+
+      util_setup_installer do |spec|
+        spec.version = '4'
+      end.install
+
+      refute File.exist?(plugin_path), 'new version installed without a plugin while older version with a plugin installed, but plugin not removed'
+    end
+  end
+
   def test_initialize
     spec = util_spec 'a' do |s|
       s.platform = Gem::Platform.new 'mswin32'

--- a/test/rubygems/test_gem_uninstaller.rb
+++ b/test/rubygems/test_gem_uninstaller.rb
@@ -169,6 +169,41 @@ class TestGemUninstaller < Gem::InstallerTestCase
     end
   end
 
+  def test_remove_plugins
+    write_file File.join(@tempdir, 'lib', 'rubygems_plugin.rb') do |io|
+      io.write "puts __FILE__"
+    end
+
+    @spec.files += %w[lib/rubygems_plugin.rb]
+
+    Gem::Installer.at(Gem::Package.build(@spec)).install
+
+    plugin_path = File.join Gem.plugins_dir, 'a_plugin.rb'
+    assert File.exist?(plugin_path), 'plugin not written'
+
+    Gem::Uninstaller.new(nil).remove_plugins @spec
+
+    refute File.exist?(plugin_path), 'plugin not removed'
+  end
+
+  def test_regenerate_plugins_for
+    write_file File.join(@tempdir, 'lib', 'rubygems_plugin.rb') do |io|
+      io.write "puts __FILE__"
+    end
+
+    @spec.files += %w[lib/rubygems_plugin.rb]
+
+    Gem::Installer.at(Gem::Package.build(@spec)).install
+
+    plugin_path = File.join Gem.plugins_dir, 'a_plugin.rb'
+    assert File.exist?(plugin_path), 'plugin not written'
+
+    FileUtils.rm plugin_path
+    Gem::Uninstaller.new(nil).regenerate_plugins_for @spec
+
+    assert File.exist?(plugin_path), 'plugin not regenerated'
+  end
+
   def test_path_ok_eh
     uninstaller = Gem::Uninstaller.new nil
 
@@ -569,6 +604,46 @@ create_makefile '#{@spec.name}'
         uninstaller.uninstall
       end
     end
+  end
+
+  def test_uninstall_keeps_plugins_up_to_date
+    write_file File.join(@tempdir, 'lib', 'rubygems_plugin.rb') do |io|
+      io.write "puts __FILE__"
+    end
+
+    plugin_path = File.join Gem.plugins_dir, 'a_plugin.rb'
+
+    @spec.version = '1'
+    Gem::Installer.at(Gem::Package.build(@spec)).install
+
+    refute File.exist?(plugin_path), 'version without plugin installed, but plugin written'
+
+    @spec.files += %w[lib/rubygems_plugin.rb]
+    @spec.version = '2'
+    Gem::Installer.at(Gem::Package.build(@spec)).install
+
+    assert File.exist?(plugin_path), 'version with plugin installed, but plugin not written'
+    assert_match %r{\Arequire.*a-2/lib/rubygems_plugin\.rb}, File.read(plugin_path), 'written plugin has incorrect content'
+
+    @spec.version = '3'
+    Gem::Installer.at(Gem::Package.build(@spec)).install
+
+    assert File.exist?(plugin_path), 'version with plugin installed, but plugin removed'
+    assert_match %r{\Arequire.*a-3/lib/rubygems_plugin\.rb}, File.read(plugin_path), 'old version installed, but plugin updated'
+
+    Gem::Uninstaller.new('a', :version => '1', :executables => true).uninstall
+
+    assert File.exist?(plugin_path), 'plugin removed when old version uninstalled'
+    assert_match %r{\Arequire.*a-3/lib/rubygems_plugin\.rb}, File.read(plugin_path), 'old version uninstalled, but plugin updated'
+
+    Gem::Uninstaller.new('a', version: '3', :executables => true).uninstall
+
+    assert File.exist?(plugin_path), 'plugin removed when old version uninstalled and another version with plugin still present'
+    assert_match %r{\Arequire.*a-2/lib/rubygems_plugin\.rb}, File.read(plugin_path), 'latest version uninstalled, but plugin not updated to previous version'
+
+    Gem::Uninstaller.new('a', version: '2', :executables => true).uninstall
+
+    refute File.exist?(plugin_path), 'last version uninstalled, but plugin still present'
   end
 
 end


### PR DESCRIPTION
# Description:

I'm pretty excited about this work. The idea is to speed up rubygems require time. This is the improvement in my computer:

#### Before

```
$ time gem env version
NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.
Gem::Specification#rubyforge_project= called from /home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/specifications/erubis-2.7.0.gemspec:17.
3.1.2

real	0m0,235s
user	0m0,230s
sys	0m0,007s
```

#### After

```
$ time gem env version
3.2.0.pre1

real	0m0,103s
user	0m0,099s
sys	0m0,007s
```

### The current (slow) rubygems plugin system

The idea comes from noticing that the rubygems plugin system is quite heavy because everytime rubygems is required, it looks in _all_ installed gems for files named `rubygems_plugin.rb`, so that it can load them. This is not just a simple system file search, rubygems also needs to evaluate every gemspec, to know what the `require_paths` for each gem are, and look for a `rubygems_plugin.rb` file in there.

As you can imagine, this is quite inefficient. And also, it explains why simple commands such as `gem env version` print warnings about deprecated gemspec syntax (#2984).

### The new (faster) rubygems plugin system

Instead, I propose to keep rubygems plugins in a well known location, so when rubygems is required, it simply needs to require whatever plugins are in there. This is, of course, much faster and does not require to look for files or evaluate gemspecs.

The tricky part is to keep this new plugins location up to date. To achieve that, we do something similar to what's currently done with binstubs. When we install a gem, we also install a plugin wrapper in there that simply requires the plugin inside the gem. When we uninstall it, we also delete that wrapper. `gem update --system` regenerates plugins, automatically migrating rubygems to the new layout.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).


