### PR TITLE
Make cmake tests less verbose on jruby

### DIFF
--- a/test/rubygems/test_gem_ext_cmake_builder.rb
+++ b/test/rubygems/test_gem_ext_cmake_builder.rb
@@ -10,9 +10,9 @@ class TestGemExtCmakeBuilder < Gem::TestCase
     # Details: https://github.com/rubygems/rubygems/issues/1270#issuecomment-177368340
     skip "CmakeBuilder doesn't work on Windows." if Gem.win_platform?
 
-    system('cmake', out: IO::NULL, err: [:child, :out])
+    _, status = Open3.capture2e('cmake')
 
-    skip 'cmake not present' unless $?.success?
+    skip 'cmake not present' unless status.success?
 
     @ext = File.join @tempdir, 'ext'
     @dest_path = File.join @tempdir, 'prefix'


### PR DESCRIPTION
# Description:

These tests work on jruby, but the flags to the system command used to detect whether `cmake` is present seem to be ignored on jruby and the output is printed to screen instead of being sent to /dev/null. This results in very verbose tests, like this:

```
$ rake TESTOPTS=--name=TestGemExtCmakeBuilder#test_self_build
(... warnings skipped ...)
Skipping `gem cert` tests on jruby.
Skipping Gem::Security tests on jruby.
Run options: --name=TestGemExtCmakeBuilder#test_self_build --seed 16839

# Running:

/home/deivid/Code/rubygems/test/rubygems/test_gem_ext_cmake_builder.rb:13: warning: system does not support options in JRuby yet: {:out=>"/dev/null", :err=>[:child, :out]}
Usage

  cmake [options] <path-to-source>
  cmake [options] <path-to-existing-build>

Specify a source directory to (re-)generate a build system for it in the
current working directory.  Specify an existing build directory to
re-generate its build system.

Run 'cmake --help' for more information.

.

Finished in 0.387301s, 2.5820 runs/s, 20.6558 assertions/s.

1 runs, 8 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for Unit Tests to /home/deivid/Code/rubygems/coverage. 2258 / 8832 LOC (25.57%) covered.
```

By using `Open3`, we get the test output clean:

```
$ rake TESTOPTS=--name=TestGemExtCmakeBuilder#test_self_build
(... warnings skipped ...)
Skipping `gem cert` tests on jruby.
Skipping Gem::Security tests on jruby.
Run options: --name=TestGemExtCmakeBuilder#test_self_build --seed 22605

# Running:

.

Finished in 0.381959s, 2.6181 runs/s, 20.9446 assertions/s.

1 runs, 8 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for Unit Tests to /home/deivid/Code/rubygems/coverage. 2258 / 8832 LOC (25.57%) covered.

```


# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
