### PR TITLE
Prefer `RUBY_PLATFORM`  to `RbConfig` to extract the local platform when it has the CPU embedded

### DIFF
--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -76,6 +76,7 @@ class Gem::Platform
 
       @cpu = case cpu
              when /i\d86/ then 'x86'
+             when /universal\.(.*)/ then $1
              else cpu
              end
 

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -13,6 +13,7 @@ class Gem::Platform
 
   def self.local
     arch = RbConfig::CONFIG['arch']
+    arch = RUBY_PLATFORM if RUBY_PLATFORM =~ /universal\..*darwin/
     arch = "#{arch}_60" if arch =~ /mswin(?:32|64)$/
     @local ||= new(arch)
   end

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -981,14 +981,11 @@ Also, a list:
 
   def util_set_arch(arch)
     RbConfig::CONFIG['arch'] = arch
-    platform = Gem::Platform.new arch
 
     Gem.instance_variable_set :@platforms, nil
     Gem::Platform.instance_variable_set :@local, nil
 
     yield if block_given?
-
-    platform
   end
 
   ##

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -296,8 +296,7 @@ class Gem::TestCase < Minitest::Test
   # directed to a temporary directory.  All install plugins are removed.
   #
   # If the +RUBY+ environment variable is set the given path is used for
-  # Gem::ruby.  The local platform is set to <tt>i386-mswin32</tt> for Windows
-  # or <tt>i686-darwin8.10.1</tt> otherwise.
+  # Gem::ruby.
 
   def setup
     @orig_env = ENV.to_hash
@@ -409,14 +408,6 @@ class Gem::TestCase < Minitest::Test
     Gem.searcher = nil
     Gem::SpecFetcher.fetcher = nil
 
-    @orig_arch = RbConfig::CONFIG['arch']
-
-    if win_platform?
-      util_set_arch 'i386-mswin32'
-    else
-      util_set_arch 'i686-darwin8.10.1'
-    end
-
     @orig_hooks = {}
     %w[post_install_hooks done_installing_hooks post_uninstall_hooks pre_uninstall_hooks pre_install_hooks pre_reset_hooks post_reset_hooks post_build_hooks].each do |name|
       @orig_hooks[name] = Gem.send(name).dup
@@ -441,8 +432,6 @@ class Gem::TestCase < Minitest::Test
         $LOADED_FEATURES.replace @orig_LOADED_FEATURES
       end
     end
-
-    RbConfig::CONFIG['arch'] = @orig_arch
 
     if defined? Gem::RemoteFetcher
       Gem::RemoteFetcher.fetcher = nil

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -1000,7 +1000,7 @@ Also, a list:
 
     RbConfig::CONFIG['arch'] = arch
 
-    Gem.instance_variable_set :@platforms, nil
+    Gem.platforms = []
     Gem::Platform.instance_variable_set :@local, nil
 
     orig_arch

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -977,15 +977,33 @@ Also, a list:
   end
 
   ##
-  # Set the platform to +arch+
+  # Set the platform to +arch+, and restore the previous value if a block is
+  # given
 
   def util_set_arch(arch)
+    orig_arch = util_change_arch(arch)
+
+    return unless block_given?
+
+    begin
+      yield
+    ensure
+      util_change_arch(orig_arch)
+    end
+  end
+
+  ##
+  # Set the platform to +arch+ and return the previous value
+
+  def util_change_arch(arch)
+    orig_arch = RbConfig::CONFIG['arch']
+
     RbConfig::CONFIG['arch'] = arch
 
     Gem.instance_variable_set :@platforms, nil
     Gem::Platform.instance_variable_set :@local, nil
 
-    yield if block_given?
+    orig_arch
   end
 
   ##

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -1431,20 +1431,24 @@ ERROR:  Possible alternatives: non_existent_with_hint
     # equivalent to --platform=ruby
     Gem.platforms = [Gem::Platform::RUBY]
 
-    @cmd.options[:explain] = true
-    @cmd.options[:args] = %w[a]
+    begin
+      @cmd.options[:explain] = true
+      @cmd.options[:args] = %w[a]
 
