### PR TITLE
Remove `forgotten_command_line_options` helper from specs

### DIFF
--- a/bundler/spec/commands/cache_spec.rb
+++ b/bundler/spec/commands/cache_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe "bundle cache" do
         gem 'rack'
       D
 
-      bundle! :cache, forgotten_command_line_options(:path => bundled_app("test"))
+      bundle! "cache --path #{bundled_app("test")}"
 
       expect(the_bundle).to include_gems "rack 1.0.0"
       expect(bundled_app("test/vendor/cache/")).to exist

--- a/bundler/spec/commands/cache_spec.rb
+++ b/bundler/spec/commands/cache_spec.rb
@@ -221,7 +221,8 @@ RSpec.describe "bundle cache" do
         end
       end
 
-      install_gemfile! <<-G, forgotten_command_line_options(:without => "wo")
+      bundle "config --local without wo"
+      install_gemfile! <<-G
         source "file:#{gem_repo1}"
         gem "rack"
         group :wo do
@@ -236,7 +237,8 @@ RSpec.describe "bundle cache" do
       expect(the_bundle).to include_gem "rack 1.0"
       expect(the_bundle).not_to include_gems "weakling", "uninstallable"
 
-      bundle! :install, forgotten_command_line_options(:without => "wo")
+      bundle "config --local without wo"
+      bundle! :install
       expect(the_bundle).to include_gem "rack 1.0"
       expect(the_bundle).not_to include_gems "weakling", "uninstallable"
     end
@@ -251,7 +253,10 @@ RSpec.describe "bundle cache" do
       bundle "install"
     end
 
-    subject { bundle :cache, forgotten_command_line_options(:frozen => true) }
+    subject do
+      bundle "config --local frozen true"
+      bundle :cache
+    end
 
     it "tries to install with frozen" do
       bundle! "config set deployment true"
@@ -299,7 +304,9 @@ RSpec.describe "bundle install with gem sources" do
       simulate_new_machine
       FileUtils.rm_rf gem_repo2
 
-      bundle! :install, forgotten_command_line_options(:deployment => true, :path => "vendor/bundle")
+      bundle "config --local deployment true"
+      bundle "config --local path vendor/bundle"
+      bundle! :install
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
 

--- a/bundler/spec/commands/cache_spec.rb
+++ b/bundler/spec/commands/cache_spec.rb
@@ -242,7 +242,7 @@ RSpec.describe "bundle cache" do
     end
   end
 
-  context "with --frozen" do
+  context "with frozen configured" do
     before do
       gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"

--- a/bundler/spec/commands/check_spec.rb
+++ b/bundler/spec/commands/check_spec.rb
@@ -123,7 +123,8 @@ RSpec.describe "bundle check" do
       gem "rack", :group => :foo
     G
 
-    bundle :install, forgotten_command_line_options(:without => "foo")
+    bundle "config --local without foo"
+    bundle :install
 
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -230,7 +231,8 @@ RSpec.describe "bundle check" do
       gem "foo"
     G
 
-    bundle! "install", forgotten_command_line_options(:deployment => true)
+    bundle "config --local deployment true"
+    bundle! "install"
     FileUtils.rm(bundled_app_lock)
 
     bundle :check

--- a/bundler/spec/commands/config_spec.rb
+++ b/bundler/spec/commands/config_spec.rb
@@ -45,7 +45,8 @@ RSpec.describe ".bundle/config" do
 
     it "can be moved with an environment variable" do
       ENV["BUNDLE_APP_CONFIG"] = tmp("foo/bar").to_s
-      bundle "install", forgotten_command_line_options(:path => "vendor/bundle")
+      bundle "config --local path vendor/bundle"
+      bundle "install"
 
       expect(bundled_app(".bundle")).not_to exist
       expect(tmp("foo/bar/config")).to exist
@@ -56,7 +57,8 @@ RSpec.describe ".bundle/config" do
       FileUtils.mkdir_p bundled_app("omg")
 
       ENV["BUNDLE_APP_CONFIG"] = "../foo"
-      bundle "install", forgotten_command_line_options(:path => "vendor/bundle").merge(:dir => bundled_app("omg"))
+      bundle "config --local path vendor/bundle"
+      bundle "install", :dir => bundled_app("omg")
 
       expect(bundled_app(".bundle")).not_to exist
       expect(bundled_app("../foo/config")).to exist

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -270,7 +270,8 @@ RSpec.describe "bundle exec" do
   end
 
   it "handles gems installed with --without", :ruby_repo do
-    install_gemfile <<-G, forgotten_command_line_options(:without => "middleware")
+    bundle "config --local without middleware"
+    install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
       gem "rack" # rack 0.9.1 and 1.0 exist
 

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -278,16 +278,16 @@ RSpec.describe "bundle install with gem sources" do
       end
 
       it "allows running bundle install --system without deleting foo", :bundler => "< 3" do
-        bundle "install", forgotten_command_line_options(:path => "vendor")
-        bundle "install", forgotten_command_line_options(:system => true)
+        bundle "install --path vendor"
+        bundle "install --system"
         FileUtils.rm_rf(bundled_app("vendor"))
         expect(the_bundle).to include_gems "rack 1.0"
       end
 
       it "allows running bundle install --system after deleting foo", :bundler => "< 3" do
-        bundle "install", forgotten_command_line_options(:path => "vendor")
+        bundle "install --path vendor"
         FileUtils.rm_rf(bundled_app("vendor"))
-        bundle "install", forgotten_command_line_options(:system => true)
+        bundle "install --system"
         expect(the_bundle).to include_gems "rack 1.0"
       end
     end

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -273,7 +273,8 @@ RSpec.describe "bundle install with gem sources" do
       end
 
       it "works" do
-        bundle "install", forgotten_command_line_options(:path => "vendor")
+        bundle "config --local path vendor"
+        bundle "install"
         expect(the_bundle).to include_gems "rack 1.0"
       end
 
@@ -549,7 +550,8 @@ RSpec.describe "bundle install with gem sources" do
     it "should display a proper message to explain the problem" do
       FileUtils.chmod(0o500, bundled_app("vendor"))
 
-      bundle :install, forgotten_command_line_options(:path => "vendor")
+      bundle "config --local path vendor"
+      bundle :install
       expect(err).to include(bundled_app("vendor").to_s)
       expect(err).to include("grant write permissions")
     end
@@ -561,7 +563,7 @@ RSpec.describe "bundle install with gem sources" do
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
-      forgotten_command_line_options(:path => "bundle")
+      bundle "config --local path bundle"
       bundle! "install", :standalone => true
     end
 

