### PR TITLE
Use modern Ruby idioms

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -790,11 +790,6 @@ class Gem::Specification < Gem::BasicSpecification
   end
   private_class_method :map_stubs
 
-  def self.uniq_by(list, &block) # :nodoc:
-    list.uniq(&block)
-  end
-  private_class_method :uniq_by
-
   def self.sort_by!(list, &block)
     list.sort_by!(&block)
   end
@@ -814,7 +809,7 @@ class Gem::Specification < Gem::BasicSpecification
     @@stubs ||= begin
       pattern = "*.gemspec"
       stubs = Gem.loaded_specs.values + installed_stubs(dirs, pattern) + default_stubs(pattern)
-      stubs = uniq_by(stubs) { |stub| stub.full_name }
+      stubs = stubs.uniq { |stub| stub.full_name }
 
       _resort!(stubs)
       @@stubs_by_name = stubs.select { |s| Gem::Platform.match s.platform }.group_by(&:name)
@@ -847,7 +842,7 @@ class Gem::Specification < Gem::BasicSpecification
       stubs = Gem.loaded_specs.values +
         installed_stubs(dirs, pattern).select { |s| Gem::Platform.match s.platform } +
         default_stubs(pattern)
-      stubs = uniq_by(stubs) { |stub| stub.full_name }.group_by(&:name)
+      stubs = stubs.uniq { |stub| stub.full_name }.group_by(&:name)
       stubs.each_value { |v| _resort!(v) }
 
       @@stubs_by_name.merge! stubs

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -790,11 +790,6 @@ class Gem::Specification < Gem::BasicSpecification
   end
   private_class_method :map_stubs
 
-  def self.sort_by!(list, &block)
-    list.sort_by!(&block)
-  end
-  private_class_method :sort_by!
-
   def self.each_spec(dirs) # :nodoc:
     each_gemspec(dirs) do |path|
       spec = self.load path


### PR DESCRIPTION
The `Specification::uniq_by` and `Specification::sort_by!` are not required since PR #2255. On top of that, `Specification::sort_by!` is not used at all. Since both methods are private, it should be safe to remove them immediately.