### PR TITLE
Adapt to change in IRB

### DIFF
--- a/bundler/spec/commands/console_spec.rb
+++ b/bundler/spec/commands/console_spec.rb
@@ -55,10 +55,10 @@ RSpec.describe "bundle console", :bundler => "< 3", :readline => true do
 
   it "uses IRB as default console" do
     bundle "console" do |input, _, _|
-      input.puts("__method__")
+      input.puts("__FILE__")
       input.puts("exit")
     end
-    expect(out).to include(":irb_binding")
+    expect(out).to include("(irb)")
   end
 
   it "starts another REPL if configured as such" do
@@ -80,10 +80,10 @@ RSpec.describe "bundle console", :bundler => "< 3", :readline => true do
     # make sure pry isn't there
 
     bundle "console" do |input, _, _|
-      input.puts("__method__")
+      input.puts("__FILE__")
       input.puts("exit")
     end
-    expect(out).to include(":irb_binding")
+    expect(out).to include("(irb)")
   end
 
   it "doesn't load any other groups" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

CI in "ruby-core mode" is broken.

## What is your fix for the problem, implemented in this PR?

The `__method__` inside an IRB console is now different. Use `__FILE__` instead.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)