### PR TITLE
Fix order dependent test failure

### DIFF
--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -78,6 +78,20 @@ module Gem
   end
 end
 
+require "rubygems/command"
+
+class Gem::Command
+
+  ##
+  # Allows resetting the hash of specific args per command.  This method is
+  # available when requiring 'rubygems/test_case'
+
+  def self.specific_extra_args_hash=(value)
+    @specific_extra_args_hash = value
+  end
+
+end
+
 ##
 # RubyGemTestCase provides a variety of methods for testing rubygems and
 # gem-related behavior in a sandbox.  Through RubyGemTestCase you can install

--- a/test/rubygems/test_gem_gem_runner.rb
+++ b/test/rubygems/test_gem_gem_runner.rb
@@ -8,6 +8,7 @@ class TestGemGemRunner < Gem::TestCase
 
     require 'rubygems/command'
     @orig_args = Gem::Command.build_args
+    @orig_specific_extra_args = Gem::Command.specific_extra_args_hash.dup
 
     require 'rubygems/gem_runner'
     @runner = Gem::GemRunner.new
@@ -17,6 +18,7 @@ class TestGemGemRunner < Gem::TestCase
     super
 
     Gem::Command.build_args = @orig_args
+    Gem::Command.specific_extra_args_hash = @orig_specific_extra_args
   end
 
   def test_do_configuration


### PR DESCRIPTION
# Description:

If tests are run against a jruby installation that _does not_ include a `jruby_native.rb` customization, they can fail in an order dependent way like this:

```
 $ rake TESTOPTS="--seed=3563 --name=/\(test_search_succeeds\|test_handle_options_system_specific\)/"
Run options: --seed=3563 "--name=/(test_search_succeeds|test_handle_options_system_specific)/"

# Running:

.F

Finished in 0.586286s, 3.4113 runs/s, 6.8226 assertions/s.

  1) Failure:
TestGemCommandsUpdateCommand#test_handle_options_system_specific [/home/deivid/Code/rubygems/test/rubygems/test_gem_commands_update_command.rb:513]:
--- expected
+++ actual
@@ -1 +1,5 @@
-{:args=>[], :document=>["rdoc", "ri"], :force=>false, :system=>"1.3.7"}
+{:document=>["rdoc", "ri"],
+ :force=>false,
+ :env_shebang=>true,
+ :system=>"1.3.7",
+ :args=>[]}

2 runs, 4 assertions, 1 failures, 0 errors, 0 skips
Coverage report generated for Unit Tests to /home/deivid/Code/rubygems/coverage. 2890 / 9057 LOC (31.91%) covered.
SimpleCov failed with exit 1
rake aborted!
Command failed with status (1)

Tasks: TOP => default => test
(See full trace by running task with --trace)
```

This change fixes the issue.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).