### PR TITLE
Never spawn subshells when building extensions

### DIFF
--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -29,7 +29,7 @@ class Gem::Ext::Builder
       make_program = (/mswin/ =~ RUBY_PLATFORM) ? 'nmake' : 'make'
     end
 
-    destdir = '"DESTDIR=%s"' % ENV['DESTDIR']
+    destdir = 'DESTDIR=%s' % ENV['DESTDIR']
 
     ['clean', '', 'install'].each do |target|
       # Pass DESTDIR via command line to override what's in MAKEFLAGS
@@ -37,7 +37,7 @@ class Gem::Ext::Builder
         make_program,
         destdir,
         target,
-      ].join(' ').rstrip
+      ].reject(&:empty?)
       begin
         run(cmd, results, "make #{target}".rstrip, make_dir)
       rescue Gem::InstallError
@@ -56,7 +56,7 @@ class Gem::Ext::Builder
         p(command)
       end
       results << "current directory: #{dir}"
-      results << (command.respond_to?(:shelljoin) ? command.shelljoin : command)
+      results << command.shelljoin
 
       require "open3"
       # Set $SOURCE_DATE_EPOCH for the subprocess.

--- a/lib/rubygems/ext/cmake_builder.rb
+++ b/lib/rubygems/ext/cmake_builder.rb
@@ -4,8 +4,7 @@ require_relative '../command'
 class Gem::Ext::CmakeBuilder < Gem::Ext::Builder
   def self.build(extension, dest_path, results, args=[], lib_dir=nil, cmake_dir=Dir.pwd)
     unless File.exist?(File.join(cmake_dir, 'Makefile'))
-      cmd = "cmake . -DCMAKE_INSTALL_PREFIX=#{dest_path}"
-      cmd << " #{Gem::Command.build_args.join ' '}" unless Gem::Command.build_args.empty?
+      cmd = ["cmake", ".", "-DCMAKE_INSTALL_PREFIX=#{dest_path}", *Gem::Command.build_args]
 
       run cmd, results, class_name, cmake_dir
     end

--- a/lib/rubygems/ext/configure_builder.rb
+++ b/lib/rubygems/ext/configure_builder.rb
@@ -8,8 +8,7 @@
 class Gem::Ext::ConfigureBuilder < Gem::Ext::Builder
   def self.build(extension, dest_path, results, args=[], lib_dir=nil, configure_dir=Dir.pwd)
     unless File.exist?(File.join(configure_dir, 'Makefile'))
-      cmd = "sh ./configure --prefix=#{dest_path}"
-      cmd << " #{args.join ' '}" unless args.empty?
+      cmd = ["sh", "./configure", "--prefix=#{dest_path}", *args]
 
       run cmd, results, class_name, configure_dir
     end

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -250,16 +250,16 @@ class Gem::TestCase < Minitest::Test
   def assert_contains_make_command(target, output, msg = nil)
     if output.match(/\n/)
       msg = message(msg) do
