### PR TITLE
Update `set_rubyopt` in `Bundler::SharedHelpers` to support paths containing spaces

### DIFF
--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -303,7 +303,7 @@ module Bundler
 
     def set_rubyopt
       rubyopt = [ENV["RUBYOPT"]].compact
-      setup_require = "-r#{File.expand_path("setup", __dir__)}"
+      setup_require = "\"-r#{File.expand_path("setup", __dir__)}\""
       return if !rubyopt.empty? && rubyopt.first =~ /#{setup_require}/
       rubyopt.unshift setup_require
       Bundler::SharedHelpers.set_env "RUBYOPT", rubyopt.join(" ")

--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -2,6 +2,7 @@
 
 require "pathname"
 require "rbconfig"
+require "shellwords"
 
 require_relative "version"
 require_relative "constants"
@@ -306,7 +307,7 @@ module Bundler
       setup_require = "\"-r#{File.expand_path("setup", __dir__)}\""
       return if !rubyopt.empty? && rubyopt.first =~ /#{setup_require}/
       rubyopt.unshift setup_require
-      Bundler::SharedHelpers.set_env "RUBYOPT", rubyopt.join(" ")
+      Bundler::SharedHelpers.set_env "RUBYOPT", Shellwords.join(rubyopt)
     end
 
     def set_rubylib


### PR DESCRIPTION
In situations where Ruby is installed into a base path that contains one
or more spaces, the previous behavior could lead to Ruby attempting to
interpret the various components of the require path set via RUBYOPT as
distinct options, leading to errors like:

```
C:/Program Files/Puppet
Labs/DevelopmentKit/private/ruby/2.5.8/bin/ruby.exe: invalid switch in
RUBYOPT: -F (RuntimeError)
```

This change wraps the entire `-r` option in quotes to ensure that Ruby
interprets it all as a single value.

Since this is an implementation detail of a private method, I wasn't sure 
where the best place to add a test would be, but I'm happy to add tests if
someone can point me in the right direction.