### PR TITLE
Windows Actions - export TMPDIR=$RUNNER_TEMP

### DIFF
--- a/.github/workflows/windows-bundler.yml
+++ b/.github/workflows/windows-bundler.yml
@@ -29,6 +29,7 @@ jobs:
         shell: bash
       - name: Run specs
         run: |
+          export TMPDIR=$RUNNER_TEMP
           bin/parallel_rspec spec
         working-directory: ./bundler
         shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,6 +25,7 @@ jobs:
         shell: bash
       - name: Run Test
         run: |
+          $env:TMPDIR = $env:RUNNER_TEMP
           ridk enable
           rake test
     timeout-minutes: 15


### PR DESCRIPTION
# Description:

1. Actions Windows CI currently uses VM's hosted on an 8 core system.  There is a hard drive (C:) and an SSD (D:).  ENV['TEMP'] & ENV["TMP'] both point to the hard drive.  From various Actions work/testing, the hard drive can be much slower than the SSD.

2. For legacy reasons, Windows supports what are referred to as 'long' and 'short' (8.3) file names.  ENV['TEMP'] & ENV["TMP'] use 'short' names.  Never having researched every possible method call in Ruby, I can't say for sure, but string comparisons could cause issues.

## What was the end-user or developer problem that led to this PR?

Odd issues with Windows Actions CI

## What is your fix for the problem, implemented in this PR?

For the 'temp path', I believe Ruby uses [ ENV['TMPDIR'], ENV["TEMP'], ENV["TMP'] ] to select the folder.  Set ENV['TMPDIR'] = ENV['RUNNER_TEMP'], which is a long file name on the SSD.
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).