### PR TITLE
Stop using deprecated OpenSSL::Digest constants

### DIFF
--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -194,7 +194,7 @@ module Bundler
       return @md5_available if defined?(@md5_available)
       @md5_available = begin
         require "openssl"
-        OpenSSL::Digest::MD5.digest("")
+        OpenSSL::Digest.digest("MD5", "")
         true
       rescue LoadError
         true

--- a/bundler/spec/bundler/fetcher/compact_index_spec.rb
+++ b/bundler/spec/bundler/fetcher/compact_index_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Bundler::Fetcher::CompactIndex do
 
         context "when FIPS-mode is active" do
           before do
-            allow(OpenSSL::Digest::MD5).to receive(:digest).
+            allow(OpenSSL::Digest).to receive(:digest).with("MD5", "").
               and_raise(OpenSSL::Digest::DigestError)
           end
 

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -364,12 +364,7 @@ EOM
                  end
 
     algorithms.each do |algorithm|
-      digester =
-        if defined?(OpenSSL::Digest)
-          OpenSSL::Digest.new algorithm
-        else
-          Digest.const_get(algorithm).new
-        end
+      digester = Gem::Security.create_digest(algorithm)
 
       digester << entry.read(16384) until entry.eof?
 

--- a/lib/rubygems/package/tar_writer.rb
+++ b/lib/rubygems/package/tar_writer.rb
@@ -145,8 +145,7 @@ class Gem::Package::TarWriter
         if digest.respond_to? :name
           digest.name
         else
-          /::([^:]+)$/ =~ digest_algorithm.name
-          $1
+          digest_algorithm.class.name[/::([^:]+)\z/, 1]
         end
 
       [digest_name, digest]
@@ -174,7 +173,7 @@ class Gem::Package::TarWriter
   def add_file_signed(name, mode, signer)
     digest_algorithms = [
       signer.digest_algorithm,
-      Digest::SHA512,
+      Digest::SHA512.new,
     ].compact.uniq
 
     digests = add_file_digest name, mode, digest_algorithms do |io|

--- a/lib/rubygems/package/tar_writer.rb
+++ b/lib/rubygems/package/tar_writer.rb
@@ -4,8 +4,6 @@
 # See LICENSE.txt for additional licensing information.
 #++
 
-require 'digest'
-
 ##
 # Allows writing of tar files
 
@@ -173,7 +171,7 @@ class Gem::Package::TarWriter
   def add_file_signed(name, mode, signer)
     digest_algorithms = [
       signer.digest_algorithm,
-      Digest::SHA512.new,
+      Gem::Security.create_digest('SHA512'),
     ].compact.uniq
 
     digests = add_file_digest name, mode, digest_algorithms do |io|

--- a/lib/rubygems/security.rb
+++ b/lib/rubygems/security.rb
@@ -341,14 +341,7 @@ module Gem::Security
   ##
   # Used internally to select the signing digest from all computed digests
 
-  DIGEST_NAME = # :nodoc:
-    if defined?(OpenSSL::Digest::SHA256)
-      'SHA256'
-    elsif defined?(OpenSSL::Digest::SHA1)
-      'SHA1'
-    else
-      'SHA512'
-    end
+  DIGEST_NAME = 'SHA256' # :nodoc:
 
   ##
   # Algorithm for creating the key pair used to sign gems

--- a/lib/rubygems/security.rb
+++ b/lib/rubygems/security.rb
@@ -339,26 +339,15 @@ module Gem::Security
   class Exception < Gem::Exception; end
 
   ##
-  # Digest algorithm used to sign gems
-
-  DIGEST_ALGORITHM =
-    if defined?(OpenSSL::Digest::SHA256)
-      OpenSSL::Digest::SHA256
-    elsif defined?(OpenSSL::Digest::SHA1)
-      OpenSSL::Digest::SHA1
-    else
-      require 'digest'
-      Digest::SHA512
-    end
-
-  ##
   # Used internally to select the signing digest from all computed digests
 
   DIGEST_NAME = # :nodoc:
-    if DIGEST_ALGORITHM.method_defined? :name
-      DIGEST_ALGORITHM.new.name
+    if defined?(OpenSSL::Digest::SHA256)
+      'SHA256'
+    elsif defined?(OpenSSL::Digest::SHA1)
+      'SHA1'
     else
-      DIGEST_ALGORITHM.name[/::([^:]+)\z/, 1]
+      'SHA512'
     end
 
   ##
