### PR TITLE
Delay removal of git shortcut DSL additions

### DIFF
--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -222,7 +222,6 @@ module Bundler
 
     def github(repo, options = {})
       raise ArgumentError, "GitHub sources require a block" unless block_given?
-      raise DeprecatedError, "The #github method has been removed" if Bundler.feature_flag.skip_default_git_sources?
       github_uri  = @git_sources["github"].call(repo)
       git_options = normalize_hash(options).merge("uri" => github_uri)
       git_source  = @sources.add_git_source(git_options)
@@ -283,8 +282,6 @@ module Bundler
   private
 
     def add_git_sources
-      return if Bundler.feature_flag.skip_default_git_sources?
-
       git_source(:github) do |repo_name|
         warn_deprecated_git_source(:github, <<-'RUBY'.strip, 'Change any "reponame" :github sources to "username/reponame".')
 "https://github.com/#{repo_name}.git"

--- a/bundler/lib/bundler/feature_flag.rb
+++ b/bundler/lib/bundler/feature_flag.rb
@@ -41,7 +41,7 @@ module Bundler
     settings_flag(:plugins) { @bundler_version >= Gem::Version.new("1.14") }
     settings_flag(:print_only_version_number) { bundler_3_mode? }
     settings_flag(:setup_makes_kernel_gem_public) { !bundler_3_mode? }
-    settings_flag(:skip_default_git_sources) { bundler_3_mode? }
+    settings_flag(:skip_default_git_sources) { bundler_4_mode? }
     settings_flag(:specific_platform) { bundler_3_mode? }
     settings_flag(:suppress_install_using_messages) { bundler_3_mode? }
     settings_flag(:unlock_source_unlocks_spec) { !bundler_3_mode? }

--- a/bundler/lib/bundler/feature_flag.rb
+++ b/bundler/lib/bundler/feature_flag.rb
@@ -41,7 +41,6 @@ module Bundler
     settings_flag(:plugins) { @bundler_version >= Gem::Version.new("1.14") }
     settings_flag(:print_only_version_number) { bundler_3_mode? }
     settings_flag(:setup_makes_kernel_gem_public) { !bundler_3_mode? }
-    settings_flag(:skip_default_git_sources) { bundler_4_mode? }
     settings_flag(:specific_platform) { bundler_3_mode? }
     settings_flag(:suppress_install_using_messages) { bundler_3_mode? }
     settings_flag(:unlock_source_unlocks_spec) { !bundler_3_mode? }

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -42,7 +42,6 @@ module Bundler
       setup_makes_kernel_gem_public
       silence_deprecations
       silence_root_warning
-      skip_default_git_sources
       specific_platform
       suppress_install_using_messages
       unlock_source_unlocks_spec

--- a/bundler/man/bundle-config.1
+++ b/bundler/man/bundle-config.1
@@ -262,9 +262,6 @@ The following is a list of all configuration keys and their purpose\. You can le
 \fBsilence_root_warning\fR (\fBBUNDLE_SILENCE_ROOT_WARNING\fR): Silence the warning Bundler prints when installing gems as root\.
 .
 .IP "\(bu" 4
-\fBskip_default_git_sources\fR (\fBBUNDLE_SKIP_DEFAULT_GIT_SOURCES\fR): Whether Bundler should skip adding default git source shortcuts to the Gemfile DSL\.
-.
-.IP "\(bu" 4
 \fBspecific_platform\fR (\fBBUNDLE_SPECIFIC_PLATFORM\fR): Allow bundler to resolve for the specific running platform and store it in the lockfile, instead of only using a generic platform\. A specific platform is the exact platform triple reported by \fBGem::Platform\.local\fR, such as \fBx86_64\-darwin\-16\fR or \fBuniversal\-java\-1\.8\fR\. On the other hand, generic platforms are those such as \fBruby\fR, \fBmswin\fR, or \fBjava\fR\. In this example, \fBx86_64\-darwin\-16\fR would map to \fBruby\fR and \fBuniversal\-java\-1\.8\fR to \fBjava\fR\.
 .
 .IP "\(bu" 4

--- a/bundler/man/bundle-config.1.txt
+++ b/bundler/man/bundle-config.1.txt
@@ -312,10 +312,6 @@ LIST OF AVAILABLE KEYS
        o   silence_root_warning   (BUNDLE_SILENCE_ROOT_WARNING):  Silence  the
            warning Bundler prints when installing gems as root.
 
-       o   skip_default_git_sources (BUNDLE_SKIP_DEFAULT_GIT_SOURCES): Whether
-           Bundler  should  skip  adding  default  git source shortcuts to the
-           Gemfile DSL.
-
        o   specific_platform  (BUNDLE_SPECIFIC_PLATFORM):  Allow  bundler   to
            resolve  for  the  specific  running  platform  and store it in the
            lockfile, instead of only using  a  generic  platform.  A  specific

--- a/bundler/man/bundle-config.ronn
+++ b/bundler/man/bundle-config.ronn
@@ -249,9 +249,6 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    be changed in the next major version.
 * `silence_root_warning` (`BUNDLE_SILENCE_ROOT_WARNING`):
    Silence the warning Bundler prints when installing gems as root.
-* `skip_default_git_sources` (`BUNDLE_SKIP_DEFAULT_GIT_SOURCES`):
-   Whether Bundler should skip adding default git source shortcuts to the
-   Gemfile DSL.
 * `specific_platform` (`BUNDLE_SPECIFIC_PLATFORM`):
    Allow bundler to resolve for the specific running platform and store it in
    the lockfile, instead of only using a generic platform.

