### PR TITLE
Fix race condition on bundler's parallel installer

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -509,7 +509,7 @@ class Gem::Installer
   end
 
   def generate_plugins # :nodoc:
-    latest = Gem::Specification.latest_spec_for(spec.name)
+    latest = Gem::Installer.install_lock.synchronize { Gem::Specification.latest_spec_for(spec.name) }
     return if latest && latest.version > spec.version
 
     ensure_writable_dir @plugins_dir


### PR DESCRIPTION
# Description:

## What was the end-user or developer problem that led to this PR?

We're getting several crashes in our specs where `Enumerable` methods are called on `nil`, resulting in crashes.

See https://github.com/rubygems/rubygems/runs/537767938 for a recent example.

Note that this issue has been aggravated since we enabled parallel installation by default in #3393.

## What is your fix for the problem, implemented in this PR?

When installing in parallel, `bundler` creates several `Gem::Installer`
instances that run in parallel. These installers access the `@@all` class
variable of `Gem::Specification` concurrently.

If a concurrent thread calls `Gem::Specification.reset` (resetting `@all` to `nil`) while another thread is running `Gem::Specification._all` or another method that expects `@@all` to be
loaded and not `nil`, that can result in `Enumerable` methods being called on `nil`, resulting in crashes.

I fix it by protecting the other concurrent access to the `@all` variable.
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
