### PR TITLE
Explicitly pass target version & tag to release drafter

### DIFF
--- a/.github/release-drafter-bundler.yml
+++ b/.github/release-drafter-bundler.yml
@@ -5,10 +5,6 @@ template: |
 
   $CHANGES
 
-name-template: "bundler-v$RESOLVED_VERSION"
-
-tag-template: "bundler-v$RESOLVED_VERSION"
-
 categories:
   - title: "Security fixes:"
     labels:
@@ -60,16 +56,3 @@ include-labels:
   - "bundler: documentation"
   - "bundler: minor enhancement"
   - "bundler: bug fix"
-
-version-resolver:
-  major:
-    labels:
-      - "bundler: breaking change"
-
-  minor:
-    labels:
-      - "bundler: feature"
-      - "bundler: major enhancement"
-      - "bundler: deprecation"
-
-  default: patch

--- a/.github/release-drafter-bundler.yml
+++ b/.github/release-drafter-bundler.yml
@@ -1,8 +1,6 @@
 ---
 
 template: |
-  ## (Unreleased)
-
   $CHANGES
 
 categories:

--- a/.github/workflows/release-drafter-bundler.yml
+++ b/.github/workflows/release-drafter-bundler.yml
@@ -20,11 +20,13 @@ jobs:
       - name: Get target version
         id: get_target_version
         run: echo "::set-output name=target_version::$(bin/rake release:target_version)"
+        working-directory: ./bundler
 
       - name: Publish changelog draft
         uses: release-drafter/release-drafter@v5
         with:
           config-name: release-drafter-bundler.yml
-          version: ${{ steps.get_target_version.outputs.target_version }}
+          version: bundler-v${{ steps.get_target_version.outputs.target_version }}
+          tag: bundler-v${{ steps.get_target_version.outputs.target_version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter-bundler.yml
+++ b/.github/workflows/release-drafter-bundler.yml
@@ -9,9 +9,22 @@ jobs:
   release_drafter_bundler:
     runs-on: ubuntu-18.04
     steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler: none
+
+      - name: Get target version
+        id: get_target_version
+        run: echo "::set-output name=target_version::$(bin/rake release:target_version)"
+
       - name: Publish changelog draft
         uses: release-drafter/release-drafter@v5
         with:
           config-name: release-drafter-bundler.yml
+          version: ${{ steps.get_target_version.outputs.target_version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -1,22 +1,6 @@
 # frozen_string_literal: true
 
-require "benchmark"
-
 require_relative "spec/support/rubygems_ext"
-
-# Benchmark task execution
-module Rake
-  class Task
-    alias_method :real_invoke, :invoke
-
-    def invoke(*args)
-      time = Benchmark.measure(@name) do
-        real_invoke(*args)
-      end
-      puts "#{@name} ran for #{time}"
-    end
-  end
-end
 
 desc "Run specs"
 task :spec do

--- a/bundler/lib/bundler/version.rb
+++ b/bundler/lib/bundler/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
 
 module Bundler
-  VERSION = "2.2.0.rc.1".freeze
+  VERSION = "2.2.0.rc.2".freeze
 
   def self.bundler_major_version
     @bundler_major_version ||= VERSION.split(".").first.to_i

--- a/bundler/task/release.rake
+++ b/bundler/task/release.rake
@@ -16,7 +16,7 @@ namespace :build_metadata do
 end
 
 task :build => ["build_metadata"] do
-  Rake::Task["build_metadata:clean"].tap(&:reenable).real_invoke
+  Rake::Task["build_metadata:clean"].tap(&:reenable).invoke
 end
 task "release:rubygem_push" => ["release:verify_docs", "release:verify_github", "build_metadata", "release:github"]
 

--- a/bundler/task/release.rake
+++ b/bundler/task/release.rake
@@ -136,6 +136,11 @@ namespace :release do
                                  }
   end
 
+  desc "Prints the current version in the version file, which should be the next release target"
+  task :target_version do
+    print Bundler::GemHelper.gemspec.version
+  end
+
   desc "Prepare a patch release with the PRs from master in the patch milestone"
   task :prepare_patch, :version do |_t, args|
     version = args.version


### PR DESCRIPTION
# Description:

Release drafter is not smart enough to figure out the version we want to release next. At least, not in the case of prereleases. Pass it explicitly instead.

In addtion to that, I only removed the "(Unreleased)" header from the release draft, since it doesn't provide any value.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
