### PR TITLE
Fix spec file lists after repo move

### DIFF
--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -34,27 +34,19 @@ module Spec
     end
 
     def tracked_files
-      skip "not in git working directory" unless git_root_dir?
-
-      @tracked_files ||= ruby_core? ? `git ls-files -z -- lib/bundler lib/bundler.rb spec/bundler man/bundler*` : `git ls-files -z`
+      @tracked_files ||= sys_exec(ruby_core? ? "git ls-files -z -- lib/bundler lib/bundler.rb spec/bundler man/bundler*" : "git ls-files -z", :dir => root)
     end
 
     def shipped_files
-      skip "not in git working directory" unless git_root_dir?
-
-      @shipped_files ||= ruby_core? ? `git ls-files -z -- lib/bundler lib/bundler.rb man/bundler* libexec/bundle*` : `git ls-files -z -- lib man exe CHANGELOG.md LICENSE.md README.md bundler.gemspec`
+      @shipped_files ||= sys_exec(ruby_core? ? "git ls-files -z -- lib/bundler lib/bundler.rb man/bundler* libexec/bundle*" : "git ls-files -z -- lib man exe CHANGELOG.md LICENSE.md README.md bundler.gemspec", :dir => root)
     end
 
     def lib_tracked_files
-      skip "not in git working directory" unless git_root_dir?
-
-      @lib_tracked_files ||= ruby_core? ? sys_exec("git ls-files -z -- lib/bundler lib/bundler.rb", :dir => root) : sys_exec("git ls-files -z -- lib", :dir => root)
+      @lib_tracked_files ||= sys_exec(ruby_core? ? "git ls-files -z -- lib/bundler lib/bundler.rb" : "git ls-files -z -- lib", :dir => root)
     end
 
     def man_tracked_files
-      skip "not in git working directory" unless git_root_dir?
-
-      @man_tracked_files ||= sys_exec("git ls-files -z -- man", :dir => root)
+      @man_tracked_files ||= sys_exec(ruby_core? ? "git ls-files -z -- man/bundler*" : "git ls-files -z -- man", :dir => root)
     end
 
     def tmp(*path)
@@ -193,11 +185,5 @@ module Spec
     end
 
     extend self
-
-  private
-
-    def git_root_dir?
-      root.to_s == `git rev-parse --show-toplevel`.chomp
-    end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

After the repo move, a bunch of quality specs are being skipped because `git` is no longer running from the right place:

```
Pending: (Failures listed here are expected and do not affect your suite's status)

  1) The library itself has no malformed whitespace
     # not in git working directory
     # ./spec/quality_spec.rb:107

  2) The library itself has no estraneous quotes
     # not in git working directory
     # ./spec/quality_spec.rb:118

  3) The library itself does not include any leftover debugging or development mechanisms
     # not in git working directory
     # ./spec/quality_spec.rb:128

  4) The library itself does not include any unresolved merge conflicts
     # not in git working directory
     # ./spec/quality_spec.rb:138

  5) The library itself maintains language quality of the documentation
     # not in git working directory
     # ./spec/quality_spec.rb:148

  6) The library itself maintains language quality of sentences used in source code
     # not in git working directory
     # ./spec/quality_spec.rb:159

  7) The library itself documents all used settings
     # not in git working directory
     # ./spec/quality_spec.rb:170

  8) The library itself ships the correct set of files
     # not in git working directory
     # ./spec/quality_spec.rb:218

  9) The library itself does not contain any warnings
     # not in git working directory
     # ./spec/quality_spec.rb:226

  10) The library itself does not use require internally, but require_relative
     # not in git working directory
     # ./spec/quality_spec.rb:250


Finished in 12 minutes 7 seconds (files took 0.88445 seconds to load)
408 examples, 0 failures, 10 pending

...............................................................................................................................................................

Retried examples: 0
```


## What is your fix for the problem, implemented in this PR?

Since now bundler specs are no longer run from the git root, we need to change this helpers to actually run `git` from the proper place.
    
Since the helpers now run `git` from the actual bundler root, not for the PWD, we no longer need to skip anything for the ruby repo either.


# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
