### PR TITLE
Enable release-drafter

### DIFF
--- a/.github/release-drafter-bundler.yml
+++ b/.github/release-drafter-bundler.yml
@@ -1,0 +1,75 @@
+---
+
+template: |
+  ## (Unreleased)
+
+  $CHANGES
+
+name-template: "bundler-v$RESOLVED_VERSION"
+
+tag-template: "bundler-v$RESOLVED_VERSION"
+
+categories:
+  - title: "Security fixes:"
+    labels:
+      - "bundler: security fix"
+
+  - title: "Breaking Changes:"
+    labels:
+      - "bundler: breaking change"
+
+  - title: "Major enhancements:"
+    labels:
+      - "bundler: major enhancement"
+
+  - title: "Deprecations:"
+    labels:
+      - "bundler: deprecation"
+
+  - title: "Features:"
+    labels:
+      - "bundler: feature"
+
+  - title: "Performance:"
+    labels:
+      - "bundler: performance"
+
+  - title: "Documentation:"
+    labels:
+      - "bundler: documentation"
+
+  - title: "Minor enhancements:"
+    labels:
+      - "bundler: minor enhancement"
+
+  - title: "Bug fixes:"
+    labels:
+      - "bundler: bug fix"
+
+change-template: "  - $TITLE [#$NUMBER]($URL)"
+
+no-changes-template: "  No changes."
+
+include-labels:
+  - "bundler: security fix"
+  - "bundler: breaking change"
+  - "bundler: major enhancement"
+  - "bundler: deprecation"
+  - "bundler: feature"
+  - "bundler: performance"
+  - "bundler: documentation"
+  - "bundler: minor enhancement"
+  - "bundler: bug fix"
+
+version-resolver:
+  major:
+    labels:
+      - "bundler: breaking change"
+
+  minor:
+    labels:
+      - "bundler: feature"
+      - "bundler: major enhancement"
+      - "bundler: deprecation"
+
+  default: patch

--- a/.github/workflows/release-drafter-bundler.yml
+++ b/.github/workflows/release-drafter-bundler.yml
@@ -1,0 +1,17 @@
+name: release-drafter-bundler
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release_drafter_bundler:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Publish changelog draft
+        uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-bundler.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1240,9 +1240,6 @@ Performance:
 Bug fixes:
 
   - only warn on invalid gemspecs (@indirect)
-
-Bug fixes:
-
   - fix installing dependencies in the correct order ([#3799](https://github.com/rubygems/bundler/issues/3799), @pducks32)
   - fix sorting of mixed DependencyLists ([#3762](https://github.com/rubygems/bundler/issues/3762), @tony-spataro-rs)
   - fix `install_if` conditionals when using the block form (@danieltdt)
@@ -1252,9 +1249,6 @@ Bug fixes:
 Bug fixes:
 
   - don't add or update BUNDLED WITH during `install` with no changes (@segiddins)
-
-Bug fixes:
-
   - fix sorting of mixed DependencyLists with RubyGems >= 2.23 ([#3762](https://github.com/rubygems/bundler/issues/3762), @tony-spataro-rs)
   - speed up resolver for path and git gems (@segiddins)
   - fix `install --force` to not reinstall Bundler ([#3743](https://github.com/rubygems/bundler/issues/3743), @karlo57)

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## (Unreleased)
+
+  No changes.
+
 ## 2.2.0.rc.1 (Jul 02, 2020)
 
 Major enhancements:


### PR DESCRIPTION
# Description:

In #3792 I'm proposing a whole new workflow for managing our changelog. But there's too many tasks in there, including stuff that pushes directly to master, so I prefer to enable one change at a time to make sure that everything works correctly.

In this PR I only enable [release-drafter](https://github.com/release-drafter/release-drafter) to publish a new release draft to github every time a PR with a relevant label is merged. 

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
