### PR TITLE
Don't load system rubygems at all when `RGV` specified for tests

### DIFF
--- a/.github/workflows/ubuntu-bundler.yml
+++ b/.github/workflows/ubuntu-bundler.yml
@@ -27,6 +27,7 @@ jobs:
           - { ruby: 2.7.1, rgv: v3.0.6  }
     env:
       RGV: ${{ matrix.rgv }}
+      RUBYOPT: --disable-gems
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby

--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -72,7 +72,7 @@ namespace :spec do
 
       raise "Couldn't configure sudo correctly to preserve path" unless `ruby -v` == `sudo -E ruby -v`
 
-      sh("sudo -E bin/rspec --tag sudo")
+      sh("sudo -E --preserve-env=RUBYOPT bin/rspec --tag sudo")
     ensure
       system("sudo", "cp", "tmp/old_sudoers", "/etc/sudoers")
       system("sudo", "chown", "-R", ENV["USER"], "tmp")

--- a/bundler/lib/bundler/psyched_yaml.rb
+++ b/bundler/lib/bundler/psyched_yaml.rb
@@ -26,12 +26,3 @@ module Bundler
     YamlLibrarySyntaxError = ::ArgumentError
   end
 end
-
-require_relative "deprecate"
-begin
-  Bundler::Deprecate.skip_during do
-    require "rubygems/safe_yaml"
-  end
-rescue LoadError
-  # it's OK if the file isn't there
-end

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -292,8 +292,7 @@ RSpec.describe "bundle exec" do
       gem "rack"
     G
 
-    rubyopt = ENV["RUBYOPT"]
-    rubyopt = ["-r#{lib_dir}/bundler/setup", rubyopt].compact.join(" ")
+    rubyopt = opt_add("-r#{lib_dir}/bundler/setup", ENV["RUBYOPT"])
 
     bundle "exec 'echo $RUBYOPT'"
     expect(out).to eq(rubyopt)

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -292,13 +292,15 @@ RSpec.describe "bundle exec" do
       gem "rack"
     G
 
-    rubyopt = opt_add("-r#{lib_dir}/bundler/setup", ENV["RUBYOPT"])
+    bundler_setup_opt = "-r#{lib_dir}/bundler/setup"
+
+    rubyopt = opt_add(bundler_setup_opt, ENV["RUBYOPT"])
 
     bundle "exec 'echo $RUBYOPT'"
-    expect(out).to eq(rubyopt)
+    expect(out.split(" ").count(bundler_setup_opt)).to eq(1)
 
     bundle "exec 'echo $RUBYOPT'", :env => { "RUBYOPT" => rubyopt }
-    expect(out).to eq(rubyopt)
+    expect(out.split(" ").count(bundler_setup_opt)).to eq(1)
   end
 
   it "does not duplicate already exec'ed RUBYLIB" do

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -733,7 +733,7 @@ The checksum of /versions does not match the checksum provided by the server! So
         gem "rack"
       G
 
-      bundle :install, :env => { "RUBYOPT" => "-I#{bundled_app("broken_ssl")}" }
+      bundle :install, :env => { "RUBYOPT" => opt_add("-I#{bundled_app("broken_ssl")}", ENV["RUBYOPT"]) }
       expect(err).to include("OpenSSL")
     end
   end

--- a/bundler/spec/install/gems/dependency_api_spec.rb
+++ b/bundler/spec/install/gems/dependency_api_spec.rb
@@ -706,7 +706,7 @@ RSpec.describe "gemcutter's dependency API" do
         gem "rack"
       G
 
-      bundle :install, :env => { "RUBYOPT" => "-I#{bundled_app("broken_ssl")}" }
+      bundle :install, :env => { "RUBYOPT" => opt_add("-I#{bundled_app("broken_ssl")}", ENV["RUBYOPT"]) }
       expect(err).to include("OpenSSL")
     end
   end

--- a/bundler/spec/install/gems/sudo_spec.rb
+++ b/bundler/spec/install/gems/sudo_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe "when using sudo", :sudo => true do
     end
 
     it "warns against that" do
-      bundle :install, :sudo => true
+      bundle :install, :sudo => :preserve_env
       expect(err).to include(warning)
     end
 
@@ -179,7 +179,7 @@ RSpec.describe "when using sudo", :sudo => true do
 
     context "when silence_root_warning = false" do
       it "warns against that" do
-        bundle :install, :sudo => true, :env => { "BUNDLE_SILENCE_ROOT_WARNING" => "false" }
+        bundle :install, :sudo => :preserve_env, :env => { "BUNDLE_SILENCE_ROOT_WARNING" => "false" }
         expect(err).to include(warning)
       end
     end

