### PR TITLE
Improve gem not found in source error messages

### DIFF
--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -302,7 +302,7 @@ module Bundler
           versions_with_platforms = specs.map {|s| [s.version, s.platform] }
           message = String.new("Could not find gem '#{SharedHelpers.pretty_dependency(requirement)}' in #{source}#{cache_message}.\n")
           message << if versions_with_platforms.any?
-            "The source contains '#{name}' at: #{formatted_versions_with_platforms(versions_with_platforms)}"
+            "The source contains the following versions of '#{name}': #{formatted_versions_with_platforms(versions_with_platforms)}"
           else
             "The source does not contain any versions of '#{name}'"
           end

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -747,7 +747,7 @@ RSpec.describe "bundle exec" do
       let(:expected) { "" }
       let(:expected_err) { <<-EOS.strip }
 \e[31mCould not find gem 'rack (= 2)' in locally installed gems.
-The source contains 'rack' at: 1.0.0\e[0m
+The source contains the following versions of 'rack': 1.0.0\e[0m
 \e[33mRun `bundle install` to install missing gems.\e[0m
       EOS
 

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "bundle install with git sources" do
         gem "foo", "1.1", :git => "#{lib_path("foo-1.0")}"
       G
 
-      expect(err).to include("The source contains 'foo' at: 1.0")
+      expect(err).to include("The source contains the following versions of 'foo': 1.0")
     end
 
     it "complains with version and platform if pinned specs don't exist in the git repo" do
@@ -103,7 +103,7 @@ RSpec.describe "bundle install with git sources" do
         end
       G
 
-      expect(err).to include("The source contains 'only_java' at: 1.0 java")
+      expect(err).to include("The source contains the following versions of 'only_java': 1.0 java")
     end
 
     it "complains with multiple versions and platforms if pinned specs don't exist in the git repo" do
@@ -124,7 +124,7 @@ RSpec.describe "bundle install with git sources" do
         end
       G
 
-      expect(err).to include("The source contains 'only_java' at: 1.0 java, 1.1 java")
+      expect(err).to include("The source contains the following versions of 'only_java': 1.0 java, 1.1 java")
     end
 
     it "still works after moving the application directory" do


### PR DESCRIPTION
Improves poor errors reported by https://github.com/rubygems/rubygems/issues/3231 when a dependency is not found in the source it's expected to be found.

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)