### PR TITLE
Reduce the number of CI jobs

### DIFF
--- a/.github/workflows/older-rubygems-bundler.yml
+++ b/.github/workflows/older-rubygems-bundler.yml
@@ -19,42 +19,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby:
-          - { name: ruby-2.3, value: 2.3.8 }
-          - { name: ruby-2.4, value: 2.4.10 }
-          - { name: ruby-2.5, value: 2.5.8 }
-          - { name: ruby-2.6, value: 2.6.6 }
-          - { name: ruby-2.7, value: 2.7.2 }
-          - { name: ruby-3.0, value: 3.0.0 }
-        rgv:
-          - { name: rgv-2.5, value: v2.5.2 }
-          - { name: rgv-2.6, value: v2.6.14 }
-          - { name: rgv-2.7, value: v2.7.11 }
-          - { name: rgv-3.0, value: v3.0.9 }
-          - { name: rgv-3.1, value: v3.1.5 }
-          - { name: rgv-3.2, value: v3.2.4 }
-
-        bundler:
-          - { name: 2, value: '' }
-
-        exclude:
-          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.4, value: 2.4.10 }, rgv: { name: rgv-2.5, value: v2.5.2 } }
-          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.5, value: 2.5.8 }, rgv: { name: rgv-2.5, value: v2.5.2 } }
-          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.5, value: 2.5.8 }, rgv: { name: rgv-2.6, value: v2.6.14 } }
-          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.6, value: 2.6.6 }, rgv: { name: rgv-2.5, value: v2.5.2 } }
-          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.6, value: 2.6.6 }, rgv: { name: rgv-2.6, value: v2.6.14 } }
-          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.6, value: 2.6.6 }, rgv: { name: rgv-2.7, value: v2.7.11 } }
-          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.2 }, rgv: { name: rgv-2.5, value: v2.5.2 } }
-          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.2 }, rgv: { name: rgv-2.6, value: v2.6.14 } }
-          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.2 }, rgv: { name: rgv-2.7, value: v2.7.11 } }
-          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.2 }, rgv: { name: rgv-3.0, value: v3.0.9 } }
-          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.0 }, rgv: { name: rgv-2.5, value: v2.5.2 } }
-          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.0 }, rgv: { name: rgv-2.6, value: v2.6.14 } }
-          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.0 }, rgv: { name: rgv-2.7, value: v2.7.11 } }
-          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.0 }, rgv: { name: rgv-3.0, value: v3.0.9 } }
-          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.0 }, rgv: { name: rgv-3.1, value: v3.1.5 } }
-
         include:
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.3, value: 2.3.8 }, rgv: { name: rgv-2.5, value: v2.5.2 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.3, value: 2.3.8 }, rgv: { name: rgv-3.2, value: v3.2.4 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.4, value: 2.4.10 }, rgv: { name: rgv-2.6, value: v2.6.14 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.4, value: 2.4.10 }, rgv: { name: rgv-3.2, value: v3.2.4 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.5, value: 2.5.8 }, rgv: { name: rgv-2.7, value: v2.7.11 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.5, value: 2.5.8 }, rgv: { name: rgv-3.2, value: v3.2.4 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.6, value: 2.6.6 }, rgv: { name: rgv-3.0, value: v3.0.9 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.6, value: 2.6.6 }, rgv: { name: rgv-3.2, value: v3.2.4 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.2 }, rgv: { name: rgv-3.1, value: v3.1.5 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.2 }, rgv: { name: rgv-3.2, value: v3.2.4 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.0 }, rgv: { name: rgv-3.2, value: v3.2.4 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.4, value: 2.4.10 }, rgv: { name: rgv-3.2, value: v3.2.4 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.5, value: 2.5.8 }, rgv: { name: rgv-3.2, value: v3.2.4 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.6, value: 2.6.6 }, rgv: { name: rgv-3.2, value: v3.2.4 } }


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The problem is that we have a very big CI matrix and we still need to add entries for the recent ruby 3.0.0 and rubygems 3.2.x releases.

## What is your fix for the problem, implemented in this PR?

My fix is to reduce the number of CI jobs. The rationale for keeping these jobs is that normally bundler is run against either the rubygems version that ships with ruby, or the latest rubygems version if it has been upgraded. Upgrades to intermediate versions of rubygems are quite rare, so I think we can skip all jobs in the middle.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)