### PR TITLE
Fix warnings when running rubygems tests on ruby 3.0

### DIFF
--- a/dev_gems.rb.lock
+++ b/dev_gems.rb.lock
@@ -86,7 +86,7 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
     unicode-display_width (1.6.1)
-    webrick (1.6.0)
+    webrick (1.7.0)
 
 PLATFORMS
   java


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The following warning when running rubygems tests on ruby 3.0:

```
/path/to/webrick-1.6.0/lib/webrick/utils.rb:50: warning: Socket.gethostbyname is deprecated; use Addrinfo.getaddrinfo instead
```

## What is your fix for the problem, implemented in this PR?

Update webrick where the problem is fixed.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)