### PR TITLE
Install suggestions

### DIFF
--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -174,8 +174,7 @@ class Gem::Command
     alert_error msg
 
     unless suppress_suggestions
-      suggestions = Gem::SpecFetcher.fetcher.suggest_gems_from_name gem_name
-
+      suggestions = Gem::SpecFetcher.fetcher.suggest_gems_from_name_regex(gem_name)
       unless suggestions.empty?
         alert_error "Possible alternatives: #{suggestions.join(", ")}"
       end

--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -174,7 +174,7 @@ class Gem::Command
     alert_error msg
 
     unless suppress_suggestions
-      suggestions = Gem::SpecFetcher.fetcher.suggest_gems_from_name_regex(gem_name)
+      suggestions = Gem::SpecFetcher.fetcher.suggest_gems_from_name(gem_name, :latest, 10)
       unless suggestions.empty?
         alert_error "Possible alternatives: #{suggestions.join(", ")}"
       end

--- a/lib/rubygems/spec_fetcher.rb
+++ b/lib/rubygems/spec_fetcher.rb
@@ -171,7 +171,7 @@ class Gem::SpecFetcher
   # Suggests gems based on the supplied +gem_name+. Returns an array of
   # alternative gem names.
 
-  def suggest_gems_from_name(gem_name, type = :latest)
+  def suggest_gems_from_name(gem_name, type = :latest, num_results = 5)
     gem_name        = gem_name.downcase.tr('_-', '')
     max             = gem_name.size / 2
     names           = available_specs(type).first.values.flatten(1)
@@ -194,10 +194,10 @@ class Gem::SpecFetcher
                 matches.uniq.sort_by { |name, dist| dist }
               end
 
-    matches.first(5).map { |name, dist| name }
+    matches.first(num_results).map { |name, dist| name }
   end
 
-  def suggest_gems_from_name_regex(gem_name, type = :latest)
+  def suggest_gems_from_name_regex(gem_name, type = :latest, num_results = 5)
     name = Regexp.new gem_name.downcase.tr('_-', '')
     names = available_specs(type).first.values.flatten(1)
 
@@ -212,7 +212,7 @@ class Gem::SpecFetcher
                 matches.uniq
               end
 
-    return matches
+    return matches.first(num_results)
   end
 
   ##

--- a/lib/rubygems/spec_fetcher.rb
+++ b/lib/rubygems/spec_fetcher.rb
@@ -197,6 +197,24 @@ class Gem::SpecFetcher
     matches.first(5).map { |name, dist| name }
   end
 
+  def suggest_gems_from_name_regex(gem_name, type = :latest)
+    name = Regexp.new gem_name
+    names = available_specs(type).first.values.flatten(1)
+
+    matches = names.map do |n|
+      next unless n.match_platform?
+      n.name if name === n.name
+    end.compact
+
+    matches = if matches.empty? && type != :prerelease
+                suggest_gems_from_name_regex gem_name, :prerelease
+              else
+                matches.uniq
+              end
+
+    return matches
+  end
+
   ##
   # Returns a list of gems available for each source in Gem::sources.
   #

--- a/lib/rubygems/spec_fetcher.rb
+++ b/lib/rubygems/spec_fetcher.rb
@@ -179,7 +179,7 @@ class Gem::SpecFetcher
 
     matches = names.map do |n|
       next unless n.match_platform?
-      [n.name, 0] if name === n.name.downcase.tr('_-', '')
+      [n.name, 0] if n.name.downcase.tr('_-', '').include?(gem_name)
     end.compact
 
     if matches.length < num_results

--- a/lib/rubygems/spec_fetcher.rb
+++ b/lib/rubygems/spec_fetcher.rb
@@ -173,7 +173,6 @@ class Gem::SpecFetcher
 
   def suggest_gems_from_name(gem_name, type = :latest, num_results = 5)
     gem_name        = gem_name.downcase.tr('_-', '')
-    name            = Regexp.new gem_name
     max             = gem_name.size / 2
     names           = available_specs(type).first.values.flatten(1)
 

--- a/lib/rubygems/spec_fetcher.rb
+++ b/lib/rubygems/spec_fetcher.rb
@@ -198,12 +198,12 @@ class Gem::SpecFetcher
   end
 
   def suggest_gems_from_name_regex(gem_name, type = :latest)
-    name = Regexp.new gem_name
+    name = Regexp.new gem_name.downcase.tr('_-', '')
     names = available_specs(type).first.values.flatten(1)
 
     matches = names.map do |n|
       next unless n.match_platform?
-      n.name if name === n.name
+      n.name if name === n.name.downcase.tr('_-', '')
     end.compact
 
     matches = if matches.empty? && type != :prerelease

