### PR TITLE
Improve gzip errors logging

### DIFF
--- a/lib/rubygems/util.rb
+++ b/lib/rubygems/util.rb
@@ -11,7 +11,13 @@ module Gem::Util
     require 'stringio'
     data = StringIO.new(data, 'r')
 
-    unzipped = Zlib::GzipReader.new(data).read
+    gzip_reader = begin
+                    Zlib::GzipReader.new(data)
+                  rescue Zlib::GzipFile::Error => e
+                    raise e.class, e.inspect, e.backtrace
+                  end
+
+    unzipped = gzip_reader.read
     unzipped.force_encoding Encoding::BINARY
     unzipped
   end


### PR DESCRIPTION
# Description:

By default, the `Zlib::GzipFile::Error` does not include the actual data that was not in gzip format that caused the error.

However, its `#inspect` method includes it.

I think this can be helpful to troubleshoot errors and give us more information to debug #3140, which we keep getting intermittently.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
