### PR TITLE
Remove extra empty line from README template

### DIFF
--- a/bundler/lib/bundler/templates/newgem/README.md.tt
+++ b/bundler/lib/bundler/templates/newgem/README.md.tt
@@ -33,7 +33,6 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/<%= config[:github_username] %>/<%= config[:name] %>.<% if config[:coc] %> This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/<%= config[:github_username] %>/<%= config[:name] %>/blob/master/CODE_OF_CONDUCT.md).<% end %>
-
 <% if config[:mit] -%>
 
 ## License


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`bundle gem my_gem --mit` generates README.md that contains extra empty line like this:

```
## Contributing

Bug reports and pull requests are welcome on GitHub at https://github.com/r7kamura/my_gem.


## License

The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
```

## What is your fix for the problem, implemented in this PR?

Removed an empty line placed before the License section from README template (README.md.tt).

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
