### PR TITLE
Restore support for old git versions

### DIFF
--- a/.github/workflows/legacy-git.yml
+++ b/.github/workflows/legacy-git.yml
@@ -1,0 +1,25 @@
+name: legacy-git
+
+on:
+  pull_request:
+
+  push:
+    branches:
+      - master
+      - 3.2
+
+jobs:
+  legacy_git:
+    name: Verify behavior under old git
+    runs-on: ubuntu-20.04
+    container:
+      image: centos/ruby-27-centos7@sha256:b24b875dcdb6cb8f2145706dcaac74bb25ae3b9d9f7ba69d7ae700a7aee1e1bd
+      options: --user=root
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install rubygems
+        run: ruby setup.rb
+      - name: Check we can install a Gemfile with git sources
+        run: bundle init && bundle add fileutils --git https://github.com/ruby/fileutils
+
+    timeout-minutes: 10

--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -156,7 +156,7 @@ module Bundler
         end
 
         def git_retry(*command, dir: SharedHelpers.pwd)
-          Bundler::Retry.new("`git -C #{dir} #{URICredentialsFilter.credential_filtered_string(command.shelljoin, uri)}`", GitNotAllowedError).attempts do
+          Bundler::Retry.new("`git #{URICredentialsFilter.credential_filtered_string(command.shelljoin, uri)}` at #{dir}", GitNotAllowedError).attempts do
             git(*command, :dir => dir)
           end
         end

--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -17,7 +17,7 @@ module Bundler
       class GitNotAllowedError < GitError
         def initialize(command)
           msg = String.new
-          msg << "Bundler is trying to run a `git #{command}` at runtime. You probably need to run `bundle install`. However, "
+          msg << "Bundler is trying to run `git #{command}` at runtime. You probably need to run `bundle install`. However, "
           msg << "this error message could probably be more useful. Please submit a ticket at https://github.com/rubygems/rubygems/issues/new?labels=Bundler&template=bundler-related-issue.md "
           msg << "with steps to reproduce as well as the following\n\nCALLER: #{caller.join("\n")}"
           super msg

--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -168,9 +168,11 @@ module Bundler
             capture_and_filter_stderr("git", "-C", dir.to_s, *command)
           end
 
-          raise GitCommandError.new(command_with_no_credentials, dir) unless status.success?
+          filtered_out = URICredentialsFilter.credential_filtered_string(out, uri)
 
-          URICredentialsFilter.credential_filtered_string(out, uri)
+          raise GitCommandError.new(command_with_no_credentials, dir, filtered_out) unless status.success?
+
+          filtered_out
         end
 
         def has_revision_cached?

--- a/bundler/spec/bundler/source/git/git_proxy_spec.rb
+++ b/bundler/spec/bundler/source/git/git_proxy_spec.rb
@@ -130,17 +130,18 @@ RSpec.describe Bundler::Source::Git::GitProxy do
     context "when given a SHA as a revision" do
       let(:revision) { "abcd" * 10 }
       let(:command) { ["reset", "--hard", revision] }
+      let(:command_for_display) { "git #{command.shelljoin}" }
 
       it "fails gracefully when resetting to the revision fails" do
         expect(subject).to receive(:git_retry).with("clone", any_args) { destination.mkpath }
         expect(subject).to receive(:git_retry).with("fetch", any_args, :dir => destination)
-        expect(subject).to receive(:git).with(*command, :dir => destination).and_raise(Bundler::Source::Git::GitCommandError.new(command, destination))
+        expect(subject).to receive(:git).with(*command, :dir => destination).and_raise(Bundler::Source::Git::GitCommandError.new(command_for_display, destination))
         expect(subject).not_to receive(:git)
 
         expect { subject.copy_to(destination, submodules) }.
           to raise_error(
             Bundler::Source::Git::MissingGitRevisionError,
-            "Git error: command `git #{command}` in directory #{destination} has failed.\n" \
+            "Git error: command `#{command_for_display}` in directory #{destination} has failed.\n" \
             "Revision #{revision} does not exist in the repository #{uri}. Maybe you misspelled it?\n" \
             "If this error persists you could try removing the cache directory '#{destination}'"
           )

--- a/bundler/spec/bundler/source/git/git_proxy_spec.rb
+++ b/bundler/spec/bundler/source/git/git_proxy_spec.rb
@@ -134,14 +134,15 @@ RSpec.describe Bundler::Source::Git::GitProxy do
       it "fails gracefully when resetting to the revision fails" do
         expect(subject).to receive(:git_retry).with("clone", any_args) { destination.mkpath }
         expect(subject).to receive(:git_retry).with("fetch", any_args, :dir => destination)
-        expect(subject).to receive(:git).with(*command, :dir => destination).and_raise(Bundler::Source::Git::GitCommandError.new(command, cache, destination))
+        expect(subject).to receive(:git).with(*command, :dir => destination).and_raise(Bundler::Source::Git::GitCommandError.new(command, destination))
         expect(subject).not_to receive(:git)
 
         expect { subject.copy_to(destination, submodules) }.
           to raise_error(
             Bundler::Source::Git::MissingGitRevisionError,
             "Git error: command `git #{command}` in directory #{destination} has failed.\n" \
-            "Revision #{revision} does not exist in the repository #{uri}. Maybe you misspelled it?" \
+            "Revision #{revision} does not exist in the repository #{uri}. Maybe you misspelled it?\n" \
+            "If this error persists you could try removing the cache directory '#{destination}'"
           )
       end
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

#4196 introduced using the `git -C` flag to workaround some JRuby issues on Windows. However, the `-C` flag is only supported since git 1.8.5, and some environments still have an old git. In particular, CentOS 7 ships an older git.

## What is your fix for the problem, implemented in this PR?

My fix is to restore the previous behavior if running on old git version, and to schedule dropping support for old git versions in bundler 3.

Fixes #4229.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
