### PR TITLE
Fix environment backup and restoring on Windows

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -34,9 +34,9 @@ require_relative "bundler/build_metadata"
 # of loaded and required modules.
 #
 module Bundler
-  environment_preserver = EnvironmentPreserver.new(ENV, EnvironmentPreserver::BUNDLER_KEYS)
+  environment_preserver = EnvironmentPreserver.from_env
   ORIGINAL_ENV = environment_preserver.restore
-  ENV.replace(environment_preserver.backup)
+  environment_preserver.replace_with_backup
   SUDO_MUTEX = Mutex.new
 
   autoload :Definition,             File.expand_path("bundler/definition", __dir__)

--- a/bundler/spec/runtime/with_unbundled_env_spec.rb
+++ b/bundler/spec/runtime/with_unbundled_env_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe "Bundler.with_env helpers" do
   describe "Bundler.original_system" do
     before do
       create_file("source.rb", <<-'RUBY')
-        Bundler.original_system(%([ "\$BUNDLE_FOO" = "bar" ] && exit 42))
+        Bundler.original_system("ruby", "-e", "exit(42) if ENV['BUNDLE_FOO'] == 'bar'")
 
         exit $?.exitstatus
       RUBY
@@ -178,7 +178,7 @@ RSpec.describe "Bundler.with_env helpers" do
   describe "Bundler.clean_system", :bundler => 2 do
     before do
       create_file("source.rb", <<-'RUBY')
-        Bundler.ui.silence { Bundler.clean_system(%([ "\$BUNDLE_FOO" = "bar" ] || exit 42)) }
+        Bundler.ui.silence { Bundler.clean_system("ruby", "-e", "exit(42) unless ENV['BUNDLE_FOO'] == 'bar'") }
 
         exit $?.exitstatus
       RUBY
@@ -193,7 +193,7 @@ RSpec.describe "Bundler.with_env helpers" do
   describe "Bundler.unbundled_system" do
     before do
       create_file("source.rb", <<-'RUBY')
-        Bundler.unbundled_system(%([ "\$BUNDLE_FOO" = "bar" ] || exit 42))
+        Bundler.unbundled_system("ruby", "-e", "exit(42) unless ENV['BUNDLE_FOO'] == 'bar'")
 
         exit $?.exitstatus
       RUBY

--- a/bundler/spec/runtime/with_unbundled_env_spec.rb
+++ b/bundler/spec/runtime/with_unbundled_env_spec.rb
@@ -161,8 +161,8 @@ RSpec.describe "Bundler.with_env helpers" do
   end
 
   describe "Bundler.original_system" do
-    let(:code) do
-      <<~RUBY
+    before do
+      create_file("source.rb", <<-'RUBY')
         Bundler.original_system(%([ "\$BUNDLE_FOO" = "bar" ] && exit 42))
 
         exit $?.exitstatus
@@ -170,16 +170,14 @@ RSpec.describe "Bundler.with_env helpers" do
     end
 
     it "runs system inside with_original_env" do
-      skip "obscure error" if Gem.win_platform?
-
-      system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib_dir} -rbundler -e '#{code}'")
+      system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib_dir} -rbundler #{bundled_app("source.rb")}")
       expect($?.exitstatus).to eq(42)
     end
   end
 
   describe "Bundler.clean_system", :bundler => 2 do
-    let(:code) do
-      <<~RUBY
+    before do
+      create_file("source.rb", <<-'RUBY')
         Bundler.ui.silence { Bundler.clean_system(%([ "\$BUNDLE_FOO" = "bar" ] || exit 42)) }
 
         exit $?.exitstatus
@@ -187,16 +185,14 @@ RSpec.describe "Bundler.with_env helpers" do
     end
 
     it "runs system inside with_clean_env" do
-      skip "obscure error" if Gem.win_platform?
-
-      system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib_dir} -rbundler -e '#{code}'")
+      system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib_dir} -rbundler #{bundled_app("source.rb")}")
       expect($?.exitstatus).to eq(42)
     end
   end
 
   describe "Bundler.unbundled_system" do
-    let(:code) do
-      <<~RUBY
+    before do
+      create_file("source.rb", <<-'RUBY')
         Bundler.unbundled_system(%([ "\$BUNDLE_FOO" = "bar" ] || exit 42))
 
         exit $?.exitstatus
