### PR TITLE
Allow releasing with a rubygems pre version

### DIFF
--- a/lib/rubygems/commands/push_command.rb
+++ b/lib/rubygems/commands/push_command.rb
@@ -79,25 +79,6 @@ The push command will use ~/.gem/credentials to authenticate to a server, but yo
   def send_gem(name)
     args = [:post, "api/v1/gems"]
 
-    latest_rubygems_version = Gem.latest_rubygems_version
-
-    if latest_rubygems_version < Gem.rubygems_version and
-         Gem.rubygems_version.prerelease? and
-         Gem::Version.new('2.0.0.rc.2') != Gem.rubygems_version
-      alert_error <<-ERROR
-You are using a beta release of RubyGems (#{Gem::VERSION}) which is not
-allowed to push gems.  Please downgrade or upgrade to a release version.
-
-The latest released RubyGems version is #{latest_rubygems_version}
-
-You can upgrade or downgrade to the latest release version with:
-
-  gem update --system=#{latest_rubygems_version}
-
-      ERROR
-      terminate_interaction 1
-    end
-
     gem_data = Gem::Package.new(name)
 
     unless @host


### PR DESCRIPTION
# Description:

This condition is too restrictive in my opinion. If a user has a pre version of rubygems installed, she should be fully responsible for it, and we shouldn't restrict any functionality.

Also, why is a new prerelease disallowed but an old prelease allowed, or why is 2.0.0.rc2 explictly whitelisted? I believe this kind of exceptions are one more reason to actually permit this.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
