### PR TITLE
unset XDG_* environmental variables for testing of rubygems.

### DIFF
--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -296,6 +296,9 @@ class Gem::TestCase < Minitest::Test
 
     ENV['GEM_VENDOR'] = nil
     ENV['GEMRC'] = nil
+    ENV['XDG_CACHE_HOME'] = nil
+    ENV['XDG_CONFIG_HOME'] = nil
+    ENV['XDG_DATA_HOME'] = nil
     ENV['SOURCE_DATE_EPOCH'] = nil
     ENV["TMPDIR"] = @tmp
 


### PR DESCRIPTION
# Description:

When the developpers uses `XDG_*` environmental variables, the tests of rubygems will override the configurations under them. I reset it in `test_case.rb`
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
