### PR TITLE
Pass more information when comparing platforms

### DIFF
--- a/bundler/lib/bundler/index.rb
+++ b/bundler/lib/bundler/index.rb
@@ -195,7 +195,11 @@ module Bundler
           if base # allow all platforms when searching from a lockfile
             dependency.matches_spec?(spec)
           else
-            dependency.matches_spec?(spec) && Gem::Platform.match_spec?(spec)
+            if Gem::Platform.respond_to? :match_spec?
+              dependency.matches_spec?(spec) && Gem::Platform.match_spec?(spec)
+            else
+              dependency.matches_spec?(spec) && Gem::Platform.match(spec.platform)
+            end
           end
         end
 

--- a/bundler/lib/bundler/index.rb
+++ b/bundler/lib/bundler/index.rb
@@ -195,7 +195,7 @@ module Bundler
           if base # allow all platforms when searching from a lockfile
             dependency.matches_spec?(spec)
           else
-            dependency.matches_spec?(spec) && Gem::Platform.match(spec.platform)
+            dependency.matches_spec?(spec) && Gem::Platform.match_spec?(spec)
           end
         end
 

--- a/lib/rubygems/available_set.rb
+++ b/lib/rubygems/available_set.rb
@@ -73,7 +73,7 @@ class Gem::AvailableSet
   end
 
   def match_platform!
-    @set.reject! {|t| !Gem::Platform.match(t.spec.platform) }
+    @set.reject! {|t| !Gem::Platform.match_spec?(t.spec) }
     @sorted = nil
     self
   end

--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -281,7 +281,7 @@ class Gem::Dependency
 
     if platform_only
       matches.reject! do |spec|
-        spec.nil? || !Gem::Platform.match(spec.platform)
+        spec.nil? || !Gem::Platform.match_spec?(spec)
       end
     end
 

--- a/lib/rubygems/name_tuple.rb
+++ b/lib/rubygems/name_tuple.rb
@@ -59,7 +59,7 @@ class Gem::NameTuple
   # Indicate if this NameTuple matches the current platform.
 
   def match_platform?
-    Gem::Platform.match @platform
+    Gem::Platform.match_gem? @platform, @name
   end
 
   ##

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -18,18 +18,38 @@ class Gem::Platform
   end
 
   def self.match(platform)
-    Gem.platforms.any? do |local_platform|
+    match_platforms?(platform, Gem.platforms)
+  end
+
+  class << self
+    extend Gem::Deprecate
+    rubygems_deprecate :match, "Gem::Platform.match_spec?"
+  end
+
+  def self.match_platforms?(platform, platforms)
+    platforms.any? do |local_platform|
       platform.nil? or
         local_platform == platform or
         (local_platform != Gem::Platform::RUBY and local_platform =~ platform)
     end
+  end
+  private_class_method :match_platforms?
+
+  def self.match_spec?(spec)
+    match_gem?(spec.platform, spec.name)
+  end
+
+  def self.match_gem?(platform, gem_name)
+    # Note: this method might be redefined by Ruby implementations to
+    # customize behavior per RUBY_ENGINE, gem_name or other criteria.
+    match_platforms?(platform, Gem.platforms)
   end
 
   def self.installable?(spec)
     if spec.respond_to? :installable_platform?
       spec.installable_platform?
     else
-      match spec.platform
+      match_spec? spec
     end
   end
 

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -9,11 +9,7 @@ require "rubygems/deprecate"
 class Gem::Platform
   @local = nil
 
-  attr_accessor :cpu
-
-  attr_accessor :os
-
-  attr_accessor :version
+  attr_accessor :cpu, :os, :version
 
   def self.local
     arch = RbConfig::CONFIG['arch']

--- a/lib/rubygems/request_set/gem_dependency_api.rb
+++ b/lib/rubygems/request_set/gem_dependency_api.rb
@@ -379,7 +379,7 @@ class Gem::RequestSet::GemDependencyAPI
         Gem::Requirement.create requirements
       end
 
-    return unless gem_platforms options
+    return unless gem_platforms name, options
 
     groups = gem_group name, options
 
@@ -532,7 +532,7 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
   # Handles the platforms: option from +options+.  Returns true if the
   # platform matches the current platform.
 
