### PR TITLE
Make config location relative to the current working directory

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,2 +1,0 @@
----
-BUNDLE_PATH__SYSTEM: "true"

--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -29,7 +29,8 @@ jobs:
         run: echo "REF=$(ruby -v | cut -d')' -f1 | cut -d' ' -f5)" >> $GITHUB_ENV
       - uses: actions/checkout@v2
         with:
-          repository: ruby/ruby
+          repository: deivid-rodriguez/ruby
+          ref: workaround-bundler-issue
           path: ruby/ruby
           fetch-depth: 10
       - name: Checkout the latest buildable revision

--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -29,8 +29,7 @@ jobs:
         run: echo "REF=$(ruby -v | cut -d')' -f1 | cut -d' ' -f5)" >> $GITHUB_ENV
       - uses: actions/checkout@v2
         with:
-          repository: deivid-rodriguez/ruby
-          ref: workaround-bundler-issue
+          repository: ruby/ruby
           path: ruby/ruby
           fetch-depth: 10
       - name: Checkout the latest buildable revision

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ require "rake/testtask"
 
 desc "Setup Rubygems dev environment"
 task :setup do
-  sh "ruby", "-I", "lib", "bundler/spec/support/bundle.rb", "install", "--gemfile=bundler/tool/bundler/dev_gems.rb"
+  sh({ "BUNDLE_PATH__SYSTEM" => "true" }, "ruby", "-I", "lib", "bundler/spec/support/bundle.rb", "install", "--gemfile=bundler/tool/bundler/dev_gems.rb")
   sh "ruby", "-I", "lib", "bundler/spec/support/bundle.rb", "lock", "--gemfile=bundler/tool/bundler/release_gems.rb"
   sh "ruby", "-I", "lib", "bundler/spec/support/bundle.rb", "lock", "--gemfile=bundler/tool/bundler/test_gems.rb"
   sh "ruby", "-I", "lib", "bundler/spec/support/bundle.rb", "lock", "--gemfile=bundler/tool/bundler/rubocop_gems.rb"
@@ -19,7 +19,7 @@ end
 
 desc "Update Rubygems dev environment"
 task :update do
-  sh "ruby", "-I", "lib", "bundler/spec/support/bundle.rb", "update", "--gemfile=bundler/tool/bundler/dev_gems.rb"
+  sh({ "BUNDLE_PATH__SYSTEM" => "true" }, "ruby", "-I", "lib", "bundler/spec/support/bundle.rb", "update", "--gemfile=bundler/tool/bundler/dev_gems.rb")
   sh "ruby", "-I", "lib", "bundler/spec/support/bundle.rb", "lock", "--update", "--gemfile=bundler/tool/bundler/release_gems.rb"
   sh "ruby", "-I", "lib", "bundler/spec/support/bundle.rb", "lock", "--update", "--gemfile=bundler/tool/bundler/test_gems.rb"
   sh "ruby", "-I", "lib", "bundler/spec/support/bundle.rb", "lock", "--update", "--gemfile=bundler/tool/bundler/rubocop_gems.rb"
@@ -32,7 +32,7 @@ end
 
 desc "Update the locked bundler version in dev environment"
 task :update_locked_bundler do |_, args|
-  sh "ruby", "-I", "lib", "bundler/spec/support/bundle.rb", "update", "--bundler", "--gemfile=bundler/tool/bundler/dev_gems.rb"
+  sh({ "BUNDLE_PATH__SYSTEM" => "true" }, "ruby", "-I", "lib", "bundler/spec/support/bundle.rb", "update", "--bundler", "--gemfile=bundler/tool/bundler/dev_gems.rb")
   sh "ruby", "-I", "lib", "bundler/spec/support/bundle.rb", "update", "--bundler", "--gemfile=bundler/tool/bundler/release_gems.rb"
   sh "ruby", "-I", "lib", "bundler/spec/support/bundle.rb", "update", "--bundler", "--gemfile=bundler/tool/bundler/test_gems.rb"
   sh "ruby", "-I", "lib", "bundler/spec/support/bundle.rb", "update", "--bundler", "--gemfile=bundler/tool/bundler/rubocop_gems.rb"
@@ -45,7 +45,7 @@ end
 
 desc "Update specific development dependencies"
 task :update_dev_dep do |_, args|
-  sh "ruby", "-I", "lib", "bundler/spec/support/bundle.rb", "update", *args, "--gemfile=bundler/tool/bundler/dev_gems.rb"
+  sh({ "BUNDLE_PATH__SYSTEM" => "true" }, "ruby", "-I", "lib", "bundler/spec/support/bundle.rb", "update", *args, "--gemfile=bundler/tool/bundler/dev_gems.rb")
 end
 
 desc "Setup git hooks"

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -288,7 +288,7 @@ module Bundler
                 rescue GemfileNotFound
                   bundle_dir = default_bundle_dir
                   raise GemfileNotFound, "Could not locate Gemfile or .bundle/ directory" unless bundle_dir
-                  Pathname.new(File.expand_path("..", bundle_dir))
+                  bundle_dir.parent
                 end
     end
 

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -297,13 +297,11 @@ module Bundler
         app_config_pathname = Pathname.new(app_config)
 
         if app_config_pathname.absolute?
