### PR TITLE
Run CI on pushes to master

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -5,8 +5,7 @@ on:
 
   push:
     branches:
-      - staging
-      - trying
+      - master
 
 jobs:
   install:

--- a/.github/workflows/jruby-bundler.yml
+++ b/.github/workflows/jruby-bundler.yml
@@ -5,8 +5,7 @@ on:
 
   push:
     branches:
-      - staging
-      - trying
+      - master
 
 jobs:
   warbler:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -5,8 +5,7 @@ on:
 
   push:
     branches:
-      - staging
-      - trying
+      - master
 
 jobs:
   macos:

--- a/.github/workflows/ubuntu-bundler.yml
+++ b/.github/workflows/ubuntu-bundler.yml
@@ -5,8 +5,7 @@ on:
 
   push:
     branches:
-      - staging
-      - trying
+      - master
 
 jobs:
   ubuntu_bundler:

--- a/.github/workflows/ubuntu-bundler3.yml
+++ b/.github/workflows/ubuntu-bundler3.yml
@@ -5,8 +5,7 @@ on:
 
   push:
     branches:
-      - staging
-      - trying
+      - master
 
 jobs:
   ubuntu_bundler3:

--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -5,8 +5,7 @@ on:
 
   push:
     branches:
-      - staging
-      - trying
+      - master
 
 jobs:
   ubuntu_lint:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -5,8 +5,7 @@ on:
 
   push:
     branches:
-      - staging
-      - trying
+      - master
 
 jobs:
   ubuntu:

--- a/.github/workflows/windows-bundler.yml
+++ b/.github/workflows/windows-bundler.yml
@@ -5,8 +5,7 @@ on:
 
   push:
     branches:
-      - staging
-      - trying
+      - master
 
 jobs:
   windows_bundler:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,8 +5,7 @@ on:
 
   push:
     branches:
-      - staging
-      - trying
+      - master
 
 jobs:
   windows:


### PR DESCRIPTION
# Description:

After `bors-ng` removal, `staging` and `trying` branches are no longer used, so remove those from CI config.

However, we're now potentially vulnerable to semantic conflicts, so running tests on pushes to `master` will help detecting these.

## What was the end-user or developer problem that led to this PR?

No problem yet, but a semantic conflict between two "parallel" PRs _could_ occur now that we don't use `bors-ng`.

## What is your fix for the problem, implemented in this PR?

No a fix, but running tests on master allows to find about these right after merge and easily identify the culprit.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
