### PR TITLE
Remove unnecessary `Gem.clear_paths` from spec setup

### DIFF
--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -77,81 +77,80 @@ namespace :man do
   if RUBY_ENGINE == "jruby"
     task(:build) {}
   else
-    begin
-      Spec::Rubygems.gem_require("ronn")
-    rescue Gem::LoadError => e
-      desc "Build the man pages"
-      task(:build) { abort "We couldn't activate ronn (#{e.requirement}). Try `gem install ronn:'#{e.requirement}'` to be able to build the help pages" }
+    directory "man"
 
-      desc "Verify man pages are in sync"
-      task(:check) { abort "We couldn't activate ronn (#{e.requirement}). Try `gem install ronn:'#{e.requirement}'` to be able to build the help pages" }
-    else
-      directory "man"
+    index = Dir["man/*.ronn"].map do |source|
+      ronn = "man/#{File.basename(source)}"
+      roff = "man/#{File.basename(source, ".ronn")}"
 
-      index = Dir["man/*.ronn"].map do |source|
-        ronn = "man/#{File.basename(source)}"
-        roff = "man/#{File.basename(source, ".ronn")}"
-
-        file roff => ["man", ronn] do
-          date = ENV["MAN_PAGES_DATE"] || Time.now.strftime("%Y-%m-%d")
-          sh "bin/ronn --warnings --roff --pipe --date #{date} #{ronn} > #{roff}"
-        end
-
-        task :build_all_pages => roff
-
-        [ronn, File.basename(roff)]
+      file roff => ["man", ronn] do
+        date = ENV["MAN_PAGES_DATE"] || Time.now.strftime("%Y-%m-%d")
+        sh "bin/ronn --warnings --roff --pipe --date #{date} #{ronn} > #{roff}"
       end
 
-      file "index.txt" do
-        index.map! do |(ronn, roff)|
-          [File.read(ronn).split(" ").first, roff]
-        end
-        index = index.sort_by(&:first)
-        justification = index.map {|(n, _f)| n.length }.max + 4
-        File.open("man/index.txt", "w") do |f|
-          index.each do |name, filename|
-            f << name.ljust(justification) << filename << "\n"
-          end
+      task :build_all_pages => roff
+
+      [ronn, File.basename(roff)]
+    end
+
+    file "index.txt" do
+      index.map! do |(ronn, roff)|
+        [File.read(ronn).split(" ").first, roff]
+      end
+      index = index.sort_by(&:first)
+      justification = index.map {|(n, _f)| n.length }.max + 4
+      File.open("man/index.txt", "w") do |f|
+        index.each do |name, filename|
+          f << name.ljust(justification) << filename << "\n"
         end
       end
-      task :build_all_pages => "index.txt"
+    end
+    task :build_all_pages => "index.txt"
 
-      desc "Remove all built man pages"
-      task :clean do
-        leftovers = Dir["man/*"].reject do |f|
-          File.extname(f) == ".ronn"
-        end
-        rm leftovers if leftovers.any?
+    desc "Make sure ronn is installed"
+    task :check_ronn do
+      begin
+        Spec::Rubygems.gem_require("ronn")
+      rescue Gem::LoadError => e
+        abort("We couldn't activate ronn (#{e.requirement}). Try `gem install ronn:'#{e.requirement}'` to be able to build the help pages")
       end
+    end
 
-      desc "Build the man pages"
-      task :build => [:clean, :build_all_pages]
-
-      desc "Sets target date for building man pages to the one currently present"
-      task :set_current_date do
-        require "date"
-        ENV["MAN_PAGES_DATE"] = Date.parse(File.readlines("man/bundle-add.1")[3].split('"')[5]).strftime("%Y-%m-%d")
+    desc "Remove all built man pages"
+    task :clean do
+      leftovers = Dir["man/*"].reject do |f|
+        File.extname(f) == ".ronn"
       end
+      rm leftovers if leftovers.any?
+    end
 
-      desc "Verify man pages are in sync"
-      task :check => [:set_current_date, :build] do
-        require "open3"
+    desc "Build the man pages"
+    task :build => [:check_ronn, :clean, :build_all_pages]
 
-        output, status = Open3.capture2e("git status --porcelain")
+    desc "Sets target date for building man pages to the one currently present"
+    task :set_current_date do
+      require "date"
+      ENV["MAN_PAGES_DATE"] = Date.parse(File.readlines("man/bundle-add.1")[3].split('"')[5]).strftime("%Y-%m-%d")
+    end
 
