### PR TITLE
Speed up boot time by adding default spec files to stub lines

### DIFF
--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -88,6 +88,14 @@ jobs:
         working-directory: ./bundler
       - name: Check rails can be installed
         run: gem install rails --verbose --backtrace
+      - name: Check default gem gets activated
+        run: ruby -rpsych -e 'exit(Gem.loaded_specs["psych"].version.to_s != "4.0.4")'
+      - name: Check upgraded default gem gets activated
+        run: |
+          gem install psych:4.0.4
+          ruby -rpsych -e 'puts "Checking psych 4.0.4 gets activated...."; exit(Gem.loaded_specs["psych"].version.to_s == "4.0.4")'
+          ruby -rpsych -e 'puts "Checking only psych 4.0.4 features are loaded between #{$LOADED_FEATURES}"; exit($LOADED_FEATURES.grep(/psych/).all?{|lf| lf =~ /psych-4.0.4/})'
+        if: matrix.ruby.name != '2.3'
     timeout-minutes: 10
 
   install_rubygems_windows:

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1203,10 +1203,18 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
           next unless $~
         end
 
-        spec.activate if already_loaded?(file)
+        spec.to_spec.activate if already_loaded?(file)
 
         @path_to_default_spec_map[file] = spec
         @path_to_default_spec_map[file.sub(suffix_regexp, "")] = spec
+      end
+    end
+
+    def regenerate_default_specs(include_stub_files:)
+      Gem::Util.glob_files_in_dir("*.gemspec", Gem.default_specifications_dir).map do |path|
+        spec = Gem::Specification.load path
+
+        write_binary(spec.loaded_from, spec.to_ruby(include_stub_files: include_stub_files))
       end
     end
 

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1210,11 +1210,11 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
       end
     end
 
-    def regenerate_default_specs(include_stub_files:)
+    def regenerate_default_specs
       Gem::Util.glob_files_in_dir("*.gemspec", Gem.default_specifications_dir).map do |path|
         spec = Gem::Specification.load path
 
-        write_binary(spec.loaded_from, spec.to_ruby(include_stub_files: include_stub_files))
+        write_binary(spec.loaded_from, spec.to_ruby)
       end
     end
 

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -615,7 +615,7 @@ abort "#{deprecation_message}"
   end
 
   def regenerate_default_specs
-    Gem.regenerate_default_specs(include_stub_files: true)
+    Gem.regenerate_default_specs
   end
 
   private

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -18,7 +18,8 @@ class Gem::Commands::SetupCommand < Gem::Command
           :site_or_vendor => "sitelibdir",
           :destdir => "", :prefix => "", :previous_version => "",
           :regenerate_binstubs => true,
-          :regenerate_plugins => true
+          :regenerate_plugins => true,
+          :regenerate_default_specs => true
 
     add_option "--previous-version=VERSION",
                "Previous version of RubyGems",
@@ -90,6 +91,11 @@ class Gem::Commands::SetupCommand < Gem::Command
     add_option "--[no-]regenerate-plugins",
                "Regenerate gem plugins" do |value, options|
       options[:regenerate_plugins] = value
+    end
+
+    add_option "--[no-]regenerate-default-specifications",
+               "Regenerate default gem specifications" do |value, options|
+      options[:regenerate_default_specifications] = value
     end
 
     add_option "-f", "--[no-]force",
@@ -182,6 +188,7 @@ By default, this RubyGems will install gem as:
 
     regenerate_binstubs(bin_dir) if options[:regenerate_binstubs]
     regenerate_plugins(bin_dir) if options[:regenerate_plugins]
+    regenerate_default_specs if options[:regenerate_default_specs]
 
     uninstall_old_gemcutter
 
@@ -605,6 +612,10 @@ abort "#{deprecation_message}"
 
     command = Gem::Commands::PristineCommand.new
     command.invoke(*args)
+  end
+
+  def regenerate_default_specs
+    Gem.regenerate_default_specs(include_stub_files: true)
   end
 
   private

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -182,7 +182,9 @@ command to remove old versions.
       say "Installing RubyGems #{version}" unless options[:silent]
 
       installed = preparing_gem_layout_for(version) do
