### PR TITLE
Make sure specs don't run deprecated commands

### DIFF
--- a/bundler/spec/commands/cache_spec.rb
+++ b/bundler/spec/commands/cache_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe "bundle cache" do
         end
       end
 
-      bundle "config --local without wo"
+      bundle "config set --local without wo"
       install_gemfile <<-G
         source "file:#{gem_repo1}"
         gem "rack"
@@ -237,7 +237,7 @@ RSpec.describe "bundle cache" do
       expect(the_bundle).to include_gem "rack 1.0"
       expect(the_bundle).not_to include_gems "weakling", "uninstallable"
 
-      bundle "config --local without wo"
+      bundle "config set --local without wo"
       bundle :install
       expect(the_bundle).to include_gem "rack 1.0"
       expect(the_bundle).not_to include_gems "weakling", "uninstallable"
@@ -254,7 +254,7 @@ RSpec.describe "bundle cache" do
     end
 
     subject do
-      bundle "config --local frozen true"
+      bundle "config set --local frozen true"
       bundle :cache, :raise_on_error => false
     end
 
@@ -304,8 +304,8 @@ RSpec.describe "bundle install with gem sources" do
       simulate_new_machine
       FileUtils.rm_rf gem_repo2
 
-      bundle "config --local deployment true"
-      bundle "config --local path vendor/bundle"
+      bundle "config set --local deployment true"
+      bundle "config set --local path vendor/bundle"
       bundle :install
       expect(the_bundle).to include_gems "rack 1.0.0"
     end

--- a/bundler/spec/commands/check_spec.rb
+++ b/bundler/spec/commands/check_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe "bundle check" do
       gem "rack", :group => :foo
     G
 
-    bundle "config --local without foo"
+    bundle "config set --local without foo"
     bundle :install
 
     gemfile <<-G
@@ -217,7 +217,7 @@ RSpec.describe "bundle check" do
       gem "foo"
     G
 
-    bundle "config --local deployment true"
+    bundle "config set --local deployment true"
     bundle "install"
     FileUtils.rm(bundled_app_lock)
 

--- a/bundler/spec/commands/config_spec.rb
+++ b/bundler/spec/commands/config_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe ".bundle/config" do
 
     it "can be moved with an environment variable" do
       ENV["BUNDLE_APP_CONFIG"] = tmp("foo/bar").to_s
-      bundle "config --local path vendor/bundle"
+      bundle "config set --local path vendor/bundle"
       bundle "install"
 
       expect(bundled_app(".bundle")).not_to exist
@@ -57,7 +57,7 @@ RSpec.describe ".bundle/config" do
       FileUtils.mkdir_p bundled_app("omg")
 
       ENV["BUNDLE_APP_CONFIG"] = "../foo"
-      bundle "config --local path vendor/bundle"
+      bundle "config set --local path vendor/bundle"
       bundle "install", :dir => bundled_app("omg")
 
       expect(bundled_app(".bundle")).not_to exist

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -269,7 +269,7 @@ RSpec.describe "bundle exec" do
   end
 
   it "handles gems installed with --without" do
-    bundle "config --local without middleware"
+    bundle "config set --local without middleware"
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
       gem "rack" # rack 0.9.1 and 1.0 exist

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -291,7 +291,7 @@ RSpec.describe "bundle install with gem sources" do
       end
 
       it "works" do
-        bundle "config --local path vendor"
+        bundle "config set --local path vendor"
         bundle "install"
         expect(the_bundle).to include_gems "rack 1.0"
       end
@@ -591,7 +591,7 @@ RSpec.describe "bundle install with gem sources" do
     it "should display a proper message to explain the problem" do
       FileUtils.chmod(0o500, bundled_app("vendor"))
 
-      bundle "config --local path vendor"
+      bundle "config set --local path vendor"
       bundle :install, :raise_on_error => false
       expect(err).to include(bundled_app("vendor").to_s)
       expect(err).to include("grant write permissions")
@@ -604,7 +604,7 @@ RSpec.describe "bundle install with gem sources" do
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
-      bundle "config --local path bundle"
+      bundle "config set --local path bundle"
       bundle "install", :standalone => true
     end
 

--- a/bundler/spec/commands/post_bundle_message_spec.rb
+++ b/bundler/spec/commands/post_bundle_message_spec.rb
@@ -29,21 +29,21 @@ RSpec.describe "post bundle message" do
       expect(out).to include(bundle_complete_message)
       expect(out).to include(installed_gems_stats)
 
-      bundle "config --local without emo"
+      bundle "config set --local without emo"
       bundle :install
       expect(out).to include(bundle_show_message)
       expect(out).to include("Gems in the group emo were not installed")
       expect(out).to include(bundle_complete_message)
       expect(out).to include(installed_gems_stats)
 
