### PR TITLE
Fix false positive warning on Windows when PATH has `File::ALT_SEPARATOR`

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -708,6 +708,8 @@ class Gem::Installer
     user_bin_dir = user_bin_dir.tr(File::ALT_SEPARATOR, File::SEPARATOR) if File::ALT_SEPARATOR
 
     path = ENV['PATH']
+    path = path.tr(File::ALT_SEPARATOR, File::SEPARATOR) if File::ALT_SEPARATOR
+
     if Gem.win_platform?
       path = path.downcase
       user_bin_dir = user_bin_dir.downcase

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -705,7 +705,7 @@ class Gem::Installer
     return if self.class.path_warning
 
     user_bin_dir = @bin_dir || Gem.bindir(gem_home)
-    user_bin_dir = user_bin_dir.tr(File::SEPARATOR, File::ALT_SEPARATOR) if
+    user_bin_dir = user_bin_dir.tr(File::ALT_SEPARATOR, File::SEPARATOR) if
       File::ALT_SEPARATOR
 
     path = ENV['PATH']

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -705,8 +705,7 @@ class Gem::Installer
     return if self.class.path_warning
 
     user_bin_dir = @bin_dir || Gem.bindir(gem_home)
-    user_bin_dir = user_bin_dir.tr(File::ALT_SEPARATOR, File::SEPARATOR) if
-      File::ALT_SEPARATOR
+    user_bin_dir = user_bin_dir.tr(File::ALT_SEPARATOR, File::SEPARATOR) if File::ALT_SEPARATOR
 
     path = ENV['PATH']
     if Gem.win_platform?

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -196,7 +196,7 @@ gem 'other', version
     bin_dir = installer.bin_dir
 
     if Gem.win_platform?
-      bin_dir = bin_dir.downcase.gsub(File::SEPARATOR, File::ALT_SEPARATOR)
+      bin_dir = bin_dir.downcase
     end
 
     orig_PATH, ENV['PATH'] =
@@ -239,7 +239,7 @@ gem 'other', version
     expected = installer.bin_dir
 
     if Gem.win_platform?
-      expected = expected.downcase.gsub(File::SEPARATOR, File::ALT_SEPARATOR)
+      expected = expected.downcase
     end
 
     assert_match expected, @ui.error

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -207,6 +207,16 @@ gem 'other', version
     end
 
     assert_empty @ui.error
+
+    return unless win_platform?
+
+    ENV['PATH'] = [orig_PATH, bin_dir.tr(File::SEPARATOR, File::ALT_SEPARATOR)].join(File::PATH_SEPARATOR)
+
+    use_ui @ui do
+      installer.check_that_user_bin_dir_is_in_path
+    end
+
+    assert_empty @ui.error
   ensure
     ENV['PATH'] = orig_PATH
   end


### PR DESCRIPTION
# Description:

This PR extracts one of the bug fixes in #2502 to a separate PR.

PATH on newer Windows sometimes can include paths using `File::ALT_SEPARATOR`. In that case, using `--user-install` could result in `rubygems` printing false warnings about the user directory not being in `PATH`.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
