### PR TITLE
Move shebang to the top of `bin/console` template

### DIFF
--- a/bundler/lib/bundler/templates/newgem/bin/console.tt
+++ b/bundler/lib/bundler/templates/newgem/bin/console.tt
@@ -1,6 +1,5 @@
-# frozen_string_literal: true
-
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "bundler/setup"
 require "<%= config[:namespaced_path] %>"

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -376,6 +376,8 @@ RSpec.describe "bundle gem" do
       expect(bundled_app("#{gem_name}/bin/console")).to exist
       expect(bundled_app("#{gem_name}/bin/setup")).to be_executable
       expect(bundled_app("#{gem_name}/bin/console")).to be_executable
+      expect(bundled_app("#{gem_name}/bin/setup").read).to start_with("#!")
+      expect(bundled_app("#{gem_name}/bin/console").read).to start_with("#!")
     end
 
     it "starts with version 0.1.0" do


### PR DESCRIPTION
In an executable script, the shebang line should be the first line (the
file needs to start with the bytes 0x23 0x21).  Putting a comment above
it will break the script.