--- a/bundler/spec/commands/post_bundle_message_spec.rb
+++ b/bundler/spec/commands/post_bundle_message_spec.rb
@@ -29,19 +29,22 @@ RSpec.describe "post bundle message" do
       expect(out).to include(bundle_complete_message)
       expect(out).to include(installed_gems_stats)
 
-      bundle! :install, forgotten_command_line_options(:without => "emo")
+      bundle "config --local without emo"
+      bundle! :install
       expect(out).to include(bundle_show_message)
       expect(out).to include("Gems in the group emo were not installed")
       expect(out).to include(bundle_complete_message)
       expect(out).to include(installed_gems_stats)
 
-      bundle! :install, forgotten_command_line_options(:without => "emo test")
+      bundle "config --local without emo test"
+      bundle! :install
       expect(out).to include(bundle_show_message)
       expect(out).to include("Gems in the groups emo and test were not installed")
       expect(out).to include(bundle_complete_message)
       expect(out).to include("4 Gemfile dependencies, 3 gems now installed.")
 
-      bundle! :install, forgotten_command_line_options(:without => "emo obama test")
+      bundle "config --local without emo obama test"
+      bundle! :install
       expect(out).to include(bundle_show_message)
       expect(out).to include("Gems in the groups emo, obama and test were not installed")
       expect(out).to include(bundle_complete_message)
@@ -52,22 +55,29 @@ RSpec.describe "post bundle message" do
       let(:bundle_path) { "./vendor" }
 
       it "shows proper messages according to the configured groups" do
-        bundle! :install, forgotten_command_line_options(:path => "vendor")
+        bundle "config --local path vendor"
+        bundle! :install
         expect(out).to include(bundle_show_path_message)
         expect(out).to_not include("Gems in the group")
         expect(out).to include(bundle_complete_message)
 
-        bundle! :install, forgotten_command_line_options(:without => "emo", :path => "vendor")
+        bundle "config --local path vendor"
+        bundle "config --local without emo"
+        bundle! :install
         expect(out).to include(bundle_show_path_message)
         expect(out).to include("Gems in the group emo were not installed")
         expect(out).to include(bundle_complete_message)
 
-        bundle! :install, forgotten_command_line_options(:without => "emo test", :path => "vendor")
+        bundle "config --local path vendor"
+        bundle "config --local without emo test"
+        bundle! :install
         expect(out).to include(bundle_show_path_message)
         expect(out).to include("Gems in the groups emo and test were not installed")
         expect(out).to include(bundle_complete_message)
 
-        bundle! :install, forgotten_command_line_options(:without => "emo obama test", :path => "vendor")
+        bundle "config --local path vendor"
+        bundle "config --local without emo obama test"
+        bundle! :install
         expect(out).to include(bundle_show_path_message)
         expect(out).to include("Gems in the groups emo, obama and test were not installed")
         expect(out).to include(bundle_complete_message)
@@ -75,8 +85,11 @@ RSpec.describe "post bundle message" do
     end
 
     describe "with an absolute `path` inside the cwd configured" do
+      let(:bundle_path) { bundled_app("cache") }
+
       it "shows proper messages according to the configured groups" do
-        bundle! :install, forgotten_command_line_options(:path => bundled_app("cache"))
+        bundle "config --local path #{bundle_path}"
+        bundle! :install
         expect(out).to include("Bundled gems are installed into `./cache`")
         expect(out).to_not include("Gems in the group")
         expect(out).to include(bundle_complete_message)
@@ -84,8 +97,11 @@ RSpec.describe "post bundle message" do
     end
 
     describe "with `path` configured to an absolute path outside the cwd" do
+      let(:bundle_path) { tmp("not_bundled_app") }
+
       it "shows proper messages according to the configured groups" do
-        bundle! :install, forgotten_command_line_options(:path => tmp("not_bundled_app"))
+        bundle "config --local path #{bundle_path}"
+        bundle! :install
         expect(out).to include("Bundled gems are installed into `#{tmp("not_bundled_app")}`")
         expect(out).to_not include("Gems in the group")
         expect(out).to include(bundle_complete_message)
@@ -136,7 +152,7 @@ The source does not contain any versions of 'not-a-gem'
     end
   end
 
-  describe "for second bundle install run" do
+  describe "for second bundle install run", :bundler => "< 3" do
     it "without any options" do
       2.times { bundle :install }
       expect(out).to include(bundle_show_message)
@@ -146,7 +162,7 @@ The source does not contain any versions of 'not-a-gem'
     end
 
     it "with --without one group" do
-      bundle! :install, forgotten_command_line_options(:without => "emo")
+      bundle! "install --without emo"
       bundle! :install
       expect(out).to include(bundle_show_message)
       expect(out).to include("Gems in the group emo were not installed")
@@ -155,7 +171,7 @@ The source does not contain any versions of 'not-a-gem'
     end
 
     it "with --without two groups" do
-      bundle! :install, forgotten_command_line_options(:without => "emo test")
+      bundle! "install --without emo test"
       bundle! :install
       expect(out).to include(bundle_show_message)
       expect(out).to include("Gems in the groups emo and test were not installed")
@@ -163,7 +179,7 @@ The source does not contain any versions of 'not-a-gem'
     end
 
     it "with --without more groups" do
-      bundle! :install, forgotten_command_line_options(:without => "emo obama test")
+      bundle! "install --without emo obama test"
       bundle :install
       expect(out).to include(bundle_show_message)
       expect(out).to include("Gems in the groups emo, obama and test were not installed")
@@ -177,17 +193,20 @@ The source does not contain any versions of 'not-a-gem'
       expect(out).not_to include("Gems in the groups")
       expect(out).to include(bundle_updated_message)
 
-      bundle! :install, forgotten_command_line_options(:without => "emo")
+      bundle "config --local without emo"
+      bundle! :install
       bundle! :update, :all => true
       expect(out).to include("Gems in the group emo were not updated")
       expect(out).to include(bundle_updated_message)
 
-      bundle! :install, forgotten_command_line_options(:without => "emo test")
+      bundle "config --local without emo test"
+      bundle! :install
       bundle! :update, :all => true
       expect(out).to include("Gems in the groups emo and test were not updated")
       expect(out).to include(bundle_updated_message)
 
-      bundle! :install, forgotten_command_line_options(:without => "emo obama test")
+      bundle "config --local without emo obama test"
+      bundle! :install
       bundle! :update, :all => true
       expect(out).to include("Gems in the groups emo, obama and test were not updated")
       expect(out).to include(bundle_updated_message)

