### PR TITLE
Rollback gem deprecate

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -41,7 +41,7 @@ class Gem::BasicSpecification
   class << self
 
     extend Gem::Deprecate
-    deprecate :default_specifications_dir, "Gem.default_specifications_dir"
+    rubygems_deprecate :default_specifications_dir, "Gem.default_specifications_dir"
 
   end
 

--- a/lib/rubygems/commands/query_command.rb
+++ b/lib/rubygems/commands/query_command.rb
@@ -6,7 +6,7 @@ require 'rubygems/deprecate'
 class Gem::Commands::QueryCommand < Gem::Command
 
   extend Gem::Deprecate
-  deprecate_command
+  rubygems_deprecate_command
 
   include Gem::QueryUtils
 

--- a/lib/rubygems/dependency_installer.rb
+++ b/lib/rubygems/dependency_installer.rb
@@ -195,7 +195,7 @@ class Gem::DependencyInstaller
 
     set
   end
-  deprecate :find_gems_with_sources
+  rubygems_deprecate :find_gems_with_sources
 
   def in_background(what) # :nodoc:
     fork_happened = false

--- a/lib/rubygems/deprecate.rb
+++ b/lib/rubygems/deprecate.rb
@@ -51,7 +51,7 @@ module Gem::Deprecate
   # telling the user of +repl+ (unless +repl+ is :none) and the
   # Rubygems version that it is planned to go away.
 
-  def deprecate(name, replacement=:none)
+  def rubygems_deprecate(name, replacement=:none)
     class_eval do
       old = "_deprecated_#{name}"
       alias_method old, name
@@ -70,7 +70,7 @@ module Gem::Deprecate
   end
 
   # Deprecation method to deprecate Rubygems commands
-  def deprecate_command
+  def rubygems_deprecate_command
     class_eval do
       define_method "deprecated?" do
         true
@@ -86,6 +86,6 @@ module Gem::Deprecate
     end
   end
 
-  module_function :deprecate, :deprecate_command, :skip_during
+  module_function :rubygems_deprecate, :rubygems_deprecate_command, :skip_during
 
 end

--- a/lib/rubygems/deprecate.rb
+++ b/lib/rubygems/deprecate.rb
@@ -49,6 +49,31 @@ module Gem::Deprecate
   # Simple deprecation method that deprecates +name+ by wrapping it up
   # in a dummy method. It warns on each call to the dummy method
   # telling the user of +repl+ (unless +repl+ is :none) and the
+  # year/month that it is planned to go away.
+
+  def deprecate(name, repl, year, month)
+    class_eval do
+      old = "_deprecated_#{name}"
+      alias_method old, name
+      define_method name do |*args, &block|
+        klass = self.kind_of? Module
+        target = klass ? "#{self}." : "#{self.class}#"
+        msg = [ "NOTE: #{target}#{name} is deprecated",
+                repl == :none ? " with no replacement" : "; use #{repl} instead",
+                ". It will be removed on or after %4d-%02d-01." % [year, month],
+                "\n#{target}#{name} called from #{Gem.location_of_caller.join(":")}",
+        ]
+        warn "Gem::Deprecate#deprecate has been deprecated with no replacement and it will be removed in Rubygems 4.\n" unless Gem::Deprecate.skip
+        warn "#{msg.join}." unless Gem::Deprecate.skip
+        send old, *args, &block
+      end
+    end
+  end
+
+  ##
+  # Simple deprecation method that deprecates +name+ by wrapping it up
+  # in a dummy method. It warns on each call to the dummy method
+  # telling the user of +repl+ (unless +repl+ is :none) and the
   # Rubygems version that it is planned to go away.
 
   def rubygems_deprecate(name, replacement=:none)

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -422,7 +422,7 @@ class Gem::Installer
     @gem_dir = directory
     extract_files
   end
-  deprecate :unpack
+  rubygems_deprecate :unpack
 
   ##
   # The location of the spec file that is installed.

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -720,7 +720,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Deprecated: You must now specify the executable name to  Gem.bin_path.
 
   attr_writer :default_executable
