### PR TITLE
Respect `required_ruby_version` and `required_rubygems_version` constraints when looking for `gem install` candidates

### DIFF
--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -62,6 +62,8 @@ jobs:
       - name: Check bundler install didn't hit the network
         run: if grep -q 'GET http' output.txt; then false; else true; fi
         working-directory: ./bundler
+      - name: Check rails can be installed
+        run: gem install rails
     timeout-minutes: 10
 
   install_rubygems_windows:

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -412,6 +412,7 @@ lib/rubygems/requirement.rb
 lib/rubygems/resolver.rb
 lib/rubygems/resolver/activation_request.rb
 lib/rubygems/resolver/api_set.rb
+lib/rubygems/resolver/api_set/gem_parser.rb
 lib/rubygems/resolver/api_specification.rb
 lib/rubygems/resolver/best_set.rb
 lib/rubygems/resolver/composed_set.rb

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -52,6 +52,7 @@ bundler/lib/bundler/cli/update.rb
 bundler/lib/bundler/cli/viz.rb
 bundler/lib/bundler/compact_index_client.rb
 bundler/lib/bundler/compact_index_client/cache.rb
+bundler/lib/bundler/compact_index_client/gem_parser.rb
 bundler/lib/bundler/compact_index_client/updater.rb
 bundler/lib/bundler/constants.rb
 bundler/lib/bundler/current_ruby.rb

--- a/bundler/lib/bundler/compact_index_client/cache.rb
+++ b/bundler/lib/bundler/compact_index_client/cache.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "gem_parser"
+
 module Bundler
   class CompactIndexClient
     class Cache
@@ -92,19 +94,9 @@ module Bundler
         header ? lines[header + 1..-1] : lines
       end
 
-      def parse_gem(string)
-        version_and_platform, rest = string.split(" ", 2)
-        version, platform = version_and_platform.split("-", 2)
-        dependencies, requirements = rest.split("|", 2).map {|s| s.split(",") } if rest
-        dependencies = dependencies ? dependencies.map {|d| parse_dependency(d) } : []
-        requirements = requirements ? requirements.map {|r| parse_dependency(r) } : []
-        [version, platform, dependencies, requirements]
-      end
-
-      def parse_dependency(string)
-        dependency = string.split(":")
-        dependency[-1] = dependency[-1].split("&") if dependency.size > 1
-        dependency
+      def parse_gem(line)
+        @dependency_parser ||= GemParser.new
+        @dependency_parser.parse(line)
       end
 
       def info_roots

--- a/bundler/lib/bundler/compact_index_client/gem_parser.rb
+++ b/bundler/lib/bundler/compact_index_client/gem_parser.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Bundler
+  class CompactIndexClient
+    class GemParser
+      def parse(line)
+        version_and_platform, rest = line.split(" ", 2)
+        version, platform = version_and_platform.split("-", 2)
+        dependencies, requirements = rest.split("|", 2).map {|s| s.split(",") } if rest
+        dependencies = dependencies ? dependencies.map {|d| parse_dependency(d) } : []
+        requirements = requirements ? requirements.map {|d| parse_dependency(d) } : []
+        [version, platform, dependencies, requirements]
+      end
+
+      private
+
+      def parse_dependency(string)
+        dependency = string.split(":")
+        dependency[-1] = dependency[-1].split("&") if dependency.size > 1
+        dependency
+      end
+    end
+  end
+end

--- a/bundler/lib/bundler/compact_index_client/gem_parser.rb
+++ b/bundler/lib/bundler/compact_index_client/gem_parser.rb
@@ -2,22 +2,26 @@
 
 module Bundler
   class CompactIndexClient
-    class GemParser
-      def parse(line)
-        version_and_platform, rest = line.split(" ", 2)
-        version, platform = version_and_platform.split("-", 2)
-        dependencies, requirements = rest.split("|", 2).map {|s| s.split(",") } if rest
-        dependencies = dependencies ? dependencies.map {|d| parse_dependency(d) } : []
-        requirements = requirements ? requirements.map {|d| parse_dependency(d) } : []
-        [version, platform, dependencies, requirements]
-      end
+    if defined?(Gem::Resolver::APISet::GemParser)
+      GemParser = Gem::Resolver::APISet::GemParser
+    else
+      class GemParser
+        def parse(line)
+          version_and_platform, rest = line.split(" ", 2)
+          version, platform = version_and_platform.split("-", 2)
+          dependencies, requirements = rest.split("|", 2).map {|s| s.split(",") } if rest
+          dependencies = dependencies ? dependencies.map {|d| parse_dependency(d) } : []
+          requirements = requirements ? requirements.map {|d| parse_dependency(d) } : []
+          [version, platform, dependencies, requirements]
+        end
 
-      private
+        private
 
-      def parse_dependency(string)
-        dependency = string.split(":")
-        dependency[-1] = dependency[-1].split("&") if dependency.size > 1
-        dependency
+        def parse_dependency(string)
+          dependency = string.split(":")
+          dependency[-1] = dependency[-1].split("&") if dependency.size > 1
+          dependency
+        end
       end
     end
   end

--- a/bundler/spec/support/artifice/vcr.rb
+++ b/bundler/spec/support/artifice/vcr.rb
@@ -39,7 +39,7 @@ class BundlerVCRHTTP < Net::HTTP
         response_io = ::Net::BufferedIO.new(response_file)
         ::Net::HTTPResponse.read_new(response_io).tap do |response|
           response.decode_content = request.decode_content if request.respond_to?(:decode_content)
