### PR TITLE
Avoid `ruby setup.rb` warnings

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -21,7 +21,9 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler: none
       - name: Install rubygems
-        run: ruby -Ilib -S rake install
+        run: ruby -Ilib -S rake install 2> errors.txt
+      - name: Check rubygems install produced no warnings
+        run: test ! -s errors.txt || (cat errors.txt && exit 1)
       - name: Run bundler installed as a default gem
         run: bundle --version
       - name: Check bundler man pages were installed and are properly picked up

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
 # -*- ruby -*-
 
+RakeFileUtils.verbose_flag = false
+
 require 'rubygems'
 require 'rubygems/package_task'
 require "rake/testtask"

--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -6,8 +6,8 @@
 #++
 
 require 'optparse'
-require 'rubygems/requirement'
-require 'rubygems/user_interaction'
+require_relative 'requirement'
+require_relative 'user_interaction'
 
 ##
 # Base class for all Gem commands.  When creating a new gem command, define

--- a/lib/rubygems/ext.rb
+++ b/lib/rubygems/ext.rb
@@ -10,9 +10,9 @@
 
 module Gem::Ext; end
 
-require 'rubygems/ext/build_error'
-require 'rubygems/ext/builder'
-require 'rubygems/ext/configure_builder'
-require 'rubygems/ext/ext_conf_builder'
-require 'rubygems/ext/rake_builder'
-require 'rubygems/ext/cmake_builder'
+require_relative 'ext/build_error'
+require_relative 'ext/builder'
+require_relative 'ext/configure_builder'
+require_relative 'ext/ext_conf_builder'
+require_relative 'ext/rake_builder'
+require_relative 'ext/cmake_builder'

--- a/lib/rubygems/ext/build_error.rb
+++ b/lib/rubygems/ext/build_error.rb
@@ -2,7 +2,7 @@
 ##
 # Raised when there is an error while building extensions.
 
-require 'rubygems/exceptions'
+require_relative '../exceptions'
 
 class Gem::Ext::BuildError < Gem::InstallError
 end

--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -5,7 +5,7 @@
 # See LICENSE.txt for permissions.
 #++
 
-require 'rubygems/user_interaction'
+require_relative '../user_interaction'
 
 class Gem::Ext::Builder
 

--- a/lib/rubygems/ext/cmake_builder.rb
+++ b/lib/rubygems/ext/cmake_builder.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rubygems/command'
+require_relative '../command'
 
 class Gem::Ext::CmakeBuilder < Gem::Ext::Builder
 

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -420,7 +420,7 @@ http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard li
   end
 
   def validate_extensions # :nodoc:
-    require 'rubygems/ext'
+    require_relative 'ext'
     builder = Gem::Ext::Builder.new(@specification)
 
     rake_extension = @specification.extensions.any? {|s| builder.builder_for(s) == Gem::Ext::RakeBuilder }

--- a/setup.rb
+++ b/setup.rb
@@ -19,7 +19,7 @@ end
 
 Dir.chdir File.dirname(__FILE__)
 
-$:.unshift 'lib'
+$:.unshift File.expand_path('lib')
 require 'rubygems'
 require 'rubygems/gem_runner'
 require 'rubygems/exceptions'


### PR DESCRIPTION
# Description:

The problem is that since https://github.com/rubygems/rubygems/pull/3580, running `ruby setup.rb` from a development copy of rubygems prints a bunch of redefinition warnings:

