### PR TITLE
Run tests in parallel but with a RSpec-like interface

### DIFF
--- a/.github/workflows/jruby-bundler.yml
+++ b/.github/workflows/jruby-bundler.yml
@@ -27,7 +27,7 @@ jobs:
         working-directory: ./bundler
       - name: Run Test
         run: |
-          bin/parallel_rspec spec --test-options '--tag jruby'
+          bin/parallel_rspec --tag jruby
         working-directory: ./bundler
       - name: Install local bundler
         run: |

--- a/.github/workflows/ubuntu-bundler3.yml
+++ b/.github/workflows/ubuntu-bundler3.yml
@@ -30,7 +30,7 @@ jobs:
         working-directory: ./bundler
       - name: Run Test
         run: |
-          bin/parallel_rspec spec
+          bin/parallel_rspec
         working-directory: ./bundler
       - name: Run Test with realworld
         run: |

--- a/.github/workflows/windows-bundler.yml
+++ b/.github/workflows/windows-bundler.yml
@@ -29,6 +29,6 @@ jobs:
         shell: bash
       - name: Run specs
         run: |
-          bin/parallel_rspec spec
+          bin/parallel_rspec
         working-directory: ./bundler
         shell: bash

--- a/bundler/.rspec_parallel
+++ b/bundler/.rspec_parallel
@@ -1,3 +1,0 @@
---format progress
---format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec.log
---require spec_helper

--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -43,7 +43,7 @@ namespace :spec do
 
   desc "Run the regular spec suite"
   task :regular do
-    sh("bin/parallel_rspec --verbose-rerun-command spec")
+    sh("bin/parallel_rspec")
   end
 
   desc "Run the real-world spec suite"

--- a/bundler/bin/parallel_rspec
+++ b/bundler/bin/parallel_rspec
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative "../spec/support/rubygems_ext"
+require_relative "../tool/turbo_tests/cli"
 
-Spec::Rubygems.gem_load("parallel_tests", "parallel_rspec")
+TurboTests::CLI.new(ARGV).run

--- a/bundler/doc/development/SETUP.md
+++ b/bundler/doc/development/SETUP.md
@@ -26,7 +26,7 @@ To work on Bundler, you'll probably want to do a couple of things:
 
 6. Optionally, you can run the test suite in parallel:
 