-  def gem_platforms(options) # :nodoc:
+  def gem_platforms(name, options) # :nodoc:
     platform_names = Array(options.delete :platform)
     platform_names.concat Array(options.delete :platforms)
     platform_names.concat @current_platforms if @current_platforms
@@ -543,7 +543,7 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
       raise ArgumentError, "unknown platform #{platform_name.inspect}" unless
         platform = PLATFORM_MAP[platform_name]
 
-      next false unless Gem::Platform.match platform
+      next false unless Gem::Platform.match_gem? platform, name
 
       if engines = ENGINE_MAP[platform_name]
         next false unless engines.include? Gem.ruby_engine

--- a/lib/rubygems/resolver/api_specification.rb
+++ b/lib/rubygems/resolver/api_specification.rb
@@ -42,7 +42,7 @@ class Gem::Resolver::APISpecification < Gem::Resolver::Specification
   end
 
   def installable_platform? # :nodoc:
-    Gem::Platform.match @platform
+    Gem::Platform.match_gem? @platform, @name
   end
 
   def pretty_print(q) # :nodoc:

--- a/lib/rubygems/resolver/specification.rb
+++ b/lib/rubygems/resolver/specification.rb
@@ -104,7 +104,7 @@ class Gem::Resolver::Specification
   # Returns true if this specification is installable on this platform.
 
   def installable_platform?
-    Gem::Platform.match spec.platform
+    Gem::Platform.match_spec? spec
   end
 
   def local? # :nodoc:

--- a/lib/rubygems/spec_fetcher.rb
+++ b/lib/rubygems/spec_fetcher.rb
@@ -98,7 +98,7 @@ class Gem::SpecFetcher
 
       found[source] = specs.select do |tup|
         if dependency.match?(tup)
-          if matching_platform and !Gem::Platform.match(tup.platform)
+          if matching_platform and !Gem::Platform.match_gem?(tup.platform, tup.name)
             pm = (
               rejected_specs[dependency] ||= \
                 Gem::PlatformMismatch.new(tup.name, tup.version))

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -804,7 +804,7 @@ class Gem::Specification < Gem::BasicSpecification
       stubs = stubs.uniq {|stub| stub.full_name }
 
       _resort!(stubs)
-      @@stubs_by_name = stubs.select {|s| Gem::Platform.match s.platform }.group_by(&:name)
+      @@stubs_by_name = stubs.select {|s| Gem::Platform.match_spec? s }.group_by(&:name)
       stubs
     end
   end
@@ -831,7 +831,7 @@ class Gem::Specification < Gem::BasicSpecification
       @@stubs_by_name[name]
     else
       pattern = "#{name}-*.gemspec"
-      stubs = installed_stubs(dirs, pattern).select {|s| Gem::Platform.match s.platform } + default_stubs(pattern)
+      stubs = installed_stubs(dirs, pattern).select {|s| Gem::Platform.match_spec? s } + default_stubs(pattern)
       stubs = stubs.uniq {|stub| stub.full_name }.group_by(&:name)
       stubs.each_value {|v| _resort!(v) }
 


### PR DESCRIPTION
* Passing the gem specification enables more flexibility
  when checking whether a gem is compatible
  with the various aspects of the "current platform"
  including OS, architecture, RUBY_ENGINE, etc.
* Relates to https://github.com/rubygems/rubygems/issues/2945
* Based on https://github.com/oracle/truffleruby/commit/ae83667c220f52cbea4e83c44d2b9f7027688a3a

## What was the end-user or developer problem that led to this PR?

As mentioned in #2945 and in other issues (notably about including the libc in the "platform"), the current Gem::Platform captures too little and is sometimes not enough to check if a precompiled extension is actually compatible with the local machine installing the gem.

One example is the `sassc` and `libv8` gems both have extensions which do not use the Ruby C API and are therefore independent of the Ruby implementation. So such precompiled "extensions" for such gems can be reused on TruffleRuby, JRuby, etc, while typical precompiled C extensions cannot due to having a different ABI.

Also consider that while `sassc` can be compiled from source, it's "just" rather slow.
But for `libv8` it's both hard to build (needs dependencies typically not installed by Rubyists) and it takes >15 minutes to compile (https://github.com/oracle/truffleruby/issues/1827#issuecomment-607386676).

## What is your fix for the problem, implemented in this PR?

This PR makes a step forwards by giving more information and therefore flexibility when checking whether a Gem's platform is compatible with the local machine.

______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
