### PR TITLE
Enable `specific_platform` by default

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -559,10 +559,7 @@ module Bundler
     end
 
     def current_platforms
-      [].tap do |platforms|
-        platforms << local_platform if Bundler.feature_flag.specific_platform?
-        platforms << generic_local_platform
-      end
+      [local_platform, generic_local_platform]
     end
 
     def change_reason

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -559,7 +559,7 @@ module Bundler
     end
 
     def current_platforms
-      [local_platform, generic_local_platform]
+      [local_platform, generic_local_platform].uniq
     end
 
     def change_reason

--- a/bundler/lib/bundler/feature_flag.rb
+++ b/bundler/lib/bundler/feature_flag.rb
@@ -41,7 +41,6 @@ module Bundler
     settings_flag(:plugins) { @bundler_version >= Gem::Version.new("1.14") }
     settings_flag(:print_only_version_number) { bundler_3_mode? }
     settings_flag(:setup_makes_kernel_gem_public) { !bundler_3_mode? }
-    settings_flag(:specific_platform) { bundler_3_mode? }
     settings_flag(:suppress_install_using_messages) { bundler_3_mode? }
     settings_flag(:unlock_source_unlocks_spec) { !bundler_3_mode? }
     settings_flag(:update_requires_all_flag) { bundler_4_mode? }

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -82,7 +82,7 @@ module Bundler
         search_object = if source.is_a?(Source::Path)
           Dependency.new(name, version)
         else
-          Bundler.feature_flag.specific_platform? || Bundler.settings[:force_ruby_platform] ? self : Dependency.new(name, version)
+          self
         end
         platform_object = Gem::Platform.new(platform)
         candidates = source.specs.search(search_object)
@@ -90,12 +90,6 @@ module Bundler
           MatchPlatform.platforms_match?(spec.platform, platform_object)
         end
         search = same_platform_candidates.last || candidates.last
-        if search && Gem::Platform.new(search.platform) != platform_object && !search.runtime_dependencies.-(dependencies.reject {|d| d.type == :development }).empty?
-          Bundler.ui.warn "Unable to use the platform-specific (#{search.platform}) version of #{name} (#{version}) " \
-            "because it has different dependencies from the #{platform} version. " \
-            "To use the platform-specific version of the gem, run `bundle config set --local specific_platform true` and install again."
-          search = source.specs.search(self).last
-        end
         search.dependencies = dependencies if search && (search.is_a?(RemoteSpecification) || search.is_a?(EndpointSpecification))
         search
       end

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -250,14 +250,6 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    be changed in the next major version.
 * `silence_root_warning` (`BUNDLE_SILENCE_ROOT_WARNING`):
    Silence the warning Bundler prints when installing gems as root.
-* `specific_platform` (`BUNDLE_SPECIFIC_PLATFORM`):
-   Allow bundler to resolve for the specific running platform and store it in
-   the lockfile, instead of only using a generic platform.
-   A specific platform is the exact platform triple reported by
-   `Gem::Platform.local`, such as `x86_64-darwin-16` or `universal-java-1.8`.
-   On the other hand, generic platforms are those such as `ruby`, `mswin`, or
-   `java`. In this example, `x86_64-darwin-16` would map to `ruby` and
-   `universal-java-1.8` to `java`.
 * `ssl_ca_cert` (`BUNDLE_SSL_CA_CERT`):
    Path to a designated CA certificate file or folder containing multiple
    certificates for trusted CAs in PEM format.

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -158,9 +158,8 @@ module Bundler
         # spec group.
         sg_ruby = sg.copy_for(Gem::Platform::RUBY)
         selected_sgs << sg_ruby if sg_ruby
-        all_platforms = @platforms + [platform]
-        next if all_platforms.to_a == [Gem::Platform::RUBY]
         sg_all_platforms = nil
+        all_platforms = @platforms + [platform]
         self.class.sort_platforms(all_platforms).reverse_each do |other_platform|
           if sg_all_platforms.nil?
             sg_all_platforms = sg.copy_for(other_platform)

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -42,7 +42,6 @@ module Bundler
       setup_makes_kernel_gem_public
       silence_deprecations
       silence_root_warning
