### PR TITLE
Rubocop normalization

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -108,6 +108,9 @@ Style/Encoding:
   Exclude:
     - test/rubygems/specifications/foo-0.0.1-x86-mswin32.gemspec
 
+Style/IfInsideElse:
+  Enabled: false
+
 Style/MethodCallWithoutArgsParentheses:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,7 +43,6 @@ Layout/EmptyLines:
 
 Layout/EmptyLinesAroundClassBody:
   Enabled: true
-  EnforcedStyle: empty_lines_except_namespace
 
 Layout/EmptyLinesAroundMethodBody:
   Enabled: true

--- a/.rubocop_bundler.yml
+++ b/.rubocop_bundler.yml
@@ -597,7 +597,7 @@ Style/IdenticalConditionalBranches:
   Enabled: true
 
 Style/IfInsideElse:
-  Enabled: true
+  Enabled: false
 
 Style/IfUnlessModifierOfIfUnless:
   Enabled: true

--- a/Rakefile
+++ b/Rakefile
@@ -383,7 +383,6 @@ end
 
 module Rubygems
   class ProjectFiles
-
     def self.all
       files = []
       exclude = %r{\A(?:\.|dev_gems|bundler/(?!lib|man|exe|[^/]+\.md|bundler.gemspec)|util/)}
@@ -397,7 +396,6 @@ module Rubygems
 
       files.sort
     end
-
   end
 end
 

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1185,7 +1185,6 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   # methods, and then we switch over to `class << self` here. Pick one or the
   # other.
   class << self
-
     ##
     # RubyGems distributors (like operating system package managers) can
     # disable RubyGems update by setting this to error message printed to
@@ -1308,7 +1307,6 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     def default_gem_load_paths
       @default_gem_load_paths ||= $LOAD_PATH[load_path_insert_index..-1]
     end
-
   end
 
   ##

--- a/lib/rubygems/available_set.rb
+++ b/lib/rubygems/available_set.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 class Gem::AvailableSet
-
   include Enumerable
 
   Tuple = Struct.new(:spec, :source)
@@ -162,5 +161,4 @@ class Gem::AvailableSet
   def inject_into_list(dep_list)
     @set.each {|t| dep_list.add t.spec }
   end
-
 end

--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -4,7 +4,6 @@
 # used by both Specification and StubSpecification.
 
 class Gem::BasicSpecification
-
   ##
   # Allows installation of extensions for git: gems.
 
@@ -39,10 +38,8 @@ class Gem::BasicSpecification
   end
 
   class << self
-
     extend Gem::Deprecate
     rubygems_deprecate :default_specifications_dir, "Gem.default_specifications_dir"
-
   end
 
   ##
@@ -345,5 +342,4 @@ class Gem::BasicSpecification
       false
     end
   end
-
 end

--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -17,7 +17,6 @@ require_relative 'user_interaction'
 # A very good example to look at is Gem::Commands::ContentsCommand
 
 class Gem::Command
-
   include Gem::UserInteraction
 
   OptionParser.accept Symbol do |value|
@@ -652,7 +651,6 @@ RubyGems is a package manager for Ruby.
   HELP
 
   # :startdoc:
-
 end
 
 ##

--- a/lib/rubygems/command_manager.rb
+++ b/lib/rubygems/command_manager.rb
@@ -32,7 +32,6 @@ require 'rubygems/text'
 # See Gem::Command for instructions on writing gem commands.
 
 class Gem::CommandManager
-
   include Gem::Text
   include Gem::UserInteraction
 
@@ -231,5 +230,4 @@ class Gem::CommandManager
       ui.backtrace e
     end
   end
-
 end

--- a/lib/rubygems/commands/build_command.rb
+++ b/lib/rubygems/commands/build_command.rb
@@ -3,7 +3,6 @@ require 'rubygems/command'
 require 'rubygems/package'
 
 class Gem::Commands::BuildCommand < Gem::Command
-
   def initialize
     super 'build', 'Build a gem from a gemspec'
 
@@ -108,5 +107,4 @@ Gems can be saved to a specified filename with the output option:
       terminate_interaction 1
     end
   end
-
 end

--- a/lib/rubygems/commands/cert_command.rb
+++ b/lib/rubygems/commands/cert_command.rb
@@ -9,7 +9,6 @@ rescue LoadError => e
 end
 
 class Gem::Commands::CertCommand < Gem::Command
-
   def initialize
     super 'cert', 'Manage RubyGems certificates and signing settings',
           :add => [], :remove => [], :list => [], :build => [], :sign => []
@@ -318,5 +317,4 @@ For further reading on signing gems see `ri Gem::Security`.
     # It's simple, but is all we need
     email =~ /\A.+@.+\z/
   end
-
 end if defined?(OpenSSL::SSL)

--- a/lib/rubygems/commands/check_command.rb
+++ b/lib/rubygems/commands/check_command.rb
@@ -5,7 +5,6 @@ require 'rubygems/validator'
 require 'rubygems/doctor'
 
 class Gem::Commands::CheckCommand < Gem::Command
-
   include Gem::VersionOption
 
   def initialize
@@ -90,5 +89,4 @@ specifications and will clean up gems that have been partially uninstalled.
   def usage # :nodoc:
     "#{program_name} [OPTIONS] [GEMNAME ...]"
   end
-
 end

--- a/lib/rubygems/commands/cleanup_command.rb
+++ b/lib/rubygems/commands/cleanup_command.rb
@@ -4,7 +4,6 @@ require 'rubygems/dependency_list'
 require 'rubygems/uninstaller'
 
 class Gem::Commands::CleanupCommand < Gem::Command
-
   def initialize
     super 'cleanup',
           'Clean up old versions of installed gems',
@@ -181,5 +180,4 @@ If no gems are named all gems in GEM_HOME are cleaned.
     # Restore path Gem::Uninstaller may have changed
     Gem.use_paths @original_home, *@original_path
   end
-
 end

--- a/lib/rubygems/commands/contents_command.rb
+++ b/lib/rubygems/commands/contents_command.rb
@@ -3,7 +3,6 @@ require 'rubygems/command'
 require 'rubygems/version_option'
 
 class Gem::Commands::ContentsCommand < Gem::Command
-
   include Gem::VersionOption
 
   def initialize
@@ -186,5 +185,4 @@ prefix or only the files that are requireable.
       [i, File.join(i, "specifications")]
     end.flatten
   end
-
 end

--- a/lib/rubygems/commands/dependency_command.rb
+++ b/lib/rubygems/commands/dependency_command.rb
@@ -4,7 +4,6 @@ require 'rubygems/local_remote_options'
 require 'rubygems/version_option'
 
 class Gem::Commands::DependencyCommand < Gem::Command
-
   include Gem::LocalRemoteOptions
   include Gem::VersionOption
 
@@ -215,5 +214,4 @@ use with other commands.
       /\A#{Regexp.union(*args)}/
     end
   end
-
 end

--- a/lib/rubygems/commands/environment_command.rb
+++ b/lib/rubygems/commands/environment_command.rb
@@ -2,7 +2,6 @@
 require 'rubygems/command'
 
 class Gem::Commands::EnvironmentCommand < Gem::Command
-
   def initialize
     super 'environment', 'Display information about the RubyGems environment'
   end
@@ -172,5 +171,4 @@ lib/rubygems/defaults/operating_system.rb
 
     return nil
   end
-
 end

--- a/lib/rubygems/commands/fetch_command.rb
+++ b/lib/rubygems/commands/fetch_command.rb
@@ -4,7 +4,6 @@ require 'rubygems/local_remote_options'
 require 'rubygems/version_option'
 
 class Gem::Commands::FetchCommand < Gem::Command
-
   include Gem::LocalRemoteOptions
   include Gem::VersionOption
 
@@ -73,5 +72,4 @@ then repackaging it.
       say "Downloaded #{spec.full_name}"
     end
   end
-
 end

--- a/lib/rubygems/commands/generate_index_command.rb
+++ b/lib/rubygems/commands/generate_index_command.rb
@@ -8,7 +8,6 @@ require 'rubygems/indexer'
 # See `gem help generate_index`
 
 class Gem::Commands::GenerateIndexCommand < Gem::Command
-
   def initialize
     super 'generate_index',
           'Generates the index files for a gem server directory',
@@ -83,5 +82,4 @@ Marshal::MINOR_VERSION constants.  It is used to ensure compatibility.
       end
     end
   end
-
 end

--- a/lib/rubygems/commands/help_command.rb
+++ b/lib/rubygems/commands/help_command.rb
@@ -2,7 +2,6 @@
 require 'rubygems/command'
 
 class Gem::Commands::HelpCommand < Gem::Command
-
   # :stopdoc:
   EXAMPLES = <<-EOF.freeze
 Some examples of 'gem' usage.
@@ -370,5 +369,4 @@ platform.
       alert_warning "Unknown command #{command_name}. Try: gem help commands"
     end
   end
-
 end

--- a/lib/rubygems/commands/info_command.rb
+++ b/lib/rubygems/commands/info_command.rb
@@ -4,7 +4,6 @@ require 'rubygems/command'
 require 'rubygems/query_utils'
 
 class Gem::Commands::InfoCommand < Gem::Command
-
   include Gem::QueryUtils
 
   def initialize
@@ -36,5 +35,4 @@ class Gem::Commands::InfoCommand < Gem::Command
   def defaults_str
     "--local"
   end
-
 end

--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -12,7 +12,6 @@ require 'rubygems/version_option'
 # See `gem help install`
 
 class Gem::Commands::InstallCommand < Gem::Command
-
   attr_reader :installed_specs # :nodoc:
 
   include Gem::VersionOption
@@ -270,5 +269,4 @@ You can use `i` command instead of `install`.
     gems = @installed_specs.length == 1 ? 'gem' : 'gems'
     say "#{@installed_specs.length} #{gems} installed"
   end
-
 end

--- a/lib/rubygems/commands/list_command.rb
+++ b/lib/rubygems/commands/list_command.rb
@@ -6,7 +6,6 @@ require 'rubygems/query_utils'
 # Searches for gems starting with the supplied argument.
 
 class Gem::Commands::ListCommand < Gem::Command
-
   include Gem::QueryUtils
 
   def initialize
@@ -39,5 +38,4 @@ To search for remote gems use the search command.
   def usage # :nodoc:
     "#{program_name} [REGEXP ...]"
   end
-
 end

--- a/lib/rubygems/commands/lock_command.rb
+++ b/lib/rubygems/commands/lock_command.rb
@@ -2,7 +2,6 @@
 require 'rubygems/command'
 
 class Gem::Commands::LockCommand < Gem::Command
-
   def initialize
     super 'lock', 'Generate a lockdown list of gems',
           :strict => false
@@ -106,5 +105,4 @@ lock it down to the exact version.
 
     gemspecs.find {|path| File.exist? path }
   end
-
 end

--- a/lib/rubygems/commands/mirror_command.rb
+++ b/lib/rubygems/commands/mirror_command.rb
@@ -3,7 +3,6 @@ require 'rubygems/command'
 
 unless defined? Gem::Commands::MirrorCommand
   class Gem::Commands::MirrorCommand < Gem::Command
-
     def initialize
       super('mirror', 'Mirror all gem files (requires rubygems-mirror)')
       begin
@@ -22,6 +21,5 @@ The mirror command has been moved to the rubygems-mirror gem.
     def execute
       alert_error "Install the rubygems-mirror gem for the mirror command"
     end
-
   end
 end

--- a/lib/rubygems/commands/open_command.rb
+++ b/lib/rubygems/commands/open_command.rb
@@ -3,7 +3,6 @@ require 'rubygems/command'
 require 'rubygems/version_option'
 
 class Gem::Commands::OpenCommand < Gem::Command
-
   include Gem::VersionOption
 
   def initialize
@@ -82,5 +81,4 @@ class Gem::Commands::OpenCommand < Gem::Command
 
     say "Unable to find gem '#{name}'"
   end
-
 end

--- a/lib/rubygems/commands/outdated_command.rb
+++ b/lib/rubygems/commands/outdated_command.rb
@@ -5,7 +5,6 @@ require 'rubygems/spec_fetcher'
 require 'rubygems/version_option'
 
 class Gem::Commands::OutdatedCommand < Gem::Command
-
   include Gem::LocalRemoteOptions
   include Gem::VersionOption
 
@@ -30,5 +29,4 @@ update the gems with the update or install commands.
       say "#{spec.name} (#{spec.version} < #{remote_version})"
     end
   end
-
 end

--- a/lib/rubygems/commands/owner_command.rb
+++ b/lib/rubygems/commands/owner_command.rb
@@ -5,7 +5,6 @@ require 'rubygems/gemcutter_utilities'
 require 'rubygems/text'
 
 class Gem::Commands::OwnerCommand < Gem::Command
-
   include Gem::Text
   include Gem::LocalRemoteOptions
   include Gem::GemcutterUtilities
@@ -109,5 +108,4 @@ permission to.
       request.add_field "OTP", options[:otp] if options[:otp]
     end
   end
-
 end

--- a/lib/rubygems/commands/pristine_command.rb
+++ b/lib/rubygems/commands/pristine_command.rb
@@ -5,7 +5,6 @@ require 'rubygems/installer'
 require 'rubygems/version_option'
 
 class Gem::Commands::PristineCommand < Gem::Command
-
   include Gem::VersionOption
 
   def initialize
@@ -188,5 +187,4 @@ extensions will be restored.
       say "Restored #{spec.full_name}"
     end
   end
-
 end

--- a/lib/rubygems/commands/push_command.rb
+++ b/lib/rubygems/commands/push_command.rb
@@ -5,7 +5,6 @@ require 'rubygems/gemcutter_utilities'
 require 'rubygems/package'
 
 class Gem::Commands::PushCommand < Gem::Command
-
   include Gem::LocalRemoteOptions
   include Gem::GemcutterUtilities
 
@@ -104,5 +103,4 @@ The push command will use ~/.gem/credentials to authenticate to a server, but yo
       gem_metadata["allowed_push_host"]
     ]
   end
-
 end

--- a/lib/rubygems/commands/query_command.rb
+++ b/lib/rubygems/commands/query_command.rb
@@ -4,7 +4,6 @@ require 'rubygems/query_utils'
 require 'rubygems/deprecate'
 
 class Gem::Commands::QueryCommand < Gem::Command
-
   extend Gem::Deprecate
   rubygems_deprecate_command
 
@@ -24,5 +23,4 @@ class Gem::Commands::QueryCommand < Gem::Command
 
     add_query_options
   end
-
 end

--- a/lib/rubygems/commands/rdoc_command.rb
+++ b/lib/rubygems/commands/rdoc_command.rb
@@ -5,7 +5,6 @@ require 'rubygems/rdoc'
 require 'fileutils'
 
 class Gem::Commands::RdocCommand < Gem::Command
-
   include Gem::VersionOption
 
   def initialize
@@ -93,5 +92,4 @@ Use --overwrite to force rebuilding of documentation.
       end
     end
   end
-
 end

--- a/lib/rubygems/commands/search_command.rb
+++ b/lib/rubygems/commands/search_command.rb
@@ -3,7 +3,6 @@ require 'rubygems/command'
 require 'rubygems/query_utils'
 
 class Gem::Commands::SearchCommand < Gem::Command
-
   include Gem::QueryUtils
 
   def initialize
@@ -38,5 +37,4 @@ To list local gems use the list command.
   def usage # :nodoc:
     "#{program_name} [REGEXP]"
   end
-
 end

--- a/lib/rubygems/commands/server_command.rb
+++ b/lib/rubygems/commands/server_command.rb
@@ -3,7 +3,6 @@ require 'rubygems/command'
 require 'rubygems/server'
 
 class Gem::Commands::ServerCommand < Gem::Command
-
   def initialize
     super 'server', 'Documentation and gem repository HTTP server',
           :port => 8808, :gemdir => [], :daemon => false
@@ -82,5 +81,4 @@ You can set up a shortcut to gem server documentation using the URL:
     options[:gemdir] = Gem.path if options[:gemdir].empty?
     Gem::Server.run options
   end
-
 end

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -6,7 +6,6 @@ require 'rubygems/command'
 # RubyGems checkout or tarball.
 
 class Gem::Commands::SetupCommand < Gem::Command
-
   HISTORY_HEADER = /^===\s*[\d.a-zA-Z]+\s*\/\s*\d{4}-\d{2}-\d{2}\s*$/.freeze
   VERSION_MATCHER = /^===\s*([\d.a-zA-Z]+)\s*\/\s*\d{4}-\d{2}-\d{2}\s*$/.freeze
 
@@ -736,5 +735,4 @@ abort "#{deprecation_message}"
   def bin_file_names
     @bin_file_names ||= []
   end
-
 end

--- a/lib/rubygems/commands/signin_command.rb
+++ b/lib/rubygems/commands/signin_command.rb
@@ -3,7 +3,6 @@ require 'rubygems/command'
 require 'rubygems/gemcutter_utilities'
 
 class Gem::Commands::SigninCommand < Gem::Command
-
   include Gem::GemcutterUtilities
 
   def initialize
@@ -31,5 +30,4 @@ class Gem::Commands::SigninCommand < Gem::Command
   def execute
     sign_in options[:host]
   end
-
 end

--- a/lib/rubygems/commands/signout_command.rb
+++ b/lib/rubygems/commands/signout_command.rb
@@ -2,7 +2,6 @@
 require 'rubygems/command'
 
 class Gem::Commands::SignoutCommand < Gem::Command
-
   def initialize
     super 'signout', 'Sign out from all the current sessions.'
   end
@@ -29,5 +28,4 @@ class Gem::Commands::SignoutCommand < Gem::Command
       say 'You have successfully signed out from all sessions.'
     end
   end
-
 end

--- a/lib/rubygems/commands/sources_command.rb
+++ b/lib/rubygems/commands/sources_command.rb
@@ -5,7 +5,6 @@ require 'rubygems/spec_fetcher'
 require 'rubygems/local_remote_options'
 
 class Gem::Commands::SourcesCommand < Gem::Command
-
   include Gem::LocalRemoteOptions
 
   def initialize
@@ -220,5 +219,4 @@ To remove a source use the --remove argument:
       say "*** Unable to remove #{desc} source cache ***"
     end
   end
-
 end

--- a/lib/rubygems/commands/specification_command.rb
+++ b/lib/rubygems/commands/specification_command.rb
@@ -5,7 +5,6 @@ require 'rubygems/version_option'
 require 'rubygems/package'
 
 class Gem::Commands::SpecificationCommand < Gem::Command
-
   include Gem::LocalRemoteOptions
   include Gem::VersionOption
 
@@ -143,5 +142,4 @@ Specific fields in the specification can be extracted in YAML format:
       say "\n"
     end
   end
-
 end

--- a/lib/rubygems/commands/stale_command.rb
+++ b/lib/rubygems/commands/stale_command.rb
@@ -2,7 +2,6 @@
 require 'rubygems/command'
 
 class Gem::Commands::StaleCommand < Gem::Command
-
   def initialize
     super('stale', 'List gems along with access times')
   end
@@ -37,5 +36,4 @@ longer using.
       say "#{name} at #{atime.strftime '%c'}"
     end
   end
-
 end

