### PR TITLE
Fix encoding mismatch errors on MinGW

### DIFF
--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -47,7 +47,7 @@ install:
       Gem::Ext::Builder.make @dest_path, results
     end
 
-    results = results.join "\n"
+    results = results.join("\n").b
 
     assert_match %r{"DESTDIR=#{ENV['DESTDIR']}" clean$},   results
     assert_match %r{"DESTDIR=#{ENV['DESTDIR']}"$},         results
@@ -78,7 +78,7 @@ install:
       Gem::Ext::Builder.make @dest_path, results
     end
 
-    results = results.join "\n"
+    results = results.join("\n").b
 
     assert_match %r{"DESTDIR=#{ENV['DESTDIR']}" clean$},   results
     assert_match %r{"DESTDIR=#{ENV['DESTDIR']}"$},         results


### PR DESCRIPTION
# Description:

GNU make in MSys is localized to use UTF-8 while Ruby's filesystem encoding is set to OEM CodePage (e.g., CP932 in Japanese Edition), the read output from the make has broken encoding and results in "invalid byte sequence" errors.
As `DESTDIR` is set to a US-ASCII 7bit clean string, matching as binary encoding should have no problems.

## What was the end-user or developer problem that led to this PR?

Test failures with MSys on Windows Japanese Edition.

## What is your fix for the problem, implemented in this PR?

Compare in binary encoding.

______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests (existing tests fail without this fix)
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
