### PR TITLE
Remove all "bang helpers" from our specs

### DIFF
--- a/bundler/spec/bundler/cli_spec.rb
+++ b/bundler/spec/bundler/cli_spec.rb
@@ -128,12 +128,12 @@ RSpec.describe "bundle executable" do
     end
 
     it "doesn't print defaults" do
-      install_gemfile! "", :verbose => true
+      install_gemfile "", :verbose => true
       expect(out).to start_with("Running `bundle install --retry 0 --verbose` with bundler #{Bundler::VERSION}")
     end
 
     it "doesn't print defaults" do
-      install_gemfile! "", :verbose => true
+      install_gemfile "", :verbose => true
       expect(out).to start_with("Running `bundle install --retry 0 --verbose` with bundler #{Bundler::VERSION}")
     end
   end

--- a/bundler/spec/bundler/cli_spec.rb
+++ b/bundler/spec/bundler/cli_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "bundle executable" do
 
   context "with no arguments" do
     it "prints a concise help message", :bundler => "3" do
-      bundle! ""
+      bundle ""
       expect(err).to be_empty
       expect(out).to include("Bundler version #{Bundler::VERSION}").
         and include("\n\nBundler commands:\n\n").
@@ -123,7 +123,7 @@ RSpec.describe "bundle executable" do
   context "with --verbose" do
     it "prints the running command" do
       gemfile ""
-      bundle! "info bundler", :verbose => true
+      bundle "info bundler", :verbose => true
       expect(out).to start_with("Running `bundle info bundler --verbose` with bundler #{Bundler::VERSION}")
     end
 
@@ -149,7 +149,7 @@ RSpec.describe "bundle executable" do
     let(:bundler_version) { "2.0" }
     let(:latest_version) { nil }
     before do
-      bundle! "config set --global disable_version_check false"
+      bundle "config set --global disable_version_check false"
 
       pristine_system_gems "bundler-#{bundler_version}"
       if latest_version
@@ -184,13 +184,13 @@ To install the latest version, run `gem install bundler`
       end
 
       context "and disable_version_check is set" do
-        before { bundle! "config set disable_version_check true", :env => { "BUNDLER_VERSION" => bundler_version } }
+        before { bundle "config set disable_version_check true", :env => { "BUNDLER_VERSION" => bundler_version } }
         include_examples "no warning"
       end
 
       context "running a parseable command" do
         it "prints no warning" do
-          bundle! "config get --parseable foo", :env => { "BUNDLER_VERSION" => bundler_version }
+          bundle "config get --parseable foo", :env => { "BUNDLER_VERSION" => bundler_version }
           expect(last_command.stdboth).to eq ""
 
           bundle "platform --ruby", :env => { "BUNDLER_VERSION" => bundler_version }, :raise_on_error => false

--- a/bundler/spec/bundler/gem_helper_spec.rb
+++ b/bundler/spec/bundler/gem_helper_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe Bundler::GemHelper do
           mock_confirm_message "#{app_name} (#{app_version}) installed."
           subject.install_gem(nil, :local)
           expect(app_gem_path).to exist
-          gem_command! :list
+          gem_command :list
           expect(out).to include("#{app_name} (#{app_version})")
         end
       end

--- a/bundler/spec/cache/gems_spec.rb
+++ b/bundler/spec/cache/gems_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "bundle cache" do
       G
 
       system_gems "rack-1.0.0", :path => path
-      bundle! :cache
+      bundle :cache
     end
 
     it "copies the .gem file to vendor/cache" do
@@ -56,7 +56,7 @@ RSpec.describe "bundle cache" do
         s.write "lib/rack.rb", "RACK = 'FAIL'"
       end
 
-      bundle! :install, :local => true
+      bundle :install, :local => true
       expect(the_bundle).to include_gems("rack 1.0.0")
     end
 
@@ -74,13 +74,13 @@ RSpec.describe "bundle cache" do
   end
 
   context "using system gems" do
-    before { bundle! "config set path.system true" }
+    before { bundle "config set path.system true" }
     let(:path) { system_gem_path }
     it_behaves_like "when there are only gemsources"
   end
 
   context "installing into a local path" do
-    before { bundle! "config set path ./.bundle" }
+    before { bundle "config set path ./.bundle" }
     let(:path) { local_gem_path }
     it_behaves_like "when there are only gemsources"
   end
@@ -99,7 +99,7 @@ RSpec.describe "bundle cache" do
     end
 
     it "uses builtin gems when installing to system gems" do
-      bundle! "config set path.system true"
+      bundle "config set path.system true"
       install_gemfile %(gem 'builtin_gem', '1.0.2')
       expect(the_bundle).to include_gems("builtin_gem 1.0.2")
     end
@@ -131,7 +131,7 @@ RSpec.describe "bundle cache" do
     end
 
     it "errors if the builtin gem isn't available to cache" do
-      bundle! "config set path.system true"
+      bundle "config set path.system true"
 
       install_gemfile <<-G
         gem 'builtin_gem', '1.0.2'

--- a/bundler/spec/cache/git_spec.rb
+++ b/bundler/spec/cache/git_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "bundle cache with git" do
     expect(bundled_app("vendor/cache/foo-1.0-#{old_ref}")).not_to exist
 
     FileUtils.rm_rf lib_path("foo-1.0")
-    run! "require 'foo'"
+    run "require 'foo'"
     expect(out).to eq("CACHE")
   end
 

--- a/bundler/spec/cache/git_spec.rb
+++ b/bundler/spec/cache/git_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe "bundle cache with git" do
     G
 
     bundle "config set cache_all true"
-    bundle! :cache
-    bundle! :cache
+    bundle :cache
+    bundle :cache
 
     expect(out).to include "Updating files in vendor/cache"
     FileUtils.rm_rf lib_path("foo-1.0")
@@ -85,9 +85,9 @@ RSpec.describe "bundle cache with git" do
     ref = git.ref_for("master", 11)
     expect(ref).not_to eq(old_ref)
 
-    bundle! "update", :all => true
+    bundle "update", :all => true
     bundle "config set cache_all true"
-    bundle! :cache
+    bundle :cache
 
     expect(bundled_app("vendor/cache/foo-1.0-#{ref}")).to exist
     expect(bundled_app("vendor/cache/foo-1.0-#{old_ref}")).not_to exist
@@ -106,7 +106,7 @@ RSpec.describe "bundle cache with git" do
     G
 
     bundle "config set cache_all true"
-    bundle! :cache
+    bundle :cache
 
     update_git "foo" do |s|
       s.write "lib/foo.rb", "puts :CACHE"
@@ -225,13 +225,13 @@ RSpec.describe "bundle cache with git" do
     gemfile <<-G
       gem "foo", :git => '#{lib_path("foo-1.0")}'
     G
-    bundle! "config set cache_all true"
-    bundle! :cache, "all-platforms" => true, :install => false, :path => "./vendor/cache"
+    bundle "config set cache_all true"
+    bundle :cache, "all-platforms" => true, :install => false, :path => "./vendor/cache"
 
     simulate_new_machine
     with_path_as "" do
-      bundle! "config set deployment true"
-      bundle! :install, :local => true
+      bundle "config set deployment true"
+      bundle :install, :local => true
       expect(the_bundle).to include_gem "foo 1.0"
     end
   end

--- a/bundler/spec/cache/git_spec.rb
+++ b/bundler/spec/cache/git_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "bundle cache with git" do
   it "runs twice without exploding" do
     build_git "foo"
 
-    install_gemfile! <<-G
+    install_gemfile <<-G
       gem "foo", :git => '#{lib_path("foo-1.0")}'
     G
 

--- a/bundler/spec/cache/platform_spec.rb
+++ b/bundler/spec/cache/platform_spec.rb
@@ -34,14 +34,14 @@ RSpec.describe "bundle cache with multiple platforms" do
   end
 
   it "ensures that a successful bundle install does not delete gems for other platforms" do
-    bundle! "install"
+    bundle "install"
 
     expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
     expect(bundled_app("vendor/cache/activesupport-2.3.5.gem")).to exist
   end
 
   it "ensures that a successful bundle update does not delete gems for other platforms" do
-    bundle! "update", :all => true
+    bundle "update", :all => true
 
     expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
     expect(bundled_app("vendor/cache/activesupport-2.3.5.gem")).to exist

--- a/bundler/spec/commands/add_spec.rb
+++ b/bundler/spec/commands/add_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe "bundle add" do
 
   describe "when a gem is added which is already specified in Gemfile with version" do
     it "shows an error when added with different version requirement" do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "rack", "1.0"
       G
@@ -212,7 +212,7 @@ RSpec.describe "bundle add" do
     end
 
     it "shows error when added without version requirements" do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "rack", "1.0"
       G
@@ -227,7 +227,7 @@ RSpec.describe "bundle add" do
 
   describe "when a gem is added which is already specified in Gemfile without version" do
     it "shows an error when added with different version requirement" do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "rack"
       G

--- a/bundler/spec/commands/add_spec.rb
+++ b/bundler/spec/commands/add_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe "bundle add" do
 
   describe "with --optimistic" do
     it "adds optimistic version" do
-      bundle! "add 'foo' --optimistic"
+      bundle "add 'foo' --optimistic"
       expect(bundled_app_gemfile.read).to include %(gem "foo", ">= 2.0")
       expect(the_bundle).to include_gems "foo 2.0"
     end
@@ -160,7 +160,7 @@ RSpec.describe "bundle add" do
 
   describe "with --strict option" do
     it "adds strict version" do
-      bundle! "add 'foo' --strict"
+      bundle "add 'foo' --strict"
       expect(bundled_app_gemfile.read).to include %(gem "foo", "= 2.0")
       expect(the_bundle).to include_gems "foo 2.0"
     end
@@ -168,7 +168,7 @@ RSpec.describe "bundle add" do
 
   describe "with no option" do
     it "adds pessimistic version" do
-      bundle! "add 'foo'"
+      bundle "add 'foo'"
       expect(bundled_app_gemfile.read).to include %(gem "foo", "~> 2.0")
       expect(the_bundle).to include_gems "foo 2.0"
     end
@@ -184,7 +184,7 @@ RSpec.describe "bundle add" do
 
   context "multiple gems" do
     it "adds multiple gems to gemfile" do
-      bundle! "add bar baz"
+      bundle "add bar baz"
 
       expect(bundled_app_gemfile.read).to match(/gem "bar", "~> 0.12.3"/)
       expect(bundled_app_gemfile.read).to match(/gem "baz", "~> 1.2"/)
@@ -242,7 +242,7 @@ RSpec.describe "bundle add" do
 
   describe "when a gem is added and cache exists" do
     it "caches all new dependencies added for the specified gem" do
-      bundle! :cache
+      bundle :cache
 
       bundle "add 'rack' --version=1.0.0"
       expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist

--- a/bundler/spec/commands/binstubs_spec.rb
+++ b/bundler/spec/commands/binstubs_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "bundle binstubs <gem>" do
     end
 
     it "allows installing all binstubs" do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rails"
       G
@@ -109,7 +109,7 @@ RSpec.describe "bundle binstubs <gem>" do
             R
           end
         end
-        install_gemfile! <<-G
+        install_gemfile <<-G
           source "#{file_uri_for(gem_repo2)}"
           gem "rack"
           gem "prints_loaded_gems"

--- a/bundler/spec/commands/binstubs_spec.rb
+++ b/bundler/spec/commands/binstubs_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe "bundle binstubs <gem>" do
       let(:system_bundler_version) { Bundler::VERSION }
 
       it "runs bundler" do
