### PR TITLE
Enable `Style/MethodCallWithoutArgsParentheses` in rubygems

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -97,6 +97,9 @@ Performance/StartWith:
 Performance/StringReplacement:
   Enabled: true
 
+Style/MethodCallWithoutArgsParentheses:
+  Enabled: true
+
 Style/MethodDefParentheses:
   Enabled: true
 

--- a/test/rubygems/test_gem_commands_signin_command.rb
+++ b/test/rubygems/test_gem_commands_signin_command.rb
@@ -23,7 +23,7 @@ class TestGemCommandsSigninCommand < Gem::TestCase
   end
 
   def test_execute_when_not_already_signed_in
-    sign_in_ui = util_capture() { @cmd.execute }
+    sign_in_ui = util_capture { @cmd.execute }
     assert_match %r{Signed in.}, sign_in_ui.output
   end
 


### PR DESCRIPTION
# Description:

As per https://github.com/rubygems/rubygems/pull/3605#discussion_r434620422.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