--- a/test/rubygems/test_gem_spec_fetcher.rb
+++ b/test/rubygems/test_gem_spec_fetcher.rb
@@ -173,9 +173,10 @@ class TestGemSpecFetcher < Gem::TestCase
     spec_fetcher do|fetcher|
       fetcher.spec 'example', 1
       fetcher.spec 'other-example', 1
+      fetcher.spec 'exampel', 1
     end
 
-    suggestions = @sf.suggest_gems_from_name('examplw')
+    suggestions = @sf.suggest_gems_from_name('examplw', type = :latest, num_results = 1)
     assert_equal ['example'], suggestions
   end
 
@@ -198,6 +199,9 @@ class TestGemSpecFetcher < Gem::TestCase
 
     suggestions = @sf.suggest_gems_from_name_regex('exampl')
     assert_equal ['example', 'other-example'], suggestions
+
+    suggestions = @sf.suggest_gems_from_name_regex('exampl', type = :latest, num_results = 1)
+    assert_equal ['example'], suggestions
   end
 
   def test_suggest_gems_from_name_regex_prerelease

--- a/test/rubygems/test_gem_spec_fetcher.rb
+++ b/test/rubygems/test_gem_spec_fetcher.rb
@@ -173,11 +173,19 @@ class TestGemSpecFetcher < Gem::TestCase
     spec_fetcher do|fetcher|
       fetcher.spec 'example', 1
       fetcher.spec 'other-example', 1
-      fetcher.spec 'exampel', 1
+      fetcher.spec 'examp', 1
     end
 
     suggestions = @sf.suggest_gems_from_name('examplw', type = :latest, num_results = 1)
     assert_equal ['example'], suggestions
+
+    suggestions = @sf.suggest_gems_from_name('other')
+    assert_equal ['other-example'], suggestions
+
+    suggestions = @sf.suggest_gems_from_name('exam')
+    assert suggestions.any? { ['examp'] }
+    assert suggestions.any? { ['example'] }
+    assert suggestions.any? { ['other-example'] }
   end
 
   def test_suggest_gems_from_name_prerelease
@@ -188,31 +196,6 @@ class TestGemSpecFetcher < Gem::TestCase
 
     suggestions = @sf.suggest_gems_from_name('examplw')
     assert_equal ['example'], suggestions
-  end
-
-  def test_suggest_gems_from_name_regex_latest
-    spec_fetcher do|fetcher|
-      fetcher.spec 'example', 1
-      fetcher.spec 'other-example', 1
-      fetcher.spec 'some-stuff', 1
-    end
-
-    suggestions = @sf.suggest_gems_from_name_regex('exampl')
-    assert_equal ['example', 'other-example'], suggestions
-
-    suggestions = @sf.suggest_gems_from_name_regex('exampl', type = :latest, num_results = 1)
-    assert_equal ['example'], suggestions
-  end
-
-  def test_suggest_gems_from_name_regex_prerelease
-    spec_fetcher do|fetcher|
-      fetcher.spec 'example', '1.a'
-      fetcher.spec 'other-example', '0.b'
-      fetcher.spec 'some-stuff', 1
-    end
-
-    suggestions = @sf.suggest_gems_from_name_regex('exampl')
-    assert_equal ['example', 'other-example'], suggestions
   end
 
   def test_available_specs_latest

--- a/test/rubygems/test_gem_spec_fetcher.rb
+++ b/test/rubygems/test_gem_spec_fetcher.rb
@@ -189,6 +189,28 @@ class TestGemSpecFetcher < Gem::TestCase
     assert_equal ['example'], suggestions
   end
 
+  def test_suggest_gems_from_name_regex_latest
+    spec_fetcher do|fetcher|
+      fetcher.spec 'example', 1
+      fetcher.spec 'other-example', 1
+      fetcher.spec 'some-stuff', 1
+    end
+
+    suggestions = @sf.suggest_gems_from_name_regex('exampl')
+    assert_equal ['example', 'other-example'], suggestions
+  end
+
+  def test_suggest_gems_from_name_regex_prerelease
+    spec_fetcher do|fetcher|
+      fetcher.spec 'example', '1.a'
+      fetcher.spec 'other-example', '0.b'
+      fetcher.spec 'some-stuff', 1
+    end
+
+    suggestions = @sf.suggest_gems_from_name_regex('exampl')
+    assert_equal ['example', 'other-example'], suggestions
+  end
+
   def test_available_specs_latest
     spec_fetcher do |fetcher|
       fetcher.spec 'a', 1


### PR DESCRIPTION
# Description:
addresses the issue: https://github.com/rubygems/rubygems/issues/3018
Makes the suggested gems when install fails more similar to the results of using `gem search`.
Just throwing an idea out there, maybe not the direction that this should be going in.
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
