### PR TITLE
Unify changelog sections in both libraries

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -572,7 +572,6 @@ Bug fixes:
 
 Security fixes:
 
-* Fixed following vulnerabilities:
   * CVE-2019-8320: Delete directory using symlink when decompressing tar
   * CVE-2019-8321: Escape sequence injection vulnerability in `verbose`
   * CVE-2019-8322: Escape sequence injection vulnerability in `gem owner`
@@ -898,7 +897,6 @@ Minor enhancements:
 
 Security fixes:
 
-* Fixed following vulnerabilities:
   * CVE-2019-8320: Delete directory using symlink when decompressing tar
   * CVE-2019-8321: Escape sequence injection vulnerability in `verbose`
   * CVE-2019-8322: Escape sequence injection vulnerability in `gem owner`

--- a/History.txt
+++ b/History.txt
@@ -76,9 +76,6 @@ Bug fixes:
 
 Compatibility changes:
 
-* Revert "Remove Gem::DependencyInstaller#find_gems_with_sources". Pull
-  request #3412 by David Rodríguez.
-* Version horizon deprecations. Pull request #3414 by Luis Sagastume.
 * Remove ruby 1.8 leftovers. Pull request #3442 by David Rodríguez.
 * Minitest cleanup. Pull request #3445 by David Rodríguez.
 * Remove `builder` gem requirement for `gem regenerate_index`. Pull

--- a/History.txt
+++ b/History.txt
@@ -398,8 +398,6 @@ Bug fixes:
 
 Compatibility changes:
 
-* Remove commented code from command.rb. Pull request #2620 by Luis
-  Sagastume.
 * Suppress keywords warning. Pull request #2934 by Nobuyoshi Nakada.
 * Suppress Ruby 2.7's real kwargs warning. Pull request #2912 by Koichi
   ITO.

--- a/History.txt
+++ b/History.txt
@@ -74,6 +74,11 @@ Bug fixes:
 * Fix `ruby setup.rb` for new plugins layout. Pull request #3144 by David
   Rodríguez.
 
+Deprecations:
+
+* Set deprecation warning on query command. Pull request #2967 by Luis
+  Sagastume.
+
 Compatibility changes:
 
 * Remove ruby 1.8 leftovers. Pull request #3442 by David Rodríguez.
@@ -90,8 +95,6 @@ Compatibility changes:
   Sagastume.
 * Remove dependency installer deprecated methods. Pull request #3106 by
   Luis Sagastume.
-* Set deprecation warning on query command. Pull request #2967 by Luis
-  Sagastume.
 * Remove Gem::UserInteraction#debug method. Pull request #3107 by Luis
   Sagastume.
 * Remove options from Gem::GemRunner.new. Pull request #3110 by Luis
@@ -192,11 +195,14 @@ Bug fixes:
 * Remove configuration that contained a typo. Pull request #2989 by David
   Rodríguez.
 
+Deprecations:
+
+* Deprecate `gem generate_index --modern` and `gem generate_index
+  --no-modern`. Pull request #2992 by David Rodríguez.
+
 Compatibility changes:
 
 * Remove 1.8.7 leftovers. Pull request #2972 by David Rodríguez.
-* Deprecate `gem generate_index --modern` and `gem generate_index
-  --no-modern`. Pull request #2992 by David Rodríguez.
 
 === 3.1.0.pre3 / 2019-11-11
 
@@ -396,27 +402,33 @@ Bug fixes:
 * Fix cryptic error on local and ignore-dependencies combination. Pull
   request #2650 by David Rodríguez.
 
+Deprecations:
+
+* Make deprecate Gem::RubyGemsVersion and Gem::ConfigMap. Pull request
+  #2857 by SHIBATA Hiroshi.
+* Deprecate Gem::RemoteFetcher#fetch_size. Pull request #2833 by Luis
+  Sagastume.
+* Explicitly deprecate `rubyforge_project`. Pull request #2798 by David
+  Rodríguez.
+* Deprecate unused Gem::Installer#unpack method. Pull request #2715 by Vít
+  Ondruch.
+* Deprecate a few unused methods. Pull request #2674 by David Rodríguez.
+* Add deprecation warnings for cli options. Pull request #2607 by Luis
+  Sagastume.
+
 Compatibility changes:
 
 * Suppress keywords warning. Pull request #2934 by Nobuyoshi Nakada.
 * Suppress Ruby 2.7's real kwargs warning. Pull request #2912 by Koichi
   ITO.
 * Fix Kernel#warn override. Pull request #2911 by Jeremy Evans.
-* Make deprecate Gem::RubyGemsVersion and Gem::ConfigMap. Pull request
-  #2857 by SHIBATA Hiroshi.
-* Deprecate Gem::RemoteFetcher#fetch_size. Pull request #2833 by Luis
-  Sagastume.
 * Remove conflict.rb code that was supposed to be removed in Rubygems 3.
   Pull request #2802 by Luis Sagastume.
-* Explicitly deprecate `rubyforge_project`. Pull request #2798 by David
-  Rodríguez.
 * Compatibility cleanups. Pull request #2754 by David Rodríguez.
 * Remove `others_possible` activation request param. Pull request #2747 by
   David Rodríguez.
 * Remove dependency installer deprecated code. Pull request #2740 by Luis
   Sagastume.
-* Deprecate unused Gem::Installer#unpack method. Pull request #2715 by Vít
-  Ondruch.
 * Removed guard condition with USE_BUNDLER_FOR_GEMDEPS. Pull request #2716
   by SHIBATA Hiroshi.
 * Skip deprecation warning during specs. Pull request #2718 by David
@@ -425,10 +437,7 @@ Compatibility changes:
 * Removed circular require. Pull request #2679 by Nobuyoshi Nakada.
 * Removed needless environmental variable for Travis CI. Pull request
   #2685 by SHIBATA Hiroshi.
-* Deprecate a few unused methods. Pull request #2674 by David Rodríguez.
 * Removing yaml require. Pull request #2538 by Luciano Sousa.
-* Add deprecation warnings for cli options. Pull request #2607 by Luis
-  Sagastume.
 
 === 3.0.8 / 2020-02-19
 
@@ -963,13 +972,16 @@ Bug fixes:
 * Fix path checks for case insensitive filesystem. Pull request #2211 by
   Lars Kanis.
 
-Compatibility changes:
+Deprecations:
 
 * Deprecate unused code before removing them at #1524. Pull request #2197
   by SHIBATA Hiroshi.
 * Deprecate for rubygems 3. Pull request #2214 by SHIBATA Hiroshi.
 * Mark deprecation to `ubygems.rb` for RubyGems 4. Pull request #2269 by
   SHIBATA Hiroshi.
+
+Compatibility changes:
+
 * Update bundler-1.16.2. Pull request #2291 by SHIBATA Hiroshi.
 
 === 2.7.6 / 2018-02-16
@@ -1162,11 +1174,8 @@ Minor enhancements:
 * Warn when requiring deprecated files. Pull request #1939 by Ellen Marie
   Dash.
 
-Compatibility changes:
+Deprecations:
 
-* Use `-rrubygems` instead of `-rubygems.rb`. Because ubygems.rb is
-  unavailable on Ruby 2.5. Pull request #2028 #2027 #2029
-  by SHIBATA Hiroshi.
 * Deprecate Gem::InstallerTestCase#util_gem_bindir and
   Gem::InstallerTestCase#util_gem_dir. Pull request #1729 by Jon Moss.
 * Deprecate passing options to Gem::GemRunner. Pull request #1730 by Jon
@@ -1174,6 +1183,12 @@ Compatibility changes:
 * Add deprecation for Gem#datadir. Pull request #1732 by Jon Moss.
 * Add deprecation warning for Gem::DependencyInstaller#gems_to_install.
   Pull request #1731 by Jon Moss.
+
+Compatibility changes:
+
+* Use `-rrubygems` instead of `-rubygems.rb`. Because ubygems.rb is
+  unavailable on Ruby 2.5. Pull request #2028 #2027 #2029
+  by SHIBATA Hiroshi.
 * Update Code of Conduct to Contributor Covenant v1.4.0. Pull request
   #1796 by Matej.
 

--- a/History.txt
+++ b/History.txt
@@ -2583,7 +2583,7 @@ Bug fixes:
 
 === 2.0.3 / 2013-03-11
 
-* Bug fixes:
+Bug fixes:
   * Reverted automatic upgrade to HTTPS as it breaks RubyGems APIs.  Fixes
     #506 by André Arko
   * Use File.realpath to remove extra / while checking if files are
@@ -2600,7 +2600,7 @@ Bug fixes:
 
 === 2.0.2 / 2013-03-06
 
-* Bug fixes:
+Bug fixes:
   * HTTPS URLs are preferred over HTTP URLs.  RubyGems will now attempt to
     upgrade any HTTP source to HTTPS.  Credit to Alex Gaynor.
   * SSL Certificates are now installed properly.  Fixes #491 by hemanth.hm
@@ -2608,7 +2608,7 @@ Bug fixes:
 
 === 2.0.1 / 2013-03-05
 
-* Bug fixes:
+Bug fixes:
   * Lazily load RubyGems.org API credentials to avoid failure during
     RubyGems installation.  Bug #465 by Isaac Sanders.
   * RubyGems now picks the latest prerelease to install.  Fixes bug #468 by
@@ -2642,7 +2642,7 @@ newer.  Older versions of bundler will not work with RubyGems 2.0.
 
 Changes since RubyGems 1.8.25 (including past pre-releases):
 
-* Breaking changes:
+Breaking changes:
 
   * Deprecated Gem.unresolved_deps in favor of
     Gem::Specification.unresolved_deps
@@ -2664,7 +2664,7 @@ Changes since RubyGems 1.8.25 (including past pre-releases):
   * Removed support for Ruby 1.9.1
   * Removed many deprecated methods
 
-* Major enhancements:
+Major enhancements:
 
   * Improved support for default gems shipping with ruby 2.0.0+
   * A gem can have arbitrary metadata through Gem::Specification#metadata
@@ -2683,7 +2683,7 @@ Changes since RubyGems 1.8.25 (including past pre-releases):
     Set RUBYGEMS_GEMDEPS=path to have it loaded. Use - as the path
     to autodetect (current and parent directories are searched).
 
-* Minor enhancements:
+Minor enhancements:
   * Added `gem check --doctor` to clean up after failed uninstallation.  Bug
     #419 by Erik Hollensbe
   * RubyGems no longer defaults to uninstalling gems if a dependency would be
@@ -2726,7 +2726,7 @@ Changes since RubyGems 1.8.25 (including past pre-releases):
     GEM_HOME
   * When building gems with non-world-readable files a warning is shown.
 
-* Bug fixes:
+Bug fixes:
   * Gem.refresh now maintains the active gem list.  Clearing the list would
     cause double-loads which would cause other bugs.  Pull Request #427 by
     Jeremy Evans
@@ -2783,7 +2783,7 @@ Changes since RubyGems 1.8.25 (including past pre-releases):
 
 Changes since RubyGems 2.0.0.rc.2:
 
-* Bug fixes:
+Bug fixes:
   * Gem.gzip and Gem.gunzip now return strings with BINARY encoding.  Issue
     #450 by Jeremy Kemper
   * Fixed placement of executables with --user-install.  Ruby bug #7779 by Jon
@@ -2798,7 +2798,7 @@ Changes since RubyGems 2.0.0.rc.2:
 
 === 2.0.0.rc.2 / 2013-02-08
 
-* Bug fixes:
+Bug fixes:
   * Fixed signature verification of gems which was broken only on master.
     Thanks to Brian Buchanan.
   * Proper exceptions are raised when verifying an unsigned gem.  Thanks to
@@ -2806,13 +2806,13 @@ Changes since RubyGems 2.0.0.rc.2:
 
 === 2.0.0.rc.1 / 2013-01-08
 
-* Minor enhancements:
+Minor enhancements:
   * This release of RubyGems can push gems to rubygems.org.  Ordinarily
     prerelease versions of RubyGems cannot push gems.
   * Added `gem check --doctor` to clean up after failed uninstallation.  Bug
     #419 by Erik Hollensbe
 
-* Bug fixes:
+Bug fixes:
   * Fixed exception raised when attempting to push gems to rubygems.org.  Bug
     #418 by André Arko
   * Gem installation will fail if RubyGems cannot load the specification from
@@ -2820,24 +2820,24 @@ Changes since RubyGems 2.0.0.rc.2:
 
 === 2.0.0.preview2.2 / 2012-12-14
 
-* Minor enhancements:
+Minor enhancements:
   * Added a cmake builder.  Pull request #265 by Allan Espinosa.
   * Removed rubyforge page from gem list output
 
-* Bug fixes:
+Bug fixes:
   * Restored RubyGems 1.8 packaging behavior of omitting directories.  Bug
     #413 by Jeremy Kemper.
 
 === 2.0.0.preview2.1 / 2012-12-08
 
-* Minor enhancements:
+Minor enhancements:
   * Gem::DependencyInstaller now passes build_args down to the installer.
     Pull Request #412 by Sam Rawlins.
   * RubyGems no longer defaults to uninstalling gems if a dependency would be
     broken.  Now you must manually say "yes".  Pull Request #406 by Shannon
     Skipper.
 
-* Bug fixes:
+Bug fixes:
   * RubyGems tests now run in FIPS mode.  Issue #365 by Vít Ondruch
   * Fixed Gem::Specification#base_dir for default gems.  Ruby Bug #7469
   * Only update the spec cache when we have permission.  Ruby Bug #7509
@@ -2855,7 +2855,7 @@ This release contains two commits not present in Ruby 2.0.0.preview2.  One
 commit is for ruby 1.8.7 support, the second allows RubyGems to work under
 $SAFE=1.  There is no functional difference compared to Ruby 2.0.0.preview2
 
-* Breaking changes:
+Breaking changes:
 
   * Deprecated Gem.unresolved_deps in favor of
     Gem::Specification.unresolved_deps
@@ -2877,7 +2877,7 @@ $SAFE=1.  There is no functional difference compared to Ruby 2.0.0.preview2
   * Removed support for Ruby 1.9.1
   * Removed many deprecated methods
 
-* Major enhancements:
+Major enhancements:
 
   * Improved support for default gems shipping with ruby 2.0.0+
   * A gem can have arbitrary metadata through Gem::Specification#metadata
@@ -2896,7 +2896,7 @@ $SAFE=1.  There is no functional difference compared to Ruby 2.0.0.preview2
     Set RUBYGEMS_GEMDEPS=path to have it loaded. Use - as the path
     to autodetect (current and parent directories are searched).
 
-* Minor enhancements:
+Minor enhancements:
 
   * Added --only-executables option to `gem pristine`.  Fixes #326
   * Added -I flag for 'gem query' to exclude installed items
@@ -2931,7 +2931,7 @@ $SAFE=1.  There is no functional difference compared to Ruby 2.0.0.preview2
     GEM_HOME
   * When building gems with non-world-readable files a warning is shown.
 
-* Bug fixes:
+Bug fixes:
 
   * Added PID to setup bin_file while installing RubyGems to protect against
     errors. Fixes #328 by ConradIrwin
@@ -3016,7 +3016,7 @@ Bug fixes:
 
 === 1.8.25 / 2013-01-24
 
-* Bug fixes:
+Bug fixes:
   * Added 11627 to setup bin_file location to protect against errors. Fixes
     #328 by ConradIrwin
   * Specification#ruby_code didn't handle Requirement with multiple
@@ -3027,7 +3027,7 @@ Bug fixes:
 
 === 1.8.24 / 2012-04-27
 
-* 1 bug fix:
+Bug fixes:
 
   * Install the .pem files properly. Fixes #320
   * Remove OpenSSL dependency from the http code path
@@ -3066,20 +3066,20 @@ You may also set :ssl_verify_mode to 0 to completely disable SSL
 certificate checks, but this is not recommended.
 
 
-* 2 security fixes:
+Security fixes:
   * Disallow redirects from https to http
   * Turn on verification of server SSL certs
 
-* 1 minor feature:
+Minor enhancements:
   * Add --clear-sources to fetch
 
-* 2 bug fixes:
+Bug fixes:
   * Use File.identical? to check if two files are the same.
   * Fixed init_with warning when using psych
 
 === 1.8.22 / 2012-04-13
 
-* 4 bug fixes:
+Bug fixes:
 
   * Workaround for psych/syck YAML date parsing issue
   * Don't trust the encoding of ARGV. Fixes #307
@@ -3088,14 +3088,14 @@ certificate checks, but this is not recommended.
 
 === 1.8.21 / 2012-03-22
 
-* 2 bug fixes:
+Bug fixes:
 
   * Add workaround for buggy yaml output from 1.9.2
   * Force 1.9.1 to remove it's prelude code. Fixes #305
 
 === 1.8.20 / 2012-03-21
 
-* 4 bug fixes:
+Bug fixes:
 
   * Add --force to `gem build` to skip validation. Fixes #297
   * Gracefully deal with YAML::PrivateType objects in Marshal'd gemspecs
@@ -3104,7 +3104,7 @@ certificate checks, but this is not recommended.
 
 === 1.8.19 / 2012-03-14
 
-* 3 bug fixes:
+Bug fixes:
 
   * Handle loading psych vs syck properly. Fixes #298
   * Make sure Date objects don't leak in via Marshal
@@ -3112,7 +3112,7 @@ certificate checks, but this is not recommended.
 
 === 1.8.18 / 2012-03-11
 
-* 4 bug fixes:
+Bug fixes:
 
   * Use Psych API to emit more compatible YAML
   * Download and write inside `gem fetch` directly. Fixes #289
@@ -3122,12 +3122,12 @@ certificate checks, but this is not recommended.
 
 === 1.8.17 / 2012-02-17
 
-* 2 minor enhancements:
+Minor enhancements:
 
   * Add MacRuby to the list of special cases for platforms (ferrous26)
   * Add a default for where to install rubygems itself
 
-* 3 bug fixes:
+Bug fixes:
 
   * Fixed gem loading issue caused by dependencies not resolving.
   * Fixed umask error when stdlib is required and unresolved dependencies exist.
