### PR TITLE
Avoid openssl autoload

### DIFF
--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -202,6 +202,7 @@ end
 # We currently include the following changes over the official version:
 # * Avoid requiring the optional `net-http-pipeline` dependency, so that its version can be selected by end users.
 # * We also include changes to require the vendored dependencies `uri` and `connection_pool` relatively.
+# * Avoid autoloading `OpenSSL` since it causes problems on jruby.
 desc "Vendor a specific version of net-http-persistent"
 Automatiek::RakeTask.new("net-http-persistent") do |lib|
   lib.version = "v4.0.0"

--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -199,10 +199,9 @@ Automatiek::RakeTask.new("fileutils") do |lib|
   lib.vendor_lib = "lib/bundler/vendor/fileutils"
 end
 
-# We currently include changes over the official version to avoid requiring
-# the optional `net-http-pipeline` dependency, so that its version can be
-# selected by end users. We also include changes to require the vendored
-# dependencies `uri` and `connection_pool` relatively.
+# We currently include the following changes over the official version:
+# * Avoid requiring the optional `net-http-pipeline` dependency, so that its version can be selected by end users.
+# * We also include changes to require the vendored dependencies `uri` and `connection_pool` relatively.
 desc "Vendor a specific version of net-http-persistent"
 Automatiek::RakeTask.new("net-http-persistent") do |lib|
   lib.version = "v4.0.0"

--- a/bundler/lib/bundler/vendor/net-http-persistent/lib/net/http/persistent.rb
+++ b/bundler/lib/bundler/vendor/net-http-persistent/lib/net/http/persistent.rb
@@ -3,8 +3,6 @@ require_relative '../../../../uri/lib/uri'
 require 'cgi' # for escaping
 require_relative '../../../../connection_pool/lib/connection_pool'
 
-autoload :OpenSSL, 'openssl'
-
 ##
 # Persistent connections for Net::HTTP
 #
@@ -149,9 +147,14 @@ class Bundler::Persistent::Net::HTTP::Persistent
   EPOCH = Time.at 0 # :nodoc:
 
   ##
-  # Is OpenSSL available?  This test works with autoload
+  # Is OpenSSL available?
 
-  HAVE_OPENSSL = defined? OpenSSL::SSL # :nodoc:
+  HAVE_OPENSSL = begin # :nodoc:
+                   require 'openssl'
+                   true
+                 rescue LoadError
+                   false
+                 end
 
   ##
   # The default connection pool size is 1/4 the allowed open files


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We got a CI failure on jruby with the following error:

```
Gem::Package::FormatError: package is corrupt, exception while verifying: uninitialized constant Gem::Security::OpenSSL (NameError) in /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/cache/yard-1.0.gem
```

It's here: https://github.com/rubygems/rubygems/runs/857727761.

## What is your fix for the problem, implemented in this PR?

This most likely points to the same jruby issues we've been workarounding lately where jruby crashes with a missing constant error when you require and set an autoload for the same thing.

So, add the same workaround as in other related tickets and don't autoload `openssl`.

This is code inside `net-http-persistent`, so adding a note too about why we're doing this.

This is a follow up to https://github.com/rubygems/rubygems/pull/3751, https://github.com/rubygems/rubygems/pull/3770, https://github.com/rubygems/rubygems/pull/3771, and https://github.com/rubygems/rubygems/pull/3781.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
