### PR TITLE
Push only the release tag

### DIFF
--- a/bundler/lib/bundler/gem_helper.rb
+++ b/bundler/lib/bundler/gem_helper.rb
@@ -117,10 +117,21 @@ module Bundler
       Dir[File.join(base, "#{name}-*.gem")].sort_by {|f| File.mtime(f) }.last
     end
 
-    def git_push(remote = "")
+    def git_push(remote = nil)
+      remote ||= default_remote
       perform_git_push remote
       perform_git_push "#{remote} --tags"
       Bundler.ui.confirm "Pushed git commits and tags."
+    end
+
+    def default_remote
+      current_branch = sh(%w[git rev-parse --abbrev-ref HEAD]).strip
+      return "origin" if current_branch.empty?
+
+      remote_for_branch = sh(%W[git config --get branch.#{current_branch}.remote]).strip
+      return "origin" if remote_for_branch.empty?
+
+      remote_for_branch
     end
 
     def allowed_push_host

--- a/bundler/lib/bundler/gem_helper.rb
+++ b/bundler/lib/bundler/gem_helper.rb
@@ -120,8 +120,8 @@ module Bundler
     def git_push(remote = nil)
       remote ||= default_remote
       perform_git_push remote
-      perform_git_push "#{remote} --tags"
-      Bundler.ui.confirm "Pushed git commits and tags."
+      perform_git_push "#{remote} #{version_tag}"
+      Bundler.ui.confirm "Pushed git commits and release tag."
     end
 
     def default_remote

--- a/bundler/lib/bundler/templates/newgem/README.md.tt
+++ b/bundler/lib/bundler/templates/newgem/README.md.tt
@@ -28,7 +28,7 @@ TODO: Write usage instructions here
 
 After checking out the repo, run `bin/setup` to install dependencies.<% if config[:test] %> Then, run `rake <%= config[:test].sub('mini', '').sub('rspec', 'spec') %>` to run the tests.<% end %> You can also run `bin/console` for an interactive prompt that will allow you to experiment.<% if config[:bin] %> Run `bundle exec <%= config[:name] %>` to use the gem in this directory, ignoring other installed copies of this gem.<% end %>
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing
 

--- a/bundler/spec/bundler/gem_helper_spec.rb
+++ b/bundler/spec/bundler/gem_helper_spec.rb
@@ -239,7 +239,7 @@ RSpec.describe Bundler::GemHelper do
           before do
             mock_build_message app_name, app_version
             mock_confirm_message "Tagged v#{app_version}."
-            mock_confirm_message "Pushed git commits and tags."
+            mock_confirm_message "Pushed git commits and release tag."
 
             sys_exec("git push -u origin master", :dir => app_path)
           end
@@ -262,7 +262,7 @@ RSpec.describe Bundler::GemHelper do
           before do
             Bundler::GemHelper.tag_prefix = "foo-"
             mock_build_message app_name, app_version
-            mock_confirm_message "Pushed git commits and tags."
+            mock_confirm_message "Pushed git commits and release tag."
 
             sys_exec("git push -u origin master", :dir => app_path)
             expect(subject).to receive(:rubygem_push).with(app_gem_path.to_s)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Currently `rake release` pushes all local tags by default, which might lead to unexpected results sometimes, for example in the case where you have a custom local remote with more tags than the remote that you're pushing to.

## What is your fix for the problem, implemented in this PR?

I believe what everyone expects here is the only the release tag to be pushed.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).