### PR TITLE
Fix source priority for transitive dependencies and split lockfile rubygems source sections

### DIFF
--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -46,15 +46,17 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: rubygems/rubygems
-      - name: Test RubyGems
+      - name: Sync tools
         run: |
           ruby tool/sync_default_gems.rb rubygems
-          make -j2 -s test-all TESTS="rubygems --no-retry"
+          ruby tool/sync_default_gems.rb bundler
+        working-directory: ruby/ruby
+      - name: Test RubyGems
+        run: make -j2 -s test-all TESTS="rubygems --no-retry"
         working-directory: ruby/ruby
         if: matrix.target == 'Rubygems'
       - name: Test Bundler
         run: |
-          ruby tool/sync_default_gems.rb bundler
           git checkout lib/bundler/bundler.gemspec
           git add .
           make test-bundler-parallel

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -904,9 +904,9 @@ module Bundler
       source_requirements = { :default => default }
       default = nil unless Bundler.feature_flag.disable_multisource?
       dependencies.each do |dep|
-        source = dep.source || default
-        next unless source
-        source_requirements[dep.name] = source
+        dep_source = dep.source || default
+        next unless dep_source
+        source_requirements[dep.name] = dep_source
       end
       metadata_dependencies.each do |dep|
         source_requirements[dep.name] = sources.metadata_source

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -918,7 +918,7 @@ module Bundler
     def pinned_spec_names(skip = nil)
       pinned_names = []
       default = Bundler.feature_flag.disable_multisource? && sources.default_source
-      @dependencies.each do |dep|
+      dependencies.each do |dep|
         dep_source = dep.source || default
         next unless dep_source
         next if dep_source == skip

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -663,19 +663,20 @@ module Bundler
     def converge_rubygems_sources
       return false if Bundler.feature_flag.disable_multisource?
 
-      changes = false
-
       # Get the RubyGems sources from the Gemfile.lock
       locked_gem_sources = @locked_sources.select {|s| s.is_a?(Source::Rubygems) }
+      return false if locked_gem_sources.empty?
+
       # Get the RubyGems remotes from the Gemfile
       actual_remotes = sources.rubygems_remotes
+      return false if actual_remotes.empty?
+
+      changes = false
 
       # If there is a RubyGems source in both
-      if !locked_gem_sources.empty? && !actual_remotes.empty?
-        locked_gem_sources.each do |locked_gem|
-          # Merge the remotes from the Gemfile into the Gemfile.lock
-          changes |= locked_gem.replace_remotes(actual_remotes, Bundler.settings[:allow_deployment_source_credential_changes])
-        end
+      locked_gem_sources.each do |locked_gem|
+        # Merge the remotes from the Gemfile into the Gemfile.lock
+        changes |= locked_gem.replace_remotes(actual_remotes, Bundler.settings[:allow_deployment_source_credential_changes])
       end
 
       changes

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -900,9 +900,8 @@ module Bundler
       # Record the specs available in each gem's source, so that those
       # specs will be available later when the resolver knows where to
       # look for that gemspec (or its dependencies)
-      default = sources.default_source
-      source_requirements = { :default => default }
-      default = nil unless Bundler.feature_flag.disable_multisource?
+      source_requirements = { :default => sources.default_source }
+      default = Bundler.feature_flag.disable_multisource? && sources.default_source
       dependencies.each do |dep|
         dep_source = dep.source || default
         next unless dep_source

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -269,7 +269,7 @@ module Bundler
           # Run a resolve against the locally available gems
           Bundler.ui.debug("Found changes from the lockfile, re-resolving dependencies because #{change_reason}")
           expanded_dependencies = expand_dependencies(dependencies + metadata_dependencies, @remote)
-          Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve, gem_version_promoter, additional_base_requirements_for_resolve, platforms)
+          Resolver.resolve(expanded_dependencies, source_requirements, last_resolve, gem_version_promoter, additional_base_requirements_for_resolve, platforms)
         end
       end
     end
@@ -904,6 +904,7 @@ module Bundler
       metadata_dependencies.each do |dep|
         source_requirements[dep.name] = sources.metadata_source
       end
+      source_requirements[:global] = index unless Bundler.feature_flag.disable_multisource?
       source_requirements[:default_bundler] = source_requirements["bundler"] || source_requirements[:default]
       source_requirements["bundler"] = sources.metadata_source # needs to come last to override
       source_requirements

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -904,7 +904,8 @@ module Bundler
       source_requirements = { :default => default }
       default = nil unless Bundler.feature_flag.disable_multisource?
       dependencies.each do |dep|
-        next unless source = dep.source || default
+        source = dep.source || default
+        next unless source
         source_requirements[dep.name] = source
       end
       metadata_dependencies.each do |dep|
@@ -919,7 +920,8 @@ module Bundler
       pinned_names = []
       default = Bundler.feature_flag.disable_multisource? && sources.default_source
       @dependencies.each do |dep|
-        next unless dep_source = dep.source || default
+        dep_source = dep.source || default
+        next unless dep_source
         next if dep_source == skip
         pinned_names << dep.name
       end

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -192,7 +192,6 @@ module Bundler
               "      gem 'rails'\n" \
               "    end\n\n"
 
-        raise DeprecatedError, msg if Bundler.feature_flag.disable_multisource?
         SharedHelpers.major_deprecation(2, msg.strip)
       end
 

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -446,11 +446,8 @@ repo_name ||= user_name
       if Bundler.feature_flag.disable_multisource?
         msg = "This Gemfile contains multiple primary sources. " \
           "Each source after the first must include a block to indicate which gems " \
-          "should come from that source"
-        unless Bundler.feature_flag.bundler_2_mode?
-          msg += ". To downgrade this error to a warning, run " \
-            "`bundle config unset disable_multisource`"
-        end
+          "should come from that source. To downgrade this error to a warning, run " \
+          "`bundle config unset disable_multisource`"
         raise GemfileEvalError, msg
       else
         Bundler::SharedHelpers.major_deprecation 2, "Your Gemfile contains multiple primary sources. " \

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -169,7 +169,6 @@ module Bundler
         with_source(@sources.add_rubygems_source("remotes" => source), &blk)
       else
         @global_rubygems_sources << source
-        @sources.global_rubygems_source = source
       end
     end
 
@@ -271,6 +270,11 @@ module Bundler
 
     def method_missing(name, *args)
       raise GemfileError, "Undefined local variable or method `#{name}' for Gemfile"
+    end
+
+    def check_primary_source_safety
+      check_path_source_safety
+      check_rubygems_source_safety
     end
 
     private
@@ -434,11 +438,6 @@ repo_name ||= user_name
       end
     end
 
-    def check_primary_source_safety
-      check_path_source_safety
-      check_rubygems_source_safety
-    end
-
     def check_path_source_safety
       return if @sources.global_path_source.nil?
 
@@ -454,7 +453,14 @@ repo_name ||= user_name
     end
 
     def check_rubygems_source_safety
-      return if @global_rubygems_sources.size <= 1
+      if @global_rubygems_sources.size <= 1
+        @sources.global_rubygems_source = @global_rubygems_sources.first
+        return
+      end
+
+      @global_rubygems_sources.each do |source|
+        @sources.add_rubygems_remote(source)
+      end
 
       if Bundler.feature_flag.disable_multisource?
         msg = "This Gemfile contains multiple primary sources. " \

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -462,19 +462,16 @@ repo_name ||= user_name
         @sources.add_rubygems_remote(source)
       end
 
-      if Bundler.feature_flag.disable_multisource?
+      if Bundler.feature_flag.bundler_3_mode?
         msg = "This Gemfile contains multiple primary sources. " \
           "Each source after the first must include a block to indicate which gems " \
-          "should come from that source. To downgrade this error to a warning, run " \
-          "`bundle config unset disable_multisource`"
+          "should come from that source"
         raise GemfileEvalError, msg
       else
         Bundler::SharedHelpers.major_deprecation 2, "Your Gemfile contains multiple primary sources. " \
           "Using `source` more than once without a block is a security risk, and " \
           "may result in installing unexpected gems. To resolve this warning, use " \
