### PR TITLE
Restore accepting custom make command with extra options as the `make` env variable

### DIFF
--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -28,13 +28,14 @@ class Gem::Ext::Builder
     unless make_program
       make_program = (/mswin/ =~ RUBY_PLATFORM) ? 'nmake' : 'make'
     end
+    make_program = Shellwords.split(make_program)
 
     destdir = 'DESTDIR=%s' % ENV['DESTDIR']
 
     ['clean', '', 'install'].each do |target|
       # Pass DESTDIR via command line to override what's in MAKEFLAGS
       cmd = [
-        make_program,
+        *make_program,
         destdir,
         target,
       ].reject(&:empty?)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Debian's gem2deb passes a set of build variables to Rubygems extension builders using ENV['make']. These options are used to produce hardened binaries, as well as to help with reproducible builds.

After ad632bb0800a07433b8d9a9dd8269dd3bcb2f068, it no longer works.

## What is your fix for the problem, implemented in this PR?

Consider this case and shellsplit it before passing it to process spawning helpers.
 
## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
