### PR TITLE
Fix test warnings

### DIFF
--- a/test/rubygems/test_gem_package_task.rb
+++ b/test/rubygems/test_gem_package_task.rb
@@ -5,19 +5,8 @@ require 'rubygems/package_task'
 
 class TestGemPackageTask < Gem::TestCase
 
-  def setup
-    super
-
-    @original_rake_fileutils_verbosity = RakeFileUtils.verbose_flag
-  end
-
-  def teardown
-    RakeFileUtils.verbose_flag = @original_rake_fileutils_verbosity
-
-    super
-  end
-
   def test_gem_package
+    original_rake_fileutils_verbosity = RakeFileUtils.verbose_flag
     RakeFileUtils.verbose_flag = false
 
     gem = Gem::Specification.new do |g|
@@ -45,6 +34,8 @@ class TestGemPackageTask < Gem::TestCase
 
       assert_path_exists 'pkg/pkgr-1.2.3.gem'
     end
+  ensure
+    RakeFileUtils.verbose_flag = original_rake_fileutils_verbosity
   end
 
   def test_gem_package_prints_to_stdout_by_default
@@ -78,8 +69,6 @@ class TestGemPackageTask < Gem::TestCase
   end
 
   def test_gem_package_with_current_platform
-    RakeFileUtils.verbose_flag = false
-
     gem = Gem::Specification.new do |g|
       g.name = "pkgr"
       g.version = "1.2.3"
@@ -93,8 +82,6 @@ class TestGemPackageTask < Gem::TestCase
   end
 
   def test_gem_package_with_ruby_platform
-    RakeFileUtils.verbose_flag = false
-
     gem = Gem::Specification.new do |g|
       g.name = "pkgr"
       g.version = "1.2.3"
@@ -108,8 +95,6 @@ class TestGemPackageTask < Gem::TestCase
   end
 
   def test_package_dir_path
-    RakeFileUtils.verbose_flag = false
-
     gem = Gem::Specification.new do |g|
       g.name = 'nokogiri'
       g.version = '1.5.0'


### PR DESCRIPTION
# Description:

Since `rake package` started printing to stdout by default in #3632, we get these warnings printed when running rubygems tests:

```
$ rake
Run options: --seed 6097

# Running:

...............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................mkdir -p pkg
mkdir -p pkg/pkgr-1.2.3
rm -f pkg/pkgr-1.2.3/x
ln x pkg/pkgr-1.2.3/x
rm -f pkg/pkgr-1.2.3/y
ln y pkg/pkgr-1.2.3/y
cd pkg/pkgr-1.2.3
cd -
....

Finished in 50.578889s, 43.0812 runs/s, 134.8191 assertions/s.
2179 runs, 6819 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for Unit Tests to /home/deivid/Code/rubygems/coverage. 8080 / 8978 LOC (90.0%) covered.
```

The reason is that, although these tests wrap the `Rake.application["package"].invoke` with a `capture_io` block, the rake application initialization happens outside of this block, and a copy of
`$stdout` is saved in there, and that's where the task prints. So the `capture_io` `$stdout` and `$stderr` dance is not effective.

To fix, we move the `Rake` application initialization inside the `capture_io` block.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
