### PR TITLE
Fix ruby-head failing bundler tests

### DIFF
--- a/.github/workflows/daily-bundler.yml
+++ b/.github/workflows/daily-bundler.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   daily_bundler:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         ruby: [ ruby-head ]

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   daily:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         ruby: [ ruby-head ]

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   install:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         ruby: [ 2.3.8, 2.4.10, 2.5.8, 2.6.6, 2.7.1, jruby-9.2.11.1 ]

--- a/.github/workflows/jruby-bundler.yml
+++ b/.github/workflows/jruby-bundler.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   jruby_bundler:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     env:
       RGV: ..

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   macos:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     strategy:
       matrix:
         ruby: [ 2.4.10, 2.5.8, 2.6.6, 2.7.1 ]

--- a/.github/workflows/ruby-core-test-suite.yml
+++ b/.github/workflows/ruby-core-test-suite.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   ruby_core:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         target: [rubygems, bundler]

--- a/.github/workflows/ubuntu-bundler.yml
+++ b/.github/workflows/ubuntu-bundler.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   ubuntu_bundler:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         ruby: [ 2.3.8, 2.4.10, 2.5.8, 2.6.6, 2.7.1 ]

--- a/.github/workflows/ubuntu-bundler3.yml
+++ b/.github/workflows/ubuntu-bundler3.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   ubuntu_bundler3:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         ruby: [ 2.4.10, 2.5.8, 2.6.6, 2.7.1 ]

--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   ubuntu_lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   ubuntu:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         ruby: [ 2.3.8, 2.4.10, 2.5.8, 2.6.6, 2.7.1, jruby-9.2.11.1, truffleruby-head ]

--- a/.github/workflows/windows-bundler.yml
+++ b/.github/workflows/windows-bundler.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   windows_bundler:
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     env:
       RGV: ..

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       matrix:
         ruby: [ 2.4.10, 2.5.8, 2.6.6, 2.7.1 ]


### PR DESCRIPTION
# Description:

This PR fixes bundler CI run against ruby-head, which had been failing for a while, [like this](https://github.com/rubygems/rubygems/actions/runs/127258555). The problem was that the `sudo` version installed on ubuntu 16.04 doesn't not accept `--preserve-env` with an argument, and our `sudo` specs use that.

I fixed it by upgrading the workflow to ubuntu 18.04.

In addition to that, I pinned all base OS versions of our workflows to avoid further inconsistencies and to prevent underlying changes in the github actions "latest" alias breaking us.

Proof of fixed build is: https://github.com/rubygems/rubygems/runs/747745016?check_suite_focus=true.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
