### PR TITLE
Don't format executables on `gem update --system`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -100,7 +100,7 @@ end
 
 desc "Install rubygems to local system"
 task :install => [:clear_package, :package] do
-  sh "ruby -Ilib bin/gem install --no-document pkg/rubygems-update-#{v}.gem && update_rubygems --no-document --no-format-executable"
+  sh "ruby -Ilib bin/gem install --no-document pkg/rubygems-update-#{v}.gem && update_rubygems --no-document"
 end
 
 desc "Clears previously built package"

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -15,7 +15,7 @@ class Gem::Commands::SetupCommand < Gem::Command
     require 'tmpdir'
 
     super 'setup', 'Install RubyGems',
-          :format_executable => true, :document => %w[ri],
+          :format_executable => false, :document => %w[ri],
           :force => true,
           :site_or_vendor => 'sitelibdir',
           :destdir => '', :prefix => '', :previous_version => '',


### PR DESCRIPTION
# Description:

This restores 3.0 behaviour and goes back to not formatting executables by default on `gem update --system`. This is friendlier for jruby and doesn't really affect OS packagers. And having changed this is actually a regression because it was never intended.

This is actually already tested by our `install-rubygems.yml` workflow, but we currently include a workaround in our "development `gem update --system` simulator task" to avoid the issue on jruby. This PR also removes the workaround.

Fixes #3564.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