--- a/bundler/spec/commands/post_bundle_message_spec.rb
+++ b/bundler/spec/commands/post_bundle_message_spec.rb
@@ -22,31 +22,25 @@ RSpec.describe "post bundle message" do
   let(:bundle_show_message)        { Bundler::VERSION.split(".").first.to_i < 3 ? bundle_show_system_message : bundle_show_path_message }
 
   describe "for fresh bundle install" do
-    it "without any options" do
+    it "shows proper messages according to the configured groups" do
       bundle :install
       expect(out).to include(bundle_show_message)
       expect(out).not_to include("Gems in the group")
       expect(out).to include(bundle_complete_message)
       expect(out).to include(installed_gems_stats)
-    end
 
-    it "with --without one group" do
       bundle! :install, forgotten_command_line_options(:without => "emo")
       expect(out).to include(bundle_show_message)
       expect(out).to include("Gems in the group emo were not installed")
       expect(out).to include(bundle_complete_message)
       expect(out).to include(installed_gems_stats)
-    end
 
-    it "with --without two groups" do
       bundle! :install, forgotten_command_line_options(:without => "emo test")
       expect(out).to include(bundle_show_message)
       expect(out).to include("Gems in the groups emo and test were not installed")
       expect(out).to include(bundle_complete_message)
       expect(out).to include("4 Gemfile dependencies, 3 gems now installed.")
-    end
 
-    it "with --without more groups" do
       bundle! :install, forgotten_command_line_options(:without => "emo obama test")
       expect(out).to include(bundle_show_message)
       expect(out).to include("Gems in the groups emo, obama and test were not installed")
@@ -54,45 +48,43 @@ RSpec.describe "post bundle message" do
       expect(out).to include("4 Gemfile dependencies, 2 gems now installed.")
     end
 
-    describe "with --path and" do
+    describe "with `path` configured" do
       let(:bundle_path) { "./vendor" }
 
-      it "without any options" do
+      it "shows proper messages according to the configured groups" do
         bundle! :install, forgotten_command_line_options(:path => "vendor")
         expect(out).to include(bundle_show_path_message)
         expect(out).to_not include("Gems in the group")
         expect(out).to include(bundle_complete_message)
-      end
 
-      it "with --without one group" do
         bundle! :install, forgotten_command_line_options(:without => "emo", :path => "vendor")
         expect(out).to include(bundle_show_path_message)
         expect(out).to include("Gems in the group emo were not installed")
         expect(out).to include(bundle_complete_message)
-      end
 
-      it "with --without two groups" do
         bundle! :install, forgotten_command_line_options(:without => "emo test", :path => "vendor")
         expect(out).to include(bundle_show_path_message)
         expect(out).to include("Gems in the groups emo and test were not installed")
         expect(out).to include(bundle_complete_message)
-      end
 
-      it "with --without more groups" do
         bundle! :install, forgotten_command_line_options(:without => "emo obama test", :path => "vendor")
         expect(out).to include(bundle_show_path_message)
         expect(out).to include("Gems in the groups emo, obama and test were not installed")
         expect(out).to include(bundle_complete_message)
       end
+    end
 
-      it "with an absolute --path inside the cwd" do
+    describe "with an absolute `path` inside the cwd configured" do
+      it "shows proper messages according to the configured groups" do
         bundle! :install, forgotten_command_line_options(:path => bundled_app("cache"))
         expect(out).to include("Bundled gems are installed into `./cache`")
         expect(out).to_not include("Gems in the group")
         expect(out).to include(bundle_complete_message)
       end
+    end
 
-      it "with an absolute --path outside the cwd" do
+    describe "with `path` configured to an absolute path outside the cwd" do
+      it "shows proper messages according to the configured groups" do
         bundle! :install, forgotten_command_line_options(:path => tmp("not_bundled_app"))
         expect(out).to include("Bundled gems are installed into `#{tmp("not_bundled_app")}`")
         expect(out).to_not include("Gems in the group")
@@ -180,27 +172,21 @@ The source does not contain any versions of 'not-a-gem'
   end
 
   describe "for bundle update" do
-    it "without any options" do
+    it "shows proper messages according to the configured groups" do
       bundle! :update, :all => true
       expect(out).not_to include("Gems in the groups")
       expect(out).to include(bundle_updated_message)
-    end
 
-    it "with --without one group" do
       bundle! :install, forgotten_command_line_options(:without => "emo")
       bundle! :update, :all => true
       expect(out).to include("Gems in the group emo were not updated")
       expect(out).to include(bundle_updated_message)
-    end
 
-    it "with --without two groups" do
       bundle! :install, forgotten_command_line_options(:without => "emo test")
       bundle! :update, :all => true
       expect(out).to include("Gems in the groups emo and test were not updated")
       expect(out).to include(bundle_updated_message)
-    end
 
-    it "with --without more groups" do
       bundle! :install, forgotten_command_line_options(:without => "emo obama test")
       bundle! :update, :all => true
       expect(out).to include("Gems in the groups emo, obama and test were not updated")

--- a/bundler/spec/install/deploy_spec.rb
+++ b/bundler/spec/install/deploy_spec.rb
@@ -279,7 +279,7 @@ RSpec.describe "install with --deployment or --frozen" do
       expect(err).not_to include("You have changed in the Gemfile")
     end
 
-    it "installs gems by default to vendor/bundle when `--deployment` is set via an environment variable", :bundler => "< 3" do
+    it "installs gems by default to vendor/bundle when deployment mode is set via an environment variable", :bundler => "< 3" do
       ENV["BUNDLE_DEPLOYMENT"] = "true"
       bundle "install"
       expect(out).to include("vendor/bundle")

--- a/bundler/spec/install/deploy_spec.rb
+++ b/bundler/spec/install/deploy_spec.rb
@@ -44,11 +44,9 @@ RSpec.describe "install with --deployment or --frozen" do
   it "still works if you are not in the app directory and specify --gemfile" do
     bundle! "install"
     simulate_new_machine
-    bundle! :install,
-      forgotten_command_line_options(:gemfile => "#{tmp}/bundled_app/Gemfile",
-                                     :deployment => true,
-                                     :path => "vendor/bundle",
-                                     :dir => tmp)
+    bundle "config --local deployment true"
+    bundle "config --local path vendor/bundle"
+    bundle! "install --gemfile #{tmp}/bundled_app/Gemfile", :dir => tmp
     expect(the_bundle).to include_gems "rack 1.0"
   end
 
@@ -60,7 +58,9 @@ RSpec.describe "install with --deployment or --frozen" do
       end
     G
     bundle! :install
