### PR TITLE
Skip flaky tests on jruby

### DIFF
--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -1051,6 +1051,8 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
   end
 
   def start_ssl_server(config = {})
+    skip "starting this test server fails randomly on jruby" if Gem.java_platform?
+
     null_logger = NilLog.new
     server = WEBrick::HTTPServer.new({
       :Port => 0,


### PR DESCRIPTION
# Description:

This is a temporary workaround for https://github.com/rubygems/rubygems/issues/3451.

It seems most likely a problem in either jruby or webrick, so until fixed upstream let's skip it so that it doesn't get in the middle.

Related upstream tickets:

https://github.com/ruby/webrick/pull/40
https://github.com/jruby/jruby/issues/6171

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
