### PR TITLE
Make sure to pass URI's to `:git`

### DIFF
--- a/bundler/spec/update/git_spec.rb
+++ b/bundler/spec/update/git_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "bundle update" do
       end
 
       install_gemfile <<-G
-        gem "rails", :git => "#{lib_path("rails")}"
+        gem "rails", :git => "#{file_uri_for(lib_path("rails"))}"
       G
 
       bundle "update rails"
@@ -61,7 +61,7 @@ RSpec.describe "bundle update" do
       end
 
       install_gemfile <<-G
-        gem "foo", :git => "#{lib_path("foo")}"
+        gem "foo", :git => "#{file_uri_for(lib_path("foo"))}"
         gem "bar"
       G
 
@@ -79,17 +79,17 @@ RSpec.describe "bundle update" do
       build_git "foo", :path => lib_path("foo_two")
 
       install_gemfile <<-G
-        gem "foo", "1.0", :git => "#{lib_path("foo_one")}"
+        gem "foo", "1.0", :git => "#{file_uri_for(lib_path("foo_one"))}"
       G
 
       FileUtils.rm_rf lib_path("foo_one")
 
       install_gemfile <<-G
-        gem "foo", "1.0", :git => "#{lib_path("foo_two")}"
+        gem "foo", "1.0", :git => "#{file_uri_for(lib_path("foo_two"))}"
       G
 
       expect(err).to be_empty
-      expect(out).to include("Fetching #{lib_path}/foo_two")
+      expect(out).to include("Fetching #{file_uri_for(lib_path)}/foo_two")
       expect(out).to include("Bundle complete!")
     end
 
@@ -184,7 +184,7 @@ RSpec.describe "bundle update" do
       build_git "foo", "1.0"
 
       install_gemfile <<-G
-        gem "foo", :git => "#{lib_path("foo-1.0")}"
+        gem "foo", :git => "#{file_uri_for(lib_path("foo-1.0"))}"
       G
 
       lib_path("foo-1.0").join(".git").rmtree
@@ -203,7 +203,7 @@ RSpec.describe "bundle update" do
 
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
-        gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
+        gem "rack", :git => "#{file_uri_for(lib_path("rack-0.8"))}", :branch => "master"
       G
 
       bundle %(config set local.rack #{lib_path("local-rack")})
@@ -215,13 +215,13 @@ RSpec.describe "bundle update" do
       build_git "rails", "2.3.2", :path => lib_path("rails")
 
       install_gemfile <<-G
-        gem "rails", :git => "#{lib_path("rails")}"
+        gem "rails", :git => "#{file_uri_for(lib_path("rails"))}"
       G
 
       update_git "rails", "3.0", :path => lib_path("rails"), :gemspec => true
 
       bundle "update", :all => true
-      expect(out).to include("Using rails 3.0 (was 2.3.2) from #{lib_path("rails")} (at master@#{revision_for(lib_path("rails"))[0..6]})")
+      expect(out).to include("Using rails 3.0 (was 2.3.2) from #{file_uri_for(lib_path("rails"))} (at master@#{revision_for(lib_path("rails"))[0..6]})")
     end
   end
 


### PR DESCRIPTION
# Description:

This PR includes the same set of changes as in https://github.com/rubygems/bundler/commit/0745c69dc175927e621b2cfdc78849b3417b74eb, but for `spec/update/git_spec.rb`.

The idea is that passing paths to `:git` should work in most cases, but on Windows the drive letter is interpreted as the scheme and causes some case mismatches because

```
irb> URI.parse("E:").to_s
=> "e:"
```


## What was the end-user or developer problem that led to this PR?

This problem caused some spec failures on Windows: https://github.com/rubygems/rubygems/pull/3132/checks?check_run_id=769928668.

## What is your fix for the problem, implemented in this PR?

The fix is to pass `file:///` URI's whenever we pass local git repositories to Gemfile `:git` DSL.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