-    bundle! :install, forgotten_command_line_options(:deployment => true, :without => "test")
+    bundle "config --local deployment true"
+    bundle "config --local without test"
+    bundle! :install
   end
 
   it "works when you bundle exec bundle", :ruby_repo do
@@ -80,7 +80,8 @@ RSpec.describe "install with --deployment or --frozen" do
     G
 
     bundle! :install
-    bundle! :install, forgotten_command_line_options(:deployment => true)
+    bundle "config --local deployment true"
+    bundle! :install
   end
 
   it "works when there are credentials in the source URL" do
@@ -90,7 +91,8 @@ RSpec.describe "install with --deployment or --frozen" do
       gem "rack-obama", ">= 1.0"
     G
 
-    bundle! :install, forgotten_command_line_options(:deployment => true).merge(:artifice => "endpoint_strict_basic_authentication")
+    bundle "config --local deployment true"
+    bundle! :install, :artifice => "endpoint_strict_basic_authentication"
   end
 
   it "works with sources given by a block" do
@@ -100,14 +102,16 @@ RSpec.describe "install with --deployment or --frozen" do
       end
     G
 
-    bundle! :install, forgotten_command_line_options(:deployment => true)
+    bundle "config --local deployment true"
+    bundle! :install
 
     expect(the_bundle).to include_gems "rack 1.0"
   end
 
   context "when replacing a host with the same host with credentials" do
     before do
-      bundle! "install", forgotten_command_line_options(:path => "vendor/bundle")
+      bundle "config --local path vendor/bundle"
+      bundle! "install"
       gemfile <<-G
       source "http://user_name:password@localgemserver.test/"
       gem "rack"
@@ -210,7 +214,8 @@ RSpec.describe "install with --deployment or --frozen" do
         gem "rack-obama"
       G
 
-      bundle :install, forgotten_command_line_options(:deployment => true)
+      bundle "config --local deployment true"
+      bundle :install
       expect(err).to include("deployment mode")
       expect(err).to include("You have added to the Gemfile")
       expect(err).to include("* rack-obama")
@@ -228,7 +233,10 @@ RSpec.describe "install with --deployment or --frozen" do
       expect(the_bundle).to include_gems "path_gem 1.0"
       FileUtils.rm_r lib_path("path_gem-1.0")
 
-      bundle! :install, forgotten_command_line_options(:path => ".bundle", :without => "development", :deployment => true).merge(:env => { "DEBUG" => "1" })
+      bundle "config --local path .bundle"
+      bundle "config --local without development"
+      bundle "config --local deployment true"
+      bundle! :install, :env => { "DEBUG" => "1" }
       run! "puts :WIN"
       expect(out).to eq("WIN")
     end
@@ -243,7 +251,9 @@ RSpec.describe "install with --deployment or --frozen" do
       expect(the_bundle).to include_gems "path_gem 1.0"
       FileUtils.rm_r lib_path("path_gem-1.0")
 
-      bundle :install, forgotten_command_line_options(:path => ".bundle", :deployment => true)
+      bundle "config --local path .bundle"
+      bundle "config --local deployment true"
+      bundle :install
       expect(err).to include("The path `#{lib_path("path_gem-1.0")}` does not exist.")
     end
 
@@ -313,7 +323,8 @@ RSpec.describe "install with --deployment or --frozen" do
         gem "activesupport"
       G
 
-      bundle :install, forgotten_command_line_options(:deployment => true)
+      bundle "config --local deployment true"
+      bundle :install
       expect(err).to include("deployment mode")
       expect(err).to include("You have added to the Gemfile:\n* activesupport\n\n")
       expect(err).to include("You have deleted from the Gemfile:\n* rack")
@@ -326,7 +337,8 @@ RSpec.describe "install with --deployment or --frozen" do
         gem "rack", :git => "git://hubz.com"
       G
 
-      bundle :install, forgotten_command_line_options(:deployment => true)
+      bundle "config --local deployment true"
+      bundle :install
       expect(err).to include("deployment mode")
       expect(err).to include("You have added to the Gemfile:\n* source: git://hubz.com (at master)")
       expect(err).not_to include("You have changed in the Gemfile")
@@ -345,7 +357,8 @@ RSpec.describe "install with --deployment or --frozen" do
         gem "rack"
       G
 
-      bundle :install, forgotten_command_line_options(:deployment => true)
+      bundle "config --local deployment true"
+      bundle :install
       expect(err).to include("deployment mode")
       expect(err).to include("You have deleted from the Gemfile:\n* source: #{lib_path("rack-1.0")} (at master@#{revision_for(lib_path("rack-1.0"))[0..6]}")
       expect(err).not_to include("You have added to the Gemfile")
@@ -368,7 +381,8 @@ RSpec.describe "install with --deployment or --frozen" do
         gem "foo", :git => "#{lib_path("rack")}"
       G
 
-      bundle :install, forgotten_command_line_options(:deployment => true)
+      bundle "config --local deployment true"
+      bundle :install
       expect(err).to include("deployment mode")
       expect(err).to include("You have changed in the Gemfile:\n* rack from `no specified source` to `#{lib_path("rack")} (at master@#{revision_for(lib_path("rack"))[0..6]})`")
       expect(err).not_to include("You have added to the Gemfile")

--- a/bundler/spec/install/gemfile/eval_gemfile_spec.rb
+++ b/bundler/spec/install/gemfile/eval_gemfile_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "bundle install with gemfile that uses eval_gemfile" do
 
     # Make sure that we are properly comparing path based gems between the
     # parsed lockfile and the evaluated gemfile.
-    it "bundles with --deployment" do
+    it "bundles with deployment mode configured" do
       bundle! :install
       bundle! :install, forgotten_command_line_options(:deployment => true)
     end

--- a/bundler/spec/install/gemfile/eval_gemfile_spec.rb
+++ b/bundler/spec/install/gemfile/eval_gemfile_spec.rb
@@ -47,7 +47,8 @@ RSpec.describe "bundle install with gemfile that uses eval_gemfile" do
     # parsed lockfile and the evaluated gemfile.
     it "bundles with deployment mode configured" do
       bundle! :install
-      bundle! :install, forgotten_command_line_options(:deployment => true)
+      bundle "config --local deployment true"
+      bundle! :install
     end
   end
 

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -290,7 +290,8 @@ RSpec.describe "bundle install from an existing gemspec" do
           s.add_dependency "activesupport", ">= 1.0.1"
         end
 
-        bundle :install, forgotten_command_line_options(:deployment => true)
+        bundle "config --local deployment true"
+        bundle :install
 
         expect(err).to include("changed")
       end
