### PR TITLE
Tweak the CI configuration on JRuby

### DIFF
--- a/.github/workflows/ubuntu-rubygems.yml
+++ b/.github/workflows/ubuntu-rubygems.yml
@@ -35,7 +35,10 @@ jobs:
         run: rake setup
       - name: Run Test
         run: rake test
-        if: "!startsWith(matrix.ruby.name, 'truffleruby')"
+        if: "!startsWith(matrix.ruby.name, 'truffleruby') && !startsWith(matrix.ruby.name, 'jruby')"
+      - name: Run Test (JRuby)
+        run: JRUBY_OPTS=--debug rake test
+        if: startsWith(matrix.ruby.name, 'jruby')
       - name: Run Test (Truffleruby)
         run: TRUFFLERUBYOPT="--experimental-options --testing-rubygems" rake test
         if: startsWith(matrix.ruby.name, 'truffleruby')

--- a/.github/workflows/ubuntu-rubygems.yml
+++ b/.github/workflows/ubuntu-rubygems.yml
@@ -24,8 +24,6 @@ jobs:
           - { name: "3.0", value: 3.0.0 }
           - { name: jruby-9.2, value: jruby-9.2.14.0 }
           - { name: truffleruby-20.3, value: truffleruby-20.3.0 }
-    env:
-      TRUFFLERUBYOPT: "--experimental-options --testing-rubygems"
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby
@@ -37,4 +35,9 @@ jobs:
         run: rake setup
       - name: Run Test
         run: rake test
+        if: "!startsWith(matrix.ruby.name, 'truffleruby')"
+      - name: Run Test (Truffleruby)
+        run: TRUFFLERUBYOPT="--experimental-options --testing-rubygems" rake test
+        if: startsWith(matrix.ruby.name, 'truffleruby')
+
     timeout-minutes: 60

--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -83,7 +83,7 @@ class TestGemRequirement < Gem::TestCase
       Gem::Requirement.parse(Gem::Version.new('2'))
   end
 
-  if RUBY_VERSION >= '2.5'
+  if RUBY_VERSION >= '2.5' && !(Gem.java_platform? && ENV["JRUBY_OPTS"] =~ /--debug/)
     def test_parse_deduplication
       assert_same '~>', Gem::Requirement.parse('~> 1').first
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

A flaky on jruby: https://github.com/rubygems/rubygems/pull/4224/checks?check_run_id=1650864997.

## What is your fix for the problem, implemented in this PR?

No fix, but this should avoid a bunch of warnings that I noticed on that CI log,
and who knows, maybe help with the flaky too.

The problem happens at the very end of the test run, and when that happens,
simplecov is usually involved.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)