### PR TITLE
Support repositories with default branch not named master

### DIFF
--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -191,7 +191,7 @@ module Bundler
 
         def find_local_revision
           allowed_with_path do
-            git("rev-parse", "--verify", ref, :dir => path).strip
+            git("rev-parse", "--verify", ref || "HEAD", :dir => path).strip
           end
         rescue GitCommandError => e
           raise MissingGitRevisionError.new(e.command, path, ref, URICredentialsFilter.credential_filtered_uri(uri))

--- a/bundler/spec/bundler/source/git_spec.rb
+++ b/bundler/spec/bundler/source/git_spec.rb
@@ -14,14 +14,14 @@ RSpec.describe Bundler::Source::Git do
 
   describe "#to_s" do
     it "returns a description" do
-      expect(subject.to_s).to eq "https://github.com/foo/bar.git (at master)"
+      expect(subject.to_s).to eq "https://github.com/foo/bar.git"
     end
 
     context "when the URI contains credentials" do
       let(:uri) { "https://my-secret-token:x-oauth-basic@github.com/foo/bar.git" }
 
       it "filters credentials" do
-        expect(subject.to_s).to eq "https://x-oauth-basic@github.com/foo/bar.git (at master)"
+        expect(subject.to_s).to eq "https://x-oauth-basic@github.com/foo/bar.git"
       end
     end
   end

--- a/bundler/spec/install/deploy_spec.rb
+++ b/bundler/spec/install/deploy_spec.rb
@@ -341,7 +341,7 @@ RSpec.describe "install in deployment or frozen mode" do
       bundle "config set --local deployment true"
       bundle :install, :raise_on_error => false
       expect(err).to include("deployment mode")
-      expect(err).to include("You have added to the Gemfile:\n* source: git://hubz.com (at master)")
+      expect(err).to include("You have added to the Gemfile:\n* source: git://hubz.com")
       expect(err).not_to include("You have changed in the Gemfile")
     end
 
@@ -361,7 +361,7 @@ RSpec.describe "install in deployment or frozen mode" do
       bundle "config set --local deployment true"
       bundle :install, :raise_on_error => false
       expect(err).to include("deployment mode")
-      expect(err).to include("You have deleted from the Gemfile:\n* source: #{lib_path("rack-1.0")} (at master@#{revision_for(lib_path("rack-1.0"))[0..6]}")
+      expect(err).to include("You have deleted from the Gemfile:\n* source: #{lib_path("rack-1.0")}")
       expect(err).not_to include("You have added to the Gemfile")
       expect(err).not_to include("You have changed in the Gemfile")
     end
@@ -385,7 +385,7 @@ RSpec.describe "install in deployment or frozen mode" do
       bundle "config set --local deployment true"
       bundle :install, :raise_on_error => false
       expect(err).to include("deployment mode")
-      expect(err).to include("You have changed in the Gemfile:\n* rack from `no specified source` to `#{lib_path("rack")} (at master@#{revision_for(lib_path("rack"))[0..6]})`")
+      expect(err).to include("You have changed in the Gemfile:\n* rack from `no specified source` to `#{lib_path("rack")}`")
       expect(err).not_to include("You have added to the Gemfile")
       expect(err).not_to include("You have deleted from the Gemfile")
     end

--- a/bundler/spec/install/git_spec.rb
+++ b/bundler/spec/install/git_spec.rb
@@ -13,6 +13,17 @@ RSpec.describe "bundle install" do
       expect(the_bundle).to include_gems "foo 1.0", :source => "git@#{lib_path("foo")}"
     end
 
