### PR TITLE
Extend `gem` DSL with a `force_ruby_platform` option

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -455,7 +455,7 @@ EOF
     end
 
     def local_platform
-      return Gem::Platform::RUBY if settings[:force_ruby_platform] || Gem.platforms == [Gem::Platform::RUBY]
+      return Gem::Platform::RUBY if settings[:force_ruby_platform]
       Gem::Platform.local
     end
 

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -806,7 +806,7 @@ module Bundler
       return [] unless @locked_gems && unlocking? && !sources.expired_sources?(@locked_gems.sources)
       converge_specs(@originally_locked_specs).map do |locked_spec|
         name = locked_spec.name
-        dep = Gem::Dependency.new(name, ">= #{locked_spec.version}")
+        dep = Dependency.new(name, ">= #{locked_spec.version}")
         DepProxy.get_proxy(dep, locked_spec.platform)
       end
     end

--- a/bundler/lib/bundler/dependency.rb
+++ b/bundler/lib/bundler/dependency.rb
@@ -109,7 +109,7 @@ module Bundler
       @env            = options["env"]
       @should_include = options.fetch("should_include", true)
       @gemfile        = options["gemfile"]
-      @force_ruby_platform = options["force_ruby_platform"]
+      @force_ruby_platform = options.fetch("force_ruby_platform", default_force_ruby_platform)
 
       @autorequire = Array(options["require"] || []) if options.key?("require")
     end
@@ -158,6 +158,18 @@ module Bundler
       super
     rescue NoMethodError
       requirement != ">= 0"
+    end
+
+    private
+
+    # The `:force_ruby_platform` attribute is `false` by default, except for
+    # TruffleRuby. TruffleRuby generally needs to force the RUBY platform
+    # variant unless the name is explicitly allowlisted.
+
+    def default_force_ruby_platform
+      return false unless Bundler.current_ruby.truffleruby?
+
+      !Gem::Platform::REUSE_AS_BINARY_ON_TRUFFLERUBY.include?(name)
     end
   end
 end

--- a/bundler/lib/bundler/dependency.rb
+++ b/bundler/lib/bundler/dependency.rb
@@ -7,7 +7,7 @@ require_relative "rubygems_ext"
 module Bundler
   class Dependency < Gem::Dependency
     attr_reader :autorequire