-          app_config_pathname
-        else
-          root.join(app_config_pathname)
+          return app_config_pathname
         end
-      else
-        root.join(".bundle")
       end
+
+      root.join(app_config || ".bundle")
     end
 
     def app_cache(custom_path = nil)

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -299,7 +299,7 @@ module Bundler
         if app_config_pathname.absolute?
           app_config_pathname
         else
-          app_config_pathname.expand_path(root)
+          root.join(app_config_pathname)
         end
       else
         root.join(".bundle")

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -227,11 +227,11 @@ module Bundler
     def user_home
       @user_home ||= begin
         home = Bundler.rubygems.user_home
-        bundle_home = File.join(home, ".bundle")
+        bundle_home = home.join(".bundle")
 
-        warning = if !File.directory?(home)
+        warning = if !home.directory?
           "`#{home}` is not a directory."
-        elsif !File.writable?(home) && (!File.directory?(bundle_home) || !File.writable?(bundle_home))
+        elsif !home.writable? && (!bundle_home.directory? || !bundle_home.writable?)
           "`#{home}` is not writable."
         end
 
@@ -241,7 +241,7 @@ module Bundler
           Bundler.ui.warn "Bundler will use `#{user_home}' as your home directory temporarily.\n"
           user_home
         else
-          Pathname.new(home)
+          home
         end
       end
     end

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -227,11 +227,9 @@ module Bundler
     def user_home
       @user_home ||= begin
         home = Bundler.rubygems.user_home
-        bundle_home = home ? File.join(home, ".bundle") : nil
+        bundle_home = File.join(home, ".bundle")
 
-        warning = if home.nil?
-          "Your home directory is not set."
-        elsif !File.directory?(home)
+        warning = if !File.directory?(home)
           "`#{home}` is not a directory."
         elsif !File.writable?(home) && (!File.directory?(bundle_home) || !File.writable?(bundle_home))
           "`#{home}` is not writable."

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -301,7 +301,7 @@ module Bundler
         end
       end
 
-      root.join(app_config || ".bundle")
+      app_config_root.join(app_config || ".bundle")
     end
 
     def app_cache(custom_path = nil)
@@ -328,8 +328,6 @@ EOF
 
     def settings
       @settings ||= Settings.new(app_config_path)
-    rescue GemfileNotFound
-      @settings = Settings.new(Pathname.new(".bundle").expand_path)
     end
 
     # @return [Hash] Environment present before Bundler was activated
@@ -696,6 +694,12 @@ EOF
       yield
     ensure
       ENV.replace(backup)
+    end
+
+    def app_config_root
+      root
+    rescue GemfileNotFound
+      Pathname.pwd
     end
   end
 end

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -701,7 +701,7 @@ EOF
     end
 
     def resolve_config_root(base = Pathname.pwd)
-      bundle_dir = default_bundle_dir(base) || SharedHelpers.find_gemfile
+      bundle_dir = default_bundle_dir(base) || SharedHelpers.find_gemfile_if_empty(ENV["BUNDLE_GEMFILE"])
 
       bundle_dir ? bundle_dir.parent : base
     end

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -55,6 +55,15 @@ module Bundler
     def initialize(*args)
       super
 
+      # At this point, settings have been already resolved, unfortunately,
+      # because some CLI help messages, flag aliases or even whole commands need
+      # to be defined according to some settings being activated or not. So once
+      # we know the `--gemfile` has been passed, we need to force a reload of
+      # everything. This logic seems buggy, since the settings we have used
+      # before this point might not be correct, but so far it has worked fine.
+      # The ideal solution would be to add some features to thor so that stuff
+      # can be defined via procs and lazily loaded, and thus we can be sure we
+      # haven't yet loaded settings at all at this point.
       custom_gemfile = options[:gemfile]
       if custom_gemfile && !custom_gemfile.empty?
         expanded_custom_gemfile = Pathname.new(custom_gemfile).expand_path

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -55,7 +55,7 @@ module Bundler
     def initialize(*args)
       super
 
-      custom_gemfile = options[:gemfile] || Bundler.settings[:gemfile]
+      custom_gemfile = options[:gemfile]
       if custom_gemfile && !custom_gemfile.empty?
         expanded_custom_gemfile = Pathname.new(custom_gemfile).expand_path
         Bundler::SharedHelpers.set_env "BUNDLE_GEMFILE", expanded_custom_gemfile.to_s

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -57,8 +57,9 @@ module Bundler
 
       custom_gemfile = options[:gemfile] || Bundler.settings[:gemfile]
       if custom_gemfile && !custom_gemfile.empty?
-        Bundler::SharedHelpers.set_env "BUNDLE_GEMFILE", File.expand_path(custom_gemfile)
-        Bundler.reset_settings_and_root!
+        expanded_custom_gemfile = Pathname.new(custom_gemfile).expand_path
+        Bundler::SharedHelpers.set_env "BUNDLE_GEMFILE", expanded_custom_gemfile.to_s
+        Bundler.reset_settings_and_root!(expanded_custom_gemfile.parent)
       end
 
       Bundler.self_manager.restart_with_locked_bundler_if_needed

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -58,8 +58,8 @@ module Bundler
       custom_gemfile = options[:gemfile]
       if custom_gemfile && !custom_gemfile.empty?
         expanded_custom_gemfile = Pathname.new(custom_gemfile).expand_path
