### PR TITLE
Fix deprecation messages for `bundle install` flags, the config should be --local as before

### DIFF
--- a/bundler/UPGRADING.md
+++ b/bundler/UPGRADING.md
@@ -9,7 +9,7 @@ look like. All these deprecations are printed by default in the Bundler 2.1 rele
 If you don't want to deal with deprecations right now and want to toggle them
 off, you can do it through configuration. Set the `BUNDLE_SILENCE_DEPRECATIONS`
 environment variable to "true", or configure it through `bundle config` either
-globally through `bundle config set silence_deprecations true` command, or
+globally through `bundle config set --global silence_deprecations true` command, or
 locally through `bundle config set --local silence_deprecations true`. From now
 on in this document we will assume that all three of these configuration options
 are available, but will only mention `bundle config set <option> <value>`.
@@ -51,7 +51,7 @@ in the upcoming 3 version.
   development and test gems.  This magic will disappear from bundler 3, and
   you will explicitly need to configure it, either through environment
   variables, application configuration, or machine configuration. For example,
-  with `bundle config set without development test`.
+  with `bundle config set --local without development test`.
 
   The removal of this kind of flag also applies to analogous commands, for
   example, to `bundle check --path`.

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -453,7 +453,7 @@ EOF
       # system binaries. If you put '-n foo' in your .gemrc, RubyGems will
       # install binstubs there instead. Unfortunately, RubyGems doesn't expose
       # that directory at all, so rather than parse .gemrc ourselves, we allow
-      # the directory to be set as well, via `bundle config set bindir foo`.
+      # the directory to be set as well, via `bundle config set --local bindir foo`.
       Bundler.settings[:system_bindir] || Bundler.rubygems.gem_bindir
     end
 

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -565,18 +565,18 @@ module Bundler
 
     desc "gem NAME [OPTIONS]", "Creates a skeleton for creating a rubygem"
     method_option :exe, :type => :boolean, :default => false, :aliases => ["--bin", "-b"], :desc => "Generate a binary executable for your library."
-    method_option :coc, :type => :boolean, :desc => "Generate a code of conduct file. Set a default with `bundle config set gem.coc true`."
+    method_option :coc, :type => :boolean, :desc => "Generate a code of conduct file. Set a default with `bundle config set --global gem.coc true`."
     method_option :edit, :type => :string, :aliases => "-e", :required => false, :banner => "EDITOR",
                          :lazy_default => [ENV["BUNDLER_EDITOR"], ENV["VISUAL"], ENV["EDITOR"]].find {|e| !e.nil? && !e.empty? },
                          :desc => "Open generated gemspec in the specified editor (defaults to $EDITOR or $BUNDLER_EDITOR)"
     method_option :ext, :type => :boolean, :default => false, :desc => "Generate the boilerplate for C extension code"
     method_option :git, :type => :boolean, :default => true, :desc => "Initialize a git repo inside your library."
-    method_option :mit, :type => :boolean, :desc => "Generate an MIT license file. Set a default with `bundle config set gem.mit true`."
-    method_option :rubocop, :type => :boolean, :desc => "Add rubocop to the generated Rakefile and gemspec. Set a default with `bundle config set gem.rubocop true`."
+    method_option :mit, :type => :boolean, :desc => "Generate an MIT license file. Set a default with `bundle config set --global gem.mit true`."
+    method_option :rubocop, :type => :boolean, :desc => "Add rubocop to the generated Rakefile and gemspec. Set a default with `bundle config set --global gem.rubocop true`."
     method_option :test, :type => :string, :lazy_default => Bundler.settings["gem.test"] || "", :aliases => "-t", :banner => "Use the specified test framework for your library",
-                         :desc => "Generate a test directory for your library, either rspec, minitest or test-unit. Set a default with `bundle config set gem.test (rspec|minitest|test-unit)`."
+                         :desc => "Generate a test directory for your library, either rspec, minitest or test-unit. Set a default with `bundle config set --global gem.test (rspec|minitest|test-unit)`."
     method_option :ci, :type => :string, :lazy_default => Bundler.settings["gem.ci"] || "",
