### PR TITLE
Log messages to stdout in `rake package`

### DIFF
--- a/lib/rubygems/package_task.rb
+++ b/lib/rubygems/package_task.rb
@@ -88,6 +88,7 @@ class Gem::PackageTask < Rake::PackageTask
     super gem.full_name, :noversion
     @gem_spec = gem
     @package_files += gem_spec.files if gem_spec.files
+    @fileutils_output = $stdout
   end
 
   ##

--- a/test/rubygems/test_gem_package_task.rb
+++ b/test/rubygems/test_gem_package_task.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
 require 'rubygems'
-require 'bundler/errors'
-begin
-  require 'rubygems/package_task'
-rescue LoadError, Bundler::GemfileNotFound
-end
+require 'rubygems/package_task'
 
 class TestGemPackageTask < Gem::TestCase
 
@@ -81,4 +77,4 @@ class TestGemPackageTask < Gem::TestCase
     assert_equal 'pkg/nokogiri-1.5.0-java', pkg.package_dir_path
   end
 
-end if defined?(Rake::PackageTask)
+end

--- a/test/rubygems/test_gem_package_task.rb
+++ b/test/rubygems/test_gem_package_task.rb
@@ -9,7 +9,15 @@ class TestGemPackageTask < Gem::TestCase
     super
 
     Rake.application = Rake::Application.new
+
+    @original_rake_fileutils_verbosity = RakeFileUtils.verbose_flag
     RakeFileUtils.verbose_flag = false
+  end
+
+  def teardown
+    RakeFileUtils.verbose_flag = @original_rake_fileutils_verbosity
+
+    super
   end
 
   def test_gem_package

--- a/test/rubygems/test_gem_package_task.rb
+++ b/test/rubygems/test_gem_package_task.rb
@@ -11,7 +11,6 @@ class TestGemPackageTask < Gem::TestCase
     Rake.application = Rake::Application.new
 
     @original_rake_fileutils_verbosity = RakeFileUtils.verbose_flag
-    RakeFileUtils.verbose_flag = false
   end
 
   def teardown
@@ -21,6 +20,8 @@ class TestGemPackageTask < Gem::TestCase
   end
 
   def test_gem_package
+    RakeFileUtils.verbose_flag = false
+
     gem = Gem::Specification.new do |g|
       g.name = "pkgr"
       g.version = "1.2.3"
@@ -47,6 +48,8 @@ class TestGemPackageTask < Gem::TestCase
   end
 
   def test_gem_package_with_current_platform
+    RakeFileUtils.verbose_flag = false
+
     gem = Gem::Specification.new do |g|
       g.name = "pkgr"
       g.version = "1.2.3"
@@ -60,6 +63,8 @@ class TestGemPackageTask < Gem::TestCase
   end
 
   def test_gem_package_with_ruby_platform
+    RakeFileUtils.verbose_flag = false
+
     gem = Gem::Specification.new do |g|
       g.name = "pkgr"
       g.version = "1.2.3"
@@ -73,6 +78,8 @@ class TestGemPackageTask < Gem::TestCase
   end
 
   def test_package_dir_path
+    RakeFileUtils.verbose_flag = false
+
     gem = Gem::Specification.new do |g|
       g.name = 'nokogiri'
       g.version = '1.5.0'

--- a/test/rubygems/test_gem_package_task.rb
+++ b/test/rubygems/test_gem_package_task.rb
@@ -47,6 +47,34 @@ class TestGemPackageTask < Gem::TestCase
     end
   end
 
+  def test_gem_package_prints_to_stdout_by_default
+    gem = Gem::Specification.new do |g|
+      g.name = "pkgr"
+      g.version = "1.2.3"
+
+      g.authors = %w[author]
+      g.files = %w[x]
+      g.summary = 'summary'
+    end
+
+    pkg = Gem::PackageTask.new(gem) do |p|
+      p.package_files << "y"
+    end
+
+    assert_equal %w[x y], pkg.package_files
+
+    Dir.chdir @tempdir do
+      FileUtils.touch 'x'
+      FileUtils.touch 'y'
+
+      _, err = capture_io do
+        Rake.application['package'].invoke
+      end
+
+      assert_empty err
+    end
+  end
+
   def test_gem_package_with_current_platform
     RakeFileUtils.verbose_flag = false
 


### PR DESCRIPTION
# Description:

During some separate work, I was trying to make sure that `rake install` doesn't print any warnings in CI.

So what I was doing is:

* Run the command.
* Redirect the error to a file.
* Make sure the file is empty.

To my surprise, the file was full of logging messages from the `rake package` task.

The underlying issue is https://github.com/ruby/fileutils/pull/49.

But I think we can workaround it with this PR.
# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
