### PR TITLE
Run unstable workflow as a daily scheduled build

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -19,7 +19,6 @@ status = [
   "windows (2.6.5)",
   "ubuntu_bundler_master (2.6.5)",
   "ubuntu (2.3.8, rubygems)",
-  "unstable (ruby-head)",
   "ubuntu (jruby-9.2.9.0, rubygems)",
 ]
 

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -1,12 +1,8 @@
 name: unstable
 
 on:
-  pull_request:
-
-  push:
-    branches:
-      - staging
-      - trying
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   unstable:


### PR DESCRIPTION
# Description:

We want our CI in PRs to be as deterministic as possible, while still find breakage with ruby-head as it changes reasonably early. I think this is a good compromise for that.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