@@ -468,6 +457,22 @@ module Gem::Security
   end
 
   ##
+  # Creates a new digest instance using the specified +algorithm+. The default
+  # is SHA256.
+
+  if defined?(OpenSSL::Digest)
+    def self.create_digest(algorithm = DIGEST_NAME)
+      OpenSSL::Digest.new(algorithm)
+    end
+  else
+    require 'digest'
+
+    def self.create_digest(algorithm = DIGEST_NAME)
+      Digest.const_get(algorithm).new
+    end
+  end
+
+  ##
   # Creates a new key pair of the specified +length+ and +algorithm+.  The
   # default is a 3072 bit RSA key.
 
@@ -528,7 +533,7 @@ module Gem::Security
 
   ##
   # Sign the public key from +certificate+ with the +signing_key+ and
-  # +signing_cert+, using the Gem::Security::DIGEST_ALGORITHM.  Uses the
+  # +signing_cert+, using the Gem::Security::DIGEST_NAME.  Uses the
   # default certificate validity range and extensions.
   #
   # Returns the newly signed certificate.
@@ -555,7 +560,7 @@ module Gem::Security
     signed = create_cert signee_subject, signee_key, age, extensions, serial
     signed.issuer = signing_cert.subject
 
-    signed.sign signing_key, Gem::Security::DIGEST_ALGORITHM.new
+    signed.sign signing_key, Gem::Security::DIGEST_NAME
   end
 
   ##

--- a/lib/rubygems/security/policy.rb
+++ b/lib/rubygems/security/policy.rb
@@ -76,7 +76,7 @@ class Gem::Security::Policy
 
   def check_data(public_key, digest, signature, data)
     raise Gem::Security::Exception, "invalid signature" unless
-      public_key.verify digest.new, signature, data.digest
+      public_key.verify digest, signature, data.digest
 
     true
   end
@@ -224,7 +224,7 @@ class Gem::Security::Policy
     end
 
     opt       = @opt
-    digester  = Gem::Security::DIGEST_ALGORITHM
+    digester  = Gem::Security.create_digest
     trust_dir = opt[:trust_dir]
     time      = Time.now
 

--- a/lib/rubygems/security/signer.rb
+++ b/lib/rubygems/security/signer.rb
@@ -81,8 +81,8 @@ class Gem::Security::Signer
       @cert_chain = [default_cert] if File.exist? default_cert
     end
 
-    @digest_algorithm = Gem::Security::DIGEST_ALGORITHM
     @digest_name      = Gem::Security::DIGEST_NAME
+    @digest_algorithm = Gem::Security.create_digest(@digest_name)
 
     if @key && !@key.is_a?(OpenSSL::PKey::RSA)
       @key = OpenSSL::PKey::RSA.new(File.read(@key), @passphrase)

--- a/lib/rubygems/security/trust_dir.rb
+++ b/lib/rubygems/security/trust_dir.rb
@@ -26,7 +26,7 @@ class Gem::Security::TrustDir
     @dir = dir
     @permissions = permissions
 
-    @digester = Gem::Security::DIGEST_ALGORITHM
+    @digester = Gem::Security.create_digest
   end
 
   ##

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -1019,7 +1019,7 @@ class TestGemPackage < Gem::Package::TarTestCase
         bogus_data = Gem::Util.gzip 'hello'
         fake_signer = Class.new do
           def digest_name; 'SHA512'; end
-          def digest_algorithm; Digest(:SHA512); end
+          def digest_algorithm; Digest(:SHA512).new; end
           def key; 'key'; end
           def sign(*); 'fake_sig'; end
         end

--- a/test/rubygems/test_gem_package_tar_writer.rb
+++ b/test/rubygems/test_gem_package_tar_writer.rb
@@ -72,7 +72,7 @@ class TestGemPackageTarWriter < Gem::Package::TarTestCase
   end
 
   def test_add_file_digest
-    digest_algorithms = Digest::SHA1, Digest::SHA512
+    digest_algorithms = Digest::SHA1.new, Digest::SHA512.new
 
     Time.stub :now, Time.at(1458518157) do
       digests = @tar_writer.add_file_digest 'x', 0644, digest_algorithms do |io|
@@ -95,7 +95,7 @@ class TestGemPackageTarWriter < Gem::Package::TarTestCase
   end
 
   def test_add_file_digest_multiple
