### PR TITLE
Version horizon deprecations

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -41,7 +41,7 @@ class Gem::BasicSpecification
   class << self
 
     extend Gem::Deprecate
-    deprecate :default_specifications_dir, "Gem.default_specifications_dir", 2020, 02
+    deprecate :default_specifications_dir, "Gem.default_specifications_dir"
 
   end
 

--- a/lib/rubygems/commands/query_command.rb
+++ b/lib/rubygems/commands/query_command.rb
@@ -6,7 +6,7 @@ require 'rubygems/deprecate'
 class Gem::Commands::QueryCommand < Gem::Command
 
   extend Gem::Deprecate
-  deprecate_command(2020, 12)
+  deprecate_command
 
   include Gem::QueryUtils
 

--- a/lib/rubygems/dependency_installer.rb
+++ b/lib/rubygems/dependency_installer.rb
@@ -195,7 +195,7 @@ class Gem::DependencyInstaller
 
     set
   end
-  deprecate :find_gems_with_sources, :none, 2020, 12
+  deprecate :find_gems_with_sources
 
   def in_background(what) # :nodoc:
     fork_happened = false

--- a/lib/rubygems/deprecate.rb
+++ b/lib/rubygems/deprecate.rb
@@ -65,6 +65,23 @@ module Gem::Deprecate
     end
   end
 
+  # Deprecation method to deprecate Rubygems commands
+  def deprecate_command(rubygems_version:)
+    class_eval do
+      define_method "deprecated?" do
+        true
+      end
+
+      define_method "deprecation_warning" do
+        msg = [ "#{self.command} command is deprecated",
+                ". It will be removed in Rubygems #{rubygems_version}.\n",
+        ]
+
+        alert_warning "#{msg.join}" unless Gem::Deprecate.skip
+      end
+    end
+  end
+
   ##
   # Simple deprecation method that deprecates +name+ by wrapping it up
   # in a dummy method. It warns on each call to the dummy method

--- a/lib/rubygems/deprecate.rb
+++ b/lib/rubygems/deprecate.rb
@@ -41,6 +41,10 @@ module Gem::Deprecate
     Gem::Deprecate.skip = original
   end
 
+  def self.next_rubygems_major_version # :nodoc:
+    Gem::Version.new(Gem.rubygems_version.segments.first).bump
+  end
+
   ##
   # Simple deprecation method that deprecates +name+ by wrapping it up
   # in a dummy method. It warns on each call to the dummy method
@@ -48,9 +52,6 @@ module Gem::Deprecate
   # Rubygems version that it is planned to go away.
 
   def deprecate(name, replacement=:none)
-    current_major = Gem::Version.new(Gem.rubygems_version.segments.first)
-    next_rubygems_major_version = current_major.bump
-
     class_eval do
       old = "_deprecated_#{name}"
       alias_method old, name
@@ -59,7 +60,7 @@ module Gem::Deprecate
         target = klass ? "#{self}." : "#{self.class}#"
         msg = [ "NOTE: #{target}#{name} is deprecated",
                 replacement == :none ? " with no replacement" : "; use #{replacement} instead",
-                ". It will be removed in Rubygems #{next_rubygems_major_version}",
+                ". It will be removed in Rubygems #{Gem::Deprecate.next_rubygems_major_version}",
                 "\n#{target}#{name} called from #{Gem.location_of_caller.join(":")}",
         ]
         warn "#{msg.join}." unless Gem::Deprecate.skip
@@ -70,9 +71,6 @@ module Gem::Deprecate
 
   # Deprecation method to deprecate Rubygems commands
   def deprecate_command
-    current_major = Gem::Version.new(Gem.rubygems_version.segments.first)
-    next_rubygems_major_version = current_major.bump
-
     class_eval do
       define_method "deprecated?" do
         true
@@ -80,7 +78,7 @@ module Gem::Deprecate
 
       define_method "deprecation_warning" do
         msg = [ "#{self.command} command is deprecated",
-                ". It will be removed in Rubygems #{next_rubygems_major_version}.\n",
+                ". It will be removed in Rubygems #{Gem::Deprecate.next_rubygems_major_version}.\n",
         ]
 
         alert_warning "#{msg.join}" unless Gem::Deprecate.skip

