### PR TITLE
Deduplicate spec groups

### DIFF
--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -160,8 +160,7 @@ module Bundler
         selected_sgs << sg_ruby if sg_ruby
         sg_all_platforms = nil
         all_platforms = @platforms + [platform]
-        sorted_all_platforms = self.class.sort_platforms(all_platforms)
-        sorted_all_platforms.reverse_each do |other_platform|
+        self.class.sort_platforms(all_platforms).reverse_each do |other_platform|
           if sg_all_platforms.nil?
             sg_all_platforms = sg.copy_for(other_platform)
           else

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -158,8 +158,9 @@ module Bundler
         # spec group.
         sg_ruby = sg.copy_for(Gem::Platform::RUBY)
         selected_sgs << sg_ruby if sg_ruby
-        sg_all_platforms = nil
         all_platforms = @platforms + [platform]
+        next if all_platforms.to_a == [Gem::Platform::RUBY]
+        sg_all_platforms = nil
         self.class.sort_platforms(all_platforms).reverse_each do |other_platform|
           if sg_all_platforms.nil?
             sg_all_platforms = sg.copy_for(other_platform)

--- a/bundler/spec/install/gems/resolving_spec.rb
+++ b/bundler/spec/install/gems/resolving_spec.rb
@@ -107,10 +107,13 @@ RSpec.describe "bundle install with install-time dependencies" do
 
         bundle :install, :env => { "DEBUG_RESOLVER_TREE" => "1" }
 
+        activated_groups = "net_b (1.0) (ruby)"
+        activated_groups += ", net_b (1.0) (#{local_platforms.join(", ")})" if local_platforms.any? && local_platforms != ["ruby"]
+
         expect(err).to include(" net_b").
           and include("BUNDLER: Starting resolution").
           and include("BUNDLER: Finished resolution").
-          and include("Attempting to activate")
+          and include("Attempting to activate [#{activated_groups}]")
       end
     end
   end


### PR DESCRIPTION
# Description:
#
While debugging resolver issues, I noticed that in the recent bundler versions, spec groups show up as duplicated, like this:

```
(...)
BUNDLER: Starting resolution (2020-09-25 22:03:05 +0200)
BUNDLER: User-requested dependencies: [#<Bundler::DepProxy:0x000055f2f02cbf80 @dep=<Bundler::Dependency type=:runtime name="rails" requirements="~> 4.2.7.1">, @__platform="ruby">, #<Bundler::DepProxy:0x000055f2f02cbd50 @dep=<Bundler::Dependency type=:runtime name="paperclip" requirements="~> 5.1.0">, @__platform="ruby">, #<Bundler::DepProxy:0x000055f2f02cbb48 @dep=<Bundler::Dependency type=:runtime name="Ruby\u0000" requirements=">= 0">, @__platform="ruby">, #<Bundler::DepProxy:0x000055f2f02cb940 @dep=<Bundler::Dependency type=:runtime name="RubyGems\u0000" requirements="= 3.2.0.rc.1" prerelease=ok>, @__platform="ruby">]
Resolving dependencies...
BUNDLER: Creating possibility state for Ruby (1 remaining)
BUNDLER:   Attempting to activate [Ruby (2.7.1.83) (ruby), Ruby (2.7.1.83) (ruby)]
BUNDLER:   Activated Ruby at [Ruby (2.7.1.83) (ruby), Ruby (2.7.1.83) (ruby)]
BUNDLER:   Requiring nested dependencies ()
BUNDLER:   Creating possibility state for RubyGems (= 3.2.0.rc.1) (1 remaining)
BUNDLER:     Attempting to activate [RubyGems (3.2.0.rc.1) (ruby), RubyGems (3.2.0.rc.1) (ruby)]
BUNDLER:     Activated RubyGems at [RubyGems (3.2.0.rc.1) (ruby), RubyGems (3.2.0.rc.1) (ruby)]
BUNDLER:     Requiring nested dependencies ()
BUNDLER:     Creating possibility state for rails (~> 4.2.7.1) (1 remaining)
BUNDLER:       Attempting to activate [rails (4.2.7.1) (ruby), rails (4.2.7.1) (ruby)]
BUNDLER:       Activated rails at [rails (4.2.7.1) (ruby), rails (4.2.7.1) (ruby)]
BUNDLER:       Requiring nested dependencies (activesupport (= 4.2.7.1), actionpack (= 4.2.7.1), actionview (= 4.2.7.1), activemodel (= 4.2.7.1), activerecord (= 4.2.7.1), actionmailer (= 4.2.7.1), activejob (= 4.2.7.1), railties (= 4.2.7.1), bundler (>= 1.3.0, < 2.0), sprockets-rails)
BUNDLER:       Creating possibility state for paperclip (~> 5.1.0) (1 remaining)
BUNDLER:         Attempting to activate [paperclip (5.1.0) (ruby), paperclip (5.1.0) (ruby)]
BUNDLER:         Activated paperclip at [paperclip (5.1.0) (ruby), paperclip (5.1.0) (ruby)]
BUNDLER:         Requiring nested dependencies (activemodel (>= 4.2.0), activesupport (>= 4.2.0), cocaine (~> 0.5.5), mime-types, mimemagic (~> 0.3.0))
BUNDLER:         Creating possibility state for bundler (>= 1.3.0, < 2.0) (0 remaining)
BUNDLER:           Unwinding for conflict: bundler (>= 1.3.0, < 2.0) to -1

BUNDLER: Finished resolution (5 steps) (Took 0.040514367 seconds) (2020-09-25 22:03:05 +0200)
(...)
```

