### PR TITLE
Fix crash when `bundle exec`'ing to bundler

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -162,7 +162,7 @@ module Bundler
     end
 
     def resolve_remotely!
-      raise "Specs already loaded" if @specs
+      return if @specs
       @remote = true
       sources.remote!
       specs

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -67,6 +67,32 @@ RSpec.describe "bundle exec" do
     expect(out).to eq(Gem::VERSION)
   end
 
+  it "works when exec'ing back to bundler with a lockfile that doesn't include the current platform" do
+    install_gemfile <<-G
+      gem "rack", "0.9.1"
+    G
+
+    # simulate lockfile generated with old version not including specific platform
+    lockfile <<-L
+      GEM
+        specs:
+          rack (0.9.1)
+
+      PLATFORMS
+        RUBY
+
+      DEPENDENCIES
+        rack (= 0.9.1)
+
+      BUNDLED WITH
+          2.1.4
+    L
+
+    bundle "exec bundle cache", :env => { "BUNDLER_VERSION" => Bundler::VERSION }
+
+    expect(out).to include("Updating files in vendor/cache")
+  end
+
   it "respects custom process title when loading through ruby" do
     skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The problem was that `bundle exec`'ing to `bundler` itself would crash if the lockfile was generated with bundler 2.1.4 and it's missing the specific platform.

I can't think of any reason to `bundle exec` to `bundler`, but it shouldn't be a way to make bundler crash.

## What is your fix for the problem, implemented in this PR?

In this case, the crash was due to `bundle exec`'ing on a definition missing the current specific platform (due to lockfile generated with older bundler). The definition would resolve gems in the main process, and then would tried to be re-resolved again inside the "bundle exec" context because of the missing platform. This double resolution would cause bundler to crash.

I don't see why we should raise an exception in this situation, specially such a cryptic one, so don't raise it.

Fixes https://github.com/rubygems/rubygems/issues/4153.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)