### PR TITLE
Remove Inch CI badge from Bundler’s readme

### DIFF
--- a/bundler/README.md
+++ b/bundler/README.md
@@ -1,6 +1,5 @@
-[![Version     ](https://img.shields.io/gem/v/bundler.svg?style=flat)](https://rubygems.org/gems/bundler)
-[![Inline docs ](https://inch-ci.org/github/rubygems/bundler.svg?style=flat)](https://inch-ci.org/github/rubygems/bundler)
-[![Slack       ](https://bundler-slackin.herokuapp.com/badge.svg)](https://bundler-slackin.herokuapp.com)
+[![Version ](https://img.shields.io/gem/v/bundler.svg?style=flat)](https://rubygems.org/gems/bundler)
+[![Slack   ](https://bundler-slackin.herokuapp.com/badge.svg)](https://bundler-slackin.herokuapp.com)
 
 # Bundler: a gem to bundle gems
 


### PR DESCRIPTION
The badge is still linked to the now-archived [rubygems/bundler](https://github.com/rubygems/bundler) repository. In https://github.com/rubygems/rubygems/pull/3606#discussion_r422361525, @deivid-rodriguez questioned whether anyone cares about Inch CI and whether it could even be configured to work well with both RubyGems and Bundler in one repository. Furthermore, both [Inch](https://github.com/rrrene/inch) and [Inch CI](https://github.com/inch-ci/inch_ci-web) haven’t seen much, if any, maintenance over the last few years.

Finally, [the old repository has only ever been built about ten times](https://inch-ci.org/github/rubygems/bundler/builds). Although, granted, these builds have all been within the last four months.

All in all, I think it’s worth considering removing this badge.