### PR TITLE
Constrain (shipped) RuboCop's version

### DIFF
--- a/bundler/lib/bundler/templates/newgem/Gemfile.tt
+++ b/bundler/lib/bundler/templates/newgem/Gemfile.tt
@@ -13,5 +13,5 @@ gem "rake-compiler"
 gem "<%= config[:test] %>", "~> <%= config[:test_framework_version] %>"
 <%- end -%>
 <%- if config[:rubocop] -%>
-gem "rubocop"
+gem "rubocop", "~> 0.80"
 <%- end -%>


### PR DESCRIPTION
Right now, we're not specifying the version constraints
on RuboCop that is shipped when a new gem is created.
This can break specs which runs rubocop on a new
skeleton gem as the newer versions of RuboCop are
released.

This commit ensures that the specs don't break by
constraining the RuboCop version.

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>

______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).