### PR TITLE
Append '.gemspec' extension only when it is not present.

### DIFF
--- a/lib/rubygems/commands/build_command.rb
+++ b/lib/rubygems/commands/build_command.rb
@@ -79,7 +79,7 @@ Gems can be saved to a specified filename with the output option:
   end
 
   def build_gem(gem_name)
-    gemspec = File.exist?(gem_name) ? gem_name : "#{gem_name}.gemspec"
+    gemspec = File.extname(gem_name) == ".gemspec" ? gem_name : "#{gem_name}.gemspec"
 
     if File.exist?(gemspec)
       spec = Gem::Specification.load(gemspec)

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -273,7 +273,7 @@ class TestGemCommandsBuildCommand < Gem::TestCase
   end
 
   def test_can_find_gemspecs_without_dot_gemspec
-    gemspec_file = File.join(@tempdir, @gem.spec_name)
+    gemspec_file = File.join(@tempdir, @gem.name)
 
     File.open gemspec_file + ".gemspec", 'w' do |gs|
       gs.write @gem.to_ruby


### PR DESCRIPTION
This avoids confusing messages such as:

~~~
$ gem build *.gemspec
ERROR:  Gemspec file not found: *.gemspec.gemspec
~~~

Please note that the `TestGemCommandsBuildCommand#test_can_find_gemspecs_without_dot_gemspec`
testcase was probably wrong from the beginning, trying to apply `.gemspec` extension to `@gem.spec_name`, which already contains the extension.

Fixes minor issue mentioned in #3953.
