### PR TITLE
Further unify release scripts

### DIFF
--- a/POLICIES.md
+++ b/POLICIES.md
@@ -57,9 +57,10 @@ smooth and no needed steps are missed.
 
 ### Steps for all releases
 
-*   Confirm milestone on GitHub is complete
-*   Update History.txt
-*   Update Manifest.txt
+*   Confirm all PRs that you want backported are properly tagged with `rubygems:
+    <type>` labels at GitHub.
+*   Run `rake prepare_stable_branch[<target_version>]`, create a PR and merge it
+    to the stable branch once CI passes.
 *   Create and push git tag
 *   Create and push `rubygems-update` gem and tgz
 *   Publish blog post

--- a/Rakefile
+++ b/Rakefile
@@ -103,7 +103,7 @@ desc "Prepare stable branch"
 task :prepare_stable_branch, [:version] do |_t, opts|
   require_relative "util/release"
 
-  Release.for_rubygems(opts[:version] || v.to_s).prepare!
+  Release.new(opts[:version] || v.to_s).prepare!
 end
 
 desc "Install rubygems to local system"

--- a/bundler/doc/playbooks/RELEASING.md
+++ b/bundler/doc/playbooks/RELEASING.md
@@ -31,9 +31,9 @@ version of Bundler.
 
 ### Patch && minor releases
 
-While pushing a gem version to RubyGems.org is as simple as `bin/rake release`,
-releasing a new version of Bundler includes a lot of communication: team consensus,
-git branching, documentation site updates, and a blog post.
+While pushing a gem version to RubyGems.org is as simple as `rake release`,
+releasing a new version of Bundler includes a lot of communication: team
+consensus, git branching, documentation site updates, and a blog post.
 
 Patch and minor releases are made by cherry-picking pill requests from `master`.
 
