### PR TITLE
Iterate on automatic changelog management

### DIFF
--- a/.github/workflows/release-drafter-bundler.yml
+++ b/.github/workflows/release-drafter-bundler.yml
@@ -47,4 +47,4 @@ jobs:
         run: |
           git add bundler/CHANGELOG.md
           git commit -m "Automatic changelog update"
-          git show
+          git push origin master

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,27 +64,42 @@ can help with. That are marked with a light gray `contribution: *`
 
 ### Type
 
-Most Issues or pull requests will have a light green `type: *` label,  which
-describes the type of the issue or pull request.
+Issues might have a light green `type: *` label,  which describes the type of
+the issue.
 
 *   **bug report** - An issue describing a bug in rubygems. This would be
     something that is broken, confusing, unexpected behavior etc.
-*   **bug fix** - A pull request that fixes a bug report.
 *   **feature request** - An issue describing a request for a new feature or
     enhancement.
-*   **feature implementation** - A pull request implementing a feature
-    request.
 *   **question** - An issue that is a more of a question than a call for
     specific changes in the codebase.
-*   **cleanup** - Generally for a pull request that improves the code base
-    without fixing a bug or implementing a feature.
-*   **major bump** - This issue or pull request requires a major version bump
+*   **cleanup** - An issue that proposes cleanups to the code base without
+    fixing a bug or implementing a feature.
+*   **major bump** - This issue  request requires a major version bump
 *   **administrative** - This issue relates to administrative tasks that need
     to take place as it relates to rubygems
 *   **documentation** - This issue relates to improving the documentation for
     in this repo. Note that much of the rubygems documentation is here:
     https://github.com/rubygems/guides
 
+Pull request might have a light orange `rubygems: *` or a light blue `bundler:
+*` label which describes the pull request according to the following criteria:
+
+*   **security fix** - A pull request that fixes a security issue.
+*   **breaking change** - A pull request including any change that requires a
+    major version bump.
+*   **major enhancement** - A pull request including a backwards compatible
+    change worth a special mention in the changelog
+*   **deprecation** - A pull request that introduces a deprecation.
+*   **feature** - A pull request implementing a feature request.
+*   **deprecation** - A pull request that implements a performance improvement.
+*   **documentation** - A pull request introducing documentation improvements
+    worth mentioning to end users.
+*   **minor enhancements** - A pull request introducing small but user visible changes.
+*   **bug fix** - A pull request that fixes a bug report.
+
+In the case of `bundler`, these labels are set by maintainers on PRs and have
+special importance because they are used to automatically build the changelog.
 
 ### Workflow / Status
 

--- a/bundler/doc/README.md
+++ b/bundler/doc/README.md
@@ -30,4 +30,5 @@ If you'd like to help make Bundler better, you totally rock! Thanks for helping 
 
 ## Maintainers
 
+* [Merging pull requests](playbooks/MERGING_A_PR.md)
 * [Releasing Bundler](playbooks/RELEASING.md)

--- a/bundler/doc/README.md
+++ b/bundler/doc/README.md
@@ -21,10 +21,13 @@ If you'd like to help make Bundler better, you totally rock! Thanks for helping 
 * [Development setup](development/SETUP.md)
 * [Submitting pull requests](development/PULL_REQUESTS.md)
 * [Adding new features](development/NEW_FEATURES.md)
-* [Releasing Bundler](development/RELEASING.md)
 
 ## Documentation
 
 * [Overview](documentation/README.md)
 * [Writing docs for man pages](documentation/WRITING.md)
 * [Documentation vision](documentation/VISION.md)
+
+## Maintainers
+
+* [Releasing Bundler](playbooks/RELEASING.md)

--- a/bundler/doc/development/README.md
+++ b/bundler/doc/development/README.md
@@ -13,7 +13,3 @@ An overview of our preferred PR process, including how to run the test suite and
 ## [Adding new features](NEW_FEATURES.md)
 
 Guidelines for proposing and writing new features for Bundler.
-
-## [Releasing Bundler](RELEASING.md)
-
-A broad-strokes overview of the release process adhered to by the Bundler core team.

