### PR TITLE
Fix incorrect re-resolution when path gem excluded and not available

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -828,7 +828,7 @@ module Bundler
       end
 
       resolve = SpecSet.new(converged)
-      @locked_specs_incomplete_for_platform = !resolve.for(expand_dependencies(deps), @unlock[:gems], true, true)
+      @locked_specs_incomplete_for_platform = !resolve.for(expand_dependencies(requested_dependencies & deps), @unlock[:gems], true, true)
       resolve = resolve.for(expand_dependencies(deps, true), @unlock[:gems], false, false, false)
       diff    = nil
 

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -635,6 +635,26 @@ RSpec.describe "Bundler.setup" do
       expect(the_bundle).to include_gems "activesupport 2.3.2"
     end
 
+    it "remembers --without and does not bail on bare Bundler.setup, even in the case of path gems no longer available" do
+      bundle "config --local without development"
+
+      path = bundled_app(File.join("vendor", "foo"))
+      build_lib "foo", :path => path
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem "activesupport", "2.3.2"
+        gem 'foo', :path => 'vendor/foo', :group => :development
+      G
+
+      FileUtils.rm_rf(path)
+
+      ruby "require 'bundler'; Bundler.setup", :env => { "DEBUG" => "1" }
+      expect(out).to include("Assuming that source at `vendor/foo` has not changed since fetching its specs errored")
+      expect(out).to include("Found no changes, using resolution from the lockfile")
+      expect(err).to be_empty
+    end
+
     it "remembers --without and does not include groups passed to Bundler.setup" do
       bundle "config --local without rails"
       install_gemfile <<-G


### PR DESCRIPTION
# Description:

According to the debugging messages, if specs for a path gem are not available at `bundler/setup` time, but the group the gem belongs to has been excluded, it should be assumed that the path source has no changes and continue.

However, there's another check for re-resolution that checks completeness for the current platform that was not filtering for requested groups only, and making this case to incorrectly re-resolve, and as a result fail due to the path gem not being available (even if not requested).

This commit should fix the problem.

Fixes #3177.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).