### PR TITLE
Restore `bundle cache --all` in all cases

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -440,10 +440,9 @@ module Bundler
     end
 
     desc "cache [OPTIONS]", "Locks and then caches all of the gems into vendor/cache"
-    unless Bundler.feature_flag.cache_all?
-      method_option "all",  :type => :boolean,
-                            :banner => "Include all sources (including path and git)."
-    end
+    method_option "all",  :type => :boolean,
+                          :default => Bundler.feature_flag.cache_all?,
+                          :banner => "Include all sources (including path and git)."
     method_option "all-platforms", :type => :boolean, :banner => "Include gems for all platforms present in the lockfile, not only the current one"
     method_option "cache-path", :type => :string, :banner =>
       "Specify a different cache path than the default (vendor/cache)."

--- a/bundler/man/bundle-config.1
+++ b/bundler/man/bundle-config.1
@@ -154,7 +154,7 @@ The following is a list of all configuration keys and their purpose\. You can le
 \fBbin\fR (\fBBUNDLE_BIN\fR): Install executables from gems in the bundle to the specified directory\. Defaults to \fBfalse\fR\.
 .
 .IP "\(bu" 4
-\fBcache_all\fR (\fBBUNDLE_CACHE_ALL\fR): Cache all gems, including path and git gems\.
+\fBcache_all\fR (\fBBUNDLE_CACHE_ALL\fR): Cache all gems, including path and git gems\. This needs to be explicitly configured on bundler 1 and bundler 2, but will be the default on bundler 3\.
 .
 .IP "\(bu" 4
 \fBcache_all_platforms\fR (\fBBUNDLE_CACHE_ALL_PLATFORMS\fR): Cache gems for all platforms\.

--- a/bundler/man/bundle-config.1.ronn
+++ b/bundler/man/bundle-config.1.ronn
@@ -150,7 +150,8 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    Install executables from gems in the bundle to the specified directory.
    Defaults to `false`.
 * `cache_all` (`BUNDLE_CACHE_ALL`):
-   Cache all gems, including path and git gems.
+   Cache all gems, including path and git gems. This needs to be explicitly
+   configured on bundler 1 and bundler 2, but will be the default on bundler 3.
 * `cache_all_platforms` (`BUNDLE_CACHE_ALL_PLATFORMS`):
    Cache gems for all platforms.
 * `cache_path` (`BUNDLE_CACHE_PATH`):


### PR DESCRIPTION
# Description:

The `bundle cache --all` flag has been going back and forth recently, since I'm not too clear what our plan on it is.

The current situation, where `bundle cache --all` only works the first time it's run is definitely not what we want.

My proposal is to restore the flag, but deprecate it. The rationale is the same for all the other flags that are silently rememebered. Instead, recommend users to use configuration, and set `bundle config cache_all true` if they want git and path gems to also be cached.

The change in the default value of `cache_all` set for bundler 3 (where path and git gems will be cached by default) is kept.

Fixes https://github.com/rubygems/rubygems/issues/3598.
______________

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).