### PR TITLE
Allow setting a tag prefix to be used by gem release tasks

### DIFF
--- a/bundler/lib/bundler/gem_helper.rb
+++ b/bundler/lib/bundler/gem_helper.rb
@@ -15,6 +15,10 @@ module Bundler
         new(opts[:dir], opts[:name]).install
       end
 
+      def tag_prefix=(prefix)
+        instance.tag_prefix = prefix
+      end
+
       def gemspec(&block)
         gemspec = instance.gemspec
         block.call(gemspec) if block
@@ -24,12 +28,15 @@ module Bundler
 
     attr_reader :spec_path, :base, :gemspec
 
+    attr_writer :tag_prefix
+
     def initialize(base = nil, name = nil)
       @base = File.expand_path(base || SharedHelpers.pwd)
       gemspecs = name ? [File.join(@base, "#{name}.gemspec")] : Dir[File.join(@base, "{,*}.gemspec")]
       raise "Unable to determine name from existing gemspec. Use :name => 'gemname' in #install_tasks to manually set it." unless gemspecs.size == 1
       @spec_path = gemspecs.first
       @gemspec = Bundler.load_gemspec(@spec_path)
+      @tag_prefix = ""
     end
 
     def install
@@ -168,7 +175,7 @@ module Bundler
     end
 
     def version_tag
-      "v#{version}"
+      "#{@tag_prefix}v#{version}"
     end
 
     def name

--- a/bundler/spec/bundler/gem_helper_spec.rb
+++ b/bundler/spec/bundler/gem_helper_spec.rb
@@ -258,6 +258,23 @@ RSpec.describe Bundler::GemHelper do
           end
         end
 
+        context "on releasing with a custom tag prefix" do
+          before do
+            Bundler::GemHelper.tag_prefix = "foo-"
+            mock_build_message app_name, app_version
+            mock_confirm_message "Pushed git commits and tags."
+
+            sys_exec("git push -u origin master", :dir => app_path)
+            expect(subject).to receive(:rubygem_push).with(app_gem_path.to_s)
+          end
+
+          it "prepends the custom prefix to the tag" do
+            mock_confirm_message "Tagged foo-v#{app_version}."
+
+            Rake.application["release"].invoke
+          end
+        end
+
         it "even if tag already exists" do
           mock_build_message app_name, app_version
           mock_confirm_message "Tag v#{app_version} has already been created."


### PR DESCRIPTION
# Description:

## What was the end-user or developer problem that led to this PR?

In order to be able to release rubygems & bundler from the same repo, we need to make sure that the generated tags don't overwrite each other. For example, we don't want the tag for the bundler 2.2.0 release to overwrite the tag for the rubygems 2.2.0 release.

## What is your fix for the problem, implemented in this PR?

My fix is to provide a `Bundler::GemHelper.tag_prefix=` setter to be able to have some control over the tag names. I plan to use it [like here](https://github.com/rubygems/rubygems/pull/3703/commits/71bd2487725d184124eb6648f977e9f7255c7602).

Honestly, I don't specially like this solution, but it fixes the issue and unblocks the releases. I'm happy to hear other proposals though.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
