### PR TITLE
Remove more unnecessary requires

### DIFF
--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -136,14 +136,10 @@ module Bundler
     end
 
     def inflate(obj)
-      require "rubygems/util"
-
       Gem::Util.inflate(obj)
     end
 
     def correct_for_windows_path(path)
-      require "rubygems/util"
-
       if Gem::Util.respond_to?(:correct_for_windows_path)
         Gem::Util.correct_for_windows_path(path)
       elsif path[0].chr == "/" && path[1].chr =~ /[a-z]/i && path[2].chr == ":"

--- a/lib/rubygems/bundler_version_finder.rb
+++ b/lib/rubygems/bundler_version_finder.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "rubygems/util"
-
 module Gem::BundlerVersionFinder
   def self.bundler_version
     version, _ = bundler_version_with_reason

--- a/lib/rubygems/commands/open_command.rb
+++ b/lib/rubygems/commands/open_command.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require 'rubygems/command'
 require 'rubygems/version_option'
-require 'rubygems/util'
 
 class Gem::Commands::OpenCommand < Gem::Command
 

--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require 'rubygems/dependency'
 require 'rubygems/exceptions'
-require 'rubygems/util'
 require 'rubygems/util/list'
 
 ##

--- a/lib/rubygems/source/git.rb
+++ b/lib/rubygems/source/git.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'rubygems/util'
 
 ##
 # A git gem for use in a gem dependencies file.

--- a/lib/rubygems/user_interaction.rb
+++ b/lib/rubygems/user_interaction.rb
@@ -5,7 +5,6 @@
 # See LICENSE.txt for permissions.
 #++
 
-require 'rubygems/util'
 require 'rubygems/deprecate'
 require 'rubygems/text'
 


### PR DESCRIPTION
This is another followup to #3751 and #3770. `rubygems/util` is autoloaded too, so we can skip those requires as well.

In this case, it should workaround this recent CI flaky failure on jruby: https://github.com/rubygems/rubygems/runs/824140494.

Copying the log for posterity:

```
Failures:

  1) [TEST_ENV_NUMBER=1] bundle platform bundle console fails when engine version doesn't match
     Failure/Error:
               raise <<~ERROR
       
                 Invoking `#{cmd}` failed with output:
                 ----------------------------------------------------------------------
                 #{command_execution.stdboth}
                 ----------------------------------------------------------------------
               ERROR

     RuntimeError:

       Invoking `/home/runner/.rubies/jruby-9.2.11.1/bin/jruby -I/home/runner/work/rubygems/rubygems/bundler/spec -r/home/runner/work/rubygems/rubygems/bundler/spec/support/artifice/fail.rb -r/home/runner/work/rubygems/rubygems/bundler/spec/support/hax.rb /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/bin/bundle install --retry 0` failed with output:
       ----------------------------------------------------------------------
       Unfortunately, an unexpected error occurred, and Bundler cannot continue.

       First, try this link to see if there are any existing issue reports for this error:
       https://github.com/rubygems/rubygems/search?q=uninitialized+constant+Gem++Util&type=Issues

       If there aren't any reports for this error yet, please create copy and paste the report template above into a new issue. Don't forget to anonymize any private data! The new issue form is located at:
       https://github.com/rubygems/rubygems/issues/new?labels=Bundler
       Fetching source index from file:///home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/remote1/
       Resolving dependencies...
       Using bundler 2.2.0.dev
       Fetching activesupport 2.3.5
       Fetching rack 0.9.1

       Installing rack 0.9.1
       --- ERROR REPORT TEMPLATE -------------------------------------------------------
       # Error Report

       ## Questions

       Please fill out answers to these questions, it'll help us figure out
       why things are going wrong.

       - **What did you do?**

         I ran the command `/home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/bin/bundle install --retry 0`

       - **What did you expect to happen?**

         I expected Bundler to...

       - **What happened instead?**

         Instead, what happened was...

       - **Have you tried any solutions posted on similar issues in our issue tracker, stack overflow, or google?**

         I tried...

       - **Have you read our issues document, https://github.com/rubygems/rubygems/blob/master/bundler/doc/contributing/ISSUES.md?**

         ...

       ## Backtrace

       ```
       NameError: uninitialized constant Gem::Util
         org/jruby/RubyModule.java:3760:in `const_missing'
         /home/runner/work/rubygems/rubygems/lib/rubygems/remote_fetcher.rb:169:in `download'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.2.0.dev/lib/bundler/rubygems_integration.rb:522:in `block in download_gem'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.2.0.dev/lib/bundler/retry.rb:40:in `run'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.2.0.dev/lib/bundler/retry.rb:30:in `attempt'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.2.0.dev/lib/bundler/rubygems_integration.rb:521:in `download_gem'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.2.0.dev/lib/bundler/source/rubygems.rb:489:in `download_gem'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.2.0.dev/lib/bundler/source/rubygems.rb:430:in `fetch_gem'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.2.0.dev/lib/bundler/source/rubygems.rb:122:in `install'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.2.0.dev/lib/bundler/installer/gem_installer.rb:67:in `install'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.2.0.dev/lib/bundler/installer/gem_installer.rb:18:in `install_from_spec'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.2.0.dev/lib/bundler/installer/parallel_installer.rb:163:in `do_install'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.2.0.dev/lib/bundler/installer/parallel_installer.rb:154:in `block in worker_pool'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.2.0.dev/lib/bundler/worker.rb:62:in `apply_func'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.2.0.dev/lib/bundler/worker.rb:57:in `block in process_queue'
         org/jruby/RubyKernel.java:1442:in `loop'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.2.0.dev/lib/bundler/worker.rb:54:in `process_queue'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.2.0.dev/lib/bundler/worker.rb:88:in `block in create_threads'
       ```

       ## Environment

       ```
       Bundler       2.2.0.dev
         Platforms   ruby, universal-java-1.8
       Ruby          2.5.7p0 (2020-03-25 revision 67816) [java]
         Full Path   /home/runner/.rubies/jruby-9.2.11.1/bin/jruby
         Config Dir  /home/runner/.rubies/jruby-9.2.11.1/etc
       RubyGems      3.2.0.pre1
         Gem Home    /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system
         Gem Path    /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system
         User Home   /home/runner/work/rubygems/rubygems/bundler/tmp/1/home
         User Path   /home/runner/work/rubygems/rubygems/bundler/tmp/1/home/.local/share/gem/jruby/2.5.0
         Bin Dir     /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/bin
       OpenSSL       
         Compiled    JRuby-OpenSSL 0.10.4
         Loaded      JRuby-OpenSSL 0.10.4
         Cert File   /usr/lib/jvm/zulu-8-azure-amd64/jre/lib/security/cacerts
         Cert Dir    /etc/ssl/certs
       Tools         
         Git         2.27.0
         RVM         not installed
         rbenv       not installed
         chruby      not installed
       Gem.ruby      /home/runner/.rubies/jruby-9.2.11.1/bin/jruby
       bundle #!     /usr/bin/env jruby

       ```

       ## Bundler Build Metadata

       ```
       Built At          2020-06-30
       Git SHA           e123287
       Released Version  
       ```

       ## Bundler settings

       ```
       retry
         Set for your local app (/home/runner/work/rubygems/rubygems/bundler/tmp/1/bundled_app/.bundle/config): 0
       spec_run
         Set via BUNDLE_SPEC_RUN: "true"
       ```

       ## Gemfile

       ### Gemfile

       ```ruby
       source "file:///home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/remote1"
       gem "rack"
       gem "activesupport", :group => :test
       gem "rack_middleware", :group => :development
       ```

       ### Gemfile.lock

       ```
       <No /home/runner/work/rubygems/rubygems/bundler/tmp/1/bundled_app/Gemfile.lock found>
       ```

       --- TEMPLATE END ----------------------------------------------------------------
       ----------------------------------------------------------------------
     # ./spec/support/helpers.rb:206:in `sys_exec'
     # ./spec/support/helpers.rb:123:in `bundle'
     # ./spec/support/helpers.rb:279:in `install_gemfile'
     # ./spec/other/platform_spec.rb:901:in `block in <main>'
     # ./spec/spec_helper.rb:102:in `block in <main>'
     # ./spec/spec_helper.rb:102:in `block in <main>'
     # ./spec/support/helpers.rb:353:in `block in with_gem_path_as'
     # ./spec/support/helpers.rb:367:in `without_env_side_effects'
     # ./spec/support/helpers.rb:349:in `with_gem_path_as'
     # ./spec/spec_helper.rb:101:in `block in <main>'
     # ./spec/spec_helper.rb:73:in `block in <main>'
     # ./spec/support/rubygems_ext.rb:90:in `gem_load_and_activate'
     # ./spec/support/rubygems_ext.rb:18:in `gem_load'
```

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