```
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/rubygems/exceptions.rb:281: warning: already initialized constant Gem::UnsatisfiableDepedencyError
/home/deivid/Code/rubygems/lib/rubygems/exceptions.rb:281: warning: previous definition of UnsatisfiableDepedencyError was here
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/rubygems/user_interaction.rb:557: warning: already initialized constant Gem::StreamUI::ThreadedDownloadReporter::MUTEX
/home/deivid/Code/rubygems/lib/rubygems/user_interaction.rb:557: warning: previous definition of MUTEX was here
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/rubygems/ext/builder.rb:20: warning: already initialized constant Gem::Ext::Builder::CHDIR_MUTEX
/home/deivid/Code/rubygems/lib/rubygems/ext/builder.rb:20: warning: previous definition of CHDIR_MUTEX was here
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/rubygems/ext/ext_conf_builder.rb:14: warning: already initialized constant Gem::Ext::ExtConfBuilder::FileEntry
/home/deivid/Code/rubygems/lib/rubygems/ext/ext_conf_builder.rb:14: warning: previous definition of FileEntry was here
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/rubygems/version.rb:158: warning: already initialized constant Gem::Version::VERSION_PATTERN
/home/deivid/Code/rubygems/lib/rubygems/version.rb:158: warning: previous definition of VERSION_PATTERN was here
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/rubygems/version.rb:159: warning: already initialized constant Gem::Version::ANCHORED_VERSION_PATTERN
/home/deivid/Code/rubygems/lib/rubygems/version.rb:159: warning: previous definition of ANCHORED_VERSION_PATTERN was here
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/rubygems/requirement.rb:14: warning: already initialized constant Gem::Requirement::OPS
/home/deivid/Code/rubygems/lib/rubygems/requirement.rb:14: warning: previous definition of OPS was here
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/rubygems/requirement.rb:24: warning: already initialized constant Gem::Requirement::SOURCE_SET_REQUIREMENT
/home/deivid/Code/rubygems/lib/rubygems/requirement.rb:24: warning: previous definition of SOURCE_SET_REQUIREMENT was here
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/rubygems/requirement.rb:27: warning: already initialized constant Gem::Requirement::PATTERN_RAW
/home/deivid/Code/rubygems/lib/rubygems/requirement.rb:27: warning: previous definition of PATTERN_RAW was here
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/rubygems/requirement.rb:32: warning: already initialized constant Gem::Requirement::PATTERN
/home/deivid/Code/rubygems/lib/rubygems/requirement.rb:32: warning: previous definition of PATTERN was here
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/rubygems/requirement.rb:37: warning: already initialized constant Gem::Requirement::DefaultRequirement
/home/deivid/Code/rubygems/lib/rubygems/requirement.rb:37: warning: previous definition of DefaultRequirement was here
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/rubygems/requirement.rb:42: warning: already initialized constant Gem::Requirement::DefaultPrereleaseRequirement
/home/deivid/Code/rubygems/lib/rubygems/requirement.rb:42: warning: previous definition of DefaultPrereleaseRequirement was here
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/rubygems/requirement.rb:311: warning: already initialized constant Gem::Version::Requirement
/home/deivid/Code/rubygems/lib/rubygems/requirement.rb:311: warning: previous definition of Requirement was here
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/rubygems/command.rb:626: warning: already initialized constant Gem::Command::HELP
/home/deivid/Code/rubygems/lib/rubygems/command.rb:626: warning: previous definition of HELP was here
  Successfully built RubyGem
  Name: bundler
  Version: 2.2.0.dev
  File: bundler-2.2.0.dev.gem
Bundler 2.2.0.dev installed
RubyGems 3.2.0.pre1 installed
Regenerating binstubs
Regenerating plugins



------------------------------------------------------------------------------

RubyGems installed the following executables:
	/home/deivid/.rbenv/versions/2.7.1/bin/gem
	/home/deivid/.rbenv/versions/2.7.1/bin/bundle
```

The problem is that `setup.rb` adds a relative `$LOAD_PATH` entry, and when the offending require happens we're in the middle of installing the default `bundler` gem and have switched folders to `bundler/`. So the dev copy of rubygems is not found and we fallback to the system rubygems.

To fix the issue, we add a full path to the `$LOAD_PATH`.

I added a check in CI to make sure that installing rubygems prints no warnings. To add that, I had to silence the development `rake install` task because due to https://github.com/rubygems/rubygems/pull/3632 and the related fileutils issue, it was printing a really really long log to standard error that messed up the check and didn't add much, really, other than being overwhelming. 

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
