### PR TITLE
Accept responses with no etag header

### DIFF
--- a/bundler/lib/bundler/compact_index_client/updater.rb
+++ b/bundler/lib/bundler/compact_index_client/updater.rb
@@ -66,8 +66,8 @@ module Bundler
             end
           end
 
-          response_etag = (response["ETag"] || "").gsub(%r{\AW/}, "")
-          if etag_for(local_temp_path) == response_etag
+          etag = (response["ETag"] || "").gsub(%r{\AW/}, "")
+          if etag.length.zero? || etag_for(local_temp_path) == etag
             SharedHelpers.filesystem_access(local_path) do
               FileUtils.mv(local_temp_path, local_path)
             end
@@ -75,7 +75,7 @@ module Bundler
           end
 
           if retrying
-            raise MisMatchedChecksumError.new(remote_path, response_etag, etag_for(local_temp_path))
+            raise MisMatchedChecksumError.new(remote_path, etag, etag_for(local_temp_path))
           end
 
           update(local_path, remote_path, :retrying)

--- a/bundler/spec/bundler/compact_index_client/updater_spec.rb
+++ b/bundler/spec/bundler/compact_index_client/updater_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe Bundler::CompactIndexClient::Updater do
 
   context "when bundler doesn't have permissions on Dir.tmpdir" do
     it "Errno::EACCES is raised" do
+      local_path # create local path before stubbing mktmpdir
       allow(Dir).to receive(:mktmpdir) { raise Errno::EACCES }
 
       expect do

--- a/bundler/spec/bundler/compact_index_client/updater_spec.rb
+++ b/bundler/spec/bundler/compact_index_client/updater_spec.rb
@@ -16,15 +16,13 @@ RSpec.describe Bundler::CompactIndexClient::Updater do
 
     let(:response) { double(:response, :body => "") }
 
-    it "MisMatchedChecksumError is raised" do
+    it "treats the response as an update" do
       # Twice: #update retries on failure
-      expect(response).to receive(:[]).with("Content-Encoding").twice { "" }
-      expect(response).to receive(:[]).with("ETag").twice { nil }
-      expect(fetcher).to receive(:call).twice { response }
+      expect(response).to receive(:[]).with("Content-Encoding") { "" }
+      expect(response).to receive(:[]).with("ETag") { nil }
+      expect(fetcher).to receive(:call) { response }
 
-      expect do
-        updater.update(local_path, remote_path)
-      end.to raise_error(Bundler::CompactIndexClient::Updater::MisMatchedChecksumError)
+      updater.update(local_path, remote_path)
     end
   end
 

--- a/bundler/spec/bundler/compact_index_client/updater_spec.rb
+++ b/bundler/spec/bundler/compact_index_client/updater_spec.rb
@@ -6,18 +6,16 @@ require "bundler/compact_index_client/updater"
 
 RSpec.describe Bundler::CompactIndexClient::Updater do
   let(:fetcher) { double(:fetcher) }
-  let(:local_path) { Pathname("/tmp/localpath") }
+  let(:local_path) { Pathname.new Dir.mktmpdir("localpath") }
   let(:remote_path) { double(:remote_path) }
 
   let!(:updater) { described_class.new(fetcher) }
 
   context "when the ETag header is missing" do
     # Regression test for https://github.com/rubygems/bundler/issues/5463
-
-    let(:response) { double(:response, :body => "") }
+    let(:response) { double(:response, :body => "abc123") }
 
     it "treats the response as an update" do
-      # Twice: #update retries on failure
       expect(response).to receive(:[]).with("Content-Encoding") { "" }
       expect(response).to receive(:[]).with("ETag") { nil }
       expect(fetcher).to receive(:call) { response }


### PR DESCRIPTION
If the server does not provide an etag header, treat all responses as a
cache miss. This should allow 3rd party gem servers to more easily
provide compact_index results. /cc @mperham

See also https://github.com/mperham/sidekiq/issues/4158.