### PR TITLE
Fix hidden bundler template installation from rubygems updater

### DIFF
--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -555,7 +555,7 @@ By default, this RubyGems will install gem as:
   # for cleanup old bundler files
   def template_files_in(dir)
     Dir.chdir dir do
-      Dir[File.join('templates', '**', '{*,.*}')].
+      Dir.glob(File.join('templates', '**', '*'), File::FNM_DOTMATCH).
         select{|f| !File.directory?(f)}
     end
   end

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -547,7 +547,7 @@ By default, this RubyGems will install gem as:
 
   def bundler_template_files
     Dir.chdir "bundler/lib" do
-      (Dir[File.join('bundler', 'templates', '**', '{*,.*}')]).
+      Dir[File.join('bundler', 'templates', '**', '{*,.*}')].
         select{|f| !File.directory?(f)}
     end
   end
@@ -555,7 +555,7 @@ By default, this RubyGems will install gem as:
   # for cleanup old bundler files
   def template_files_in(dir)
     Dir.chdir dir do
-      (Dir[File.join('templates', '**', '{*,.*}')]).
+      Dir[File.join('templates', '**', '{*,.*}')].
         select{|f| !File.directory?(f)}
     end
   end

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -547,7 +547,7 @@ By default, this RubyGems will install gem as:
 
   def bundler_template_files
     Dir.chdir "bundler/lib" do
-      Dir[File.join('bundler', 'templates', '**', '{*,.*}')].
+      Dir.glob(File.join('bundler', 'templates', '**', '*'), File::FNM_DOTMATCH).
         select{|f| !File.directory?(f)}
     end
   end

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -276,6 +276,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     lib_rubygems          = File.join lib, 'rubygems'
     lib_bundler           = File.join lib, 'bundler'
     lib_rubygems_defaults = File.join lib_rubygems, 'defaults'
+    lib_bundler_templates = File.join lib_bundler, 'templates'
 
     securerandom_rb = File.join lib, 'securerandom.rb'
 
@@ -287,8 +288,9 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     old_builder_rb     = File.join lib_rubygems, 'builder.rb'
     old_format_rb      = File.join lib_rubygems, 'format.rb'
     old_bundler_c_rb   = File.join lib_bundler,  'c.rb'
+    old_bundler_ci     = File.join lib_bundler_templates, '.lecacy_ci', 'config.yml'
 
-    files_that_go   = [old_gauntlet_rubygems_rb, old_builder_rb, old_format_rb, old_bundler_c_rb]
+    files_that_go   = [old_gauntlet_rubygems_rb, old_builder_rb, old_format_rb, old_bundler_c_rb, old_bundler_ci]
     files_that_stay = [securerandom_rb, engine_defaults_rb, os_defaults_rb]
 
     create_dummy_files(files_that_go + files_that_stay)

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -28,6 +28,8 @@ class TestGemCommandsSetupCommand < Gem::TestCase
       bundler/exe/bundle
       bundler/lib/bundler.rb
       bundler/lib/bundler/b.rb
+      bundler/lib/bundler/templates/.circleci/config.yml
+      bundler/lib/bundler/templates/.travis.yml
       bundler/man/bundle-b.1
       bundler/man/bundle-b.1.txt
       bundler/man/gemfile.5
@@ -184,6 +186,9 @@ class TestGemCommandsSetupCommand < Gem::TestCase
 
       assert_path_exists File.join(dir, 'bundler.rb')
       assert_path_exists File.join(dir, 'bundler/b.rb')
+
+      assert_path_exists File.join(dir, 'bundler/templates/.circleci/config.yml')
+      assert_path_exists File.join(dir, 'bundler/templates/.travis.yml')
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When `gem update --system` installs bundler as a default gem, it was not installing any templates inside hidden folders.

I found this issue while reviewing #3667.

## What is your fix for the problem, implemented in this PR?

The fix is to use `Dir.glob` with the `File::FNM_DOTMATCH` flag so that these files are not ignored.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
