### PR TITLE
Simplify initial gem help output

### DIFF
--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -625,8 +625,7 @@ class Gem::Command
   # :stopdoc:
 
   HELP = <<-HELP.freeze
-RubyGems is a sophisticated package manager for Ruby.  This is a
-basic help message containing pointers to more information.
+RubyGems is a package manager for Ruby.
 
   Usage:
     gem -h/--help


### PR DESCRIPTION
Yes, RubyGems is sophisticated, but that's not a helpful description. It is,
without question, a package manager for Ruby.

And no, we don't need to explain that argument-less command output is a basic
help message with pointers, the pointers themselves can show that for us by
being printed directly below.

Before:

```
$ gem
RubyGems is a sophisticated package manager for Ruby.  This is a
basic help message containing pointers to more information.

  Usage:
    gem -h/--help
    gem -v/--version
    gem command [arguments...] [options...]

  Examples:
    gem install rake
    gem list --local
    gem build package.gemspec
    gem help install

  Further help:
    gem help commands            list all 'gem' commands
    gem help examples            show some examples of usage
    gem help gem_dependencies    gem dependencies file guide
    gem help platforms           gem platforms guide
    gem help <COMMAND>           show help on COMMAND
                                   (e.g. 'gem help install')
    gem server                   present a web page at
                                 http://localhost:8808/
                                 with info about installed gems
  Further information:
    http://guides.rubygems.org
```

After:

```
$ gem
RubyGems is a package manager for Ruby.

  Usage:
    gem -h/--help
    gem -v/--version
    gem command [arguments...] [options...]

  Examples:
    gem install rake
    gem list --local
    gem build package.gemspec
    gem help install

  Further help:
    gem help commands            list all 'gem' commands
    gem help examples            show some examples of usage
    gem help gem_dependencies    gem dependencies file guide
    gem help platforms           gem platforms guide
    gem help <COMMAND>           show help on COMMAND
                                   (e.g. 'gem help install')
    gem server                   present a web page at
                                 http://localhost:8808/
                                 with info about installed gems
  Further information:
    http://guides.rubygems.org
```

We save a line, and lose precious little.