### PR TITLE
Removed self-hosted YAML Serializer and PsychedYAML

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -641,12 +641,11 @@ EOF
     private
 
     def eval_yaml_gemspec(path, contents)
-      require_relative "bundler/psyched_yaml"
+      Kernel.send(:require, "yaml")
 
-      # If the YAML is invalid, Syck raises an ArgumentError, and Psych
-      # raises a Psych::SyntaxError. See psyched_yaml.rb for more info.
+      # If the YAML is invalid, Psych raises a Psych::SyntaxError.
       Gem::Specification.from_yaml(contents)
-    rescue YamlLibrarySyntaxError, ArgumentError, Gem::EndOfYAMLException, Gem::Exception
+    rescue Psych::SyntaxError, Gem::EndOfYAMLException, Gem::Exception
       eval_gemspec(path, contents)
     end
 

--- a/bundler/lib/bundler/plugin/index.rb
+++ b/bundler/lib/bundler/plugin/index.rb
@@ -148,8 +148,8 @@ module Bundler
 
           data = index_f.read
 
-          require_relative "../yaml_serializer"
-          index = YAMLSerializer.load(data)
+          require "yaml"
+          index = YAML.load(data)
 
           @commands.merge!(index["commands"])
           @hooks.merge!(index["hooks"])
@@ -171,10 +171,10 @@ module Bundler
           "sources"      => @sources,
         }
 
-        require_relative "../yaml_serializer"
+        require "yaml"
         SharedHelpers.filesystem_access(index_file) do |index_f|
           FileUtils.mkdir_p(index_f.dirname)
-          File.open(index_f, "w") {|f| f.puts YAMLSerializer.dump(index) }
+          File.open(index_f, "w") {|f| f.puts YAML.dump(index) }
         end
       end
     end

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -116,7 +116,7 @@ module Bundler
     end
 
     def configuration
-      require_relative "psyched_yaml"
+      require "yaml"
       Gem.configuration
     rescue Gem::SystemExitException, LoadError => e
       Bundler.ui.error "#{e.class}: #{e.message}"
@@ -253,7 +253,7 @@ module Bundler
 
     def spec_from_gem(path, policy = nil)
       require "rubygems/security"
-      require_relative "psyched_yaml"
+      require "yaml"
       gem_from_path(path, security_policies[policy]).spec
     rescue Exception, Gem::Exception, Gem::Security::Exception => e # rubocop:disable Lint/RescueException
       if e.is_a?(Gem::Security::Exception) ||

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "uri"
+
 module Bundler
   class Settings
     autoload :Mirror,  File.expand_path("mirror", __dir__)
@@ -139,11 +141,7 @@ module Bundler
     end
 
     def mirror_for(uri)
-      if uri.is_a?(String)
-        require_relative "vendored_uri"
-        uri = Bundler::URI(uri)
-      end
-
+      uri = URI(uri.to_s) unless uri.is_a?(URI)
       gem_mirrors.for(uri.to_s).uri
     end
 
@@ -358,8 +356,8 @@ module Bundler
       return unless file
       SharedHelpers.filesystem_access(file) do |p|
         FileUtils.mkdir_p(p.dirname)
-        require_relative "yaml_serializer"
-        p.open("w") {|f| f.write(YAMLSerializer.dump(hash)) }
+        require "yaml"
+        p.open("w") {|f| f.write(YAML.dump(hash)) }
       end
     end
 
@@ -398,8 +396,8 @@ module Bundler
       SharedHelpers.filesystem_access(config_file, :read) do |file|
         valid_file = file.exist? && !file.size.zero?
         return {} unless valid_file
-        require_relative "yaml_serializer"
-        YAMLSerializer.load file.read
+        require "yaml"
+        YAML.load file.read
       end
     end
 
@@ -426,8 +424,7 @@ module Bundler
         suffix = $3
       end
       uri = "#{uri}/" unless uri.end_with?("/")
-      require_relative "vendored_uri"
-      uri = Bundler::URI(uri)
+      uri = URI(uri)
       unless uri.absolute?
         raise ArgumentError, format("Gem sources must be absolute. You provided '%s'.", uri)
       end

--- a/bundler/spec/bundler/bundler_spec.rb
+++ b/bundler/spec/bundler/bundler_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Bundler do
         context "with Psych as YAML::Engine" do
           it "raises a GemspecError after YAML load throws Psych::SyntaxError" do
             orig_yamler = YAML::ENGINE.yamler
-            YAML::ENGINE.yamler = "psych"
+            YAML::ENGINE.yamler = "yaml"
 
             expect { subject }.to raise_error(Bundler::GemspecError)
 

--- a/bundler/spec/bundler/psyched_yaml_spec.rb
+++ b/bundler/spec/bundler/psyched_yaml_spec.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require "bundler/psyched_yaml"
-
-RSpec.describe "Bundler::YamlLibrarySyntaxError" do
-  it "is raised on YAML parse errors" do
-    expect { YAML.parse "{foo" }.to raise_error(Bundler::YamlLibrarySyntaxError)
-  end
-end

--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "bundler/psyched_yaml"
+require "yaml"
 require "bundler/vendored_fileutils"
 require "bundler/vendored_uri"
 require "digest"


### PR DESCRIPTION
# Description:

Migrate from https://github.com/rubygems/bundler/pull/6536

I hope to unify the specification of YAML serializer in Rubygems. But We have a some of the activated issues related to the default gems.
______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
