### PR TITLE
bundler: Remove explicit `psych` activation.

### DIFF
--- a/bundler/lib/bundler/psyched_yaml.rb
+++ b/bundler/lib/bundler/psyched_yaml.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-# Psych could be a gem, so try to ask for it
-begin
-  gem "psych"
-rescue LoadError
-end if defined?(gem)
-
 # Psych could be in the stdlib
 # but it's too late if Syck is already loaded
 begin


### PR DESCRIPTION
# Description:

On the commit: https://github.com/rubygems/rubygems/commit/1ccf0912a161d20e0c4a7b139fd76e8739a411ba , we removed `gem 'psych'` line to fix the similar error at https://github.com/rubygems/rubygems/issues/3629 .

There is one more part to remove in bundler code. And it's not harmful to remove it. See https://github.com/rubygems/rubygems/issues/3629#issuecomment-630697387 .

## What was the end-user or developer problem that led to this PR?

In the Fedora RPM Ruby environment where there is no default gem psych but there is regular gem psych, the following error happens.

```
$ cat test3.rb 
require 'psych'
require 'bundler/psyched_yaml' # <= The error happens.
```

```
$ ruby test3.rb
/usr/lib64/gems/ruby/psych-3.1.0/psych.so: warning: already initialized constant Psych::Parser::ANY
...
/usr/share/gems/gems/psych-3.1.0/lib/psych/parser.rb:34:in `<class:Parser>': superclass mismatch for class Mark (TypeError)
```


## What is your fix for the problem, implemented in this PR?

Remove `gem 'psych'` line causing the error. It's same with https://github.com/rubygems/rubygems/pull/3636 .

______________

# Tasks:

- [X] Describe the problem / feature
- [ ] Write tests
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
