### PR TITLE
Fix test warning (and disallow test warnings)

### DIFF
--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -283,9 +283,6 @@ class Gem::TestCase < Minitest::Test
 
   include Gem::DefaultUserInteraction
 
-  undef_method :default_test if instance_methods.include? 'default_test' or
-                                instance_methods.include? :default_test
-
   ##
   # #setup prepares a sandboxed location to install gems.  All installs are
   # directed to a temporary directory.  All install plugins are removed.

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -799,7 +799,7 @@ class Gem::TestCase < Minitest::Test
 
     lib_dir = File.join(@tempdir, "default_gems", "lib")
     lib_dir.instance_variable_set(:@gem_prelude_index, lib_dir)
-    Gem.instance_variable_set(:@default_gem_load_paths, [*Gem.instance_variable_get(:@default_gem_load_paths), lib_dir])
+    Gem.instance_variable_set(:@default_gem_load_paths, [*Gem.send(:default_gem_load_paths), lib_dir])
     $LOAD_PATH.unshift(lib_dir)
     files.each do |file|
       rb_path = File.join(lib_dir, file)

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -292,6 +292,10 @@ class Gem::TestCase < Minitest::Test
   # or <tt>i686-darwin8.10.1</tt> otherwise.
 
   def setup
+    @orig_stderr = $stderr.dup
+    @captured_stderr = Tempfile.new("captured_stderr")
+    $stderr.reopen @captured_stderr
+
     @orig_env = ENV.to_hash
     @tmp = File.expand_path("tmp")
 
@@ -465,6 +469,16 @@ class Gem::TestCase < Minitest::Test
     end
 
     @back_ui.close
+
+    $stderr.rewind
+    err = @captured_stderr.read
+    assert_empty err
+  ensure
+    @captured_stderr.unlink
+
+    $stderr.reopen @orig_stderr
+    @orig_stderr.close
+    @captured_stderr.close
   end
 
   def credential_setup

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -292,8 +292,6 @@ class Gem::TestCase < Minitest::Test
   # or <tt>i686-darwin8.10.1</tt> otherwise.
 
   def setup
-    super
-
     @orig_env = ENV.to_hash
     @tmp = File.expand_path("tmp")
 


### PR DESCRIPTION
# Description:

#3793 introduced a warning during `rubygems` test suite:

```
warning: instance variable @default_gem_load_paths not initialized
```

because the variable is not more lazily set.

This PR fixes the warning and disallows further warnings from creeping into the test suite.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