-    use_ui @ui do
-      assert_raises Gem::MockGemUi::SystemExitException, @ui.error do
-        @cmd.execute
+      use_ui @ui do
+        assert_raises Gem::MockGemUi::SystemExitException, @ui.error do
+          @cmd.execute
+        end
       end
+
+      out = @ui.output.split "\n"
+
+      assert_equal "Gems to install:", out.shift
+      assert_equal "  a-2", out.shift
+      assert_empty out
+    ensure
+      Gem.platforms = []
     end
-
-    out = @ui.output.split "\n"
-
-    assert_equal "Gems to install:", out.shift
-    assert_equal "  a-2", out.shift
-    assert_empty out
   end
 
   def test_explain_platform_ruby_ignore_dependencies
@@ -1460,20 +1464,24 @@ ERROR:  Possible alternatives: non_existent_with_hint
     # equivalent to --platform=ruby
     Gem.platforms = [Gem::Platform::RUBY]
 
-    @cmd.options[:ignore_dependencies] = true
-    @cmd.options[:explain] = true
-    @cmd.options[:args] = %w[a]
+    begin
+      @cmd.options[:ignore_dependencies] = true
+      @cmd.options[:explain] = true
+      @cmd.options[:args] = %w[a]
 
-    use_ui @ui do
-      assert_raises Gem::MockGemUi::SystemExitException, @ui.error do
-        @cmd.execute
+      use_ui @ui do
+        assert_raises Gem::MockGemUi::SystemExitException, @ui.error do
+          @cmd.execute
+        end
       end
+
+      out = @ui.output.split "\n"
+
+      assert_equal "Gems to install:", out.shift
+      assert_equal "  a-3", out.shift
+      assert_empty out
+    ensure
+      Gem.platforms = []
     end
-
-    out = @ui.output.split "\n"
-
-    assert_equal "Gems to install:", out.shift
-    assert_equal "  a-3", out.shift
-    assert_empty out
   end
 end

--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -681,17 +681,21 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
     # equivalent to --platform=ruby
     Gem.platforms = [Gem::Platform::RUBY]
 
-    @cmd.options[:explain] = true
-    @cmd.options[:args] = %w[a]
+    begin
+      @cmd.options[:explain] = true
+      @cmd.options[:args] = %w[a]
 
-    use_ui @ui do
-      @cmd.execute
+      use_ui @ui do
+        @cmd.execute
+      end
+
+      out = @ui.output.split "\n"
+
+      assert_equal "Gems to update:", out.shift
+      assert_equal "  a-2", out.shift
+      assert_empty out
+    ensure
+      Gem.platforms = []
     end
-
-    out = @ui.output.split "\n"
-
-    assert_equal "Gems to update:", out.shift
-    assert_equal "  a-2", out.shift
-    assert_empty out
   end
 end

--- a/test/rubygems/test_gem_commands_yank_command.rb
+++ b/test/rubygems/test_gem_commands_yank_command.rb
@@ -31,6 +31,8 @@ class TestGemCommandsYankCommand < Gem::TestCase
     assert_equal "HOST",       @cmd.options[:host]
     assert_nil                 @cmd.options[:platform]
     assert_equal req('= 1.0'), @cmd.options[:version]
+  ensure
+    Gem.platforms = []
   end
 
   def test_handle_options_missing_argument

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -203,14 +203,6 @@ class TestGemPlatform < Gem::TestCase
     assert_equal '1', platform.version
   end
 
-  def test_to_s
-    if win_platform?
-      assert_equal 'x86-mswin32-60', Gem::Platform.local.to_s
-    else
-      assert_equal 'x86-darwin-8', Gem::Platform.local.to_s
-    end
-  end
-
   def test_equals2
     my = Gem::Platform.new %w[cpu my_platform 1]
     other = Gem::Platform.new %w[cpu other_platform 1]

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -10,6 +10,31 @@ class TestGemPlatform < Gem::TestCase
     end
   end
 
