### PR TITLE
Improve the independence of bundler specs from rubygems

### DIFF
--- a/bundler/spec/commands/clean_spec.rb
+++ b/bundler/spec/commands/clean_spec.rb
@@ -625,8 +625,10 @@ RSpec.describe "bundle clean" do
     expect(out).to eq("1.0")
   end
 
-  it "when using --force, it doesn't remove default gem binaries", :rubygems => ">= 3.2.0.rc.1" do
+  it "when using --force, it doesn't remove default gem binaries" do
     skip "does not work on ruby 3.0 because it changes the path to look for default gems, tsort is a default gem there, and we can't install it either like we do with fiddle because it doesn't yet exist" unless RUBY_VERSION < "3.0.0"
+
+    skip "does not work on rubygems versions where `--install_dir` doesn't respect --default" unless Gem::Installer.for_spec(loaded_gemspec, :install_dir => "/foo").default_spec_file == "/foo/specifications/default/bundler-#{Bundler::VERSION}.gemspec" # Since rubygems 3.2.0.rc.2
 
     default_irb_version = ruby "gem 'irb', '< 999999'; require 'irb'; puts IRB::VERSION", :raise_on_error => false
     skip "irb isn't a default gem" if default_irb_version.empty?

--- a/bundler/spec/support/filters.rb
+++ b/bundler/spec/support/filters.rb
@@ -26,7 +26,6 @@ RSpec.configure do |config|
 
   git_version = Bundler::Source::Git::GitProxy.new(nil, nil, nil).version
 
-  config.filter_run_excluding :rubygems => RequirementChecker.against(Gem::VERSION)
   config.filter_run_excluding :git => RequirementChecker.against(git_version)
   config.filter_run_excluding :bundler => RequirementChecker.against(Bundler::VERSION.split(".")[0])
   config.filter_run_excluding :ruby_repo => !ENV["GEM_COMMAND"].nil?


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

While creating the release PR for the next bundler version, I got a failure because I hadn't backport a rubygems PR. I shouldn't need to backport any rubygems specific PRs to get the CI green on the stable branch.

## What is your fix for the problem, implemented in this PR?

I made the spec detect whether the rubygems version it's running against has the fix it needs, and skip the spec otherwise.

Also, since the :rubygems filter was unused, I removed it, since I feel it's best to always do this kind of feature detection rather than hardcoding version checks.

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)