### PR TITLE
Clean built extensions after install

### DIFF
--- a/bundler/lib/bundler/stub_specification.rb
+++ b/bundler/lib/bundler/stub_specification.rb
@@ -16,8 +16,17 @@ module Bundler
       # Stub has no concept of source, which means that extension_dir may be wrong
       # This is the case for git-based gems. So, instead manually assign the extension dir
       return unless source.respond_to?(:extension_dir_name)
-      unique_extension_dir = [source.extension_dir_name, File.basename(full_gem_path)].uniq.join("-")
-      extension_dir = File.join(extensions_dir, unique_extension_dir)
+      extension_dir_name = source.extension_dir_name
+      unique_extension_dir = [extension_dir_name, File.basename(full_gem_path)].uniq.join("-")
+      extension_dir = File.join(
+        stub.extensions_dir,
+        '..', '..', '..', # Fix stub.extension_dir
+        extension_dir_name,
+        "extensions",
+        Gem::Platform.local.to_s,
+        Gem.extension_api_version,
+        unique_extension_dir
+      )
       stub.extension_dir = File.expand_path(extension_dir)
     end
 

--- a/bundler/lib/bundler/stub_specification.rb
+++ b/bundler/lib/bundler/stub_specification.rb
@@ -16,8 +16,9 @@ module Bundler
       # Stub has no concept of source, which means that extension_dir may be wrong
       # This is the case for git-based gems. So, instead manually assign the extension dir
       return unless source.respond_to?(:extension_dir_name)
-      path = File.join(stub.extensions_dir, source.extension_dir_name)
-      stub.extension_dir = File.expand_path(path)
+      unique_extension_dir = [source.extension_dir_name, File.basename(full_gem_path)].uniq.join("-")
+      extension_dir = File.join(extensions_dir, unique_extension_dir)
+      stub.extension_dir = File.expand_path(extension_dir)
     end
 
     def to_yaml

--- a/bundler/spec/install/gems/native_extensions_spec.rb
+++ b/bundler/spec/install/gems/native_extensions_spec.rb
@@ -141,6 +141,8 @@ RSpec.describe "installing a gem with native extensions" do
       gem "c_extension_two", :git => #{lib_path("gems").to_s.dump}
     G
 
+    run 'puts $LOAD_PATH.grep(/extensions/).each { |path| raise "Invalid LOAD_PATH: #{ path }" unless File.directory?(path) }'
+
     run "Bundler.require; puts CExtension_one.new.value; puts CExtension_two.new.value"
     expect(out).to eq("one\ntwo")
   end

--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -222,4 +222,8 @@ EOF
 
     destination
   end
+
+  def clean_intermediate_files
+    FileUtils.rm Dir["#{@spec.gem_dir}/**/*.{so,o,bundle}"]
+  end
 end

--- a/lib/rubygems/ext/cargo_builder.rb
+++ b/lib/rubygems/ext/cargo_builder.rb
@@ -139,9 +139,7 @@ class Gem::Ext::CargoBuilder < Gem::Ext::Builder
   end
 
   def final_extension_path(dest_path)
-    dylib_path = cargo_dylib_path(dest_path)
-    dlext_name = "#{spec.name}.#{makefile_config("DLEXT")}"
-    dylib_path.gsub(File.basename(dylib_path), dlext_name)
+    File.join dest_path, "#{spec.name}.#{makefile_config("DLEXT")}"
   end
 
   def cargo_dylib_path(dest_path)

--- a/lib/rubygems/install_update_options.rb
+++ b/lib/rubygems/install_update_options.rb
@@ -178,6 +178,11 @@ module Gem::InstallUpdateOptions
                "Suggest alternates when gems are not found") do |v,o|
       options[:suggest_alternate] = v
     end
+
+    add_option(:"Install/Update", "--dirty",
+               "Leave build artifacts on the gem directory") do |v,o|
+      options[:dirty] = v
+    end
   end
 
   ##

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -841,6 +841,7 @@ TEXT
     builder = Gem::Ext::Builder.new spec, build_args
 
     builder.build_extensions
+    builder.clean_intermediate_files
   end
 
   ##

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -841,7 +841,7 @@ TEXT
     builder = Gem::Ext::Builder.new spec, build_args
 
     builder.build_extensions
-    builder.clean_intermediate_files
+    builder.clean_intermediate_files unless options[:dirty]
   end
 
   ##

--- a/test/rubygems/test_gem_ext_cargo_builder.rb
+++ b/test/rubygems/test_gem_ext_cargo_builder.rb
@@ -55,7 +55,7 @@ class TestGemExtCargoBuilder < Gem::TestCase
     end
 
     output = output.join "\n"
-    bundle = File.join(@dest_path, "release/rust_ruby_example.#{RbConfig::CONFIG['DLEXT']}")
+    bundle = File.join(@dest_path, "rust_ruby_example.#{RbConfig::CONFIG['DLEXT']}")
 
     assert_match(/Finished/, output)
     assert_match(/release/, output)

