### PR TITLE
Bump vendored molinillo of rubygems to 0.7.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -53,6 +53,7 @@ begin
   require "automatiek"
 
   Automatiek::RakeTask.new("molinillo") do |lib|
+    lib.version = "0.7.0"
     lib.download = { :github => "https://github.com/CocoaPods/Molinillo" }
     lib.namespace = "Molinillo"
     lib.prefix = "Gem::Resolver"

--- a/lib/rubygems/resolver/activation_request.rb
+++ b/lib/rubygems/resolver/activation_request.rb
@@ -28,10 +28,18 @@ class Gem::Resolver::ActivationRequest
     when Gem::Specification
       @spec == other
     when Gem::Resolver::ActivationRequest
-      @spec == other.spec && @request == other.request
+      @spec == other.spec
     else
       false
     end
+  end
+
+  def eql?(other)
+    self == other
+  end
+
+  def hash
+    @spec.hash
   end
 
   ##

--- a/lib/rubygems/resolver/api_specification.rb
+++ b/lib/rubygems/resolver/api_specification.rb
@@ -46,6 +46,10 @@ class Gem::Resolver::APISpecification < Gem::Resolver::Specification
       @dependencies == other.dependencies
   end
 
+  def hash
+    @set.hash ^ @name.hash ^ @version.hash ^ @platform.hash ^ @dependencies.hash
+  end
+
   def fetch_development_dependencies # :nodoc:
     spec = source.fetch_spec Gem::NameTuple.new @name, @version, @platform
 

--- a/lib/rubygems/resolver/dependency_request.rb
+++ b/lib/rubygems/resolver/dependency_request.rb
@@ -28,7 +28,7 @@ class Gem::Resolver::DependencyRequest
     when Gem::Dependency
       @dependency == other
     when Gem::Resolver::DependencyRequest
-      @dependency == other.dependency && @requester == other.requester
+      @dependency == other.dependency
     else
       false
     end

--- a/lib/rubygems/resolver/index_specification.rb
+++ b/lib/rubygems/resolver/index_specification.rb
@@ -33,6 +33,17 @@ class Gem::Resolver::IndexSpecification < Gem::Resolver::Specification
     spec.dependencies
   end
 
+  def ==(other)
+    self.class === other &&
+      @name == other.name &&
+      @version == other.version &&
+      @platform == other.platform
+  end
+
+  def hash
+    @name.hash ^ @version.hash ^ @platform.hash
+  end
+
   def inspect # :nodoc:
     '#<%s %s source %s>' % [self.class, full_name, @source]
   end

--- a/lib/rubygems/resolver/molinillo/lib/molinillo.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
-require 'rubygems/resolver/molinillo/lib/molinillo/gem_metadata'
-require 'rubygems/resolver/molinillo/lib/molinillo/errors'
-require 'rubygems/resolver/molinillo/lib/molinillo/resolver'
-require 'rubygems/resolver/molinillo/lib/molinillo/modules/ui'
-require 'rubygems/resolver/molinillo/lib/molinillo/modules/specification_provider'
+
+require_relative 'molinillo/gem_metadata'
+require_relative 'molinillo/errors'
+require_relative 'molinillo/resolver'
+require_relative 'molinillo/modules/ui'
+require_relative 'molinillo/modules/specification_provider'
 
 # Gem::Resolver::Molinillo is a generic dependency resolution algorithm.
 module Gem::Resolver::Molinillo

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/delegates/resolution_state.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/delegates/resolution_state.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Gem::Resolver::Molinillo
   # @!visibility private
   module Delegates
@@ -44,6 +45,12 @@ module Gem::Resolver::Molinillo
       def conflicts
         current_state = state || Gem::Resolver::Molinillo::ResolutionState.empty
         current_state.conflicts
+      end
+
+      # (see Gem::Resolver::Molinillo::ResolutionState#unused_unwind_options)
+      def unused_unwind_options
+        current_state = state || Gem::Resolver::Molinillo::ResolutionState.empty
+        current_state.unused_unwind_options
       end
     end
   end

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/delegates/specification_provider.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/delegates/specification_provider.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Gem::Resolver::Molinillo
   module Delegates
     # Delegates all {Gem::Resolver::Molinillo::SpecificationProvider} methods to a

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
+
 require 'set'
 require 'tsort'
 
