### PR TITLE
Let more exceptions flow

### DIFF
--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -674,10 +674,9 @@ EOM
     when 'data.tar.gz' then
       verify_gz entry
     end
-  rescue => e
-    message = "package is corrupt, exception while verifying: " +
-              "#{e.message} (#{e.class})"
-    raise Gem::Package::FormatError.new message, @gem
+  rescue
+    warn "Exception while verifying #{@gem.path}"
+    raise
   end
 
   ##

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -1069,11 +1069,22 @@ class TestGemPackage < Gem::Package::TarTestCase
 
     package = Gem::Package.new @gem
 
-    e = assert_raises Gem::Package::FormatError do
-      package.verify_entry entry
+    _, err = use_ui @ui do
+      e = nil
+
+      out_err = capture_io do
+        e = assert_raises ArgumentError do
+          package.verify_entry entry
+        end
+      end
+
+      assert_equal "whatever", e.message
+      assert_equal "full_name", e.backtrace_locations.first.label
+
+      out_err
     end
 
-    assert_equal "package is corrupt, exception while verifying: whatever (ArgumentError) in #{@gem}", e.message
+    assert_equal "Exception while verifying #{@gem}\n", err
 
     valid_metadata = ["metadata", "metadata.gz"]
     valid_metadata.each do |vm|


### PR DESCRIPTION
# Description:

If any error happens while verifying a package entry, it doesn't mean
that the package is corrupt. It could be a bug in rubygems, for example.
This in fact happened in CI and the current error doesn't make it easy
to troubleshoot the root cause, since it doesn't provide a backtrace.

See
https://github.com/rubygems/rubygems/pull/3807/checks?check_run_id=862526615.

So I propose to let the exception happens. There was something useful
about the previous message, which is the file entry where the error
happened, so I'm keeping that information in a warning message.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).