### PR TITLE
add BUNDLE_NO_SUDO env var to disallow sudo

### DIFF
--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -47,6 +47,9 @@ configuration only from the local application.
 Executing bundle with the `BUNDLE_IGNORE_CONFIG` environment variable set will
 cause it to ignore all configuration.
 
+Executing bundle with the `BUNDLE_NO_SUDO` environment variable set will
+disallow using sudo.
+
 Executing `bundle config set --local disable_multisource true` upgrades the warning about
 the Gemfile containing multiple primary sources to an error. Executing `bundle
 config unset disable_multisource` downgrades this error to a warning.

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -257,7 +257,7 @@ module Bundler
     def allow_sudo?
       key = key_for(:path)
       path_configured = @temporary.key?(key) || @local_config.key?(key)
-      !path_configured
+      !path_configured && ENV["BUNDLE_NO_SUDO"].nil?
     end
 
     def ignore_config?

--- a/bundler/man/bundle-config.1
+++ b/bundler/man/bundle-config.1
@@ -57,6 +57,9 @@ Executing \fBbundle config unset \-\-local <name> <value>\fR will delete the con
 Executing bundle with the \fBBUNDLE_IGNORE_CONFIG\fR environment variable set will cause it to ignore all configuration\.
 .
 .P
+Executing bundle with the \fBBUNDLE_NO_SUDO\fR environment variable set will disallow using sudo\.
+.
+.P
 Executing \fBbundle config set \-\-local disable_multisource true\fR upgrades the warning about the Gemfile containing multiple primary sources to an error\. Executing \fBbundle config unset disable_multisource\fR downgrades this error to a warning\.
 .
 .SH "REMEMBERING OPTIONS"

--- a/bundler/spec/bundler/settings_spec.rb
+++ b/bundler/spec/bundler/settings_spec.rb
@@ -327,4 +327,13 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
       expect(settings["mirror.https://rubygems.org/"]).to eq("http://rubygems-mirror.org")
     end
   end
+
+  describe "allow_sudo?" do
+    context "when BUNDLE_NO_SUDO is set" do
+      before { ENV["BUNDLE_NO_SUDO"] = "TRUE" }
+      it "allow_sudo? is false" do
+        expect(settings.allow_sudo?).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

https://github.com/NixOS/nixpkgs/issues/101479

In nixpkgs we create a declarative readonly bundler filesystem environment, so we do not want bundler to try to edit these files, and we do not need it to warn us that it cannot edit them.

## What is your fix for the problem, implemented in this PR?

Executing bundle with the BUNDLE_NO_SUDO environment variable set will disallow using sudo.


## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
