### PR TITLE
Clear ENV['BUNDLER_VERSION'] in TestCase#setup

### DIFF
--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -298,6 +298,7 @@ class Gem::TestCase < Minitest::Test
     ENV['XDG_CONFIG_HOME'] = nil
     ENV['XDG_DATA_HOME'] = nil
     ENV['SOURCE_DATE_EPOCH'] = nil
+    ENV['BUNDLER_VERSION'] = nil
     ENV["TMPDIR"] = @tmp
 
     @current_dir = Dir.pwd


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Failures in ruby/ruby CI when `ENV['BUNDLER_VERSION']` was set.  Below are the three tests:
```
test_gem.rb:341             TestGem#test_activate_bin_path_gives_proper_error_for_bundler
test_gem_dependency.rb:353  TestGemDependency#test_to_specs_respects_bundler_version
test_kernel.rb:115          TestKernel#test_gem_bundler
```

## What is your fix for the problem, implemented in this PR?

Add `ENV['BUNDLER_VERSION'] = nil` to `TestCase#setup`

Closes #4107


## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
