### PR TITLE
Disable `fail-fast` mode in CI

### DIFF
--- a/.github/workflows/daily-bundler.yml
+++ b/.github/workflows/daily-bundler.yml
@@ -8,9 +8,6 @@ jobs:
   daily_bundler:
     runs-on: ubuntu-18.04
     if: github.repository == 'rubygems/rubygems'
-    strategy:
-      matrix:
-        ruby: [ ruby-head ]
     env:
       RGV: ..
     steps:
@@ -19,7 +16,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: ruby-head
           bundler: none
 
       - name: Show Ruby version

--- a/.github/workflows/daily-rubygems.yml
+++ b/.github/workflows/daily-rubygems.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-18.04
     if: github.repository == 'rubygems/rubygems'
     strategy:
+      fail-fast: false
       matrix:
         ruby: [ ruby-head, truffleruby-head ]
     env:

--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -12,6 +12,7 @@ jobs:
   install_rubygems:
     runs-on: ubuntu-18.04
     strategy:
+      fail-fast: false
       matrix:
         ruby: [ 2.3.8, 2.4.10, 2.5.8, 2.6.6, 2.7.1, jruby-9.2.11.1 ]
         openssl: [true, false]

--- a/.github/workflows/macos-rubygems.yml
+++ b/.github/workflows/macos-rubygems.yml
@@ -12,6 +12,7 @@ jobs:
   macos_rubygems:
     runs-on: macos-10.15
     strategy:
+      fail-fast: false
       matrix:
         ruby: [ 2.4.10, 2.5.8, 2.6.6, 2.7.1 ]
     steps:

--- a/.github/workflows/older-rubygems-bundler.yml
+++ b/.github/workflows/older-rubygems-bundler.yml
@@ -16,6 +16,7 @@ jobs:
   older_rubygems_bundler:
     runs-on: ubuntu-18.04
     strategy:
+      fail-fast: false
       matrix:
         ruby: [ 2.3.8, 2.4.10, 2.5.8, 2.6.6, 2.7.1 ]
         rgv: [ v2.5.2, v2.6.14, v2.7.10, v3.0.8, v3.1.4 ]

--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -12,6 +12,7 @@ jobs:
   ruby_core:
     runs-on: ubuntu-18.04
     strategy:
+      fail-fast: false
       matrix:
         target: [rubygems, bundler]
     steps:

--- a/.github/workflows/ubuntu-bundler.yml
+++ b/.github/workflows/ubuntu-bundler.yml
@@ -12,6 +12,7 @@ jobs:
   ubuntu_bundler:
     runs-on: ubuntu-18.04
     strategy:
+      fail-fast: false
       matrix:
         ruby: [ 2.3.8, 2.4.10, 2.5.8, 2.6.6, 2.7.1 ]
         bundler: [ '', 3.0.0 ]

--- a/.github/workflows/ubuntu-rubygems.yml
+++ b/.github/workflows/ubuntu-rubygems.yml
@@ -12,6 +12,7 @@ jobs:
   ubuntu_rubygems:
     runs-on: ubuntu-18.04
     strategy:
+      fail-fast: false
       matrix:
         ruby: [ 2.3.8, 2.4.10, 2.5.8, 2.6.6, 2.7.1, jruby-9.2.11.1, truffleruby-20.2.0 ]
     env:

--- a/.github/workflows/windows-bundler.yml
+++ b/.github/workflows/windows-bundler.yml
@@ -16,6 +16,7 @@ jobs:
       RGV: ..
 
     strategy:
+      fail-fast: false
       matrix:
         ruby: [ '2.4', '2.5', '2.6', '2.7' ]
 

--- a/.github/workflows/windows-rubygems.yml
+++ b/.github/workflows/windows-rubygems.yml
@@ -12,6 +12,7 @@ jobs:
   windows_rubygems:
     runs-on: windows-2019
     strategy:
+      fail-fast: false
       matrix:
         ruby: [ 2.4.10, 2.5.8, 2.6.6, 2.7.1 ]
     steps:


### PR DESCRIPTION
Github Actions "fails fast" by default. However, most of the times when I get an unexpected build failure, I'll want to know if it's specific to a ruby-version or other variables our matrix use, so a `fail-fast: false` by default is more useful to me.

This is obviously heavier, but not that much heavier I believe because by the time a job fails, other jobs might already be closed to completion, and this does not affect the majority of cases where everything passes.  

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).