### PR TITLE
Reuse otp passed by user in api request retry

### DIFF
--- a/lib/rubygems/commands/owner_command.rb
+++ b/lib/rubygems/commands/owner_command.rb
@@ -105,7 +105,6 @@ permission to.
     rubygems_api_request method, "api/v1/gems/#{name}/owners", scope: get_owner_scope(method: method) do |request|
       request.set_form_data 'email' => owner
       request.add_field "Authorization", api_key
-      request.add_field "OTP", options[:otp] if options[:otp]
     end
   end
 

--- a/lib/rubygems/commands/push_command.rb
+++ b/lib/rubygems/commands/push_command.rb
@@ -91,7 +91,6 @@ The push command will use ~/.gem/credentials to authenticate to a server, but yo
       request.add_field "Content-Length", request.body.size
       request.add_field "Content-Type",   "application/octet-stream"
       request.add_field "Authorization",  api_key
-      request.add_field "OTP", options[:otp] if options[:otp]
     end
   end
 

--- a/lib/rubygems/commands/yank_command.rb
+++ b/lib/rubygems/commands/yank_command.rb
@@ -74,7 +74,6 @@ data you will need to change them immediately and yank your gem.
     name = get_one_gem_name
     response = rubygems_api_request(method, api, host, scope: get_yank_scope) do |request|
       request.add_field("Authorization", api_key)
