### PR TITLE
Add ruby 3.0.0 and rubygems 3.2.4 to CI

### DIFF
--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -16,11 +16,11 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - { name: 2.3, value: 2.3.8 }
-          - { name: 2.4, value: 2.4.10 }
-          - { name: 2.5, value: 2.5.8 }
-          - { name: 2.6, value: 2.6.6 }
-          - { name: 2.7, value: 2.7.2 }
+          - { name: "2.3", value: 2.3.8 }
+          - { name: "2.4", value: 2.4.10 }
+          - { name: "2.5", value: 2.5.8 }
+          - { name: "2.6", value: 2.6.6 }
+          - { name: "2.7", value: 2.7.2 }
           - { name: jruby-9.2, value: jruby-9.2.14.0 }
           - { name: truffleruby-20.2, value: truffleruby-20.2.0 }
         openssl:
@@ -77,7 +77,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - { name: 2.7, value: 2.7.2 }
+          - { name: "2.7", value: 2.7.2 }
           - { name: jruby-9.2, value: jruby-9.2.14.0 }
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -21,6 +21,7 @@ jobs:
           - { name: "2.5", value: 2.5.8 }
           - { name: "2.6", value: 2.6.6 }
           - { name: "2.7", value: 2.7.2 }
+          - { name: "3.0", value: 3.0.0 }
           - { name: jruby-9.2, value: jruby-9.2.14.0 }
           - { name: truffleruby-20.2, value: truffleruby-20.2.0 }
         openssl:
@@ -77,7 +78,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - { name: "2.7", value: 2.7.2 }
+          - { name: "3.0", value: 3.0.0 }
           - { name: jruby-9.2, value: jruby-9.2.14.0 }
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/macos-rubygems.yml
+++ b/.github/workflows/macos-rubygems.yml
@@ -16,10 +16,10 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - { name: 2.4, value: 2.4.10 }
-          - { name: 2.5, value: 2.5.8 }
-          - { name: 2.6, value: 2.6.6 }
-          - { name: 2.7, value: 2.7.2 }
+          - { name: "2.4", value: 2.4.10 }
+          - { name: "2.5", value: 2.5.8 }
+          - { name: "2.6", value: 2.6.6 }
+          - { name: "2.7", value: 2.7.2 }
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby

--- a/.github/workflows/macos-rubygems.yml
+++ b/.github/workflows/macos-rubygems.yml
@@ -20,6 +20,7 @@ jobs:
           - { name: "2.5", value: 2.5.8 }
           - { name: "2.6", value: 2.6.6 }
           - { name: "2.7", value: 2.7.2 }
+          - { name: "3.0", value: 3.0.0 }
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby

--- a/.github/workflows/older-rubygems-bundler.yml
+++ b/.github/workflows/older-rubygems-bundler.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   older_rubygems_bundler:
-    name: Bundler ${{ matrix.bundler.name }} against old Rubygems (${{ matrix.ruby.name }}, ${{ matrix.rgv.name}})
+    name: Bundler ${{ matrix.bundler.name }} against old Rubygems (${{ matrix.ruby.name }}, ${{ matrix.rgv.name }})
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false

--- a/.github/workflows/older-rubygems-bundler.yml
+++ b/.github/workflows/older-rubygems-bundler.yml
@@ -25,12 +25,14 @@ jobs:
           - { name: ruby-2.5, value: 2.5.8 }
           - { name: ruby-2.6, value: 2.6.6 }
           - { name: ruby-2.7, value: 2.7.2 }
+          - { name: ruby-3.0, value: 3.0.0 }
         rgv:
           - { name: rgv-2.5, value: v2.5.2 }
           - { name: rgv-2.6, value: v2.6.14 }
           - { name: rgv-2.7, value: v2.7.10 }
           - { name: rgv-3.0, value: v3.0.8 }
           - { name: rgv-3.1, value: v3.1.4 }
+          - { name: rgv-3.2, value: v3.2.4 }
 
         bundler:
           - { name: 2, value: '' }
@@ -46,12 +48,18 @@ jobs:
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.2 }, rgv: { name: rgv-2.6, value: v2.6.14 } }
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.2 }, rgv: { name: rgv-2.7, value: v2.7.10 } }
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.2 }, rgv: { name: rgv-3.0, value: v3.0.8 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.0 }, rgv: { name: rgv-2.5, value: v2.5.2 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.0 }, rgv: { name: rgv-2.6, value: v2.6.14 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.0 }, rgv: { name: rgv-2.7, value: v2.7.10 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.0 }, rgv: { name: rgv-3.0, value: v3.0.8 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.0 }, rgv: { name: rgv-3.1, value: v3.1.4 } }
 
         include:
