### PR TITLE
Ad-hoc fix of bundler specs

### DIFF
--- a/bundler/spec/bundler/cli_spec.rb
+++ b/bundler/spec/bundler/cli_spec.rb
@@ -2,6 +2,16 @@
 
 require "bundler/cli"
 
+using Module.new {
+  # Some `man` (e.g., on macOS) always highlights the output even to
+  # non-tty.
+  refine Spec::Helpers do
+    def out
+      super.gsub(/.[\b]/, '')
+    end
+  end
+}
+
 RSpec.describe "bundle executable" do
   it "returns non-zero exit status when passed unrecognized options" do
     bundle "--invalid_argument", :raise_on_error => false

--- a/bundler/spec/bundler/cli_spec.rb
+++ b/bundler/spec/bundler/cli_spec.rb
@@ -7,7 +7,7 @@ using Module.new {
   # non-tty.
   refine Spec::Helpers do
     def out
-      super.gsub(/.[\b]/, '')
+      super.gsub(/.[\b]/, "")
     end
   end
 }

--- a/bundler/spec/bundler/cli_spec.rb
+++ b/bundler/spec/bundler/cli_spec.rb
@@ -10,7 +10,7 @@ using Module.new {
       super.gsub(/.[\b]/, "")
     end
   end
-}
+} if RUBY_VERSION >= "2.4"
 
 RSpec.describe "bundle executable" do
   it "returns non-zero exit status when passed unrecognized options" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The current bundler specs failed with macOS env.

See https://github.com/ruby/ruby/runs/1515898062?check_suite_focus=true#step:13:204

@nobu added it's workaround to cli_spec.rb.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