@@ -558,7 +559,8 @@ RSpec.describe "bundle install from an existing gemspec" do
     it "installs the ruby platform gemspec and skips dev deps with `without development` configured" do
       simulate_platform "ruby"
 
-      install_gemfile! <<-G, forgotten_command_line_options(:without => "development")
+      bundle "config --local without development"
+      install_gemfile! <<-G
         source "#{file_uri_for(gem_repo1)}"
         gemspec :path => '#{tmp.join("foo")}', :name => 'foo'
       G

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -555,7 +555,7 @@ RSpec.describe "bundle install from an existing gemspec" do
       expect(the_bundle).to include_gems "foo 1.0.0", "rack 1.0.0"
     end
 
-    it "installs the ruby platform gemspec and skips dev deps with --without development" do
+    it "installs the ruby platform gemspec and skips dev deps with `without development` configured" do
       simulate_platform "ruby"
 
       install_gemfile! <<-G, forgotten_command_line_options(:without => "development")

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -1043,7 +1043,8 @@ RSpec.describe "bundle install with git sources" do
 
       simulate_new_machine
 
-      bundle! :install, forgotten_command_line_options(:deployment => true)
+      bundle "config --local deployment true"
+      bundle! :install
     end
   end
 

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -1032,7 +1032,7 @@ RSpec.describe "bundle install with git sources" do
     end
   end
 
-  describe "bundle install --deployment with git sources" do
+  describe "bundle install with deployment mode configured and git sources" do
     it "works" do
       build_git "valim", :path => lib_path("valim")
 

--- a/bundler/spec/install/gemfile/path_spec.rb
+++ b/bundler/spec/install/gemfile/path_spec.rb
@@ -131,7 +131,8 @@ RSpec.describe "bundle install with explicit source paths" do
       gem 'foo', :path => File.expand_path("../foo-1.0", __FILE__)
     G
 
-    bundle! :install, forgotten_command_line_options(:frozen => true)
+    bundle "config --local frozen true"
+    bundle! :install
     expect(exitstatus).to eq(0) if exitstatus
   end
 

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -263,7 +263,8 @@ RSpec.describe "bundle install across platforms" do
       gem "rack", "1.0.0"
     G
 
-    bundle! :install, forgotten_command_line_options(:path => "vendor/bundle")
+    bundle "config --local path vendor/bundle"
+    bundle! :install
 
     FileUtils.mv(vendored_gems, bundled_app("vendor/bundle", Gem.ruby_engine, "1.8"))
 

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -107,7 +107,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
         expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
         expect(bundled_app("vendor/cache/rack-obama-1.0.gem")).to exist
 
-        bundle! :install, forgotten_command_line_options(:deployment => true)
+        bundle "config --local deployment true"
+        bundle! :install
 
         expect(the_bundle).to include_gems("rack-obama 1.0.0", "rack 1.0.0")
       end
@@ -485,7 +486,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
         gem 'bar', '~> 0.1', :source => '#{file_uri_for(gem_repo4)}'
       G
 
-      bundle! :install, forgotten_command_line_options(:path => "../gems/system")
+      bundle "config --local path ../gems/system"
+      bundle! :install
 
       # And then we add some new versions...
       update_repo4 do

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -80,7 +80,9 @@ RSpec.describe "compact index api" do
     G
     bundle! :install, :artifice => "compact_index"
 
-    bundle! :install, forgotten_command_line_options(:deployment => true, :path => "vendor/bundle").merge(:artifice => "compact_index")
+    bundle "config --local deployment true"
+    bundle "config --local path vendor/bundle"
+    bundle! :install, :artifice => "compact_index"
     expect(out).to include("Fetching gem metadata from #{source_uri}")
     expect(the_bundle).to include_gems "rack 1.0.0"
   end
@@ -130,7 +132,8 @@ RSpec.describe "compact index api" do
     G
 
     bundle "install", :artifice => "compact_index"
-    bundle! :install, forgotten_command_line_options(:deployment => true).merge(:artifice => "compact_index")
+    bundle "config --local deployment true"
+    bundle! :install, :artifice => "compact_index"
 
     expect(the_bundle).to include_gems("foo 1.0")
   end

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "compact index api" do
     expect(the_bundle).to include_gems "net-sftp 1.1.1"
   end
 
-  it "should use the endpoint when using --deployment" do
+  it "should use the endpoint when using deployment mode" do
     gemfile <<-G
       source "#{source_uri}"
       gem "rack"
@@ -103,7 +103,7 @@ RSpec.describe "compact index api" do
     expect(the_bundle).to include_gems("rails 2.3.2")
   end
 
-  it "handles git dependencies that are in rubygems using --deployment" do
+  it "handles git dependencies that are in rubygems using deployment mode" do
     build_git "foo" do |s|
       s.executables = "foobar"
       s.add_dependency "rails", "2.3.2"
@@ -116,12 +116,13 @@ RSpec.describe "compact index api" do
 
     bundle! :install, :artifice => "compact_index"
 
-    bundle "install --deployment", :artifice => "compact_index"
+    bundle "config --local deployment true"
+    bundle :install, :artifice => "compact_index"
 
     expect(the_bundle).to include_gems("rails 2.3.2")
   end
 
-  it "doesn't fail if you only have a git gem with no deps when using --deployment" do
+  it "doesn't fail if you only have a git gem with no deps when using deployment mode" do
     build_git "foo"
     gemfile <<-G
       source "#{source_uri}"
@@ -473,7 +474,7 @@ The checksum of /versions does not match the checksum provided by the server! So
     expect(the_bundle).to include_gems "back_deps 1.0"
   end
 
-  it "fetches again when more dependencies are found in subsequent sources using --deployment with blocks" do
+  it "fetches again when more dependencies are found in subsequent sources using deployment mode with blocks" do
     build_repo2 do
       build_gem "back_deps" do |s|
         s.add_dependency "foo"
@@ -489,8 +490,8 @@ The checksum of /versions does not match the checksum provided by the server! So
     G
 
     bundle! :install, :artifice => "compact_index_extra"
-
-    bundle "install --deployment", :artifice => "compact_index_extra"
+    bundle "config --local deployment true"
+    bundle! :install, :artifice => "compact_index_extra"
     expect(the_bundle).to include_gems "back_deps 1.0"
   end
 

--- a/bundler/spec/install/gems/dependency_api_spec.rb
+++ b/bundler/spec/install/gems/dependency_api_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "gemcutter's dependency API" do
     expect(the_bundle).to include_gems "net-sftp 1.1.1"
   end
 
-  it "should use the endpoint when using --deployment" do
+  it "should use the endpoint when using deployment mode" do
     gemfile <<-G
       source "#{source_uri}"
       gem "rack"
