### PR TITLE
[Bundler] Definition: initialize an instance variable to avoid a Ruby warning

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -77,6 +77,7 @@ module Bundler
       @locked_bundler_version = nil
       @locked_ruby_version    = nil
       @locked_specs_incomplete_for_platform = false
+      @new_platform = nil
 
       if lockfile && File.exist?(lockfile)
         @lockfile_contents = Bundler.read_file(lockfile)


### PR DESCRIPTION
# Description:

This PR avoids a Ruby warning "instance variable `@new_platform` not initialized".

## What was the end-user or developer problem that led to this PR?

A warning was emitted on using Bundler:

```
/home/travis/.rvm/rubies/ruby-head/lib/ruby/2.8.0/bundler/definition.rb:569: warning: instance variable @new_platform not initialized
/home/travis/.rvm/rubies/ruby-head/lib/ruby/2.8.0/bundler/definition.rb:537: warning: instance variable @new_platform not initialized
```


## What is your fix for the problem, implemented in this PR?

I initialized the instance variable along with some other instance variables which were set to nil in the constructor.

______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