-        $ bin/parallel_rspec spec
+        $ bin/parallel_rspec
 
 7. Set up a shell alias to run Bundler from your clone, e.g. a Bash alias ([follow these instructions](https://www.moncefbelyamani.com/create-aliases-in-bash-profile-to-assign-shortcuts-for-common-terminal-commands/) for adding aliases to your `~/.bashrc` profile):
 

--- a/bundler/tool/turbo_tests.rb
+++ b/bundler/tool/turbo_tests.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "open3"
+require "fileutils"
+require "json"
+
+require_relative "turbo_tests/reporter"
+require_relative "turbo_tests/runner"
+require_relative "turbo_tests/json_rows_formatter"
+
+module TurboTests
+  FakeException = Struct.new(:backtrace, :message, :cause)
+  class FakeException
+    def self.from_obj(obj)
+      if obj
+        klass =
+          Class.new(FakeException) do
+            define_singleton_method(:name) do
+              obj["class_name"]
+            end
+          end
+
+        klass.new(
+          obj["backtrace"],
+          obj["message"],
+          FakeException.from_obj(obj["cause"])
+        )
+      end
+    end
+  end
+
+  FakeExecutionResult = Struct.new(:example_skipped?, :pending_message, :status, :pending_fixed?, :exception)
+  class FakeExecutionResult
+    def self.from_obj(obj)
+      new(
+        obj["example_skipped?"],
+        obj["pending_message"],
+        obj["status"].to_sym,
+        obj["pending_fixed?"],
+        FakeException.from_obj(obj["exception"])
+      )
+    end
+  end
+
+  FakeExample = Struct.new(:execution_result, :location, :full_description, :metadata, :location_rerun_argument)
+  class FakeExample
+    def self.from_obj(obj)
+      metadata = obj["metadata"]
+
+      metadata["shared_group_inclusion_backtrace"].map! do |frame|
+        RSpec::Core::SharedExampleGroupInclusionStackFrame.new(
+          frame["shared_group_name"],
+          frame["inclusion_location"]
+        )
+      end
+
+      metadata[:shared_group_inclusion_backtrace] = metadata.delete("shared_group_inclusion_backtrace")
+
+      new(
+        FakeExecutionResult.from_obj(obj["execution_result"]),
+        obj["location"],
+        obj["full_description"],
+        metadata,
+        obj["location_rerun_argument"],
+      )
+    end
+
+    def notification
+      RSpec::Core::Notifications::ExampleNotification.for(
+        self
+      )
+    end
+  end
+end

--- a/bundler/tool/turbo_tests/cli.rb
+++ b/bundler/tool/turbo_tests/cli.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require_relative "../turbo_tests"
+
+require "optparse"
+
+module TurboTests
+  class CLI
+    def initialize(argv)
+      @argv = argv
+    end
+
+    def run
+      requires = []
+      formatters = []
+      tags = []
+      verbose = false
+      fail_fast = nil
+
+      OptionParser.new do |opts|
+        opts.on("-r", "--require PATH", "Require a file.") do |filename|
+          requires << filename
+        end
+
+        opts.on("-f", "--format FORMATTER", "Choose a formatter.") do |name|
+          formatters << {
+            :name => name,
+            :outputs => [],
+          }
+        end
+
+        opts.on("-t", "--tag TAG", "Run examples with the specified tag.") do |tag|
+          tags << tag
+        end
+
+        opts.on("-o", "--out FILE", "Write output to a file instead of $stdout") do |filename|
+          if formatters.empty?
+            formatters << {
+              :name => "progress",
+              :outputs => [],
+            }
+          end
+          formatters.last[:outputs] << filename
+        end
+
+        opts.on("-v", "--verbose", "More output") do
+          verbose = true
+        end
+
+        opts.on("--fail-fast=[N]") do |n|
+          n = begin
+                Integer(n)
+              rescue StandardError
+                nil
+              end
+          fail_fast = n.nil? || n < 1 ? 1 : n
+        end
+      end.parse!(@argv)
+
+      requires.each {|f| require(f) }
+
+      if formatters.empty?
+        formatters << {
+          :name => "progress",
+          :outputs => [],
+        }
+      end
+
+      formatters.each do |formatter|
+        if formatter[:outputs].empty?
+          formatter[:outputs] << "-"
+        end
+      end
+
+      exit TurboTests::Runner.run(
+        :formatters => formatters,
+        :tags => tags,
+        :files => @argv.empty? ? ["spec"] : @argv,
+        :verbose => verbose,
+        :fail_fast => fail_fast
+      )
+    end
+  end
+end

--- a/bundler/tool/turbo_tests/json_rows_formatter.rb
+++ b/bundler/tool/turbo_tests/json_rows_formatter.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "json"
+require "rspec/core"
+require "rspec/core/formatters"
+require "rspec/core/notifications"
+
+module RSpecExt
+  def handle_interrupt
+    if RSpec.world.wants_to_quit
+      exit!(1)
+    else
+      RSpec.world.wants_to_quit = true
+    end
+  end
+end
+
+RSpec::Core::Runner.singleton_class.prepend(RSpecExt)
+
+module TurboTests
+  # An RSpec formatter used for each subprocess during parallel test execution
+  class JsonRowsFormatter
+    RSpec::Core::Formatters.register(
+      self,
+      :close,
+      :example_failed,
+      :example_passed,
+      :example_pending,
+      :seed
+    )
+
+    attr_reader :output
+
+    def initialize(output)
+      @output = output
+    end
+
+    def example_passed(notification)
+      output_row(
+        "type" => :example_passed,
+        "example" => example_to_json(notification.example)
+      )
+    end
+
+    def example_pending(notification)
+      output_row(
+        "type" => :example_pending,
+        "example" => example_to_json(notification.example)
+      )
+    end
+
+    def example_failed(notification)
+      output_row(
+        "type" => :example_failed,
+        "example" => example_to_json(notification.example)
+      )
+    end
+
+    def seed(notification)
+      output_row(
+        "type" => :seed,
+        "seed" => notification.seed,
+      )
+    end
+
+    def close(notification)
+      output_row(
+        "type" => :close,
+      )
+    end
+
+  private
+
+    def exception_to_json(exception)
+      if exception
+        {
+          "class_name" => exception.class.name.to_s,
+          "backtrace" => exception.backtrace,
+          "message" => exception.message,
+          "cause" => exception_to_json(exception.cause),
+        }
+      end
+    end
+
+    def execution_result_to_json(result)
+      {
+        "example_skipped?" => result.example_skipped?,
+        "pending_message" => result.pending_message,
+        "status" => result.status,
+        "pending_fixed?" => result.pending_fixed?,
+        "exception" => exception_to_json(result.exception),
+      }
+    end
+
+    def stack_frame_to_json(frame)
+      {
+        "shared_group_name" => frame.shared_group_name,
+        "inclusion_location" => frame.inclusion_location,
+      }
+    end
+
+    def example_to_json(example)
+      {
+        "execution_result" => execution_result_to_json(example.execution_result),
+        "location" => example.location,
+        "full_description" => example.full_description,
+        "metadata" => {
+          "shared_group_inclusion_backtrace" =>
+            example.metadata[:shared_group_inclusion_backtrace].map {|frame| stack_frame_to_json(frame) },
+        },
+        "location_rerun_argument" => example.location_rerun_argument,
+      }
+    end
+
+    def output_row(obj)
+      output.puts ENV["RSPEC_FORMATTER_OUTPUT_ID"] + obj.to_json
+    end
+  end
+end

--- a/bundler/tool/turbo_tests/reporter.rb
+++ b/bundler/tool/turbo_tests/reporter.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module TurboTests
+  class Reporter
+    def self.from_config(formatter_config, start_time)
+      reporter = new(start_time)
+
+      formatter_config.each do |config|
+        name, outputs = config.values_at(:name, :outputs)
+
+        outputs.map! do |filename|
+          filename == "-" ? STDOUT : File.open(filename, "w")
+        end
+
+        reporter.add(name, outputs)
+      end
+
+      reporter
+    end
+
+    attr_reader :pending_examples
+    attr_reader :failed_examples
+
+    def initialize(start_time)
+      @formatters = []
+      @pending_examples = []
+      @failed_examples = []
+      @all_examples = []
+      @start_time = start_time
+    end
+
+    def add(name, outputs)
+      outputs.each do |output|
+        formatter_class =
+          case name
+          when "p", "progress"
+            RSpec::Core::Formatters::ProgressFormatter
+          else
+            Kernel.const_get(name)
+          end
+
+        @formatters << formatter_class.new(output)
+      end
+    end
+
+    def example_passed(example)
+      delegate_to_formatters(:example_passed, example.notification)
+
+      @all_examples << example
+    end
+
+    def example_pending(example)
+      delegate_to_formatters(:example_pending, example.notification)
+
+      @all_examples << example
+      @pending_examples << example
+    end
+
+    def example_failed(example)
+      delegate_to_formatters(:example_failed, example.notification)
+
+      @all_examples << example
+      @failed_examples << example
+    end
+
+    def finish
+      end_time = Time.now
+
+      delegate_to_formatters(:start_dump,
+        RSpec::Core::Notifications::NullNotification)
+      delegate_to_formatters(:dump_pending,
+        RSpec::Core::Notifications::ExamplesNotification.new(
+          self
+        ))
+      delegate_to_formatters(:dump_failures,
+        RSpec::Core::Notifications::ExamplesNotification.new(
+          self
+        ))
+      delegate_to_formatters(:dump_summary,
+        RSpec::Core::Notifications::SummaryNotification.new(
+          end_time - @start_time,
+          @all_examples,
+          @failed_examples,
+          @pending_examples,
+          0,
+          0
+        ))
+      delegate_to_formatters(:close,
+        RSpec::Core::Notifications::NullNotification)
+    end
+
+  protected
+
+    def delegate_to_formatters(method, *args)
+      @formatters.each do |formatter|
+        formatter.send(method, *args) if formatter.respond_to?(method)
+      end
+    end
+  end
+end

--- a/bundler/tool/turbo_tests/runner.rb
+++ b/bundler/tool/turbo_tests/runner.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+require "json"
+
+require "parallel_tests/rspec/runner"
+
+module TurboTests
+  class Runner
+    def self.run(opts = {})
+      files = opts[:files]
+      formatters = opts[:formatters]
+      tags = opts[:tags]
+      start_time = opts.fetch(:start_time) { Time.now }
+      verbose = opts.fetch(:verbose, false)
+      fail_fast = opts.fetch(:fail_fast, nil)
+
+      reporter = Reporter.from_config(formatters, start_time)
+
+      new(
+        :reporter => reporter,
+        :files => files,
+        :tags => tags,
+        :verbose => verbose,
+        :fail_fast => fail_fast
+      ).run
+    end
+
+    def initialize(opts)
+      @reporter = opts[:reporter]
+      @files = opts[:files]
+      @tags = opts[:tags]
+      @verbose = opts[:verbose]
+      @fail_fast = opts[:fail_fast]
+      @failure_count = 0
+      @runtime_log = "tmp/parallel_runtime_rspec.log"
+
+      @messages = Queue.new
+      @threads = []
+    end
+
+    def run
+      @num_processes = ParallelTests.determine_number_of_processes(nil)
+
+      tests_in_groups =
+        ParallelTests::RSpec::Runner.tests_in_groups(
+          @files,
+          @num_processes,
+          :runtime_log => @runtime_log
+        )
+
+      tests_in_groups.each_with_index do |tests, process_id|
+        start_regular_subprocess(tests, process_id + 1)
+      end
+
+      handle_messages
+
+      @reporter.finish
+
+      @threads.each(&:join)
+
+      @reporter.failed_examples.empty?
+    end
+
+  protected
+
+    def start_regular_subprocess(tests, process_id)
+      start_subprocess(
+        { "TEST_ENV_NUMBER" => process_id.to_s },
+        @tags.map {|tag| "--tag=#{tag}" },
+        tests,
+        process_id
+      )
+    end
+
+    def start_subprocess(env, extra_args, tests, process_id)
+      if tests.empty?
+        @messages << {
+          "type" => "exit",
+          "process_id" => process_id,
+        }
+      else
+        require "securerandom"
+        env["RSPEC_FORMATTER_OUTPUT_ID"] = SecureRandom.uuid
+        env["RUBYOPT"] = "-I#{File.expand_path("..", __dir__)}"
+
+        command_name = Gem.win_platform? ? [Gem.ruby, "bin/rspec"] : "bin/rspec"
+
+        command = [
+          *command_name,
+          *extra_args,
+          "--format", "ParallelTests::RSpec::RuntimeLogger",
+          "--out", @runtime_log,
+          "--format", "TurboTests::JsonRowsFormatter",
+          *tests
+        ]
+
+        if @verbose
+          command_str = [
+            env.map {|k, v| "#{k}=#{v}" }.join(" "),
+            command.join(" "),
+          ].select {|x| x.size > 0 }.join(" ")
+
+          STDOUT.puts "Process #{process_id}: #{command_str}"
+        end
+
+        _stdin, stdout, stderr, _wait_thr = Open3.popen3(env, *command)
+
+        @threads <<
+          Thread.new do
+            require "json"
+            stdout.each_line do |line|
+              result = line.split(env["RSPEC_FORMATTER_OUTPUT_ID"])
+
+              output = result.shift
+              STDOUT.print(output) unless output.empty?
+
+              message = result.shift
+              next unless message
+
+              message = JSON.parse(message)
+              message["process_id"] = process_id
+              @messages << message
+            end
+
+            @messages << { "type" => "exit", "process_id" => process_id }
+          end
+
+        @threads << start_copy_thread(stderr, STDERR)
+      end
+    end
+
+    def start_copy_thread(src, dst)
+      Thread.new do
+        loop do
+          begin
+            msg = src.readpartial(4096)
+          rescue EOFError
+            break
+          else
+            dst.write(msg)
+          end
+        end
+      end
+    end
+
+    def handle_messages
+      exited = 0
+
+      loop do
+        message = @messages.pop
+        case message["type"]
+        when "example_passed"
+          example = FakeExample.from_obj(message["example"])
+          @reporter.example_passed(example)
+        when "example_pending"
+          example = FakeExample.from_obj(message["example"])
+          @reporter.example_pending(example)
+        when "example_failed"
+          example = FakeExample.from_obj(message["example"])
+          @reporter.example_failed(example)
+          @failure_count += 1
+          if fail_fast_met
+            @threads.each(&:kill)
+            break
+          end
+        when "seed"
+        when "close"
+        when "exit"
+          exited += 1
+          if exited == @num_processes
+            break
+          end
+        else
+          warn("Unhandled message in main process: #{message}")
+        end
+      end
+    rescue Interrupt
+    end
+
+    def fail_fast_met
+      !@fail_fast.nil? && @fail_fast >= @failure_count
+    end
+  end
+end


### PR DESCRIPTION
# Description

## The problem

The current `parallel_rspec` script provided by `parallel_tests` has several issues:

### * Can't be run without arguments.

Unlike `rspec`, it doesn't just run by default, you need to always specify files or folders to run.  Instead, it should default to run all specs.

### * Hard to use interface.

To run only specs with a specific tag, you have to do the cumbersome `bin/parallel_rspec spec --test-options '--tag jruby'`, instead of just `bin/parallel_rspec --tag jruby`.

### * Can't be interrupted in a useful way.

Hitting `Ctrl-C` during a parallel_tests run aborts the process, but doesn't show any information about the current failures. Many times I make some changes and want to double check what they break. Without this, I'm down to either run the parallel suite completely, or manually specify `--fail-fast` in the cumbersome way specified in the previous bullet point. I'm not sure if this happens for everybody but it happens for me [and other people](https://github.com/grosser/parallel_tests/issues/385) and it's very annoying.

### * Randomly crashes on ruby 2.7 under Windows.

We keep getting a [random but very frequent crash](https://github.com/grosser/parallel_tests/issues/705), and I can't figure out why it's happening or how to prevent it. The rewrite works consistently and thus allows our tests to pass consistently on Windows + 2.7.

### * The test output is messy.

The output of all processes is interleaved, and not combined, leading to some weird test output. On a green test run it could be considered just a matter of taste, but when there are a lot of test failures, having them all reported together at the end of the output is what you want. Specially in CI, having to scroll through all the output looking for failures is annoying,specially on Windows where we also have lots of pending tests.

## The solution

This implements a simple runner on top of `parallel_tests` that behaves just like plain `rspec` and solves all of these problems. The idea is to get the exact same CLI interface provided by `rspec`, but that runs in parallel.

The implementation adds a formatter that prints json rows with tests results, a reporter that combines output from all processes into a unified report, and a runner that splits the tests in groups using the json rows formatter, and syncronizes the output from them passing it onto the reporter.

The initial code and idea has been adapted from [discourse "turbo_tests"](https://github.com/discourse/discourse/tree/master/lib/turbo_tests), kudos to them :purple_heart:. I only adapted it to our needs (multiple rubies support, Windows support, and so on). I found out about this idea through [this parallel_tests issue](https://github.com/grosser/parallel_tests/issues/708).

## Results

Regarding the Ctrl-C issue, compare:

<details>
<summary>An aborted test run with the new runner</summary>

```shell
$ bin/parallel_rspec spec/
Using recorded test runtime
.........................................................................................................F......................................................................................................................................................................................................F......F...................................................................................F.................................*............................................................................................................................^C

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Bundler.setup with gemified standard libraries default gem activation activates newer versions of did_you_mean
     # No reason given
     # ./spec/runtime/setup_spec.rb:1293

nil versions are discouraged and will be deprecated in Rubygems 4

Failures:

  1) bundle lock properly adds platforms when platform requirements come from different dependencies
     Failure/Error: expect(bundled_app_lock).to eq("BOO")
     
       expected: "BOO"
            got: #<Pathname:/home/deivid/Code/rubygems/bundler/tmp/2/bundled_app/Gemfile.lock>
     
       (compared using ==)
     
       Diff:
       @@ -1,2 +1,2 @@
       -"BOO"
       +#<Pathname:/home/deivid/Code/rubygems/bundler/tmp/2/bundled_app/Gemfile.lock>
     
     
       Commands:
       $ gem build ffi
       Successfully built RubyGem
         Name: ffi
         Version: 1.9.14
         File: ffi-1.9.14.gem
       # $? => 0
     
       $ gem build ffi
       Successfully built RubyGem
         Name: ffi
         Version: 1.9.14
         File: ffi-1.9.14-x86-mingw32.gem
       # $? => 0
     
       $ gem build gssapi
       Successfully built RubyGem
         Name: gssapi
         Version: 0.1
         File: gssapi-0.1.gem
       # $? => 0
     
       $ gem build gssapi
       Successfully built RubyGem
         Name: gssapi
         Version: 0.2
         File: gssapi-0.2.gem
       # $? => 0
     
       $ gem build gssapi
       Successfully built RubyGem
         Name: gssapi
         Version: 0.3
         File: gssapi-0.3.gem
       # $? => 0
     
       $ gem build gssapi
       Successfully built RubyGem
         Name: gssapi
         Version: 1.2.0
         File: gssapi-1.2.0.gem
       WARNING:  open-ended dependency on ffi (>= 1.0.1) is not recommended
         if ffi is semantically versioned, use:
           add_runtime_dependency 'ffi', '~> 1.0', '>= 1.0.1'
       WARNING:  See https://guides.rubygems.org/specification-reference/ for help
       # $? => 0
     
       $ gem build mixlib-shellout
       Successfully built RubyGem
         Name: mixlib-shellout
         Version: 2.2.6
         File: mixlib-shellout-2.2.6.gem
       # $? => 0
     
       $ gem build mixlib-shellout
       Successfully built RubyGem
         Name: mixlib-shellout
         Version: 2.2.6
         File: mixlib-shellout-2.2.6-universal-mingw32.gem
       # $? => 0
     
       $ gem build win32-process
       Successfully built RubyGem
         Name: win32-process
         Version: 0.8.3
         File: win32-process-0.8.3.gem
       WARNING:  open-ended dependency on ffi (>= 1.0.0) is not recommended
         if ffi is semantically versioned, use:
           add_runtime_dependency 'ffi', '~> 1.0', '>= 1.0.0'
       WARNING:  See https://guides.rubygems.org/specification-reference/ for help
       # $? => 0
     
       $ gem build win32-process
       Successfully built RubyGem
         Name: win32-process
         Version: 0.8.2
         File: win32-process-0.8.2.gem
       WARNING:  open-ended dependency on ffi (>= 1.0.0) is not recommended
         if ffi is semantically versioned, use:
           add_runtime_dependency 'ffi', '~> 1.0', '>= 1.0.0'
       WARNING:  See https://guides.rubygems.org/specification-reference/ for help
       # $? => 0
     
       $ gem build win32-process
       Successfully built RubyGem
         Name: win32-process
         Version: 0.8.1
         File: win32-process-0.8.1.gem
       WARNING:  open-ended dependency on ffi (>= 1.0.0) is not recommended
         if ffi is semantically versioned, use:
           add_runtime_dependency 'ffi', '~> 1.0', '>= 1.0.0'
       WARNING:  See https://guides.rubygems.org/specification-reference/ for help
       # $? => 0
     
       $ gem build win32-process
       Successfully built RubyGem
         Name: win32-process
         Version: 0.8.0
         File: win32-process-0.8.0.gem
       WARNING:  open-ended dependency on ffi (>= 1.0.0) is not recommended
         if ffi is semantically versioned, use:
           add_runtime_dependency 'ffi', '~> 1.0', '>= 1.0.0'
       WARNING:  See https://guides.rubygems.org/specification-reference/ for help
       # $? => 0
     
       $ gem generate_index
       Generating Marshal quick index gemspecs for 13 gems
       .............
       Complete
       Generated Marshal quick index gemspecs: 0.009s
       Generating specs index
       Generated specs index: 0.001s
       Generating latest specs index
       Generated latest specs index: 0.000s
       Generating prerelease specs index
       Generated prerelease specs index: 0.000s
       Compressing indices
       Compressed indices: 0.005s
       # $? => 0
     
       $  /home/deivid/.rbenv/versions/2.7.1/bin/ruby -I/home/deivid/Code/rubygems/bundler/lib:/home/deivid/Code/rubygems/bundler/spec -rsupport/hax -rsupport/artifice/fail /home/deivid/Code/rubygems/bundler/exe/bundle lock
       Fetching source index from file:///home/deivid/Code/rubygems/bundler/tmp/2/gems/remote4/
       Resolving dependencies...
       Writing lockfile to /home/deivid/Code/rubygems/bundler/tmp/2/bundled_app/Gemfile.lock
       # $? => 0
     # ./spec/support/matchers.rb:217:in `lockfile_should_be'
     # ./spec/commands/lock_spec.rb:293:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:112:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:112:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:79:in `block (2 levels) in <top (required)>'
     # ./spec/support/rubygems_ext.rb:77:in `load'
     # ./spec/support/rubygems_ext.rb:77:in `gem_load_and_activate'
     # ./spec/support/rubygems_ext.rb:20:in `gem_load'

  2) Bundler.setup when BUNDLED WITH is older does not change the lock
     Failure/Error: expect(bundled_app_lock).to eq("BOO")
     
       expected: "BOO"
            got: #<Pathname:/home/deivid/Code/rubygems/bundler/tmp/3/bundled_app/Gemfile.lock>
     
       (compared using ==)
     
       Diff:
       @@ -1,2 +1,2 @@
       -"BOO"
       +#<Pathname:/home/deivid/Code/rubygems/bundler/tmp/3/bundled_app/Gemfile.lock>
     
     
       Commands:
       $  /home/deivid/.rbenv/versions/2.7.1/bin/ruby -I/home/deivid/Code/rubygems/bundler/lib:/home/deivid/Code/rubygems/bundler/spec -rsupport/hax -rsupport/artifice/fail /home/deivid/Code/rubygems/bundler/exe/bundle install --retry 0
       Fetching source index from file:///home/deivid/Code/rubygems/bundler/tmp/3/gems/remote1/
       Resolving dependencies...
       Using bundler 2.2.0.dev
       Fetching rack 1.0.0
       Installing rack 1.0.0
       Bundle complete! 1 Gemfile dependency, 2 gems now installed.
       Use `bundle info [gemname]` to see where a bundled gem is installed.
       Post-install message from rack:
       Rack's post install message
       # $? => 0
     
       $ /home/deivid/.rbenv/versions/2.7.1/bin/ruby -I/home/deivid/Code/rubygems/bundler/lib -w -e require\ \'/home/deivid/Code/rubygems/bundler/lib/bundler/setup\'
       # $? => 0
     # ./spec/support/matchers.rb:217:in `lockfile_should_be'
     # ./spec/runtime/setup_spec.rb:1112:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:112:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:112:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:79:in `block (2 levels) in <top (required)>'
     # ./spec/support/rubygems_ext.rb:77:in `load'
     # ./spec/support/rubygems_ext.rb:77:in `gem_load_and_activate'
     # ./spec/support/rubygems_ext.rb:20:in `gem_load'

  3) Bundler.setup when BUNDLED WITH is not present does not change the lock
     Failure/Error: expect(bundled_app_lock).to eq("BOO")
     
       expected: "BOO"
            got: #<Pathname:/home/deivid/Code/rubygems/bundler/tmp/3/bundled_app/Gemfile.lock>
     
       (compared using ==)
     
       Diff:
       @@ -1,2 +1,2 @@
       -"BOO"
       +#<Pathname:/home/deivid/Code/rubygems/bundler/tmp/3/bundled_app/Gemfile.lock>
     
     
       Commands:
       $  /home/deivid/.rbenv/versions/2.7.1/bin/ruby -I/home/deivid/Code/rubygems/bundler/lib:/home/deivid/Code/rubygems/bundler/spec -rsupport/hax -rsupport/artifice/fail /home/deivid/Code/rubygems/bundler/exe/bundle install --retry 0
       Fetching source index from file:///home/deivid/Code/rubygems/bundler/tmp/3/gems/remote1/
       Resolving dependencies...
       Using bundler 2.2.0.dev
       Fetching rack 1.0.0
       Installing rack 1.0.0
       Bundle complete! 1 Gemfile dependency, 2 gems now installed.
       Use `bundle info [gemname]` to see where a bundled gem is installed.
       Post-install message from rack:
       Rack's post install message
       # $? => 0
     
       $ /home/deivid/.rbenv/versions/2.7.1/bin/ruby -I/home/deivid/Code/rubygems/bundler/lib -w -e require\ \'/home/deivid/Code/rubygems/bundler/lib/bundler/setup\'
       # $? => 0
     # ./spec/support/matchers.rb:217:in `lockfile_should_be'
     # ./spec/runtime/setup_spec.rb:1094:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:112:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:112:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:79:in `block (2 levels) in <top (required)>'
     # ./spec/support/rubygems_ext.rb:77:in `load'
     # ./spec/support/rubygems_ext.rb:77:in `gem_load_and_activate'
     # ./spec/support/rubygems_ext.rb:20:in `gem_load'

  4) Bundler.setup when BUNDLED WITH is newer does not change the lock or warn
     Failure/Error: expect(bundled_app_lock).to eq("BOO")
     
       expected: "BOO"
            got: #<Pathname:/home/deivid/Code/rubygems/bundler/tmp/3/bundled_app/Gemfile.lock>
     
       (compared using ==)
     
       Diff:
       @@ -1,2 +1,2 @@
       -"BOO"
       +#<Pathname:/home/deivid/Code/rubygems/bundler/tmp/3/bundled_app/Gemfile.lock>
     
     
       Commands:
       $  /home/deivid/.rbenv/versions/2.7.1/bin/ruby -I/home/deivid/Code/rubygems/bundler/lib:/home/deivid/Code/rubygems/bundler/spec -rsupport/hax -rsupport/artifice/fail /home/deivid/Code/rubygems/bundler/exe/bundle install --retry 0
       Fetching source index from file:///home/deivid/Code/rubygems/bundler/tmp/3/gems/remote1/
       Resolving dependencies...
       Using bundler 2.2.0.dev
       Fetching rack 1.0.0
       Installing rack 1.0.0
       Bundle complete! 1 Gemfile dependency, 2 gems now installed.
       Use `bundle info [gemname]` to see where a bundled gem is installed.
       Post-install message from rack:
       Rack's post install message
       # $? => 0
     
       $ /home/deivid/.rbenv/versions/2.7.1/bin/ruby -I/home/deivid/Code/rubygems/bundler/lib -w -e require\ \'/home/deivid/Code/rubygems/bundler/lib/bundler/setup\'
       # $? => 0
     # ./spec/support/matchers.rb:217:in `lockfile_should_be'
     # ./spec/runtime/setup_spec.rb:1104:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:112:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:112:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:79:in `block (2 levels) in <top (required)>'
     # ./spec/support/rubygems_ext.rb:77:in `load'
     # ./spec/support/rubygems_ext.rb:77:in `gem_load_and_activate'
     # ./spec/support/rubygems_ext.rb:20:in `gem_load'

Finished in 1 minute 18.28 seconds (files took 0 seconds to load)
554 examples, 4 failures, 1 pending

Failed examples:

rspec ./spec/commands/lock_spec.rb:255 # bundle lock properly adds platforms when platform requirements come from different dependencies
rspec ./spec/runtime/setup_spec.rb:1109 # Bundler.setup when BUNDLED WITH is older does not change the lock
rspec ./spec/runtime/setup_spec.rb:1091 # Bundler.setup when BUNDLED WITH is not present does not change the lock
rspec ./spec/runtime/setup_spec.rb:1099 # Bundler.setup when BUNDLED WITH is newer does not change the lock or warn
```
</details>

vs

<details>
<summary>An aborted test run with the old runner</summary>

```shell
$ bin/parallel_rspec spec/
8 processes for 164 specs, ~ 20 specs per process
.....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................F...........................................................................................................F..........F.........F..................................................................................................................^C
RSpec is shutting down and will print the summary report... Interrupt again to force quit.
RSpec is shutting down and will print the summary report... Interrupt again to force quit.

RSpec is shutting down and will print the summary report... Interrupt again to force quit.
RSpec is shutting down and will print the summary report... Interrupt again to force quit.



RSpec is shutting down and will print the summary report... Interrupt again to force quit.
RSpec is shutting down and will print the summary report... Interrupt again to force quit.

RSpec is shutting down and will print the summary report... Interrupt again to force quit.


RSpec is shutting down and will print the summary report... Interrupt again to force quit.
F

Retried examples: 0

#<Thread:0x000055cbb75ed070 /home/deivid/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/parallel_tests-2.32.0/lib/parallel_tests/cli.rb:36 run> terminated with exception (report_on_exception is true):
Traceback (most recent call last):
	6: from /home/deivid/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/parallel_tests-2.32.0/lib/parallel_tests/cli.rb:36:in `block in handle_interrupt'
	5: from /home/deivid/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/parallel_tests-2.32.0/lib/parallel_tests/cli.rb:36:in `times'
	4: from /home/deivid/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/parallel_tests-2.32.0/lib/parallel_tests/cli.rb:36:in `block (2 levels) in handle_interrupt'
	3: from /home/deivid/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/parallel_tests-2.32.0/lib/parallel_tests.rb:47:in `stop_all_processes'
	2: from /home/deivid/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/parallel_tests-2.32.0/lib/parallel_tests.rb:47:in `each'
	1: from /home/deivid/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/parallel_tests-2.32.0/lib/parallel_tests.rb:47:in `block in stop_all_processes'
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/parallel_tests-2.32.0/lib/parallel_tests.rb:47:in `kill': No such process (Errno::ESRCH)



Took 17 seconds
Tests Failed
```
</details>

Or regarding the interleaved output, compare:

<details>
<summary>A green test run output with current parallel_rspec</summary>

```shell
$ bin/parallel_rspec spec/
Using recorded test runtime
8 processes for 164 specs, ~ 20 specs per process
................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................*............................................................................................................................................................................................................................................................................................................................................................................................................................................**.............................................................................**.........................................................................................................................................................................................................................................................................

Retried examples: 0


Finished in 9 minutes 16 seconds (files took 1.27 seconds to load)
292 examples, 0 failures

................................................................................................................................................................

Retried examples: 0


Finished in 10 minutes 4 seconds (files took 0.93997 seconds to load)
392 examples, 0 failures

....................................................................................................

Retried examples: 0


Finished in 10 minutes 27 seconds (files took 1.15 seconds to load)
349 examples, 0 failures

.........................................

Retried examples: 0


Pending: (Failures listed here are expected and do not affect your suite's status)

  1) bundle exec `load`ing a ruby file instead of `exec`ing regarding $0 and __FILE__ when the path is relative with a leading ./ relative paths with ./ have absolute __FILE__
     # Not yet implemented
     # ./spec/commands/exec_spec.rb:797


Finished in 10 minutes 36 seconds (files took 1.19 seconds to load)
538 examples, 0 failures, 1 pending

.............

Retried examples: 0


Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Bundler.setup with gemified standard libraries default gem activation activates newer versions of bundler
     # No reason given
     # ./spec/runtime/setup_spec.rb:1293

  2) Bundler.setup with gemified standard libraries default gem activation activates older versions of bundler
     # No reason given
     # ./spec/runtime/setup_spec.rb:1308

  3) Bundler.setup with gemified standard libraries default gem activation activates newer versions of did_you_mean
     # No reason given
     # ./spec/runtime/setup_spec.rb:1293

  4) Bundler.setup with gemified standard libraries default gem activation activates older versions of did_you_mean
     # No reason given
     # ./spec/runtime/setup_spec.rb:1308


Finished in 10 minutes 39 seconds (files took 1.49 seconds to load)
436 examples, 0 failures, 4 pending

................................................................................................

Retried examples: 0


Finished in 11 minutes 7 seconds (files took 0.87856 seconds to load)
285 examples, 0 failures

............................................................

Retried examples: 0


Finished in 11 minutes 18 seconds (files took 0.8849 seconds to load)
237 examples, 0 failures

....

Retried examples: 0


Finished in 11 minutes 22 seconds (files took 1.18 seconds to load)
320 examples, 0 failures


2849 examples, 0 failures, 5 pendings

Took 683 seconds (11:23)
```
</details>

vs

<details>
<summary>A green test run output with the new runner</summary>

```shell
$ bin/parallel_rspec spec/
Using recorded test runtime
..............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................*..................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................*......................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................*..............................................................................................................................*...........................................................................*.............................................................................................................................................................................................................................................................................................................................................................................................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) bundle exec `load`ing a ruby file instead of `exec`ing regarding $0 and __FILE__ when the path is relative with a leading ./ relative paths with ./ have absolute __FILE__
     # Not yet implemented
     # ./spec/commands/exec_spec.rb:797

  2) Bundler.setup with gemified standard libraries default gem activation activates newer versions of did_you_mean
     # No reason given
     # ./spec/runtime/setup_spec.rb:1293

  3) Bundler.setup with gemified standard libraries default gem activation activates older versions of bundler
     # No reason given
     # ./spec/runtime/setup_spec.rb:1308

  4) Bundler.setup with gemified standard libraries default gem activation activates newer versions of bundler
     # No reason given
     # ./spec/runtime/setup_spec.rb:1293

  5) Bundler.setup with gemified standard libraries default gem activation activates older versions of did_you_mean
     # No reason given
     # ./spec/runtime/setup_spec.rb:1308


Finished in 11 minutes 25 seconds (files took 0 seconds to load)
2849 examples, 0 failures, 5 pending
```
</details>

## Future work

I wanted to open this PR to present the work and to accelerate #3397, but as follow up work, I would:

* Extract the code to a gem.
* Remove the `parallel_tests` dependency, since it's currently only used for finding the number of processors, for the "test times" formatter, and for splitting the tests into groups.
* Get discourse to use the gem.
* In the future, I think ideally the work could be made into a `--parallel` flag to `rspec`.

Thoughts welcome!