### PR TITLE
Add all matching variants with the same platform specificity to the lockfile

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -274,9 +274,8 @@ module Bundler
           else
             # Run a resolve against the locally available gems
             Bundler.ui.debug("Found changes from the lockfile, re-resolving dependencies because #{change_reason}")
-            platforms_for_resolve = platforms.one? {|p| generic(p) == Gem::Platform::RUBY } ? platforms : platforms.reject{|p| p == Gem::Platform::RUBY }
             expanded_dependencies = expand_dependencies(dependencies + metadata_dependencies, @remote)
-            last_resolve.merge Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve, gem_version_promoter, additional_base_requirements_for_resolve, platforms_for_resolve)
+            last_resolve.merge Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve, gem_version_promoter, additional_base_requirements_for_resolve, platforms)
           end
 
         # filter out gems that _can_ be installed on multiple platforms, but don't need

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -275,7 +275,7 @@ module Bundler
             # Run a resolve against the locally available gems
             Bundler.ui.debug("Found changes from the lockfile, re-resolving dependencies because #{change_reason}")
             platforms_for_resolve = platforms.one? {|p| generic(p) == Gem::Platform::RUBY } ? platforms : platforms.reject{|p| p == Gem::Platform::RUBY }
-            expanded_dependencies = expand_dependencies(dependencies + metadata_dependencies, @remote, platforms_for_resolve.map {|p| generic(p) })
+            expanded_dependencies = expand_dependencies(dependencies + metadata_dependencies, @remote)
             last_resolve.merge Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve, gem_version_promoter, additional_base_requirements_for_resolve, platforms_for_resolve)
           end
 
@@ -876,8 +876,7 @@ module Bundler
       end
     end
 
-    def expand_dependencies(dependencies, remote = false, platforms = nil)
-      platforms ||= @platforms
+    def expand_dependencies(dependencies, remote = false)
       deps = []
       dependencies.each do |dep|
         dep = Dependency.new(dep, ">= 0") unless dep.respond_to?(:name)

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -4,7 +4,7 @@ require_relative "match_platform"
 
 module Bundler
   class LazySpecification
-    Identifier = Struct.new(:name, :version, :source, :platform, :dependencies)
+    Identifier = Struct.new(:name, :version, :platform)
     class Identifier
       include Comparable
       def <=>(other)
@@ -108,7 +108,7 @@ module Bundler
     end
 
     def identifier
-      @__identifier ||= Identifier.new(name, version, source, platform, dependencies)
+      @__identifier ||= Identifier.new(name, version, platform)
     end
 
     def git_version

--- a/bundler/lib/bundler/resolver/spec_group.rb
+++ b/bundler/lib/bundler/resolver/spec_group.rb
@@ -109,7 +109,7 @@ module Bundler
         return [] unless spec
         # Only allow endpoint specifications since they won't hit the network to
         # fetch the full gemspec when calling required_ruby_version
-        return [] unless spec.is_a?(EndpointSpecification) || spec.is_a?(Gem::Specification)
+        return [] unless spec.is_a?(Gem::Specification)
         dependencies = []
         if !spec.required_ruby_version.nil? && !spec.required_ruby_version.none?
           dependencies << DepProxy.new(Gem::Dependency.new("Ruby\0", spec.required_ruby_version), platform)

--- a/bundler/lib/bundler/resolver/spec_group.rb
+++ b/bundler/lib/bundler/resolver/spec_group.rb
@@ -106,10 +106,7 @@ module Bundler
       end
 
       def metadata_dependencies(spec, platform)
-        return [] unless spec
-        # Only allow endpoint specifications since they won't hit the network to
-        # fetch the full gemspec when calling required_ruby_version
-        return [] unless spec.is_a?(Gem::Specification)
+        return [] unless spec && spec.is_a?(Gem::Specification)
         dependencies = []
         if !spec.required_ruby_version.nil? && !spec.required_ruby_version.none?
           dependencies << DepProxy.new(Gem::Dependency.new("Ruby\0", spec.required_ruby_version), platform)

--- a/bundler/lib/bundler/resolver/spec_group.rb
+++ b/bundler/lib/bundler/resolver/spec_group.rb
@@ -109,7 +109,7 @@ module Bundler
         return [] unless spec
         # Only allow endpoint specifications since they won't hit the network to
         # fetch the full gemspec when calling required_ruby_version
-        return [] if !spec.is_a?(EndpointSpecification) && !spec.is_a?(Gem::Specification)
+        return [] unless spec.is_a?(EndpointSpecification) || spec.is_a?(Gem::Specification)
         dependencies = []
         if !spec.required_ruby_version.nil? && !spec.required_ruby_version.none?
           dependencies << DepProxy.new(Gem::Dependency.new("Ruby\0", spec.required_ruby_version), platform)

--- a/bundler/lib/bundler/resolver/spec_group.rb
+++ b/bundler/lib/bundler/resolver/spec_group.rb
@@ -42,12 +42,8 @@ module Bundler
         copied_sg
       end
 
-      def spec_for(platform)
-        @specs[platform]
-      end
-
       def for?(platform)
-        !spec_for(platform).nil?
+        !@specs[platform].nil?
       end
 
       def to_s

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -22,10 +22,11 @@ module Bundler
         break unless dep = deps.shift
         next if !handled.add?(dep) || skip.include?(dep.name)
 
-        if spec = spec_for_dependency(dep, match_current_platform)
-          specs << spec
+        specs_for_dep = spec_for_dependency(dep, match_current_platform)
+        if specs_for_dep.any?
+          specs += specs_for_dep
 
-          spec.dependencies.each do |d|
+          specs_for_dep.first.dependencies.each do |d|
             next if d.type == :development
             d = DepProxy.new(d, dep.__platform) unless match_current_platform
             deps << d


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The problem is that with the following `Gemfile`:

```
source "https://rubygems.org"

gem "libv8"
```

running `bundle lock --add-platform universal-darwin` will generate the
following lockfile:

```
GEM
  remote: https://rubygems.org/
  specs:
    libv8 (8.4.255.0-universal-darwin-15)

PLATFORMS
  universal-darwin

DEPENDENCIES
  libv8

BUNDLED WITH
   2.3.0.dev
```

There's no reason to choose `8.4.255.0-universal-darwin-15` over, for example,
`8.4.255.0-universal-darwin-20`, and choosing `8.4.255.0-universal-darwin-15`
means a developer running on `universal-darwin-20` won't get the best variant
for help platform when running `bundle install`.

## What is your fix for the problem, implemented in this PR?

My fix is to add all variants with the same platform specificity to the
lockfile, as long as they all have the same dependencies (since otherwise, the
resolution would be different).

Fixes https://github.com/rubygems/rubygems/issues/4166#issuecomment-747847799.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)