-      specific_platform
       suppress_install_using_messages
       unlock_source_unlocks_spec
       update_requires_all_flag

--- a/bundler/man/bundle-config.1
+++ b/bundler/man/bundle-config.1
@@ -262,9 +262,6 @@ The following is a list of all configuration keys and their purpose\. You can le
 \fBsilence_root_warning\fR (\fBBUNDLE_SILENCE_ROOT_WARNING\fR): Silence the warning Bundler prints when installing gems as root\.
 .
 .IP "\(bu" 4
-\fBspecific_platform\fR (\fBBUNDLE_SPECIFIC_PLATFORM\fR): Allow bundler to resolve for the specific running platform and store it in the lockfile, instead of only using a generic platform\. A specific platform is the exact platform triple reported by \fBGem::Platform\.local\fR, such as \fBx86_64\-darwin\-16\fR or \fBuniversal\-java\-1\.8\fR\. On the other hand, generic platforms are those such as \fBruby\fR, \fBmswin\fR, or \fBjava\fR\. In this example, \fBx86_64\-darwin\-16\fR would map to \fBruby\fR and \fBuniversal\-java\-1\.8\fR to \fBjava\fR\.
-.
-.IP "\(bu" 4
 \fBssl_ca_cert\fR (\fBBUNDLE_SSL_CA_CERT\fR): Path to a designated CA certificate file or folder containing multiple certificates for trusted CAs in PEM format\.
 .
 .IP "\(bu" 4

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -422,8 +422,6 @@ RSpec.describe "bundle install from an existing gemspec" do
           end
         end
 
-        bundle "config specific_platform false"
-
         %w[ruby jruby].each do |platform|
           simulate_platform(platform) do
             install_gemfile <<-G

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -255,32 +255,6 @@ RSpec.describe "bundle install across platforms" do
     expect(the_bundle).to include_gems "nokogiri 1.4.2 JAVA", "weakling 0.0.3"
   end
 
-  it "works with gems that have extra platform-specific runtime dependencies", :bundler => "< 3" do
-    simulate_platform x64_mac
-
-    update_repo2 do
-      build_gem "facter", "2.4.6"
-      build_gem "facter", "2.4.6" do |s|
-        s.platform = "universal-darwin"
-        s.add_runtime_dependency "CFPropertyList"
-      end
-      build_gem "CFPropertyList"
-    end
-
-    install_gemfile <<-G
-      source "#{file_uri_for(gem_repo2)}"
-
-      gem "facter"
-    G
-
-    expect(err).to include "Unable to use the platform-specific (universal-darwin) version of facter (2.4.6) " \
-      "because it has different dependencies from the ruby version. " \
-      "To use the platform-specific version of the gem, run `bundle config set --local specific_platform true` and install again."
-
-    expect(the_bundle).to include_gem "facter 2.4.6"
-    expect(the_bundle).not_to include_gem "CFPropertyList"
-  end
-
   it "works with gems with platform-specific dependency having different requirements order" do
     simulate_platform x64_mac
 

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "bundle install with specific_platform enabled" do
-  before do
-    bundle "config set specific_platform true"
-  end
-
+RSpec.describe "bundle install with specific platforms" do
   let(:google_protobuf) { <<-G }
     source "#{file_uri_for(gem_repo2)}"
     gem "google-protobuf"

--- a/bundler/spec/install/gems/resolving_spec.rb
+++ b/bundler/spec/install/gems/resolving_spec.rb
@@ -239,13 +239,7 @@ RSpec.describe "bundle install with install-time dependencies" do
 
       let(:ruby_requirement) { %("#{RUBY_VERSION}") }
       let(:error_message_requirement) { "~> #{RUBY_VERSION}.0" }
-      let(:error_message_platform) do
-        if Bundler.feature_flag.specific_platform?
-          " #{Bundler.local_platform}"
-        else
-          ""
-        end
-      end
+      let(:error_message_platform) { " #{Bundler.local_platform}" }
 
       shared_examples_for "ruby version conflicts" do
         it "raises an error during resolution" do

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -981,38 +981,7 @@ RSpec.describe "the lockfile format" do
     G
   end
 
