### PR TITLE
Simplify nested gem activation exceptions

### DIFF
--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -156,8 +156,7 @@ module Kernel
     RUBYGEMS_ACTIVATION_MONITOR.enter
 
     begin
-      if load_error.message.start_with?("Could not find") or
-          (load_error.message.end_with?(path) and Gem.try_activate(path))
+      if load_error.message.end_with?(path) and Gem.try_activate(path)
         require_again = true
       end
     ensure


### PR DESCRIPTION
# Description:

In #3445, I noticed after removing minitest's load rescue, that the activation error you get when you try to run the tests without having the right minitest version is really verbose, way too much than I would have expected. See:

```
$ rake
Traceback (most recent call last):
	11: from /home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/rake-13.0.1/lib/rake/rake_test_loader.rb:5:in `<main>'
	10: from /home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/rake-13.0.1/lib/rake/rake_test_loader.rb:5:in `select'
	 9: from /home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/rake-13.0.1/lib/rake/rake_test_loader.rb:17:in `block in <main>'
	 8: from /home/deivid/Code/rubygems/lib/rubygems/core_ext/kernel_require.rb:91:in `require'
	 7: from /home/deivid/Code/rubygems/lib/rubygems/core_ext/kernel_require.rb:91:in `require'
	 6: from /home/deivid/Code/rubygems/test/rubygems/test_bundled_ca.rb:2:in `<top (required)>'
	 5: from /home/deivid/Code/rubygems/lib/rubygems/core_ext/kernel_require.rb:74:in `require'
	 4: from /home/deivid/Code/rubygems/lib/rubygems/core_ext/kernel_require.rb:74:in `require'
	 3: from /home/deivid/Code/rubygems/lib/rubygems/test_case.rb:14:in `<top (required)>'
	 2: from /home/deivid/Code/rubygems/lib/rubygems/core_ext/kernel_gem.rb:62:in `gem'
	 1: from /home/deivid/Code/rubygems/lib/rubygems/dependency.rb:323:in `to_spec'
/home/deivid/Code/rubygems/lib/rubygems/dependency.rb:313:in `to_specs': Could not find 'minitest' (~> 5.13) - did find: [minitest-4.7.5] (Gem::MissingSpecVersionError)
Checked in 'GEM_PATH=/home/deivid/.gem/ruby/2.7.0:/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0', execute `gem env` for more information
	12: from /home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/rake-13.0.1/lib/rake/rake_test_loader.rb:5:in `<main>'
	11: from /home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/rake-13.0.1/lib/rake/rake_test_loader.rb:5:in `select'
	10: from /home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/rake-13.0.1/lib/rake/rake_test_loader.rb:17:in `block in <main>'
	 9: from /home/deivid/Code/rubygems/lib/rubygems/core_ext/kernel_require.rb:91:in `require'
	 8: from /home/deivid/Code/rubygems/lib/rubygems/core_ext/kernel_require.rb:91:in `require'
	 7: from /home/deivid/Code/rubygems/test/rubygems/test_bundled_ca.rb:2:in `<top (required)>'
	 6: from /home/deivid/Code/rubygems/lib/rubygems/core_ext/kernel_require.rb:155:in `require'
	 5: from /home/deivid/Code/rubygems/lib/rubygems/core_ext/kernel_require.rb:167:in `rescue in require'
	 4: from /home/deivid/Code/rubygems/lib/rubygems/core_ext/kernel_require.rb:167:in `require'
	 3: from /home/deivid/Code/rubygems/lib/rubygems/test_case.rb:14:in `<top (required)>'
	 2: from /home/deivid/Code/rubygems/lib/rubygems/core_ext/kernel_gem.rb:62:in `gem'
	 1: from /home/deivid/Code/rubygems/lib/rubygems/dependency.rb:323:in `to_spec'
/home/deivid/Code/rubygems/lib/rubygems/dependency.rb:313:in `to_specs': Could not find 'minitest' (~> 5.13) - did find: [minitest-4.7.5] (Gem::MissingSpecVersionError)
Checked in 'GEM_PATH=/home/deivid/.gem/ruby/2.7.0:/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0', execute `gem env` for more information
	12: from /home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/rake-13.0.1/lib/rake/rake_test_loader.rb:5:in `<main>'
	11: from /home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/rake-13.0.1/lib/rake/rake_test_loader.rb:5:in `select'
	10: from /home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/rake-13.0.1/lib/rake/rake_test_loader.rb:17:in `block in <main>'
	 9: from /home/deivid/Code/rubygems/lib/rubygems/core_ext/kernel_require.rb:155:in `require'
	 8: from /home/deivid/Code/rubygems/lib/rubygems/core_ext/kernel_require.rb:167:in `rescue in require'
	 7: from /home/deivid/Code/rubygems/lib/rubygems/core_ext/kernel_require.rb:167:in `require'
	 6: from /home/deivid/Code/rubygems/test/rubygems/test_bundled_ca.rb:2:in `<top (required)>'
	 5: from /home/deivid/Code/rubygems/lib/rubygems/core_ext/kernel_require.rb:74:in `require'
	 4: from /home/deivid/Code/rubygems/lib/rubygems/core_ext/kernel_require.rb:74:in `require'
	 3: from /home/deivid/Code/rubygems/lib/rubygems/test_case.rb:14:in `<top (required)>'
	 2: from /home/deivid/Code/rubygems/lib/rubygems/core_ext/kernel_gem.rb:62:in `gem'
	 1: from /home/deivid/Code/rubygems/lib/rubygems/dependency.rb:323:in `to_spec'
