### PR TITLE
Lock parallel ~> 1.19.2

### DIFF
--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "bundle gem" do
     prepare_gemspec(bundled_app(gem_name, "#{gem_name}.gemspec"))
     rubocop_version = RUBY_VERSION > "2.4" ? "0.90.0" : "0.80.1"
     gems = ["minitest", "rake", "rake-compiler", "rspec", "rubocop -v #{rubocop_version}", "test-unit"]
+    gems.unshift "parallel -v 1.19.2" if RUBY_VERSION < "2.5"
     gems += ["rubocop-ast -v 0.4.0"] if rubocop_version == "0.90.0"
     path = Bundler.feature_flag.default_install_uses_path? ? local_gem_path(:base => bundled_app(gem_name)) : system_gem_path
     realworld_system_gems gems, :path => path


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The latest version of `parallel` gem show https://github.com/rubygems/rubygems/pull/4053/checks?check_run_id=1371824322#step:7:460 

## What is your fix for the problem, implemented in this PR?

Lock the old version of `parallel` that is supporeted Ruby 2.3 and 2.4.

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