-        Bundler::SharedHelpers.set_env "BUNDLE_GEMFILE", expanded_custom_gemfile.to_s
         Bundler.reset_settings_and_root!(expanded_custom_gemfile.parent)
+        Bundler.settings.temporary(:gemfile => expanded_custom_gemfile)
       end
 
       Bundler.self_manager.restart_with_locked_bundler_if_needed

--- a/bundler/lib/bundler/fetcher.rb
+++ b/bundler/lib/bundler/fetcher.rb
@@ -250,9 +250,7 @@ module Bundler
           con.cert_store = bundler_cert_store
         end
 
-        ssl_client_cert = Bundler.settings[:ssl_client_cert] ||
-          (Gem.configuration.ssl_client_cert if
-            Gem.configuration.respond_to?(:ssl_client_cert))
+        ssl_client_cert = Bundler.settings[:ssl_client_cert] || Gem.configuration.ssl_client_cert
         if ssl_client_cert
           pem = File.read(ssl_client_cert)
           con.cert = OpenSSL::X509::Certificate.new(pem)

--- a/bundler/lib/bundler/inline.rb
+++ b/bundler/lib/bundler/inline.rb
@@ -42,7 +42,7 @@ def gemfile(install = false, options = {}, &gemfile)
     bundler_module = class << Bundler; self; end
     bundler_module.send(:remove_method, :root)
     def Bundler.root
-      Bundler::SharedHelpers.pwd.expand_path
+      Bundler::SharedHelpers.pwd
     end
     old_gemfile = ENV["BUNDLE_GEMFILE"]
     Bundler::SharedHelpers.set_env "BUNDLE_GEMFILE", "Gemfile"

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -135,7 +135,7 @@ module Bundler
     end
 
     def user_home
-      Gem.user_home
+      Pathname.new(Gem.user_home)
     end
 
     def gem_path

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -442,7 +442,7 @@ module Bundler
       elsif ENV["BUNDLE_USER_HOME"] && !ENV["BUNDLE_USER_HOME"].empty?
         Pathname.new(ENV["BUNDLE_USER_HOME"]).join("config")
       else
-        Pathname.new(Bundler.rubygems.user_home).join(".bundle/config")
+        Bundler.rubygems.user_home.join(".bundle/config")
       end
     end
 

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -86,7 +86,7 @@ module Bundler
       "BUNDLE_TIMEOUT" => 10,
     }.freeze
 
-    def initialize(root = nil)
+    def initialize(root)
       @root            = root
       @local_config    = load_config(local_config_file)
       @env_config      = ENV.to_h.select {|key, _value| key =~ /\ABUNDLE_.+/ }
@@ -116,8 +116,6 @@ module Bundler
     end
 
     def set_local(key, value)
-      local_config_file || raise(GemfileNotFound, "Could not locate Gemfile")
-
       set_key(key, value, @local_config, local_config_file)
     end
 
@@ -447,7 +445,7 @@ module Bundler
     end
 
     def local_config_file
-      @root.join("config") if @root
+      @root.join("config")
     end
 
     def load_config(config_file)

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -447,7 +447,7 @@ module Bundler
     end
 
     def local_config_file
-      Pathname.new(@root).join("config") if @root
+      @root.join("config") if @root
     end
 
     def load_config(config_file)

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -441,7 +441,7 @@ module Bundler
         Pathname.new(ENV["BUNDLE_USER_CONFIG"])
       elsif ENV["BUNDLE_USER_HOME"] && !ENV["BUNDLE_USER_HOME"].empty?
         Pathname.new(ENV["BUNDLE_USER_HOME"]).join("config")
-      elsif Bundler.rubygems.user_home && !Bundler.rubygems.user_home.empty?
+      else
         Pathname.new(Bundler.rubygems.user_home).join(".bundle/config")
       end
     end

--- a/bundler/lib/bundler/settings/validator.rb
+++ b/bundler/lib/bundler/settings/validator.rb
@@ -86,7 +86,7 @@ module Bundler
         root = begin
                  Bundler.root
                rescue GemfileNotFound
-                 Pathname.pwd.expand_path
+                 Pathname.pwd
                end
 
         path = begin

--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -13,13 +13,13 @@ module Bundler
     def root
       gemfile = find_gemfile
       raise GemfileNotFound, "Could not locate Gemfile" unless gemfile
-      Pathname.new(gemfile).tap{|x| x.untaint if RUBY_VERSION < "2.7" }.expand_path.parent
+      expand(gemfile).parent
     end
 
     def default_gemfile
       gemfile = find_gemfile
       raise GemfileNotFound, "Could not locate Gemfile" unless gemfile
-      Pathname.new(gemfile).tap{|x| x.untaint if RUBY_VERSION < "2.7" }.expand_path
+      expand(gemfile)
     end
 
     def default_lockfile