--- a/bundler/doc/playbooks/MERGING_A_PR.md
+++ b/bundler/doc/playbooks/MERGING_A_PR.md
@@ -1,0 +1,35 @@
+# Merging a PR
+
+Bundler requires all CI status checks to pass before a PR can me merged. So make
+sure that's the case before merging.
+
+Also, bundler manages the changelog and github release drafts automatically
+using information from merged PRs. So, if a PR has user visible changes that
+should be included in a future release, make sure the following information is
+accurate:
+
+* The PR has a good descriptive title. That will be the wording for the
+  corresponding changelog entry.
+
+* The PR has an accurate label. If a PR is to be included in a release, the
+  label must be one of the following:
+
+  * "bundler: security fix"
+  * "bundler: breaking change"
+  * "bundler: major enhancement"
+  * "bundler: deprecation"
+  * "bundler: feature"
+  * "bundler: performance"
+  * "bundler: documentation"
+  * "bundler: minor enhancement"
+  * "bundler: bug fix"
+
+  This label will indicate the section in the changelog that the PR will take,
+  and will also define the target version for the next release. For example, if
+  you merge a PR tagged as "type: breaking change", the next target version used
+  for the github release draft will be a major version.
+
+Finally, don't forget to review the changes in detail. Make sure you try them
+locally if they are not trivial and make sure you request changes and ask as
+many questions as needed until you are convinced that including the changes into
+bundler is a strict improvement and will not make things regress in any way.

--- a/bundler/doc/playbooks/RELEASING.md
+++ b/bundler/doc/playbooks/RELEASING.md
@@ -51,29 +51,13 @@ $ git cherry-pick -m 1 dd6aef9
 The `bin/rake release:prepare_patch` command will automatically handle
 cherry-picking, and is further detailed below.
 
-## Changelog
-
-Bundler maintains a list of changes present in each version in the `CHANGELOG.md` file.
-Entries should not be added in pull requests, but are rather written by the Bundler
-maintainers before the release.
-
-To fill in the changelog, maintainers can go through the relevant PRs using the
-`bin/rake release:open_unreleased_prs` and manually add a changelog entry for each
-PR that it's about to be released.
-
-If you're releasing a patch level version, you can use `rake
-release:open_unreleased_prs` to instead label each relevant PR with the proper
-milestone of the version to be release. Then the `bin/rake release:patch` task will
-go _only_ through those PRs, and prompt you to add a changelog entry for each of
-them.
-
 ## Releases
 
 ### Minor releases
 
 While pushing a gem version to RubyGems.org is as simple as `bin/rake release`,
 releasing a new version of Bundler includes a lot of communication: team consensus,
-git branching, changelog writing, documentation site updates, and a blog post.
+git branching, documentation site updates, and a blog post.
 
 Dizzy yet? Us too.
 
@@ -85,7 +69,7 @@ Here's the checklist for releasing new minor versions:
 * [ ] Create a new stable branch from master (see **Branching** below)
 * [ ] Create a PR to the stable branch that:
   * [ ] Updates `version.rb` to a prerelease number, e.g. `1.12.pre.1`
-  * [ ] Updates `CHANGELOG.md` to include all of the features, bugfixes, etc for that version.
+  * [ ] Updates `CHANGELOG.md` to include a release header for the new version, leaving the "(Unreleased)" section empty.
 * [ ] Get the PR reviewed, make sure CI is green, and merge it.
 * [ ] Pull the updated stable brnach, wait for CI to complete on it and get excited.
 * [ ] Run `bin/rake release` from the updated stable branch, tweet, blog, let people know about the prerelease!

--- a/bundler/task/release.rake
+++ b/bundler/task/release.rake
@@ -110,8 +110,8 @@ namespace :release do
   end
 
   desc "Push the release to Github releases"
-  task :github, :version do |_t, args|
-    version = Gem::Version.new(args.version || Bundler::GemHelper.gemspec.version)
+  task :github do
+    version = Gem::Version.new(Bundler::GemHelper.gemspec.version)
     tag = "bundler-v#{version}"
 
     gh_api_authenticated_request :path => "/repos/rubygems/rubygems/releases",

--- a/bundler/task/release.rake
+++ b/bundler/task/release.rake
@@ -43,7 +43,9 @@ namespace :release do
     end
 
     def replace_unreleased_notes(new_content)
-      full_new_changelog = [unreleased_section_title, "", new_content, released_notes].join("\n") + "\n")
+      new_content_with_references = new_content.gsub(/#(\d+)/, '[#\1](https://github.com/rubygems/rubygems/pull/\1)')
+
+      full_new_changelog = [unreleased_section_title, "", new_content_with_references, released_notes].join("\n") + "\n"
 
       File.open("CHANGELOG.md", "w:UTF-8") {|f| f.write(full_new_changelog) }
     end


### PR DESCRIPTION
# Description:

This seems to be working now, so I'm enabling pushing the updated changelog to the default branch. Next time we merge a properly tagged PR, we should get a new released draft and automatic commit pushed to the default branch with the updated changelog.

This PR, in addition to doing that, also:

* Adds documentation for the new changelog management workflow.
* Cleans up some old tasks no longer need with the new workflow.
* Fixes an issue when writing to the changelog where references would be missing.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
