### PR TITLE
Convert `simulate_ruby_engine` to `ruby_engine_is` guard

### DIFF
--- a/bundler/spec/commands/outdated_spec.rb
+++ b/bundler/spec/commands/outdated_spec.rb
@@ -606,7 +606,7 @@ RSpec.describe "bundle outdated" do
     end
 
     it "reports that updates are available if the JRuby platform is used" do
-      simulate_ruby_engine "jruby", "1.6.7" do
+      ruby_engine_is "jruby", "1.6.7" do
         simulate_platform "jruby" do
           install_gemfile <<-G
             source "#{file_uri_for(gem_repo2)}"

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -169,20 +169,20 @@ RSpec.describe "bundle install from an existing gemspec" do
 
   it "should match a lockfile on non-ruby platforms with a transitive platform dependency" do
     simulate_platform java
-    simulate_ruby_engine "jruby"
+    ruby_engine_is "jruby" do
+      build_lib("foo", :path => tmp.join("foo")) do |s|
+        s.add_dependency "platform_specific"
+      end
 
-    build_lib("foo", :path => tmp.join("foo")) do |s|
-      s.add_dependency "platform_specific"
+      system_gems "platform_specific-1.0-java", :path => :bundle_path, :keep_path => true
+
+      install_gemfile! <<-G
+        gemspec :path => '#{tmp.join("foo")}'
+      G
+
+      bundle! "update --bundler", :verbose => true
+      expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 JAVA"
     end
-
-    system_gems "platform_specific-1.0-java", :path => :bundle_path, :keep_path => true
-
-    install_gemfile! <<-G
-      gemspec :path => '#{tmp.join("foo")}'
-    G
-
-    bundle! "update --bundler", :verbose => true
-    expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 JAVA"
   end
 
   it "should evaluate the gemspec in its directory" do
@@ -380,7 +380,7 @@ RSpec.describe "bundle install from an existing gemspec" do
         end
 
         it "should install" do
-          simulate_ruby_engine "jruby" do
+          ruby_engine_is "jruby" do
             simulate_platform "java" do
               results = bundle "install", :artifice => "endpoint"
               expect(results).to include("Installing rack 1.0.0")
@@ -394,7 +394,7 @@ RSpec.describe "bundle install from an existing gemspec" do
         let(:platform) { "java" }
 
         it "should install" do
-          simulate_ruby_engine "jruby" do
+          ruby_engine_is "jruby" do
             simulate_platform "java" do
               results = bundle "install", :artifice => "endpoint"
               expect(results).to include("Installing rack 1.0.0")

--- a/bundler/spec/install/gemfile_spec.rb
+++ b/bundler/spec/install/gemfile_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "bundle install" do
   context "with engine specified in symbol" do
     it "does not raise any error parsing Gemfile" do
       simulate_ruby_version "2.3.0" do
-        simulate_ruby_engine "jruby", "9.1.2.0" do
+        ruby_engine_is "jruby", "9.1.2.0" do
           install_gemfile! <<-G
             source "#{file_uri_for(gem_repo1)}"
             ruby "2.3.0", :engine => :jruby, :engine_version => "9.1.2.0"
@@ -78,7 +78,7 @@ RSpec.describe "bundle install" do
 
     it "installation succeeds" do
       simulate_ruby_version "2.3.0" do
-        simulate_ruby_engine "jruby", "9.1.2.0" do
+        ruby_engine_is "jruby", "9.1.2.0" do
           install_gemfile! <<-G
             source "#{file_uri_for(gem_repo1)}"
             ruby "2.3.0", :engine => :jruby, :engine_version => "9.1.2.0"

--- a/bundler/spec/other/platform_spec.rb
+++ b/bundler/spec/other/platform_spec.rb
@@ -450,7 +450,7 @@ G
     end
 
     it "fails when engine version doesn't match" do
-      ruby_engine_is "ruby" do
+      ruby_engine_is "jruby" do
         install_gemfile <<-G
           source "#{file_uri_for(gem_repo1)}"
           gem "rack"

--- a/bundler/spec/other/platform_spec.rb
+++ b/bundler/spec/other/platform_spec.rb
@@ -302,7 +302,7 @@ G
     end
 
     it "installs fine with any engine" do
-      simulate_ruby_engine "jruby" do
+      ruby_engine_is "jruby" do
         install_gemfile <<-G
           source "#{file_uri_for(gem_repo1)}"
           gem "rack"
@@ -350,7 +350,7 @@ G
     end
 
     it "doesn't install when engine version doesn't match" do
-      simulate_ruby_engine "jruby" do
+      ruby_engine_is "jruby" do
         install_gemfile <<-G
           source "#{file_uri_for(gem_repo1)}"
           gem "rack"
@@ -396,7 +396,7 @@ G
     end
 
     it "checks fine with any engine" do
