### PR TITLE
Fix edge case resulting in a crash when using `zeitwerk` inside a nested `bundle exec` invocation

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -602,6 +602,10 @@ EOF
       reset_rubygems!
     end
 
+    def reset_settings!
+      @settings = nil
+    end
+
     def reset_paths!
       @bin_path = nil
       @bundler_major_version = nil

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -57,7 +57,7 @@ module Bundler
       custom_gemfile = options[:gemfile] || Bundler.settings[:gemfile]
       if custom_gemfile && !custom_gemfile.empty?
         Bundler::SharedHelpers.set_env "BUNDLE_GEMFILE", File.expand_path(custom_gemfile)
-        Bundler.reset_paths!
+        Bundler.reset_settings!
       end
 
       Bundler.settings.set_command_option_if_given :retry, options[:retry]

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -865,6 +865,8 @@ __FILE__: #{path.to_s.inspect}
   context "nested bundle exec" do
     context "when bundle in a local path" do
       before do
+        skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
+
         gemfile <<-G
           source "#{file_uri_for(gem_repo1)}"
           gem "rack"
@@ -874,8 +876,6 @@ __FILE__: #{path.to_s.inspect}
       end
 
       it "correctly shells out" do
-        skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
-
         file = bundled_app("file_that_bundle_execs.rb")
         create_file(file, <<-RUBY)
           #!#{Gem.ruby}


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

See #3270 for the realworld problem. It's a combination of using dependencies that monkeypatch `Kernel.require`, and using several levels of nested `bundle exec`s.

When bundler's CLI is initialized, we check whether a custom `Gemfile` is configured, and in that case we invalidate the whole bundler environment so that the whole thing is reloaded using the new `Gemfile`. When we are inside a nested `bundle exec`, the original Gemfile is explicitly configured so that further subprocesses always use it, so we fall into this situation.

The problem is that we're resetting too much, and that can cause dependencies that further decorate `Kernel.require` to lose their decorations.

## What is your fix for the problem, implemented in this PR?

The fix is to only reset what we really need to reset here, namely, the settings so that they are reloaded using the new `Gemfile` as a base.

Fixes #3270.

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)