### PR TITLE
Make sure rubygems/package can be directly required reliably

### DIFF
--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -42,6 +42,7 @@
 # #files are the files in the .gem tar file, not the Ruby files in the gem
 # #extract_files and #contents automatically call #verify
 
+require "rubygems"
 require 'rubygems/security'
 require 'rubygems/specification'
 require 'rubygems/user_interaction'

--- a/test/rubygems/test_project_sanity.rb
+++ b/test/rubygems/test_project_sanity.rb
@@ -12,4 +12,10 @@ class TestProjectSanity < Minitest::Test
     assert status.success?, "Expected Manifest.txt to be up to date, but it's not. Run `rake update_manifest` to sync it."
   end
 
+  def test_require_rubygems_package
+    _, status = Open3.capture2e("ruby -v --disable-gems -I 'lib' -e 'require \"rubygems/package\"'")
+
+    assert status.success?
+  end
+
 end

--- a/test/rubygems/test_project_sanity.rb
+++ b/test/rubygems/test_project_sanity.rb
@@ -2,7 +2,7 @@
 
 require "open3"
 
-class TestProjectSanity < Minitest::Test
+class TestProjectSanity < Gem::TestCase
 
   def test_manifest_is_up_to_date
     skip unless File.exist?(File.expand_path("../../../Rakefile", __FILE__))
@@ -13,9 +13,11 @@ class TestProjectSanity < Minitest::Test
   end
 
   def test_require_rubygems_package
-    _, status = Open3.capture2e("ruby -v --disable-gems -I 'lib' -e 'require \"rubygems/package\"'")
+    require "rubygems/test_case"
 
-    assert status.success?
+    err, status = Open3.capture2e(*ruby_with_rubygems_in_load_path, "--disable-gems", "-e", "'require \"rubygems/package\"'")
+
+    assert status.success?, err
   end
 
 end

--- a/test/rubygems/test_project_sanity.rb
+++ b/test/rubygems/test_project_sanity.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "rubygems/test_case"
 require "open3"
 
 class TestProjectSanity < Gem::TestCase
@@ -13,8 +14,6 @@ class TestProjectSanity < Gem::TestCase
   end
 
   def test_require_rubygems_package
-    require "rubygems/test_case"
-
     err, status = Open3.capture2e(*ruby_with_rubygems_in_load_path, "--disable-gems", "-e", "'require \"rubygems/package\"'")
 
     assert status.success?, err


### PR DESCRIPTION
# Description:
closes https://github.com/rubygems/rubygems/issues/3650

______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
