### PR TITLE
Ensure `Version#canonical_segments` cannot be modified

### DIFF
--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -372,7 +372,7 @@ class Gem::Version
     @canonical_segments ||=
       _split_segments.map! do |segments|
         segments.reverse_each.drop_while {|s| s == 0 }.reverse
-      end.reduce(&:concat)
+      end.reduce(&:concat).freeze
   end
 
   def freeze

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -214,6 +214,7 @@ class TestGemVersion < Gem::TestCase
     assert_equal [1], v("1.0.0").canonical_segments
     assert_equal [1, "a", 1], v("1.0.0.a.1.0").canonical_segments
     assert_equal [1, 2, 3, "pre", 1], v("1.2.3-1").canonical_segments
+    assert v("1.0.0").canonical_segments.frozen?
   end
 
   def test_frozen_version


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since `Gem::Version` instances are cached based on the version string, `canonical_segments` should not be modifiable, otherwise things like `Gem::Version#<=>` (and any other uses of `canonical_versions`) will have different results.

Consider this (on Rails 6.0.3.4):

```ruby
Rails.gem_version > Gem::Version.new('6.0')
```

This should be `true`, but we actually had it return `false` because another gem we depended on did something like this:

```ruby
segments = Rails.gem_version.canonical_segments

segments.pop until segments.length <= 2
```

This modified the `canonical_segments` array in place, resulting in the `false` return from `>`.

The gem in question should definitely be calling `dup` on `canonical_segments`, but there's nothing that stops it from *not* doing so, and manipulating the array directly.

## What is your fix for the problem, implemented in this PR?

Now, if someone tries to do that, they'll get a `FrozenError`, which seems preferable!

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)