### PR TITLE
Strip off trailing whitespace and punctuation for PR titles

### DIFF
--- a/util/changelog.rb
+++ b/util/changelog.rb
@@ -132,7 +132,7 @@ class Changelog
 
   def format_entry_for(pull)
     new_entry = entry_template
-      .gsub(/%pull_request_title/, pull.title)
+      .gsub(/%pull_request_title/, pull.title.strip.delete_suffix("."))
       .gsub(/%pull_request_number/, pull.number.to_s)
       .gsub(/%pull_request_url/, pull.html_url)
       .gsub(/%pull_request_author/, pull.user.name || pull.user.login)


### PR DESCRIPTION
# Description:

Leave it up to the `.changelog.yml` file how this is handled.

This allows us to "forget" removing trailing punctuation from PR titles that include it and still get a nicely formatted changelog without double trailing dots.

Fixes https://github.com/rubygems/rubygems/issues/3961.

# Tasks:

- [x] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).