### PR TITLE
Fix bundler using git cache as the install location

### DIFF
--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -158,8 +158,6 @@ module Bundler
       end
 
       def specs(*)
-        set_local!(app_cache_path) if has_app_cache? && !local?
-
         if requires_checkout? && !@copied
           fetch
           git_proxy.copy_to(install_path, submodules)
@@ -256,10 +254,6 @@ module Bundler
         @local       = true
         @local_specs = @git_proxy = nil
         @cache_path  = @install_path = path
-      end
-
-      def has_app_cache?
-        cached_revision && super
       end
 
       def requires_checkout?

--- a/bundler/spec/cache/git_spec.rb
+++ b/bundler/spec/cache/git_spec.rb
@@ -193,14 +193,31 @@ RSpec.describe "bundle cache with git" do
     expect(gemspec).to_not match("`echo bob`")
   end
 
-  it "can install after bundle cache with git not installed" do
+  it "can install after bundle cache without cloning remote repositories" do
     build_git "foo"
 
     gemfile <<-G
       gem "foo", :git => '#{lib_path("foo-1.0")}'
     G
     bundle "config set cache_all true"
+    bundle "config set path vendor/bundle"
     bundle :cache, "all-platforms" => true, :install => false
+
+    simulate_new_machine
+    bundle "config set deployment true"
+    bundle "install --local --verbose"
+    expect(out).to_not include("Fetching")
+    expect(the_bundle).to include_gem "foo 1.0"
+  end
+
+  it "can use gems after copying install folder to a different machine with git not installed" do
+    build_git "foo"
+
+    gemfile <<-G
+      gem "foo", :git => '#{lib_path("foo-1.0")}'
+    G
+    bundle "config set path vendor/bundle"
+    bundle :install
 
     simulate_new_machine
     with_path_as "" do
@@ -208,5 +225,34 @@ RSpec.describe "bundle cache with git" do
       bundle :install, :local => true
       expect(the_bundle).to include_gem "foo 1.0"
     end
+  end
+
+  it "doesn't fail when git gem has extensions and an empty cache folder is present before bundle install" do
+    build_git "puma" do |s|
+      s.add_dependency "rake"
+      s.extensions << "Rakefile"
+      s.executables = "puma"
+      s.write "Rakefile", <<-RUBY
+        task :default do
+          path = File.expand_path("../lib", __FILE__)
+          FileUtils.mkdir_p(path)
+          File.open("\#{path}/puma.rb", "w") do |f|
+            f.puts "PUMA = 'YES'"
+          end
+        end
+      RUBY
+    end
+
+    FileUtils.mkdir_p(bundled_app("vendor/cache"))
+    bundle "config set cache_all all"
+
+    install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
+      gem "puma", :git => "#{lib_path("puma-1.0")}"
+    G
+
+    bundle "exec puma"
+
+    expect(out).to eq("YES")
   end
 end

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -1415,7 +1415,7 @@ In Gemfile:
         to include("You need to install git to be able to use gems from git repositories. For help installing git, please refer to GitHub's tutorial at https://help.github.com/articles/set-up-git")
     end
 
-    it "installs a packaged git gem successfully" do
+    it "doesn't need git in the new machine if an installed git gem is copied to another machine" do
       build_git "foo"
 
       install_gemfile <<-G
@@ -1423,8 +1423,8 @@ In Gemfile:
           gem 'foo'
         end
       G
-      bundle "config set cache_all true"
-      bundle :cache
+      bundle "config set path vendor/bundle"
+      bundle :install
       simulate_new_machine
 
       bundle "install", :env => { "PATH" => "" }


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Bundler uses the cache as the final install location for git gems.

## What is your fix for the problem, implemented in this PR?

My fix is to remove the code that implements that feature, since it seems wrong. I had to change some specs, because git _is_ necessary when you have a cache. The cache is only meant to avoid hitting the network for fetching the source packages for installation.

Fixes #3204.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