-    attr_reader :groups, :platforms, :gemfile, :git, :github, :branch, :ref
+    attr_reader :groups, :platforms, :gemfile, :git, :github, :branch, :ref, :force_ruby_platform
 
     # rubocop:disable Naming/VariableNumber
     PLATFORM_MAP = {
@@ -109,6 +109,7 @@ module Bundler
       @env            = options["env"]
       @should_include = options.fetch("should_include", true)
       @gemfile        = options["gemfile"]
+      @force_ruby_platform = options["force_ruby_platform"]
 
       @autorequire = Array(options["require"] || []) if options.key?("require")
     end

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -16,7 +16,7 @@ module Bundler
     VALID_PLATFORMS = Bundler::Dependency::PLATFORM_MAP.keys.freeze
 
     VALID_KEYS = %w[group groups git path glob name branch ref tag require submodules
-                    platform platforms type source install_if gemfile].freeze
+                    platform platforms type source install_if gemfile force_ruby_platform].freeze
 
     GITHUB_PULL_REQUEST_URL = %r{\Ahttps://github\.com/([A-Za-z0-9_\-\.]+/[A-Za-z0-9_\-\.]+)/pull/(\d+)\z}.freeze
 

--- a/bundler/lib/bundler/gem_helpers.rb
+++ b/bundler/lib/bundler/gem_helpers.rb
@@ -5,6 +5,7 @@ module Bundler
     GENERIC_CACHE = { Gem::Platform::RUBY => Gem::Platform::RUBY } # rubocop:disable Style/MutableConstant
     GENERICS = [
       [Gem::Platform.new("java"), Gem::Platform.new("java")],
+      [Gem::Platform.new("universal-java"), Gem::Platform.new("java")],
       [Gem::Platform.new("mswin32"), Gem::Platform.new("mswin32")],
       [Gem::Platform.new("mswin64"), Gem::Platform.new("mswin64")],
       [Gem::Platform.new("universal-mingw32"), Gem::Platform.new("universal-mingw32")],

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -7,7 +7,7 @@ module Bundler
     include MatchPlatform
 
     attr_reader :name, :version, :dependencies, :platform
-    attr_accessor :source, :remote
+    attr_accessor :source, :remote, :force_ruby_platform
 
     def initialize(name, version, platform, source = nil)
       @name          = name
@@ -152,7 +152,7 @@ module Bundler
     # explicitly add a more specific platform.
     #
     def ruby_platform_materializes_to_ruby_platform?
-      !Bundler.most_specific_locked_platform?(generic_local_platform) || Bundler.settings[:force_ruby_platform]
+      !Bundler.most_specific_locked_platform?(generic_local_platform) || force_ruby_platform || Bundler.settings[:force_ruby_platform]
     end
   end
 end

--- a/bundler/lib/bundler/man/gemfile.5
+++ b/bundler/lib/bundler/man/gemfile.5
@@ -331,6 +331,30 @@ gem "nokogiri",   platforms: [:mri_18, :jruby]
 .P
 All operations involving groups (\fBbundle install\fR \fIbundle\-install\.1\.html\fR, \fBBundler\.setup\fR, \fBBundler\.require\fR) behave exactly the same as if any groups not matching the current platform were explicitly excluded\.
 .
+.SS "FORCE_RUBY_PLATFORM"
+If you always want the pure ruby variant of a gem to be chosen over platform specific variants, you can use the \fBforce_ruby_platform\fR option:
+.
+.IP "" 4
+.
+.nf
+
+gem "ffi", force_ruby_platform: true
+.
+.fi
+.
+.IP "" 0
+.
+.P
+This can be handy (assuming the pure ruby variant works fine) when:
+.
+.IP "\(bu" 4
+You\'re having issues with the platform specific variant\.
+.
+.IP "\(bu" 4
+The platform specific variant does not yet support a newer ruby (and thus has a \fBrequired_ruby_version\fR upper bound), but you still want your Gemfile{\.lock} files to resolve under that ruby\.
+.
+.IP "" 0
+.
 .SS "SOURCE"
 You can select an alternate Rubygems repository for a gem using the \':source\' option\.
 .

--- a/bundler/lib/bundler/man/gemfile.5
+++ b/bundler/lib/bundler/man/gemfile.5
@@ -688,7 +688,7 @@ The \fB\.gemspec\fR \fIhttp://guides\.rubygems\.org/specification\-reference/\fR
 If you wish to use Bundler to help install dependencies for a gem while it is being developed, use the \fBgemspec\fR method to pull in the dependencies listed in the \fB\.gemspec\fR file\.
 .
 .P
-The \fBgemspec\fR method adds any runtime dependencies as gem requirements in the default group\. It also adds development dependencies as gem requirements in the \fBdevelopment\fR group\. Finally, it adds a gem requirement on your project (\fB:path => \'\.\'\fR)\. In conjunction with \fBBundler\.setup\fR, this allows you to require project files in your test code as you would if the project were installed as a gem; you need not manipulate the load path manually or require project files via relative paths\.
+The \fBgemspec\fR method adds any runtime dependencies as gem requirements in the default group\. It also adds development dependencies as gem requirements in the \fBdevelopment\fR group\. Finally, it adds a gem requirement on your project (\fBpath: \'\.\'\fR)\. In conjunction with \fBBundler\.setup\fR, this allows you to require project files in your test code as you would if the project were installed as a gem; you need not manipulate the load path manually or require project files via relative paths\.
 .
 .P
 The \fBgemspec\fR method supports optional \fB:path\fR, \fB:glob\fR, \fB:name\fR, and \fB:development_group\fR options, which control where bundler looks for the \fB\.gemspec\fR, the glob it uses to look for the gemspec (defaults to: "{,\fI,\fR/*}\.gemspec"), what named \fB\.gemspec\fR it uses (if more than one is present), and which group development dependencies are included in\.

--- a/bundler/lib/bundler/man/gemfile.5.ronn
+++ b/bundler/lib/bundler/man/gemfile.5.ronn
@@ -231,6 +231,20 @@ All operations involving groups ([`bundle install`](bundle-install.1.html), `Bun
 `Bundler.require`) behave exactly the same as if any groups not
 matching the current platform were explicitly excluded.
 
+### FORCE_RUBY_PLATFORM
+
+If you always want the pure ruby variant of a gem to be chosen over platform
+specific variants, you can use the `force_ruby_platform` option:
+
+    gem "ffi", force_ruby_platform: true
+
+This can be handy (assuming the pure ruby variant works fine) when:
+
+* You're having issues with the platform specific variant.
+* The platform specific variant does not yet support a newer ruby (and thus has
+  a `required_ruby_version` upper bound), but you still want your Gemfile{.lock}
+  files to resolve under that ruby.
+
 ### SOURCE
 
 You can select an alternate Rubygems repository for a gem using the ':source'

--- a/bundler/lib/bundler/man/gemfile.5.ronn
+++ b/bundler/lib/bundler/man/gemfile.5.ronn
@@ -495,8 +495,8 @@ the `.gemspec` file.
 
 The `gemspec` method adds any runtime dependencies as gem requirements in the
 default group. It also adds development dependencies as gem requirements in the
-`development` group. Finally, it adds a gem requirement on your project (`:path
-=> '.'`). In conjunction with `Bundler.setup`, this allows you to require project
+`development` group. Finally, it adds a gem requirement on your project (`path:
+'.'`). In conjunction with `Bundler.setup`, this allows you to require project
 files in your test code as you would if the project were installed as a gem; you
 need not manipulate the load path manually or require project files via relative
 paths.

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -143,9 +143,12 @@ module Bundler
             end
 
             spec_group_ruby = SpecGroup.create_for(specs_by_platform, [Gem::Platform::RUBY], Gem::Platform::RUBY)
-            groups << spec_group_ruby if spec_group_ruby
+            if spec_group_ruby
+              spec_group_ruby.force_ruby_platform = dependency.force_ruby_platform
+              groups << spec_group_ruby
+            end
 
-            next groups if @resolving_only_for_ruby
+            next groups if @resolving_only_for_ruby || dependency.force_ruby_platform
 
             spec_group = SpecGroup.create_for(specs_by_platform, @platforms, platform)
             groups << spec_group

--- a/bundler/lib/bundler/resolver/spec_group.rb
+++ b/bundler/lib/bundler/resolver/spec_group.rb
@@ -4,7 +4,7 @@ module Bundler
   class Resolver
     class SpecGroup
       attr_accessor :name, :version, :source
-      attr_accessor :activated_platforms
+      attr_accessor :activated_platforms, :force_ruby_platform
 
       def self.create_for(specs, all_platforms, specific_platform)
         specific_platform_specs = specs[specific_platform]
@@ -35,6 +35,7 @@ module Bundler
 
           specs.map do |s|
             lazy_spec = LazySpecification.new(name, version, s.platform, source)
+            lazy_spec.force_ruby_platform = force_ruby_platform
             lazy_spec.dependencies.replace s.dependencies
             lazy_spec
           end
@@ -88,7 +89,7 @@ module Bundler
         dependencies = []
         @specs[platform].first.dependencies.each do |dep|
           next if dep.type == :development
-          dependencies << DepProxy.get_proxy(dep, platform)
+          dependencies << DepProxy.get_proxy(Dependency.new(dep.name, dep.requirement), platform)
         end
         dependencies
       end
@@ -98,10 +99,10 @@ module Bundler
         return [] if spec.is_a?(LazySpecification)
         dependencies = []
         unless spec.required_ruby_version.none?
-          dependencies << DepProxy.get_proxy(Gem::Dependency.new("Ruby\0", spec.required_ruby_version), platform)
+          dependencies << DepProxy.get_proxy(Dependency.new("Ruby\0", spec.required_ruby_version), platform)
         end
         unless spec.required_rubygems_version.none?
-          dependencies << DepProxy.get_proxy(Gem::Dependency.new("RubyGems\0", spec.required_rubygems_version), platform)
+          dependencies << DepProxy.get_proxy(Dependency.new("RubyGems\0", spec.required_rubygems_version), platform)
         end
         dependencies
       end

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -222,27 +222,9 @@ module Gem
     MINGW = Gem::Platform.new("x86-mingw32")
     X64_MINGW = [Gem::Platform.new("x64-mingw32"),
                  Gem::Platform.new("x64-mingw-ucrt")].freeze
-  end
 
-  Platform.singleton_class.module_eval do
-    unless Platform.singleton_methods.include?(:match_spec?)
-      def match_spec?(spec)
-        match_gem?(spec.platform, spec.name)
-      end
-
-      def match_gem?(platform, gem_name)
-        match_platforms?(platform, Gem.platforms)
-      end
-
-      private
-
-      def match_platforms?(platform, platforms)
-        platforms.any? do |local_platform|
-          platform.nil? ||
-            local_platform == platform ||
-            (local_platform != Gem::Platform::RUBY && local_platform =~ platform)
-        end
-      end
+    if RUBY_ENGINE == "truffleruby" && !defined?(REUSE_AS_BINARY_ON_TRUFFLERUBY)
+      REUSE_AS_BINARY_ON_TRUFFLERUBY = %w[libv8 sorbet-static].freeze
     end
   end
 

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -176,7 +176,7 @@ module Bundler
     def specs_for_dependency(dep, match_current_platform)
       specs_for_name = lookup[dep.name]
       if match_current_platform
-        GemHelpers.select_best_platform_match(specs_for_name.select {|s| Gem::Platform.match_spec?(s) }, Bundler.local_platform)
+        GemHelpers.select_best_platform_match(specs_for_name, Bundler.local_platform)
       else
         specs_for_name_and_platform = GemHelpers.select_best_platform_match(specs_for_name, dep.force_ruby_platform ? Gem::Platform::RUBY : dep.__platform)
         specs_for_name_and_platform.any? ? specs_for_name_and_platform : specs_for_name

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -30,7 +30,7 @@ module Bundler
 
           specs_for_dep.first.dependencies.each do |d|
             next if d.type == :development
-            d = DepProxy.get_proxy(d, dep.__platform) unless match_current_platform
+            d = DepProxy.get_proxy(Dependency.new(d.name, d.requirement), dep.__platform) unless match_current_platform
             deps << d
           end
         elsif check
@@ -178,7 +178,7 @@ module Bundler
       if match_current_platform
         GemHelpers.select_best_platform_match(specs_for_name.select {|s| Gem::Platform.match_spec?(s) }, Bundler.local_platform)
       else
-        specs_for_name_and_platform = GemHelpers.select_best_platform_match(specs_for_name, dep.__platform)
+        specs_for_name_and_platform = GemHelpers.select_best_platform_match(specs_for_name, dep.force_ruby_platform ? Gem::Platform::RUBY : dep.__platform)
         specs_for_name_and_platform.any? ? specs_for_name_and_platform : specs_for_name
       end
     end

--- a/bundler/spec/install/gemfile/force_ruby_platform_spec.rb
+++ b/bundler/spec/install/gemfile/force_ruby_platform_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+RSpec.describe "bundle install with force_ruby_platform DSL option", :jruby do
+  context "when no transitive deps" do
+    before do
+      build_repo4 do
+        # Build a gem with platform specific versions
+        build_gem("platform_specific") do |s|
+          s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0.0 RUBY'"
+        end
+
+        build_gem("platform_specific") do |s|
+          s.platform = Bundler.local_platform
+          s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0.0 #{Bundler.local_platform}'"
+        end
+
+        # Build the exact same gem with a different name to compare using vs not using the option
+        build_gem("platform_specific_forced") do |s|
+          s.write "lib/platform_specific_forced.rb", "PLATFORM_SPECIFIC_FORCED = '1.0.0 RUBY'"
+        end
+
+        build_gem("platform_specific_forced") do |s|
+          s.platform = Bundler.local_platform
+          s.write "lib/platform_specific_forced.rb", "PLATFORM_SPECIFIC_FORCED = '1.0.0 #{Bundler.local_platform}'"
+        end
+      end
+    end
+
+    it "pulls the pure ruby variant of the given gem" do
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo4)}"
+
+        gem "platform_specific_forced", :force_ruby_platform => true
+        gem "platform_specific"
+      G
+
+      expect(the_bundle).to include_gems "platform_specific_forced 1.0.0 RUBY"
+      expect(the_bundle).to include_gems "platform_specific 1.0.0 #{Bundler.local_platform}"
+    end
+
+    it "still respects a global `force_ruby_platform` config" do
+      install_gemfile <<-G, :env => { "BUNDLE_FORCE_RUBY_PLATFORM" => "true" }
+        source "#{file_uri_for(gem_repo4)}"
+
+        gem "platform_specific_forced", :force_ruby_platform => true
+        gem "platform_specific"
+      G
+
+      expect(the_bundle).to include_gems "platform_specific_forced 1.0.0 RUBY"
+      expect(the_bundle).to include_gems "platform_specific 1.0.0 RUBY"
+    end
+  end
+
+  context "when also a transitive dependency" do
+    before do
+      build_repo4 do
+        build_gem("depends_on_platform_specific") {|s| s.add_runtime_dependency "platform_specific" }
+
+        build_gem("platform_specific") do |s|
+          s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0.0 RUBY'"
+        end
+
+        build_gem("platform_specific") do |s|
+          s.platform = Bundler.local_platform
+          s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0.0 #{Bundler.local_platform}'"
+        end
+      end
+    end
+
+    it "still pulls the ruby variant" do
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo4)}"
+
+        gem "depends_on_platform_specific"
+        gem "platform_specific", :force_ruby_platform => true
+      G
+
+      expect(the_bundle).to include_gems "platform_specific 1.0.0 RUBY"
+    end
+  end
+
+  context "with transitive dependencies with platform specific versions" do
+    before do
+      build_repo4 do
+        build_gem("depends_on_platform_specific") do |s|
+          s.add_runtime_dependency "platform_specific"
+          s.write "lib/depends_on_platform_specific.rb", "DEPENDS_ON_PLATFORM_SPECIFIC = '1.0.0 RUBY'"
+        end
+
+        build_gem("depends_on_platform_specific") do |s|
+          s.add_runtime_dependency "platform_specific"
+          s.platform = Bundler.local_platform
+          s.write "lib/depends_on_platform_specific.rb", "DEPENDS_ON_PLATFORM_SPECIFIC = '1.0.0 #{Bundler.local_platform}'"
+        end
+
+        build_gem("platform_specific") do |s|
+          s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0.0 RUBY'"
+        end
+
+        build_gem("platform_specific") do |s|
+          s.platform = Bundler.local_platform
+          s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0.0 #{Bundler.local_platform}'"
+        end
+      end
+    end
+
+    it "ignores ruby variants for the transitive dependencies" do
+      install_gemfile <<-G, :env => { "DEBUG_RESOLVER" => "true" }
+        source "#{file_uri_for(gem_repo4)}"
+
+        gem "depends_on_platform_specific", :force_ruby_platform => true
+      G
+
+      expect(the_bundle).to include_gems "depends_on_platform_specific 1.0.0 RUBY"
+      expect(the_bundle).to include_gems "platform_specific 1.0.0 #{Bundler.local_platform}"
+    end
+  end
+end

--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -137,8 +137,8 @@ module Spec
         ENV["BUNDLE_PATH__SYSTEM"] = "true"
       end
 
-      output = `#{Gem.ruby} #{File.expand_path("support/bundle.rb", Path.spec_dir)} install --verbose`
-      raise "Error when installing gems in #{gemfile}: #{output}" unless $?.success?
+      puts `#{Gem.ruby} #{File.expand_path("support/bundle.rb", Path.spec_dir)} install --verbose`
+      raise unless $?.success?
     ensure
       if path
         ENV["BUNDLE_PATH"] = old_path


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes it would be useful, specially when we enable the `specific_platform` setting by default to be able to opt-out of the standard platform priority and always force the ruby variant for specific gems.

## What is your fix for the problem, implemented in this PR?

Add a `:force_ruby_platform` option to the `gem` DSL.

This is the "per gem" equivalent of the `force_ruby_platform` setting.

This can be handy (assuming the pure ruby variant works just fine) when:

* You're having issues with the platform specific variant.

* The platform specific variant does not yet support a newer ruby (and thus has a `required_ruby_version` upper bound), but you still want your Gemfile{.lock} files to resolve under that ruby.

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

This PR closes https://github.com/rubygems/rubygems/issues/3347.