### PR TITLE
Make `bundle clean --force` leave default gem executables untouched

### DIFF
--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -411,6 +411,17 @@ module Bundler
     # Replace or hook into RubyGems to provide a bundlerized view
     # of the world.
     def replace_entrypoints(specs)
+      specs_by_name = add_default_gems_to(specs)
+
+      replace_gem(specs, specs_by_name)
+      stub_rubygems(specs)
+      replace_bin_path(specs_by_name)
+
+      Gem.clear_paths
+    end
+
+    # Add default gems not already present in specs, and return them as a hash.
+    def add_default_gems_to(specs)
       specs_by_name = specs.reduce({}) do |h, s|
         h[s.name] = s
         h
@@ -425,11 +436,7 @@ module Bundler
         specs_by_name[default_spec_name] = default_spec
       end
 
-      replace_gem(specs, specs_by_name)
-      stub_rubygems(specs)
-      replace_bin_path(specs_by_name)
-
-      Gem.clear_paths
+      specs_by_name
     end
 
     def undo_replacements

--- a/bundler/lib/bundler/runtime.rb
+++ b/bundler/lib/bundler/runtime.rb
@@ -155,7 +155,7 @@ module Bundler
       spec_cache_paths     = []
       spec_gemspec_paths   = []
       spec_extension_paths = []
-      specs.each do |spec|
+      Bundler.rubygems.add_default_gems_to(specs).values.each do |spec|
         spec_gem_paths << spec.full_gem_path
         # need to check here in case gems are nested like for the rails git repo
         md = %r{(.+bundler/gems/.+-[a-f0-9]{7,12})}.match(spec.full_gem_path)

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -758,7 +758,7 @@ module Spec
 
         gem_path = File.expand_path("#{@spec.full_name}.gem", lib_path)
         if opts[:to_system]
-          @context.system_gems gem_path
+          @context.system_gems gem_path, :default => opts[:default]
         elsif opts[:to_bundle]
           @context.system_gems gem_path, :path => @context.default_bundle_path
         else

--- a/bundler/spec/support/hax.rb
+++ b/bundler/spec/support/hax.rb
@@ -9,6 +9,8 @@ module Gem
     Gem.ruby = ENV["RUBY"]
   end
 
+  @default_dir = ENV["BUNDLER_GEM_DEFAULT_DIR"] if ENV["BUNDLER_GEM_DEFAULT_DIR"]
+
   if ENV["BUNDLER_SPEC_PLATFORM"]
     class Platform
       @local = new(ENV["BUNDLER_SPEC_PLATFORM"])

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -290,26 +290,30 @@ module Spec
       gems = gems.flatten
       options = gems.last.is_a?(Hash) ? gems.pop : {}
       path = options.fetch(:path, system_gem_path)
+      default = options.fetch(:default, false)
       with_gem_path_as(path) do
         gem_repo = options.fetch(:gem_repo, gem_repo1)
         gems.each do |g|
           gem_name = g.to_s
           if gem_name.start_with?("bundler")
             version = gem_name.match(/\Abundler-(?<version>.*)\z/)[:version] if gem_name != "bundler"
-            with_built_bundler(version) {|gem_path| install_gem(gem_path) }
+            with_built_bundler(version) {|gem_path| install_gem(gem_path, default) }
           elsif gem_name =~ %r{\A(?:[a-zA-Z]:)?/.*\.gem\z}
-            install_gem(gem_name)
+            install_gem(gem_name, default)
           else
-            install_gem("#{gem_repo}/gems/#{gem_name}.gem")
+            install_gem("#{gem_repo}/gems/#{gem_name}.gem", default)
           end
         end
       end
     end
 
-    def install_gem(path)
+    def install_gem(path, default = false)
       raise "OMG `#{path}` does not exist!" unless File.exist?(path)
 
-      gem_command "install --no-document --ignore-dependencies '#{path}'"
+      args = "--no-document --ignore-dependencies"
+      args += " --default --install-dir #{system_gem_path}" if default
+
+      gem_command "install #{args} '#{path}'"
     end
 
     def with_built_bundler(version = nil)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The problem is that running `bundle clean --force` on any application will remove any executables from default gems, leaving those default gems unusable.

## What is your fix for the problem, implemented in this PR?

My fix is to avoid touching default gems at all when running `bundle clean --force`.

Writing a spec for this fix requires a bug fix in rubygems, so this PR is built on top of #3906.

Fixes #3757.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).