### PR TITLE
Add max_retries, replace_resolv, and timeout for slow internet connections

### DIFF
--- a/test/rubygems/test_gem_request.rb
+++ b/test/rubygems/test_gem_request.rb
@@ -248,6 +248,23 @@ class TestGemRequest < Gem::TestCase
     assert_equal 'Wed, 02 Jan 2013 03:04:05 GMT', modified_header
   end
 
+  def test_fetch_with_slow_internet
+    uri = URI.parse "#{@gem_repo}/specs.#{Gem.marshal_version}"
+
+    response = util_stub_net_http(
+      body: :junk, code: 200, replace_resolv: true
+    ) do
+      @request = Gem::Request.create_with_proxy(
+        uri, Net::HTTP::Get, nil, nil, replace_resolv: true
+      )
+
+      @request.fetch
+    end
+
+    assert_equal 200, response.code
+    assert_equal :junk, response.body
+  end
+
   def test_user_agent
     ua = make_request(@uri, nil, nil, nil).user_agent
 


### PR DESCRIPTION
# Description:

Possible related issues: #2677 #3226 #1701 #585

In short, my internet sucks, which means, I have to call `gem install <some gem>` and `gem update` multiple times until they finally work.

By adding a `max_retries` and `timeout` setting, through my testing, I now only need to call these commands once.

I think this is important for people that live in countries/cities with poor quality of internet (especially developing countries).

## What was the end-user or developer problem that led to this PR?

When running `gem install <some gem>` or `gem update` with bad/slow internet, you'll constantly get this error:

`Failed to open TCP connection to rubygems.org:443 (getaddrinfo: Name or service not known) (SocketError)`

because the DNS resolver times out, or you'll get general timeout errors (Open/Read/SSL connect timeout errors).

## What is your fix for the problem, implemented in this PR?

By default, nothing is set/changed for users.

The user must change their `~/.gemrc` file:

```yaml
:max_retries: 3
:replace_resolv: true
:timeout: 300
```

`max_retries` must be an integer.

`timeout` is the number of seconds, which can be `nil`, a float, or an int. It sets the Open, Read, SSL, and Continue timeouts (via [Net::HTTP](https://ruby-doc.org/stdlib-2.7.0/libdoc/net/http/rdoc/Net/HTTP.html)).

`replace_resolv` will do:

```ruby
require 'resolv'
require 'resolv-replace'
```

In my testing, this didn't improve anything for me, but many Stackoverflow answers cite this as a way to improve DNS issues in Ruby with slow internet. I would recommend not setting this, and instead just using this:

```yaml
:max_retries: 3
:timeout: 300
```

Here are the default values:

```yaml
:max_retries: 0
:replace_resolv: false
:timeout: null # nil
```

______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
