### PR TITLE
Always show underlying error when fetching specs fails

### DIFF
--- a/bundler/lib/bundler/fetcher/index.rb
+++ b/bundler/lib/bundler/fetcher/index.rb
@@ -8,7 +8,7 @@ module Bundler
     class Index < Base
       def specs(_gem_names)
         Bundler.rubygems.fetch_all_remote_specs(remote)
-      rescue Gem::RemoteFetcher::FetchError, OpenSSL::SSL::SSLError, Net::HTTPFatalError => e
+      rescue Gem::RemoteFetcher::FetchError => e
         case e.message
         when /certificate verify failed/
           raise CertificateFailureError.new(display_uri)

--- a/bundler/lib/bundler/fetcher/index.rb
+++ b/bundler/lib/bundler/fetcher/index.rb
@@ -19,8 +19,7 @@ module Bundler
           raise BadAuthenticationError, remote_uri if remote_uri.userinfo
           raise AuthenticationRequiredError, remote_uri
         else
-          Bundler.ui.trace e
-          raise HTTPError, "Could not fetch specs from #{display_uri}"
+          raise HTTPError, "Could not fetch specs from #{display_uri} due to underlying error <#{e.message}>"
         end
       end
 

--- a/bundler/spec/bundler/fetcher/index_spec.rb
+++ b/bundler/spec/bundler/fetcher/index_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Bundler::Fetcher::Index do
       before { allow(Bundler).to receive(:ui).and_return(double(:trace => nil)) }
 
       it "should raise a Bundler::HTTPError" do
-        expect { subject.specs(gem_names) }.to raise_error(Bundler::HTTPError, "Could not fetch specs from http://sample_uri.com")
+        expect { subject.specs(gem_names) }.to raise_error(Bundler::HTTPError, "Could not fetch specs from http://sample_uri.com due to underlying error <You get an error, you get an error! (http://sample_uri.com)>")
       end
     end
   end

--- a/bundler/spec/bundler/fetcher/index_spec.rb
+++ b/bundler/spec/bundler/fetcher/index_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Bundler::Fetcher::Index do
   context "error handling" do
     let(:remote_uri) { Bundler::URI("http://remote-uri.org") }
     before do
-      allow(rubygems).to receive(:fetch_all_remote_specs) { raise Gem::RemoteFetcher::FetchError.new(error_message, nil) }
+      allow(rubygems).to receive(:fetch_all_remote_specs) { raise Gem::RemoteFetcher::FetchError.new(error_message, display_uri) }
       allow(subject).to receive(:remote_uri).and_return(remote_uri)
     end
 

--- a/bundler/spec/bundler/fetcher/index_spec.rb
+++ b/bundler/spec/bundler/fetcher/index_spec.rb
@@ -17,100 +17,81 @@ RSpec.describe Bundler::Fetcher::Index do
   end
 
   context "error handling" do