@@ -94,7 +94,7 @@ $ git cherry-pick -m 1 dd6aef9
 After running the task, you'll have a release branch ready to be merged into the
 stable branch. You'll want to open a PR from this branch into the stable branch
 and provided CI is green, you can go ahead, merge the PR and run `bin/rake
-release` from the updated stable branch.
+release` from `bundler/` directory in the updated stable branch.
 
 Here's the checklist for releasing new minor versions:
 
@@ -105,7 +105,8 @@ Here's the checklist for releasing new minor versions:
   a PR to the stable branch with the generated changes.
 * [ ] Get the PR reviewed, make sure CI is green, and merge it.
 * [ ] Pull the updated stable branch, wait for CI to complete on it and get excited.
-* [ ] Run `bin/rake release` from the updated stable branch, tweet, blog, let people know about the prerelease!
+* [ ] Run `bin/rake release` from the `bundler/` directory updated stable
+  branch, tweet, blog, let people know about the prerelease!
 * [ ] Wait a **minimum of 7 days**
 * [ ] If significant problems are found, increment the prerelease (i.e. 2.2.pre.2)
   and repeat, but treating `.pre.2` as a _patch release_. In general, once a stable
@@ -123,7 +124,8 @@ Wait! You're not done yet! After your prelease looks good:
 * [ ] Write a blog post announcing the new version, highlighting new features and
   notable bugfixes
 * [ ] Pull the updated stable branch, wait for CI to complete on it and get excited.
-* [ ] Run `bin/rake release` in the bundler repo, tweet, link to the blog post, etc.
+* [ ] Run `bin/rake release` in the `bundler/` directory of the updated stable
+  branch, tweet, link to the blog post, etc.
 
 At this point, you're a release manager! Pour yourself several tasty drinks and
 think about taking a vacation in the tropics.

--- a/bundler/doc/playbooks/RELEASING.md
+++ b/bundler/doc/playbooks/RELEASING.md
@@ -37,14 +37,39 @@ git branching, documentation site updates, and a blog post.
 
 Patch and minor releases are made by cherry-picking pill requests from `master`.
 
-There is a `bin/rake release:prepare[<target_version>]` rake task that helps
-with creating a release. It takes a single argument, the _exact_ release being
-made (e.g.  `2.2.3`). This task checks out the appropriate stable branch
-(`3.2`), grabs all merged but unreleased PRs from GitHub that are compatible
-with the target release level, and then cherry-picks those changes (and only
-those changes) to a new branch based off the stable branch.  Then bumps the
-version in the version file, synchronizes the changelog to include all
-backported changes and commits that change on top of the cherry-picks.
+### Branching
+
+Bundler releases are syncronized with rubygems releases at the moment. That
+means that releases for both share the same stable branch, and they should
+generally happen together.
+
+Minor releases of the next version start with a new release branch from the
+current state of master: `3.2`, and are immediately followed by a prerelease
+(might be a `.pre.1` version or a `.rc.1` version depending on the readiness of
+the stable branch) or even directly by the final stable release.
+
+The current conventional naming for stable branches is `x+1.y`, where `x.y` is
+the version of `bundler` that will be released. This is because `rubygems-x+1.y`
+will be released at the same time.
+
+For example, `rubygems-3.2.0` and `bundler-2.2.0` will be both released from the
+`3.2` stable branch.
+
+Once a stable branch has been cut from `master`, changes for that minor release
+series (bundler 2.2) will only be made _intentionally_, via patch releases.
+That is to say, changes to `master` by default _won't_ make their way into any
+`2.2` version, and development on `master` will be targeting the next minor
+or major release.
+
+There is a `rake prepare_stable_branch[<target_rubugems_version>]` rake task
+that helps with creating a release. It takes a single argument, the _exact
+rubygems release_ being made (e.g.  `3.2.3` when releasing bundler `2.2.3`).
+This task checks out the appropriate stable branch (`3.2`), grabs all merged but
+unreleased PRs from both bundler & rubygems from GitHub that are compatible with
+the target release level, and then cherry-picks those changes (and only those
+changes) to a new branch based off the stable branch. Then bumps the version in
+all version files, synchronizes both changelogs to include all backported
+changes and commits that change on top of the cherry-picks.
 
 Note that this task requires all user facing pull requests to be tagged with
 specific labels. See [Merging a PR](/bundler/doc/playbooks/MERGING_A_PR.md) for
@@ -76,8 +101,8 @@ Here's the checklist for releasing new minor versions:
 * [ ] Check with the core team to ensure that there is consensus around shipping a
   feature release. As a general rule, this should always be okay, since features
   should _never break backwards compatibility_
-* [ ] Run `bin/rake release:prepare[<target_pre_version>]` and create a PR to
-  the stable branch with the generated changes.
+* [ ] Run `rake prepare_stable_branch[<target_rubygems_pre_version>]` and create
+  a PR to the stable branch with the generated changes.
 * [ ] Get the PR reviewed, make sure CI is green, and merge it.
 * [ ] Pull the updated stable branch, wait for CI to complete on it and get excited.
 * [ ] Run `bin/rake release` from the updated stable branch, tweet, blog, let people know about the prerelease!
@@ -88,8 +113,8 @@ Here's the checklist for releasing new minor versions:
 
 Wait! You're not done yet! After your prelease looks good:
 
-* [ ] Run `bin/rake release:prepare[<target_version>]` and create a PR to the
-  stable branch.
+* [ ] Run `rake prepare_stable_branch[<target_rubygems_version>]` and create a
+  PR to the stable branch.
 * [ ] Get the PR reviewed, make sure CI is green, and merge it.
 * [ ] In the [rubygems/bundler-site](https://github.com/rubygems/bundler-site) repo,
   copy the previous version's docs to create a new version (e.g. `cp -r v2.1 v2.2`)
@@ -106,30 +131,6 @@ think about taking a vacation in the tropics.
 Beware, the first couple of days after the first non-prerelease version in a minor version
 series can often yield a lot of bug reports. This is normal, and doesn't mean you've done
 _anything_ wrong as the release manager.
-
-#### Branching
-
-Bundler releases are syncronized with rubygems releases at the moment. That
-means that releases for both share the same stable branch, and they should
-generally happen together.
-
-Minor releases of the next version start with a new release branch from the
-current state of master: `3.2`, and are immediately followed by a prerelease
-(might be a `.pre.1` version or a `.rc.1` version depending on the readiness of
-the stable branch) or even directly by the final stable release.
-
-The current conventional naming for stable branches is `x+1.y`, where `x.y` is
-the version of `bundler` that will be released. This is because `rubygems-x+1.y`
-will be released at the same time.
-
-For example, `rubygems-3.2.0` and `bundler-2.2.0` will be both released from the
-`3.2` stable branch.
-
-Once a stable branch has been cut from `master`, changes for that minor release
-series (bundler 2.2) will only be made _intentionally_, via patch releases.
-That is to say, changes to `master` by default _won't_ make their way into any
-`2.2` version, and development on `master` will be targeting the next minor
-or major release.
 
 ## Beta testing
 

--- a/bundler/task/release.rake
+++ b/bundler/task/release.rake
@@ -35,9 +35,4 @@ namespace :release do
 
     Release.for_bundler(gemspec_version).create_for_github!
   end
-
-  desc "Prepare a new release"
-  task :prepare, [:version] do |_t, opts|
-    Release.for_bundler(opts[:version]).prepare!
-  end
 end

--- a/bundler/task/release.rake
+++ b/bundler/task/release.rake
@@ -2,7 +2,6 @@
 
 require_relative "../lib/bundler/gem_tasks"
 require_relative "../spec/support/build_metadata"
-require_relative "../../util/changelog"
 require_relative "../../util/release"
 
 Bundler::GemHelper.tag_prefix = "bundler-"
@@ -24,7 +23,7 @@ task "release:rubygem_push" => ["release:verify_docs", "build_metadata", "releas
 
 desc "Generates the changelog for a specific target version"
 task :generate_changelog, [:version] do |_t, opts|
-  Changelog.for_bundler(opts[:version]).cut!
+  Release.for_bundler(opts[:version]).cut_changelog!
 end
 
 namespace :release do

--- a/util/changelog.rb
+++ b/util/changelog.rb
@@ -5,14 +5,14 @@ require "yaml"
 class Changelog
   def self.for_rubygems(version)
     @rubygems ||= new(
-      "History.txt",
+      File.expand_path("../History.txt", __dir__),
       version,
     )
   end
 
   def self.for_bundler(version)
     @bundler ||= new(
-      "CHANGELOG.md",
+      File.expand_path("../bundler/CHANGELOG.md", __dir__),
       version,
     )
   end

--- a/util/changelog.rb
+++ b/util/changelog.rb
@@ -161,7 +161,7 @@ class Changelog
   end
 
   def group_by_labels(pulls)
-    grouped_pulls = pulls.group_by do |pull|
+    grouped_pulls = pulls.sort_by(&:merged_at).group_by do |pull|
       relevant_label_for(pull)
     end
 

--- a/util/release.rb
+++ b/util/release.rb
@@ -84,11 +84,11 @@ class Release
     @changelog.cut!(previous_version, relevant_pull_requests_since_last_release)
   end
 
-  def create_for_github!(release_notes)
+  def create_for_github!
     tag = "#{@tag_prefix}#{@version}"
 
     gh_client.create_release "rubygems/rubygems", tag, :name => tag,
-                                                       :body => release_notes.join("\n").strip,
+                                                       :body => @changelog.release_notes.join("\n").strip,
                                                        :prerelease => @version.prerelease?
   end
 

--- a/util/release.rb
+++ b/util/release.rb
@@ -3,44 +3,127 @@
 require_relative "changelog"
 
 class Release
+  module GithubAPI
+    def gh_client
+      @gh_client ||= begin
+        require "netrc"
+        _username, token = Netrc.read["api.github.com"]
+
+        require "octokit"
+        Octokit::Client.new(:access_token => token)
+      end
+    end
+  end
+
+  module SubRelease
+    include GithubAPI
+
+    attr_reader :version, :changelog, :version_files, :title, :tag_prefix
+
+    def cut_changelog_for!(pull_requests)
+      set_relevant_pull_requests_from(pull_requests)
+
+      cut_changelog!
+    end
+
+    def cut_changelog!
+      @changelog.cut!(previous_version, relevant_pull_requests)
+    end
+
+    def create_for_github!
+      tag = "#{@tag_prefix}#{@version}"
+
+      gh_client.create_release "rubygems/rubygems", tag, :name => tag,
+                                                         :body => @changelog.release_notes.join("\n").strip,
+                                                         :prerelease => @version.prerelease?
+    end
+
+    def previous_version
+      @latest_release ||= latest_release.tag_name.gsub(/^#{@tag_prefix}/, "")
+    end
+
+    def latest_release
+      @latest_release ||= gh_client.releases("rubygems/rubygems").select {|release| release.tag_name.start_with?(@tag_prefix) }.sort_by(&:created_at).last
+    end
+
+    attr_reader :relevant_pull_requests
+
+    def set_relevant_pull_requests_from(pulls)
+      @relevant_pull_requests = pulls.select {|pull| @changelog.relevant_label_for(pull) }
+    end
+  end
+
+  class Bundler
+    include SubRelease
+
+    def initialize(version)
+      @version = version
+      @changelog = Changelog.for_bundler(version)
+      @version_files = [File.expand_path("../bundler/lib/bundler/version.rb", __dir__)]
+      @title = "Bundler version #{version} with changelog"
+      @tag_prefix = "bundler-v"
+    end
+  end
+
+  class Rubygems
+    include SubRelease
+
+    def initialize(version)
+      @version = version
+      @changelog = Changelog.for_rubygems(version)
+      @version_files = [File.expand_path("../lib/rubygems.rb", __dir__), File.expand_path("../rubygems-update.gemspec", __dir__)]
+      @title = "Rubygems version #{version} with changelog"
+      @tag_prefix = "v"
+    end
+  end
+
+  include GithubAPI
+
   def self.for_bundler(version)
-    new(
-      version,
-      changelog: Changelog.for_bundler(version),
-      release_branch: "release_bundler/#{version}",
-      stable_branch: Gem::Version.new(version).segments.map.with_index {|s, i| i == 0 ? s + 1 : s }[0, 2].join("."),
-      version_files: [File.expand_path("../bundler/lib/bundler/version.rb", __dir__)],
-      title: "Bundler version #{version} with changelog",
-      tag_prefix: "bundler-v",
-    )
+    rubygems_version = Gem::Version.new(version).segments.map.with_index {|s, i| i == 0 ? s + 1 : s }.join(".")
+
+    release = new(rubygems_version)
+    release.set_bundler_as_current_library
+    release
   end
 
   def self.for_rubygems(version)
-    new(
-      version,
-      changelog: Changelog.for_rubygems(version),
-      release_branch: "release_rubygems/#{version}",
-      stable_branch: Gem::Version.new(version).segments[0, 2].join("."),
-      version_files: [File.expand_path("../lib/rubygems.rb", __dir__), File.expand_path("../rubygems-update.gemspec", __dir__)],
-      title: "Rubygems version #{version} with changelog",
-      tag_prefix: "v",
-    )
+    release = new(version)
+    release.set_rubygems_as_current_library
+    release
   end
 
-  def initialize(version, changelog:, stable_branch:, release_branch:, version_files:, title:, tag_prefix:)
-    @version = version
-    @changelog = changelog
-    @stable_branch = stable_branch
-    @release_branch = release_branch
-    @version_files = version_files
-    @title = title
-    @tag_prefix = tag_prefix
+  #
+  # Accepts the version of the rubygems library to be released
+  #
+  def initialize(version)
+    segments = Gem::Version.new(version).segments
+
+    rubygems_version = segments.join(".")
+    @rubygems = Rubygems.new(rubygems_version)
+
+    bundler_version = segments.map.with_index {|s, i| i == 0 ? s - 1 : s }.join(".")
+    @bundler = Bundler.new(bundler_version)
+
+    @stable_branch = segments[0, 2].join(".")
+    @release_branch = "release/bundler_#{bundler_version}_rubygems_#{rubygems_version}"
+  end
+
+  def set_bundler_as_current_library
+    @current_library = @bundler
+  end
+
+  def set_rubygems_as_current_library
+    @current_library = @rubygems
   end
 
   def prepare!
     initial_branch = `git rev-parse --abbrev-ref HEAD`.strip
 
     system("git", "checkout", "-b", @release_branch, @stable_branch, exception: true)
+
+    @bundler.set_relevant_pull_requests_from(unreleased_pull_requests)
+    @rubygems.set_relevant_pull_requests_from(unreleased_pull_requests)
 
     begin
       prs = relevant_unreleased_pull_requests
@@ -62,17 +145,19 @@ class Release
         end
       end
 
-      @version_files.each do |version_file|
-        version_contents = File.read(version_file)
-        unless version_contents.sub!(/^(.*VERSION = )"#{Gem::Version::VERSION_PATTERN}"/i, "\\1#{@version.to_s.dump}")
-          raise "Failed to update #{version_file}, is it in the expected format?"
+      [@bundler, @rubygems].each do |library|
+        library.version_files.each do |version_file|
+          version_contents = File.read(version_file)
+          unless version_contents.sub!(/^(.*VERSION = )"#{Gem::Version::VERSION_PATTERN}"/i, "\\1#{library.version.to_s.dump}")
+            raise "Failed to update #{version_file}, is it in the expected format?"
+          end
+          File.open(version_file, "w") {|f| f.write(version_contents) }
         end
-        File.open(version_file, "w") {|f| f.write(version_contents) }
+
+        library.cut_changelog!
+
+        system("git", "commit", "-am", library.title, exception: true)
       end
-
-      @changelog.cut!(previous_version, prs)
-
-      system("git", "commit", "-am", @title, exception: true)
     rescue StandardError
       system("git", "checkout", initial_branch, exception: true)
       system("git", "branch", "-D", @release_branch, exception: true)
@@ -81,34 +166,20 @@ class Release
   end
 
   def cut_changelog!
-    @changelog.cut!(previous_version, relevant_pull_requests_since_last_release)
-  end
-
-  def create_for_github!
-    tag = "#{@tag_prefix}#{@version}"
-
-    gh_client.create_release "rubygems/rubygems", tag, :name => tag,
-                                                       :body => @changelog.release_notes.join("\n").strip,
-                                                       :prerelease => @version.prerelease?
+    @current_library.cut_changelog_for!(unreleased_pull_requests)
   end
 
   private
 
   def relevant_unreleased_pull_requests
-    pr_ids = unreleased_pr_ids
-
-    relevant_pull_requests_for(pr_ids)
+    (@bundler.relevant_pull_requests + @rubygems.relevant_pull_requests).sort_by(&:merged_at)
   end
 
-  def previous_version
-    latest_release.tag_name.gsub(/^#{@tag_prefix}/, "")
+  def unreleased_pull_requests
+    @unreleased_pull_requests ||= scan_unreleased_pull_requests(unreleased_pr_ids)
   end
 
-  def latest_release
-    @latest_release ||= gh_client.releases("rubygems/rubygems").select {|release| release.tag_name.start_with?(@tag_prefix) }.sort_by(&:created_at).last
-  end
-
-  def relevant_pull_requests_for(ids)
+  def scan_unreleased_pull_requests(ids)
     pulls = gh_client.pull_requests("rubygems/rubygems", :sort => :updated, :state => :closed, :direction => :desc)
 
     loop do
@@ -119,7 +190,7 @@ class Release
       pulls.concat gh_client.get(gh_client.last_response.rels[:next].href)
     end
 
-    pulls.select {|pull| @changelog.relevant_label_for(pull) }.sort_by(&:merged_at)
+    pulls
   end
 
   def unreleased_pr_ids
@@ -132,15 +203,5 @@ class Release
 
       /^Merge pull request #(\d+)/.match(message)[1].to_i
     end.compact
-  end
-
-  def gh_client
-    @gh_client ||= begin
-      require "netrc"
-      _username, token = Netrc.read["api.github.com"]
-
-      require "octokit"
-      Octokit::Client.new(:access_token => token)
-    end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I recently refactored release task so that now we have two different tasks to
backport PRs:

* `rake prepare_stable_branch[<rubygems_target_version>]` to prepare the stable branch for the rubygems release (backporting only rubygems-related PRs).

* `bin/rake release:prepare[<bundler_target_version>]` (from the bundler/ directory) to prepare the stable branch for the bundler release (backporting only bundler-related PRs).

However, since some PRs make changes in both libraries (for example, make a change in rubygems code and adapt to the change in bundler code), this was problematic since it could more easily lead to merge conflicts and required weird tagging to force backporting of rubygems PRs within the bundler tasks and vviceversa.

## What is your fix for the problem, implemented in this PR?

This PR changes the strategy to use a single task to prepare the stable branch for both libraries.

So, now, we only need to run `bin/rake prepare_stable_branch[<rubygems_target_version>]` and that will automatically:

* Backport all relevant PRs to the stable branch for both bundler & rubygems.
* Edit version files, generate the changelog for rubygems including all the rubygems PRs and commit it.
* Edit version files, generate the changelog for bundler including all the bundler PRs and commit it.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)