### PR TITLE
Handle custom messages in json rows formatter

### DIFF
--- a/bundler/tool/turbo_tests/json_rows_formatter.rb
+++ b/bundler/tool/turbo_tests/json_rows_formatter.rb
@@ -22,6 +22,7 @@ module TurboTests
   class JsonRowsFormatter
     RSpec::Core::Formatters.register(
       self,
+      :message,
       :close,
       :example_failed,
       :example_passed,
@@ -52,6 +53,13 @@ module TurboTests
       output_row(
         "type" => :example_failed,
         "example" => example_to_json(notification.example)
+      )
+    end
+
+    def message(notification)
+      output_row(
+        "type" => :message,
+        "message" => notification.message
       )
     end
 

--- a/bundler/tool/turbo_tests/reporter.rb
+++ b/bundler/tool/turbo_tests/reporter.rb
@@ -63,6 +63,10 @@ module TurboTests
       @failed_examples << example
     end
 
+    def message(notification)
+      delegate_to_formatters(:message, notification)
+    end
+
     def finish
       end_time = Time.now
 

--- a/bundler/tool/turbo_tests/runner.rb
+++ b/bundler/tool/turbo_tests/runner.rb
@@ -164,6 +164,9 @@ module TurboTests
             @threads.each(&:kill)
             break
           end
+        when "message"
+          notification = RSpec::Core::Notifications::MessageNotification.new(message["message"])
+          @reporter.message(notification)
         when "close"
         when "exit"
           exited += 1


### PR DESCRIPTION
# Description:

RSpec handles errors in `before(:suite)` hooks as "custom messages" since they don't belong to a specific example. Unless we handle them too, we get nothing reported for these kind of errors.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