-      simulate_ruby_engine "jruby" do
+      ruby_engine_is "jruby" do
         install_gemfile <<-G
           source "#{file_uri_for(gem_repo1)}"
           gem "rack"
@@ -450,7 +450,7 @@ G
     end
 
     it "fails when engine version doesn't match" do
-      simulate_ruby_engine "ruby" do
+      ruby_engine_is "ruby" do
         install_gemfile <<-G
           source "#{file_uri_for(gem_repo1)}"
           gem "rack"
@@ -514,7 +514,7 @@ G
     end
 
     it "updates fine with any engine" do
-      simulate_ruby_engine "jruby" do
+      ruby_engine_is "jruby" do
         gemfile <<-G
           source "#{file_uri_for(gem_repo2)}"
           gem "activesupport"
@@ -564,7 +564,7 @@ G
     end
 
     it "fails when ruby engine version doesn't match" do
-      simulate_ruby_engine "jruby" do
+      ruby_engine_is "jruby" do
         gemfile <<-G
           source "#{file_uri_for(gem_repo2)}"
           gem "activesupport"
@@ -618,7 +618,7 @@ G
     end
 
     it "prints path if ruby version is correct for any engine" do
-      simulate_ruby_engine "jruby" do
+      ruby_engine_is "jruby" do
         install_gemfile! <<-G
           source "#{file_uri_for(gem_repo1)}"
           gem "rails"
@@ -656,7 +656,7 @@ G
     end
 
     it "fails if engine version doesn't match", :bundler => "< 3" do
-      simulate_ruby_engine "jruby" do
+      ruby_engine_is "jruby" do
         gemfile <<-G
           source "#{file_uri_for(gem_repo1)}"
           gem "rails"
@@ -705,7 +705,7 @@ G
     end
 
     it "copies the .gem file to vendor/cache when ruby version matches for any engine" do
-      simulate_ruby_engine "jruby" do
+      ruby_engine_is "jruby" do
         install_gemfile! <<-G
           source "#{file_uri_for(gem_repo1)}"
           gem 'rack'
@@ -741,7 +741,7 @@ G
     end
 
     it "fails if the engine version doesn't match" do
-      simulate_ruby_engine "jruby" do
+      ruby_engine_is "jruby" do
         gemfile <<-G
           gem 'rack'
 
@@ -786,7 +786,7 @@ G
     end
 
     it "copies the .gem file to vendor/cache when ruby version matches any engine" do
-      simulate_ruby_engine "jruby" do
+      ruby_engine_is "jruby" do
         install_gemfile! <<-G
           source "#{file_uri_for(gem_repo1)}"
           gem 'rack'
@@ -822,7 +822,7 @@ G
     end
 
     it "fails if the engine version doesn't match" do
-      simulate_ruby_engine "jruby" do
+      ruby_engine_is "jruby" do
         gemfile <<-G
           gem 'rack'
 
@@ -865,7 +865,7 @@ G
     end
 
     it "activates the correct gem when ruby version matches any engine" do
-      simulate_ruby_engine "jruby" do
+      ruby_engine_is "jruby" do
         system_gems "rack-1.0.0", "rack-0.9.1", :path => :bundle_path
         gemfile <<-G
           gem "rack", "0.9.1"
@@ -901,7 +901,7 @@ G
     end
 
     # it "fails when the engine version doesn't match" do
-    #   simulate_ruby_engine "jruby" do
+    #   ruby_engine_is "jruby" do
     #     gemfile <<-G
     #       gem "rack", "0.9.1"
     #
@@ -954,7 +954,7 @@ G
     end
 
     it "starts IRB with the default group loaded when ruby version matches any engine", :readline do
-      simulate_ruby_engine "jruby" do
+      ruby_engine_is "jruby" do
         gemfile <<-G
           source "#{file_uri_for(gem_repo1)}"
           gem "rack"
@@ -1001,7 +1001,7 @@ G
     end
 
     it "fails when engine version doesn't match" do
-      simulate_ruby_engine "jruby" do
+      ruby_engine_is "jruby" do
         gemfile <<-G
           source "#{file_uri_for(gem_repo1)}"
           gem "rack"
@@ -1058,7 +1058,7 @@ G
     end
 
     it "makes a Gemfile.lock if setup succeeds for any engine" do
-      simulate_ruby_engine "jruby" do
+      ruby_engine_is "jruby" do
         install_gemfile <<-G
           source "#{file_uri_for(gem_repo1)}"
           gem "yard"
@@ -1113,7 +1113,7 @@ G
     end
 
     it "fails when engine version doesn't match" do
-      simulate_ruby_engine "jruby" do
+      ruby_engine_is "jruby" do
         install_gemfile <<-G
           source "#{file_uri_for(gem_repo1)}"
           gem "yard"
@@ -1192,7 +1192,7 @@ G
     end
 
     it "returns list of outdated gems when the ruby version matches for any engine" do
