### PR TITLE
Delay `fileutils` loading to fix some warnings

### DIFF
--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -5,15 +5,14 @@
 # See LICENSE.txt for permissions.
 #++
 
-require 'fileutils'
-require 'tempfile'
 require 'shellwords'
 
 class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
 
-  FileEntry = FileUtils::Entry_ # :nodoc:
-
   def self.build(extension, dest_path, results, args=[], lib_dir=nil)
+    require 'fileutils'
+    require 'tempfile'
+
     tmp_dest = Dir.mktmpdir(".gem.", ".")
 
     # Some versions of `mktmpdir` return absolute paths, which will break make
@@ -71,7 +70,7 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
             FileUtils.cp_r entries, lib_dir, :remove_destination => true
           end
 
-          FileEntry.new(tmp_dest).traverse do |ent|
+          FileUtils::Entry_.new(tmp_dest).traverse do |ent|
             destent = ent.class.new(dest_path, ent.rel)
             destent.exist? or FileUtils.mv(ent.path, destent.path)
           end


### PR DESCRIPTION
# Description:

This is another side effect of https://github.com/rubygems/rubygems/pull/3580.

If the following conditions are met:

* You have a default version of fileutils and a higher version of fileutils installed as a regular gem. This case is common on ruby 2.6.

* You use a bundler generated binstub on a gem setup with a `Gemfile` using the `gemspec` DSL.

Then `fileutils` redefinition warnings happen because of the following:

The gist of a bundler generated binstub is:

```ruby
require "bundler/setup"
load Gem.bin_path("rake", "rake")
```

First configure bundler, then load the requested gem.

When `require "bundler/setup"` is called under the previously mentioned setup, `ext_conf_builder.rb` ends up being required because of the new validation that gemspecs with rake extensions depend on `rake`. And that loads the latest version of `fileutils` because of using "rubygems
monkeypatched require" that auto-chooses the latest version of default gems.

After that, when `Gem.bin_path` gets called, `ext_conf_builder.rb` gets required again, but this time already using "bundler's unmonkeypatched require" which means the default version is chosen and thus the redefinition warning happens.

The solution as usual is to lazily load `fileutils`.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
