### PR TITLE
Bump vendored libraries

### DIFF
--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -213,6 +213,10 @@ else
     lib.vendor_lib = "lib/bundler/vendor/fileutils"
   end
 
+  # We currently include changes over the official version to avoid requiring
+  # the optional `net-http-pipeline` dependency, so that its version can be
+  # selected by end users. We also include changes to require the vendored
+  # dependencies `uri` and `connection_pool` relatively.
   desc "Vendor a specific version of net-http-persistent"
   Automatiek::RakeTask.new("net-http-persistent") do |lib|
     lib.download = { :github => "https://github.com/drbrain/net-http-persistent" }

--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -219,6 +219,7 @@ else
   # dependencies `uri` and `connection_pool` relatively.
   desc "Vendor a specific version of net-http-persistent"
   Automatiek::RakeTask.new("net-http-persistent") do |lib|
+    lib.version = "v4.0.0"
     lib.download = { :github => "https://github.com/drbrain/net-http-persistent" }
     lib.namespace = "Net::HTTP::Persistent"
     lib.prefix = "Bundler::Persistent"

--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -197,6 +197,7 @@ else
 
   desc "Vendor a specific version of thor"
   Automatiek::RakeTask.new("thor") do |lib|
+    lib.version = "v1.0.1"
     lib.download = { :github => "https://github.com/erikhuda/thor" }
     lib.namespace = "Thor"
     lib.prefix = "Bundler"

--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -206,6 +206,7 @@ else
 
   desc "Vendor a specific version of fileutils"
   Automatiek::RakeTask.new("fileutils") do |lib|
+    lib.version = "v1.4.1"
     lib.download = { :github => "https://github.com/ruby/fileutils" }
     lib.namespace = "FileUtils"
     lib.prefix = "Bundler"

--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -195,9 +195,6 @@ else
     lib.vendor_lib = "lib/bundler/vendor/molinillo"
   end
 
-  # We currently cherry-pick changes to use `require_relative` internally
-  # instead of regular `require`. They are already in thor's master branch but
-  # still need to be released.
   desc "Vendor a specific version of thor"
   Automatiek::RakeTask.new("thor") do |lib|
     lib.download = { :github => "https://github.com/erikhuda/thor" }

--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -213,9 +213,6 @@ else
     lib.vendor_lib = "lib/bundler/vendor/fileutils"
   end
 
-  # We currently cherry-pick changes to use `require_relative` internally
-  # instead of regular `require`. They are pending review at
-  # https://github.com/drbrain/net-http-persistent/pull/106
   desc "Vendor a specific version of net-http-persistent"
   Automatiek::RakeTask.new("net-http-persistent") do |lib|
     lib.download = { :github => "https://github.com/drbrain/net-http-persistent" }

--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -233,8 +233,10 @@ else
       sublib.vendor_lib = "lib/bundler/vendor/connection_pool"
     end
 
+    # We currently include changes over the official version to require internal paths
+    # relatively.
     lib.dependency("uri") do |sublib|
-      sublib.version = "master"
+      sublib.version = "v0.10.0"
       sublib.download = { :github => "https://github.com/ruby/uri" }
       sublib.namespace = "URI"
       sublib.prefix = "Bundler"

--- a/bundler/lib/bundler/vendor/thor/lib/thor.rb
+++ b/bundler/lib/bundler/vendor/thor/lib/thor.rb
@@ -344,13 +344,6 @@ class Bundler::Thor
       command && disable_required_check.include?(command.name.to_sym)
     end
 
-    def deprecation_warning(message) #:nodoc:
-      unless ENV['THOR_SILENCE_DEPRECATION']
-        warn "Deprecation warning: #{message}\n" +
-          'You can silence deprecations warning by setting the environment variable THOR_SILENCE_DEPRECATION.'
-      end
-    end
-
   protected
 
     def stop_on_unknown_option #:nodoc:

--- a/bundler/lib/bundler/vendor/thor/lib/thor/actions/create_link.rb
+++ b/bundler/lib/bundler/vendor/thor/lib/thor/actions/create_link.rb
@@ -33,7 +33,8 @@ class Bundler::Thor
       # Boolean:: true if it is identical, false otherwise.
       #
       def identical?
-        exists? && File.identical?(render, destination)
+        source = File.expand_path(render, File.dirname(destination))
+        exists? && File.identical?(source, destination)
       end
 
       def invoke!

--- a/bundler/lib/bundler/vendor/thor/lib/thor/base.rb
+++ b/bundler/lib/bundler/vendor/thor/lib/thor/base.rb
@@ -22,6 +22,15 @@ class Bundler::Thor
 
   TEMPLATE_EXTNAME = ".tt"
 
+  class << self
+    def deprecation_warning(message) #:nodoc:
+      unless ENV['THOR_SILENCE_DEPRECATION']
+        warn "Deprecation warning: #{message}\n" +
+          'You can silence deprecations warning by setting the environment variable THOR_SILENCE_DEPRECATION.'
+      end
+    end
+  end
+
   module Base
     attr_accessor :options, :parent_options, :args
 

--- a/bundler/lib/bundler/vendor/thor/lib/thor/version.rb
+++ b/bundler/lib/bundler/vendor/thor/lib/thor/version.rb
@@ -1,3 +1,3 @@
 class Bundler::Thor
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
# Description:

Just a review pass of our vendored code.

We're currently vendoring `uri`'s master branch because the [uri gem has no associated tag](https://github.com/ruby/uri/issues/7) and automatiek needs that.

For now I upgraded to latest master, but it's probably best to create the git tag, and revert to 0.10.0.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