-      bundle "config --local without emo test"
+      bundle "config set --local without emo test"
       bundle :install
       expect(out).to include(bundle_show_message)
       expect(out).to include("Gems in the groups emo and test were not installed")
       expect(out).to include(bundle_complete_message)
       expect(out).to include("4 Gemfile dependencies, 3 gems now installed.")
 
-      bundle "config --local without emo obama test"
+      bundle "config set --local without emo obama test"
       bundle :install
       expect(out).to include(bundle_show_message)
       expect(out).to include("Gems in the groups emo, obama and test were not installed")
@@ -55,28 +55,28 @@ RSpec.describe "post bundle message" do
       let(:bundle_path) { "./vendor" }
 
       it "shows proper messages according to the configured groups" do
-        bundle "config --local path vendor"
+        bundle "config set --local path vendor"
         bundle :install
         expect(out).to include(bundle_show_path_message)
         expect(out).to_not include("Gems in the group")
         expect(out).to include(bundle_complete_message)
 
-        bundle "config --local path vendor"
-        bundle "config --local without emo"
+        bundle "config set --local path vendor"
+        bundle "config set --local without emo"
         bundle :install
         expect(out).to include(bundle_show_path_message)
         expect(out).to include("Gems in the group emo were not installed")
         expect(out).to include(bundle_complete_message)
 
-        bundle "config --local path vendor"
-        bundle "config --local without emo test"
+        bundle "config set --local path vendor"
+        bundle "config set --local without emo test"
         bundle :install
         expect(out).to include(bundle_show_path_message)
         expect(out).to include("Gems in the groups emo and test were not installed")
         expect(out).to include(bundle_complete_message)
 
-        bundle "config --local path vendor"
-        bundle "config --local without emo obama test"
+        bundle "config set --local path vendor"
+        bundle "config set --local without emo obama test"
         bundle :install
         expect(out).to include(bundle_show_path_message)
         expect(out).to include("Gems in the groups emo, obama and test were not installed")
@@ -88,7 +88,7 @@ RSpec.describe "post bundle message" do
       let(:bundle_path) { bundled_app("cache") }
 
       it "shows proper messages according to the configured groups" do
-        bundle "config --local path #{bundle_path}"
+        bundle "config set --local path #{bundle_path}"
         bundle :install
         expect(out).to include("Bundled gems are installed into `./cache`")
         expect(out).to_not include("Gems in the group")
@@ -100,7 +100,7 @@ RSpec.describe "post bundle message" do
       let(:bundle_path) { tmp("not_bundled_app") }
 
       it "shows proper messages according to the configured groups" do
-        bundle "config --local path #{bundle_path}"
+        bundle "config set --local path #{bundle_path}"
         bundle :install
         expect(out).to include("Bundled gems are installed into `#{tmp("not_bundled_app")}`")
         expect(out).to_not include("Gems in the group")
@@ -193,19 +193,19 @@ The source does not contain any versions of 'not-a-gem'
       expect(out).not_to include("Gems in the groups")
       expect(out).to include(bundle_updated_message)
 
-      bundle "config --local without emo"
+      bundle "config set --local without emo"
       bundle :install
       bundle :update, :all => true
       expect(out).to include("Gems in the group emo were not updated")
       expect(out).to include(bundle_updated_message)
 
-      bundle "config --local without emo test"
+      bundle "config set --local without emo test"
       bundle :install
       bundle :update, :all => true
       expect(out).to include("Gems in the groups emo and test were not updated")
       expect(out).to include(bundle_updated_message)
 
-      bundle "config --local without emo obama test"
+      bundle "config set --local without emo obama test"
       bundle :install
       bundle :update, :all => true
       expect(out).to include("Gems in the groups emo, obama and test were not updated")

--- a/bundler/spec/install/deploy_spec.rb
+++ b/bundler/spec/install/deploy_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe "install in deployment or frozen mode" do
   it "still works if you are not in the app directory and specify --gemfile" do
     bundle "install"
     simulate_new_machine
-    bundle "config --local deployment true"
-    bundle "config --local path vendor/bundle"
+    bundle "config set --local deployment true"
+    bundle "config set --local path vendor/bundle"
     bundle "install --gemfile #{tmp}/bundled_app/Gemfile", :dir => tmp
     expect(the_bundle).to include_gems "rack 1.0"
   end
@@ -58,8 +58,8 @@ RSpec.describe "install in deployment or frozen mode" do
       end
     G
     bundle :install
-    bundle "config --local deployment true"
-    bundle "config --local without test"
+    bundle "config set --local deployment true"
+    bundle "config set --local without test"
     bundle :install
   end
 
@@ -67,7 +67,7 @@ RSpec.describe "install in deployment or frozen mode" do
     skip "doesn't find bundle" if Gem.win_platform?
 
     bundle :install
