### PR TITLE
Workaround flaky on jruby

### DIFF
--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -897,8 +897,6 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
   end
 
   def test_ssl_client_cert_auth_connection
-    skip 'openssl in jruby fails' if java_platform?
-
     ssl_server = self.class.start_ssl_server({
       :SSLVerifyClient =>
         OpenSSL::SSL::VERIFY_PEER | OpenSSL::SSL::VERIFY_FAIL_IF_NO_PEER_CERT})


### PR DESCRIPTION
# Description:

The problem is that some remote fetcher tests randomly fail on JRuby. We did have a skip for that, but it was located in the wrong place. For now I moved the skip hoping that this will give us some extra CI stability.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

Closes #3105.