### PR TITLE
Remove options from Gem::GemRunner.new

### DIFF
--- a/lib/rubygems/gem_runner.rb
+++ b/lib/rubygems/gem_runner.rb
@@ -26,13 +26,9 @@ Gem.load_env_plugins rescue nil
 
 class Gem::GemRunner
 
-  def initialize(options={})
-    if !options.empty? && !Gem::Deprecate.skip
-      Kernel.warn "NOTE: passing options to Gem::GemRunner.new is deprecated with no replacement. It will be removed on or after 2016-10-01."
-    end
-
-    @command_manager_class = options[:command_manager] || Gem::CommandManager
-    @config_file_class = options[:config_file] || Gem::ConfigFile
+  def initialize
+    @command_manager_class = Gem::CommandManager
+    @config_file_class = Gem::ConfigFile
   end
 
   ##


### PR DESCRIPTION
# Description:

Remove passing options to `Gem::GemRunner.new` 

It was supposed to be deprecated in `2016`
______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
