### PR TITLE
Revert resolving all Gemfile platforms automatically

### DIFF
--- a/bundler/lib/bundler/cli/outdated.rb
+++ b/bundler/lib/bundler/cli/outdated.rb
@@ -76,8 +76,6 @@ module Bundler
         next unless gems.empty? || gems.include?(current_spec.name)
 
         active_spec = retrieve_active_spec(definition, current_spec)
-        next unless active_spec
-
         next unless filter_options_patch.empty? || update_present_via_semver_portions(current_spec, active_spec, options)
 
         gem_outdated = Gem::Version.new(active_spec.version) > Gem::Version.new(current_spec.version)
@@ -146,8 +144,6 @@ module Bundler
     end
 
     def retrieve_active_spec(definition, current_spec)
-      return unless current_spec.match_platform(Bundler.local_platform)
-
       if strict
         active_spec = definition.find_resolved_spec(current_spec)
       else
@@ -233,6 +229,8 @@ module Bundler
     end
 
     def update_present_via_semver_portions(current_spec, active_spec, options)
+      return false if active_spec.nil?
+
       current_major = current_spec.version.segments.first
       active_major = active_spec.version.segments.first
 

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -123,7 +123,7 @@ module Bundler
       end
       @unlocking ||= @unlock[:ruby] ||= (!@locked_ruby_version ^ !@ruby_version)
 
-      add_platforms unless Bundler.frozen_bundle?
+      add_current_platform unless Bundler.frozen_bundle?
 
       converge_path_sources_to_gemspec_sources
       @path_changes = converge_paths
@@ -554,10 +554,8 @@ module Bundler
 
     private
 
-    def add_platforms
-      (@dependencies.flat_map(&:expanded_platforms) + current_platforms).uniq.each do |platform|
-        add_platform(platform)
-      end
+    def add_current_platform
+      current_platforms.each {|platform| add_platform(platform) }
     end
 
     def current_platforms

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -430,7 +430,7 @@ RSpec.describe "bundle install with platform conditionals" do
     expect(out).not_to match(/Could not find gem 'some_gem/)
   end
 
-  it "resolves all platforms by default and without warning messages" do
+  it "does not print a warning when a dependency is unused on a platform different from the current one" do
     simulate_platform "ruby"
 
     gemfile <<-G
@@ -447,14 +447,9 @@ RSpec.describe "bundle install with platform conditionals" do
       GEM
         remote: #{file_uri_for(gem_repo1)}/
         specs:
-          rack (1.0.0)
 
       PLATFORMS
-        java
         ruby
-        x64-mingw32
-        x86-mingw32
-        x86-mswin32
 
       DEPENDENCIES
         rack


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This is the second time I revert this change, since I have found some cases where this might cause pain, and I want to battle test multiplatform fixes before attempting this.

See https://github.com/rubygems/rubygems/issues/4018 for more on this.

## What is your fix for the problem, implemented in this PR?

My fix is to revert resolving only for the current platform like it's been done historically.

I think ideally, when we introduce something like this, we should consider making it opt-in by recording this intention in the `Gemfile`, maybe with an unscoped `platforms` DSL, or by an explicit CLI flag, like `bundle install --all-platforms`, or `bundle lock --all-platforms`.

The part I'm not reverting is removing the warning about dependencies being unused under the current platform, since it is pretty much expected on a multiplatform context.

Closes https://github.com/rubygems/rubygems/issues/4018.

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)