### PR TITLE
Avoid calling LoadError#message to not trigger DidYouMean

### DIFF
--- a/bundler/lib/bundler/runtime.rb
+++ b/bundler/lib/bundler/runtime.rb
@@ -43,14 +43,6 @@ module Bundler
       self
     end
 
-    REQUIRE_ERRORS = [
-      /^no such file to load -- (.+)$/i,
-      /^Missing \w+ (?:file\s*)?([^\s]+.rb)$/i,
-      /^Missing API definition file in (.+)$/i,
-      /^cannot load such file -- (.+)$/i,
-      /^dlopen\([^)]*\): Library not loaded: (.+)$/i,
-    ].freeze
-
     def require(*groups)
       groups.map!(&:to_sym)
       groups = [:default] if groups.empty?
@@ -79,16 +71,14 @@ module Bundler
             end
           end
         rescue LoadError => e
-          REQUIRE_ERRORS.find {|r| r =~ e.message }
-          raise if dep.autorequire || $1 != required_file
+          raise if dep.autorequire || e.path != required_file
 
           if dep.autorequire.nil? && dep.name.include?("-")
             begin
               namespaced_file = dep.name.tr("-", "/")
               Kernel.require namespaced_file
             rescue LoadError => e
-              REQUIRE_ERRORS.find {|r| r =~ e.message }
-              raise if $1 != namespaced_file
+              raise if e.path != namespaced_file
             end
           end
         end


### PR DESCRIPTION
Ref: https://github.com/ruby/did_you_mean/commit/078e9b625c887cabb9d88284a73084f260316dcd
Ref: https://github.com/rubygems/rubygems/pull/3660

While profiling our application boot against `ruby-head` I noticed it spend a lot of time in `DidYouMean`:

```
==================================
  Mode: cpu(1000)
  Samples: 59251 (14.73% miss rate)
  GC: 18583 (31.36%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
...
       929   (1.6%)         929   (1.6%)     DidYouMean::Jaro.distance
```

```
==================================
  Mode: wall(1000)
  Samples: 61040 (14.92% miss rate)
  GC: 18959 (31.06%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
...
       939   (1.5%)         939   (1.5%)     DidYouMean::Jaro.distance
```

Overall if I look at `DidYouMean::RequirePathChecker#corrections` specifically, it's `1.7%` of boot time
```
DidYouMean::RequirePathChecker#corrections (/usr/lib/ruby-shopify/ruby-shopify-head/lib/ruby/2.8.0/did_you_mean/spell_checkers/require_path_checker.rb:25)
  samples:     6 self (0.0%)  /    982 total (1.7%)
```

So the idea here is to do like Active Support when it parses `NameError` message, use `original_message` to skip the correction lookup.


cc @yuki24 @deivid-rodriguez 