### PR TITLE
Fix incorrect `gem uninstall --all` message

### DIFF
--- a/lib/rubygems/commands/uninstall_command.rb
+++ b/lib/rubygems/commands/uninstall_command.rb
@@ -143,7 +143,7 @@ that is a dependency of an existing gem.  You can use the
       uninstall_gem spec.name
     end
 
-    alert "Uninstalled all gems in #{options[:install_dir]}"
+    alert "Uninstalled all gems in #{options[:install_dir] || Gem.dir}"
   end
 
   def uninstall_specific

--- a/test/rubygems/test_gem_commands_uninstall_command.rb
+++ b/test/rubygems/test_gem_commands_uninstall_command.rb
@@ -361,6 +361,7 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
     end
 
     assert_equal %w[default-1], Gem::Specification.all_names.sort
+    assert_equal "INFO:  Uninstalled all gems in #{@gemhome}", @ui.output.split("\n").last
   end
 
   def test_execute_outside_gem_home


### PR DESCRIPTION
# Description:

Currently `gem uninstall --all` shows the following incorrect message
after completion:

```
INFO:  Uninstalled all gems in
```

Now it shows something that actually makes sense like:

```
INFO:  Uninstalled all gems in /home/deivid/Code/rubygems/tmp/test_rubygems_6986/gemhome
```

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
