### PR TITLE
Fix `--platform` option to `gem specification` being ignored

### DIFF
--- a/lib/rubygems/commands/specification_command.rb
+++ b/lib/rubygems/commands/specification_command.rb
@@ -126,6 +126,12 @@ Specific fields in the specification can be extracted in YAML format:
       terminate_interaction 1
     end
 
+    platform = get_platform_from_requirements(options)
+
+    if platform
+      specs = specs.select{|s| s.platform.to_s == platform }
+    end
+
     unless options[:all]
       specs = [specs.max_by {|s| s.version }]
     end

--- a/lib/rubygems/commands/yank_command.rb
+++ b/lib/rubygems/commands/yank_command.rb
@@ -92,8 +92,4 @@ data you will need to change them immediately and yank your gem.
   rescue
     nil
   end
-
-  def get_platform_from_requirements(requirements)
-    Gem.platforms[1].to_s if requirements.key? :added_platform
-  end
 end

--- a/lib/rubygems/version_option.rb
+++ b/lib/rubygems/version_option.rb
@@ -73,4 +73,10 @@ module Gem::VersionOption
     end
   end
 
+  ##
+  # Extract platform given on the command line
+
+  def get_platform_from_requirements(requirements)
+    Gem.platforms[1].to_s if requirements.key? :added_platform
+  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

While debugging a different issue, I wanted to know how the specification of the precompiled version of the `google-protobuf` gem for linux looked like.

So I was running

```
gem specification --remote google-protobuf --platform x86_64-linux
```

But I would keep getting the pure ruby version of the specification.

## What is your fix for the problem, implemented in this PR?

I think, if `--platform` option is given, it should print only specifications for the given platform.

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)