--- a/test/rubygems/test_gem_install_update_options.rb
+++ b/test/rubygems/test_gem_install_update_options.rb
@@ -26,6 +26,7 @@ class TestGemInstallUpdateOptions < Gem::InstallerTestCase
       -i /install_to
       -w
       --post-install-message
+      --dirty
     ]
 
     args.concat %w[--vendor] unless Gem.java_platform?

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1584,6 +1584,41 @@ gem 'other', version
     end
   end
 
+  def test_install_extension_clean_intermediate_files
+    pend "extensions don't quite work on jruby" if Gem.java_platform?
+    @spec = setup_base_spec
+    @spec.require_paths = ["."]
+    @spec.extensions << "extconf.rb"
+
+    File.write File.join(@tempdir, "extconf.rb"), <<-RUBY
+      require "mkmf"
+      CONFIG['CC'] = '$(TOUCH) $@ ||'
+      CONFIG['LDSHARED'] = '$(TOUCH) $@ ||'
+      $ruby = '#{Gem.ruby}'
+      create_makefile("#{@spec.name}")
+    RUBY
+
+    # empty depend file for no auto dependencies
+    @spec.files += %W[depend #{@spec.name}.c].each do |file|
+      write_file File.join(@tempdir, file)
+    end
+
+    shared_object = "#{@spec.name}.#{RbConfig::CONFIG["DLEXT"]}"
+    extension_file = File.join @spec.extension_dir, shared_object
+    intermediate_file = File.join @spec.gem_dir, shared_object
+
+    assert_path_not_exist extension_file, "no before installing"
+    use_ui @ui do
+      path = Gem::Package.build @spec
+
+      installer = Gem::Installer.at path
+      installer.install
+    end
+
+    assert_path_exist extension_file, "installed"
+    assert_path_not_exist intermediate_file
+  end
+
   def test_installation_satisfies_dependency_eh
     installer = setup_base_installer
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1619,6 +1619,42 @@ gem 'other', version
     assert_path_not_exist intermediate_file
   end
 
+  def test_dirty_install_extension
+    pend "extensions don't quite work on jruby" if Gem.java_platform?
+    @spec = setup_base_spec
+    @spec.require_paths = ["."]
+    @spec.extensions << "extconf.rb"
+
+    File.write File.join(@tempdir, "extconf.rb"), <<-RUBY
+      require "mkmf"
+      CONFIG['CC'] = '$(TOUCH) $@ ||'
+      CONFIG['LDSHARED'] = '$(TOUCH) $@ ||'
+      $ruby = '#{Gem.ruby}'
+      create_makefile("#{@spec.name}")
+    RUBY
+
+    # empty depend file for no auto dependencies
+    @spec.files += %W[depend #{@spec.name}.c].each do |file|
+      write_file File.join(@tempdir, file)
+    end
+
+    shared_object = "#{@spec.name}.#{RbConfig::CONFIG["DLEXT"]}"
+    extension_file = File.join @spec.extension_dir, shared_object
+    intermediate_file = File.join @spec.gem_dir, shared_object
+
+    assert_path_not_exist extension_file, "no before installing"
+    use_ui @ui do
+      path = Gem::Package.build @spec
+
+      installer = Gem::Installer.at path
+      installer.options[:dirty] = true
+      installer.install
+    end
+
+    assert_path_exist extension_file
+    assert_path_exist intermediate_file
+  end
+
   def test_installation_satisfies_dependency_eh
     installer = setup_base_installer
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1559,7 +1559,7 @@ gem 'other', version
         write_file File.join(@tempdir, file)
       end
 
-      so = File.join(@spec.gem_dir, "#{@spec.name}.#{RbConfig::CONFIG["DLEXT"]}")
+      so = File.join(@spec.extension_dir, "#{@spec.name}.#{RbConfig::CONFIG["DLEXT"]}")
       assert_path_not_exist so
       use_ui @ui do
         path = Gem::Package.build @spec

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -694,13 +694,14 @@ class TestGemRequire < Gem::TestCase
 
     spec.files += ["extconf.rb", "depend", "#{name}.c"]
 
-    so = File.join(spec.gem_dir, "#{name}.#{RbConfig::CONFIG["DLEXT"]}")
-    assert_path_not_exist so
+    extension_file = File.join(spec.extension_dir, "#{name}.#{RbConfig::CONFIG["DLEXT"]}")
+    assert_path_not_exist extension_file
 
     path = Gem::Package.build spec
     installer = Gem::Installer.at path
     installer.install
-    assert_path_exist so
+
+    assert_path_exist extension_file
 
     spec.gem_dir
   end


### PR DESCRIPTION
This should fix #3958, it is based on a comment of @simi there.

It just adds a `clean` step after `install` to remove object files.

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)