### PR TITLE
Use ARGV for version number of util/update_changelog.rb

### DIFF
--- a/util/update_changelog.rb
+++ b/util/update_changelog.rb
@@ -42,12 +42,13 @@ def sentence(text)
   text.end_with?('.') ? text : text << '.'
 end
 
+from = ARGV.shift || Gem::VERSION
 branch = ARGV.shift || "HEAD"
 
 history = File.read(File.expand_path('../../History.txt', __FILE__))
 
 File.open(File.expand_path('../../ChangeLog', __FILE__), 'w') do |changelog|
-  commits = `git log --oneline v#{Gem::VERSION}..#{branch}`.split("\n")
+  commits = `git log --oneline v#{from}..#{branch}`.split("\n")
   prs = commits.reverse_each.map { |c| c =~ /(Auto merge of|Merge pull request|Merge) #(\d+)/ && $2 }.compact.uniq.sort!
   prs.each do |pr|
     next if history =~ /Pull\srequest\s##{pr}/m


### PR DESCRIPTION
# Description:

## What is your fix for the problem, implemented in this PR?

I always update `Gem::VERSION` constant manually when I release the new version. After merging this pull-request, the release manager can use the following command for generating changelog from GitHub pull-request.

```
$ ruby util/update_changelog.rb 3.1.3 # in 3.1 branch
```

______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
