### PR TITLE
Fix a bunch of test issues on Windows

### DIFF
--- a/bundler/spec/install/allow_offline_install_spec.rb
+++ b/bundler/spec/install/allow_offline_install_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe "bundle install with :allow_offline_install" do
 
   context "with no cached data locally" do
     it "still installs" do
-      skip "corrupt test gem" if Gem.win_platform?
-
       install_gemfile! <<-G, :artifice => "compact_index"
         source "http://testgemserver.local"
         gem "rack-obama"
@@ -28,8 +26,6 @@ RSpec.describe "bundle install with :allow_offline_install" do
 
   context "with cached data locally" do
     it "will install from the compact index" do
-      skip "corrupt test gem" if Gem.win_platform?
-
       system_gems ["rack-1.0.0"], :path => :bundle_path
 
       bundle! "config set clean false"

--- a/bundler/spec/install/deploy_spec.rb
+++ b/bundler/spec/install/deploy_spec.rb
@@ -84,8 +84,6 @@ RSpec.describe "install with --deployment or --frozen" do
   end
 
   it "works when there are credentials in the source URL" do
-    skip "corrupt test gem" if Gem.win_platform?
-
     install_gemfile(<<-G, :artifice => "endpoint_strict_basic_authentication", :quiet => true)
       source "http://user:pass@localgemserver.test/"
 

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe "compact index api" do
   let(:source_uri) { "http://#{source_hostname}" }
 
   it "should use the API" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem "rack"
@@ -28,8 +26,6 @@ RSpec.describe "compact index api" do
   end
 
   it "should handle nested dependencies" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem "rails"
@@ -48,8 +44,6 @@ RSpec.describe "compact index api" do
   end
 
   it "should handle case sensitivity conflicts" do
-    skip "artifice issues?" if Gem.win_platform?
-
     build_repo4 do
       build_gem "rack", "1.0" do |s|
         s.add_runtime_dependency("Rack", "0.1")
@@ -70,8 +64,6 @@ RSpec.describe "compact index api" do
   end
 
   it "should handle multiple gem dependencies on the same gem" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem "net-sftp"
@@ -82,8 +74,6 @@ RSpec.describe "compact index api" do
   end
 
   it "should use the endpoint when using --deployment" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem "rack"
@@ -96,8 +86,6 @@ RSpec.describe "compact index api" do
   end
 
   it "handles git dependencies that are in rubygems" do
-    skip "artifice issues?" if Gem.win_platform?
-
     build_git "foo" do |s|
       s.executables = "foobar"
       s.add_dependency "rails", "2.3.2"
@@ -116,8 +104,6 @@ RSpec.describe "compact index api" do
   end
 
   it "handles git dependencies that are in rubygems using --deployment" do
-    skip "artifice issues?" if Gem.win_platform?
-
     build_git "foo" do |s|
       s.executables = "foobar"
       s.add_dependency "rails", "2.3.2"
@@ -162,8 +148,6 @@ RSpec.describe "compact index api" do
   end
 
   it "falls back when the API URL returns 403 Forbidden" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem "rack"
@@ -175,8 +159,6 @@ RSpec.describe "compact index api" do
   end
 
   it "falls back when the versions endpoint has a checksum mismatch" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem "rack"
@@ -191,8 +173,6 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   it "falls back when the user's home directory does not exist or is not writable" do
-    skip "artifice issues?" if Gem.win_platform?
-
     ENV["HOME"] = tmp("missing_home").to_s
 
     gemfile <<-G
@@ -206,8 +186,6 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   it "handles host redirects" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem "rack"
@@ -218,8 +196,6 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   it "handles host redirects without Net::HTTP::Persistent" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem "rack"
@@ -244,8 +220,6 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   it "times out when Bundler::Fetcher redirects too much" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem "rack"
@@ -256,10 +230,6 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   context "when --full-index is specified" do
-    before do
-      skip "artifice issues?" if Gem.win_platform?
-    end
-
     it "should use the modern index for install" do
       gemfile <<-G
         source "#{source_uri}"
@@ -300,8 +270,6 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   it "fetches again when more dependencies are found in subsequent sources", :bundler => "< 3" do
-    skip "artifice issues?" if Gem.win_platform?
-
     build_repo2 do
       build_gem "back_deps" do |s|
         s.add_dependency "foo"
@@ -320,8 +288,6 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   it "fetches again when more dependencies are found in subsequent sources with source blocks" do
-    skip "artifice issues?" if Gem.win_platform?
-
     build_repo2 do
       build_gem "back_deps" do |s|
         s.add_dependency "foo"
@@ -340,8 +306,6 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   it "fetches gem versions even when those gems are already installed" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem "rack", "1.0.0"
@@ -365,8 +329,6 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   it "considers all possible versions of dependencies from all api gem sources", :bundler => "< 3" do
-    skip "artifice issues?" if Gem.win_platform?
-
     # In this scenario, the gem "somegem" only exists in repo4.  It depends on specific version of activesupport that
     # exists only in repo1.  There happens also be a version of activesupport in repo4, but not the one that version 1.0.0
     # of somegem wants. This test makes sure that bundler actually finds version 1.2.3 of active support in the other
