### PR TITLE
Only rescue the errors we actually want to rescue

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -468,7 +468,10 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     subdirs.each do |name|
       subdir = File.join dir, name
       next if File.exist? subdir
-      FileUtils.mkdir_p subdir, **options rescue nil
+      begin
+        FileUtils.mkdir_p subdir, **options
+      rescue Errno::EACCES
+      end
     end
   ensure
     File.umask old_umask


### PR DESCRIPTION
# Description:

Ruby's `rbinstaller.rb` is incorrectly calling `Gem.ensure_gem_subdirectories` with keyword arguments [here](https://github.com/ruby/ruby/blob/83705c42cedd9489596859827d7201c59feccebd/tool/rbinstall.rb#L822) and [here](https://github.com/ruby/ruby/blob/83705c42cedd9489596859827d7201c59feccebd/tool/rbinstall.rb#L869).

But this method does not take keyword args :grimacing:.

Because of this blind rescue, this error goes unnoticed when `rbinstaller.rb` is run. 

This PR fixes this problem by rescuing only the specific error we intend to rescue, and let any other errors happen.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
