### PR TITLE
Raise consistent errors with or without `bundle exec`

### DIFF
--- a/bundler/lib/bundler/cli/exec.rb
+++ b/bundler/lib/bundler/cli/exec.rb
@@ -63,10 +63,10 @@ module Bundler
       Kernel.load(file)
     rescue SystemExit, SignalException
       raise
-    rescue Exception => e # rubocop:disable Lint/RescueException
+    rescue Exception # rubocop:disable Lint/RescueException
       Bundler.ui.error "bundler: failed to load command: #{cmd} (#{file})"
-      backtrace = e.backtrace ? e.backtrace.take_while {|bt| !bt.start_with?(__FILE__) } : []
-      abort "#{e.class}: #{e.message}\n  #{backtrace.join("\n  ")}"
+      Bundler::FriendlyErrors.disable!
+      raise
     end
 
     def process_title(file, args)

--- a/bundler/lib/bundler/friendly_errors.rb
+++ b/bundler/lib/bundler/friendly_errors.rb
@@ -6,6 +6,18 @@ module Bundler
   module FriendlyErrors
     module_function
 
+    def enable!
+      @disabled = false
+    end
+
+    def disabled?
+      @disabled
+    end
+
+    def disable!
+      @disabled = true
+    end
+
     def log_error(error)
       case error
       when YamlSyntaxError
@@ -114,10 +126,13 @@ module Bundler
   end
 
   def self.with_friendly_errors
+    FriendlyErrors.enable!
     yield
   rescue SignalException
     raise
   rescue Exception => e # rubocop:disable Lint/RescueException
+    raise if FriendlyErrors.disabled?
+
     FriendlyErrors.log_error(e)
     exit FriendlyErrors.exit_status(e)
   end

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -698,15 +698,23 @@ RSpec.describe "bundle exec" do
       let(:exit_code) { 1 }
       let(:expected_err) do
         "bundler: failed to load command: #{path} (#{path})" \
-        "\nRuntimeError: ERROR\n  #{path}:10:in `<top (required)>'"
+        "\n#{path}:10:in `<top (required)>': ERROR (RuntimeError)"
       end
-      it_behaves_like "it runs"
+
+      it "runs like a normally executed executable" do
+        skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
+
+        subject
+        expect(exitstatus).to eq(exit_code)
+        expect(err).to start_with(expected_err)
+        expect(out).to eq(expected)
+      end
     end
 
     context "the executable raises an error without a backtrace" do
       let(:executable) { super() << "\nclass Err < Exception\ndef backtrace; end;\nend\nraise Err" }
       let(:exit_code) { 1 }
-      let(:expected_err) { "bundler: failed to load command: #{path} (#{path})\nErr: Err" }
+      let(:expected_err) { "bundler: failed to load command: #{path} (#{path})\n#{system_gem_path("bin/bundle")}: Err (Err)" }
       let(:expected) { super() }
 
       it_behaves_like "it runs"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Scripts raise different exceptions depending whether they are being run with or
without `bundle exec`.

## What is your fix for the problem, implemented in this PR?

My fix is to disable friendly errors in the `bundle exec` case, and let the original exception in the script being run happen.

Fixes https://github.com/rubygems/rubygems/issues/3368.

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)