### PR TITLE
Fix new plugins layout edge cases

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -319,6 +319,13 @@ module Gem
   end
 
   ##
+  # The path were rubygems plugins are to be installed.
+
+  def self.plugindir(install_dir=Gem.dir)
+    File.join install_dir, 'plugins'
+  end
+
+  ##
   # Reset the +dir+ and +path+ values.  The next time +dir+ or +path+
   # is requested, the values will be calculated from scratch.  This is
   # mainly used by the unit tests to provide test isolation.
@@ -423,10 +430,6 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
   def self.spec_cache_dir
     paths.spec_cache_dir
-  end
-
-  def self.plugins_dir
-    File.join(dir, "plugins")
   end
 
   ##
@@ -1103,7 +1106,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   # Find rubygems plugin files in the standard location and load them
 
   def self.load_plugins
-    load_plugin_files Gem::Util.glob_files_in_dir("*#{Gem.plugin_suffix_pattern}", plugins_dir)
+    load_plugin_files Gem::Util.glob_files_in_dir("*#{Gem.plugin_suffix_pattern}", plugindir)
   end
 
   ##

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -184,14 +184,14 @@ command to remove old versions.
     else
       require "tmpdir"
       tmpdir = Dir.mktmpdir
-      FileUtils.mv Gem.plugins_dir, tmpdir
+      FileUtils.mv Gem.plugindir, tmpdir
 
       status = yield
 
       if status
         FileUtils.rm_rf tmpdir
       else
-        FileUtils.mv File.join(tmpdir, "plugins"), Gem.plugins_dir
+        FileUtils.mv File.join(tmpdir, "plugins"), Gem.plugindir
       end
 
       status

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -512,7 +512,7 @@ class Gem::Installer
     latest = Gem::Specification.latest_spec_for(spec.name)
     return if latest && latest.version > spec.version
 
-    ensure_writable_dir Gem.plugins_dir
+    ensure_writable_dir @plugins_dir
 
     if spec.plugins.empty?
       remove_plugins_for(spec)
@@ -681,6 +681,7 @@ class Gem::Installer
     @force               = options[:force]
     @install_dir         = options[:install_dir]
     @gem_home            = options[:install_dir] || Gem.dir
+    @plugins_dir         = File.join(@gem_home, "plugins")
     @ignore_dependencies = options[:ignore_dependencies]
     @format_executable   = options[:format_executable]
     @wrappers            = options[:wrappers]

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -515,9 +515,9 @@ class Gem::Installer
     ensure_writable_dir @plugins_dir
 
     if spec.plugins.empty?
-      remove_plugins_for(spec)
+      remove_plugins_for(spec, @plugins_dir)
     else
-      regenerate_plugins_for(spec)
+      regenerate_plugins_for(spec, @plugins_dir)
     end
   end
 

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -681,7 +681,7 @@ class Gem::Installer
     @force               = options[:force]
     @install_dir         = options[:install_dir]
     @gem_home            = options[:install_dir] || Gem.dir
-    @plugins_dir         = File.join(@gem_home, "plugins")
+    @plugins_dir         = Gem.plugindir(@gem_home)
     @ignore_dependencies = options[:ignore_dependencies]
     @format_executable   = options[:format_executable]
     @wrappers            = options[:wrappers]

--- a/lib/rubygems/installer_uninstaller_utils.rb
+++ b/lib/rubygems/installer_uninstaller_utils.rb
@@ -5,7 +5,7 @@
 
 module Gem::InstallerUninstallerUtils
 
-  def regenerate_plugins_for(spec, plugins_dir = Gem.plugins_dir)
+  def regenerate_plugins_for(spec, plugins_dir)
     spec.plugins.each do |plugin|
       plugin_script_path = File.join plugins_dir, "#{spec.name}_plugin#{File.extname(plugin)}"
 
@@ -17,7 +17,7 @@ module Gem::InstallerUninstallerUtils
     end
   end
 
-  def remove_plugins_for(spec, plugins_dir = Gem.plugins_dir)
+  def remove_plugins_for(spec, plugins_dir)
     FileUtils.rm_f Gem::Util.glob_files_in_dir("#{spec.name}#{Gem.plugin_suffix_pattern}", plugins_dir)
   end
 

--- a/lib/rubygems/installer_uninstaller_utils.rb
+++ b/lib/rubygems/installer_uninstaller_utils.rb
@@ -5,9 +5,9 @@
 
 module Gem::InstallerUninstallerUtils
 
