### PR TITLE
Update links from rubygems/bundler to rubygems/rubygems

### DIFF
--- a/.github/ISSUE_TEMPLATE/bundler-related-issue.md
+++ b/.github/ISSUE_TEMPLATE/bundler-related-issue.md
@@ -13,7 +13,7 @@ Before processing your issue please confirm that:
 
 - [ ] You checked all the following documents and couldn't find a solution for your issue:
 
-- [Troubleshooting common issues](https://github.com/rubygems/bundler/blob/master/doc/TROUBLESHOOTING.md)
+- [Troubleshooting common issues](https://github.com/rubygems/rubygems/blob/master/bundler/doc/TROUBLESHOOTING.md)
 - [Bundler documentation site](https://bundler.io/)
 - [Bundler man pages](https://bundler.io/man/bundle.1.html)
 - [Bundler command line reference](https://bundler.io/v2.0/commands.html)

--- a/bundler/README.md
+++ b/bundler/README.md
@@ -55,8 +55,8 @@ While some Bundler contributors are compensated by Ruby Together, the project ma
 
 ### Code of Conduct
 
-Everyone interacting in the Bundler project's codebases, issue trackers, chat rooms, and mailing lists is expected to follow the [Bundler code of conduct](https://github.com/rubygems/bundler/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the Bundler project's codebases, issue trackers, chat rooms, and mailing lists is expected to follow the [Bundler code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
 
 ### License
 
-Bundler is available under an [MIT License](https://github.com/rubygems/bundler/blob/master/LICENSE.md).
+Bundler is available under an [MIT License](https://github.com/rubygems/rubygems/blob/master/bundler/LICENSE.md).

--- a/bundler/bundler.gemspec
+++ b/bundler/bundler.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   if s.respond_to?(:metadata=)
     s.metadata = {
-      "bug_tracker_uri" => "https://github.com/rubygems/rubygems/issues",
+      "bug_tracker_uri" => "https://github.com/rubygems/rubygems/issues?q=is%3Aopen+is%3Aissue+label%3ABundler",
       "changelog_uri" => "https://github.com/rubygems/rubygems/blob/master/bundler/CHANGELOG.md",
       "homepage_uri" => "https://bundler.io/",
       "source_code_uri" => "https://github.com/rubygems/rubygems/",

--- a/bundler/bundler.gemspec
+++ b/bundler/bundler.gemspec
@@ -24,10 +24,10 @@ Gem::Specification.new do |s|
 
   if s.respond_to?(:metadata=)
     s.metadata = {
-      "bug_tracker_uri" => "https://github.com/rubygems/bundler/issues",
-      "changelog_uri" => "https://github.com/rubygems/bundler/blob/master/CHANGELOG.md",
+      "bug_tracker_uri" => "https://github.com/rubygems/rubygems/issues",
+      "changelog_uri" => "https://github.com/rubygems/rubygems/blob/master/bundler/CHANGELOG.md",
       "homepage_uri" => "https://bundler.io/",
-      "source_code_uri" => "https://github.com/rubygems/bundler/",
+      "source_code_uri" => "https://github.com/rubygems/rubygems/",
     }
   end
 

--- a/bundler/doc/POLICIES.md
+++ b/bundler/doc/POLICIES.md
@@ -72,7 +72,7 @@ Contributors who have contributed regularly for more than six months (or impleme
 
 ### Enforcement guidelines
 
-First off, Bundler's policies and enforcement of those policies are subsidiary to [Bundler's code of conduct](https://github.com/rubygems/bundler/blob/master/CODE_OF_CONDUCT.md) in any case where they conflict. The first priority is treating human beings with respect and empathy, and figuring out project guidelines and sticking to them will always come after that.
+First off, Bundler's policies and enforcement of those policies are subsidiary to [Bundler's code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) in any case where they conflict. The first priority is treating human beings with respect and empathy, and figuring out project guidelines and sticking to them will always come after that.
 
 When it comes to carrying out our own policies, we're all regular humans trying to do the best we can. There will probably be times when we don't stick to our policies or goals. If you notice a discrepancy between real-life actions and these policies and goals, please bring it up! We want to make sure that our actions and our policies line up, and that our policies exemplify our goals.
 

--- a/bundler/doc/contributing/HOW_YOU_CAN_HELP.md
+++ b/bundler/doc/contributing/HOW_YOU_CAN_HELP.md
@@ -19,7 +19,7 @@ Generally, great ways to get started helping out with Bundler are:
   - closing issues that are not complete
   - adding a failing test for reproducible [reported bugs](https://github.com/rubygems/rubygems/issues)
   - reviewing [pull requests](https://github.com/rubygems/rubygems/pulls) and suggesting improvements
-  - improving existing code, including suggestions from [CodeClimate](https://codeclimate.com/github/rubygems/bundler)
+  - improving existing code, including suggestions from [CodeClimate](https://codeclimate.com/github/rubygems/rubygems)
   - writing code (no patch is too small! fix typos or bad whitespace)
     - get started setting up your dev environment with [these instructions](../development/SETUP.md)
   - backfilling [unit tests](https://github.com/rubygems/rubygems/tree/master/bundler/spec/bundler) for modules that lack coverage.

--- a/bundler/doc/contributing/ISSUES.md
+++ b/bundler/doc/contributing/ISSUES.md
@@ -46,6 +46,6 @@ If your version of Bundler does not have the `bundle env` command, then please i
 
 If you have either `rubygems-bundler` or `open_gem` installed, please try removing them and then following the troubleshooting steps above before opening a new ticket.
 
-[Create a gist](https://gist.github.com) containing all of that information, then visit the [Bundler issue tracker](https://github.com/rubygems/bundler/issues) and [create a ticket](https://github.com/rubygems/bundler/issues/new) describing your problem and linking to your gist.
+[Create a gist](https://gist.github.com) containing all of that information, then visit the [Bundler issue tracker](https://github.com/rubygems/rubygems/issues) and [create a ticket](https://github.com/rubygems/rubygems/issues/new?labels=Bundler&template=bundler-related-issue.md) describing your problem and linking to your gist.
 
 Thanks for reporting issues and helping make Bundler better!

--- a/bundler/doc/contributing/ISSUES.md
+++ b/bundler/doc/contributing/ISSUES.md
@@ -46,6 +46,6 @@ If your version of Bundler does not have the `bundle env` command, then please i
 
 If you have either `rubygems-bundler` or `open_gem` installed, please try removing them and then following the troubleshooting steps above before opening a new ticket.
 
-[Create a gist](https://gist.github.com) containing all of that information, then visit the [Bundler issue tracker](https://github.com/rubygems/rubygems/issues) and [create a ticket](https://github.com/rubygems/rubygems/issues/new?labels=Bundler&template=bundler-related-issue.md) describing your problem and linking to your gist.
+[Create a gist](https://gist.github.com) containing all of that information, then visit the [Bundler issue tracker](https://github.com/rubygems/rubygems/issues?q=is%3Aopen+is%3Aissue+label%3ABundler) and [create a ticket](https://github.com/rubygems/rubygems/issues/new?labels=Bundler&template=bundler-related-issue.md) describing your problem and linking to your gist.
 
 Thanks for reporting issues and helping make Bundler better!

--- a/bundler/doc/playbooks/TEAM_CHANGES.md
+++ b/bundler/doc/playbooks/TEAM_CHANGES.md
@@ -24,7 +24,7 @@ Interested in adding someone to the team? Here's the process.
 
 ## Removing a team member
 
-When the conditions in [POLICIES](https://github.com/rubygems/bundler/blob/master/doc/POLICIES.md#maintainer-team-guidelines) are met, or when team members choose to retire, here's how to remove someone from the team.
+When the conditions in [POLICIES](https://github.com/rubygems/rubygems/blob/master/bundler/doc/POLICIES.md#maintainer-team-guidelines) are met, or when team members choose to retire, here's how to remove someone from the team.
 
 - Remove them from the owners list on RubyGems.org by running
   ```
@@ -35,7 +35,7 @@ When the conditions in [POLICIES](https://github.com/rubygems/bundler/blob/maste
 - Remove them from the [maintainers team][org_team] on GitHub
 - Remove them from the maintainers Slack channel
 
-[policies]: https://github.com/rubygems/bundler/blob/master/doc/POLICIES.md#bundler-policies
+[policies]: https://github.com/rubygems/rubygems/blob/master/bundler/doc/POLICIES.md#bundler-policies
 [org_team]: https://github.com/orgs/bundler/teams/maintainers/members
 [team]: https://bundler.io/contributors.html
 [maintainers]: https://github.com/rubygems/bundler-site/blob/02483d3f79f243774722b3fc18a471ca77b1c424/source/contributors.html.haml#L25

--- a/bundler/lib/bundler/cli/issue.rb
+++ b/bundler/lib/bundler/cli/issue.rb
@@ -10,7 +10,7 @@ module Bundler
         be sure to check out these resources:
 
         1. Check out our troubleshooting guide for quick fixes to common issues:
-        https://github.com/rubygems/bundler/blob/master/doc/TROUBLESHOOTING.md
+        https://github.com/rubygems/rubygems/blob/master/bundler/doc/TROUBLESHOOTING.md
 
         2. Instructions for common Bundler uses can be found on the documentation
         site: https://bundler.io/
@@ -22,7 +22,7 @@ module Bundler
         still aren't working the way you expect them to, please let us know so
         that we can diagnose and help fix the problem you're having. Please
         view the Filing Issues guide for more information:
-        https://github.com/rubygems/bundler/blob/master/doc/contributing/ISSUES.md
+        https://github.com/rubygems/rubygems/blob/master/bundler/doc/contributing/ISSUES.md
 
       EOS
 

--- a/bundler/lib/bundler/friendly_errors.rb
+++ b/bundler/lib/bundler/friendly_errors.rb
@@ -76,7 +76,7 @@ module Bundler
 
           I tried...
 
-        - **Have you read our issues document, https://github.com/rubygems/rubygems/blob/master/doc/contributing/ISSUES.md?**
+        - **Have you read our issues document, https://github.com/rubygems/rubygems/blob/master/bundler/doc/contributing/ISSUES.md?**
 
           ...
 
@@ -100,7 +100,7 @@ module Bundler
         #{issues_url(e)}
 
         If there aren't any reports for this error yet, please create copy and paste the report template above into a new issue. Don't forget to anonymize any private data! The new issue form is located at:
-        https://github.com/rubygems/rubygems/issues/new
+        https://github.com/rubygems/rubygems/issues/new?labels=Bundler
       EOS
     end
 

--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -18,7 +18,7 @@ module Bundler
         def initialize(command)
           msg = String.new
           msg << "Bundler is trying to run a `git #{command}` at runtime. You probably need to run `bundle install`. However, "
-          msg << "this error message could probably be more useful. Please submit a ticket at https://github.com/rubygems/bundler/issues "
+          msg << "this error message could probably be more useful. Please submit a ticket at https://github.com/rubygems/rubygems/issues/new?labels=Bundler&template=bundler-related-issue.md "
           msg << "with steps to reproduce as well as the following\n\nCALLER: #{caller.join("\n")}"
           super msg
         end


### PR DESCRIPTION
Updates links from [github.com/rubygems/bundler](https://github.com/rubygems/bundler) to [github.com/rubygems/rubygems](https://github.com/rubygems/rubygems) as the former repository has been archived on GitHub.