### PR TITLE
Make `--default` and `--install-dir` options to `gem install` play nice together

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -433,7 +433,7 @@ class Gem::Installer
   #
 
   def default_spec_file
-    File.join Gem.default_specifications_dir, "#{spec.full_name}.gemspec"
+    File.join gem_home, "specifications", "default", "#{spec.full_name}.gemspec"
   end
 
   ##

--- a/lib/rubygems/installer_test_case.rb
+++ b/lib/rubygems/installer_test_case.rb
@@ -108,9 +108,9 @@ class Gem::InstallerTestCase < Gem::TestCase
   #
   # And returns a Gem::Installer for the @spec that installs into @gemhome
 
-  def setup_base_installer
+  def setup_base_installer(force = true)
     @gem = setup_base_gem
-    util_installer @spec, @gemhome
+    util_installer @spec, @gemhome, false, force
   end
 
   ##
@@ -182,7 +182,7 @@ class Gem::InstallerTestCase < Gem::TestCase
   #   lib/code.rb
   #   ext/a/mkrf_conf.rb
 
-  def util_setup_gem(ui = @ui)
+  def util_setup_gem(ui = @ui, force = true)
     @spec.files << File.join('lib', 'code.rb')
     @spec.extensions << File.join('ext', 'a', 'mkrf_conf.rb')
 
@@ -214,17 +214,18 @@ class Gem::InstallerTestCase < Gem::TestCase
       end
     end
 
-    Gem::Installer.at @gem
+    Gem::Installer.at @gem, :force => force
   end
 
   ##
   # Creates an installer for +spec+ that will install into +gem_home+.  If
   # +user+ is true a user-install will be performed.
 
-  def util_installer(spec, gem_home, user=false)
+  def util_installer(spec, gem_home, user=false, force=true)
     Gem::Installer.at(spec.cache_file,
                        :install_dir => gem_home,
-                       :user_install => user)
+                       :user_install => user,
+                       :force => force)
   end
 
   @@symlink_supported = nil

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -367,7 +367,6 @@ class Gem::TestCase < Minitest::Test
 
     ENV['GEM_PRIVATE_KEY_PASSPHRASE'] = PRIVATE_KEY_PASSPHRASE
 
-    @default_spec_dir = File.join @gemhome, "specifications", "default"
     if Gem.java_platform?
       @orig_default_gem_home = RbConfig::CONFIG['default_gem_home']
       RbConfig::CONFIG['default_gem_home'] = @gemhome
@@ -795,7 +794,7 @@ class Gem::TestCase < Minitest::Test
   def new_default_spec(name, version, deps = nil, *files)
     spec = util_spec name, version, deps
 
-    spec.loaded_from = File.join(@default_spec_dir, spec.spec_name)
+    spec.loaded_from = File.join(@gemhome, "specifications", "default", spec.spec_name)
     spec.files = files
 
     lib_dir = File.join(@tempdir, "default_gems", "lib")

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -753,13 +753,6 @@ class Gem::TestCase < Minitest::Test
   # Installs the provided default specs including writing the spec file
 
   def install_default_gems(*specs)
-    install_default_specs(*specs)
-  end
-
-  ##
-  # Install the provided default specs
-
-  def install_default_specs(*specs)
     specs.each do |spec|
       installer = Gem::Installer.for_spec(spec, :install_as_default => true)
       installer.install

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -380,8 +380,6 @@ class Gem::TestCase < Minitest::Test
     Gem::Specification.unresolved_deps.clear
     Gem.use_paths(@gemhome)
 
-    Gem::Security.reset
-
     Gem.loaded_specs.clear
     Gem.instance_variable_set(:@activated_gem_paths, 0)
     Gem.clear_default_specs

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -754,12 +754,6 @@ class Gem::TestCase < Minitest::Test
 
   def install_default_gems(*specs)
     install_default_specs(*specs)
-
-    specs.each do |spec|
-      File.open spec.loaded_from, 'w' do |io|
-        io.write spec.to_ruby_for_cache
-      end
-    end
   end
 
   ##

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -367,7 +367,8 @@ class Gem::TestCase < Minitest::Test
 
     ENV['GEM_PRIVATE_KEY_PASSPHRASE'] = PRIVATE_KEY_PASSPHRASE
 
