### PR TITLE
add plugin hooks for bundle check

### DIFF
--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Bug fixes:
 
   - Fix broken exception recovery code when installing plugins [#3487](https://github.com/rubygems/rubygems/pull/3487)
+  - Add plugin hooks for `bundle check` command, `before-check-all` and `after-check-all`
 
 ## 2.2.0.rc.1 (Jul 02, 2020)
 

--- a/bundler/lib/bundler/cli/check.rb
+++ b/bundler/lib/bundler/cli/check.rb
@@ -14,10 +14,15 @@ module Bundler
       begin
         definition = Bundler.definition
         definition.validate_runtime!
+
+        Plugin.hook(Plugin::Events::GEM_BEFORE_CHECK_ALL, definition.dependencies)
+
         not_installed = definition.missing_specs
       rescue GemNotFound, VersionConflict
         Bundler.ui.error "Bundler can't satisfy your Gemfile's dependencies."
         Bundler.ui.warn "Install missing gems with `bundle install`."
+
+        Plugin.hook(Plugin::Events::GEM_AFTER_CHECK_ALL, definition.dependencies)
         exit 1
       end
 
@@ -25,13 +30,19 @@ module Bundler
         Bundler.ui.error "The following gems are missing"
         not_installed.each {|s| Bundler.ui.error " * #{s.name} (#{s.version})" }
         Bundler.ui.warn "Install missing gems with `bundle install`"
+
+        Plugin.hook(Plugin::Events::GEM_AFTER_CHECK_ALL, definition.dependencies)
         exit 1
       elsif !Bundler.default_lockfile.file? && Bundler.frozen_bundle?
         Bundler.ui.error "This bundle has been frozen, but there is no #{Bundler.default_lockfile.relative_path_from(SharedHelpers.pwd)} present"
+
+        Plugin.hook(Plugin::Events::GEM_AFTER_CHECK_ALL, definition.dependencies)
         exit 1
       else
         Bundler.load.lock(:preserve_unknown_sections => true) unless options[:"dry-run"]
         Bundler.ui.info "The Gemfile's dependencies are satisfied"
+
+        Plugin.hook(Plugin::Events::GEM_AFTER_CHECK_ALL, definition.dependencies)
       end
     end
   end

--- a/bundler/lib/bundler/plugin/events.rb
+++ b/bundler/lib/bundler/plugin/events.rb
@@ -56,6 +56,18 @@ module Bundler
       #   Includes an Array of Bundler::Dependency objects
       #   GEM_AFTER_INSTALL_ALL = "after-install-all"
       define :GEM_AFTER_INSTALL_ALL,  "after-install-all"
+
+      # @!parse
+      #   A hook called before any gems check
+      #   Includes an Array of Bundler::Dependency objects
+      #   GEM_BEFORE_CHECK_ALL = "before-check-all"
+      define :GEM_BEFORE_CHECK_ALL, "before-check-all"
+
+      # @!parse
+      #   A hook called after any gems check
+      #   Includes an Array of Bundler::Dependency objects
+      #   GEM_AFTER_CHECK_ALL = "after-check-all"
+      define :GEM_AFTER_CHECK_ALL,  "after-check-all"
     end
   end
 end


### PR DESCRIPTION
# Description:

I want to be able to execute a plugin when `bundle check` is run.

## What was the end-user or developer problem that led to this PR?

I'm not able to execute a plugin when `bundle check` is run.

## What is your fix for the problem, implemented in this PR?

Introduce `before-check-all` and `after-check-all` hooks when `bundle check` is run.

______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
