### PR TITLE
Use space before block parameters everywhere

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -68,6 +68,10 @@ Layout/IndentationWidth:
 Layout/SpaceAroundOperators:
   Enabled: true
 
+Layout/SpaceInsideBlockBraces:
+  Enabled: true
+  SpaceBeforeBlockParameters: true
+
 Layout/SpaceInsideParens:
   Enabled: true
 

--- a/Rakefile
+++ b/Rakefile
@@ -405,7 +405,7 @@ end
 
 desc "Update the manifest to reflect what's on disk"
 task :update_manifest do
-  File.open('Manifest.txt', 'w') {|f| f.puts(Rubygems::ProjectFiles.all.sort) }
+  File.open('Manifest.txt', 'w') { |f| f.puts(Rubygems::ProjectFiles.all.sort) }
 end
 
 desc "Check the manifest is up to date"

--- a/bundler/.rubocop.yml
+++ b/bundler/.rubocop.yml
@@ -363,7 +363,7 @@ Layout/SpaceInsideArrayPercentLiteral:
 
 Layout/SpaceInsideBlockBraces:
   Enabled: true
-  SpaceBeforeBlockParameters: false
+  SpaceBeforeBlockParameters: true
 
 Layout/SpaceInsideHashLiteralBraces:
   Enabled: true

--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -102,7 +102,7 @@ namespace :man do
       directory "man"
 
       index = []
-      sources = Dir["man/*.ronn"].map {|f| File.basename(f, ".ronn") }
+      sources = Dir["man/*.ronn"].map { |f| File.basename(f, ".ronn") }
       sources.map do |basename|
         ronn = "man/#{basename}.ronn"
         manual_section = ".1" unless basename =~ /\.(\d+)\Z/
@@ -126,7 +126,7 @@ namespace :man do
           [File.read(ronn).split(" ").first, roff]
         end
         index = index.sort_by(&:first)
-        justification = index.map {|(n, _f)| n.length }.max + 4
+        justification = index.map { |(n, _f)| n.length }.max + 4
         File.open("man/index.txt", "w") do |f|
           index.each do |name, filename|
             f << name.ljust(justification) << filename << "\n"

--- a/bundler/bundler.gemspec
+++ b/bundler/bundler.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = ">= 2.3.0"
   s.required_rubygems_version = ">= 2.5.2"
 
