### PR TITLE
Add Gem.disable_system_update_message to disable gem update --system if needed.

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1189,6 +1189,12 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   class << self
 
     ##
+    # RubyGems distributors (like operating system package managers) can
+    # disable RubyGems update by setting this to error message printed to
+    # end-users on gem update --system instead of actual update.
+    attr_accessor :disable_system_update_message
+
+    ##
     # Hash of loaded Gem::Specification keyed by name
 
     attr_reader :loaded_specs

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -264,7 +264,7 @@ command to remove old versions.
   def update_rubygems
     if Gem.disable_system_update_message
       alert_error Gem.disable_system_update_message
-      return
+      terminate_interaction 1
     end
 
     check_update_arguments

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -262,6 +262,11 @@ command to remove old versions.
   # Update RubyGems software to the latest version.
 
   def update_rubygems
+    if Gem.disable_system_update_message
+      alert_error Gem.disable_system_update_message
+      return
+    end
+
     check_update_arguments
 
     version, requirement = rubygems_target_version

--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -238,6 +238,23 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
                  @ui.error
   end
 
+  def test_execute_system_with_disabled_update
+    old_disable_system_update_message = Gem.disable_system_update_message
+    Gem.disable_system_update_message = "Please use package manager instead."
+
+    @cmd.options[:args] = []
+    @cmd.options[:system] = true
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    assert_empty @ui.output
+    assert_equal "ERROR:  Please use package manager instead.\n", @ui.error
+  ensure
+    Gem.disable_system_update_message = old_disable_system_update_message
+  end
+
   # before:
   #   a1 -> c1.2
   # after:

--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -245,8 +245,10 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
     @cmd.options[:args] = []
     @cmd.options[:system] = true
 
-    use_ui @ui do
-      @cmd.execute
+    assert_raises Gem::MockGemUi::TermError do
+      use_ui @ui do
+        @cmd.execute
+      end
     end
 
     assert_empty @ui.output


### PR DESCRIPTION
This is initial take on possibility to disable `gem update --system` useful for distribution maintainers.

For Debian, this can be set at https://salsa.debian.org/ruby-team/rubygems-integration/-/blob/39d3a082f568ec0b6c9acd10e54a4a31a08bd8b5/lib/rubygems/defaults/operating_system.rb#L56. End-users can disable this by providing `DEBIAN_DISABLE_RUBYGEMS_INTEGRATION` as they can do that already for the rest of integration patches.

For Fedora, this can be set at https://src.fedoraproject.org/rpms/rubygems/blob/master/f/operating_system.rb. Not sure if any env variable is needed to make users able to disable this.

@terceiro (Debian ruby maintainer) @voxik (Fedora ruby maintainer), would this be useful for you :question: 

### example

```ruby
# operating_system.rb
if Gem.respond_to?(:disable_system_update_message=)
  Gem.disable_system_update_message = 'RubyGems is updated by system package manager. Please use "abc update rubygems" instead.'
end
```

```
[retro@retro  rubygems (disable-update *%=)]❤ gem update --system
ERROR:  RubyGems is updated by system package manager. Please use "abc update rubygems" instead.
```