### PR TITLE
Fix CI

### DIFF
--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "bundle gem" do
 
   def bundle_exec_rubocop
     prepare_gemspec(bundled_app(gem_name, "#{gem_name}.gemspec"))
-    rubocop_version = RUBY_VERSION > "2.4" ? "0.85.1" : "0.80.1"
+    rubocop_version = RUBY_VERSION > "2.4" ? "0.90.0" : "0.80.1"
     gems = ["minitest", "rake", "rake-compiler", "rspec", "rubocop -v #{rubocop_version}", "test-unit"]
     path = Bundler.feature_flag.default_install_uses_path? ? local_gem_path(:base => bundled_app(gem_name)) : system_gem_path
     realworld_system_gems gems, :path => path

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "bundle gem" do
     prepare_gemspec(bundled_app(gem_name, "#{gem_name}.gemspec"))
     rubocop_version = RUBY_VERSION > "2.4" ? "0.90.0" : "0.80.1"
     gems = ["minitest", "rake", "rake-compiler", "rspec", "rubocop -v #{rubocop_version}", "test-unit"]
+    gems += ["rubocop-ast -v 0.4.0"] if rubocop_version == "0.90.0"
     path = Bundler.feature_flag.default_install_uses_path? ? local_gem_path(:base => bundled_app(gem_name)) : system_gem_path
     realworld_system_gems gems, :path => path
     bundle "exec rubocop --debug --config .rubocop.yml", :dir => bundled_app(gem_name)

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "bundle gem" do
     gems = ["minitest", "rake", "rake-compiler", "rspec", "rubocop -v #{rubocop_version}", "test-unit"]
     path = Bundler.feature_flag.default_install_uses_path? ? local_gem_path(:base => bundled_app(gem_name)) : system_gem_path
     realworld_system_gems gems, :path => path
-    bundle "exec rubocop --config .rubocop.yml", :dir => bundled_app(gem_name)
+    bundle "exec rubocop --debug --config .rubocop.yml", :dir => bundled_app(gem_name)
   end
 
   let(:generated_gemspec) { Bundler.load_gemspec_uncached(bundled_app(gem_name).join("#{gem_name}.gemspec")) }


### PR DESCRIPTION
# Description:

## What was the end-user or developer problem that led to this PR?

The release of `rubocop-ast 0.4.0` broke some `bundle gem` tests that make sure `rubocop` runs cleanly on a generated gem.

The reason is that this new release doesn't seem compatible with the `rubocop` version we were testing against.

## What is your fix for the problem, implemented in this PR?

My fix is to upgrade our tests to use the latest version (which is compatible with rubocop-ast 0.4.0), and to also lock `rubocop-ast` to 0.4.0 to avoid similar failures in the future.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).