### PR TITLE
Remove redundant "bundler/setup"

### DIFF
--- a/bundler/lib/bundler/templates/newgem/spec/spec_helper.rb.tt
+++ b/bundler/lib/bundler/templates/newgem/spec/spec_helper.rb.tt
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "bundler/setup"
 require "<%= config[:namespaced_path] %>"
 
 RSpec.configure do |config|


### PR DESCRIPTION
Having "bundler/setup" in spec_helper doesn't make
much sense. On the other hand, it becomes a problem
for downstream as they constantly have to keep patching
this from all the libraries.

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>

______________

#### Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
