### PR TITLE
Add Bundler::Definition.no_lock accessor for skipping lock file creation/update 

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -7,6 +7,11 @@ module Bundler
   class Definition
     include GemHelpers
 
+    class << self
+      # Do not create or modify a lockfile (Makes #lock a noop)
+      attr_accessor :no_lock
+    end
+
     attr_reader(
       :dependencies,
       :locked_deps,
@@ -331,6 +336,8 @@ module Bundler
     end
 
     def lock(file, preserve_unknown_sections = false)
+      return if Definition.no_lock
+
       contents = to_lock
 
       # Convert to \r\n if the existing lock has them

--- a/bundler/spec/bundler/definition_spec.rb
+++ b/bundler/spec/bundler/definition_spec.rb
@@ -31,6 +31,16 @@ RSpec.describe Bundler::Definition do
           to raise_error(Bundler::TemporaryResourceError, /temporarily unavailable/)
       end
     end
+    context "when Bundler::Definition.no_lock is set to true" do
+      subject { Bundler::Definition.new(nil, [], Bundler::SourceList.new, []) }
+      before { Bundler::Definition.no_lock = true }
+      after { Bundler::Definition.no_lock = false }
+
+      it "does not create a lock file" do
+        subject.lock("Gemfile.lock")
+        expect(File.file?("Gemfile.lock")).to eq false
+      end
+    end
   end
 
   describe "detects changes" do


### PR DESCRIPTION
# Description:

Migrated from https://github.com/rubygems/bundler/pull/7173

/cc @jeremyevans 

______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