@@ -83,7 +83,7 @@ RSpec.describe "gemcutter's dependency API" do
     expect(the_bundle).to include_gems("rails 2.3.2")
   end
 
-  it "handles git dependencies that are in rubygems using --deployment" do
+  it "handles git dependencies that are in rubygems using deployment mode" do
     build_git "foo" do |s|
       s.executables = "foobar"
       s.add_dependency "rails", "2.3.2"
@@ -96,12 +96,13 @@ RSpec.describe "gemcutter's dependency API" do
 
     bundle :install, :artifice => "endpoint"
 
-    bundle "install --deployment", :artifice => "endpoint"
+    bundle "config --local deployment true"
+    bundle :install, :artifice => "endpoint"
 
     expect(the_bundle).to include_gems("rails 2.3.2")
   end
 
-  it "doesn't fail if you only have a git gem with no deps when using --deployment" do
+  it "doesn't fail if you only have a git gem with no deps when using deployment mode" do
     build_git "foo"
     gemfile <<-G
       source "#{source_uri}"
@@ -446,7 +447,7 @@ RSpec.describe "gemcutter's dependency API" do
     expect(the_bundle).to include_gems "back_deps 1.0"
   end
 
-  it "fetches again when more dependencies are found in subsequent sources using --deployment with blocks" do
+  it "fetches again when more dependencies are found in subsequent sources using deployment mode with blocks" do
     build_repo2 do
       build_gem "back_deps" do |s|
         s.add_dependency "foo"
@@ -463,7 +464,8 @@ RSpec.describe "gemcutter's dependency API" do
 
     bundle :install, :artifice => "endpoint_extra"
 
-    bundle "install --deployment", :artifice => "endpoint_extra"
+    bundle "config --local deployment true"
+    bundle! "install", :artifice => "endpoint_extra"
     expect(the_bundle).to include_gems "back_deps 1.0"
   end
 

--- a/bundler/spec/install/gems/dependency_api_spec.rb
+++ b/bundler/spec/install/gems/dependency_api_spec.rb
@@ -60,7 +60,9 @@ RSpec.describe "gemcutter's dependency API" do
     G
     bundle :install, :artifice => "endpoint"
 
-    bundle! :install, forgotten_command_line_options(:deployment => true, :path => "vendor/bundle").merge(:artifice => "endpoint")
+    bundle "config --local deployment true"
+    bundle "config --local path vendor/bundle"
+    bundle! :install, :artifice => "endpoint"
     expect(out).to include("Fetching gem metadata from #{source_uri}")
     expect(the_bundle).to include_gems "rack 1.0.0"
   end
@@ -110,7 +112,8 @@ RSpec.describe "gemcutter's dependency API" do
     G
 
     bundle "install", :artifice => "endpoint"
-    bundle! :install, forgotten_command_line_options(:deployment => true).merge(:artifice => "endpoint")
+    bundle "config --local deployment true"
+    bundle! :install, :artifice => "endpoint"
 
     expect(the_bundle).to include_gems("foo 1.0")
   end

--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -55,7 +55,8 @@ RSpec.shared_examples "bundle install --standalone" do
         source "#{file_uri_for(gem_repo1)}"
         gem "rails"
       G
-      bundle! :install, forgotten_command_line_options(:path => bundled_app("bundle")).merge(:standalone => true, :dir => cwd)
+      bundle "config --local path #{bundled_app("bundle")}"
+      bundle! :install, :standalone => true, :dir => cwd
     end
 
     let(:expected_gems) do
@@ -70,7 +71,8 @@ RSpec.shared_examples "bundle install --standalone" do
 
   describe "with gems with native extension", :ruby_repo do
     before do
-      install_gemfile <<-G, forgotten_command_line_options(:path => bundled_app("bundle")).merge(:standalone => true, :dir => cwd)
+      bundle "config --local path #{bundled_app("bundle")}"
+      install_gemfile <<-G, :standalone => true, :dir => cwd
         source "#{file_uri_for(gem_repo1)}"
         gem "very_simple_binary"
       G
@@ -103,7 +105,8 @@ RSpec.shared_examples "bundle install --standalone" do
           end
         G
       end
-      install_gemfile <<-G, forgotten_command_line_options(:path => bundled_app("bundle")).merge(:standalone => true, :dir => cwd)
+      bundle "config --local path #{bundled_app("bundle")}"
+      install_gemfile <<-G, :standalone => true, :dir => cwd
         gem "bar", :git => "#{lib_path("bar-1.0")}"
       G
     end
@@ -123,7 +126,8 @@ RSpec.shared_examples "bundle install --standalone" do
         gem "rails"
         gem "devise", :git => "#{lib_path("devise-1.0")}"
       G
-      bundle! :install, forgotten_command_line_options(:path => bundled_app("bundle")).merge(:standalone => true, :dir => cwd)
+      bundle "config --local path #{bundled_app("bundle")}"
+      bundle! :install, :standalone => true, :dir => cwd
     end
 
     let(:expected_gems) do
@@ -150,7 +154,8 @@ RSpec.shared_examples "bundle install --standalone" do
           gem "rack-test"
         end
       G
-      bundle! :install, forgotten_command_line_options(:path => bundled_app("bundle")).merge(:standalone => true, :dir => cwd)
+      bundle "config --local path #{bundled_app("bundle")}"
+      bundle! :install, :standalone => true, :dir => cwd
     end
 
     let(:expected_gems) do
@@ -163,7 +168,8 @@ RSpec.shared_examples "bundle install --standalone" do
     include_examples "common functionality"
 
     it "allows creating a standalone file with limited groups" do
-      bundle! :install, forgotten_command_line_options(:path => bundled_app("bundle")).merge(:standalone => "default", :dir => cwd)
+      bundle "config --local path #{bundled_app("bundle")}"
+      bundle! :install, :standalone => "default", :dir => cwd
 
       load_error_ruby <<-RUBY, "spec"
         $:.unshift File.expand_path("bundle")
@@ -179,7 +185,9 @@ RSpec.shared_examples "bundle install --standalone" do
     end
 
     it "allows `without` configuration to limit the groups used in a standalone" do
-      bundle! :install, forgotten_command_line_options(:path => bundled_app("bundle"), :without => "test").merge(:standalone => true, :dir => cwd)
+      bundle "config --local path #{bundled_app("bundle")}"
+      bundle "config --local without test"
+      bundle! :install, :standalone => true, :dir => cwd
 
       load_error_ruby <<-RUBY, "spec"
         $:.unshift File.expand_path("bundle")