--- a/bundler/spec/runtime/gem_tasks_spec.rb
+++ b/bundler/spec/runtime/gem_tasks_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
 
   it "includes the relevant tasks" do
     with_gem_path_as(Spec::Path.base_system_gems.to_s) do
-      sys_exec "#{rake} -T", :env => { "RUBYOPT" => "-I#{lib_dir}" }
+      sys_exec "#{rake} -T", :env => { "RUBYOPT" => opt_add("-I#{lib_dir}", ENV["RUBYOPT"]) }
     end
 
     expect(err).to be_empty
@@ -47,7 +47,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
 
   it "defines a working `rake install` task" do
     with_gem_path_as(Spec::Path.base_system_gems.to_s) do
-      sys_exec "#{rake} install", :env => { "RUBYOPT" => "-I#{lib_dir}" }
+      sys_exec "#{rake} install", :env => { "RUBYOPT" => opt_add("-I#{lib_dir}", ENV["RUBYOPT"]) }
     end
 
     expect(err).to be_empty

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -1372,7 +1372,7 @@ end
     end
 
     it "takes care of requiring rubygems" do
-      sys_exec("#{Gem.ruby} -I#{lib_dir} -rbundler/setup -e'puts true'", :env => { "RUBYOPT" => "--disable=gems" })
+      sys_exec("#{Gem.ruby} -I#{lib_dir} -rbundler/setup -e'puts true'", :env => { "RUBYOPT" => opt_add("--disable=gems", ENV["RUBYOPT"]) })
 
       expect(last_command.stdboth).to eq("true")
     end

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -1372,7 +1372,7 @@ end
     end
 
     it "takes care of requiring rubygems" do
-      sys_exec("#{Gem.ruby} -I#{lib_dir} -e \"puts require('bundler/setup')\"", :env => { "RUBYOPT" => "--disable=gems" })
+      sys_exec("#{Gem.ruby} -I#{lib_dir} -rbundler/setup -e'puts true'", :env => { "RUBYOPT" => "--disable=gems" })
 
       expect(last_command.stdboth).to eq("true")
     end

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -357,6 +357,10 @@ module Spec
       end
     end
 
+    def opt_add(option, options)
+      [option.strip, options].compact.join(" ")
+    end
+
     def break_git!
       FileUtils.mkdir_p(tmp("broken_path"))
       File.open(tmp("broken_path/git"), "w", 0o755) do |f|

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -203,6 +203,7 @@ module Spec
 
     def sys_exec(cmd, options = {})
       env = options[:env] || {}
+      env["RUBYOPT"] = opt_add("-r#{spec_dir}/support/switch_rubygems.rb", env["RUBYOPT"] || ENV["RUBYOPT"])
       dir = options[:dir] || bundled_app
       command_execution = CommandExecution.new(cmd.to_s, dir)
 

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -358,7 +358,13 @@ module Spec
     end
 
     def opt_add(option, options)
-      [option.strip, options].compact.join(" ")
+      [option.strip, options].compact.reject(&:empty?).join(" ")
+    end
+
+    def opt_remove(option, options)
+      return unless options
+
+      options.split(" ").reject {|opt| opt.strip == option.strip }.join(" ")
     end
 
     def break_git!

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -78,7 +78,7 @@ module Spec
 
     def bundle(cmd, options = {}, &block)
       with_sudo = options.delete(:sudo)
-      sudo = with_sudo == :preserve_env ? "sudo -E" : "sudo" if with_sudo
+      sudo = with_sudo == :preserve_env ? "sudo -E --preserve-env=RUBYOPT" : "sudo" if with_sudo
 
       bundle_bin = options.delete("bundle_bin") || bindir.join("bundle")
 

--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -13,8 +13,7 @@ module Spec
     end
 
     def gem_load(gem_name, bin_container)
-      require_relative "rubygems_version_manager"
-      RubygemsVersionManager.new(ENV["RGV"]).switch
+      require_relative "switch_rubygems"
 
       gem_load_and_activate(gem_name, bin_container)
     end

--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -3,7 +3,6 @@
 require_relative "path"
 
 $LOAD_PATH.unshift(Spec::Path.lib_dir.to_s)
-require "bundler"
 
 module Spec
   module Rubygems
@@ -94,6 +93,7 @@ module Spec
     end
 
     def gem_activate(gem_name)
+      require "bundler"
       gem_requirement = Bundler::LockfileParser.new(File.read(dev_lockfile)).dependencies[gem_name]&.requirement
       gem gem_name, gem_requirement
     end
@@ -101,6 +101,7 @@ module Spec
     def install_gems(gemfile, lockfile)
       old_gemfile = ENV["BUNDLE_GEMFILE"]
       ENV["BUNDLE_GEMFILE"] = gemfile.to_s
