### PR TITLE
Remove deprecated Gem::RemoteFetcher#fetch_size

### DIFF
--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -7,7 +7,6 @@ require 'rubygems/uri_formatter'
 require 'rubygems/uri_parsing'
 require 'rubygems/user_interaction'
 require 'resolv'
-require 'rubygems/deprecate'
 
 ##
 # RemoteFetcher handles the details of fetching gems and gem information from
@@ -16,8 +15,6 @@ require 'rubygems/deprecate'
 class Gem::RemoteFetcher
 
   include Gem::UserInteraction
-  extend Gem::Deprecate
-
   include Gem::UriParsing
 
   ##
@@ -308,17 +305,6 @@ class Gem::RemoteFetcher
 
     data
   end
-
-  ##
-  # Returns the size of +uri+ in bytes.
-
-  def fetch_size(uri)
-    response = fetch_path(uri, nil, true)
-
-    response['content-length'].to_i
-  end
-
-  deprecate :fetch_size, :none, 2019, 12
 
   ##
   # Performs a Net::HTTP request of type +request_class+ on +uri+ returning

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -164,7 +164,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     assert_equal 'uri scheme is invalid: nil', e.message
   end
 
-  def test_fetch_size_socket_error
+  def test_fetch_path_socket_error
     fetcher = Gem::RemoteFetcher.new nil
     @fetcher = fetcher
     def fetcher.request(uri, request_class, last_modified = nil)
@@ -173,9 +173,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
 
     uri = 'http://gems.example.com/yaml'
     e = assert_raises Gem::RemoteFetcher::FetchError do
-      Gem::Deprecate.skip_during do
-        fetcher.fetch_size uri
-      end
+      @fetcher.fetch_path(uri, nil, true)
     end
 
     assert_equal "SocketError: oops (#{uri})", e.message

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -153,14 +153,12 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     assert_equal proxy_uri, fetcher.instance_variable_get(:@proxy).to_s
   end
 
-  def test_fetch_size_bad_uri
+  def test_fetch_path_bad_uri
     fetcher = Gem::RemoteFetcher.new nil
     @fetcher = fetcher
 
     e = assert_raises ArgumentError do
-      Gem::Deprecate.skip_during do
-        fetcher.fetch_size 'gems.example.com/yaml'
-      end
+      @fetcher.fetch_path("gems.example.com/yaml", nil, true)
     end
 
     assert_equal 'uri scheme is invalid: nil', e.message

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -182,9 +182,8 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
   def test_no_proxy
     use_ui @stub_ui do
       assert_data_from_server @fetcher.fetch_path(@server_uri)
-      Gem::Deprecate.skip_during do
-        assert_equal SERVER_DATA.size, @fetcher.fetch_size(@server_uri)
-      end
+      response = @fetcher.fetch_path(@server_uri, nil, true)
+      assert_equal SERVER_DATA.size, response['content-length'].to_i
     end
   end
 


### PR DESCRIPTION
# Description:
Remove `Gem::RemoteFetcher#fetch_size` and modify remote fetcher tests to use `fetch_path` instead
______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
