### PR TITLE
Revert "Remove Gem::DependencyInstaller#find_gems_with_sources"

### DIFF
--- a/test/rubygems/test_gem_dependency_installer.rb
+++ b/test/rubygems/test_gem_dependency_installer.rb
@@ -911,6 +911,117 @@ class TestGemDependencyInstaller < Gem::TestCase
     assert_equal %w[d-2], inst.installed_gems.map { |s| s.full_name }
   end
 
+  def test_find_gems_gems_with_sources
+    util_setup_gems
+
+    inst = Gem::DependencyInstaller.new
+    dep = Gem::Dependency.new 'b', '>= 0'
+
+    Gem::Specification.reset
+
+    set = Gem::Deprecate.skip_during do
+      inst.find_gems_with_sources(dep)
+    end
+
+    assert_kind_of Gem::AvailableSet, set
+
+    s = set.set.first
+
+    assert_equal @b1, s.spec
+    assert_equal Gem::Source.new(@gem_repo), s.source
+  end
+
+  def test_find_gems_with_sources_local
+    util_setup_gems
+
+    FileUtils.mv @a1_gem, @tempdir
+    inst = Gem::DependencyInstaller.new
+    dep = Gem::Dependency.new 'a', '>= 0'
+    set = nil
+
+    Dir.chdir @tempdir do
+      set = Gem::Deprecate.skip_during do
+        inst.find_gems_with_sources dep
+      end
+    end
+
+    gems = set.sorted
+
+    assert_equal 2, gems.length
+
+    remote, local = gems
+
+    assert_equal 'a-1', local.spec.full_name, 'local spec'
+    assert_equal File.join(@tempdir, @a1.file_name),
+                 local.source.download(local.spec), 'local path'
+
+    assert_equal 'a-1', remote.spec.full_name, 'remote spec'
+    assert_equal Gem::Source.new(@gem_repo), remote.source, 'remote path'
+  end
+
+  def test_find_gems_with_sources_prerelease
+    util_setup_gems
+
+    installer = Gem::DependencyInstaller.new
+
+    dependency = Gem::Dependency.new('a', Gem::Requirement.default)
+
+    set = Gem::Deprecate.skip_during do
+      installer.find_gems_with_sources(dependency)
+    end
+
+    releases = set.all_specs
+
+    assert releases.any? { |s| s.name == 'a' and s.version.to_s == '1' }
+    refute releases.any? { |s| s.name == 'a' and s.version.to_s == '1.a' }
+
+    dependency.prerelease = true
+
+    set = Gem::Deprecate.skip_during do
+      installer.find_gems_with_sources(dependency)
+    end
+
+    prereleases = set.all_specs
+
+    assert_equal [@a1_pre, @a1], prereleases
+  end
+
+  def test_find_gems_with_sources_with_best_only_and_platform
+    util_setup_gems
+    a1_x86_mingw32, = util_gem 'a', '1' do |s|
+      s.platform = 'x86-mingw32'
+    end
+    util_setup_spec_fetcher @a1, a1_x86_mingw32
+    Gem.platforms << Gem::Platform.new('x86-mingw32')
+
+    installer = Gem::DependencyInstaller.new
+
+    dependency = Gem::Dependency.new('a', Gem::Requirement.default)
+
+    set = Gem::Deprecate.skip_during do
+      installer.find_gems_with_sources(dependency, true)
+    end
+
+    releases = set.all_specs
+
+    assert_equal [a1_x86_mingw32], releases
+  end
+
+  def test_find_gems_with_sources_with_bad_source
+    Gem.sources.replace ["http://not-there.nothing"]
+
+    installer = Gem::DependencyInstaller.new
+
+    dep = Gem::Dependency.new('a')
+
+    out = Gem::Deprecate.skip_during do
+      installer.find_gems_with_sources(dep)
+    end
+
+    assert out.empty?
+    assert_kind_of Gem::SourceFetchProblem, installer.errors.first
+  end
+
   def test_resolve_dependencies
     util_setup_gems
 


### PR DESCRIPTION
# Description:

I noticed that a pretty popular gem, `ruby-debug-ide`, is using `Gem::DependencyInstaller#find_gems_with_sources`, so removing this method means that installation of any `Gemfile` including `ruby-debug-ide` will break in the next rubygems version.

We obviously don't want that, so I'm reverting the removal for the moment.

Final removal is postponed until next year until we find a better way to manage deprecations (#3013).

Note that the check `ruby-debug-ide` is actually broken, but we still don't want to break installing it. Hopefully, they will fix this and stop using this method soon. See https://github.com/ruby-debug/ruby-debug-ide/pull/142.

Closes #3411.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
