### PR TITLE
Sort requirements in Gem::Requirement to succeed comparison with different order

### DIFF
--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -129,6 +129,34 @@ module Gem
     end
   end
 
+  unless Gem::Requirement.new("> 1", "< 2") == Gem::Requirement.new("< 2", "> 1")
+    class Requirement
+      module OrderIndependentComparison
+        def ==(other)
+          if _requirements_sorted? && other._requirements_sorted?
+            super
+          else
+            _with_sorted_requirements == other._with_sorted_requirements
+          end
+        end
+
+        protected
+
+        def _requirements_sorted?
+          return @_are_requirements_sorted if defined?(@_are_requirements_sorted)
+          strings = as_list
+          @_are_requirements_sorted = strings == strings.sort
+        end
+
+        def _with_sorted_requirements
+          @_with_sorted_requirements ||= _requirements_sorted? ? self : self.class.new(as_list.sort)
+        end
+      end
+
+      prepend OrderIndependentComparison
+    end
+  end
+
   class Platform
     JAVA  = Gem::Platform.new("java") unless defined?(JAVA)
     MSWIN = Gem::Platform.new("mswin32") unless defined?(MSWIN)

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -129,6 +129,7 @@ module Gem
     end
   end
 
+  # comparison is done order independently since rubygems 3.2.0.rc.2
   unless Gem::Requirement.new("> 1", "< 2") == Gem::Requirement.new("< 2", "> 1")
     class Requirement
       module OrderIndependentComparison

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -256,7 +256,7 @@ RSpec.describe "bundle install across platforms" do
     expect(the_bundle).not_to include_gem "CFPropertyList"
   end
 
-  it "works with gems with platform-specific dependency having different requirements order", :rubygems => ">= 3.2.0.rc.2" do
+  it "works with gems with platform-specific dependency having different requirements order" do
     simulate_platform x64_mac
 
     update_repo2 do

--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -131,6 +131,7 @@ class Gem::Requirement
     requirements = requirements.flatten
     requirements.compact!
     requirements.uniq!
+    requirements.sort!
 
     if requirements.empty?
       @requirements = [DefaultRequirement]

--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -283,11 +283,11 @@ class Gem::Requirement
   protected
 
   def _sorted_requirements
-    requirements.sort_by(&:to_s)
+    @_sorted_requirements ||= requirements.sort_by(&:to_s)
   end
 
   def _tilde_requirements
-    _sorted_requirements.select {|r| r.first == "~>" }
+    @_tilde_requirements ||= _sorted_requirements.select {|r| r.first == "~>" }
   end
 
   private

--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -131,7 +131,7 @@ class Gem::Requirement
     requirements = requirements.flatten
     requirements.compact!
     requirements.uniq!
-    requirements.sort!
+    requirements.sort_by!(&:to_s)
 
     if requirements.empty?
       @requirements = [DefaultRequirement]

--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -131,7 +131,6 @@ class Gem::Requirement
     requirements = requirements.flatten
     requirements.compact!
     requirements.uniq!
-    requirements.sort_by!(&:to_s)
 
     if requirements.empty?
       @requirements = [DefaultRequirement]
@@ -271,7 +270,7 @@ class Gem::Requirement
     return unless Gem::Requirement === other
 
     # An == check is always necessary
-    return false unless requirements == other.requirements
+    return false unless _sorted_requirements == other._sorted_requirements
 
     # An == check is sufficient unless any requirements use ~>
     return true unless _tilde_requirements.any?
@@ -283,8 +282,12 @@ class Gem::Requirement
 
   protected
 
+  def _sorted_requirements
+    requirements.sort_by(&:to_s)
+  end
+
   def _tilde_requirements
-    requirements.select {|r| r.first == "~>" }
+    _sorted_requirements.select {|r| r.first == "~>" }
   end
 
   private

--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -22,7 +22,7 @@ class TestGemRequirement < Gem::TestCase
     refute_requirement_equal "~> 1.3", "~> 1.3.0"
     refute_requirement_equal "~> 1.3.0", "~> 1.3"
 
-    assert_requirement_equal ["> 2", "~> 1.3"], ["~> 1.3", "> 2"]
+    assert_requirement_equal ["> 2", "~> 1.3", "~> 1.3.1"], ["~> 1.3.1", "~> 1.3", "> 2"]
 
     assert_requirement_equal ["> 2", "~> 1.3"], ["> 2.0", "~> 1.3"]
     assert_requirement_equal ["> 2.0", "~> 1.3"], ["> 2", "~> 1.3"]

