### PR TITLE
Deprecate rubyforge_project attribute only during build time.

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -563,6 +563,7 @@ test/rubygems/sff/discover.rb
 test/rubygems/simple_gem.rb
 test/rubygems/specifications/bar-0.0.2.gemspec
 test/rubygems/specifications/foo-0.0.1-x86-mswin32.gemspec
+test/rubygems/specifications/rubyforge-0.0.1.gemspec
 test/rubygems/ssl_cert.pem
 test/rubygems/ssl_key.pem
 test/rubygems/test_bundled_ca.rb

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -6,6 +6,7 @@
 # See LICENSE.txt for permissions.
 #++
 
+require 'set'
 require 'rubygems/version'
 require 'rubygems/requirement'
 require 'rubygems/platform'
@@ -192,6 +193,12 @@ class Gem::Specification < Gem::BasicSpecification
   NOT_FOUND = Struct.new(:to_spec, :this).new # :nodoc:
   @@spec_with_requirable_file = {}
   @@active_stub_with_requirable_file = {}
+
+  # Tracking removed method calls to warn users during build time.
+  REMOVED_METHODS = [:rubyforge_project=].freeze # :nodoc:
+  def removed_method_calls
+    @removed_method_calls ||= Set.new
+  end
 
   ######################################################################
   # :section: Required gemspec attributes
@@ -726,13 +733,6 @@ class Gem::Specification < Gem::BasicSpecification
   # Allows deinstallation of gems with legacy platforms.
 
   attr_writer :original_platform # :nodoc:
-
-  ##
-  # Deprecated via specification policy and ignored during runtime.
-  #
-  # Formerly used to set rubyforge project.
-
-  attr_accessor :rubyforge_project
 
   ##
   # The Gem::Specification version of this gemspec.
@@ -2097,9 +2097,15 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   ##
+  # Track removed method calls to warn about during build time.
   # Warn about unknown attributes while loading a spec.
 
   def method_missing(sym, *a, &b) # :nodoc:
+    if REMOVED_METHODS.include?(sym)
+      removed_method_calls << sym
+      return
+    end
+
     if @specification_version > CURRENT_SPECIFICATION_VERSION and
       sym.to_s =~ /=$/
       warn "ignoring #{sym} loading #{full_name}" if $DEBUG

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -728,12 +728,11 @@ class Gem::Specification < Gem::BasicSpecification
   attr_writer :original_platform # :nodoc:
 
   ##
-  # Deprecated and ignored.
+  # Deprecated via specification policy and ignored during runtime.
   #
   # Formerly used to set rubyforge project.
 
-  attr_writer :rubyforge_project
-  rubygems_deprecate :rubyforge_project=
+  attr_accessor :rubyforge_project
 
   ##
   # The Gem::Specification version of this gemspec.

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -6,7 +6,6 @@
 # See LICENSE.txt for permissions.
 #++
 
-require 'set'
 require 'rubygems/version'
 require 'rubygems/requirement'
 require 'rubygems/platform'
@@ -197,7 +196,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Tracking removed method calls to warn users during build time.
   REMOVED_METHODS = [:rubyforge_project=].freeze # :nodoc:
   def removed_method_calls
-    @removed_method_calls ||= Set.new
+    @removed_method_calls ||= []
   end
 
   ######################################################################

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -21,6 +21,8 @@ class Gem::SpecificationPolicy
     funding_uri
   ].freeze # :nodoc:
 
+  DEPRECATED_ATTRIBUTES = [:rubyforge_project].freeze #:nodoc:
+
   def initialize(specification)
     @warnings = 0
 
@@ -75,6 +77,8 @@ class Gem::SpecificationPolicy
     validate_values
 
     validate_dependencies
+
+    validate_deprecated_attributes
 
     if @warnings > 0
       if strict
@@ -407,6 +411,12 @@ http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard li
     return if File.read(executable_path, 2) == '#!'
 
     warning "#{executable_path} is missing #! line"
+  end
+
+  def validate_deprecated_attributes # :nodoc:
+    DEPRECATED_ATTRIBUTES.each do |attr|
+      warning("#{attr} is deprecated") unless @specification.send(attr).nil?
+    end
   end
 
   def warning(statement) # :nodoc:

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -21,8 +21,6 @@ class Gem::SpecificationPolicy
     funding_uri
   ].freeze # :nodoc:
 
-  DEPRECATED_ATTRIBUTES = [:rubyforge_project].freeze #:nodoc:
-
   def initialize(specification)
     @warnings = 0
 
@@ -78,7 +76,7 @@ class Gem::SpecificationPolicy
 
     validate_dependencies
 
-    validate_deprecated_attributes
+    validate_removed_attributes
 
     if @warnings > 0
       if strict
@@ -413,9 +411,9 @@ http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard li
     warning "#{executable_path} is missing #! line"
   end
 