@@ -199,6 +199,10 @@ module Bundler
     end
 
     private
+
+    def expand(file)
+      Pathname.new(file).tap{|x| x.untaint if RUBY_VERSION < "2.7" }.expand_path
+    end
 
     def validate_bundle_path
       path_separator = Bundler.rubygems.path_separator

--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -26,9 +26,9 @@ module Bundler
       gemfile = default_gemfile
 
       case gemfile.basename.to_s
-      when "gems.rb" then Pathname.new(gemfile.sub(/.rb$/, ".locked"))
-      else Pathname.new("#{gemfile}.lock")
-      end.tap{|x| x.untaint if RUBY_VERSION < "2.7" }
+      when "gems.rb" then gemfile.sub(/.rb$/, ".locked")
+      else gemfile.sub(/$/, ".lock")
+      end
     end
 
     def default_bundle_dir

--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -36,8 +36,12 @@ module Bundler
     end
 
     def find_gemfile
-      given = ENV["BUNDLE_GEMFILE"]
-      return expand(given) if given && !given.empty?
+      require_relative "../bundler"
+      find_gemfile_if_empty(Bundler.settings[:gemfile])
+    end
+
+    def find_gemfile_if_empty(candidate)
+      return expand(candidate) if candidate && !candidate.empty?
       find_file(*gemfile_names)
     end
 

--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -240,7 +240,7 @@ module Bundler
 
     def search_up(*names)
       previous = nil
-      current  = File.expand_path(SharedHelpers.pwd).tap{|x| x.untaint if RUBY_VERSION < "2.7" }
+      current  = File.expand_path(pwd).tap{|x| x.untaint if RUBY_VERSION < "2.7" }
 
       until !File.directory?(current) || current == previous
         if ENV["BUNDLER_SPEC_RUN"]
@@ -286,16 +286,16 @@ module Bundler
       # bundler is a default gem, exe path is separate
       exe_file = Bundler.rubygems.bin_path("bundler", "bundle", VERSION) unless File.exist?(exe_file)
 
-      Bundler::SharedHelpers.set_env "BUNDLE_BIN_PATH", exe_file
-      Bundler::SharedHelpers.set_env "BUNDLE_GEMFILE", find_gemfile.to_s
-      Bundler::SharedHelpers.set_env "BUNDLER_VERSION", Bundler::VERSION
+      set_env "BUNDLE_BIN_PATH", exe_file
+      set_env "BUNDLE_GEMFILE", find_gemfile.to_s
+      set_env "BUNDLER_VERSION", Bundler::VERSION
     end
 
     def set_path
       validate_bundle_path
       paths = (ENV["PATH"] || "").split(File::PATH_SEPARATOR)
       paths.unshift "#{Bundler.bundle_path}/bin"
-      Bundler::SharedHelpers.set_env "PATH", paths.uniq.join(File::PATH_SEPARATOR)
+      set_env "PATH", paths.uniq.join(File::PATH_SEPARATOR)
     end
 
     def set_rubyopt
@@ -303,13 +303,13 @@ module Bundler
       setup_require = "-r#{File.expand_path("setup", __dir__)}"
       return if !rubyopt.empty? && rubyopt.first =~ /#{setup_require}/
       rubyopt.unshift setup_require
-      Bundler::SharedHelpers.set_env "RUBYOPT", rubyopt.join(" ")
+      set_env "RUBYOPT", rubyopt.join(" ")
     end
 
     def set_rubylib
       rubylib = (ENV["RUBYLIB"] || "").split(File::PATH_SEPARATOR)
       rubylib.unshift bundler_ruby_lib unless RbConfig::CONFIG["rubylibdir"] == bundler_ruby_lib
-      Bundler::SharedHelpers.set_env "RUBYLIB", rubylib.uniq.join(File::PATH_SEPARATOR)
+      set_env "RUBYLIB", rubylib.uniq.join(File::PATH_SEPARATOR)
     end
 
     def bundler_ruby_lib

--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -238,7 +238,7 @@ module Bundler
 
     def search_up(*names)
       previous = nil
-      current  = pwd.tap{|x| x.untaint if RUBY_VERSION < "2.7" }.expand_path
+      current  = pwd.tap{|x| x.untaint if RUBY_VERSION < "2.7" }
 
       until !current.directory? || current == previous
         if ENV["BUNDLER_SPEC_RUN"]

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -12,7 +12,7 @@ module Bundler
       # Ask for X gems per API request
       API_REQUEST_SIZE = 50
 
-      attr_reader :remotes, :caches
+      attr_reader :remotes
 
       def initialize(options = {})
         @options = options
@@ -21,9 +21,12 @@ module Bundler
         @allow_remote = false
         @allow_cached = false
         @allow_local = options["allow_local"] || false
-        @caches = [cache_path, *Bundler.rubygems.gem_cache]
 
         Array(options["remotes"]).reverse_each {|r| add_remote(r) }
+      end
+
+      def caches
+        @caches ||= [cache_path, *Bundler.rubygems.gem_cache]
       end
 
       def local_only!
