### PR TITLE
Fix RuboCop offenses

### DIFF
--- a/bundler/lib/bundler/templates/newgem/Gemfile.tt
+++ b/bundler/lib/bundler/templates/newgem/Gemfile.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 # Specify your gem's dependencies in <%= config[:name] %>.gemspec

--- a/bundler/lib/bundler/templates/newgem/Rakefile.tt
+++ b/bundler/lib/bundler/templates/newgem/Rakefile.tt
@@ -36,4 +36,4 @@ Rake::ExtensionTask.new("<%= config[:underscored_name] %>") do |ext|
 end
 
 <% end -%>
-task :default => <%= default_task_names.size == 1 ? default_task_names.first.inspect : default_task_names.inspect %>
+task default: <%= default_task_names.size == 1 ? default_task_names.first.inspect : default_task_names.inspect %>

--- a/bundler/lib/bundler/templates/newgem/Rakefile.tt
+++ b/bundler/lib/bundler/templates/newgem/Rakefile.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 <% default_task_names = [config[:test_task]].compact -%>
 <% case config[:test] -%>
@@ -27,7 +29,7 @@ RuboCop::RakeTask.new
 <% default_task_names.unshift(:clobber, :compile) -%>
 require "rake/extensiontask"
 
-task :build => :compile
+task build: :compile
 
 Rake::ExtensionTask.new("<%= config[:underscored_name] %>") do |ext|
   ext.lib_dir = "lib/<%= config[:namespaced_path] %>"

--- a/bundler/lib/bundler/templates/newgem/bin/console.tt
+++ b/bundler/lib/bundler/templates/newgem/bin/console.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #!/usr/bin/env ruby
 
 require "bundler/setup"

--- a/bundler/lib/bundler/templates/newgem/lib/newgem.rb.tt
+++ b/bundler/lib/bundler/templates/newgem/lib/newgem.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "<%= config[:namespaced_path] %>/version"
 <%- if config[:ext] -%>
 require "<%= config[:namespaced_path] %>/<%= config[:underscored_name] %>"

--- a/bundler/lib/bundler/templates/newgem/lib/newgem/version.rb.tt
+++ b/bundler/lib/bundler/templates/newgem/lib/newgem/version.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <%- config[:constant_array].each_with_index do |c, i| -%>
 <%= "  " * i %>module <%= c %>
 <%- end -%>

--- a/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -24,7 +24,9 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files = Dir.chdir(File.expand_path(__dir__)) do
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  end
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]

--- a/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "lib/<%=config[:namespaced_path]%>/version"
 
 Gem::Specification.new do |spec|
@@ -6,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.authors       = [<%= config[:author].inspect %>]
   spec.email         = [<%= config[:email].inspect %>]
 
-  spec.summary       = %q{TODO: Write a short summary, because RubyGems requires one.}
-  spec.description   = %q{TODO: Write a longer description or delete this line.}
+  spec.summary       = "TODO: Write a short summary, because RubyGems requires one."
+  spec.description   = "TODO: Write a longer description or delete this line."
   spec.homepage      = "TODO: Put your gem's website or public repo URL here."
 <%- if config[:mit] -%>
   spec.license       = "MIT"
@@ -22,9 +24,7 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path("..", __FILE__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  end
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]

--- a/bundler/lib/bundler/templates/newgem/rubocop.yml.tt
+++ b/bundler/lib/bundler/templates/newgem/rubocop.yml.tt
@@ -5,3 +5,6 @@ Style/StringLiterals:
 Style/StringLiteralsInInterpolation:
   Enabled: true
   EnforcedStyle: double_quotes
+
+Layout/LineLength:
+  Max: 120

--- a/bundler/lib/bundler/templates/newgem/spec/newgem_spec.rb.tt
+++ b/bundler/lib/bundler/templates/newgem/spec/newgem_spec.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe <%= config[:constant_name] %> do
   it "has a version number" do
     expect(<%= config[:constant_name] %>::VERSION).not_to be nil

--- a/bundler/lib/bundler/templates/newgem/spec/spec_helper.rb.tt
+++ b/bundler/lib/bundler/templates/newgem/spec/spec_helper.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/setup"
 require "<%= config[:namespaced_path] %>"
 

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -155,9 +155,10 @@ RSpec.describe "bundle gem" do
     it "generates a gem skeleton with rubocop" do
       gem_skeleton_assertions
       expect(bundled_app("test-gem/Rakefile")).to read_as(
-        include('require "rubocop/rake_task"').
+        include('# frozen_string_literal: true').
+        and(include('require "rubocop/rake_task"').
         and(include("RuboCop::RakeTask.new").
-        and(match(/:default.+:rubocop/)))
+        and(match(/default:.+:rubocop/))))
       )
     end
 
@@ -182,7 +183,6 @@ RSpec.describe "bundle gem" do
       realworld_system_gems gems, :path => path
       bundle "install", :dir => bundled_app("#{gem_name}")
       bundle "exec rubocop", :dir => bundled_app("#{gem_name}")
