### PR TITLE
Remove fileutils autoload

### DIFF
--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -129,6 +129,7 @@ class Gem::RemoteFetcher
     gem_file_name = File.basename spec.cache_file
     local_gem_path = File.join cache_dir, gem_file_name
 
+    require "fileutils"
     FileUtils.mkdir_p cache_dir rescue nil unless File.exist? cache_dir
 
     source_uri = parse_uri(source_uri)

--- a/lib/rubygems/source.rb
+++ b/lib/rubygems/source.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-autoload :FileUtils, 'fileutils'
 
 require "rubygems/text"
 ##


### PR DESCRIPTION
# Description:

We got another crash on jruby due to the issue they have where sometimes both explicitly autoloading and requiring something fails: https://github.com/rubygems/rubygems/pull/3778/checks?check_run_id=830626276.

In this case, I'd like to try removing the top level `autoload`, since this `autoload` keeps coming up and surprising me. I don't recall the situation, but I was definitely bitten by this inside `bundler` when I was expecting `Bundler`'s own copy of `fileutils` to be loaded, and instead getting the default version.

Let's run tests and see what fails.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
