### PR TITLE
Update the gem method for Gem::Installer

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -47,11 +47,6 @@ class Gem::Installer
   include Gem::InstallerUninstallerUtils
 
   ##
-  # Filename of the gem being installed.
-
-  attr_reader :gem
-
-  ##
   # The directory a gem's executables will be installed into
 
   attr_reader :bin_dir
@@ -887,6 +882,13 @@ TEXT
 
   def dir
     gem_dir.to_s
+  end
+
+  ##
+  # Filename of the gem being installed.
+
+  def gem
+    @package.gem.path
   end
 
   ##

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -2122,6 +2122,16 @@ gem 'other', version
     assert_kind_of(Gem::Package, installer.package)
   end
 
+  def test_gem_attribute
+    gem = quick_gem 'c' do |spec|
+      util_make_exec spec, '#!/usr/bin/ruby', 'exe'
+    end
+
+    installer = util_installer(gem, @gemhome)
+    assert_respond_to(installer, :gem)
+    assert_kind_of(String, installer.gem)
+  end
+
   def old_ruby_required(requirement)
     spec = util_spec 'old_ruby_required', '1' do |s|
       s.required_ruby_version = requirement


### PR DESCRIPTION
Currently the `gem` method on the `Gem::Installer` class method is always nil, since it's an `attr_reader` but `@gem` is never set anywhere.

This PR updates it so that it returns the filename of the gem package.

Followup to https://github.com/rubygems/rubygems/issues/2750