-require 'rubygems/resolver/molinillo/lib/molinillo/dependency_graph/log'
-require 'rubygems/resolver/molinillo/lib/molinillo/dependency_graph/vertex'
+require_relative 'dependency_graph/log'
+require_relative 'dependency_graph/vertex'
 
 module Gem::Resolver::Molinillo
   # A directed acyclic graph that is tuned to hold named dependencies
@@ -123,6 +124,7 @@ module Gem::Resolver::Molinillo
       dot.join("\n")
     end
 
+    # @param [DependencyGraph] other
     # @return [Boolean] whether the two dependency graphs are equal, determined
     #   by a recursive traversal of each {#root_vertices} and its
     #   {Vertex#successors}
@@ -147,8 +149,8 @@ module Gem::Resolver::Molinillo
       vertex = add_vertex(name, payload, root)
       vertex.explicit_requirements << requirement if root
       parent_names.each do |parent_name|
-        parent_node = vertex_named(parent_name)
-        add_edge(parent_node, vertex, requirement)
+        parent_vertex = vertex_named(parent_name)
+        add_edge(parent_vertex, vertex, requirement)
       end
       vertex
     end
@@ -189,7 +191,7 @@ module Gem::Resolver::Molinillo
     # @return [Edge] the added edge
     def add_edge(origin, destination, requirement)
       if destination.path_to?(origin)
-        raise CircularDependencyError.new([origin, destination])
+        raise CircularDependencyError.new(path(destination, origin))
       end
       add_edge_no_circular(origin, destination, requirement)
     end
@@ -217,6 +219,38 @@ module Gem::Resolver::Molinillo
     # @return (see #add_edge)
     def add_edge_no_circular(origin, destination, requirement)
       log.add_edge_no_circular(self, origin.name, destination.name, requirement)
+    end
+
+    # Returns the path between two vertices
+    # @raise [ArgumentError] if there is no path between the vertices
+    # @param [Vertex] from
+    # @param [Vertex] to
+    # @return [Array<Vertex>] the shortest path from `from` to `to`
+    def path(from, to)
+      distances = Hash.new(vertices.size + 1)
+      distances[from.name] = 0
+      predecessors = {}
+      each do |vertex|
+        vertex.successors.each do |successor|
+          if distances[successor.name] > distances[vertex.name] + 1
+            distances[successor.name] = distances[vertex.name] + 1
+            predecessors[successor] = vertex
+          end
+        end
+      end
+
+      path = [to]
+      while before = predecessors[to]
+        path << before
+        to = before
+        break if to == from
+      end
+
+      unless path.last.equal?(from)
+        raise ArgumentError, "There is no path from #{from.name} to #{to.name}"
+      end
+
+      path.reverse
     end
   end
 end

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/action.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/action.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Gem::Resolver::Molinillo
   class DependencyGraph
     # An action that modifies a {DependencyGraph} that is reversible.

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/add_edge_no_circular.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/add_edge_no_circular.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-require 'rubygems/resolver/molinillo/lib/molinillo/dependency_graph/action'
+
+require_relative 'action'
 module Gem::Resolver::Molinillo
   class DependencyGraph
     # @!visibility private

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/add_vertex.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/add_vertex.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-require 'rubygems/resolver/molinillo/lib/molinillo/dependency_graph/action'
+
+require_relative 'action'
 module Gem::Resolver::Molinillo
   class DependencyGraph
     # @!visibility private

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/delete_edge.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/delete_edge.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-require 'rubygems/resolver/molinillo/lib/molinillo/dependency_graph/action'
+
+require_relative 'action'
 module Gem::Resolver::Molinillo
   class DependencyGraph
     # @!visibility private

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/detach_vertex_named.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/detach_vertex_named.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-require 'rubygems/resolver/molinillo/lib/molinillo/dependency_graph/action'
+
+require_relative 'action'
 module Gem::Resolver::Molinillo
   class DependencyGraph
     # @!visibility private

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/log.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/log.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
-require 'rubygems/resolver/molinillo/lib/molinillo/dependency_graph/add_edge_no_circular'
-require 'rubygems/resolver/molinillo/lib/molinillo/dependency_graph/add_vertex'
-require 'rubygems/resolver/molinillo/lib/molinillo/dependency_graph/delete_edge'
-require 'rubygems/resolver/molinillo/lib/molinillo/dependency_graph/detach_vertex_named'
-require 'rubygems/resolver/molinillo/lib/molinillo/dependency_graph/set_payload'
-require 'rubygems/resolver/molinillo/lib/molinillo/dependency_graph/tag'
+
+require_relative 'add_edge_no_circular'
+require_relative 'add_vertex'
+require_relative 'delete_edge'
+require_relative 'detach_vertex_named'
+require_relative 'set_payload'
+require_relative 'tag'
 
 module Gem::Resolver::Molinillo
   class DependencyGraph

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/set_payload.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/set_payload.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-require 'rubygems/resolver/molinillo/lib/molinillo/dependency_graph/action'
+
+require_relative 'action'
 module Gem::Resolver::Molinillo
   class DependencyGraph
     # @!visibility private

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/tag.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/tag.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-require 'rubygems/resolver/molinillo/lib/molinillo/dependency_graph/action'
+
+require_relative 'action'
 module Gem::Resolver::Molinillo
   class DependencyGraph
     # @!visibility private
