### PR TITLE
Fix `bundle install` copying `with` and `without` config to local configuration

### DIFF
--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -161,14 +161,11 @@ module Bundler
       without |= Bundler.settings[:without].map(&:to_s)
       without -= options[:with] if options[:with]
 
-      options[:with]    = with
-      options[:without] = without
-
       # need to nil them out first to get around validation for backwards compatibility
       Bundler.settings.set_command_option :without, nil
       Bundler.settings.set_command_option :with,    nil
-      Bundler.settings.set_command_option :without, options[:without] - options[:with]
-      Bundler.settings.set_command_option :with,    options[:with]
+      Bundler.settings.set_command_option :without, without - with
+      Bundler.settings.set_command_option :with,    with
     end
 
     def normalize_settings

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -164,7 +164,7 @@ module Bundler
       # need to nil them out first to get around validation for backwards compatibility
       Bundler.settings.set_command_option :without, nil
       Bundler.settings.set_command_option :with,    nil
-      Bundler.settings.set_command_option :without, without - with
+      Bundler.settings.set_command_option :without, without
       Bundler.settings.set_command_option :with,    with
     end
 

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -150,20 +150,16 @@ module Bundler
 
       check_for_group_conflicts_in_cli_options
 
-      Bundler.settings.set_command_option :with, nil if options[:with] == []
-      Bundler.settings.set_command_option :without, nil if options[:without] == []
-
       with = options.fetch(:with, [])
       with |= Bundler.settings[:with].map(&:to_s)
       with -= options[:without] if options[:without]
+      with = nil if options[:with] == []
 
       without = options.fetch(:without, [])
       without |= Bundler.settings[:without].map(&:to_s)
       without -= options[:with] if options[:with]
+      without = nil if options[:without] == []
 
-      # need to nil them out first to get around validation for backwards compatibility
-      Bundler.settings.set_command_option :without, nil
-      Bundler.settings.set_command_option :with,    nil
       Bundler.settings.set_command_option :without, without
       Bundler.settings.set_command_option :with,    with
     end

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -12,8 +12,6 @@ module Bundler
 
       warn_if_root
 
-      normalize_groups
-
       Bundler::SharedHelpers.set_env "RB_USER_INSTALL", "1" if Bundler::FREEBSD
 
       # Disable color in deployment mode
@@ -165,6 +163,14 @@ module Bundler
 
       options[:with]    = with
       options[:without] = without
+
+      unless Bundler.settings[:without] == options[:without] && Bundler.settings[:with] == options[:with]
+        # need to nil them out first to get around validation for backwards compatibility
+        Bundler.settings.set_command_option :without, nil
+        Bundler.settings.set_command_option :with,    nil
+        Bundler.settings.set_command_option :without, options[:without] - options[:with]
+        Bundler.settings.set_command_option :with,    options[:with]
+      end
     end
 
     def normalize_settings
@@ -191,13 +197,7 @@ module Bundler
 
       Bundler.settings.set_command_option_if_given :clean, options["clean"]
 
-      unless Bundler.settings[:without] == options[:without] && Bundler.settings[:with] == options[:with]
-        # need to nil them out first to get around validation for backwards compatibility
-        Bundler.settings.set_command_option :without, nil
-        Bundler.settings.set_command_option :with,    nil
-        Bundler.settings.set_command_option :without, options[:without] - options[:with]
-        Bundler.settings.set_command_option :with,    options[:with]
-      end
+      normalize_groups
 
       options[:force] = options[:redownload]
     end

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -164,13 +164,11 @@ module Bundler
       options[:with]    = with
       options[:without] = without
 
-      unless Bundler.settings[:without] == options[:without] && Bundler.settings[:with] == options[:with]
-        # need to nil them out first to get around validation for backwards compatibility
-        Bundler.settings.set_command_option :without, nil
-        Bundler.settings.set_command_option :with,    nil
-        Bundler.settings.set_command_option :without, options[:without] - options[:with]
-        Bundler.settings.set_command_option :with,    options[:with]
-      end
+      # need to nil them out first to get around validation for backwards compatibility
+      Bundler.settings.set_command_option :without, nil
+      Bundler.settings.set_command_option :with,    nil
+      Bundler.settings.set_command_option :without, options[:without] - options[:with]
+      Bundler.settings.set_command_option :with,    options[:with]
     end
 
     def normalize_settings
