### PR TITLE
Reenable skipped test on jruby

### DIFF
--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -897,8 +897,6 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
   end
 
   def test_ssl_client_cert_auth_connection
-    skip 'openssl in jruby fails' if java_platform?
-
     ssl_server = self.class.start_ssl_server({
       :SSLVerifyClient =>
         OpenSSL::SSL::VERIFY_PEER | OpenSSL::SSL::VERIFY_FAIL_IF_NO_PEER_CERT})


### PR DESCRIPTION
# Description:

We used to have some flaky test failures on tests similar to this one, but it seems like they are gone. This test doesn't look too special compared to the others in this file, and the "skip comment" talks about openssl in general, not about the specific test which sounds work since `openssl` _does_ work on `jruby`.

So I'll tentatively reenable it.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
