### PR TITLE
test/rubygems/test_gem_package.rb: Skip a test when TMPDIR is too long

### DIFF
--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -605,6 +605,8 @@ class TestGemPackage < Gem::Package::TarTestCase
     destination_user_subdir = File.join destination_user_dir, 'dir'
     FileUtils.mkdir_p destination_user_subdir
 
+    skip "TMPDIR seems too long to add it as symlink into tar" if destination_user_dir.size > 90
+
     tgz_io = util_tar_gz do |tar|
       tar.add_symlink 'link', destination_user_dir, 16877
       tar.add_symlink 'link/dir', '.', 16877


### PR DESCRIPTION
to suppress the following failure:

https://rubyci.org/logs/rubyci.s3.amazonaws.com/solaris11-gcc/ruby-master/log/20200617T130007Z.fail.html.gz
https://rubyci.org/logs/rubyci.s3.amazonaws.com/android29-x86_64/ruby-master/log/20200617T131443Z.fail.html.gz
```
1) Failure:
TestGemPackage#test_extract_symlink_parent_doesnt_delete_user_dir
[/export/home/chkbuild/chkbuild-gcc/tmp/build/20200617T130007Z/ruby/test/rubygems/test_gem_package.rb:620]:
--- expected
+++ actual
@@ -1 +1 @@
-"installing into parent path /export/home/chkbuild/chkbuild-gcc/tmp/build/20200617T130007Z/ruby/tmp/test_rubygems_15916/extract/user/dir of /export/home/chkbuild/chkbuild-gcc/tmp/build/20200617T130007Z/ruby/tmp/test_rubygems_15916/extract/subdir is not allowed"
+"installing into parent path link/dir of /export/home/chkbuild/chkbuild-gcc/tmp/build/20200617T130007Z/ruby/tmp/test_rubygems_15916/extract/subdir is not allowed"
```

These CI environments use very long TMPDIR for some reason.
The test case creates a directory in TMPDIR and attempts to add a
symbolic link to the path into a tarball.  However, tar format limits
the maximum length up to 99, so the path is truncated.
This truncation makes the path check of `Gem::Package#install_location`
pass through, and then the check of `#mkdir_p_safe` raises an error.
The error message is slightly different from the expected value, so the
test fails.

I tentatively skip the test when TMPDIR is long.
This commit is just for sync with ruby/ruby master.
https://github.com/ruby/ruby/commit/e30ff63fd4eb24fd638259cb10638668f0f2ceeb


See #3737