### PR TITLE
Ignore internal frames in RubyGems' Kernel#warn

### DIFF
--- a/lib/rubygems/core_ext/kernel_warn.rb
+++ b/lib/rubygems/core_ext/kernel_warn.rb
@@ -4,7 +4,7 @@
 if RUBY_VERSION >= "2.5"
 
   module Kernel
-    path = "#{__dir__}/" # Frames to be skipped start with this path.
+    rubygems_path = "#{__dir__}/" # Frames to be skipped start with this path.
 
     original_warn = method(:warn)
 
@@ -40,7 +40,8 @@ if RUBY_VERSION >= "2.5"
 
           start += 1
 
-          unless loc.path.start_with?(path)
+          path = loc.path
+          unless path.start_with?(rubygems_path) or path.start_with?('<internal:')
             # Non-rubygems frames
             uplevel -= 1
           end


### PR DESCRIPTION
* Fixes https://github.com/oracle/truffleruby/issues/2046
* `<internal:` is a common prefix also used by core Ruby files in CRuby.
* test_no_kernel_require_in_*warn_with_uplevel already test this.
* Unfortunately just skipping `<internal:` in the Ruby implementation
  is not enough, because RubyGems' #warn would not skip the
  `<internal:` require (TruffleRuby defines #require in Ruby),
  and the Ruby implementation's #warn would not skip
  RubyGems's #require. The #caller_locations(0) look like this:

  ```
  warnee.rb:1:in `<top (required)>' # where #warn is called
  <internal:core> core/kernel.rb:234:in `gem_original_require' # not skipped by RubyGems' warn, skipped by the Ruby impl
  rubygems/core_ext/kernel_require.rb:54:in `require' # not skipped by the Ruby impl's warn, what would be shown without this fix
  warn.rb:1:in `<main>' # what would be correct

  warn.rb is
  require "warnee"
  warnee.rb is
  puts caller_locations(0), nil
  warn "oops", uplevel: 1
  ```

cc @deivid-rodriguez 