### PR TITLE
Minor release blog post generation fixes

### DIFF
--- a/util/changelog.rb
+++ b/util/changelog.rb
@@ -66,7 +66,7 @@ class Changelog
     last_change_type = types.pop
 
     if types.empty?
-      types = ''
+      types = +''
     else
       types = types.join(', ') << ' and '
     end

--- a/util/changelog.rb
+++ b/util/changelog.rb
@@ -60,7 +60,7 @@ class Changelog
   def change_types_for_blog
     types = release_notes
       .select {|line| change_types.include?(line) }
-      .map {|line| line.downcase.tr '^a-z ', '' }
+      .map {|line| line.downcase.tr('^a-z ', '').strip }
       .uniq
 
     last_change_type = types.pop


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Script generating this rubygems release blog post crashed. In addition to that,
the release change types have some annoying extra spaces. I don't think they
render different in the website, but they annoy me when I see them in the
blog post sources :sweat_smile:

## What is your fix for the problem, implemented in this PR?

Fix is to make sure we don't try to modify a frozen string in the case when the
release has a single type of changes, and that we string trailing and leading
whitespaces from the list of changes.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)