### PR TITLE
Revert the glob_files_in_dir optimization

### DIFF
--- a/lib/rubygems/util.rb
+++ b/lib/rubygems/util.rb
@@ -99,11 +99,7 @@ module Gem::Util
   # returning absolute paths to the matching files.
 
   def self.glob_files_in_dir(glob, base_path)
-    if RUBY_VERSION >= "2.5"
-      Dir.glob(glob, base: base_path).map! {|f| File.expand_path(f, base_path) }
-    else
-      Dir.glob(File.expand_path(glob, base_path))
-    end
+    Dir.glob(File.expand_path(glob, base_path))
   end
 
   ##


### PR DESCRIPTION
It was introduced in https://github.com/rubygems/rubygems/pull/2336

At that time it was using `File.join` and might have been faster.

But since https://github.com/rubygems/rubygems/pull/2536 it now use
`File.expand_path` and it bench slower on my machine:

```ruby
require 'benchmark/ips'

def old_glob_files_in_dir(glob, base_path)
  Dir.glob(File.expand_path(glob, base_path))
end

def new_glob_files_in_dir(glob, base_path)
  Dir.glob(glob, base: base_path).map! {|f| File.expand_path(f, base_path) }
end

Benchmark.ips do |x|
  x.report('old') { old_glob_files_in_dir("*.gemspec", "/opt/rubies/2.8.0-dev/lib/ruby/gems/2.8.0/specifications/default") }
  x.report('new') { new_glob_files_in_dir("*.gemspec", "/opt/rubies/2.8.0-dev/lib/ruby/gems/2.8.0/specifications/default") }
  x.compare!
end
```

```
Warming up --------------------------------------
                 old   679.000  i/100ms
                 new   507.000  i/100ms
Calculating -------------------------------------
                 old      6.830k (± 2.1%) i/s -     34.629k in   5.072317s
                 new      5.099k (± 1.5%) i/s -     25.857k in   5.072127s

Comparison:
                 old:     6830.0 i/s
                 new:     5099.1 i/s - 1.34x  slower
```

That's on MRI 2.6.5 but 2.7.1 and 2.8.0-dev give similar results.