-        if status.success? && output.empty?
-          puts
-          puts "Man pages are in sync"
-          puts
-        else
-          sh("git status --porcelain")
+    desc "Verify man pages are in sync"
+    task :check => [:check_ronn, :set_current_date, :build] do
+      require "open3"
 
-          puts
-          puts "Man pages are out of sync. Above you can see the list of files that got modified or generated from rebuilding them. Please review and commit the results."
-          puts
+      output, status = Open3.capture2e("git status --porcelain")
 
-          exit(1)
-        end
+      if status.success? && output.empty?
+        puts
+        puts "Man pages are in sync"
+        puts
+      else
+        sh("git status --porcelain")
+
+        puts
+        puts "Man pages are out of sync. Above you can see the list of files that got modified or generated from rebuilding them. Please review and commit the results."
+        puts
+
+        exit(1)
       end
     end
   end

--- a/bundler/bin/bundle
+++ b/bundler/bin/bundle
@@ -2,7 +2,8 @@
 # frozen_string_literal: true
 
 require "rubygems"
-bundler_gemspec = Gem::Specification.load(File.expand_path("../bundler.gemspec", __dir__))
-bundler_gemspec.instance_variable_set(:@full_gem_path, File.expand_path("..", __dir__))
+require_relative "../spec/support/path"
+bundler_gemspec = Spec::Path.loaded_gemspec
+bundler_gemspec.instance_variable_set(:@full_gem_path, Spec::Path.source_root)
 bundler_gemspec.activate if bundler_gemspec.respond_to?(:activate)
-load File.expand_path("../exe/bundle", __dir__)
+load File.expand_path("bundle", Spec::Path.bindir)

--- a/bundler/bin/bundle
+++ b/bundler/bin/bundle
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "rubygems"
-bundler_gemspec = Gem::Specification.load(File.expand_path("../../bundler.gemspec", __FILE__))
-bundler_gemspec.instance_variable_set(:@full_gem_path, File.expand_path("../..", __FILE__))
+bundler_gemspec = Gem::Specification.load(File.expand_path("../bundler.gemspec", __dir__))
+bundler_gemspec.instance_variable_set(:@full_gem_path, File.expand_path("..", __dir__))
 bundler_gemspec.activate if bundler_gemspec.respond_to?(:activate)
-load File.expand_path("../../exe/bundle", __FILE__)
+load File.expand_path("../exe/bundle", __dir__)

--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -67,12 +67,9 @@ RSpec.configure do |config|
   end
 
   config.around :each do |example|
-    if ENV["RUBY"]
-      orig_ruby = Gem.ruby
-      Gem.ruby = ENV["RUBY"]
+    with_correct_ruby_for_core_repo do
+      example.run
     end
-    example.run
-    Gem.ruby = orig_ruby if ENV["RUBY"]
   end
 
   config.before :suite do
@@ -90,9 +87,11 @@ RSpec.configure do |config|
   end
 
   config.before :all do
-    build_repo1
+    with_correct_ruby_for_core_repo do
+      build_repo1
 
-    reset_paths!
+      reset_paths!
+    end
   end
 
   config.around :each do |example|

--- a/bundler/spec/support/bin/bundle
+++ b/bundler/spec/support/bin/bundle
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "rubygems"
-require_relative "../spec/support/path"
+require_relative "../path"
 bundler_gemspec = Spec::Path.loaded_gemspec
 bundler_gemspec.instance_variable_set(:@full_gem_path, Spec::Path.source_root)
 bundler_gemspec.activate if bundler_gemspec.respond_to?(:activate)

--- a/bundler/spec/support/bin/bundle
+++ b/bundler/spec/support/bin/bundle
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 require "rubygems"

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -23,6 +23,17 @@ module Spec
       Gem.clear_paths
     end
 
+    def with_correct_ruby_for_core_repo
+      if ENV["RUBY"]
+        orig_ruby = Gem.ruby
+        Gem.ruby = ENV["RUBY"]
+      end
+
+      yield
+
+      Gem.ruby = orig_ruby if ENV["RUBY"]
+    end
+
     def the_bundle(*args)
       TheBundle.new(*args)
     end

--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -6,7 +6,7 @@ require "rbconfig"
 module Spec
   module Path
     def source_root
