### PR TITLE
Fixed the missing require for Changelog class

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -278,6 +278,7 @@ namespace 'blog' do
     name  = `git config --get user.name`.strip
     email = `git config --get user.email`.strip
 
+    require_relative "util/changelog"
     history = Changelog.for_rubygems(v.to_s)
 
     require 'tempfile'


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When I invoked `rake blog:publish`, It failed caused by the missing library.

## What is your fix for the problem, implemented in this PR?

Added `util/changelog` for its task.

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
