### PR TITLE
Fix issue with `cache_all_platforms` and `specific_platform` configured

### DIFF
--- a/bundler/lib/bundler/installer.rb
+++ b/bundler/lib/bundler/installer.rb
@@ -299,7 +299,7 @@ module Bundler
 
     # returns whether or not a re-resolve was needed
     def resolve_if_needed(options)
-      if !@definition.unlocking? && !options["force"] && !options["all-platforms"] && !Bundler.settings[:inline] && Bundler.default_lockfile.file?
+      if !@definition.unlocking? && !options["force"] && !Bundler.settings[:inline] && Bundler.default_lockfile.file?
         return false if @definition.nothing_changed? && !@definition.missing_specs?
       end
 

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -100,6 +100,7 @@ module Bundler
       @specs.map do |s|
         next s unless s.is_a?(LazySpecification)
         s.source.dependency_names = names if s.source.respond_to?(:dependency_names=)
+        s.source.remote!
         spec = s.__materialize__
         raise GemNotFound, "Could not find #{s.full_name} in any of the sources" unless spec
         spec

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "bundle install with specific_platform enabled" do
     it "caches both the universal-darwin and ruby gems when --all-platforms is passed and properly picks them up on further bundler invocations" do
       setup_multiplatform_gem
       gemfile(google_protobuf)
-      bundle "package --all-platforms"
+      bundle "cache --all-platforms"
       expect([cached_gem("google-protobuf-3.0.0.alpha.5.0.5.1"), cached_gem("google-protobuf-3.0.0.alpha.5.0.5.1-universal-darwin")]).
         to all(exist)
 

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -36,6 +36,18 @@ RSpec.describe "bundle install with specific_platform enabled" do
       expect(err).to be_empty
     end
 
+    it "caches both the universal-darwin and ruby gems when cache_all_platforms is configured and properly picks them up on further bundler invocations" do
+      setup_multiplatform_gem
+      gemfile(google_protobuf)
+      bundle "config set --local cache_all_platforms true"
+      bundle "cache"
+      expect([cached_gem("google-protobuf-3.0.0.alpha.5.0.5.1"), cached_gem("google-protobuf-3.0.0.alpha.5.0.5.1-universal-darwin")]).
+        to all(exist)
+
+      bundle "install --verbose"
+      expect(err).to be_empty
+    end
+
     it "caches multiplatform git gems with a single gemspec when --all-platforms is passed" do
       git = build_git "pg_array_parser", "1.0"
 

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -25,12 +25,15 @@ RSpec.describe "bundle install with specific_platform enabled" do
       ])
     end
 
-    it "caches both the universal-darwin and ruby gems when --all-platforms is passed" do
+    it "caches both the universal-darwin and ruby gems when --all-platforms is passed and properly picks them up on further bundler invocations" do
       setup_multiplatform_gem
       gemfile(google_protobuf)
       bundle "package --all-platforms"
       expect([cached_gem("google-protobuf-3.0.0.alpha.5.0.5.1"), cached_gem("google-protobuf-3.0.0.alpha.5.0.5.1-universal-darwin")]).
         to all(exist)
+
+      bundle "install --verbose"
+      expect(err).to be_empty
     end
 
     it "caches multiplatform git gems with a single gemspec when --all-platforms is passed" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In this case, when running `bundle install`, bundler would be unable to find some gems when updating the cache.

The reason is that the set of specs is initially materialized for the current platform for the standard `bundle install` behavior. But then when bundler tries to update the cache, the sources have that set of specs cached, and bundler is unable to find specs that are not for the current platform.

## What is your fix for the problem, implemented in this PR?

The solution is to invalidate sources cache before materializing for all platforms, so that remote platform specific versions are considered.

Fixes #3328.

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)