### PR TITLE
Fix `bin/rake release:prepare` task

### DIFF
--- a/bundler/task/release.rake
+++ b/bundler/task/release.rake
@@ -46,7 +46,7 @@ namespace :release do
     version = opts[:version]
     changelog = Changelog.for_bundler(version)
 
-    branch = version.segments.map.with_index {|s, i| i == 0 ? s + 1 : s }[0, 2].join(".")
+    branch = Gem::Version.new(version).segments.map.with_index {|s, i| i == 0 ? s + 1 : s }[0, 2].join(".")
 
     previous_branch = `git rev-parse --abbrev-ref HEAD`.strip
     release_branch = "release_bundler/#{version}"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I run `bin/rake release:prepare[2.2.0.rc.2]` and it crashed.

## What is your fix for the problem, implemented in this PR?

The version given in the CLI is a String, not a `Gem::Version`.

Create a proper Gem::Version.

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)