-    bundle "config --local deployment true"
+    bundle "config set --local deployment true"
     bundle :install
     bundle "exec bundle check", :env => { "PATH" => path }
   end
@@ -81,7 +81,7 @@ RSpec.describe "install in deployment or frozen mode" do
     G
 
     bundle :install
-    bundle "config --local deployment true"
+    bundle "config set --local deployment true"
     bundle :install
   end
 
@@ -92,7 +92,7 @@ RSpec.describe "install in deployment or frozen mode" do
       gem "rack-obama", ">= 1.0"
     G
 
-    bundle "config --local deployment true"
+    bundle "config set --local deployment true"
     bundle :install, :artifice => "endpoint_strict_basic_authentication"
   end
 
@@ -103,7 +103,7 @@ RSpec.describe "install in deployment or frozen mode" do
       end
     G
 
-    bundle "config --local deployment true"
+    bundle "config set --local deployment true"
     bundle :install
 
     expect(the_bundle).to include_gems "rack 1.0"
@@ -111,7 +111,7 @@ RSpec.describe "install in deployment or frozen mode" do
 
   context "when replacing a host with the same host with credentials" do
     before do
-      bundle "config --local path vendor/bundle"
+      bundle "config set --local path vendor/bundle"
       bundle "install"
       gemfile <<-G
       source "http://user_name:password@localgemserver.test/"
@@ -215,7 +215,7 @@ RSpec.describe "install in deployment or frozen mode" do
         gem "rack-obama"
       G
 
-      bundle "config --local deployment true"
+      bundle "config set --local deployment true"
       bundle :install, :raise_on_error => false
       expect(err).to include("deployment mode")
       expect(err).to include("You have added to the Gemfile")
@@ -234,9 +234,9 @@ RSpec.describe "install in deployment or frozen mode" do
       expect(the_bundle).to include_gems "path_gem 1.0"
       FileUtils.rm_r lib_path("path_gem-1.0")
 
-      bundle "config --local path .bundle"
-      bundle "config --local without development"
-      bundle "config --local deployment true"
+      bundle "config set --local path .bundle"
+      bundle "config set --local without development"
+      bundle "config set --local deployment true"
       bundle :install, :env => { "DEBUG" => "1" }
       run "puts :WIN"
       expect(out).to eq("WIN")
@@ -252,8 +252,8 @@ RSpec.describe "install in deployment or frozen mode" do
       expect(the_bundle).to include_gems "path_gem 1.0"
       FileUtils.rm_r lib_path("path_gem-1.0")
 
-      bundle "config --local path .bundle"
-      bundle "config --local deployment true"
+      bundle "config set --local path .bundle"
+      bundle "config set --local deployment true"
       bundle :install, :raise_on_error => false
       expect(err).to include("The path `#{lib_path("path_gem-1.0")}` does not exist.")
     end
@@ -324,7 +324,7 @@ RSpec.describe "install in deployment or frozen mode" do
         gem "activesupport"
       G
 
-      bundle "config --local deployment true"
+      bundle "config set --local deployment true"
       bundle :install, :raise_on_error => false
       expect(err).to include("deployment mode")
       expect(err).to include("You have added to the Gemfile:\n* activesupport\n\n")
@@ -338,7 +338,7 @@ RSpec.describe "install in deployment or frozen mode" do
         gem "rack", :git => "git://hubz.com"
       G
 
-      bundle "config --local deployment true"
+      bundle "config set --local deployment true"
       bundle :install, :raise_on_error => false
       expect(err).to include("deployment mode")
       expect(err).to include("You have added to the Gemfile:\n* source: git://hubz.com (at master)")
@@ -358,7 +358,7 @@ RSpec.describe "install in deployment or frozen mode" do
         gem "rack"
       G
 
-      bundle "config --local deployment true"
+      bundle "config set --local deployment true"
       bundle :install, :raise_on_error => false
       expect(err).to include("deployment mode")
       # The drive letter of the Windows environment is fragile value in GitHub Actions
@@ -385,7 +385,7 @@ RSpec.describe "install in deployment or frozen mode" do
         gem "foo", :git => "#{lib_path("rack")}"
       G
 
-      bundle "config --local deployment true"
+      bundle "config set --local deployment true"
       bundle :install, :raise_on_error => false
       expect(err).to include("deployment mode")
       # The drive letter of the Windows environment is fragile value in GitHub Actions

--- a/bundler/spec/install/gemfile/eval_gemfile_spec.rb
+++ b/bundler/spec/install/gemfile/eval_gemfile_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "bundle install with gemfile that uses eval_gemfile" do
     # parsed lockfile and the evaluated gemfile.
     it "bundles with deployment mode configured" do
       bundle :install
