### PR TITLE
Bump minitest development dependency to 5.14.3

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,9 +7,7 @@ require 'psych'
 
 desc "Setup Rubygems dev environment"
 task :setup do
-  version = File.read("dev_gems.rb.lock").split(/BUNDLED WITH\n   /).last
-  sh "gem install bundler:#{version}"
-  sh "bundle install --gemfile=dev_gems.rb"
+  sh "ruby bundler/bin/bundle install --gemfile=dev_gems.rb"
 end
 
 desc "Setup git hooks"

--- a/dev_gems.rb
+++ b/dev_gems.rb
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "rdoc", "6.2.0" # 6.2.1 is required > Ruby 2.3
-gem "minitest", "~> 5.14", ">= 5.14.2" # 5.14.2 is required to support Ruby 3.0
+gem "minitest", "~> 5.14", ">= 5.14.3" # 5.14.3 is required to support Ruby 3.1
 gem "minitest-bisect", "~> 1.5"
 gem "simplecov", "~> 0.17.0"
 gem "rubocop", "~> 0.80.1"

--- a/dev_gems.rb.lock
+++ b/dev_gems.rb.lock
@@ -30,7 +30,7 @@ GEM
     jmespath (1.4.0)
     json (2.3.0)
     json (2.3.0-java)
-    minitest (5.14.2)
+    minitest (5.14.3)
     minitest-bisect (1.5.1)
       minitest-server (~> 1.0)
       path_expander (~> 1.1)
@@ -96,7 +96,7 @@ PLATFORMS
 
 DEPENDENCIES
   aws-sdk-s3 (~> 1.87)
-  minitest (~> 5.14, >= 5.14.2)
+  minitest (~> 5.14, >= 5.14.3)
   minitest-bisect (~> 1.5)
   netrc (~> 0.11.0)
   octokit (~> 4.18)

--- a/dev_gems.rb.lock
+++ b/dev_gems.rb.lock
@@ -112,4 +112,4 @@ DEPENDENCIES
   webrick (~> 1.6)
 
 BUNDLED WITH
-   2.2.3
+   2.3.0.dev


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Our daily CI is failing.

## What is your fix for the problem, implemented in this PR?

Make sure we use a minitest version compatible with ruby's HEAD.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)