### PR TITLE
Use space inside block braces everywhere

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -68,6 +68,10 @@ Layout/IndentationWidth:
 Layout/SpaceAroundOperators:
   Enabled: true
 
+Layout/SpaceInsideBlockBraces:
+  Enabled: true
+  SpaceBeforeBlockParameters: false
+
 Layout/SpaceInsideParens:
   Enabled: true
 

--- a/bin/update_rubygems
+++ b/bin/update_rubygems
@@ -20,7 +20,7 @@ unless ARGV.grep(/--version=([\d\.]*)/).empty?
   exec Gem.ruby, '-S', $PROGRAM_NAME, "_#{$1}_"
 end
 
-update_dir = $LOAD_PATH.find { |dir| dir =~ /rubygems-update/ }
+update_dir = $LOAD_PATH.find {|dir| dir =~ /rubygems-update/ }
 
 if update_dir.nil?
   puts "Error: Cannot find RubyGems update path!"

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -504,7 +504,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
     gem_specifications = @gemdeps ? Gem.loaded_specs.values : Gem::Specification.stubs
 
-    files.concat gem_specifications.map { |spec|
+    files.concat gem_specifications.map {|spec|
       spec.matches_for_glob("#{glob}#{Gem.suffix_pattern}")
     }.flatten
 
@@ -519,7 +519,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     glob_with_suffixes = "#{glob}#{Gem.suffix_pattern}"
     $LOAD_PATH.map do |load_path|
       Gem::Util.glob_files_in_dir(glob_with_suffixes, load_path)
-    end.flatten.select { |file| File.file? file.tap(&Gem::UNTAINT) }
+    end.flatten.select {|file| File.file? file.tap(&Gem::UNTAINT) }
   end
 
   ##
@@ -539,7 +539,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
     files = find_files_from_load_path glob if check_load_path
 
-    files.concat Gem::Specification.latest_specs(true).map { |spec|
+    files.concat Gem::Specification.latest_specs(true).map {|spec|
       spec.matches_for_glob("#{glob}#{Gem.suffix_pattern}")
     }.flatten
 
@@ -1014,7 +1014,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     paths.flatten!
     paths.compact!
     hash = { "GEM_HOME" => home, "GEM_PATH" => paths.empty? ? home : paths.join(File::PATH_SEPARATOR) }
-    hash.delete_if { |_, v| v.nil? }
+    hash.delete_if {|_, v| v.nil? }
     self.paths = hash
   end
 
@@ -1024,7 +1024,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   def self.win_platform?
     if @@win_platform.nil?
       ruby_platform = RbConfig::CONFIG['host_os']
-      @@win_platform = !!WIN_PATTERNS.find { |r| ruby_platform =~ r }
+      @@win_platform = !!WIN_PATTERNS.find {|r| ruby_platform =~ r }
     end
 
     @@win_platform
@@ -1101,7 +1101,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
     if path == "-"
       Gem::Util.traverse_parents Dir.pwd do |directory|
-        dep_file = GEM_DEP_FILES.find { |f| File.file?(f) }
+        dep_file = GEM_DEP_FILES.find {|f| File.file?(f) }
 
         next unless dep_file
 
@@ -1212,7 +1212,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     #
 
     def register_default_spec(spec)
-      extended_require_paths = spec.require_paths.map {|f| f + "/"}
+      extended_require_paths = spec.require_paths.map {|f| f + "/" }
       new_format = extended_require_paths.any? {|path| spec.files.any? {|f| f.start_with? path } }
 
       if new_format

--- a/lib/rubygems/available_set.rb
+++ b/lib/rubygems/available_set.rb
@@ -70,11 +70,11 @@ class Gem::AvailableSet
   end
 
   def all_specs
-    @set.map { |t| t.spec }
+    @set.map {|t| t.spec }
   end
 
   def match_platform!
-    @set.reject! { |t| !Gem::Platform.match(t.spec.platform) }
+    @set.reject! {|t| !Gem::Platform.match(t.spec.platform) }
     @sorted = nil
     self
   end
@@ -91,7 +91,7 @@ class Gem::AvailableSet
   end
 
   def source_for(spec)
-    f = @set.find { |t| t.spec == spec }
+    f = @set.find {|t| t.spec == spec }
     f.source
   end
 
@@ -160,7 +160,7 @@ class Gem::AvailableSet
   end
 
   def inject_into_list(dep_list)
-    @set.each { |t| dep_list.add t.spec }
+    @set.each {|t| dep_list.add t.spec }
   end
 
 end

--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -276,7 +276,7 @@ class Gem::BasicSpecification
   def matches_for_glob(glob) # TODO: rename?
     glob = File.join(self.lib_dirs_glob, glob)
 
-    Dir[glob].map { |f| f.tap(&Gem::UNTAINT) } # FIX our tests are broken, run w/ SAFE=1
+    Dir[glob].map {|f| f.tap(&Gem::UNTAINT) } # FIX our tests are broken, run w/ SAFE=1
   end
 
   ##
@@ -335,12 +335,12 @@ class Gem::BasicSpecification
   def have_file?(file, suffixes)
     return true if raw_require_paths.any? do |path|
       base = File.join(gems_dir, full_name, path.tap(&Gem::UNTAINT), file).tap(&Gem::UNTAINT)
-      suffixes.any? { |suf| File.file? base + suf }
+      suffixes.any? {|suf| File.file? base + suf }
     end
 
     if have_extensions?
       base = File.join extension_dir, file
-      suffixes.any? { |suf| File.file? base + suf }
+      suffixes.any? {|suf| File.file? base + suf }
     else
       false
     end

--- a/lib/rubygems/bundler_version_finder.rb
+++ b/lib/rubygems/bundler_version_finder.rb
@@ -44,9 +44,9 @@ To install the missing version, run `gem install bundler:#{vr.first}`
   def self.filter!(specs)
     return unless bundler_version = self.bundler_version
 
-    specs.reject! { |spec| spec.version.segments.first != bundler_version.segments.first }
+    specs.reject! {|spec| spec.version.segments.first != bundler_version.segments.first }
 
-    exact_match_index = specs.find_index { |spec| spec.version == bundler_version }
+    exact_match_index = specs.find_index {|spec| spec.version == bundler_version }
     return unless exact_match_index
 
     specs.unshift(specs.delete_at(exact_match_index))
@@ -86,7 +86,7 @@ To install the missing version, run `gem install bundler:#{vr.first}`
     unless gemfile
       begin
         Gem::Util.traverse_parents(Dir.pwd) do |directory|
-          next unless gemfile = Gem::GEM_DEP_FILES.find { |f| File.file?(f.tap(&Gem::UNTAINT)) }
+          next unless gemfile = Gem::GEM_DEP_FILES.find {|f| File.file?(f.tap(&Gem::UNTAINT)) }
 
           gemfile = File.join directory, gemfile
           break

--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -125,7 +125,7 @@ class Gem::Command
     @program_name = "gem #{command}"
     @defaults = defaults
     @options = defaults.dup
-    @option_groups = Hash.new { |h,k| h[k] = [] }
+    @option_groups = Hash.new {|h,k| h[k] = [] }
     @deprecated_options = { command => {} }
     @parser = nil
     @when_invoked = nil
@@ -162,7 +162,7 @@ class Gem::Command
 
     if errors and !errors.empty?
       msg << ", here is why:\n"
-      errors.each { |x| msg << "          #{x.wordy}\n" }
+      errors.each {|x| msg << "          #{x.wordy}\n" }
     else
       if required_by and gem != required_by
         msg << " (required by #{required_by}) in any repository"
@@ -192,7 +192,7 @@ class Gem::Command
             "Please specify at least one gem name (e.g. gem build GEMNAME)"
     end
 
-    args.select { |arg| arg !~ /^-/ }
+    args.select {|arg| arg !~ /^-/ }
   end
 
   ##
@@ -364,7 +364,7 @@ class Gem::Command
 
   def remove_option(name)
     @option_groups.each do |_, option_list|
-      option_list.reject! { |args, _| args.any? { |x| x.is_a?(String) && x =~ /^#{name}/ } }
+      option_list.reject! {|args, _| args.any? {|x| x.is_a?(String) && x =~ /^#{name}/ } }
     end
   end
 
@@ -417,7 +417,7 @@ class Gem::Command
 
   def merge_options(new_options)
     @options = @defaults.clone
-    new_options.each { |k,v| @options[k] = v }
+    new_options.each {|k,v| @options[k] = v }
   end
 
   ##
@@ -496,7 +496,7 @@ class Gem::Command
 
     configure_options "", regular_options
 
-    @option_groups.sort_by { |n,_| n.to_s }.each do |group_name, option_list|
+    @option_groups.sort_by {|n,_| n.to_s }.each do |group_name, option_list|
       @parser.separator nil
       configure_options group_name, option_list
     end

--- a/lib/rubygems/command_manager.rb
+++ b/lib/rubygems/command_manager.rb
@@ -138,7 +138,7 @@ class Gem::CommandManager
   # Return a sorted list of all command names as strings.
 
   def command_names
-    @commands.keys.collect {|key| key.to_s}.sort
+    @commands.keys.collect {|key| key.to_s }.sort
   end
 
   ##
@@ -203,9 +203,9 @@ class Gem::CommandManager
   def find_command_possibilities(cmd_name)
     len = cmd_name.length
 
-    found = command_names.select { |name| cmd_name == name[0, len] }
+    found = command_names.select {|name| cmd_name == name[0, len] }
 
-    exact = found.find { |name| name == cmd_name }
+    exact = found.find {|name| name == cmd_name }
 
     exact ? [exact] : found
   end

--- a/lib/rubygems/commands/cert_command.rb
+++ b/lib/rubygems/commands/cert_command.rb
@@ -186,7 +186,7 @@ class Gem::Commands::CertCommand < Gem::Command
       subject = certificate.subject.to_s
       subject.downcase.index filter
     end.sort_by do |certificate, _|
-      certificate.subject.to_a.map { |name, data,| [name, data] }
+      certificate.subject.to_a.map {|name, data,| [name, data] }
     end.each do |certificate, path|
       yield certificate, path
     end

--- a/lib/rubygems/commands/cleanup_command.rb
+++ b/lib/rubygems/commands/cleanup_command.rb
@@ -69,7 +69,7 @@ If no gems are named all gems in GEM_HOME are cleaned.
       until done do
         clean_gems
 
-        this_set = @gems_to_cleanup.map { |spec| spec.full_name }.sort
+        this_set = @gems_to_cleanup.map {|spec| spec.full_name }.sort
 
         done = this_set.empty? || last_set == this_set
 
@@ -82,7 +82,7 @@ If no gems are named all gems in GEM_HOME are cleaned.
     say "Clean up complete"
 
     verbose do
-      skipped = @default_gems.map { |spec| spec.full_name }
+      skipped = @default_gems.map {|spec| spec.full_name }
 
       "Skipped default gems: #{skipped.join ', '}"
     end
@@ -99,7 +99,7 @@ If no gems are named all gems in GEM_HOME are cleaned.
     @full = Gem::DependencyList.from_specs
 
     deplist = Gem::DependencyList.new
-    @gems_to_cleanup.each { |spec| deplist.add spec }
+    @gems_to_cleanup.each {|spec| deplist.add spec }
 
     deps = deplist.strongly_connected_components.flatten
 

--- a/lib/rubygems/commands/contents_command.rb
+++ b/lib/rubygems/commands/contents_command.rb
@@ -175,7 +175,7 @@ prefix or only the files that are requireable.
 
     if Gem.configuration.verbose
       say "\nDirectories searched:"
-      @spec_dirs.sort.each { |dir| say dir }
+      @spec_dirs.sort.each {|dir| say dir }
     end
 
     return nil

--- a/lib/rubygems/commands/dependency_command.rb
+++ b/lib/rubygems/commands/dependency_command.rb
@@ -59,14 +59,14 @@ use with other commands.
 
     ss, = fetcher.spec_for_dependency dependency
 
-    ss.map { |spec, _| spec }
+    ss.map {|spec, _| spec }
   end
 
   def fetch_specs(name_pattern, dependency) # :nodoc:
     specs = []
 
     if local?
-      specs.concat Gem::Specification.stubs.find_all { |spec|
+      specs.concat Gem::Specification.stubs.find_all {|spec|
         name_pattern =~ spec.name and
           dependency.requirement.satisfied_by? spec.version
       }.map(&:to_spec)
@@ -92,7 +92,7 @@ use with other commands.
   def display_pipe(specs) # :nodoc:
     specs.each do |spec|
       unless spec.dependencies.empty?
-        spec.dependencies.sort_by { |dep| dep.name }.each do |dep|
+        spec.dependencies.sort_by {|dep| dep.name }.each do |dep|
           say "#{dep.name} --version '#{dep.requirement}'"
         end
       end
@@ -156,7 +156,7 @@ use with other commands.
     response = String.new
     response << '  ' * level + "Gem #{spec.full_name}\n"
     unless spec.dependencies.empty?
-      spec.dependencies.sort_by { |dep| dep.name }.each do |dep|
+      spec.dependencies.sort_by {|dep| dep.name }.each do |dep|
         response << '  ' * level + "  #{dep}\n"
       end
     end
@@ -168,11 +168,11 @@ use with other commands.
 
     ss, _ = fetcher.spec_for_dependency dependency
 
-    ss.map { |s,o| s }
+    ss.map {|s,o| s }
   end
 
   def reverse_dependencies(specs) # :nodoc:
-    reverse = Hash.new { |h, k| h[k] = [] }
+    reverse = Hash.new {|h, k| h[k] = [] }
 
     return reverse unless options[:reverse_dependencies]
 

--- a/lib/rubygems/commands/fetch_command.rb
+++ b/lib/rubygems/commands/fetch_command.rb
@@ -57,11 +57,11 @@ then repackaging it.
         Gem::SpecFetcher.fetcher.spec_for_dependency dep
 
       if platform
-        filtered = specs_and_sources.select { |s,| s.platform == platform }
+        filtered = specs_and_sources.select {|s,| s.platform == platform }
         specs_and_sources = filtered unless filtered.empty?
       end
 
-      spec, source = specs_and_sources.max_by { |s,| s.version }
+      spec, source = specs_and_sources.max_by {|s,| s.version }
 
       if spec.nil?
         show_lookup_failure gem_name, version, errors, options[:domain]

--- a/lib/rubygems/commands/help_command.rb
+++ b/lib/rubygems/commands/help_command.rb
@@ -324,7 +324,7 @@ platform.
 
     margin_width = 4
 
-    desc_width = @command_manager.command_names.map { |n| n.size }.max + 4
+    desc_width = @command_manager.command_names.map {|n| n.size }.max + 4
 
     summary_width = 80 - margin_width - desc_width
     wrap_indent = ' ' * (margin_width + desc_width)

--- a/lib/rubygems/commands/lock_command.rb
+++ b/lib/rubygems/commands/lock_command.rb
@@ -104,7 +104,7 @@ lock it down to the exact version.
       File.join path, "specifications", "#{gem_full_name}.gemspec"
     end
 
-    gemspecs.find { |path| File.exist? path }
+    gemspecs.find {|path| File.exist? path }
   end
 
 end

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -217,7 +217,7 @@ By default, this RubyGems will install gem as:
     say
 
     say "RubyGems installed the following executables:"
-    say bin_file_names.map { |name| "\t#{name}\n" }
+    say bin_file_names.map {|name| "\t#{name}\n" }
     say
 
     unless bin_file_names.grep(/#{File::SEPARATOR}gem$/)
@@ -548,7 +548,7 @@ By default, this RubyGems will install gem as:
   def bundler_template_files
     Dir.chdir "bundler/lib" do
       Dir.glob(File.join('bundler', 'templates', '**', '*'), File::FNM_DOTMATCH).
-        select{|f| !File.directory?(f)}
+        select{|f| !File.directory?(f) }
     end
   end
 
@@ -556,7 +556,7 @@ By default, this RubyGems will install gem as:
   def template_files_in(dir)
     Dir.chdir dir do
       Dir.glob(File.join('templates', '**', '*'), File::FNM_DOTMATCH).
-        select{|f| !File.directory?(f)}
+        select{|f| !File.directory?(f) }
     end
   end
 

--- a/lib/rubygems/commands/specification_command.rb
+++ b/lib/rubygems/commands/specification_command.rb
@@ -119,7 +119,7 @@ Specific fields in the specification can be extracted in YAML format:
       dep.prerelease = options[:prerelease]
       found, _ = Gem::SpecFetcher.fetcher.spec_for_dependency dep
 
-      specs.push(*found.map { |spec,| spec })
+      specs.push(*found.map {|spec,| spec })
     end
 
     if specs.empty?
@@ -128,7 +128,7 @@ Specific fields in the specification can be extracted in YAML format:
     end
 
     unless options[:all]
-      specs = [specs.max_by { |s| s.version }]
+      specs = [specs.max_by {|s| s.version }]
     end
 
     specs.each do |s|

--- a/lib/rubygems/commands/stale_command.rb
+++ b/lib/rubygems/commands/stale_command.rb
@@ -33,7 +33,7 @@ longer using.
       end
     end
 
-    gem_to_atime.sort_by { |_, atime| atime }.each do |name, atime|
+    gem_to_atime.sort_by {|_, atime| atime }.each do |name, atime|
       say "#{name} at #{atime.strftime '%c'}"
     end
   end

--- a/lib/rubygems/commands/uninstall_command.rb
+++ b/lib/rubygems/commands/uninstall_command.rb
@@ -136,7 +136,7 @@ that is a dependency of an existing gem.  You can use the
   end
 
   def uninstall_all
-    specs = Gem::Specification.reject { |spec| spec.default_gem? }
+    specs = Gem::Specification.reject {|spec| spec.default_gem? }
 
     specs.each do |spec|
       options[:version] = spec.version

--- a/lib/rubygems/commands/unpack_command.rb
+++ b/lib/rubygems/commands/unpack_command.rb
@@ -157,7 +157,7 @@ command help for an example.
 
     specs = dependency.matching_specs
 
-    selected = specs.max_by { |s| s.version }
+    selected = specs.max_by {|s| s.version }
 
     return Gem::RemoteFetcher.fetcher.download_to_cache(dependency) unless
       selected

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -107,7 +107,7 @@ command to remove old versions.
 
     updated = update_gems gems_to_update
 
-    updated_names = updated.map { |spec| spec.name }
+    updated_names = updated.map {|spec| spec.name }
     not_updated_names = options[:args].uniq - updated_names
 
     if updated.empty?
@@ -126,7 +126,7 @@ command to remove old versions.
 
     spec_tuples, errors = fetcher.search_for_dependency dependency
 
-    error = errors.find { |e| e.respond_to? :exception }
+    error = errors.find {|e| e.respond_to? :exception }
 
     raise error if error
 
@@ -231,7 +231,7 @@ command to remove old versions.
   end
 
   def update_gem(name, version = Gem::Requirement.default)
-    return if @updated.any? { |spec| spec.name == name }
+    return if @updated.any? {|spec| spec.name == name }
 
     update_options = options.dup
     update_options[:prerelease] = version.prerelease?
@@ -292,7 +292,7 @@ command to remove old versions.
 
     highest_installed_gems.each do |l_name, l_spec|
       next if not gem_names.empty? and
-              gem_names.none? { |name| name == l_spec.name }
+              gem_names.none? {|name| name == l_spec.name }
 
       highest_remote_tup = highest_remote_name_tuple l_spec
       highest_remote_ver = highest_remote_tup.version

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -434,7 +434,7 @@ if you believe they were disclosed to a third party.
     yaml_hash[:ssl_client_cert] =
       @hash[:ssl_client_cert] if @hash.key? :ssl_client_cert
 
-    keys = yaml_hash.keys.map { |key| key.to_s }
+    keys = yaml_hash.keys.map {|key| key.to_s }
     keys << 'debug'
     re = Regexp.union(*keys)
 

--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -130,7 +130,7 @@ module Kernel
 
       # Ok, now find a gem that has no conflicts, starting
       # at the highest version.
-      valid = found_specs.find { |s| !s.has_conflicts? }
+      valid = found_specs.find {|s| !s.has_conflicts? }
 
       unless valid
         le = Gem::LoadError.new "unable to find a version of '#{names.first}' to activate"

--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -322,13 +322,13 @@ class Gem::Dependency
   def to_spec
     matches = self.to_specs.compact
 
-    active = matches.find { |spec| spec.activated? }
+    active = matches.find {|spec| spec.activated? }
     return active if active
 
     return matches.first if prerelease?
 
     # Move prereleases to the end of the list for >= 0 requirements
-    pre, matches = matches.partition { |spec| spec.version.prerelease? }
+    pre, matches = matches.partition {|spec| spec.version.prerelease? }
     matches += pre if requirement == Gem::Requirement.default
 
     matches.first

--- a/lib/rubygems/dependency_list.rb
+++ b/lib/rubygems/dependency_list.rb
@@ -101,11 +101,11 @@ class Gem::DependencyList
   end
 
   def find_name(full_name)
-    @specs.find { |spec| spec.full_name == full_name }
+    @specs.find {|spec| spec.full_name == full_name }
   end
 
   def inspect # :nodoc:
-    "%s %p>" % [super[0..-2], map { |s| s.full_name }]
+    "%s %p>" % [super[0..-2], map {|s| s.full_name }]
   end
 
   ##
@@ -116,7 +116,7 @@ class Gem::DependencyList
   end
 
   def why_not_ok?(quick = false)
-    unsatisfied = Hash.new { |h,k| h[k] = [] }
+    unsatisfied = Hash.new {|h,k| h[k] = [] }
     each do |spec|
       spec.runtime_dependencies.each do |dep|
         inst = Gem::Specification.any? do |installed_spec|
@@ -124,7 +124,7 @@ class Gem::DependencyList
             dep.requirement.satisfied_by? installed_spec.version
         end
 
-        unless inst or @specs.find { |s| s.satisfies_requirement? dep }
+        unless inst or @specs.find {|s| s.satisfies_requirement? dep }
           unsatisfied[spec.name] << dep
           return unsatisfied if quick
         end
@@ -184,7 +184,7 @@ class Gem::DependencyList
   # Removes the gemspec matching +full_name+ from the dependency list
 
   def remove_by_name(full_name)
-    @specs.delete_if { |spec| spec.full_name == full_name }
+    @specs.delete_if {|spec| spec.full_name == full_name }
   end
 
   ##
@@ -192,7 +192,7 @@ class Gem::DependencyList
   # gemspecs that have a dependency satisfied by the named gemspec.
 
   def spec_predecessors
-    result = Hash.new { |h,k| h[k] = [] }
+    result = Hash.new {|h,k| h[k] = [] }
 
     specs = @specs.sort.reverse
 
@@ -238,7 +238,7 @@ class Gem::DependencyList
   # +ignored+.
 
   def active_count(specs, ignored)
-    specs.count { |spec| ignored[spec.full_name].nil? }
+    specs.count {|spec| ignored[spec.full_name].nil? }
   end
 
 end

--- a/lib/rubygems/doctor.rb
+++ b/lib/rubygems/doctor.rb
@@ -31,7 +31,7 @@ class Gem::Doctor
 
   missing =
     Gem::REPOSITORY_SUBDIRECTORIES.sort -
-      REPOSITORY_EXTENSION_MAP.map { |(k,_)| k }.sort
+      REPOSITORY_EXTENSION_MAP.map {|(k,_)| k }.sort
 
   raise "Update REPOSITORY_EXTENSION_MAP, missing: #{missing.join ', '}" unless
     missing.empty?
@@ -53,7 +53,7 @@ class Gem::Doctor
   # Specs installed in this gem repository
 
   def installed_specs # :nodoc:
-    @installed_specs ||= Gem::Specification.map { |s| s.full_name }
+    @installed_specs ||= Gem::Specification.map {|s| s.full_name }
   end
 
   ##

--- a/lib/rubygems/exceptions.rb
+++ b/lib/rubygems/exceptions.rb
@@ -245,7 +245,7 @@ class Gem::UnsatisfiableDependencyError < Gem::DependencyError
 
   def initialize(dep, platform_mismatch=nil)
     if platform_mismatch and !platform_mismatch.empty?
-      plats = platform_mismatch.map { |x| x.platform.to_s }.sort.uniq
+      plats = platform_mismatch.map {|x| x.platform.to_s }.sort.uniq
       super "Unable to resolve dependency: No match for '#{dep}' on this platform. Found: #{plats.join(', ')}"
     else
       if dep.explicit?

--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -66,7 +66,7 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
           if Gem.install_extension_in_lib and lib_dir
             FileUtils.mkdir_p lib_dir
             entries = Dir.entries(tmp_dest) - %w[. ..]
-            entries = entries.map { |entry| File.join tmp_dest, entry }
+            entries = entries.map {|entry| File.join tmp_dest, entry }
             FileUtils.cp_r entries, lib_dir, :remove_destination => true
           end
 

--- a/lib/rubygems/indexer.rb
+++ b/lib/rubygems/indexer.rb
@@ -365,7 +365,7 @@ class Gem::Indexer
     end
 
     specs = map_gems_to_specs updated_gems
-    prerelease, released = specs.partition { |s| s.version.prerelease? }
+    prerelease, released = specs.partition {|s| s.version.prerelease? }
 
     files = build_marshal_gemspecs specs
 

--- a/lib/rubygems/install_update_options.rb
+++ b/lib/rubygems/install_update_options.rb
@@ -154,7 +154,7 @@ module Gem::InstallUpdateOptions
                'Omit the named groups (comma separated)',
                'when installing from a gem dependencies',
                'file') do |v,o|
-      options[:without_groups].concat v.map { |without| without.intern }
+      options[:without_groups].concat v.map {|without| without.intern }
     end
 
     add_option(:"Install/Update", '--default',

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -410,7 +410,7 @@ class Gem::Installer
 
   def installation_satisfies_dependency?(dependency)
     return true if @options[:development] and dependency.type == :development
-    return true if installed_specs.detect { |s| dependency.matches_spec? s }
+    return true if installed_specs.detect {|s| dependency.matches_spec? s }
     return false if @only_install_dir
     not dependency.matching_specs.empty?
   end
@@ -584,7 +584,7 @@ class Gem::Installer
   def shebang(bin_file_name)
     ruby_name = RbConfig::CONFIG['ruby_install_name'] if @env_shebang
     path = File.join gem_dir, spec.bindir, bin_file_name
-    first_line = File.open(path, "rb") {|file| file.gets} || ""
+    first_line = File.open(path, "rb") {|file| file.gets } || ""
 
     if first_line.start_with?("#!")
       # Preserve extra words on shebang line, like "-w".  Thanks RPA.

--- a/lib/rubygems/local_remote_options.rb
+++ b/lib/rubygems/local_remote_options.rb
@@ -26,7 +26,7 @@ module Gem::LocalRemoteOptions
 
       valid_uri_schemes = ["http", "https", "file", "s3"]
       unless valid_uri_schemes.include?(uri.scheme)
-        msg = "Invalid uri scheme for #{value}\nPreface URLs with one of #{valid_uri_schemes.map{|s| "#{s}://"}}"
+        msg = "Invalid uri scheme for #{value}\nPreface URLs with one of #{valid_uri_schemes.map{|s| "#{s}://" }}"
         raise ArgumentError, msg
       end
 

--- a/lib/rubygems/name_tuple.rb
+++ b/lib/rubygems/name_tuple.rb
@@ -26,7 +26,7 @@ class Gem::NameTuple
   # NameTuple objects.
 
   def self.from_list(list)
-    list.map { |t| new(*t) }
+    list.map {|t| new(*t) }
   end
 
   ##
@@ -34,7 +34,7 @@ class Gem::NameTuple
   # [name, version, platform] tuples.
 
   def self.to_basic(list)
-    list.map { |t| t.to_a }
+    list.map {|t| t.to_a }
   end
 
   ##

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -198,7 +198,7 @@ class Gem::Package
     @build_time      = Gem.source_date_epoch
     @checksums       = {}
     @contents        = nil
-    @digests         = Hash.new { |h, algorithm| h[algorithm] = {} }
+    @digests         = Hash.new {|h, algorithm| h[algorithm] = {} }
     @files           = nil
     @security_policy = security_policy
     @signatures      = {}
@@ -219,7 +219,7 @@ class Gem::Package
   def add_checksums(tar)
     Gem.load_yaml
 
-    checksums_by_algorithm = Hash.new { |h, algorithm| h[algorithm] = {} }
+    checksums_by_algorithm = Hash.new {|h, algorithm| h[algorithm] = {} }
 
     @checksums.each do |name, digests|
       digests.each do |algorithm, digest|
@@ -582,10 +582,10 @@ EOM
         )
 
       @spec.signing_key = nil
-      @spec.cert_chain = @signer.cert_chain.map { |cert| cert.to_s }
+      @spec.cert_chain = @signer.cert_chain.map {|cert| cert.to_s }
     else
       @signer = Gem::Security::Signer.new nil, nil, passphrase
-      @spec.cert_chain = @signer.cert_chain.map { |cert| cert.to_pem } if
+      @spec.cert_chain = @signer.cert_chain.map {|cert| cert.to_pem } if
         @signer.cert_chain
     end
   end

--- a/lib/rubygems/package/old.rb
+++ b/lib/rubygems/package/old.rb
@@ -42,7 +42,7 @@ class Gem::Package::Old < Gem::Package
       read_until_dashes io # spec
       header = file_list io
 
-      @contents = header.map { |file| file['path'] }
+      @contents = header.map {|file| file['path'] }
     end
   end
 

--- a/lib/rubygems/package/tar_header.rb
+++ b/lib/rubygems/package/tar_header.rb
@@ -210,7 +210,7 @@ class Gem::Package::TarHeader
   private
 
   def calculate_checksum(header)
-    header.unpack("C*").inject { |a, b| a + b }
+    header.unpack("C*").inject {|a, b| a + b }
   end
 
   def header(checksum = @checksum)

--- a/lib/rubygems/package/tar_test_case.rb
+++ b/lib/rubygems/package/tar_test_case.rb
@@ -68,7 +68,7 @@ class Gem::Package::TarTestCase < Gem::TestCase
   end
 
   def calc_checksum(header)
-    sum = header.unpack("C*").inject{|s,a| s + a}
+    sum = header.unpack("C*").inject{|s,a| s + a }
     SP(Z(to_oct(sum, 6)))
   end
 

--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -68,7 +68,7 @@ class Gem::PathSupport
       gem_path = default_path
     end
 
-    gem_path.map { |path| expand(path) }.uniq
+    gem_path.map {|path| expand(path) }.uniq
   end
 
   # Return the default Gem path

--- a/lib/rubygems/query_utils.rb
+++ b/lib/rubygems/query_utils.rb
@@ -75,7 +75,7 @@ is too hard to use.
 
     terminate_interaction(check_installed_gems(gem_names)) if check_installed_gems?
 
-    gem_names.each { |n| show_gems(n) }
+    gem_names.each {|n| show_gems(n) }
   end
 
   private
@@ -187,12 +187,12 @@ is too hard to use.
   # Check if gem +name+ version +version+ is installed.
 
   def installed?(name, req = Gem::Requirement.default)
-    Gem::Specification.any? { |s| s.name =~ name and req =~ s.version }
+    Gem::Specification.any? {|s| s.name =~ name and req =~ s.version }
   end
 
   def output_query_results(spec_tuples)
     output = []
-    versions = Hash.new { |h,name| h[name] = [] }
+    versions = Hash.new {|h,name| h[name] = [] }
 
     spec_tuples.each do |spec_tuple, source|
       versions[spec_tuple.name] << [spec_tuple, source]
@@ -209,9 +209,9 @@ is too hard to use.
 
   def output_versions(output, versions)
     versions.each do |gem_name, matching_tuples|
-      matching_tuples = matching_tuples.sort_by { |n,_| n.version }.reverse
+      matching_tuples = matching_tuples.sort_by {|n,_| n.version }.reverse
 
-      platforms = Hash.new { |h,version| h[version] = [] }
+      platforms = Hash.new {|h,version| h[version] = [] }
 
       matching_tuples.each do |n, _|
         platforms[n.version] << n.platform if n.platform
@@ -254,7 +254,7 @@ is too hard to use.
 
     list =
       if platforms.empty? or options[:details]
-        name_tuples.map { |n| n.version }.uniq
+        name_tuples.map {|n| n.version }.uniq
       else
         platforms.sort.reverse.map do |version, pls|
           out = version.to_s
@@ -332,7 +332,7 @@ is too hard to use.
 
   def spec_platforms(entry, platforms)
     non_ruby = platforms.any? do |_, pls|
-      pls.any? { |pl| pl != Gem::Platform::RUBY }
+      pls.any? {|pl| pl != Gem::Platform::RUBY }
     end
 
     return unless non_ruby
@@ -343,7 +343,7 @@ is too hard to use.
     else
       entry << "    Platforms:\n"
 
-      sorted_platforms = platforms.sort_by { |version,| version }
+      sorted_platforms = platforms.sort_by {|version,| version }
 
       sorted_platforms.each do |version, pls|
         label = "        #{version}: "

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -106,7 +106,7 @@ class Gem::RemoteFetcher
 
     return if found.empty?
 
-    spec, source = found.max_by { |(s,_)| s.version }
+    spec, source = found.max_by {|(s,_)| s.version }
 
     download spec, source.uri
   end
@@ -212,7 +212,7 @@ class Gem::RemoteFetcher
   def fetch_http(uri, last_modified = nil, head = false, depth = 0)
     fetch_type = head ? Net::HTTP::Head : Net::HTTP::Get
     response   = request uri, fetch_type, last_modified do |req|
-      headers.each { |k,v| req.add_field(k,v) }
+      headers.each {|k,v| req.add_field(k,v) }
     end
 
     case response
@@ -327,7 +327,7 @@ class Gem::RemoteFetcher
   end
 
   def close_all
-    @pools.each_value {|pool| pool.close_all}
+    @pools.each_value {|pool| pool.close_all }
   end
 
   private

--- a/lib/rubygems/request/connection_pools.rb
+++ b/lib/rubygems/request/connection_pools.rb
@@ -31,7 +31,7 @@ class Gem::Request::ConnectionPools # :nodoc:
   end
 
   def close_all
-    @pools.each_value {|pool| pool.close_all}
+    @pools.each_value {|pool| pool.close_all }
   end
 
   private

--- a/lib/rubygems/request_set.rb
+++ b/lib/rubygems/request_set.rb
@@ -184,7 +184,7 @@ class Gem::RequestSet
       if req.installed?
         req.spec.spec.build_extensions
 
-        if @always_install.none? { |spec| spec == req.spec.spec }
+        if @always_install.none? {|spec| spec == req.spec.spec }
           yield req, nil if block_given?
           next
         end
@@ -269,7 +269,7 @@ class Gem::RequestSet
     gem_home, ENV['GEM_HOME'] = ENV['GEM_HOME'], dir
 
     existing = force ? [] : specs_in(dir)
-    existing.delete_if { |s| @always_install.include? s }
+    existing.delete_if {|s| @always_install.include? s }
 
     dir = File.expand_path dir
 
@@ -283,7 +283,7 @@ class Gem::RequestSet
     sorted_requests.each do |request|
       spec = request.spec
 
-      if existing.find { |s| s.full_name == spec.full_name }
+      if existing.find {|s| s.full_name == spec.full_name }
         yield request, nil if block_given?
         next
       end
@@ -386,7 +386,7 @@ class Gem::RequestSet
       q.text 'sets:'
 
       q.breakable
-      q.pp @sets.map { |set| set.class }
+      q.pp @sets.map {|set| set.class }
     end
   end
 
@@ -440,7 +440,7 @@ class Gem::RequestSet
   end
 
   def specs
-    @specs ||= @requests.map { |r| r.full_spec }
+    @specs ||= @requests.map {|r| r.full_spec }
   end
 
   def specs_in(dir)

--- a/lib/rubygems/request_set/gem_dependency_api.rb
+++ b/lib/rubygems/request_set/gem_dependency_api.rb
@@ -206,7 +206,7 @@ class Gem::RequestSet::GemDependencyAPI
     @git_set            = @set.git_set
     @git_sources        = {}
     @installing         = false
-    @requires           = Hash.new { |h, name| h[name] = [] }
+    @requires           = Hash.new {|h, name| h[name] = [] }
     @vendor_set         = @set.vendor_set
     @source_set         = @set.source_set
     @gem_sources        = {}

--- a/lib/rubygems/request_set/lockfile.rb
+++ b/lib/rubygems/request_set/lockfile.rb
@@ -89,7 +89,7 @@ class Gem::RequestSet::Lockfile
   def add_DEPENDENCIES(out) # :nodoc:
     out << "DEPENDENCIES"
 
-    out.concat @dependencies.sort_by { |name,| name }.map { |name, requirement|
+    out.concat @dependencies.sort_by {|name,| name }.map {|name, requirement|
       "  #{name}#{requirement.for_lockfile}"
     }
 
@@ -103,12 +103,12 @@ class Gem::RequestSet::Lockfile
       request.spec.source.uri
     end
 
-    source_groups.sort_by { |group,| group.to_s }.map do |group, requests|
+    source_groups.sort_by {|group,| group.to_s }.map do |group, requests|
       out << "GEM"
       out << "  remote: #{group}"
       out << "  specs:"
 
-      requests.sort_by { |request| request.name }.each do |request|
+      requests.sort_by {|request| request.name }.each do |request|
         next if request.spec.name == 'bundler'
         platform = "-#{request.spec.platform}" unless
           Gem::Platform::RUBY == request.spec.platform
@@ -140,10 +140,10 @@ class Gem::RequestSet::Lockfile
       out << "  revision: #{revision}"
       out << "  specs:"
 
-      requests.sort_by { |request| request.name }.each do |request|
+      requests.sort_by {|request| request.name }.each do |request|
         out << "    #{request.name} (#{request.version})"
 
-        dependencies = request.spec.dependencies.sort_by { |dep| dep.name }
+        dependencies = request.spec.dependencies.sort_by {|dep| dep.name }
         dependencies.each do |dep|
           out << "      #{dep.name}#{dep.requirement.for_lockfile}"
         end
@@ -185,9 +185,9 @@ class Gem::RequestSet::Lockfile
   def add_PLATFORMS(out) # :nodoc:
     out << "PLATFORMS"
 
-    platforms = requests.map { |request| request.spec.platform }.uniq
+    platforms = requests.map {|request| request.spec.platform }.uniq
 
-    platforms = platforms.sort_by { |platform| platform.to_s }
+    platforms = platforms.sort_by {|platform| platform.to_s }
 
     platforms.each do |platform|
       out << "  #{platform}"
@@ -197,7 +197,7 @@ class Gem::RequestSet::Lockfile
   end
 
   def spec_groups
-    requests.group_by { |request| request.spec.class }
+    requests.group_by {|request| request.spec.class }
   end
 
   ##

--- a/lib/rubygems/request_set/lockfile/tokenizer.rb
+++ b/lib/rubygems/request_set/lockfile/tokenizer.rb
@@ -23,7 +23,7 @@ class Gem::RequestSet::Lockfile::Tokenizer
   end
 
   def to_a
-    @tokens.map { |token| [token.type, token.value, token.column, token.line] }
+    @tokens.map {|token| [token.type, token.value, token.column, token.line] }
   end
 
   def skip(type)

--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -12,18 +12,18 @@ require "rubygems/deprecate"
 class Gem::Requirement
 
   OPS = { #:nodoc:
-    "="  =>  lambda { |v, r| v == r },
-    "!=" =>  lambda { |v, r| v != r },
-    ">"  =>  lambda { |v, r| v >  r },
-    "<"  =>  lambda { |v, r| v <  r },
-    ">=" =>  lambda { |v, r| v >= r },
-    "<=" =>  lambda { |v, r| v <= r },
-    "~>" =>  lambda { |v, r| v >= r && v.release < r.bump }
+    "="  =>  lambda {|v, r| v == r },
+    "!=" =>  lambda {|v, r| v != r },
+    ">"  =>  lambda {|v, r| v >  r },
+    "<"  =>  lambda {|v, r| v <  r },
+    ">=" =>  lambda {|v, r| v >= r },
+    "<=" =>  lambda {|v, r| v <= r },
+    "~>" =>  lambda {|v, r| v >= r && v.release < r.bump }
   }.freeze
 
   SOURCE_SET_REQUIREMENT = Struct.new(:for_lockfile).new "!" # :nodoc:
 
-  quoted = OPS.keys.map { |k| Regexp.quote k }.join "|"
+  quoted = OPS.keys.map {|k| Regexp.quote k }.join "|"
   PATTERN_RAW = "\\s*(#{quoted})?\\s*(#{Gem::Version::VERSION_PATTERN})\\s*".freeze # :nodoc:
 
   ##
@@ -137,7 +137,7 @@ class Gem::Requirement
     if requirements.empty?
       @requirements = [DefaultRequirement]
     else
-      @requirements = requirements.map! { |r| self.class.parse r }
+      @requirements = requirements.map! {|r| self.class.parse r }
     end
   end
 
@@ -148,7 +148,7 @@ class Gem::Requirement
     new = new.flatten
     new.compact!
     new.uniq!
-    new = new.map { |r| self.class.parse r }
+    new = new.map {|r| self.class.parse r }
 
     @requirements.concat new
   end
@@ -188,7 +188,7 @@ class Gem::Requirement
   end
 
   def as_list # :nodoc:
-    requirements.map { |op, version| "#{op} #{version}" }
+    requirements.map {|op, version| "#{op} #{version}" }
   end
 
   def hash # :nodoc:
@@ -233,7 +233,7 @@ class Gem::Requirement
   # are prereleases
 
   def prerelease?
-    requirements.any? { |r| r.last.prerelease? }
+    requirements.any? {|r| r.last.prerelease? }
   end
 
   def pretty_print(q) # :nodoc:
@@ -249,7 +249,7 @@ class Gem::Requirement
     raise ArgumentError, "Need a Gem::Version: #{version.inspect}" unless
       Gem::Version === version
     # #28965: syck has a bug with unquoted '=' YAML.loading as YAML::DefaultKey
-    requirements.all? { |op, rv| (OPS[op] || OPS["="]).call version, rv }
+    requirements.all? {|op, rv| (OPS[op] || OPS["="]).call version, rv }
   end
 
   alias :=== :satisfied_by?
@@ -285,7 +285,7 @@ class Gem::Requirement
   protected
 
   def _tilde_requirements
-    requirements.select { |r| r.first == "~>" }
+    requirements.select {|r| r.first == "~>" }
   end
 
   private

--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -116,7 +116,7 @@ class Gem::Resolver
   def explain(stage, *data) # :nodoc:
     return unless DEBUG_RESOLVER
 
-    d = data.map { |x| x.pretty_inspect }.join(", ")
+    d = data.map {|x| x.pretty_inspect }.join(", ")
     $stderr.printf "%10s %s\n", stage.to_s.upcase, d
   end
 
@@ -189,7 +189,7 @@ class Gem::Resolver
 
   def resolve
     locking_dg = Molinillo::DependencyGraph.new
-    Molinillo::Resolver.new(self, self).resolve(@needed.map { |d| DependencyRequest.new d, nil }, locking_dg).tsort.map(&:payload).compact
+    Molinillo::Resolver.new(self, self).resolve(@needed.map {|d| DependencyRequest.new d, nil }, locking_dg).tsort.map(&:payload).compact
   rescue Molinillo::VersionConflict => e
     conflict = e.conflicts.values.first
     raise Gem::DependencyResolutionError, Conflict.new(conflict.requirement_trees.first.first, conflict.existing, conflict.requirement)
@@ -206,7 +206,7 @@ class Gem::Resolver
 
     if (skip_dep_gems = skip_gems[dependency.name]) && !skip_dep_gems.empty?
       matching = all.select do |api_spec|
-        skip_dep_gems.any? { |s| api_spec.version == s.version }
+        skip_dep_gems.any? {|s| api_spec.version == s.version }
       end
 
       all = matching unless matching.empty?
@@ -235,7 +235,7 @@ class Gem::Resolver
       raise exc
     end
 
-    groups = Hash.new { |hash, key| hash[key] = [] }
+    groups = Hash.new {|hash, key| hash[key] = [] }
 
     # create groups & sources in the same loop
     sources = possibles.map do |spec|
@@ -248,9 +248,9 @@ class Gem::Resolver
 
     sources.each do |source|
       groups[source].
-        sort_by { |spec| [spec.version, Gem::Platform.local =~ spec.platform ? 1 : 0] }.
-        map { |spec| ActivationRequest.new spec, dependency }.
-        each { |activation_request| activation_requests << activation_request }
+        sort_by {|spec| [spec.version, Gem::Platform.local =~ spec.platform ? 1 : 0] }.
+        map {|spec| ActivationRequest.new spec, dependency }.
+        each {|activation_request| activation_requests << activation_request }
     end
 
     activation_requests

--- a/lib/rubygems/resolver/api_set.rb
+++ b/lib/rubygems/resolver/api_set.rb
@@ -33,7 +33,7 @@ class Gem::Resolver::APISet < Gem::Resolver::Set
     @dep_uri = dep_uri
     @uri     = dep_uri + '../..'
 
-    @data   = Hash.new { |h,k| h[k] = [] }
+    @data   = Hash.new {|h,k| h[k] = [] }
     @source = Gem::Source.new @uri
 
     @to_fetch = []
@@ -67,7 +67,7 @@ class Gem::Resolver::APISet < Gem::Resolver::Set
 
   def prefetch(reqs)
     return unless @remote
-    names = reqs.map { |r| r.dependency.name }
+    names = reqs.map {|r| r.dependency.name }
     needed = names - @data.keys - @to_fetch
 
     @to_fetch += needed

--- a/lib/rubygems/resolver/composed_set.rb
+++ b/lib/rubygems/resolver/composed_set.rb
@@ -40,11 +40,11 @@ class Gem::Resolver::ComposedSet < Gem::Resolver::Set
   def remote=(remote)
     super
 
-    @sets.each { |set| set.remote = remote }
+    @sets.each {|set| set.remote = remote }
   end
 
   def errors
-    @errors + @sets.map { |set| set.errors }.flatten
+    @errors + @sets.map {|set| set.errors }.flatten
   end
 
   ##
@@ -60,7 +60,7 @@ class Gem::Resolver::ComposedSet < Gem::Resolver::Set
   # Prefetches +reqs+ in all sets.
 
   def prefetch(reqs)
-    @sets.each { |s| s.prefetch(reqs) }
+    @sets.each {|s| s.prefetch(reqs) }
   end
 
 end

--- a/lib/rubygems/resolver/conflict.rb
+++ b/lib/rubygems/resolver/conflict.rb
@@ -55,7 +55,7 @@ class Gem::Resolver::Conflict
     activated   = @activated.spec.full_name
     dependency  = @failed_dep.dependency
     requirement = dependency.requirement
-    alternates  = dependency.matching_specs.map { |spec| spec.full_name }
+    alternates  = dependency.matching_specs.map {|spec| spec.full_name }
 
     unless alternates.empty?
       matching = <<-MATCHING.chomp

--- a/lib/rubygems/resolver/index_set.rb
+++ b/lib/rubygems/resolver/index_set.rb
@@ -17,7 +17,7 @@ class Gem::Resolver::IndexSet < Gem::Resolver::Set
         Gem::SpecFetcher.fetcher
       end
 
-    @all = Hash.new { |h,k| h[k] = [] }
+    @all = Hash.new {|h,k| h[k] = [] }
 
     list, errors = @f.available_specs :complete
 

--- a/lib/rubygems/resolver/installer_set.rb
+++ b/lib/rubygems/resolver/installer_set.rb
@@ -118,12 +118,12 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
     dep = req.dependency
 
     return res if @ignore_dependencies and
-              @always_install.none? { |spec| dep.match? spec }
+              @always_install.none? {|spec| dep.match? spec }
 
     name = dep.name
 
     dep.matching_specs.each do |gemspec|
-      next if @always_install.any? { |spec| spec.name == gemspec.name }
+      next if @always_install.any? {|spec| spec.name == gemspec.name }
 
       res << Gem::Resolver::InstalledSpecification.new(self, gemspec)
     end unless @ignore_installed
@@ -168,7 +168,7 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
   end
 
   def inspect # :nodoc:
-    always_install = @always_install.map { |s| s.full_name }
+    always_install = @always_install.map {|s| s.full_name }
 
     '#<%s domain: %s specs: %p always install: %p>' % [
       self.class, @domain, @specs.keys, always_install,

--- a/lib/rubygems/resolver/lock_set.rb
+++ b/lib/rubygems/resolver/lock_set.rb
@@ -75,7 +75,7 @@ class Gem::Resolver::LockSet < Gem::Resolver::Set
       q.text 'specs:'
 
       q.breakable
-      q.pp @specs.map { |spec| spec.full_name }
+      q.pp @specs.map {|spec| spec.full_name }
     end
   end
 

--- a/lib/rubygems/security.rb
+++ b/lib/rubygems/security.rb
@@ -485,7 +485,7 @@ module Gem::Security
 
     dcs = dcs.split '.'
 
-    name = "CN=#{cn}/#{dcs.map { |dc| "DC=#{dc}" }.join '/'}"
+    name = "CN=#{cn}/#{dcs.map {|dc| "DC=#{dc}" }.join '/'}"
 
     OpenSSL::X509::Name.parse name
   end

--- a/lib/rubygems/security/signer.rb
+++ b/lib/rubygems/security/signer.rb
@@ -106,7 +106,7 @@ class Gem::Security::Signer
   # this value is preferred, otherwise the subject is used.
 
   def extract_name(cert) # :nodoc:
-    subject_alt_name = cert.extensions.find { |e| 'subjectAltName' == e.oid }
+    subject_alt_name = cert.extensions.find {|e| 'subjectAltName' == e.oid }
 
     if subject_alt_name
       /\Aemail:/ =~ subject_alt_name.value # rubocop:disable Performance/StartWith

--- a/lib/rubygems/server.rb
+++ b/lib/rubygems/server.rb
@@ -442,8 +442,8 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
     logger  = WEBrick::Log.new nil, WEBrick::BasicLog::FATAL
     @server = WEBrick::HTTPServer.new :DoNotListen => true, :Logger => logger
 
-    @spec_dirs = @gem_dirs.map { |gem_dir| File.join gem_dir, 'specifications' }
-    @spec_dirs.reject! { |spec_dir| !File.directory? spec_dir }
+    @spec_dirs = @gem_dirs.map {|gem_dir| File.join gem_dir, 'specifications' }
+    @spec_dirs.reject! {|spec_dir| !File.directory? spec_dir }
 
     reset_gems
 
@@ -458,7 +458,7 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
 
   def uri_encode(str)
     str.gsub(URI::UNSAFE) do |match|
-      match.each_byte.map { |c| sprintf('%%%02X', c.ord) }.join
+      match.each_byte.map {|c| sprintf('%%%02X', c.ord) }.join
     end
   end
 
@@ -615,11 +615,11 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
         }
       end
 
-      deps = deps.sort_by { |dep| [dep["name"].downcase, dep["version"]] }
+      deps = deps.sort_by {|dep| [dep["name"].downcase, dep["version"]] }
       deps.last["is_last"] = true unless deps.empty?
 
       # executables
-      executables = spec.executables.sort.collect { |exec| {"executable" => exec} }
+      executables = spec.executables.sort.collect {|exec| {"executable" => exec} }
       executables = nil if executables.empty?
       executables.last["is_last"] = true if executables
 
@@ -668,7 +668,7 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
       "version" => Gem::VERSION,
     }
 
-    specs = specs.sort_by { |spec| [spec["name"].downcase, spec["version"]] }
+    specs = specs.sort_by {|spec| [spec["name"].downcase, spec["version"]] }
     specs.last["is_last"] = true
 
     # tag all specs with first_name_entry
@@ -869,7 +869,7 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
     listeners = @server.listeners.map{|l| l.addr[2] }
 
     # TODO: 0.0.0.0 == any, not localhost.
-    host = listeners.any?{|l| l == '0.0.0.0'} ? 'localhost' : listeners.first
+    host = listeners.any?{|l| l == '0.0.0.0' } ? 'localhost' : listeners.first
 
     say "Launching browser to http://#{host}:#{@port}"
 

--- a/lib/rubygems/source/local.rb
+++ b/lib/rubygems/source/local.rb
@@ -61,7 +61,7 @@ class Gem::Source::Local < Gem::Source
           when :latest
             tup = pkg.spec.name_tuple
 
-            cur = names.find { |x| x.name == tup.name }
+            cur = names.find {|x| x.name == tup.name }
             if !cur
               names << tup
             elsif cur.version < tup.version
@@ -98,7 +98,7 @@ class Gem::Source::Local < Gem::Source
       end
     end
 
-    found.max_by { |s| s.version }
+    found.max_by {|s| s.version }
   end
 
   def fetch_spec(name) # :nodoc:

--- a/lib/rubygems/source_list.rb
+++ b/lib/rubygems/source_list.rb
@@ -90,7 +90,7 @@ class Gem::SourceList
   # Yields each source URI in the list.
 
   def each
-    @sources.each { |s| yield s.uri.to_s }
+    @sources.each {|s| yield s.uri.to_s }
   end
 
   ##
@@ -115,7 +115,7 @@ class Gem::SourceList
   # Returns an Array of source URI Strings.
 
   def to_a
-    @sources.map { |x| x.uri.to_s }
+    @sources.map {|x| x.uri.to_s }
   end
 
   alias_method :to_ary, :to_a
@@ -135,7 +135,7 @@ class Gem::SourceList
     if other.kind_of? Gem::Source
       @sources.include? other
     else
-      @sources.find { |x| x.uri.to_s == other.to_s }
+      @sources.find {|x| x.uri.to_s == other.to_s }
     end
   end
 
@@ -146,7 +146,7 @@ class Gem::SourceList
     if source.kind_of? Gem::Source
       @sources.delete source
     else
-      @sources.delete_if { |x| x.uri.to_s == source.to_s }
+      @sources.delete_if {|x| x.uri.to_s == source.to_s }
     end
   end
 

--- a/lib/rubygems/spec_fetcher.rb
+++ b/lib/rubygems/spec_fetcher.rb
@@ -92,8 +92,8 @@ class Gem::SpecFetcher
 
     list.each do |source, specs|
       if dependency.name.is_a?(String) && specs.respond_to?(:bsearch)
-        start_index = (0 ... specs.length).bsearch{ |i| specs[i].name >= dependency.name }
-        end_index   = (0 ... specs.length).bsearch{ |i| specs[i].name > dependency.name }
+        start_index = (0 ... specs.length).bsearch{|i| specs[i].name >= dependency.name }
+        end_index   = (0 ... specs.length).bsearch{|i| specs[i].name > dependency.name }
         specs = specs[start_index ... end_index] if start_index && end_index
       end
 
@@ -122,7 +122,7 @@ class Gem::SpecFetcher
       end
     end
 
-    tuples = tuples.sort_by { |x| x[0] }
+    tuples = tuples.sort_by {|x| x[0] }
 
     return [tuples, errors]
   end
@@ -194,10 +194,10 @@ class Gem::SpecFetcher
     matches = if matches.empty? && type != :prerelease
                 suggest_gems_from_name gem_name, :prerelease
               else
-                matches.uniq.sort_by { |name, dist| dist }
+                matches.uniq.sort_by {|name, dist| dist }
               end
 
-    matches.map { |name, dist| name }.uniq.first(num_results)
+    matches.map {|name, dist| name }.uniq.first(num_results)
   end
 
   ##
@@ -254,7 +254,7 @@ class Gem::SpecFetcher
 
   def tuples_for(source, type, gracefully_ignore=false) # :nodoc:
     @caches[type][source.uri] ||=
-      source.load_specs(type).sort_by { |tup| tup.name }
+      source.load_specs(type).sort_by {|tup| tup.name }
   rescue Gem::RemoteFetcher::FetchError
     raise unless gracefully_ignore
     []

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -180,8 +180,8 @@ class Gem::Specification < Gem::BasicSpecification
                                       end
   end
 
-  @@attributes = @@default_value.keys.sort_by { |s| s.to_s }
-  @@array_attributes = @@default_value.reject { |k,v| v != [] }.keys
+  @@attributes = @@default_value.keys.sort_by {|s| s.to_s }
+  @@array_attributes = @@default_value.reject {|k,v| v != [] }.keys
   @@nil_attributes, @@non_nil_attributes = @@default_value.keys.partition do |k|
     @@default_value[k].nil?
   end
@@ -747,8 +747,8 @@ class Gem::Specification < Gem::BasicSpecification
       # After a reset, make sure already loaded specs
       # are still marked as activated.
       specs = {}
-      Gem.loaded_specs.each_value{|s| specs[s] = true}
-      @@all.each{|s| s.activated = true if specs[s]}
+      Gem.loaded_specs.each_value{|s| specs[s] = true }
+      @@all.each{|s| s.activated = true if specs[s] }
     end
     @@all
   end
@@ -768,7 +768,7 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   def self.gemspec_stubs_in(dir, pattern)
-    Gem::Util.glob_files_in_dir(pattern, dir).map { |path| yield path }.select(&:valid?)
+    Gem::Util.glob_files_in_dir(pattern, dir).map {|path| yield path }.select(&:valid?)
   end
   private_class_method :gemspec_stubs_in
 
@@ -783,7 +783,7 @@ class Gem::Specification < Gem::BasicSpecification
     dirs.flat_map do |dir|
       base_dir = File.dirname dir
       gems_dir = File.join base_dir, "gems"
-      gemspec_stubs_in(dir, pattern) { |path| yield path, base_dir, gems_dir }
+      gemspec_stubs_in(dir, pattern) {|path| yield path, base_dir, gems_dir }
     end
   end
   private_class_method :map_stubs
@@ -802,10 +802,10 @@ class Gem::Specification < Gem::BasicSpecification
     @@stubs ||= begin
       pattern = "*.gemspec"
       stubs = installed_stubs(dirs, pattern) + default_stubs(pattern)
-      stubs = stubs.uniq { |stub| stub.full_name }
+      stubs = stubs.uniq {|stub| stub.full_name }
 
       _resort!(stubs)
-      @@stubs_by_name = stubs.select { |s| Gem::Platform.match s.platform }.group_by(&:name)
+      @@stubs_by_name = stubs.select {|s| Gem::Platform.match s.platform }.group_by(&:name)
       stubs
     end
   end
@@ -832,9 +832,9 @@ class Gem::Specification < Gem::BasicSpecification
       @@stubs_by_name[name]
     else
       pattern = "#{name}-*.gemspec"
-      stubs = installed_stubs(dirs, pattern).select { |s| Gem::Platform.match s.platform } + default_stubs(pattern)
-      stubs = stubs.uniq { |stub| stub.full_name }.group_by(&:name)
-      stubs.each_value { |v| _resort!(v) }
+      stubs = installed_stubs(dirs, pattern).select {|s| Gem::Platform.match s.platform } + default_stubs(pattern)
+      stubs = stubs.uniq {|stub| stub.full_name }.group_by(&:name)
+      stubs.each_value {|v| _resort!(v) }
 
       @@stubs_by_name.merge! stubs
       @@stubs_by_name[name] ||= EMPTY
@@ -928,7 +928,7 @@ class Gem::Specification < Gem::BasicSpecification
   def self.dirs=(dirs)
     self.reset
 
-    @@dirs = Array(dirs).map { |dir| File.join dir, "specifications" }
+    @@dirs = Array(dirs).map {|dir| File.join dir, "specifications" }
   end
 
   extend Enumerable
@@ -1012,9 +1012,9 @@ class Gem::Specification < Gem::BasicSpecification
 
   def self.find_in_unresolved(path)
     # TODO: do we need these?? Kill it
-    specs = unresolved_deps.values.map { |dep| dep.to_specs }.flatten
+    specs = unresolved_deps.values.map {|dep| dep.to_specs }.flatten
 
-    specs.find_all { |spec| spec.contains_requirable_file? path }
+    specs.find_all {|spec| spec.contains_requirable_file? path }
   end
 
   ##
@@ -1022,7 +1022,7 @@ class Gem::Specification < Gem::BasicSpecification
   # specs that contain the file matching +path+.
 
   def self.find_in_unresolved_tree(path)
-    specs = unresolved_deps.values.map { |dep| dep.to_specs }.flatten
+    specs = unresolved_deps.values.map {|dep| dep.to_specs }.flatten
 
     specs.each do |spec|
       spec.traverse do |from_spec, dep, to_spec, trail|
@@ -1077,11 +1077,11 @@ class Gem::Specification < Gem::BasicSpecification
   # Return the latest installed spec for gem +name+.
 
   def self.latest_spec_for(name)
-    latest_specs(true).find { |installed_spec| installed_spec.name == name }
+    latest_specs(true).find {|installed_spec| installed_spec.name == name }
   end
 
   def self._latest_specs(specs, prerelease = false) # :nodoc:
-    result = Hash.new { |h,k| h[k] = {} }
+    result = Hash.new {|h,k| h[k] = {} }
     native = {}
 
     specs.reverse_each do |spec|
@@ -1094,7 +1094,7 @@ class Gem::Specification < Gem::BasicSpecification
     result.map(&:last).map(&:values).flatten.reject do |spec|
       minimum = native[spec.name]
       minimum && spec.version < minimum
-    end.sort_by{ |tup| tup.name }
+    end.sort_by{|tup| tup.name }
   end
 
   ##
@@ -1168,7 +1168,7 @@ class Gem::Specification < Gem::BasicSpecification
   # version as well.
 
   def self.outdated
-    outdated_and_latest_version.map { |local, _| local.name }
+    outdated_and_latest_version.map {|local, _| local.name }
   end
 
   ##
@@ -1189,7 +1189,7 @@ class Gem::Specification < Gem::BasicSpecification
         Gem::Dependency.new local_spec.name, ">= #{local_spec.version}"
 
       remotes, = fetcher.search_for_dependency dependency
-      remotes  = remotes.map { |n, _| n.version }
+      remotes  = remotes.map {|n, _| n.version }
 
       latest_remote = remotes.sort.last
 
@@ -1220,7 +1220,7 @@ class Gem::Specification < Gem::BasicSpecification
 
   def self.reset
     @@dirs = nil
-    Gem.pre_reset_hooks.each { |hook| hook.call }
+    Gem.pre_reset_hooks.each {|hook| hook.call }
     @@all = nil
     @@stubs = nil
     @@stubs_by_name = {}
@@ -1237,19 +1237,19 @@ class Gem::Specification < Gem::BasicSpecification
         versions = find_all_by_name(dep.name)
         unless versions.empty?
           warn "      Available/installed versions of this gem:"
-          versions.each { |s| warn "      - #{s.version}" }
+          versions.each {|s| warn "      - #{s.version}" }
         end
       end
       warn "#{w}: Clearing out unresolved specs. Try 'gem cleanup <gem>'"
       warn "Please report a bug if this causes problems."
       unresolved.clear
     end
-    Gem.post_reset_hooks.each { |hook| hook.call }
+    Gem.post_reset_hooks.each {|hook| hook.call }
   end
 
   # DOC: This method needs documented or nodoc'd
   def self.unresolved_deps
-    @unresolved_deps ||= Hash.new { |h, n| h[n] = Gem::Dependency.new n }
+    @unresolved_deps ||= Hash.new {|h, n| h[n] = Gem::Dependency.new n }
   end
 
   ##
@@ -1280,7 +1280,7 @@ class Gem::Specification < Gem::BasicSpecification
     # Cleanup any YAML::PrivateType. They only show up for an old bug
     # where nil => null, so just convert them to nil based on the type.
 
-    array.map! { |e| e.kind_of?(YAML::PrivateType) ? nil : e }
+    array.map! {|e| e.kind_of?(YAML::PrivateType) ? nil : e }
 
     spec.instance_variable_set :@rubygems_version,          array[0]
     # spec version
@@ -1433,7 +1433,7 @@ class Gem::Specification < Gem::BasicSpecification
     self.summary              = sanitize_string(summary)
     self.description          = sanitize_string(description)
     self.post_install_message = sanitize_string(post_install_message)
-    self.authors              = authors.collect { |a| sanitize_string(a) }
+    self.authors              = authors.collect {|a| sanitize_string(a) }
   end
 
   ##
@@ -1456,7 +1456,7 @@ class Gem::Specification < Gem::BasicSpecification
     return nil if executables.nil?
 
     if @bindir
-      Array(executables).map { |e| File.join(@bindir, e) }
+      Array(executables).map {|e| File.join(@bindir, e) }
     else
       executables
     end
@@ -1538,7 +1538,7 @@ class Gem::Specification < Gem::BasicSpecification
   def build_args
     if File.exist? build_info_file
       build_info = File.readlines build_info_file
-      build_info = build_info.map { |x| x.strip }
+      build_info = build_info.map {|x| x.strip }
       build_info.delete ""
       build_info
     else
@@ -1630,7 +1630,7 @@ class Gem::Specification < Gem::BasicSpecification
 
   def conficts_when_loaded_with?(list_of_specs) # :nodoc:
     result = list_of_specs.any? do |spec|
-      spec.dependencies.any? { |dep| dep.runtime? && (dep.name == name) && !satisfies_requirement?(dep) }
+      spec.dependencies.any? {|dep| dep.runtime? && (dep.name == name) && !satisfies_requirement?(dep) }
     end
     result
   end
@@ -1765,7 +1765,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Returns all specs that matches this spec's runtime dependencies.
 
   def dependent_specs
-    runtime_dependencies.map { |dep| dep.to_specs }.flatten
+    runtime_dependencies.map {|dep| dep.to_specs }.flatten
   end
 
   ##
@@ -1779,7 +1779,7 @@ class Gem::Specification < Gem::BasicSpecification
   # List of dependencies that are used for development
 
   def development_dependencies
-    dependencies.select { |d| d.type == :development }
+    dependencies.select {|d| d.type == :development }
   end
 
   ##
@@ -2283,9 +2283,9 @@ class Gem::Specification < Gem::BasicSpecification
   def ruby_code(obj)
     case obj
     when String             then obj.dump + ".freeze"
-    when Array              then '[' + obj.map { |x| ruby_code x }.join(", ") + ']'
+    when Array              then '[' + obj.map {|x| ruby_code x }.join(", ") + ']'
     when Hash               then
-      seg = obj.keys.sort.map { |k| "#{k.to_s.dump} => #{obj[k].to_s.dump}" }
+      seg = obj.keys.sort.map {|k| "#{k.to_s.dump} => #{obj[k].to_s.dump}" }
       "{ #{seg.join(', ')} }"
     when Gem::Version       then obj.to_s.dump
     when DateLike           then obj.strftime('%Y-%m-%d').dump
@@ -2313,7 +2313,7 @@ class Gem::Specification < Gem::BasicSpecification
   # True if this gem has the same attributes as +other+.
 
   def same_attributes?(spec)
-    @@attributes.all? { |name, default| self.send(name) == spec.send(name) }
+    @@attributes.all? {|name, default| self.send(name) == spec.send(name) }
   end
 
   private :same_attributes?
@@ -2555,7 +2555,7 @@ class Gem::Specification < Gem::BasicSpecification
           unless result == :next
             spec_name = dep_spec.name
             dep_spec.traverse(trail, visited, &block) unless
-              trail.any? { |s| s.name == spec_name }
+              trail.any? {|s| s.name == spec_name }
           end
         end
       end
@@ -2580,11 +2580,11 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   def keep_only_files_and_directories
-    @executables.delete_if      { |x| File.directory?(File.join(@bindir, x)) }
-    @extensions.delete_if       { |x| File.directory?(x) && !File.symlink?(x) }
-    @extra_rdoc_files.delete_if { |x| File.directory?(x) && !File.symlink?(x) }
-    @files.delete_if            { |x| File.directory?(x) && !File.symlink?(x) }
-    @test_files.delete_if       { |x| File.directory?(x) && !File.symlink?(x) }
+    @executables.delete_if      {|x| File.directory?(File.join(@bindir, x)) }
+    @extensions.delete_if       {|x| File.directory?(x) && !File.symlink?(x) }
+    @extra_rdoc_files.delete_if {|x| File.directory?(x) && !File.symlink?(x) }
+    @files.delete_if            {|x| File.directory?(x) && !File.symlink?(x) }
+    @test_files.delete_if       {|x| File.directory?(x) && !File.symlink?(x) }
   end
 
   def validate_metadata

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -154,7 +154,7 @@ class Gem::SpecificationPolicy
 
   def validate_duplicate_dependencies # :nodoc:
     # NOTE: see REFACTOR note in Gem::Dependency about types - this might be brittle
-    seen = Gem::Dependency::TYPES.inject({}) { |types, type| types.merge({ type => {}}) }
+    seen = Gem::Dependency::TYPES.inject({}) {|types, type| types.merge({ type => {}}) }
 
     error_messages = []
     @specification.dependencies.each do |dep|
@@ -215,7 +215,7 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
       end
     end
     if warning_messages.any?
-      warning_messages.each { |warning_message| warning warning_message }
+      warning_messages.each {|warning_message| warning warning_message }
     end
   end
 
@@ -292,7 +292,7 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
   def validate_non_files
     return unless packaging
 
-    non_files = @specification.files.reject {|x| File.file?(x) || File.symlink?(x)}
+    non_files = @specification.files.reject {|x| File.file?(x) || File.symlink?(x) }
 
     unless non_files.empty?
       error "[\"#{non_files.join "\", \""}\"] are not files"
@@ -338,7 +338,7 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
               String
             end
 
-    unless Array === val and val.all? {|x| x.kind_of?(klass)}
+    unless Array === val and val.all? {|x| x.kind_of?(klass) }
       error "#{field} must be an Array of #{klass}"
     end
   end
@@ -369,7 +369,7 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
 license value '#{license}' is invalid.  Use a license identifier from
 http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard license.
         WARNING
-        message += "Did you mean #{suggestions.map { |s| "'#{s}'"}.join(', ')}?\n" unless suggestions.nil?
+        message += "Did you mean #{suggestions.map {|s| "'#{s}'" }.join(', ')}?\n" unless suggestions.nil?
         warning(message)
       end
     end
@@ -433,7 +433,7 @@ http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard li
       validate_shebang_line_in(executable)
     end
 
-    @specification.files.select { |f| File.symlink?(f) }.each do |file|
+    @specification.files.select {|f| File.symlink?(f) }.each do |file|
       warning "#{file} is a symlink, which is not supported on all platforms"
     end
   end
@@ -461,7 +461,7 @@ http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard li
     builder = Gem::Ext::Builder.new(@specification)
 
     rake_extension = @specification.extensions.any? {|s| builder.builder_for(s) == Gem::Ext::RakeBuilder }
-    rake_dependency = @specification.dependencies.any? {|d| d.name == 'rake'}
+    rake_dependency = @specification.dependencies.any? {|d| d.name == 'rake' }
 
     warning <<-WARNING if rake_extension && !rake_dependency
 You have specified rake based extension, but rake is not added as dependency. It is recommended to add rake as a dependency in gemspec since there's no guarantee rake will be already installed.

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -269,7 +269,7 @@ class Gem::TestCase < Minitest::Test
       end
     end
 
-    assert scan_make_command_lines(output).any? { |line|
+    assert scan_make_command_lines(output).any? {|line|
       make = parse_make_command_line(line)
 
       if make[:targets].include?(target)
@@ -426,9 +426,9 @@ class Gem::TestCase < Minitest::Test
     $LOAD_PATH.replace @orig_LOAD_PATH if @orig_LOAD_PATH
     if @orig_LOADED_FEATURES
       if @orig_LOAD_PATH
-        paths = @orig_LOAD_PATH.map {|path| File.join(File.expand_path(path), "/")}
+        paths = @orig_LOAD_PATH.map {|path| File.join(File.expand_path(path), "/") }
         ($LOADED_FEATURES - @orig_LOADED_FEATURES).each do |feat|
-          unless paths.any? {|path| feat.start_with?(path)}
+          unless paths.any? {|path| feat.start_with?(path) }
             $LOADED_FEATURES.delete(feat)
           end
         end
@@ -792,7 +792,7 @@ class Gem::TestCase < Minitest::Test
   ensure
     prefix = File.dirname(__FILE__) + "/"
     new_features = ($LOADED_FEATURES - old_loaded_features)
-    old_loaded_features.concat(new_features.select {|f| f.rindex(prefix, 0)})
+    old_loaded_features.concat(new_features.select {|f| f.rindex(prefix, 0) })
     $LOADED_FEATURES.replace old_loaded_features
   end
 
@@ -1015,7 +1015,7 @@ Also, a list:
 
     spec_fetcher = Gem::SpecFetcher.fetcher
 
-    prerelease, all = all_specs.partition { |spec| spec.version.prerelease? }
+    prerelease, all = all_specs.partition {|spec| spec.version.prerelease? }
     latest = Gem::Specification._latest_specs all_specs
 
     spec_fetcher.specs[@uri] = []
@@ -1037,7 +1037,7 @@ Also, a list:
     unless Gem::RemoteFetcher === @fetcher
       v = Gem.marshal_version
 
-      specs = all.map { |spec| spec.name_tuple }
+      specs = all.map {|spec| spec.name_tuple }
       s_zip = util_gzip Marshal.dump Gem::NameTuple.to_basic specs
 
       latest_specs = latest.map do |spec|
@@ -1046,7 +1046,7 @@ Also, a list:
 
       l_zip = util_gzip Marshal.dump Gem::NameTuple.to_basic latest_specs
 
-      prerelease_specs = prerelease.map { |spec| spec.name_tuple }
+      prerelease_specs = prerelease.map {|spec| spec.name_tuple }
       p_zip = util_gzip Marshal.dump Gem::NameTuple.to_basic prerelease_specs
 
       @fetcher.data["#{@gem_repo}specs.#{v}.gz"]            = s_zip
@@ -1442,7 +1442,7 @@ Also, a list:
     # Finds all gems matching +dep+ in this set.
 
     def find_all(dep)
-      @specs.find_all { |s| dep.match? s, @prerelease }
+      @specs.find_all {|s| dep.match? s, @prerelease }
     end
 
     ##

--- a/lib/rubygems/test_utilities.rb
+++ b/lib/rubygems/test_utilities.rb
@@ -76,7 +76,7 @@ class Gem::FakeFetcher
 
   def cache_update_path(uri, path = nil, update = true)
     if data = fetch_path(uri)
-      open(path, 'wb') { |io| io.write data } if path and update
+      open(path, 'wb') {|io| io.write data } if path and update
       data
     else
       Gem.read_binary(path) if path

--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -114,10 +114,10 @@ class Gem::Uninstaller
     if list.empty?
       return unless other_repo_specs.any?
 
-      other_repos = other_repo_specs.map { |spec| spec.base_dir }.uniq
+      other_repos = other_repo_specs.map {|spec| spec.base_dir }.uniq
 
       message = ["#{@gem} is not installed in GEM_HOME, try:"]
-      message.concat other_repos.map { |repo|
+      message.concat other_repos.map {|repo|
         "\tgem uninstall -i #{repo} #{@gem}"
       }
 
@@ -126,7 +126,7 @@ class Gem::Uninstaller
       remove_all list
 
     elsif list.size > 1
-      gem_names = list.map { |gem| gem.full_name }
+      gem_names = list.map {|gem| gem.full_name }
       gem_names << "All versions"
 
       say
@@ -197,7 +197,7 @@ class Gem::Uninstaller
 
     return if executables.empty?
 
-    executables = executables.map { |exec| formatted_program_filename exec }
+    executables = executables.map {|exec| formatted_program_filename exec }
 
     remove = if @force_executables.nil?
                ask_yes_no("Remove executables:\n" +
@@ -232,7 +232,7 @@ class Gem::Uninstaller
   # NOTE: removes uninstalled gems from +list+.
 
   def remove_all(list)
-    list.each { |spec| uninstall_gem spec }
+    list.each {|spec| uninstall_gem spec }
   end
 
   ##
@@ -339,7 +339,7 @@ class Gem::Uninstaller
     end
 
     spec.dependent_gems(@check_dev).each do |dep_spec, dep, satlist|
-      unless siblings.any? { |s| s.satisfies_requirement? dep }
+      unless siblings.any? {|s| s.satisfies_requirement? dep }
         msg << "#{dep_spec.name}-#{dep_spec.version} depends on #{dep}"
       end
     end

--- a/lib/rubygems/user_interaction.rb
+++ b/lib/rubygems/user_interaction.rb
@@ -323,7 +323,7 @@ class Gem::StreamUI
 
   def _gets_noecho
     require_io_console
-    @ins.noecho {@ins.gets}
+    @ins.noecho { @ins.gets }
   end
 
   ##

--- a/lib/rubygems/validator.rb
+++ b/lib/rubygems/validator.rb
@@ -60,7 +60,7 @@ class Gem::Validator
   # TODO needs further cleanup
 
   def alien(gems=[])
-    errors = Hash.new { |h,k| h[k] = {} }
+    errors = Hash.new {|h,k| h[k] = {} }
 
     Gem::Specification.each do |spec|
       next unless gems.include? spec.name unless gems.empty?

--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -231,7 +231,7 @@ class Gem::Version
   def bump
     @@bump[self] ||= begin
                        segments = self.segments
-                       segments.pop while segments.any? { |s| String === s }
+                       segments.pop while segments.any? {|s| String === s }
                        segments.pop if segments.size > 1
 
                        segments[-1] = segments[-1].succ
@@ -310,7 +310,7 @@ class Gem::Version
   def release
     @@release[self] ||= if prerelease?
                           segments = self.segments
-                          segments.pop while segments.any? { |s| String === s }
+                          segments.pop while segments.any? {|s| String === s }
                           self.class.new segments.join('.')
                         else
                           self
@@ -327,7 +327,7 @@ class Gem::Version
   def approximate_recommendation
     segments = self.segments
 
-    segments.pop    while segments.any? { |s| String === s }
+    segments.pop    while segments.any? {|s| String === s }
     segments.pop    while segments.size > 2
     segments.push 0 while segments.size < 2
 

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -21,7 +21,7 @@ class TestGem < Gem::TestCase
     common_installer_setup
 
     ENV.delete 'RUBYGEMS_GEMDEPS'
-    @additional = %w[a b].map { |d| File.join @tempdir, d }
+    @additional = %w[a b].map {|d| File.join @tempdir, d }
 
     util_remove_interrupt_command
   end
@@ -105,7 +105,7 @@ class TestGem < Gem::TestCase
 
     installed = Gem.install 'a', '= 1', :install_dir => gemhome2
 
-    assert_equal %w[a-1], installed.map { |spec| spec.full_name }
+    assert_equal %w[a-1], installed.map {|spec| spec.full_name }
 
     assert_path_exists File.join(gemhome2, 'gems', 'a-1')
   end
@@ -124,7 +124,7 @@ class TestGem < Gem::TestCase
       rescue StandardError
         Gem.install 'a', '= 1', :install_dir => gemhome2
       end
-    assert_equal %w[a-1], installed.map { |spec| spec.full_name }
+    assert_equal %w[a-1], installed.map {|spec| spec.full_name }
   end
 
   def test_self_install_permissions
@@ -208,7 +208,7 @@ class TestGem < Gem::TestCase
     end
     assert_equal(expected, result)
   ensure
-    File.chmod(0755, *Dir.glob(@gemhome + '/gems/**/').map {|path| path.tap(&Gem::UNTAINT)})
+    File.chmod(0755, *Dir.glob(@gemhome + '/gems/**/').map {|path| path.tap(&Gem::UNTAINT) })
   end
 
   def test_require_missing
@@ -337,7 +337,7 @@ class TestGem < Gem::TestCase
       L
     end
 
-    File.open("Gemfile", "w") { |f| f.puts('source "https://rubygems.org"') }
+    File.open("Gemfile", "w") {|f| f.puts('source "https://rubygems.org"') }
 
     e = assert_raises Gem::GemNotFoundException do
       load Gem.activate_bin_path("bundler", "bundle", ">= 0.a")
@@ -376,7 +376,7 @@ class TestGem < Gem::TestCase
       L
     end
 
-    File.open("Gemfile", "w") { |f| f.puts('source "https://rubygems.org"') }
+    File.open("Gemfile", "w") {|f| f.puts('source "https://rubygems.org"') }
 
     load Gem.activate_bin_path("bundler", "bundle", ">= 0.a")
 
@@ -410,7 +410,7 @@ class TestGem < Gem::TestCase
       L
     end
 
-    File.open("Gemfile", "w") { |f| f.puts('source "https://rubygems.org"') }
+    File.open("Gemfile", "w") {|f| f.puts('source "https://rubygems.org"') }
 
     load Gem.activate_bin_path("bundler", "bundle", "= 1.17.3")
 
@@ -1021,7 +1021,7 @@ class TestGem < Gem::TestCase
 
     Gem.refresh
 
-    Gem::Specification.each{|spec| assert spec.activated? if spec == s}
+    Gem::Specification.each{|spec| assert spec.activated? if spec == s }
 
     Gem.loaded_specs.delete(s)
     Gem.refresh
@@ -1163,7 +1163,7 @@ class TestGem < Gem::TestCase
   def test_self_post_build
     assert_equal 1, Gem.post_build_hooks.length
 
-    Gem.post_build { |installer| }
+    Gem.post_build {|installer| }
 
     assert_equal 2, Gem.post_build_hooks.length
   end
@@ -1171,7 +1171,7 @@ class TestGem < Gem::TestCase
   def test_self_post_install
     assert_equal 1, Gem.post_install_hooks.length
 
-    Gem.post_install { |installer| }
+    Gem.post_install {|installer| }
 
     assert_equal 2, Gem.post_install_hooks.length
   end
@@ -1179,7 +1179,7 @@ class TestGem < Gem::TestCase
   def test_self_done_installing
     assert_empty Gem.done_installing_hooks
 
-    Gem.done_installing { |gems| }
+    Gem.done_installing {|gems| }
 
     assert_equal 1, Gem.done_installing_hooks.length
   end
@@ -1187,7 +1187,7 @@ class TestGem < Gem::TestCase
   def test_self_post_reset
     assert_empty Gem.post_reset_hooks
 
-    Gem.post_reset { }
+    Gem.post_reset {}
 
     assert_equal 1, Gem.post_reset_hooks.length
   end
@@ -1195,7 +1195,7 @@ class TestGem < Gem::TestCase
   def test_self_post_uninstall
     assert_equal 1, Gem.post_uninstall_hooks.length
 
-    Gem.post_uninstall { |installer| }
+    Gem.post_uninstall {|installer| }
 
     assert_equal 2, Gem.post_uninstall_hooks.length
   end
@@ -1203,7 +1203,7 @@ class TestGem < Gem::TestCase
   def test_self_pre_install
     assert_equal 1, Gem.pre_install_hooks.length
 
-    Gem.pre_install { |installer| }
+    Gem.pre_install {|installer| }
 
     assert_equal 2, Gem.pre_install_hooks.length
   end
@@ -1211,7 +1211,7 @@ class TestGem < Gem::TestCase
   def test_self_pre_reset
     assert_empty Gem.pre_reset_hooks
 
-    Gem.pre_reset { }
+    Gem.pre_reset {}
 
     assert_equal 1, Gem.pre_reset_hooks.length
   end
@@ -1219,7 +1219,7 @@ class TestGem < Gem::TestCase
   def test_self_pre_uninstall
     assert_equal 1, Gem.pre_uninstall_hooks.length
 
-    Gem.pre_uninstall { |installer| }
+    Gem.pre_uninstall {|installer| }
 
     assert_equal 2, Gem.pre_uninstall_hooks.length
   end
@@ -1248,7 +1248,7 @@ class TestGem < Gem::TestCase
 
     install_specs b1, b2, b3
 
-    specs1 = Gem::Specification.stubs.find_all { |s| s.name == 'b' }
+    specs1 = Gem::Specification.stubs.find_all {|s| s.name == 'b' }
     Gem::Specification.reset
     specs2 = Gem::Specification.stubs_for('b')
     assert_equal specs1.map(&:version), specs2.map(&:version)
@@ -1397,7 +1397,7 @@ class TestGem < Gem::TestCase
       r.gem "b", "= 1"
     end
 
-    activated = Gem::Specification.map { |x| x.full_name }
+    activated = Gem::Specification.map {|x| x.full_name }
 
     assert_equal %w[a-1 b-1 c-2], activated.sort
   end
@@ -1518,8 +1518,8 @@ class TestGem < Gem::TestCase
   def test_gem_path_ordering
     refute_equal Gem.dir, Gem.user_dir
 
-    write_file File.join(@tempdir, 'lib', "g.rb") { |fp| fp.puts "" }
-    write_file File.join(@tempdir, 'lib', 'm.rb') { |fp| fp.puts "" }
+    write_file File.join(@tempdir, 'lib', "g.rb") {|fp| fp.puts "" }
+    write_file File.join(@tempdir, 'lib', 'm.rb') {|fp| fp.puts "" }
 
     g = util_spec 'g', '1', nil, "lib/g.rb"
     m = util_spec 'm', '1', nil, "lib/m.rb"
@@ -1574,8 +1574,8 @@ class TestGem < Gem::TestCase
   end
 
   def test_gem_path_ordering_short
-    write_file File.join(@tempdir, 'lib', "g.rb") { |fp| fp.puts "" }
-    write_file File.join(@tempdir, 'lib', 'm.rb') { |fp| fp.puts "" }
+    write_file File.join(@tempdir, 'lib', "g.rb") {|fp| fp.puts "" }
+    write_file File.join(@tempdir, 'lib', 'm.rb') {|fp| fp.puts "" }
 
     g = util_spec 'g', '1', nil, "lib/g.rb"
     m = util_spec 'm', '1', nil, "lib/m.rb"
@@ -1632,7 +1632,7 @@ class TestGem < Gem::TestCase
     ENV['RUBYGEMS_GEMDEPS'] = "-"
 
     expected_specs = [a, b, util_spec("bundler", Bundler::VERSION), c].compact
-    assert_equal expected_specs, Gem.use_gemdeps.sort_by { |s| s.name }
+    assert_equal expected_specs, Gem.use_gemdeps.sort_by {|s| s.name }
   end
 
   BUNDLER_LIB_PATH = File.expand_path $LOAD_PATH.find {|lp| File.file?(File.join(lp, "bundler.rb")) }
@@ -1765,7 +1765,7 @@ class TestGem < Gem::TestCase
     spec = util_spec 'a', 1
     install_specs spec
 
-    spec = Gem::Specification.find { |s| s == spec }
+    spec = Gem::Specification.find {|s| s == spec }
     refute spec.activated?
 
     File.open gem_deps_file, 'w' do |io|
@@ -1826,7 +1826,7 @@ class TestGem < Gem::TestCase
 
     spec = util_spec 'a', 1
     install_specs spec
-    spec = Gem::Specification.find { |s| s == spec }
+    spec = Gem::Specification.find {|s| s == spec }
 
     refute spec.activated?
 
@@ -1904,7 +1904,7 @@ You may need to `gem install -g` to install missing gems
     spec = util_spec 'a', 1
     install_specs spec
 
-    spec = Gem::Specification.find { |s| s == spec }
+    spec = Gem::Specification.find {|s| s == spec }
     refute spec.activated?
 
     File.open 'x', 'w' do |io|

--- a/test/rubygems/test_gem_available_set.rb
+++ b/test/rubygems/test_gem_available_set.rb
@@ -37,12 +37,12 @@ class TestGemAvailableSet < Gem::TestCase
 
     dep = Gem::Resolver::DependencyRequest.new dep('a'), nil
 
-    assert_equal %w[a-1], set.find_all(dep).map { |spec| spec.full_name }
+    assert_equal %w[a-1], set.find_all(dep).map {|spec| spec.full_name }
 
     dep = Gem::Resolver::DependencyRequest.new dep('a', '>= 0.a'), nil
 
     assert_equal %w[a-1 a-1.a],
-                 set.find_all(dep).map { |spec| spec.full_name }.sort
+                 set.find_all(dep).map {|spec| spec.full_name }.sort
   end
 
   def test_match_platform
@@ -123,7 +123,7 @@ class TestGemAvailableSet < Gem::TestCase
     set.add a2a, @source
     set.add a2, @source
 
-    g = set.sorted.map { |t| t.spec }
+    g = set.sorted.map {|t| t.spec }
 
     assert_equal [a3a, a2, a2a, a1, a1a], g
   end

--- a/test/rubygems/test_gem_bundler_version_finder.rb
+++ b/test/rubygems/test_gem_bundler_version_finder.rb
@@ -120,7 +120,7 @@ class TestGemBundlerVersionFinder < Gem::TestCase
 
   def test_filter
     versions = %w[1 1.0 1.0.1.1 2 2.a 2.0 2.1.1 3 3.a 3.0 3.1.1]
-    specs = versions.map { |v| util_spec("bundler", v) }
+    specs = versions.map {|v| util_spec("bundler", v) }
 
     assert_equal %w[1 1.0 1.0.1.1 2 2.a 2.0 2.1.1 3 3.a 3.0 3.1.1], util_filter_specs(specs).map(&:version).map(&:to_s)
 

--- a/test/rubygems/test_gem_command.rb
+++ b/test/rubygems/test_gem_command.rb
@@ -34,7 +34,7 @@ class TestGemCommand < Gem::TestCase
 
   def test_self_add_specific_extra_args
     added_args = %w[--all]
-    @cmd.add_option('--all') { |v,o| }
+    @cmd.add_option('--all') {|v,o| }
 
     Gem::Command.add_specific_extra_args @cmd_name, added_args
 

--- a/test/rubygems/test_gem_commands_cert_command.rb
+++ b/test/rubygems/test_gem_commands_cert_command.rb
@@ -675,12 +675,12 @@ ERROR:  --private-key not specified and ~/.gem/gem-private_key.pem does not exis
     ]
 
     assert_equal [PUBLIC_CERT.to_pem, ALTERNATE_CERT.to_pem],
-                 @cmd.options[:add].map { |cert| cert.to_pem }
+                 @cmd.options[:add].map {|cert| cert.to_pem }
 
     assert_equal %w[nobody example], @cmd.options[:remove]
 
     assert_equal %w[nobody@example other@example],
-                 @cmd.options[:build].map { |name| name.to_s }
+                 @cmd.options[:build].map {|name| name.to_s }
 
     assert_equal ['', 'example'], @cmd.options[:list]
   end

--- a/test/rubygems/test_gem_commands_contents_command.rb
+++ b/test/rubygems/test_gem_commands_contents_command.rb
@@ -240,7 +240,7 @@ lib/foo.rb
       [RbConfig::CONFIG['bindir'], 'default_command'],
       [RbConfig::CONFIG['rubylibdir'], 'default/gem.rb'],
       [RbConfig::CONFIG['archdir'], 'default_gem.so']
-    ].sort.map{|a|File.join a}.join "\n"
+    ].sort.map{|a|File.join a }.join "\n"
 
     assert_equal expected, @ui.output.chomp
     assert_equal "", @ui.error

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -43,7 +43,7 @@ class TestGemCommandsInstallCommand < Gem::TestCase
       end
     end
 
-    assert_equal %w[a-2], @cmd.installed_specs.map { |spec| spec.full_name }
+    assert_equal %w[a-2], @cmd.installed_specs.map {|spec| spec.full_name }
   end
 
   def test_execute_explicit_version_includes_prerelease
@@ -65,7 +65,7 @@ class TestGemCommandsInstallCommand < Gem::TestCase
       end
     end
 
-    assert_equal %w[a-2.a], @cmd.installed_specs.map { |spec| spec.full_name }
+    assert_equal %w[a-2.a], @cmd.installed_specs.map {|spec| spec.full_name }
   end
 
   def test_execute_local
@@ -91,7 +91,7 @@ class TestGemCommandsInstallCommand < Gem::TestCase
       end
     end
 
-    assert_equal %w[a-2], @cmd.installed_specs.map { |spec| spec.full_name }
+    assert_equal %w[a-2], @cmd.installed_specs.map {|spec| spec.full_name }
 
     assert_match "1 gem installed", @ui.output
   end
@@ -182,7 +182,7 @@ ERROR:  Could not find a valid gem 'bar' (= 0.5) (required by 'foo' (>= 0)) in a
       end
     end
 
-    assert_equal %w[a-2 b-2.a c-3], @cmd.installed_specs.map { |spec| spec.full_name }.sort
+    assert_equal %w[a-2 b-2.a c-3], @cmd.installed_specs.map {|spec| spec.full_name }.sort
 
     assert_match "3 gems installed", @ui.output
   end
@@ -449,7 +449,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
       end
     end
 
-    assert_equal %w[a-1], @cmd.installed_specs.map { |spec| spec.full_name }
+    assert_equal %w[a-1], @cmd.installed_specs.map {|spec| spec.full_name }
   end
 
   def test_execute_prerelease_wins_over_previous_ver
@@ -467,7 +467,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
       end
     end
 
-    assert_equal %w[a-2.a], @cmd.installed_specs.map { |spec| spec.full_name }
+    assert_equal %w[a-2.a], @cmd.installed_specs.map {|spec| spec.full_name }
   end
 
   def test_execute_with_version_specified_by_colon
@@ -484,7 +484,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
       end
     end
 
-    assert_equal %w[a-1], @cmd.installed_specs.map { |spec| spec.full_name }
+    assert_equal %w[a-1], @cmd.installed_specs.map {|spec| spec.full_name }
   end
 
   def test_execute_prerelease_skipped_when_non_pre_available
@@ -502,7 +502,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
       end
     end
 
-    assert_equal %w[a-2], @cmd.installed_specs.map { |spec| spec.full_name }
+    assert_equal %w[a-2], @cmd.installed_specs.map {|spec| spec.full_name }
   end
 
   def test_execute_rdoc
@@ -627,7 +627,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
       end
     end
 
-    assert_equal %w[a-2], @cmd.installed_specs.map { |spec| spec.full_name }
+    assert_equal %w[a-2], @cmd.installed_specs.map {|spec| spec.full_name }
 
     assert_match "1 gem installed", @ui.output
   end
@@ -647,7 +647,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
       end
     end
 
-    assert_equal %w[a-2], @cmd.installed_specs.map { |spec| spec.full_name }
+    assert_equal %w[a-2], @cmd.installed_specs.map {|spec| spec.full_name }
 
     assert_match "1 gem installed", @ui.output
   end
@@ -688,7 +688,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
       end
     end
 
-    assert_equal %w[a-1], @cmd.installed_specs.map { |spec| spec.full_name }
+    assert_equal %w[a-1], @cmd.installed_specs.map {|spec| spec.full_name }
 
     assert_match "1 gem installed", @ui.output
 
@@ -722,7 +722,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
       end
     end
 
-    assert_equal %w[a-2 b-2], @cmd.installed_specs.map { |spec| spec.full_name }
+    assert_equal %w[a-2 b-2], @cmd.installed_specs.map {|spec| spec.full_name }
 
     assert_match "2 gems installed", @ui.output
   end
@@ -764,7 +764,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
       end
     end
 
-    assert_equal %w[a-1 b-1], @cmd.installed_specs.map { |spec| spec.full_name }
+    assert_equal %w[a-1 b-1], @cmd.installed_specs.map {|spec| spec.full_name }
   end
 
   def test_execute_conservative
@@ -790,7 +790,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
       end
     end
 
-    assert_equal %w[b-2], @cmd.installed_specs.map { |spec| spec.full_name }
+    assert_equal %w[b-2], @cmd.installed_specs.map {|spec| spec.full_name }
 
     assert_equal "", @ui.error
     assert_match "1 gem installed", @ui.output
@@ -812,7 +812,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
 
     @cmd.install_gem 'a', '>= 0'
 
-    assert_equal %w[a-2], @cmd.installed_specs.map { |s| s.full_name }
+    assert_equal %w[a-2], @cmd.installed_specs.map {|s| s.full_name }
 
     assert done_installing, 'documentation was not generated'
   end
@@ -826,7 +826,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
 
     @cmd.install_gem 'a', '>= 0'
 
-    assert_equal %w[a-2], @cmd.installed_specs.map { |spec| spec.full_name }
+    assert_equal %w[a-2], @cmd.installed_specs.map {|spec| spec.full_name }
   end
 
   def test_install_gem_ignore_dependencies_remote_platform_local
@@ -843,7 +843,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
 
     @cmd.install_gem 'a', '>= 0'
 
-    assert_equal %W[a-3-#{local}], @cmd.installed_specs.map { |spec| spec.full_name }
+    assert_equal %W[a-3-#{local}], @cmd.installed_specs.map {|spec| spec.full_name }
   end
 
   def test_install_gem_ignore_dependencies_specific_file
@@ -857,7 +857,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
 
     @cmd.install_gem File.join(@tempdir, spec.file_name), nil
 
-    assert_equal %w[a-2], @cmd.installed_specs.map { |s| s.full_name }
+    assert_equal %w[a-2], @cmd.installed_specs.map {|s| s.full_name }
   end
 
   def test_parses_requirement_from_gemname
@@ -927,7 +927,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
       end
     end
 
-    assert_equal %w[a-2], @cmd.installed_specs.map { |spec| spec.full_name }
+    assert_equal %w[a-2], @cmd.installed_specs.map {|spec| spec.full_name }
 
     assert_match "1 gem installed", @ui.output
 
@@ -954,7 +954,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
       end
     end
 
-    assert_equal %w[], @cmd.installed_specs.map { |spec| spec.full_name }
+    assert_equal %w[], @cmd.installed_specs.map {|spec| spec.full_name }
 
     assert_match "Using a (2)", @ui.output
     assert File.exist?("#{@gemdeps}.lock")
@@ -978,7 +978,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
       end
     end
 
-    assert_equal %w[], @cmd.installed_specs.map { |spec| spec.full_name }
+    assert_equal %w[], @cmd.installed_specs.map {|spec| spec.full_name }
 
     assert_match "Using a (2)", @ui.output
     assert !File.exist?("#{@gemdeps}.lock")
@@ -1003,7 +1003,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
       end
     end
 
-    assert_equal %w[], @cmd.installed_specs.map { |spec| spec.full_name }
+    assert_equal %w[], @cmd.installed_specs.map {|spec| spec.full_name }
 
     assert_match "Using a (1)", @ui.output
   end
@@ -1025,7 +1025,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
       end
     end
 
-    assert_equal %w[a-2], @cmd.installed_specs.map { |spec| spec.full_name }
+    assert_equal %w[a-2], @cmd.installed_specs.map {|spec| spec.full_name }
 
     assert_match "Installing a (2)", @ui.output
   end
@@ -1048,7 +1048,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
       end
     end
 
-    names = @cmd.installed_specs.map { |spec| spec.full_name }
+    names = @cmd.installed_specs.map {|spec| spec.full_name }
 
     assert_equal %w[q-1.0 r-2.0], names
 
@@ -1075,7 +1075,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
       end
     end
 
-    names = @cmd.installed_specs.map { |spec| spec.full_name }
+    names = @cmd.installed_specs.map {|spec| spec.full_name }
 
     assert_equal %w[r-2.0], names
 
@@ -1102,7 +1102,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
       end
     end
 
-    names = @cmd.installed_specs.map { |spec| spec.full_name }
+    names = @cmd.installed_specs.map {|spec| spec.full_name }
 
     assert_equal %w[q-1.0 r-2.0], names
 
@@ -1134,7 +1134,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
       end
     end
 
-    names = @cmd.installed_specs.map { |spec| spec.full_name }
+    names = @cmd.installed_specs.map {|spec| spec.full_name }
 
     assert_equal %w[q-1.0 r-2.0], names
 
@@ -1169,7 +1169,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
       end
     end
 
-    names = @cmd.installed_specs.map { |spec| spec.full_name }
+    names = @cmd.installed_specs.map {|spec| spec.full_name }
 
     assert_equal %w[r-2.0], names
 

--- a/test/rubygems/test_gem_commands_query_command.rb
+++ b/test/rubygems/test_gem_commands_query_command.rb
@@ -644,7 +644,7 @@ a (2 universal-darwin, 1 ruby x86-linux)
   end
 
   def test_execute_show_default_gems
-    spec_fetcher { |fetcher| fetcher.spec 'a', 2 }
+    spec_fetcher {|fetcher| fetcher.spec 'a', 2 }
 
     a1 = new_default_spec 'a', 1
     install_default_specs a1

--- a/test/rubygems/test_gem_commands_signin_command.rb
+++ b/test/rubygems/test_gem_commands_signin_command.rb
@@ -66,7 +66,7 @@ class TestGemCommandsSigninCommand < Gem::TestCase
   end
 
   def test_execute_with_valid_creds_set_for_default_host
-    util_capture {@cmd.execute}
+    util_capture { @cmd.execute }
 
     api_key     = 'a5fdbb6ba150cbb83aad2bb2fede64cf040453903'
     credentials = YAML.load_file Gem.configuration.credentials_path

--- a/test/rubygems/test_gem_dependency_installer.rb
+++ b/test/rubygems/test_gem_dependency_installer.rb
@@ -157,7 +157,7 @@ class TestGemDependencyInstaller < Gem::TestCase
       inst.install 'b'
     end
 
-    assert_equal %w[b-1], inst.installed_gems.map { |s| s.full_name },
+    assert_equal %w[b-1], inst.installed_gems.map {|s| s.full_name },
                  'sanity check'
 
     Dir.chdir @tempdir do
@@ -165,7 +165,7 @@ class TestGemDependencyInstaller < Gem::TestCase
       inst.install 'e'
     end
 
-    assert_equal %w[a-1 e-1], inst.installed_gems.map { |s| s.full_name }
+    assert_equal %w[a-1 e-1], inst.installed_gems.map {|s| s.full_name }
   end
 
   def test_install_cache_dir
@@ -182,7 +182,7 @@ class TestGemDependencyInstaller < Gem::TestCase
       inst.install 'b'
     end
 
-    assert_equal %w[a-1 b-1], inst.installed_gems.map { |s| s.full_name }
+    assert_equal %w[a-1 b-1], inst.installed_gems.map {|s| s.full_name }
 
     assert File.exist? File.join(@gemhome, "cache", @a1.file_name)
     assert File.exist? File.join(@gemhome, "cache", @b1.file_name)
@@ -207,7 +207,7 @@ class TestGemDependencyInstaller < Gem::TestCase
       inst.install 'a', req("= 2")
     end
 
-    assert_equal %w[a-2], inst.installed_gems.map { |s| s.full_name },
+    assert_equal %w[a-2], inst.installed_gems.map {|s| s.full_name },
                  'sanity check'
 
     FileUtils.rm File.join(@tempdir, a2.file_name)
@@ -218,7 +218,7 @@ class TestGemDependencyInstaller < Gem::TestCase
     end
 
     assert_equal %w[a-2 b-1], Gem::Specification.map(&:full_name)
-    assert_equal %w[b-1], inst.installed_gems.map { |s| s.full_name }
+    assert_equal %w[b-1], inst.installed_gems.map {|s| s.full_name }
   end
 
   # This asserts that if a gem's dependency is satisfied by an
@@ -255,7 +255,7 @@ class TestGemDependencyInstaller < Gem::TestCase
     end
 
     assert_equal %w[a-2 b-1], Gem::Specification.map(&:full_name)
-    assert_equal %w[b-1], inst.installed_gems.map { |s| s.full_name }
+    assert_equal %w[b-1], inst.installed_gems.map {|s| s.full_name }
   end
 
   def test_install_dependency
@@ -278,7 +278,7 @@ class TestGemDependencyInstaller < Gem::TestCase
       inst.install 'b'
     end
 
-    assert_equal %w[a-1 b-1], inst.installed_gems.map { |s| s.full_name }
+    assert_equal %w[a-1 b-1], inst.installed_gems.map {|s| s.full_name }
 
     assert done_installing_ran, 'post installs hook was not run'
   end
@@ -300,7 +300,7 @@ class TestGemDependencyInstaller < Gem::TestCase
       inst.install 'b'
     end
 
-    assert_equal %w[a-1 aa-1 b-1], inst.installed_gems.map { |s| s.full_name }
+    assert_equal %w[a-1 aa-1 b-1], inst.installed_gems.map {|s| s.full_name }
   end
 
   def test_install_dependency_development_deep
@@ -322,7 +322,7 @@ class TestGemDependencyInstaller < Gem::TestCase
       inst.install 'd'
     end
 
-    assert_equal %w[a-1 aa-1 b-1 c-1 d-1], inst.installed_gems.map { |s| s.full_name }
+    assert_equal %w[a-1 aa-1 b-1 c-1 d-1], inst.installed_gems.map {|s| s.full_name }
   end
 
   def test_install_dependency_development_shallow
@@ -344,7 +344,7 @@ class TestGemDependencyInstaller < Gem::TestCase
       inst.install 'd'
     end
 
-    assert_equal %w[c-1 d-1], inst.installed_gems.map { |s| s.full_name }
+    assert_equal %w[c-1 d-1], inst.installed_gems.map {|s| s.full_name }
   end
 
   def test_install_dependency_existing
@@ -360,7 +360,7 @@ class TestGemDependencyInstaller < Gem::TestCase
       inst.install 'b'
     end
 
-    assert_equal %w[b-1], inst.installed_gems.map { |s| s.full_name }
+    assert_equal %w[b-1], inst.installed_gems.map {|s| s.full_name }
   end
 
   def test_install_dependency_existing_extension
@@ -397,7 +397,7 @@ class TestGemDependencyInstaller < Gem::TestCase
       Dir.chdir pwd
     end
 
-    assert_equal %w[f-1], inst.installed_gems.map { |s| s.full_name }
+    assert_equal %w[f-1], inst.installed_gems.map {|s| s.full_name }
 
     assert_path_exists e1.extension_dir
   end
@@ -417,7 +417,7 @@ class TestGemDependencyInstaller < Gem::TestCase
       inst.install 'f'
     end
 
-    assert_equal %w[f-2], inst.installed_gems.map { |s| s.full_name }
+    assert_equal %w[f-2], inst.installed_gems.map {|s| s.full_name }
   end
 
   def test_install_local
@@ -431,7 +431,7 @@ class TestGemDependencyInstaller < Gem::TestCase
       inst.install 'a-1.gem'
     end
 
-    assert_equal %w[a-1], inst.installed_gems.map { |s| s.full_name }
+    assert_equal %w[a-1], inst.installed_gems.map {|s| s.full_name }
   end
 
   def test_install_local_prerelease
@@ -445,7 +445,7 @@ class TestGemDependencyInstaller < Gem::TestCase
       inst.install 'a-1.a.gem'
     end
 
-    assert_equal %w[a-1.a], inst.installed_gems.map { |s| s.full_name }
+    assert_equal %w[a-1.a], inst.installed_gems.map {|s| s.full_name }
   end
 
   def test_install_local_dependency
@@ -461,7 +461,7 @@ class TestGemDependencyInstaller < Gem::TestCase
       inst.install 'b-1.gem'
     end
 
-    assert_equal %w[a-1 b-1], inst.installed_gems.map { |s| s.full_name }
+    assert_equal %w[a-1 b-1], inst.installed_gems.map {|s| s.full_name }
   end
 
   def test_install_local_dependency_installed
@@ -479,7 +479,7 @@ class TestGemDependencyInstaller < Gem::TestCase
       inst.install 'b-1.gem'
     end
 
-    assert_equal %w[b-1], inst.installed_gems.map { |s| s.full_name }
+    assert_equal %w[b-1], inst.installed_gems.map {|s| s.full_name }
   end
 
   def test_install_local_subdir
@@ -492,7 +492,7 @@ class TestGemDependencyInstaller < Gem::TestCase
       inst.install 'gems/a-1.gem'
     end
 
-    assert_equal %w[a-1], inst.installed_gems.map { |s| s.full_name }
+    assert_equal %w[a-1], inst.installed_gems.map {|s| s.full_name }
   end
 
   def test_install_minimal_deps
@@ -518,7 +518,7 @@ class TestGemDependencyInstaller < Gem::TestCase
       inst.install 'b', req('= 1')
     end
 
-    assert_equal %w[b-1], inst.installed_gems.map { |s| s.full_name },
+    assert_equal %w[b-1], inst.installed_gems.map {|s| s.full_name },
                  'sanity check'
 
     Dir.chdir @tempdir do
@@ -526,7 +526,7 @@ class TestGemDependencyInstaller < Gem::TestCase
       inst.install 'e'
     end
 
-    assert_equal %w[a-1 e-1], inst.installed_gems.map { |s| s.full_name }
+    assert_equal %w[a-1 e-1], inst.installed_gems.map {|s| s.full_name }
   end
 
   def test_install_no_document
@@ -576,7 +576,7 @@ class TestGemDependencyInstaller < Gem::TestCase
       inst.install 'b'
     end
 
-    assert_equal %w[b-1], inst.installed_gems.map { |s| s.full_name }
+    assert_equal %w[b-1], inst.installed_gems.map {|s| s.full_name }
   end
 
   def test_install_build_args
@@ -606,7 +606,7 @@ class TestGemDependencyInstaller < Gem::TestCase
       inst.install 'b'
     end
 
-    assert_equal %w[b-1], inst.installed_gems.map { |s| s.full_name }
+    assert_equal %w[b-1], inst.installed_gems.map {|s| s.full_name }
   end
 
   def test_install_install_dir
@@ -627,7 +627,7 @@ class TestGemDependencyInstaller < Gem::TestCase
       inst.install 'b'
     end
 
-    assert_equal %w[a-1 b-1], inst.installed_gems.map { |s| s.full_name }
+    assert_equal %w[a-1 b-1], inst.installed_gems.map {|s| s.full_name }
 
     assert File.exist?(File.join(gemhome2, 'specifications', @a1.spec_name))
     assert File.exist?(File.join(gemhome2, 'cache', @a1.file_name))
@@ -651,7 +651,7 @@ class TestGemDependencyInstaller < Gem::TestCase
       inst.install 'b'
     end
 
-    assert_equal %w[a-1 b-1], inst.installed_gems.map { |s| s.full_name }
+    assert_equal %w[a-1 b-1], inst.installed_gems.map {|s| s.full_name }
     a1, b1 = inst.installed_gems
 
     assert_equal a1.spec_file, a1.loaded_from
@@ -675,7 +675,7 @@ class TestGemDependencyInstaller < Gem::TestCase
       inst.install 'b'
     end
 
-    assert_equal %w[a-1 b-1], inst.installed_gems.map { |s| s.full_name }
+    assert_equal %w[a-1 b-1], inst.installed_gems.map {|s| s.full_name }
   end
 
   def test_install_domain_local
@@ -694,7 +694,7 @@ class TestGemDependencyInstaller < Gem::TestCase
       assert_equal expected, e.message
     end
 
-    assert_equal [], inst.installed_gems.map { |s| s.full_name }
+    assert_equal [], inst.installed_gems.map {|s| s.full_name }
   end
 
   def test_install_domain_remote
@@ -710,7 +710,7 @@ class TestGemDependencyInstaller < Gem::TestCase
     inst = Gem::DependencyInstaller.new :domain => :remote
     inst.install 'a'
 
-    assert_equal %w[a-1], inst.installed_gems.map { |s| s.full_name }
+    assert_equal %w[a-1], inst.installed_gems.map {|s| s.full_name }
   end
 
   def test_install_dual_repository
@@ -727,7 +727,7 @@ class TestGemDependencyInstaller < Gem::TestCase
       inst.install 'a'
     end
 
-    assert_equal %w[a-1], inst.installed_gems.map { |s| s.full_name },
+    assert_equal %w[a-1], inst.installed_gems.map {|s| s.full_name },
                  'sanity check'
 
     ENV['GEM_HOME'] = @gemhome
@@ -739,7 +739,7 @@ class TestGemDependencyInstaller < Gem::TestCase
       inst.install 'b'
     end
 
-    assert_equal %w[b-1], inst.installed_gems.map { |s| s.full_name }
+    assert_equal %w[b-1], inst.installed_gems.map {|s| s.full_name }
   end
 
   def test_install_reinstall
@@ -774,7 +774,7 @@ class TestGemDependencyInstaller < Gem::TestCase
       inst.install 'a'
     end
 
-    assert_equal %w[a-1], inst.installed_gems.map { |s| s.full_name }
+    assert_equal %w[a-1], inst.installed_gems.map {|s| s.full_name }
   end
 
   def test_install_remote_dep
@@ -794,7 +794,7 @@ class TestGemDependencyInstaller < Gem::TestCase
       inst.install dep
     end
 
-    assert_equal %w[a-1], inst.installed_gems.map { |s| s.full_name }
+    assert_equal %w[a-1], inst.installed_gems.map {|s| s.full_name }
   end
 
   def test_install_remote_platform_newer
@@ -827,7 +827,7 @@ class TestGemDependencyInstaller < Gem::TestCase
     inst = Gem::DependencyInstaller.new :domain => :remote
     inst.install 'a'
 
-    assert_equal %w[a-1], inst.installed_gems.map { |s| s.full_name }
+    assert_equal %w[a-1], inst.installed_gems.map {|s| s.full_name }
   end
 
   def test_install_platform_is_ignored_when_a_file_is_specified
@@ -838,17 +838,17 @@ class TestGemDependencyInstaller < Gem::TestCase
     inst = Gem::DependencyInstaller.new :domain => :local
     inst.install a_gem
 
-    assert_equal %w[a-1-cpu-other_platform-1], inst.installed_gems.map { |s| s.full_name }
+    assert_equal %w[a-1-cpu-other_platform-1], inst.installed_gems.map {|s| s.full_name }
   end
 
   if defined? OpenSSL
     def test_install_security_policy
       util_setup_gems
 
-      data = File.open(@a1_gem, 'rb') { |f| f.read }
+      data = File.open(@a1_gem, 'rb') {|f| f.read }
       @fetcher.data['http://gems.example.com/gems/a-1.gem'] = data
 
-      data = File.open(@b1_gem, 'rb') { |f| f.read }
+      data = File.open(@b1_gem, 'rb') {|f| f.read }
       @fetcher.data['http://gems.example.com/gems/b-1.gem'] = data
 
       policy = Gem::Security::HighSecurity
@@ -861,7 +861,7 @@ class TestGemDependencyInstaller < Gem::TestCase
       assert_equal 'unsigned gems are not allowed by the High Security policy',
                    e.message
 
-      assert_equal %w[], inst.installed_gems.map { |s| s.full_name }
+      assert_equal %w[], inst.installed_gems.map {|s| s.full_name }
     end
   end
 
@@ -883,32 +883,32 @@ class TestGemDependencyInstaller < Gem::TestCase
   def test_install_version
     util_setup_d
 
-    data = File.open(@d2_gem, 'rb') { |f| f.read }
+    data = File.open(@d2_gem, 'rb') {|f| f.read }
     @fetcher.data['http://gems.example.com/gems/d-2.gem'] = data
 
-    data = File.open(@d1_gem, 'rb') { |f| f.read }
+    data = File.open(@d1_gem, 'rb') {|f| f.read }
     @fetcher.data['http://gems.example.com/gems/d-1.gem'] = data
 
     inst = Gem::DependencyInstaller.new
 
     inst.install 'd', '= 1'
 
-    assert_equal %w[d-1], inst.installed_gems.map { |s| s.full_name }
+    assert_equal %w[d-1], inst.installed_gems.map {|s| s.full_name }
   end
 
   def test_install_version_default
     util_setup_d
 
-    data = File.open(@d2_gem, 'rb') { |f| f.read }
+    data = File.open(@d2_gem, 'rb') {|f| f.read }
     @fetcher.data['http://gems.example.com/gems/d-2.gem'] = data
 
-    data = File.open(@d1_gem, 'rb') { |f| f.read }
+    data = File.open(@d1_gem, 'rb') {|f| f.read }
     @fetcher.data['http://gems.example.com/gems/d-1.gem'] = data
 
     inst = Gem::DependencyInstaller.new
     inst.install 'd'
 
-    assert_equal %w[d-2], inst.installed_gems.map { |s| s.full_name }
+    assert_equal %w[d-2], inst.installed_gems.map {|s| s.full_name }
   end
 
   def test_find_gems_gems_with_sources
@@ -972,8 +972,8 @@ class TestGemDependencyInstaller < Gem::TestCase
 
     releases = set.all_specs
 
-    assert releases.any? { |s| s.name == 'a' and s.version.to_s == '1' }
-    refute releases.any? { |s| s.name == 'a' and s.version.to_s == '1.a' }
+    assert releases.any? {|s| s.name == 'a' and s.version.to_s == '1' }
+    refute releases.any? {|s| s.name == 'a' and s.version.to_s == '1.a' }
 
     dependency.prerelease = true
 
@@ -1031,7 +1031,7 @@ class TestGemDependencyInstaller < Gem::TestCase
     inst = Gem::DependencyInstaller.new
     request_set = inst.resolve_dependencies 'b', req('>= 0')
 
-    requests = request_set.sorted_requests.map { |req| req.full_name }
+    requests = request_set.sorted_requests.map {|req| req.full_name }
 
     assert_equal %w[a-1 b-1], requests
   end
@@ -1045,7 +1045,7 @@ class TestGemDependencyInstaller < Gem::TestCase
     inst = Gem::DependencyInstaller.new :ignore_dependencies => true
     request_set = inst.resolve_dependencies 'b', req('>= 0')
 
-    requests = request_set.sorted_requests.map { |req| req.full_name }
+    requests = request_set.sorted_requests.map {|req| req.full_name }
 
     assert request_set.ignore_dependencies
 
@@ -1062,7 +1062,7 @@ class TestGemDependencyInstaller < Gem::TestCase
     inst = Gem::DependencyInstaller.new
     request_set = inst.resolve_dependencies 'a-1.gem', req('>= 0')
 
-    requests = request_set.sorted_requests.map { |req| req.full_name }
+    requests = request_set.sorted_requests.map {|req| req.full_name }
 
     assert_equal %w[a-1], requests
   end

--- a/test/rubygems/test_gem_dependency_list.rb
+++ b/test/rubygems/test_gem_dependency_list.rb
@@ -53,7 +53,7 @@ class TestGemDependencyList < Gem::TestCase
 
     order = @deplist.dependency_order
 
-    assert_equal %w[d-1 c-1 b-1 a-1], order.map { |s| s.full_name }
+    assert_equal %w[d-1 c-1 b-1 a-1], order.map {|s| s.full_name }
   end
 
   def test_dependency_order_circle
@@ -62,7 +62,7 @@ class TestGemDependencyList < Gem::TestCase
 
     order = @deplist.dependency_order
 
-    assert_equal %w[b-1 c-1 a-1], order.map { |s| s.full_name }
+    assert_equal %w[b-1 c-1 a-1], order.map {|s| s.full_name }
   end
 
   def test_dependency_order_development
@@ -80,7 +80,7 @@ class TestGemDependencyList < Gem::TestCase
 
     order = deplist.dependency_order
 
-    assert_equal %w[g-1 a-1 f-1 e-1], order.map { |s| s.full_name },
+    assert_equal %w[g-1 a-1 f-1 e-1], order.map {|s| s.full_name },
                  'development on'
 
     deplist2 = Gem::DependencyList.new
@@ -88,7 +88,7 @@ class TestGemDependencyList < Gem::TestCase
 
     order = deplist2.dependency_order
 
-    assert_equal %w[a-1 g-1 f-1 e-1], order.map { |s| s.full_name },
+    assert_equal %w[a-1 g-1 f-1 e-1], order.map {|s| s.full_name },
                  'development off'
   end
 
@@ -100,7 +100,7 @@ class TestGemDependencyList < Gem::TestCase
 
     order = @deplist.dependency_order
 
-    assert_equal %w[d-1 c-2 b-1 a-2 e-1], order.map { |s| s.full_name },
+    assert_equal %w[d-1 c-2 b-1 a-2 e-1], order.map {|s| s.full_name },
                  'deps of trimmed specs not included'
   end
 
@@ -109,7 +109,7 @@ class TestGemDependencyList < Gem::TestCase
 
     order = @deplist.dependency_order
 
-    assert_equal %w[c-2 a-1], order.map { |s| s.full_name }
+    assert_equal %w[c-2 a-1], order.map {|s| s.full_name }
   end
 
   def test_find_name

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -721,7 +721,7 @@ gem 'other', version
     installer.generate_bin
 
     default_shebang = Gem.ruby
-    shebang_line = open("#{@gemhome}/bin/executable") { |f| f.readlines.first }
+    shebang_line = open("#{@gemhome}/bin/executable") {|f| f.readlines.first }
     assert_match(/\A#!/, shebang_line)
     assert_match(/#{default_shebang}/, shebang_line)
   end
@@ -1383,7 +1383,7 @@ gem 'other', version
       installer.install
     end
 
-    expected = File.join @spec.full_require_paths.find { |path|
+    expected = File.join @spec.full_require_paths.find {|path|
       File.exist? File.join path, 'b.rb'
     }, 'b.rb'
     assert_equal expected, @spec.matches_for_glob('b.rb').first

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -443,7 +443,7 @@ class TestGemPackage < Gem::Package::TarTestCase
   end
 
   def test_raw_spec
-    data_tgz = util_tar_gz { }
+    data_tgz = util_tar_gz {}
 
     gem = util_tar do |tar|
       tar.add_file 'data.tar.gz', 0644 do |io|
@@ -490,7 +490,7 @@ class TestGemPackage < Gem::Package::TarTestCase
   end
 
   def test_extract_files_empty
-    data_tgz = util_tar_gz { }
+    data_tgz = util_tar_gz {}
 
     gem = util_tar do |tar|
       tar.add_file 'data.tar.gz', 0644 do |io|

--- a/test/rubygems/test_gem_package_tar_writer.rb
+++ b/test/rubygems/test_gem_package_tar_writer.rb
@@ -202,7 +202,7 @@ class TestGemPackageTarWriter < Gem::Package::TarTestCase
   end
 
   def test_add_file_simple_data
-    @tar_writer.add_file_simple("lib/foo/bar", 0, 10) { |f| f.write @data }
+    @tar_writer.add_file_simple("lib/foo/bar", 0, 10) {|f| f.write @data }
     @tar_writer.flush
 
     assert_equal @data + ("\0" * (512 - @data.size)),

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -712,7 +712,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
       assert_fetch_s3 url, '20f974027db2f3cd6193565327a7c73457a138efb1a63ea248d185ce6827d41b'
     end
   ensure
-    ENV.each_key {|key| ENV.delete(key) if key.start_with?('AWS')}
+    ENV.each_key {|key| ENV.delete(key) if key.start_with?('AWS') }
     Gem.configuration[:s3_source] = nil
   end
 
@@ -728,7 +728,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
       assert_fetch_s3 url, '4afc3010757f1fd143e769f1d1dabd406476a4fc7c120e9884fd02acbb8f26c9', nil, 'us-west-2'
     end
   ensure
-    ENV.each_key {|key| ENV.delete(key) if key.start_with?('AWS')}
+    ENV.each_key {|key| ENV.delete(key) if key.start_with?('AWS') }
     Gem.configuration[:s3_source] = nil
   end
 
@@ -744,7 +744,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
       assert_fetch_s3 url, '935160a427ef97e7630f799232b8f208c4a4e49aad07d0540572a2ad5fe9f93c', 'testtoken'
     end
   ensure
-    ENV.each_key {|key| ENV.delete(key) if key.start_with?('AWS')}
+    ENV.each_key {|key| ENV.delete(key) if key.start_with?('AWS') }
     Gem.configuration[:s3_source] = nil
   end
 
@@ -1102,7 +1102,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
       :Logger          => null_logger,
       :AccessLog       => null_logger
     )
-    s.mount_proc("/kill") { |req, res| s.shutdown }
+    s.mount_proc("/kill") {|req, res| s.shutdown }
     s.mount_proc("/yaml") do |req, res|
       if req["X-Captain"]
         res.body = req["X-Captain"]

--- a/test/rubygems/test_gem_request_set.rb
+++ b/test/rubygems/test_gem_request_set.rb
@@ -324,7 +324,7 @@ ruby "0"
     res = rs.resolve StaticSet.new([a, b])
     assert_equal 2, res.size
 
-    names = res.map { |s| s.full_name }.sort
+    names = res.map {|s| s.full_name }.sort
 
     assert_equal ["a-2", "b-2"], names
 
@@ -343,7 +343,7 @@ ruby "0"
     res = rs.resolve StaticSet.new([a, b, c])
     assert_equal 3, res.size
 
-    names = res.map { |s| s.full_name }.sort
+    names = res.map {|s| s.full_name }.sort
 
     assert_equal %w[a-1.b b-1.b c-1.1.b], names
   end
@@ -410,12 +410,12 @@ ruby "0"
     res = rs.resolve
     assert_equal 1, res.size
 
-    names = res.map { |s| s.full_name }.sort
+    names = res.map {|s| s.full_name }.sort
 
     assert_equal %w[a-1], names
 
     assert_equal [@DR::BestSet, @DR::GitSet, @DR::VendorSet, @DR::SourceSet],
-                 rs.sets.map { |set| set.class }
+                 rs.sets.map {|set| set.class }
   end
 
   def test_resolve_ignore_dependencies
@@ -429,7 +429,7 @@ ruby "0"
     res = rs.resolve StaticSet.new([a, b])
     assert_equal 1, res.size
 
-    names = res.map { |s| s.full_name }.sort
+    names = res.map {|s| s.full_name }.sort
 
     assert_equal %w[a-2], names
   end
@@ -474,12 +474,12 @@ ruby "0"
     res = rs.resolve
     assert_equal 2, res.size
 
-    names = res.map { |s| s.full_name }.sort
+    names = res.map {|s| s.full_name }.sort
 
     assert_equal ["a-1", "b-2"], names
 
     assert_equal [@DR::BestSet, @DR::GitSet, @DR::VendorSet, @DR::SourceSet],
-                 rs.sets.map { |set| set.class }
+                 rs.sets.map {|set| set.class }
   end
 
   def test_sorted_requests
@@ -492,7 +492,7 @@ ruby "0"
 
     rs.resolve StaticSet.new([a, b, c])
 
-    names = rs.sorted_requests.map { |s| s.full_name }
+    names = rs.sorted_requests.map {|s| s.full_name }
     assert_equal %w[c-2 b-2 a-2], names
   end
 
@@ -521,14 +521,14 @@ ruby "0"
       installers << installer
     end
 
-    assert_equal %w[b-1 a-1], reqs.map { |req| req.full_name }
+    assert_equal %w[b-1 a-1], reqs.map {|req| req.full_name }
     assert_equal %w[b-1 a-1],
-                 installers.map { |installer| installer.spec.full_name }
+                 installers.map {|installer| installer.spec.full_name }
 
     assert_path_exists File.join @gemhome, 'specifications', 'a-1.gemspec'
     assert_path_exists File.join @gemhome, 'specifications', 'b-1.gemspec'
 
-    assert_equal %w[b-1 a-1], installed.map { |s| s.full_name }
+    assert_equal %w[b-1 a-1], installed.map {|s| s.full_name }
 
     assert done_installing_ran
   end
@@ -551,7 +551,7 @@ ruby "0"
     assert_path_exists File.join @tempdir, 'specifications', 'a-1.gemspec'
     assert_path_exists File.join @tempdir, 'specifications', 'b-1.gemspec'
 
-    assert_equal %w[b-1 a-1], installed.map { |s| s.full_name }
+    assert_equal %w[b-1 a-1], installed.map {|s| s.full_name }
   end
 
   def test_install_into_development_shallow
@@ -583,7 +583,7 @@ ruby "0"
       assert_equal @tempdir, ENV['GEM_HOME']
     end
 
-    assert_equal %w[a-1 b-1], installed.map { |s| s.full_name }.sort
+    assert_equal %w[a-1 b-1], installed.map {|s| s.full_name }.sort
   end
 
   def test_sorted_requests_development_shallow
@@ -608,7 +608,7 @@ ruby "0"
 
     rs.resolve StaticSet.new [a_spec, b_spec, c_spec]
 
-    assert_equal %w[b-1 a-1], rs.sorted_requests.map { |req| req.full_name }
+    assert_equal %w[b-1 a-1], rs.sorted_requests.map {|req| req.full_name }
   end
 
   def test_tsort_each_child_development
@@ -637,7 +637,7 @@ ruby "0"
 
     deps = rs.enum_for(:tsort_each_child, a_req).to_a
 
-    assert_equal %w[b], deps.map { |dep| dep.name }
+    assert_equal %w[b], deps.map {|dep| dep.name }
   end
 
   def test_tsort_each_child_development_shallow

--- a/test/rubygems/test_gem_request_set_gem_dependency_api.rb
+++ b/test/rubygems/test_gem_request_set_gem_dependency_api.rb
@@ -50,7 +50,7 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
     end
     @gda.gemspec
     assert_equal %w[ foo bar ].sort, @set.dependencies.map(&:name).sort
-    bar = @set.dependencies.find { |d| d.name == 'bar' }
+    bar = @set.dependencies.find {|d| d.name == 'bar' }
     assert_equal [["<", Gem::Version.create('1.6.4')],
                   [">=", Gem::Version.create('1.6.0')]], bar.requirement.requirements.sort
   end
@@ -490,7 +490,7 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
       groups = @gda.send :gem_group, 'a', :group => :b, :groups => [:c, :d]
     end
 
-    assert_equal [:a, :b, :c, :d], groups.sort_by { |group| group.to_s }
+    assert_equal [:a, :b, :c, :d], groups.sort_by {|group| group.to_s }
   end
 
   def test_gemspec

--- a/test/rubygems/test_gem_request_set_lockfile_parser.rb
+++ b/test/rubygems/test_gem_request_set_lockfile_parser.rb
@@ -94,7 +94,7 @@ DEPENDENCIES
 
     assert lockfile_set, 'could not find a LockSet'
 
-    assert_equal %w[a-2], lockfile_set.specs.map { |tuple| tuple.full_name }
+    assert_equal %w[a-2], lockfile_set.specs.map {|tuple| tuple.full_name }
   end
 
   def test_parse_dependencies
@@ -124,7 +124,7 @@ DEPENDENCIES
 
     assert lockfile_set, 'could not find a LockSet'
 
-    assert_equal %w[a-2], lockfile_set.specs.map { |tuple| tuple.full_name }
+    assert_equal %w[a-2], lockfile_set.specs.map {|tuple| tuple.full_name }
   end
 
   def test_parse_DEPENDENCIES_git
@@ -218,7 +218,7 @@ DEPENDENCIES
 
     assert lockfile_set, 'found a LockSet'
 
-    assert_equal %w[a-2], lockfile_set.specs.map { |s| s.full_name }
+    assert_equal %w[a-2], lockfile_set.specs.map {|s| s.full_name }
   end
 
   def test_parse_GEM_remote_multiple
@@ -246,10 +246,10 @@ DEPENDENCIES
 
     assert lockfile_set, 'found a LockSet'
 
-    assert_equal %w[a-2], lockfile_set.specs.map { |s| s.full_name }
+    assert_equal %w[a-2], lockfile_set.specs.map {|s| s.full_name }
 
     assert_equal %w[https://gems.example/ https://other.example/],
-                 lockfile_set.specs.flat_map { |s| s.sources.map{ |src| src.uri.to_s } }
+                 lockfile_set.specs.flat_map {|s| s.sources.map{|src| src.uri.to_s } }
   end
 
   def test_parse_GIT
@@ -284,7 +284,7 @@ DEPENDENCIES
 
     assert git_set, 'could not find a GitSet'
 
-    assert_equal %w[a-2], git_set.specs.values.map { |s| s.full_name }
+    assert_equal %w[a-2], git_set.specs.values.map {|s| s.full_name }
 
     assert_equal [dep('b', '>= 3'), dep('c')],
                  git_set.specs.values.first.dependencies
@@ -438,7 +438,7 @@ DEPENDENCIES
 
     assert vendor_set, 'could not find a VendorSet'
 
-    assert_equal %w[a-1], vendor_set.specs.values.map { |s| s.full_name }
+    assert_equal %w[a-1], vendor_set.specs.values.map {|s| s.full_name }
 
     spec = vendor_set.load_spec 'a', nil, nil, nil
 
@@ -497,14 +497,14 @@ DEPENDENCIES
 
     assert lockfile_set, 'could not find a LockSet'
 
-    assert_equal %w[a-2 b-3], lockfile_set.specs.map { |tuple| tuple.full_name }
+    assert_equal %w[a-2 b-3], lockfile_set.specs.map {|tuple| tuple.full_name }
 
     expected = [
       Gem::Platform::RUBY,
       Gem::Platform.new('x86_64-linux'),
     ]
 
-    assert_equal expected, lockfile_set.specs.map { |tuple| tuple.platform }
+    assert_equal expected, lockfile_set.specs.map {|tuple| tuple.platform }
 
     spec = lockfile_set.specs.first
 

--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -390,8 +390,8 @@ class TestGemRequirement < Gem::TestCase
     r2 = req('2.0', '1.0')
     assert_equal r1.hash, r2.hash
 
-    r1 = req('1.0', '2.0').tap { |r| r.concat(['3.0']) }
-    r2 = req('3.0', '1.0').tap { |r| r.concat(['2.0']) }
+    r1 = req('1.0', '2.0').tap {|r| r.concat(['3.0']) }
+    r2 = req('3.0', '1.0').tap {|r| r.concat(['2.0']) }
     assert_equal r1.hash, r2.hash
   end
 

--- a/test/rubygems/test_gem_resolver.rb
+++ b/test/rubygems/test_gem_resolver.rb
@@ -26,10 +26,10 @@ class TestGemResolver < Gem::TestCase
   def assert_resolves_to(expected, resolver)
     actual = resolver.resolve
 
-    exp = expected.sort_by { |s| s.full_name }
-    act = actual.map { |a| a.spec.spec }.sort_by { |s| s.full_name }
+    exp = expected.sort_by {|s| s.full_name }
+    act = actual.map {|a| a.spec.spec }.sort_by {|s| s.full_name }
 
-    msg = "Set of gems was not the same: #{exp.map { |x| x.full_name}.inspect} != #{act.map { |x| x.full_name}.inspect}"
+    msg = "Set of gems was not the same: #{exp.map {|x| x.full_name }.inspect} != #{act.map {|x| x.full_name }.inspect}"
 
     assert_equal exp, act, msg
   rescue Gem::DependencyResolutionError => e
@@ -105,7 +105,7 @@ class TestGemResolver < Gem::TestCase
 
     res.requests a1, act, reqs
 
-    assert_equal ['b (= 2)'], reqs.map { |req| req.to_s }
+    assert_equal ['b (= 2)'], reqs.map {|req| req.to_s }
   end
 
   def test_requests_development
@@ -127,7 +127,7 @@ class TestGemResolver < Gem::TestCase
 
     res.requests spec, act, reqs
 
-    assert_equal ['b (= 2)'], reqs.map { |req| req.to_s }
+    assert_equal ['b (= 2)'], reqs.map {|req| req.to_s }
 
     assert spec.instance_variable_defined? :@called
   end

--- a/test/rubygems/test_gem_resolver_api_set.rb
+++ b/test/rubygems/test_gem_resolver_api_set.rb
@@ -128,7 +128,7 @@ class TestGemResolverAPISet < Gem::TestCase
 
     set.prefetch [a_dep, b_dep]
 
-    assert_equal %w[a-1], set.find_all(a_dep).map { |s| s.full_name }
+    assert_equal %w[a-1], set.find_all(a_dep).map {|s| s.full_name }
     assert_empty          set.find_all(b_dep)
   end
 

--- a/test/rubygems/test_gem_resolver_best_set.rb
+++ b/test/rubygems/test_gem_resolver_best_set.rb
@@ -30,7 +30,7 @@ class TestGemResolverBestSet < Gem::TestCase
 
     found = set.find_all req
 
-    assert_equal %w[a-1], found.map { |s| s.full_name }
+    assert_equal %w[a-1], found.map {|s| s.full_name }
   end
 
   def test_find_all_fallback
@@ -50,7 +50,7 @@ class TestGemResolverBestSet < Gem::TestCase
 
     found = set.find_all req
 
-    assert_equal %w[a-1], found.map { |s| s.full_name }
+    assert_equal %w[a-1], found.map {|s| s.full_name }
   end
 
   def test_find_all_local

--- a/test/rubygems/test_gem_resolver_index_set.rb
+++ b/test/rubygems/test_gem_resolver_index_set.rb
@@ -42,7 +42,7 @@ class TestGemResolverIndexSet < Gem::TestCase
 
     found = set.find_all req
 
-    assert_equal %w[a-1], found.map { |s| s.full_name }
+    assert_equal %w[a-1], found.map {|s| s.full_name }
   end
 
   def test_find_all_local
@@ -83,7 +83,7 @@ class TestGemResolverIndexSet < Gem::TestCase
 
     found = set.find_all req
 
-    assert_equal %w[a-1.a], found.map { |s| s.full_name }
+    assert_equal %w[a-1.a], found.map {|s| s.full_name }
   end
 
 end

--- a/test/rubygems/test_gem_resolver_installer_set.rb
+++ b/test/rubygems/test_gem_resolver_installer_set.rb
@@ -15,7 +15,7 @@ class TestGemResolverInstallerSet < Gem::TestCase
 
     set.add_always_install dep('a')
 
-    assert_equal %w[a-2], set.always_install.map { |s| s.full_name }
+    assert_equal %w[a-2], set.always_install.map {|s| s.full_name }
 
     e = assert_raises Gem::UnsatisfiableDependencyError do
       set.add_always_install dep('b')
@@ -49,7 +49,7 @@ class TestGemResolverInstallerSet < Gem::TestCase
 
     set.add_always_install dep('a')
 
-    assert_equal %w[a-1], set.always_install.map { |s| s.full_name }
+    assert_equal %w[a-1], set.always_install.map {|s| s.full_name }
   end
 
   def test_add_always_install_prerelease
@@ -62,7 +62,7 @@ class TestGemResolverInstallerSet < Gem::TestCase
 
     set.add_always_install dep('a')
 
-    assert_equal %w[a-1], set.always_install.map { |s| s.full_name }
+    assert_equal %w[a-1], set.always_install.map {|s| s.full_name }
   end
 
   def test_add_always_install_prerelease_only
@@ -93,7 +93,7 @@ class TestGemResolverInstallerSet < Gem::TestCase
 
     req = Gem::Resolver::DependencyRequest.new dep('a'), nil
 
-    assert_equal %w[a-1], set.find_all(req).map { |spec| spec.full_name }
+    assert_equal %w[a-1], set.find_all(req).map {|spec| spec.full_name }
   end
 
   def test_consider_local_eh
@@ -149,7 +149,7 @@ class TestGemResolverInstallerSet < Gem::TestCase
 
     req = Gem::Resolver::DependencyRequest.new dep('a'), nil
 
-    assert_equal %w[a-2], set.find_all(req).map { |spec| spec.full_name }
+    assert_equal %w[a-2], set.find_all(req).map {|spec| spec.full_name }
   end
 
   def test_find_all_prerelease
@@ -162,12 +162,12 @@ class TestGemResolverInstallerSet < Gem::TestCase
 
     req = Gem::Resolver::DependencyRequest.new dep('a'), nil
 
-    assert_equal %w[a-1], set.find_all(req).map { |spec| spec.full_name }
+    assert_equal %w[a-1], set.find_all(req).map {|spec| spec.full_name }
 
     req = Gem::Resolver::DependencyRequest.new dep('a', '>= 0.a'), nil
 
     assert_equal %w[a-1 a-1.a],
-                 set.find_all(req).map { |spec| spec.full_name }.sort
+                 set.find_all(req).map {|spec| spec.full_name }.sort
   end
 
   def test_load_spec

--- a/test/rubygems/test_gem_resolver_lock_set.rb
+++ b/test/rubygems/test_gem_resolver_lock_set.rb
@@ -16,7 +16,7 @@ class TestGemResolverLockSet < Gem::TestCase
     specs = @set.add 'a', '2', Gem::Platform::RUBY
     spec = specs.first
 
-    assert_equal %w[a-2], @set.specs.map { |t| t.full_name }
+    assert_equal %w[a-2], @set.specs.map {|t| t.full_name }
 
     assert_kind_of Gem::Resolver::LockSpecification, spec
 
@@ -34,11 +34,11 @@ class TestGemResolverLockSet < Gem::TestCase
 
     found = @set.find_all dep 'a'
 
-    assert_equal %w[a-2], found.map { |s| s.full_name }
+    assert_equal %w[a-2], found.map {|s| s.full_name }
 
     found = @set.find_all dep 'a', '>= 0.a'
 
-    assert_equal %w[a-1.a a-2], found.map { |s| s.full_name }
+    assert_equal %w[a-1.a a-2], found.map {|s| s.full_name }
   end
 
   def test_load_spec

--- a/test/rubygems/test_gem_security.rb
+++ b/test/rubygems/test_gem_security.rb
@@ -40,16 +40,16 @@ class TestGemSecurity < Gem::TestCase
     assert_equal    name.to_s,             cert.subject.to_s
 
     assert_equal 3, cert.extensions.length,
-                 cert.extensions.map { |e| e.to_a.first }
+                 cert.extensions.map {|e| e.to_a.first }
 
-    constraints = cert.extensions.find { |ext| ext.oid == 'basicConstraints' }
+    constraints = cert.extensions.find {|ext| ext.oid == 'basicConstraints' }
     assert_equal 'CA:FALSE', constraints.value
 
-    key_usage = cert.extensions.find { |ext| ext.oid == 'keyUsage' }
+    key_usage = cert.extensions.find {|ext| ext.oid == 'keyUsage' }
     assert_equal 'Digital Signature, Key Encipherment, Data Encipherment',
                  key_usage.value
 
-    key_ident = cert.extensions.find { |ext| ext.oid == 'subjectKeyIdentifier' }
+    key_ident = cert.extensions.find {|ext| ext.oid == 'subjectKeyIdentifier' }
     assert_equal 59, key_ident.value.length
     assert_equal '5F:43:6E:F6:9A:8E:45:25:E9:22:E3:7D:37:5E:A4:D5:36:02:85:1B',
                  key_ident.value
@@ -85,19 +85,19 @@ class TestGemSecurity < Gem::TestCase
     assert_equal    name.to_s,             cert.issuer.to_s
 
     assert_equal 5, cert.extensions.length,
-                 cert.extensions.map { |e| e.to_a.first }
+                 cert.extensions.map {|e| e.to_a.first }
 
-    constraints = cert.extensions.find { |ext| ext.oid == 'subjectAltName' }
+    constraints = cert.extensions.find {|ext| ext.oid == 'subjectAltName' }
     assert_equal 'email:nobody@example', constraints.value
 
-    constraints = cert.extensions.find { |ext| ext.oid == 'basicConstraints' }
+    constraints = cert.extensions.find {|ext| ext.oid == 'basicConstraints' }
     assert_equal 'CA:FALSE', constraints.value
 
-    key_usage = cert.extensions.find { |ext| ext.oid == 'keyUsage' }
+    key_usage = cert.extensions.find {|ext| ext.oid == 'keyUsage' }
     assert_equal 'Digital Signature, Key Encipherment, Data Encipherment',
                  key_usage.value
 
-    key_ident = cert.extensions.find { |ext| ext.oid == 'subjectKeyIdentifier' }
+    key_ident = cert.extensions.find {|ext| ext.oid == 'subjectKeyIdentifier' }
     assert_equal 59, key_ident.value.length
     assert_equal '5F:43:6E:F6:9A:8E:45:25:E9:22:E3:7D:37:5E:A4:D5:36:02:85:1B',
                  key_ident.value
@@ -188,20 +188,20 @@ class TestGemSecurity < Gem::TestCase
     assert_in_delta Time.now + 60,         signed.not_after, 10
 
     assert_equal 4, signed.extensions.length,
-                 signed.extensions.map { |e| e.to_a.first }
+                 signed.extensions.map {|e| e.to_a.first }
 
-    constraints = signed.extensions.find { |ext| ext.oid == 'issuerAltName' }
+    constraints = signed.extensions.find {|ext| ext.oid == 'issuerAltName' }
     assert_equal 'email:nobody@example', constraints.value, 'issuerAltName'
 
-    constraints = signed.extensions.find { |ext| ext.oid == 'basicConstraints' }
+    constraints = signed.extensions.find {|ext| ext.oid == 'basicConstraints' }
     assert_equal 'CA:FALSE', constraints.value
 
-    key_usage = signed.extensions.find { |ext| ext.oid == 'keyUsage' }
+    key_usage = signed.extensions.find {|ext| ext.oid == 'keyUsage' }
     assert_equal 'Digital Signature, Key Encipherment, Data Encipherment',
                  key_usage.value
 
     key_ident =
-      signed.extensions.find { |ext| ext.oid == 'subjectKeyIdentifier' }
+      signed.extensions.find {|ext| ext.oid == 'subjectKeyIdentifier' }
     assert_equal 59, key_ident.value.length
     assert_equal '5F:43:6E:F6:9A:8E:45:25:E9:22:E3:7D:37:5E:A4:D5:36:02:85:1B',
                  key_ident.value
@@ -227,23 +227,23 @@ class TestGemSecurity < Gem::TestCase
     assert_equal "sha256WithRSAEncryption", signed.signature_algorithm
 
     assert_equal 5, signed.extensions.length,
-                 signed.extensions.map { |e| e.to_a.first }
+                 signed.extensions.map {|e| e.to_a.first }
 
-    constraints = signed.extensions.find { |ext| ext.oid == 'issuerAltName' }
+    constraints = signed.extensions.find {|ext| ext.oid == 'issuerAltName' }
     assert_equal 'email:nobody@example', constraints.value, 'issuerAltName'
 
-    constraints = signed.extensions.find { |ext| ext.oid == 'subjectAltName' }
+    constraints = signed.extensions.find {|ext| ext.oid == 'subjectAltName' }
     assert_equal 'email:signee@example', constraints.value, 'subjectAltName'
 
-    constraints = signed.extensions.find { |ext| ext.oid == 'basicConstraints' }
+    constraints = signed.extensions.find {|ext| ext.oid == 'basicConstraints' }
     assert_equal 'CA:FALSE', constraints.value
 
-    key_usage = signed.extensions.find { |ext| ext.oid == 'keyUsage' }
+    key_usage = signed.extensions.find {|ext| ext.oid == 'keyUsage' }
     assert_equal 'Digital Signature, Key Encipherment, Data Encipherment',
                  key_usage.value
 
     key_ident =
-      signed.extensions.find { |ext| ext.oid == 'subjectKeyIdentifier' }
+      signed.extensions.find {|ext| ext.oid == 'subjectKeyIdentifier' }
     assert_equal 59, key_ident.value.length
     assert_equal '5F:43:6E:F6:9A:8E:45:25:E9:22:E3:7D:37:5E:A4:D5:36:02:85:1B',
                  key_ident.value

--- a/test/rubygems/test_gem_security_signer.rb
+++ b/test/rubygems/test_gem_security_signer.rb
@@ -37,8 +37,8 @@ class TestGemSecuritySigner < Gem::TestCase
   def test_initialize_cert_chain_mixed
     signer = Gem::Security::Signer.new nil, [@cert_file, CHILD_CERT]
 
-    assert_equal [PUBLIC_CERT, CHILD_CERT].map { |c| c.to_pem },
-                 signer.cert_chain.map { |c| c.to_pem }
+    assert_equal [PUBLIC_CERT, CHILD_CERT].map {|c| c.to_pem },
+                 signer.cert_chain.map {|c| c.to_pem }
   end
 
   def test_initialize_cert_chain_invalid
@@ -50,8 +50,8 @@ class TestGemSecuritySigner < Gem::TestCase
   def test_initialize_cert_chain_path
     signer = Gem::Security::Signer.new nil, [@cert_file]
 
-    assert_equal [PUBLIC_CERT].map { |c| c.to_pem },
-                 signer.cert_chain.map { |c| c.to_pem }
+    assert_equal [PUBLIC_CERT].map {|c| c.to_pem },
+                 signer.cert_chain.map {|c| c.to_pem }
   end
 
   def test_initialize_default
@@ -66,7 +66,7 @@ class TestGemSecuritySigner < Gem::TestCase
     signer = Gem::Security::Signer.new nil, nil
 
     assert_equal PRIVATE_KEY.to_pem, signer.key.to_pem
-    assert_equal [PUBLIC_CERT.to_pem], signer.cert_chain.map { |c| c.to_pem }
+    assert_equal [PUBLIC_CERT.to_pem], signer.cert_chain.map {|c| c.to_pem }
   end
 
   def test_initialize_key_path
@@ -100,7 +100,7 @@ class TestGemSecuritySigner < Gem::TestCase
     signer.load_cert_chain
 
     assert_equal [PUBLIC_CERT.to_pem, CHILD_CERT.to_pem],
-                 signer.cert_chain.map { |c| c.to_pem }
+                 signer.cert_chain.map {|c| c.to_pem }
   end
 
   def test_load_cert_chain_broken
@@ -112,7 +112,7 @@ class TestGemSecuritySigner < Gem::TestCase
     signer.load_cert_chain
 
     assert_equal [CHILD_CERT.to_pem, GRANDCHILD_CERT.to_pem],
-                 signer.cert_chain.map { |c| c.to_pem }
+                 signer.cert_chain.map {|c| c.to_pem }
   end
 
   def test_sign

--- a/test/rubygems/test_gem_source.rb
+++ b/test/rubygems/test_gem_source.rb
@@ -123,7 +123,7 @@ class TestGemSource < Gem::TestCase
   end
 
   def test_load_specs
-    released = @source.load_specs(:released).map { |spec| spec.full_name }
+    released = @source.load_specs(:released).map {|spec| spec.full_name }
     assert_equal %W[a-2 a-1 b-2], released
 
     cache_dir = File.join Gem.spec_cache_dir, 'gems.example.com%80'

--- a/test/rubygems/test_gem_source_git.rb
+++ b/test/rubygems/test_gem_source_git.rb
@@ -187,7 +187,7 @@ class TestGemSourceGit < Gem::TestCase
     source.cache
 
     e = assert_raises Gem::Exception do
-      capture_subprocess_io {source.rev_parse}
+      capture_subprocess_io { source.rev_parse }
     end
 
     assert_equal "unable to find reference nonexistent in #{@repository}",
@@ -244,7 +244,7 @@ class TestGemSourceGit < Gem::TestCase
       specs = source.specs
     end
 
-    assert_equal %w[a-1 b-1], specs.map { |spec| spec.full_name }
+    assert_equal %w[a-1 b-1], specs.map {|spec| spec.full_name }
 
     a_spec = specs.shift
 

--- a/test/rubygems/test_gem_source_local.rb
+++ b/test/rubygems/test_gem_source_local.rb
@@ -73,7 +73,7 @@ class TestGemSourceLocal < Gem::TestCase
 
     @sl.load_specs :released
 
-    inner = [@a, @ap, @b].map { |t| t.name_tuple }.inspect
+    inner = [@a, @ap, @b].map {|t| t.name_tuple }.inspect
 
     assert_equal "#<Gem::Source::Local specs: #{inner}>", @sl.inspect
   end

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -720,7 +720,7 @@ end
       version
     ]
 
-    actual_value = Gem::Specification.attribute_names.map { |a| a.to_s }.sort
+    actual_value = Gem::Specification.attribute_names.map {|a| a.to_s }.sort
 
     assert_equal expected_value, actual_value
   end
@@ -1113,13 +1113,13 @@ dependencies: []
     install_specs @a1
 
     assert_includes Gem::Specification.all_names, 'a-1'
-    assert_includes Gem::Specification.stubs.map { |s| s.full_name }, 'a-1'
+    assert_includes Gem::Specification.stubs.map {|s| s.full_name }, 'a-1'
 
     uninstall_gem @a1
     Gem::Specification.reset
 
     refute_includes Gem::Specification.all_names, 'a-1'
-    refute_includes Gem::Specification.stubs.map { |s| s.full_name }, 'a-1'
+    refute_includes Gem::Specification.stubs.map {|s| s.full_name }, 'a-1'
   end
 
   def test_self_remove_spec_removed
@@ -1134,7 +1134,7 @@ dependencies: []
     Gem::Specification.reset
 
     refute_includes Gem::Specification.all_names, 'a-1'
-    refute_includes Gem::Specification.stubs.map { |s| s.full_name }, 'a-1'
+    refute_includes Gem::Specification.stubs.map {|s| s.full_name }, 'a-1'
   end
 
   def test_self_stubs_for_lazy_loading
@@ -1146,14 +1146,14 @@ dependencies: []
     save_gemspec('a-1', '1', dir_standard_specs){|s| s.name = 'a' }
     save_gemspec('b-1', '1', dir_standard_specs){|s| s.name = 'b' }
 
-    assert_equal ['a-1'], Gem::Specification.stubs_for('a').map { |s| s.full_name }
+    assert_equal ['a-1'], Gem::Specification.stubs_for('a').map {|s| s.full_name }
     assert_equal 1, Gem::Specification.class_variable_get(:@@stubs_by_name).length
-    assert_equal ['b-1'], Gem::Specification.stubs_for('b').map { |s| s.full_name }
+    assert_equal ['b-1'], Gem::Specification.stubs_for('b').map {|s| s.full_name }
     assert_equal 2, Gem::Specification.class_variable_get(:@@stubs_by_name).length
 
     assert_equal(
-      Gem::Specification.stubs_for('a').map { |s| s.object_id },
-      Gem::Specification.stubs_for('a').map { |s| s.object_id }
+      Gem::Specification.stubs_for('a').map {|s| s.object_id },
+      Gem::Specification.stubs_for('a').map {|s| s.object_id }
     )
 
     Gem.loaded_specs.delete 'a'
@@ -1179,7 +1179,7 @@ dependencies: []
 
     #create specs
     platforms.each do |plat|
-      spec = Gem::Specification.new(gem, v) { |s| s.platform = plat }
+      spec = Gem::Specification.new(gem, v) {|s| s.platform = plat }
       File.open File.join(user_spec_dir, "#{gem}-#{v}-#{plat}.gemspec"), 'w' do |io|
         io.write spec.to_ruby
       end
@@ -1370,12 +1370,12 @@ dependencies: []
       awesome.add_dependency :gem_name
     end
 
-    assert_equal %w[true gem_name], gem.dependencies.map { |dep| dep.name }
+    assert_equal %w[true gem_name], gem.dependencies.map {|dep| dep.name }
   end
 
   def test_add_dependency_from_existing_dependency
     dep  = Gem::Dependency.new("existing_dep", Gem::Requirement.new('> 1'), :runtime)
-    spec = Gem::Specification.new { |s| s.add_dependency dep }
+    spec = Gem::Specification.new {|s| s.add_dependency dep }
     assert_equal dep, spec.dependencies.first
   end
 
@@ -1384,7 +1384,7 @@ dependencies: []
       awesome.add_development_dependency "monkey"
     end
 
-    monkey = gem.dependencies.detect { |d| d.name == "monkey" }
+    monkey = gem.dependencies.detect {|d| d.name == "monkey" }
     assert_equal(:development, monkey.type)
   end
 
@@ -1482,7 +1482,7 @@ dependencies: []
     default = new_default_spec 'default', 2
     install_default_gems default
 
-    stub = Gem::Specification.stubs.find { |s| s.name == 'default' }
+    stub = Gem::Specification.stubs.find {|s| s.name == 'default' }
     assert_predicate stub, :default_gem?
 
     stub = Gem::Specification.find_all_by_name('default').first
@@ -2330,7 +2330,7 @@ dependencies: []
 
     expected = %w[rake jabber4r pqa]
 
-    assert_equal expected, @c1.runtime_dependencies.map { |d| d.name }
+    assert_equal expected, @c1.runtime_dependencies.map {|d| d.name }
   end
 
   def test_spaceship_name
@@ -3040,8 +3040,8 @@ Please report a bug if this causes problems.
 
     specification.define_singleton_method(:find_all_by_name) do |dep_name|
       [
-        specification.new { |s| s.name = "z", s.version = Gem::Version.new("1") },
-        specification.new { |s| s.name = "z", s.version = Gem::Version.new("2") }
+        specification.new {|s| s.name = "z", s.version = Gem::Version.new("1") },
+        specification.new {|s| s.name = "z", s.version = Gem::Version.new("2") }
       ]
     end
 

--- a/test/rubygems/test_gem_util.rb
+++ b/test/rubygems/test_gem_util.rb
@@ -56,8 +56,8 @@ class TestGemUtil < Gem::TestCase
     list = [1,2,3,4,5].inject(Gem::List.new(0)) do |m,o|
       Gem::List.new o, m
     end
-    assert_equal 5, list.find { |x| x == 5 }
-    assert_equal 4, list.find { |x| x == 4 }
+    assert_equal 5, list.find {|x| x == 5 }
+    assert_equal 4, list.find {|x| x == 4 }
   end
 
   def test_glob_files_in_dir

--- a/test/rubygems/test_kernel.rb
+++ b/test/rubygems/test_kernel.rb
@@ -19,7 +19,7 @@ class TestKernel < Gem::TestCase
 
   def test_gem
     assert gem('a', '= 1'), "Should load"
-    assert $:.any? { |p| %r{a-1/lib} =~ p }
+    assert $:.any? {|p| %r{a-1/lib} =~ p }
   end
 
   def test_gem_default
@@ -49,13 +49,13 @@ class TestKernel < Gem::TestCase
   def test_gem_redundant
     assert gem('a', '= 1'), "Should load"
     refute gem('a', '= 1'), "Should not load"
-    assert_equal 1, $:.select { |p| %r{a-1/lib} =~ p }.size
+    assert_equal 1, $:.select {|p| %r{a-1/lib} =~ p }.size
   end
 
   def test_gem_overlapping
     assert gem('a', '= 1'), "Should load"
     refute gem('a', '>= 1'), "Should not load"
-    assert_equal 1, $:.select { |p| %r{a-1/lib} =~ p }.size
+    assert_equal 1, $:.select {|p| %r{a-1/lib} =~ p }.size
   end
 
   def test_gem_prerelease
@@ -82,13 +82,13 @@ class TestKernel < Gem::TestCase
     assert_match(/activated a-1/, ex.message)
     assert_equal 'a', ex.name
 
-    assert $:.any? { |p| %r{a-1/lib} =~ p }
-    refute $:.any? { |p| %r{a-2/lib} =~ p }
+    assert $:.any? {|p| %r{a-1/lib} =~ p }
+    refute $:.any? {|p| %r{a-2/lib} =~ p }
   end
 
   def test_gem_not_adding_bin
     assert gem('a', '= 1'), "Should load"
-    refute $:.any? { |p| %r{a-1/bin} =~ p }
+    refute $:.any? {|p| %r{a-1/bin} =~ p }
   end
 
   def test_gem_failing_inside_require_doesnt_cause_double_exceptions
@@ -103,7 +103,7 @@ class TestKernel < Gem::TestCase
       "./activate.rb"
     )
 
-    load_errors = output.split("\n").select { |line| line.include?("Could not find")}
+    load_errors = output.split("\n").select {|line| line.include?("Could not find") }
 
     assert_equal 1, load_errors.size
   end
@@ -113,7 +113,7 @@ class TestKernel < Gem::TestCase
     quick_gem 'bundler', '2.a'
 
     assert gem('bundler')
-    assert $:.any? { |p| %r{bundler-1/lib} =~ p }
+    assert $:.any? {|p| %r{bundler-1/lib} =~ p }
   end
 
   def test_gem_bundler_missing_bundler_version
@@ -134,7 +134,7 @@ class TestKernel < Gem::TestCase
       quick_gem 'bundler', '2.a'
 
       assert gem('bundler', '>= 0.a')
-      assert $:.any? { |p| %r{bundler-1/lib} =~ p }
+      assert $:.any? {|p| %r{bundler-1/lib} =~ p }
     end
   end
 

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -52,7 +52,7 @@ class TestGemRequire < Gem::TestCase
     foo1 = File.join lp1, 'foo.rb'
 
     FileUtils.mkdir_p lp1
-    File.open(foo1, 'w') { |f| f.write "class Object; HELLO = 'foo1' end" }
+    File.open(foo1, 'w') {|f| f.write "class Object; HELLO = 'foo1' end" }
 
     lp = $LOAD_PATH.dup
 
@@ -64,7 +64,7 @@ class TestGemRequire < Gem::TestCase
     foo2 = File.join lp2, 'foo.rb'
 
     FileUtils.mkdir_p lp2
-    File.open(foo2, 'w') { |f| f.write "class Object; HELLO = 'foo2' end" }
+    File.open(foo2, 'w') {|f| f.write "class Object; HELLO = 'foo2' end" }
 
     $LOAD_PATH.unshift lp2
     refute_require 'foo'
@@ -89,7 +89,7 @@ class TestGemRequire < Gem::TestCase
     c_rb = File.join dash_i_arg, 'b', 'c.rb'
 
     FileUtils.mkdir_p File.dirname c_rb
-    File.open(c_rb, 'w') { |f| f.write "class Object; HELLO = 'world' end" }
+    File.open(c_rb, 'w') {|f| f.write "class Object; HELLO = 'world' end" }
 
     lp = $LOAD_PATH.dup
 
@@ -131,7 +131,7 @@ class TestGemRequire < Gem::TestCase
     c_rb = File.join dash_i_arg, 'c', 'c.rb'
 
     FileUtils.mkdir_p File.dirname c_rb
-    File.open(c_rb, 'w') { |f| f.write "class Object; HELLO = 'world' end" }
+    File.open(c_rb, 'w') {|f| f.write "class Object; HELLO = 'world' end" }
 
     assert_require 'test_gem_require_a'
 
@@ -413,8 +413,8 @@ class TestGemRequire < Gem::TestCase
   def test_require_doesnt_traverse_development_dependencies
     a = util_spec("a#{$$}", "1", nil, "lib/a#{$$}.rb")
     z = util_spec("z", "1", "w" => "> 0")
-    w1 = util_spec("w", "1") { |s| s.add_development_dependency "non-existent" }
-    w2 = util_spec("w", "2") { |s| s.add_development_dependency "non-existent" }
+    w1 = util_spec("w", "1") {|s| s.add_development_dependency "non-existent" }
+    w2 = util_spec("w", "2") {|s| s.add_development_dependency "non-existent" }
 
     install_specs a, w1, w2, z
 
@@ -728,7 +728,7 @@ class TestGemRequire < Gem::TestCase
     a_rb = File.join dash_i_lib_arg, "#{name}.rb"
 
     FileUtils.mkdir_p File.dirname a_rb
-    File.open(a_rb, 'w') { |f| f.write "# #{name}.rb" }
+    File.open(a_rb, 'w') {|f| f.write "# #{name}.rb" }
 
     dash_i_lib_arg
   end

--- a/util/CL2notes
+++ b/util/CL2notes
@@ -23,7 +23,7 @@ end
 
 version = ARGV.shift || Gem::VERSION
 
-entries = Hash.new { |h,file| h[file] = [] }
+entries = Hash.new {|h,file| h[file] = [] }
 entry = []
 file = nil
 
@@ -45,7 +45,7 @@ IO.foreach 'ChangeLog' do |line|
   end
 end
 
-entries.sort_by { |file, | file }.each do |file, file_entries|
+entries.sort_by {|file, | file }.each do |file, file_entries|
   puts "* #{file}"
   file_entries.each do |file_entry|
     file_entry = format_text file_entry, 74, 4

--- a/util/update_bundled_ca_certificates.rb
+++ b/util/update_bundled_ca_certificates.rb
@@ -66,7 +66,7 @@ def test_certificates(certificates, uri)
       if match
         $needed_combinations << match
         puts
-        puts match.map { |certificate| certificate.subject }
+        puts match.map {|certificate| certificate.subject }
         return
       else
         print '.'

--- a/util/update_changelog.rb
+++ b/util/update_changelog.rb
@@ -49,7 +49,7 @@ history = File.read(File.expand_path('../../History.txt', __FILE__))
 
 File.open(File.expand_path('../../ChangeLog', __FILE__), 'w') do |changelog|
   commits = `git log --oneline v#{from}..#{branch}`.split("\n")
-  prs = commits.reverse_each.map { |c| c =~ /(Auto merge of|Merge pull request|Merge) #(\d+)/ && $2 }.compact.uniq.sort!
+  prs = commits.reverse_each.map {|c| c =~ /(Auto merge of|Merge pull request|Merge) #(\d+)/ && $2 }.compact.uniq.sort!
   prs.each do |pr|
     next if history =~ /Pull\srequest\s##{pr}/m
     details = github_api "/repos/rubygems/rubygems/pulls/#{pr}"


### PR DESCRIPTION
# Description:

In #3704 @hsbt refused to switch to using a space before block parameters in bundler's code base.

I'm sad about that, but I still prefer any style that's consistent over my own preferences.

So, instead of changing `bundler` to use the style that I like, I propose to change `rubygems` to use the style that I don't like, so that at least we have a consistent code base in this regard.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
