### PR TITLE
No chdir on git operations

### DIFF
--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -169,7 +169,7 @@ module Bundler
           end
         end
 
-        def git(command, check_errors = true, error_msg = nil)
+        def git(command, check_errors = true)
           command_with_no_credentials = URICredentialsFilter.credential_filtered_string(command, uri)
           raise GitNotAllowedError.new(command_with_no_credentials) unless allow?
 
@@ -178,7 +178,7 @@ module Bundler
           end
 
           stdout_with_no_credentials = URICredentialsFilter.credential_filtered_string(out, uri)
-          raise GitCommandError.new(command_with_no_credentials, path, error_msg) if check_errors && !status.success?
+          raise GitCommandError.new(command_with_no_credentials, path) if check_errors && !status.success?
           stdout_with_no_credentials
         end
 

--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -67,13 +67,13 @@ module Bundler
 
         def branch
           @branch ||= allowed_in_path do
-            git("rev-parse --abbrev-ref HEAD").strip
+            git("rev-parse --abbrev-ref HEAD", :dir => path).strip
           end
         end
 
         def contains?(commit)
           allowed_in_path do
-            result, status = git_null("branch --contains #{commit}")
+            result, status = git_null("branch --contains #{commit}", :dir => path)
             status.success? && result =~ /^\* (.*)$/
           end
         end
@@ -101,7 +101,7 @@ module Bundler
           end
 
           in_path do
