### PR TITLE
Backport Ruby core changes for RubyGems

### DIFF
--- a/test/rubygems/test_gem_ext_cmake_builder.rb
+++ b/test/rubygems/test_gem_ext_cmake_builder.rb
@@ -12,6 +12,7 @@ class TestGemExtCmakeBuilder < Gem::TestCase
 
     begin
       _, status = Open3.capture2e('cmake')
+      skip 'cmake not present' unless status.success?
     rescue Errno::ENOENT
       skip 'cmake not present'
     end

--- a/test/rubygems/test_gem_ext_cmake_builder.rb
+++ b/test/rubygems/test_gem_ext_cmake_builder.rb
@@ -10,9 +10,11 @@ class TestGemExtCmakeBuilder < Gem::TestCase
     # Details: https://github.com/rubygems/rubygems/issues/1270#issuecomment-177368340
     skip "CmakeBuilder doesn't work on Windows." if Gem.win_platform?
 
-    _, status = Open3.capture2e('cmake')
-
-    skip 'cmake not present' unless status.success?
+    begin
+      _, status = Open3.capture2e('cmake')
+    rescue Errno::ENOENT
+      skip 'cmake not present'
+    end
 
     @ext = File.join @tempdir, 'ext'
     @dest_path = File.join @tempdir, 'prefix'

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -151,6 +151,7 @@ class TestGemRequire < Gem::TestCase
 
   def test_dash_i_respects_default_library_extension_priority
     skip "extensions don't quite work on jruby" if Gem.java_platform?
+    skip "not installed yet" unless RbConfig::TOPDIR
 
     dash_i_ext_arg = util_install_extension_file('a')
     dash_i_lib_arg = util_install_ruby_file('a')
@@ -251,6 +252,8 @@ class TestGemRequire < Gem::TestCase
       this test, somehow require will load the benchmark in b, and ignore that the
       stdlib one is already in $LOADED_FEATURES?. Reproducible by running the
       spaceship_specific_file test before this one" if java_platform?
+
+    skip "not installed yet" unless RbConfig::TOPDIR
 
     lib_dir = File.expand_path("../../lib", File.dirname(__FILE__))
     rubylibdir = File.realdirpath(RbConfig::CONFIG["rubylibdir"])


### PR DESCRIPTION
# Description:

I have some changes in ruby core repo for rubygems. this PR includes the revert changes for [XDG support](https://github.com/rubygems/rubygems/issues/3618). Other changes are ready to merge for the current master branch.

@deivid-rodriguez If you are working #3618, I separate https://github.com/rubygems/rubygems/commit/8e8596919fd047fe7a8aab2c2aeab64fcbef63cd to https://github.com/rubygems/rubygems/commit/77ee36bbb2135c191ece291cee4d5c294cb5c4b1 from this PR, and will submit new PR from them.

We should fix these changes before releasing RG 3.2.0.
______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