@@ -197,7 +195,7 @@ module Bundler
 
       Bundler.settings.set_command_option_if_given :clean, options["clean"]
 
-      normalize_groups
+      normalize_groups if options[:without] || options[:with]
 
       options[:force] = options[:redownload]
     end

--- a/bundler/spec/install/gemfile/groups_spec.rb
+++ b/bundler/spec/install/gemfile/groups_spec.rb
@@ -91,6 +91,15 @@ RSpec.describe "bundle install with groups" do
         expect(the_bundle).to include_gems "rack 1.0.0", :groups => [:default]
       end
 
+      it "respects global `without` configuration, but does not save it locally" do
+        bundle "config without emo"
+        bundle! :install
+        expect(the_bundle).to include_gems "rack 1.0.0", :groups => [:default]
+        bundle "config list"
+        expect(out).not_to include("Set for your local app (#{bundled_app(".bundle/config")}): [:emo]")
+        expect(out).to include("Set for the current user (#{home(".bundle/config")}): [:emo]")
+      end
+
       it "does not install gems from the excluded group" do
         bundle "config --local without emo"
         bundle :install

--- a/bundler/spec/install/gemfile/groups_spec.rb
+++ b/bundler/spec/install/gemfile/groups_spec.rb
@@ -86,29 +86,33 @@ RSpec.describe "bundle install with groups" do
       end
 
       it "installs gems in the default group" do
-        bundle! :install, forgotten_command_line_options(:without => "emo")
+        bundle "config --local without emo"
+        bundle! :install
         expect(the_bundle).to include_gems "rack 1.0.0", :groups => [:default]
       end
 
       it "does not install gems from the excluded group" do
-        bundle :install, :without => "emo"
+        bundle "config --local without emo"
+        bundle :install
         expect(the_bundle).not_to include_gems "activesupport 2.3.5", :groups => [:default]
       end
 
-      it "does not install gems from the previously excluded group" do
-        bundle :install, forgotten_command_line_options(:without => "emo")
+      it "remembers previous exclusion with `--without`", :bundler => "< 3" do
+        bundle "install --without emo"
         expect(the_bundle).not_to include_gems "activesupport 2.3.5"
         bundle :install
         expect(the_bundle).not_to include_gems "activesupport 2.3.5"
       end
 
       it "does not say it installed gems from the excluded group" do
-        bundle! :install, forgotten_command_line_options(:without => "emo")
+        bundle "config --local without emo"
+        bundle! :install
         expect(out).not_to include("activesupport")
       end
 
       it "allows Bundler.setup for specific groups" do
-        bundle :install, forgotten_command_line_options(:without => "emo")
+        bundle "config --local without emo"
+        bundle :install
         run!("require 'rack'; puts RACK", :default)
         expect(out).to eq("1.0.0")
       end
@@ -122,7 +126,8 @@ RSpec.describe "bundle install with groups" do
           end
         G
 
-        bundle :install, forgotten_command_line_options(:without => "emo")
+        bundle "config --local without emo"
+        bundle :install
         expect(the_bundle).to include_gems "activesupport 2.3.2", :groups => [:default]
       end
 
@@ -138,15 +143,15 @@ RSpec.describe "bundle install with groups" do
         ENV["BUNDLE_WITHOUT"] = nil
       end
 
-      it "clears --without when passed an empty list" do
-        bundle :install, forgotten_command_line_options(:without => "emo")
+      it "clears --without when passed an empty list", :bundler => "< 3" do
+        bundle "install --without emo"
 
-        bundle :install, forgotten_command_line_options(:without => "")
+        bundle "install --without ''"
         expect(the_bundle).to include_gems "activesupport 2.3.5"
       end
 
-      it "doesn't clear without when nothing is passed" do
-        bundle :install, forgotten_command_line_options(:without => "emo")
+      it "doesn't clear without when nothing is passed", :bundler => "< 3" do
+        bundle "install --without emo"
 
         bundle :install
         expect(the_bundle).not_to include_gems "activesupport 2.3.5"
@@ -158,12 +163,13 @@ RSpec.describe "bundle install with groups" do
       end
 
       it "installs gems from the optional group when requested" do
