### PR TITLE
Handle unexpected behavior with URI#merge and subpaths missing trailing slashes

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -664,6 +664,7 @@ test/rubygems/test_gem_source_list.rb
 test/rubygems/test_gem_source_local.rb
 test/rubygems/test_gem_source_lock.rb
 test/rubygems/test_gem_source_specific_file.rb
+test/rubygems/test_gem_source_subpath_problem.rb
 test/rubygems/test_gem_source_vendor.rb
 test/rubygems/test_gem_spec_fetcher.rb
 test/rubygems/test_gem_specification.rb

--- a/lib/rubygems/source.rb
+++ b/lib/rubygems/source.rb
@@ -80,7 +80,7 @@ class Gem::Source
   def dependency_resolver_set # :nodoc:
     return Gem::Resolver::IndexSet.new self if 'file' == uri.scheme
 
-    bundler_api_uri = uri + './api/v1/dependencies'
+    bundler_api_uri = enforce_trailing_slash(uri) + './api/v1/dependencies'
 
     begin
       fetcher = Gem::RemoteFetcher.fetcher
@@ -132,7 +132,7 @@ class Gem::Source
 
     spec_file_name = name_tuple.spec_name
 
-    source_uri = uri + "#{Gem::MARSHAL_SPEC_DIR}#{spec_file_name}"
+    source_uri = enforce_trailing_slash(uri) + "#{Gem::MARSHAL_SPEC_DIR}#{spec_file_name}"
 
     cache_dir = cache_dir source_uri
 
@@ -176,7 +176,7 @@ class Gem::Source
     file       = FILES[type]
     fetcher    = Gem::RemoteFetcher.fetcher
     file_name  = "#{file}.#{Gem.marshal_version}"
-    spec_path  = uri + "#{file_name}.gz"
+    spec_path  = enforce_trailing_slash(uri) + "#{file_name}.gz"
     cache_dir  = cache_dir spec_path
     local_file = File.join(cache_dir, file_name)
     retried    = false
@@ -226,6 +226,12 @@ class Gem::Source
   def typo_squatting?(host, distance_threshold=4)
     return if @uri.host.nil?
     levenshtein_distance(@uri.host, host).between? 1, distance_threshold
+  end
+
+  private
+
+  def enforce_trailing_slash(uri)
+    uri.merge(uri.path.gsub(/\/+$/, '') + '/')
   end
 end
 

--- a/test/rubygems/test_gem_source_subpath_problem.rb
+++ b/test/rubygems/test_gem_source_subpath_problem.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+require 'rubygems/test_case'
+require 'rubygems/source'
+
+class TestGemSourceSubpathProblem < Gem::TestCase
+  def tuple(*args)
+    Gem::NameTuple.new(*args)
+  end
+
+  def setup
+    super
+
+    @gem_repo = "http://gems.example.com/private"
+
+    spec_fetcher
+
+    @source = Gem::Source.new(@gem_repo)
+
+    util_make_gems
+  end
+
+  def test_dependency_resolver_set
+    response = Net::HTTPResponse.new '1.1', 200, 'OK'
+    response.uri = URI('http://example') if response.respond_to? :uri
+
+    @fetcher.data["#{@gem_repo}/api/v1/dependencies"] = response
+
+    set = @source.dependency_resolver_set
+
+    assert_kind_of Gem::Resolver::APISet, set
+  end
+
+  def test_fetch_spec
+    @fetcher.data["#{@gem_repo}/#{Gem::MARSHAL_SPEC_DIR}#{@a1.spec_name}.rz"] = Zlib::Deflate.deflate(Marshal.dump(@a1))
+
+    spec = @source.fetch_spec tuple('a', Gem::Version.new(1), 'ruby')
+    assert_equal @a1.full_name, spec.full_name
+  end
+
+  def test_load_specs
+    @fetcher.data["#{@gem_repo}/latest_specs.#{Gem.marshal_version}.gz"] = util_gzip(Marshal.dump([
+      Gem::NameTuple.new(@a1.name, @a1.version, 'ruby'),
+      Gem::NameTuple.new(@b2.name, @b2.version, 'ruby'),
+    ]))
+
+    released = @source.load_specs(:latest).map {|spec| spec.full_name }
+    assert_equal %W[a-1 b-2], released
+  end
+end


### PR DESCRIPTION
Due to how `URI#merge` works (which `URI#+` is aliased to), when using a source under a subpath, it can get overwritten:

```ruby
> URI.parse('https://gems.example.com/private') + './api/v1/dependencies'
=> #<URI::HTTPS https://gems.example.com/api/v1/dependencies>
> URI.parse('https://gems.example.com/private/') + './api/v1/dependencies'
=> #<URI::HTTPS https://gems.example.com/private/api/v1/dependencies>
```

It's not immediately obvious that errors fetching would be caused by a missing slash, especially if you have a server mounted at both `/` and `/private`.

This PR makes sure that calls to `URI#+` are more obvious and subpaths aren't overwritten and instead appended.

Fixes https://github.com/rubygems/rubygems/issues/1829.