-                       :desc => "Generate CI configuration, either GitHub Actions, Travis CI, GitLab CI or CircleCI. Set a default with `bundle config set gem.ci (github|travis|gitlab|circle)`"
+                       :desc => "Generate CI configuration, either GitHub Actions, Travis CI, GitLab CI or CircleCI. Set a default with `bundle config set --global gem.ci (github|travis|gitlab|circle)`"
 
     def gem(name)
     end
@@ -744,7 +744,7 @@ module Bundler
 
     # Automatically invoke `bundle install` and resume if
     # Bundler.settings[:auto_install] exists. This is set through config cmd
-    # `bundle config set auto_install 1`.
+    # `bundle config set --global auto_install 1`.
     #
     # Note that this method `nil`s out the global Definition object, so it
     # should be called first, before you instantiate anything like an
@@ -842,7 +842,7 @@ module Bundler
       Bundler::SharedHelpers.major_deprecation 2,\
         "The `#{flag_name}` flag is deprecated because it relies on being " \
         "remembered across bundler invocations, which bundler will no longer " \
-        "do in future versions. Instead please use `bundle config set #{name.tr("-", "_")} " \
+        "do in future versions. Instead please use `bundle config set --local #{name.tr("-", "_")} " \
         "'#{value}'`, and stop using this flag"
     end
   end

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -457,7 +457,7 @@ repo_name ||= user_name
           "Using `source` more than once without a block is a security risk, and " \
           "may result in installing unexpected gems. To resolve this warning, use " \
           "a block to indicate which gems should come from the secondary source. " \
-          "To upgrade this warning to an error, run `bundle config set " \
+          "To upgrade this warning to an error, run `bundle config set --local " \
           "disable_multisource true`."
       end
     end

--- a/bundler/lib/bundler/fetcher.rb
+++ b/bundler/lib/bundler/fetcher.rb
@@ -47,7 +47,7 @@ module Bundler
         remote_uri = filter_uri(remote_uri)
         super "Authentication is required for #{remote_uri}.\n" \
           "Please supply credentials for this source. You can do this by running:\n" \
-          " bundle config set #{remote_uri} username:password"
+          " bundle config set --global #{remote_uri} username:password"
       end
     end
     # This error is raised if HTTP authentication is provided, but incorrect.

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -89,7 +89,7 @@ module Bundler
         if search && Gem::Platform.new(search.platform) != platform_object && !search.runtime_dependencies.-(dependencies.reject {|d| d.type == :development }).empty?
           Bundler.ui.warn "Unable to use the platform-specific (#{search.platform}) version of #{name} (#{version}) " \
             "because it has different dependencies from the #{platform} version. " \
-            "To use the platform-specific version of the gem, run `bundle config set specific_platform true` and install again."
+            "To use the platform-specific version of the gem, run `bundle config set --local specific_platform true` and install again."
           search = source.specs.search(self).last
         end
         search.dependencies = dependencies if search && (search.is_a?(RemoteSpecification) || search.is_a?(EndpointSpecification))

--- a/bundler/lib/bundler/rubygems_gem_installer.rb
+++ b/bundler/lib/bundler/rubygems_gem_installer.rb
@@ -60,7 +60,7 @@ module Bundler
 
           If you wish to continue installing the downloaded gem, and are certain it does not pose a \
           security issue despite the mismatching checksum, do the following:
