### PR TITLE
Don't create `test_dir` folder in bundler repo root

### DIFF
--- a/bundler/spec/bundler/shared_helpers_spec.rb
+++ b/bundler/spec/bundler/shared_helpers_spec.rb
@@ -428,8 +428,8 @@ RSpec.describe Bundler::SharedHelpers do
       let(:file_op_block) { proc {|path| FileUtils.mkdir_p(path) } }
 
       it "performs the operation in the passed block" do
-        subject.filesystem_access("./test_dir", &file_op_block)
-        expect(Pathname.new("test_dir")).to exist
+        subject.filesystem_access(bundled_app("test_dir"), &file_op_block)
+        expect(bundled_app("test_dir")).to exist
       end
     end
 


### PR DESCRIPTION
# Description:

Running `bin/rspec spec/bundler/shared_helpers_spec.rb` inside the `bundler` folder leaves an empty `test_dir` folder at the root of the bundler folder.

Instead, we should create the empty `test_dir` folder under `tmp/`.

This PR supersedes https://github.com/rubygems/bundler/pull/7673.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
