### PR TITLE
Fix incorrect `rake check_manifest`

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -138,6 +138,7 @@ bundler/lib/bundler/templates/gems.rb
 bundler/lib/bundler/templates/newgem/.circleci/config.yml.tt
 bundler/lib/bundler/templates/newgem/.github/workflows/main.yml.tt
 bundler/lib/bundler/templates/newgem/.gitlab-ci.yml.tt
+bundler/lib/bundler/templates/newgem/.travis.yml.tt
 bundler/lib/bundler/templates/newgem/CODE_OF_CONDUCT.md.tt
 bundler/lib/bundler/templates/newgem/Gemfile.tt
 bundler/lib/bundler/templates/newgem/LICENSE.txt.tt
@@ -160,7 +161,6 @@ bundler/lib/bundler/templates/newgem/test/minitest/newgem_test.rb.tt
 bundler/lib/bundler/templates/newgem/test/minitest/test_helper.rb.tt
 bundler/lib/bundler/templates/newgem/test/test-unit/newgem_test.rb.tt
 bundler/lib/bundler/templates/newgem/test/test-unit/test_helper.rb.tt
-bundler/lib/bundler/templates/newgem/.travis.yml.tt
 bundler/lib/bundler/ui.rb
 bundler/lib/bundler/ui/rg_proxy.rb
 bundler/lib/bundler/ui/shell.rb

--- a/Rakefile
+++ b/Rakefile
@@ -397,7 +397,7 @@ module Rubygems
         files << path
       end
 
-      files
+      files.sort
     end
 
   end
@@ -405,12 +405,12 @@ end
 
 desc "Update the manifest to reflect what's on disk"
 task :update_manifest do
-  File.open('Manifest.txt', 'w') {|f| f.puts(Rubygems::ProjectFiles.all.sort) }
+  File.open('Manifest.txt', 'w') {|f| f.puts(Rubygems::ProjectFiles.all) }
 end
 
 desc "Check the manifest is up to date"
 task :check_manifest do
-  if File.read("Manifest.txt").split.sort != Rubygems::ProjectFiles.all.sort
+  if File.read("Manifest.txt").split != Rubygems::ProjectFiles.all
     abort "Manifest is out of date. Run `rake update_manifest` to sync it"
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Our `rake check_manifest` task was failing to detect that the manifest was not properly sorted.

## What is your fix for the problem, implemented in this PR?

My fix is to make sure `rake check_manifest` always detects unsorted manifests properly and to fix the current manifest ordering.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
