### PR TITLE
Real jruby

### DIFF
--- a/.github/workflows/jruby-bundler.yml
+++ b/.github/workflows/jruby-bundler.yml
@@ -8,7 +8,7 @@ on:
       - master
 
 jobs:
-  warbler:
+  jruby_bundler:
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/jruby-bundler.yml
+++ b/.github/workflows/jruby-bundler.yml
@@ -11,12 +11,23 @@ jobs:
   warbler:
     runs-on: ubuntu-latest
 
+    env:
+      RGV: ..
+
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: jruby-9.2.11.0
+      - name: Prepare dependencies
+        run: |
+          bin/rake spec:parallel_deps
+        working-directory: ./bundler
+      - name: Run Test
+        run: |
+          bin/parallel_rspec spec --test-options '--tag jruby'
+        working-directory: ./bundler
       - name: Install local bundler
         run: |
           bin/rake install:local

--- a/bundler/spec/commands/outdated_spec.rb
+++ b/bundler/spec/commands/outdated_spec.rb
@@ -605,24 +605,20 @@ RSpec.describe "bundle outdated" do
       expect(out).to end_with("Bundle up to date!")
     end
 
-    it "reports that updates are available if the JRuby platform is used" do
-      simulate_ruby_engine "jruby", "1.6.7" do
-        simulate_platform "jruby" do
-          install_gemfile <<-G
-            source "#{file_uri_for(gem_repo2)}"
-            gem "laduradura", '= 5.15.2', :platforms => [:ruby, :jruby]
-          G
+    it "reports that updates are available if the JRuby platform is used", :jruby do
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "laduradura", '= 5.15.2', :platforms => [:ruby, :jruby]
+      G
 
-          bundle "outdated"
+      bundle "outdated"
 
-          expected_output = <<~TABLE.strip
-            Gem         Current  Latest  Requested  Groups
-            laduradura  5.15.2   5.15.3  = 5.15.2   default
-          TABLE
+      expected_output = <<~TABLE.strip
+        Gem         Current  Latest  Requested  Groups
+        laduradura  5.15.2   5.15.3  = 5.15.2   default
+      TABLE
 
-          expect(out).to end_with(expected_output)
-        end
-      end
+      expect(out).to end_with(expected_output)
     end
   end
 

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -167,10 +167,7 @@ RSpec.describe "bundle install from an existing gemspec" do
     expect(out.scan(message).size).to eq(1)
   end
 
-  it "should match a lockfile on non-ruby platforms with a transitive platform dependency" do
-    simulate_platform java
-    simulate_ruby_engine "jruby"
-
+  it "should match a lockfile on non-ruby platforms with a transitive platform dependency", :jruby do
     build_lib("foo", :path => tmp.join("foo")) do |s|
       s.add_dependency "platform_specific"
     end
@@ -365,13 +362,11 @@ RSpec.describe "bundle install from an existing gemspec" do
         L
       end
 