@@ -3137,7 +3137,7 @@ certificate checks, but this is not recommended.
 
 === 1.8.16 / 2012-02-12
 
-* 3 bug fixes:
+Bug fixes:
 
   * Fix gem specification loading when encoding is not UTF-8. #146
   * Allow group writable if umask allows it already.
@@ -3145,37 +3145,39 @@ certificate checks, but this is not recommended.
 
 === 1.8.15 / 2012-01-06
 
-* 1 bug fix:
+Bug fixes:
 
   * Don't eager load yaml, it creates a bad loop. Fixes #256
 
 === 1.8.14 / 2012-01-05
 
-* 2 bug fixes:
+Bug fixes:
 
   * Ignore old/bad cache data in Version
   * Make sure our YAML workarounds are loaded properly. Fixes #250.
 
 === 1.8.13 / 2011-12-21
 
-* 1 bug fix:
+Bug fixes:
 
   * Check loaded_specs properly when trying to satisfy a dep
 
-* 2 minor enhancements:
+Minor enhancements:
 
   * Remove using #loaded_path? for performance
   * Remove Zlib workaround for Windows build.
 
 === 1.8.12 / 2011-12-02
 
-* Bug fix:
+Bug fixes:
+
   * Handle more cases where Syck's DefaultKey showed up in requirements
     and wasn't cleaned out.
 
 === 1.8.11 / 2011-10-03
 
-* Bug fix:
+Bug fixes:
+
   * Deprecate was moved to Gem::Deprecate to stop polluting the top-level
     namespace.
 
@@ -3185,7 +3187,7 @@ RubyGems 1.8.10 contains a security fix that prevents malicious gems from
 executing code when their specification is loaded.  See
 https://github.com/rubygems/rubygems/pull/165 for details.
 
-* 5 bug fixes:
+Bug fixes:
 
   * RubyGems escapes strings in ruby-format specs using #dump instead of #to_s
     and %q to prevent code injection.  Issue #165 by Postmodern
@@ -3198,19 +3200,19 @@ https://github.com/rubygems/rubygems/pull/165 for details.
 
 === 1.8.9 / 2011-08-23
 
-* Bug fixes:
+Bug fixes:
 
   * Fixed uninstalling multiple gems using `gem uninstall`
   * Gem.use_paths splatted to take multiple paths!  Issue #148
 
 === 1.8.8 / 2011-08-11
 
-* Bug fix:
+Bug fixes:
   * The encoding of a gem's YAML spec is now UTF-8.  Issue #149
 
 === 1.8.7 / 2011-08-04
 
-* Bug fixes:
+Bug fixes:
   * Added missing require for `gem uninstall --format-executable`
   * The correct name of the executable being uninstalled is now displayed with
     --format-executable
@@ -3224,12 +3226,12 @@ https://github.com/rubygems/rubygems/pull/165 for details.
 
 === 1.8.6 / 2011-07-25
 
-* 1 minor enhancement:
+Minor enhancements:
 
   * Add autorequires and delay startup of RubyGems until require is called.
     See Ruby bug #4962
 
-* 9 bug fixes:
+Bug fixes:
 
   * Restore behavior of Gem::Specification#loaded?  Ruby Bug #5032
   * Clean up SourceIndex.add_specs to not be so damn noisy. (tadman)
@@ -3243,25 +3245,25 @@ https://github.com/rubygems/rubygems/pull/165 for details.
 
 === 1.8.5 / 2011-05-31
 
-* 2 minor enhancement:
+Minor enhancements:
 
   * The -u option to 'update local source cache' is official deprecated.
   * Remove has_rdoc deprecations from Specification.
 
-* 2 bug fixes:
+Bug fixes:
 
   * Handle bad specs more gracefully.
   * Reset any Gem paths changed in the installer.
 
 === 1.8.4 / 2011-05-25
 
-* 1 minor enhancement:
+Minor enhancements:
 
   * Removed default_executable deprecations from Specification.
 
 === 1.8.3 / 2011-05-19
 
-* 4 bug fixes:
+Bug fixes:
 
   * Fix independent testing of test_gem_package_tar_output.  Ruby Bug #4686 by
     Shota Fukumori
@@ -3272,12 +3274,12 @@ https://github.com/rubygems/rubygems/pull/165 for details.
 
 === 1.8.2 / 2011-05-11
 
-* 2 minor enhancements:
+Minor enhancements:
 
   * Moved #outdated from OutdatedCommand to Specification (for Isolate).
   * Print out a warning about missing executables.
 
-* 3 bug fixes:
+Bug fixes:
 
   * Added missing requires to fix various upgrade issues.
   * `gem pristine` respects multiple gem repositories.
@@ -3285,11 +3287,11 @@ https://github.com/rubygems/rubygems/pull/165 for details.
 
 === 1.8.1 / 2011-05-05
 
-* 1 minor enhancement:
+Minor enhancements:
 
   * Added Gem::Requirement#specific? and Gem::Dependency#specific?
 
-* 4 bug fixes:
+Bug fixes:
 
   * Typo on Indexer rendered it useless on Windows
   * gem dep can fetch remote dependencies for non-latest gems again.
@@ -3311,7 +3313,7 @@ extensions.  You will need to run `gem pristine gem_with_extension --
 --build-arg` to regenerate a gem with an extension where it requires special
 build arguments.
 
-* 24(+) Deprecations (WOOT!):
+Deprecations:
 
   * DependencyList.from_source_index deprecated the source_index argument.
   * Deprecated Dependency.new(/regex/).
@@ -3332,13 +3334,13 @@ build arguments.
   * Deprecated all of Gem::GemPathSearcher.
   * Deprecated Gem::Specification#default_executable.
 
-* 2 major enhancements:
+Major enhancements:
 
   * Gem::SourceIndex functionality has been moved to Gem::Specification.
     Gem::SourceIndex is completely disconnected from Gem::Specification
   * Refactored GemPathSearcher entirely out. RIPMF
 
-* 41 minor enhancements:
+Minor enhancements:
 
   * Added CommandManager#unregister_command
   * Added Dependency#matching_specs + to_specs.
@@ -3387,7 +3389,7 @@ build arguments.
     extensions.
   * `gem pristine` can now restore multiple gems.
 
-* 6 bug fixes:
+Bug fixes:
 
   * DependencyInstaller passed around a source_index instance but used
     Gem.source_index.
@@ -3401,13 +3403,13 @@ build arguments.
 
 === 1.7.1 / 2011-03-32
 
-* 1 bug fix:
+Bug fixes:
   * Fixed missing file in Manifest.txt.  (Also a bug in hoe was fixed where
     `rake check_manifest` showing a diff would not exit with an error.)
 
 === 1.7.0 / 2011-03-32
 
-* 16 Deprecations (woot!)
+Deprecations:
   * Deprecated Gem.all_load_paths, latest_load_paths, promote_load_path, and
     cache.
   * Deprecated RemoteFetcher#open_uri_or_path.
@@ -3419,7 +3421,7 @@ build arguments.
     test_suite_file(=).
   * Deprecated Specification#has_rdoc= and default_executable=
 
-* 26 minor enhancements:
+Minor enhancements:
   * Added stupid simple deprecation module.
   * Added --spec option to `gem unpack` to output a gem's original metadata
   * Added packaging option to Specification#validate
@@ -3451,7 +3453,7 @@ build arguments.
   * UpdateCommand#gems_to_update now returns (name, version) pairs.
   * UpdateCommand#which_to_update now takes an optional system argument.
 
-* 11 bug fixes:
+Bug fixes:
   * Added missing remote fetcher require to pristine command (aarnell)
   * Building gems now checks to ensure all required fields are non-nil
   * Fix option parser when summary is nil.
@@ -3469,7 +3471,7 @@ build arguments.
 
 === 1.6.2 / 2011-03-08
 
-Bug Fixes:
+Bug fixes:
 
 * require of an activated gem could cause activation conflicts.  Fixes
   Bug #29056 by Dave Verwer.
@@ -3477,7 +3479,7 @@ Bug Fixes:
 
 === 1.6.1 / 2011-03-03
 
-Bug Fixes:
+Bug fixes:
 
 * Installation no longer fails when a dependency from a version that won't be
   installed is unsatisfied.
@@ -3488,7 +3490,7 @@ Bug Fixes:
 
 === 1.6.0 / 2011-02-29
 
-4 Deprecations:
+Deprecations:
 
 * RubyGems no longer requires 'thread'.  Rails < 3 will need to add require
   'thread' to their applications.
@@ -3497,13 +3499,13 @@ Bug Fixes:
 * Gem::LoadError#version_requirements has been removed.  Use
   Gem::LoadError#requirement.
 
-2 Major Enhancements:
+Major enhancements:
 
 * Rewrote how Gem::activate (gem and require) resolves dependencies.
 * Gem::LoadError#version_requirement has been removed. Use
   Gem::LoadError#requirement.
 
-17 Minor Enhancments:
+Minor enhancements:
 
 * Added --key to `gem push` for setting alternate API keys.
 * Added --format-executable support to gem uninstall.
@@ -3528,7 +3530,7 @@ Bug Fixes:
   locally cached gem specifications.
 * SpecFetcher.fetch_spec can now take a string source_uri.
 
-10 Bug Fixes:
+Bug fixes:
 
 * Added missing require of Gem::RemoteFetcher to the unpack command.
 * RubyGems now completely removes a previous install when reinstalling.
@@ -3543,14 +3545,14 @@ Bug Fixes:
 
 === 1.5.3 / 2011-02-26
 
-Bug Fixes:
+Bug fixes:
 
 * Fix for a bug in Syck which causes install failures for gems packaged with
   Psych.  Bug #28965 by Aaron Patterson.
 
 === 1.5.2 / 2011-02-10
 
-Bug Fixes:
+Bug fixes:
 
 * Fixed <tt>gem update --system</tt>.  RubyGems can now update itself again.
 
@@ -3558,11 +3560,11 @@ Bug Fixes:
 
 ==== NOTE: `gem update --system` is broken. See UPGRADING.rdoc.
 
-Minor Enhancement:
+Minor enhancements:
 
 * Added ability to do gem update --system X.Y.Z.
 
-Bug Fixes:
+Bug fixes:
 
 * Scrub !!null YAML from 1.9.2 (install and build).
 * Added missing requires for user_interaction.
@@ -3575,12 +3577,12 @@ Bug Fixes:
 
 ==== NOTE: `gem update --system` is broken. See UPGRADING.rdoc.
 
-Major Enhancements:
+Major enhancements:
 
 * Finally fixed all known 1.9.x issues. Upgrading is now possible!
 * Merged huge 1.3.7/ruby-core changes to master.
 
-Minor Enhancements:
+Minor enhancements:
 
 * Added UPGRADING.rdoc to help deal with 1.9 issues.
 * Gem::Format now gives better errors for corrupt gem files and includes paths
@@ -3593,7 +3595,7 @@ Minor Enhancements:
 * Gem::SilentUI now behaves like Gem::StreamUI for asking questions.  Patch by
   Erik Hollensbe.
 
-Bug Fixes:
+Bug fixes:
 
 * `gem update` was implicitly doing --system.
 * 1.9.3: Fixed encoding errors causing gem installs to die during rdoc phase.
@@ -3619,7 +3621,7 @@ Since apparently nobody reads my emails, blog posts or the README:
 
 DO NOT UPDATE RUBYGEMS ON RUBY 1.9! See UPGRADING.rdoc for details.
 
-Bug fix:
+Bug fixes:
 
 * Specification#load was untainting a frozen string (via `gem build *.spec`)
 
@@ -3633,7 +3635,7 @@ You have been warned!
 
 NOTE: We've switched to git/github. See README.rdoc for details.
 
-New features:
+Features:
 
 * Added --launch option to `gem server`. (gthiesfeld)
 * Added fuzzy name matching on install failures. (gstark/presidentbeef)
@@ -3665,7 +3667,7 @@ http://gems.rubyforge.org with https://rubygems.org/
 
 http://gems.rubyforge.org will continue to work for the foreseeable future.
 
-New features:
+Features:
 
 * `gem` commands
   * `gem install` and `gem fetch` now report alternate platforms when a
@@ -3698,7 +3700,7 @@ Bug fixes:
 
 === 1.3.6 / 2010-02-17
 
-New features:
+Features:
 
 * `gem` commands
   * Added `gem push` and `gem owner` for interacting with modern/Gemcutter
@@ -3729,7 +3731,7 @@ Bug fixes:
 * Gem::RemoteFetcher no longer copies the file if it is where we want it.
   Patch #27409 by Jakub Šťastný.
 
-Deprecation Notices:
+Deprecations:
 
 * lib/rubygems/timer.rb has been removed.
 * Gem::Dependency#version_requirements is deprecated and will be removed on or
@@ -3745,7 +3747,7 @@ Bug fixes:
 * Fix use of prerelease gems.
 * Gem.bin_path no longer escapes path with spaces. Bug #25935 and #26458.
 
-Deprecation Notices:
+Deprecations:
 
 * Bulk index update is no longer supported (the code currently remains, but not
   the tests)
@@ -3754,7 +3756,7 @@ Deprecation Notices:
 
 === 1.3.4 / 2009-05-03
 
-Bug Fixes:
+Bug fixes:
 
 * Fixed various warnings
 * Gem::ruby_version works correctly for 1.8 branch and trunk
@@ -3765,7 +3767,7 @@ Bug Fixes:
   drives.  Bug #25882 by Lars Christensen
 * Fix typo in Gem::Requirement#parse.  Bug #26000 by Mike Gunderloy.
 
-Deprecation Notices:
+Deprecations:
 
 * Bulk index update is no longer supported (the code currently remains, but not
   the tests)
@@ -3774,7 +3776,7 @@ Deprecation Notices:
 
 === 1.3.3 / 2009-05-04
 
-New Features:
+Features:
 
 * `gem server` allows port names (from /etc/services) with --port.
 * `gem server` now has search that jumps to RDoc.  Patch #22959 by Vladimir
@@ -3784,7 +3786,7 @@ New Features:
 * Gem::Specification#has_rdoc= is deprecated and ignored (defaults to true)
 * RDoc is now generated regardless of Gem::Specification#has_rdoc?
 
-Bug Fixes:
+Bug fixes:
 
 * `gem clean` now cleans up --user-install gems.  Bug #25516 by Brett
   Eisenberg.
@@ -3806,7 +3808,7 @@ Bug Fixes:
 * Raise Gem::LoadError if Kernel#gem fails due to previously-loaded gem.  Bug
   reported by Alf Mikula.
 
-Deprecation Notices:
+Deprecations:
 
 * Gem::manage_gems has been removed.
 * Time::today has been removed early.  There was no way to make it warn and be
@@ -3814,7 +3816,7 @@ Deprecation Notices:
 
 === 1.3.2 / 2009-04-15
 
-Select New Features:
+Features:
 
 * RubyGems now loads plugins from rubygems_plugin.rb in installed gems.
   This can be used to add commands (See Gem::CommandManager) or add
@@ -3842,7 +3844,7 @@ Select New Features:
   * Modern indicies can now be updated incrementally.
   * Legacy indicies can be updated separately from modern.
 
-Select Bugs Fixed:
+Bug fixes:
 
 * Better gem activation error message. Patch #23082.
 * Kernel methods are now private.  Patch #20801 by James M. Lawrence.
@@ -3868,7 +3870,7 @@ Select Bugs Fixed:
   * Deal with extraneous quotation mark when autogenerating .bat file on MS
     Windows.  Bug #22712.
 
-Deprecation Notices:
+Deprecations:
 
 * Gem::manage_gems has been removed.
 * Time::today will be removed in RubyGems 1.4.
@@ -3878,7 +3880,7 @@ Lavena and Daniel Berger for continuing windows support.
 
 === 1.3.1 / 2008-10-28
 
-Bugs fixed:
+Bug fixes:
 
 * Disregard ownership of ~ under Windows while creating ~/.gem.  Fixes
   issues related to no uid support under Windows.
@@ -3889,13 +3891,13 @@ Bugs fixed:
 * Gem::location_of_caller now behaves on Windows.  Patch by Daniel Berger.
 * Silence PATH warning.
 
-Deprecation Notices:
+Deprecations:
 
 * Gem::manage_gems will be removed on or after March 2009.
 
 === 1.3.0 / 2008-09-25
 
-New features:
+Features:
 
 * RubyGems doesn't print LOCAL/REMOTE titles for `gem query` and friends if
   stdout is not a TTY, except with --both.
@@ -3909,12 +3911,12 @@ New features:
 * RubyGems now updates the ri cache when the rdoc gem is installed and
   documentation is generated.
 
-Deprecation Notices:
+Deprecations:
 
 * Gem::manage_gems now warns when called.  It will be removed on or after March
   2009.
 
-Bugs Fixed:
+Bug fixes:
 
 * RubyGems 1.3.0+ now updates when no previous rubygems-update is installed.
   Bug #20775 by Hemant Kumar.
@@ -3938,7 +3940,7 @@ Bugs Fixed:
 * `gem lock --strict` works again.  Patch #21814 by Sven Engelhardt.
 * Platform detection for Solaris was improved.  Patch #21911 by Bob Remeika.
 
-Other Changes Include:
+Minor enhancements:
 
 * `gem help install` now describes _version_ argument to executable stubs
 * `gem help environment` describes environment variables and ~/.gemrc and
@@ -3966,7 +3968,7 @@ Other Changes Include:
 
 === 1.2.0 / 2008-06-21
 
-New features:
+Features:
 
 * RubyGems no longer performs bulk updates and instead only fetches the gemspec
   files it needs.  Alternate sources will need to upgrade to RubyGems 1.2 to
@@ -3985,7 +3987,7 @@ New features:
 * setup.rb now handles --vendor and --destdir for packagers
 * `gem stale` command that lists gems by last access time
 
-Bugs Fixed:
+Bug fixes:
 
 * File modes from gems are now honored, patch #19737
 * Marshal Gem::Specification objects from the future can now be loaded.