-        system Gem.ruby, "--disable-gems", "setup.rb", *args
+        preparing_default_gemspecs_for(version) do
+          system Gem.ruby, "--disable-gems", "setup.rb", *args
+        end
       end
 
       say "RubyGems system software updated" if installed unless options[:silent]
@@ -206,6 +208,16 @@ command to remove old versions.
       end
 
       status
+    end
+  end
+
+  def preparing_default_gemspecs_for(version)
+    if Gem::Version.new(version) >= Gem::Version.new("3.3.a")
+      yield
+    else
+      Gem.regenerate_default_specs(include_stub_files: false)
+
+      yield
     end
   end
 

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -182,9 +182,7 @@ command to remove old versions.
       say "Installing RubyGems #{version}" unless options[:silent]
 
       installed = preparing_gem_layout_for(version) do
-        preparing_default_gemspecs_for(version) do
-          system Gem.ruby, "--disable-gems", "setup.rb", *args
-        end
+        system Gem.ruby, "--disable-gems", "setup.rb", *args
       end
 
       say "RubyGems system software updated" if installed unless options[:silent]
@@ -208,16 +206,6 @@ command to remove old versions.
       end
 
       status
-    end
-  end
-
-  def preparing_default_gemspecs_for(version)
-    if Gem::Version.new(version) >= Gem::Version.new("3.3.a")
-      yield
-    else
-      Gem.regenerate_default_specs(include_stub_files: false)
-
-      yield
     end
   end
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -875,7 +875,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Loads the default specifications. It should be called only once.
 
   def self.load_defaults
-    each_spec([Gem.default_specifications_dir]) do |spec|
+    default_stubs.each do |spec|
       # #load returns nil if the spec is bad, so we just ignore
       # it at this stage
       Gem.register_default_spec(spec)
@@ -2462,13 +2462,14 @@ class Gem::Specification < Gem::BasicSpecification
   # be eval'ed and reconstruct the same specification later.  Attributes that
   # still have their default values are omitted.
 
-  def to_ruby
+  def to_ruby(include_stub_files: true)
     mark_version
     result = []
     result << "# -*- encoding: utf-8 -*-"
     result << "#{Gem::StubSpecification::PREFIX}#{name} #{version} #{platform} #{raw_require_paths.join("\0")}"
     result << "#{Gem::StubSpecification::PREFIX}#{extensions.join "\0"}" unless
       extensions.empty?
+    result << "#{Gem::StubSpecification::FILES_PREFIX}#{files.join("\0")}" if include_stub_files && default_gem?
     result << nil
     result << "Gem::Specification.new do |s|"
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2462,14 +2462,14 @@ class Gem::Specification < Gem::BasicSpecification
   # be eval'ed and reconstruct the same specification later.  Attributes that
   # still have their default values are omitted.
 
-  def to_ruby(include_stub_files: true)
+  def to_ruby
     mark_version
     result = []
     result << "# -*- encoding: utf-8 -*-"
     result << "#{Gem::StubSpecification::PREFIX}#{name} #{version} #{platform} #{raw_require_paths.join("\0")}"
     result << "#{Gem::StubSpecification::PREFIX}#{extensions.join "\0"}" unless
       extensions.empty?
-    result << "#{Gem::StubSpecification::FILES_PREFIX}#{files.join("\0")}" if include_stub_files && default_gem?
+    result << "#{Gem::StubSpecification::FILES_PREFIX}#{files.join("\0")}" if default_gem?
     result << nil
     result << "Gem::Specification.new do |s|"
 

--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -35,11 +35,8 @@ class Gem::StubSpecification < Gem::BasicSpecification
     def initialize(data, extensions)
       parts          = data[PREFIX.length..-1].split(" ".freeze, 4)
       @name          = parts[0].freeze
-      @version       = if Gem::Version.correct?(parts[1])
-        Gem::Version.new(parts[1])
-      else
-        Gem::Version.new(0)
-      end
+      parts.insert(1, 0) unless Gem::Version.correct?(parts[1])
+      @version       = Gem::Version.new(parts[1])
 
       @platform      = Gem::Platform.new parts[2]
       @extensions    = extensions

--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -188,7 +188,11 @@ class Gem::StubSpecification < Gem::BasicSpecification
   # List of files in the gem
 
   def files