-      bundle "config --local deployment true"
+      bundle "config set --local deployment true"
       bundle :install
     end
   end

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -291,7 +291,7 @@ RSpec.describe "bundle install from an existing gemspec" do
           s.add_dependency "activesupport", ">= 1.0.1"
         end
 
-        bundle "config --local deployment true"
+        bundle "config set --local deployment true"
         bundle :install, :raise_on_error => false
 
         expect(err).to include("changed")
@@ -560,7 +560,7 @@ RSpec.describe "bundle install from an existing gemspec" do
     it "installs the ruby platform gemspec and skips dev deps with `without development` configured" do
       simulate_platform "ruby"
 
-      bundle "config --local without development"
+      bundle "config set --local without development"
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gemspec :path => '#{tmp.join("foo")}', :name => 'foo'

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe "bundle install with git sources" do
     end
 
     it "still works after moving the application directory" do
-      bundle "config --local path vendor/bundle"
+      bundle "config set --local path vendor/bundle"
       bundle "install"
 
       FileUtils.mv bundled_app, tmp("bundled_app.bck")
@@ -133,7 +133,7 @@ RSpec.describe "bundle install with git sources" do
     end
 
     it "can still install after moving the application directory" do
-      bundle "config --local path vendor/bundle"
+      bundle "config set --local path vendor/bundle"
       bundle "install"
 
       FileUtils.mv bundled_app, tmp("bundled_app.bck")
@@ -1062,7 +1062,7 @@ RSpec.describe "bundle install with git sources" do
 
       simulate_new_machine
 
-      bundle "config --local deployment true"
+      bundle "config set --local deployment true"
       bundle :install
     end
   end

--- a/bundler/spec/install/gemfile/groups_spec.rb
+++ b/bundler/spec/install/gemfile/groups_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "bundle install with groups" do
       end
 
       it "installs gems in the default group" do
-        bundle "config --local without emo"
+        bundle "config set --local without emo"
         bundle :install
         expect(the_bundle).to include_gems "rack 1.0.0", :groups => [:default]
       end
@@ -101,7 +101,7 @@ RSpec.describe "bundle install with groups" do
       end
 
       it "does not install gems from the excluded group" do
-        bundle "config --local without emo"
+        bundle "config set --local without emo"
         bundle :install
         expect(the_bundle).not_to include_gems "activesupport 2.3.5", :groups => [:default]
       end
@@ -114,13 +114,13 @@ RSpec.describe "bundle install with groups" do
       end
 
       it "does not say it installed gems from the excluded group" do
-        bundle "config --local without emo"
+        bundle "config set --local without emo"
         bundle :install
         expect(out).not_to include("activesupport")
       end
 
       it "allows Bundler.setup for specific groups" do
-        bundle "config --local without emo"
+        bundle "config set --local without emo"
         bundle :install
         run("require 'rack'; puts RACK", :default)
         expect(out).to eq("1.0.0")
@@ -135,7 +135,7 @@ RSpec.describe "bundle install with groups" do
           end
         G
 
-        bundle "config --local without emo"
+        bundle "config set --local without emo"
         bundle :install
         expect(the_bundle).to include_gems "activesupport 2.3.2", :groups => [:default]
       end
@@ -172,7 +172,7 @@ RSpec.describe "bundle install with groups" do
       end
 
       it "installs gems from the optional group when requested" do
-        bundle "config --local with debugging"
+        bundle "config set --local with debugging"
         bundle :install
         expect(the_bundle).to include_gems "thin 1.0"
       end
@@ -198,13 +198,13 @@ RSpec.describe "bundle install with groups" do
       end
 
       it "removes groups from without when passed at --with", :bundler => "< 3" do
-        bundle "config --local without emo"
+        bundle "config set --local without emo"
         bundle "install --with emo"
         expect(the_bundle).to include_gems "activesupport 2.3.5"
       end
 
       it "removes groups from with when passed at --without", :bundler => "< 3" do
-        bundle "config --local with debugging"
+        bundle "config set --local with debugging"
         bundle "install --without debugging", :raise_on_error => false
         expect(the_bundle).not_to include_gem "thin 1.0"
       end
@@ -235,13 +235,13 @@ RSpec.describe "bundle install with groups" do
       end
 
       it "has no effect when listing a not optional group in with" do
-        bundle "config --local with emo"
+        bundle "config set --local with emo"
         bundle :install
         expect(the_bundle).to include_gems "activesupport 2.3.5"
       end
 
       it "has no effect when listing an optional group in without" do
-        bundle "config --local without debugging"
+        bundle "config set --local without debugging"
         bundle :install
         expect(the_bundle).not_to include_gems "thin 1.0"
       end
@@ -259,13 +259,13 @@ RSpec.describe "bundle install with groups" do
       end
 
       it "installs gems in the default group" do
