### PR TITLE
Add missing `fileutils` require in rubygems installer

### DIFF
--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -30,11 +30,15 @@ RSpec.describe "bundle install with git sources" do
       expect(Dir["#{default_bundle_path}/cache/bundler/git/foo-1.0-*"]).to have_attributes :size => 1
     end
 
-    it "caches the git repo globally" do
+    it "caches the git repo globally and properly uses the cached repo on the next invocation" do
       simulate_new_machine
       bundle "config set global_gem_cache true"
       bundle :install
       expect(Dir["#{home}/.bundle/cache/git/foo-1.0-*"]).to have_attributes :size => 1
+
+      bundle "install --verbose"
+      expect(err).to be_empty
+      expect(out).to include("Using foo 1.0 from #{lib_path("foo")}")
     end
 
     it "caches the evaluated gemspec" do

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -523,6 +523,7 @@ module Spec
           file = Pathname.new(path).join(file)
           FileUtils.mkdir_p(file.dirname)
           File.open(file, "w") {|f| f.puts source }
+          File.chmod("+x", file) if @spec.executables.map {|exe| "#{@spec.bindir}/#{exe}" }.include?(file)
         end
         path
       end

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -530,6 +530,7 @@ class Gem::Installer
   def generate_bin_script(filename, bindir)
     bin_script_path = File.join bindir, formatted_program_filename(filename)
 
+    require 'fileutils'
     FileUtils.rm_f bin_script_path # prior install may have been --no-wrappers
 
     File.open bin_script_path, 'wb', 0755 do |file|


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When bundling a git gem including executables, the second time `bundle install`
is run (when the gem has been cached), we would get a crash like:

```
NameError: uninitialized constant Gem::Installer::FileUtils
Did you mean?  FileTest
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/installer.rb:536:in `generate_bin_script'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/installer.rb:506:in `block in generate_bin'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/installer.rb:482:in `each'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/installer.rb:482:in `generate_bin'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/bundler/source/path/installer.rb:46:in `generate_bin'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/bundler/source/path/installer.rb:36:in `post_install'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/bundler/source/path.rb:242:in `generate_bin'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/bundler/source/git.rb:184:in `install'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/bundler/installer/gem_installer.rb:67:in `install'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/bundler/installer/gem_installer.rb:18:in `install_from_spec'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/bundler/installer/parallel_installer.rb:163:in `do_install'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/bundler/installer/parallel_installer.rb:148:in `install_serially'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/bundler/installer/parallel_installer.rb:99:in `call'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/bundler/installer/parallel_installer.rb:78:in `call'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/bundler/installer.rb:285:in `install_in_parallel'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/bundler/installer.rb:209:in `install'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/bundler/installer.rb:91:in `block in run'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/bundler/process_lock.rb:12:in `block in lock'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/bundler/process_lock.rb:9:in `open'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/bundler/process_lock.rb:9:in `lock'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/bundler/installer.rb:72:in `run'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/bundler/installer.rb:24:in `install'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/bundler/cli/install.rb:64:in `run'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/bundler/cli.rb:262:in `block in install'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/bundler/settings.rb:116:in `temporary'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/bundler/cli.rb:261:in `install'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/bundler/cli.rb:30:in `dispatch'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/bundler/cli.rb:24:in `start'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.0.rc.2/exe/bundle:49:in `block in <top (required)>'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/bundler/friendly_errors.rb:117:in `with_friendly_errors'
  /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.0.rc.2/exe/bundle:37:in `<top (required)>'
  /home/deivid/.rbenv/versions/2.7.2/bin/bundle:23:in `load'
  /home/deivid/.rbenv/versions/2.7.2/bin/bundle:23:in `<main>'
  /home/deivid/.rbenv/versions/2.7.2/bin/ruby_executable_hooks:24:in `eval'
  /home/deivid/.rbenv/versions/2.7.2/bin/ruby_executable_hooks:24:in `<main>'
```

## What is your fix for the problem, implemented in this PR?

Bundler inherits from rubygems installer and uses this method directly. It can happen that `fileutils` is not yet required at that point.

To repro the issue I needed to make sure that the executables inside dummy specs have the executable bit set. Otherwise a different code path that _does_ require `fileutils` is run. This seems like a good thing anyways since it better resembles the real world.

The fix is to add the missing require.

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)