### PR TITLE
Complete specs for newgem generator CHANGELOG.md

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -162,6 +162,7 @@ bundler/lib/bundler/templates/Executable.bundler
 bundler/lib/bundler/templates/Executable.standalone
 bundler/lib/bundler/templates/Gemfile
 bundler/lib/bundler/templates/gems.rb
+bundler/lib/bundler/templates/newgem/CHANGELOG.md.tt
 bundler/lib/bundler/templates/newgem/CODE_OF_CONDUCT.md.tt
 bundler/lib/bundler/templates/newgem/Gemfile.tt
 bundler/lib/bundler/templates/newgem/LICENSE.txt.tt

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -589,6 +589,7 @@ module Bundler
     method_option :git, :type => :boolean, :default => true, :desc => "Initialize a git repo inside your library."
     method_option :mit, :type => :boolean, :desc => "Generate an MIT license file. Set a default with `bundle config set --global gem.mit true`."
     method_option :rubocop, :type => :boolean, :desc => "Add rubocop to the generated Rakefile and gemspec. Set a default with `bundle config set --global gem.rubocop true`."
+    method_option :changelog, :type => :boolean, :desc => "Generate changelog file. Set a default with `bundle config set --global gem.changelog true`."
     method_option :test, :type => :string, :lazy_default => Bundler.settings["gem.test"] || "", :aliases => "-t", :banner => "Use the specified test framework for your library",
                          :desc => "Generate a test directory for your library, either rspec, minitest or test-unit. Set a default with `bundle config set --global gem.test (rspec|minitest|test-unit)`."
     method_option :ci, :type => :string, :lazy_default => Bundler.settings["gem.ci"] || "",

--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -141,6 +141,18 @@ module Bundler
         templates.merge!("CODE_OF_CONDUCT.md.tt" => "CODE_OF_CONDUCT.md")
       end
 
+      if ask_and_set(:changelog, "Do you want to include a changelog?",
+        "A changelog is a file which contains a curated, chronologically ordered list of notable " \
+        "changes for each version of a project. To make it easier for users and contributors to" \
+        " see precisely what notable changes have been made between each release (or version) of" \
+        " the project. Whether consumers or developers, the end users of software are" \
+        " human beings who care about what's in the software. When the software changes, people " \
+        "want to know why and how. see https://keepachangelog.com")
+        config[:changelog] = true
+        Bundler.ui.info "Changelog enabled in config"
+        templates.merge!("CHANGELOG.md.tt" => "CHANGELOG.md")
+      end
+
       if ask_and_set(:rubocop, "Do you want to add rubocop as a dependency for gems you generate?",
         "RuboCop is a static code analyzer that has out-of-the-box rules for many " \
         "of the guidelines in the community style guide. " \

--- a/bundler/lib/bundler/templates/newgem/CHANGELOG.md.tt
+++ b/bundler/lib/bundler/templates/newgem/CHANGELOG.md.tt
@@ -1,0 +1,5 @@
+## [Unreleased]
+
+## [0.1.0] - <%= Time.now.strftime('%F') %>
+
+- Initial release

--- a/bundler/spec/bundler/gem_helper_spec.rb
+++ b/bundler/spec/bundler/gem_helper_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe Bundler::GemHelper do
   let(:app_gemspec_path) { app_path.join("#{app_name}.gemspec") }
 
   before(:each) do
-    global_config "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__COC" => "false", "BUNDLE_GEM__RUBOCOP" => "false", "BUNDLE_GEM__CI" => "false"
+    global_config "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__COC" => "false", "BUNDLE_GEM__RUBOCOP" => "false",
+                  "BUNDLE_GEM__CI" => "false", "BUNDLE_GEM__CHANGELOG" => "false"
     bundle "gem #{app_name}"
     prepare_gemspec(app_gemspec_path)
   end

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -158,6 +158,26 @@ RSpec.describe "bundle gem" do
     end
   end
 
+  shared_examples_for "--changelog flag" do
+    before do
+      bundle "gem #{gem_name} --changelog"
+    end
+    it "generates a gem skeleton with a CHANGELOG", :readline do
+      gem_skeleton_assertions
+      expect(bundled_app("#{gem_name}/CHANGELOG.md")).to exist
+    end
+  end
+
+  shared_examples_for "--no-changelog flag" do
+    before do
+      bundle "gem #{gem_name} --no-changelog"
+    end
+    it "generates a gem skeleton without a CHANGELOG", :readline do
+      gem_skeleton_assertions
+      expect(bundled_app("#{gem_name}/CHANGELOG.md")).to_not exist
+    end
+  end
+
   shared_examples_for "--rubocop flag" do
     before do
       bundle "gem #{gem_name} --rubocop"
@@ -904,6 +924,22 @@ RSpec.describe "bundle gem" do
       it_behaves_like "--rubocop flag"
       it_behaves_like "--no-rubocop flag"
     end
+
+    context "with changelog option in bundle config settings set to true" do
+      before do
+        global_config "BUNDLE_GEM__CHANGELOG" => "true"
+      end
+      it_behaves_like "--changelog flag"
+      it_behaves_like "--no-changelog flag"
+    end
+
+    context "with changelog option in bundle config settings set to false" do
+      before do
+        global_config "BUNDLE_GEM__CHANGELOG" => "false"
+      end
+      it_behaves_like "--changelog flag"
+      it_behaves_like "--no-changelog flag"
+    end
   end
 
   context "gem naming with underscore", :readline do
@@ -1088,6 +1124,17 @@ Usage: "bundle gem NAME [OPTIONS]"
       end
 
       expect(bundled_app("foobar/CODE_OF_CONDUCT.md")).to exist
+    end
+
+    it "asks about CHANGELOG" do
+      global_config "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__CI" => "false", "BUNDLE_GEM__RUBOCOP" => "false",
+                    "BUNDLE_GEM__COC" => "false"
+
+      bundle "gem foobar" do |input, _, _|
+        input.puts "yes"
+      end
+
+      expect(bundled_app("foobar/CHANGELOG.md")).to exist
     end
   end
 


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

The discussion in [the original PR](https://github.com/rubygems/rubygems/pull/3908) welcomes a newcomer to resolve the leftover suggestions to get the original PR over the goal line. The original PR adds the option to include a CHANGELOG.md when running `bundle gem <GEM>`. Thank you @kieranklaassen for the excellent improvement and thank you for opening up another opportunity to contribute. 

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

I simply fixed a typo in the spec and followed the instructions to set the CHANGELOG global config to false in the main before hook. I also wrote the spec to verify there is a prompt (on the first run) that asks if the user would like to include a CHANGELOG.md.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
