### PR TITLE
Use workflow file name for checking status

### DIFF
--- a/.github/workflows/daily-bundler.yml
+++ b/.github/workflows/daily-bundler.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Get previous status
         if: always()
-        run: echo "::set-env name=OLD_STATUS::$(curl -sS 'https://api.github.com/repos/rubygems/rubygems/actions/workflows/982279/runs?event=schedule&branch=master' | jq '.workflow_runs | .[1].conclusion')"
+        run: echo "::set-env name=OLD_STATUS::$(curl -sS 'https://api.github.com/repos/rubygems/rubygems/actions/workflows/daily-bundler.yml/runs?event=schedule&branch=master' | jq '.workflow_runs | .[1].conclusion')"
 
       - uses: 8398a7/action-slack@v3
         with:

--- a/.github/workflows/daily-rubygems.yml
+++ b/.github/workflows/daily-rubygems.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Get previous status
         if: always()
-        run: echo "::set-env name=OLD_STATUS::$(curl -sS 'https://api.github.com/repos/rubygems/rubygems/actions/workflows/716807/runs?event=schedule&branch=master' | jq '.workflow_runs | .[1].conclusion')"
+        run: echo "::set-env name=OLD_STATUS::$(curl -sS 'https://api.github.com/repos/rubygems/rubygems/actions/workflows/daily-rubygems.yml/runs?event=schedule&branch=master' | jq '.workflow_runs | .[1].conclusion')"
 
       - uses: 8398a7/action-slack@v3
         with:


### PR DESCRIPTION
# Description:

We renamed one of these workflows, and daily notifications started having false positives, because when you rename a workflow, its id changes.

By using the workflow name, we both fix this problem and remove those ugly magic numbers from the configuration.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).