### PR TITLE
Normalize heredoc delimiters

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -81,6 +81,9 @@ Lint/DuplicateMethods:
 Lint/ParenthesesAsGroupedExpression:
   Enabled: true
 
+Naming/HeredocDelimiterCase:
+  Enabled: true
+
 Naming/HeredocDelimiterNaming:
   Enabled: true
   ForbiddenDelimiters:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -81,6 +81,11 @@ Lint/DuplicateMethods:
 Lint/ParenthesesAsGroupedExpression:
   Enabled: true
 
+Naming/HeredocDelimiterNaming:
+  Enabled: true
+  ForbiddenDelimiters:
+    - ^RB$
+
 Style/MethodDefParentheses:
   Enabled: true
 

--- a/bundler/.rubocop.yml
+++ b/bundler/.rubocop.yml
@@ -414,6 +414,11 @@ Naming/FileName:
 Naming/HeredocDelimiterCase:
   Enabled: true
 
+Naming/HeredocDelimiterNaming:
+  Enabled: true
+  ForbiddenDelimiters:
+    - ^RB$
+
 Naming/MethodName:
   Enabled: true
 

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -573,10 +573,10 @@ module Bundler
 
     def backport_ext_builder_monitor
       # So we can avoid requiring "rubygems/ext" in its entirety
-      Gem.module_eval <<-RB, __FILE__, __LINE__ + 1
+      Gem.module_eval <<-RUBY, __FILE__, __LINE__ + 1
         module Ext
         end
-      RB
+      RUBY
 
       require "rubygems/ext/builder"
 

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -875,10 +875,10 @@ __FILE__: #{path.to_s.inspect}
         skip "https://github.com/rubygems/bundler/issues/6898" if Gem.win_platform?
 
         file = bundled_app("file_that_bundle_execs.rb")
-        create_file(file, <<-RB)
+        create_file(file, <<-RUBY)
           #!#{Gem.ruby}
           puts `bundle exec echo foo`
-        RB
+        RUBY
         file.chmod(0o777)
         bundle! "exec #{file}"
         expect(out).to eq("foo")
@@ -897,21 +897,21 @@ __FILE__: #{path.to_s.inspect}
 
         build_repo4 do
           build_gem "openssl", openssl_version do |s|
-            s.write("lib/openssl.rb", <<-RB)
+            s.write("lib/openssl.rb", <<-RUBY)
               raise "custom openssl should not be loaded, it's not in the gemfile!"
-            RB
+            RUBY
           end
         end
 
         system_gems(:bundler, "openssl-#{openssl_version}", :gem_repo => gem_repo4)
 
         file = bundled_app("require_openssl.rb")
-        create_file(file, <<-RB)
+        create_file(file, <<-RUBY)
           #!/usr/bin/env ruby
           require "openssl"
           puts OpenSSL::VERSION
           warn Gem.loaded_specs.values.map(&:full_name)
-        RB
+        RUBY
         file.chmod(0o777)
 
         aggregate_failures do

--- a/bundler/spec/runtime/with_unbundled_env_spec.rb
+++ b/bundler/spec/runtime/with_unbundled_env_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe "Bundler.with_env helpers" do
 
   describe "Bundler.original_env" do
     it "should return the PATH present before bundle was activated" do
-      create_file("source.rb", <<-RB)
+      create_file("source.rb", <<-RUBY)
         print Bundler.original_env["PATH"]
-      RB
+      RUBY
       path = `getconf PATH`.strip + "#{File::PATH_SEPARATOR}/foo"
       with_path_as(path) do
         bundle_exec_ruby!(bundled_app("source.rb").to_s)
@@ -29,9 +29,9 @@ RSpec.describe "Bundler.with_env helpers" do
     end
 
     it "should return the GEM_PATH present before bundle was activated" do
-      create_file("source.rb", <<-RB)
+      create_file("source.rb", <<-RUBY)
         print Bundler.original_env['GEM_PATH']
-      RB
+      RUBY
       gem_path = ENV["GEM_PATH"] + "#{File::PATH_SEPARATOR}/foo"
       with_gem_path_as(gem_path) do
         bundle_exec_ruby!(bundled_app("source.rb").to_s)
