### PR TITLE
Unswallow `Gem::Package::FormatError`

### DIFF
--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -251,8 +251,6 @@ module Bundler
       require "rubygems/security"
       require_relative "psyched_yaml"
       gem_from_path(path, security_policies[policy]).spec
-    rescue Gem::Package::FormatError
-      raise GemspecError, "Could not read gem at #{path}. It may be corrupted."
     rescue Exception, Gem::Exception, Gem::Security::Exception => e # rubocop:disable Lint/RescueException
       if e.is_a?(Gem::Security::Exception) ||
           e.message =~ /unknown trust policy|unsigned gem/i ||


### PR DESCRIPTION
# Description:

This error [happened in a CI run](https://github.com/rubygems/rubygems/pull/3773/checks?check_run_id=826531863), and as it is currently, it doesn't give any useful information about the underlying cause. Let's not swallow the original error.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
