### PR TITLE
Fix `Gem::Platform#inspect` showing duplicate information

### DIFF
--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -121,10 +121,6 @@ class Gem::Platform
     end
   end
 
-  def inspect
-    "%s @cpu=%p, @os=%p, @version=%p>" % [super[0..-2], *to_a]
-  end
-
   def to_a
     [@cpu, @os, @version]
   end

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -356,6 +356,14 @@ class TestGemPlatform < Gem::TestCase
     assert_local_match 'sparc-solaris2.8-mq5.3'
   end
 
+  def test_inspect
+    result = Gem::Platform.new("universal-java11").inspect
+
+    assert_equal 1, result.scan(/@cpu=/).size
+    assert_equal 1, result.scan(/@os=/).size
+    assert_equal 1, result.scan(/@version=/).size
+  end
+
   def assert_local_match(name)
     assert_match Gem::Platform.local, name
   end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

`Gem::Platform#inspect` shows duplicated information. For example,

```
irb(main):001:0> Gem::Platform.new(RbConfig::CONFIG["arch"])
=> #<Gem::Platform:0x27df95e @os="java", @version="11", @cpu="universal" @cpu="universal", @os="java", @version="11">
```

## What is your fix for the problem, implemented in this PR?

Remove the custom implementation.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)