### PR TITLE
chore: Add History.txt entry for 3.1.2

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,5 +1,24 @@
 # coding: UTF-8
 
+=== 3.1.2 / 2019-12-20
+
+Minor enhancements:
+
+* Restore non prompting `gem update --system` behavior. Pull request #3040
+  by David Rodríguez.
+* Show only release notes for new code installed. Pull request #3041 by
+  David Rodríguez.
+* Inform about installed `bundle` executable after `gem update --system`.
+  Pull request #3042 by David Rodríguez.
+* Use Bundler 2.1.2. Pull request #3043 by SHIBATA Hiroshi.
+
+Bug fixes:
+
+* Require `uri` in source.rb. Pull request #3034 by mihaibuzgau.
+* Fix `gem update --system --force`. Pull request #3035 by David
+  Rodríguez.
+* Move `require uri` to source_list. Pull request #3038 by mihaibuzgau.
+
 === 3.1.1 / 2019-12-16
 
 Bug fixes:


### PR DESCRIPTION
# Description:

This PR adds a changelog entry for an already-released version of RubyGems.

## What was the end-user or developer problem that led to this PR?

`History.txt` lacked 3.1.2 in it.

## What is your fix for the problem, implemented in this PR?

Add a new entry at the top, all information taken from [GitHub Releases](https://github.com/rubygems/rubygems/releases/tag/v3.1.2) and [the blog post](https://blog.rubygems.org/2019/12/20/3.1.2-released.html).

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