-        bundle :install, forgotten_command_line_options(:with => "debugging")
+        bundle "config --local with debugging"
+        bundle :install
         expect(the_bundle).to include_gems "thin 1.0"
       end
 
-      it "installs gems from the previously requested group" do
-        bundle :install, forgotten_command_line_options(:with => "debugging")
+      it "installs gems from the previously requested group", :bundler => "< 3" do
+        bundle "install --with debugging"
         expect(the_bundle).to include_gems "thin 1.0"
         bundle :install
         expect(the_bundle).to include_gems "thin 1.0"
@@ -176,26 +182,26 @@ RSpec.describe "bundle install with groups" do
         ENV["BUNDLE_WITH"] = nil
       end
 
-      it "clears --with when passed an empty list" do
-        bundle :install, forgotten_command_line_options(:with => "debugging")
-        bundle :install, forgotten_command_line_options(:with => "")
+      it "clears --with when passed an empty list", :bundler => "< 3" do
+        bundle "install --with debugging"
+        bundle "install --with ''"
         expect(the_bundle).not_to include_gems "thin 1.0"
       end
 
       it "removes groups from without when passed at --with", :bundler => "< 3" do
-        bundle :install, forgotten_command_line_options(:without => "emo")
-        bundle :install, forgotten_command_line_options(:with => "emo")
+        bundle "config --local without emo"
+        bundle "install --with emo"
         expect(the_bundle).to include_gems "activesupport 2.3.5"
       end
 
       it "removes groups from with when passed at --without", :bundler => "< 3" do
-        bundle :install, forgotten_command_line_options(:with => "debugging")
-        bundle :install, forgotten_command_line_options(:without => "debugging")
+        bundle "config --local with debugging"
+        bundle "install --without debugging"
         expect(the_bundle).not_to include_gem "thin 1.0"
       end
 
       it "errors out when passing a group to with and without via CLI flags", :bundler => "< 3" do
-        bundle :install, forgotten_command_line_options(:with => "emo debugging", :without => "emo")
+        bundle "install --with emo debugging --without emo"
         expect(last_command).to be_failure
         expect(err).to include("The offending groups are: emo")
       end
@@ -213,19 +219,21 @@ RSpec.describe "bundle install with groups" do
         expect(the_bundle).to include_gem "thin 1.0"
       end
 
-      it "can add and remove a group at the same time" do
-        bundle :install, forgotten_command_line_options(:with => "debugging", :without => "emo")
+      it "can add and remove a group at the same time", :bundler => "< 3" do
+        bundle "install --with debugging --without emo"
         expect(the_bundle).to include_gems "thin 1.0"
         expect(the_bundle).not_to include_gems "activesupport 2.3.5"
       end
 
       it "has no effect when listing a not optional group in with" do
-        bundle :install, forgotten_command_line_options(:with => "emo")
+        bundle "config --local with emo"
+        bundle :install
         expect(the_bundle).to include_gems "activesupport 2.3.5"
       end
 
       it "has no effect when listing an optional group in without" do
-        bundle :install, forgotten_command_line_options(:without => "debugging")
+        bundle "config --local without debugging"
+        bundle :install
         expect(the_bundle).not_to include_gems "thin 1.0"
       end
     end
@@ -242,12 +250,14 @@ RSpec.describe "bundle install with groups" do
       end
 
       it "installs gems in the default group" do
-        bundle! :install, forgotten_command_line_options(:without => "emo lolercoaster")
+        bundle "config --local without emo lolercoaster"
+        bundle! :install
         expect(the_bundle).to include_gems "rack 1.0.0"
       end
 
       it "installs the gem if any of its groups are installed" do
-        bundle! :install, forgotten_command_line_options(:without => "emo")
+        bundle "config --local without emo"
+        bundle! :install
         expect(the_bundle).to include_gems "rack 1.0.0", "activesupport 2.3.5"
       end
 
@@ -268,16 +278,20 @@ RSpec.describe "bundle install with groups" do
         end
 
         it "installs the gem unless all groups are excluded" do
-          bundle :install, forgotten_command_line_options(:without => "emo")
+          bundle "config --local without emo"
+          bundle :install
           expect(the_bundle).to include_gems "activesupport 2.3.5"
 
