### PR TITLE
Update endpoint of gem signin command

### DIFF
--- a/lib/rubygems/commands/owner_command.rb
+++ b/lib/rubygems/commands/owner_command.rb
@@ -52,9 +52,8 @@ permission to.
 
   def execute
     @host = options[:host]
-    @scope = get_scope
 
-    sign_in
+    sign_in(scope: get_owner_scope)
     name = get_one_gem_name
 
     add_owners    name, options[:add]
@@ -103,17 +102,17 @@ permission to.
   private
 
   def send_owner_request(method, name, owner)
-    rubygems_api_request method, "api/v1/gems/#{name}/owners" do |request|
+    rubygems_api_request method, "api/v1/gems/#{name}/owners", scope: get_owner_scope(method: method) do |request|
       request.set_form_data 'email' => owner
       request.add_field "Authorization", api_key
       request.add_field "OTP", options[:otp] if options[:otp]
     end
   end
 
-  def get_scope
-    if options[:add].any?
+  def get_owner_scope(method: nil)
+    if method == :post || options.any? && options[:add].any?
       :add_owner
-    elsif options[:remove].any?
+    elsif method == :delete || options.any? && options[:remove].any?
       :remove_owner
     end
   end

--- a/lib/rubygems/commands/owner_command.rb
+++ b/lib/rubygems/commands/owner_command.rb
@@ -52,6 +52,7 @@ permission to.
 
   def execute
     @host = options[:host]
+    @scope = get_scope
 
     sign_in
     name = get_one_gem_name
@@ -106,6 +107,14 @@ permission to.
       request.set_form_data 'email' => owner
       request.add_field "Authorization", api_key
       request.add_field "OTP", options[:otp] if options[:otp]
+    end
+  end
+
+  def get_scope
+    if options[:add].any?
+      :add_owner
+    elsif options[:remove].any?
+      :remove_owner
     end
   end
 end

--- a/lib/rubygems/commands/push_command.rb
+++ b/lib/rubygems/commands/push_command.rb
@@ -61,8 +61,7 @@ The push command will use ~/.gem/credentials to authenticate to a server, but yo
               options[:host]
             end
 
-    @scope = :push_rubygem
-    sign_in @host
+    sign_in @host, scope: get_push_scope
 
     send_gem(gem_name)
   end
@@ -87,7 +86,7 @@ The push command will use ~/.gem/credentials to authenticate to a server, but yo
   private
 
   def send_push_request(name, args)
-    rubygems_api_request(*args) do |request|
+    rubygems_api_request(*args, scope: get_push_scope) do |request|
       request.body = Gem.read_binary name
       request.add_field "Content-Length", request.body.size
       request.add_field "Content-Type",   "application/octet-stream"
@@ -103,5 +102,9 @@ The push command will use ~/.gem/credentials to authenticate to a server, but yo
       gem_metadata["default_gem_server"],
       gem_metadata["allowed_push_host"],
     ]
+  end
+
+  def get_push_scope
+    :push_rubygem
   end
 end

--- a/lib/rubygems/commands/push_command.rb
+++ b/lib/rubygems/commands/push_command.rb
@@ -61,6 +61,7 @@ The push command will use ~/.gem/credentials to authenticate to a server, but yo
               options[:host]
             end
 
+    @scope = :push_rubygem
     sign_in @host
 
     send_gem(gem_name)

--- a/lib/rubygems/commands/yank_command.rb
+++ b/lib/rubygems/commands/yank_command.rb
@@ -46,6 +46,7 @@ data you will need to change them immediately and yank your gem.
 
   def execute
     @host = options[:host]
+    @scope = :yank_rubygem
 
     sign_in @host
 

--- a/lib/rubygems/commands/yank_command.rb
+++ b/lib/rubygems/commands/yank_command.rb
@@ -46,9 +46,8 @@ data you will need to change them immediately and yank your gem.
 
   def execute
     @host = options[:host]
-    @scope = :yank_rubygem
 
