### PR TITLE
Fix Kernel#warn override to handle backtrace location with nil path

### DIFF
--- a/lib/rubygems/core_ext/kernel_warn.rb
+++ b/lib/rubygems/core_ext/kernel_warn.rb
@@ -38,10 +38,11 @@ if RUBY_VERSION >= "2.5"
 
           start += 1
 
-          path = loc.path
-          unless path.start_with?(rubygems_path) or path.start_with?('<internal:')
-            # Non-rubygems frames
-            uplevel -= 1
+          if path = loc.path
+            unless path.start_with?(rubygems_path) or path.start_with?('<internal:')
+              # Non-rubygems frames
+              uplevel -= 1
+            end
           end
         end
         uplevel = start


### PR DESCRIPTION
It's very unlikely to hit this case, but it is possible, as
Thread::Backtrace::Location#path can return nil if the location is
a cfunc with no previous iseq.  See location_path in vm_backtrace.c
in Ruby (https://github.com/ruby/ruby/blob/master/vm_backtrace.c#L277). 

# Description:

Kernel#warn override can fail with NoMethodError in rare case.

## What was the end-user or developer problem that led to this PR?

Kernel#warn override broke as I was testing optimizations to partial
backtrace generation in CRuby (https://bugs.ruby-lang.org/issues/17031).

## What is your fix for the problem, implemented in this PR?

Check that path is not nil before using it.

I can't think of a way to test this without having Ruby call Kernel#warn
without ever reaching an iseq method.  I think this could be accomplished
by `at_exit(&method(:cfunc_that_calls_kernel_warn))`, but I haven't tested
to confirm.
______________

# Tasks:

- [X] Describe the problem / feature
- [ ] Write tests
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