-          1. run `bundle config set disable_checksum_validation true` to turn off checksum verification
+          1. run `bundle config set --local disable_checksum_validation true` to turn off checksum verification
           2. run `bundle install`
 
           (More info: The expected SHA256 checksum was #{checksum.inspect}, but the \

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -147,7 +147,7 @@ module Bundler
       if source.uri =~ /^git\:/
         Bundler.ui.warn "The git source `#{source.uri}` uses the `git` protocol, " \
           "which transmits data without encryption. Disable this warning with " \
-          "`bundle config set git.allow_insecure true`, or switch to the `https` " \
+          "`bundle config set --local git.allow_insecure true`, or switch to the `https` " \
           "protocol to keep your data secure."
       end
     end

--- a/bundler/man/bundle-config.1
+++ b/bundler/man/bundle-config.1
@@ -57,13 +57,13 @@ Executing \fBbundle config unset \-\-local <name> <value>\fR will delete the con
 Executing bundle with the \fBBUNDLE_IGNORE_CONFIG\fR environment variable set will cause it to ignore all configuration\.
 .
 .P
-Executing \fBbundle config set disable_multisource true\fR upgrades the warning about the Gemfile containing multiple primary sources to an error\. Executing \fBbundle config unset disable_multisource\fR downgrades this error to a warning\.
+Executing \fBbundle config set \-\-local disable_multisource true\fR upgrades the warning about the Gemfile containing multiple primary sources to an error\. Executing \fBbundle config unset disable_multisource\fR downgrades this error to a warning\.
 .
 .SH "REMEMBERING OPTIONS"
 Flags passed to \fBbundle install\fR or the Bundler runtime, such as \fB\-\-path foo\fR or \fB\-\-without production\fR, are remembered between commands and saved to your local application\'s configuration (normally, \fB\./\.bundle/config\fR)\.
 .
 .P
-However, this will be changed in bundler 3, so it\'s better not to rely on this behavior\. If these options must be remembered, it\'s better to set them using \fBbundle config\fR (e\.g\., \fBbundle config set path foo\fR)\.
+However, this will be changed in bundler 3, so it\'s better not to rely on this behavior\. If these options must be remembered, it\'s better to set them using \fBbundle config\fR (e\.g\., \fBbundle config set \-\-local path foo\fR)\.
 .
 .P
 The options that can be configured are:
@@ -111,7 +111,7 @@ Since the specific location of that executable can change from machine to machin
 .
 .nf
 
-bundle config set build\.mysql \-\-with\-mysql\-config=/usr/local/mysql/bin/mysql_config
+bundle config set \-\-global build\.mysql \-\-with\-mysql\-config=/usr/local/mysql/bin/mysql_config
 .
 .fi
 .
@@ -312,7 +312,7 @@ Bundler also allows you to work against a git repository locally instead of usin
 .
 .nf
 
-bundle config set local\.GEM_NAME /path/to/local/git/repository
+bundle config set \-\-local local\.GEM_NAME /path/to/local/git/repository
 .
 .fi
 .
@@ -325,7 +325,7 @@ For example, in order to use a local Rack repository, a developer could call:
 .
 .nf
 
-bundle config set local\.rack ~/Work/git/rack
+bundle config set \-\-local local\.rack ~/Work/git/rack
 .
 .fi
 .
@@ -347,7 +347,7 @@ Bundler supports overriding gem sources with mirrors\. This allows you to config
 .
 .nf
 
-bundle config set mirror\.SOURCE_URL MIRROR_URL
+bundle config set \-\-global mirror\.SOURCE_URL MIRROR_URL
 .
 .fi
 .
@@ -360,7 +360,7 @@ For example, to use a mirror of rubygems\.org hosted at rubygems\-mirror\.org:
 .
 .nf
 
-bundle config set mirror\.http://rubygems\.org http://rubygems\-mirror\.org
+bundle config set \-\-global mirror\.http://rubygems\.org http://rubygems\-mirror\.org
 .
 .fi
 .
@@ -373,7 +373,7 @@ Each mirror also provides a fallback timeout setting\. If the mirror does not re
 .
 .nf
 
-bundle config set mirror\.SOURCE_URL\.fallback_timeout TIMEOUT
+bundle config set \-\-global mirror\.SOURCE_URL\.fallback_timeout TIMEOUT
 .
 .fi
 .
@@ -386,7 +386,7 @@ For example, to fall back to rubygems\.org after 3 seconds:
 .
 .nf
 
-bundle config set mirror\.https://rubygems\.org\.fallback_timeout 3
+bundle config set \-\-global mirror\.https://rubygems\.org\.fallback_timeout 3
 .
 .fi
 .
@@ -402,7 +402,7 @@ Bundler allows you to configure credentials for any gem source, which allows you
 .
 .nf
 
-bundle config set SOURCE_HOSTNAME USERNAME:PASSWORD
+bundle config set \-\-global SOURCE_HOSTNAME USERNAME:PASSWORD
 .
 .fi
 .
@@ -415,7 +415,7 @@ For example, to save the credentials of user \fBclaudette\fR for the gem source 
 .
 .nf
 
-bundle config set gems\.longerous\.com claudette:s00pers3krit
+bundle config set \-\-global gems\.longerous\.com claudette:s00pers3krit
 .
 .fi
 .
@@ -441,7 +441,7 @@ For gems with a git source with HTTP(S) URL you can specify credentials like so:
 .
 .nf
 
-bundle config set https://github\.com/bundler/bundler\.git username:password
+bundle config set \-\-global https://github\.com/bundler/bundler\.git username:password
 .
 .fi
 .

--- a/bundler/man/bundle-config.1.txt
+++ b/bundler/man/bundle-config.1.txt
@@ -58,8 +58,8 @@ DESCRIPTION
        Executing bundle with the BUNDLE_IGNORE_CONFIG environment variable set
        will cause it to ignore all configuration.
 
-       Executing bundle  config  set  disable_multisource  true  upgrades  the
-       warning  about  the  Gemfile  containing multiple primary sources to an
+       Executing bundle config set --local disable_multisource  true  upgrades
+       the warning about the Gemfile containing multiple primary sources to an
        error. Executing bundle  config  unset  disable_multisource  downgrades
        this error to a warning.
 
@@ -70,7 +70,8 @@ REMEMBERING OPTIONS
 
        However,  this will be changed in bundler 3, so it's better not to rely
        on this behavior. If these options must be remembered, it's  better  to
-       set them using bundle config (e.g., bundle config set path foo).
+       set  them  using  bundle  config  (e.g., bundle config set --local path
+       foo).
 
        The options that can be configured are:
 
@@ -120,7 +121,7 @@ BUILD OPTIONS
 
 
 
-           bundle config set build.mysql --with-mysql-config=/usr/local/mysql/bin/mysql_config
+           bundle config set --global build.mysql --with-mysql-config=/usr/local/mysql/bin/mysql_config
 
 
 
@@ -376,7 +377,7 @@ LOCAL GIT REPOS
 
 
 
-           bundle config set local.GEM_NAME /path/to/local/git/repository
+           bundle config set --local local.GEM_NAME /path/to/local/git/repository
 
 
 
@@ -385,7 +386,7 @@ LOCAL GIT REPOS
 
 
 
-           bundle config set local.rack ~/Work/git/rack
+           bundle config set --local local.rack ~/Work/git/rack
 
 
 
@@ -418,7 +419,7 @@ MIRRORS OF GEM SOURCES
 
 
 
-           bundle config set mirror.SOURCE_URL MIRROR_URL
+           bundle config set --global mirror.SOURCE_URL MIRROR_URL
 
 
 
@@ -427,7 +428,7 @@ MIRRORS OF GEM SOURCES
 
 
 
-           bundle config set mirror.http://rubygems.org http://rubygems-mirror.org
+           bundle config set --global mirror.http://rubygems.org http://rubygems-mirror.org
 
 
 
@@ -437,7 +438,7 @@ MIRRORS OF GEM SOURCES
 
 
 
-           bundle config set mirror.SOURCE_URL.fallback_timeout TIMEOUT
+           bundle config set --global mirror.SOURCE_URL.fallback_timeout TIMEOUT
 
 
 
@@ -445,7 +446,7 @@ MIRRORS OF GEM SOURCES
 
 
 
-           bundle config set mirror.https://rubygems.org.fallback_timeout 3
+           bundle config set --global mirror.https://rubygems.org.fallback_timeout 3
 
 
 
@@ -458,7 +459,7 @@ CREDENTIALS FOR GEM SOURCES
 
 
 
-           bundle config set SOURCE_HOSTNAME USERNAME:PASSWORD
+           bundle config set --global SOURCE_HOSTNAME USERNAME:PASSWORD
 
 
 
@@ -467,7 +468,7 @@ CREDENTIALS FOR GEM SOURCES
 
 
 
-           bundle config set gems.longerous.com claudette:s00pers3krit
+           bundle config set --global gems.longerous.com claudette:s00pers3krit
 
 
 
@@ -484,7 +485,7 @@ CREDENTIALS FOR GEM SOURCES
 
 
 
-           bundle config set https://github.com/bundler/bundler.git username:password
+           bundle config set --global https://github.com/bundler/bundler.git username:password
 
 
 

--- a/bundler/man/bundle-config.ronn
+++ b/bundler/man/bundle-config.ronn
@@ -47,7 +47,7 @@ configuration only from the local application.
 Executing bundle with the `BUNDLE_IGNORE_CONFIG` environment variable set will
 cause it to ignore all configuration.
 
-Executing `bundle config set disable_multisource true` upgrades the warning about
+Executing `bundle config set --local disable_multisource true` upgrades the warning about
 the Gemfile containing multiple primary sources to an error. Executing `bundle
 config unset disable_multisource` downgrades this error to a warning.
 
@@ -59,7 +59,7 @@ application's configuration (normally, `./.bundle/config`).
 
 However, this will be changed in bundler 3, so it's better not to rely on this
 behavior. If these options must be remembered, it's better to set them using
-`bundle config` (e.g., `bundle config set path foo`).
+`bundle config` (e.g., `bundle config set --local path foo`).
 
 The options that can be configured are:
 
@@ -103,7 +103,7 @@ pass configuration flags to `gem install` to specify where to find the
 Since the specific location of that executable can change from machine
 to machine, you can specify these flags on a per-machine basis.
 
-    bundle config set build.mysql --with-mysql-config=/usr/local/mysql/bin/mysql_config
+    bundle config set --global build.mysql --with-mysql-config=/usr/local/mysql/bin/mysql_config
 
 After running this command, every time bundler needs to install the
 `mysql` gem, it will pass along the flags you specified.
@@ -299,11 +299,11 @@ Bundler also allows you to work against a git repository locally
 instead of using the remote version. This can be achieved by setting
 up a local override:
 
-    bundle config set local.GEM_NAME /path/to/local/git/repository
+    bundle config set --local local.GEM_NAME /path/to/local/git/repository
 
 For example, in order to use a local Rack repository, a developer could call:
 
-    bundle config set local.rack ~/Work/git/rack
+    bundle config set --local local.rack ~/Work/git/rack
 
 Now instead of checking out the remote git repository, the local
 override will be used. Similar to a path source, every time the local
@@ -333,21 +333,21 @@ Bundler supports overriding gem sources with mirrors. This allows you to
 configure rubygems.org as the gem source in your Gemfile while still using your
 mirror to fetch gems.
 
-    bundle config set mirror.SOURCE_URL MIRROR_URL
+    bundle config set --global mirror.SOURCE_URL MIRROR_URL
 
 For example, to use a mirror of rubygems.org hosted at rubygems-mirror.org:
 
-    bundle config set mirror.http://rubygems.org http://rubygems-mirror.org
+    bundle config set --global mirror.http://rubygems.org http://rubygems-mirror.org
 
 Each mirror also provides a fallback timeout setting. If the mirror does not
 respond within the fallback timeout, Bundler will try to use the original
 server instead of the mirror.
 
-    bundle config set mirror.SOURCE_URL.fallback_timeout TIMEOUT
+    bundle config set --global mirror.SOURCE_URL.fallback_timeout TIMEOUT
 
 For example, to fall back to rubygems.org after 3 seconds:
 
-    bundle config set mirror.https://rubygems.org.fallback_timeout 3
+    bundle config set --global mirror.https://rubygems.org.fallback_timeout 3
 
 The default fallback timeout is 0.1 seconds, but the setting can currently
 only accept whole seconds (for example, 1, 15, or 30).
@@ -357,12 +357,12 @@ only accept whole seconds (for example, 1, 15, or 30).
 Bundler allows you to configure credentials for any gem source, which allows
 you to avoid putting secrets into your Gemfile.
 
-    bundle config set SOURCE_HOSTNAME USERNAME:PASSWORD
+    bundle config set --global SOURCE_HOSTNAME USERNAME:PASSWORD
 
 For example, to save the credentials of user `claudette` for the gem source at
 `gems.longerous.com`, you would run:
 
-    bundle config set gems.longerous.com claudette:s00pers3krit
+    bundle config set --global gems.longerous.com claudette:s00pers3krit
 
 Or you can set the credentials as an environment variable like this:
 
@@ -370,7 +370,7 @@ Or you can set the credentials as an environment variable like this:
 
 For gems with a git source with HTTP(S) URL you can specify credentials like so:
 
-    bundle config set https://github.com/bundler/bundler.git username:password
+    bundle config set --global https://github.com/bundler/bundler.git username:password
 
 Or you can set the credentials as an environment variable like so:
 

--- a/bundler/man/gemfile.5
+++ b/bundler/man/gemfile.5
@@ -227,8 +227,8 @@ To specify multiple groups to ignore, specify a list of groups separated by spac
 .
 .nf
 
-bundle config set without test
-bundle config set without development test
+bundle config set \-\-local without test
+bundle config set \-\-local without development test
 .
 .fi
 .

--- a/bundler/man/gemfile.5.ronn
+++ b/bundler/man/gemfile.5.ronn
@@ -163,8 +163,8 @@ not install with the `without` configuration.
 
 To specify multiple groups to ignore, specify a list of groups separated by spaces.
 
-    bundle config set without test
-    bundle config set without development test
+    bundle config set --local without test
+    bundle config set --local without development test
 
 Also, calling `Bundler.setup` with no parameters, or calling `require "bundler/setup"`
 will setup all groups except for the ones you excluded via `--without` (since they

--- a/bundler/man/gemfile.5.txt
+++ b/bundler/man/gemfile.5.txt
@@ -211,8 +211,8 @@ GEMS
 
 
 
-           bundle config set without test
-           bundle config set without development test
+           bundle config set --local without test
+           bundle config set --local without development test
 
 
 

--- a/bundler/spec/bundler/source_list_spec.rb
+++ b/bundler/spec/bundler/source_list_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Bundler::SourceList do
         let(:msg) do
           "The git source `git://existing-git.org/path.git` " \
           "uses the `git` protocol, which transmits data without encryption. " \
-          "Disable this warning with `bundle config set git.allow_insecure true`, " \
+          "Disable this warning with `bundle config set --local git.allow_insecure true`, " \
           "or switch to the `https` protocol to keep your data secure."
         end
 

--- a/bundler/spec/commands/outdated_spec.rb
+++ b/bundler/spec/commands/outdated_spec.rb
@@ -555,7 +555,7 @@ RSpec.describe "bundle outdated" do
     end
   end
 
-  context "after bundle config set deployment true" do
+  context "after bundle config set --local deployment true" do
     before do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
@@ -563,7 +563,7 @@ RSpec.describe "bundle outdated" do
         gem "rack"
         gem "foo"
       G
-      bundle "config set deployment true"
+      bundle "config set --local deployment true"
     end
 
     it "outputs a helpful message about being in deployment mode" do

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe "bundle install across platforms" do
 
     expect(err).to include "Unable to use the platform-specific (universal-darwin) version of facter (2.4.6) " \
       "because it has different dependencies from the ruby version. " \
-      "To use the platform-specific version of the gem, run `bundle config set specific_platform true` and install again."
+      "To use the platform-specific version of the gem, run `bundle config set --local specific_platform true` and install again."
 
     expect(the_bundle).to include_gem "facter 2.4.6"
     expect(the_bundle).not_to include_gem "CFPropertyList"

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -690,7 +690,7 @@ The checksum of /versions does not match the checksum provided by the server! So
 
       it "shows instructions if auth is not provided for the source" do
         bundle :install, :artifice => "compact_index_strict_basic_authentication", :raise_on_error => false
-        expect(err).to include("bundle config set #{source_hostname} username:password")
+        expect(err).to include("bundle config set --global #{source_hostname} username:password")
       end
 
       it "fails if authentication has already been provided, but failed" do
@@ -878,7 +878,7 @@ The checksum of /versions does not match the checksum provided by the server! So
         and include("1. delete the downloaded gem located at: `#{default_bundle_path}/gems/rack-1.0.0/rack-1.0.0.gem`").
         and include("2. run `bundle install`").
         and include("If you wish to continue installing the downloaded gem, and are certain it does not pose a security issue despite the mismatching checksum, do the following:").
-        and include("1. run `bundle config set disable_checksum_validation true` to turn off checksum verification").
+        and include("1. run `bundle config set --local disable_checksum_validation true` to turn off checksum verification").
         and include("2. run `bundle install`").
         and match(/\(More info: The expected SHA256 checksum was "#{"ab" * 22}", but the checksum for the downloaded gem was ".+?"\.\)/)
     end

--- a/bundler/spec/install/gems/dependency_api_spec.rb
+++ b/bundler/spec/install/gems/dependency_api_spec.rb
@@ -664,7 +664,7 @@ RSpec.describe "gemcutter's dependency API" do
 
       it "shows instructions if auth is not provided for the source" do
         bundle :install, :artifice => "endpoint_strict_basic_authentication", :raise_on_error => false
-        expect(err).to include("bundle config set #{source_hostname} username:password")
+        expect(err).to include("bundle config set --global #{source_hostname} username:password")
       end
 
       it "fails if authentication has already been provided, but failed" do

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe "major deprecations" do
       expect(deprecations).to include(
         "The `--path` flag is deprecated because it relies on being " \
         "remembered across bundler invocations, which bundler will no " \
-        "longer do in future versions. Instead please use `bundle config set " \
+        "longer do in future versions. Instead please use `bundle config set --local " \
         "path 'vendor/bundle'`, and stop using this flag"
       )
     end
@@ -135,7 +135,7 @@ RSpec.describe "major deprecations" do
       expect(deprecations).to include(
         "The `--path` flag is deprecated because it relies on being " \
         "remembered across bundler invocations, which bundler will no " \
-        "longer do in future versions. Instead please use `bundle config set " \
+        "longer do in future versions. Instead please use `bundle config set --local " \
         "path 'vendor/bundle'`, and stop using this flag"
       )
     end
@@ -339,7 +339,7 @@ RSpec.describe "major deprecations" do
             "The `#{flag_name}` flag is deprecated because it relies on " \
             "being remembered across bundler invocations, which bundler " \
             "will no longer do in future versions. Instead please use " \
-            "`bundle config set #{option_name} '#{value}'`, and stop using this flag"
+            "`bundle config set --local #{option_name} '#{value}'`, and stop using this flag"
           )
         end
 
@@ -362,7 +362,7 @@ RSpec.describe "major deprecations" do
         "Using `source` more than once without a block is a security risk, and " \
         "may result in installing unexpected gems. To resolve this warning, use " \
         "a block to indicate which gems should come from the secondary source. " \
-        "To upgrade this warning to an error, run `bundle config set " \
+        "To upgrade this warning to an error, run `bundle config set --local " \
         "disable_multisource true`."
       )
     end


### PR DESCRIPTION
* Closes https://github.com/rubygems/rubygems/issues/3916.
* Always show --local or --global for `bundle config set` commands as
  the default is global which can be not intuitive (#3916).

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
