### PR TITLE
Workaround for another jruby crash when autoloading a constant

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -63,7 +63,6 @@ module Bundler
   autoload :Resolver,               File.expand_path("bundler/resolver", __dir__)
   autoload :Retry,                  File.expand_path("bundler/retry", __dir__)
   autoload :RubyDsl,                File.expand_path("bundler/ruby_dsl", __dir__)
-  autoload :RubyGemsGemInstaller,   File.expand_path("bundler/rubygems_gem_installer", __dir__)
   autoload :RubyVersion,            File.expand_path("bundler/ruby_version", __dir__)
   autoload :Runtime,                File.expand_path("bundler/runtime", __dir__)
   autoload :Settings,               File.expand_path("bundler/settings", __dir__)

--- a/bundler/lib/bundler/source/path/installer.rb
+++ b/bundler/lib/bundler/source/path/installer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../../rubygems_gem_installer"
+
 module Bundler
   class Source
     class Path

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -145,6 +145,8 @@ module Bundler
 
           Bundler.mkdir_p bin_path, :no_sudo => true unless spec.executables.empty? || Bundler.rubygems.provides?(">= 2.7.5")
 
+          require_relative "../rubygems_gem_installer"
+
           installed_spec = Bundler::RubyGemsGemInstaller.at(
             path,
             :install_dir         => install_path.to_s,


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

See https://github.com/rubygems/rubygems/runs/1662234887.

## What is your fix for the problem, implemented in this PR?

JRuby has issue with autoload that come up once in a while in our test suite. Normally they happen when a file is required explicitly and the constant it provides is also autoloaded. We normally workaround those issues by removing either the require or the autoload, and they never reappear.

However in this case I can't see the duplicated require/autoload, so since the constant is only used in two places I'm replacing the `autoload` with two inline requires.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)