-    data.files
+    if default_gem?
+      data.files.any? ? data.files : to_spec.files
+    else
+      to_spec.files
+    end
   end
 
   def full_name

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -443,42 +443,6 @@ class TestGemRequire < Gem::TestCase
     end
   end
 
-  def test_realworld_default_gem
-    omit "this test can't work under ruby-core setup" if ruby_repo?
-
-    cmd = <<-RUBY
-      $stderr = $stdout
-      require "json"
-      puts Gem.loaded_specs["json"]
-    RUBY
-    output = Gem::Util.popen(*ruby_with_rubygems_in_load_path, "-e", cmd).strip
-    assert $?.success?
-    refute_empty output
-  end
-
-  def test_realworld_upgraded_default_gem
-    omit "this test can't work under ruby-core setup" if ruby_repo?
-
-    newer_json = util_spec("json", "999.99.9", nil, ["lib/json.rb"])
-    install_gem newer_json
-
-    path = "#{@tempdir}/test_realworld_upgraded_default_gem.rb"
-    code = <<-RUBY
-      $stderr = $stdout
-      require "json"
-      puts Gem.loaded_specs["json"].version
-      puts $LOADED_FEATURES
-    RUBY
-    File.write(path, code)
-
-    output = Gem::Util.popen({ "GEM_HOME" => @gemhome }, *ruby_with_rubygems_in_load_path, path).strip
-    assert $?.success?
-    refute_empty output
-    assert_equal "999.99.9", output.lines[0].chomp
-    # Make sure only files from the newer json gem are loaded, and no files from the default json gem
-    assert_equal ["#{@gemhome}/gems/json-999.99.9/lib/json.rb"], output.lines.grep(%r{/gems/json-}).map(&:chomp)
-  end
-
   def test_default_gem_and_normal_gem
     default_gem_spec = new_default_spec("default", "2.0.0.0",
                                         nil, "default/gem.rb")


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Rubygems boot time is slow. One of the causes if that all default gems are evaluated, in order to figure out which files they include and be able to "upgrade requires" in case a higher version is installed. So for example, when `require "psych"` is run, rubygems checks whether there's any file named "psych.rb` inside a default gem, and in that case activates the highest version of that default gem in the system.

This works, but evaluating all default specs in order to do this is expensive.

## What is your fix for the problem, implemented in this PR?

My fix is, similarly to what we do with other information inside gemspecs to avoid having to actually re-evaluate once they are insalled, is to create a new stub line including the list of files inside the gem. So, before this patch, the `psych` gemspec installed would like like this:

```ruby
# -*- encoding: utf-8 -*-
# stub: psych 3.3.0 ruby lib
# stub: ext/psych/extconf.rb

Gem::Specification.new do |s|
  s.name = "psych".freeze
  s.version = "3.3.0"

  s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
  s.require_paths = ["lib".freeze]
  s.authors = ["Aaron Patterson".freeze, "SHIBATA Hiroshi".freeze, "Charles Oliver Nutter".freeze]
  s.date = "2021-07-08"
  s.description = "Psych is a YAML parser and emitter. Psych leverages libyaml[https://pyyaml.org/wiki/LibYAML]\nfor its YAML parsing and emitting capabilities. In addition to wrapping libyaml,\nPsych also knows how to serialize and de-serialize most Ruby objects to and from the YAML format.\n".freeze
  s.email = ["aaron@tenderlovemaking.com".freeze, "hsbt@ruby-lang.org".freeze, "headius@headius.com".freeze]
  s.extensions = ["ext/psych/extconf.rb".freeze]
  s.extra_rdoc_files = ["README.md".freeze]
  s.files = ["README.md".freeze, "ext/psych/extconf.rb".freeze, "psych.rb".freeze, "psych.so".freeze, "psych/class_loader.rb".freeze, "psych/coder.rb".freeze, "psych/core_ext.rb".freeze, "psych/exception.rb".freeze, "psych/handler.rb".freeze, "psych/handlers/document_stream.rb".freeze, "psych/handlers/recorder.rb".freeze, "psych/json/ruby_events.rb".freeze, "psych/json/stream.rb".freeze, "psych/json/tree_builder.rb".freeze, "psych/json/yaml_events.rb".freeze, "psych/nodes.rb".freeze, "psych/nodes/alias.rb".freeze, "psych/nodes/document.rb".freeze, "psych/nodes/mapping.rb".freeze, "psych/nodes/node.rb".freeze, "psych/nodes/scalar.rb".freeze, "psych/nodes/sequence.rb".freeze, "psych/nodes/stream.rb".freeze, "psych/omap.rb".freeze, "psych/parser.rb".freeze, "psych/scalar_scanner.rb".freeze, "psych/set.rb".freeze, "psych/stream.rb".freeze, "psych/streaming.rb".freeze, "psych/syntax_error.rb".freeze, "psych/tree_builder.rb".freeze, "psych/versions.rb".freeze, "psych/visitors.rb".freeze, "psych/visitors/depth_first.rb".freeze, "psych/visitors/emitter.rb".freeze, "psych/visitors/json_tree.rb".freeze, "psych/visitors/to_ruby.rb".freeze, "psych/visitors/visitor.rb".freeze, "psych/visitors/yaml_tree.rb".freeze, "psych/y.rb".freeze]
  s.homepage = "https://github.com/ruby/psych".freeze
  s.licenses = ["MIT".freeze]
  s.rdoc_options = ["--main".freeze, "README.md".freeze]
  s.required_ruby_version = Gem::Requirement.new(">= 2.4.0".freeze)
  s.rubygems_version = "3.3.0.dev".freeze
  s.summary = "Psych is a YAML parser and emitter".freeze
end
```

but now it looks like this (note the 4th comment on top of the file):

```ruby
# -*- encoding: utf-8 -*-
# stub: psych 3.3.0 ruby lib
# stub: ext/psych/extconf.rb
# files-stub: README.mdext/psych/extconf.rbpsych.rbpsych.sopsych/class_loader.rbpsych/coder.rbpsych/core_ext.rbpsych/exception.rbpsych/handler.rbpsych/handlers/document_stream.rbpsych/handlers/recorder.rbpsych/json/ruby_events.rbpsych/json/stream.rbpsych/json/tree_builder.rbpsych/json/yaml_events.rbpsych/nodes.rbpsych/nodes/alias.rbpsych/nodes/document.rbpsych/nodes/mapping.rbpsych/nodes/node.rbpsych/nodes/scalar.rbpsych/nodes/sequence.rbpsych/nodes/stream.rbpsych/omap.rbpsych/parser.rbpsych/scalar_scanner.rbpsych/set.rbpsych/stream.rbpsych/streaming.rbpsych/syntax_error.rbpsych/tree_builder.rbpsych/versions.rbpsych/visitors.rbpsych/visitors/depth_first.rbpsych/visitors/emitter.rbpsych/visitors/json_tree.rbpsych/visitors/to_ruby.rbpsych/visitors/visitor.rbpsych/visitors/yaml_tree.rbpsych/y.rb

Gem::Specification.new do |s|
  s.name = "psych".freeze
  s.version = "3.3.0"

  s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
  s.require_paths = ["lib".freeze]
  s.authors = ["Aaron Patterson".freeze, "SHIBATA Hiroshi".freeze, "Charles Oliver Nutter".freeze]
  s.date = "2021-07-08"
  s.description = "Psych is a YAML parser and emitter. Psych leverages libyaml[https://pyyaml.org/wiki/LibYAML]\nfor its YAML parsing and emitting capabilities. In addition to wrapping libyaml,\nPsych also knows how to serialize and de-serialize most Ruby objects to and from the YAML format.\n".freeze
  s.email = ["aaron@tenderlovemaking.com".freeze, "hsbt@ruby-lang.org".freeze, "headius@headius.com".freeze]
  s.extensions = ["ext/psych/extconf.rb".freeze]
  s.extra_rdoc_files = ["README.md".freeze]
  s.files = ["README.md".freeze, "ext/psych/extconf.rb".freeze, "psych.rb".freeze, "psych.so".freeze, "psych/class_loader.rb".freeze, "psych/coder.rb".freeze, "psych/core_ext.rb".freeze, "psych/exception.rb".freeze, "psych/handler.rb".freeze, "psych/handlers/document_stream.rb".freeze, "psych/handlers/recorder.rb".freeze, "psych/json/ruby_events.rb".freeze, "psych/json/stream.rb".freeze, "psych/json/tree_builder.rb".freeze, "psych/json/yaml_events.rb".freeze, "psych/nodes.rb".freeze, "psych/nodes/alias.rb".freeze, "psych/nodes/document.rb".freeze, "psych/nodes/mapping.rb".freeze, "psych/nodes/node.rb".freeze, "psych/nodes/scalar.rb".freeze, "psych/nodes/sequence.rb".freeze, "psych/nodes/stream.rb".freeze, "psych/omap.rb".freeze, "psych/parser.rb".freeze, "psych/scalar_scanner.rb".freeze, "psych/set.rb".freeze, "psych/stream.rb".freeze, "psych/streaming.rb".freeze, "psych/syntax_error.rb".freeze, "psych/tree_builder.rb".freeze, "psych/versions.rb".freeze, "psych/visitors.rb".freeze, "psych/visitors/depth_first.rb".freeze, "psych/visitors/emitter.rb".freeze, "psych/visitors/json_tree.rb".freeze, "psych/visitors/to_ruby.rb".freeze, "psych/visitors/visitor.rb".freeze, "psych/visitors/yaml_tree.rb".freeze, "psych/y.rb".freeze]
  s.homepage = "https://github.com/ruby/psych".freeze
  s.licenses = ["MIT".freeze]
  s.rdoc_options = ["--main".freeze, "README.md".freeze]
  s.required_ruby_version = Gem::Requirement.new(">= 2.4.0".freeze)
  s.rubygems_version = "3.3.0.dev".freeze
  s.summary = "Psych is a YAML parser and emitter".freeze
end
```
That way we can use the existing mechanism to avoid evaulating gemspecs if stub lines already include the information we need.

