### PR TITLE
Workaround rubygems upgrade on jruby

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -22,4 +22,6 @@ jobs:
           bundler: none
       - name: Install rubygems
         run: ruby -Ilib -S rake install
+      - name: Run bundler installed as a default gem
+        run: bundle --version
     timeout-minutes: 10

--- a/Rakefile
+++ b/Rakefile
@@ -100,7 +100,7 @@ end
 
 desc "Install rubygems to local system"
 task :install => [:clear_package, :package] do
-  sh "ruby -Ilib bin/gem install --no-document pkg/rubygems-update-#{v}.gem && update_rubygems --no-document"
+  sh "ruby -Ilib bin/gem install --no-document pkg/rubygems-update-#{v}.gem && update_rubygems --no-document --no-format-executable"
 end
 
 desc "Clears previously built package"


### PR DESCRIPTION
# Description:

This is just a local workaround to #3564.

In https://github.com/rubygems/rubygems/pull/3562 I'm adding basic smoke tests to check that rubygems installs `bundler` man pages to the proper location, and that `bundler` picks those from the right place inside the ruby installation.

This is not a fix, since it only applies to our development environment, but it allows those tests to work on `jruby` too.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