@@ -195,7 +203,8 @@ RSpec.shared_examples "bundle install --standalone" do
     end
 
     it "allows `path` configuration to change the location of the standalone bundle" do
-      bundle! "install", forgotten_command_line_options(:path => "path/to/bundle").merge(:standalone => true, :dir => cwd)
+      bundle "config --local path path/to/bundle"
+      bundle! "install", :standalone => true, :dir => cwd
 
       ruby <<-RUBY
         $:.unshift File.expand_path("path/to/bundle")
@@ -209,8 +218,10 @@ RSpec.shared_examples "bundle install --standalone" do
     end
 
     it "allows `without` to limit the groups used in a standalone" do
-      bundle! :install, forgotten_command_line_options(:without => "test").merge(:dir => cwd)
-      bundle! :install, forgotten_command_line_options(:path => bundled_app("bundle")).merge(:standalone => true, :dir => cwd)
+      bundle "config --local without test"
+      bundle! :install, :dir => cwd
+      bundle "config --local path #{bundled_app("bundle")}"
+      bundle! :install, :standalone => true, :dir => cwd
 
       load_error_ruby <<-RUBY, "spec"
         $:.unshift File.expand_path("bundle")
@@ -235,7 +246,8 @@ RSpec.shared_examples "bundle install --standalone" do
           source "#{source_uri}"
           gem "rails"
         G
-        bundle! :install, forgotten_command_line_options(:path => bundled_app("bundle")).merge(:standalone => true, :artifice => "endpoint", :dir => cwd)
+        bundle "config --local path #{bundled_app("bundle")}"
+        bundle! :install, :standalone => true, :artifice => "endpoint", :dir => cwd
       end
 
       let(:expected_gems) do
@@ -255,7 +267,8 @@ RSpec.shared_examples "bundle install --standalone" do
         source "#{file_uri_for(gem_repo1)}"
         gem "rails"
       G
-      bundle! :install, forgotten_command_line_options(:path => bundled_app("bundle")).merge(:standalone => true, :binstubs => true, :dir => cwd)
+      bundle "config --local path #{bundled_app("bundle")}"
+      bundle! :install, :standalone => true, :binstubs => true, :dir => cwd
     end
 
     let(:expected_gems) do

--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -178,7 +178,7 @@ RSpec.shared_examples "bundle install --standalone" do
       expect(err).to eq("ZOMG LOAD ERROR")
     end
 
-    it "allows --without to limit the groups used in a standalone" do
+    it "allows `without` configuration to limit the groups used in a standalone" do
       bundle! :install, forgotten_command_line_options(:path => bundled_app("bundle"), :without => "test").merge(:standalone => true, :dir => cwd)
 
       load_error_ruby <<-RUBY, "spec"
@@ -194,7 +194,7 @@ RSpec.shared_examples "bundle install --standalone" do
       expect(err).to eq("ZOMG LOAD ERROR")
     end
 
-    it "allows --path to change the location of the standalone bundle" do
+    it "allows `path` configuration to change the location of the standalone bundle" do
       bundle! "install", forgotten_command_line_options(:path => "path/to/bundle").merge(:standalone => true, :dir => cwd)
 
       ruby <<-RUBY
@@ -208,7 +208,7 @@ RSpec.shared_examples "bundle install --standalone" do
       expect(out).to eq("2.3.2")
     end
 
-    it "allows remembered --without to limit the groups used in a standalone" do
+    it "allows `without` to limit the groups used in a standalone" do
       bundle! :install, forgotten_command_line_options(:without => "test").merge(:dir => cwd)
       bundle! :install, forgotten_command_line_options(:path => bundled_app("bundle")).merge(:standalone => true, :dir => cwd)
 

--- a/bundler/spec/install/git_spec.rb
+++ b/bundler/spec/install/git_spec.rb
@@ -57,7 +57,9 @@ RSpec.describe "bundle install" do
           foo!
       L
 
-      bundle! :install, forgotten_command_line_options(:path => "vendor/bundle", :without => "development")
+      bundle "config --local path vendor/bundle"
+      bundle "config --local without development"
+      bundle! :install
 
       expect(out).to include("Bundle complete!")
     end

--- a/bundler/spec/install/path_spec.rb
+++ b/bundler/spec/install/path_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe "bundle install" do
     end
 
     it "does not use available system gems with bundle --path vendor/bundle", :bundler => "< 3" do
-      bundle! :install, forgotten_command_line_options(:path => "vendor/bundle")
+      bundle "config --local path vendor/bundle"
+      bundle! :install
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
 
@@ -22,14 +23,16 @@ RSpec.describe "bundle install" do
       dir = bundled_app("bun++dle")
       dir.mkpath
 
-      bundle! :install, forgotten_command_line_options(:path => dir.join("vendor/bundle")).merge(:dir => dir)
+      bundle "config --local path #{dir.join("vendor/bundle")}"
+      bundle! :install, :dir => dir
       expect(out).to include("installed into `./vendor/bundle`")
 
       dir.rmtree
     end
 
     it "prints a warning to let the user know what has happened with bundle --path vendor/bundle" do
-      bundle! :install, forgotten_command_line_options(:path => "vendor/bundle")
+      bundle "config --local path vendor/bundle"
+      bundle! :install
       expect(out).to include("gems are installed into `./vendor/bundle`")
     end
 
@@ -98,7 +101,8 @@ RSpec.describe "bundle install" do
       context "when set via #{type}" do
         it "installs gems to a path if one is specified" do
           set_bundle_path(type, bundled_app("vendor2").to_s)
-          bundle! :install, forgotten_command_line_options(:path => "vendor/bundle")
+          bundle "config --local path vendor/bundle"
+          bundle! :install
 
           expect(vendored_gems("gems/rack-1.0.0")).to be_directory
           expect(bundled_app("vendor2")).not_to be_directory
@@ -147,7 +151,8 @@ RSpec.describe "bundle install" do
     end
 
     it "sets BUNDLE_PATH as the first argument to bundle install" do
-      bundle! :install, forgotten_command_line_options(:path => "./vendor/bundle")
+      bundle "config --local path ./vendor/bundle"
+      bundle! :install
 
       expect(vendored_gems("gems/rack-1.0.0")).to be_directory
       expect(the_bundle).to include_gems "rack 1.0.0"
@@ -156,7 +161,8 @@ RSpec.describe "bundle install" do
     it "disables system gems when passing a path to install" do
       # This is so that vendored gems can be distributed to others
       build_gem "rack", "1.1.0", :to_system => true
-      bundle! :install, forgotten_command_line_options(:path => "./vendor/bundle")
+      bundle "config --local path ./vendor/bundle"
+      bundle! :install
 
       expect(vendored_gems("gems/rack-1.0.0")).to be_directory
       expect(the_bundle).to include_gems "rack 1.0.0"