+    it "displays the correct default branch" do
+      build_git "foo", "1.0", :path => lib_path("foo"), :default_branch => "main"
+
+      install_gemfile <<-G, :verbose => true
+        gem "foo", :git => "#{file_uri_for(lib_path("foo"))}"
+      G
+
+      expect(out).to include("Using foo 1.0 from #{file_uri_for(lib_path("foo"))} (at main@#{revision_for(lib_path("foo"))[0..6]})")
+      expect(the_bundle).to include_gems "foo 1.0", :source => "git@#{lib_path("foo")}"
+    end
+
     it "displays the ref of the gem repository when using branch~num as a ref" do
       skip "maybe branch~num notation doesn't work on Windows' git" if Gem.win_platform?
 

--- a/bundler/spec/install/git_spec.rb
+++ b/bundler/spec/install/git_spec.rb
@@ -2,10 +2,10 @@
 
 RSpec.describe "bundle install" do
   context "git sources" do
-    it "displays the revision hash of the gem repository", :bundler => "< 3" do
+    it "displays the revision hash of the gem repository" do
       build_git "foo", "1.0", :path => lib_path("foo")
 
-      install_gemfile <<-G
+      install_gemfile <<-G, :verbose => true
         gem "foo", :git => "#{file_uri_for(lib_path("foo"))}"
       G
 
@@ -13,7 +13,7 @@ RSpec.describe "bundle install" do
       expect(the_bundle).to include_gems "foo 1.0", :source => "git@#{lib_path("foo")}"
     end
 
-    it "displays the ref of the gem repository when using branch~num as a ref", :bundler => "< 3" do
+    it "displays the ref of the gem repository when using branch~num as a ref" do
       skip "maybe branch~num notation doesn't work on Windows' git" if Gem.win_platform?
 
       build_git "foo", "1.0", :path => lib_path("foo")
@@ -22,7 +22,7 @@ RSpec.describe "bundle install" do
       rev2 = revision_for(lib_path("foo"))[0..6]
       update_git "foo", "3.0", :path => lib_path("foo"), :gemspec => true
 
-      install_gemfile <<-G
+      install_gemfile <<-G, :verbose => true
         gem "foo", :git => "#{file_uri_for(lib_path("foo"))}", :ref => "master~2"
       G
 
@@ -31,7 +31,7 @@ RSpec.describe "bundle install" do
 
       update_git "foo", "4.0", :path => lib_path("foo"), :gemspec => true
 
-      bundle :update, :all => true
+      bundle :update, :all => true, :verbose => true
       expect(out).to include("Using foo 2.0 (was 1.0) from #{file_uri_for(lib_path("foo"))} (at master~2@#{rev2})")
       expect(the_bundle).to include_gems "foo 2.0", :source => "git@#{lib_path("foo")}"
     end

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -1134,7 +1134,7 @@ RSpec.describe "the lockfile format" do
     G
 
     expect(bundled_app_lock).not_to exist
-    expect(err).to include "rack (>= 0) should come from an unspecified source and git://hubz.com (at master)"
+    expect(err).to include "rack (>= 0) should come from an unspecified source and git://hubz.com"
   end
 
   it "works correctly with multiple version dependencies" do

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -547,9 +547,11 @@ module Spec
 
     class GitBuilder < LibBuilder
       def _build(options)
+        default_branch = options[:default_branch] || "master"
         path = options[:path] || _default_path
         source = options[:source] || "git@#{path}"
         super(options.merge(:path => path, :source => source))
+        @context.git("config --global init.defaultBranch #{default_branch}", path)
         @context.git("init", path)
         @context.git("add *", path)
         @context.git("config user.email lol@wut.com", path)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Bundler doesn't support non-master default branches, so you can't currently point to, for example, [simplecov's repo](https://github.com/simplecov-ruby/simplecov), unless you add an explicit `branch: => "main"` to your git sources configuration.

Bundler should just work in this case without having to make the default branch explicit.

## What is your fix for the problem, implemented in this PR?

My fix is to make sure the code doesn't assume a specific branch until we have actually cloned the repository. This means that when a git sources is printed, it no longer includes "master" if  the source is only present in the `Gemfile` and has not yet been installed.

Fixes #4009.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)