### PR TITLE
Show errors whenever `sys_exec` fails

### DIFF
--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -101,9 +101,9 @@ RSpec.configure do |config|
       with_gem_path_as(system_gem_path) do
         Bundler.ui.silence { example.run }
 
-        all_output = command_executions.map(&:to_s_verbose).join("\n\n")
+        all_output = all_commands_output
         if example.exception && !all_output.empty?
-          message = example.exception.message + "\n\nCommands:\n#{all_output}"
+          message = example.exception.message + all_output
           (class << example.exception; self; end).send(:define_method, :message) do
             message
           end

--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -99,11 +99,9 @@ RSpec.configure do |config|
       FileUtils.cp_r pristine_system_gem_path, system_gem_path
 
       with_gem_path_as(system_gem_path) do
-        @command_executions = []
-
         Bundler.ui.silence { example.run }
 
-        all_output = @command_executions.map(&:to_s_verbose).join("\n\n")
+        all_output = command_executions.map(&:to_s_verbose).join("\n\n")
         if example.exception && !all_output.empty?
           warn all_output unless config.formatters.grep(RSpec::Core::Formatters::DocumentationFormatter).empty?
           message = example.exception.message + "\n\nCommands:\n#{all_output}"

--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -103,7 +103,6 @@ RSpec.configure do |config|
 
         all_output = command_executions.map(&:to_s_verbose).join("\n\n")
         if example.exception && !all_output.empty?
-          warn all_output unless config.formatters.grep(RSpec::Core::Formatters::DocumentationFormatter).empty?
           message = example.exception.message + "\n\nCommands:\n#{all_output}"
           (class << example.exception; self; end).send(:define_method, :message) do
             message

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -27,8 +27,12 @@ module Spec
       TheBundle.new(*args)
     end
 
+    def command_executions
+      @command_executions ||= []
+    end
+
     def last_command
-      @command_executions.last || raise("There is no last command")
+      command_executions.last || raise("There is no last command")
     end
 
     def out
@@ -192,7 +196,7 @@ module Spec
         command_execution.exitstatus = wait_thr && wait_thr.value.exitstatus
       end
 
-      (@command_executions ||= []) << command_execution
+      command_executions << command_execution
 
       unless options[:raise_on_error] == false || command_execution.success?
         raise "Invoking #{cmd} failed!"

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -199,7 +199,7 @@ module Spec
       command_executions << command_execution
 
       unless options[:raise_on_error] == false || command_execution.success?
-        raise "Invoking #{cmd} failed!"
+        raise "Invoking `#{cmd}` failed!"
       end
 
       command_execution.stdout

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -211,6 +211,12 @@ module Spec
       command_execution.stdout
     end
 
+    def all_commands_output
+      return [] if command_executions.empty?
+
+      "\n\nCommands:\n#{command_executions.map(&:to_s_verbose).join("\n\n")}"
+    end
+
     def config(config = nil, path = bundled_app(".bundle/config"))
       return YAML.load_file(path) unless config
       FileUtils.mkdir_p(File.dirname(path))

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -196,11 +196,17 @@ module Spec
         command_execution.exitstatus = wait_thr && wait_thr.value.exitstatus
       end
 
-      command_executions << command_execution
-
       unless options[:raise_on_error] == false || command_execution.success?
-        raise "Invoking `#{cmd}` failed!"
+        raise <<~ERROR
+
+          Invoking `#{cmd}` failed with output:
+          ----------------------------------------------------------------------
+          #{command_execution.stdboth}
+          ----------------------------------------------------------------------
+        ERROR
       end
+
+      command_executions << command_execution
 
       command_execution.stdout
     end

--- a/bundler/spec/support/rubygems_version_manager.rb
+++ b/bundler/spec/support/rubygems_version_manager.rb
@@ -24,6 +24,12 @@ class RubygemsVersionManager
 
   def assert_system_features_not_loaded!
     at_exit do
+      errors = if $?.nil?
+        ""
+      else
+        all_commands_output
+      end
+
       rubylibdir = RbConfig::CONFIG["rubylibdir"]
 
       rubygems_path = rubylibdir + "/rubygems"
@@ -38,8 +44,10 @@ class RubygemsVersionManager
       end
 
       if bad_loaded_features.any?
-        raise "the following features were incorrectly loaded:\n#{bad_loaded_features.join("\n")}"
+        errors += "the following features were incorrectly loaded:\n#{bad_loaded_features.join("\n")}"
       end
+
+      raise errors unless errors.empty?
     end
   end
 

--- a/bundler/spec/support/rubygems_version_manager.rb
+++ b/bundler/spec/support/rubygems_version_manager.rb
@@ -68,7 +68,7 @@ private
     return unless local_copy_switch_needed?
 
     sys_exec("git remote update", :dir => local_copy_path)
-    sys_exec("git checkout #{target_tag} --quiet", :dir => local_copy_path)
+    sys_exec("git checkout #{target_tag}", :dir => local_copy_path)
 
     ENV["RGV"] = local_copy_path.to_s
   end


### PR DESCRIPTION
# Description:

Previously, when `sys_exec` would fail as part of a spec, errors would be displayed, but when `sys_exec` is used outside of specs, errors wouldn't be displayed.

For example, if the initial git commands used by bundler specs to checkout the proper rubygems version fail, we would get something like:

```
 /home/runner/work/rubygems/rubygems/bundler/spec/support/rubygems_version_manager.rb:33:in `block in assert_system_features_not_loaded!': uninitialized constant RubygemsVersionManager::Gem (NameError)
/home/runner/work/rubygems/rubygems/bundler/spec/support/helpers.rb:198:in `sys_exec': Invoking git checkout v3.1.4 --quiet failed! (RuntimeError)
	from /home/runner/work/rubygems/rubygems/bundler/spec/support/rubygems_version_manager.rb:71:in `switch_local_copy_if_needed'
	from /home/runner/work/rubygems/rubygems/bundler/spec/support/rubygems_version_manager.rb:20:in `switch'
	from /home/runner/work/rubygems/rubygems/bundler/spec/support/switch_rubygems.rb:4:in `<top (required)>'
	from /home/runner/work/rubygems/rubygems/bundler/spec/support/rubygems_ext.rb:16:in `require_relative'
	from /home/runner/work/rubygems/rubygems/bundler/spec/support/rubygems_ext.rb:16:in `gem_load'
	from bin/rake:6:in `<main>'
/home/runner/work/rubygems/rubygems/bundler/spec/support/helpers.rb:198:in `sys_exec': Invoking git checkout v3.1.4 --quiet failed! (RuntimeError)
	from /home/runner/work/rubygems/rubygems/bundler/spec/support/rubygems_version_manager.rb:71:in `switch_local_copy_if_needed'
	from /home/runner/work/rubygems/rubygems/bundler/spec/support/rubygems_version_manager.rb:20:in `switch'
	from /home/runner/work/rubygems/rubygems/bundler/spec/support/switch_rubygems.rb:4:in `<top (required)>'
	from /home/runner/work/rubygems/rubygems/bundler/spec/support/rubygems_ext.rb:16:in `require_relative'
	from /home/runner/work/rubygems/rubygems/bundler/spec/support/rubygems_ext.rb:16:in `gem_load'
	from bin/rake:6:in `<main>'
```

which doesn't really let us know what went wrong.

With these changes, errors should be displayed every time.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