-          response.uri = request.uri if request.respond_to?(:uri)
+          response.uri = request.uri
 
           response.reading_body(response_io, request.response_body_permitted?) do
             response_block.call(response) if response_block

--- a/lib/rubygems/dependency_installer.rb
+++ b/lib/rubygems/dependency_installer.rb
@@ -286,6 +286,7 @@ class Gem::DependencyInstaller
 
     installer_set = Gem::Resolver::InstallerSet.new @domain
     installer_set.ignore_installed = (@minimal_deps == false) || @only_install_dir
+    installer_set.force = @force
 
     if consider_local?
       if dep_or_name =~ /\.gem$/ and File.file? dep_or_name

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -643,7 +643,7 @@ class Gem::Installer
       ruby_version = Gem.ruby_version
       unless rrv.satisfied_by? ruby_version
         raise Gem::RuntimeRequirementNotMetError,
-          "#{spec.name} requires Ruby version #{rrv}. The current ruby version is #{ruby_version}."
+          "#{spec.full_name} requires Ruby version #{rrv}. The current ruby version is #{ruby_version}."
       end
     end
   end
@@ -653,7 +653,7 @@ class Gem::Installer
       unless rrgv.satisfied_by? Gem.rubygems_version
         rg_version = Gem::VERSION
         raise Gem::RuntimeRequirementNotMetError,
-          "#{spec.name} requires RubyGems version #{rrgv}. The current RubyGems version is #{rg_version}. " +
+          "#{spec.full_name} requires RubyGems version #{rrgv}. The current RubyGems version is #{rg_version}. " +
           "Try 'gem update --system' to update RubyGems itself."
       end
     end

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -638,27 +638,6 @@ class Gem::Installer
     end
   end
 
-  def ensure_required_ruby_version_met # :nodoc:
-    if rrv = spec.required_ruby_version
-      ruby_version = Gem.ruby_version
-      unless rrv.satisfied_by? ruby_version
-        raise Gem::RuntimeRequirementNotMetError,
-          "#{spec.full_name} requires Ruby version #{rrv}. The current ruby version is #{ruby_version}."
-      end
-    end
-  end
-
-  def ensure_required_rubygems_version_met # :nodoc:
-    if rrgv = spec.required_rubygems_version
-      unless rrgv.satisfied_by? Gem.rubygems_version
-        rg_version = Gem::VERSION
-        raise Gem::RuntimeRequirementNotMetError,
-          "#{spec.full_name} requires RubyGems version #{rrgv}. The current RubyGems version is #{rg_version}. " +
-          "Try 'gem update --system' to update RubyGems itself."
-      end
-    end
-  end
-
   def ensure_dependencies_met # :nodoc:
     deps = spec.runtime_dependencies
     deps |= spec.development_dependencies if @development
@@ -914,8 +893,6 @@ TEXT
 
     return true if @force
 
-    ensure_required_ruby_version_met
-    ensure_required_rubygems_version_met
     ensure_dependencies_met unless @ignore_dependencies
 
     true

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -215,7 +215,7 @@ class Gem::RemoteFetcher
 
     case response
     when Net::HTTPOK, Net::HTTPNotModified then
-      response.uri = uri if response.respond_to? :uri
+      response.uri = uri
       head ? response : response.body
     when Net::HTTPMovedPermanently, Net::HTTPFound, Net::HTTPSeeOther,
          Net::HTTPTemporaryRedirect then

--- a/lib/rubygems/request_set.rb
+++ b/lib/rubygems/request_set.rb
@@ -195,19 +195,8 @@ class Gem::RequestSet
             yield req, installer if block_given?
           end
         rescue Gem::RuntimeRequirementNotMetError => e
-          recent_match = req.spec.set.find_all(req.request).sort_by(&:version).reverse_each.find do |s|
-            s = s.spec
-            s.required_ruby_version.satisfied_by?(Gem.ruby_version) &&
-              s.required_rubygems_version.satisfied_by?(Gem.rubygems_version) &&
-              Gem::Platform.installable?(s)
-          end
-          if recent_match
-            suggestion = "The last version of #{req.request} to support your Ruby & RubyGems was #{recent_match.version}. Try installing it with `gem install #{recent_match.name} -v #{recent_match.version}`"
-            suggestion += " and then running the current command again" unless @always_install.include?(req.spec.spec)
-          else
-            suggestion = "There are no versions of #{req.request} compatible with your Ruby & RubyGems"
-            suggestion += ". Maybe try installing an older version of the gem you're looking for?" unless @always_install.include?(req.spec.spec)
-          end
+          suggestion = "There are no versions of #{req.request} compatible with your Ruby & RubyGems"
+          suggestion += ". Maybe try installing an older version of the gem you're looking for?" unless @always_install.include?(req.spec.spec)
           e.suggestion = suggestion
           raise
         end

--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -261,7 +261,12 @@ class Gem::Resolver
   end
 
   def requirement_satisfied_by?(requirement, activated, spec)
-    requirement.matches_spec? spec
+    matches_spec = requirement.matches_spec? spec
+    return matches_spec if @soft_missing
+
+    matches_spec &&
+      spec.spec.required_ruby_version.satisfied_by?(Gem.ruby_version) &&
+      spec.spec.required_rubygems_version.satisfied_by?(Gem.rubygems_version)
   end
 
   def name_for(dependency)