-      simulate_ruby_engine "jruby" do
+      ruby_engine_is "jruby" do
         bundle! :install
         update_repo2 do
           build_gem "activesupport", "3.0"
@@ -1256,7 +1256,7 @@ G
     end
 
     it "fails when the engine version doesn't match" do
-      simulate_ruby_engine "jruby" do
+      ruby_engine_is "jruby" do
         update_repo2 do
           build_gem "activesupport", "3.0"
           update_git "foo", :path => lib_path("foo")
@@ -1276,7 +1276,7 @@ G
     end
 
     it "fails when the patchlevel doesn't match" do
-      simulate_ruby_engine "jruby" do
+      ruby_engine_is "jruby" do
         update_repo2 do
           build_gem "activesupport", "3.0"
           update_git "foo", :path => lib_path("foo")
@@ -1296,7 +1296,7 @@ G
     end
 
     it "fails when the patchlevel is a fixnum" do
-      simulate_ruby_engine "jruby" do
+      ruby_engine_is "jruby" do
         update_repo2 do
           build_gem "activesupport", "3.0"
           update_git "foo", :path => lib_path("foo")

--- a/bundler/spec/support/hax.rb
+++ b/bundler/spec/support/hax.rb
@@ -46,23 +46,3 @@ if ENV["BUNDLER_SPEC_WINDOWS"] == "true"
     WINDOWS = true
   end
 end
-
-class Object
-  if ENV["BUNDLER_SPEC_RUBY_ENGINE"]
-    if RUBY_ENGINE != "jruby" && ENV["BUNDLER_SPEC_RUBY_ENGINE"] == "jruby"
-      begin
-        # this has to be done up front because psych will try to load a .jar
-        # if it thinks its on jruby
-        require "psych"
-      rescue LoadError
-        nil
-      end
-    end
-
-    remove_const :RUBY_ENGINE
-    RUBY_ENGINE = ENV["BUNDLER_SPEC_RUBY_ENGINE"]
-
-    remove_const :RUBY_ENGINE_VERSION
-    RUBY_ENGINE_VERSION = ENV["BUNDLER_SPEC_RUBY_ENGINE_VERSION"]
-  end
-end

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -463,17 +463,8 @@ module Spec
       ENV["BUNDLER_SPEC_RUBY_VERSION"] = old if block_given?
     end
 
-    def simulate_ruby_engine(engine, version = "1.6.0")
-      return if engine == local_ruby_engine
-
-      old = ENV["BUNDLER_SPEC_RUBY_ENGINE"]
-      ENV["BUNDLER_SPEC_RUBY_ENGINE"] = engine
-      old_version = ENV["BUNDLER_SPEC_RUBY_ENGINE_VERSION"]
-      ENV["BUNDLER_SPEC_RUBY_ENGINE_VERSION"] = version
-      yield if block_given?
-    ensure
-      ENV["BUNDLER_SPEC_RUBY_ENGINE"] = old if block_given?
-      ENV["BUNDLER_SPEC_RUBY_ENGINE_VERSION"] = old_version if block_given?
+    def ruby_engine_is(engine, version = "1.6.0")
+      yield if engine == local_ruby_engine && Gem::Version.new(RUBY_ENGINE_VERSION) >= Gem::Version.new(version)
     end
 
     def simulate_bundler_version(version)

--- a/bundler/spec/support/platforms.rb
+++ b/bundler/spec/support/platforms.rb
@@ -65,12 +65,10 @@ module Spec
     end
 
     def local_ruby_engine
-      ENV["BUNDLER_SPEC_RUBY_ENGINE"] || RUBY_ENGINE
+      RUBY_ENGINE
     end
 
     def local_engine_version
-      return ENV["BUNDLER_SPEC_RUBY_ENGINE_VERSION"] if ENV["BUNDLER_SPEC_RUBY_ENGINE_VERSION"]
-
       RUBY_ENGINE_VERSION
     end
 


### PR DESCRIPTION
`simulate_ruby_engine` replaces `RUBY_ENGINE` to make MRI pretend JRuby.
This is a completely unreasonable and impossible idea because the
constant `RUBY_ENGINE` is used to insert a code fragment for a
particular engine, like this:

https://github.com/ruby/ruby/commit/2b6848af0e
```
require "jruby" if RUBY_ENGINE == "jruby"
```

And a bundler spec fails like this:

https://github.com/ruby/ruby/runs/542345866?check_suite_focus=true#step:14:106
```
/home/runner/work/ruby/ruby/src/lib/irb/ruby-lex.rb:14:in `require': cannot load such file -- jruby (LoadError)
```

This changeset converts all `simulate_ruby_engine` to `ruby_engine_is`
guard that executes a given block only on the specified engine.
If you want to test it with JRuby, you must use JRuby, not make MRI
pretend JRuby.

cc/ @headius @hsbt 