-    @default_dir = File.join @tempdir, 'default'
+    @default_dir = @gemhome
+
     @default_spec_dir = File.join @default_dir, "specifications", "default"
     if Gem.java_platform?
       @orig_default_gem_home = RbConfig::CONFIG['default_gem_home']
@@ -376,6 +377,9 @@ class Gem::TestCase < Minitest::Test
       Gem.instance_variable_set(:@default_dir, @default_dir)
     end
     FileUtils.mkdir_p @default_spec_dir
+
+    @orig_bindir = RbConfig::CONFIG["bindir"]
+    RbConfig::CONFIG["bindir"] = File.join @gemhome, "bin"
 
     Gem::Specification.unresolved_deps.clear
     Gem.use_paths(@gemhome)
@@ -447,6 +451,8 @@ class Gem::TestCase < Minitest::Test
                          @orig_SYSTEM_WIDE_CONFIG_FILE
 
     Gem.ruby = @orig_ruby if @orig_ruby
+
+    RbConfig::CONFIG['bindir'] = @orig_bindir
 
     if Gem.java_platform?
       RbConfig::CONFIG['default_gem_home'] = @orig_default_gem_home
@@ -741,7 +747,7 @@ class Gem::TestCase < Minitest::Test
 
   def install_specs(*specs)
     specs.each do |spec|
-      Gem::Installer.for_spec(spec).install
+      Gem::Installer.for_spec(spec, :force => true).install
     end
 
     Gem.searcher = nil

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -337,6 +337,7 @@ class Gem::TestCase < Minitest::Test
     @git = ENV['GIT'] || (win_platform? ? 'git.exe' : 'git')
 
     Gem.ensure_gem_subdirectories @gemhome
+    Gem.ensure_default_gem_subdirectories @gemhome
 
     @orig_LOAD_PATH = $LOAD_PATH.dup
     $LOAD_PATH.map! do |s|
@@ -373,7 +374,6 @@ class Gem::TestCase < Minitest::Test
     else
       Gem.instance_variable_set(:@default_dir, @gemhome)
     end
-    FileUtils.mkdir_p @default_spec_dir
 
     @orig_bindir = RbConfig::CONFIG["bindir"]
     RbConfig::CONFIG["bindir"] = File.join @gemhome, "bin"

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -362,7 +362,6 @@ class Gem::TestCase < Minitest::Test
     Gem.send :remove_instance_variable, :@ruby_version if
       Gem.instance_variables.include? :@ruby_version
 
-    FileUtils.mkdir_p @gemhome
     FileUtils.mkdir_p @userhome
 
     ENV['GEM_PRIVATE_KEY_PASSPHRASE'] = PRIVATE_KEY_PASSPHRASE

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -367,14 +367,12 @@ class Gem::TestCase < Minitest::Test
 
     ENV['GEM_PRIVATE_KEY_PASSPHRASE'] = PRIVATE_KEY_PASSPHRASE
 
-    @default_dir = @gemhome
-
-    @default_spec_dir = File.join @default_dir, "specifications", "default"
+    @default_spec_dir = File.join @gemhome, "specifications", "default"
     if Gem.java_platform?
       @orig_default_gem_home = RbConfig::CONFIG['default_gem_home']
-      RbConfig::CONFIG['default_gem_home'] = @default_dir
+      RbConfig::CONFIG['default_gem_home'] = @gemhome
     else
-      Gem.instance_variable_set(:@default_dir, @default_dir)
+      Gem.instance_variable_set(:@default_dir, @gemhome)
     end
     FileUtils.mkdir_p @default_spec_dir
 

--- a/test/rubygems/test_gem_commands_cleanup_command.rb
+++ b/test/rubygems/test_gem_commands_cleanup_command.rb
@@ -210,7 +210,7 @@ class TestGemCommandsCleanupCommand < Gem::TestCase
     @b_2 = util_spec 'b', 3
 
     install_gem @b_1
-    install_default_specs @b_default
+    install_default_gems @b_default
     install_gem @b_2
 
     @cmd.options[:args] = []

--- a/test/rubygems/test_gem_commands_contents_command.rb
+++ b/test/rubygems/test_gem_commands_contents_command.rb
@@ -227,7 +227,7 @@ lib/foo.rb
                                         nil, "default/gem.rb")
     default_gem_spec.executables = ["default_command"]
     default_gem_spec.files += ["default_gem.so"]
