### PR TITLE
Prefer RbConfig::CONFIG['EXEEXT'] over hardcorded '.exe'

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -586,7 +586,7 @@ EOF
 
     def git_present?
       return @git_present if defined?(@git_present)
-      @git_present = Bundler.which("git") || Bundler.which("git.exe")
+      @git_present = Bundler.which("git#{RbConfig::CONFIG['EXEEXT']}")
     end
 
     def feature_flag

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -331,7 +331,7 @@ class Gem::TestCase < Minitest::Test
                    ruby
                  end
 
-    @git = ENV['GIT'] || (win_platform? ? 'git.exe' : 'git')
+    @git = ENV['GIT'] || "git#{RbConfig::CONFIG['EXEEXT']}"
 
     Gem.ensure_gem_subdirectories @gemhome
 
@@ -1230,7 +1230,7 @@ Also, a list:
     ruby = ENV["RUBY"]
     return ruby if ruby
     ruby = "ruby"
-    rubyexe = "#{ruby}.exe"
+    rubyexe = "#{ruby}#{RbConfig::CONFIG['EXEEXT']}"
 
     3.times do
       if File.exist? ruby and File.executable? ruby and !File.directory? ruby


### PR DESCRIPTION
# Description:

Prefer `RbConfig::CONFIG['EXEEXT']` over hardcorded `'.exe'`.

## What was the end-user or developer problem that led to this PR?

Nothing to the end-user.
More portable a little.

## What is your fix for the problem, implemented in this PR?

Same as the description.

______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
