### PR TITLE
Remove `auto_config_jobs` feature flag

### DIFF
--- a/bundler/lib/bundler/feature_flag.rb
+++ b/bundler/lib/bundler/feature_flag.rb
@@ -30,7 +30,6 @@ module Bundler
     settings_flag(:allow_bundler_dependency_conflicts) { bundler_3_mode? }
     settings_flag(:allow_offline_install) { bundler_3_mode? }
     settings_flag(:auto_clean_without_path) { bundler_3_mode? }
-    settings_flag(:auto_config_jobs) { bundler_3_mode? }
     settings_flag(:cache_all) { bundler_3_mode? }
     settings_flag(:default_install_uses_path) { bundler_3_mode? }
     settings_flag(:deployment_means_frozen) { bundler_3_mode? }

--- a/bundler/lib/bundler/installer.rb
+++ b/bundler/lib/bundler/installer.rb
@@ -204,18 +204,7 @@ module Bundler
 
       return 1 unless can_install_in_parallel?
 
-      auto_config_jobs = Bundler.feature_flag.auto_config_jobs?
-      if jobs = Bundler.settings[:jobs]
-        if auto_config_jobs
-          jobs
-        else
-          [jobs.pred, 1].max
-        end
-      elsif auto_config_jobs
-        processor_count
-      else
-        1
-      end
+      Bundler.settings[:jobs] || processor_count
     end
 
     def processor_count

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -12,7 +12,6 @@ module Bundler
       allow_offline_install
       auto_clean_without_path
       auto_install
-      auto_config_jobs
       cache_all
       cache_all_platforms
       default_install_uses_path

--- a/bundler/spec/quality_spec.rb
+++ b/bundler/spec/quality_spec.rb
@@ -169,7 +169,6 @@ RSpec.describe "The library itself" do
 
   it "documents all used settings" do
     exemptions = %w[
-      auto_config_jobs
       deployment_means_frozen
       forget_cli_options
       gem.coc


### PR DESCRIPTION
# Description:

In https://github.com/rubygems/bundler/pull/5986 several changes were made:

* Fix bundler incorrectly setting the number of parallel installer jobs to be one unit less that the value specified by the user.
* Hide the fix under a feature flag.
* Introduce the feature of auto-configuring the number of parallel installer jobs to be the number of available processors.
* Hide the feature under the same feature flag.

In my opinion, hiding both the fix and the feature under a feature flag is wrong and they should instead be enabled by default.

The rationale is that:

* We should not hide fixes under feature flags (that's for breaking features).
* We should not hide non-breaking features under feature flags (that's for breaking features).

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
