### PR TITLE
Fix building rake extensions that require openssl

### DIFF
--- a/lib/rubygems/ext/rake_builder.rb
+++ b/lib/rubygems/ext/rake_builder.rb
@@ -19,7 +19,7 @@ class Gem::Ext::RakeBuilder < Gem::Ext::Builder
       rake = rake.shellsplit
     else
       begin
-        rake = [Gem.ruby, "-I#{File.expand_path("..", __dir__)}", "-rrubygems", Gem.bin_path('rake', 'rake')]
+        rake = [Gem.ruby, "-I#{File.expand_path("../..", __dir__)}", "-rrubygems", Gem.bin_path('rake', 'rake')]
       rescue Gem::Exception
         rake = [Gem.default_exec_format % 'rake']
       end

--- a/test/rubygems/test_gem_ext_rake_builder.rb
+++ b/test/rubygems/test_gem_ext_rake_builder.rb
@@ -47,6 +47,31 @@ class TestGemExtRakeBuilder < Gem::TestCase
     end
   end
 
+  def test_class_no_openssl_override
+    create_temp_mkrf_file('task :default')
+
+    rake = util_spec 'rake' do |s|
+      s.executables = %w[rake]
+      s.files = %w[bin/rake]
+    end
+
+    output = []
+
+    write_file File.join(@tempdir, 'bin', 'rake') do |fp|
+      fp.puts "#!/usr/bin/ruby"
+      fp.puts "require 'openssl'; puts OpenSSL"
+    end
+
+    install_gem rake
+
+    Gem::Ext::RakeBuilder.build 'mkrf_conf.rb', @dest_path, output, [''], nil, @ext
+
+    output = output.join "\n"
+
+    assert_match "OpenSSL", output
+    assert_match %r{^#{Regexp.escape Gem.ruby} mkrf_conf\.rb}, output
+  end
+
   def test_class_build_no_mkrf_passes_args
     output = []
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Building a rake extension that requires openssl fails.

## What is your fix for the problem, implemented in this PR?

We were passing an incorrect folder, and one which has a `openssl.rb`
file inside. So this file was shadowing the require of the "real openssl".

This `-I` parameter is not really needed in real life I believe, since there can
be at most one rubygems installation at a given ruby installation. I think the
idea of this parameter is that our tests never leak to the "system rubygems",
because when testing there are two copies of rubygems involved (the one being
tested, and the one from the ruby we're running).

I'm not sure using this `-I` parameter here is a good idea, so since I'm not
sure I'm just keeping things as they are for now and fixing the bug.

Fixes #4161.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)