@@ -204,14 +200,14 @@ RSpec.describe "Bundler.with_env helpers" do
     end
 
     it "runs system inside with_unbundled_env" do
-      system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib_dir} -rbundler -e '#{code}'")
+      system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib_dir} -rbundler #{bundled_app("source.rb")}")
       expect($?.exitstatus).to eq(42)
     end
   end
 
   describe "Bundler.original_exec" do
-    let(:code) do
-      <<~RUBY
+    before do
+      create_file("source.rb", <<-'RUBY')
         Process.fork do
           exit Bundler.original_exec(%(test "\$BUNDLE_FOO" = "bar"))
         end
@@ -225,14 +221,14 @@ RSpec.describe "Bundler.with_env helpers" do
     it "runs exec inside with_original_env" do
       skip "Fork not implemented" if Gem.win_platform?
 
-      system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib_dir} -rbundler -e '#{code}'")
+      system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib_dir} -rbundler #{bundled_app("source.rb")}")
       expect($?.exitstatus).to eq(0)
     end
   end
 
   describe "Bundler.clean_exec", :bundler => 2 do
-    let(:code) do
-      <<~RUBY
+    before do
+      create_file("source.rb", <<-'RUBY')
         Process.fork do
           exit Bundler.ui.silence { Bundler.clean_exec(%(test "\$BUNDLE_FOO" = "bar")) }
         end
@@ -246,14 +242,14 @@ RSpec.describe "Bundler.with_env helpers" do
     it "runs exec inside with_clean_env" do
       skip "Fork not implemented" if Gem.win_platform?
 
-      system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib_dir} -rbundler -e '#{code}'")
+      system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib_dir} -rbundler #{bundled_app("source.rb")}")
       expect($?.exitstatus).to eq(1)
     end
   end
 
   describe "Bundler.unbundled_exec" do
-    let(:code) do
-      <<~RUBY
+    before do
+      create_file("source.rb", <<-'RUBY')
         Process.fork do
           exit Bundler.unbundled_exec(%(test "\$BUNDLE_FOO" = "bar"))
         end
@@ -267,7 +263,7 @@ RSpec.describe "Bundler.with_env helpers" do
     it "runs exec inside with_clean_env" do
       skip "Fork not implemented" if Gem.win_platform?
 
-      system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib_dir} -rbundler -e '#{code}'")
+      system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib_dir} -rbundler #{bundled_app("source.rb")}")
       expect($?.exitstatus).to eq(1)
     end
   end

--- a/bundler/spec/runtime/with_unbundled_env_spec.rb
+++ b/bundler/spec/runtime/with_unbundled_env_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe "Bundler.with_env helpers" do
     bundle "install", options
   end
 
+  def run_bundler_script(env, script)
+    system(env, "ruby -I#{lib_dir} -rbundler #{script}")
+  end
+
   describe "Bundler.original_env" do
     it "should return the PATH present before bundle was activated" do
       code = "print Bundler.original_env['PATH']"
@@ -170,7 +174,7 @@ RSpec.describe "Bundler.with_env helpers" do
     end
 
     it "runs system inside with_original_env" do
-      system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib_dir} -rbundler #{bundled_app("source.rb")}")
+      run_bundler_script({ "BUNDLE_FOO" => "bar" }, bundled_app("source.rb"))
       expect($?.exitstatus).to eq(42)
     end
   end
@@ -185,7 +189,7 @@ RSpec.describe "Bundler.with_env helpers" do
     end
 
     it "runs system inside with_clean_env" do
-      system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib_dir} -rbundler #{bundled_app("source.rb")}")
+      run_bundler_script({ "BUNDLE_FOO" => "bar" }, bundled_app("source.rb"))
       expect($?.exitstatus).to eq(42)
     end
   end
@@ -200,7 +204,7 @@ RSpec.describe "Bundler.with_env helpers" do
     end
 
     it "runs system inside with_unbundled_env" do
-      system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib_dir} -rbundler #{bundled_app("source.rb")}")
+      run_bundler_script({ "BUNDLE_FOO" => "bar" }, bundled_app("source.rb"))
       expect($?.exitstatus).to eq(42)
     end
   end
