### PR TITLE
One more changelog management fix

### DIFF
--- a/.github/workflows/changelog-bundler.yml
+++ b/.github/workflows/changelog-bundler.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - name: Clone repo
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -20,27 +18,14 @@ jobs:
           ruby-version: 2.7.1
           bundler: none
 
-      - name: Check for changelog modifications
-        id: path_check
-        run: echo "::set-output name=changelog_modified::$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -c '^bundler/CHANGELOG.md$')"
-
       - name: Install dependencies
         run: bin/rake dev:deps
         working-directory: ./bundler
-        if: steps.path_check.outputs.changelog_modified != '0'
-
-      - name: Update release draft from changelog
-        run: bin/rake release:github_draft
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        working-directory: ./bundler
-        if: steps.path_check.outputs.changelog_modified != '0'
 
       - name: Get target version
         id: get_target_version
         run: echo "::set-output name=target_version::$(bin/rake release:target_version)"
         working-directory: ./bundler
-        if: steps.path_check.outputs.changelog_modified == '0'
 
       - name: Publish changelog draft
         id: publish_github_release_draft
@@ -51,24 +36,20 @@ jobs:
           tag: bundler-v${{ steps.get_target_version.outputs.target_version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: steps.path_check.outputs.changelog_modified == '0'
 
       - name: Write new changelog
         run: bin/rake release:write_changelog
         env:
           NEW_CHANGELOG_CONTENT: ${{ steps.publish_github_release_draft.outputs.body }}
         working-directory: ./bundler
-        if: steps.path_check.outputs.changelog_modified == '0'
 
       - name: Set up git config
         run: |
           git config user.name "The Bundler Bot"
           git config user.email "bot@bundler.io"
-        if: steps.path_check.outputs.changelog_modified == '0'
 
       - name: Commit and show the changes
         run: |
           git add bundler/CHANGELOG.md
           git commit -m "Automatic changelog update"
           git push origin master
-        if: steps.path_check.outputs.changelog_modified == '0'

--- a/bundler/task/release.rake
+++ b/bundler/task/release.rake
@@ -50,10 +50,6 @@ namespace :release do
       File.open("CHANGELOG.md", "w:UTF-8") {|f| f.write(full_new_changelog) }
     end
 
-    def unreleased_notes
-      join_and_strip(lines.take_while {|line| !line.start_with?(release_section_token) })
-    end
-
   private
 
     def unreleased_section_title
@@ -82,12 +78,8 @@ namespace :release do
   end
 
   def new_gh_client
-    token = ENV["GITHUB_TOKEN"]
-
-    unless token
-      require "netrc"
-      _username, token = Netrc.read["api.github.com"]
-    end
+    require "netrc"
+    _username, token = Netrc.read["api.github.com"]
 
     require "octokit"
     Octokit::Client.new(:access_token => token)
@@ -107,31 +99,6 @@ namespace :release do
   desc "Prints the current version in the version file, which should be the next release target"
   task :target_version do
     print Bundler::GemHelper.gemspec.version
-  end
-
-  desc "Sync the current draft release with the changelog"
-  task :github_draft do
-    version = Bundler::GemHelper.gemspec.version
-    unreleased_notes = Changelog.new.unreleased_notes
-    tag = "bundler-v#{version}"
-
-    gh_client = new_gh_client
-    gh_client.auto_paginate = true
-
-    releases = gh_client.releases("rubygems/rubygems")
-    release_draft = releases.find {|release| release.draft == true }
-
-    options = {
-      :body => unreleased_notes,
-      :prerelease => version.prerelease?,
-      :draft => true,
-    }
-
-    if release_draft
-      gh_client.update_release(release_draft.url, options.merge(:tag_name => tag))
-    else
-      gh_client.create_release("rubygems/rubygems", tag, options)
-    end
   end
 
   desc "Replace the unreleased section in the changelog with new content. Pass the new content through ENV['NEW_CHANGELOG_CONTENT']"


### PR DESCRIPTION
# Description:

The `release-drafter` library is idempotent in the sense that every time it runs, it fetches all commits since the last release that landed through PRs and pushes an updated draft using that information.

So any edits in the release must be done in the PRs themselves, like fixing a typo in the title, or labelling a missing PR, or changing the label for a PR.

Every change should be properly transmitted to the changelog and release draft every time pushes land to the default branch.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
