### PR TITLE
Spec improvements

### DIFF
--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -293,7 +293,7 @@ RSpec.describe "bundle exec" do
     G
 
     rubyopt = ENV["RUBYOPT"]
-    rubyopt = "-r#{lib_dir}/bundler/setup #{rubyopt}"
+    rubyopt = ["-r#{lib_dir}/bundler/setup", rubyopt].compact.join(" ")
 
     bundle "exec 'echo $RUBYOPT'"
     expect(out).to have_rubyopts(rubyopt)

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -296,10 +296,10 @@ RSpec.describe "bundle exec" do
     rubyopt = ["-r#{lib_dir}/bundler/setup", rubyopt].compact.join(" ")
 
     bundle "exec 'echo $RUBYOPT'"
-    expect(out).to have_rubyopts(rubyopt)
+    expect(out).to eq(rubyopt)
 
     bundle "exec 'echo $RUBYOPT'", :env => { "RUBYOPT" => rubyopt }
-    expect(out).to have_rubyopts(rubyopt)
+    expect(out).to eq(rubyopt)
   end
 
   it "does not duplicate already exec'ed RUBYLIB" do

--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -83,7 +83,7 @@ RSpec.configure do |config|
   config.before :suite do
     require_relative "support/rubygems_ext"
     Spec::Rubygems.test_setup
-    ENV["RUBYOPT"] = "#{ENV["RUBYOPT"]} -r#{Spec::Path.spec_dir}/support/hax.rb"
+    ENV["RUBYOPT"] = [ENV["RUBYOPT"], "-r#{Spec::Path.spec_dir}/support/hax.rb"].compact.join(" ")
     ENV["BUNDLE_SPEC_RUN"] = "true"
     ENV["BUNDLE_USER_CONFIG"] = ENV["BUNDLE_USER_CACHE"] = ENV["BUNDLE_USER_PLUGIN"] = nil
     ENV["GEMRC"] = nil

--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -83,7 +83,6 @@ RSpec.configure do |config|
   config.before :suite do
     require_relative "support/rubygems_ext"
     Spec::Rubygems.test_setup
-    ENV["RUBYOPT"] = [ENV["RUBYOPT"], "-r#{Spec::Path.spec_dir}/support/hax.rb"].compact.join(" ")
     ENV["BUNDLE_SPEC_RUN"] = "true"
     ENV["BUNDLE_USER_CONFIG"] = ENV["BUNDLE_USER_CACHE"] = ENV["BUNDLE_USER_PLUGIN"] = nil
     ENV["GEMRC"] = nil

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -90,7 +90,6 @@ module Spec
       env["PATH"].gsub!("#{Path.root}/exe", "") if env["PATH"] && system_bundler
 
       requires = options.delete(:requires) || []
-      requires << "#{Path.spec_dir}/support/hax.rb"
 
       artifice = options.delete(:artifice) do
         if RSpec.current_example.metadata[:realworld]
@@ -174,6 +173,7 @@ module Spec
       lib_option = "-I#{libs.join(File::PATH_SEPARATOR)}"
 
       requires = options.delete(:requires) || []
+      requires << "#{Path.spec_dir}/support/hax.rb"
       require_option = requires.map {|r| "-r#{r}" }
 
       [sudo, Gem.ruby, *lib_option, *require_option].compact.join(" ")

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -90,7 +90,7 @@ module Spec
       env["PATH"].gsub!("#{Path.root}/exe", "") if env["PATH"] && system_bundler
 
       requires = options.delete(:requires) || []
-      requires << "support/hax"
+      requires << "#{Path.spec_dir}/support/hax.rb"
 
       artifice = options.delete(:artifice) do
         if RSpec.current_example.metadata[:realworld]
@@ -100,7 +100,7 @@ module Spec
         end
       end
       if artifice
-        requires << "support/artifice/#{artifice}"
+        requires << "#{Path.spec_dir}/support/artifice/#{artifice}.rb"
       end
 
       requires_str = requires.map {|r| "-r#{r}" }.join(" ")

--- a/bundler/spec/support/matchers.rb
+++ b/bundler/spec/support/matchers.rb
@@ -75,16 +75,6 @@ module Spec
       end
     end
 
-    RSpec::Matchers.define :have_rubyopts do |*args|
-      args = args.flatten
-      args = args.first.split(/\s+/) if args.size == 1
-
-      match do |actual|
-        actual = actual.split(/\s+/) if actual.is_a?(String)
-        args.all? {|arg| actual.include?(arg) } && actual.uniq.size == actual.size
-      end
-    end
-
     RSpec::Matchers.define :be_sorted do
       diffable
       attr_reader :expected

--- a/bundler/spec/support/rubygems_version_manager.rb
+++ b/bundler/spec/support/rubygems_version_manager.rb
@@ -36,7 +36,7 @@ private
 
     cmd = [ruby, $0, *ARGV].compact
 
-    ENV["RUBYOPT"] = "-I#{local_copy_path.join("lib")} #{ENV["RUBYOPT"]}"
+    ENV["RUBYOPT"] = ["-I#{local_copy_path.join("lib")}", ENV["RUBYOPT"]].compact.join(" ")
 
     exec(ENV, *cmd)
   end


### PR DESCRIPTION
# Description:

While debugging an issue, I noticed that the `hax.rb` file was getting required inside subprocesses both through `RUBYOPT` and through a explicit `-r` flag to ruby.

This PR is a refactor to remove the require of this file from the global `RUBYOPT` environment variable.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
