### PR TITLE
Expose `--no-minimal-deps` flag to install the latest version of dependencies

### DIFF
--- a/lib/rubygems/dependency_installer.rb
+++ b/lib/rubygems/dependency_installer.rb
@@ -285,7 +285,7 @@ class Gem::DependencyInstaller
     request_set.prerelease = @prerelease
 
     installer_set = Gem::Resolver::InstallerSet.new @domain
-    installer_set.ignore_installed = @only_install_dir
+    installer_set.ignore_installed = (@minimal_deps == false) || @only_install_dir
 
     if consider_local?
       if dep_or_name =~ /\.gem$/ and File.file? dep_or_name

--- a/lib/rubygems/install_update_options.rb
+++ b/lib/rubygems/install_update_options.rb
@@ -122,10 +122,10 @@ module Gem::InstallUpdateOptions
       options[:minimal_deps] = true
     end
 
-    add_option(:"Install/Update", "--minimal-deps",
+    add_option(:"Install/Update", "--[no-]minimal-deps",
                 "Don't upgrade any dependencies that already",
                 "meet version requirements") do |value, options|
-      options[:minimal_deps] = true
+      options[:minimal_deps] = value
     end
 
     add_option(:"Install/Update", "--[no-]post-install-message",

--- a/test/rubygems/test_gem_dependency_installer.rb
+++ b/test/rubygems/test_gem_dependency_installer.rb
@@ -528,6 +528,40 @@ class TestGemDependencyInstaller < Gem::TestCase
     assert_equal %w[a-1 e-1], inst.installed_gems.map {|s| s.full_name }
   end
 
+  def test_install_no_minimal_deps
+    util_setup_gems
+
+    _, e1_gem = util_gem 'e', '1' do |s|
+      s.add_dependency 'b'
+    end
+
+    _, b2_gem = util_gem 'b', '2' do |s|
+      s.add_dependency 'a'
+    end
+
+    FileUtils.mv @a1_gem, @tempdir
+    FileUtils.mv @b1_gem, @tempdir
+    FileUtils.mv  b2_gem, @tempdir
+    FileUtils.mv  e1_gem, @tempdir
+
+    inst = nil
+
+    Dir.chdir @tempdir do
+      inst = Gem::DependencyInstaller.new :ignore_dependencies => true
+      inst.install 'b', req('= 1')
+    end
+
+    assert_equal %w[b-1], inst.installed_gems.map {|s| s.full_name },
+                 'sanity check'
+
+    Dir.chdir @tempdir do
+      inst = Gem::DependencyInstaller.new :minimal_deps => false
+      inst.install 'e'
+    end
+
+    assert_equal %w[a-1 b-2 e-1], inst.installed_gems.map {|s| s.full_name }
+  end
+
   def test_install_no_document
     util_setup_gems
 

--- a/test/rubygems/test_gem_install_update_options.rb
+++ b/test/rubygems/test_gem_install_update_options.rb
@@ -193,6 +193,12 @@ class TestGemInstallUpdateOptions < Gem::InstallerTestCase
     assert_equal true, @cmd.options[:post_install_message]
   end
 
+  def test_minimal_deps_no
+    @cmd.handle_options %w[--no-minimal-deps]
+
+    assert_equal false, @cmd.options[:minimal_deps]
+  end
+
   def test_minimal_deps
     @cmd.handle_options %w[--minimal-deps]
 

--- a/test/rubygems/test_gem_install_update_options.rb
+++ b/test/rubygems/test_gem_install_update_options.rb
@@ -192,4 +192,10 @@ class TestGemInstallUpdateOptions < Gem::InstallerTestCase
 
     assert_equal true, @cmd.options[:post_install_message]
   end
+
+  def test_minimal_deps
+    @cmd.handle_options %w[--minimal-deps]
+
+    assert_equal true, @cmd.options[:minimal_deps]
+  end
 end


### PR DESCRIPTION
Regardless of what's currently installed.

Fixes https://github.com/rubygems/rubygems/issues/403.

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)