@@ -221,7 +225,7 @@ RSpec.describe "Bundler.with_env helpers" do
     it "runs exec inside with_original_env" do
       skip "Fork not implemented" if Gem.win_platform?
 
-      system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib_dir} -rbundler #{bundled_app("source.rb")}")
+      run_bundler_script({ "BUNDLE_FOO" => "bar" }, bundled_app("source.rb"))
       expect($?.exitstatus).to eq(0)
     end
   end
@@ -242,7 +246,7 @@ RSpec.describe "Bundler.with_env helpers" do
     it "runs exec inside with_clean_env" do
       skip "Fork not implemented" if Gem.win_platform?
 
-      system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib_dir} -rbundler #{bundled_app("source.rb")}")
+      run_bundler_script({ "BUNDLE_FOO" => "bar" }, bundled_app("source.rb"))
       expect($?.exitstatus).to eq(1)
     end
   end
@@ -263,7 +267,7 @@ RSpec.describe "Bundler.with_env helpers" do
     it "runs exec inside with_clean_env" do
       skip "Fork not implemented" if Gem.win_platform?
 
-      system({ "BUNDLE_FOO" => "bar" }, "ruby -I#{lib_dir} -rbundler #{bundled_app("source.rb")}")
+      run_bundler_script({ "BUNDLE_FOO" => "bar" }, bundled_app("source.rb"))
       expect($?.exitstatus).to eq(1)
     end
   end

--- a/bundler/spec/runtime/with_unbundled_env_spec.rb
+++ b/bundler/spec/runtime/with_unbundled_env_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Bundler.with_env helpers" do
   end
 
   def run_bundler_script(env, script)
-    system(env, "ruby -I#{lib_dir} -rbundler #{script}")
+    system(env, "ruby", "-I#{lib_dir}", "-rbundler", script.to_s)
   end
 
   describe "Bundler.original_env" do

--- a/bundler/spec/runtime/with_unbundled_env_spec.rb
+++ b/bundler/spec/runtime/with_unbundled_env_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe "Bundler.with_env helpers" do
   describe "Bundler.with_original_env" do
     it "should set ENV to original_env in the block" do
       expected = Bundler.original_env
-      actual = Bundler.with_original_env { ENV.to_hash }
+      actual = Bundler.with_original_env { Bundler::EnvironmentPreserver.env_to_hash(ENV) }
       expect(actual).to eq(expected)
     end
 
@@ -147,7 +147,7 @@ RSpec.describe "Bundler.with_env helpers" do
       expected = Bundler.unbundled_env
 
       actual = Bundler.ui.silence do
-        Bundler.with_clean_env { ENV.to_hash }
+        Bundler.with_clean_env { Bundler::EnvironmentPreserver.env_to_hash(ENV) }
       end
 
       expect(actual).to eq(expected)
@@ -165,7 +165,7 @@ RSpec.describe "Bundler.with_env helpers" do
   describe "Bundler.with_unbundled_env" do
     it "should set ENV to unbundled_env in the block" do
       expected = Bundler.unbundled_env
-      actual = Bundler.with_unbundled_env { ENV.to_hash }
+      actual = Bundler.with_unbundled_env { Bundler::EnvironmentPreserver.env_to_hash(ENV) }
       expect(actual).to eq(expected)
     end
 


### PR DESCRIPTION
# Description:

This PR fixes several failing specs about backing & restoring the environment on Windows. It also simplifies the specs because they were failing as well due to complicated command lines that were not properly shellescaped.

## What was the end-user or developer problem that led to this PR?

Environment backup and restore specs are failing on Windows.
 
## What is your fix for the problem, implemented in this PR?

`ENV` is case insensitive on Windows, but on other platforms is not. However, our `EnvironmentPreserver` class operates on ruby hashes, so it's case sensitive.
    
So whenever we use `ENV.to_hash`, we need to make sure to canonalize the keys, so they are always UPCASED.
    
In addition to that, due to [a bug in ruby](https://bugs.ruby-lang.org/issues/16798), `ENV.replace` doesn't work when using the canonical name for an environment variable does not match the case being passed to it. So we workaround that by using `ENV.clear` + manual setting on each key instead.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