-      context "using JRuby with explicit platform" do
-        let(:platform) { "java" }
-
+      context "using JRuby with explicit platform", :jruby do
         before do
           create_file(
-            tmp.join("foo", "foo-#{platform}.gemspec"),
-            build_spec("foo", "1.0", platform) do
+            tmp.join("foo", "foo-java.gemspec"),
+            build_spec("foo", "1.0", "java") do
               dep "rack", "=1.0.0"
               @spec.authors = "authors"
               @spec.summary = "summary"
@@ -380,27 +375,17 @@ RSpec.describe "bundle install from an existing gemspec" do
         end
 
         it "should install" do
-          simulate_ruby_engine "jruby" do
-            simulate_platform "java" do
-              results = bundle "install", :artifice => "endpoint"
-              expect(results).to include("Installing rack 1.0.0")
-              expect(the_bundle).to include_gems "rack 1.0.0"
-            end
-          end
+          results = bundle "install", :artifice => "endpoint"
+          expect(results).to include("Installing rack 1.0.0")
+          expect(the_bundle).to include_gems "rack 1.0.0"
         end
       end
 
-      context "using JRuby" do
-        let(:platform) { "java" }
-
+      context "using JRuby", :jruby do
         it "should install" do
-          simulate_ruby_engine "jruby" do
-            simulate_platform "java" do
-              results = bundle "install", :artifice => "endpoint"
-              expect(results).to include("Installing rack 1.0.0")
-              expect(the_bundle).to include_gems "rack 1.0.0"
-            end
-          end
+          results = bundle "install", :artifice => "endpoint"
+          expect(results).to include("Installing rack 1.0.0")
+          expect(the_bundle).to include_gems "rack 1.0.0"
         end
       end
 

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -353,7 +353,6 @@ RSpec.describe "bundle install with platform conditionals" do
 
   it "does not attempt to install gems from :rbx when using --local" do
     simulate_platform "ruby"
-    simulate_ruby_engine "ruby"
 
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -366,7 +365,6 @@ RSpec.describe "bundle install with platform conditionals" do
 
   it "does not attempt to install gems from other rubies when using --local" do
     simulate_platform "ruby"
-    simulate_ruby_engine "ruby"
     other_ruby_version_tag = RUBY_VERSION =~ /^1\.8/ ? :ruby_19 : :ruby_18
 
     gemfile <<-G
@@ -380,7 +378,6 @@ RSpec.describe "bundle install with platform conditionals" do
 
   it "resolves all platforms by default and without warning messages" do
     simulate_platform "ruby"
-    simulate_ruby_engine "ruby"
 
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"

--- a/bundler/spec/install/gemfile_spec.rb
+++ b/bundler/spec/install/gemfile_spec.rb
@@ -62,32 +62,24 @@ RSpec.describe "bundle install" do
     end
   end
 
-  context "with engine specified in symbol" do
+  context "with engine specified in symbol", :jruby do
     it "does not raise any error parsing Gemfile" do
-      simulate_ruby_version "2.3.0" do
-        simulate_ruby_engine "jruby", "9.1.2.0" do
-          install_gemfile! <<-G
-            source "#{file_uri_for(gem_repo1)}"
-            ruby "2.3.0", :engine => :jruby, :engine_version => "9.1.2.0"
-          G
+      install_gemfile! <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        ruby "#{RUBY_VERSION}", :engine => :jruby, :engine_version => "#{RUBY_ENGINE_VERSION}"
+      G
 
-          expect(out).to match(/Bundle complete!/)
-        end
-      end
+      expect(out).to match(/Bundle complete!/)
     end
 
     it "installation succeeds" do
-      simulate_ruby_version "2.3.0" do
-        simulate_ruby_engine "jruby", "9.1.2.0" do
-          install_gemfile! <<-G
-            source "#{file_uri_for(gem_repo1)}"
-            ruby "2.3.0", :engine => :jruby, :engine_version => "9.1.2.0"
-            gem "rack"
-          G
+      install_gemfile! <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        ruby "#{RUBY_VERSION}", :engine => :jruby, :engine_version => "#{RUBY_ENGINE_VERSION}"
+        gem "rack"
+      G
 
-          expect(the_bundle).to include_gems "rack 1.0.0"
-        end
-      end
+      expect(the_bundle).to include_gems "rack 1.0.0"
     end
   end
 

--- a/bundler/spec/other/platform_spec.rb
+++ b/bundler/spec/other/platform_spec.rb
@@ -1085,9 +1085,7 @@ G
 
       FileUtils.rm(bundled_app_lock)
 
-      ruby <<-R
-        require 'bundler/setup'
-      R
+      ruby "require 'bundler/setup'"
 
       expect(bundled_app_lock).not_to exist
       should_be_ruby_version_incorrect
@@ -1104,9 +1102,7 @@ G
 
       FileUtils.rm(bundled_app_lock)
 
-      ruby <<-R
-        require 'bundler/setup'
-      R
+      ruby "require 'bundler/setup'"
 
       expect(bundled_app_lock).not_to exist
       should_be_engine_incorrect
@@ -1124,9 +1120,7 @@ G
 
         FileUtils.rm(bundled_app_lock)
 
-        ruby <<-R
-          require 'bundler/setup'
-        R
+      ruby "require 'bundler/setup'"
 
         expect(bundled_app_lock).not_to exist
         should_be_engine_version_incorrect
@@ -1144,9 +1138,7 @@ G
 
       FileUtils.rm(bundled_app_lock)
 
-      ruby <<-R
-        require 'bundler/setup'
-      R
+      ruby "require 'bundler/setup'"
 
       expect(bundled_app_lock).not_to exist
       should_be_patchlevel_incorrect

--- a/bundler/spec/other/platform_spec.rb
+++ b/bundler/spec/other/platform_spec.rb
@@ -301,17 +301,15 @@ G
       expect(bundled_app_lock).to exist
     end
 
-    it "installs fine with any engine" do
-      simulate_ruby_engine "jruby" do
-        install_gemfile <<-G
-          source "#{file_uri_for(gem_repo1)}"
-          gem "rack"
+    it "installs fine with any engine", :jruby do
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rack"
 
-          #{ruby_version_correct_engineless}
-        G
+        #{ruby_version_correct_engineless}
+      G
 
-        expect(bundled_app_lock).to exist
-      end
+      expect(bundled_app_lock).to exist
     end
 
     it "installs fine when the patchlevel matches" do
@@ -349,18 +347,16 @@ G
       should_be_engine_incorrect
     end
 
-    it "doesn't install when engine version doesn't match" do
-      simulate_ruby_engine "jruby" do
-        install_gemfile <<-G
-          source "#{file_uri_for(gem_repo1)}"
-          gem "rack"
+    it "doesn't install when engine version doesn't match", :jruby do
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rack"
 
-          #{engine_version_incorrect}
-        G
+        #{engine_version_incorrect}
+      G
 
-        expect(bundled_app_lock).not_to exist
-        should_be_engine_version_incorrect
-      end
+      expect(bundled_app_lock).not_to exist
+      should_be_engine_version_incorrect
     end
 
     it "doesn't install when patchlevel doesn't match" do
@@ -395,24 +391,22 @@ G
       expect(out).to eq("Resolving dependencies...\nThe Gemfile's dependencies are satisfied")
     end
 
-    it "checks fine with any engine" do
-      simulate_ruby_engine "jruby" do
-        install_gemfile <<-G
-          source "#{file_uri_for(gem_repo1)}"
-          gem "rack"
-        G
+    it "checks fine with any engine", :jruby do
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rack"
+      G
 
-        gemfile <<-G
-          source "#{file_uri_for(gem_repo1)}"
-          gem "rack"
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rack"
 
-          #{ruby_version_correct_engineless}
-        G
+        #{ruby_version_correct_engineless}
+      G
 
-        bundle :check
-        expect(exitstatus).to eq(0) if exitstatus
-        expect(out).to eq("Resolving dependencies...\nThe Gemfile's dependencies are satisfied")
-      end
+      bundle :check
+      expect(exitstatus).to eq(0) if exitstatus
+      expect(out).to eq("Resolving dependencies...\nThe Gemfile's dependencies are satisfied")
     end
 
     it "fails when ruby version doesn't match" do
@@ -449,23 +443,21 @@ G
       should_be_engine_incorrect
     end
 
-    it "fails when engine version doesn't match" do
-      simulate_ruby_engine "ruby" do
-        install_gemfile <<-G
-          source "#{file_uri_for(gem_repo1)}"
-          gem "rack"
-        G
+    it "fails when engine version doesn't match", :jruby do
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rack"
+      G
 
-        gemfile <<-G
-          source "#{file_uri_for(gem_repo1)}"
-          gem "rack"
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rack"
 
-          #{engine_version_incorrect}
-        G
+        #{engine_version_incorrect}
+      G
 
-        bundle :check
-        should_be_engine_version_incorrect
-      end
+      bundle :check
+      should_be_engine_version_incorrect
     end
 
     it "fails when patchlevel doesn't match" do
@@ -513,22 +505,20 @@ G
       expect(the_bundle).to include_gems "rack 1.2", "rack-obama 1.0", "activesupport 3.0"
     end
 
-    it "updates fine with any engine" do
-      simulate_ruby_engine "jruby" do
-        gemfile <<-G
-          source "#{file_uri_for(gem_repo2)}"
-          gem "activesupport"
-          gem "rack-obama"
+    it "updates fine with any engine", :jruby do
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "activesupport"
+        gem "rack-obama"
 
-          #{ruby_version_correct_engineless}
-        G
-        update_repo2 do
-          build_gem "activesupport", "3.0"
-        end
-
-        bundle "update", :all => true
-        expect(the_bundle).to include_gems "rack 1.2", "rack-obama 1.0", "activesupport 3.0"
+        #{ruby_version_correct_engineless}
+      G
+      update_repo2 do
+        build_gem "activesupport", "3.0"
       end
+
+      bundle "update", :all => true
+      expect(the_bundle).to include_gems "rack 1.2", "rack-obama 1.0", "activesupport 3.0"
     end
 
     it "fails when ruby version doesn't match" do
@@ -547,7 +537,7 @@ G
       should_be_ruby_version_incorrect
     end
 
-    it "fails when ruby engine doesn't match" do
+    it "fails when ruby engine doesn't match", :jruby do
       gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "activesupport"
@@ -563,22 +553,20 @@ G
       should_be_engine_incorrect
     end
 
-    it "fails when ruby engine version doesn't match" do
-      simulate_ruby_engine "jruby" do
-        gemfile <<-G
-          source "#{file_uri_for(gem_repo2)}"
-          gem "activesupport"
-          gem "rack-obama"
+    it "fails when ruby engine version doesn't match", :jruby do
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "activesupport"
+        gem "rack-obama"
 
-          #{engine_version_incorrect}
-        G
-        update_repo2 do
-          build_gem "activesupport", "3.0"
-        end
-
-        bundle :update, :all => true
-        should_be_engine_version_incorrect
+        #{engine_version_incorrect}
+      G
+      update_repo2 do
+        build_gem "activesupport", "3.0"
       end
+
+      bundle :update, :all => true
+      should_be_engine_version_incorrect
     end
 
     it "fails when patchlevel doesn't match" do
@@ -617,18 +605,16 @@ G
       expect(out).to eq(default_bundle_path("gems", "rails-2.3.2").to_s)
     end
 
-    it "prints path if ruby version is correct for any engine" do
-      simulate_ruby_engine "jruby" do
-        install_gemfile! <<-G
-          source "#{file_uri_for(gem_repo1)}"
-          gem "rails"
+    it "prints path if ruby version is correct for any engine", :jruby do
+      install_gemfile! <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rails"
 
-          #{ruby_version_correct_engineless}
-        G
+        #{ruby_version_correct_engineless}
+      G
 
-        bundle "info rails --path"
-        expect(out).to eq(default_bundle_path("gems", "rails-2.3.2").to_s)
-      end
+      bundle "info rails --path"
+      expect(out).to eq(default_bundle_path("gems", "rails-2.3.2").to_s)
     end
 
     it "fails if ruby version doesn't match", :bundler => "< 3" do
@@ -655,18 +641,16 @@ G
       should_be_engine_incorrect
     end
 
-    it "fails if engine version doesn't match", :bundler => "< 3" do
-      simulate_ruby_engine "jruby" do
-        gemfile <<-G
-          source "#{file_uri_for(gem_repo1)}"
-          gem "rails"
+    it "fails if engine version doesn't match", :bundler => "< 3", :jruby => true do
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rails"
 
-          #{engine_version_incorrect}
-        G
+        #{engine_version_incorrect}
+      G
 
-        bundle "show rails"
-        should_be_engine_version_incorrect
-      end
+      bundle "show rails"
+      should_be_engine_version_incorrect
     end
 
     it "fails when patchlevel doesn't match", :bundler => "< 3" do
@@ -704,18 +688,16 @@ G
       expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
     end
 
-    it "copies the .gem file to vendor/cache when ruby version matches for any engine" do
-      simulate_ruby_engine "jruby" do
-        install_gemfile! <<-G
-          source "#{file_uri_for(gem_repo1)}"
-          gem 'rack'
+    it "copies the .gem file to vendor/cache when ruby version matches for any engine", :jruby do
+      install_gemfile! <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem 'rack'
 
-          #{ruby_version_correct_engineless}
-        G
+        #{ruby_version_correct_engineless}
+      G
 
-        bundle! :cache
-        expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
-      end
+      bundle! :cache
+      expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
     end
 
     it "fails if the ruby version doesn't match" do
@@ -740,17 +722,15 @@ G
       should_be_engine_incorrect
     end
 
-    it "fails if the engine version doesn't match" do
-      simulate_ruby_engine "jruby" do
-        gemfile <<-G
-          gem 'rack'
+    it "fails if the engine version doesn't match", :jruby do
+      gemfile <<-G
+        gem 'rack'
 
-          #{engine_version_incorrect}
-        G
+        #{engine_version_incorrect}
+      G
 
-        bundle :cache
-        should_be_engine_version_incorrect
-      end
+      bundle :cache
+      should_be_engine_version_incorrect
     end
 
     it "fails when patchlevel doesn't match" do
@@ -785,18 +765,16 @@ G
       expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
     end
 
-    it "copies the .gem file to vendor/cache when ruby version matches any engine" do
-      simulate_ruby_engine "jruby" do
-        install_gemfile! <<-G
-          source "#{file_uri_for(gem_repo1)}"
-          gem 'rack'
+    it "copies the .gem file to vendor/cache when ruby version matches any engine", :jruby do
+      install_gemfile! <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem 'rack'
 
-          #{ruby_version_correct_engineless}
-        G
+        #{ruby_version_correct_engineless}
+      G
 
-        bundle :cache
-        expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
-      end
+      bundle :cache
+      expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
     end
 
     it "fails if the ruby version doesn't match" do
@@ -821,17 +799,15 @@ G
       should_be_engine_incorrect
     end
 
-    it "fails if the engine version doesn't match" do
-      simulate_ruby_engine "jruby" do
-        gemfile <<-G
-          gem 'rack'
+    it "fails if the engine version doesn't match", :jruby do
+      gemfile <<-G
+        gem 'rack'
 
-          #{engine_version_incorrect}
-        G
+        #{engine_version_incorrect}
+      G
 
-        bundle :cache
-        should_be_engine_version_incorrect
-      end
+      bundle :cache
+      should_be_engine_version_incorrect
     end
 
     it "fails when patchlevel doesn't match" do
@@ -864,18 +840,16 @@ G
       expect(out).to include("0.9.1")
     end
 
-    it "activates the correct gem when ruby version matches any engine" do
-      simulate_ruby_engine "jruby" do
-        system_gems "rack-1.0.0", "rack-0.9.1", :path => :bundle_path
-        gemfile <<-G
-          gem "rack", "0.9.1"
+    it "activates the correct gem when ruby version matches any engine", :jruby do
+      system_gems "rack-1.0.0", "rack-0.9.1", :path => :bundle_path
+      gemfile <<-G
+        gem "rack", "0.9.1"
 
-          #{ruby_version_correct_engineless}
-        G
+        #{ruby_version_correct_engineless}
+      G
 
-        bundle "exec rackup"
-        expect(out).to include("0.9.1")
-      end
+      bundle "exec rackup"
+      expect(out).to include("0.9.1")
     end
 
     it "fails when the ruby version doesn't match" do
@@ -900,17 +874,15 @@ G
       should_be_engine_incorrect
     end
 
-    # it "fails when the engine version doesn't match" do
-    #   simulate_ruby_engine "jruby" do
-    #     gemfile <<-G
-    #       gem "rack", "0.9.1"
+    # it "fails when the engine version doesn't match", :jruby do
+    #   gemfile <<-G
+    #     gem "rack", "0.9.1"
     #
-    #       #{engine_version_incorrect}
-    #     G
+    #     #{engine_version_incorrect}
+    #   G
     #
-    #     bundle "exec rackup"
-    #     should_be_engine_version_incorrect
-    #   end
+    #   bundle "exec rackup"
+    #   should_be_engine_version_incorrect
     # end
 
     it "fails when patchlevel doesn't match" do
@@ -953,23 +925,21 @@ G
       expect(out).to include("0.9.1")
     end
 
-    it "starts IRB with the default group loaded when ruby version matches any engine", :readline do
-      simulate_ruby_engine "jruby" do
-        gemfile <<-G
-          source "#{file_uri_for(gem_repo1)}"
-          gem "rack"
-          gem "activesupport", :group => :test
-          gem "rack_middleware", :group => :development
+    it "starts IRB with the default group loaded when ruby version matches", :readline, :jruby do
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rack"
+        gem "activesupport", :group => :test
+        gem "rack_middleware", :group => :development
 
-          #{ruby_version_correct_engineless}
-        G
+        #{ruby_version_correct_engineless}
+      G
 
-        bundle "console" do |input, _, _|
-          input.puts("puts RACK")
-          input.puts("exit")
-        end
-        expect(out).to include("0.9.1")
+      bundle "console" do |input, _, _|
+        input.puts("puts RACK")
+        input.puts("exit")
       end
+      expect(out).to include("0.9.1")
     end
 
     it "fails when ruby version doesn't match" do
@@ -1000,20 +970,18 @@ G
       should_be_engine_incorrect
     end
 
-    it "fails when engine version doesn't match" do
-      simulate_ruby_engine "jruby" do
-        gemfile <<-G
-          source "#{file_uri_for(gem_repo1)}"
-          gem "rack"
-          gem "activesupport", :group => :test
-          gem "rack_middleware", :group => :development
+    it "fails when engine version doesn't match", :jruby do
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rack"
+        gem "activesupport", :group => :test
+        gem "rack_middleware", :group => :development
 
-          #{engine_version_incorrect}
-        G
+        #{engine_version_incorrect}
+      G
 
-        bundle "console"
-        should_be_engine_version_incorrect
-      end
+      bundle "console"
+      should_be_engine_version_incorrect
     end
 
     it "fails when patchlevel doesn't match" do
@@ -1057,21 +1025,19 @@ G
       expect(bundled_app_lock).to exist
     end
 
-    it "makes a Gemfile.lock if setup succeeds for any engine" do
-      simulate_ruby_engine "jruby" do
-        install_gemfile <<-G
-          source "#{file_uri_for(gem_repo1)}"
-          gem "yard"
-          gem "rack"
+    it "makes a Gemfile.lock if setup succeeds for any engine", :jruby do
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem "yard"
+        gem "rack"
 
-          #{ruby_version_correct_engineless}
-        G
+        #{ruby_version_correct_engineless}
+      G
 
-        FileUtils.rm(bundled_app_lock)
+      FileUtils.rm(bundled_app_lock)
 
-        run "1"
-        expect(bundled_app_lock).to exist
-      end
+      run "1"
+      expect(bundled_app_lock).to exist
     end
 
     it "fails when ruby version doesn't match" do
@@ -1108,23 +1074,21 @@ G
       should_be_engine_incorrect
     end
 
-    it "fails when engine version doesn't match" do
-      simulate_ruby_engine "jruby" do
-        install_gemfile <<-G
-          source "#{file_uri_for(gem_repo1)}"
-          gem "yard"
-          gem "rack"
+    it "fails when engine version doesn't match", :jruby do
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem "yard"
+        gem "rack"
 
-          #{engine_version_incorrect}
-        G
+        #{engine_version_incorrect}
+      G
 
-        FileUtils.rm(bundled_app_lock)
+      FileUtils.rm(bundled_app_lock)
 
       ruby "require 'bundler/setup'"
 
-        expect(bundled_app_lock).not_to exist
-        should_be_engine_version_incorrect
-      end
+      expect(bundled_app_lock).not_to exist
+      should_be_engine_version_incorrect
     end
 
     it "fails when patchlevel doesn't match" do
@@ -1183,32 +1147,30 @@ G
       expect(out).to match(Regexp.new(expected_output))
     end
 
-    it "returns list of outdated gems when the ruby version matches for any engine" do
-      simulate_ruby_engine "jruby" do
-        bundle! :install
-        update_repo2 do
-          build_gem "activesupport", "3.0"
-          update_git "foo", :path => lib_path("foo")
-        end
-
-        gemfile <<-G
-          source "#{file_uri_for(gem_repo2)}"
-          gem "activesupport", "2.3.5"
-          gem "foo", :git => "#{lib_path("foo")}"
-
-          #{ruby_version_correct_engineless}
-        G
-
-        bundle "outdated"
-
-        expected_output = <<~TABLE.gsub("x", "\\\h").tr(".", "\.").strip
-          Gem            Current      Latest       Requested  Groups
-          activesupport  2.3.5        3.0          = 2.3.5    default
-          foo            1.0 xxxxxxx  1.0 xxxxxxx  >= 0       default
-        TABLE
-
-        expect(out).to match(Regexp.new(expected_output))
+    it "returns list of outdated gems when the ruby version matches for any engine", :jruby do
+      bundle! :install
+      update_repo2 do
+        build_gem "activesupport", "3.0"
+        update_git "foo", :path => lib_path("foo")
       end
+
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "activesupport", "2.3.5"
+        gem "foo", :git => "#{lib_path("foo")}"
+
+        #{ruby_version_correct_engineless}
+      G
+
+      bundle "outdated"
+
+      expected_output = <<~TABLE.gsub("x", "\\\h").tr(".", "\.").strip
+        Gem            Current      Latest       Requested  Groups
+        activesupport  2.3.5        3.0          = 2.3.5    default
+        foo            1.0 xxxxxxx  1.0 xxxxxxx  >= 0       default
+      TABLE
+
+      expect(out).to match(Regexp.new(expected_output))
     end
 
     it "fails when the ruby version doesn't match" do
@@ -1247,64 +1209,58 @@ G
       should_be_engine_incorrect
     end
 
-    it "fails when the engine version doesn't match" do
-      simulate_ruby_engine "jruby" do
-        update_repo2 do
-          build_gem "activesupport", "3.0"
-          update_git "foo", :path => lib_path("foo")
-        end
-
-        gemfile <<-G
-          source "#{file_uri_for(gem_repo2)}"
-          gem "activesupport", "2.3.5"
-          gem "foo", :git => "#{lib_path("foo")}"
-
-          #{engine_version_incorrect}
-        G
-
-        bundle "outdated"
-        should_be_engine_version_incorrect
+    it "fails when the engine version doesn't match", :jruby do
+      update_repo2 do
+        build_gem "activesupport", "3.0"
+        update_git "foo", :path => lib_path("foo")
       end
+
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "activesupport", "2.3.5"
+        gem "foo", :git => "#{lib_path("foo")}"
+
+        #{engine_version_incorrect}
+      G
+
+      bundle "outdated"
+      should_be_engine_version_incorrect
     end
 
-    it "fails when the patchlevel doesn't match" do
-      simulate_ruby_engine "jruby" do
-        update_repo2 do
-          build_gem "activesupport", "3.0"
-          update_git "foo", :path => lib_path("foo")
-        end
-
-        gemfile <<-G
-          source "#{file_uri_for(gem_repo2)}"
-          gem "activesupport", "2.3.5"
-          gem "foo", :git => "#{lib_path("foo")}"
-
-          #{patchlevel_incorrect}
-        G
-
-        bundle "outdated"
-        should_be_patchlevel_incorrect
+    it "fails when the patchlevel doesn't match", :jruby do
+      update_repo2 do
+        build_gem "activesupport", "3.0"
+        update_git "foo", :path => lib_path("foo")
       end
+
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "activesupport", "2.3.5"
+        gem "foo", :git => "#{lib_path("foo")}"
+
+        #{patchlevel_incorrect}
+      G
+
+      bundle "outdated"
+      should_be_patchlevel_incorrect
     end
 
-    it "fails when the patchlevel is a fixnum" do
-      simulate_ruby_engine "jruby" do
-        update_repo2 do
-          build_gem "activesupport", "3.0"
-          update_git "foo", :path => lib_path("foo")
-        end
-
-        gemfile <<-G
-          source "#{file_uri_for(gem_repo2)}"
-          gem "activesupport", "2.3.5"
-          gem "foo", :git => "#{lib_path("foo")}"
-
-          #{patchlevel_fixnum}
-        G
-
-        bundle "outdated"
-        should_be_patchlevel_fixnum
+    it "fails when the patchlevel is a fixnum", :jruby do
+      update_repo2 do
+        build_gem "activesupport", "3.0"
+        update_git "foo", :path => lib_path("foo")
       end
+
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "activesupport", "2.3.5"
+        gem "foo", :git => "#{lib_path("foo")}"
+
+        #{patchlevel_fixnum}
+      G
+
+      bundle "outdated"
+      should_be_patchlevel_fixnum
     end
   end
 end

--- a/bundler/spec/support/filters.rb
+++ b/bundler/spec/support/filters.rb
@@ -42,6 +42,7 @@ RSpec.configure do |config|
   config.filter_run_excluding :no_color_tty => Gem.win_platform? || !ENV["GITHUB_ACTION"].nil?
   config.filter_run_excluding :permissions => Gem.win_platform?
   config.filter_run_excluding :readline => Gem.win_platform?
+  config.filter_run_excluding :jruby => RUBY_PLATFORM != "java"
 
   config.filter_run_when_matching :focus unless ENV["CI"]
 end

--- a/bundler/spec/support/hax.rb
+++ b/bundler/spec/support/hax.rb
@@ -46,23 +46,3 @@ if ENV["BUNDLER_SPEC_WINDOWS"] == "true"
     WINDOWS = true
   end
 end
-
-class Object
-  if ENV["BUNDLER_SPEC_RUBY_ENGINE"]
-    if RUBY_ENGINE != "jruby" && ENV["BUNDLER_SPEC_RUBY_ENGINE"] == "jruby"
-      begin
-        # this has to be done up front because psych will try to load a .jar
-        # if it thinks its on jruby
-        require "psych"
-      rescue LoadError
-        nil
-      end
-    end
-
-    remove_const :RUBY_ENGINE
-    RUBY_ENGINE = ENV["BUNDLER_SPEC_RUBY_ENGINE"]
-
-    remove_const :RUBY_ENGINE_VERSION
-    RUBY_ENGINE_VERSION = ENV["BUNDLER_SPEC_RUBY_ENGINE_VERSION"]
-  end
-end

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -62,8 +62,8 @@ module Spec
     def run(cmd, *args)
       opts = args.last.is_a?(Hash) ? args.pop : {}
       groups = args.map(&:inspect).join(", ")
-      setup = "require '#{lib_dir}/bundler' ; Bundler.ui.silence { Bundler.setup(#{groups}) }\n"
-      ruby(setup + cmd, opts)
+      setup = "require '#{lib_dir}/bundler' ; Bundler.ui.silence { Bundler.setup(#{groups}) }"
+      ruby([setup, cmd].join(" ; "), opts)
     end
     bang :run
 
@@ -158,7 +158,8 @@ module Spec
 
     def ruby(ruby, options = {})
       lib_option = options[:no_lib] ? "" : " -I#{lib_dir}"
-      sys_exec(%(#{Gem.ruby}#{lib_option} -w -e #{ruby.shellescape}), options)
+      escaped_ruby = RUBY_PLATFORM == "java" ? ruby.shellescape.dump : ruby.shellescape
+      sys_exec(%(#{Gem.ruby}#{lib_option} -w -e #{escaped_ruby}), options)
     end
     bang :ruby
 
@@ -366,16 +367,8 @@ module Spec
       path = opts.fetch(:path, system_gem_path)
       if path == :bundle_path
         bundle_dir = opts.fetch(:bundle_dir, bundled_app)
-        path = ruby!(<<-RUBY, :dir => bundle_dir)
-          require "bundler"
-          begin
-            puts Bundler.bundle_path
-          rescue Bundler::GemfileNotFound
-            ENV["BUNDLE_GEMFILE"] = "Gemfile"
-            retry
-          end
-
-        RUBY
+        code = 'require "bundler"; begin; puts Bundler.bundle_path; rescue Bundler::GemfileNotFound; ENV["BUNDLE_GEMFILE"] = "Gemfile"; retry; end'
+        path = ruby!(code, :dir => bundle_dir)
       end
       gems = gems.flatten
 

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -456,19 +456,6 @@ module Spec
       ENV["BUNDLER_SPEC_RUBY_VERSION"] = old if block_given?
     end
 
-    def simulate_ruby_engine(engine, version = "1.6.0")
-      return if engine == local_ruby_engine
-
-      old = ENV["BUNDLER_SPEC_RUBY_ENGINE"]
-      ENV["BUNDLER_SPEC_RUBY_ENGINE"] = engine
-      old_version = ENV["BUNDLER_SPEC_RUBY_ENGINE_VERSION"]
-      ENV["BUNDLER_SPEC_RUBY_ENGINE_VERSION"] = version
-      yield if block_given?
-    ensure
-      ENV["BUNDLER_SPEC_RUBY_ENGINE"] = old if block_given?
-      ENV["BUNDLER_SPEC_RUBY_ENGINE_VERSION"] = old_version if block_given?
-    end
-
     def simulate_bundler_version(version)
       old = ENV["BUNDLER_SPEC_VERSION"]
       ENV["BUNDLER_SPEC_VERSION"] = version.to_s

--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -76,7 +76,7 @@ module Spec
       if Bundler::VERSION.split(".").first.to_i < 3
         system_gem_path(*path)
       else
-        bundled_app(*[".bundle", ENV.fetch("BUNDLER_SPEC_RUBY_ENGINE", Gem.ruby_engine), RbConfig::CONFIG["ruby_version"], *path].compact)
+        bundled_app(*[".bundle", Gem.ruby_engine, RbConfig::CONFIG["ruby_version"], *path].compact)
       end
     end
 

--- a/bundler/spec/support/platforms.rb
+++ b/bundler/spec/support/platforms.rb
@@ -65,12 +65,10 @@ module Spec
     end
 
     def local_ruby_engine
-      ENV["BUNDLER_SPEC_RUBY_ENGINE"] || RUBY_ENGINE
+      RUBY_ENGINE
     end
 
     def local_engine_version
-      return ENV["BUNDLER_SPEC_RUBY_ENGINE_VERSION"] if ENV["BUNDLER_SPEC_RUBY_ENGINE_VERSION"]
-
       RUBY_ENGINE_VERSION
     end
 


### PR DESCRIPTION
# Description:

This is my alternative proposal to #3457.

The `simulate_ruby_engine` approach of overwriting constants such as `RUBY_ENGINE` is brittle and has caused some specs to break in ruby-core, so we should get rid of it.

As an alternative, I'm migrating the specs using it to a real jruby CI.

I had to add a few workarounds to get the specs passing on jruby, due to [a bug in jruby](https://github.com/jruby/jruby/issues/6153).

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