@@ -13,11 +14,11 @@ module Gem::Resolver::Molinillo
       end
 
       # (see Action#up)
-      def up(_graph)
+      def up(graph)
       end
 
       # (see Action#down)
-      def down(_graph)
+      def down(graph)
       end
 
       # @!group Tag

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/vertex.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/vertex.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Gem::Resolver::Molinillo
   class DependencyGraph
     # A vertex in a {DependencyGraph} that encapsulates a {#name} and a
@@ -32,7 +33,7 @@ module Gem::Resolver::Molinillo
       # @return [Array<Object>] all of the requirements that required
       #   this vertex
       def requirements
-        incoming_edges.map(&:requirement) + explicit_requirements
+        (incoming_edges.map(&:requirement) + explicit_requirements).uniq
       end
 
       # @return [Array<Edge>] the edges of {#graph} that have `self` as their
@@ -49,14 +50,25 @@ module Gem::Resolver::Molinillo
         incoming_edges.map(&:origin)
       end
 
-      # @return [Array<Vertex>] the vertices of {#graph} where `self` is a
+      # @return [Set<Vertex>] the vertices of {#graph} where `self` is a
       #   {#descendent?}
       def recursive_predecessors
-        vertices = predecessors
-        vertices += vertices.map(&:recursive_predecessors).flatten(1)
-        vertices.uniq!
+        _recursive_predecessors
+      end
+
+      # @param [Set<Vertex>] vertices the set to add the predecessors to
+      # @return [Set<Vertex>] the vertices of {#graph} where `self` is a
+      #   {#descendent?}
+      def _recursive_predecessors(vertices = Set.new)
+        incoming_edges.each do |edge|
+          vertex = edge.origin
+          next unless vertices.add?(vertex)
+          vertex._recursive_predecessors(vertices)
+        end
+
         vertices
       end
+      protected :_recursive_predecessors
 
       # @return [Array<Vertex>] the vertices of {#graph} that have an edge with
       #   `self` as their {Edge#origin}
@@ -64,14 +76,25 @@ module Gem::Resolver::Molinillo
         outgoing_edges.map(&:destination)
       end
 
-      # @return [Array<Vertex>] the vertices of {#graph} where `self` is an
+      # @return [Set<Vertex>] the vertices of {#graph} where `self` is an
       #   {#ancestor?}
       def recursive_successors
-        vertices = successors
-        vertices += vertices.map(&:recursive_successors).flatten(1)
-        vertices.uniq!
+        _recursive_successors
+      end
+
+      # @param [Set<Vertex>] vertices the set to add the successors to
+      # @return [Set<Vertex>] the vertices of {#graph} where `self` is an
+      #   {#ancestor?}
+      def _recursive_successors(vertices = Set.new)
+        outgoing_edges.each do |edge|
+          vertex = edge.destination
+          next unless vertices.add?(vertex)
+          vertex._recursive_successors(vertices)
+        end
+
         vertices
       end
+      protected :_recursive_successors
 
       # @return [String] a string suitable for debugging
       def inspect
@@ -107,10 +130,20 @@ module Gem::Resolver::Molinillo
       # dependency graph?
       # @return true iff there is a path following edges within this {#graph}
       def path_to?(other)
-        equal?(other) || successors.any? { |v| v.path_to?(other) }
+        _path_to?(other)
       end
 
       alias descendent? path_to?
