### PR TITLE
Re-use install update default options

### DIFF
--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -27,6 +27,8 @@ class Gem::Commands::InstallCommand < Gem::Command
       :without_groups    => [],
     })
 
+    defaults.merge!(install_update_options)
+
     super 'install', 'Install a gem into the local repository', defaults
 
     add_install_update_options

--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -43,8 +43,9 @@ class Gem::Commands::InstallCommand < Gem::Command
   end
 
   def defaults_str # :nodoc:
-    "--both --version '#{Gem::Requirement.default}' --document --no-force\n" +
-    "--install-dir #{Gem.dir} --lock"
+    "--both --version '#{Gem::Requirement.default}' --no-force\n" +
+    "--install-dir #{Gem.dir} --lock\n" +
+    install_update_defaults_str
   end
 
   def description # :nodoc:

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -20,9 +20,10 @@ class Gem::Commands::UpdateCommand < Gem::Command
 
   def initialize
     options = {
-      :document => %w[ri],
       :force    => false
     }
+
+    options.merge!(install_update_options)
 
     super 'update', 'Update installed gems to the latest version', options
 

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -20,7 +20,7 @@ class Gem::Commands::UpdateCommand < Gem::Command
 
   def initialize
     options = {
-      :force    => false
+      :force => false,
     }
 
     options.merge!(install_update_options)

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -20,7 +20,7 @@ class Gem::Commands::UpdateCommand < Gem::Command
 
   def initialize
     options = {
-      :document => %w[rdoc ri],
+      :document => %w[ri],
       :force    => false
     }
 

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -19,9 +19,12 @@ class Gem::Commands::UpdateCommand < Gem::Command
   attr_reader :updated # :nodoc:
 
   def initialize
-    super 'update', 'Update installed gems to the latest version',
+    options = {
       :document => %w[rdoc ri],
       :force    => false
+    }
+
+    super 'update', 'Update installed gems to the latest version', options
 
     add_install_update_options
 
@@ -51,7 +54,8 @@ class Gem::Commands::UpdateCommand < Gem::Command
   end
 
   def defaults_str # :nodoc:
-    "--document --no-force --install-dir #{Gem.dir}"
+    "--no-force --install-dir #{Gem.dir}\n" +
+    install_update_defaults_str
   end
 
   def description # :nodoc:

--- a/lib/rubygems/install_update_options.rb
+++ b/lib/rubygems/install_update_options.rb
@@ -186,7 +186,6 @@ module Gem::InstallUpdateOptions
   def install_update_options
     {
       :document => %w[ri],
-      :wrappers => true,
     }
   end
 
@@ -194,7 +193,7 @@ module Gem::InstallUpdateOptions
   # Default description for the gem install and update commands.
 
   def install_update_defaults_str
-    '--document=ri --wrappers'
+    '--document=ri'
   end
 
 end

--- a/lib/rubygems/install_update_options.rb
+++ b/lib/rubygems/install_update_options.rb
@@ -184,7 +184,7 @@ module Gem::InstallUpdateOptions
   # Default options for the gem install command.
 
   def install_update_defaults_str
-    '--document=rdoc,ri --wrappers'
+    '--document=ri --wrappers'
   end
 
 end

--- a/lib/rubygems/install_update_options.rb
+++ b/lib/rubygems/install_update_options.rb
@@ -181,7 +181,17 @@ module Gem::InstallUpdateOptions
   end
 
   ##
-  # Default options for the gem install command.
+  # Default options for the gem install and update commands.
+
+  def install_update_options
+    {
+      :document => %w[ri],
+      :wrappers => true,
+    }
+  end
+
+  ##
+  # Default description for the gem install and update commands.
 
   def install_update_defaults_str
     '--document=ri --wrappers'

--- a/test/rubygems/test_gem_command_manager.rb
+++ b/test/rubygems/test_gem_command_manager.rb
@@ -266,7 +266,6 @@ class TestGemCommandManager < Gem::TestCase
     #check defaults
     @command_manager.process_args %w[update]
     assert_includes check_options[:document], 'ri'
-    assert_equal true, check_options[:wrappers]
 
     #check settings
     check_options = nil

--- a/test/rubygems/test_gem_command_manager.rb
+++ b/test/rubygems/test_gem_command_manager.rb
@@ -265,7 +265,8 @@ class TestGemCommandManager < Gem::TestCase
 
     #check defaults
     @command_manager.process_args %w[update]
-    assert_includes check_options[:document], 'rdoc'
+    assert_includes check_options[:document], 'ri'
+    assert_equal true, check_options[:wrappers]
 
     #check settings
     check_options = nil

--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -554,7 +554,6 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
       :args     => [],
       :document => %w[ri],
       :force    => false,
-      :wrappers => true,
       :system   => true,
     }
 
@@ -574,7 +573,6 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
       :args     => [],
       :document => %w[ri],
       :force    => false,
-      :wrappers => true,
       :system   => "1.3.7",
     }
 

--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -552,8 +552,9 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
 
     expected = {
       :args     => [],
-      :document => %w[rdoc ri],
+      :document => %w[ri],
       :force    => false,
+      :wrappers => true,
       :system   => true,
     }
 
@@ -571,8 +572,9 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
 
     expected = {
       :args     => [],
-      :document => %w[rdoc ri],
+      :document => %w[ri],
       :force    => false,
+      :wrappers => true,
       :system   => "1.3.7",
     }
 


### PR DESCRIPTION
# Description:

I found the current `install_update_default_str` is not used in RubyGems at https://github.com/rubygems/rubygems/pull/2847#issuecomment-670486536

I re-use the its method and extract the current default options to `install_update_options.rb` from ` install_command.rb` and `update_command.rb`.

And I removed `rdoc` document option from `gem update`. It's breaking changes with RubyGems 3.1. But It's inconsistency with `install` command for 9 years ago.  see https://github.com/rubygems/rubygems/blob/master/lib/rubygems/dependency_installer.rb#L20

______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