--- a/lib/rubygems/deprecate.rb
+++ b/lib/rubygems/deprecate.rb
@@ -47,7 +47,10 @@ module Gem::Deprecate
   # telling the user of +repl+ (unless +repl+ is :none) and the
   # Rubygems version that it is planned to go away.
 
-  def deprecate(name:, replacement:)
+  def deprecate(name, replacement=:none)
+    current_major = Gem::Version.new(Gem.rubygems_version.segments.first)
+    next_rubygems_major_version = current_major.bump
+
     class_eval do
       old = "_deprecated_#{name}"
       alias_method old, name
@@ -55,8 +58,8 @@ module Gem::Deprecate
         klass = self.kind_of? Module
         target = klass ? "#{self}." : "#{self.class}#"
         msg = [ "NOTE: #{target}#{name} is deprecated",
-                repl == :none ? " with no replacement" : "; use #{replacement} instead",
-                ". It will be removed in Rubygems #{rubygems_version}",
+                replacement == :none ? " with no replacement" : "; use #{replacement} instead",
+                ". It will be removed in Rubygems #{next_rubygems_major_version}",
                 "\n#{target}#{name} called from #{Gem.location_of_caller.join(":")}",
         ]
         warn "#{msg.join}." unless Gem::Deprecate.skip
@@ -67,7 +70,9 @@ module Gem::Deprecate
 
   # Deprecation method to deprecate Rubygems commands
   def deprecate_command
-    next_rubygems_major_version = Gem.rubygems_version + 1
+    current_major = Gem::Version.new(Gem.rubygems_version.segments.first)
+    next_rubygems_major_version = current_major.bump
+
     class_eval do
       define_method "deprecated?" do
         true

--- a/lib/rubygems/deprecate.rb
+++ b/lib/rubygems/deprecate.rb
@@ -45,9 +45,9 @@ module Gem::Deprecate
   # Simple deprecation method that deprecates +name+ by wrapping it up
   # in a dummy method. It warns on each call to the dummy method
   # telling the user of +repl+ (unless +repl+ is :none) and the
-  #Rubygems version that it is planned to go away.
+  # Rubygems version that it is planned to go away.
 
-  def deprecate(name:, replacement:, rubygems_version:)
+  def deprecate(name:, replacement:)
     class_eval do
       old = "_deprecated_#{name}"
       alias_method old, name
@@ -66,7 +66,8 @@ module Gem::Deprecate
   end
 
   # Deprecation method to deprecate Rubygems commands
-  def deprecate_command(rubygems_version:)
+  def deprecate_command
+    next_rubygems_major_version = Gem.rubygems_version + 1
     class_eval do
       define_method "deprecated?" do
         true
@@ -74,7 +75,7 @@ module Gem::Deprecate
 
       define_method "deprecation_warning" do
         msg = [ "#{self.command} command is deprecated",
-                ". It will be removed in Rubygems #{rubygems_version}.\n",
+                ". It will be removed in Rubygems #{next_rubygems_major_version}.\n",
         ]
 
         alert_warning "#{msg.join}" unless Gem::Deprecate.skip
@@ -82,46 +83,6 @@ module Gem::Deprecate
     end
   end
 
-  ##
-  # Simple deprecation method that deprecates +name+ by wrapping it up
-  # in a dummy method. It warns on each call to the dummy method
-  # telling the user of +repl+ (unless +repl+ is :none) and the
-  # year/month that it is planned to go away.
-
-  def deprecate(name, repl, year, month)
-    class_eval do
-      old = "_deprecated_#{name}"
-      alias_method old, name
-      define_method name do |*args, &block|
-        klass = self.kind_of? Module
-        target = klass ? "#{self}." : "#{self.class}#"
-        msg = [ "NOTE: #{target}#{name} is deprecated",
-                repl == :none ? " with no replacement" : "; use #{repl} instead",
-                ". It will be removed on or after %4d-%02d-01." % [year, month],
-                "\n#{target}#{name} called from #{Gem.location_of_caller.join(":")}",
-        ]
-        warn "#{msg.join}." unless Gem::Deprecate.skip
-        send old, *args, &block
-      end
-    end
-  end
-
-  # Deprecation method to deprecate Rubygems commands
-  def deprecate_command(year, month)
-    class_eval do
-      define_method "deprecated?" do
-        true
-      end
-
-      define_method "deprecation_warning" do
-        msg = [ "#{self.command} command is deprecated",
-                ". It will be removed on or after %4d-%02d-01.\n" % [year, month],
-        ]
-
-        alert_warning "#{msg.join}" unless Gem::Deprecate.skip
-      end
-    end
-  end
   module_function :deprecate, :deprecate_command, :skip_during
 
 end

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -422,7 +422,7 @@ class Gem::Installer
     @gem_dir = directory
     extract_files
   end
