### PR TITLE
Schedule all builds running against ruby-head

### DIFF
--- a/.github/workflows/daily-bundler.yml
+++ b/.github/workflows/daily-bundler.yml
@@ -1,15 +1,17 @@
-name: daily
+name: daily-bundler
 
 on:
   schedule:
     - cron: '0 0 * * *'
 
 jobs:
-  daily:
+  daily_bundler:
     runs-on: ubuntu-16.04
     strategy:
       matrix:
         ruby: [ ruby-head ]
+    env:
+      RGV: ..
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby
@@ -17,8 +19,13 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler: none
-      - name: Test rubygems
+      - name: Prepare dependencies
         run: |
-          rake setup
-          rake test
+          sudo apt-get install graphviz -y
+          bin/rake spec:parallel_deps
+        working-directory: ./bundler
+      - name: Run Test
+        run: |
+          bin/rake spec:all
+        working-directory: ./bundler
     timeout-minutes: 60

--- a/.github/workflows/ubuntu-bundler.yml
+++ b/.github/workflows/ubuntu-bundler.yml
@@ -53,19 +53,7 @@ jobs:
         working-directory: ./bundler
       - name: Run Test
         run: |
-          bin/parallel_rspec spec
-        working-directory: ./bundler
-        continue-on-error: ${{ matrix.ruby == 'head' }}
-      - name: Run Test with realworld
-        run: |
-          bin/rake spec:realworld
-        env:
-          BUNDLER_SPEC_PRE_RECORDED: 1
-        working-directory: ./bundler
-        continue-on-error: ${{ matrix.ruby == 'head' }}
-      - name: Run Test with sudo
-        run: |
-          bin/rake spec:sudo
+          bin/rake spec:all
         working-directory: ./bundler
         continue-on-error: ${{ matrix.ruby == 'head' }}
     timeout-minutes: 60

--- a/.github/workflows/ubuntu-bundler.yml
+++ b/.github/workflows/ubuntu-bundler.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ 2.3.8, 2.4.9, 2.5.7, 2.6.5, head ]
+        ruby: [ 2.3.8, 2.4.9, 2.5.7, 2.6.5 ]
         rgv: [ v2.5.2, v2.6.14, v2.7.10, v3.0.6, .. ]
         exclude:
           - ruby: 2.4.9
@@ -27,14 +27,6 @@ jobs:
             rgv: v2.6.14
           - ruby: 2.6.5
             rgv: v2.7.10
-          - ruby: head
-            rgv: v2.5.2
-          - ruby: head
-            rgv: v2.6.14
-          - ruby: head
-            rgv: v2.7.10
-          - ruby: head
-            rgv: v3.0.6
     env:
       RGV: ${{ matrix.rgv }}
     steps:
@@ -55,5 +47,4 @@ jobs:
         run: |
           bin/rake spec:all
         working-directory: ./bundler
-        continue-on-error: ${{ matrix.ruby == 'head' }}
     timeout-minutes: 60

--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -38,8 +38,18 @@ namespace :spec do
     Spec::Rubygems.install_parallel_test_deps
   end
 
+  desc "Run all specs"
+  task :all => %w[spec:regular spec:realworld spec:sudo]
+
+  desc "Run the regular spec suite"
+  task :regular do
+    sh("bin/parallel_rspec spec")
+  end
+
   desc "Run the real-world spec suite"
-  task :realworld => %w[set_realworld spec]
+  task :realworld do
+    sh("BUNDLER_SPEC_PRE_RECORDED=1 bin/rspec --tag realworld")
+  end
 
   namespace :realworld do
     desc "Re-record cassettes for the realworld specs"
@@ -50,12 +60,8 @@ namespace :spec do
     end
   end
 
-  task :set_realworld do
-    ENV["BUNDLER_REALWORLD_TESTS"] = "1"
-  end
-
   desc "Run the spec suite with the sudo tests"
-  task :sudo => %w[set_sudo] do
+  task :sudo do
     require "open3"
     output, status = Open3.capture2e("sudo", "cp", "/etc/sudoers", "tmp/old_sudoers")
     raise "Couldn't read sudoers file: #{output}" unless status.success?
@@ -66,15 +72,11 @@ namespace :spec do
 
       raise "Couldn't configure sudo correctly to preserve path" unless `ruby -v` == `sudo -E ruby -v`
 
-      sh("sudo -E bin/rspec")
+      sh("sudo -E bin/rspec --tag sudo")
     ensure
       system("sudo", "cp", "tmp/old_sudoers", "/etc/sudoers")
       system("sudo", "chown", "-R", ENV["USER"], "tmp")
     end
-  end
-
-  task :set_sudo do
-    ENV["BUNDLER_SUDO_TESTS"] = "1"
   end
 end
 

--- a/bundler/spec/support/filters.rb
+++ b/bundler/spec/support/filters.rb
@@ -21,17 +21,8 @@ class RequirementChecker < Proc
 end
 
 RSpec.configure do |config|
-  if ENV["BUNDLER_SUDO_TESTS"] && Spec::Sudo.present?
-    config.filter_run :sudo => true
-  else
-    config.filter_run_excluding :sudo => true
-  end
-
-  if ENV["BUNDLER_REALWORLD_TESTS"]
-    config.filter_run :realworld => true
-  else
-    config.filter_run_excluding :realworld => true
-  end
+  config.filter_run_excluding :sudo => true
+  config.filter_run_excluding :realworld => true
 
   git_version = Bundler::Source::Git::GitProxy.new(nil, nil, nil).version
 

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -8,11 +8,7 @@ module Spec
     def reset!
       Dir.glob("#{tmp}/{gems/*,*}", File::FNM_DOTMATCH).each do |dir|
         next if %w[base remote1 gems rubygems . ..].include?(File.basename(dir))
-        if ENV["BUNDLER_SUDO_TESTS"]
-          `sudo rm -rf "#{dir}"`
-        else
-          FileUtils.rm_rf(dir)
-        end
+        FileUtils.rm_rf(dir)
       end
       FileUtils.mkdir_p(home)
       FileUtils.mkdir_p(tmpdir)


### PR DESCRIPTION
# Description:

This should reduce the number of jobs that get run for every PR, which is very high right now.

It also makes bundler's CI setup consistent with rubygems, which already runs ruby-head builds on a scheduled basis.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
