### PR TITLE
Improve specs debugability

### DIFF
--- a/bundler/spec/commands/add_spec.rb
+++ b/bundler/spec/commands/add_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "bundle add" do
 
     build_git "foo", "2.0"
 
-    install_gemfile <<-G
+    install_gemfile! <<-G
       source "#{file_uri_for(gem_repo2)}"
       gem "weakling", "~> 0.0.1"
     G
@@ -200,7 +200,7 @@ RSpec.describe "bundle add" do
 
   describe "when a gem is added which is already specified in Gemfile with version" do
     it "shows an error when added with different version requirement" do
-      install_gemfile <<-G
+      install_gemfile! <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "rack", "1.0"
       G
@@ -212,7 +212,7 @@ RSpec.describe "bundle add" do
     end
 
     it "shows error when added without version requirements" do
-      install_gemfile <<-G
+      install_gemfile! <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "rack", "1.0"
       G
@@ -227,7 +227,7 @@ RSpec.describe "bundle add" do
 
   describe "when a gem is added which is already specified in Gemfile without version" do
     it "shows an error when added with different version requirement" do
-      install_gemfile <<-G
+      install_gemfile! <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "rack"
       G

--- a/bundler/spec/commands/info_spec.rb
+++ b/bundler/spec/commands/info_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "bundle info" do
   context "with a standard Gemfile" do
     before do
-      install_gemfile <<-G
+      install_gemfile! <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rails"
         gem "has_metadata"
@@ -87,7 +87,7 @@ RSpec.describe "bundle info" do
     end
 
     it "prints out git info" do
-      install_gemfile <<-G
+      install_gemfile! <<-G
         gem "foo", :git => "#{lib_path("foo-1.0")}"
       G
       expect(the_bundle).to include_gems "foo 1.0"
@@ -102,7 +102,7 @@ RSpec.describe "bundle info" do
       end
       @revision = revision_for(lib_path("foo-1.0"))[0...6]
 
-      install_gemfile <<-G
+      install_gemfile! <<-G
         gem "foo", :git => "#{lib_path("foo-1.0")}", :branch => "omg"
       G
       expect(the_bundle).to include_gems "foo 1.0.omg"
@@ -113,7 +113,7 @@ RSpec.describe "bundle info" do
 
     it "doesn't print the branch when tied to a ref" do
       sha = revision_for(lib_path("foo-1.0"))
-      install_gemfile <<-G
+      install_gemfile! <<-G
         gem "foo", :git => "#{lib_path("foo-1.0")}", :ref => "#{sha}"
       G
 
@@ -123,7 +123,7 @@ RSpec.describe "bundle info" do
 
     it "handles when a version is a '-' prerelease" do
       @git = build_git("foo", "1.0.0-beta.1", :path => lib_path("foo"))
-      install_gemfile <<-G
+      install_gemfile! <<-G
         gem "foo", "1.0.0-beta.1", :git => "#{lib_path("foo")}"
       G
       expect(the_bundle).to include_gems "foo 1.0.0.pre.beta.1"
@@ -135,7 +135,7 @@ RSpec.describe "bundle info" do
 
   context "with a valid regexp for gem name" do
     it "presents alternatives", :readline do
-      install_gemfile <<-G
+      install_gemfile! <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
         gem "rack-obama"
@@ -148,7 +148,7 @@ RSpec.describe "bundle info" do
 
   context "with an invalid regexp for gem name" do
     it "does not find the gem" do
-      install_gemfile <<-G
+      install_gemfile! <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rails"
       G

--- a/bundler/spec/commands/show_spec.rb
+++ b/bundler/spec/commands/show_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "bundle show", :bundler => "< 3" do
   context "with a standard Gemfile" do
     before :each do
-      install_gemfile <<-G
+      install_gemfile! <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rails"
       G
@@ -94,7 +94,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
     end
 
     it "prints out git info" do
-      install_gemfile <<-G
+      install_gemfile! <<-G
         gem "foo", :git => "#{lib_path("foo-1.0")}"
       G
       expect(the_bundle).to include_gems "foo 1.0"
@@ -109,7 +109,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
       end
       @revision = revision_for(lib_path("foo-1.0"))[0...6]
 
-      install_gemfile <<-G
+      install_gemfile! <<-G
         gem "foo", :git => "#{lib_path("foo-1.0")}", :branch => "omg"
       G
       expect(the_bundle).to include_gems "foo 1.0.omg"
@@ -120,7 +120,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
 
     it "doesn't print the branch when tied to a ref" do
       sha = revision_for(lib_path("foo-1.0"))
-      install_gemfile <<-G
+      install_gemfile! <<-G
         gem "foo", :git => "#{lib_path("foo-1.0")}", :ref => "#{sha}"
       G
 
@@ -130,7 +130,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
 
     it "handles when a version is a '-' prerelease" do
       @git = build_git("foo", "1.0.0-beta.1", :path => lib_path("foo"))
-      install_gemfile <<-G
+      install_gemfile! <<-G
         gem "foo", "1.0.0-beta.1", :git => "#{lib_path("foo")}"
       G
       expect(the_bundle).to include_gems "foo 1.0.0.pre.beta.1"
@@ -166,7 +166,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
 
   context "with a valid regexp for gem name" do
     it "presents alternatives", :readline do
-      install_gemfile <<-G
+      install_gemfile! <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
         gem "rack-obama"
@@ -179,7 +179,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
 
   context "with an invalid regexp for gem name" do
     it "does not find the gem" do
-      install_gemfile <<-G
+      install_gemfile! <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rails"
       G

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -1310,9 +1310,10 @@ In Gemfile:
         puts FOO
       R
 
+      installed_time = out
+
       update_git("foo", :branch => "branch2")
 
