### PR TITLE
Fix setting build metadata in development

### DIFF
--- a/bundler/lib/bundler/build_metadata.rb
+++ b/bundler/lib/bundler/build_metadata.rb
@@ -32,14 +32,6 @@ module Bundler
         return @git_commit_sha = Dir.chdir(git_dir) { `git rev-parse --short HEAD`.strip.freeze }
       end
 
-      # If Bundler is a submodule in RubyGems, get the submodule commit
-      git_sub_dir = File.join(File.expand_path("../../../..", __FILE__), ".git")
-      if File.directory?(git_sub_dir)
-        return @git_commit_sha = Dir.chdir(git_sub_dir) do
-          `git ls-tree --abbrev=8 HEAD bundler`.split(/\s/).fetch(2, "").strip.freeze
-        end
-      end
-
       @git_commit_sha ||= "unknown"
     end
 

--- a/bundler/lib/bundler/build_metadata.rb
+++ b/bundler/lib/bundler/build_metadata.rb
@@ -27,7 +27,7 @@ module Bundler
 
       # If Bundler has been installed without its .git directory and without a
       # commit instance variable then we can't determine its commits SHA.
-      git_dir = File.join(File.expand_path("../../..", __FILE__), ".git")
+      git_dir = File.join(File.expand_path("../../../..", __FILE__), ".git")
       if File.directory?(git_dir)
         return @git_commit_sha = Dir.chdir(git_dir) { `git rev-parse --short HEAD`.strip.freeze }
       end

--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -15,6 +15,7 @@ require "rspec/expectations"
 require "rspec/mocks"
 
 require_relative "support/builders"
+require_relative "support/build_metadata"
 require_relative "support/filters"
 require_relative "support/helpers"
 require_relative "support/indexes"

