### PR TITLE
Fix SystemStackError when overriding `Warning.warn`

### DIFF
--- a/lib/rubygems/core_ext/kernel_warn.rb
+++ b/lib/rubygems/core_ext/kernel_warn.rb
@@ -45,10 +45,9 @@ if RUBY_VERSION >= "2.5"
             end
           end
         end
-        uplevel = start
+        kw[:uplevel] = start
       end
 
-      kw[:uplevel] = uplevel
       original_warn.call(*messages, **kw)
     }
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When overriding `Warning.warn` like this:

```ruby
module Warning
  def warn(str)
    # some custom pre-processing of the warning message
    super
  end
end

warn 'Foo Bar'
```

Rubygems would throw a `SystemStackError`.

## What is your fix for the problem, implemented in this PR?

While experimenting with a solution, I changed our monkeypatch to use `prepend` instead, and that revealed an off-by-one error in the implementation. The previous implementation was working because (I have no idea why), two duplicated entries were present in the callstack for `kernel_require.rb`, automatically "correcting" the issue.

This implementation feels better and works as expected with `Warning.warn`.

Fixes #2588.

# Tasks:

- [x] Describe the problem / feature
- [x] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).