@@ -391,8 +353,6 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   it "considers all possible versions of dependencies from all api gem sources when using blocks", :bundler => "< 3" do
-    skip "artifice issues?" if Gem.win_platform?
-
     # In this scenario, the gem "somegem" only exists in repo4.  It depends on specific version of activesupport that
     # exists only in repo1.  There happens also be a version of activesupport in repo4, but not the one that version 1.0.0
     # of somegem wants. This test makes sure that bundler actually finds version 1.2.3 of active support in the other
@@ -418,8 +378,6 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   it "prints API output properly with back deps" do
-    skip "artifice issues?" if Gem.win_platform?
-
     build_repo2 do
       build_gem "back_deps" do |s|
         s.add_dependency "foo"
@@ -441,8 +399,6 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   it "does not fetch every spec if the index of gems is large when doing back deps" do
-    skip "artifice issues?" if Gem.win_platform?
-
     build_repo2 do
       build_gem "back_deps" do |s|
         s.add_dependency "foo"
@@ -468,8 +424,6 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   it "does not fetch every spec if the index of gems is large when doing back deps & everything is the compact index" do
-    skip "artifice issues?" if Gem.win_platform?
-
     build_repo4 do
       build_gem "back_deps" do |s|
         s.add_dependency "foo"
@@ -494,8 +448,6 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   it "uses the endpoint if all sources support it" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
 
@@ -507,8 +459,6 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   it "fetches again when more dependencies are found in subsequent sources using --deployment", :bundler => "< 3" do
-    skip "artifice issues?" if Gem.win_platform?
-
     build_repo2 do
       build_gem "back_deps" do |s|
         s.add_dependency "foo"
@@ -529,8 +479,6 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   it "fetches again when more dependencies are found in subsequent sources using --deployment with blocks" do
-    skip "artifice issues?" if Gem.win_platform?
-
     build_repo2 do
       build_gem "back_deps" do |s|
         s.add_dependency "foo"
@@ -552,8 +500,6 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   it "does not refetch if the only unmet dependency is bundler" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
 
@@ -577,7 +523,7 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   it "installs the binstubs", :bundler => "< 3" do
-    skip "artifice issues?" if Gem.win_platform?
+    skip "exec format error" if Gem.win_platform?
 
     gemfile <<-G
       source "#{source_uri}"
@@ -591,8 +537,6 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   it "installs the bins when using --path and uses autoclean", :bundler => "< 3" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem "rack"
@@ -604,8 +548,6 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   it "installs the bins when using --path and uses bundle clean", :bundler => "< 3" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem "rack"
@@ -617,8 +559,6 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   it "prints post_install_messages" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem 'rack-obama'
@@ -629,8 +569,6 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   it "should display the post install message for a dependency" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem 'rack_middleware'
@@ -653,8 +591,6 @@ The checksum of /versions does not match the checksum provided by the server! So
     end
 
     it "passes basic authentication details and strips out creds" do
-      skip "artifice issues?" if Gem.win_platform?
-
       gemfile <<-G
         source "#{basic_auth_source_uri}"
         gem "rack"
@@ -666,8 +602,6 @@ The checksum of /versions does not match the checksum provided by the server! So
     end
 
     it "strips http basic authentication creds for modern index" do
-      skip "artifice issues?" if Gem.win_platform?
-
       gemfile <<-G
         source "#{basic_auth_source_uri}"
         gem "rack"
@@ -689,8 +623,6 @@ The checksum of /versions does not match the checksum provided by the server! So
     end
 
     it "strips http basic auth creds when warning about ambiguous sources", :bundler => "< 3" do
-      skip "artifice issues?" if Gem.win_platform?
-
       gemfile <<-G
         source "#{basic_auth_source_uri}"
         source "#{file_uri_for(gem_repo1)}"
@@ -704,8 +636,6 @@ The checksum of /versions does not match the checksum provided by the server! So
     end
 
     it "does not pass the user / password to different hosts on redirect" do
-      skip "artifice issues?" if Gem.win_platform?
-
       gemfile <<-G
         source "#{basic_auth_source_uri}"
         gem "rack"
@@ -724,8 +654,6 @@ The checksum of /versions does not match the checksum provided by the server! So
       end
 
       it "reads authentication details by host name from bundle config" do
-        skip "artifice issues?" if Gem.win_platform?
-
         bundle "config set #{source_hostname} #{user}:#{password}"
 
         bundle! :install, :artifice => "compact_index_strict_basic_authentication"
@@ -735,8 +663,6 @@ The checksum of /versions does not match the checksum provided by the server! So
       end
 
       it "reads authentication details by full url from bundle config" do
-        skip "artifice issues?" if Gem.win_platform?
-
         # The trailing slash is necessary here; Fetcher canonicalizes the URI.
         bundle "config set #{source_uri}/ #{user}:#{password}"
 
