### PR TITLE
Support running specs against a ruby tarball

### DIFF
--- a/bundler/spec/quality_spec.rb
+++ b/bundler/spec/quality_spec.rb
@@ -216,7 +216,7 @@ RSpec.describe "The library itself" do
   end
 
   it "ships the correct set of files" do
-    git_list = shipped_files
+    git_list = git_ls_files(ruby_core? ? "lib/bundler lib/bundler.rb man/bundle* man/gemfile* libexec/bundle*" : "lib man exe CHANGELOG.md LICENSE.md README.md bundler.gemspec")
 
     gem_list = loaded_gemspec.files
 

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -331,7 +331,7 @@ module Spec
 
         build_metadata = {
           :built_at => loaded_gemspec.date.utc.strftime("%Y-%m-%d"),
-          :git_commit_sha => sys_exec("git rev-parse --short HEAD", :dir => source_root).strip,
+          :git_commit_sha => git_commit_sha,
         }
 
         replace_build_metadata(build_metadata, dir: build_path) # rubocop:disable Style/HashSyntax

--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -238,7 +238,7 @@ module Spec
     end
 
     def tracked_files_glob
-      ruby_core? ?  "lib/bundler lib/bundler.rb spec/bundler man/bundle*" : ""
+      ruby_core? ? "lib/bundler lib/bundler.rb spec/bundler man/bundle*" : ""
     end
 
     def shipped_files_glob


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When bundler specs are run from a ruby tarball (ruby-core does this), there's no git folder, so `git ls-files` fails.

https://github.com/ruby/actions/runs/703745101?check_suite_focus=true#step:16:27.

## What is your fix for the problem, implemented in this PR?

Support this case by making specs rely on the list of files from the bundler gemspec instead, and invert the spec that makes sure we ship the right set of files.

As per the other quality specs, skip them in this case.

@znz Could you verify if this works as an alternative to https://github.com/ruby/ruby/commit/67d2a715ca35090fbb3ab13df5b7348b1807dd47?

Thanks!

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
