### PR TITLE
Fix `typo_squatting?` false positive for `rubygems.org` itself

### DIFF
--- a/lib/rubygems/source.rb
+++ b/lib/rubygems/source.rb
@@ -225,7 +225,7 @@ class Gem::Source
 
   def typo_squatting?(host, distance_threshold=4)
     return if @uri.host.nil?
-    levenshtein_distance(@uri.host, host) <= distance_threshold
+    levenshtein_distance(@uri.host, host).between? 1, distance_threshold
   end
 end
 

--- a/test/rubygems/test_gem_source.rb
+++ b/test/rubygems/test_gem_source.rb
@@ -240,6 +240,11 @@ class TestGemSource < Gem::TestCase
     refute rubygems_source.typo_squatting?("rubysertgems.org")
   end
 
+  def test_typo_squatting_false_positive
+    rubygems_source = Gem::Source.new("https://rubygems.org")
+    refute rubygems_source.typo_squatting?("rubygems.org")
+  end
+
   def test_typo_squatting_custom_distance_threshold
     rubygems_source = Gem::Source.new("https://rubgems.org")
     distance_threshold = 5


### PR DESCRIPTION
# Description:

Correct typo_squatting behaviour to allow adding https://rubygems.org without triggering input

## What was the end-user or developer problem that led to this PR?

AMI prebuilt using internal gem server + another scripted scenario for some of our builds which re-add https://rubygems.org

This triggers the prompt saying that https://rubygems.org is similar to https://rubygems.org which totally breaks the script due to a) No option to default -y b) Strict tty checks with no default which cause a failure and mean for horrible workarounds c) This specific issue which is independent but contributes to the overall problem.

## What is your fix for the problem, implemented in this PR?

Ensure that correctly entered https://rubygems.org does _not_ raise the result that it is similar, because it is _not_ similar but identical and poses no issue with the desired effect (that stops folks accidentally configuring camped domains and getting supply chain attacks).

We do this by instead of using <= distrance_threshold (which also covers zero) by instead using a range check from 1..distance_threshold
______________

# Tasks:

- [X] Describe the problem / feature
- [X] Write tests
- [X] Write code to solve the problem
- [X] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
