### PR TITLE
Requiring rubygems/source_specific_file is deprecated, remove it.

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -495,7 +495,6 @@ lib/rubygems/source/specific_file.rb
 lib/rubygems/source/vendor.rb
 lib/rubygems/source_list.rb
 lib/rubygems/source_local.rb
-lib/rubygems/source_specific_file.rb
 lib/rubygems/spec_fetcher.rb
 lib/rubygems/specification.rb
 lib/rubygems/specification_policy.rb

--- a/lib/rubygems/source_specific_file.rb
+++ b/lib/rubygems/source_specific_file.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-require 'rubygems/source/specific_file'
-
-unless Gem::Deprecate.skip
-  Kernel.warn "#{Gem.location_of_caller(3).join(':')}: Warning: Requiring rubygems/source_specific_file is deprecated; please use rubygems/source/specific_file instead."
-end


### PR DESCRIPTION
# Description:

This deprecation has been showing since `2017`

```
d1f199be8 (Ellen Marie Dash 2017-06-03 17:27:39 -0400 5)   Kernel.warn "#{Gem.location_of_caller(3).join(':')}: Warning: Requiring rubygems/source_specific_file is deprecated; please use rubygems/source/specific_file instead."
```
______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