-  deprecate :unpack, :none, 2020, 04
+  deprecate :unpack
 
   ##
   # The location of the spec file that is installed.

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -720,7 +720,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Deprecated: You must now specify the executable name to  Gem.bin_path.
 
   attr_writer :default_executable
-  deprecate :default_executable=, :none, 2018, 12
+  deprecate :default_executable=
 
   ##
   # Allows deinstallation of gems with legacy platforms.
@@ -733,7 +733,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Formerly used to set rubyforge project.
 
   attr_writer :rubyforge_project
-  deprecate :rubyforge_project=, :none, 2019, 12
+  deprecate :rubyforge_project=
 
   ##
   # The Gem::Specification version of this gemspec.
@@ -1725,7 +1725,7 @@ class Gem::Specification < Gem::BasicSpecification
     end
     result
   end
-  deprecate :default_executable, :none, 2018, 12
+  deprecate :default_executable
 
   ##
   # The default value for specification attribute +name+
@@ -1928,7 +1928,7 @@ class Gem::Specification < Gem::BasicSpecification
   def has_rdoc # :nodoc:
     true
   end
-  deprecate :has_rdoc, :none, 2018, 12
+  deprecate :has_rdoc
 
   ##
   # Deprecated and ignored.
@@ -1938,10 +1938,10 @@ class Gem::Specification < Gem::BasicSpecification
   def has_rdoc=(ignored) # :nodoc:
     @has_rdoc = true
   end
-  deprecate :has_rdoc=, :none, 2018, 12
+  deprecate :has_rdoc=
 
   alias :has_rdoc? :has_rdoc # :nodoc:
-  deprecate :has_rdoc?, :none, 2018, 12
+  deprecate :has_rdoc?
 
   ##
   # True if this gem has files in test_files

--- a/test/rubygems/test_deprecate.rb
+++ b/test/rubygems/test_deprecate.rb
@@ -54,7 +54,7 @@ class TestDeprecate < Gem::TestCase
     def bar
       @message = "bar"
     end
-    deprecate :foo, :bar, 2099, 3
+    deprecate :foo, :bar
 
   end
 
