### PR TITLE
Tweaks to the TEAM_CHANGES playbook

### DIFF
--- a/bundler/doc/playbooks/TEAM_CHANGES.md
+++ b/bundler/doc/playbooks/TEAM_CHANGES.md
@@ -36,7 +36,7 @@ When the conditions in [POLICIES](https://github.com/rubygems/rubygems/blob/mast
 - Remove them from the maintainers Slack channel
 
 [policies]: https://github.com/rubygems/rubygems/blob/master/bundler/doc/POLICIES.md#bundler-policies
-[org_team]: https://github.com/orgs/bundler/teams/maintainers/members
+[org_team]: https://github.com/orgs/rubygems/teams/maintainers/members
 [team]: https://bundler.io/contributors.html
 [maintainers]: https://github.com/rubygems/bundler-site/blob/02483d3f79f243774722b3fc18a471ca77b1c424/source/contributors.html.haml#L25
 [list]: https://github.com/rubygems/bundler-site/blob/02483d3f79f243774722b3fc18a471ca77b1c424/lib/tasks/contributors.rake#L8

--- a/bundler/doc/playbooks/TEAM_CHANGES.md
+++ b/bundler/doc/playbooks/TEAM_CHANGES.md
@@ -38,5 +38,5 @@ When the conditions in [POLICIES](https://github.com/rubygems/rubygems/blob/mast
 [policies]: https://github.com/rubygems/rubygems/blob/master/bundler/doc/POLICIES.md#bundler-policies
 [org_team]: https://github.com/orgs/rubygems/teams/maintainers/members
 [team]: https://bundler.io/contributors.html
-[maintainers]: https://github.com/rubygems/bundler-site/blob/02483d3f79f243774722b3fc18a471ca77b1c424/source/contributors.html.haml#L25
-[list]: https://github.com/rubygems/bundler-site/blob/02483d3f79f243774722b3fc18a471ca77b1c424/lib/tasks/contributors.rake#L8
+[maintainers]: https://github.com/rubygems/bundler-site/blob/f00eb65da0697c2cb0e7b4d6e5ba47ecc1538eb2/source/contributors.html.haml#L25
+[list]: https://github.com/rubygems/bundler-site/blob/f00eb65da0697c2cb0e7b4d6e5ba47ecc1538eb2/lib/tasks/contributors.rake#L8

--- a/bundler/doc/playbooks/TEAM_CHANGES.md
+++ b/bundler/doc/playbooks/TEAM_CHANGES.md
@@ -15,7 +15,7 @@ Interested in adding someone to the team? Here's the process.
     - Add them to the [maintainers team][org_team] on GitHub
     - Add them to the [Team page][team] on bundler.io, in the [maintainers list][maintainers]
     - Add them to the [list of team members][list] in `contributors.rake`
-    - Add them to the authors list in `bundler.gemspec`
+    - Add them to the authors list in `bundler.gemspec` && `rubygems-update.gemspec`
     - Add them to the owners list on RubyGems.org by running
       ```
       $ gem owner -a EMAIL bundler


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

No issue, just that we're onboarding a new team member.

## What is your fix for the problem, implemented in this PR?

The main tweak is that I think the proper team that grants permissions to our repos is the maintainers team under the rubygems org, not the maintainers team under the bundler org.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)