### PR TITLE
Lazily load `erb`

### DIFF
--- a/bundler/lib/bundler/installer.rb
+++ b/bundler/lib/bundler/installer.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "erb"
 require "rubygems/dependency_installer"
 require_relative "worker"
 require_relative "installer/parallel_installer"
@@ -136,6 +135,7 @@ module Bundler
         end
 
         mode = Bundler::WINDOWS ? "wb:UTF-8" : "w"
+        require "erb"
         content = if RUBY_VERSION >= "2.6"
           ERB.new(template, :trim_mode => "-").result(binding)
         else
@@ -182,6 +182,7 @@ module Bundler
         executable_path = executable_path
 
         mode = Bundler::WINDOWS ? "wb:UTF-8" : "w"
+        require "erb"
         content = if RUBY_VERSION >= "2.6"
           ERB.new(template, :trim_mode => "-").result(binding)
         else


### PR DESCRIPTION
Similarly to https://github.com/rubygems/rubygems/pull/4010, I noticed that the `erb` default gem is activated everytime `gemfile(true, &block)` is used.

This technically prevents using the `erb` gem in this kind of situation, and also difficults writing a spec for https://github.com/rubygems/rubygems/pull/3991.

So, let's lazily load `erb` when it's needed.

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)