### PR TITLE
Restore change to copy global with/without config locally upon `bundle install`

### DIFF
--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -152,16 +152,20 @@ module Bundler
 
       check_for_group_conflicts_in_cli_options
 
+      Bundler.settings.set_command_option :with, nil if options[:with] == []
+      Bundler.settings.set_command_option :without, nil if options[:without] == []
+
       with = options.fetch(:with, [])
       with |= Bundler.settings[:with].map(&:to_s)
       with -= options[:without] if options[:without]
-      with = nil if options[:with] == []
 
       without = options.fetch(:without, [])
       without |= Bundler.settings[:without].map(&:to_s)
       without -= options[:with] if options[:with]
-      without = nil if options[:without] == []
 
+      # need to nil them out first to get around validation for backwards compatibility
+      Bundler.settings.set_command_option :without, nil
+      Bundler.settings.set_command_option :with,    nil
       Bundler.settings.set_command_option :without, without
       Bundler.settings.set_command_option :with,    with
     end

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -166,11 +166,13 @@ module Bundler
       options[:with]    = with
       options[:without] = without
 
-      # need to nil them out first to get around validation for backwards compatibility
-      Bundler.settings.set_command_option :without, nil
-      Bundler.settings.set_command_option :with,    nil
-      Bundler.settings.set_command_option :without, options[:without] - options[:with]
-      Bundler.settings.set_command_option :with,    options[:with]
+      unless Bundler.settings[:without] == options[:without] && Bundler.settings[:with] == options[:with]
+        # need to nil them out first to get around validation for backwards compatibility
+        Bundler.settings.set_command_option :without, nil
+        Bundler.settings.set_command_option :with,    nil
+        Bundler.settings.set_command_option :without, options[:without] - options[:with]
+        Bundler.settings.set_command_option :with,    options[:with]
+      end
     end
 
     def normalize_settings
@@ -197,7 +199,7 @@ module Bundler
 
       Bundler.settings.set_command_option_if_given :clean, options["clean"]
 
-      normalize_groups if options[:without] || options[:with]
+      normalize_groups
 
       options[:force] = options[:redownload]
     end

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -166,7 +166,7 @@ module Bundler
       # need to nil them out first to get around validation for backwards compatibility
       Bundler.settings.set_command_option :without, nil
       Bundler.settings.set_command_option :with,    nil
-      Bundler.settings.set_command_option :without, without
+      Bundler.settings.set_command_option :without, without - with
       Bundler.settings.set_command_option :with,    with
     end
 

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -163,11 +163,14 @@ module Bundler
       without |= Bundler.settings[:without].map(&:to_s)
       without -= options[:with] if options[:with]
 
+      options[:with]    = with
+      options[:without] = without
+
       # need to nil them out first to get around validation for backwards compatibility
       Bundler.settings.set_command_option :without, nil
       Bundler.settings.set_command_option :with,    nil
-      Bundler.settings.set_command_option :without, without - with
-      Bundler.settings.set_command_option :with,    with
+      Bundler.settings.set_command_option :without, options[:without] - options[:with]
+      Bundler.settings.set_command_option :with,    options[:with]
     end
 
     def normalize_settings

--- a/bundler/spec/install/gemfile/groups_spec.rb
+++ b/bundler/spec/install/gemfile/groups_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "bundle install with groups" do
       end
 
       it "respects global `without` configuration, but does not save it locally" do
-        bundle "config without emo"
+        bundle "config set without emo"
         bundle :install
         expect(the_bundle).to include_gems "rack 1.0.0", :groups => [:default]
         bundle "config list"

--- a/bundler/spec/install/gemfile/groups_spec.rb
+++ b/bundler/spec/install/gemfile/groups_spec.rb
@@ -91,13 +91,29 @@ RSpec.describe "bundle install with groups" do
         expect(the_bundle).to include_gems "rack 1.0.0", :groups => [:default]
       end
 
-      it "respects global `without` configuration, but does not save it locally" do
+      it "respects global `without` configuration, and saves it locally", :bundler => "< 3" do
+        bundle "config set without emo"
+        bundle :install
+        expect(the_bundle).to include_gems "rack 1.0.0", :groups => [:default]
+        bundle "config list"
+        expect(out).to include("Set for your local app (#{bundled_app(".bundle/config")}): [:emo]")
+        expect(out).to include("Set for the current user (#{home(".bundle/config")}): [:emo]")
+      end
+
+      it "respects global `without` configuration, but does not save it locally", :bundler => "3" do
         bundle "config set without emo"
         bundle :install
         expect(the_bundle).to include_gems "rack 1.0.0", :groups => [:default]
         bundle "config list"
         expect(out).not_to include("Set for your local app (#{bundled_app(".bundle/config")}): [:emo]")
         expect(out).to include("Set for the current user (#{home(".bundle/config")}): [:emo]")
+      end
+
+      it "allows running application where groups where configured by a different user", :bundler => "< 3" do
+        bundle "config set without emo"
+        bundle :install
+        bundle "exec ruby -e 'puts 42'", :env => { "BUNDLE_USER_HOME" => tmp("new_home").to_s }
+        expect(out).to include("42")
       end
 
       it "does not install gems from the excluded group" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Turns out https://github.com/rubygems/rubygems/pull/3666, which I thought was a bug fix, broke things for some people.

The problem is that people are righteously assuming that `bundle config` should save configuration locally to the application, but currently it doesn't work like that.

This "feature" of `bundle install` automatically copying global `with` and `without` configuration to the local configuration was creating the false impression that `bundle config` worked as you would expect and keeping people's expectations working.

## What is your fix for the problem, implemented in this PR?

I considered just making the switch and changing `bundle config` to be local but a few examples come up that could break because of doing that, so for the time being I'm just going to revert the change and release a patch release with the revert.

Fixes #4142.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)