### PR TITLE
Fix bundler installing gems for a different platform when running in frozen mode and current platform not in the lockfile

### DIFF
--- a/bundler/lib/bundler/cli/update.rb
+++ b/bundler/lib/bundler/cli/update.rb
@@ -82,7 +82,7 @@ module Bundler
           locked_spec = locked_info[:spec]
           new_spec = Bundler.definition.specs[name].first
           unless new_spec
-            if Bundler.rubygems.platforms.none? {|p| locked_spec.match_platform(p) }
+            unless locked_spec.match_platform(Bundler.local_platform)
               Bundler.ui.warn "Bundler attempted to update #{name} but it was not considered because it is for a different platform from the current one"
             end
 

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -519,7 +519,8 @@ module Bundler
       end
 
       raise ProductionError, "Your bundle only supports platforms #{@platforms.map(&:to_s)} " \
-        "but your local platform is #{Bundler.local_platform}.
+        "but your local platform is #{Bundler.local_platform}. " \
+        "Add the current platform to the lockfile with `bundle lock --add-platform #{Bundler.local_platform}` and try again."
     end
 
     def add_platform(platform)

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -515,14 +515,12 @@ module Bundler
 
     def validate_platforms!
       return if @platforms.any? do |bundle_platform|
-        Bundler.rubygems.platforms.any? do |local_platform|
-          MatchPlatform.platforms_match?(bundle_platform, local_platform)
-        end
+        MatchPlatform.platforms_match?(bundle_platform, Bundler.local_platform)
       end
 
       raise ProductionError, "Your bundle only supports platforms #{@platforms.map(&:to_s)} " \
-        "but your local platforms are #{Bundler.rubygems.platforms.map(&:to_s)}, and " \
-        "there's no compatible match between those two lists."
+        "but your local platform is #{Bundler.local_platform}, and " \
+        "there's no compatible match between those."
     end
 
     def add_platform(platform)

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -519,8 +519,7 @@ module Bundler
       end
 
       raise ProductionError, "Your bundle only supports platforms #{@platforms.map(&:to_s)} " \
-        "but your local platform is #{Bundler.local_platform}, and " \
-        "there's no compatible match between those."
+        "but your local platform is #{Bundler.local_platform}.
     end
 
     def add_platform(platform)

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -110,11 +110,6 @@ module Bundler
       obj.to_s
     end
 
-    def platforms
-      return [Gem::Platform::RUBY] if Bundler.settings[:force_ruby_platform]
-      Gem.platforms
-    end
-
     def configuration
       require_relative "psyched_yaml"
       Gem.configuration

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -184,11 +184,7 @@ module Bundler
     def spec_for_dependency(dep, match_current_platform)
       specs_for_platforms = lookup[dep.name]
       if match_current_platform
-        Bundler.rubygems.platforms.reverse_each do |pl|
-          match = GemHelpers.select_best_platform_match(specs_for_platforms, pl)
-          return match if match
-        end
-        nil
+        GemHelpers.select_best_platform_match(specs_for_platforms, Bundler.local_platform)
       else
         GemHelpers.select_best_platform_match(specs_for_platforms, dep.__platform)
       end

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -667,7 +667,10 @@ RSpec.describe "bundle install with gem sources" do
     it "should fail loudly if the lockfile platforms don't include the current platform" do
       simulate_platform(Gem::Platform.new("x86_64-linux")) { bundle "install", :raise_on_error => false }
 
-      expect(err).to eq("Your bundle only supports platforms [\"x86_64-darwin-19\"] but your local platform is x86_64-linux.")
+      expect(err).to eq(
+        "Your bundle only supports platforms [\"x86_64-darwin-19\"] but your local platform is x86_64-linux. " \
+        "Add the current platform to the lockfile with `bundle lock --add-platform x86_64-linux` and try again."
+      )
     end
   end
 end

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -667,7 +667,7 @@ RSpec.describe "bundle install with gem sources" do
     it "should fail loudly if the lockfile platforms don't include the current platform" do
       simulate_platform(Gem::Platform.new("x86_64-linux")) { bundle "install", :raise_on_error => false }
 
-      expect(err).to eq("Your bundle only supports platforms [\"x86_64-darwin-19\"] but your local platform is x86_64-linux, and there's no compatible match between those.")
+      expect(err).to eq("Your bundle only supports platforms [\"x86_64-darwin-19\"] but your local platform is x86_64-linux.")
     end
   end
 end

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -630,4 +630,44 @@ RSpec.describe "bundle install with gem sources" do
                         "setting them for authentication.")
     end
   end
+
+  context "in a frozen bundle" do
+    before do
+      build_repo4 do
+        build_gem "libv8", "8.4.255.0" do |s|
+          s.platform = "x86_64-darwin-19"
+        end
+      end
+
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo4)}"
+
+        gem "libv8"
+      G
+
+      lockfile <<-L
+        GEM
+          remote: #{file_uri_for(gem_repo4)}/
+          specs:
+            libv8 (8.4.255.0-x86_64-darwin-19)
+
+        PLATFORMS
+          x86_64-darwin-19
+
+        DEPENDENCIES
+          libv8
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      bundle "config set --local deployment true"
+    end
+
+    it "should fail loudly if the lockfile platforms don't include the current platform" do
+      simulate_platform(Gem::Platform.new("x86_64-linux")) { bundle "install", :raise_on_error => false }
+
+      expect(err).to eq("Your bundle only supports platforms [\"x86_64-darwin-19\"] but your local platform is x86_64-linux, and there's no compatible match between those.")
+    end
+  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since bundler 2.2.1, bundler could end up installing dependencies not valid for the current platform.

## What is your fix for the problem, implemented in this PR?

RUBY is no longer included as a platform in the lockfile, however it's still included in the list of rubygems platforms, so the check was not doing the right thing.

Instead, use our own logic.

Fixes https://github.com/rubygems/rubygems/issues/4166.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)