### PR TITLE
Don't handle `-I` paths specially before default gems

### DIFF
--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -39,41 +39,6 @@ module Kernel
 
     path = path.to_path if path.respond_to? :to_path
 
-    # Ensure -I beats a default gem
-    # https://github.com/rubygems/rubygems/pull/1868
-    resolved_path = begin
-      rp = nil
-      Gem.suffixes.each do |s|
-        load_path_insert_index = Gem.load_path_insert_index
-        break unless load_path_insert_index
-
-        $LOAD_PATH[0...load_path_insert_index].each do |lp|
-          safe_lp = lp.dup.tap(&Gem::UNTAINT)
-          begin
-            if File.symlink? safe_lp # for backward compatibility
-              next
-            end
-          rescue SecurityError
-            RUBYGEMS_ACTIVATION_MONITOR.exit
-            raise
-          end
-
-          full_path = File.expand_path(File.join(safe_lp, "#{path}#{s}"))
-          if File.file?(full_path)
-            rp = full_path
-            break
-          end
-        end
-        break if rp
-      end
-      rp
-    end
-
-    if resolved_path
-      RUBYGEMS_ACTIVATION_MONITOR.exit
-      return gem_original_require(resolved_path)
-    end
-
     if spec = Gem.find_unresolved_default_spec(path)
       begin
         Kernel.send(:gem, spec.name, Gem::Requirement.default_prerelease)

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -114,7 +114,7 @@ class TestGemRequire < Gem::TestCase
     assert_require 'b/c'
     assert_require 'c/c' # this should be required from -I
     assert_equal "world", ::Object::HELLO
-    assert_equal %w[a-1 b-1], loaded_spec_names
+    assert_equal %w[a-1 b-1 c-2], loaded_spec_names
   ensure
     $LOAD_PATH.replace lp
     Object.send :remove_const, :HELLO if Object.const_defined? :HELLO


### PR DESCRIPTION
# Description:

This PR stops handling `-I` paths specially in our custom require.

* Supersedes #3639.
* Fixes #3491.
* Fixes #3631.
* Fixes #3647.

## What was the end-user or developer problem that led to this PR?

This code was added so that when `-I` is specified with a name that matches a requirable path in a default gem, the default gem would never get activated. That #1868.

That turned out to be too much to assume, and has caused several issues along the way (see git log for references).

When a user specifies `-I` as a CLI flag, she expects paths in that location to take more precedence than other locations in the `$LOAD_PATH`. And that has always happened with rubygems require.

Making other assumptions on user expectations is too much, and adding all the code to handle not activating a default gem at all has caused issues and behavioral differences from standard's ruby require. And we never got an end user report about any problems anyways, the "issue" only affected
Samuel and myself when testing bundler and rubygems in combination. At least myself, not sure how Samuel got there.


## What is your fix for the problem, implemented in this PR?

The fix is removing the code and adapting the spec to allow a default gem to be activated if it matches a path found in a `-I` path. Still pending to run CI and see if there are any other unforeseen problems.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