--- a/lib/rubygems/resolver/api_set/gem_parser.rb
+++ b/lib/rubygems/resolver/api_set/gem_parser.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Gem::Resolver::APISet::GemParser
+  def parse(line)
+    version_and_platform, rest = line.split(" ", 2)
+    version, platform = version_and_platform.split("-", 2)
+    dependencies, requirements = rest.split("|", 2).map {|s| s.split(",") } if rest
+    dependencies = dependencies ? dependencies.map {|d| parse_dependency(d) } : []
+    requirements = requirements ? requirements.map {|d| parse_dependency(d) } : []
+    [version, platform, dependencies, requirements]
+  end
+
+  private
+
+  def parse_dependency(string)
+    dependency = string.split(":")
+    dependency[-1] = dependency[-1].split("&") if dependency.size > 1
+    dependency
+  end
+end

--- a/lib/rubygems/resolver/api_specification.rb
+++ b/lib/rubygems/resolver/api_specification.rb
@@ -35,6 +35,8 @@ class Gem::Resolver::APISpecification < Gem::Resolver::Specification
     @dependencies = api_data[:dependencies].map do |name, ver|
       Gem::Dependency.new(name, ver.split(/\s*,\s*/)).freeze
     end.freeze
+    @required_ruby_version = Gem::Requirement.new(api_data.dig(:requirements, :ruby)).freeze
+    @required_rubygems_version = Gem::Requirement.new(api_data.dig(:requirements, :rubygems)).freeze
   end
 
   def ==(other) # :nodoc:

--- a/lib/rubygems/resolver/api_specification.rb
+++ b/lib/rubygems/resolver/api_specification.rb
@@ -44,12 +44,11 @@ class Gem::Resolver::APISpecification < Gem::Resolver::Specification
       @set          == other.set and
       @name         == other.name and
       @version      == other.version and
-      @platform     == other.platform and
-      @dependencies == other.dependencies
+      @platform     == other.platform
   end
 
   def hash
-    @set.hash ^ @name.hash ^ @version.hash ^ @platform.hash ^ @dependencies.hash
+    @set.hash ^ @name.hash ^ @version.hash ^ @platform.hash
   end
 
   def fetch_development_dependencies # :nodoc:

--- a/lib/rubygems/resolver/best_set.rb
+++ b/lib/rubygems/resolver/best_set.rb
@@ -60,7 +60,7 @@ class Gem::Resolver::BestSet < Gem::Resolver::ComposedSet
   def replace_failed_api_set(error) # :nodoc:
     uri = error.uri
     uri = URI uri unless URI === uri
-    uri.query = nil
+    uri = uri + "."
 
     raise error unless api_set = @sets.find do |set|
       Gem::Resolver::APISet === set and set.dep_uri == uri

--- a/lib/rubygems/resolver/index_specification.rb
+++ b/lib/rubygems/resolver/index_specification.rb
@@ -33,6 +33,21 @@ class Gem::Resolver::IndexSpecification < Gem::Resolver::Specification
     spec.dependencies
   end
 
+  ##
+  # The required_ruby_version constraint for this specification
+
+  def required_ruby_version
+    spec.required_ruby_version
+  end
+
+  ##
+  # The required_rubygems_version constraint for this specification
+  #
+
+  def required_rubygems_version
+    spec.required_rubygems_version
+  end
+
   def ==(other)
     self.class === other &&
       @name == other.name &&

--- a/lib/rubygems/resolver/installer_set.rb
+++ b/lib/rubygems/resolver/installer_set.rb
@@ -26,6 +26,12 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
   attr_reader :remote_set # :nodoc:
 
   ##
+  # Ignore ruby & rubygems specification constraints.
+  #
+
+  attr_accessor :force # :nodoc:
+
+  ##
   # Creates a new InstallerSet that will look for gems in +domain+.
 
   def initialize(domain)
@@ -41,6 +47,7 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
     @local               = {}
     @local_source        = Gem::Source::Local.new
     @remote_set          = Gem::Resolver::BestSet.new
+    @force               = false
     @specs               = {}
   end
 
@@ -63,15 +70,30 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
         Gem::Platform.local === s.platform
     end
 
-    if found.empty?
-      exc = Gem::UnsatisfiableDependencyError.new request
-      exc.errors = errors
-
-      raise exc
+    found = found.sort_by do |s|
+      [s.version, s.platform == Gem::Platform::RUBY ? -1 : 1]
     end
 
-    newest = found.max_by do |s|
-      [s.version, s.platform == Gem::Platform::RUBY ? -1 : 1]
+    newest = found.last
+
+    unless @force
+      found_matching_metadata = found.select do |spec|
+        metadata_satisfied?(spec)
+      end
+
+      if found_matching_metadata.empty?
+        if newest
+          ensure_required_ruby_version_met(newest.spec)
+          ensure_required_rubygems_version_met(newest.spec)
+        else
+          exc = Gem::UnsatisfiableDependencyError.new request
+          exc.errors = errors
+
+          raise exc
+        end
+      else
+        newest = found_matching_metadata.last
+      end
     end
 
     @always_install << newest.spec
@@ -219,6 +241,34 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
       @domain = nil unless remote
     when :both then
       @domain = :local unless remote
+    end
+  end
+
+  private
+
+  def metadata_satisfied?(spec)
+    spec.required_ruby_version.satisfied_by?(Gem.ruby_version) &&
+      spec.required_rubygems_version.satisfied_by?(Gem.rubygems_version)
+  end
+
+  def ensure_required_ruby_version_met(spec) # :nodoc:
+    if rrv = spec.required_ruby_version
+      ruby_version = Gem.ruby_version
+      unless rrv.satisfied_by? ruby_version
+        raise Gem::RuntimeRequirementNotMetError,
+          "#{spec.full_name} requires Ruby version #{rrv}. The current ruby version is #{ruby_version}."
+      end
+    end
+  end
+
+  def ensure_required_rubygems_version_met(spec) # :nodoc:
+    if rrgv = spec.required_rubygems_version
+      unless rrgv.satisfied_by? Gem.rubygems_version
+        rg_version = Gem::VERSION
+        raise Gem::RuntimeRequirementNotMetError,
+          "#{spec.full_name} requires RubyGems version #{rrgv}. The current RubyGems version is #{rg_version}. " +
+          "Try 'gem update --system' to update RubyGems itself."
+      end
     end
   end
 end

