### PR TITLE
`gem install --user` fails with `Gem::FilePermissionError` on the system plugins directory

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -189,6 +189,7 @@ class Gem::Installer
     if options[:user_install]
       @gem_home = Gem.user_dir
       @bin_dir = Gem.bindir gem_home unless options[:bin_dir]
+      @plugins_dir = Gem.plugindir(gem_home)
       check_that_user_bin_dir_is_in_path
     end
   end

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -767,6 +767,28 @@ gem 'other', version
     assert File.exist?(plugin_path), 'plugin not written to install_dir'
   end
 
+  def test_generate_plugins_with_user_install
+    spec = quick_gem 'a' do |s|
+      write_file File.join(@tempdir, 'lib', 'rubygems_plugin.rb') do |io|
+        io.write "puts __FILE__"
+      end
+
+      s.files += %w[lib/rubygems_plugin.rb]
+    end
+
+    util_build_gem spec
+
+    File.chmod(0555, Gem.plugindir)
+    system_path = File.join(Gem.plugindir, 'a_plugin.rb')
+    user_path = File.join(Gem.plugindir(Gem.user_dir), 'a_plugin.rb')
+    installer = util_installer spec, Gem.dir, :user
+
+    assert_equal spec, installer.install
+
+    assert !File.exist?(system_path), 'plugin not written to user plugins_dir'
+    assert File.exist?(user_path), 'plugin not written to user plugins_dir'
+  end
+
   def test_keeps_plugins_up_to_date
     # NOTE: version a-2 is already installed by setup hooks
 


### PR DESCRIPTION
# Description:

`gem install --user` fails with `Gem::FilePermissionError` on the system plugins directory.

## What was the end-user or developer problem that led to this PR?

With the master branch of ruby, `gem install` requires write-permission of the system plugins directory, **even with `--user` option**.
I think that installation with `--user` option should not require such privilege nor touch the system directories.

```
$ gem env version
3.2.0.pre1

$ gem install --debug --user yard
Exception `Gem::FilePermissionError' at /opt/local/lib/ruby/2.8.0/rubygems/installer.rb:962 - You don't have write permissions for the /opt/local/lib/ruby/gems/2.8.0/plugins directory.
ERROR:  While executing gem ... (Gem::FilePermissionError)
    You don't have write permissions for the /opt/local/lib/ruby/gems/2.8.0/plugins directory.
	/opt/local/lib/ruby/2.8.0/rubygems/installer.rb:962:in `ensure_writable_dir'
	/opt/local/lib/ruby/2.8.0/rubygems/installer.rb:515:in `generate_plugins'
	/opt/local/lib/ruby/2.8.0/rubygems/installer.rb:323:in `install'
	/opt/local/lib/ruby/2.8.0/rubygems/resolver/specification.rb:93:in `install'
	/opt/local/lib/ruby/2.8.0/rubygems/request_set.rb:195:in `block in install'
	/opt/local/lib/ruby/2.8.0/rubygems/request_set.rb:183:in `each'
	/opt/local/lib/ruby/2.8.0/rubygems/request_set.rb:183:in `install'
	/opt/local/lib/ruby/2.8.0/rubygems/commands/install_command.rb:208:in `install_gem'
	/opt/local/lib/ruby/2.8.0/rubygems/commands/install_command.rb:224:in `block in install_gems'
	/opt/local/lib/ruby/2.8.0/rubygems/commands/install_command.rb:217:in `each'
	/opt/local/lib/ruby/2.8.0/rubygems/commands/install_command.rb:217:in `install_gems'
	/opt/local/lib/ruby/2.8.0/rubygems/commands/install_command.rb:165:in `execute'
	/opt/local/lib/ruby/2.8.0/rubygems/command.rb:324:in `invoke_with_build_args'
	/opt/local/lib/ruby/2.8.0/rubygems/command_manager.rb:178:in `process_args'
	/opt/local/lib/ruby/2.8.0/rubygems/command_manager.rb:148:in `run'
	/opt/local/lib/ruby/2.8.0/rubygems/gem_runner.rb:55:in `run'
	/opt/local/bin/gem:28:in `<main>'
```

## What is your fix for the problem, implemented in this PR?

Fixes the `Gem::FilePermissionError` without the privilege.
Initialize `@plugins_dir` to the user gem directory, when installing with `--user` option.

______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
