### PR TITLE
Increase timeouts in test_gem_stream_ui.rb

### DIFF
--- a/test/rubygems/test_gem_stream_ui.rb
+++ b/test/rubygems/test_gem_stream_ui.rb
@@ -7,7 +7,7 @@ class TestGemStreamUI < Gem::TestCase
 
   # increase timeout with MJIT for --jit-wait testing
   mjit_enabled = defined?(RubyVM::MJIT) && RubyVM::MJIT.enabled?
-  SHORT_TIMEOUT = RUBY_ENGINE == "ruby" && !mjit_enabled ? 0.1 : 1.0
+  SHORT_TIMEOUT = (RUBY_ENGINE == "ruby" && !mjit_enabled) ? 0.1 : 1.0
 
   module IsTty
     attr_accessor :tty

--- a/test/rubygems/test_gem_stream_ui.rb
+++ b/test/rubygems/test_gem_stream_ui.rb
@@ -5,7 +5,9 @@ require 'timeout'
 
 class TestGemStreamUI < Gem::TestCase
 
-  SHORT_TIMEOUT = (defined?(RubyVM::MJIT) && RubyVM::MJIT.enabled?) ? 1.0 : 0.1 # increase timeout with MJIT for --jit-wait testing
+  # increase timeout with MJIT for --jit-wait testing
+  mjit_enabled = defined?(RubyVM::MJIT) && RubyVM::MJIT.enabled?
+  SHORT_TIMEOUT = RUBY_ENGINE == "ruby" && !mjit_enabled ? 0.1 : 1.0
 
   module IsTty
     attr_accessor :tty


### PR DESCRIPTION
* 0.1s is really short and fails in CI: #3622

cc @deivid-rodriguez 