### PR TITLE
Make Gem::SystemExitException properly exit with a given code

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -561,6 +561,7 @@ test/rubygems/ssl_key.pem
 test/rubygems/test_bundled_ca.rb
 test/rubygems/test_config.rb
 test/rubygems/test_deprecate.rb
+test/rubygems/test_exit.rb
 test/rubygems/test_gem.rb
 test/rubygems/test_gem_available_set.rb
 test/rubygems/test_gem_bundler_version_finder.rb

--- a/bin/gem
+++ b/bin/gem
@@ -7,12 +7,7 @@
 
 require 'rubygems'
 require 'rubygems/gem_runner'
-require 'rubygems/exceptions'
 
 args = ARGV.clone
 
-begin
-  Gem::GemRunner.new.run args
-rescue Gem::SystemExitException => e
-  exit e.exit_code
-end
+Gem::GemRunner.new.run args

--- a/lib/rubygems/exceptions.rb
+++ b/lib/rubygems/exceptions.rb
@@ -225,7 +225,7 @@ class Gem::SystemExitException < SystemExit
   def initialize(exit_code)
     @exit_code = exit_code
 
-    super "Exiting RubyGems with exit_code #{exit_code}"
+    super exit_code, "Exiting RubyGems with exit_code #{exit_code}"
   end
 end
 

--- a/setup.rb
+++ b/setup.rb
@@ -21,7 +21,6 @@ Dir.chdir File.dirname(__FILE__)
 $:.unshift File.expand_path('lib')
 require 'rubygems'
 require 'rubygems/gem_runner'
-require 'rubygems/exceptions'
 
 Gem::CommandManager.instance.register_command :setup
 
@@ -31,8 +30,4 @@ if ENV["GEM_PREV_VER"]
 end
 args.unshift 'setup'
 
-begin
-  Gem::GemRunner.new.run args
-rescue Gem::SystemExitException => e
-  exit e.exit_code
-end
+Gem::GemRunner.new.run args

--- a/test/rubygems/test_exit.rb
+++ b/test/rubygems/test_exit.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative 'helper'
+require 'rubygems'
+
+class TestExit < Gem::TestCase
+  def test_exit
+    system(*ruby_with_rubygems_in_load_path, "-e", "raise Gem::SystemExitException.new(2)")
+    assert_equal 2, $?.exitstatus
+  end
+end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The gem command does not properly exit with a non-zero exit code in some cases.

I found gem update --system did not properly return a non-zero exit code when it failed with a permission error.

```
$ gem update --system; echo $?
Updating rubygems-update
Successfully installed rubygems-update-3.1.4
Installing RubyGems 3.1.4
ERROR:  While executing gem ... (Errno::EACCES)
   Permission denied @ rb_sysopen - /usr/local/lib/ruby/site_ruby/2.6.0/ubygems.rb
0
$ gem --version
3.0.3
```

## What is your fix for the problem, implemented in this PR?

The cause was in how Gem::SystemExitException initializes itself.  It didn't pass an exit code to the super method.  See the document of SystemExit.new() for details.

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