-    sign_in @host
+    sign_in @host, scope: get_yank_scope
 
     version   = get_version_from_requirements(options[:version])
     platform  = get_platform_from_requirements(options)
@@ -73,7 +72,7 @@ data you will need to change them immediately and yank your gem.
 
   def yank_api_request(method, version, platform, api)
     name = get_one_gem_name
-    response = rubygems_api_request(method, api, host) do |request|
+    response = rubygems_api_request(method, api, host, scope: get_yank_scope) do |request|
       request.add_field("Authorization", api_key)
       request.add_field("OTP", options[:otp]) if options[:otp]
 
@@ -92,5 +91,9 @@ data you will need to change them immediately and yank your gem.
     requirements.requirements.first[1].version
   rescue
     nil
+  end
+
+  def get_yank_scope
+    :yank_rubygem
   end
 end

--- a/test/rubygems/test_gem_commands_owner_command.rb
+++ b/test/rubygems/test_gem_commands_owner_command.rb
@@ -275,4 +275,52 @@ EOF
     assert_match 'Code: ', @otp_ui.output
     assert_equal '111111', @stub_fetcher.last_request['OTP']
   end
+
+  def test_remove_owners_unathorized_api_key
+    response_forbidden = "The API key doesn't have access"
+    response_success   = "Owner removed successfully."
+
+    @stub_fetcher.data["#{Gem.host}/api/v1/gems/freewill/owners"] = [
+      [response_forbidden, 403, 'Forbidden'],
+      [response_success, 200, "OK"],
+    ]
+    @stub_fetcher.data["#{Gem.host}/api/v1/api_key"] = ["", 200, "OK"]
+    @cmd.instance_variable_set :@scope, :remove_owner
+
+    @stub_ui = Gem::MockGemUi.new "some@mail.com\npass\n"
+    use_ui @stub_ui do
+      @cmd.remove_owners("freewill", ["some@example"])
+    end
+
+    access_notice = "The existing key doesn't have access of remove_owner on RubyGems.org. Please sign in to update access."
+    assert_match access_notice, @stub_ui.output
+    assert_match "Email:", @stub_ui.output
+    assert_match "Password:", @stub_ui.output
+    assert_match "Added remove_owner scope to the API key", @stub_ui.output
+    assert_match response_success, @stub_ui.output
+  end
+
+  def test_add_owners_unathorized_api_key
+    response_forbidden = "The API key doesn't have access"
+    response_success   = "Owner added successfully."
+
+    @stub_fetcher.data["#{Gem.host}/api/v1/gems/freewill/owners"] = [
+      [response_forbidden, 403, 'Forbidden'],
+      [response_success, 200, "OK"],
+    ]
+    @stub_fetcher.data["#{Gem.host}/api/v1/api_key"] = ["", 200, "OK"]
+    @cmd.instance_variable_set :@scope, :add_owner
+
+    @stub_ui = Gem::MockGemUi.new "some@mail.com\npass\n"
+    use_ui @stub_ui do
+      @cmd.add_owners("freewill", ["some@example"])
+    end
+
+    access_notice = "The existing key doesn't have access of add_owner on RubyGems.org. Please sign in to update access."
+    assert_match access_notice, @stub_ui.output
+    assert_match "Email:", @stub_ui.output
+    assert_match "Password:", @stub_ui.output
+    assert_match "Added add_owner scope to the API key", @stub_ui.output
+    assert_match response_success, @stub_ui.output
+  end
 end

--- a/test/rubygems/test_gem_commands_owner_command.rb
+++ b/test/rubygems/test_gem_commands_owner_command.rb
@@ -296,7 +296,7 @@ EOF
     assert_match access_notice, @stub_ui.output
     assert_match "Email:", @stub_ui.output
     assert_match "Password:", @stub_ui.output
-    assert_match "Added remove_owner scope to the API key", @stub_ui.output
+    assert_match "Added remove_owner scope to the existing API key", @stub_ui.output
     assert_match response_success, @stub_ui.output
   end
 
