### PR TITLE
Undeprecate the `--no-cache` flag

### DIFF
--- a/bundler/UPGRADING.md
+++ b/bundler/UPGRADING.md
@@ -33,7 +33,7 @@ in the upcoming 3 version.
 
 * Flags passed to `bundle install` that relied on being remembered across invocations have been deprecated.
 
-  In particular, the `--clean`, `--deployment`, `--frozen`, `--no-cache`,
+  In particular, the `--clean`, `--deployment`, `--frozen`,
   `--no-prune`, `--path`, `--shebang`, `--system`, `--without`, and `--with`
   options to `bundle install`.
 

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -250,7 +250,7 @@ module Bundler
     def install
       SharedHelpers.major_deprecation(2, "The `--force` option has been renamed to `--redownload`") if ARGV.include?("--force")
 
-      %w[clean deployment frozen no-cache no-prune path shebang system without with].each do |option|
+      %w[clean deployment frozen no-prune path shebang system without with].each do |option|
         remembered_flag_deprecation(option)
       end
 

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -317,7 +317,6 @@ RSpec.describe "major deprecations" do
       "clean" => ["clean", true],
       "deployment" => ["deployment", true],
       "frozen" => ["frozen", true],
-      "no-cache" => ["no_cache", true],
       "no-deployment" => ["deployment", false],
       "no-prune" => ["no_prune", true],
       "path" => ["path", "vendor/bundle"],


### PR DESCRIPTION
# Description:

## What was the end-user or developer problem that led to this PR?

While working on #3685, I discovered that `--no-cache` is not a remembered option.

That means it shouldn't have been deprecated. At least not for that reason.

## What is your fix for the problem, implemented in this PR?

My fix is to undeprecate the flag.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
