### PR TITLE
Fix ruby-core intermittent test failure

### DIFF
--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'benchmark'
 require 'rubygems/test_case'
+require 'date'
 require 'pathname'
 require 'stringio'
 require 'rubygems/ext'


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

An intermittent test failure on the CI jobs that simulate running tests from ruby-core. For example, https://github.com/rubygems/rubygems/pull/4039/checks?check_run_id=1314248387.

It only happens randomly. I guess depending on the order tests run, the require is sometimes provided by previous tests and sometimes not.

It can be reproduced on a copy of ruby/ruby, with

```
$ ruby tool/sync_default_gems.rb rubygems
$ make test-all TESTS="test/rubygems/test_gem_specification.rb -j2"
```

Most likely introduced by 0af1449db90748d5f484898825147f2169a7d5dd.

## What is your fix for the problem, implemented in this PR?

Fix it by requiring `date` on top of the file using it.

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)