### PR TITLE
Send a slack notification when daily ruby-head build fails

### DIFF
--- a/.github/workflows/daily-bundler.yml
+++ b/.github/workflows/daily-bundler.yml
@@ -35,19 +35,9 @@ jobs:
           bin/rake spec:all
         working-directory: ./bundler
 
-      - uses: actions/download-artifact@v2
-        with:
-          name: bundler_status
-          path: status.txt
+      - name: Get previous status
         if: always()
-
-      - name: Save status
-        if: always()
-        run: echo "${{ job.status }}" > new_status.txt
-
-      - name: Compare with previous run
-        if: always()
-        run: echo "::set-env name=STATUS_CHANGED::$(diff status.txt new_status.txt; echo $?)"
+        run: echo "::set-env name=OLD_STATUS::$(curl -sS 'https://api.github.com/repos/rubygems/rubygems/actions/runs?event=schedule&branch=master' | jq '.workflow_runs | map(select(.workflow_id == 982279)) | .[0].conclusion')"
 
       - uses: 8398a7/action-slack@v3
         with:
@@ -55,16 +45,6 @@ jobs:
           fields: repo,message,commit,author,action,eventName,ref,workflow
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
-        if: failure() && env.STATUS_CHANGED != '0'
-
-      - name: Rotate status
-        run: mv new_status.txt status.txt
-        if: always()
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: bundler_status
-          path: status.txt
-        if: always()
+        if: failure() && env.OLD_STATUS == '"success"'
 
     timeout-minutes: 60

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -27,19 +27,9 @@ jobs:
           rake setup
           rake test
 
-      - uses: actions/download-artifact@v2
-        with:
-          name: rubygems_status
-          path: status.txt
+      - name: Get previous status
         if: always()
-
-      - name: Save status
-        if: always()
-        run: echo "${{ job.status }}" > new_status.txt
-
-      - name: Compare with previous run
-        if: always()
-        run: echo "::set-env name=STATUS_CHANGED::$(diff status.txt new_status.txt; echo $?)"
+        run: echo "::set-env name=OLD_STATUS::$(curl -sS 'https://api.github.com/repos/rubygems/rubygems/actions/runs?event=schedule&branch=master' | jq '.workflow_runs | map(select(.workflow_id == 716807)) | .[0].conclusion')"
 
       - uses: 8398a7/action-slack@v3
         with:
@@ -47,16 +37,6 @@ jobs:
           fields: repo,message,commit,action,workflow
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
-        if: env.STATUS_CHANGED != '0'
-
-      - name: Rotate status
-        run: mv new_status.txt status.txt
-        if: always()
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: rubygems_status
-          path: status.txt
-        if: always()
+        if: failure() && env.OLD_STATUS == '"success"'
 
     timeout-minutes: 60


### PR DESCRIPTION
# Description:

This is follow up to #3672. I believe this one does the trick. At least I tried it in https://github.com/rubygems/rubygems/runs/740017559?check_suite_focus=true and it did the right thing: build failed, but previous build also failed, so notification was skipped since it's supposed to have already been notified.

The previous approach of using artifacts didn't work because artifacts allow to pass information between the jobs of a workflow, but not being different workflow runs. Using the github workflows API seems to work just fine and it's also simpler.

This PR closes #3557.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
