### PR TITLE
Handle `--no-deployment` flag deprecation

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -254,6 +254,8 @@ module Bundler
         remembered_flag_deprecation(option)
       end
 
+      remembered_negative_flag_deprecation("no-deployment")
+
       require_relative "cli/install"
       Bundler.settings.temporary(:no_install => false) do
         Install.new(options.dup).run
@@ -812,10 +814,22 @@ module Bundler
       nil
     end
 
+    def remembered_negative_flag_deprecation(name)
+      positive_name = name.gsub(/\Ano-/, "")
+      option = current_command.options[positive_name]
+      flag_name = "--no-" + option.switch_name.gsub(/\A--/, "")
+
+      flag_deprecation(positive_name, flag_name, option)
+    end
+
     def remembered_flag_deprecation(name)
       option = current_command.options[name]
       flag_name = option.switch_name
 
+      flag_deprecation(name, flag_name, option)
+    end
+
+    def flag_deprecation(name, flag_name, option)
       name_index = ARGV.find {|arg| flag_name == arg.split("=")[0] }
       return unless name_index
 

--- a/bundler/lib/bundler/cli/outdated.rb
+++ b/bundler/lib/bundler/cli/outdated.rb
@@ -220,12 +220,10 @@ module Bundler
 
     def check_for_deployment_mode!
       return unless Bundler.frozen_bundle?
-      suggested_command = if Bundler.settings.locations("frozen")[:global]
+      suggested_command = if Bundler.settings.locations("frozen").keys.&([:global, :local]).any?
         "bundle config unset frozen"
       elsif Bundler.settings.locations("deployment").keys.&([:global, :local]).any?
         "bundle config unset deployment"
-      else
-        "bundle install --no-deployment"
       end
       raise ProductionError, "You are trying to check outdated gems in " \
         "deployment mode. Run `bundle outdated` elsewhere.\n" \

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -402,12 +402,10 @@ module Bundler
              "updated #{Bundler.default_lockfile.relative_path_from(SharedHelpers.pwd)} to version control."
 
       unless explicit_flag
-        suggested_command = if Bundler.settings.locations("frozen")[:global]
+        suggested_command = if Bundler.settings.locations("frozen").keys.&([:global, :local]).any?
           "bundle config unset frozen"
         elsif Bundler.settings.locations("deployment").keys.&([:global, :local]).any?
           "bundle config unset deployment"
-        else
-          "bundle install --no-deployment"
         end
         msg << "\n\nIf this is a development machine, remove the #{Bundler.default_gemfile} " \
                "freeze \nby running `#{suggested_command}`."

--- a/bundler/spec/commands/outdated_spec.rb
+++ b/bundler/spec/commands/outdated_spec.rb
@@ -537,7 +537,7 @@ RSpec.describe "bundle outdated" do
 
   context "after bundle install --deployment", :bundler => "< 3" do
     before do
-      install_gemfile <<-G, forgotten_command_line_options(:deployment => true)
+      install_gemfile <<-G, :deployment => true
         source "#{file_uri_for(gem_repo2)}"
 
         gem "rack"

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -318,6 +318,7 @@ RSpec.describe "major deprecations" do
       "deployment" => ["deployment", true],
       "frozen" => ["frozen", true],
       "no-cache" => ["no_cache", true],
+      "no-deployment" => ["deployment", false],
       "no-prune" => ["no_prune", true],
       "path" => ["path", "vendor/bundle"],
       "shebang" => ["shebang", "ruby27"],


### PR DESCRIPTION
# Description:

This flag represents the default behaviour of `bundle install`, and the only reason it exists is to "override" previous `--deployment` flag usages which were silently remembered. So it should be deprecated just like all the other flags the rely on remembering their values across invocations.

## What is your fix for the problem, implemented in this PR?

This PR stops recommending using this flag inside `CLI` messages and deprecates it.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
