### PR TITLE
3.1 backport - Deprecate rubyforge_project attribute only during build time.

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -566,6 +566,7 @@ test/rubygems/sff/discover.rb
 test/rubygems/simple_gem.rb
 test/rubygems/specifications/bar-0.0.2.gemspec
 test/rubygems/specifications/foo-0.0.1-x86-mswin32.gemspec
+test/rubygems/specifications/rubyforge-0.0.1.gemspec
 test/rubygems/ssl_cert.pem
 test/rubygems/ssl_key.pem
 test/rubygems/test_bundled_ca.rb

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -75,6 +75,8 @@ class Gem::SpecificationPolicy
 
     validate_dependencies
 
+    validate_removed_attributes
+
     if @warnings > 0
       if strict
         error "specification has warnings"
@@ -406,6 +408,12 @@ http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard li
     return if File.read(executable_path, 2) == '#!'
 
     warning "#{executable_path} is missing #! line"
+  end
+
+  def validate_removed_attributes # :nodoc:
+    @specification.removed_method_calls.each do |attr|
+      warning("#{attr} is deprecated and ignored. Please remove this from your gemspec to ensure that your gem continues to build in the future.")
+    end
   end
 
   def warning(statement) # :nodoc:

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -96,6 +96,8 @@ class Gem::TestCase < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Uni
 
   TEST_PATH = ENV.fetch('RUBYGEMS_TEST_PATH', File.expand_path('../../../test/rubygems', __FILE__))
 
+  SPECIFICATIONS = File.expand_path(File.join(TEST_PATH, "specifications"), __FILE__)
+
   def assert_activate(expected, *specs)
     specs.each do |spec|
       case spec

--- a/test/rubygems/specifications/rubyforge-0.0.1.gemspec
+++ b/test/rubygems/specifications/rubyforge-0.0.1.gemspec
@@ -1,0 +1,14 @@
+# -*- encoding: utf-8 -*-
+
+Gem::Specification.new do |s|
+  s.name              = "rubyforge"
+  s.version           = "0.0.1"
+  s.platform          = "ruby"
+  s.require_paths     = ["lib"]
+  s.summary           = "A very bar gem"
+  s.authors           = ["unknown"]
+  s.license           = 'MIT'
+  s.homepage          = 'http://example.com'
+  s.files             = ['README.md']
+  s.rubyforge_project = 'abc'
+end

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -122,6 +122,23 @@ class TestGemCommandsBuildCommand < Gem::TestCase
     util_test_build_gem @gem
   end
 
+  def test_execute_rubyforge_project_warning
+    rubyforge_gemspec = File.join SPECIFICATIONS, "rubyforge-0.0.1.gemspec"
+
+    @cmd.options[:args] = [rubyforge_gemspec]
+
+    use_ui @ui do
+      Dir.chdir @tempdir do
+        @cmd.execute
+      end
+    end
+
+    error = @ui.error.split("\n")
+    assert_equal "WARNING:  rubyforge_project= is deprecated and ignored. Please remove this from your gemspec to ensure that your gem continues to build in the future.", error.shift
+    assert_equal "WARNING:  See http://guides.rubygems.org/specification-reference/ for help", error.shift
+    assert_equal [], error
+  end
+
   def test_execute_strict_with_warnings
     bad_gem = util_spec 'some_bad_gem' do |s|
       s.files = ['README.md']

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3128,6 +3128,21 @@ http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
     warning
   end
 
+  def test_removed_methods
+    assert_equal Gem::Specification::REMOVED_METHODS, [:rubyforge_project=]
+  end
+
+  def test_validate_removed_rubyforge_project
+    util_setup_validate
+
+    use_ui @ui do
+      @a1.rubyforge_project = 'invalid-attribute'
+      @a1.validate
+    end
+
+    assert_match "rubyforge_project= is deprecated", @ui.error
+  end
+
   def test_validate_license_values
     util_setup_validate
 

--- a/test/rubygems/test_gem_stub_specification.rb
+++ b/test/rubygems/test_gem_stub_specification.rb
@@ -4,7 +4,6 @@ require "rubygems/stub_specification"
 
 class TestStubSpecification < Gem::TestCase
 
-  SPECIFICATIONS = File.expand_path(File.join("..", "specifications"), __FILE__)
   FOO = File.join SPECIFICATIONS, "foo-0.0.1-x86-mswin32.gemspec"
   BAR = File.join SPECIFICATIONS, "bar-0.0.2.gemspec"
 


### PR DESCRIPTION
- backports #3506 to 3.1