-    shared_examples_for "the error is properly handled" do
-      let(:remote_uri) { Bundler::URI("http://remote-uri.org") }
+    let(:remote_uri) { Bundler::URI("http://remote-uri.org") }
+    before do
+      allow(rubygems).to receive(:fetch_all_remote_specs) { raise Gem::RemoteFetcher::FetchError.new(error_message, nil) }
+      allow(subject).to receive(:remote_uri).and_return(remote_uri)
+    end
+
+    context "when certificate verify failed" do
+      let(:error_message) { "certificate verify failed" }
+
+      it "should raise a Bundler::Fetcher::CertificateFailureError" do
+        expect { subject.specs(gem_names) }.to raise_error(Bundler::Fetcher::CertificateFailureError,
+          %r{Could not verify the SSL certificate for http://sample_uri.com})
+      end
+    end
+
+    context "when a 401 response occurs" do
+      let(:error_message) { "401" }
+
       before do
-        allow(subject).to receive(:remote_uri).and_return(remote_uri)
+        allow(remote_uri).to receive(:userinfo).and_return(userinfo)
       end
 
-      context "when certificate verify failed" do
-        let(:error_message) { "certificate verify failed" }
+      context "and there was userinfo" do
+        let(:userinfo) { double(:userinfo) }
 
-        it "should raise a Bundler::Fetcher::CertificateFailureError" do
-          expect { subject.specs(gem_names) }.to raise_error(Bundler::Fetcher::CertificateFailureError,
-            %r{Could not verify the SSL certificate for http://sample_uri.com})
-        end
-      end
-
-      context "when a 401 response occurs" do
-        let(:error_message) { "401" }
-
-        before do
-          allow(remote_uri).to receive(:userinfo).and_return(userinfo)
-        end
-
-        context "and there was userinfo" do
-          let(:userinfo) { double(:userinfo) }
-
-          it "should raise a Bundler::Fetcher::BadAuthenticationError" do
-            expect { subject.specs(gem_names) }.to raise_error(Bundler::Fetcher::BadAuthenticationError,
-              %r{Bad username or password for http://remote-uri.org})
-          end
-        end
-
-        context "and there was no userinfo" do
-          let(:userinfo) { nil }
-
-          it "should raise a Bundler::Fetcher::AuthenticationRequiredError" do
-            expect { subject.specs(gem_names) }.to raise_error(Bundler::Fetcher::AuthenticationRequiredError,
-              %r{Authentication is required for http://remote-uri.org})
-          end
+        it "should raise a Bundler::Fetcher::BadAuthenticationError" do
+          expect { subject.specs(gem_names) }.to raise_error(Bundler::Fetcher::BadAuthenticationError,
+            %r{Bad username or password for http://remote-uri.org})
         end
       end
 
-      context "when a 403 response occurs" do
-        let(:error_message) { "403" }
+      context "and there was no userinfo" do
+        let(:userinfo) { nil }
 
-        before do
-          allow(remote_uri).to receive(:userinfo).and_return(userinfo)
-        end
-
-        context "and there was userinfo" do
-          let(:userinfo) { double(:userinfo) }
-
-          it "should raise a Bundler::Fetcher::BadAuthenticationError" do
-            expect { subject.specs(gem_names) }.to raise_error(Bundler::Fetcher::BadAuthenticationError,
-              %r{Bad username or password for http://remote-uri.org})
-          end
-        end
-
-        context "and there was no userinfo" do
-          let(:userinfo) { nil }
-
-          it "should raise a Bundler::Fetcher::AuthenticationRequiredError" do
-            expect { subject.specs(gem_names) }.to raise_error(Bundler::Fetcher::AuthenticationRequiredError,
-              %r{Authentication is required for http://remote-uri.org})
-          end
-        end
-      end
-
-      context "any other message is returned" do
-        let(:error_message) { "You get an error, you get an error!" }
-
-        before { allow(Bundler).to receive(:ui).and_return(double(:trace => nil)) }
-
-        it "should raise a Bundler::HTTPError" do
-          expect { subject.specs(gem_names) }.to raise_error(Bundler::HTTPError, "Could not fetch specs from http://sample_uri.com")
+        it "should raise a Bundler::Fetcher::AuthenticationRequiredError" do
+          expect { subject.specs(gem_names) }.to raise_error(Bundler::Fetcher::AuthenticationRequiredError,
+            %r{Authentication is required for http://remote-uri.org})
         end
       end
     end
 
-    context "when a Gem::RemoteFetcher::FetchError occurs" do
-      before { allow(rubygems).to receive(:fetch_all_remote_specs) { raise Gem::RemoteFetcher::FetchError.new(error_message, nil) } }
+    context "when a 403 response occurs" do
+      let(:error_message) { "403" }
 
-      it_behaves_like "the error is properly handled"
+      before do
+        allow(remote_uri).to receive(:userinfo).and_return(userinfo)
+      end
+
+      context "and there was userinfo" do
+        let(:userinfo) { double(:userinfo) }
+
+        it "should raise a Bundler::Fetcher::BadAuthenticationError" do
+          expect { subject.specs(gem_names) }.to raise_error(Bundler::Fetcher::BadAuthenticationError,
+            %r{Bad username or password for http://remote-uri.org})
+        end
+      end
+
+      context "and there was no userinfo" do
+        let(:userinfo) { nil }
+
+        it "should raise a Bundler::Fetcher::AuthenticationRequiredError" do
+          expect { subject.specs(gem_names) }.to raise_error(Bundler::Fetcher::AuthenticationRequiredError,
+            %r{Authentication is required for http://remote-uri.org})
+        end
+      end
     end
 
-    context "when a OpenSSL::SSL::SSLError occurs" do
-      before { allow(rubygems).to receive(:fetch_all_remote_specs) { raise OpenSSL::SSL::SSLError.new(error_message) } }
+    context "any other message is returned" do
+      let(:error_message) { "You get an error, you get an error!" }
 
-      it_behaves_like "the error is properly handled"
-    end
+      before { allow(Bundler).to receive(:ui).and_return(double(:trace => nil)) }
 
-    context "when a Net::HTTPFatalError occurs" do
-      before { allow(rubygems).to receive(:fetch_all_remote_specs) { raise Net::HTTPFatalError.new(error_message, 404) } }
-
-      it_behaves_like "the error is properly handled"
+      it "should raise a Bundler::HTTPError" do
+        expect { subject.specs(gem_names) }.to raise_error(Bundler::HTTPError, "Could not fetch specs from http://sample_uri.com")
+      end
     end
   end
 end

--- a/bundler/spec/realworld/mirror_probe_spec.rb
+++ b/bundler/spec/realworld/mirror_probe_spec.rb
@@ -74,10 +74,10 @@ RSpec.describe "fetching dependencies with a not available mirror", :realworld =
       bundle :install, :artifice => nil, :raise_on_error => false
 
       expect(out).to include("Fetching source index from #{mirror}")
-      expect(err).to include("Retrying fetcher due to error (2/4): Bundler::HTTPError Could not fetch specs from #{mirror}")
-      expect(err).to include("Retrying fetcher due to error (3/4): Bundler::HTTPError Could not fetch specs from #{mirror}")
-      expect(err).to include("Retrying fetcher due to error (4/4): Bundler::HTTPError Could not fetch specs from #{mirror}")
-      expect(err).to include("Could not fetch specs from #{mirror}")
+      expect(err).to include("Retrying fetcher due to error (2/4): Bundler::HTTPError Could not fetch specs from #{mirror}/ due to underlying error <Errno::ECONNREFUSED: Failed to open TCP connection to #{host}:#{@mirror_port} (Connection refused - connect(2) for \"#{host}\" port #{@mirror_port}) (#{mirror}/specs.4.8.gz)>")
+      expect(err).to include("Retrying fetcher due to error (3/4): Bundler::HTTPError Could not fetch specs from #{mirror}/ due to underlying error <Errno::ECONNREFUSED: Failed to open TCP connection to #{host}:#{@mirror_port} (Connection refused - connect(2) for \"#{host}\" port #{@mirror_port}) (#{mirror}/specs.4.8.gz)>")
+      expect(err).to include("Retrying fetcher due to error (4/4): Bundler::HTTPError Could not fetch specs from #{mirror}/ due to underlying error <Errno::ECONNREFUSED: Failed to open TCP connection to #{host}:#{@mirror_port} (Connection refused - connect(2) for \"#{host}\" port #{@mirror_port}) (#{mirror}/specs.4.8.gz)>")
+      expect(err).to include("Could not fetch specs from #{mirror}/ due to underlying error <Errno::ECONNREFUSED: Failed to open TCP connection to #{host}:#{@mirror_port} (Connection refused - connect(2) for \"#{host}\" port #{@mirror_port}) (#{mirror}/specs.4.8.gz)>")
     end
 
     it "prints each error and warning on a new line" do
@@ -90,10 +90,10 @@ RSpec.describe "fetching dependencies with a not available mirror", :realworld =
 
       expect(out).to include "Fetching source index from #{mirror}/"
       expect(err).to include <<-EOS.strip
-Retrying fetcher due to error (2/4): Bundler::HTTPError Could not fetch specs from #{mirror}/
-Retrying fetcher due to error (3/4): Bundler::HTTPError Could not fetch specs from #{mirror}/
-Retrying fetcher due to error (4/4): Bundler::HTTPError Could not fetch specs from #{mirror}/
-Could not fetch specs from #{mirror}/
+Retrying fetcher due to error (2/4): Bundler::HTTPError Could not fetch specs from #{mirror}/ due to underlying error <Errno::ECONNREFUSED: Failed to open TCP connection to #{host}:#{@mirror_port} (Connection refused - connect(2) for \"#{host}\" port #{@mirror_port}) (#{mirror}/specs.4.8.gz)>
+Retrying fetcher due to error (3/4): Bundler::HTTPError Could not fetch specs from #{mirror}/ due to underlying error <Errno::ECONNREFUSED: Failed to open TCP connection to #{host}:#{@mirror_port} (Connection refused - connect(2) for \"#{host}\" port #{@mirror_port}) (#{mirror}/specs.4.8.gz)>
+Retrying fetcher due to error (4/4): Bundler::HTTPError Could not fetch specs from #{mirror}/ due to underlying error <Errno::ECONNREFUSED: Failed to open TCP connection to #{host}:#{@mirror_port} (Connection refused - connect(2) for \"#{host}\" port #{@mirror_port}) (#{mirror}/specs.4.8.gz)>
+Could not fetch specs from #{mirror}/ due to underlying error <Errno::ECONNREFUSED: Failed to open TCP connection to #{host}:#{@mirror_port} (Connection refused - connect(2) for \"#{host}\" port #{@mirror_port}) (#{mirror}/specs.4.8.gz)>
       EOS
     end
   end
@@ -112,10 +112,10 @@ Could not fetch specs from #{mirror}/
       bundle :install, :artifice => nil, :raise_on_error => false
 
       expect(out).to include("Fetching source index from #{mirror}")
-      expect(err).to include("Retrying fetcher due to error (2/4): Bundler::HTTPError Could not fetch specs from #{mirror}")
-      expect(err).to include("Retrying fetcher due to error (3/4): Bundler::HTTPError Could not fetch specs from #{mirror}")
-      expect(err).to include("Retrying fetcher due to error (4/4): Bundler::HTTPError Could not fetch specs from #{mirror}")
-      expect(err).to include("Could not fetch specs from #{mirror}")
+      expect(err).to include("Retrying fetcher due to error (2/4): Bundler::HTTPError Could not fetch specs from #{mirror}/ due to underlying error <Errno::ECONNREFUSED: Failed to open TCP connection to #{host}:#{@mirror_port} (Connection refused - connect(2) for \"#{host}\" port #{@mirror_port}) (#{mirror}/specs.4.8.gz)>")
+      expect(err).to include("Retrying fetcher due to error (3/4): Bundler::HTTPError Could not fetch specs from #{mirror}/ due to underlying error <Errno::ECONNREFUSED: Failed to open TCP connection to #{host}:#{@mirror_port} (Connection refused - connect(2) for \"#{host}\" port #{@mirror_port}) (#{mirror}/specs.4.8.gz)>")
+      expect(err).to include("Retrying fetcher due to error (4/4): Bundler::HTTPError Could not fetch specs from #{mirror}/ due to underlying error <Errno::ECONNREFUSED: Failed to open TCP connection to #{host}:#{@mirror_port} (Connection refused - connect(2) for \"#{host}\" port #{@mirror_port}) (#{mirror}/specs.4.8.gz)>")
+      expect(err).to include("Could not fetch specs from #{mirror}/ due to underlying error <Errno::ECONNREFUSED: Failed to open TCP connection to #{host}:#{@mirror_port} (Connection refused - connect(2) for \"#{host}\" port #{@mirror_port}) (#{mirror}/specs.4.8.gz)>")
     end
   end
 
@@ -138,7 +138,7 @@ Could not fetch specs from #{mirror}/
   end
 
   def setup_mirror
-    mirror_port = find_unused_port
-    @mirror_uri = "http://#{host}:#{mirror_port}"
+    @mirror_port = find_unused_port
+    @mirror_uri = "http://#{host}:#{@mirror_port}"
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When network failures happen, errors could be more helpful.

## What is your fix for the problem, implemented in this PR?

Include the underlying network error in the default output.

Fixes https://github.com/rubygems/rubygems/issues/3805.

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)