@@ -747,8 +673,6 @@ The checksum of /versions does not match the checksum provided by the server! So
       end
 
       it "should use the API" do
-        skip "artifice issues?" if Gem.win_platform?
-
         bundle "config set #{source_hostname} #{user}:#{password}"
         bundle! :install, :artifice => "compact_index_strict_basic_authentication"
         expect(out).to include("Fetching gem metadata from #{source_uri}")
@@ -756,8 +680,6 @@ The checksum of /versions does not match the checksum provided by the server! So
       end
 
       it "prefers auth supplied in the source uri" do
-        skip "artifice issues?" if Gem.win_platform?
-
         gemfile <<-G
           source "#{basic_auth_source_uri}"
           gem "rack"
@@ -786,8 +708,6 @@ The checksum of /versions does not match the checksum provided by the server! So
       let(:password) { nil }
 
       it "passes basic authentication details" do
-        skip "artifice issues?" if Gem.win_platform?
-
         gemfile <<-G
           source "#{basic_auth_source_uri}"
           gem "rack"
@@ -845,8 +765,6 @@ The checksum of /versions does not match the checksum provided by the server! So
 
   context ".gemrc with sources is present" do
     it "uses other sources declared in the Gemfile" do
-      skip "artifice issues?" if Gem.win_platform?
-
       File.open(home(".gemrc"), "w") do |file|
         file.puts({ :sources => ["https://rubygems.org"] }.to_yaml)
       end
@@ -867,7 +785,7 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   it "performs partial update with a non-empty range" do
-    skip "artifice issues?" if Gem.win_platform?
+    skip "HTTP_RANGE not set" if Gem.win_platform?
 
     gemfile <<-G
       source "#{source_uri}"
@@ -890,8 +808,6 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   it "performs partial update while local cache is updated by another process" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem 'rack'
@@ -910,8 +826,6 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   it "performs full update of compact index info cache if range is not satisfiable" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem 'rack', '0.9.1'
@@ -955,8 +869,6 @@ The checksum of /versions does not match the checksum provided by the server! So
 
   describe "checksum validation" do
     it "raises when the checksum does not match" do
-      skip "artifice issues?" if Gem.win_platform?
-
       install_gemfile <<-G, :artifice => "compact_index_wrong_gem_checksum"
         source "#{source_uri}"
         gem "rack"
@@ -977,8 +889,6 @@ The checksum of /versions does not match the checksum provided by the server! So
     end
 
     it "raises when the checksum is the wrong length" do
-      skip "artifice issues?" if Gem.win_platform?
-
       install_gemfile <<-G, :artifice => "compact_index_wrong_gem_checksum", :env => { "BUNDLER_SPEC_RACK_CHECKSUM" => "checksum!" }
         source "#{source_uri}"
         gem "rack"
@@ -988,8 +898,6 @@ The checksum of /versions does not match the checksum provided by the server! So
     end
 
     it "does not raise when disable_checksum_validation is set" do
-      skip "artifice issues?" if Gem.win_platform?
-
       bundle! "config set disable_checksum_validation true"
       install_gemfile! <<-G, :artifice => "compact_index_wrong_gem_checksum"
         source "#{source_uri}"
@@ -999,8 +907,6 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   it "works when cache dir is world-writable" do
-    skip "artifice issues?" if Gem.win_platform?
-
     install_gemfile! <<-G, :artifice => "compact_index"
       File.umask(0000)
       source "#{source_uri}"
@@ -1009,8 +915,6 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   it "doesn't explode when the API dependencies are wrong" do
-    skip "artifice issues?" if Gem.win_platform?
-
     install_gemfile <<-G, :artifice => "compact_index_wrong_dependencies", :env => { "DEBUG" => "true" }
       source "#{source_uri}"
       gem "rails"
@@ -1027,8 +931,6 @@ Either installing with `--full-index` or running `bundle update rails` should fi
   end
 
   it "does not duplicate specs in the lockfile when updating and a dependency is not installed" do
-    skip "artifice issues?" if Gem.win_platform?
-
     install_gemfile! <<-G, :artifice => "compact_index"
       source "#{source_uri}" do
         gem "rails"

--- a/bundler/spec/install/gems/dependency_api_spec.rb
+++ b/bundler/spec/install/gems/dependency_api_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe "gemcutter's dependency API" do
   let(:source_uri) { "http://#{source_hostname}" }
 
   it "should use the API" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem "rack"
@@ -28,8 +26,6 @@ RSpec.describe "gemcutter's dependency API" do
   end
 
   it "should handle nested dependencies" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem "rails"
@@ -48,8 +44,6 @@ RSpec.describe "gemcutter's dependency API" do
   end
 
   it "should handle multiple gem dependencies on the same gem" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem "net-sftp"
@@ -60,8 +54,6 @@ RSpec.describe "gemcutter's dependency API" do
   end
 
   it "should use the endpoint when using --deployment" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem "rack"
