### PR TITLE
Remove explicit require for autoloaded constant

### DIFF
--- a/lib/rubygems/dependency_installer.rb
+++ b/lib/rubygems/dependency_installer.rb
@@ -5,7 +5,6 @@ require 'rubygems/package'
 require 'rubygems/installer'
 require 'rubygems/spec_fetcher'
 require 'rubygems/user_interaction'
-require 'rubygems/source'
 require 'rubygems/available_set'
 require 'rubygems/deprecate'
 

--- a/lib/rubygems/source_list.rb
+++ b/lib/rubygems/source_list.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'rubygems/source'
 
 ##
 # The SourceList represents the sources rubygems has been configured to use.


### PR DESCRIPTION
# Description:

This is a followup to #3751. It workarounds another instance of the same issue in jruby by removing a couple of other redundant requires.

Closes #3696.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
