### PR TITLE
Automatic management of the changelog

### DIFF
--- a/.github/release-drafter-bundler.yml
+++ b/.github/release-drafter-bundler.yml
@@ -1,0 +1,75 @@
+---
+
+template: |
+  ## (Unreleased)
+
+  $CHANGES
+
+name-template: "bundler-v$RESOLVED_VERSION"
+
+tag-template: "bundler-v$RESOLVED_VERSION"
+
+categories:
+  - title: "Security fixes:"
+    labels:
+      - "bundler: security fix"
+
+  - title: "Breaking Changes:"
+    labels:
+      - "bundler: breaking change"
+
+  - title: "Major enhancements:"
+    labels:
+      - "bundler: major enhancement"
+
+  - title: "Deprecations:"
+    labels:
+      - "bundler: deprecation"
+
+  - title: "Features:"
+    labels:
+      - "bundler: feature"
+
+  - title: "Performance:"
+    labels:
+      - "bundler: performance"
+
+  - title: "Documentation:"
+    labels:
+      - "bundler: documentation"
+
+  - title: "Minor enhancements:"
+    labels:
+      - "bundler: minor enhancement"
+
+  - title: "Bug fixes:"
+    labels:
+      - "bundler: bug fix"
+
+change-template: "  - $TITLE [#$NUMBER]($URL)"
+
+no-changes-template: "  No changes."
+
+include-labels:
+  - "bundler: security fix"
+  - "bundler: breaking change"
+  - "bundler: major enhancement"
+  - "bundler: deprecation"
+  - "bundler: feature"
+  - "bundler: performance"
+  - "bundler: documentation"
+  - "bundler: minor enhancement"
+  - "bundler: bug fix"
+
+version-resolver:
+  major:
+    labels:
+      - "bundler: breaking change"
+
+  minor:
+    labels:
+      - "bundler: feature"
+      - "bundler: major enhancement"
+      - "bundler: deprecation"
+
+  default: patch

--- a/.github/workflows/changelog-synchronizer-bundler.yml
+++ b/.github/workflows/changelog-synchronizer-bundler.yml
@@ -1,0 +1,28 @@
+name: changelog-synchronizer-bundler
+
+on:
+  push:
+    branches:
+      - master
+
+    paths:
+      - bundler/CHANGELOG.md
+
+jobs:
+  changelog_synchronizer_bundler:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.1
+          bundler: none
+
+      - name: Update release draft from changelog
+        run: bin/rake release:github_draft
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        working-directory: ./bundler

