### PR TITLE
Remove `:path => :bundle path` calls from specs

### DIFF
--- a/bundler/spec/cache/gems_spec.rb
+++ b/bundler/spec/cache/gems_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "bundle cache" do
         gem 'rack'
       G
 
-      system_gems "rack-1.0.0", :path => :bundle_path
+      system_gems "rack-1.0.0", :path => path
       bundle! :cache
     end
 
@@ -75,11 +75,13 @@ RSpec.describe "bundle cache" do
 
   context "using system gems" do
     before { bundle! "config set path.system true" }
+    let(:path) { system_gem_path }
     it_behaves_like "when there are only gemsources"
   end
 
   context "installing into a local path" do
     before { bundle! "config set path ./.bundle" }
+    let(:path) { local_gem_path }
     it_behaves_like "when there are only gemsources"
   end
 

--- a/bundler/spec/cache/gems_spec.rb
+++ b/bundler/spec/cache/gems_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "bundle cache" do
     end
 
     it "uses the cache as a source when installing gems with --local" do
-      system_gems [], :path => :bundle_path
+      system_gems [], :path => default_bundle_path
       bundle "install --local"
 
       expect(the_bundle).to include_gems("rack 1.0.0")
@@ -46,7 +46,7 @@ RSpec.describe "bundle cache" do
     end
 
     it "does not reinstall gems from the cache if they exist in the bundle" do
-      system_gems "rack-1.0.0", :path => :bundle_path
+      system_gems "rack-1.0.0", :path => default_bundle_path
 
       gemfile <<-G
         gem "rack"

--- a/bundler/spec/commands/check_spec.rb
+++ b/bundler/spec/commands/check_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe "bundle check" do
       end
     G
 
-    system_gems "rack-1.0.0", :path => :bundle_path
+    system_gems "rack-1.0.0", :path => default_bundle_path
 
     lockfile <<-G
       GEM
@@ -175,7 +175,7 @@ RSpec.describe "bundle check" do
       end
     G
 
-    system_gems "rack-1.0.0", :path => :bundle_path
+    system_gems "rack-1.0.0", :path => default_bundle_path
 
     lockfile <<-G
       GEM

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "bundle exec" do
   let(:system_gems_to_install) { %w[rack-1.0.0 rack-0.9.1] }
   before :each do
-    system_gems(system_gems_to_install, :path => :bundle_path)
+    system_gems(system_gems_to_install, :path => default_bundle_path)
   end
 
   it "works with --gemfile flag" do

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe "bundle install with gem sources" do
     end
 
     it "does not reinstall any gem that is already available locally" do
-      system_gems "activesupport-2.3.2", :path => :bundle_path
+      system_gems "activesupport-2.3.2", :path => default_bundle_path
 
       build_repo2 do
         build_gem "activesupport", "2.3.2" do |s|

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -252,7 +252,8 @@ RSpec.describe "bundle gem" do
     prepare_gemspec(bundled_app("newgem", "newgem.gemspec"))
 
     gems = ["rake-13.0.1"]
-    system_gems gems, :path => :bundle_path, :bundle_dir => bundled_app("newgem")
+    path = Bundler.feature_flag.default_install_uses_path? ? local_gem_path(:base => bundled_app("newgem")) : system_gem_path
+    system_gems gems, :path => path
     bundle! "exec rake build", :dir => bundled_app("newgem")
 
     expect(last_command.stdboth).not_to include("ERROR")

--- a/bundler/spec/install/allow_offline_install_spec.rb
+++ b/bundler/spec/install/allow_offline_install_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "bundle install with :allow_offline_install" do
 
   context "with cached data locally" do
     it "will install from the compact index" do
-      system_gems ["rack-1.0.0"], :path => :bundle_path
+      system_gems ["rack-1.0.0"], :path => default_bundle_path
 
       bundle! "config set clean false"
       install_gemfile! <<-G, :artifice => "compact_index"

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe "bundle install from an existing gemspec" do
       s.add_dependency "platform_specific"
     end
 
-    system_gems "platform_specific-1.0-java", :path => :bundle_path, :keep_path => true
+    system_gems "platform_specific-1.0-java", :path => default_bundle_path, :keep_path => true
 
     install_gemfile! <<-G
       gemspec :path => '#{tmp.join("foo")}'

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -402,7 +402,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
     context "with an existing lockfile" do
       before do
