### PR TITLE
Specify explicit separator not to be affected by $;

### DIFF
--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -77,7 +77,7 @@ class Gem::Command
     when Array
       @extra_args = value
     when String
-      @extra_args = value.split
+      @extra_args = value.split(' ')
     end
   end
 

--- a/test/rubygems/test_gem_command.rb
+++ b/test/rubygems/test_gem_command.rb
@@ -57,6 +57,27 @@ class TestGemCommand < Gem::TestCase
     assert_equal [], h
   end
 
+  def test_self_extra_args
+    verbose, $VERBOSE, separator = $VERBOSE, nil, $;
+    extra_args = Gem::Command.extra_args
+
+    Gem::Command.extra_args = %w[--all]
+    assert_equal %w[--all], Gem::Command.extra_args
+
+    Gem::Command.extra_args = "--file --help"
+    assert_equal %w[--file --help], Gem::Command.extra_args
+
+    $; = "="
+
+    Gem::Command.extra_args = "--awesome=true --verbose"
+    assert_equal %w[--awesome=true --verbose], Gem::Command.extra_args
+
+  ensure
+    Gem::Command.extra_args = extra_args
+    $; = separator
+    $VERBOSE = verbose
+  end
+
   def test_basic_accessors
     assert_equal "doit", @cmd.command
     assert_equal "gem doit", @cmd.program_name


### PR DESCRIPTION
# Description:

Get rid to be affected by `$;`.

## What was the end-user or developer problem that led to this PR?

Usually nothing.
When using rubygems as a library, the global variable can be set non-nil value.

## What is your fix for the problem, implemented in this PR?

Specify separator argument to `String#split` explicitly.

______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
