### PR TITLE
Restore changelog about 3.0.7 and 3.0.8

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -343,6 +343,25 @@ Style changes:
   David Rodríguez.
 * Rubocop 0.71. Pull request #2785 by David Rodríguez.
 
+=== 3.0.8 / 2020-02-19
+
+Bug fixes:
+
+* Gem::Specification#to_ruby needs OpenSSL. Pull request #2937 by
+  Nobuyoshi Nakada.
+
+=== 3.0.7 / 2020-02-18
+
+Bug fixes:
+
+* Fix underscore version selection for bundler #2908 by David Rodríguez.
+* Add missing wrapper. Pull request #2690 by David Rodríguez.
+* Make Gem::Specification#ruby_code handle OpenSSL::PKey::RSA objects.
+  Pull request #2782 by Luis Sagastume.
+* Installer.rb - fix #windows_stub_script. Pull request #2876 by MSP-Greg.
+* Use IAM role to extract security-credentials for EC2 instance. Pull
+  request #2894 by Alexander Pakulov.
+
 === 3.0.6 / 2019-08-17
 
 Bug fixes:


### PR DESCRIPTION
# Description:

I missed to add 3.0.7 and 3.0.8 when releasing them.
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
