### PR TITLE
Deprecate server command

### DIFF
--- a/lib/rubygems/command_manager.rb
+++ b/lib/rubygems/command_manager.rb
@@ -174,8 +174,13 @@ class Gem::CommandManager
     else
       cmd_name = args.shift.downcase
       cmd = find_command cmd_name
-      cmd.invoke_with_build_args args, build_args
-      cmd.deprecation_warning if cmd.deprecated?
+      if cmd_name == "server"
+        cmd.deprecation_warning if cmd.deprecated?
+        cmd.invoke_with_build_args args, build_args
+      else
+        cmd.invoke_with_build_args args, build_args
+        cmd.deprecation_warning if cmd.deprecated?
+      end
     end
   end
 

--- a/lib/rubygems/command_manager.rb
+++ b/lib/rubygems/command_manager.rb
@@ -174,13 +174,8 @@ class Gem::CommandManager
     else
       cmd_name = args.shift.downcase
       cmd = find_command cmd_name
-      if cmd_name == "server"
-        cmd.deprecation_warning if cmd.deprecated?
-        cmd.invoke_with_build_args args, build_args
-      else
-        cmd.invoke_with_build_args args, build_args
-        cmd.deprecation_warning if cmd.deprecated?
-      end
+      cmd.deprecation_warning if cmd.deprecated?
+      cmd.invoke_with_build_args args, build_args
     end
   end
 

--- a/lib/rubygems/commands/server_command.rb
+++ b/lib/rubygems/commands/server_command.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 require 'rubygems/command'
 require 'rubygems/server'
+require 'rubygems/deprecate'
 
 class Gem::Commands::ServerCommand < Gem::Command
+  extend Gem::Deprecate
+  rubygems_deprecate_command
+
   def initialize
     super 'server', 'Documentation and gem repository HTTP server',
           :port => 8808, :gemdir => [], :daemon => false

--- a/test/rubygems/test_gem_commands_help_command.rb
+++ b/test/rubygems/test_gem_commands_help_command.rb
@@ -59,7 +59,7 @@ class TestGemCommandsHelpCommand < Gem::TestCase
     util_gem 'commands' do |out, err|
       deprecated_commands = mgr.command_names.select {|cmd| mgr[cmd].deprecated? }
       deprecated_commands.each do |cmd|
-        refute_match(/\s+#{cmd}\s+\S+/, out)
+        refute_match(/\A\s+#{cmd}\s+\S+\z/, out)
       end
     end
   end

--- a/test/rubygems/test_gem_gem_runner.rb
+++ b/test/rubygems/test_gem_gem_runner.rb
@@ -74,7 +74,7 @@ class TestGemGemRunner < Gem::TestCase
     args = %w[query]
 
     use_ui @ui do
-      assert_nil @runner.run(args)
+      @runner.run(args)
     end
 
     assert_match(/WARNING:  query command is deprecated. It will be removed in Rubygems [0-9]+/, @ui.error)
@@ -85,7 +85,7 @@ class TestGemGemRunner < Gem::TestCase
     args = %w[info]
 
     use_ui @ui do
-      assert_nil @runner.run(args)
+      @runner.run(args)
     end
 
     assert_empty @ui.error
@@ -95,7 +95,7 @@ class TestGemGemRunner < Gem::TestCase
     args = %w[list]
 
     use_ui @ui do
-      assert_nil @runner.run(args)
+      @runner.run(args)
     end
 
     assert_empty @ui.error
@@ -105,7 +105,7 @@ class TestGemGemRunner < Gem::TestCase
     args = %w[search]
 
     use_ui @ui do
-      assert_nil @runner.run(args)
+      @runner.run(args)
     end
 
     assert_empty @ui.error


### PR DESCRIPTION
# Description:

Deprecate Server command since is not used and is currently unmaintained. 
______________

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