-    install_default_specs(default_gem_spec)
+    install_default_gems(default_gem_spec)
 
     @cmd.options[:args] = %w[default]
 

--- a/test/rubygems/test_gem_commands_pristine_command.rb
+++ b/test/rubygems/test_gem_commands_pristine_command.rb
@@ -577,7 +577,7 @@ class TestGemCommandsPristineCommand < Gem::TestCase
   def test_execute_default_gem
     default_gem_spec = new_default_spec("default", "2.0.0.0",
                                         nil, "default/gem.rb")
-    install_default_specs(default_gem_spec)
+    install_default_gems(default_gem_spec)
 
     @cmd.options[:args] = %w[default]
 

--- a/test/rubygems/test_gem_commands_query_command.rb
+++ b/test/rubygems/test_gem_commands_query_command.rb
@@ -644,7 +644,7 @@ a (2 universal-darwin, 1 ruby x86-linux)
     spec_fetcher {|fetcher| fetcher.spec 'a', 2 }
 
     a1 = new_default_spec 'a', 1
-    install_default_specs a1
+    install_default_gems a1
 
     use_ui @stub_ui do
       @cmd.execute
@@ -663,7 +663,7 @@ EOF
   def test_execute_show_default_gems_with_platform
     a1 = new_default_spec 'a', 1
     a1.platform = 'java'
-    install_default_specs a1
+    install_default_gems a1
 
     use_ui @stub_ui do
       @cmd.execute
@@ -685,7 +685,7 @@ EOF
     end
 
     a1 = new_default_spec 'a', 1
-    install_default_specs a1
+    install_default_gems a1
 
     @cmd.handle_options %w[-l -d]
 

--- a/test/rubygems/test_gem_dependency_installer.rb
+++ b/test/rubygems/test_gem_dependency_installer.rb
@@ -749,7 +749,7 @@ class TestGemDependencyInstaller < Gem::TestCase
     inst = nil
 
     Dir.chdir @tempdir do
-      inst = Gem::DependencyInstaller.new
+      inst = Gem::DependencyInstaller.new :force => true
       inst.install 'a'
     end
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -83,7 +83,7 @@ end
   end
 
   def test_check_executable_overwrite_default_bin_dir
-    installer = setup_base_installer
+    installer = setup_base_installer(false)
 
     bindir(Gem.bindir) do
       util_conflict_executable false
@@ -143,7 +143,7 @@ gem 'other', version
   end
 
   def test_check_executable_overwrite_other_gem
-    installer = setup_base_installer
+    installer = setup_base_installer(false)
 
     util_conflict_executable true
 
@@ -1134,7 +1134,7 @@ gem 'other', version
         Gem::Package.build @spec
       end
     end
-    installer = Gem::Installer.at @gem
+    installer = Gem::Installer.at @gem, :force => true
     build_rake_in do
       use_ui @ui do
         assert_equal @spec, installer.install
@@ -1337,7 +1337,7 @@ gem 'other', version
 
     # reinstall the gem, this is also the same as pristine
     use_ui @ui do
-      installer = Gem::Installer.at path
+      installer = Gem::Installer.at path, :force => true
       installer.install
     end
 
@@ -1537,6 +1537,7 @@ gem 'other', version
     installer = setup_base_installer
     @spec.add_dependency 'b', '> 5'
     installer = util_setup_gem
+    installer.force = false
 
     use_ui @ui do
       assert_raises Gem::InstallError do

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -2170,6 +2170,23 @@ gem 'other', version
     assert_equal ['exe/executable'], default_spec.files
   end
 
+  def test_default_gem_to_specific_install_dir
+    @gem = setup_base_gem
+    installer = util_installer @spec, "#{@gemhome}2"
+    installer.options[:install_as_default] = true
+
+    use_ui @ui do
+      installer.install
+    end
+
+    assert_directory_exists File.join("#{@gemhome}2", 'specifications')
+    assert_directory_exists File.join("#{@gemhome}2", 'specifications', 'default')
+
+    default_spec = eval File.read File.join("#{@gemhome}2", 'specifications', 'default', 'a-2.gemspec')
+    assert_equal Gem::Version.new("2"), default_spec.version
+    assert_equal ['bin/executable'], default_spec.files
+  end
+
   def test_package_attribute
     gem = quick_gem 'c' do |spec|
       util_make_exec spec, '#!/usr/bin/ruby', 'exe'

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3838,7 +3838,7 @@ end
 
     default_gem_spec = new_default_spec("default", "2.0.0.0",
                                         nil, "default/gem.rb")
