### PR TITLE
Spare some unneeded rescue blocks

### DIFF
--- a/bundler/lib/bundler/cli/exec.rb
+++ b/bundler/lib/bundler/cli/exec.rb
@@ -27,7 +27,7 @@ module Bundler
         if !Bundler.settings[:disable_exec_load] && ruby_shebang?(bin_path)
           return kernel_load(bin_path, *args)
         end
-        kernel_exec(bin_path, *args)
+        Kernel.exec(bin_path, *args)
       else
         # exec using the given command
         kernel_exec(cmd, *args)


### PR DESCRIPTION
# Description:

The `kernel_exec` method wraps `Kernel.exec` with some rescues to make sure that the file we're exec'ing to exists and is executable. In this branch of the code, though, we already used `Bundler.which` to find a proper executable, so those precautions are not necessary.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