When rubygems is updated, all default gemspecs will be regenerated to include this line. When rubygems is downgraded, gemspecs are left there without that line, but I don't think that will cause any issues since the comment will be ignored by older rubygems.

The results I'm getting with this optimization are pretty unstable, but they show a consistent speedup. Compared to current master branch, rubygems boots ~20% faster, and the overhead of rubygems over ruby boot time goes from ~75% slower to ~50% slower.

```
$ hyperfine --prepare 'git checkout speedup && rake install' --command-name optimization 'ruby -e1' --prepare 'git checkout master && rake install' --command-name current 'ruby -e1'
Benchmark #1: optimization
  Time (mean ± σ):      71.8 ms ±   5.7 ms    [User: 59.0 ms, System: 15.0 ms]
  Range (min … max):    66.6 ms …  85.3 ms    10 runs
 
Benchmark #2: current
  Time (mean ± σ):      84.4 ms ±   4.2 ms    [User: 73.5 ms, System: 13.2 ms]
  Range (min … max):    79.2 ms …  90.7 ms    10 runs
 
Summary
  'optimization' ran
    1.18 ± 0.11 times faster than 'current'
```

```
$ hyperfine --prepare 'git checkout speedup && rake install' --command-name optimization 'ruby -e1' --prepare 'git checkout master && rake install' --command-name current 'ruby -e1' --prepare ''  --command-name without-rubygems 'ruby --disable-gems -e1'
Benchmark #1: optimization
  Time (mean ± σ):      67.8 ms ±   1.1 ms    [User: 59.9 ms, System: 10.0 ms]
  Range (min … max):    66.9 ms …  70.5 ms    10 runs
 
Benchmark #2: current
  Time (mean ± σ):      80.5 ms ±   0.7 ms    [User: 71.8 ms, System: 10.8 ms]
  Range (min … max):    79.7 ms …  81.7 ms    10 runs
 
Benchmark #3: without-rubygems
  Time (mean ± σ):      46.6 ms ±  10.4 ms    [User: 32.1 ms, System: 17.1 ms]
  Range (min … max):    33.0 ms …  78.1 ms    77 runs
 
Summary
  'without-rubygems' ran
    1.46 ± 0.33 times faster than 'optimization'
    1.73 ± 0.39 times faster than 'current'
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)