### PR TITLE
Update WRITING.md with the right name of current Bundler's repository

### DIFF
--- a/bundler/doc/documentation/WRITING.md
+++ b/bundler/doc/documentation/WRITING.md
@@ -1,5 +1,7 @@
 # Writing docs for man pages
 
+*Any commands or file paths in this document assume that you are inside [the bundler/ directory of the rubygems/rubygems repository](https://github.com/rubygems/rubygems/tree/master/bundler).*
+
 A primary source of help for Bundler users are the man pages: the output printed when you run `bundle help` (or `bundler help`). These pages can be a little tricky to format and preview, but are pretty straightforward once you get the hang of it.
 
 _Note: `bundler` and `bundle` may be used interchangeably in the CLI. This guide uses `bundle` because it's cuter._
@@ -55,9 +57,9 @@ $ bin/rspec ./spec/quality_spec.rb
 
 # Writing docs for [the Bundler documentation site](https://bundler.io)
 
-If you'd like to submit a pull request for any of the primary commands or utilities on [the Bundler documentation site](https://bundler.io), please follow the instructions above for writing documentation for man pages from the `rubygems/bundler` repository. They are the same in each case.
+If you'd like to submit a pull request for any of the primary commands or utilities on [the Bundler documentation site](https://bundler.io), please follow the instructions above for writing documentation for man pages from the `rubygems/rubygems` repository. They are the same in each case.
 
-Note: Editing `.ronn` files from the `rubygems/bundler` repository for the primary commands and utilities documentation is all you need 🎉. There is no need to manually change anything in the `rubygems/bundler-site` repository, because the man pages and the docs for primary commands and utilities on [the Bundler documentation site](https://bundler.io) are one in the same. They are generated automatically from the `rubygems/bundler` repository's `.ronn` files from the `rake man/build` command. In other words, after updating `.ronn` file and running `rake man/build` in `bundler`, `.ronn` files map to the auto-generated files in the `source/man` directory of `bundler-site`.
+Note: Editing `.ronn` files from the `rubygems/rubygems` repository for the primary commands and utilities documentation is all you need 🎉. There is no need to manually change anything in the `rubygems/bundler-site` repository, because the man pages and the docs for primary commands and utilities on [the Bundler documentation site](https://bundler.io) are one in the same. They are generated automatically from the `rubygems/rubygems` repository's `.ronn` files from the `rake man/build` command. In other words, after updating `.ronn` file and running `rake man/build` in `bundler`, `.ronn` files map to the auto-generated files in the `source/man` directory of `bundler-site`.
 
 Additionally, if you'd like to add a guide or tutorial: in the `rubygems/bundler-site` repository, go to `/bundler-site/source/current_version_of_bundler/guides` and add [a new Markdown file](https://guides.github.com/features/mastering-markdown/) (with an extension ending in `.md`). Be sure to correctly format the title of your new guide, like so:
 ```


### PR DESCRIPTION
# Description:

## What was the end-user or developer problem that led to this PR?

In the document [WRITING.md](https://github.com/rubygems/rubygems/blob/master/bundler/doc/documentation/WRITING.md) there are some references to the Bundle repository as "`rubygems/bundler` repository". Due to the actual name of the repository where Bundler is being maintained now is `rubygems/rubygems` I'm proposing some changes.

## What is your fix for the problem, implemented in this PR?

I contributed by:

- [x] Replacing the relevant occurrences of `rubygems/bundler`with `rubygems/rubygems`.

- [x] Adding exact paths where relevant to avoid ambiguity.

- [x] Adding links where relevant pointing to the mentioned repository.

# Tasks pending:

There is a path described in the document that I couldn't find at its worth checking:

<img width="1035" alt="Screen Shot 2020-03-25 at 11 38 26 PM" src="https://user-images.githubusercontent.com/47565678/77610903-f2543500-6ef1-11ea-9fdb-c70f6e8cfba3.png">

I couldn't find the man directory at the [described path](https://github.com/rubygems/bundler-site/tree/master/source).

Thank you very much!

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
