### PR TITLE
Fix tag creation in github release tasks

### DIFF
--- a/util/release.rb
+++ b/util/release.rb
@@ -35,7 +35,8 @@ class Release
 
       gh_client.create_release "rubygems/rubygems", tag, :name => tag,
                                                          :body => @changelog.release_notes.join("\n").strip,
-                                                         :prerelease => @version.prerelease?
+                                                         :prerelease => @version.prerelease?,
+                                                         :target_commitish => @stable_branch
     end
 
     def previous_version
@@ -56,8 +57,9 @@ class Release
   class Bundler
     include SubRelease
 
-    def initialize(version)
+    def initialize(version, stable_branch)
       @version = Gem::Version.new(version)
+      @stable_branch = stable_branch
       @changelog = Changelog.for_bundler(version)
       @version_files = [File.expand_path("../bundler/lib/bundler/version.rb", __dir__)]
       @title = "Bundler version #{version} with changelog"
@@ -68,8 +70,9 @@ class Release
   class Rubygems
     include SubRelease
 
-    def initialize(version)
+    def initialize(version, stable_branch)
       @version = Gem::Version.new(version)
+      @stable_branch = stable_branch
       @changelog = Changelog.for_rubygems(version)
       @version_files = [File.expand_path("../lib/rubygems.rb", __dir__), File.expand_path("../rubygems-update.gemspec", __dir__)]
       @title = "Rubygems version #{version} with changelog"
@@ -99,13 +102,14 @@ class Release
   def initialize(version)
     segments = Gem::Version.new(version).segments
 
+    @stable_branch = segments[0, 2].join(".")
+
     rubygems_version = segments.join(".")
-    @rubygems = Rubygems.new(rubygems_version)
+    @rubygems = Rubygems.new(rubygems_version, @stable_branch)
 
     bundler_version = segments.map.with_index {|s, i| i == 0 ? s - 1 : s }.join(".")
-    @bundler = Bundler.new(bundler_version)
+    @bundler = Bundler.new(bundler_version, @stable_branch)
 
-    @stable_branch = segments[0, 2].join(".")
     @release_branch = "release/bundler_#{bundler_version}_rubygems_#{rubygems_version}"
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Our rubygems release task doesn't seem to do any git tagging. In
addition to that, the GitHub releases API automatically tags the release
from the default branch if the given tag doesn't exist.

The combination of those two things results in the `rake
upload_to_github` task creating a tag based off an incorrect branch.

## What is your fix for the problem, implemented in this PR?

Fix is to pass the proper branch to the github releases API.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)