-        bundle "config --local without emo lolercoaster"
+        bundle "config set --local without emo lolercoaster"
         bundle :install
         expect(the_bundle).to include_gems "rack 1.0.0"
       end
 
       it "installs the gem if any of its groups are installed" do
-        bundle "config --local without emo"
+        bundle "config set --local without emo"
         bundle :install
         expect(the_bundle).to include_gems "rack 1.0.0", "activesupport 2.3.5"
       end
@@ -287,19 +287,19 @@ RSpec.describe "bundle install with groups" do
         end
 
         it "installs the gem unless all groups are excluded" do
-          bundle "config --local without emo"
+          bundle "config set --local without emo"
           bundle :install
           expect(the_bundle).to include_gems "activesupport 2.3.5"
 
-          bundle "config --local without lolercoaster"
+          bundle "config set --local without lolercoaster"
           bundle :install
           expect(the_bundle).to include_gems "activesupport 2.3.5"
 
-          bundle "config --local without emo lolercoaster"
+          bundle "config set --local without emo lolercoaster"
           bundle :install
           expect(the_bundle).not_to include_gems "activesupport 2.3.5"
 
-          bundle "config --local without 'emo lolercoaster'"
+          bundle "config set --local without 'emo lolercoaster'"
           bundle :install
           expect(the_bundle).not_to include_gems "activesupport 2.3.5"
         end
@@ -320,13 +320,13 @@ RSpec.describe "bundle install with groups" do
       end
 
       it "installs gems in the default group" do
-        bundle "config --local without emo lolercoaster"
+        bundle "config set --local without emo lolercoaster"
         bundle :install
         expect(the_bundle).to include_gems "rack 1.0.0"
       end
 
       it "installs the gem if any of its groups are installed" do
-        bundle "config --local without emo"
+        bundle "config set --local without emo"
         bundle :install
         expect(the_bundle).to include_gems "rack 1.0.0", "activesupport 2.3.5"
       end
@@ -364,7 +364,7 @@ RSpec.describe "bundle install with groups" do
 
       system_gems "rack-0.9.1"
 
-      bundle "config --local without rack"
+      bundle "config set --local without rack"
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "rack"
@@ -388,7 +388,7 @@ RSpec.describe "bundle install with groups" do
 
     it "does not hit the remote a second time" do
       FileUtils.rm_rf gem_repo2
-      bundle "config --local without rack"
+      bundle "config set --local without rack"
       bundle :install, :verbose => true
       expect(last_command.stdboth).not_to match(/fetching/i)
     end

--- a/bundler/spec/install/gemfile/path_spec.rb
+++ b/bundler/spec/install/gemfile/path_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe "bundle install with explicit source paths" do
       gem 'foo', :path => File.expand_path("../foo-1.0", __FILE__)
     G
 
-    bundle "config --local frozen true"
+    bundle "config set --local frozen true"
     bundle :install
   end
 

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -317,7 +317,7 @@ RSpec.describe "bundle install across platforms" do
       gem "rack", "1.0.0"
     G
 
-    bundle "config --local path vendor/bundle"
+    bundle "config set --local path vendor/bundle"
     bundle :install
 
     FileUtils.mv(vendored_gems, bundled_app("vendor/bundle", Gem.ruby_engine, "1.8"))

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
         expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
         expect(bundled_app("vendor/cache/rack-obama-1.0.gem")).to exist
 
-        bundle "config --local deployment true"
+        bundle "config set --local deployment true"
         bundle :install
 
         expect(the_bundle).to include_gems("rack-obama 1.0.0", "rack 1.0.0")
@@ -486,7 +486,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
         gem 'bar', '~> 0.1', :source => '#{file_uri_for(gem_repo4)}'
       G
 
-      bundle "config --local path ../gems/system"
+      bundle "config set --local path ../gems/system"
       bundle :install
 
       # And then we add some new versions...

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -80,8 +80,8 @@ RSpec.describe "compact index api" do
     G
     bundle :install, :artifice => "compact_index"
 
-    bundle "config --local deployment true"
-    bundle "config --local path vendor/bundle"
+    bundle "config set --local deployment true"
+    bundle "config set --local path vendor/bundle"
     bundle :install, :artifice => "compact_index"
     expect(out).to include("Fetching gem metadata from #{source_uri}")
     expect(the_bundle).to include_gems "rack 1.0.0"
@@ -118,7 +118,7 @@ RSpec.describe "compact index api" do
 
     bundle :install, :artifice => "compact_index"
 
-    bundle "config --local deployment true"
+    bundle "config set --local deployment true"
     bundle :install, :artifice => "compact_index"
 
     expect(the_bundle).to include_gems("rails 2.3.2")