+  def test_self_local_is_inferred_from_RUBY_PLATFORM_when_universal_darwin
+    orig_arch_config = RbConfig::CONFIG["arch"]
+    orig_platform = RUBY_PLATFORM
+
+    Object.send :remove_const, :RUBY_PLATFORM
+    Object.const_set :RUBY_PLATFORM, "universal.x86_64-darwin19"
+
+    RbConfig::CONFIG["arch"] = "universal-darwin19"
+
+    Gem::Platform.instance_variable_set :@local, nil
+
+    local_platform = Gem::Platform.local
+
+    assert_equal "x86_64", local_platform.cpu
+    assert_equal "darwin", local_platform.os
+    assert_equal "19", local_platform.version
+  ensure
+    RbConfig::CONFIG["arch"] = orig_arch_config
+
+    Object.send :remove_const, :RUBY_PLATFORM
+    Object.const_set :RUBY_PLATFORM, orig_platform
+
+    Gem::Platform.instance_variable_set :@local, nil
+  end
+
   def test_self_match
     Gem::Deprecate.skip_during do
       assert Gem::Platform.match(nil), 'nil == ruby'

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -5,9 +5,9 @@ require 'rbconfig'
 
 class TestGemPlatform < Gem::TestCase
   def test_self_local
-    util_set_arch 'i686-darwin8.10.1'
-
-    assert_equal Gem::Platform.new(%w[x86 darwin 8]), Gem::Platform.local
+    util_set_arch 'i686-darwin8.10.1' do
+      assert_equal Gem::Platform.new(%w[x86 darwin 8]), Gem::Platform.local
+    end
   end
 
   def test_self_match
@@ -234,20 +234,23 @@ class TestGemPlatform < Gem::TestCase
     uni_darwin8 = Gem::Platform.new 'universal-darwin8.0'
     x86_darwin8 = Gem::Platform.new 'i686-darwin8.0'
 
-    util_set_arch 'powerpc-darwin8'
-    assert((ppc_darwin8 === Gem::Platform.local), 'powerpc =~ universal')
-    assert((uni_darwin8 === Gem::Platform.local), 'powerpc =~ universal')
-    refute((x86_darwin8 === Gem::Platform.local), 'powerpc =~ universal')
+    util_set_arch 'powerpc-darwin8' do
+      assert((ppc_darwin8 === Gem::Platform.local), 'powerpc =~ universal')
+      assert((uni_darwin8 === Gem::Platform.local), 'powerpc =~ universal')
+      refute((x86_darwin8 === Gem::Platform.local), 'powerpc =~ universal')
+    end
 
-    util_set_arch 'i686-darwin8'
-    refute((ppc_darwin8 === Gem::Platform.local), 'powerpc =~ universal')
-    assert((uni_darwin8 === Gem::Platform.local), 'x86 =~ universal')
-    assert((x86_darwin8 === Gem::Platform.local), 'powerpc =~ universal')
+    util_set_arch 'i686-darwin8' do
+      refute((ppc_darwin8 === Gem::Platform.local), 'powerpc =~ universal')
+      assert((uni_darwin8 === Gem::Platform.local), 'x86 =~ universal')
+      assert((x86_darwin8 === Gem::Platform.local), 'powerpc =~ universal')
+    end
 
-    util_set_arch 'universal-darwin8'
-    assert((ppc_darwin8 === Gem::Platform.local), 'universal =~ ppc')
-    assert((uni_darwin8 === Gem::Platform.local), 'universal =~ universal')
-    assert((x86_darwin8 === Gem::Platform.local), 'universal =~ x86')
+    util_set_arch 'universal-darwin8' do
+      assert((ppc_darwin8 === Gem::Platform.local), 'universal =~ ppc')
+      assert((uni_darwin8 === Gem::Platform.local), 'universal =~ universal')
+      assert((x86_darwin8 === Gem::Platform.local), 'universal =~ x86')
+    end
   end
 
   def test_nil_cpu_arch_is_treated_as_universal