--- a/lib/rubygems/resolver/spec_specification.rb
+++ b/lib/rubygems/resolver/spec_specification.rb
@@ -23,6 +23,20 @@ class Gem::Resolver::SpecSpecification < Gem::Resolver::Specification
   end
 
   ##
+  # The required_ruby_version constraint for this specification
+
+  def required_ruby_version
+    spec.required_ruby_version
+  end
+
+  ##
+  # The required_rubygems_version constraint for this specification
+
+  def required_rubygems_version
+    spec.required_rubygems_version
+  end
+
+  ##
   # The name and version of the specification.
   #
   # Unlike Gem::Specification#full_name, the platform is not included.

--- a/lib/rubygems/resolver/specification.rb
+++ b/lib/rubygems/resolver/specification.rb
@@ -44,6 +44,16 @@ class Gem::Resolver::Specification
   attr_reader :version
 
   ##
+  # The required_ruby_version constraint for this specification.
+
+  attr_reader :required_ruby_version
+
+  ##
+  # The required_ruby_version constraint for this specification.
+
+  attr_reader :required_rubygems_version
+
+  ##
   # Sets default instance variables for the specification.
 
   def initialize
@@ -53,6 +63,8 @@ class Gem::Resolver::Specification
     @set          = nil
     @source       = nil
     @version      = nil
+    @required_ruby_version = Gem::Requirement.default
+    @required_rubygems_version = Gem::Requirement.default
   end
 
   ##

--- a/lib/rubygems/source.rb
+++ b/lib/rubygems/source.rb
@@ -80,7 +80,15 @@ class Gem::Source
   def dependency_resolver_set # :nodoc:
     return Gem::Resolver::IndexSet.new self if 'file' == uri.scheme
 
-    bundler_api_uri = enforce_trailing_slash(uri) + './api/v1/dependencies'
+    fetch_uri = if uri.host == "rubygems.org"
+                  index_uri = uri.dup
+                  index_uri.host = "index.rubygems.org"
+                  index_uri
+                else
+                  uri
+                end
+
+    bundler_api_uri = enforce_trailing_slash(fetch_uri)
 
     begin
       fetcher = Gem::RemoteFetcher.fetcher
@@ -88,7 +96,7 @@ class Gem::Source
     rescue Gem::RemoteFetcher::FetchError
       Gem::Resolver::IndexSet.new self
     else
-      Gem::Resolver::APISet.new response.uri
+      Gem::Resolver::APISet.new response.uri + "./info/"
     end
   end
 

--- a/lib/rubygems/source.rb
+++ b/lib/rubygems/source.rb
@@ -88,11 +88,7 @@ class Gem::Source
     rescue Gem::RemoteFetcher::FetchError
       Gem::Resolver::IndexSet.new self
     else
-      if response.respond_to? :uri
-        Gem::Resolver::APISet.new response.uri
-      else
-        Gem::Resolver::APISet.new bundler_api_uri
-      end
+      Gem::Resolver::APISet.new response.uri
     end
   end
 

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -504,6 +504,57 @@ ERROR:  Possible alternatives: non_existent_with_hint
     assert_equal %w[a-2], @cmd.installed_specs.map {|spec| spec.full_name }
   end
 
+  def test_execute_required_ruby_version
+    next_ruby = Gem.ruby_version.segments.map.with_index{|n, i| i == 1 ? n + 1 : n }.join(".")
+
+    local = Gem::Platform.local
+    spec_fetcher do |fetcher|
+      fetcher.download 'a', 2
+      fetcher.download 'a', 2 do |s|
+        s.required_ruby_version = "< #{RUBY_VERSION}.a"
+        s.platform = local
+      end
+      fetcher.download 'a', 3 do |s|
+        s.required_ruby_version = ">= #{next_ruby}"
+      end
+      fetcher.download 'a', 3 do |s|
+        s.required_ruby_version = ">= #{next_ruby}"
+        s.platform = local
+      end
+    end
+
+    @cmd.options[:args] = %w[a]
+
+    use_ui @ui do
+      assert_raises Gem::MockGemUi::SystemExitException, @ui.error do
+        @cmd.execute
+      end
+    end
+
+    assert_equal %w[a-2], @cmd.installed_specs.map {|spec| spec.full_name }
+  end
+
+  def test_execute_required_ruby_version_upper_bound
+    local = Gem::Platform.local
+    spec_fetcher do |fetcher|
+      fetcher.gem 'a', 2.0
+      fetcher.gem 'a', 2.0 do |s|
+        s.required_ruby_version = "< #{RUBY_VERSION}.a"
+        s.platform = local
+      end
+    end
+
+    @cmd.options[:args] = %w[a]
+
+    use_ui @ui do
+      assert_raises Gem::MockGemUi::SystemExitException, @ui.error do
+        @cmd.execute
+      end
+    end
+
+    assert_equal %w[a-2.0], @cmd.installed_specs.map {|spec| spec.full_name }
+  end
+
   def test_execute_required_ruby_version_specific_not_met
     spec_fetcher do |fetcher|
       fetcher.gem 'a', '1.0' do |s|

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -504,6 +504,86 @@ ERROR:  Possible alternatives: non_existent_with_hint
     assert_equal %w[a-2], @cmd.installed_specs.map {|spec| spec.full_name }
   end
 