-        'Expected output containing make command "%s": %s' % [
+        "Expected output containing make command \"%s\", but was \n\nBEGIN_OF_OUTPUT\n%sEND_OF_OUTPUT" % [
           ('%s %s' % [make_command, target]).rstrip,
-          output.inspect,
+          output,
         ]
       end
     else
       msg = message(msg) do
         'Expected make command "%s": %s' % [
           ('%s %s' % [make_command, target]).rstrip,
-          output.inspect,
+          output,
         ]
       end
     end

--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -47,9 +47,9 @@ install:
 
     results = results.join("\n").b
 
-    assert_match %r{"DESTDIR=#{ENV['DESTDIR']}" clean$},   results
-    assert_match %r{"DESTDIR=#{ENV['DESTDIR']}"$},         results
-    assert_match %r{"DESTDIR=#{ENV['DESTDIR']}" install$}, results
+    assert_match %r{DESTDIR\\=#{ENV['DESTDIR']} clean$},   results
+    assert_match %r{DESTDIR\\=#{ENV['DESTDIR']}$},         results
+    assert_match %r{DESTDIR\\=#{ENV['DESTDIR']} install$}, results
 
     if /nmake/ !~ results
       assert_match %r{^clean: destination$},   results
@@ -76,9 +76,9 @@ install:
 
     results = results.join("\n").b
 
-    assert_match %r{"DESTDIR=#{ENV['DESTDIR']}" clean$},   results
-    assert_match %r{"DESTDIR=#{ENV['DESTDIR']}"$},         results
-    assert_match %r{"DESTDIR=#{ENV['DESTDIR']}" install$}, results
+    assert_match %r{DESTDIR\\=#{ENV['DESTDIR']} clean$},   results
+    assert_match %r{DESTDIR\\=#{ENV['DESTDIR']}$},         results
+    assert_match %r{DESTDIR\\=#{ENV['DESTDIR']} install$}, results
   end
 
   def test_build_extensions

--- a/test/rubygems/test_gem_ext_cmake_builder.rb
+++ b/test/rubygems/test_gem_ext_cmake_builder.rb
@@ -40,8 +40,7 @@ install (FILES test.txt DESTINATION bin)
 
     output = output.join "\n"
 
-    assert_match \
-      %r{^cmake \. -DCMAKE_INSTALL_PREFIX=#{Regexp.escape @dest_path}}, output
+    assert_match %r{^cmake \. -DCMAKE_INSTALL_PREFIX=#{Regexp.escape @dest_path}}, output
     assert_match %r{#{Regexp.escape @ext}}, output
     assert_contains_make_command '', output
     assert_contains_make_command 'install', output
@@ -58,11 +57,10 @@ install (FILES test.txt DESTINATION bin)
     output = output.join "\n"
 
     shell_error_msg = %r{(CMake Error: .*)}
-    sh_prefix_cmake = "cmake . -DCMAKE_INSTALL_PREFIX="
 
     assert_match 'cmake failed', error.message
 
-    assert_match %r{^#{sh_prefix_cmake}#{Regexp.escape @dest_path}}, output
+    assert_match %r{^cmake . -DCMAKE_INSTALL_PREFIX=#{Regexp.escape @dest_path}}, output
     assert_match %r{#{shell_error_msg}}, output
   end
 

--- a/test/rubygems/test_gem_ext_cmake_builder.rb
+++ b/test/rubygems/test_gem_ext_cmake_builder.rb
@@ -40,7 +40,7 @@ install (FILES test.txt DESTINATION bin)
 
     output = output.join "\n"
 
-    assert_match %r{^cmake \. -DCMAKE_INSTALL_PREFIX=#{Regexp.escape @dest_path}}, output
+    assert_match %r{^cmake \. -DCMAKE_INSTALL_PREFIX\\=#{Regexp.escape @dest_path}}, output
     assert_match %r{#{Regexp.escape @ext}}, output
     assert_contains_make_command '', output
     assert_contains_make_command 'install', output
@@ -60,7 +60,7 @@ install (FILES test.txt DESTINATION bin)
 
     assert_match 'cmake failed', error.message
 
-    assert_match %r{^cmake . -DCMAKE_INSTALL_PREFIX=#{Regexp.escape @dest_path}}, output
+    assert_match %r{^cmake . -DCMAKE_INSTALL_PREFIX\\=#{Regexp.escape @dest_path}}, output
     assert_match %r{#{shell_error_msg}}, output
   end
 

--- a/test/rubygems/test_gem_ext_configure_builder.rb
+++ b/test/rubygems/test_gem_ext_configure_builder.rb
@@ -28,7 +28,7 @@ class TestGemExtConfigureBuilder < Gem::TestCase
     Gem::Ext::ConfigureBuilder.build nil, @dest_path, output, [], nil, @ext
 
     assert_match(/^current directory:/, output.shift)
-    assert_equal "sh ./configure --prefix=#{@dest_path}", output.shift
+    assert_equal "sh ./configure --prefix\\=#{@dest_path}", output.shift
     assert_equal "", output.shift
     assert_match(/^current directory:/, output.shift)
     assert_contains_make_command 'clean', output.shift
@@ -50,7 +50,7 @@ class TestGemExtConfigureBuilder < Gem::TestCase
     end
 
     shell_error_msg = %r{(\./configure: .*)|((?:[Cc]an't|cannot) open '?\./configure'?(?:: No such file or directory)?)}
-    sh_prefix_configure = "sh ./configure --prefix="
+    sh_prefix_configure = "sh ./configure --prefix\\="
 
     assert_match 'configure failed', error.message
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In https://github.com/rubygems/rubygems/pull/4189 I was expecting CI to pass, however it failed because apparently on Windows, `Open3.capture2e` does not seem to start a new shell even when given a string argument, and that made my changes break some tests.

I think not spawning a new shell should be our default behaviour.

## What is your fix for the problem, implemented in this PR?

My fix is to change our `Open3.capture2e` calls to always receive an array, so that it always try to run the command directly instead of starting a new shell.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)