-          "a block to indicate which gems should come from the secondary source. " \
-          "To upgrade this warning to an error, run `bundle config set --local " \
-          "disable_multisource true`."
+          "a block to indicate which gems should come from the secondary source."
       end
     end
 

--- a/bundler/lib/bundler/feature_flag.rb
+++ b/bundler/lib/bundler/feature_flag.rb
@@ -32,7 +32,6 @@ module Bundler
     settings_flag(:cache_all) { bundler_3_mode? }
     settings_flag(:default_install_uses_path) { bundler_3_mode? }
     settings_flag(:deployment_means_frozen) { bundler_3_mode? }
-    settings_flag(:disable_multisource) { bundler_3_mode? }
     settings_flag(:forget_cli_options) { bundler_3_mode? }
     settings_flag(:global_gem_cache) { bundler_3_mode? }
     settings_flag(:only_update_to_newer_versions) { bundler_3_mode? }

--- a/bundler/lib/bundler/inline.rb
+++ b/bundler/lib/bundler/inline.rb
@@ -50,6 +50,7 @@ def gemfile(install = false, options = {}, &gemfile)
     Bundler::Plugin.gemfile_install(&gemfile) if Bundler.feature_flag.plugins?
     builder = Bundler::Dsl.new
     builder.instance_eval(&gemfile)
+    builder.check_primary_source_safety
 
     Bundler.settings.temporary(:frozen => false) do
       definition = builder.to_definition(nil, true)

--- a/bundler/lib/bundler/lockfile_parser.rb
+++ b/bundler/lib/bundler/lockfile_parser.rb
@@ -64,8 +64,6 @@ module Bundler
       @state        = nil
       @specs        = {}
 
-      @rubygems_aggregate = Source::Rubygems.new
-
       if lockfile.match(/<<<<<<<|=======|>>>>>>>|\|\|\|\|\|\|\|/)
         raise LockfileError, "Your #{Bundler.default_lockfile.relative_path_from(SharedHelpers.pwd)} contains merge conflicts.\n" \
           "Run `git checkout HEAD -- #{Bundler.default_lockfile.relative_path_from(SharedHelpers.pwd)}` first to get a clean lock."
@@ -138,9 +136,9 @@ module Bundler
             @current_source = TYPES[@type].from_lock(@opts)
           else
             Array(@opts["remote"]).each do |url|
-              @rubygems_aggregate.add_remote(url)
+              rubygems_aggregate.add_remote(url)
             end
-            @current_source = @rubygems_aggregate
+            @current_source = rubygems_aggregate
           end
 
           @sources << @current_source
@@ -244,6 +242,10 @@ module Bundler
 
     def parse_ruby(line)
       @ruby_version = line.strip
+    end
+
+    def rubygems_aggregate
+      @rubygems_aggregate ||= Source::Rubygems.new
     end
   end
 end

--- a/bundler/lib/bundler/lockfile_parser.rb
+++ b/bundler/lib/bundler/lockfile_parser.rb
@@ -89,7 +89,6 @@ module Bundler
           send("parse_#{@state}", line)
         end
       end
-      @sources << @rubygems_aggregate unless Bundler.feature_flag.disable_multisource?
       @specs = @specs.values.sort_by(&:identifier)
       warn_for_outdated_bundler_version
     rescue ArgumentError => e
@@ -137,13 +136,14 @@ module Bundler
           if Bundler.feature_flag.disable_multisource?
             @opts["remotes"] = @opts.delete("remote")
             @current_source = TYPES[@type].from_lock(@opts)
-            @sources << @current_source
           else
             Array(@opts["remote"]).each do |url|
               @rubygems_aggregate.add_remote(url)
             end
             @current_source = @rubygems_aggregate
           end
+
+          @sources << @current_source
         when PLUGIN
           @current_source = Plugin.source_from_lock(@opts)
           @sources << @current_source

--- a/bundler/lib/bundler/lockfile_parser.rb
+++ b/bundler/lib/bundler/lockfile_parser.rb
@@ -131,11 +131,13 @@ module Bundler
             @sources << @current_source
           end
         when GEM
-          if Bundler.feature_flag.disable_multisource?
+          source_remotes = Array(@opts["remote"])
+
+          if source_remotes.size == 1
             @opts["remotes"] = @opts.delete("remote")
             @current_source = TYPES[@type].from_lock(@opts)
           else
-            Array(@opts["remote"]).each do |url|
+            source_remotes.each do |url|
               rubygems_aggregate.add_remote(url)
             end
             @current_source = rubygems_aggregate

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -56,9 +56,6 @@ Executing \fBbundle config unset \-\-local <name> <value>\fR will delete the con
 .P
 Executing bundle with the \fBBUNDLE_IGNORE_CONFIG\fR environment variable set will cause it to ignore all configuration\.
 .
-.P
-Executing \fBbundle config set \-\-local disable_multisource true\fR upgrades the warning about the Gemfile containing multiple primary sources to an error\. Executing \fBbundle config unset disable_multisource\fR downgrades this error to a warning\.
-.
 .SH "REMEMBERING OPTIONS"
 Flags passed to \fBbundle install\fR or the Bundler runtime, such as \fB\-\-path foo\fR or \fB\-\-without production\fR, are remembered between commands and saved to your local application\'s configuration (normally, \fB\./\.bundle/config\fR)\.
 .
@@ -182,9 +179,6 @@ The following is a list of all configuration keys and their purpose\. You can le
 .
 .IP "\(bu" 4
 \fBdisable_local_revision_check\fR (\fBBUNDLE_DISABLE_LOCAL_REVISION_CHECK\fR): Allow Bundler to use a local git override without checking if the revision present in the lockfile is present in the repository\.
-.
-.IP "\(bu" 4
-\fBdisable_multisource\fR (\fBBUNDLE_DISABLE_MULTISOURCE\fR): When set, Gemfiles containing multiple sources will produce errors instead of warnings\. Use \fBbundle config unset disable_multisource\fR to unset\.
 .
 .IP "\(bu" 4
 \fBdisable_shared_gems\fR (\fBBUNDLE_DISABLE_SHARED_GEMS\fR): Stop Bundler from accessing gems installed to RubyGems\' normal location\.

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -47,10 +47,6 @@ configuration only from the local application.
 Executing bundle with the `BUNDLE_IGNORE_CONFIG` environment variable set will
 cause it to ignore all configuration.
 
-Executing `bundle config set --local disable_multisource true` upgrades the warning about
-the Gemfile containing multiple primary sources to an error. Executing `bundle
-config unset disable_multisource` downgrades this error to a warning.
-
 ## REMEMBERING OPTIONS
 
 Flags passed to `bundle install` or the Bundler runtime, such as `--path foo` or
@@ -178,10 +174,6 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
 * `disable_local_revision_check` (`BUNDLE_DISABLE_LOCAL_REVISION_CHECK`):
    Allow Bundler to use a local git override without checking if the revision
    present in the lockfile is present in the repository.
-* `disable_multisource` (`BUNDLE_DISABLE_MULTISOURCE`):
-   When set, Gemfiles containing multiple sources will produce errors
-   instead of warnings.
-   Use `bundle config unset disable_multisource` to unset.
 * `disable_shared_gems` (`BUNDLE_DISABLE_SHARED_GEMS`):
    Stop Bundler from accessing gems installed to RubyGems' normal location.
 * `disable_version_check` (`BUNDLE_DISABLE_VERSION_CHECK`):

--- a/bundler/lib/bundler/plugin.rb
+++ b/bundler/lib/bundler/plugin.rb
@@ -105,6 +105,7 @@ module Bundler
         else
           builder.eval_gemfile(gemfile)
         end
