### PR TITLE
Show unique change types in rubygems release blog post

### DIFF
--- a/util/changelog.rb
+++ b/util/changelog.rb
@@ -62,6 +62,7 @@ class Changelog
     types = release_notes
       .select {|line| change_types.include?(line) }
       .map {|line| line.downcase.tr '^a-z ', '' }
+      .uniq
 
     last_change_type = types.pop
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Rubygems 3.2.0 release blog post has [duplicated change types](https://blog.rubygems.org/2020/12/10/3.2.0-released.html).

## What is your fix for the problem, implemented in this PR?

The reason is that since a final release aggregates multiple pre-releases, duplicate change types can happen.

Solution is to use `.uniq`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)