-  def regenerate_plugins_for(spec)
+  def regenerate_plugins_for(spec, plugins_dir = Gem.plugins_dir)
     spec.plugins.each do |plugin|
-      plugin_script_path = File.join Gem.plugins_dir, "#{spec.name}_plugin#{File.extname(plugin)}"
+      plugin_script_path = File.join plugins_dir, "#{spec.name}_plugin#{File.extname(plugin)}"
 
       File.open plugin_script_path, 'wb' do |file|
         file.puts "require '#{plugin}'"
@@ -17,8 +17,8 @@ module Gem::InstallerUninstallerUtils
     end
   end
 
-  def remove_plugins_for(spec)
-    FileUtils.rm_f Gem::Util.glob_files_in_dir("#{spec.name}#{Gem.plugin_suffix_pattern}", Gem.plugins_dir)
+  def remove_plugins_for(spec, plugins_dir = Gem.plugins_dir)
+    FileUtils.rm_f Gem::Util.glob_files_in_dir("#{spec.name}#{Gem.plugin_suffix_pattern}", plugins_dir)
   end
 
 end

--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -50,7 +50,7 @@ class Gem::Uninstaller
     @gem                = gem
     @version            = options[:version] || Gem::Requirement.default
     @gem_home           = File.realpath(options[:install_dir] || Gem.dir)
-    @plugins_dir        = File.join(@gem_home, 'plugins')
+    @plugins_dir        = Gem.plugindir(@gem_home)
     @force_executables  = options[:executables]
     @force_all          = options[:all]
     @force_ignore       = options[:ignore]

--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -50,6 +50,7 @@ class Gem::Uninstaller
     @gem                = gem
     @version            = options[:version] || Gem::Requirement.default
     @gem_home           = File.realpath(options[:install_dir] || Gem.dir)
+    @plugins_dir        = File.join(@gem_home, 'plugins')
     @force_executables  = options[:executables]
     @force_all          = options[:all]
     @force_ignore       = options[:ignore]
@@ -281,7 +282,7 @@ class Gem::Uninstaller
   def remove_plugins(spec) # :nodoc:
     return if spec.plugins.empty?
 
-    remove_plugins_for(spec)
+    remove_plugins_for(spec, @plugins_dir)
   end
 
   ##
@@ -291,7 +292,7 @@ class Gem::Uninstaller
     latest = Gem::Specification.latest_spec_for(@spec.name)
     return if latest.nil?
 
-    regenerate_plugins_for(latest)
+    regenerate_plugins_for(latest, @plugins_dir)
   end
 
   ##

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -107,7 +107,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     end
     install_gem gem
 
-    File.join Gem.plugins_dir, "#{name}_plugin.rb"
+    File.join Gem.plugindir, "#{name}_plugin.rb"
   end
 
   def test_execute_regenerate_binstubs
@@ -164,7 +164,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     gem_plugin_path = gem_install_with_plugin 'a'
 
     # Simulate gem installed with an older rubygems without a plugins layout
-    FileUtils.rm_rf Gem.plugins_dir
+    FileUtils.rm_rf Gem.plugindir
 
     @cmd.options[:document] = []
     @cmd.execute

--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -169,12 +169,12 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
     @cmd.options[:args]          = []
     @cmd.options[:system]        = "3.1"
 
-    FileUtils.mkdir_p Gem.plugins_dir
-    write_file File.join(Gem.plugins_dir, 'a_plugin.rb')
+    FileUtils.mkdir_p Gem.plugindir
+    write_file File.join(Gem.plugindir, 'a_plugin.rb')
 
     @cmd.execute
 
-    refute_path_exists Gem.plugins_dir, "Plugins folder not removed when updating rubygems to pre-3.2"
+    refute_path_exists Gem.plugindir, "Plugins folder not removed when updating rubygems to pre-3.2"
   end
 
   def test_execute_system_specific_newer_than_or_equal_to_3_2_leaves_plugins_dir_alone
@@ -187,13 +187,13 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
     @cmd.options[:args]          = []
     @cmd.options[:system]        = "3.2"
 
-    FileUtils.mkdir_p Gem.plugins_dir
-    plugin_file = File.join(Gem.plugins_dir, 'a_plugin.rb')
+    FileUtils.mkdir_p Gem.plugindir
+    plugin_file = File.join(Gem.plugindir, 'a_plugin.rb')
     write_file plugin_file
 
     @cmd.execute
 
