### PR TITLE
Make the test suite pass under `umask 077`

### DIFF
--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -17,8 +17,13 @@ class TestGemCommandsBuildCommand < Gem::TestCase
 
     readme_file = File.join(@tempdir, 'README.md')
 
-    File.open readme_file, 'w' do |f|
-      f.write 'My awesome gem'
+    begin
+      umask_orig = File.umask(2)
+      File.open readme_file, 'w' do |f|
+        f.write 'My awesome gem'
+      end
+    ensure
+      File.umask(umask_orig)
     end
 
     @gem = util_spec 'some_gem' do |s|

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -2188,7 +2188,7 @@ gem 'other', version
   end
 
   def mask
-    0100755 & (~File.umask)
+    0100755
   end
 
 end

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3805,12 +3805,17 @@ end
       FileUtils.mkdir_p "test"
       FileUtils.mkdir_p "bin"
 
-      FileUtils.touch File.join("ext", "a", "extconf.rb")
-      FileUtils.touch File.join("lib", "code.rb")
-      FileUtils.touch File.join("test", "suite.rb")
+      begin
+        umask_orig = File.umask(2)
+        FileUtils.touch File.join("ext", "a", "extconf.rb")
+        FileUtils.touch File.join("lib", "code.rb")
+        FileUtils.touch File.join("test", "suite.rb")
 
-      File.open "bin/exec", "w", 0755 do |fp|
-        fp.puts "#!#{Gem.ruby}"
+        File.open "bin/exec", "w", 0755 do |fp|
+          fp.puts "#!#{Gem.ruby}"
+        end
+      ensure
+        File.umask(umask_orig)
       end
     end
   end


### PR DESCRIPTION
Some tests had failed under `umask 077` mode.  As far as I investigated,
there is no actual bug.  All failures were caused by tests that create a
wrong-permission file or expect wrong permission.

This changeset fixes the tests.
