### PR TITLE
Better CI job names

### DIFF
--- a/.github/workflows/daily-bundler.yml
+++ b/.github/workflows/daily-bundler.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   daily_bundler:
+    name: Bundler (ruby-head)
     runs-on: ubuntu-18.04
     if: github.repository == 'rubygems/rubygems'
     env:

--- a/.github/workflows/daily-rubygems.yml
+++ b/.github/workflows/daily-rubygems.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   daily_rubygems:
+    name: Rubygems (ruby-head)
     runs-on: ubuntu-18.04
     if: github.repository == 'rubygems/rubygems'
     strategy:

--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -10,18 +10,27 @@ on:
 
 jobs:
   install_rubygems_ubuntu:
+    name: Install Rubygems on Ubuntu (${{ matrix.ruby.name }}, ${{ matrix.openssl.name }})
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.3.8, 2.4.10, 2.5.8, 2.6.6, 2.7.2, jruby-9.2.11.1 ]
-        openssl: [true, false]
+        ruby:
+          - { name: 2.3, value: 2.3.8 }
+          - { name: 2.4, value: 2.4.10 }
+          - { name: 2.5, value: 2.5.8 }
+          - { name: 2.6, value: 2.6.6 }
+          - { name: 2.7, value: 2.7.2 }
+          - { name: jruby-9.2, value: jruby-9.2.11.1 }
+        openssl:
+          - { name: "openssl", value: true }
+          - { name: "no-openssl", value: false }
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: ${{ matrix.ruby.value }}
           bundler: none
       - name: Install rubygems
         run: ruby -Ilib -S rake install 2> errors.txt
@@ -31,13 +40,13 @@ jobs:
         run: gem list bundler
         env:
           RUBYOPT: -Itest/rubygems/fake_certlib
-        if: matrix.openssl == false
+        if: matrix.openssl.value == false
       - name: Run a local rubygems command
         run: gem list bundler
-        if: matrix.openssl == true
+        if: matrix.openssl.value == true
       - name: Run a remote rubygems command
         run: gem outdated
-        if: matrix.openssl == true
+        if: matrix.openssl.value == true
       - name: Run bundler installed as a default gem
         run: bundle --version
       - name: Check bundler man pages were installed and are properly picked up
@@ -56,6 +65,7 @@ jobs:
     timeout-minutes: 10
 
   install_rubygems_windows:
+    name: Install Rubygems on Windows
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/jruby-bundler.yml
+++ b/.github/workflows/jruby-bundler.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   jruby_bundler:
+    name: Bundler (JRuby)
     runs-on: ubuntu-18.04
 
     env:

--- a/.github/workflows/macos-rubygems.yml
+++ b/.github/workflows/macos-rubygems.yml
@@ -10,17 +10,22 @@ on:
 
 jobs:
   macos_rubygems:
+    name: Rubygems on MacOS (${{ matrix.ruby.name }})
     runs-on: macos-10.15
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.4.10, 2.5.8, 2.6.6, 2.7.2 ]
+        ruby:
+          - { name: 2.4, value: 2.4.10 }
+          - { name: 2.5, value: 2.5.8 }
+          - { name: 2.6, value: 2.6.6 }
+          - { name: 2.7, value: 2.7.2 }
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: ${{ matrix.ruby.value }}
           bundler: none
       - name: Install Dependencies
         run: rake setup

--- a/.github/workflows/older-rubygems-bundler.yml
+++ b/.github/workflows/older-rubygems-bundler.yml
@@ -14,31 +14,46 @@ on:
 
 jobs:
   older_rubygems_bundler:
+    name: Bundler ${{ matrix.bundler.name }} against old Rubygems (${{ matrix.ruby.name }}, ${{ matrix.rgv.name}})
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.3.8, 2.4.10, 2.5.8, 2.6.6, 2.7.2 ]
-        rgv: [ v2.5.2, v2.6.14, v2.7.10, v3.0.8, v3.1.4 ]
-        bundler: [ '' ]
+        ruby:
+          - { name: ruby-2.3, value: 2.3.8 }
+          - { name: ruby-2.4, value: 2.4.10 }
+          - { name: ruby-2.5, value: 2.5.8 }
+          - { name: ruby-2.6, value: 2.6.6 }
+          - { name: ruby-2.7, value: 2.7.2 }
+        rgv:
+          - { name: rgv-2.5, value: v2.5.2 }
+          - { name: rgv-2.6, value: v2.6.14 }
+          - { name: rgv-2.7, value: v2.7.10 }
+          - { name: rgv-3.0, value: v3.0.8 }
+          - { name: rgv-3.1, value: v3.1.4 }
+
+        bundler:
+          - { name: 2, value: '' }
+
         exclude:
-          - { bundler: '', ruby: 2.4.10, rgv: v2.5.2  }
-          - { bundler: '', ruby: 2.5.8, rgv: v2.5.2  }
-          - { bundler: '', ruby: 2.5.8, rgv: v2.6.14 }
-          - { bundler: '', ruby: 2.6.6, rgv: v2.5.2  }
-          - { bundler: '', ruby: 2.6.6, rgv: v2.6.14 }
-          - { bundler: '', ruby: 2.6.6, rgv: v2.7.10 }
-          - { bundler: '', ruby: 2.7.2, rgv: v2.5.2  }
-          - { bundler: '', ruby: 2.7.2, rgv: v2.6.14 }
-          - { bundler: '', ruby: 2.7.2, rgv: v2.7.10 }
-          - { bundler: '', ruby: 2.7.2, rgv: v3.0.8  }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.4, value: 2.4.10 }, rgv: { name: rgv-2.5, value: v2.5.2 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.5, value: 2.5.8 }, rgv: { name: rgv-2.5, value: v2.5.2 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.5, value: 2.5.8 }, rgv: { name: rgv-2.6, value: v2.6.14 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.6, value: 2.6.6 }, rgv: { name: rgv-2.5, value: v2.5.2 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.6, value: 2.6.6 }, rgv: { name: rgv-2.6, value: v2.6.14 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.6, value: 2.6.6 }, rgv: { name: rgv-2.7, value: v2.7.10 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.2 }, rgv: { name: rgv-2.5, value: v2.5.2 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.2 }, rgv: { name: rgv-2.6, value: v2.6.14 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.2 }, rgv: { name: rgv-2.7, value: v2.7.10 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.2 }, rgv: { name: rgv-3.0, value: v3.0.8 } }
+
         include:
-          - { bundler: 3.0.0, ruby: 2.4.10, rgv: v3.1.4 }
-          - { bundler: 3.0.0, ruby: 2.5.8, rgv: v3.1.4 }
-          - { bundler: 3.0.0, ruby: 2.6.6, rgv: v3.1.4 }
-          - { bundler: 3.0.0, ruby: 2.7.2, rgv: v3.1.4 }
+          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.4, value: 2.4.10 }, rgv: { name: rgv-3.1, value: v3.1.4 } }
+          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.5, value: 2.5.8 }, rgv: { name: rgv-3.1, value: v3.1.4 } }
+          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.6, value: 2.6.6 }, rgv: { name: rgv-3.1, value: v3.1.4 } }
+          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.7, value: 2.7.2 }, rgv: { name: rgv-3.1, value: v3.1.4 } }
     env:
-      RGV: ${{ matrix.rgv }}
+      RGV: ${{ matrix.rgv.value }}
       RUBYOPT: --disable-gems
     steps:
       - uses: actions/checkout@v2
@@ -47,14 +62,14 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: ${{ matrix.ruby.value }}
           bundler: none
       - name: Install graphviz
         run: sudo apt-get install graphviz -y
-        if: matrix.bundler == ''
+        if: matrix.bundler.value == ''
       - name: Replace version
-        run: BUNDLER_SPEC_SUB_VERSION=${{ matrix.bundler }} bin/rake override_version
-        if: matrix.bundler != ''
+        run: BUNDLER_SPEC_SUB_VERSION=${{ matrix.bundler.value }} bin/rake override_version
+        if: matrix.bundler.value != ''
         working-directory: ./bundler
       - name: Prepare dependencies
         run: |

--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -10,11 +10,12 @@ on:
 
 jobs:
   ruby_core:
+    name: ${{matrix.target}} under a ruby-core setup
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:
-        target: [rubygems, bundler]
+        target: [Rubygems, Bundler]
     steps:
       - name: Set up latest ruby head
         uses: ruby/setup-ruby@v1
@@ -50,7 +51,7 @@ jobs:
           ruby tool/sync_default_gems.rb rubygems
           make test-all TESTS="rubygems -j2"
         working-directory: ruby/ruby
-        if: matrix.target == 'rubygems'
+        if: matrix.target == 'Rubygems'
       - name: Test Bundler
         run: |
           ruby tool/sync_default_gems.rb bundler
@@ -58,4 +59,4 @@ jobs:
           git add .
           make test-bundler-parallel
         working-directory: ruby/ruby
-        if: matrix.target == 'bundler'
+        if: matrix.target == 'Bundler'

--- a/.github/workflows/ubuntu-bundler.yml
+++ b/.github/workflows/ubuntu-bundler.yml
@@ -10,14 +10,24 @@ on:
 
 jobs:
   ubuntu_bundler:
+    name: Bundler ${{ matrix.bundler.name }} (${{ matrix.ruby.name }})
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.3.8, 2.4.10, 2.5.8, 2.6.6, 2.7.2 ]
-        bundler: [ '', 3.0.0 ]
+        ruby:
+          - { name: ruby-2.3, value: 2.3.8 }
+          - { name: ruby-2.4, value: 2.4.10 }
+          - { name: ruby-2.5, value: 2.5.8 }
+          - { name: ruby-2.6, value: 2.6.6 }
+          - { name: ruby-2.7, value: 2.7.2 }
+
+        bundler:
+          - { name: 2, value: '' }
+          - { name: 3, value: 3.0.0 }
+
         exclude:
-          - { bundler: 3.0.0, ruby: 2.3.8 }
+          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.3, value: 2.3.8 } }
     env:
       RGV: ..
       RUBYOPT: --disable-gems
@@ -26,14 +36,14 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: ${{ matrix.ruby.value }}
           bundler: none
       - name: Install graphviz
         run: sudo apt-get install graphviz -y
-        if: matrix.bundler == ''
+        if: matrix.bundler.value == ''
       - name: Replace version
-        run: BUNDLER_SPEC_SUB_VERSION=${{ matrix.bundler }} bin/rake override_version
-        if: matrix.bundler != ''
+        run: BUNDLER_SPEC_SUB_VERSION=${{ matrix.bundler.value }} bin/rake override_version
+        if: matrix.bundler.value != ''
         working-directory: ./bundler
       - name: Prepare dependencies
         run: |

--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   ubuntu_lint:
+    name: Lint
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ubuntu-rubygems.yml
+++ b/.github/workflows/ubuntu-rubygems.yml
@@ -10,11 +10,19 @@ on:
 
 jobs:
   ubuntu_rubygems:
+    name: Rubygems on Ubuntu (${{ matrix.ruby.name }})
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.3.8, 2.4.10, 2.5.8, 2.6.6, 2.7.2, jruby-9.2.11.1, truffleruby-20.2.0 ]
+        ruby:
+          - { name: 2.3, value: 2.3.8 }
+          - { name: 2.4, value: 2.4.10 }
+          - { name: 2.5, value: 2.5.8 }
+          - { name: 2.6, value: 2.6.6 }
+          - { name: 2.7, value: 2.7.2 }
+          - { name: jruby-9.2, value: jruby-9.2.11.1 }
+          - { name: truffleruby-20.2, value: truffleruby-20.2.0 }
     env:
       TRUFFLERUBYOPT: "--experimental-options --testing-rubygems"
     steps:
@@ -22,7 +30,7 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: ${{ matrix.ruby.value }}
           bundler: none
       - name: Install Dependencies
         run: rake setup

--- a/.github/workflows/windows-bundler.yml
+++ b/.github/workflows/windows-bundler.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 'jruby-9.2.11.1', '2.4', '2.5', '2.6', '2.7' ]
+        ruby: [ 'jruby-9.2.11.1', '2.4.10', '2.5.8', '2.6.6', '2.7.2' ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/windows-bundler.yml
+++ b/.github/workflows/windows-bundler.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   windows_bundler:
+    name: Bundler on Windows (${{ matrix.ruby.name }})
+
     runs-on: windows-2019
 
     env:
@@ -18,14 +20,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 'jruby-9.2.11.1', '2.4.10', '2.5.8', '2.6.6', '2.7.2' ]
+        ruby:
+          - { name: jruby-9.2, value: jruby-9.2.11.1 }
+          - { name: ruby-2.4, value: 2.4.10 }
+          - { name: ruby-2.5, value: 2.5.8 }
+          - { name: ruby-2.6, value: 2.6.6 }
+          - { name: ruby-2.7, value: 2.7.2 }
 
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: ${{ matrix.ruby.value }}
           bundler: none
       - name: Install dependencies
         run: |
@@ -37,4 +44,4 @@ jobs:
           bin/parallel_rspec
         working-directory: ./bundler
         shell: bash
-        if: "!startsWith(matrix.ruby, 'jruby')"
+        if: "!startsWith(matrix.ruby.name, 'jruby')"

--- a/.github/workflows/windows-rubygems.yml
+++ b/.github/workflows/windows-rubygems.yml
@@ -10,17 +10,22 @@ on:
 
 jobs:
   windows_rubygems:
+    name: Rubygems on Windows (${{ matrix.ruby.name }})
     runs-on: windows-2019
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.4.10, 2.5.8, 2.6.6, 2.7.2 ]
+        ruby:
+          - { name: 2.4, value: 2.4.10 }
+          - { name: 2.5, value: 2.5.8 }
+          - { name: 2.6, value: 2.6.6 }
+          - { name: 2.7, value: 2.7.2 }
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: ${{ matrix.ruby.value }}
           bundler: none
       - name: Install Dependencies
         run: rake setup


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Our CI configuration uses exact versions. This helps us with the determinism of our CI, making it less dependent on external changes, following the principle that CI should fail if and only if the code inside a PR breaks something.

However, since exact versions are used to build job names, that means every time we bump the tested versions, the job names change and we have to change our protected branch configuration to enforce the checks with the new names.

## What is your fix for the problem, implemented in this PR?

With these changes I expect to keep the best of both worlds: CI determinism, and stable and descriptive job names.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)