### PR TITLE
Debug parallel install error

### DIFF
--- a/bundler/lib/bundler/errors.rb
+++ b/bundler/lib/bundler/errors.rb
@@ -56,6 +56,7 @@ module Bundler
   class SudoNotPermittedError < BundlerError; status_code(30); end
   class ThreadCreationError < BundlerError; status_code(33); end
   class APIResponseMismatchError < BundlerError; status_code(34); end
+  class APIResponseInvalidDependenciesError < BundlerError; status_code(35); end
   class GemfileEvalError < GemfileError; end
   class MarshalError < StandardError; end
 

--- a/bundler/lib/bundler/installer/gem_installer.rb
+++ b/bundler/lib/bundler/installer/gem_installer.rb
@@ -23,7 +23,7 @@ module Bundler
       raise
     rescue Errno::ENOSPC
       return false, out_of_space_message
-    rescue StandardError => e
+    rescue Bundler::BundlerError, Gem::InstallError, Bundler::APIResponseInvalidDependenciesError => e
       return false, specific_failure_message(e)
     end
 

--- a/bundler/lib/bundler/installer/gem_installer.rb
+++ b/bundler/lib/bundler/installer/gem_installer.rb
@@ -19,7 +19,7 @@ module Bundler
       Bundler.ui.debug "#{worker}:  #{spec.name} (#{spec.version}) from #{spec.loaded_from}"
       generate_executable_stubs
       return true, post_install_message
-    rescue Bundler::InstallHookError, Bundler::SecurityError, APIResponseMismatchError
+    rescue Bundler::InstallHookError, Bundler::SecurityError, Bundler::APIResponseMismatchError
       raise
     rescue Errno::ENOSPC
       return false, out_of_space_message

--- a/bundler/lib/bundler/installer/parallel_installer.rb
+++ b/bundler/lib/bundler/installer/parallel_installer.rb
@@ -160,11 +160,7 @@ module Bundler
       gem_installer = Bundler::GemInstaller.new(
         spec_install.spec, @installer, @standalone, worker_num, @force
       )
-      success, message = begin
-        gem_installer.install_from_spec
-      rescue RuntimeError => e
-        raise e, "#{e}\n\n#{require_tree_for_spec(spec_install.spec)}"
-      end
+      success, message = gem_installer.install_from_spec
       if success
         spec_install.state = :installed
         spec_install.post_install_message = message unless message.nil?

--- a/bundler/lib/bundler/installer/parallel_installer.rb
+++ b/bundler/lib/bundler/installer/parallel_installer.rb
@@ -99,7 +99,7 @@ module Bundler
         install_serially
       end
 
-      handle_error if @specs.any?(&:failed?)
+      handle_error if failed_specs.any?
       @specs
     ensure
       worker_pool && worker_pool.stop
@@ -131,6 +131,10 @@ module Bundler
     end
 
   private
+
+    def failed_specs
+      @specs.select(&:failed?)
+    end
 
     def install_with_worker
       enqueue_specs
@@ -190,7 +194,7 @@ module Bundler
     end
 
     def handle_error
-      errors = @specs.select(&:failed?).map(&:error)
+      errors = failed_specs.map(&:error)
       if exception = errors.find {|e| e.is_a?(Bundler::BundlerError) }
         raise exception
       end

--- a/bundler/lib/bundler/installer/parallel_installer.rb
+++ b/bundler/lib/bundler/installer/parallel_installer.rb
@@ -194,7 +194,7 @@ module Bundler
       if exception = errors.find {|e| e.is_a?(Bundler::BundlerError) }
         raise exception
       end
-      raise Bundler::InstallError, errors.map(&:to_s).join("\n\n")
+      raise Bundler::InstallError, errors.join("\n\n")
     end
 
     def require_tree_for_spec(spec)

--- a/bundler/lib/bundler/remote_specification.rb
+++ b/bundler/lib/bundler/remote_specification.rb
@@ -50,6 +50,8 @@ module Bundler
     # once the remote gem is downloaded, the backend specification will
     # be swapped out.
     def __swap__(spec)
+      raise APIResponseInvalidDependenciesError unless spec.dependencies.all? {|d| d.is_a?(Gem::Dependency) }
+
       SharedHelpers.ensure_same_dependencies(self, dependencies, spec.dependencies)
       @_remote_specification = spec
     end
@@ -76,6 +78,7 @@ module Bundler
         deps = method_missing(:dependencies)
 
         # allow us to handle when the specs dependencies are an array of array of string
+        # in order to delay the crash to `#__swap__` where it results in a friendlier error
         # see https://github.com/rubygems/bundler/issues/5797
         deps = deps.map {|d| d.is_a?(Gem::Dependency) ? d : Gem::Dependency.new(*d) }
 


### PR DESCRIPTION
# Description:

This is a refactoring PR to make it easier to figure out https://github.com/rubygems/rubygems/issues/3392.

What we currently know is that a `Bundler::InstallError` with empty message is being raised at:

https://github.com/rubygems/rubygems/blob/7a8048a54ae2304c94b99043609ea6497e7c969d/bundler/lib/bundler/installer/parallel_installer.rb#L197

That error is presumably generated by one of the parallel worker installation threads, and since it's not a `Bundler::BundlerError` because in that case it would be raised in the previous line, I believe it's being passed to the parent thread in the catch-all rescue here:

https://github.com/rubygems/rubygems/blob/7a8048a54ae2304c94b99043609ea6497e7c969d/bundler/lib/bundler/installer/gem_installer.rb#L26-L27

I believe this is too much "error swallowing" since it makes it difficult to identify the real culprit of unexpected errors.

So the end goal of this PR is to replace that catch-all rescue with a more concrete list of exceptions without changing any end user behaviour, so that next time the error appears, it will be more apparent what the cause is.

While working on this I added other minor refactorings too.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
