### PR TITLE
Do not pre-install Bundler for RubyGems and Bundler tests

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -16,6 +16,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler: none
       - name: Test bundler
         run: |
           bin/rake spec:parallel_deps

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -19,6 +19,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler: none
       - name: Install rubygems
         run: ruby -Ilib -S rake install
     timeout-minutes: 10

--- a/.github/workflows/jruby-bundler.yml
+++ b/.github/workflows/jruby-bundler.yml
@@ -20,6 +20,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: jruby-9.2.11.0
+          bundler: none
       - name: Prepare dependencies
         run: |
           bin/rake spec:parallel_deps

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -19,6 +19,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler: none
       - name: Install Dependencies
         run: rake setup
       - name: Run Test

--- a/.github/workflows/ubuntu-bundler.yml
+++ b/.github/workflows/ubuntu-bundler.yml
@@ -43,6 +43,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler: none
       - name: Prepare dependencies
         run: |
           sudo apt-get install graphviz -y

--- a/.github/workflows/ubuntu-bundler3.yml
+++ b/.github/workflows/ubuntu-bundler3.yml
@@ -22,6 +22,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler: none
       - name: Prepare dependencies
         run: |
           BUNDLER_SPEC_SUB_VERSION=3.0.0 bin/rake override_version

--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -16,6 +16,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.6.5
+          bundler: none
       - name: Install Dependencies
         run: rake setup
       - name: Run Lint

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -19,6 +19,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler: none
       - name: Run Test
         run: |
           rake setup

--- a/.github/workflows/windows-bundler.yml
+++ b/.github/workflows/windows-bundler.yml
@@ -21,6 +21,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler: none
       - name: Install dependencies
         run: |
           bin/rake spec:parallel_deps

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,6 +19,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler: none
       - name: Install Dependencies
         run: rake setup
         shell: bash


### PR DESCRIPTION
It looks like `rake setup` already installs Bundler, so there is no need for `ruby/setup-ruby` to also install Bundler.

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
