### PR TITLE
Fix `Bundler::Plugin::API::Source#to_s` having empty source type

### DIFF
--- a/bundler/lib/bundler/plugin/api/source.rb
+++ b/bundler/lib/bundler/plugin/api/source.rb
@@ -260,7 +260,7 @@ module Bundler
         end
 
         def to_s
-          "plugin source for #{options[:type]} with uri #{uri}"
+          "plugin source for #{@type} with uri #{@uri}"
         end
 
         # Note: Do not override if you don't know what you are doing.

--- a/bundler/spec/bundler/plugin/api/source_spec.rb
+++ b/bundler/spec/bundler/plugin/api/source_spec.rb
@@ -79,4 +79,10 @@ RSpec.describe Bundler::Plugin::API::Source do
       end
     end
   end
+
+  describe "to_s" do
+    it "returns the string with type and uri" do
+      expect(source.to_s).to eq("plugin source for spec_type with uri uri://to/test")
+    end
+  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I found this small bug during developing bundler plugin.

## What is your fix for the problem, implemented in this PR?

The fix is self explanatory and covered with spec.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] ~Write code to solve the problem~
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
