### PR TITLE
Avoid duplicated generation of APISpecification objects

### DIFF
--- a/lib/rubygems/resolver/api_specification.rb
+++ b/lib/rubygems/resolver/api_specification.rb
@@ -7,6 +7,17 @@
 
 class Gem::Resolver::APISpecification < Gem::Resolver::Specification
   ##
+  # We assume that all instances of this class are immutable;
+  # so avoid duplicated generation for performance.
+  @@cache = {}
+  def self.new(set, api_data)
+    cache_key = [set, api_data]
+    cache = @@cache[cache_key]
+    return cache if cache
+    @@cache[cache_key] = super
+  end
+
+  ##
   # Creates an APISpecification for the given +set+ from the rubygems.org
   # +api_data+.
   #
@@ -18,12 +29,12 @@ class Gem::Resolver::APISpecification < Gem::Resolver::Specification
 
     @set = set
     @name = api_data[:name]
-    @version = Gem::Version.new api_data[:number]
-    @platform = Gem::Platform.new api_data[:platform]
-    @original_platform = api_data[:platform]
+    @version = Gem::Version.new(api_data[:number]).freeze
+    @platform = Gem::Platform.new(api_data[:platform]).freeze
+    @original_platform = api_data[:platform].freeze
     @dependencies = api_data[:dependencies].map do |name, ver|
-      Gem::Dependency.new name, ver.split(/\s*,\s*/)
-    end
+      Gem::Dependency.new(name, ver.split(/\s*,\s*/)).freeze
+    end.freeze
   end
 
   def ==(other) # :nodoc:


### PR DESCRIPTION
# Description:

## What was the end-user or developer problem that led to this PR?

`gem install aws-sdk` is painfully slow

## What is your fix for the problem, implemented in this PR?

As far as I could see, `Gem::Resolver::APISpecification` objects are
supposed to be immutable.  If my guessing is correct, then we can cache
and reuse its instances for performance.
At least, `rake` passes on my machine.

Before this change:

```
$ time ruby -I lib bin/gem install --no-doc aws-sdk
Successfully installed aws-sdk-3.0.1
1 gem installed
real    0m37.104s
user    0m36.952s
sys     0m0.333s
```

After this change:

```
$ time ruby -I lib bin/gem install --no-doc aws-sdk
Successfully installed aws-sdk-3.0.1
1 gem installed
real    0m23.905s
user    0m23.740s
sys     0m0.365s
```

# Tasks:

- [X] Describe the problem / feature
- [ ] Write tests
- [X] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).