### PR TITLE
Fix typo in `bundle pristine` warning message

### DIFF
--- a/bundler/lib/bundler/cli/pristine.rb
+++ b/bundler/lib/bundler/cli/pristine.rb
@@ -30,7 +30,7 @@ module Bundler
           FileUtils.rm_rf spec.full_gem_path
         when Source::Git
           if source.local?
-            Bundler.ui.warn("Cannot pristine #{gem_name}. Gem is locally overriden.")
+            Bundler.ui.warn("Cannot pristine #{gem_name}. Gem is locally overridden.")
             next
           end
 

--- a/bundler/spec/commands/pristine_spec.rb
+++ b/bundler/spec/commands/pristine_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "bundle pristine", :ruby_repo do
 
       bundle "pristine"
       expect(changes_txt).to be_file
-      expect(err).to include("Cannot pristine #{spec.name} (#{spec.version}#{spec.git_version}). Gem is locally overriden.")
+      expect(err).to include("Cannot pristine #{spec.name} (#{spec.version}#{spec.git_version}). Gem is locally overridden.")
     end
   end
 


### PR DESCRIPTION
# Description:

s/overriden/overridden/

______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [ ] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