+        builder.check_primary_source_safety
         definition = builder.to_definition(nil, true)
 
         return if definition.dependencies.empty?

--- a/bundler/lib/bundler/plugin/installer.rb
+++ b/bundler/lib/bundler/plugin/installer.rb
@@ -16,15 +16,13 @@ module Bundler
 
         version = options[:version] || [">= 0"]
 
-        Bundler.settings.temporary(:disable_multisource => false) do
-          if options[:git]
-            install_git(names, version, options)
-          elsif options[:local_git]
-            install_local_git(names, version, options)
-          else
-            sources = options[:source] || Bundler.rubygems.sources
-            install_rubygems(names, version, sources)
-          end
+        if options[:git]
+          install_git(names, version, options)
+        elsif options[:local_git]
+          install_local_git(names, version, options)
+        else
+          sources = options[:source] || Bundler.rubygems.sources
+          install_rubygems(names, version, sources)
         end
       end
 
@@ -84,6 +82,7 @@ module Bundler
         deps = names.map {|name| Dependency.new name, version }
 
         definition = Definition.new(nil, deps, source_list, true)
+        definition.allow_multisource!
         install_definition(definition)
       end
 

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -457,14 +457,12 @@ module Bundler
         sources.uniq!
         next if sources.size <= 1
 
-        multisource_disabled = Bundler.feature_flag.disable_multisource?
-
         msg = ["The gem '#{name}' was found in multiple relevant sources."]
         msg.concat sources.map {|s| "  * #{s}" }.sort
-        msg << "You #{multisource_disabled ? :must : :should} add this gem to the source block for the source you wish it to be installed from."
+        msg << "You #{@lockfile_uses_separate_rubygems_sources ? :must : :should} add this gem to the source block for the source you wish it to be installed from."
         msg = msg.join("\n")
 
-        raise SecurityError, msg if multisource_disabled
+        raise SecurityError, msg if @lockfile_uses_separate_rubygems_sources
         Bundler.ui.warn "Warning: #{msg}"
       end
     end

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -323,7 +323,7 @@ module Bundler
             "The source does not contain any versions of '#{name}'"
           end
         else
-          message = "Could not find gem '#{requirement}' in any of the gem sources " \
+          message = "Could not find gem '#{SharedHelpers.pretty_dependency(requirement)}' in any of the gem sources " \
             "listed in your Gemfile#{cache_message}."
         end
         raise GemNotFound, message

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -124,8 +124,7 @@ module Bundler
       dependency = dependency_proxy.dep
       name = dependency.name
       search_result = @search_for[dependency_proxy] ||= begin
-        index = index_for(dependency)
-        results = index.search(dependency, @base[name])
+        results = results_for(dependency, @base[name])
 
         if vertex = @base_dg.vertex_named(name)
           locked_requirement = vertex.payload.requirement
@@ -205,6 +204,10 @@ module Bundler
       else
         @source_requirements[:global]
       end
+    end
+
+    def results_for(dependency, base)
+      index_for(dependency).search(dependency, base)
     end
 
     def name_for(dependency)

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -199,7 +199,7 @@ module Bundler
         source.specs
       elsif @no_aggregate_global_source
         Index.build do |idx|
-          dependency.all_sources.each {|s| idx.add_source(s.specs) if s }
+          dependency.all_sources.each {|s| idx.add_source(s.specs) }
         end
       else
         @source_requirements[:global]
@@ -236,11 +236,11 @@ module Bundler
 
     def relevant_sources_for_vertex(vertex)
       if vertex.root?
-        [@source_requirements[vertex.name]]
+        [@source_requirements[vertex.name]].compact
       elsif @no_aggregate_global_source
         vertex.recursive_predecessors.map do |v|
           @source_requirements[v.name]
-        end << @source_requirements[:default]
+        end.compact << @source_requirements[:default]
       else
         []
       end

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -20,7 +20,6 @@ module Bundler
       disable_exec_load
       disable_local_branch_check
       disable_local_revision_check
-      disable_multisource
       disable_shared_gems
       disable_version_check
       force_ruby_platform

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -21,6 +21,7 @@ module Bundler
         @allow_remote = false
         @allow_cached = false
         @caches = [cache_path, *Bundler.rubygems.gem_cache]
+        @disable_multisource = true
 
         Array(options["remotes"] || []).reverse_each {|r| add_remote(r) }
       end
@@ -49,8 +50,16 @@ module Bundler
         o.is_a?(Rubygems) && (o.credless_remotes - credless_remotes).empty?
       end
 
+      def disable_multisource?
+        @disable_multisource
+      end
+
+      def allow_multisource!
+        @disable_multisource = false
+      end
+
       def can_lock?(spec)
-        return super if Bundler.feature_flag.disable_multisource?
+        return super if disable_multisource?
         spec.source.is_a?(Rubygems)
       end
 

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -110,10 +110,6 @@ module Bundler
       all_sources.each(&:remote!)
     end
 
-    def rubygems_primary_remotes
-      @rubygems_aggregate.remotes
-    end
-
     private
 
     def rubygems_aggregate_class

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -5,6 +5,7 @@ module Bundler
     attr_reader :path_sources,
       :git_sources,
       :plugin_sources,
+      :global_path_source,
       :metadata_source
 
     def global_rubygems_source
@@ -16,6 +17,7 @@ module Bundler
       @git_sources            = []
       @plugin_sources         = []
       @global_rubygems_source = nil
+      @global_path_source     = nil
       @rubygems_sources       = []
       @metadata_source        = Source::Metadata.new
     end
@@ -24,7 +26,9 @@ module Bundler
       if options["gemspec"]
         add_source_to_list Source::Gemspec.new(options), path_sources
       else
-        add_source_to_list Source::Path.new(options), path_sources
+        path_source = add_source_to_list Source::Path.new(options), path_sources
+        @global_path_source ||= path_source if options["global"]
+        path_source
       end
     end
 

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -5,15 +5,17 @@ module Bundler
     attr_reader :path_sources,
       :git_sources,
       :plugin_sources,
-      :global_rubygems_source,
       :metadata_source
+
+    def global_rubygems_source
+      @global_rubygems_source ||= rubygems_aggregate_class.new
+    end
 
     def initialize
       @path_sources           = []
       @git_sources            = []
       @plugin_sources         = []
       @global_rubygems_source = nil
-      @rubygems_aggregate     = rubygems_aggregate_class.new
       @rubygems_sources       = []
       @metadata_source        = Source::Metadata.new
     end
@@ -49,12 +51,12 @@ module Bundler
     end
 
     def add_rubygems_remote(uri)
-      @rubygems_aggregate.add_remote(uri)
-      @rubygems_aggregate
+      global_rubygems_source.add_remote(uri)
+      global_rubygems_source
     end
 
     def default_source
-      global_rubygems_source || @rubygems_aggregate
+      global_rubygems_source
     end
 
     def rubygems_sources
@@ -94,7 +96,7 @@ module Bundler
 
       replacement_rubygems = !Bundler.feature_flag.disable_multisource? &&
         replacement_sources.detect {|s| s.is_a?(Source::Rubygems) }
-      @rubygems_aggregate = replacement_rubygems if replacement_rubygems
+      @global_rubygems_source = replacement_rubygems if replacement_rubygems
 
       return true if !equal_sources?(lock_sources, replacement_sources) && !equivalent_sources?(lock_sources, replacement_sources)
       return true if replacement_rubygems && rubygems_remotes.sort_by(&:to_s) != replacement_rubygems.remotes.sort_by(&:to_s)

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -47,11 +47,7 @@ module Bundler
     end
 
     def global_rubygems_source=(uri)
-      if Bundler.feature_flag.disable_multisource?
-        @global_rubygems_source ||= rubygems_aggregate_class.new("remotes" => uri)
-      else
-        add_rubygems_remote(uri)
-      end
+      @global_rubygems_source ||= rubygems_aggregate_class.new("remotes" => uri)
     end
 
     def add_rubygems_remote(uri)

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -43,12 +43,12 @@ module Bundler
     def global_rubygems_source=(uri)
       if Bundler.feature_flag.disable_multisource?
         @global_rubygems_source ||= rubygems_aggregate_class.new("remotes" => uri)
