### PR TITLE
Bump minitest to latest 5.14.2

### DIFF
--- a/dev_gems.rb
+++ b/dev_gems.rb
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "rdoc", "6.2.0" # 6.2.1 is required > Ruby 2.3
 gem "rake", "~> 13.0"
-gem "minitest", "~> 5.13"
+gem "minitest", "~> 5.14", ">= 5.14.2" # 5.14.2 is required to support Ruby 3.0
 gem "simplecov", "~> 0.17.0"
 gem "rubocop", "~> 0.80.1"
 gem "rubocop-performance", "~> 1.5.2"

--- a/dev_gems.rb.lock
+++ b/dev_gems.rb.lock
@@ -7,7 +7,7 @@ GEM
     jaro_winkler (1.5.4-java)
     json (2.3.0)
     json (2.3.0-java)
-    minitest (5.14.0)
+    minitest (5.14.2)
     parallel (1.19.1)
     parser (2.7.0.5)
       ast (~> 2.4.0)
@@ -39,7 +39,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  minitest (~> 5.13)
+  minitest (~> 5.14, >= 5.14.2)
   rake (~> 13.0)
   rdoc (= 6.2.0)
   rubocop (~> 0.80.1)


### PR DESCRIPTION
# Description:

This is to fix our ruby-head build, since the version there has been bumped to ruby 3.0.dev and minitest needed a new release to support that.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).