### PR TITLE
Preserve `self` when calling the original Kernel#warn method

### DIFF
--- a/lib/rubygems/core_ext/kernel_warn.rb
+++ b/lib/rubygems/core_ext/kernel_warn.rb
@@ -6,7 +6,7 @@ if RUBY_VERSION >= "2.5"
   module Kernel
     rubygems_path = "#{__dir__}/" # Frames to be skipped start with this path.
 
-    original_warn = method(:warn)
+    original_warn = instance_method(:warn)
 
     remove_method :warn
 
@@ -17,9 +17,9 @@ if RUBY_VERSION >= "2.5"
     module_function define_method(:warn) {|*messages, **kw|
       unless uplevel = kw[:uplevel]
         if Gem.java_platform?
-          return original_warn.call(*messages)
+          return original_warn.bind(self).call(*messages)
         else
-          return original_warn.call(*messages, **kw)
+          return original_warn.bind(self).call(*messages, **kw)
         end
       end
 
@@ -48,7 +48,7 @@ if RUBY_VERSION >= "2.5"
         kw[:uplevel] = start
       end
 
-      original_warn.call(*messages, **kw)
+      original_warn.bind(self).call(*messages, **kw)
     }
   end
 end

--- a/lib/rubygems/core_ext/kernel_warn.rb
+++ b/lib/rubygems/core_ext/kernel_warn.rb
@@ -45,10 +45,9 @@ if RUBY_VERSION >= "2.5"
             end
           end
         end
-        uplevel = start
+        kw[:uplevel] = start
       end
 
-      kw[:uplevel] = uplevel
       original_warn.call(*messages, **kw)
     }
   end


### PR DESCRIPTION
Alternative to https://github.com/rubygems/rubygems/pull/3985 which does not require adding a new module next to Kernel, and also works if some class inherits from `BasicObject` and `include Kernel`.

* This fixes infinite recursion when monkey-patching Warning#warn, which is [not recommended](https://github.com/rubygems/rubygems/issues/2588#issuecomment-702379220), but still should behave the same whether RubyGems is loaded or not.
* Fixes https://github.com/rubygems/rubygems/issues/2588.

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

cc @deivid-rodriguez 
