### PR TITLE
Remove unnecessary guard clause

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -617,7 +617,6 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
   def self.load_yaml
     return if @yaml_loaded
-    return unless defined?(gem)
 
     begin
       # Try requiring the gem version *or* stdlib version of psych.


### PR DESCRIPTION
# Description:

Since 1ccf0912a161d20e0c4a7b139fd76e8739a411ba, this method no longer uses `Kernel.gem`, so this guard clause is now unnecessary.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
