### PR TITLE
Fix Windows CI

### DIFF
--- a/bundler/spec/commands/clean_spec.rb
+++ b/bundler/spec/commands/clean_spec.rb
@@ -639,7 +639,7 @@ RSpec.describe "bundle clean" do
       end
     end
 
-    realworld_system_gems "fiddle"
+    realworld_system_gems "fiddle --version 1.0.0"
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Bundler CI on Windows failing after the ffi 1.0.1 release. See https://github.com/rubygems/rubygems/pull/4066/checks?check_run_id=1410838984.

## What is your fix for the problem, implemented in this PR?

We need to make sure the version of ffi we install here matches the version that comes with ruby by default.

## Make sure he following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)