### PR TITLE
Deduplicate the requirement operators in memory

### DIFF
--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -111,7 +111,7 @@ class Gem::Requirement
     elsif $1 == ">=" && $2 == "0.a"
       DefaultPrereleaseRequirement
     else
-      [$1 || "=", Gem::Version.new($2)]
+      [-($1 || "="), Gem::Version.new($2)]
     end
   end
 

--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -81,6 +81,12 @@ class TestGemRequirement < Gem::TestCase
       Gem::Requirement.parse(Gem::Version.new('2'))
   end
 
+  if RUBY_VERSION >= '2.5'
+    def test_parse_deduplication
+      assert_same '~>', Gem::Requirement.parse('~> 1').first
+    end
+  end
+
   def test_parse_bad
     [
       nil,


### PR DESCRIPTION
While working on a new heap profiler, I noticed some String duplications coming from Rubygems. I never noticed them so far because they are instantiated earlier than my previous profiler.

This is for a ~300 gems Gemfile
```
  25.80 kB     645  "~>"
  16.00 kB     400  ">="
   6.36 kB     159  "ruby"
   3.96 kB      99  "<"
   6.84 kB      90  "/tmp/bundle/ruby/2.7.0/bundler/gems"
   3.40 kB      85  "bin"
   3.20 kB      80  "="

total:  65.56 kB
```

I haven't pinpointed the source of `"ruby"`, `"bin"` and `"/tmp/bundle/ruby/2.7.0/bundler/gems"` yet, I need to improve my profiler first.