### PR TITLE
Followup to no chdir in git source

### DIFF
--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -167,9 +167,9 @@ module Bundler
             capture_and_filter_stderr(uri, "git #{command}", :chdir => dir.to_s)
           end
 
-          stdout_with_no_credentials = URICredentialsFilter.credential_filtered_string(out, uri)
           raise GitCommandError.new(command_with_no_credentials, path, dir) unless status.success?
-          stdout_with_no_credentials
+
+          URICredentialsFilter.credential_filtered_string(out, uri)
         end
 
         def has_revision_cached?


### PR DESCRIPTION
# Description:

This is a small followup to #3516. In that PR, I stopped changing folders inside the ruby process when running git operations for better thread safety.

After that change, the `in_path` helper name and other methods no longer make sense, since we no longer switch folders inside them.

This PR renames them to better convey what they do, and add a couple of other minor refactorings inside the `git` source.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
