### PR TITLE
Fix `gem build -C`

### DIFF
--- a/lib/rubygems/commands/build_command.rb
+++ b/lib/rubygems/commands/build_command.rb
@@ -23,7 +23,9 @@ class Gem::Commands::BuildCommand < Gem::Command
       options[:output] = value
     end
 
-    add_option '-C PATH', '', 'Run as if gem build was started in <PATH> instead of the current working directory.' do |value, options|
+    add_option '-C PATH', '', 'Look for the code of the gem to be built',
+                              'in <PATH>. The GEMSPEC_FILE given as an',
+                              'argument is not influenced by this option' do |value, options|
       options[:build_path] = value
     end
   end

--- a/lib/rubygems/commands/build_command.rb
+++ b/lib/rubygems/commands/build_command.rb
@@ -85,8 +85,7 @@ Gems can be saved to a specified filename with the output option:
       spec = Gem::Specification.load(gemspec)
 
       if options[:build_path]
-        Dir.chdir(File.dirname(gemspec)) do
-          spec = Gem::Specification.load(File.basename(gemspec))
+        Dir.chdir(options[:build_path]) do
           build_package(spec)
         end
       else

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -272,6 +272,47 @@ class TestGemCommandsBuildCommand < Gem::TestCase
     assert_equal "this is a summary", spec.summary
   end
 
+  def test_execute_outside_dir_with_external_gemspec
+    gemspec_dir = File.join @tempdir, 'gemspec_dir'
+    gemspec_file = File.join gemspec_dir, @gem.spec_name
+
+    gemcode_dir = File.join @tempdir, 'build_command_gem'
+    readme_file = File.join gemcode_dir, 'README.md'
+
+    FileUtils.mkdir_p gemspec_dir
+    FileUtils.mkdir_p gemcode_dir
+
+    File.open readme_file, 'w' do |f|
+      f.write "My awesome gem in nested directory"
+    end
+
+    File.open gemspec_file, 'w' do |gs|
+      gs.write @gem.to_ruby
+    end
+
+    @cmd.options[:build_path] = gemcode_dir
+    @cmd.options[:args] = [gemspec_file]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    output = @ui.output.split "\n"
+    assert_equal "  Successfully built RubyGem", output.shift
+    assert_equal "  Name: some_gem", output.shift
+    assert_equal "  Version: 2", output.shift
+    assert_equal "  File: some_gem-2.gem", output.shift
+    assert_equal [], output
+
+    gem_file = File.join gemcode_dir, File.basename(@gem.cache_file)
+    assert File.exist?(gem_file)
+
+    spec = Gem::Package.new(gem_file).spec
+
+    assert_equal "some_gem", spec.name
+    assert_equal "this is a summary", spec.summary
+  end
+
   def test_can_find_gemspecs_without_dot_gemspec
     gemspec_file = File.join(@tempdir, @gem.spec_name)
 


### PR DESCRIPTION
The directory specified by `-C` option must be reflected, while the already loaded spec file must be used, wherever it came from. This also fixes confusing messages when .gemspec file was not found at all.

Fixes #3953

I have not tried to run the test suite, so let me see what is going to fail ...
