### PR TITLE
Added help message for gem i webrick in gem server command

### DIFF
--- a/lib/rubygems/server.rb
+++ b/lib/rubygems/server.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'webrick'
 require 'zlib'
 require 'erb'
 require 'uri'
@@ -424,6 +423,13 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
   ERB
 
   def self.run(options)
+    begin
+      require 'webrick'
+    rescue LoadError
+      puts "webrick is not found. You may need to `gem install webrick` to install webrick."
+      exit
+    end
+
     new(options[:gemdir], options[:port], options[:daemon],
         options[:launch], options[:addresses]).run
   end

--- a/lib/rubygems/server.rb
+++ b/lib/rubygems/server.rb
@@ -423,6 +423,11 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
   ERB
 
   def self.run(options)
+    new(options[:gemdir], options[:port], options[:daemon],
+        options[:launch], options[:addresses]).run
+  end
+
+  def initialize(gem_dirs, port, daemon, launch = nil, addresses = nil)
     begin
       require 'webrick'
     rescue LoadError
@@ -430,11 +435,6 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
       exit
     end
 
-    new(options[:gemdir], options[:port], options[:daemon],
-        options[:launch], options[:addresses]).run
-  end
-
-  def initialize(gem_dirs, port, daemon, launch = nil, addresses = nil)
     Gem::RDoc.load_rdoc
     Socket.do_not_reverse_lookup = true
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Unfortunately, The ruby core team & Matz decide to remove webrick from stdlib skipped default gems and bundled gems. We gave up to maintain the vulnerability of webrick. 

## What is your fix for the problem, implemented in this PR?

I added help message for webrick installation after Ruby 3.0.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
