### PR TITLE
Don't load more specs after the whole set of specs has been setup

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -182,6 +182,7 @@ class Gem::Specification < Gem::BasicSpecification
     @@default_value[k].nil?
   end
 
+  @@stubs = nil
   @@stubs_by_name = {}
 
   # Sentinel object to represent "not found" stubs
@@ -823,10 +824,10 @@ class Gem::Specification < Gem::BasicSpecification
   # only returns stubs that match Gem.platforms
 
   def self.stubs_for(name)
-    if @@stubs_by_name[name]
-      @@stubs_by_name[name]
+    if @@stubs
+      @@stubs_by_name[name] || []
     else
-      @@stubs_by_name[name] = stubs_for_pattern("#{name}-*.gemspec")
+      @@stubs_by_name[name] ||= stubs_for_pattern("#{name}-*.gemspec")
     end
   end
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -826,10 +826,7 @@ class Gem::Specification < Gem::BasicSpecification
     if @@stubs_by_name[name]
       @@stubs_by_name[name]
     else
-      pattern = "#{name}-*.gemspec"
-      stubs = stubs_for_pattern(pattern)
-
-      @@stubs_by_name[name] = stubs
+      @@stubs_by_name[name] = stubs_for_pattern("#{name}-*.gemspec")
     end
   end
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -800,10 +800,8 @@ class Gem::Specification < Gem::BasicSpecification
   def self.stubs
     @@stubs ||= begin
       pattern = "*.gemspec"
-      stubs = installed_stubs(dirs, pattern) + default_stubs(pattern)
-      stubs = stubs.uniq {|stub| stub.full_name }
+      stubs = stubs_for_pattern(pattern, false)
 
-      _resort!(stubs)
       @@stubs_by_name = stubs.select {|s| Gem::Platform.match_spec? s }.group_by(&:name)
       stubs
     end
@@ -829,12 +827,23 @@ class Gem::Specification < Gem::BasicSpecification
       @@stubs_by_name[name]
     else
       pattern = "#{name}-*.gemspec"
-      stubs = installed_stubs(dirs, pattern).select {|s| Gem::Platform.match_spec? s } + default_stubs(pattern)
-      stubs = stubs.uniq {|stub| stub.full_name }
-      _resort!(stubs)
+      stubs = stubs_for_pattern(pattern)
 
       @@stubs_by_name[name] = stubs
     end
+  end
+
+  ##
+  # Finds stub specifications matching a pattern from the standard locations,
+  # optionally filtering out specs not matching the current platform
+  #
+  def self.stubs_for_pattern(pattern, match_platform = true) # :nodoc:
+    installed_stubs = installed_stubs(Gem::Specification.dirs, pattern)
+    installed_stubs.select! {|s| Gem::Platform.match_spec? s } if match_platform
+    stubs = installed_stubs + default_stubs(pattern)
+    stubs = stubs.uniq {|stub| stub.full_name }
+    _resort!(stubs)
+    stubs
   end
 
   def self._resort!(specs) # :nodoc:

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -820,8 +820,6 @@ class Gem::Specification < Gem::BasicSpecification
     end
   end
 
-  EMPTY = [].freeze # :nodoc:
-
   ##
   # Returns a Gem::StubSpecification for installed gem named +name+
   # only returns stubs that match Gem.platforms
@@ -832,11 +830,10 @@ class Gem::Specification < Gem::BasicSpecification
     else
       pattern = "#{name}-*.gemspec"
       stubs = installed_stubs(dirs, pattern).select {|s| Gem::Platform.match_spec? s } + default_stubs(pattern)
-      stubs = stubs.uniq {|stub| stub.full_name }.group_by(&:name)
-      stubs.each_value {|v| _resort!(v) }
+      stubs = stubs.uniq {|stub| stub.full_name }
+      _resort!(stubs)
 
-      @@stubs_by_name.merge! stubs
-      @@stubs_by_name[name] ||= EMPTY
+      @@stubs_by_name[name] = stubs
     end
   end
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1161,6 +1161,14 @@ dependencies: []
     Gem::Specification.class_variable_set(:@@stubs, nil)
   end
 
+  def test_self_stubs_for_no_lazy_loading_after_all_specs_setup
+    Gem::Specification.all = [util_spec('a', '1')]
+
+    save_gemspec('b-1', '1', File.join(Gem.dir, 'specifications')){|s| s.name = 'b' }
+
+    assert_equal [], Gem::Specification.stubs_for('b').map {|s| s.full_name }
+  end
+
   def test_self_stubs_for_mult_platforms
     # gems for two different platforms are installed with --user-install
     # the correct one should be returned in the array


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If bundler is being used, and spec is not included in the bundle, `Gem::Specification.find_by_name` will still leak outside of the bundle and find globally installed specs.

## What is your fix for the problem, implemented in this PR?

This is a regression of https://github.com/rubygems/rubygems/pull/2711.

The lazy loading provided by that PR when the whole set of `@@stubs` is not yet set is still interesting, so I kept that but restored the old behaviour of not trying to load anything else once `@@stubs` have been set.

Fixes https://github.com/rubygems/rubygems/issues/4253.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)