### PR TITLE
Remove deprecated + broken rubygems/source_local.

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -495,7 +495,6 @@ lib/rubygems/source/lock.rb
 lib/rubygems/source/specific_file.rb
 lib/rubygems/source/vendor.rb
 lib/rubygems/source_list.rb
-lib/rubygems/source_local.rb
 lib/rubygems/spec_fetcher.rb
 lib/rubygems/specification.rb
 lib/rubygems/specification_policy.rb

--- a/lib/rubygems/source_local.rb
+++ b/lib/rubygems/source_local.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-require 'rubygems/source'
-require 'rubygems/source_local'
-
-unless Gem::Deprecate.skip
-  Kernel.warn "#{Gem.location_of_caller(3).join(':')}: Warning: Requiring rubygems/source_local is deprecated; please use rubygems/source/local instead."
-end


### PR DESCRIPTION
# Description:

This PR removes `rubygems/source_local`, as discussed in #3158.

Closes #3158.

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

`rubygems/source_local` has been deprecated for 3 years, and has been broken for that entire
period. It required itself instead of `rubygems/source/local`, so it just printed a deprecation warning without preserving the original functionality.

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

I removed it, because it doesn't seem to be worth fixing a deprecated file that's been entirely broken for 3 years.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests (N/A)
- [ ] Write code to solve the problem (N/A)
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
