### PR TITLE
Have "gem update --system" pass through the --silent flag.

### DIFF
--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -283,6 +283,7 @@ command to remove old versions.
 
   def update_rubygems_arguments # :nodoc:
     args = []
+    args << '--silent' if options[:silent]
     args << '--prefix' << Gem.prefix if Gem.prefix
     args << '--no-document' unless options[:document].include?('rdoc') || options[:document].include?('ri')
     args << '--no-format-executable' if options[:no_format_executable]

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -238,7 +238,7 @@ command to remove old versions.
 
     @installer = Gem::DependencyInstaller.new update_options
 
-    say "Updating #{name}"
+    say "Updating #{name}" unless options[:system] && options[:silent]
     begin
       @installer.install name, Gem::Requirement.new(version)
     rescue Gem::InstallError, Gem::DependencyError => e

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -168,13 +168,13 @@ command to remove old versions.
     update_dir = File.join Gem.dir, 'gems', "rubygems-update-#{version}"
 
     Dir.chdir update_dir do
-      say "Installing RubyGems #{version}"
+      say "Installing RubyGems #{version}" unless options[:silent]
 
       installed = preparing_gem_layout_for(version) do
         system Gem.ruby, '--disable-gems', 'setup.rb', *args
       end
 
-      say "RubyGems system software updated" if installed
+      say "RubyGems system software updated" if installed unless options[:silent]
     end
   end
 

--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -257,6 +257,34 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
     Gem.disable_system_update_message = old_disable_system_update_message
   end
 
+  # The other style of `gem update --system` tests don't actually run
+  # setup.rb, so we just check that setup.rb gets the `--silent` flag.
+  def test_execute_system_silent_passed_to_setuprb
+    @cmd.options[:args] = []
+    @cmd.options[:system] = true
+    @cmd.options[:silent] = true
+
+    assert_equal true, @cmd.update_rubygems_arguments.include?('--silent')
+  end
+
+  def test_execute_system_silent
+    spec_fetcher do |fetcher|
+      fetcher.download 'rubygems-update', 9 do |s|
+        s.files = %w[setup.rb]
+      end
+    end
+
+    @cmd.options[:args]          = []
+    @cmd.options[:system]        = true
+    @cmd.options[:silent]        = true
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    assert_empty @ui.output
+  end
+
   # before:
   #   a1 -> c1.2
   # after:


### PR DESCRIPTION
# Description:

Attempt at fixing #2907.

<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

`gem update --system --silent` did not work.

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

If `gem update --system` gets `--silent`, pass it through to `setup.rb`.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
