### PR TITLE
fix indentation in gem env

### DIFF
--- a/lib/rubygems/commands/environment_command.rb
+++ b/lib/rubygems/commands/environment_command.rb
@@ -127,7 +127,7 @@ lib/rubygems/defaults/operating_system.rb
 
     out << "  - RUBYGEMS PLATFORMS:\n"
     Gem.platforms.each do |platform|
-      out << "    - #{platform}\n"
+      out << "     - #{platform}\n"
     end
 
     out << "  - GEM PATHS:\n"


### PR DESCRIPTION
# Description:

There is a tiny bit of missing indentation in `gem env`, specifically the list in `RUBYGEMS PLATFORM` section

Before:
```
RubyGems Environment:
  - RUBYGEMS VERSION: 3.1.2
  ..
  - RUBYGEMS PLATFORMS:
    - ruby
    - x86_64-darwin-19
  - GEM PATHS:
     - /Users/colby/.asdf/installs/ruby/2.7.0/lib/ruby/gems/2.7.0
     - /Users/colby/.gem/ruby/2.7.0
```

After:
```
RubyGems Environment:
  - RUBYGEMS VERSION: 3.2.0.pre1
  ...
  - RUBYGEMS PLATFORMS:
     - ruby
     - x86_64-darwin-19
  - GEM PATHS:
     - /Users/colby/.asdf/installs/ruby/2.7.0/lib/ruby/gems/2.7.0
     - /Users/colby/.gem/ruby/2.7.0
```