### PR TITLE
Fix `ruby setup.rb` for new plugins layout

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -482,13 +482,7 @@ class Gem::Installer
   def generate_bin # :nodoc:
     return if spec.executables.nil? or spec.executables.empty?
 
-    begin
-      Dir.mkdir @bin_dir, *[options[:dir_mode] && 0755].compact
-    rescue SystemCallError
-      raise unless File.directory? @bin_dir
-    end
-
-    raise Gem::FilePermissionError.new(@bin_dir) unless File.writable? @bin_dir
+    ensure_writable_dir @bin_dir
 
     spec.executables.each do |filename|
       filename.tap(&Gem::UNTAINT)
@@ -953,6 +947,16 @@ TEXT
   def write_cache_file
     cache_file = File.join gem_home, 'cache', spec.file_name
     @package.copy_to cache_file
+  end
+
+  def ensure_writable_dir(dir) # :nodoc:
+    begin
+      Dir.mkdir dir, *[options[:dir_mode] && 0755].compact
+    rescue SystemCallError
+      raise unless File.directory? dir
+    end
+
+    raise Gem::FilePermissionError.new(dir) unless File.writable? dir
   end
 
 end

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -512,6 +512,8 @@ class Gem::Installer
     latest = Gem::Specification.latest_spec_for(spec.name)
     return if latest && latest.version > spec.version
 
+    ensure_writable_dir Gem.plugins_dir
+
     if spec.plugins.empty?
       remove_plugins_for(spec)
     else

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -160,6 +160,18 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     assert_equal "I changed it!\n", File.read(gem_plugin_path)
   end
 
+  def test_execute_regenerate_plugins_creates_plugins_dir_if_not_there
+    gem_plugin_path = gem_install_with_plugin 'a'
+
+    # Simulate gem installed with an older rubygems without a plugins layout
+    FileUtils.rm_rf Gem.plugins_dir
+
+    @cmd.options[:document] = []
+    @cmd.execute
+
+    assert_match %r{\Arequire}, File.read(gem_plugin_path)
+  end
+
   def test_execute_informs_about_installed_executables
     use_ui @ui do
       @cmd.execute


### PR DESCRIPTION
# Description:

Currently, if you have a gem installed that includes rubygems plugins and you run `ruby setup.rb` from a checkout of the rubygems repo, you'll get an error like this:

```
$ ruby setup.rb 
  Successfully built RubyGem
  Name: bundler
  Version: 2.2.0.dev
  File: bundler-2.2.0.dev.gem
Bundler 2.2.0.dev installed
RubyGems 3.2.0.pre1 installed
Regenerating binstubs
Regenerating plugins
ERROR:  While executing gem ... (Errno::ENOENT)
    No such file or directory @ rb_sysopen - /home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/plugins/yard_plugin.rb
```

This PR fixes the problem.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).