+
+      # @param [Vertex] other the vertex to check if there's a path to
+      # @param [Set<Vertex>] visited the vertices of {#graph} that have been visited
+      # @return [Boolean] whether there is a path to `other` from `self`
+      def _path_to?(other, visited = Set.new)
+        return false unless visited.add?(self)
+        return true if equal?(other)
+        successors.any? { |v| v._path_to?(other, visited) }
+      end
+      protected :_path_to?
 
       # Is there a path from `other` to `self` following edges in the
       # dependency graph?

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/errors.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/errors.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Gem::Resolver::Molinillo
   # An error that occurred during the resolution process
   class ResolverError < StandardError; end
@@ -17,7 +18,7 @@ module Gem::Resolver::Molinillo
     # @param [Array<Object>] required_by @see {#required_by}
     def initialize(dependency, required_by = [])
       @dependency = dependency
-      @required_by = required_by
+      @required_by = required_by.uniq
       super()
     end
 
@@ -41,11 +42,11 @@ module Gem::Resolver::Molinillo
     attr_reader :dependencies
 
     # Initializes a new error with the given circular vertices.
-    # @param [Array<DependencyGraph::Vertex>] nodes the nodes in the dependency
+    # @param [Array<DependencyGraph::Vertex>] vertices the vertices in the dependency
     #   that caused the error
-    def initialize(nodes)
-      super "There is a circular dependency between #{nodes.map(&:name).join(' and ')}"
-      @dependencies = nodes.map(&:payload).to_set
+    def initialize(vertices)
+      super "There is a circular dependency between #{vertices.map(&:name).join(' and ')}"
+      @dependencies = vertices.map { |vertex| vertex.payload.possibilities.last }.to_set
     end
   end
 
@@ -55,11 +56,16 @@ module Gem::Resolver::Molinillo
     #   resolution to fail
     attr_reader :conflicts
 
+    # @return [SpecificationProvider] the specification provider used during
+    #   resolution
+    attr_reader :specification_provider
+
     # Initializes a new error with the given version conflicts.
     # @param [{String => Resolution::Conflict}] conflicts see {#conflicts}
-    def initialize(conflicts)
+    # @param [SpecificationProvider] specification_provider see {#specification_provider}
+    def initialize(conflicts, specification_provider)
       pairs = []
-      conflicts.values.flatten.map(&:requirements).flatten.each do |conflicting|
+      conflicts.values.flat_map(&:requirements).each do |conflicting|
         conflicting.each do |source, conflict_requirements|
           conflict_requirements.each do |c|
             pairs << [c, source]
@@ -69,7 +75,69 @@ module Gem::Resolver::Molinillo
 
       super "Unable to satisfy the following requirements:\n\n" \
         "#{pairs.map { |r, d| "- `#{r}` required by `#{d}`" }.join("\n")}"
+
       @conflicts = conflicts