--- a/lib/rubygems/commands/uninstall_command.rb
+++ b/lib/rubygems/commands/uninstall_command.rb
@@ -10,7 +10,6 @@ require 'fileutils'
 # See `gem help uninstall`
 
 class Gem::Commands::UninstallCommand < Gem::Command
-
   include Gem::VersionOption
 
   def initialize
@@ -195,5 +194,4 @@ that is a dependency of an existing gem.  You can use the
   def uninstall(gem_name)
     Gem::Uninstaller.new(gem_name, options).uninstall
   end
-
 end

--- a/lib/rubygems/commands/unpack_command.rb
+++ b/lib/rubygems/commands/unpack_command.rb
@@ -13,7 +13,6 @@ module Gem::Security # :nodoc:
 end
 
 class Gem::Commands::UnpackCommand < Gem::Command
-
   include Gem::VersionOption
   include Gem::SecurityOption
 
@@ -173,5 +172,4 @@ command help for an example.
 
     path
   end
-
 end

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -10,7 +10,6 @@ require 'rubygems/install_message' # must come before rdoc for messaging
 require 'rubygems/rdoc'
 
 class Gem::Commands::UpdateCommand < Gem::Command
-
   include Gem::InstallUpdateOptions
   include Gem::LocalRemoteOptions
   include Gem::VersionOption
@@ -310,5 +309,4 @@ command to remove old versions.
 
     result
   end
-
 end

--- a/lib/rubygems/commands/which_command.rb
+++ b/lib/rubygems/commands/which_command.rb
@@ -2,7 +2,6 @@
 require 'rubygems/command'
 
 class Gem::Commands::WhichCommand < Gem::Command
-
   def initialize
     super 'which', 'Find the location of a library file you can require',
           :search_gems_first => false, :show_all => false
@@ -85,5 +84,4 @@ requiring to see why it does not behave as you expect.
   def usage # :nodoc:
     "#{program_name} FILE [FILE ...]"
   end
-
 end

--- a/lib/rubygems/commands/yank_command.rb
+++ b/lib/rubygems/commands/yank_command.rb
@@ -5,7 +5,6 @@ require 'rubygems/version_option'
 require 'rubygems/gemcutter_utilities'
 
 class Gem::Commands::YankCommand < Gem::Command
-
   include Gem::LocalRemoteOptions
   include Gem::VersionOption
   include Gem::GemcutterUtilities
@@ -97,5 +96,4 @@ data you will need to change them immediately and yank your gem.
   def get_platform_from_requirements(requirements)
     Gem.platforms[1].to_s if requirements.key? :added_platform
   end
-
 end

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -37,7 +37,6 @@ require 'rbconfig'
 # - per environment (gemrc files listed in the GEMRC environment variable)
 
 class Gem::ConfigFile
-
   include Gem::UserInteraction
 
   DEFAULT_BACKTRACE = false
@@ -497,5 +496,4 @@ if you believe they were disclosed to a third party.
       end
     end
   end
-
 end

--- a/lib/rubygems/core_ext/kernel_warn.rb
+++ b/lib/rubygems/core_ext/kernel_warn.rb
@@ -11,9 +11,7 @@ if RUBY_VERSION >= "2.5"
     remove_method :warn
 
     class << self
-
       remove_method :warn
-
     end
 
     module_function define_method(:warn) {|*messages, **kw|

--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -3,7 +3,6 @@
 # The Dependency class holds a Gem name and a Gem::Requirement.
 
 class Gem::Dependency
-
   ##
   # Valid dependency types.
   #--
@@ -344,5 +343,4 @@ class Gem::Dependency
       :released
     end
   end
-
 end

--- a/lib/rubygems/dependency_installer.rb
+++ b/lib/rubygems/dependency_installer.rb
@@ -12,7 +12,6 @@ require 'rubygems/deprecate'
 # Installs a gem along with all its dependencies from local and remote gems.
 
 class Gem::DependencyInstaller
-
   include Gem::UserInteraction
   extend Gem::Deprecate
 
@@ -335,5 +334,4 @@ class Gem::DependencyInstaller
 
     request_set
   end
-
 end

--- a/lib/rubygems/dependency_list.rb
+++ b/lib/rubygems/dependency_list.rb
@@ -17,7 +17,6 @@ require 'rubygems/deprecate'
 # this class necessary anymore?  Especially #ok?, #why_not_ok?
 
 class Gem::DependencyList
-
   attr_reader :specs
 
   include Enumerable
@@ -240,5 +239,4 @@ class Gem::DependencyList
   def active_count(specs, ignored)
     specs.count {|spec| ignored[spec.full_name].nil? }
   end
-
 end

--- a/lib/rubygems/doctor.rb
+++ b/lib/rubygems/doctor.rb
@@ -12,7 +12,6 @@ require 'rubygems/user_interaction'
 # removing the bogus specification.
 
 class Gem::Doctor
-
   include Gem::UserInteraction
 
   ##
@@ -129,5 +128,4 @@ class Gem::Doctor
   rescue Errno::ENOENT
     # ignore
   end
-
 end

--- a/lib/rubygems/errors.rb
+++ b/lib/rubygems/errors.rb
@@ -13,13 +13,11 @@ module Gem
   # already activated gems or that RubyGems is otherwise unable to activate.
 
   class LoadError < ::LoadError
-
     # Name of gem
     attr_accessor :name
 
     # Version requirement of gem
     attr_accessor :requirement
-
   end
 
   ##
@@ -27,7 +25,6 @@ module Gem
   # system.  Instead of rescuing from this class, make sure to rescue from the
   # superclass Gem::LoadError to catch all types of load errors.
   class MissingSpecError < Gem::LoadError
-
     def initialize(name, requirement, extra_message=nil)
       @name        = name
       @requirement = requirement
@@ -45,7 +42,6 @@ module Gem
       total = Gem::Specification.stubs.size
       "Could not find '#{name}' (#{requirement}) among #{total} total gem(s)\n"
     end
-
   end
 
   ##
@@ -53,7 +49,6 @@ module Gem
   # not the requested version. Instead of rescuing from this class, make sure to
   # rescue from the superclass Gem::LoadError to catch all types of load errors.
   class MissingSpecVersionError < MissingSpecError
-
     attr_reader :specs
 
     def initialize(name, requirement, specs)
@@ -70,13 +65,11 @@ module Gem
       names = specs.map(&:full_name)
       "Could not find '#{name}' (#{requirement}) - did find: [#{names.join ','}]\n"
     end
-
   end
 
   # Raised when there are conflicting gem specs loaded
 
   class ConflictError < LoadError
-
     ##
     # A Hash mapping conflicting specifications to the dependencies that
     # caused the conflict
@@ -101,7 +94,6 @@ module Gem
 
       super("Unable to activate #{target.full_name}, because #{reason}")
     end
-
   end
 
   class ErrorReason; end
@@ -113,7 +105,6 @@ module Gem
   # in figuring out why a gem couldn't be installed.
   #
   class PlatformMismatch < ErrorReason
-
     ##
     # the name of the gem
     attr_reader :name
@@ -151,7 +142,6 @@ module Gem
          @platforms.size == 1 ? '' : 's',
          @platforms.join(' ,')]
     end
-
   end
 
   ##
@@ -159,7 +149,6 @@ module Gem
   # data from a source
 
   class SourceFetchProblem < ErrorReason
-
     ##
     # Creates a new SourceFetchProblem for the given +source+ and +error+.
 
@@ -190,6 +179,5 @@ module Gem
     # The "exception" alias allows you to call raise on a SourceFetchProblem.
 
     alias exception error
-
   end
 end

--- a/lib/rubygems/exceptions.rb
+++ b/lib/rubygems/exceptions.rb
@@ -19,7 +19,6 @@ class Gem::DependencyRemovalException < Gem::Exception; end
 # and #conflicting_dependencies
 
 class Gem::DependencyResolutionError < Gem::DependencyError
-
   attr_reader :conflict
 
   def initialize(conflict)
@@ -32,25 +31,20 @@ class Gem::DependencyResolutionError < Gem::DependencyError
   def conflicting_dependencies
     @conflict.conflicting_dependencies
   end
-
 end
 
 ##
 # Raised when attempting to uninstall a gem that isn't in GEM_HOME.
 
 class Gem::GemNotInHomeException < Gem::Exception
-
   attr_accessor :spec
-
 end
 
 ###
 # Raised when removing a gem with the uninstall command fails
 
 class Gem::UninstallError < Gem::Exception
-
   attr_accessor :spec
-
 end
 
 class Gem::DocumentError < Gem::Exception; end
@@ -64,7 +58,6 @@ class Gem::EndOfYAMLException < Gem::Exception; end
 # operating on the given directory.
 
 class Gem::FilePermissionError < Gem::Exception
-
   attr_reader :directory
 
   def initialize(directory)
@@ -72,15 +65,12 @@ class Gem::FilePermissionError < Gem::Exception
 
     super "You don't have write permissions for the #{directory} directory."
   end
-
 end
 
 ##
 # Used to raise parsing and loading errors
 class Gem::FormatException < Gem::Exception
-
   attr_accessor :file_path
-
 end
 
 class Gem::GemNotFoundException < Gem::Exception; end
@@ -89,7 +79,6 @@ class Gem::GemNotFoundException < Gem::Exception; end
 # Raised by the DependencyInstaller when a specific gem cannot be found
 
 class Gem::SpecificGemNotFoundException < Gem::GemNotFoundException
-
   ##
   # Creates a new SpecificGemNotFoundException for a gem with the given +name+
   # and +version+.  Any +errors+ encountered when attempting to find the gem
@@ -117,7 +106,6 @@ class Gem::SpecificGemNotFoundException < Gem::GemNotFoundException
   # Errors encountered attempting to find the gem.
 
   attr_reader :errors
-
 end
 
 ##
@@ -125,7 +113,6 @@ end
 # inability to find a valid possible spec for a request.
 
 class Gem::ImpossibleDependenciesError < Gem::Exception
-
   attr_reader :conflicts
   attr_reader :request
 
@@ -153,17 +140,14 @@ class Gem::ImpossibleDependenciesError < Gem::Exception
   def dependency
     @request.dependency
   end
-
 end
 
 class Gem::InstallError < Gem::Exception; end
 class Gem::RuntimeRequirementNotMetError < Gem::InstallError
-
   attr_accessor :suggestion
   def message
     [suggestion, super].compact.join("\n\t")
   end
-
 end
 
 ##
@@ -205,7 +189,6 @@ class Gem::VerificationError < Gem::Exception; end
 # exit_code
 
 class Gem::SystemExitException < SystemExit
-
   ##
   # The exit code for the process
 
@@ -219,7 +202,6 @@ class Gem::SystemExitException < SystemExit
 
     super "Exiting RubyGems with exit_code #{exit_code}"
   end
-
 end
 
 ##
@@ -227,7 +209,6 @@ end
 # there is no spec.
 
 class Gem::UnsatisfiableDependencyError < Gem::DependencyError
-
   ##
   # The unsatisfiable dependency.  This is a
   # Gem::Resolver::DependencyRequest, not a Gem::Dependency
@@ -272,7 +253,6 @@ class Gem::UnsatisfiableDependencyError < Gem::DependencyError
   def version
     @dependency.requirement
   end
-
 end
 
 ##

--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -8,7 +8,6 @@
 require_relative '../user_interaction'
 
 class Gem::Ext::Builder
-
   include Gem::UserInteraction
 
   ##
@@ -227,5 +226,4 @@ EOF
 
     destination
   end
-
 end

--- a/lib/rubygems/ext/cmake_builder.rb
+++ b/lib/rubygems/ext/cmake_builder.rb
@@ -2,7 +2,6 @@
 require_relative '../command'
 
 class Gem::Ext::CmakeBuilder < Gem::Ext::Builder
-
   def self.build(extension, dest_path, results, args=[], lib_dir=nil)
     unless File.exist?('Makefile')
       cmd = "cmake . -DCMAKE_INSTALL_PREFIX=#{dest_path}"
@@ -15,5 +14,4 @@ class Gem::Ext::CmakeBuilder < Gem::Ext::Builder
 
     results
   end
-
 end

--- a/lib/rubygems/ext/configure_builder.rb
+++ b/lib/rubygems/ext/configure_builder.rb
@@ -6,7 +6,6 @@
 #++
 
 class Gem::Ext::ConfigureBuilder < Gem::Ext::Builder
-
   def self.build(extension, dest_path, results, args=[], lib_dir=nil)
     unless File.exist?('Makefile')
       cmd = "sh ./configure --prefix=#{dest_path}"
@@ -19,5 +18,4 @@ class Gem::Ext::ConfigureBuilder < Gem::Ext::Builder
 
     results
   end
-
 end

--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -8,7 +8,6 @@
 require 'shellwords'
 
 class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
-
   def self.build(extension, dest_path, results, args=[], lib_dir=nil)
     require 'fileutils'
     require 'tempfile'
@@ -92,5 +91,4 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
     path[0..Dir.pwd.length - 1] = '.' if path.start_with?(Dir.pwd)
     path
   end
-
 end

--- a/lib/rubygems/ext/rake_builder.rb
+++ b/lib/rubygems/ext/rake_builder.rb
@@ -8,7 +8,6 @@
 require "shellwords"
 
 class Gem::Ext::RakeBuilder < Gem::Ext::Builder
-
   def self.build(extension, dest_path, results, args=[], lib_dir=nil)
     if File.basename(extension) =~ /mkrf_conf/i
       run([Gem.ruby, File.basename(extension), *args], results)
@@ -31,5 +30,4 @@ class Gem::Ext::RakeBuilder < Gem::Ext::Builder
 
     results
   end
-
 end

--- a/lib/rubygems/gem_runner.rb
+++ b/lib/rubygems/gem_runner.rb
@@ -24,7 +24,6 @@ Gem.load_env_plugins rescue nil
 # classes they call directly.
 
 class Gem::GemRunner
-
   def initialize
     @command_manager_class = Gem::CommandManager
     @config_file_class = Gem::ConfigFile
@@ -75,7 +74,6 @@ class Gem::GemRunner
     Gem.use_paths Gem.configuration[:gemhome], Gem.configuration[:gempath]
     Gem::Command.extra_args = Gem.configuration[:gem]
   end
-
 end
 
 Gem.load_plugins

--- a/lib/rubygems/indexer.rb
+++ b/lib/rubygems/indexer.rb
@@ -8,7 +8,6 @@ require 'tmpdir'
 # Top level class for building the gem repository index.
 
 class Gem::Indexer
-
   include Gem::UserInteraction
 
   ##
@@ -424,5 +423,4 @@ class Gem::Indexer
       Marshal.dump specs_index, io
     end
   end
-
 end

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -28,7 +28,6 @@ require 'fileutils'
 # file.  See Gem.pre_install and Gem.post_install for details.
 
 class Gem::Installer
-
   extend Gem::Deprecate
 
   ##
@@ -73,7 +72,6 @@ class Gem::Installer
   @install_lock = Mutex.new
 
   class << self
-
     ##
     # True if we've warned about PATH not including Gem.bindir
 
@@ -98,7 +96,6 @@ class Gem::Installer
     def exec_format
       @exec_format ||= Gem.default_exec_format
     end
-
   end
 
   ##
@@ -111,7 +108,6 @@ class Gem::Installer
   end
 
   class FakePackage
-
     attr_accessor :spec
 
     attr_accessor :dir_mode
@@ -137,7 +133,6 @@ class Gem::Installer
 
     def copy_to(path)
     end
-
   end
 
   ##
@@ -962,5 +957,4 @@ TEXT
 
     raise Gem::FilePermissionError.new(dir) unless File.writable? dir
   end
-
 end

--- a/lib/rubygems/installer_test_case.rb
+++ b/lib/rubygems/installer_test_case.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/installer'
 
 class Gem::Installer
-
   ##
   # Available through requiring rubygems/installer_test_case
 
@@ -58,14 +57,12 @@ class Gem::Installer
   # Available through requiring rubygems/installer_test_case
 
   attr_writer :wrappers
-
 end
 
 ##
 # A test case for Gem::Installer.
 
 class Gem::InstallerTestCase < Gem::TestCase
-
   def setup
     super
 
@@ -246,5 +243,4 @@ class Gem::InstallerTestCase < Gem::TestCase
     end
     @@symlink_supported
   end
-
 end

--- a/lib/rubygems/mock_gem_ui.rb
+++ b/lib/rubygems/mock_gem_ui.rb
@@ -6,27 +6,22 @@ require 'rubygems/user_interaction'
 # retrieval during tests.
 
 class Gem::MockGemUi < Gem::StreamUI
-
   ##
   # Raised when you haven't provided enough input to your MockGemUi
 
   class InputEOFError < RuntimeError
-
     def initialize(question)
       super "Out of input for MockGemUi on #{question.inspect}"
     end
-
   end
 
   class TermError < RuntimeError
-
     attr_reader :exit_code
 
     def initialize(exit_code)
       super
       @exit_code = exit_code
     end
-
   end
   class SystemExitException < RuntimeError; end
 
@@ -87,5 +82,4 @@ class Gem::MockGemUi < Gem::StreamUI
     raise TermError, status if status != 0
     raise SystemExitException
   end
-
 end

--- a/lib/rubygems/name_tuple.rb
+++ b/lib/rubygems/name_tuple.rb
@@ -5,7 +5,6 @@
 # wrap the data returned from the indexes.
 
 class Gem::NameTuple
-
   def initialize(name, version, platform="ruby")
     @name = name
     @version = version
@@ -119,5 +118,4 @@ class Gem::NameTuple
   def hash
     to_a.hash
   end
-
 end

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -47,13 +47,11 @@ require 'rubygems/user_interaction'
 require 'zlib'
 
 class Gem::Package
-
   include Gem::UserInteraction
 
   class Error < Gem::Exception; end
 
   class FormatError < Error
-
     attr_reader :path
 
     def initialize(message, source = nil)
@@ -65,16 +63,13 @@ class Gem::Package
 
       super message
     end
-
   end
 
   class PathError < Error
-
     def initialize(destination, destination_dir)
       super "installing into parent path %s of %s is not allowed" %
               [destination, destination_dir]
     end
-
   end
 
   class NonSeekableIO < Error; end
@@ -711,7 +706,6 @@ EOM
   rescue Zlib::GzipFile::Error => e
     raise Gem::Package::FormatError.new(e.message, entry.full_name)
   end
-
 end
 
 require 'rubygems/package/digest_io'

--- a/lib/rubygems/package/digest_io.rb
+++ b/lib/rubygems/package/digest_io.rb
@@ -3,7 +3,6 @@
 # IO wrapper that creates digests of contents written to the IO it wraps.
 
 class Gem::Package::DigestIO
-
   ##
   # Collected digests for wrapped writes.
   #
@@ -60,5 +59,4 @@ class Gem::Package::DigestIO
 
     result
   end
-
 end

--- a/lib/rubygems/package/file_source.rb
+++ b/lib/rubygems/package/file_source.rb
@@ -7,7 +7,6 @@
 # object to `Gem::Package.new`.
 
 class Gem::Package::FileSource < Gem::Package::Source # :nodoc: all
-
   attr_reader :path
 
   def initialize(path)
