### PR TITLE
Adds additional uniqueness to `Requirement` hashes

### DIFF
--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -190,7 +190,7 @@ class Gem::Requirement
   end
 
   def hash # :nodoc:
-    requirements.sort.hash
+    requirements.map {|r| r.first == "~>" || r.first == "=" ? [r[0], r[1].to_s] : r }.sort.hash
   end
 
   def marshal_dump # :nodoc:

--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -401,6 +401,27 @@ class TestGemRequirement < Gem::TestCase
     assert_equal r1.hash, r2.hash
   end
 
+  def test_hash_equality_same_as_equals
+    refute_requirement_hash_equal "= 1.2", "= 1.3"
+    refute_requirement_hash_equal "= 1.3", "= 1.2"
+
+    refute_requirement_hash_equal "~> 1.3", "~> 1.3.0"
+    refute_requirement_hash_equal "~> 1.3.0", "~> 1.3"
+
+    assert_requirement_hash_equal ["> 2", "~> 1.3", "~> 1.3.1"], ["~> 1.3.1", "~> 1.3", "> 2"]
+
+    assert_requirement_hash_equal ["> 2", "~> 1.3"], ["> 2.0", "~> 1.3"]
+    assert_requirement_hash_equal ["> 2.0", "~> 1.3"], ["> 2", "~> 1.3"]
+
+    refute_requirement_hash_equal "= 1.0", "= 1.0.0"
+    refute_requirement_hash_equal "= 1.1", "= 1.1.0"
+    refute_requirement_hash_equal "= 1", "= 1.0.0"
+
+    refute_requirement_hash_equal "1.0", "1.0.0"
+    refute_requirement_hash_equal "1.1", "1.1.0"
+    refute_requirement_hash_equal "1", "1.0.0"
+  end
+
   # Assert that two requirements are equal. Handles Gem::Requirements,
   # strings, arrays, numbers, and versions.
 
@@ -415,6 +436,13 @@ class TestGemRequirement < Gem::TestCase
       "#{requirement} is satisfied by #{version}"
   end
 
+  # Assert that two requirement hashes are equal. Handles Gem::Requirements,
+  # strings, arrays, numbers, and versions.
+
+  def assert_requirement_hash_equal(expected, actual)
+    assert_equal req(expected).hash, req(actual).hash
+  end
+
   # Refute the assumption that two requirements are equal.
 
   def refute_requirement_equal(unexpected, actual)
@@ -426,5 +454,11 @@ class TestGemRequirement < Gem::TestCase
   def refute_satisfied_by(version, requirement)
     refute req(requirement).satisfied_by?(v(version)),
       "#{requirement} is not satisfied by #{version}"
+  end
+
+  # Refute the assumption that two requirements hashes are equal.
+
+  def refute_requirement_hash_equal(unexpected, actual)
+    refute_equal req(unexpected).hash, req(actual).hash
   end
 end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

`Gem::Requirement#hash` currently returns the same hash for "\~> 2.0" and "\~> 2.0.0" even though these are not equal according to `Gem::Requirement#==`.

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

This fix returns a unique hash that is similar equality guarantees as `Gem::Requirement#==`,
though it also provides different hashes when an exact match is
requested, whereas `==` only differentiates them when there is a tilde
requirement.

`Gem::Requirement#==` gives:

```
  assert_requirement_equal "= 1.0", "= 1.0.0"
```

Whereas `Gem::Requirement#hash` gives:

```
  refute_requirement_hash_equal "= 1.0", "= 1.0.0"
```

I am not at all sure if the functioning of `Gem::Requirement#==` should not be changed as gem bumping depends on the full number of points even when they are 0, much like in the case of a tilde requirement.

## Make sure the following tasks are checked

- [x ] Describe the problem / feature
- [x ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x ] Write code to solve the problem
- [x ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
