### PR TITLE
Fix platform issues when running under a frozen bundle

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -204,10 +204,6 @@ module Bundler
       @locked_specs - specs
     end
 
-    def new_platform?
-      @new_platform
-    end
-
     def missing_specs
       missing = []
       resolve.materialize(requested_dependencies, missing)

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -553,10 +553,9 @@ module Bundler
     end
 
     def current_platforms
-      current_platform = Bundler.local_platform
       [].tap do |platforms|
-        platforms << current_platform if Bundler.feature_flag.specific_platform?
-        platforms << generic(current_platform)
+        platforms << local_platform if Bundler.feature_flag.specific_platform?
+        platforms << generic_local_platform
       end
     end
 

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -890,11 +890,17 @@ module Bundler
       dependencies.each do |dep|
         dep = Dependency.new(dep, ">= 0") unless dep.respond_to?(:name)
         next unless remote || dep.current_platform?
-        dep.gem_platforms(Resolver.sort_platforms(@platforms)).each do |p|
-          deps << DepProxy.new(dep, p) if remote || p == generic_local_platform
-        end
+        target_platforms = dep.gem_platforms(Resolver.sort_platforms(@platforms))
+        target_platforms &= [generic_local_platform] unless remote
+        deps += expand_dependency_with_platforms(dep, target_platforms)
       end
       deps
+    end
+
+    def expand_dependency_with_platforms(dep, platforms)
+      platforms.map do |p|
+        DepProxy.new(dep, p)
+      end
     end
 
     def dependencies_for(groups)

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -891,7 +891,7 @@ module Bundler
       deps = []
       dependencies.each do |dep|
         dep = Dependency.new(dep, ">= 0") unless dep.respond_to?(:name)
-        next if !remote && !dep.current_platform?
+        next unless remote || dep.current_platform?
         dep.gem_platforms(sorted_platforms).each do |p|
           deps << DepProxy.new(dep, p) if remote || p == generic_local_platform
         end

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -887,12 +887,11 @@ module Bundler
     end
 
     def expand_dependencies(dependencies, remote = false)
-      sorted_platforms = Resolver.sort_platforms(@platforms)
       deps = []
       dependencies.each do |dep|
         dep = Dependency.new(dep, ">= 0") unless dep.respond_to?(:name)
         next unless remote || dep.current_platform?
-        dep.gem_platforms(sorted_platforms).each do |p|
+        dep.gem_platforms(Resolver.sort_platforms(@platforms)).each do |p|
           deps << DepProxy.new(dep, p) if remote || p == generic_local_platform
         end
       end

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -890,8 +890,7 @@ module Bundler
       dependencies.each do |dep|
         dep = Dependency.new(dep, ">= 0") unless dep.respond_to?(:name)
         next unless remote || dep.current_platform?
-        target_platforms = dep.gem_platforms(Resolver.sort_platforms(@platforms))
-        target_platforms &= [generic_local_platform] unless remote
+        target_platforms = dep.gem_platforms(remote ? Resolver.sort_platforms(@platforms) : [generic_local_platform])
         deps += expand_dependency_with_platforms(dep, target_platforms)
       end
       deps

--- a/bundler/lib/bundler/gem_helpers.rb
+++ b/bundler/lib/bundler/gem_helpers.rb
@@ -24,9 +24,14 @@ module Bundler
     module_function :generic
 
     def generic_local_platform
-      generic(Bundler.local_platform)
+      generic(local_platform)
     end
     module_function :generic_local_platform
+
+    def local_platform
+      Bundler.local_platform
+    end
+    module_function :local_platform
 
     def platform_specificity_match(spec_platform, user_platform)
       spec_platform = Gem::Platform.new(spec_platform)

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -50,6 +50,31 @@ RSpec.describe "bundle install across platforms" do
     expect(the_bundle).to include_gems "platform_specific 1.0 JAVA"
   end
 
+  it "pulls the pure ruby version on jruby if the java platform is not present in the lockfile and bundler is run in frozen mode", :jruby do
+    lockfile <<-G
+      GEM
+        remote: #{file_uri_for(gem_repo1)}
+        specs:
+          platform_specific (1.0)
+
+      PLATFORMS
+        ruby
+
+      DEPENDENCIES
+        platform_specific
+    G
+
+    bundle "config set --local frozen true"
+
+    install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
+
+      gem "platform_specific"
+    G
+
+    expect(the_bundle).to include_gems "platform_specific 1.0 RUBY"
+  end
+
   it "works with gems that have different dependencies" do
     simulate_platform "java"
     install_gemfile <<-G


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In the case of running under jruby, on a frozen bundle, and against a lockfile only including the ruby platform, `expand_dependencies` would end up filtering out all dependencies, causing errors.

The reason is that on a frozen bundle, the local platform is not added to the array of definition platforms, since only platform information from the lockfile should be used. That means that under the previous logic, `expand_dependencies` would filter out everything.

## What is your fix for the problem, implemented in this PR?

The solution is to make sure to always _at least_ expand all dependencies with the local platform.

Note that it should still be preferred to "unfreeze" the application, and rebundle using jruby, so that platform specific dependencies are picked up. But if the desired to use only pure ruby versions of dependencies, this changes gets that case working too without weird errors.

Fixes #3874.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).