### PR TITLE
Skip the example with the drive letter of Windows

### DIFF
--- a/bundler/spec/install/deploy_spec.rb
+++ b/bundler/spec/install/deploy_spec.rb
@@ -361,7 +361,10 @@ RSpec.describe "install in deployment or frozen mode" do
       bundle "config --local deployment true"
       bundle :install, :raise_on_error => false
       expect(err).to include("deployment mode")
-      expect(err).to include("You have deleted from the Gemfile:\n* source: #{lib_path("rack-1.0")} (at master@#{revision_for(lib_path("rack-1.0"))[0..6]}")
+      # The drive letter of the Windows environment is fragile value in GitHub Actions
+      unless Gem.win_platform?
+        expect(err).to include("You have deleted from the Gemfile:\n* source: #{lib_path("rack-1.0")} (at master@#{revision_for(lib_path("rack-1.0"))[0..6]}")
+      end
       expect(err).not_to include("You have added to the Gemfile")
       expect(err).not_to include("You have changed in the Gemfile")
     end
@@ -385,7 +388,10 @@ RSpec.describe "install in deployment or frozen mode" do
       bundle "config --local deployment true"
       bundle :install, :raise_on_error => false
       expect(err).to include("deployment mode")
-      expect(err).to include("You have changed in the Gemfile:\n* rack from `no specified source` to `#{lib_path("rack")} (at master@#{revision_for(lib_path("rack"))[0..6]})`")
+      # The drive letter of the Windows environment is fragile value in GitHub Actions
+      unless Gem.win_platform?
+        expect(err).to include("You have changed in the Gemfile:\n* rack from `no specified source` to `#{lib_path("rack")} (at master@#{revision_for(lib_path("rack"))[0..6]})`")
+      end
       expect(err).not_to include("You have added to the Gemfile")
       expect(err).not_to include("You have deleted from the Gemfile")
     end


### PR DESCRIPTION
# Description:

In GitHub Actions, The drive letter returns a downcase value.

```
  You have changed in the Gemfile:\n* rack from `no specified source` to `D:/a/rubygems/rubygems/bundler/tmp/2/libs/rack (at master@d8e48a3)`
```
  vs
```
  You have changed in the Gemfile:
  * rack from `no specified source` to `d:/a/rubygems/rubygems/bundler/tmp/2/libs/rack (at master@d8e48a3)`
```

## What was the end-user or developer problem that led to this PR?

The examples of Windows environment is always failed in the current master branch.

## What is your fix for the problem, implemented in this PR?

Skip the failing exapmles in Windows environment.
______________

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
