### PR TITLE
Update bundler setup.md docs

### DIFF
--- a/bundler/doc/development/SETUP.md
+++ b/bundler/doc/development/SETUP.md
@@ -1,4 +1,4 @@
-# Development setup
+# Bundler Development setup
 
 To work on Bundler, you'll probably want to do a couple of things:
 
@@ -11,6 +11,10 @@ To work on Bundler, you'll probably want to do a couple of things:
     And for OS X (with brew installed):
 
         $ brew install graphviz
+
+* From the rubygems root directory change into the bundler directory:
+
+        $ cd bundler
 
 * Install Bundler's development dependencies:
 


### PR DESCRIPTION
# Description:

The original commands assume that Bundler is the top level project. This PR adds docs indicating that setting up bundler locally now requires moving into a sub-folder.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
