### PR TITLE
Speed up some terribly slow tests

### DIFF
--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -404,15 +404,13 @@ The checksum of /versions does not match the checksum provided by the server! So
         s.add_dependency "foo"
       end
       build_gem "missing"
-      # need to hit the limit
-      1.upto(Bundler::Source::Rubygems::API_REQUEST_LIMIT) do |i|
-        build_gem "gem#{i}"
-      end
 
       FileUtils.rm_rf Dir[gem_repo2("gems/foo-*.gem")]
     end
 
-    install_gemfile! <<-G, :artifice => "compact_index_extra_missing"
+    api_request_limit = low_api_request_limit_for(gem_repo2)
+
+    install_gemfile! <<-G, :artifice => "compact_index_extra_missing", :env => { "BUNDLER_SPEC_API_REQUEST_LIMIT" => api_request_limit.to_s }
       source "#{source_uri}"
       source "#{source_uri}/extra" do
         gem "back_deps"
@@ -428,15 +426,13 @@ The checksum of /versions does not match the checksum provided by the server! So
         s.add_dependency "foo"
       end
       build_gem "missing"
-      # need to hit the limit
-      1.upto(Bundler::Source::Rubygems::API_REQUEST_LIMIT) do |i|
-        build_gem "gem#{i}"
-      end
 
       FileUtils.rm_rf Dir[gem_repo4("gems/foo-*.gem")]
     end
 
-    install_gemfile! <<-G, :artifice => "compact_index_extra_api_missing"
+    api_request_limit = low_api_request_limit_for(gem_repo4)
+
+    install_gemfile! <<-G, :artifice => "compact_index_extra_api_missing", :env => { "BUNDLER_SPEC_API_REQUEST_LIMIT" => api_request_limit.to_s }
       source "#{source_uri}"
       source "#{source_uri}/extra" do
         gem "back_deps"

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -412,14 +412,13 @@ The checksum of /versions does not match the checksum provided by the server! So
       FileUtils.rm_rf Dir[gem_repo2("gems/foo-*.gem")]
     end
 
-    gemfile <<-G
+    install_gemfile! <<-G, :artifice => "compact_index_extra_missing"
       source "#{source_uri}"
       source "#{source_uri}/extra" do
         gem "back_deps"
       end
     G
 
-    bundle! :install, :artifice => "compact_index_extra_missing"
     expect(the_bundle).to include_gems "back_deps 1.0"
   end
 

--- a/bundler/spec/install/gems/dependency_api_spec.rb
+++ b/bundler/spec/install/gems/dependency_api_spec.rb
@@ -392,7 +392,7 @@ RSpec.describe "gemcutter's dependency API" do
       gem "back_deps"
     G
 
-    bundle :install, :artifice => "endpoint_extra_missing"
+    bundle! :install, :artifice => "endpoint_extra_missing"
     expect(the_bundle).to include_gems "back_deps 1.0"
   end
 
@@ -417,7 +417,7 @@ RSpec.describe "gemcutter's dependency API" do
       end
     G
 
-    bundle :install, :artifice => "endpoint_extra_missing"
+    bundle! :install, :artifice => "endpoint_extra_missing"
     expect(the_bundle).to include_gems "back_deps 1.0"
   end
 

--- a/bundler/spec/install/gems/dependency_api_spec.rb
+++ b/bundler/spec/install/gems/dependency_api_spec.rb
@@ -386,13 +386,12 @@ RSpec.describe "gemcutter's dependency API" do
       FileUtils.rm_rf Dir[gem_repo2("gems/foo-*.gem")]
     end
 
-    gemfile <<-G
+    install_gemfile! <<-G, :artifice => "endpoint_extra_missing"
       source "#{source_uri}"
       source "#{source_uri}/extra"
       gem "back_deps"
     G
 
-    bundle! :install, :artifice => "endpoint_extra_missing"
     expect(the_bundle).to include_gems "back_deps 1.0"
   end
 
@@ -410,14 +409,13 @@ RSpec.describe "gemcutter's dependency API" do
       FileUtils.rm_rf Dir[gem_repo2("gems/foo-*.gem")]
     end
 
-    gemfile <<-G
+    install_gemfile! <<-G, :artifice => "endpoint_extra_missing"
       source "#{source_uri}"
       source "#{source_uri}/extra" do
         gem "back_deps"
       end
     G
 
-    bundle! :install, :artifice => "endpoint_extra_missing"
     expect(the_bundle).to include_gems "back_deps 1.0"
   end
 

