### PR TITLE
Make printed drive letters consistent on Windows

### DIFF
--- a/bundler/lib/bundler/uri_credentials_filter.rb
+++ b/bundler/lib/bundler/uri_credentials_filter.rb
@@ -8,6 +8,8 @@ module Bundler
       return uri_to_anonymize if uri_to_anonymize.nil?
       uri = uri_to_anonymize.dup
       if uri.is_a?(String)
+        return uri if File.exist?(uri)
+
         require_relative "vendored_uri"
         uri = Bundler::URI(uri)
       end

--- a/bundler/spec/install/deploy_spec.rb
+++ b/bundler/spec/install/deploy_spec.rb
@@ -361,10 +361,7 @@ RSpec.describe "install in deployment or frozen mode" do
       bundle "config --local deployment true"
       bundle :install, :raise_on_error => false
       expect(err).to include("deployment mode")
-      # The drive letter of the Windows environment is fragile value in GitHub Actions
-      unless Gem.win_platform?
-        expect(err).to include("You have deleted from the Gemfile:\n* source: #{lib_path("rack-1.0")} (at master@#{revision_for(lib_path("rack-1.0"))[0..6]}")
-      end
+      expect(err).to include("You have deleted from the Gemfile:\n* source: #{lib_path("rack-1.0")} (at master@#{revision_for(lib_path("rack-1.0"))[0..6]}")
       expect(err).not_to include("You have added to the Gemfile")
       expect(err).not_to include("You have changed in the Gemfile")
     end
@@ -388,10 +385,7 @@ RSpec.describe "install in deployment or frozen mode" do
       bundle "config --local deployment true"
       bundle :install, :raise_on_error => false
       expect(err).to include("deployment mode")
-      # The drive letter of the Windows environment is fragile value in GitHub Actions
-      unless Gem.win_platform?
-        expect(err).to include("You have changed in the Gemfile:\n* rack from `no specified source` to `#{lib_path("rack")} (at master@#{revision_for(lib_path("rack"))[0..6]})`")
-      end
+      expect(err).to include("You have changed in the Gemfile:\n* rack from `no specified source` to `#{lib_path("rack")} (at master@#{revision_for(lib_path("rack"))[0..6]})`")
       expect(err).not_to include("You have added to the Gemfile")
       expect(err).not_to include("You have deleted from the Gemfile")
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes driver letters are printed with inconsistent casing on Windows. This is unexpected and sometimes can cause surprising test failures, like the ones I'm unskipping here and like https://github.com/rubygems/rubygems/runs/1310494829?check_suite_focus=true.

The problem is that the helper that removes credentials from URLs for display, does the following when passed an actual file with a Windows driver letter.

```
URI("A:/foo").to_s
=> "a:/foo"
```

Namely, the `uri` library interprets the drive letter as the scheme and downcases it, causing the inconsistency.

## What is your fix for the problem, implemented in this PR?

My fix is to make the helper return the original argument when the string given is an actual file, since I believe in that case we can safely assume it includes no credentials.

An alternative would be to wrap the passed string with `file://` to give it a proper scheme, and then remove it after cleanup and before returning from the method. However, the initial approach is simpler and I think it's also safe.

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)