### PR TITLE
Don't authenticate github API through query parameters

### DIFF
--- a/bundler/task/release.rake
+++ b/bundler/task/release.rake
@@ -32,7 +32,7 @@ task "release:rubygem_push" => ["release:verify_docs", "release:verify_github", 
 namespace :release do
   task :verify_docs => :"man:check"
 
-  def gh_api_post(opts)
+  def gh_api_authenticated_request(opts)
     require "netrc"
     require "net/http"
     require "json"
@@ -70,7 +70,7 @@ namespace :release do
 
   task :verify_github do
     require "pp"
-    gh_api_post :path => "/user"
+    gh_api_authenticated_request :path => "/user"
   end
 
   def confirm(prompt = "")
@@ -136,13 +136,13 @@ namespace :release do
     version = Gem::Version.new(args.version || Bundler::GemHelper.gemspec.version)
     tag = "bundler-v#{version}"
 
-    gh_api_post :path => "/repos/rubygems/rubygems/releases",
-                :body => {
-                  :tag_name => tag,
-                  :name => tag,
-                  :body => release_notes(version),
-                  :prerelease => version.prerelease?,
-                }
+    gh_api_authenticated_request :path => "/repos/rubygems/rubygems/releases",
+                                 :body => {
+                                   :tag_name => tag,
+                                   :name => tag,
+                                   :body => release_notes(version),
+                                   :prerelease => version.prerelease?,
+                                 }
   end
 
   desc "Prepare a patch release with the PRs from master in the patch milestone"

--- a/bundler/task/release.rake
+++ b/bundler/task/release.rake
@@ -68,6 +68,7 @@ namespace :release do
     JSON.parse(response.body)
   end
 
+  desc "Make sure github API is ready to be used"
   task :verify_github do
     require "pp"
     gh_api_authenticated_request :path => "/user"

--- a/bundler/task/release.rake
+++ b/bundler/task/release.rake
@@ -70,7 +70,6 @@ namespace :release do
 
   desc "Make sure github API is ready to be used"
   task :verify_github do
-    require "pp"
     gh_api_authenticated_request :path => "/user"
   end
 


### PR DESCRIPTION
When releasing, I got an email from Github that this is deprecated.

This PR fixes it, while also improving some related stuff.

This is a follow up to https://github.com/rubygems/rubygems/pull/3678.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