-  deprecate :default_executable=
+  rubygems_deprecate :default_executable=
 
   ##
   # Allows deinstallation of gems with legacy platforms.
@@ -733,7 +733,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Formerly used to set rubyforge project.
 
   attr_writer :rubyforge_project
-  deprecate :rubyforge_project=
+  rubygems_deprecate :rubyforge_project=
 
   ##
   # The Gem::Specification version of this gemspec.
@@ -1723,7 +1723,7 @@ class Gem::Specification < Gem::BasicSpecification
     end
     result
   end
-  deprecate :default_executable
+  rubygems_deprecate :default_executable
 
   ##
   # The default value for specification attribute +name+
@@ -1926,7 +1926,7 @@ class Gem::Specification < Gem::BasicSpecification
   def has_rdoc # :nodoc:
     true
   end
-  deprecate :has_rdoc
+  rubygems_deprecate :has_rdoc
 
   ##
   # Deprecated and ignored.
@@ -1936,10 +1936,10 @@ class Gem::Specification < Gem::BasicSpecification
   def has_rdoc=(ignored) # :nodoc:
     @has_rdoc = true
   end
-  deprecate :has_rdoc=
+  rubygems_deprecate :has_rdoc=
 
   alias :has_rdoc? :has_rdoc # :nodoc:
-  deprecate :has_rdoc?
+  rubygems_deprecate :has_rdoc?
 
   ##
   # True if this gem has files in test_files

--- a/test/rubygems/test_deprecate.rb
+++ b/test/rubygems/test_deprecate.rb
@@ -58,6 +58,20 @@ class TestDeprecate < Gem::TestCase
 
   end
 
+  class OtherThing
+
+    extend Gem::Deprecate
+    attr_accessor :message
+    def foo
+      @message = "foo"
+    end
+    def bar
+      @message = "bar"
+    end
+    deprecate :foo, :bar, 2099, 3
+
+  end
+
   def test_deprecated_method_calls_the_old_method
     capture_io do
       thing = Thing.new
@@ -93,6 +107,18 @@ class TestDeprecate < Gem::TestCase
     assert Gem::Commands::FooCommand.new("foo").deprecated?
   ensure
     Gem::Commands.send(:remove_const, :FooCommand)
+  end
+
+  def test_deprecated_method_outputs_a_warning_old_way
+    out, err = capture_io do
+      thing = OtherThing.new
+      thing.foo
+    end
+
+    assert_equal "", out
+    assert_match(/Gem::Deprecate#deprecate has been deprecated with no replacement and it will be removed in Rubygems 4\./, err)
+    assert_match(/Thing#foo is deprecated; use bar instead\./, err)
+    assert_match(/on or after 2099-03-01/, err)
   end
 
 end

--- a/test/rubygems/test_deprecate.rb
+++ b/test/rubygems/test_deprecate.rb
@@ -54,7 +54,7 @@ class TestDeprecate < Gem::TestCase
     def bar
       @message = "bar"
     end
-    deprecate :foo, :bar
+    rubygems_deprecate :foo, :bar
 
   end
 
@@ -77,12 +77,12 @@ class TestDeprecate < Gem::TestCase
     assert_match(/in Rubygems [0-9]+/, err)
   end
 
-  def test_deprecate_command
+  def test_rubygems_deprecate_command
     require 'rubygems/command'
     foo_command = Class.new(Gem::Command) do
       extend Gem::Deprecate
 
-      deprecate_command
+      rubygems_deprecate_command
 
       def execute
         puts "pew pew!"

--- a/test/rubygems/test_gem_command_manager.rb
+++ b/test/rubygems/test_gem_command_manager.rb
@@ -281,7 +281,7 @@ class TestGemCommandManager < Gem::TestCase
     foo_command = Class.new(Gem::Command) do
       extend Gem::Deprecate
 
-      deprecate_command
+      rubygems_deprecate_command
 
       def execute
         say "pew pew!"


### PR DESCRIPTION
# Description:
closes https://github.com/rubygems/rubygems/issues/3512

This PR does a few things:
- Restore old depreciation method 
- Deprecates old deprecation method
- Rename new version horizon deprecation methods

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
