### PR TITLE
CmakeLists.txt eruby annotation

### DIFF
--- a/lib/rubygems/ext/cmake_builder.rb
+++ b/lib/rubygems/ext/cmake_builder.rb
@@ -1,11 +1,24 @@
 # frozen_string_literal: true
 require 'rubygems/command'
+require 'erb'
 
 class Gem::Ext::CmakeBuilder < Gem::Ext::Builder
 
+  def self.generate(erb_path)
+    tpl = File.read erb_path
+    erb = ERB.new tpl
+    erb.result binding
+  end
+
   def self.build(extension, dest_path, results, args=[], lib_dir=nil)
+    if !File.exist?('CMakeLists.txt') && File.exist?('CMakeLists.txt.erb')
+      File.open('CMakeLists.txt', 'w') { |f| f.write generate('CMakeLists.txt.erb') }
+    end
+
     unless File.exist?('Makefile')
       cmd = +"cmake . -DCMAKE_INSTALL_PREFIX=#{dest_path}"
+      cmd << " -G \"NMake Makefiles\"" if /mswin/ =~ RUBY_PLATFORM
+      cmd << " -DCMAKE_BUILD_TYPE=Release" unless /\-DCMAKE_BUILD_TYPE/ =~ Gem::Command.build_args.join
       cmd << " #{Gem::Command.build_args.join ' '}" unless Gem::Command.build_args.empty?
 
       run cmd, results

--- a/lib/rubygems/ext/cmake_builder.rb
+++ b/lib/rubygems/ext/cmake_builder.rb
@@ -5,7 +5,7 @@ class Gem::Ext::CmakeBuilder < Gem::Ext::Builder
 
   def self.build(extension, dest_path, results, args=[], lib_dir=nil)
     unless File.exist?('Makefile')
-      cmd = "cmake . -DCMAKE_INSTALL_PREFIX=#{dest_path}"
+      cmd = +"cmake . -DCMAKE_INSTALL_PREFIX=#{dest_path}"
       cmd << " #{Gem::Command.build_args.join ' '}" unless Gem::Command.build_args.empty?
 
       run cmd, results


### PR DESCRIPTION
Currently, CMakeLists.txt can be specified in the spec file instead of extconf.rb.
However, unlike extconf.rb, the method of reflecting the information of the Ruby interpreter was unknown.

With this change, the information of the Ruby interpreter can be reflected using eRuby.
eg: s.extensions = %w[ext/CMakeLists.txt.erb]
