### PR TITLE
Fix some warnings during `bin/rake spec:deps`

### DIFF
--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -77,81 +77,80 @@ namespace :man do
   if RUBY_ENGINE == "jruby"
     task(:build) {}
   else
-    begin
-      Spec::Rubygems.gem_require("ronn")
-    rescue Gem::LoadError => e
-      desc "Build the man pages"
-      task(:build) { abort "We couldn't activate ronn (#{e.requirement}). Try `gem install ronn:'#{e.requirement}'` to be able to build the help pages" }
+    directory "man"
 
-      desc "Verify man pages are in sync"
-      task(:check) { abort "We couldn't activate ronn (#{e.requirement}). Try `gem install ronn:'#{e.requirement}'` to be able to build the help pages" }
-    else
-      directory "man"
+    index = Dir["man/*.ronn"].map do |source|
+      ronn = "man/#{File.basename(source)}"
+      roff = "man/#{File.basename(source, ".ronn")}"
 
-      index = Dir["man/*.ronn"].map do |source|
-        ronn = "man/#{File.basename(source)}"
-        roff = "man/#{File.basename(source, ".ronn")}"
-
-        file roff => ["man", ronn] do
-          date = ENV["MAN_PAGES_DATE"] || Time.now.strftime("%Y-%m-%d")
-          sh "bin/ronn --warnings --roff --pipe --date #{date} #{ronn} > #{roff}"
-        end
-
-        task :build_all_pages => roff
-
-        [ronn, File.basename(roff)]
+      file roff => ["man", ronn] do
+        date = ENV["MAN_PAGES_DATE"] || Time.now.strftime("%Y-%m-%d")
+        sh "bin/ronn --warnings --roff --pipe --date #{date} #{ronn} > #{roff}"
       end
 
-      file "index.txt" do
-        index.map! do |(ronn, roff)|
-          [File.read(ronn).split(" ").first, roff]
-        end
-        index = index.sort_by(&:first)
-        justification = index.map {|(n, _f)| n.length }.max + 4
-        File.open("man/index.txt", "w") do |f|
-          index.each do |name, filename|
-            f << name.ljust(justification) << filename << "\n"
-          end
+      task :build_all_pages => roff
+
+      [ronn, File.basename(roff)]
+    end
+
+    file "index.txt" do
+      index.map! do |(ronn, roff)|
+        [File.read(ronn).split(" ").first, roff]
+      end
+      index = index.sort_by(&:first)
+      justification = index.map {|(n, _f)| n.length }.max + 4
+      File.open("man/index.txt", "w") do |f|
+        index.each do |name, filename|
+          f << name.ljust(justification) << filename << "\n"
         end
       end
-      task :build_all_pages => "index.txt"
+    end
+    task :build_all_pages => "index.txt"
 
-      desc "Remove all built man pages"
-      task :clean do
-        leftovers = Dir["man/*"].reject do |f|
-          File.extname(f) == ".ronn"
-        end
-        rm leftovers if leftovers.any?
+    desc "Make sure ronn is installed"
+    task :check_ronn do
+      begin
+        Spec::Rubygems.gem_require("ronn")
+      rescue Gem::LoadError => e
+        abort("We couldn't activate ronn (#{e.requirement}). Try `gem install ronn:'#{e.requirement}'` to be able to build the help pages")
       end
+    end
 
-      desc "Build the man pages"
-      task :build => [:clean, :build_all_pages]
-
-      desc "Sets target date for building man pages to the one currently present"
-      task :set_current_date do
-        require "date"
-        ENV["MAN_PAGES_DATE"] = Date.parse(File.readlines("man/bundle-add.1")[3].split('"')[5]).strftime("%Y-%m-%d")
+    desc "Remove all built man pages"
+    task :clean do
+      leftovers = Dir["man/*"].reject do |f|
+        File.extname(f) == ".ronn"
       end
+      rm leftovers if leftovers.any?
+    end
 
-      desc "Verify man pages are in sync"
-      task :check => [:set_current_date, :build] do
-        require "open3"
+    desc "Build the man pages"
+    task :build => [:check_ronn, :clean, :build_all_pages]
 
-        output, status = Open3.capture2e("git status --porcelain")
+    desc "Sets target date for building man pages to the one currently present"
+    task :set_current_date do
+      require "date"
+      ENV["MAN_PAGES_DATE"] = Date.parse(File.readlines("man/bundle-add.1")[3].split('"')[5]).strftime("%Y-%m-%d")
+    end
 
-        if status.success? && output.empty?
-          puts
-          puts "Man pages are in sync"
-          puts
-        else
-          sh("git status --porcelain")
+    desc "Verify man pages are in sync"
+    task :check => [:check_ronn, :set_current_date, :build] do
+      require "open3"
 
-          puts
-          puts "Man pages are out of sync. Above you can see the list of files that got modified or generated from rebuilding them. Please review and commit the results."
-          puts
+      output, status = Open3.capture2e("git status --porcelain")
 
-          exit(1)
-        end
+      if status.success? && output.empty?
+        puts
+        puts "Man pages are in sync"
+        puts
+      else
+        sh("git status --porcelain")
+
+        puts
+        puts "Man pages are out of sync. Above you can see the list of files that got modified or generated from rebuilding them. Please review and commit the results."
+        puts
+
+        exit(1)
       end
     end
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If you have multiple versions of `mustache` or `rdiscount` installed on your system and you run `bin/rake spec:deps` from the root of the `bundler` folder, you'll get warnings like this:

```
WARN: Unresolved or ambiguous specs during Gem::Specification.reset:
      rdiscount (>= 1.5.8)
      Available/installed versions of this gem:
      - 2.2.0.2
      - 2.2.0.1
      mustache (>= 0.7.0)
      Available/installed versions of this gem:
      - 1.1.1
      - 1.0.5
      - 0.99.8
WARN: Clearing out unresolved specs. Try 'gem cleanup <gem>'
Please report a bug if this causes problems.
```

The explanation is that loading the `Rakefile` requires `ronn` for loading the man pages tasks. `rdiscount` and `mustache` are dependencies of `ronn`, but since there are multiple versions of them on the system, they are left unresolved until they are eventually required. However, during `bin/rake spec:deps`, `bundler` will change the rubygems environment to prepare for the specs and eventually calls `Gem::Specification.reset` to apply new gem paths. Since these gems are unresolved at that time, a warning is printed.

## What is your fix for the problem, implemented in this PR?

The solution is to lazily require ronn only when man pages tasks are actually run.

This commit is best viewed [ignoring whitespace changes](https://github.com/rubygems/rubygems/pull/3986/files?w=1).

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).