### PR TITLE
Fix Resolver::APISet to always include prereleases when necessary

### DIFF
--- a/lib/rubygems/resolver/api_set.rb
+++ b/lib/rubygems/resolver/api_set.rb
@@ -52,7 +52,7 @@ class Gem::Resolver::APISet < Gem::Resolver::Set
     end
 
     versions(req.name).each do |ver|
-      if req.dependency.match? req.name, ver[:number]
+      if req.dependency.match? req.name, ver[:number], @prerelease
         res << Gem::Resolver::APISpecification.new(self, ver)
       end
     end

--- a/test/rubygems/test_gem_resolver_api_set.rb
+++ b/test/rubygems/test_gem_resolver_api_set.rb
@@ -55,6 +55,35 @@ class TestGemResolverAPISet < Gem::TestCase
     assert_equal expected, set.find_all(a_dep)
   end
 
+  def test_find_all_prereleases
+    spec_fetcher
+
+    data = [
+      { :name         => 'a',
+        :number       => '1',
+        :platform     => 'ruby',
+        :dependencies => [] },
+      { :name         => 'a',
+        :number       => '2.a',
+        :platform     => 'ruby',
+        :dependencies => [] },
+    ]
+
+    @fetcher.data["#{@dep_uri}?gems=a"] = Marshal.dump data
+
+    set = @DR::APISet.new @dep_uri
+    set.prerelease = true
+
+    a_dep = @DR::DependencyRequest.new dep('a'), nil
+
+    expected = [
+      @DR::APISpecification.new(set, data.first),
+      @DR::APISpecification.new(set, data.last),
+    ]
+
+    assert_equal expected, set.find_all(a_dep)
+  end
+
   def test_find_all_cache
     spec_fetcher
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

```
gem install rails --pre
```

fails to install the latest rails prerelease.

## What is your fix for the problem, implemented in this PR?

Previous versions of molinillo, specifically before https://github.com/CocoaPods/Molinillo/commit/d29a053fe9ee6f07b1d7d6f501f882fa307c9390, would include special logic for dealing with prereleases. Now this logic needs to be implemented by the specification provider, in this case, rubygems.

That change in molinillo made an issue in our `Resolver::APISet` implementation manifest, where even if the set has been created with the `prerelease` flag, it would fail to return prereleases unless the dependency explicitly allowed them. For example, it would return prereleases given the dependency "activesupport, = 6.1.rc2", but it will fail to return prereleases given the dependency "activesupport, >= 4.2.0". In the latter case, we also want prereleases returned when the `--pre` flag has been passed to `gem install`, i.e., when the API set has been created with the prerelease flag.

Fixes #4112.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)