### PR TITLE
Prioritize `path.system` over `path` when it makes sense

### DIFF
--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -195,14 +195,16 @@ module Bundler
 
     # for legacy reasons, in Bundler 2, we do not respect :disable_shared_gems
     def path
-      key  = key_for(:path)
-      path = ENV[key] || @global_config[key]
-      if path && !@temporary.key?(key) && !@local_config.key?(key)
-        return Path.new(path, false)
+      configs.each do |_level, settings|
+        path = value_for("path", settings)
+        path_system = value_for("path.system", settings)
+        disabled_shared_gems = value_for("disable_shared_gems", settings)
+        next if path.nil? && path_system.nil? && disabled_shared_gems.nil?
+        system_path = path_system || (disabled_shared_gems == false)
+        return Path.new(path, system_path)
       end
 
-      system_path = self["path.system"] || (self[:disable_shared_gems] == false)
-      Path.new(self[:path], system_path)
+      Path.new(nil, false)
     end
 
     Path = Struct.new(:explicit_path, :system_path) do

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -278,7 +278,7 @@ module Bundler
       all.each do |raw_key|
         [@local_config, @env_config, @global_config].each do |settings|
           value = converted_value(settings[key_for(raw_key)], raw_key)
-          Validator.validate!(raw_key, value, settings.to_hash.dup)
+          Validator.validate!(raw_key, value, settings.dup)
         end
       end
     end

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -182,20 +182,20 @@ module Bundler
 
       locations = []
 
-      if @temporary.key?(key)
-        locations << "Set for the current command: #{converted_value(@temporary[key], exposed_key).inspect}"
+      if value = @temporary[key]
+        locations << "Set for the current command: #{converted_value(value, exposed_key).inspect}"
       end
 
-      if @local_config.key?(key)
-        locations << "Set for your local app (#{local_config_file}): #{converted_value(@local_config[key], exposed_key).inspect}"
+      if value = @local_config[key]
+        locations << "Set for your local app (#{local_config_file}): #{converted_value(value, exposed_key).inspect}"
       end
 
       if value = ENV[key]
         locations << "Set via #{key}: #{converted_value(value, exposed_key).inspect}"
       end
 
-      if @global_config.key?(key)
-        locations << "Set for the current user (#{global_config_file}): #{converted_value(@global_config[key], exposed_key).inspect}"
+      if value = @global_config[key]
+        locations << "Set for the current user (#{global_config_file}): #{converted_value(value, exposed_key).inspect}"
       end
 
       return ["You have not configured a value for `#{exposed_key}`"] if locations.empty?

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -277,7 +277,7 @@ module Bundler
     def validate!
       all.each do |raw_key|
         [@local_config, @env_config, @global_config].each do |settings|
-          value = converted_value(settings[key_for(raw_key)], raw_key)
+          value = value_for(raw_key, settings)
           Validator.validate!(raw_key, value, settings.dup)
         end
       end
@@ -290,6 +290,10 @@ module Bundler
     end
 
     private
+
+    def value_for(name, config)
+      converted_value(config[key_for(name)], name)
+    end
 
     def parent_setting_for(name)
       split_specific_setting_for(name)[0]

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -63,12 +63,12 @@ module Bundler
     ].freeze
 
     DEFAULT_CONFIG = {
-      :silence_deprecations => false,
-      :disable_version_check => true,
-      :prefer_patch => false,
-      :redirect => 5,
-      :retry => 3,
-      :timeout => 10,
+      "BUNDLE_SILENCE_DEPRECATIONS" => false,
+      "BUNDLE_DISABLE_VERSION_CHECK" => true,
+      "BUNDLE_PREFER_PATCH" => false,
+      "BUNDLE_REDIRECT" => 5,
+      "BUNDLE_RETRY" => 3,
+      "BUNDLE_TIMEOUT" => 10,
     }.freeze
 
     def initialize(root = nil)
@@ -84,7 +84,7 @@ module Bundler
               @local_config.fetch(key) do
               ENV.fetch(key) do
               @global_config.fetch(key) do