-          bundle :install, forgotten_command_line_options(:without => "lolercoaster")
+          bundle "config --local without lolercoaster"
+          bundle :install
           expect(the_bundle).to include_gems "activesupport 2.3.5"
 
-          bundle :install, forgotten_command_line_options(:without => "emo lolercoaster")
+          bundle "config --local without emo lolercoaster"
+          bundle :install
           expect(the_bundle).not_to include_gems "activesupport 2.3.5"
 
-          bundle :install, forgotten_command_line_options(:without => "'emo lolercoaster'")
+          bundle "config --local without 'emo lolercoaster'"
+          bundle :install
           expect(the_bundle).not_to include_gems "activesupport 2.3.5"
         end
       end
@@ -297,12 +311,14 @@ RSpec.describe "bundle install with groups" do
       end
 
       it "installs gems in the default group" do
-        bundle! :install, forgotten_command_line_options(:without => "emo lolercoaster")
+        bundle "config --local without emo lolercoaster"
+        bundle! :install
         expect(the_bundle).to include_gems "rack 1.0.0"
       end
 
       it "installs the gem if any of its groups are installed" do
-        bundle! :install, forgotten_command_line_options(:without => "emo")
+        bundle "config --local without emo"
+        bundle! :install
         expect(the_bundle).to include_gems "rack 1.0.0", "activesupport 2.3.5"
       end
     end
@@ -339,7 +355,8 @@ RSpec.describe "bundle install with groups" do
 
       system_gems "rack-0.9.1"
 
-      install_gemfile <<-G, forgotten_command_line_options(:without => "rack")
+      bundle "config --local without rack"
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "rack"
 
@@ -362,7 +379,8 @@ RSpec.describe "bundle install with groups" do
 
     it "does not hit the remote a second time" do
       FileUtils.rm_rf gem_repo2
-      bundle! :install, forgotten_command_line_options(:without => "rack").merge(:verbose => true)
+      bundle "config --local without rack"
+      bundle! :install, :verbose => true
       expect(last_command.stdboth).not_to match(/fetching/i)
     end
   end

--- a/bundler/spec/install/gemfile/groups_spec.rb
+++ b/bundler/spec/install/gemfile/groups_spec.rb
@@ -267,22 +267,16 @@ RSpec.describe "bundle install with groups" do
           G
         end
 
-        it "installs the gem w/ option --without emo" do
+        it "installs the gem unless all groups are excluded" do
           bundle :install, forgotten_command_line_options(:without => "emo")
           expect(the_bundle).to include_gems "activesupport 2.3.5"
-        end
 
-        it "installs the gem w/ option --without lolercoaster" do
           bundle :install, forgotten_command_line_options(:without => "lolercoaster")
           expect(the_bundle).to include_gems "activesupport 2.3.5"
-        end
 
-        it "does not install the gem w/ option --without emo lolercoaster" do
           bundle :install, forgotten_command_line_options(:without => "emo lolercoaster")
           expect(the_bundle).not_to include_gems "activesupport 2.3.5"
-        end
 
-        it "does not install the gem w/ option --without 'emo lolercoaster'" do
           bundle :install, forgotten_command_line_options(:without => "'emo lolercoaster'")
           expect(the_bundle).not_to include_gems "activesupport 2.3.5"
         end

--- a/bundler/spec/install/gemfile/groups_spec.rb
+++ b/bundler/spec/install/gemfile/groups_spec.rb
@@ -157,19 +157,19 @@ RSpec.describe "bundle install with groups" do
         expect(the_bundle).not_to include_gems "thin 1.0"
       end
 
-      it "does install gems from the optional group when requested" do
+      it "installs gems from the optional group when requested" do
         bundle :install, forgotten_command_line_options(:with => "debugging")
         expect(the_bundle).to include_gems "thin 1.0"
       end
 
-      it "does install gems from the previously requested group" do
+      it "installs gems from the previously requested group" do
         bundle :install, forgotten_command_line_options(:with => "debugging")
         expect(the_bundle).to include_gems "thin 1.0"
         bundle :install
         expect(the_bundle).to include_gems "thin 1.0"
       end
 
-      it "does install gems from the optional groups requested with BUNDLE_WITH" do
+      it "installs gems from the optional groups requested with BUNDLE_WITH" do
         ENV["BUNDLE_WITH"] = "debugging"
         bundle :install
         expect(the_bundle).to include_gems "thin 1.0"
