### PR TITLE
Make `bundle config --local` docs clearer

### DIFF
--- a/bundler/man/bundle-config.1
+++ b/bundler/man/bundle-config.1
@@ -16,7 +16,7 @@ This command allows you to interact with Bundler\'s configuration system\.
 Bundler loads configuration settings in this order:
 .
 .IP "1." 4
-Local config (\fBapp/\.bundle/config\fR or \fB$BUNDLE_APP_CONFIG/config\fR)
+Local config (\fB<project_root>/\.bundle/config\fR or \fB$BUNDLE_APP_CONFIG/config\fR)
 .
 .IP "2." 4
 Environmental variables (\fBENV\fR)
@@ -42,7 +42,7 @@ Executing \fBbundle config set <name> <value>\fR will set that configuration to 
 Executing \fBbundle config set \-\-global <name> <value>\fR works the same as above\.
 .
 .P
-Executing \fBbundle config set \-\-local <name> <value>\fR will set that configuration to the local application\. The configuration will be stored in \fBapp/\.bundle/config\fR\. If \fBBUNDLE_APP_CONFIG\fR is set, the configuration will be stored in \fB$BUNDLE_APP_CONFIG/config\fR\.
+Executing \fBbundle config set \-\-local <name> <value>\fR will set that configuration in the directory for the local application\. The configuration will be stored in \fB<project_root>/\.bundle/config\fR\. If \fBBUNDLE_APP_CONFIG\fR is set, the configuration will be stored in \fB$BUNDLE_APP_CONFIG/config\fR\.
 .
 .P
 Executing \fBbundle config unset <name>\fR will delete the configuration in both local and global sources\.

--- a/bundler/man/bundle-config.1.txt
+++ b/bundler/man/bundle-config.1.txt
@@ -14,7 +14,8 @@ DESCRIPTION
 
        Bundler loads configuration settings in this order:
 
-       1.  Local config (app/.bundle/config or $BUNDLE_APP_CONFIG/config)
+       1.  Local        config        (<project_root>/.bundle/config        or
+           $BUNDLE_APP_CONFIG/config)
 
        2.  Environmental variables (ENV)
 
@@ -24,25 +25,26 @@ DESCRIPTION
 
 
 
-       Executing bundle config list with will print  a  list  of  all  bundler
-       configuration  for the current bundle, and where that configuration was
+       Executing  bundle  config  list  with  will print a list of all bundler
+       configuration for the current bundle, and where that configuration  was
        set.
 
-       Executing bundle config  get  <name>  will  print  the  value  of  that
+       Executing  bundle  config  get  <name>  will  print  the  value of that
        configuration setting, and where it was set.
 
-       Executing  bundle config set <name> <value> will set that configuration
-       to the value specified for all bundles executed as  the  current  user.
-       The  configuration  will be stored in ~/.bundle/config. If name already
+       Executing bundle config set <name> <value> will set that  configuration
+       to  the  value  specified for all bundles executed as the current user.
+       The configuration will be stored in ~/.bundle/config. If  name  already
        is set, name will be overridden and user will be warned.
 
-       Executing bundle config set --global <name> <value> works the  same  as
+       Executing  bundle  config set --global <name> <value> works the same as
        above.
 
-       Executing  bundle  config  set  --local  <name>  <value>  will set that
-       configuration to the  local  application.  The  configuration  will  be
-       stored   in   app/.bundle/config.  If  BUNDLE_APP_CONFIG  is  set,  the
-       configuration will be stored in $BUNDLE_APP_CONFIG/config.
+       Executing bundle config  set  --local  <name>  <value>  will  set  that
+       configuration   in   the  directory  for  the  local  application.  The
+       configuration  will  be  stored  in  <project_root>/.bundle/config.  If
+       BUNDLE_APP_CONFIG   is   set,  the  configuration  will  be  stored  in
+       $BUNDLE_APP_CONFIG/config.
 
        Executing bundle config unset <name> will delete the  configuration  in
        both local and global sources.

--- a/bundler/man/bundle-config.ronn
+++ b/bundler/man/bundle-config.ronn
@@ -11,7 +11,7 @@ This command allows you to interact with Bundler's configuration system.
 
 Bundler loads configuration settings in this order:
 
-1. Local config (`app/.bundle/config` or `$BUNDLE_APP_CONFIG/config`)
+1. Local config (`<project_root>/.bundle/config` or `$BUNDLE_APP_CONFIG/config`)
 2. Environmental variables (`ENV`)
 3. Global config (`~/.bundle/config`)
 4. Bundler default config
@@ -30,10 +30,10 @@ overridden and user will be warned.
 
 Executing `bundle config set --global <name> <value>` works the same as above.
 
-Executing `bundle config set --local <name> <value>` will set that configuration to
-the local application. The configuration will be stored in `app/.bundle/config`. If
-`BUNDLE_APP_CONFIG` is set, the configuration will be stored in
-`$BUNDLE_APP_CONFIG/config`.
+Executing `bundle config set --local <name> <value>` will set that configuration
+in the directory for the local application. The configuration will be stored in
+`<project_root>/.bundle/config`. If `BUNDLE_APP_CONFIG` is set, the configuration
+will be stored in `$BUNDLE_APP_CONFIG/config`.
 
 Executing `bundle config unset <name>` will delete the configuration in both
 local and global sources.


### PR DESCRIPTION
The previous references to "app" could easily be confused with the
"app" directory of a Rails project, leading people to look in the
wrong place for Bundler configuration. Instead use a variable that
should make it clearer that we mean the top level of the project.

Fixes #3385.

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