@@ -362,9 +365,9 @@ module Bundler
 
       def cached_path(spec)
         global_cache_path = download_cache_path(spec)
-        @caches << global_cache_path if global_cache_path
+        caches << global_cache_path if global_cache_path
 
-        possibilities = @caches.map {|p| "#{p}/#{spec.file_name}" }
+        possibilities = caches.map {|p| "#{p}/#{spec.file_name}" }
         possibilities.find {|p| File.exist?(p) }
       end
 

--- a/bundler/spec/bundler/bundler_spec.rb
+++ b/bundler/spec/bundler/bundler_spec.rb
@@ -210,18 +210,18 @@ EOF
   describe "#user_home" do
     context "home directory is set" do
       it "should return the user home" do
-        path = "/home/oggy"
+        path = Pathname("/home/oggy")
         allow(Bundler.rubygems).to receive(:user_home).and_return(path)
-        allow(File).to receive(:directory?).with(path).and_return true
-        allow(File).to receive(:writable?).with(path).and_return true
-        expect(Bundler.user_home).to eq(Pathname(path))
+        allow(path).to receive(:directory?).and_return true
+        allow(path).to receive(:writable?).and_return true
+        expect(Bundler.user_home).to eq(path)
       end
 
       context "is not a directory" do
         it "should issue a warning and return a temporary user home" do
-          path = "/home/oggy"
+          path = Pathname("/home/oggy")
           allow(Bundler.rubygems).to receive(:user_home).and_return(path)
-          allow(File).to receive(:directory?).with(path).and_return false
+          allow(path).to receive(:directory?).and_return false
           allow(Bundler).to receive(:tmp).and_return(Pathname.new("/tmp/trulyrandom"))
           expect(Bundler.ui).to receive(:warn).with("`/home/oggy` is not a directory.\n")
           expect(Bundler.ui).to receive(:warn).with("Bundler will use `/tmp/trulyrandom' as your home directory temporarily.\n")
@@ -230,14 +230,14 @@ EOF
       end
 
       context "is not writable" do
-        let(:path) { "/home/oggy" }
-        let(:dotbundle) { "/home/oggy/.bundle" }
+        let(:path) { Pathname("/home/oggy") }
+        let(:dotbundle) { Pathname("/home/oggy/.bundle") }
 
         it "should issue a warning and return a temporary user home" do
           allow(Bundler.rubygems).to receive(:user_home).and_return(path)
-          allow(File).to receive(:directory?).with(path).and_return true
-          allow(File).to receive(:writable?).with(path).and_return false
-          allow(File).to receive(:directory?).with(dotbundle).and_return false
+          allow(path).to receive(:directory?).and_return true
+          allow(path).to receive(:writable?).and_return false
+          allow(dotbundle).to receive(:directory?).and_return false
           allow(Bundler).to receive(:tmp).and_return(Pathname.new("/tmp/trulyrandom"))
           expect(Bundler.ui).to receive(:warn).with("`/home/oggy` is not writable.\n")
           expect(Bundler.ui).to receive(:warn).with("Bundler will use `/tmp/trulyrandom' as your home directory temporarily.\n")
@@ -247,11 +247,11 @@ EOF
         context ".bundle exists and have correct permissions" do
           it "should return the user home" do
             allow(Bundler.rubygems).to receive(:user_home).and_return(path)
-            allow(File).to receive(:directory?).with(path).and_return true
-            allow(File).to receive(:writable?).with(path).and_return false
-            allow(File).to receive(:directory?).with(dotbundle).and_return true
-            allow(File).to receive(:writable?).with(dotbundle).and_return true
-            expect(Bundler.user_home).to eq(Pathname(path))
+            allow(path).to receive(:directory?).and_return true
+            allow(path).to receive(:writable?).and_return true
+            allow(dotbundle).to receive(:directory?).and_return true
+            allow(dotbundle).to receive(:writable?).and_return true
+            expect(Bundler.user_home).to eq(path)
           end
         end
       end

--- a/bundler/spec/bundler/bundler_spec.rb
+++ b/bundler/spec/bundler/bundler_spec.rb
@@ -370,6 +370,45 @@ MESSAGE
     end
   end
 
+  describe "#default_bundle_dir" do
+    before do
+      allow(Pathname).to receive(:pwd).and_return(bundled_app)
+    end
+
+    context ".bundle does not exist" do
+      it "returns nil" do
+        expect(subject.default_bundle_dir).to be_nil
+      end
+    end
+
+    context ".bundle is global .bundle" do
+      let(:global_rubygems_dir) { Pathname.new(bundled_app) }
+
+      before do
+        Dir.mkdir bundled_app(".bundle")
+        allow(Bundler.rubygems).to receive(:user_home).and_return(global_rubygems_dir)
+      end
+
+      it "returns nil" do
+        expect(subject.default_bundle_dir).to be_nil
+      end
+    end
+
+    context ".bundle is not global .bundle" do
+      let(:global_rubygems_dir)      { Pathname.new("/path/rubygems") }
+      let(:expected_bundle_dir_path) { Pathname.new("#{bundled_app}/.bundle") }
+
+      before do
+        Dir.mkdir bundled_app(".bundle")
+        allow(Bundler.rubygems).to receive(:user_home).and_return(global_rubygems_dir)
+      end
+
+      it "returns the .bundle path" do
+        expect(subject.default_bundle_dir).to eq(expected_bundle_dir_path)
+      end
+    end
+  end
+
   context "user cache dir" do
     let(:home_path)                  { Pathname.new(ENV["HOME"]) }
 

