### PR TITLE
remove explicit require for auto-loaded constant

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1335,8 +1335,6 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   autoload :Specification,      File.expand_path('rubygems/specification', __dir__)
   autoload :Util,               File.expand_path('rubygems/util', __dir__)
   autoload :Version,            File.expand_path('rubygems/version', __dir__)
-
-  require "rubygems/specification"
 end
 
 require 'rubygems/exceptions'

--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -2,9 +2,6 @@
 ##
 # The Dependency class holds a Gem name and a Gem::Requirement.
 
-require "rubygems/bundler_version_finder"
-require "rubygems/requirement"
-
 class Gem::Dependency
 
   ##

--- a/lib/rubygems/gem_runner.rb
+++ b/lib/rubygems/gem_runner.rb
@@ -7,7 +7,6 @@
 
 require 'rubygems'
 require 'rubygems/command_manager'
-require 'rubygems/config_file'
 require 'rubygems/deprecate'
 
 ##

--- a/lib/rubygems/name_tuple.rb
+++ b/lib/rubygems/name_tuple.rb
@@ -4,8 +4,6 @@
 # Represents a gem of name +name+ at +version+ of +platform+. These
 # wrap the data returned from the indexes.
 
-require 'rubygems/platform'
-
 class Gem::NameTuple
 
   def initialize(name, version, platform="ruby")

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -43,7 +43,6 @@
 
 require "rubygems"
 require 'rubygems/security'
-require 'rubygems/specification'
 require 'rubygems/user_interaction'
 require 'zlib'
 

--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "rubygems/version"
 require "rubygems/deprecate"
 
 ##

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -6,9 +6,6 @@
 # See LICENSE.txt for permissions.
 #++
 
-require 'rubygems/version'
-require 'rubygems/requirement'
-require 'rubygems/platform'
 require 'rubygems/deprecate'
 require 'rubygems/basic_specification'
 require 'rubygems/stub_specification'


### PR DESCRIPTION
I do not think RGs needs:
`autoload :Specification, 'rubygems/specification'` 
as well as 
`require 'rubygems/specification'`

maybe for compatibility we should only keep the `require` and remove the `autoload` instead?
the intention seems to have been to only have one, when the require was added but got lost: https://github.com/rubygems/rubygems/commit/0962032ce05d64fd4b87edf748c1e8e93a44f6b7 (https://github.com/rubygems/rubygems/commit/10f1094f81fdb6dfb680655b684d73e226de5400)


## What was the end-user or developer problem that led to this PR?

This is revealing a rare JRuby 9.2 auto-loading bug: https://github.com/jruby/jruby/issues/6293

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
