### PR TITLE
Restore sequential install by default on Windows

### DIFF
--- a/bundler/lib/bundler/installer.rb
+++ b/bundler/lib/bundler/installer.rb
@@ -202,8 +202,6 @@ module Bundler
         return jobs
       end
 
-      return 1 unless can_install_in_parallel?
-
       Bundler.settings[:jobs] || processor_count
     end
 
@@ -261,10 +259,6 @@ module Bundler
             ", so the dependency is being ignored"
         end
       end
-    end
-
-    def can_install_in_parallel?
-      true
     end
 
     def install_in_parallel(size, standalone, force = false)

--- a/bundler/lib/bundler/installer.rb
+++ b/bundler/lib/bundler/installer.rb
@@ -202,7 +202,14 @@ module Bundler
         return jobs
       end
 
-      Bundler.settings[:jobs] || processor_count
+      if jobs = Bundler.settings[:jobs]
+        return jobs
+      end
+
+      # Parallelization has some issues on Windows, so it's not yet the default
+      return 1 if Gem.win_platform?
+
+      processor_count
     end
 
     def processor_count


### PR DESCRIPTION
# Description:

Since we [enabled parallel installation by default](https://github.com/rubygems/rubygems/pull/3393), we've fixed all the issues related to it that have come up, except for [a Windows issue](https://github.com/rubygems/rubygems/issues/3448) that we haven't yet figured out. This issue is hit by our specs on a daily basis and there's no reason to believe that it won't be hit by end users in a similar way.

So, both to stop the testing flakyness and to prevent regressions in the default behavior on Windows, I'd rather leave the default as it was before on Windows for now.

Closes https://github.com/rubygems/rubygems/issues/3448.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).