-      request.add_field("OTP", options[:otp]) if options[:otp]
 
       data = {
         'gem_name' => name,

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -94,25 +94,16 @@ module Gem::GemcutterUtilities
     end
 
     uri = URI.parse "#{self.host}/#{path}"
+    response = request_with_otp(method, uri, &block)
 
-    request_method = Net::HTTP.const_get method.to_s.capitalize
-    response = Gem::RemoteFetcher.fetcher.request(uri, request_method, &block)
-
-    otp = ""
     if mfa_unauthorized?(response)
-      response = Gem::RemoteFetcher.fetcher.request(uri, request_method) do |req|
-        otp = get_otp
-        req.add_field "OTP", otp
-        block.call(req)
-      end
+      ask_otp
+      response = request_with_otp(method, uri, &block)
     end
 
     if api_key_forbidden?(response)
-      update_scope(scope, otp)
-      Gem::RemoteFetcher.fetcher.request(uri, request_method) do |req|
-        req.add_field "OTP", otp unless otp.empty?
-        block.call(req)
-      end
+      update_scope(scope)
+      request_with_otp(method, uri, &block)
     else
       response
     end
@@ -122,16 +113,10 @@ module Gem::GemcutterUtilities
     response.kind_of?(Net::HTTPUnauthorized) && response.body.start_with?('You have enabled multifactor authentication')
   end
 
-  def get_otp
-    say 'You have enabled multi-factor authentication. Please enter OTP code.'
-    ask 'Code: '
-  end
-
-  def update_scope(scope, otp)
+  def update_scope(scope)
     sign_in_host        = self.host
     pretty_host         = pretty_host(sign_in_host)
     update_scope_params = { scope => true }
-    otp                 = options[:otp] || otp
 
     say "The existing key doesn't have access of #{scope} on #{pretty_host}. Please sign in to update access."
 
@@ -141,7 +126,7 @@ module Gem::GemcutterUtilities
     response = rubygems_api_request(:put, "api/v1/api_key",
                                     sign_in_host, scope: scope) do |request|
       request.basic_auth email, password
-      request.add_field "OTP", otp unless otp.empty?
+      request["OTP"] = options[:otp] if options[:otp]
       request.body = URI.encode_www_form({:api_key => api_key }.merge(update_scope_params))
     end
 
@@ -174,7 +159,7 @@ module Gem::GemcutterUtilities
     response = rubygems_api_request(:post, "api/v1/api_key",
                                     sign_in_host, scope: scope) do |request|
       request.basic_auth email, password
-      request.add_field "OTP", options[:otp] if options[:otp]
+      request["OTP"] = options[:otp] if options[:otp]
       request.body = URI.encode_www_form({ name: key_name }.merge(scope_params))
     end
 
@@ -234,6 +219,20 @@ module Gem::GemcutterUtilities
   end
 
   private
+
+  def request_with_otp(method, uri, &block)
+    request_method = Net::HTTP.const_get method.to_s.capitalize
+
+    Gem::RemoteFetcher.fetcher.request(uri, request_method) do |req|
+      req["OTP"] = options[:otp] if options[:otp]
+      block.call(req)
+    end
+  end
+
+  def ask_otp
+    say 'You have enabled multi-factor authentication. Please enter OTP code.'
+    options[:otp] = ask 'Code: '
+  end
 
   def pretty_host(host)
     if Gem::DEFAULT_HOST == host

--- a/lib/rubygems/test_utilities.rb
+++ b/lib/rubygems/test_utilities.rb
@@ -38,7 +38,7 @@ class Gem::FakeFetcher
     @paths = []
   end
 
-  def find_data(path, nargs = 3)
+  def find_data(path)
     return Gem.read_binary path.path if URI === path and 'file' == path.scheme
 
     if URI === path and "URI::#{path.scheme.upcase}" != path.class.name
@@ -54,10 +54,11 @@ class Gem::FakeFetcher
       raise Gem::RemoteFetcher::FetchError.new("no data for #{path}", path)
     end
 
-    data = @data[path]
-
-    data.flatten! and return data.shift(nargs) if data.respond_to?(:flatten!)
-    data
+    if @data[path].kind_of?(Array) && @data[path].first.kind_of?(Array)
+      @data[path].shift
+    else
+      @data[path]
+    end
   end
 
   def fetch_path(path, mtime = nil, head = false)

--- a/test/rubygems/test_gem_commands_push_command.rb
+++ b/test/rubygems/test_gem_commands_push_command.rb
@@ -404,11 +404,13 @@ class TestGemCommandsPushCommand < Gem::TestCase
     assert_equal '111111', @fetcher.last_request['OTP']
   end
 
-  def test_sending_gem_unathorized_api_key
+  def test_sending_gem_unathorized_api_key_with_mfa_enabled
+    response_mfa_enabled = "You have enabled multifactor authentication but your request doesn't have the correct OTP code. Please check it and retry."
     response_forbidden = "The API key doesn't have access"
     response_success   = 'Successfully registered gem: freewill (1.0.0)'
 
     @fetcher.data["#{@host}/api/v1/gems"] = [
+      [response_mfa_enabled, 401, 'Unauthorized'],
       [response_forbidden, 403, 'Forbidden'],
       [response_success, 200, "OK"],
     ]
@@ -417,17 +419,20 @@ class TestGemCommandsPushCommand < Gem::TestCase
     @cmd.instance_variable_set :@host, @host
     @cmd.instance_variable_set :@scope, :push_rubygem
 
-    @ui = Gem::MockGemUi.new "some@mail.com\npass\n"
+    @ui = Gem::MockGemUi.new "11111\nsome@mail.com\npass\n"
     use_ui @ui do
       @cmd.send_gem(@path)
     end
 
+    mfa_notice = "You have enabled multi-factor authentication. Please enter OTP code."
     access_notice = "The existing key doesn't have access of push_rubygem on https://rubygems.example. Please sign in to update access."
+    assert_match mfa_notice, @ui.output
     assert_match access_notice, @ui.output
     assert_match "Email:", @ui.output
     assert_match "Password:", @ui.output
     assert_match "Added push_rubygem scope to the existing API key", @ui.output
     assert_match response_success, @ui.output
+    assert_equal '11111', @fetcher.last_request['OTP']
   end
 
   private


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

Fixes failed commands with access update or fist invocation (no local API key):
```
$ gem yank somegem -v 0.0.1
Don't have an account yet? Create one at http://localhost:3000/sign_up
   Email:   some@rubygems.org
  Password:   
You have enabled multi-factor authentication. Please enter OTP code.
Code:   320292
Added yank_rubygem scope to the existing API key
You have enabled multifactor authentication but no OTP code provided.
Please fill it and retry.
```

## What is your fix for the problem, implemented in this PR?

reuse otp passed by the user in api request retry

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
