### PR TITLE
Bundler - fix executable binstubs (project binstubs) on Windows

### DIFF
--- a/bundler/lib/bundler/installer.rb
+++ b/bundler/lib/bundler/installer.rb
@@ -135,12 +135,17 @@ module Bundler
           next
         end
 
-        File.open(binstub_path, "w", 0o777 & ~File.umask) do |f|
-          if RUBY_VERSION >= "2.6"
-            f.puts ERB.new(template, :trim_mode => "-").result(binding)
-          else
-            f.puts ERB.new(template, nil, "-").result(binding)
-          end
+        mode = Bundler::WINDOWS ? "wb:UTF-8" : "w"
+        content = if RUBY_VERSION >= "2.6"
+          ERB.new(template, :trim_mode => "-").result(binding)
+        else
+          ERB.new(template, nil, "-").result(binding)
+        end
+
+        File.write(binstub_path, content, :mode => mode, :perm => 0o777 & ~File.umask)
+        if Bundler::WINDOWS
+          prefix = "@ruby -x \"%~f0\" %*\n@exit /b %ERRORLEVEL%\n\n"
+          File.write("#{binstub_path}.cmd", prefix + content, :mode => mode)
         end
       end
 
@@ -175,12 +180,18 @@ module Bundler
         next if executable == "bundle"
         executable_path = Pathname(spec.full_gem_path).join(spec.bindir, executable).relative_path_from(bin_path)
         executable_path = executable_path
-        File.open "#{bin_path}/#{executable}", "w", 0o755 do |f|
-          if RUBY_VERSION >= "2.6"
-            f.puts ERB.new(template, :trim_mode => "-").result(binding)
-          else
-            f.puts ERB.new(template, nil, "-").result(binding)
-          end
+
+        mode = Bundler::WINDOWS ? "wb:UTF-8" : "w"
+        content = if RUBY_VERSION >= "2.6"
+          ERB.new(template, :trim_mode => "-").result(binding)
+        else
+          ERB.new(template, nil, "-").result(binding)
+        end
+
+        File.write("#{bin_path}/#{executable}", content, :mode => mode, :perm => 0o755)
+        if Bundler::WINDOWS
+          prefix = "@ruby -x \"%~f0\" %*\n@exit /b %ERRORLEVEL%\n\n"
+          File.write("#{bin_path}/#{executable}.cmd", prefix + content, :mode => mode)
         end
       end
     end

--- a/bundler/spec/commands/binstubs_spec.rb
+++ b/bundler/spec/commands/binstubs_spec.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe "bundle binstubs <gem>" do
-  before do
-    skip "https://github.com/rubygems/bundler/issues/6894" if Gem.win_platform?
-  end
-
   context "when the gem exists in the lockfile" do
     it "sets up the binstub" do
       install_gemfile <<-G
@@ -79,6 +75,7 @@ RSpec.describe "bundle binstubs <gem>" do
 
     context "when generating bundle binstub outside bundler" do
       it "should abort" do
+        skip "Unknown issue" if Gem.win_platform?
         install_gemfile <<-G
           source "#{file_uri_for(gem_repo1)}"
           gem "rack"

--- a/bundler/spec/commands/binstubs_spec.rb
+++ b/bundler/spec/commands/binstubs_spec.rb
@@ -75,7 +75,6 @@ RSpec.describe "bundle binstubs <gem>" do
 
     context "when generating bundle binstub outside bundler" do
       it "should abort" do
-        skip "Unknown issue" if Gem.win_platform?
         install_gemfile <<-G
           source "#{file_uri_for(gem_repo1)}"
           gem "rack"
@@ -285,8 +284,7 @@ RSpec.describe "bundle binstubs <gem>" do
         G
 
         bundle "binstubs rack --shebang jruby"
-
-        expect(File.open(bundled_app("bin/rackup")).gets).to eq("#!/usr/bin/env jruby\n")
+        expect(File.readlines(bundled_app("bin/rackup")).first).to eq("#!/usr/bin/env jruby\n")
       end
     end
   end

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -522,8 +522,6 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   it "installs the binstubs", :bundler => "< 3" do
-    skip "exec format error" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem "rack"

--- a/bundler/spec/install/gems/dependency_api_spec.rb
+++ b/bundler/spec/install/gems/dependency_api_spec.rb
@@ -496,8 +496,6 @@ RSpec.describe "gemcutter's dependency API" do
   end
 
   it "installs the binstubs", :bundler => "< 3" do
