### PR TITLE
Eval defaults with frozen_string_literal: true

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1953,6 +1953,8 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   eval <<-RUBY, binding, __FILE__, __LINE__ + 1
+    # frozen_string_literal: true
+
     def set_nil_attributes_to_nil
       #{@@nil_attributes.map {|key| "@#{key} = nil" }.join "; "}
     end


### PR DESCRIPTION
Ref: https://github.com/rubygems/rubygems/pull/3846

This is where most of the duplicated `"ruby"` strings come from. `# frozen_string_literal: true` is not "inherited" by `eval`. I found similar patterns in Rails a few times.