+  def test_execute_required_ruby_version_specific_not_met
+    spec_fetcher do |fetcher|
+      fetcher.gem 'a', '1.0' do |s|
+        s.required_ruby_version = '= 1.4.6'
+      end
+    end
+
+    @cmd.options[:args] = %w[a]
+
+    use_ui @ui do
+      assert_raises Gem::MockGemUi::TermError do
+        @cmd.execute
+      end
+    end
+
+    errs = @ui.error.split("\n")
+    assert_equal "ERROR:  Error installing a:", errs.shift
+    assert_equal "\ta-1.0 requires Ruby version = 1.4.6. The current ruby version is #{Gem.ruby_version}.", errs.shift
+  end
+
+  def test_execute_required_ruby_version_specific_prerelease_met
+    spec_fetcher do |fetcher|
+      fetcher.gem 'a', '1.0' do |s|
+        s.required_ruby_version = '>= 1.4.6.preview2'
+      end
+    end
+
+    @cmd.options[:args] = %w[a]
+
+    use_ui @ui do
+      assert_raises Gem::MockGemUi::SystemExitException, @ui.error do
+        @cmd.execute
+      end
+    end
+
+    assert_equal %w[a-1.0], @cmd.installed_specs.map {|spec| spec.full_name }
+  end
+
+  def test_execute_required_ruby_version_specific_prerelease_not_met
+    next_ruby_pre = Gem.ruby_version.segments.map.with_index{|n, i| i == 1 ? n + 1 : n }.join(".") + ".a"
+
+    spec_fetcher do |fetcher|
+      fetcher.gem 'a', '1.0' do |s|
+        s.required_ruby_version = "> #{next_ruby_pre}"
+      end
+    end
+
+    @cmd.options[:args] = %w[a]
+
+    use_ui @ui do
+      assert_raises Gem::MockGemUi::TermError do
+        @cmd.execute
+      end
+    end
+
+    errs = @ui.error.split("\n")
+    assert_equal "ERROR:  Error installing a:", errs.shift
+    assert_equal "\ta-1.0 requires Ruby version > #{next_ruby_pre}. The current ruby version is #{Gem.ruby_version}.", errs.shift
+  end
+
+  def test_execute_required_rubygems_version_wrong
+    spec_fetcher do |fetcher|
+      fetcher.gem 'a', '1.0' do |s|
+        s.required_rubygems_version = '< 0'
+      end
+    end
+
+    @cmd.options[:args] = %w[a]
+
+    use_ui @ui do
+      assert_raises Gem::MockGemUi::TermError do
+        @cmd.execute
+      end
+    end
+
+    errs = @ui.error.split("\n")
+    assert_equal "ERROR:  Error installing a:", errs.shift
+    assert_equal "\ta-1.0 requires RubyGems version < 0. The current RubyGems version is #{Gem.rubygems_version}. Try 'gem update --system' to update RubyGems itself.", errs.shift
+  end
+
   def test_execute_rdoc
     specs = spec_fetcher do |fetcher|
       fetcher.gem 'a', 2

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1172,12 +1172,16 @@ gem 'other', version
   end
 
   def test_install_force
+    _, missing_dep_gem = util_gem 'missing_dep', '1' do |s|
+      s.add_dependency 'doesnt_exist', '1'
+    end
+
     use_ui @ui do
-      installer = Gem::Installer.at old_ruby_required('= 1.4.6'), :force => true
+      installer = Gem::Installer.at missing_dep_gem, :force => true
       installer.install
     end
 
-    gem_dir = File.join(@gemhome, 'gems', 'old_ruby_required-1')
+    gem_dir = File.join(@gemhome, 'gems', 'missing_dep-1')
     assert_path_exists gem_dir
   end
 
@@ -2202,16 +2206,6 @@ gem 'other', version
     installer = util_installer(gem, @gemhome)
     assert_respond_to(installer, :gem)
     assert_kind_of(String, installer.gem)
-  end
-
-  def old_ruby_required(requirement)
-    spec = util_spec 'old_ruby_required', '1' do |s|
-      s.required_ruby_version = requirement
-    end
-
-    util_build_gem spec
-
-    spec.cache_file
   end
 
   def util_execless

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1620,54 +1620,6 @@ gem 'other', version
     end
   end
 