--- a/bundler/spec/bundler/dsl_spec.rb
+++ b/bundler/spec/bundler/dsl_spec.rb
@@ -63,9 +63,9 @@ RSpec.describe Bundler::Dsl do
       end
     end
 
-    context "default git sources", :bundler => "3" do
-      it "has none" do
-        expect(subject.instance_variable_get(:@git_sources)).to eq({})
+    context "default git sources" do
+      it "has bitbucket, gist, and github" do
+        expect(subject.instance_variable_get(:@git_sources).keys.sort).to eq(%w[bitbucket gist github])
       end
     end
   end
@@ -208,7 +208,7 @@ RSpec.describe Bundler::Dsl do
       end
     end
 
-    describe "#github", :bundler => "2" do
+    describe "#github" do
       it "from github" do
         spree_gems = %w[spree_core spree_api spree_backend]
         subject.github "spree" do
@@ -221,7 +221,7 @@ RSpec.describe Bundler::Dsl do
       end
     end
 
-    describe "#github", :bundler => "3" do
+    describe "#github", :bundler => "4" do
       it "from github" do
         expect do
           spree_gems = %w[spree_core spree_api spree_backend]

--- a/bundler/spec/bundler/dsl_spec.rb
+++ b/bundler/spec/bundler/dsl_spec.rb
@@ -220,17 +220,6 @@ RSpec.describe Bundler::Dsl do
         end
       end
     end
-
-    describe "#github", :bundler => "4" do
-      it "from github" do
-        expect do
-          spree_gems = %w[spree_core spree_api spree_backend]
-          subject.github "spree" do
-            spree_gems.each {|spree_gem| subject.send :gem, spree_gem }
-          end
-        end.to raise_error(Bundler::DeprecatedError, /github method has been removed/)
-      end
-    end
   end
 
   describe "syntax errors" do

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -416,25 +416,34 @@ RSpec.describe "major deprecations" do
     end
 
     context "with github gems" do
-      it "warns about removal", :bundler => "2" do
+      it "does not warn about removal", :bundler => "2" do
+        expect(Bundler.ui).not_to receive(:warn)
+        subject.gem("sparks", :github => "indirect/sparks")
+        github_uri = "https://github.com/indirect/sparks.git"
+        expect(subject.dependencies.first.source.uri).to eq(github_uri)
+      end
+
+      it "warns about removal", :bundler => "3" do
         msg = <<-EOS
 The :github git source is deprecated, and will be removed in the future. Change any "reponame" :github sources to "username/reponame". Add this code to the top of your Gemfile to ensure it continues to work:
 
     git_source(:github) {|repo_name| "https://github.com/\#{repo_name}.git" }
 
         EOS
-        expect(Bundler::SharedHelpers).to receive(:major_deprecation).with(3, msg)
+        expect(Bundler.ui).to receive(:warn).with("[DEPRECATED] #{msg}")
         subject.gem("sparks", :github => "indirect/sparks")
         github_uri = "https://github.com/indirect/sparks.git"
         expect(subject.dependencies.first.source.uri).to eq(github_uri)
       end
-
-      pending "should fail with a helpful error", :bundler => "3"
     end
 
     context "with bitbucket gems" do
-      it "warns about removal", :bundler => "2" do
-        allow(Bundler.ui).to receive(:deprecate)
+      it "does not warn about removal", :bundler => "2" do
+        expect(Bundler.ui).not_to receive(:warn)
+        subject.gem("not-really-a-gem", :bitbucket => "mcorp/flatlab-rails")
+      end
+
+      it "warns about removal", :bundler => "3" do
         msg = <<-EOS
 The :bitbucket git source is deprecated, and will be removed in the future. Add this code to the top of your Gemfile to ensure it continues to work:
 
@@ -445,27 +454,27 @@ The :bitbucket git source is deprecated, and will be removed in the future. Add 
     end
 
         EOS
-        expect(Bundler::SharedHelpers).to receive(:major_deprecation).with(3, msg)
+        expect(Bundler.ui).to receive(:warn).with("[DEPRECATED] #{msg}")
         subject.gem("not-really-a-gem", :bitbucket => "mcorp/flatlab-rails")
       end
-
-      pending "should fail with a helpful error", :bundler => "3"
     end
 
     context "with gist gems" do
-      it "warns about removal", :bundler => "2" do
-        allow(Bundler.ui).to receive(:deprecate)
+      it "does not warn about removal", :bundler => "2" do
+        expect(Bundler.ui).not_to receive(:warn)
+        subject.gem("not-really-a-gem", :gist => "1234")
+      end
+
+      it "warns about removal", :bundler => "3" do
         msg = <<-EOS
 The :gist git source is deprecated, and will be removed in the future. Add this code to the top of your Gemfile to ensure it continues to work:
 
     git_source(:gist) {|repo_name| "https://gist.github.com/\#{repo_name}.git" }
 
         EOS
-        expect(Bundler::SharedHelpers).to receive(:major_deprecation).with(3, msg)
+        expect(Bundler.ui).to receive(:warn).with("[DEPRECATED] #{msg}")
         subject.gem("not-really-a-gem", :gist => "1234")
       end
-
-      pending "should fail with a helpful error", :bundler => "3"
     end
   end
 


### PR DESCRIPTION
# Description:

Fixes #3579.

We delayed the deprecation of git based DSL shortcuts in rubygems/bundler#7000, but didn't delay their removal.

This PR does that.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
