### PR TITLE
Fix remaining RuboCop issues

### DIFF
--- a/bundler/lib/bundler/templates/newgem/Gemfile.tt
+++ b/bundler/lib/bundler/templates/newgem/Gemfile.tt
@@ -9,9 +9,11 @@ gem "rake", "~> 13.0"
 <%- if config[:ext] -%>
 gem "rake-compiler"
 <%- end -%>
+
 <%- if config[:test] -%>
 gem "<%= config[:test] %>", "~> <%= config[:test_framework_version] %>"
 <%- end -%>
+
 <%- if config[:rubocop] -%>
 gem "rubocop", "~> 0.80"
 <%- end -%>

--- a/bundler/lib/bundler/templates/newgem/Gemfile.tt
+++ b/bundler/lib/bundler/templates/newgem/Gemfile.tt
@@ -7,13 +7,14 @@ gemspec
 
 gem "rake", "~> 13.0"
 <%- if config[:ext] -%>
+
 gem "rake-compiler"
 <%- end -%>
-
 <%- if config[:test] -%>
+
 gem "<%= config[:test] %>", "~> <%= config[:test_framework_version] %>"
 <%- end -%>
-
 <%- if config[:rubocop] -%>
+
 gem "rubocop", "~> 0.80"
 <%- end -%>

--- a/bundler/lib/bundler/templates/newgem/Rakefile.tt
+++ b/bundler/lib/bundler/templates/newgem/Rakefile.tt
@@ -36,4 +36,8 @@ Rake::ExtensionTask.new("<%= config[:underscored_name] %>") do |ext|
 end
 
 <% end -%>
-task default: <%= default_task_names.size == 1 ? default_task_names.first.inspect : default_task_names.inspect %>
+<% if default_task_names.size == 1 -%>
+task default: <%= default_task_names.first.inspect %>
+<% else -%>
+task default: %i[<%= default_task_names.join(" ") %>]
+<% end -%>

--- a/bundler/lib/bundler/templates/newgem/ext/newgem/extconf.rb.tt
+++ b/bundler/lib/bundler/templates/newgem/ext/newgem/extconf.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "mkmf"
 
 create_makefile(<%= config[:makefile_path].inspect %>)

--- a/bundler/lib/bundler/templates/newgem/test/minitest/newgem_test.rb.tt
+++ b/bundler/lib/bundler/templates/newgem/test/minitest/newgem_test.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class <%= config[:constant_name] %>Test < Minitest::Test

--- a/bundler/lib/bundler/templates/newgem/test/minitest/test_helper.rb.tt
+++ b/bundler/lib/bundler/templates/newgem/test/minitest/test_helper.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "<%= config[:namespaced_path] %>"
 

--- a/bundler/lib/bundler/templates/newgem/test/test-unit/newgem_test.rb.tt
+++ b/bundler/lib/bundler/templates/newgem/test/test-unit/newgem_test.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class <%= config[:constant_name] %>Test < Test::Unit::TestCase

--- a/bundler/lib/bundler/templates/newgem/test/test-unit/test_helper.rb.tt
+++ b/bundler/lib/bundler/templates/newgem/test/test-unit/test_helper.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "<%= config[:namespaced_path] %>"
 

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -914,7 +914,7 @@ RSpec.describe "bundle gem" do
             ext.lib_dir = "lib/#{gem_name}"
           end
 
-          task default: [:clobber, :compile]
+          task default: %i[clobber compile]
         RAKEFILE
 
         expect(bundled_app("#{gem_name}/Rakefile").read).to eq(rakefile)

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -212,35 +212,35 @@ RSpec.describe "bundle gem" do
     end
   end
 
-  it "has no rubocop offenses when using --rubocop flag" do
+  it "has no rubocop offenses when using --rubocop flag", :readline do
     skip "ruby_core has an 'ast.rb' file that gets in the middle and breaks this spec" if ruby_core?
     bundle "gem #{gem_name} --rubocop"
     bundle_exec_rubocop
     expect(err).to be_empty
   end
 
-  it "has no rubocop offenses when using --ext and --rubocop flag" do
+  it "has no rubocop offenses when using --ext and --rubocop flag", :readline do
     skip "ruby_core has an 'ast.rb' file that gets in the middle and breaks this spec" if ruby_core?
     bundle "gem #{gem_name} --ext --rubocop"
     bundle_exec_rubocop
     expect(err).to be_empty
   end
 
-  it "has no rubocop offenses when using --ext, --test=minitest, and --rubocop flag" do
+  it "has no rubocop offenses when using --ext, --test=minitest, and --rubocop flag", :readline do
     skip "ruby_core has an 'ast.rb' file that gets in the middle and breaks this spec" if ruby_core?
     bundle "gem #{gem_name} --ext --test=minitest --rubocop"
     bundle_exec_rubocop
     expect(err).to be_empty
   end
 
-  it "has no rubocop offenses when using --ext, --test=rspec, and --rubocop flag" do
+  it "has no rubocop offenses when using --ext, --test=rspec, and --rubocop flag", :readline do
     skip "ruby_core has an 'ast.rb' file that gets in the middle and breaks this spec" if ruby_core?
     bundle "gem #{gem_name} --ext --test=rspec --rubocop"
     bundle_exec_rubocop
     expect(err).to be_empty
   end
 
-  it "has no rubocop offenses when using --ext, --ext=test-unit, and --rubocop flag" do
+  it "has no rubocop offenses when using --ext, --ext=test-unit, and --rubocop flag", :readline do
     skip "ruby_core has an 'ast.rb' file that gets in the middle and breaks this spec" if ruby_core?
     bundle "gem #{gem_name} --ext --test=test-unit --rubocop"
     bundle_exec_rubocop


### PR DESCRIPTION
With #3731 and #3740 merged, this covers up the
remaining part of the issues.
This was discovered when one tries to create a gem
with a different framework.
Could be reproduced with:
`bundle gem foo --ext --test=minitest --rubocop`

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
