### PR TITLE
Resolve latest version via `gem contents`

### DIFF
--- a/lib/rubygems/commands/contents_command.rb
+++ b/lib/rubygems/commands/contents_command.rb
@@ -167,7 +167,7 @@ prefix or only the files that are requireable.
   end
 
   def spec_for(name)
-    spec = Gem::Specification.find_all_by_name(name, @version).last
+    spec = Gem::Specification.find_all_by_name(name, @version).first
 
     return spec if spec
 

--- a/test/rubygems/test_gem_commands_contents_command.rb
+++ b/test/rubygems/test_gem_commands_contents_command.rb
@@ -152,6 +152,23 @@ class TestGemCommandsContentsCommand < Gem::TestCase
     assert_equal "", @ui.error
   end
 
+  def test_execute_show_install_dir_latest_version
+    @cmd.options[:args] = %w[foo]
+    @cmd.options[:show_install_dir] = true
+
+    gem 'foo', 1
+    gem 'foo', 2
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    expected = File.join @gemhome, 'gems', 'foo-2'
+
+    assert_equal "#{expected}\n", @ui.output
+    assert_equal "", @ui.error
+  end
+
   def test_execute_show_install_dir_version
     @cmd.options[:args] = %w[foo]
     @cmd.options[:show_install_dir] = true

--- a/test/rubygems/test_gem_commands_contents_command.rb
+++ b/test/rubygems/test_gem_commands_contents_command.rb
@@ -105,6 +105,22 @@ class TestGemCommandsContentsCommand < Gem::TestCase
     assert_empty @ui.error
   end
 
+  def test_execute_missing_version
+    @cmd.options[:args] = %w[foo]
+    @cmd.options[:version] = Gem::Requirement.new '= 2'
+
+    gem 'foo', 1
+
+    assert_raises Gem::MockGemUi::TermError do
+      use_ui @ui do
+        @cmd.execute
+      end
+    end
+
+    assert_match "Unable to find gem 'foo'", @ui.output
+    assert_empty @ui.error
+  end
+
   def test_execute_missing_multiple
     @cmd.options[:args] = %w[foo bar]
 


### PR DESCRIPTION
# Description:
## Issue
Scenario: I have two versions of gem `foo` installed.
Current behavior: `gem contents foo` returns information about the older version.
Expected behavior: `gem contents foo` returns information about the newer version.
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
