### PR TITLE
Fix `gem outdated` incorrectly handling platform specific gems

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -844,7 +844,9 @@ class Gem::Specification < Gem::BasicSpecification
     specs.sort! do |a, b|
       names = a.name <=> b.name
       next names if names.nonzero?
-      b.version <=> a.version
+      versions = b.version <=> a.version
+      next versions if versions.nonzero?
+      b.platform == Gem::Platform::RUBY ? -1 : 1
     end
   end
 
@@ -1080,20 +1082,15 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   def self._latest_specs(specs, prerelease = false) # :nodoc:
-    result = Hash.new {|h,k| h[k] = {} }
-    native = {}
+    result = {}
 
     specs.reverse_each do |spec|
       next if spec.version.prerelease? unless prerelease
 
-      native[spec.name] = spec.version if spec.platform == Gem::Platform::RUBY
-      result[spec.name][spec.platform] = spec
+      result[spec.name] = spec
     end
 
-    result.map(&:last).map(&:values).flatten.reject do |spec|
-      minimum = native[spec.name]
-      minimum && spec.version < minimum
-    end.sort_by{|tup| tup.name }
+    result.map(&:last).flatten.sort_by{|tup| tup.name }
   end
 
   ##

--- a/test/rubygems/test_gem_commands_outdated_command.rb
+++ b/test/rubygems/test_gem_commands_outdated_command.rb
@@ -28,4 +28,22 @@ class TestGemCommandsOutdatedCommand < Gem::TestCase
     assert_equal "foo (0.2 < 2.0)\n", @ui.output
     assert_equal "", @ui.error
   end
+
+  def test_execute_with_up_to_date_platform_specific_gem
+    spec_fetcher do |fetcher|
+      fetcher.download 'foo', '2.0'
+
+      fetcher.gem 'foo', '1.0'
+      fetcher.gem 'foo', '2.0' do |s|
+        s.platform = Gem::Platform.local
+      end
+    end
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    assert_equal "", @ui.output
+    assert_equal "", @ui.error
+  end
 end

--- a/test/rubygems/test_gem_dependency_installer.rb
+++ b/test/rubygems/test_gem_dependency_installer.rb
@@ -44,7 +44,7 @@ class TestGemDependencyInstaller < Gem::TestCase
       s.add_development_dependency 'c'
     end
 
-    util_reset_gems
+    util_setup_spec_fetcher(@a1, @a1_pre, @b1, @d1)
   end
 
   def test_install
@@ -1125,16 +1125,6 @@ class TestGemDependencyInstaller < Gem::TestCase
     @d1, @d1_gem = util_gem 'd', '1'
     @d2, @d2_gem = util_gem 'd', '2'
 
-    util_reset_gems
-  end
-
-  def util_reset_gems
-    @a1     ||= nil
-    @b1     ||= nil
-    @a1_pre ||= nil
-    @d1     ||= nil
-    @d2     ||= nil
-
-    util_setup_spec_fetcher(*[@a1, @a1_pre, @b1, @d1, @d2].compact)
+    util_setup_spec_fetcher(@d1, @d2)
   end
 end

--- a/test/rubygems/test_gem_dependency_installer.rb
+++ b/test/rubygems/test_gem_dependency_installer.rb
@@ -287,8 +287,6 @@ class TestGemDependencyInstaller < Gem::TestCase
 
     @aa1, @aa1_gem = util_gem 'aa', '1'
 
-    util_reset_gems
-
     FileUtils.mv @a1_gem, @tempdir
     FileUtils.mv @aa1_gem, @tempdir
     FileUtils.mv @b1_gem, @tempdir
@@ -306,8 +304,6 @@ class TestGemDependencyInstaller < Gem::TestCase
     util_setup_gems
 
     @aa1, @aa1_gem = util_gem 'aa', '1'
-
-    util_reset_gems
 
     FileUtils.mv @a1_gem, @tempdir
     FileUtils.mv @aa1_gem, @tempdir
@@ -328,8 +324,6 @@ class TestGemDependencyInstaller < Gem::TestCase
     util_setup_gems
 
     @aa1, @aa1_gem = util_gem 'aa', '1'
-
-    util_reset_gems
 
     FileUtils.mv @a1_gem, @tempdir
     FileUtils.mv @aa1_gem, @tempdir

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3522,19 +3522,6 @@ Did you mean 'Ruby'?
     specfile.delete
   end
 
-  ##
-  # KEEP p-1-x86-darwin-8
-  # KEEP p-1
-  # KEEP c-1.2
-  # KEEP a_evil-9
-  #      a-1
-  #      a-1-x86-my_platform-1
-  # KEEP a-2
-  #      a-2-x86-other_platform-1
-  # KEEP a-2-x86-my_platform-1
-  #      a-3.a
-  # KEEP a-3-x86-other_platform-1
-
   def test_latest_specs
     spec_fetcher do |fetcher|
       fetcher.spec 'a', 1 do |s|

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3544,8 +3544,6 @@ Did you mean 'Ruby'?
     end
 
     expected = %W[
-      a-2
-      a-2-x86-my_platform-1
       a-3-x86-other_platform-1
     ]
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If you have an up to date platform specific gem installed, and a lower ruby specific version, it would report the gem as out of date.

See https://github.com/sparklemotion/nokogiri/issues/2165#issuecomment-754397985.

## What is your fix for the problem, implemented in this PR?

My fix is to  change the outcome of `Gem.latest_specs` to return the latest spec for each gem, not the latest spec for each gem and platform.

I don't see how the previous behavior could be useful, and it was causing this bug.

I also had to add a small tweak to a sorting method because one test was no longer relying on the previous behavior of `Gem.latest_specs` and was no returning the RUBY variant first in the edge case of two gems with the same version but different platform installed at the same time.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)