### PR TITLE
Remove old workaround for non-git environments

### DIFF
--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -9,7 +9,7 @@ on:
       - 3.2
 
 jobs:
-  install_rubygems:
+  install_rubygems_ubuntu:
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
@@ -51,4 +51,21 @@ jobs:
       - name: Check bundler install didn't hit the network
         run: if grep -q 'GET http' output.txt; then false; else true; fi
         working-directory: ./bundler
+    timeout-minutes: 10
+
+  install_rubygems_windows:
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.1
+          bundler: none
+      - name: Install rubygems
+        run: ruby setup.rb
+        shell: bash
+      - name: Check installation didn't modify gemspec line feeds
+        run: ruby -Ilib -e'exit 1 if File.readlines("bundler/bundler.gemspec").first.end_with?("\r\n")'
+        shell: bash
     timeout-minutes: 10

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -394,10 +394,6 @@ By default, this RubyGems will install gem as:
     specs_dir = File.join(options[:destdir], specs_dir) unless Gem.win_platform?
     mkdir_p specs_dir, :mode => 0755
 
-    # Workaround for non-git environment.
-    gemspec = File.open('bundler/bundler.gemspec', 'rb'){|f| f.read.gsub(/`git ls-files -z`/, "''") }
-    File.open('bundler/bundler.gemspec', 'w'){|f| f.write gemspec }
-
     bundler_spec = Gem::Specification.load("bundler/bundler.gemspec")
     bundler_spec.files = Dir.chdir("bundler") { Dir["{*.md,{lib,exe,man}/**/*}"] }
     bundler_spec.executables -= %w[bundler bundle_ruby]


### PR DESCRIPTION
# Description:

I noticed that running `ruby setup.rb` was rewriting the `bundler.gemspec` when I run it on Windows on a shared folder and noticed that all line feeds had been rewritten.

This is no longer necessary since we no longer use `git` in bundler's gemspec.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).