### PR TITLE
bring back the possibility to install a plugin from path

### DIFF
--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Bug fixes:
 
   - Fix broken exception recovery code when installing plugins [#3487](https://github.com/rubygems/rubygems/pull/3487)
+  - Bring back the possibility to install a plugin from path
 
 ## 2.2.0.rc.1 (Jul 02, 2020)
 

--- a/bundler/lib/bundler/plugin/dsl.rb
+++ b/bundler/lib/bundler/plugin/dsl.rb
@@ -10,7 +10,7 @@ module Bundler
       # So that we don't have to override all there methods to dummy ones
       # explicitly.
       # They will be handled by method_missing
-      [:gemspec, :gem, :path, :install_if, :platforms, :env].each {|m| undef_method m }
+      [:gemspec, :gem, :install_if, :platforms, :env].each {|m| undef_method m }
 
       # This lists the plugins that was added automatically and not specified by
       # the user.


### PR DESCRIPTION
# Description:

Documentation states that it is possible to install a plugin from a `path`, but it's not working.

```ruby
plugin 'my_plugin', path: '/path/to/plugin' # Installs from a path
```

## What was the end-user or developer problem that led to this PR?

I was not able to install the plugin from a local path.

## What is your fix for the problem, implemented in this PR?

It allows us to use the `path` option again.

Fixes https://github.com/rubygems/rubygems/issues/3355.
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
