### PR TITLE
Ship default .rubocop.yml

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -154,6 +154,7 @@ bundler/lib/bundler/templates/newgem/lib/newgem.rb.tt
 bundler/lib/bundler/templates/newgem/lib/newgem/version.rb.tt
 bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
 bundler/lib/bundler/templates/newgem/rspec.tt
+bundler/lib/bundler/templates/newgem/rubocop.yml.tt
 bundler/lib/bundler/templates/newgem/spec/newgem_spec.rb.tt
 bundler/lib/bundler/templates/newgem/spec/spec_helper.rb.tt
 bundler/lib/bundler/templates/newgem/test/minitest/newgem_test.rb.tt

--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -79,7 +79,6 @@ module Bundler
       ]
 
       templates.merge!("gitignore.tt" => ".gitignore") if Bundler.git_present?
-      templates.merge!("rubocop.yml.tt" => ".rubocop.yml")
 
       if test_framework = ask_and_set_test_framework
         config[:test] = test_framework
@@ -149,6 +148,7 @@ module Bundler
         "and the Ruby Style Guides (https://github.com/rubocop-hq/ruby-style-guide).")
         config[:rubocop] = true
         Bundler.ui.info "RuboCop enabled in config"
+        templates.merge!("rubocop.yml.tt" => ".rubocop.yml")
       end
 
       templates.merge!("exe/newgem.tt" => "exe/#{name}") if config[:exe]

--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -79,6 +79,7 @@ module Bundler
       ]
 
       templates.merge!("gitignore.tt" => ".gitignore") if Bundler.git_present?
+      templates.merge!("rubocop.yml.tt" => ".rubocop.yml")
 
       if test_framework = ask_and_set_test_framework
         config[:test] = test_framework

--- a/bundler/lib/bundler/templates/newgem/rubocop.yml.tt
+++ b/bundler/lib/bundler/templates/newgem/rubocop.yml.tt
@@ -1,0 +1,7 @@
+Style/StringLiterals:
+  Enabled: true
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  Enabled: true
+  EnforcedStyle: double_quotes

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -169,6 +169,10 @@ RSpec.describe "bundle gem" do
       rubocop_dep = builder.dependencies.find {|d| d.name == "rubocop" }
       expect(rubocop_dep).not_to be_nil
     end
+
+    it "generates a default .rubocop.yml" do
+      expect(bundled_app("#{gem_name}/.rubocop.yml")).to exist
+    end
   end
 
   shared_examples_for "--no-rubocop flag" do
@@ -191,6 +195,10 @@ RSpec.describe "bundle gem" do
       builder.dependencies
       rubocop_dep = builder.dependencies.find {|d| d.name == "rubocop" }
       expect(rubocop_dep).to be_nil
+    end
+
+    it "doesn't generate a default .rubocop.yml" do
+      expect(bundled_app("#{gem_name}/.rubocop.yml")).to_not exist
     end
   end
 
@@ -318,7 +326,6 @@ RSpec.describe "bundle gem" do
       expect(bundled_app("#{gem_name}/lib/#{require_path}.rb")).to exist
       expect(bundled_app("#{gem_name}/lib/#{require_path}/version.rb")).to exist
       expect(bundled_app("#{gem_name}/.gitignore")).to exist
-      expect(bundled_app("#{gem_name}/.rubocop.yml")).to exist
 
       expect(bundled_app("#{gem_name}/bin/setup")).to exist
       expect(bundled_app("#{gem_name}/bin/console")).to exist
@@ -375,12 +382,6 @@ RSpec.describe "bundle gem" do
       bundle "gem #{gem_name}"
 
       expect(bundled_app("#{gem_name}/lib/#{require_path}.rb").read).to match(/class Error < StandardError; end$/)
-    end
-
-    it "creates a default .rubocop.yml" do
-      bundle "gem #{gem_name}"
-
-      expect(bundled_app("#{gem_name}/.rubocop.yml")).to exist
     end
 
     it "runs rake without problems" do

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -318,6 +318,7 @@ RSpec.describe "bundle gem" do
       expect(bundled_app("#{gem_name}/lib/#{require_path}.rb")).to exist
       expect(bundled_app("#{gem_name}/lib/#{require_path}/version.rb")).to exist
       expect(bundled_app("#{gem_name}/.gitignore")).to exist
+      expect(bundled_app("#{gem_name}/.rubocop.yml")).to exist
 
       expect(bundled_app("#{gem_name}/bin/setup")).to exist
       expect(bundled_app("#{gem_name}/bin/console")).to exist
@@ -374,6 +375,12 @@ RSpec.describe "bundle gem" do
       bundle "gem #{gem_name}"
 
       expect(bundled_app("#{gem_name}/lib/#{require_path}.rb").read).to match(/class Error < StandardError; end$/)
+    end
+
+    it "creates a default .rubocop.yml" do
+      bundle "gem #{gem_name}"
+
+      expect(bundled_app("#{gem_name}/.rubocop.yml")).to exist
     end
 
     it "runs rake without problems" do


### PR DESCRIPTION
### Description:

Currently, there is no `.rubocop.yml` shipped by default.
So when a user runs `rubocop` after creating a new gem via `bundle gem foo`, it throws a bunch of offenses.

With the default `.rubocop.yml` present, the number of those offenses significantly reduce by 25.

### What was the end-user or developer problem that led to this PR?

A bunch of offenses thrown by rubocop since there's no default `.rubocop.yml` file.

### What is your fix for the problem, implemented in this PR?

This PR adds a default `.rubocop.yml` file. 
______________

### Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>