@@ -74,8 +66,6 @@ RSpec.describe "gemcutter's dependency API" do
   end
 
   it "handles git dependencies that are in rubygems" do
-    skip "artifice issues?" if Gem.win_platform?
-
     build_git "foo" do |s|
       s.executables = "foobar"
       s.add_dependency "rails", "2.3.2"
@@ -94,8 +84,6 @@ RSpec.describe "gemcutter's dependency API" do
   end
 
   it "handles git dependencies that are in rubygems using --deployment" do
-    skip "artifice issues?" if Gem.win_platform?
-
     build_git "foo" do |s|
       s.executables = "foobar"
       s.add_dependency "rails", "2.3.2"
@@ -140,8 +128,6 @@ RSpec.describe "gemcutter's dependency API" do
   end
 
   it "falls back when hitting the Gemcutter Dependency Limit" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem "activesupport"
@@ -168,8 +154,6 @@ RSpec.describe "gemcutter's dependency API" do
   end
 
   it "falls back when Gemcutter API doesn't return proper Marshal format" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem "rack"
@@ -181,8 +165,6 @@ RSpec.describe "gemcutter's dependency API" do
   end
 
   it "falls back when the API URL returns 403 Forbidden" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem "rack"
@@ -194,8 +176,6 @@ RSpec.describe "gemcutter's dependency API" do
   end
 
   it "handles host redirects" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem "rack"
@@ -206,8 +186,6 @@ RSpec.describe "gemcutter's dependency API" do
   end
 
   it "handles host redirects without Net::HTTP::Persistent" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem "rack"
@@ -232,8 +210,6 @@ RSpec.describe "gemcutter's dependency API" do
   end
 
   it "timeouts when Bundler::Fetcher redirects too much" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem "rack"
@@ -244,10 +220,6 @@ RSpec.describe "gemcutter's dependency API" do
   end
 
   context "when --full-index is specified" do
-    before do
-      skip "artifice issues?" if Gem.win_platform?
-    end
-
     it "should use the modern index for install" do
       gemfile <<-G
         source "#{source_uri}"
@@ -272,8 +244,6 @@ RSpec.describe "gemcutter's dependency API" do
   end
 
   it "fetches again when more dependencies are found in subsequent sources", :bundler => "< 3" do
-    skip "artifice issues?" if Gem.win_platform?
-
     build_repo2 do
       build_gem "back_deps" do |s|
         s.add_dependency "foo"
@@ -292,8 +262,6 @@ RSpec.describe "gemcutter's dependency API" do
   end
 
   it "fetches again when more dependencies are found in subsequent sources using blocks" do
-    skip "artifice issues?" if Gem.win_platform?
-
     build_repo2 do
       build_gem "back_deps" do |s|
         s.add_dependency "foo"
@@ -313,8 +281,6 @@ RSpec.describe "gemcutter's dependency API" do
   end
 
   it "fetches gem versions even when those gems are already installed" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem "rack", "1.0.0"
@@ -337,8 +303,6 @@ RSpec.describe "gemcutter's dependency API" do
   end
 
   it "considers all possible versions of dependencies from all api gem sources", :bundler => "< 3" do
-    skip "artifice issues?" if Gem.win_platform?
-
     # In this scenario, the gem "somegem" only exists in repo4.  It depends on specific version of activesupport that
     # exists only in repo1.  There happens also be a version of activesupport in repo4, but not the one that version 1.0.0
     # of somegem wants. This test makes sure that bundler actually finds version 1.2.3 of active support in the other
@@ -363,8 +327,6 @@ RSpec.describe "gemcutter's dependency API" do
   end
 
   it "considers all possible versions of dependencies from all api gem sources using blocks" do
-    skip "artifice issues?" if Gem.win_platform?
-
     # In this scenario, the gem "somegem" only exists in repo4.  It depends on specific version of activesupport that
     # exists only in repo1.  There happens also be a version of activesupport in repo4, but not the one that version 1.0.0
     # of somegem wants. This test makes sure that bundler actually finds version 1.2.3 of active support in the other
@@ -390,8 +352,6 @@ RSpec.describe "gemcutter's dependency API" do
   end
 
   it "prints API output properly with back deps" do
-    skip "artifice issues?" if Gem.win_platform?
-
     build_repo2 do
       build_gem "back_deps" do |s|
         s.add_dependency "foo"
@@ -413,8 +373,6 @@ RSpec.describe "gemcutter's dependency API" do
   end
 
   it "does not fetch every spec if the index of gems is large when doing back deps", :bundler => "< 3" do
-    skip "artifice issues?" if Gem.win_platform?
-
     build_repo2 do
       build_gem "back_deps" do |s|
         s.add_dependency "foo"
@@ -439,8 +397,6 @@ RSpec.describe "gemcutter's dependency API" do
   end
 
   it "does not fetch every spec if the index of gems is large when doing back deps using blocks" do
-    skip "artifice issues?" if Gem.win_platform?
-
     build_repo2 do
       build_gem "back_deps" do |s|
         s.add_dependency "foo"