-      installed_time = out
       expect(installed_time).to match(/\A\d+\.\d+\z/)
 
       install_gemfile <<-G

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -694,7 +694,7 @@ module Spec
           raise "You can't specify `master` as the branch" if branch == "master"
           escaped_branch = Shellwords.shellescape(branch)
 
-          if capture("git branch | grep #{escaped_branch}", libpath).empty?
+          if capture("git branch -l #{escaped_branch}", libpath).empty?
             capture("git branch #{escaped_branch}", libpath)
           end
 

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -729,9 +729,7 @@ module Spec
     private
 
       def git(cmd)
-        Bundler::SharedHelpers.with_clean_git_env do
-          Open3.capture2e("git #{cmd}", :chdir => path)[0].strip
-        end
+        Open3.capture2e("git #{cmd}", :chdir => path)[0].strip
       end
     end
 

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -668,10 +668,10 @@ module Spec
         super(options.merge(:path => path, :source => source))
         capture("git init", path)
         capture("git add *", path)
-        capture("git config user.email \"lol@wut.com\"", path)
-        capture("git config user.name \"lolwut\"", path)
+        capture("git config user.email lol@wut.com", path)
+        capture("git config user.name lolwut", path)
         capture("git config commit.gpgsign false", path)
-        capture("git commit -m \"OMG INITIAL COMMIT\"", path)
+        capture("git commit -m OMG_INITIAL_COMMIT", path)
       end
     end
 
@@ -719,7 +719,7 @@ module Spec
         end
         super(options.merge(:path => libpath, :gemspec => update_gemspec, :source => source))
         capture("git add *", libpath)
-        capture("git commit -m \"BUMP\"", libpath)
+        capture("git commit -m BUMP", libpath)
       end
     end
 

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -436,13 +436,13 @@ module Spec
       opts = args.last.is_a?(Hash) ? args.last : {}
       builder = opts[:bare] ? GitBareBuilder : GitBuilder
       spec = build_with(builder, name, args, &block)
-      GitReader.new(opts[:path] || lib_path(spec.full_name))
+      GitReader.new(self, opts[:path] || lib_path(spec.full_name))
     end
 
     def update_git(name, *args, &block)
       opts = args.last.is_a?(Hash) ? args.last : {}
       spec = build_with(GitUpdater, name, args, &block)
-      GitReader.new(opts[:path] || lib_path(spec.full_name))
+      GitReader.new(self, opts[:path] || lib_path(spec.full_name))
     end
 
     def build_plugin(name, *args, &blk)
@@ -714,22 +714,17 @@ module Spec
     end
 
     class GitReader
-      attr_reader :path
+      attr_reader :context, :path
 
-      def initialize(path)
+      def initialize(context, path)
+        @context = context
         @path = path
       end
 
       def ref_for(ref, len = nil)
-        ref = git "rev-parse #{ref}"
+        ref = context.git "rev-parse #{ref}", path
         ref = ref[0..len] if len
         ref
-      end
-
-    private
-
-      def git(cmd)
-        Open3.capture2e("git #{cmd}", :chdir => path)[0].strip
       end
     end
 

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -683,36 +683,31 @@ module Spec
     end
 
     class GitUpdater < LibBuilder
-      def silently(str, dir)
-        output, _error, _status = Open3.capture3(str, :chdir => dir)
-        output
-      end
-
       def _build(options)
         libpath = options[:path] || _default_path
         update_gemspec = options[:gemspec] || false
         source = options[:source] || "git@#{libpath}"
 
-        silently "git checkout master", libpath
+        capture "git checkout master", libpath
 
         if branch = options[:branch]
           raise "You can't specify `master` as the branch" if branch == "master"
           escaped_branch = Shellwords.shellescape(branch)
 
           if capture("git branch | grep #{escaped_branch}", libpath).empty?
-            silently("git branch #{escaped_branch}", libpath)
+            capture("git branch #{escaped_branch}", libpath)
           end
 
-          silently("git checkout #{escaped_branch}", libpath)
+          capture("git checkout #{escaped_branch}", libpath)
         elsif tag = options[:tag]
           capture("git tag #{Shellwords.shellescape(tag)}", libpath)
         elsif options[:remote]
-          silently("git remote add origin #{options[:remote]}", libpath)
+          capture("git remote add origin #{options[:remote]}", libpath)
         elsif options[:push]
-          silently("git push origin #{options[:push]}", libpath)
+          capture("git push origin #{options[:push]}", libpath)
         end
 
-        current_ref = silently("git rev-parse HEAD", libpath).strip
+        current_ref = capture("git rev-parse HEAD", libpath).strip
         _default_files.keys.each do |path|
           _default_files[path] += "\n#{Builders.constantize(name)}_PREV_REF = '#{current_ref}'"
         end

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -551,8 +551,7 @@ module Spec
       end
 
       def capture(cmd, dir)
-        output, _status = Open3.capture2e(cmd, :chdir => dir)
-        output
+        @context.sys_exec(cmd, :dir => dir)
       end
 
       def method_missing(*args, &blk)

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -187,6 +187,10 @@ module Spec
       "#{Gem.ruby} -S #{ENV["GEM_PATH"]}/bin/rake"
     end
 
+    def git(cmd, path)
+      sys_exec("git #{cmd}", :dir => path)
+    end
+
     def sys_exec(cmd, options = {})
       env = options[:env] || {}
       dir = options[:dir] || bundled_app


### PR DESCRIPTION
# Description:

While working on #3397, I made several changes to improve the debugability of bundler specs. In particular:

* Fail earlier when a `bundle install` command fails, so that the culprit is more apparent.
* When building test git repos with git subcommands, make sure those commands are properly recorded and their results are logged in case of errors.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