-    spec_path = File.join(@default_spec_dir, default_gem_spec.spec_name)
+    spec_path = File.join(@gemhome, "specifications", "default", default_gem_spec.spec_name)
     write_file(spec_path) do |file|
       file.print(default_gem_spec.to_ruby)
     end

--- a/test/rubygems/test_gem_uninstaller.rb
+++ b/test/rubygems/test_gem_uninstaller.rb
@@ -177,7 +177,7 @@ class TestGemUninstaller < Gem::InstallerTestCase
 
     @spec.files += %w[lib/rubygems_plugin.rb]
 
-    Gem::Installer.at(Gem::Package.build(@spec)).install
+    Gem::Installer.at(Gem::Package.build(@spec), :force => true).install
 
     plugin_path = File.join Gem.plugindir, 'a_plugin.rb'
     assert File.exist?(plugin_path), 'plugin not written'
@@ -194,7 +194,7 @@ class TestGemUninstaller < Gem::InstallerTestCase
 
     @spec.files += %w[lib/rubygems_plugin.rb]
 
-    Gem::Installer.at(Gem::Package.build(@spec)).install
+    Gem::Installer.at(Gem::Package.build(@spec), :force => true).install
 
     plugin_path = File.join Gem.plugindir, 'a_plugin.rb'
     assert File.exist?(plugin_path), 'plugin not written'
@@ -212,7 +212,7 @@ class TestGemUninstaller < Gem::InstallerTestCase
 
     @spec.files += %w[lib/rubygems_plugin.rb]
 
-    Gem::Installer.at(Gem::Package.build(@spec)).install
+    Gem::Installer.at(Gem::Package.build(@spec), :force => true).install
 
     plugin_path = File.join Gem.plugindir, 'a_plugin.rb'
     assert File.exist?(plugin_path), 'plugin not written'
@@ -314,7 +314,7 @@ create_makefile '#{@spec.name}'
     use_ui @ui do
       path = Gem::Package.build @spec
 
-      installer = Gem::Installer.at path
+      installer = Gem::Installer.at path, :force => true
       installer.install
     end
 
@@ -633,19 +633,19 @@ create_makefile '#{@spec.name}'
     plugin_path = File.join Gem.plugindir, 'a_plugin.rb'
 
     @spec.version = '1'
-    Gem::Installer.at(Gem::Package.build(@spec)).install
+    Gem::Installer.at(Gem::Package.build(@spec), :force => true).install
 
     refute File.exist?(plugin_path), 'version without plugin installed, but plugin written'
 
     @spec.files += %w[lib/rubygems_plugin.rb]
     @spec.version = '2'
-    Gem::Installer.at(Gem::Package.build(@spec)).install
+    Gem::Installer.at(Gem::Package.build(@spec), :force => true).install
 
     assert File.exist?(plugin_path), 'version with plugin installed, but plugin not written'
     assert_match %r{\Arequire.*a-2/lib/rubygems_plugin\.rb}, File.read(plugin_path), 'written plugin has incorrect content'
 
     @spec.version = '3'
-    Gem::Installer.at(Gem::Package.build(@spec)).install
+    Gem::Installer.at(Gem::Package.build(@spec), :force => true).install
 
     assert File.exist?(plugin_path), 'version with plugin installed, but plugin removed'
     assert_match %r{\Arequire.*a-3/lib/rubygems_plugin\.rb}, File.read(plugin_path), 'old version installed, but plugin updated'

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -406,7 +406,7 @@ class TestGemRequire < Gem::TestCase
     # Remove an old default gem version directly from disk as if someone ran
     # gem cleanup.
     FileUtils.rm_rf(File.join @gemhome, "#{b1.full_name}")
