### PR TITLE
Improve bundler's Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bundler-related-issue.md
+++ b/.github/ISSUE_TEMPLATE/bundler-related-issue.md
@@ -44,5 +44,3 @@ Please answer the following questions so we can process your issue as fast as po
 ### Please run `bundle env` and paste the output below:
 
     Your answer:
-
-Thank you!

--- a/.github/ISSUE_TEMPLATE/bundler-related-issue.md
+++ b/.github/ISSUE_TEMPLATE/bundler-related-issue.md
@@ -37,6 +37,6 @@ Please fill in the following sections so we can process your issue as fast as po
 
 <!-- Replace this with the actual result you got. Paste the output of your command here. -->
 
-### Please run `bundle env` and paste the output below:
+### If not included with the output of your command, run `bundle env` and paste the output below
 
 <!-- Replace this with the result of `bundle env`. -->

--- a/.github/ISSUE_TEMPLATE/bundler-related-issue.md
+++ b/.github/ISSUE_TEMPLATE/bundler-related-issue.md
@@ -37,10 +37,6 @@ Please fill in the following sections so we can process your issue as fast as po
 
 <!-- Replace this with the actual result you got. Paste the output of your command here. -->
 
-### Is there an exception backtrace? If so, please copy it below.
-
-<!-- Replace this with the exception backtrace you got, if any. -->
-
 ### Please run `bundle env` and paste the output below:
 
 <!-- Replace this with the result of `bundle env`. -->