@@ -182,13 +182,13 @@ RSpec.describe "bundle install with groups" do
         expect(the_bundle).not_to include_gems "thin 1.0"
       end
 
-      it "does remove groups from without when passed at --with", :bundler => "< 3" do
+      it "removes groups from without when passed at --with", :bundler => "< 3" do
         bundle :install, forgotten_command_line_options(:without => "emo")
         bundle :install, forgotten_command_line_options(:with => "emo")
         expect(the_bundle).to include_gems "activesupport 2.3.5"
       end
 
-      it "does remove groups from with when passed at --without", :bundler => "< 3" do
+      it "removes groups from with when passed at --without", :bundler => "< 3" do
         bundle :install, forgotten_command_line_options(:with => "debugging")
         bundle :install, forgotten_command_line_options(:without => "debugging")
         expect(the_bundle).not_to include_gem "thin 1.0"
@@ -219,12 +219,12 @@ RSpec.describe "bundle install with groups" do
         expect(the_bundle).not_to include_gems "activesupport 2.3.5"
       end
 
-      it "does have no effect when listing a not optional group in with" do
+      it "has no effect when listing a not optional group in with" do
         bundle :install, forgotten_command_line_options(:with => "emo")
         expect(the_bundle).to include_gems "activesupport 2.3.5"
       end
 
-      it "does have no effect when listing an optional group in without" do
+      it "has no effect when listing an optional group in without" do
         bundle :install, forgotten_command_line_options(:without => "debugging")
         expect(the_bundle).not_to include_gems "thin 1.0"
       end

--- a/bundler/spec/install/gemfile/groups_spec.rb
+++ b/bundler/spec/install/gemfile/groups_spec.rb
@@ -126,16 +126,6 @@ RSpec.describe "bundle install with groups" do
         expect(the_bundle).to include_gems "activesupport 2.3.2", :groups => [:default]
       end
 
-      it "still works on a different machine and excludes gems" do
-        bundle :install, forgotten_command_line_options(:without => "emo")
-
-        simulate_new_machine
-        bundle :install, forgotten_command_line_options(:without => "emo")
-
-        expect(the_bundle).to include_gems "rack 1.0.0", :groups => [:default]
-        expect(the_bundle).not_to include_gems "activesupport 2.3.5", :groups => [:default]
-      end
-
       it "still works when BUNDLE_WITHOUT is set" do
         ENV["BUNDLE_WITHOUT"] = "emo"
 

--- a/bundler/spec/install/gemfile/groups_spec.rb
+++ b/bundler/spec/install/gemfile/groups_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe "bundle install with groups" do
         ENV["BUNDLE_WITHOUT"] = nil
       end
 
-      it "clears without when passed an empty list" do
+      it "clears --without when passed an empty list" do
         bundle :install, forgotten_command_line_options(:without => "emo")
 
         bundle :install, forgotten_command_line_options(:without => "")
@@ -176,7 +176,7 @@ RSpec.describe "bundle install with groups" do
         ENV["BUNDLE_WITH"] = nil
       end
 
-      it "clears with when passed an empty list" do
+      it "clears --with when passed an empty list" do
         bundle :install, forgotten_command_line_options(:with => "debugging")
         bundle :install, forgotten_command_line_options(:with => "")
         expect(the_bundle).not_to include_gems "thin 1.0"

--- a/bundler/spec/install/gemfile/groups_spec.rb
+++ b/bundler/spec/install/gemfile/groups_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "bundle install with groups" do
     end
   end
 
-  describe "installing --without" do
+  describe "without option" do
     describe "with gems assigned to a single group" do
       before :each do
         gemfile <<-G
@@ -333,7 +333,7 @@ RSpec.describe "bundle install with groups" do
     end
   end
 
-  describe "when locked and installed with --without" do
+  describe "when locked and installed with `without` option" do
     before(:each) do
       build_repo2
 


### PR DESCRIPTION
# Description:

This PR fixes an issue where `bundle install` would unexpectedly copy global `with` and `without` configuration to the local application configuration.

While I was at it, I refactored both the specs and the handling of `with` and `without` options inside `bundle install`.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
