### PR TITLE
Make sure rubocop locks to the right version

### DIFF
--- a/util/rubocop
+++ b/util/rubocop
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+ENV["BUNDLE_GEMFILE"] = File.expand_path("../dev_gems.rb", __dir__)
 require "bundler/setup"
 
 load Gem.bin_path("rubocop", "rubocop")


### PR DESCRIPTION
# Description:

After installing the latest version of rubocop on my system, I noticed that our binstub would use the higher version instead of the one we're locked to.

This PR should fix that.
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
