### PR TITLE
Fix incorrect test to test what it wants to test

### DIFF
--- a/lib/rubygems/installer_test_case.rb
+++ b/lib/rubygems/installer_test_case.rb
@@ -171,10 +171,10 @@ class Gem::InstallerTestCase < Gem::TestCase
   ##
   # Sets up the base @gem, builds it and returns an installer for it.
   #
-  def util_setup_installer
+  def util_setup_installer(&block)
     @gem = setup_base_gem
 
-    util_setup_gem
+    util_setup_gem(&block)
   end
 
   ##

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -940,7 +940,13 @@ gem 'other', version
   end
 
   def test_install_creates_binstub_that_prefers_user_installed_gem_to_default
-    install_default_gems new_default_spec('default', '2')
+    default_spec = new_default_spec('default', '2', nil, 'exe/executable')
+    default_spec.executables = 'executable'
+    install_default_gems default_spec
+
+    exe = File.join @gemhome, 'bin', 'executable'
+
+    assert_path_exists exe, "default gem's executable not installed"
 
     installer = util_setup_installer do |spec|
       spec.name = 'default'
@@ -957,8 +963,6 @@ gem 'other', version
         @newspec = installer.install
       end
     end
-
-    exe = File.join @gemhome, 'bin', 'executable'
 
     e = assert_raises RuntimeError do
       instance_eval File.read(exe)


### PR DESCRIPTION
# Description:

This PR fixes an incorrect test that I found while working on #3108.

Previously `util_setup_installer` was ignoring the block passed to it, the user installed gem was not even named "default". However, since it installed an executable with the same name as the default gem, the test still passed.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
