### PR TITLE
Fixed incorrect man path with ruby installation path

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -123,6 +123,8 @@ module Bundler
       end
 
       man_path  = File.expand_path("../../../man", __FILE__)
+      # man files are located under the share directory with the default gems of bundler
+      man_path = File.expand_path("../../../../../share/man/man1", __FILE__) unless File.directory?(man_path)
       man_pages = Hash[Dir.glob(File.join(man_path, "*")).grep(/.*\.\d*\Z/).collect do |f|
         [File.basename(f, ".*"), f]
       end]

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -122,7 +122,7 @@ module Bundler
       else command = "bundle-#{cli}"
       end
 
-      man_path  = File.expand_path("../../../man", __FILE__)
+      man_path = File.expand_path("../../../man", __FILE__)
       # man files are located under the share directory with the default gems of bundler
       man_path = File.expand_path("../../../../../share/man/man1", __FILE__) unless File.directory?(man_path)
       man_pages = Hash[Dir.glob(File.join(man_path, "*")).grep(/.*\.\d*\Z/).collect do |f|


### PR DESCRIPTION
# Description:

## What was the end-user or developer problem that led to this PR?

See https://bugs.ruby-lang.org/issues/15359

## What is your fix for the problem, implemented in this PR?

I added the workaround for the man path with the default gems.
______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
