### PR TITLE
Remove `builder` gem requirement for `gem regenerate_index`

### DIFF
--- a/dev_gems.rb
+++ b/dev_gems.rb
@@ -1,6 +1,5 @@
 source "https://rubygems.org"
 
-gem "builder", "~> 3.0"
 gem "rdoc", "6.2.0" # 6.2.1 is required > Ruby 2.3
 gem "rake", "~> 13.0"
 gem "minitest", "~> 5.13"

--- a/dev_gems.rb.lock
+++ b/dev_gems.rb.lock
@@ -2,7 +2,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
-    builder (3.2.4)
     docile (1.3.2)
     jaro_winkler (1.5.4)
     jaro_winkler (1.5.4-java)
@@ -40,7 +39,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  builder (~> 3.0)
   minitest (~> 5.13)
   rake (~> 13.0)
   rdoc (= 6.2.0)

--- a/lib/rubygems/indexer.rb
+++ b/lib/rubygems/indexer.rb
@@ -11,11 +11,6 @@ rescue LoadError # this rubygems + old ruby
 else # this rubygems + ruby trunk with bundler
   rescue_exceptions << Bundler::GemfileNotFound
 end
-begin
-  gem 'builder'
-  require 'builder/xchar'
-rescue *rescue_exceptions
-end
 
 ##
 # Top level class for building the gem repository index.
@@ -61,11 +56,6 @@ class Gem::Indexer
     require 'fileutils'
     require 'tmpdir'
     require 'zlib'
-
-    unless defined?(Builder::XChar)
-      raise "Gem::Indexer requires that the XML Builder library be installed:" +
-            "\n\tgem install builder"
-    end
 
     options = { :build_modern => true }.merge options
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1441,13 +1441,7 @@ class Gem::Specification < Gem::BasicSpecification
     # HACK the #to_s is in here because RSpec has an Array of Arrays of
     # Strings for authors.  Need a way to disallow bad values on gemspec
     # generation.  (Probably won't happen.)
-    string = string.to_s
-
-    begin
-      Builder::XChar.encode string
-    rescue NameError, NoMethodError
-      string.to_xs
-    end
+    string.to_s
   end
 
   ##

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -1537,10 +1537,4 @@ begin
 rescue LoadError, Gem::LoadError
 end
 
-begin
-  gem 'builder'
-  require 'builder/xchar'
-rescue LoadError, Gem::LoadError
-end
-
 require 'rubygems/test_utilities'

--- a/test/rubygems/test_gem_commands_generate_index_command.rb
+++ b/test/rubygems/test_gem_commands_generate_index_command.rb
@@ -3,10 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/indexer'
 require 'rubygems/commands/generate_index_command'
 
-unless defined?(Builder::XChar)
-  warn "generate_index tests are being skipped.  Install builder gem."
-end
-
 class TestGemCommandsGenerateIndexCommand < Gem::TestCase
 
   def setup
@@ -83,4 +79,4 @@ class TestGemCommandsGenerateIndexCommand < Gem::TestCase
       @ui.error
   end
 
-end if defined?(Builder::XChar)
+end

--- a/test/rubygems/test_gem_indexer.rb
+++ b/test/rubygems/test_gem_indexer.rb
@@ -2,10 +2,6 @@
 require 'rubygems/test_case'
 require 'rubygems/indexer'
 
-unless defined?(Builder::XChar)
-  warn "Gem::Indexer tests are being skipped.  Install builder gem."
-end
-
 class TestGemIndexer < Gem::TestCase
 
   def setup
@@ -360,4 +356,4 @@ class TestGemIndexer < Gem::TestCase
     refute File.exist?(file), "#{file} exists"
   end
 
-end if defined?(Builder::XChar)
+end

--- a/test/rubygems/test_gem_source.rb
+++ b/test/rubygems/test_gem_source.rb
@@ -55,8 +55,6 @@ class TestGemSource < Gem::TestCase
   end
 
   def test_dependency_resolver_set_file_uri
-    skip 'install builder gem' unless defined? Builder::XChar
-
     Gem::Indexer.new(@tempdir).generate_index
 
     source = Gem::Source.new "file://#{@tempdir}/"


### PR DESCRIPTION
# Description:

This requirement was introduced 14 years ago in 7ce7039b390440754954df5efea619e9f57ef823, and I don't think it's necessary anymore. I made several tests introducing UTF-8 characters in gemspec files and generating indexes out of them, and couldn't find any issues. Gemspec files are read with UTF-8 encoding these days.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
