### PR TITLE
Install to correct plugins dir when using `--build-root`

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -696,7 +696,7 @@ class Gem::Installer
       @bin_dir = File.join(@build_root, @bin_dir.gsub(/^[a-zA-Z]:/, ''))
       @gem_home = File.join(@build_root, @gem_home.gsub(/^[a-zA-Z]:/, ''))
       @plugins_dir = File.join(@build_root, @plugins_dir.gsub(/^[a-zA-Z]:/, ''))
-      alert_warning "You build with buildroot.\n  Build root: #{@build_root}\n  Bin dir: #{@bin_dir}\n  Gem home: #{@gem_home}"
+      alert_warning "You build with buildroot.\n  Build root: #{@build_root}\n  Bin dir: #{@bin_dir}\n  Gem home: #{@gem_home}\n  Plugins dir: #{@plugins_dir}"
     end
   end
 

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -695,6 +695,7 @@ class Gem::Installer
     unless @build_root.nil?
       @bin_dir = File.join(@build_root, @bin_dir.gsub(/^[a-zA-Z]:/, ''))
       @gem_home = File.join(@build_root, @gem_home.gsub(/^[a-zA-Z]:/, ''))
+      @plugins_dir = File.join(@build_root, @plugins_dir.gsub(/^[a-zA-Z]:/, ''))
       alert_warning "You build with buildroot.\n  Build root: #{@build_root}\n  Bin dir: #{@bin_dir}\n  Gem home: #{@gem_home}"
     end
   end

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -798,6 +798,31 @@ gem 'other', version
     assert File.exist?(user_path), 'plugin not written to user plugins_dir'
   end
 
+  def test_generate_plugins_with_build_root
+    spec = quick_gem 'a' do |s|
+      write_file File.join(@tempdir, 'lib', 'rubygems_plugin.rb') do |io|
+        io.write "puts __FILE__"
+      end
+
+      s.files += %w[lib/rubygems_plugin.rb]
+    end
+
+    util_build_gem spec
+
+    File.chmod(0555, Gem.plugindir)
+    system_path = File.join(Gem.plugindir, 'a_plugin.rb')
+
+    build_root = File.join(@tempdir, 'build_root')
+    build_root_path = File.join(build_root, Gem.plugindir.gsub(/^[a-zA-Z]:/, ''), 'a_plugin.rb')
+
+    installer = Gem::Installer.at spec.cache_file, :build_root => build_root
+
+    assert_equal spec, installer.install
+
+    assert !File.exist?(system_path), 'plugin written incorrect written to system plugins_dir'
+    assert File.exist?(build_root_path), 'plugin not written to build_root'
+  end
+
   def test_keeps_plugins_up_to_date
     # NOTE: version a-2 is already installed by setup hooks
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1818,6 +1818,7 @@ gem 'other', version
     build_root = File.join @tempdir, 'build_root'
     bin_dir = File.join(build_root, @gemhome.gsub(/^[a-zA-Z]:/, ''), 'bin')
     gem_home = File.join(build_root, @gemhome.gsub(/^[a-zA-Z]:/, ''))
+    plugins_dir = File.join(build_root, @gemhome.gsub(/^[a-zA-Z]:/, ''), 'plugins')
 
     @gem = setup_base_gem
     installer = use_ui(@ui) { Gem::Installer.at @gem, :build_root => build_root }
@@ -1832,6 +1833,7 @@ gem 'other', version
     assert_equal "  Build root: #{build_root}", errors.shift
     assert_equal "  Bin dir: #{bin_dir}", errors.shift
     assert_equal "  Gem home: #{gem_home}", errors.shift
+    assert_equal "  Plugins dir: #{plugins_dir}", errors.shift
   end
 
   def test_shebang_arguments

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1791,13 +1791,22 @@ gem 'other', version
 
   def test_process_options_build_root
     build_root = File.join @tempdir, 'build_root'
+    bin_dir = File.join(build_root, @gemhome.gsub(/^[a-zA-Z]:/, ''), 'bin')
+    gem_home = File.join(build_root, @gemhome.gsub(/^[a-zA-Z]:/, ''))
 
     @gem = setup_base_gem
-    installer = Gem::Installer.at @gem, :build_root => build_root
+    installer = use_ui(@ui) { Gem::Installer.at @gem, :build_root => build_root }
 
     assert_equal build_root, installer.build_root
-    assert_equal File.join(build_root, @gemhome.gsub(/^[a-zA-Z]:/, ''), 'bin'), installer.bin_dir
-    assert_equal File.join(build_root, @gemhome.gsub(/^[a-zA-Z]:/, '')), installer.gem_home
+    assert_equal bin_dir, installer.bin_dir
+    assert_equal gem_home, installer.gem_home
+
+    errors = @ui.error.split("\n")
+
+    assert_equal "WARNING:  You build with buildroot.", errors.shift
+    assert_equal "  Build root: #{build_root}", errors.shift
+    assert_equal "  Bin dir: #{bin_dir}", errors.shift
+    assert_equal "  Gem home: #{gem_home}", errors.shift
   end
 
   def test_shebang_arguments


### PR DESCRIPTION
# Description:

We missed this case when introducing the new plugins layout.

As a bonus, I added a few minor improvements and refactoring to this option.

Fixes #3971.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).