### PR TITLE
Properly install and look for man pages

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -24,4 +24,6 @@ jobs:
         run: ruby -Ilib -S rake install
       - name: Run bundler installed as a default gem
         run: bundle --version
+      - name: Check bundler man pages were installed and are properly picked up
+        run: bundle install --help | grep -q BUNDLE-INSTALL
     timeout-minutes: 10

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -123,9 +123,9 @@ module Bundler
       end
 
       man_path = File.expand_path("../../../man", __FILE__)
-      # man files are located under the share directory with the default gems of bundler
-      man_path = File.expand_path("../../../../../share/man/man1", __FILE__) unless File.directory?(man_path)
-      man_pages = Hash[Dir.glob(File.join(man_path, "*")).grep(/.*\.\d*\Z/).collect do |f|
+      # man files are located under ruby's mandir with the default gems of bundler
+      man_path = RbConfig::CONFIG["mandir"] unless File.directory?(man_path)
+      man_pages = Hash[Dir.glob(File.join(man_path, "**", "*")).grep(/.*\.\d*\Z/).collect do |f|
         [File.basename(f, ".*"), f]
       end]
 
@@ -134,7 +134,7 @@ module Bundler
         if Bundler.which("man") && man_path !~ %r{^file:/.+!/META-INF/jruby.home/.+}
           Kernel.exec "man #{man_page}"
         else
-          puts File.read("#{man_path}/#{File.basename(man_page)}.txt")
+          puts File.read("#{File.dirname(man_page)}/#{File.basename(man_page)}.txt")
         end
       elsif command_path = Bundler.which("bundler-#{cli}")
         Kernel.exec(command_path, "--help")

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -130,10 +130,11 @@ module Bundler
       end]
 
       if man_pages.include?(command)
+        man_page = man_pages[command]
         if Bundler.which("man") && man_path !~ %r{^file:/.+!/META-INF/jruby.home/.+}
-          Kernel.exec "man #{man_pages[command]}"
+          Kernel.exec "man #{man_page}"
         else
-          puts File.read("#{man_path}/#{File.basename(man_pages[command])}.txt")
+          puts File.read("#{man_path}/#{File.basename(man_page)}.txt")
         end
       elsif command_path = Bundler.which("bundler-#{cli}")
         Kernel.exec(command_path, "--help")

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -550,14 +550,7 @@ abort "#{deprecation_message}"
         file.start_with? 'defaults'
       end
 
-      Dir.chdir old_lib_dir do
-        to_remove.each do |file|
-          FileUtils.rm_f file
-
-          warn "unable to remove old file #{file} please remove it by hand" if
-            File.exist? file
-        end
-      end
+      remove_file_list(to_remove, old_lib_dir)
     end
   end
 
@@ -642,6 +635,17 @@ abort "#{deprecation_message}"
     end
 
     install file, dest_file, :mode => options[:data_mode] || 0644
+  end
+
+  def remove_file_list(files, dir)
+    Dir.chdir dir do
+      files.each do |file|
+        FileUtils.rm_f file
+
+        warn "unable to remove old file #{file} please remove it by hand" if
+          File.exist? file
+      end
+    end
   end
 
   def target_bin_path(bin_dir, bin_file)

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -324,9 +324,7 @@ By default, this RubyGems will install gem as:
       pem_files = pem_files_in path
 
       Dir.chdir path do
-        install_file_list(lib_files, lib_dir)
-
-        install_file_list(pem_files, lib_dir)
+        install_file_list(lib_files + pem_files, lib_dir)
       end
     end
   end

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -312,16 +312,6 @@ By default, this RubyGems will install gem as:
     end
   end
 
-  def install_file(file, dest_dir)
-    dest_file = File.join dest_dir, file
-    dest_dir = File.dirname dest_file
-    unless File.directory? dest_dir
-      mkdir_p dest_dir, :mode => 0755
-    end
-
-    install file, dest_file, :mode => options[:data_mode] || 0644
-  end
-
   def install_lib(lib_dir)
     libs = { 'RubyGems' => 'lib' }
     libs['Bundler'] = 'bundler/lib'
@@ -643,6 +633,16 @@ abort "#{deprecation_message}"
   end
 
   private
+
+  def install_file(file, dest_dir)
+    dest_file = File.join dest_dir, file
+    dest_dir = File.dirname dest_file
+    unless File.directory? dest_dir
+      mkdir_p dest_dir, :mode => 0755
+    end
+
+    install file, dest_file, :mode => options[:data_mode] || 0644
+  end
 
   def target_bin_path(bin_dir, bin_file)
     bin_file_formatted = if options[:format_executable]

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -324,13 +324,9 @@ By default, this RubyGems will install gem as:
       pem_files = pem_files_in path
 
       Dir.chdir path do
