### PR TITLE
Update actions/checkout@v2 for fetch-deptch=1

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         ruby: [ ruby-head ]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         ruby: [ 2.3.8, 2.4.9, 2.5.7, 2.6.5, jruby-9.2.11.0 ]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/jruby-bundler.yml
+++ b/.github/workflows/jruby-bundler.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         ruby: [ 2.4.9, 2.5.7, 2.6.5 ]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ubuntu-bundler.yml
+++ b/.github/workflows/ubuntu-bundler.yml
@@ -38,7 +38,7 @@ jobs:
     env:
       RGV: ${{ matrix.rgv }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ubuntu-bundler3.yml
+++ b/.github/workflows/ubuntu-bundler3.yml
@@ -17,7 +17,7 @@ jobs:
     env:
       RGV: ${{ matrix.rgv }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -11,7 +11,7 @@ jobs:
   ubuntu_lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         ruby: [ 2.3.8, 2.4.9, 2.5.7, 2.6.5, jruby-9.2.11.0 ]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/windows-bundler.yml
+++ b/.github/workflows/windows-bundler.yml
@@ -16,7 +16,7 @@ jobs:
         ruby: [ '2.4', '2.5', '2.6' ]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         ruby: [ 2.4.9, 2.5.7, 2.6.5 ]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
# Description:

## What was the end-user or developer problem that led to this PR?

The current Actions randomly fail with `git checkout`. See https://github.com/rubygems/rubygems/pull/3457/checks?check_run_id=544020837#step:2:698

## What is your fix for the problem, implemented in this PR?

`actions/checkout@v2` uses `fetch-deptch=1` as the default configuration. We should try to use it.

______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
