### PR TITLE
Fix spec failure under weird situations

### DIFF
--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -13,6 +13,7 @@ require "bundler"
 require "rspec/core"
 require "rspec/expectations"
 require "rspec/mocks"
+require "diff/lcs"
 
 require_relative "support/builders"
 require_relative "support/build_metadata"


### PR DESCRIPTION
To reproduce:

* Make sure you have at least two different versions of `diff-lcs` on your system.
* Run `bin/rspec spec/quality_spec.rb:170`.

Then you'll get a failure like this:

```
Run options:
  include {:locations=>{"./spec/quality_spec.rb"=>[170]}}
  exclude {:jruby=>true, :readline=>false, :permissions=>false, :no_color_tty=>false, :ruby_repo=>false, :bundler=>"!= 2", :git=>"!= 2.28.0", :rubygems=>"!= 3.2.0.rc.1", :realworld=>true, :sudo=>true}

Randomized with seed 40105
WARN: Unresolved or ambiguous specs during Gem::Specification.reset:
      diff-lcs (>= 1.2.0, < 2.0)
      Available/installed versions of this gem:
      - 1.4.4
      - 1.3
WARN: Clearing out unresolved specs. Try 'gem cleanup <gem>'
Please report a bug if this causes problems.
F

Retried examples: 0

Failures:

  1) The library itself documents all used settings
     Failure/Error: differ = RSpec::Support::Differ.new

     LoadError:
       cannot load such file -- diff/lcs

       Commands:
       $ git ls-files -z -- lib
       lib/bundler.rblib/bundler/build_metadata.rb(...)
       # $? => 0
     # ./spec/support/matchers.rb:85:in `block (3 levels) in <module:Matchers>'
     # ./spec/support/matchers.rb:83:in `tap'
     # ./spec/support/matchers.rb:83:in `block (2 levels) in <module:Matchers>'
     # ./spec/quality_spec.rb:209:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:111:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:111:in `block (3 levels) in <top (required)>'
     # ./spec/support/helpers.rb:352:in `block in with_gem_path_as'
     # ./spec/support/helpers.rb:366:in `without_env_side_effects'
     # ./spec/support/helpers.rb:348:in `with_gem_path_as'
     # ./spec/spec_helper.rb:110:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:82:in `block (2 levels) in <top (required)>'
     # ./spec/support/rubygems_ext.rb:90:in `load'
     # ./spec/support/rubygems_ext.rb:90:in `gem_load_and_activate'
     # ./spec/support/rubygems_ext.rb:18:in `gem_load'

Finished in 1.15 seconds (files took 0.16514 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/quality_spec.rb:170 # The library itself documents all used settings

Randomized with seed 40105
```

The reason for the failure is that:

* Since there's several different `diff-lcs` versions on our system, rubygems will leave the actual version unresolved and delay the final resolution to the time the dependency is required.
* `diff/lcs` ends up being required when our specs have already called `Gem::Specification.reset` to set the path of the dummy test gems.

The two above mean at require time of `diff-lcs`, rubygems no longer has the information to find it.

To fix this issue, we require `diff-lcs` eagerly.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).