@@ -466,8 +422,6 @@ RSpec.describe "gemcutter's dependency API" do
   end
 
   it "uses the endpoint if all sources support it" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
 
@@ -479,8 +433,6 @@ RSpec.describe "gemcutter's dependency API" do
   end
 
   it "fetches again when more dependencies are found in subsequent sources using --deployment", :bundler => "< 3" do
-    skip "artifice issues?" if Gem.win_platform?
-
     build_repo2 do
       build_gem "back_deps" do |s|
         s.add_dependency "foo"
@@ -501,8 +453,6 @@ RSpec.describe "gemcutter's dependency API" do
   end
 
   it "fetches again when more dependencies are found in subsequent sources using --deployment with blocks" do
-    skip "artifice issues?" if Gem.win_platform?
-
     build_repo2 do
       build_gem "back_deps" do |s|
         s.add_dependency "foo"
@@ -547,7 +497,7 @@ RSpec.describe "gemcutter's dependency API" do
   end
 
   it "installs the binstubs", :bundler => "< 3" do
-    skip "artifice issues?" if Gem.win_platform?
+    skip "exec format error" if Gem.win_platform?
 
     gemfile <<-G
       source "#{source_uri}"
@@ -561,8 +511,6 @@ RSpec.describe "gemcutter's dependency API" do
   end
 
   it "installs the bins when using --path and uses autoclean", :bundler => "< 3" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem "rack"
@@ -574,8 +522,6 @@ RSpec.describe "gemcutter's dependency API" do
   end
 
   it "installs the bins when using --path and uses bundle clean", :bundler => "< 3" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem "rack"
@@ -587,8 +533,6 @@ RSpec.describe "gemcutter's dependency API" do
   end
 
   it "prints post_install_messages" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem 'rack-obama'
@@ -599,8 +543,6 @@ RSpec.describe "gemcutter's dependency API" do
   end
 
   it "should display the post install message for a dependency" do
-    skip "artifice issues?" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem 'rack_middleware'
@@ -623,8 +565,6 @@ RSpec.describe "gemcutter's dependency API" do
     end
 
     it "passes basic authentication details and strips out creds" do
-      skip "artifice issues?" if Gem.win_platform?
-
       gemfile <<-G
         source "#{basic_auth_source_uri}"
         gem "rack"
@@ -636,8 +576,6 @@ RSpec.describe "gemcutter's dependency API" do
     end
 
     it "strips http basic authentication creds for modern index" do
-      skip "artifice issues?" if Gem.win_platform?
-
       gemfile <<-G
         source "#{basic_auth_source_uri}"
         gem "rack"
@@ -659,8 +597,6 @@ RSpec.describe "gemcutter's dependency API" do
     end
 
     it "strips http basic auth creds when warning about ambiguous sources", :bundler => "< 3" do
-      skip "artifice issues?" if Gem.win_platform?
-
       gemfile <<-G
         source "#{basic_auth_source_uri}"
         source "#{file_uri_for(gem_repo1)}"
@@ -674,8 +610,6 @@ RSpec.describe "gemcutter's dependency API" do
     end
 
     it "does not pass the user / password to different hosts on redirect" do
-      skip "artifice issues?" if Gem.win_platform?
-
       gemfile <<-G
         source "#{basic_auth_source_uri}"
         gem "rack"
@@ -694,8 +628,6 @@ RSpec.describe "gemcutter's dependency API" do
       end
 
       it "reads authentication details by host name from bundle config" do
-        skip "artifice issues?" if Gem.win_platform?
-
         bundle "config set #{source_hostname} #{user}:#{password}"
 
         bundle :install, :artifice => "endpoint_strict_basic_authentication"
@@ -705,8 +637,6 @@ RSpec.describe "gemcutter's dependency API" do
       end
 
       it "reads authentication details by full url from bundle config" do
-        skip "artifice issues?" if Gem.win_platform?
-
         # The trailing slash is necessary here; Fetcher canonicalizes the URI.
         bundle "config set #{source_uri}/ #{user}:#{password}"
 
@@ -717,8 +647,6 @@ RSpec.describe "gemcutter's dependency API" do
       end
 
       it "should use the API" do
-        skip "artifice issues?" if Gem.win_platform?
-
         bundle "config set #{source_hostname} #{user}:#{password}"
         bundle :install, :artifice => "endpoint_strict_basic_authentication"
         expect(out).to include("Fetching gem metadata from #{source_uri}")
@@ -726,8 +654,6 @@ RSpec.describe "gemcutter's dependency API" do
       end
 
       it "prefers auth supplied in the source uri" do
-        skip "artifice issues?" if Gem.win_platform?
-
         gemfile <<-G
           source "#{basic_auth_source_uri}"
           gem "rack"
@@ -756,8 +682,6 @@ RSpec.describe "gemcutter's dependency API" do
       let(:password) { nil }
 
       it "passes basic authentication details" do
