### PR TITLE
Fix correctness and performance regression in `require`

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -594,9 +594,19 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   end
 
   ##
+  # The number of paths in the `$LOAD_PATH` from activated gems. Used to
+  # prioritize `-I` and `ENV['RUBYLIB`]` entries during `require`.
+
+  def self.activated_gem_paths
+    @activated_gem_paths ||= 0
+  end
+
+  ##
   # Add a list of paths to the $LOAD_PATH at the proper place.
 
   def self.add_to_load_path(*paths)
+    @activated_gem_paths = activated_gem_paths + paths.size
+
     insert_index = load_path_insert_index
 
     if insert_index

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -590,7 +590,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
     index = $LOAD_PATH.index RbConfig::CONFIG['sitelibdir']
 
-    index
+    index || 0
   end
 
   ##
@@ -607,15 +607,8 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   def self.add_to_load_path(*paths)
     @activated_gem_paths = activated_gem_paths + paths.size
 
-    insert_index = load_path_insert_index
-
-    if insert_index
-      # gem directories must come after -I and ENV['RUBYLIB']
-      $LOAD_PATH.insert(insert_index, *paths)
-    else
-      # we are probably testing in core, -I and RUBYLIB don't apply
-      $LOAD_PATH.unshift(*paths)
-    end
+    # gem directories must come after -I and ENV['RUBYLIB']
+    $LOAD_PATH.insert(Gem.load_path_insert_index, *paths)
   end
 
   @yaml_loaded = false

--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -43,8 +43,9 @@ module Kernel
     # https://github.com/rubygems/rubygems/pull/1868
     resolved_path = begin
       rp = nil
+      load_path_check_index = Gem.load_path_insert_index - Gem.activated_gem_paths
       Gem.suffixes.each do |s|
-        $LOAD_PATH[0...Gem.load_path_insert_index - Gem.activated_gem_paths].each do |lp|
+        $LOAD_PATH[0...load_path_check_index].each do |lp|
           safe_lp = lp.dup.tap(&Gem::UNTAINT)
           begin
             if File.symlink? safe_lp # for backward compatibility

--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -47,7 +47,7 @@ module Kernel
         load_path_insert_index = Gem.load_path_insert_index
         break unless load_path_insert_index
 
-        $LOAD_PATH[0...load_path_insert_index].each do |lp|
+        $LOAD_PATH[0...load_path_insert_index - Gem.activated_gem_paths].each do |lp|
           safe_lp = lp.dup.tap(&Gem::UNTAINT)
           begin
             if File.symlink? safe_lp # for backward compatibility

--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -41,7 +41,6 @@ module Kernel
 
     if spec = Gem.find_unresolved_default_spec(path)
       # Ensure -I beats a default gem
-      # https://github.com/rubygems/rubygems/pull/1868
       resolved_path = begin
         rp = nil
         load_path_check_index = Gem.load_path_insert_index - Gem.activated_gem_paths

--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -44,10 +44,7 @@ module Kernel
     resolved_path = begin
       rp = nil
       Gem.suffixes.each do |s|
-        load_path_insert_index = Gem.load_path_insert_index
-        break unless load_path_insert_index
-
-        $LOAD_PATH[0...load_path_insert_index - Gem.activated_gem_paths].each do |lp|
+        $LOAD_PATH[0...Gem.load_path_insert_index - Gem.activated_gem_paths].each do |lp|
           safe_lp = lp.dup.tap(&Gem::UNTAINT)
           begin
             if File.symlink? safe_lp # for backward compatibility

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -384,6 +384,7 @@ class Gem::TestCase < Minitest::Test
     Gem::Security.reset
 
     Gem.loaded_specs.clear
+    Gem.instance_variable_set(:@activated_gem_paths, 0)
     Gem.clear_default_specs
     Bundler.reset!
 

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -45,6 +45,35 @@ class TestGemRequire < Gem::TestCase
     refute require(path), "'#{path}' was not yet required"
   end
 
+  def test_respect_loaded_features_caching_like_standard_require
+    dir = Dir.mktmpdir("test_require", @tempdir)
+
+    lp1 = File.join dir, 'foo1'
+    foo1 = File.join lp1, 'foo.rb'
+
+    FileUtils.mkdir_p lp1
+    File.open(foo1, 'w') { |f| f.write "class Object; HELLO = 'foo1' end" }
+
+    lp = $LOAD_PATH.dup
+
+    $LOAD_PATH.unshift lp1
+    assert_require 'foo'
+    assert_equal "foo1", ::Object::HELLO
+
+    lp2 = File.join dir, 'foo2'
+    foo2 = File.join lp2, 'foo.rb'
+
+    FileUtils.mkdir_p lp2
+    File.open(foo2, 'w') { |f| f.write "class Object; HELLO = 'foo2' end" }
+
+    $LOAD_PATH.unshift lp2
+    refute_require 'foo'
+    assert_equal "foo1", ::Object::HELLO
+  ensure
+    $LOAD_PATH.replace lp
+    Object.send :remove_const, :HELLO if Object.const_defined? :HELLO
+  end
+
   # Providing -I on the commandline should always beat gems
   def test_dash_i_beats_gems
     a1 = util_spec "a", "1", {"b" => "= 1"}, "lib/test_gem_require_a.rb"

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -420,6 +420,17 @@ class TestGemRequire < Gem::TestCase
     assert_equal 0, times_called
   end
 
+  def test_second_gem_require_does_not_resolve_path_manually_before_going_through_standard_require
+    a1 = util_spec "a", "1", nil, "lib/test_gem_require_a.rb"
+    install_gem a1
+
+    assert_require "test_gem_require_a"
+
+    stub(:gem_original_require, ->(path) { assert_equal "test_gem_require_a", path }) do
+      require "test_gem_require_a"
+    end
+  end
+
   def test_realworld_default_gem
     testing_ruby_repo = !ENV["GEM_COMMAND"].nil?
     skip "this test can't work under ruby-core setup" if testing_ruby_repo || java_platform?


### PR DESCRIPTION
# Description:

A recent fix in rubygems, #1868, caused both a perfomance and a functionality regression in our custom `require`.

## What was the end-user or developer problem that led to this PR?

On one hand, `require` was made slower because it traverse all activated gems by default.

On the other hand, the unintended manual traversing of those paths also caused divergences in functionality from the standard `require` since the `$LOADED_FEATURES` cache would no longer be hit.

## What is your fix for the problem, implemented in this PR?

This PR keeps track of the activated gem paths in order to traverse only directories prepended to the `$LOAD_PATH` by ruby `CLI` flags or environment variables.

Fixes #3491.
Fixes #3631.
Fixes #3647.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
