### PR TITLE
Show a backtrace for flaky spec failure

### DIFF
--- a/bundler/spec/install/gems/resolving_spec.rb
+++ b/bundler/spec/install/gems/resolving_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe "bundle install with install-time dependencies" do
           gem "net_e"
         G
 
-        bundle :install, :env => { "DEBUG_RESOLVER_TREE" => "1" }
+        bundle :install, :env => { "DEBUG_RESOLVER_TREE" => "1", "DEBUG" => "1" }
 
         activated_groups = if local_platforms.any?
           "net_b (1.0) (#{local_platforms.join(", ")})"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

A flaky spec we're getting recently. I have a specific candidate when I think this error is being raised. Showing a backtrace will help me confirm the theory.

## What is your fix for the problem, implemented in this PR?

I think we should probably showing a backtrace by default. But for now I just want to figure out this flaky spec, so I'm enabling debug mode for this spec so that it shows a backtrace.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)