### PR TITLE
Report GitLab CI within bundler user-agent string

### DIFF
--- a/bundler/lib/bundler/fetcher.rb
+++ b/bundler/lib/bundler/fetcher.rb
@@ -229,6 +229,7 @@ module Bundler
         "BUILDBOX" => "buildbox",
         "GO_SERVER_URL" => "go",
         "SNAP_CI" => "snap",
+        "GITLAB_CI" => "gitlab",
         "CI_NAME" => ENV["CI_NAME"],
         "CI" => "ci",
       }

--- a/bundler/spec/bundler/fetcher_spec.rb
+++ b/bundler/spec/bundler/fetcher_spec.rb
@@ -150,9 +150,10 @@ RSpec.describe Bundler::Fetcher do
       end
 
       it "from many CI" do
-        with_env_vars("TRAVIS" => "foo", "CI_NAME" => "my_ci") do
+        with_env_vars("TRAVIS" => "foo", "GITLAB_CI" => "gitlab", "CI_NAME" => "my_ci") do
           ci_part = fetcher.user_agent.split(" ").find {|x| x.start_with?("ci/") }
           expect(ci_part).to match("travis")
+          expect(ci_part).to match("gitlab")
           expect(ci_part).to match("my_ci")
         end
       end


### PR DESCRIPTION
# Description:

Bundler user-agent is being used to generate content for rubygems stats
https://stats.rubygems.org 

This adds GitLab CI specific ENV variable.

## What was the end-user or developer problem that led to this PR?

There is a limited amount of CI providers being listed in https://stats.rubygems.org/

By including GitLab we expect that a portion of the current "Ci" item should include GitLab CI and therefore report correctly.

## What is your fix for the problem, implemented in this PR?

Added specific ENV to the list of known providers. This will allow bundler to report that information, which can later on be parsed by https://github.com/rubytogether/kirby

______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
