### PR TITLE
Make bundle gem create travis.yml by default

### DIFF
--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -79,12 +79,11 @@ module Bundler
       ]
 
       templates.merge!("gitignore.tt" => ".gitignore") if Bundler.git_present?
+      templates.merge!("travis.yml.tt" => ".travis.yml")
 
       if test_framework = ask_and_set_test_framework
         config[:test] = test_framework
         config[:test_framework_version] = TEST_FRAMEWORK_VERSIONS[test_framework]
-
-        templates.merge!("travis.yml.tt" => ".travis.yml")
 
         case test_framework
         when "rspec"

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "bundle gem" do
     expect(bundled_app("#{gem_name}/Rakefile")).to exist
     expect(bundled_app("#{gem_name}/lib/#{require_path}.rb")).to exist
     expect(bundled_app("#{gem_name}/lib/#{require_path}/version.rb")).to exist
+    expect(bundled_app("#{gem_name}/.travis.yml").read).to match(/- #{RUBY_VERSION}/)
   end
 
   let(:generated_gemspec) { Bundler.load_gemspec_uncached(bundled_app(gem_name).join("#{gem_name}.gemspec")) }
@@ -590,10 +591,6 @@ RSpec.describe "bundle gem" do
       it "defaults to rspec" do
         expect(bundled_app("#{gem_name}/spec/spec_helper.rb")).to exist
         expect(bundled_app("#{gem_name}/test/test_helper.rb")).to_not exist
-      end
-
-      it "creates a .travis.yml file to test the library against the current Ruby version on Travis CI" do
-        expect(bundled_app("#{gem_name}/.travis.yml").read).to match(/- #{RUBY_VERSION}/)
       end
     end
 


### PR DESCRIPTION
# Description:

## What was the end-user or developer problem that led to this PR?

While working on a different PR to update selecting a test framework for `bundle gem`, I found that the creation of `travis.yml` is dependent on the presence of a test framework being configured (via `--test` or `Bundler.settings["gem.test"]`) when `bundle gem` is executed.

Testing is one of multiple CI responsibilities, so perhaps it makes more sense to generate `travis.yml` by default, even if a user has explicitly configured no test framework?

## What is your fix for the problem, implemented in this PR?

This PR will allow `bundle gem` to create `travis.yml` by default instead of depending on whether a test framework has been configured.

______________

# Tasks:

- [X] Describe the problem / feature
- [X] Write tests
- [X] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
