### PR TITLE
Fix activation issue on old rubygems versions

### DIFF
--- a/bundler/exe/bundle
+++ b/bundler/exe/bundle
@@ -15,6 +15,9 @@ else
   require "bundler"
 end
 
+# Workaround for non-activated bundler spec due to missing https://github.com/rubygems/rubygems/commit/4e306d7bcdee924b8d80ca9db6125aa59ee4e5a3
+gem "bundler", Bundler::VERSION if Gem.rubygems_version < Gem::Version.new("2.6.2")
+
 # Check if an older version of bundler is installed
 $LOAD_PATH.each do |path|
   next unless path =~ %r{/bundler-0\.(\d+)} && $1.to_i < 9

--- a/bundler/spec/runtime/gem_tasks_spec.rb
+++ b/bundler/spec/runtime/gem_tasks_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
   end
 
   it "includes the relevant tasks" do
-    with_gem_path_as(Spec::Path.base_system_gems.to_s) do
+    with_gem_path_as(base_system_gems.to_s) do
       sys_exec "#{rake} -T", :env => { "RUBYOPT" => opt_add("-I#{lib_dir}", ENV["RUBYOPT"]) }
     end
 
@@ -46,7 +46,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
   end
 
   it "defines a working `rake install` task" do
-    with_gem_path_as(Spec::Path.base_system_gems.to_s) do
+    with_gem_path_as(base_system_gems.to_s) do
       sys_exec "#{rake} install", :env => { "RUBYOPT" => opt_add("-I#{lib_dir}", ENV["RUBYOPT"]) }
     end
 
@@ -70,7 +70,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
   end
 
   it "adds 'pkg' to rake/clean's CLOBBER" do
-    with_gem_path_as(Spec::Path.base_system_gems.to_s) do
+    with_gem_path_as(base_system_gems.to_s) do
       sys_exec! %(#{rake} -e 'load "Rakefile"; puts CLOBBER.inspect')
     end
     expect(out).to eq '["pkg"]'

--- a/bundler/spec/runtime/gem_tasks_spec.rb
+++ b/bundler/spec/runtime/gem_tasks_spec.rb
@@ -68,6 +68,24 @@ RSpec.describe "require 'bundler/gem_tasks'" do
     end
   end
 
+  context "bundle path configured locally" do
+    before do
+      bundle "config set path vendor/bundle"
+    end
+
+    it "works" do
+      install_gemfile! <<-G
+        source "#{file_uri_for(gem_repo1)}"
+
+        gem "rake"
+      G
+
+      bundle! "exec rake -T"
+
+      expect(err).to be_empty
+    end
+  end
+
   it "adds 'pkg' to rake/clean's CLOBBER" do
     with_gem_path_as(base_system_gems.to_s) do
       sys_exec! %(#{rake} -e 'load "Rakefile"; puts CLOBBER.inspect'), :env => { "GEM_HOME" => system_gem_path.to_s }

--- a/bundler/spec/runtime/gem_tasks_spec.rb
+++ b/bundler/spec/runtime/gem_tasks_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
 
   it "includes the relevant tasks" do
     with_gem_path_as(base_system_gems.to_s) do
-      sys_exec "#{rake} -T", :env => { "RUBYOPT" => opt_add("-I#{lib_dir}", ENV["RUBYOPT"]) }
+      sys_exec "#{rake} -T"
     end
 
     expect(err).to be_empty
@@ -47,7 +47,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
 
   it "defines a working `rake install` task" do
     with_gem_path_as(base_system_gems.to_s) do
-      sys_exec "#{rake} install", :env => { "RUBYOPT" => opt_add("-I#{lib_dir}", ENV["RUBYOPT"]) }
+      sys_exec "#{rake} install"
     end
 
     expect(err).to be_empty

--- a/bundler/spec/runtime/gem_tasks_spec.rb
+++ b/bundler/spec/runtime/gem_tasks_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe "require 'bundler/gem_tasks'" do
 
     bundled_app("Rakefile").open("w") do |f|
       f.write <<-RAKEFILE
-        $:.unshift("#{lib_dir}")
         require "bundler/gem_tasks"
       RAKEFILE
     end
@@ -29,7 +28,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
 
   it "includes the relevant tasks" do
     with_gem_path_as(base_system_gems.to_s) do
-      sys_exec "#{rake} -T"
+      sys_exec "#{rake} -T", :env => { "GEM_HOME" => system_gem_path.to_s }
     end
 
     expect(err).to be_empty
@@ -47,7 +46,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
 
   it "defines a working `rake install` task" do
     with_gem_path_as(base_system_gems.to_s) do
-      sys_exec "#{rake} install"
+      sys_exec "#{rake} install", :env => { "GEM_HOME" => system_gem_path.to_s }
     end
 
     expect(err).to be_empty
@@ -71,7 +70,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
 
   it "adds 'pkg' to rake/clean's CLOBBER" do
     with_gem_path_as(base_system_gems.to_s) do
-      sys_exec! %(#{rake} -e 'load "Rakefile"; puts CLOBBER.inspect')
+      sys_exec! %(#{rake} -e 'load "Rakefile"; puts CLOBBER.inspect'), :env => { "GEM_HOME" => system_gem_path.to_s }
     end
     expect(out).to eq '["pkg"]'
   end


### PR DESCRIPTION
# Description:

On rubygems versions without https://github.com/rubygems/rubygems/commit/4e306d7bcdee924b8d80ca9db6125aa59ee4e5a3, the bundler spec might not be properly activated through the rubygems binstub.

In these cases, bundler still _sometimes_ work due to this hack here:

https://github.com/rubygems/rubygems/blob/8552046009342c790a1139ad212130c49d5a7b8a/bundler/lib/bundler/source/metadata.rb#L13-L27

But other times it doesn't work leading to crashes like https://github.com/rubygems/rubygems/issues/3570.

My goal with previous refactoring PRs was to be able to completely remove the above hack, but I'm not yet ready.

So for now, I explicitly activate the spec when running under those old rubygems versions.

Closes #3570.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
