### PR TITLE
Show RSpec filter annoucements when running plain rspec

### DIFF
--- a/bundler/.rspec_parallel
+++ b/bundler/.rspec_parallel
@@ -1,4 +1,3 @@
 --format progress
 --format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec.log
 --require spec_helper
---require support/parallel.rb

--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -23,7 +23,6 @@ require_relative "support/filters"
 require_relative "support/helpers"
 require_relative "support/indexes"
 require_relative "support/matchers"
-require_relative "support/parallel"
 require_relative "support/permissions"
 require_relative "support/platforms"
 require_relative "support/sometimes"
@@ -49,6 +48,8 @@ RSpec.configure do |config|
 
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
+
+  config.silence_filter_announcements = !ENV["TEST_ENV_NUMBER"].nil?
 
   config.disable_monkey_patching!
 

--- a/bundler/spec/support/parallel.rb
+++ b/bundler/spec/support/parallel.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-RSpec.configure do |config|
-  config.silence_filter_announcements = true
-end


### PR DESCRIPTION
I think never showing them was unintentional.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
