### PR TITLE
Skip a test that attempts to remove the current directory on Solaris

### DIFF
--- a/test/rubygems/test_gem_bundler_version_finder.rb
+++ b/test/rubygems/test_gem_bundler_version_finder.rb
@@ -80,6 +80,7 @@ class TestGemBundlerVersionFinder < Gem::TestCase
 
   def test_deleted_directory
     skip "Cannot perform this test on windows" if win_platform?
+    skip "Cannot perform this test on Solaris" if /solaris/ =~ RUBY_PLATFORM
     require "tmpdir"
 
     orig_dir = Dir.pwd


### PR DESCRIPTION
https://rubyci.org/logs/rubyci.s3.amazonaws.com/unstable11s/ruby-master/log/20200324T072504Z.fail.html.gz
```
  1) Error:
TestGemBundlerVersionFinder#test_deleted_directory:
Errno::EINVAL: Invalid argument @ dir_s_rmdir - /home/rubyci/chkbuild/tmp/build/20200324T072504Z/tmp/some_dir20200324-15590-996kcf
    /export/home/rubyci/chkbuild-tmp/tmp/build/20200324T072504Z/ruby/lib/fileutils.rb:1460:in `rmdir'
    /export/home/rubyci/chkbuild-tmp/tmp/build/20200324T072504Z/ruby/lib/fileutils.rb:1460:in `block in remove_dir1'
    /export/home/rubyci/chkbuild-tmp/tmp/build/20200324T072504Z/ruby/lib/fileutils.rb:1471:in `platform_support'
    /export/home/rubyci/chkbuild-tmp/tmp/build/20200324T072504Z/ruby/lib/fileutils.rb:1459:in `remove_dir1'
    /export/home/rubyci/chkbuild-tmp/tmp/build/20200324T072504Z/ruby/lib/fileutils.rb:1452:in `remove'
    /export/home/rubyci/chkbuild-tmp/tmp/build/20200324T072504Z/ruby/lib/fileutils.rb:780:in `block in remove_entry'
    /export/home/rubyci/chkbuild-tmp/tmp/build/20200324T072504Z/ruby/lib/fileutils.rb:1509:in `postorder_traverse'
    /export/home/rubyci/chkbuild-tmp/tmp/build/20200324T072504Z/ruby/lib/fileutils.rb:778:in `remove_entry'
    /export/home/rubyci/chkbuild-tmp/tmp/build/20200324T072504Z/ruby/lib/tmpdir.rb:97:in `mktmpdir'
    /export/home/rubyci/chkbuild-tmp/tmp/build/20200324T072504Z/ruby/test/rubygems/test_gem_bundler_version_finder.rb:88:in `test_deleted_directory'
```

The operation that attempts to remove the current wokring directory seems to be prohibited on Solaris.

```
mame@Ruby-S11:~$ uname -a
SunOS Ruby-S11 5.11 11.4.10.3.0 sun4v sparc sun4v
mame@Ruby-S11:~$ mkdir foo
mame@Ruby-S11:~$ cd foo
mame@Ruby-S11:~/foo$ rmdir ~/foo
rmdir: directory "/export/home/users/mame/foo": Can't remove current directory or ..
```