### PR TITLE
Fix commands printed on rake extension build failures

### DIFF
--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -56,7 +56,7 @@ class Gem::Ext::Builder
         p(command)
       end
       results << "current directory: #{dir}"
-      results << (command.respond_to?(:shelljoin) ? command.shelljoin : command)
+      results << (command.respond_to?(:join) ? command.join(' ') : command)
 
       require "open3"
       # Set $SOURCE_DATE_EPOCH for the subprocess.

--- a/test/rubygems/test_gem_ext_rake_builder.rb
+++ b/test/rubygems/test_gem_ext_rake_builder.rb
@@ -24,7 +24,7 @@ class TestGemExtRakeBuilder < Gem::TestCase
 
       refute_match %r{^rake failed:}, output
       assert_match %r{^#{Regexp.escape Gem.ruby} mkrf_conf\.rb}, output
-      assert_match %r{^#{Regexp.escape rake} RUBYARCHDIR\\=#{Regexp.escape @dest_path} RUBYLIBDIR\\=#{Regexp.escape @dest_path}}, output
+      assert_match %r{^#{Regexp.escape rake} RUBYARCHDIR=#{Regexp.escape @dest_path} RUBYLIBDIR=#{Regexp.escape @dest_path}}, output
     end
   end
 
@@ -43,7 +43,7 @@ class TestGemExtRakeBuilder < Gem::TestCase
 
       refute_match %r{^rake failed:}, output
       assert_match %r{^#{Regexp.escape Gem.ruby} mkrf_conf\.rb}, output
-      assert_match %r{^#{Regexp.escape rake} RUBYARCHDIR\\=#{Regexp.escape @dest_path} RUBYLIBDIR\\=#{Regexp.escape @dest_path}}, output
+      assert_match %r{^#{Regexp.escape rake} RUBYARCHDIR=#{Regexp.escape @dest_path} RUBYLIBDIR=#{Regexp.escape @dest_path}}, output
     end
   end
 
@@ -81,7 +81,7 @@ class TestGemExtRakeBuilder < Gem::TestCase
       output = output.join "\n"
 
       refute_match %r{^rake failed:}, output
-      assert_match %r{^#{Regexp.escape rake} RUBYARCHDIR\\=#{Regexp.escape @dest_path} RUBYLIBDIR\\=#{Regexp.escape @dest_path} test1 test2}, output
+      assert_match %r{^#{Regexp.escape rake} RUBYARCHDIR=#{Regexp.escape @dest_path} RUBYLIBDIR=#{Regexp.escape @dest_path} test1 test2}, output
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In the case of a rake extension build failure, the commands that are printed as the ones that failed are incorrect.

## What is your fix for the problem, implemented in this PR?

The commands we print with the output on failures shouldn't be shellscaped, because if the `run` method is passed an array the command is invoked directly without going through an extra shell.

My fix is to not shellescape them.

Fixes the issue detected at https://github.com/rubygems/rubygems/pull/4190/files#r548235855.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)