@@ -132,7 +132,7 @@ RSpec.describe "compact index api" do
     G
 
     bundle "install", :artifice => "compact_index"
-    bundle "config --local deployment true"
+    bundle "config set --local deployment true"
     bundle :install, :artifice => "compact_index"
 
     expect(the_bundle).to include_gems("foo 1.0")
@@ -503,7 +503,7 @@ The checksum of /versions does not match the checksum provided by the server! So
     G
 
     bundle :install, :artifice => "compact_index_extra"
-    bundle "config --local deployment true"
+    bundle "config set --local deployment true"
     bundle :install, :artifice => "compact_index_extra"
     expect(the_bundle).to include_gems "back_deps 1.0"
   end

--- a/bundler/spec/install/gems/dependency_api_spec.rb
+++ b/bundler/spec/install/gems/dependency_api_spec.rb
@@ -60,8 +60,8 @@ RSpec.describe "gemcutter's dependency API" do
     G
     bundle :install, :artifice => "endpoint"
 
-    bundle "config --local deployment true"
-    bundle "config --local path vendor/bundle"
+    bundle "config set --local deployment true"
+    bundle "config set --local path vendor/bundle"
     bundle :install, :artifice => "endpoint"
     expect(out).to include("Fetching gem metadata from #{source_uri}")
     expect(the_bundle).to include_gems "rack 1.0.0"
@@ -98,7 +98,7 @@ RSpec.describe "gemcutter's dependency API" do
 
     bundle :install, :artifice => "endpoint"
 
-    bundle "config --local deployment true"
+    bundle "config set --local deployment true"
     bundle :install, :artifice => "endpoint"
 
     expect(the_bundle).to include_gems("rails 2.3.2")
@@ -112,7 +112,7 @@ RSpec.describe "gemcutter's dependency API" do
     G
 
     bundle "install", :artifice => "endpoint"
-    bundle "config --local deployment true"
+    bundle "config set --local deployment true"
     bundle :install, :artifice => "endpoint"
 
     expect(the_bundle).to include_gems("foo 1.0")
@@ -475,7 +475,7 @@ RSpec.describe "gemcutter's dependency API" do
 
     bundle :install, :artifice => "endpoint_extra"
 
-    bundle "config --local deployment true"
+    bundle "config set --local deployment true"
     bundle "install", :artifice => "endpoint_extra"
     expect(the_bundle).to include_gems "back_deps 1.0"
   end

--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -55,7 +55,7 @@ RSpec.shared_examples "bundle install --standalone" do
         source "#{file_uri_for(gem_repo1)}"
         gem "rails"
       G
-      bundle "config --local path #{bundled_app("bundle")}"
+      bundle "config set --local path #{bundled_app("bundle")}"
       bundle :install, :standalone => true, :dir => cwd
     end
 
@@ -71,7 +71,7 @@ RSpec.shared_examples "bundle install --standalone" do
 
   describe "with gems with native extension", :ruby_repo do
     before do
-      bundle "config --local path #{bundled_app("bundle")}"
+      bundle "config set --local path #{bundled_app("bundle")}"
       install_gemfile <<-G, :standalone => true, :dir => cwd
         source "#{file_uri_for(gem_repo1)}"
         gem "very_simple_binary"
@@ -105,7 +105,7 @@ RSpec.shared_examples "bundle install --standalone" do
           end
         G
       end
-      bundle "config --local path #{bundled_app("bundle")}"
+      bundle "config set --local path #{bundled_app("bundle")}"
       install_gemfile <<-G, :standalone => true, :dir => cwd, :raise_on_error => false
         gem "bar", :git => "#{lib_path("bar-1.0")}"
       G
@@ -126,7 +126,7 @@ RSpec.shared_examples "bundle install --standalone" do
         gem "rails"
         gem "devise", :git => "#{lib_path("devise-1.0")}"
       G
-      bundle "config --local path #{bundled_app("bundle")}"
+      bundle "config set --local path #{bundled_app("bundle")}"
       bundle :install, :standalone => true, :dir => cwd
     end
 
@@ -154,7 +154,7 @@ RSpec.shared_examples "bundle install --standalone" do
           gem "rack-test"
         end
       G
-      bundle "config --local path #{bundled_app("bundle")}"
+      bundle "config set --local path #{bundled_app("bundle")}"
       bundle :install, :standalone => true, :dir => cwd
     end
 
@@ -168,7 +168,7 @@ RSpec.shared_examples "bundle install --standalone" do
     include_examples "common functionality"
 
     it "allows creating a standalone file with limited groups" do
-      bundle "config --local path #{bundled_app("bundle")}"
+      bundle "config set --local path #{bundled_app("bundle")}"
       bundle :install, :standalone => "default", :dir => cwd
 
       load_error_ruby <<-RUBY, "spec"
