### PR TITLE
Ad-hoc fix for platform regression

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -212,6 +212,15 @@ module Bundler
         end
     end
 
+    def locked_bundler_version
+      return nil unless defined?(@definition) && @definition
+
+      locked_gems = definition.locked_gems
+      return nil unless locked_gems
+
+      locked_gems.bundler_version
+    end
+
     def ruby_scope
       "#{Bundler.rubygems.ruby_engine}/#{RbConfig::CONFIG["ruby_version"]}"
     end

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -20,6 +20,40 @@ RSpec.describe "bundle install with specific platforms" do
       ])
     end
 
+    it "understands that a non-plaform specific gem in a old lockfile doesn't necessarily mean installing the non-specific variant" do
+      setup_multiplatform_gem
+
+      system_gems "bundler-2.1.4"
+
+      # Consistent location to install and look for gems
+      bundle "config set --local path vendor/bundle", :env => { "BUNDLER_VERSION" => "2.1.4" }
+
+      install_gemfile(google_protobuf, :env => { "BUNDLER_VERSION" => "2.1.4" })
+
+      # simulate lockfile created with old bundler, which only locks for ruby platform
+      lockfile <<-L
+        GEM
+          remote: #{file_uri_for(gem_repo2)}/
+          specs:
+            google-protobuf (3.0.0.alpha.5.0.5.1)
+
+        PLATFORMS
+          ruby
+
+        DEPENDENCIES
+          google-protobuf
+
+        BUNDLED WITH
+           2.1.4
+      L
+
+      # force strict usage of the lock file by setting frozen mode
+      bundle "config set --local frozen true", :env => { "BUNDLER_VERSION" => "2.1.4" }
+
+      # make sure the platform that got actually installed with the old bundler is used
+      expect(the_bundle).to include_gem("google-protobuf 3.0.0.alpha.5.0.5.1 universal-darwin")
+    end
+
     it "caches the universal-darwin gem when --all-platforms is passed and properly picks it up on further bundler invocations" do
       setup_multiplatform_gem
       gemfile(google_protobuf)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In bundler 2.2 we switched to a "strict platform materialization". That means that the exact resolution, including the platform specific gems resolved for each specific platform, and the specific platforms themselves are now recorded in the lockfile.

Previously, the resolution was done without considering platform specific variants at all, and then at install time, a platform specific version for the resolved version would be installed if it happens to exist.

With the fixed behaviour though, if we are materializing a lock file created with an old bundler version, the new bundler version will interpret that the pure ruby version was resolved (since that's what it finds in the lock file) and try to materialize that. However, that version doesn't really exist in the system (it's the platform specific variant that got installed).

This change should restore backwards compatibility in this regard.

## What is your fix for the problem, implemented in this PR?

My fix is to check the version of bundler present in the lock file (if it exists), which indicates the version of bundler that created it. If that version is prior to 2.2.0, we fallback to the old behaviour.

We should be able to remove this once we have proper bundler version switching.

Fixes #4123.
Fixes #4122 too, I think.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)