### PR TITLE
Prevent adding platforms when force_ruby_platform is true

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -524,6 +524,11 @@ module Bundler
     end
 
     def add_platform(platform)
+      if Bundler.settings[:force_ruby_platform] && platform != Gem::Platform::RUBY
+        setting_locations = Bundler.settings.pretty_values_for(:force_ruby_platform).join("\n")
+        raise InvalidOption, "Unable to add the platform `#{platform}` because `force_ruby_platform` is true:\n#{setting_locations}"
+      end
+
       @new_platform ||= !@platforms.include?(platform)
       @platforms |= [platform]
     end

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -123,6 +123,15 @@ RSpec.describe "bundle install with specific platforms" do
           google-protobuf-3.0.0.alpha.5.0.5.1-universal-darwin
         ])
       end
+
+      it "fails if force_ruby_platform is set" do
+        setup_multiplatform_gem
+        bundle "config set force_ruby_platform true"
+        install_gemfile(google_protobuf)
+        bundle "lock --add-platform=#{linux}", :raise_on_error => false
+
+        expect(err).to start_with("Unable to add the platform `#{linux}` because `force_ruby_platform` is true:\nSet for the current user")
+      end
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Closes #4125. 

## What is your fix for the problem, implemented in this PR?

Fail with error when running `bundle lock --add-platform` if `force_ruby_platform` is true

This PR does **not** address the other half of #4125 (Bundler silently removes other platforms when the lockfile is updated while `force_ruby_platform` is set).

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