--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -22,6 +22,8 @@ class TestGemRequirement < Gem::TestCase
     refute_requirement_equal "~> 1.3", "~> 1.3.0"
     refute_requirement_equal "~> 1.3.0", "~> 1.3"
 
+    assert_requirement_equal ["> 2", "~> 1.3"], ["~> 1.3", "> 2"]
+
     assert_requirement_equal ["> 2", "~> 1.3"], ["> 2.0", "~> 1.3"]
     assert_requirement_equal ["> 2.0", "~> 1.3"], ["> 2", "~> 1.3"]
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2557,11 +2557,11 @@ Gem::Specification.new do |s|
   if s.respond_to? :add_runtime_dependency then
     s.add_runtime_dependency(%q<rake>.freeze, [\"> 0.4\"])
     s.add_runtime_dependency(%q<jabber4r>.freeze, [\"> 0.0.0\"])
-    s.add_runtime_dependency(%q<pqa>.freeze, [\"> 0.4\", \"<= 0.6\"])
+    s.add_runtime_dependency(%q<pqa>.freeze, [\"<= 0.6\", \"> 0.4\"])
   else
     s.add_dependency(%q<rake>.freeze, [\"> 0.4\"])
     s.add_dependency(%q<jabber4r>.freeze, [\"> 0.0.0\"])
-    s.add_dependency(%q<pqa>.freeze, [\"> 0.4\", \"<= 0.6\"])
+    s.add_dependency(%q<pqa>.freeze, [\"<= 0.6\", \"> 0.4\"])
   end
 end
     SPEC
@@ -2578,7 +2578,7 @@ end
       s.add_dependency 'b', ['~> 1.0', '>= 1.0.0']
     end
 
-    assert_includes spec.to_ruby, '"~> 1.0", ">= 1.0.0"'
+    assert_includes spec.to_ruby, '">= 1.0.0", "~> 1.0"'
   end
 
   def test_to_ruby_legacy

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2557,11 +2557,11 @@ Gem::Specification.new do |s|
   if s.respond_to? :add_runtime_dependency then
     s.add_runtime_dependency(%q<rake>.freeze, [\"> 0.4\"])
     s.add_runtime_dependency(%q<jabber4r>.freeze, [\"> 0.0.0\"])
-    s.add_runtime_dependency(%q<pqa>.freeze, [\"<= 0.6\", \"> 0.4\"])
+    s.add_runtime_dependency(%q<pqa>.freeze, [\"> 0.4\", \"<= 0.6\"])
   else
     s.add_dependency(%q<rake>.freeze, [\"> 0.4\"])
     s.add_dependency(%q<jabber4r>.freeze, [\"> 0.0.0\"])
-    s.add_dependency(%q<pqa>.freeze, [\"<= 0.6\", \"> 0.4\"])
+    s.add_dependency(%q<pqa>.freeze, [\"> 0.4\", \"<= 0.6\"])
   end
 end
     SPEC
@@ -2578,7 +2578,7 @@ end
       s.add_dependency 'b', ['~> 1.0', '>= 1.0.0']
     end
 
-    assert_includes spec.to_ruby, '">= 1.0.0", "~> 1.0"'
+    assert_includes spec.to_ruby, '"~> 1.0", ">= 1.0.0"'
   end
 
   def test_to_ruby_legacy


### PR DESCRIPTION
# Description:

This PR ensures that comparison of requirements works properly when order or requirements is different.
Before this PR following two dependencies are considered different:
```ruby
<Gem::Dependency type=:runtime name="fspath" requirements="< 4, >= 2.1">
<Gem::Dependency type=:runtime name="fspath" requirements=">= 2.1, < 4">
```

## What was the end-user or developer problem that led to this PR?

When debugging an issue toy/image_optim_pack#20 I've found that in certain conditions platform-specific gem is not selected and an invalid warning is displayed due to comparison of equal dependencies failing. I was able to reproduce it by running following commands:

```shell
gem uninstall image_optim_pack --all

gem install image_optim_pack --platform ruby

cat <<GEMFILE > Gemfile
source 'https://rubygems.org'
gem 'image_optim'
GEMFILE
bundle

cat <<GEMFILE > Gemfile
source 'https://rubygems.org'
gem 'image_optim'
gem 'image_optim_pack'
GEMFILE
bundle
```

## What is your fix for the problem, implemented in this PR?

Debugging the issue I found that inside `Bundler::LazySpecification#__materialize__` the comparison of dependencies failed due to different order of requirements which led to the warning suggesting that ruby and platform specific gems have different dependencies and selected ruby version of the gem. Suggested change fixes the behaviour.

______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