-    FileUtils.rm_rf(File.join @default_spec_dir, "#{b1.full_name}.gemspec")
+    FileUtils.rm_rf(File.join @gemhome, "specifications", "default", "#{b1.full_name}.gemspec")
 
     # Require gems that have not been removed.
     assert_require 'a/b'

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -405,7 +405,7 @@ class TestGemRequire < Gem::TestCase
 
     # Remove an old default gem version directly from disk as if someone ran
     # gem cleanup.
-    FileUtils.rm_rf(File.join @default_dir, "#{b1.full_name}")
+    FileUtils.rm_rf(File.join @gemhome, "#{b1.full_name}")
     FileUtils.rm_rf(File.join @default_spec_dir, "#{b1.full_name}.gemspec")
 
     # Require gems that have not been removed.

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -120,7 +120,7 @@ class TestGemRequire < Gem::TestCase
     c1 = new_default_spec "c", "1", nil, "c/c.rb"
     c2 = new_default_spec "c", "2", nil, "c/c.rb"
 
-    install_default_specs c1, c2, b1, a1
+    install_default_gems c1, c2, b1, a1
 
     dir = Dir.mktmpdir("test_require", @tempdir)
     dash_i_arg = File.join dir, 'lib'
@@ -433,7 +433,7 @@ class TestGemRequire < Gem::TestCase
   def test_default_gem_only
     default_gem_spec = new_default_spec("default", "2.0.0.0",
                                         nil, "default/gem.rb")
-    install_default_specs(default_gem_spec)
+    install_default_gems(default_gem_spec)
     assert_require "default/gem"
     assert_equal %w[default-2.0.0.0], loaded_spec_names
   end
@@ -441,7 +441,7 @@ class TestGemRequire < Gem::TestCase
   def test_default_gem_require_activates_just_once
     default_gem_spec = new_default_spec("default", "2.0.0.0",
                                         nil, "default/gem.rb")
-    install_default_specs(default_gem_spec)
+    install_default_gems(default_gem_spec)
 
     assert_require "default/gem"
 
@@ -506,7 +506,7 @@ class TestGemRequire < Gem::TestCase
   def test_default_gem_and_normal_gem
     default_gem_spec = new_default_spec("default", "2.0.0.0",
                                         nil, "default/gem.rb")
-    install_default_specs(default_gem_spec)
+    install_default_gems(default_gem_spec)
     normal_gem_spec = util_spec("default", "3.0", nil,
                                "lib/default/gem.rb")
     install_specs(normal_gem_spec)
@@ -544,11 +544,11 @@ class TestGemRequire < Gem::TestCase
   def test_default_gem_prerelease
     default_gem_spec = new_default_spec("default", "2.0.0",
                                         nil, "default/gem.rb")
-    install_default_specs(default_gem_spec)
+    install_default_gems(default_gem_spec)
 
     normal_gem_higher_prerelease_spec = util_spec("default", "3.0.0.rc2", nil,
                                                   "lib/default/gem.rb")
-    install_default_specs(normal_gem_higher_prerelease_spec)
+    install_default_gems(normal_gem_higher_prerelease_spec)
 
     assert_require "default/gem"
     assert_equal %w[default-3.0.0.rc2], loaded_spec_names
@@ -586,7 +586,7 @@ class TestGemRequire < Gem::TestCase
   def test_require_when_gem_defined
     default_gem_spec = new_default_spec("default", "2.0.0.0",
                                         nil, "default/gem.rb")
-    install_default_specs(default_gem_spec)
+    install_default_gems(default_gem_spec)
     c = Class.new do
       def self.gem(*args)
         raise "received #gem with #{args.inspect}"


### PR DESCRIPTION
# Description:

These options are probably not really used in real life together, but I happened to need them while writing a spec for a bundler issue fix. In particular, for https://github.com/rubygems/rubygems/issues/3757.

## What was the end-user or developer problem that led to this PR?d

The problem is that when `--default` and `--install-dir` options are given to `gem install`, the default specification file should be installed to the `specifications/default` folder in `install-dir`, not to the one in the default gem directory.

## What is your fix for the problem, implemented in this PR?

The fix seemed really simple, but due to the cumbersome setup of rubygems tests, it broke a lot of tests, so I had to refactor rubygems test setup to play nice with the change. More information is given in the individual commits.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).