@@ -40,7 +40,7 @@ RSpec.describe "Bundler.with_env helpers" do
     end
 
     it "works with nested bundle exec invocations" do
-      create_file("exe.rb", <<-'RB')
+      create_file("exe.rb", <<-'RUBY')
         count = ARGV.first.to_i
         exit if count < 0
         STDERR.puts "#{count} #{ENV["PATH"].end_with?("#{File::PATH_SEPARATOR}/foo")}"
@@ -48,7 +48,7 @@ RSpec.describe "Bundler.with_env helpers" do
           ENV["PATH"] = "#{ENV["PATH"]}#{File::PATH_SEPARATOR}/foo"
         end
         exec(Gem.ruby, __FILE__, (count - 1).to_s)
-      RB
+      RUBY
       path = `getconf PATH`.strip + File::PATH_SEPARATOR + File.dirname(Gem.ruby)
       with_path_as(path) do
         build_bundler_context
@@ -66,9 +66,9 @@ RSpec.describe "Bundler.with_env helpers" do
       ENV.replace(ENV.to_hash.delete_if {|k, _v| k.start_with?(Bundler::EnvironmentPreserver::BUNDLER_PREFIX) })
 
       original = ruby!('puts ENV.to_a.map {|e| e.join("=") }.sort.join("\n")')
-      create_file("source.rb", <<-RB)
+      create_file("source.rb", <<-RUBY)
         puts Bundler.original_env.to_a.map {|e| e.join("=") }.sort.join("\n")
-      RB
+      RUBY
       bundle_exec_ruby! bundled_app("source.rb")
       expect(out).to eq original
     end
@@ -76,27 +76,27 @@ RSpec.describe "Bundler.with_env helpers" do
 
   shared_examples_for "an unbundling helper" do
     it "should delete BUNDLE_PATH" do
-      create_file("source.rb", <<-RB)
+      create_file("source.rb", <<-RUBY)
         print #{modified_env}.has_key?('BUNDLE_PATH')
-      RB
+      RUBY
       ENV["BUNDLE_PATH"] = "./foo"
       bundle_exec_ruby! bundled_app("source.rb")
       expect(last_command.stdboth).to include "false"
     end
 
     it "should remove '-rbundler/setup' from RUBYOPT" do
-      create_file("source.rb", <<-RB)
+      create_file("source.rb", <<-RUBY)
         print #{modified_env}['RUBYOPT']
-      RB
+      RUBY
       ENV["RUBYOPT"] = "-W2 -rbundler/setup #{ENV["RUBYOPT"]}"
       bundle_exec_ruby! bundled_app("source.rb"), :env => { "BUNDLER_SPEC_DISABLE_DEFAULT_BUNDLER_GEM" => "true" }
       expect(last_command.stdboth).not_to include("-rbundler/setup")
     end
 
     it "should restore RUBYLIB", :ruby_repo do
-      create_file("source.rb", <<-RB)
+      create_file("source.rb", <<-RUBY)
         print #{modified_env}['RUBYLIB']
-      RB
+      RUBY
       ENV["RUBYLIB"] = lib_dir.to_s + File::PATH_SEPARATOR + "/foo"
       ENV["BUNDLER_ORIG_RUBYLIB"] = lib_dir.to_s + File::PATH_SEPARATOR + "/foo-original"
       bundle_exec_ruby! bundled_app("source.rb")
@@ -104,9 +104,9 @@ RSpec.describe "Bundler.with_env helpers" do
     end
 
     it "should restore the original MANPATH" do
-      create_file("source.rb", <<-RB)
+      create_file("source.rb", <<-RUBY)
         print #{modified_env}['MANPATH']
-      RB
+      RUBY
       ENV["MANPATH"] = "/foo"
       ENV["BUNDLER_ORIG_MANPATH"] = "/foo-original"
       bundle_exec_ruby! bundled_app("source.rb")

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -401,11 +401,11 @@ module Gem
           target[k] = v
         when Array
           unless Gem::Deprecate.skip
