### PR TITLE
Revert "Exclude empty suffix from `-I` require loop"

### DIFF
--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -43,7 +43,7 @@ module Kernel
     # https://github.com/rubygems/rubygems/pull/1868
     resolved_path = begin
       rp = nil
-      Gem.suffixes[1..-1].each do |s|
+      Gem.suffixes.each do |s|
         load_path_insert_index = Gem.load_path_insert_index
         break unless load_path_insert_index
 


### PR DESCRIPTION
# Description:

This reverts commit 4fc0ab21c0f7713829abb522ce3b6d8e24c126b3.

Technically, extensionless ruby files are valid ruby files that can be required. For example, `bin/bundle` is sometimes required from other binstubs even if it's also runnable directly.

So, we should technically consider this kind of files too.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
