### PR TITLE
Update man page and deprecation warning for binstubs --all

### DIFF
--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -81,10 +81,10 @@ namespace :man do
       Spec::Rubygems.gem_require("ronn")
     rescue Gem::LoadError => e
       desc "Build the man pages"
-      task(:build) { abort "We couln't activate ronn (#{e.requirement}). Try `gem install ronn:'#{e.requirement}'` to be able to build the help pages" }
+      task(:build) { abort "We couldn't activate ronn (#{e.requirement}). Try `gem install ronn:'#{e.requirement}'` to be able to build the help pages" }
 
       desc "Verify man pages are in sync"
-      task(:check) { abort "We couln't activate ronn (#{e.requirement}). Try `gem install ronn:'#{e.requirement}'` to be able to build the help pages" }
+      task(:check) { abort "We couldn't activate ronn (#{e.requirement}). Try `gem install ronn:'#{e.requirement}'` to be able to build the help pages" }
     else
       directory "man"
 

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -53,7 +53,7 @@ module Bundler
 
       if options["binstubs"]
         Bundler::SharedHelpers.major_deprecation 2,
-          "The --binstubs option will be removed in favor of `bundle binstubs`"
+          "The --binstubs option will be removed in favor of `bundle binstubs --all`"
       end
 
       Plugin.gemfile_install(Bundler.default_gemfile) if Bundler.feature_flag.plugins?

--- a/bundler/man/bundle-binstubs.1
+++ b/bundler/man/bundle-binstubs.1
@@ -36,5 +36,7 @@ Makes binstubs that can work without depending on Rubygems or Bundler at runtime
 \fB\-\-shebang\fR
 Specify a different shebang executable name than the default (default \'ruby\')
 .
-.SH "BUNDLE INSTALL \-\-BINSTUBS"
-To create binstubs for all the gems in the bundle you can use the \fB\-\-binstubs\fR flag in bundle install(1) \fIbundle\-install\.1\.html\fR\.
+.TP
+\fB\-\-all\fR
+Create binstubs for all gems in the bundle\.
+

--- a/bundler/man/bundle-binstubs.1.txt
+++ b/bundler/man/bundle-binstubs.1.txt
@@ -39,9 +39,8 @@ OPTIONS
               Specify a different shebang executable  name  than  the  default
               (default 'ruby')
 
-BUNDLE INSTALL --BINSTUBS
-       To  create  binstubs  for  all  the  gems in the bundle you can use the
-       --binstubs flag in bundle install(1) bundle-install.1.html.
+       --all  Create binstubs for all gems in the bundle.
+
 
 
 

--- a/bundler/man/bundle-binstubs.ronn
+++ b/bundler/man/bundle-binstubs.ronn
@@ -37,7 +37,5 @@ Calling binstubs with [GEM [GEM]] will create binstubs for all given gems.
 * `--shebang`:
   Specify a different shebang executable name than the default (default 'ruby')
 
-## BUNDLE INSTALL --BINSTUBS
-
-To create binstubs for all the gems in the bundle you can use the `--binstubs`
-flag in [bundle install(1)](bundle-install.1.html).
+* `--all`:
+  Create binstubs for all gems in the bundle.

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -271,7 +271,7 @@ RSpec.describe "major deprecations" do
     end
 
     it "should output a deprecation warning", :bundler => "2" do
-      expect(deprecations).to include("The --binstubs option will be removed in favor of `bundle binstubs`")
+      expect(deprecations).to include("The --binstubs option will be removed in favor of `bundle binstubs --all`")
     end
 
     pending "fails with a helpful error", :bundler => "3"


### PR DESCRIPTION
Resolves #3251

Update the deprecation warning to point the user to the `--all` option
for bundle binstubs as the preferred way to install binstubs for all
gems in a bundle.

Update `bundle binstubs` man page to include the `--all` option :tada:
and remove the note pointing to the now deprecated method of installing
all binstubs.
