### PR TITLE
Clarify gem install --bindir purpose

### DIFF
--- a/lib/rubygems/install_update_options.rb
+++ b/lib/rubygems/install_update_options.rb
@@ -25,8 +25,8 @@ module Gem::InstallUpdateOptions
     end
 
     add_option(:"Install/Update", '-n', '--bindir DIR',
-               'Directory where executables are',
-               'located') do |value, options|
+               'Directory where executables will be',
+               'placed when the gem is installed') do |value, options|
       options[:bin_dir] = File.expand_path(value)
     end
 


### PR DESCRIPTION
The sentence "Directory where executables are located" suggests that
"executables" are already "located" (prior to running the command) there.

I know this is obvious from the perspective of implementors but this is
confusing, especially from the perspective of someone who doesn't realize there
is a difference between a gem and its binary executable.

This propose alternative suggest by the use of the future tense that this is a
prospective binary executable installation path and not a present one:

> Directory where executables will be placed when the gem is installed