### PR TITLE
.gitattributes - diff=ruby, eol, rubocop_bundler.yml - eol

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# git log -L:<method>:<file>
+*.rb diff=ruby
+*.gemspec diff=ruby
+bin/* diff=ruby
+bundler/bin/* diff=ruby
+bundler/exe/* diff=ruby
+
+# Auto detect text files and perform LF normalization
+* text eol=lf

--- a/.rubocop_bundler.yml
+++ b/.rubocop_bundler.yml
@@ -297,6 +297,7 @@ Layout/EndAlignment:
 
 Layout/EndOfLine:
   Enabled: true
+  EnforcedStyle: lf
 
 Layout/ExtraSpacing:
   Enabled: true


### PR DESCRIPTION
## Description:

.gitattributes- text eol=lf, add diff=ruby for several directories

rubocop_bundler.yml - set Layout/EndOfLine to match RubyGems (EOL should be lf)

## What was the end-user or developer problem that led to this PR?

Running RuboCop on Bundler showed errors for **every.file.in.bundler**.

## What is your fix for the problem, implemented in this PR?

see Desc

______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