-          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.4, value: 2.4.10 }, rgv: { name: rgv-3.1, value: v3.1.4 } }
-          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.5, value: 2.5.8 }, rgv: { name: rgv-3.1, value: v3.1.4 } }
-          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.6, value: 2.6.6 }, rgv: { name: rgv-3.1, value: v3.1.4 } }
-          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.7, value: 2.7.2 }, rgv: { name: rgv-3.1, value: v3.1.4 } }
+          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.4, value: 2.4.10 }, rgv: { name: rgv-3.2, value: v3.2.4 } }
+          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.5, value: 2.5.8 }, rgv: { name: rgv-3.2, value: v3.2.4 } }
+          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.6, value: 2.6.6 }, rgv: { name: rgv-3.2, value: v3.2.4 } }
+          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.7, value: 2.7.2 }, rgv: { name: rgv-3.2, value: v3.2.4 } }
+          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.0, value: 3.0.0 }, rgv: { name: rgv-3.2, value: v3.2.4 } }
     env:
       RGV: ${{ matrix.rgv.value }}
       RUBYOPT: --disable-gems

--- a/.github/workflows/ubuntu-bundler.yml
+++ b/.github/workflows/ubuntu-bundler.yml
@@ -21,6 +21,7 @@ jobs:
           - { name: ruby-2.5, value: 2.5.8 }
           - { name: ruby-2.6, value: 2.6.6 }
           - { name: ruby-2.7, value: 2.7.2 }
+          - { name: ruby-3.0, value: 3.0.0 }
 
         bundler:
           - { name: 2, value: '' }

--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.2
+          ruby-version: 3.0.0
           bundler: none
       - name: Install Dependencies
         run: rake setup

--- a/.github/workflows/ubuntu-rubygems.yml
+++ b/.github/workflows/ubuntu-rubygems.yml
@@ -21,6 +21,7 @@ jobs:
           - { name: "2.5", value: 2.5.8 }
           - { name: "2.6", value: 2.6.6 }
           - { name: "2.7", value: 2.7.2 }
+          - { name: "3.0", value: 3.0.0 }
           - { name: jruby-9.2, value: jruby-9.2.14.0 }
           - { name: truffleruby-20.2, value: truffleruby-20.2.0 }
     env:

--- a/.github/workflows/ubuntu-rubygems.yml
+++ b/.github/workflows/ubuntu-rubygems.yml
@@ -16,11 +16,11 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - { name: 2.3, value: 2.3.8 }
-          - { name: 2.4, value: 2.4.10 }
-          - { name: 2.5, value: 2.5.8 }
-          - { name: 2.6, value: 2.6.6 }
-          - { name: 2.7, value: 2.7.2 }
+          - { name: "2.3", value: 2.3.8 }
+          - { name: "2.4", value: 2.4.10 }
+          - { name: "2.5", value: 2.5.8 }
+          - { name: "2.6", value: 2.6.6 }
+          - { name: "2.7", value: 2.7.2 }
           - { name: jruby-9.2, value: jruby-9.2.14.0 }
           - { name: truffleruby-20.2, value: truffleruby-20.2.0 }
     env:

--- a/.github/workflows/windows-bundler.yml
+++ b/.github/workflows/windows-bundler.yml
@@ -26,6 +26,7 @@ jobs:
           - { name: ruby-2.5, value: 2.5.8 }
           - { name: ruby-2.6, value: 2.6.6 }
           - { name: ruby-2.7, value: 2.7.2 }
+          - { name: ruby-3.0, value: 3.0.0 }
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/windows-rubygems.yml
+++ b/.github/workflows/windows-rubygems.yml
@@ -16,10 +16,10 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - { name: 2.4, value: 2.4.10 }
-          - { name: 2.5, value: 2.5.8 }
-          - { name: 2.6, value: 2.6.6 }
-          - { name: 2.7, value: 2.7.2 }
+          - { name: "2.4", value: 2.4.10 }
+          - { name: "2.5", value: 2.5.8 }
+          - { name: "2.6", value: 2.6.6 }
+          - { name: "2.7", value: 2.7.2 }
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby

--- a/.github/workflows/windows-rubygems.yml
+++ b/.github/workflows/windows-rubygems.yml
@@ -20,6 +20,7 @@ jobs:
           - { name: "2.5", value: 2.5.8 }
           - { name: "2.6", value: 2.6.6 }
           - { name: "2.7", value: 2.7.2 }
+          - { name: "3.0", value: 3.0.0 }
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We're still not testing against ruby 3.0.0, and bundler against the latest 3.2 release of rubygems.

## What is your fix for the problem, implemented in this PR?

My fix is to add the missing entries to the CI matrix.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)