### PR TITLE
Update friendly errors to the current repo name

### DIFF
--- a/bundler/lib/bundler/friendly_errors.rb
+++ b/bundler/lib/bundler/friendly_errors.rb
@@ -76,7 +76,7 @@ module Bundler
 
           I tried...
 
-        - **Have you read our issues document, https://github.com/rubygems/bundler/blob/master/doc/contributing/ISSUES.md?**
+        - **Have you read our issues document, https://github.com/rubygems/rubygems/blob/master/doc/contributing/ISSUES.md?**
 
           ...
 
@@ -100,7 +100,7 @@ module Bundler
         #{issues_url(e)}
 
         If there aren't any reports for this error yet, please create copy and paste the report template above into a new issue. Don't forget to anonymize any private data! The new issue form is located at:
-        https://github.com/rubygems/bundler/issues/new
+        https://github.com/rubygems/rubygems/issues/new
       EOS
     end
 
@@ -108,7 +108,7 @@ module Bundler
       message = exception.message.lines.first.tr(":", " ").chomp
       message = message.split("-").first if exception.is_a?(Errno)
       require "cgi"
-      "https://github.com/rubygems/bundler/search?q=" \
+      "https://github.com/rubygems/rubygems/search?q=" \
         "#{CGI.escape(message)}&type=Issues"
     end
   end

--- a/bundler/spec/bundler/friendly_errors_spec.rb
+++ b/bundler/spec/bundler/friendly_errors_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe Bundler, "friendly errors" do
     it "generates a search URL for the exception message" do
       exception = Exception.new("Exception message")
 
-      expect(Bundler::FriendlyErrors.issues_url(exception)).to eq("https://github.com/rubygems/bundler/search?q=Exception+message&type=Issues")
+      expect(Bundler::FriendlyErrors.issues_url(exception)).to eq("https://github.com/rubygems/rubygems/search?q=Exception+message&type=Issues")
     end
 
     it "generates a search URL for only the first line of a multi-line exception message" do
@@ -224,7 +224,7 @@ First line of the exception message
 Second line of the exception message
 END
 
-      expect(Bundler::FriendlyErrors.issues_url(exception)).to eq("https://github.com/rubygems/bundler/search?q=First+line+of+the+exception+message&type=Issues")
+      expect(Bundler::FriendlyErrors.issues_url(exception)).to eq("https://github.com/rubygems/rubygems/search?q=First+line+of+the+exception+message&type=Issues")
     end
 
     it "generates the url without colons" do
@@ -233,7 +233,7 @@ Exception ::: with ::: colons :::
 END
       issues_url = Bundler::FriendlyErrors.issues_url(exception)
       expect(issues_url).not_to include("%3A")
-      expect(issues_url).to eq("https://github.com/rubygems/bundler/search?q=#{CGI.escape("Exception     with     colons    ")}&type=Issues")
+      expect(issues_url).to eq("https://github.com/rubygems/rubygems/search?q=#{CGI.escape("Exception     with     colons    ")}&type=Issues")
     end
 
     it "removes information after - for Errono::EACCES" do
@@ -243,7 +243,7 @@ END
       allow(exception).to receive(:is_a?).with(Errno).and_return(true)
       issues_url = Bundler::FriendlyErrors.issues_url(exception)
       expect(issues_url).not_to include("/Users/foo/bar")
-      expect(issues_url).to eq("https://github.com/rubygems/bundler/search?q=#{CGI.escape("Errno  EACCES  Permission denied @ dir_s_mkdir ")}&type=Issues")
+      expect(issues_url).to eq("https://github.com/rubygems/rubygems/search?q=#{CGI.escape("Errno  EACCES  Permission denied @ dir_s_mkdir ")}&type=Issues")
     end
   end
 end


### PR DESCRIPTION
# Description:

<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

Update friendly errors to the current repo name

## What was the end-user or developer problem that led to this PR?

I encountered issues when using bundler as part of another project, and the error message was: 

```
Unfortunately, an unexpected error occurred, and Bundler cannot continue.

First, try this link to see if there are any existing issue reports for this error:
https://github.com/bundler/bundler/search?q=Too+many+open+files+%40+rb_sysopen+-+%2Fdev%2Fnull&type=Issues

If there aren't any reports for this error yet, please create copy and paste the report template above into a new issue. Don't forget to anonymize any private data! The new issue form is located at:
https://github.com/bundler/bundler/issues/new
```

However, https://github.com/bundler/bundler/ redirects to https://github.com/rubygems/bundler/, which is now archived, so I cannot log a new issue even if I wanted to. 


## What is your fix for the problem, implemented in this PR?

Looking at the last commit on rubygems/bundler before the archive, it looks like it's now part of this repo, so this PR changes the named repo that users to search for/log issues. 
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
