### PR TITLE
Remove multiline gem specifications correctly

### DIFF
--- a/bundler/lib/bundler/injector.rb
+++ b/bundler/lib/bundler/injector.rb
@@ -183,7 +183,7 @@ module Bundler
       # remove lines which match the regex
       new_gemfile = IO.readlines(gemfile_path).reject {|line| line.match(patterns) }
 
-      # remove lone \n and append them with other strings
+      # remove line \n and append them with other strings
       new_gemfile.each_with_index do |_line, index|
         if new_gemfile[index + 1] == "\n"
           new_gemfile[index] += new_gemfile[index + 1]

--- a/bundler/spec/commands/remove_spec.rb
+++ b/bundler/spec/commands/remove_spec.rb
@@ -44,6 +44,30 @@ RSpec.describe "bundle remove" do
           source "#{file_uri_for(gem_repo1)}"
         G
       end
+
+      context "when gem is specified in multiple lines" do
+        it "shows success for removed gem" do
+          gemfile <<-G
+            source '#{file_uri_for(gem_repo1)}'
+
+            gem 'git'
+            gem 'rack',
+                git: 'https://github.com/rack/rack',
+                branch: 'master'
+            gem 'nokogiri'
+          G
+
+          bundle! "remove rack"
+
+          expect(out).to include("rack was removed.")
+          gemfile_should_be <<-G
+            source '#{file_uri_for(gem_repo1)}'
+
+            gem 'git'
+            gem 'nokogiri'
+          G
+        end
+      end
     end
 
     context "when gem is not present in gemfile" do


### PR DESCRIPTION
# Description:

Migrated from https://github.com/rubygems/bundler/pull/7454.

Fixes https://github.com/rubygems/rubygems/issues/3306.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