--- a/bundler/spec/install/gems/dependency_api_spec.rb
+++ b/bundler/spec/install/gems/dependency_api_spec.rb
@@ -378,15 +378,13 @@ RSpec.describe "gemcutter's dependency API" do
         s.add_dependency "foo"
       end
       build_gem "missing"
-      # need to hit the limit
-      1.upto(Bundler::Source::Rubygems::API_REQUEST_LIMIT) do |i|
-        build_gem "gem#{i}"
-      end
 
       FileUtils.rm_rf Dir[gem_repo2("gems/foo-*.gem")]
     end
 
-    install_gemfile! <<-G, :artifice => "endpoint_extra_missing"
+    api_request_limit = low_api_request_limit_for(gem_repo2)
+
+    install_gemfile! <<-G, :artifice => "endpoint_extra_missing", :env => { "BUNDLER_SPEC_API_REQUEST_LIMIT" => api_request_limit.to_s }
       source "#{source_uri}"
       source "#{source_uri}/extra"
       gem "back_deps"
@@ -401,15 +399,13 @@ RSpec.describe "gemcutter's dependency API" do
         s.add_dependency "foo"
       end
       build_gem "missing"
-      # need to hit the limit
-      1.upto(Bundler::Source::Rubygems::API_REQUEST_LIMIT) do |i|
-        build_gem "gem#{i}"
-      end
 
       FileUtils.rm_rf Dir[gem_repo2("gems/foo-*.gem")]
     end
 
-    install_gemfile! <<-G, :artifice => "endpoint_extra_missing"
+    api_request_limit = low_api_request_limit_for(gem_repo2)
+
+    install_gemfile! <<-G, :artifice => "endpoint_extra_missing", :env => { "BUNDLER_SPEC_API_REQUEST_LIMIT" => api_request_limit.to_s }
       source "#{source_uri}"
       source "#{source_uri}/extra" do
         gem "back_deps"

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -17,6 +17,18 @@ module Spec
       Gem::Platform.new(platform)
     end
 
+    # Returns a number smaller than the size of the index. Useful for specs that
+    # need the API request limit to be reached for some reason.
+    def low_api_request_limit_for(gem_repo)
+      all_gems = Dir[gem_repo.join("gems/*.gem")]
+
+      all_gem_names = all_gems.map do |file|
+        File.basename(file, ".gem").match(/\A(?<gem_name>[^-]+)-.*\z/)[:gem_name]
+      end.uniq
+
+      (all_gem_names - ["bundler"]).size
+    end
+
     def build_repo1
       build_repo gem_repo1 do
         build_gem "rack", %w[0.9.1 1.0.0] do |s|

--- a/bundler/spec/support/hax.rb
+++ b/bundler/spec/support/hax.rb
@@ -46,3 +46,18 @@ if ENV["BUNDLER_SPEC_WINDOWS"] == "true"
     WINDOWS = true
   end
 end
+
+if ENV["BUNDLER_SPEC_API_REQUEST_LIMIT"]
+  require_relative "path"
+  require "#{Spec::Path.lib_dir}/bundler/source"
+  require "#{Spec::Path.lib_dir}/bundler/source/rubygems"
+
+  module Bundler
+    class Source
+      class Rubygems < Source
+        remove_const :API_REQUEST_LIMIT
+        API_REQUEST_LIMIT = ENV["BUNDLER_SPEC_API_REQUEST_LIMIT"].to_i
+      end
+    end
+  end
+end

--- a/bundler/spec/support/hax.rb
+++ b/bundler/spec/support/hax.rb
@@ -33,7 +33,7 @@ if ENV["BUNDLER_SPEC_VERSION"]
 
   module Bundler
     remove_const(:VERSION) if const_defined?(:VERSION)
-    VERSION = ENV["BUNDLER_SPEC_VERSION"].dup
+    VERSION = ENV["BUNDLER_SPEC_VERSION"]
   end
 end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The problem was that some tests, 4 to be precise, were really really slow, because each of them created 500 dummy gems in 500 separate subprocesses.

## What is your fix for the problem, implemented in this PR?

My fix is to, instead of making a very big index so that the API request limit is reached, we should mock the API request limit, so that creating dummy gems is not needed.

This results in a 99% improvement on the sequential running time of these tests, which brings it down from 4 minutes to 4 seconds on my machine, and I believe it could make specs actually runnable under jruby.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