@@ -266,94 +269,106 @@ class TestGemPlatform < Gem::TestCase
     armv5 = Gem::Platform.new 'armv5-linux'
     armv7 = Gem::Platform.new 'armv7-linux'
 
-    util_set_arch 'armv5-linux'
-    assert((arm   === Gem::Platform.local), 'arm   === armv5')
-    assert((armv5 === Gem::Platform.local), 'armv5 === armv5')
-    refute((armv7 === Gem::Platform.local), 'armv7 === armv5')
-    refute((Gem::Platform.local === arm), 'armv5 === arm')
+    util_set_arch 'armv5-linux' do
+      assert((arm   === Gem::Platform.local), 'arm   === armv5')
+      assert((armv5 === Gem::Platform.local), 'armv5 === armv5')
+      refute((armv7 === Gem::Platform.local), 'armv7 === armv5')
+      refute((Gem::Platform.local === arm), 'armv5 === arm')
+    end
 
-    util_set_arch 'armv7-linux'
-    assert((arm   === Gem::Platform.local), 'arm   === armv7')
-    refute((armv5 === Gem::Platform.local), 'armv5 === armv7')
-    assert((armv7 === Gem::Platform.local), 'armv7 === armv7')
-    refute((Gem::Platform.local === arm), 'armv7 === arm')
+    util_set_arch 'armv7-linux' do
+      assert((arm   === Gem::Platform.local), 'arm   === armv7')
+      refute((armv5 === Gem::Platform.local), 'armv5 === armv7')
+      assert((armv7 === Gem::Platform.local), 'armv7 === armv7')
+      refute((Gem::Platform.local === arm), 'armv7 === arm')
+    end
   end
 
   def test_equals3_version
-    util_set_arch 'i686-darwin8'
+    util_set_arch 'i686-darwin8' do
+      x86_darwin = Gem::Platform.new ['x86', 'darwin', nil]
+      x86_darwin7 = Gem::Platform.new ['x86', 'darwin', '7']
+      x86_darwin8 = Gem::Platform.new ['x86', 'darwin', '8']
+      x86_darwin9 = Gem::Platform.new ['x86', 'darwin', '9']
 
-    x86_darwin = Gem::Platform.new ['x86', 'darwin', nil]
-    x86_darwin7 = Gem::Platform.new ['x86', 'darwin', '7']
-    x86_darwin8 = Gem::Platform.new ['x86', 'darwin', '8']
-    x86_darwin9 = Gem::Platform.new ['x86', 'darwin', '9']
+      assert((x86_darwin  === Gem::Platform.local), 'x86_darwin === x86_darwin8')
+      assert((x86_darwin8 === Gem::Platform.local), 'x86_darwin8 === x86_darwin8')
 
-    assert((x86_darwin  === Gem::Platform.local), 'x86_darwin === x86_darwin8')
-    assert((x86_darwin8 === Gem::Platform.local), 'x86_darwin8 === x86_darwin8')
-
-    refute((x86_darwin7 === Gem::Platform.local), 'x86_darwin7 === x86_darwin8')
-    refute((x86_darwin9 === Gem::Platform.local), 'x86_darwin9 === x86_darwin8')
+      refute((x86_darwin7 === Gem::Platform.local), 'x86_darwin7 === x86_darwin8')
+      refute((x86_darwin9 === Gem::Platform.local), 'x86_darwin9 === x86_darwin8')
+    end
   end
 
   def test_equals_tilde
-    util_set_arch 'i386-mswin32'
+    util_set_arch 'i386-mswin32' do
+      assert_local_match 'mswin32'
+      assert_local_match 'i386-mswin32'
 
-    assert_local_match 'mswin32'
-    assert_local_match 'i386-mswin32'
+      # oddballs
+      assert_local_match 'i386-mswin32-mq5.3'
+      assert_local_match 'i386-mswin32-mq6'
+      refute_local_match 'win32-1.8.2-VC7'
+      refute_local_match 'win32-1.8.4-VC6'
+      refute_local_match 'win32-source'
+      refute_local_match 'windows'
+    end
 
