### PR TITLE
Fix ruby-head failing rubygems tests

### DIFF
--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -358,6 +358,7 @@ class Gem::TestCase < Minitest::Test
 
     ENV['HOME'] = @userhome
     Gem.instance_variable_set :@user_home, nil
+    Gem.instance_variable_set :@data_home, nil
     Gem.instance_variable_set :@gemdeps, nil
     Gem.instance_variable_set :@env_requirements_by_name, nil
     Gem.send :remove_instance_variable, :@ruby_version if


### PR DESCRIPTION
# Description:

This PR fixes rubygems build against `ruby-head`, which had been broken for a while (since [the `XDG` PR](https://github.com/ruby/ruby/pull/2174) landed).

In `ruby-head` (where system rubygems already has the `XDG` standard implementation), some tests currently depend on the presence of a `~/.gem` folder in the home of the user that runs the tests. If that file is present, tests pass, otherwise they don't.

For example, the following passes if you have a `~/.gem` folder but fails otherwise with:

```
$ rake TESTOPTS="--name=/TestGemCommandsGenerateIndexCommand#test_execute$\|TestGemCommandsUpdateCommand#test_execute_user_install/ -v"
Run options: "--name=/TestGemCommandsGenerateIndexCommand#test_execute$|TestGemCommandsUpdateCommand#test_execute_user_install/" -v --seed 17318

# Running:

TestGemCommandsGenerateIndexCommand#test_execute = 0.02 s = .
TestGemCommandsUpdateCommand#test_execute_user_install = /rubygems/test/rubygems/test_gem_commands_update_command.rb:412: warning: instance variable @user_install not initialized
0.04 s = F

Finished in 0.095337s, 20.9783 runs/s, 20.9783 assertions/s.

  1) Failure:
TestGemCommandsUpdateCommand#test_execute_user_install [/rubygems/test/rubygems/test_gem_commands_update_command.rb:414]:
user_install must be set on the installer

2 runs, 2 assertions, 1 failures, 0 errors, 0 skips
rake aborted!
Command failed with status (1)

Tasks: TOP => default => test
(See full trace by running task with --trace)

```

This is because the very initial `require` of the default `did_you_mean` gem that ruby does on startup runs _before_  the global `setup` hook of our tests run. During this require `Gem.data_home` and its value is memoized to a path in the real users home (not the fake user's home that our tests setup, since that code hasn't run yet). Then that memoized value is used when looking for the default folders to look for gems, and since there's no `~/.gem` folder, its value is actually used as part of the `Gem.user_dir` folder in `Gem::Specification.dirs` (this is how we've approached backwards compatibility for the `XDG` feature). That means dummy test gems with the `--user-install` flag are installed to global, real locations and everything is messed up.

This commit fixes the issue by resetting the `Gem.data_home` value in case it has already been memoized.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