@@ -29,5 +28,4 @@ class Gem::Package::FileSource < Gem::Package::Source # :nodoc: all
   def with_read_io(&block)
     File.open path, 'rb', &block
   end
-
 end

--- a/lib/rubygems/package/io_source.rb
+++ b/lib/rubygems/package/io_source.rb
@@ -8,7 +8,6 @@
 # object to `Gem::Package.new`.
 
 class Gem::Package::IOSource < Gem::Package::Source # :nodoc: all
-
   attr_reader :io
 
   def initialize(io)
@@ -41,5 +40,4 @@ class Gem::Package::IOSource < Gem::Package::Source # :nodoc: all
 
   def path
   end
-
 end

--- a/lib/rubygems/package/old.rb
+++ b/lib/rubygems/package/old.rb
@@ -12,7 +12,6 @@
 # Please pretend this doesn't exist.
 
 class Gem::Package::Old < Gem::Package
-
   undef_method :spec=
 
   ##
@@ -166,5 +165,4 @@ class Gem::Package::Old < Gem::Package
 
     true
   end
-
 end

--- a/lib/rubygems/package/tar_header.rb
+++ b/lib/rubygems/package/tar_header.rb
@@ -28,7 +28,6 @@
 # A header for a tar file
 
 class Gem::Package::TarHeader
-
   ##
   # Fields in the tar header
 
@@ -241,5 +240,4 @@ class Gem::Package::TarHeader
   def oct(num, len)
     "%0#{len}o" % num
   end
-
 end

--- a/lib/rubygems/package/tar_reader.rb
+++ b/lib/rubygems/package/tar_reader.rb
@@ -8,7 +8,6 @@
 # TarReader reads tar files and allows iteration over their items
 
 class Gem::Package::TarReader
-
   include Enumerable
 
   ##
@@ -120,7 +119,6 @@ class Gem::Package::TarReader
   ensure
     rewind
   end
-
 end
 
 require 'rubygems/package/tar_reader/entry'

--- a/lib/rubygems/package/tar_reader/entry.rb
+++ b/lib/rubygems/package/tar_reader/entry.rb
@@ -8,7 +8,6 @@
 # Class for reading entries out of a tar file
 
 class Gem::Package::TarReader::Entry
-
   ##
   # Header for this tar entry
 
@@ -165,5 +164,4 @@ class Gem::Package::TarReader::Entry
     @io.pos = @orig_pos
     @read = 0
   end
-
 end

--- a/lib/rubygems/package/tar_test_case.rb
+++ b/lib/rubygems/package/tar_test_case.rb
@@ -6,7 +6,6 @@ require 'rubygems/package'
 # A test case for Gem::Package::Tar* classes
 
 class Gem::Package::TarTestCase < Gem::TestCase
-
   def ASCIIZ(str, length)
     str + "\0" * (length - str.length)
   end
@@ -137,5 +136,4 @@ class Gem::Package::TarTestCase < Gem::TestCase
   def util_symlink_entry
     util_entry tar_symlink_header("foo", "bar", 0, Time.now, "link")
   end
-
 end

--- a/lib/rubygems/package/tar_writer.rb
+++ b/lib/rubygems/package/tar_writer.rb
@@ -8,14 +8,12 @@
 # Allows writing of tar files
 
 class Gem::Package::TarWriter
-
   class FileOverflow < StandardError; end
 
   ##
   # IO wrapper that allows writing a limited amount of data
 
   class BoundedStream
-
     ##
     # Maximum number of bytes that can be written
 
@@ -47,14 +45,12 @@ class Gem::Package::TarWriter
       @written += data.bytesize
       data.bytesize
     end
-
   end
 
   ##
   # IO wrapper that provides only #write
 
   class RestrictedStream
-
     ##
     # Creates a new RestrictedStream wrapping +io+
 
@@ -68,7 +64,6 @@ class Gem::Package::TarWriter
     def write(data)
       @io.write data
     end
-
   end
 
   ##
@@ -330,5 +325,4 @@ class Gem::Package::TarWriter
 
     return name, prefix
   end
-
 end

--- a/lib/rubygems/package_task.rb
+++ b/lib/rubygems/package_task.rb
@@ -57,7 +57,6 @@ require 'rake/packagetask'
 #   end
 
 class Gem::PackageTask < Rake::PackageTask
-
   ##
   # Ruby Gem::Specification containing the metadata for this package.  The
   # name, version and package_files are automatically determined from the
@@ -120,5 +119,4 @@ class Gem::PackageTask < Rake::PackageTask
       end
     end
   end
-
 end

--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -5,7 +5,6 @@
 # to the rest of RubyGems.
 #
 class Gem::PathSupport
-
   ##
   # The default system path for managing Gems.
   attr_reader :home
@@ -88,5 +87,4 @@ class Gem::PathSupport
       path
     end
   end
-
 end

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -7,7 +7,6 @@ require "rubygems/deprecate"
 # See `gem help platform` for information on platform matching.
 
 class Gem::Platform
-
   @local = nil
 
   attr_accessor :cpu
@@ -202,5 +201,4 @@ class Gem::Platform
   # This will be replaced with Gem::Platform::local.
 
   CURRENT = 'current'.freeze
-
 end

--- a/lib/rubygems/psych_tree.rb
+++ b/lib/rubygems/psych_tree.rb
@@ -2,7 +2,6 @@
 module Gem
   if defined? ::Psych::Visitors
     class NoAliasYAMLTree < Psych::Visitors::YAMLTree
-
       def self.create
         new({})
       end unless respond_to? :create
@@ -28,7 +27,6 @@ module Gem
       end
 
       private :format_time
-
     end
   end
 end

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -13,7 +13,6 @@ require 'resolv'
 # a remote source.
 
 class Gem::RemoteFetcher
-
   include Gem::UserInteraction
   include Gem::UriParsing
 
@@ -22,7 +21,6 @@ class Gem::RemoteFetcher
   # that could happen while downloading from the internet.
 
   class FetchError < Gem::Exception
-
     include Gem::UriParsing
 
     ##
@@ -43,7 +41,6 @@ class Gem::RemoteFetcher
     def to_s # :nodoc:
       "#{super} (#{uri})"
     end
-
   end
 
   ##
@@ -342,5 +339,4 @@ class Gem::RemoteFetcher
       @pools[proxy] ||= Gem::Request::ConnectionPools.new proxy, @cert_files
     end
   end
-
 end

--- a/lib/rubygems/request.rb
+++ b/lib/rubygems/request.rb
@@ -4,7 +4,6 @@ require 'time'
 require 'rubygems/user_interaction'
 
 class Gem::Request
-
   extend Gem::UserInteraction
   include Gem::UserInteraction
 
@@ -291,7 +290,6 @@ class Gem::Request
 
     ua
   end
-
 end
 
 require 'rubygems/request/http_pool'

--- a/lib/rubygems/request/connection_pools.rb
+++ b/lib/rubygems/request/connection_pools.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
 class Gem::Request::ConnectionPools # :nodoc:
-
   @client = Net::HTTP
 
   class << self
-
     attr_accessor :client
-
   end
 
   def initialize(proxy_uri, cert_files)
@@ -95,5 +92,4 @@ class Gem::Request::ConnectionPools # :nodoc:
       net_http_args
     end
   end
-
 end

--- a/lib/rubygems/request/http_pool.rb
+++ b/lib/rubygems/request/http_pool.rb
@@ -6,7 +6,6 @@
 # use it.
 
 class Gem::Request::HTTPPool # :nodoc:
-
   attr_reader :cert_files, :proxy_uri
 
   def initialize(http_args, cert_files, proxy_uri)
@@ -44,5 +43,4 @@ class Gem::Request::HTTPPool # :nodoc:
     connection.start
     connection
   end
-
 end

--- a/lib/rubygems/request/https_pool.rb
+++ b/lib/rubygems/request/https_pool.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 class Gem::Request::HTTPSPool < Gem::Request::HTTPPool # :nodoc:
-
   private
 
   def setup_connection(connection)
     Gem::Request.configure_connection_for_https(connection, @cert_files)
     super
   end
-
 end

--- a/lib/rubygems/request_set.rb
+++ b/lib/rubygems/request_set.rb
@@ -15,7 +15,6 @@ require 'tsort'
 #   #=> ["nokogiri-1.6.0", "mini_portile-0.5.1", "pg-0.17.0"]
 
 class Gem::RequestSet
-
   include TSort
 
   ##
@@ -471,7 +470,6 @@ class Gem::RequestSet
       yield match
     end
   end
-
 end
 
 require 'rubygems/request_set/gem_dependency_api'

--- a/lib/rubygems/request_set/gem_dependency_api.rb
+++ b/lib/rubygems/request_set/gem_dependency_api.rb
@@ -31,7 +31,6 @@
 # See `gem help install` and `gem help gem_dependencies` for further details.
 
 class Gem::RequestSet::GemDependencyAPI
