### PR TITLE
Add actions to automatically bump man page month

### DIFF
--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -1,10 +1,6 @@
 name: monthly
 
 on:
-  push
-    branches:
-      - master
-
   schedule:
     - cron: '0 0 1 * *'
 
@@ -18,24 +14,25 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: 2.7.1
           bundler: none
 
-      - name: Install dependencies
-        run: rake setup
+      - name: Install ronn
+        run: gem install ronn:'~> 0.7.3'
 
       - name: Update month
         run: bin/rake man:build
+        working-directory: ./bundler
 
-      - name: Commit changes
-        uses: EndBug/add-and-commit@v4
-        with:
-          author_name: Utkarsh Gupta
-          author_email: utkarsh@debian.org
-          message: "Bump man pages month"
-          add: "bundler/man/*"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
-        if: failure() && env.OLD_STATUS == '"success"'
+      - name: Set up git config
+        run: |
+          git config user.name "The Bundler Bot"
+          git config user.email "bot@bundler.io"
 
-    timeout-minutes: 60
+      - name: Commit and push the changes
+        run: |
+          git add bundler/man/*
+          git commit -m "Bump man pages month"
+          git push origin master
+
+    timeout-minutes: 15

--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -1,0 +1,41 @@
+name: monthly
+
+on:
+  push
+    branches:
+      - master
+
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  run:
+    name: Refresh month of man pages
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler: none
+
+      - name: Install dependencies
+        run: rake setup
+
+      - name: Update month
+        run: bin/rake man:build
+
+      - name: Commit changes
+        uses: EndBug/add-and-commit@v4
+        with:
+          author_name: Utkarsh Gupta
+          author_email: utkarsh@debian.org
+          message: "Bump man pages month"
+          add: "bundler/man/*"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+        if: failure() && env.OLD_STATUS == '"success"'
+
+    timeout-minutes: 60


### PR DESCRIPTION
At the beginning of every month, the CI breaks as it has a check that makes sure that man pages stay in sync with their sources.

Therefore, someone (David) has to manually update the man pages every month by running `bin/rake man:build`.

With this, having actions doing this can help save manual work.

Closes: #3582

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write code to solve the problem

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