@@ -185,8 +185,8 @@ RSpec.shared_examples "bundle install --standalone" do
     end
 
     it "allows `without` configuration to limit the groups used in a standalone" do
-      bundle "config --local path #{bundled_app("bundle")}"
-      bundle "config --local without test"
+      bundle "config set --local path #{bundled_app("bundle")}"
+      bundle "config set --local without test"
       bundle :install, :standalone => true, :dir => cwd
 
       load_error_ruby <<-RUBY, "spec"
@@ -203,7 +203,7 @@ RSpec.shared_examples "bundle install --standalone" do
     end
 
     it "allows `path` configuration to change the location of the standalone bundle" do
-      bundle "config --local path path/to/bundle"
+      bundle "config set --local path path/to/bundle"
       bundle "install", :standalone => true, :dir => cwd
 
       ruby <<-RUBY
@@ -218,9 +218,9 @@ RSpec.shared_examples "bundle install --standalone" do
     end
 
     it "allows `without` to limit the groups used in a standalone" do
-      bundle "config --local without test"
+      bundle "config set --local without test"
       bundle :install, :dir => cwd
-      bundle "config --local path #{bundled_app("bundle")}"
+      bundle "config set --local path #{bundled_app("bundle")}"
       bundle :install, :standalone => true, :dir => cwd
 
       load_error_ruby <<-RUBY, "spec"
@@ -246,7 +246,7 @@ RSpec.shared_examples "bundle install --standalone" do
           source "#{source_uri}"
           gem "rails"
         G
-        bundle "config --local path #{bundled_app("bundle")}"
+        bundle "config set --local path #{bundled_app("bundle")}"
         bundle :install, :standalone => true, :artifice => "endpoint", :dir => cwd
       end
 
@@ -267,7 +267,7 @@ RSpec.shared_examples "bundle install --standalone" do
         source "#{file_uri_for(gem_repo1)}"
         gem "rails"
       G
-      bundle "config --local path #{bundled_app("bundle")}"
+      bundle "config set --local path #{bundled_app("bundle")}"
       bundle :install, :standalone => true, :binstubs => true, :dir => cwd
     end
 

--- a/bundler/spec/install/git_spec.rb
+++ b/bundler/spec/install/git_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe "bundle install" do
           foo!
       L
 
-      bundle "config --local path vendor/bundle"
-      bundle "config --local without development"
+      bundle "config set --local path vendor/bundle"
+      bundle "config set --local without development"
       bundle :install
 
       expect(out).to include("Bundle complete!")

--- a/bundler/spec/install/path_spec.rb
+++ b/bundler/spec/install/path_spec.rb
@@ -14,14 +14,14 @@ RSpec.describe "bundle install" do
     end
 
     it "does not use available system gems with `vendor/bundle" do
-      bundle "config --local path vendor/bundle"
+      bundle "config set --local path vendor/bundle"
       bundle :install
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
 
     it "uses system gems with `path.system` configured with more priority than `path`" do
-      bundle "config --local path.system true"
-      bundle "config --global path vendor/bundle"
+      bundle "config set --local path.system true"
+      bundle "config set --global path vendor/bundle"
       bundle :install
       run "require 'rack'", :raise_on_error => false
       expect(out).to include("FAIL")
@@ -31,7 +31,7 @@ RSpec.describe "bundle install" do
       dir = bundled_app("bun++dle")
       dir.mkpath
 
-      bundle "config --local path #{dir.join("vendor/bundle")}"
+      bundle "config set --local path #{dir.join("vendor/bundle")}"
       bundle :install, :dir => dir
       expect(out).to include("installed into `./vendor/bundle`")
 
@@ -39,7 +39,7 @@ RSpec.describe "bundle install" do
     end
 
     it "prints a message to let the user know where gems where installed" do
-      bundle "config --local path vendor/bundle"
+      bundle "config set --local path vendor/bundle"
       bundle :install
       expect(out).to include("gems are installed into `./vendor/bundle`")
     end
@@ -109,7 +109,7 @@ RSpec.describe "bundle install" do
       context "when set via #{type}" do
         it "installs gems to a path if one is specified" do
           set_bundle_path(type, bundled_app("vendor2").to_s)
-          bundle "config --local path vendor/bundle"
+          bundle "config set --local path vendor/bundle"
           bundle :install
 
           expect(vendored_gems("gems/rack-1.0.0")).to be_directory
@@ -159,7 +159,7 @@ RSpec.describe "bundle install" do
     end
 
     it "sets BUNDLE_PATH as the first argument to bundle install" do
-      bundle "config --local path ./vendor/bundle"
+      bundle "config set --local path ./vendor/bundle"
       bundle :install
 
       expect(vendored_gems("gems/rack-1.0.0")).to be_directory
