### PR TITLE
Make sure lockfile is locked to the proper bundler version on each branch

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,11 @@ task :setup do
   sh "ruby", "bundler/bin/bundle", "install", "--gemfile=dev_gems.rb"
 end
 
+desc "Update Rubygems dev environment"
+task :update do |_, args|
+  sh "ruby", "bundler/bin/bundle", "update", *args, "--gemfile=dev_gems.rb"
+end
+
 desc "Setup git hooks"
 task :git_hooks do
   sh "git config core.hooksPath .githooks"

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ require 'psych'
 
 desc "Setup Rubygems dev environment"
 task :setup do
-  sh "ruby bundler/bin/bundle install --gemfile=dev_gems.rb"
+  sh "ruby", "bundler/bin/bundle", "install", "--gemfile=dev_gems.rb"
 end
 
 desc "Setup git hooks"

--- a/util/release.rb
+++ b/util/release.rb
@@ -161,6 +161,7 @@ class Release
       system("git", "commit", "-am", "Changelog for Bundler version #{@bundler.version}", exception: true)
 
       @bundler.bump_versions!
+      system("rake", "update[--bundler]", exception: true)
       system("git", "commit", "-am", "Bump Bundler version to #{@bundler.version}", exception: true)
 
       @rubygems.cut_changelog!

--- a/util/release.rb
+++ b/util/release.rb
@@ -18,7 +18,7 @@ class Release
   module SubRelease
     include GithubAPI
 
-    attr_reader :version, :changelog, :version_files, :name, :tag_prefix
+    attr_reader :version, :changelog, :version_files, :tag_prefix
 
     def cut_changelog_for!(pull_requests)
       set_relevant_pull_requests_from(pull_requests)
@@ -72,7 +72,6 @@ class Release
       @stable_branch = stable_branch
       @changelog = Changelog.for_bundler(version)
       @version_files = [File.expand_path("../bundler/lib/bundler/version.rb", __dir__)]
-      @name = "Bundler"
       @tag_prefix = "bundler-v"
     end
   end
@@ -85,7 +84,6 @@ class Release
       @stable_branch = stable_branch
       @changelog = Changelog.for_rubygems(version)
       @version_files = [File.expand_path("../lib/rubygems.rb", __dir__), File.expand_path("../rubygems-update.gemspec", __dir__)]
-      @name = "Rubygems"
       @tag_prefix = "v"
     end
   end
@@ -159,13 +157,17 @@ class Release
         end
       end
 
-      [@bundler, @rubygems].each do |library|
-        library.cut_changelog!
-        system("git", "commit", "-am", "Changelog for #{library.name} version #{library.version}", exception: true)
+      @bundler.cut_changelog!
+      system("git", "commit", "-am", "Changelog for Bundler version #{@bundler.version}", exception: true)
 
-        library.bump_versions!
-        system("git", "commit", "-am", "Bump #{library.name} version to #{library.version}", exception: true)
-      end
+      @bundler.bump_versions!
+      system("git", "commit", "-am", "Bump Bundler version to #{@bundler.version}", exception: true)
+
+      @rubygems.cut_changelog!
+      system("git", "commit", "-am", "Changelog for Rubygems version #{@rubygems.version}", exception: true)
+
+      @rubygems.bump_versions!
+      system("git", "commit", "-am", "Bump Rubygems version to #{@rubygems.version}", exception: true)
     rescue StandardError
       system("git", "checkout", initial_branch, exception: true)
       system("git", "branch", "-D", @release_branch, exception: true)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Our `rake setup` task will use the development bundler. In the stable branch, that's currently 2.2.5, but the `dev_gems.rb.locked` is locked to bundler 2.3.0.dev.

That generates a warning when running `rake setup` on the stable branch like:

```
Warning: the running version of Bundler (2.2.5) is older than the version that created the lockfile (2.3.0.dev). We suggest you to upgrade to the version that created the lockfile by running `gem install bundler:2.3.0.dev --pre`.
```

## What is your fix for the problem, implemented in this PR?

This PR makes sure the `dev_gems.rb.locked` file is always locked to the proper development bundler in the stable branch.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)