### PR TITLE
Disable minitest plugins

### DIFF
--- a/dev_gems.rb
+++ b/dev_gems.rb
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "rdoc", "6.2.0" # 6.2.1 is required > Ruby 2.3
 gem "minitest", "~> 5.14", ">= 5.14.2" # 5.14.2 is required to support Ruby 3.0
+gem "minitest-bisect", "~> 1.5"
 gem "simplecov", "~> 0.17.0"
 gem "rubocop", "~> 0.80.1"
 gem "rubocop-performance", "~> 1.5.2"

--- a/dev_gems.rb.lock
+++ b/dev_gems.rb.lock
@@ -31,6 +31,11 @@ GEM
     json (2.3.0)
     json (2.3.0-java)
     minitest (5.14.2)
+    minitest-bisect (1.5.1)
+      minitest-server (~> 1.0)
+      path_expander (~> 1.1)
+    minitest-server (1.0.6)
+      minitest (~> 5.0)
     multipart-post (2.1.1)
     mustache (1.1.1)
     netrc (0.11.0)
@@ -42,6 +47,7 @@ GEM
       parallel
     parser (2.7.0.5)
       ast (~> 2.4.0)
+    path_expander (1.1.0)
     public_suffix (4.0.6)
     rainbow (3.0.0)
     rdiscount (2.2.0.2)
@@ -91,6 +97,7 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk-s3 (~> 1.87)
   minitest (~> 5.14, >= 5.14.2)
+  minitest-bisect (~> 1.5)
   netrc (~> 0.11.0)
   octokit (~> 4.18)
   parallel_tests (~> 2.29)

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -32,6 +32,15 @@ else
   require 'bundler'
 end
 
+# Enable server plugin needed for bisection
+if ENV["RG_BISECT_SERVER_PLUGIN"]
+  require ENV["RG_BISECT_SERVER_PLUGIN"]
+
+  Minitest.extensions << "server"
+end
+
+ENV["MT_NO_PLUGINS"] = "true"
+
 require 'minitest/autorun'
 
 ENV["JARS_SKIP"] = "true" if Gem.java_platform? # avoid unnecessary and noisy `jar-dependencies` post install hook

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -26,7 +26,11 @@ begin
 rescue LoadError
 end
 
-require 'bundler'
+if File.exist?(bundler_gemspec)
+  require_relative '../../bundler/lib/bundler'
+else
+  require 'bundler'
+end
 
 require 'minitest/autorun'
 

--- a/util/bisect
+++ b/util/bisect
@@ -7,7 +7,6 @@ seed = begin
          abort "Specify the failing seed as the SEED environment variable"
        end
 
-ENV["RUBYOPT"] = "-Ilib:bundler/lib:test:#{Gem.dir}/gems/minitest-server-1.0.5/lib"
 ENV["MTB_VERBOSE"] = "2"
 
 begin

--- a/util/bisect
+++ b/util/bisect
@@ -9,8 +9,14 @@ seed = begin
 
 ENV["MTB_VERBOSE"] = "2"
 
+require_relative "../bundler/lib/bundler"
+
+locked_specs = Bundler::LockfileParser.new(File.read("dev_gems.rb.lock")).specs
+
+minitest_bisect_version = locked_specs.find{|spec| spec.name == "minitest-bisect" }.version
+
 begin
-  minitest_bisect = Gem.bin_path("minitest-bisect", "minitest_bisect")
+  minitest_bisect = Gem.bin_path("minitest-bisect", "minitest_bisect", minitest_bisect_version)
 rescue Gem::GemNotFoundException
   abort "Install minitest-bisect gem to run a rubygems test suite bisection"
 end

--- a/util/bisect
+++ b/util/bisect
@@ -12,6 +12,11 @@ ENV["MTB_VERBOSE"] = "2"
 require_relative "../bundler/lib/bundler"
 
 locked_specs = Bundler::LockfileParser.new(File.read("dev_gems.rb.lock")).specs
+minitest_server = locked_specs.find{|spec| spec.name == "minitest-server" }.full_name
+minitest_server_path = Gem::Specification.find_all_by_full_name(minitest_server).first.gem_dir
+minitest_server_plugin = Gem::Util.glob_files_in_dir("**/minitest/*_plugin.rb", minitest_server_path).first
+
+ENV["RG_BISECT_SERVER_PLUGIN"] = minitest_server_plugin
 
 minitest_bisect_version = locked_specs.find{|spec| spec.name == "minitest-bisect" }.version
 