--- a/bundler/spec/bundler/bundler_spec.rb
+++ b/bundler/spec/bundler/bundler_spec.rb
@@ -256,16 +256,6 @@ EOF
         end
       end
     end
-
-    context "home directory is not set" do
-      it "should issue warning and return a temporary user home" do
-        allow(Bundler.rubygems).to receive(:user_home).and_return(nil)
-        allow(Bundler).to receive(:tmp).and_return(Pathname.new("/tmp/trulyrandom"))
-        expect(Bundler.ui).to receive(:warn).with("Your home directory is not set.\n")
-        expect(Bundler.ui).to receive(:warn).with("Bundler will use `/tmp/trulyrandom' as your home directory temporarily.\n")
-        expect(Bundler.user_home).to eq(Pathname("/tmp/trulyrandom"))
-      end
-    end
   end
 
   describe "#requires_sudo?" do

--- a/bundler/spec/bundler/definition_spec.rb
+++ b/bundler/spec/bundler/definition_spec.rb
@@ -5,7 +5,6 @@ require "bundler/definition"
 RSpec.describe Bundler::Definition do
   describe "#lock" do
     before do
-      allow(Bundler).to receive(:settings) { Bundler::Settings.new(".") }
       allow(Bundler::SharedHelpers).to receive(:find_gemfile) { Pathname.new("Gemfile") }
       allow(Bundler).to receive(:ui) { double("UI", :info => "", :debug => "") }
     end

--- a/bundler/spec/bundler/plugin/index_spec.rb
+++ b/bundler/spec/bundler/plugin/index_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Bundler::Plugin::Index do
   Index = Bundler::Plugin::Index
 
   before do
-    allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+    allow(Pathname).to receive(:pwd).and_return(bundled_app)
     gemfile "source \"#{file_uri_for(gem_repo1)}\""
     path = lib_path(plugin_name)
     index.register_plugin("new-plugin", path.to_s, [path.join("lib").to_s], commands, sources, hooks)

--- a/bundler/spec/bundler/plugin_spec.rb
+++ b/bundler/spec/bundler/plugin_spec.rb
@@ -243,7 +243,8 @@ RSpec.describe Bundler::Plugin do
   describe "#root" do
     context "in app dir" do
       before do
-        allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+        allow(Pathname).to receive(:pwd).and_return(bundled_app)
+        FileUtils.touch(bundled_app.join("Gemfile"))
       end
 
       it "returns plugin dir in app .bundle path" do
@@ -253,7 +254,7 @@ RSpec.describe Bundler::Plugin do
 
     context "outside app dir" do
       before do
-        allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(nil)
+        allow(Bundler::SharedHelpers).to receive(:pwd).and_return(root)
       end
 
       it "returns plugin dir in global bundle path" do

--- a/bundler/spec/bundler/settings_spec.rb
+++ b/bundler/spec/bundler/settings_spec.rb
@@ -65,9 +65,9 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
   describe "#global_config_file" do
     context "when $HOME is not accessible" do
       it "does not raise" do
-        expect(Bundler.rubygems).to receive(:user_home).twice.and_return(nil)
+        expect(Bundler.rubygems).to receive(:user_home).twice.and_return(Pathname.new("/"))
 
-        expect(subject.send(:global_config_file)).to be_nil
+        expect(subject.send(:global_config_file)).to eq(Pathname.new("/.bundle/config"))
       end
     end
   end

--- a/bundler/spec/bundler/settings_spec.rb
+++ b/bundler/spec/bundler/settings_spec.rb
@@ -127,7 +127,7 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
 
   describe "#temporary" do
     it "reset after used" do
-      allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+      allow(Pathname).to receive(:pwd).and_return(bundled_app)
 
       Bundler.settings.set_command_option :no_install, true
 

--- a/bundler/spec/bundler/settings_spec.rb
+++ b/bundler/spec/bundler/settings_spec.rb
@@ -5,17 +5,6 @@ require "bundler/settings"
 RSpec.describe Bundler::Settings do
   subject(:settings) { described_class.new(bundled_app) }
 