/home/deivid/Code/rubygems/lib/rubygems/dependency.rb:313:in `to_specs': Could not find 'minitest' (~> 5.13) - did find: [minitest-4.7.5] (Gem::MissingSpecVersionError)
Checked in 'GEM_PATH=/home/deivid/.gem/ruby/2.7.0:/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0', execute `gem env` for more information
	13: from /home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/rake-13.0.1/lib/rake/rake_test_loader.rb:5:in `<main>'
	12: from /home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/rake-13.0.1/lib/rake/rake_test_loader.rb:5:in `select'
	11: from /home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/rake-13.0.1/lib/rake/rake_test_loader.rb:17:in `block in <main>'
	10: from /home/deivid/Code/rubygems/lib/rubygems/core_ext/kernel_require.rb:155:in `require'
	 9: from /home/deivid/Code/rubygems/lib/rubygems/core_ext/kernel_require.rb:167:in `rescue in require'
	 8: from /home/deivid/Code/rubygems/lib/rubygems/core_ext/kernel_require.rb:167:in `require'
	 7: from /home/deivid/Code/rubygems/test/rubygems/test_bundled_ca.rb:2:in `<top (required)>'
	 6: from /home/deivid/Code/rubygems/lib/rubygems/core_ext/kernel_require.rb:155:in `require'
	 5: from /home/deivid/Code/rubygems/lib/rubygems/core_ext/kernel_require.rb:167:in `rescue in require'
	 4: from /home/deivid/Code/rubygems/lib/rubygems/core_ext/kernel_require.rb:167:in `require'
	 3: from /home/deivid/Code/rubygems/lib/rubygems/test_case.rb:14:in `<top (required)>'
	 2: from /home/deivid/Code/rubygems/lib/rubygems/core_ext/kernel_gem.rb:62:in `gem'
	 1: from /home/deivid/Code/rubygems/lib/rubygems/dependency.rb:323:in `to_spec'
/home/deivid/Code/rubygems/lib/rubygems/dependency.rb:313:in `to_specs': Could not find 'minitest' (~> 5.13) - did find: [minitest-4.7.5] (Gem::MissingSpecVersionError)
Checked in 'GEM_PATH=/home/deivid/.gem/ruby/2.7.0:/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0', execute `gem env` for more information
rake aborted!
Command failed with status (1)

Tasks: TOP => default => test
(See full trace by running task with --trace)

```

We get the same exception like... 4 times!!

So I decided to investigate why.

My conclusion is that this is a bug in our custom require.

I fixed it by removing the condition to retry the `require` and all tests (plus my regression test) still seem to pass. I also digged into history. It was introduced in c1fd10db02ea93b911b373272349a1be88c252ae with commit message saying "Fixed gem loading issue caused by dependencies not resolving.", but no further explanation of what the actual issue was nor any regression tests or anything. So... :man_shrugging:.

I also made some experiments while trying to understand our full custom require, but couldn't find anything that this could break.

I plan to dig a bit more tomorrow, but I wanted to check with other devs and CI too.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