-    skip "exec format error" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem "rack"

--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -281,14 +281,10 @@ RSpec.shared_examples "bundle install --standalone" do
     include_examples "common functionality"
 
     it "creates stubs that use the standalone load path" do
-      skip "exec format error" if Gem.win_platform?
-
       expect(sys_exec("bin/rails -v").chomp).to eql "2.3.2"
     end
 
     it "creates stubs that can be executed from anywhere" do
-      skip "exec format error" if Gem.win_platform?
-
       require "tmpdir"
       sys_exec(%(#{bundled_app("bin/rails")} -v), :dir => Dir.tmpdir)
       expect(out).to eq("2.3.2")

--- a/bundler/spec/runtime/executable_spec.rb
+++ b/bundler/spec/runtime/executable_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe "Running bin/* commands" do
   end
 
   it "runs the bundled command when in the bundle" do
-    skip "exec format error" if Gem.win_platform?
-
     bundle "binstubs rack"
 
     build_gem "rack", "2.0", :to_system => true do |s|
@@ -22,8 +20,6 @@ RSpec.describe "Running bin/* commands" do
   end
 
   it "allows the location of the gem stubs to be specified" do
-    skip "created in bin :/" if Gem.win_platform?
-
     bundle "binstubs rack", :path => "gbin"
 
     expect(bundled_app("bin")).not_to exist
@@ -34,8 +30,6 @@ RSpec.describe "Running bin/* commands" do
   end
 
   it "allows absolute paths as a specification of where to install bin stubs" do
-    skip "exec format error" if Gem.win_platform?
-
     bundle "binstubs rack", :path => tmp("bin")
 
     gembin tmp("bin/rackup")
@@ -44,19 +38,15 @@ RSpec.describe "Running bin/* commands" do
 
   it "uses the default ruby install name when shebang is not specified" do
     bundle "binstubs rack"
-    expect(File.open(bundled_app("bin/rackup")).gets).to eq("#!/usr/bin/env #{RbConfig::CONFIG["ruby_install_name"]}\n")
+    expect(File.readlines(bundled_app("bin/rackup")).first).to eq("#!/usr/bin/env #{RbConfig::CONFIG["ruby_install_name"]}\n")
   end
 
   it "allows the name of the shebang executable to be specified" do
-    skip "not created with custom name :/" if Gem.win_platform?
-
     bundle "binstubs rack", :shebang => "ruby-foo"
-    expect(File.open(bundled_app("bin/rackup")).gets).to eq("#!/usr/bin/env ruby-foo\n")
+    expect(File.readlines(bundled_app("bin/rackup")).first).to eq("#!/usr/bin/env ruby-foo\n")
   end
 
   it "runs the bundled command when out of the bundle" do
-    skip "exec format error" if Gem.win_platform?
-
     bundle "binstubs rack"
 
     build_gem "rack", "2.0", :to_system => true do |s|
@@ -68,8 +58,6 @@ RSpec.describe "Running bin/* commands" do
   end
 
   it "works with gems in path" do
-    skip "exec format error" if Gem.win_platform?
-
     build_lib "rack", :path => lib_path("rack") do |s|
       s.executables = "rackup"
     end
@@ -100,8 +88,6 @@ RSpec.describe "Running bin/* commands" do
   end
 
   it "does not generate bin stubs if the option was not specified" do
-    skip "generated :/" if Gem.win_platform?
-
     bundle "install"
 
     expect(bundled_app("bin/rackup")).not_to exist
@@ -153,8 +139,6 @@ RSpec.describe "Running bin/* commands" do
   end
 
   it "use BUNDLE_GEMFILE gemfile for binstub" do
-    skip "exec format error" if Gem.win_platform?
-
     # context with bin/bundler w/ default Gemfile
     bundle "binstubs bundler"
 


### PR DESCRIPTION
# Description:

Generate Windows specific project binstubs, and remove related spec skips.

After removing global skip, one additional skip is needed, see 2nd commit.  This adds 33 additional specs, so test time increases...

## What was the end-user or developer problem that led to this PR?

Discussion in https://github.com/rubygems/rubygems/issues/3381

## What is your fix for the problem, implemented in this PR?

Fix `Bundler::Installer#generate_bundler_executable_stubs` & `Bundler::Installer#generate_standalone_bundler_executable_stubs`, write files with 'LF` for EOL.
______________

# Tasks:

- [x] Describe the problem / feature
- [x]  Fix tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).