### PR TITLE
Stop linking to outdated page in release blog post

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -309,9 +309,7 @@ To update to the latest RubyGems you can run:
 
     gem update --system
 
-If you need to upgrade or downgrade please follow the [how to upgrade/downgrade
-RubyGems][upgrading] instructions.  To install RubyGems by hand see the
-[Download RubyGems][download] page.
+To install RubyGems by hand see the [Download RubyGems][download] page.
 
 #{history.release_notes_for_blog.join("\n")}
 
@@ -320,7 +318,6 @@ SHA256 Checksums:
 #{checksums}
 
 [download]: https://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
 
       ANNOUNCEMENT
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We're linking to this outdated page in our rubygems release blog post.

## What is your fix for the problem, implemented in this PR?

Remove it, it doesn't seem necessary.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)