-  def test_pre_install_checks_ruby_version
-    use_ui @ui do
-      installer = Gem::Installer.at old_ruby_required('= 1.4.6')
-      e = assert_raises Gem::RuntimeRequirementNotMetError do
-        installer.pre_install_checks
-      end
-      rv = Gem.ruby_version
-      assert_equal "old_ruby_required-1 requires Ruby version = 1.4.6. The current ruby version is #{rv}.",
-                   e.message
-    end
-  end
-
-  def test_pre_install_checks_ruby_version_with_prereleases
-    util_set_RUBY_VERSION '2.6.0', -1, '63539', 'ruby 2.6.0preview2 (2018-05-31 trunk 63539) [x86_64-linux]'
-
-    installer = Gem::Installer.at old_ruby_required('>= 2.6.0.preview2')
-    assert installer.pre_install_checks
-
-    installer = Gem::Installer.at old_ruby_required('> 2.6.0.preview2')
-    e = assert_raises Gem::RuntimeRequirementNotMetError do
-      assert installer.pre_install_checks
-    end
-    assert_equal "old_ruby_required-1 requires Ruby version > 2.6.0.preview2. The current ruby version is 2.6.0.preview2.",
-                 e.message
-  ensure
-    util_restore_RUBY_VERSION
-  end
-
-  def test_pre_install_checks_wrong_rubygems_version
-    spec = util_spec 'old_rubygems_required', '1' do |s|
-      s.required_rubygems_version = '< 0'
-    end
-
-    util_build_gem spec
-
-    gem = File.join(@gemhome, 'cache', spec.file_name)
-
-    use_ui @ui do
-      installer = Gem::Installer.at gem
-      e = assert_raises Gem::RuntimeRequirementNotMetError do
-        installer.pre_install_checks
-      end
-      rgv = Gem::VERSION
-      assert_equal "old_rubygems_required-1 requires RubyGems version < 0. The current RubyGems version is #{rgv}. " +
-        "Try 'gem update --system' to update RubyGems itself.", e.message
-    end
-  end
-
   def test_pre_install_checks_malicious_name
     spec = util_spec '../malicious', '1'
     def spec.full_name # so the spec is buildable

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1627,7 +1627,7 @@ gem 'other', version
         installer.pre_install_checks
       end
       rv = Gem.ruby_version
-      assert_equal "old_ruby_required requires Ruby version = 1.4.6. The current ruby version is #{rv}.",
+      assert_equal "old_ruby_required-1 requires Ruby version = 1.4.6. The current ruby version is #{rv}.",
                    e.message
     end
   end
@@ -1642,7 +1642,7 @@ gem 'other', version
     e = assert_raises Gem::RuntimeRequirementNotMetError do
       assert installer.pre_install_checks
     end
-    assert_equal "old_ruby_required requires Ruby version > 2.6.0.preview2. The current ruby version is 2.6.0.preview2.",
+    assert_equal "old_ruby_required-1 requires Ruby version > 2.6.0.preview2. The current ruby version is 2.6.0.preview2.",
                  e.message
   ensure
     util_restore_RUBY_VERSION
@@ -1663,7 +1663,7 @@ gem 'other', version
         installer.pre_install_checks
       end
       rgv = Gem::VERSION
-      assert_equal "old_rubygems_required requires RubyGems version < 0. The current RubyGems version is #{rgv}. " +
+      assert_equal "old_rubygems_required-1 requires RubyGems version < 0. The current RubyGems version is #{rgv}. " +
         "Try 'gem update --system' to update RubyGems itself.", e.message
     end
   end

--- a/test/rubygems/test_gem_resolver_api_set.rb
+++ b/test/rubygems/test_gem_resolver_api_set.rb
@@ -6,29 +6,29 @@ class TestGemResolverAPISet < Gem::TestCase
     super
 
     @DR = Gem::Resolver
-    @dep_uri = URI "#{@gem_repo}api/v1/dependencies"
+    @dep_uri = URI "#{@gem_repo}info/"
   end
 
   def test_initialize
     set = @DR::APISet.new
 
-    assert_equal URI('https://rubygems.org/api/v1/dependencies'), set.dep_uri
-    assert_equal URI('https://rubygems.org'),                     set.uri
-    assert_equal Gem::Source.new(URI('https://rubygems.org')),    set.source
+    assert_equal URI('https://index.rubygems.org/info/'),            set.dep_uri
+    assert_equal URI('https://index.rubygems.org/'),                 set.uri
+    assert_equal Gem::Source.new(URI('https://index.rubygems.org')), set.source
   end
 
   def test_initialize_deeper_uri
-    set = @DR::APISet.new 'https://rubygemsserver.com/mygems/api/v1/dependencies'
+    set = @DR::APISet.new 'https://rubygemsserver.com/mygems/info'
 
-    assert_equal URI('https://rubygemsserver.com/mygems/api/v1/dependencies'), set.dep_uri
-    assert_equal URI('https://rubygemsserver.com/mygems/'),                    set.uri
-    assert_equal Gem::Source.new(URI('https://rubygemsserver.com/mygems/')), set.source
+    assert_equal URI('https://rubygemsserver.com/mygems/info'),       set.dep_uri
+    assert_equal URI('https://rubygemsserver.com/'),                  set.uri
+    assert_equal Gem::Source.new(URI('https://rubygemsserver.com/')), set.source
   end
 
   def test_initialize_uri
     set = @DR::APISet.new @dep_uri
 
-    assert_equal URI("#{@gem_repo}api/v1/dependencies"), set.dep_uri
+    assert_equal URI("#{@gem_repo}info/"), set.dep_uri
     assert_equal URI("#{@gem_repo}"), set.uri
   end
 
@@ -42,7 +42,7 @@ class TestGemResolverAPISet < Gem::TestCase
         :dependencies => [] },
     ]
 
-    @fetcher.data["#{@dep_uri}?gems=a"] = Marshal.dump data
+    @fetcher.data["#{@dep_uri}a"] = "---\n1  "
 
     set = @DR::APISet.new @dep_uri
 
@@ -69,7 +69,7 @@ class TestGemResolverAPISet < Gem::TestCase
         :dependencies => [] },
     ]
 
-    @fetcher.data["#{@dep_uri}?gems=a"] = Marshal.dump data
+    @fetcher.data["#{@dep_uri}a"] = "---\n1\n2.a"
 
     set = @DR::APISet.new @dep_uri
     set.prerelease = true
@@ -94,7 +94,7 @@ class TestGemResolverAPISet < Gem::TestCase
         :dependencies => [] },
     ]
 
-    @fetcher.data["#{@dep_uri}?gems=a"] = Marshal.dump data
+    @fetcher.data["#{@dep_uri}a"] = "---\n1  "
 
     set = @DR::APISet.new @dep_uri
 
