### PR TITLE
Introduce COMPACT_INDEX_POOL env var to limit compact index thread pool

### DIFF
--- a/bundler/lib/bundler/fetcher/compact_index.rb
+++ b/bundler/lib/bundler/fetcher/compact_index.rb
@@ -111,11 +111,15 @@ module Bundler
       def bundle_worker(func = nil)
         @bundle_worker ||= begin
           worker_name = "Compact Index (#{display_uri.host})"
-          Bundler::Worker.new(Bundler.current_ruby.rbx? ? 1 : 25, worker_name, func)
+          Bundler::Worker.new(worker_pool_limit, worker_name, func)
         end
         @bundle_worker.tap do |worker|
           worker.instance_variable_set(:@func, func) if func
         end
+      end
+
+      def worker_pool_limit
+        Bundler.current_ruby.rbx? ? 1 : ENV.fetch("COMPACT_INDEX_POOL", 25).to_i
       end
 
       def cache_path


### PR DESCRIPTION
# Description:

Migrated from https://github.com/rubygems/bundler/pull/6617
______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
