### PR TITLE
Use DidYouMean::SpellChecker for gem suggestions in Bundler

### DIFF
--- a/bundler/lib/bundler/cli/common.rb
+++ b/bundler/lib/bundler/cli/common.rb
@@ -60,11 +60,11 @@ module Bundler
     end
 
     def self.gem_not_found_message(missing_gem_name, alternatives)
-      require_relative "../similarity_detector"
+      require "did_you_mean/spell_checker"
       message = "Could not find gem '#{missing_gem_name}'."
-      alternate_names = alternatives.map {|a| a.respond_to?(:name) ? a.name : a }
-      suggestions = SimilarityDetector.new(alternate_names).similar_word_list(missing_gem_name)
-      message += "\nDid you mean #{suggestions}?" if suggestions
+      alternate_names = alternatives.map { |a| a.respond_to?(:name) ? a.name : a }
+      suggestions = DidYouMean::SpellChecker.new(dictionary: alternate_names).correct(missing_gem_name)
+      message += "\nDid you mean #{word_list(suggestions)}?" unless suggestions.empty?
       message
     end
 
@@ -96,6 +96,22 @@ module Bundler
       clean ||= Bundler.feature_flag.auto_clean_without_path? && Bundler.settings[:path].nil?
       clean &&= !Bundler.use_system_gems?
       clean
+    end
+
+    protected
+
+    def self.word_list(words)
+      if words.empty?
+        return ''
+      end
+
+      words = words.map { |word| "'#{word}'" }
+
+      if words.length == 1
+        return words[0]
+      end
+
+      [words[0..-2].join(", "), words[-1]].join(" or ")
     end
   end
 end

--- a/bundler/lib/bundler/similarity_detector.rb
+++ b/bundler/lib/bundler/similarity_detector.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# This module is not used anywhere in Bundler
+# It is included for backwards compatibility in-case someone is relying on it
+
 module Bundler
   class SimilarityDetector
     SimilarityScore = Struct.new(:string, :distance)

--- a/bundler/spec/bundler/cli_common_spec.rb
+++ b/bundler/spec/bundler/cli_common_spec.rb
@@ -1,0 +1,18 @@
+require 'bundler/cli'
+
+RSpec.describe Bundler::CLI::Common do
+  describe 'gem_not_found_message' do
+    it 'should suggest alternate gem names' do
+      message = subject.gem_not_found_message('ralis', ['BOGUS'])
+      expect(message).to match("Could not find gem 'ralis'.$")
+      message = subject.gem_not_found_message("ralis", ["rails"])
+      expect(message).to match("Did you mean 'rails'?")
+      message = subject.gem_not_found_message("meail", %w[email fail eval])
+      expect(message).to match("Did you mean 'email'?")
+      message = subject.gem_not_found_message("nokogri", %w[nokogiri rails sidekiq dog])
+      expect(message).to match("Did you mean 'nokogiri'?")
+      message = subject.gem_not_found_message("methosd", %w[method methods bogus])
+      expect(message).to match("Did you mean 'methods' or 'method'?")
+    end
+  end
+end


### PR DESCRIPTION
Similar to https://github.com/rubygems/rubygems/pull/3856

* * *

replaces `Bundler::SimilarityDetector` with [`DidYouMean::SpellChecker`](https://github.com/ruby/did_you_mean/blob/2ddf39b874808685965dbc47d344cf6c7651807c/lib/did_you_mean/spell_checker.rb)

1. Higher quality spelling suggestions in my testing
1. Benefit from upstream improvements, less code to maintain in this repo. The current `Bundler::SimilarityDetector.levenshtein_distance` dynamic programming implementation could be optimized quite a bit. 
1. Should see a significant performance improvement, under the hood `DidYouMean::SpellChecker` [is highly optimized](https://github.com/ruby/did_you_mean/commit/bf64b25501c07ee8475997e94ca51db67a7f31ed#diff-6ed35dc5fb06924d97b2a98adb0bc285).

RubyGems 3.0 supports Ruby 2.3 or later. Ruby 2.3 and later ships with the `did_you_mean` gem.

# Description:

## Notes for reviewer

- `Bundler::SimilarityDetector` is not used in Bundler anymore. I would like to delete it, but I haven't haven't because I am not sure if we should pull the rug out from people that might be using for their own purposes. **What should we do to phase out this module?**

## What was the end-user or developer problem that led to this PR?

Was improving performance over in https://github.com/rubygems/rubygems/pull/3856 and saw this as an opportunity as well.

## What is your fix for the problem, implemented in this PR?

Use `DidYouMean::SpellChecker` as a drop-in replacement for `Bundler::SimilarityDetector`

______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
