### PR TITLE
Add GEM_USER_INSTALL environment variable

### DIFF
--- a/lib/rubygems/commands/environment_command.rb
+++ b/lib/rubygems/commands/environment_command.rb
@@ -52,6 +52,9 @@ GEM_HOME environment variables. GEM_HOME sets the default repository to
 install into. GEM_PATH allows multiple local repositories to be searched for
 gems.
 
+GEM_USER_INSTALL forces the default repository to be in the user's home
+directory when set (so --[no-]user-install becomes moot).
+
 If you are behind a proxy server, RubyGems uses the HTTP_PROXY,
 HTTP_PROXY_USER and HTTP_PROXY_PASS environment variables to discover the
 proxy server.

--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -23,7 +23,8 @@ class Gem::PathSupport
   # hashtable, or defaults to ENV, the system environment.
   #
   def initialize(env)
-    @home = env["GEM_HOME"] || Gem.default_dir
+    default_dir = env["GEM_USER_INSTALL"] ? Gem.user_dir : Gem.default_dir
+    @home = env["GEM_HOME"] || default_dir
 
     if File::ALT_SEPARATOR
       @home = @home.gsub(File::ALT_SEPARATOR, File::SEPARATOR)


### PR DESCRIPTION
Many (most) people don't install gems in the default directory, but in
the user's directory (--user-install), this can be configured by
distributions using /etc/gemrc.

However, that doesn't work for bundler, which has no global
configuration.

Many bugs have been opened about this mismatch, but there's no easy
clean solution, except this.

The environment variable GEM_USER_INSTALL overrides the installation
directory (home) so it is the same as the user's home directory, so
there's effectively only one directory (and --[no-]user-install has no
effect).

Distributions can set this variable on, and then finally 'gem install'
and 'bundle install' would use the same location without user
intervention.

Fixes issue #4027.

Signed-off-by: Felipe Contreras <felipe.contreras@gmail.com>