+      else
+        add_rubygems_remote(uri)
       end
-      add_rubygems_remote(uri)
     end
 
     def add_rubygems_remote(uri)
-      return if Bundler.feature_flag.disable_multisource?
       @rubygems_aggregate.add_remote(uri)
       @rubygems_aggregate
     end

--- a/bundler/spec/bundler/dsl_spec.rb
+++ b/bundler/spec/bundler/dsl_spec.rb
@@ -195,19 +195,6 @@ RSpec.describe Bundler::Dsl do
     #   gem 'spree_api'
     #   gem 'spree_backend'
     # end
-    describe "#github", :bundler => "< 3" do
-      it "from github" do
-        spree_gems = %w[spree_core spree_api spree_backend]
-        subject.github "spree" do
-          spree_gems.each {|spree_gem| subject.send :gem, spree_gem }
-        end
-
-        subject.dependencies.each do |d|
-          expect(d.source.uri).to eq("https://github.com/spree/spree.git")
-        end
-      end
-    end
-
     describe "#github" do
       it "from github" do
         spree_gems = %w[spree_core spree_api spree_backend]

--- a/bundler/spec/bundler/dsl_spec.rb
+++ b/bundler/spec/bundler/dsl_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Bundler::Dsl do
       expect { subject.git_source(:example) }.to raise_error(Bundler::InvalidOption)
     end
 
-    context "default hosts", :bundler => "2" do
+    context "default hosts", :bundler => "< 3" do
       it "converts :github to URI using https" do
         subject.gem("sparks", :github => "indirect/sparks")
         github_uri = "https://github.com/indirect/sparks.git"

--- a/bundler/spec/bundler/plugin_spec.rb
+++ b/bundler/spec/bundler/plugin_spec.rb
@@ -110,6 +110,7 @@ RSpec.describe Bundler::Plugin do
     before do
       allow(Plugin::DSL).to receive(:new) { builder }
       allow(builder).to receive(:eval_gemfile).with(gemfile)
+      allow(builder).to receive(:check_primary_source_safety)
       allow(builder).to receive(:to_definition) { definition }
       allow(builder).to receive(:inferred_plugins) { [] }
     end

--- a/bundler/spec/bundler/source_list_spec.rb
+++ b/bundler/spec/bundler/source_list_spec.rb
@@ -372,26 +372,7 @@ RSpec.describe Bundler::SourceList do
       source_list.add_git_source("uri" => "git://first-git.org/path.git")
     end
 