@@ -172,7 +178,8 @@ RSpec.describe "bundle install" do
         gem "very_simple_binary"
       G
 
-      bundle! :install, forgotten_command_line_options(:path => "./vendor/bundle")
+      bundle "config --local path ./vendor/bundle"
+      bundle! :install
 
       expect(vendored_gems("gems/very_simple_binary-1.0")).to be_directory
       expect(vendored_gems("extensions")).to be_directory
@@ -183,7 +190,8 @@ RSpec.describe "bundle install" do
       run "require 'very_simple_binary_c'"
       expect(err).to include("Bundler::GemNotFound")
 
-      bundle :install, forgotten_command_line_options(:path => "./vendor/bundle")
+      bundle "config --local path ./vendor/bundle"
+      bundle :install
 
       expect(vendored_gems("gems/very_simple_binary-1.0")).to be_directory
       expect(vendored_gems("extensions")).to be_directory
@@ -202,7 +210,8 @@ RSpec.describe "bundle install" do
         gem "rack"
       G
 
-      bundle :install, forgotten_command_line_options(:path => "bundle")
+      bundle "config --local path bundle"
+      bundle :install
       expect(err).to include("file already exists")
     end
   end

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -1293,7 +1293,8 @@ RSpec.describe "the lockfile format" do
       gem "omg", :git => "#{lib_path("omg")}", :branch => 'master'
     G
 
-    bundle! :install, forgotten_command_line_options(:path => "vendor")
+    bundle "config --local path vendor"
+    bundle! :install
     expect(the_bundle).to include_gems "omg 1.0"
 
     # Create a Gemfile.lock that has duplicate GIT sections

--- a/bundler/spec/plugins/install_spec.rb
+++ b/bundler/spec/plugins/install_spec.rb
@@ -215,7 +215,8 @@ RSpec.describe "bundler plugin install" do
           gem 'rack', "1.0.0"
         G
 
-        install_gemfile! <<-G, forgotten_command_line_options(:deployment => true)
+        bundle "config --local deployment true"
+        install_gemfile! <<-G
           source '#{file_uri_for(gem_repo2)}'
           plugin 'foo'
           gem 'rack', "1.0.0"

--- a/bundler/spec/plugins/source/example_spec.rb
+++ b/bundler/spec/plugins/source/example_spec.rb
@@ -156,7 +156,8 @@ RSpec.describe "real source plugins" do
       end
 
       it "copies repository to vendor cache and uses it even when installed with `path` configured" do
-        bundle! :install, forgotten_command_line_options(:path => "vendor/bundle")
+        bundle "config --local path vendor/bundle"
+        bundle! :install
         bundle "config set cache_all true"
         bundle! :cache
 
@@ -167,7 +168,8 @@ RSpec.describe "real source plugins" do
       end
 
       it "bundler package copies repository to vendor cache" do
-        bundle! :install, forgotten_command_line_options(:path => "vendor/bundle")
+        bundle "config --local path vendor/bundle"
+        bundle! :install
         bundle "config set cache_all true"
         bundle! :cache
 

--- a/bundler/spec/plugins/source/example_spec.rb
+++ b/bundler/spec/plugins/source/example_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe "real source plugins" do
         expect(the_bundle).to include_gems("a-path-gem 1.0")
       end
 
-      it "copies repository to vendor cache and uses it even when installed with bundle --path" do
+      it "copies repository to vendor cache and uses it even when installed with `path` configured" do
         bundle! :install, forgotten_command_line_options(:path => "vendor/bundle")
         bundle "config set cache_all true"
         bundle! :cache

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -481,13 +481,15 @@ RSpec.describe "Bundler.setup" do
     end
 
     it "works even when the cache directory has been deleted" do
-      bundle! :install, forgotten_command_line_options(:path => "vendor/bundle")
+      bundle "config --local path vendor/bundle"
+      bundle! :install
       FileUtils.rm_rf vendored_gems("cache")
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
 
     it "does not randomly change the path when specifying --path and the bundle directory becomes read only" do
-      bundle! :install, forgotten_command_line_options(:path => "vendor/bundle")
+      bundle "config --local path vendor/bundle"
+      bundle! :install
 
       with_read_only("#{bundled_app}/**/*") do
         expect(the_bundle).to include_gems "rack 1.0.0"
@@ -590,7 +592,8 @@ RSpec.describe "Bundler.setup" do
 
   describe "when excluding groups" do
     it "doesn't change the resolve if --without is used" do
-      install_gemfile <<-G, forgotten_command_line_options(:without => :rails)
+      bundle "config --local without rails"
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "activesupport"
 
@@ -605,7 +608,8 @@ RSpec.describe "Bundler.setup" do
     end
 
     it "remembers --without and does not bail on bare Bundler.setup" do
-      install_gemfile <<-G, forgotten_command_line_options(:without => :rails)
+      bundle "config --local without rails"
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "activesupport"
 
@@ -620,7 +624,8 @@ RSpec.describe "Bundler.setup" do
     end
 
     it "remembers --without and does not include groups passed to Bundler.setup" do
-      install_gemfile <<-G, forgotten_command_line_options(:without => :rails)
+      bundle "config --local without rails"
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "activesupport"
 

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -130,21 +130,6 @@ module Spec
     end
     bang :bundle
 
-    def forgotten_command_line_options(options)
-      options = options.map do |k, v|
-        v = '""' if v && v.to_s.empty?
-        [k, v]
-      end
-      options.each do |k, v|
-        if v.nil?
-          bundle! "config unset #{k}"
-        else
-          bundle! "config set --local #{k} #{v}"
-        end
-      end
-      {}
-    end
-
     def bundler(cmd, options = {})
       options[:bundle_bin] = system_gem_path.join("bin/bundler")
       bundle(cmd, options)

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -131,12 +131,10 @@ module Spec
     bang :bundle
 
     def forgotten_command_line_options(options)
-      remembered = Bundler::VERSION.split(".", 2).first == "2"
       options = options.map do |k, v|
         v = '""' if v && v.to_s.empty?
         [k, v]
       end
-      return Hash[options] if remembered
       options.each do |k, v|
         if v.nil?
           bundle! "config unset #{k}"


### PR DESCRIPTION
# Description:

This PR removes this helper method from our specs, because all usages of it led to warnings on bundler 2. Instead, we should use the new recommended way of using `bundle config` whenever possible.

Only exceptions are when explicitly testing the functionality of the deprecated flags, and those specs should be limited to bundler 2.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
