### PR TITLE
Lazily load `time`, `cgi`, and `zlib`

### DIFF
--- a/lib/rubygems/indexer.rb
+++ b/lib/rubygems/indexer.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require 'rubygems'
 require 'rubygems/package'
-require 'time'
 require 'tmpdir'
 
 ##

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -44,7 +44,6 @@
 require "rubygems"
 require 'rubygems/security'
 require 'rubygems/user_interaction'
-require 'zlib'
 
 class Gem::Package
   include Gem::UserInteraction
@@ -186,6 +185,8 @@ class Gem::Package
   # Creates a new package that will read or write to the file +gem+.
 
   def initialize(gem, security_policy) # :notnew:
+    require 'zlib'
+
     @gem = gem
 
     @build_time      = Gem.source_date_epoch

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -78,7 +78,6 @@ class Gem::RemoteFetcher
   def initialize(proxy=nil, dns=nil, headers={})
     require 'net/http'
     require 'stringio'
-    require 'time'
     require 'uri'
 
     Socket.do_not_reverse_lookup = true

--- a/lib/rubygems/request.rb
+++ b/lib/rubygems/request.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'net/http'
-require 'time'
 require 'rubygems/user_interaction'
 
 class Gem::Request
@@ -144,6 +143,7 @@ class Gem::Request
     request.add_field 'Keep-Alive', '30'
 
     if @last_modified
+      require 'time'
       request.add_field 'If-Modified-Since', @last_modified.httpdate
     end
 

--- a/lib/rubygems/uri_formatter.rb
+++ b/lib/rubygems/uri_formatter.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'cgi'
 
 ##
 # The UriFormatter handles URIs from user-input and escaping.
@@ -18,6 +17,8 @@ class Gem::UriFormatter
   # Creates a new URI formatter for +uri+.
 
   def initialize(uri)
+    require 'cgi'
+
     @uri = uri
   end
 

--- a/util/create_certs.rb
+++ b/util/create_certs.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'openssl'
-require 'time'
 
 class CertificateBuilder
   attr_reader :start


### PR DESCRIPTION
While creating a spec for https://github.com/rubygems/rubygems/pull/3991, I noticed that these default gems are loaded eagerly every time `rubygems/dependency_installer` is required.

The spec I was writing requires me to use a fresh dummy location for default gems, but since these gems are loaded, I'm also required to create dummy versions of these gems in there too.

I figured that a better solution than making the test more complicated is to lazily load these default gem dependencies only when they are used.

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)