### PR TITLE
Multiple gems in git repo bugfix

### DIFF
--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -51,7 +51,8 @@ module Gem
       alias_method :rg_extension_dir, :extension_dir
       def extension_dir
         @bundler_extension_dir ||= if source.respond_to?(:extension_dir_name)
-          File.expand_path(File.join(extensions_dir, source.extension_dir_name))
+          unique_extension_dir = [source.extension_dir_name, File.basename(full_gem_path)].uniq.join("-")
+          File.expand_path(File.join(extensions_dir, unique_extension_dir))
         else
           rg_extension_dir
         end

--- a/bundler/spec/install/gems/native_extensions_spec.rb
+++ b/bundler/spec/install/gems/native_extensions_spec.rb
@@ -87,6 +87,58 @@ RSpec.describe "installing a gem with native extensions", :ruby_repo do
     expect(out).to eq("true")
   end
 
+  it "installs correctly from git when multiple gems with extensions share one repository" do
+    build_repo2 do
+      ["one", "two"].each do |n|
+        build_lib "c_extension_#{n}", "1.0", :path => lib_path("gems/c_extension_#{n}") do |s|
+          s.extensions = ["ext/extconf.rb"]
+          s.write "ext/extconf.rb", <<-E
+            require "mkmf"
+            name = "c_extension_bundle_#{n}"
+            dir_config(name)
+            raise "OMG" unless with_config("c_extension_#{n}") == "#{n}"
+            create_makefile(name)
+          E
+
+          s.write "ext/c_extension_#{n}.c", <<-C
+            #include "ruby.h"
+
+            VALUE c_extension_#{n}_value(VALUE self) {
+              return rb_str_new_cstr("#{n}");
+            }
+
+            void Init_c_extension_bundle_#{n}() {
+              VALUE c_Extension = rb_define_class("CExtension_#{n}", rb_cObject);
+              rb_define_method(c_Extension, "value", c_extension_#{n}_value, 0);
+            }
+          C
+
+          s.write "lib/c_extension_#{n}.rb", <<-C
+            require "c_extension_bundle_#{n}"
+          C
+        end
+      end
+      build_git "gems", :path => lib_path("gems"), :gemspec => false
+    end
+
+    bundle! "config set build.c_extension_one --with-c_extension_one=one"
+    bundle! "config set build.c_extension_two --with-c_extension_two=two"
+
+    # 1st time, require only one gem -- only one of the extensions gets built.
+    install_gemfile! <<-G
+      gem "c_extension_one", :git => #{lib_path("gems").to_s.dump}
+    G
+
+    # 2nd time, require both gems -- we need both extensions to be built now.
+    install_gemfile! <<-G
+      gem "c_extension_one", :git => #{lib_path("gems").to_s.dump}
+      gem "c_extension_two", :git => #{lib_path("gems").to_s.dump}
+    G
+
+    run! "Bundler.require; puts CExtension_one.new.value; puts CExtension_two.new.value"
+    expect(out).to eq("one\ntwo")
+  end
+
   it "install with multiple build flags" do
     build_git "c_extension" do |s|
       s.extensions = ["ext/extconf.rb"]


### PR DESCRIPTION
# Description:

This change is an important fix for when a Gemfile specifies multiple gems that are contained in one git repository (where each gem is in a subdirectory within the repo) and they all have native extensions.

Without this change, in certain situations bundler would only build one of the native extensions but not the others.

______________

The fix is to separate the extensions build path for each gem inside the repository, so that the `gem.build_complete` file exists independently for each separate gem.

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

______________

# Tasks:

- [X] Describe the problem / feature
- [X] Write tests
- [X] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

______________

This PR replaces https://github.com/rubygems/rubygems/pull/3435 and adds a test.
