### PR TITLE
Fix flaky spec failure

### DIFF
--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -681,7 +681,7 @@ RSpec.describe "bundle update" do
       G
 
       bundle! "update", :all => true
-      expect(out).to include "Resolving dependencies...\nBundle updated!"
+      expect(out).to match(/Resolving dependencies\.\.\.\.*\nBundle updated!/)
 
       update_repo4 do
         build_gem "foo", "2.0"
@@ -689,12 +689,7 @@ RSpec.describe "bundle update" do
 
       bundle! "update", :all => true
       out.sub!("Removing foo (1.0)\n", "")
-      expect(out).to include strip_whitespace(<<-EOS).strip
-        Resolving dependencies...
-        Fetching foo 2.0 (was 1.0)
-        Installing foo 2.0 (was 1.0)
-        Bundle updated
-      EOS
+      expect(out).to match(/Resolving dependencies\.\.\.\.*\nFetching foo 2\.0 \(was 1\.0\)\nInstalling foo 2\.0 \(was 1\.0\)\nBundle updated/)
     end
   end
 

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -681,7 +681,6 @@ RSpec.describe "bundle update" do
       G
 
       bundle! "update", :all => true
-      out.gsub!(/RubyGems [\d\.]+ is not threadsafe.*\n?/, "")
       expect(out).to include "Resolving dependencies...\nBundle updated!"
 
       update_repo4 do
@@ -690,7 +689,6 @@ RSpec.describe "bundle update" do
 
       bundle! "update", :all => true
       out.sub!("Removing foo (1.0)\n", "")
-      out.gsub!(/RubyGems [\d\.]+ is not threadsafe.*\n?/, "")
       expect(out).to include strip_whitespace(<<-EOS).strip
         Resolving dependencies...
         Fetching foo 2.0 (was 1.0)

--- a/bundler/spec/other/platform_spec.rb
+++ b/bundler/spec/other/platform_spec.rb
@@ -388,7 +388,7 @@ G
 
       bundle :check
       expect(exitstatus).to eq(0) if exitstatus
-      expect(out).to eq("Resolving dependencies...\nThe Gemfile's dependencies are satisfied")
+      expect(out).to match(/\AResolving dependencies\.\.\.\.*\nThe Gemfile's dependencies are satisfied\z/)
     end
 
     it "checks fine with any engine", :jruby do
@@ -406,7 +406,7 @@ G
 
       bundle :check
       expect(exitstatus).to eq(0) if exitstatus
-      expect(out).to eq("Resolving dependencies...\nThe Gemfile's dependencies are satisfied")
+      expect(out).to match(/\AResolving dependencies\.\.\.\.*\nThe Gemfile's dependencies are satisfied\z/)
     end
 
     it "fails when ruby version doesn't match" do


### PR DESCRIPTION
# Description:

Fixes the following flaky spec failure: https://github.com/rubygems/rubygems/pull/3583/checks?check_run_id=636444911

```
1) bundle update with suppress_install_using_messages set only prints `Using` for versions that have changed
   Failure/Error:
     expect(out).to include strip_whitespace(<<-EOS).strip
       Resolving dependencies...
       Fetching foo 2.0 (was 1.0)
       Installing foo 2.0 (was 1.0)
       Bundle updated
     EOS

     expected "Fetching source index from file:///home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/remote4/\nR...solving dependencies....\nFetching foo 2.0 (was 1.0)\nInstalling foo 2.0 (was 1.0)\nBundle updated!" to include "Resolving dependencies...\nFetching foo 2.0 (was 1.0)\nInstalling foo 2.0 (was 1.0)\nBundle updated"
     Diff:
     @@ -1,2 +1,6 @@
     -Resolving dependencies...\nFetching foo 2.0 (was 1.0)\nInstalling foo 2.0 (was 1.0)\nBundle updated
     +Fetching source index from file:///home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/remote4/
     +Resolving dependencies....
     +Fetching foo 2.0 (was 1.0)
     +Installing foo 2.0 (was 1.0)
     +Bundle updated!
```

Depending on the conditions of the system where the spec is run, the resolver could take longer so that an extra dot is printed while resolving.

This change makes the spec resilient to that.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