-              DEFAULT_CONFIG.fetch(name) do
+              DEFAULT_CONFIG.fetch(key) do
                 nil
               end end end end end
 

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -207,14 +207,14 @@ module Bundler
       key  = key_for(:path)
       path = ENV[key] || @global_config[key]
       if path && !@temporary.key?(key) && !@local_config.key?(key)
-        return Path.new(path, false, false)
+        return Path.new(path, false)
       end
 
       system_path = self["path.system"] || (self[:disable_shared_gems] == false)
-      Path.new(self[:path], system_path, Bundler.feature_flag.default_install_uses_path?)
+      Path.new(self[:path], system_path)
     end
 
-    Path = Struct.new(:explicit_path, :system_path, :default_install_uses_path) do
+    Path = Struct.new(:explicit_path, :system_path) do
       def path
         path = base_path
         path = File.join(path, Bundler.ruby_scope) unless use_system_gems?
@@ -224,7 +224,7 @@ module Bundler
       def use_system_gems?
         return true if system_path
         return false if explicit_path
-        !default_install_uses_path
+        !Bundler.feature_flag.default_install_uses_path?
       end
 
       def base_path

--- a/bundler/spec/install/path_spec.rb
+++ b/bundler/spec/install/path_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "bundle install" do
       G
     end
 
-    it "does not use available system gems with `vendor/bundle", :bundler => "< 3" do
+    it "does not use available system gems with `vendor/bundle" do
       bundle "config --local path vendor/bundle"
       bundle :install
       expect(the_bundle).to include_gems "rack 1.0.0"

--- a/bundler/spec/install/path_spec.rb
+++ b/bundler/spec/install/path_spec.rb
@@ -19,6 +19,14 @@ RSpec.describe "bundle install" do
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
 
+    it "uses system gems with `path.system` configured with more priority than `path`" do
+      bundle "config --local path.system true"
+      bundle "config --global path vendor/bundle"
+      bundle :install
+      run "require 'rack'", :raise_on_error => false
+      expect(out).to include("FAIL")
+    end
+
     it "handles paths with regex characters in them" do
       dir = bundled_app("bun++dle")
       dir.mkpath

--- a/bundler/spec/install/path_spec.rb
+++ b/bundler/spec/install/path_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe "bundle install" do
-  describe "with --path" do
+  describe "with path configured" do
     before :each do
       build_gem "rack", "1.0.0", :to_system => true do |s|
         s.write "lib/rack.rb", "puts 'FAIL'"
@@ -13,7 +13,7 @@ RSpec.describe "bundle install" do
       G
     end
 
-    it "does not use available system gems with bundle --path vendor/bundle", :bundler => "< 3" do
+    it "does not use available system gems with `vendor/bundle", :bundler => "< 3" do
       bundle "config --local path vendor/bundle"
       bundle :install
       expect(the_bundle).to include_gems "rack 1.0.0"
@@ -30,7 +30,7 @@ RSpec.describe "bundle install" do
       dir.rmtree
     end
 
-    it "prints a warning to let the user know what has happened with bundle --path vendor/bundle" do
+    it "prints a warning to let the user know where gems where installed" do
       bundle "config --local path vendor/bundle"
       bundle :install
       expect(out).to include("gems are installed into `./vendor/bundle`")

--- a/bundler/spec/install/path_spec.rb
+++ b/bundler/spec/install/path_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "bundle install" do
       dir.rmtree
     end
 
-    it "prints a warning to let the user know where gems where installed" do
+    it "prints a message to let the user know where gems where installed" do
       bundle "config --local path vendor/bundle"
       bundle :install
       expect(out).to include("gems are installed into `./vendor/bundle`")


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If a user configures `path.system true` locally, and `path foo` globally, gems are still installed to `foo`, even if they should be installed to `GEM_PATH`, give that local configuration should have more priority.

## What is your fix for the problem, implemented in this PR?

My fix is to remove some special logic that was preventing this case to work, and also to relax the `path` and `path.system` validation that makes sure there are no conflicts between them to allow this case.

Fixes https://github.com/rubygems/rubygems/issues/3931.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).