-        skip "artifice issues?" if Gem.win_platform?
-
         gemfile <<-G
           source "#{basic_auth_source_uri}"
           gem "rack"
@@ -815,8 +739,6 @@ RSpec.describe "gemcutter's dependency API" do
 
   context ".gemrc with sources is present" do
     it "uses other sources declared in the Gemfile" do
-      skip "artifice issues?" if Gem.win_platform?
-
       File.open(home(".gemrc"), "w") do |file|
         file.puts({ :sources => ["https://rubygems.org"] }.to_yaml)
       end

--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -226,8 +226,6 @@ RSpec.shared_examples "bundle install --standalone" do
 
     describe "simple gems" do
       before do
-        skip "artifice issues maybe" if Gem.win_platform?
-
         gemfile <<-G
           source "#{source_uri}"
           gem "rails"

--- a/bundler/spec/install/global_cache_spec.rb
+++ b/bundler/spec/install/global_cache_spec.rb
@@ -16,8 +16,6 @@ RSpec.describe "global gem caching" do
     end
 
     it "caches gems into the global cache on download" do
-      skip "corrupt test gem" if Gem.win_platform?
-
       install_gemfile! <<-G, :artifice => "compact_index"
         source "#{source}"
         gem "rack"
@@ -40,10 +38,6 @@ RSpec.describe "global gem caching" do
     end
 
     describe "when the same gem from different sources is installed" do
-      before do
-        skip "corrupt test gem" if Gem.win_platform?
-      end
-
       it "should use the appropriate one from the global cache" do
         install_gemfile! <<-G, :artifice => "compact_index"
           source "#{source}"
@@ -140,8 +134,6 @@ RSpec.describe "global gem caching" do
 
     describe "when installing gems from a different directory" do
       it "uses the global cache as a source" do
-        skip "corrupt test gem" if Gem.win_platform?
-
         install_gemfile! <<-G, :artifice => "compact_index"
           source "#{source}"
           gem "rack"

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -303,8 +303,6 @@ RSpec.describe "the lockfile format" do
   end
 
   it "generates a lockfile without credentials for a configured source", :bundler => "< 3" do
-    skip "corrupt test gem" if Gem.win_platform?
-
     bundle "config set http://localgemserver.test/ user:pass"
 
     install_gemfile(<<-G, :artifice => "endpoint_strict_basic_authentication", :quiet => true)

--- a/bundler/spec/support/artifice/compact_index.rb
+++ b/bundler/spec/support/artifice/compact_index.rb
@@ -100,7 +100,7 @@ class CompactIndexAPI < Endpoint
   get "/versions" do
     etag_response do
       file = tmp("versions.list")
-      file.delete if file.file?
+      FileUtils.rm_f(file)
       file = CompactIndex::VersionsFile.new(file.to_s)
       file.create(gems)
       file.contents

--- a/bundler/spec/support/artifice/compact_index_concurrent_download.rb
+++ b/bundler/spec/support/artifice/compact_index_concurrent_download.rb
@@ -21,7 +21,7 @@ class CompactIndexConcurrentDownload < CompactIndexAPI
 
     etag_response do
       file = tmp("versions.list")
-      file.delete if file.file?
+      FileUtils.rm_f(file)
       file = CompactIndex::VersionsFile.new(file.to_s)
       file.create(gems)
       file.contents

--- a/bundler/spec/support/artifice/compact_index_concurrent_download.rb
+++ b/bundler/spec/support/artifice/compact_index_concurrent_download.rb
@@ -10,7 +10,7 @@ class CompactIndexConcurrentDownload < CompactIndexAPI
       "localgemserver.test.80.dd34752a738ee965a2a4298dc16db6c5", "versions")
 
     # Verify the original (empty) content hasn't been deleted, e.g. on a retry
-    File.read(versions) == "" || raise("Original file should be present and empty")
+    File.binread(versions) == "" || raise("Original file should be present and empty")
 
     # Verify this is only requested once for a partial download
     env["HTTP_RANGE"] || raise("Missing Range header for expected partial download")

--- a/bundler/spec/support/artifice/compact_index_creds_diff_host.rb
+++ b/bundler/spec/support/artifice/compact_index_creds_diff_host.rb
@@ -31,7 +31,7 @@ class CompactIndexCredsDiffHost < CompactIndexAPI
 
   get "/no/creds/:id" do
     if request.host.include?("diffhost") && !auth.provided?
-      File.read("#{gem_repo1}/gems/#{params[:id]}")
+      File.binread("#{gem_repo1}/gems/#{params[:id]}")
     end
   end
 end

--- a/bundler/spec/support/artifice/compact_index_extra.rb
+++ b/bundler/spec/support/artifice/compact_index_extra.rb
@@ -14,11 +14,11 @@ class CompactIndexExtra < CompactIndexAPI
   end
 
   get "/extra/specs.4.8.gz" do
-    File.read("#{gem_repo2}/specs.4.8.gz")
+    File.binread("#{gem_repo2}/specs.4.8.gz")
   end
 
   get "/extra/prerelease_specs.4.8.gz" do
