### PR TITLE
Add `--force` option to `gem sources` command

### DIFF
--- a/lib/rubygems/commands/sources_command.rb
+++ b/lib/rubygems/commands/sources_command.rb
@@ -34,6 +34,10 @@ class Gem::Commands::SourcesCommand < Gem::Command
       options[:update] = value
     end
 
+    add_option '-f', '--[no-]force', "Do not show any confirmation prompts and behave as if 'yes' was always answered" do |value, options|
+      options[:force] = value
+    end
+
     add_proxy_option
   end
 
@@ -71,7 +75,7 @@ class Gem::Commands::SourcesCommand < Gem::Command
 Do you want to add this source?
       QUESTION
 
-      terminate_interaction 1 unless ask_yes_no question
+      terminate_interaction 1 unless options[:force] || ask_yes_no(question)
     end
   end
 
@@ -86,7 +90,7 @@ https://rubygems.org is recommended for security over #{uri}
 Do you want to add this insecure source?
       QUESTION
 
-      terminate_interaction 1 unless ask_yes_no question
+      terminate_interaction 1 unless options[:force] || ask_yes_no(question)
     end
   end
 


### PR DESCRIPTION
Allows --force to override use of http URLs and typo checks

# Description:

As discussed in #3955 implements a --force option to the sources command

## What was the end-user or developer problem that led to this PR?

Discussed in #3955 as a complete solution to scripted use of gem which cannot handle no tty input within ask_yes_no

## What is your fix for the problem, implemented in this PR?

Localised fix within commands/sources_command.rb since implementation within user_interaction.rb suggests the creation of user_interaction_options.rb to follow the framework but this would require a larger scale change to centralise the several already implemented --force options within other modules. --force chosen to be consistent with other module usage vs -y.

Also note that --force potentially does different things in other modules so the refactor mentioned is potentially extensive which is why the override is confined to the sources command implementation.

Closes #3955.
______________

# Tasks:

- [X] Describe the problem / feature
- [X] Write tests
- [X] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
