### PR TITLE
Allow installing from non https sources

### DIFF
--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -64,6 +64,8 @@ jobs:
         working-directory: ./bundler
       - name: Check rails can be installed
         run: gem install rails
+      - name: Check we can install using non https sources
+        run: gem install benchmark-ips --clear-sources --source http://rubygems.org --backtrace --verbose
     timeout-minutes: 10
 
   install_rubygems_windows:

--- a/lib/rubygems/request.rb
+++ b/lib/rubygems/request.rb
@@ -44,9 +44,9 @@ class Gem::Request
   end
 
   def self.configure_connection_for_https(connection, cert_files)
-    raise Gem::Exception.new('OpenSSl is not available. Install OpenSSL and rebuild Ruby (preferred) or use non-HTTPS sources') unless Gem::HAVE_OPENSSL
+    connection.use_ssl = Gem::HAVE_OPENSSL
+    return connection unless Gem::HAVE_OPENSSL
 
-    connection.use_ssl = true
     connection.verify_mode =
       Gem.configuration.ssl_verify_mode || OpenSSL::SSL::VERIFY_PEER
     store = OpenSSL::X509::Store.new


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

OpenSSL is not mandatory but installing from non https sources fail.

## What is your fix for the problem, implemented in this PR?

My fix is to allow it, since it's not hard.

But I think we should at least print a warning.

Fixes #4191.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)