### PR TITLE
Remove encoding magic comments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -101,6 +101,11 @@ Performance/StartWith:
 Performance/StringReplacement:
   Enabled: true
 
+Style/Encoding:
+  Enabled: true
+  Exclude:
+    - test/rubygems/specifications/foo-0.0.1-x86-mswin32.gemspec
+
 Style/MethodCallWithoutArgsParentheses:
   Enabled: true
 

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # frozen_string_literal: true
 #--
 # Copyright (C) 2004 Mauricio Julio Fernández Pradier

--- a/lib/rubygems/package/tar_header.rb
+++ b/lib/rubygems/package/tar_header.rb
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # frozen_string_literal: true
 #--
 # Copyright (C) 2004 Mauricio Julio Fernández Pradier

--- a/lib/rubygems/package/tar_reader.rb
+++ b/lib/rubygems/package/tar_reader.rb
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # frozen_string_literal: true
 #--
 # Copyright (C) 2004 Mauricio Julio Fernández Pradier

--- a/lib/rubygems/package/tar_reader/entry.rb
+++ b/lib/rubygems/package/tar_reader/entry.rb
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # frozen_string_literal: true
 #++
 # Copyright (C) 2004 Mauricio Julio Fernández Pradier

--- a/lib/rubygems/package/tar_writer.rb
+++ b/lib/rubygems/package/tar_writer.rb
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # frozen_string_literal: true
 #--
 # Copyright (C) 2004 Mauricio Julio Fernández Pradier

--- a/test/rubygems/specifications/bar-0.0.2.gemspec
+++ b/test/rubygems/specifications/bar-0.0.2.gemspec
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 Gem::Specification.new do |s|
   s.name          = "bar"
   s.version       = "0.0.2"

--- a/test/rubygems/specifications/rubyforge-0.0.1.gemspec
+++ b/test/rubygems/specifications/rubyforge-0.0.1.gemspec
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 Gem::Specification.new do |s|
   s.name              = "rubyforge"
   s.version           = "0.0.1"

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -1,4 +1,3 @@
-# coding: UTF-8
 # frozen_string_literal: true
 
 require 'rubygems/test_case'

--- a/test/rubygems/test_gem_ext_ext_conf_builder.rb
+++ b/test/rubygems/test_gem_ext_ext_conf_builder.rb
@@ -1,4 +1,3 @@
-# coding: UTF-8
 # frozen_string_literal: true
 
 require 'rubygems/test_case'

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require 'rubygems/package/tar_test_case'

--- a/test/rubygems/test_gem_security_policy.rb
+++ b/test/rubygems/test_gem_security_policy.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require 'rubygems/test_case'


### PR DESCRIPTION
# Description:

This PR removes magic encoding comments from rubygems code base in another small step to reconcile bundler & rubygems code styles.

These comments are no longer needed since ruby 2.0.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
