### PR TITLE
Don't abort release on missing credentials file

### DIFF
--- a/bundler/lib/bundler/gem_helper.rb
+++ b/bundler/lib/bundler/gem_helper.rb
@@ -106,9 +106,6 @@ module Bundler
       cmd = [*gem_command, "push", path]
       cmd << "--key" << gem_key if gem_key
       cmd << "--host" << allowed_push_host if allowed_push_host
-      unless allowed_push_host || Bundler.user_home.join(".gem/credentials").file?
-        raise "Your rubygems.org credentials aren't set. Run `gem signin` to set them."
-      end
       sh_with_input(cmd)
       Bundler.ui.confirm "Pushed #{name} #{version} to #{gem_push_host}"
     end


### PR DESCRIPTION
# Description:

`gem push` already asks for credentials on the fly and properly save
them for future runs if they are not already there, so I believe this is
unnecessary.

This is an initial proposal to fix #3779.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