+      @specification_provider = specification_provider
+    end
+
+    require_relative 'delegates/specification_provider'
+    include Delegates::SpecificationProvider
+
+    # @return [String] An error message that includes requirement trees,
+    #   which is much more detailed & customizable than the default message
+    # @param [Hash] opts the options to create a message with.
+    # @option opts [String] :solver_name The user-facing name of the solver
+    # @option opts [String] :possibility_type The generic name of a possibility
+    # @option opts [Proc] :reduce_trees A proc that reduced the list of requirement trees
+    # @option opts [Proc] :printable_requirement A proc that pretty-prints requirements
+    # @option opts [Proc] :additional_message_for_conflict A proc that appends additional
+    #   messages for each conflict
+    # @option opts [Proc] :version_for_spec A proc that returns the version number for a
+    #   possibility
+    def message_with_trees(opts = {})
+      solver_name = opts.delete(:solver_name) { self.class.name.split('::').first }
+      possibility_type = opts.delete(:possibility_type) { 'possibility named' }
+      reduce_trees = opts.delete(:reduce_trees) { proc { |trees| trees.uniq.sort_by(&:to_s) } }
+      printable_requirement = opts.delete(:printable_requirement) { proc { |req| req.to_s } }
+      additional_message_for_conflict = opts.delete(:additional_message_for_conflict) { proc {} }
+      version_for_spec = opts.delete(:version_for_spec) { proc(&:to_s) }
+      incompatible_version_message_for_conflict = opts.delete(:incompatible_version_message_for_conflict) do
+        proc do |name, _conflict|
+          %(#{solver_name} could not find compatible versions for #{possibility_type} "#{name}":)
+        end
+      end
+
+      conflicts.sort.reduce(''.dup) do |o, (name, conflict)|
+        o << "\n" << incompatible_version_message_for_conflict.call(name, conflict) << "\n"
+        if conflict.locked_requirement
+          o << %(  In snapshot (#{name_for_locking_dependency_source}):\n)
+          o << %(    #{printable_requirement.call(conflict.locked_requirement)}\n)
+          o << %(\n)
+        end
+        o << %(  In #{name_for_explicit_dependency_source}:\n)
+        trees = reduce_trees.call(conflict.requirement_trees)
+
+        o << trees.map do |tree|
+          t = ''.dup
+          depth = 2
+          tree.each do |req|
+            t << '  ' * depth << req.to_s
+            unless tree.last == req
+              if spec = conflict.activated_by_name[name_for(req)]
+                t << %( was resolved to #{version_for_spec.call(spec)}, which)
+              end
+              t << %( depends on)
+            end
+            t << %(\n)
+            depth += 1
+          end
+          t
+        end.join("\n")
+
+        additional_message_for_conflict.call(o, name, conflict)
+
+        o
+      end.strip
     end
   end
 end

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/gem_metadata.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/gem_metadata.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
+
 module Gem::Resolver::Molinillo
   # The version of Gem::Resolver::Molinillo.
-  VERSION = '0.5.7'.freeze
+  VERSION = '0.7.0'.freeze
 end

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/modules/specification_provider.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/modules/specification_provider.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Gem::Resolver::Molinillo
   # Provides information about specifcations and dependencies to the resolver,
   # allowing the {Resolver} class to remain generic while still providing power

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/modules/ui.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/modules/ui.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Gem::Resolver::Molinillo
   # Conveys information about the resolution process to a user.
   module UI
@@ -48,7 +49,8 @@ module Gem::Resolver::Molinillo
       if debug?
         debug_info = yield
         debug_info = debug_info.inspect unless debug_info.is_a?(String)
-        output.puts debug_info.split("\n").map { |s| ' ' * depth + s }
+        debug_info = debug_info.split("\n").map { |s| ":#{depth.to_s.rjust 4}: #{s}" }
+        output.puts debug_info
       end
     end
 

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/resolver.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/resolver.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-require 'rubygems/resolver/molinillo/lib/molinillo/dependency_graph'
+
+require_relative 'dependency_graph'
 
 module Gem::Resolver::Molinillo
   # This class encapsulates a dependency resolver.
@@ -8,7 +9,7 @@ module Gem::Resolver::Molinillo
   #
   #
   class Resolver
-    require 'rubygems/resolver/molinillo/lib/molinillo/resolution'
+    require_relative 'resolution'
 
     # @return [SpecificationProvider] the specification provider used
     #   in the resolution process

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/state.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/state.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Gem::Resolver::Molinillo
   # A state that a {Resolution} can be in
   # @attr [String] name the name of the current requirement
@@ -7,7 +8,8 @@ module Gem::Resolver::Molinillo
   # @attr [Object] requirement the current requirement
   # @attr [Object] possibilities the possibilities to satisfy the current requirement
   # @attr [Integer] depth the depth of the resolution
-  # @attr [Set<Object>] conflicts unresolved conflicts
+  # @attr [Hash] conflicts unresolved conflicts, indexed by dependency name
+  # @attr [Array<UnwindDetails>] unused_unwind_options unwinds for previous conflicts that weren't explored
   ResolutionState = Struct.new(
     :name,
     :requirements,
@@ -15,14 +17,15 @@ module Gem::Resolver::Molinillo
     :requirement,
     :possibilities,
     :depth,
-    :conflicts
+    :conflicts,
+    :unused_unwind_options
   )
 
   class ResolutionState
     # Returns an empty resolution state
     # @return [ResolutionState] an empty state
     def self.empty
-      new(nil, [], DependencyGraph.new, nil, nil, 0, Set.new)
+      new(nil, [], DependencyGraph.new, nil, nil, 0, {}, [])
     end
   end
 
@@ -40,7 +43,8 @@ module Gem::Resolver::Molinillo
         requirement,
         [possibilities.pop],
         depth + 1,
-        conflicts.dup
+        conflicts.dup,
+        unused_unwind_options.dup
       ).tap do |state|
         state.activated.tag(state)
       end


### PR DESCRIPTION
# Description:

The problem is that rubygems uses a different version of molinillo than bundler.

So should get those in sync so that we can eventually use a single resolver.

This PR upgrades rubygems molinillo to the latest molinillo's master, which is what bundler currently uses.

Supersedes https://github.com/rubygems/rubygems/pull/2026.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