--- a/.github/workflows/release-drafter-bundler.yml
+++ b/.github/workflows/release-drafter-bundler.yml
@@ -1,0 +1,44 @@
+name: release-drafter-bundler
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release_drafter_bundler:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Publish changelog draft
+        id: publish_github_release_draft
+        uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-bundler.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Clone repo
+        uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.1
+          bundler: none
+
+      - name: Write new changelog
+        run: bin/rake release:write_changelog
+        env:
+          NEW_CHANGELOG_CONTENT: ${{ steps.publish_github_release_draft.outputs.body }}
+        working-directory: ./bundler
+
+      - name: Set up git config
+        run: |
+          git config user.name "The Bundler Bot"
+          git config user.email "bot@bundler.io"
+
+      - name: Commit and push the changes
+        run: |
+          git add bundler/man/*
+          git commit -m "Automatic changelog update"
+          git push origin master

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,27 +64,42 @@ can help with. That are marked with a light gray `contribution: *`
 
 ### Type
 
-Most Issues or pull requests will have a light green `type: *` label,  which
-describes the type of the issue or pull request.
+Issues might have a light green `type: *` label,  which describes the type of
+the issue.
 
 *   **bug report** - An issue describing a bug in rubygems. This would be
     something that is broken, confusing, unexpected behavior etc.
-*   **bug fix** - A pull request that fixes a bug report.
 *   **feature request** - An issue describing a request for a new feature or
     enhancement.
-*   **feature implementation** - A pull request implementing a feature
-    request.
 *   **question** - An issue that is a more of a question than a call for
     specific changes in the codebase.
-*   **cleanup** - Generally for a pull request that improves the code base
-    without fixing a bug or implementing a feature.
-*   **major bump** - This issue or pull request requires a major version bump
+*   **cleanup** - An issue tah proposes cleanups to the code base without fixing
+    a bug or implementing a feature.
+*   **major bump** - This issue  request requires a major version bump
 *   **administrative** - This issue relates to administrative tasks that need
     to take place as it relates to rubygems
 *   **documentation** - This issue relates to improving the documentation for
     in this repo. Note that much of the rubygems documentation is here:
     https://github.com/rubygems/guides
 
+Pull request might have a light orange `rubygems: *` or a light blue `bundler:
+*` label which describes the pull request according to the following criteria:
+
+*   **security fix** - A pull request that fixes a security issue.
+*   **breaking change** - A pull request including any change that requires a
+    major version bump.
+*   **major enhancement** - A pull request including a backwards compatible
+    change worth a special mention in the changelog
+*   **deprecation** - A pull request that introduces a deprecation.
+*   **feature** - A pull request implementing a feature request.
+*   **deprecation** - A pull request that implements a performance improvement.
+*   **documentation** - A pull request introducing documentation improvements
+    worth mentioning to end users.
+*   **minor enhancements** - A pull request introducing small but user visible changes.
+*   **bug fix** - A pull request that fixes a bug report.
+
+In the case of `bundler`, these labels are set by maintainers on PRs and have
+special importance because they are used to automatically build the changelog.
 
 ### Workflow / Status
 

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1240,9 +1240,6 @@ Performance:
 Bug fixes:
 
   - only warn on invalid gemspecs (@indirect)
-
-Bug fixes:
-
   - fix installing dependencies in the correct order ([#3799](https://github.com/rubygems/bundler/issues/3799), @pducks32)
   - fix sorting of mixed DependencyLists ([#3762](https://github.com/rubygems/bundler/issues/3762), @tony-spataro-rs)
   - fix `install_if` conditionals when using the block form (@danieltdt)
@@ -1252,9 +1249,6 @@ Bug fixes:
 Bug fixes:
 
   - don't add or update BUNDLED WITH during `install` with no changes (@segiddins)
-
-Bug fixes:
-
   - fix sorting of mixed DependencyLists with RubyGems >= 2.23 ([#3762](https://github.com/rubygems/bundler/issues/3762), @tony-spataro-rs)
   - speed up resolver for path and git gems (@segiddins)
   - fix `install --force` to not reinstall Bundler ([#3743](https://github.com/rubygems/bundler/issues/3743), @karlo57)

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## (Unreleased)
+
+  No changes.
+
 ## 2.2.0.rc.1 (Jul 02, 2020)
 
 Major enhancements:

--- a/bundler/doc/README.md
+++ b/bundler/doc/README.md
@@ -30,4 +30,5 @@ If you'd like to help make Bundler better, you totally rock! Thanks for helping 
 
 ## Maintainers
 
+* [Merging pull requests](playbooks/MERGING_A_PR.md)
 * [Releasing Bundler](playbooks/RELEASING.md)

--- a/bundler/doc/README.md
+++ b/bundler/doc/README.md
@@ -21,10 +21,13 @@ If you'd like to help make Bundler better, you totally rock! Thanks for helping 
 * [Development setup](development/SETUP.md)
 * [Submitting pull requests](development/PULL_REQUESTS.md)
 * [Adding new features](development/NEW_FEATURES.md)
-* [Releasing Bundler](development/RELEASING.md)
 
 ## Documentation
 
 * [Overview](documentation/README.md)
 * [Writing docs for man pages](documentation/WRITING.md)
 * [Documentation vision](documentation/VISION.md)
+
+## Maintainers
+
+* [Releasing Bundler](playbooks/RELEASING.md)

--- a/bundler/doc/development/README.md
+++ b/bundler/doc/development/README.md
@@ -13,7 +13,3 @@ An overview of our preferred PR process, including how to run the test suite and
 ## [Adding new features](NEW_FEATURES.md)
 
 Guidelines for proposing and writing new features for Bundler.
-
-## [Releasing Bundler](RELEASING.md)
-
-A broad-strokes overview of the release process adhered to by the Bundler core team.

--- a/bundler/doc/playbooks/MERGING_A_PR.md
+++ b/bundler/doc/playbooks/MERGING_A_PR.md
@@ -1,0 +1,35 @@
+# Merging a PR
+
+Bundler requires all CI status checks to pass before a PR can me merged. So make
+sure that's the case before merging.
+
+Also, bundler manages the changelog and github release drafts automatically
+using information from merged PRs. So, if a PR has user visible changes that
+should be included in a future release, make sure the following information is
+accurate:
+
+* The PR has a good descriptive title. That will be the wording for the
+  corresponding changelog entry.
+
+* The PR has an accurate label. If a PR is to be included in a release, the
+  label must be one of the following:
+
+  * "bundler: security fix"
+  * "bundler: breaking change"
+  * "bundler: major enhancement"
+  * "bundler: deprecation"
+  * "bundler: feature"
+  * "bundler: performance"
+  * "bundler: documentation"
+  * "bundler: minor enhancement"
+  * "bundler: bug fix"
+
+  This label will indicate the section in the changelog that the PR will take,
+  and will also define the target version for the next release. For example, if
+  you merge a PR tagged as "type: breaking change", the next target version used
+  for the github release draft will be a major version.
+
+Finally, don't forget to review the changes in detail. Make sure you try them
+locally if they are not trivial and make sure you request changes and ask as
+many questions as needed until you are convinced that including the changes into
+bundler is a strict improvement and will not make things regress in any way.

--- a/bundler/doc/playbooks/RELEASING.md
+++ b/bundler/doc/playbooks/RELEASING.md
@@ -51,29 +51,13 @@ $ git cherry-pick -m 1 dd6aef9
 The `bin/rake release:prepare_patch` command will automatically handle
 cherry-picking, and is further detailed below.
 
-## Changelog
-
-Bundler maintains a list of changes present in each version in the `CHANGELOG.md` file.
-Entries should not be added in pull requests, but are rather written by the Bundler
-maintainers before the release.
-
-To fill in the changelog, maintainers can go through the relevant PRs using the
-`bin/rake release:open_unreleased_prs` and manually add a changelog entry for each
-PR that it's about to be released.
-
-If you're releasing a patch level version, you can use `rake
-release:open_unreleased_prs` to instead label each relevant PR with the proper
-milestone of the version to be release. Then the `bin/rake release:patch` task will
-go _only_ through those PRs, and prompt you to add a changelog entry for each of
-them.
-
 ## Releases
 
 ### Minor releases
 
 While pushing a gem version to RubyGems.org is as simple as `bin/rake release`,
 releasing a new version of Bundler includes a lot of communication: team consensus,
-git branching, changelog writing, documentation site updates, and a blog post.
+git branching, documentation site updates, and a blog post.
 
 Dizzy yet? Us too.
 
@@ -85,7 +69,7 @@ Here's the checklist for releasing new minor versions:
 * [ ] Create a new stable branch from master (see **Branching** below)
 * [ ] Create a PR to the stable branch that:
   * [ ] Updates `version.rb` to a prerelease number, e.g. `1.12.pre.1`
-  * [ ] Updates `CHANGELOG.md` to include all of the features, bugfixes, etc for that version.
+  * [ ] Updates `CHANGELOG.md` to include a release header for the new version, leaving the "(Unreleased)" section empty.
 * [ ] Get the PR reviewed, make sure CI is green, and merge it.
 * [ ] Pull the updated stable brnach, wait for CI to complete on it and get excited.
 * [ ] Run `bin/rake release` from the updated stable branch, tweet, blog, let people know about the prerelease!

--- a/bundler/task/release.rake
+++ b/bundler/task/release.rake
@@ -86,31 +86,31 @@ namespace :release do
     parsed_response
   end
 
-  def release_notes(version)
-    title_token = "## "
-    current_version_title = "#{title_token}#{version}"
-    current_minor_title = "#{title_token}#{version.segments[0, 2].join(".")}"
-    text = File.open("CHANGELOG.md", "r:UTF-8", &:read)
-    lines = text.split("\n")
-
-    current_version_index = lines.find_index {|line| line.strip =~ /^#{current_version_title}($|\b)/ }
-    unless current_version_index
-      raise "Update the changelog for the last version (#{version})"
-    end
-    current_version_index += 1
-    previous_version_lines = lines[current_version_index.succ...-1]
-    previous_version_index = current_version_index + (
-      previous_version_lines.find_index {|line| line.start_with?(title_token) && !line.start_with?(current_minor_title) } ||
-      lines.count
-    )
-
-    relevant = lines[current_version_index..previous_version_index]
-
-    relevant.join("\n").strip
-  end
-
   desc "Push the release to Github releases"
   task :github do
+    def release_notes(version)
+      title_token = "## "
+      current_version_title = "#{title_token}#{version}"
+      current_minor_title = "#{title_token}#{version.segments[0, 2].join(".")}"
+      text = File.open("CHANGELOG.md", "r:UTF-8", &:read)
+      lines = text.split("\n")
+
+      current_version_index = lines.find_index {|line| line.strip =~ /^#{current_version_title}($|\b)/ }
+      unless current_version_index
+        raise "Update the changelog for the last version (#{version})"
+      end
+      current_version_index += 1
+      previous_version_lines = lines[current_version_index.succ...-1]
+      previous_version_index = current_version_index + (
+        previous_version_lines.find_index {|line| line.start_with?(title_token) && !line.start_with?(current_minor_title) } ||
+        lines.count
+      )
+
+      relevant = lines[current_version_index..previous_version_index]
+
+      relevant.join("\n").strip
+    end
+
     version = Gem::Version.new(Bundler::GemHelper.gemspec.version)
     tag = "bundler-v#{version}"
 

--- a/bundler/task/release.rake
+++ b/bundler/task/release.rake
@@ -110,8 +110,8 @@ namespace :release do
   end
 
   desc "Push the release to Github releases"
-  task :github, :version do |_t, args|
-    version = Gem::Version.new(args.version || Bundler::GemHelper.gemspec.version)
+  task :github do
+    version = Gem::Version.new(Bundler::GemHelper.gemspec.version)
     tag = "bundler-v#{version}"
 
     gh_api_authenticated_request :path => "/repos/rubygems/rubygems/releases",

--- a/bundler/task/release.rake
+++ b/bundler/task/release.rake
@@ -23,6 +23,52 @@ task "release:rubygem_push" => ["release:verify_docs", "release:verify_github", 
 namespace :release do
   task :verify_docs => :"man:check"
 
+  class ChangelogParser
+    def release_notes(version)
+      current_version_title = "#{section_token}#{version}"
+      current_minor_title = "#{section_token}#{version.segments[0, 2].join(".")}"
+
+      current_version_index = lines.find_index {|line| line.strip =~ /^#{current_version_title}($|\b)/ }
+      unless current_version_index
+        raise "Update the changelog for the last version (#{version})"
+      end
+      current_version_index += 1
+      previous_version_lines = lines[current_version_index.succ...-1]
+      previous_version_index = current_version_index + (
+        previous_version_lines.find_index {|line| line.start_with?(section_token) && !line.start_with?(current_minor_title) } ||
+        lines.count
+      )
+
+      lines[current_version_index..previous_version_index]
+    end
+
+    def unreleased_notes
+      lines.take_while {|line| line.start_with?(unreleased_section_title) || !line.start_with?(section_token) }
+    end
+
+    def released_notes
+      lines.drop_while {|line| line.start_with?(unreleased_section_title) || !line.start_with?(section_token) }
+    end
+
+  private
+
+    def unreleased_section_title
+      "#{section_token}(Unreleased)"
+    end
+
+    def lines
+      @lines ||= content.split("\n")
+    end
+
+    def content
+      File.open("CHANGELOG.md", "r:UTF-8", &:read)
+    end
+
+    def section_token
+      "## "
+    end
+  end
+
   def gh_api_authenticated_request(opts)
     require "netrc"
     require "net/http"
@@ -89,76 +135,42 @@ namespace :release do
 
   desc "Push the release to Github releases"
   task :github do
-    def release_notes(version)
-      title_token = "## "
-      current_version_title = "#{title_token}#{version}"
-      current_minor_title = "#{title_token}#{version.segments[0, 2].join(".")}"
-      text = File.open("CHANGELOG.md", "r:UTF-8", &:read)
-      lines = text.split("\n")
-
-      current_version_index = lines.find_index {|line| line.strip =~ /^#{current_version_title}($|\b)/ }
-      unless current_version_index
-        raise "Update the changelog for the last version (#{version})"
-      end
-      current_version_index += 1
-      previous_version_lines = lines[current_version_index.succ...-1]
-      previous_version_index = current_version_index + (
-        previous_version_lines.find_index {|line| line.start_with?(title_token) && !line.start_with?(current_minor_title) } ||
-        lines.count
-      )
-
-      relevant = lines[current_version_index..previous_version_index]
-
-      relevant.join("\n").strip
-    end
-
     version = Gem::Version.new(Bundler::GemHelper.gemspec.version)
+    release_notes = ChangelogParser.new.release_notes(version).join("\n").strip
     tag = "bundler-v#{version}"
 
     gh_api_authenticated_request :path => "/repos/rubygems/rubygems/releases",
                                  :body => {
                                    :tag_name => tag,
                                    :name => tag,
-                                   :body => release_notes(version),
+                                   :body => release_notes,
                                    :prerelease => version.prerelease?,
                                  }
   end
 
   desc "Sync the current draft release with the changelog"
   task :github_draft do
-    def unreleased_notes
-      section_token = "## "
-      unreleased_section_title = "#{section_token}(Unreleased)"
-      changelog_content = File.open("CHANGELOG.md", "r:UTF-8", &:read).split("\n")
-
-      unreleased_content = changelog_content.take_while {|line| line.start_with?(unreleased_section_title) || !line.start_with?(section_token) }
-
-      unreleased_content.join("\n").strip
-    end
-
     version = Bundler::GemHelper.gemspec.version
+    unreleased_notes = ChangelogParser.new.unreleased_notes.join("\n").strip
     tag = "bundler-v#{version}"
 
-    gh_api_post :path => "/repos/rubygems/rubygems/releases",
-                :body => {
-                  :tag_name => tag,
-                  :name => tag,
-                  :body => unreleased_notes,
-                  :prerelease => version.prerelease?,
-                  :draft => true,
-                }
+    gh_api_authenticated_request :path => "/repos/rubygems/rubygems/releases",
+                                 :body => {
+                                   :tag_name => tag,
+                                   :name => tag,
+                                   :body => unreleased_notes,
+                                   :prerelease => version.prerelease?,
+                                   :draft => true,
+                                 }
   end
 
   desc "Replace the unreleased section in the changelog with new content. Pass the new content through ENV['NEW_CHANGELOG_CONTENT']"
   task :write_changelog do
-    section_token = "## "
-    unreleased_section_title = "#{section_token}(Unreleased)"
-    changelog_content = File.open("CHANGELOG.md", "r:UTF-8", &:read).split("\n")
+    released_notes = ChangelogParser.new.released_notes
 
-    current_rest_of_content = changelog_content.drop_while {|line| line.start_with?(unreleased_section_title) || !line.start_with?(section_token) }
     new_content = ENV["NEW_CHANGELOG_CONTENT"]
 
-    File.open("CHANGELOG.md", "w:UTF-8") {|f| f.write([new_content, current_rest_of_content].join("\n") + "\n") } if new_content
+    File.open("CHANGELOG.md", "w:UTF-8") {|f| f.write([new_content, released_notes].join("\n") + "\n") } if new_content
   end
 
   desc "Prepare a patch release with the PRs from master in the patch milestone"

--- a/bundler/task/release.rake
+++ b/bundler/task/release.rake
@@ -64,19 +64,6 @@ namespace :release do
     gh_api_authenticated_request :path => "/user"
   end
 
-  def confirm(prompt = "")
-    loop do
-      print(prompt)
-      print(": ") unless prompt.empty?
-
-      answer = $stdin.gets.strip
-      break if answer == "y"
-      abort if answer == "n"
-    end
-  rescue Interrupt
-    abort
-  end
-
   def gh_api_request(opts)
     require "net/http"
     require "json"
@@ -201,39 +188,5 @@ namespace :release do
     File.open(version_file, "w") {|f| f.write(version_contents) }
 
     sh("git", "commit", "-am", "Version #{version}")
-  end
-
-  desc "Open all PRs that have not been included in a stable release"
-  task :open_unreleased_prs do
-    def prs(on = "master")
-      commits = `git log --oneline origin/#{on} -- bundler`.split("\n")
-      commits.reverse_each.map {|c| c =~ /(Auto merge of|Merge pull request|Merge) #(\d+)/ && $2 }.compact
-    end
-
-    def minor_release_tags
-      `git ls-remote origin`.split("\n").map {|r| r =~ %r{refs/tags/bundler-v([\d.]+)$} && $1 }.compact.map {|v| Gem::Version.create(Gem::Version.create(v).segments[0, 2].join(".")) }.sort.uniq
-    end
-
-    def to_stable_branch(release_tag)
-      release_tag.segments.map.with_index {|s, i| i == 0 ? s + 1 : s }[0, 2].join(".")
-    end
-
-    last_stable = to_stable_branch(minor_release_tags[-1])
-    previous_to_last_stable = to_stable_branch(minor_release_tags[-2])
-
-    in_release = prs("HEAD") - prs(last_stable) - prs(previous_to_last_stable)
-
-    n_prs = in_release.size
-
-    print "About to review #{n_prs} pending PRs. "
-
-    confirm "Continue? (y/n)"
-
-    in_release.each.with_index do |pr, idx|
-      url_opener = /darwin/ =~ RUBY_PLATFORM ? "open" : "xdg-open"
-      url = "https://github.com/rubygems/rubygems/pull/#{pr}"
-      print "[#{idx + 1}/#{n_prs}] #{url}. (n)ext/(o)pen? "
-      system(url_opener, url, :out => IO::NULL, :err => IO::NULL) if $stdin.gets.strip == "o"
-    end
   end
 end

--- a/bundler/task/release.rake
+++ b/bundler/task/release.rake
@@ -136,6 +136,18 @@ namespace :release do
                                  }
   end
 
+  desc "Replace the unreleased section in the changelog with new content. Pass the new content through ENV['NEW_CHANGELOG_CONTENT']"
+  task :write_changelog do
+    section_token = "## "
+    unreleased_section_title = "#{section_token}(Unreleased)"
+    changelog_content = File.open("CHANGELOG.md", "r:UTF-8", &:read).split("\n")
+
+    current_rest_of_content = changelog_content.drop_while {|line| line.start_with?(unreleased_section_title) || !line.start_with?(section_token) }
+    new_content = ENV["NEW_CHANGELOG_CONTENT"]
+
+    File.open("CHANGELOG.md", "w:UTF-8") {|f| f.write([new_content, current_rest_of_content].join("\n") + "\n") } if new_content
+  end
+
   desc "Prepare a patch release with the PRs from master in the patch milestone"
   task :prepare_patch, :version do |_t, args|
     version = args.version


### PR DESCRIPTION
# Description:

## What was the end-user or developer problem that led to this PR?

One of the biggest pain points of releasing bundler is having to go through each unreleased PR and manually write the changelog if applicable. This is really tedious and takes precious time.

## What is your fix for the problem, implemented in this PR?

In this PR I propose a change in our workflows to automatically manage the changelog.

The workflow is as follow:

* PR is opened.
* PR is created by default with the `skip-bundler-changelog` label (this should be changed at https://github.com/rubygems/issue-triage and the label created). This is so that if no actions are taken, the PR is not included in the changelog by default.
* Review process happens until is ready to merge.
* Maintainers evaluate the PR and replace the `skip-bundler-changelog` label with any of the following labels if it makes sense to do so. The following is a mapping of PR labels to changelog sections (a couple of them would need to be created), so that if a PR with one of the labels is merged, a corresponding changelog entry is created:

    | Label | Changelog section |
    | ------- | ------------------------- |
    | type: security | Security: |
    |  type: major bump | Breaking Changes: |
    |  type: highlight | Highlights: |
    |  type: deprecation | Deprecations: |
    |  type: feature implementation | Features: |
    |  type: performance | Performance: |
    |  type: documentation | Documentation: |
    |  type: improvement | Improvements: |
    |  type: bug fix | Bugfixes: |

* Maintainer edits the PR title to properly describe the PR if necessary.
* Maintaner merges the PR.

After the PR is merged, the following should happen automatically:

* A new release draft is created and pushed to github if the merged PR doesn't include the `skip-bundler-changelog` label.
* The unreleased section of the changelog is modified to include the title of the recently merged PR and committed back to the default branch. 

By doing it this way, we reduce a lot the amount of work needed to release bundler, because the changelog will always be ready.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
