### PR TITLE
Allow tests without rake

### DIFF
--- a/lib/rubygems/package_task.rb
+++ b/lib/rubygems/package_task.rb
@@ -22,11 +22,6 @@
 
 require 'rubygems'
 require 'rubygems/package'
-begin
-  gem 'rake'
-rescue Gem::LoadError
-end
-
 require 'rake/packagetask'
 
 ##

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -1534,24 +1534,4 @@ Also, a list:
 
 end
 
-# require dependencies that are not discoverable once GEM_HOME and GEM_PATH
-# are wiped
-begin
-  gem 'rake'
-rescue Gem::LoadError
-end
-
-begin
-  require 'rake/packagetask'
-rescue LoadError
-end
-
-begin
-  gem 'rdoc'
-  require 'rdoc'
-
-  require 'rubygems/rdoc'
-rescue LoadError, Gem::LoadError
-end
-
 require 'rubygems/test_utilities'

--- a/test/rubygems/test_gem_package_task.rb
+++ b/test/rubygems/test_gem_package_task.rb
@@ -1,7 +1,16 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
 require 'rubygems'
-require 'rubygems/package_task'
+
+begin
+  require 'rubygems/package_task'
+rescue LoadError => e
+  raise unless e.path == 'rake/packagetask'
+end
+
+unless defined?(Rake::PackageTask)
+  warn 'Skipping Gem::PackageTask tests.  rake not found.'
+end
 
 class TestGemPackageTask < Gem::TestCase
 
@@ -107,4 +116,4 @@ class TestGemPackageTask < Gem::TestCase
     assert_equal 'pkg/nokogiri-1.5.0-java', pkg.package_dir_path
   end
 
-end
+end if defined?(Rake::PackageTask)

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -5,8 +5,7 @@ require 'webrick'
 begin
   require 'webrick/https'
 rescue LoadError => e
-  raise unless (e.respond_to?(:path) && e.path == 'openssl') ||
-               e.message =~ / -- openssl$/
+  raise unless e.path == 'openssl'
 end
 
 unless defined?(OpenSSL::SSL)


### PR DESCRIPTION
# Description:

While integrating the latest rubygems HEAD commits into ruby-core I noticed an error like the following:

```
/home/runner/work/ruby/ruby/src/test/rubygems/test_gem_package_task.rb: cannot load such file -- rake/packagetask (Test::Unit::ProxyError)
```

I believe this is because ruby-core doesn't run tests through `rake` but directly through `ruby`, and the environment where tests run usually does not even have `rake` installed.

So I changed test code to only `warn` about `rake` not being installed in this case, just like we do for `openssl` in `test_gem_remote_fetcher` tests.

Also took the chance to simplify a bunch of other related stuff.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
