### PR TITLE
Remove functionality to create an Gem::Installer object with a string

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -180,15 +180,7 @@ class Gem::Installer
     require 'fileutils'
 
     @options = options
-    if package.is_a? String
-      security_policy = options[:security_policy]
-      @package = Gem::Package.new package, security_policy
-      if $VERBOSE
-        warn "constructing an Installer object with a string is deprecated. Please use Gem::Installer.at (called from: #{caller.first})"
-      end
-    else
-      @package = package
-    end
+    @package = package
 
     process_options
 


### PR DESCRIPTION
# Description:

This deprecation warning has been showing since `2015`
```shell
de3f8d0de lib/rubygems/installer.rb          (Aaron Patterson       2015-04-10 14:20:44 -0700 187)         warn "constructing an Installer object with a string is deprecated. Please use Gem::Installer.at (called from: #{caller.first})"
```
 Maybe it's time to actually remove functionality to create `Gem::Installer` objects with a string.
______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
