### PR TITLE
Fix running `rake release` from an ambiguous ref

### DIFF
--- a/bundler/lib/bundler/gem_helper.rb
+++ b/bundler/lib/bundler/gem_helper.rb
@@ -117,12 +117,13 @@ module Bundler
     def git_push(remote = nil)
       remote ||= default_remote
       perform_git_push remote
-      perform_git_push "#{remote} #{version_tag}"
+      perform_git_push "#{remote} refs/tags/#{version_tag}"
       Bundler.ui.confirm "Pushed git commits and release tag."
     end
 
     def default_remote
-      current_branch = sh(%w[git rev-parse --abbrev-ref HEAD]).strip
+      # We can replace this with `git branch --show-current` once we drop support for git < 2.22.0
+      current_branch = sh(%w[git rev-parse --abbrev-ref HEAD]).gsub(%r{\Aheads/}, "").strip
 
       remote_for_branch = sh(%W[git config --get branch.#{current_branch}.remote]).strip
       return "origin" if remote_for_branch.empty?

--- a/bundler/lib/bundler/gem_helper.rb
+++ b/bundler/lib/bundler/gem_helper.rb
@@ -123,7 +123,6 @@ module Bundler
 
     def default_remote
       current_branch = sh(%w[git rev-parse --abbrev-ref HEAD]).strip
-      return "origin" if current_branch.empty?
 
       remote_for_branch = sh(%W[git config --get branch.#{current_branch}.remote]).strip
       return "origin" if remote_for_branch.empty?

--- a/bundler/spec/bundler/gem_helper_spec.rb
+++ b/bundler/spec/bundler/gem_helper_spec.rb
@@ -256,6 +256,16 @@ RSpec.describe Bundler::GemHelper do
 
             Rake.application["release"].invoke
           end
+
+          it "also works when releasing from an ambiguous reference" do
+            # Create a branch with the same name as the tag
+            sys_exec("git checkout -b v#{app_version}", :dir => app_path)
+            sys_exec("git push -u origin v#{app_version}", :dir => app_path)
+
+            expect(subject).to receive(:rubygem_push).with(app_gem_path.to_s)
+
+            Rake.application["release"].invoke
+          end
         end
 
         context "on releasing with a custom tag prefix" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In bundler 2.2.0, we started pushing only the explicit tag that we are
releasing, as opposed to all local tags, because pushing all tags is unnecessary
and can lead to surprising results depending on your local remotes.

However, with this change we need to manually extract the remote to push to, and
for that we hadn't considered the edge case of releasing from an ambigous
reference, for example, releasing from a branch with the same name as the tag.

## What is your fix for the problem, implemented in this PR?

My fix is to consider that `git rev-parse --abbrev-ref HEAD` will return a
qualified reference name if the current HEAD ref is ambiguous, and also to pass
a qualified ref to `git push` when pushing the tag because otherwise it will
fail for the same reason.

Fixes https://github.com/rubygems/rubygems/issues/4218.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)