### PR TITLE
Fix misspellings in default API key name

### DIFF
--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -260,8 +260,8 @@ module Gem::GemcutterUtilities
   end
 
   def get_key_name(scope)
-    hostname = Socket.gethostname || "unkown-host"
-    user = ENV["USER"] || ENV["USERNAME"] || "unkown-user"
+    hostname = Socket.gethostname || "unknown-host"
+    user = ENV["USER"] || ENV["USERNAME"] || "unknown-user"
     ts = Time.now.strftime("%Y%m%d%H%M%S")
     default_key_name = "#{hostname}-#{user}-#{ts}"
 


### PR DESCRIPTION
Forward-port from https://github.com/ruby/ruby/commit/63849a1cd98c7ae3a7d6af3f69814f01dfae25ea