### PR TITLE
Configure templates for issue creation

### DIFF
--- a/.github/ISSUE_TEMPLATE/-rubygems-related-issue.md
+++ b/.github/ISSUE_TEMPLATE/-rubygems-related-issue.md
@@ -1,0 +1,29 @@
+---
+name: "RubyGems related issue"
+about: This template is intended for RubyGems specific related issues.
+title: ''
+labels: 'RubyGems'
+assignees: ''
+
+---
+
+I'm having a problem or would like to suggest a feature.
+
+My current problem is _________
+
+This issue is related to:
+
+  - [ ] Network problems
+  - [ ] Installing a library
+  - [ ] Publishing a library
+  - [ ] The command line `gem`
+  - [ ] Other
+
+Here are my current environment details:
+
+```
+$ gem env version
+PASTE HERE
+```
+
+I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

--- a/.github/ISSUE_TEMPLATE/bundler-related-issue.md
+++ b/.github/ISSUE_TEMPLATE/bundler-related-issue.md
@@ -1,0 +1,55 @@
+---
+name: Bundler related issue
+about: This template is intended for Bundler specific related issues.
+title: ''
+labels: 'Bundler'
+assignees: ''
+
+---
+
+Thank you for contributing to the [rubygems](https://github.com/rubygems/rubygems) repository, and specifically to the [Bundler](https://bundler.io/) gem.
+
+Before processing your issue please confirm that:
+
+- [ ] You checked all the following documents and couldn't find a solution for your issue:
+
+- [Troubleshooting common issues](https://github.com/rubygems/bundler/blob/master/doc/TROUBLESHOOTING.md)
+- [Bundler documentation site](https://bundler.io/)
+- [Bundler man pages](https://bundler.io/man/bundle.1.html)
+- [Bundler command line reference](https://bundler.io/v2.0/commands.html)
+
+If you haven't done that, please do it before creating a new issue.
+
+Please answer the following questions so we can process your issue as fast as possible:
+
+1. Do you have a reproduction script? It would be really helpful for us if you provide one. Examples: [Sample repro script for Bundler issues](https://gist.github.com/xaviershay/6207550), [Another sample repro script for Bundler issues](https://gist.github.com/xaviershay/6295889).
+
+    Script URL: 
+
+2. What are you trying to accomplish?
+
+    Your answer:
+
+3. What command did you run?
+
+    Your answer:
+
+4. What were you expecting to happen?
+
+    Your answer:
+
+5. What actually happened?
+
+    Your answer:
+
+6. Is there an exception backtrace? If so, please copy it below.
+
+    Your answer:
+
+7. Please run `bundle env` and paste the output below:
+
+    Your answer:
+
+For more information please check [Filing Issues: a guide](https://github.com/rubygems/rubygems/blob/master/bundler/doc/contributing/ISSUES.md).
+
+Thank you!

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+# If users select a blank issue the default template will be loaded.
+blank_issues_enabled: true


### PR DESCRIPTION
# Description:

Hi everyone

My name is David Auza. I'm a software engineering student from Colombia 🇨🇴. 

I'm really working hard to create a valuable proposal to participate in this year's Google Summer of Code as a Bundler Maintainer. 

While working on that I decided to create a template for issues related directly with Bundler. Let me tell you what I did and what I found:

My first approach was to inspect the file located at rubygems/.github/ISSUE_TEMPLATE.md 

There I found the following message:

<img width="1281" alt="Screen Shot 2020-03-22 at 7 54 21 PM (2)" src="https://user-images.githubusercontent.com/47565678/77269513-13f5b800-6c77-11ea-8aa9-b93766a04b84.png">

<br>

So I decided to contribute not only by creating the new Bundler template but by configuring everything to follow the new [issue template workflow](https://help.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates). 

The results of the implementation are that users can now choose between two templates if they want to create a new issue:

`This is especially important since today issues labeled with Bundler represent near 66% of all open issues.`

<img width="1281" alt="Screen Shot 2020-03-22 at 8 00 19 PM (2)" src="https://user-images.githubusercontent.com/47565678/77269745-d0e81480-6c77-11ea-97dd-1ebb285bd38b.png">

<br>

If they click on the RubyGems template the usual template will be shown: 

<img width="1281" alt="Screen Shot 2020-03-22 at 8 02 34 PM (2)" src="https://user-images.githubusercontent.com/47565678/77269835-1f95ae80-6c78-11ea-90bf-475fc3369a84.png">

<br>

And if the users decide to go to the Bundler template they will find the newly created template:

<img width="1281" alt="Screen Shot 2020-03-22 at 8 04 58 PM (2)" src="https://user-images.githubusercontent.com/47565678/77269952-78fddd80-6c78-11ea-8a81-0c7a386519ae.png">

<br>

That template was created keeping in mind the recommendations found in the [Filling Issues: a Guide](https://github.com/rubygems/bundler/blob/master/doc/contributing/ISSUES.md) file, originally found on the previous [Bundler](https://github.com/rubygems/bundler) repository.

Below you can find the proposed form:

# Proposed Template for Bundler related issues

Thank you for contributing to the [rubygems](https://github.com/rubygems/rubygems) repository, and specifically to the [Bundler](https://bundler.io/) gem.

Before processing your issue please confirm that:

- [ ] You checked all the following documents and couldn't find a solution for your issue:

- [Troubleshooting common issues](https://github.com/rubygems/bundler/blob/master/doc/TROUBLESHOOTING.md)
- [Bundler documentation site](https://bundler.io/)
- [Bundler man pages](https://bundler.io/man/bundle.1.html)
- [Bundler command line reference](https://bundler.io/v2.0/commands.html)

If you haven't done that, please do it before creating a new issue.

Please answer the following questions so we can process your issue as fast as possible:

1. Do you have a reproduction script? It would be really helpful for us if you provide one. Examples: [Sample repro script for Bundler issues](https://gist.github.com/xaviershay/6207550), [Another sample repro script for Bundler issues](https://gist.github.com/xaviershay/6295889).

    Script URL: 

2. What are you trying to accomplish?

    Your answer:

3. What command did you run?

    Your answer:

4. What were you expecting to happen?

    Your answer:

5. What actually happened?

    Your answer:

6. Is there an exception backtrace? If so, please copy it below.

    Your answer:

7. Please run `bundle env` and paste the output below:

    Your answer:

For more information please check [Filing Issues: a guide](https://github.com/rubygems/rubygems/blob/master/bundler/doc/contributing/ISSUES.md).

Thank you!

# Final Comments

Please let me know if you guys like this and if something additional should be made.

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