-            git_retry %(fetch --force --quiet --tags #{uri_escaped_with_configured_credentials} "refs/heads/*:refs/heads/*" #{extra_ref})
+            git_retry %(fetch --force --quiet --tags #{uri_escaped_with_configured_credentials} "refs/heads/*:refs/heads/*" #{extra_ref}), :dir => path
           end
         end
 
@@ -125,58 +125,56 @@ module Bundler
             end
           end
           # method 2
-          SharedHelpers.chdir(destination) do
-            git_retry %(fetch --force --quiet --tags "#{path}")
+          git_retry %(fetch --force --quiet --tags "#{path}"), :dir => destination
 
-            begin
-              git "reset --hard #{@revision}"
-            rescue GitCommandError => e
-              raise MissingGitRevisionError.new(e.command, path, destination, @revision, URICredentialsFilter.credential_filtered_uri(uri))
-            end
+          begin
+            git "reset --hard #{@revision}", :dir => destination
+          rescue GitCommandError => e
+            raise MissingGitRevisionError.new(e.command, path, destination, @revision, URICredentialsFilter.credential_filtered_uri(uri))
+          end
 
-            if submodules
-              git_retry "submodule update --init --recursive"
-            elsif Gem::Version.create(version) >= Gem::Version.create("2.9.0")
-              git_retry "submodule deinit --all --force"
-            end
+          if submodules
+            git_retry "submodule update --init --recursive", :dir => destination
+          elsif Gem::Version.create(version) >= Gem::Version.create("2.9.0")
+            git_retry "submodule deinit --all --force", :dir => destination
           end
         end
 
       private
 
-        def git_null(command)
+        def git_null(command, dir: SharedHelpers.pwd)
           command_with_no_credentials = URICredentialsFilter.credential_filtered_string(command, uri)
           raise GitNotAllowedError.new(command_with_no_credentials) unless allow?
 
           out, status = SharedHelpers.with_clean_git_env do
-            capture_and_ignore_stderr("git #{command}")
+            capture_and_ignore_stderr("git #{command}", :chdir => dir.to_s)
           end
 
           [URICredentialsFilter.credential_filtered_string(out, uri), status]
         end
 
-        def git_retry(command)
+        def git_retry(command, dir: SharedHelpers.pwd)
           Bundler::Retry.new("`git #{URICredentialsFilter.credential_filtered_string(command, uri)}`", GitNotAllowedError).attempts do
-            git(command)
+            git(command, :dir => dir)
           end
         end
 
-        def git(command)
+        def git(command, dir: SharedHelpers.pwd)
           command_with_no_credentials = URICredentialsFilter.credential_filtered_string(command, uri)
           raise GitNotAllowedError.new(command_with_no_credentials) unless allow?
 
           out, status = SharedHelpers.with_clean_git_env do
-            capture_and_filter_stderr(uri, "git #{command}")
+            capture_and_filter_stderr(uri, "git #{command}", :chdir => dir.to_s)
           end
 
           stdout_with_no_credentials = URICredentialsFilter.credential_filtered_string(out, uri)
-          raise GitCommandError.new(command_with_no_credentials, path, SharedHelpers.pwd) unless status.success?
+          raise GitCommandError.new(command_with_no_credentials, path, dir) unless status.success?
           stdout_with_no_credentials
         end
 
         def has_revision_cached?
           return unless @revision
-          in_path { git("cat-file -e #{@revision}") }
+          in_path { git("cat-file -e #{@revision}", :dir => path) }
           true
         rescue GitError
           false
@@ -188,7 +186,7 @@ module Bundler
 
         def find_local_revision
           allowed_in_path do
-            git("rev-parse --verify #{Shellwords.shellescape(ref)}").strip
+            git("rev-parse --verify #{Shellwords.shellescape(ref)}", :dir => path).strip
           end
         rescue GitCommandError => e
           raise MissingGitRevisionError.new(e.command, path, path, ref, URICredentialsFilter.credential_filtered_uri(uri))
@@ -226,8 +224,7 @@ module Bundler
 
         def in_path(&blk)
           checkout unless path.exist?
-          _ = URICredentialsFilter # load it before we chdir
-          SharedHelpers.chdir(path, &blk)
+          blk.call
         end
 
         def allowed_in_path
@@ -235,16 +232,16 @@ module Bundler
           raise GitError, "The git source #{uri} is not yet checked out. Please run `bundle install` before trying to start your application"
         end
 
-        def capture_and_filter_stderr(uri, cmd)
+        def capture_and_filter_stderr(uri, cmd, chdir: SharedHelpers.pwd)
           require "open3"
-          return_value, captured_err, status = Open3.capture3(cmd)
+          return_value, captured_err, status = Open3.capture3(cmd, :chdir => chdir)
           Bundler.ui.warn URICredentialsFilter.credential_filtered_string(captured_err, uri) if uri && !captured_err.empty?
           [return_value, status]
         end
 
-        def capture_and_ignore_stderr(cmd)
+        def capture_and_ignore_stderr(cmd, chdir: SharedHelpers.pwd)
           require "open3"
-          return_value, _, status = Open3.capture3(cmd)
+          return_value, _, status = Open3.capture3(cmd, :chdir => chdir)
           [return_value, status]
         end
       end

--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -62,15 +62,7 @@ module Bundler
         end
 
         def revision
-          return @revision if @revision
-
-          begin
-            @revision ||= find_local_revision
-          rescue GitCommandError => e
-            raise MissingGitRevisionError.new(e.command, path, ref, URICredentialsFilter.credential_filtered_uri(uri))
-          end
-
-          @revision
+          @revision ||= find_local_revision
         end
 
         def branch
@@ -198,6 +190,8 @@ module Bundler
           allowed_in_path do
             git("rev-parse --verify #{Shellwords.shellescape(ref)}").strip
           end
+        rescue GitCommandError => e
+          raise MissingGitRevisionError.new(e.command, path, ref, URICredentialsFilter.credential_filtered_uri(uri))
         end
 
         # Escape the URI for git commands

--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -169,7 +169,7 @@ module Bundler
           end
         end
 
-        def git(command, check_errors = true)
+        def git(command)
           command_with_no_credentials = URICredentialsFilter.credential_filtered_string(command, uri)
           raise GitNotAllowedError.new(command_with_no_credentials) unless allow?
 
@@ -178,7 +178,7 @@ module Bundler
           end
 
           stdout_with_no_credentials = URICredentialsFilter.credential_filtered_string(out, uri)
-          raise GitCommandError.new(command_with_no_credentials, path) if check_errors && !status.success?
+          raise GitCommandError.new(command_with_no_credentials, path) unless status.success?
           stdout_with_no_credentials
         end
 
@@ -196,7 +196,7 @@ module Bundler
 
         def find_local_revision
           allowed_in_path do
-            git("rev-parse --verify #{Shellwords.shellescape(ref)}", true).strip
+            git("rev-parse --verify #{Shellwords.shellescape(ref)}").strip
           end
         end
 

--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -27,13 +27,13 @@ module Bundler
       class GitCommandError < GitError
         attr_reader :command
 
-        def initialize(command, path = nil, extra_info = nil)
+        def initialize(command, path, extra_info = nil)
           @command = command
 
           msg = String.new
           msg << "Git error: command `git #{command}` in directory #{SharedHelpers.pwd} has failed."
           msg << "\n#{extra_info}" if extra_info
-          msg << "\nIf this error persists you could try removing the cache directory '#{path}'" if path && path.exist?
+          msg << "\nIf this error persists you could try removing the cache directory '#{path}'" if path.exist?
           super msg
         end
       end

--- a/bundler/spec/bundler/source/git/git_proxy_spec.rb
+++ b/bundler/spec/bundler/source/git/git_proxy_spec.rb
@@ -133,8 +133,8 @@ RSpec.describe Bundler::Source::Git::GitProxy do
 
       it "fails gracefully when resetting to the revision fails" do
         expect(subject).to receive(:git_retry).with(start_with("clone ")) { destination.mkpath }
-        expect(subject).to receive(:git_retry).with(start_with("fetch "))
-        expect(subject).to receive(:git).with(command).and_raise(Bundler::Source::Git::GitCommandError.new(command, cache, destination))
+        expect(subject).to receive(:git_retry).with(start_with("fetch "), :dir => destination)
+        expect(subject).to receive(:git).with(command, :dir => destination).and_raise(Bundler::Source::Git::GitCommandError.new(command, cache, destination))
         expect(subject).not_to receive(:git)
 
         expect { subject.copy_to(destination, submodules) }.

--- a/bundler/spec/bundler/source/git/git_proxy_spec.rb
+++ b/bundler/spec/bundler/source/git/git_proxy_spec.rb
@@ -123,6 +123,7 @@ RSpec.describe Bundler::Source::Git::GitProxy do
   end
 
   describe "#copy_to" do
+    let(:cache) { tmpdir("cache_path") }
     let(:destination) { tmpdir("copy_to_path") }
     let(:submodules) { false }
 
@@ -133,7 +134,7 @@ RSpec.describe Bundler::Source::Git::GitProxy do
       it "fails gracefully when resetting to the revision fails" do
         expect(subject).to receive(:git_retry).with(start_with("clone ")) { destination.mkpath }
         expect(subject).to receive(:git_retry).with(start_with("fetch "))
-        expect(subject).to receive(:git).with(command).and_raise(Bundler::Source::Git::GitCommandError, command)
+        expect(subject).to receive(:git).with(command).and_raise(Bundler::Source::Git::GitCommandError.new(command, cache))
         expect(subject).not_to receive(:git)
 
         expect { subject.copy_to(destination, submodules) }.

--- a/bundler/spec/bundler/source/git/git_proxy_spec.rb
+++ b/bundler/spec/bundler/source/git/git_proxy_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe Bundler::Source::Git::GitProxy do
       it "fails gracefully when resetting to the revision fails" do
         expect(subject).to receive(:git_retry).with(start_with("clone ")) { destination.mkpath }
         expect(subject).to receive(:git_retry).with(start_with("fetch "))
-        expect(subject).to receive(:git).with(command).and_raise(Bundler::Source::Git::GitCommandError.new(command, cache))
+        expect(subject).to receive(:git).with(command).and_raise(Bundler::Source::Git::GitCommandError.new(command, cache, destination))
         expect(subject).not_to receive(:git)
 
         expect { subject.copy_to(destination, submodules) }.


### PR DESCRIPTION
# Description:

While working on #3397, I was getting a lot of thread safety issues in tests that perform git operations. Bundler is supposed to reuse the mutex rubygems uses for building extensions that need to change folders for compilation in a thread safe manner. I couldn't stop the issue, but something in there seems not thread safe.

My solution, since I'm bad at spotting thread safety issues, is to fix the root cause instead and not change the CWD when performing `git` operations.

With these changes, I managed to get a Windows passing CI for bundler under ruby 2.7.

I'm extracting the change here though to make the change more focused and explain it.

This PR also includes some refactoring I made in the `GitProxy` class to be able to remove the dependency on the CWD. 

This PR should also close https://github.com/rubygems/rubygems/issues/3448.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