-  it "persists the spec's platform to the lockfile", :bundler => "< 3" do
-    build_repo2 do
-      build_gem "platform_specific", "1.0" do |s|
-        s.platform = Gem::Platform.new("universal-java-16")
-      end
-    end
-
-    simulate_platform "universal-java-16"
-
-    install_gemfile <<-G
-      source "#{file_uri_for(gem_repo2)}"
-      gem "platform_specific"
-    G
-
-    lockfile_should_be <<-G
-      GEM
-        remote: #{file_uri_for(gem_repo2)}/
-        specs:
-          platform_specific (1.0-java)
-
-      PLATFORMS
-        java
-
-      DEPENDENCIES
-        platform_specific
-
-      BUNDLED WITH
-         #{Bundler::VERSION}
-    G
-  end
-
-  it "persists the spec's platform and specific platform to the lockfile", :bundler => "3" do
+  it "persists the spec's platform and specific platform to the lockfile" do
     build_repo2 do
       build_gem "platform_specific", "1.0" do |s|
         s.platform = Gem::Platform.new("universal-java-16")

--- a/bundler/spec/plugins/source/example_spec.rb
+++ b/bundler/spec/plugins/source/example_spec.rb
@@ -67,32 +67,7 @@ RSpec.describe "real source plugins" do
       expect(the_bundle).to include_gems("a-path-gem 1.0")
     end
 
-    it "writes to lock file", :bundler => "< 3" do
-      bundle "install"
-
-      lockfile_should_be <<-G
-        PLUGIN SOURCE
-          remote: #{lib_path("a-path-gem-1.0")}
-          type: mpath
-          specs:
-            a-path-gem (1.0)
-
-        GEM
-          remote: #{file_uri_for(gem_repo2)}/
-          specs:
-
-        PLATFORMS
-          #{generic_local_platform}
-
-        DEPENDENCIES
-          a-path-gem!
-
-        BUNDLED WITH
-           #{Bundler::VERSION}
-      G
-    end
-
-    it "writes to lock file", :bundler => "3" do
+    it "writes to lock file" do
       bundle "install"
 
       lockfile_should_be <<-G
@@ -363,34 +338,7 @@ RSpec.describe "real source plugins" do
       expect(the_bundle).to include_gems("ma-gitp-gem 1.0")
     end
 
-    it "writes to lock file", :bundler => "< 3" do
-      revision = revision_for(lib_path("ma-gitp-gem-1.0"))
-      bundle "install"
-
-      lockfile_should_be <<-G
-        PLUGIN SOURCE
-          remote: #{file_uri_for(lib_path("ma-gitp-gem-1.0"))}
-          type: gitp
-          revision: #{revision}
-          specs:
-            ma-gitp-gem (1.0)
-
-        GEM
-          remote: #{file_uri_for(gem_repo2)}/
-          specs:
-
-        PLATFORMS
-          #{generic_local_platform}
-
-        DEPENDENCIES
-          ma-gitp-gem!
-
-        BUNDLED WITH
-           #{Bundler::VERSION}
-      G
-    end
-
-    it "writes to lock file", :bundler => "3" do
+    it "writes to lock file" do
       revision = revision_for(lib_path("ma-gitp-gem-1.0"))
       bundle "install"
 

--- a/bundler/spec/support/platforms.rb
+++ b/bundler/spec/support/platforms.rb
@@ -94,11 +94,7 @@ module Spec
     end
 
     def local_platforms
-      if Bundler.feature_flag.specific_platform?
-        [local, specific_local_platform]
-      else
-        [local]
-      end
+      [local, specific_local_platform].uniq
     end
   end
 end

--- a/bundler/test_gems.rb.lock
+++ b/bundler/test_gems.rb.lock
@@ -25,6 +25,7 @@ PLATFORMS
   java
   ruby
   x64-mingw32
+  x86_64-linux
 
 DEPENDENCIES
   artifice (~> 0.6.0)


### PR DESCRIPTION
To properly support gems providing native platform versions with different dependencies than their pure ruby counterparts.

Nokogiri will start doing this soon. In particular, for each version, the pure ruby variant will not have a `required_ruby_version` upper bound, but the native variant will. Bundler should always install a valid bundle in this case.

Closes https://github.com/rubygems/rubygems/issues/3200.
Closes https://github.com/rubygems/rubygems/issues/4012.


## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)