### PR TITLE
Fix `gem update --system` displaying too many changelog entries

### DIFF
--- a/.changelog.yml
+++ b/.changelog.yml
@@ -4,7 +4,7 @@ header_template: "=== %new_version / %release_date"
 
 entry_template: "* %pull_request_title. Pull request #%pull_request_number by %pull_request_author"
 
-release_date_format: "%Y-%m-%-d"
+release_date_format: "%Y-%m-%d"
 
 entry_wrapping: 74
 

--- a/History.txt
+++ b/History.txt
@@ -12,7 +12,7 @@ Bug fixes:
 * Fix Resolver::APISet to always include prereleases when necessary. Pull
   request #4113 by deivid-rodriguez
 
-=== 3.2.0 / 2020-12-7
+=== 3.2.0 / 2020-12-07
 
 Enhancements:
 
@@ -68,7 +68,7 @@ Performance:
 * Don't change ruby process CWD when building extensions. Pull request
   #3498 by deivid-rodriguez
 
-=== 3.2.0.rc.2 / 2020-10-8
+=== 3.2.0.rc.2 / 2020-10-08
 
 Enhancements:
 

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -683,3 +683,4 @@ test/rubygems/test_remote_fetch_error.rb
 test/rubygems/test_require.rb
 test/rubygems/wrong_key_cert.pem
 test/rubygems/wrong_key_cert_32.pem
+test/test_changelog_generator.rb

--- a/test/test_changelog_generator.rb
+++ b/test/test_changelog_generator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require_relative "../util/changelog"
+require "rubygems/commands/setup_command"
+
+class ChangelogTest < Minitest::Test
+  def setup
+    @changelog = Changelog.for_rubygems(Gem::VERSION)
+  end
+
+  def test_format_header
+    Time.stub :now, Time.new(2020, 1, 1) do
+      assert_match Gem::Commands::SetupCommand::HISTORY_HEADER, @changelog.send(:format_header)
+    end
+  end
+end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I noticed that `gem update --system` was displaying too many changelog entries.

## What is your fix for the problem, implemented in this PR?

The regular expresion to parse these entries required 2 digits in the last
component of the date, resulting in incorrectly showing release notes for these
versions, since they were incorrectly parsed as changelog entries instead of
version headers.

My fix is to correct existing wrong entries, correct the generator to ensure
future correctness, and add a test to ensure we don't regress.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)