### PR TITLE
Respect already loaded files from default gems

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1230,6 +1230,8 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
           next unless $~
         end
 
+        spec.activate if already_loaded?(file)
+
         @path_to_default_spec_map[file] = spec
         @path_to_default_spec_map[file.sub(suffix_regexp, "")] = spec
       end
@@ -1294,6 +1296,18 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     # work
 
     attr_reader :pre_uninstall_hooks
+
+    private
+
+    def already_loaded?(file)
+      default_gem_load_paths.find do |load_path_entry|
+        $LOADED_FEATURES.include?("#{load_path_entry}/#{file}")
+      end
+    end
+
+    def default_gem_load_paths
+      @default_gem_load_paths ||= $LOAD_PATH[load_path_insert_index..-1]
+    end
 
   end
 

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -802,6 +802,7 @@ class Gem::TestCase < Minitest::Test
 
     lib_dir = File.join(@tempdir, "default_gems", "lib")
     lib_dir.instance_variable_set(:@gem_prelude_index, lib_dir)
+    Gem.instance_variable_set(:@default_gem_load_paths, [*Gem.instance_variable_get(:@default_gem_load_paths), lib_dir])
     $LOAD_PATH.unshift(lib_dir)
     files.each do |file|
       rb_path = File.join(lib_dir, file)

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -271,6 +271,24 @@ class TestGemRequire < Gem::TestCase
     $LOAD_PATH.replace lp if load_path_changed
   end
 
+  def test_activate_via_require_respects_loaded_default_from_default_gems
+    a1 = new_default_spec "a", "1", nil, "a.rb"
+
+    # simulate requiring a default gem before rubygems is loaded
+    Kernel.send(:gem_original_require, "a")
+
+    # simulate registering default specs on loading rubygems
+    install_default_gems a1
+
+    a2 = util_spec "a", "2", nil, "lib/a.rb"
+
+    install_specs a2
+
+    refute_require 'a'
+
+    assert_equal %w[a-1], loaded_spec_names
+  end
+
   def test_already_activated_direct_conflict
     a1 = util_spec "a", "1", { "b" => "> 0" }
     b1 = util_spec "b", "1", { "c" => ">= 1" }, "lib/ib.rb"


### PR DESCRIPTION
# Description:

This PR fixes the first issue described in #3131, by considering files already loaded and activating their corresponding specifications during default gem registration.

Closes #3131.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