@@ -169,7 +169,7 @@ RSpec.describe "bundle install" do
     it "disables system gems when passing a path to install" do
       # This is so that vendored gems can be distributed to others
       build_gem "rack", "1.1.0", :to_system => true
-      bundle "config --local path ./vendor/bundle"
+      bundle "config set --local path ./vendor/bundle"
       bundle :install
 
       expect(vendored_gems("gems/rack-1.0.0")).to be_directory
@@ -186,7 +186,7 @@ RSpec.describe "bundle install" do
         gem "very_simple_binary"
       G
 
-      bundle "config --local path ./vendor/bundle"
+      bundle "config set --local path ./vendor/bundle"
       bundle :install
 
       expect(vendored_gems("gems/very_simple_binary-1.0")).to be_directory
@@ -198,7 +198,7 @@ RSpec.describe "bundle install" do
       run "require 'very_simple_binary_c'", :raise_on_error => false
       expect(err).to include("Bundler::GemNotFound")
 
-      bundle "config --local path ./vendor/bundle"
+      bundle "config set --local path ./vendor/bundle"
       bundle :install
 
       expect(vendored_gems("gems/very_simple_binary-1.0")).to be_directory
@@ -218,7 +218,7 @@ RSpec.describe "bundle install" do
         gem "rack"
       G
 
-      bundle "config --local path bundle"
+      bundle "config set --local path bundle"
       bundle :install, :raise_on_error => false
       expect(err).to include("file already exists")
     end

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -1235,7 +1235,7 @@ RSpec.describe "the lockfile format" do
       gem "omg", :git => "#{lib_path("omg")}", :branch => 'master'
     G
 
-    bundle "config --local path vendor"
+    bundle "config set --local path vendor"
     bundle :install
     expect(the_bundle).to include_gems "omg 1.0"
 

--- a/bundler/spec/plugins/install_spec.rb
+++ b/bundler/spec/plugins/install_spec.rb
@@ -228,7 +228,7 @@ RSpec.describe "bundler plugin install" do
           gem 'rack', "1.0.0"
         G
 
-        bundle "config --local deployment true"
+        bundle "config set --local deployment true"
         install_gemfile <<-G
           source '#{file_uri_for(gem_repo2)}'
           plugin 'foo'

--- a/bundler/spec/plugins/source/example_spec.rb
+++ b/bundler/spec/plugins/source/example_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe "real source plugins" do
       end
 
       it "copies repository to vendor cache and uses it even when installed with `path` configured" do
-        bundle "config --local path vendor/bundle"
+        bundle "config set --local path vendor/bundle"
         bundle :install
         bundle "config set cache_all true"
         bundle :cache
@@ -169,7 +169,7 @@ RSpec.describe "real source plugins" do
       end
 
       it "bundler package copies repository to vendor cache" do
-        bundle "config --local path vendor/bundle"
+        bundle "config set --local path vendor/bundle"
         bundle :install
         bundle "config set cache_all true"
         bundle :cache

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -493,14 +493,14 @@ RSpec.describe "Bundler.setup" do
     end
 
     it "works even when the cache directory has been deleted" do
-      bundle "config --local path vendor/bundle"
+      bundle "config set --local path vendor/bundle"
       bundle :install
       FileUtils.rm_rf vendored_gems("cache")
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
 
     it "does not randomly change the path when specifying --path and the bundle directory becomes read only" do
-      bundle "config --local path vendor/bundle"
+      bundle "config set --local path vendor/bundle"
       bundle :install
 
       with_read_only("#{bundled_app}/**/*") do
@@ -604,7 +604,7 @@ RSpec.describe "Bundler.setup" do
 
   describe "when excluding groups" do
     it "doesn't change the resolve if --without is used" do
-      bundle "config --local without rails"
+      bundle "config set --local without rails"
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "activesupport"
@@ -620,7 +620,7 @@ RSpec.describe "Bundler.setup" do
     end
 
     it "remembers --without and does not bail on bare Bundler.setup" do
-      bundle "config --local without rails"
+      bundle "config set --local without rails"
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "activesupport"
@@ -636,7 +636,7 @@ RSpec.describe "Bundler.setup" do
     end
 
     it "remembers --without and does not bail on bare Bundler.setup, even in the case of path gems no longer available" do
-      bundle "config --local without development"
+      bundle "config set --local without development"
 
       path = bundled_app(File.join("vendor", "foo"))
       build_lib "foo", :path => path
@@ -656,7 +656,7 @@ RSpec.describe "Bundler.setup" do
     end
 
     it "remembers --without and does not include groups passed to Bundler.setup" do
-      bundle "config --local without rails"
+      bundle "config set --local without rails"
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "activesupport"


### PR DESCRIPTION
Just normalizing calls to `bundle config` inside specs so that they don't warn.

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)