### PR TITLE
Fix test failure when version is exactly 3.2

### DIFF
--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -198,13 +198,13 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
 
   def test_execute_system_specific_newer_than_or_equal_to_3_2_leaves_plugins_dir_alone
     spec_fetcher do |fetcher|
-      fetcher.download 'rubygems-update', 3.2 do |s|
+      fetcher.download 'rubygems-update', "3.2.a" do |s|
         s.files = %w[setup.rb]
       end
     end
 
     @cmd.options[:args]          = []
-    @cmd.options[:system]        = "3.2"
+    @cmd.options[:system]        = "3.2.a"
 
     FileUtils.mkdir_p Gem.plugindir
     plugin_file = File.join(Gem.plugindir, 'a_plugin.rb')


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In the stable branch (when version is exactly 3.2), this test fails because rubygems updater aborts early in the specific case when we are upgrading to the exact same rubygems version being run with an "already installed" message.

## What is your fix for the problem, implemented in this PR?

To fix this problem, I change the test to use the earliest possible 3.2 prerelease, which is the same version that shipped the new layout and it's a past release so it should pass consistently no matter when the running rubygems release is.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)