@@ -4000,7 +4002,7 @@ Bugs Fixed:
 * Gem::DependencyInstaller resets installed gems every install, bug #19444
 * Gem.default_path is now honored if GEM_PATH is not set, patch #19502
 
-Other Changes Include:
+Minor enhancements:
 
 * setup.rb
   * stub files created by RubyGems 0.7.x and older are no longer removed.  When
@@ -4021,7 +4023,7 @@ Other Changes Include:
 
 === 1.1.1 / 2008-04-11
 
-Bugs Fixed:
+Bug fixes:
 
 * Gem.prefix now returns non-nil only when RubyGems was installed outside
   sitelibdir or libdir.
@@ -4038,7 +4040,7 @@ Bugs Fixed:
 
 === 1.1.0 / 2008-03-29
 
-New features:
+Features:
 
 * RubyGems now uses persistent connections on index updates.  Index updates are
   much faster now.
@@ -4050,7 +4052,7 @@ New features:
 * `gem spec` now extracts specifications from .gem files.
 * `gem query --installed` to aid automation of checking for gems.
 
-Bugs Fixed:
+Bug fixes:
 
 * RubyGems works with both Config and RbConfig now.
 * Executables are now cleaned upon uninstall.
@@ -4066,7 +4068,7 @@ Bugs Fixed:
 * Gem stub scripts on windows now work outside Gem.bindir.
 * `gem sources -r` now works without network access.
 
-Other Changes Include:
+Minor enhancements:
 
 * RubyGems now requires Ruby > 1.8.3.
 * Release notes are now printed upon installation.
@@ -4079,24 +4081,24 @@ For a full list of changes to RubyGems, see the ChangeLog file.
 
 === 1.0.1 / 2007-12-20
 
-Bugs Fixed:
+Bug fixes:
 
 * Installation on Ruby 1.8.3 through 1.8.5 fixed
 * `gem build` on 1.8.3 fixed
 
-Other Changes Include:
+Minor enhancements:
 
 * Since RubyGems 0.9.5, RubyGems is no longer supported on Ruby 1.8.2 or older,
   this is official in RubyGems 1.0.1.
 
 === 1.0.0 / 2007-12-20
 
-Major New Features Include:
+Features:
 
 * RubyGems warns about various problems with gemspecs during gem building
 * More-consistent versioning for the RubyGems software
 
-Other Changes Include:
+Minor enhancements:
 
 * Fixed various bugs and problems with installing gems on Windows
 * Fixed using `gem server` for installing gems
@@ -4110,7 +4112,7 @@ Other Changes Include:
 * `gem unpack` can now unpack into a specific directory with --target
 * OpenSSL is no longer required by default
 
-Deprecations and Deletions:
+Breaking changes:
 
 * Kernel#require_gem has been removed
 * Executables without a shebang will not be wrapped in a future version, this
@@ -4124,7 +4126,7 @@ Deprecations and Deletions:
 
 === 0.9.5 / 2007-11-19
 
-Major New Features Include:
+Features:
 
 * Platform support
 * Automatic installation of platform gems
@@ -4136,7 +4138,7 @@ Major New Features Include:
 * Improved stubs and `gem.bat` on mswin, including better compatibility
   with the One-Click Installer.
 
-Other Changes Include:
+Minor enhancements:
 
 * Time::today is deprecated and will be removed at a future date
 * Gem::manage_gems is deprecated and will be removed at a future date
@@ -4187,7 +4189,7 @@ If you are experiencing problems with the source index (e.g. strange
 "No Method" errors), or problems with zlib (e.g. "Buffer Error"
 messsage), we recommend upgrading to RubyGems 0.9.4.
 
-Bug Fixes Include:
+Bug fixes:
 
 * Several people have been experiencing problems with no method errors
   on the source index cache.  The source index cache is now a bit more
@@ -4201,7 +4203,7 @@ Bug Fixes Include:
 
 === 0.9.3 / 2007-05-10
 
-Bug Fixes Include:
+Bug fixes:
 
 The ZLib library on Windows will occasionally complains about a buffer error
 when unpacking gems.  The Gems software has a workaround for that problem, but
@@ -4211,7 +4213,7 @@ have permanently enabled the work around on all versions.
 
 === 0.9.2 / 2007-02-05
 
-Bug Fixes Include:
+Bug fixes:
 
 * The "unpack" command now works properly.
 * User name and password are now passed properly to the authenticating
@@ -4229,7 +4231,7 @@ number one change is that we can now download the gem index
 incrementally.  This will greatly speed up the gem command when only a
 few gems are out of date.
 
-Major Enhancments include:
+Major enhancements:
 
 * The gem index is now downloaded incrementally, only updating entries
   that are out of date.  If more than 50 entries are out of date, we
@@ -4245,7 +4247,7 @@ Major Enhancments include:
 * A gemri command is included to read gem RI docs (only needed for
   Ruby 1.8.4 or earlier).
 
-Minor enhancements include:
+Minor enhancements:
 
 * Version 0.0.0 is now a valid gem version.
 * Better detection of missing SSL functionality.
@@ -4259,7 +4261,7 @@ Minor enhancements include:
 * .rbw is now a supported suffix for RubyGem's custom require.
 * Several Ruby 1.9 compatibility fixes (Eric Hodel).
 
-Bug Fixes:
+Bug fixes:
 
 * Added dashes to gemspecs generated in Ruby 1.8.3.  This solves some
   cross-Ruby version compatibility issues.

--- a/History.txt
+++ b/History.txt
@@ -79,7 +79,7 @@ Deprecations:
 * Set deprecation warning on query command. Pull request #2967 by Luis
   Sagastume.
 
-Compatibility changes:
+Breaking changes:
 
 * Remove ruby 1.8 leftovers. Pull request #3442 by David Rodríguez.
 * Minitest cleanup. Pull request #3445 by David Rodríguez.
@@ -200,7 +200,7 @@ Deprecations:
 * Deprecate `gem generate_index --modern` and `gem generate_index
   --no-modern`. Pull request #2992 by David Rodríguez.
 
-Compatibility changes:
+Breaking changes:
 
 * Remove 1.8.7 leftovers. Pull request #2972 by David Rodríguez.
 
@@ -416,7 +416,7 @@ Deprecations:
 * Add deprecation warnings for cli options. Pull request #2607 by Luis
   Sagastume.
 
-Compatibility changes:
+Breaking changes:
 
 * Suppress keywords warning. Pull request #2934 by Nobuyoshi Nakada.
 * Suppress Ruby 2.7's real kwargs warning. Pull request #2912 by Koichi
@@ -834,7 +834,7 @@ Bug fixes:
 * Fix tests when --program-suffix and similar ruby configure options are
   used. Pull request #2529 by Jeremy Evans.
 
-Compatibility changes:
+Breaking changes:
 
 * IO.binread is not provided at Ruby 1.8. Pull request #2093 by SHIBATA
   Hiroshi.
@@ -980,7 +980,7 @@ Deprecations:
 * Mark deprecation to `ubygems.rb` for RubyGems 4. Pull request #2269 by
   SHIBATA Hiroshi.
 
-Compatibility changes:
+Breaking changes:
 
 * Update bundler-1.16.2. Pull request #2291 by SHIBATA Hiroshi.
 
@@ -1184,7 +1184,7 @@ Deprecations:
 * Add deprecation warning for Gem::DependencyInstaller#gems_to_install.
   Pull request #1731 by Jon Moss.
 
-Compatibility changes:
+Breaking changes:
 
 * Use `-rrubygems` instead of `-rubygems.rb`. Because ubygems.rb is
   unavailable on Ruby 2.5. Pull request #2028 #2027 #2029

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.2.0.rc.1 (Jul 02, 2020)
 
-Highlights:
+Major enhancements:
 
   - Windows support. There's still gotchas and unimplemented features, but a Windows CI is now enforced.
   - Full multiplatform support. Bundler should now seamlessly handle multiplatform `Gemfile` or `gems.rb` files.