-        system_gems "rack-0.9.1", "rack-1.0.0", :path => :bundle_path
+        system_gems "rack-0.9.1", "rack-1.0.0", :path => default_bundle_path
 
         lockfile <<-L
           GEM

--- a/bundler/spec/other/platform_spec.rb
+++ b/bundler/spec/other/platform_spec.rb
@@ -826,7 +826,7 @@ G
   context "bundle exec" do
     before do
       ENV["BUNDLER_FORCE_TTY"] = "true"
-      system_gems "rack-1.0.0", "rack-0.9.1", :path => :bundle_path
+      system_gems "rack-1.0.0", "rack-0.9.1", :path => default_bundle_path
     end
 
     it "activates the correct gem when ruby version matches" do
@@ -841,7 +841,7 @@ G
     end
 
     it "activates the correct gem when ruby version matches any engine", :jruby do
-      system_gems "rack-1.0.0", "rack-0.9.1", :path => :bundle_path
+      system_gems "rack-1.0.0", "rack-0.9.1", :path => default_bundle_path
       gemfile <<-G
         gem "rack", "0.9.1"
 

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -760,7 +760,7 @@ module Spec
         if opts[:to_system]
           @context.system_gems gem_path, :keep_path => true
         elsif opts[:to_bundle]
-          @context.system_gems gem_path, :path => :bundle_path, :keep_path => true
+          @context.system_gems gem_path, :path => @context.default_bundle_path, :keep_path => true
         else
           FileUtils.mv(gem_path, destination)
         end

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -390,11 +390,6 @@ module Spec
     def system_gems(*gems)
       opts = gems.last.is_a?(Hash) ? gems.last : {}
       path = opts.fetch(:path, system_gem_path)
-      if path == :bundle_path
-        bundle_dir = opts.fetch(:bundle_dir, bundled_app)
-        code = 'require "bundler"; begin; puts Bundler.bundle_path; rescue Bundler::GemfileNotFound; ENV["BUNDLE_GEMFILE"] = "Gemfile"; retry; end'
-        path = ruby!(code, :dir => bundle_dir)
-      end
       gems = gems.flatten
 
       unless opts[:keep_path]

--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -66,7 +66,7 @@ module Spec
 
     def default_bundle_path(*path)
       if Bundler.feature_flag.default_install_uses_path?
-        bundled_app(*[".bundle", Gem.ruby_engine, RbConfig::CONFIG["ruby_version"], *path].compact)
+        local_gem_path(*path)
       else
         system_gem_path(*path)
       end
@@ -137,6 +137,10 @@ module Spec
 
     def system_gem_path(*path)
       tmp("gems/system", *path)
+    end
+
+    def local_gem_path(*path)
+      bundled_app(*[".bundle", Gem.ruby_engine, RbConfig::CONFIG["ruby_version"], *path].compact)
     end
 
     def lib_path(*args)

--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -139,8 +139,8 @@ module Spec
       tmp("gems/system", *path)
     end
 
-    def local_gem_path(*path)
-      bundled_app(*[".bundle", Gem.ruby_engine, RbConfig::CONFIG["ruby_version"], *path].compact)
+    def local_gem_path(*path, base: bundled_app)
+      base.join(*[".bundle", Gem.ruby_engine, RbConfig::CONFIG["ruby_version"], *path].compact)
     end
 
     def lib_path(*args)

--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -65,10 +65,10 @@ module Spec
     end
 
     def default_bundle_path(*path)
-      if Bundler::VERSION.split(".").first.to_i < 3
-        system_gem_path(*path)
-      else
+      if Bundler.feature_flag.default_install_uses_path?
         bundled_app(*[".bundle", Gem.ruby_engine, RbConfig::CONFIG["ruby_version"], *path].compact)
+      else
+        system_gem_path(*path)
       end
     end
 


### PR DESCRIPTION
# Description:

Some specs pass a `path => :bundle_path` parameter to the `system_gems` helper. This calculates the path to which `bundler` would install specs by default (either the system gems path or a path under `./.bundle` depending on the major version of `bundler`).

In order to calculate this path, a ruby subprocess that loads `bundler` is used, and the output of this subprocess is used as the path.

This is super brittle, and I'm constant bitten by it, because adding debugging output to many parts of bundler results in this subprocess printing something that's not a path (because of the extra output), and causes weird test failures.

This PR refactors specs to not use this hack, so the debugging experience is better.

It also simplifies the code and should make it faster since a bunch of subproceses are skipped.

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
