### PR TITLE
Add missing openssl require

### DIFF
--- a/bundler/spec/bundler/env_spec.rb
+++ b/bundler/spec/bundler/env_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "bundler/settings"
+require "openssl"
 
 RSpec.describe Bundler::Env do
   let(:git_proxy_stub) { Bundler::Source::Git::GitProxy.new(nil, nil, nil) }


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Running `bin/rspec spec/bundler/env_spec.rb:17` fails.

## What is your fix for the problem, implemented in this PR?

Add the missing require.

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)