### PR TITLE
Removed the depdendency of English library

### DIFF
--- a/lib/rubygems/commands/contents_command.rb
+++ b/lib/rubygems/commands/contents_command.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'English'
 require 'rubygems/command'
 require 'rubygems/version_option'
 
@@ -106,7 +105,8 @@ prefix or only the files that are requireable.
     spec.files.map do |file|
       case file
       when /\A#{spec.bindir}\//
-        [RbConfig::CONFIG['bindir'], $POSTMATCH]
+        # $' is POSTMATCH
+        [RbConfig::CONFIG['bindir'], $']
       when /\.so\z/
         [RbConfig::CONFIG['archdir'], file]
       else

--- a/lib/rubygems/commands/open_command.rb
+++ b/lib/rubygems/commands/open_command.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'English'
 require 'rubygems/command'
 require 'rubygems/version_option'
 require 'rubygems/util'


### PR DESCRIPTION
# Description:

English.rb is extracted to the default gems at https://github.com/ruby/ruby/commit/2c5764ec223d976e0d0da1494596a1519104be3e

## What was the end-user or developer problem that led to this PR?

After the Ruby 2.8 or 3.0, the users can't specify the version of English gem with the some of RubyGems commands.

## What is your fix for the problem, implemented in this PR?

I removed English.rb from RubyGems.
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
