### PR TITLE
Optimize CI

### DIFF
--- a/.github/workflows/older-rubygems-bundler.yml
+++ b/.github/workflows/older-rubygems-bundler.yml
@@ -1,0 +1,62 @@
+name: older-rubygems-bundler
+
+on:
+  pull_request:
+
+  push:
+    branches:
+      - master
+      - 3.2
+
+jobs:
+  older_rubygems_bundler:
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        ruby: [ 2.3.8, 2.4.10, 2.5.8, 2.6.6, 2.7.1 ]
+        rgv: [ v2.5.2, v2.6.14, v2.7.10, v3.0.8, v3.1.4 ]
+        bundler: [ '' ]
+        exclude:
+          - { bundler: '', ruby: 2.4.10, rgv: v2.5.2  }
+          - { bundler: '', ruby: 2.5.8, rgv: v2.5.2  }
+          - { bundler: '', ruby: 2.5.8, rgv: v2.6.14 }
+          - { bundler: '', ruby: 2.6.6, rgv: v2.5.2  }
+          - { bundler: '', ruby: 2.6.6, rgv: v2.6.14 }
+          - { bundler: '', ruby: 2.6.6, rgv: v2.7.10 }
+          - { bundler: '', ruby: 2.7.1, rgv: v2.5.2  }
+          - { bundler: '', ruby: 2.7.1, rgv: v2.6.14 }
+          - { bundler: '', ruby: 2.7.1, rgv: v2.7.10 }
+          - { bundler: '', ruby: 2.7.1, rgv: v3.0.8  }
+        include:
+          - { bundler: 3.0.0, ruby: 2.4.10, rgv: v3.1.4 }
+          - { bundler: 3.0.0, ruby: 2.5.8, rgv: v3.1.4 }
+          - { bundler: 3.0.0, ruby: 2.6.6, rgv: v3.1.4 }
+          - { bundler: 3.0.0, ruby: 2.7.1, rgv: v3.1.4 }
+    env:
+      RGV: ${{ matrix.rgv }}
+      RUBYOPT: --disable-gems
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler: none
+      - name: Install graphviz
+        run: sudo apt-get install graphviz -y
+        if: matrix.bundler == ''
+      - name: Replace version
+        run: BUNDLER_SPEC_SUB_VERSION=${{ matrix.bundler }} bin/rake override_version
+        if: matrix.bundler != ''
+        working-directory: ./bundler
+      - name: Prepare dependencies
+        run: |
+          bin/rake spec:parallel_deps
+        working-directory: ./bundler
+      - name: Run Test
+        run: |
+          bin/rake spec:all
+        working-directory: ./bundler
+    timeout-minutes: 60

--- a/.github/workflows/older-rubygems-bundler.yml
+++ b/.github/workflows/older-rubygems-bundler.yml
@@ -2,6 +2,10 @@ name: older-rubygems-bundler
 
 on:
   pull_request:
+    paths:
+      - bundler/**
+      - .github/workflows/older-rubygems-bundler.yml
+      - .rubocop_bundler.yml
 
   push:
     branches:

--- a/.github/workflows/ubuntu-bundler.yml
+++ b/.github/workflows/ubuntu-bundler.yml
@@ -14,40 +14,14 @@ jobs:
     strategy:
       matrix:
         ruby: [ 2.3.8, 2.4.10, 2.5.8, 2.6.6, 2.7.1 ]
-        rgv: [ v2.5.2, v2.6.14, v2.7.10, v3.0.8, v3.1.4, .. ]
-        bundler: [ '' ]
+        bundler: [ '', 3.0.0 ]
         exclude:
-          - { bundler: '', ruby: 2.4.10, rgv: v2.5.2  }
-          - { bundler: '', ruby: 2.5.8, rgv: v2.5.2  }
-          - { bundler: '', ruby: 2.5.8, rgv: v2.6.14 }
-          - { bundler: '', ruby: 2.6.6, rgv: v2.5.2  }
-          - { bundler: '', ruby: 2.6.6, rgv: v2.6.14 }
-          - { bundler: '', ruby: 2.6.6, rgv: v2.7.10 }
-          - { bundler: '', ruby: 2.7.1, rgv: v2.5.2  }
-          - { bundler: '', ruby: 2.7.1, rgv: v2.6.14 }
-          - { bundler: '', ruby: 2.7.1, rgv: v2.7.10 }
-          - { bundler: '', ruby: 2.7.1, rgv: v3.0.8  }
-        include:
-          - { bundler: 3.0.0, ruby: 2.4.10, rgv: v3.1.4 }
-          - { bundler: 3.0.0, ruby: 2.4.10, rgv: .. }
-          - { bundler: 3.0.0, ruby: 2.5.8, rgv: v3.1.4 }
-          - { bundler: 3.0.0, ruby: 2.5.8, rgv: .. }
-          - { bundler: 3.0.0, ruby: 2.6.6, rgv: v3.1.4 }
-          - { bundler: 3.0.0, ruby: 2.6.6, rgv: .. }
-          - { bundler: 3.0.0, ruby: 2.7.1, rgv: v3.1.4 }
-          - { bundler: 3.0.0, ruby: 2.7.1, rgv: .. }
+          - { bundler: 3.0.0, ruby: 2.3.8 }
     env:
-      RGV: ${{ matrix.rgv }}
+      RGV: ..
       RUBYOPT: --disable-gems
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-        if: matrix.rgv != '..'
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-        if: matrix.rgv == '..'
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
# Description:

Many of our CI matrix entries take care of testing bundler's code against different (old) versions of rubygems. In these cases, if only code in rubygems changes, it's pointless to run all these builds, since since the code being changed is not exercised by any of them (they only run old rubygems, not the code that we have changed).

So, we can skip these builds in the case where only rubygems files have been changed by a PR.

Supersedes #3745.

Closes #3735.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
