### PR TITLE
Fix some intermittent test failures on truffleruby

### DIFF
--- a/test/rubygems/test_gem_gem_runner.rb
+++ b/test/rubygems/test_gem_gem_runner.rb
@@ -8,6 +8,7 @@ class TestGemGemRunner < Gem::TestCase
     require 'rubygems/command'
     @orig_args = Gem::Command.build_args
     @orig_specific_extra_args = Gem::Command.specific_extra_args_hash.dup
+    @orig_extra_args = Gem::Command.extra_args.dup
 
     require 'rubygems/gem_runner'
     @runner = Gem::GemRunner.new
@@ -18,6 +19,7 @@ class TestGemGemRunner < Gem::TestCase
 
     Gem::Command.build_args = @orig_args
     Gem::Command.specific_extra_args_hash = @orig_specific_extra_args
+    Gem::Command.extra_args = @orig_extra_args
   end
 
   def test_do_configuration


### PR DESCRIPTION
# Description:

Since they changed their default to not generate documentation on `gem install`, we're getting some intermittent test failures. Can be reproduced with:

```
TRUFFLERUBYOPT="--experimental-options --testing-rubygems" TESTOPTS=--name="/^\(?:TestGemGemRunner#\(?:test_list_succeeds\)\|TestGemCommandsUpdateCommand#\(?:test_handle_options_system\)\)$/ --seed=54277 --verbose" rake
```

Fix it by resetting all permanent CLI options when CLI runner loads configuration.


# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).