### PR TITLE
Show ruby version in ruby-head builds

### DIFF
--- a/.github/workflows/daily-bundler.yml
+++ b/.github/workflows/daily-bundler.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler: none
+      - name: Show Ruby version
+        run: ruby --version
       - name: Prepare dependencies
         run: |
           sudo apt-get install graphviz -y

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -17,6 +17,8 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler: none
+      - name: Show Ruby version
+        run: ruby --version
       - name: Test rubygems
         run: |
           rake setup


### PR DESCRIPTION
# Description:

Some tests are failing against ruby-head. I want to display the exact reference of the built ruby so I can try reproduce locally by building that.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