Not sure if this has any influence in the resolution process, but it's certainly inconvenient for debugging and it didn't happen in previous versions.

With these changes, we get deduplicated groups again:

```
BUNDLER: Starting resolution (2020-09-25 22:04:23 +0200)
BUNDLER: User-requested dependencies: [#<Bundler::DepProxy:0x00005633db9d2ed8 @dep=<Bundler::Dependency type=:runtime name="rails" requirements="~> 4.2.7.1">, @__platform="ruby">, #<Bundler::DepProxy:0x00005633db9d2d98 @dep=<Bundler::Dependency type=:runtime name="paperclip" requirements="~> 5.1.0">, @__platform="ruby">, #<Bundler::DepProxy:0x00005633db9d2c58 @dep=<Bundler::Dependency type=:runtime name="Ruby\u0000" requirements=">= 0">, @__platform="ruby">, #<Bundler::DepProxy:0x00005633db9d2b18 @dep=<Bundler::Dependency type=:runtime name="RubyGems\u0000" requirements="= 3.2.0.rc.1" prerelease=ok>, @__platform="ruby">]
Resolving dependencies...
BUNDLER: Creating possibility state for Ruby (1 remaining)
BUNDLER:   Attempting to activate [Ruby (2.7.1.83) (ruby)]
BUNDLER:   Activated Ruby at [Ruby (2.7.1.83) (ruby)]
BUNDLER:   Requiring nested dependencies ()
BUNDLER:   Creating possibility state for RubyGems (= 3.2.0.rc.1) (1 remaining)
BUNDLER:     Attempting to activate [RubyGems (3.2.0.rc.1) (ruby)]
BUNDLER:     Activated RubyGems at [RubyGems (3.2.0.rc.1) (ruby)]
BUNDLER:     Requiring nested dependencies ()
BUNDLER:     Creating possibility state for rails (~> 4.2.7.1) (1 remaining)
BUNDLER:       Attempting to activate [rails (4.2.7.1) (ruby)]
BUNDLER:       Activated rails at [rails (4.2.7.1) (ruby)]
BUNDLER:       Requiring nested dependencies (activesupport (= 4.2.7.1), actionpack (= 4.2.7.1), actionview (= 4.2.7.1), activemodel (= 4.2.7.1), activerecord (= 4.2.7.1), actionmailer (= 4.2.7.1), activejob (= 4.2.7.1), railties (= 4.2.7.1), bundler (>= 1.3.0, < 2.0), sprockets-rails)
BUNDLER:       Creating possibility state for paperclip (~> 5.1.0) (1 remaining)
BUNDLER:         Attempting to activate [paperclip (5.1.0) (ruby)]
BUNDLER:         Activated paperclip at [paperclip (5.1.0) (ruby)]
BUNDLER:         Requiring nested dependencies (activemodel (>= 4.2.0), activesupport (>= 4.2.0), cocaine (~> 0.5.5), mime-types, mimemagic (~> 0.3.0))
BUNDLER:         Creating possibility state for bundler (>= 1.3.0, < 2.0) (0 remaining)
BUNDLER:           Unwinding for conflict: bundler (>= 1.3.0, < 2.0) to -1

BUNDLER: Finished resolution (5 steps) (Took 0.036523214 seconds) (2020-09-25 22:04:23 +0200)
```

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).