### PR TITLE
Fix broken `bundler` executable after `gem update --system`

### DIFF
--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -375,9 +375,7 @@ By default, this RubyGems will install gem as:
     specs_dir = File.join(options[:destdir], specs_dir) unless Gem.win_platform?
     mkdir_p specs_dir, :mode => 0755
 
-    bundler_spec = Gem::Specification.load("bundler/bundler.gemspec")
-    bundler_spec.files = Dir.chdir("bundler") { Dir["{*.md,{lib,exe}/**/*}"] }
-    bundler_spec.executables -= %w[bundler bundle_ruby]
+    bundler_spec = Dir.chdir("bundler") { Gem::Specification.load("bundler.gemspec") }
 
     # Remove bundler-*.gemspec in default specification directory.
     Dir.entries(specs_dir).

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -24,6 +24,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
       lib/rubygems/test_case.rb
       lib/rubygems/ssl_certs/rubygems.org/foo.pem
       bundler/exe/bundle
+      bundler/exe/bundler
       bundler/lib/bundler.rb
       bundler/lib/bundler/b.rb
       bundler/bin/bundler/man/bundle-b.1
@@ -41,7 +42,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     gemspec.name = "bundler"
     gemspec.version = BUNDLER_VERS
     gemspec.bindir = "exe"
-    gemspec.executables = ["bundle"]
+    gemspec.executables = ["bundle", "bundler"]
 
     File.open 'bundler/bundler.gemspec', 'w' do |io|
       io.puts gemspec.to_ruby
@@ -135,6 +136,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     exec_line = out.shift until exec_line == "RubyGems installed the following executables:"
     assert_equal "\t#{default_gem_bin_path}", out.shift
     assert_equal "\t#{default_bundle_bin_path}", out.shift
+    assert_equal "\t#{default_bundler_bin_path}", out.shift
   end
 
   def test_env_shebang_flag
@@ -152,6 +154,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     bin_env = win_platform? ? "" : %w[/usr/bin/env /bin/env].find {|f| File.executable?(f) } + " "
     assert_match %r{\A#!\s*#{bin_env}#{ruby_exec}}, File.read(default_gem_bin_path)
     assert_match %r{\A#!\s*#{bin_env}#{ruby_exec}}, File.read(default_bundle_bin_path)
+    assert_match %r{\A#!\s*#{bin_env}#{ruby_exec}}, File.read(default_bundler_bin_path)
     assert_match %r{\A#!\s*#{bin_env}#{ruby_exec}}, File.read(gem_bin_path)
   end
 
@@ -386,5 +389,9 @@ class TestGemCommandsSetupCommand < Gem::TestCase
 
   def default_bundle_bin_path
     File.join @install_dir, 'bin', 'bundle'
+  end
+
+  def default_bundler_bin_path
+    File.join @install_dir, 'bin', 'bundler'
   end
 end unless Gem.java_platform?


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

After running `gem update --system`, the `bundler` executable no longer works.

## What is your fix for the problem, implemented in this PR?

For some reason we were "editing" the default bundler gemspec before installing it. This PR removes all that to restore a working `bundler` command after `gem update --system`.

Fixes #4217.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)