### PR TITLE
Make sure `tmp` folder exists before calling `Dir.tmpdir`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,5 @@
 /misc
 /notes.txt
 /pkg
-/tmp/*
-!/tmp/.keep
+/tmp
 /coverage

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -702,7 +702,6 @@ test/rubygems/test_remote_fetch_error.rb
 test/rubygems/test_require.rb
 test/rubygems/wrong_key_cert.pem
 test/rubygems/wrong_key_cert_32.pem
-tmp/.keep
 util/CL2notes
 util/bisect
 util/cops/deprecations.rb

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -298,11 +298,14 @@ class Gem::TestCase < Minitest::Test
     super
 
     @orig_env = ENV.to_hash
+    @tmp = File.expand_path("tmp")
+
+    Dir.mkdir @tmp
 
     ENV['GEM_VENDOR'] = nil
     ENV['GEMRC'] = nil
     ENV['SOURCE_DATE_EPOCH'] = nil
-    ENV["TMPDIR"] = File.expand_path("tmp")
+    ENV["TMPDIR"] = @tmp
 
     @current_dir = Dir.pwd
     @fetcher     = nil
@@ -319,7 +322,7 @@ class Gem::TestCase < Minitest::Test
     @tempdir = File.join(tmpdir, "test_rubygems_#{$$}")
     @tempdir.tap(&Gem::UNTAINT)
 
-    FileUtils.mkdir_p @tempdir
+    FileUtils.mkdir @tempdir
 
     @orig_SYSTEM_WIDE_CONFIG_FILE = Gem::ConfigFile::SYSTEM_WIDE_CONFIG_FILE
     Gem::ConfigFile.send :remove_const, :SYSTEM_WIDE_CONFIG_FILE
@@ -445,7 +448,7 @@ class Gem::TestCase < Minitest::Test
 
     Dir.chdir @current_dir
 
-    FileUtils.rm_rf @tempdir
+    FileUtils.rm_rf @tmp
 
     ENV.replace(@orig_env)
 


### PR DESCRIPTION
# Description:

This was guaranteed by our gitignore setup where a `tmp/` folder is always present right after cloning the repository, but was not guaranteed under the ruby-core setup.

This alternative approach should always work.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
