### PR TITLE
Give a proper error if cache path does not have write access

### DIFF
--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -487,8 +487,15 @@ module Bundler
           uri = spec.remote.uri
           Bundler.ui.confirm("Fetching #{version_message(spec)}")
           rubygems_local_path = Bundler.rubygems.download_gem(spec, uri, download_path)
+
+          # older rubygems return varying file:// variants depending on version
+          rubygems_local_path = rubygems_local_path.gsub(/\Afile:/, "") unless Bundler.rubygems.provides?(">= 3.2.0.rc.2")
+          rubygems_local_path = rubygems_local_path.gsub(%r{\A//}, "") if Bundler.rubygems.provides?("< 3.1.0")
+
           if rubygems_local_path != local_path
-            FileUtils.mv(rubygems_local_path, local_path)
+            SharedHelpers.filesystem_access(local_path) do
+              FileUtils.mv(rubygems_local_path, local_path)
+            end
           end
           cache_globally(spec, local_path)
         end

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -580,8 +580,10 @@ RSpec.describe "bundle install with gem sources" do
   end
 
   describe "when bundle path does not have write access", :permissions do
+    let(:bundle_path) { bundled_app("vendor") }
+
     before do
-      FileUtils.mkdir_p(bundled_app("vendor"))
+      FileUtils.mkdir_p(bundle_path)
       gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
@@ -589,11 +591,11 @@ RSpec.describe "bundle install with gem sources" do
     end
 
     it "should display a proper message to explain the problem" do
-      FileUtils.chmod(0o500, bundled_app("vendor"))
+      FileUtils.chmod(0o500, bundle_path)
 
       bundle "config set --local path vendor"
       bundle :install, :raise_on_error => false
-      expect(err).to include(bundled_app("vendor").to_s)
+      expect(err).to include(bundle_path.to_s)
       expect(err).to include("grant write permissions")
     end
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If the cache path doesn't have write access, user will get a crash on `bundle install`.

## What is your fix for the problem, implemented in this PR?

My fix is to wrap the filesystem access with the proper rescues so that we give a proper error to the user.

Fixes https://github.com/rubygems/rubygems/issues/4210.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)