### PR TITLE
Improve rubocop setup in the new gem template

### DIFF
--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -147,6 +147,7 @@ module Bundler
         "For more information, see the RuboCop docs (https://docs.rubocop.org/en/stable/) " \
         "and the Ruby Style Guides (https://github.com/rubocop-hq/ruby-style-guide).")
         config[:rubocop] = true
+        config[:rubocop_version] = Gem.ruby_version < Gem::Version.new("2.4.a") ? "0.80.1" : "0.90.0"
         Bundler.ui.info "RuboCop enabled in config"
         templates.merge!("rubocop.yml.tt" => ".rubocop.yml")
       end

--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -59,6 +59,7 @@ module Bundler
         :exe              => options[:exe],
         :bundler_version  => bundler_dependency_version,
         :github_username  => github_username.empty? ? "[USERNAME]" : github_username,
+        :required_ruby_version => Gem.ruby_version < Gem::Version.new("2.4.a") ? "2.3.0" : "2.4.0",
       }
       ensure_safe_gem_name(name, constant_array)
 

--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -147,7 +147,7 @@ module Bundler
         "For more information, see the RuboCop docs (https://docs.rubocop.org/en/stable/) " \
         "and the Ruby Style Guides (https://github.com/rubocop-hq/ruby-style-guide).")
         config[:rubocop] = true
-        config[:rubocop_version] = Gem.ruby_version < Gem::Version.new("2.4.a") ? "0.80.1" : "0.90.0"
+        config[:rubocop_version] = Gem.ruby_version < Gem::Version.new("2.4.a") ? "0.81.0" : "1.7"
         Bundler.ui.info "RuboCop enabled in config"
         templates.merge!("rubocop.yml.tt" => ".rubocop.yml")
       end

--- a/bundler/lib/bundler/templates/newgem/Gemfile.tt
+++ b/bundler/lib/bundler/templates/newgem/Gemfile.tt
@@ -16,5 +16,5 @@ gem "<%= config[:test] %>", "~> <%= config[:test_framework_version] %>"
 <%- end -%>
 <%- if config[:rubocop] -%>
 
-gem "rubocop", "~> 0.80"
+gem "rubocop", "~> <%= config[:rubocop_version] %>"
 <%- end -%>

--- a/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
 <%- if config[:mit] -%>
   spec.license       = "MIT"
 <%- end -%>
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= <%= config[:required_ruby_version] %>")
 
   spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
 

--- a/bundler/lib/bundler/templates/newgem/rubocop.yml.tt
+++ b/bundler/lib/bundler/templates/newgem/rubocop.yml.tt
@@ -1,3 +1,6 @@
+AllCops:
+  TargetRubyVersion: <%= ::Gem::Version.new(config[:required_ruby_version]).segments[0..1].join(".") %>
+
 Style/StringLiterals:
   Enabled: true
   EnforcedStyle: double_quotes

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe "bundle gem" do
 
   def bundle_exec_rubocop
     prepare_gemspec(bundled_app(gem_name, "#{gem_name}.gemspec"))
-    rubocop_version = RUBY_VERSION > "2.4" ? "0.90.0" : "0.80.1"
+    rubocop_version = RUBY_VERSION > "2.4" ? "1.7.0" : "0.81.0"
     gems = ["minitest", "rake", "rake-compiler", "rspec", "rubocop -v #{rubocop_version}", "test-unit"]
     gems.unshift "parallel -v 1.19.2" if RUBY_VERSION < "2.5"
-    gems += ["rubocop-ast -v 0.4.0"] if rubocop_version == "0.90.0"
+    gems += ["rubocop-ast -v 1.4.0"] if rubocop_version == "1.7.0"
     path = Bundler.feature_flag.default_install_uses_path? ? local_gem_path(:base => bundled_app(gem_name)) : system_gem_path
     realworld_system_gems gems, :path => path
     bundle "exec rubocop --debug --config .rubocop.yml", :dir => bundled_app(gem_name)

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -416,9 +416,7 @@ RSpec.describe "bundle gem" do
     it "sets a minimum ruby version" do
       bundle "gem #{gem_name}"
 
-      bundler_gemspec = Bundler::GemHelper.new(gemspec_dir).gemspec
-
-      expect(bundler_gemspec.required_ruby_version).to eq(generated_gemspec.required_ruby_version)
+      expect(generated_gemspec.required_ruby_version).to eq(Gem::Requirement.new(Gem.ruby_version < Gem::Version.new("2.4.a") ? ">= 2.3.0" : ">= 2.4.0"))
     end
 
     it "requires the version file" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

By default, until we drop support for ruby 2.3 and ruby 2.4, we generate gems that still specific ruby 2.3 as the minimum version.

However, in the generated Gemfile we specify `~> 0.80` as the rubocop constraint. This will end up install a rubocop version that doesn't actually support ruby 2.3.

The gem author may not notice that and might end up pushing a gem that does not support ruby 2.3 while claiming it does.

## What is your fix for the problem, implemented in this PR?

My fix is to specify a target rubocop version in the generated configuration and make sure that a version supporting it is specified in the Gemfile.

Closes #4231.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)