--- a/bundler/spec/support/build_metadata.rb
+++ b/bundler/spec/support/build_metadata.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative "path"
+require_relative "helpers"
+
+module Spec
+  module BuildMetadata
+    include Spec::Path
+    include Spec::Helpers
+
+    def write_build_metadata(dir: source_root)
+      build_metadata = {
+        :git_commit_sha => git_commit_sha,
+        :built_at => loaded_gemspec.date.utc.strftime("%Y-%m-%d"),
+        :release => true,
+      }
+
+      replace_build_metadata(build_metadata, dir: dir) # rubocop:disable Style/HashSyntax
+    end
+
+    def reset_build_metadata(dir: source_root)
+      build_metadata = {
+        :release => false,
+      }
+
+      replace_build_metadata(build_metadata, dir: dir) # rubocop:disable Style/HashSyntax
+    end
+
+  private
+
+    def replace_build_metadata(build_metadata, dir:)
+      build_metadata_file = File.expand_path("lib/bundler/build_metadata.rb", dir)
+
+      ivars = build_metadata.sort.map do |k, v|
+        "    @#{k} = #{loaded_gemspec.send(:ruby_code, v)}"
+      end.join("\n")
+
+      contents = File.read(build_metadata_file)
+      contents.sub!(/^(\s+# begin ivars).+(^\s+# end ivars)/m, "\\1\n#{ivars}\n\\2")
+      File.open(build_metadata_file, "w") {|f| f << contents }
+    end
+
+    def git_commit_sha
+      ruby_core_tarball? ? "unknown" : sys_exec("git rev-parse --short HEAD", :dir => source_root).strip
+    end
+
+    extend self
+  end
+end

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -333,6 +333,7 @@ module Spec
         build_metadata = {
           :built_at => loaded_gemspec.date.utc.strftime("%Y-%m-%d"),
           :git_commit_sha => git_commit_sha,
+          :release => true,
         }
 
         replace_build_metadata(build_metadata, dir: build_path) # rubocop:disable Style/HashSyntax

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -330,13 +330,7 @@ module Spec
 
         replace_version_file(version, dir: build_path) # rubocop:disable Style/HashSyntax
 
-        build_metadata = {
-          :built_at => loaded_gemspec.date.utc.strftime("%Y-%m-%d"),
-          :git_commit_sha => git_commit_sha,
-          :release => true,
-        }
-
-        replace_build_metadata(build_metadata, dir: build_path) # rubocop:disable Style/HashSyntax
+        Spec::BuildMetadata.write_build_metadata(dir: build_path) # rubocop:disable Style/HashSyntax
 
         gem_command "build #{relative_gemspec}", :dir => build_path
 

--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -208,18 +208,6 @@ module Spec
       File.open(version_file, "w") {|f| f << contents }
     end
 
-    def replace_build_metadata(build_metadata, dir: source_root)
-      build_metadata_file = File.expand_path("lib/bundler/build_metadata.rb", dir)
-
-      ivars = build_metadata.sort.map do |k, v|
-        "    @#{k} = #{loaded_gemspec.send(:ruby_code, v)}"
-      end.join("\n")
-
-      contents = File.read(build_metadata_file)
-      contents.sub!(/^(\s+# begin ivars).+(^\s+# end ivars)/m, "\\1\n#{ivars}\n\\2")
-      File.open(build_metadata_file, "w") {|f| f << contents }
-    end
-
     def ruby_core?
       # avoid to warnings
       @ruby_core ||= nil
@@ -229,10 +217,6 @@ module Spec
       else
         @ruby_core
       end
-    end
-
-    def git_commit_sha
-      ruby_core_tarball? ? "unknown" : sys_exec("git rev-parse --short HEAD", :dir => source_root).strip
     end
 
   private

--- a/bundler/task/release.rake
+++ b/bundler/task/release.rake
@@ -8,7 +8,7 @@ task :build_metadata do
   build_metadata = {
     :built_at => Bundler::GemHelper.gemspec.date.utc.strftime("%Y-%m-%d"),
     :git_commit_sha => `git rev-parse --short HEAD`.strip,
-    :release => Rake::Task["release"].instance_variable_get(:@already_invoked),
+    :release => true,
   }
 
   Spec::Path.replace_build_metadata(build_metadata)

--- a/bundler/task/release.rake
+++ b/bundler/task/release.rake
@@ -1,26 +1,17 @@
 # frozen_string_literal: true
 
 require_relative "../lib/bundler/gem_tasks"
+require_relative "../spec/support/build_metadata"
 
 Bundler::GemHelper.tag_prefix = "bundler-"
 
 task :build_metadata do
-  build_metadata = {
-    :built_at => Bundler::GemHelper.gemspec.date.utc.strftime("%Y-%m-%d"),
-    :git_commit_sha => `git rev-parse --short HEAD`.strip,
-    :release => true,
-  }
-
-  Spec::Path.replace_build_metadata(build_metadata)
+  Spec::BuildMetadata.write_build_metadata
 end
 
 namespace :build_metadata do
   task :clean do
-    build_metadata = {
-      :release => false,
-    }
-
-    Spec::Path.replace_build_metadata(build_metadata)
+    Spec::BuildMetadata.reset_build_metadata
   end
 end
 


### PR DESCRIPTION
# Description:

This code should've changed when we merged the repos, but we forgot to do it.

Before this PR:

```
$ bin/bundle version
Bundler version 2.2.0.dev (2020-07-02 commit 54d9c28b)
(master) deivid@chaba ~/Code/rubygems/rubygems/bundler $ git show 54d9c28b
tree 54d9c28b

.gitignore
.rspec
CHANGELOG.md
LICENSE.md
README.md
Rakefile
UPGRADING.md
bin/
bundler.gemspec
dev_gems.rb
dev_gems.rb.lock
doc/
exe/
lib/
man/
spec/
task/
test_gems.rb
test_gems.rb.lock
tool/
```

After this PR:

```
$ bin/bundle version
Bundler version 2.2.0.dev (2020-07-02 commit 378d38a5c1)
$ git show 378d38a5c1 
commit 378d38a5c17dd710728513155f713e215798496a (HEAD -> build_metadata, origin/build_metadata)
Author: David Rodríguez <deivid.rodriguez@riseup.net>
Date:   Thu Jul 2 13:10:45 2020 +0200

    More refactoring of setting build metadata

diff --git a/bundler/spec/support/build_metadata.rb b/bundler/spec/support/build_metadata.rb
index e8994226bd..b49729fa33 100644
--- a/bundler/spec/support/build_metadata.rb
+++ b/bundler/spec/support/build_metadata.rb
@@ -9,7 +9,7 @@ module BuildMetadata
     include Spec::Helpers
 
     def write_build_metadata(build_metadata, dir: source_root)
-      replace_build_metadata(build_metadata.merge(:git_commit_sha => git_commit_sha))
+      replace_build_metadata(build_metadata.merge(:git_commit_sha => git_commit_sha, :built_at => loaded_gemspec.date.utc.strftime("%Y-%m-%d")))
     end
 
     def replace_build_metadata(build_metadata, dir: source_root)
diff --git a/bundler/spec/support/helpers.rb b/bundler/spec/support/helpers.rb
index b3239a3974..668526412d 100644
--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -330,11 +330,7 @@ def with_built_bundler(version = nil)
 
         replace_version_file(version, dir: build_path) # rubocop:disable Style/HashSyntax
 
-        build_metadata = {
-          :built_at => loaded_gemspec.date.utc.strftime("%Y-%m-%d"),
-        }
-
-        Spec::BuildMetadata.write_build_metadata(build_metadata, dir: build_path) # rubocop:disable Style/HashSyntax
+        Spec::BuildMetadata.write_build_metadata({}, dir: build_path) # rubocop:disable Style/HashSyntax
 
         gem_command "build #{relative_gemspec}", :dir => build_path
 
diff --git a/bundler/task/release.rake b/bundler/task/release.rake
index 50a50adb78..2113ef273d 100644
--- a/bundler/task/release.rake
+++ b/bundler/task/release.rake
@@ -7,7 +7,6 @@ Bundler::GemHelper.tag_prefix = "bundler-"
 
 task :build_metadata do
   build_metadata = {
-    :built_at => Bundler::GemHelper.gemspec.date.utc.strftime("%Y-%m-%d"),
     :release => Rake::Task["release"].instance_variable_get(:@already_invoked),
   }
 
```

Note that this is only for development. The release scripts should properly setting these values correctly.

While figuring this out, I moved some common logic around this together.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
