### PR TITLE
Make sure `install_if` specs are run and pass

### DIFF
--- a/bundler/spec/install/gemfile/install_if_spec.rb
+++ b/bundler/spec/install/gemfile/install_if_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "bundle install with install_if conditionals" do
             rack
 
       PLATFORMS
-        ruby
+        #{lockfile_platforms}
 
       DEPENDENCIES
         activesupport (= 2.3.5)


### PR DESCRIPTION

# Description:

As discovered and fixed by @hsbt at https://github.com/rubygems/rubygems/pull/3612, this test file was unrunnable.

We hadn't noticed because it was not being run by default due to its unconventional naming.

This PR fixes the name so that the file is run by default by RSpec.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
