### PR TITLE
Deprecate `Gem::Util.silent_system`

### DIFF
--- a/lib/rubygems/source/git.rb
+++ b/lib/rubygems/source/git.rb
@@ -103,9 +103,11 @@ class Gem::Source::Git < Gem::Source
 
       success = system @git, 'reset', '--quiet', '--hard', rev_parse
 
-      success &&=
-        Gem::Util.silent_system @git, 'submodule', 'update',
-               '--quiet', '--init', '--recursive' if @need_submodules
+      if @need_submodules
+        _, status = Open3.capture2e(@git, 'submodule', 'update', '--quiet', '--init', '--recursive')
+
+        success &&= status.success?
+      end
 
       success
     end

--- a/lib/rubygems/util.rb
+++ b/lib/rubygems/util.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
+require 'rubygems/deprecate'
+
 ##
 # This module contains various utility methods as module methods.
 
 module Gem::Util
+
   ##
   # Zlib::GzipReader wrapper that unzips +data+.
 
@@ -65,6 +68,14 @@ module Gem::Util
       cmds = command.dup
     end
     system(*(cmds << opt))
+  end
+
+  class << self
+
+    extend Gem::Deprecate
+
+    rubygems_deprecate :silent_system
+
   end
 
   ##

--- a/test/rubygems/test_gem_source_git.rb
+++ b/test/rubygems/test_gem_source_git.rb
@@ -69,8 +69,9 @@ class TestGemSourceGit < Gem::TestCase
     git_gem 'b'
 
     Dir.chdir 'git/a' do
-      Gem::Util.silent_system @git, 'submodule', '--quiet',
-                              'add', File.expand_path('../b'), 'b'
+      output, status = Open3.capture2e(@git, 'submodule', '--quiet', 'add', File.expand_path('../b'), 'b')
+      assert status.success?, output
+
       system @git, 'commit', '--quiet', '-m', 'add submodule b'
     end
 

--- a/test/rubygems/test_gem_util.rb
+++ b/test/rubygems/test_gem_util.rb
@@ -15,8 +15,10 @@ class TestGemUtil < Gem::TestCase
 
   def test_silent_system
     skip if Gem.java_platform?
-    assert_silent do
-      Gem::Util.silent_system(*ruby_with_rubygems_in_load_path, '-e', 'puts "hello"; warn "hello"')
+    Gem::Deprecate.skip_during do
+      assert_silent do
+        Gem::Util.silent_system(*ruby_with_rubygems_in_load_path, '-e', 'puts "hello"; warn "hello"')
+      end
     end
   end
 


### PR DESCRIPTION
# Description:

My motivation for this PR was to get rid of some warnings when running rubygems tests under jruby:

#### Before

```
$ rake
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.jruby.ext.openssl.SecurityHelper (file:/home/deivid/.rbenv/versions/jruby-9.2.11.1/lib/ruby/stdlib/jopenssl.jar) to field java.security.MessageDigest.provider
WARNING: Please consider reporting this to the maintainers of org.jruby.ext.openssl.SecurityHelper
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.jruby.ext.openssl.SecurityHelper (file:/home/deivid/.rbenv/versions/jruby-9.2.11.1/lib/ruby/stdlib/jopenssl.jar) to field java.security.MessageDigest.provider
WARNING: Please consider reporting this to the maintainers of org.jruby.ext.openssl.SecurityHelper
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
Skipping `gem cert` tests on jruby.
Skipping Gem::Security tests on jruby.
Run options: --seed 39359

# Running:

.........................................................................../home/deivid/Code/rubygems/rubygems/lib/rubygems/util.rb:67: warning: system does not support options in JRuby yet: {:out=>"/dev/null", :err=>[:child, :out]}
/home/deivid/Code/rubygems/rubygems/lib/rubygems/util.rb:67: warning: system does not support options in JRuby yet: {:out=>"/dev/null", :err=>[:child, :out]}
..S........S..........S.....................S.........................................................................................................S...SS...................................S.....S..S......................SS......S..S...............................................................................................................................................S....S...................................SS...........................S................S..........S...............................................S...............................S.......S............................................................................................................................................SSS.................................................................................................................................................................................................S...S...S......................................................................S....S....................S............^[[B...................................................................................................................................................................................................S....................................................................................................................................................................................................................S........S.....................................................................................................................................................................................S..................................................S.........S.......................................S...S..................................................................S...........................................................S...............................................................................................................

Finished in 225.419934s, 9.0365 runs/s, 27.4643 assertions/s.
2037 runs, 6191 assertions, 0 failures, 0 errors, 43 skips

You have skipped tests. Run with --verbose for details.
Coverage report generated for Unit Tests to /home/deivid/Code/rubygems/rubygems/coverage. 7585 / 9216 LOC (82.3%) covered.
```

#### After

```
$ rake
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.jruby.ext.openssl.SecurityHelper (file:/home/deivid/.rbenv/versions/jruby-9.2.11.1/lib/ruby/stdlib/jopenssl.jar) to field java.security.MessageDigest.provider
WARNING: Please consider reporting this to the maintainers of org.jruby.ext.openssl.SecurityHelper
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.jruby.ext.openssl.SecurityHelper (file:/home/deivid/.rbenv/versions/jruby-9.2.11.1/lib/ruby/stdlib/jopenssl.jar) to field java.security.MessageDigest.provider
WARNING: Please consider reporting this to the maintainers of org.jruby.ext.openssl.SecurityHelper
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
Skipping `gem cert` tests on jruby.
Skipping Gem::Security tests on jruby.
Run options: --seed 26330

# Running:

.............................................................................................S..S..........................................................................................................................S......................................................................................................................S............S.....................................................S..............S.................S............................................................................S....S..S.........S...S...........................SS..............................................................................S..............S......................................................................................S.................S.................S.S.S.................................S.........S......................................S..............................S..S................................................S............S..S.....................................................S..S.S.......................................................................................................................................................................................................................................................................................................................................SS....S......................................................................................................................................................................................S.........S...............................................................................................................................................................................................................................................S.....S.................................S.S...S...................................................................................................................................................................................................

Finished in 239.191748s, 8.5162 runs/s, 25.8872 assertions/s.
2037 runs, 6192 assertions, 0 failures, 0 errors, 43 skips

You have skipped tests. Run with --verbose for details.
Coverage report generated for Unit Tests to /home/deivid/Code/rubygems/rubygems/coverage. 7585 / 9217 LOC (82.29%) covered.
```

But then I thought that we can probably get rid of this helper, since there's better tools for the job in the standard library.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
