### PR TITLE
Remove unintended new line in `gem query` deprecation message

### DIFF
--- a/lib/rubygems/commands/query_command.rb
+++ b/lib/rubygems/commands/query_command.rb
@@ -13,7 +13,7 @@ class Gem::Commands::QueryCommand < Gem::Command
   def deprecation_warning
     warning_without_suggested_alternatives
 
-    message = "\nIt is recommended that you use `gem search` or `gem list` instead.\n"
+    message = "It is recommended that you use `gem search` or `gem list` instead.\n"
     alert_warning message unless Gem::Deprecate.skip
   end
 

--- a/test/rubygems/test_gem_gem_runner.rb
+++ b/test/rubygems/test_gem_gem_runner.rb
@@ -78,7 +78,7 @@ class TestGemGemRunner < Gem::TestCase
     end
 
     assert_match(/WARNING:  query command is deprecated. It will be removed in Rubygems [0-9]+/, @ui.error)
-    assert_match(/It is recommended that you use `gem search` or `gem list` instead/, @ui.error)
+    assert_match(/WARNING:  It is recommended that you use `gem search` or `gem list` instead/, @ui.error)
   end
 
   def test_info_succeeds


### PR DESCRIPTION
With it, the warning looks weird, like this:

```
WARNING:  query command is deprecated. It will be removed in Rubygems 4.
WARNING:
It is recommended that you use `gem search` or `gem list` instead.
```

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)