### PR TITLE
Fix thread safety issue when tests `gem build` bundler

### DIFF
--- a/bundler/spec/quality_es_spec.rb
+++ b/bundler/spec/quality_es_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "La biblioteca si misma" do
   it "mantiene la calidad de lenguaje de la documentación" do
     included = /ronn/
     error_messages = []
-    man_tracked_files.split("\x0").each do |filename|
+    man_tracked_files.each do |filename|
       next unless filename =~ included
       error_messages << check_for_expendable_words(filename)
       error_messages << check_for_specific_pronouns(filename)
@@ -51,7 +51,7 @@ RSpec.describe "La biblioteca si misma" do
   it "mantiene la calidad de lenguaje de oraciones usadas en el código fuente" do
     error_messages = []
     exempt = /vendor/
-    lib_tracked_files.split("\x0").each do |filename|
+    lib_tracked_files.each do |filename|
       next if filename =~ exempt
       error_messages << check_for_expendable_words(filename)
       error_messages << check_for_specific_pronouns(filename)

--- a/bundler/spec/quality_spec.rb
+++ b/bundler/spec/quality_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe "The library itself" do
   it "has no malformed whitespace" do
     exempt = /\.gitmodules|fixtures|vendor|LICENSE|vcr_cassettes|rbreadline\.diff|\.txt$/
     error_messages = []
-    tracked_files.split("\x0").each do |filename|
+    tracked_files.each do |filename|
       next if filename =~ exempt
       error_messages << check_for_tab_characters(filename)
       error_messages << check_for_extra_spaces(filename)
@@ -118,7 +118,7 @@ RSpec.describe "The library itself" do
   it "has no estraneous quotes" do
     exempt = /vendor|vcr_cassettes|LICENSE|rbreadline\.diff/
     error_messages = []
-    tracked_files.split("\x0").each do |filename|
+    tracked_files.each do |filename|
       next if filename =~ exempt
       error_messages << check_for_straneous_quotes(filename)
     end
@@ -128,7 +128,7 @@ RSpec.describe "The library itself" do
   it "does not include any leftover debugging or development mechanisms" do
     exempt = %r{quality_spec.rb|support/helpers|vcr_cassettes|\.md|\.ronn|\.txt|\.5|\.1}
     error_messages = []
-    tracked_files.split("\x0").each do |filename|
+    tracked_files.each do |filename|
       next if filename =~ exempt
       error_messages << check_for_debugging_mechanisms(filename)
     end
@@ -138,7 +138,7 @@ RSpec.describe "The library itself" do
   it "does not include any unresolved merge conflicts" do
     error_messages = []
     exempt = %r{lock/lockfile_spec|quality_spec|vcr_cassettes|\.ronn|lockfile_parser\.rb}
-    tracked_files.split("\x0").each do |filename|
+    tracked_files.each do |filename|
       next if filename =~ exempt
       error_messages << check_for_git_merge_conflicts(filename)
     end
@@ -148,7 +148,7 @@ RSpec.describe "The library itself" do
   it "maintains language quality of the documentation" do
     included = /ronn/
     error_messages = []
-    man_tracked_files.split("\x0").each do |filename|
+    man_tracked_files.each do |filename|
       next unless filename =~ included
       error_messages << check_for_expendable_words(filename)
       error_messages << check_for_specific_pronouns(filename)
@@ -159,7 +159,7 @@ RSpec.describe "The library itself" do
   it "maintains language quality of sentences used in source code" do
     error_messages = []
     exempt = /vendor|vcr_cassettes|CODE_OF_CONDUCT/
-    lib_tracked_files.split("\x0").each do |filename|
+    lib_tracked_files.each do |filename|
       next if filename =~ exempt
       error_messages << check_for_expendable_words(filename)
       error_messages << check_for_specific_pronouns(filename)
@@ -185,7 +185,7 @@ RSpec.describe "The library itself" do
     Bundler::Settings::ARRAY_KEYS.each {|k| all_settings[k] << "in Bundler::Settings::ARRAY_KEYS" }
 
     key_pattern = /([a-z\._-]+)/i
