### PR TITLE
Restore full compatibility with previous lockfiles

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -212,13 +212,10 @@ module Bundler
         end
     end
 
-    def locked_bundler_version
-      return nil unless defined?(@definition) && @definition
+    def most_specific_locked_platform?(platform)
+      return false unless defined?(@definition) && @definition
 
-      locked_gems = definition.locked_gems
-      return nil unless locked_gems
-
-      locked_gems.bundler_version
+      definition.most_specific_locked_platform == platform
     end
 
     def ruby_scope

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -123,7 +123,7 @@ module Bundler
       end
       @unlocking ||= @unlock[:ruby] ||= (!@locked_ruby_version ^ !@ruby_version)
 
-      add_current_platform unless Bundler.frozen_bundle?
+      add_current_platform unless current_ruby_platform_locked? || Bundler.frozen_bundle?
 
       converge_path_sources_to_gemspec_sources
       @path_changes = converge_paths
@@ -513,9 +513,7 @@ module Bundler
     end
 
     def validate_platforms!
-      return if @platforms.any? do |bundle_platform|
-        MatchPlatform.platforms_match?(bundle_platform, Bundler.local_platform)
-      end
+      return if current_platform_locked?
 
       raise ProductionError, "Your bundle only supports platforms #{@platforms.map(&:to_s)} " \
         "but your local platform is #{Bundler.local_platform}. " \
@@ -552,6 +550,18 @@ module Bundler
     end
 
     private
+
+    def current_ruby_platform_locked?
+      return false unless generic_local_platform == Gem::Platform::RUBY
+
+      current_platform_locked?
+    end
+
+    def current_platform_locked?
+      @platforms.any? do |bundle_platform|
+        MatchPlatform.platforms_match?(bundle_platform, Bundler.local_platform)
+      end
+    end
 
     def add_current_platform
       add_platform(local_platform)

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -530,6 +530,12 @@ module Bundler
       raise InvalidOption, "Unable to remove the platform `#{platform}` since the only platforms are #{@platforms.join ", "}"
     end
 
+    def most_specific_locked_platform
+      @platforms.min_by do |bundle_platform|
+        platform_specificity_match(bundle_platform, local_platform)
+      end
+    end
+
     def find_resolved_spec(current_spec)
       specs.find_by_name_and_platform(current_spec.name, current_spec.platform)
     end

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -131,17 +131,16 @@ module Bundler
     end
 
     #
-    # Bundler 2.2.0 was the first version that records the full resolution
-    # including platform specific gems in the lockfile, which means that if a
-    # gem with RUBY platform is recorded, the RUBY platform version of the gem
-    # should be installed. Previously bundler would record only generic versions
-    # in the lockfile and then install the most specific platform variant if
-    # available.
+    # For backwards compatibility with existing lockfiles, if the most specific
+    # locked platform is RUBY, we keep the previous behaviour of resolving the
+    # best platform variant at materiliazation time. For previous bundler
+    # versions (before 2.2.0) this was always the case (except when the lockfile
+    # only included non-ruby platforms), but we're also keeping this behaviour
+    # on newer bundlers unless users generate the lockfile from scratch or
+    # explicitly add a more specific platform.
     #
     def ruby_platform_materializes_to_ruby_platform?
-      locked_bundler_version = Bundler.locked_bundler_version
-
-      locked_bundler_version.nil? || Gem::Version.new(locked_bundler_version) >= Gem::Version.new("2.2.0")
+      !Bundler.most_specific_locked_platform?(Gem::Platform::RUBY)
     end
   end
 end

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -420,6 +420,53 @@ RSpec.describe "bundle lock" do
     G
   end
 
+  it "respects the previous lockfile if it had a matching less specific platform already locked, and installs the best variant for each platform" do
+    build_repo4 do
+      build_gem "libv8", "8.4.255.0" do |s|
+        s.platform = "x86_64-darwin-19"
+      end
+
+      build_gem "libv8", "8.4.255.0" do |s|
+        s.platform = "x86_64-darwin-20"
+      end
+    end
+
+    gemfile <<-G
+      source "#{file_uri_for(gem_repo4)}"
+
+      gem "libv8"
+    G
+
+    lockfile <<-G
+      GEM
+        remote: #{file_uri_for(gem_repo4)}/
+        specs:
+          libv8 (8.4.255.0-x86_64-darwin-19)
+          libv8 (8.4.255.0-x86_64-darwin-20)
+
+      PLATFORMS
+        x86_64-darwin
+
+      DEPENDENCIES
+        libv8
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    G
+
+    previous_lockfile = lockfile
+
+    %w[x86_64-darwin-19 x86_64-darwin-20].each do |platform|
+      simulate_platform(Gem::Platform.new(platform)) do
+        bundle "lock"
+        expect(lockfile).to eq(previous_lockfile)
+
+        bundle "install"
+        expect(the_bundle).to include_gem("libv8 8.4.255.0 #{platform}")
+      end
+    end
+  end
+
   context "when an update is available" do
     let(:repo) { gem_repo2 }
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

What I thought was a harmless change in the lockfile format (adding the specific platform to the list of platforms in the lockfile) has caused several issues for users, just because of the fact of generating changes in the lockfile during `bundle exec`, even if the bundle can be satisfied. See #4176 or #4155 for examples.

## What is your fix for the problem, implemented in this PR?

My fix is to restore the previous behaviour if dealing with an old lockfile. An old lockfile is a lockfile where the most specific ruby platform is RUBY itself, since previous lockfiles wouldn't lock the specific platform.

The rationale for doing this is that the bug locking the specific platform was meant to fix was a very rare edge case where different variants of the same gem would have either different dependencies or different ruby/rubygems version requirements. However, if people have a working lockfile, we can assume they are not running into this issue, so the most user friendly approach is to keep the same behaviour for this people, and only apply the bug fix to freshly generated lockfiles, and to people explicitly requesting specific platforms on existing lockfiles through `bundle lock --add-platform`.

Fixes https://github.com/rubygems/rubygems/issues/4176 and all regressions due to bundler 2.2.x creating lockfile changes over 2.1.x Gemfiles.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)