-  def validate_deprecated_attributes # :nodoc:
-    DEPRECATED_ATTRIBUTES.each do |attr|
-      warning("#{attr} is deprecated") unless @specification.send(attr).nil?
+  def validate_removed_attributes # :nodoc:
+    @specification.removed_method_calls.each do |attr|
+      warning("#{attr} is deprecated and ignored. Please remove this from your gemspec to ensure that your gem continues to build in the future.")
     end
   end
 

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -112,6 +112,8 @@ class Gem::TestCase < Minitest::Test
 
   TEST_PATH = ENV.fetch('RUBYGEMS_TEST_PATH', File.expand_path('../../../test/rubygems', __FILE__))
 
+  SPECIFICATIONS = File.expand_path(File.join(TEST_PATH, "specifications"), __FILE__)
+
   def assert_activate(expected, *specs)
     specs.each do |spec|
       case spec

--- a/test/rubygems/specifications/rubyforge-0.0.1.gemspec
+++ b/test/rubygems/specifications/rubyforge-0.0.1.gemspec
@@ -1,0 +1,14 @@
+# -*- encoding: utf-8 -*-
+
+Gem::Specification.new do |s|
+  s.name              = "rubyforge"
+  s.version           = "0.0.1"
+  s.platform          = "ruby"
+  s.require_paths     = ["lib"]
+  s.summary           = "A very bar gem"
+  s.authors           = ["unknown"]
+  s.license           = 'MIT'
+  s.homepage          = 'http://example.com'
+  s.files             = ['README.md']
+  s.rubyforge_project = 'abc'
+end

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -127,6 +127,23 @@ class TestGemCommandsBuildCommand < Gem::TestCase
     util_test_build_gem @gem
   end
 
+  def test_execute_rubyforge_project_warning
+    rubyforge_gemspec = File.join SPECIFICATIONS, "rubyforge-0.0.1.gemspec"
+
+    @cmd.options[:args] = [rubyforge_gemspec]
+
+    use_ui @ui do
+      Dir.chdir @tempdir do
+        @cmd.execute
+      end
+    end
+
+    error = @ui.error.split("\n")
+    assert_equal "WARNING:  rubyforge_project= is deprecated and ignored. Please remove this from your gemspec to ensure that your gem continues to build in the future.", error.shift
+    assert_equal "WARNING:  See https://guides.rubygems.org/specification-reference/ for help", error.shift
+    assert_equal [], error
+  end
+
   def test_execute_strict_with_warnings
     bad_gem = util_spec 'some_bad_gem' do |s|
       s.files = ['README.md']

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3110,24 +3110,19 @@ http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
     warning
   end
 
-  def test_deprecated_attributes
-    assert_equal Gem::SpecificationPolicy::DEPRECATED_ATTRIBUTES, [:rubyforge_project]
+  def test_removed_methods
+    assert_equal Gem::Specification::REMOVED_METHODS, [:rubyforge_project=]
   end
 
-  def test_validate_deprecated_attributes
+  def test_validate_removed_rubyforge_project
     util_setup_validate
 
     use_ui @ui do
-      Gem::SpecificationPolicy::DEPRECATED_ATTRIBUTES.each do |attr|
-        @a1.send("#{attr}=", 'invalid-attribute')
-      end
-
+      @a1.rubyforge_project = 'invalid-attribute'
       @a1.validate
     end
 
-    Gem::SpecificationPolicy::DEPRECATED_ATTRIBUTES.each do |attr|
-      assert_match "#{attr} is deprecated", @ui.error
-    end
+    assert_match "rubyforge_project= is deprecated", @ui.error
   end
 
   def test_validate_license_values

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3110,6 +3110,26 @@ http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
     warning
   end
 
+  def test_deprecated_attributes
+    assert_equal Gem::SpecificationPolicy::DEPRECATED_ATTRIBUTES, [:rubyforge_project]
+  end
+
+  def test_validate_deprecated_attributes
+    util_setup_validate
+
+    use_ui @ui do
+      Gem::SpecificationPolicy::DEPRECATED_ATTRIBUTES.each do |attr|
+        @a1.send("#{attr}=", 'invalid-attribute')
+      end
+
+      @a1.validate
+    end
+
+    Gem::SpecificationPolicy::DEPRECATED_ATTRIBUTES.each do |attr|
+      assert_match "#{attr} is deprecated", @ui.error
+    end
+  end
+
   def test_validate_license_values
     util_setup_validate
 

--- a/test/rubygems/test_gem_stub_specification.rb
+++ b/test/rubygems/test_gem_stub_specification.rb
@@ -4,7 +4,6 @@ require "rubygems/stub_specification"
 
 class TestStubSpecification < Gem::TestCase
 
-  SPECIFICATIONS = File.expand_path(File.join("..", "specifications"), __FILE__)
   FOO = File.join SPECIFICATIONS, "foo-0.0.1-x86-mswin32.gemspec"
   BAR = File.join SPECIFICATIONS, "bar-0.0.2.gemspec"
 


### PR DESCRIPTION
:information_source: initial idea as discussed on Slack with @deivid-rodriguez