### PR TITLE
Make --dry-run flag consistent across rubygems commands

### DIFF
--- a/lib/rubygems/commands/cleanup_command.rb
+++ b/lib/rubygems/commands/cleanup_command.rb
@@ -15,6 +15,12 @@ class Gem::Commands::CleanupCommand < Gem::Command
       options[:dryrun] = true
     end
 
+    add_option('-n', '-d', '--dryrun',
+               'Do not uninstall gems') do |value, options|
+      options[:dryrun] = true
+    end
+    deprecate_option('--dryrun', extra_msg: 'Use --dry-run instead')
+
     add_option('-D', '--[no-]check-development',
                'Check development dependencies while uninstalling',
                '(default: true)') do |value, options|
@@ -41,7 +47,7 @@ class Gem::Commands::CleanupCommand < Gem::Command
   end
 
   def defaults_str # :nodoc:
-    "--no-dryrun"
+    "--no-dry-run"
   end
 
   def description # :nodoc:

--- a/lib/rubygems/commands/cleanup_command.rb
+++ b/lib/rubygems/commands/cleanup_command.rb
@@ -10,7 +10,7 @@ class Gem::Commands::CleanupCommand < Gem::Command
           :force => false, :install_dir => Gem.dir,
           :check_dev => true
 
-    add_option('-n', '-d', '--dryrun',
+    add_option('-n', '-d', '--dry-run',
                'Do not uninstall gems') do |value, options|
       options[:dryrun] = true
     end

--- a/lib/rubygems/commands/cleanup_command.rb
+++ b/lib/rubygems/commands/cleanup_command.rb
@@ -15,7 +15,7 @@ class Gem::Commands::CleanupCommand < Gem::Command
       options[:dryrun] = true
     end
 
-    add_option('-n', '-d', '--dryrun',
+    add_option('--dryrun',
                'Do not uninstall gems') do |value, options|
       options[:dryrun] = true
     end

--- a/lib/rubygems/commands/cleanup_command.rb
+++ b/lib/rubygems/commands/cleanup_command.rb
@@ -15,7 +15,7 @@ class Gem::Commands::CleanupCommand < Gem::Command
       options[:dryrun] = true
     end
 
-    add_option('--dryrun',
+    add_option(:Deprecated, '--dryrun',
                'Do not uninstall gems') do |value, options|
       options[:dryrun] = true
     end

--- a/test/rubygems/test_gem_commands_cleanup_command.rb
+++ b/test/rubygems/test_gem_commands_cleanup_command.rb
@@ -26,6 +26,17 @@ class TestGemCommandsCleanupCommand < Gem::TestCase
     assert @cmd.options[:dryrun]
   end
 
+  def test_handle_options_deprecated_dry_run
+    use_ui @ui do
+      @cmd.handle_options %w[--dryrun]
+      assert @cmd.options[:dryrun]
+    end
+
+    assert_equal \
+      "WARNING:  The \"--dryrun\" option has been deprecated and will be removed in future versions of Rubygems. Use --dry-run instead\n",
+      @ui.error
+  end
+
   def test_handle_options_n
     @cmd.handle_options %w[-n]
     assert @cmd.options[:dryrun]

--- a/test/rubygems/test_gem_commands_cleanup_command.rb
+++ b/test/rubygems/test_gem_commands_cleanup_command.rb
@@ -22,7 +22,7 @@ class TestGemCommandsCleanupCommand < Gem::TestCase
   end
 
   def test_handle_options_dry_run
-    @cmd.handle_options %w[--dryrun]
+    @cmd.handle_options %w[--dry-run]
     assert @cmd.options[:dryrun]
   end
 


### PR DESCRIPTION
# Description:
closes https://github.com/rubygems/rubygems/issues/3866

Make `--dryrun` flag consistent across Rubygems commands
______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
