### PR TITLE
Add missing fileutils require

### DIFF
--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -32,8 +32,11 @@ jobs:
       - name: Simulate no openssl
         run: ruby util/remove_openssl.rb
         if: matrix.openssl == false
-      - name: Run installed rubygems
+      - name: Run a local rubygems command
         run: gem list bundler
+      - name: Run a remote rubygems command
+        run: gem outdated
+        if: matrix.openssl == true
       - name: Run bundler installed as a default gem
         run: bundle --version
       - name: Check bundler man pages were installed and are properly picked up

--- a/lib/rubygems/source.rb
+++ b/lib/rubygems/source.rb
@@ -179,7 +179,10 @@ class Gem::Source
     local_file = File.join(cache_dir, file_name)
     retried    = false
 
-    FileUtils.mkdir_p cache_dir if update_cache?
+    if update_cache?
+      require "fileutils"
+      FileUtils.mkdir_p cache_dir
+    end
 
     spec_dump = fetcher.cache_update_path spec_path, local_file, update_cache?
 


### PR DESCRIPTION
# Description:

On my system, the error was being hidden by the presence of a YARD rubygems plugin that was providing the require and making things work.

However, on a pristine system, `gem outdated` would fail with

```
 ERROR:  While executing gem ... (NameError)
    uninitialized constant Gem::Source::FileUtils
Did you mean?  FileTest
```

Fixes #3894.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).