### PR TITLE
Add `--all-platforms` flag to `bundle binstubs` to generate binstubs for all platforms

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -381,6 +381,8 @@ module Bundler
       "Make binstubs that can work without the Bundler runtime"
     method_option "all", :type => :boolean, :banner =>
       "Install binstubs for all gems"
+    method_option "all-platforms", :type => :boolean, :default => false, :banner =>
+      "Install binstubs for all platforms"
     def binstubs(*gems)
       require_relative "cli/binstubs"
       Binstubs.new(options, gems).run

--- a/bundler/lib/bundler/cli/binstubs.rb
+++ b/bundler/lib/bundler/cli/binstubs.rb
@@ -16,7 +16,11 @@ module Bundler
       Bundler.settings.set_command_option_if_given :shebang, options["shebang"]
       installer = Installer.new(Bundler.root, Bundler.definition)
 
-      installer_opts = { :force => options[:force], :binstubs_cmd => true }
+      installer_opts = {
+        :force => options[:force],
+        :binstubs_cmd => true,
+        :all_platforms => options["all-platforms"],
+      }
 
       if options[:all]
         raise InvalidOption, "Cannot specify --all with specific gems" unless gems.empty?
@@ -38,7 +42,7 @@ module Bundler
         if options[:standalone]
           next Bundler.ui.warn("Sorry, Bundler can only be run via RubyGems.") if gem_name == "bundler"
           Bundler.settings.temporary(:path => (Bundler.settings[:path] || Bundler.root)) do
-            installer.generate_standalone_bundler_executable_stubs(spec)
+            installer.generate_standalone_bundler_executable_stubs(spec, installer_opts)
           end
         else
           installer.generate_bundler_executable_stubs(spec, installer_opts)

--- a/bundler/lib/bundler/installer.rb
+++ b/bundler/lib/bundler/installer.rb
@@ -143,7 +143,7 @@ module Bundler
         end
 
         File.write(binstub_path, content, :mode => mode, :perm => 0o777 & ~File.umask)
-        if Bundler::WINDOWS
+        if Bundler::WINDOWS || options[:all_platforms]
           prefix = "@ruby -x \"%~f0\" %*\n@exit /b %ERRORLEVEL%\n\n"
           File.write("#{binstub_path}.cmd", prefix + content, :mode => mode)
         end
@@ -164,7 +164,7 @@ module Bundler
       end
     end
 
-    def generate_standalone_bundler_executable_stubs(spec)
+    def generate_standalone_bundler_executable_stubs(spec, options = {})
       # double-assignment to avoid warnings about variables that will be used by ERB
       bin_path = Bundler.bin_path
       unless path = Bundler.settings[:path]
@@ -190,7 +190,7 @@ module Bundler
         end
 
         File.write("#{bin_path}/#{executable}", content, :mode => mode, :perm => 0o755)
-        if Bundler::WINDOWS
+        if Bundler::WINDOWS || options[:all_platforms]
           prefix = "@ruby -x \"%~f0\" %*\n@exit /b %ERRORLEVEL%\n\n"
           File.write("#{bin_path}/#{executable}.cmd", prefix + content, :mode => mode)
         end

--- a/bundler/spec/commands/binstubs_spec.rb
+++ b/bundler/spec/commands/binstubs_spec.rb
@@ -51,6 +51,18 @@ RSpec.describe "bundle binstubs <gem>" do
       expect(bundled_app("bin/rake")).to exist
     end
 
+    it "allows installing binstubs for all platforms" do
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rack"
+      G
+
+      bundle "binstubs rack --all-platforms"
+
+      expect(bundled_app("bin/rackup")).to exist
+      expect(bundled_app("bin/rackup.cmd")).to exist
+    end
+
     it "displays an error when used without any gem" do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
@@ -354,6 +366,14 @@ RSpec.describe "bundle binstubs <gem>" do
       it "generates a standalone binstub at the given path" do
         bundle "binstubs rack --standalone --path foo"
         expect(bundled_app("foo/rackup")).to exist
+      end
+    end
+
+    context "when specified --all-platforms option" do
+      it "generates standalone binstubs for all platforms" do
+        bundle "binstubs rack --standalone --all-platforms"
+        expect(bundled_app("bin/rackup")).to exist
+        expect(bundled_app("bin/rackup.cmd")).to exist
       end
     end
   end


### PR DESCRIPTION
# Description:

<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

This closes #2120

> I stumbled across the fact that when working with jruby on a Linux system, no Windows stub files are generated for installed gems. This is reasonable for a native ruby installation, but it would be nice to also generate windows stubs in a jruby environment because this would make the jruby folder portable also across OS types as long as there is a JRE available.

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

This adds `--all-platforms` option suggested by segiddins

I think the manpages also should be updated but I'm not quite sure how to go about doing that

______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
