### PR TITLE
Skip gemspec validations that warn except when on a gem authoring context

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2590,6 +2590,7 @@ class Gem::Specification < Gem::BasicSpecification
   def validate_metadata
     Gem::SpecificationPolicy.new(self).validate_metadata
   end
+  rubygems_deprecate :validate_metadata
 
   ##
   # Checks that dependencies use requirements as we recommend.  Warnings are
@@ -2598,12 +2599,14 @@ class Gem::Specification < Gem::BasicSpecification
   def validate_dependencies
     Gem::SpecificationPolicy.new(self).validate_dependencies
   end
+  rubygems_deprecate :validate_dependencies
 
   ##
   # Checks to see if the files to be packaged are world-readable.
   def validate_permissions
     Gem::SpecificationPolicy.new(self).validate_permissions
   end
+  rubygems_deprecate :validate_permissions
 
   ##
   # Set the version to +version+, potentially also setting

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2592,17 +2592,11 @@ class Gem::Specification < Gem::BasicSpecification
   end
   rubygems_deprecate :validate_metadata
 
-  ##
-  # Checks that dependencies use requirements as we recommend.  Warnings are
-  # issued when dependencies are open-ended or overly strict for semantic
-  # versioning.
   def validate_dependencies
     Gem::SpecificationPolicy.new(self).validate_dependencies
   end
   rubygems_deprecate :validate_dependencies
 
-  ##
-  # Checks to see if the files to be packaged are world-readable.
   def validate_permissions
     Gem::SpecificationPolicy.new(self).validate_permissions
   end

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -37,6 +37,9 @@ class Gem::SpecificationPolicy
   #
   # Raises InvalidSpecificationException if the spec does not pass the
   # checks.
+  #
+  # It also performs some validations that do not raise but print warning
+  # messages instead.
 
   def validate(strict = false)
     validate_nil_attributes

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -44,7 +44,7 @@ class Gem::SpecificationPolicy
   def validate(strict = false)
     validate_required!
 
-    validate_optional(strict)
+    validate_optional(strict) if packaging || strict
 
     true
   end

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -309,8 +309,7 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
             end
 
     unless Array === val and val.all? {|x| x.kind_of?(klass)}
-      raise(Gem::InvalidSpecificationException,
-            "#{field} must be an Array of #{klass}")
+      error "#{field} must be an Array of #{klass}"
     end
   end
 

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -127,7 +127,9 @@ class Gem::SpecificationPolicy
   end
 
   ##
-  # Implementation for Specification#validate_dependencies
+  # Checks that dependencies use requirements as we recommend.  Warnings are
+  # issued when dependencies are open-ended or overly strict for semantic
+  # versioning.
 
   def validate_dependencies # :nodoc:
     # NOTE: see REFACTOR note in Gem::Dependency about types - this might be brittle

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -33,8 +33,7 @@ class Gem::SpecificationPolicy
   attr_accessor :packaging
 
   ##
-  # Checks that the specification contains all required fields, and does a
-  # very basic sanity check.
+  # Does a sanity check on the specification.
   #
   # Raises InvalidSpecificationException if the spec does not pass the
   # checks.

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3141,6 +3141,17 @@ http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
     WARNING
   end
 
+  def test_validate_license_in_a_non_packaging_context
+    util_setup_validate
+
+    use_ui @ui do
+      @a1.licenses.clear
+      @a1.validate(false)
+    end
+
+    assert_empty @ui.error
+  end
+
   def test_removed_methods
     assert_equal Gem::Specification::REMOVED_METHODS, [:rubyforge_project=]
   end


### PR DESCRIPTION
# Description:

## What was the end-user or developer problem that led to this PR?

As highlighted by #3664, gemspec validations can be slow.

## What is your fix for the problem, implemented in this PR?

Also, gemspec validations are targeted to gem authors, not final users. That's (I guess) why bundler [silences them](https://github.com/rubygems/bundler/blob/35be6d9a603084f719fec4f4028c18860def07f6/lib/bundler/rubygems_integration.rb#L70) when using `path` gems. It needs to validate them to make sure they are functional, but it's not interested in validation warnings.

So, my proposal is to limit the "optional linting" than emits warnings to "gem packaging" contexts.

As per the implementation, I "reused" the `packaging` parameter to `Gem::Specification#validate` for this. The [introduction of this parameter](https://github.com/rubygems/rubygems/commit/e95ff9a2d52f65e25b5e4a60c3f64d751c9e6df4) is not very explicit about its motivation, but I believe the intention was precisely to do something like this.

Closes #3664.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).