-
   ENGINE_MAP = { # :nodoc:
     :jruby        => %w[jruby],
     :jruby_18     => %w[jruby],
@@ -842,5 +841,4 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
 
     Gem.sources << url
   end
-
 end

--- a/lib/rubygems/request_set/lockfile.rb
+++ b/lib/rubygems/request_set/lockfile.rb
@@ -5,12 +5,10 @@
 # constructed.
 
 class Gem::RequestSet::Lockfile
-
   ##
   # Raised when a lockfile cannot be parsed
 
   class ParseError < Gem::Exception
-
     ##
     # The column where the error was encountered
 
@@ -36,7 +34,6 @@ class Gem::RequestSet::Lockfile
       @path   = path
       super "#{message} (at line #{line} column #{column})"
     end
-
   end
 
   ##
@@ -237,7 +234,6 @@ class Gem::RequestSet::Lockfile
   def requests
     @set.sorted_requests
   end
-
 end
 
 require 'rubygems/request_set/lockfile/tokenizer'

--- a/lib/rubygems/request_set/lockfile/parser.rb
+++ b/lib/rubygems/request_set/lockfile/parser.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 class Gem::RequestSet::Lockfile::Parser
-
   ###
   # Parses lockfiles
 
@@ -341,5 +340,4 @@ class Gem::RequestSet::Lockfile::Parser
   def unget(token) # :nodoc:
     @tokens.unshift token
   end
-
 end

--- a/lib/rubygems/request_set/lockfile/tokenizer.rb
+++ b/lib/rubygems/request_set/lockfile/tokenizer.rb
@@ -2,7 +2,6 @@
 require 'rubygems/request_set/lockfile/parser'
 
 class Gem::RequestSet::Lockfile::Tokenizer
-
   Token = Struct.new :type, :value, :column, :line
   EOF   = Token.new :EOF
 
@@ -110,5 +109,4 @@ class Gem::RequestSet::Lockfile::Tokenizer
 
     @tokens
   end
-
 end

--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -9,7 +9,6 @@ require "rubygems/deprecate"
 # together in RubyGems.
 
 class Gem::Requirement
-
   OPS = { #:nodoc:
     "="  =>  lambda {|v, r| v == r },
     "!=" =>  lambda {|v, r| v != r },
@@ -299,14 +298,11 @@ class Gem::Requirement
       end
     end
   end
-
 end
 
 class Gem::Version
-
   # This is needed for compatibility with older yaml
   # gemspecs.
 
   Requirement = Gem::Requirement # :nodoc:
-
 end

--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -10,7 +10,6 @@ require 'rubygems/util/list'
 # all the requirements.
 
 class Gem::Resolver
-
   require 'rubygems/resolver/molinillo'
 
   ##
@@ -312,7 +311,6 @@ class Gem::Resolver
     end
   end
   private :amount_constrained
-
 end
 
 require 'rubygems/resolver/activation_request'

--- a/lib/rubygems/resolver/activation_request.rb
+++ b/lib/rubygems/resolver/activation_request.rb
@@ -4,7 +4,6 @@
 # dependency that was used to introduce this activation.
 
 class Gem::Resolver::ActivationRequest
-
   ##
   # The parent request for this activation request.
 
@@ -152,5 +151,4 @@ class Gem::Resolver::ActivationRequest
   def name_tuple
     @name_tuple ||= Gem::NameTuple.new(name, version, platform)
   end
-
 end

--- a/lib/rubygems/resolver/api_set.rb
+++ b/lib/rubygems/resolver/api_set.rb
@@ -4,7 +4,6 @@
 # Returns instances of APISpecification.
 
 class Gem::Resolver::APISet < Gem::Resolver::Set
-
   ##
   # The URI for the dependency API this APISet uses.
 
@@ -121,5 +120,4 @@ class Gem::Resolver::APISet < Gem::Resolver::Set
 
     @data[name]
   end
-
 end

--- a/lib/rubygems/resolver/api_specification.rb
+++ b/lib/rubygems/resolver/api_specification.rb
@@ -6,7 +6,6 @@
 # is the name, version, and dependencies.
 
 class Gem::Resolver::APISpecification < Gem::Resolver::Specification
-
   ##
   # Creates an APISpecification for the given +set+ from the rubygems.org
   # +api_data+.
@@ -86,5 +85,4 @@ class Gem::Resolver::APISpecification < Gem::Resolver::Specification
   def source # :nodoc:
     @set.source
   end
-
 end

--- a/lib/rubygems/resolver/best_set.rb
+++ b/lib/rubygems/resolver/best_set.rb
@@ -5,7 +5,6 @@
 # It combines IndexSet and APISet
 
 class Gem::Resolver::BestSet < Gem::Resolver::ComposedSet
-
   ##
   # Creates a BestSet for the given +sources+ or Gem::sources if none are
   # specified.  +sources+ must be a Gem::SourceList.
@@ -74,5 +73,4 @@ class Gem::Resolver::BestSet < Gem::Resolver::ComposedSet
       index_set
     end
   end
-
 end

--- a/lib/rubygems/resolver/composed_set.rb
+++ b/lib/rubygems/resolver/composed_set.rb
@@ -9,7 +9,6 @@
 # This method will eliminate nesting of composed sets.
 
 class Gem::Resolver::ComposedSet < Gem::Resolver::Set
-
   attr_reader :sets # :nodoc:
 
   ##
@@ -62,5 +61,4 @@ class Gem::Resolver::ComposedSet < Gem::Resolver::Set
   def prefetch(reqs)
     @sets.each {|s| s.prefetch(reqs) }
   end
-
 end

--- a/lib/rubygems/resolver/conflict.rb
+++ b/lib/rubygems/resolver/conflict.rb
@@ -4,7 +4,6 @@
 # with a spec that would be activated.
 
 class Gem::Resolver::Conflict
-
   ##
   # The specification that was activated prior to the conflict
 
@@ -151,5 +150,4 @@ class Gem::Resolver::Conflict
   def requester
     @failed_dep.requester
   end
-
 end

--- a/lib/rubygems/resolver/current_set.rb
+++ b/lib/rubygems/resolver/current_set.rb
@@ -5,9 +5,7 @@
 # for installed gems.
 
 class Gem::Resolver::CurrentSet < Gem::Resolver::Set
-
   def find_all(req)
     req.dependency.matching_specs
   end
-
 end

--- a/lib/rubygems/resolver/dependency_request.rb
+++ b/lib/rubygems/resolver/dependency_request.rb
@@ -4,7 +4,6 @@
 # contained the Dependency.
 
 class Gem::Resolver::DependencyRequest
-
   ##
   # The wrapped Gem::Dependency
 
@@ -116,5 +115,4 @@ class Gem::Resolver::DependencyRequest
   def to_s # :nodoc:
     @dependency.to_s
   end
-
 end

--- a/lib/rubygems/resolver/git_set.rb
+++ b/lib/rubygems/resolver/git_set.rb
@@ -10,7 +10,6 @@
 #   set.add_git_gem 'rake', 'git://example/rake.git', tag: 'rake-10.1.0'
 
 class Gem::Resolver::GitSet < Gem::Resolver::Set
-
   ##
   # The root directory for git gems in this set.  This is usually Gem.dir, the
   # installation directory for regular gems.
@@ -118,5 +117,4 @@ class Gem::Resolver::GitSet < Gem::Resolver::Set
       end
     end
   end
-
 end

--- a/lib/rubygems/resolver/git_specification.rb
+++ b/lib/rubygems/resolver/git_specification.rb
@@ -5,7 +5,6 @@
 # option.
 
 class Gem::Resolver::GitSpecification < Gem::Resolver::SpecSpecification
-
   def ==(other) # :nodoc:
     self.class === other and
       @set  == other.set and
@@ -54,5 +53,4 @@ class Gem::Resolver::GitSpecification < Gem::Resolver::SpecSpecification
       q.pp @source
     end
   end
-
 end

--- a/lib/rubygems/resolver/index_set.rb
+++ b/lib/rubygems/resolver/index_set.rb
@@ -4,7 +4,6 @@
 # source index.
 
 class Gem::Resolver::IndexSet < Gem::Resolver::Set
-
   def initialize(source = nil) # :nodoc:
     super()
 
@@ -76,5 +75,4 @@ class Gem::Resolver::IndexSet < Gem::Resolver::Set
       end
     end
   end
-
 end

--- a/lib/rubygems/resolver/index_specification.rb
+++ b/lib/rubygems/resolver/index_specification.rb
@@ -5,7 +5,6 @@
 # and +version+ are needed.
 
 class Gem::Resolver::IndexSpecification < Gem::Resolver::Specification
-
   ##
   # An IndexSpecification is created from the index format described in `gem
   # help generate_index`.
@@ -65,5 +64,4 @@ class Gem::Resolver::IndexSpecification < Gem::Resolver::Specification
         @source.fetch_spec tuple
       end
   end
-
 end

--- a/lib/rubygems/resolver/installed_specification.rb
+++ b/lib/rubygems/resolver/installed_specification.rb
@@ -4,7 +4,6 @@
 # locally.
 
 class Gem::Resolver::InstalledSpecification < Gem::Resolver::SpecSpecification
-
   def ==(other) # :nodoc:
     self.class === other and
       @set  == other.set and
@@ -54,5 +53,4 @@ class Gem::Resolver::InstalledSpecification < Gem::Resolver::SpecSpecification
   def source
     @source ||= Gem::Source::Installed.new
   end
-
 end

--- a/lib/rubygems/resolver/installer_set.rb
+++ b/lib/rubygems/resolver/installer_set.rb
@@ -4,7 +4,6 @@
 # files
 
 class Gem::Resolver::InstallerSet < Gem::Resolver::Set
-
   ##
   # List of Gem::Specification objects that must always be installed.
 
@@ -223,5 +222,4 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
       @domain = :local unless remote
     end
   end
-
 end

--- a/lib/rubygems/resolver/local_specification.rb
+++ b/lib/rubygems/resolver/local_specification.rb
@@ -3,7 +3,6 @@
 # A LocalSpecification comes from a .gem file on the local filesystem.
 
 class Gem::Resolver::LocalSpecification < Gem::Resolver::SpecSpecification
-
   ##
   # Returns +true+ if this gem is installable for the current platform.
 
@@ -37,5 +36,4 @@ class Gem::Resolver::LocalSpecification < Gem::Resolver::SpecSpecification
       q.text "source: #{@source.path}"
     end
   end
-
 end

--- a/lib/rubygems/resolver/lock_set.rb
+++ b/lib/rubygems/resolver/lock_set.rb
@@ -3,7 +3,6 @@
 # A set of gems from a gem dependencies lockfile.
 
 class Gem::Resolver::LockSet < Gem::Resolver::Set
-
   attr_reader :specs # :nodoc:
 
   ##
@@ -78,5 +77,4 @@ class Gem::Resolver::LockSet < Gem::Resolver::Set
       q.pp @specs.map {|spec| spec.full_name }
     end
   end
-
 end

--- a/lib/rubygems/resolver/lock_specification.rb
+++ b/lib/rubygems/resolver/lock_specification.rb
@@ -6,7 +6,6 @@
 # lockfile.
 
 class Gem::Resolver::LockSpecification < Gem::Resolver::Specification
-
   attr_reader :sources
 
   def initialize(set, name, version, sources, platform)
@@ -83,5 +82,4 @@ class Gem::Resolver::LockSpecification < Gem::Resolver::Specification
       s.dependencies.concat @dependencies
     end
   end
-
 end

--- a/lib/rubygems/resolver/requirement_list.rb
+++ b/lib/rubygems/resolver/requirement_list.rb
@@ -7,7 +7,6 @@
 # first.
 
 class Gem::Resolver::RequirementList
-
   include Enumerable
 
   ##
@@ -79,5 +78,4 @@ class Gem::Resolver::RequirementList
     x = @exact[0,5]
     x + @list[0,5 - x.size]
   end
-
 end

--- a/lib/rubygems/resolver/set.rb
+++ b/lib/rubygems/resolver/set.rb
@@ -4,7 +4,6 @@
 # dependencies) used in resolution.  This set is abstract.
 
 class Gem::Resolver::Set
-
   ##
   # Set to true to disable network access for this set
 
@@ -53,5 +52,4 @@ class Gem::Resolver::Set
   def remote? # :nodoc:
     @remote
   end
-
 end

--- a/lib/rubygems/resolver/source_set.rb
+++ b/lib/rubygems/resolver/source_set.rb
@@ -4,7 +4,6 @@
 # Kind off like BestSet but filters the sources for gems
 
 class Gem::Resolver::SourceSet < Gem::Resolver::Set
-
   ##
   # Creates a SourceSet for the given +sources+ or Gem::sources if none are
   # specified.  +sources+ must be a Gem::SourceList.
@@ -43,5 +42,4 @@ class Gem::Resolver::SourceSet < Gem::Resolver::Set
     link = @links[name]
     @sets[link] ||= Gem::Source.new(link).dependency_resolver_set if link
   end
-
 end

--- a/lib/rubygems/resolver/spec_specification.rb
+++ b/lib/rubygems/resolver/spec_specification.rb
@@ -4,7 +4,6 @@
 # Resolver specifications that are backed by a Gem::Specification.
 
 class Gem::Resolver::SpecSpecification < Gem::Resolver::Specification
-
   ##
   # A SpecSpecification is created for a +set+ for a Gem::Specification in
   # +spec+.  The +source+ is either where the +spec+ came from, or should be
@@ -52,5 +51,4 @@ class Gem::Resolver::SpecSpecification < Gem::Resolver::Specification
   def version
     spec.version
   end
-
 end

--- a/lib/rubygems/resolver/specification.rb
+++ b/lib/rubygems/resolver/specification.rb
@@ -5,7 +5,6 @@
 # dependency resolution in the resolver is included.
 
 class Gem::Resolver::Specification
-
   ##
   # The dependencies of the gem for this specification
 
@@ -111,5 +110,4 @@ class Gem::Resolver::Specification
   def local? # :nodoc:
     false
   end
-
 end

--- a/lib/rubygems/resolver/stats.rb
+++ b/lib/rubygems/resolver/stats.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 class Gem::Resolver::Stats
-
   def initialize
     @max_depth = 0
     @max_requirements = 0
@@ -43,5 +42,4 @@ class Gem::Resolver::Stats
     $stdout.printf PATTERN, "Backtracking #", @backtracking
     $stdout.printf PATTERN, "Iteration #", @iterations
   end
-
 end

--- a/lib/rubygems/resolver/vendor_set.rb
+++ b/lib/rubygems/resolver/vendor_set.rb
@@ -15,7 +15,6 @@
 # rake.gemspec (watching the given name).
 
 class Gem::Resolver::VendorSet < Gem::Resolver::Set
-
   ##
   # The specifications for this set.
 
@@ -83,5 +82,4 @@ class Gem::Resolver::VendorSet < Gem::Resolver::Set
       end
     end
   end
-
 end

--- a/lib/rubygems/resolver/vendor_specification.rb
+++ b/lib/rubygems/resolver/vendor_specification.rb
@@ -5,7 +5,6 @@
 # option.
 
 class Gem::Resolver::VendorSpecification < Gem::Resolver::SpecSpecification
-
   def ==(other) # :nodoc:
     self.class === other and
       @set  == other.set and
@@ -20,5 +19,4 @@ class Gem::Resolver::VendorSpecification < Gem::Resolver::SpecSpecification
   def install(options = {})
     yield nil
   end
-
 end

--- a/lib/rubygems/s3_uri_signer.rb
+++ b/lib/rubygems/s3_uri_signer.rb
@@ -6,9 +6,7 @@ require 'openssl'
 # S3URISigner implements AWS SigV4 for S3 Source to avoid a dependency on the aws-sdk-* gems
 # More on AWS SigV4: https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html
 class Gem::S3URISigner
-
   class ConfigurationError < Gem::Exception
-
     def initialize(message)
       super message
     end
@@ -16,11 +14,9 @@ class Gem::S3URISigner
     def to_s # :nodoc:
       "#{super}"
     end
-
   end
 
   class InstanceProfileError < Gem::Exception
-
     def initialize(message)
       super message
     end
@@ -28,7 +24,6 @@ class Gem::S3URISigner
     def to_s # :nodoc:
       "#{super}"
     end
-
   end
 
   attr_accessor :uri
@@ -179,5 +174,4 @@ class Gem::S3URISigner
   BASE64_URI_TRANSLATE = { "+" => "%2B", "/" => "%2F", "=" => "%3D", "\n" => "" }.freeze
   EC2_IAM_INFO = "http://169.254.169.254/latest/meta-data/iam/info".freeze
   EC2_IAM_SECURITY_CREDENTIALS = "http://169.254.169.254/latest/meta-data/iam/security-credentials/".freeze
-
 end

--- a/lib/rubygems/security/policy.rb
+++ b/lib/rubygems/security/policy.rb
@@ -8,7 +8,6 @@ require 'rubygems/user_interaction'
 # Gem::Security::Policies.
 
 class Gem::Security::Policy
-
   include Gem::UserInteraction
 
   attr_reader :name
@@ -291,5 +290,4 @@ class Gem::Security::Policy
   end
 
   alias to_s name # :nodoc:
-
 end

--- a/lib/rubygems/security/signer.rb
+++ b/lib/rubygems/security/signer.rb
@@ -5,7 +5,6 @@
 require "rubygems/user_interaction"
 
 class Gem::Security::Signer
-
   include Gem::UserInteraction
 
   ##
@@ -202,5 +201,4 @@ class Gem::Security::Signer
       end
     end
   end
-
 end

--- a/lib/rubygems/security/trust_dir.rb
+++ b/lib/rubygems/security/trust_dir.rb
@@ -4,7 +4,6 @@
 # verification.
 
 class Gem::Security::TrustDir
-
   ##
   # Default permissions for the trust directory and its contents
 
@@ -115,5 +114,4 @@ class Gem::Security::TrustDir
       FileUtils.mkdir_p @dir, :mode => @permissions[:trust_dir]
     end
   end
-
 end

--- a/lib/rubygems/server.rb
+++ b/lib/rubygems/server.rb
@@ -29,7 +29,6 @@ require 'rubygems/rdoc'
 # TODO Refactor into a real WEBrick servlet to remove code duplication.
 
 class Gem::Server
-
   attr_reader :spec_dirs
 
   include ERB::Util
@@ -875,5 +874,4 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
 
     system("#{@launch} http://#{host}:#{@port}")
   end
-
 end

--- a/lib/rubygems/source.rb
+++ b/lib/rubygems/source.rb
@@ -8,7 +8,6 @@ require "rubygems/text"
 # bundler dependency API and so-forth.
 
 class Gem::Source
-
   include Comparable
   include Gem::Text
 
@@ -223,7 +222,6 @@ class Gem::Source
     return if @uri.host.nil?
     levenshtein_distance(@uri.host, host) <= distance_threshold
   end
-
 end
 
 require 'rubygems/source/git'

--- a/lib/rubygems/source/git.rb
+++ b/lib/rubygems/source/git.rb
@@ -11,7 +11,6 @@
 #   source.specs
 
 class Gem::Source::Git < Gem::Source
-
   ##
   # The name of the gem created by this git gem.
 
@@ -238,5 +237,4 @@ class Gem::Source::Git < Gem::Source
 
     Digest::SHA1.hexdigest normalized
   end
-
 end

--- a/lib/rubygems/source/installed.rb
+++ b/lib/rubygems/source/installed.rb
@@ -3,7 +3,6 @@
 # Represents an installed gem.  This is used for dependency resolution.
 
 class Gem::Source::Installed < Gem::Source
-
   def initialize # :nodoc:
     @uri = nil
   end
@@ -36,5 +35,4 @@ class Gem::Source::Installed < Gem::Source
   def pretty_print(q) # :nodoc:
     q.text '[Installed]'
   end
-
 end

--- a/lib/rubygems/source/local.rb
+++ b/lib/rubygems/source/local.rb
@@ -4,7 +4,6 @@
 # dependencies.
 
 class Gem::Source::Local < Gem::Source
-
   def initialize # :nodoc:
     @specs   = nil
     @api_uri = nil
@@ -129,5 +128,4 @@ class Gem::Source::Local < Gem::Source
       end
     end
   end
-
 end

--- a/lib/rubygems/source/lock.rb
+++ b/lib/rubygems/source/lock.rb
@@ -5,7 +5,6 @@
 # dependency lock files.
 
 class Gem::Source::Lock < Gem::Source
-
   ##
   # The wrapped Gem::Source
 
@@ -48,5 +47,4 @@ class Gem::Source::Lock < Gem::Source
   def uri # :nodoc:
     @wrapped.uri
   end
-
 end

--- a/lib/rubygems/source/specific_file.rb
+++ b/lib/rubygems/source/specific_file.rb
@@ -4,7 +4,6 @@
 # local gems.
 
 class Gem::Source::SpecificFile < Gem::Source
-
   ##
   # The path to the gem for this specific file.
 
@@ -69,5 +68,4 @@ class Gem::Source::SpecificFile < Gem::Source
       super
     end
   end
-
 end

--- a/lib/rubygems/source/vendor.rb
+++ b/lib/rubygems/source/vendor.rb
@@ -3,7 +3,6 @@
 # This represents a vendored source that is similar to an installed gem.
 
 class Gem::Source::Vendor < Gem::Source::Installed
-
   ##
   # Creates a new Vendor source for a gem that was unpacked at +path+.
 
@@ -23,5 +22,4 @@ class Gem::Source::Vendor < Gem::Source::Installed
       nil
     end
   end
-
 end

--- a/lib/rubygems/source_list.rb
+++ b/lib/rubygems/source_list.rb
@@ -14,7 +14,6 @@
 # The most common way to get a SourceList is Gem.sources.
 
 class Gem::SourceList
-
   include Enumerable
 
   ##
@@ -148,5 +147,4 @@ class Gem::SourceList
       @sources.delete_if {|x| x.uri.to_s == source.to_s }
     end
   end
-
 end

--- a/lib/rubygems/spec_fetcher.rb
+++ b/lib/rubygems/spec_fetcher.rb
@@ -9,7 +9,6 @@ require 'rubygems/name_tuple'
 # SpecFetcher handles metadata updates from remote gem repositories.
 
 class Gem::SpecFetcher
-
   include Gem::UserInteraction
   include Gem::Text
 
@@ -259,5 +258,4 @@ class Gem::SpecFetcher
     raise unless gracefully_ignore
     []
   end
-
 end

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -34,7 +34,6 @@ require 'rubygems/util/list'
 # items you may add to a specification.
 
 class Gem::Specification < Gem::BasicSpecification
-
   extend Gem::Deprecate
 
   # REFACTOR: Consider breaking out this version stuff into a separate
@@ -2659,5 +2658,4 @@ class Gem::Specification < Gem::BasicSpecification
   def raw_require_paths # :nodoc:
     @require_paths
   end
-
 end

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -1,7 +1,6 @@
 require 'rubygems/user_interaction'
 
 class Gem::SpecificationPolicy
-
   include Gem::UserInteraction
 
   VALID_NAME_PATTERN = /\A[a-zA-Z0-9\.\-\_]+\z/.freeze # :nodoc:
@@ -483,5 +482,4 @@ You have specified rake based extension, but rake is not added as dependency. It
   def help_text # :nodoc:
     "See https://guides.rubygems.org/specification-reference/ for help"
   end
-
 end

--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -5,7 +5,6 @@
 # information.
 
 class Gem::StubSpecification < Gem::BasicSpecification
-
   # :nodoc:
   PREFIX = "# stub: ".freeze
 
@@ -13,7 +12,6 @@ class Gem::StubSpecification < Gem::BasicSpecification
   OPEN_MODE = 'r:UTF-8:-'.freeze
 
   class StubLine # :nodoc: all
-
     attr_reader :name, :version, :platform, :require_paths, :extensions,
                 :full_name
 
@@ -56,7 +54,6 @@ class Gem::StubSpecification < Gem::BasicSpecification
         REQUIRE_PATHS[x] || x
       end
     end
-
   end
 
   def self.default_gemspec_stub(filename, base_dir, gems_dir)
@@ -212,5 +209,4 @@ class Gem::StubSpecification < Gem::BasicSpecification
   def stubbed?
     data.is_a? StubLine
   end
-
 end

--- a/lib/rubygems/syck_hack.rb
+++ b/lib/rubygems/syck_hack.rb
@@ -40,13 +40,11 @@ module YAML # :nodoc:
   # should.
   module Syck
     class DefaultKey
-
       remove_method :to_s rescue nil
 
       def to_s
         '='
       end
-
     end
   end
 

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -83,7 +83,6 @@ end
 require "rubygems/command"
 
 class Gem::Command
-
   ##
   # Allows resetting the hash of specific args per command.  This method is
   # available when requiring 'rubygems/test_case'
@@ -91,7 +90,6 @@ class Gem::Command
   def self.specific_extra_args_hash=(value)
     @specific_extra_args_hash = value
   end
-
 end
 
 ##
@@ -101,7 +99,6 @@ end
 # your normal set of gems is not affected.
 
 class Gem::TestCase < Minitest::Test
-
   extend Gem::Deprecate
 
   attr_accessor :fetcher # :nodoc:
@@ -1267,11 +1264,11 @@ Also, a list:
   end
 
   class << self
-
     # :nodoc:
     ##
     # Return the join path, with escaping backticks, dollars, and
     # double-quotes.  Unlike `shellescape`, equal-sign is not escaped.
+
     private
 
     def escape_path(*path)
@@ -1282,7 +1279,6 @@ Also, a list:
         "\"#{path.gsub(/[`$"]/, '\\&')}\""
       end
     end
-
   end
 
   @@good_rake = "#{rubybin} #{escape_path(TEST_PATH, 'good_rake.rb')}"
@@ -1400,7 +1396,6 @@ Also, a list:
   # It is available by requiring Gem::TestCase.
 
   class StaticSet < Gem::Resolver::Set
-
     ##
     # A StaticSet ignores remote because it has a fixed set of gems.
 
@@ -1455,7 +1450,6 @@ Also, a list:
 
     def prefetch(reqs) # :nodoc:
     end
-
   end
 
   ##
@@ -1523,7 +1517,6 @@ Also, a list:
     PUBLIC_KEY  = nil
     PUBLIC_CERT = nil
   end if defined?(OpenSSL::SSL)
-
 end
 
 require 'rubygems/test_utilities'

--- a/lib/rubygems/test_utilities.rb
+++ b/lib/rubygems/test_utilities.rb
@@ -29,7 +29,6 @@ require 'rubygems/remote_fetcher'
 # See RubyGems' tests for more examples of FakeFetcher.
 
 class Gem::FakeFetcher
-
   attr_reader :data
   attr_reader :last_request
   attr_accessor :paths
@@ -162,16 +161,13 @@ class Gem::FakeFetcher
 
     download spec, source.uri.to_s
   end
-
 end
 
 # :stopdoc:
 class Gem::RemoteFetcher
-
   def self.fetcher=(fetcher)
     @fetcher = fetcher
   end
-
 end
 # :startdoc:
 
@@ -191,7 +187,6 @@ end
 # After the gems are created they are removed from Gem.dir.
 
 class Gem::TestCase::SpecFetcherSetup
-
   ##
   # Executes a SpecFetcher setup block.  Yields an instance then creates the
   # gems and specifications defined in the instance.
@@ -346,7 +341,6 @@ class Gem::TestCase::SpecFetcherSetup
       io.write spec.to_ruby_for_cache
     end
   end
-
 end
 
 ##
@@ -358,7 +352,6 @@ end
 # This class was added to flush out problems in Rubinius' IO implementation.
 
 class TempIO < Tempfile
-
   ##
   # Creates a new TempIO that will be initialized to contain +string+.
 
@@ -376,5 +369,4 @@ class TempIO < Tempfile
     flush
     Gem.read_binary path
   end
-
 end

--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -21,7 +21,6 @@ require 'rubygems/user_interaction'
 # file.  See Gem.pre_uninstall and Gem.post_uninstall for details.
 
 class Gem::Uninstaller
-
   include Gem::UserInteraction
 
   include Gem::InstallerUninstallerUtils
@@ -374,5 +373,4 @@ class Gem::Uninstaller
 
     raise e
   end
-
 end

--- a/lib/rubygems/uri_formatter.rb
+++ b/lib/rubygems/uri_formatter.rb
@@ -9,7 +9,6 @@ require 'cgi'
 #   p uf.normalize #=> 'http://example.com'
 
 class Gem::UriFormatter
-
   ##
   # The URI to be formatted.
 
@@ -44,5 +43,4 @@ class Gem::UriFormatter
     return unless @uri
     CGI.unescape @uri
   end
-
 end

--- a/lib/rubygems/uri_parser.rb
+++ b/lib/rubygems/uri_parser.rb
@@ -5,7 +5,6 @@
 #
 
 class Gem::UriParser
-
   ##
   # Parses the #uri, raising if it's invalid
 
@@ -32,5 +31,4 @@ class Gem::UriParser
   rescue URI::InvalidURIError
     uri
   end
-
 end

--- a/lib/rubygems/user_interaction.rb
+++ b/lib/rubygems/user_interaction.rb
@@ -172,7 +172,6 @@ end
 # Gem::StreamUI implements a simple stream based user interface.
 
 class Gem::StreamUI
-
   extend Gem::Deprecate
 
   ##
@@ -387,7 +386,6 @@ class Gem::StreamUI
   # An absolutely silent progress reporter.
 
   class SilentProgressReporter