-      @source_root ||= Pathname.new(ruby_core? ? "../../../.." : "../../..").expand_path(__FILE__)
+      @source_root ||= Pathname.new(ruby_core? ? "../../.." : "../..").expand_path(__dir__)
     end
 
     def root

--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -87,7 +87,7 @@ module Spec
     end
 
     def install_gems(gemfile)
-      puts sys_exec "#{File.expand_path("bin/bundle", Path.source_root)} install --gemfile #{gemfile}", :env => { "BUNDLE_PATH__SYSTEM" => "true" }
+      puts sys_exec "#{File.expand_path("support/bin/bundle", Path.spec_dir)} install --gemfile #{gemfile}", :env => { "BUNDLE_PATH__SYSTEM" => "true" }
     end
 
     def test_gemfile

--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -4,12 +4,15 @@ require_relative "path"
 
 $LOAD_PATH.unshift(Spec::Path.source_lib_dir.to_s)
 
+require_relative "helpers"
+
 module Spec
   module Rubygems
     extend self
+    extend Spec::Helpers
 
     def dev_setup
-      install_gems(dev_gemfile, dev_lockfile)
+      install_gems(dev_gemfile)
     end
 
     def gem_load(gem_name, bin_container)
@@ -68,7 +71,7 @@ module Spec
 
       workaround_loaded_specs_issue
 
-      install_gems(test_gemfile, test_lockfile)
+      install_gems(test_gemfile)
     end
 
     private
@@ -98,23 +101,12 @@ module Spec
       gem gem_name, gem_requirement
     end
 
-    def install_gems(gemfile, lockfile)
-      old_gemfile = ENV["BUNDLE_GEMFILE"]
-      ENV["BUNDLE_GEMFILE"] = gemfile.to_s
-      require "bundler"
-      definition = Bundler::Definition.build(gemfile, lockfile, nil)
-      definition.validate_runtime!
-      Bundler::Installer.install(Path.source_root, definition, :path => ENV["GEM_HOME"])
-    ensure
-      ENV["BUNDLE_GEMFILE"] = old_gemfile
+    def install_gems(gemfile)
+      puts sys_exec "bundle install --gemfile #{gemfile}"
     end
 
     def test_gemfile
       Path.test_gemfile
-    end
-
-    def test_lockfile
-      lockfile_for(test_gemfile)
     end
 
     def dev_gemfile

--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -87,7 +87,7 @@ module Spec
     end
 
     def install_gems(gemfile)
-      puts sys_exec "#{File.expand_path("bin/bundle", Path.source_root)} install --gemfile #{gemfile}"
+      puts sys_exec "#{File.expand_path("bin/bundle", Path.source_root)} install --gemfile #{gemfile}", :env => { "BUNDLE_PATH__SYSTEM" => "true" }
     end
 
     def test_gemfile

--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -86,7 +86,7 @@ module Spec
     end
 
     def install_gems(gemfile)
-      puts sys_exec "#{File.expand_path("exe/bundle", Path.source_root)} install --gemfile #{gemfile}"
+      puts sys_exec "#{File.expand_path("bin/bundle", Path.source_root)} install --gemfile #{gemfile}"
     end
 
     def test_gemfile

--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -87,7 +87,7 @@ module Spec
     end
 
     def install_gems(gemfile)
-      puts sys_exec "#{Gem.ruby} #{File.expand_path("support/bin/bundle", Path.spec_dir)} install --gemfile #{gemfile}", :env => { "BUNDLE_PATH__SYSTEM" => "true" }
+      puts sys_exec "#{build_ruby_cmd} #{File.expand_path("support/bin/bundle", Path.spec_dir)} install --gemfile #{gemfile}", :env => { "BUNDLE_PATH__SYSTEM" => "true" }
     end
 
     def test_gemfile

--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -86,7 +86,7 @@ module Spec
     end
 
     def install_gems(gemfile)
-      puts sys_exec "bundle install --gemfile #{gemfile}"
+      puts sys_exec "#{File.expand_path("exe/bundle", Path.source_root)} install --gemfile #{gemfile}"
     end
 
     def test_gemfile

--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -58,8 +58,6 @@ module Spec
     end
 
     def setup_test_paths
-      Gem.clear_paths
-
       ENV["BUNDLE_PATH"] = nil
       ENV["GEM_HOME"] = ENV["GEM_PATH"] = Path.base_system_gems.to_s
       ENV["PATH"] = [Path.system_gem_path.join("bin"), ENV["PATH"]].join(File::PATH_SEPARATOR)

