### PR TITLE
Test TruffleRuby 20.2.0 in CI

### DIFF
--- a/.github/workflows/ubuntu-rubygems.yml
+++ b/.github/workflows/ubuntu-rubygems.yml
@@ -13,7 +13,9 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        ruby: [ 2.3.8, 2.4.10, 2.5.8, 2.6.6, 2.7.1, jruby-9.2.11.1 ]
+        ruby: [ 2.3.8, 2.4.10, 2.5.8, 2.6.6, 2.7.1, jruby-9.2.11.1, truffleruby-20.2.0 ]
+    env:
+      TRUFFLERUBYOPT: "--experimental-options --testing-rubygems"
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby


### PR DESCRIPTION
Now that there is a release of TruffleRuby [passing all tests](https://github.com/eregon/rubygems/runs/1012248544?check_suite_focus=true), we can test it on every change :)

cc @hsbt @deivid-rodriguez 