### PR TITLE
Handle relative paths in Bundler gem tasks

### DIFF
--- a/bundler/lib/bundler/gem_helper.rb
+++ b/bundler/lib/bundler/gem_helper.rb
@@ -25,8 +25,8 @@ module Bundler
     attr_reader :spec_path, :base, :gemspec
 
     def initialize(base = nil, name = nil)
-      @base = (base ||= SharedHelpers.pwd)
-      gemspecs = name ? [File.join(base, "#{name}.gemspec")] : Dir[File.join(base, "{,*}.gemspec")]
+      @base = File.expand_path(base || SharedHelpers.pwd)
+      gemspecs = name ? [File.join(@base, "#{name}.gemspec")] : Dir[File.join(@base, "{,*}.gemspec")]
       raise "Unable to determine name from existing gemspec. Use :name => 'gemname' in #install_tasks to manually set it." unless gemspecs.size == 1
       @spec_path = gemspecs.first
       @gemspec = Bundler.load_gemspec(@spec_path)

--- a/bundler/spec/bundler/gem_helper_spec.rb
+++ b/bundler/spec/bundler/gem_helper_spec.rb
@@ -138,6 +138,26 @@ RSpec.describe Bundler::GemHelper do
           expect(app_gem_path).to exist
         end
       end
+
+      context "when building in the current working directory" do
+        it "creates .gem file" do
+          mock_build_message app_name, app_version
+          Dir.chdir app_path do
+            Bundler::GemHelper.new.build_gem
+          end
+          expect(app_gem_path).to exist
+        end
+      end
+
+      context "when building in a location relative to the current working directory" do
+        it "creates .gem file" do
+          mock_build_message app_name, app_version
+          Dir.chdir File.dirname(app_path) do
+            Bundler::GemHelper.new(File.basename(app_path)).build_gem
+          end
+          expect(app_gem_path).to exist
+        end
+      end
     end
 
     describe "#install_gem" do


### PR DESCRIPTION
# Description:

<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

Fixes #3585 

`Bundler::GemHelper#build_gem` only works if the `base` directory (passed via the `:dir` option to `Bundler::GemHelper.install_tasks`) is an absolute path.

## What is your fix for the problem, implemented in this PR?

Call `File.expand_path` on the `base` path in the constructor.

______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
