### PR TITLE
Look for absolute path when removing bundler/setup from RUBYOPT in Bundler.unbundled_env method

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -353,7 +353,9 @@ EOF
       env.delete_if {|k, _| k[0, 7] == "BUNDLE_" }
 
       if env.key?("RUBYOPT")
-        env["RUBYOPT"] = env["RUBYOPT"].sub "-rbundler/setup", ""
+        rubyopt = env["RUBYOPT"].split(" ")
+        rubyopt.delete("-rbundler/setup")
+        env["RUBYOPT"] = rubyopt.join(" ")
       end
 
       if env.key?("RUBYLIB")

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -354,6 +354,7 @@ EOF
 
       if env.key?("RUBYOPT")
         rubyopt = env["RUBYOPT"].split(" ")
+        rubyopt.delete("-r#{File.expand_path("bundler/setup", __dir__)}")
         rubyopt.delete("-rbundler/setup")
         env["RUBYOPT"] = rubyopt.join(" ")
       end

--- a/bundler/spec/runtime/with_unbundled_env_spec.rb
+++ b/bundler/spec/runtime/with_unbundled_env_spec.rb
@@ -84,11 +84,11 @@ RSpec.describe "Bundler.with_env helpers" do
       expect(last_command.stdboth).to include "false"
     end
 
-    it "should remove '-rbundler/setup' from RUBYOPT" do
+    it "should remove '-rbundler/setup' from RUBYOPT even if it was present in original env" do
       create_file("source.rb", <<-RUBY)
         print #{modified_env}['RUBYOPT']
       RUBY
-      ENV["RUBYOPT"] = "-W2 -rbundler/setup #{ENV["RUBYOPT"]}"
+      ENV["BUNDLER_ORIG_RUBYOPT"] = "-W2 -rbundler/setup #{ENV["RUBYOPT"]}"
       simulate_bundler_version_when_missing_prerelease_default_gem_activation do
         bundle_exec_ruby bundled_app("source.rb")
       end

--- a/bundler/spec/runtime/with_unbundled_env_spec.rb
+++ b/bundler/spec/runtime/with_unbundled_env_spec.rb
@@ -84,7 +84,19 @@ RSpec.describe "Bundler.with_env helpers" do
       expect(last_command.stdboth).to include "false"
     end
 
-    it "should remove '-rbundler/setup' from RUBYOPT even if it was present in original env" do
+    it "should remove absolute path to 'bundler/setup' from RUBYOPT even if it was present in original env" do
+      create_file("source.rb", <<-RUBY)
+        print #{modified_env}['RUBYOPT']
+      RUBY
+      setup_require = "-r#{lib_dir}/bundler/setup"
+      ENV["BUNDLER_ORIG_RUBYOPT"] = "-W2 #{setup_require} #{ENV["RUBYOPT"]}"
+      simulate_bundler_version_when_missing_prerelease_default_gem_activation do
+        bundle_exec_ruby bundled_app("source.rb")
+      end
+      expect(last_command.stdboth).not_to include(setup_require)
+    end
+
+    it "should remove relative path to 'bundler/setup' from RUBYOPT even if it was present in original env" do
       create_file("source.rb", <<-RUBY)
         print #{modified_env}['RUBYOPT']
       RUBY


### PR DESCRIPTION
# Why?

Resolves #3705

Bundler no longer supplies the require in RUBYOPT as a relative path but as an absolute path (see https://github.com/rubygems/rubygems/commit/afc00b1e74466cf2b66cac652acc731f8c713a76 ) 

# What?

This updates `unbundled_env` to match that behavior and looks for a require with an absolute path to `bundler/setup` when removing traces of bundler from the environment variable RUBYOPT. It will also continue to look for relative paths to remove as well in order to not create issues with existing scripts people might have that sets it as a relative path.

# Testing Notes

In the examples below, to follow along you'll have to change the absolute paths in the commands based on where your ruby gems and bundler repo are located on your computer. I found `$ gem list -d bundler` helpful to see the path bundler is installed at.

I would expect this issue to appear only on 2.2.0.rc.1 and later because that is the release the commit was in changing RUBYOPT to have an absolute and not relative path and it was:

```
$ RUBYOPT=-r/Users/ross/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/bundler-2.2.0.rc.1/lib/bundler/setup bundler/bin/bundle exec ruby -rbundler -e'puts Bundler::VERSION'
=> 2.2.0.rc.1

$ RUBYOPT=-r/Users/ross/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/bundler-2.2.0.rc.1/lib/bundler/setup bundle exec ruby -rbundler -e'puts Bundler.unbundled_env["RUBYOPT"]'
=> -r/Users/ross/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/bundler-2.2.0.rc.1/lib/bundler/setup
```

I then confirmed that the -r statement in RUBYOPT was removed when running the bundler code from this feature branch:

```
$ RUBYOPT=-r/Users/ross/dev/rubygems/bundler/lib/bundler/setup bundle exec ruby -rbundler -e'puts Bundler::VERSION'
=> 2.2.0.rc.2

$ RUBYOPT=-r/Users/ross/dev/rubygems/bundler/lib/bundler/setup bundle exec ruby -rbundler -e'puts Bundler.unbundled_env["RUBYOPT"]'
=> # Nothing returned
```

I went back to version 2.1.2 to see what the behavior was before:
```
$ bundle exec ruby -rbundler -e'puts Bundler::VERSION'
=> 2.1.2

$ bundle exec ruby -rbundler -e'puts ENV["RUBYOPT"]'
=> -r/Users/ross/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/setup

$ bundle exec ruby -rbundler -e'puts Bundler.unbundled_env["RUBYOPT"]'
=> # Nothing

$ RUBYOPT=-rbundler/setup bundle exec ruby -rbundler -e'puts Bundler.unbundled_env["RUBYOPT"]'
=> # Still nothing

# Doesn't remove an absolute path
$ RUBYOPT=-r/Users/ross/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/setup bundle exec ruby -rbundler -e'puts Bundler.unbundled_env["RUBYOPT"]'
=> -r/Users/ross/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/setup
```

This gives me confidence that:
- The issue was only present in and after 2.2.0.rc.1
- The change in this behavior addresses the issues seen in 2.2.0.rc.1

# Caveats

One caveat to mention is that before using `unbundled_env` would always remove `bundler/setup` from RUBYOPT regardless of the version of bundler the entry in RUBYOPT was targeted at. After this change, `unbundled_env` only removes the absolute path for `bundler/setup` that points to the currently activated version of bundler. We discussed making a broader regex for trying to clean up any -r for `bundler/setup` but were concerned that might be too broad and might lead to trouble.