### PR TITLE
Fix `bundle outdated --strict` crash

### DIFF
--- a/bundler/lib/bundler/cli/outdated.rb
+++ b/bundler/lib/bundler/cli/outdated.rb
@@ -76,6 +76,8 @@ module Bundler
         next unless gems.empty? || gems.include?(current_spec.name)
 
         active_spec = retrieve_active_spec(definition, current_spec)
+        next unless active_spec
+
         next unless filter_options_patch.empty? || update_present_via_semver_portions(current_spec, active_spec, options)
 
         gem_outdated = Gem::Version.new(active_spec.version) > Gem::Version.new(current_spec.version)
@@ -229,8 +231,6 @@ module Bundler
     end
 
     def update_present_via_semver_portions(current_spec, active_spec, options)
-      return false if active_spec.nil?
-
       current_major = current_spec.version.segments.first
       active_major = active_spec.version.segments.first
 

--- a/bundler/spec/commands/outdated_spec.rb
+++ b/bundler/spec/commands/outdated_spec.rb
@@ -429,6 +429,17 @@ RSpec.describe "bundle outdated" do
       expect(out).to end_with(expected_output)
     end
 
+    it "doesn't crash when some deps unused on the current platform" do
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "activesupport", platforms: [:ruby_22]
+      G
+
+      bundle :outdated, filter_strict_option => true
+
+      expect(out).to end_with("Bundle up to date!")
+    end
+
     it "only reports gem dependencies when they can actually be updated" do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This command would crash when there are some dependencies not used under
the current platform.

## What is your fix for the problem, implemented in this PR?

Check for `nil` at the proper place.

Fixes https://github.com/rubygems/rubygems/issues/4130.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)