### PR TITLE
Deprecate `bundle cache --all` flag

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -461,6 +461,12 @@ module Bundler
       bundle without having to download any additional gems.
     D
     def cache
+      SharedHelpers.major_deprecation 2,
+        "The `--all` flag is deprecated because it relies on being " \
+        "remembered across bundler invocations, which bundler will no longer " \
+        "do in future versions. Instead please use `bundle config set cache_all true`, " \
+        "and stop using this flag" if ARGV.include?("--all")
+
       require_relative "cli/cache"
       Cache.new(options).run
     end

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -838,7 +838,7 @@ module Bundler
       value = options[name]
       value = value.join(" ").to_s if option.type == :array
 
-      Bundler::SharedHelpers.major_deprecation 2,\
+      Bundler::SharedHelpers.major_deprecation 2,
         "The `#{flag_name}` flag is deprecated because it relies on being " \
         "remembered across bundler invocations, which bundler will no longer " \
         "do in future versions. Instead please use `bundle config set --local #{name.tr("-", "_")} " \

--- a/bundler/lib/bundler/cli/cache.rb
+++ b/bundler/lib/bundler/cli/cache.rb
@@ -37,12 +37,6 @@ module Bundler
       all = options.fetch(:all, Bundler.feature_flag.cache_all? || nil)
 
       Bundler.settings.set_command_option_if_given :cache_all, all
-
-      if Bundler.definition.has_local_dependencies? && !Bundler.feature_flag.cache_all?
-        Bundler.ui.warn "Your Gemfile contains path and git dependencies. If you want "    \
-          "to cache them as well, please pass the --all flag. This will be the default " \
-          "on Bundler 3.0."
-      end
     end
   end
 end

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -319,10 +319,6 @@ module Bundler
       sources.rubygems_sources.any? {|s| s.remotes.any? }
     end
 
-    def has_local_dependencies?
-      !sources.path_sources.empty? || !sources.git_sources.empty?
-    end
-
     def spec_git_paths
       sources.git_sources.map {|s| File.realpath(s.path) if File.exist?(s.path) }.compact
     end

--- a/bundler/spec/cache/git_spec.rb
+++ b/bundler/spec/cache/git_spec.rb
@@ -174,32 +174,6 @@ RSpec.describe "bundle cache with git" do
     expect(the_bundle).to include_gems "has_submodule 1.0"
   end
 
-  it "displays warning message when detecting git repo in Gemfile", :bundler => "< 3" do
-    build_git "foo"
-
-    install_gemfile <<-G
-      gem "foo", :git => '#{lib_path("foo-1.0")}'
-    G
-
-    bundle :cache
-
-    expect(err).to include("Your Gemfile contains path and git dependencies.")
-  end
-
-  it "does not display warning message if cache_all is set in bundle config" do
-    build_git "foo"
-
-    install_gemfile <<-G
-      gem "foo", :git => '#{lib_path("foo-1.0")}'
-    G
-
-    bundle "config set cache_all true"
-    bundle :cache
-    bundle :cache
-
-    expect(err).not_to include("Your Gemfile contains path and git dependencies.")
-  end
-
   it "caches pre-evaluated gemspecs" do
     git = build_git "foo"
 

--- a/bundler/spec/cache/path_spec.rb
+++ b/bundler/spec/cache/path_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe "bundle cache with path" do
     expect(bundled_app("vendor/cache/foo-1.0")).not_to exist
   end
 
-  it "raises a warning without --all", :bundler => "< 3" do
+  it "does not cache path gems by default", :bundler => "< 3" do
     build_lib "foo"
 
     install_gemfile <<-G
@@ -99,8 +99,20 @@ RSpec.describe "bundle cache with path" do
     G
 
     bundle :cache
-    expect(err).to match(/please pass the \-\-all flag/)
+    expect(err).to be_empty
     expect(bundled_app("vendor/cache/foo-1.0")).not_to exist
+  end
+
+  it "caches path gems by default", :bundler => "3" do
+    build_lib "foo"
+
+    install_gemfile <<-G
+      gem "foo", :path => '#{lib_path("foo-1.0")}'
+    G
+
+    bundle :cache
+    expect(err).to be_empty
+    expect(bundled_app("vendor/cache/foo-1.0")).to exist
   end
 
   it "stores the given flag" do

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -143,6 +143,28 @@ RSpec.describe "major deprecations" do
     pending "should fail with a helpful error", :bundler => "3"
   end
 
+  context "bundle cache --all" do
+    before do
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rack"
+      G
+
+      bundle "cache --all", :raise_on_error => false
+    end
+
+    it "should print a deprecation warning", :bundler => "2" do
+      expect(deprecations).to include(
+        "The `--all` flag is deprecated because it relies on being " \
+        "remembered across bundler invocations, which bundler will no " \
+        "longer do in future versions. Instead please use `bundle config set " \
+        "cache_all true`, and stop using this flag"
+      )
+    end
+
+    pending "should fail with a helpful error", :bundler => "3"
+  end
+
   describe "bundle config" do
     describe "old list interface" do
       before do


### PR DESCRIPTION
# Description:

Just like we've done with the other sticky options, I think we should deprecate it in favour of explicitly configuring `bundle config set --local cache_all true`.

I was really unsure about what to do with the `--all` flag, because looking back at the history of changes & PRs, it looked like there was a plan to deprecate it, and make it the default behavuor, so that caching git and path gems is not optional.

However, I'm not really sure whether that would be correct or not, or whether it makes sense to allow not caching git & path gems.

So, I propose to keep the option as a configuration setting, `cache_all`, which will be changing its default value in bundler 3 from false to true.

Regarding the flag, I propose to deprecate it, since it behaves similarly to all the other sticky options which we have already deprecated.

This is a follow up to #3914.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
