### PR TITLE
Small lint job improvements

### DIFF
--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -25,8 +25,8 @@ jobs:
         run: rake rubocop
       - name: Generate docs
         run: rake docs
-      - name: Install Dependencies
-        run: bin/rake dev:deps
+      - name: Install & Check Dependencies
+        run: bin/rake dev:frozen_deps
         working-directory: ./bundler
       - name: "Check RVM integration, man:check"
         run: bin/rake check_rvm_integration man:check

--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -25,7 +25,7 @@ jobs:
         run: rake rubocop
       - name: Generate docs
         run: rake docs
-      - name: Install Dependencies in Bundler
+      - name: Install Dependencies
         run: bin/rake dev:deps
         working-directory: ./bundler
       - name: "Check RVM integration, man:check"

--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Generate docs
         run: rake docs
       - name: Install Dependencies in Bundler
-        run: bin/rake spec:deps
+        run: bin/rake dev:deps
         working-directory: ./bundler
       - name: "Check RVM integration, man:check"
         run: bin/rake check_rvm_integration man:check

--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -135,23 +135,10 @@ namespace :man do
 
     desc "Verify man pages are in sync"
     task :check => [:check_ronn, :set_current_date, :build] do
-      require "open3"
-
-      output, status = Open3.capture2e("git status --porcelain")
-
-      if status.success? && output.empty?
-        puts
-        puts "Man pages are in sync"
-        puts
-      else
-        sh("git status --porcelain")
-
-        puts
-        puts "Man pages are out of sync. Above you can see the list of files that got modified or generated from rebuilding them. Please review and commit the results."
-        puts
-
-        exit(1)
-      end
+      Spec::Rubygems.check_source_control_changes(
+        :success_message => "Man pages are in sync",
+        :error_message => "Man pages are out of sync. Above you can see the list of files that got modified or generated from rebuilding them. Please review and commit the results."
+      )
     end
   end
 end

--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -12,6 +12,14 @@ namespace :dev do
   task :deps do
     Spec::Rubygems.dev_setup
   end
+
+  desc "Ensure dev dependencies are installed, and make sure no lockifle changes are generated"
+  task :frozen_deps => :deps do
+    Spec::Rubygems.check_source_control_changes(
+      :success_message => "Development dependencies were installed and the lockfile is in sync",
+      :error_message => "Development dependencies were installed but the lockfile is out of sync. Commit the updated lockfile and try again"
+    )
+  end
 end
 
 namespace :spec do

--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -71,6 +71,26 @@ module Spec
       install_gems(test_gemfile, test_lockfile)
     end
 
+    def check_source_control_changes(success_message:, error_message:)
+      require "open3"
+
+      output, status = Open3.capture2e("git status --porcelain")
+
+      if status.success? && output.empty?
+        puts
+        puts success_message
+        puts
+      else
+        system("git status --porcelain")
+
+        puts
+        puts error_message
+        puts
+
+        exit(1)
+      end
+    end
+
     private
 
     # Some rubygems versions include loaded specs when loading gemspec stubs


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Last time I changed the main Gemfile, I forgot to properly update the lockfile and I got a weird error about man docs being out of sync.

## What is your fix for the problem, implemented in this PR?

The problem is that the task verifying that man pages are in sync will fail if there's any source control changes generated by previous tasks, which is confusing.

Instead, I made sure we fail earlier and with a better message if the lockfile is out of sync.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)