@@ -108,7 +108,7 @@ class TestGemResolverAPISet < Gem::TestCase
 
     assert_equal expected, set.find_all(a_dep)
 
-    @fetcher.data.delete "#{@dep_uri}?gems=a"
+    @fetcher.data.delete "#{@dep_uri}a"
   end
 
   def test_find_all_local
@@ -123,7 +123,7 @@ class TestGemResolverAPISet < Gem::TestCase
   def test_find_all_missing
     spec_fetcher
 
-    @fetcher.data["#{@dep_uri}?gems=a"] = Marshal.dump []
+    @fetcher.data["#{@dep_uri}a"] = "---"
 
     set = @DR::APISet.new @dep_uri
 
@@ -131,7 +131,7 @@ class TestGemResolverAPISet < Gem::TestCase
 
     assert_empty set.find_all(a_dep)
 
-    @fetcher.data.delete "#{@dep_uri}?gems=a"
+    @fetcher.data.delete "#{@dep_uri}a"
 
     assert_empty set.find_all(a_dep)
   end
@@ -139,15 +139,8 @@ class TestGemResolverAPISet < Gem::TestCase
   def test_prefetch
     spec_fetcher
 
-    data = [
-      { :name         => 'a',
-        :number       => '1',
-        :platform     => 'ruby',
-        :dependencies => [] },
-    ]
-
-    @fetcher.data["#{@dep_uri}?gems=a,b"] = Marshal.dump data
-    @fetcher.data["#{@dep_uri}?gems=b"]   = Marshal.dump []
+    @fetcher.data["#{@dep_uri}a"] = "---\n1  \n"
+    @fetcher.data["#{@dep_uri}b"] = "---"
 
     set = @DR::APISet.new @dep_uri
 
@@ -163,14 +156,7 @@ class TestGemResolverAPISet < Gem::TestCase
   def test_prefetch_cache
     spec_fetcher
 
-    data = [
-      { :name         => 'a',
-        :number       => '1',
-        :platform     => 'ruby',
-        :dependencies => [] },
-    ]
-
-    @fetcher.data["#{@dep_uri}?gems=a"] = Marshal.dump data
+    @fetcher.data["#{@dep_uri}a"] = "---\n1  \n"
 
     set = @DR::APISet.new @dep_uri
 
@@ -179,8 +165,8 @@ class TestGemResolverAPISet < Gem::TestCase
 
     set.prefetch [a_dep]
 
-    @fetcher.data.delete "#{@dep_uri}?gems=a"
-    @fetcher.data["#{@dep_uri}?gems=b"]   = Marshal.dump []
+    @fetcher.data.delete "#{@dep_uri}a"
+    @fetcher.data["#{@dep_uri}?b"] = "---"
 
     set.prefetch [a_dep, b_dep]
   end
@@ -188,14 +174,8 @@ class TestGemResolverAPISet < Gem::TestCase
   def test_prefetch_cache_missing
     spec_fetcher
 
-    data = [
-      { :name         => 'a',
-        :number       => '1',
-        :platform     => 'ruby',
-        :dependencies => [] },
-    ]
-
-    @fetcher.data["#{@dep_uri}?gems=a,b"] = Marshal.dump data
+    @fetcher.data["#{@dep_uri}a"] = "---\n1  \n"
+    @fetcher.data["#{@dep_uri}b"] = "---"
 
     set = @DR::APISet.new @dep_uri
 
@@ -204,7 +184,8 @@ class TestGemResolverAPISet < Gem::TestCase
 
     set.prefetch [a_dep, b_dep]
 
-    @fetcher.data.delete "#{@dep_uri}?gems=a,b"
+    @fetcher.data.delete "#{@dep_uri}a"
+    @fetcher.data.delete "#{@dep_uri}b"
 
     set.prefetch [a_dep, b_dep]
   end
@@ -212,15 +193,8 @@ class TestGemResolverAPISet < Gem::TestCase
   def test_prefetch_local
     spec_fetcher
 
-    data = [
-      { :name         => 'a',
-        :number       => '1',
-        :platform     => 'ruby',
-        :dependencies => [] },
-    ]
-
-    @fetcher.data["#{@dep_uri}?gems=a,b"] = Marshal.dump data
-    @fetcher.data["#{@dep_uri}?gems=b"]   = Marshal.dump []
+    @fetcher.data["#{@dep_uri}a"] = "---\n1  \n"
+    @fetcher.data["#{@dep_uri}b"] = "---"
 
     set = @DR::APISet.new @dep_uri
     set.remote = false

--- a/test/rubygems/test_gem_resolver_api_specification.rb
+++ b/test/rubygems/test_gem_resolver_api_specification.rb
@@ -39,7 +39,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
 
     rails = specs['rails-3.0.3']
 
-    repo = @gem_repo + 'api/v1/dependencies'
+    repo = @gem_repo + 'info'
 
     set = Gem::Resolver::APISet.new repo
 
@@ -123,7 +123,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
       fetcher.spec 'a', 1
     end
 
