### PR TITLE
Remove duplicated test

### DIFF
--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -164,21 +164,6 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     assert_equal 'uri scheme is invalid: nil', e.message
   end
 
-  def test_fetch_path_socket_error
-    fetcher = Gem::RemoteFetcher.new nil
-    @fetcher = fetcher
-    def fetcher.request(uri, request_class, last_modified = nil)
-      raise SocketError, "oops"
-    end
-
-    uri = 'http://gems.example.com/yaml'
-    e = assert_raises Gem::RemoteFetcher::FetchError do
-      @fetcher.fetch_path(uri, nil, true)
-    end
-
-    assert_equal "SocketError: oops (#{uri})", e.message
-  end
-
   def test_no_proxy
     use_ui @stub_ui do
       assert_data_from_server @fetcher.fetch_path(@server_uri)


### PR DESCRIPTION
# Description:

After https://github.com/rubygems/rubygems/pull/3111/commits/f14464458198cf0c0cc02fb8588dca31fe098935 we now get a warning when we run tests like:

```
$ rake
/home/deivid/Code/rubygems/test/rubygems/test_gem_remote_fetcher.rb:485: warning: method redefined; discarding old test_fetch_path_socket_error
/home/deivid/Code/rubygems/test/rubygems/test_gem_remote_fetcher.rb:167: warning: previous definition of test_fetch_path_socket_error was here
Run options: --seed 61325

# Running:

....................................................................................................................................................................................................................................................................................................
```

Since the original test was testing the now removed `fetch_size` method, I figure we can remove the test.


# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
