### PR TITLE
Revert failing on test warnings

### DIFF
--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -292,10 +292,6 @@ class Gem::TestCase < Minitest::Test
   # or <tt>i686-darwin8.10.1</tt> otherwise.
 
   def setup
-    @orig_stderr = $stderr.dup
-    @captured_stderr = Tempfile.new("captured_stderr")
-    $stderr.reopen @captured_stderr
-
     @orig_env = ENV.to_hash
     @tmp = File.expand_path("tmp")
 
@@ -469,16 +465,6 @@ class Gem::TestCase < Minitest::Test
     end
 
     @back_ui.close
-
-    $stderr.rewind
-    err = @captured_stderr.read
-    assert_empty err
-  ensure
-    @captured_stderr.unlink
-
-    $stderr.reopen @orig_stderr
-    @orig_stderr.close
-    @captured_stderr.close
   end
 
   def credential_setup


### PR DESCRIPTION
It has failed on Windows and I'm unsure why. See https://github.com/rubygems/rubygems/pull/3811/checks?check_run_id=859385341, which shows the following failure:

```
  1) Failure:
TestGemConfigFile#test_handle_arguments_debug [D:/a/rubygems/rubygems/lib/rubygems/test_case.rb:475]:
Expected "removing C:/Users/RUNNER~1/AppData/Local/Temp/captured_stderr20200710-2340-1d4by0w...\n" +
"done\n" to be empty.
```

The check seems brittle anyways since it could potentially fail because of warnings outside of our control.

So, revert commit 694e6afee769ffb3168a564ee7d315af2a934993.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).