### PR TITLE
Remove old `gauntlet_rubygems.rb` file on rubygems upgrade

### DIFF
--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -604,6 +604,9 @@ abort "#{deprecation_message}"
 
       to_remove = old_lib_files - lib_files
 
+      gauntlet_rubygems = File.join(lib_dir, 'gauntlet_rubygems.rb')
+      to_remove << gauntlet_rubygems if File.exist? gauntlet_rubygems
+
       to_remove.delete_if do |file|
         file.start_with? 'defaults'
       end

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -277,11 +277,13 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     engine_defaults_rb = File.join lib_rubygems_defaults, 'jruby.rb'
     os_defaults_rb     = File.join lib_rubygems_defaults, 'operating_system.rb'
 
+    old_gauntlet_rubygems_rb = File.join lib, 'gauntlet_rubygems.rb'
+
     old_builder_rb     = File.join lib_rubygems, 'builder.rb'
     old_format_rb      = File.join lib_rubygems, 'format.rb'
     old_bundler_c_rb   = File.join lib_bundler,  'c.rb'
 
-    files_that_go   = [old_builder_rb, old_format_rb, old_bundler_c_rb]
+    files_that_go   = [old_gauntlet_rubygems_rb, old_builder_rb, old_format_rb, old_bundler_c_rb]
     files_that_stay = [securerandom_rb, engine_defaults_rb, os_defaults_rb]
 
     create_dummy_files(files_that_go + files_that_stay)


### PR DESCRIPTION
# Description:

The file was removed at https://github.com/rubygems/rubygems/commit/65b709b095b8354ac2620d1a5d7d537e539f6498, shipped with rubygems 2.6.5.

There's a similar situation with the `ubygems.rb` file, but since that file was more documented and widely used, I think it's a good deprecation path to keep doing what we've been doing until now: nothing, leave the file in there.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
