### PR TITLE
Enable `Style/NilComparison` cop in rubygems

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -129,6 +129,9 @@ Style/MultilineIfThen:
 Style/MutableConstant:
   Enabled: true
 
+Style/NilComparison:
+  Enabled: true
+
 Style/BlockDelimiters:
   Enabled: true
 

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -295,7 +295,7 @@ class Gem::RemoteFetcher
 
     data = fetch_path(uri, mtime)
 
-    if data == nil # indicates the server returned 304 Not Modified
+    if data.nil? # indicates the server returned 304 Not Modified
       return Gem.read_binary(path)
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I was reviewing a PR and noticed this a little inconsistency being introduced.

## What is your fix for the problem, implemented in this PR?

My fix is to enable the corresponding cop.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)