--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -42,6 +42,7 @@ module Spec
     end
 
     def install_parallel_test_deps
+      Gem.clear_paths
       require "parallel"
 
       prev_env_test_number = ENV["TEST_ENV_NUMBER"]

--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -67,24 +67,10 @@ module Spec
     def install_test_deps
       setup_test_paths
 
-      workaround_loaded_specs_issue
-
       install_gems(test_gemfile)
     end
 
     private
-
-    # Some rubygems versions include loaded specs when loading gemspec stubs
-    # from the file system. In this situation, that makes bundler incorrectly
-    # assume that `rake` is already installed at `tmp/` because it's installed
-    # globally, and makes it skip installing it to the proper location for our
-    # tests. To workaround, we remove `rake` from the loaded specs when running
-    # under those versions, so that `bundler` does the right thing.
-    def workaround_loaded_specs_issue
-      current_rubygems_version = Gem::Version.new(Gem::VERSION)
-
-      Gem.loaded_specs.delete("rake") if current_rubygems_version >= Gem::Version.new("3.0.0.beta2") && current_rubygems_version < Gem::Version.new("3.2.0")
-    end
 
     def gem_load_and_activate(gem_name, bin_container)
       gem_activate(gem_name)

--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -87,7 +87,7 @@ module Spec
     end
 
     def install_gems(gemfile)
-      puts sys_exec "#{File.expand_path("support/bin/bundle", Path.spec_dir)} install --gemfile #{gemfile}", :env => { "BUNDLE_PATH__SYSTEM" => "true" }
+      puts sys_exec "#{Gem.ruby} #{File.expand_path("support/bin/bundle", Path.spec_dir)} install --gemfile #{gemfile}", :env => { "BUNDLE_PATH__SYSTEM" => "true" }
     end
 
     def test_gemfile


### PR DESCRIPTION
# Description:

Bundler specs only rely on a modified rubygems environment where everything is under `tmp` for specs that shell out. For those, modifying the `GEM_PATH` and `GEM_HOME` environment variables so that they are properly setup when rubygems is loaded inside the subprocess is enough.

For unit specs, modifying the `rubygems` environment on the fly through `Gem.clear_paths` is not really needed, and can actually cause problems. For example, I had two versions of `diff-lcs` installed of my system and I was getting warnings like this:

```
WARN: Unresolved or ambiguous specs during Gem::Specification.reset:
      diff-lcs (>= 1.2.0, < 2.0)
WARN: Clearing out unresolved specs. Try 'gem cleanup <gem>'
Please report a bug if this causes problems.
```

The warnings were there for a good reason. If I ignored them and introduce a test failure on a unit spec, I would've got errors like the following where failing to require `diff/lcs` would mask the actual test failures:

```
Failures:

  1) Bundler::Fetcher::Index error handling when a OpenSSL::SSL::SSLError occurs behaves like the error is properly handled when a 401 response occurs and there was userinfo should raise a Bundler::Fetcher::BadAuthenticationError
     Failure/Error:
       expect { subject.specs(gem_names) }.to raise_error(Bundler::Fetcher::BadAuthenticationError,
         %r{Baad username or password for http://remote-uri.org})

     LoadError:
       cannot load such file -- diff/lcs
     Shared Example Group: "the error is properly handled" called from ./spec/bundler/fetcher/index_spec.rb:107
     # ./spec/bundler/fetcher/index_spec.rb:46:in `block (6 levels) in <top (required)>'
     # ./spec/spec_helper.rb:102:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:102:in `block (3 levels) in <top (required)>'
     # ./spec/support/helpers.rb:353:in `block in with_gem_path_as'
     # ./spec/support/helpers.rb:367:in `without_env_side_effects'
     # ./spec/support/helpers.rb:349:in `with_gem_path_as'
     # ./spec/spec_helper.rb:101:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:73:in `block (2 levels) in <top (required)>'
     # ./spec/support/rubygems_ext.rb:90:in `load'
     # ./spec/support/rubygems_ext.rb:90:in `gem_load_and_activate'
     # ./spec/support/rubygems_ext.rb:18:in `gem_load'
```

By removing this method call, I believe we open the door to eventually be able to run `bundler` specs through `bundler`, but I'll try that out another time.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
