### PR TITLE
Use better owner & group for files in rubygems package

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -162,7 +162,7 @@ file "pkg/rubygems-#{v}.tgz" => "pkg/rubygems-#{v}" do
       sh "7z a -ttar  rubygems-#{v}.tar rubygems-#{v}"
       sh "7z a -tgzip rubygems-#{v}.tgz rubygems-#{v}.tar"
     else
-      sh "tar -czf rubygems-#{v}.tgz rubygems-#{v}"
+      sh "tar -czf rubygems-#{v}.tgz --owner=rubygems:0 --group=rubygems:0 rubygems-#{v}"
     end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The rubygems package we're currently shipping can't be extracted inside a docker container.

The problem is detailed at https://github.com/rubygems/rubygems/issues/3977#issuecomment-726034458.

The TL;DR is that depending on which system is used to create the package, the packaged files can have very high UID and GUID, and inside a rootless docker container, `tar` can't handle those.

## What is your fix for the problem, implemented in this PR?

My fix is to pass explicit group and owner to the `tar` command that creates the package, so that `tar` can handle it.

The values are consistent with what's included in the official ruby package, so I believe they should work fine.

Fixes https://github.com/rubygems/rubygems/issues/3977.

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)