### PR TITLE
Fix `specific_platform` and `cache_all` with `bundle cache --all-platforms`

### DIFF
--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -79,7 +79,11 @@ module Bundler
       @specification = if source.is_a?(Source::Gemspec) && source.gemspec.name == name
         source.gemspec.tap {|s| s.source = source }
       else
-        search_object = Bundler.feature_flag.specific_platform? || Bundler.settings[:force_ruby_platform] ? self : Dependency.new(name, version)
+        search_object = if source.is_a?(Source::Path)
+          Dependency.new(name, version)
+        else
+          Bundler.feature_flag.specific_platform? || Bundler.settings[:force_ruby_platform] ? self : Dependency.new(name, version)
+        end
         platform_object = Gem::Platform.new(platform)
         candidates = source.specs.search(search_object)
         same_platform_candidates = candidates.select do |spec|

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -3,7 +3,86 @@
 RSpec.describe "bundle install with specific_platform enabled" do
   before do
     bundle "config set specific_platform true"
+  end
 
+  let(:google_protobuf) { <<-G }
+    source "#{file_uri_for(gem_repo2)}"
+    gem "google-protobuf"
+  G
+
+  context "when on a darwin machine" do
+    before { simulate_platform "x86_64-darwin-15" }
+
+    it "locks to both the specific darwin platform and ruby" do
+      setup_multiplatform_gem
+      install_gemfile(google_protobuf)
+      allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+      expect(the_bundle.locked_gems.platforms).to eq([pl("ruby"), pl("x86_64-darwin-15")])
+      expect(the_bundle).to include_gem("google-protobuf 3.0.0.alpha.5.0.5.1 universal-darwin")
+      expect(the_bundle.locked_gems.specs.map(&:full_name)).to eq(%w[
+        google-protobuf-3.0.0.alpha.5.0.5.1
+        google-protobuf-3.0.0.alpha.5.0.5.1-universal-darwin
+      ])
+    end
+
+    it "caches both the universal-darwin and ruby gems when --all-platforms is passed" do
+      setup_multiplatform_gem
+      gemfile(google_protobuf)
+      bundle "package --all-platforms"
+      expect([cached_gem("google-protobuf-3.0.0.alpha.5.0.5.1"), cached_gem("google-protobuf-3.0.0.alpha.5.0.5.1-universal-darwin")]).
+        to all(exist)
+    end
+
+    it "uses the platform-specific gem with extra dependencies" do
+      setup_multiplatform_gem_with_different_dependencies_per_platform
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "facter"
+      G
+      allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+
+      expect(the_bundle.locked_gems.platforms).to eq([pl("ruby"), pl("x86_64-darwin-15")])
+      expect(the_bundle).to include_gems("facter 2.4.6 universal-darwin", "CFPropertyList 1.0")
+      expect(the_bundle.locked_gems.specs.map(&:full_name)).to eq(["CFPropertyList-1.0",
+                                                                   "facter-2.4.6",
+                                                                   "facter-2.4.6-universal-darwin"])
+    end
+
+    context "when adding a platform via lock --add_platform" do
+      before do
+        allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+      end
+
+      it "adds the foreign platform" do
+        setup_multiplatform_gem
+        install_gemfile(google_protobuf)
+        bundle "lock --add-platform=#{x64_mingw}"
+
+        expect(the_bundle.locked_gems.platforms).to eq([rb, x64_mingw, pl("x86_64-darwin-15")])
+        expect(the_bundle.locked_gems.specs.map(&:full_name)).to eq(%w[
+          google-protobuf-3.0.0.alpha.5.0.5.1
+          google-protobuf-3.0.0.alpha.5.0.5.1-universal-darwin
+          google-protobuf-3.0.0.alpha.5.0.5.1-x64-mingw32
+        ])
+      end
+
+      it "falls back on plain ruby when that version doesnt have a platform-specific gem" do
+        setup_multiplatform_gem
+        install_gemfile(google_protobuf)
+        bundle "lock --add-platform=#{java}"
+
+        expect(the_bundle.locked_gems.platforms).to eq([java, rb, pl("x86_64-darwin-15")])
+        expect(the_bundle.locked_gems.specs.map(&:full_name)).to eq(%w[
+          google-protobuf-3.0.0.alpha.5.0.5.1
+          google-protobuf-3.0.0.alpha.5.0.5.1-universal-darwin
+        ])
+      end
+    end
+  end
+
+  private
+
+  def setup_multiplatform_gem
     build_repo2 do
       build_gem("google-protobuf", "3.0.0.alpha.5.0.5.1")
       build_gem("google-protobuf", "3.0.0.alpha.5.0.5.1") {|s| s.platform = "x86_64-linux" }
