### PR TITLE
Move `automatiek` to the main repo

### DIFF
--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -252,4 +252,6 @@ end
 
 task :default => :spec
 
-Dir["task/*.rake"].each(&method(:load))
+load "task/build_metadata.rake"
+load "task/bundler_3.rake"
+load "task/release.rake"

--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -168,80 +168,62 @@ namespace :man do
   end
 end
 
-begin
-  Spec::Rubygems.gem_require("automatiek")
-rescue Gem::LoadError => e
-  msg = "We couldn't activate automatiek (#{e.requirement}). Try `gem install automatiek:'#{e.requirement}'` to be able to vendor gems"
+load "task/automatiek.rake"
 
-  namespace :vendor do
-    desc "Vendor a specific version of molinillo"
-    task(:molinillo) { abort msg }
+desc "Vendor a specific version of molinillo"
+Automatiek::RakeTask.new("molinillo") do |lib|
+  lib.download = { :github => "https://github.com/CocoaPods/Molinillo" }
+  lib.namespace = "Molinillo"
+  lib.prefix = "Bundler"
+  lib.vendor_lib = "lib/bundler/vendor/molinillo"
+end
 
-    desc "Vendor a specific version of fileutils"
-    task(:fileutils) { abort msg }
+desc "Vendor a specific version of thor"
+Automatiek::RakeTask.new("thor") do |lib|
+  lib.version = "v1.0.1"
+  lib.download = { :github => "https://github.com/erikhuda/thor" }
+  lib.namespace = "Thor"
+  lib.prefix = "Bundler"
+  lib.vendor_lib = "lib/bundler/vendor/thor"
+end
 
-    desc "Vendor a specific version of thor"
-    task(:thor) { abort msg }
+desc "Vendor a specific version of fileutils"
+Automatiek::RakeTask.new("fileutils") do |lib|
+  lib.version = "v1.4.1"
+  lib.download = { :github => "https://github.com/ruby/fileutils" }
+  lib.namespace = "FileUtils"
+  lib.prefix = "Bundler"
+  lib.vendor_lib = "lib/bundler/vendor/fileutils"
+end
 
-    desc "Vendor a specific version of net-http-persistent"
-    task(:"net-http-persistent") { abort msg }
+# We currently include changes over the official version to avoid requiring
+# the optional `net-http-pipeline` dependency, so that its version can be
+# selected by end users. We also include changes to require the vendored
+# dependencies `uri` and `connection_pool` relatively.
+desc "Vendor a specific version of net-http-persistent"
+Automatiek::RakeTask.new("net-http-persistent") do |lib|
+  lib.version = "v4.0.0"
+  lib.download = { :github => "https://github.com/drbrain/net-http-persistent" }
+  lib.namespace = "Net::HTTP::Persistent"
+  lib.prefix = "Bundler::Persistent"
+  lib.vendor_lib = "lib/bundler/vendor/net-http-persistent"
+
+  lib.dependency("connection_pool") do |sublib|
+    sublib.version = "v2.2.2"
+    sublib.download = { :github => "https://github.com/mperham/connection_pool" }
+    sublib.namespace = "ConnectionPool"
+    sublib.prefix = "Bundler"
+    sublib.vendor_lib = "lib/bundler/vendor/connection_pool"
   end
-else
-  desc "Vendor a specific version of molinillo"
-  Automatiek::RakeTask.new("molinillo") do |lib|
-    lib.download = { :github => "https://github.com/CocoaPods/Molinillo" }
-    lib.namespace = "Molinillo"
-    lib.prefix = "Bundler"
-    lib.vendor_lib = "lib/bundler/vendor/molinillo"
-  end
 
-  desc "Vendor a specific version of thor"
-  Automatiek::RakeTask.new("thor") do |lib|
-    lib.version = "v1.0.1"
-    lib.download = { :github => "https://github.com/erikhuda/thor" }
-    lib.namespace = "Thor"
-    lib.prefix = "Bundler"
-    lib.vendor_lib = "lib/bundler/vendor/thor"
-  end
-
-  desc "Vendor a specific version of fileutils"
-  Automatiek::RakeTask.new("fileutils") do |lib|
-    lib.version = "v1.4.1"
-    lib.download = { :github => "https://github.com/ruby/fileutils" }
-    lib.namespace = "FileUtils"
-    lib.prefix = "Bundler"
-    lib.vendor_lib = "lib/bundler/vendor/fileutils"
-  end
-
-  # We currently include changes over the official version to avoid requiring
-  # the optional `net-http-pipeline` dependency, so that its version can be
-  # selected by end users. We also include changes to require the vendored
-  # dependencies `uri` and `connection_pool` relatively.
-  desc "Vendor a specific version of net-http-persistent"
-  Automatiek::RakeTask.new("net-http-persistent") do |lib|
-    lib.version = "v4.0.0"
-    lib.download = { :github => "https://github.com/drbrain/net-http-persistent" }
-    lib.namespace = "Net::HTTP::Persistent"
-    lib.prefix = "Bundler::Persistent"
-    lib.vendor_lib = "lib/bundler/vendor/net-http-persistent"
-
-    lib.dependency("connection_pool") do |sublib|
-      sublib.version = "v2.2.2"
-      sublib.download = { :github => "https://github.com/mperham/connection_pool" }
-      sublib.namespace = "ConnectionPool"
-      sublib.prefix = "Bundler"
-      sublib.vendor_lib = "lib/bundler/vendor/connection_pool"
-    end
-
-    # We currently include changes over the official version to require internal paths
-    # relatively.
-    lib.dependency("uri") do |sublib|
-      sublib.version = "v0.10.0"
-      sublib.download = { :github => "https://github.com/ruby/uri" }
-      sublib.namespace = "URI"
-      sublib.prefix = "Bundler"
-      sublib.vendor_lib = "lib/bundler/vendor/uri"
-    end
+  # We currently include changes over the official version to require internal paths
+  # relatively.
+  lib.dependency("uri") do |sublib|
+    sublib.version = "v0.10.0"
+    sublib.download = { :github => "https://github.com/ruby/uri" }
+    sublib.namespace = "URI"
+    sublib.prefix = "Bundler"
+    sublib.vendor_lib = "lib/bundler/vendor/uri"
   end
 end
 

