### PR TITLE
Support non-gnu libc linux platforms

### DIFF
--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -66,7 +66,7 @@ class Gem::Platform
     when String then
       arch = arch.split '-'
 
-      if arch.length > 2 and arch.last !~ /\d/ # reassemble x86-linux-gnu
+      if arch.length > 2 and arch.last !~ /\d+(\.\d+)?$/ # reassemble x86-linux-{libc}
         extra = arch.pop
         arch.last << "-#{extra}"
       end

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -146,7 +146,8 @@ class Gem::Platform
   ##
   # Does +other+ match this platform?  Two platforms match if they have the
   # same CPU, or either has a CPU of 'universal', they have the same OS, and
-  # they have the same version, or either has no version.
+  # they have the same version, or either has no version (except for 'linux'
+  # where the version is the libc name, with no version standing for 'gnu')
   #
   # Additionally, the platform will match if the local CPU is 'arm' and the
   # other CPU starts with "arm" (for generic ARM family support).
@@ -162,7 +163,11 @@ class Gem::Platform
     @os == other.os and
 
     # version
-    (@version.nil? or other.version.nil? or @version == other.version)
+    (
+      (@os != 'linux' and (@version.nil? or other.version.nil?)) or
+      (@os == 'linux' and ((@version.nil? and other.version == 'gnu') or (@version == 'gnu' and other.version == nil))) or
+      @version == other.version
+    )
   end
 
   ##

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -165,7 +165,6 @@ class Gem::Platform
     # version
     (
       (@os != 'linux' and (@version.nil? or other.version.nil?)) or
-      (@os == 'linux' and ((@version.nil? and other.version == 'gnu') or (@version == 'gnu' and other.version == nil))) or
       @version == other.version
     )
   end

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -145,6 +145,7 @@ class TestGemPlatform < Gem::TestCase
     test_cases.each do |arch, expected|
       platform = Gem::Platform.new arch
       assert_equal expected, platform.to_a, arch.inspect
+      assert_equal expected, Gem::Platform.new(platform.to_s).to_a, arch.inspect
     end
   end
 

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -134,7 +134,9 @@ class TestGemPlatform < Gem::TestCase
       'i386-solaris2.8'        => ['x86',       'solaris',   '2.8'],
       'mswin32'                => ['x86',       'mswin32',   nil],
       'x86_64-linux'           => ['x86_64',    'linux',     nil],
+      'x86_64-linux-gnu'       => ['x86_64',    'linux',     nil],
       'x86_64-linux-musl'      => ['x86_64',    'linux',     'musl'],
+      'x86_64-linux-uclibc'    => ['x86_64',    'linux',     'uclibc'],
       'x86_64-openbsd3.9'      => ['x86_64',    'openbsd',   '3.9'],
       'x86_64-openbsd4.0'      => ['x86_64',    'openbsd',   '4.0'],
       'x86_64-openbsd'         => ['x86_64',    'openbsd',   nil],
@@ -259,6 +261,32 @@ class TestGemPlatform < Gem::TestCase
     assert((with_uni_arch === with_nil_arch), 'universal =~ nil')
     assert((with_nil_arch === with_x86_arch), 'nil =~ x86')
     assert((with_x86_arch === with_nil_arch), 'x86 =~ nil')
+  end
+
+  def test_nil_version_is_treated_as_any_version
+    x86_darwin_8 = Gem::Platform.new 'i686-darwin8.0'
+    x86_darwin_nil = Gem::Platform.new 'i686-darwin'
+
+    assert((x86_darwin_8 === x86_darwin_nil), '8.0 =~ nil')
+    assert((x86_darwin_nil === x86_darwin_8), 'nil =~ 8.0')
+  end
+
+  def test_nil_version_is_stricter_for_linux_os
+    x86_linux = Gem::Platform.new 'i686-linux'
+    x86_linux_gnu = Gem::Platform.new 'i686-linux-gnu'
+    x86_linux_musl = Gem::Platform.new 'i686-linux-musl'
+    x86_linux_uclibc = Gem::Platform.new 'i686-linux-uclibc'
+
+    assert((x86_linux === x86_linux_gnu), 'linux =~ linux-gnu')
+    assert((x86_linux_gnu === x86_linux), 'linux-gnu =~ linux')
+    assert(!(x86_linux_gnu === x86_linux_musl), 'linux-gnu =~ linux-musl')
+    assert(!(x86_linux_musl === x86_linux_gnu), 'linux-musl =~ linux-gnu')
+    assert(!(x86_linux_uclibc === x86_linux_musl), 'linux-uclibc =~ linux-musl')
+    assert(!(x86_linux_musl === x86_linux_uclibc), 'linux-musl =~ linux-uclibc')
+    assert(!(x86_linux === x86_linux_musl), 'linux =~ linux-musl')
+    assert(!(x86_linux_musl === x86_linux), 'linux-musl =~ linux')
+    assert(!(x86_linux === x86_linux_uclibc), 'linux =~ linux-uclibc')
+    assert(!(x86_linux_uclibc === x86_linux), 'linux-uclibc =~ linux')
   end
 
   def test_equals3_cpu_arm


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).

## What was the end-user or developer problem that led to this PR?

Attempting to install a gem published as both `*-linux` and `*-linux-musl` results in the incorrect gem being picked up, causing build failures due to binary incompatibility. This is caused by the `nil` wildcard swallowing the libc information upon version comparison.

Followup to #2922
Closes #3174
    
## What is your fix for the problem, implemented in this PR?

Handle the `linux` case by performing only non-wildcard equality on the version and asserting `'gnu'` and `nil` equivalence, while preserving the current behaviour for other OSes.

Impact of this change is expected to be limited to none, as `*-linux` gems working on non-`*-linux` platforms such as *`-linux-musl` are vanishingly rare due to the stringent requirements and moves required to produce them. Therefore, as codified in the codebase preceding this pull request, it can be assumed that the set of gems published as `*-linux` is strictly equal to the set of gems that would be marked `-linux-gnu` only (if that were a thing).

Alternative considered: implement an additional, optional `@libc` attribute, thus setting the `@version` one to be always `nil` for an `@os` being `'linux'`. This would do away with some of the hacks in there, but would significantly alter the existing code for very little immediate value, and would break code currently depending on checking for `@version` being `musl` on recent rubygems.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