-    digest_algorithms = [Digest::SHA1, Digest::SHA512]
+    digest_algorithms = [Digest::SHA1.new, Digest::SHA512.new]
 
     Time.stub :now, Time.at(1458518157) do
       digests = @tar_writer.add_file_digest 'x', 0644, digest_algorithms do |io|

--- a/test/rubygems/test_gem_security_policy.rb
+++ b/test/rubygems/test_gem_security_policy.rb
@@ -33,7 +33,7 @@ class TestGemSecurityPolicy < Gem::TestCase
       s.files = %w[lib/code.rb]
     end
 
-    @digest = Gem::Security::DIGEST_ALGORITHM
+    @digest = OpenSSL::Digest.new Gem::Security::DIGEST_NAME
     @trust_dir = Gem::Security.trust_dir.dir # HACK use the object
 
     @no        = Gem::Security::NoSecurity
@@ -396,13 +396,11 @@ class TestGemSecurityPolicy < Gem::TestCase
   def test_verify_wrong_digest_type
     Gem::Security.trust_dir.trust_cert PUBLIC_CERT
 
-    sha512 = OpenSSL::Digest::SHA512
-
-    data = sha512.new
+    data = OpenSSL::Digest.new('SHA512')
     data << 'hello'
 
     digests    = { 'SHA512' => { 0 => data } }
-    signature  = PRIVATE_KEY.sign sha512.new, data.digest
+    signature  = PRIVATE_KEY.sign 'sha512', data.digest
     signatures = { 0 => signature }
 
     e = assert_raises Gem::Security::Exception do
@@ -481,7 +479,7 @@ class TestGemSecurityPolicy < Gem::TestCase
     def s.full_name() 'metadata.gz' end
 
     digests = package.digest s
-    digests[Gem::Security::DIGEST_NAME]['data.tar.gz'] = @digest.new 'hello'
+    digests[Gem::Security::DIGEST_NAME]['data.tar.gz'] = @digest.hexdigest 'hello'
 
     metadata_gz_digest = digests[Gem::Security::DIGEST_NAME]['metadata.gz']
 
@@ -510,7 +508,7 @@ class TestGemSecurityPolicy < Gem::TestCase
     def s.full_name() 'metadata.gz' end
 
     digests = package.digest s
-    digests[Gem::Security::DIGEST_NAME]['data.tar.gz'] = @digest.new 'hello'
+    digests[Gem::Security::DIGEST_NAME]['data.tar.gz'] = @digest.hexdigest 'hello'
 
     assert_raises Gem::Security::Exception do
       @high.verify_signatures @spec, digests, {}

--- a/test/rubygems/test_gem_security_trust_dir.rb
+++ b/test/rubygems/test_gem_security_trust_dir.rb
@@ -18,7 +18,7 @@ class TestGemSecurityTrustDir < Gem::TestCase
   end
 
   def test_cert_path
-    digest = Gem::Security::DIGEST_ALGORITHM.hexdigest PUBLIC_CERT.subject.to_s
+    digest = OpenSSL::Digest.hexdigest Gem::Security::DIGEST_NAME, PUBLIC_CERT.subject.to_s
 
     expected = File.join @dest_dir, "cert-#{digest}.pem"
 
@@ -42,7 +42,7 @@ class TestGemSecurityTrustDir < Gem::TestCase
   end
 
   def test_name_path
-    digest = Gem::Security::DIGEST_ALGORITHM.hexdigest PUBLIC_CERT.subject.to_s
+    digest = OpenSSL::Digest.hexdigest Gem::Security::DIGEST_NAME, PUBLIC_CERT.subject.to_s
 
     expected = File.join @dest_dir, "cert-#{digest}.pem"
 

--- a/util/create_certs.rb
+++ b/util/create_certs.rb
@@ -68,7 +68,7 @@ class CertificateBuilder
       cert.add_extension ef.create_extension('keyUsage', 'keyCertSign', true)
     end
 
-    cert.sign issuer_key, OpenSSL::Digest::SHA1.new
+    cert.sign issuer_key, 'SHA1'
 
     puts "created cert - subject: #{cert.subject}, issuer: #{cert.issuer}"
     cert


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Prepare for the deprecations planned in https://github.com/ruby/openssl/pull/366

## What is your fix for the problem, implemented in this PR?

Refactoring and moving a few things around, making a `create_digest` helper method to account for the cases where OpenSSL is not available.

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