@@ -320,7 +320,7 @@ EOF
     assert_match access_notice, @stub_ui.output
     assert_match "Email:", @stub_ui.output
     assert_match "Password:", @stub_ui.output
-    assert_match "Added add_owner scope to the API key", @stub_ui.output
+    assert_match "Added add_owner scope to the existing API key", @stub_ui.output
     assert_match response_success, @stub_ui.output
   end
 end

--- a/test/rubygems/test_gem_commands_push_command.rb
+++ b/test/rubygems/test_gem_commands_push_command.rb
@@ -404,6 +404,32 @@ class TestGemCommandsPushCommand < Gem::TestCase
     assert_equal '111111', @fetcher.last_request['OTP']
   end
 
+  def test_sending_gem_unathorized_api_key
+    response_forbidden = "The API key doesn't have access"
+    response_success   = 'Successfully registered gem: freewill (1.0.0)'
+
+    @fetcher.data["#{@host}/api/v1/gems"] = [
+      [response_forbidden, 403, 'Forbidden'],
+      [response_success, 200, "OK"],
+    ]
+
+    @fetcher.data["#{@host}/api/v1/api_key"] = ["", 200, "OK"]
+    @cmd.instance_variable_set :@host, @host
+    @cmd.instance_variable_set :@scope, :push_rubygem
+
+    @ui = Gem::MockGemUi.new "some@mail.com\npass\n"
+    use_ui @ui do
+      @cmd.send_gem(@path)
+    end
+
+    access_notice = "The existing key doesn't have access of push_rubygem on https://rubygems.example. Please sign in to update access."
+    assert_match access_notice, @ui.output
+    assert_match "Email:", @ui.output
+    assert_match "Password:", @ui.output
+    assert_match "Added push_rubygem scope to the API key", @ui.output
+    assert_match response_success, @ui.output
+  end
+
   private
 
   def singleton_gem_class

--- a/test/rubygems/test_gem_commands_push_command.rb
+++ b/test/rubygems/test_gem_commands_push_command.rb
@@ -426,7 +426,7 @@ class TestGemCommandsPushCommand < Gem::TestCase
     assert_match access_notice, @ui.output
     assert_match "Email:", @ui.output
     assert_match "Password:", @ui.output
-    assert_match "Added push_rubygem scope to the API key", @ui.output
+    assert_match "Added push_rubygem scope to the existing API key", @ui.output
     assert_match response_success, @ui.output
   end
 

--- a/test/rubygems/test_gem_commands_signin_command.rb
+++ b/test/rubygems/test_gem_commands_signin_command.rb
@@ -82,7 +82,9 @@ class TestGemCommandsSigninCommand < Gem::TestCase
     key_name_ui = Gem::MockGemUi.new "#{email}\n#{password}\ntest-key\n\ny\n\n\n\n\n\n"
     util_capture(key_name_ui, nil, api_key, fetcher) { @cmd.execute }
 
-    assert_match "API Key name [#{Socket.gethostname}]", key_name_ui.output
+    user = ENV["USER"] || ENV["USERNAME"]
+
+    assert_match "API Key name [#{Socket.gethostname}-#{user}", key_name_ui.output
     assert_match "index_rubygems [y/N]", key_name_ui.output
     assert_match "push_rubygem [y/N]", key_name_ui.output
     assert_match "yank_rubygem [y/N]", key_name_ui.output

--- a/test/rubygems/test_gem_commands_signin_command.rb
+++ b/test/rubygems/test_gem_commands_signin_command.rb
@@ -83,13 +83,13 @@ class TestGemCommandsSigninCommand < Gem::TestCase
     util_capture(key_name_ui, nil, api_key, fetcher) { @cmd.execute }
 
     assert_match "API Key name [#{Socket.gethostname}]", key_name_ui.output
