### PR TITLE
Delay deprecation still used by recent bundlers

### DIFF
--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -21,11 +21,6 @@ class Gem::Platform
     match_platforms?(platform, Gem.platforms)
   end
 
-  class << self
-    extend Gem::Deprecate
-    rubygems_deprecate :match, "Gem::Platform.match_spec?"
-  end
-
   def self.match_platforms?(platform, platforms)
     platforms.any? do |local_platform|
       platform.nil? or


### PR DESCRIPTION
Bundler 2.1.4 still uses this, let's wait a bit longer.

As an example, booting tests on my project using bundler 2.1.4 against the latest rubygems prerelease leads to this:

```
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
test app tmp/test_apps/rails_60 already exists; skipping test app generation
bin/parallel_rspec spec/
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/index.rb:198.
8 processes for 98 specs, ~ 12 specs per process
^Crake aborted!
Interrupt: 
/home/deivid/Code/activeadmin/tasks/test.rake:45:in `block (2 levels) in <top (required)>'
Tasks: TOP => default => test => spec => spec:all => spec:regular
(See full trace by running task with --trace)
```

This will annoy people for sure, let's just delay it.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)