### PR TITLE
Use Authorization header on util/update_changelog.rb

### DIFF
--- a/util/update_changelog.rb
+++ b/util/update_changelog.rb
@@ -3,19 +3,15 @@
 require 'json'
 require 'net/http'
 
-def access_token_query_string
-  @access_token_query_string ||= begin
-    token = ENV['GITHUB_API_TOKEN']
-    token ? "?access_token=#{token.strip}" : ''
-  end
-end
-
 def github_api(path)
   base = 'https://api.github.com'
   url = path.start_with?(base) ? path : base + path
-  url += access_token_query_string
   uri = URI.parse(url)
-  return unless response = Net::HTTP.get_response(uri)
+  http = Net::HTTP.new(uri.host, uri.port)
+  http.use_ssl = true
+  req = Net::HTTP::Get.new(uri.request_uri)
+  req["authorization"] = "token #{ENV['GITHUB_API_TOKEN']}" if ENV['GITHUB_API_TOKEN']
+  response = http.request(req)
   JSON.load(response.body)
 end
 


### PR DESCRIPTION
# Description:

The query parameters usage will be deprecated in Sep, 2020.

https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/

## What is your fix for the problem, implemented in this PR?

Use HTTP authorization header wiwth `Net::HTTP`
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