-        lib_files.each do |lib_file|
-          install_file lib_file, lib_dir
-        end
+        install_file_list(lib_files, lib_dir)
 
-        pem_files.each do |pem_file|
-          install_file pem_file, lib_dir
-        end
+        install_file_list(pem_files, lib_dir)
       end
     end
   end
@@ -633,6 +629,12 @@ abort "#{deprecation_message}"
   end
 
   private
+
+  def install_file_list(files, dest_dir)
+    files.each do |file|
+      install_file file, dest_dir
+    end
+  end
 
   def install_file(file, dest_dir)
     dest_file = File.join dest_dir, file

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -329,7 +329,7 @@ By default, this RubyGems will install gem as:
       say "Installing #{tool}" if @verbose
 
       lib_files = rb_files_in path
-      lib_files.concat(template_files) if tool == 'Bundler'
+      lib_files.concat(bundler_template_files) if tool == 'Bundler'
 
       pem_files = pem_files_in path
 
@@ -503,8 +503,7 @@ By default, this RubyGems will install gem as:
     end
   end
 
-  # for installation of bundler as default gems
-  def template_files
+  def bundler_template_files
     Dir.chdir "bundler/lib" do
       (Dir[File.join('bundler', 'templates', '**', '{*,.*}')]).
         select{|f| !File.directory?(f)}

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -70,18 +70,13 @@ class TestGemCommandsSetupCommand < Gem::TestCase
       io.puts gemspec.to_ruby
     end
 
-    FileUtils.mkdir_p File.join(Gem.default_dir, "specifications")
+    spec_fetcher do |fetcher|
+      fetcher.download "bundler", "1.15.4"
 
-    open(File.join(Gem.default_dir, "specifications", "bundler-#{BUNDLER_VERS}.gemspec"), 'w') do |io|
-      io.puts "# bundler-#{BUNDLER_VERS}"
+      fetcher.gem "bundler", BUNDLER_VERS
+
+      fetcher.gem "bundler-audit", "1.0.0"
     end
-
-    open(File.join(Gem.default_dir, "specifications", "bundler-audit-1.0.0.gemspec"), 'w') do |io|
-      io.puts '# bundler-audit'
-    end
-
-    FileUtils.mkdir_p 'default/gems/bundler-1.15.4'
-    FileUtils.mkdir_p 'default/gems/bundler-audit-1.0.0'
   end
 
   def gem_install(name)
@@ -249,14 +244,14 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     assert_path_exists File.join(default_dir, "bundler-#{BUNDLER_VERS}.gemspec")
 
     # expect to not remove bundler-* gemspecs.
-    assert_path_exists File.join(Gem.default_dir, "specifications", "bundler-audit-1.0.0.gemspec")
+    assert_path_exists File.join(Gem.dir, "specifications", "bundler-audit-1.0.0.gemspec")
 
     # expect to remove normal gem that was same version. because it's promoted default gems.
-    refute_path_exists File.join(Gem.default_dir, "specifications", "bundler-#{BUNDLER_VERS}.gemspec")
+    refute_path_exists File.join(Gem.dir, "specifications", "bundler-#{BUNDLER_VERS}.gemspec")
 
-    assert_path_exists "default/gems/bundler-#{BUNDLER_VERS}"
-    assert_path_exists 'default/gems/bundler-1.15.4'
-    assert_path_exists 'default/gems/bundler-audit-1.0.0'
+    assert_path_exists "#{Gem.dir}/gems/bundler-#{BUNDLER_VERS}"
+    assert_path_exists "#{Gem.dir}/gems/bundler-1.15.4"
+    assert_path_exists "#{Gem.dir}/gems/bundler-audit-1.0.0"
   end
 
   def test_install_default_bundler_gem_with_force_flag

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -54,8 +54,6 @@ class TestGemCommandsSetupCommand < Gem::TestCase
       io.puts '# b.rb'
     end
 
-    FileUtils.mkdir_p 'default/gems'
-
     gemspec = Gem::Specification.new
     gemspec.author = "Us"
     gemspec.name = "bundler"

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -254,15 +254,8 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     # expect to remove normal gem that was same version. because it's promoted default gems.
     refute_path_exists File.join(Gem.default_dir, "specifications", "bundler-#{BUNDLER_VERS}.gemspec")
 
-    # expect to install default gems. It location was `site_ruby` directory on real world.
     assert_path_exists "default/gems/bundler-#{BUNDLER_VERS}"
-
-    # expect to not remove other versions of bundler on `site_ruby`
     assert_path_exists 'default/gems/bundler-1.15.4'
