### PR TITLE
Accept not only /usr/bin/env but also /bin/env in some tests

### DIFF
--- a/test/rubygems/test_gem_commands_pristine_command.rb
+++ b/test/rubygems/test_gem_commands_pristine_command.rb
@@ -160,11 +160,9 @@ class TestGemCommandsPristineCommand < Gem::TestCase
 
     ruby_exec = sprintf Gem.default_exec_format, 'ruby'
 
-    if win_platform?
-      assert_match %r%\A#!\s*#{ruby_exec}%, File.read(gem_exec)
-    else
-      assert_match %r%\A#!\s*/usr/bin/env #{ruby_exec}%, File.read(gem_exec)
-    end
+    bin_env = win_platform? ? "" : %w(/usr/bin/env /bin/env).find {|f| File.executable?(f) } + " "
+
+    assert_match %r%\A#!\s*#{bin_env}#{ruby_exec}%, File.read(gem_exec)
   end
 
   def test_execute_extensions_explicit

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -196,15 +196,10 @@ class TestGemCommandsSetupCommand < Gem::TestCase
 
     ruby_exec = sprintf Gem.default_exec_format, 'ruby'
 
-    if Gem.win_platform?
-      assert_match %r%\A#!\s*#{ruby_exec}%, File.read(default_gem_bin_path)
-      assert_match %r%\A#!\s*#{ruby_exec}%, File.read(default_bundle_bin_path)
-      assert_match %r%\A#!\s*#{ruby_exec}%, File.read(gem_bin_path)
-    else
-      assert_match %r%\A#!/usr/bin/env #{ruby_exec}%, File.read(default_gem_bin_path)
-      assert_match %r%\A#!/usr/bin/env #{ruby_exec}%, File.read(default_bundle_bin_path)
-      assert_match %r%\A#!/usr/bin/env #{ruby_exec}%, File.read(gem_bin_path)
-    end
+    bin_env = win_platform? ? "" : %w(/usr/bin/env /bin/env).find {|f| File.executable?(f) } + " "
+    assert_match %r%\A#!\s*#{bin_env}#{ruby_exec}%, File.read(default_gem_bin_path)
+    assert_match %r%\A#!\s*#{bin_env}#{ruby_exec}%, File.read(default_bundle_bin_path)
+    assert_match %r%\A#!\s*#{bin_env}#{ruby_exec}%, File.read(gem_bin_path)
   end
 
   def test_pem_files_in

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1824,9 +1824,9 @@ gem 'other', version
 
     shebang = installer.shebang 'executable'
 
-    env_shebang = "/usr/bin/env" unless Gem.win_platform?
+    bin_env = get_bin_env
 
-    assert_equal("#!#{env_shebang} #{RbConfig::CONFIG['ruby_install_name']}",
+    assert_equal("#!#{bin_env} #{RbConfig::CONFIG['ruby_install_name']}",
                  shebang)
   end
 
@@ -1905,10 +1905,18 @@ gem 'other', version
     assert_equal "#!test", shebang
   end
 
+  def get_bin_env
+    if win_platform?
+      ""
+    else
+      %w(/usr/bin/env /bin/env).find {|f| File.executable?(f) }
+    end
+  end
+
   def test_shebang_custom_with_expands
     installer = setup_base_installer
 
-    bin_env = win_platform? ? '' : '/usr/bin/env'
+    bin_env = get_bin_env
     conf = Gem::ConfigFile.new []
     conf[:custom_shebang] = '1 $env 2 $ruby 3 $exec 4 $name'
 
@@ -1924,7 +1932,7 @@ gem 'other', version
   def test_shebang_custom_with_expands_and_arguments
     installer = setup_base_installer
 
-    bin_env = win_platform? ? '' : '/usr/bin/env'
+    bin_env = get_bin_env
     conf = Gem::ConfigFile.new []
     conf[:custom_shebang] = '1 $env 2 $ruby 3 $exec'
 


### PR DESCRIPTION
RubyGems chooses available one from the two: /usr/bin/env or /bin/env

https://github.com/rubygems/rubygems/blob/20b0d609484df2b514954ba9ef890a7cbdd01d18/lib/rubygems/installer.rb#L38

So, it is good not to hard-code /usr/bin/env in tests.

Actually, these tests fail on Android because it provides /bin/env
available but not /usr/bin/env.

https://rubyci.org/logs/rubyci.s3.amazonaws.com/android28-x86_64/ruby-master/log/20200324T074312Z.fail.html.gz