-  s.files = Dir.glob("{lib,man,exe}/**/*", File::FNM_DOTMATCH).reject {|f| File.directory?(f) }
+  s.files = Dir.glob("{lib,man,exe}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
 
   # Include the CHANGELOG.md, LICENSE.md, README.md manually
   s.files += %w[CHANGELOG.md LICENSE.md README.md]

--- a/bundler/exe/bundle
+++ b/bundler/exe/bundle
@@ -43,7 +43,7 @@ Bundler.with_friendly_errors do
 
   # Allow any command to use --help flag to show help for that command
   help_flags = %w[--help -h]
-  help_flag_used = ARGV.any? {|a| help_flags.include? a }
+  help_flag_used = ARGV.any? { |a| help_flags.include? a }
   args = help_flag_used ? Bundler::CLI.reformatted_help_args(ARGV) : ARGV
 
   Bundler::CLI.start(args, :debug => true)

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -104,7 +104,7 @@ module Bundler
       @bin_path ||= begin
         path = settings[:bin] || "bin"
         path = Pathname.new(path).expand_path(root).expand_path
-        SharedHelpers.filesystem_access(path) {|p| FileUtils.mkdir_p(p) }
+        SharedHelpers.filesystem_access(path) { |p| FileUtils.mkdir_p(p) }
         path
       end
     end
@@ -350,7 +350,7 @@ EOF
         env["MANPATH"] = env["BUNDLER_ORIG_MANPATH"]
       end
 
-      env.delete_if {|k, _| k[0, 7] == "BUNDLE_" }
+      env.delete_if { |k, _| k[0, 7] == "BUNDLE_" }
 
       if env.key?("RUBYOPT")
         env["RUBYOPT"] = env["RUBYOPT"].sub "-rbundler/setup", ""
@@ -482,7 +482,7 @@ EOF
 
         # if any directory is not writable, we need sudo
         files = [path, bin_dir] | Dir[bundle_path.join("build_info/*").to_s] | Dir[bundle_path.join("*").to_s]
-        unwritable_files = files.reject {|f| File.writable?(f) }
+        unwritable_files = files.reject { |f| File.writable?(f) }
         sudo_needed = !unwritable_files.empty?
         if sudo_needed
           Bundler.ui.warn "Following files may not be writable, so sudo is needed:\n  #{unwritable_files.map(&:to_s).sort.join("\n  ")}"

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -48,7 +48,7 @@ module Bundler
     end
 
     def self.aliases_for(command_name)
-      COMMAND_ALIASES.select {|k, _| k == command_name }.invert
+      COMMAND_ALIASES.select { |k, _| k == command_name }.invert
     end
 
     def initialize(*args)
@@ -71,7 +71,7 @@ module Bundler
       unprinted_warnings = Bundler.ui.unprinted_warnings
       Bundler.ui = UI::Shell.new(options)
       Bundler.ui.level = "debug" if options["verbose"]
-      unprinted_warnings.each {|w| Bundler.ui.warn(w) }
+      unprinted_warnings.each { |w| Bundler.ui.warn(w) }
 
       if ENV["RUBYGEMS_GEMDEPS"] && !ENV["RUBYGEMS_GEMDEPS"].empty?
         Bundler.ui.warn(
@@ -93,10 +93,10 @@ module Bundler
       primary_commands = ["install", "update", "cache", "exec", "config", "help"]
 
       list = self.class.printable_commands(true)
-      by_name = list.group_by {|name, _message| name.match(/^bundle (\w+)/)[1] }
+      by_name = list.group_by { |name, _message| name.match(/^bundle (\w+)/)[1] }
       utilities = by_name.keys.sort - primary_commands
-      primary_commands.map! {|name| (by_name[name] || raise("no primary command #{name}")).first }
-      utilities.map! {|name| by_name[name].first }
+      primary_commands.map! { |name| (by_name[name] || raise("no primary command #{name}")).first }
+      utilities.map! { |name| by_name[name].first }
 
       shell.say "Bundler commands:\n\n"
 
@@ -324,10 +324,10 @@ module Bundler
         if ARGV[0] == "show"
           rest = ARGV[1..-1]
 
-          if flag = rest.find{|arg| ["--verbose", "--outdated"].include?(arg) }
+          if flag = rest.find{ |arg| ["--verbose", "--outdated"].include?(arg) }
             Bundler::SharedHelpers.major_deprecation(2, "the `#{flag}` flag to `bundle show` was undocumented and will be removed without replacement")
           else
-            new_command = rest.find {|arg| !arg.start_with?("--") } ? "info" : "list"
+            new_command = rest.find { |arg| !arg.start_with?("--") } ? "info" : "list"
 
             new_arguments = rest.map do |arg|
               next arg if arg != "--paths"
@@ -530,7 +530,7 @@ module Bundler
 
     desc "licenses", "Prints the license of all gems in the bundle"
     def licenses
-      Bundler.load.specs.sort_by {|s| s.license.to_s }.reverse_each do |s|
+      Bundler.load.specs.sort_by { |s| s.license.to_s }.reverse_each do |s|
         gem_name = s.name
         license  = s.license || s.licenses
 
@@ -567,7 +567,7 @@ module Bundler
     method_option :exe, :type => :boolean, :default => false, :aliases => ["--bin", "-b"], :desc => "Generate a binary executable for your library."
     method_option :coc, :type => :boolean, :desc => "Generate a code of conduct file. Set a default with `bundle config set gem.coc true`."
     method_option :edit, :type => :string, :aliases => "-e", :required => false, :banner => "EDITOR",
-                         :lazy_default => [ENV["BUNDLER_EDITOR"], ENV["VISUAL"], ENV["EDITOR"]].find {|e| !e.nil? && !e.empty? },
+                         :lazy_default => [ENV["BUNDLER_EDITOR"], ENV["VISUAL"], ENV["EDITOR"]].find { |e| !e.nil? && !e.empty? },
                          :desc => "Open generated gemspec in the specified editor (defaults to $EDITOR or $BUNDLER_EDITOR)"
     method_option :ext, :type => :boolean, :default => false, :desc => "Generate the boilerplate for C extension code"
     method_option :git, :type => :boolean, :default => true, :desc => "Initialize a git repo inside your library."
@@ -719,10 +719,10 @@ module Bundler
       help_flags = %w[--help -h]
       exec_commands = ["exec"] + COMMAND_ALIASES["exec"]
 
-      help_used = args.index {|a| help_flags.include? a }
-      exec_used = args.index {|a| exec_commands.include? a }
+      help_used = args.index { |a| help_flags.include? a }
+      exec_used = args.index { |a| exec_commands.include? a }
 
-      command = args.find {|a| bundler_commands.include? a }
+      command = args.find { |a| bundler_commands.include? a }
       command = all_aliases[command] if all_aliases[command]
 
       if exec_used && help_used
@@ -796,7 +796,7 @@ module Bundler
                send(:compact_index_client).
                instance_variable_get(:@cache).
                dependencies("bundler").
-               map {|d| Gem::Version.new(d.first) }.
+               map { |d| Gem::Version.new(d.first) }.
                max
       return unless latest
 
@@ -833,7 +833,7 @@ module Bundler
     end
 
     def flag_deprecation(name, flag_name, option)
-      name_index = ARGV.find {|arg| flag_name == arg.split("=")[0] }
+      name_index = ARGV.find { |arg| flag_name == arg.split("=")[0] }
       return unless name_index
 
       value = options[name]

--- a/bundler/lib/bundler/cli/add.rb
+++ b/bundler/lib/bundler/cli/add.rb
@@ -25,7 +25,7 @@ module Bundler
     end
 
     def inject_dependencies
-      dependencies = gems.map {|g| Bundler::Dependency.new(g, version, options) }
+      dependencies = gems.map { |g| Bundler::Dependency.new(g, version, options) }
 
       Injector.inject(dependencies,
         :conservative_versioning => options[:version].nil?, # Perform conservative versioning only when version is not specified

--- a/bundler/lib/bundler/cli/binstubs.rb
+++ b/bundler/lib/bundler/cli/binstubs.rb
@@ -28,7 +28,7 @@ module Bundler
       end
 
       gems.each do |gem_name|
-        spec = Bundler.definition.specs.find {|s| s.name == gem_name }
+        spec = Bundler.definition.specs.find { |s| s.name == gem_name }
         unless spec
           raise GemNotFound, Bundler::CLI::Common.gem_not_found_message(
             gem_name, Bundler.definition.specs

--- a/bundler/lib/bundler/cli/check.rb
+++ b/bundler/lib/bundler/cli/check.rb
@@ -23,7 +23,7 @@ module Bundler
 
       if not_installed.any?
         Bundler.ui.error "The following gems are missing"
-        not_installed.each {|s| Bundler.ui.error " * #{s.name} (#{s.version})" }
+        not_installed.each { |s| Bundler.ui.error " * #{s.name} (#{s.version})" }
         Bundler.ui.warn "Install missing gems with `bundle install`"
         exit 1
       elsif !Bundler.default_lockfile.file? && Bundler.frozen_bundle?

--- a/bundler/lib/bundler/cli/common.rb
+++ b/bundler/lib/bundler/cli/common.rb
@@ -23,7 +23,7 @@ module Bundler
       command_in_past_tense = command == :install ? "installed" : "updated"
       groups = Bundler.settings[:without]
       group_list = [groups[0...-1].join(", "), groups[-1..-1]].
-        reject {|s| s.to_s.empty? }.join(" and ")
+        reject { |s| s.to_s.empty? }.join(" and ")
       group_str = groups.size == 1 ? "group" : "groups"
       "Gems in the #{group_str} #{group_list} were not #{command_in_past_tense}."
     end
@@ -62,7 +62,7 @@ module Bundler
     def self.gem_not_found_message(missing_gem_name, alternatives)
       require_relative "../similarity_detector"
       message = "Could not find gem '#{missing_gem_name}'."
-      alternate_names = alternatives.map {|a| a.respond_to?(:name) ? a.name : a }
+      alternate_names = alternatives.map { |a| a.respond_to?(:name) ? a.name : a }
       suggestions = SimilarityDetector.new(alternate_names).similar_word_list(missing_gem_name)
       message += "\nDid you mean #{suggestions}?" if suggestions
       message
@@ -87,7 +87,7 @@ module Bundler
     end
 
     def self.patch_level_options(options)
-      [:major, :minor, :patch].select {|v| options.keys.include?(v.to_s) }
+      [:major, :minor, :patch].select { |v| options.keys.include?(v.to_s) }
     end
 
     def self.clean_after_install?

--- a/bundler/lib/bundler/cli/config.rb
+++ b/bundler/lib/bundler/cli/config.rb
@@ -18,7 +18,7 @@ module Bundler
         if ARGV.size == 1
           ["config", "list"]
         elsif ARGV.include?("--delete")
-          ARGV.map {|arg| arg == "--delete" ? "unset" : arg }
+          ARGV.map { |arg| arg == "--delete" ? "unset" : arg }
         elsif ARGV.include?("--global") || ARGV.include?("--local") || ARGV.size == 3
           ["config", "set", *ARGV[1..-1]]
         else
@@ -177,7 +177,7 @@ module Bundler
 
       def validate_scope!
         @explicit_scope = true
-        scopes = %w[global local].select {|s| options[s] }
+        scopes = %w[global local].select { |s| options[s] }
         case scopes.size
         when 0
           @scope = "global"

--- a/bundler/lib/bundler/cli/doctor.rb
+++ b/bundler/lib/bundler/cli/doctor.rb
@@ -23,9 +23,9 @@ module Bundler
 
     def dylibs_darwin(path)
       output = `/usr/bin/otool -L "#{path}"`.chomp
-      dylibs = output.split("\n")[1..-1].map {|l| l.match(DARWIN_REGEX).captures[0] }.uniq
+      dylibs = output.split("\n")[1..-1].map { |l| l.match(DARWIN_REGEX).captures[0] }.uniq
       # ignore @rpath and friends
-      dylibs.reject {|dylib| dylib.start_with? "@" }
+      dylibs.reject { |dylib| dylib.start_with? "@" }
     end
 
     def dylibs_ldd(path)
@@ -70,7 +70,7 @@ module Bundler
 
       definition.specs.each do |spec|
         bundles_for_gem(spec).each do |bundle|
-          bad_paths = dylibs(bundle).select {|f| !File.exist?(f) }
+          bad_paths = dylibs(bundle).select { |f| !File.exist?(f) }
           if bad_paths.any?
             broken_links[spec] ||= []
             broken_links[spec].concat(bad_paths)
@@ -86,7 +86,7 @@ module Bundler
           paths.uniq.map do |path|
             "\n * #{spec.name}: #{path}"
           end
-        end.flatten.sort.each {|m| message += m }
+        end.flatten.sort.each { |m| message += m }
         raise ProductionError, message
       elsif !permissions_valid
         Bundler.ui.info "No issues found with the installed bundle"

--- a/bundler/lib/bundler/cli/exec.rb
+++ b/bundler/lib/bundler/cli/exec.rb
@@ -59,13 +59,13 @@ module Bundler
       $0 = file
       Process.setproctitle(process_title(file, args)) if Process.respond_to?(:setproctitle)
       require_relative "../setup"
-      TRAPPED_SIGNALS.each {|s| trap(s, "DEFAULT") }
+      TRAPPED_SIGNALS.each { |s| trap(s, "DEFAULT") }
       Kernel.load(file)
     rescue SystemExit, SignalException
       raise
     rescue Exception => e # rubocop:disable Lint/RescueException
       Bundler.ui.error "bundler: failed to load command: #{cmd} (#{file})"
-      backtrace = e.backtrace ? e.backtrace.take_while {|bt| !bt.start_with?(__FILE__) } : []
+      backtrace = e.backtrace ? e.backtrace.take_while { |bt| !bt.start_with?(__FILE__) } : []
       abort "#{e.class}: #{e.message}\n  #{backtrace.join("\n  ")}"
     end
 
@@ -86,8 +86,8 @@ module Bundler
         return false
       end
 
-      first_line = File.open(file, "rb") {|f| f.read(possibilities.map(&:size).max) }
-      possibilities.any? {|shebang| first_line.start_with?(shebang) }
+      first_line = File.open(file, "rb") { |f| f.read(possibilities.map(&:size).max) }
+      possibilities.any? { |shebang| first_line.start_with?(shebang) }
     end
   end
 end

--- a/bundler/lib/bundler/cli/info.rb
+++ b/bundler/lib/bundler/cli/info.rb
@@ -25,7 +25,7 @@ module Bundler
   private
 
     def spec_for_gem(gem_name)
-      spec = Bundler.definition.specs.find {|s| s.name == gem_name }
+      spec = Bundler.definition.specs.find { |s| s.name == gem_name }
       spec || default_gem_spec(gem_name) || Bundler::CLI::Common.select_spec(gem_name, :regex_match)
     end
 

--- a/bundler/lib/bundler/cli/inject.rb
+++ b/bundler/lib/bundler/cli/inject.rb
@@ -22,8 +22,8 @@ module Bundler
       # when `inject` support addition of more than one gem, then this loop will
       # help. Currently this loop is running once.
       gems.each_slice(4) do |gem_name, gem_version, gem_group, gem_source|
-        ops = Gem::Requirement::OPS.map {|key, _val| key }
-        has_op = ops.any? {|op| gem_version.start_with? op }
+        ops = Gem::Requirement::OPS.map { |key, _val| key }
+        has_op = ops.any? { |op| gem_version.start_with? op }
         gem_version = "~> #{gem_version}" unless has_op
         deps << Bundler::Dependency.new(gem_name, gem_version, "group" => gem_group, "source" => gem_source)
       end
@@ -51,7 +51,7 @@ module Bundler
       definition.resolve_remotely!
       specs = definition.index[name].sort_by(&:version)
       unless options[:pre]
-        specs.delete_if {|b| b.respond_to?(:version) && b.version.prerelease? }
+        specs.delete_if { |b| b.respond_to?(:version) && b.version.prerelease? }
       end
       spec = specs.last
       spec.version.to_s

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -199,7 +199,7 @@ module Bundler
         Bundler.ui.warn "Warning: the gem '#{name}' was found in multiple sources."
         Bundler.ui.warn "Installed from: #{installed_from_uri}"
         Bundler.ui.warn "Also found in:"
-        also_found_in_uris.each {|uri| Bundler.ui.warn "  * #{uri}" }
+        also_found_in_uris.each { |uri| Bundler.ui.warn "  * #{uri}" }
         Bundler.ui.warn "You should add a source requirement to restrict this gem to your preferred source."
         Bundler.ui.warn "For example:"
         Bundler.ui.warn "    gem '#{name}', :source => '#{installed_from_uri}'"

--- a/bundler/lib/bundler/cli/list.rb
+++ b/bundler/lib/bundler/cli/list.rb
@@ -17,16 +17,16 @@ module Bundler
         filtered_specs_by_groups
       else
         Bundler.load.specs
-      end.reject {|s| s.name == "bundler" }.sort_by(&:name)
+      end.reject { |s| s.name == "bundler" }.sort_by(&:name)
 
       return Bundler.ui.info "No gems in the Gemfile" if specs.empty?
 
-      return specs.each {|s| Bundler.ui.info s.name } if @options["name-only"]
-      return specs.each {|s| Bundler.ui.info s.full_gem_path } if @options["paths"]
+      return specs.each { |s| Bundler.ui.info s.name } if @options["name-only"]
+      return specs.each { |s| Bundler.ui.info s.full_gem_path } if @options["paths"]
 
       Bundler.ui.info "Gems included by the bundle:"
 
-      specs.each {|s| Bundler.ui.info "  * #{s.name} (#{s.version}#{s.git_version})" }
+      specs.each { |s| Bundler.ui.info "  * #{s.name} (#{s.version}#{s.git_version})" }
 
       Bundler.ui.info "Use `bundle info` to print more detailed information about a gem"
     end
@@ -47,9 +47,9 @@ module Bundler
 
       show_groups =
         if @without_group.any?
-          groups.reject {|g| @without_group.include?(g) }
+          groups.reject { |g| @without_group.include?(g) }
         elsif @only_group.any?
-          groups.select {|g| @only_group.include?(g) }
+          groups.select { |g| @only_group.include?(g) }
         else
           groups
         end.map(&:to_sym)

--- a/bundler/lib/bundler/cli/open.rb
+++ b/bundler/lib/bundler/cli/open.rb
@@ -11,7 +11,7 @@ module Bundler
     end
 
     def run
-      editor = [ENV["BUNDLER_EDITOR"], ENV["VISUAL"], ENV["EDITOR"]].find {|e| !e.nil? && !e.empty? }
+      editor = [ENV["BUNDLER_EDITOR"], ENV["VISUAL"], ENV["EDITOR"]].find { |e| !e.nil? && !e.empty? }
       return Bundler.ui.info("To open a bundled gem, set $EDITOR or $BUNDLER_EDITOR") unless editor
       return unless spec = Bundler::CLI::Common.select_spec(name, :regex_match)
       if spec.default_gem?

--- a/bundler/lib/bundler/cli/outdated.rb
+++ b/bundler/lib/bundler/cli/outdated.rb
@@ -34,7 +34,7 @@ module Bundler
       current_specs = Bundler.ui.silence { Bundler.definition.resolve }
 
       current_dependencies = Bundler.ui.silence do
-        Bundler.load.dependencies.map {|dep| [dep.name, dep] }.to_h
+        Bundler.load.dependencies.map { |dep| [dep.name, dep] }.to_h
       end
 
       definition = if gems.empty? && sources.empty?
@@ -103,7 +103,7 @@ module Bundler
         end
       else
         if options_include_groups
-          relevant_outdated_gems = outdated_gems.group_by {|g| g[:groups] }.sort.flat_map do |groups, gems|
+          relevant_outdated_gems = outdated_gems.group_by { |g| g[:groups] }.sort.flat_map do |groups, gems|
             contains_group = groups.split(", ").include?(options[:group])
             next unless options[:groups] || contains_group
 
@@ -153,7 +153,7 @@ module Bundler
       else
         active_specs = definition.find_indexed_specs(current_spec)
         if !current_spec.version.prerelease? && !options[:pre] && active_specs.size > 1
-          active_specs.delete_if {|b| b.respond_to?(:version) && b.version.prerelease? }
+          active_specs.delete_if { |b| b.respond_to?(:version) && b.version.prerelease? }
         end
         active_spec = active_specs.last
       end
@@ -266,12 +266,12 @@ module Bundler
       data = matrix[1..-1]
 
       column_sizes = Array.new(header.size) do |index|
-        matrix.max_by {|row| row[index].length }[index].length
+        matrix.max_by { |row| row[index].length }[index].length
       end
 
       Bundler.ui.info justify(header, column_sizes)
 
-      data.sort_by! {|row| row[0] }
+      data.sort_by! { |row| row[0] }
 
       data.each do |row|
         Bundler.ui.info justify(row, column_sizes)

--- a/bundler/lib/bundler/cli/platform.rb
+++ b/bundler/lib/bundler/cli/platform.rb
@@ -11,7 +11,7 @@ module Bundler
       platforms, ruby_version = Bundler.ui.silence do
         locked_ruby_version = Bundler.locked_gems && Bundler.locked_gems.ruby_version
         gemfile_ruby_version = Bundler.definition.ruby_version && Bundler.definition.ruby_version.single_version_string
-        [Bundler.definition.platforms.map {|p| "* #{p}" },
+        [Bundler.definition.platforms.map { |p| "* #{p}" },
          locked_ruby_version || gemfile_ruby_version]
       end
       output = []

--- a/bundler/lib/bundler/cli/show.rb
+++ b/bundler/lib/bundler/cli/show.rb
@@ -39,7 +39,7 @@ module Bundler
         Bundler.load.specs.sort_by(&:name).each do |s|
           desc = "  * #{s.name} (#{s.version}#{s.git_version})"
           if @verbose
-            latest = latest_specs.find {|l| l.name == s.name }
+            latest = latest_specs.find { |l| l.name == s.name }
             Bundler.ui.info <<-END.gsub(/^ +/, "")
               #{desc}
               \tSummary:  #{s.summary || "No description available."}

--- a/bundler/lib/bundler/cli/update.rb
+++ b/bundler/lib/bundler/cli/update.rb
@@ -38,7 +38,7 @@ module Bundler
         Bundler::CLI::Common.ensure_all_gems_in_lockfile!(gems)
 
         if groups.any?
-          deps = Bundler.definition.dependencies.select {|d| (d.groups & groups).any? }
+          deps = Bundler.definition.dependencies.select { |d| (d.groups & groups).any? }
           gems.concat(deps.map(&:name))
         end
 
@@ -82,7 +82,7 @@ module Bundler
           locked_spec = locked_info[:spec]
           new_spec = Bundler.definition.specs[name].first
           unless new_spec
-            if Bundler.rubygems.platforms.none? {|p| locked_spec.match_platform(p) }
+            if Bundler.rubygems.platforms.none? { |p| locked_spec.match_platform(p) }
               Bundler.ui.warn "Bundler attempted to update #{name} but it was not considered because it is for a different platform from the current one"
             end
 

--- a/bundler/lib/bundler/compact_index_client.rb
+++ b/bundler/lib/bundler/compact_index_client.rb
@@ -69,7 +69,7 @@ module Bundler
       Bundler::CompactIndexClient.debug { "dependencies(#{names})" }
       execution_mode.call(names) do |name|
         update_info(name)
-        @cache.dependencies(name).map {|d| d.unshift(name) }
+        @cache.dependencies(name).map { |d| d.unshift(name) }
       end.flatten(1)
     end
 

--- a/bundler/lib/bundler/compact_index_client/cache.rb
+++ b/bundler/lib/bundler/compact_index_client/cache.rb
@@ -23,7 +23,7 @@ module Bundler
       end
 
       def versions
-        versions_by_name = Hash.new {|hash, key| hash[key] = [] }
+        versions_by_name = Hash.new { |hash, key| hash[key] = [] }
         info_checksums_by_name = {}
 
         lines(versions_path).each do |line|
@@ -95,9 +95,9 @@ module Bundler
       def parse_gem(string)
         version_and_platform, rest = string.split(" ", 2)
         version, platform = version_and_platform.split("-", 2)
-        dependencies, requirements = rest.split("|", 2).map {|s| s.split(",") } if rest
-        dependencies = dependencies ? dependencies.map {|d| parse_dependency(d) } : []
-        requirements = requirements ? requirements.map {|r| parse_dependency(r) } : []
+        dependencies, requirements = rest.split("|", 2).map { |s| s.split(",") } if rest
+        dependencies = dependencies ? dependencies.map { |d| parse_dependency(d) } : []
+        requirements = requirements ? requirements.map { |r| parse_dependency(r) } : []
         [version, platform, dependencies, requirements]
       end
 

--- a/bundler/lib/bundler/compact_index_client/updater.rb
+++ b/bundler/lib/bundler/compact_index_client/updater.rb
@@ -60,9 +60,9 @@ module Bundler
 
           SharedHelpers.filesystem_access(local_temp_path) do
             if response.is_a?(Net::HTTPPartialContent) && local_temp_path.size.nonzero?
-              local_temp_path.open("a") {|f| f << slice_body(content, 1..-1) }
+              local_temp_path.open("a") { |f| f << slice_body(content, 1..-1) }
             else
-              local_temp_path.open("w") {|f| f << content }
+              local_temp_path.open("w") { |f| f << content }
             end
           end
 

--- a/bundler/lib/bundler/current_ruby.rb
+++ b/bundler/lib/bundler/current_ruby.rb
@@ -22,7 +22,7 @@ module Bundler
       2.7
     ].freeze
 
-    KNOWN_MAJOR_VERSIONS = KNOWN_MINOR_VERSIONS.map {|v| v.split(".", 2).first }.uniq.freeze
+    KNOWN_MAJOR_VERSIONS = KNOWN_MINOR_VERSIONS.map { |v| v.split(".", 2).first }.uniq.freeze
 
     KNOWN_PLATFORMS = %w[
       jruby

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -59,7 +59,7 @@ module Bundler
       else
         unlock = unlock.dup
         @unlocking_bundler = unlock.delete(:bundler)
-        unlock.delete_if {|_k, v| Array(v).empty? }
+        unlock.delete_if { |_k, v| Array(v).empty? }
         @unlocking = !unlock.empty?
       end
 
@@ -315,7 +315,7 @@ module Bundler
     private :double_check_for_index
 
     def has_rubygems_remotes?
-      sources.rubygems_sources.any? {|s| s.remotes.any? }
+      sources.rubygems_sources.any? { |s| s.remotes.any? }
     end
 
     def has_local_dependencies?
@@ -323,7 +323,7 @@ module Bundler
     end
 
     def spec_git_paths
-      sources.git_sources.map {|s| File.realpath(s.path) if File.exist?(s.path) }.compact
+      sources.git_sources.map { |s| File.realpath(s.path) if File.exist?(s.path) }.compact
     end
 
     def groups
@@ -357,7 +357,7 @@ module Bundler
       end
 
       SharedHelpers.filesystem_access(file) do |p|
-        File.open(p, "wb") {|f| f.puts(contents) }
+        File.open(p, "wb") { |f| f.puts(contents) }
       end
     end
 
@@ -417,8 +417,8 @@ module Bundler
 
       new_platforms = @platforms - @locked_platforms
       deleted_platforms = @locked_platforms - @platforms
-      added.concat new_platforms.map {|p| "* platform: #{p}" }
-      deleted.concat deleted_platforms.map {|p| "* platform: #{p}" }
+      added.concat new_platforms.map { |p| "* platform: #{p}" }
+      deleted.concat deleted_platforms.map { |p| "* platform: #{p}" }
 
       gemfile_sources = sources.lock_sources
 
@@ -430,28 +430,28 @@ module Bundler
 
       # Check if it is possible that the source is only changed thing
       if (new_deps.empty? && deleted_deps.empty?) && (!new_sources.empty? && !deleted_sources.empty?)
-        new_sources.reject! {|source| (source.path? && source.path.exist?) || equivalent_rubygems_remotes?(source) }
-        deleted_sources.reject! {|source| (source.path? && source.path.exist?) || equivalent_rubygems_remotes?(source) }
+        new_sources.reject! { |source| (source.path? && source.path.exist?) || equivalent_rubygems_remotes?(source) }
+        deleted_sources.reject! { |source| (source.path? && source.path.exist?) || equivalent_rubygems_remotes?(source) }
       end
 
       if @locked_sources != gemfile_sources
         if new_sources.any?
-          added.concat new_sources.map {|source| "* source: #{source}" }
+          added.concat new_sources.map { |source| "* source: #{source}" }
         end
 
         if deleted_sources.any?
-          deleted.concat deleted_sources.map {|source| "* source: #{source}" }
+          deleted.concat deleted_sources.map { |source| "* source: #{source}" }
         end
       end
 
-      added.concat new_deps.map {|d| "* #{pretty_dep(d)}" } if new_deps.any?
+      added.concat new_deps.map { |d| "* #{pretty_dep(d)}" } if new_deps.any?
       if deleted_deps.any?
-        deleted.concat deleted_deps.map {|d| "* #{pretty_dep(d)}" }
+        deleted.concat deleted_deps.map { |d| "* #{pretty_dep(d)}" }
       end
 
-      both_sources = Hash.new {|h, k| h[k] = [] }
-      @dependencies.each {|d| both_sources[d.name][0] = d }
-      @locked_deps.each  {|name, d| both_sources[name][1] = d.source }
+      both_sources = Hash.new { |h, k| h[k] = [] }
+      @dependencies.each { |d| both_sources[d.name][0] = d }
+      @locked_deps.each  { |name, d| both_sources[name][1] = d.source }
 
       both_sources.each do |name, (dep, lock_source)|
         next if lock_source.nil? || (dep && lock_source.can_lock?(dep))
@@ -527,7 +527,7 @@ module Bundler
     end
 
     def find_indexed_specs(current_spec)
-      index[current_spec.name].select {|spec| spec.match_platform(current_spec.platform) }.sort_by(&:version)
+      index[current_spec.name].select { |spec| spec.match_platform(current_spec.platform) }.sort_by(&:version)
     end
 
     attr_reader :sources
@@ -559,7 +559,7 @@ module Bundler
 
     def change_reason
       if unlocking?
-        unlock_reason = @unlock.reject {|_k, v| Array(v).empty? }.map do |k, v|
+        unlock_reason = @unlock.reject { |_k, v| Array(v).empty? }.map do |k, v|
           if v == true
             k.to_s
           else
@@ -586,21 +586,21 @@ module Bundler
     # Check if the specs of the given source changed
     # according to the locked source.
     def specs_changed?(source)
-      locked = @locked_sources.find {|s| s == source }
+      locked = @locked_sources.find { |s| s == source }
 
       !locked || dependencies_for_source_changed?(source, locked) || specs_for_source_changed?(source)
     end
 
     def dependencies_for_source_changed?(source, locked_source = source)
-      deps_for_source = @dependencies.select {|s| s.source == source }
-      locked_deps_for_source = @locked_deps.values.select {|dep| dep.source == locked_source }
+      deps_for_source = @dependencies.select { |s| s.source == source }
+      locked_deps_for_source = @locked_deps.values.select { |dep| dep.source == locked_source }
 
       Set.new(deps_for_source) != Set.new(locked_deps_for_source)
     end
 
     def specs_for_source_changed?(source)
       locked_index = Index.new
-      locked_index.use(@locked_specs.select {|s| source.can_lock?(s) })
+      locked_index.use(@locked_specs.select { |s| source.can_lock?(s) })
 
       # order here matters, since Index#== is checking source.specs.include?(locked_index)
       locked_index != source.specs
@@ -616,7 +616,7 @@ module Bundler
       locals = []
 
       Bundler.settings.local_overrides.map do |k, v|
-        spec   = @dependencies.find {|s| s.name == k }
+        spec   = @dependencies.find { |s| s.name == k }
         source = spec && spec.source
         if source && source.respond_to?(:local_override!)
           source.unlock! if @unlock[:gems].include?(spec.name)
@@ -627,7 +627,7 @@ module Bundler
       sources_with_changes = locals.select do |source, changed|
         changed || specs_changed?(source)
       end.map(&:first)
-      !sources_with_changes.each {|source| @unlock[:sources] << source.name }.empty?
+      !sources_with_changes.each { |source| @unlock[:sources] << source.name }.empty?
     end
 
     def converge_paths
@@ -638,7 +638,7 @@ module Bundler
 
     def converge_path_source_to_gemspec_source(source)
       return source unless source.instance_of?(Source::Path)
-      gemspec_source = sources.path_sources.find {|s| s.is_a?(Source::Gemspec) && s.as_path_source == source }
+      gemspec_source = sources.path_sources.find { |s| s.is_a?(Source::Gemspec) && s.as_path_source == source }
       gemspec_source || source
     end
 
@@ -660,7 +660,7 @@ module Bundler
       changes = false
 
       # Get the RubyGems sources from the Gemfile.lock
-      locked_gem_sources = @locked_sources.select {|s| s.is_a?(Source::Rubygems) }
+      locked_gem_sources = @locked_sources.select { |s| s.is_a?(Source::Rubygems) }
       # Get the RubyGems remotes from the Gemfile
       actual_remotes = sources.rubygems_remotes
 
@@ -764,7 +764,7 @@ module Bundler
           end
 
           dep.source.unlock! if dep.source.respond_to?(:unlock!)
-          dep.source.specs.each {|s| @unlock[:gems] << s.name }
+          dep.source.specs.each { |s| @unlock[:gems] << s.name }
         end
       end
 
@@ -773,7 +773,7 @@ module Bundler
       converged = []
       @locked_specs.each do |s|
         # Replace the locked dependency's source with the equivalent source from the Gemfile
-        dep = @dependencies.find {|d| s.satisfies?(d) }
+        dep = @dependencies.find { |d| s.satisfies?(d) }
         s.source = (dep && dep.source) || sources.get(s.source)
 
         # Don't add a spec to the list if its source is expired. For example,
@@ -798,7 +798,7 @@ module Bundler
             # don't error if the path/git source isn't available
             next if @locked_specs.
                     for(requested_dependencies, [], false, true, false).
-                    none? {|locked_spec| locked_spec.source == s.source }
+                    none? { |locked_spec| locked_spec.source == s.source }
 
             raise
           end
@@ -809,10 +809,10 @@ module Bundler
           # commonly happens if the version changed in the gemspec
           next unless new_spec
 
-          new_runtime_deps = new_spec.dependencies.select {|d| d.type != :development }
-          old_runtime_deps = s.dependencies.select {|d| d.type != :development }
+          new_runtime_deps = new_spec.dependencies.select { |d| d.type != :development }
+          old_runtime_deps = s.dependencies.select { |d| d.type != :development }
           # If the dependencies of the path source have changed and locked spec can't satisfy new dependencies, unlock it
-          next unless new_runtime_deps.sort == old_runtime_deps.sort || new_runtime_deps.all? {|d| satisfies_locked_spec?(d) }
+          next unless new_runtime_deps.sort == old_runtime_deps.sort || new_runtime_deps.all? { |d| satisfies_locked_spec?(d) }
 
           s.dependencies.replace(new_spec.dependencies)
         end
@@ -829,9 +829,9 @@ module Bundler
       sources.all_sources.each do |source|
         next unless source.respond_to?(:unlock!)
 
-        unless resolve.any? {|s| s.source == source }
+        unless resolve.any? { |s| s.source == source }
           diff ||= @locked_specs.to_a - resolve.to_a
-          source.unlock! if diff.any? {|s| s.source == source }
+          source.unlock! if diff.any? { |s| s.source == source }
         end
       end
 
@@ -846,7 +846,7 @@ module Bundler
     end
 
     def satisfies_locked_spec?(dep)
-      @locked_specs[dep].any? {|s| s.satisfies?(dep) && (!dep.source || s.source.include?(dep.source)) }
+      @locked_specs[dep].any? { |s| s.satisfies?(dep) && (!dep.source || s.source.include?(dep.source)) }
     end
 
     # This list of dependencies is only used in #resolve, so it's OK to add
@@ -980,7 +980,7 @@ module Bundler
 
     def additional_base_requirements_for_resolve
       return [] unless @locked_gems && Bundler.feature_flag.only_update_to_newer_versions?
-      dependencies_by_name = dependencies.inject({}) {|memo, dep| memo.update(dep.name => dep) }
+      dependencies_by_name = dependencies.inject({}) { |memo, dep| memo.update(dep.name => dep) }
       @locked_gems.specs.reduce({}) do |requirements, locked_spec|
         name = locked_spec.name
         dependency = dependencies_by_name[name]

--- a/bundler/lib/bundler/dependency.rb
+++ b/bundler/lib/bundler/dependency.rb
@@ -102,7 +102,7 @@ module Bundler
     end
 
     def expanded_platforms
-      @platforms.map {|pl| PLATFORM_MAP[pl] }
+      @platforms.map { |pl| PLATFORM_MAP[pl] }
     end
 
     def should_include?

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -44,7 +44,7 @@ module Bundler
       @gemfile = expanded_gemfile_path
       @gemfiles << expanded_gemfile_path
       contents ||= Bundler.read_file(@gemfile.to_s)
-      instance_eval(contents.dup.tap{|x| x.untaint if RUBY_VERSION < "2.7" }, gemfile.to_s, 1)
+      instance_eval(contents.dup.tap{ |x| x.untaint if RUBY_VERSION < "2.7" }, gemfile.to_s, 1)
     rescue Exception => e # rubocop:disable Lint/RescueException
       message = "There was an error " \
         "#{e.is_a?(GemfileEvalError) ? "evaluating" : "parsing"} " \
@@ -63,15 +63,15 @@ module Bundler
       development_group = opts[:development_group] || :development
       expanded_path     = gemfile_root.join(path)
 
-      gemspecs = Dir[File.join(expanded_path, "{,*}.gemspec")].map {|g| Bundler.load_gemspec(g) }.compact
-      gemspecs.reject! {|s| s.name != name } if name
+      gemspecs = Dir[File.join(expanded_path, "{,*}.gemspec")].map { |g| Bundler.load_gemspec(g) }.compact
+      gemspecs.reject! { |s| s.name != name } if name
       Index.sort_specs(gemspecs)
-      specs_by_name_and_version = gemspecs.group_by {|s| [s.name, s.version] }
+      specs_by_name_and_version = gemspecs.group_by { |s| [s.name, s.version] }
 
       case specs_by_name_and_version.size
       when 1
         specs = specs_by_name_and_version.values.first
-        spec = specs.find {|s| s.match_platform(Bundler.local_platform) } || specs.first
+        spec = specs.find { |s| s.match_platform(Bundler.local_platform) } || specs.first
 
         @gemspecs << spec
 
@@ -100,7 +100,7 @@ module Bundler
       dep = Dependency.new(name, version, options)
 
       # if there's already a dependency with this name we try to prefer one
-      if current = @dependencies.find {|d| d.name == dep.name }
+      if current = @dependencies.find { |d| d.name == dep.name }
         deleted_dep = @dependencies.delete(current) if current.type == :development
 
         if current.requirement != dep.requirement
@@ -199,7 +199,7 @@ module Bundler
       source_options = normalize_hash(options).merge(
         "path" => Pathname.new(path),
         "root_path" => gemfile_root,
-        "gemspec" => gemspecs.find {|g| g.name == options["name"] }
+        "gemspec" => gemspecs.find { |g| g.name == options["name"] }
       )
       source = @sources.add_path_source(source_options)
       with_source(source, &blk)
@@ -397,7 +397,7 @@ repo_name ||= user_name
     def normalize_group_options(opts, groups)
       normalize_hash(opts)
 
-      groups = groups.map {|group| ":#{group}" }.join(", ")
+      groups = groups.map { |group| ":#{group}" }.join(", ")
       validate_keys("group #{groups}", opts, %w[optional])
 
       opts["optional"] ||= false
@@ -414,7 +414,7 @@ repo_name ||= user_name
       return true unless invalid_keys.any?
 
       message = String.new
-      message << "You passed #{invalid_keys.map {|k| ":" + k }.join(", ")} "
+      message << "You passed #{invalid_keys.map { |k| ":" + k }.join(", ")} "
       message << if invalid_keys.size > 1
         "as options for #{command}, but they are invalid."
       else
@@ -545,7 +545,7 @@ The :#{name} git source is deprecated, and will be removed in the future.#{addit
 
           return m unless backtrace && dsl_path && contents
 
-          trace_line = backtrace.find {|l| l.include?(dsl_path.to_s) } || trace_line
+          trace_line = backtrace.find { |l| l.include?(dsl_path.to_s) } || trace_line
           return m unless trace_line
           line_numer = trace_line.split(":")[1].to_i - 1
           return m unless line_numer

--- a/bundler/lib/bundler/endpoint_specification.rb
+++ b/bundler/lib/bundler/endpoint_specification.rb
@@ -14,7 +14,7 @@ module Bundler
       @name         = name
       @version      = Gem::Version.create version
       @platform     = platform
-      @dependencies = dependencies.map {|dep, reqs| build_dependency(dep, reqs) }
+      @dependencies = dependencies.map { |dep, reqs| build_dependency(dep, reqs) }
 
       @loaded_from          = nil
       @remote_specification = nil

--- a/bundler/lib/bundler/env.rb
+++ b/bundler/lib/bundler/env.rb
@@ -49,7 +49,7 @@ module Bundler
       end
 
       if print_gemspecs
-        dsl = Dsl.new.tap {|d| d.eval_gemfile(Bundler.default_gemfile) }
+        dsl = Dsl.new.tap { |d| d.eval_gemfile(Bundler.default_gemfile) }
         out << "\n## Gemspecs\n" unless dsl.gemspecs.empty?
         dsl.gemspecs.each do |gs|
           out << "\n### #{File.basename(gs.loaded_from)}"
@@ -138,7 +138,7 @@ module Bundler
       return if pairs.empty?
       out << "\n" unless out.empty?
       out << "## #{title}\n\n```\n"
-      ljust = pairs.map {|k, _v| k.to_s.length }.max
+      ljust = pairs.map { |k, _v| k.to_s.length }.max
       pairs.each do |k, v|
         out << "#{k.to_s.ljust(ljust)}  #{v}\n"
       end

--- a/bundler/lib/bundler/environment_preserver.rb
+++ b/bundler/lib/bundler/environment_preserver.rb
@@ -25,7 +25,7 @@ module Bundler
       to_hash = env.to_hash
       return to_hash unless Gem.win_platform?
 
-      to_hash.each_with_object({}) {|(k,v), a| a[k.upcase] = v }
+      to_hash.each_with_object({}) { |(k,v), a| a[k.upcase] = v }
     end
 
     # @param env [Hash]
@@ -46,7 +46,7 @@ module Bundler
 
       ENV.clear
 
-      backup.each {|k, v| ENV[k] = v }
+      backup.each { |k, v| ENV[k] = v }
     end
 
     # @return [Hash]

--- a/bundler/lib/bundler/errors.rb
+++ b/bundler/lib/bundler/errors.rb
@@ -4,7 +4,7 @@ module Bundler
   class BundlerError < StandardError
     def self.status_code(code)
       define_method(:status_code) { code }
-      if match = BundlerError.all_errors.find {|_k, v| v == code }
+      if match = BundlerError.all_errors.find { |_k, v| v == code }
         error, _ = match
         raise ArgumentError,
           "Trying to register #{self} for status code #{code} but #{error} is already registered"

--- a/bundler/lib/bundler/feature_flag.rb
+++ b/bundler/lib/bundler/feature_flag.rb
@@ -25,7 +25,7 @@ module Bundler
     end
     private_class_method :settings_method
 
-    (1..10).each {|v| define_method("bundler_#{v}_mode?") { major_version >= v } }
+    (1..10).each { |v| define_method("bundler_#{v}_mode?") { major_version >= v } }
 
     settings_flag(:allow_bundler_dependency_conflicts) { bundler_3_mode? }
     settings_flag(:allow_offline_install) { bundler_3_mode? }

--- a/bundler/lib/bundler/fetcher.rb
+++ b/bundler/lib/bundler/fetcher.rb
@@ -70,7 +70,7 @@ module Bundler
     FAIL_ERRORS = begin
       fail_errors = [AuthenticationRequiredError, BadAuthenticationError, FallbackError]
       fail_errors << Gem::Requirement::BadRequirementError if defined?(Gem::Requirement::BadRequirementError)
-      fail_errors.concat(NET_ERRORS.map {|e| SharedHelpers.const_get_safely(e, Net) }.compact)
+      fail_errors.concat(NET_ERRORS.map { |e| SharedHelpers.const_get_safely(e, Net) }.compact)
     end.freeze
 
     class << self
@@ -204,7 +204,7 @@ module Bundler
     end
 
     def fetchers
-      @fetchers ||= FETCHERS.map {|f| f.new(downloader, @remote, uri) }
+      @fetchers ||= FETCHERS.map { |f| f.new(downloader, @remote, uri) }
     end
 
     def http_proxy
@@ -233,7 +233,7 @@ module Bundler
         "CI_NAME" => ENV["CI_NAME"],
         "CI" => "ci",
       }
-      env_cis.find_all {|env, _| ENV[env] }.map {|_, ci| ci }
+      env_cis.find_all { |env, _| ENV[env] }.map { |_, ci| ci }
     end
 
     def connection
@@ -273,8 +273,8 @@ module Bundler
 
     # cached gem specification path, if one exists
     def gemspec_cached_path(spec_file_name)
-      paths = Bundler.rubygems.spec_cache_dirs.map {|dir| File.join(dir, spec_file_name) }
-      paths = paths.select {|path| File.file? path }
+      paths = Bundler.rubygems.spec_cache_dirs.map { |dir| File.join(dir, spec_file_name) }
+      paths = paths.select { |path| File.file? path }
       paths.first
     end
 
@@ -298,7 +298,7 @@ module Bundler
         end
       else
         store.set_default_paths
-        Gem::Request.get_cert_files.each {|c| store.add_file c }
+        Gem::Request.get_cert_files.each { |c| store.add_file c }
       end
       store
     end

--- a/bundler/lib/bundler/fetcher/compact_index.rb
+++ b/bundler/lib/bundler/fetcher/compact_index.rb
@@ -46,8 +46,8 @@ module Bundler
                    @bundle_worker = nil # reset it.  Not sure if necessary
                    serial_compact_index_client.dependencies(remaining_gems)
                  end
-          next_gems = deps.map {|d| d[3].map(&:first).flatten(1) }.flatten(1).uniq
-          deps.each {|dep| gem_info << dep }
+          next_gems = deps.map { |d| d[3].map(&:first).flatten(1) }.flatten(1).uniq
+          deps.each { |dep| gem_info << dep }
           complete_gems.concat(deps.map(&:first)).uniq!
           remaining_gems = next_gems - complete_gems
         end
@@ -62,7 +62,7 @@ module Bundler
         contents = compact_index_client.spec(*spec)
         return nil if contents.nil?
         contents.unshift(spec.first)
-        contents[3].map! {|d| Gem::Dependency.new(*d) }
+        contents[3].map! { |d| Gem::Dependency.new(*d) }
         EndpointSpecification.new(*contents)
       end
       compact_index_request :fetch_spec
@@ -94,9 +94,9 @@ module Bundler
 
       def parallel_compact_index_client
         compact_index_client.execution_mode = lambda do |inputs, &blk|
-          func = lambda {|object, _index| blk.call(object) }
+          func = lambda { |object, _index| blk.call(object) }
           worker = bundle_worker(func)
-          inputs.each {|input| worker.enq(input) }
+          inputs.each { |input| worker.enq(input) }
           inputs.map { worker.deq }
         end
 

--- a/bundler/lib/bundler/fetcher/dependency.rb
+++ b/bundler/lib/bundler/fetcher/dependency.rb
@@ -66,7 +66,7 @@ module Bundler
 
         gem_list.each do |s|
           deps_list.concat(s[:dependencies].map(&:first))
-          deps = s[:dependencies].map {|n, d| [n, d.split(", ")] }
+          deps = s[:dependencies].map { |n, d| [n, d.split(", ")] }
           spec_list.push([s[:name], s[:number], s[:platform], deps])
         end
         [spec_list, deps_list]

--- a/bundler/lib/bundler/fetcher/downloader.rb
+++ b/bundler/lib/bundler/fetcher/downloader.rb
@@ -58,7 +58,7 @@ module Bundler
         end
         connection.request(uri, req)
       rescue NoMethodError => e
-        raise unless ["undefined method", "use_ssl="].all? {|snippet| e.message.include? snippet }
+        raise unless ["undefined method", "use_ssl="].all? { |snippet| e.message.include? snippet }
         raise LoadError.new("cannot load such file -- openssl")
       rescue OpenSSL::SSL::SSLError
         raise CertificateFailureError.new(uri)

--- a/bundler/lib/bundler/fetcher/index.rb
+++ b/bundler/lib/bundler/fetcher/index.rb
@@ -46,8 +46,8 @@ module Bundler
 
       # cached gem specification path, if one exists
       def gemspec_cached_path(spec_file_name)
-        paths = Bundler.rubygems.spec_cache_dirs.map {|dir| File.join(dir, spec_file_name) }
-        paths.find {|path| File.file? path }
+        paths = Bundler.rubygems.spec_cache_dirs.map { |dir| File.join(dir, spec_file_name) }
+        paths.find { |path| File.file? path }
       end
     end
   end

--- a/bundler/lib/bundler/gem_helper.rb
+++ b/bundler/lib/bundler/gem_helper.rb
@@ -75,7 +75,7 @@ module Bundler
       file_name = nil
       sh([*gem_command, "build", "-V", spec_path]) do
         file_name = File.basename(built_gem_path)
-        SharedHelpers.filesystem_access(File.join(base, "pkg")) {|p| FileUtils.mkdir_p(p) }
+        SharedHelpers.filesystem_access(File.join(base, "pkg")) { |p| FileUtils.mkdir_p(p) }
         FileUtils.mv(built_gem_path, "pkg")
         Bundler.ui.confirm "#{name} #{version} built to pkg/#{file_name}."
       end
@@ -107,7 +107,7 @@ module Bundler
     end
 
     def built_gem_path
-      Dir[File.join(base, "#{name}-*.gem")].sort_by {|f| File.mtime(f) }.last
+      Dir[File.join(base, "#{name}-*.gem")].sort_by { |f| File.mtime(f) }.last
     end
 
     def git_push(remote = "")

--- a/bundler/lib/bundler/gem_helpers.rb
+++ b/bundler/lib/bundler/gem_helpers.rb
@@ -42,8 +42,8 @@ module Bundler
     module_function :platform_specificity_match
 
     def select_best_platform_match(specs, platform)
-      specs.select {|spec| spec.match_platform(platform) }.
-        min_by {|spec| platform_specificity_match(spec.platform, platform) }
+      specs.select { |spec| spec.match_platform(platform) }.
+        min_by { |spec| platform_specificity_match(spec.platform, platform) }
     end
     module_function :select_best_platform_match
 

--- a/bundler/lib/bundler/gem_version_promoter.rb
+++ b/bundler/lib/bundler/gem_version_promoter.rb
@@ -108,7 +108,7 @@ module Bundler
 
           must_match = minor? ? [0] : [0, 1]
 
-          matches = must_match.map {|idx| gsv.segments[idx] == lsv.segments[idx] }
+          matches = must_match.map { |idx| gsv.segments[idx] == lsv.segments[idx] }
           matches.uniq == [true] ? (gsv >= lsv) : false
         else
           true
@@ -176,14 +176,14 @@ module Bundler
     end
 
     def move_version_to_end(result, version)
-      move, keep = result.partition {|s| s.version.to_s == version.to_s }
+      move, keep = result.partition { |s| s.version.to_s == version.to_s }
       keep.concat(move)
     end
 
     def debug_format_result(dep, spec_groups)
       a = [dep.to_s,
-           spec_groups.map {|sg| [sg.version, sg.dependencies_for_activated_platforms.map {|dp| [dp.name, dp.requirement.to_s] }] }]
-      last_map = a.last.map {|sg_data| [sg_data.first.version, sg_data.last.map {|aa| aa.join(" ") }] }
+           spec_groups.map { |sg| [sg.version, sg.dependencies_for_activated_platforms.map { |dp| [dp.name, dp.requirement.to_s] }] }]
+      last_map = a.last.map { |sg_data| [sg_data.first.version, sg_data.last.map { |aa| aa.join(" ") }] }
       [a.first, last_map, level, strict ? :strict : :not_strict]
     end
   end

--- a/bundler/lib/bundler/graph.rb
+++ b/bundler/lib/bundler/graph.rb
@@ -14,7 +14,7 @@ module Bundler
       @without_groups    = without.map(&:to_sym)
 
       @groups            = []
-      @relations         = Hash.new {|h, k| h[k] = Set.new }
+      @relations         = Hash.new { |h, k| h[k] = Set.new }
       @node_options      = {}
       @edge_options      = {}
 
@@ -50,7 +50,7 @@ module Bundler
     end
 
     def _groups
-      relations = Hash.new {|h, k| h[k] = Set.new }
+      relations = Hash.new { |h, k| h[k] = Set.new }
       @env.current_dependencies.each do |dependency|
         dependency.groups.each do |group|
           next if @without_groups.include?(group)
@@ -88,7 +88,7 @@ module Bundler
     end
 
     def spec_for_dependency(dependency)
-      @env.requested_specs.find {|s| s.name == dependency.name }
+      @env.requested_specs.find { |s| s.name == dependency.name }
     end
 
     class GraphVizClient

--- a/bundler/lib/bundler/index.rb
+++ b/bundler/lib/bundler/index.rb
@@ -21,15 +21,15 @@ module Bundler
     def initialize
       @sources = []
       @cache = {}
-      @specs = Hash.new {|h, k| h[k] = {} }
-      @all_specs = Hash.new {|h, k| h[k] = EMPTY_SEARCH }
+      @specs = Hash.new { |h, k| h[k] = {} }
+      @all_specs = Hash.new { |h, k| h[k] = EMPTY_SEARCH }
     end
 
     def initialize_copy(o)
       @sources = o.sources.dup
       @cache = {}
-      @specs = Hash.new {|h, k| h[k] = {} }
-      @all_specs = Hash.new {|h, k| h[k] = EMPTY_SEARCH }
+      @specs = Hash.new { |h, k| h[k] = {} }
+      @all_specs = Hash.new { |h, k| h[k] = EMPTY_SEARCH }
 
       o.specs.each do |name, hash|
         @specs[name] = hash.dup
@@ -111,7 +111,7 @@ module Bundler
       specs.values.each do |spec_sets|
         spec_sets.values.each(&blk)
       end
-      sources.each {|s| s.each(&blk) }
+      sources.each { |s| s.each(&blk) }
       self
     end
 
@@ -168,8 +168,8 @@ module Bundler
     end
 
     def dependencies_eql?(spec, other_spec)
-      deps       = spec.dependencies.select {|d| d.type != :development }
-      other_deps = other_spec.dependencies.select {|d| d.type != :development }
+      deps       = spec.dependencies.select { |d| d.type != :development }
+      other_deps = other_spec.dependencies.select { |d| d.type != :development }
       Set.new(deps) == Set.new(other_deps)
     end
 

--- a/bundler/lib/bundler/injector.rb
+++ b/bundler/lib/bundler/injector.rb
@@ -70,7 +70,7 @@ module Bundler
 
         show_warning("No gems were removed from the gemfile.") if deps.empty?
 
-        deps.each {|dep| Bundler.ui.confirm "#{SharedHelpers.pretty_dependency(dep, false)} was removed." }
+        deps.each { |dep| Bundler.ui.confirm "#{SharedHelpers.pretty_dependency(dep, false)} was removed." }
       end
     end
 
@@ -161,7 +161,7 @@ module Bundler
       removed_deps = []
 
       gems.each do |gem_name|
-        deleted_dep = builder.dependencies.find {|d| d.name == gem_name }
+        deleted_dep = builder.dependencies.find { |d| d.name == gem_name }
 
         if deleted_dep.nil?
           raise GemfileError, "`#{gem_name}` is not specified in #{gemfile_path} so it could not be removed."
@@ -202,7 +202,7 @@ module Bundler
         end
       end
 
-      %w[group source env install_if].each {|block| remove_nested_blocks(new_gemfile, block) }
+      %w[group source env install_if].each { |block| remove_nested_blocks(new_gemfile, block) }
 
       new_gemfile.join.chomp
     end
@@ -213,7 +213,7 @@ module Bundler
       nested_blocks = 0
 
       # count number of nested blocks
-      gemfile.each_with_index {|line, index| nested_blocks += 1 if !gemfile[index + 1].nil? && gemfile[index + 1].include?(block_name) && line.include?(block_name) }
+      gemfile.each_with_index { |line, index| nested_blocks += 1 if !gemfile[index + 1].nil? && gemfile[index + 1].include?(block_name) && line.include?(block_name) }
 
       while nested_blocks >= 0
         nested_blocks -= 1
@@ -251,7 +251,7 @@ module Bundler
       end
 
       # record gems which could not be removed due to some reasons
-      errored_deps = builder.dependencies.select {|d| d.gemfile == gemfile_path } & removed_deps.select {|d| d.gemfile == gemfile_path }
+      errored_deps = builder.dependencies.select { |d| d.gemfile == gemfile_path } & removed_deps.select { |d| d.gemfile == gemfile_path }
 
       show_warning "#{errored_deps.map(&:name).join(", ")} could not be removed." unless errored_deps.empty?
 

--- a/bundler/lib/bundler/installer.rb
+++ b/bundler/lib/bundler/installer.rb
@@ -106,7 +106,7 @@ module Bundler
         if options.any?
           Bundler.ui.warn "#{spec.name} has no executables, but you may want " \
             "one from a gem it depends on."
-          options.each {|name, bins| Bundler.ui.warn "  #{name} has: #{bins.join(", ")}" }
+          options.each { |name, bins| Bundler.ui.warn "  #{name} has: #{bins.join(", ")}" }
         else
           Bundler.ui.warn "There are no executables for the gem #{spec.name}."
         end
@@ -217,7 +217,7 @@ module Bundler
     def load_plugins
       Bundler.rubygems.load_plugins
 
-      requested_path_gems = @definition.requested_specs.select {|s| s.source.is_a?(Source::Path) }
+      requested_path_gems = @definition.requested_specs.select { |s| s.source.is_a?(Source::Path) }
       path_plugin_files = requested_path_gems.map do |spec|
         begin
           Bundler.rubygems.spec_matches_for_glob(spec, "rubygems_plugin#{Bundler.rubygems.suffix_pattern}")

--- a/bundler/lib/bundler/installer/parallel_installer.rb
+++ b/bundler/lib/bundler/installer/parallel_installer.rb
@@ -48,20 +48,20 @@ module Bundler
       # sure needed dependencies have been installed.
       def dependencies_installed?(all_specs)
         installed_specs = all_specs.select(&:installed?).map(&:name)
-        dependencies.all? {|d| installed_specs.include? d.name }
+        dependencies.all? { |d| installed_specs.include? d.name }
       end
 
       # Represents only the non-development dependencies, the ones that are
       # itself and are in the total list.
       def dependencies
         @dependencies ||= begin
-          all_dependencies.reject {|dep| ignorable_dependency? dep }
+          all_dependencies.reject { |dep| ignorable_dependency? dep }
         end
       end
 
       def missing_lockfile_dependencies(all_spec_names)
-        deps = all_dependencies.reject {|dep| ignorable_dependency? dep }
-        deps.reject {|dep| all_spec_names.include? dep.name }
+        deps = all_dependencies.reject { |dep| ignorable_dependency? dep }
+        deps.reject { |dep| all_spec_names.include? dep.name }
       end
 
       # Represents all dependencies
@@ -85,9 +85,9 @@ module Bundler
       @size = size
       @standalone = standalone
       @force = force
-      @specs = all_specs.map {|s| SpecInstallation.new(s) }
+      @specs = all_specs.map { |s| SpecInstallation.new(s) }
       @spec_set = all_specs
-      @rake = @specs.find {|s| s.name == "rake" }
+      @rake = @specs.find { |s| s.name == "rake" }
     end
 
     def call
@@ -111,7 +111,7 @@ module Bundler
           s,
           s.missing_lockfile_dependencies(@specs.map(&:name)),
         ]
-      end.reject {|a| a.last.empty? }
+      end.reject { |a| a.last.empty? }
       return if missing_dependencies.empty?
 
       warning = []
@@ -150,7 +150,7 @@ module Bundler
     end
 
     def worker_pool
-      @worker_pool ||= Bundler::Worker.new @size, "Parallel Installer", lambda {|spec_install, worker_num|
+      @worker_pool ||= Bundler::Worker.new @size, "Parallel Installer", lambda { |spec_install, worker_num|
         do_install(spec_install, worker_num)
       }
     end
@@ -191,7 +191,7 @@ module Bundler
 
     def handle_error
       errors = failed_specs.map(&:error)
-      if exception = errors.find {|e| e.is_a?(Bundler::BundlerError) }
+      if exception = errors.find { |e| e.is_a?(Bundler::BundlerError) }
         raise exception
       end
       raise Bundler::InstallError, errors.join("\n\n")

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -77,7 +77,7 @@ module Bundler
 
     def __materialize__
       @specification = if source.is_a?(Source::Gemspec) && source.gemspec.name == name
-        source.gemspec.tap {|s| s.source = source }
+        source.gemspec.tap { |s| s.source = source }
       else
         search_object = Bundler.feature_flag.specific_platform? || Bundler.settings[:force_ruby_platform] ? self : Dependency.new(name, version)
         platform_object = Gem::Platform.new(platform)
@@ -86,7 +86,7 @@ module Bundler
           MatchPlatform.platforms_match?(spec.platform, platform_object)
         end
         search = same_platform_candidates.last || candidates.last
-        if search && Gem::Platform.new(search.platform) != platform_object && !search.runtime_dependencies.-(dependencies.reject {|d| d.type == :development }).empty?
+        if search && Gem::Platform.new(search.platform) != platform_object && !search.runtime_dependencies.-(dependencies.reject { |d| d.type == :development }).empty?
           Bundler.ui.warn "Unable to use the platform-specific (#{search.platform}) version of #{name} (#{version}) " \
             "because it has different dependencies from the #{platform} version. " \
             "To use the platform-specific version of the gem, run `bundle config set specific_platform true` and install again."

--- a/bundler/lib/bundler/lockfile_generator.rb
+++ b/bundler/lib/bundler/lockfile_generator.rb
@@ -35,7 +35,7 @@ module Bundler
         out << source.to_lock
 
         # Find all specs for this source
-        specs = definition.resolve.select {|s| source.can_lock?(s) }
+        specs = definition.resolve.select { |s| source.can_lock?(s) }
         add_specs(specs)
       end
     end
@@ -82,7 +82,7 @@ module Bundler
           out << "  #{val}\n"
         end
       when Hash
-        value.to_a.sort_by {|k, _| k.to_s }.each do |key, val|
+        value.to_a.sort_by { |k, _| k.to_s }.each do |key, val|
           out << "  #{key}: #{val}\n"
         end
       when String

--- a/bundler/lib/bundler/lockfile_parser.rb
+++ b/bundler/lib/bundler/lockfile_parser.rb
@@ -129,7 +129,7 @@ module Bundler
           @current_source = TYPES[@type].from_lock(@opts)
           # Strip out duplicate GIT sections
           if @sources.include?(@current_source)
-            @current_source = @sources.find {|s| s == @current_source }
+            @current_source = @sources.find { |s| s == @current_source }
           else
             @sources << @current_source
           end
@@ -193,7 +193,7 @@ module Bundler
       dep = Bundler::Dependency.new(name, version)
 
       if pinned && dep.name != "bundler"
-        spec = @specs.find {|_, v| v.name == dep.name }
+        spec = @specs.find { |_, v| v.name == dep.name }
         dep.source = spec.last.source if spec
 
         # Path sources need to know what the default name / version

--- a/bundler/lib/bundler/plugin.rb
+++ b/bundler/lib/bundler/plugin.rb
@@ -19,11 +19,11 @@ module Bundler
   module_function
 
     def reset!
-      instance_variables.each {|i| remove_instance_variable(i) }
+      instance_variables.each { |i| remove_instance_variable(i) }
 
       @sources = {}
       @commands = {}
-      @hooks_by_event = Hash.new {|h, k| h[k] = [] }
+      @hooks_by_event = Hash.new { |h, k| h[k] = [] }
       @loaded_plugin_names = []
     end
 
@@ -40,8 +40,8 @@ module Bundler
       save_plugins names, specs
     rescue PluginError => e
       if specs
-        specs_to_delete = Hash[specs.select {|k, _v| names.include?(k) && !index.commands.values.include?(k) }]
-        specs_to_delete.values.each {|spec| Bundler.rm_rf(spec.full_gem_path) }
+        specs_to_delete = Hash[specs.select { |k, _v| names.include?(k) && !index.commands.values.include?(k) }]
+        specs_to_delete.values.each { |spec| Bundler.rm_rf(spec.full_gem_path) }
       end
 
       Bundler.ui.error "Failed to install plugin #{name}: #{e.message}\n  #{e.backtrace.join("\n ")}"
@@ -110,7 +110,7 @@ module Bundler
 
         return if definition.dependencies.empty?
 
-        plugins = definition.dependencies.map(&:name).reject {|p| index.installed? p }
+        plugins = definition.dependencies.map(&:name).reject { |p| index.installed? p }
         installed_specs = Installer.new.install_definition(definition)
 
         save_plugins plugins, installed_specs, builder.inferred_plugins
@@ -225,9 +225,9 @@ module Bundler
       plugins = index.hook_plugins(event)
       return unless plugins.any?
 
-      (plugins - @loaded_plugin_names).each {|name| load_plugin(name) }
+      (plugins - @loaded_plugin_names).each { |name| load_plugin(name) }
 
-      @hooks_by_event[event].each {|blk| blk.call(*args, &arg_blk) }
+      @hooks_by_event[event].each { |blk| blk.call(*args, &arg_blk) }
     end
 
     # currently only intended for specs
@@ -279,7 +279,7 @@ module Bundler
 
       @commands = {}
       @sources = {}
-      @hooks_by_event = Hash.new {|h, k| h[k] = [] }
+      @hooks_by_event = Hash.new { |h, k| h[k] = [] }
 
       load_paths = spec.load_paths
       Bundler.rubygems.add_to_load_path(load_paths)
@@ -291,7 +291,7 @@ module Bundler
         raise MalformattedPlugin, "#{e.class}: #{e.message}"
       end
 
-      if optional_plugin && @sources.keys.any? {|s| source? s }
+      if optional_plugin && @sources.keys.any? { |s| source? s }
         Bundler.rm_rf(path)
         false
       else

--- a/bundler/lib/bundler/plugin/dsl.rb
+++ b/bundler/lib/bundler/plugin/dsl.rb
@@ -10,7 +10,7 @@ module Bundler
       # So that we don't have to override all there methods to dummy ones
       # explicitly.
       # They will be handled by method_missing
-      [:gemspec, :gem, :path, :install_if, :platforms, :env].each {|m| undef_method m }
+      [:gemspec, :gem, :path, :install_if, :platforms, :env].each { |m| undef_method m }
 
       # This lists the plugins that was added automatically and not specified by
       # the user.
@@ -43,7 +43,7 @@ module Bundler
 
         plugin_name = "bundler-source-#{options["type"]}"
 
-        return if @dependencies.any? {|d| d.name == plugin_name }
+        return if @dependencies.any? { |d| d.name == plugin_name }
 
         plugin(plugin_name)
         @inferred_plugins << plugin_name

--- a/bundler/lib/bundler/plugin/index.rb
+++ b/bundler/lib/bundler/plugin/index.rb
@@ -52,11 +52,11 @@ module Bundler
 
         common = commands & @commands.keys
         raise CommandConflict.new(name, common) unless common.empty?
-        commands.each {|c| @commands[c] = name }
+        commands.each { |c| @commands[c] = name }
 
         common = sources & @sources.keys
         raise SourceConflict.new(name, common) unless common.empty?
-        sources.each {|k| @sources[k] = name }
+        sources.each { |k| @sources[k] = name }
 
         hooks.each do |event|
           event_hooks = (@hooks[event] ||= []) << name
@@ -72,9 +72,9 @@ module Bundler
       end
 
       def unregister_plugin(name)
-        @commands.delete_if {|_, v| v == name }
-        @sources.delete_if {|_, v| v == name }
-        @hooks.each {|_, plugin_names| plugin_names.delete(name) }
+        @commands.delete_if { |_, v| v == name }
+        @sources.delete_if { |_, v| v == name }
+        @hooks.each { |_, plugin_names| plugin_names.delete(name) }
         @plugin_paths.delete(name)
         @load_paths.delete(name)
         save_index
@@ -117,7 +117,7 @@ module Bundler
       end
 
       def plugin_commands(plugin)
-        @commands.find_all {|_, n| n == plugin }.map(&:first)
+        @commands.find_all { |_, n| n == plugin }.map(&:first)
       end
 
       def source?(source)
@@ -174,7 +174,7 @@ module Bundler
         require_relative "../yaml_serializer"
         SharedHelpers.filesystem_access(index_file) do |index_f|
           FileUtils.mkdir_p(index_f.dirname)
-          File.open(index_f, "w") {|f| f.puts YAMLSerializer.dump(index) }
+          File.open(index_f, "w") { |f| f.puts YAMLSerializer.dump(index) }
         end
       end
     end

--- a/bundler/lib/bundler/plugin/installer.rb
+++ b/bundler/lib/bundler/plugin/installer.rb
@@ -81,7 +81,7 @@ module Bundler
         source_list.add_git_source(git_source_options) if git_source_options
         source_list.add_rubygems_source("remotes" => rubygems_source) if rubygems_source
 
-        deps = names.map {|name| Dependency.new name, version }
+        deps = names.map { |name| Dependency.new name, version }
 
         definition = Definition.new(nil, deps, source_list, true)
         install_definition(definition)

--- a/bundler/lib/bundler/remote_specification.rb
+++ b/bundler/lib/bundler/remote_specification.rb
@@ -50,7 +50,7 @@ module Bundler
     # once the remote gem is downloaded, the backend specification will
     # be swapped out.
     def __swap__(spec)
-      raise APIResponseInvalidDependenciesError unless spec.dependencies.all? {|d| d.is_a?(Gem::Dependency) }
+      raise APIResponseInvalidDependenciesError unless spec.dependencies.all? { |d| d.is_a?(Gem::Dependency) }
 
       SharedHelpers.ensure_same_dependencies(self, dependencies, spec.dependencies)
       @_remote_specification = spec
@@ -80,7 +80,7 @@ module Bundler
         # allow us to handle when the specs dependencies are an array of array of string
         # in order to delay the crash to `#__swap__` where it results in a friendlier error
         # see https://github.com/rubygems/bundler/issues/5797
-        deps = deps.map {|d| d.is_a?(Gem::Dependency) ? d : Gem::Dependency.new(*d) }
+        deps = deps.map { |d| d.is_a?(Gem::Dependency) ? d : Gem::Dependency.new(*d) }
 
         deps
       end

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -34,7 +34,7 @@ module Bundler
         dep = Dependency.new(ls.name, ls.version)
         @base_dg.add_vertex(ls.name, DepProxy.new(dep, ls.platform), true)
       end
-      additional_base_requirements.each {|d| @base_dg.add_vertex(d.name, d) }
+      additional_base_requirements.each { |d| @base_dg.add_vertex(d.name, d) }
       @platforms = platforms
       @gem_version_promoter = gem_version_promoter
       @allow_bundler_dependency_conflicts = Bundler.feature_flag.allow_bundler_dependency_conflicts?
@@ -44,21 +44,21 @@ module Bundler
 
     def start(requirements)
       @gem_version_promoter.prerelease_specified = @prerelease_specified = {}
-      requirements.each {|dep| @prerelease_specified[dep.name] ||= dep.prerelease? }
+      requirements.each { |dep| @prerelease_specified[dep.name] ||= dep.prerelease? }
 
       verify_gemfile_dependencies_are_found!(requirements)
       dg = @resolver.resolve(requirements, @base_dg)
       dg.
-        tap {|resolved| validate_resolved_specs!(resolved) }.
+        tap { |resolved| validate_resolved_specs!(resolved) }.
         map(&:payload).
-        reject {|sg| sg.name.end_with?("\0") }.
+        reject { |sg| sg.name.end_with?("\0") }.
         map(&:to_specs).
         flatten
     rescue Molinillo::VersionConflict => e
       message = version_conflict_message(e)
       raise VersionConflict.new(e.conflicts.keys.uniq, message)
     rescue Molinillo::CircularDependencyError => e
-      names = e.dependencies.sort_by(&:name).map {|d| "gem '#{d.name}'" }
+      names = e.dependencies.sort_by(&:name).map { |d| "gem '#{d.name}'" }
       raise CyclicDependencyError, "Your bundle requires gems that depend" \
         " on each other, creating an infinite loop. Please remove" \
         " #{names.count > 1 ? "either " : ""}#{names.join(" or ")}" \
@@ -75,7 +75,7 @@ module Bundler
       return unless debug?
       debug_info = yield
       debug_info = debug_info.inspect unless debug_info.is_a?(String)
-      warn debug_info.split("\n").map {|s| "BUNDLER: " + "  " * depth + s }
+      warn debug_info.split("\n").map { |s| "BUNDLER: " + "  " * depth + s }
     end
 
     def debug?
@@ -120,7 +120,7 @@ module Bundler
         if !@prerelease_specified[dependency.name] && (!@use_gvp || locked_requirement.nil?)
           # Move prereleases to the beginning of the list, so they're considered
           # last during resolution.
-          pre, results = results.partition {|spec| spec.version.prerelease? }
+          pre, results = results.partition { |spec| spec.version.prerelease? }
           results = pre + results
         end
 
@@ -180,7 +180,7 @@ module Bundler
       elsif @lockfile_uses_separate_rubygems_sources
         Index.build do |idx|
           if dependency.all_sources
-            dependency.all_sources.each {|s| idx.add_source(s.specs) if s }
+            dependency.all_sources.each { |s| idx.add_source(s.specs) if s }
           else
             idx.add_source @source_requirements[:default].specs
           end
@@ -247,7 +247,7 @@ module Bundler
     def self.platform_sort_key(platform)
       # Prefer specific platform to not specific platform
       return ["99-LAST", "", "", ""] if Gem::Platform::RUBY == platform
-      ["00", *platform.to_a.map {|part| part || "" }]
+      ["00", *platform.to_a.map { |part| part || "" }]
     end
 
   private
@@ -270,7 +270,7 @@ module Bundler
             all - 1_000_000
           else
             search = search_for(dependency)
-            search = @prerelease_specified[dependency.name] ? search.count : search.count {|s| !s.version.prerelease? }
+            search = @prerelease_specified[dependency.name] ? search.count : search.count { |s| !s.version.prerelease? }
             search - all
           end
         end
@@ -299,7 +299,7 @@ module Bundler
             "try passing them all to `bundle update`"
         elsif source = @source_requirements[name]
           specs = source.specs[name]
-          versions_with_platforms = specs.map {|s| [s.version, s.platform] }
+          versions_with_platforms = specs.map { |s| [s.version, s.platform] }
           message = String.new("Could not find gem '#{SharedHelpers.pretty_dependency(requirement)}' in #{source}#{cache_message}.\n")
           message << if versions_with_platforms.any?
             "The source contains '#{name}' at: #{formatted_versions_with_platforms(versions_with_platforms)}"
@@ -341,7 +341,7 @@ module Bundler
         :possibility_type => possibility_type,
         :reduce_trees => lambda do |trees|
           # called first, because we want to reduce the amount of work required to find maximal empty sets
-          trees = trees.uniq {|t| t.flatten.map {|dep| [dep.name, dep.requirement] } }
+          trees = trees.uniq { |t| t.flatten.map { |dep| [dep.name, dep.requirement] } }
 
           # bail out if tree size is too big for Array#combination to make any sense
           return trees if trees.size > 15
@@ -351,11 +351,11 @@ module Bundler
             Bundler::VersionRanges.empty?(*Bundler::VersionRanges.for_many(deps.map(&:requirement)))
           end.min_by(&:size)
 
-          trees.reject! {|t| !maximal.include?(t.last) } if maximal
+          trees.reject! { |t| !maximal.include?(t.last) } if maximal
 
-          trees.sort_by {|t| t.reverse.map(&:name) }
+          trees.sort_by { |t| t.reverse.map(&:name) }
         end,
-        :printable_requirement => lambda {|req| SharedHelpers.pretty_dependency(req) },
+        :printable_requirement => lambda { |req| SharedHelpers.pretty_dependency(req) },
         :additional_message_for_conflict => lambda do |o, name, conflict|
           if name == "bundler"
             o << %(\n  Current Bundler version:\n    bundler (#{Bundler::VERSION}))
@@ -406,7 +406,7 @@ module Bundler
             end
           end
         end,
-        :version_for_spec => lambda {|spec| spec.version },
+        :version_for_spec => lambda { |spec| spec.version },
         :incompatible_version_message_for_conflict => lambda do |name, _conflict|
           if name.end_with?("\0")
             %(#{solver_name} found conflicting requirements for the #{name} version:)
@@ -425,14 +425,14 @@ module Bundler
         if default_index = sources.index(@source_requirements[:default])
           sources.delete_at(default_index)
         end
-        sources.reject! {|s| s.specs[name].empty? }
+        sources.reject! { |s| s.specs[name].empty? }
         sources.uniq!
         next if sources.size <= 1
 
         multisource_disabled = Bundler.feature_flag.disable_multisource?
 
         msg = ["The gem '#{name}' was found in multiple relevant sources."]
-        msg.concat sources.map {|s| "  * #{s}" }.sort
+        msg.concat sources.map { |s| "  * #{s}" }.sort
         msg << "You #{multisource_disabled ? :must : :should} add this gem to the source block for the source you wish it to be installed from."
         msg = msg.join("\n")
 

--- a/bundler/lib/bundler/resolver/spec_group.rb
+++ b/bundler/lib/bundler/resolver/spec_group.rb
@@ -60,7 +60,7 @@ module Bundler
       end
 
       def dependencies_for_activated_platforms
-        dependencies = @activated_platforms.map {|p| __dependencies[p] }
+        dependencies = @activated_platforms.map { |p| __dependencies[p] }
         metadata_dependencies = @activated_platforms.map do |platform|
           metadata_dependencies(@specs[platform], platform)
         end

--- a/bundler/lib/bundler/retry.rb
+++ b/bundler/lib/bundler/retry.rb
@@ -44,7 +44,7 @@ module Bundler
 
     def fail_attempt(e)
       @failed = true
-      if last_attempt? || @exceptions.any? {|k| e.is_a?(k) }
+      if last_attempt? || @exceptions.any? { |k| e.is_a?(k) }
         Bundler.ui.info "" unless Bundler.ui.debug?
         raise e
       end

--- a/bundler/lib/bundler/ruby_version.rb
+++ b/bundler/lib/bundler/ruby_version.rb
@@ -120,7 +120,7 @@ module Bundler
 
     def exact?
       return @exact if defined?(@exact)
-      @exact = versions.all? {|v| Gem::Requirement.create(v).exact? }
+      @exact = versions.all? { |v| Gem::Requirement.create(v).exact? }
     end
 
   private

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -29,7 +29,7 @@ module Gem
       # gems at that time, this method could be called inside another require,
       # thus raising with that constant being undefined. Better to check a method
       if source.respond_to?(:path) || (source.respond_to?(:bundler_plugin_api_source?) && source.bundler_plugin_api_source?)
-        Pathname.new(loaded_from).dirname.expand_path(source.root).to_s.tap{|x| x.untaint if RUBY_VERSION < "2.7" }
+        Pathname.new(loaded_from).dirname.expand_path(source.root).to_s.tap{ |x| x.untaint if RUBY_VERSION < "2.7" }
       else
         rg_full_gem_path
       end
@@ -116,13 +116,13 @@ module Gem
     end
 
     def to_yaml_properties
-      instance_variables.reject {|p| ["@source", "@groups", "@all_sources"].include?(p.to_s) }
+      instance_variables.reject { |p| ["@source", "@groups", "@all_sources"].include?(p.to_s) }
     end
 
     def to_lock
       out = String.new("  #{name}")
       unless requirement.none?
-        reqs = requirement.requirements.map {|o, v| "#{o} #{v}" }.sort.reverse
+        reqs = requirement.requirements.map { |o, v| "#{o} #{v}" }.sort.reverse
         out << " (#{reqs.join(", ")})"
       end
       out

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -195,14 +195,14 @@ module Bundler
     end
 
     def gem_cache
-      gem_path.map {|p| File.expand_path("cache", p) }
+      gem_path.map { |p| File.expand_path("cache", p) }
     end
 
     def spec_cache_dirs
       @spec_cache_dirs ||= begin
-        dirs = gem_path.map {|dir| File.join(dir, "specifications") }
+        dirs = gem_path.map { |dir| File.join(dir, "specifications") }
         dirs << Gem.spec_cache_dir if Gem.respond_to?(:spec_cache_dir) # Not in RubyGems 2.0.3 or earlier
-        dirs.uniq.select {|dir| File.directory? dir }
+        dirs.uniq.select { |dir| File.directory? dir }
       end
     end
 
@@ -219,7 +219,7 @@ module Bundler
     end
 
     def loaded_gem_paths
-      loaded_gem_paths = Gem.loaded_specs.map {|_, s| s.full_require_paths }
+      loaded_gem_paths = Gem.loaded_specs.map { |_, s| s.full_require_paths }
       loaded_gem_paths.flatten
     end
 
@@ -274,7 +274,7 @@ module Bundler
     end
 
     def security_policy_keys
-      %w[High Medium Low AlmostNo No].map {|level| "#{level}Security" }
+      %w[High Medium Low AlmostNo No].map { |level| "#{level}Security" }
     end
 
     def security_policies
@@ -352,7 +352,7 @@ module Bundler
         raise ArgumentError, "you must supply exec_name" unless exec_name
 
         spec_with_name = specs_by_name[gem_name]
-        matching_specs_by_exec_name = specs_by_name.values.select {|s| s.executables.include?(exec_name) }
+        matching_specs_by_exec_name = specs_by_name.values.select { |s| s.executables.include?(exec_name) }
         spec = matching_specs_by_exec_name.delete(spec_with_name)
 
         unless spec || !matching_specs_by_exec_name.empty?
@@ -438,9 +438,9 @@ module Bundler
         redefine_method(klass, sym, method)
       end
       if Binding.public_method_defined?(:source_location)
-        post_reset_hooks.reject! {|proc| proc.binding.source_location[0] == __FILE__ }
+        post_reset_hooks.reject! { |proc| proc.binding.source_location[0] == __FILE__ }
       else
-        post_reset_hooks.reject! {|proc| proc.binding.eval("__FILE__") == __FILE__ }
+        post_reset_hooks.reject! { |proc| proc.binding.eval("__FILE__") == __FILE__ }
       end
       @replaced_methods.clear
     end

--- a/bundler/lib/bundler/runtime.rb
+++ b/bundler/lib/bundler/runtime.rb
@@ -31,7 +31,7 @@ module Bundler
         check_for_activated_spec!(spec)
 
         Bundler.rubygems.mark_loaded(spec)
-        spec.load_paths.reject {|path| $LOAD_PATH.include?(path) }
+        spec.load_paths.reject { |path| $LOAD_PATH.include?(path) }
       end.reverse.flatten
 
       Bundler.rubygems.add_to_load_path(load_paths)
@@ -79,7 +79,7 @@ module Bundler
             end
           end
         rescue LoadError => e
-          REQUIRE_ERRORS.find {|r| r =~ e.message }
+          REQUIRE_ERRORS.find { |r| r =~ e.message }
           raise if dep.autorequire || $1 != required_file
 
           if dep.autorequire.nil? && dep.name.include?("-")
@@ -87,7 +87,7 @@ module Bundler
               namespaced_file = dep.name.tr("-", "/")
               Kernel.require namespaced_file
             rescue LoadError => e
-              REQUIRE_ERRORS.find {|r| r =~ e.message }
+              REQUIRE_ERRORS.find { |r| r =~ e.message }
               raise if $1 != namespaced_file
             end
           end
@@ -190,8 +190,8 @@ module Bundler
       stale_gemspec_files  = gemspec_files - spec_gemspec_paths
       stale_extension_dirs = extension_dirs - spec_extension_paths
 
-      removed_stale_gem_dirs = stale_gem_dirs.collect {|dir| remove_dir(dir, dry_run) }
-      removed_stale_git_dirs = stale_git_dirs.collect {|dir| remove_dir(dir, dry_run) }
+      removed_stale_gem_dirs = stale_gem_dirs.collect { |dir| remove_dir(dir, dry_run) }
+      removed_stale_git_dirs = stale_git_dirs.collect { |dir| remove_dir(dir, dry_run) }
       output = removed_stale_gem_dirs + removed_stale_git_dirs
 
       unless dry_run

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -112,7 +112,7 @@ module Bundler
     end
 
     def temporary(update)
-      existing = Hash[update.map {|k, _| [k, @temporary[key_for(k)]] }]
+      existing = Hash[update.map { |k, _| [k, @temporary[key_for(k)]] }]
       update.each do |k, v|
         set_key(k, v, @temporary, nil)
       end
@@ -120,7 +120,7 @@ module Bundler
       begin
         yield
       ensure
-        existing.each {|k, v| set_key(k, v, @temporary, nil) }
+        existing.each { |k, v| set_key(k, v, @temporary, nil) }
       end
     end
 
@@ -353,7 +353,7 @@ module Bundler
       SharedHelpers.filesystem_access(file) do |p|
         FileUtils.mkdir_p(p.dirname)
         require_relative "yaml_serializer"
-        p.open("w") {|f| f.write(YAMLSerializer.dump(hash)) }
+        p.open("w") { |f| f.write(YAMLSerializer.dump(hash)) }
       end
     end
 

--- a/bundler/lib/bundler/settings/validator.rb
+++ b/bundler/lib/bundler/settings/validator.rb
@@ -18,7 +18,7 @@ module Bundler
 
         def fail!(key, value, *reasons)
           reasons.unshift @description
-          raise InvalidOption, "Setting `#{key}` to #{value.inspect} failed:\n#{reasons.map {|r| " - #{r}" }.join("\n")}"
+          raise InvalidOption, "Setting `#{key}` to #{value.inspect} failed:\n#{reasons.map { |r| " - #{r}" }.join("\n")}"
         end
 
         def set(settings, key, value, *reasons)
@@ -39,19 +39,19 @@ module Bundler
       end
 
       def self.rules
-        @rules ||= Hash.new {|h, k| h[k] = [] }
+        @rules ||= Hash.new { |h, k| h[k] = [] }
       end
       private_class_method :rules
 
       def self.rule(keys, description, &blk)
         rule = Rule.new(keys, description, &blk)
-        keys.each {|k| rules[k] << rule }
+        keys.each { |k| rules[k] << rule }
       end
       private_class_method :rule
 
       def self.validate!(key, value, settings)
         rules_to_validate = rules[key]
-        rules_to_validate.each {|rule| rule.validate!(key, value, settings) }
+        rules_to_validate.each { |rule| rule.validate!(key, value, settings) }
       end
 
       rule %w[path path.system], "path and path.system are mutually exclusive" do |key, value, settings|

--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -13,13 +13,13 @@ module Bundler
     def root
       gemfile = find_gemfile
       raise GemfileNotFound, "Could not locate Gemfile" unless gemfile
-      Pathname.new(gemfile).tap{|x| x.untaint if RUBY_VERSION < "2.7" }.expand_path.parent
+      Pathname.new(gemfile).tap{ |x| x.untaint if RUBY_VERSION < "2.7" }.expand_path.parent
     end
 
     def default_gemfile
       gemfile = find_gemfile
       raise GemfileNotFound, "Could not locate Gemfile" unless gemfile
-      Pathname.new(gemfile).tap{|x| x.untaint if RUBY_VERSION < "2.7" }.expand_path
+      Pathname.new(gemfile).tap{ |x| x.untaint if RUBY_VERSION < "2.7" }.expand_path
     end
 
     def default_lockfile
@@ -28,7 +28,7 @@ module Bundler
       case gemfile.basename.to_s
       when "gems.rb" then Pathname.new(gemfile.sub(/.rb$/, ".locked"))
       else Pathname.new("#{gemfile}.lock")
-      end.tap{|x| x.untaint if RUBY_VERSION < "2.7" }
+      end.tap{ |x| x.untaint if RUBY_VERSION < "2.7" }
     end
 
     def default_bundle_dir
@@ -65,11 +65,11 @@ module Bundler
         h.update(k => ENV[k])
       end
 
-      keys.each {|key| ENV.delete(key) }
+      keys.each { |key| ENV.delete(key) }
 
       block.call
     ensure
-      keys.each {|key| ENV[key] = old_env[key] }
+      keys.each { |key| ENV[key] = old_env[key] }
     end
 
     def set_bundle_environment
@@ -100,7 +100,7 @@ module Bundler
     #
     # @see {Bundler::PermissionError}
     def filesystem_access(path, action = :write, &block)
-      yield(path.dup.tap{|x| x.untaint if RUBY_VERSION < "2.7" })
+      yield(path.dup.tap{ |x| x.untaint if RUBY_VERSION < "2.7" })
     rescue Errno::EACCES
       raise PermissionError.new(path, action)
     rescue Errno::EAGAIN
@@ -142,7 +142,7 @@ module Bundler
 
     def print_major_deprecations!
       multiple_gemfiles = search_up(".") do |dir|
-        gemfiles = gemfile_names.select {|gf| File.file? File.expand_path(gf, dir) }
+        gemfiles = gemfile_names.select { |gf| File.file? File.expand_path(gf, dir) }
         next if gemfiles.empty?
         break gemfiles.size != 1
       end
@@ -160,10 +160,10 @@ module Bundler
     end
 
     def ensure_same_dependencies(spec, old_deps, new_deps)
-      new_deps = new_deps.reject {|d| d.type == :development }
-      old_deps = old_deps.reject {|d| d.type == :development }
+      new_deps = new_deps.reject { |d| d.type == :development }
+      old_deps = old_deps.reject { |d| d.type == :development }
 
-      without_type = proc {|d| Gem::Dependency.new(d.name, d.requirements_list.sort) }
+      without_type = proc { |d| Gem::Dependency.new(d.name, d.requirements_list.sort) }
       new_deps.map!(&without_type)
       old_deps.map!(&without_type)
 
@@ -209,7 +209,7 @@ module Bundler
     end
 
     def write_to_gemfile(gemfile_path, contents)
-      filesystem_access(gemfile_path) {|g| File.open(g, "w") {|file| file.puts contents } }
+      filesystem_access(gemfile_path) { |g| File.open(g, "w") { |file| file.puts contents } }
     end
 
   private
@@ -250,7 +250,7 @@ module Bundler
 
     def search_up(*names)
       previous = nil
-      current  = File.expand_path(SharedHelpers.pwd).tap{|x| x.untaint if RUBY_VERSION < "2.7" }
+      current  = File.expand_path(SharedHelpers.pwd).tap{ |x| x.untaint if RUBY_VERSION < "2.7" }
 
       until !File.directory?(current) || current == previous
         if ENV["BUNDLE_SPEC_RUN"]

--- a/bundler/lib/bundler/similarity_detector.rb
+++ b/bundler/lib/bundler/similarity_detector.rb
@@ -11,8 +11,8 @@ module Bundler
 
     # return an array of words similar to 'word' from the corpus
     def similar_words(word, limit = 3)
-      words_by_similarity = @corpus.map {|w| SimilarityScore.new(w, levenshtein_distance(word, w)) }
-      words_by_similarity.select {|s| s.distance <= limit }.sort_by(&:distance).map(&:string)
+      words_by_similarity = @corpus.map { |w| SimilarityScore.new(w, levenshtein_distance(word, w)) }
+      words_by_similarity.select { |s| s.distance <= limit }.sort_by(&:distance).map(&:string)
     end
 
     # return the result of 'similar_words', concatenated into a list
@@ -36,7 +36,7 @@ module Bundler
       dm = [] # distance matrix
 
       # Initialize first row values
-      dm[0] = (0..this.length).collect {|i| i * ins }
+      dm[0] = (0..this.length).collect { |i| i * ins }
       fill = [0] * (this.length - 1)
 
       # Initialize first column values

--- a/bundler/lib/bundler/source.rb
+++ b/bundler/lib/bundler/source.rb
@@ -19,7 +19,7 @@ module Bundler
       message += " (#{spec.platform})" if spec.platform != Gem::Platform::RUBY && !spec.platform.nil?
 
       if Bundler.locked_gems
-        locked_spec = Bundler.locked_gems.specs.find {|s| s.name == spec.name }
+        locked_spec = Bundler.locked_gems.specs.find { |s| s.name == spec.name }
         locked_spec_version = locked_spec.version if locked_spec
         if locked_spec_version && spec.version != locked_spec_version
           message += Bundler.ui.add_color(" (was #{locked_spec_version})", version_color(spec.version, locked_spec_version))

--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -17,7 +17,7 @@ module Bundler
         @allow_remote = false
 
         # Stringify options that could be set as symbols
-        %w[ref branch tag revision].each {|k| options[k] = options[k].to_s if options[k] }
+        %w[ref branch tag revision].each { |k| options[k] = options[k].to_s if options[k] }
 
         @uri        = options["uri"] || ""
         @safe_uri   = URICredentialsFilter.credential_filtered_uri(@uri)
@@ -246,7 +246,7 @@ module Bundler
           next unless spec
           Bundler.rubygems.set_installed_by_version(spec)
           Bundler.rubygems.validate(spec)
-          File.open(spec_path, "wb") {|file| file.write(spec.to_ruby) }
+          File.open(spec_path, "wb") { |file| file.write(spec.to_ruby) }
         end
       end
 
@@ -316,7 +316,7 @@ module Bundler
 
       def load_gemspec(file)
         stub = Gem::StubSpecification.gemspec_stub(file, install_path.parent, install_path.parent)
-        stub.full_gem_path = Pathname.new(file).dirname.expand_path(root).to_s.tap{|x| x.untaint if RUBY_VERSION < "2.7" }
+        stub.full_gem_path = Pathname.new(file).dirname.expand_path(root).to_s.tap{ |x| x.untaint if RUBY_VERSION < "2.7" }
         StubSpecification.from_stub(stub)
       end
 

--- a/bundler/lib/bundler/source/metadata.rb
+++ b/bundler/lib/bundler/source/metadata.rb
@@ -25,11 +25,11 @@ module Bundler
             s.loaded_from = File.expand_path("..", __FILE__)
           end
 
-          if local_spec = Bundler.rubygems.find_name("bundler").find {|s| s.version.to_s == VERSION }
+          if local_spec = Bundler.rubygems.find_name("bundler").find { |s| s.version.to_s == VERSION }
             idx << local_spec
           end
 
-          idx.each {|s| s.source = self }
+          idx.each { |s| s.source = self }
         end
       end
 

--- a/bundler/lib/bundler/source/path.rb
+++ b/bundler/lib/bundler/source/path.rb
@@ -171,7 +171,7 @@ module Bundler
 
         if File.directory?(expanded_path)
           # We sort depth-first since `<<` will override the earlier-found specs
-          Dir["#{expanded_path}/#{@glob}"].sort_by {|p| -p.split(File::SEPARATOR).size }.each do |file|
+          Dir["#{expanded_path}/#{@glob}"].sort_by { |p| -p.split(File::SEPARATOR).size }.each do |file|
             next unless spec = load_gemspec(file)
             spec.source = self
 
@@ -192,8 +192,8 @@ module Bundler
               s.authors = ["no one"]
               if expanded_path.join("bin").exist?
                 executables = expanded_path.join("bin").children
-                executables.reject! {|p| File.directory?(p) }
-                s.executables = executables.map {|c| c.basename.to_s }
+                executables.reject! { |p| File.directory?(p) }
+                s.executables = executables.map { |c| c.basename.to_s }
               end
             end
           end

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -22,7 +22,7 @@ module Bundler
         @allow_cached = false
         @caches = [cache_path, *Bundler.rubygems.gem_cache]
 
-        Array(options["remotes"] || []).reverse_each {|r| add_remote(r) }
+        Array(options["remotes"] || []).reverse_each { |r| add_remote(r) }
       end
 
       def remote!
@@ -317,8 +317,8 @@ module Bundler
       end
 
       def cached_path(spec)
-        possibilities = @caches.map {|p| "#{p}/#{spec.file_name}" }
-        possibilities.find {|p| File.exist?(p) }
+        possibilities = @caches.map { |p| "#{p}/#{spec.file_name}" }
+        possibilities.find { |p| File.exist?(p) }
       end
 
       def normalize_uri(uri)
@@ -342,7 +342,7 @@ module Bundler
 
       def remove_auth(remote)
         if remote.user || remote.password
-          remote.dup.tap {|uri| uri.user = uri.password = nil }.to_s
+          remote.dup.tap { |uri| uri.user = uri.password = nil }.to_s
         else
           remote.to_s
         end
@@ -382,7 +382,7 @@ module Bundler
       end
 
       def api_fetchers
-        fetchers.select {|f| f.use_api && f.fetchers.first.api_fetcher? }
+        fetchers.select { |f| f.use_api && f.fetchers.first.api_fetcher? }
       end
 
       def remote_specs

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -72,7 +72,7 @@ module Bundler
     end
 
     def get(source)
-      source_list_for(source).find {|s| equal_source?(source, s) || equivalent_source?(source, s) }
+      source_list_for(source).find { |s| equal_source?(source, s) || equivalent_source?(source, s) }
     end
 
     def lock_sources
@@ -90,12 +90,12 @@ module Bundler
 
       [path_sources, git_sources, plugin_sources].each do |source_list|
         source_list.map! do |source|
-          replacement_sources.find {|s| s == source } || source
+          replacement_sources.find { |s| s == source } || source
         end
       end
 
       replacement_rubygems = !Bundler.feature_flag.disable_multisource? &&
-        replacement_sources.detect {|s| s.is_a?(Source::Rubygems) }
+        replacement_sources.detect { |s| s.is_a?(Source::Rubygems) }
       @rubygems_aggregate = replacement_rubygems if replacement_rubygems
 
       return true if !equal_sources?(lock_sources, replacement_sources) && !equivalent_sources?(lock_sources, replacement_sources)
@@ -169,15 +169,15 @@ module Bundler
     def equivalent_sources?(lock_sources, replacement_sources)
       return false unless Bundler.settings[:allow_deployment_source_credential_changes]
 
-      lock_rubygems_sources, lock_other_sources = lock_sources.partition {|s| s.is_a?(Source::Rubygems) }
-      replacement_rubygems_sources, replacement_other_sources = replacement_sources.partition {|s| s.is_a?(Source::Rubygems) }
+      lock_rubygems_sources, lock_other_sources = lock_sources.partition { |s| s.is_a?(Source::Rubygems) }
+      replacement_rubygems_sources, replacement_other_sources = replacement_sources.partition { |s| s.is_a?(Source::Rubygems) }
 
       equivalent_rubygems_sources?(lock_rubygems_sources, replacement_rubygems_sources) && equal_sources?(lock_other_sources, replacement_other_sources)
     end
 
     def equivalent_rubygems_sources?(lock_sources, replacement_sources)
       actual_remotes = replacement_sources.map(&:remotes).flatten.uniq
-      lock_sources.all? {|s| s.equivalent_remotes?(actual_remotes) }
+      lock_sources.all? { |s| s.equivalent_remotes?(actual_remotes) }
     end
   end
 end

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -110,18 +110,18 @@ module Bundler
       arr = sorted.dup
       set.each do |set_spec|
         full_name = set_spec.full_name
-        next if arr.any? {|spec| spec.full_name == full_name }
+        next if arr.any? { |spec| spec.full_name == full_name }
         arr << set_spec
       end
       SpecSet.new(arr)
     end
 
     def find_by_name_and_platform(name, platform)
-      @specs.detect {|spec| spec.name == name && spec.match_platform(platform) }
+      @specs.detect { |spec| spec.name == name && spec.match_platform(platform) }
     end
 
     def what_required(spec)
-      unless req = find {|s| s.dependencies.any? {|d| d.type == :runtime && d.name == spec.name } }
+      unless req = find { |s| s.dependencies.any? { |d| d.type == :runtime && d.name == spec.name } }
         return [spec]
       end
       what_required(req) << spec
@@ -150,7 +150,7 @@ module Bundler
   private
 
     def sorted
-      rake = @specs.find {|s| s.name == "rake" }
+      rake = @specs.find { |s| s.name == "rake" }
       begin
         @sorted ||= ([rake] + tsort).compact.uniq
       rescue TSort::Cyclic => error
@@ -167,7 +167,7 @@ module Bundler
 
     def lookup
       @lookup ||= begin
-        lookup = Hash.new {|h, k| h[k] = [] }
+        lookup = Hash.new { |h, k| h[k] = [] }
         Index.sort_specs(@specs).reverse_each do |s|
           lookup[s.name] << s
         end
@@ -177,7 +177,7 @@ module Bundler
 
     def tsort_each_node
       # MUST sort by name for backwards compatibility
-      @specs.sort_by(&:name).each {|s| yield s }
+      @specs.sort_by(&:name).each { |s| yield s }
     end
 
     def spec_for_dependency(dep, match_current_platform)
@@ -196,7 +196,7 @@ module Bundler
     def tsort_each_child(s)
       s.dependencies.sort_by(&:name).each do |d|
         next if d.type == :development
-        lookup[d.name].each {|s2| yield s2 }
+        lookup[d.name].each { |s2| yield s2 }
       end
     end
   end

--- a/bundler/lib/bundler/templates/Gemfile
+++ b/bundler/lib/bundler/templates/Gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # gem "rails"

--- a/bundler/lib/bundler/templates/gems.rb
+++ b/bundler/lib/bundler/templates/gems.rb
@@ -3,6 +3,6 @@
 # A sample gems.rb
 source "https://rubygems.org"
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # gem "rails"

--- a/bundler/lib/bundler/version_ranges.rb
+++ b/bundler/lib/bundler/version_ranges.rb
@@ -76,7 +76,7 @@ module Bundler
     end
 
     def self.for_many(requirements)
-      requirements = requirements.map(&:requirements).flatten(1).map {|r| r.join(" ") }
+      requirements = requirements.map(&:requirements).flatten(1).map { |r| r.join(" ") }
       requirements << ">= 0.a" if requirements.empty?
       requirement = Gem::Requirement.new(requirements)
       self.for(requirement)
@@ -95,7 +95,7 @@ module Bundler
         else raise "unknown version op #{op} in requirement #{requirement}"
         end
       end.uniq
-      ranges, neqs = ranges.partition {|r| !r.is_a?(NEq) }
+      ranges, neqs = ranges.partition { |r| !r.is_a?(NEq) }
 
       [ranges.sort, neqs.map(&:version)]
     end

--- a/bundler/lib/bundler/yaml_serializer.rb
+++ b/bundler/lib/bundler/yaml_serializer.rb
@@ -17,7 +17,7 @@ module Bundler
         if v.is_a?(Hash)
           yaml << dump_hash(v).gsub(/^(?!$)/, "  ") # indent all non-empty lines
         elsif v.is_a?(Array) # Expected to be array of strings
-          yaml << "\n- " << v.map {|s| s.to_s.gsub(/\s+/, " ").inspect }.join("\n- ") << "\n"
+          yaml << "\n- " << v.map { |s| s.to_s.gsub(/\s+/, " ").inspect }.join("\n- ") << "\n"
         else
           yaml << " " << v.to_s.gsub(/\s+/, " ").inspect << "\n"
         end

--- a/bundler/spec/bundler/cli_spec.rb
+++ b/bundler/spec/bundler/cli_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe "bundle executable" do
       if latest_version
         info_path = home(".bundle/cache/compact_index/rubygems.org.443.29b0360b937aa4d161703e6160654e47/info/bundler")
         info_path.parent.mkpath
-        info_path.open("w") {|f| f.write "#{latest_version}\n" }
+        info_path.open("w") { |f| f.write "#{latest_version}\n" }
       end
     end
 

--- a/bundler/spec/bundler/definition_spec.rb
+++ b/bundler/spec/bundler/definition_spec.rb
@@ -320,7 +320,7 @@ RSpec.describe Bundler::Definition do
   describe "find_indexed_specs" do
     it "with no platform set in indexed specs" do
       index = Bundler::Index.new
-      %w[1.0.0 1.0.1 1.1.0].each {|v| index << build_stub_spec("foo", v) }
+      %w[1.0.0 1.0.1 1.1.0].each { |v| index << build_stub_spec("foo", v) }
 
       dfn = Bundler::Definition.new(nil, [], mock_source_list, true)
       dfn.instance_variable_set("@index", index)

--- a/bundler/spec/bundler/dsl_spec.rb
+++ b/bundler/spec/bundler/dsl_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Bundler::Dsl do
 
   describe "#git_source" do
     it "registers custom hosts" do
-      subject.git_source(:example) {|repo_name| "git@git.example.com:#{repo_name}.git" }
-      subject.git_source(:foobar) {|repo_name| "git@foobar.com:#{repo_name}.git" }
+      subject.git_source(:example) { |repo_name| "git@git.example.com:#{repo_name}.git" }
+      subject.git_source(:foobar) { |repo_name| "git@foobar.com:#{repo_name}.git" }
       subject.gem("dobry-pies", :example => "strzalek/dobry-pies")
       example_uri = "git@git.example.com:strzalek/dobry-pies.git"
       expect(subject.dependencies.first.source.uri).to eq(example_uri)
@@ -17,7 +17,7 @@ RSpec.describe Bundler::Dsl do
 
     it "raises exception on invalid hostname" do
       expect do
-        subject.git_source(:group) {|repo_name| "git@git.example.com:#{repo_name}.git" }
+        subject.git_source(:group) { |repo_name| "git@git.example.com:#{repo_name}.git" }
       end.to raise_error(Bundler::InvalidOption)
     end
 
@@ -167,7 +167,7 @@ RSpec.describe Bundler::Dsl do
     end
 
     it "allows specifying a branch on git gems with a git_source" do
-      subject.git_source(:test_source) {|n| "https://github.com/#{n}" }
+      subject.git_source(:test_source) { |n| "https://github.com/#{n}" }
       subject.gem("foo", :branch => "test", :test_source => "bundler/bundler")
       dep = subject.dependencies.last
       expect(dep.name).to eq "foo"
@@ -184,7 +184,7 @@ RSpec.describe Bundler::Dsl do
       it "from a single repo" do
         rails_gems = %w[railties action_pack active_model]
         subject.git "https://github.com/rails/rails.git" do
-          rails_gems.each {|rails_gem| subject.send :gem, rails_gem }
+          rails_gems.each { |rails_gem| subject.send :gem, rails_gem }
         end
         expect(subject.dependencies.map(&:name)).to match_array rails_gems
       end
@@ -199,7 +199,7 @@ RSpec.describe Bundler::Dsl do
       it "from github" do
         spree_gems = %w[spree_core spree_api spree_backend]
         subject.github "spree" do
-          spree_gems.each {|spree_gem| subject.send :gem, spree_gem }
+          spree_gems.each { |spree_gem| subject.send :gem, spree_gem }
         end
 
         subject.dependencies.each do |d|
@@ -212,7 +212,7 @@ RSpec.describe Bundler::Dsl do
       it "from github" do
         spree_gems = %w[spree_core spree_api spree_backend]
         subject.github "spree" do
-          spree_gems.each {|spree_gem| subject.send :gem, spree_gem }
+          spree_gems.each { |spree_gem| subject.send :gem, spree_gem }
         end
 
         subject.dependencies.each do |d|

--- a/bundler/spec/bundler/fetcher/compact_index_spec.rb
+++ b/bundler/spec/bundler/fetcher/compact_index_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe Bundler::Fetcher::CompactIndex do
   end
 
   describe "#specs_for_names" do
-    let(:thread_list) { Thread.list.select {|thread| thread.status == "run" } }
-    let(:thread_inspection) { thread_list.map {|th| "  * #{th}:\n    #{th.backtrace_locations.join("\n    ")}" }.join("\n") }
+    let(:thread_list) { Thread.list.select { |thread| thread.status == "run" } }
+    let(:thread_inspection) { thread_list.map { |th| "  * #{th}:\n    #{th.backtrace_locations.join("\n    ")}" }.join("\n") }
 
     it "has only one thread open at the end of the run" do
       compact_index.specs_for_names(["lskdjf"])

--- a/bundler/spec/bundler/fetcher/dependency_spec.rb
+++ b/bundler/spec/bundler/fetcher/dependency_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Bundler::Fetcher::Dependency do
     before do
       stub_const("Bundler::Fetcher::FAIL_ERRORS", fail_errors)
       allow(Bundler::Retry).to receive(:new).with("dependency api", fail_errors).and_return(bundler_retry)
-      allow(bundler_retry).to receive(:attempts) {|&block| block.call }
+      allow(bundler_retry).to receive(:attempts) { |&block| block.call }
       allow(subject).to receive(:log_specs) {}
       allow(subject).to receive(:remote_uri).and_return(remote_uri)
       allow(Bundler).to receive_message_chain(:ui, :debug?)

--- a/bundler/spec/bundler/fetcher_spec.rb
+++ b/bundler/spec/bundler/fetcher_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Bundler::Fetcher do
     context "when bunder ssl ssl configuration is set" do
       before do
         cert = File.join(Spec::Path.tmpdir, "cert")
-        File.open(cert, "w") {|f| f.write "PEM" }
+        File.open(cert, "w") { |f| f.write "PEM" }
         allow(Bundler.settings).to receive(:[]).and_return(nil)
         allow(Bundler.settings).to receive(:[]).with(:ssl_client_cert).and_return(cert)
         expect(OpenSSL::X509::Certificate).to receive(:new).with("PEM").and_return("cert")
@@ -144,14 +144,14 @@ RSpec.describe Bundler::Fetcher do
     describe "include CI information" do
       it "from one CI" do
         with_env_vars("JENKINS_URL" => "foo") do
-          ci_part = fetcher.user_agent.split(" ").find {|x| x.start_with?("ci/") }
+          ci_part = fetcher.user_agent.split(" ").find { |x| x.start_with?("ci/") }
           expect(ci_part).to match("jenkins")
         end
       end
 
       it "from many CI" do
         with_env_vars("TRAVIS" => "foo", "GITLAB_CI" => "gitlab", "CI_NAME" => "my_ci") do
-          ci_part = fetcher.user_agent.split(" ").find {|x| x.start_with?("ci/") }
+          ci_part = fetcher.user_agent.split(" ").find { |x| x.start_with?("ci/") }
           expect(ci_part).to match("travis")
           expect(ci_part).to match("gitlab")
           expect(ci_part).to match("my_ci")

--- a/bundler/spec/bundler/gem_helper_spec.rb
+++ b/bundler/spec/bundler/gem_helper_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Bundler::GemHelper do
       content = app_gemspec_content.gsub("TODO: ", "")
       content.sub!(/homepage\s+= ".*"/, 'homepage = ""')
       content.gsub!(/spec\.metadata.+\n/, "")
-      File.open(app_gemspec_path, "w") {|file| file << content }
+      File.open(app_gemspec_path, "w") { |file| file << content }
     end
 
     it "uses a shell UI for output" do
@@ -126,7 +126,7 @@ RSpec.describe Bundler::GemHelper do
       context "when build failed" do
         it "raises an error with appropriate message" do
           # break the gemspec by adding back the TODOs
-          File.open(app_gemspec_path, "w") {|file| file << app_gemspec_content }
+          File.open(app_gemspec_path, "w") { |file| file << app_gemspec_content }
           expect { subject.build_gem }.to raise_error(/TODO/)
         end
       end

--- a/bundler/spec/bundler/index_spec.rb
+++ b/bundler/spec/bundler/index_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Bundler::Index do
   let(:specs) { [] }
-  subject { described_class.build {|i| i.use(specs) } }
+  subject { described_class.build { |i| i.use(specs) } }
 
   context "specs with a nil platform" do
     let(:spec) do
@@ -20,14 +20,14 @@ RSpec.describe Bundler::Index do
       end
 
       it "finds the spec when a ruby platform is specified" do
-        query = spec.dup.tap {|s| s.platform = "ruby" }
+        query = spec.dup.tap { |s| s.platform = "ruby" }
         expect(subject.search(query)).to eq([spec])
       end
     end
   end
 
   context "with specs that include development dependencies" do
-    let(:specs) { [*build_spec("a", "1.0.0") {|s| s.development("b", "~> 1.0") }] }
+    let(:specs) { [*build_spec("a", "1.0.0") { |s| s.development("b", "~> 1.0") }] }
 
     it "does not include b in #dependency_names" do
       expect(subject.dependency_names).not_to include("b")

--- a/bundler/spec/bundler/installer/parallel_installer_spec.rb
+++ b/bundler/spec/bundler/installer/parallel_installer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Bundler::ParallelInstaller do
   context "when dependencies that are not on the overall installation list are the only ones not installed" do
     let(:all_specs) do
       [
-        build_spec("alpha", "1.0") {|s| s.runtime "a", "1" },
+        build_spec("alpha", "1.0") { |s| s.runtime "a", "1" },
       ].flatten
     end
 

--- a/bundler/spec/bundler/lockfile_parser_spec.rb
+++ b/bundler/spec/bundler/lockfile_parser_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe Bundler::LockfileParser do
         expect(subject.sources).to eq sources
         expect(subject.dependencies).to eq dependencies
         expect(subject.specs).to eq specs
-        expect(Hash[subject.specs.map {|s| [s, s.dependencies] }]).to eq Hash[subject.specs.map {|s| [s, s.dependencies] }]
+        expect(Hash[subject.specs.map { |s| [s, s.dependencies] }]).to eq Hash[subject.specs.map { |s| [s, s.dependencies] }]
         expect(subject.platforms).to eq platforms
         expect(subject.bundler_version).to eq bundler_version
         expect(subject.ruby_version).to eq ruby_version

--- a/bundler/spec/bundler/shared_helpers_spec.rb
+++ b/bundler/spec/bundler/shared_helpers_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Bundler::SharedHelpers do
   before do
     pwd_stub
     allow(Bundler.rubygems).to receive(:ext_lock).and_return(ext_lock_double)
-    allow(ext_lock_double).to receive(:synchronize) {|&block| block.call }
+    allow(ext_lock_double).to receive(:synchronize) { |&block| block.call }
   end
 
   let(:pwd_stub) { allow(subject).to receive(:pwd).and_return(bundled_app) }
@@ -425,7 +425,7 @@ RSpec.describe Bundler::SharedHelpers do
 
   describe "#filesystem_access" do
     context "system has proper permission access" do
-      let(:file_op_block) { proc {|path| FileUtils.mkdir_p(path) } }
+      let(:file_op_block) { proc { |path| FileUtils.mkdir_p(path) } }
 
       it "performs the operation in the passed block" do
         subject.filesystem_access(bundled_app("test_dir"), &file_op_block)
@@ -434,7 +434,7 @@ RSpec.describe Bundler::SharedHelpers do
     end
 
     context "system throws Errno::EACESS" do
-      let(:file_op_block) { proc {|_path| raise Errno::EACCES } }
+      let(:file_op_block) { proc { |_path| raise Errno::EACCES } }
 
       it "raises a PermissionError" do
         expect { subject.filesystem_access("/path", &file_op_block) }.to raise_error(
@@ -444,7 +444,7 @@ RSpec.describe Bundler::SharedHelpers do
     end
 
     context "system throws Errno::EAGAIN" do
-      let(:file_op_block) { proc {|_path| raise Errno::EAGAIN } }
+      let(:file_op_block) { proc { |_path| raise Errno::EAGAIN } }
 
       it "raises a TemporaryResourceError" do
         expect { subject.filesystem_access("/path", &file_op_block) }.to raise_error(
@@ -454,7 +454,7 @@ RSpec.describe Bundler::SharedHelpers do
     end
 
     context "system throws Errno::EPROTO" do
-      let(:file_op_block) { proc {|_path| raise Errno::EPROTO } }
+      let(:file_op_block) { proc { |_path| raise Errno::EPROTO } }
 
       it "raises a VirtualProtocolError" do
         expect { subject.filesystem_access("/path", &file_op_block) }.to raise_error(
@@ -464,7 +464,7 @@ RSpec.describe Bundler::SharedHelpers do
     end
 
     context "system throws Errno::ENOTSUP" do
-      let(:file_op_block) { proc {|_path| raise Errno::ENOTSUP } }
+      let(:file_op_block) { proc { |_path| raise Errno::ENOTSUP } }
 
       it "raises a OperationNotSupportedError" do
         expect { subject.filesystem_access("/path", &file_op_block) }.to raise_error(
@@ -474,7 +474,7 @@ RSpec.describe Bundler::SharedHelpers do
     end
 
     context "system throws Errno::ENOSPC" do
-      let(:file_op_block) { proc {|_path| raise Errno::ENOSPC } }
+      let(:file_op_block) { proc { |_path| raise Errno::ENOSPC } }
 
       it "raises a NoSpaceOnDeviceError" do
         expect { subject.filesystem_access("/path", &file_op_block) }.to raise_error(
@@ -485,7 +485,7 @@ RSpec.describe Bundler::SharedHelpers do
 
     context "system throws an unhandled SystemCallError" do
       let(:error) { SystemCallError.new("Shields down", 1337) }
-      let(:file_op_block) { proc {|_path| raise error } }
+      let(:file_op_block) { proc { |_path| raise error } }
 
       it "raises a GenericSystemCallError" do
         expect { subject.filesystem_access("/path", &file_op_block) }.to raise_error(

--- a/bundler/spec/bundler/source/rubygems/remote_spec.rb
+++ b/bundler/spec/bundler/source/rubygems/remote_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Bundler::Source::Rubygems::Remote do
   end
 
   before do
-    allow(Digest(:MD5)).to receive(:hexdigest).with(duck_type(:to_s)) {|string| "MD5HEX(#{string})" }
+    allow(Digest(:MD5)).to receive(:hexdigest).with(duck_type(:to_s)) { |string| "MD5HEX(#{string})" }
   end
 
   let(:uri_no_auth) { Bundler::URI("https://gems.example.com") }

--- a/bundler/spec/bundler/worker_spec.rb
+++ b/bundler/spec/bundler/worker_spec.rb
@@ -5,7 +5,7 @@ require "bundler/worker"
 RSpec.describe Bundler::Worker do
   let(:size) { 5 }
   let(:name) { "Spec Worker" }
-  let(:function) { proc {|object, worker_number| [object, worker_number] } }
+  let(:function) { proc { |object, worker_number| [object, worker_number] } }
   subject { described_class.new(size, name, function) }
 
   after { subject.stop }

--- a/bundler/spec/cache/gems_spec.rb
+++ b/bundler/spec/cache/gems_spec.rb
@@ -269,7 +269,7 @@ RSpec.describe "bundle cache" do
 
     it "handles directories and non .gem files in the cache" do
       bundled_app("vendor/cache/foo").mkdir
-      File.open(bundled_app("vendor/cache/bar"), "w") {|f| f.write("not a gem") }
+      File.open(bundled_app("vendor/cache/bar"), "w") { |f| f.write("not a gem") }
       bundle :cache
     end
 

--- a/bundler/spec/cache/git_spec.rb
+++ b/bundler/spec/cache/git_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe "bundle cache with git" do
     # Insert a gemspec method that shells out
     spec_lines = lib_path("foo-1.0/foo.gemspec").read.split("\n")
     spec_lines.insert(-2, "s.description = `echo bob`")
-    update_git("foo") {|s| s.write "foo.gemspec", spec_lines.join("\n") }
+    update_git("foo") { |s| s.write "foo.gemspec", spec_lines.join("\n") }
 
     install_gemfile <<-G
       gem "foo", :git => '#{lib_path("foo-1.0")}'

--- a/bundler/spec/commands/clean_spec.rb
+++ b/bundler/spec/commands/clean_spec.rb
@@ -443,7 +443,7 @@ RSpec.describe "bundle clean" do
     bundle "update", :all => true
 
     files = Pathname.glob(bundled_app(".bundle", Bundler.ruby_scope, "*", "*"))
-    files.map! {|f| f.to_s.sub(bundled_app(".bundle", Bundler.ruby_scope).to_s, "") }
+    files.map! { |f| f.to_s.sub(bundled_app(".bundle", Bundler.ruby_scope).to_s, "") }
     expect(files.sort).to eq %w[
       /cache/foo-1.0.1.gem
       /gems/foo-1.0.1

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -368,7 +368,7 @@ RSpec.describe "bundle exec" do
 
   describe "with help flags" do
     each_prefix = proc do |string, &blk|
-      1.upto(string.length) {|l| blk.call(string[0, l]) }
+      1.upto(string.length) { |l| blk.call(string[0, l]) }
     end
     each_prefix.call("exec") do |exec|
       describe "when #{exec} is used" do
@@ -620,7 +620,7 @@ RSpec.describe "bundle exec" do
     RUBY
 
     before do
-      bundled_app(path).open("w") {|f| f << executable }
+      bundled_app(path).open("w") { |f| f << executable }
       bundled_app(path).chmod(0o755)
 
       install_gemfile <<-G

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -567,7 +567,7 @@ RSpec.describe "bundle install with gem sources" do
 
     it "includes the standalone path" do
       bundle "binstubs rack", :standalone => true
-      standalone_line = File.read(bundled_app("bin/rackup")).each_line.find {|line| line.include? "$:.unshift" }.strip
+      standalone_line = File.read(bundled_app("bin/rackup")).each_line.find { |line| line.include? "$:.unshift" }.strip
       expect(standalone_line).to eq %($:.unshift File.expand_path "../../bundle", path.realpath)
     end
   end

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "bundle gem" do
     EOF
     @git_config_location = ENV["GIT_CONFIG"]
     path = "#{tmp}/test_git_config.txt"
-    File.open(path, "w") {|f| f.write(git_config_content) }
+    File.open(path, "w") { |f| f.write(git_config_content) }
     ENV["GIT_CONFIG"] = path
   end
 
@@ -166,7 +166,7 @@ RSpec.describe "bundle gem" do
       builder = Bundler::Dsl.new
       builder.eval_gemfile(bundled_app("#{gem_name}/Gemfile"))
       builder.dependencies
-      rubocop_dep = builder.dependencies.find {|d| d.name == "rubocop" }
+      rubocop_dep = builder.dependencies.find { |d| d.name == "rubocop" }
       expect(rubocop_dep).not_to be_nil
     end
   end
@@ -189,7 +189,7 @@ RSpec.describe "bundle gem" do
       builder = Bundler::Dsl.new
       builder.eval_gemfile(bundled_app("#{gem_name}/Gemfile"))
       builder.dependencies
-      rubocop_dep = builder.dependencies.find {|d| d.name == "rubocop" }
+      rubocop_dep = builder.dependencies.find { |d| d.name == "rubocop" }
       expect(rubocop_dep).to be_nil
     end
   end
@@ -446,7 +446,7 @@ RSpec.describe "bundle gem" do
         builder = Bundler::Dsl.new
         builder.eval_gemfile(bundled_app("#{gem_name}/Gemfile"))
         builder.dependencies
-        rspec_dep = builder.dependencies.find {|d| d.name == "rspec" }
+        rspec_dep = builder.dependencies.find { |d| d.name == "rspec" }
         expect(rspec_dep).to be_specific
       end
 
@@ -494,7 +494,7 @@ RSpec.describe "bundle gem" do
         builder = Bundler::Dsl.new
         builder.eval_gemfile(bundled_app("#{gem_name}/Gemfile"))
         builder.dependencies
-        minitest_dep = builder.dependencies.find {|d| d.name == "minitest" }
+        minitest_dep = builder.dependencies.find { |d| d.name == "minitest" }
         expect(minitest_dep).to be_specific
       end
 
@@ -550,7 +550,7 @@ RSpec.describe "bundle gem" do
         builder = Bundler::Dsl.new
         builder.eval_gemfile(bundled_app("#{gem_name}/Gemfile"))
         builder.dependencies
-        test_unit_dep = builder.dependencies.find {|d| d.name == "test-unit" }
+        test_unit_dep = builder.dependencies.find { |d| d.name == "test-unit" }
         expect(test_unit_dep).to be_specific
       end
 

--- a/bundler/spec/commands/outdated_spec.rb
+++ b/bundler/spec/commands/outdated_spec.rb
@@ -626,7 +626,7 @@ RSpec.describe "bundle outdated" do
     it "reports that a gem has a newer version" do
       subject
 
-      outdated_gems = out.split("\n").drop_while {|l| !l.start_with?("Gem") }[1..-1]
+      outdated_gems = out.split("\n").drop_while { |l| !l.start_with?("Gem") }[1..-1]
 
       expect(outdated_gems.size).to be > 0
     end

--- a/bundler/spec/commands/pristine_spec.rb
+++ b/bundler/spec/commands/pristine_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "bundle pristine", :ruby_repo do
       changed_file = Pathname.new(spec.full_gem_path).join("lib/foo.rb")
       diff = "#Pristine spec changes"
 
-      File.open(changed_file, "a") {|f| f.puts diff }
+      File.open(changed_file, "a") { |f| f.puts diff }
       expect(File.read(changed_file)).to include(diff)
 
       bundle "pristine"
@@ -103,7 +103,7 @@ RSpec.describe "bundle pristine", :ruby_repo do
       changed_file = Pathname.new(spec.full_gem_path).join("lib/baz.rb")
       diff = "#Pristine spec changes"
 
-      File.open(changed_file, "a") {|f| f.puts diff }
+      File.open(changed_file, "a") { |f| f.puts diff }
       expect(File.read(changed_file)).to include(diff)
 
       bundle "pristine"
@@ -116,7 +116,7 @@ RSpec.describe "bundle pristine", :ruby_repo do
       changed_file = Pathname.new(spec.full_gem_path).join("lib/baz/dev.rb")
       diff = "#Pristine spec changes"
 
-      File.open(changed_file, "a") {|f| f.puts "#Pristine spec changes" }
+      File.open(changed_file, "a") { |f| f.puts "#Pristine spec changes" }
       expect(File.read(changed_file)).to include(diff)
 
       bundle "pristine"

--- a/bundler/spec/commands/show_spec.rb
+++ b/bundler/spec/commands/show_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
       expect(out).to include(default_bundle_path("gems", "rails-2.3.2").to_s)
 
       # Gem names are the last component of their path.
-      gem_list = out.split.map {|p| p.split("/").last }
+      gem_list = out.split.map { |p| p.split("/").last }
       expect(gem_list).to eq(gem_list.sort)
     end
 
@@ -143,7 +143,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
   context "in a fresh gem in a blank git repo" do
     before :each do
       build_git "foo", :path => lib_path("foo")
-      File.open(lib_path("foo/Gemfile"), "w") {|f| f.puts "gemspec" }
+      File.open(lib_path("foo/Gemfile"), "w") { |f| f.puts "gemspec" }
       sys_exec "rm -rf .git && git init", :dir => lib_path("foo")
     end
 

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -464,7 +464,7 @@ RSpec.describe "bundle update in more complicated situations" do
     G
 
     update_repo2 do
-      build_gem("thin", "2.0") {|s| s.add_dependency "rack" }
+      build_gem("thin", "2.0") { |s| s.add_dependency "rack" }
       build_gem "rack", "10.0"
     end
 
@@ -527,9 +527,9 @@ RSpec.describe "bundle update in more complicated situations" do
     before do
       build_repo4 do
         build_gem("a", "0.9")
-        build_gem("a", "0.9") {|s| s.platform = "java" }
+        build_gem("a", "0.9") { |s| s.platform = "java" }
         build_gem("a", "1.1")
-        build_gem("a", "1.1") {|s| s.platform = "java" }
+        build_gem("a", "1.1") { |s| s.platform = "java" }
       end
 
       gemfile <<-G
@@ -567,8 +567,8 @@ RSpec.describe "bundle update in more complicated situations" do
   context "when the dependency is for a different platform" do
     before do
       build_repo4 do
-        build_gem("a", "0.9") {|s| s.platform = "java" }
-        build_gem("a", "1.1") {|s| s.platform = "java" }
+        build_gem("a", "0.9") { |s| s.platform = "java" }
+        build_gem("a", "1.1") { |s| s.platform = "java" }
       end
 
       gemfile <<-G

--- a/bundler/spec/install/failure_spec.rb
+++ b/bundler/spec/install/failure_spec.rb
@@ -128,7 +128,7 @@ In Gemfile:
           build_gem "a"
         end
 
-        gem_repo4("gems", "a-1.0.gem").open("w") {|f| f << "<html></html>" }
+        gem_repo4("gems", "a-1.0.gem").open("w") { |f| f << "<html></html>" }
       end
 
       it "removes the downloaded .gem" do

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -542,7 +542,7 @@ RSpec.describe "bundle install from an existing gemspec" do
       build_lib("foo", :path => tmp.join("foo")) do |s|
         s.version = "1.0.0"
         s.add_development_dependency "rack"
-        s.write "foo-universal-java.gemspec", build_spec("foo", "1.0.0", "universal-java") {|sj| sj.runtime "rack", "1.0.0" }.first.to_ruby
+        s.write "foo-universal-java.gemspec", build_spec("foo", "1.0.0", "universal-java") { |sj| sj.runtime "rack", "1.0.0" }.first.to_ruby
       end
     end
 

--- a/bundler/spec/install/gemfile/path_spec.rb
+++ b/bundler/spec/install/gemfile/path_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe "bundle install with explicit source paths" do
       gem "aaa", :path => "./aaa"
     G
 
-    File.open(lib_path("demo/Gemfile"), "w") {|f| f.puts gemfile }
+    File.open(lib_path("demo/Gemfile"), "w") { |f| f.puts gemfile }
 
     lockfile = <<~L
       PATH
@@ -243,7 +243,7 @@ RSpec.describe "bundle install with explicit source paths" do
       gemspec
     G
 
-    File.open(lib_path("foo/Gemfile"), "w") {|f| f.puts gemfile }
+    File.open(lib_path("foo/Gemfile"), "w") { |f| f.puts gemfile }
 
     bundle "install", :dir => lib_path("foo")
     expect(the_bundle).to include_gems "foo 1.0", :dir => lib_path("foo")
@@ -646,7 +646,7 @@ RSpec.describe "bundle install with explicit source paths" do
         gemspec
         gem 'rack'
       G
-      File.open(lib_path("private_lib/Gemfile"), "w") {|f| f.puts gemfile }
+      File.open(lib_path("private_lib/Gemfile"), "w") { |f| f.puts gemfile }
 
       bundle :install, :env => { "DEBUG" => "1" }, :artifice => "endpoint", :dir => lib_path("private_lib")
       expect(out).to match(%r{^HTTP GET http://localgemserver\.test/api/v1/dependencies\?gems=rack$})

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "bundle install across platforms" do
       build_gem "empyrean", "0.1.0"
       build_gem "coderay", "1.1.2"
       build_gem "method_source", "0.9.0"
-      build_gem("spoon", "0.0.6") {|s| s.add_runtime_dependency "ffi" }
+      build_gem("spoon", "0.0.6") { |s| s.add_runtime_dependency "ffi" }
       build_gem "pry", "0.11.3" do |s|
         s.platform = "java"
         s.add_runtime_dependency "coderay", "~> 1.1.0"
@@ -89,7 +89,7 @@ RSpec.describe "bundle install across platforms" do
         s.add_runtime_dependency "coderay", "~> 1.1.0"
         s.add_runtime_dependency "method_source", "~> 0.9.0"
       end
-      build_gem("ffi", "1.9.23") {|s| s.platform = "java" }
+      build_gem("ffi", "1.9.23") { |s| s.platform = "java" }
       build_gem("ffi", "1.9.23")
     end
 

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -6,31 +6,31 @@ RSpec.describe "bundle install with specific_platform enabled" do
 
     build_repo2 do
       build_gem("google-protobuf", "3.0.0.alpha.5.0.5.1")
-      build_gem("google-protobuf", "3.0.0.alpha.5.0.5.1") {|s| s.platform = "x86_64-linux" }
-      build_gem("google-protobuf", "3.0.0.alpha.5.0.5.1") {|s| s.platform = "x86-mingw32" }
-      build_gem("google-protobuf", "3.0.0.alpha.5.0.5.1") {|s| s.platform = "x86-linux" }
-      build_gem("google-protobuf", "3.0.0.alpha.5.0.5.1") {|s| s.platform = "x64-mingw32" }
-      build_gem("google-protobuf", "3.0.0.alpha.5.0.5.1") {|s| s.platform = "universal-darwin" }
+      build_gem("google-protobuf", "3.0.0.alpha.5.0.5.1") { |s| s.platform = "x86_64-linux" }
+      build_gem("google-protobuf", "3.0.0.alpha.5.0.5.1") { |s| s.platform = "x86-mingw32" }
+      build_gem("google-protobuf", "3.0.0.alpha.5.0.5.1") { |s| s.platform = "x86-linux" }
+      build_gem("google-protobuf", "3.0.0.alpha.5.0.5.1") { |s| s.platform = "x64-mingw32" }
+      build_gem("google-protobuf", "3.0.0.alpha.5.0.5.1") { |s| s.platform = "universal-darwin" }
 
-      build_gem("google-protobuf", "3.0.0.alpha.5.0.5") {|s| s.platform = "x86_64-linux" }
-      build_gem("google-protobuf", "3.0.0.alpha.5.0.5") {|s| s.platform = "x86-linux" }
-      build_gem("google-protobuf", "3.0.0.alpha.5.0.5") {|s| s.platform = "x64-mingw32" }
-      build_gem("google-protobuf", "3.0.0.alpha.5.0.5") {|s| s.platform = "x86-mingw32" }
+      build_gem("google-protobuf", "3.0.0.alpha.5.0.5") { |s| s.platform = "x86_64-linux" }
+      build_gem("google-protobuf", "3.0.0.alpha.5.0.5") { |s| s.platform = "x86-linux" }
+      build_gem("google-protobuf", "3.0.0.alpha.5.0.5") { |s| s.platform = "x64-mingw32" }
+      build_gem("google-protobuf", "3.0.0.alpha.5.0.5") { |s| s.platform = "x86-mingw32" }
       build_gem("google-protobuf", "3.0.0.alpha.5.0.5")
 
-      build_gem("google-protobuf", "3.0.0.alpha.5.0.4") {|s| s.platform = "universal-darwin" }
-      build_gem("google-protobuf", "3.0.0.alpha.5.0.4") {|s| s.platform = "x86_64-linux" }
-      build_gem("google-protobuf", "3.0.0.alpha.5.0.4") {|s| s.platform = "x86-mingw32" }
-      build_gem("google-protobuf", "3.0.0.alpha.5.0.4") {|s| s.platform = "x86-linux" }
-      build_gem("google-protobuf", "3.0.0.alpha.5.0.4") {|s| s.platform = "x64-mingw32" }
+      build_gem("google-protobuf", "3.0.0.alpha.5.0.4") { |s| s.platform = "universal-darwin" }
+      build_gem("google-protobuf", "3.0.0.alpha.5.0.4") { |s| s.platform = "x86_64-linux" }
+      build_gem("google-protobuf", "3.0.0.alpha.5.0.4") { |s| s.platform = "x86-mingw32" }
+      build_gem("google-protobuf", "3.0.0.alpha.5.0.4") { |s| s.platform = "x86-linux" }
+      build_gem("google-protobuf", "3.0.0.alpha.5.0.4") { |s| s.platform = "x64-mingw32" }
       build_gem("google-protobuf", "3.0.0.alpha.5.0.4")
 
       build_gem("google-protobuf", "3.0.0.alpha.5.0.3")
-      build_gem("google-protobuf", "3.0.0.alpha.5.0.3") {|s| s.platform = "x86_64-linux" }
-      build_gem("google-protobuf", "3.0.0.alpha.5.0.3") {|s| s.platform = "x86-mingw32" }
-      build_gem("google-protobuf", "3.0.0.alpha.5.0.3") {|s| s.platform = "x86-linux" }
-      build_gem("google-protobuf", "3.0.0.alpha.5.0.3") {|s| s.platform = "x64-mingw32" }
-      build_gem("google-protobuf", "3.0.0.alpha.5.0.3") {|s| s.platform = "universal-darwin" }
+      build_gem("google-protobuf", "3.0.0.alpha.5.0.3") { |s| s.platform = "x86_64-linux" }
+      build_gem("google-protobuf", "3.0.0.alpha.5.0.3") { |s| s.platform = "x86-mingw32" }
+      build_gem("google-protobuf", "3.0.0.alpha.5.0.3") { |s| s.platform = "x86-linux" }
+      build_gem("google-protobuf", "3.0.0.alpha.5.0.3") { |s| s.platform = "x64-mingw32" }
+      build_gem("google-protobuf", "3.0.0.alpha.5.0.3") { |s| s.platform = "universal-darwin" }
 
       build_gem("google-protobuf", "3.0.0.alpha.4.0")
       build_gem("google-protobuf", "3.0.0.alpha.3.1.pre")

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -838,7 +838,7 @@ The checksum of /versions does not match the checksum provided by the server! So
     expected_rack_info_content = File.read(rake_info_path)
 
     # Modify the cache files. We expect them to be reset to the normal ones when we re-run :install
-    File.open(rake_info_path, "w") {|f| f << (expected_rack_info_content + "this is different") }
+    File.open(rake_info_path, "w") { |f| f << (expected_rack_info_content + "this is different") }
 
     # Update the Gemfile so the next install does its normal things
     gemfile <<-G

--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -3,7 +3,7 @@
 RSpec.shared_examples "bundle install --standalone" do
   shared_examples "common functionality" do
     it "still makes the gems available to normal bundler" do
-      args = expected_gems.map {|k, v| "#{k} #{v}" }
+      args = expected_gems.map { |k, v| "#{k} #{v}" }
       expect(the_bundle).to include_gems(*args)
     end
 
@@ -80,7 +80,7 @@ RSpec.shared_examples "bundle install --standalone" do
 
     it "generates a bundle/bundler/setup.rb with the proper paths" do
       expected_path = bundled_app("bundle/bundler/setup.rb")
-      extension_line = File.read(expected_path).each_line.find {|line| line.include? "/extensions/" }.strip
+      extension_line = File.read(expected_path).each_line.find { |line| line.include? "/extensions/" }.strip
       expect(extension_line).to start_with '$:.unshift "#{path}/../#{ruby_engine}/#{ruby_version}/extensions/'
       expect(extension_line).to end_with '/very_simple_binary-1.0"'
     end
@@ -307,7 +307,7 @@ RSpec.shared_examples "bundle install --standalone" do
     end
 
     it "creates stubs with the correct load path" do
-      extension_line = File.read(bundled_app("bin/rails")).each_line.find {|line| line.include? "$:.unshift" }.strip
+      extension_line = File.read(bundled_app("bin/rails")).each_line.find { |line| line.include? "$:.unshift" }.strip
       expect(extension_line).to eq %($:.unshift File.expand_path "../../bundle", path.realpath)
     end
   end

--- a/bundler/spec/install/global_cache_spec.rb
+++ b/bundler/spec/install/global_cache_spec.rb
@@ -217,8 +217,8 @@ RSpec.describe "global gem caching" do
 
       FileUtils.rm Dir[home(".bundle", "cache", "extensions", "**", "*binary_c*")]
 
-      gem_binary_cache.join("very_simple_binary_c.rb").open("w") {|f| f << "puts File.basename(__FILE__)" }
-      git_binary_cache.join("very_simple_git_binary_c.rb").open("w") {|f| f << "puts File.basename(__FILE__)" }
+      gem_binary_cache.join("very_simple_binary_c.rb").open("w") { |f| f << "puts File.basename(__FILE__)" }
+      git_binary_cache.join("very_simple_git_binary_c.rb").open("w") { |f| f << "puts File.basename(__FILE__)" }
 
       bundle "config set --local path different_path"
       bundle :install

--- a/bundler/spec/install/path_spec.rb
+++ b/bundler/spec/install/path_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe "bundle install" do
 
           bundle :install
 
-          paths_to_exist = %w[cache/rack-1.0.0.gem gems/rack-1.0.0 specifications/rack-1.0.0.gemspec].map {|path| bundled_app(Bundler.ruby_scope, path) }
+          paths_to_exist = %w[cache/rack-1.0.0.gem gems/rack-1.0.0 specifications/rack-1.0.0.gemspec].map { |path| bundled_app(Bundler.ruby_scope, path) }
           expect(paths_to_exist).to all exist
           expect(the_bundle).to include_gems "rack 1.0.0"
         end

--- a/bundler/spec/install/redownload_spec.rb
+++ b/bundler/spec/install/redownload_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "bundle install" do
       rack_lib = default_bundle_path("gems/rack-1.0.0/lib/rack.rb")
 
       bundle :install
-      rack_lib.open("w") {|f| f.write("blah blah blah") }
+      rack_lib.open("w") { |f| f.write("blah blah blah") }
       bundle :install, flag => true
 
       expect(out).to include "Installing rack 1.0.0"
@@ -41,7 +41,7 @@ RSpec.describe "bundle install" do
         foo_lib = default_bundle_path("bundler/gems/foo-1.0-#{ref}/lib/foo.rb")
 
         bundle :install
-        foo_lib.open("w") {|f| f.write("blah blah blah") }
+        foo_lib.open("w") { |f| f.write("blah blah blah") }
         bundle :install, flag => true
 
         expect(foo_lib.open(&:read)).to eq("FOO = '1.0'\n")

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -1412,7 +1412,7 @@ RSpec.describe "the lockfile format" do
 
         update_repo2
         win_lock = File.read(bundled_app_lock).gsub(/\n/, "\r\n")
-        File.open(bundled_app_lock, "wb") {|f| f.puts(win_lock) }
+        File.open(bundled_app_lock, "wb") { |f| f.puts(win_lock) }
         set_lockfile_mtime_to_known_value
 
         expect { bundle "update", :all => true }.to change { File.mtime(bundled_app_lock) }
@@ -1433,7 +1433,7 @@ RSpec.describe "the lockfile format" do
 
       it "preserves Gemfile.lock \\n\\r line endings" do
         win_lock = File.read(bundled_app_lock).gsub(/\n/, "\r\n")
-        File.open(bundled_app_lock, "wb") {|f| f.puts(win_lock) }
+        File.open(bundled_app_lock, "wb") { |f| f.puts(win_lock) }
         set_lockfile_mtime_to_known_value
 
         expect do
@@ -1483,7 +1483,7 @@ private
   end
 
   def previous_major(version)
-    version.split(".").map.with_index {|v, i| i == 0 ? v.to_i - 1 : v }.join(".")
+    version.split(".").map.with_index { |v, i| i == 0 ? v.to_i - 1 : v }.join(".")
   end
 
   def bump_minor(version)
@@ -1491,6 +1491,6 @@ private
   end
 
   def bump(version, segment)
-    version.split(".").map.with_index {|v, i| i == segment ? v.to_i + 1 : v }.join(".")
+    version.split(".").map.with_index { |v, i| i == segment ? v.to_i + 1 : v }.join(".")
   end
 end

--- a/bundler/spec/other/platform_spec.rb
+++ b/bundler/spec/other/platform_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "bundle platform" do
   context "without flags" do
     let(:bundle_platform_platforms_string) do
-      local_platforms.reverse.map {|pl| "* #{pl}" }.join("\n")
+      local_platforms.reverse.map { |pl| "* #{pl}" }.join("\n")
     end
 
     it "returns all the output" do

--- a/bundler/spec/quality_spec.rb
+++ b/bundler/spec/quality_spec.rb
@@ -177,17 +177,17 @@ RSpec.describe "The library itself" do
       use_gem_version_promoter_for_major_updates
     ]
 
-    all_settings = Hash.new {|h, k| h[k] = [] }
+    all_settings = Hash.new { |h, k| h[k] = [] }
     documented_settings = []
 
-    Bundler::Settings::BOOL_KEYS.each {|k| all_settings[k] << "in Bundler::Settings::BOOL_KEYS" }
-    Bundler::Settings::NUMBER_KEYS.each {|k| all_settings[k] << "in Bundler::Settings::NUMBER_KEYS" }
-    Bundler::Settings::ARRAY_KEYS.each {|k| all_settings[k] << "in Bundler::Settings::ARRAY_KEYS" }
+    Bundler::Settings::BOOL_KEYS.each { |k| all_settings[k] << "in Bundler::Settings::BOOL_KEYS" }
+    Bundler::Settings::NUMBER_KEYS.each { |k| all_settings[k] << "in Bundler::Settings::NUMBER_KEYS" }
+    Bundler::Settings::ARRAY_KEYS.each { |k| all_settings[k] << "in Bundler::Settings::ARRAY_KEYS" }
 
     key_pattern = /([a-z\._-]+)/i
     lib_tracked_files.each do |filename|
       each_line(filename) do |line, number|
-        line.scan(/Bundler\.settings\[:#{key_pattern}\]/).flatten.each {|s| all_settings[s] << "referenced at `#{filename}:#{number.succ}`" }
+        line.scan(/Bundler\.settings\[:#{key_pattern}\]/).flatten.each { |s| all_settings[s] << "referenced at `#{filename}:#{number.succ}`" }
       end
     end
     documented_settings = File.read("man/bundle-config.ronn")[/LIST OF AVAILABLE KEYS.*/m].scan(/^\* `#{key_pattern}`/).flatten
@@ -232,8 +232,8 @@ RSpec.describe "The library itself" do
       lib/bundler/templates/gems.rb
     ]
     files_to_require = lib_tracked_files.grep(/\.rb$/) - exclusions
-    files_to_require.reject! {|f| f.start_with?("lib/bundler/vendor") }
-    files_to_require.map! {|f| File.expand_path(f, source_root) }
+    files_to_require.reject! { |f| f.start_with?("lib/bundler/vendor") }
+    files_to_require.map! { |f| File.expand_path(f, source_root) }
     sys_exec("ruby -w") do |input, _, _|
       files_to_require.each do |f|
         input.puts "require '#{f}'"
@@ -242,7 +242,7 @@ RSpec.describe "The library itself" do
 
     warnings = last_command.stdboth.split("\n")
     # ignore warnings around deprecated Object#=~ method in RubyGems
-    warnings.reject! {|w| w =~ %r{rubygems\/version.rb.*deprecated\ Object#=~} }
+    warnings.reject! { |w| w =~ %r{rubygems\/version.rb.*deprecated\ Object#=~} }
 
     expect(warnings).to be_well_formed
   end

--- a/bundler/spec/resolver/basic_spec.rb
+++ b/bundler/spec/resolver/basic_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe "Resolving" do
 
   it "raises an exception with the minimal set of conflicting dependencies" do
     @index = build_index do
-      %w[0.9 1.0 2.0].each {|v| gem("a", v) }
+      %w[0.9 1.0 2.0].each { |v| gem("a", v) }
       gem("b", "1.0") { dep "a", ">= 2" }
       gem("c", "1.0") { dep "a", "< 1" }
     end

--- a/bundler/spec/runtime/executable_spec.rb
+++ b/bundler/spec/runtime/executable_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe "Running bin/* commands" do
 
     # generate other Gemfile with executable gem
     build_repo2 do
-      build_gem("bindir") {|s| s.executables = "foo" }
+      build_gem("bindir") { |s| s.executables = "foo" }
     end
 
     create_file("OtherGemfile", <<-G)

--- a/bundler/spec/runtime/gem_tasks_spec.rb
+++ b/bundler/spec/runtime/gem_tasks_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
       "rake install",
       "rake release[remote]",
     ]
-    tasks = out.lines.to_a.map {|s| s.split("#").first.strip }
+    tasks = out.lines.to_a.map { |s| s.split("#").first.strip }
     expect(tasks & expected_tasks).to eq(expected_tasks)
     expect(exitstatus).to eq(0) if exitstatus
   end

--- a/bundler/spec/runtime/inline_spec.rb
+++ b/bundler/spec/runtime/inline_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "bundler/inline#gemfile" do
   def script(code, options = {})
     requires = ["#{lib_dir}/bundler/inline"]
     requires.unshift "#{spec_dir}/support/artifice/" + options.delete(:artifice) if options.key?(:artifice)
-    requires = requires.map {|r| "require '#{r}'" }.join("\n")
+    requires = requires.map { |r| "require '#{r}'" }.join("\n")
     ruby("#{requires}\n\n" + code, options)
   end
 
@@ -91,7 +91,7 @@ RSpec.describe "bundler/inline#gemfile" do
 
     expect(out).to include("Installing activesupport")
     err_lines = err.split("\n")
-    err_lines.reject!{|line| line =~ /\.rb:\d+: warning: / } unless RUBY_VERSION < "2.7"
+    err_lines.reject!{ |line| line =~ /\.rb:\d+: warning: / } unless RUBY_VERSION < "2.7"
     expect(err_lines).to be_empty
     expect(exitstatus).to be_zero if exitstatus
   end

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe "Bundler.setup" do
     def clean_load_path(lp)
       without_bundler_load_path = ruby("puts $LOAD_PATH").split("\n")
       lp -= without_bundler_load_path
-      lp.map! {|p| p.sub(/^#{Regexp.union system_gem_path.to_s, default_bundle_path.to_s, lib_dir.to_s}/i, "") }
+      lp.map! { |p| p.sub(/^#{Regexp.union system_gem_path.to_s, default_bundle_path.to_s, lib_dir.to_s}/i, "") }
     end
 
     it "puts loaded gems after -I and RUBYLIB", :ruby_repo do
@@ -128,7 +128,7 @@ RSpec.describe "Bundler.setup" do
       RUBY
 
       load_path = out.split("\n")
-      rack_load_order = load_path.index {|path| path.include?("rack") }
+      rack_load_order = load_path.index { |path| path.include?("rack") }
 
       expect(err).to be_empty
       expect(load_path).to include(a_string_ending_with("dash_i_dir"), "rubylib_dir")
@@ -396,7 +396,7 @@ RSpec.describe "Bundler.setup" do
 
       context "when the ruby stdlib is a substring of Gem.path" do
         it "does not reject the stdlib from $LOAD_PATH" do
-          substring = "/" + $LOAD_PATH.find {|p| p =~ /vendor_ruby/ }.split("/")[2]
+          substring = "/" + $LOAD_PATH.find { |p| p =~ /vendor_ruby/ }.split("/")[2]
           run "puts 'worked!'", :env => { "GEM_PATH" => substring }
           expect(out).to eq("worked!")
         end
@@ -809,7 +809,7 @@ end
 
       gemspec_content = File.binread(gemspec).
                 sub("Bundler::VERSION", %("#{Bundler::VERSION}")).
-                lines.reject {|line| line =~ %r{lib/bundler/version} }.join
+                lines.reject { |line| line =~ %r{lib/bundler/version} }.join
 
       File.open(File.join(specifications_dir, "#{full_name}.gemspec"), "wb") do |f|
         f.write(gemspec_content)

--- a/bundler/spec/runtime/with_unbundled_env_spec.rb
+++ b/bundler/spec/runtime/with_unbundled_env_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "Bundler.with_env helpers" do
 
     it "removes variables that bundler added", :ruby_repo do
       # Simulate bundler has not yet been loaded
-      ENV.replace(ENV.to_hash.delete_if {|k, _v| k.start_with?(Bundler::EnvironmentPreserver::BUNDLER_PREFIX) })
+      ENV.replace(ENV.to_hash.delete_if { |k, _v| k.start_with?(Bundler::EnvironmentPreserver::BUNDLER_PREFIX) })
 
       original = ruby('puts ENV.to_a.map {|e| e.join("=") }.sort.join("\n")')
       create_file("source.rb", <<-RUBY)

--- a/bundler/spec/support/artifice/compact_index.rb
+++ b/bundler/spec/support/artifice/compact_index.rb
@@ -43,7 +43,7 @@ class CompactIndexAPI < Endpoint
 
       if ranges
         status 206
-        body ranges.map! {|range| slice_body(response_body, range) }.join
+        body ranges.map! { |range| slice_body(response_body, range) }.join
       else
         status 200
         body response_body
@@ -55,7 +55,7 @@ class CompactIndexAPI < Endpoint
     end
 
     def parse_etags(value)
-      value ? value.split(/, ?/).select {|s| s.sub!(/"(.*)"/, '\1') } : []
+      value ? value.split(/, ?/).select { |s| s.sub!(/"(.*)"/, '\1') } : []
     end
 
     def slice_body(body, range)
@@ -75,8 +75,8 @@ class CompactIndexAPI < Endpoint
 
         specs.group_by(&:name).map do |name, versions|
           gem_versions = versions.map do |spec|
-            deps = spec.dependencies.select {|d| d.type == :runtime }.map do |d|
-              reqs = d.requirement.requirements.map {|r| r.join(" ") }.join(", ")
+            deps = spec.dependencies.select { |d| d.type == :runtime }.map do |d|
+              reqs = d.requirement.requirements.map { |r| r.join(" ") }.join(", ")
               CompactIndex::Dependency.new(d.name, reqs)
             end
             checksum = begin
@@ -111,7 +111,7 @@ class CompactIndexAPI < Endpoint
 
   get "/info/:name" do
     etag_response do
-      gem = gems.find {|g| g.name == params[:name] }
+      gem = gems.find { |g| g.name == params[:name] }
       CompactIndex.info(gem ? gem.versions : [])
     end
   end

--- a/bundler/spec/support/artifice/compact_index_concurrent_download.rb
+++ b/bundler/spec/support/artifice/compact_index_concurrent_download.rb
@@ -17,7 +17,7 @@ class CompactIndexConcurrentDownload < CompactIndexAPI
 
     # Overwrite the file in parallel, which should be then overwritten
     # after a successful download to prevent corruption
-    File.open(versions, "w") {|f| f.puts "another process" }
+    File.open(versions, "w") { |f| f.puts "another process" }
 
     etag_response do
       file = tmp("versions.list")

--- a/bundler/spec/support/artifice/compact_index_extra_api.rb
+++ b/bundler/spec/support/artifice/compact_index_extra_api.rb
@@ -23,7 +23,7 @@ class CompactIndexExtraApi < CompactIndexAPI
 
   get "/extra/info/:name" do
     etag_response do
-      gem = gems(gem_repo4).find {|g| g.name == params[:name] }
+      gem = gems(gem_repo4).find { |g| g.name == params[:name] }
       CompactIndex.info(gem ? gem.versions : [])
     end
   end

--- a/bundler/spec/support/artifice/compact_index_range_not_satisfiable.rb
+++ b/bundler/spec/support/artifice/compact_index_range_not_satisfiable.rb
@@ -24,7 +24,7 @@ class CompactIndexRangeNotSatisfiable < CompactIndexAPI
       status 416
     else
       etag_response do
-        gem = gems.find {|g| g.name == params[:name] }
+        gem = gems.find { |g| g.name == params[:name] }
         CompactIndex.info(gem ? gem.versions : [])
       end
     end

--- a/bundler/spec/support/artifice/compact_index_rate_limited.rb
+++ b/bundler/spec/support/artifice/compact_index_rate_limited.rb
@@ -33,7 +33,7 @@ class CompactIndexRateLimited < CompactIndexAPI
     begin
       if RequestCounter.size == 1
         etag_response do
-          gem = gems.find {|g| g.name == params[:name] }
+          gem = gems.find { |g| g.name == params[:name] }
           CompactIndex.info(gem ? gem.versions : [])
         end
       else

--- a/bundler/spec/support/artifice/compact_index_wrong_dependencies.rb
+++ b/bundler/spec/support/artifice/compact_index_wrong_dependencies.rb
@@ -7,8 +7,8 @@ Artifice.deactivate
 class CompactIndexWrongDependencies < CompactIndexAPI
   get "/info/:name" do
     etag_response do
-      gem = gems.find {|g| g.name == params[:name] }
-      gem.versions.each {|gv| gv.dependencies.clear } if gem
+      gem = gems.find { |g| g.name == params[:name] }
+      gem.versions.each { |gv| gv.dependencies.clear } if gem
       CompactIndex.info(gem ? gem.versions : [])
     end
   end

--- a/bundler/spec/support/artifice/compact_index_wrong_gem_checksum.rb
+++ b/bundler/spec/support/artifice/compact_index_wrong_gem_checksum.rb
@@ -8,10 +8,10 @@ class CompactIndexWrongGemChecksum < CompactIndexAPI
   get "/info/:name" do
     etag_response do
       name = params[:name]
-      gem = gems.find {|g| g.name == name }
+      gem = gems.find { |g| g.name == name }
       checksum = ENV.fetch("BUNDLER_SPEC_#{name.upcase}_CHECKSUM") { "ab" * 22 }
       versions = gem ? gem.versions : []
-      versions.each {|v| v.checksum = checksum }
+      versions.each { |v| v.checksum = checksum }
       CompactIndex.info(versions)
     end
   end

--- a/bundler/spec/support/artifice/endpoint.rb
+++ b/bundler/spec/support/artifice/endpoint.rb
@@ -55,8 +55,8 @@ class Endpoint < Sinatra::Base
           :name         => spec.name,
           :number       => spec.version.version,
           :platform     => spec.platform.to_s,
-          :dependencies => spec.dependencies.select {|dep| dep.type == :runtime }.map do |dep|
-            [dep.name, dep.requirement.requirements.map {|a| a.join(" ") }.join(", ")]
+          :dependencies => spec.dependencies.select { |dep| dep.type == :runtime }.map do |dep|
+            [dep.name, dep.requirement.requirements.map { |a| a.join(" ") }.join(", ")]
           end,
         }
       end.compact

--- a/bundler/spec/support/artifice/fail.rb
+++ b/bundler/spec/support/artifice/fail.rb
@@ -27,7 +27,7 @@ class Fail < Net::HTTP
 
   def exception(req)
     name = ENV.fetch("BUNDLER_SPEC_EXCEPTION") { "Errno::ENETUNREACH" }
-    const = name.split("::").reduce(Object) {|mod, sym| mod.const_get(sym) }
+    const = name.split("::").reduce(Object) { |mod, sym| mod.const_get(sym) }
     const.new("host down: Bundler spec artifice fail! #{req["PATH_INFO"]}")
   end
 end

--- a/bundler/spec/support/artifice/vcr.rb
+++ b/bundler/spec/support/artifice/vcr.rb
@@ -31,7 +31,7 @@ class BundlerVCRHTTP < Net::HTTP
 
     def recorded_response?
       return true if ENV["BUNDLER_SPEC_PRE_RECORDED"]
-      request_pair_paths.all? {|f| File.exist?(f) }
+      request_pair_paths.all? { |f| File.exist?(f) }
     end
 
     def recorded_response
@@ -91,7 +91,7 @@ class BundlerVCRHTTP < Net::HTTP
         end
       end
       body = contents =~ /^([^>].*)/m && $1
-      Net::HTTP.const_get(method.capitalize).new(path, headers).tap {|r| r.body = body if body }
+      Net::HTTP.const_get(method.capitalize).new(path, headers).tap { |r| r.body = body if body }
     end
 
     def request_to_string(request)
@@ -128,7 +128,7 @@ class BundlerVCRHTTP < Net::HTTP
     end
 
     def binwrite(path, contents)
-      File.open(path, "wb:ASCII-8BIT") {|f| f.write(contents) }
+      File.open(path, "wb:ASCII-8BIT") { |f| f.write(contents) }
     end
   end
 

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -511,7 +511,7 @@ module Spec
       end
 
       def versions(versions)
-        versions.split(/\s+/).each {|version| yield v(version) }
+        versions.split(/\s+/).each { |version| yield v(version) }
       end
     end
 
@@ -646,7 +646,7 @@ module Spec
         @files.each do |file, source|
           file = Pathname.new(path).join(file)
           FileUtils.mkdir_p(file.dirname)
-          File.open(file, "w") {|f| f.puts source }
+          File.open(file, "w") { |f| f.puts source }
         end
         path
       end

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -46,7 +46,7 @@ module Spec
     end
 
     def deprecations
-      err.split("\n").select {|l| l =~ MAJOR_DEPRECATION }.join("\n").split(MAJOR_DEPRECATION)
+      err.split("\n").select { |l| l =~ MAJOR_DEPRECATION }.join("\n").split(MAJOR_DEPRECATION)
     end
 
     def exitstatus
@@ -148,7 +148,7 @@ module Spec
 
       requires = options.delete(:requires) || []
       requires << "#{Path.spec_dir}/support/hax.rb"
-      require_option = requires.map {|r| "-r#{r}" }
+      require_option = requires.map { |r| "-r#{r}" }
 
       [sudo, Gem.ruby, *lib_option, *require_option].compact.join(" ")
     end
@@ -268,7 +268,7 @@ module Spec
         gem_name = g.to_s
         if gem_name.start_with?("bundler")
           version = gem_name.match(/\Abundler-(?<version>.*)\z/)[:version] if gem_name != "bundler"
-          with_built_bundler(version) {|gem_path| install_gem(gem_path) }
+          with_built_bundler(version) { |gem_path| install_gem(gem_path) }
         elsif gem_name =~ %r{\A(?:[a-zA-Z]:)?/.*\.gem\z}
           install_gem(gem_name)
         else
@@ -353,7 +353,7 @@ module Spec
     def opt_remove(option, options)
       return unless options
 
-      options.split(" ").reject {|opt| opt.strip == option.strip }.join(" ")
+      options.split(" ").reject { |opt| opt.strip == option.strip }.join(" ")
     end
 
     def break_git!
@@ -506,7 +506,7 @@ module Spec
       changed_lines = pathname.readlines.map do |line|
         yield line
       end
-      File.open(pathname, "w") {|file| file.puts(changed_lines.join) }
+      File.open(pathname, "w") { |file| file.puts(changed_lines.join) }
     end
 
     def with_env_vars(env_hash, &block)

--- a/bundler/spec/support/indexes.rb
+++ b/bundler/spec/support/indexes.rb
@@ -9,7 +9,7 @@ module Spec
 
     def platform(*args)
       @platforms ||= []
-      @platforms.concat args.map {|p| Gem::Platform.new(p) }
+      @platforms.concat args.map { |p| Gem::Platform.new(p) }
     end
 
     alias_method :platforms, :platform
@@ -70,7 +70,7 @@ module Spec
       search = Bundler::GemVersionPromoter.new(@locked, unlock).tap do |s|
         s.level = opts.first
         s.strict = opts.include?(:strict)
-        s.prerelease_specified = Hash[@deps.map {|d| [d.name, d.requirement.prerelease?] }]
+        s.prerelease_specified = Hash[@deps.map { |d| [d.name, d.requirement.prerelease?] }]
       end
       should_resolve_and_include specs, [@base, search]
     end

--- a/bundler/spec/support/matchers.rb
+++ b/bundler/spec/support/matchers.rb
@@ -25,12 +25,12 @@ module Spec
       end
 
       def matches?(target, &blk)
-        return false if @failure_index = @preconditions.index {|pc| !pc.matches?(target, &blk) }
+        return false if @failure_index = @preconditions.index { |pc| !pc.matches?(target, &blk) }
         @matcher.matches?(target, &blk)
       end
 
       def does_not_match?(target, &blk)
-        return false if @failure_index = @preconditions.index {|pc| !pc.matches?(target, &blk) }
+        return false if @failure_index = @preconditions.index { |pc| !pc.matches?(target, &blk) }
         if @matcher.respond_to?(:does_not_match?)
           @matcher.does_not_match?(target, &blk)
         else
@@ -65,13 +65,13 @@ module Spec
       dep = Bundler::Dependency.new(*args)
 
       match do |actual|
-        actual.length == 1 && actual.all? {|d| d == dep }
+        actual.length == 1 && actual.all? { |d| d == dep }
       end
     end
 
     RSpec::Matchers.define :have_gem do |*args|
       match do |actual|
-        actual.length == args.length && actual.all? {|a| args.include?(a.full_name) }
+        actual.length == args.length && actual.all? { |a| args.include?(a.full_name) }
       end
     end
 
@@ -170,11 +170,11 @@ module Spec
       end
 
       failure_message do
-        super() + " but:\n" + @errors.map {|e| indent(e) }.join("\n")
+        super() + " but:\n" + @errors.map { |e| indent(e) }.join("\n")
       end
 
       failure_message_when_negated do
-        super() + " but:\n" + @errors.map {|e| indent(e) }.join("\n")
+        super() + " but:\n" + @errors.map { |e| indent(e) }.join("\n")
       end
     end
     RSpec::Matchers.define_negated_matcher :not_include_gems, :include_gems

--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -55,7 +55,7 @@ module Spec
 
     def path
       env_path = ENV["PATH"]
-      env_path = env_path.split(File::PATH_SEPARATOR).reject {|path| path == bindir.to_s }.join(File::PATH_SEPARATOR) if ruby_core?
+      env_path = env_path.split(File::PATH_SEPARATOR).reject { |path| path == bindir.to_s }.join(File::PATH_SEPARATOR) if ruby_core?
       env_path
     end
 
@@ -205,7 +205,7 @@ module Spec
       version_file = File.expand_path("lib/bundler/version.rb", dir)
       contents = File.read(version_file)
       contents.sub!(/(^\s+VERSION\s*=\s*)"#{Gem::Version::VERSION_PATTERN}"/, %(\\1"#{version}"))
-      File.open(version_file, "w") {|f| f << contents }
+      File.open(version_file, "w") { |f| f << contents }
     end
 
     def replace_build_metadata(build_metadata, dir: source_root)
@@ -217,7 +217,7 @@ module Spec
 
       contents = File.read(build_metadata_file)
       contents.sub!(/^(\s+# begin ivars).+(^\s+# end ivars)/m, "\\1\n#{ivars}\n\\2")
-      File.open(build_metadata_file, "w") {|f| f << contents }
+      File.open(build_metadata_file, "w") { |f| f << contents }
     end
 
     def ruby_core?

--- a/bundler/spec/support/platforms.rb
+++ b/bundler/spec/support/platforms.rb
@@ -49,7 +49,7 @@ module Spec
     end
 
     def not_local
-      all_platforms.find {|p| p != generic_local_platform }
+      all_platforms.find { |p| p != generic_local_platform }
     end
 
     def local_tag
@@ -61,7 +61,7 @@ module Spec
     end
 
     def not_local_tag
-      [:ruby, :jruby].find {|tag| tag != local_tag }
+      [:ruby, :jruby].find { |tag| tag != local_tag }
     end
 
     def local_ruby_engine

--- a/bundler/spec/support/rubygems_version_manager.rb
+++ b/bundler/spec/support/rubygems_version_manager.rb
@@ -34,7 +34,7 @@ class RubygemsVersionManager
 
       bad_loaded_features = $LOADED_FEATURES.select do |loaded_feature|
         (loaded_feature.start_with?(rubygems_path) && !loaded_feature.start_with?(rubygems_default_path)) ||
-          (loaded_feature.start_with?(bundler_path) && !bundler_exemptions.any? {|bundler_exemption| loaded_feature.start_with?(bundler_exemption) })
+          (loaded_feature.start_with?(bundler_path) && !bundler_exemptions.any? { |bundler_exemption| loaded_feature.start_with?(bundler_exemption) })
       end
 
       if bad_loaded_features.any?

--- a/bundler/spec/support/silent_logger.rb
+++ b/bundler/spec/support/silent_logger.rb
@@ -4,7 +4,7 @@ require "logger"
 module Spec
   class SilentLogger
     (::Logger.instance_methods - Object.instance_methods).each do |logger_instance_method|
-      define_method(logger_instance_method) {|*args, &blk| }
+      define_method(logger_instance_method) { |*args, &blk| }
     end
   end
 end

--- a/bundler/spec/support/streams.rb
+++ b/bundler/spec/support/streams.rb
@@ -10,10 +10,10 @@ def capture(*args)
   begin
     result = StringIO.new
     result.close if opts[:closed]
-    args.each {|stream| eval "$#{stream} = result" }
+    args.each { |stream| eval "$#{stream} = result" }
     yield
   ensure
-    args.each {|stream| eval("$#{stream} = #{stream.upcase}") }
+    args.each { |stream| eval("$#{stream} = #{stream.upcase}") }
   end
   result.string
 end

--- a/bundler/task/release.rake
+++ b/bundler/task/release.rake
@@ -10,7 +10,7 @@ namespace :release do
   task :verify_docs => :"man:check"
 
   task :verify_files do
-    git_list = IO.popen("git ls-files -z", &:read).split("\x0").select {|f| f.match(%r{^(lib|man|exe)/}) }
+    git_list = IO.popen("git ls-files -z", &:read).split("\x0").select { |f| f.match(%r{^(lib|man|exe)/}) }
     git_list += %w[CHANGELOG.md LICENSE.md README.md bundler.gemspec]
 
     gem_list = Gem::Specification.load("bundler.gemspec").files
@@ -113,14 +113,14 @@ namespace :release do
     text = File.open("CHANGELOG.md", "r:UTF-8", &:read)
     lines = text.split("\n")
 
-    current_version_index = lines.find_index {|line| line.strip =~ /^#{current_version_title}($|\b)/ }
+    current_version_index = lines.find_index { |line| line.strip =~ /^#{current_version_title}($|\b)/ }
     unless current_version_index
       raise "Update the changelog for the last version (#{version})"
     end
     current_version_index += 1
     previous_version_lines = lines[current_version_index.succ...-1]
     previous_version_index = current_version_index + (
-      previous_version_lines.find_index {|line| line.start_with?(title_token) && !line.start_with?(current_minor_title) } ||
+      previous_version_lines.find_index { |line| line.start_with?(title_token) && !line.start_with?(current_minor_title) } ||
       lines.count
     )
 
@@ -161,7 +161,7 @@ namespace :release do
     puts "Cherry-picking PRs milestoned for #{version} (currently #{bundler_spec.version}) into the stable branch..."
 
     milestones = gh_api_request(:path => "repos/bundler/bundler/milestones?state=open")
-    unless patch_milestone = milestones.find {|m| m["title"] == version }
+    unless patch_milestone = milestones.find { |m| m["title"] == version }
       abort "failed to find #{version} milestone on GitHub"
     end
     prs = gh_api_request(:path => "repos/bundler/bundler/issues?milestone=#{patch_milestone["number"]}&state=all")
@@ -175,8 +175,8 @@ namespace :release do
     branch = version.split(".", 3)[0, 2].push("stable").join("-")
     sh("git", "checkout", "-b", "release/#{version}", branch)
 
-    commits = `git log --oneline origin/master --`.split("\n").map {|l| l.split(/\s/, 2) }.reverse
-    commits.select! {|_sha, message| message =~ /(Auto merge of|Merge pull request|Merge) ##{Regexp.union(*prs)}/ }
+    commits = `git log --oneline origin/master --`.split("\n").map { |l| l.split(/\s/, 2) }.reverse
+    commits.select! { |_sha, message| message =~ /(Auto merge of|Merge pull request|Merge) ##{Regexp.union(*prs)}/ }
 
     abort "Could not find commits for all PRs" unless commits.size == prs.size
 
@@ -193,7 +193,7 @@ namespace :release do
     unless version_contents.sub!(/^(\s*VERSION = )"#{Gem::Version::VERSION_PATTERN}"/, "\\1#{version.to_s.dump}")
       abort "failed to update #{version_file}, is it in the expected format?"
     end
-    File.open(version_file, "w") {|f| f.write(version_contents) }
+    File.open(version_file, "w") { |f| f.write(version_contents) }
 
     sh("git", "commit", "-am", "Version #{version}")
   end
@@ -202,11 +202,11 @@ namespace :release do
   task :open_unreleased_prs do
     def prs(on = "master")
       commits = `git log --oneline origin/#{on} --`.split("\n")
-      commits.reverse_each.map {|c| c =~ /(Auto merge of|Merge pull request|Merge) #(\d+)/ && $2 }.compact
+      commits.reverse_each.map { |c| c =~ /(Auto merge of|Merge pull request|Merge) #(\d+)/ && $2 }.compact
     end
 
     def minor_release_tags
-      `git ls-remote origin`.split("\n").map {|r| r =~ %r{refs/tags/v([\d.]+)$} && $1 }.compact.map {|v| Gem::Version.create(Gem::Version.create(v).segments[0, 2].join(".")) }.sort.uniq
+      `git ls-remote origin`.split("\n").map { |r| r =~ %r{refs/tags/v([\d.]+)$} && $1 }.compact.map { |v| Gem::Version.create(Gem::Version.create(v).segments[0, 2].join(".")) }.sort.uniq
     end
 
     def to_stable_branch(release_tag)

--- a/bundler/tool/turbo_tests/cli.rb
+++ b/bundler/tool/turbo_tests/cli.rb
@@ -49,7 +49,7 @@ module TurboTests
         end
       end.parse!(@argv)
 
-      requires.each {|f| require(f) }
+      requires.each { |f| require(f) }
 
       formatters.each do |formatter|
         if formatter[:outputs].empty?

--- a/bundler/tool/turbo_tests/json_rows_formatter.rb
+++ b/bundler/tool/turbo_tests/json_rows_formatter.rb
@@ -106,7 +106,7 @@ module TurboTests
         "full_description" => example.full_description,
         "metadata" => {
           "shared_group_inclusion_backtrace" =>
-            example.metadata[:shared_group_inclusion_backtrace].map {|frame| stack_frame_to_json(frame) },
+            example.metadata[:shared_group_inclusion_backtrace].map { |frame| stack_frame_to_json(frame) },
         },
         "location_rerun_argument" => example.location_rerun_argument,
       }

--- a/bundler/tool/turbo_tests/runner.rb
+++ b/bundler/tool/turbo_tests/runner.rb
@@ -63,7 +63,7 @@ module TurboTests
     def start_regular_subprocess(tests, process_id)
       start_subprocess(
         { "TEST_ENV_NUMBER" => process_id.to_s },
-        @tags.map {|tag| "--tag=#{tag}" },
+        @tags.map { |tag| "--tag=#{tag}" },
         tests,
         process_id
       )

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -232,7 +232,7 @@ module Gem
 
   def self.finish_resolve(request_set=Gem::RequestSet.new)
     request_set.import Gem::Specification.unresolved_deps.values
-    request_set.import Gem.loaded_specs.values.map {|s| Gem::Dependency.new(s.name, s.version) }
+    request_set.import Gem.loaded_specs.values.map { |s| Gem::Dependency.new(s.name, s.version) }
 
     request_set.resolve_current.each do |s|
       s.full_spec.activate
@@ -1212,8 +1212,8 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     #
 
     def register_default_spec(spec)
-      extended_require_paths = spec.require_paths.map {|f| f + "/"}
-      new_format = extended_require_paths.any? {|path| spec.files.any? {|f| f.start_with? path } }
+      extended_require_paths = spec.require_paths.map { |f| f + "/" }
+      new_format = extended_require_paths.any? { |path| spec.files.any? { |f| f.start_with? path } }
 
       if new_format
         prefix_group = extended_require_paths.join("|")

--- a/lib/rubygems/command_manager.rb
+++ b/lib/rubygems/command_manager.rb
@@ -138,7 +138,7 @@ class Gem::CommandManager
   # Return a sorted list of all command names as strings.
 
   def command_names
-    @commands.keys.collect {|key| key.to_s}.sort
+    @commands.keys.collect { |key| key.to_s }.sort
   end
 
   ##

--- a/lib/rubygems/commands/pristine_command.rb
+++ b/lib/rubygems/commands/pristine_command.rb
@@ -109,7 +109,7 @@ extensions will be restored.
               end.flatten
             end
 
-    specs = specs.select{|spec| RUBY_ENGINE == spec.platform || Gem::Platform.local === spec.platform || spec.platform == Gem::Platform::RUBY }
+    specs = specs.select{ |spec| RUBY_ENGINE == spec.platform || Gem::Platform.local === spec.platform || spec.platform == Gem::Platform::RUBY }
 
     if specs.to_a.empty?
       raise Gem::Exception,

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -310,7 +310,7 @@ By default, this RubyGems will install gem as:
   def shebang
     if options[:env_shebang]
       ruby_name = RbConfig::CONFIG['ruby_install_name']
-      @env_path ||= ENV_PATHS.find {|env_path| File.executable? env_path }
+      @env_path ||= ENV_PATHS.find { |env_path| File.executable? env_path }
       "#!#{@env_path} #{ruby_name}\n"
     else
       "#!#{Gem.ruby}\n"
@@ -396,8 +396,8 @@ By default, this RubyGems will install gem as:
     mkdir_p specs_dir, :mode => 0755
 
     # Workaround for non-git environment.
-    gemspec = File.open('bundler/bundler.gemspec', 'rb'){|f| f.read.gsub(/`git ls-files -z`/, "''") }
-    File.open('bundler/bundler.gemspec', 'w'){|f| f.write gemspec }
+    gemspec = File.open('bundler/bundler.gemspec', 'rb'){ |f| f.read.gsub(/`git ls-files -z`/, "''") }
+    File.open('bundler/bundler.gemspec', 'w'){ |f| f.write gemspec }
 
     bundler_spec = Gem::Specification.load("bundler/bundler.gemspec")
     bundler_spec.files = Dir.chdir("bundler") { Dir["{*.md,{lib,exe,man}/**/*}"] }
@@ -405,8 +405,8 @@ By default, this RubyGems will install gem as:
 
     # Remove bundler-*.gemspec in default specification directory.
     Dir.entries(specs_dir).
-      select {|gs| gs.start_with?("bundler-") }.
-      each {|gs| File.delete(File.join(specs_dir, gs)) }
+      select { |gs| gs.start_with?("bundler-") }.
+      each { |gs| File.delete(File.join(specs_dir, gs)) }
 
     default_spec_path = File.join(specs_dir, "#{bundler_spec.full_name}.gemspec")
     Gem.write_binary(default_spec_path, bundler_spec.to_ruby)
@@ -422,8 +422,8 @@ By default, this RubyGems will install gem as:
     # Remove gem files that were same version of vendored bundler.
     if File.directory? bundler_spec.gems_dir
       Dir.entries(bundler_spec.gems_dir).
-        select {|default_gem| File.basename(default_gem) == "bundler-#{bundler_spec.version}" }.
-        each {|default_gem| rm_r File.join(bundler_spec.gems_dir, default_gem) }
+        select { |default_gem| File.basename(default_gem) == "bundler-#{bundler_spec.version}" }.
+        each { |default_gem| rm_r File.join(bundler_spec.gems_dir, default_gem) }
     end
 
     bundler_bin_dir = bundler_spec.bin_dir
@@ -445,7 +445,7 @@ By default, this RubyGems will install gem as:
       end
     end
 
-    bundler_spec.executables.each {|executable| bin_file_names << target_bin_path(bin_dir, executable) }
+    bundler_spec.executables.each { |executable| bin_file_names << target_bin_path(bin_dir, executable) }
 
     say "Bundler #{bundler_spec.version} installed"
   end
@@ -548,7 +548,7 @@ By default, this RubyGems will install gem as:
   def bundler_template_files
     Dir.chdir "bundler/lib" do
       Dir.glob(File.join('bundler', 'templates', '**', '*'), File::FNM_DOTMATCH).
-        select{|f| !File.directory?(f)}
+        select{ |f| !File.directory?(f) }
     end
   end
 
@@ -556,7 +556,7 @@ By default, this RubyGems will install gem as:
   def template_files_in(dir)
     Dir.chdir dir do
       Dir.glob(File.join('templates', '**', '*'), File::FNM_DOTMATCH).
-        select{|f| !File.directory?(f)}
+        select{ |f| !File.directory?(f) }
     end
   end
 

--- a/lib/rubygems/core_ext/kernel_warn.rb
+++ b/lib/rubygems/core_ext/kernel_warn.rb
@@ -16,7 +16,7 @@ if RUBY_VERSION >= "2.5"
 
     end
 
-    module_function define_method(:warn) {|*messages, **kw|
+    module_function define_method(:warn) { |*messages, **kw|
       unless uplevel = kw[:uplevel]
         if Gem.java_platform?
           return original_warn.call(*messages)

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -584,7 +584,7 @@ class Gem::Installer
   def shebang(bin_file_name)
     ruby_name = RbConfig::CONFIG['ruby_install_name'] if @env_shebang
     path = File.join gem_dir, spec.bindir, bin_file_name
-    first_line = File.open(path, "rb") {|file| file.gets} || ""
+    first_line = File.open(path, "rb") { |file| file.gets } || ""
 
     if first_line.start_with?("#!")
       # Preserve extra words on shebang line, like "-w".  Thanks RPA.
@@ -600,7 +600,7 @@ class Gem::Installer
       which = which.gsub(/\$(\w+)/) do
         case $1
         when "env"
-          @env_path ||= ENV_PATHS.find {|env_path| File.executable? env_path }
+          @env_path ||= ENV_PATHS.find { |env_path| File.executable? env_path }
         when "ruby"
           "#{Gem.ruby}#{opts}"
         when "exec"
@@ -617,7 +617,7 @@ class Gem::Installer
       "#!/bin/sh\n'exec' #{ruby_name.dump} '-x' \"$0\" \"$@\"\n#{shebang}"
     else
       # Create a plain shebang line.
-      @env_path ||= ENV_PATHS.find {|env_path| File.executable? env_path }
+      @env_path ||= ENV_PATHS.find { |env_path| File.executable? env_path }
       "#!#{@env_path} #{ruby_name}"
     end
   end
@@ -738,11 +738,11 @@ class Gem::Installer
       raise Gem::InstallError, "#{spec} has an invalid name"
     end
 
-    if spec.raw_require_paths.any?{|path| path =~ /\R/ }
+    if spec.raw_require_paths.any?{ |path| path =~ /\R/ }
       raise Gem::InstallError, "#{spec} has an invalid require_paths"
     end
 
-    if spec.extensions.any?{|ext| ext =~ /\R/ }
+    if spec.extensions.any?{ |ext| ext =~ /\R/ }
       raise Gem::InstallError, "#{spec} has an invalid extensions"
     end
 
@@ -750,11 +750,11 @@ class Gem::Installer
       raise Gem::InstallError, "#{spec} has an invalid specification_version"
     end
 
-    if spec.dependencies.any? {|dep| dep.type != :runtime && dep.type != :development }
+    if spec.dependencies.any? { |dep| dep.type != :runtime && dep.type != :development }
       raise Gem::InstallError, "#{spec} has an invalid dependencies"
     end
 
-    if spec.dependencies.any? {|dep| dep.name =~ /(?:\R|[<>])/ }
+    if spec.dependencies.any? { |dep| dep.name =~ /(?:\R|[<>])/ }
       raise Gem::InstallError, "#{spec} has an invalid dependencies"
     end
   end

--- a/lib/rubygems/local_remote_options.rb
+++ b/lib/rubygems/local_remote_options.rb
@@ -26,7 +26,7 @@ module Gem::LocalRemoteOptions
 
       valid_uri_schemes = ["http", "https", "file", "s3"]
       unless valid_uri_schemes.include?(uri.scheme)
-        msg = "Invalid uri scheme for #{value}\nPreface URLs with one of #{valid_uri_schemes.map{|s| "#{s}://"}}"
+        msg = "Invalid uri scheme for #{value}\nPreface URLs with one of #{valid_uri_schemes.map{ |s| "#{s}://" }}"
         raise ArgumentError, msg
       end
 

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -704,7 +704,7 @@ EOM
               'package content (data.tar.gz) is missing', @gem
     end
 
-    if duplicates = @files.group_by {|f| f }.select {|k,v| v.size > 1 }.map(&:first) and duplicates.any?
+    if duplicates = @files.group_by { |f| f }.select { |k,v| v.size > 1 }.map(&:first) and duplicates.any?
       raise Gem::Security::Exception, "duplicate files in the package: (#{duplicates.map(&:inspect).join(', ')})"
     end
   end

--- a/lib/rubygems/package/tar_test_case.rb
+++ b/lib/rubygems/package/tar_test_case.rb
@@ -68,7 +68,7 @@ class Gem::Package::TarTestCase < Gem::TestCase
   end
 
   def calc_checksum(header)
-    sum = header.unpack("C*").inject{|s,a| s + a}
+    sum = header.unpack("C*").inject{ |s,a| s + a }
     SP(Z(to_oct(sum, 6)))
   end
 

--- a/lib/rubygems/query_utils.rb
+++ b/lib/rubygems/query_utils.rb
@@ -70,7 +70,7 @@ is too hard to use.
     gem_names = Array(options[:name])
 
     if !args.empty?
-      gem_names = options[:exact] ? args.map{|arg| /\A#{Regexp.escape(arg)}\Z/ } : args.map{|arg| /#{arg}/i }
+      gem_names = options[:exact] ? args.map{ |arg| /\A#{Regexp.escape(arg)}\Z/ } : args.map{ |arg| /#{arg}/i }
     end
 
     terminate_interaction(check_installed_gems(gem_names)) if check_installed_gems?

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -327,7 +327,7 @@ class Gem::RemoteFetcher
   end
 
   def close_all
-    @pools.each_value {|pool| pool.close_all}
+    @pools.each_value { |pool| pool.close_all }
   end
 
   private

--- a/lib/rubygems/request/connection_pools.rb
+++ b/lib/rubygems/request/connection_pools.rb
@@ -31,7 +31,7 @@ class Gem::Request::ConnectionPools # :nodoc:
   end
 
   def close_all
-    @pools.each_value {|pool| pool.close_all}
+    @pools.each_value { |pool| pool.close_all }
   end
 
   private

--- a/lib/rubygems/server.rb
+++ b/lib/rubygems/server.rb
@@ -866,10 +866,10 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
   end
 
   def launch
-    listeners = @server.listeners.map{|l| l.addr[2] }
+    listeners = @server.listeners.map{ |l| l.addr[2] }
 
     # TODO: 0.0.0.0 == any, not localhost.
-    host = listeners.any?{|l| l == '0.0.0.0'} ? 'localhost' : listeners.first
+    host = listeners.any?{ |l| l == '0.0.0.0' } ? 'localhost' : listeners.first
 
     say "Launching browser to http://#{host}:#{@port}"
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -747,8 +747,8 @@ class Gem::Specification < Gem::BasicSpecification
       # After a reset, make sure already loaded specs
       # are still marked as activated.
       specs = {}
-      Gem.loaded_specs.each_value{|s| specs[s] = true}
-      @@all.each{|s| s.activated = true if specs[s]}
+      Gem.loaded_specs.each_value{ |s| specs[s] = true }
+      @@all.each{ |s| s.activated = true if specs[s] }
     end
     @@all
   end
@@ -960,7 +960,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Returns every spec that has the given +full_name+
 
   def self.find_all_by_full_name(full_name)
-    stubs.select {|s| s.full_name == full_name }.map(&:to_spec)
+    stubs.select { |s| s.full_name == full_name }.map(&:to_spec)
   end
 
   ##
@@ -1959,12 +1959,12 @@ class Gem::Specification < Gem::BasicSpecification
 
   eval <<-RUBY, binding, __FILE__, __LINE__ + 1
     def set_nil_attributes_to_nil
-      #{@@nil_attributes.map {|key| "@#{key} = nil" }.join "; "}
+      #{@@nil_attributes.map { |key| "@#{key} = nil" }.join "; "}
     end
     private :set_nil_attributes_to_nil
 
     def set_not_nil_attributes_to_default_values
-      #{@@non_nil_attributes.map {|key| "@#{key} = #{INITIALIZE_CODE_FOR_DEFAULTS[key]}" }.join ";"}
+      #{@@non_nil_attributes.map { |key| "@#{key} = #{INITIALIZE_CODE_FOR_DEFAULTS[key]}" }.join ";"}
     end
     private :set_not_nil_attributes_to_default_values
   RUBY

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -292,7 +292,7 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
   def validate_non_files
     return unless packaging
 
-    non_files = @specification.files.reject {|x| File.file?(x) || File.symlink?(x)}
+    non_files = @specification.files.reject { |x| File.file?(x) || File.symlink?(x) }
 
     unless non_files.empty?
       error "[\"#{non_files.join "\", \""}\"] are not files"
@@ -338,7 +338,7 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
               String
             end
 
-    unless Array === val and val.all? {|x| x.kind_of?(klass)}
+    unless Array === val and val.all? { |x| x.kind_of?(klass) }
       error "#{field} must be an Array of #{klass}"
     end
   end
@@ -369,7 +369,7 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
 license value '#{license}' is invalid.  Use a license identifier from
 http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard license.
         WARNING
-        message += "Did you mean #{suggestions.map { |s| "'#{s}'"}.join(', ')}?\n" unless suggestions.nil?
+        message += "Did you mean #{suggestions.map { |s| "'#{s}'" }.join(', ')}?\n" unless suggestions.nil?
         warning(message)
       end
     end
@@ -460,8 +460,8 @@ http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard li
     require_relative 'ext'
     builder = Gem::Ext::Builder.new(@specification)
 
-    rake_extension = @specification.extensions.any? {|s| builder.builder_for(s) == Gem::Ext::RakeBuilder }
-    rake_dependency = @specification.dependencies.any? {|d| d.name == 'rake'}
+    rake_extension = @specification.extensions.any? { |s| builder.builder_for(s) == Gem::Ext::RakeBuilder }
+    rake_dependency = @specification.dependencies.any? { |d| d.name == 'rake' }
 
     warning <<-WARNING if rake_extension && !rake_dependency
 You have specified rake based extension, but rake is not added as dependency. It is recommended to add rake as a dependency in gemspec since there's no guarantee rake will be already installed.

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -426,9 +426,9 @@ class Gem::TestCase < Minitest::Test
     $LOAD_PATH.replace @orig_LOAD_PATH if @orig_LOAD_PATH
     if @orig_LOADED_FEATURES
       if @orig_LOAD_PATH
-        paths = @orig_LOAD_PATH.map {|path| File.join(File.expand_path(path), "/")}
+        paths = @orig_LOAD_PATH.map { |path| File.join(File.expand_path(path), "/") }
         ($LOADED_FEATURES - @orig_LOADED_FEATURES).each do |feat|
-          unless paths.any? {|path| feat.start_with?(path)}
+          unless paths.any? { |path| feat.start_with?(path) }
             $LOADED_FEATURES.delete(feat)
           end
         end
@@ -792,7 +792,7 @@ class Gem::TestCase < Minitest::Test
   ensure
     prefix = File.dirname(__FILE__) + "/"
     new_features = ($LOADED_FEATURES - old_loaded_features)
-    old_loaded_features.concat(new_features.select {|f| f.rindex(prefix, 0)})
+    old_loaded_features.concat(new_features.select { |f| f.rindex(prefix, 0) })
     $LOADED_FEATURES.replace old_loaded_features
   end
 

--- a/lib/rubygems/user_interaction.rb
+++ b/lib/rubygems/user_interaction.rb
@@ -323,7 +323,7 @@ class Gem::StreamUI
 
   def _gets_noecho
     require_io_console
-    @ins.noecho {@ins.gets}
+    @ins.noecho { @ins.gets }
   end
 
   ##

--- a/lib/rubygems/util.rb
+++ b/lib/rubygems/util.rb
@@ -89,7 +89,7 @@ module Gem::Util
 
   def self.glob_files_in_dir(glob, base_path)
     if RUBY_VERSION >= "2.5"
-      Dir.glob(glob, base: base_path).map! {|f| File.expand_path(f, base_path) }
+      Dir.glob(glob, base: base_path).map! { |f| File.expand_path(f, base_path) }
     else
       Dir.glob(File.expand_path(glob, base_path))
     end

--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -372,7 +372,7 @@ class Gem::Version
   def canonical_segments
     @canonical_segments ||=
       _split_segments.map! do |segments|
-        segments.reverse_each.drop_while {|s| s == 0 }.reverse
+        segments.reverse_each.drop_while { |s| s == 0 }.reverse
       end.reduce(&:concat)
   end
 
@@ -399,7 +399,7 @@ class Gem::Version
   end
 
   def _split_segments
-    string_start = _segments.index {|s| s.is_a?(String) }
+    string_start = _segments.index { |s| s.is_a?(String) }
     string_segments = segments
     numeric_segments = string_segments.slice!(0, string_start || string_segments.size)
     return numeric_segments, string_segments

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -208,7 +208,7 @@ class TestGem < Gem::TestCase
     end
     assert_equal(expected, result)
   ensure
-    File.chmod(0755, *Dir.glob(@gemhome + '/gems/**/').map {|path| path.tap(&Gem::UNTAINT)})
+    File.chmod(0755, *Dir.glob(@gemhome + '/gems/**/').map { |path| path.tap(&Gem::UNTAINT) })
   end
 
   def test_require_missing
@@ -1021,7 +1021,7 @@ class TestGem < Gem::TestCase
 
     Gem.refresh
 
-    Gem::Specification.each{|spec| assert spec.activated? if spec == s}
+    Gem::Specification.each{ |spec| assert spec.activated? if spec == s }
 
     Gem.loaded_specs.delete(s)
     Gem.refresh
@@ -1187,7 +1187,7 @@ class TestGem < Gem::TestCase
   def test_self_post_reset
     assert_empty Gem.post_reset_hooks
 
-    Gem.post_reset { }
+    Gem.post_reset {}
 
     assert_equal 1, Gem.post_reset_hooks.length
   end
@@ -1211,7 +1211,7 @@ class TestGem < Gem::TestCase
   def test_self_pre_reset
     assert_empty Gem.pre_reset_hooks
 
-    Gem.pre_reset { }
+    Gem.pre_reset {}
 
     assert_equal 1, Gem.pre_reset_hooks.length
   end
@@ -1635,7 +1635,7 @@ class TestGem < Gem::TestCase
     assert_equal expected_specs, Gem.use_gemdeps.sort_by { |s| s.name }
   end
 
-  BUNDLER_LIB_PATH = File.expand_path $LOAD_PATH.find {|lp| File.file?(File.join(lp, "bundler.rb")) }
+  BUNDLER_LIB_PATH = File.expand_path $LOAD_PATH.find { |lp| File.file?(File.join(lp, "bundler.rb")) }
   BUNDLER_FULL_NAME = "bundler-#{Bundler::VERSION}".freeze
 
   def add_bundler_full_name(names)

--- a/test/rubygems/test_gem_commands_contents_command.rb
+++ b/test/rubygems/test_gem_commands_contents_command.rb
@@ -240,7 +240,7 @@ lib/foo.rb
       [RbConfig::CONFIG['bindir'], 'default_command'],
       [RbConfig::CONFIG['rubylibdir'], 'default/gem.rb'],
       [RbConfig::CONFIG['archdir'], 'default_gem.so']
-    ].sort.map{|a|File.join a}.join "\n"
+    ].sort.map{ |a|File.join a }.join "\n"
 
     assert_equal expected, @ui.output.chomp
     assert_equal "", @ui.error

--- a/test/rubygems/test_gem_commands_pristine_command.rb
+++ b/test/rubygems/test_gem_commands_pristine_command.rb
@@ -160,7 +160,7 @@ class TestGemCommandsPristineCommand < Gem::TestCase
 
     ruby_exec = sprintf Gem.default_exec_format, 'ruby'
 
-    bin_env = win_platform? ? "" : %w[/usr/bin/env /bin/env].find {|f| File.executable?(f) } + " "
+    bin_env = win_platform? ? "" : %w[/usr/bin/env /bin/env].find { |f| File.executable?(f) } + " "
 
     assert_match %r{\A#!\s*#{bin_env}#{ruby_exec}}, File.read(gem_exec)
   end

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -149,7 +149,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
 
     ruby_exec = sprintf Gem.default_exec_format, 'ruby'
 
-    bin_env = win_platform? ? "" : %w[/usr/bin/env /bin/env].find {|f| File.executable?(f) } + " "
+    bin_env = win_platform? ? "" : %w[/usr/bin/env /bin/env].find { |f| File.executable?(f) } + " "
     assert_match %r{\A#!\s*#{bin_env}#{ruby_exec}}, File.read(default_gem_bin_path)
     assert_match %r{\A#!\s*#{bin_env}#{ruby_exec}}, File.read(default_bundle_bin_path)
     assert_match %r{\A#!\s*#{bin_env}#{ruby_exec}}, File.read(gem_bin_path)
@@ -297,9 +297,9 @@ class TestGemCommandsSetupCommand < Gem::TestCase
 
     @cmd.remove_old_lib_files lib
 
-    files_that_go.each {|file| refute_path_exists file }
+    files_that_go.each { |file| refute_path_exists file }
 
-    files_that_stay.each {|file| assert_path_exists file }
+    files_that_stay.each { |file| assert_path_exists file }
   end
 
   def test_remove_old_man_files
@@ -320,9 +320,9 @@ class TestGemCommandsSetupCommand < Gem::TestCase
 
     @cmd.remove_old_man_files man
 
-    files_that_go.each {|file| refute_path_exists file }
+    files_that_go.each { |file| refute_path_exists file }
 
-    files_that_stay.each {|file| assert_path_exists file }
+    files_that_stay.each { |file| assert_path_exists file }
   end
 
   def test_show_release_notes

--- a/test/rubygems/test_gem_commands_signin_command.rb
+++ b/test/rubygems/test_gem_commands_signin_command.rb
@@ -66,7 +66,7 @@ class TestGemCommandsSigninCommand < Gem::TestCase
   end
 
   def test_execute_with_valid_creds_set_for_default_host
-    util_capture {@cmd.execute}
+    util_capture { @cmd.execute }
 
     api_key     = 'a5fdbb6ba150cbb83aad2bb2fede64cf040453903'
     credentials = YAML.load_file Gem.configuration.credentials_path

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1891,7 +1891,7 @@ gem 'other', version
     if win_platform?
       ""
     else
-      %w[/usr/bin/env /bin/env].find {|f| File.executable?(f) }
+      %w[/usr/bin/env /bin/env].find { |f| File.executable?(f) }
     end
   end
 

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -443,7 +443,7 @@ class TestGemPackage < Gem::Package::TarTestCase
   end
 
   def test_raw_spec
-    data_tgz = util_tar_gz { }
+    data_tgz = util_tar_gz {}
 
     gem = util_tar do |tar|
       tar.add_file 'data.tar.gz', 0644 do |io|
@@ -490,7 +490,7 @@ class TestGemPackage < Gem::Package::TarTestCase
   end
 
   def test_extract_files_empty
-    data_tgz = util_tar_gz { }
+    data_tgz = util_tar_gz {}
 
     gem = util_tar do |tar|
       tar.add_file 'data.tar.gz', 0644 do |io|

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -94,8 +94,8 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
 
   def setup
     @proxies = %w[https_proxy http_proxy HTTP_PROXY http_proxy_user HTTP_PROXY_USER http_proxy_pass HTTP_PROXY_PASS no_proxy NO_PROXY]
-    @old_proxies = @proxies.map {|k| ENV[k] }
-    @proxies.each {|k| ENV[k] = nil }
+    @old_proxies = @proxies.map { |k| ENV[k] }
+    @proxies.each { |k| ENV[k] = nil }
 
     super
     start_servers
@@ -127,7 +127,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     stop_servers
     super
     Gem.configuration[:http_proxy] = nil
-    @proxies.each_with_index {|k, i| ENV[k] = @old_proxies[i] }
+    @proxies.each_with_index { |k, i| ENV[k] = @old_proxies[i] }
   end
 
   def test_self_fetcher
@@ -712,7 +712,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
       assert_fetch_s3 url, '20f974027db2f3cd6193565327a7c73457a138efb1a63ea248d185ce6827d41b'
     end
   ensure
-    ENV.each_key {|key| ENV.delete(key) if key.start_with?('AWS')}
+    ENV.each_key { |key| ENV.delete(key) if key.start_with?('AWS') }
     Gem.configuration[:s3_source] = nil
   end
 
@@ -728,7 +728,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
       assert_fetch_s3 url, '4afc3010757f1fd143e769f1d1dabd406476a4fc7c120e9884fd02acbb8f26c9', nil, 'us-west-2'
     end
   ensure
-    ENV.each_key {|key| ENV.delete(key) if key.start_with?('AWS')}
+    ENV.each_key { |key| ENV.delete(key) if key.start_with?('AWS') }
     Gem.configuration[:s3_source] = nil
   end
 
@@ -744,7 +744,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
       assert_fetch_s3 url, '935160a427ef97e7630f799232b8f208c4a4e49aad07d0540572a2ad5fe9f93c', 'testtoken'
     end
   ensure
-    ENV.each_key {|key| ENV.delete(key) if key.start_with?('AWS')}
+    ENV.each_key { |key| ENV.delete(key) if key.start_with?('AWS') }
     Gem.configuration[:s3_source] = nil
   end
 

--- a/test/rubygems/test_gem_request.rb
+++ b/test/rubygems/test_gem_request.rb
@@ -23,8 +23,8 @@ class TestGemRequest < Gem::TestCase
 
   def setup
     @proxies = %w[http_proxy https_proxy HTTP_PROXY http_proxy_user HTTP_PROXY_USER http_proxy_pass HTTP_PROXY_PASS no_proxy NO_PROXY]
-    @old_proxies = @proxies.map {|k| ENV[k] }
-    @proxies.each {|k| ENV[k] = nil }
+    @old_proxies = @proxies.map { |k| ENV[k] }
+    @proxies.each { |k| ENV[k] = nil }
 
     super
 
@@ -37,7 +37,7 @@ class TestGemRequest < Gem::TestCase
   def teardown
     super
     Gem.configuration[:http_proxy] = nil
-    @proxies.each_with_index {|k, i| ENV[k] = @old_proxies[i] }
+    @proxies.each_with_index { |k, i| ENV[k] = @old_proxies[i] }
   end
 
   def test_initialize_proxy

--- a/test/rubygems/test_gem_resolver.rb
+++ b/test/rubygems/test_gem_resolver.rb
@@ -29,7 +29,7 @@ class TestGemResolver < Gem::TestCase
     exp = expected.sort_by { |s| s.full_name }
     act = actual.map { |a| a.spec.spec }.sort_by { |s| s.full_name }
 
-    msg = "Set of gems was not the same: #{exp.map { |x| x.full_name}.inspect} != #{act.map { |x| x.full_name}.inspect}"
+    msg = "Set of gems was not the same: #{exp.map { |x| x.full_name }.inspect} != #{act.map { |x| x.full_name }.inspect}"
 
     assert_equal exp, act, msg
   rescue Gem::DependencyResolutionError => e

--- a/test/rubygems/test_gem_source_git.rb
+++ b/test/rubygems/test_gem_source_git.rb
@@ -187,7 +187,7 @@ class TestGemSourceGit < Gem::TestCase
     source.cache
 
     e = assert_raises Gem::Exception do
-      capture_subprocess_io {source.rev_parse}
+      capture_subprocess_io { source.rev_parse }
     end
 
     assert_equal "unable to find reference nonexistent in #{@repository}",

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1143,8 +1143,8 @@ dependencies: []
 
     dir_standard_specs = File.join Gem.dir, 'specifications'
 
-    save_gemspec('a-1', '1', dir_standard_specs){|s| s.name = 'a' }
-    save_gemspec('b-1', '1', dir_standard_specs){|s| s.name = 'b' }
+    save_gemspec('a-1', '1', dir_standard_specs){ |s| s.name = 'a' }
+    save_gemspec('b-1', '1', dir_standard_specs){ |s| s.name = 'b' }
 
     assert_equal ['a-1'], Gem::Specification.stubs_for('a').map { |s| s.full_name }
     assert_equal 1, Gem::Specification.class_variable_get(:@@stubs_by_name).length
@@ -3755,12 +3755,12 @@ end
 
     a1 = util_spec "a", "1"
     a1_pre = util_spec "a", "1.0.0.pre.1"
-    a_1_platform = util_spec("a", "1") {|s| s.platform = pl }
+    a_1_platform = util_spec("a", "1") { |s| s.platform = pl }
     a_b_1 = util_spec "a-b", "1"
-    a_b_1_platform = util_spec("a-b", "1") {|s| s.platform = pl }
+    a_b_1_platform = util_spec("a-b", "1") { |s| s.platform = pl }
 
     a_b_1_1 = util_spec "a-b-1", "1"
-    a_b_1_1_platform = util_spec("a-b-1", "1") {|s| s.platform = pl }
+    a_b_1_1_platform = util_spec("a-b-1", "1") { |s| s.platform = pl }
 
     install_specs(a1, a1_pre, a_1_platform, a_b_1, a_b_1_platform,
                   a_b_1_1, a_b_1_1_platform)

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -111,7 +111,7 @@ class TestGemVersion < Gem::TestCase
 
   def bench_anchored_version_pattern
     assert_performance_linear 0.5 do |count|
-      version_string = count.times.map {|i| "0" * i.succ }.join(".") << "."
+      version_string = count.times.map { |i| "0" * i.succ }.join(".") << "."
       version_string =~ Gem::Version::ANCHORED_VERSION_PATTERN
     end
   rescue RegexpError

--- a/test/rubygems/test_kernel.rb
+++ b/test/rubygems/test_kernel.rb
@@ -103,7 +103,7 @@ class TestKernel < Gem::TestCase
       "./activate.rb"
     )
 
-    load_errors = output.split("\n").select { |line| line.include?("Could not find")}
+    load_errors = output.split("\n").select { |line| line.include?("Could not find") }
 
     assert_equal 1, load_errors.size
   end

--- a/util/patch_with_prs.rb
+++ b/util/patch_with_prs.rb
@@ -48,8 +48,8 @@ confirm "You are about to release #{version}, currently #{Gem::VERSION}"
 branch = version.split(".", 3)[0, 2].join(".")
 sh("git", "checkout", branch)
 
-commits = `git log --oneline origin/master --`.split("\n").map {|l| l.split(/\s/, 2) }.reverse
-commits.select! {|_sha, message| message =~ /(Auto merge of|Merge pull request|Merge) ##{Regexp.union(*prs)}/ }
+commits = `git log --oneline origin/master --`.split("\n").map { |l| l.split(/\s/, 2) }.reverse
+commits.select! { |_sha, message| message =~ /(Auto merge of|Merge pull request|Merge) ##{Regexp.union(*prs)}/ }
 
 unless system("git", "cherry-pick", "-x", "-m", "1", *commits.map(&:first))
   abort unless system("zsh")
@@ -62,7 +62,7 @@ version_contents = File.read(version_file)
 unless version_contents.sub!(/^(\s*VERSION = )(["'])#{Gem::Version::VERSION_PATTERN}\2/, "\\1#{version.to_s.dump}")
   abort "failed to update #{version_file}, is it in the expected format?"
 end
-File.open(version_file, "w") {|f| f.write(version_contents) }
+File.open(version_file, "w") { |f| f.write(version_contents) }
 
 confirm "Update changelog"
 sh("git", "commit", "-am", "Version #{version} with changelog")


### PR DESCRIPTION
# Description:

This commit changes our internal style and also the style used in the
generated `Gemfile` by our gem generator.

This style is used everywhere, end users have opened PRs in the past to
tweak the generated style, and I keep doing the same style mistake that
doesn't appease our current configuration, so this change also maximizes
my own happiness.

This is a migration of https://github.com/rubygems/bundler/pull/7645 into the new repo.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
