### PR TITLE
Fix release notes including not only the latest release

### DIFF
--- a/util/changelog.rb
+++ b/util/changelog.rb
@@ -32,7 +32,6 @@ class Changelog
 
   def release_notes
     current_version_title = "#{release_section_token}#{version}"
-    current_minor_title = "#{release_section_token}#{version.segments[0, 2].join(".")}"
 
     current_version_index = lines.find_index {|line| line.strip =~ /^#{current_version_title}($|\b)/ }
     unless current_version_index
@@ -41,7 +40,7 @@ class Changelog
     current_version_index += 1
     previous_version_lines = lines[current_version_index.succ...-1]
     previous_version_index = current_version_index + (
-      previous_version_lines.find_index {|line| line.start_with?(release_section_token) && !line.start_with?(current_minor_title) } ||
+      previous_version_lines.find_index {|line| line.start_with?(release_section_token) } ||
       lines.count
     )
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We automatically extract release notes from the changelog, but they include all changes from the previous minor release. We use these for the blog and for github releases, and that's not what we want. We just want the changes for the latest release.

## What is your fix for the problem, implemented in this PR?

Remove the special logic making this work in the way we don't want.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)