### PR TITLE
Fix some cases of running `bundler` on a path including brackets

### DIFF
--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -63,7 +63,7 @@ module Bundler
       development_group = opts[:development_group] || :development
       expanded_path     = gemfile_root.join(path)
 
-      gemspecs = Dir[File.join(expanded_path, "{,*}.gemspec")].map {|g| Bundler.load_gemspec(g) }.compact
+      gemspecs = Gem::Util.glob_files_in_dir("{,*}.gemspec", expanded_path).map {|g| Bundler.load_gemspec(g) }.compact
       gemspecs.reject! {|s| s.name != name } if name
       Index.sort_specs(gemspecs)
       specs_by_name_and_version = gemspecs.group_by {|s| [s.name, s.version] }

--- a/bundler/lib/bundler/gem_helper.rb
+++ b/bundler/lib/bundler/gem_helper.rb
@@ -32,7 +32,7 @@ module Bundler
 
     def initialize(base = nil, name = nil)
       @base = File.expand_path(base || SharedHelpers.pwd)
-      gemspecs = name ? [File.join(@base, "#{name}.gemspec")] : Dir[File.join(@base, "{,*}.gemspec")]
+      gemspecs = name ? [File.join(@base, "#{name}.gemspec")] : Gem::Util.glob_files_in_dir("{,*}.gemspec", @base)
       raise "Unable to determine name from existing gemspec. Use :name => 'gemname' in #install_tasks to manually set it." unless gemspecs.size == 1
       @spec_path = gemspecs.first
       @gemspec = Bundler.load_gemspec(@spec_path)
@@ -111,7 +111,7 @@ module Bundler
     end
 
     def built_gem_path
-      Dir[File.join(base, "#{name}-*.gem")].sort_by {|f| File.mtime(f) }.last
+      Gem::Util.glob_files_in_dir("#{name}-*.gem", base).sort_by {|f| File.mtime(f) }.last
     end
 
     def git_push(remote = nil)

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -173,6 +173,22 @@ module Gem
     undef_method :eql? if method_defined? :eql?
     alias_method :eql?, :==
   end
+
+  require "rubygems/util"
+
+  Util.singleton_class.module_eval do
+    if Util.singleton_methods.include?(:glob_files_in_dir) # since 3.0.0.beta.2
+      remove_method :glob_files_in_dir
+    end
+
+    def glob_files_in_dir(glob, base_path)
+      if RUBY_VERSION >= "2.5"
+        Dir.glob(glob, :base => base_path).map! {|f| File.expand_path(f, base_path) }
+      else
+        Dir.glob(File.join(base_path.to_s.gsub(/[\[\]]/, '\\\\\\&'), glob)).map! {|f| File.expand_path(f) }
+      end
+    end
+  end
 end
 
 module Gem

--- a/bundler/lib/bundler/source/path.rb
+++ b/bundler/lib/bundler/source/path.rb
@@ -171,7 +171,7 @@ module Bundler
 
         if File.directory?(expanded_path)
           # We sort depth-first since `<<` will override the earlier-found specs
-          Dir["#{expanded_path}/#{@glob}"].sort_by {|p| -p.split(File::SEPARATOR).size }.each do |file|
+          Gem::Util.glob_files_in_dir(@glob, expanded_path).sort_by {|p| -p.split(File::SEPARATOR).size }.each do |file|
             next unless spec = load_gemspec(file)
             spec.source = self
 

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -511,7 +511,7 @@ RSpec.describe "bundle install with gem sources" do
   end
 
   describe "when Bundler root contains regex chars" do
-    it "doesn't blow up" do
+    it "doesn't blow up when using the `gem` DSL" do
       root_dir = tmp("foo[]bar")
 
       FileUtils.mkdir_p(root_dir)
@@ -519,6 +519,22 @@ RSpec.describe "bundle install with gem sources" do
       build_lib "foo"
       gemfile = <<-G
         gem 'foo', :path => "#{lib_path("foo-1.0")}"
+      G
+      File.open("#{root_dir}/Gemfile", "w") do |file|
+        file.puts gemfile
+      end
+
+      bundle :install, :dir => root_dir
+    end
+
+    it "doesn't blow up when using the `gemspec` DSL" do
+      root_dir = tmp("foo[]bar")
+
+      FileUtils.mkdir_p(root_dir)
+
+      build_lib "foo", :path => root_dir
+      gemfile = <<-G
+        gemspec
       G
       File.open("#{root_dir}/Gemfile", "w") do |file|
         file.puts gemfile

--- a/bundler/spec/realworld/fixtures/warbler/Gemfile.lock
+++ b/bundler/spec/realworld/fixtures/warbler/Gemfile.lock
@@ -26,4 +26,4 @@ DEPENDENCIES
   warbler (~> 2.0)
 
 BUNDLED WITH
-   2.2.0.rc.1
+   2.2.0.rc.2

--- a/bundler/spec/realworld/fixtures/warbler/Gemfile.lock
+++ b/bundler/spec/realworld/fixtures/warbler/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    jruby-jars (9.2.9.0)
+    jruby-jars (9.2.11.1)
     jruby-rack (1.1.21)
     rake (13.0.1)
     rubyzip (1.3.0)

--- a/bundler/spec/runtime/gem_tasks_spec.rb
+++ b/bundler/spec/runtime/gem_tasks_spec.rb
@@ -67,6 +67,18 @@ RSpec.describe "require 'bundler/gem_tasks'" do
     end
   end
 
+  context "rake build when path has brackets", :ruby_repo do
+    before do
+      bracketed_bundled_app = tmp.join("bundled[app")
+      FileUtils.cp_r bundled_app, bracketed_bundled_app
+      bundle "exec rake build", :dir => bracketed_bundled_app
+    end
+
+    it "still runs successfully" do
+      expect(err).to be_empty
+    end
+  end
+
   context "bundle path configured locally" do
     before do
       bundle "config set path vendor/bundle"


### PR DESCRIPTION
# Description:

I used a a monkey patch of `Gem::Util.glob_files_in_dir` that supports brackets. Something like this will be built in once https://bugs.ruby-lang.org/issues/8258 is implemented, although to `base:` option of `Dir.glob` already handles this fine. So once ruby 2.5 

Fixes #3841.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
