### PR TITLE
Normalize changelog.rb indentation.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -89,6 +89,9 @@ Lint/DuplicateMethods:
 Lint/ParenthesesAsGroupedExpression:
   Enabled: true
 
+Layout/EndAlignment:
+  Enabled: true
+
 Naming/HeredocDelimiterCase:
   Enabled: true
 

--- a/util/changelog.rb
+++ b/util/changelog.rb
@@ -27,7 +27,7 @@ class Changelog
                :minor
              else
                :patch
-               end
+             end
   end
 
   def release_notes


### PR DESCRIPTION
- fixes `rake test` warning

>  rubygems/util/changelog.rb:30: warning: mismatched indentations at 'end' with 'else' at 28