### PR TITLE
Rename scheduled build

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,11 +1,11 @@
-name: unstable
+name: daily
 
 on:
   schedule:
     - cron: '0 0 * * *'
 
 jobs:
-  unstable:
+  daily:
     runs-on: ubuntu-16.04
     strategy:
       matrix:


### PR DESCRIPTION
# Description:

The current scheduled build is not currently working, and I'm not sure why. A potential cause is that this specific workflow has already run as a "regular workflow" in the past, so that somehow could be preventing it from running now as a scheduled workflow? :man_shrugging:

As a blind guess, I'd like to check whether renaming it fixes the issue.

If this doesn't work, I'll ask at Github support.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
