### PR TITLE
Do not override Kernel#warn when there is no need

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -119,6 +119,10 @@ module Gem
   # to avoid deprecation warnings in Ruby 2.7.
   UNTAINT = RUBY_VERSION < '2.7' ? :untaint.to_sym : proc{}
 
+  # When https://bugs.ruby-lang.org/issues/17259 is available, there is no need to override Kernel#warn
+  KERNEL_WARN_IGNORES_INTERNAL_ENTRIES = RUBY_ENGINE == "truffleruby" ||
+      (RUBY_ENGINE == "ruby" && RUBY_VERSION >= '3.0')
+
   ##
   # An Array of Regexps that match windows Ruby platforms.
 

--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -17,6 +17,8 @@ module Kernel
     private :gem_original_require
   end
 
+  file = Gem::KERNEL_WARN_IGNORES_INTERNAL_ENTRIES ? "<internal:#{__FILE__}>" : __FILE__
+  module_eval <<'RUBY', file, __LINE__
   ##
   # When RubyGems is required, Kernel#require is replaced with our own which
   # is capable of loading gems on demand.
@@ -166,6 +168,7 @@ module Kernel
       end
     end
   end
+RUBY
 
   private :require
 

--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -18,7 +18,7 @@ module Kernel
   end
 
   file = Gem::KERNEL_WARN_IGNORES_INTERNAL_ENTRIES ? "<internal:#{__FILE__}>" : __FILE__
-  module_eval <<'RUBY', file, __LINE__
+  module_eval <<'RUBY', file, __LINE__ + 1
   ##
   # When RubyGems is required, Kernel#require is replaced with our own which
   # is capable of loading gems on demand.

--- a/lib/rubygems/core_ext/kernel_warn.rb
+++ b/lib/rubygems/core_ext/kernel_warn.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # `uplevel` keyword argument of Kernel#warn is available since ruby 2.5.
-if RUBY_VERSION >= "2.5"
+if RUBY_VERSION >= "2.5" && !Gem::KERNEL_WARN_IGNORES_INTERNAL_ENTRIES
 
   module Kernel
     rubygems_path = "#{__dir__}/" # Frames to be skipped start with this path.

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -709,7 +709,7 @@ class TestGemRequire < Gem::TestCase
         RUBY
 
         _, err = capture_subprocess_io do
-          system(*ruby_with_rubygems_in_load_path, "-w", "--enable=gems", "-C", dir, "-I", dir, "main.rb")
+          system(*ruby_with_rubygems_in_load_path, "-w", "--disable=gems", "-C", dir, "-I", dir, "main.rb")
         end
         assert_match(/main\.rb:2: warning: This is a deprecated method$/, err)
         _, err = capture_subprocess_io do


### PR DESCRIPTION
* On Ruby implementations where https://bugs.ruby-lang.org/issues/17259
  is available, backtrace entries starting with `<internal:` are ignored
  for Kernel#warn. We can then define RubyGems's Kernel#require with
  such a filename and it will automatically be skipped for Kernel#warn.
* This is much less fragile (overriding Kernel#warn causes multiple
  issues and is very difficult to do properly) and it is also more
  efficient (the override would walk the stack multiple times).

Based on the idea in https://github.com/rubygems/rubygems/pull/3987#issuecomment-704334889

cc @deivid-rodriguez 

## What was the end-user or developer problem that led to this PR?

There were various issues due to monkey patching Kernel#warn, a quick search reveals at least:
https://github.com/rubygems/rubygems/issues/3053
https://github.com/rubygems/rubygems/issues/2588
https://github.com/rubygems/rubygems/pull/2911
and ~12 PRs seem to match `Kernel#require`: https://github.com/rubygems/rubygems/pulls?q=is%3Apr+Kernel%23warn
(original PR: https://github.com/rubygems/rubygems/pull/2442)

Also as a Ruby implementor, I can say overriding Kernel methods when it's not strictly needed leads to all kind of troubles.
Notably I got some headaches to handle the filtering in TruffleRuby and still let the filtering on RubyGems understand what's going on (it was not enough to just filter twice to give an idea of the complexity).

And of course having subtle behavior differences when passing `--disable-gems` for Kernel#warn is very confusing (I got tricked by this multiple times).

## What is your fix for the problem, implemented in this PR?

This PR is a nice way to not need to monkey-patch at all, and still always skip RubyGems' `require` when using `warn('message', uplevel: 1)`, for instance at the top of a file to emit a deprecation warning. So it fixes the original problem https://github.com/rubygems/rubygems/pull/2442 without monkey-patching anything.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