-    # oddballs
-    assert_local_match 'i386-mswin32-mq5.3'
-    assert_local_match 'i386-mswin32-mq6'
-    refute_local_match 'win32-1.8.2-VC7'
-    refute_local_match 'win32-1.8.4-VC6'
-    refute_local_match 'win32-source'
-    refute_local_match 'windows'
+    util_set_arch 'i686-linux' do
+      assert_local_match 'i486-linux'
+      assert_local_match 'i586-linux'
+      assert_local_match 'i686-linux'
+    end
 
-    util_set_arch 'i686-linux'
-    assert_local_match 'i486-linux'
-    assert_local_match 'i586-linux'
-    assert_local_match 'i686-linux'
+    util_set_arch 'i686-darwin8' do
+      assert_local_match 'i686-darwin8.4.1'
+      assert_local_match 'i686-darwin8.8.2'
+    end
 
-    util_set_arch 'i686-darwin8'
-    assert_local_match 'i686-darwin8.4.1'
-    assert_local_match 'i686-darwin8.8.2'
+    util_set_arch 'java' do
+      assert_local_match 'java'
+      assert_local_match 'jruby'
+    end
 
-    util_set_arch 'java'
-    assert_local_match 'java'
-    assert_local_match 'jruby'
+    util_set_arch 'universal-dotnet2.0' do
+      assert_local_match 'universal-dotnet'
+      assert_local_match 'universal-dotnet-2.0'
+      refute_local_match 'universal-dotnet-4.0'
+      assert_local_match 'dotnet'
+      assert_local_match 'dotnet-2.0'
+      refute_local_match 'dotnet-4.0'
+    end
 
-    util_set_arch 'universal-dotnet2.0'
-    assert_local_match 'universal-dotnet'
-    assert_local_match 'universal-dotnet-2.0'
-    refute_local_match 'universal-dotnet-4.0'
-    assert_local_match 'dotnet'
-    assert_local_match 'dotnet-2.0'
-    refute_local_match 'dotnet-4.0'
+    util_set_arch 'universal-dotnet4.0' do
+      assert_local_match 'universal-dotnet'
+      refute_local_match 'universal-dotnet-2.0'
+      assert_local_match 'universal-dotnet-4.0'
+      assert_local_match 'dotnet'
+      refute_local_match 'dotnet-2.0'
+      assert_local_match 'dotnet-4.0'
+    end
 
-    util_set_arch 'universal-dotnet4.0'
-    assert_local_match 'universal-dotnet'
-    refute_local_match 'universal-dotnet-2.0'
-    assert_local_match 'universal-dotnet-4.0'
-    assert_local_match 'dotnet'
-    refute_local_match 'dotnet-2.0'
-    assert_local_match 'dotnet-4.0'
+    util_set_arch 'universal-macruby-1.0' do
+      assert_local_match 'universal-macruby'
+      assert_local_match 'macruby'
+      refute_local_match 'universal-macruby-0.10'
+      assert_local_match 'universal-macruby-1.0'
+    end
 
-    util_set_arch 'universal-macruby-1.0'
-    assert_local_match 'universal-macruby'
-    assert_local_match 'macruby'
-    refute_local_match 'universal-macruby-0.10'
-    assert_local_match 'universal-macruby-1.0'
+    util_set_arch 'powerpc-darwin' do
+      assert_local_match 'powerpc-darwin'
+    end
 
-    util_set_arch 'powerpc-darwin'
-    assert_local_match 'powerpc-darwin'
+    util_set_arch 'powerpc-darwin7' do
+      assert_local_match 'powerpc-darwin7.9.0'
+    end
 
-    util_set_arch 'powerpc-darwin7'
-    assert_local_match 'powerpc-darwin7.9.0'
+    util_set_arch 'powerpc-darwin8' do
+      assert_local_match 'powerpc-darwin8.10.0'
+    end
 
