### PR TITLE
Suppress warnings coming from `jar-dependencies`

### DIFF
--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -30,6 +30,8 @@ require 'bundler'
 
 require 'minitest/autorun'
 
+ENV["JARS_SKIP"] = "true" if Gem.java_platform? # avoid unnecessary and noisy `jar-dependencies` post install hook
+
 require 'rubygems/deprecate'
 
 require 'fileutils'


### PR DESCRIPTION
# Description:

This is a default gem on jruby, which ships with a rubygems plugin, which prints warnings all over the place during our tests.

This plugin is unnecessary from our tests, so I disable it through the `JARS_SKIP` environment variable provided by this gem.

I [fixed the underlying issue](https://github.com/mkristian/jar-dependencies/pull/74) in the gem itself, but we can disable the post install hooks altogether since we don't need them anyways.

### Before

```
$ rake
NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.
Gem::Specification#rubyforge_project= called from /home/deivid/.rbenv/versions/jruby-9.2.11.0/lib/ruby/gems/shared/specifications/default/json-2.2.0-java.gemspec:18.
NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed in Rubygems 4
Gem::Specification#rubyforge_project= called from /home/deivid/.rbenv/versions/jruby-9.2.11.0/lib/ruby/gems/shared/specifications/default/json-2.2.0-java.gemspec:18.
NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed in Rubygems 4
Gem::Specification#rubyforge_project= called from /home/deivid/.rbenv/versions/jruby-9.2.11.0/lib/ruby/gems/shared/specifications/default/json-2.2.0-java.gemspec:18.
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.jruby.ext.openssl.SecurityHelper (file:/home/deivid/.rbenv/versions/jruby-9.2.11.0/lib/ruby/gems/shared/gems/jruby-openssl-0.10.5.dev-java/lib/jopenssl.jar) to constructor java.security.KeyFactory(java.security.KeyFactorySpi,java.security.Provider,java.lang.String)
WARNING: Please consider reporting this to the maintainers of org.jruby.ext.openssl.SecurityHelper
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
Skipping `gem cert` tests on jruby.
Skipping Gem::Security tests on jruby.
Run options: --seed 59820

# Running:

.../home/deivid/.rbenv/versions/jruby-9.2.11.0/lib/ruby/stdlib/jars/installer.rb:48: warning: Ambiguous first argument; make sure.
.............................................................................S.....S.........................................................................................................................................................................................................................................................../home/deivid/.rbenv/versions/jruby-9.2.11.0/lib/ruby/gems/shared/gems/webrick-1.6.0/lib/webrick/https.rb:50: warning: javax.net.ssl.SSLPeerUnverifiedException: peer not authenticated
................/home/deivid/.rbenv/versions/jruby-9.2.11.0/lib/ruby/gems/shared/gems/webrick-1.6.0/lib/webrick/https.rb:50: warning: javax.net.ssl.SSLPeerUnverifiedException: peer not authenticated
........................../home/deivid/.rbenv/versions/jruby-9.2.11.0/lib/ruby/gems/shared/gems/webrick-1.6.0/lib/webrick/https.rb:50: warning: javax.net.ssl.SSLPeerUnverifiedException: peer not authenticated
.............................................................................................................................................................jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/default/gems/default-2
.jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/default/gems/default-2
.jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/default/gems/default-2
.jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/default/gems/default-2
.jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/default/gems/default-2
.jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/default/gems/default-2
.jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/default/gems/default-2
.jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/default/gems/default-2
.jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/default/gems/default-2
.jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/default/gems/default-2
..................................................S...................................................jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/default/gems/b-2
.....................S..................................S....................................................S.jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/gemhome/gems/a-1
.jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/gemhome/gems/a-1
jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/gemhome/gems/a-1
..............jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/default/gems/default-2.0.0.0
...S..S.S.......................................................................................................................................S.........................S.........................../home/deivid/Code/rubygems/lib/rubygems/util.rb:61: warning: system does not support options in JRuby yet: {:out=>"/dev/null", :err=>[:child, :out]}
/home/deivid/Code/rubygems/lib/rubygems/util.rb:61: warning: system does not support options in JRuby yet: {:out=>"/dev/null", :err=>[:child, :out]}
......................jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/default/gems/a-1
.jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/default/gems/a-1-java
...jar-dependencies: No such file or directory - /tmp/test_rubygems_23628/default/gems/a-1
...................S........................................................................................S............S..........S.......S.S............S..........................................................................S.......................................S................................................................................................................................S.SS.......................................................................................................................................................................................................S......................................S.................S....................S........................................S..S...........S.............S........................................S.............S..................................................................................S...S........S............................................................................................................................

Finished in 280.222738s, 7.2228 runs/s, 21.9611 assertions/s.

2024 runs, 6154 assertions, 0 failures, 0 errors, 36 skips

You have skipped tests. Run with --verbose for details.
Coverage report generated for Unit Tests to /home/deivid/Code/rubygems/coverage. 7600 / 9185 LOC (82.74%) covered.
```

### After

```
$ rake
NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.
Gem::Specification#rubyforge_project= called from /home/deivid/.rbenv/versions/jruby-9.2.11.0/lib/ruby/gems/shared/specifications/default/json-2.2.0-java.gemspec:18.
NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed in Rubygems 4
Gem::Specification#rubyforge_project= called from /home/deivid/.rbenv/versions/jruby-9.2.11.0/lib/ruby/gems/shared/specifications/default/json-2.2.0-java.gemspec:18.
NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed in Rubygems 4
Gem::Specification#rubyforge_project= called from /home/deivid/.rbenv/versions/jruby-9.2.11.0/lib/ruby/gems/shared/specifications/default/json-2.2.0-java.gemspec:18.
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.jruby.ext.openssl.SecurityHelper (file:/home/deivid/.rbenv/versions/jruby-9.2.11.0/lib/ruby/gems/shared/gems/jruby-openssl-0.10.5.dev-java/lib/jopenssl.jar) to constructor java.security.KeyFactory(java.security.KeyFactorySpi,java.security.Provider,java.lang.String)
WARNING: Please consider reporting this to the maintainers of org.jruby.ext.openssl.SecurityHelper
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
Skipping `gem cert` tests on jruby.
Skipping Gem::Security tests on jruby.
Run options: --seed 50622

# Running:

......................................................S.....S...................................................................................................................................................................S...............................................................................................S.................................S........................................................................................................................................S..S.S............S................S..................................................S.......................................................................................................................................................................S......................./home/deivid/Code/rubygems/lib/rubygems/util.rb:61: warning: system does not support options in JRuby yet: {:out=>"/dev/null", :err=>[:child, :out]}
/home/deivid/Code/rubygems/lib/rubygems/util.rb:61: warning: system does not support options in JRuby yet: {:out=>"/dev/null", :err=>[:child, :out]}
..............................................S....S...........................S.SS...........................................................S..............S..S...............................................................................................S........................S..................................S.....................................S.......S................S..........S..................................S......S......................................S......................................................S..........................................................................................................................................................................................................................................................................................S.S.S..........................................................................................................................S....S................................................/home/deivid/.rbenv/versions/jruby-9.2.11.0/lib/ruby/gems/shared/gems/webrick-1.6.0/lib/webrick/https.rb:50: warning: javax.net.ssl.SSLPeerUnverifiedException: peer not authenticated
./home/deivid/.rbenv/versions/jruby-9.2.11.0/lib/ruby/gems/shared/gems/webrick-1.6.0/lib/webrick/https.rb:50: warning: javax.net.ssl.SSLPeerUnverifiedException: peer not authenticated
...../home/deivid/.rbenv/versions/jruby-9.2.11.0/lib/ruby/gems/shared/gems/webrick-1.6.0/lib/webrick/https.rb:50: warning: javax.net.ssl.SSLPeerUnverifiedException: peer not authenticated
...................................................................................................................................................................................................................................................................

Finished in 263.616086s, 7.6778 runs/s, 23.3446 assertions/s.

2024 runs, 6154 assertions, 0 failures, 0 errors, 36 skips

You have skipped tests. Run with --verbose for details.
Coverage report generated for Unit Tests to /home/deivid/Code/rubygems/coverage. 7598 / 9185 LOC (82.72%) covered.
```

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