-    File.read("#{gem_repo2}/prerelease_specs.4.8.gz")
+    File.binread("#{gem_repo2}/prerelease_specs.4.8.gz")
   end
 
   get "/extra/quick/Marshal.4.8/:id" do
@@ -26,11 +26,11 @@ class CompactIndexExtra < CompactIndexAPI
   end
 
   get "/extra/fetch/actual/gem/:id" do
-    File.read("#{gem_repo2}/quick/Marshal.4.8/#{params[:id]}")
+    File.binread("#{gem_repo2}/quick/Marshal.4.8/#{params[:id]}")
   end
 
   get "/extra/gems/:id" do
-    File.read("#{gem_repo2}/gems/#{params[:id]}")
+    File.binread("#{gem_repo2}/gems/#{params[:id]}")
   end
 end
 

--- a/bundler/spec/support/artifice/compact_index_extra_api.rb
+++ b/bundler/spec/support/artifice/compact_index_extra_api.rb
@@ -29,11 +29,11 @@ class CompactIndexExtraApi < CompactIndexAPI
   end
 
   get "/extra/specs.4.8.gz" do
-    File.read("#{gem_repo4}/specs.4.8.gz")
+    File.binread("#{gem_repo4}/specs.4.8.gz")
   end
 
   get "/extra/prerelease_specs.4.8.gz" do
-    File.read("#{gem_repo4}/prerelease_specs.4.8.gz")
+    File.binread("#{gem_repo4}/prerelease_specs.4.8.gz")
   end
 
   get "/extra/quick/Marshal.4.8/:id" do
@@ -41,11 +41,11 @@ class CompactIndexExtraApi < CompactIndexAPI
   end
 
   get "/extra/fetch/actual/gem/:id" do
-    File.read("#{gem_repo4}/quick/Marshal.4.8/#{params[:id]}")
+    File.binread("#{gem_repo4}/quick/Marshal.4.8/#{params[:id]}")
   end
 
   get "/extra/gems/:id" do
-    File.read("#{gem_repo4}/gems/#{params[:id]}")
+    File.binread("#{gem_repo4}/gems/#{params[:id]}")
   end
 end
 

--- a/bundler/spec/support/artifice/compact_index_extra_api.rb
+++ b/bundler/spec/support/artifice/compact_index_extra_api.rb
@@ -14,7 +14,7 @@ class CompactIndexExtraApi < CompactIndexAPI
   get "/extra/versions" do
     etag_response do
       file = tmp("versions.list")
-      file.delete if file.file?
+      FileUtils.rm_f(file)
       file = CompactIndex::VersionsFile.new(file.to_s)
       file.create(gems(gem_repo4))
       file.contents

--- a/bundler/spec/support/artifice/compact_index_partial_update.rb
+++ b/bundler/spec/support/artifice/compact_index_partial_update.rb
@@ -18,19 +18,19 @@ class CompactIndexPartialUpdate < CompactIndexAPI
     )
 
     # Verify a cached copy of the versions file exists
-    unless File.read(cached_versions_path).start_with?("created_at: ")
+    unless File.binread(cached_versions_path).start_with?("created_at: ")
       raise("Cached versions file should be present and have content")
     end
 
     # Verify that a partial request is made, starting from the index of the
     # final byte of the cached file.
-    unless env["HTTP_RANGE"] == "bytes=#{File.read(cached_versions_path).bytesize - 1}-"
+    unless env["HTTP_RANGE"] == "bytes=#{File.binread(cached_versions_path).bytesize - 1}-"
       raise("Range header should be present, and start from the index of the final byte of the cache.")
     end
 
     etag_response do
       # Return the exact contents of the cache.
-      File.read(cached_versions_path)
+      File.binread(cached_versions_path)
     end
   end
 end

--- a/bundler/spec/support/artifice/compact_index_range_not_satisfiable.rb
+++ b/bundler/spec/support/artifice/compact_index_range_not_satisfiable.rb
@@ -11,7 +11,7 @@ class CompactIndexRangeNotSatisfiable < CompactIndexAPI
     else
       etag_response do
         file = tmp("versions.list")
-        file.delete if file.file?
+        FileUtils.rm_f(file)
         file = CompactIndex::VersionsFile.new(file.to_s)
         file.create(gems)
         file.contents

--- a/bundler/spec/support/artifice/endpoint.rb
+++ b/bundler/spec/support/artifice/endpoint.rb
@@ -77,11 +77,11 @@ class Endpoint < Sinatra::Base
   end
 
   get "/fetch/actual/gem/:id" do
-    File.read("#{GEM_REPO}/quick/Marshal.4.8/#{params[:id]}")
+    File.binread("#{GEM_REPO}/quick/Marshal.4.8/#{params[:id]}")
   end
 
   get "/gems/:id" do
-    File.read("#{GEM_REPO}/gems/#{params[:id]}")
+    File.binread("#{GEM_REPO}/gems/#{params[:id]}")
   end
 
   get "/api/v1/dependencies" do