-    util_set_arch 'powerpc-darwin8'
-    assert_local_match 'powerpc-darwin8.10.0'
-
-    util_set_arch 'sparc-solaris2.8'
-    assert_local_match 'sparc-solaris2.8-mq5.3'
+    util_set_arch 'sparc-solaris2.8' do
+      assert_local_match 'sparc-solaris2.8-mq5.3'
+    end
   end
 
   def assert_local_match(name)

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -386,6 +386,10 @@ class TestGemPlatform < Gem::TestCase
     util_set_arch 'sparc-solaris2.8' do
       assert_local_match 'sparc-solaris2.8-mq5.3'
     end
+
+    util_set_arch 'universal.x86_64-darwin19' do
+      assert_local_match 'x86_64-darwin'
+    end
   end
 
   def assert_local_match(name)

--- a/test/rubygems/test_gem_request_set_lockfile.rb
+++ b/test/rubygems/test_gem_request_set_lockfile.rb
@@ -9,7 +9,7 @@ class TestGemRequestSetLockfile < Gem::TestCase
 
     Gem::RemoteFetcher.fetcher = @fetcher = Gem::FakeFetcher.new
 
-    util_set_arch 'i686-darwin8.10.1'
+    @previous_arch = util_change_arch 'i686-darwin8.10.1'
 
     @set = Gem::RequestSet.new
 
@@ -20,6 +20,12 @@ class TestGemRequestSetLockfile < Gem::TestCase
     @set.instance_variable_set :@vendor_set, @vendor_set
 
     @gem_deps_file = 'gem.deps.rb'
+  end
+
+  def teardown
+    util_change_arch @previous_arch
+
+    super
   end
 
   def lockfile

--- a/test/rubygems/test_gem_spec_fetcher.rb
+++ b/test/rubygems/test_gem_spec_fetcher.rb
@@ -106,39 +106,39 @@ class TestGemSpecFetcher < Gem::TestCase
   end
 
   def test_spec_for_dependency_platform
-    util_set_arch 'i386-linux'
+    util_set_arch 'i386-linux' do
+      spec_fetcher do |fetcher|
+        fetcher.legacy_platform
+      end
 
-    spec_fetcher do |fetcher|
-      fetcher.legacy_platform
+      dep = Gem::Dependency.new 'pl', 1
+      specs_and_sources, _ = @sf.spec_for_dependency dep
+
+      spec_names = specs_and_sources.map do |spec, source_uri|
+        [spec.full_name, source_uri]
+      end
+
+      assert_equal [['pl-1-x86-linux', Gem::Source.new(@gem_repo)]],
+                   spec_names
     end
-
-    dep = Gem::Dependency.new 'pl', 1
-    specs_and_sources, _ = @sf.spec_for_dependency dep
-
-    spec_names = specs_and_sources.map do |spec, source_uri|
-      [spec.full_name, source_uri]
-    end
-
-    assert_equal [['pl-1-x86-linux', Gem::Source.new(@gem_repo)]],
-                 spec_names
   end
 
   def test_spec_for_dependency_mismatched_platform
-    util_set_arch 'hrpa-989'
+    util_set_arch 'hrpa-989' do
+      spec_fetcher do |fetcher|
+        fetcher.legacy_platform
+      end
 
-    spec_fetcher do |fetcher|
-      fetcher.legacy_platform
+      dep = Gem::Dependency.new 'pl', 1
+      specs_and_sources, errors = @sf.spec_for_dependency dep
+
+      assert_equal 0, specs_and_sources.size
+      assert_equal 1, errors.size
+      pmm = errors.first
+
+      assert_equal "i386-linux", pmm.platforms.first
+      assert_equal "Found pl (1), but was for platform i386-linux", pmm.wordy
     end
-
-    dep = Gem::Dependency.new 'pl', 1
-    specs_and_sources, errors = @sf.spec_for_dependency dep
-
-    assert_equal 0, specs_and_sources.size
-    assert_equal 1, errors.size
-    pmm = errors.first
-
-    assert_equal "i386-linux", pmm.platforms.first
-    assert_equal "Found pl (1), but was for platform i386-linux", pmm.wordy
   end
 
   def test_spec_for_dependency_bad_fetch_spec

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -463,10 +463,11 @@ end
 
     @w1 = util_spec 'w', '1', 'x' => nil
 
