### PR TITLE
Omit deprecated commands from command help output

### DIFF
--- a/lib/rubygems/commands/help_command.rb
+++ b/lib/rubygems/commands/help_command.rb
@@ -332,6 +332,8 @@ platform.
     @command_manager.command_names.each do |cmd_name|
       command = @command_manager[cmd_name]
 
+      next if command.deprecated?
+
       summary =
         if command
           command.summary

--- a/lib/rubygems/commands/query_command.rb
+++ b/lib/rubygems/commands/query_command.rb
@@ -32,7 +32,7 @@ class Gem::Commands::QueryCommand < Gem::Command
     add_query_options
   end
 
-  def description
+  def description # :nodoc:
     <<-EOF
 The query command is the basis for the list and search commands.
 

--- a/lib/rubygems/commands/query_command.rb
+++ b/lib/rubygems/commands/query_command.rb
@@ -31,4 +31,13 @@ class Gem::Commands::QueryCommand < Gem::Command
 
     add_query_options
   end
+
+  def description
+    <<-EOF
+The query command is the basis for the list and search commands.
+
+You should really use the list and search commands instead.  This command
+is too hard to use.
+    EOF
+  end
 end

--- a/lib/rubygems/query_utils.rb
+++ b/lib/rubygems/query_utils.rb
@@ -57,15 +57,6 @@ module Gem::QueryUtils
     "--local --name-matches // --no-details --versions --no-installed"
   end
 
-  def description # :nodoc:
-    <<-EOF
-The query command is the basis for the list and search commands.
-
-You should really use the list and search commands instead.  This command
-is too hard to use.
-    EOF
-  end
-
   def execute
     gem_names = Array(options[:name])
 

--- a/test/rubygems/test_gem_commands_help_command.rb
+++ b/test/rubygems/test_gem_commands_help_command.rb
@@ -40,13 +40,26 @@ class TestGemCommandsHelpCommand < Gem::TestCase
 
     util_gem 'commands' do |out, err|
       mgr.command_names.each do |cmd|
-        assert_match(/\s+#{cmd}\s+\S+/, out)
+        unless mgr[cmd].deprecated?
+          assert_match(/\s+#{cmd}\s+\S+/, out)
+        end
       end
 
       if Gem::HAVE_OPENSSL
         assert_empty err
 
         refute_match 'No command found for ', out
+      end
+    end
+  end
+
+  def test_gem_help_commands_omits_deprecated_commands
+    mgr = Gem::CommandManager.new
+
+    util_gem 'commands' do |out, err|
+      deprecated_commands = mgr.command_names.select {|cmd| mgr[cmd].deprecated? }
+      deprecated_commands.each do |cmd|
+        refute_match(/\s+#{cmd}\s+\S+/, out)
       end
     end
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?
`gem query` was deprecated in rubygems 3.2. It was noted in #3984 that there should be a deprecation warning in the CLI (done in #4021) and a message in [the guides](https://guides.rubygems.org/command-reference/#gem-query).

A PR was opened to address the message (rubygems/guides#270) in Guides, but it [was pointed out](https://github.com/rubygems/guides/pull/270#issuecomment-712832643) that the file being changed is auto-generated. This change leans into that auto-generation and should make rubygems/guides#270 redundant.

Closes #3984 

## What is your fix for the problem, implemented in this PR?

Add the deprecation note to the command's summary so that it can be relied upon for auto-generating the documentation. This note will display near the heading in the guides.

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
