### PR TITLE
Fix incorrect error message on Windows

### DIFF
--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -118,7 +118,7 @@ module Bundler
               git_retry %(clone --no-checkout --quiet "#{path}" "#{destination}")
               File.chmod(((File.stat(destination).mode | 0o777) & ~File.umask), destination)
             rescue Errno::EEXIST => e
-              file_path = e.message[%r{.*?(/.*)}, 1]
+              file_path = e.message[%r{.*?((?:[a-zA-Z]:)?/.*)}, 1]
               raise GitError, "Bundler could not install a gem because it needs to " \
                 "create a directory, but a file exists - #{file_path}. Please delete " \
                 "this file and try again."

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -933,8 +933,6 @@ RSpec.describe "bundle install with git sources" do
   end
 
   it "prints a friendly error if a file blocks the git repo" do
-    skip "drive letter is not detected correctly in error message" if Gem.win_platform?
-
     build_git "foo"
 
     FileUtils.mkdir_p(default_bundle_path)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We're parsing the exception message here looking for a path, but we were not considering potential drive letters on Windows. So we were showing an invalid path in the final error.

## What is your fix for the problem, implemented in this PR?

Add an optional part to the regexp to also capture the drive letter.

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)