### PR TITLE
Load rubygems plugins from RUBYLIB during `bundle install` and `bundle update`

### DIFF
--- a/bundler/lib/bundler/installer.rb
+++ b/bundler/lib/bundler/installer.rb
@@ -244,6 +244,7 @@ module Bundler
         end
       end.flatten
       Bundler.rubygems.load_plugin_files(path_plugin_files)
+      Bundler.rubygems.load_env_plugins
     end
 
     def ensure_specs_are_compatible!

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -227,6 +227,10 @@ module Bundler
       Gem.load_plugin_files(files) if Gem.respond_to?(:load_plugin_files)
     end
 
+    def load_env_plugins
+      Gem.load_env_plugins if Gem.respond_to?(:load_env_plugins)
+    end
+
     def ui=(obj)
       Gem::DefaultUserInteraction.ui = obj
     end

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -222,6 +222,18 @@ RSpec.describe "bundle install with gem sources" do
       expect(the_bundle).to include_gems "rack 1.0.0", "activesupport 2.3.5"
     end
 
+    it "loads env plugins" do
+      plugin_msg = "hello from an env plugin!"
+      create_file "plugins/rubygems_plugin.rb", "puts '#{plugin_msg}'"
+      rubylib = ENV["RUBYLIB"].to_s.split(File::PATH_SEPARATOR).unshift(bundled_app("plugins").to_s).join(File::PATH_SEPARATOR)
+      install_gemfile <<-G, :env => { "RUBYLIB" => rubylib }
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rack"
+      G
+
+      expect(last_command.stdboth).to include(plugin_msg)
+    end
+
     describe "with a gem that installs multiple platforms" do
       it "installs gems for the local platform as first choice" do
         skip "version is 1.0, not 1.0.0" if Gem.win_platform?


### PR DESCRIPTION
# Description:
Restore load_env_plugins so that plugins stored in RUBYLIB are loaded by bundler.

# What was the end-user or developer problem that led to this PR?

https://github.com/rubygems/bundler/pull/4954 broke plugins that are loaded by setting RUBYLIB. The comments in the PR make clear that the intention was to augment the set of plugins being loaded, not remove ENV plugins and replace with only plugins in the standard location. This hook does work when loaded by `gem install` because of https://github.com/rubygems/rubygems/blob/0ab446f46556e83a36d9e026acae26468bc08b91/lib/rubygems/gem_runner.rb#L15.

This explains why when rbenv attempts to hook into bundler like in the following link, it doesn't work -- this code is never actually executed during `bundle install`. https://github.com/rbenv/rbenv/blob/0843745be9267de0296de8725c5b7bfcbbb6bddf/rbenv.d/exec/gem-rehash/rubygems_plugin.rb#L14-L35

## What is your fix for the problem, implemented in this PR?

This PR restores the load from environment variables that was erroneously removed in https://github.com/rubygems/bundler/pull/4954

______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