-
-    # TODO: We need to assert to remove same version of bundler on gem_dir directory(It's not site_ruby dir)
-
-    # expect to not remove bundler-* directory.
     assert_path_exists 'default/gems/bundler-audit-1.0.0'
   end
 

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -36,7 +36,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     end
 
     File.open 'lib/rubygems/ssl_certs/rubygems.org/foo.pem', 'w' do |io|
-      io.puts 'PEM'
+      io.puts '# foo.pem'
     end
 
     FileUtils.mkdir_p 'bundler/exe'

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -28,6 +28,10 @@ class TestGemCommandsSetupCommand < Gem::TestCase
       bundler/exe/bundle
       bundler/lib/bundler.rb
       bundler/lib/bundler/b.rb
+      bundler/man/bundle-b.1
+      bundler/man/bundle-b.1.txt
+      bundler/man/gemfile.5
+      bundler/man/gemfile.5.txt
     ]
 
     create_dummy_files(filelist)
@@ -159,6 +163,16 @@ class TestGemCommandsSetupCommand < Gem::TestCase
                  @cmd.rb_files_in('lib').sort
   end
 
+  def test_bundler_man1_files_in
+    assert_equal %w[bundle-b.1 bundle-b.1.txt],
+                 @cmd.bundler_man1_files_in('bundler/man').sort
+  end
+
+  def test_bundler_man5_files_in
+    assert_equal %w[gemfile.5 gemfile.5.txt],
+                 @cmd.bundler_man5_files_in('bundler/man').sort
+  end
+
   def test_install_lib
     @cmd.extend FileUtils
 
@@ -170,6 +184,19 @@ class TestGemCommandsSetupCommand < Gem::TestCase
 
       assert_path_exists File.join(dir, 'bundler.rb')
       assert_path_exists File.join(dir, 'bundler/b.rb')
+    end
+  end
+
+  def test_install_man
+    @cmd.extend FileUtils
+
+    Dir.mktmpdir 'man' do |dir|
+      @cmd.install_man dir
+
+      assert_path_exists File.join("#{dir}/man1", 'bundle-b.1')
+      assert_path_exists File.join("#{dir}/man1", 'bundle-b.1.txt')
+      assert_path_exists File.join("#{dir}/man5", 'gemfile.5')
+      assert_path_exists File.join("#{dir}/man5", 'gemfile.5.txt')
     end
   end
 
@@ -260,6 +287,29 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     create_dummy_files(files_that_go + files_that_stay)
 
     @cmd.remove_old_lib_files lib
+
+    files_that_go.each {|file| refute_path_exists file }
+
+    files_that_stay.each {|file| assert_path_exists file }
+  end
+
+  def test_remove_old_man_files
+    man = File.join @install_dir, 'man'
+
+    ruby_1             = File.join man, 'man1', 'ruby.1'
+    bundle_b_1         = File.join man, 'man1', 'bundle-b.1'
+    bundle_b_1_txt     = File.join man, 'man1', 'bundle-b.1.txt'
+    bundle_old_b_1     = File.join man, 'man1', 'bundle-old_b.1'
+    bundle_old_b_1_txt = File.join man, 'man1', 'bundle-old_b.1.txt'
+    gemfile_5          = File.join man, 'man5', 'gemfile.5'
+    gemfile_5_txt      = File.join man, 'man5', 'gemfile.5.txt'
+
+    files_that_go   = [bundle_old_b_1, bundle_old_b_1_txt]
+    files_that_stay = [ruby_1, bundle_b_1, bundle_b_1_txt, gemfile_5, gemfile_5_txt]
+
+    create_dummy_files(files_that_go + files_that_stay)
+
+    @cmd.remove_old_man_files man
 
     files_that_go.each {|file| refute_path_exists file }
 

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -23,8 +23,8 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     FileUtils.mkdir_p 'bin'
     FileUtils.mkdir_p 'lib/rubygems/ssl_certs/rubygems.org'
 
-    File.open 'bin/gem', 'w' do
-      |io| io.puts '# gem'
+    File.open 'bin/gem', 'w' do |io|
+      io.puts '# gem'
     end
 
     File.open 'lib/rubygems.rb', 'w' do |io|

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -79,30 +79,6 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     end
   end
 