@@ -17,7 +17,7 @@ Features:
   - `bundle gem` now supports a `--ci` flag and a `gem.ci` configuration that adds CI config files for the main CI providers to the generated gem skeleton [#3667](https://github.com/rubygems/rubygems/pull/3667)
   - Allow setting a tag prefix to be used by release tasks [#3766](https://github.com/rubygems/rubygems/pull/3766)
 
-Improvements:
+Minor enhancements:
 
   - `bundle outdated` now prints output in columns for better readability [#4474](https://github.com/rubygems/bundler/pull/4474)
   - bundler's `release` rake task now prints a better message when not being logged in and trying to push a gem [#7513](https://github.com/rubygems/bundler/pull/7513)
@@ -35,7 +35,7 @@ Improvements:
   - Remove some requires that might workaround some autoloading issues on jruby [#3771](https://github.com/rubygems/rubygems/pull/3771)
   - Unswallow an error that should make some random crashes on jruby easier to troubleshoot [#3774](https://github.com/rubygems/rubygems/pull/3774)
 
-Bugfixes:
+Bug fixes:
 
   - Fix `bundle pristine` removing gems with local overrides. Be conservative by printing a warning and skipping the removal [#7423](https://github.com/rubygems/bundler/pull/7423)
   - Fix multiplaform resolution edge cases [#7522](https://github.com/rubygems/bundler/pull/7522) and [#7578](https://github.com/rubygems/bundler/pull/7578)
@@ -65,14 +65,14 @@ Bugfixes:
 
 ## 2.1.4 (January 5, 2020)
 
-Bugfixes:
+Bug fixes:
 
   - Fix `net-http-pipeline` no longer being allowed in Gemfiles if already installed in the system due to our vendored version of `net-http-persistent` optionally requiring it [#7529](https://github.com/bundler/bundler/pull/7529)
   - Fix inline gems no longer being requirable if no Gemfile is present in the directory hierarchy [#7537](https://github.com/bundler/bundler/pull/7537)
 
 ## 2.1.3 (January 2, 2020)
 
-Bugfixes:
+Bug fixes:
 
   - Fix `rake build` when path has spaces on it [#7514](https://github.com/bundler/bundler/pull/7514)
   - Fix `rake release` git push tasks when the running shell has `git` as an alias of another command (like `hub`) [#7510](https://github.com/bundler/bundler/pull/7510)
@@ -81,13 +81,13 @@ Bugfixes:
 
 ## 2.1.2 (December 20, 2019)
 
-Bugfixes:
+Bug fixes:
 
   - Restore an explicit `require "rubygems"` on top `rubygems_integration.rb` to avoid some missing constant errors under some convoluted setups [#7505](https://github.com/rubygems/bundler/pull/7505)
 
 ## 2.1.1 (December 17, 2019)
 
-Bugfixes:
+Bug fixes:
 
   - Fix some cases of shelling out to `rubygems` still being silent [#7493](https://github.com/rubygems/bundler/pull/7493)
   - Restore compatibility with `rubygems-bundler` so that binstubs work under `RVM` [#7498](https://github.com/rubygems/bundler/pull/7498)
@@ -104,14 +104,14 @@ Features:
 
     plus other PRs removing or lazily loading usages of these gems from other places to not interfere with user's choice, such as [#7471](https://github.com/rubygems/bundler/pull/7471) or [#7473](https://github.com/bundler/bundler/pull/7473)
 
-Bugfixes:
+Bug fixes:
 
   - Fix `bundle exec rake install` failing [#7474](https://github.com/rubygems/bundler/pull/7474)
   - Fix `bundle exec`'ing to rubygems being silent [#7442](https://github.com/rubygems/bundler/pull/7442)
   - Restore previous `BUNDLE_GEMFILE` in `bundler/inline` [#7418](https://github.com/rubygems/bundler/pull/7418)
   - Fix error when using `gem` DSL's `:glob` option for selecting gemspecs from a specific source [#7419](https://github.com/rubygems/bundler/pull/7419)
 
-Changes:
+Minor enhancements:
 
   - `bundle config` no longer warns when using "old interface" (might be deprecated again in the future) [#7475](https://github.com/rubygems/bundler/pull/7475)
   - `bundle update` no longer warns when used without arguments (might be deprecated again in the future) [#7475](https://github.com/rubygems/bundler/pull/7475)
@@ -124,7 +124,7 @@ Features:
   - Reconcile `bundle cache` vs `bundle package` everywhere. Now in docs, CLI help and everywhere else `bundle cache` is the preferred version and `bundle package` remains as an alias [#7389](https://github.com/rubygems/bundler/pull/7389)
   - Display some basic `bundler` documentation together with ruby's RDoc based documentation [#7394](https://github.com/rubygems/bundler/pull/7394)
 
-Bugfixes:
+Bug fixes:
 
   - Fix typos deprecation message and upgrading docs [#7374](https://github.com/rubygems/bundler/pull/7374)
   - Deprecation warnings about `taint` usage on ruby 2.7 [#7385](https://github.com/rubygems/bundler/pull/7385)
@@ -135,7 +135,7 @@ Bugfixes:
 
 ## 2.1.0.pre.2 (September 15, 2019)
 
-Bugfixes:
+Bug fixes:
 
   - Fix `bundle clean` trying to delete non-existent directory ([#7340](https://github.com/rubygems/bundler/pull/7340))
   - Fix warnings about keyword argument separation on ruby 2.7 ([#7337](https://github.com/rubygems/bundler/pull/7337))
@@ -188,7 +188,7 @@ Features:
   - Several improvements on new gem templates ([#6924](https://github.com/rubygems/bundler/pull/6924), [#6968](https://github.com/bundler/bundler/pull/6968), [#7209](https://github.com/bundler/bundler/pull/7209), [#7222](https://github.com/bundler/bundler/pull/7222), [#7238](https://github.com/bundler/bundler/pull/7238))
   - Add `--[no-]git` option to `bundle gem` to generate non source control gems. Useful for monorepos, for example ([#7263](https://github.com/rubygems/bundler/pull/7263))
 
-Bugfixes:
+Bug fixes:
 
   - Raise when the same gem is available in multiple sources, and show a suggestion to solve it ([#5985](https://github.com/rubygems/bundler/pull/5985))
   - Validate that bundler has permissions to write to the tmp directory, and raise with a meaningful error otherwise ([#5954](https://github.com/rubygems/bundler/pull/5954))
@@ -240,7 +240,7 @@ Documentation:
 
 ## 2.0.2 (2019-06-13)
 
-Changes:
+Minor enhancements:
 
   - Fixes for Bundler integration with ruby-src ([#6941](https://github.com/rubygems/bundler/pull/6941), [#6973](https://github.com/bundler/bundler/pull/6973), [#6977](https://github.com/bundler/bundler/pull/6977), [#6315](https://github.com/bundler/bundler/pull/6315), [#7061](https://github.com/bundler/bundler/pull/7061))
   - Use `__dir__` instead of `__FILE__` when generating a gem with `bundle gem` ([#6503](https://github.com/rubygems/bundler/pull/6503))
@@ -266,7 +266,7 @@ Documentation:
 
 ## 2.0.1 (2019-01-04)
 
-Changes:
+Bug fixes:
 
   - Relaxed RubyGems requirement to `>= 2.5.0` ([#6867](https://github.com/rubygems/bundler/pull/6867))
 
@@ -280,9 +280,12 @@ Breaking Changes:
 
   - Bundler 2 now requires RubyGems 3.0.0 at minimum
 
-Changes:
+Bug fixes:
 
   - Ruby 2.6 compatibility fixes (@segiddins)
+
+Minor enhancements:
+
   - Import changes from Bundler 1.17.3 release
 
   Note: To upgrade your Gemfile to Bundler 2 you will need to run `bundle update --bundler`
@@ -311,7 +314,7 @@ Breaking Changes:
 
 ## 1.17.3 (2018-12-27)
 
-Bugfixes:
+Bug fixes:
 
  - Fix a Bundler error when installing gems on old versions of RubyGems ([#6839](https://github.com/rubygems/bundler/issues/6839), @colby-swandale)
  - Fix a rare issue where Bundler was removing itself after a `bundle clean` ([#6829](https://github.com/rubygems/bundler/issues/6829), @colby-swandale)
@@ -376,12 +379,12 @@ Features:
 
 ## 1.16.6 (2018-10-05)
 
-Changes:
+Minor enhancements:
 
   - Add an error message when adding a gem with `bundle add` that's already in the bundle ([#6341](https://github.com/rubygems/bundler/issues/6341), @agrim123)
   - Add Homepage, Source Code and Changelog URI metadata fields to the `bundle gem` gemspec template (@walf443)
 
-Bugfixes:
+Bug fixes:
 
   - Fix issue where updating a gem resulted in the gem's version being downgraded when `BUNDLE_ONLY_UPDATE_TO_NEWER_VERSIONS` was set ([#6529](https://github.com/rubygems/bundler/issues/6529), @theflow)
   - Fix some rescue calls that don't specifiy error type (@utilum)
@@ -398,11 +401,11 @@ Documentation:
 
 ## 1.16.5 (2018-09-18)
 
-Changes:
+Minor enhancements:
 
   - Add support for TruffleRuby (@eregon)
 
-Bugfixes:
+Bug fixes:
 
   - Avoid printing git errors when checking the version on incorrectly packaged versions of Bundler ([#6453](https://github.com/rubygems/bundler/issues/6453), @greysteil)
   - Fix issue where Bundler does not check the given class when comparing equality in DepProxy (@ChrisBr)
@@ -414,13 +417,13 @@ Bugfixes:
 
 ## 1.16.4 (2018-08-17)
 
-Changes:
+Minor enhancements:
 
   - Welcome new members to the Bundler core team (@indirect)
   - Don't mutate original error trees when determining version_conflict_message (@greysteil)
   - Update vendored Molinillo to 0.6.6 (@segiddins)
 
-Bugfixes:
+Bug fixes:
 
   - Reword bundle update regression message to be more clear to the user when a gem's version is downgraded ([#6584](https://github.com/rubygems/bundler/issues/6584), @ralphbolo)
   - Respect --conservative flag when updating a dependency group ([#6560](https://github.com/rubygems/bundler/issues/6560), @greysteil)
@@ -439,7 +442,7 @@ Features:
 
   - Support URI::File of Ruby 2.6 (@hsbt)
 
-Bugfixes:
+Bug fixes:
 
   - Expand symlinks during setup to allow Bundler to load correctly when using symlinks in $GEM_HOME ([#6465](https://github.com/rubygems/bundler/issues/6465), @ojab, @indirect)
   - Dont let Bundler create temporary folders for gem installs which are owned by root ([#6258](https://github.com/rubygems/bundler/issues/6258), @colby-swandale)
@@ -456,7 +459,7 @@ Documentation:
 
 ## 1.16.2 (2018-04-20)
 
-Changes:
+Minor enhancements:
 
   - Include the gem's source in the gem install error message when available (@papanikge)
   - Remove unnecessary executable bit from gem template (@voxik)
@@ -465,7 +468,7 @@ Changes:
   - Use `Bundler.rubygems.inflate` instead of the Gem::Util method directly (@segiddins)
   - Remove unused instance variable (@segiddins)
 
-Bugfixes:
+Bug fixes:
 
   - Only trap INT signal and have Ruby's signal default handler be invoked (@shayonj)
   - Fix warning about the use of `__FILE__` in RubyGems integration testing (@MSP-Greg)
@@ -506,7 +509,7 @@ Documentation:
 
 ## 1.16.1 (2017-12-12)
 
-Bugfixes:
+Bug fixes:
 
   - avoid hanging on complex resolver errors ([#6114](https://github.com/rubygems/bundler/issues/6114), @halfbyte)
   - avoid an error when running `bundle update --group` ([#6156](https://github.com/rubygems/bundler/issues/6156), @mattbrictson)
@@ -519,7 +522,7 @@ Bugfixes:
 
 ## 1.16.0 (2017-10-31)
 
-Bugfixes:
+Bug fixes:
 
   - avoid new RubyGems warning about unsafe YAML loading (to keep output consistent) (@segiddins)
   - load digest subclasses in a thread-safe manner (@segiddins, @colby-swandale)
@@ -537,7 +540,7 @@ Features:
 
   - the output from `bundle env` includes more information, particularly both the compiled & loaded versions of OpenSSL (@indirect)
 
-Bugfixes:
+Bug fixes:
 
   - fix a bug where installing on FreeBSD would accidentally raise an error ([#6013](https://github.com/rubygems/bundler/issues/6013), @olleolleolle)
   - fix a regression in 1.16 where pre-release gems could accidentally be resolved even when the gemfile contained no pre-release requirements (@greysteil)
@@ -546,7 +549,7 @@ Bugfixes:
 
 ## 1.16.0.pre.2 (2017-09-06)
 
-Bugfixes:
+Bug fixes:
 
   - handle when a connection is missing a socket when warning about OpenSSL version (@greysteil)
   - the description for the `rake release` task now reflects `$RUBYGEMS_HOST` (@wadetandy)
@@ -573,7 +576,7 @@ Features:
   - allow adding credentials to a gem source during deployment when `allow_deployment_source_credential_changes` is set (@adrian-gomez)
   - making an outdated (and insecure) TLS connection to rubygems.org will print a warning (@segiddins)
 
-Bugfixes:
+Bug fixes:
 
   - allow configuring a mirror fallback timeout without a trailing slash ([#4830](https://github.com/rubygems/bundler/issues/4830), @segiddins)
   - fix handling of mirrors for file: urls that contain upper-case characters (@segiddins)
@@ -597,7 +600,7 @@ Bugfixes:
 
 ## 1.15.4 (2017-08-19)
 
-Bugfixes:
+Bug fixes:
 
   - handle file conflicts gracefully in `bundle gem` (@rafaelfranca, @segiddins)
   - bundler will fail gracefully when the bundle path contains the system path separator ([#5485](https://github.com/rubygems/bundler/issues/5485), ajwann)
@@ -606,7 +609,7 @@ Bugfixes:
 
 ## 1.15.3 (2017-07-21)
 
-Bugfixes:
+Bug fixes:
 
   - ensure that empty strings passed to `bundle config` are serialized & parsed properly ([#5881](https://github.com/rubygems/bundler/issues/5881), @segiddins)
   - avoid printing an outdated version warning when running a parseable command (@segiddins)
@@ -617,7 +620,7 @@ Features:
 
   - new gemfiles created by bundler will include an explicit `github` git source that uses `https` (@segiddins)
 
-Bugfixes:
+Bug fixes:
 
   - inline gemfiles work when `BUNDLE_BIN` is set ([#5847](https://github.com/rubygems/bundler/issues/5847), @segiddins)
   - avoid using the old dependency API when there are no changes to the compact index files ([#5373](https://github.com/rubygems/bundler/issues/5373), @greysteil)
@@ -631,7 +634,7 @@ Bugfixes:
 
 ## 1.15.1 (2017-06-02)
 
-Bugfixes:
+Bug fixes:
 
   - `bundle lock --update GEM` will fail gracefully when the gem is not in the lockfile ([#5693](https://github.com/rubygems/bundler/issues/5693), @segiddins)
   - `bundle init --gemspec` will fail gracefully when the gemspec is invalid (@colby-swandale)
@@ -644,14 +647,14 @@ Bugfixes:
 
 ## 1.15.0.pre.4 (2017-05-10)
 
-Bugfixes:
+Bug fixes:
 
   - avoid conflicts when `Gem.finish_resolve` is called after the bundle has been set up (@segiddins)
   - ensure that `Gem::Specification.find_by_name` always returns an object that can have `#to_spec` called on it ([#5592](https://github.com/rubygems/bundler/issues/5592), @jules2689)
 
 ## 1.15.0.pre.3 (2017-04-30)
 
-Bugfixes:
+Bug fixes:
 
   - avoid redundant blank lines in the readme generated by `bundle gem` (@koic)
   - ensure that `open-uri` is not loaded after `bundle exec` (@segiddins)
@@ -661,7 +664,7 @@ Bugfixes:
 
 ## 1.15.0.pre.2 (2017-04-23)
 
-Bugfixes:
+Bug fixes:
 
   - ensure pre-existing fit caches are updated from remote sources ([#5423](https://github.com/rubygems/bundler/issues/5423), @alextaylor000)
   - avoid duplicating specs in the lockfile after updating with the gem uninstalled ([#5599](https://github.com/rubygems/bundler/issues/5599), @segiddins)
@@ -694,7 +697,7 @@ Performance:
   - avoid diffing large arrays when no sources in the gemfile have changed (@segiddins)
   - avoid evaluating full gemspecs when running with RubyGems 2.5+ (@segiddins)
 
-Bugfixes:
+Bug fixes:
 
   - fix cases where `bundle update` would print a resolver conflict instead of updating the selected gems ([#5031](https://github.com/rubygems/bundler/issues/5031), [#5095](https://github.com/bundler/bundler/issues/5095), @segiddins)
   - print out a stack trace after an interrupt when running in debug mode (@segiddins)
@@ -713,7 +716,7 @@ Bugfixes:
 
 ## 1.14.6 (2017-03-03)
 
-Bugfixes:
+Bug fixes:
 
   - avoid undefined constant `Bundler::Plugin::API::Source` exception ([#5409](https://github.com/rubygems/bundler/issues/5409), @segiddins)
   - avoid incorrect warnings about needing to enable `specific_platform` (@segiddins)
@@ -723,7 +726,7 @@ Bugfixes:
 
 ## 1.14.5 (2017-02-22)
 
-Bugfixes:
+Bug fixes:
 
   - avoid loading all unused gemspecs during `bundle exec` on RubyGems 2.3+ (@segiddins)
   - improve resolver performance when dependencies have zero or one total possibilities ignoring requirements ([#5444](https://github.com/rubygems/bundler/issues/5444), [#5457](https://github.com/bundler/bundler/issues/5457), @segiddins)
@@ -738,7 +741,7 @@ Bugfixes:
 
 ## 1.14.4 (2017-02-12)
 
-Bugfixes:
+Bug fixes:
 
   - fail gracefully when attempting to overwrite an existing directory with `bundle gem` ([#5358](https://github.com/rubygems/bundler/issues/5358), @nodo)
   - fix a resolver bug that would cause bundler to report conflicts that it could resolve ([#5359](https://github.com/rubygems/bundler/issues/5359), [#5362](https://github.com/bundler/bundler/issues/5362), @segiddins)
@@ -751,27 +754,27 @@ Bugfixes:
 
 ## 1.14.3 (2017-01-24)
 
-Bugfixes:
+Bug fixes:
 
   - fix the resolver attempting to activate ruby-platform gems when the bundle is only for other platforms ([#5349](https://github.com/rubygems/bundler/issues/5349), [#5356](https://github.com/bundler/bundler/issues/5356), @segiddins)
   - avoid re-resolving a locked gemfile that uses `gemspec` and includes development dependencies ([#5349](https://github.com/rubygems/bundler/issues/5349), @segiddins)
 
 ## 1.14.2 (2017-01-22)
 
-Bugfixes:
+Bug fixes:
 
   - fix using `force_ruby_platform` on windows ([#5344](https://github.com/rubygems/bundler/issues/5344), @segiddins)
   - fix an incorrect version conflict error when using `gemspec` on multiple platforms ([#5340](https://github.com/rubygems/bundler/issues/5340), @segiddins)
 
 ## 1.14.1 (2017-01-21)
 
-Bugfixes:
+Bug fixes:
 
   - work around a ruby 2.2.2 bug that caused a stack consistency error during installation ([#5342](https://github.com/rubygems/bundler/issues/5342), @segiddins)
 
 ## 1.14.0 (2017-01-20)
 
-Bugfixes:
+Bug fixes:
 
   - ensure `Settings::Mirror` is autoloaded under the `Settings` namespace
     ([#5238](https://github.com/rubygems/bundler/issues/5238), @segiddins)
@@ -779,7 +782,7 @@ Bugfixes:
 
 ## 1.14.0.pre.2 (2017-01-11)
 
-Bugfixes:
+Bug fixes:
 
   - allow not selecting a gem when running `bundle open` ([#5301](https://github.com/rubygems/bundler/issues/5301), @segiddins)
   - support installing gems from git branches that contain shell metacharacters ([#5295](https://github.com/rubygems/bundler/issues/5295), @segiddins)
@@ -813,7 +816,7 @@ Performance:
   - improve `require "bundler"` performance by ~5x (@segiddins)
   - allow install gems in parallel when running on rubygems 2+
 
-Bugfixes:
+Bug fixes:
 
   - config files with CRLF line endings can be read ([#4435](https://github.com/rubygems/bundler/issues/4435), @segiddins)
   - `bundle lock` activates gems for the current platform even if they were activated under a different platform for a separate dependency ([#4896](https://github.com/rubygems/bundler/issues/4896), @segiddins)
@@ -851,19 +854,19 @@ Features:
 
 ## 1.13.6 (2016-10-22)
 
-Bugfixes:
+Bug fixes:
 
   - make the `gem` method public again, fixing a regression in 1.13.4 ([#5102](https://github.com/rubygems/bundler/issues/5102), @segiddins)
 
 ## 1.13.5 (2016-10-15)
 
-Bugfixes:
+Bug fixes:
 
   - Ensure a locked pre-release spec can always be re-resolved ([#5089](https://github.com/rubygems/bundler/issues/5089), @segiddins)
 
 ## 1.13.4 (2016-10-11)
 
-Bugfixes:
+Bug fixes:
 
  - stop printing warning when compact index versions file is rewritten ([#5064](https://github.com/rubygems/bundler/issues/5064), @indirect)
  - fix `parent directory is world writable but not sticky` error on install ([#5043](https://github.com/rubygems/bundler/issues/5043), @indirect)
@@ -872,13 +875,13 @@ Bugfixes:
 
 ## 1.13.3 (2016-10-10)
 
-Bugfixes:
+Bug fixes:
 
   - add support for weak etags to the new index (@segiddins)
 
 ## 1.13.2 (2016-09-30)
 
-Bugfixes:
+Bug fixes:
 
   - allow `Settings` to be initialized without a root directory (@m1k3)
   - allow specifying ruby engines in the gemfile as a symbol ([#4919](https://github.com/rubygems/bundler/issues/4919), @JuanitoFatas)
@@ -894,7 +897,7 @@ Performance:
 
 ## 1.13.1 (2016-09-13)
 
-Bugfixes:
+Bug fixes:
 
   - ensure that `Gem::Source` is available, fixing several exceptions ([#4944](https://github.com/rubygems/bundler/issues/4944), @dekellum)
   - ensure that dependency resolution works when multiple gems have the same dependency ([#4961](https://github.com/rubygems/bundler/issues/4961), @segiddins)
@@ -918,7 +921,7 @@ Features:
   - add `only_update_to_newer_versions` setting to prevent downgrades during `update` (@segiddins)
   - expanded experimental plugin support to include hooks and sources (@asutoshpalai)
 
-Bugfixes:
+Bug fixes:
 
   - retry gem downloads ([#4846](https://github.com/rubygems/bundler/issues/4846), @jkeiser)
   - improve the CompactIndex to handle capitalized legacy gems ([#4867](https://github.com/rubygems/bundler/issues/4867), @segiddins)
@@ -942,7 +945,7 @@ Features:
   - when `bundle config major_deprecations` or `BUNDLE_MAJOR_DEPRECATIONS` is set, deprecation warnings for bundler 2 will be printed (@segiddins)
   - when running with `--verbose`, bundler will print the reason it is re-resolving a gemfile (@segiddins)
 
-Bugfixes:
+Bug fixes:
 
   - fix support for running RubyGems 1.x on Ruby 2.3 ([#4698](https://github.com/rubygems/bundler/issues/4698), @segiddins)
   - fix bundle exec'ing to a ruby file when gems are installed into a path ([#4592](https://github.com/rubygems/bundler/issues/4592), @chrismo)
@@ -979,7 +982,7 @@ Features:
   - add `--add-platform` option to `bundle lock` (@segiddins)
   - fail gracefully when a resolved spec's `required_ruby_version` or `required_rubygems_version` is incompatible (@segiddins)
 
-Bugfixes:
+Bug fixes:
 
   - implicitly unlock the resolved ruby version when the declared requirements in the gemfile are incompatible with the locked version ([#4595](https://github.com/rubygems/bundler/issues/4595), [#4627](https://github.com/bundler/bundler/issues/4627), @segiddins)
   - add support for quoted paths in `$PATH` ([#4323](https://github.com/rubygems/bundler/issues/4323), @segiddins)
@@ -996,19 +999,19 @@ Bugfixes:
 
 ## 1.12.6 (2016-10-10)
 
-Bugfixes:
+Bug fixes:
   - add support for weak etags to the new index (@segiddins)
 
 ## 1.12.5 (2016-05-25)
 
-Bugfixes:
+Bug fixes:
   - only take over `--help` on `bundle exec` when the first two arguments are `exec` and `--help` ([#4596](https://github.com/rubygems/bundler/issues/4596), @segiddins)
   - don't require `require: true` dependencies that are excluded via `env` or `install_if` (@BrianHawley)
   - reduce the number of threads used simultaneously by bundler ([#4367](https://github.com/rubygems/bundler/issues/4367), @will-in-wi)
 
 ## 1.12.4 (2016-05-16)
 
-Bugfixes:
+Bug fixes:
   - ensure concurrent use of the new index can't corrupt the cache ([#4519](https://github.com/rubygems/bundler/issues/4519), @domcleal)
   - allow missing rubygems credentials when pushing a gem with a custom host ([#4437](https://github.com/rubygems/bundler/issues/4437), @Cohen-Carlisle)
   - fix installing built-in specs with `--standalone` ([#4557](https://github.com/rubygems/bundler/issues/4557), @segiddins)
@@ -1016,19 +1019,19 @@ Bugfixes:
 
 ## 1.12.3 (2016-05-06)
 
-Bugfixes:
+Bug fixes:
   - fix uncoditionally writing `.bundle/config` when running `bundle install` (@segiddins)
   - fall back to the dependency API and the full index when the home directory is not writable (@segiddins)
 
 ## 1.12.2 (2016-05-04)
 
-Bugfixes:
+Bug fixes:
   - fix modifying a frozen string when the resolver conflicts on dependencies with requirements ([#4520](https://github.com/rubygems/bundler/issues/4520), @grzuy)
   - fix `bundle exec foo --help` not showing the invoked command's help ([#4480](https://github.com/rubygems/bundler/issues/4480), @b-ggs)
 
 ## 1.12.1 (2016-04-30)
 
-Bugfixes:
+Bug fixes:
   - automatically fallback when the new index has a checksum mismatch instead of erroring (@segiddins)
   - fix computation of new index file local checksums on Windows ([#4472](https://github.com/rubygems/bundler/issues/4472), @mwrock)
   - properly handle certain resolver backtracking cases without erroring (@segiddins, [#4484](https://github.com/rubygems/bundler/issues/4484))
@@ -1040,13 +1043,13 @@ Bugfixes:
 
 ## 1.12.0.rc.4 (2016-04-21)
 
-Bugfixes:
+Bug fixes:
 
   - don't fail when `bundle outdated` is run with flags and the lockfile contains non-semver versions ([#4438](https://github.com/rubygems/bundler/issues/4438), @RochesterinNYC)
 
 ## 1.12.0.rc.3 (2016-04-19)
 
-Bugfixes:
+Bug fixes:
 
   - don't allow new attributes to dirty a lockfile when running `bundle exec`, `-rbundler/setup`, or `bundle check` (@segiddins)
 
@@ -1056,7 +1059,7 @@ Features:
 
   - `bundle outdated` handles all combinations of `--major`, `--minor`, and `--patch` ([#4396](https://github.com/rubygems/bundler/issues/4396), @RochesterinNYC)
 
-Bugfixes:
+Bug fixes:
 
   - prevent endless recursive copy for `bundle package --all` ([#4392](https://github.com/rubygems/bundler/issues/4392), @RochesterinNYC)
   - allow executables that are `load`ed to exit non-0 via an `at_exit` hook when invoked by `bundle exec` (@segiddins)
@@ -1068,7 +1071,7 @@ Performance:
 
   - Download gem metadata from globally distributed CDN endpoints ([#4358](https://github.com/rubygems/bundler/issues/4358), @segiddins)
 
-Bugfixes:
+Bug fixes:
 
   - handle Ruby pre-releases built from source ([#4324](https://github.com/rubygems/bundler/issues/4324), @RochesterinNYC)
   - support binstubs from RubyGems 2.6 ([#4341](https://github.com/rubygems/bundler/issues/4341), @segiddins)
@@ -1086,7 +1089,7 @@ Features:
   - add `Bundler.clean_env` and `Bundler.original_env` ([#4232](https://github.com/rubygems/bundler/issues/4232), @njam)
   - add `--frozen` support to `bundle package` ([#3356](https://github.com/rubygems/bundler/issues/3356), @RochesterinNYC)
 
-Bugfixes:
+Bug fixes:
 
   - place bundler loaded gems after `-I` and `RUBYLIB` (@Elffers)
   - give a better error message when filesystem access raises an `EPROTO` error ([#3581](https://github.com/rubygems/bundler/issues/3581), [#3932](https://github.com/bundler/bundler/issues/3932), [#4163](https://github.com/bundler/bundler/issues/4163), @RochesterinNYC)
@@ -1120,7 +1123,7 @@ Features:
   - add support for ruby 2.4 ([#4266](https://github.com/rubygems/bundler/issues/4266), @segiddins)
   - add `bundle outdated --parseable` for machine-readable output (@RochesterinNYC)
 
-Bugfixes:
+Bug fixes:
 
   - fix `bundle package --all` recursing endlessly ([#4158](https://github.com/rubygems/bundler/issues/4158), @RochesterinNYC)
   - fail fast on more errors when fetching remote resources ([#4154](https://github.com/rubygems/bundler/issues/4154), @RochesterinNYC)
@@ -1145,13 +1148,13 @@ Bugfixes:
 
 ## 1.11.2 (2015-12-15)
 
-Bugfixes:
+Bug fixes:
 
   - _really_ stop calling `required_ruby_version` on nil @specifications ([#4147](https://github.com/rubygems/bundler/issues/4147), @indirect)
 
 ## 1.11.1 (2015-12-15)
 
-Bugfixes:
+Bug fixes:
 
   - lazy-load Psych, again ([#4149](https://github.com/rubygems/bundler/issues/4149), @indirect)
   - allow gemspec gems on other platforms ([#4150](https://github.com/rubygems/bundler/issues/4150), @indirect)
@@ -1164,7 +1167,7 @@ Bugfixes:
 
 ## 1.11.0.pre.2 (2015-12-06)
 
-Bugfixes:
+Bug fixes:
 
   - fail gracefully when trying to execute a non-executable file ([#4081](https://github.com/rubygems/bundler/issues/4081), @fotanus)
   - fix a crash when pushing a gem via `rake release` (@segiddins)
@@ -1195,7 +1198,7 @@ Features:
   - add `pkg` to rake's clobber list ([#3676](https://github.com/rubygems/bundler/issues/3676), @jasonkarns)
   - retry fetching specs when fetching version metadata fails (@jingweno)
 
-Bugfixes:
+Bug fixes:
 
   - avoid showing bundler version warning messages twice (@fotanus)
   - fix running `bundle check` with `--path` when the gems are only installed globally (@akihiro17)
@@ -1234,11 +1237,11 @@ Performance:
 
 ## 1.10.6 (2015-07-22)
 
-Workarounds:
+Bug fixes:
 
   - only warn on invalid gemspecs (@indirect)
 
-Bugfixes:
+Bug fixes:
 
   - fix installing dependencies in the correct order ([#3799](https://github.com/rubygems/bundler/issues/3799), @pducks32)
   - fix sorting of mixed DependencyLists ([#3762](https://github.com/rubygems/bundler/issues/3762), @tony-spataro-rs)
@@ -1246,11 +1249,11 @@ Bugfixes:
 
 ## 1.10.5 (2015-06-24)
 
-Workarounds:
+Bug fixes:
 
   - don't add or update BUNDLED WITH during `install` with no changes (@segiddins)
 
-Bugfixes:
+Bug fixes:
 
   - fix sorting of mixed DependencyLists with RubyGems >= 2.23 ([#3762](https://github.com/rubygems/bundler/issues/3762), @tony-spataro-rs)
   - speed up resolver for path and git gems (@segiddins)
@@ -1258,18 +1261,15 @@ Bugfixes:
 
 ## 1.10.4 (2015-06-16)
 
-Workarounds:
+Bug fixes:
 
   - don't add BUNDLED WITH to the lock when Spring runs `check` over and over (@indirect)
-
-Bugfixes:
-
   - display "with native extensions" log output correctly (@ivantsepp)
   - alias `i` to `install`, `c` to `check`, and `e` to `exec` (@indirect)
 
 ## 1.10.3 (2015-06-03)
 
-Bugfixes:
+Bug fixes:
 
   - allow missing gemspec files when validating path and git gems ([#3686](https://github.com/rubygems/bundler/issues/3686), [#3698](https://github.com/bundler/bundler/issues/3698), @segiddins)
   - fix regression in `rake install` ([#3701](https://github.com/rubygems/bundler/issues/3701), [#3705](https://github.com/bundler/bundler/issues/3705), @segiddins)
@@ -1278,13 +1278,13 @@ Bugfixes:
 
 ## 1.10.2 (2015-05-29)
 
-Bugfixes:
+Bug fixes:
 
   - fix regression in `bundle update GEM` performance introduced in 1.10.0 ([#3687](https://github.com/rubygems/bundler/issues/3687), @segiddins)
 
 ## 1.10.1 (2015-05-28)
 
-Bugfixes:
+Bug fixes:
 
   - silence ruby warning when running CLI commands (@segiddins)
   - validate gemspecs in non-packaging mode ([#3681](https://github.com/rubygems/bundler/issues/3681), @segiddins)
@@ -1301,7 +1301,7 @@ Features:
   - dramatically speed up resolving some slow Gemfiles ([#3635](https://github.com/rubygems/bundler/issues/3635), @segiddins)
   - track CI platforms running Bundler ([#3646](https://github.com/rubygems/bundler/issues/3646), @fotanus)
 
-Bugfixes:
+Bug fixes:
 
   - allow `viz` to work with prereleases ([#3621](https://github.com/rubygems/bundler/issues/3621), [#3217](https://github.com/bundler/bundler/issues/3217), @aprescott)
   - validate gemspecs used in path and git gems ([#3639](https://github.com/rubygems/bundler/issues/3639), @segiddins, @indirect)
@@ -1310,13 +1310,13 @@ Bugfixes:
 
 ## 1.10.0.pre.2 (2015-05-07)
 
-Bugfixes:
+Bug fixes:
 
   - make BUNDLED WITH backwards compatible ([#3623](https://github.com/rubygems/bundler/issues/3623), @segiddins)
 
 ## 1.10.0.pre.1 (2015-05-05)
 
-Bugfixes:
+Bug fixes:
 
   - always clean up tmp dirs ([#3277](https://github.com/rubygems/bundler/issues/3277), @hone, @indirect, @segiddins)
 
@@ -1337,7 +1337,7 @@ Features:
   - make timeouts and retries configurable via `config` ([#3601](https://github.com/rubygems/bundler/issues/3601), @pducks32)
   - add `install_if` Gemfile method for conditional installs ([#3611](https://github.com/rubygems/bundler/issues/3611), @segiddins)
 
-Bugfixes:
+Bug fixes:
 
   - standalone mode now uses builtin gems correctly ([#3610](https://github.com/rubygems/bundler/issues/3610), @segiddins)
   - fix `rake spec:deps` on MinGW Ruby 2.0+ ([#3487](https://github.com/rubygems/bundler/issues/3487), @marutosi)
@@ -1359,25 +1359,25 @@ Features:
 
 ## 1.9.9 (2015-05-16)
 
-Bugfixes:
+Bug fixes:
 
   - read mirror and credential settings from older versions ([#3557](https://github.com/rubygems/bundler/issues/3557), @Strech)
 
 ## 1.9.8 (2015-05-12)
 
-Bugfixes:
+Bug fixes:
 
   - fix regression in sudo mode introduced by 1.9.7 ([#3642](https://github.com/rubygems/bundler/issues/3642), @segiddins)
 
 ## 1.9.7 (2015-05-11)
 
-Bugfixes:
+Bug fixes:
 
   - always clean up tmp dirs ([#3277](https://github.com/rubygems/bundler/issues/3277), @hone, @indirect, @segiddins)
 
 ## 1.9.6 (2015-05-02)
 
-Bugfixes:
+Bug fixes:
 
   - use RubyGems spec stubs if available (@segiddins)
   - allow creating gems with names containing two dashes ([#3483](https://github.com/rubygems/bundler/issues/3483), @janlelis)
@@ -1385,20 +1385,20 @@ Bugfixes:
 
 ## 1.9.5 (2015-04-29)
 
-Bugfixes:
+Bug fixes:
 
   - respect Gemfile sources when installing a gem present in two sources ([#3585](https://github.com/rubygems/bundler/issues/3585), @tmoore)
 
 ## 1.9.4 (2015-04-13)
 
-Bugfixes:
+Bug fixes:
 
   - fix regression in installing x86 and universal gems ([#3565](https://github.com/rubygems/bundler/issues/3565), @jdmundrawala)
   - improve error when gems are missing ([#3564](https://github.com/rubygems/bundler/issues/3564), @sealocal)
 
 ## 1.9.3 (2015-04-12)
 
-Bugfixes:
+Bug fixes:
 
   - handle removal of `specs` from rubygems/rubygems@620910 ([#3558](https://github.com/rubygems/bundler/issues/3558), @indirect)
   - install 'universal' gems on Windows ([#3066](https://github.com/rubygems/bundler/issues/3066), @jdmundrawala)
@@ -1407,7 +1407,7 @@ Bugfixes:
 
 ## 1.9.2 (2015-03-30)
 
-Bugfixes:
+Bug fixes:
 
   - ensure gem executables are executable ([#3517](https://github.com/rubygems/bundler/issues/3517), [#3511](https://github.com/bundler/bundler/issues/3511), @indirect)
   - fix warnings in Molinillo ([#3516](https://github.com/rubygems/bundler/issues/3516), @segiddins)
@@ -1417,7 +1417,7 @@ Bugfixes:
 
 ## 1.9.1 (2015-03-21)
 
-Bugfixes:
+Bug fixes:
 
   - avoid exception in 'bundler/gem_tasks' ([#3492](https://github.com/rubygems/bundler/issues/3492), @segiddins)
 
@@ -1425,7 +1425,7 @@ Bugfixes:
 
 ## 1.9.0.rc (2015-03-13)
 
-Bugfixes:
+Bug fixes:
 
   - make Bundler.which stop finding directories (@nohoho)
   - handle Bundler prereleases correctly ([#3470](https://github.com/rubygems/bundler/issues/3470), @segiddins)
@@ -1433,7 +1433,7 @@ Bugfixes:
 
 ## 1.9.0.pre.1 (2015-03-11)
 
-Bugfixes:
+Bug fixes:
 
   - make `gem` command work again (@arthurnn)
 
@@ -1444,66 +1444,66 @@ Features:
   - prefer gemspecs closest to the directory root ([#3428](https://github.com/rubygems/bundler/issues/3428), @segiddins)
   - debug log for API request limits ([#3452](https://github.com/rubygems/bundler/issues/3452), @neerfri)
 
-"Features":
+Minor enhancements:
 
   - Molinillo resolver, shared with CocoaPods (@segiddins)
   - updated Thor to v0.19.1 (@segiddins)
 
 ## 1.8.9 (2015-05-02)
 
-Bugfixes:
+Bug fixes:
 
   - Use RubyGems spec stubs if available (@segiddins)
 
 ## 1.8.8 (2015-04-29)
 
-Bugfixes:
+Bug fixes:
 
   - Respect Gemfile sources when installing a gem present in two sources ([#3585](https://github.com/rubygems/bundler/issues/3585), @tmoore)
 
 ## 1.8.7 (2015-04-07)
 
-Bugfixes:
+Bug fixes:
 
   - stop suppressing errors inside gems that get required ([#3549](https://github.com/rubygems/bundler/issues/3549), @indirect)
 
 ## 1.8.6 (2015-03-30)
 
-Bugfixes:
+Bug fixes:
 
   - keep gems locked when updating another gem from the same source ([#3250](https://github.com/rubygems/bundler/issues/3250), @indirect)
   - resolve race that could build gems without saved arguments ([#3404](https://github.com/rubygems/bundler/issues/3404), @indirect)
 
 ## 1.8.5 (2015-03-11)
 
-Bugfixes:
+Bug fixes:
 
   - remove MIT license from gemspec when removing license file (@indirect)
   - respect 'no' immediately as well as saving it in `gem` config (@kirs)
 
 ## 1.8.4 (2015-03-05)
 
-Bugfixes:
+Bug fixes:
 
   - document --all-platforms option ([#3449](https://github.com/rubygems/bundler/issues/3449), @moeffju)
   - find gems from all sources on exec after install ([#3450](https://github.com/rubygems/bundler/issues/3450), @TimMoore)
 
 ## 1.8.3 (2015-02-24)
 
-Bugfixes:
+Bug fixes:
 
   - handle boolean values for gem settings (@EduardoBautista)
   - stop always looking for updated `path` gems ([#3414](https://github.com/rubygems/bundler/issues/3414), [#3417](https://github.com/bundler/bundler/issues/3417), [#3429](https://github.com/bundler/bundler/issues/3429), @TimMoore)
 
 ## 1.8.2 (2015-02-14)
 
-Bugfixes:
+Bug fixes:
 
   - allow config settings for gems with 'http' in the name again ([#3398](https://github.com/rubygems/bundler/issues/3398), @TimMoore)
 
 ## 1.8.1 (2015-02-13)
 
-Bugfixes:
+Bug fixes:
 
   - synchronize building git gem native extensions ([#3385](https://github.com/rubygems/bundler/issues/3385), @antifuchs & @indirect)
   - set gemspec bindir correctly ([#3392](https://github.com/rubygems/bundler/issues/3392), @TimMoore)
@@ -1514,12 +1514,9 @@ Bugfixes:
 
 ## 1.8.0 (2015-02-10)
 
-Bugfixes:
+Bug fixes:
 
   - gemfile `github` blocks now work ([#3379](https://github.com/rubygems/bundler/issues/3379), @indirect)
-
-Bugfixes from v1.7.13:
-
   - look up installed gems in remote sources ([#3300](https://github.com/rubygems/bundler/issues/3300), [#3368](https://github.com/bundler/bundler/issues/3368), [#3377](https://github.com/bundler/bundler/issues/3377), [#3380](https://github.com/bundler/bundler/issues/3380), [#3381](https://github.com/bundler/bundler/issues/3381), @indirect)
   - look up gems across all sources to satisfy dependencies ([#3365](https://github.com/rubygems/bundler/issues/3365), @keiths-osc)
   - request dependencies for no more than 100 gems at a time ([#3367](https://github.com/rubygems/bundler/issues/3367), @segiddins)
@@ -1530,11 +1527,11 @@ Features:
 
   - add `config disable_multisource` option to ensure sources can't compete (@indirect)
 
-Bugfixes:
+Bug fixes:
 
   - don't add extra quotes around long, quoted config values (@aroben, [#3338](https://github.com/rubygems/bundler/issues/3338))
 
-Security:
+Security fixes:
 
   - warn when more than one top-level source is present (@indirect)
 
@@ -1562,7 +1559,7 @@ Features:
   - add `config gemfile /path` for other Gemfile locations (@dholdren)
   - add `github` method alonside the `git` method (@BenMorganIO)
 
-Bugfixes:
+Bug fixes:
 
   - reduce memory usage with threaded parallel workers (@Who828)
   - support read-only git gems (@pmahoney)
@@ -1575,20 +1572,20 @@ Documentation:
 
 ## 1.7.15 (2015-04-29)
 
-Bugfixes:
+Bug fixes:
 
   - Respect Gemfile sources when installing a gem present in two sources ([#3585](https://github.com/rubygems/bundler/issues/3585), @tmoore)
 
 ## 1.7.14 (2015-03-30)
 
-Bugfixes:
+Bug fixes:
 
   - Keep gems locked when updating another gem from the same source ([#3250](https://github.com/rubygems/bundler/issues/3250), @indirect)
   - Don't add extra quotes around long, quoted config values (@aroben, [#3338](https://github.com/rubygems/bundler/issues/3338))
 
 ## 1.7.13 (2015-02-07)
 
-Bugfixes:
+Bug fixes:
 
   - Look up installed gems in remote sources ([#3300](https://github.com/rubygems/bundler/issues/3300), [#3368](https://github.com/bundler/bundler/issues/3368), [#3377](https://github.com/bundler/bundler/issues/3377), [#3380](https://github.com/bundler/bundler/issues/3380), [#3381](https://github.com/bundler/bundler/issues/3381), @indirect)
   - Look up gems across all sources to satisfy dependencies ([#3365](https://github.com/rubygems/bundler/issues/3365), @keiths-osc)
@@ -1596,29 +1593,29 @@ Bugfixes:
 
 ## 1.7.12 (2015-01-08)
 
-Bugfixes:
+Bug fixes:
 
   - Always send credentials for sources, fixing private Gemfury gems ([#3342](https://github.com/rubygems/bundler/issues/3342), @TimMoore)
 
 ## 1.7.11 (2015-01-04)
 
-Bugfixes:
+Bug fixes:
 
   - Recognize `:mri_22` and `:mingw_22`, rather than just `:ruby_22` ([#3328](https://github.com/rubygems/bundler/issues/3328), @myabc)
 
 ## 1.7.10 (2014-12-29)
 
-Bugfixes:
+Bug fixes:
 
   - Fix source blocks sometimes causing deployment mode to fail wrongly ([#3298](https://github.com/rubygems/bundler/issues/3298), @TimMoore)
 
-Features(?):
+Features:
 
   - Support `platform :mri_22` and related version bits ([#3309](https://github.com/rubygems/bundler/issues/3309), @thomasfedb)
 
 ## 1.7.9 (2014-12-09)
 
-Bugfixes:
+Bug fixes:
 
   - Fix an issue where bundler sometime spams one gem in Gemfile.lock ([#3216](https://github.com/rubygems/bundler/issues/3216), @Who828)
   - Ensure bundle update installs the newer version of the gem ([#3089](https://github.com/rubygems/bundler/issues/3089), @Who828)
@@ -1626,13 +1623,13 @@ Bugfixes:
 
 ## 1.7.8 (2014-12-06)
 
-Bugfixes:
+Bug fixes:
 
   - Hide credentials while warning about gems with ambiguous sources ([#3256](https://github.com/rubygems/bundler/issues/3256), @TimMoore)
 
 ## 1.7.7 (2014-11-19)
 
-Bugfixes:
+Bug fixes:
 
   - Ensure server credentials stored in config or ENV will be used ([#3180](https://github.com/rubygems/bundler/issues/3180), @arronmabrey)
   - Fix race condition causing errors while installing git-based gems ([#3174](https://github.com/rubygems/bundler/issues/3174), @Who828)
@@ -1640,20 +1637,20 @@ Bugfixes:
 
 ## 1.7.6 (2014-11-11)
 
-Bugfixes:
+Bug fixes:
 
   - CA certificates that work with all OpenSSLs (@luislavena, @indirect)
 
 ## 1.7.5 (2014-11-10)
 
-Bugfixes:
+Bug fixes:
 
   - Fix --deployment with source blocks and non-alphabetical gems ([#3224](https://github.com/rubygems/bundler/issues/3224), @TimMoore)
   - Vendor CA chain to validate new rubygems.org HTTPS certificate (@indirect)
 
 ## 1.7.4 (2014-10-19)
 
-Bugfixes:
+Bug fixes:
 
   - Allow --deployment after `pack` while using source blocks ([#3167](https://github.com/rubygems/bundler/issues/3167), @TimMoore)
   - Use dependency API even when HTTP credentials are in ENV ([#3191](https://github.com/rubygems/bundler/issues/3191), @fvaleur)
@@ -1662,20 +1659,20 @@ Bugfixes:
 
 ## 1.7.3 (2014-09-14)
 
-Bugfixes:
+Bug fixes:
 
   - `extconf.rb` is now generated with the right path for `create_makefile` (@andremedeiros)
   - Fix various Ruby warnings (@piotrsanarki, @indirect)
 
 ## 1.7.2 (2014-08-23)
 
-Bugfixes:
+Bug fixes:
 
   - Revert gem source sorting in lock files (@indirect)
 
 ## 1.7.1 (2014-08-20)
 
-Bugfixes:
+Bug fixes:
 
   - Install gems from one source needed by gems in another source (@indirect)
   - Install the same gem versions even after some are installed (@TimMoore)
@@ -1683,7 +1680,7 @@ Bugfixes:
 
 ## 1.7.0 (2014-08-13)
 
-Security:
+Security fixes:
 
   - Fix for CVE-2013-0334, installing gems from an unexpected source (@TimMoore)
 
@@ -1692,7 +1689,7 @@ Features:
   - Gemfile `source` calls now take a block containing gems from that source (@TimMoore)
   - Added the `:source` option to `gem` to specify a source (@TimMoore)
 
-Bugfixes:
+Bug fixes:
 
   - Warn on ambiguous gems available from more than one source (@TimMoore)
 
@@ -1708,19 +1705,19 @@ Documentation:
 
 ## 1.6.6 (2014-08-23)
 
-Bugfixes:
+Bug fixes:
 
   - restore Gemfile credentials to Gemfile.lock (@indirect)
 
 ## 1.6.5 (2014-07-23)
 
-Bugfixes:
+Bug fixes:
 
   - require openssl explicitly to fix rare HTTPS request failures (@indirect, [#3107](https://github.com/rubygems/bundler/issues/3107))
 
 ## 1.6.4 (2014-07-17)
 
-Bugfixes:
+Bug fixes:
 
   - fix undefined constant error when can't find gem during binstubs ([#3095](https://github.com/rubygems/bundler/issues/3095), @jetaggart)
   - work when installed git gems are not writable ([#3092](https://github.com/rubygems/bundler/issues/3092), @pmahoney)
@@ -1732,7 +1729,7 @@ Bugfixes:
 
 ## 1.6.3 (2014-06-16)
 
-Bugfixes:
+Bug fixes:
 
   - fix regression when resolving many conflicts ([#2994](https://github.com/rubygems/bundler/issues/2994), @Who828)
   - use local gemspec for builtin gems during install --local ([#3041](https://github.com/rubygems/bundler/issues/3041), @Who828)
@@ -1741,7 +1738,7 @@ Bugfixes:
 
 ## 1.6.2 (2014-04-13)
 
-Bugfixes:
+Bug fixes:
 
   - fix an exception when using builtin gems ([#2915](https://github.com/rubygems/bundler/issues/2915), [#2963](https://github.com/bundler/bundler/issues/2963), @gnufied)
   - cache gems that are built in to the running ruby ([#2975](https://github.com/rubygems/bundler/issues/2975), @indirect)
@@ -1755,7 +1752,7 @@ Features:
 
 ## 1.6.1 (2014-04-02)
 
-Bugfixes:
+Bug fixes:
 
   - update C extensions when git gem versions change ([#2948](https://github.com/rubygems/bundler/issues/2948), @dylanahsmith)
 
@@ -1765,7 +1762,7 @@ Features:
 
 ## 1.6.0 (2014-03-28)
 
-Bugfixes:
+Bug fixes:
 
   - many Gemfiles that caused incorrect errors now resolve correctly (@Who828)
   - redirects across hosts now work on rubies without OpenSSL ([#2686](https://github.com/rubygems/bundler/issues/2686), @grddev)
@@ -1801,14 +1798,14 @@ Documentation:
 
 ## 1.5.3 (2014-02-06)
 
-Bugfixes:
+Bug fixes:
 
   - find "missing" gems that are actually present ([#2780](https://github.com/rubygems/bundler/issues/2780), [#2818](https://github.com/bundler/bundler/issues/2818), [#2854](https://github.com/bundler/bundler/issues/2854))
   - use n-1 cores when given n jobs for parallel install (@jdickey)
 
 ## 1.5.2 (2014-01-10)
 
-Bugfixes:
+Bug fixes:
 
   - fix integration with Rubygems 1.8.0-1.8.19
   - handle ENETDOWN exception during network requests
@@ -1819,7 +1816,7 @@ Bugfixes:
 
 ## 1.5.1 (2013-12-28)
 
-Bugfixes:
+Bug fixes:
 
   - correctly find gems installed with Ruby by default
 
@@ -1829,7 +1826,7 @@ Features:
 
   - install missing gems if their specs are present (@hone)
 
-Bugfixes:
+Bug fixes:
 
   - use print for "Installing…" so messages are thread-safe (@TimMoore)
 
@@ -1840,7 +1837,7 @@ Features:
   - Support threaded installation on Rubygems 2.0.7+
   - Debug installation logs in .bundle/install.log
 
-Bugfixes:
+Bug fixes:
 
   - Try to catch gem installation race conditions
 
@@ -1855,7 +1852,7 @@ Features:
   - don't redownload installed specs for `bundle install` ([#2680](https://github.com/rubygems/bundler/issues/2680), @cainlevy)
   - override gem sources with mirrors ([#2650](https://github.com/rubygems/bundler/issues/2650), @danielsdeleo, @mkristian)
 
-Bugfixes:
+Bug fixes:
 
   - fix sharing same SSL socket when forking workers for parallel install ([#2632](https://github.com/rubygems/bundler/issues/2632))
   - fix msg typo in GitNotAllowedError ([#2654](https://github.com/rubygems/bundler/issues/2654), @joyicecloud)
@@ -1882,7 +1879,7 @@ Features:
   - add `--retry` to retry failed network and git commands (@schneems)
   - include command and versions in User-Agent (@indirect, @joyicecloud)
 
-Bugfixes:
+Bug fixes:
 
   - allow passwordless Basic Auth ([#2606](https://github.com/rubygems/bundler/issues/2606), @rykov)
   - don't suggest `gem install foo` when `foo` is a git gem that fails (@kirs)
@@ -1908,7 +1905,7 @@ Features:
   - add quiet option to `bundle package` ([#2573](https://github.com/rubygems/bundler/issues/2573), @shtirlic)
   - use RUBYLIB instead of RUBYOPT for better Windows support ([#2536](https://github.com/rubygems/bundler/issues/2536), @equinux)
 
-Bugfixes:
+Bug fixes:
 
   - reduce stack size while resolving to fix JRuby overflow ([#2510](https://github.com/rubygems/bundler/issues/2510), @headius)
   - display GitErrors while loading specs in --verbose mode ([#2461](https://github.com/rubygems/bundler/issues/2461))
@@ -1917,7 +1914,7 @@ Bugfixes:
 
 ## 1.3.6 (8 January 2014)
 
-Bugfixes:
+Bug fixes:
 
   - make gemspec path option preserve relative paths in lock file (@bwillis)
   - use umask when creating binstubs ([#1618](https://github.com/rubygems/bundler/issues/1618), @v-yarotsky)
@@ -1941,7 +1938,7 @@ Features:
 
   - progress indicator while resolver is running (@chief)
 
-Bugfixes:
+Bug fixes:
 
   - update local overrides with orphaned revisions (@jamesferguson)
   - revert to working quoting of RUBYOPT on Windows (@ogra)
@@ -1950,7 +1947,7 @@ Bugfixes:
 
 ## 1.3.4 (15 March 2013)
 
-Bugfixes:
+Bug fixes:
 
   - load YAML on Rubygems versions that define module YAML
   - fix regression that broke --without on ruby 1.8.7
@@ -1963,7 +1960,7 @@ Features:
   - mention skipped groups in bundle install and bundle update output (@simi)
   - `gem` creates rake tasks for minitest (@coop) and rspec
 
-Bugfixes:
+Bug fixes:
 
   - require rbconfig for standalone mode
 
@@ -1973,13 +1970,13 @@ Features:
 
   - include rubygems.org CA chain
 
-Bugfixes:
+Bug fixes:
 
   - don't store --dry-run as a Bundler setting
 
 ## 1.3.1 (3 March 2013)
 
-Bugfixes:
+Bug fixes:
 
   - include manpages in gem, restoring many help pages
   - handle more SSL certificate verification failures
@@ -1996,7 +1993,7 @@ Features:
   - set $MANPATH inside `exec` for gems with man pages (@sunaku)
   - partial gem names for `open` and `update` now return a list (@takkanm)
 
-Bugfixes:
+Bug fixes:
 
   - `update` now (again) finds gems that aren't listed in the Gemfile
   - `install` now (again) updates cached gems that aren't in the Gemfile
@@ -2005,7 +2002,7 @@ Bugfixes:
 
 ## 1.3.0.pre.8 (12 February 2013)
 
-Security:
+Security fixes:
 
   - validate SSL certificate chain during HTTPS network requests
   - don't send HTTP Basic Auth creds when redirected to other hosts (@perplexes)
@@ -2024,7 +2021,7 @@ Features:
   - inform users when the resolver starts
   - disable reverse DNS to speed up API requests (@raggi)
 
-Bugfixes:
+Bug fixes:
 
   - raise errors while requiring dashed gems ([#1807](https://github.com/rubygems/bundler/issues/1807))
   - quote the Bundler path on Windows (@jgeiger, [#1862](https://github.com/rubygems/bundler/issues/1862), [#1856](https://github.com/bundler/bundler/issues/1856))
@@ -2036,7 +2033,7 @@ Bugfixes:
 
 ## 1.3.0.pre.7 (22 January 2013)
 
-Bugfixes:
+Bug fixes:
 
   - stubs for gems with dev deps no longer cause exceptions ([#2272](https://github.com/rubygems/bundler/issues/2272))
   - don't suggest binstubs to --binstubs users
@@ -2051,7 +2048,7 @@ Features:
   - `bundle env` prints info about bundler's environment (@peeja)
   - add `BUNDLE_IGNORE_CONFIG` environment variable support (@richo)
 
-Bugfixes:
+Bug fixes:
 
   - don't overwrite custom binstubs during `install --binstubs`
   - don't throw an exception if `binstubs` gem doesn't exist
@@ -2064,7 +2061,7 @@ Features:
   - make `--standalone` require lines ruby engine/version agnostic
   - add `--dry-run` to `bundle clean` (@wfarr, [#2237](https://github.com/rubygems/bundler/issues/2237))
 
-Bugfixes:
+Bug fixes:
 
   - don't skip writing binstubs when doing `bundle install`
   - distinguish between ruby 1.9/2.0 when using :platforms (@spastorino)
@@ -2077,7 +2074,7 @@ Features:
   - `bundle install --binstubs ""` will remove binstubs option
   - `bundle clean --dry-run` will print out gems instead of removing them
 
-Bugfixes:
+Bug fixes:
 
   - Avoid stack traces when Ctrl+C during bundle command (@mitchellh)
   - fix YAML parsing in in ruby-preview2
@@ -2091,7 +2088,7 @@ Features:
   - added platforms :ruby_20 and :mri_20, since the ABI has changed
   - added '--edit' option to open generated gemspec in editor
 
-Bugfixes:
+Bug fixes:
 
   - :git gems with extensions now work with Rubygems >= 2.0 (@jeremy)
   - revert SemVer breaking change to :github
@@ -2107,7 +2104,7 @@ Features:
   - `gem` generates files correctly for names like `jquery-rails` (@banyan, [#2201](https://github.com/rubygems/bundler/issues/2201))
   - use gems from gists with the :gist option in the Gemfile (@jgaskins)
 
-Bugfixes:
+Bug fixes:
 
   - Gemfile sources other than rubygems.org work even when .gemrc contains sources
   - caching git gems now caches specs, fixing e.g. git ls-files (@bison, [#2039](https://github.com/rubygems/bundler/issues/2039))
@@ -2132,7 +2129,7 @@ Features:
   - `gem` command generates MIT license (@BrentWheeldon)
   - gem rake task 'release' resuses existing tags (@shtirlic)
 
-Bugfixes:
+Bug fixes:
 
   - JRuby new works with HTTPS gem sources (@davidcelis)
   - `install` installs both rake rake-built gems at once (@crowbot, [#2107](https://github.com/rubygems/bundler/issues/2107))
@@ -2146,7 +2143,7 @@ Bugfixes:
 
 ## 1.2.5 (Feb 24, 2013)
 
-Bugfixes:
+Bug fixes:
 
   - install Gemfiles with HTTP sources even without OpenSSL present
   - display CerficateFailureError message in full
@@ -2159,7 +2156,7 @@ Features:
   - inform users when the resolver starts
   - disable reverse DNS to speed up API requests (@raggi)
 
-Bugfixes:
+Bug fixes:
 
   - don't send user/pass when redirected to another host (@perplexes)
   - load gemspecs containing unicode (@gaffneyc, [#2301](https://github.com/rubygems/bundler/issues/2301))
@@ -2169,13 +2166,13 @@ Bugfixes:
 
 ## 1.2.3 (Nov 29, 2012)
 
-Bugfixes:
+Bug fixes:
 
   - fix exceptions while loading some gemspecs
 
 ## 1.2.2 (Nov 14, 2012)
 
-Bugfixes:
+Bug fixes:
 
   - support new Psych::SyntaxError for Ruby 2.0.0 (@tenderlove, @sol)
   - `bundle viz` works with git gems again (@hirochachacha)
@@ -2183,14 +2180,14 @@ Bugfixes:
 
 ## 1.2.1 (Sep 19, 2012)
 
-Bugfixes:
+Bug fixes:
 
   - `bundle clean` now works with BUNDLE_WITHOUT groups again
   - have a net/http read timeout around the Gemcutter API Endpoint
 
 ## 1.2.0 (Aug 30, 2012)
 
-Bugfixes:
+Bug fixes:
 
   - raise original error message from LoadError's
 
@@ -2200,7 +2197,7 @@ Documentation:
 
 ## 1.2.0.rc.2 (Aug 8, 2012)
 
-Bugfixes:
+Bug fixes:
 
   - `clean` doesn't remove gems that are included in the lockfile
 
@@ -2217,7 +2214,7 @@ Features:
   - fall back on the full index when experiencing syck errors ([#1419](https://github.com/rubygems/bundler/issues/1419))
   - handle syntax errors in Ruby gemspecs ([#1974](https://github.com/rubygems/bundler/issues/1974))
 
-Bugfixes:
+Bug fixes:
 
   - fix `pack`/`cache` with `--all` (@josevalim, [#1989](https://github.com/rubygems/bundler/issues/1989))
   - don't display warning message when `cache_all` is set
@@ -2230,7 +2227,7 @@ Features:
 
   - Git gems import submodules of submodules recursively (@nwwatson, [#1935](https://github.com/rubygems/bundler/issues/1935))
 
-Bugfixes:
+Bug fixes:
 
   - Exit from `check` with a non-zero status when frozen with no lock
   - Use `latest_release` in Capistrano and Vlad integration ([#1264](https://github.com/rubygems/bundler/issues/1264))
@@ -2266,7 +2263,7 @@ Performance:
 
   - bundle exec shouldn't run Bundler.setup just setting the right rubyopts options is enough (@spastorino, [#1598](https://github.com/rubygems/bundler/issues/1598))
 
-Bugfixes:
+Bug fixes:
 
   - Avoid passing RUBYOPT changes in with_clean_env block (@eric1234, [#1604](https://github.com/rubygems/bundler/issues/1604))
   - Use the same ruby to run subprocesses as is running rake (@brixen)
@@ -2286,7 +2283,7 @@ Features:
 
 ## 1.1.4 (May 27, 2012)
 
-Bugfixes:
+Bug fixes:
 
   - Use `latest_release` in Capistrano and Vlad integration ([#1264](https://github.com/rubygems/bundler/issues/1264))
   - Unknown exceptions now link to ISSUES for help instead of a new ticket
@@ -2296,19 +2293,19 @@ Bugfixes:
 
 ## 1.1.3 (March 23, 2012)
 
-Bugfixes:
+Bug fixes:
 
   - escape the bundler root path (@tenderlove, [#1789](https://github.com/rubygems/bundler/issues/1789))
 
 ## 1.1.2 (March 20, 2012)
 
-Bugfixes:
+Bug fixes:
 
   - Fix --deployment for multiple PATH sections of the same source ([#1782](https://github.com/rubygems/bundler/issues/1782))
 
 ## 1.1.1 (March 14, 2012)
 
-Bugfixes:
+Bug fixes:
 
   - Rescue EAGAIN so the fetcher works on JRuby on Windows
   - Stop asking users to report gem installation errors
@@ -2323,7 +2320,7 @@ Performance:
 
 ## 1.1.0 (Mar 7, 2012)
 
-Bugfixes:
+Bug fixes:
 
   - Clean up corrupted lockfiles on bundle installs
   - Prevent duplicate GIT sources
@@ -2335,7 +2332,7 @@ Performance:
 
   - don't resolve if the Gemfile.lock and Gemfile haven't changed
 
-Bugfixes:
+Bug fixes:
 
   - Load gemspecs from git even when a released gem has the same version ([#1609](https://github.com/rubygems/bundler/issues/1609))
   - Declare an accurate Ruby version requirement of 1.8.7 or newer ([#1619](https://github.com/rubygems/bundler/issues/1619))
@@ -2344,13 +2341,13 @@ Bugfixes:
 
 ## 1.1.rc.7 (Dec 29, 2011)
 
-Bugfixes:
+Bug fixes:
 
   - Fix bug where `clean` would break when using :path with no gemspec
 
 ## 1.1.rc.6 (Dec 22, 2011)
 
-Bugfixes:
+Bug fixes:
 
   - Fix performance regression from 1.0 (@spastorino, [#1511](https://github.com/rubygems/bundler/issues/1511), [#1591](https://github.com/bundler/bundler/issues/1591), [#1592](https://github.com/bundler/bundler/issues/1592))
   - Load gems correctly when GEM_HOME is blank
@@ -2359,7 +2356,7 @@ Bugfixes:
 
 ## 1.1.rc.5 (Dec 14, 2011)
 
-Bugfixes:
+Bug fixes:
 
   - Fix ASCII encoding errors with gem (rerelease with ruby 1.8)
 
@@ -2369,14 +2366,14 @@ Features:
 
   - `bundle viz` has the option to output a DOT file instead of a PNG (@hirochachacha, [#683](https://github.com/rubygems/bundler/issues/683))
 
-Bugfixes:
+Bug fixes:
 
   - Ensure binstubs generated when using --standalone point to the standalonde bundle (@cowboyd, [#1588](https://github.com/rubygems/bundler/issues/1588))
   - fix `bundle viz` (@hirochachacha, [#1586](https://github.com/rubygems/bundler/issues/1586))
 
 ## 1.1.rc.3 (Dec 8, 2011)
 
-Bugfixes:
+Bug fixes:
 
   - fix relative_path so it checks Bundler.root is actually in the beginning of the path ([#1582](https://github.com/rubygems/bundler/issues/1582))
   - fix bundle outdated doesn't list all gems (@joelmoss, [#1521](https://github.com/rubygems/bundler/issues/1521))
@@ -2388,7 +2385,7 @@ Features:
   - Added README.md to `newgem` (@ognevsky, [#1574](https://github.com/rubygems/bundler/issues/1574))
   - Added LICENSE (MIT) to newgem (@ognevsky, [#1571](https://github.com/rubygems/bundler/issues/1571))
 
-Bugfixes:
+Bug fixes:
 
   - only auto-namespace requires for implied requires ([#1531](https://github.com/rubygems/bundler/issues/1531))
   - fix bundle clean output for git repos ([#1473](https://github.com/rubygems/bundler/issues/1473))
@@ -2415,7 +2412,7 @@ Features:
   - build passes on ruby 1.9.3rc1 ([#1458](https://github.com/rubygems/bundler/issues/1458), [#1469](https://github.com/bundler/bundler/issues/1469))
   - hide basic auth credentials for custom sources ([#1440](https://github.com/rubygems/bundler/issues/1440), [#1463](https://github.com/bundler/bundler/issues/1463))
 
-Bugfixes:
+Bug fixes:
 
   - fix index search result caching ([#1446](https://github.com/rubygems/bundler/issues/1446), [#1466](https://github.com/bundler/bundler/issues/1466))
   - fix fetcher prints multiple times during install ([#1445](https://github.com/rubygems/bundler/issues/1445), [#1462](https://github.com/bundler/bundler/issues/1462))
@@ -2446,7 +2443,7 @@ Features:
   - load rubygems plugins in the bundle binary (@tpope, [#1364](https://github.com/rubygems/bundler/issues/1364))
   - make `--standalone` respect `--path` (@cowboyd, [#1361](https://github.com/rubygems/bundler/issues/1361))
 
-Bugfixes:
+Bug fixes:
 
   - Fix `clean` to handle nested gems in a git repo ([#1329](https://github.com/rubygems/bundler/issues/1329))
   - Fix conflict from revert of benchmark tool (@boffbowsh, [#1355](https://github.com/rubygems/bundler/issues/1355))
@@ -2459,7 +2456,7 @@ Bugfixes:
 
 ## 1.1.pre.8 (Aug 13, 2011)
 
-Bugfixes:
+Bug fixes:
 
   - Fix `bundle check` to not print fatal error message (@cldwalker, [#1347](https://github.com/rubygems/bundler/issues/1347))
   - Fix require_sudo when Gem.bindir isn't writeable ([#1352](https://github.com/rubygems/bundler/issues/1352))
@@ -2468,14 +2465,14 @@ Bugfixes:
 
 ## 1.1.pre.7 (Aug 8, 2011)
 
-Bugfixes:
+Bug fixes:
 
   - Fixed invalid byte sequence error while installing gem on Ruby 1.9 ([#1341](https://github.com/rubygems/bundler/issues/1341))
   - Fixed exception when sudo was needed to install gems (@spastorino)
 
 ## 1.1.pre.6 (Aug 8, 2011)
 
-Bugfixes:
+Bug fixes:
 
   - Fix cross repository dependencies ([#1138](https://github.com/rubygems/bundler/issues/1138))
   - Fix git dependency fetching from API endpoint ([#1254](https://github.com/rubygems/bundler/issues/1254))
@@ -2492,7 +2489,7 @@ Features:
 
 ## 1.1.pre.5 (June 11, 2011)
 
-Bugfixes:
+Bug fixes:
 
   - Fix LazySpecification on Ruby 1.9 (@dpiddy, [#1232](https://github.com/rubygems/bundler/issues/1232))
   - Fix HTTP proxy support (@leobessa, [#878](https://github.com/rubygems/bundler/issues/878))
@@ -2510,7 +2507,7 @@ Features:
 
 ## 1.1.pre.4 (May 5, 2011)
 
-Bugfixes:
+Bug fixes:
 
   - Fix bug that could prevent installing new gems
 
@@ -2523,7 +2520,7 @@ Features:
   - Add Bundler.clean_system, and clean_exec (@wuputah)
   - Use git config for gem author name and email (@krekoten)
 
-Bugfixes:
+Bug fixes:
 
   - Fix error calling Bundler.rubygems.gem_path
   - Fix error when Gem.path returns Gem::FS instead of String
@@ -2537,7 +2534,7 @@ Features:
 
 ## 1.1.pre.1 (February 2, 2011)
 
-Bugfixes:
+Bug fixes:
 
   - Compatibility with changes made by Rubygems 1.5
 
@@ -2552,7 +2549,7 @@ Features:
   - Make it possible to override a .gemspec dependency's source in the
     Gemfile
 
-Removed:
+Breaking Changes:
 
   - Removed bundle lock
   - Removed bundle install <path>
@@ -2565,7 +2562,7 @@ Removed:
 
 ## 1.0.21.rc (September 29, 2011)
 
-Bugfixes:
+Bug fixes:
 
   - Load Psych unless Syck is defined, because 1.9.2 defines YAML
 
@@ -2575,7 +2572,7 @@ Features:
 
   - Add platform :maglev (@timfel, [#1444](https://github.com/rubygems/bundler/issues/1444))
 
-Bugfixes:
+Bug fixes:
 
   - Ensure YAML is required even if Psych is found
   - Handle directory names that contain invalid regex characters
@@ -2587,7 +2584,7 @@ Features:
   - Rescue interrupts to `bundle` while loading bundler.rb ([#1395](https://github.com/rubygems/bundler/issues/1395))
   - Allow clearing without groups by passing `--without ''` ([#1259](https://github.com/rubygems/bundler/issues/1259))
 
-Bugfixes:
+Bug fixes:
 
   - Manually sort requirements in the lockfile ([#1375](https://github.com/rubygems/bundler/issues/1375))
   - Remove several warnings generated by ruby -w (@stephencelis)
@@ -2603,7 +2600,7 @@ Features:
   - Report gem installation failures clearly (@rwilcox, [#1380](https://github.com/rubygems/bundler/issues/1380))
   - Useful error for cap and vlad on first deploy (@nexmat, @kirs)
 
-Bugfixes:
+Bug fixes:
 
   - `exec` now works when the command contains 'exec'
   - Only touch lock after changes on Windows (@robertwahler, [#1358](https://github.com/rubygems/bundler/issues/1358))
@@ -2611,7 +2608,7 @@ Bugfixes:
 
 ## 1.0.18 (August 16, 2011)
 
-Bugfixes:
+Bug fixes:
 
   - Fix typo in DEBUG_RESOLVER (@geemus)
   - Fixes rake 0.9.x warning (@mtylty, [#1333](https://github.com/rubygems/bundler/issues/1333))
@@ -2626,7 +2623,7 @@ Features:
 
 ## 1.0.17 (August 8, 2011)
 
-Bugfixes:
+Bug fixes:
 
   - Fix rake issues with rubygems 1.3.x ([#1342](https://github.com/rubygems/bundler/issues/1342))
   - Fixed invalid byte sequence error while installing gem on Ruby 1.9 ([#1341](https://github.com/rubygems/bundler/issues/1341))
@@ -2639,7 +2636,7 @@ Features:
   - Shortcuts (like `bundle i`) for all commands (@amatsuda)
   - Correcly identify missing child dependency in error message
 
-Bugfixes:
+Bug fixes:
 
   - Allow Windows network share paths with forward slashes (@mtscout6, [#1253](https://github.com/rubygems/bundler/issues/1253))
   - Check for rubygems.org credentials so `rake release` doesn't hang ([#980](https://github.com/rubygems/bundler/issues/980))
@@ -2658,7 +2655,7 @@ Features:
 
   - Improved Rubygems integration, removed many deprecation notices
 
-Bugfixes:
+Bug fixes:
 
   - Escape URL arguments to git correctly on Windows (1.0.14 regression)
 
@@ -2670,7 +2667,7 @@ Features:
   - Include gem rake tasks with "require 'bundler/gem_tasks" (@indirect)
   - Include user name and email from git config in new gemspec (@ognevsky)
 
-Bugfixes:
+Bug fixes:
 
   - Set file permissions after checking out git repos (@tissak)
   - Remove deprecated call to Gem::SourceIndex#all_gems (@mpj)
@@ -2692,7 +2689,7 @@ Features:
   - Support Rake 0.9 and greater (@e2)
   - Output full errors for non-TTYs e.g. pow (@josh)
 
-Bugfixes:
+Bug fixes:
 
   - Allow spaces in gem path names for gem tasks (@rslifka)
   - Have cap run bundle install from release_path (@martinjagusch)
@@ -2706,7 +2703,7 @@ Features:
   - Better error message when git fails and cache is present (@parndt)
   - Honor :bundle_cmd in cap `rake` command (@voidlock, @cgriego)
 
-Bugfixes:
+Bug fixes:
 
   - Compatibility with Rubygems 1.7 and Rails 2.3 and vendored gems (@evanphx)
   - Fix changing gem order in lock (@gucki)
@@ -2722,7 +2719,7 @@ Features:
   - Compatibility with Rubygems 1.6 and 1.7
   - Better error messages when a git command fails
 
-Bugfixes:
+Bug fixes:
 
   - Don't always update gemspec gems (@carllerche)
   - Remove ivar warnings (@jackdempsey)
@@ -2731,14 +2728,14 @@ Bugfixes:
 
 ## 1.0.10 (February 1, 2011)
 
-Bugfixes:
+Bug fixes:
 
   - Fix a regression loading YAML gemspecs from :git and :path gems
   - Requires, namespaces, etc. to work with changes in Rubygems 1.5
 
 ## 1.0.9 (January 19, 2011)
 
-Bugfixes:
+Bug fixes:
 
   - Fix a bug where Bundler.require could remove gems from the load
     path. In Rails apps with a default application.rb, this removed
@@ -2754,7 +2751,7 @@ Features:
   - Use `less` as help pager instead of `more`
   - Run `bundle exec rake` instead of `rake` in Capistrano tasks
 
-Bugfixes:
+Bug fixes:
 
   - Fix --no-cache option for `bundle install`
   - Allow Vlad deploys to work without Capistrano gem installed
@@ -2768,14 +2765,14 @@ Bugfixes:
 
 ## 1.0.7 (November 17, 2010)
 
-Bugfixes:
+Bug fixes:
 
   - Remove Bundler version from the lockfile because it broke
     backwards compatibility with 1.0.0-1.0.5. Sorry. :(
 
 ## 1.0.6 (November 16, 2010)
 
-Bugfixes:
+Bug fixes:
 
   - Fix regression in `update` that caused long/wrong results
   - Allow git gems on other platforms while installing ([#579](https://github.com/rubygems/bundler/issues/579))
@@ -2790,13 +2787,13 @@ Features:
 
 ## 1.0.5 (November 13, 2010)
 
-Bugfixes:
+Bug fixes:
 
   - Fix regression disabling all operations that employ sudo
 
 ## 1.0.4 (November 12, 2010)
 
-Bugfixes:
+Bug fixes:
 
   - Expand relative :paths from Bundler.root (eg ./foogem)
   - Allow git gems in --without groups while --frozen
@@ -2821,7 +2818,7 @@ Features:
 
 ## 1.0.3 (October 15, 2010)
 
-Bugfixes:
+Bug fixes:
 
   - Use bitwise or in #hash to reduce the chance of overflow
   - `bundle update` now works with :git + :tag updates
@@ -2837,7 +2834,7 @@ Bugfixes:
 
 ## 1.0.2 (October 2, 2010)
 
-Bugfix:
+Bug fixes:
 
   - Actually include the man pages in the gem, so help works
 
@@ -2853,7 +2850,7 @@ Features:
   - Allow subclassing of GemHelper for custom tasks
   - Chdir to gem directory during `bundle open`
 
-Bugfixes:
+Bug fixes:
 
   - Allow gemspec requirements with a list of versions
   - Accept lockfiles with windows line endings
@@ -2869,7 +2866,7 @@ Features:
 
   - You can now define `:bundle_cmd` in the capistrano task
 
-Bugfixes:
+Bug fixes:
 
   - Various bugfixes to the built-in rake helpers
   - Fix a bug where shortrefs weren't unique enough and were
@@ -2892,7 +2889,7 @@ Features:
   - Much better documentation for most of the commands and Gemfile
     format
 
-Bugfixes:
+Bug fixes:
 
   - Don't attempt to create directories if they already exist
   - Fix the capistrano task so that it actually runs
@@ -2909,7 +2906,7 @@ Features:
 
   - Make the Capistrano task more concise.
 
-Bugfixes:
+Bug fixes:
 
   - Fix a regression with determining whether or not to use sudo
   - Allow using the --gemfile flag with the --deployment flag
@@ -2924,7 +2921,7 @@ Features:
     (default with --deployment)
   - Basic Capistrano task now added as 'bundler/capistrano'
 
-Bugfixes:
+Bug fixes:
 
   - Multiple bundler process no longer share a tmp directory
   - `bundle update GEM` always updates dependencies of GEM as well
@@ -2946,7 +2943,7 @@ Features:
   - Improve message from `bundle check` under various conditions
   - Better error when a changed Gemfile conflicts with Gemfile.lock
 
-Bugfixes:
+Bug fixes:
 
   - Create bin/ directory if it is missing, then install binstubs
   - Error nicely on the edge case of a pinned gem with no spec
@@ -3073,7 +3070,7 @@ Features:
 
 ## 0.9.25 (May 3, 2010)
 
-Bugfixes:
+Bug fixes:
 
   - explicitly coerce Pathname objects to Strings for Ruby 1.9
   - fix some newline weirdness in output from install command
@@ -3089,7 +3086,7 @@ Features:
   - raise Bundler::GemNotFound instead of calling exit! inside library code
   - Rubygems 1.3.5 compatibility for the adventurous, not supported by me :)
 
-Bugfixes:
+Bug fixes:
 
   - don't try to regenerate environment.rb if it is read-only
   - prune outdated gems with the platform "ruby"
@@ -3099,7 +3096,7 @@ Bugfixes:
 
 ## 0.9.23 (April 20, 2010)
 
-Bugfixes:
+Bug fixes:
 
   - cache command no longer prunes gems created by an older rubygems version
   - cache command no longer prunes gems that are for other platforms
@@ -3114,7 +3111,7 @@ Features:
   - remove .gem files generated after installing a gem from a :path ([#286](https://github.com/rubygems/bundler/issues/286))
   - improve install/lock messaging ([#284](https://github.com/rubygems/bundler/issues/284))
 
-Bugfixes:
+Bug fixes:
 
   - ignore cached gems that are for another platform ([#288](https://github.com/rubygems/bundler/issues/288))
   - install Windows gems that have no architecture set, like rcov ([#277](https://github.com/rubygems/bundler/issues/277))
@@ -3125,7 +3122,7 @@ Bugfixes:
 
 ## 0.9.21 (April 16, 2010)
 
-Bugfixes:
+Bug fixes:
 
   - don't raise 'omg wtf' when lockfile is outdated
 
@@ -3137,7 +3134,7 @@ Features:
   - no backtraces when calling Bundler.setup if gems are missing
   - no backtraces when trying to exec a file without the executable bit
 
-Bugfixes:
+Bug fixes:
 
   - fix infinite recursion in Bundler.setup after loading a bundled Bundler gem
   - request install instead of lock when env.rb is out of sync with Gemfile.lock
@@ -3149,7 +3146,7 @@ Features:
   - suggest `bundle install --relock` when the Gemfile has changed ([#272](https://github.com/rubygems/bundler/issues/272))
   - source support for Rubygems servers without prerelease gem indexes ([#262](https://github.com/rubygems/bundler/issues/262))
 
-Bugfixes:
+Bug fixes:
 
   - don't set up all groups every time Bundler.setup is called while locked ([#263](https://github.com/rubygems/bundler/issues/263))
   - fix #full_gem_path for git gems while locked ([#268](https://github.com/rubygems/bundler/issues/268))
@@ -3162,7 +3159,7 @@ Features:
 
   - console command that runs irb with bundle (and optional group) already loaded
 
-Bugfixes:
+Bug fixes:
 
   - Bundler.setup now fully disables system gems, even when unlocked ([#266](https://github.com/rubygems/bundler/issues/266), [#246](https://github.com/bundler/bundler/issues/246))
     - fixes Yard, which found plugins in Gem.source_index that it could not load
@@ -3175,7 +3172,7 @@ Features:
   - Bundler.require now calls Bundler.setup automatically
   - Gem::Specification#add_bundler_dependencies added for gemspecs
 
-Bugfixes:
+Bug fixes:
 
   - Gem paths are not longer duplicated while loading bundler
   - exec no longer duplicates RUBYOPT if it is already set correctly
@@ -3188,7 +3185,7 @@ Features:
   - resolver output now indicates whether remote sources were checked
   - print error instead of backtrace when exec cannot find a binary ([#241](https://github.com/rubygems/bundler/issues/241))
 
-Bugfixes:
+Bug fixes:
 
   - show, check, and open commands work again while locked (oops)
   - show command for git gems
@@ -3209,7 +3206,7 @@ Features:
      - regenerates env_file if it was generated by an older version
   - update cached/packed gems when you update gems via bundle install
 
-Bugfixes:
+Bug fixes:
 
   - prep for Rubygems 1.3.7 changes
   - install command now pulls git branches correctly ([#211](https://github.com/rubygems/bundler/issues/211))
@@ -3228,7 +3225,7 @@ Features:
   - show command now aliased as 'list'
   - VISUAL env var respected for GUI editors
 
-Bugfixes:
+Bug fixes:
 
   - exec command now finds binaries from gems with no gemspec
   - note source of Gemfile resolver errors
@@ -3236,7 +3233,7 @@ Bugfixes:
 
 ## 0.9.13 (March 23, 2010)
 
-Bugfixes:
+Bug fixes:
 
   - exec command now finds binaries from gems installed via :path
   - gem dependencies are pulled in even if their type is nil
@@ -3252,7 +3249,7 @@ Features:
   - check command takes a --without option
   - check command exits 1 if the check fails
 
-Bugfixes:
+Bug fixes:
 
   - perform a topological sort on resolved gems ([#191](https://github.com/rubygems/bundler/issues/191))
   - gems from git work even when paths or repos have spaces ([#196](https://github.com/rubygems/bundler/issues/196))
@@ -3277,7 +3274,7 @@ Features:
   - improve backtraces when a gemspec is invalid
   - improve performance by installing gems from the cache if present
 
-Bugfixes:
+Bug fixes:
 
   - normalize parameters to Bundler.require ([#153](https://github.com/rubygems/bundler/issues/153))
   - check now checks installed gems rather than cached gems ([#162](https://github.com/rubygems/bundler/issues/162))
@@ -3293,7 +3290,7 @@ Bugfixes:
 
   - depends on Rubygems 1.3.6
 
-Bugfixes:
+Bug fixes:
 
   - support locking after install --without
   - don't reinstall gems from the cache if they're already in the bundle
@@ -3301,7 +3298,7 @@ Bugfixes:
 
 ## 0.9.9 (February 25, 2010)
 
-Bugfixes:
+Bug fixes:
 
   - don't die if GEM_HOME is an empty string
   - fixes for Ruby 1.8.6 and 1.9
@@ -3320,7 +3317,7 @@ Features:
   - print a useful warning if building a gem fails
   - allow manual configuration via BUNDLE_PATH
 
-Bugfixes:
+Bug fixes:
 
   - eval gemspecs in the gem directory so relative paths work
   - make default spec for git sources valid
@@ -3328,7 +3325,7 @@ Bugfixes:
 
 ## 0.9.7 (February 17, 2010)
 
-Bugfixes:
+Bug fixes:
 
   - don't say that a gem from an excluded group is "installing"
   - improve crippling rubygems in locked scenarios
@@ -3340,7 +3337,7 @@ Features:
   - allow String group names
   - a number of improvements in the documentation and error messages
 
-Bugfixes:
+Bug fixes:
 
   - set SourceIndex#spec_dirs to solve a problem involving Rails 2.3 in unlocked mode
   - ensure Rubygems is fully loaded in Ruby 1.9 before patching it
@@ -3359,7 +3356,7 @@ Features:
   - Bundler.require fails silently if a library does not have a file on the load path with its name
   - Basic support for multiple rubies by namespacing the default bundle path using the version and engine
 
-Bugfixes:
+Bug fixes:
 
   - if the bundle is locked and .bundle/environment.rb is not present when Bundler.setup is called, generate it
   - same if it's not present with `bundle check`

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -142,27 +142,27 @@ Bugfixes:
 
 ## 2.1.0.pre.1 (August 28, 2019)
 
-One of the biggest changes in bundler 2.1.0 is that deprecations for upcoming
-breaking changes in bundler 3 will be turned on by default. We do this to grab
-feedback and communicate early to our users the kind of changes we're intending
-to ship with bundler 3. See
-[#6965](https://github.com/rubygems/bundler/pull/6965).
+  One of the biggest changes in bundler 2.1.0 is that deprecations for upcoming
+  breaking changes in bundler 3 will be turned on by default. We do this to grab
+  feedback and communicate early to our users the kind of changes we're intending
+  to ship with bundler 3. See
+  [#6965](https://github.com/rubygems/bundler/pull/6965).
 
-Another important improvement is a better coexistence between bundler
-installations and the default copy of bundler that comes with ruby installed as
-a default gem. Since bundler is shipped as a default gem with ruby, a number of
-users have been affected by issues where bundler ends up failing due to version
-mismatches, because at some point of the execution, bundler switches to run the
-default copy instead of the expected version. A number of PRs have been focused
-on minimizing (hopefully eliminating) this, such as
-[#7100](https://github.com/rubygems/bundler/pull/7100),
-[#7137](https://github.com/rubygems/bundler/pull/7137),
-[#6996](https://github.com/rubygems/bundler/pull/6996),
-[#7056](https://github.com/rubygems/bundler/pull/7056),
-[#7062](https://github.com/rubygems/bundler/pull/7062),
-[#7193](https://github.com/rubygems/bundler/pull/7193),
-[#7216](https://github.com/rubygems/bundler/pull/7216),
-[#7274](https://github.com/rubygems/bundler/pull/7274)
+  Another important improvement is a better coexistence between bundler
+  installations and the default copy of bundler that comes with ruby installed as
+  a default gem. Since bundler is shipped as a default gem with ruby, a number of
+  users have been affected by issues where bundler ends up failing due to version
+  mismatches, because at some point of the execution, bundler switches to run the
+  default copy instead of the expected version. A number of PRs have been focused
+  on minimizing (hopefully eliminating) this, such as
+  [#7100](https://github.com/rubygems/bundler/pull/7100),
+  [#7137](https://github.com/rubygems/bundler/pull/7137),
+  [#6996](https://github.com/rubygems/bundler/pull/6996),
+  [#7056](https://github.com/rubygems/bundler/pull/7056),
+  [#7062](https://github.com/rubygems/bundler/pull/7062),
+  [#7193](https://github.com/rubygems/bundler/pull/7193),
+  [#7216](https://github.com/rubygems/bundler/pull/7216),
+  [#7274](https://github.com/rubygems/bundler/pull/7274)
 
 Deprecations:
 
@@ -234,9 +234,9 @@ Documentation:
   - Fix incorrect sections when explaining `:git`, `:branch`, and `:ref` options ([#7265](https://github.com/rubygems/bundler/pull/7265))
   - Fix mentions to remembered options in docs to explain the current state ([#7242](https://github.com/rubygems/bundler/pull/7242))
 
-Internally, there's also been a bunch of improvements in our development
-environment, test suite, policies, contributing docs, and a bunch of cleanups of
-old compatibility code.
+  Internally, there's also been a bunch of improvements in our development
+  environment, test suite, policies, contributing docs, and a bunch of cleanups of
+  old compatibility code.
 
 ## 2.0.2 (2019-06-13)
 
@@ -272,7 +272,7 @@ Changes:
 
 ## 2.0.0 (2019-01-03)
 
-No new changes
+  No new changes
 
 ## 2.0.0.pre.3 (2018-12-30)
 
@@ -285,7 +285,7 @@ Changes:
   - Ruby 2.6 compatibility fixes (@segiddins)
   - Import changes from Bundler 1.17.3 release
 
-Note: To upgrade your Gemfile to Bundler 2 you will need to run `bundle update --bundler`
+  Note: To upgrade your Gemfile to Bundler 2 you will need to run `bundle update --bundler`
 
 ## 2.0.0.pre.2 (2018-11-27)
 
@@ -297,7 +297,7 @@ Changes
 
   - Add compatibility for Bundler merge into ruby-src
 
-Note: To upgrade your Gemfile to Bundler 2 you will need to run `bundle update --bundler`
+  Note: To upgrade your Gemfile to Bundler 2 you will need to run `bundle update --bundler`
 
 ## 2.0.0.pre.1 (2018-11-09)
 
@@ -307,7 +307,7 @@ Breaking Changes:
   - Dropped support for version of RubyGems under 2.5
   - Moved error messages from STDOUT to STDERR
 
-Note: To upgrade your Gemfile to Bundler 2 you will need to run `bundle update --bundler`
+  Note: To upgrade your Gemfile to Bundler 2 you will need to run `bundle update --bundler`
 
 ## 1.17.3 (2018-12-27)
 
@@ -330,7 +330,7 @@ Documentation:
 
 ## 1.17.0 (2018-10-25)
 
-No new changes.
+  No new changes.
 
 ## 1.17.0.pre.2 (2018-10-13)
 
@@ -343,7 +343,7 @@ Features:
   - Add error message to `bundle add` to check adding duplicate gems to the Gemfile
   - When asking for `sudo`, Bundler will show a list of folders/files that require elevated permissions to write to.
 
-The following new features are available but are not enabled by default. These are intended to be tested by users for the upcoming release of Bundler 2.
+  The following new features are available but are not enabled by default. These are intended to be tested by users for the upcoming release of Bundler 2.
 
   - Improve deprecation warning message for `bundle show` command
   - Improve deprecation warning message for the `--force` option in `bundle install`
@@ -367,7 +367,7 @@ Features:
   - Add `--without-group` and `--only-group` options to `bundle list` ([#6564](https://github.com/rubygems/bundler/issues/6564), @agrim123)
   - Add `--gemfile` option to the `bundle exec` command ([#5924](https://github.com/rubygems/bundler/issues/5924), @ankitkataria)
 
-The following new features are available but are not enabled by default. These are intended to be tested by users for the upcoming release of Bundler 2.
+  The following new features are available but are not enabled by default. These are intended to be tested by users for the upcoming release of Bundler 2.
 
   - Make `install --path` relative to the current working directory ([#2048](https://github.com/rubygems/bundler/issues/2048), @igorbozato)
   - Auto-configure job count ([#5808](https://github.com/rubygems/bundler/issues/5808), @segiddins)
@@ -640,7 +640,7 @@ Bugfixes:
 
 ## 1.15.0 (2017-05-19)
 
-This space intentionally left blank.
+  This space intentionally left blank.
 
 ## 1.15.0.pre.4 (2017-05-10)
 
@@ -901,7 +901,7 @@ Bugfixes:
 
 ## 1.13.0 (2016-09-05)
 
-This space deliberately left blank.
+  This space deliberately left blank.
 
 ## 1.13.0.rc.2 (2016-08-21)
 
@@ -1036,7 +1036,7 @@ Bugfixes:
 
 ## 1.12.0 (2016-04-28)
 
-This space intentionally left blank.
+  This space intentionally left blank.
 
 ## 1.12.0.rc.4 (2016-04-21)
 
@@ -1160,7 +1160,7 @@ Bugfixes:
 
 ## 1.11.0 (2015-12-12)
 
-(this space intentionally left blank)
+  (this space intentionally left blank)
 
 ## 1.11.0.pre.2 (2015-12-06)
 
@@ -1292,7 +1292,7 @@ Bugfixes:
 
 ## 1.10.0 (2015-05-28)
 
-(this space intentionally left blank)
+  (this space intentionally left blank)
 
 ## 1.10.0.rc (2015-05-16)
 
@@ -1835,12 +1835,12 @@ Bugfixes:
 
 ## 1.5.0.rc.2 (2013-12-18)
 
-"Features":
+Features:
 
   - Support threaded installation on Rubygems 2.0.7+
   - Debug installation logs in .bundle/install.log
 
-"Bugfixes":
+Bugfixes:
 
   - Try to catch gem installation race conditions
 
@@ -2981,25 +2981,25 @@ Bugfixes:
     would always say "the git source is not checked out" when
     running `bundle install`
 
-NOTE: We received several reports of "the git source has not
-been checked out. Please run bundle install". As far as we
-can tell, these problems have two possible causes:
+  NOTE: We received several reports of "the git source has not
+  been checked out. Please run bundle install". As far as we
+  can tell, these problems have two possible causes:
 
-1. `bundle install ~/.bundle` in one user, but actually running
-   the application as another user. Never install gems to a
-   directory scoped to a user (`~` or `$HOME`) in deployment.
-2. A bug that happened when changing a gem to a git source.
+  1. `bundle install ~/.bundle` in one user, but actually running
+     the application as another user. Never install gems to a
+     directory scoped to a user (`~` or `$HOME`) in deployment.
+  2. A bug that happened when changing a gem to a git source.
 
-To mitigate several common causes of `(1)`, please use the
-new `--production` flag. This flag is simply a roll-up of
-the best practices we have been encouraging people to use
-for deployment.
+  To mitigate several common causes of `(1)`, please use the
+  new `--production` flag. This flag is simply a roll-up of
+  the best practices we have been encouraging people to use
+  for deployment.
 
-If you want to share gems across deployments, and you use
-Capistrano, symlink release_path/current/vendor/bundle to
-release_path/shared/bundle. This will keep deployments
-snappy while maintaining the benefits of clean, deploy-time
-isolation.
+  If you want to share gems across deployments, and you use
+  Capistrano, symlink release_path/current/vendor/bundle to
+  release_path/shared/bundle. This will keep deployments
+  snappy while maintaining the benefits of clean, deploy-time
+  isolation.
 
 ## 1.0.0.rc.1 (July 26, 2010)
 

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -272,7 +272,7 @@ Changes:
 
 ## 2.0.0 (2019-01-03)
 
-  No new changes
+  No changes.
 
 ## 2.0.0.pre.3 (2018-12-30)
 
@@ -330,7 +330,7 @@ Documentation:
 
 ## 1.17.0 (2018-10-25)
 
-  No new changes.
+  No changes.
 
 ## 1.17.0.pre.2 (2018-10-13)
 
@@ -640,7 +640,7 @@ Bugfixes:
 
 ## 1.15.0 (2017-05-19)
 
-  This space intentionally left blank.
+  No changes.
 
 ## 1.15.0.pre.4 (2017-05-10)
 
@@ -901,7 +901,7 @@ Bugfixes:
 
 ## 1.13.0 (2016-09-05)
 
-  This space deliberately left blank.
+  No changes.
 
 ## 1.13.0.rc.2 (2016-08-21)
 
@@ -1036,7 +1036,7 @@ Bugfixes:
 
 ## 1.12.0 (2016-04-28)
 
-  This space intentionally left blank.
+  No changes.
 
 ## 1.12.0.rc.4 (2016-04-21)
 
@@ -1160,7 +1160,7 @@ Bugfixes:
 
 ## 1.11.0 (2015-12-12)
 
-  (this space intentionally left blank)
+  No changes.
 
 ## 1.11.0.pre.2 (2015-12-06)
 
@@ -1292,7 +1292,7 @@ Bugfixes:
 
 ## 1.10.0 (2015-05-28)
 
-  (this space intentionally left blank)
+  No changes.
 
 ## 1.10.0.rc (2015-05-16)
 
@@ -2561,7 +2561,7 @@ Removed:
 
 ## 1.0.21 (September 30, 2011)
 
-  - No changes from RC
+  No changes.
 
 ## 1.0.21.rc (September 29, 2011)
 


### PR DESCRIPTION
This PR intends to keep unifying workflows in the new rubygems + bundler monorepo.

In this case, I standarize changelogs to use the same set of sections.

The result is the union of the labels rubygems currently uses with the labels
bundler current uses, just to be able to make the unification without triggering
any discussion of which the sections should actually be.

The only exception I made to this is the remove the "Style changes" section from
the rubygems changelog, since in my opinion those changes should clearly not be
included since they don't provide any value to end users.

But if others disagree I'm happy to remove that from this PR and keep that
section for now.

On top of that there's some naming unification, like renaming the section I just
made up in bundler in the last rc release, "Hightlights", to match rubygems
"Major enhancements", which conveys the same intention.

The final set of sections for both repositories is now:

   * Breaking changes
   * Bug fixes
   * ~Compatibility changes~
   * Deprecations
   * Documentation
   * Features
   * Major enhancements
   * Minor enhancements
   * Performance
   * Security fixes