+      require "bundler"
       definition = Bundler::Definition.build(gemfile, lockfile, nil)
       definition.validate_runtime!
       Bundler::Installer.install(Path.root, definition, :path => ENV["GEM_HOME"])

--- a/bundler/spec/support/rubygems_version_manager.rb
+++ b/bundler/spec/support/rubygems_version_manager.rb
@@ -36,7 +36,7 @@ private
 
     cmd = [ruby, $0, *ARGV].compact
 
-    ENV["RUBYOPT"] = opt_add("-I#{local_copy_path.join("lib")}", ENV["RUBYOPT"])
+    ENV["RUBYOPT"] = opt_add("-I#{local_copy_path.join("lib")}", opt_remove("--disable-gems", ENV["RUBYOPT"]))
 
     exec(ENV, *cmd)
   end

--- a/bundler/spec/support/rubygems_version_manager.rb
+++ b/bundler/spec/support/rubygems_version_manager.rb
@@ -36,7 +36,7 @@ private
 
     cmd = [ruby, $0, *ARGV].compact
 
-    ENV["RUBYOPT"] = ["-I#{local_copy_path.join("lib")}", ENV["RUBYOPT"]].compact.join(" ")
+    ENV["RUBYOPT"] = opt_add("-I#{local_copy_path.join("lib")}", ENV["RUBYOPT"])
 
     exec(ENV, *cmd)
   end

--- a/bundler/spec/support/rubygems_version_manager.rb
+++ b/bundler/spec/support/rubygems_version_manager.rb
@@ -15,9 +15,32 @@ class RubygemsVersionManager
   def switch
     return if use_system?
 
+    assert_system_features_not_loaded!
+
     switch_local_copy_if_needed
 
     reexec_if_needed
+  end
+
+  def assert_system_features_not_loaded!
+    at_exit do
+      rubylibdir = RbConfig::CONFIG["rubylibdir"]
+
+      rubygems_path = rubylibdir + "/rubygems"
+      rubygems_default_path = rubygems_path + "/defaults"
+
+      bundler_path = rubylibdir + "/bundler"
+      bundler_exemptions = Gem.rubygems_version < Gem::Version.new("3.2.0") ? [bundler_path + "/errors.rb"] : []
+
+      bad_loaded_features = $LOADED_FEATURES.select do |loaded_feature|
+        (loaded_feature.start_with?(rubygems_path) && !loaded_feature.start_with?(rubygems_default_path)) ||
+          (loaded_feature.start_with?(bundler_path) && !bundler_exemptions.any? {|bundler_exemption| loaded_feature.start_with?(bundler_exemption) })
+      end
+
+      if bad_loaded_features.any?
+        raise "the following features were incorrectly loaded:\n#{bad_loaded_features.join("\n")}"
+      end
+    end
   end
 
 private

--- a/bundler/spec/support/switch_rubygems.rb
+++ b/bundler/spec/support/switch_rubygems.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require_relative "rubygems_version_manager"
+RubygemsVersionManager.new(ENV["RGV"]).switch

--- a/bundler/test_gems.rb.lock
+++ b/bundler/test_gems.rb.lock
@@ -23,6 +23,7 @@ GEM
     tilt (2.0.10)
 
 PLATFORMS
+  java
   ruby
 
 DEPENDENCIES

--- a/bundler/tool/turbo_tests/runner.rb
+++ b/bundler/tool/turbo_tests/runner.rb
@@ -78,7 +78,7 @@ module TurboTests
       else
         require "securerandom"
         env["RSPEC_FORMATTER_OUTPUT_ID"] = SecureRandom.uuid
-        env["RUBYOPT"] = "-I#{File.expand_path("..", __dir__)}"
+        env["RUBYOPT"] = ["-I#{File.expand_path("..", __dir__)}", ENV["RUBYOPT"]].compact.join(" ")
 
         command_name = Gem.win_platform? ? [Gem.ruby, "bin/rspec"] : "bin/rspec"
 

--- a/lib/rubygems/indexer.rb
+++ b/lib/rubygems/indexer.rb
@@ -4,14 +4,6 @@ require 'rubygems/package'
 require 'time'
 require 'tmpdir'
 
-rescue_exceptions = [LoadError]
-begin
-  require 'bundler/errors'
-rescue LoadError # this rubygems + old ruby
-else # this rubygems + ruby trunk with bundler
-  rescue_exceptions << Bundler::GemfileNotFound
-end
-
 ##
 # Top level class for building the gem repository index.
 


### PR DESCRIPTION
# Description:

In #3592 I noticed that "system rubygems" is being loaded by our tests. I think this is fine if we don't specify `ENV["RGV"]` but if we do, rubygems should always be picked up from there.

This PR tries to implement that.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