@@ -38,83 +117,17 @@ RSpec.describe "bundle install with specific_platform enabled" do
       build_gem("google-protobuf", "3.0.0.alpha.2.0")
       build_gem("google-protobuf", "3.0.0.alpha.1.1")
       build_gem("google-protobuf", "3.0.0.alpha.1.0")
+    end
+  end
 
+  def setup_multiplatform_gem_with_different_dependencies_per_platform
+    build_repo2 do
       build_gem("facter", "2.4.6")
       build_gem("facter", "2.4.6") do |s|
         s.platform = "universal-darwin"
         s.add_runtime_dependency "CFPropertyList"
       end
       build_gem("CFPropertyList")
-    end
-  end
-
-  let(:google_protobuf) { <<-G }
-    source "#{file_uri_for(gem_repo2)}"
-    gem "google-protobuf"
-  G
-
-  context "when on a darwin machine" do
-    before { simulate_platform "x86_64-darwin-15" }
-
-    it "locks to both the specific darwin platform and ruby" do
-      install_gemfile(google_protobuf)
-      allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
-      expect(the_bundle.locked_gems.platforms).to eq([pl("ruby"), pl("x86_64-darwin-15")])
-      expect(the_bundle).to include_gem("google-protobuf 3.0.0.alpha.5.0.5.1 universal-darwin")
-      expect(the_bundle.locked_gems.specs.map(&:full_name)).to eq(%w[
-        google-protobuf-3.0.0.alpha.5.0.5.1
-        google-protobuf-3.0.0.alpha.5.0.5.1-universal-darwin
-      ])
-    end
-
-    it "caches both the universal-darwin and ruby gems when --all-platforms is passed" do
-      gemfile(google_protobuf)
-      bundle "package --all-platforms"
-      expect([cached_gem("google-protobuf-3.0.0.alpha.5.0.5.1"), cached_gem("google-protobuf-3.0.0.alpha.5.0.5.1-universal-darwin")]).
-        to all(exist)
-    end
-
-    it "uses the platform-specific gem with extra dependencies" do
-      install_gemfile <<-G
-        source "#{file_uri_for(gem_repo2)}"
-        gem "facter"
-      G
-      allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
-
-      expect(the_bundle.locked_gems.platforms).to eq([pl("ruby"), pl("x86_64-darwin-15")])
-      expect(the_bundle).to include_gems("facter 2.4.6 universal-darwin", "CFPropertyList 1.0")
-      expect(the_bundle.locked_gems.specs.map(&:full_name)).to eq(["CFPropertyList-1.0",
-                                                                   "facter-2.4.6",
-                                                                   "facter-2.4.6-universal-darwin"])
-    end
-
-    context "when adding a platform via lock --add_platform" do
-      before do
-        allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
-      end
-
-      it "adds the foreign platform" do
-        install_gemfile(google_protobuf)
-        bundle "lock --add-platform=#{x64_mingw}"
-
-        expect(the_bundle.locked_gems.platforms).to eq([rb, x64_mingw, pl("x86_64-darwin-15")])
-        expect(the_bundle.locked_gems.specs.map(&:full_name)).to eq(%w[
-          google-protobuf-3.0.0.alpha.5.0.5.1
-          google-protobuf-3.0.0.alpha.5.0.5.1-universal-darwin
-          google-protobuf-3.0.0.alpha.5.0.5.1-x64-mingw32
-        ])
-      end
-
-      it "falls back on plain ruby when that version doesnt have a platform-specific gem" do
-        install_gemfile(google_protobuf)
-        bundle "lock --add-platform=#{java}"
-
-        expect(the_bundle.locked_gems.platforms).to eq([java, rb, pl("x86_64-darwin-15")])
-        expect(the_bundle.locked_gems.specs.map(&:full_name)).to eq(%w[
-          google-protobuf-3.0.0.alpha.5.0.5.1
-          google-protobuf-3.0.0.alpha.5.0.5.1-universal-darwin
-        ])
-      end
     end
   end
 end

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -940,7 +940,7 @@ RSpec.describe "the lockfile format" do
     G
   end
 
