### PR TITLE
Autoload `Bundler::RemoteSpecification` to workaround crash on jruby

### DIFF
--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -565,7 +565,6 @@ module Bundler
     end
 
     def all_specs
-      require_relative "remote_specification"
       Gem::Specification.stubs.map do |stub|
         StubSpecification.from_stub(stub)
       end

--- a/bundler/lib/bundler/stub_specification.rb
+++ b/bundler/lib/bundler/stub_specification.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "remote_specification"
-
 module Bundler
   class StubSpecification < RemoteSpecification
     def self.from_stub(stub)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

A [random spec failure](https://github.com/rubygems/rubygems/pull/4113/checks?check_run_id=1524686833) on jruby.

## What is your fix for the problem, implemented in this PR?

Try avoid a bug in jruby with a weird race condition when the same code is both required and autoloaded.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)