### PR TITLE
Fix resolver crash when a candidate has 0 matching platforms

### DIFF
--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -155,6 +155,8 @@ module Bundler
         search.each do |sg|
           next unless sg.for?(platform)
           sg_all_platforms = sg.copy_for(self.class.sort_platforms(@platforms).reverse)
+          next unless sg_all_platforms
+
           selected_sgs << sg_all_platforms
 
           next if sg_all_platforms.activated_platforms == [Gem::Platform::RUBY]


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Under some circumstances, updating your bundle crashes.

## What is your fix for the problem, implemented in this PR?

It can happen that a candidate for upgrade has 0 matching platforms. For example, if running a `bundle update` on x86_64-darwin-19, the libv8 gem version 5.0.71.48.1beta2 has no variant matching that platform.

In this case, the candidate should be ignored.

As a note, I changed "5.0.71.48.1beta2" to "15.0.71.48.1beta2" in the added spec, because I feel it's a defect in the current resolver that having version "8.4.255.0" locked in your lockfile, a dependency with lower version is even checked. By changing this I make sure the spec will still check what it's supposed to check even if we improve that.

Fixes https://github.com/rubygems/rubygems/issues/4158.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)