### PR TITLE
Prefer to use String#match

### DIFF
--- a/lib/rubygems/compatibility.rb
+++ b/lib/rubygems/compatibility.rb
@@ -38,3 +38,23 @@ module Gem
 
   RubyGemsPackageVersion = VERSION
 end
+
+# https://github.com/ruby/csv/pull/30
+unless String.method_defined?(:match?)
+  module Gem
+    module MatchP
+      refine String do
+        def match?(pattern)
+          pattern === self
+        end
+      end
+    end
+
+    refine Regexp do
+      def match?(string)
+        self === string
+      end
+    end
+  end
+
+end

--- a/lib/rubygems/package/tar_header.rb
+++ b/lib/rubygems/package/tar_header.rb
@@ -30,6 +30,8 @@
 
 class Gem::Package::TarHeader
 
+  using Gem::MatchP
+
   ##
   # Fields in the tar header
 
@@ -126,7 +128,7 @@ class Gem::Package::TarHeader
   end
 
   def self.strict_oct(str)
-    return str.oct if str =~ /\A[0-7]*\z/
+    return str.oct if str.match?(/\A[0-7]*\z/)
     raise ArgumentError, "#{str.inspect} is not an octal string"
   end
 


### PR DESCRIPTION
# Description:

`String#match?` is faster 10% than `=~` .

see https://github.com/ruby/csv/pull/30
______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
