### PR TITLE
Speed up setup test by not installing docs

### DIFF
--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -125,6 +125,8 @@ class TestGemCommandsSetupCommand < Gem::TestCase
   end
 
   def test_execute_informs_about_installed_executables
+    @cmd.options[:document] = []
+
     use_ui @ui do
       @cmd.execute
     end


### PR DESCRIPTION
# Description:

This also makes this test consistent with the other tests in this file.

Under the ruby-core setup, these are the results:

### Before

```
ubuntu@a996b4b8aa58:/ruby$ make -j2 test-all TESTS="--verbose --tty=no test/rubygems/test_gem_commands_setup_command.rb"
Run options: 
  --seed=32923
  "--ruby=./miniruby -I./lib -I. -I.ext/common  ./tool/runruby.rb --extout=.ext  -- --disable-gems"
  --excludes-dir=./test/excludes
  --name=!/memory_leak/
  --verbose
  --tty=no

# Running tests:

TestGemCommandsSetupCommand#test_bundler_man1_files_in = 0.11 s = .
TestGemCommandsSetupCommand#test_bundler_man5_files_in = 0.03 s = .
TestGemCommandsSetupCommand#test_env_shebang_flag = 0.12 s = .
TestGemCommandsSetupCommand#test_execute_informs_about_installed_executables = 29.55 s = .
TestGemCommandsSetupCommand#test_execute_no_regenerate_binstubs = 0.11 s = .
TestGemCommandsSetupCommand#test_execute_no_regenerate_plugins = 0.10 s = .
TestGemCommandsSetupCommand#test_execute_regenerate_binstubs = 0.10 s = .
TestGemCommandsSetupCommand#test_execute_regenerate_plugins = 0.10 s = .
TestGemCommandsSetupCommand#test_execute_regenerate_plugins_creates_plugins_dir_if_not_there = 0.11 s = .
TestGemCommandsSetupCommand#test_install_default_bundler_gem = 0.05 s = .
TestGemCommandsSetupCommand#test_install_default_bundler_gem_with_force_flag = 0.06 s = .
TestGemCommandsSetupCommand#test_install_lib = 0.05 s = .
TestGemCommandsSetupCommand#test_install_man = 0.04 s = .
TestGemCommandsSetupCommand#test_pem_files_in = 0.04 s = .
TestGemCommandsSetupCommand#test_rb_files_in = 0.04 s = .
TestGemCommandsSetupCommand#test_remove_old_lib_files = 0.05 s = .
TestGemCommandsSetupCommand#test_remove_old_man_files = 0.05 s = .
TestGemCommandsSetupCommand#test_show_release_notes = 0.05 s = .
Finished tests in 31.440035s, 0.5725 tests/s, 1.7494 assertions/s.
18 tests, 55 assertions, 0 failures, 0 errors, 0 skips
```

### After

```
ubuntu@a996b4b8aa58:/ruby$ make -j2 test-all TESTS="--verbose --tty=no test/rubygems/test_gem_commands_setup_command.rb"
Run options: 
  --seed=43700
  "--ruby=./miniruby -I./lib -I. -I.ext/common  ./tool/runruby.rb --extout=.ext  -- --disable-gems"
  --excludes-dir=./test/excludes
  --name=!/memory_leak/
  --verbose
  --tty=no

# Running tests:

TestGemCommandsSetupCommand#test_bundler_man1_files_in = 0.11 s = .
TestGemCommandsSetupCommand#test_bundler_man5_files_in = 0.03 s = .
TestGemCommandsSetupCommand#test_env_shebang_flag = 0.13 s = .
TestGemCommandsSetupCommand#test_execute_informs_about_installed_executables = 0.08 s = .
TestGemCommandsSetupCommand#test_execute_no_regenerate_binstubs = 0.11 s = .
TestGemCommandsSetupCommand#test_execute_no_regenerate_plugins = 0.10 s = .
TestGemCommandsSetupCommand#test_execute_regenerate_binstubs = 0.11 s = .
TestGemCommandsSetupCommand#test_execute_regenerate_plugins = 0.10 s = .
TestGemCommandsSetupCommand#test_execute_regenerate_plugins_creates_plugins_dir_if_not_there = 0.11 s = .
TestGemCommandsSetupCommand#test_install_default_bundler_gem = 0.06 s = .
TestGemCommandsSetupCommand#test_install_default_bundler_gem_with_force_flag = 0.06 s = .
TestGemCommandsSetupCommand#test_install_lib = 0.05 s = .
TestGemCommandsSetupCommand#test_install_man = 0.04 s = .
TestGemCommandsSetupCommand#test_pem_files_in = 0.04 s = .
TestGemCommandsSetupCommand#test_rb_files_in = 0.05 s = .
TestGemCommandsSetupCommand#test_remove_old_lib_files = 0.05 s = .
TestGemCommandsSetupCommand#test_remove_old_man_files = 0.05 s = .
TestGemCommandsSetupCommand#test_show_release_notes = 0.04 s = .
Finished tests in 1.868676s, 9.6325 tests/s, 29.4326 assertions/s.
18 tests, 55 assertions, 0 failures, 0 errors, 0 skips
```

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