-  it "keeps existing platforms in the lockfile", :bundler => "< 3" do
+  it "keeps existing platforms in the lockfile" do
     lockfile <<-G
       GEM
         remote: #{file_uri_for(gem_repo2)}/
@@ -971,49 +971,7 @@ RSpec.describe "the lockfile format" do
 
       PLATFORMS
         java
-        #{generic_local_platform}
-
-      DEPENDENCIES
-        rack
-
-      BUNDLED WITH
-         #{Bundler::VERSION}
-    G
-  end
-
-  it "keeps existing platforms in the lockfile", :bundler => "3" do
-    lockfile <<-G
-      GEM
-        remote: #{file_uri_for(gem_repo2)}/
-        specs:
-          rack (1.0.0)
-
-      PLATFORMS
-        java
-
-      DEPENDENCIES
-        rack
-
-      BUNDLED WITH
-         #{Bundler::VERSION}
-    G
-
-    install_gemfile <<-G
-      source "#{file_uri_for(gem_repo2)}/"
-
-      gem "rack"
-    G
-
-    lockfile_should_be <<-G
-      GEM
-        remote: #{file_uri_for(gem_repo2)}/
-        specs:
-          rack (1.0.0)
-
-      PLATFORMS
-        java
-        #{generic_local_platform}
-        #{specific_local_platform}
+        #{lockfile_platforms}
 
       DEPENDENCIES
         rack

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -417,34 +417,6 @@ RSpec.describe "the lockfile format" do
     expect(the_bundle).to include_gems "net-sftp 1.1.1", "net-ssh 1.0.0"
   end
 
-  it "generates a simple lockfile for a single pinned source, gem with a version requirement", :bundler => "< 3" do
-    git = build_git "foo"
-
-    install_gemfile <<-G
-      gem "foo", :git => "#{lib_path("foo-1.0")}"
-    G
-
-    lockfile_should_be <<-G
-      GIT
-        remote: #{lib_path("foo-1.0")}
-        revision: #{git.ref_for("master")}
-        specs:
-          foo (1.0)
-
-      GEM
-        specs:
-
-      PLATFORMS
-        #{lockfile_platforms}
-
-      DEPENDENCIES
-        foo!
-
-      BUNDLED WITH
-         #{Bundler::VERSION}
-    G
-  end
-
   it "generates a simple lockfile for a single pinned source, gem with a version requirement" do
     git = build_git "foo"
 

--- a/bundler/test_gems.rb.lock
+++ b/bundler/test_gems.rb.lock
@@ -24,6 +24,7 @@ GEM
 PLATFORMS
   java
   ruby
+  x64-mingw32
 
 DEPENDENCIES
   artifice (~> 0.6.0)

--- a/dev_gems.rb.lock
+++ b/dev_gems.rb.lock
@@ -85,4 +85,4 @@ DEPENDENCIES
   webrick (~> 1.6)
 
 BUNDLED WITH
-   2.1.4
+   2.2.0.rc.2

--- a/dev_gems.rb.lock
+++ b/dev_gems.rb.lock
@@ -68,6 +68,7 @@ GEM
 PLATFORMS
   java
   ruby
+  x64-mingw32
 
 DEPENDENCIES
   minitest (~> 5.14, >= 5.14.2)

--- a/dev_gems.rb.lock
+++ b/dev_gems.rb.lock
@@ -69,6 +69,7 @@ PLATFORMS
   java
   ruby
   x64-mingw32
+  x86_64-linux
 
 DEPENDENCIES
   minitest (~> 5.14, >= 5.14.2)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If using the `specific_platform` and `cache_all` setting, it is expected that `git` gems will be cached.

However, enabling `specific_platform` causes bundler to look only for platform specific versions of the `gemspec` in the `git` source, which is something that hardly ever happens.

## What is your fix for the problem, implemented in this PR?

Specially case this situation so that the git gem is properly cached in this case.

Fixes https://github.com/rubygems/rubygems/issues/3361.

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)