--- a/bundler/dev_gems.rb
+++ b/bundler/dev_gems.rb
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "automatiek", "~> 0.3.0"
 gem "parallel_tests", "~> 2.29"
 gem "ronn", "~> 0.7.3", :platform => :ruby
 gem "rspec-core", "~> 3.8"

--- a/bundler/dev_gems.rb.lock
+++ b/bundler/dev_gems.rb.lock
@@ -1,7 +1,6 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    automatiek (0.3.0)
     diff-lcs (1.3)
     hpricot (0.8.6)
     mustache (1.1.1)
@@ -28,7 +27,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  automatiek (~> 0.3.0)
   parallel_tests (~> 2.29)
   ronn (~> 0.7.3)
   rspec-core (~> 3.8)

--- a/bundler/task/automatiek.rake
+++ b/bundler/task/automatiek.rake
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rake"
+require "rake/tasklib"
+
+require_relative "automatiek/gem"
+
+module Automatiek
+  class RakeTask < Rake::TaskLib
+    def initialize(*args, &task_block)
+      @gem = Gem.new(*args, &task_block)
+
+      namespace :vendor do
+        desc "Vendors #{@gem.gem_name}" unless ::Rake.application.last_description
+        task(@gem.gem_name, [:version] => []) do |_, task_args|
+          @gem.vendor!(task_args[:version])
+        end
+      end
+    end
+  end
+end

--- a/bundler/task/automatiek/gem.rb
+++ b/bundler/task/automatiek/gem.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "fileutils"
+
+module Automatiek
+  class Gem
+    def initialize(gem_name, &block)
+      @gem_name = gem_name
+      @dependencies = []
+      block.call(self) if block
+    end
+
+    def vendor!(version = nil)
+      update(version || self.version)
+
+      @dependencies.each do |dependency|
+        dependency.vendor!
+        dependency.namespace_files(vendor_lib)
+      end
+
+      namespace_files(vendor_lib)
+
+      clean
+    end
+
+    def download=(opts = {}, &block)
+      if block
+        @download = block
+      elsif github = opts.delete(:github)
+        @download = lambda do |version|
+          Dir.chdir File.dirname(vendor_lib) do
+            `curl -L #{github}/archive/#{version}.tar.gz | tar -xz`
+            unless $?.success?
+              raise "Downloading & untarring #{gem_name} (#{version}) failed"
+            end
+            FileUtils.mv "#{github.split("/").last}-#{version.sub(/^v/, "")}", gem_name
+          end
+        end
+      end
+    end
+
+    def dependency(name, &block)
+      dep = self.class.new(name, &block)
+      @dependencies << dep
+    end
+
+    attr_accessor :gem_name
+    attr_accessor :namespace
+    attr_accessor :prefix
+    attr_accessor :vendor_lib
+    attr_accessor :version
+
+    def update(version)
+      FileUtils.rm_rf vendor_lib
+      @download.call(version)
+    end
+
+    def require_target
+      @require_target ||= vendor_lib.sub(%r{^(.+?/)?lib/}, "") << "/lib"
+    end
+
+    def require_entrypoint
+      @require_entrypoint ||= gem_name.tr("-", "/")
+    end
+
+    attr_writer :require_entrypoint
+
+    def namespace_files(folder)
+      files = Dir.glob("#{folder}/**/*.rb")
+      process(files, /module Kernel/, "module #{prefix}")
+      process(files, /::#{namespace}/, "::#{prefix}::#{namespace}")
+      process(files, /(?<!\w|def |:)#{namespace}\b/, "#{prefix}::#{namespace}")
+      process(files, /require (["'])#{Regexp.escape require_entrypoint}/, "require \\1#{require_target}/#{require_entrypoint}")
+      process(files, %r{(autoload\s+[:\w]+,\s+["'])(#{Regexp.escape require_entrypoint}[\w\/]+["'])}, "\\1#{require_target}/\\2")
+    end
+
+    def clean
+      files = Dir.glob("#{vendor_lib}/*", File::FNM_DOTMATCH).reject {|f| %(. .. lib).include? f.split("/").last }
+      FileUtils.rm_r files
+    end
+
+  private
+
+    def process(files, regex, replacement = "")
+      files.each do |file|
+        contents = File.read(file)
+        contents.gsub!(regex, replacement)
+        File.open(file, "w") {|f| f << contents }
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Description:

Currently the process of vendoring dependencies is quite tedious because either it requires manual changes, or `automatiek` needs to be refined and tweaked constantly to accommodate new dependencies we vendor. 

## What was the end-user or developer problem that led to this PR?

Since `automatiek` lives as a external gem, when we need to change it, we need to wait for a release before using it in `bundler`, sice our current `Gemfile` setup does not support "git sourced gems". So this process is not very agile.

## What is your fix for the problem, implemented in this PR?

My fix is to move automatiek to the rubygems repo, since it's just one ruby file.

See https://github.com/segiddins/automatiek/issues/10.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).