-    assert_path_exists Gem.plugins_dir, "Plugin folder removed when updating rubygems to post-3.2"
+    assert_path_exists Gem.plugindir, "Plugin folder removed when updating rubygems to post-3.2"
     assert_path_exists plugin_file, "Plugin removed when updating rubygems to post-3.2"
   end
 

--- a/test/rubygems/test_gem_doctor.rb
+++ b/test/rubygems/test_gem_doctor.rb
@@ -158,8 +158,8 @@ This directory does not appear to be a RubyGems repository, skipping
 
     Gem.use_paths @gemhome.to_s
 
-    FileUtils.mkdir_p Gem.plugins_dir
-    bad_plugin = File.join(Gem.plugins_dir, "a_badly_named_file.rb")
+    FileUtils.mkdir_p Gem.plugindir
+    bad_plugin = File.join(Gem.plugindir, "a_badly_named_file.rb")
     write_file bad_plugin
 
     doctor = Gem::Doctor.new @gemhome

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -757,7 +757,7 @@ gem 'other', version
       installer.install
     end
 
-    plugin_path = File.join Gem.plugins_dir, 'a_plugin.rb'
+    plugin_path = File.join Gem.plugindir, 'a_plugin.rb'
 
     FileUtils.rm plugin_path
 
@@ -798,7 +798,7 @@ gem 'other', version
         spec.files += %w[lib/rubygems_plugin.rb]
       end.install
 
-      plugin_path = File.join Gem.plugins_dir, 'a_plugin.rb'
+      plugin_path = File.join Gem.plugindir, 'a_plugin.rb'
       refute File.exist?(plugin_path), 'old version installed while newer version without plugin also installed, but plugin written'
 
       util_setup_installer do |spec|
@@ -806,7 +806,7 @@ gem 'other', version
         spec.files += %w[lib/rubygems_plugin.rb]
       end.install
 
-      plugin_path = File.join Gem.plugins_dir, 'a_plugin.rb'
+      plugin_path = File.join Gem.plugindir, 'a_plugin.rb'
       assert File.exist?(plugin_path), 'latest version reinstalled, but plugin not written'
       assert_match %r{\Arequire.*a-2/lib/rubygems_plugin\.rb}, File.read(plugin_path), 'written plugin has incorrect content'
 
@@ -815,7 +815,7 @@ gem 'other', version
         spec.files += %w[lib/rubygems_plugin.rb]
       end.install
 
-      plugin_path = File.join Gem.plugins_dir, 'a_plugin.rb'
+      plugin_path = File.join Gem.plugindir, 'a_plugin.rb'
       assert File.exist?(plugin_path), 'latest version installed, but plugin removed'
       assert_match %r{\Arequire.*a-3/lib/rubygems_plugin\.rb}, File.read(plugin_path), 'written plugin has incorrect content'
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -766,6 +766,25 @@ gem 'other', version
     assert File.exist?(plugin_path), 'plugin not written'
   end
 
+  def test_generate_plugins_with_install_dir
+    spec = quick_gem 'a' do |spec|
+      write_file File.join(@tempdir, 'lib', 'rubygems_plugin.rb') do |io|
+        io.write "puts __FILE__"
+      end
+
+      spec.files += %w[lib/rubygems_plugin.rb]
+    end
+
+    util_build_gem spec
+
+    plugin_path = File.join "#{@gemhome}2", 'plugins', 'a_plugin.rb'
+    installer = util_installer spec, "#{@gemhome}2"
+
+    assert_equal spec, installer.install
+
+    assert File.exist?(plugin_path), 'plugin not written to install_dir'
+  end
+
   def test_keeps_plugins_up_to_date
     # NOTE: version a-2 is already installed by setup hooks
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -808,6 +808,17 @@ gem 'other', version
     end
   end
 
+  def test_generates_plugins_dir_under_install_dir_if_not_there
+    Gem.use_paths "#{@gemhome}2" # Set GEM_HOME to an uninitialized repo
+
+    @spec = util_spec 'a'
+
+    path = Gem::Package.build @spec
+
+    installer = Gem::Installer.at path, :install_dir => "#{@gemhome}3"
+    assert_equal @spec, installer.install
+  end
+
   def test_initialize
     spec = util_spec 'a' do |s|
       s.platform = Gem::Platform.new 'mswin32'

