### PR TITLE
Fix regression related to locked ruby

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -868,8 +868,8 @@ module Bundler
       @metadata_dependencies ||= begin
         ruby_versions = concat_ruby_version_requirements(@ruby_version)
         if ruby_versions.empty? || !@ruby_version.exact?
-          concat_ruby_version_requirements(RubyVersion.system, ruby_versions)
-          concat_ruby_version_requirements(locked_ruby_version_object, ruby_versions) unless @unlock[:ruby]
+          concat_ruby_version_requirements(RubyVersion.system)
+          concat_ruby_version_requirements(locked_ruby_version_object) unless @unlock[:ruby]
         end
         [
           Dependency.new("Ruby\0", ruby_versions),

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -866,11 +866,7 @@ module Bundler
 
     def metadata_dependencies
       @metadata_dependencies ||= begin
-        ruby_versions = concat_ruby_version_requirements(@ruby_version)
-        if ruby_versions.empty? || !@ruby_version.exact?
-          concat_ruby_version_requirements(RubyVersion.system)
-          concat_ruby_version_requirements(locked_ruby_version_object) unless @unlock[:ruby]
-        end
+        ruby_versions = ruby_version_requirements(@ruby_version)
         [
           Dependency.new("Ruby\0", ruby_versions),
           Dependency.new("RubyGems\0", Gem::VERSION),
@@ -878,19 +874,19 @@ module Bundler
       end
     end
 
-    def concat_ruby_version_requirements(ruby_version, ruby_versions = [])
-      return ruby_versions unless ruby_version
+    def ruby_version_requirements(ruby_version)
+      return [] unless ruby_version
       if ruby_version.patchlevel
-        ruby_versions << ruby_version.to_gem_version_with_patchlevel
+        [ruby_version.to_gem_version_with_patchlevel]
       else
-        ruby_versions.concat(ruby_version.versions.map do |version|
+        ruby_version.versions.map do |version|
           requirement = Gem::Requirement.new(version)
           if requirement.exact?
             "~> #{version}.0"
           else
             requirement
           end
-        end)
+        end
       end
     end
 

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -497,6 +497,16 @@ RSpec.describe "bundle install with gem sources" do
             #{Bundler::VERSION}
         L
       end
+
+      it "does not crash when unlocking" do
+        gemfile <<-G
+          ruby '>= 2.1.0'
+        G
+
+        bundle "update"
+
+        expect(err).not_to include("Could not find gem 'Ruby")
+      end
     end
   end
 

--- a/bundler/spec/install/gems/resolving_spec.rb
+++ b/bundler/spec/install/gems/resolving_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe "bundle install with install-time dependencies" do
 
       describe "with a < requirement" do
         let(:ruby_requirement) { %("< 5000") }
-        let(:error_message_requirement) { Gem::Requirement.new(["< 5000", "= #{Bundler::RubyVersion.system.to_gem_version_with_patchlevel}"]).to_s }
+        let(:error_message_requirement) { "< 5000" }
 
         it_behaves_like "ruby version conflicts"
       end
@@ -241,7 +241,7 @@ RSpec.describe "bundle install with install-time dependencies" do
       describe "with a compound requirement" do
         let(:reqs) { ["> 0.1", "< 5000"] }
         let(:ruby_requirement) { reqs.map(&:dump).join(", ") }
-        let(:error_message_requirement) { Gem::Requirement.new(reqs + ["= #{Bundler::RubyVersion.system.to_gem_version_with_patchlevel}"]).to_s }
+        let(:error_message_requirement) { Gem::Requirement.new(reqs).to_s }
 
         it_behaves_like "ruby version conflicts"
       end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

A few months ago we introduced [a change in how we handle the locked ruby version](https://github.com/rubygems/bundler/pull/7559) that has caused a (fortunately still unreleased) regression.

The regression will be hit be applications:

* Using the `ruby` DSL.
* Having a locked ruby version different from the running ruby version.
* Running `bundle update`.

In that case, whereas previously things would just work, we now get an error like the following:


```
Could not find gem 'Ruby (>= 2.2.2, = 2.7.1.83, = 2.6.5.114)' in the local ruby installation. The source contains 'Ruby' at: 2.7.1.83
```

## What is your fix for the problem, implemented in this PR?

This PR reverts the offending PR, and adds a regression spec.

The offending PR (that tried to reactivate this unsued code, but caused this regression), also linked to an alternative PR removing the unused code instead. As a bonus, this PR backports that alternative solution to the new repository.
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).