### PR TITLE
The bug report template should be printed to standard error

### DIFF
--- a/bundler/lib/bundler/friendly_errors.rb
+++ b/bundler/lib/bundler/friendly_errors.rb
@@ -51,7 +51,7 @@ module Bundler
     end
 
     def request_issue_report_for(e)
-      Bundler.ui.info <<-EOS.gsub(/^ {8}/, "")
+      Bundler.ui.error <<-EOS.gsub(/^ {8}/, ""), nil, nil
         --- ERROR REPORT TEMPLATE -------------------------------------------------------
         # Error Report
 
@@ -94,7 +94,7 @@ module Bundler
 
       Bundler.ui.error "Unfortunately, an unexpected error occurred, and Bundler cannot continue."
 
-      Bundler.ui.warn <<-EOS.gsub(/^ {8}/, "")
+      Bundler.ui.error <<-EOS.gsub(/^ {8}/, ""), nil, :yellow
 
         First, try this link to see if there are any existing issue reports for this error:
         #{issues_url(e)}

--- a/bundler/lib/bundler/ui/shell.rb
+++ b/bundler/lib/bundler/ui/shell.rb
@@ -28,17 +28,17 @@ module Bundler
         tell_me(msg, :green, newline) if level("confirm")
       end
 
-      def warn(msg, newline = nil)
+      def warn(msg, newline = nil, color = :yellow)
         return unless level("warn")
         return if @warning_history.include? msg
         @warning_history << msg
 
-        tell_err(msg, :yellow, newline)
+        tell_err(msg, color, newline)
       end
 
-      def error(msg, newline = nil)
+      def error(msg, newline = nil, color = :red)
         return unless level("error")
-        tell_err(msg, :red, newline)
+        tell_err(msg, color, newline)
       end
 
       def debug(msg, newline = nil)

--- a/bundler/spec/bundler/friendly_errors_spec.rb
+++ b/bundler/spec/bundler/friendly_errors_spec.rb
@@ -193,9 +193,9 @@ RSpec.describe Bundler, "friendly errors" do
 
   describe "#request_issue_report_for" do
     it "calls relevant methods for Bundler.ui" do
-      expect(Bundler.ui).to receive(:info)
-      expect(Bundler.ui).to receive(:error)
-      expect(Bundler.ui).to receive(:warn)
+      expect(Bundler.ui).not_to receive(:info)
+      expect(Bundler.ui).to receive(:error).exactly(3).times
+      expect(Bundler.ui).not_to receive(:warn)
       Bundler::FriendlyErrors.request_issue_report_for(StandardError.new)
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

While writing a spec for another bug, I noticed that the bug report template is being printed to STDOUT. I believe that's unexpected.

## What is your fix for the problem, implemented in this PR?

So I changed it to be printed to STDERR.

I also added some optional color parameters to the UI helpers, so that I could keep the current output colors.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).