### PR TITLE
Add Reverse Dependencies section to info command

### DIFF
--- a/bundler/lib/bundler/cli/info.rb
+++ b/bundler/lib/bundler/cli/info.rb
@@ -73,13 +73,22 @@ module Bundler
       gem_info << "\tBug Tracker: #{metadata["bug_tracker_uri"]}\n" if metadata.key?("bug_tracker_uri")
       gem_info << "\tMailing List: #{metadata["mailing_list_uri"]}\n" if metadata.key?("mailing_list_uri")
       gem_info << "\tPath: #{spec.full_gem_path}\n"
-      gem_info << "\tDefault Gem: yes" if spec.respond_to?(:default_gem?) && spec.default_gem?
+      gem_info << "\tDefault Gem: yes\n" if spec.respond_to?(:default_gem?) && spec.default_gem?
+      gem_info << "\tReverse Dependencies: \n\t\t#{gem_dependencies.join("\n\t\t")}" if gem_dependencies.any?
 
       if name != "bundler" && spec.deleted_gem?
         return Bundler.ui.warn "The gem #{name} has been deleted. Gemspec information is still available though:\n#{gem_info}"
       end
 
       Bundler.ui.info gem_info
+    end
+
+    def gem_dependencies
+      @gem_dependencies ||= Bundler.definition.specs.map do |spec|
+        dependency = spec.dependencies.find {|dep| dep.name == gem_name }
+        next unless dependency
+        "#{spec.name} (#{spec.version}) depends on #{gem_name} (#{dependency.requirements_list.join(", ")})"
+      end.compact.sort
     end
   end
 end

--- a/bundler/spec/commands/info_spec.rb
+++ b/bundler/spec/commands/info_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe "bundle info" do
         source "#{file_uri_for(gem_repo2)}"
         gem "rails"
         gem "has_metadata"
+        gem "thin"
       G
     end
 
@@ -121,6 +122,30 @@ RSpec.describe "bundle info" do
 
       it "excludes the homepage field from the output" do
         expect(out).to_not include("Homepage:")
+      end
+    end
+
+    context "when gem has a reverse dependency on any version" do
+      it "prints the details" do
+        bundle "info rack"
+
+        expect(out).to include("Reverse Dependencies: \n\t\tthin (1.0) depends on rack (>= 0)")
+      end
+    end
+
+    context "when gem has a reverse dependency on a specific version" do
+      it "prints the details" do
+        bundle "info actionpack"
+
+        expect(out).to include("Reverse Dependencies: \n\t\trails (2.3.2) depends on actionpack (= 2.3.2)")
+      end
+    end
+
+    context "when gem has no reverse dependencies" do
+      it "excludes the reverse dependencies field from the output" do
+        bundle "info rails"
+
+        expect(out).not_to include("Reverse Dependencies:")
       end
     end
   end


### PR DESCRIPTION
# Description:

Add a 'Reverse Dependencies' section at the bottom of the info command
output.

## What was the end-user or developer problem that led to this PR?

This intends to provide a better alternative to manually searching the
lockfile for dependency information.

## What is your fix for the problem, implemented in this PR?

This displays the name, version, and imposed version
requirements of all gems in the bundle that depend on the given gem.

Note: This PR was originally at https://github.com/rubygems/bundler/pull/7165, then moved to https://github.com/rubygems/rubygems/pull/3436, and is now here.  Hopefully the 3rd try is the charm 🙂 

Fixes https://github.com/rubygems/rubygems/issues/3336.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [x] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