-    util_set_arch 'cpu-my_platform1'
-    install_specs @x1_m, @x1_o, @w1
+    util_set_arch 'cpu-my_platform1' do
+      install_specs @x1_m, @x1_o, @w1
 
-    assert_activate %w[x-1-cpu-my_platform-1 w-1], @w1, @x1_m
+      assert_activate %w[x-1-cpu-my_platform-1 w-1], @w1, @x1_m
+    end
   end
 
   ##
@@ -1997,9 +1998,10 @@ dependencies: []
 
     test_cases.each do |arch, expected|
       @a1 = Gem::Specification.new "a", 1
-      util_set_arch arch
-      @a1.platform = 'current'
-      assert_equal expected, @a1.full_name
+      util_set_arch arch do
+        @a1.platform = 'current'
+        assert_equal expected, @a1.full_name
+      end
     end
   end
 
@@ -2100,9 +2102,10 @@ dependencies: []
     }
 
     test_cases.each do |arch, expected|
-      util_set_arch arch
-      @a1.platform = Gem::Platform::CURRENT
-      assert_equal Gem::Platform.new(expected), @a1.platform
+      util_set_arch arch do
+        @a1.platform = Gem::Platform::CURRENT
+        assert_equal Gem::Platform.new(expected), @a1.platform
+      end
     end
   end
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1671,13 +1671,15 @@ dependencies: []
   end
 
   def test_contains_requirable_file_eh_extension_different_platform
-    ext_spec(platform: Gem::Platform.new("java"))
+    util_set_arch 'i686-darwin8.10.1' do
+      ext_spec(platform: Gem::Platform.new("java"))
 
-    _, err = capture_io do
-      refute @ext.contains_requirable_file? 'nonexistent'
+      _, err = capture_io do
+        refute @ext.contains_requirable_file? 'nonexistent'
+      end
+
+      assert_empty err
     end
-
-    assert_empty err
   end
 
   def test_date
@@ -1972,21 +1974,23 @@ dependencies: []
   end
 
   def test_full_name
-    assert_equal 'a-1', @a1.full_name
+    util_set_arch 'i686-darwin8.10.1' do
+      assert_equal 'a-1', @a1.full_name
 
-    @a1 = Gem::Specification.new "a", 1
-    @a1.platform = Gem::Platform.new ['universal', 'darwin', nil]
-    assert_equal 'a-1-universal-darwin', @a1.full_name
+      @a1 = Gem::Specification.new "a", 1
+      @a1.platform = Gem::Platform.new ['universal', 'darwin', nil]
+      assert_equal 'a-1-universal-darwin', @a1.full_name
 
-    @a1 = Gem::Specification.new "a", 1
-    @a1.instance_variable_set :@new_platform, 'mswin32'
-    assert_equal 'a-1-mswin32', @a1.full_name, 'legacy'
+      @a1 = Gem::Specification.new "a", 1
+      @a1.instance_variable_set :@new_platform, 'mswin32'
+      assert_equal 'a-1-mswin32', @a1.full_name, 'legacy'
 
-    return if win_platform?
+      return if win_platform?
 
-    @a1 = Gem::Specification.new "a", 1
-    @a1.platform = 'current'
-    assert_equal 'a-1-x86-darwin-8', @a1.full_name
+      @a1 = Gem::Specification.new "a", 1
+      @a1.platform = 'current'
+      assert_equal 'a-1-x86-darwin-8', @a1.full_name
+    end
   end
 
   def test_full_name_windows
@@ -2509,20 +2513,21 @@ end
   end
 
   def test_to_ruby_fancy
-    make_spec_c1
+    util_set_arch 'i686-darwin8.10.1' do
+      make_spec_c1
 
-    @c1.platform = Gem::Platform.local
-    ruby_code = @c1.to_ruby
+      @c1.platform = Gem::Platform.local
+      ruby_code = @c1.to_ruby
 
