### PR TITLE
Add CHANGELOG.md to newgem generator

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -135,6 +135,7 @@ bundler/lib/bundler/templates/Executable.bundler
 bundler/lib/bundler/templates/Executable.standalone
 bundler/lib/bundler/templates/Gemfile
 bundler/lib/bundler/templates/gems.rb
+bundler/lib/bundler/templates/newgem/CHANGELOG.md.tt
 bundler/lib/bundler/templates/newgem/CODE_OF_CONDUCT.md.tt
 bundler/lib/bundler/templates/newgem/Gemfile.tt
 bundler/lib/bundler/templates/newgem/LICENSE.txt.tt

--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -69,6 +69,7 @@ module Bundler
         "newgem.gemspec.tt" => "#{name}.gemspec",
         "Rakefile.tt" => "Rakefile",
         "README.md.tt" => "README.md",
+        "CHANGELOG.md.tt" => "CHANGELOG.md",
         "bin/console.tt" => "bin/console",
         "bin/setup.tt" => "bin/setup",
       }

--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -146,8 +146,8 @@ module Bundler
         "changes for each version of a project. To make it easier for users and contributors to" \
         " see precisely what notable changes have been made between each release (or version) of" \
         " the project. Whether consumers or developers, the end users of software are" \
-        " human beings who care about what's in the software. When the software changes, people" \
-        " want to know why and how. see https://keepachangelog.com")
+        " human beings who care about what's in the software. When the software changes, people " \
+        "want to know why and how. see https://keepachangelog.com")
         config[:changelog] = true
         Bundler.ui.info "Changelog enabled in config"
         templates.merge!("CHANGELOG.md.tt" => "CHANGELOG.md")

--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -69,7 +69,6 @@ module Bundler
         "newgem.gemspec.tt" => "#{name}.gemspec",
         "Rakefile.tt" => "Rakefile",
         "README.md.tt" => "README.md",
-        "CHANGELOG.md.tt" => "CHANGELOG.md",
         "bin/console.tt" => "bin/console",
         "bin/setup.tt" => "bin/setup",
       }
@@ -140,6 +139,18 @@ module Bundler
         config[:coc] = true
         Bundler.ui.info "Code of conduct enabled in config"
         templates.merge!("CODE_OF_CONDUCT.md.tt" => "CODE_OF_CONDUCT.md")
+      end
+
+      if ask_and_set(:changelog, "Do you want to include a changelog?",
+        "A changelog is a file which contains a curated, chronologically ordered list of notable " \
+        "changes for each version of a project. To make it easier for users and contributors to" \
+        " see precisely what notable changes have been made between each release (or version) of" \
+        " the project. Whether consumers or developers, the end users of software are" \
+        " human beings who care about what's in the software. When the software changes, people" \
+        " want to know why and how. see https://keepachangelog.com")
+        config[:changelog] = true
+        Bundler.ui.info "Changelog enabled in config"
+        templates.merge!("CHANGELOG.md.tt" => "CHANGELOG.md")
       end
 
       if ask_and_set(:rubocop, "Do you want to add rubocop as a dependency for gems you generate?",

--- a/bundler/lib/bundler/templates/newgem/CHANGELOG.md.tt
+++ b/bundler/lib/bundler/templates/newgem/CHANGELOG.md.tt
@@ -1,0 +1,5 @@
+## [Unreleased]
+
+## [0.1.0] - <%= Time.now.strftime('%F') %>
+
+- Initial release

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe "bundle gem" do
   def gem_skeleton_assertions
     expect(bundled_app("#{gem_name}/#{gem_name}.gemspec")).to exist
     expect(bundled_app("#{gem_name}/README.md")).to exist
+    expect(bundled_app("#{gem_name}/CHANGELOG.md")).to exist
     expect(bundled_app("#{gem_name}/Gemfile")).to exist
     expect(bundled_app("#{gem_name}/Rakefile")).to exist
     expect(bundled_app("#{gem_name}/lib/#{require_path}.rb")).to exist

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe "bundle gem" do
   def gem_skeleton_assertions
     expect(bundled_app("#{gem_name}/#{gem_name}.gemspec")).to exist
     expect(bundled_app("#{gem_name}/README.md")).to exist
-    expect(bundled_app("#{gem_name}/CHANGELOG.md")).to exist
     expect(bundled_app("#{gem_name}/Gemfile")).to exist
     expect(bundled_app("#{gem_name}/Rakefile")).to exist
     expect(bundled_app("#{gem_name}/lib/#{require_path}.rb")).to exist
@@ -154,6 +153,26 @@ RSpec.describe "bundle gem" do
         expect(bundled_app("#{gem_name}/README.md").read).not_to include("## Code of Conduct")
         expect(bundled_app("#{gem_name}/README.md").read).not_to include("https://github.com/bundleuser/#{gem_name}/blob/master/CODE_OF_CONDUCT.md")
       end
+    end
+  end
+
+  shared_examples_for "--changelog flag" do
+    before do
+      bundle! "gem #{gem_name} --changelog"
+    end
+    it "generates a gem skeleton with CHANGELOG license" do
+      gem_skeleton_assertions
+      expect(bundled_app("#{gem_name}/CHANGELOG.md")).to exist
+    end
+  end
+
+  shared_examples_for "--no-changelog flag" do
+    before do
+      bundle! "gem #{gem_name} --no-changelog"
+    end
+    it "generates a gem skeleton without CHANGELOG license" do
+      gem_skeleton_assertions
+      expect(bundled_app("#{gem_name}/CHANGELOG.md")).to_not exist
     end
   end
 

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe "bundle gem" do
     before do
       bundle! "gem #{gem_name} --changelog"
     end
-    it "generates a gem skeleton with CHANGELOG license" do
+    it "generates a gem skeleton with a CHANGELOG" do
       gem_skeleton_assertions
       expect(bundled_app("#{gem_name}/CHANGELOG.md")).to exist
     end


### PR DESCRIPTION
This feature adds a `CHANGELOG.md` file when running `bundle gem mygem` in addition to all other gem skeleton files.

I keep adding it myself and it is best practice to keep a changelog. Let me know if there is any reason this was not there yet or if there is anything I can improve. Thanks!