-    assert_match "index_rubygems [n]", key_name_ui.output
-    assert_match "push_rubygem [n]", key_name_ui.output
-    assert_match "yank_rubygem [n]", key_name_ui.output
-    assert_match "add_owner [n]", key_name_ui.output
-    assert_match "remove_owner [n]", key_name_ui.output
-    assert_match "webhook_actions [n]", key_name_ui.output
-    assert_match "show_dashboard [n]", key_name_ui.output
+    assert_match "index_rubygems [y/N]", key_name_ui.output
+    assert_match "push_rubygem [y/N]", key_name_ui.output
+    assert_match "yank_rubygem [y/N]", key_name_ui.output
+    assert_match "add_owner [y/N]", key_name_ui.output
+    assert_match "remove_owner [y/N]", key_name_ui.output
+    assert_match "access_webhooks [y/N]", key_name_ui.output
+    assert_match "show_dashboard [y/N]", key_name_ui.output
     assert_equal "name=test-key&push_rubygem=true", fetcher.last_request.body
 
     credentials = YAML.load_file Gem.configuration.credentials_path

--- a/test/rubygems/test_gem_commands_signin_command.rb
+++ b/test/rubygems/test_gem_commands_signin_command.rb
@@ -73,14 +73,36 @@ class TestGemCommandsSigninCommand < Gem::TestCase
     assert_equal api_key, credentials[:rubygems_api_key]
   end
 
+  def test_excute_with_key_name_and_scope
+    email     = 'you@example.com'
+    password  = 'secret'
+    api_key   = '1234'
+    fetcher   = Gem::RemoteFetcher.fetcher
+
+    key_name_ui = Gem::MockGemUi.new "#{email}\n#{password}\ntest-key\n\ny\n\n\n\n\n\n"
+    util_capture(key_name_ui, nil, api_key, fetcher) { @cmd.execute }
+
+    assert_match "API Key name [#{Socket.gethostname}]", key_name_ui.output
+    assert_match "index_rubygems [n]", key_name_ui.output
+    assert_match "push_rubygem [n]", key_name_ui.output
+    assert_match "yank_rubygem [n]", key_name_ui.output
+    assert_match "add_owner [n]", key_name_ui.output
+    assert_match "remove_owner [n]", key_name_ui.output
+    assert_match "webhook_actions [n]", key_name_ui.output
+    assert_match "show_dashboard [n]", key_name_ui.output
+    assert_equal "name=test-key&push_rubygem=true", fetcher.last_request.body
+
+    credentials = YAML.load_file Gem.configuration.credentials_path
+    assert_equal api_key, credentials[:rubygems_api_key]
+  end
+
   # Utility method to capture IO/UI within the block passed
 
-  def util_capture(ui_stub = nil, host = nil, api_key = nil)
+  def util_capture(ui_stub = nil, host = nil, api_key = nil, fetcher = Gem::FakeFetcher.new)
     api_key ||= 'a5fdbb6ba150cbb83aad2bb2fede64cf040453903'
     response  = [api_key, 200, 'OK']
     email     = 'you@example.com'
     password  = 'secret'
-    fetcher   = Gem::FakeFetcher.new
 
     # Set the expected response for the Web-API supplied
     ENV['RUBYGEMS_HOST']       = host || Gem::DEFAULT_HOST
@@ -88,7 +110,7 @@ class TestGemCommandsSigninCommand < Gem::TestCase
     fetcher.data[data_key]     = response
     Gem::RemoteFetcher.fetcher = fetcher
 
-    sign_in_ui = ui_stub || Gem::MockGemUi.new("#{email}\n#{password}\n")
+    sign_in_ui = ui_stub || Gem::MockGemUi.new("#{email}\n#{password}\n\n\n\n\n\n\n\n\n")
 
     use_ui sign_in_ui do
       yield

--- a/test/rubygems/test_gem_commands_yank_command.rb
+++ b/test/rubygems/test_gem_commands_yank_command.rb
@@ -174,7 +174,7 @@ class TestGemCommandsYankCommand < Gem::TestCase
     assert_match access_notice, @ui.output
     assert_match "Email:", @ui.output
     assert_match "Password:", @ui.output
