### PR TITLE
Update test_realworld_default_gem to use rubygems project sources

### DIFF
--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -391,7 +391,8 @@ class TestGemRequire < Gem::TestCase
       require "json"
       puts Gem.loaded_specs["json"]
     RUBY
-    output = Gem::Util.popen(Gem.ruby, "-e", cmd).strip
+    rubygems_libdir = File.expand_path('../../../lib', __FILE__)
+    output = Gem::Util.popen(Gem.ruby, "-I#{rubygems_libdir}", "-e", cmd).strip
     refute_empty output
   end
 


### PR DESCRIPTION
# Description:

The current test uses `popen` and appears to load `rubygems` from the ruby implementation instead of the `rubygems` from the project directory under test.

<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

This was found while test spec failures for https://github.com/rubygems/rubygems/pull/2797.

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

The fix is to pass the `rubygems` project `lib` dir to the `popen` command to ensure correct files are loaded.
<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

______________



I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