-
     ##
     # The count of items is never updated for the silent progress reporter.
 
@@ -412,14 +410,12 @@ class Gem::StreamUI
 
     def done
     end
-
   end
 
   ##
   # A basic dotted progress reporter.
 
   class SimpleProgressReporter
-
     include Gem::DefaultUserInteraction
 
     ##
@@ -457,14 +453,12 @@ class Gem::StreamUI
     def done
       @out.puts "\n#{@terminal_message}"
     end
-
   end
 
   ##
   # A progress reporter that prints out messages about the current progress.
 
   class VerboseProgressReporter
-
     include Gem::DefaultUserInteraction
 
     ##
@@ -501,7 +495,6 @@ class Gem::StreamUI
     def done
       @out.puts @terminal_message
     end
-
   end
 
   ##
@@ -519,7 +512,6 @@ class Gem::StreamUI
   # An absolutely silent download reporter.
 
   class SilentDownloadReporter
-
     ##
     # The silent download reporter ignores all arguments
 
@@ -545,14 +537,12 @@ class Gem::StreamUI
 
     def done
     end
-
   end
 
   ##
   # A progress reporter that behaves nicely with threaded downloading.
 
   class ThreadedDownloadReporter
-
     MUTEX = Mutex.new
 
     ##
@@ -601,9 +591,7 @@ class Gem::StreamUI
         @out.puts message
       end
     end
-
   end
-
 end
 
 ##
@@ -611,7 +599,6 @@ end
 # STDOUT, and STDERR.
 
 class Gem::ConsoleUI < Gem::StreamUI
-
   ##
   # The Console UI has no arguments as it defaults to reading input from
   # stdin, output to stdout and warnings or errors to stderr.
@@ -619,14 +606,12 @@ class Gem::ConsoleUI < Gem::StreamUI
   def initialize
     super STDIN, STDOUT, STDERR, true
   end
-
 end
 
 ##
 # SilentUI is a UI choice that is absolutely silent.
 
 class Gem::SilentUI < Gem::StreamUI
-
   ##
   # The SilentUI has no arguments as it does not use any stream.
 
@@ -652,5 +637,4 @@ class Gem::SilentUI < Gem::StreamUI
   def progress_reporter(*args) # :nodoc:
     SilentProgressReporter.new(@outs, *args)
   end
-
 end

--- a/lib/rubygems/util.rb
+++ b/lib/rubygems/util.rb
@@ -71,11 +71,9 @@ module Gem::Util
   end
 
   class << self
-
     extend Gem::Deprecate
 
     rubygems_deprecate :silent_system
-
   end
 
   ##

--- a/lib/rubygems/util/licenses.rb
+++ b/lib/rubygems/util/licenses.rb
@@ -2,7 +2,6 @@
 require 'rubygems/text'
 
 class Gem::Licenses
-
   extend Gem::Text
 
   NONSTANDARD = 'Nonstandard'.freeze
@@ -435,5 +434,4 @@ class Gem::Licenses
     return unless lowest < license.size
     by_distance[lowest]
   end
-
 end

--- a/lib/rubygems/util/list.rb
+++ b/lib/rubygems/util/list.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 module Gem
   class List
-
     include Enumerable
     attr_accessor :value, :tail
 
@@ -34,6 +33,5 @@ module Gem
       return List.new(value) unless list
       List.new value, list
     end
-
   end
 end

--- a/lib/rubygems/validator.rb
+++ b/lib/rubygems/validator.rb
@@ -12,7 +12,6 @@ require 'rubygems/installer'
 # Validator performs various gem file and gem database validation
 
 class Gem::Validator
-
   include Gem::UserInteraction
 
   def initialize # :nodoc:
@@ -141,5 +140,4 @@ class Gem::Validator
 
     errors
   end
-
 end

--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -150,7 +150,6 @@
 # a zero to give a sensible result.
 
 class Gem::Version
-
   autoload :Requirement, File.expand_path('requirement', __dir__)
 
   include Comparable
@@ -404,5 +403,4 @@ class Gem::Version
     numeric_segments = string_segments.slice!(0, string_start || string_segments.size)
     return numeric_segments, string_segments
   end
-
 end

--- a/test/rubygems/plugin/load/rubygems_plugin.rb
+++ b/test/rubygems/plugin/load/rubygems_plugin.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
 class TestGem
-
   TEST_PLUGIN_LOAD = :loaded
-
 end

--- a/test/rubygems/rubygems/commands/crash_command.rb
+++ b/test/rubygems/rubygems/commands/crash_command.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
 class Gem::Commands::CrashCommand < Gem::Command
-
   raise "crash"
-
 end

--- a/test/rubygems/rubygems_plugin.rb
+++ b/test/rubygems/rubygems_plugin.rb
@@ -11,7 +11,6 @@ module Gem::Commands
 end
 
 class Gem::Commands::InterruptCommand < Gem::Command
-
   def initialize
     super('interrupt', 'Raises an Interrupt Exception', {})
   end
@@ -19,7 +18,6 @@ class Gem::Commands::InterruptCommand < Gem::Command
   def execute
     raise Interrupt, "Interrupt exception"
   end
-
 end
 
 Gem::CommandManager.instance.register_command :interrupt

--- a/test/rubygems/test_bundled_ca.rb
+++ b/test/rubygems/test_bundled_ca.rb
@@ -10,7 +10,6 @@ require 'rubygems/request'
 
 if ENV["CI"] || ENV["TEST_SSL"]
   class TestBundledCA < Gem::TestCase
-
     THIS_FILE = File.expand_path __FILE__
 
     def bundled_certificate_store
@@ -54,6 +53,5 @@ if ENV["CI"] || ENV["TEST_SSL"]
     def test_accessing_new_index
       assert_https('fastly.rubygems.org')
     end
-
   end
 end

--- a/test/rubygems/test_config.rb
+++ b/test/rubygems/test_config.rb
@@ -4,7 +4,6 @@ require 'rubygems'
 require 'shellwords'
 
 class TestConfig < Gem::TestCase
-
   def test_datadir
     util_make_gems
     spec = Gem::Specification.find_by_name("a")
@@ -25,5 +24,4 @@ class TestConfig < Gem::TestCase
     assert_equal(Gem.ruby, ruby)
     assert_match(/\/bad_rake.rb\z/, rake)
   end
-
 end

--- a/test/rubygems/test_deprecate.rb
+++ b/test/rubygems/test_deprecate.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/deprecate'
 
 class TestDeprecate < Gem::TestCase
-
   def setup
     super
 
@@ -41,7 +40,6 @@ class TestDeprecate < Gem::TestCase
   end
 
   class Thing
-
     extend Gem::Deprecate
     attr_accessor :message
     def foo
@@ -51,11 +49,9 @@ class TestDeprecate < Gem::TestCase
       @message = "bar"
     end
     rubygems_deprecate :foo, :bar
-
   end
 
   class OtherThing
-
     extend Gem::Deprecate
     attr_accessor :message
     def foo
@@ -65,7 +61,6 @@ class TestDeprecate < Gem::TestCase
       @message = "bar"
     end
     deprecate :foo, :bar, 2099, 3
-
   end
 
   def test_deprecated_method_calls_the_old_method