-    dep_uri = URI(@gem_repo) + 'api/v1/dependencies'
+    dep_uri = URI(@gem_repo) + 'info'
     set = Gem::Resolver::APISet.new dep_uri
     data = {
       :name         => 'a',
@@ -147,7 +147,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
       end
     end
 
-    dep_uri = URI(@gem_repo) + 'api/v1/dependencies'
+    dep_uri = URI(@gem_repo) + 'info'
     set = Gem::Resolver::APISet.new dep_uri
     data = {
       :name         => 'j',

--- a/test/rubygems/test_gem_resolver_best_set.rb
+++ b/test/rubygems/test_gem_resolver_best_set.rb
@@ -39,7 +39,7 @@ class TestGemResolverBestSet < Gem::TestCase
 
     set = @DR::BestSet.new
 
-    api_uri = URI(@gem_repo) + './api/v1/dependencies'
+    api_uri = URI(@gem_repo)
 
     set.sets << Gem::Resolver::APISet.new(api_uri)
 
@@ -99,12 +99,12 @@ class TestGemResolverBestSet < Gem::TestCase
   def test_replace_failed_api_set
     set = @DR::BestSet.new
 
-    api_uri = URI(@gem_repo) + './api/v1/dependencies'
+    api_uri = URI(@gem_repo) + './info/'
     api_set = Gem::Resolver::APISet.new api_uri
 
     set.sets << api_set
 
-    error_uri = api_uri + '?gems=a'
+    error_uri = api_uri + 'a'
 
     error = Gem::RemoteFetcher::FetchError.new 'bogus', error_uri
 

--- a/test/rubygems/test_gem_source.rb
+++ b/test/rubygems/test_gem_source.rb
@@ -44,7 +44,7 @@ class TestGemSource < Gem::TestCase
 
   def test_dependency_resolver_set_bundler_api
     response = Net::HTTPResponse.new '1.1', 200, 'OK'
-    response.uri = URI('http://example') if response.respond_to? :uri
+    response.uri = URI('http://example')
 
     @fetcher.data["#{@gem_repo}api/v1/dependencies"] = response
 

--- a/test/rubygems/test_gem_source.rb
+++ b/test/rubygems/test_gem_source.rb
@@ -46,7 +46,7 @@ class TestGemSource < Gem::TestCase
     response = Net::HTTPResponse.new '1.1', 200, 'OK'
     response.uri = URI('http://example')
 
-    @fetcher.data["#{@gem_repo}api/v1/dependencies"] = response
+    @fetcher.data[@gem_repo] = response
 
     set = @source.dependency_resolver_set
 

--- a/test/rubygems/test_gem_source_subpath_problem.rb
+++ b/test/rubygems/test_gem_source_subpath_problem.rb
@@ -21,7 +21,7 @@ class TestGemSourceSubpathProblem < Gem::TestCase
 
   def test_dependency_resolver_set
     response = Net::HTTPResponse.new '1.1', 200, 'OK'
-    response.uri = URI('http://example') if response.respond_to? :uri
+    response.uri = URI('http://example')
 
     @fetcher.data["#{@gem_repo}/api/v1/dependencies"] = response
 

--- a/test/rubygems/test_gem_source_subpath_problem.rb
+++ b/test/rubygems/test_gem_source_subpath_problem.rb
@@ -23,7 +23,7 @@ class TestGemSourceSubpathProblem < Gem::TestCase
     response = Net::HTTPResponse.new '1.1', 200, 'OK'
     response.uri = URI('http://example')
 
-    @fetcher.data["#{@gem_repo}/api/v1/dependencies"] = response
+    @fetcher.data["#{@gem_repo}/"] = response
 
     set = @source.dependency_resolver_set
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The end user problem is a long standing issue in the rubygems client. If your current ruby (similar with rubygems) version does not support the latest version of your target gem for installation, `gem install` will fail.

Instead, it should install the newest version that's compatible with your current ruby (and rubygems).

This has caused pain in the past in CI when we released a new version of bundler dropping support for old rubies, and suddenly CIs running `gem install bundler` would start failing on those rubies.

## What is your fix for the problem, implemented in this PR?

My fix is to start using the CompactIndex API when looking for dependencies, which provides this information.

This will be another step towards phasing out the old dependency API in the future, since rubygems will no longer use it.

Before this PR:

```
$ ruby -v
ruby 2.4.10p364 (2020-03-31 revision 67879) [x86_64-linux]

$ gem install activesupport 
ERROR:  Error installing activesupport:
	The last version of activesupport (>= 0) to support your Ruby & RubyGems was 5.2.4.4. Try installing it with `gem install activesupport -v 5.2.4.4`
	activesupport requires Ruby version >= 2.5.0. The current ruby version is 2.4.10.364.
```

After this PR:

```
$ ruby -v
ruby 2.4.10p364 (2020-03-31 revision 67879) [x86_64-linux]

$ gem install activesupport 
Successfully installed activesupport-5.2.4.4
1 gem installed
```

Currently I'm marking this PR as WIP, because I don't like this behaviour:

```
$ ruby -v
ruby 2.4.10p364 (2020-03-31 revision 67879) [x86_64-linux]

$ gem install activesupport:6.0.3
ERROR:  Could not find a valid gem 'activesupport' (= 6.0.3) (required by 'activesupport' (6.0.3)) in any repository
ERROR:  Possible alternatives: active_support-custom_logger, active_support-dependencies_patch, active_support-encrypted_redis_cache_store, active_support-lazy_load_patch, active_support_alias_class_method, activesupport, activesupport-cache-redis_multiplexer, activesupport-cascadestore, activesupport-core-ext, activesupport-current_attributes
```

Instead, I should get an error like the one you currently get when running `gem install activesupport` on ruby 2.4, telling you about your current ruby not being supported by the required activesupport version.

Fixes https://github.com/rubygems/rubygems/issues/2575.
Fixes https://github.com/rubygems/rubygems/issues/3089.

Closes https://github.com/rubygems/rubygems/issues/2900.
Closes https://github.com/rubygems/rubygems/pull/2655.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
