### PR TITLE
Make sure the default branch always has a development version

### DIFF
--- a/bundler/lib/bundler/version.rb
+++ b/bundler/lib/bundler/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
 
 module Bundler
-  VERSION = "2.2.1".freeze
+  VERSION = "2.3.0.dev".freeze
 
   def self.bundler_major_version
     @bundler_major_version ||= VERSION.split(".").first.to_i

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -8,7 +8,7 @@
 require 'rbconfig'
 
 module Gem
-  VERSION = "3.2.1".freeze
+  VERSION = "3.3.0.dev".freeze
 end
 
 # Must be first since it unloads the prelude from 1.9.2

--- a/rubygems-update.gemspec
+++ b/rubygems-update.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "rubygems-update"
-  s.version = "3.2.1"
+  s.version = "3.3.0.dev"
   s.authors = ["Jim Weirich", "Chad Fowler", "Eric Hodel", "Luis Lavena", "Aaron Patterson", "Samuel Giddins", "André Arko", "Evan Phoenix", "Hiroshi SHIBATA"]
   s.email = ["", "", "drbrain@segment7.net", "luislavena@gmail.com", "aaron@tenderlovemaking.com", "segiddins@segiddins.me", "andre@arko.net", "evan@phx.io", "hsbt@ruby-lang.org"]
 

--- a/util/release.rb
+++ b/util/release.rb
@@ -18,7 +18,7 @@ class Release
   module SubRelease
     include GithubAPI
 
-    attr_reader :version, :changelog, :version_files, :title, :tag_prefix
+    attr_reader :version, :changelog, :version_files, :name, :tag_prefix
 
     def cut_changelog_for!(pull_requests)
       set_relevant_pull_requests_from(pull_requests)
@@ -72,7 +72,7 @@ class Release
       @stable_branch = stable_branch
       @changelog = Changelog.for_bundler(version)
       @version_files = [File.expand_path("../bundler/lib/bundler/version.rb", __dir__)]
-      @title = "Bundler version #{version} with changelog"
+      @name = "Bundler"
       @tag_prefix = "bundler-v"
     end
   end
@@ -85,7 +85,7 @@ class Release
       @stable_branch = stable_branch
       @changelog = Changelog.for_rubygems(version)
       @version_files = [File.expand_path("../lib/rubygems.rb", __dir__), File.expand_path("../rubygems-update.gemspec", __dir__)]
-      @title = "Rubygems version #{version} with changelog"
+      @name = "Rubygems"
       @tag_prefix = "v"
     end
   end
@@ -160,10 +160,11 @@ class Release
       end
 
       [@bundler, @rubygems].each do |library|
-        library.bump_versions!
         library.cut_changelog!
+        system("git", "commit", "-am", "Changelog for #{library.name} version #{library.version}", exception: true)
 
-        system("git", "commit", "-am", library.title, exception: true)
+        library.bump_versions!
+        system("git", "commit", "-am", "Bump #{library.name} version to #{library.version}", exception: true)
       end
     rescue StandardError
       system("git", "checkout", initial_branch, exception: true)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Currently when we release a patch level version, the version in the main branch
suddenly becomes older than the one in the stable branch, which is incorrect
since it has more up to date code. Even having the same version as the stable
branch seems incorrect for the same reason.

This actually causes weird local test failures if you have the latest version
installed, and currently the main branch has a lower version.

## What is your fix for the problem, implemented in this PR?

My fix is to make sure the main branch always has a higher development version.
In order to make merging back the stable branch easier after a release, I
splitted the changelog and version bumps into different commits, since we'll
want the changelog to be cherry-picked, but not the version bumps.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)