### PR TITLE
Rename workflows for consistency and easier auto-labelling

### DIFF
--- a/.github/workflows/daily-rubygems.yml
+++ b/.github/workflows/daily-rubygems.yml
@@ -1,11 +1,11 @@
-name: daily
+name: daily-rubygems
 
 on:
   schedule:
     - cron: '0 0 * * *'
 
 jobs:
-  daily:
+  daily_rubygems:
     runs-on: ubuntu-18.04
     strategy:
       matrix:

--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -1,4 +1,4 @@
-name: install
+name: install-rubygems
 
 on:
   pull_request:
@@ -9,7 +9,7 @@ on:
       - 3.2
 
 jobs:
-  install:
+  install_rubygems:
     runs-on: ubuntu-18.04
     strategy:
       matrix:

--- a/.github/workflows/macos-rubygems.yml
+++ b/.github/workflows/macos-rubygems.yml
@@ -1,4 +1,4 @@
-name: windows
+name: macos_rubygems
 
 on:
   pull_request:
@@ -9,8 +9,8 @@ on:
       - 3.2
 
 jobs:
-  windows:
-    runs-on: windows-2019
+  macos_rubygems:
+    runs-on: macos-10.15
     strategy:
       matrix:
         ruby: [ 2.4.10, 2.5.8, 2.6.6, 2.7.1 ]
@@ -23,9 +23,6 @@ jobs:
           bundler: none
       - name: Install Dependencies
         run: rake setup
-        shell: bash
       - name: Run Test
-        run: |
-          ridk enable
-          rake test
+        run: rake test
     timeout-minutes: 15

--- a/.github/workflows/monthly-bundler.yml
+++ b/.github/workflows/monthly-bundler.yml
@@ -1,11 +1,11 @@
-name: monthly
+name: monthly-bundler
 
 on:
   schedule:
     - cron: '0 0 1 * *'
 
 jobs:
-  run:
+  monthly_bundler:
     name: Refresh month of man pages
     runs-on: ubuntu-18.04
     steps:

--- a/.github/workflows/ubuntu-rubygems.yml
+++ b/.github/workflows/ubuntu-rubygems.yml
@@ -1,4 +1,4 @@
-name: ubuntu
+name: ubuntu-rubygems
 
 on:
   pull_request:
@@ -9,7 +9,7 @@ on:
       - 3.2
 
 jobs:
-  ubuntu:
+  ubuntu_rubygems:
     runs-on: ubuntu-18.04
     strategy:
       matrix:

--- a/.github/workflows/windows-rubygems.yml
+++ b/.github/workflows/windows-rubygems.yml
@@ -1,4 +1,4 @@
-name: macos
+name: windows_rubygems
 
 on:
   pull_request:
@@ -9,8 +9,8 @@ on:
       - 3.2
 
 jobs:
-  macos:
-    runs-on: macos-10.15
+  windows_rubygems:
+    runs-on: windows-2019
     strategy:
       matrix:
         ruby: [ 2.4.10, 2.5.8, 2.6.6, 2.7.1 ]
@@ -23,6 +23,9 @@ jobs:
           bundler: none
       - name: Install Dependencies
         run: rake setup
+        shell: bash
       - name: Run Test
-        run: rake test
+        run: |
+          ridk enable
+          rake test
     timeout-minutes: 15


### PR DESCRIPTION
# Description:

Make those related to `rubygems` only end with `-rubygems.yml`, and those related to `bundler` only end with `-bundler.yml`.

This was suggested by @simi at https://github.com/rubygems/rubygems/pull/3166#issuecomment-598705333, and it makes automatic labelling easier.

References: https://github.com/rubygems/issue-triage/pull/4.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