-    lib_tracked_files.split("\x0").each do |filename|
+    lib_tracked_files.each do |filename|
       each_line(filename) do |line, number|
         line.scan(/Bundler\.settings\[:#{key_pattern}\]/).flatten.each {|s| all_settings[s] << "referenced at `#{filename}:#{number.succ}`" }
       end
@@ -216,7 +216,7 @@ RSpec.describe "The library itself" do
   end
 
   it "ships the correct set of files" do
-    git_list = shipped_files.split("\x0")
+    git_list = shipped_files
 
     gem_list = Gem::Specification.load(gemspec.to_s).files
 
@@ -231,7 +231,7 @@ RSpec.describe "The library itself" do
       lib/bundler/vlad.rb
       lib/bundler/templates/gems.rb
     ]
-    files_to_require = lib_tracked_files.split("\x0").grep(/\.rb$/) - exclusions
+    files_to_require = lib_tracked_files.grep(/\.rb$/) - exclusions
     files_to_require.reject! {|f| f.start_with?("lib/bundler/vendor") }
     files_to_require.map! {|f| File.expand_path("../#{f}", __dir__) }
     sys_exec!("ruby -w") do |input, _, _|
@@ -250,7 +250,7 @@ RSpec.describe "The library itself" do
   it "does not use require internally, but require_relative" do
     exempt = %r{templates/|vendor/}
     all_bad_requires = []
-    lib_tracked_files.split("\x0").each do |filename|
+    lib_tracked_files.each do |filename|
       next if filename =~ exempt
       each_line(filename) do |line, number|
         line.scan(/^ *require "bundler/).each { all_bad_requires << "#{filename}:#{number.succ}" }

--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -34,19 +34,19 @@ module Spec
     end
 
     def tracked_files
-      @tracked_files ||= sys_exec(ruby_core? ? "git ls-files -z -- lib/bundler lib/bundler.rb spec/bundler man/bundler*" : "git ls-files -z", :dir => root)
+      @tracked_files ||= sys_exec(ruby_core? ? "git ls-files -z -- lib/bundler lib/bundler.rb spec/bundler man/bundler*" : "git ls-files -z", :dir => root).split("\x0")
     end
 
     def shipped_files
-      @shipped_files ||= sys_exec(ruby_core? ? "git ls-files -z -- lib/bundler lib/bundler.rb man/bundler* libexec/bundle*" : "git ls-files -z -- lib man exe CHANGELOG.md LICENSE.md README.md bundler.gemspec", :dir => root)
+      @shipped_files ||= sys_exec(ruby_core? ? "git ls-files -z -- lib/bundler lib/bundler.rb man/bundler* libexec/bundle*" : "git ls-files -z -- lib man exe CHANGELOG.md LICENSE.md README.md bundler.gemspec", :dir => root).split("\x0")
     end
 
     def lib_tracked_files
-      @lib_tracked_files ||= sys_exec(ruby_core? ? "git ls-files -z -- lib/bundler lib/bundler.rb" : "git ls-files -z -- lib", :dir => root)
+      @lib_tracked_files ||= sys_exec(ruby_core? ? "git ls-files -z -- lib/bundler lib/bundler.rb" : "git ls-files -z -- lib", :dir => root).split("\x0")
     end
 
     def man_tracked_files
-      @man_tracked_files ||= sys_exec(ruby_core? ? "git ls-files -z -- man/bundler*" : "git ls-files -z -- man", :dir => root)
+      @man_tracked_files ||= sys_exec(ruby_core? ? "git ls-files -z -- man/bundler*" : "git ls-files -z -- man", :dir => root).split("\x0")
     end
 
     def tmp(*path)

--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -159,20 +159,6 @@ module Spec
       tmp "tmpdir", *args
     end
 
-    def with_root_gemspec
-      if ruby_core?
-        root_gemspec = root.join("bundler.gemspec")
-        # Dir.chdir for Dir.glob in gemspec
-        spec = Dir.chdir(root) { Gem::Specification.load(gemspec.to_s) }
-        spec.bindir = "libexec"
-        File.open(root_gemspec.to_s, "w") {|f| f.write spec.to_ruby }
-        yield(root_gemspec)
-        FileUtils.rm(root_gemspec)
-      else
-        yield(gemspec)
-      end
-    end
-
     def ruby_core?
       # avoid to warnings
       @ruby_core ||= nil


### PR DESCRIPTION
# Description:

Previous we were building a test gem in the root folder, and then moving it to `tmp/`. This could run into thread safety issues where two test build a test gem concurrently and one of them finishes and cleans it up before the other test uses it.
    
Now we copy all files to tmp first, and then build the gem safely in there.
    
This has the added benefits of:
    
* Not needing special code to support ruby-core, since we the tmp location is the same in both setups.
* Not needing the rubygems feature of building a gem on a folder and writing the result on a separate folder.

This PR fixes the flaky test failure mentioned in https://github.com/rubygems/rubygems/issues/3568#issuecomment-621113761.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