--- a/test/rubygems/test_gem_uninstaller.rb
+++ b/test/rubygems/test_gem_uninstaller.rb
@@ -178,7 +178,7 @@ class TestGemUninstaller < Gem::InstallerTestCase
 
     Gem::Installer.at(Gem::Package.build(@spec)).install
 
-    plugin_path = File.join Gem.plugins_dir, 'a_plugin.rb'
+    plugin_path = File.join Gem.plugindir, 'a_plugin.rb'
     assert File.exist?(plugin_path), 'plugin not written'
 
     Gem::Uninstaller.new(nil).remove_plugins @spec
@@ -195,7 +195,7 @@ class TestGemUninstaller < Gem::InstallerTestCase
 
     Gem::Installer.at(Gem::Package.build(@spec)).install
 
-    plugin_path = File.join Gem.plugins_dir, 'a_plugin.rb'
+    plugin_path = File.join Gem.plugindir, 'a_plugin.rb'
     assert File.exist?(plugin_path), 'plugin not written'
 
     Dir.mkdir "#{@gemhome}2"
@@ -213,11 +213,11 @@ class TestGemUninstaller < Gem::InstallerTestCase
 
     Gem::Installer.at(Gem::Package.build(@spec)).install
 
-    plugin_path = File.join Gem.plugins_dir, 'a_plugin.rb'
+    plugin_path = File.join Gem.plugindir, 'a_plugin.rb'
     assert File.exist?(plugin_path), 'plugin not written'
 
     FileUtils.rm plugin_path
-    Gem::Uninstaller.new(nil).regenerate_plugins_for @spec, Gem.plugins_dir
+    Gem::Uninstaller.new(nil).regenerate_plugins_for @spec, Gem.plugindir
 
     assert File.exist?(plugin_path), 'plugin not regenerated'
   end
@@ -629,7 +629,7 @@ create_makefile '#{@spec.name}'
       io.write "puts __FILE__"
     end
 
-    plugin_path = File.join Gem.plugins_dir, 'a_plugin.rb'
+    plugin_path = File.join Gem.plugindir, 'a_plugin.rb'
 
     @spec.version = '1'
     Gem::Installer.at(Gem::Package.build(@spec)).install

--- a/test/rubygems/test_gem_uninstaller.rb
+++ b/test/rubygems/test_gem_uninstaller.rb
@@ -217,7 +217,7 @@ class TestGemUninstaller < Gem::InstallerTestCase
     assert File.exist?(plugin_path), 'plugin not written'
 
     FileUtils.rm plugin_path
-    Gem::Uninstaller.new(nil).regenerate_plugins_for @spec
+    Gem::Uninstaller.new(nil).regenerate_plugins_for @spec, Gem.plugins_dir
 
     assert File.exist?(plugin_path), 'plugin not regenerated'
   end

--- a/test/rubygems/test_gem_uninstaller.rb
+++ b/test/rubygems/test_gem_uninstaller.rb
@@ -186,6 +186,24 @@ class TestGemUninstaller < Gem::InstallerTestCase
     refute File.exist?(plugin_path), 'plugin not removed'
   end
 
+  def test_remove_plugins_with_install_dir
+    write_file File.join(@tempdir, 'lib', 'rubygems_plugin.rb') do |io|
+      io.write "puts __FILE__"
+    end
+
+    @spec.files += %w[lib/rubygems_plugin.rb]
+
+    Gem::Installer.at(Gem::Package.build(@spec)).install
+
+    plugin_path = File.join Gem.plugins_dir, 'a_plugin.rb'
+    assert File.exist?(plugin_path), 'plugin not written'
+
+    Dir.mkdir "#{@gemhome}2"
+    Gem::Uninstaller.new(nil, :install_dir => "#{@gemhome}2").remove_plugins @spec
+
+    assert File.exist?(plugin_path), 'plugin unintentionally removed'
+  end
+
   def test_regenerate_plugins_for
     write_file File.join(@tempdir, 'lib', 'rubygems_plugin.rb') do |io|
       io.write "puts __FILE__"


### PR DESCRIPTION
# Description:

I run into some issues with the new plugins layout while working on an unrelated bundler PR. The problem in a few words is that the rubygems plugin management system does not respect the `:install_dir` parameter to `Gem::Installer` and `Gem::Uninstaller`.

This PR fixes that.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