-
       expect($?.exitstatus).to eq(0) if exitstatus
     end
   end
@@ -555,7 +555,7 @@ RSpec.describe "bundle gem" do
             t.test_files = FileList["test/**/*_test.rb"]
           end
 
-          task :default => :test
+          task default: :test
         RAKEFILE
 
         expect(bundled_app("#{gem_name}/Rakefile").read).to eq(rakefile)
@@ -613,7 +613,7 @@ RSpec.describe "bundle gem" do
             t.test_files = FileList["test/**/*_test.rb"]
           end
 
-          task :default => :test
+          task default: :test
         RAKEFILE
 
         expect(bundled_app("#{gem_name}/Rakefile").read).to eq(rakefile)
@@ -914,7 +914,7 @@ RSpec.describe "bundle gem" do
             ext.lib_dir = "lib/#{gem_name}"
           end
 
-          task :default => [:clobber, :compile]
+          task default: [:clobber, :compile]
         RAKEFILE
 
         expect(bundled_app("#{gem_name}/Rakefile").read).to eq(rakefile)
@@ -1010,7 +1010,7 @@ Usage: "bundle gem NAME [OPTIONS]"
 
         RSpec::Core::RakeTask.new(:spec)
 
-        task :default => :spec
+        task default: :spec
       RAKEFILE
 
       expect(bundled_app("foobar/Rakefile").read).to eq(rakefile)

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe "bundle gem" do
     it "generates a gem skeleton with rubocop" do
       gem_skeleton_assertions
       expect(bundled_app("test-gem/Rakefile")).to read_as(
-        include('# frozen_string_literal: true').
+        include("# frozen_string_literal: true").
         and(include('require "rubocop/rake_task"').
         and(include("RuboCop::RakeTask.new").
         and(match(/default:.+:rubocop/))))
@@ -176,11 +176,11 @@ RSpec.describe "bundle gem" do
     end
 
     it "run rubocop inside the generated gem with no offenses" do
-      prepare_gemspec(bundled_app("#{gem_name}", "#{gem_name}.gemspec"))
+      prepare_gemspec(bundled_app(gem_name, "#{gem_name}.gemspec"))
       gems = ["rake", "rubocop"]
-      path = Bundler.feature_flag.default_install_uses_path? ? local_gem_path(:base => bundled_app("#{gem_name}")) : system_gem_path
+      path = Bundler.feature_flag.default_install_uses_path? ? local_gem_path(:base => bundled_app(gem_name)) : system_gem_path
       realworld_system_gems gems, :path => path
-      bundle "exec rubocop --ignore-parent-exclusion", :dir => bundled_app("#{gem_name}")
+      bundle "exec rubocop --ignore-parent-exclusion", :dir => bundled_app(gem_name)
       expect($?.exitstatus).to eq(0) if exitstatus
     end
   end

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -177,12 +177,10 @@ RSpec.describe "bundle gem" do
 
     it "run rubocop inside the generated gem with no offenses" do
       prepare_gemspec(bundled_app("#{gem_name}", "#{gem_name}.gemspec"))
-
-      gems = ["rubocop"]
+      gems = ["rake", "rubocop"]
       path = Bundler.feature_flag.default_install_uses_path? ? local_gem_path(:base => bundled_app("#{gem_name}")) : system_gem_path
       realworld_system_gems gems, :path => path
-      bundle "install", :dir => bundled_app("#{gem_name}")
-      bundle "exec rubocop", :dir => bundled_app("#{gem_name}")
+      bundle "exec rubocop --ignore-parent-exclusion", :dir => bundled_app("#{gem_name}")
       expect($?.exitstatus).to eq(0) if exitstatus
     end
   end

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe "bundle gem" do
       gems = ["rake", "rubocop -v 0.80.1"]
       path = Bundler.feature_flag.default_install_uses_path? ? local_gem_path(:base => bundled_app(gem_name)) : system_gem_path
       realworld_system_gems gems, :path => path
-      bundle "exec rubocop --ignore-parent-exclusion", :dir => bundled_app(gem_name)
+      bundle "exec rubocop --config .rubocop.yml", :dir => bundled_app(gem_name)
       expect($?.exitstatus).to eq(0) if exitstatus
     end
   end

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -173,6 +173,18 @@ RSpec.describe "bundle gem" do
     it "generates a default .rubocop.yml" do
       expect(bundled_app("#{gem_name}/.rubocop.yml")).to exist
     end
+
+    it "run rubocop inside the generated gem with no offenses" do
+      prepare_gemspec(bundled_app("#{gem_name}", "#{gem_name}.gemspec"))
+
+      gems = ["rubocop"]
+      path = Bundler.feature_flag.default_install_uses_path? ? local_gem_path(:base => bundled_app("#{gem_name}")) : system_gem_path
+      realworld_system_gems gems, :path => path
+      bundle "install", :dir => bundled_app("#{gem_name}")
+      bundle "exec rubocop", :dir => bundled_app("#{gem_name}")
+
+      expect($?.exitstatus).to eq(0) if exitstatus
+    end
   end
 
   shared_examples_for "--no-rubocop flag" do

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -532,6 +532,8 @@ RSpec.describe "bundle gem" do
 
       it "creates a default rake task to run the test suite" do
         rakefile = strip_whitespace <<-RAKEFILE
+          # frozen_string_literal: true
+
           require "bundler/gem_tasks"
           require "rake/testtask"
 
@@ -588,6 +590,8 @@ RSpec.describe "bundle gem" do
 
       it "creates a default rake task to run the test suite" do
         rakefile = strip_whitespace <<-RAKEFILE
+          # frozen_string_literal: true
+
           require "bundler/gem_tasks"
           require "rake/testtask"
 
@@ -887,10 +891,12 @@ RSpec.describe "bundle gem" do
 
       it "depends on compile task for build" do
         rakefile = strip_whitespace <<-RAKEFILE
+          # frozen_string_literal: true
+
           require "bundler/gem_tasks"
           require "rake/extensiontask"
 
-          task :build => :compile
+          task build: :compile
 
           Rake::ExtensionTask.new("#{gem_name}") do |ext|
             ext.lib_dir = "lib/#{gem_name}"
@@ -985,6 +991,8 @@ Usage: "bundle gem NAME [OPTIONS]"
 
       expect(bundled_app("foobar/spec/spec_helper.rb")).to exist
       rakefile = strip_whitespace <<-RAKEFILE
+        # frozen_string_literal: true
+
         require "bundler/gem_tasks"
         require "rspec/core/rake_task"
 

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -175,14 +175,15 @@ RSpec.describe "bundle gem" do
       expect(bundled_app("#{gem_name}/.rubocop.yml")).to exist
     end
 
-    it "run rubocop inside the generated gem with no offenses" do
+    it "runs rubocop inside the generated gem with no offenses" do
+      skip "ruby_core has an 'ast.rb' file that gets in the middle and breaks this spec" if ruby_core?
       prepare_gemspec(bundled_app(gem_name, "#{gem_name}.gemspec"))
       rubocop_version = RUBY_VERSION > "2.4" ? "0.85.1" : "0.80.1"
       gems = ["rake", "rubocop -v #{rubocop_version}"]
       path = Bundler.feature_flag.default_install_uses_path? ? local_gem_path(:base => bundled_app(gem_name)) : system_gem_path
       realworld_system_gems gems, :path => path
       bundle "exec rubocop --config .rubocop.yml", :dir => bundled_app(gem_name)
-      expect($?.exitstatus).to eq(0) if exitstatus
+      expect(err).to be_empty
     end
   end
 

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe "bundle gem" do
 
     it "run rubocop inside the generated gem with no offenses" do
       prepare_gemspec(bundled_app(gem_name, "#{gem_name}.gemspec"))
-      gems = ["rake", "rubocop"]
+      gems = ["rake", "rubocop -v 0.80.1"]
       path = Bundler.feature_flag.default_install_uses_path? ? local_gem_path(:base => bundled_app(gem_name)) : system_gem_path
       realworld_system_gems gems, :path => path
       bundle "exec rubocop --ignore-parent-exclusion", :dir => bundled_app(gem_name)

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -177,7 +177,8 @@ RSpec.describe "bundle gem" do
 
     it "run rubocop inside the generated gem with no offenses" do
       prepare_gemspec(bundled_app(gem_name, "#{gem_name}.gemspec"))
-      gems = ["rake", "rubocop -v 0.80.1"]
+      rubocop_version = RUBY_VERSION > "2.4" ? "0.85.1" : "0.80.1"
+      gems = ["rake", "rubocop -v #{rubocop_version}"]
       path = Bundler.feature_flag.default_install_uses_path? ? local_gem_path(:base => bundled_app(gem_name)) : system_gem_path
       realworld_system_gems gems, :path => path
       bundle "exec rubocop --config .rubocop.yml", :dir => bundled_app(gem_name)

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -490,11 +490,11 @@ module Spec
       process_file(pathname) do |line|
         case line
         when /spec\.metadata\["(?:allowed_push_host|homepage_uri|source_code_uri|changelog_uri)"\]/, /spec\.homepage/
-          line.gsub(/\=.*$/, "= 'http://example.org'")
+          line.gsub(/\=.*$/, '= "http://example.org"')
         when /spec\.summary/
-          line.gsub(/\=.*$/, "= %q{A short summary of my new gem.}")
+          line.gsub(/\=.*$/, '= "A short summary of my new gem."')
         when /spec\.description/
-          line.gsub(/\=.*$/, "= %q{A longer description of my new gem.}")
+          line.gsub(/\=.*$/, '= "A longer description of my new gem."')
         else
           line
         end


### PR DESCRIPTION
These offenses appear when you create a gem with
`bundle gem foo` and run `rubocop` over it.

Initially, there were around 45 offenses detected,
but with #3731 and this, the number of offenses
have been reduced to 0.

@bronzdoc, as promised, here's this :tada: 

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>

______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write code to solve the problem
- [x] Write tests
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
