### PR TITLE
Warn on duplicate dependency in a specification

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -560,6 +560,10 @@ class Gem::Specification < Gem::BasicSpecification
   #   spec.add_runtime_dependency 'example', '~> 1.1', '>= 1.1.4'
 
   def add_runtime_dependency(gem, *requirements)
+    if requirements.uniq.size != requirements.size
+      warn "WARNING: duplicate dependency #{requirements}"
+    end
+
     add_dependency_with_type(gem, :runtime, requirements)
   end
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -561,7 +561,7 @@ class Gem::Specification < Gem::BasicSpecification
 
   def add_runtime_dependency(gem, *requirements)
     if requirements.uniq.size != requirements.size
-      warn "WARNING: duplicate dependency #{requirements}"
+      warn "WARNING: duplicated #{gem} dependency #{requirements}"
     end
 
     add_dependency_with_type(gem, :runtime, requirements)

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3060,6 +3060,13 @@ Please report a bug if this causes problems.
     end
   end
 
+  def test_duplicate_runtime_dependency
+    expected = "WARNING: duplicate dependency [\"~> 3.0\", \"~> 3.0\"]\n"
+    assert_output nil, expected do
+      @a1.add_runtime_dependency "b", "~> 3.0", "~> 3.0"
+    end
+  end
+
   def set_orig(cls)
     s_cls = cls.singleton_class
     s_cls.send :alias_method, :orig_unresolved_deps , :unresolved_deps

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3061,7 +3061,7 @@ Please report a bug if this causes problems.
   end
 
   def test_duplicate_runtime_dependency
-    expected = "WARNING: duplicate dependency [\"~> 3.0\", \"~> 3.0\"]\n"
+    expected = "WARNING: duplicated b dependency [\"~> 3.0\", \"~> 3.0\"]\n"
     assert_output nil, expected do
       @a1.add_runtime_dependency "b", "~> 3.0", "~> 3.0"
     end


### PR DESCRIPTION
# Description:
Closes https://github.com/rubygems/rubygems/issues/3676

Warns whenever we have a duplicate runtime dependency

`spec.add_runtime_dependency "rails", "~> 3.0", "~> 3.0"` #=>`WARNING: duplicated rails dependency ["~> 3.0", "~> 3.0"]`

______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
