### PR TITLE
only stat user home once when path is missing

### DIFF
--- a/lib/rubygems/source.rb
+++ b/lib/rubygems/source.rb
@@ -35,6 +35,7 @@ class Gem::Source
     end
 
     @uri = uri
+    @update_cache = nil
   end
 
   ##
@@ -114,7 +115,8 @@ class Gem::Source
   # Returns true when it is possible and safe to update the cache directory.
 
   def update_cache?
-    @update_cache ||=
+    return @update_cache unless @update_cache.nil?
+    @update_cache =
       begin
         File.stat(Gem.user_home).uid == Process.uid
       rescue Errno::ENOENT


### PR DESCRIPTION
noticed several unnecessary stat calls when `Gem.user_home` was set to non existent path.

## What was the end-user or developer problem that led to this PR?

just poking around RGs

## What is your fix for the problem, implemented in this PR?

treat `false` as an end state - do not `stat` again when looking for cache and `false` already

--- 

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