-    local = Gem::Platform.local
-    expected_platform = "[#{local.cpu.inspect}, #{local.os.inspect}, #{local.version.inspect}]"
-    stub_require_paths =
-      @c1.instance_variable_get(:@require_paths).join "\u0000"
-    extensions = @c1.extensions.join "\u0000"
+      local = Gem::Platform.local
+      expected_platform = "[#{local.cpu.inspect}, #{local.os.inspect}, #{local.version.inspect}]"
+      stub_require_paths =
+        @c1.instance_variable_get(:@require_paths).join "\u0000"
+      extensions = @c1.extensions.join "\u0000"
 
-    expected = <<-SPEC
+      expected = <<-SPEC
 # -*- encoding: utf-8 -*-
-# stub: a 1 #{win_platform? ? "x86-mswin32-60" : "x86-darwin-8"} #{stub_require_paths}
+# stub: a 1 x86-darwin-8 #{stub_require_paths}
 # stub: #{extensions}
 
 Gem::Specification.new do |s|
@@ -2560,13 +2565,14 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<pqa>.freeze, [\"> 0.4\", \"<= 0.6\"])
   end
 end
-    SPEC
+      SPEC
 
-    assert_equal expected, ruby_code
+      assert_equal expected, ruby_code
 
-    same_spec = eval ruby_code
+      same_spec = eval ruby_code
 
-    assert_equal @c1, same_spec
+      assert_equal @c1, same_spec
+    end
   end
 
   def test_to_ruby_keeps_requirements_as_originally_specified

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1670,7 +1670,7 @@ dependencies: []
     assert_equal expected, err
   end
 
-  def test_contains_requirable_file_eh_extension_java_platform
+  def test_contains_requirable_file_eh_extension_different_platform
     ext_spec(platform: Gem::Platform.new("java"))
 
     _, err = capture_io do

--- a/test/rubygems/test_gem_version_option.rb
+++ b/test/rubygems/test_gem_version_option.rb
@@ -15,6 +15,8 @@ class TestGemVersionOption < Gem::TestCase
     @cmd.add_platform_option
 
     assert @cmd.handles?(%w[--platform x86-darwin])
+  ensure
+    Gem.platforms = []
   end
 
   def test_add_version_option
@@ -48,6 +50,8 @@ class TestGemVersionOption < Gem::TestCase
     ]
 
     assert_equal expected, Gem.platforms
+  ensure
+    Gem.platforms = []
   end
 
   def test_platform_option_ruby
@@ -60,6 +64,8 @@ class TestGemVersionOption < Gem::TestCase
     ]
 
     assert_equal expected, Gem.platforms
+  ensure
+    Gem.platforms = []
   end
 
   def test_platform_option_twice
@@ -73,6 +79,8 @@ class TestGemVersionOption < Gem::TestCase
     ]
 
     assert_equal expected, Gem.platforms
+  ensure
+    Gem.platforms = []
   end
 
   def test_version_option


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

On some MacOS platforms, it can happen that rubygems installs a arm targeted gem on an intel based platform.

## What is your fix for the problem, implemented in this PR?

The problem is rubygems infers the local platform to be "universal", an in that case, rubygems considers any darwin variant a good candidate for installation.  This could also be a problem in ruby, I'll double check with ruby-core developers, but for now I'm proposing a workaround/fix in rubygems.

The fix is us to make sure we infer the local platform from `RUBY_PLATFORM` since it includes * more accurate information in this case.

I added an extra commit to make it so that the new platform inferred in this case is considered x86_64, so that variant gets installed.

However, unless we understand what the correct thing to do is here, I don't think we should introduce that second change and let rubygems choose the non-platform specific version.

Fixes https://github.com/rubygems/rubygems/issues/4234.

NOTE: The PR also includes a bunch of test changes to make sure that the platform is only mocked when needed and side effects are restored afterwards. I don't think it's strictly necessary for this, but it makes our tests better and potentially catch more platform specific issues.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)