### PR TITLE
Fix `--build-root` flag under Windows

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -695,7 +695,7 @@ class Gem::Installer
     unless @build_root.nil?
       require 'pathname'
       @build_root = Pathname.new(@build_root).expand_path
-      @bin_dir = File.join(@build_root, options[:bin_dir] || Gem.bindir(@gem_home))
+      @bin_dir = File.join(@build_root, @bin_dir)
       @gem_home = File.join(@build_root, @gem_home)
       alert_warning "You build with buildroot.\n  Build root: #{@build_root}\n  Bin dir: #{@bin_dir}\n  Gem home: #{@gem_home}"
     end

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -694,7 +694,7 @@ class Gem::Installer
 
     unless @build_root.nil?
       require 'pathname'
-      @build_root = Pathname.new(@build_root).expand_path
+      @build_root = Pathname.new(@build_root)
       @bin_dir = File.join(@build_root, @bin_dir)
       @gem_home = File.join(@build_root, @gem_home)
       alert_warning "You build with buildroot.\n  Build root: #{@build_root}\n  Bin dir: #{@bin_dir}\n  Gem home: #{@gem_home}"

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -693,8 +693,6 @@ class Gem::Installer
     @build_args = options[:build_args] || Gem::Command.build_args
 
     unless @build_root.nil?
-      require 'pathname'
-      @build_root = Pathname.new(@build_root)
       @bin_dir = File.join(@build_root, @bin_dir)
       @gem_home = File.join(@build_root, @gem_home)
       alert_warning "You build with buildroot.\n  Build root: #{@build_root}\n  Bin dir: #{@bin_dir}\n  Gem home: #{@gem_home}"

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -693,8 +693,8 @@ class Gem::Installer
     @build_args = options[:build_args] || Gem::Command.build_args
 
     unless @build_root.nil?
-      @bin_dir = File.join(@build_root, @bin_dir)
-      @gem_home = File.join(@build_root, @gem_home)
+      @bin_dir = File.join(@build_root, @bin_dir.gsub(/^[a-zA-Z]:/, ''))
+      @gem_home = File.join(@build_root, @gem_home.gsub(/^[a-zA-Z]:/, ''))
       alert_warning "You build with buildroot.\n  Build root: #{@build_root}\n  Bin dir: #{@bin_dir}\n  Gem home: #{@gem_home}"
     end
   end

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1156,6 +1156,15 @@ gem 'other', version
     assert_path_exists gem_dir
   end
 
+  def test_install_build_root
+    build_root = File.join(@tempdir, 'build_root')
+
+    @gem = setup_base_gem
+    installer = Gem::Installer.at @gem, :build_root => build_root
+
+    assert_equal @spec, installer.install
+  end
+
   def test_install_missing_dirs
     installer = setup_base_installer
 
@@ -1787,8 +1796,8 @@ gem 'other', version
     installer = Gem::Installer.at @gem, :build_root => build_root
 
     assert_equal build_root, installer.build_root
-    assert_equal File.join(build_root, @gemhome, 'bin'), installer.bin_dir
-    assert_equal File.join(build_root, @gemhome), installer.gem_home
+    assert_equal File.join(build_root, @gemhome.gsub(/^[a-zA-Z]:/, ''), 'bin'), installer.bin_dir
+    assert_equal File.join(build_root, @gemhome.gsub(/^[a-zA-Z]:/, '')), installer.gem_home
   end
 
   def test_shebang_arguments

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1786,7 +1786,7 @@ gem 'other', version
     @gem = setup_base_gem
     installer = Gem::Installer.at @gem, :build_root => build_root
 
-    assert_equal Pathname(build_root), installer.build_root
+    assert_equal build_root, installer.build_root
     assert_equal File.join(build_root, @gemhome, 'bin'), installer.bin_dir
     assert_equal File.join(build_root, @gemhome), installer.gem_home
   end

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -794,7 +794,7 @@ gem 'other', version
 
     assert_equal spec, installer.install
 
-    assert !File.exist?(system_path), 'plugin not written to user plugins_dir'
+    assert !File.exist?(system_path), 'plugin incorrectly written to system plugins_dir'
     assert File.exist?(user_path), 'plugin not written to user plugins_dir'
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The `--build-root` flag is broken under Windows, because invalid paths are generated.

## What is your fix for the problem, implemented in this PR?

Trim drive letters to generate a valid path.

This PR also includes some minor refactorings.

This issue was discovered by the regression spec added in https://github.com/rubygems/rubygems/pull/3972.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).