### PR TITLE
Remove more code that made lib/ and test/ dependent on each other

### DIFF
--- a/test/rubygems/test_bundled_ca.rb
+++ b/test/rubygems/test_bundled_ca.rb
@@ -15,15 +15,10 @@ require 'rubygems/request'
 #
 
 class TestBundledCA < Gem::TestCase
-  THIS_FILE = File.expand_path __FILE__
-
   def bundled_certificate_store
     store = OpenSSL::X509::Store.new
 
-    ssl_cert_glob =
-      File.expand_path '../../../lib/rubygems/ssl_certs/*/*.pem', THIS_FILE
-
-    Dir[ssl_cert_glob].each do |ssl_cert|
+    Gem::Request.get_cert_files.each do |ssl_cert|
       store.add_file ssl_cert
     end
 


### PR DESCRIPTION
This is a followup to https://github.com/rubygems/rubygems/pull/4001, fixing the same kind of issue in another place.

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)