--- a/.github/ISSUE_TEMPLATE/bundler-related-issue.md
+++ b/.github/ISSUE_TEMPLATE/bundler-related-issue.md
@@ -9,7 +9,7 @@ assignees: ''
 
 Thank you for contributing to the [rubygems](https://github.com/rubygems/rubygems) repository, and specifically to the [Bundler](https://bundler.io/) gem.
 
-Before processing your issue please confirm that:
+Before opening your issue please confirm that:
 
 - [ ] You checked all the following documents and couldn't find a solution for your issue:
 

--- a/.github/ISSUE_TEMPLATE/bundler-related-issue.md
+++ b/.github/ISSUE_TEMPLATE/bundler-related-issue.md
@@ -17,7 +17,7 @@ Please fill in the following sections so we can process your issue as fast as po
 
 -->
 
-### Do you have a reproduction script? It would be really helpful for us if you provide one. Examples: [Sample repro script for Bundler issues](https://gist.github.com/xaviershay/6207550), [Another sample repro script for Bundler issues](https://gist.github.com/xaviershay/6295889).
+### Post system independent steps to reproduce the problem. Examples: [Sample repro script for Bundler issues](https://gist.github.com/xaviershay/6207550), [Another sample repro script for Bundler issues](https://gist.github.com/xaviershay/6295889).
 
     Script URL: 
 

--- a/.github/ISSUE_TEMPLATE/bundler-related-issue.md
+++ b/.github/ISSUE_TEMPLATE/bundler-related-issue.md
@@ -13,7 +13,7 @@ Thank you for contributing to the [rubygems](https://github.com/rubygems/rubygem
 
 Before opening your issue, make sure you have checked [our filing issues guide](https://github.com/rubygems/rubygems/blob/master/bundler/doc/contributing/ISSUES.md).
 
-Please answer the following questions so we can process your issue as fast as possible:
+Please fill in the following sections so we can process your issue as fast as possible:
 
 -->
 

--- a/.github/ISSUE_TEMPLATE/bundler-related-issue.md
+++ b/.github/ISSUE_TEMPLATE/bundler-related-issue.md
@@ -7,11 +7,15 @@ assignees: ''
 
 ---
 
+<!--
+
 Thank you for contributing to the [rubygems](https://github.com/rubygems/rubygems) repository, and specifically to the [Bundler](https://bundler.io/) gem.
 
 Before opening your issue, make sure you have checked [our filing issues guide](https://github.com/rubygems/rubygems/blob/master/bundler/doc/contributing/ISSUES.md).
 
 Please answer the following questions so we can process your issue as fast as possible:
+
+-->
 
 ### Do you have a reproduction script? It would be really helpful for us if you provide one. Examples: [Sample repro script for Bundler issues](https://gist.github.com/xaviershay/6207550), [Another sample repro script for Bundler issues](https://gist.github.com/xaviershay/6295889).
 

--- a/.github/ISSUE_TEMPLATE/bundler-related-issue.md
+++ b/.github/ISSUE_TEMPLATE/bundler-related-issue.md
@@ -26,7 +26,7 @@ Please fill in the following sections so we can process your issue as fast as po
 <!--
 
 Fill this with system independent repro steps so that maintainers can reproduce your issue on their machines.
-Examples: [Sample repro script for Bundler issues](https://gist.github.com/xaviershay/6207550), [Another sample repro script for Bundler issues](https://gist.github.com/xaviershay/6295889).
+Examples: https://gist.github.com/xaviershay/6207550, https://gist.github.com/xaviershay/6295889
 
 -->
 

--- a/.github/ISSUE_TEMPLATE/bundler-related-issue.md
+++ b/.github/ISSUE_TEMPLATE/bundler-related-issue.md
@@ -19,28 +19,28 @@ Please fill in the following sections so we can process your issue as fast as po
 
 ### Describe the problem as clearly as you can
 
-    Your anwser:
+<!-- Replace this with an explanation of the problem you are having. Be as much clear and precise as you can. -->
 
 ### Post system independent steps to reproduce the problem. Examples: [Sample repro script for Bundler issues](https://gist.github.com/xaviershay/6207550), [Another sample repro script for Bundler issues](https://gist.github.com/xaviershay/6295889).
 
-    Script URL: 
+<!-- Fill this with system independent repro steps so that maintainers can reproduce your issue on their machines. -->
 
 ### What command did you run?
 
-    Your answer:
+<!-- Replace this with the command that you run. -->
 
 ### What were you expecting to happen?
 
-    Your answer:
+<!-- Replace this with the results you expected before running the command. -->
 
 ### What actually happened?
 
-    Your answer:
+<!-- Replace this with the actual result you got. Paste the output of your command here. -->
 
 ### Is there an exception backtrace? If so, please copy it below.
 
-    Your answer:
+<!-- Replace this with the exception backtrace you got, if any. -->
 
 ### Please run `bundle env` and paste the output below:
 
-    Your answer:
+<!-- Replace this with the result of `bundle env`. -->

--- a/.github/ISSUE_TEMPLATE/bundler-related-issue.md
+++ b/.github/ISSUE_TEMPLATE/bundler-related-issue.md
@@ -30,7 +30,7 @@ Examples: https://gist.github.com/xaviershay/6207550, https://gist.github.com/xa
 
 -->
 
-### What command did you run?
+### Which command did you run?
 
 <!-- Replace this with the command that you run. -->
 

--- a/.github/ISSUE_TEMPLATE/bundler-related-issue.md
+++ b/.github/ISSUE_TEMPLATE/bundler-related-issue.md
@@ -17,6 +17,10 @@ Please fill in the following sections so we can process your issue as fast as po
 
 -->
 
+### Describe the problem as clearly as you can
+
+    Your anwser:
+
 ### Post system independent steps to reproduce the problem. Examples: [Sample repro script for Bundler issues](https://gist.github.com/xaviershay/6207550), [Another sample repro script for Bundler issues](https://gist.github.com/xaviershay/6295889).
 
     Script URL: 

--- a/.github/ISSUE_TEMPLATE/bundler-related-issue.md
+++ b/.github/ISSUE_TEMPLATE/bundler-related-issue.md
@@ -21,9 +21,14 @@ Please fill in the following sections so we can process your issue as fast as po
 
 <!-- Replace this with an explanation of the problem you are having. Be as much clear and precise as you can. -->
 
-### Post system independent steps to reproduce the problem. Examples: [Sample repro script for Bundler issues](https://gist.github.com/xaviershay/6207550), [Another sample repro script for Bundler issues](https://gist.github.com/xaviershay/6295889).
+### Post system independent steps to reproduce the problem
 
-<!-- Fill this with system independent repro steps so that maintainers can reproduce your issue on their machines. -->
+<!--
+
+Fill this with system independent repro steps so that maintainers can reproduce your issue on their machines.
+Examples: [Sample repro script for Bundler issues](https://gist.github.com/xaviershay/6207550), [Another sample repro script for Bundler issues](https://gist.github.com/xaviershay/6295889).
+
+-->
 
 ### What command did you run?
 

--- a/.github/ISSUE_TEMPLATE/bundler-related-issue.md
+++ b/.github/ISSUE_TEMPLATE/bundler-related-issue.md
@@ -13,31 +13,31 @@ Before opening your issue, make sure you have checked [our filing issues guide](
 
 Please answer the following questions so we can process your issue as fast as possible:
 
-1. Do you have a reproduction script? It would be really helpful for us if you provide one. Examples: [Sample repro script for Bundler issues](https://gist.github.com/xaviershay/6207550), [Another sample repro script for Bundler issues](https://gist.github.com/xaviershay/6295889).
+### Do you have a reproduction script? It would be really helpful for us if you provide one. Examples: [Sample repro script for Bundler issues](https://gist.github.com/xaviershay/6207550), [Another sample repro script for Bundler issues](https://gist.github.com/xaviershay/6295889).
 
     Script URL: 
 
-2. What are you trying to accomplish?
+### What are you trying to accomplish?
 
     Your answer:
 
-3. What command did you run?
+### What command did you run?
 
     Your answer:
 
-4. What were you expecting to happen?
+### What were you expecting to happen?
 
     Your answer:
 
-5. What actually happened?
+### What actually happened?
 
     Your answer:
 
-6. Is there an exception backtrace? If so, please copy it below.
+### Is there an exception backtrace? If so, please copy it below.
 
     Your answer:
 
-7. Please run `bundle env` and paste the output below:
+### Please run `bundle env` and paste the output below:
 
     Your answer:
 

--- a/.github/ISSUE_TEMPLATE/bundler-related-issue.md
+++ b/.github/ISSUE_TEMPLATE/bundler-related-issue.md
@@ -25,10 +25,6 @@ Please fill in the following sections so we can process your issue as fast as po
 
     Script URL: 
 
-### What are you trying to accomplish?
-
-    Your answer:
-
 ### What command did you run?
 
     Your answer:

--- a/.github/ISSUE_TEMPLATE/bundler-related-issue.md
+++ b/.github/ISSUE_TEMPLATE/bundler-related-issue.md
@@ -9,16 +9,7 @@ assignees: ''
 
 Thank you for contributing to the [rubygems](https://github.com/rubygems/rubygems) repository, and specifically to the [Bundler](https://bundler.io/) gem.
 
-Before opening your issue please confirm that:
-
-- [ ] You checked all the following documents and couldn't find a solution for your issue:
-
-- [Troubleshooting common issues](https://github.com/rubygems/rubygems/blob/master/bundler/doc/TROUBLESHOOTING.md)
-- [Bundler documentation site](https://bundler.io/)
-- [Bundler man pages](https://bundler.io/man/bundle.1.html)
-- [Bundler command line reference](https://bundler.io/v2.0/commands.html)
-
-If you haven't done that, please do it before creating a new issue.
+Before opening your issue, make sure you have checked [our filing issues guide](https://github.com/rubygems/rubygems/blob/master/bundler/doc/contributing/ISSUES.md).
 
 Please answer the following questions so we can process your issue as fast as possible:
 
@@ -49,7 +40,5 @@ Please answer the following questions so we can process your issue as fast as po
 7. Please run `bundle env` and paste the output below:
 
     Your answer:
-
-For more information please check [Filing Issues: a guide](https://github.com/rubygems/rubygems/blob/master/bundler/doc/contributing/ISSUES.md).
 
 Thank you!


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I believe the current issue template is not very useful for both reporters (too many questions), and for maintainers (too much not useful text and bad formatting).

## What is your fix for the problem, implemented in this PR?

My fix is to make small improvements to it. I tried to justify each change on its own commit.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
