### PR TITLE
Allow to ignore "required_ruby_version" requirement

### DIFF
--- a/bundler/lib/bundler/endpoint_specification.rb
+++ b/bundler/lib/bundler/endpoint_specification.rb
@@ -121,6 +121,14 @@ module Bundler
           @required_rubygems_version = Gem::Requirement.new(v)
         when "ruby"
           @required_ruby_version = Gem::Requirement.new(v)
+
+          if ENV["RUBYGEMS_IGNORE_RUBY_VERSION_REQUIREMENT"]
+            req = @required_ruby_version.requirements.map do |op, version|
+              op = op == "~>" ? ">=" : op
+              "#{op} #{version}"
+            end
+            @required_ruby_version = Gem::Requirement.new req
+          end
         end
       end
     rescue StandardError => e

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -668,6 +668,14 @@ class Gem::Specification < Gem::BasicSpecification
 
   def required_ruby_version=(req)
     @required_ruby_version = Gem::Requirement.create req
+
+    if ENV["RUBYGEMS_IGNORE_RUBY_VERSION_REQUIREMENT"]
+      req = @required_ruby_version.requirements.map do |op, version|
+        op = op == "~>" ? ">=" : op
+        "#{op} #{version}"
+      end
+      @required_ruby_version = Gem::Requirement.new req
+    end
   end
 
   ##
@@ -1049,6 +1057,10 @@ class Gem::Specification < Gem::BasicSpecification
 
     input = normalize_yaml_input input
     spec = Gem::SafeYAML.safe_load input
+    if ENV["RUBYGEMS_IGNORE_RUBY_VERSION_REQUIREMENT"]
+      # Call the method "required_ruby_version=" to replace "~>" with ">="
+      spec.required_ruby_version = spec.required_ruby_version
+    end
 
     if spec && spec.class == FalseClass
       raise Gem::EndOfYAMLException


### PR DESCRIPTION


<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->
Unfortunately, some gems have a requirement like:

```
s.required_ruby_version = "~> 2.4"
```

In fact, this is somewhat non-sense because Ruby version is not the
semantic versioning: so there are some incompatibilities even in minor
release. Allowing Ruby 2.7 but denying 3.0 does not make sense.
Worse, this makes it difficult to try Ruby 3.0 in the real-world
applications.

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

This changeset allows a user to ignore the "required_ruby_version"
requirement by manually specifying an environment called
`RUBYGEMS_IGNORE_RUBY_VERSION_REQUIREMENT`.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