-  describe "#set_local" do
-    context "when the local config file is not found" do
-      subject(:settings) { described_class.new(nil) }
-
-      it "raises a GemfileNotFound error with explanation" do
-        expect { subject.set_local("foo", "bar") }.
-          to raise_error(Bundler::GemfileNotFound, "Could not locate Gemfile")
-      end
-    end
-  end
-
   describe "load_config" do
     let(:hash) do
       {
@@ -73,16 +62,6 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
   end
 
   describe "#[]" do
-    context "when the local config file is not found" do
-      subject(:settings) { described_class.new }
-
-      it "does not raise" do
-        expect do
-          subject["foo"]
-        end.not_to raise_error
-      end
-    end
-
     context "when not set" do
       context "when default value present" do
         it "retrieves value" do

--- a/bundler/spec/bundler/shared_helpers_spec.rb
+++ b/bundler/spec/bundler/shared_helpers_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Bundler::SharedHelpers do
         after { FileUtils.rm(bundled_app_gemfile) }
 
         it "returns path of the bundle Gemfile" do
-          expect(subject.in_bundle?).to eq("#{bundled_app}/Gemfile")
+          expect(subject.in_bundle?).to eq(bundled_app_gemfile)
         end
       end
 
@@ -131,7 +131,7 @@ RSpec.describe Bundler::SharedHelpers do
       before { ENV["BUNDLE_GEMFILE"] = "/path/Gemfile" }
 
       it "returns ENV['BUNDLE_GEMFILE']" do
-        expect(subject.in_bundle?).to eq("/path/Gemfile")
+        expect(subject.in_bundle?).to eq(Pathname.new("/path/Gemfile").expand_path)
       end
     end
 

--- a/bundler/spec/bundler/shared_helpers_spec.rb
+++ b/bundler/spec/bundler/shared_helpers_spec.rb
@@ -69,41 +69,6 @@ RSpec.describe Bundler::SharedHelpers do
     end
   end
 
-  describe "#default_bundle_dir" do
-    context ".bundle does not exist" do
-      it "returns nil" do
-        expect(subject.default_bundle_dir).to be_nil
-      end
-    end
-
-    context ".bundle is global .bundle" do
-      let(:global_rubygems_dir) { Pathname.new(bundled_app) }
-
-      before do
-        Dir.mkdir bundled_app(".bundle")
-        allow(Bundler.rubygems).to receive(:user_home).and_return(global_rubygems_dir)
-      end
-
-      it "returns nil" do
-        expect(subject.default_bundle_dir).to be_nil
-      end
-    end
-
-    context ".bundle is not global .bundle" do
-      let(:global_rubygems_dir)      { Pathname.new("/path/rubygems") }
-      let(:expected_bundle_dir_path) { Pathname.new("#{bundled_app}/.bundle") }
-
-      before do
-        Dir.mkdir bundled_app(".bundle")
-        allow(Bundler.rubygems).to receive(:user_home).and_return(global_rubygems_dir)
-      end
-
-      it "returns the .bundle path" do
-        expect(subject.default_bundle_dir).to eq(expected_bundle_dir_path)
-      end
-    end
-  end
-
   describe "#in_bundle?" do
     it "calls the find_gemfile method" do
       expect(subject).to receive(:find_gemfile)

--- a/bundler/spec/commands/config_spec.rb
+++ b/bundler/spec/commands/config_spec.rb
@@ -71,6 +71,21 @@ RSpec.describe ".bundle/config" do
       expect(the_bundle).to include_gems "rack 1.0.0", :dir => bundled_app("omg")
     end
 
+    it "allows configuring Gemfile" do
+      FileUtils.mkdir_p bundled_app("omg/gmo")
+
+      gemfile bundled_app("omg/gmo/AnotherGemfile"), <<-G
+        source "#{file_uri_for(gem_repo1)}"
+      G
+
+      bundle "config set --local gemfile omg/gmo/AnotherGemfile"
+
+      bundle "install"
+
+      expect(out).to include("0 Gemfile dependencies")
+      expect(the_bundle).not_to include_gems "rack 1.0.0"
+    end
+
     it "is relative to the Gemfile if there's no previous configuration" do
       FileUtils.mkdir_p bundled_app("omg/gmo")
 
@@ -570,17 +585,33 @@ end
 
 RSpec.describe "setting gemfile via config" do
   context "when only the non-default Gemfile exists" do
-    it "persists the gemfile location to .bundle/config" do
+    before do
       gemfile bundled_app("NotGemfile"), <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
       G
 
       bundle "config set --local gemfile #{bundled_app("NotGemfile")}"
+    end
+
+    it "persists the gemfile location to .bundle/config" do
       expect(File.exist?(bundled_app(".bundle/config"))).to eq(true)
 
       bundle "config list"
       expect(out).to include("NotGemfile")
+    end
+
+    it "gets used when requiring bundler/setup" do
+      bundle :install
+      code = "puts $LOAD_PATH.count {|path| path =~ /rack/} == 1"
+
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+      G
+
+      ruby code, :env => { "RUBYOPT" => "-r#{lib_dir}/bundler/setup" }
+
+      expect(out).to eq("true")
     end
   end
 end

--- a/bundler/spec/plugins/install_spec.rb
+++ b/bundler/spec/plugins/install_spec.rb
@@ -184,7 +184,7 @@ RSpec.describe "bundler plugin install" do
 
   context "Gemfile eval" do
     before do
-      allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+      allow(Pathname).to receive(:pwd).and_return(bundled_app)
     end
 
     it "installs plugins listed in gemfile" do
@@ -293,7 +293,7 @@ RSpec.describe "bundler plugin install" do
 
   describe "local plugin" do
     it "is installed when inside an app" do
-      allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+      allow(Pathname).to receive(:pwd).and_return(bundled_app)
       gemfile ""
       bundle "plugin install foo --source #{file_uri_for(gem_repo2)}"
 

--- a/bundler/spec/plugins/source_spec.rb
+++ b/bundler/spec/plugins/source_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "bundler source plugin" do
         end
       G
 
-      allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+      allow(Pathname).to receive(:pwd).and_return(bundled_app)
       plugin_should_be_installed("bundler-source-psource")
     end
 
@@ -76,7 +76,7 @@ RSpec.describe "bundler source plugin" do
         end
 
         it "installs the explicit one" do
-          allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+          allow(Pathname).to receive(:pwd).and_return(bundled_app)
           plugin_should_be_installed("another-psource")
         end
 
@@ -102,7 +102,7 @@ RSpec.describe "bundler source plugin" do
         end
 
         it "installs the default one" do
-          allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+          allow(Pathname).to receive(:pwd).and_return(bundled_app)
           plugin_should_be_installed("bundler-source-psource")
         end
       end

--- a/bundler/spec/runtime/load_spec.rb
+++ b/bundler/spec/runtime/load_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Bundler.load" do
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
-      allow(Bundler::SharedHelpers).to receive(:pwd).and_return(bundled_app)
+      allow(Pathname).to receive(:pwd).and_return(bundled_app)
     end
 
     it "provides a list of the env dependencies" do
@@ -33,7 +33,7 @@ RSpec.describe "Bundler.load" do
         gem "rack"
       G
       bundle :install
-      allow(Bundler::SharedHelpers).to receive(:pwd).and_return(bundled_app)
+      allow(Pathname).to receive(:pwd).and_return(bundled_app)
     end
 
     it "provides a list of the env dependencies" do
@@ -103,7 +103,7 @@ RSpec.describe "Bundler.load" do
         source "#{file_uri_for(gem_repo1)}"
         gem "activerecord"
       G
-      allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+      allow(Pathname).to receive(:pwd).and_return(bundled_app)
       Bundler.load.specs.each do |spec|
         expect(spec.to_yaml).not_to match(/^\s+source:/)
         expect(spec.to_yaml).not_to match(/^\s+groups:/)

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -180,7 +180,6 @@ module Spec
 
     def sys_exec(cmd, options = {})
       env = options[:env] || {}
-      env["RUBYOPT"] = opt_add(opt_add("-r#{spec_dir}/support/switch_rubygems.rb", env["RUBYOPT"]), ENV["RUBYOPT"])
       dir = options[:dir] || bundled_app
       command_execution = CommandExecution.new(cmd.to_s, dir)
 


### PR DESCRIPTION
This PR ports https://github.com/rubygems/bundler/pull/6713 from the old repository.

### What was the end-user problem that led to this PR?

There are two related end-user problems.

* When a custom `Gemfile` is configured via `BUNDLE_GEMFILE` and we run `bundle config`, the local config is not generated in the current working directory. The reason is in the diagnosis section, but the end user problem is that it is very counterintuitive. On bundler 2 this is aggravated because of "sticky options". See https://github.com/bundler/bundler/issues/2048#issuecomment-7615264 for an example.

* When configuring a custom gemfile via settings, it is not respected when requiring `bundler/setup`. See #6589.

### What was your diagnosis of the problem?

My diagnosis was that the config location is currently resolved from the current `Gemfile` location, and that leads to configuration being created on counterintuitive locations. For example, you have `BUNDLE_GEMFILE` set to a particular non-root location, and run `bundle config` on the root folder, but no local config is apparently generated... until you figure out it's being generated in the same folder `BUNDLE_GEMFILE` is pointing to.

Also, since the config location depends on the location of the current `Gemfile`, we can't consistently resolve the `Gemfile` from configuration, because of a chicken-and-egg problem. We need the `Gemfile` to figure out where the config is, but we need the config to figure out where the `Gemfile` is. This is why #3363 can't currently work.

### What is your fix for the problem, implemented in this PR?

My fix was to change how we resolve the configuration root, and instead look up in the directory hierarchy for an existing local config, and otherwise default to the current working directory. With that in place, fixing #6589 is easy. My changes led to a single spec failure. Even if it's just one, it is backwards incompatible if backwards compatibility is defined by our current set of specs. Since I'd like to be able to opt-in to the new behavior right now on bundler 1, I made a feature flag for this change. This feature flag needed to be different from the other feature flags we currently have, because it can't be config-based (chicken-and-egg problem again). So I introduced "env-based feature flags".

Once we have the new configuration root resolution in place, the fix for #6589 is to add knowledge to the `find_gemfile` method to read from settings (and not just from env).

### Why did you choose this fix out of the possible options?

I chose this fix because changing the way we resolve configuration seemed like the only way to resolve the problems that I wanted to fix here.

Fixes https://github.com/rubygems/rubygems/issues/3363.
Fixes https://github.com/rubygems/bundler/issues/2048 (the remaining part of it, https://github.com/rubygems/bundler/issues/2048#issuecomment-7615264 and https://github.com/rubygems/bundler/issues/2048#issuecomment-47390038).
Fixes https://github.com/rubygems/rubygems/issues/3294.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).