@@ -74,7 +74,7 @@ class TestDeprecate < Gem::TestCase
 
     assert_equal "", out
     assert_match(/Thing#foo is deprecated; use bar instead\./, err)
-    assert_match(/on or after 2099-03-01/, err)
+    assert_match(/in Rubygems [0-9]+/, err)
   end
 
   def test_deprecate_command
@@ -82,7 +82,7 @@ class TestDeprecate < Gem::TestCase
     foo_command = Class.new(Gem::Command) do
       extend Gem::Deprecate
 
-      deprecate_command(2099, 4)
+      deprecate_command
 
       def execute
         puts "pew pew!"

--- a/test/rubygems/test_gem_command_manager.rb
+++ b/test/rubygems/test_gem_command_manager.rb
@@ -281,7 +281,7 @@ class TestGemCommandManager < Gem::TestCase
     foo_command = Class.new(Gem::Command) do
       extend Gem::Deprecate
 
-      deprecate_command(2099, 4)
+      deprecate_command
 
       def execute
         say "pew pew!"
@@ -296,7 +296,7 @@ class TestGemCommandManager < Gem::TestCase
     end
 
     assert_equal "pew pew!\n", @ui.output
-    assert_equal("WARNING:  foo command is deprecated. It will be removed on or after 2099-04-01.\n", @ui.error)
+    assert_match(/WARNING:  foo command is deprecated. It will be removed in Rubygems [0-9]+/, @ui.error)
   ensure
     Gem::Commands.send(:remove_const, :FooCommand)
   end

--- a/test/rubygems/test_gem_gem_runner.rb
+++ b/test/rubygems/test_gem_gem_runner.rb
@@ -76,7 +76,7 @@ class TestGemGemRunner < Gem::TestCase
       assert_nil @runner.run(args)
     end
 
-    assert_match /WARNING:  query command is deprecated. It will be removed in Rubygems [0-9]+/, @ui.error
+    assert_match(/WARNING:  query command is deprecated. It will be removed in Rubygems [0-9]+/, @ui.error)
   end
 
   def test_info_succeeds

--- a/test/rubygems/test_gem_gem_runner.rb
+++ b/test/rubygems/test_gem_gem_runner.rb
@@ -76,7 +76,7 @@ class TestGemGemRunner < Gem::TestCase
       assert_nil @runner.run(args)
     end
 
-    assert_equal "WARNING:  query command is deprecated. It will be removed on or after 2020-12-01.\n", @ui.error
+    assert_match /WARNING:  query command is deprecated. It will be removed in Rubygems [0-9]+/, @ui.error
   end
 
   def test_info_succeeds

--- a/util/cops/deprecations.rb
+++ b/util/cops/deprecations.rb
@@ -8,36 +8,24 @@ module RuboCop
       #
       # @example
       #
-      #   As of March, 2019
+      #   As of March, 2020
       #
       #   # bad
-      #   deprecate :safdfa, nil, 2018, 12
-      #   deprecate :safdfa, nil, 2019, 03
+      #   deprecate :safdfa, :none
       #
       #   # good
-      #   deprecate :safdfa, nil, 2019, 04
+      #   deprecate :safdfa
+      #   deprecate :safdfa, safdfa_replacement,
       #
       class Deprecations < Cop
 
-        MSG = "Remove `deprecate` calls with dates in the past, along with " \
-          "the methods they deprecate, or expand the deprecation horizons to " \
-          "a future date"
+        MSG = "Remove `deprecate` calls for the next major release " \
 
         def on_send(node)
           _receiver, method_name, *args = *node
           return unless method_name == :deprecate
 
-          scheduled_year = args[2].children.last
-          scheduled_month = args[3].children.last
-
-          current_time = Time.now
-
-          current_year = current_time.year
-          current_month = current_time.month
-
-          if current_year >= scheduled_year || (current_year == scheduled_year && current_month >= scheduled_month)
-            add_offense(node)
-          end
+          add_offense(node)
         end
 
         private

--- a/util/cops/deprecations.rb
+++ b/util/cops/deprecations.rb
@@ -8,22 +8,17 @@ module RuboCop
       #
       # @example
       #
-      #   As of March, 2020
-      #
       #   # bad
       #   deprecate :safdfa, :none
       #
       #   # good
-      #   deprecate :safdfa
-      #   deprecate :safdfa, safdfa_replacement,
+      #   the `deprecate` call is fully removed
       #
       class Deprecations < Cop
 
-        MSG = "Remove `deprecate` calls for the next major release " \
-
         def on_send(node)
           _receiver, method_name, *args = *node
-          return unless method_name == :deprecate
+          return unless method_name == :deprecate || method_name == :deprecate_command
 
           add_offense(node)
         end
@@ -31,7 +26,8 @@ module RuboCop
         private
 
         def message(node)
-          format(MSG, method: node.method_name)
+          msg = "Remove `#{node.method_name}` calls for the next major release "
+          format(msg, method: node.method_name)
         end
 
       end

--- a/util/cops/deprecations.rb
+++ b/util/cops/deprecations.rb
@@ -12,7 +12,7 @@ module RuboCop
       #   deprecate :safdfa, :none
       #
       #   # good
-      #   the `deprecate` call is fully removed
+      #   # the `deprecate` call is fully removed
       #
       class Deprecations < Cop
 


### PR DESCRIPTION
# Description:
First step of https://github.com/rubygems/rubygems/issues/3013

This PR makes `deprecate` and `deprecate_command` accept a date horizon and instead of a date, 
______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