--- a/util/bisect
+++ b/util/bisect
@@ -23,7 +23,7 @@ minitest_bisect_version = locked_specs.find{|spec| spec.name == "minitest-bisect
 begin
   minitest_bisect = Gem.bin_path("minitest-bisect", "minitest_bisect", minitest_bisect_version)
 rescue Gem::GemNotFoundException
-  abort "Install minitest-bisect gem to run a rubygems test suite bisection"
+  abort "Install minitest-bisect through `rake setup` to run a rubygems test suite bisection"
 end
 
 load minitest_bisect


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Minitest loads plugins from the whole gem system, making our tests less isolated.

I was getting this issue when running rubygems tests just because I had rails 6.0 and rails 6.1 installed.

```
Traceback (most recent call last):
	9: from /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/minitest-5.14.2/lib/minitest.rb:68:in `block in autorun'
	8: from /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/minitest-5.14.2/lib/minitest.rb:126:in `run'
	7: from /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/minitest-5.14.2/lib/minitest.rb:97:in `load_plugins'
	6: from /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/minitest-5.14.2/lib/minitest.rb:97:in `each'
	5: from /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/minitest-5.14.2/lib/minitest.rb:103:in `block in load_plugins'
	4: from /home/deivid/Code/rubygems/rubygems/lib/rubygems/core_ext/kernel_require.rb:85:in `require'
	3: from /home/deivid/Code/rubygems/rubygems/lib/rubygems/core_ext/kernel_require.rb:85:in `require'
	2: from /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/railties-6.0.3.4/lib/minitest/rails_plugin.rb:4:in `<top (required)>'
	1: from /home/deivid/Code/rubygems/rubygems/lib/rubygems/core_ext/kernel_require.rb:148:in `require'
/home/deivid/Code/rubygems/rubygems/lib/rubygems/core_ext/kernel_require.rb:148:in `require': cannot load such file -- rails/test_unit/reporter (LoadError)
	12: from /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/minitest-5.14.2/lib/minitest.rb:68:in `block in autorun'
	11: from /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/minitest-5.14.2/lib/minitest.rb:126:in `run'
	10: from /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/minitest-5.14.2/lib/minitest.rb:97:in `load_plugins'
	 9: from /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/minitest-5.14.2/lib/minitest.rb:97:in `each'
	 8: from /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/minitest-5.14.2/lib/minitest.rb:103:in `block in load_plugins'
	 7: from /home/deivid/Code/rubygems/rubygems/lib/rubygems/core_ext/kernel_require.rb:85:in `require'
	 6: from /home/deivid/Code/rubygems/rubygems/lib/rubygems/core_ext/kernel_require.rb:85:in `require'
	 5: from /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/railties-6.0.3.4/lib/minitest/rails_plugin.rb:4:in `<top (required)>'
	 4: from /home/deivid/Code/rubygems/rubygems/lib/rubygems/core_ext/kernel_require.rb:149:in `require'
	 3: from /home/deivid/Code/rubygems/rubygems/lib/rubygems/core_ext/kernel_require.rb:153:in `rescue in require'
	 2: from /home/deivid/Code/rubygems/rubygems/lib/rubygems.rb:209:in `try_activate'
	 1: from /home/deivid/Code/rubygems/rubygems/lib/rubygems/specification.rb:1111:in `activate'
/home/deivid/Code/rubygems/rubygems/lib/rubygems/specification.rb:1988:in `raise_if_conflicts': Unable to activate railties-6.0.3.4, because activesupport-6.1.0 conflicts with activesupport (= 6.0.3.4) (Gem::ConflictError)
	13: from /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/minitest-5.14.2/lib/minitest.rb:68:in `block in autorun'
	12: from /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/minitest-5.14.2/lib/minitest.rb:126:in `run'
	11: from /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/minitest-5.14.2/lib/minitest.rb:97:in `load_plugins'
	10: from /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/minitest-5.14.2/lib/minitest.rb:97:in `each'
	 9: from /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/minitest-5.14.2/lib/minitest.rb:103:in `block in load_plugins'
	 8: from /home/deivid/Code/rubygems/rubygems/lib/rubygems/core_ext/kernel_require.rb:85:in `require'
	 7: from /home/deivid/Code/rubygems/rubygems/lib/rubygems/core_ext/kernel_require.rb:85:in `require'
	 6: from /home/deivid/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/railties-6.0.3.4/lib/minitest/rails_plugin.rb:4:in `<top (required)>'
	 5: from /home/deivid/Code/rubygems/rubygems/lib/rubygems/core_ext/kernel_require.rb:149:in `require'
	 4: from /home/deivid/Code/rubygems/rubygems/lib/rubygems/core_ext/kernel_require.rb:153:in `rescue in require'
	 3: from /home/deivid/Code/rubygems/rubygems/lib/rubygems.rb:208:in `try_activate'
	 2: from /home/deivid/Code/rubygems/rubygems/lib/rubygems.rb:215:in `rescue in try_activate'
	 1: from /home/deivid/Code/rubygems/rubygems/lib/rubygems/specification.rb:1111:in `activate'
/home/deivid/Code/rubygems/rubygems/lib/rubygems/specification.rb:1988:in `raise_if_conflicts': Unable to activate railties-6.0.3.4, because activesupport-6.1.0 conflicts with activesupport (= 6.0.3.4) (Gem::ConflictError)
```

It makes no sense since our tests don't really use any rails stuff.

## What is your fix for the problem, implemented in this PR?

To workaround this issue, I enabled the `MT_NO_PLUGINS` environment variable that disables any minitest plugin loading. However, that would break our bisections that require the `minitest-server` and `minitest-bisect` plugins. So to workaround that what I did was to manually load those plugins when necessary.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)