### PR TITLE
Add `set` as a non supported default gem

### DIFF
--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -1231,6 +1231,7 @@ end
         end << "bundler"
         exempts << "fiddle" if Gem.win_platform? && Gem::Version.new(Gem::VERSION) >= Gem::Version.new("2.7")
         exempts << "uri" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7")
+        exempts << "set" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.8")
         exempts
       end
 


### PR DESCRIPTION
# Description:

As per #3912, I'm adding `set` as an exemption to the specs as a non supported default gem, until we can handle its promotion.

This is to get the daily bundler workflow against ruby-head back to green.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
