### PR TITLE
Make `util/bisect` script more useful

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -70,14 +70,7 @@ end
 
 desc "Run a test suite bisection"
 task(:bisect) do
-  seed = begin
-           Integer(ENV["SEED"])
-         rescue
-           abort "Specify the failing seed as the SEED environment variable"
-         end
-
-  gemdir = `gem env gemdir`.chomp
-  sh "SEED=#{seed} MTB_VERBOSE=2 util/bisect -Ilib:bundler/lib:test:#{gemdir}/gems/minitest-server-1.0.5/lib test"
+  sh "util/bisect"
 end
 
 # --------------------------------------------------------------------

--- a/util/bisect
+++ b/util/bisect
@@ -7,8 +7,7 @@ seed = begin
          abort "Specify the failing seed as the SEED environment variable"
        end
 
-gemdir = `gem env gemdir`.chomp
-ENV["RUBYOPT"] = "-Ilib:bundler/lib:test:#{gemdir}/gems/minitest-server-1.0.5/lib"
+ENV["RUBYOPT"] = "-Ilib:bundler/lib:test:#{Gem.dir}/gems/minitest-server-1.0.5/lib"
 ENV["MTB_VERBOSE"] = "2"
 
 begin

--- a/util/bisect
+++ b/util/bisect
@@ -1,6 +1,16 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+seed = begin
+         Integer(ENV["SEED"])
+       rescue
+         abort "Specify the failing seed as the SEED environment variable"
+       end
+
+gemdir = `gem env gemdir`.chomp
+ENV["RUBYOPT"] = "-Ilib:bundler/lib:test:#{gemdir}/gems/minitest-server-1.0.5/lib"
+ENV["MTB_VERBOSE"] = "2"
+
 begin
   minitest_bisect = Gem.bin_path("minitest-bisect", "minitest_bisect")
 rescue Gem::GemNotFoundException


### PR DESCRIPTION
# Description:

Sometimes when I work on order dependent test failures, I forget to run bisections through `rake bisect` and run the `util/bisect` script directly. But that does not currently work.

This PR moves changes inside `util/bisect` so that it works regardless of how it's run.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
