### PR TITLE
Replace links directing to the old bundler repo with new ones

### DIFF
--- a/bundler/README.md
+++ b/bundler/README.md
@@ -43,7 +43,7 @@ To get in touch with the Bundler core team and other Bundler users, please see [
 
 ### Contributing
 
-If you'd like to contribute to Bundler, that's awesome, and we <3 you. We've put together [the Bundler contributor guide](https://github.com/rubygems/bundler/blob/master/doc/contributing/README.md) with all of the information you need to get started.
+If you'd like to contribute to Bundler, that's awesome, and we <3 you. We've put together [the Bundler contributor guide](https://github.com/rubygems/rubygems/blob/master/bundler/doc/contributing/README.md) with all of the information you need to get started.
 
 If you'd like to request a substantial change to Bundler or to the Bundler documentation, refer to the [Bundler RFC process](https://github.com/bundler/rfcs) for more information.
 

--- a/bundler/doc/contributing/COMMUNITY.md
+++ b/bundler/doc/contributing/COMMUNITY.md
@@ -2,7 +2,7 @@
 
 Community is an important part of all we do. If you'd like to be part of the Bundler community, you can jump right in and start helping make Bundler better for everyone who uses it.
 
-It would be tremendously helpful to have more people answering questions about Bundler (and often simply about [RubyGems](https://github.com/rubygems/rubygems) or Ruby itself) in our [issue tracker](https://github.com/rubygems/bundler/issues) or on [Stack Overflow](https://stackoverflow.com/questions/tagged/bundler).
+It would be tremendously helpful to have more people answering questions about Bundler (and often simply about [RubyGems](https://github.com/rubygems/rubygems) or Ruby itself) in our [issue tracker](https://github.com/rubygems/rubygems/issues) or on [Stack Overflow](https://stackoverflow.com/questions/tagged/bundler).
 
 Additional documentation and explanation is always helpful, too. If you have any suggestions for the Bundler website [bundler.io](https://bundler.io), we would absolutely love it if you opened an issue or pull request on the [bundler-site](https://github.com/rubygems/bundler-site) repository.
 

--- a/bundler/doc/contributing/HOW_YOU_CAN_HELP.md
+++ b/bundler/doc/contributing/HOW_YOU_CAN_HELP.md
@@ -6,22 +6,22 @@ If at any point you get stuck, here's how to [get in touch with the Bundler team
 
 ## First contribution suggestions
 
-We track [small bugs and features](https://github.com/rubygems/bundler/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) so that anyone who wants to help can start with something that's not too overwhelming.
+We track [small bugs and features](https://github.com/rubygems/rubygems/issues?q=is%3Aissue+is%3Aopen+label%3Abundler+label%3A%22good+first+issue%22) so that anyone who wants to help can start with something that's not too overwhelming.
 
 Generally, great ways to get started helping out with Bundler are:
 
   - using prerelease versions (run `gem install bundler --pre`)
-  - [reporting bugs you encounter or suggesting new features](https://github.com/rubygems/bundler/issues/new)
+  - [reporting bugs you encounter or suggesting new features](https://github.com/rubygems/rubygems/issues/new)
     - see our [issues guide](ISSUES.md) for help on filing issues
     - see the [new features documentation](../development/NEW_FEATURES.md) for more
   - adding to or editing [the Bundler documentation website](https://bundler.io) and [Bundler man pages](https://bundler.io/man/bundle.1.html)
   - [checking issues for completeness](BUG_TRIAGE.md)
   - closing issues that are not complete
-  - adding a failing test for reproducible [reported bugs](https://github.com/rubygems/bundler/issues)
-  - reviewing [pull requests](https://github.com/rubygems/bundler/pulls) and suggesting improvements
+  - adding a failing test for reproducible [reported bugs](https://github.com/rubygems/rubygems/issues)
+  - reviewing [pull requests](https://github.com/rubygems/rubygems/pulls) and suggesting improvements
   - improving existing code, including suggestions from [CodeClimate](https://codeclimate.com/github/rubygems/bundler)
   - writing code (no patch is too small! fix typos or bad whitespace)
     - get started setting up your dev environment with [these instructions](../development/SETUP.md)
-  - backfilling [unit tests](https://github.com/rubygems/bundler/tree/master/spec/bundler) for modules that lack coverage.
+  - backfilling [unit tests](https://github.com/rubygems/rubygems/tree/master/bundler/spec/bundler) for modules that lack coverage.
 
 If nothing on those lists looks good, [talk to us](https://slack.bundler.io/), and we'll figure out what you can help with. We can absolutely use your help, no matter what level of programming skill you have at the moment.

--- a/bundler/doc/contributing/README.md
+++ b/bundler/doc/contributing/README.md
@@ -4,11 +4,11 @@ Thank you for your interest in making Bundler better! We welcome contributions f
 
 Before submitting a contribution, read through the following guidelines:
 
-* [Bundler Code of Conduct](https://github.com/rubygems/bundler/blob/master/CODE_OF_CONDUCT.md) (By participating in Bundler, you agree to abide by the terms laid out in the CoC.)
-* [Issue Reporting Guidelines](https://github.com/rubygems/bundler/blob/master/doc/contributing/ISSUES.md)
-* [Pull Request Guidelines](https://github.com/rubygems/bundler/blob/master/doc/development/PULL_REQUESTS.md)
+* [Bundler Code of Conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) (By participating in Bundler, you agree to abide by the terms laid out in the CoC.)
+* [Issue Reporting Guidelines](https://github.com/rubygems/rubygems/blob/master/bundler/doc/contributing/ISSUES.md)
+* [Pull Request Guidelines](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md)
 
-And be sure to [set up your development environment](https://github.com/rubygems/bundler/blob/master/doc/development/SETUP.md).
+And be sure to [set up your development environment](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/SETUP.md).
 
 ## Feature Requests
 
@@ -18,11 +18,11 @@ To request substantial changes to Bundler and/or Bundler documentation, please r
 
 Here are the different ways you can start contributing to the Bundler project:
 
-* [First contribution suggestions](https://github.com/rubygems/bundler/blob/master/doc/contributing/HOW_YOU_CAN_HELP.md)
-* [Adding new features](https://github.com/rubygems/bundler/blob/master/doc/development/NEW_FEATURES.md)
-* [Triaging bugs](https://github.com/rubygems/bundler/blob/master/doc/contributing/BUG_TRIAGE.md)
-* [Writing documentation](https://github.com/rubygems/bundler/blob/master/doc/documentation/WRITING.md)
-* [Community engagement](https://github.com/rubygems/bundler/blob/master/doc/contributing/COMMUNITY.md)
+* [First contribution suggestions](/bundler/doc/contributing/HOW_YOU_CAN_HELP.md)
+* [Adding new features](/bundler/doc/development/NEW_FEATURES.md)
+* [Triaging bugs](/bundler/doc/contributing/BUG_TRIAGE.md)
+* [Writing documentation](/bundler/doc/documentation/WRITING.md)
+* [Community engagement](/bundler/doc/contributing/COMMUNITY.md)
 
 ## Supporting Bundler
 

--- a/bundler/doc/development/NEW_FEATURES.md
+++ b/bundler/doc/development/NEW_FEATURES.md
@@ -2,7 +2,7 @@
 
 If you would like to add a new feature to Bundler, please follow these steps:
 
-  1. [Create an issue](https://github.com/rubygems/bundler/issues/new) with the [`feature-request` label](https://github.com/rubygems/bundler/labels/type:%20feature-request) to discuss your feature.
+  1. [Create an issue](https://github.com/rubygems/rubygems/issues/new) with the [`feature-request` label](https://github.com/rubygems/rubygems/labels/type:%20feature-request) to discuss your feature.
   2. Base your commits on the master branch, since we follow [SemVer](https://semver.org) and don't add new features to old releases.
   3. Commit the code and at least one test covering your changes to a feature branch in your fork.
   4. Send us a [pull request](PULL_REQUESTS.md) from your feature branch.

--- a/bundler/doc/development/SETUP.md
+++ b/bundler/doc/development/SETUP.md
@@ -2,7 +2,7 @@
 
 Bundler doesn't use a Gemfile to list development dependencies, because when we tried it we couldn't tell if we were awake or it was just another level of dreams. To work on Bundler, you'll probably want to do a couple of things:
 
-1. [Fork the Bundler repo](https://github.com/rubygems/bundler), and clone the fork onto your machine. ([Follow this tutorial](https://help.github.com/articles/fork-a-repo/) for instructions on forking a repo.)
+1. [Fork the Rubygems repo](https://github.com/rubygems/rubygems), and clone the fork onto your machine. ([Follow this tutorial](https://help.github.com/articles/fork-a-repo/) for instructions on forking a repo.)
 
 2. Install `groff-base` and `graphviz` packages using your package manager:
 


### PR DESCRIPTION
# Description:
Some of the links in contribution docs referenced to old links in the bundler repo, which are replaced in this request.
____________


I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
