### PR TITLE
Run CI at 3.1 branch head as well.

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -5,8 +5,7 @@ on:
 
   push:
     branches:
-      - staging
-      - trying
+      - 3.1
 
 jobs:
   install:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -5,8 +5,7 @@ on:
 
   push:
     branches:
-      - staging
-      - trying
+      - 3.1
 
 jobs:
   macos:

--- a/.github/workflows/ruby-master.yml
+++ b/.github/workflows/ruby-master.yml
@@ -5,8 +5,7 @@ on:
 
   push:
     branches:
-      - staging
-      - trying
+      - 3.1
 
 jobs:
   ruby_master:

--- a/.github/workflows/ubuntu-bundler-master.yml
+++ b/.github/workflows/ubuntu-bundler-master.yml
@@ -5,8 +5,7 @@ on:
 
   push:
     branches:
-      - staging
-      - trying
+      - 3.1
 
 jobs:
   ubuntu_bundler_master:

--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -5,8 +5,7 @@ on:
 
   push:
     branches:
-      - staging
-      - trying
+      - 3.1
 
 jobs:
   ubuntu_lint:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -5,8 +5,7 @@ on:
 
   push:
     branches:
-      - staging
-      - trying
+      - 3.1
 
 jobs:
   ubuntu:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,8 +5,7 @@ on:
 
   push:
     branches:
-      - staging
-      - trying
+      - 3.1
 
 jobs:
   windows:

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -135,7 +135,7 @@ class TestGemCommandsBuildCommand < Gem::TestCase
 
     error = @ui.error.split("\n")
     assert_equal "WARNING:  rubyforge_project= is deprecated and ignored. Please remove this from your gemspec to ensure that your gem continues to build in the future.", error.shift
-    assert_equal "WARNING:  See http://guides.rubygems.org/specification-reference/ for help", error.shift
+    assert_equal "WARNING:  See https://guides.rubygems.org/specification-reference/ for help", error.shift
     assert_equal [], error
   end
 


### PR DESCRIPTION
Hello, I was about to check 3.1 head branch CI status after recent merges and I have spotted it doesn't start build on push. This change should change it.