### PR TITLE
Fix double chdir warning

### DIFF
--- a/bundler/lib/bundler/source/path/installer.rb
+++ b/bundler/lib/bundler/source/path/installer.rb
@@ -26,18 +26,16 @@ module Bundler
         end
 
         def post_install
-          SharedHelpers.chdir(@gem_dir) do
-            run_hooks(:pre_install)
+          run_hooks(:pre_install)
 
-            unless @disable_extensions
-              build_extensions
-              run_hooks(:post_build)
-            end
-
-            generate_bin unless spec.executables.nil? || spec.executables.empty?
-
-            run_hooks(:post_install)
+          unless @disable_extensions
+            build_extensions
+            run_hooks(:post_build)
           end
+
+          generate_bin unless spec.executables.nil? || spec.executables.empty?
+
+          run_hooks(:post_install)
         ensure
           Bundler.rm_rf(@tmp_dir) if Bundler.requires_sudo?
         end

--- a/bundler/spec/install/gems/native_extensions_spec.rb
+++ b/bundler/spec/install/gems/native_extensions_spec.rb
@@ -38,9 +38,8 @@ RSpec.describe "installing a gem with native extensions", :ruby_repo do
     G
 
     bundle "config set build.c_extension --with-c_extension=hello"
-    bundle "install"
+    bundle! "install"
 
-    expect(out).not_to include("extconf.rb failed")
     expect(out).to include("Installing c_extension 1.0 with native extensions")
 
     run "Bundler.require; puts CExtension.new.its_true"
@@ -82,8 +81,6 @@ RSpec.describe "installing a gem with native extensions", :ruby_repo do
       gem "c_extension", :git => #{lib_path("c_extension-1.0").to_s.dump}
     G
 
-    expect(out).not_to include("extconf.rb failed")
-
     run! "Bundler.require; puts CExtension.new.its_true"
     expect(out).to eq("true")
   end
@@ -122,8 +119,6 @@ RSpec.describe "installing a gem with native extensions", :ruby_repo do
     install_gemfile! <<-G
       gem "c_extension", :git => #{lib_path("c_extension-1.0").to_s.dump}
     G
-
-    expect(out).not_to include("extconf.rb failed")
 
     run! "Bundler.require; puts CExtension.new.its_true"
     expect(out).to eq("true")

--- a/bundler/spec/install/gems/native_extensions_spec.rb
+++ b/bundler/spec/install/gems/native_extensions_spec.rb
@@ -81,6 +81,8 @@ RSpec.describe "installing a gem with native extensions", :ruby_repo do
       gem "c_extension", :git => #{lib_path("c_extension-1.0").to_s.dump}
     G
 
+    expect(err).to_not include("warning: conflicting chdir during another chdir block")
+
     run! "Bundler.require; puts CExtension.new.its_true"
     expect(out).to eq("true")
   end


### PR DESCRIPTION
Closes #2904.

## What was the end-user or developer problem that led to this PR?

When bundler installs a git gem with extensions, the following warning is printed:

```
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/site_ruby/2.7.0/rubygems/ext/builder.rb:175: warning: conflicting chdir during another chdir block
```

## What is your fix for the problem, implemented in this PR?

My fix is to remove the outermost directory change which turned out to be unnecessary.

I found this issue while reviewing #3475.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
