### PR TITLE
Unrescue exception to get more information

### DIFF
--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -61,14 +61,16 @@ class Gem::Ext::Builder
       require "open3"
       # Set $SOURCE_DATE_EPOCH for the subprocess.
       env = {'SOURCE_DATE_EPOCH' => Gem.source_date_epoch_string}
-      output, status = Open3.capture2e(env, *command, :chdir => dir)
+      output, status = begin
+                         Open3.capture2e(env, *command, :chdir => dir)
+                       rescue => error
+                         raise Gem::InstallError, "#{command_name || class_name} failed#{error.message}"
+                       end
       if verbose
         puts output
       else
         results << output
       end
-    rescue => error
-      raise Gem::InstallError, "#{command_name || class_name} failed#{error.message}"
     ensure
       ENV['RUBYGEMS_GEMDEPS'] = rubygems_gemdeps
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

It's been a while but our beloved flaky CI failures are back: https://github.com/rubygems/rubygems/runs/1599989644

## What is your fix for the problem, implemented in this PR?

No fix, but I hope moving this rescue clause will make figuring it out easier.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)