-    assert_match "Added yank_rubygem scope to the API key", @ui.output
+    assert_match "Added yank_rubygem scope to the existing API key", @ui.output
     assert_match response_success, @ui.output
   end
 end

--- a/test/rubygems/test_gem_commands_yank_command.rb
+++ b/test/rubygems/test_gem_commands_yank_command.rb
@@ -147,4 +147,34 @@ class TestGemCommandsYankCommand < Gem::TestCase
     assert_equal 'key', @fetcher.last_request['Authorization']
     assert_equal [yank_uri], @fetcher.paths
   end
+
+  def test_yank_gem_unathorized_api_key
+    response_forbidden = "The API key doesn't have access"
+    response_success   = 'Successfully yanked'
+    host               = 'http://example'
+
+    @fetcher.data["#{host}/api/v1/gems/yank"] = [
+      [response_forbidden, 403, 'Forbidden'],
+      [response_success, 200, "OK"],
+    ]
+
+    @fetcher.data["#{host}/api/v1/api_key"] = ["", 200, "OK"]
+    @cmd.options[:args]           = %w[a]
+    @cmd.options[:added_platform] = true
+    @cmd.options[:version]        = req('= 1.0')
+    @cmd.instance_variable_set :@host, host
+    @cmd.instance_variable_set :@scope, :yank_rubygem
+
+    @ui = Gem::MockGemUi.new "some@mail.com\npass\n"
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    access_notice = "The existing key doesn't have access of yank_rubygem on http://example. Please sign in to update access."
+    assert_match access_notice, @ui.output
+    assert_match "Email:", @ui.output
+    assert_match "Password:", @ui.output
+    assert_match "Added yank_rubygem scope to the API key", @ui.output
+    assert_match response_success, @ui.output
+  end
 end

--- a/test/rubygems/test_gem_gemcutter_utilities.rb
+++ b/test/rubygems/test_gem_gemcutter_utilities.rb
@@ -202,7 +202,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
 
     assert_match 'You have enabled multi-factor authentication. Please enter OTP code.', @sign_in_ui.output
     assert_match 'Code: ', @sign_in_ui.output
-    assert_match 'Signed in.', @sign_in_ui.output
+    assert_match 'Signed in with API key:', @sign_in_ui.output
     assert_equal '111111', @fetcher.last_request['OTP']
   end
 

--- a/test/rubygems/test_gem_gemcutter_utilities.rb
+++ b/test/rubygems/test_gem_gemcutter_utilities.rb
@@ -233,7 +233,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
     @fetcher.data["#{host}/api/v1/api_key"] = response
     Gem::RemoteFetcher.fetcher = @fetcher
 
-    @sign_in_ui = Gem::MockGemUi.new("#{email}\n#{password}\n" + extra_input)
+    @sign_in_ui = Gem::MockGemUi.new("#{email}\n#{password}\n\n\n\n\n\n\n\n\n" + extra_input)
 
     use_ui @sign_in_ui do
       if args.length > 0


### PR DESCRIPTION
# Description:

Updates `gem signin` command to use a new endpoint which requires an API key name and scopes the key should have access to. Each invocation of `gem signin` will create a new API key.

## What was the end-user or developer problem that led to this PR?

A single API key with access to everything was a security risk.

## What is your fix for the problem, implemented in this PR?

Majority of changes related to this is on the server-side and can be seen here: https://github.com/rubygems/rubygems.org/pull/1962

A brief summary of the changes:
- adds support for multiple API keys per account and split access into scopes. `show_dashabord` is an exclusive scope.
- stores API key to DB after hashing
- legacy `user.api_key` will be migrated to the new table `api_keys` and will have all scopes enabled (full access).
- `GET api/v1/api_keys` will continue to return `user.api_key` so that `gem signin` doesn't break for old clients. (may be deleted in future)
- new API keys will have `rubygems_` prefix enabling us to sign up for the GitHub program for notifications of key pushed in public repos. 


______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
