### PR TITLE
Bump rubocop to 0.77.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ AllCops:
 Layout/AccessModifierIndentation:
   Enabled: true
 
-Layout/AlignArray:
+Layout/ArrayAlignment:
   Enabled: true
 
 Layout/BlockAlignment:
@@ -46,11 +46,11 @@ Layout/EmptyLinesAroundClassBody:
 Layout/EmptyLinesAroundMethodBody:
   Enabled: true
 
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   Enabled: true
   EnforcedStyle: consistent
 
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   Enabled: true
   EnforcedStyle: consistent
 
@@ -66,7 +66,7 @@ Layout/SpaceAroundOperators:
 Layout/SpaceInsideParens:
   Enabled: true
 
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Enabled: true
 
 Layout/TrailingWhitespace:

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,4 @@ gem "rdoc", "6.2.0" # 6.2.1 is required > Ruby 2.3
 gem "rake", "~> 13.0"
 gem "minitest", "~> 5.0"
 gem "simplecov", "~> 0.17.0"
-gem "rubocop", "~> 0.74.0"
+gem "rubocop", "~> 0.77.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
     rainbow (3.0.0)
     rake (13.0.1)
     rdoc (6.2.0)
-    rubocop (0.74.0)
+    rubocop (0.77.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
@@ -36,7 +36,7 @@ DEPENDENCIES
   minitest (~> 5.0)
   rake (~> 13.0)
   rdoc (= 6.2.0)
-  rubocop (~> 0.74.0)
+  rubocop (~> 0.77.0)
   simplecov (~> 0.17.0)
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,4 +40,4 @@ DEPENDENCIES
   simplecov (~> 0.17.0)
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/util/rubocop
+++ b/util/rubocop
@@ -1,8 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-begin
-  load Gem.bin_path("rubocop", "rubocop", "~> 0.74.0")
-rescue Gem::GemNotFoundException
-  abort "Install the rubocop gem (~> 0.74.0) to run a static analysis"
-end
+require "bundler/setup"
+
+load Gem.bin_path("rubocop", "rubocop")


### PR DESCRIPTION
# Description:

This is a first step towards unifying bundler & rubygems code style: use the same rubocop version.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
