### PR TITLE
Improve missing spec error

### DIFF
--- a/lib/rubygems/errors.rb
+++ b/lib/rubygems/errors.rb
@@ -28,14 +28,15 @@ module Gem
   # superclass Gem::LoadError to catch all types of load errors.
   class MissingSpecError < Gem::LoadError
 
-    def initialize(name, requirement)
+    def initialize(name, requirement, extra_message=nil)
       @name        = name
       @requirement = requirement
+      @extra_message = extra_message
     end
 
     def message # :nodoc:
       build_message +
-        "Checked in 'GEM_PATH=#{Gem.path.join(File::PATH_SEPARATOR)}', execute `gem env` for more information"
+        "Checked in 'GEM_PATH=#{Gem.path.join(File::PATH_SEPARATOR)}' #{@extra_message}, execute `gem env` for more information"
     end
 
     private

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1393,7 +1393,11 @@ class Gem::Specification < Gem::BasicSpecification
         raise e
       end
 
-      specs = spec_dep.to_specs
+      begin
+        specs = spec_dep.to_specs
+      rescue Gem::MissingSpecError => e
+        raise Gem::MissingSpecError.new(e.name, e.requirement, "at: #{self.spec_file}")
+      end
 
       if specs.size == 1
         specs.first.activate

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1272,6 +1272,7 @@ class TestGem < Gem::TestCase
     end
 
     assert_match %r{Could not find 'b' }, e.message
+    assert_match %r{at: #{a.spec_file}}, e.message
   end
 
   def test_self_try_activate_missing_prerelease


### PR DESCRIPTION
Closes https://github.com/rubygems/rubygems/issues/3521

Show gemspec location when a `Gem::MissingSpecError` is raised while trying to activate a gem

---
I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
