### PR TITLE
Push rubygems releases to Github too

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -174,6 +174,13 @@ file "pkg/rubygems-#{v}.tgz" => "pkg/rubygems-#{v}" do
   end
 end
 
+desc "Upload the release to Github releases"
+task :upload_to_github do
+  require_relative "util/release"
+
+  Release.for_rubygems(v).create_for_github!
+end
+
 desc "Upload release to S3"
 task :upload_to_s3 do
   begin
@@ -190,7 +197,7 @@ task :upload_to_s3 do
 end
 
 desc "Upload release to rubygems.org"
-task :upload => %w[upload_to_s3]
+task :upload => %w[upload_to_github upload_to_s3]
 
 directory '../guides.rubygems.org' do
   sh 'git', 'clone',


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I think @hsbt has to create a github release manually after every rubygems release.

## What is your fix for the problem, implemented in this PR?

Use our existing tooling to automate that.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)