-  def gem_install(name)
-    gem = util_spec name do |s|
-      s.executables = [name]
-      s.files = %W[bin/#{name}]
-    end
-    write_file File.join @tempdir, 'bin', name do |f|
-      f.puts '#!/usr/bin/ruby'
-    end
-    install_gem gem
-    File.join @gemhome, 'bin', name
-  end
-
-  def gem_install_with_plugin(name)
-    gem = util_spec name do |s|
-      s.files = %W[lib/rubygems_plugin.rb]
-    end
-    write_file File.join @tempdir, 'lib', 'rubygems_plugin.rb' do |f|
-      f.puts "require '#{gem.plugins.first}'"
-    end
-    install_gem gem
-
-    File.join Gem.plugindir, "#{name}_plugin.rb"
-  end
-
   def test_execute_regenerate_binstubs
     gem_bin_path = gem_install 'a'
     write_file gem_bin_path do |io|
@@ -388,6 +364,30 @@ class TestGemCommandsSetupCommand < Gem::TestCase
   end
 
   private
+
+  def gem_install(name)
+    gem = util_spec name do |s|
+      s.executables = [name]
+      s.files = %W[bin/#{name}]
+    end
+    write_file File.join @tempdir, 'bin', name do |f|
+      f.puts '#!/usr/bin/ruby'
+    end
+    install_gem gem
+    File.join @gemhome, 'bin', name
+  end
+
+  def gem_install_with_plugin(name)
+    gem = util_spec name do |s|
+      s.files = %W[lib/rubygems_plugin.rb]
+    end
+    write_file File.join @tempdir, 'lib', 'rubygems_plugin.rb' do |f|
+      f.puts "require '#{gem.plugins.first}'"
+    end
+    install_gem gem
+
+    File.join Gem.plugindir, "#{name}_plugin.rb"
+  end
 
   def default_gem_bin_path
     gem_exec = sprintf Gem.default_exec_format, 'gem'


### PR DESCRIPTION
# Description:

Unfortunately https://github.com/rubygems/rubygems/pull/3535 didn't fix the issue. See repro steps below:

```
$ ruby setup.rb
  Successfully built RubyGem
  Name: bundler
  Version: 2.2.0.dev
  File: bundler-2.2.0.dev.gem
Bundler 2.2.0.dev installed
RubyGems 3.2.0.pre1 installed
Regenerating binstubs
Regenerating plugins



------------------------------------------------------------------------------

RubyGems installed the following executables:
	/home/deivid/.rbenv/versions/2.7.1/bin/gem
	/home/deivid/.rbenv/versions/2.7.1/bin/bundle

$ bundle install --help
Usage:
  bundle install [OPTIONS]

Options:
      [--binstubs=Generate bin stubs for bundled gems to ./bin]                                                                                                             
      [--clean=Run bundle clean automatically after install], [--no-clean]                                                                                                  
      [--deployment=Install using defaults tuned for deployment environments], [--no-deployment]                                                                            
      [--frozen=Do not allow the Gemfile.lock to be updated after this install], [--no-frozen]                                                                              
      [--full-index=Fall back to using the single-file index of all gems], [--no-full-index]                                                                                
      [--gemfile=Use the specified gemfile instead of Gemfile]                                                                                                              
  -j, [--jobs=Specify the number of jobs to run in parallel]                                                                                                                
      [--local=Do not attempt to fetch gems remotely and use the gem cache instead], [--no-local]                                                                           
      [--no-cache=Don't update the existing gem cache.]                                                                                                                     
  --force, [--redownload=Force downloading every gem.], [--no-redownload]                                                                                                   
      [--no-prune=Don't remove stale gems from the cache.]                                                                                                                  
      [--path=Specify a different path than the system default ($BUNDLE_PATH or $GEM_HOME). Bundler will remember this value for future installs on this machine]           
      [--quiet=Only output warnings and errors.], [--no-quiet]                                                                                                              
      [--shebang=Specify a different shebang executable name than the default (usually 'ruby')]                                                                             
      [--standalone=Make a bundle that can work without the Bundler runtime]                                                                                                
      [--system=Install to the system location ($BUNDLE_PATH or $GEM_HOME) even if the bundle was previously installed somewhere else for this application], [--no-system]  
      [--trust-policy=Gem trust policy (like gem install -P). Must be one of HighSecurity|MediumSecurity|LowSecurity|AlmostNoSecurity|NoSecurity]                           
      [--without=Exclude gems that are part of the specified named group.]                                                                                                  
      [--with=Include gems that are part of the specified named group.]                                                                                                     
      [--no-color]                                                                                                                                                          # Disable colorization in output
  -r, [--retry=NUM]                                                                                                                                                         # Specify the number of times you wish to attempt network commands
  -V, [--verbose], [--no-verbose]                                                                                                                                           # Enable verbose output mode

Description:
  Install will install all of the gems in the current bundle, making them available for use. In a freshly checked out repository, this command will give you the same gem versions as the last person who updated the Gemfile and ran `bundle
  update`.

  Passing [DIR] to install (e.g. vendor) will cause the unpacked gems to be installed into the [DIR] directory rather than into system gems.

  If the bundle has already been installed, bundler will tell you so and then exit.
```

This PR should fix the issue in general.

It also fixes #3563.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
