### PR TITLE
Better rubocop setup

### DIFF
--- a/.rubocop_bundler.yml
+++ b/.rubocop_bundler.yml
@@ -3,9 +3,18 @@ require: rubocop-performance
 AllCops:
   DisabledByDefault: true
   TargetRubyVersion: 2.3
+  Include:
+    - bundler/**/*.rb
+    - bundler/**/*.gemspec
+    - bundler/**/Rakefile
+    - bundler/**/Gemfile
+    - bundler/**/*.rake
   Exclude:
-    - tmp/**/*
-    - lib/bundler/vendor/**/*
+    - bin/*
+    - pkg/**/*
+    - util/**/*
+    - bundler/tmp/**/*
+    - bundler/lib/bundler/vendor/**/*
   DisplayCopNames: true
   CacheRootDirectory: tmp/rubocop
   MaxFilesInCache: 5000
@@ -163,7 +172,7 @@ Lint/SafeNavigationConsistency:
 Lint/ScriptPermission:
   Enabled: true
   Exclude:
-    - 'lib/bundler/templates/Executable'
+    - 'bundler/lib/bundler/templates/Executable'
 
 Lint/ShadowedArgument:
   Enabled: true
@@ -409,7 +418,7 @@ Naming/ConstantName:
 Naming/FileName:
   Enabled: true
   Exclude:
-    - 'spec/realworld/fixtures/warbler/bin/warbler-example.rb'
+    - 'bundler/spec/realworld/fixtures/warbler/bin/warbler-example.rb'
 
 Naming/HeredocDelimiterCase:
   Enabled: true

--- a/bundler/bin/rubocop
+++ b/bundler/bin/rubocop
@@ -1,7 +1,11 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-ARGV.replace(%w[--config bundler/.rubocop.yml] + ARGV + %w[bundler])
+new_argv = ARGV.map do |argv|
+  File.exist?(argv) ? File.expand_path(argv) : argv
+end
+
+ARGV.replace(%w[--config .rubocop_bundler.yml] + new_argv)
 
 repo_root = File.expand_path("../..", __dir__)
 

--- a/bundler/bin/rubocop
+++ b/bundler/bin/rubocop
@@ -1,5 +1,10 @@
-#!/usr/bin/env bash
+#!/usr/bin/env ruby
+# frozen_string_literal: true
 
-cd "${BASH_SOURCE[0]%/*}/../.." || exit 1
+ARGV.replace(%w[--config bundler/.rubocop.yml] + ARGV + %w[bundler])
 
-util/rubocop --config bundler/.rubocop.yml "$@" bundler
+repo_root = File.expand_path("../..", __dir__)
+
+Dir.chdir(repo_root)
+
+load File.expand_path("util/rubocop", repo_root)


### PR DESCRIPTION
# Description:

Our rubocop binstub for `bundler` was a bit broken. For example, running `bin/rubocop lib/bundler.rb` would lead to:

```
$ bin/rubocop  lib/bundler.rb 
Inspecting 376 files
.

0 files inspected, no offenses detected
Error: No such file or directory: /home/deivid/Code/rubygems/rubygems/lib/bundler.rb
```

This PR fixes that issue and as a result unbreaks my editor integration with rubocop, which was broken due to this issue.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
