### PR TITLE
Scripts in `util/` shouldn't be shipped

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -703,14 +703,3 @@ test/rubygems/test_remote_fetch_error.rb
 test/rubygems/test_require.rb
 test/rubygems/wrong_key_cert.pem
 test/rubygems/wrong_key_cert_32.pem
-util/CL2notes
-util/bisect
-util/cops/deprecations.rb
-util/create_certs.rb
-util/create_certs.sh
-util/create_encrypted_key.rb
-util/generate_spdx_license_list.rb
-util/patch_with_prs.rb
-util/rubocop
-util/update_bundled_ca_certificates.rb
-util/update_changelog.rb

--- a/Rakefile
+++ b/Rakefile
@@ -386,7 +386,7 @@ module Rubygems
 
     def self.all
       files = []
-      exclude = %r{\A(?:\.|dev_gems|bundler/(?!lib|man|exe|[^/]+\.md|bundler.gemspec))}
+      exclude = %r{\A(?:\.|dev_gems|bundler/(?!lib|man|exe|[^/]+\.md|bundler.gemspec)|util/)}
       tracked_files = `git ls-files`.split("\n")
 
       tracked_files.each do |path|


### PR DESCRIPTION
# Description:

They are intended only for development and don't get installed anyways.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
