### PR TITLE
Reset also root when in a nested invocation

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -602,8 +602,9 @@ EOF
       reset_rubygems!
     end
 
-    def reset_settings!
+    def reset_settings_and_root!
       @settings = nil
+      @root = nil
     end
 
     def reset_paths!

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -57,7 +57,7 @@ module Bundler
       custom_gemfile = options[:gemfile] || Bundler.settings[:gemfile]
       if custom_gemfile && !custom_gemfile.empty?
         Bundler::SharedHelpers.set_env "BUNDLE_GEMFILE", File.expand_path(custom_gemfile)
-        Bundler.reset_settings!
+        Bundler.reset_settings_and_root!
       end
 
       Bundler.settings.set_command_option_if_given :retry, options[:retry]


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Under some circumstances, a nested invocation of a subprocess inside a `bundle
exec` run can end up resolving the bundle path location incorrectly.

Fixes https://github.com/rubygems/rubygems/issues/4131.

## What is your fix for the problem, implemented in this PR?

Reset bundle root so that the location is properly re-resolved.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)