### PR TITLE
Revert "Minitest cleanup"

### DIFF
--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -98,7 +98,7 @@ end
 # and uninstall gems, fetch remote gems through a stub fetcher and be assured
 # your normal set of gems is not affected.
 
-class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Unit::TestCase)
+class Gem::TestCase < Minitest::Test
 
   extend Gem::Deprecate
 

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -11,7 +11,10 @@ if File.exist?(bundler_gemspec)
   Gem::Specification.dirs.shift
 end
 
-gem 'minitest', '~> 5.13'
+begin
+  gem 'minitest', '~> 5.13'
+rescue Gem::LoadError
+end
 
 begin
   require 'simplecov'
@@ -95,7 +98,7 @@ end
 # and uninstall gems, fetch remote gems through a stub fetcher and be assured
 # your normal set of gems is not affected.
 
-class Gem::TestCase < Minitest::Test
+class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Unit::TestCase)
 
   extend Gem::Deprecate
 
@@ -122,6 +125,11 @@ class Gem::TestCase < Minitest::Test
     loaded = Gem.loaded_specs.values.map(&:full_name)
 
     assert_equal expected.sort, loaded.sort if expected
+  end
+
+  def assert_path_exists(path, msg = nil)
+    msg = message(msg) { "Expected path '#{path}' to exist" }
+    assert File.exist?(path), msg
   end
 
   def assert_directory_exists(path, msg = nil)
@@ -215,6 +223,11 @@ class Gem::TestCase < Minitest::Test
     else
       RbConfig::CONFIG.delete 'EXEEXT'
     end
+  end
+
+  def refute_path_exists(path, msg = nil)
+    msg = message(msg) { "Expected path '#{path}' to not exist" }
+    refute File.exist?(path), msg
   end
 
   def scan_make_command_lines(output)

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -127,11 +127,6 @@ class Gem::TestCase < Minitest::Test
     assert_equal expected.sort, loaded.sort if expected
   end
 
-  def assert_path_exists(path, msg = nil)
-    msg = message(msg) { "Expected path '#{path}' to exist" }
-    assert File.exist?(path), msg
-  end
-
   def assert_directory_exists(path, msg = nil)
     msg = message(msg) { "Expected path '#{path}' to be a directory" }
     assert_path_exists path
@@ -223,11 +218,6 @@ class Gem::TestCase < Minitest::Test
     else
       RbConfig::CONFIG.delete 'EXEEXT'
     end
-  end
-
-  def refute_path_exists(path, msg = nil)
-    msg = message(msg) { "Expected path '#{path}' to not exist" }
-    refute File.exist?(path), msg
   end
 
   def scan_make_command_lines(output)


### PR DESCRIPTION
# Description:

## What was the end-user or developer problem that led to this PR?

Unfortunately,  https://github.com/rubygems/rubygems/pull/3445 completely broke the test suite on the ruby core repository.

## What is your fix for the problem, implemented in this PR?

Reverted the related changes for the ruby core.
______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
