### PR TITLE
Incorporate a more reliable path check in Kernel#require

### DIFF
--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -148,7 +148,7 @@ module Kernel
     RUBYGEMS_ACTIVATION_MONITOR.enter
 
     begin
-      if load_error.message.end_with?(path) and Gem.try_activate(path)
+      if load_error.path == path and Gem.try_activate(path)
         require_again = true
       end
     ensure


### PR DESCRIPTION
This pull request replaces the `load_error.message.end_with?` call with `load_error.path`, which I believe is more reliable (unnoticeably faster.)

## What was the end-user or developer problem that led to this PR?

A few weeks ago, I added [a "Did you mean?" feature to `LoadError`](https://github.com/ruby/did_you_mean/pull/143) so users would be notified of a typo with possible suggestions. It seemed safe to do so as most of the tests were passing in [the Ruby CI](https://github.com/ruby/ruby/pull/3135). However I have found one issue where some gems could not be loaded with `require "gem_name"` any more even though it is clearly installed:

```sh
$ gem list | grep pry
pry (0.13.1)
pry-byebug (3.9.0)
pry-rails (0.3.9)

$ ruby -e 'require "pry"'
Traceback (most recent call last):
        2: from -e:1:in `<main>'
        1: from ~/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
~/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require': cannot load such file -- pry (LoadError)
Did you mean?  pty
```

It turns out that the problem is in the `require` method in Rubygems, where we call `end_with?` on the error message of the load error. Rubygems depends on the error message, and `did_you_mean` overrides it with something unexpected for Rubygems, hence breaking `require`.

## What is your fix for the problem, implemented in this PR?

In this case, we can simply use the `LoadError#path` method. It's been available [at least Ruby 2.0.0](https://docs.ruby-lang.org/en/2.0.0/LoadError.html) and LoadError's error message is [generated based off of the same `path` value in Ruby](https://github.com/ruby/ruby/blob/073cc5e815fcf5178fe4e515fcde74dc3597adeb/error.c#L1974-L1976), so I feel pretty good about it.

In terms of testing, I'm not sure if it's worth it. I could write a test for it, but it does look a bit too contrived and it could even cause an issue when the test suite is parallelized:

```ruby
def test_normal_gems_with_overridden_load_error_message
  normal_gem_spec = util_spec("default", "3.0", nil, "lib/default/gem.rb")
  install_specs(normal_gem_spec)

  LoadError.define_method :message do
    "Overridden message"
  end

  assert_require "default/gem"
  assert_equal %w[default-3.0], loaded_spec_names
ensure
  LoadError.class_eval do
    undef message
    def message
      to_s
    end
  end
end
```

I also can't image anyone would ever go back to `message.end_with?`, so I'll just leave the test there and lease the decision up to the maintainers here.

______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