@@ -115,5 +110,4 @@ class TestDeprecate < Gem::TestCase
     assert_match(/Thing#foo is deprecated; use bar instead\./, err)
     assert_match(/on or after 2099-03-01/, err)
   end
-
 end

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -8,7 +8,6 @@ require 'tmpdir'
 require 'rbconfig'
 
 class TestGem < Gem::TestCase
-
   PLUGINS_LOADED = [] # rubocop:disable Style/MutableConstant
 
   PROJECT_DIR = File.expand_path('../../..', __FILE__).tap(&Gem::UNTAINT)
@@ -2033,5 +2032,4 @@ You may need to `gem install -g` to install missing gems
   def util_cache_dir
     File.join Gem.dir, "cache"
   end
-
 end

--- a/test/rubygems/test_gem_available_set.rb
+++ b/test/rubygems/test_gem_available_set.rb
@@ -4,7 +4,6 @@ require 'rubygems/available_set'
 require 'rubygems/security'
 
 class TestGemAvailableSet < Gem::TestCase
-
   def setup
     super
 
@@ -127,5 +126,4 @@ class TestGemAvailableSet < Gem::TestCase
 
     assert_equal [a3a, a2, a2a, a1, a1a], g
   end
-
 end

--- a/test/rubygems/test_gem_bundler_version_finder.rb
+++ b/test/rubygems/test_gem_bundler_version_finder.rb
@@ -2,7 +2,6 @@
 require 'rubygems/test_case'
 
 class TestGemBundlerVersionFinder < Gem::TestCase
-
   def setup
     super
 
@@ -146,5 +145,4 @@ class TestGemBundlerVersionFinder < Gem::TestCase
     bvf.filter!(specs)
     specs
   end
-
 end

--- a/test/rubygems/test_gem_command.rb
+++ b/test/rubygems/test_gem_command.rb
@@ -3,13 +3,10 @@ require 'rubygems/test_case'
 require 'rubygems/command'
 
 class Gem::Command
-
   public :parser
-
 end
 
 class TestGemCommand < Gem::TestCase
-
   def setup
     super
 
@@ -388,5 +385,4 @@ ERROR:  Possible alternatives: non_existent_with_hint
 
     assert_equal expected, @ui.error
   end
-
 end

--- a/test/rubygems/test_gem_command_manager.rb
+++ b/test/rubygems/test_gem_command_manager.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/command_manager'
 
 class TestGemCommandManager < Gem::TestCase
-
   PROJECT_DIR = File.expand_path('../../..', __FILE__).tap(&Gem::UNTAINT)
 
   def setup
@@ -300,5 +299,4 @@ class TestGemCommandManager < Gem::TestCase
   ensure
     Gem::Commands.send(:remove_const, :FooCommand)
   end
-
 end

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -4,7 +4,6 @@ require 'rubygems/commands/build_command'
 require 'rubygems/package'
 
 class TestGemCommandsBuildCommand < Gem::TestCase
-
   CERT_FILE = cert_path 'public3072'
   SIGNING_KEY = key_path 'private3072'
 
@@ -509,5 +508,4 @@ class TestGemCommandsBuildCommand < Gem::TestCase
   ensure
     ENV["SOURCE_DATE_EPOCH"] = epoch
   end
-
 end

--- a/test/rubygems/test_gem_commands_cert_command.rb
+++ b/test/rubygems/test_gem_commands_cert_command.rb
@@ -11,7 +11,6 @@ if Gem.java_platform?
 end
 
 class TestGemCommandsCertCommand < Gem::TestCase
-
   ALTERNATE_CERT = load_cert 'alternate'
   EXPIRED_PUBLIC_CERT = load_cert 'expired'
 
@@ -806,5 +805,4 @@ ERROR:  --private-key not specified and ~/.gem/gem-private_key.pem does not exis
     assert_equal "invalid argument: --sign #{nonexistent}: does not exist",
                  e.message
   end
-
 end if defined?(OpenSSL::SSL) && !Gem.java_platform?

--- a/test/rubygems/test_gem_commands_check_command.rb
+++ b/test/rubygems/test_gem_commands_check_command.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/commands/check_command'
 
 class TestGemCommandsCheckCommand < Gem::TestCase
-
   def setup
     super
 
@@ -65,5 +64,4 @@ class TestGemCommandsCheckCommand < Gem::TestCase
     refute_path_exists b.gem_dir
     refute_path_exists b.spec_file
   end
-
 end

--- a/test/rubygems/test_gem_commands_cleanup_command.rb
+++ b/test/rubygems/test_gem_commands_cleanup_command.rb
@@ -4,7 +4,6 @@ require 'rubygems/commands/cleanup_command'
 require 'rubygems/installer'
 
 class TestGemCommandsCleanupCommand < Gem::TestCase
-
   def setup
     super
 
@@ -278,5 +277,4 @@ class TestGemCommandsCleanupCommand < Gem::TestCase
     assert_path_exists d_1.gem_dir
     assert_path_exists d_2.gem_dir
   end
-
 end

--- a/test/rubygems/test_gem_commands_contents_command.rb
+++ b/test/rubygems/test_gem_commands_contents_command.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/commands/contents_command'
 
 class TestGemCommandsContentsCommand < Gem::TestCase
-
   def setup
     super
 
@@ -268,5 +267,4 @@ lib/foo.rb
     assert_equal Gem::Requirement.new('0.0.2'), @cmd.options[:version]
     assert @cmd.options[:show_install_dir]
   end
-
 end

--- a/test/rubygems/test_gem_commands_dependency_command.rb
+++ b/test/rubygems/test_gem_commands_dependency_command.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/commands/dependency_command'
 
 class TestGemCommandsDependencyCommand < Gem::TestCase
-
   def setup
     super
     @stub_ui = Gem::MockGemUi.new
@@ -225,5 +224,4 @@ ERROR:  Only reverse dependencies for local gems are supported.
     assert_equal "Gem a-2.a\n\n", @stub_ui.output
     assert_equal '', @stub_ui.error
   end
-
 end

--- a/test/rubygems/test_gem_commands_environment_command.rb
+++ b/test/rubygems/test_gem_commands_environment_command.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/commands/environment_command'
 
 class TestGemCommandsEnvironmentCommand < Gem::TestCase
-
   def setup
     super
 
@@ -141,5 +140,4 @@ class TestGemCommandsEnvironmentCommand < Gem::TestCase
     assert_equal "#{Gem.platforms.join File::PATH_SEPARATOR}\n", @ui.output
     assert_equal '', @ui.error
   end
-
 end

--- a/test/rubygems/test_gem_commands_fetch_command.rb
+++ b/test/rubygems/test_gem_commands_fetch_command.rb
@@ -5,7 +5,6 @@ require 'rubygems/security'
 require 'rubygems/commands/fetch_command'
 
 class TestGemCommandsFetchCommand < Gem::TestCase
-
   def setup
     super
 
@@ -122,5 +121,4 @@ class TestGemCommandsFetchCommand < Gem::TestCase
     assert_path_exists(File.join(@tempdir, a1.file_name),
                        "#{a1.full_name} not fetched")
   end
-
 end

--- a/test/rubygems/test_gem_commands_generate_index_command.rb
+++ b/test/rubygems/test_gem_commands_generate_index_command.rb
@@ -4,7 +4,6 @@ require 'rubygems/indexer'
 require 'rubygems/commands/generate_index_command'
 
 class TestGemCommandsGenerateIndexCommand < Gem::TestCase
-
   def setup
     super
 
@@ -78,5 +77,4 @@ class TestGemCommandsGenerateIndexCommand < Gem::TestCase
       "WARNING:  The \"--no-modern\" option has been deprecated and will be removed in Rubygems 4.0. The `--no-modern` option is currently ignored. Modern indexes (specs, latest_specs, and prerelease_specs) are always generated.\n",
       @ui.error
   end
-
 end

--- a/test/rubygems/test_gem_commands_help_command.rb
+++ b/test/rubygems/test_gem_commands_help_command.rb
@@ -6,7 +6,6 @@ require "rubygems/package"
 require "rubygems/command_manager"
 
 class TestGemCommandsHelpCommand < Gem::TestCase
-
   def setup
     super
 
@@ -71,5 +70,4 @@ class TestGemCommandsHelpCommand < Gem::TestCase
 
     yield @ui.output, @ui.error
   end
-
 end

--- a/test/rubygems/test_gem_commands_info_command.rb
+++ b/test/rubygems/test_gem_commands_info_command.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/commands/info_command'
 
 class TestGemCommandsInfoCommand < Gem::TestCase
-
   def setup
     super
 
@@ -41,5 +40,4 @@ class TestGemCommandsInfoCommand < Gem::TestCase
     assert_match %r{#{@gem.summary}\n}, @ui.output
     assert_match "", @ui.error
   end
-
 end

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -5,7 +5,6 @@ require 'rubygems/request_set'
 require 'rubygems/rdoc'
 
 class TestGemCommandsInstallCommand < Gem::TestCase
-
   def setup
     super
     common_installer_setup
@@ -1346,5 +1345,4 @@ ERROR:  Possible alternatives: non_existent_with_hint
     assert_equal "  a-3", out.shift
     assert_empty out
   end
-
 end

--- a/test/rubygems/test_gem_commands_list_command.rb
+++ b/test/rubygems/test_gem_commands_list_command.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/commands/list_command'
 
 class TestGemCommandsListCommand < Gem::TestCase
-
   def setup
     super
 
@@ -30,5 +29,4 @@ class TestGemCommandsListCommand < Gem::TestCase
     assert_equal "true\n", @ui.output
     assert_equal '', @ui.error
   end
-
 end

--- a/test/rubygems/test_gem_commands_lock_command.rb
+++ b/test/rubygems/test_gem_commands_lock_command.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/commands/lock_command'
 
 class TestGemCommandsLockCommand < Gem::TestCase
-
   def setup
     super
 
@@ -64,5 +63,4 @@ gem 'd', '= 1'
 
     assert_equal 'Could not find gem c-1, try using the full name', e.message
   end
-
 end

--- a/test/rubygems/test_gem_commands_mirror.rb
+++ b/test/rubygems/test_gem_commands_mirror.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/commands/mirror_command'
 
 class TestGemCommandsMirrorCommand < Gem::TestCase
-
   def setup
     super
 
@@ -17,5 +16,4 @@ class TestGemCommandsMirrorCommand < Gem::TestCase
 
     assert_match %r{Install the rubygems-mirror}i, @ui.error
   end
-
 end

--- a/test/rubygems/test_gem_commands_open_command.rb
+++ b/test/rubygems/test_gem_commands_open_command.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/commands/open_command'
 
 class TestGemCommandsOpenCommand < Gem::TestCase
-
   def setup
     super
 
@@ -96,5 +95,4 @@ class TestGemCommandsOpenCommand < Gem::TestCase
     assert_match %r{'foo' is a default gem and can't be opened\.} , @ui.output
     assert_equal "", @ui.error
   end
-
 end

--- a/test/rubygems/test_gem_commands_outdated_command.rb
+++ b/test/rubygems/test_gem_commands_outdated_command.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/commands/outdated_command'
 
 class TestGemCommandsOutdatedCommand < Gem::TestCase
-
   def setup
     super
 
@@ -29,5 +28,4 @@ class TestGemCommandsOutdatedCommand < Gem::TestCase
     assert_equal "foo (0.2 < 2.0)\n", @ui.output
     assert_equal "", @ui.error
   end
-
 end

--- a/test/rubygems/test_gem_commands_owner_command.rb
+++ b/test/rubygems/test_gem_commands_owner_command.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/commands/owner_command'
 
 class TestGemCommandsOwnerCommand < Gem::TestCase
-
   def setup
     super
 
@@ -276,5 +275,4 @@ EOF
     assert_match 'Code: ', @otp_ui.output
     assert_equal '111111', @stub_fetcher.last_request['OTP']
   end
-
 end

--- a/test/rubygems/test_gem_commands_pristine_command.rb
+++ b/test/rubygems/test_gem_commands_pristine_command.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/commands/pristine_command'
 
 class TestGemCommandsPristineCommand < Gem::TestCase
-
   def setup
     super
     common_installer_setup
@@ -656,5 +655,4 @@ class TestGemCommandsPristineCommand < Gem::TestCase
     assert @cmd.options[:extensions]
     assert @cmd.options[:extensions_set]
   end
-
 end

--- a/test/rubygems/test_gem_commands_push_command.rb
+++ b/test/rubygems/test_gem_commands_push_command.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/commands/push_command'
 
 class TestGemCommandsPushCommand < Gem::TestCase
-
   def setup
     super
 
@@ -410,5 +409,4 @@ class TestGemCommandsPushCommand < Gem::TestCase
   def singleton_gem_class
     class << Gem; self; end
   end
-
 end

--- a/test/rubygems/test_gem_commands_query_command.rb
+++ b/test/rubygems/test_gem_commands_query_command.rb
@@ -19,7 +19,6 @@ module TestGemCommandsQueryCommandSetup
 end
 
 class TestGemCommandsQueryCommandWithInstalledGems < Gem::TestCase
-
   include TestGemCommandsQueryCommandSetup
 
   def test_execute
@@ -607,11 +606,9 @@ pl (1 i386-linux)
       fetcher.spec 'a', '3.a'
     end
   end
-
 end
 
 class TestGemCommandsQueryCommandWithoutInstalledGems < Gem::TestCase
-
   include TestGemCommandsQueryCommandSetup
 
   def test_execute_platform
@@ -857,5 +854,4 @@ othergem (1.2.3)
       fetcher.download 'a', '3.a'
     end
   end
-
 end

--- a/test/rubygems/test_gem_commands_search_command.rb
+++ b/test/rubygems/test_gem_commands_search_command.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/commands/search_command'
 
 class TestGemCommandsSearchCommand < Gem::TestCase
-
   def setup
     super
 
@@ -13,5 +12,4 @@ class TestGemCommandsSearchCommand < Gem::TestCase
   def test_initialize
     assert_equal :remote, @cmd.defaults[:domain]
   end
-
 end

--- a/test/rubygems/test_gem_commands_server_command.rb
+++ b/test/rubygems/test_gem_commands_server_command.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/commands/server_command'
 
 class TestGemCommandsServerCommand < Gem::TestCase
-
   def setup
     super
 
@@ -59,5 +58,4 @@ class TestGemCommandsServerCommand < Gem::TestCase
     assert_equal 'invalid argument: -p 65536: not a port number',
                  e.message
   end
-
 end

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -4,7 +4,6 @@ require 'rubygems/test_case'
 require 'rubygems/commands/setup_command'
 
 class TestGemCommandsSetupCommand < Gem::TestCase
-
   bundler_gemspec = File.expand_path("../../../bundler/lib/bundler/version.rb", __FILE__)
   if File.exist?(bundler_gemspec)
     BUNDLER_VERS = File.read(bundler_gemspec).match(/VERSION = "(#{Gem::Version::VERSION_PATTERN})"/)[1]
@@ -420,5 +419,4 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     bundle_exec = sprintf Gem.default_exec_format, 'bundle'
     File.join @install_dir, 'bin', bundle_exec
   end
-
 end unless Gem.java_platform?

--- a/test/rubygems/test_gem_commands_signin_command.rb
+++ b/test/rubygems/test_gem_commands_signin_command.rb
@@ -4,7 +4,6 @@ require 'rubygems/commands/signin_command'
 require 'rubygems/installer'
 
 class TestGemCommandsSigninCommand < Gem::TestCase
-
   def setup
     super
 
@@ -97,5 +96,4 @@ class TestGemCommandsSigninCommand < Gem::TestCase
 
     sign_in_ui
   end
-
 end

--- a/test/rubygems/test_gem_commands_signout_command.rb
+++ b/test/rubygems/test_gem_commands_signout_command.rb
@@ -5,7 +5,6 @@ require 'rubygems/commands/signout_command'
 require 'rubygems/installer'
 
 class TestGemCommandsSignoutCommand < Gem::TestCase
-
   def setup
     super
     @cmd = Gem::Commands::SignoutCommand.new
@@ -28,5 +27,4 @@ class TestGemCommandsSignoutCommand < Gem::TestCase
 
     assert_match %r{You are not currently signed in}, @sign_out_ui.error
   end
-
 end

--- a/test/rubygems/test_gem_commands_sources_command.rb
+++ b/test/rubygems/test_gem_commands_sources_command.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/commands/sources_command'
 
 class TestGemCommandsSourcesCommand < Gem::TestCase
-
   def setup
     super
 
@@ -422,5 +421,4 @@ beta-gems.example.com is not a URI
     assert_equal "source cache successfully updated\n", @ui.output
     assert_equal '', @ui.error
   end
-
 end

--- a/test/rubygems/test_gem_commands_specification_command.rb
+++ b/test/rubygems/test_gem_commands_specification_command.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/commands/specification_command'
 
 class TestGemCommandsSpecificationCommand < Gem::TestCase
-
   def setup
     super
 
@@ -246,5 +245,4 @@ class TestGemCommandsSpecificationCommand < Gem::TestCase
     assert_match %r{s.name = "foo"}, @ui.output
     assert_equal '', @ui.error
   end
-
 end

--- a/test/rubygems/test_gem_commands_stale_command.rb
+++ b/test/rubygems/test_gem_commands_stale_command.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/commands/stale_command'
 
 class TestGemCommandsStaleCommand < Gem::TestCase
-
   def setup
     super
     @stub_ui = Gem::MockGemUi.new
@@ -40,5 +39,4 @@ class TestGemCommandsStaleCommand < Gem::TestCase
     assert_equal("#{foo_bar.name}-#{foo_bar.version}", lines[0].split.first)
     assert_equal("#{bar_baz.name}-#{bar_baz.version}", lines[1].split.first)
   end
-
 end

--- a/test/rubygems/test_gem_commands_uninstall_command.rb
+++ b/test/rubygems/test_gem_commands_uninstall_command.rb
@@ -3,7 +3,6 @@ require 'rubygems/installer_test_case'
 require 'rubygems/commands/uninstall_command'
 
 class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
-
   def setup
     super
     @cmd = Gem::Commands::UninstallCommand.new
@@ -502,5 +501,4 @@ WARNING:  Use your OS package manager to uninstall vendor gems
       end
     end
   end
-
 end

--- a/test/rubygems/test_gem_commands_unpack_command.rb
+++ b/test/rubygems/test_gem_commands_unpack_command.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/commands/unpack_command'
 
 class TestGemCommandsUnpackCommand < Gem::TestCase
-
   def setup
     super
 
@@ -221,5 +220,4 @@ class TestGemCommandsUnpackCommand < Gem::TestCase
 
     assert @cmd.options[:spec]
   end
-
 end

--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/commands/update_command'
 
 class TestGemCommandsUpdateCommand < Gem::TestCase
-
   def setup
     super
     common_installer_setup
@@ -647,5 +646,4 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
     assert_equal "  a-2", out.shift
     assert_empty out
   end
-
 end

--- a/test/rubygems/test_gem_commands_which_command.rb
+++ b/test/rubygems/test_gem_commands_which_command.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/commands/which_command'
 
 class TestGemCommandsWhichCommand < Gem::TestCase
-
   def setup
     super
     Gem::Specification.reset
@@ -82,5 +81,4 @@ class TestGemCommandsWhichCommand < Gem::TestCase
       FileUtils.touch filename
     end
   end
-
 end

--- a/test/rubygems/test_gem_commands_yank_command.rb
+++ b/test/rubygems/test_gem_commands_yank_command.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/commands/yank_command'
 
 class TestGemCommandsYankCommand < Gem::TestCase
-
   def setup
     super
 
@@ -148,5 +147,4 @@ class TestGemCommandsYankCommand < Gem::TestCase
     assert_equal 'key', @fetcher.last_request['Authorization']
     assert_equal [yank_uri], @fetcher.paths
   end
-
 end

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/config_file'
 
 class TestGemConfigFile < Gem::TestCase
-
   def setup
     super
 
@@ -492,5 +491,4 @@ if you believe they were disclosed to a third party.
     util_config_file
     assert_equal(true, @cfg.disable_default_gem_server)
   end
-
 end

--- a/test/rubygems/test_gem_dependency.rb
+++ b/test/rubygems/test_gem_dependency.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/dependency'
 
 class TestGemDependency < Gem::TestCase
-
   def test_initialize
     d = dep "pkg", "> 1.0"
 
@@ -391,5 +390,4 @@ class TestGemDependency < Gem::TestCase
     assert_equal dep("a", " >= 1.a").identity, :abs_latest
     assert_equal dep("a").identity, :latest
   end
-
 end

--- a/test/rubygems/test_gem_dependency_installer.rb
+++ b/test/rubygems/test_gem_dependency_installer.rb
@@ -4,7 +4,6 @@ require 'rubygems/dependency_installer'
 require 'rubygems/security'
 
 class TestGemDependencyInstaller < Gem::TestCase
-
   def setup
     super
     common_installer_setup
@@ -1128,5 +1127,4 @@ class TestGemDependencyInstaller < Gem::TestCase
                               @d1, @d2, @x1_m, @x1_o, @w1, @y1,
                               @y1_1_p, @z1].compact)
   end
-
 end

--- a/test/rubygems/test_gem_dependency_list.rb
+++ b/test/rubygems/test_gem_dependency_list.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/dependency_list'
 
 class TestGemDependencyList < Gem::TestCase
-
   def setup
     super
 
@@ -262,5 +261,4 @@ class TestGemDependencyList < Gem::TestCase
 
     @deplist.add @a1, @a2, @b1, @c2, @d1
   end
-
 end

--- a/test/rubygems/test_gem_dependency_resolution_error.rb
+++ b/test/rubygems/test_gem_dependency_resolution_error.rb
@@ -2,7 +2,6 @@
 require 'rubygems/test_case'
 
 class TestGemDependencyResolutionError < Gem::TestCase
-
   def setup
     super
 
@@ -24,5 +23,4 @@ class TestGemDependencyResolutionError < Gem::TestCase
     assert_match %r{^conflicting dependencies a \(= 1\) and a \(= 2\)$},
                  @error.message
   end
-
 end

--- a/test/rubygems/test_gem_doctor.rb
+++ b/test/rubygems/test_gem_doctor.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/doctor'
 
 class TestGemDoctor < Gem::TestCase
-
   def gem(name)
     spec = quick_gem name do |gem|
       gem.files = %W[lib/#{name}.rb Rakefile]
@@ -192,5 +191,4 @@ Removed file plugins/a_badly_named_file.rb
 
     assert doctor.gem_repository?, 'gems installed'
   end
-
 end

--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -4,7 +4,6 @@ require 'rubygems/ext'
 require 'rubygems/installer'
 
 class TestGemExtBuilder < Gem::TestCase
-
   def setup
     super
 
@@ -134,7 +133,6 @@ install:
 
   def test_build_extensions_install_ext_only
     class << Gem
-
       alias orig_install_extension_in_lib install_extension_in_lib
 
       remove_method :install_extension_in_lib
@@ -142,7 +140,6 @@ install:
       def Gem.install_extension_in_lib
         false
       end
-
     end
 
     @spec.extensions << 'ext/extconf.rb'
@@ -179,11 +176,9 @@ install:
     refute_path_exists File.join @spec.gem_dir, 'lib', 'a', 'b.rb'
   ensure
     class << Gem
-
       remove_method :install_extension_in_lib
 
       alias install_extension_in_lib orig_install_extension_in_lib
-
     end
   end
 
@@ -317,5 +312,4 @@ install:
 
     assert_equal %w[--with-foo-dir=/nonexistent], builder.build_args
   end
-
 end unless Gem.java_platform?

--- a/test/rubygems/test_gem_ext_cmake_builder.rb
+++ b/test/rubygems/test_gem_ext_cmake_builder.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/ext'
 
 class TestGemExtCmakeBuilder < Gem::TestCase
-
   def setup
     super
 
@@ -87,5 +86,4 @@ install (FILES test.txt DESTINATION bin)
     assert_contains_make_command '', output
     assert_contains_make_command 'install', output
   end
-
 end

--- a/test/rubygems/test_gem_ext_configure_builder.rb
+++ b/test/rubygems/test_gem_ext_configure_builder.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/ext'
 
 class TestGemExtConfigureBuilder < Gem::TestCase
-
   def setup
     super
 
@@ -83,5 +82,4 @@ class TestGemExtConfigureBuilder < Gem::TestCase
     assert_contains_make_command '', output[4]
     assert_contains_make_command 'install', output[7]
   end
-
 end

--- a/test/rubygems/test_gem_ext_ext_conf_builder.rb
+++ b/test/rubygems/test_gem_ext_ext_conf_builder.rb
@@ -4,7 +4,6 @@ require 'rubygems/test_case'
 require 'rubygems/ext'
 
 class TestGemExtExtConfBuilder < Gem::TestCase
-
   def setup
     super
 
@@ -240,5 +239,4 @@ end
       RbConfig::CONFIG.delete 'configure_args'
     end
   end
-
 end

--- a/test/rubygems/test_gem_ext_rake_builder.rb
+++ b/test/rubygems/test_gem_ext_rake_builder.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/ext'
 
 class TestGemExtRakeBuilder < Gem::TestCase
-
   def setup
     super
 
@@ -91,5 +90,4 @@ class TestGemExtRakeBuilder < Gem::TestCase
       EO_MKRF
     end
   end
-
 end

--- a/test/rubygems/test_gem_gem_runner.rb
+++ b/test/rubygems/test_gem_gem_runner.rb
@@ -2,7 +2,6 @@
 require 'rubygems/test_case'
 
 class TestGemGemRunner < Gem::TestCase
-
   def setup
     super
 
@@ -108,5 +107,4 @@ class TestGemGemRunner < Gem::TestCase
 
     assert_empty @ui.error
   end
-
 end

--- a/test/rubygems/test_gem_gemcutter_utilities.rb
+++ b/test/rubygems/test_gem_gemcutter_utilities.rb
@@ -5,7 +5,6 @@ require 'rubygems/command'
 require 'rubygems/gemcutter_utilities'
 
 class TestGemGemcutterUtilities < Gem::TestCase
-
   def setup
     super
 
@@ -262,5 +261,4 @@ class TestGemGemcutterUtilities < Gem::TestCase
       @cmd.verify_api_key :missing
     end
   end
-
 end

--- a/test/rubygems/test_gem_impossible_dependencies_error.rb
+++ b/test/rubygems/test_gem_impossible_dependencies_error.rb
@@ -2,7 +2,6 @@
 require 'rubygems/test_case'
 
 class TestGemImpossibleDependenciesError < Gem::TestCase
-
   def test_message_conflict
     request = dependency_request dep('net-ssh', '>= 2.0.13'), 'rye', '0.9.8'
 
@@ -57,5 +56,4 @@ rye-0.9.8 requires net-ssh (>= 2.0.13) but it conflicted:
 
     assert_equal expected, error.message
   end
-
 end

--- a/test/rubygems/test_gem_indexer.rb
+++ b/test/rubygems/test_gem_indexer.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/indexer'
 
 class TestGemIndexer < Gem::TestCase
-
   def setup
     super
 
@@ -355,5 +354,4 @@ class TestGemIndexer < Gem::TestCase
     file = File.join dir, name
     refute File.exist?(file), "#{file} exists"
   end
-
 end

--- a/test/rubygems/test_gem_install_update_options.rb
+++ b/test/rubygems/test_gem_install_update_options.rb
@@ -5,7 +5,6 @@ require 'rubygems/command'
 require 'rubygems/dependency_installer'
 
 class TestGemInstallUpdateOptions < Gem::InstallerTestCase
-
   def setup
     super
 
@@ -193,5 +192,4 @@ class TestGemInstallUpdateOptions < Gem::InstallerTestCase
 
     assert_equal true, @cmd.options[:post_install_message]
   end
-
 end

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -2,7 +2,6 @@
 require 'rubygems/installer_test_case'
 
 class TestGemInstaller < Gem::InstallerTestCase
-
   def setup
     super
     common_installer_setup
@@ -2212,5 +2211,4 @@ gem 'other', version
   def mask
     0100755
   end
-
 end

--- a/test/rubygems/test_gem_local_remote_options.rb
+++ b/test/rubygems/test_gem_local_remote_options.rb
@@ -4,7 +4,6 @@ require 'rubygems/local_remote_options'
 require 'rubygems/command'
 
 class TestGemLocalRemoteOptions < Gem::TestCase
-
   def setup
     super
 
@@ -130,5 +129,4 @@ class TestGemLocalRemoteOptions < Gem::TestCase
 
     assert_equal [@gem_repo], Gem.sources
   end
-
 end

--- a/test/rubygems/test_gem_name_tuple.rb
+++ b/test/rubygems/test_gem_name_tuple.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/name_tuple'
 
 class TestGemNameTuple < Gem::TestCase
-
   def test_full_name
     n = Gem::NameTuple.new "a", Gem::Version.new(0), "ruby"
     assert_equal "a-0", n.full_name
@@ -40,5 +39,4 @@ class TestGemNameTuple < Gem::TestCase
 
     assert_equal 1, a_p.<=>(a)
   end
-
 end

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -4,7 +4,6 @@ require 'rubygems/package/tar_test_case'
 require 'digest'
 
 class TestGemPackage < Gem::Package::TarTestCase
-
   def setup
     super
 
@@ -1173,5 +1172,4 @@ class TestGemPackage < Gem::Package::TarTestCase
 
     StringIO.new tgz_io.string
   end
-
 end

--- a/test/rubygems/test_gem_package_old.rb
+++ b/test/rubygems/test_gem_package_old.rb
@@ -5,7 +5,6 @@ unless Gem.java_platform? # jruby can't require the simple_gem file
   require 'rubygems/simple_gem'
 
   class TestGemPackageOld < Gem::TestCase
-
     def setup
       super
 
@@ -87,6 +86,5 @@ unless Gem.java_platform? # jruby can't require the simple_gem file
                    'and cannot be verified',
                    e.message
     end
-
   end
 end

--- a/test/rubygems/test_gem_package_tar_header.rb
+++ b/test/rubygems/test_gem_package_tar_header.rb
@@ -3,7 +3,6 @@ require 'rubygems/package/tar_test_case'
 require 'rubygems/package'
 
 class TestGemPackageTarHeader < Gem::Package::TarTestCase
-
   def setup
     super
 
@@ -223,5 +222,4 @@ Access_Points_09202018.csv
     assert_equal 0, tar_header.uid
     assert_equal 0, tar_header.gid
   end
-
 end

--- a/test/rubygems/test_gem_package_tar_reader.rb
+++ b/test/rubygems/test_gem_package_tar_reader.rb
@@ -3,7 +3,6 @@ require 'rubygems/package/tar_test_case'
 require 'rubygems/package'
 
 class TestGemPackageTarReader < Gem::Package::TarTestCase
-
   def test_each_entry
     tar = tar_dir_header "foo", "bar", 0, Time.now
     tar << tar_file_header("bar", "baz", 0, 0, Time.now)
@@ -85,5 +84,4 @@ class TestGemPackageTarReader < Gem::Package::TarTestCase
   ensure
     io.close!
   end
-
 end

--- a/test/rubygems/test_gem_package_tar_reader_entry.rb
+++ b/test/rubygems/test_gem_package_tar_reader_entry.rb
@@ -3,7 +3,6 @@ require 'rubygems/package/tar_test_case'
 require 'rubygems/package'
 
 class TestGemPackageTarReaderEntry < Gem::Package::TarTestCase
-
   def setup
     super
 
@@ -150,5 +149,4 @@ class TestGemPackageTarReaderEntry < Gem::Package::TarTestCase
 
     assert_equal char, @entry.getc
   end
-
 end

--- a/test/rubygems/test_gem_package_tar_writer.rb
+++ b/test/rubygems/test_gem_package_tar_writer.rb
@@ -4,7 +4,6 @@ require 'rubygems/package/tar_writer'
 require 'minitest/mock'
 
 class TestGemPackageTarWriter < Gem::Package::TarTestCase
-
   def setup
     super
 
@@ -330,5 +329,4 @@ class TestGemPackageTarWriter < Gem::Package::TarTestCase
     end
     assert_includes exception.message, name
   end
-
 end

--- a/test/rubygems/test_gem_package_task.rb
+++ b/test/rubygems/test_gem_package_task.rb
@@ -13,7 +13,6 @@ unless defined?(Rake::PackageTask)
 end
 
 class TestGemPackageTask < Gem::TestCase
-
   def test_gem_package
     original_rake_fileutils_verbosity = RakeFileUtils.verbose_flag
     RakeFileUtils.verbose_flag = false
@@ -115,5 +114,4 @@ class TestGemPackageTask < Gem::TestCase
 
     assert_equal 'pkg/nokogiri-1.5.0-java', pkg.package_dir_path
   end
-
 end if defined?(Rake::PackageTask)

--- a/test/rubygems/test_gem_path_support.rb
+++ b/test/rubygems/test_gem_path_support.rb
@@ -4,7 +4,6 @@ require 'rubygems'
 require 'fileutils'
 
 class TestGemPathSupport < Gem::TestCase
-
   def setup
     super
 
@@ -140,5 +139,4 @@ class TestGemPathSupport < Gem::TestCase
     assert_equal dir, ps.home
     assert_equal [dir, not_existing], ps.path
   end
-
 end

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -4,7 +4,6 @@ require 'rubygems/platform'
 require 'rbconfig'
 
 class TestGemPlatform < Gem::TestCase
-
   def test_self_local
     util_set_arch 'i686-darwin8.10.1'
 
@@ -305,5 +304,4 @@ class TestGemPlatform < Gem::TestCase
   def refute_local_match(name)
     refute_match Gem::Platform.local, name
   end
-
 end

--- a/test/rubygems/test_gem_rdoc.rb
+++ b/test/rubygems/test_gem_rdoc.rb
@@ -4,7 +4,6 @@ require 'rubygems/test_case'
 require 'rubygems/rdoc'
 
 class TestGemRDoc < Gem::TestCase
-
   Gem::RDoc.load_rdoc
 
   def setup
@@ -134,5 +133,4 @@ class TestGemRDoc < Gem::TestCase
       FileUtils.rm_r @a.doc_dir
     end
   end
-
 end

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -31,7 +31,6 @@ require 'minitest/mock'
 # proxy is configured.
 
 class TestGemRemoteFetcher < Gem::TestCase
-
   include Gem::DefaultUserInteraction
 
   SERVER_DATA = <<-EOY.freeze
@@ -1000,10 +999,8 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
   end
 
   class NilLog < WEBrick::Log
-
     def log(level, data) #Do nothing
     end
-
   end
 
   private
@@ -1145,5 +1142,4 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
   def key(filename)
     OpenSSL::PKey::RSA.new(File.read(File.join(__dir__, filename)))
   end
-
 end if defined?(OpenSSL::SSL)

--- a/test/rubygems/test_gem_request.rb
+++ b/test/rubygems/test_gem_request.rb
@@ -9,7 +9,6 @@ unless defined?(OpenSSL::SSL)
 end
 
 class TestGemRequest < Gem::TestCase
-
   CA_CERT_FILE     = cert_path 'ca'
   CHILD_CERT       = load_cert 'child'
   EXPIRED_CERT     = load_cert 'expired'
@@ -488,7 +487,6 @@ ERROR:  Certificate  is an invalid CA certificate
   end
 
   class Conn
-
     attr_accessor :payload
 
     def new(*args); self; end
@@ -507,7 +505,5 @@ ERROR:  Certificate  is an invalid CA certificate
       self.payload = req
       @response
     end
-
   end
-
 end if defined?(OpenSSL::SSL)

--- a/test/rubygems/test_gem_request_connection_pools.rb
+++ b/test/rubygems/test_gem_request_connection_pools.rb
@@ -4,15 +4,12 @@ require 'rubygems/request'
 require 'timeout'
 
 class TestGemRequestConnectionPool < Gem::TestCase
-
   class FakeHttp
-
     def initialize(*args)
     end
 
     def start
     end
-
   end
 
   def setup
@@ -150,5 +147,4 @@ class TestGemRequestConnectionPool < Gem::TestCase
       end
     end.join
   end
-
 end

--- a/test/rubygems/test_gem_request_set.rb
+++ b/test/rubygems/test_gem_request_set.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/request_set'
 
 class TestGemRequestSet < Gem::TestCase
-
   def setup
     super
 
@@ -668,5 +667,4 @@ ruby "0"
 
     assert_empty deps
   end
-
 end

--- a/test/rubygems/test_gem_request_set_gem_dependency_api.rb
+++ b/test/rubygems/test_gem_request_set_gem_dependency_api.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/request_set'
 
 class TestGemRequestSetGemDependencyAPI < Gem::TestCase
-
   def setup
     super
 
@@ -845,5 +844,4 @@ end
 
     assert_equal engine_version, RUBY_ENGINE_VERSION if engine
   end
-
 end unless Gem.java_platform?

--- a/test/rubygems/test_gem_request_set_lockfile.rb
+++ b/test/rubygems/test_gem_request_set_lockfile.rb
@@ -4,7 +4,6 @@ require 'rubygems/request_set'
 require 'rubygems/request_set/lockfile'
 
 class TestGemRequestSetLockfile < Gem::TestCase
-
   def setup
     super
 
@@ -466,5 +465,4 @@ DEPENDENCIES
 
     assert_equal 'hello', File.read(gem_deps_lock_file)
   end
-
 end

--- a/test/rubygems/test_gem_request_set_lockfile_parser.rb
+++ b/test/rubygems/test_gem_request_set_lockfile_parser.rb
@@ -6,7 +6,6 @@ require 'rubygems/request_set/lockfile/tokenizer'
 require 'rubygems/request_set/lockfile/parser'
 
 class TestGemRequestSetLockfileParser < Gem::TestCase
-
   def setup
     super
     @gem_deps_file = 'gem.deps.rb'
@@ -541,5 +540,4 @@ DEPENDENCIES
     parser = tokenizer.make_parser set, platforms
     parser.parse
   end
-
 end

--- a/test/rubygems/test_gem_request_set_lockfile_tokenizer.rb
+++ b/test/rubygems/test_gem_request_set_lockfile_tokenizer.rb
@@ -6,7 +6,6 @@ require 'rubygems/request_set/lockfile/tokenizer'
 require 'rubygems/request_set/lockfile/parser'
 
 class TestGemRequestSetLockfileTokenizer < Gem::TestCase
-
   def setup
     super
 
@@ -304,5 +303,4 @@ GEM
   def tokenize_lockfile
     Gem::RequestSet::Lockfile::Tokenizer.from_file(@lock_file).to_a
   end
-
 end

--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require "rubygems/requirement"
 
 class TestGemRequirement < Gem::TestCase
-
   def test_concat
     r = req '>= 1'
 
@@ -421,5 +420,4 @@ class TestGemRequirement < Gem::TestCase
     refute req(requirement).satisfied_by?(v(version)),
       "#{requirement} is not satisfied by #{version}"
   end
-
 end

--- a/test/rubygems/test_gem_resolver.rb
+++ b/test/rubygems/test_gem_resolver.rb
@@ -2,7 +2,6 @@
 require 'rubygems/test_case'
 
 class TestGemResolver < Gem::TestCase
-
   def setup
     super
 
@@ -789,5 +788,4 @@ class TestGemResolver < Gem::TestCase
     assert_match "No match for 'a (= 1)' on this platform. Found: c-p-1",
                  e.message
   end
-
 end

--- a/test/rubygems/test_gem_resolver_activation_request.rb
+++ b/test/rubygems/test_gem_resolver_activation_request.rb
@@ -2,7 +2,6 @@
 require 'rubygems/test_case'
 
 class TestGemResolverActivationRequest < Gem::TestCase
-
   def setup
     super
 
@@ -40,5 +39,4 @@ class TestGemResolverActivationRequest < Gem::TestCase
 
     assert @req.installed?
   end
-
 end

--- a/test/rubygems/test_gem_resolver_api_set.rb
+++ b/test/rubygems/test_gem_resolver_api_set.rb
@@ -2,7 +2,6 @@
 require 'rubygems/test_case'
 
 class TestGemResolverAPISet < Gem::TestCase
-
   def setup
     super
 
@@ -204,5 +203,4 @@ class TestGemResolverAPISet < Gem::TestCase
 
     assert_empty set.instance_variable_get :@data
   end
-
 end

--- a/test/rubygems/test_gem_resolver_api_specification.rb
+++ b/test/rubygems/test_gem_resolver_api_specification.rb
@@ -2,7 +2,6 @@
 require 'rubygems/test_case'
 
 class TestGemResolverAPISpecification < Gem::TestCase
-
   def test_initialize
     set = Gem::Resolver::APISet.new
     data = {
@@ -164,5 +163,4 @@ class TestGemResolverAPISpecification < Gem::TestCase
     assert_kind_of Gem::Specification, spec
     assert_equal 'j-1-java', spec.full_name
   end
-
 end

--- a/test/rubygems/test_gem_resolver_best_set.rb
+++ b/test/rubygems/test_gem_resolver_best_set.rb
@@ -2,7 +2,6 @@
 require 'rubygems/test_case'
 
 class TestGemResolverBestSet < Gem::TestCase
-
   def setup
     super
 
@@ -133,5 +132,4 @@ class TestGemResolverBestSet < Gem::TestCase
 
     assert_equal error, e
   end
-
 end

--- a/test/rubygems/test_gem_resolver_composed_set.rb
+++ b/test/rubygems/test_gem_resolver_composed_set.rb
@@ -2,7 +2,6 @@
 require 'rubygems/test_case'
 
 class TestGemResolverComposedSet < Gem::TestCase
-
   def test_errors
     index_set   = Gem::Resolver::IndexSet.new
     current_set = Gem::Resolver::CurrentSet.new
@@ -41,5 +40,4 @@ class TestGemResolverComposedSet < Gem::TestCase
     refute best_set.remote?
     refute current_set.remote?
   end
-
 end

--- a/test/rubygems/test_gem_resolver_conflict.rb
+++ b/test/rubygems/test_gem_resolver_conflict.rb
@@ -2,7 +2,6 @@
 require 'rubygems/test_case'
 
 class TestGemResolverConflict < Gem::TestCase
-
   def test_explanation
     root  =
       dependency_request dep('net-ssh', '>= 2.0.13'), 'rye', '0.9.8'
@@ -79,5 +78,4 @@ class TestGemResolverConflict < Gem::TestCase
 
     assert_equal expected, conflict.request_path(child.requester)
   end
-
 end

--- a/test/rubygems/test_gem_resolver_dependency_request.rb
+++ b/test/rubygems/test_gem_resolver_dependency_request.rb
@@ -2,7 +2,6 @@
 require 'rubygems/test_case'
 
 class TestGemResolverDependencyRequest < Gem::TestCase
-
   def setup
     super
 
@@ -80,5 +79,4 @@ class TestGemResolverDependencyRequest < Gem::TestCase
 
     assert_equal dependency, dr.dependency
   end
-
 end

--- a/test/rubygems/test_gem_resolver_git_set.rb
+++ b/test/rubygems/test_gem_resolver_git_set.rb
@@ -2,7 +2,6 @@
 require 'rubygems/test_case'
 
 class TestGemResolverGitSet < Gem::TestCase
-
   def setup
     super
 
@@ -185,5 +184,4 @@ class TestGemResolverGitSet < Gem::TestCase
 
     assert_equal "#{@gemhome}2", spec.source.root_dir
   end
-
 end

--- a/test/rubygems/test_gem_resolver_git_specification.rb
+++ b/test/rubygems/test_gem_resolver_git_specification.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/installer'
 
 class TestGemResolverGitSpecification < Gem::TestCase
-
   def setup
     super
 
@@ -110,5 +109,4 @@ class TestGemResolverGitSpecification < Gem::TestCase
 
     assert called
   end
-
 end

--- a/test/rubygems/test_gem_resolver_index_set.rb
+++ b/test/rubygems/test_gem_resolver_index_set.rb
@@ -2,7 +2,6 @@
 require 'rubygems/test_case'
 
 class TestGemResolverIndexSet < Gem::TestCase
-
   def setup
     super
 
@@ -85,5 +84,4 @@ class TestGemResolverIndexSet < Gem::TestCase
 
     assert_equal %w[a-1.a], found.map {|s| s.full_name }
   end
-
 end

--- a/test/rubygems/test_gem_resolver_index_specification.rb
+++ b/test/rubygems/test_gem_resolver_index_specification.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/available_set'
 
 class TestGemResolverIndexSpecification < Gem::TestCase
-
   def test_initialize
     set     = Gem::Resolver::IndexSet.new
     source  = Gem::Source.new @gem_repo
@@ -90,5 +89,4 @@ class TestGemResolverIndexSpecification < Gem::TestCase
 
     assert_equal a_2_p.full_name, spec.full_name
   end
-
 end

--- a/test/rubygems/test_gem_resolver_installed_specification.rb
+++ b/test/rubygems/test_gem_resolver_installed_specification.rb
@@ -2,7 +2,6 @@
 require 'rubygems/test_case'
 
 class TestGemResolverInstalledSpecification < Gem::TestCase
-
   def setup
     super
 
@@ -44,5 +43,4 @@ class TestGemResolverInstalledSpecification < Gem::TestCase
 
     assert b_spec.installable_platform?
   end
-
 end

--- a/test/rubygems/test_gem_resolver_installer_set.rb
+++ b/test/rubygems/test_gem_resolver_installer_set.rb
@@ -2,7 +2,6 @@
 require 'rubygems/test_case'
 
 class TestGemResolverInstallerSet < Gem::TestCase
-
   def test_add_always_install
     spec_fetcher do |fetcher|
       fetcher.download 'a', 1
@@ -255,5 +254,4 @@ class TestGemResolverInstallerSet < Gem::TestCase
     refute set.consider_local?
     refute set.consider_remote?
   end
-
 end

--- a/test/rubygems/test_gem_resolver_local_specification.rb
+++ b/test/rubygems/test_gem_resolver_local_specification.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/available_set'
 
 class TestGemResolverLocalSpecification < Gem::TestCase
-
   def setup
     super
 
@@ -41,5 +40,4 @@ class TestGemResolverLocalSpecification < Gem::TestCase
 
     assert b_spec.installable_platform?
   end
-
 end

--- a/test/rubygems/test_gem_resolver_lock_set.rb
+++ b/test/rubygems/test_gem_resolver_lock_set.rb
@@ -2,7 +2,6 @@
 require 'rubygems/test_case'
 
 class TestGemResolverLockSet < Gem::TestCase
-
   def setup
     super
 
@@ -59,5 +58,4 @@ class TestGemResolverLockSet < Gem::TestCase
   def test_prefetch
     assert_respond_to @set, :prefetch
   end
-
 end

--- a/test/rubygems/test_gem_resolver_lock_specification.rb
+++ b/test/rubygems/test_gem_resolver_lock_specification.rb
@@ -4,7 +4,6 @@ require 'rubygems/installer'
 require 'rubygems/resolver'
 
 class TestGemResolverLockSpecification < Gem::TestCase
-
   def setup
     super
 
@@ -95,5 +94,4 @@ class TestGemResolverLockSpecification < Gem::TestCase
 
     assert_same real_spec, l_spec.spec
   end
-
 end

--- a/test/rubygems/test_gem_resolver_requirement_list.rb
+++ b/test/rubygems/test_gem_resolver_requirement_list.rb
@@ -2,7 +2,6 @@
 require 'rubygems/test_case'
 
 class TestGemResolverRequirementList < Gem::TestCase
-
   def setup
     super
 
@@ -16,5 +15,4 @@ class TestGemResolverRequirementList < Gem::TestCase
 
     assert_equal [req], @list.each.to_a
   end
-
 end

--- a/test/rubygems/test_gem_resolver_specification.rb
+++ b/test/rubygems/test_gem_resolver_specification.rb
@@ -2,9 +2,7 @@
 require 'rubygems/test_case'
 
 class TestGemResolverSpecification < Gem::TestCase
-
   class TestSpec < Gem::Resolver::Specification
-
     attr_writer :source
     attr_reader :spec
 
@@ -13,7 +11,6 @@ class TestGemResolverSpecification < Gem::TestCase
 
       @spec = spec
     end
-
   end
 
   def test_install
@@ -62,5 +59,4 @@ class TestGemResolverSpecification < Gem::TestCase
 
     assert_equal source, a_spec.source
   end
-
 end

--- a/test/rubygems/test_gem_resolver_vendor_set.rb
+++ b/test/rubygems/test_gem_resolver_vendor_set.rb
@@ -2,7 +2,6 @@
 require 'rubygems/test_case'
 
 class TestGemResolverVendorSet < Gem::TestCase
-
   def setup
     super
 
@@ -79,5 +78,4 @@ class TestGemResolverVendorSet < Gem::TestCase
       @set.load_spec 'b', v(1), Gem::Platform::RUBY, nil
     end
   end
-
 end

--- a/test/rubygems/test_gem_resolver_vendor_specification.rb
+++ b/test/rubygems/test_gem_resolver_vendor_specification.rb
@@ -2,7 +2,6 @@
 require 'rubygems/test_case'
 
 class TestGemResolverVendorSpecification < Gem::TestCase
-
   def setup
     super
 
@@ -79,5 +78,4 @@ class TestGemResolverVendorSpecification < Gem::TestCase
 
     assert_equal v(1), v_spec.version
   end
-
 end

--- a/test/rubygems/test_gem_security.rb
+++ b/test/rubygems/test_gem_security.rb
@@ -11,7 +11,6 @@ if Gem.java_platform?
 end
 
 class TestGemSecurity < Gem::TestCase
-
   CHILD_KEY = load_key 'child'
 
   ALTERNATE_CERT = load_cert 'child'
@@ -310,5 +309,4 @@ class TestGemSecurity < Gem::TestCase
 
     assert_equal key.to_pem, key_from_file.to_pem
   end
-
 end if defined?(OpenSSL::SSL) && !Gem.java_platform?

--- a/test/rubygems/test_gem_security_policy.rb
+++ b/test/rubygems/test_gem_security_policy.rb
@@ -7,7 +7,6 @@ unless defined?(OpenSSL::SSL)
 end
 
 class TestGemSecurityPolicy < Gem::TestCase
-
   ALTERNATE_KEY    = load_key 'alternate'
   INVALID_KEY      = load_key 'invalid'
   CHILD_KEY        = load_key 'child'
@@ -533,5 +532,4 @@ class TestGemSecurityPolicy < Gem::TestCase
 
     return digests, signatures
   end
-
 end if defined?(OpenSSL::SSL)

--- a/test/rubygems/test_gem_security_signer.rb
+++ b/test/rubygems/test_gem_security_signer.rb
@@ -6,7 +6,6 @@ unless defined?(OpenSSL::SSL)
 end
 
 class TestGemSecuritySigner < Gem::TestCase
-
   ALTERNATE_KEY  = load_key 'alternate'
   CHILD_KEY      = load_key 'child'
   GRANDCHILD_KEY = load_key 'grandchild'
@@ -215,5 +214,4 @@ toqvglr0kdbknSRRjBVLK6tsgr07aLT9gNP7mTW2PA==
       signer.sign 'hello'
     end
   end
-
 end if defined?(OpenSSL::SSL)

--- a/test/rubygems/test_gem_security_trust_dir.rb
+++ b/test/rubygems/test_gem_security_trust_dir.rb
@@ -6,7 +6,6 @@ unless defined?(OpenSSL::SSL)
 end
 
 class TestGemSecurityTrustDir < Gem::TestCase
-
   CHILD_CERT = load_cert 'child'
 
   def setup
@@ -96,5 +95,4 @@ class TestGemSecurityTrustDir < Gem::TestCase
 
     assert_equal mask, File.stat(@dest_dir).mode unless win_platform?
   end
-
 end if defined?(OpenSSL::SSL)

--- a/test/rubygems/test_gem_server.rb
+++ b/test/rubygems/test_gem_server.rb
@@ -4,13 +4,10 @@ require 'rubygems/server'
 require 'stringio'
 
 class Gem::Server
-
   attr_reader :server
-
 end
 
 class TestGemServer < Gem::TestCase
-
   def process_based_port
     0
   end
@@ -608,5 +605,4 @@ class TestGemServer < Gem::TestCase
 
     @server.instance_variable_set :@server, webrick
   end
-
 end

--- a/test/rubygems/test_gem_silent_ui.rb
+++ b/test/rubygems/test_gem_silent_ui.rb
@@ -4,7 +4,6 @@ require 'rubygems/user_interaction'
 require 'timeout'
 
 class TestGemSilentUI < Gem::TestCase
-
   def setup
     super
     @sui = Gem::SilentUI.new
@@ -114,5 +113,4 @@ class TestGemSilentUI < Gem::TestCase
     assert_empty out, 'No output'
     assert_empty err, 'No output'
   end
-
 end

--- a/test/rubygems/test_gem_source.rb
+++ b/test/rubygems/test_gem_source.rb
@@ -4,7 +4,6 @@ require 'rubygems/source'
 require 'rubygems/indexer'
 
 class TestGemSource < Gem::TestCase
-
   def tuple(*args)
     Gem::NameTuple.new(*args)
   end
@@ -246,5 +245,4 @@ class TestGemSource < Gem::TestCase
     distance_threshold = 5
     assert rubygems_source.typo_squatting?("rubysertgems.org", distance_threshold)
   end
-
 end

--- a/test/rubygems/test_gem_source_fetch_problem.rb
+++ b/test/rubygems/test_gem_source_fetch_problem.rb
@@ -2,7 +2,6 @@
 require 'rubygems/test_case'
 
 class TestGemSourceFetchProblem < Gem::TestCase
-
   def test_exception
     source = Gem::Source.new @gem_repo
     error  = RuntimeError.new 'test'
@@ -24,5 +23,4 @@ class TestGemSourceFetchProblem < Gem::TestCase
 
     refute_match sf.wordy, 'secret'
   end
-
 end

--- a/test/rubygems/test_gem_source_git.rb
+++ b/test/rubygems/test_gem_source_git.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/source'
 
 class TestGemSourceGit < Gem::TestCase
-
   def setup
     super
 
@@ -300,5 +299,4 @@ class TestGemSourceGit < Gem::TestCase
     assert_equal '291c4caac7feba8bb64c297987028acb3dde6cfe',
                  source.uri_hash
   end
-
 end

--- a/test/rubygems/test_gem_source_installed.rb
+++ b/test/rubygems/test_gem_source_installed.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/source'
 
 class TestGemSourceInstalled < Gem::TestCase
-
   def test_spaceship
     a1 = quick_gem 'a', '1'
     util_build_gem a1
@@ -32,5 +31,4 @@ class TestGemSourceInstalled < Gem::TestCase
     assert_equal(1, vendor.<=>(installed), 'vendor <=> installed')
     assert_equal(-1, installed.<=>(vendor), 'installed <=> vendor')
   end
-
 end

--- a/test/rubygems/test_gem_source_list.rb
+++ b/test/rubygems/test_gem_source_list.rb
@@ -3,7 +3,6 @@ require 'rubygems/source_list'
 require 'rubygems/test_case'
 
 class TestGemSourceList < Gem::TestCase
-
   def setup
     super
 
@@ -115,5 +114,4 @@ class TestGemSourceList < Gem::TestCase
     @sl.delete Gem::Source.new(@uri)
     assert_equal @sl.sources, []
   end
-
 end

--- a/test/rubygems/test_gem_source_local.rb
+++ b/test/rubygems/test_gem_source_local.rb
@@ -5,7 +5,6 @@ require 'rubygems/source'
 require 'fileutils'
 
 class TestGemSourceLocal < Gem::TestCase
-
   def setup
     super
 
@@ -104,5 +103,4 @@ class TestGemSourceLocal < Gem::TestCase
     assert_equal(-1, specific.<=>(local), 'specific <=> local')
     assert_equal(1, local.<=>(specific), 'local <=> specific')
   end
-
 end

--- a/test/rubygems/test_gem_source_lock.rb
+++ b/test/rubygems/test_gem_source_lock.rb
@@ -2,7 +2,6 @@
 require 'rubygems/test_case'
 
 class TestGemSourceLock < Gem::TestCase
-
   def test_fetch_spec
     spec_fetcher do |fetcher|
       fetcher.spec 'a', 1
@@ -110,5 +109,4 @@ class TestGemSourceLock < Gem::TestCase
 
     assert_equal URI(@gem_repo), lock.uri
   end
-
 end

--- a/test/rubygems/test_gem_source_specific_file.rb
+++ b/test/rubygems/test_gem_source_specific_file.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/source'
 
 class TestGemSourceSpecificFile < Gem::TestCase
-
   def setup
     super
 
@@ -73,5 +72,4 @@ class TestGemSourceSpecificFile < Gem::TestCase
     assert_equal(0, a1_source.<=>(a1_source), 'a1_source <=> a1_source')
     assert_equal(1, a2_source.<=>(a1_source), 'a2_source <=> a1_source')
   end
-
 end

--- a/test/rubygems/test_gem_source_vendor.rb
+++ b/test/rubygems/test_gem_source_vendor.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/source'
 
 class TestGemSourceVendor < Gem::TestCase
-
   def test_initialize
     source = Gem::Source::Vendor.new 'vendor/foo'
 
@@ -27,5 +26,4 @@ class TestGemSourceVendor < Gem::TestCase
     assert_equal(1, vendor.<=>(installed), 'vendor <=> installed')
     assert_equal(-1, installed.<=>(vendor), 'installed <=> vendor')
   end
-
 end

--- a/test/rubygems/test_gem_spec_fetcher.rb
+++ b/test/rubygems/test_gem_spec_fetcher.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/spec_fetcher'
 
 class TestGemSpecFetcher < Gem::TestCase
-
   def tuple(*args)
     Gem::NameTuple.new(*args)
   end
@@ -335,5 +334,4 @@ class TestGemSpecFetcher < Gem::TestCase
     assert_equal({}, specs)
     assert_kind_of Gem::SourceFetchProblem, errors.first
   end
-
 end

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -9,7 +9,6 @@ require 'rubygems/installer'
 require 'rubygems/platform'
 
 class TestGemSpecification < Gem::TestCase
-
   LEGACY_YAML_SPEC = <<-EOF.freeze
 --- !ruby/object:Gem::Specification
 rubygems_version: "1.0"
@@ -1837,7 +1836,6 @@ dependencies: []
       RbConfig::CONFIG['ENABLE_SHARED'], 'no'
 
     class << Gem
-
       alias orig_default_ext_dir_for default_ext_dir_for
 
       remove_method :default_ext_dir_for
@@ -1845,7 +1843,6 @@ dependencies: []
       def Gem.default_ext_dir_for(base_dir)
         'elsewhere'
       end
-
     end
 
     ext_spec
@@ -1859,11 +1856,9 @@ dependencies: []
     RbConfig::CONFIG['ENABLE_SHARED'] = enable_shared
 
     class << Gem
-
       remove_method :default_ext_dir_for
 
       alias default_ext_dir_for orig_default_ext_dir_for
-
     end
   end
 
@@ -2153,11 +2148,9 @@ dependencies: []
 
   def test_require_paths_default_ext_dir_for
     class << Gem
-
       send :alias_method, :orig_default_ext_dir_for, :default_ext_dir_for
 
       remove_method :default_ext_dir_for
-
     end
 
     def Gem.default_ext_dir_for(base_dir)
@@ -2173,11 +2166,9 @@ dependencies: []
     end
   ensure
     class << Gem
-
       send :remove_method, :default_ext_dir_for
       send :alias_method,  :default_ext_dir_for, :orig_default_ext_dir_for
       send :remove_method, :orig_default_ext_dir_for
-
     end
   end
 
@@ -3926,5 +3917,4 @@ end
   ensure
     $VERBOSE = old_verbose
   end
-
 end

--- a/test/rubygems/test_gem_stream_ui.rb
+++ b/test/rubygems/test_gem_stream_ui.rb
@@ -4,7 +4,6 @@ require 'rubygems/user_interaction'
 require 'timeout'
 
 class TestGemStreamUI < Gem::TestCase
-
   # increase timeout with MJIT for --jit-wait testing
   mjit_enabled = defined?(RubyVM::MJIT) && RubyVM::MJIT.enabled?
   SHORT_TIMEOUT = (RUBY_ENGINE == "ruby" && !mjit_enabled) ? 0.1 : 1.0
@@ -222,5 +221,4 @@ class TestGemStreamUI < Gem::TestCase
     reporter.fetch 'a.gem', 1024
     assert_equal "", @out.string
   end
-
 end

--- a/test/rubygems/test_gem_stub_specification.rb
+++ b/test/rubygems/test_gem_stub_specification.rb
@@ -3,7 +3,6 @@ require "rubygems/test_case"
 require "rubygems/stub_specification"
 
 class TestStubSpecification < Gem::TestCase
-
   FOO = File.join SPECIFICATIONS, "foo-0.0.1-x86-mswin32.gemspec"
   BAR = File.join SPECIFICATIONS, "bar-0.0.2.gemspec"
 
@@ -291,5 +290,4 @@ end
       return stub
     end
   end
-
 end

--- a/test/rubygems/test_gem_text.rb
+++ b/test/rubygems/test_gem_text.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require "rubygems/text"
 
 class TestGemText < Gem::TestCase
-
   include Gem::Text
 
   def test_format_text
@@ -94,5 +93,4 @@ Without the wrapping, the text might not look good in the RSS feed.
   def test_clean_text
     assert_equal ".]2;nyan.", clean_text("\e]2;nyan\a")
   end
-
 end

--- a/test/rubygems/test_gem_uninstaller.rb
+++ b/test/rubygems/test_gem_uninstaller.rb
@@ -3,7 +3,6 @@ require 'rubygems/installer_test_case'
 require 'rubygems/uninstaller'
 
 class TestGemUninstaller < Gem::InstallerTestCase
-
   def setup
     super
     @installer = setup_base_installer
@@ -665,5 +664,4 @@ create_makefile '#{@spec.name}'
 
     refute File.exist?(plugin_path), 'last version uninstalled, but plugin still present'
   end
-
 end

--- a/test/rubygems/test_gem_unsatisfiable_dependency_error.rb
+++ b/test/rubygems/test_gem_unsatisfiable_dependency_error.rb
@@ -2,7 +2,6 @@
 require 'rubygems/test_case'
 
 class TestGemUnsatisfiableDependencyError < Gem::TestCase
-
   def setup
     super
 
@@ -28,5 +27,4 @@ class TestGemUnsatisfiableDependencyError < Gem::TestCase
   def test_version
     assert_equal @a_dep.requirement, @e.version
   end
-
 end

--- a/test/rubygems/test_gem_uri_formatter.rb
+++ b/test/rubygems/test_gem_uri_formatter.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/uri_formatter'
 
 class TestGemUriFormatter < Gem::TestCase
-
   def test_normalize_uri
     assert_equal 'FILE://example/',
       Gem::UriFormatter.new('FILE://example/').normalize
@@ -24,5 +23,4 @@ class TestGemUriFormatter < Gem::TestCase
   def test_unescape
     assert_equal 'a@b\c', Gem::UriFormatter.new('a%40b%5Cc').unescape
   end
-
 end

--- a/test/rubygems/test_gem_util.rb
+++ b/test/rubygems/test_gem_util.rb
@@ -3,7 +3,6 @@ require 'rubygems/test_case'
 require 'rubygems/util'
 
 class TestGemUtil < Gem::TestCase
-
   def test_class_popen
     skip "popen with a block does not behave well on jruby" if Gem.java_platform?
     assert_equal "0\n", Gem::Util.popen(*ruby_with_rubygems_in_load_path, '-e', 'p 0')
@@ -86,5 +85,4 @@ class TestGemUtil < Gem::TestCase
     path = "/home/skillet"
     assert_equal "/home/skillet", Gem::Util.correct_for_windows_path(path)
   end
-
 end

--- a/test/rubygems/test_gem_validator.rb
+++ b/test/rubygems/test_gem_validator.rb
@@ -4,7 +4,6 @@ require "rubygems/test_case"
 require "rubygems/validator"
 
 class TestGemValidator < Gem::TestCase
-
   def setup
     super
 
@@ -40,5 +39,4 @@ class TestGemValidator < Gem::TestCase
 
     assert_empty alien
   end
-
 end

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -5,7 +5,6 @@ require "rubygems/version"
 require "minitest/benchmark"
 
 class TestGemVersion < Gem::TestCase
-
   class V < ::Gem::Version
   end
 
@@ -298,5 +297,4 @@ class TestGemVersion < Gem::TestCase
   def refute_version_equal(unexpected, actual)
     refute_equal v(unexpected), v(actual)
   end
-
 end

--- a/test/rubygems/test_gem_version_option.rb
+++ b/test/rubygems/test_gem_version_option.rb
@@ -4,7 +4,6 @@ require 'rubygems/command'
 require 'rubygems/version_option'
 
 class TestGemVersionOption < Gem::TestCase
-
   def setup
     super
 
@@ -162,5 +161,4 @@ class TestGemVersionOption < Gem::TestCase
 
     assert_equal expected, @cmd.options
   end
-
 end

--- a/test/rubygems/test_kernel.rb
+++ b/test/rubygems/test_kernel.rb
@@ -2,7 +2,6 @@
 require 'rubygems/test_case'
 
 class TestKernel < Gem::TestCase
-
   def setup
     super
 
@@ -137,5 +136,4 @@ class TestKernel < Gem::TestCase
       assert $:.any? {|p| %r{bundler-1/lib} =~ p }
     end
   end
-
 end

--- a/test/rubygems/test_project_sanity.rb
+++ b/test/rubygems/test_project_sanity.rb
@@ -4,7 +4,6 @@ require "rubygems/test_case"
 require "open3"
 
 class TestProjectSanity < Gem::TestCase
-
   def test_manifest_is_up_to_date
     skip unless File.exist?(File.expand_path("../../../Rakefile", __FILE__))
 
@@ -18,5 +17,4 @@ class TestProjectSanity < Gem::TestCase
 
     assert status.success?, err
   end
-
 end

--- a/test/rubygems/test_remote_fetch_error.rb
+++ b/test/rubygems/test_remote_fetch_error.rb
@@ -2,7 +2,6 @@
 require 'rubygems/test_case'
 
 class TestRemoteFetchError < Gem::TestCase
-
   def test_password_redacted
     error = Gem::RemoteFetcher::FetchError.new('There was an error fetching', 'https://user:secret@gemsource.org')
     refute_match 'secret', error.to_s
@@ -17,5 +16,4 @@ class TestRemoteFetchError < Gem::TestCase
     error = Gem::RemoteFetcher::FetchError.new('There was an error fetching', 'https://gemsource.org')
     assert_equal error.to_s, 'There was an error fetching (https://gemsource.org)'
   end
-
 end

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -3,9 +3,7 @@ require 'rubygems/test_case'
 require 'rubygems'
 
 class TestGemRequire < Gem::TestCase
-
   class Latch
-
     def initialize(count = 1)
       @count = count
       @lock  = Monitor.new
@@ -24,7 +22,6 @@ class TestGemRequire < Gem::TestCase
         @cv.wait_while { @count > 0 }
       end
     end
-
   end
 
   def setup
@@ -568,10 +565,8 @@ class TestGemRequire < Gem::TestCase
   def test_try_activate_error_unlocks_require_monitor
     silence_warnings do
       class << ::Gem
-
         alias old_try_activate try_activate
         def try_activate(*); raise 'raised from try_activate'; end
-
       end
     end
 
@@ -582,9 +577,7 @@ class TestGemRequire < Gem::TestCase
   ensure
     silence_warnings do
       class << ::Gem
-
         alias try_activate old_try_activate
-
       end
     end
     Kernel::RUBYGEMS_ACTIVATION_MONITOR.exit
@@ -740,5 +733,4 @@ class TestGemRequire < Gem::TestCase
 
     dash_i_lib_arg
   end
-
 end

--- a/util/cops/deprecations.rb
+++ b/util/cops/deprecations.rb
@@ -15,7 +15,6 @@ module RuboCop
       #   # the `deprecate` call is fully removed
       #
       class Deprecations < Cop
-
         def on_send(node)
           _receiver, method_name, *args = *node
           return unless method_name == :rubygems_deprecate || method_name == :rubygems_deprecate_command
@@ -29,7 +28,6 @@ module RuboCop
           msg = "Remove `#{node.method_name}` calls for the next major release "
           format(msg, method: node.method_name)
         end
-
       end
     end
   end

--- a/util/create_certs.rb
+++ b/util/create_certs.rb
@@ -3,7 +3,6 @@ require 'openssl'
 require 'time'
 
 class CertificateBuilder
-
   attr_reader :start
 
   def initialize(key_size = 2048)
@@ -105,7 +104,6 @@ class CertificateBuilder
 
     [validity, validity_32]
   end
-
 end
 
 cb = CertificateBuilder.new


### PR DESCRIPTION
# Description:

Another small step towards normalizing `rubygems` and `bundler` code style.

In this case:

* I enforced no empty lines around class body inside `rubygems` to normalize the code style with the one `bundler` uses.
* ~I enabled `Style/IfInsideElse` inside `rubygems` to normalize the code style with the one `bundler` uses.~ Ended up disabling the cop.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
