### PR TITLE
Let Net::HTTP decompress the index instead of doing it manually

### DIFF
--- a/bundler/lib/bundler/compact_index_client/updater.rb
+++ b/bundler/lib/bundler/compact_index_client/updater.rb
@@ -2,7 +2,6 @@
 
 require_relative "../vendored_fileutils"
 require "stringio"
-require "zlib"
 
 module Bundler
   class CompactIndexClient
@@ -45,18 +44,12 @@ module Bundler
               else
                 "bytes=#{local_temp_path.size}-"
               end
-          else
-            # Fastly ignores Range when Accept-Encoding: gzip is set
-            headers["Accept-Encoding"] = "gzip"
           end
 
           response = @fetcher.call(remote_path, headers)
           return nil if response.is_a?(Net::HTTPNotModified)
 
           content = response.body
-          if response["Content-Encoding"] == "gzip"
-            content = Zlib::GzipReader.new(StringIO.new(content)).read
-          end
 
           SharedHelpers.filesystem_access(local_temp_path) do
             if response.is_a?(Net::HTTPPartialContent) && local_temp_path.size.nonzero?

--- a/bundler/lib/bundler/compact_index_client/updater.rb
+++ b/bundler/lib/bundler/compact_index_client/updater.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative "../vendored_fileutils"
-require "stringio"
 
 module Bundler
   class CompactIndexClient

--- a/bundler/spec/bundler/compact_index_client/updater_spec.rb
+++ b/bundler/spec/bundler/compact_index_client/updater_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe Bundler::CompactIndexClient::Updater do
     let(:response) { double(:response, :body => "abc123") }
 
     it "treats the response as an update" do
-      expect(response).to receive(:[]).with("Content-Encoding") { "" }
       expect(response).to receive(:[]).with("ETag") { nil }
       expect(fetcher).to receive(:call) { response }
 
@@ -29,8 +28,7 @@ RSpec.describe Bundler::CompactIndexClient::Updater do
     let(:response) { double(:response, :body => "") }
 
     it "raises HTTPError" do
-      expect(response).to receive(:[]).with("Content-Encoding") { "gzip" }
-      expect(fetcher).to receive(:call) { response }
+      expect(fetcher).to receive(:call).and_raise(Zlib::GzipFile::Error)
 
       expect do
         updater.update(local_path, remote_path)


### PR DESCRIPTION
* Setting the Accept-Encoding header actually disables the automatic
  decompression as documented in Net::HTTP.
  https://github.com/ruby/ruby/blob/79a8ed07650dcbb36ec4b49a22596275e6c0fe23/lib/net/http/response.rb#L105-L107
  https://github.com/ruby/ruby/blob/c5eb24349a4535948514fe765c3ddb0628d81004/lib/net/http/request.rb#L11-L12
* This is also more memory efficient as Net::HTTP decompresses chunk
  by chunk instead of having the entire compressed String in memory
  and also wrapped in a StringIO which is particularly inefficient.
* See https://github.com/oracle/truffleruby/issues/2127#issuecomment-730492319
  for more details.

As a result, `bundler` no longer uses `stringio`, so the require for it can be removed avoid potential issues with the `stringio` default gem. So this PR also closes #3860.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