@@ -89,11 +89,11 @@ class Endpoint < Sinatra::Base
   end
 
   get "/specs.4.8.gz" do
-    File.read("#{GEM_REPO}/specs.4.8.gz")
+    File.binread("#{GEM_REPO}/specs.4.8.gz")
   end
 
   get "/prerelease_specs.4.8.gz" do
-    File.read("#{GEM_REPO}/prerelease_specs.4.8.gz")
+    File.binread("#{GEM_REPO}/prerelease_specs.4.8.gz")
   end
 end
 

--- a/bundler/spec/support/artifice/endpoint_creds_diff_host.rb
+++ b/bundler/spec/support/artifice/endpoint_creds_diff_host.rb
@@ -31,7 +31,7 @@ class EndpointCredsDiffHost < Endpoint
 
   get "/no/creds/:id" do
     if request.host.include?("diffhost") && !auth.provided?
-      File.read("#{gem_repo1}/gems/#{params[:id]}")
+      File.binread("#{gem_repo1}/gems/#{params[:id]}")
     end
   end
 end

--- a/bundler/spec/support/artifice/endpoint_extra.rb
+++ b/bundler/spec/support/artifice/endpoint_extra.rb
@@ -10,11 +10,11 @@ class EndpointExtra < Endpoint
   end
 
   get "/extra/specs.4.8.gz" do
-    File.read("#{gem_repo2}/specs.4.8.gz")
+    File.binread("#{gem_repo2}/specs.4.8.gz")
   end
 
   get "/extra/prerelease_specs.4.8.gz" do
-    File.read("#{gem_repo2}/prerelease_specs.4.8.gz")
+    File.binread("#{gem_repo2}/prerelease_specs.4.8.gz")
   end
 
   get "/extra/quick/Marshal.4.8/:id" do
@@ -22,11 +22,11 @@ class EndpointExtra < Endpoint
   end
 
   get "/extra/fetch/actual/gem/:id" do
-    File.read("#{gem_repo2}/quick/Marshal.4.8/#{params[:id]}")
+    File.binread("#{gem_repo2}/quick/Marshal.4.8/#{params[:id]}")
   end
 
   get "/extra/gems/:id" do
-    File.read("#{gem_repo2}/gems/#{params[:id]}")
+    File.binread("#{gem_repo2}/gems/#{params[:id]}")
   end
 end
 

--- a/bundler/spec/support/artifice/endpoint_extra_api.rb
+++ b/bundler/spec/support/artifice/endpoint_extra_api.rb
@@ -11,11 +11,11 @@ class EndpointExtraApi < Endpoint
   end
 
   get "/extra/specs.4.8.gz" do
-    File.read("#{gem_repo4}/specs.4.8.gz")
+    File.binread("#{gem_repo4}/specs.4.8.gz")
   end
 
   get "/extra/prerelease_specs.4.8.gz" do
-    File.read("#{gem_repo4}/prerelease_specs.4.8.gz")
+    File.binread("#{gem_repo4}/prerelease_specs.4.8.gz")
   end
 
   get "/extra/quick/Marshal.4.8/:id" do
@@ -23,11 +23,11 @@ class EndpointExtraApi < Endpoint
   end
 
   get "/extra/fetch/actual/gem/:id" do
-    File.read("#{gem_repo4}/quick/Marshal.4.8/#{params[:id]}")
+    File.binread("#{gem_repo4}/quick/Marshal.4.8/#{params[:id]}")
   end
 
   get "/extra/gems/:id" do
-    File.read("#{gem_repo4}/gems/#{params[:id]}")
+    File.binread("#{gem_repo4}/gems/#{params[:id]}")
   end
 end
 

--- a/bundler/spec/support/artifice/endpoint_mirror_source.rb
+++ b/bundler/spec/support/artifice/endpoint_mirror_source.rb
@@ -5,7 +5,7 @@ require_relative "endpoint"
 class EndpointMirrorSource < Endpoint
   get "/gems/:id" do
     if request.env["HTTP_X_GEMFILE_SOURCE"] == "https://server.example.org/"
-      File.read("#{gem_repo1}/gems/#{params[:id]}")
+      File.binread("#{gem_repo1}/gems/#{params[:id]}")
     else
       halt 500
     end

--- a/bundler/spec/support/artifice/vcr.rb
+++ b/bundler/spec/support/artifice/vcr.rb
@@ -79,7 +79,7 @@ class BundlerVCRHTTP < Net::HTTP
     end
 
     def read_stored_request(path)
-      contents = File.read(path)
+      contents = File.binread(path)
       headers = {}
       method = nil
       path = nil


### PR DESCRIPTION
# Description:

Some specs where reporting "corrupt test gem" because the `.gem` was
being read in non-binary mode, and that made the header size of the gem
not match the actual size and caused tar entry reading to crash.

I changed the specific calls from the fake servers classes, but also
changed all the other `File.read` calls to `File.binread` to prevent
similar future issues.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