-            warn <<-eowarn
+            warn <<-EOWARN
 Array values in the parameter to `Gem.paths=` are deprecated.
 Please use a String or nil.
 An Array (#{env.inspect}) was passed in from #{caller[3]}
-            eowarn
+            EOWARN
           end
           target[k] = v.join File::PATH_SEPARATOR
         end

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1961,7 +1961,7 @@ class Gem::Specification < Gem::BasicSpecification
     yaml_initialize coder.tag, coder.map
   end
 
-  eval <<-RB, binding, __FILE__, __LINE__ + 1
+  eval <<-RUBY, binding, __FILE__, __LINE__ + 1
     def set_nil_attributes_to_nil
       #{@@nil_attributes.map {|key| "@#{key} = nil" }.join "; "}
     end
@@ -1971,7 +1971,7 @@ class Gem::Specification < Gem::BasicSpecification
       #{@@non_nil_attributes.map {|key| "@#{key} = #{INITIALIZE_CODE_FOR_DEFAULTS[key]}" }.join ";"}
     end
     private :set_not_nil_attributes_to_default_values
-  RB
+  RUBY
 
   ##
   # Specification constructor. Assigns the default values to the attributes

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -324,19 +324,19 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
 
       if !Gem::Licenses.match?(license)
         suggestions = Gem::Licenses.suggestions(license)
-        message = <<-warning
+        message = <<-WARNING
 license value '#{license}' is invalid.  Use a license identifier from
 http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard license.
-        warning
+        WARNING
         message += "Did you mean #{suggestions.map { |s| "'#{s}'"}.join(', ')}?\n" unless suggestions.nil?
         warning(message)
       end
     end
 
-    warning <<-warning if licenses.empty?
+    warning <<-WARNING if licenses.empty?
 licenses is empty, but is recommended.  Use a license identifier from
 http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard license.
-    warning
+    WARNING
   end
 
   LAZY = '"FIxxxXME" or "TOxxxDO"'.gsub(/xxx/, '')

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -359,7 +359,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     @cmd.options[:previous_version] = Gem::Version.new '2.0.2'
 
     File.open 'History.txt', 'w' do |io|
-      io.puts <<-History_txt
+      io.puts <<-HISTORY_TXT
 # coding: UTF-8
 
 === #{Gem::VERSION} / 2013-03-26
@@ -377,7 +377,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
 
 * Bug fixes:
   * Yet more bugs fixed
-      History_txt
+      HISTORY_TXT
     end
 
     use_ui @ui do

--- a/test/rubygems/test_gem_ext_cmake_builder.rb
+++ b/test/rubygems/test_gem_ext_cmake_builder.rb
@@ -23,11 +23,11 @@ class TestGemExtCmakeBuilder < Gem::TestCase
 
   def test_self_build
     File.open File.join(@ext, 'CMakeLists.txt'), 'w' do |cmakelists|
-      cmakelists.write <<-eo_cmake
+      cmakelists.write <<-EO_CMAKE
 cmake_minimum_required(VERSION 2.6)
 project(self_build NONE)
 install (FILES test.txt DESTINATION bin)
-      eo_cmake
+      EO_CMAKE
     end
 
     FileUtils.touch File.join(@ext, 'test.txt')

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -81,7 +81,7 @@ gems:
   # Generated via:
   #   x = OpenSSL::PKey::DH.new(2048) # wait a while...
   #   x.to_s => pem
-  TEST_KEY_DH2048 = OpenSSL::PKey::DH.new <<-_end_of_pem_
+  TEST_KEY_DH2048 = OpenSSL::PKey::DH.new <<-_END_OF_PEM_
 -----BEGIN DH PARAMETERS-----
 MIIBCAKCAQEA3Ze2EHSfYkZLUn557torAmjBgPsqzbodaRaGZtgK1gEU+9nNJaFV
 G1JKhmGUiEDyIW7idsBpe4sX/Wqjnp48Lr8IeI/SlEzLdoGpf05iRYXC8Cm9o8aM
@@ -90,7 +90,7 @@ cfmVgoSEAo9YLBpzoji2jHkO7Q5IPt4zxbTdlmmGFLc/GO9q7LGHhC+rcMcNTGsM
 NP0fuvVAIB158VnQ0liHSwcl6+9vE1mL0Jo/qEXQxl0+UdKDjaGfTsn6HIrwTnmJ
 PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
 -----END DH PARAMETERS-----
-    _end_of_pem_
+    _END_OF_PEM_
 
   def setup
     @proxies = %w[https_proxy http_proxy HTTP_PROXY http_proxy_user HTTP_PROXY_USER http_proxy_pass HTTP_PROXY_PASS no_proxy NO_PROXY]

--- a/test/rubygems/test_gem_request_set.rb
+++ b/test/rubygems/test_gem_request_set.rb
@@ -396,9 +396,9 @@ ruby "0"
     rs = Gem::RequestSet.new
 
     tf = Tempfile.open 'gem.deps.rb' do |io|
-      io.puts <<-gems_deps_rb
+      io.puts <<-GEMS_DEPS_RB
         gem "#{name}", :git => "#{repository}"
-      gems_deps_rb
+      GEMS_DEPS_RB
 
       io.flush
 
@@ -459,10 +459,10 @@ ruby "0"
     rs = Gem::RequestSet.new
 
     tf = Tempfile.open 'gem.deps.rb' do |io|
-      io.puts <<-gems_deps_rb
+      io.puts <<-GEMS_DEPS_RB
         gem "#{a_name}", :path => "#{a_directory}"
         gem "#{b_name}", :path => "#{b_directory}"
-      gems_deps_rb
+      GEMS_DEPS_RB
 
       io.flush
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3104,10 +3104,10 @@ Please report a bug if this causes problems.
       @a1.validate
     end
 
-    assert_match <<-warning, @ui.error
+    assert_match <<-WARNING, @ui.error
 WARNING:  licenses is empty, but is recommended.  Use a license identifier from
 http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
-    warning
+    WARNING
   end
 
   def test_validate_license_values
@@ -3118,10 +3118,10 @@ http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
       @a1.validate
     end
 
-    assert_match <<-warning, @ui.error
+    assert_match <<-WARNING, @ui.error
 WARNING:  license value 'BSD' is invalid.  Use a license identifier from
 http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
-    warning
+    WARNING
   end
 
   def test_validate_license_values_plus
@@ -3165,14 +3165,14 @@ http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
       @a1.validate
     end
 
-    assert_match <<-warning, @ui.error
+    assert_match <<-WARNING, @ui.error
 WARNING:  license value 'GPL-2.0+ FOO' is invalid.  Use a license identifier from
 http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
-    warning
-    assert_match <<-warning, @ui.error
+    WARNING
+    assert_match <<-WARNING, @ui.error
 WARNING:  license value 'GPL-2.0 FOO' is invalid.  Use a license identifier from
 http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
-    warning
+    WARNING
   end
 
   def test_validate_license_with_invalid_exception
@@ -3183,10 +3183,10 @@ http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
       @a1.validate
     end
 
-    assert_match <<-warning, @ui.error
+    assert_match <<-WARNING, @ui.error
 WARNING:  license value 'GPL-2.0+ WITH Autocofn-exception-2.0' is invalid.  Use a license identifier from
 http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
-    warning
+    WARNING
   end
 
   def test_validate_license_gives_suggestions
@@ -3197,11 +3197,11 @@ http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
       @a1.validate
     end
 
-    assert_match <<-warning, @ui.error
+    assert_match <<-WARNING, @ui.error
 WARNING:  license value 'ruby' is invalid.  Use a license identifier from
 http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
 Did you mean 'Ruby'?
-    warning
+    WARNING
   end
 
   def test_validate_empty_files


### PR DESCRIPTION
# Description:

On another PR, I noticed that while normally we use `RUBY` as the delimiter for heredocs including ruby code, sometimes we use `RB`.

`RUBY` is better so I'm replacing `RB` occurrences with `RUBY`.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
