### PR TITLE
Remove all `syck` references

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -641,10 +641,8 @@ EOF
     def eval_yaml_gemspec(path, contents)
       require_relative "bundler/psyched_yaml"
 
-      # If the YAML is invalid, Syck raises an ArgumentError, and Psych
-      # raises a Psych::SyntaxError. See psyched_yaml.rb for more info.
       Gem::Specification.from_yaml(contents)
-    rescue YamlLibrarySyntaxError, ArgumentError, Gem::EndOfYAMLException, Gem::Exception
+    rescue ::Psych::SyntaxError, ArgumentError, Gem::EndOfYAMLException, Gem::Exception
       eval_gemspec(path, contents)
     end
 

--- a/bundler/lib/bundler/endpoint_specification.rb
+++ b/bundler/lib/bundler/endpoint_specification.rb
@@ -3,7 +3,6 @@
 module Bundler
   # used for Creating Specifications from the Gemcutter Endpoint
   class EndpointSpecification < Gem::Specification
-    ILLFORMED_MESSAGE = 'Ill-formed requirement ["#<YAML::Syck::DefaultKey'.freeze
     include MatchPlatform
 
     attr_reader :name, :version, :platform, :required_rubygems_version, :required_ruby_version, :checksum
@@ -129,13 +128,6 @@ module Bundler
 
     def build_dependency(name, requirements)
       Gem::Dependency.new(name, requirements)
-    rescue ArgumentError => e
-      raise unless e.message.include?(ILLFORMED_MESSAGE)
-      puts # we shouldn't print the error message on the "fetching info" status line
-      raise GemspecError,
-        "Unfortunately, the gem #{name} (#{version}) has an invalid " \
-        "gemspec.\nPlease ask the gem author to yank the bad version to fix " \
-        "this issue. For more information, see http://bit.ly/syck-defaultkey."
     end
   end
 end

--- a/bundler/lib/bundler/psyched_yaml.rb
+++ b/bundler/lib/bundler/psyched_yaml.rb
@@ -1,22 +1,10 @@
 # frozen_string_literal: true
 
-# Psych could be in the stdlib
-# but it's too late if Syck is already loaded
 begin
-  require "psych" unless defined?(Syck)
+  require "psych"
 rescue LoadError
   # Apparently Psych wasn't available. Oh well.
 end
 
 # At least load the YAML stdlib, whatever that may be
 require "yaml" unless defined?(YAML.dump)
-
-module Bundler
-  # On encountering invalid YAML,
-  # Psych raises Psych::SyntaxError
-  if defined?(::Psych::SyntaxError)
-    YamlLibrarySyntaxError = ::Psych::SyntaxError
-  else # Syck raises ArgumentError
-    YamlLibrarySyntaxError = ::ArgumentError
-  end
-end

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -117,7 +117,7 @@ module Bundler
       Bundler.ui.error "#{e.class}: #{e.message}"
       Bundler.ui.trace e
       raise
-    rescue YamlLibrarySyntaxError => e
+    rescue ::Psych::SyntaxError => e
       raise YamlSyntaxError.new(e, "Your RubyGems configuration, which is " \
         "usually located in ~/.gemrc, contains invalid YAML syntax.")
     end

--- a/bundler/spec/bundler/bundler_spec.rb
+++ b/bundler/spec/bundler/bundler_spec.rb
@@ -21,30 +21,6 @@ RSpec.describe Bundler do
       it "catches YAML syntax errors" do
         expect { subject }.to raise_error(Bundler::GemspecError, /error while loading `test.gemspec`/)
       end
-
-      context "on Rubies with a settable YAML engine", :if => defined?(YAML::ENGINE) do
-        context "with Syck as YAML::Engine" do
-          it "raises a GemspecError after YAML load throws ArgumentError" do
-            orig_yamler = YAML::ENGINE.yamler
-            YAML::ENGINE.yamler = "syck"
-
-            expect { subject }.to raise_error(Bundler::GemspecError)
-
-            YAML::ENGINE.yamler = orig_yamler
-          end
-        end
-
-        context "with Psych as YAML::Engine" do
-          it "raises a GemspecError after YAML load throws Psych::SyntaxError" do
-            orig_yamler = YAML::ENGINE.yamler
-            YAML::ENGINE.yamler = "psych"
-
-            expect { subject }.to raise_error(Bundler::GemspecError)
-
-            YAML::ENGINE.yamler = orig_yamler
-          end
-        end
-      end
     end
 
     context "with correct YAML file", :if => defined?(Encoding) do

--- a/bundler/spec/bundler/endpoint_specification_spec.rb
+++ b/bundler/spec/bundler/endpoint_specification_spec.rb
@@ -32,22 +32,6 @@ RSpec.describe Bundler::EndpointSpecification do
         )
       end
     end
-
-    context "when there is an ill formed requirement" do
-      before do
-        allow(Gem::Dependency).to receive(:new).with(name, [requirement1, requirement2]) {
-          raise ArgumentError.new("Ill-formed requirement [\"#<YAML::Syck::DefaultKey")
-        }
-        # Eliminate extra line break in rspec output due to `puts` in `#build_dependency`
-        allow(subject).to receive(:puts) {}
-      end
-
-      it "should raise a Bundler::GemspecError with invalid gemspec message" do
-        expect { subject.send(:build_dependency, name, [requirement1, requirement2]) }.to raise_error(
-          Bundler::GemspecError, /Unfortunately, the gem foo \(1\.0\.0\) has an invalid gemspec/
-        )
-      end
-    end
   end
 
   describe "#parse_metadata" do

--- a/bundler/spec/bundler/psyched_yaml_spec.rb
+++ b/bundler/spec/bundler/psyched_yaml_spec.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require "bundler/psyched_yaml"
-
-RSpec.describe "Bundler::YamlLibrarySyntaxError" do
-  it "is raised on YAML parse errors" do
-    expect { YAML.parse "{foo" }.to raise_error(Bundler::YamlLibrarySyntaxError)
-  end
-end


### PR DESCRIPTION
# Description:

While working on a performance improvement, I stumbled upon an issue when (un)marshalling an object very early in the `ruby` process, and getting some errors about `Syck` constants not being defined.

After reading [this blog post](https://blog.rubygems.org/2011/08/31/shaving-the-yaml-yak.html), published almost 10 years ago already, my understanding is that this problem could come up in two ways:

* Rubygems.org serving "corrupted gemspecs". As far as I understand this was fixed in rubygems.org a lot time ago, since
https://github.com/rubygems/rubygems.org/pull/331.

* Clients having a ten years old gemspec cache with some of these bad gemspecs. In this case, there's no easy solution but I think ten years is enough and rebuilding the cache should do the trick.

So, I think it's time we remove this.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