-    it "combines the rubygems sources into a single instance, removing duplicate remotes from the end", :bundler => "< 3" do
-      expect(source_list.lock_sources).to eq [
-        Bundler::Source::Git.new("uri" => "git://first-git.org/path.git"),
-        Bundler::Source::Git.new("uri" => "git://second-git.org/path.git"),
-        Bundler::Source::Git.new("uri" => "git://third-git.org/path.git"),
-        ASourcePlugin.new("uri" => "https://second-plugin.org/random"),
-        ASourcePlugin.new("uri" => "https://third-bar.org/foo"),
-        Bundler::Source::Path.new("path" => "/first/path/to/gem"),
-        Bundler::Source::Path.new("path" => "/second/path/to/gem"),
-        Bundler::Source::Path.new("path" => "/third/path/to/gem"),
-        Bundler::Source::Rubygems.new("remotes" => [
-          "https://duplicate-rubygems.org",
-          "https://first-rubygems.org",
-          "https://second-rubygems.org",
-          "https://third-rubygems.org",
-        ]),
-      ]
-    end
-
-    it "returns all sources, without combining rubygems sources", :bundler => "3" do
+    it "returns all sources, without combining rubygems sources" do
       expect(source_list.lock_sources).to eq [
         Bundler::Source::Git.new("uri" => "git://first-git.org/path.git"),
         Bundler::Source::Git.new("uri" => "git://second-git.org/path.git"),

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -762,7 +762,8 @@ RSpec.describe "bundle exec" do
       let(:exit_code) { Bundler::GemNotFound.new.status_code }
       let(:expected) { "" }
       let(:expected_err) { <<-EOS.strip }
-\e[31mCould not find gem 'rack (= 2)' in any of the gem sources listed in your Gemfile.\e[0m
+\e[31mCould not find gem 'rack (= 2)' in locally installed gems.
+The source contains the following versions of 'rack': 0.9.1, 1.0.0\e[0m
 \e[33mRun `bundle install` to install missing gems.\e[0m
       EOS
 

--- a/bundler/spec/commands/post_bundle_message_spec.rb
+++ b/bundler/spec/commands/post_bundle_message_spec.rb
@@ -113,16 +113,7 @@ RSpec.describe "post bundle message" do
         bundle "config set force_ruby_platform true"
       end
 
-      it "should report a helpful error message", :bundler => "< 3" do
-        install_gemfile <<-G, :raise_on_error => false
-          source "#{file_uri_for(gem_repo1)}"
-          gem "rack"
-          gem "not-a-gem", :group => :development
-        G
-        expect(err).to include("Could not find gem 'not-a-gem' in any of the gem sources listed in your Gemfile.")
-      end
-
-      it "should report a helpful error message", :bundler => "3" do
+      it "should report a helpful error message" do
         install_gemfile <<-G, :raise_on_error => false
           source "#{file_uri_for(gem_repo1)}"
           gem "rack"

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -422,14 +422,13 @@ RSpec.describe "bundle install from an existing gemspec" do
           end
         end
 
-        %w[ruby jruby].each do |platform|
-          simulate_platform(platform) do
-            install_gemfile <<-G
-              source "#{file_uri_for(gem_repo2)}"
-              gemspec
-            G
-          end
-        end
+        gemfile <<-G
+          source "#{file_uri_for(gem_repo2)}"
+          gemspec
+        G
+
+        simulate_platform("ruby") { bundle "install" }
+        simulate_platform("jruby") { bundle "install" }
       end
 
       context "on ruby" do

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
           it "installs from the same source without any warning" do
             bundle :install
             expect(err).not_to include("Warning")
-            expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0")
+            expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0", :source => "remote3")
           end
         end
 
@@ -196,7 +196,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
               bundle :install
 
               expect(err).not_to include("Warning: the gem 'rack' was found in multiple sources.")
-              expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0")
+              expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0", :source => "remote3")
 
               # In https://github.com/bundler/bundler/issues/3585 this failed
               # when there is already a lock file, and the gems are missing, so try again
@@ -204,7 +204,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
               bundle :install
 
               expect(err).not_to include("Warning: the gem 'rack' was found in multiple sources.")
-              expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0")
+              expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0", :source => "remote3")
             end
           end
         end

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
       it "installs the gems without any warning" do
         bundle :install
-        expect(out).not_to include("Warning")
+        expect(err).not_to include("Warning")
         expect(the_bundle).to include_gems("rack-obama 1.0.0")
         expect(the_bundle).to include_gems("rack 1.0.0", :source => "remote1")
       end
@@ -137,7 +137,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
       it "installs the gems without any warning" do
         bundle :install
-        expect(out).not_to include("Warning")
+        expect(err).not_to include("Warning")
         expect(the_bundle).to include_gems("rack-obama 1.0.0", "rack 1.0.0")
       end
     end
@@ -173,7 +173,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
           it "installs from the same source without any warning" do
             bundle :install
-            expect(out).not_to include("Warning")
+            expect(err).not_to include("Warning")
             expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0")
           end
         end
@@ -196,7 +196,6 @@ RSpec.describe "bundle install with gems on multiple sources" do
             it "installs from the same source without any warning" do
               bundle :install
 
-              expect(out).not_to include("Warning: the gem 'rack' was found in multiple sources.")
               expect(err).not_to include("Warning: the gem 'rack' was found in multiple sources.")
               expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0")
 
@@ -204,7 +203,6 @@ RSpec.describe "bundle install with gems on multiple sources" do
               system_gems []
               bundle :install
 
-              expect(out).not_to include("Warning: the gem 'rack' was found in multiple sources.")
               expect(err).not_to include("Warning: the gem 'rack' was found in multiple sources.")
               expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0")
             end
@@ -232,7 +230,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
           it "installs from the other source without any warning" do
             bundle :install
-            expect(out).not_to include("Warning")
+            expect(err).not_to include("Warning")
             expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0")
           end
         end

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -199,6 +199,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
               expect(err).not_to include("Warning: the gem 'rack' was found in multiple sources.")
               expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0")
 
+              # In https://github.com/bundler/bundler/issues/3585 this failed
               # when there is already a lock file, and the gems are missing, so try again
               system_gems []
               bundle :install

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
           end
         end
 
-        gemfile <<-G
+        install_gemfile <<-G
           source "#{file_uri_for(gem_repo3)}"
           gem "rack-obama" # should come from repo3!
           gem "rack", :source => "#{file_uri_for(gem_repo1)}"
@@ -136,7 +136,6 @@ RSpec.describe "bundle install with gems on multiple sources" do
       end
 
       it "installs the gems without any warning" do
-        bundle :install
         expect(err).not_to include("Warning")
         expect(the_bundle).to include_gems("rack-obama 1.0.0", "rack 1.0.0")
       end
@@ -221,7 +220,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
         context "and not in any other sources" do
           before do
-            gemfile <<-G
+            install_gemfile <<-G
               source "#{file_uri_for(gem_repo2)}"
               source "#{file_uri_for(gem_repo3)}" do
                 gem "depends_on_rack"
@@ -230,7 +229,6 @@ RSpec.describe "bundle install with gems on multiple sources" do
           end
 
           it "installs from the other source without any warning" do
-            bundle :install
             expect(err).not_to include("Warning")
             expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0")
           end
@@ -388,14 +386,13 @@ RSpec.describe "bundle install with gems on multiple sources" do
           build_gem "not_in_repo1", "1.0.0"
         end
 
-        gemfile <<-G
+        install_gemfile <<-G, :raise_on_error => false
           source "#{file_uri_for(gem_repo3)}"
           gem "not_in_repo1", :source => "#{file_uri_for(gem_repo1)}"
         G
       end
 
       it "does not install the gem" do
-        bundle :install, :raise_on_error => false
         expect(err).to include("Could not find gem 'not_in_repo1'")
       end
     end
@@ -456,14 +453,13 @@ RSpec.describe "bundle install with gems on multiple sources" do
     before do
       system_gems "rack-0.9.1"
 
-      gemfile <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rack" # shoud come from repo1!
       G
     end
 
     it "installs the gems without any warning" do
-      bundle :install
       expect(err).not_to include("Warning")
       expect(the_bundle).to include_gems("rack 1.0.0")
     end

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
         G
       end
 
-      it "warns about ambiguous gems, but installs anyway, prioritizing sources last to first", :bundler => "2" do
+      it "warns about ambiguous gems, but installs anyway, prioritizing sources last to first", :bundler => "< 3" do
         bundle :install
 
         expect(err).to include("Warning: the gem 'rack' was found in multiple sources.")
@@ -54,7 +54,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
         G
       end
 
-      it "warns about ambiguous gems, but installs anyway", :bundler => "2" do
+      it "warns about ambiguous gems, but installs anyway", :bundler => "< 3" do
         bundle :install
         expect(err).to include("Warning: the gem 'rack' was found in multiple sources.")
         expect(err).to include("Installed from: #{file_uri_for(gem_repo1)}")
@@ -247,7 +247,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
             G
           end
 
-          it "installs from the other source and warns about ambiguous gems", :bundler => "2" do
+          it "installs from the other source and warns about ambiguous gems", :bundler => "< 3" do
             bundle :install
             expect(err).to include("Warning: the gem 'rack' was found in multiple sources.")
             expect(err).to include("Installed from: #{file_uri_for(gem_repo2)}")
@@ -279,7 +279,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
             G
           end
 
-          it "installs the dependency from the pinned source without warning", :bundler => "2" do
+          it "installs the dependency from the pinned source without warning", :bundler => "< 3" do
             bundle :install
 
             expect(err).not_to include("Warning: the gem 'rack' was found in multiple sources.")
@@ -614,7 +614,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
       G
     end
 
-    it "keeps the old version", :bundler => "2" do
+    it "keeps the old version", :bundler => "< 3" do
       expect(the_bundle).to include_gems("rack 1.0.0")
     end
 

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -187,25 +187,19 @@ RSpec.describe "bundle install with gems on multiple sources" do
             end
           end
 
-          context "when disable_multisource is set" do
-            before do
-              bundle "config set disable_multisource true"
-            end
+          it "installs from the same source without any warning" do
+            bundle :install
 
-            it "installs from the same source without any warning" do
-              bundle :install
+            expect(err).not_to include("Warning: the gem 'rack' was found in multiple sources.")
+            expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0", :source => "remote3")
 
-              expect(err).not_to include("Warning: the gem 'rack' was found in multiple sources.")
-              expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0", :source => "remote3")
+            # In https://github.com/bundler/bundler/issues/3585 this failed
+            # when there is already a lock file, and the gems are missing, so try again
+            system_gems []
+            bundle :install
 
-              # In https://github.com/bundler/bundler/issues/3585 this failed
-              # when there is already a lock file, and the gems are missing, so try again
-              system_gems []
-              bundle :install
-
-              expect(err).not_to include("Warning: the gem 'rack' was found in multiple sources.")
-              expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0", :source => "remote3")
-            end
+            expect(err).not_to include("Warning: the gem 'rack' was found in multiple sources.")
+            expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0", :source => "remote3")
           end
         end
       end
@@ -302,80 +296,74 @@ RSpec.describe "bundle install with gems on multiple sources" do
     end
 
     context "when a top-level gem has an indirect dependency" do
-      context "when disable_multisource is set" do
+      before do
+        build_repo gem_repo2 do
+          build_gem "depends_on_rack", "1.0.1" do |s|
+            s.add_dependency "rack"
+          end
+        end
+
+        build_repo gem_repo3 do
+          build_gem "unrelated_gem", "1.0.0"
+        end
+
+        gemfile <<-G
+          source "#{file_uri_for(gem_repo2)}"
+
+          gem "depends_on_rack"
+
+          source "#{file_uri_for(gem_repo3)}" do
+            gem "unrelated_gem"
+          end
+        G
+      end
+
+      context "and the dependency is only in the top-level source" do
         before do
-          bundle "config set disable_multisource true"
+          update_repo gem_repo2 do
+            build_gem "rack", "1.0.0"
+          end
         end
 
+        it "installs all gems without warning" do
+          bundle :install
+          expect(err).not_to include("Warning")
+          expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0", "unrelated_gem 1.0.0")
+        end
+      end
+
+      context "and the dependency is only in a pinned source" do
         before do
-          build_repo gem_repo2 do
-            build_gem "depends_on_rack", "1.0.1" do |s|
-              s.add_dependency "rack"
+          update_repo gem_repo3 do
+            build_gem "rack", "1.0.0" do |s|
+              s.write "lib/rack.rb", "RACK = 'FAIL'"
             end
-          end
-
-          build_repo gem_repo3 do
-            build_gem "unrelated_gem", "1.0.0"
-          end
-
-          gemfile <<-G
-            source "#{file_uri_for(gem_repo2)}"
-
-            gem "depends_on_rack"
-
-            source "#{file_uri_for(gem_repo3)}" do
-              gem "unrelated_gem"
-            end
-          G
-        end
-
-        context "and the dependency is only in the top-level source" do
-          before do
-            update_repo gem_repo2 do
-              build_gem "rack", "1.0.0"
-            end
-          end
-
-          it "installs all gems without warning" do
-            bundle :install
-            expect(err).not_to include("Warning")
-            expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0", "unrelated_gem 1.0.0")
           end
         end
 
-        context "and the dependency is only in a pinned source" do
-          before do
-            update_repo gem_repo3 do
-              build_gem "rack", "1.0.0" do |s|
-                s.write "lib/rack.rb", "RACK = 'FAIL'"
-              end
-            end
+        it "does not find the dependency" do
+          bundle :install, :raise_on_error => false
+          expect(err).to include("Could not find gem 'rack', which is required by gem 'depends_on_rack', in any of the relevant sources")
+        end
+      end
+
+      context "and the dependency is in both the top-level and a pinned source" do
+        before do
+          update_repo gem_repo2 do
+            build_gem "rack", "1.0.0"
           end
 
-          it "does not find the dependency" do
-            bundle :install, :raise_on_error => false
-            expect(err).to include("Could not find gem 'rack', which is required by gem 'depends_on_rack', in any of the relevant sources")
+          update_repo gem_repo3 do
+            build_gem "rack", "1.0.0" do |s|
+              s.write "lib/rack.rb", "RACK = 'FAIL'"
+            end
           end
         end
 
-        context "and the dependency is in both the top-level and a pinned source" do
-          before do
-            update_repo gem_repo2 do
-              build_gem "rack", "1.0.0"
-            end
-
-            update_repo gem_repo3 do
-              build_gem "rack", "1.0.0" do |s|
-                s.write "lib/rack.rb", "RACK = 'FAIL'"
-              end
-            end
-          end
-
-          it "installs the dependency from the top-level source without warning" do
-            bundle :install
-            expect(err).not_to include("Warning")
-            expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0", "unrelated_gem 1.0.0")
-          end
+        it "installs the dependency from the top-level source without warning" do
+          bundle :install
+          expect(err).not_to include("Warning")
+          expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0", "unrelated_gem 1.0.0")
         end
       end
     end
@@ -393,7 +381,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
       end
 
       it "does not install the gem" do
-        expect(err).to include("Could not find gem 'not_in_repo1'")
+        expect(err).to include("Could not find gem 'not_in_repo1")
       end
     end
 
@@ -426,6 +414,92 @@ RSpec.describe "bundle install with gems on multiple sources" do
       # Reproduction of https://github.com/rubygems/bundler/issues/3298
       it "does not unlock the installed gem on exec" do
         expect(the_bundle).to include_gems("rack 0.9.1")
+      end
+    end
+
+    context "with a lockfile with aggregated rubygems sources" do
+      let(:aggregate_gem_section_lockfile) do
+        <<~L
+          GEM
+            remote: #{file_uri_for(gem_repo1)}/
+            remote: #{file_uri_for(gem_repo3)}/
+            specs:
+              rack (0.9.1)
+
+          PLATFORMS
+            #{specific_local_platform}
+
+          DEPENDENCIES
+            rack!
+
+          BUNDLED WITH
+             #{Bundler::VERSION}
+        L
+      end
+
+      let(:split_gem_section_lockfile) do
+        <<~L
+          GEM
+            remote: #{file_uri_for(gem_repo1)}/
+            specs:
+
+          GEM
+            remote: #{file_uri_for(gem_repo3)}/
+            specs:
+              rack (0.9.1)
+
+          PLATFORMS
+            #{specific_local_platform}
+
+          DEPENDENCIES
+            rack!
+
+          BUNDLED WITH
+             #{Bundler::VERSION}
+        L
+      end
+
+      before do
+        build_repo gem_repo3 do
+          build_gem "rack", "0.9.1"
+        end
+
+        gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
+          source "#{file_uri_for(gem_repo3)}" do
+            gem 'rack'
+          end
+        G
+
+        lockfile aggregate_gem_section_lockfile
+      end
+
+      it "installs a lockfile with separate rubygems source sections if not in frozen mode" do
+        bundle "install"
+
+        expect(lockfile).to eq(split_gem_section_lockfile)
+
+        expect(the_bundle).to include_gems("rack 0.9.1", :source => "remote3")
+      end
+
+      it "installs the existing lockfile but prints a warning if in frozen mode", :bundler => "< 3" do
+        bundle "config set --local deployment true"
+
+        bundle "install"
+
+        expect(lockfile).to eq(aggregate_gem_section_lockfile)
+
+        expect(the_bundle).to include_gems("rack 0.9.1", :source => "remote3")
+      end
+
+      it "refuses to install the existing lockfile and prints an error if in frozen mode", :bundler => "3" do
+        bundle "config set --local deployment true"
+
+        bundle "install", :raise_on_error =>false
+
+        expect(lockfile).to eq(aggregate_gem_section_lockfile)
+        expect(err).to include("Your lockfile contains a single rubygems source section with multiple remotes, which is insecure.")
+        expect(out).to be_empty
       end
     end
 
@@ -610,16 +684,12 @@ RSpec.describe "bundle install with gems on multiple sources" do
       G
     end
 
-    it "keeps the old version", :bundler => "< 3" do
-      expect(the_bundle).to include_gems("rack 1.0.0")
-    end
-
-    it "installs the higher version in the new repo", :bundler => "3" do
+    it "installs the higher version in the new repo" do
       expect(the_bundle).to include_gems("rack 1.2")
     end
   end
 
-  context "when a gem is available from multiple ambiguous sources", :bundler => "3" do
+  context "when a gem is available from multiple ambiguous sources" do
     it "raises, suggesting a source block" do
       build_repo4 do
         build_gem "depends_on_rack" do |s|

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -202,6 +202,24 @@ RSpec.describe "bundle install with gems on multiple sources" do
             expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0", :source => "remote3")
           end
         end
+
+        context "and in another source with a higher version" do
+          before do
+            # need this to be broken to check for correct source ordering
+            build_repo gem_repo2 do
+              build_gem "rack", "1.0.1" do |s|
+                s.write "lib/rack.rb", "RACK = 'FAIL'"
+              end
+            end
+          end
+
+          it "installs from the same source without any warning" do
+            bundle :install
+
+            expect(err).not_to include("Warning: the gem 'rack' was found in multiple sources.")
+            expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0", :source => "remote3")
+          end
+        end
       end
 
       context "when the indirect dependency is in a different source" do

--- a/bundler/spec/install/gems/flex_spec.rb
+++ b/bundler/spec/install/gems/flex_spec.rb
@@ -245,37 +245,7 @@ RSpec.describe "bundle flex_install" do
   end
 
   describe "when adding a new source" do
-    it "updates the lockfile", :bundler => "< 3" do
-      build_repo2
-      install_gemfile <<-G
-        source "#{file_uri_for(gem_repo1)}"
-        gem "rack"
-      G
-      install_gemfile <<-G
-        source "#{file_uri_for(gem_repo1)}"
-        source "#{file_uri_for(gem_repo2)}"
-        gem "rack"
-      G
-
-      lockfile_should_be <<-L
-      GEM
-        remote: #{file_uri_for(gem_repo1)}/
-        remote: #{file_uri_for(gem_repo2)}/
-        specs:
-          rack (1.0.0)
-
-      PLATFORMS
-        #{lockfile_platforms}
-
-      DEPENDENCIES
-        rack
-
-      BUNDLED WITH
-         #{Bundler::VERSION}
-      L
-    end
-
-    it "updates the lockfile", :bundler => "3" do
+    it "updates the lockfile" do
       build_repo2
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -318,40 +318,7 @@ RSpec.describe "the lockfile format" do
     G
   end
 
-  it "generates a lockfile without credentials for a configured source", :bundler => "< 3" do
-    bundle "config set http://localgemserver.test/ user:pass"
-
-    install_gemfile(<<-G, :artifice => "endpoint_strict_basic_authentication", :quiet => true)
-      source "http://localgemserver.test/" do
-
-      end
-
-      source "http://user:pass@othergemserver.test/" do
-        gem "rack-obama", ">= 1.0"
-      end
-    G
-
-    lockfile_should_be <<-G
-      GEM
-        remote: http://localgemserver.test/
-        remote: http://user:pass@othergemserver.test/
-        specs:
-          rack (1.0.0)
-          rack-obama (1.0)
-            rack
-
-      PLATFORMS
-        #{lockfile_platforms}
-
-      DEPENDENCIES
-        rack-obama (>= 1.0)!
-
-      BUNDLED WITH
-         #{Bundler::VERSION}
-    G
-  end
-
-  it "generates a lockfile without credentials for a configured source", :bundler => "3" do
+  it "generates a lockfile without credentials for a configured source" do
     bundle "config set http://localgemserver.test/ user:pass"
 
     install_gemfile(<<-G, :artifice => "endpoint_strict_basic_authentication", :quiet => true)

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -383,10 +383,50 @@ RSpec.describe "major deprecations" do
         "Your Gemfile contains multiple primary sources. " \
         "Using `source` more than once without a block is a security risk, and " \
         "may result in installing unexpected gems. To resolve this warning, use " \
-        "a block to indicate which gems should come from the secondary source. " \
-        "To upgrade this warning to an error, run `bundle config set --local " \
-        "disable_multisource true`."
+        "a block to indicate which gems should come from the secondary source."
       )
+    end
+
+    pending "fails with a helpful error", :bundler => "3"
+  end
+
+  context "bundle install with a lockfile with a single rubygems section with multiple remotes in frozen mode" do
+    before do
+      build_repo gem_repo3 do
+        build_gem "rack", "0.9.1"
+      end
+
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        source "#{file_uri_for(gem_repo3)}" do
+          gem 'rack'
+        end
+      G
+
+      lockfile <<~L
+        GEM
+          remote: #{file_uri_for(gem_repo1)}/
+          remote: #{file_uri_for(gem_repo3)}/
+          specs:
+            rack (0.9.1)
+
+        PLATFORMS
+          ruby
+
+        DEPENDENCIES
+          rack!
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      bundle "config set --local deployment true"
+    end
+
+    it "shows a deprecation", :bundler => "< 3" do
+      bundle "install"
+
+      expect(deprecations).to include("Your lockfile contains a single rubygems source section with multiple remotes, which is insecure. You should regenerate your lockfile in a non frozen environment.")
     end
 
     pending "fails with a helpful error", :bundler => "3"

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "major deprecations" do
         bundle "exec ruby -e #{source.dump}"
       end
 
-      it "is deprecated in favor of .unbundled_env", :bundler => "2" do
+      it "is deprecated in favor of .unbundled_env", :bundler => "< 3" do
         expect(deprecations).to include \
           "`Bundler.clean_env` has been deprecated in favor of `Bundler.unbundled_env`. " \
           "If you instead want the environment before bundler was originally loaded, use `Bundler.original_env` " \
@@ -33,7 +33,7 @@ RSpec.describe "major deprecations" do
         bundle "exec ruby -e #{source.dump}"
       end
 
-      it "is deprecated in favor of .unbundled_env", :bundler => "2" do
+      it "is deprecated in favor of .unbundled_env", :bundler => "< 3" do
         expect(deprecations).to include(
           "`Bundler.with_clean_env` has been deprecated in favor of `Bundler.with_unbundled_env`. " \
           "If you instead want the environment before bundler was originally loaded, use `Bundler.with_original_env` " \
@@ -50,7 +50,7 @@ RSpec.describe "major deprecations" do
         bundle "exec ruby -e #{source.dump}"
       end
 
-      it "is deprecated in favor of .unbundled_system", :bundler => "2" do
+      it "is deprecated in favor of .unbundled_system", :bundler => "< 3" do
         expect(deprecations).to include(
           "`Bundler.clean_system` has been deprecated in favor of `Bundler.unbundled_system`. " \
           "If you instead want to run the command in the environment before bundler was originally loaded, use `Bundler.original_system` " \
@@ -67,7 +67,7 @@ RSpec.describe "major deprecations" do
         bundle "exec ruby -e #{source.dump}"
       end
 
-      it "is deprecated in favor of .unbundled_exec", :bundler => "2" do
+      it "is deprecated in favor of .unbundled_exec", :bundler => "< 3" do
         expect(deprecations).to include(
           "`Bundler.clean_exec` has been deprecated in favor of `Bundler.unbundled_exec`. " \
           "If you instead want to exec to a command in the environment before bundler was originally loaded, use `Bundler.original_exec` " \
@@ -84,7 +84,7 @@ RSpec.describe "major deprecations" do
         bundle "exec ruby -e #{source.dump}"
       end
 
-      it "is deprecated in favor of .load", :bundler => "2" do
+      it "is deprecated in favor of .load", :bundler => "< 3" do
         expect(deprecations).to include "Bundler.environment has been removed in favor of Bundler.load (called at -e:1)"
       end
 
@@ -109,7 +109,7 @@ RSpec.describe "major deprecations" do
       bundle "check --path vendor/bundle", :raise_on_error => false
     end
 
-    it "should print a deprecation warning", :bundler => "2" do
+    it "should print a deprecation warning", :bundler => "< 3" do
       expect(deprecations).to include(
         "The `--path` flag is deprecated because it relies on being " \
         "remembered across bundler invocations, which bundler will no " \
@@ -131,7 +131,7 @@ RSpec.describe "major deprecations" do
       bundle "check --path=vendor/bundle", :raise_on_error => false
     end
 
-    it "should print a deprecation warning", :bundler => "2" do
+    it "should print a deprecation warning", :bundler => "< 3" do
       expect(deprecations).to include(
         "The `--path` flag is deprecated because it relies on being " \
         "remembered across bundler invocations, which bundler will no " \
@@ -153,7 +153,7 @@ RSpec.describe "major deprecations" do
       bundle "cache --all", :raise_on_error => false
     end
 
-    it "should print a deprecation warning", :bundler => "2" do
+    it "should print a deprecation warning", :bundler => "< 3" do
       expect(deprecations).to include(
         "The `--all` flag is deprecated because it relies on being " \
         "remembered across bundler invocations, which bundler will no " \
@@ -292,7 +292,7 @@ RSpec.describe "major deprecations" do
       G
     end
 
-    it "should output a deprecation warning", :bundler => "2" do
+    it "should output a deprecation warning", :bundler => "< 3" do
       expect(deprecations).to include("The --binstubs option will be removed in favor of `bundle binstubs --all`")
     end
 
@@ -356,7 +356,7 @@ RSpec.describe "major deprecations" do
           bundle "install #{flag_name} #{value}"
         end
 
-        it "should print a deprecation warning", :bundler => "2" do
+        it "should print a deprecation warning", :bundler => "< 3" do
           expect(deprecations).to include(
             "The `#{flag_name}` flag is deprecated because it relies on " \
             "being remembered across bundler invocations, which bundler " \
@@ -378,7 +378,7 @@ RSpec.describe "major deprecations" do
       G
     end
 
-    it "shows a deprecation", :bundler => "2" do
+    it "shows a deprecation", :bundler => "< 3" do
       expect(deprecations).to include(
         "Your Gemfile contains multiple primary sources. " \
         "Using `source` more than once without a block is a security risk, and " \
@@ -422,7 +422,7 @@ RSpec.describe "major deprecations" do
       RUBY
     end
 
-    it "should print a capistrano deprecation warning", :bundler => "2" do
+    it "should print a capistrano deprecation warning", :bundler => "< 3" do
       expect(deprecations).to include("Bundler no longer integrates " \
                              "with Capistrano, but Capistrano provides " \
                              "its own integration with Bundler via the " \
@@ -439,7 +439,7 @@ RSpec.describe "major deprecations" do
     end
 
     context "with github gems" do
-      it "does not warn about removal", :bundler => "2" do
+      it "does not warn about removal", :bundler => "< 3" do
         expect(Bundler.ui).not_to receive(:warn)
         subject.gem("sparks", :github => "indirect/sparks")
         github_uri = "https://github.com/indirect/sparks.git"
@@ -461,7 +461,7 @@ The :github git source is deprecated, and will be removed in the future. Change 
     end
 
     context "with bitbucket gems" do
-      it "does not warn about removal", :bundler => "2" do
+      it "does not warn about removal", :bundler => "< 3" do
         expect(Bundler.ui).not_to receive(:warn)
         subject.gem("not-really-a-gem", :bitbucket => "mcorp/flatlab-rails")
       end
@@ -483,7 +483,7 @@ The :bitbucket git source is deprecated, and will be removed in the future. Add 
     end
 
     context "with gist gems" do
-      it "does not warn about removal", :bundler => "2" do
+      it "does not warn about removal", :bundler => "< 3" do
         expect(Bundler.ui).not_to receive(:warn)
         subject.gem("not-really-a-gem", :gist => "1234")
       end
@@ -514,7 +514,7 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
         bundle :show
       end
 
-      it "prints a deprecation warning recommending `bundle list`", :bundler => "2" do
+      it "prints a deprecation warning recommending `bundle list`", :bundler => "< 3" do
         expect(deprecations).to include("use `bundle list` instead of `bundle show`")
       end
 
@@ -526,7 +526,7 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
         bundle "show --outdated"
       end
 
-      it "prints a deprecation warning informing about its removal", :bundler => "2" do
+      it "prints a deprecation warning informing about its removal", :bundler => "< 3" do
         expect(deprecations).to include("the `--outdated` flag to `bundle show` was undocumented and will be removed without replacement")
       end
 
@@ -538,7 +538,7 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
         bundle "show --verbose"
       end
 
-      it "prints a deprecation warning informing about its removal", :bundler => "2" do
+      it "prints a deprecation warning informing about its removal", :bundler => "< 3" do
         expect(deprecations).to include("the `--verbose` flag to `bundle show` was undocumented and will be removed without replacement")
       end
 
@@ -550,7 +550,7 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
         bundle "show rack"
       end
 
-      it "prints a deprecation warning recommending `bundle info`", :bundler => "2" do
+      it "prints a deprecation warning recommending `bundle info`", :bundler => "< 3" do
         expect(deprecations).to include("use `bundle info rack` instead of `bundle show rack`")
       end
 
@@ -562,7 +562,7 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
         bundle "show --paths"
       end
 
-      it "prints a deprecation warning recommending `bundle list`", :bundler => "2" do
+      it "prints a deprecation warning recommending `bundle list`", :bundler => "< 3" do
         expect(deprecations).to include("use `bundle list` instead of `bundle show --paths`")
       end
 
@@ -574,7 +574,7 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
         bundle "show rack --paths"
       end
 
-      it "prints deprecation warning recommending `bundle info`", :bundler => "2" do
+      it "prints deprecation warning recommending `bundle info`", :bundler => "< 3" do
         expect(deprecations).to include("use `bundle info rack --path` instead of `bundle show rack --paths`")
       end
 
@@ -587,7 +587,7 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
       bundle "console", :raise_on_error => false
     end
 
-    it "prints a deprecation warning", :bundler => "2" do
+    it "prints a deprecation warning", :bundler => "< 3" do
       expect(deprecations).to include \
         "bundle console will be replaced by `bin/console` generated by `bundle gem <name>`"
     end
@@ -603,7 +603,7 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
       bundle "viz"
     end
 
-    it "prints a deprecation warning", :bundler => "2" do
+    it "prints a deprecation warning", :bundler => "< 3" do
       expect(deprecations).to include "The `viz` command has been moved to the `bundle-viz` gem, see https://github.com/bundler/bundler-viz"
     end
 

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe "major deprecations" do
       )
     end
 
-    pending "should fail with a helpful error", :bundler => "3"
+    pending "fails with a helpful error", :bundler => "3"
   end
 
   context "bundle check --path=" do
@@ -140,7 +140,7 @@ RSpec.describe "major deprecations" do
       )
     end
 
-    pending "should fail with a helpful error", :bundler => "3"
+    pending "fails with a helpful error", :bundler => "3"
   end
 
   context "bundle cache --all" do
@@ -162,7 +162,7 @@ RSpec.describe "major deprecations" do
       )
     end
 
-    pending "should fail with a helpful error", :bundler => "3"
+    pending "fails with a helpful error", :bundler => "3"
   end
 
   describe "bundle config" do
@@ -365,7 +365,7 @@ RSpec.describe "major deprecations" do
           )
         end
 
-        pending "should fail with a helpful error", :bundler => "3"
+        pending "fails with a helpful error", :bundler => "3"
       end
     end
   end
@@ -389,7 +389,7 @@ RSpec.describe "major deprecations" do
       )
     end
 
-    pending "should fail with a helpful error", :bundler => "3"
+    pending "fails with a helpful error", :bundler => "3"
   end
 
   context "when Bundler.setup is run in a ruby script" do
@@ -429,7 +429,7 @@ RSpec.describe "major deprecations" do
                              "capistrano-bundler gem. Use it instead.")
     end
 
-    pending "should fail with a helpful error", :bundler => "3"
+    pending "fails with a helpful error", :bundler => "3"
   end
 
   describe Bundler::Dsl do

--- a/bundler/spec/support/indexes.rb
+++ b/bundler/spec/support/indexes.rb
@@ -30,7 +30,7 @@ module Spec
       args[1] ||= Bundler::GemVersionPromoter.new # gem_version_promoter
       args[2] ||= [] # additional_base_requirements
       args[3] ||= @platforms # platforms
-      Bundler::Resolver.resolve(deps, @index, source_requirements, *args)
+      Bundler::Resolver.resolve(deps, source_requirements, *args)
     end
 
     def should_resolve_as(specs)

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1958,15 +1958,8 @@ class TestGem < Gem::TestCase
       io.write 'gem "a"'
     end
 
-    platform = Bundler::GemHelpers.generic_local_platform
-    if platform == Gem::Platform::RUBY
-      platform = ''
-    else
-      platform = " #{platform}"
-    end
-
     expected = <<-EXPECTED
-Could not find gem 'a#{platform}' in any of the gem sources listed in your Gemfile.
+Could not find gem 'a' in any of the gem sources listed in your Gemfile.
 You may need to `gem install -g` to install missing gems
 
     EXPECTED

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1959,7 +1959,8 @@ class TestGem < Gem::TestCase
     end
 
     expected = <<-EXPECTED
-Could not find gem 'a' in any of the gem sources listed in your Gemfile.
+Could not find gem 'a' in locally installed gems.
+The source does not contain any versions of 'a'
 You may need to `gem install -g` to install missing gems
 
     EXPECTED


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We have several source priority bug fixes in master that we have never released because they need the `disable_multisource` setting toggled, and that will only happen by default in Bundler 3.

The reason for this is that this setting drops support for multiple global sources in the `gems.rb/Gemfile` file, and also enables separate section for each rubygems source in the lockfile. We considered this to be backwards incompatible, although I'm not sure that was the right call after looking into this.

## What is your fix for the problem, implemented in this PR?
    
This commit enables the functionality by default, and completely removes the `disable_multisource` setting. The only backwards compatible concern I'm having is when some is using a lokfile in the old format in
frozen mode. In that case, to not break any workflows, we print a warning and still use that lockfile. Also, plugins still need the
previous functionality. I think this can probably be fixed later, but I'm not doing that here.

In every other case, we will run in the new secure mode and update the `Gemfile.lock` file with the new format.

In addition, this PR also fixes source priority for transitive dependencies, which was not fully fixed by enabling the `disable_multisource` mode.

Fixes #3643.
Fixes #3982.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
