### PR TITLE
Remove explicit `psych` activation

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -618,13 +618,6 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     return unless defined?(gem)
 
     begin
-      gem 'psych', '>= 2.0.0'
-    rescue Gem::LoadError
-      # It's OK if the user does not have the psych gem installed.  We will
-      # attempt to require the stdlib version
-    end
-
-    begin
       # Try requiring the gem version *or* stdlib version of psych.
       require 'psych'
     rescue ::LoadError


### PR DESCRIPTION
# Description:

We don't need to explictly activate `psych` since `require` will take care of that automatically.

We don't need to care about a minimum version either since the oldest ruby we support at the moment ships with a `psych` version higher than 2.0.0.

Closes #3629.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
