### PR TITLE
Vendors DidYouMean::Levenshtein.distance from did_you_mean @ 1.4.0

### DIFF
--- a/lib/rubygems/text.rb
+++ b/lib/rubygems/text.rb
@@ -49,37 +49,38 @@ module Gem::Text
     end
   end
 
-  # This code is based directly on the Text gem implementation
   # Returns a value representing the "cost" of transforming str1 into str2
+  # Vendored version of DidYouMean::Levenshtein.distance from the ruby/did_you_mean gem @ 1.4.0
+  # https://git.io/JJgZI
   def levenshtein_distance(str1, str2)
-    s = str1
-    t = str2
-    n = s.length
-    m = t.length
-
-    return m if (0 == n)
-    return n if (0 == m)
+    n = str1.length
+    m = str2.length
+    return m if n.zero?
+    return n if m.zero?
 
     d = (0..m).to_a
     x = nil
 
-    str1.each_char.each_with_index do |char1,i|
-      e = i + 1
+    # to avoid duplicating an enumerable object, create it outside of the loop
+    str2_codepoints = str2.codepoints
 
-      str2.each_char.each_with_index do |char2,j|
-        cost = (char1 == char2) ? 0 : 1
+    str1.each_codepoint.with_index(1) do |char1, i|
+      j = 0
+      while j < m
+        cost = (char1 == str2_codepoints[j]) ? 0 : 1
         x = min3(
-             d[j + 1] + 1, # insertion
-             e + 1,      # deletion
-             d[j] + cost # substitution
-           )
-        d[j] = e
-        e = x
-      end
+          d[j + 1] + 1, # insertion
+          i + 1,      # deletion
+          d[j] + cost # substitution
+        )
+        d[j] = i
+        i = x
 
+        j += 1
+      end
       d[m] = x
     end
 
-    return x
+    x
   end
 end

--- a/test/rubygems/test_gem_text.rb
+++ b/test/rubygems/test_gem_text.rb
@@ -83,6 +83,12 @@ Without the wrapping, the text might not look good in the RSS feed.
     assert_equal 7, levenshtein_distance("zentest", "xxxxxxx")
   end
 
+  def test_levenshtein_distance_all
+    assert_equal 6, levenshtein_distance("algorithm", "altruistic")
+    assert_equal 3, levenshtein_distance("saturday", "sunday")
+    assert_equal 3, levenshtein_distance("kitten", "sitting")
+  end
+
   def test_truncate_text
     assert_equal "abc", truncate_text("abc", "desc")
     assert_equal "Truncating desc to 2 characters:\nab", truncate_text("abc", "desc", 2)


### PR DESCRIPTION
- Similar to https://github.com/rubygems/rubygems/pull/3857

* * *

# Description:

_See edit history and thread for full story_

- Significant performance boost

## Benchmarks

:chart: [Benchmark code](https://github.com/austinpray/rubygems_levenshtein_distance/blob/master/text_gem_bench.rb) [(permalink)](https://github.com/austinpray/rubygems_levenshtein_distance/blob/f76e1cdcab98a40b2aef3e49206761f2dee896f7/text_gem_bench.rb)

Looks like this could be a **2x performance boost**

```
# Single Insertion

Warming up --------------------------------------
              Before     3.844k i/100ms
               After     8.307k i/100ms
Calculating -------------------------------------
              Before     38.015k (± 1.4%) i/s -    192.200k in   5.056880s
               After     83.084k (± 3.8%) i/s -    415.350k in   5.007893s
# Complex

Warming up --------------------------------------
              Before     4.481k i/100ms
               After     9.399k i/100ms
Calculating -------------------------------------
              Before     44.281k (± 2.9%) i/s -    224.050k in   5.064414s
               After     97.084k (± 4.2%) i/s -    488.748k in   5.044751s
```

## What was the end-user or developer problem that led to this PR?

While looking for reference implementations of the edit distance algorithm I saw that the `DidYouMean::Levenshtein.distance` function is highly optimized. I figured it's a good idea to consolidate implementations of this method!

## What is your fix for the problem, implemented in this PR?

`GEM::Text.levenshtein_distance` is now a vendored version of `DidYouMean::Levenshtein.distance`

## Old history before the squash

For posterity the old history is here:
- https://github.com/austinpray/rubygems/tree/levenshtein-dym-b4squash
- https://github.com/austinpray/rubygems/tree/9b8bca135491f0dcc5c53f0326874239818b899d

______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
