### PR TITLE
Resolver: require NameTuple before use

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1348,6 +1348,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   autoload :DependencyList,     File.expand_path('rubygems/dependency_list', __dir__)
   autoload :Installer,          File.expand_path('rubygems/installer', __dir__)
   autoload :Licenses,           File.expand_path('rubygems/util/licenses', __dir__)
+  autoload :NameTuple,          File.expand_path('rubygems/name_tuple', __dir__)
   autoload :PathSupport,        File.expand_path('rubygems/path_support', __dir__)
   autoload :Platform,           File.expand_path('rubygems/platform', __dir__)
   autoload :RequestSet,         File.expand_path('rubygems/request_set', __dir__)

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -302,6 +302,21 @@ class TestGem < Gem::TestCase
     assert_equal %w(a-1 b-2 c-1), loaded_spec_names
   end
 
+  def test_activate_bin_path_in_debug_mode
+    a1 = util_spec 'a', '1' do |s|
+      s.executables = ['exec']
+    end
+
+    install_specs a1
+
+    output, status = Open3.capture2e(
+      { "GEM_HOME" => Gem.paths.home, "DEBUG_RESOLVER" => "1" },
+      Gem.ruby, "-I", File.expand_path("../../lib", __dir__), "-e", "\"Gem.activate_bin_path('a', 'exec', '>= 0')\""
+    )
+
+    assert status.success?, output
+  end
+
   def test_activate_bin_path_gives_proper_error_for_bundler
     bundler = util_spec 'bundler', '2' do |s|
       s.executables = ['bundle']


### PR DESCRIPTION
# Description:

Resolver asks Molinillo to resolve-then-activate a gem, which can lead to using `Gem::NameTuple` before it has been loaded.

This PR adds a require at the top of Resolver, among the other utility-like requires.

I considered using an `autoload`, but was unsure where to put it.

## Indications

https://github.com/hashicorp/vagrant/pull/8079 is a fix in another project, to work around this issue.

A backtrace, on my machine:

<details>

```
	18: from /Users/olle/.rvm/gems/ruby-2.6.3@lotus/bin/ruby_executable_hooks:25:in `<main>'
	17: from /Users/olle/.rvm/gems/ruby-2.6.3@lotus/bin/ruby_executable_hooks:25:in `eval'
	16: from /Users/olle/.rvm/gems/ruby-2.6.3@lotus/bin/bundle:23:in `<main>'
	15: from /Users/olle/.rvm/rubies/ruby-2.6.3/lib/ruby/site_ruby/2.6.0/rubygems.rb:295:in `activate_bin_path'
	14: from /Users/olle/.rvm/rubies/ruby-2.6.3/lib/ruby/site_ruby/2.6.0/rubygems.rb:295:in `synchronize'
	13: from /Users/olle/.rvm/rubies/ruby-2.6.3/lib/ruby/site_ruby/2.6.0/rubygems.rb:297:in `block in activate_bin_path'
	12: from /Users/olle/.rvm/rubies/ruby-2.6.3/lib/ruby/site_ruby/2.6.0/rubygems.rb:234:in `finish_resolve'
	11: from /Users/olle/.rvm/rubies/ruby-2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/request_set.rb:435:in `resolve_current'
	10: from /Users/olle/.rvm/rubies/ruby-2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/request_set.rb:423:in `resolve'
	 9: from /Users/olle/.rvm/rubies/ruby-2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/resolver.rb:192:in `resolve'
	 8: from /Users/olle/.rvm/rubies/ruby-2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/resolver/molinillo/lib/molinillo/resolver.rb:42:in `resolve'
	 7: from /Users/olle/.rvm/rubies/ruby-2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:78:in `resolve'
	 6: from /Users/olle/.rvm/rubies/ruby-2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:137:in `process_topmost_state'
	 5: from /Users/olle/.rvm/rubies/ruby-2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:313:in `attempt_to_activate'
	 4: from /Users/olle/.rvm/rubies/ruby-2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:307:in `debug'
	 3: from /Users/olle/.rvm/rubies/ruby-2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/resolver/molinillo/lib/molinillo/modules/ui.rb:49:in `debug'
	 2: from /Users/olle/.rvm/rubies/ruby-2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:313:in `block in attempt_to_activate'
	 1: from /Users/olle/.rvm/rubies/ruby-2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/resolver/activation_request.rb:76:in `full_name'
/Users/olle/.rvm/rubies/ruby-2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/resolver/activation_request.rb:153:in `name_tuple': uninitialized constant Gem::NameTuple (NameError)
```

<summary>A backtrace</summary>

</details>
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
