### PR TITLE
fix: MiniTest file and class should starts with 'test'

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -157,8 +157,8 @@ bundler/lib/bundler/templates/newgem/rspec.tt
 bundler/lib/bundler/templates/newgem/rubocop.yml.tt
 bundler/lib/bundler/templates/newgem/spec/newgem_spec.rb.tt
 bundler/lib/bundler/templates/newgem/spec/spec_helper.rb.tt
-bundler/lib/bundler/templates/newgem/test/minitest/newgem_test.rb.tt
 bundler/lib/bundler/templates/newgem/test/minitest/test_helper.rb.tt
+bundler/lib/bundler/templates/newgem/test/minitest/test_newgem.rb.tt
 bundler/lib/bundler/templates/newgem/test/test-unit/newgem_test.rb.tt
 bundler/lib/bundler/templates/newgem/test/test-unit/test_helper.rb.tt
 bundler/lib/bundler/templates/newgem/travis.yml.tt

--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -95,7 +95,7 @@ module Bundler
         when "minitest"
           templates.merge!(
             "test/minitest/test_helper.rb.tt" => "test/test_helper.rb",
-            "test/minitest/newgem_test.rb.tt" => "test/#{namespaced_path}_test.rb"
+            "test/minitest/test_newgem.rb.tt" => "test/test_#{namespaced_path}.rb"
           )
           config[:test_task] = :test
         when "test-unit"

--- a/bundler/lib/bundler/templates/newgem/Rakefile.tt
+++ b/bundler/lib/bundler/templates/newgem/Rakefile.tt
@@ -3,7 +3,16 @@
 require "bundler/gem_tasks"
 <% default_task_names = [config[:test_task]].compact -%>
 <% case config[:test] -%>
-<% when "minitest", "test-unit" -%>
+<% when "minitest" -%>
+require "rake/testtask"
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/**/test_*.rb"]
+end
+
+<% when "test-unit" -%>
 require "rake/testtask"
 
 Rake::TestTask.new(:test) do |t|

--- a/bundler/lib/bundler/templates/newgem/test/minitest/test_newgem.rb.tt
+++ b/bundler/lib/bundler/templates/newgem/test/minitest/test_newgem.rb.tt
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class <%= config[:constant_name] %>Test < Minitest::Test
+class Test<%= config[:constant_name] %> < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::<%= config[:constant_name] %>::VERSION
   end

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -532,7 +532,7 @@ RSpec.describe "bundle gem" do
       end
 
       it "builds spec skeleton" do
-        expect(bundled_app("#{gem_name}/test/#{require_path}_test.rb")).to exist
+        expect(bundled_app("#{gem_name}/test/test_#{require_path}.rb")).to exist
         expect(bundled_app("#{gem_name}/test/test_helper.rb")).to exist
       end
     end
@@ -552,7 +552,7 @@ RSpec.describe "bundle gem" do
       end
 
       it "builds spec skeleton" do
-        expect(bundled_app("#{gem_name}/test/#{require_path}_test.rb")).to exist
+        expect(bundled_app("#{gem_name}/test/test_#{require_path}.rb")).to exist
         expect(bundled_app("#{gem_name}/test/test_helper.rb")).to exist
       end
 
@@ -561,11 +561,11 @@ RSpec.describe "bundle gem" do
       end
 
       it "requires 'test_helper'" do
-        expect(bundled_app("#{gem_name}/test/#{require_path}_test.rb").read).to include(%(require "test_helper"))
+        expect(bundled_app("#{gem_name}/test/test_#{require_path}.rb").read).to include(%(require "test_helper"))
       end
 
       it "creates a default test which fails" do
-        expect(bundled_app("#{gem_name}/test/#{require_path}_test.rb").read).to include("assert false")
+        expect(bundled_app("#{gem_name}/test/test_#{require_path}.rb").read).to include("assert false")
       end
     end
 
@@ -585,7 +585,7 @@ RSpec.describe "bundle gem" do
           Rake::TestTask.new(:test) do |t|
             t.libs << "test"
             t.libs << "lib"
-            t.test_files = FileList["test/**/*_test.rb"]
+            t.test_files = FileList["test/**/test_*.rb"]
           end
 
           task default: :test


### PR DESCRIPTION
# Description:

<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

`bundle gem ${newgem} --test=minitest` command generates `${Newgem}Test` test class in `${newgem}_test.rb` file.
[In the official documentation example](https://docs.ruby-lang.org/en/2.0.0/MiniTest.html#module-MiniTest-label-Unit+tests), Minitest's test class starts with `Test`, instead of ending with `Test`.
Neither will cause any real harm, but I think it's better to match the official one.

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

`bundle gem ${newgem} --test=minitest` command generates `Test${Newgem}` test class in `$test_{newgem}.rb` file.
Then I modify the Rakefile template to work with `$test_{newgem}.rb` file.

______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
