### PR TITLE
Fix ls-files matching regexp

### DIFF
--- a/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -25,10 +25,10 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{\A(?:test|spec|features)/}) }
   end
   spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 <%- if config[:ext] -%>
   spec.extensions    = ["ext/<%= config[:underscored_name] %>/extconf.rb"]


### PR DESCRIPTION
# Description:

As splitting by NUL means to allow the file names to contain newlines, path names should match at beginning-of-string instead of beginning-of-line.

## What was the end-user or developer problem that led to this PR?

Nothing.
Sane programmers never use newline in pathnames.

## What is your fix for the problem, implemented in this PR?

Match by `\A` instead of `^`.
Also made a regexp group uncaptured.
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