-        sys_exec! "bin/bundle install", :env => { "DEBUG" => "1" }
+        sys_exec "bin/bundle install", :env => { "DEBUG" => "1" }
         expect(out).to include %(Using bundler #{system_bundler_version}\n)
       end
 
@@ -196,7 +196,7 @@ RSpec.describe "bundle binstubs <gem>" do
         before { lockfile.gsub(system_bundler_version, "1.1.1") }
 
         it "calls through to the latest bundler version" do
-          sys_exec! "bin/bundle update --bundler", :env => { "DEBUG" => "1" }
+          sys_exec "bin/bundle update --bundler", :env => { "DEBUG" => "1" }
           expect(out).to include %(Using bundler #{system_bundler_version}\n)
         end
 
@@ -211,14 +211,14 @@ RSpec.describe "bundle binstubs <gem>" do
       context "without a lockfile" do
         it "falls back to the latest installed bundler" do
           FileUtils.rm bundled_app_lock
-          sys_exec! "bin/bundle install", :env => { "DEBUG" => "1" }
+          sys_exec "bin/bundle install", :env => { "DEBUG" => "1" }
           expect(out).to include "Using bundler #{system_bundler_version}\n"
         end
       end
 
       context "using another binstub" do
         it "loads all gems" do
-          sys_exec! bundled_app("bin/print_loaded_gems").to_s
+          sys_exec bundled_app("bin/print_loaded_gems").to_s
           expect(out).to eq %(["bundler-#{Bundler::VERSION}", "prints_loaded_gems-1.0", "rack-1.2"])
         end
 

--- a/bundler/spec/commands/binstubs_spec.rb
+++ b/bundler/spec/commands/binstubs_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "bundle binstubs <gem>" do
         gem "rails"
       G
 
-      bundle! :binstubs, :all => true
+      bundle :binstubs, :all => true
 
       expect(bundled_app("bin/rails")).to exist
       expect(bundled_app("bin/rake")).to exist
@@ -114,7 +114,7 @@ RSpec.describe "bundle binstubs <gem>" do
           gem "rack"
           gem "prints_loaded_gems"
         G
-        bundle! "binstubs bundler rack prints_loaded_gems"
+        bundle "binstubs bundler rack prints_loaded_gems"
       end
 
       let(:system_bundler_version) { Bundler::VERSION }
@@ -326,8 +326,8 @@ RSpec.describe "bundle binstubs <gem>" do
         gem "rails"
       G
 
-      bundle! "binstubs rack", :path => "exec"
-      bundle! :install
+      bundle "binstubs rack", :path => "exec"
+      bundle :install
 
       expect(bundled_app("exec/rails")).to exist
     end
@@ -342,18 +342,18 @@ RSpec.describe "bundle binstubs <gem>" do
     end
 
     it "generates a standalone binstub" do
-      bundle! "binstubs rack --standalone"
+      bundle "binstubs rack --standalone"
       expect(bundled_app("bin/rackup")).to exist
     end
 
     it "generates a binstub that does not depend on rubygems or bundler" do
-      bundle! "binstubs rack --standalone"
+      bundle "binstubs rack --standalone"
       expect(File.read(bundled_app("bin/rackup"))).to_not include("Gem.bin_path")
     end
 
     context "when specified --path option" do
       it "generates a standalone binstub at the given path" do
-        bundle! "binstubs rack --standalone --path foo"
+        bundle "binstubs rack --standalone --path foo"
         expect(bundled_app("foo/rackup")).to exist
       end
     end

--- a/bundler/spec/commands/cache_spec.rb
+++ b/bundler/spec/commands/cache_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "bundle cache" do
           D
 
           bundle "config set cache_all true"
-          bundle! :cache
+          bundle :cache
 
           expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
           expect(bundled_app("vendor/cache/nokogiri-1.4.2.gem")).to exist
@@ -88,7 +88,7 @@ RSpec.describe "bundle cache" do
           D
 
           bundle "config set cache_all true"
-          bundle! :cache
+          bundle :cache
 
           expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
           expect(bundled_app("vendor/cache/nokogiri-1.4.2.gem")).to exist
@@ -133,7 +133,7 @@ RSpec.describe "bundle cache" do
         D
 
         bundle "config set cache_all true"
-        bundle! :cache
+        bundle :cache
 
         expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
         expect(bundled_app("vendor/cache/nokogiri-1.4.2.gem")).to exist
@@ -152,7 +152,7 @@ RSpec.describe "bundle cache" do
         gem 'rack'
       D
 
-      bundle! "cache --path #{bundled_app("test")}"
+      bundle "cache --path #{bundled_app("test")}"
 
       expect(the_bundle).to include_gems "rack 1.0.0"
       expect(bundled_app("test/vendor/cache/")).to exist
@@ -166,7 +166,7 @@ RSpec.describe "bundle cache" do
         gem 'rack'
       D
 
-      bundle! "cache --no-install"
+      bundle "cache --no-install"
 
       expect(the_bundle).not_to include_gems "rack 1.0.0"
       expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
@@ -178,8 +178,8 @@ RSpec.describe "bundle cache" do
         gem 'rack'
       D
 
-      bundle! "cache --no-install"
-      bundle! "install"
+      bundle "cache --no-install"
+      bundle "install"
 
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
@@ -190,8 +190,8 @@ RSpec.describe "bundle cache" do
         gem "rack", "1.0.0"
       D
 
-      bundle! "cache --no-install"
-      bundle! "update --all"
+      bundle "cache --no-install"
+      bundle "update --all"
 
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
@@ -231,14 +231,14 @@ RSpec.describe "bundle cache" do
         end
       G
 
-      bundle! :cache, "all-platforms" => true
+      bundle :cache, "all-platforms" => true
       expect(bundled_app("vendor/cache/weakling-0.0.3.gem")).to exist
       expect(bundled_app("vendor/cache/uninstallable-2.0.gem")).to exist
       expect(the_bundle).to include_gem "rack 1.0"
       expect(the_bundle).not_to include_gems "weakling", "uninstallable"
 
       bundle "config --local without wo"
-      bundle! :install
+      bundle :install
       expect(the_bundle).to include_gem "rack 1.0"
       expect(the_bundle).not_to include_gems "weakling", "uninstallable"
     end
@@ -259,7 +259,7 @@ RSpec.describe "bundle cache" do
     end
 
     it "tries to install with frozen" do
-      bundle! "config set deployment true"
+      bundle "config set deployment true"
       gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
@@ -300,13 +300,13 @@ RSpec.describe "bundle install with gem sources" do
         gem "rack"
       G
 
-      bundle! :cache
+      bundle :cache
       simulate_new_machine
       FileUtils.rm_rf gem_repo2
 
       bundle "config --local deployment true"
       bundle "config --local path vendor/bundle"
-      bundle! :install
+      bundle :install
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
 

--- a/bundler/spec/commands/cache_spec.rb
+++ b/bundler/spec/commands/cache_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe "bundle cache" do
       end
 
       bundle "config --local without wo"
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "file:#{gem_repo1}"
         gem "rack"
         group :wo do
@@ -295,7 +295,7 @@ RSpec.describe "bundle install with gem sources" do
 
     it "does not hit the remote at all" do
       build_repo2
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "rack"
       G

--- a/bundler/spec/commands/check_spec.rb
+++ b/bundler/spec/commands/check_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe "bundle check" do
 
   it "uses the without setting" do
     bundle "config set without foo"
-    install_gemfile! <<-G
+    install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
       group :foo do
         gem "rack"
@@ -207,7 +207,7 @@ RSpec.describe "bundle check" do
   end
 
   it "fails when there's no lock file and frozen is set" do
-    install_gemfile! <<-G
+    install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
       gem "foo"
     G

--- a/bundler/spec/commands/check_spec.rb
+++ b/bundler/spec/commands/check_spec.rb
@@ -95,13 +95,13 @@ RSpec.describe "bundle check" do
       end
     G
 
-    bundle! "install --without foo"
-    bundle! "check"
+    bundle "install --without foo"
+    bundle "check"
     expect(out).to include("The Gemfile's dependencies are satisfied")
   end
 
   it "uses the without setting" do
-    bundle! "config set without foo"
+    bundle "config set without foo"
     install_gemfile! <<-G
       source "#{file_uri_for(gem_repo1)}"
       group :foo do
@@ -109,7 +109,7 @@ RSpec.describe "bundle check" do
       end
     G
 
-    bundle! "check"
+    bundle "check"
     expect(out).to include("The Gemfile's dependencies are satisfied")
   end
 
@@ -213,7 +213,7 @@ RSpec.describe "bundle check" do
     G
 
     bundle "config --local deployment true"
-    bundle! "install"
+    bundle "install"
     FileUtils.rm(bundled_app_lock)
 
     bundle :check, :raise_on_error => false
@@ -233,13 +233,13 @@ RSpec.describe "bundle check" do
       end
 
       it "returns success" do
-        bundle! "check --path vendor/bundle"
+        bundle "check --path vendor/bundle"
         expect(out).to include("The Gemfile's dependencies are satisfied")
       end
 
       it "should write to .bundle/config" do
         bundle "check --path vendor/bundle"
-        bundle! "check"
+        bundle "check"
       end
     end
 
@@ -324,7 +324,7 @@ RSpec.describe "bundle check" do
     context "is newer" do
       it "does not change the lock but warns" do
         lockfile lock_with(Bundler::VERSION.succ)
-        bundle! :check
+        bundle :check
         expect(err).to include("the running version of Bundler (#{Bundler::VERSION}) is older than the version that created the lockfile (#{Bundler::VERSION.succ})")
         lockfile_should_be lock_with(Bundler::VERSION.succ)
       end

--- a/bundler/spec/commands/clean_spec.rb
+++ b/bundler/spec/commands/clean_spec.rb
@@ -27,16 +27,16 @@ RSpec.describe "bundle clean" do
 
     bundle "config set path vendor/bundle"
     bundle "config set clean false"
-    bundle! "install"
+    bundle "install"
 
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
 
       gem "thin"
     G
-    bundle! "install"
+    bundle "install"
 
-    bundle! :clean
+    bundle :clean
 
     expect(out).to include("Removing foo (1.0)")
 
@@ -86,7 +86,7 @@ RSpec.describe "bundle clean" do
 
     bundle "config set path vendor/bundle"
     bundle "config set clean false"
-    bundle! "install"
+    bundle "install"
 
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -94,9 +94,9 @@ RSpec.describe "bundle clean" do
       gem "rack", "0.9.1"
       gem "foo"
     G
-    bundle! "update rack"
+    bundle "update rack"
 
-    bundle! :clean
+    bundle :clean
 
     expect(out).to include("Removing rack (1.0.0)")
 
@@ -234,13 +234,13 @@ RSpec.describe "bundle clean" do
     G
 
     bundle "config set path vendor/bundle"
-    bundle! "install"
+    bundle "install"
 
     update_git "foo", :path => lib_path("foo-bar")
     revision2 = revision_for(lib_path("foo-bar"))
 
-    bundle! "update", :all => true
-    bundle! :clean
+    bundle "update", :all => true
+    bundle :clean
 
     expect(out).to include("Removing foo-bar (#{revision[0..11]})")
 
@@ -319,7 +319,7 @@ RSpec.describe "bundle clean" do
   end
 
   it "displays an error when used without --path" do
-    bundle! "config set path.system true"
+    bundle "config set path.system true"
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
 
@@ -364,7 +364,7 @@ RSpec.describe "bundle clean" do
   end
 
   it "does not call clean automatically when using system gems" do
-    bundle! "config set path.system true"
+    bundle "config set path.system true"
 
     install_gemfile! <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -421,7 +421,7 @@ RSpec.describe "bundle clean" do
       build_gem "foo", "1.0.1"
     end
 
-    bundle! "update", :all => true
+    bundle "update", :all => true
 
     should_have_gems "foo-1.0.1"
     should_not_have_gems "foo-1.0"
@@ -440,7 +440,7 @@ RSpec.describe "bundle clean" do
       build_gem "foo", "1.0.1"
     end
 
-    bundle! "update", :all => true
+    bundle "update", :all => true
 
     files = Pathname.glob(bundled_app(".bundle", Bundler.ruby_scope, "*", "*"))
     files.map! {|f| f.to_s.sub(bundled_app(".bundle", Bundler.ruby_scope).to_s, "") }
@@ -480,18 +480,18 @@ RSpec.describe "bundle clean" do
       gem "foo"
     G
     bundle "config set path vendor/bundle"
-    bundle! "install"
+    bundle "install"
 
     update_repo2 do
       build_gem "foo", "1.0.1"
     end
 
-    bundle! :update, :all => true
+    bundle :update, :all => true
     should_have_gems "foo-1.0", "foo-1.0.1"
   end
 
   it "does not clean on bundle update when using --system" do
-    bundle! "config set path.system true"
+    bundle "config set path.system true"
 
     build_repo2
 
@@ -500,19 +500,19 @@ RSpec.describe "bundle clean" do
 
       gem "foo"
     G
-    bundle! "install"
+    bundle "install"
 
     update_repo2 do
       build_gem "foo", "1.0.1"
     end
-    bundle! :update, :all => true
+    bundle :update, :all => true
 
     gem_command! :list
     expect(out).to include("foo (1.0.1, 1.0)")
   end
 
   it "cleans system gems when --force is used" do
-    bundle! "config set path.system true"
+    bundle "config set path.system true"
 
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -602,7 +602,7 @@ RSpec.describe "bundle clean" do
   end
 
   it "when using --force on system gems, it doesn't remove binaries" do
-    bundle! "config set path.system true"
+    bundle "config set path.system true"
 
     build_repo2
     update_repo2 do
@@ -644,7 +644,7 @@ RSpec.describe "bundle clean" do
 
     bundle "config set path vendor/bundle"
     bundle "install"
-    bundle! :clean
+    bundle :clean
   end
 
   it "doesn't remove gems in dry-run mode with path set" do
@@ -749,7 +749,7 @@ RSpec.describe "bundle clean" do
 
     bundle "config set path vendor/bundle"
     bundle "config set clean false"
-    bundle! "install"
+    bundle "install"
 
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -758,8 +758,8 @@ RSpec.describe "bundle clean" do
       gem "weakling"
     G
 
-    bundle! "config set auto_install 1"
-    bundle! :clean
+    bundle "config set auto_install 1"
+    bundle :clean
     expect(out).to include("Installing weakling 0.0.3")
     should_have_gems "thin-1.0", "rack-1.0.0", "weakling-0.0.3"
     should_not_have_gems "foo-1.0"
@@ -777,11 +777,11 @@ RSpec.describe "bundle clean" do
     G
 
     bundle "config set path vendor/bundle"
-    bundle! "install"
+    bundle "install"
     expect(vendored_gems("bundler/gems/extensions")).to exist
     expect(vendored_gems("bundler/gems/very_simple_git_binary-1.0-#{revision[0..11]}")).to exist
 
-    bundle! :clean
+    bundle :clean
     expect(out).to be_empty
 
     expect(vendored_gems("bundler/gems/extensions")).to exist
@@ -798,7 +798,7 @@ RSpec.describe "bundle clean" do
     G
 
     bundle "config set path vendor/bundle"
-    bundle! "install"
+    bundle "install"
 
     very_simple_binary_extensions_dir =
       Pathname.glob("#{vendored_gems}/extensions/*/*/very_simple_binary-1.0").first
@@ -816,8 +816,8 @@ RSpec.describe "bundle clean" do
       gem "simple_binary"
     G
 
-    bundle! "install"
-    bundle! :clean
+    bundle "install"
+    bundle :clean
     expect(out).to eq("Removing very_simple_binary (1.0)")
 
     expect(very_simple_binary_extensions_dir).not_to exist
@@ -838,7 +838,7 @@ RSpec.describe "bundle clean" do
     G
 
     bundle "config set path vendor/bundle"
-    bundle! "install"
+    bundle "install"
 
     very_simple_binary_extensions_dir =
       Pathname.glob("#{vendored_gems}/bundler/gems/extensions/*/*/very_simple_git_binary-1.0-#{short_revision}").first
@@ -849,16 +849,16 @@ RSpec.describe "bundle clean" do
       gem "very_simple_git_binary", :git => "#{lib_path("very_simple_git_binary-1.0")}", :ref => "#{revision}"
     G
 
-    bundle! "install"
-    bundle! :clean
+    bundle "install"
+    bundle :clean
     expect(out).to include("Removing thin (1.0)")
     expect(very_simple_binary_extensions_dir).to exist
 
     gemfile <<-G
     G
 
-    bundle! "install"
-    bundle! :clean
+    bundle "install"
+    bundle :clean
     expect(out).to eq("Removing very_simple_git_binary-1.0 (#{short_revision})")
 
     expect(very_simple_binary_extensions_dir).not_to exist
@@ -881,8 +881,8 @@ RSpec.describe "bundle clean" do
     bundle :lock
     bundle "config set without development"
     bundle "config set path vendor/bundle"
-    bundle! "install"
-    bundle! :clean
+    bundle "install"
+    bundle :clean
 
     very_simple_binary_extensions_dir =
       Pathname.glob("#{vendored_gems}/bundler/gems/extensions/*/*/very_simple_git_binary-1.0-#{short_revision}").first

--- a/bundler/spec/commands/clean_spec.rb
+++ b/bundler/spec/commands/clean_spec.rb
@@ -379,7 +379,7 @@ RSpec.describe "bundle clean" do
       gem "rack"
     G
 
-    gem_command! :list
+    gem_command :list
     expect(out).to include("rack (1.0.0)").and include("thin (1.0)")
   end
 
@@ -507,7 +507,7 @@ RSpec.describe "bundle clean" do
     end
     bundle :update, :all => true
 
-    gem_command! :list
+    gem_command :list
     expect(out).to include("foo (1.0.1, 1.0)")
   end
 
@@ -531,7 +531,7 @@ RSpec.describe "bundle clean" do
     bundle "clean --force"
 
     expect(out).to include("Removing foo (1.0)")
-    gem_command! :list
+    gem_command :list
     expect(out).not_to include("foo (1.0)")
     expect(out).to include("rack (1.0.0)")
   end
@@ -565,7 +565,7 @@ RSpec.describe "bundle clean" do
       expect(err).to include(system_gem_path.to_s)
       expect(err).to include("grant write permissions")
 
-      gem_command! :list
+      gem_command :list
       expect(out).to include("foo (1.0)")
       expect(out).to include("rack (1.0.0)")
     end

--- a/bundler/spec/commands/clean_spec.rb
+++ b/bundler/spec/commands/clean_spec.rb
@@ -366,14 +366,14 @@ RSpec.describe "bundle clean" do
   it "does not call clean automatically when using system gems" do
     bundle "config set path.system true"
 
-    install_gemfile! <<-G
+    install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
 
       gem "thin"
       gem "rack"
     G
 
-    install_gemfile! <<-G
+    install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
 
       gem "rack"
@@ -430,7 +430,7 @@ RSpec.describe "bundle clean" do
   it "automatically cleans when path has not been set", :bundler => "3" do
     build_repo2
 
-    install_gemfile! <<-G
+    install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}"
 
       gem "foo"

--- a/bundler/spec/commands/config_spec.rb
+++ b/bundler/spec/commands/config_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe ".bundle/config" do
     end
 
     it "can also be set explicitly" do
-      bundle! "config set --global foo global"
+      bundle "config set --global foo global"
       run! "puts Bundler.settings[:foo]"
       expect(out).to eq("global")
     end
@@ -401,42 +401,42 @@ E
 
   describe "subcommands" do
     it "list" do
-      bundle! "config list"
+      bundle "config list"
       expect(out).to eq "Settings are listed in order of priority. The top value will be used.\nspec_run\nSet via BUNDLE_SPEC_RUN: \"true\""
 
-      bundle! "config list", :parseable => true
+      bundle "config list", :parseable => true
       expect(out).to eq "spec_run=true"
     end
 
     it "get" do
       ENV["BUNDLE_BAR"] = "bar_val"
 
-      bundle! "config get foo"
+      bundle "config get foo"
       expect(out).to eq "Settings for `foo` in order of priority. The top value will be used\nYou have not configured a value for `foo`"
 
       ENV["BUNDLE_FOO"] = "foo_val"
 
-      bundle! "config get foo --parseable"
+      bundle "config get foo --parseable"
       expect(out).to eq "foo=foo_val"
 
-      bundle! "config get foo"
+      bundle "config get foo"
       expect(out).to eq "Settings for `foo` in order of priority. The top value will be used\nSet via BUNDLE_FOO: \"foo_val\""
     end
 
     it "set" do
-      bundle! "config set foo 1"
+      bundle "config set foo 1"
       expect(out).to eq ""
 
-      bundle! "config set --local foo 2"
+      bundle "config set --local foo 2"
       expect(out).to eq ""
 
-      bundle! "config set --global foo 3"
+      bundle "config set --global foo 3"
       expect(out).to eq "Your application has set foo to \"2\". This will override the global value you are currently setting"
 
-      bundle! "config set --parseable --local foo 4"
+      bundle "config set --parseable --local foo 4"
       expect(out).to eq "foo=4"
 
-      bundle! "config set --local foo 4.1"
+      bundle "config set --local foo 4.1"
       expect(out).to eq "You are replacing the current local value of foo, which is currently \"4\""
 
       bundle "config set --global --local foo 5", :raise_on_error => false
@@ -445,39 +445,39 @@ E
     end
 
     it "unset" do
-      bundle! "config unset foo"
+      bundle "config unset foo"
       expect(out).to eq ""
 
-      bundle! "config set foo 1"
-      bundle! "config unset foo --parseable"
+      bundle "config set foo 1"
+      bundle "config unset foo --parseable"
       expect(out).to eq ""
 
-      bundle! "config set --local foo 1"
-      bundle! "config set --global foo 2"
+      bundle "config set --local foo 1"
+      bundle "config set --global foo 2"
 
-      bundle! "config unset foo"
+      bundle "config unset foo"
       expect(out).to eq ""
-      expect(bundle!("config get foo")).to eq "Settings for `foo` in order of priority. The top value will be used\nYou have not configured a value for `foo`"
+      expect(bundle("config get foo")).to eq "Settings for `foo` in order of priority. The top value will be used\nYou have not configured a value for `foo`"
 
-      bundle! "config set --local foo 1"
-      bundle! "config set --global foo 2"
+      bundle "config set --local foo 1"
+      bundle "config set --global foo 2"
 
-      bundle! "config unset foo --local"
+      bundle "config unset foo --local"
       expect(out).to eq ""
-      expect(bundle!("config get foo")).to eq "Settings for `foo` in order of priority. The top value will be used\nSet for the current user (#{home(".bundle/config")}): \"2\""
-      bundle! "config unset foo --global"
+      expect(bundle("config get foo")).to eq "Settings for `foo` in order of priority. The top value will be used\nSet for the current user (#{home(".bundle/config")}): \"2\""
+      bundle "config unset foo --global"
       expect(out).to eq ""
-      expect(bundle!("config get foo")).to eq "Settings for `foo` in order of priority. The top value will be used\nYou have not configured a value for `foo`"
+      expect(bundle("config get foo")).to eq "Settings for `foo` in order of priority. The top value will be used\nYou have not configured a value for `foo`"
 
-      bundle! "config set --local foo 1"
-      bundle! "config set --global foo 2"
+      bundle "config set --local foo 1"
+      bundle "config set --global foo 2"
 
-      bundle! "config unset foo --global"
+      bundle "config unset foo --global"
       expect(out).to eq ""
-      expect(bundle!("config get foo")).to eq "Settings for `foo` in order of priority. The top value will be used\nSet for your local app (#{bundled_app(".bundle/config")}): \"1\""
-      bundle! "config unset foo --local"
+      expect(bundle("config get foo")).to eq "Settings for `foo` in order of priority. The top value will be used\nSet for your local app (#{bundled_app(".bundle/config")}): \"1\""
+      bundle "config unset foo --local"
       expect(out).to eq ""
-      expect(bundle!("config get foo")).to eq "Settings for `foo` in order of priority. The top value will be used\nYou have not configured a value for `foo`"
+      expect(bundle("config get foo")).to eq "Settings for `foo` in order of priority. The top value will be used\nYou have not configured a value for `foo`"
 
       bundle "config unset foo --local --global", :raise_on_error => false
       expect(last_command).to be_failure

--- a/bundler/spec/commands/config_spec.rb
+++ b/bundler/spec/commands/config_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe ".bundle/config" do
 
     it "can also be set explicitly" do
       bundle "config set --global foo global"
-      run! "puts Bundler.settings[:foo]"
+      run "puts Bundler.settings[:foo]"
       expect(out).to eq("global")
     end
 

--- a/bundler/spec/commands/doctor_spec.rb
+++ b/bundler/spec/commands/doctor_spec.rb
@@ -7,7 +7,7 @@ require "bundler/cli/doctor"
 
 RSpec.describe "bundle doctor" do
   before(:each) do
-    install_gemfile! <<-G
+    install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -355,7 +355,7 @@ RSpec.describe "bundle exec" do
 
   it "raises a helpful error when exec'ing to something outside of the bundle", :ruby_repo do
     bundle "config set clean false" # want to keep the rackup binstub
-    install_gemfile! <<-G
+    install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
       gem "with_license"
     G
@@ -895,7 +895,7 @@ __FILE__: #{path.to_s.inspect}
         skip "https://github.com/rubygems/bundler/issues/6898" if Gem.win_platform?
         skip "openssl isn't a default gem" if expected.empty?
 
-        install_gemfile! "" # must happen before installing the broken system gem
+        install_gemfile "" # must happen before installing the broken system gem
 
         build_repo4 do
           build_gem "openssl", openssl_version do |s|
@@ -935,7 +935,7 @@ __FILE__: #{path.to_s.inspect}
       before do
         build_git "simple_git_binary", &:add_c_extension
         bundle "config set --local path .bundle"
-        install_gemfile! <<-G
+        install_gemfile <<-G
           gem "simple_git_binary", :git => '#{lib_path("simple_git_binary-1.0")}'
         G
       end

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -157,11 +157,11 @@ RSpec.describe "bundle exec" do
       gem "rack_two", "1.0.0"
     G
 
-    bundle! "exec rackup"
+    bundle "exec rackup"
 
     expect(out).to eq("0.9.1")
 
-    bundle! "exec rackup", :dir => bundled_app2
+    bundle "exec rackup", :dir => bundled_app2
     expect(out).to eq("1.0.0")
   end
 
@@ -178,7 +178,7 @@ RSpec.describe "bundle exec" do
       end
 
       it "uses version provided by ruby" do
-        bundle! "exec irb --version"
+        bundle "exec irb --version"
 
         expect(out).to include(default_irb_version)
       end
@@ -203,7 +203,7 @@ RSpec.describe "bundle exec" do
       end
 
       it "uses version specified" do
-        bundle! "exec irb --version"
+        bundle "exec irb --version"
 
         expect(out).to eq(specified_irb_version)
         expect(err).to be_empty
@@ -231,7 +231,7 @@ RSpec.describe "bundle exec" do
           gem "gem_depending_on_old_irb"
         G
 
-        bundle! "exec irb --version"
+        bundle "exec irb --version"
       end
 
       it "uses resolved version" do
@@ -260,7 +260,7 @@ RSpec.describe "bundle exec" do
       gem "rack_two", "1.0.0"
     G
 
-    bundle! "exec rackup"
+    bundle "exec rackup"
 
     expect(last_command.stderr).to eq(
       "Bundler is using a binstub that was created for a different gem (rack).\n" \
@@ -354,13 +354,13 @@ RSpec.describe "bundle exec" do
   end
 
   it "raises a helpful error when exec'ing to something outside of the bundle", :ruby_repo do
-    bundle! "config set clean false" # want to keep the rackup binstub
+    bundle "config set clean false" # want to keep the rackup binstub
     install_gemfile! <<-G
       source "#{file_uri_for(gem_repo1)}"
       gem "with_license"
     G
     [true, false].each do |l|
-      bundle! "config set disable_exec_load #{l}"
+      bundle "config set disable_exec_load #{l}"
       bundle "exec rackup", :raise_on_error => false
       expect(err).to include "can't find executable rackup for gem rack. rack is not currently included in the bundle, perhaps you meant to add it to your Gemfile?"
     end
@@ -598,8 +598,8 @@ RSpec.describe "bundle exec" do
       end
       Bundler.rubygems.extend(Monkey)
       G
-      bundle! "config set path.system true"
-      bundle! "install"
+      bundle "config set path.system true"
+      bundle "install"
       bundle "exec ruby -e '`bundle -v`; puts $?.success?'", :env => { "BUNDLER_VERSION" => Bundler::VERSION }
       expect(out).to match("true")
     end
@@ -827,7 +827,7 @@ __FILE__: #{path.to_s.inspect}
         it "receives the signal" do
           skip "https://github.com/rubygems/bundler/issues/6898" if Gem.win_platform?
 
-          bundle!("exec #{path}") do |_, o, thr|
+          bundle("exec #{path}") do |_, o, thr|
             o.gets # Consumes 'Started' and ensures that thread has started
             Process.kill("INT", thr.pid)
           end
@@ -854,7 +854,7 @@ __FILE__: #{path.to_s.inspect}
             Signal.trap(n, "IGNORE")
           end
 
-          bundle!("exec #{path}")
+          bundle("exec #{path}")
 
           expect(out).to eq(test_signals.count.to_s)
         end
@@ -870,7 +870,7 @@ __FILE__: #{path.to_s.inspect}
           gem "rack"
         G
         bundle "config set path vendor/bundler"
-        bundle! :install
+        bundle :install
       end
 
       it "correctly shells out", :ruby_repo do
@@ -882,7 +882,7 @@ __FILE__: #{path.to_s.inspect}
           puts `bundle exec echo foo`
         RUBY
         file.chmod(0o777)
-        bundle! "exec #{file}", :env => { "PATH" => path }
+        bundle "exec #{file}", :env => { "PATH" => path }
         expect(out).to eq("foo")
       end
     end
@@ -918,9 +918,9 @@ __FILE__: #{path.to_s.inspect}
 
         env = { "PATH" => path }
         aggregate_failures do
-          expect(bundle!("exec #{file}", :artifice => nil, :env => env)).to eq(expected)
-          expect(bundle!("exec bundle exec #{file}", :artifice => nil, :env => env)).to eq(expected)
-          expect(bundle!("exec ruby #{file}", :artifice => nil, :env => env)).to eq(expected)
+          expect(bundle("exec #{file}", :artifice => nil, :env => env)).to eq(expected)
+          expect(bundle("exec bundle exec #{file}", :artifice => nil, :env => env)).to eq(expected)
+          expect(bundle("exec ruby #{file}", :artifice => nil, :env => env)).to eq(expected)
           expect(run!(file.read, :artifice => nil, :env => env)).to eq(expected)
         end
 
@@ -934,19 +934,19 @@ __FILE__: #{path.to_s.inspect}
     context "with a git gem that includes extensions", :ruby_repo do
       before do
         build_git "simple_git_binary", &:add_c_extension
-        bundle! "config set --local path .bundle"
+        bundle "config set --local path .bundle"
         install_gemfile! <<-G
           gem "simple_git_binary", :git => '#{lib_path("simple_git_binary-1.0")}'
         G
       end
 
       it "allows calling bundle install" do
-        bundle! "exec bundle install"
+        bundle "exec bundle install"
       end
 
       it "allows calling bundle install after removing gem.build_complete" do
         FileUtils.rm_rf Dir[bundled_app(".bundle/**/gem.build_complete")]
-        bundle! "exec #{Gem.ruby} -S bundle install"
+        bundle "exec #{Gem.ruby} -S bundle install"
       end
     end
   end

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -921,7 +921,7 @@ __FILE__: #{path.to_s.inspect}
           expect(bundle("exec #{file}", :artifice => nil, :env => env)).to eq(expected)
           expect(bundle("exec bundle exec #{file}", :artifice => nil, :env => env)).to eq(expected)
           expect(bundle("exec ruby #{file}", :artifice => nil, :env => env)).to eq(expected)
-          expect(run!(file.read, :artifice => nil, :env => env)).to eq(expected)
+          expect(run(file.read, :artifice => nil, :env => env)).to eq(expected)
         end
 
         skip "ruby_core has openssl and rubygems in the same folder, and this test needs rubygems require but default openssl not in a directly added entry in $LOAD_PATH" if ruby_core?

--- a/bundler/spec/commands/info_spec.rb
+++ b/bundler/spec/commands/info_spec.rb
@@ -13,13 +13,13 @@ RSpec.describe "bundle info" do
     it "creates a Gemfile.lock when invoked with a gem name" do
       FileUtils.rm(bundled_app_lock)
 
-      bundle! "info rails"
+      bundle "info rails"
 
       expect(bundled_app_lock).to exist
     end
 
     it "prints information if gem exists in bundle" do
-      bundle! "info rails"
+      bundle "info rails"
       expect(out).to include "* rails (2.3.2)
 \tSummary: This is just a fake gem for testing
 \tHomepage: http://example.com
@@ -27,12 +27,12 @@ RSpec.describe "bundle info" do
     end
 
     it "prints path if gem exists in bundle" do
-      bundle! "info rails --path"
+      bundle "info rails --path"
       expect(out).to eq(default_bundle_path("gems", "rails-2.3.2").to_s)
     end
 
     it "prints the path to the running bundler" do
-      bundle! "info bundler --path"
+      bundle "info bundler --path"
       expect(out).to eq(root.to_s)
     end
 
@@ -52,7 +52,7 @@ RSpec.describe "bundle info" do
 
     context "given a default gem shippped in ruby", :ruby_repo do
       it "prints information about the default gem" do
-        bundle! "info rdoc"
+        bundle "info rdoc"
         expect(out).to include("* rdoc")
         expect(out).to include("Default Gem: yes")
       end
@@ -60,7 +60,7 @@ RSpec.describe "bundle info" do
 
     context "given a gem with metadata" do
       it "prints the gem metadata" do
-        bundle! "info has_metadata"
+        bundle "info has_metadata"
         expect(out).to include "* has_metadata (1.0)
 \tSummary: This is just a fake gem for testing
 \tHomepage: http://example.com
@@ -101,7 +101,7 @@ RSpec.describe "bundle info" do
       G
       expect(the_bundle).to include_gems "foo 1.0"
 
-      bundle! "info foo"
+      bundle "info foo"
       expect(out).to include("foo (1.0 #{@git.ref_for("master", 6)}")
     end
 
@@ -116,7 +116,7 @@ RSpec.describe "bundle info" do
       G
       expect(the_bundle).to include_gems "foo 1.0.omg"
 
-      bundle! "info foo"
+      bundle "info foo"
       expect(out).to include("foo (1.0 #{@git.ref_for("omg", 6)}")
     end
 
@@ -126,7 +126,7 @@ RSpec.describe "bundle info" do
         gem "foo", :git => "#{lib_path("foo-1.0")}", :ref => "#{sha}"
       G
 
-      bundle! "info foo"
+      bundle "info foo"
       expect(out).to include("foo (1.0 #{sha[0..6]})")
     end
 
@@ -137,7 +137,7 @@ RSpec.describe "bundle info" do
       G
       expect(the_bundle).to include_gems "foo 1.0.0.pre.beta.1"
 
-      bundle! "info foo"
+      bundle "info foo"
       expect(out).to include("foo (1.0.0.pre.beta.1")
     end
   end
@@ -150,7 +150,7 @@ RSpec.describe "bundle info" do
         gem "rack-obama"
       G
 
-      bundle! "info rac"
+      bundle "info rac"
       expect(out).to eq "1 : rack\n2 : rack-obama\n0 : - exit -\n>"
     end
   end

--- a/bundler/spec/commands/info_spec.rb
+++ b/bundler/spec/commands/info_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "bundle info" do
   context "with a standard Gemfile" do
     before do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rails"
         gem "has_metadata"
@@ -96,7 +96,7 @@ RSpec.describe "bundle info" do
     end
 
     it "prints out git info" do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         gem "foo", :git => "#{lib_path("foo-1.0")}"
       G
       expect(the_bundle).to include_gems "foo 1.0"
@@ -111,7 +111,7 @@ RSpec.describe "bundle info" do
       end
       @revision = revision_for(lib_path("foo-1.0"))[0...6]
 
-      install_gemfile! <<-G
+      install_gemfile <<-G
         gem "foo", :git => "#{lib_path("foo-1.0")}", :branch => "omg"
       G
       expect(the_bundle).to include_gems "foo 1.0.omg"
@@ -122,7 +122,7 @@ RSpec.describe "bundle info" do
 
     it "doesn't print the branch when tied to a ref" do
       sha = revision_for(lib_path("foo-1.0"))
-      install_gemfile! <<-G
+      install_gemfile <<-G
         gem "foo", :git => "#{lib_path("foo-1.0")}", :ref => "#{sha}"
       G
 
@@ -132,7 +132,7 @@ RSpec.describe "bundle info" do
 
     it "handles when a version is a '-' prerelease" do
       @git = build_git("foo", "1.0.0-beta.1", :path => lib_path("foo"))
-      install_gemfile! <<-G
+      install_gemfile <<-G
         gem "foo", "1.0.0-beta.1", :git => "#{lib_path("foo")}"
       G
       expect(the_bundle).to include_gems "foo 1.0.0.pre.beta.1"
@@ -144,7 +144,7 @@ RSpec.describe "bundle info" do
 
   context "with a valid regexp for gem name" do
     it "presents alternatives", :readline do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
         gem "rack-obama"
@@ -157,7 +157,7 @@ RSpec.describe "bundle info" do
 
   context "with an invalid regexp for gem name" do
     it "does not find the gem" do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rails"
       G

--- a/bundler/spec/commands/init_spec.rb
+++ b/bundler/spec/commands/init_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "bundle init" do
   it "generates a Gemfile" do
-    bundle! :init
+    bundle :init
     expect(out).to include("Writing new Gemfile")
     expect(bundled_app_gemfile).to be_file
   end
@@ -28,11 +28,11 @@ RSpec.describe "bundle init" do
     let(:subdir) { "child_dir" }
 
     it "lets users generate a Gemfile in a child directory" do
-      bundle! :init
+      bundle :init
 
       FileUtils.mkdir bundled_app(subdir)
 
-      bundle! :init, :dir => bundled_app(subdir)
+      bundle :init, :dir => bundled_app(subdir)
 
       expect(out).to include("Writing new Gemfile")
       expect(bundled_app("#{subdir}/Gemfile")).to be_file
@@ -99,7 +99,7 @@ RSpec.describe "bundle init" do
     before { bundle "config set init_gems_rb true" }
 
     it "generates a gems.rb" do
-      bundle! :init
+      bundle :init
       expect(out).to include("Writing new gems.rb")
       expect(bundled_app("gems.rb")).to be_file
     end
@@ -125,11 +125,11 @@ RSpec.describe "bundle init" do
       let(:subdir) { "child_dir" }
 
       it "lets users generate a Gemfile in a child directory" do
-        bundle! :init
+        bundle :init
 
         FileUtils.mkdir bundled_app(subdir)
 
-        bundle! :init, :dir => bundled_app(subdir)
+        bundle :init, :dir => bundled_app(subdir)
 
         expect(out).to include("Writing new gems.rb")
         expect(bundled_app("#{subdir}/gems.rb")).to be_file

--- a/bundler/spec/commands/inject_spec.rb
+++ b/bundler/spec/commands/inject_spec.rb
@@ -80,9 +80,9 @@ Usage: "bundle inject GEM VERSION"
     before do
       bundle "install"
       if Bundler.feature_flag.bundler_3_mode?
-        bundle! "config set --local deployment true"
+        bundle "config set --local deployment true"
       else
-        bundle! "config set --local frozen true"
+        bundle "config set --local frozen true"
       end
     end
 

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "bundle install with gem sources" do
         gem "rack"
       G
 
-      bundle! :install # can't use install_gemfile since it sets retry
+      bundle :install # can't use install_gemfile since it sets retry
       expect(bundled_app(".bundle")).not_to exist
     end
 
@@ -45,7 +45,7 @@ RSpec.describe "bundle install with gem sources" do
         gem "rack"
       G
 
-      bundle! :install, :env => { "BUNDLE_PATH__SYSTEM" => "true" } # can't use install_gemfile since it sets retry
+      bundle :install, :env => { "BUNDLE_PATH__SYSTEM" => "true" } # can't use install_gemfile since it sets retry
       expect(bundled_app(".bundle")).not_to exist
     end
 
@@ -562,11 +562,11 @@ RSpec.describe "bundle install with gem sources" do
         gem "rack"
       G
       bundle "config --local path bundle"
-      bundle! "install", :standalone => true
+      bundle "install", :standalone => true
     end
 
     it "includes the standalone path" do
-      bundle! "binstubs rack", :standalone => true
+      bundle "binstubs rack", :standalone => true
       standalone_line = File.read(bundled_app("bin/rackup")).each_line.find {|line| line.include? "$:.unshift" }.strip
       expect(standalone_line).to eq %($:.unshift File.expand_path "../../bundle", path.realpath)
     end

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -557,7 +557,7 @@ RSpec.describe "bundle install with gem sources" do
 
   context "after installing with --standalone" do
     before do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G

--- a/bundler/spec/commands/list_spec.rb
+++ b/bundler/spec/commands/list_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "bundle list" do
 
     context "when group is present" do
       it "prints the gems not in the specified group" do
-        bundle! "list --without-group test"
+        bundle "list --without-group test"
 
         expect(out).to include("  * rack (1.0.0)")
         expect(out).to include("  * rails (2.3.2)")
@@ -48,7 +48,7 @@ RSpec.describe "bundle list" do
 
     context "when multiple groups" do
       it "prints the gems not in the specified groups" do
-        bundle! "list --without-group test production"
+        bundle "list --without-group test production"
 
         expect(out).to include("  * rack (1.0.0)")
         expect(out).not_to include("  * rails (2.3.2)")
@@ -70,7 +70,7 @@ RSpec.describe "bundle list" do
 
     context "when group is present" do
       it "prints the gems in the specified group" do
-        bundle! "list --only-group default"
+        bundle "list --only-group default"
 
         expect(out).to include("  * rack (1.0.0)")
         expect(out).not_to include("  * rspec (1.2.7)")
@@ -87,7 +87,7 @@ RSpec.describe "bundle list" do
 
     context "when multiple groups" do
       it "prints the gems in the specified groups" do
-        bundle! "list --only-group default production"
+        bundle "list --only-group default production"
 
         expect(out).to include("  * rack (1.0.0)")
         expect(out).to include("  * rails (2.3.2)")

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "bundle lock" do
   it "writes a lockfile when there is an outdated lockfile using --update" do
     lockfile @lockfile.gsub("2.3.2", "2.3.1")
 
-    bundle! "lock --update"
+    bundle "lock --update"
 
     expect(read_lockfile).to eq(@lockfile)
   end
@@ -156,9 +156,9 @@ RSpec.describe "bundle lock" do
       gem "thin"
       gem "rack_middleware", :group => "test"
     G
-    bundle! "config set without test"
-    bundle! "config set path .bundle"
-    bundle! "lock"
+    bundle "config set without test"
+    bundle "config set path .bundle"
+    bundle "lock"
     expect(bundled_app(".bundle")).not_to exist
   end
 
@@ -213,7 +213,7 @@ RSpec.describe "bundle lock" do
   end
 
   it "supports adding new platforms" do
-    bundle! "lock --add-platform java x86-mingw32"
+    bundle "lock --add-platform java x86-mingw32"
 
     allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
     lockfile = Bundler::LockfileParser.new(read_lockfile)
@@ -221,7 +221,7 @@ RSpec.describe "bundle lock" do
   end
 
   it "supports adding the `ruby` platform" do
-    bundle! "lock --add-platform ruby"
+    bundle "lock --add-platform ruby"
 
     allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
     lockfile = Bundler::LockfileParser.new(read_lockfile)
@@ -234,13 +234,13 @@ RSpec.describe "bundle lock" do
   end
 
   it "allows removing platforms" do
-    bundle! "lock --add-platform java x86-mingw32"
+    bundle "lock --add-platform java x86-mingw32"
 
     allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
     lockfile = Bundler::LockfileParser.new(read_lockfile)
     expect(lockfile.platforms).to match_array(local_platforms.unshift(java, mingw).uniq)
 
-    bundle! "lock --remove-platform java"
+    bundle "lock --remove-platform java"
 
     lockfile = Bundler::LockfileParser.new(read_lockfile)
     expect(lockfile.platforms).to match_array(local_platforms.unshift(mingw).uniq)
@@ -288,7 +288,7 @@ RSpec.describe "bundle lock" do
       gem "gssapi"
     G
 
-    simulate_platform(mingw) { bundle! :lock }
+    simulate_platform(mingw) { bundle :lock }
 
     lockfile_should_be <<-G
       GEM
@@ -313,7 +313,7 @@ RSpec.describe "bundle lock" do
          #{Bundler::VERSION}
     G
 
-    simulate_platform(rb) { bundle! :lock }
+    simulate_platform(rb) { bundle :lock }
 
     lockfile_should_be <<-G
       GEM
@@ -353,14 +353,14 @@ RSpec.describe "bundle lock" do
     end
 
     it "does not implicitly update" do
-      bundle! "lock"
+      bundle "lock"
 
       expect(read_lockfile).to eq(@lockfile)
     end
 
     it "accounts for changes in the gemfile" do
       gemfile gemfile.gsub('"foo"', '"foo", "2.0"')
-      bundle! "lock"
+      bundle "lock"
 
       expect(read_lockfile).to eq(@lockfile.sub("foo (1.0)", "foo (2.0)").sub(/foo$/, "foo (= 2.0)"))
     end

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -249,7 +249,7 @@ RSpec.describe "bundle gem" do
       load_paths = [lib_dir, spec_dir]
       load_path_str = "-I#{load_paths.join(File::PATH_SEPARATOR)}"
 
-      sys_exec! "#{Gem.ruby} #{load_path_str} #{bindir.join("bundle")} gem #{gem_name}", :env => { "PATH" => "" }
+      sys_exec "#{Gem.ruby} #{load_path_str} #{bindir.join("bundle")} gem #{gem_name}", :env => { "PATH" => "" }
     end
 
     it "creates the gem without the need for git" do

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "bundle gem" do
   describe "git repo initialization" do
     shared_examples_for "a gem with an initial git repo" do
       before do
-        bundle! "gem #{gem_name} #{flags}"
+        bundle "gem #{gem_name} #{flags}"
       end
 
       it "generates a gem skeleton with a .git folder", :readline do
@@ -83,7 +83,7 @@ RSpec.describe "bundle gem" do
 
     context "when passing --no-git", :readline do
       before do
-        bundle! "gem #{gem_name} --no-git"
+        bundle "gem #{gem_name} --no-git"
       end
       it "generates a gem skeleton without a .git folder" do
         gem_skeleton_assertions
@@ -94,7 +94,7 @@ RSpec.describe "bundle gem" do
 
   shared_examples_for "--mit flag" do
     before do
-      bundle! "gem #{gem_name} --mit"
+      bundle "gem #{gem_name} --mit"
     end
     it "generates a gem skeleton with MIT license" do
       gem_skeleton_assertions
@@ -105,7 +105,7 @@ RSpec.describe "bundle gem" do
 
   shared_examples_for "--no-mit flag" do
     before do
-      bundle! "gem #{gem_name} --no-mit"
+      bundle "gem #{gem_name} --no-mit"
     end
     it "generates a gem skeleton without MIT license" do
       gem_skeleton_assertions
@@ -115,7 +115,7 @@ RSpec.describe "bundle gem" do
 
   shared_examples_for "--coc flag" do
     before do
-      bundle! "gem #{gem_name} --coc"
+      bundle "gem #{gem_name} --coc"
     end
     it "generates a gem skeleton with MIT license" do
       gem_skeleton_assertions
@@ -132,7 +132,7 @@ RSpec.describe "bundle gem" do
 
   shared_examples_for "--no-coc flag" do
     before do
-      bundle! "gem #{gem_name} --no-coc"
+      bundle "gem #{gem_name} --no-coc"
     end
     it "generates a gem skeleton without Code of Conduct" do
       gem_skeleton_assertions
@@ -149,7 +149,7 @@ RSpec.describe "bundle gem" do
 
   shared_examples_for "--rubocop flag" do
     before do
-      bundle! "gem #{gem_name} --rubocop"
+      bundle "gem #{gem_name} --rubocop"
     end
 
     it "generates a gem skeleton with rubocop" do
@@ -175,7 +175,7 @@ RSpec.describe "bundle gem" do
     define_negated_matcher :exclude, :include
 
     before do
-      bundle! "gem #{gem_name} --no-rubocop"
+      bundle "gem #{gem_name} --no-rubocop"
     end
 
     it "generates a gem skeleton without rubocop" do
@@ -216,7 +216,7 @@ RSpec.describe "bundle gem" do
   context "README.md", :readline do
     context "git config github.user present" do
       before do
-        bundle! "gem #{gem_name}"
+        bundle "gem #{gem_name}"
       end
 
       it "contribute URL set to git username" do
@@ -228,7 +228,7 @@ RSpec.describe "bundle gem" do
     context "git config github.user is absent" do
       before do
         sys_exec("git config --unset github.user")
-        bundle! "gem #{gem_name}"
+        bundle "gem #{gem_name}"
       end
 
       it "contribute URL set to [USERNAME]" do
@@ -239,7 +239,7 @@ RSpec.describe "bundle gem" do
   end
 
   it "creates a new git repository", :readline do
-    bundle! "gem #{gem_name}"
+    bundle "gem #{gem_name}"
     expect(bundled_app("#{gem_name}/.git")).to exist
   end
 
@@ -266,14 +266,14 @@ RSpec.describe "bundle gem" do
   end
 
   it "generates a valid gemspec", :readline, :ruby_repo do
-    bundle! "gem newgem --bin"
+    bundle "gem newgem --bin"
 
     prepare_gemspec(bundled_app("newgem", "newgem.gemspec"))
 
     gems = ["rake-13.0.1"]
     path = Bundler.feature_flag.default_install_uses_path? ? local_gem_path(:base => bundled_app("newgem")) : system_gem_path
     system_gems gems, :path => path
-    bundle! "exec rake build", :dir => bundled_app("newgem")
+    bundle "exec rake build", :dir => bundled_app("newgem")
 
     expect(last_command.stdboth).not_to include("ERROR")
   end
@@ -282,7 +282,7 @@ RSpec.describe "bundle gem" do
     it "resolves ." do
       create_temporary_dir("tmp")
 
-      bundle! "gem .", :dir => bundled_app("tmp")
+      bundle "gem .", :dir => bundled_app("tmp")
 
       expect(bundled_app("tmp/lib/tmp.rb")).to exist
     end
@@ -290,7 +290,7 @@ RSpec.describe "bundle gem" do
     it "resolves .." do
       create_temporary_dir("temp/empty_dir")
 
-      bundle! "gem ..", :dir => bundled_app("temp/empty_dir")
+      bundle "gem ..", :dir => bundled_app("temp/empty_dir")
 
       expect(bundled_app("temp/lib/temp.rb")).to exist
     end
@@ -298,7 +298,7 @@ RSpec.describe "bundle gem" do
     it "resolves relative directory" do
       create_temporary_dir("tmp/empty/tmp")
 
-      bundle! "gem ../../empty", :dir => bundled_app("tmp/empty/tmp")
+      bundle "gem ../../empty", :dir => bundled_app("tmp/empty/tmp")
 
       expect(bundled_app("tmp/empty/lib/empty.rb")).to exist
     end
@@ -310,7 +310,7 @@ RSpec.describe "bundle gem" do
 
   shared_examples_for "generating a gem" do
     it "generates a gem skeleton" do
-      bundle! "gem #{gem_name}"
+      bundle "gem #{gem_name}"
 
       expect(bundled_app("#{gem_name}/#{gem_name}.gemspec")).to exist
       expect(bundled_app("#{gem_name}/Gemfile")).to exist
@@ -326,14 +326,14 @@ RSpec.describe "bundle gem" do
     end
 
     it "starts with version 0.1.0" do
-      bundle! "gem #{gem_name}"
+      bundle "gem #{gem_name}"
 
       expect(bundled_app("#{gem_name}/lib/#{require_path}/version.rb").read).to match(/VERSION = "0.1.0"/)
     end
 
     context "git config user.{name,email} is set" do
       before do
-        bundle! "gem #{gem_name}"
+        bundle "gem #{gem_name}"
       end
 
       it_should_behave_like "git config is present"
@@ -343,21 +343,21 @@ RSpec.describe "bundle gem" do
       before do
         sys_exec("git config --unset user.name", :dir => bundled_app)
         sys_exec("git config --unset user.email", :dir => bundled_app)
-        bundle! "gem #{gem_name}"
+        bundle "gem #{gem_name}"
       end
 
       it_should_behave_like "git config is absent"
     end
 
     it "sets gemspec metadata['allowed_push_host']" do
-      bundle! "gem #{gem_name}"
+      bundle "gem #{gem_name}"
 
       expect(generated_gemspec.metadata["allowed_push_host"]).
         to match(/mygemserver\.com/)
     end
 
     it "sets a minimum ruby version" do
-      bundle! "gem #{gem_name}"
+      bundle "gem #{gem_name}"
 
       bundler_gemspec = Bundler::GemHelper.new(gemspec_dir).gemspec
 
@@ -365,19 +365,19 @@ RSpec.describe "bundle gem" do
     end
 
     it "requires the version file" do
-      bundle! "gem #{gem_name}"
+      bundle "gem #{gem_name}"
 
       expect(bundled_app("#{gem_name}/lib/#{require_path}.rb").read).to match(%r{require "#{require_path}/version"})
     end
 
     it "creates a base error class" do
-      bundle! "gem #{gem_name}"
+      bundle "gem #{gem_name}"
 
       expect(bundled_app("#{gem_name}/lib/#{require_path}.rb").read).to match(/class Error < StandardError; end$/)
     end
 
     it "runs rake without problems" do
-      bundle! "gem #{gem_name}"
+      bundle "gem #{gem_name}"
 
       system_gems ["rake-13.0.1"]
 
@@ -396,7 +396,7 @@ RSpec.describe "bundle gem" do
 
     context "--exe parameter set" do
       before do
-        bundle! "gem #{gem_name} --exe"
+        bundle "gem #{gem_name} --exe"
       end
 
       it "builds exe skeleton" do
@@ -410,7 +410,7 @@ RSpec.describe "bundle gem" do
 
     context "--bin parameter set" do
       before do
-        bundle! "gem #{gem_name} --bin"
+        bundle "gem #{gem_name} --bin"
       end
 
       it "builds exe skeleton" do
@@ -424,7 +424,7 @@ RSpec.describe "bundle gem" do
 
     context "no --test parameter" do
       before do
-        bundle! "gem #{gem_name}"
+        bundle "gem #{gem_name}"
       end
 
       it_behaves_like "test framework is absent"
@@ -432,7 +432,7 @@ RSpec.describe "bundle gem" do
 
     context "--test parameter set to rspec" do
       before do
-        bundle! "gem #{gem_name} --test=rspec"
+        bundle "gem #{gem_name} --test=rspec"
       end
 
       it "builds spec skeleton" do
@@ -461,8 +461,8 @@ RSpec.describe "bundle gem" do
 
     context "gem.test setting set to rspec" do
       before do
-        bundle! "config set gem.test rspec"
-        bundle! "gem #{gem_name}"
+        bundle "config set gem.test rspec"
+        bundle "gem #{gem_name}"
       end
 
       it "builds spec skeleton" do
@@ -474,8 +474,8 @@ RSpec.describe "bundle gem" do
 
     context "gem.test setting set to rspec and --test is set to minitest" do
       before do
-        bundle! "config set gem.test rspec"
-        bundle! "gem #{gem_name} --test=minitest"
+        bundle "config set gem.test rspec"
+        bundle "gem #{gem_name} --test=minitest"
       end
 
       it "builds spec skeleton" do
@@ -486,7 +486,7 @@ RSpec.describe "bundle gem" do
 
     context "--test parameter set to minitest" do
       before do
-        bundle! "gem #{gem_name} --test=minitest"
+        bundle "gem #{gem_name} --test=minitest"
       end
 
       it "depends on a specific version of minitest" do
@@ -518,8 +518,8 @@ RSpec.describe "bundle gem" do
 
     context "gem.test setting set to minitest" do
       before do
-        bundle! "config set gem.test minitest"
-        bundle! "gem #{gem_name}"
+        bundle "config set gem.test minitest"
+        bundle "gem #{gem_name}"
       end
 
       it "creates a default rake task to run the test suite" do
@@ -542,7 +542,7 @@ RSpec.describe "bundle gem" do
 
     context "--test parameter set to test-unit" do
       before do
-        bundle! "gem #{gem_name} --test=test-unit"
+        bundle "gem #{gem_name} --test=test-unit"
       end
 
       it "depends on a specific version of test-unit" do
@@ -574,8 +574,8 @@ RSpec.describe "bundle gem" do
 
     context "gem.test setting set to test-unit" do
       before do
-        bundle! "config set gem.test test-unit"
-        bundle! "gem #{gem_name}"
+        bundle "config set gem.test test-unit"
+        bundle "gem #{gem_name}"
       end
 
       it "creates a default rake task to run the test suite" do
@@ -598,8 +598,8 @@ RSpec.describe "bundle gem" do
 
     context "gem.test set to rspec and --test with no arguments", :hint_text do
       before do
-        bundle! "config set gem.test rspec"
-        bundle! "gem #{gem_name} --test"
+        bundle "config set gem.test rspec"
+        bundle "gem #{gem_name} --test"
       end
 
       it "builds spec skeleton" do
@@ -615,8 +615,8 @@ RSpec.describe "bundle gem" do
 
     context "gem.test setting set to false and --test with no arguments", :hint_text do
       before do
-        bundle! "config set gem.test false"
-        bundle! "gem #{gem_name} --test"
+        bundle "config set gem.test false"
+        bundle "gem #{gem_name} --test"
       end
 
       it "asks to generate test files" do
@@ -632,7 +632,7 @@ RSpec.describe "bundle gem" do
 
     context "gem.test setting not set and --test with no arguments", :hint_text do
       before do
-        bundle! "gem #{gem_name} --test"
+        bundle "gem #{gem_name} --test"
       end
 
       it "asks to generate test files" do
@@ -650,7 +650,7 @@ RSpec.describe "bundle gem" do
 
     context "--ci with no argument" do
       it "does not generate any CI config" do
-        bundle! "gem #{gem_name}"
+        bundle "gem #{gem_name}"
 
         expect(bundled_app("#{gem_name}/.github/workflows/main.yml")).to_not exist
         expect(bundled_app("#{gem_name}/.travis.yml")).to_not exist
@@ -661,7 +661,7 @@ RSpec.describe "bundle gem" do
 
     context "--ci set to github" do
       it "generates a GitHub Actions config file" do
-        bundle! "gem #{gem_name} --ci=github"
+        bundle "gem #{gem_name} --ci=github"
 
         expect(bundled_app("#{gem_name}/.github/workflows/main.yml")).to exist
       end
@@ -669,7 +669,7 @@ RSpec.describe "bundle gem" do
 
     context "--ci set to gitlab" do
       it "generates a GitLab CI config file" do
-        bundle! "gem #{gem_name} --ci=gitlab"
+        bundle "gem #{gem_name} --ci=gitlab"
 
         expect(bundled_app("#{gem_name}/.gitlab-ci.yml")).to exist
       end
@@ -677,7 +677,7 @@ RSpec.describe "bundle gem" do
 
     context "--ci set to circle" do
       it "generates a CircleCI config file" do
-        bundle! "gem #{gem_name} --ci=circle"
+        bundle "gem #{gem_name} --ci=circle"
 
         expect(bundled_app("#{gem_name}/.circleci/config.yml")).to exist
       end
@@ -685,7 +685,7 @@ RSpec.describe "bundle gem" do
 
     context "--ci set to travis" do
       it "generates a Travis CI config file" do
-        bundle! "gem #{gem_name} --ci=travis"
+        bundle "gem #{gem_name} --ci=travis"
 
         expect(bundled_app("#{gem_name}/.travis.yml")).to exist
       end
@@ -702,8 +702,8 @@ RSpec.describe "bundle gem" do
 
     context "gem.ci setting set to github" do
       it "generates a GitHub Actions config file" do
-        bundle! "config set gem.ci github"
-        bundle! "gem #{gem_name}"
+        bundle "config set gem.ci github"
+        bundle "gem #{gem_name}"
 
         expect(bundled_app("#{gem_name}/.github/workflows/main.yml")).to exist
       end
@@ -711,8 +711,8 @@ RSpec.describe "bundle gem" do
 
     context "gem.ci setting set to travis" do
       it "generates a Travis CI config file" do
-        bundle! "config set gem.ci travis"
-        bundle! "gem #{gem_name}"
+        bundle "config set gem.ci travis"
+        bundle "gem #{gem_name}"
 
         expect(bundled_app("#{gem_name}/.travis.yml")).to exist
       end
@@ -720,8 +720,8 @@ RSpec.describe "bundle gem" do
 
     context "gem.ci setting set to gitlab" do
       it "generates a GitLab CI config file" do
-        bundle! "config set gem.ci gitlab"
-        bundle! "gem #{gem_name}"
+        bundle "config set gem.ci gitlab"
+        bundle "gem #{gem_name}"
 
         expect(bundled_app("#{gem_name}/.gitlab-ci.yml")).to exist
       end
@@ -729,8 +729,8 @@ RSpec.describe "bundle gem" do
 
     context "gem.ci setting set to circle" do
       it "generates a CircleCI config file" do
-        bundle! "config set gem.ci circle"
-        bundle! "gem #{gem_name}"
+        bundle "config set gem.ci circle"
+        bundle "gem #{gem_name}"
 
         expect(bundled_app("#{gem_name}/.circleci/config.yml")).to exist
       end
@@ -738,8 +738,8 @@ RSpec.describe "bundle gem" do
 
     context "gem.ci set to github and --ci with no arguments", :hint_text do
       before do
-        bundle! "config set gem.ci github"
-        bundle! "gem #{gem_name} --ci"
+        bundle "config set gem.ci github"
+        bundle "gem #{gem_name} --ci"
       end
 
       it "generates a GitHub Actions config file" do
@@ -753,8 +753,8 @@ RSpec.describe "bundle gem" do
 
     context "gem.ci setting set to false and --ci with no arguments", :hint_text do
       before do
-        bundle! "config set gem.ci false"
-        bundle! "gem #{gem_name} --ci"
+        bundle "config set gem.ci false"
+        bundle "gem #{gem_name} --ci"
       end
 
       it "asks to setup CI" do
@@ -768,7 +768,7 @@ RSpec.describe "bundle gem" do
 
     context "gem.ci setting not set and --ci with no arguments", :hint_text do
       before do
-        bundle! "gem #{gem_name} --ci"
+        bundle "gem #{gem_name} --ci"
       end
 
       it "asks to setup CI" do
@@ -784,7 +784,7 @@ RSpec.describe "bundle gem" do
 
     context "--edit option" do
       it "opens the generated gemspec in the user's text editor" do
-        output = bundle! "gem #{gem_name} --edit=echo"
+        output = bundle "gem #{gem_name} --edit=echo"
         gemspec_path = File.join(bundled_app, gem_name, "#{gem_name}.gemspec")
         expect(output).to include("echo \"#{gemspec_path}\"")
       end
@@ -853,7 +853,7 @@ RSpec.describe "bundle gem" do
     let(:flags) { nil }
 
     it "does not nest constants" do
-      bundle! ["gem", gem_name, flags].compact.join(" ")
+      bundle ["gem", gem_name, flags].compact.join(" ")
       expect(bundled_app("#{gem_name}/lib/#{require_path}/version.rb").read).to match(/module TestGem/)
       expect(bundled_app("#{gem_name}/lib/#{require_path}.rb").read).to match(/module TestGem/)
     end
@@ -864,7 +864,7 @@ RSpec.describe "bundle gem" do
       let(:flags) { "--ext" }
 
       before do
-        bundle! ["gem", gem_name, flags].compact.join(" ")
+        bundle ["gem", gem_name, flags].compact.join(" ")
       end
 
       it "builds ext skeleton" do
@@ -902,7 +902,7 @@ RSpec.describe "bundle gem" do
     let(:require_path) { "test/gem" }
 
     it "nests constants so they work" do
-      bundle! "gem #{gem_name}"
+      bundle "gem #{gem_name}"
       expect(bundled_app("#{gem_name}/lib/#{require_path}/version.rb").read).to match(/module Test\n  module Gem/)
       expect(bundled_app("#{gem_name}/lib/#{require_path}.rb").read).to match(/module Test\n  module Gem/)
     end
@@ -912,7 +912,7 @@ RSpec.describe "bundle gem" do
 
   describe "uncommon gem names" do
     it "can deal with two dashes", :readline do
-      bundle! "gem a--a"
+      bundle "gem a--a"
 
       expect(bundled_app("a--a/a--a.gemspec")).to exist
     end
@@ -971,7 +971,7 @@ Usage: "bundle gem NAME [OPTIONS]"
     it "asks about test framework" do
       global_config "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__COC" => "false"
 
-      bundle! "gem foobar" do |input, _, _|
+      bundle "gem foobar" do |input, _, _|
         input.puts "rspec"
       end
 
@@ -992,7 +992,7 @@ Usage: "bundle gem NAME [OPTIONS]"
     it "asks about CI service" do
       global_config "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__COC" => "false", "BUNDLE_GEM__RUBOCOP" => "false"
 
-      bundle! "gem foobar" do |input, _, _|
+      bundle "gem foobar" do |input, _, _|
         input.puts "github"
       end
 
@@ -1002,9 +1002,9 @@ Usage: "bundle gem NAME [OPTIONS]"
     it "asks about MIT license" do
       global_config "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__COC" => "false", "BUNDLE_GEM__CI" => "false", "BUNDLE_GEM__RUBOCOP" => "false"
 
-      bundle! "config list"
+      bundle "config list"
 
-      bundle! "gem foobar" do |input, _, _|
+      bundle "gem foobar" do |input, _, _|
         input.puts "yes"
       end
 
@@ -1014,7 +1014,7 @@ Usage: "bundle gem NAME [OPTIONS]"
     it "asks about CoC" do
       global_config "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__CI" => "false", "BUNDLE_GEM__RUBOCOP" => "false"
 
-      bundle! "gem foobar" do |input, _, _|
+      bundle "gem foobar" do |input, _, _|
         input.puts "yes"
       end
 
@@ -1034,7 +1034,7 @@ Usage: "bundle gem NAME [OPTIONS]"
   context "on conflicts with a previously created directory", :readline do
     it "should succeed" do
       FileUtils.mkdir_p(bundled_app("conflict-foobar/Gemfile"))
-      bundle! "gem conflict-foobar"
+      bundle "gem conflict-foobar"
       expect(out).to include("file_clash  conflict-foobar/Gemfile").
         and include "Initializing git repo in #{bundled_app("conflict-foobar")}"
     end

--- a/bundler/spec/commands/open_spec.rb
+++ b/bundler/spec/commands/open_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "bundle open" do
 
     it "allows selecting exit from many match gems", :readline do
       env = { "EDITOR" => "echo editor", "VISUAL" => "echo visual", "BUNDLER_EDITOR" => "echo bundler_editor" }
-      bundle! "open active", :env => env do |input, _, _|
+      bundle "open active", :env => env do |input, _, _|
         input.puts "0"
       end
     end

--- a/bundler/spec/commands/open_spec.rb
+++ b/bundler/spec/commands/open_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe "bundle open" do
 
   context "when opening a default gem" do
     let(:default_gems) do
-      ruby!(<<-RUBY).split("\n")
+      ruby(<<-RUBY).split("\n")
         if Gem::Specification.is_a?(Enumerable)
           puts Gem::Specification.select(&:default_gem?).map(&:name)
         end

--- a/bundler/spec/commands/outdated_spec.rb
+++ b/bundler/spec/commands/outdated_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe "bundle outdated" do
 
   describe "with --verbose option" do
     it "shows the location of the latest version's gemspec if installed" do
-      bundle! "config set clean false"
+      bundle "config set clean false"
 
       update_repo2 { build_gem "activesupport", "3.0" }
       update_repo2 { build_gem "terranova", "9" }
@@ -279,7 +279,7 @@ RSpec.describe "bundle outdated" do
         build_gem "activesupport", "2.3.4"
       end
 
-      bundle! "config set clean false"
+      bundle "config set clean false"
 
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
@@ -565,7 +565,7 @@ RSpec.describe "bundle outdated" do
         gem "rack"
         gem "foo"
       G
-      bundle! "config set deployment true"
+      bundle "config set deployment true"
     end
 
     it "outputs a helpful message about being in deployment mode" do

--- a/bundler/spec/commands/post_bundle_message_spec.rb
+++ b/bundler/spec/commands/post_bundle_message_spec.rb
@@ -30,21 +30,21 @@ RSpec.describe "post bundle message" do
       expect(out).to include(installed_gems_stats)
 
       bundle "config --local without emo"
-      bundle! :install
+      bundle :install
       expect(out).to include(bundle_show_message)
       expect(out).to include("Gems in the group emo were not installed")
       expect(out).to include(bundle_complete_message)
       expect(out).to include(installed_gems_stats)
 
       bundle "config --local without emo test"
-      bundle! :install
+      bundle :install
       expect(out).to include(bundle_show_message)
       expect(out).to include("Gems in the groups emo and test were not installed")
       expect(out).to include(bundle_complete_message)
       expect(out).to include("4 Gemfile dependencies, 3 gems now installed.")
 
       bundle "config --local without emo obama test"
-      bundle! :install
+      bundle :install
       expect(out).to include(bundle_show_message)
       expect(out).to include("Gems in the groups emo, obama and test were not installed")
       expect(out).to include(bundle_complete_message)
@@ -56,28 +56,28 @@ RSpec.describe "post bundle message" do
 
       it "shows proper messages according to the configured groups" do
         bundle "config --local path vendor"
-        bundle! :install
+        bundle :install
         expect(out).to include(bundle_show_path_message)
         expect(out).to_not include("Gems in the group")
         expect(out).to include(bundle_complete_message)
 
         bundle "config --local path vendor"
         bundle "config --local without emo"
-        bundle! :install
+        bundle :install
         expect(out).to include(bundle_show_path_message)
         expect(out).to include("Gems in the group emo were not installed")
         expect(out).to include(bundle_complete_message)
 
         bundle "config --local path vendor"
         bundle "config --local without emo test"
-        bundle! :install
+        bundle :install
         expect(out).to include(bundle_show_path_message)
         expect(out).to include("Gems in the groups emo and test were not installed")
         expect(out).to include(bundle_complete_message)
 
         bundle "config --local path vendor"
         bundle "config --local without emo obama test"
-        bundle! :install
+        bundle :install
         expect(out).to include(bundle_show_path_message)
         expect(out).to include("Gems in the groups emo, obama and test were not installed")
         expect(out).to include(bundle_complete_message)
@@ -89,7 +89,7 @@ RSpec.describe "post bundle message" do
 
       it "shows proper messages according to the configured groups" do
         bundle "config --local path #{bundle_path}"
-        bundle! :install
+        bundle :install
         expect(out).to include("Bundled gems are installed into `./cache`")
         expect(out).to_not include("Gems in the group")
         expect(out).to include(bundle_complete_message)
@@ -101,7 +101,7 @@ RSpec.describe "post bundle message" do
 
       it "shows proper messages according to the configured groups" do
         bundle "config --local path #{bundle_path}"
-        bundle! :install
+        bundle :install
         expect(out).to include("Bundled gems are installed into `#{tmp("not_bundled_app")}`")
         expect(out).to_not include("Gems in the group")
         expect(out).to include(bundle_complete_message)
@@ -162,8 +162,8 @@ The source does not contain any versions of 'not-a-gem'
     end
 
     it "with --without one group" do
-      bundle! "install --without emo"
-      bundle! :install
+      bundle "install --without emo"
+      bundle :install
       expect(out).to include(bundle_show_message)
       expect(out).to include("Gems in the group emo were not installed")
       expect(out).to include(bundle_complete_message)
@@ -171,15 +171,15 @@ The source does not contain any versions of 'not-a-gem'
     end
 
     it "with --without two groups" do
-      bundle! "install --without emo test"
-      bundle! :install
+      bundle "install --without emo test"
+      bundle :install
       expect(out).to include(bundle_show_message)
       expect(out).to include("Gems in the groups emo and test were not installed")
       expect(out).to include(bundle_complete_message)
     end
 
     it "with --without more groups" do
-      bundle! "install --without emo obama test"
+      bundle "install --without emo obama test"
       bundle :install
       expect(out).to include(bundle_show_message)
       expect(out).to include("Gems in the groups emo, obama and test were not installed")
@@ -189,25 +189,25 @@ The source does not contain any versions of 'not-a-gem'
 
   describe "for bundle update" do
     it "shows proper messages according to the configured groups" do
-      bundle! :update, :all => true
+      bundle :update, :all => true
       expect(out).not_to include("Gems in the groups")
       expect(out).to include(bundle_updated_message)
 
       bundle "config --local without emo"
-      bundle! :install
-      bundle! :update, :all => true
+      bundle :install
+      bundle :update, :all => true
       expect(out).to include("Gems in the group emo were not updated")
       expect(out).to include(bundle_updated_message)
 
       bundle "config --local without emo test"
-      bundle! :install
-      bundle! :update, :all => true
+      bundle :install
+      bundle :update, :all => true
       expect(out).to include("Gems in the groups emo and test were not updated")
       expect(out).to include(bundle_updated_message)
 
       bundle "config --local without emo obama test"
-      bundle! :install
-      bundle! :update, :all => true
+      bundle :install
+      bundle :update, :all => true
       expect(out).to include("Gems in the groups emo, obama and test were not updated")
       expect(out).to include(bundle_updated_message)
     end

--- a/bundler/spec/commands/pristine_spec.rb
+++ b/bundler/spec/commands/pristine_spec.rb
@@ -45,9 +45,9 @@ RSpec.describe "bundle pristine", :ruby_repo do
     end
 
     it "does not delete the bundler gem" do
-      bundle! "install"
-      bundle! "pristine"
-      bundle! "-v"
+      bundle "install"
+      bundle "pristine"
+      bundle "-v"
 
       expected = if Bundler::VERSION < "3.0"
         "Bundler version"
@@ -68,7 +68,7 @@ RSpec.describe "bundle pristine", :ruby_repo do
       File.open(changed_file, "a") {|f| f.puts diff }
       expect(File.read(changed_file)).to include(diff)
 
-      bundle! "pristine"
+      bundle "pristine"
       expect(File.read(changed_file)).to_not include(diff)
     end
 
@@ -79,7 +79,7 @@ RSpec.describe "bundle pristine", :ruby_repo do
       FileUtils.touch(changes_txt)
       expect(changes_txt).to be_file
 
-      bundle! "pristine"
+      bundle "pristine"
       expect(changes_txt).not_to be_file
     end
 
@@ -153,7 +153,7 @@ RSpec.describe "bundle pristine", :ruby_repo do
       FileUtils.touch(weakling_changes_txt)
       expect(weakling_changes_txt).to be_file
 
-      bundle! "pristine foo bar weakling"
+      bundle "pristine foo bar weakling"
 
       expect(err).to include("Cannot pristine bar (1.0). Gem is sourced from local path.")
       expect(out).to include("Installing weakling 1.0")
@@ -178,7 +178,7 @@ RSpec.describe "bundle pristine", :ruby_repo do
     # This just verifies that the generated Makefile from the c_ext gem makes
     # use of the build_args from the bundle config
     it "applies the config when installing the gem" do
-      bundle! "pristine"
+      bundle "pristine"
 
       makefile_contents = File.read(c_ext_dir.join("Makefile").to_s)
       expect(makefile_contents).to match(/libpath =.*#{c_ext_dir}/)
@@ -195,7 +195,7 @@ RSpec.describe "bundle pristine", :ruby_repo do
     # This just verifies that the generated Makefile from the c_ext gem makes
     # use of the build_args from the bundle config
     it "applies the config when installing the gem" do
-      bundle! "pristine"
+      bundle "pristine"
 
       makefile_contents = File.read(c_ext_dir.join("Makefile").to_s)
       expect(makefile_contents).to match(/libpath =.*#{c_ext_dir}/)

--- a/bundler/spec/commands/pristine_spec.rb
+++ b/bundler/spec/commands/pristine_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "bundle pristine", :ruby_repo do
       build_lib "bar", :path => lib_path("bar")
     end
 
-    install_gemfile! <<-G
+    install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}"
       gem "weakling"
       gem "very_simple_binary"

--- a/bundler/spec/commands/remove_spec.rb
+++ b/bundler/spec/commands/remove_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "bundle remove" do
         gem "rack"
       G
 
-      bundle! "remove rack --install"
+      bundle "remove rack --install"
 
       expect(out).to include("rack was removed.")
       expect(the_bundle).to_not include_gems "rack"
@@ -37,7 +37,7 @@ RSpec.describe "bundle remove" do
           gem "rack"
         G
 
-        bundle! "remove rack"
+        bundle "remove rack"
 
         expect(out).to include("rack was removed.")
         gemfile_should_be <<-G
@@ -57,7 +57,7 @@ RSpec.describe "bundle remove" do
             gem 'nokogiri'
           G
 
-          bundle! "remove rack"
+          bundle "remove rack"
 
           expect(out).to include("rack was removed.")
           gemfile_should_be <<-G
@@ -93,7 +93,7 @@ RSpec.describe "bundle remove" do
           gem "rails"
         G
 
-        bundle! "remove rack rails"
+        bundle "remove rack rails"
 
         expect(out).to include("rack was removed.")
         expect(out).to include("rails was removed.")
@@ -135,7 +135,7 @@ RSpec.describe "bundle remove" do
         gem "rack", :group => [:dev]
       G
 
-      bundle! "remove rack"
+      bundle "remove rack"
 
       expect(out).to include("rack was removed.")
       gemfile_should_be <<-G
@@ -155,7 +155,7 @@ RSpec.describe "bundle remove" do
           end
         G
 
-        bundle! "remove rspec"
+        bundle "remove rspec"
 
         expect(out).to include("rspec was removed.")
         gemfile_should_be <<-G
@@ -175,7 +175,7 @@ RSpec.describe "bundle remove" do
           end
         G
 
-        bundle! "remove rack"
+        bundle "remove rack"
 
         expect(out).to include("rack was removed.")
         gemfile_should_be <<-G
@@ -201,7 +201,7 @@ RSpec.describe "bundle remove" do
           end
         G
 
-        bundle! "remove rspec"
+        bundle "remove rspec"
 
         expect(out).to include("rspec was removed.")
         gemfile_should_be <<-G
@@ -220,7 +220,7 @@ RSpec.describe "bundle remove" do
           end
         G
 
-        bundle! "remove rspec"
+        bundle "remove rspec"
 
         expect(out).to include("rspec was removed.")
         gemfile_should_be <<-G
@@ -243,7 +243,7 @@ RSpec.describe "bundle remove" do
           end
         G
 
-        bundle! "remove rspec"
+        bundle "remove rspec"
 
         expect(out).to include("rspec was removed.")
         gemfile_should_be <<-G
@@ -266,7 +266,7 @@ RSpec.describe "bundle remove" do
           end
         G
 
-        bundle! "remove rspec"
+        bundle "remove rspec"
 
         expect(out).to include("rspec was removed.")
         gemfile_should_be <<-G
@@ -289,7 +289,7 @@ RSpec.describe "bundle remove" do
           end
         G
 
-        bundle! "remove rspec"
+        bundle "remove rspec"
 
         expect(out).to include("rspec was removed.")
         gemfile_should_be <<-G
@@ -316,7 +316,7 @@ RSpec.describe "bundle remove" do
           end
         G
 
-        bundle! "remove rspec"
+        bundle "remove rspec"
 
         expect(out).to include("rspec was removed.")
         gemfile_should_be <<-G
@@ -360,7 +360,7 @@ RSpec.describe "bundle remove" do
           gem "minitest"
         G
 
-        bundle! "remove rails rack rspec minitest"
+        bundle "remove rails rack rspec minitest"
 
         expect(out).to include("rails was removed.")
         expect(out).to include("minitest was removed.")
@@ -392,9 +392,9 @@ RSpec.describe "bundle remove" do
         end
       G
 
-      bundle! "install"
+      bundle "install"
 
-      bundle! "remove rspec"
+      bundle "remove rspec"
 
       expect(out).to include("rspec was removed.")
       gemfile_should_be <<-G
@@ -420,7 +420,7 @@ RSpec.describe "bundle remove" do
           gem "rack"
         G
 
-        bundle! "remove rack"
+        bundle "remove rack"
 
         expect(out).to include("rack was removed.")
       end
@@ -438,7 +438,7 @@ RSpec.describe "bundle remove" do
           eval_gemfile "Gemfile-other"
         G
 
-        bundle! "remove rack"
+        bundle "remove rack"
 
         expect(bundled_app("Gemfile-other").read).to_not include("gem \"rack\"")
         expect(out).to include("rack was removed.")
@@ -553,7 +553,7 @@ RSpec.describe "bundle remove" do
           gem"rack"
         G
 
-        bundle! "remove rack"
+        bundle "remove rack"
 
         expect(out).to include("rack was removed.")
         expect(bundled_app("Gemfile-other").read).to_not include("gem \"rack\"")
@@ -571,7 +571,7 @@ RSpec.describe "bundle remove" do
         end
       G
 
-      bundle! "remove rack"
+      bundle "remove rack"
 
       expect(out).to include("rack was removed.")
       gemfile_should_be <<-G
@@ -590,7 +590,7 @@ RSpec.describe "bundle remove" do
         end
       G
 
-      bundle! "remove rack"
+      bundle "remove rack"
 
       expect(out).to include("rack was removed.")
       gemfile_should_be <<-G
@@ -611,7 +611,7 @@ RSpec.describe "bundle remove" do
         gemspec :path => '#{tmp.join("foo")}', :name => 'foo'
       G
 
-      bundle! "remove foo"
+      bundle "remove foo"
 
       expect(out).to include("foo could not be removed.")
     end

--- a/bundler/spec/commands/show_spec.rb
+++ b/bundler/spec/commands/show_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
     it "creates a Gemfile.lock if one did not exist" do
       FileUtils.rm(bundled_app_lock)
 
-      bundle! "show"
+      bundle "show"
 
       expect(bundled_app_lock).to exist
     end
@@ -20,18 +20,18 @@ RSpec.describe "bundle show", :bundler => "< 3" do
     it "creates a Gemfile.lock when invoked with a gem name" do
       FileUtils.rm(bundled_app_lock)
 
-      bundle! "show rails"
+      bundle "show rails"
 
       expect(bundled_app_lock).to exist
     end
 
     it "prints path if gem exists in bundle" do
-      bundle! "show rails"
+      bundle "show rails"
       expect(out).to eq(default_bundle_path("gems", "rails-2.3.2").to_s)
     end
 
     it "prints path if gem exists in bundle (with --paths option)" do
-      bundle! "show rails --paths"
+      bundle "show rails --paths"
       expect(out).to eq(default_bundle_path("gems", "rails-2.3.2").to_s)
     end
 
@@ -45,7 +45,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
     end
 
     it "prints the path to the running bundler" do
-      bundle! "show bundler"
+      bundle "show bundler"
       expect(out).to eq(root.to_s)
     end
 
@@ -55,7 +55,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
     end
 
     it "prints path of all gems in bundle sorted by name" do
-      bundle! "show --paths"
+      bundle "show --paths"
 
       expect(out).to include(default_bundle_path("gems", "rake-13.0.1").to_s)
       expect(out).to include(default_bundle_path("gems", "rails-2.3.2").to_s)
@@ -66,7 +66,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
     end
 
     it "prints summary of gems" do
-      bundle! "show --verbose"
+      bundle "show --verbose"
 
       expect(out).to include <<~MSG
         * actionmailer (2.3.2)
@@ -77,7 +77,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
     end
 
     it "includes bundler in the summary of gems" do
-      bundle! "show --verbose"
+      bundle "show --verbose"
 
       expect(out).to include <<~MSG
         * bundler (#{Bundler::VERSION})
@@ -99,7 +99,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
       G
       expect(the_bundle).to include_gems "foo 1.0"
 
-      bundle! :show
+      bundle :show
       expect(out).to include("foo (1.0 #{@git.ref_for("master", 6)}")
     end
 
@@ -114,7 +114,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
       G
       expect(the_bundle).to include_gems "foo 1.0.omg"
 
-      bundle! :show
+      bundle :show
       expect(out).to include("foo (1.0 #{@git.ref_for("omg", 6)}")
     end
 
@@ -124,7 +124,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
         gem "foo", :git => "#{lib_path("foo-1.0")}", :ref => "#{sha}"
       G
 
-      bundle! :show
+      bundle :show
       expect(out).to include("foo (1.0 #{sha[0..6]})")
     end
 
@@ -135,7 +135,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
       G
       expect(the_bundle).to include_gems "foo 1.0.0.pre.beta.1"
 
-      bundle! :show
+      bundle :show
       expect(out).to include("foo (1.0.0.pre.beta.1")
     end
   end
@@ -160,7 +160,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
     G
 
     bundle "config set auto_install 1"
-    bundle! :show
+    bundle :show
     expect(out).to include("Installing foo 1.0")
   end
 
@@ -172,7 +172,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
         gem "rack-obama"
       G
 
-      bundle! "show rac"
+      bundle "show rac"
       expect(out).to eq "1 : rack\n2 : rack-obama\n0 : - exit -\n>"
     end
   end
@@ -211,9 +211,9 @@ RSpec.describe "bundle show", :bundler => "< 3" do
         end
       end
 
-      bundle! "show --outdated"
+      bundle "show --outdated"
 
-      bundle! "install"
+      bundle "install"
       expect(the_bundle).to include_gem("rails 2.3.2")
     end
   end

--- a/bundler/spec/commands/show_spec.rb
+++ b/bundler/spec/commands/show_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "bundle show", :bundler => "< 3" do
   context "with a standard Gemfile" do
     before :each do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rails"
       G
@@ -94,7 +94,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
     end
 
     it "prints out git info" do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         gem "foo", :git => "#{lib_path("foo-1.0")}"
       G
       expect(the_bundle).to include_gems "foo 1.0"
@@ -109,7 +109,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
       end
       @revision = revision_for(lib_path("foo-1.0"))[0...6]
 
-      install_gemfile! <<-G
+      install_gemfile <<-G
         gem "foo", :git => "#{lib_path("foo-1.0")}", :branch => "omg"
       G
       expect(the_bundle).to include_gems "foo 1.0.omg"
@@ -120,7 +120,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
 
     it "doesn't print the branch when tied to a ref" do
       sha = revision_for(lib_path("foo-1.0"))
-      install_gemfile! <<-G
+      install_gemfile <<-G
         gem "foo", :git => "#{lib_path("foo-1.0")}", :ref => "#{sha}"
       G
 
@@ -130,7 +130,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
 
     it "handles when a version is a '-' prerelease" do
       @git = build_git("foo", "1.0.0-beta.1", :path => lib_path("foo"))
-      install_gemfile! <<-G
+      install_gemfile <<-G
         gem "foo", "1.0.0-beta.1", :git => "#{lib_path("foo")}"
       G
       expect(the_bundle).to include_gems "foo 1.0.0.pre.beta.1"
@@ -166,7 +166,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
 
   context "with a valid regexp for gem name" do
     it "presents alternatives", :readline do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
         gem "rack-obama"
@@ -179,7 +179,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
 
   context "with an invalid regexp for gem name" do
     it "does not find the gem" do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rails"
       G
@@ -198,7 +198,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
     end
 
     it "doesn't update gems to newer versions" do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "rails"
       G

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "bundle update" do
         build_gem "activesupport", "3.0"
       end
 
-      bundle! "update", :all => true
+      bundle "update", :all => true
       expect(out).to include("Bundle updated!")
       expect(the_bundle).to include_gems "rack 1.2", "rack-obama 1.0", "activesupport 3.0"
     end
@@ -65,14 +65,14 @@ RSpec.describe "bundle update" do
         gem "rack", "1.0"
       G
 
-      bundle! "update --gemfile OmgFile", :all => true
+      bundle "update --gemfile OmgFile", :all => true
 
       expect(bundled_app("OmgFile.lock")).to exist
     end
   end
 
   context "when update_requires_all_flag is set" do
-    before { bundle! "config set update_requires_all_flag true" }
+    before { bundle "config set update_requires_all_flag true" }
 
     it "errors when passed nothing" do
       install_gemfile! ""
@@ -133,7 +133,7 @@ RSpec.describe "bundle update" do
   describe "when a possible resolve requires an older version of a locked gem" do
     context "and only_update_to_newer_versions is set" do
       before do
-        bundle! "config set only_update_to_newer_versions true"
+        bundle "config set only_update_to_newer_versions true"
       end
 
       it "does not go to an older version" do
@@ -167,7 +167,7 @@ RSpec.describe "bundle update" do
           end
         end
 
-        bundle! "update", :all => true
+        bundle "update", :all => true
 
         expect(the_bundle).to include_gems("slim 3.0.9", "slim-rails 3.1.3", "slim_lint 0.16.1")
       end
@@ -193,7 +193,7 @@ RSpec.describe "bundle update" do
           gem "b", "1.0"
         G
 
-        bundle! "update b"
+        bundle "update b"
 
         expect(the_bundle).to include_gems("a 1.0", "b 1.0")
       end
@@ -281,7 +281,7 @@ RSpec.describe "bundle update" do
 
   describe "in a frozen bundle" do
     it "should fail loudly", :bundler => "< 3" do
-      bundle! "install --deployment"
+      bundle "install --deployment"
       bundle "update", :all => true, :raise_on_error => false
 
       expect(last_command).to be_failure
@@ -290,14 +290,14 @@ RSpec.describe "bundle update" do
     end
 
     it "should suggest different command when frozen is set globally", :bundler => "< 3" do
-      bundle! "config set --global frozen 1"
+      bundle "config set --global frozen 1"
       bundle "update", :all => true, :raise_on_error => false
       expect(err).to match(/You are trying to install in deployment mode after changing.your Gemfile/m).
         and match(/freeze \nby running `bundle config unset frozen`./m)
     end
 
     it "should suggest different command when frozen is set globally", :bundler => "3" do
-      bundle! "config set --global deployment true"
+      bundle "config set --global deployment true"
       bundle "update", :all => true, :raise_on_error => false
       expect(err).to match(/You are trying to install in deployment mode after changing.your Gemfile/m).
         and match(/freeze \nby running `bundle config unset deployment`./m)
@@ -312,7 +312,7 @@ RSpec.describe "bundle update" do
       G
       update_repo2 { build_gem "activesupport", "3.0" }
 
-      bundle! "update --source activesupport"
+      bundle "update --source activesupport"
       expect(the_bundle).to include_gem "activesupport 3.0"
     end
 
@@ -323,12 +323,12 @@ RSpec.describe "bundle update" do
       G
       update_repo2 { build_gem "activesupport", "3.0" }
 
-      bundle! "update --source activesupport"
+      bundle "update --source activesupport"
       expect(the_bundle).not_to include_gem "activesupport 3.0"
     end
 
     context "with unlock_source_unlocks_spec set to false" do
-      before { bundle! "config set unlock_source_unlocks_spec false" }
+      before { bundle "config set unlock_source_unlocks_spec false" }
 
       it "should not update gems not included in the source that happen to have the same name" do
         install_gemfile <<-G
@@ -468,7 +468,7 @@ RSpec.describe "bundle update in more complicated situations" do
       build_gem "rack", "10.0"
     end
 
-    bundle! "update thin rack-obama"
+    bundle "update thin rack-obama"
     expect(last_command.stdboth).to include "Bundler attempted to update rack-obama but its version stayed the same"
     expect(the_bundle).to include_gems "thin 2.0", "rack 10.0", "rack-obama 1.0"
   end
@@ -484,7 +484,7 @@ RSpec.describe "bundle update in more complicated situations" do
       s.write "lib/foo2.rb", "puts :foo2"
     end
 
-    bundle! "update foo"
+    bundle "update foo"
 
     expect(last_command.stdboth).not_to include "attempted to update"
   end
@@ -501,7 +501,7 @@ RSpec.describe "bundle update in more complicated situations" do
       gem "rack"
     G
 
-    bundle! "update rack"
+    bundle "update rack"
 
     expect(last_command.stdboth).not_to include "attempted to update"
   end
@@ -554,12 +554,12 @@ RSpec.describe "bundle update in more complicated situations" do
     end
 
     it "allows updating" do
-      bundle! :update, :all => true
+      bundle :update, :all => true
       expect(the_bundle).to include_gem "a 1.1"
     end
 
     it "allows updating a specific gem" do
-      bundle! "update a"
+      bundle "update a"
       expect(the_bundle).to include_gem "a 1.1"
     end
   end
@@ -593,7 +593,7 @@ RSpec.describe "bundle update in more complicated situations" do
     end
 
     it "is not updated because it is not actually included in the bundle" do
-      bundle! "update a"
+      bundle "update a"
       expect(last_command.stdboth).to include "Bundler attempted to update a but it was not considered because it is for a different platform from the current one"
       expect(the_bundle).to_not include_gem "a"
     end
@@ -638,7 +638,7 @@ RSpec.describe "bundle update when a gem depends on a newer version of bundler" 
   end
 
   it "should warn that the newer version of Bundler would conflict", :bundler => "3" do
-    bundle! "update", :all => true
+    bundle "update", :all => true
     expect(err).to include("rails (3.0.1) has dependency bundler").
       and include("so the dependency is being ignored")
     expect(the_bundle).to include_gem "rails 3.0.1"
@@ -666,7 +666,7 @@ RSpec.describe "bundle update" do
   end
 
   context "with suppress_install_using_messages set" do
-    before { bundle! "config set suppress_install_using_messages true" }
+    before { bundle "config set suppress_install_using_messages true" }
 
     it "only prints `Using` for versions that have changed" do
       build_repo4 do
@@ -680,14 +680,14 @@ RSpec.describe "bundle update" do
         gem "foo"
       G
 
-      bundle! "update", :all => true
+      bundle "update", :all => true
       expect(out).to match(/Resolving dependencies\.\.\.\.*\nBundle updated!/)
 
       update_repo4 do
         build_gem "foo", "2.0"
       end
 
-      bundle! "update", :all => true
+      bundle "update", :all => true
       out.sub!("Removing foo (1.0)\n", "")
       expect(out).to match(/Resolving dependencies\.\.\.\.*\nFetching foo 2\.0 \(was 1\.0\)\nInstalling foo 2\.0 \(was 1\.0\)\nBundle updated/)
     end
@@ -828,7 +828,7 @@ RSpec.describe "bundle update --bundler" do
 
     FileUtils.rm_r gem_repo4
 
-    bundle! :update, :bundler => true, :verbose => true
+    bundle :update, :bundler => true, :verbose => true
     expect(the_bundle).to include_gem "rack 1.0"
 
     expect(the_bundle.locked_gems.bundler_version).to eq v(Bundler::VERSION)
@@ -872,8 +872,8 @@ RSpec.describe "bundle update conservative" do
 
     context "with patch set as default update level in config" do
       it "should do a patch level update" do
-        bundle! "config set --local prefer_patch true"
-        bundle! "update foo"
+        bundle "config set --local prefer_patch true"
+        bundle "update foo"
 
         expect(the_bundle).to include_gems "foo 1.4.5", "bar 2.1.1", "qux 1.0.0"
       end
@@ -881,13 +881,13 @@ RSpec.describe "bundle update conservative" do
 
     context "patch preferred" do
       it "single gem updates dependent gem to minor" do
-        bundle! "update --patch foo"
+        bundle "update --patch foo"
 
         expect(the_bundle).to include_gems "foo 1.4.5", "bar 2.1.1", "qux 1.0.0"
       end
 
       it "update all" do
-        bundle! "update --patch", :all => true
+        bundle "update --patch", :all => true
 
         expect(the_bundle).to include_gems "foo 1.4.5", "bar 2.1.1", "qux 1.0.1"
       end
@@ -895,7 +895,7 @@ RSpec.describe "bundle update conservative" do
 
     context "minor preferred" do
       it "single gem updates dependent gem to major" do
-        bundle! "update --minor foo"
+        bundle "update --minor foo"
 
         expect(the_bundle).to include_gems "foo 1.5.1", "bar 3.0.0", "qux 1.0.0"
       end
@@ -903,13 +903,13 @@ RSpec.describe "bundle update conservative" do
 
     context "strict" do
       it "patch preferred" do
-        bundle! "update --patch foo bar --strict"
+        bundle "update --patch foo bar --strict"
 
         expect(the_bundle).to include_gems "foo 1.4.4", "bar 2.0.5", "qux 1.0.0"
       end
 
       it "minor preferred" do
-        bundle! "update --minor --strict", :all => true
+        bundle "update --minor --strict", :all => true
 
         expect(the_bundle).to include_gems "foo 1.5.0", "bar 2.1.1", "qux 1.1.0"
       end

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -75,19 +75,19 @@ RSpec.describe "bundle update" do
     before { bundle "config set update_requires_all_flag true" }
 
     it "errors when passed nothing" do
-      install_gemfile! ""
+      install_gemfile ""
       bundle :update, :raise_on_error => false
       expect(err).to eq("To update everything, pass the `--all` flag.")
     end
 
     it "errors when passed --all and another option" do
-      install_gemfile! ""
+      install_gemfile ""
       bundle "update --all foo", :raise_on_error => false
       expect(err).to eq("Cannot specify --all along with specific options.")
     end
 
     it "updates everything when passed --all" do
-      install_gemfile! ""
+      install_gemfile ""
       bundle "update --all"
       expect(out).to include("Bundle updated!")
     end
@@ -153,7 +153,7 @@ RSpec.describe "bundle update" do
           end
         end
 
-        install_gemfile! <<-G
+        install_gemfile <<-G
           source "#{file_uri_for(gem_repo4)}"
           gem "slim-rails"
           gem "slim_lint"
@@ -179,7 +179,7 @@ RSpec.describe "bundle update" do
           build_gem "b", "2.0"
         end
 
-        install_gemfile! <<-G
+        install_gemfile <<-G
           source "#{file_uri_for(gem_repo4)}"
           gem "a"
           gem "b"
@@ -306,7 +306,7 @@ RSpec.describe "bundle update" do
 
   describe "with --source option" do
     it "should not update gems not included in the source that happen to have the same name", :bundler => "< 3" do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "activesupport"
       G
@@ -317,7 +317,7 @@ RSpec.describe "bundle update" do
     end
 
     it "should not update gems not included in the source that happen to have the same name", :bundler => "3" do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "activesupport"
       G
@@ -456,7 +456,7 @@ RSpec.describe "bundle update in more complicated situations" do
   end
 
   it "will warn when some explicitly updated gems are not updated" do
-    install_gemfile! <<-G
+    install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}"
 
       gem "thin"
@@ -476,7 +476,7 @@ RSpec.describe "bundle update in more complicated situations" do
   it "will not warn when an explicitly updated git gem changes sha but not version" do
     build_git "foo"
 
-    install_gemfile! <<-G
+    install_gemfile <<-G
       gem "foo", :git => '#{lib_path("foo-1.0")}'
     G
 
@@ -492,7 +492,7 @@ RSpec.describe "bundle update in more complicated situations" do
   it "will not warn when changing gem sources but not versions" do
     build_git "rack"
 
-    install_gemfile! <<-G
+    install_gemfile <<-G
       gem "rack", :git => '#{lib_path("rack-1.0")}'
     G
 
@@ -674,7 +674,7 @@ RSpec.describe "bundle update" do
         build_gem "foo"
       end
 
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo4)}"
         gem "bar"
         gem "foo"
@@ -819,7 +819,7 @@ RSpec.describe "bundle update --bundler" do
       build_gem "rack", "1.0"
     end
 
-    install_gemfile! <<-G
+    install_gemfile <<-G
       source "#{file_uri_for(gem_repo4)}"
       gem "rack"
     G

--- a/bundler/spec/commands/version_spec.rb
+++ b/bundler/spec/commands/version_spec.rb
@@ -11,36 +11,36 @@ RSpec.describe "bundle version" do
 
   context "with -v" do
     it "outputs the version", :bundler => "< 3" do
-      bundle! "-v"
+      bundle "-v"
       expect(out).to eq("Bundler version #{Bundler::VERSION}")
     end
 
     it "outputs the version", :bundler => "3" do
-      bundle! "-v"
+      bundle "-v"
       expect(out).to eq(Bundler::VERSION)
     end
   end
 
   context "with --version" do
     it "outputs the version", :bundler => "< 3" do
-      bundle! "--version"
+      bundle "--version"
       expect(out).to eq("Bundler version #{Bundler::VERSION}")
     end
 
     it "outputs the version", :bundler => "3" do
-      bundle! "--version"
+      bundle "--version"
       expect(out).to eq(Bundler::VERSION)
     end
   end
 
   context "with version" do
     it "outputs the version with build metadata", :bundler => "< 3" do
-      bundle! "version"
+      bundle "version"
       expect(out).to match(/\ABundler version #{Regexp.escape(Bundler::VERSION)} \(\d{4}-\d{2}-\d{2} commit #{COMMIT_HASH}\)\z/)
     end
 
     it "outputs the version with build metadata", :bundler => "3" do
-      bundle! "version"
+      bundle "version"
       expect(out).to match(/\A#{Regexp.escape(Bundler::VERSION)} \(\d{4}-\d{2}-\d{2} commit #{COMMIT_HASH}\)\z/)
     end
   end

--- a/bundler/spec/commands/viz_spec.rb
+++ b/bundler/spec/commands/viz_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe "bundle viz", :bundler => "< 3", :if => Bundler.which("dot") do
       gem "rack-obama"
     G
 
-    bundle! "viz"
+    bundle "viz"
     expect(out).to include("gem_graph.png")
 
-    bundle! "viz", :format => "debug"
+    bundle "viz", :format => "debug"
     expect(out).to eq(strip_whitespace(<<-DOT).strip)
       digraph Gemfile {
       concentrate = "true";
@@ -48,10 +48,10 @@ RSpec.describe "bundle viz", :bundler => "< 3", :if => Bundler.which("dot") do
       gem "rack-obama"
     G
 
-    bundle! "viz"
+    bundle "viz"
     expect(out).to include("gem_graph.png")
 
-    bundle! "viz", :format => :debug, :version => true
+    bundle "viz", :format => :debug, :version => true
     expect(out).to eq(strip_whitespace(<<-EOS).strip)
       digraph Gemfile {
       concentrate = "true";
@@ -89,7 +89,7 @@ RSpec.describe "bundle viz", :bundler => "< 3", :if => Bundler.which("dot") do
         gem "rack-obama"
       G
 
-      bundle! "viz", :format => "debug"
+      bundle "viz", :format => "debug"
       expect(out).to eq(strip_whitespace(<<-DOT).strip)
         digraph Gemfile {
         concentrate = "true";
@@ -121,7 +121,7 @@ RSpec.describe "bundle viz", :bundler => "< 3", :if => Bundler.which("dot") do
         end
       G
 
-      bundle! "viz --without=rails"
+      bundle "viz --without=rails"
       expect(out).to include("gem_graph.png")
     end
 
@@ -139,7 +139,7 @@ RSpec.describe "bundle viz", :bundler => "< 3", :if => Bundler.which("dot") do
         end
       G
 
-      bundle! "viz --without=rails:rack"
+      bundle "viz --without=rails:rack"
       expect(out).to include("gem_graph.png")
     end
   end

--- a/bundler/spec/install/allow_offline_install_spec.rb
+++ b/bundler/spec/install/allow_offline_install_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "bundle install with :allow_offline_install" do
 
   context "with no cached data locally" do
     it "still installs" do
-      install_gemfile! <<-G, :artifice => "compact_index"
+      install_gemfile <<-G, :artifice => "compact_index"
         source "http://testgemserver.local"
         gem "rack-obama"
       G
@@ -29,7 +29,7 @@ RSpec.describe "bundle install with :allow_offline_install" do
       system_gems ["rack-1.0.0"], :path => default_bundle_path
 
       bundle "config set clean false"
-      install_gemfile! <<-G, :artifice => "compact_index"
+      install_gemfile <<-G, :artifice => "compact_index"
         source "http://testgemserver.local"
         gem "rack-obama"
         gem "rack", "< 1.0"
@@ -74,7 +74,7 @@ RSpec.describe "bundle install with :allow_offline_install" do
 
       git = build_git "a", "1.0.0", :path => lib_path("a")
       update_git("a", :path => git.path, :branch => "new_branch")
-      install_gemfile! <<-G
+      install_gemfile <<-G
         gem "a", :git => #{git.path.to_s.dump}
       G
 
@@ -83,7 +83,7 @@ RSpec.describe "bundle install with :allow_offline_install" do
       expect(the_bundle).to be_locked
 
       break_git_remote_ops! do
-        install_gemfile! <<-G
+        install_gemfile <<-G
           gem "a", :git => #{git.path.to_s.dump}, :branch => "new_branch"
         G
       end

--- a/bundler/spec/install/allow_offline_install_spec.rb
+++ b/bundler/spec/install/allow_offline_install_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "bundle install with :allow_offline_install" do
     it "will install from the compact index" do
       system_gems ["rack-1.0.0"], :path => default_bundle_path
 
-      bundle! "config set clean false"
+      bundle "config set clean false"
       install_gemfile! <<-G, :artifice => "compact_index"
         source "http://testgemserver.local"
         gem "rack-obama"
@@ -42,7 +42,7 @@ RSpec.describe "bundle install with :allow_offline_install" do
         gem "rack-obama"
       G
 
-      bundle! :update, :artifice => "fail", :all => true
+      bundle :update, :artifice => "fail", :all => true
       expect(last_command.stdboth).to include "Using the cached data for the new index because of a network error"
 
       expect(the_bundle).to include_gems("rack-obama 1.0", "rack 1.0.0")
@@ -78,7 +78,7 @@ RSpec.describe "bundle install with :allow_offline_install" do
         gem "a", :git => #{git.path.to_s.dump}
       G
 
-      break_git_remote_ops! { bundle! :update, :all => true }
+      break_git_remote_ops! { bundle :update, :all => true }
       expect(err).to include("Using cached git data because of network errors")
       expect(the_bundle).to be_locked
 

--- a/bundler/spec/install/binstubs_spec.rb
+++ b/bundler/spec/install/binstubs_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "bundle install" do
     end
 
     it "warns about the situation" do
-      bundle! "exec rackup"
+      bundle "exec rackup"
 
       expect(last_command.stderr).to include(
         "The `rackup` executable in the `fake` gem is being loaded, but it's also present in other gems (rack).\n" \

--- a/bundler/spec/install/bundler_spec.rb
+++ b/bundler/spec/install/bundler_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe "bundle install" do
     end
 
     it "can install dependencies with newer bundler version with system gems" do
-      bundle! "config set path.system true"
+      bundle "config set path.system true"
 
       system_gems "bundler-99999999.99.1"
 
@@ -156,12 +156,12 @@ RSpec.describe "bundle install" do
         gem "rails", "3.0"
       G
 
-      bundle! "check"
+      bundle "check"
       expect(out).to include("The Gemfile's dependencies are satisfied")
     end
 
     it "can install dependencies with newer bundler version with a local path" do
-      bundle! "config set path .bundle"
+      bundle "config set path .bundle"
 
       system_gems "bundler-99999999.99.1"
 
@@ -170,12 +170,12 @@ RSpec.describe "bundle install" do
         gem "rails", "3.0"
       G
 
-      bundle! "check"
+      bundle "check"
       expect(out).to include("The Gemfile's dependencies are satisfied")
     end
 
     context "with allow_bundler_dependency_conflicts set" do
-      before { bundle! "config set allow_bundler_dependency_conflicts true" }
+      before { bundle "config set allow_bundler_dependency_conflicts true" }
 
       it "are forced to the current bundler version with warnings when no compatible version is found" do
         build_repo4 do

--- a/bundler/spec/install/bundler_spec.rb
+++ b/bundler/spec/install/bundler_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe "bundle install" do
     end
 
     it "does not cause a conflict if new dependencies in the Gemfile require older dependencies than the lockfile" do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem 'rails', "2.3.2"
       G
@@ -151,7 +151,7 @@ RSpec.describe "bundle install" do
 
       system_gems "bundler-99999999.99.1"
 
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "rails", "3.0"
       G
@@ -165,7 +165,7 @@ RSpec.describe "bundle install" do
 
       system_gems "bundler-99999999.99.1"
 
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "rails", "3.0"
       G
@@ -184,7 +184,7 @@ RSpec.describe "bundle install" do
           end
         end
 
-        install_gemfile! <<-G
+        install_gemfile <<-G
           source "#{file_uri_for(gem_repo4)}"
           gem "requires_nonexistant_bundler"
         G

--- a/bundler/spec/install/deploy_spec.rb
+++ b/bundler/spec/install/deploy_spec.rb
@@ -36,17 +36,17 @@ RSpec.describe "install in deployment or frozen mode" do
 
     it "doesn't mess up a subsequent `bundle install` after you try to deploy without a lock" do
       bundle "install --deployment", :raise_on_error => false
-      bundle! :install
+      bundle :install
       expect(the_bundle).to include_gems "rack 1.0"
     end
   end
 
   it "still works if you are not in the app directory and specify --gemfile" do
-    bundle! "install"
+    bundle "install"
     simulate_new_machine
     bundle "config --local deployment true"
     bundle "config --local path vendor/bundle"
-    bundle! "install --gemfile #{tmp}/bundled_app/Gemfile", :dir => tmp
+    bundle "install --gemfile #{tmp}/bundled_app/Gemfile", :dir => tmp
     expect(the_bundle).to include_gems "rack 1.0"
   end
 
@@ -57,19 +57,19 @@ RSpec.describe "install in deployment or frozen mode" do
         gem "foo", :git => "#{lib_path("foo-1.0")}"
       end
     G
-    bundle! :install
+    bundle :install
     bundle "config --local deployment true"
     bundle "config --local without test"
-    bundle! :install
+    bundle :install
   end
 
   it "works when you bundle exec bundle", :ruby_repo do
     skip "doesn't find bundle" if Gem.win_platform?
 
-    bundle! :install
+    bundle :install
     bundle "config --local deployment true"
     bundle :install
-    bundle! "exec bundle check", :env => { "PATH" => path }
+    bundle "exec bundle check", :env => { "PATH" => path }
   end
 
   it "works when using path gems from the same path and the version is specified" do
@@ -80,9 +80,9 @@ RSpec.describe "install in deployment or frozen mode" do
       gem "bar", :path => "#{lib_path("nested")}"
     G
 
-    bundle! :install
+    bundle :install
     bundle "config --local deployment true"
-    bundle! :install
+    bundle :install
   end
 
   it "works when there are credentials in the source URL" do
@@ -93,7 +93,7 @@ RSpec.describe "install in deployment or frozen mode" do
     G
 
     bundle "config --local deployment true"
-    bundle! :install, :artifice => "endpoint_strict_basic_authentication"
+    bundle :install, :artifice => "endpoint_strict_basic_authentication"
   end
 
   it "works with sources given by a block" do
@@ -104,7 +104,7 @@ RSpec.describe "install in deployment or frozen mode" do
     G
 
     bundle "config --local deployment true"
-    bundle! :install
+    bundle :install
 
     expect(the_bundle).to include_gems "rack 1.0"
   end
@@ -112,7 +112,7 @@ RSpec.describe "install in deployment or frozen mode" do
   context "when replacing a host with the same host with credentials" do
     before do
       bundle "config --local path vendor/bundle"
-      bundle! "install"
+      bundle "install"
       gemfile <<-G
       source "http://user_name:password@localgemserver.test/"
       gem "rack"
@@ -131,7 +131,7 @@ RSpec.describe "install in deployment or frozen mode" do
         rack
       G
 
-      bundle! "config set --local deployment true"
+      bundle "config set --local deployment true"
     end
 
     it "prevents the replace by default" do
@@ -141,17 +141,17 @@ RSpec.describe "install in deployment or frozen mode" do
     end
 
     context "when allow_deployment_source_credential_changes is true" do
-      before { bundle! "config set allow_deployment_source_credential_changes true" }
+      before { bundle "config set allow_deployment_source_credential_changes true" }
 
       it "allows the replace" do
-        bundle! :install
+        bundle :install
 
         expect(out).to match(/Bundle complete!/)
       end
     end
 
     context "when allow_deployment_source_credential_changes is false" do
-      before { bundle! "config set allow_deployment_source_credential_changes false" }
+      before { bundle "config set allow_deployment_source_credential_changes false" }
 
       it "prevents the replace" do
         bundle :install, :raise_on_error => false
@@ -183,29 +183,29 @@ RSpec.describe "install in deployment or frozen mode" do
 
   describe "with an existing lockfile" do
     before do
-      bundle! "install"
+      bundle "install"
     end
 
     it "installs gems by default to vendor/bundle", :bundler => "< 3" do
-      bundle! "install --deployment"
+      bundle "install --deployment"
       expect(out).to include("vendor/bundle")
     end
 
     it "installs gems to custom path if specified", :bundler => "< 3" do
-      bundle! "install --path vendor/bundle2 --deployment"
+      bundle "install --path vendor/bundle2 --deployment"
       expect(out).to include("vendor/bundle2")
     end
 
     it "works with the --deployment flag if you didn't change anything", :bundler => "< 3" do
-      bundle! "install --deployment"
+      bundle "install --deployment"
     end
 
     it "works with the --frozen flag if you didn't change anything", :bundler => "< 3" do
-      bundle! "install --frozen"
+      bundle "install --frozen"
     end
 
     it "works with BUNDLE_FROZEN if you didn't change anything" do
-      bundle! :install, :env => { "BUNDLE_FROZEN" => "true" }
+      bundle :install, :env => { "BUNDLE_FROZEN" => "true" }
     end
 
     it "explodes with the --deployment flag if you make a change and don't check in the lockfile" do
@@ -237,7 +237,7 @@ RSpec.describe "install in deployment or frozen mode" do
       bundle "config --local path .bundle"
       bundle "config --local without development"
       bundle "config --local deployment true"
-      bundle! :install, :env => { "DEBUG" => "1" }
+      bundle :install, :env => { "DEBUG" => "1" }
       run! "puts :WIN"
       expect(out).to eq("WIN")
     end
@@ -391,9 +391,9 @@ RSpec.describe "install in deployment or frozen mode" do
     end
 
     it "remembers that the bundle is frozen at runtime" do
-      bundle! :lock
+      bundle :lock
 
-      bundle! "config set --local deployment true"
+      bundle "config set --local deployment true"
 
       gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
@@ -422,19 +422,19 @@ You have deleted from the Gemfile:
         gem "foo", :path => "#{lib_path("foo")}"
       G
 
-      bundle! :install
+      bundle :install
       expect(the_bundle).to include_gems "foo 1.0"
 
       bundle "config set cache_all true"
-      bundle! :cache
+      bundle :cache
       expect(bundled_app("vendor/cache/foo")).to be_directory
 
-      bundle! "install --local"
+      bundle "install --local"
       expect(out).to include("Updating files in vendor/cache")
 
       simulate_new_machine
-      bundle! "config set --local deployment true"
-      bundle! "install --verbose"
+      bundle "config set --local deployment true"
+      bundle "install --verbose"
       expect(out).not_to include("You are trying to install in deployment mode after changing your Gemfile")
       expect(out).not_to include("You have added to the Gemfile")
       expect(out).not_to include("You have deleted from the Gemfile")

--- a/bundler/spec/install/deploy_spec.rb
+++ b/bundler/spec/install/deploy_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe "install in deployment or frozen mode" do
   end
 
   it "works with sources given by a block" do
-    install_gemfile! <<-G
+    install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}" do
         gem "rack"
       end
@@ -226,7 +226,7 @@ RSpec.describe "install in deployment or frozen mode" do
 
     it "works if a path gem is missing but is in a without group" do
       build_lib "path_gem"
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rake"
         gem "path_gem", :path => "#{lib_path("path_gem-1.0")}", :group => :development
@@ -244,7 +244,7 @@ RSpec.describe "install in deployment or frozen mode" do
 
     it "explodes if a path gem is missing" do
       build_lib "path_gem"
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rake"
         gem "path_gem", :path => "#{lib_path("path_gem-1.0")}", :group => :development
@@ -418,7 +418,7 @@ You have deleted from the Gemfile:
   context "with path in Gemfile and packed" do
     it "works fine after bundle package and bundle install --local" do
       build_lib "foo", :path => lib_path("foo")
-      install_gemfile! <<-G
+      install_gemfile <<-G
         gem "foo", :path => "#{lib_path("foo")}"
       G
 

--- a/bundler/spec/install/deploy_spec.rb
+++ b/bundler/spec/install/deploy_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe "install in deployment or frozen mode" do
       bundle "config --local without development"
       bundle "config --local deployment true"
       bundle :install, :env => { "DEBUG" => "1" }
-      run! "puts :WIN"
+      run "puts :WIN"
       expect(out).to eq("WIN")
     end
 

--- a/bundler/spec/install/gemfile/eval_gemfile_spec.rb
+++ b/bundler/spec/install/gemfile/eval_gemfile_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "bundle install with gemfile that uses eval_gemfile" do
         source "#{file_uri_for(gem_repo1)}"
         eval_gemfile "other/Gemfile"
       G
-      install_gemfile! "eval_gemfile File.expand_path('Gemfile-alt')"
+      install_gemfile "eval_gemfile File.expand_path('Gemfile-alt')"
 
       expect(the_bundle).to include_gem "rack 1.0.0"
     end

--- a/bundler/spec/install/gemfile/eval_gemfile_spec.rb
+++ b/bundler/spec/install/gemfile/eval_gemfile_spec.rb
@@ -39,16 +39,16 @@ RSpec.describe "bundle install with gemfile that uses eval_gemfile" do
     end
 
     it "installs the path gem" do
-      bundle! :install
+      bundle :install
       expect(the_bundle).to include_gem("a 1.0")
     end
 
     # Make sure that we are properly comparing path based gems between the
     # parsed lockfile and the evaluated gemfile.
     it "bundles with deployment mode configured" do
-      bundle! :install
+      bundle :install
       bundle "config --local deployment true"
-      bundle! :install
+      bundle :install
     end
   end
 

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -255,7 +255,7 @@ RSpec.describe "bundle install from an existing gemspec" do
 
     expect(the_bundle).to include_gems "foo 1.0.0"
 
-    run! "Gem.finish_resolve; puts 'WIN'"
+    run "Gem.finish_resolve; puts 'WIN'"
     expect(out).to eq("WIN")
   end
 

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe "bundle install from an existing gemspec" do
       s.add_dependency "rack"
     end
 
-    install_gemfile! <<-G
+    install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
       gemspec :path => '#{tmp.join("foo")}'
     G
@@ -157,7 +157,7 @@ RSpec.describe "bundle install from an existing gemspec" do
       s.add_development_dependency "thin"
     end
 
-    install_gemfile! <<-G
+    install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
       gemspec :path => '#{tmp.join("foo")}'
     G
@@ -175,7 +175,7 @@ RSpec.describe "bundle install from an existing gemspec" do
 
     system_gems "platform_specific-1.0-java", :path => default_bundle_path
 
-    install_gemfile! <<-G
+    install_gemfile <<-G
       gemspec :path => '#{tmp.join("foo")}'
     G
 
@@ -209,7 +209,7 @@ RSpec.describe "bundle install from an existing gemspec" do
       f.write "#{gemspec.strip}.tap { gem 'rack-obama'; require 'rack/obama' }"
     end
 
-    install_gemfile! <<-G
+    install_gemfile <<-G
       gemspec
     G
 
@@ -247,7 +247,7 @@ RSpec.describe "bundle install from an existing gemspec" do
       build_gem "foo", "0.0.1"
     end
 
-    install_gemfile! <<-G
+    install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}"
       gem "deps"
       gemspec :path => '#{tmp.join("foo")}', :name => 'foo'
@@ -280,7 +280,7 @@ RSpec.describe "bundle install from an existing gemspec" do
           s.add_dependency "activesupport", ">= 1"
         end
 
-        install_gemfile! <<-G
+        install_gemfile <<-G
           source "#{file_uri_for(gem_repo1)}"
           gemspec
         G
@@ -549,7 +549,7 @@ RSpec.describe "bundle install from an existing gemspec" do
     it "installs the ruby platform gemspec" do
       simulate_platform "ruby"
 
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gemspec :path => '#{tmp.join("foo")}', :name => 'foo'
       G
@@ -561,7 +561,7 @@ RSpec.describe "bundle install from an existing gemspec" do
       simulate_platform "ruby"
 
       bundle "config --local without development"
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gemspec :path => '#{tmp.join("foo")}', :name => 'foo'
       G

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe "bundle install from an existing gemspec" do
       gemspec :path => '#{tmp.join("foo")}'
     G
 
-    bundle! "install", :verbose => true
+    bundle "install", :verbose => true
 
     message = "Found no changes, using resolution from the lockfile"
     expect(out.scan(message).size).to eq(1)
@@ -162,7 +162,7 @@ RSpec.describe "bundle install from an existing gemspec" do
       gemspec :path => '#{tmp.join("foo")}'
     G
 
-    bundle! "install", :verbose => true
+    bundle "install", :verbose => true
 
     message = "Found no changes, using resolution from the lockfile"
     expect(out.scan(message).size).to eq(1)
@@ -179,7 +179,7 @@ RSpec.describe "bundle install from an existing gemspec" do
       gemspec :path => '#{tmp.join("foo")}'
     G
 
-    bundle! "update --bundler", :verbose => true
+    bundle "update --bundler", :verbose => true
     expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 JAVA"
   end
 
@@ -268,7 +268,7 @@ RSpec.describe "bundle install from an existing gemspec" do
 
     build_lib "omg", "1.0", :path => lib_path("omg")
 
-    bundle! :install, :env => { "BUNDLE_BUNDLE_ONLY_UPDATE_TO_NEWER_VERSIONS" => "true" }
+    bundle :install, :env => { "BUNDLE_BUNDLE_ONLY_UPDATE_TO_NEWER_VERSIONS" => "true" }
 
     expect(the_bundle).to include_gems "omg 1.0"
   end

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe "bundle install with git sources" do
 
     it "caches the git repo globally" do
       simulate_new_machine
-      bundle! "config set global_gem_cache true"
-      bundle! :install
+      bundle "config set global_gem_cache true"
+      bundle :install
       expect(Dir["#{home}/.bundle/cache/git/foo-1.0-*"]).to have_attributes :size => 1
     end
 
@@ -277,7 +277,7 @@ RSpec.describe "bundle install with git sources" do
     it "does not download random non-head refs" do
       sys_exec("git update-ref -m \"Bundler Spec!\" refs/bundler/1 master~1", :dir => lib_path("foo-1.0"))
 
-      bundle! "config set global_gem_cache true"
+      bundle "config set global_gem_cache true"
 
       install_gemfile! <<-G
         git "#{lib_path("foo-1.0")}" do
@@ -286,7 +286,7 @@ RSpec.describe "bundle install with git sources" do
       G
 
       # ensure we also git fetch after cloning
-      bundle! :update, :all => true
+      bundle :update, :all => true
 
       sys_exec("git ls-remote .", :dir => Dir[home(".bundle/cache/git/foo-*")].first)
 
@@ -410,8 +410,8 @@ RSpec.describe "bundle install with git sources" do
         gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
       G
 
-      bundle! %(config set local.rack #{lib_path("local-rack")})
-      bundle! :install
+      bundle %(config set local.rack #{lib_path("local-rack")})
+      bundle :install
 
       run "require 'rack'"
       expect(out).to eq("LOCAL")
@@ -451,8 +451,8 @@ RSpec.describe "bundle install with git sources" do
         gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
       G
 
-      bundle! %(config set local.rack #{lib_path("local-rack")})
-      bundle! :install
+      bundle %(config set local.rack #{lib_path("local-rack")})
+      bundle :install
       run! "require 'rack'"
       expect(out).to eq("LOCAL")
     end
@@ -1046,7 +1046,7 @@ RSpec.describe "bundle install with git sources" do
       simulate_new_machine
 
       bundle "config --local deployment true"
-      bundle! :install
+      bundle :install
     end
   end
 
@@ -1332,7 +1332,7 @@ In Gemfile:
       installed_time = out
 
       update_git("foo")
-      bundle! "update foo"
+      bundle "update foo"
 
       run! <<-R
         require 'foo'
@@ -1393,14 +1393,14 @@ In Gemfile:
       bundle :cache
       simulate_new_machine
 
-      bundle! "install", :env => { "PATH" => "" }
+      bundle "install", :env => { "PATH" => "" }
       expect(out).to_not include("You need to install git to be able to use gems from git repositories.")
     end
   end
 
   describe "when the git source is overridden with a local git repo" do
     before do
-      bundle! "config set --global local.foo #{lib_path("foo")}"
+      bundle "config set --global local.foo #{lib_path("foo")}"
     end
 
     describe "and git output is colorized" do

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe "bundle install with git sources" do
       G
       expect(err).to be_empty
 
-      run! <<-RUBY
+      run <<-RUBY
         require 'foo'
         puts "WIN" if defined?(FOO)
       RUBY
@@ -266,7 +266,7 @@ RSpec.describe "bundle install with git sources" do
       G
       expect(err).to be_empty
 
-      run! <<-RUBY
+      run <<-RUBY
         require 'foo'
         puts "WIN" if defined?(FOO)
       RUBY
@@ -453,7 +453,7 @@ RSpec.describe "bundle install with git sources" do
 
       bundle %(config set local.rack #{lib_path("local-rack")})
       bundle :install
-      run! "require 'rack'"
+      run "require 'rack'"
       expect(out).to eq("LOCAL")
     end
 
@@ -1135,7 +1135,7 @@ RSpec.describe "bundle install with git sources" do
       R
       expect(out).to eq("YES")
 
-      run! <<-R
+      run <<-R
         puts $:.grep(/ext/)
       R
       expect(out).to include(Pathname.glob(default_bundle_path("bundler/gems/extensions/**/foo-1.0-*")).first.to_s)
@@ -1223,7 +1223,7 @@ In Gemfile:
         gem "foo", :git => "#{lib_path("foo-1.0")}"
       G
 
-      run! <<-R
+      run <<-R
         require 'foo'
         puts FOO
       R
@@ -1236,7 +1236,7 @@ In Gemfile:
         gem "foo", :git => "#{lib_path("foo-1.0")}"
       G
 
-      run! <<-R
+      run <<-R
         require 'foo'
         puts FOO
       R
@@ -1265,7 +1265,7 @@ In Gemfile:
         gem "foo", :git => "#{lib_path("foo-1.0")}"
       G
 
-      run! <<-R
+      run <<-R
         require 'foo'
         puts FOO
       R
@@ -1279,7 +1279,7 @@ In Gemfile:
         gem "foo", :git => "#{lib_path("foo-1.0")}"
       G
 
-      run! <<-R
+      run <<-R
         require 'foo'
         puts FOO
       R
@@ -1307,7 +1307,7 @@ In Gemfile:
         gem "foo", :git => "#{lib_path("foo-1.0")}"
       G
 
-      run! <<-R
+      run <<-R
         require 'foo'
         puts FOO
       R
@@ -1323,7 +1323,7 @@ In Gemfile:
         gem "foo", :git => "#{lib_path("foo-1.0")}", :branch => "branch2"
       G
 
-      run! <<-R
+      run <<-R
         require 'foo'
         puts FOO
       R
@@ -1334,7 +1334,7 @@ In Gemfile:
       update_git("foo")
       bundle "update foo"
 
-      run! <<-R
+      run <<-R
         require 'foo'
         puts FOO
       R

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe "bundle install with git sources" do
         s.write("lib/foo.rb", "raise 'FAIL'")
       end
 
-      install_gemfile! <<-G
+      install_gemfile <<-G
         git "#{lib_path("foo-1.0")}", :ref => "refs/bundler/1" do
           gem "foo"
         end
@@ -241,7 +241,7 @@ RSpec.describe "bundle install with git sources" do
     end
 
     it "works when the revision is a non-head ref and it was previously downloaded" do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         git "#{lib_path("foo-1.0")}" do
           gem "foo"
         end
@@ -259,7 +259,7 @@ RSpec.describe "bundle install with git sources" do
         s.write("lib/foo.rb", "raise 'FAIL'")
       end
 
-      install_gemfile! <<-G
+      install_gemfile <<-G
         git "#{lib_path("foo-1.0")}", :ref => "refs/bundler/1" do
           gem "foo"
         end
@@ -279,7 +279,7 @@ RSpec.describe "bundle install with git sources" do
 
       bundle "config set global_gem_cache true"
 
-      install_gemfile! <<-G
+      install_gemfile <<-G
         git "#{lib_path("foo-1.0")}" do
           gem "foo"
         end
@@ -446,7 +446,7 @@ RSpec.describe "bundle install with git sources" do
         s.write "lib/rack.rb", "puts :LOCAL"
       end
 
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
       G

--- a/bundler/spec/install/gemfile/groups_spec.rb
+++ b/bundler/spec/install/gemfile/groups_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe "bundle install with groups" do
       it "allows Bundler.setup for specific groups" do
         bundle "config --local without emo"
         bundle :install
-        run!("require 'rack'; puts RACK", :default)
+        run("require 'rack'; puts RACK", :default)
         expect(out).to eq("1.0.0")
       end
 

--- a/bundler/spec/install/gemfile/groups_spec.rb
+++ b/bundler/spec/install/gemfile/groups_spec.rb
@@ -87,13 +87,13 @@ RSpec.describe "bundle install with groups" do
 
       it "installs gems in the default group" do
         bundle "config --local without emo"
-        bundle! :install
+        bundle :install
         expect(the_bundle).to include_gems "rack 1.0.0", :groups => [:default]
       end
 
       it "respects global `without` configuration, but does not save it locally" do
         bundle "config without emo"
-        bundle! :install
+        bundle :install
         expect(the_bundle).to include_gems "rack 1.0.0", :groups => [:default]
         bundle "config list"
         expect(out).not_to include("Set for your local app (#{bundled_app(".bundle/config")}): [:emo]")
@@ -115,7 +115,7 @@ RSpec.describe "bundle install with groups" do
 
       it "does not say it installed gems from the excluded group" do
         bundle "config --local without emo"
-        bundle! :install
+        bundle :install
         expect(out).not_to include("activesupport")
       end
 
@@ -218,13 +218,13 @@ RSpec.describe "bundle install with groups" do
       it "allows the BUNDLE_WITH setting to override BUNDLE_WITHOUT" do
         ENV["BUNDLE_WITH"] = "debugging"
 
-        bundle! :install
+        bundle :install
         expect(the_bundle).to include_gem "thin 1.0"
 
         ENV["BUNDLE_WITHOUT"] = "debugging"
         expect(the_bundle).to include_gem "thin 1.0"
 
-        bundle! :install
+        bundle :install
         expect(the_bundle).to include_gem "thin 1.0"
       end
 
@@ -260,13 +260,13 @@ RSpec.describe "bundle install with groups" do
 
       it "installs gems in the default group" do
         bundle "config --local without emo lolercoaster"
-        bundle! :install
+        bundle :install
         expect(the_bundle).to include_gems "rack 1.0.0"
       end
 
       it "installs the gem if any of its groups are installed" do
         bundle "config --local without emo"
-        bundle! :install
+        bundle :install
         expect(the_bundle).to include_gems "rack 1.0.0", "activesupport 2.3.5"
       end
 
@@ -321,13 +321,13 @@ RSpec.describe "bundle install with groups" do
 
       it "installs gems in the default group" do
         bundle "config --local without emo lolercoaster"
-        bundle! :install
+        bundle :install
         expect(the_bundle).to include_gems "rack 1.0.0"
       end
 
       it "installs the gem if any of its groups are installed" do
         bundle "config --local without emo"
-        bundle! :install
+        bundle :install
         expect(the_bundle).to include_gems "rack 1.0.0", "activesupport 2.3.5"
       end
     end
@@ -389,7 +389,7 @@ RSpec.describe "bundle install with groups" do
     it "does not hit the remote a second time" do
       FileUtils.rm_rf gem_repo2
       bundle "config --local without rack"
-      bundle! :install, :verbose => true
+      bundle :install, :verbose => true
       expect(last_command.stdboth).not_to match(/fetching/i)
     end
   end

--- a/bundler/spec/install/gemfile/lockfile_spec.rb
+++ b/bundler/spec/install/gemfile/lockfile_spec.rb
@@ -16,12 +16,12 @@ RSpec.describe "bundle install with a lockfile present" do
 
     context "with plugins disabled" do
       before do
-        bundle! "config set plugins false"
+        bundle "config set plugins false"
         subject
       end
 
       it "does not evaluate the gemfile twice" do
-        bundle! :install
+        bundle :install
 
         with_env_vars("BUNDLER_SPEC_NO_APPEND" => "1") { expect(the_bundle).to include_gem "rack 1.0.0" }
 
@@ -34,7 +34,7 @@ RSpec.describe "bundle install with a lockfile present" do
         before { FileUtils.rm_rf bundled_app(".bundle") }
 
         it "does not evaluate the gemfile twice" do
-          bundle! :install
+          bundle :install
 
           with_env_vars("BUNDLER_SPEC_NO_APPEND" => "1") { expect(the_bundle).to include_gem "rack 1.0.0" }
 

--- a/bundler/spec/install/gemfile/path_spec.rb
+++ b/bundler/spec/install/gemfile/path_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe "bundle install with explicit source paths" do
     G
 
     bundle "config --local frozen true"
-    bundle! :install
+    bundle :install
     expect(exitstatus).to eq(0) if exitstatus
   end
 
@@ -185,7 +185,7 @@ RSpec.describe "bundle install with explicit source paths" do
 
     build_lib "omg", "1.0", :path => lib_path("omg")
 
-    bundle! :install, :env => { "BUNDLE_BUNDLE_ONLY_UPDATE_TO_NEWER_VERSIONS" => "true" }
+    bundle :install, :env => { "BUNDLE_BUNDLE_ONLY_UPDATE_TO_NEWER_VERSIONS" => "true" }
 
     expect(the_bundle).to include_gems "omg 1.0"
   end

--- a/bundler/spec/install/gemfile/path_spec.rb
+++ b/bundler/spec/install/gemfile/path_spec.rb
@@ -727,7 +727,7 @@ RSpec.describe "bundle install with explicit source paths" do
         s.write("lib/rubygems_plugin.rb", "FileUtils.touch('#{bar_file}')")
       end
 
-      install_gemfile! <<-G
+      install_gemfile <<-G
         gem "foo", :path => "#{lib_path("foo-1.0")}"
         gem "bar", :path => "#{lib_path("bar-1.0")}"
       G

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe "bundle install across platforms" do
 
     simulate_platform java
 
-    install_gemfile! <<-G
+    install_gemfile <<-G
       source "#{file_uri_for(gem_repo4)}"
 
       gem "empyrean", "0.1.0"
@@ -242,7 +242,7 @@ RSpec.describe "bundle install across platforms" do
       build_gem "CFPropertyList"
     end
 
-    install_gemfile! <<-G
+    install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}"
 
       gem "facter"

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe "bundle install across platforms" do
          #{Bundler::VERSION}
     L
 
-    bundle! "lock --add-platform ruby"
+    bundle "lock --add-platform ruby"
 
     good_lockfile = strip_whitespace(<<-L)
       GEM
@@ -195,23 +195,23 @@ RSpec.describe "bundle install across platforms" do
 
     aggregate_failures do
       lockfile bad_lockfile
-      bundle! :install
+      bundle :install
       lockfile_should_be good_lockfile
 
       lockfile bad_lockfile
-      bundle! :update, :all => true
+      bundle :update, :all => true
       lockfile_should_be good_lockfile
 
       lockfile bad_lockfile
-      bundle! "update ffi"
+      bundle "update ffi"
       lockfile_should_be good_lockfile
 
       lockfile bad_lockfile
-      bundle! "update empyrean"
+      bundle "update empyrean"
       lockfile_should_be good_lockfile
 
       lockfile bad_lockfile
-      bundle! :lock
+      bundle :lock
       lockfile_should_be good_lockfile
     end
   end
@@ -264,11 +264,11 @@ RSpec.describe "bundle install across platforms" do
     G
 
     bundle "config --local path vendor/bundle"
-    bundle! :install
+    bundle :install
 
     FileUtils.mv(vendored_gems, bundled_app("vendor/bundle", Gem.ruby_engine, "1.8"))
 
-    bundle! :install
+    bundle :install
     expect(vendored_gems("gems/rack-1.0.0")).to exist
   end
 end
@@ -386,7 +386,7 @@ RSpec.describe "bundle install with platform conditionals" do
       gem "rack", :platform => [:mingw, :mswin, :x64_mingw, :jruby]
     G
 
-    bundle! "install"
+    bundle "install"
 
     expect(err).to be_empty
 

--- a/bundler/spec/install/gemfile/ruby_spec.rb
+++ b/bundler/spec/install/gemfile/ruby_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "ruby requirement" do
   end
 
   it "allows requirements with trailing whitespace" do
-    install_gemfile! <<-G
+    install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
       ruby "#{RUBY_VERSION}\\n \t\\n"
       gem "rack"

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -544,7 +544,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
   context "when a gem is installed to system gems" do
     before do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
@@ -590,7 +590,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
   describe "source changed to one containing a higher version of a dependency" do
     before do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
 
         gem "rack"

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -95,20 +95,20 @@ RSpec.describe "bundle install with gems on multiple sources" do
       end
 
       it "installs the gems without any warning" do
-        bundle! :install
+        bundle :install
         expect(out).not_to include("Warning")
         expect(the_bundle).to include_gems("rack-obama 1.0.0")
         expect(the_bundle).to include_gems("rack 1.0.0", :source => "remote1")
       end
 
       it "can cache and deploy" do
-        bundle! :cache
+        bundle :cache
 
         expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
         expect(bundled_app("vendor/cache/rack-obama-1.0.gem")).to exist
 
         bundle "config --local deployment true"
-        bundle! :install
+        bundle :install
 
         expect(the_bundle).to include_gems("rack-obama 1.0.0", "rack 1.0.0")
       end
@@ -190,11 +190,11 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
           context "when disable_multisource is set" do
             before do
-              bundle! "config set disable_multisource true"
+              bundle "config set disable_multisource true"
             end
 
             it "installs from the same source without any warning" do
-              bundle! :install
+              bundle :install
 
               expect(out).not_to include("Warning: the gem 'rack' was found in multiple sources.")
               expect(err).not_to include("Warning: the gem 'rack' was found in multiple sources.")
@@ -202,7 +202,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
               # when there is already a lock file, and the gems are missing, so try again
               system_gems []
-              bundle! :install
+              bundle :install
 
               expect(out).not_to include("Warning: the gem 'rack' was found in multiple sources.")
               expect(err).not_to include("Warning: the gem 'rack' was found in multiple sources.")
@@ -307,7 +307,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
     context "when a top-level gem has an indirect dependency" do
       context "when disable_multisource is set" do
         before do
-          bundle! "config set disable_multisource true"
+          bundle "config set disable_multisource true"
         end
 
         before do
@@ -444,9 +444,9 @@ RSpec.describe "bundle install with gems on multiple sources" do
       end
 
       it "does not unlock the non-path gem after install" do
-        bundle! :install
+        bundle :install
 
-        bundle! %(exec ruby -e 'puts "OK"')
+        bundle %(exec ruby -e 'puts "OK"')
 
         expect(out).to include("OK")
       end
@@ -487,7 +487,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
       G
 
       bundle "config --local path ../gems/system"
-      bundle! :install
+      bundle :install
 
       # And then we add some new versions...
       update_repo4 do
@@ -535,7 +535,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
       end
 
       it "does not re-resolve" do
-        bundle! :install, :verbose => true
+        bundle :install, :verbose => true
         expect(out).to include("using resolution from the lockfile")
         expect(out).not_to include("re-resolving dependencies")
       end
@@ -583,7 +583,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
         G
 
         # But we should still be able to find rack 2.0.1.1.forked and install it
-        bundle! :install
+        bundle :install
       end
     end
   end

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "bundle install with specific_platform enabled" do
     before { simulate_platform "x86_64-darwin-15" }
 
     it "locks to both the specific darwin platform and ruby" do
-      install_gemfile!(google_protobuf)
+      install_gemfile(google_protobuf)
       allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
       expect(the_bundle.locked_gems.platforms).to eq([pl("ruby"), pl("x86_64-darwin-15")])
       expect(the_bundle).to include_gem("google-protobuf 3.0.0.alpha.5.0.5.1 universal-darwin")
@@ -75,7 +75,7 @@ RSpec.describe "bundle install with specific_platform enabled" do
     end
 
     it "uses the platform-specific gem with extra dependencies" do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "facter"
       G
@@ -94,7 +94,7 @@ RSpec.describe "bundle install with specific_platform enabled" do
       end
 
       it "adds the foreign platform" do
-        install_gemfile!(google_protobuf)
+        install_gemfile(google_protobuf)
         bundle "lock --add-platform=#{x64_mingw}"
 
         expect(the_bundle.locked_gems.platforms).to eq([rb, x64_mingw, pl("x86_64-darwin-15")])
@@ -106,7 +106,7 @@ RSpec.describe "bundle install with specific_platform enabled" do
       end
 
       it "falls back on plain ruby when that version doesnt have a platform-specific gem" do
-        install_gemfile!(google_protobuf)
+        install_gemfile(google_protobuf)
         bundle "lock --add-platform=#{java}"
 
         expect(the_bundle.locked_gems.platforms).to eq([java, rb, pl("x86_64-darwin-15")])

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "bundle install with specific_platform enabled" do
 
     it "caches both the universal-darwin and ruby gems when --all-platforms is passed" do
       gemfile(google_protobuf)
-      bundle! "package --all-platforms"
+      bundle "package --all-platforms"
       expect([cached_gem("google-protobuf-3.0.0.alpha.5.0.5.1"), cached_gem("google-protobuf-3.0.0.alpha.5.0.5.1-universal-darwin")]).
         to all(exist)
     end
@@ -95,7 +95,7 @@ RSpec.describe "bundle install with specific_platform enabled" do
 
       it "adds the foreign platform" do
         install_gemfile!(google_protobuf)
-        bundle! "lock --add-platform=#{x64_mingw}"
+        bundle "lock --add-platform=#{x64_mingw}"
 
         expect(the_bundle.locked_gems.platforms).to eq([rb, x64_mingw, pl("x86_64-darwin-15")])
         expect(the_bundle.locked_gems.specs.map(&:full_name)).to eq(%w[
@@ -107,7 +107,7 @@ RSpec.describe "bundle install with specific_platform enabled" do
 
       it "falls back on plain ruby when that version doesnt have a platform-specific gem" do
         install_gemfile!(google_protobuf)
-        bundle! "lock --add-platform=#{java}"
+        bundle "lock --add-platform=#{java}"
 
         expect(the_bundle.locked_gems.platforms).to eq([java, rb, pl("x86_64-darwin-15")])
         expect(the_bundle.locked_gems.specs.map(&:full_name)).to eq(%w[

--- a/bundler/spec/install/gemfile_spec.rb
+++ b/bundler/spec/install/gemfile_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "bundle install" do
 
   context "with engine specified in symbol", :jruby do
     it "does not raise any error parsing Gemfile" do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         ruby "#{RUBY_VERSION}", :engine => :jruby, :engine_version => "#{RUBY_ENGINE_VERSION}"
       G
@@ -73,7 +73,7 @@ RSpec.describe "bundle install" do
     end
 
     it "installation succeeds" do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         ruby "#{RUBY_VERSION}", :engine => :jruby, :engine_version => "#{RUBY_ENGINE_VERSION}"
         gem "rack"

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "compact index api" do
 
     # can't use `include_gems` here since the `require` will conflict on a
     # case-insensitive FS
-    run! "Bundler.require; puts Gem.loaded_specs.values_at('rack', 'Rack').map(&:full_name)"
+    run "Bundler.require; puts Gem.loaded_specs.values_at('rack', 'Rack').map(&:full_name)"
     expect(out).to eq("rack-1.0\nRack-0.1")
   end
 

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "compact index api" do
       build_gem "Rack", "0.1"
     end
 
-    install_gemfile! <<-G, :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+    install_gemfile <<-G, :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
       source "#{source_uri}"
       gem "rack", "1.0"
       gem "Rack", "0.1"
@@ -265,7 +265,7 @@ The checksum of /versions does not match the checksum provided by the server! So
       #{source_uri}/info/rack
     EOS
 
-    install_gemfile! <<-G, :artifice => "compact_index", :verbose => true
+    install_gemfile <<-G, :artifice => "compact_index", :verbose => true
       source "#{source_uri}"
       gem "rack"
     G
@@ -299,7 +299,7 @@ The checksum of /versions does not match the checksum provided by the server! So
       FileUtils.rm_rf Dir[gem_repo2("gems/foo-*.gem")]
     end
 
-    install_gemfile! <<-G, :artifice => "compact_index_extra", :verbose => true
+    install_gemfile <<-G, :artifice => "compact_index_extra", :verbose => true
       source "#{source_uri}"
       source "#{source_uri}/extra" do
         gem "back_deps"
@@ -414,7 +414,7 @@ The checksum of /versions does not match the checksum provided by the server! So
 
     api_request_limit = low_api_request_limit_for(gem_repo2)
 
-    install_gemfile! <<-G, :artifice => "compact_index_extra_missing", :env => { "BUNDLER_SPEC_API_REQUEST_LIMIT" => api_request_limit.to_s }.merge(env_for_missing_prerelease_default_gem_activation)
+    install_gemfile <<-G, :artifice => "compact_index_extra_missing", :env => { "BUNDLER_SPEC_API_REQUEST_LIMIT" => api_request_limit.to_s }.merge(env_for_missing_prerelease_default_gem_activation)
       source "#{source_uri}"
       source "#{source_uri}/extra" do
         gem "back_deps"
@@ -436,7 +436,7 @@ The checksum of /versions does not match the checksum provided by the server! So
 
     api_request_limit = low_api_request_limit_for(gem_repo4)
 
-    install_gemfile! <<-G, :artifice => "compact_index_extra_api_missing", :env => { "BUNDLER_SPEC_API_REQUEST_LIMIT" => api_request_limit.to_s }.merge(env_for_missing_prerelease_default_gem_activation)
+    install_gemfile <<-G, :artifice => "compact_index_extra_api_missing", :env => { "BUNDLER_SPEC_API_REQUEST_LIMIT" => api_request_limit.to_s }.merge(env_for_missing_prerelease_default_gem_activation)
       source "#{source_uri}"
       source "#{source_uri}/extra" do
         gem "back_deps"
@@ -898,7 +898,7 @@ The checksum of /versions does not match the checksum provided by the server! So
 
     it "does not raise when disable_checksum_validation is set" do
       bundle "config set disable_checksum_validation true"
-      install_gemfile! <<-G, :artifice => "compact_index_wrong_gem_checksum"
+      install_gemfile <<-G, :artifice => "compact_index_wrong_gem_checksum"
         source "#{source_uri}"
         gem "rack"
       G
@@ -906,7 +906,7 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   it "works when cache dir is world-writable" do
-    install_gemfile! <<-G, :artifice => "compact_index"
+    install_gemfile <<-G, :artifice => "compact_index"
       File.umask(0000)
       source "#{source_uri}"
       gem "rack"
@@ -930,7 +930,7 @@ Either installing with `--full-index` or running `bundle update rails` should fi
   end
 
   it "does not duplicate specs in the lockfile when updating and a dependency is not installed" do
-    install_gemfile! <<-G, :artifice => "compact_index"
+    install_gemfile <<-G, :artifice => "compact_index"
       source "#{source_uri}" do
         gem "rails"
         gem "activemerchant"

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -936,7 +936,7 @@ Either installing with `--full-index` or running `bundle update rails` should fi
         gem "activemerchant"
       end
     G
-    gem_command! "uninstall activemerchant"
+    gem_command "uninstall activemerchant"
     bundle "update rails", :artifice => "compact_index"
     expect(lockfile.scan(/activemerchant \(/).size).to eq(1)
   end

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "compact index api" do
       gem "rack"
     G
 
-    bundle! :install, :artifice => "compact_index"
+    bundle :install, :artifice => "compact_index"
     expect(out).to include("Fetching gem metadata from #{source_uri}")
     expect(the_bundle).to include_gems "rack 1.0.0"
   end
@@ -31,7 +31,7 @@ RSpec.describe "compact index api" do
       gem "rails"
     G
 
-    bundle! :install, :artifice => "compact_index"
+    bundle :install, :artifice => "compact_index"
     expect(out).to include("Fetching gem metadata from #{source_uri}")
     expect(the_bundle).to include_gems(
       "rails 2.3.2",
@@ -69,7 +69,7 @@ RSpec.describe "compact index api" do
       gem "net-sftp"
     G
 
-    bundle! :install, :artifice => "compact_index"
+    bundle :install, :artifice => "compact_index"
     expect(the_bundle).to include_gems "net-sftp 1.1.1"
   end
 
@@ -78,11 +78,11 @@ RSpec.describe "compact index api" do
       source "#{source_uri}"
       gem "rack"
     G
-    bundle! :install, :artifice => "compact_index"
+    bundle :install, :artifice => "compact_index"
 
     bundle "config --local deployment true"
     bundle "config --local path vendor/bundle"
-    bundle! :install, :artifice => "compact_index"
+    bundle :install, :artifice => "compact_index"
     expect(out).to include("Fetching gem metadata from #{source_uri}")
     expect(the_bundle).to include_gems "rack 1.0.0"
   end
@@ -100,7 +100,7 @@ RSpec.describe "compact index api" do
       end
     G
 
-    bundle! :install, :artifice => "compact_index"
+    bundle :install, :artifice => "compact_index"
 
     expect(the_bundle).to include_gems("rails 2.3.2")
   end
@@ -116,7 +116,7 @@ RSpec.describe "compact index api" do
       gem 'foo', :git => "#{file_uri_for(lib_path("foo-1.0"))}"
     G
 
-    bundle! :install, :artifice => "compact_index"
+    bundle :install, :artifice => "compact_index"
 
     bundle "config --local deployment true"
     bundle :install, :artifice => "compact_index"
@@ -133,7 +133,7 @@ RSpec.describe "compact index api" do
 
     bundle "install", :artifice => "compact_index"
     bundle "config --local deployment true"
-    bundle! :install, :artifice => "compact_index"
+    bundle :install, :artifice => "compact_index"
 
     expect(the_bundle).to include_gems("foo 1.0")
   end
@@ -146,7 +146,7 @@ RSpec.describe "compact index api" do
       gem "rcov"
     G
 
-    bundle! :install, :artifice => "windows"
+    bundle :install, :artifice => "windows"
     expect(out).to include("Fetching source index from #{source_uri}")
     expect(the_bundle).to include_gems "rcov 1.0.0"
   end
@@ -157,7 +157,7 @@ RSpec.describe "compact index api" do
       gem "rack"
     G
 
-    bundle! :install, :verbose => true, :artifice => "compact_index_forbidden"
+    bundle :install, :verbose => true, :artifice => "compact_index_forbidden"
     expect(out).to include("Fetching gem metadata from #{source_uri}")
     expect(the_bundle).to include_gems "rack 1.0.0"
   end
@@ -168,7 +168,7 @@ RSpec.describe "compact index api" do
       gem "rack"
     G
 
-    bundle! :install, :verbose => true, :artifice => "compact_index_checksum_mismatch"
+    bundle :install, :verbose => true, :artifice => "compact_index_checksum_mismatch"
     expect(out).to include("Fetching gem metadata from #{source_uri}")
     expect(out).to include <<-'WARN'
 The checksum of /versions does not match the checksum provided by the server! Something is wrong (local checksum is "\"d41d8cd98f00b204e9800998ecf8427e\"", was expecting "\"123\"").
@@ -184,7 +184,7 @@ The checksum of /versions does not match the checksum provided by the server! So
       gem "rack"
     G
 
-    bundle! :install, :artifice => "compact_index"
+    bundle :install, :artifice => "compact_index"
     expect(out).to include("Fetching gem metadata from #{source_uri}")
     expect(the_bundle).to include_gems "rack 1.0.0"
   end
@@ -195,7 +195,7 @@ The checksum of /versions does not match the checksum provided by the server! So
       gem "rack"
     G
 
-    bundle! :install, :artifice => "compact_index_host_redirect"
+    bundle :install, :artifice => "compact_index_host_redirect"
     expect(the_bundle).to include_gems "rack 1.0.0"
   end
 
@@ -218,7 +218,7 @@ The checksum of /versions does not match the checksum provided by the server! So
       H
     end
 
-    bundle! :install, :artifice => "compact_index_host_redirect", :requires => [lib_path("disable_net_http_persistent.rb")]
+    bundle :install, :artifice => "compact_index_host_redirect", :requires => [lib_path("disable_net_http_persistent.rb")]
     expect(out).to_not match(/Too many redirects/)
     expect(the_bundle).to include_gems "rack 1.0.0"
   end
@@ -251,7 +251,7 @@ The checksum of /versions does not match the checksum provided by the server! So
         gem "rack"
       G
 
-      bundle! "update --full-index", :artifice => "compact_index", :all => true
+      bundle "update --full-index", :artifice => "compact_index", :all => true
       expect(out).to include("Fetching source index from #{source_uri}")
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
@@ -259,7 +259,7 @@ The checksum of /versions does not match the checksum provided by the server! So
 
   it "does not double check for gems that are only installed locally" do
     system_gems %w[rack-1.0.0 thin-1.0 net_a-1.0]
-    bundle! "config set --local path.system true"
+    bundle "config set --local path.system true"
     ENV["BUNDLER_SPEC_ALL_REQUESTS"] = strip_whitespace(<<-EOS).strip
       #{source_uri}/versions
       #{source_uri}/info/rack
@@ -287,7 +287,7 @@ The checksum of /versions does not match the checksum provided by the server! So
       gem "back_deps"
     G
 
-    bundle! :install, :artifice => "compact_index_extra"
+    bundle :install, :artifice => "compact_index_extra"
     expect(the_bundle).to include_gems "back_deps 1.0", "foo 1.0"
   end
 
@@ -314,7 +314,7 @@ The checksum of /versions does not match the checksum provided by the server! So
       source "#{source_uri}"
       gem "rack", "1.0.0"
     G
-    bundle! :install, :artifice => "compact_index_extra_api"
+    bundle :install, :artifice => "compact_index_extra_api"
     expect(the_bundle).to include_gems "rack 1.0.0"
 
     build_repo4 do
@@ -328,7 +328,7 @@ The checksum of /versions does not match the checksum provided by the server! So
       source "#{source_uri}/extra"
       gem "rack", "1.2"
     G
-    bundle! :install, :artifice => "compact_index_extra_api"
+    bundle :install, :artifice => "compact_index_extra_api"
     expect(the_bundle).to include_gems "rack 1.2"
   end
 
@@ -350,7 +350,7 @@ The checksum of /versions does not match the checksum provided by the server! So
       gem 'somegem', '1.0.0'
     G
 
-    bundle! :install, :artifice => "compact_index_extra_api"
+    bundle :install, :artifice => "compact_index_extra_api"
 
     expect(the_bundle).to include_gems "somegem 1.0.0"
     expect(the_bundle).to include_gems "activesupport 1.2.3"
@@ -375,7 +375,7 @@ The checksum of /versions does not match the checksum provided by the server! So
       end
     G
 
-    bundle! :install, :artifice => "compact_index_extra_api"
+    bundle :install, :artifice => "compact_index_extra_api"
 
     expect(the_bundle).to include_gems "somegem 1.0.0"
     expect(the_bundle).to include_gems "activesupport 1.2.3"
@@ -396,7 +396,7 @@ The checksum of /versions does not match the checksum provided by the server! So
       end
     G
 
-    bundle! :install, :artifice => "compact_index_extra"
+    bundle :install, :artifice => "compact_index_extra"
 
     expect(out).to include("Fetching gem metadata from http://localgemserver.test/")
     expect(out).to include("Fetching source index from http://localgemserver.test/extra")
@@ -453,7 +453,7 @@ The checksum of /versions does not match the checksum provided by the server! So
       gem 'foo'
     G
 
-    bundle! :install, :artifice => "compact_index_api_missing"
+    bundle :install, :artifice => "compact_index_api_missing"
     expect(the_bundle).to include_gems "foo 1.0"
   end
 
@@ -471,7 +471,7 @@ The checksum of /versions does not match the checksum provided by the server! So
       gem "back_deps"
     G
 
-    bundle! :install, :artifice => "compact_index_extra"
+    bundle :install, :artifice => "compact_index_extra"
 
     bundle "install --deployment", :artifice => "compact_index_extra"
     expect(the_bundle).to include_gems "back_deps 1.0"
@@ -492,9 +492,9 @@ The checksum of /versions does not match the checksum provided by the server! So
       end
     G
 
-    bundle! :install, :artifice => "compact_index_extra"
+    bundle :install, :artifice => "compact_index_extra"
     bundle "config --local deployment true"
-    bundle! :install, :artifice => "compact_index_extra"
+    bundle :install, :artifice => "compact_index_extra"
     expect(the_bundle).to include_gems "back_deps 1.0"
   end
 
@@ -505,7 +505,7 @@ The checksum of /versions does not match the checksum provided by the server! So
       gem "bundler_dep"
     G
 
-    bundle! :install, :artifice => "compact_index"
+    bundle :install, :artifice => "compact_index"
     expect(out).to include("Fetching gem metadata from #{source_uri}")
   end
 
@@ -517,7 +517,7 @@ The checksum of /versions does not match the checksum provided by the server! So
       source "#{source_uri}"
       gem "rails"
     G
-    bundle! :install, :artifice => "compact_index"
+    bundle :install, :artifice => "compact_index"
     expect(the_bundle).to include_gems "rails 2.3.2"
   end
 
@@ -563,7 +563,7 @@ The checksum of /versions does not match the checksum provided by the server! So
       gem 'rack-obama'
     G
 
-    bundle! :install, :artifice => "compact_index"
+    bundle :install, :artifice => "compact_index"
     expect(out).to include("Post-install message from rack:")
   end
 
@@ -573,7 +573,7 @@ The checksum of /versions does not match the checksum provided by the server! So
       gem 'rack_middleware'
     G
 
-    bundle! :install, :artifice => "compact_index"
+    bundle :install, :artifice => "compact_index"
     expect(out).to include("Post-install message from rack:")
     expect(out).to include("Rack's post install message")
   end
@@ -595,7 +595,7 @@ The checksum of /versions does not match the checksum provided by the server! So
         gem "rack"
       G
 
-      bundle! :install, :artifice => "compact_index_basic_authentication"
+      bundle :install, :artifice => "compact_index_basic_authentication"
       expect(out).not_to include("#{user}:#{password}")
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
@@ -606,7 +606,7 @@ The checksum of /versions does not match the checksum provided by the server! So
         gem "rack"
       G
 
-      bundle! :install, :artifice => "endopint_marshal_fail_basic_authentication"
+      bundle :install, :artifice => "endopint_marshal_fail_basic_authentication"
       expect(out).not_to include("#{user}:#{password}")
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
@@ -628,7 +628,7 @@ The checksum of /versions does not match the checksum provided by the server! So
         gem "rack"
       G
 
-      bundle! :install, :artifice => "compact_index_basic_authentication"
+      bundle :install, :artifice => "compact_index_basic_authentication"
       expect(err).to include("Warning: the gem 'rack' was found in multiple sources.")
       expect(err).not_to include("#{user}:#{password}")
       expect(the_bundle).to include_gems "rack 1.0.0"
@@ -640,7 +640,7 @@ The checksum of /versions does not match the checksum provided by the server! So
         gem "rack"
       G
 
-      bundle! :install, :artifice => "compact_index_creds_diff_host"
+      bundle :install, :artifice => "compact_index_creds_diff_host"
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
 
@@ -655,7 +655,7 @@ The checksum of /versions does not match the checksum provided by the server! So
       it "reads authentication details by host name from bundle config" do
         bundle "config set #{source_hostname} #{user}:#{password}"
 
-        bundle! :install, :artifice => "compact_index_strict_basic_authentication"
+        bundle :install, :artifice => "compact_index_strict_basic_authentication"
 
         expect(out).to include("Fetching gem metadata from #{source_uri}")
         expect(the_bundle).to include_gems "rack 1.0.0"
@@ -665,7 +665,7 @@ The checksum of /versions does not match the checksum provided by the server! So
         # The trailing slash is necessary here; Fetcher canonicalizes the URI.
         bundle "config set #{source_uri}/ #{user}:#{password}"
 
-        bundle! :install, :artifice => "compact_index_strict_basic_authentication"
+        bundle :install, :artifice => "compact_index_strict_basic_authentication"
 
         expect(out).to include("Fetching gem metadata from #{source_uri}")
         expect(the_bundle).to include_gems "rack 1.0.0"
@@ -673,7 +673,7 @@ The checksum of /versions does not match the checksum provided by the server! So
 
       it "should use the API" do
         bundle "config set #{source_hostname} #{user}:#{password}"
-        bundle! :install, :artifice => "compact_index_strict_basic_authentication"
+        bundle :install, :artifice => "compact_index_strict_basic_authentication"
         expect(out).to include("Fetching gem metadata from #{source_uri}")
         expect(the_bundle).to include_gems "rack 1.0.0"
       end
@@ -686,7 +686,7 @@ The checksum of /versions does not match the checksum provided by the server! So
 
         bundle "config set #{source_hostname} otheruser:wrong"
 
-        bundle! :install, :artifice => "compact_index_strict_basic_authentication"
+        bundle :install, :artifice => "compact_index_strict_basic_authentication"
         expect(the_bundle).to include_gems "rack 1.0.0"
       end
 
@@ -712,7 +712,7 @@ The checksum of /versions does not match the checksum provided by the server! So
           gem "rack"
         G
 
-        bundle! :install, :artifice => "compact_index_basic_authentication"
+        bundle :install, :artifice => "compact_index_basic_authentication"
         expect(the_bundle).to include_gems "rack 1.0.0"
       end
     end
@@ -774,7 +774,7 @@ The checksum of /versions does not match the checksum provided by the server! So
           gem 'rack'
         G
 
-        bundle! :install, :artifice => "compact_index_forbidden"
+        bundle :install, :artifice => "compact_index_forbidden"
 
         expect(exitstatus).to eq(0) if exitstatus
       ensure
@@ -792,7 +792,7 @@ The checksum of /versions does not match the checksum provided by the server! So
     G
 
     # Initial install creates the cached versions file
-    bundle! :install, :artifice => "compact_index"
+    bundle :install, :artifice => "compact_index"
 
     # Update the Gemfile so we can check subsequent install was successful
     gemfile <<-G
@@ -801,7 +801,7 @@ The checksum of /versions does not match the checksum provided by the server! So
     G
 
     # Second install should make only a partial request to /versions
-    bundle! :install, :artifice => "compact_index_partial_update"
+    bundle :install, :artifice => "compact_index_partial_update"
 
     expect(the_bundle).to include_gems "rack 1.0.0"
   end
@@ -818,7 +818,7 @@ The checksum of /versions does not match the checksum provided by the server! So
     FileUtils.mkdir_p(File.dirname(versions))
     FileUtils.touch(versions)
 
-    bundle! :install, :artifice => "compact_index_concurrent_download"
+    bundle :install, :artifice => "compact_index_concurrent_download"
 
     expect(File.read(versions)).to start_with("created_at")
     expect(the_bundle).to include_gems "rack 1.0.0"
@@ -833,7 +833,7 @@ The checksum of /versions does not match the checksum provided by the server! So
     rake_info_path = File.join(Bundler.rubygems.user_home, ".bundle", "cache", "compact_index",
       "localgemserver.test.80.dd34752a738ee965a2a4298dc16db6c5", "info", "rack")
 
-    bundle! :install, :artifice => "compact_index"
+    bundle :install, :artifice => "compact_index"
 
     expected_rack_info_content = File.read(rake_info_path)
 
@@ -848,7 +848,7 @@ The checksum of /versions does not match the checksum provided by the server! So
 
     # The cache files now being longer means the requested range is going to be not satisfiable
     # Bundler must end up requesting the whole file to fix things up.
-    bundle! :install, :artifice => "compact_index_range_not_satisfiable"
+    bundle :install, :artifice => "compact_index_range_not_satisfiable"
 
     resulting_rack_info_content = File.read(rake_info_path)
 
@@ -897,7 +897,7 @@ The checksum of /versions does not match the checksum provided by the server! So
     end
 
     it "does not raise when disable_checksum_validation is set" do
-      bundle! "config set disable_checksum_validation true"
+      bundle "config set disable_checksum_validation true"
       install_gemfile! <<-G, :artifice => "compact_index_wrong_gem_checksum"
         source "#{source_uri}"
         gem "rack"
@@ -937,7 +937,7 @@ Either installing with `--full-index` or running `bundle update rails` should fi
       end
     G
     gem_command! "uninstall activemerchant"
-    bundle! "update rails", :artifice => "compact_index"
+    bundle "update rails", :artifice => "compact_index"
     expect(lockfile.scan(/activemerchant \(/).size).to eq(1)
   end
 end

--- a/bundler/spec/install/gems/dependency_api_spec.rb
+++ b/bundler/spec/install/gems/dependency_api_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "gemcutter's dependency API" do
 
     bundle "config --local deployment true"
     bundle "config --local path vendor/bundle"
-    bundle! :install, :artifice => "endpoint"
+    bundle :install, :artifice => "endpoint"
     expect(out).to include("Fetching gem metadata from #{source_uri}")
     expect(the_bundle).to include_gems "rack 1.0.0"
   end
@@ -113,7 +113,7 @@ RSpec.describe "gemcutter's dependency API" do
 
     bundle "install", :artifice => "endpoint"
     bundle "config --local deployment true"
-    bundle! :install, :artifice => "endpoint"
+    bundle :install, :artifice => "endpoint"
 
     expect(the_bundle).to include_gems("foo 1.0")
   end
@@ -241,7 +241,7 @@ RSpec.describe "gemcutter's dependency API" do
         gem "rack"
       G
 
-      bundle! "update --full-index", :artifice => "endpoint", :all => true
+      bundle "update --full-index", :artifice => "endpoint", :all => true
       expect(out).to include("Fetching source index from #{source_uri}")
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
@@ -324,7 +324,7 @@ RSpec.describe "gemcutter's dependency API" do
       gem 'somegem', '1.0.0'
     G
 
-    bundle! :install, :artifice => "endpoint_extra_api"
+    bundle :install, :artifice => "endpoint_extra_api"
 
     expect(the_bundle).to include_gems "somegem 1.0.0"
     expect(the_bundle).to include_gems "activesupport 1.2.3"
@@ -468,7 +468,7 @@ RSpec.describe "gemcutter's dependency API" do
     bundle :install, :artifice => "endpoint_extra"
 
     bundle "config --local deployment true"
-    bundle! "install", :artifice => "endpoint_extra"
+    bundle "install", :artifice => "endpoint_extra"
     expect(the_bundle).to include_gems "back_deps 1.0"
   end
 

--- a/bundler/spec/install/gems/dependency_api_spec.rb
+++ b/bundler/spec/install/gems/dependency_api_spec.rb
@@ -388,7 +388,7 @@ RSpec.describe "gemcutter's dependency API" do
 
     api_request_limit = low_api_request_limit_for(gem_repo2)
 
-    install_gemfile! <<-G, :artifice => "endpoint_extra_missing", :env => { "BUNDLER_SPEC_API_REQUEST_LIMIT" => api_request_limit.to_s }.merge(env_for_missing_prerelease_default_gem_activation)
+    install_gemfile <<-G, :artifice => "endpoint_extra_missing", :env => { "BUNDLER_SPEC_API_REQUEST_LIMIT" => api_request_limit.to_s }.merge(env_for_missing_prerelease_default_gem_activation)
       source "#{source_uri}"
       source "#{source_uri}/extra"
       gem "back_deps"
@@ -409,7 +409,7 @@ RSpec.describe "gemcutter's dependency API" do
 
     api_request_limit = low_api_request_limit_for(gem_repo2)
 
-    install_gemfile! <<-G, :artifice => "endpoint_extra_missing", :env => { "BUNDLER_SPEC_API_REQUEST_LIMIT" => api_request_limit.to_s }.merge(env_for_missing_prerelease_default_gem_activation)
+    install_gemfile <<-G, :artifice => "endpoint_extra_missing", :env => { "BUNDLER_SPEC_API_REQUEST_LIMIT" => api_request_limit.to_s }.merge(env_for_missing_prerelease_default_gem_activation)
       source "#{source_uri}"
       source "#{source_uri}/extra" do
         gem "back_deps"

--- a/bundler/spec/install/gems/flex_spec.rb
+++ b/bundler/spec/install/gems/flex_spec.rb
@@ -248,11 +248,11 @@ RSpec.describe "bundle flex_install" do
   describe "when adding a new source" do
     it "updates the lockfile", :bundler => "< 3" do
       build_repo2
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         source "#{file_uri_for(gem_repo2)}"
         gem "rack"
@@ -278,12 +278,12 @@ RSpec.describe "bundle flex_install" do
 
     it "updates the lockfile", :bundler => "3" do
       build_repo2
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         source "#{file_uri_for(gem_repo2)}" do
         end

--- a/bundler/spec/install/gems/native_extensions_spec.rb
+++ b/bundler/spec/install/gems/native_extensions_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "installing a gem with native extensions", :ruby_repo do
     G
 
     bundle "config set build.c_extension --with-c_extension=hello"
-    bundle! "install"
+    bundle "install"
 
     expect(out).to include("Installing c_extension 1.0 with native extensions")
 
@@ -75,7 +75,7 @@ RSpec.describe "installing a gem with native extensions", :ruby_repo do
       C
     end
 
-    bundle! "config set build.c_extension --with-c_extension=hello"
+    bundle "config set build.c_extension --with-c_extension=hello"
 
     install_gemfile! <<-G
       gem "c_extension", :git => #{lib_path("c_extension-1.0").to_s.dump}
@@ -121,8 +121,8 @@ RSpec.describe "installing a gem with native extensions", :ruby_repo do
       build_git "gems", :path => lib_path("gems"), :gemspec => false
     end
 
-    bundle! "config set build.c_extension_one --with-c_extension_one=one"
-    bundle! "config set build.c_extension_two --with-c_extension_two=two"
+    bundle "config set build.c_extension_one --with-c_extension_one=one"
+    bundle "config set build.c_extension_two --with-c_extension_two=two"
 
     # 1st time, require only one gem -- only one of the extensions gets built.
     install_gemfile! <<-G
@@ -168,7 +168,7 @@ RSpec.describe "installing a gem with native extensions", :ruby_repo do
       C
     end
 
-    bundle! "config set build.c_extension --with-c_extension=hello --with-c_extension_bundle-dir=hola"
+    bundle "config set build.c_extension --with-c_extension=hello --with-c_extension_bundle-dir=hola"
 
     install_gemfile! <<-G
       gem "c_extension", :git => #{lib_path("c_extension-1.0").to_s.dump}

--- a/bundler/spec/install/gems/native_extensions_spec.rb
+++ b/bundler/spec/install/gems/native_extensions_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "installing a gem with native extensions", :ruby_repo do
 
     bundle "config set build.c_extension --with-c_extension=hello"
 
-    install_gemfile! <<-G
+    install_gemfile <<-G
       gem "c_extension", :git => #{lib_path("c_extension-1.0").to_s.dump}
     G
 
@@ -125,12 +125,12 @@ RSpec.describe "installing a gem with native extensions", :ruby_repo do
     bundle "config set build.c_extension_two --with-c_extension_two=two"
 
     # 1st time, require only one gem -- only one of the extensions gets built.
-    install_gemfile! <<-G
+    install_gemfile <<-G
       gem "c_extension_one", :git => #{lib_path("gems").to_s.dump}
     G
 
     # 2nd time, require both gems -- we need both extensions to be built now.
-    install_gemfile! <<-G
+    install_gemfile <<-G
       gem "c_extension_one", :git => #{lib_path("gems").to_s.dump}
       gem "c_extension_two", :git => #{lib_path("gems").to_s.dump}
     G
@@ -170,7 +170,7 @@ RSpec.describe "installing a gem with native extensions", :ruby_repo do
 
     bundle "config set build.c_extension --with-c_extension=hello --with-c_extension_bundle-dir=hola"
 
-    install_gemfile! <<-G
+    install_gemfile <<-G
       gem "c_extension", :git => #{lib_path("c_extension-1.0").to_s.dump}
     G
 

--- a/bundler/spec/install/gems/native_extensions_spec.rb
+++ b/bundler/spec/install/gems/native_extensions_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "installing a gem with native extensions", :ruby_repo do
 
     expect(err).to_not include("warning: conflicting chdir during another chdir block")
 
-    run! "Bundler.require; puts CExtension.new.its_true"
+    run "Bundler.require; puts CExtension.new.its_true"
     expect(out).to eq("true")
   end
 
@@ -135,7 +135,7 @@ RSpec.describe "installing a gem with native extensions", :ruby_repo do
       gem "c_extension_two", :git => #{lib_path("gems").to_s.dump}
     G
 
-    run! "Bundler.require; puts CExtension_one.new.value; puts CExtension_two.new.value"
+    run "Bundler.require; puts CExtension_one.new.value; puts CExtension_two.new.value"
     expect(out).to eq("one\ntwo")
   end
 
@@ -174,7 +174,7 @@ RSpec.describe "installing a gem with native extensions", :ruby_repo do
       gem "c_extension", :git => #{lib_path("c_extension-1.0").to_s.dump}
     G
 
-    run! "Bundler.require; puts CExtension.new.its_true"
+    run "Bundler.require; puts CExtension.new.its_true"
     expect(out).to eq("true")
   end
 end

--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -56,7 +56,7 @@ RSpec.shared_examples "bundle install --standalone" do
         gem "rails"
       G
       bundle "config --local path #{bundled_app("bundle")}"
-      bundle! :install, :standalone => true, :dir => cwd
+      bundle :install, :standalone => true, :dir => cwd
     end
 
     let(:expected_gems) do
@@ -127,7 +127,7 @@ RSpec.shared_examples "bundle install --standalone" do
         gem "devise", :git => "#{lib_path("devise-1.0")}"
       G
       bundle "config --local path #{bundled_app("bundle")}"
-      bundle! :install, :standalone => true, :dir => cwd
+      bundle :install, :standalone => true, :dir => cwd
     end
 
     let(:expected_gems) do
@@ -155,7 +155,7 @@ RSpec.shared_examples "bundle install --standalone" do
         end
       G
       bundle "config --local path #{bundled_app("bundle")}"
-      bundle! :install, :standalone => true, :dir => cwd
+      bundle :install, :standalone => true, :dir => cwd
     end
 
     let(:expected_gems) do
@@ -169,7 +169,7 @@ RSpec.shared_examples "bundle install --standalone" do
 
     it "allows creating a standalone file with limited groups" do
       bundle "config --local path #{bundled_app("bundle")}"
-      bundle! :install, :standalone => "default", :dir => cwd
+      bundle :install, :standalone => "default", :dir => cwd
 
       load_error_ruby <<-RUBY, "spec"
         $:.unshift File.expand_path("bundle")
@@ -187,7 +187,7 @@ RSpec.shared_examples "bundle install --standalone" do
     it "allows `without` configuration to limit the groups used in a standalone" do
       bundle "config --local path #{bundled_app("bundle")}"
       bundle "config --local without test"
-      bundle! :install, :standalone => true, :dir => cwd
+      bundle :install, :standalone => true, :dir => cwd
 
       load_error_ruby <<-RUBY, "spec"
         $:.unshift File.expand_path("bundle")
@@ -204,7 +204,7 @@ RSpec.shared_examples "bundle install --standalone" do
 
     it "allows `path` configuration to change the location of the standalone bundle" do
       bundle "config --local path path/to/bundle"
-      bundle! "install", :standalone => true, :dir => cwd
+      bundle "install", :standalone => true, :dir => cwd
 
       ruby <<-RUBY
         $:.unshift File.expand_path("path/to/bundle")
@@ -219,9 +219,9 @@ RSpec.shared_examples "bundle install --standalone" do
 
     it "allows `without` to limit the groups used in a standalone" do
       bundle "config --local without test"
-      bundle! :install, :dir => cwd
+      bundle :install, :dir => cwd
       bundle "config --local path #{bundled_app("bundle")}"
-      bundle! :install, :standalone => true, :dir => cwd
+      bundle :install, :standalone => true, :dir => cwd
 
       load_error_ruby <<-RUBY, "spec"
         $:.unshift File.expand_path("bundle")
@@ -247,7 +247,7 @@ RSpec.shared_examples "bundle install --standalone" do
           gem "rails"
         G
         bundle "config --local path #{bundled_app("bundle")}"
-        bundle! :install, :standalone => true, :artifice => "endpoint", :dir => cwd
+        bundle :install, :standalone => true, :artifice => "endpoint", :dir => cwd
       end
 
       let(:expected_gems) do
@@ -268,7 +268,7 @@ RSpec.shared_examples "bundle install --standalone" do
         gem "rails"
       G
       bundle "config --local path #{bundled_app("bundle")}"
-      bundle! :install, :standalone => true, :binstubs => true, :dir => cwd
+      bundle :install, :standalone => true, :binstubs => true, :dir => cwd
     end
 
     let(:expected_gems) do

--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -290,7 +290,7 @@ RSpec.shared_examples "bundle install --standalone" do
       skip "exec format error" if Gem.win_platform?
 
       require "tmpdir"
-      sys_exec!(%(#{bundled_app("bin/rails")} -v), :dir => Dir.tmpdir)
+      sys_exec(%(#{bundled_app("bin/rails")} -v), :dir => Dir.tmpdir)
       expect(out).to eq("2.3.2")
     end
 
@@ -302,7 +302,7 @@ RSpec.shared_examples "bundle install --standalone" do
       symlink = File.join(symlink_dir, "rails")
 
       File.symlink(bundled_app("bin/rails"), symlink)
-      sys_exec!("#{symlink} -v")
+      sys_exec("#{symlink} -v")
       expect(out).to eq("2.3.2")
     end
 

--- a/bundler/spec/install/gems/sudo_spec.rb
+++ b/bundler/spec/install/gems/sudo_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "when using sudo", :sudo => true do
       end
 
       before do
-        bundle! "config set path.system true"
+        bundle "config set path.system true"
         subdir.mkpath
         sudo "chmod u-w #{subdir}"
       end
@@ -32,7 +32,7 @@ RSpec.describe "when using sudo", :sudo => true do
 
   describe "and GEM_HOME is owned by root" do
     before :each do
-      bundle! "config set path.system true"
+      bundle "config set path.system true"
       chown_system_gems_to_root
     end
 
@@ -141,7 +141,7 @@ RSpec.describe "when using sudo", :sudo => true do
 
   describe "and GEM_HOME is not writable" do
     it "installs" do
-      bundle! "config set path.system true"
+      bundle "config set path.system true"
       gem_home = tmp("sudo_gem_home")
       sudo "mkdir -p #{gem_home}"
       sudo "chmod ugo-w #{gem_home}"

--- a/bundler/spec/install/git_spec.rb
+++ b/bundler/spec/install/git_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "bundle install" do
 
       update_git "foo", "4.0", :path => lib_path("foo"), :gemspec => true
 
-      bundle! :update, :all => true
+      bundle :update, :all => true
       expect(out).to include("Using foo 2.0 (was 1.0) from #{file_uri_for(lib_path("foo"))} (at master~2@#{rev2})")
       expect(the_bundle).to include_gems "foo 2.0", :source => "git@#{lib_path("foo")}"
     end
@@ -59,7 +59,7 @@ RSpec.describe "bundle install" do
 
       bundle "config --local path vendor/bundle"
       bundle "config --local without development"
-      bundle! :install
+      bundle :install
 
       expect(out).to include("Bundle complete!")
     end

--- a/bundler/spec/install/git_spec.rb
+++ b/bundler/spec/install/git_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "bundle install" do
     it "displays the revision hash of the gem repository", :bundler => "< 3" do
       build_git "foo", "1.0", :path => lib_path("foo")
 
-      install_gemfile! <<-G
+      install_gemfile <<-G
         gem "foo", :git => "#{file_uri_for(lib_path("foo"))}"
       G
 
@@ -22,7 +22,7 @@ RSpec.describe "bundle install" do
       rev2 = revision_for(lib_path("foo"))[0..6]
       update_git "foo", "3.0", :path => lib_path("foo"), :gemspec => true
 
-      install_gemfile! <<-G
+      install_gemfile <<-G
         gem "foo", :git => "#{file_uri_for(lib_path("foo"))}", :ref => "master~2"
       G
 
@@ -71,7 +71,7 @@ RSpec.describe "bundle install" do
         build_git "gems", :path => lib_path("gems"), :gemspec => false
       end
 
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "foo", :git => "#{file_uri_for(lib_path("gems"))}", :glob => "foo/*.gemspec"
         gem "zebra", :git => "#{file_uri_for(lib_path("gems"))}", :glob => "zebra/*.gemspec"

--- a/bundler/spec/install/global_cache_spec.rb
+++ b/bundler/spec/install/global_cache_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe "global gem caching" do
       cached_extensions = Pathname.glob(home(".bundle", "cache", "extensions", "*", "*", "*", "*", "*")).sort
       expect(cached_extensions).to eq [gem_binary_cache, git_binary_cache].sort
 
-      run! <<-R
+      run <<-R
         require 'very_simple_binary_c'; puts ::VERY_SIMPLE_BINARY_IN_C
         require 'very_simple_git_binary_c'; puts ::VERY_SIMPLE_GIT_BINARY_IN_C
       R
@@ -225,7 +225,7 @@ RSpec.describe "global gem caching" do
 
       expect(Dir[home(".bundle", "cache", "extensions", "**", "*binary_c*")]).to all(end_with(".rb"))
 
-      run! <<-R
+      run <<-R
         require 'very_simple_binary_c'
         require 'very_simple_git_binary_c'
       R

--- a/bundler/spec/install/global_cache_spec.rb
+++ b/bundler/spec/install/global_cache_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe "global gem caching" do
-  before { bundle! "config set global_gem_cache true" }
+  before { bundle "config set global_gem_cache true" }
 
   describe "using the cross-application user cache" do
     let(:source)  { "http://localgemserver.test" }
@@ -64,7 +64,7 @@ RSpec.describe "global gem caching" do
           gem "rack", "1.0.0"
         G
 
-        bundle! :install, :artifice => "compact_index_no_gem"
+        bundle :install, :artifice => "compact_index_no_gem"
         # rack 1.0.0 is installed and rack 0.9.1 is not
         expect(the_bundle).to include_gems "rack 1.0.0"
         expect(the_bundle).not_to include_gems "rack 0.9.1"
@@ -75,7 +75,7 @@ RSpec.describe "global gem caching" do
           gem "rack", "0.9.1"
         G
 
-        bundle! :install, :artifice => "compact_index_no_gem"
+        bundle :install, :artifice => "compact_index_no_gem"
         # rack 0.9.1 is installed and rack 1.0.0 is not
         expect(the_bundle).to include_gems "rack 0.9.1"
         expect(the_bundle).not_to include_gems "rack 1.0.0"
@@ -87,7 +87,7 @@ RSpec.describe "global gem caching" do
           gem "rack"
         G
 
-        bundle! :install, :artifice => "compact_index"
+        bundle :install, :artifice => "compact_index"
         simulate_new_machine
         expect(the_bundle).not_to include_gems "rack 1.0.0"
         expect(source_global_cache("rack-1.0.0.gem")).to exist
@@ -98,7 +98,7 @@ RSpec.describe "global gem caching" do
           gem "rack", "0.9.1"
         G
 
-        bundle! :install, :artifice => "compact_index"
+        bundle :install, :artifice => "compact_index"
         simulate_new_machine
         expect(the_bundle).not_to include_gems "rack 0.9.1"
         expect(source2_global_cache("rack-0.9.1.gem")).to exist
@@ -174,7 +174,7 @@ RSpec.describe "global gem caching" do
 
         # Install using the global cache instead of by downloading the .gem
         # from the server
-        bundle! :install, :artifice => "compact_index_no_gem", :dir => bundled_app2
+        bundle :install, :artifice => "compact_index_no_gem", :dir => bundled_app2
 
         # activesupport is installed and both are in the global cache
         expect(the_bundle).not_to include_gems "rack 1.0.0", :dir => bundled_app2
@@ -220,8 +220,8 @@ RSpec.describe "global gem caching" do
       gem_binary_cache.join("very_simple_binary_c.rb").open("w") {|f| f << "puts File.basename(__FILE__)" }
       git_binary_cache.join("very_simple_git_binary_c.rb").open("w") {|f| f << "puts File.basename(__FILE__)" }
 
-      bundle! "config set --local path different_path"
-      bundle! :install
+      bundle "config set --local path different_path"
+      bundle :install
 
       expect(Dir[home(".bundle", "cache", "extensions", "**", "*binary_c*")]).to all(end_with(".rb"))
 

--- a/bundler/spec/install/global_cache_spec.rb
+++ b/bundler/spec/install/global_cache_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "global gem caching" do
     end
 
     it "caches gems into the global cache on download" do
-      install_gemfile! <<-G, :artifice => "compact_index"
+      install_gemfile <<-G, :artifice => "compact_index"
         source "#{source}"
         gem "rack"
       G
@@ -29,7 +29,7 @@ RSpec.describe "global gem caching" do
       source_global_cache.mkpath
       FileUtils.cp(gem_repo1("gems/rack-1.0.0.gem"), source_global_cache("rack-1.0.0.gem"))
 
-      install_gemfile! <<-G, :artifice => "compact_index_no_gem"
+      install_gemfile <<-G, :artifice => "compact_index_no_gem"
         source "#{source}"
         gem "rack"
       G
@@ -39,7 +39,7 @@ RSpec.describe "global gem caching" do
 
     describe "when the same gem from different sources is installed" do
       it "should use the appropriate one from the global cache" do
-        install_gemfile! <<-G, :artifice => "compact_index"
+        install_gemfile <<-G, :artifice => "compact_index"
           source "#{source}"
           gem "rack"
         G
@@ -49,7 +49,7 @@ RSpec.describe "global gem caching" do
         expect(source_global_cache("rack-1.0.0.gem")).to exist
         # rack 1.0.0 is not installed and it is in the global cache
 
-        install_gemfile! <<-G, :artifice => "compact_index"
+        install_gemfile <<-G, :artifice => "compact_index"
           source "#{source2}"
           gem "rack", "0.9.1"
         G
@@ -134,7 +134,7 @@ RSpec.describe "global gem caching" do
 
     describe "when installing gems from a different directory" do
       it "uses the global cache as a source" do
-        install_gemfile! <<-G, :artifice => "compact_index"
+        install_gemfile <<-G, :artifice => "compact_index"
           source "#{source}"
           gem "rack"
           gem "activesupport"
@@ -150,7 +150,7 @@ RSpec.describe "global gem caching" do
         expect(the_bundle).not_to include_gems "rack 1.0.0"
         expect(the_bundle).not_to include_gems "activesupport 2.3.5"
 
-        install_gemfile! <<-G, :artifice => "compact_index_no_gem"
+        install_gemfile <<-G, :artifice => "compact_index_no_gem"
           source "#{source}"
           gem "rack"
         G
@@ -193,7 +193,7 @@ RSpec.describe "global gem caching" do
       build_lib "very_simple_path_binary", &:add_c_extension
       revision = revision_for(lib_path("very_simple_git_binary-1.0"))[0, 12]
 
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
 
         gem "very_simple_binary"

--- a/bundler/spec/install/path_spec.rb
+++ b/bundler/spec/install/path_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "bundle install" do
 
     it "does not use available system gems with bundle --path vendor/bundle", :bundler => "< 3" do
       bundle "config --local path vendor/bundle"
-      bundle! :install
+      bundle :install
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
 
@@ -24,7 +24,7 @@ RSpec.describe "bundle install" do
       dir.mkpath
 
       bundle "config --local path #{dir.join("vendor/bundle")}"
-      bundle! :install, :dir => dir
+      bundle :install, :dir => dir
       expect(out).to include("installed into `./vendor/bundle`")
 
       dir.rmtree
@@ -32,7 +32,7 @@ RSpec.describe "bundle install" do
 
     it "prints a warning to let the user know what has happened with bundle --path vendor/bundle" do
       bundle "config --local path vendor/bundle"
-      bundle! :install
+      bundle :install
       expect(out).to include("gems are installed into `./vendor/bundle`")
     end
 
@@ -52,24 +52,24 @@ RSpec.describe "bundle install" do
     end
 
     context "with path_relative_to_cwd set to true" do
-      before { bundle! "config set path_relative_to_cwd true" }
+      before { bundle "config set path_relative_to_cwd true" }
 
       it "installs the bundle relatively to current working directory", :bundler => "< 3" do
-        bundle! "install --gemfile='#{bundled_app}/Gemfile' --path vendor/bundle", :dir => bundled_app.parent
+        bundle "install --gemfile='#{bundled_app}/Gemfile' --path vendor/bundle", :dir => bundled_app.parent
         expect(out).to include("installed into `./vendor/bundle`")
         expect(bundled_app("../vendor/bundle")).to be_directory
         expect(the_bundle).to include_gems "rack 1.0.0"
       end
 
       it "installs the standalone bundle relative to the cwd" do
-        bundle! :install, :gemfile => bundled_app_gemfile, :standalone => true, :dir => bundled_app.parent
+        bundle :install, :gemfile => bundled_app_gemfile, :standalone => true, :dir => bundled_app.parent
         expect(out).to include("installed into `./bundled_app/bundle`")
         expect(bundled_app("bundle")).to be_directory
         expect(bundled_app("bundle/ruby")).to be_directory
 
-        bundle! "config unset path"
+        bundle "config unset path"
 
-        bundle! :install, :gemfile => bundled_app_gemfile, :standalone => true, :dir => bundled_app("subdir").tap(&:mkpath)
+        bundle :install, :gemfile => bundled_app_gemfile, :standalone => true, :dir => bundled_app("subdir").tap(&:mkpath)
         expect(out).to include("installed into `../bundle`")
         expect(bundled_app("bundle")).to be_directory
         expect(bundled_app("bundle/ruby")).to be_directory
@@ -93,7 +93,7 @@ RSpec.describe "bundle install" do
       if type == :env
         ENV["BUNDLE_PATH"] = location
       elsif type == :global
-        bundle! "config set path #{location}", "no-color" => nil
+        bundle "config set path #{location}", "no-color" => nil
       end
     end
 
@@ -102,7 +102,7 @@ RSpec.describe "bundle install" do
         it "installs gems to a path if one is specified" do
           set_bundle_path(type, bundled_app("vendor2").to_s)
           bundle "config --local path vendor/bundle"
-          bundle! :install
+          bundle :install
 
           expect(vendored_gems("gems/rack-1.0.0")).to be_directory
           expect(bundled_app("vendor2")).not_to be_directory
@@ -111,9 +111,9 @@ RSpec.describe "bundle install" do
 
         it "installs gems to ." do
           set_bundle_path(type, ".")
-          bundle! "config set --global disable_shared_gems true"
+          bundle "config set --global disable_shared_gems true"
 
-          bundle! :install
+          bundle :install
 
           paths_to_exist = %w[cache/rack-1.0.0.gem gems/rack-1.0.0 specifications/rack-1.0.0.gemspec].map {|path| bundled_app(Bundler.ruby_scope, path) }
           expect(paths_to_exist).to all exist
@@ -123,7 +123,7 @@ RSpec.describe "bundle install" do
         it "installs gems to the path" do
           set_bundle_path(type, bundled_app("vendor").to_s)
 
-          bundle! :install
+          bundle :install
 
           expect(bundled_app("vendor", Bundler.ruby_scope, "gems/rack-1.0.0")).to be_directory
           expect(the_bundle).to include_gems "rack 1.0.0"
@@ -133,7 +133,7 @@ RSpec.describe "bundle install" do
           set_bundle_path(type, "vendor")
 
           FileUtils.mkdir_p bundled_app("lol")
-          bundle! :install, :dir => bundled_app("lol")
+          bundle :install, :dir => bundled_app("lol")
 
           expect(bundled_app("vendor", Bundler.ruby_scope, "gems/rack-1.0.0")).to be_directory
           expect(the_bundle).to include_gems "rack 1.0.0"
@@ -152,7 +152,7 @@ RSpec.describe "bundle install" do
 
     it "sets BUNDLE_PATH as the first argument to bundle install" do
       bundle "config --local path ./vendor/bundle"
-      bundle! :install
+      bundle :install
 
       expect(vendored_gems("gems/rack-1.0.0")).to be_directory
       expect(the_bundle).to include_gems "rack 1.0.0"
@@ -162,7 +162,7 @@ RSpec.describe "bundle install" do
       # This is so that vendored gems can be distributed to others
       build_gem "rack", "1.1.0", :to_system => true
       bundle "config --local path ./vendor/bundle"
-      bundle! :install
+      bundle :install
 
       expect(vendored_gems("gems/rack-1.0.0")).to be_directory
       expect(the_bundle).to include_gems "rack 1.0.0"
@@ -179,7 +179,7 @@ RSpec.describe "bundle install" do
       G
 
       bundle "config --local path ./vendor/bundle"
-      bundle! :install
+      bundle :install
 
       expect(vendored_gems("gems/very_simple_binary-1.0")).to be_directory
       expect(vendored_gems("extensions")).to be_directory

--- a/bundler/spec/install/process_lock_spec.rb
+++ b/bundler/spec/install/process_lock_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "process lock spec" do
         end
       end
 
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G

--- a/bundler/spec/install/redownload_spec.rb
+++ b/bundler/spec/install/redownload_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe "bundle install" do
     it "re-installs installed gems" do
       rack_lib = default_bundle_path("gems/rack-1.0.0/lib/rack.rb")
 
-      bundle! :install
+      bundle :install
       rack_lib.open("w") {|f| f.write("blah blah blah") }
-      bundle! :install, flag => true
+      bundle :install, flag => true
 
       expect(out).to include "Installing rack 1.0.0"
       expect(rack_lib.open(&:read)).to eq("RACK = '1.0.0'\n")
@@ -22,7 +22,7 @@ RSpec.describe "bundle install" do
     end
 
     it "works on first bundle install" do
-      bundle! :install, flag => true
+      bundle :install, flag => true
 
       expect(out).to include "Installing rack 1.0.0"
       expect(the_bundle).to include_gems "rack 1.0.0"
@@ -40,16 +40,16 @@ RSpec.describe "bundle install" do
       it "re-installs installed gems" do
         foo_lib = default_bundle_path("bundler/gems/foo-1.0-#{ref}/lib/foo.rb")
 
-        bundle! :install
+        bundle :install
         foo_lib.open("w") {|f| f.write("blah blah blah") }
-        bundle! :install, flag => true
+        bundle :install, flag => true
 
         expect(foo_lib.open(&:read)).to eq("FOO = '1.0'\n")
         expect(the_bundle).to include_gems "foo 1.0"
       end
 
       it "works on first bundle install" do
-        bundle! :install, flag => true
+        bundle :install, flag => true
 
         expect(the_bundle).to include_gems "foo 1.0"
       end
@@ -62,12 +62,12 @@ RSpec.describe "bundle install" do
     end
 
     it "shows a deprecation when single flag passed" do
-      bundle! "install --force"
+      bundle "install --force"
       expect(err).to include "[DEPRECATED] The `--force` option has been renamed to `--redownload`"
     end
 
     it "shows a deprecation when multiple flags passed" do
-      bundle! "install --no-color --force"
+      bundle "install --no-color --force"
       expect(err).to include "[DEPRECATED] The `--force` option has been renamed to `--redownload`"
     end
   end
@@ -78,12 +78,12 @@ RSpec.describe "bundle install" do
     end
 
     it "does not show a deprecation when single flag passed" do
-      bundle! "install --redownload"
+      bundle "install --redownload"
       expect(err).not_to include "[DEPRECATED] The `--force` option has been renamed to `--redownload`"
     end
 
     it "does not show a deprecation when single multiple flags passed" do
-      bundle! "install --no-color --redownload"
+      bundle "install --no-color --redownload"
       expect(err).not_to include "[DEPRECATED] The `--force` option has been renamed to `--redownload`"
     end
   end

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -620,7 +620,7 @@ RSpec.describe "the lockfile format" do
   it "serializes pinned path sources to the lockfile even when packaging" do
     build_lib "foo"
 
-    install_gemfile! <<-G
+    install_gemfile <<-G
       gem "foo", :path => "#{lib_path("foo-1.0")}"
     G
 
@@ -1048,7 +1048,7 @@ RSpec.describe "the lockfile format" do
 
     simulate_platform "universal-java-16"
 
-    install_gemfile! <<-G
+    install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}"
       gem "platform_specific"
     G
@@ -1079,7 +1079,7 @@ RSpec.describe "the lockfile format" do
 
     simulate_platform "universal-java-16"
 
-    install_gemfile! <<-G
+    install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}"
       gem "platform_specific"
     G

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -496,7 +496,7 @@ RSpec.describe "the lockfile format" do
          #{Bundler::VERSION}
     L
 
-    bundle! "install"
+    bundle "install"
     expect(the_bundle).to include_gems "rack 1.0.0"
   end
 
@@ -625,8 +625,8 @@ RSpec.describe "the lockfile format" do
     G
 
     bundle "config set cache_all true"
-    bundle! :cache
-    bundle! :install, :local => true
+    bundle :cache
+    bundle :install, :local => true
 
     lockfile_should_be <<-G
       PATH
@@ -1294,7 +1294,7 @@ RSpec.describe "the lockfile format" do
     G
 
     bundle "config --local path vendor"
-    bundle! :install
+    bundle :install
     expect(the_bundle).to include_gems "omg 1.0"
 
     # Create a Gemfile.lock that has duplicate GIT sections

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe "major deprecations" do
   describe "bundle config" do
     describe "old list interface" do
       before do
-        bundle! "config"
+        bundle "config"
       end
 
       it "warns", :bundler => "3" do
@@ -158,7 +158,7 @@ RSpec.describe "major deprecations" do
 
     describe "old get interface" do
       before do
-        bundle! "config waka"
+        bundle "config waka"
       end
 
       it "warns", :bundler => "3" do
@@ -170,7 +170,7 @@ RSpec.describe "major deprecations" do
 
     describe "old set interface" do
       before do
-        bundle! "config waka wakapun"
+        bundle "config waka wakapun"
       end
 
       it "warns", :bundler => "3" do
@@ -182,7 +182,7 @@ RSpec.describe "major deprecations" do
 
     describe "old set interface with --local" do
       before do
-        bundle! "config --local waka wakapun"
+        bundle "config --local waka wakapun"
       end
 
       it "warns", :bundler => "3" do
@@ -194,7 +194,7 @@ RSpec.describe "major deprecations" do
 
     describe "old set interface with --global" do
       before do
-        bundle! "config --global waka wakapun"
+        bundle "config --global waka wakapun"
       end
 
       it "warns", :bundler => "3" do
@@ -206,7 +206,7 @@ RSpec.describe "major deprecations" do
 
     describe "old unset interface" do
       before do
-        bundle! "config --delete waka"
+        bundle "config --delete waka"
       end
 
       it "warns", :bundler => "3" do
@@ -218,7 +218,7 @@ RSpec.describe "major deprecations" do
 
     describe "old unset interface with --local" do
       before do
-        bundle! "config --delete --local waka"
+        bundle "config --delete --local waka"
       end
 
       it "warns", :bundler => "3" do
@@ -230,7 +230,7 @@ RSpec.describe "major deprecations" do
 
     describe "old unset interface with --global" do
       before do
-        bundle! "config --delete --global waka"
+        bundle "config --delete --global waka"
       end
 
       it "warns", :bundler => "3" do
@@ -250,14 +250,14 @@ RSpec.describe "major deprecations" do
     end
 
     it "warns when no options are given", :bundler => "3" do
-      bundle! "update"
+      bundle "update"
       expect(deprecations).to include("Pass --all to `bundle update` to update everything")
     end
 
     pending "fails with a helpful error when no options are given", :bundler => "3"
 
     it "does not warn when --all is passed" do
-      bundle! "update --all"
+      bundle "update --all"
       expect(deprecations).to be_empty
     end
   end
@@ -489,7 +489,7 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
 
     context "without flags" do
       before do
-        bundle! :show
+        bundle :show
       end
 
       it "prints a deprecation warning recommending `bundle list`", :bundler => "2" do
@@ -501,7 +501,7 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
 
     context "with --outdated flag" do
       before do
-        bundle! "show --outdated"
+        bundle "show --outdated"
       end
 
       it "prints a deprecation warning informing about its removal", :bundler => "2" do
@@ -513,7 +513,7 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
 
     context "with --verbose flag" do
       before do
-        bundle! "show --verbose"
+        bundle "show --verbose"
       end
 
       it "prints a deprecation warning informing about its removal", :bundler => "2" do
@@ -525,7 +525,7 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
 
     context "with a gem argument" do
       before do
-        bundle! "show rack"
+        bundle "show rack"
       end
 
       it "prints a deprecation warning recommending `bundle info`", :bundler => "2" do

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "major deprecations" do
 
   describe "Bundler" do
     before do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
@@ -290,7 +290,7 @@ RSpec.describe "major deprecations" do
 
     it "should print a proper warning, and use gems.rb" do
       create_file "gems.rb"
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
@@ -373,7 +373,7 @@ RSpec.describe "major deprecations" do
   context "when Bundler.setup is run in a ruby script" do
     before do
       create_file "gems.rb"
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rack", :group => :test
       G
@@ -481,7 +481,7 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
 
   context "bundle show" do
     before do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G

--- a/bundler/spec/other/platform_spec.rb
+++ b/bundler/spec/other/platform_spec.rb
@@ -594,7 +594,7 @@ G
     end
 
     it "prints path if ruby version is correct" do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rails"
 
@@ -606,7 +606,7 @@ G
     end
 
     it "prints path if ruby version is correct for any engine", :jruby do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rails"
 
@@ -689,7 +689,7 @@ G
     end
 
     it "copies the .gem file to vendor/cache when ruby version matches for any engine", :jruby do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
 
@@ -748,7 +748,7 @@ G
 
   context "bundle pack" do
     before do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
       G
@@ -766,7 +766,7 @@ G
     end
 
     it "copies the .gem file to vendor/cache when ruby version matches any engine", :jruby do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
 

--- a/bundler/spec/other/platform_spec.rb
+++ b/bundler/spec/other/platform_spec.rb
@@ -232,7 +232,7 @@ G
            #{Bundler::VERSION}
       L
 
-      bundle! "platform --ruby"
+      bundle "platform --ruby"
       expect(out).to eq("ruby 1.0.0p127")
     end
 
@@ -241,7 +241,7 @@ G
         ruby ">= 1.8.7"
       G
 
-      bundle! "platform --ruby"
+      bundle "platform --ruby"
       expect(out).to eq("ruby 1.8.7")
     end
 
@@ -250,7 +250,7 @@ G
         ruby ">= 1.8.7", "< 2.0.0"
       G
 
-      bundle! "platform --ruby"
+      bundle "platform --ruby"
       expect(out).to eq("ruby 1.8.7")
     end
   end
@@ -696,7 +696,7 @@ G
         #{ruby_version_correct_engineless}
       G
 
-      bundle! :cache
+      bundle :cache
       expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
     end
 
@@ -1148,7 +1148,7 @@ G
     end
 
     it "returns list of outdated gems when the ruby version matches for any engine", :jruby do
-      bundle! :install
+      bundle :install
       update_repo2 do
         build_gem "activesupport", "3.0"
         update_git "foo", :path => lib_path("foo")

--- a/bundler/spec/plugins/install_spec.rb
+++ b/bundler/spec/plugins/install_spec.rb
@@ -210,13 +210,13 @@ RSpec.describe "bundler plugin install" do
 
     context "in deployment mode" do
       it "installs plugins" do
-        install_gemfile! <<-G
+        install_gemfile <<-G
           source '#{file_uri_for(gem_repo2)}'
           gem 'rack', "1.0.0"
         G
 
         bundle "config --local deployment true"
-        install_gemfile! <<-G
+        install_gemfile <<-G
           source '#{file_uri_for(gem_repo2)}'
           plugin 'foo'
           gem 'rack', "1.0.0"

--- a/bundler/spec/plugins/source/example_spec.rb
+++ b/bundler/spec/plugins/source/example_spec.rb
@@ -157,9 +157,9 @@ RSpec.describe "real source plugins" do
 
       it "copies repository to vendor cache and uses it even when installed with `path` configured" do
         bundle "config --local path vendor/bundle"
-        bundle! :install
+        bundle :install
         bundle "config set cache_all true"
-        bundle! :cache
+        bundle :cache
 
         expect(bundled_app("vendor/cache/a-path-gem-1.0-#{uri_hash}")).to exist
 
@@ -169,9 +169,9 @@ RSpec.describe "real source plugins" do
 
       it "bundler package copies repository to vendor cache" do
         bundle "config --local path vendor/bundle"
-        bundle! :install
+        bundle :install
         bundle "config set cache_all true"
-        bundle! :cache
+        bundle :cache
 
         expect(bundled_app("vendor/cache/a-path-gem-1.0-#{uri_hash}")).to exist
 
@@ -205,7 +205,7 @@ RSpec.describe "real source plugins" do
       end
 
       it "installs" do
-        bundle! "install"
+        bundle "install"
 
         expect(the_bundle).to include_gems("a-path-gem 1.0")
       end

--- a/bundler/spec/quality_spec.rb
+++ b/bundler/spec/quality_spec.rb
@@ -234,7 +234,7 @@ RSpec.describe "The library itself" do
     files_to_require = lib_tracked_files.grep(/\.rb$/) - exclusions
     files_to_require.reject! {|f| f.start_with?("lib/bundler/vendor") }
     files_to_require.map! {|f| File.expand_path(f, source_root) }
-    sys_exec!("ruby -w") do |input, _, _|
+    sys_exec("ruby -w") do |input, _, _|
       files_to_require.each do |f|
         input.puts "require '#{f}'"
       end

--- a/bundler/spec/realworld/dependency_api_spec.rb
+++ b/bundler/spec/realworld/dependency_api_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "gemcutter's dependency API", :realworld => true do
       @t.run
 
       wait_for_server("127.0.0.1", port)
-      bundle! "config set timeout 1"
+      bundle "config set timeout 1"
     end
 
     after do

--- a/bundler/spec/realworld/dependency_api_spec.rb
+++ b/bundler/spec/realworld/dependency_api_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "gemcutter's dependency API", :realworld => true do
     end
 
     it "times out and falls back on the modern index" do
-      install_gemfile! <<-G, :artifice => nil
+      install_gemfile <<-G, :artifice => nil
         source "#{@server_uri}"
         gem "rack"
       G

--- a/bundler/spec/realworld/double_check_spec.rb
+++ b/bundler/spec/realworld/double_check_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "double checking sources", :realworld => true, :sometimes => true
       end
     RUBY
 
-    ruby! cmd
-    ruby! cmd
+    ruby cmd
+    ruby cmd
   end
 end

--- a/bundler/spec/realworld/edgecases_spec.rb
+++ b/bundler/spec/realworld/edgecases_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
       gem 'capybara', '~> 2.2.0'
       gem 'rack-cache', '1.2.0' # last version that works on Ruby 1.9
     G
-    bundle! :lock
+    bundle :lock
     expect(lockfile).to include(rubygems_version("rails", "~> 5.0"))
     expect(lockfile).to include("capybara (2.2.1)")
   end
@@ -43,7 +43,7 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
       gem "gxapi_rails", "< 0.1.0" # 0.1.0 was released way after the test was written
       gem 'rack-cache', '1.2.0' # last version that works on Ruby 1.9
     G
-    bundle! :lock
+    bundle :lock
     expect(lockfile).to include("gxapi_rails (0.0.6)")
   end
 
@@ -56,7 +56,7 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
       gem "activerecord", "~> 3.0"
       gem "builder", "~> 2.1.2"
     G
-    bundle! :lock
+    bundle :lock
     expect(lockfile).to include(rubygems_version("i18n", "~> 0.6.0"))
     expect(lockfile).to include(rubygems_version("activesupport", "~> 3.0"))
   end
@@ -189,7 +189,7 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
         rails (~> 4.2.7.1)
     L
 
-    bundle! "lock --update paperclip"
+    bundle "lock --update paperclip"
 
     expect(lockfile).to include(rubygems_version("paperclip", "~> 5.1.0"))
   end
@@ -204,7 +204,7 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
     G
 
     bundle "config set --local path vendor/bundle"
-    bundle! :install
+    bundle :install
     expect(err).not_to include("Could not find rake")
     expect(err).to be_empty
   end
@@ -332,7 +332,7 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
         activesupport!
     L
 
-    bundle! :lock
+    bundle :lock
     expect(err).to be_empty
   end
 

--- a/bundler/spec/realworld/edgecases_spec.rb
+++ b/bundler/spec/realworld/edgecases_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
   def rubygems_version(name, requirement)
-    ruby! <<-RUBY
+    ruby <<-RUBY
       require "#{spec_dir}/support/artifice/vcr"
       require "#{lib_dir}/bundler"
       require "#{lib_dir}/bundler/source/rubygems/remote"

--- a/bundler/spec/runtime/executable_spec.rb
+++ b/bundler/spec/runtime/executable_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "Running bin/* commands" do
   before :each do
-    install_gemfile! <<-G
+    install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G
@@ -140,7 +140,7 @@ RSpec.describe "Running bin/* commands" do
   end
 
   it "rewrites bins on binstubs (to maintain backwards compatibility)" do
-    install_gemfile! <<-G
+    install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G

--- a/bundler/spec/runtime/executable_spec.rb
+++ b/bundler/spec/runtime/executable_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Running bin/* commands" do
   it "runs the bundled command when in the bundle" do
     skip "exec format error" if Gem.win_platform?
 
-    bundle! "binstubs rack"
+    bundle "binstubs rack"
 
     build_gem "rack", "2.0", :to_system => true do |s|
       s.executables = "rackup"
@@ -24,7 +24,7 @@ RSpec.describe "Running bin/* commands" do
   it "allows the location of the gem stubs to be specified" do
     skip "created in bin :/" if Gem.win_platform?
 
-    bundle! "binstubs rack", :path => "gbin"
+    bundle "binstubs rack", :path => "gbin"
 
     expect(bundled_app("bin")).not_to exist
     expect(bundled_app("gbin/rackup")).to exist
@@ -36,28 +36,28 @@ RSpec.describe "Running bin/* commands" do
   it "allows absolute paths as a specification of where to install bin stubs" do
     skip "exec format error" if Gem.win_platform?
 
-    bundle! "binstubs rack", :path => tmp("bin")
+    bundle "binstubs rack", :path => tmp("bin")
 
     gembin tmp("bin/rackup")
     expect(out).to eq("1.0.0")
   end
 
   it "uses the default ruby install name when shebang is not specified" do
-    bundle! "binstubs rack"
+    bundle "binstubs rack"
     expect(File.open(bundled_app("bin/rackup")).gets).to eq("#!/usr/bin/env #{RbConfig::CONFIG["ruby_install_name"]}\n")
   end
 
   it "allows the name of the shebang executable to be specified" do
     skip "not created with custom name :/" if Gem.win_platform?
 
-    bundle! "binstubs rack", :shebang => "ruby-foo"
+    bundle "binstubs rack", :shebang => "ruby-foo"
     expect(File.open(bundled_app("bin/rackup")).gets).to eq("#!/usr/bin/env ruby-foo\n")
   end
 
   it "runs the bundled command when out of the bundle" do
     skip "exec format error" if Gem.win_platform?
 
-    bundle! "binstubs rack"
+    bundle "binstubs rack"
 
     build_gem "rack", "2.0", :to_system => true do |s|
       s.executables = "rackup"
@@ -78,7 +78,7 @@ RSpec.describe "Running bin/* commands" do
       gem "rack", :path => "#{lib_path("rack")}"
     G
 
-    bundle! "binstubs rack"
+    bundle "binstubs rack"
 
     build_gem "rack", "2.0", :to_system => true do |s|
       s.executables = "rackup"
@@ -94,7 +94,7 @@ RSpec.describe "Running bin/* commands" do
       gem "bundler"
     G
 
-    bundle! "binstubs bundler"
+    bundle "binstubs bundler"
 
     expect(bundled_app("bin/bundle")).to exist
   end
@@ -102,7 +102,7 @@ RSpec.describe "Running bin/* commands" do
   it "does not generate bin stubs if the option was not specified" do
     skip "generated :/" if Gem.win_platform?
 
-    bundle! "install"
+    bundle "install"
 
     expect(bundled_app("bin/rackup")).not_to exist
   end
@@ -110,13 +110,13 @@ RSpec.describe "Running bin/* commands" do
   it "allows you to stop installing binstubs", :bundler => "< 3" do
     skip "delete permission error" if Gem.win_platform?
 
-    bundle! "install --binstubs bin/"
+    bundle "install --binstubs bin/"
     bundled_app("bin/rackup").rmtree
-    bundle! "install --binstubs \"\""
+    bundle "install --binstubs \"\""
 
     expect(bundled_app("bin/rackup")).not_to exist
 
-    bundle! "config bin"
+    bundle "config bin"
     expect(out).to include("You have not configured a value for `bin`")
   end
 
@@ -126,7 +126,7 @@ RSpec.describe "Running bin/* commands" do
       gem "activesupport"
     G
 
-    bundle! :install, :binstubs => "bin"
+    bundle :install, :binstubs => "bin"
 
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -147,7 +147,7 @@ RSpec.describe "Running bin/* commands" do
 
     create_file("bin/rackup", "OMG")
 
-    bundle! "binstubs rack"
+    bundle "binstubs rack"
 
     expect(bundled_app("bin/rackup").read).to_not eq("OMG")
   end
@@ -156,7 +156,7 @@ RSpec.describe "Running bin/* commands" do
     skip "exec format error" if Gem.win_platform?
 
     # context with bin/bundler w/ default Gemfile
-    bundle! "binstubs bundler"
+    bundle "binstubs bundler"
 
     # generate other Gemfile with executable gem
     build_repo2 do
@@ -171,7 +171,7 @@ RSpec.describe "Running bin/* commands" do
     # generate binstub for executable from non default Gemfile (other then bin/bundler version)
     ENV["BUNDLE_GEMFILE"] = "OtherGemfile"
     bundle "install"
-    bundle! "binstubs bindir"
+    bundle "binstubs bindir"
 
     # remove user settings
     ENV["BUNDLE_GEMFILE"] = nil

--- a/bundler/spec/runtime/gem_tasks_spec.rb
+++ b/bundler/spec/runtime/gem_tasks_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
 
   it "adds 'pkg' to rake/clean's CLOBBER" do
     with_gem_path_as(base_system_gems.to_s) do
-      sys_exec! %(#{rake} -e 'load "Rakefile"; puts CLOBBER.inspect'), :env => { "GEM_HOME" => system_gem_path.to_s }
+      sys_exec %(#{rake} -e 'load "Rakefile"; puts CLOBBER.inspect'), :env => { "GEM_HOME" => system_gem_path.to_s }
     end
     expect(out).to eq '["pkg"]'
   end

--- a/bundler/spec/runtime/gem_tasks_spec.rb
+++ b/bundler/spec/runtime/gem_tasks_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
 
     expect(err).to be_empty
 
-    bundle! "exec rake install"
+    bundle "exec rake install"
 
     expect(err).to be_empty
   end
@@ -60,7 +60,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
     before do
       spaced_bundled_app = tmp.join("bundled app")
       FileUtils.cp_r bundled_app, spaced_bundled_app
-      bundle! "exec rake build", :dir => spaced_bundled_app
+      bundle "exec rake build", :dir => spaced_bundled_app
     end
 
     it "still runs successfully" do
@@ -80,7 +80,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
         gem "rake"
       G
 
-      bundle! "exec rake -T"
+      bundle "exec rake -T"
 
       expect(err).to be_empty
     end

--- a/bundler/spec/runtime/gem_tasks_spec.rb
+++ b/bundler/spec/runtime/gem_tasks_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
       RAKEFILE
     end
 
-    install_gemfile! <<-G
+    install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
 
       gem "rake"
@@ -74,7 +74,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
     end
 
     it "works", :ruby_repo do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
 
         gem "rake"

--- a/bundler/spec/runtime/load_spec.rb
+++ b/bundler/spec/runtime/load_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "Bundler.load" do
         gem "activesupport", :group => :test
       G
 
-      ruby! <<-RUBY
+      ruby <<-RUBY
         require "#{lib_dir}/bundler"
         Bundler.setup :default
         Bundler.require :default

--- a/bundler/spec/runtime/load_spec.rb
+++ b/bundler/spec/runtime/load_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "Bundler.load" do
   describe "with a gemfile" do
     before(:each) do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
@@ -75,7 +75,7 @@ RSpec.describe "Bundler.load" do
 
   describe "when called twice" do
     it "doesn't try to load the runtime twice" do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
         gem "activesupport", :group => :test
@@ -99,7 +99,7 @@ RSpec.describe "Bundler.load" do
 
   describe "not hurting brittle rubygems" do
     it "does not inject #source into the generated YAML of the gem specs" do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "activerecord"
       G

--- a/bundler/spec/runtime/load_spec.rb
+++ b/bundler/spec/runtime/load_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Bundler.load" do
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
-      bundle! :install
+      bundle :install
       allow(Bundler::SharedHelpers).to receive(:pwd).and_return(bundled_app)
     end
 

--- a/bundler/spec/runtime/platform_spec.rb
+++ b/bundler/spec/runtime/platform_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
     G
 
     simulate_platform "x86-darwin-10"
-    install_gemfile! <<-G
+    install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
       gem "nokogiri"
     G
@@ -75,7 +75,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
 
     simulate_platform "x86-darwin-100"
 
-    install_gemfile! <<-G
+    install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
       gem "nokogiri"
       gem "platform_specific"
@@ -87,7 +87,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
   it "allows specifying only-ruby-platform" do
     simulate_platform "java"
 
-    install_gemfile! <<-G
+    install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
       gem "nokogiri"
       gem "platform_specific"
@@ -102,7 +102,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
 
   it "allows specifying only-ruby-platform on windows with dependency platforms" do
     simulate_windows do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "nokogiri", :platforms => [:mingw, :mswin, :x64_mingw, :jruby]
         gem "platform_specific"
@@ -159,7 +159,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
           requires_platform_specific
       L
 
-      install_gemfile! <<-G, :verbose => true
+      install_gemfile <<-G, :verbose => true
         source "#{file_uri_for(gem_repo2)}"
         gem "requires_platform_specific"
       G

--- a/bundler/spec/runtime/platform_spec.rb
+++ b/bundler/spec/runtime/platform_spec.rb
@@ -93,9 +93,9 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
       gem "platform_specific"
     G
 
-    bundle! "config set force_ruby_platform true"
+    bundle "config set force_ruby_platform true"
 
-    bundle! "install"
+    bundle "install"
 
     expect(the_bundle).to include_gems "nokogiri 1.4.2", "platform_specific 1.0 RUBY"
   end
@@ -108,9 +108,9 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
         gem "platform_specific"
       G
 
-      bundle! "config set force_ruby_platform true"
+      bundle "config set force_ruby_platform true"
 
-      bundle! "install"
+      bundle "install"
 
       expect(the_bundle).to include_gems "platform_specific 1.0 RUBY"
       expect(the_bundle).to not_include_gems "nokogiri"
@@ -126,11 +126,11 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
       source "#{file_uri_for(gem_repo1)}"
       gemspec
     G
-    bundle! :lock
+    bundle :lock
 
     simulate_windows do
-      bundle! "config set force_ruby_platform true"
-      bundle! "install"
+      bundle "config set force_ruby_platform true"
+      bundle "install"
 
       expect(the_bundle).to include_gems "rack 1.0"
     end

--- a/bundler/spec/runtime/require_spec.rb
+++ b/bundler/spec/runtime/require_spec.rb
@@ -375,7 +375,7 @@ RSpec.describe "Bundler.require" do
       gem "rack"
     G
 
-    run! <<-R
+    run <<-R
       path = File.join(Gem.dir, "specifications", "rack-1.0.0.gemspec")
       contents = File.read(path)
       contents = contents.lines.to_a.insert(-2, "\n  raise 'broken gemspec'\n").join
@@ -384,7 +384,7 @@ RSpec.describe "Bundler.require" do
       end
     R
 
-    run! <<-R
+    run <<-R
       Bundler.require
       puts "WIN"
     R
@@ -399,7 +399,7 @@ RSpec.describe "Bundler.require" do
       gem "foo", :git => "#{lib_path("foo-1.0")}"
     G
 
-    run! <<-R
+    run <<-R
       path = Gem.loaded_specs["foo"].loaded_from
       contents = File.read(path)
       contents = contents.lines.to_a.insert(-2, "\n  raise 'broken gemspec'\n").join
@@ -408,7 +408,7 @@ RSpec.describe "Bundler.require" do
       end
     R
 
-    run! <<-R
+    run <<-R
       Bundler.require
       puts "WIN"
     R

--- a/bundler/spec/runtime/require_spec.rb
+++ b/bundler/spec/runtime/require_spec.rb
@@ -370,7 +370,7 @@ RSpec.describe "Bundler.require" do
   end
 
   it "does not load rubygems gemspecs that are used" do
-    install_gemfile! <<-G
+    install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G
@@ -395,7 +395,7 @@ RSpec.describe "Bundler.require" do
   it "does not load git gemspecs that are used" do
     build_git "foo"
 
-    install_gemfile! <<-G
+    install_gemfile <<-G
       gem "foo", :git => "#{lib_path("foo-1.0")}"
     G
 

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -670,7 +670,7 @@ RSpec.describe "Bundler.setup" do
       gem "rack"
     G
 
-    run! <<-R
+    run <<-R
       File.open(File.join(Gem.dir, "specifications", "broken.gemspec"), "w") do |f|
         f.write <<-RUBY
 # -*- encoding: utf-8 -*-
@@ -685,7 +685,7 @@ end
       end
     R
 
-    run! <<-R
+    run <<-R
       puts "WIN"
     R
 
@@ -722,7 +722,7 @@ end
           gem "with_man"
         G
 
-        run! "puts ENV['MANPATH']"
+        run "puts ENV['MANPATH']"
         expect(out).to eq("#{default_bundle_path("gems/with_man-1.0/man")}#{File::PATH_SEPARATOR}/foo")
       end
     end
@@ -736,7 +736,7 @@ end
           gem "with_man"
         G
 
-        run! "puts ENV['MANPATH']"
+        run "puts ENV['MANPATH']"
         expect(out).to eq(default_bundle_path("gems/with_man-1.0/man").to_s)
       end
     end

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe "Bundler.setup" do
     end
 
     it "falls back to order the load path alphabetically for backwards compatibility" do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "weakling"
         gem "duradura"
@@ -665,7 +665,7 @@ RSpec.describe "Bundler.setup" do
   end
 
   it "does not load all gemspecs" do
-    install_gemfile! <<-G
+    install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G
@@ -717,7 +717,7 @@ end
       before { ENV["MANPATH"] = "/foo#{File::PATH_SEPARATOR}" }
 
       it "adds the gem's man dir to the MANPATH" do
-        install_gemfile! <<-G
+        install_gemfile <<-G
           source "#{file_uri_for(gem_repo4)}"
           gem "with_man"
         G
@@ -731,7 +731,7 @@ end
       before { ENV.delete("MANPATH") }
 
       it "adds the gem's man dir to the MANPATH" do
-        install_gemfile! <<-G
+        install_gemfile <<-G
           source "#{file_uri_for(gem_repo4)}"
           gem "with_man"
         G
@@ -1194,7 +1194,7 @@ end
     end
 
     it "does not load openssl" do
-      install_gemfile! ""
+      install_gemfile ""
       ruby! <<-RUBY
         require "#{lib_dir}/bundler/setup"
         puts defined?(OpenSSL) || "undefined"
@@ -1250,13 +1250,13 @@ end
       RUBY
 
       it "activates no gems with -rbundler/setup" do
-        install_gemfile! ""
+        install_gemfile ""
         ruby! code, :env => { "RUBYOPT" => activation_warning_hack_rubyopt + " -r#{lib_dir}/bundler/setup" }
         expect(out).to eq("{}")
       end
 
       it "activates no gems with bundle exec" do
-        install_gemfile! ""
+        install_gemfile ""
         create_file("script.rb", code)
         bundle "exec ruby ./script.rb", :env => { "RUBYOPT" => activation_warning_hack_rubyopt }
         expect(out).to eq("{}")
@@ -1265,7 +1265,7 @@ end
       it "activates no gems with bundle exec that is loaded" do
         skip "not executable" if Gem.win_platform?
 
-        install_gemfile! ""
+        install_gemfile ""
         create_file("script.rb", "#!/usr/bin/env ruby\n\n#{code}")
         FileUtils.chmod(0o777, bundled_app("script.rb"))
         bundle "exec ./script.rb", :artifice => nil, :env => { "RUBYOPT" => activation_warning_hack_rubyopt }
@@ -1324,7 +1324,7 @@ end
             build_gem g, "999999"
           end
 
-          install_gemfile! <<-G
+          install_gemfile <<-G
             source "#{file_uri_for(gem_repo4)}"
             gem "#{g}", "999999"
           G
@@ -1340,7 +1340,7 @@ end
             build_gem g, "0.0.0.a"
           end
 
-          install_gemfile! <<-G
+          install_gemfile <<-G
             source "#{file_uri_for(gem_repo4)}"
             gem "#{g}", "0.0.0.a"
           G
@@ -1369,7 +1369,7 @@ end
     end
 
     it "keeps Kernel#gem private", :bundler => "3" do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
@@ -1385,7 +1385,7 @@ end
     end
 
     it "keeps Kernel#require private" do
-      install_gemfile! <<-G
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe "Bundler.setup" do
 
   context "load order" do
     def clean_load_path(lp)
-      without_bundler_load_path = ruby!("puts $LOAD_PATH").split("\n")
+      without_bundler_load_path = ruby("puts $LOAD_PATH").split("\n")
       lp -= without_bundler_load_path
       lp.map! {|p| p.sub(/^#{Regexp.union system_gem_path.to_s, default_bundle_path.to_s, lib_dir.to_s}/i, "") }
     end
@@ -143,7 +143,7 @@ RSpec.describe "Bundler.setup" do
         gem "rails"
       G
 
-      ruby! <<-RUBY
+      ruby <<-RUBY
         require '#{lib_dir}/bundler'
         Bundler.setup
         puts $LOAD_PATH
@@ -171,7 +171,7 @@ RSpec.describe "Bundler.setup" do
         gem "terranova"
       G
 
-      ruby! <<-RUBY
+      ruby <<-RUBY
         require '#{lib_dir}/bundler/setup'
         puts $LOAD_PATH
       RUBY
@@ -1158,14 +1158,14 @@ end
 
     context "is not present" do
       it "does not change the lock" do
-        expect { ruby! "require '#{lib_dir}/bundler/setup'" }.not_to change { lockfile }
+        expect { ruby "require '#{lib_dir}/bundler/setup'" }.not_to change { lockfile }
       end
     end
 
     context "is newer" do
       let(:ruby_version) { "5.5.5" }
       it "does not change the lock or warn" do
-        expect { ruby! "require '#{lib_dir}/bundler/setup'" }.not_to change { lockfile }
+        expect { ruby "require '#{lib_dir}/bundler/setup'" }.not_to change { lockfile }
         expect(out).to be_empty
         expect(err).to be_empty
       end
@@ -1174,7 +1174,7 @@ end
     context "is older" do
       let(:ruby_version) { "1.0.0" }
       it "does not change the lock" do
-        expect { ruby! "require '#{lib_dir}/bundler/setup'" }.not_to change { lockfile }
+        expect { ruby "require '#{lib_dir}/bundler/setup'" }.not_to change { lockfile }
       end
     end
   end
@@ -1195,7 +1195,7 @@ end
 
     it "does not load openssl" do
       install_gemfile ""
-      ruby! <<-RUBY
+      ruby <<-RUBY
         require "#{lib_dir}/bundler/setup"
         puts defined?(OpenSSL) || "undefined"
         require "openssl"
@@ -1251,7 +1251,7 @@ end
 
       it "activates no gems with -rbundler/setup" do
         install_gemfile ""
-        ruby! code, :env => { "RUBYOPT" => activation_warning_hack_rubyopt + " -r#{lib_dir}/bundler/setup" }
+        ruby code, :env => { "RUBYOPT" => activation_warning_hack_rubyopt + " -r#{lib_dir}/bundler/setup" }
         expect(out).to eq("{}")
       end
 
@@ -1359,7 +1359,7 @@ end
         gem "rack"
       G
 
-      ruby! <<-RUBY
+      ruby <<-RUBY
         require "#{lib_dir}/bundler/setup"
         Object.new.gem "rack"
         puts Gem.loaded_specs["rack"].full_name

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -482,14 +482,14 @@ RSpec.describe "Bundler.setup" do
 
     it "works even when the cache directory has been deleted" do
       bundle "config --local path vendor/bundle"
-      bundle! :install
+      bundle :install
       FileUtils.rm_rf vendored_gems("cache")
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
 
     it "does not randomly change the path when specifying --path and the bundle directory becomes read only" do
       bundle "config --local path vendor/bundle"
-      bundle! :install
+      bundle :install
 
       with_read_only("#{bundled_app}/**/*") do
         expect(the_bundle).to include_gems "rack 1.0.0"
@@ -518,7 +518,7 @@ RSpec.describe "Bundler.setup" do
       G
 
       bundle %(config set local.rack #{lib_path("local-rack")})
-      bundle! :install
+      bundle :install
 
       FileUtils.rm_rf(lib_path("local-rack"))
       run "require 'rack'", :raise_on_error => false
@@ -536,7 +536,7 @@ RSpec.describe "Bundler.setup" do
       G
 
       bundle %(config set local.rack #{lib_path("local-rack")})
-      bundle! :install
+      bundle :install
 
       gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
@@ -558,7 +558,7 @@ RSpec.describe "Bundler.setup" do
       G
 
       bundle %(config set local.rack #{lib_path("local-rack")})
-      bundle! :install
+      bundle :install
 
       gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
@@ -971,7 +971,7 @@ end
 
   describe "with system gems in the bundle" do
     before :each do
-      bundle! "config set path.system true"
+      bundle "config set path.system true"
       system_gems "rack-1.0.0"
 
       install_gemfile <<-G
@@ -1258,7 +1258,7 @@ end
       it "activates no gems with bundle exec" do
         install_gemfile! ""
         create_file("script.rb", code)
-        bundle! "exec ruby ./script.rb", :env => { "RUBYOPT" => activation_warning_hack_rubyopt }
+        bundle "exec ruby ./script.rb", :env => { "RUBYOPT" => activation_warning_hack_rubyopt }
         expect(out).to eq("{}")
       end
 
@@ -1268,7 +1268,7 @@ end
         install_gemfile! ""
         create_file("script.rb", "#!/usr/bin/env ruby\n\n#{code}")
         FileUtils.chmod(0o777, bundled_app("script.rb"))
-        bundle! "exec ./script.rb", :artifice => nil, :env => { "RUBYOPT" => activation_warning_hack_rubyopt }
+        bundle "exec ./script.rb", :artifice => nil, :env => { "RUBYOPT" => activation_warning_hack_rubyopt }
         expect(out).to eq("{}")
       end
 
@@ -1286,9 +1286,9 @@ end
 
         bundle "config set --local path vendor/bundle"
 
-        bundle! :install
+        bundle :install
 
-        bundle! :check
+        bundle :check
 
         expect(out).to eq("The Gemfile's dependencies are satisfied")
       end

--- a/bundler/spec/runtime/with_unbundled_env_spec.rb
+++ b/bundler/spec/runtime/with_unbundled_env_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "Bundler.with_env helpers" do
   def bundle_exec_ruby!(args, options = {})
     build_bundler_context options
-    bundle! "exec '#{Gem.ruby}' #{args}", options
+    bundle "exec '#{Gem.ruby}' #{args}", options
   end
 
   def build_bundler_context(options = {})

--- a/bundler/spec/runtime/with_unbundled_env_spec.rb
+++ b/bundler/spec/runtime/with_unbundled_env_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe "Bundler.with_env helpers" do
-  def bundle_exec_ruby!(args, options = {})
+  def bundle_exec_ruby(args, options = {})
     build_bundler_context options
     bundle "exec '#{Gem.ruby}' #{args}", options
   end
@@ -23,7 +23,7 @@ RSpec.describe "Bundler.with_env helpers" do
       RUBY
       path = `getconf PATH`.strip + "#{File::PATH_SEPARATOR}/foo"
       with_path_as(path) do
-        bundle_exec_ruby!(bundled_app("source.rb").to_s)
+        bundle_exec_ruby(bundled_app("source.rb").to_s)
         expect(last_command.stdboth).to eq(path)
       end
     end
@@ -34,7 +34,7 @@ RSpec.describe "Bundler.with_env helpers" do
       RUBY
       gem_path = ENV["GEM_PATH"] + "#{File::PATH_SEPARATOR}/foo"
       with_gem_path_as(gem_path) do
-        bundle_exec_ruby!(bundled_app("source.rb").to_s)
+        bundle_exec_ruby(bundled_app("source.rb").to_s)
         expect(last_command.stdboth).to eq(gem_path)
       end
     end
@@ -52,7 +52,7 @@ RSpec.describe "Bundler.with_env helpers" do
       path = `getconf PATH`.strip + File::PATH_SEPARATOR + File.dirname(Gem.ruby)
       with_path_as(path) do
         build_bundler_context
-        bundle_exec_ruby!("#{bundled_app("exe.rb")} 2")
+        bundle_exec_ruby("#{bundled_app("exe.rb")} 2")
       end
       expect(err).to eq <<-EOS.strip
 2 false
@@ -65,11 +65,11 @@ RSpec.describe "Bundler.with_env helpers" do
       # Simulate bundler has not yet been loaded
       ENV.replace(ENV.to_hash.delete_if {|k, _v| k.start_with?(Bundler::EnvironmentPreserver::BUNDLER_PREFIX) })
 
-      original = ruby!('puts ENV.to_a.map {|e| e.join("=") }.sort.join("\n")')
+      original = ruby('puts ENV.to_a.map {|e| e.join("=") }.sort.join("\n")')
       create_file("source.rb", <<-RUBY)
         puts Bundler.original_env.to_a.map {|e| e.join("=") }.sort.join("\n")
       RUBY
-      bundle_exec_ruby! bundled_app("source.rb")
+      bundle_exec_ruby bundled_app("source.rb")
       expect(out).to eq original
     end
   end
@@ -80,7 +80,7 @@ RSpec.describe "Bundler.with_env helpers" do
         print #{modified_env}.has_key?('BUNDLE_PATH')
       RUBY
       ENV["BUNDLE_PATH"] = "./foo"
-      bundle_exec_ruby! bundled_app("source.rb")
+      bundle_exec_ruby bundled_app("source.rb")
       expect(last_command.stdboth).to include "false"
     end
 
@@ -90,7 +90,7 @@ RSpec.describe "Bundler.with_env helpers" do
       RUBY
       ENV["RUBYOPT"] = "-W2 -rbundler/setup #{ENV["RUBYOPT"]}"
       simulate_bundler_version_when_missing_prerelease_default_gem_activation do
-        bundle_exec_ruby! bundled_app("source.rb")
+        bundle_exec_ruby bundled_app("source.rb")
       end
       expect(last_command.stdboth).not_to include("-rbundler/setup")
     end
@@ -101,7 +101,7 @@ RSpec.describe "Bundler.with_env helpers" do
       RUBY
       ENV["RUBYLIB"] = lib_dir.to_s + File::PATH_SEPARATOR + "/foo"
       ENV["BUNDLER_ORIG_RUBYLIB"] = lib_dir.to_s + File::PATH_SEPARATOR + "/foo-original"
-      bundle_exec_ruby! bundled_app("source.rb")
+      bundle_exec_ruby bundled_app("source.rb")
       expect(last_command.stdboth).to include("/foo-original")
     end
 
@@ -111,7 +111,7 @@ RSpec.describe "Bundler.with_env helpers" do
       RUBY
       ENV["MANPATH"] = "/foo"
       ENV["BUNDLER_ORIG_MANPATH"] = "/foo-original"
-      bundle_exec_ruby! bundled_app("source.rb")
+      bundle_exec_ruby bundled_app("source.rb")
       expect(last_command.stdboth).to include("/foo-original")
     end
   end

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -406,7 +406,7 @@ module Spec
       @_build_repo = File.basename(path)
       yield
       with_gem_path_as Path.base_system_gems do
-        gem_command! :generate_index, :dir => path
+        gem_command :generate_index, :dir => path
       end
     ensure
       @_build_path = nil
@@ -753,7 +753,7 @@ module Spec
         elsif opts[:skip_validation]
           @context.gem_command "build --force #{@spec.name}", :dir => lib_path
         else
-          @context.gem_command! "build #{@spec.name}", :dir => lib_path
+          @context.gem_command "build #{@spec.name}", :dir => lib_path
         end
 
         gem_path = File.expand_path("#{@spec.full_name}.gem", lib_path)

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -292,7 +292,7 @@ module Spec
     def install_gem(path)
       raise "OMG `#{path}` does not exist!" unless File.exist?(path)
 
-      gem_command! "install --no-document --ignore-dependencies '#{path}'"
+      gem_command "install --no-document --ignore-dependencies '#{path}'"
     end
 
     def with_built_bundler(version = nil)
@@ -320,7 +320,7 @@ module Spec
 
         replace_build_metadata(build_metadata, dir: build_path) # rubocop:disable Style/HashSyntax
 
-        gem_command! "build #{relative_gemspec}", :dir => build_path
+        gem_command "build #{relative_gemspec}", :dir => build_path
 
         yield(bundler_path)
       ensure
@@ -408,7 +408,7 @@ module Spec
 
       with_gem_path_as(system_gem_path) do
         gems.each do |gem|
-          gem_command! "install --no-document #{gem}"
+          gem_command "install --no-document #{gem}"
         end
       end
     end

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -23,12 +23,6 @@ module Spec
       Gem.clear_paths
     end
 
-    def self.bang(method)
-      define_method("#{method}!") do |*args, &blk|
-        send(method, *args, &blk)
-      end
-    end
-
     def the_bundle(*args)
       TheBundle.new(*args)
     end
@@ -65,7 +59,6 @@ module Spec
       setup = "require '#{lib_dir}/bundler' ; Bundler.ui.silence { Bundler.setup(#{groups}) }"
       ruby([setup, cmd].join(" ; "), opts)
     end
-    bang :run
 
     def load_error_run(ruby, name, *args)
       cmd = <<-RUBY
@@ -125,7 +118,6 @@ module Spec
       cmd = "#{ruby_cmd} #{bundle_bin} #{cmd}#{args}"
       sys_exec(cmd, { :env => env, :dir => dir, :raise_on_error => raise_on_error }, &block)
     end
-    bang :bundle
 
     def bundler(cmd, options = {})
       options[:bundle_bin] = system_gem_path.join("bin/bundler")
@@ -137,7 +129,6 @@ module Spec
       escaped_ruby = RUBY_PLATFORM == "java" ? ruby.shellescape.dump : ruby.shellescape
       sys_exec(%(#{ruby_cmd} -w -e #{escaped_ruby}), options)
     end
-    bang :ruby
 
     def load_error_ruby(ruby, name, opts = {})
       ruby(<<-R)
@@ -170,7 +161,6 @@ module Spec
     def gem_command(command, options = {})
       sys_exec("#{Path.gem_bin} #{command}", options)
     end
-    bang :gem_command
 
     def rake
       "#{Gem.ruby} -S #{ENV["GEM_PATH"]}/bin/rake"
@@ -207,7 +197,6 @@ module Spec
 
       command_execution.stdout
     end
-    bang :sys_exec
 
     def config(config = nil, path = bundled_app(".bundle/config"))
       return YAML.load_file(path) unless config
@@ -264,7 +253,6 @@ module Spec
       opts[:retry] ||= 0
       bundle :install, opts
     end
-    bang :install_gemfile
 
     def lock_gemfile(*args)
       gemfile(*args)

--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -240,7 +240,7 @@ module Spec
     def git_ls_files(glob)
       skip "Not running on a git context, since running tests from a tarball" if ruby_core_tarball?
 
-      sys_exec!("git ls-files -z -- #{glob}", :dir => source_root).split("\x0")
+      sys_exec("git ls-files -z -- #{glob}", :dir => source_root).split("\x0")
     end
 
     def tracked_files_glob

--- a/bundler/spec/support/rubygems_version_manager.rb
+++ b/bundler/spec/support/rubygems_version_manager.rb
@@ -67,8 +67,8 @@ private
   def switch_local_copy_if_needed
     return unless local_copy_switch_needed?
 
-    sys_exec!("git remote update", :dir => local_copy_path)
-    sys_exec!("git checkout #{target_tag} --quiet", :dir => local_copy_path)
+    sys_exec("git remote update", :dir => local_copy_path)
+    sys_exec("git checkout #{target_tag} --quiet", :dir => local_copy_path)
 
     ENV["RGV"] = local_copy_path.to_s
   end
@@ -86,7 +86,7 @@ private
   end
 
   def local_copy_tag
-    sys_exec!("git rev-parse --abbrev-ref HEAD", :dir => local_copy_path)
+    sys_exec("git rev-parse --abbrev-ref HEAD", :dir => local_copy_path)
   end
 
   def local_copy_path
@@ -100,7 +100,7 @@ private
 
     unless rubygems_path.directory?
       rubygems_path.parent.mkpath
-      sys_exec!("git clone https://github.com/rubygems/rubygems.git #{rubygems_path}")
+      sys_exec("git clone https://github.com/rubygems/rubygems.git #{rubygems_path}")
     end
 
     rubygems_path

--- a/bundler/spec/update/gemfile_spec.rb
+++ b/bundler/spec/update/gemfile_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe "bundle update" do
         gem 'rack'
       G
 
-      bundle! :install, :gemfile => bundled_app("NotGemfile")
-      bundle! :update, :gemfile => bundled_app("NotGemfile"), :all => true
+      bundle :install, :gemfile => bundled_app("NotGemfile")
+      bundle :update, :gemfile => bundled_app("NotGemfile"), :all => true
 
       # Specify BUNDLE_GEMFILE for `the_bundle`
       # to retrieve the proper Gemfile
@@ -26,11 +26,11 @@ RSpec.describe "bundle update" do
       G
 
       bundle "config set --local gemfile #{bundled_app("NotGemfile")}"
-      bundle! :install
+      bundle :install
     end
 
     it "uses the gemfile to update" do
-      bundle! "update", :all => true
+      bundle "update", :all => true
       bundle "list"
 
       expect(out).to include("rack (1.0.0)")
@@ -38,7 +38,7 @@ RSpec.describe "bundle update" do
 
     it "uses the gemfile while in a subdirectory" do
       bundled_app("subdir").mkpath
-      bundle! "update", :all => true, :dir => bundled_app("subdir")
+      bundle "update", :all => true, :dir => bundled_app("subdir")
       bundle "list", :dir => bundled_app("subdir")
 
       expect(out).to include("rack (1.0.0)")

--- a/bundler/spec/update/gems/post_install_spec.rb
+++ b/bundler/spec/update/gems/post_install_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe "bundle update" do
       gem 'thin'
     G
 
-    bundle! "config set #{config}" if config
+    bundle "config set #{config}" if config
 
-    bundle! :install
+    bundle :install
   end
 
   shared_examples "a config observer" do
@@ -52,7 +52,7 @@ RSpec.describe "bundle update" do
         gem 'thin'
       G
 
-      bundle! :update, :all => true
+      bundle :update, :all => true
     end
 
     it_behaves_like "a post-install message outputter"
@@ -67,7 +67,7 @@ RSpec.describe "bundle update" do
         gem 'thin'
       G
 
-      bundle! :update, :all => true
+      bundle :update, :all => true
     end
 
     it_behaves_like "a post-install message outputter"

--- a/bundler/spec/update/git_spec.rb
+++ b/bundler/spec/update/git_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "bundle update" do
         s.add_dependency "activesupport", "= 3.0"
       end
 
-      install_gemfile! <<-G
+      install_gemfile <<-G
         gem "rails", :git => "#{lib_path("rails")}"
       G
 
@@ -158,7 +158,7 @@ RSpec.describe "bundle update" do
       end
 
       it "unlocks the source when submodules are removed from git source", :git => ">= 2.9.0" do
-        install_gemfile! <<-G
+        install_gemfile <<-G
           source "#{file_uri_for(gem_repo4)}"
           git "#{lib_path("has_submodule-1.0")}", :submodules => true do
             gem "has_submodule"
@@ -168,7 +168,7 @@ RSpec.describe "bundle update" do
         run! "require 'submodule'"
         expect(out).to eq("GIT")
 
-        install_gemfile! <<-G
+        install_gemfile <<-G
           source "#{file_uri_for(gem_repo4)}"
           git "#{lib_path("has_submodule-1.0")}" do
             gem "has_submodule"

--- a/bundler/spec/update/git_spec.rb
+++ b/bundler/spec/update/git_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "bundle update" do
         gem "rails", :git => "#{lib_path("rails")}"
       G
 
-      bundle! "update rails"
+      bundle "update rails"
       expect(the_bundle).to include_gems "rails 3.0", "activesupport 3.0"
     end
 

--- a/bundler/spec/update/git_spec.rb
+++ b/bundler/spec/update/git_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe "bundle update" do
           end
         G
 
-        run! "require 'submodule'"
+        run "require 'submodule'"
         expect(out).to eq("GIT")
 
         install_gemfile <<-G
@@ -175,7 +175,7 @@ RSpec.describe "bundle update" do
           end
         G
 
-        run! "require 'submodule'"
+        run "require 'submodule'"
         expect(out).to eq("GEM")
       end
     end

--- a/bundler/spec/update/redownload_spec.rb
+++ b/bundler/spec/update/redownload_spec.rb
@@ -10,24 +10,24 @@ RSpec.describe "bundle update" do
 
   describe "with --force" do
     it "shows a deprecation when single flag passed", :bundler => 2 do
-      bundle! "update rack --force"
+      bundle "update rack --force"
       expect(err).to include "[DEPRECATED] The `--force` option has been renamed to `--redownload`"
     end
 
     it "shows a deprecation when multiple flags passed", :bundler => 2 do
-      bundle! "update rack --no-color --force"
+      bundle "update rack --no-color --force"
       expect(err).to include "[DEPRECATED] The `--force` option has been renamed to `--redownload`"
     end
   end
 
   describe "with --redownload" do
     it "does not show a deprecation when single flag passed" do
-      bundle! "update rack --redownload"
+      bundle "update rack --redownload"
       expect(err).not_to include "[DEPRECATED] The `--force` option has been renamed to `--redownload`"
     end
 
     it "does not show a deprecation when single multiple flags passed" do
-      bundle! "update rack --no-color --redownload"
+      bundle "update rack --no-color --redownload"
       expect(err).not_to include "[DEPRECATED] The `--force` option has been renamed to `--redownload`"
     end
   end


### PR DESCRIPTION
# Description:

After #3685, all of our test helpers that shell out raise by default, so we no longer need a different set of helpers to achieve that.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
