### PR TITLE
Fix regression caused by the `only_update_to_newer_versions` feature flag

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -984,8 +984,9 @@ module Bundler
       @locked_gems.specs.reduce({}) do |requirements, locked_spec|
         name = locked_spec.name
         dependency = dependencies_by_name[name]
+        next requirements unless dependency
         next requirements if @locked_gems.dependencies[name] != dependency
-        next requirements if dependency && dependency.source.is_a?(Source::Path)
+        next requirements if dependency.source.is_a?(Source::Path)
         dep = Gem::Dependency.new(name, ">= #{locked_spec.version}")
         requirements[name] = DepProxy.new(dep, locked_spec.platform)
         requirements

--- a/bundler/spec/commands/check_spec.rb
+++ b/bundler/spec/commands/check_spec.rb
@@ -78,13 +78,13 @@ RSpec.describe "bundle check" do
     G
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
-      gem 'rails_fail'
+      gem 'rails_pinned_to_old_activesupport'
     G
 
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
       gem "rails"
-      gem "rails_fail"
+      gem "rails_pinned_to_old_activesupport"
     G
 
     bundle :check

--- a/bundler/spec/install/bundler_spec.rb
+++ b/bundler/spec/install/bundler_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe "bundle install" do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "activemerchant"
-        gem "rails_fail"
+        gem "rails_pinned_to_old_activesupport"
       G
 
       nice_error = <<-E.strip.gsub(/^ {8}/, "")
@@ -105,7 +105,7 @@ RSpec.describe "bundle install" do
             activemerchant was resolved to 1.0, which depends on
               activesupport (>= 2.0.0)
 
-            rails_fail was resolved to 1.0, which depends on
+            rails_pinned_to_old_activesupport was resolved to 1.0, which depends on
               activesupport (= 1.2.3)
       E
       expect(err).to include(nice_error)
@@ -116,7 +116,7 @@ RSpec.describe "bundle install" do
 
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
-        gem "rails_fail"
+        gem "rails_pinned_to_old_activesupport"
         gem "activesupport", "2.3.5"
       G
 
@@ -125,7 +125,7 @@ RSpec.describe "bundle install" do
           In Gemfile:
             activesupport (= 2.3.5)
 
-            rails_fail was resolved to 1.0, which depends on
+            rails_pinned_to_old_activesupport was resolved to 1.0, which depends on
               activesupport (= 1.2.3)
       E
       expect(err).to include(nice_error)
@@ -139,7 +139,7 @@ RSpec.describe "bundle install" do
 
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
-        gem "rails_fail"
+        gem "rails_pinned_to_old_activesupport"
       G
 
       expect(out).to include("Installing activesupport 1.2.3 (was 2.3.2)")

--- a/bundler/spec/install/bundler_spec.rb
+++ b/bundler/spec/install/bundler_spec.rb
@@ -131,6 +131,21 @@ RSpec.describe "bundle install" do
       expect(err).to include(nice_error)
     end
 
+    it "does not cause a conflict if new dependencies in the Gemfile require older dependencies than the lockfile" do
+      install_gemfile! <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem 'rails', "2.3.2"
+      G
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "rails_fail"
+      G
+
+      expect(out).to include("Installing activesupport 1.2.3 (was 2.3.2)")
+      expect(err).to be_empty
+    end
+
     it "can install dependencies with newer bundler version with system gems" do
       bundle! "config set path.system true"
 

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -76,7 +76,7 @@ module Spec
           s.add_dependency "activesupport", ">= 2.0.0"
         end
 
-        build_gem "rails_fail" do |s|
+        build_gem "rails_pinned_to_old_activesupport" do |s|
           s.add_dependency "activesupport", "= 1.2.3"
         end
 


### PR DESCRIPTION
# Description:

This is another bug found by the work in #3685, which seems to confirm that raising on errors every time we shell out inside bundler specs by default is indeed a good move :tada:.

The `only_update_to_newer_versions` feature flag will enable some new behaviour in bundler 3 (or maybe earlier if we decide to consider it a bug fix) that prevents `bundle update` from unexpectedly downgrading direct dependencies.

This seems reasonable, but the current implementation is adding additional requirements for all locked dependencies, not only from the ones in the `Gemfile`. That causes some situations where the `Gemfile` is edited and will resolve to older versions to start failing.

This commit fixes the problem by making sure extra requirements are added exclusively for direct dependencies in the `Gemfile`, not for all direct dependencies in the lock file.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
