### PR TITLE
Fix `bundle config` inside an application saving configuration globally

### DIFF
--- a/bundler/lib/bundler/cli/config.rb
+++ b/bundler/lib/bundler/cli/config.rb
@@ -180,7 +180,7 @@ module Bundler
         scopes = %w[global local].select {|s| options[s] }
         case scopes.size
         when 0
-          @scope = "global"
+          @scope = inside_app? ? "local" : "global"
           @explicit_scope = false
         when 1
           @scope = scopes.first
@@ -188,6 +188,15 @@ module Bundler
           raise InvalidOption,
             "The options #{scopes.join " and "} were specified. Please only use one of the switches at a time."
         end
+      end
+
+      private
+
+      def inside_app?
+        Bundler.root
+        true
+      rescue GemfileNotFound
+        false
       end
     end
   end

--- a/bundler/spec/commands/config_spec.rb
+++ b/bundler/spec/commands/config_spec.rb
@@ -43,6 +43,12 @@ RSpec.describe ".bundle/config" do
       G
     end
 
+    it "is local by default" do
+      bundle "config set foo bar"
+      expect(bundled_app(".bundle/config")).to exist
+      expect(home(".bundle/config")).not_to exist
+    end
+
     it "can be moved with an environment variable" do
       ENV["BUNDLE_APP_CONFIG"] = tmp("foo/bar").to_s
       bundle "config set --local path vendor/bundle"
@@ -67,6 +73,12 @@ RSpec.describe ".bundle/config" do
   end
 
   describe "location without a gemfile" do
+    it "is global by default" do
+      bundle "config set foo bar"
+      expect(bundled_app(".bundle/config")).not_to exist
+      expect(home(".bundle/config")).to exist
+    end
+
     it "works with an absolute path" do
       ENV["BUNDLE_APP_CONFIG"] = tmp("foo/bar").to_s
       bundle "config set --local path vendor/bundle"
@@ -359,7 +371,7 @@ E
 
     it "doesn't return quotes around values" do
       bundle "config set foo '1'"
-      run "puts Bundler.settings.send(:global_config_file).read"
+      run "puts Bundler.settings.send(:local_config_file).read"
       expect(out).to include('"1"')
       run "puts Bundler.settings[:foo]"
       expect(out).to eq("1")

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -291,7 +291,7 @@ RSpec.describe "bundle exec" do
       end
     end
 
-    bundle "config set path.system true"
+    bundle "config set --global path.system true"
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -157,9 +157,9 @@ RSpec.describe "bundle lock" do
       gem "rack_middleware", :group => "test"
     G
     bundle "config set without test"
-    bundle "config set path .bundle"
+    bundle "config set path vendor/bundle"
     bundle "lock"
-    expect(bundled_app(".bundle")).not_to exist
+    expect(bundled_app("vendor/bundle")).not_to exist
   end
 
   # see update_spec for more coverage on same options. logic is shared so it's not necessary

--- a/bundler/spec/install/gemfile/groups_spec.rb
+++ b/bundler/spec/install/gemfile/groups_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "bundle install with groups" do
       end
 
       it "respects global `without` configuration, and saves it locally", :bundler => "< 3" do
-        bundle "config set without emo"
+        bundle "config set --global without emo"
         bundle :install
         expect(the_bundle).to include_gems "rack 1.0.0", :groups => [:default]
         bundle "config list"
@@ -101,7 +101,7 @@ RSpec.describe "bundle install with groups" do
       end
 
       it "respects global `without` configuration, but does not save it locally", :bundler => "3" do
-        bundle "config set without emo"
+        bundle "config set --global without emo"
         bundle :install
         expect(the_bundle).to include_gems "rack 1.0.0", :groups => [:default]
         bundle "config list"

--- a/bundler/spec/realworld/parallel_spec.rb
+++ b/bundler/spec/realworld/parallel_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "parallel", :realworld => true do
   end
 
   it "works with --standalone" do
-    gemfile <<-G, :standalone => true
+    gemfile <<-G
       source "https://rubygems.org"
       gem "diff-lcs"
     G

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -237,33 +237,31 @@ module Spec
       config(config, home(".bundle/config"))
     end
 
-    def create_file(*args)
-      path = bundled_app(args.shift)
-      path = args.shift if args.first.is_a?(Pathname)
-      str  = args.shift || ""
+    def create_file(path, contents = "")
+      path = Pathname.new(path).expand_path(bundled_app) unless path.is_a?(Pathname)
       path.dirname.mkpath
       File.open(path.to_s, "w") do |f|
-        f.puts strip_whitespace(str)
+        f.puts strip_whitespace(contents)
       end
     end
 
     def gemfile(*args)
-      contents = args.shift
+      contents = args.pop
 
       if contents.nil?
         File.open(bundled_app_gemfile, "r", &:read)
       else
-        create_file("Gemfile", contents, *args)
+        create_file(args.pop || "Gemfile", contents)
       end
     end
 
     def lockfile(*args)
-      contents = args.shift
+      contents = args.pop
 
       if contents.nil?
         File.open(bundled_app_lock, "r", &:read)
       else
-        create_file("Gemfile.lock", contents, *args)
+        create_file(args.pop || "Gemfile.lock", contents)
       end
     end
 
@@ -274,8 +272,8 @@ module Spec
     end
 
     def install_gemfile(*args)
+      opts = args.last.is_a?(Hash) ? args.pop : {}
       gemfile(*args)
-      opts = args.last.is_a?(Hash) ? args.last : {}
       bundle :install, opts
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Users expect `bundle config` to save configuration to the local application when `bundle config` is run on an application context. This is because other tools work like that (`git`), and because usual app specific configurations (`without`, `path`) are no generally desired to be applied to all the apps of a user.

Also, there's no documentation anywhere about it being global by default.

Someone could be relaying on this, but I'm going to call this a bug, and just change the behavior, because we keep getting issues about it.

## What is your fix for the problem, implemented in this PR?

Change `bundle config` to be local by default like everyone expects.

Fixes https://github.com/rubygems/rubygems/issues/3926.
Fixes https://github.com/rubygems/rubygems/issues/4142.
Fixes https://github.com/rubygems/rubygems/issues/4813.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)