### PR TITLE
Merge rubygems 3.2.0.rc.2 and remove some stuff that was not actually released

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -2,10 +2,6 @@
 
 Minor enhancements:
 
-* Don't hit the network when installing dependencyless local gemspec. Pull
-  request #3968 by deivid-rodriguez
-* Add `--force` option to `gem sources` command. Pull request #3956 by
-  andy-smith-msm
 * Make --dry-run flag consistent across rubygems commands. Pull request
   #3867 by bronzdoc
 * Disallow downgrades to too old versions. Pull request #3566 by
@@ -23,16 +19,6 @@ Minor enhancements:
 
 Bug fixes:
 
-* Append '.gemspec' extension only when it is not present.. Pull request
-  #3988 by voxik
-* Install to correct plugins dir when using `--build-root`. Pull request
-  #3972 by deivid-rodriguez
-* Fix `--build-root` flag under Windows. Pull request #3975 by
-  deivid-rodriguez
-* Fix `typo_squatting?` false positive for `rubygems.org` itself. Pull
-  request #3951 by andy-smith-msm
-* Make `--default` and `--install-dir` options to `gem install` play nice
-  together. Pull request #3906 by deivid-rodriguez
 * Add missing fileutils require. Pull request #3911 by deivid-rodriguez
 * Fix false positive warning on Windows when PATH has
   `File::ALT_SEPARATOR`. Pull request #3829 by deivid-rodriguez
@@ -45,8 +31,6 @@ Bug fixes:
 
 Performance:
 
-* Don't change ruby process CWD when building extensions. Pull request
-  #3498 by deivid-rodriguez
 * Avoid duplicated generation of APISpecification objects. Pull request
   #3940 by mame
 * Eval defaults with frozen_string_literal: true. Pull request #3847 by

--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,60 @@
+=== 3.2.0.rc.2 / 2020-10-8
+
+Minor enhancements:
+
+* Don't hit the network when installing dependencyless local gemspec. Pull
+  request #3968 by deivid-rodriguez
+* Add `--force` option to `gem sources` command. Pull request #3956 by
+  andy-smith-msm
+* Make --dry-run flag consistent across rubygems commands. Pull request
+  #3867 by bronzdoc
+* Disallow downgrades to too old versions. Pull request #3566 by
+  deivid-rodriguez
+* Added `--platform` option to `build` command. Pull request #3079 by nobu
+* Have "gem update --system" pass through the `--silent` flag. Pull
+  request #3789 by duckinator
+* Add writable check for cache dir. Pull request #3876 by xndcn
+* Warn on duplicate dependency in a specification. Pull request #3864 by
+  bronzdoc
+* Fix indentation in `gem env`. Pull request #3861 by colby-swandale
+* Let more exceptions flow. Pull request #3819 by deivid-rodriguez
+* Ignore internal frames in RubyGems' Kernel#warn. Pull request #3810 by
+  eregon
+
+Bug fixes:
+
+* Append '.gemspec' extension only when it is not present.. Pull request
+  #3988 by voxik
+* Install to correct plugins dir when using `--build-root`. Pull request
+  #3972 by deivid-rodriguez
+* Fix `--build-root` flag under Windows. Pull request #3975 by
+  deivid-rodriguez
+* Fix `typo_squatting?` false positive for `rubygems.org` itself. Pull
+  request #3951 by andy-smith-msm
+* Make `--default` and `--install-dir` options to `gem install` play nice
+  together. Pull request #3906 by deivid-rodriguez
+* Add missing fileutils require. Pull request #3911 by deivid-rodriguez
+* Fix false positive warning on Windows when PATH has
+  `File::ALT_SEPARATOR`. Pull request #3829 by deivid-rodriguez
+* Fix Kernel#warn override to handle backtrace location with nil path.
+  Pull request #3852 by jeremyevans
+* Don't format executables on `gem update --system`. Pull request #3811 by
+  deivid-rodriguez
+* `gem install --user` fails with `Gem::FilePermissionError` on the system
+  plugins directory. Pull request #3804 by nobu
+
+Performance:
+
+* Don't change ruby process CWD when building extensions. Pull request
+  #3498 by deivid-rodriguez
+* Avoid duplicated generation of APISpecification objects. Pull request
+  #3940 by mame
+* Eval defaults with frozen_string_literal: true. Pull request #3847 by
+  casperisfine
+* Deduplicate the requirement operators in memory. Pull request #3846 by
+  casperisfine
+* Optimize Gem.already_loaded?. Pull request #3793 by casperisfine
+
 === 3.2.0.rc.1 / 2020-07-04
 
 Major enhancements:

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -8,7 +8,7 @@
 require 'rbconfig'
 
 module Gem
-  VERSION = "3.2.0.rc.1".freeze
+  VERSION = "3.2.0.rc.2".freeze
 end
 
 # Must be first since it unloads the prelude from 1.9.2

--- a/rubygems-update.gemspec
+++ b/rubygems-update.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "rubygems-update"
-  s.version = "3.2.0.rc.1"
+  s.version = "3.2.0.rc.2"
   s.authors = ["Jim Weirich", "Chad Fowler", "Eric Hodel", "Luis Lavena", "Aaron Patterson", "Samuel Giddins", "André Arko", "Evan Phoenix", "Hiroshi SHIBATA"]
   s.email = ["", "", "drbrain@segment7.net", "luislavena@gmail.com", "aaron@tenderlovemaking.com", "segiddins@segiddins.me", "andre@arko.net", "evan@phx.io", "hsbt@ruby-lang.org"]
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Due to a discrepancy in bundler & rubygems release workflows, changelog was generated including PRs that were not actually released.

## What is your fix for the problem, implemented in this PR?

Fix the changelog manually for now to reflect what was released.

Closes https://github.com/rubygems/rubygems/issues/4007.

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)