### PR TITLE
Prevent remove command from deleting gemfile lines that are comments

### DIFF
--- a/bundler/lib/bundler/injector.rb
+++ b/bundler/lib/bundler/injector.rb
@@ -183,7 +183,7 @@ module Bundler
       new_gemfile = []
       multiline_removal = false
       IO.readlines(gemfile_path).each do |line|
-        if line.match(patterns)
+        if line.match(patterns) && is_not_a_line_comment?(line)
           multiline_removal = line.rstrip.end_with?(",")
           # skip lines which match the regex
           next
@@ -205,6 +205,11 @@ module Bundler
       %w[group source env install_if].each {|block| remove_nested_blocks(new_gemfile, block) }
 
       new_gemfile.join.chomp
+    end
+
+    # @param [String] line         Individual line of gemfile content.
+    def is_not_a_line_comment?(line)
+      line.match(/^(?=#).*/).nil?
     end
 
     # @param [Array] gemfile       Array of gemfile contents.

--- a/bundler/lib/bundler/injector.rb
+++ b/bundler/lib/bundler/injector.rb
@@ -179,11 +179,11 @@ module Bundler
     # @param [Pathname] gemfile_path The Gemfile from which to remove dependencies.
     def remove_gems_from_gemfile(gems, gemfile_path)
       patterns = /gem\s+(['"])#{Regexp.union(gems)}\1|gem\s*\((['"])#{Regexp.union(gems)}\2\)/
-
       new_gemfile = []
       multiline_removal = false
       IO.readlines(gemfile_path).each do |line|
-        if line.match(patterns) && is_not_a_line_comment?(line)
+        match_data = line.match(patterns)
+        if match_data && is_not_within_comment?(line, match_data)
           multiline_removal = line.rstrip.end_with?(",")
           # skip lines which match the regex
           next
@@ -207,9 +207,11 @@ module Bundler
       new_gemfile.join.chomp
     end
 
-    # @param [String] line         Individual line of gemfile content.
-    def is_not_a_line_comment?(line)
-      line.match(/^(?=#).*/).nil?
+    # @param [String] line          Individual line of gemfile content.
+    # @param [MatchData] match_data Data about Regex match.
+    def is_not_within_comment?(line, match_data)
+      match_start_index = match_data.offset(0).first
+      !line[0..match_start_index].include?("#")
     end
 
     # @param [Array] gemfile       Array of gemfile contents.

--- a/bundler/spec/commands/remove_spec.rb
+++ b/bundler/spec/commands/remove_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "bundle remove" do
     end
   end
 
-  describe "remove mutiple gems from gemfile" do
+  describe "remove multiple gems from gemfile" do
     context "when all gems are present in gemfile" do
       it "shows success fir all removed gems" do
         gemfile <<-G
@@ -210,7 +210,7 @@ RSpec.describe "bundle remove" do
       end
     end
 
-    context "when the gem belongs to mutiple groups" do
+    context "when the gem belongs to multiple groups" do
       it "removes the groups" do
         gemfile <<-G
           source "#{file_uri_for(gem_repo1)}"
@@ -614,6 +614,45 @@ RSpec.describe "bundle remove" do
       bundle "remove foo"
 
       expect(out).to include("foo could not be removed.")
+    end
+  end
+
+  describe "with comments that mention gems" do
+    context "when comment is a separate line comment" do
+      it "does not remove the line comment" do
+        gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
+
+          # gem "rack" might be used in the future
+          gem "rack"
+        G
+
+        bundle "remove rack"
+
+        expect(out).to include("rack was removed.")
+        gemfile_should_be <<-G
+          source "#{file_uri_for(gem_repo1)}"
+
+          # gem "rack" might be used in the future
+        G
+      end
+    end
+
+    context "when gem specified for removal has an inline comment" do
+      it "removes the inline comment" do
+        gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
+
+          gem "rack" # gem "rack" can be removed
+        G
+
+        bundle "remove rack"
+
+        expect(out).to include("rack was removed.")
+        gemfile_should_be <<-G
+          source "#{file_uri_for(gem_repo1)}"
+        G
+      end
     end
   end
 end

--- a/bundler/spec/commands/remove_spec.rb
+++ b/bundler/spec/commands/remove_spec.rb
@@ -643,7 +643,7 @@ RSpec.describe "bundle remove" do
         gemfile <<-G
           source "#{file_uri_for(gem_repo1)}"
 
-          gem "rack" # gem "rack" can be removed
+          gem "rack" # this can be removed
         G
 
         bundle "remove rack"
@@ -651,6 +651,47 @@ RSpec.describe "bundle remove" do
         expect(out).to include("rack was removed.")
         gemfile_should_be <<-G
           source "#{file_uri_for(gem_repo1)}"
+        G
+      end
+    end
+
+    context "when gem specified for removal is mentioned in other gem's comment" do
+      it "does not remove other gem" do
+        gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
+          gem "puma" # implements interface provided by gem "rack"
+
+          gem "rack"
+        G
+
+        bundle "remove rack"
+
+        expect(out).to_not include("puma was removed.")
+        expect(out).to include("rack was removed.")
+        gemfile_should_be <<-G
+          source "#{file_uri_for(gem_repo1)}"
+          gem "puma" # implements interface provided by gem "rack"
+        G
+      end
+    end
+
+    context "when gem specified for removal has a comment that mentions other gem" do
+      it "does not remove other gem" do
+        gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
+          gem "puma" # implements interface provided by gem "rack"
+
+          gem "rack"
+        G
+
+        bundle "remove puma"
+
+        expect(out).to include("puma was removed.")
+        expect(out).to_not include("rack was removed.")
+        gemfile_should_be <<-G
+          source "#{file_uri_for(gem_repo1)}"
+
+          gem "rack"
         G
       end
     end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

Running `bundle remove foo`, removes the respective gem, "foo", from the Gemfile, but also removes any comments containing `gem "foo"`, where "foo" is the name of the removed gem (fixes https://github.com/rubygems/rubygems/issues/3276).

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

In the code that removes text from gemfiles, there is a regular expression that identifies lines where the gems targeted for removal are mentioned. To complement this, I use an additional regular expression to make sure the mention of the gem is not a line comment.

I included two tests. One test verifies such a line comment is not deleted. The other test makes sure a typical inline comment is still removed in a normal `bundle remove` scenario.

Please let me know if you think there are important cases that I missed. It is my understanding that the
```
=begin
=end 
```
comment syntax is very rarely used.

Any and all feedback is greatly appreciated!
## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
