### PR TITLE
Indicate a gem which has been deleted on `bundle info`

### DIFF
--- a/bundler/lib/bundler/cli/info.rb
+++ b/bundler/lib/bundler/cli/info.rb
@@ -40,10 +40,13 @@ module Bundler
     end
 
     def print_gem_path(spec)
-      path = if spec.name == "bundler"
-        File.expand_path("../../../..", __FILE__)
+      if spec.name == "bundler"
+        path = File.expand_path("../../../..", __FILE__)
       else
-        spec.full_gem_path
+        path = spec.full_gem_path
+        unless File.directory?(path)
+          return Bundler.ui.warn "The gem #{gem_name} has been deleted. It was installed at: #{path}"
+        end
       end
 
       Bundler.ui.info path

--- a/bundler/spec/commands/info_spec.rb
+++ b/bundler/spec/commands/info_spec.rb
@@ -41,6 +41,15 @@ RSpec.describe "bundle info" do
       expect(err).to eq("Could not find gem 'missing'.")
     end
 
+    it "warns if path no longer exists on disk" do
+      FileUtils.rm_rf(default_bundle_path("gems", "rails-2.3.2"))
+
+      bundle "info rails --path"
+
+      expect(err).to match(/has been deleted/i)
+      expect(err).to match(default_bundle_path("gems", "rails-2.3.2").to_s)
+    end
+
     context "given a default gem shippped in ruby", :ruby_repo do
       it "prints information about the default gem" do
         bundle! "info rdoc"


### PR DESCRIPTION
# Description:

`bundle info` does not indicate a gem which has been deleted, unlike `bundle show`

Fixes #3493.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
