### PR TITLE
Suggest alternatives in `gem query` deprecation

### DIFF
--- a/lib/rubygems/commands/query_command.rb
+++ b/lib/rubygems/commands/query_command.rb
@@ -9,6 +9,14 @@ class Gem::Commands::QueryCommand < Gem::Command
 
   include Gem::QueryUtils
 
+  alias warning_without_suggested_alternatives deprecation_warning
+  def deprecation_warning
+    warning_without_suggested_alternatives
+
+    message = "\nIt is recommended that you use `gem search` or `gem list` instead.\n"
+    alert_warning message unless Gem::Deprecate.skip
+  end
+
   def initialize(name = 'query',
                  summary = 'Query gem information in local or remote repositories')
     super name, summary,

--- a/test/rubygems/test_gem_gem_runner.rb
+++ b/test/rubygems/test_gem_gem_runner.rb
@@ -78,6 +78,7 @@ class TestGemGemRunner < Gem::TestCase
     end
 
     assert_match(/WARNING:  query command is deprecated. It will be removed in Rubygems [0-9]+/, @ui.error)
+    assert_match(/It is recommended that you use `gem search` or `gem list` instead/, @ui.error)
   end
 
   def test_info_succeeds


### PR DESCRIPTION
##  What was the end-user or developer problem that led to this PR?
`gem query` was deprecated in rubygems 3.2. Prior to the command being deprecated, there was an injunction to use `list` or `search`. While the `query` command is going away, the usefulness of this suggestion is still present, as pointed out in #3984.

[@deivid-rodriguez's comment](https://github.com/rubygems/rubygems/issues/3984#issuecomment-702048149) on the [linked issue](#3984) suggested adding suggestions for the now-deprecated `query` command, along with adding information about the deprecation to rubygems.org.

Note: since the described problem requires changes in two repositories, this is the first of two pull requests to address this issue.

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
