### PR TITLE
Fix -I require priority

### DIFF
--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -532,6 +532,8 @@ class TestGemRequire < Gem::TestCase
     end
   end
 
+  private
+
   def silence_warnings
     old_verbose, $VERBOSE = $VERBOSE, false
     yield


### PR DESCRIPTION
# Description:

If `require "a"` is run when two folders have been specified in the -I option including a "a.rb" file and a "a.so" file respectively, [the ruby spec says](https://github.com/ruby/spec/blob/d80a6e2b221d4f17a8cadcac75ef950c59cba901/core/kernel/shared/require.rb#L234-L246) that the ".rb" file should always be preferred. However, the logic we added in https://github.com/rubygems/rubygems/commit/6b81076d9 to make the -I option always beat default gems does not respect
this spec, creating a difference from the original ruby-core's require.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
