### PR TITLE
Fix resolver edge cases and speed up bundler

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -890,7 +890,7 @@ module Bundler
       dependencies.each do |dep|
         dep = Dependency.new(dep, ">= 0") unless dep.respond_to?(:name)
         next unless remote || dep.current_platform?
-        target_platforms = dep.gem_platforms(remote ? Resolver.sort_platforms(@platforms) : [generic_local_platform])
+        target_platforms = dep.gem_platforms(remote ? @platforms : [generic_local_platform])
         deps += expand_dependency_with_platforms(dep, target_platforms)
       end
       deps

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -263,19 +263,18 @@ module Bundler
     def resolve
       @resolve ||= begin
         last_resolve = converge_locked_specs
-        resolve =
-          if Bundler.frozen_bundle?
-            Bundler.ui.debug "Frozen, using resolution from the lockfile"
-            last_resolve
-          elsif !unlocking? && nothing_changed?
-            Bundler.ui.debug("Found no changes, using resolution from the lockfile")
-            last_resolve
-          else
-            # Run a resolve against the locally available gems
-            Bundler.ui.debug("Found changes from the lockfile, re-resolving dependencies because #{change_reason}")
-            expanded_dependencies = expand_dependencies(dependencies + metadata_dependencies, @remote)
-            last_resolve.merge Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve, gem_version_promoter, additional_base_requirements_for_resolve, platforms)
-          end
+        if Bundler.frozen_bundle?
+          Bundler.ui.debug "Frozen, using resolution from the lockfile"
+          last_resolve
+        elsif !unlocking? && nothing_changed?
+          Bundler.ui.debug("Found no changes, using resolution from the lockfile")
+          last_resolve
+        else
+          # Run a resolve against the locally available gems
+          Bundler.ui.debug("Found changes from the lockfile, re-resolving dependencies because #{change_reason}")
+          expanded_dependencies = expand_dependencies(dependencies + metadata_dependencies, @remote)
+          last_resolve.merge Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve, gem_version_promoter, additional_base_requirements_for_resolve, platforms)
+        end
       end
     end
 

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -276,10 +276,6 @@ module Bundler
             expanded_dependencies = expand_dependencies(dependencies + metadata_dependencies, @remote)
             last_resolve.merge Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve, gem_version_promoter, additional_base_requirements_for_resolve, platforms)
           end
-
-        # filter out gems that _can_ be installed on multiple platforms, but don't need
-        # to be
-        resolve.for(expand_dependencies(dependencies, true), [], false, false, false)
       end
     end
 

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -273,7 +273,7 @@ module Bundler
           # Run a resolve against the locally available gems
           Bundler.ui.debug("Found changes from the lockfile, re-resolving dependencies because #{change_reason}")
           expanded_dependencies = expand_dependencies(dependencies + metadata_dependencies, @remote)
-          last_resolve.merge Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve, gem_version_promoter, additional_base_requirements_for_resolve, platforms)
+          Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve, gem_version_promoter, additional_base_requirements_for_resolve, platforms)
         end
       end
     end

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -4,22 +4,6 @@ require_relative "match_platform"
 
 module Bundler
   class LazySpecification
-    Identifier = Struct.new(:name, :version, :platform)
-    class Identifier
-      include Comparable
-      def <=>(other)
-        return unless other.is_a?(Identifier)
-        [name, version, platform_string] <=> [other.name, other.version, other.platform_string]
-      end
-
-      protected
-
-      def platform_string
-        platform_string = platform.to_s
-        platform_string == Index::RUBY ? Index::NULL : platform_string
-      end
-    end
-
     include MatchPlatform
 
     attr_reader :name, :version, :dependencies, :platform
@@ -108,12 +92,19 @@ module Bundler
     end
 
     def identifier
-      @__identifier ||= Identifier.new(name, version, platform)
+      @__identifier ||= [name, version, platform_string]
     end
 
     def git_version
       return unless source.is_a?(Bundler::Source::Git)
       " #{source.revision[0..6]}"
+    end
+
+    protected
+
+    def platform_string
+      platform_string = platform.to_s
+      platform_string == Index::RUBY ? Index::NULL : platform_string
     end
 
     private

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -147,7 +147,7 @@ module Bundler
 
             next groups if @platforms == [Gem::Platform::RUBY]
 
-            spec_group = SpecGroup.create_for(specs_by_platform, self.class.sort_platforms(@platforms).reverse, platform)
+            spec_group = SpecGroup.create_for(specs_by_platform, @platforms, platform)
             groups << spec_group if spec_group
 
             groups
@@ -230,13 +230,6 @@ module Bundler
           vertex.payload ? 0 : search_for(dependency).count,
           self.class.platform_sort_key(dependency.__platform),
         ]
-      end
-    end
-
-    # Sort platforms from most general to most specific
-    def self.sort_platforms(platforms)
-      platforms.sort_by do |platform|
-        platform_sort_key(platform)
       end
     end
 

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -151,17 +151,14 @@ module Bundler
         selected_sgs = []
         search.each do |sg|
           next unless sg.for?(platform)
-          sg_all_platforms = sg.copy_for(self.class.sort_platforms(@platforms).reverse)
-          next unless sg_all_platforms
 
-          selected_sgs << sg_all_platforms
+          sg_ruby = sg.copy_for([Gem::Platform::RUBY])
+          selected_sgs << sg_ruby if sg_ruby
 
           next if @platforms == [Gem::Platform::RUBY]
 
-          sg_ruby = sg.copy_for([Gem::Platform::RUBY])
-          next unless sg_ruby
-
-          selected_sgs.insert(-2, sg_ruby)
+          sg_all_platforms = sg.copy_for(self.class.sort_platforms(@platforms).reverse)
+          selected_sgs << sg_all_platforms if sg_all_platforms
         end
         selected_sgs
       end

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -37,6 +37,7 @@ module Bundler
       end
       additional_base_requirements.each {|d| @base_dg.add_vertex(d.name, d) }
       @platforms = platforms
+      @resolving_only_for_ruby = platforms == [Gem::Platform::RUBY]
       @gem_version_promoter = gem_version_promoter
       @use_gvp = Bundler.feature_flag.use_gem_version_promoter_for_major_updates? || !@gem_version_promoter.major?
       @lockfile_uses_separate_rubygems_sources = Bundler.feature_flag.disable_multisource?
@@ -145,7 +146,7 @@ module Bundler
             spec_group_ruby = SpecGroup.create_for(specs_by_platform, [Gem::Platform::RUBY], Gem::Platform::RUBY)
             groups << spec_group_ruby if spec_group_ruby
 
-            next groups if @platforms == [Gem::Platform::RUBY]
+            next groups if @resolving_only_for_ruby
 
             spec_group = SpecGroup.create_for(specs_by_platform, @platforms, platform)
             groups << spec_group if spec_group

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -157,8 +157,7 @@ module Bundler
           selected_sgs << sg_all_platforms
 
           next if sg_all_platforms.activated_platforms == [Gem::Platform::RUBY]
-          # Add a spec group for "non platform specific spec" as the fallback
-          # spec group.
+
           sg_ruby = sg.copy_for([Gem::Platform::RUBY])
           next unless sg_ruby
 

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -156,7 +156,7 @@ module Bundler
 
           selected_sgs << sg_all_platforms
 
-          next if sg_all_platforms.activated_platforms == [Gem::Platform::RUBY]
+          next if @platforms == [Gem::Platform::RUBY]
 
           sg_ruby = sg.copy_for([Gem::Platform::RUBY])
           next unless sg_ruby

--- a/bundler/lib/bundler/resolver/spec_group.rb
+++ b/bundler/lib/bundler/resolver/spec_group.rb
@@ -92,19 +92,16 @@ module Bundler
       def __dependencies
         @dependencies = Hash.new do |dependencies, platform|
           dependencies[platform] = []
-          specs = @specs[platform]
-          if spec = specs.first
-            spec.dependencies.each do |dep|
-              next if dep.type == :development
-              dependencies[platform] << DepProxy.get_proxy(dep, platform)
-            end
+          @specs[platform].first.dependencies.each do |dep|
+            next if dep.type == :development
+            dependencies[platform] << DepProxy.get_proxy(dep, platform)
           end
           dependencies[platform]
         end
       end
 
       def metadata_dependencies(spec, platform)
-        return [] unless spec && spec.is_a?(Gem::Specification)
+        return [] unless spec.is_a?(Gem::Specification)
         dependencies = []
         if !spec.required_ruby_version.nil? && !spec.required_ruby_version.none?
           dependencies << DepProxy.get_proxy(Gem::Dependency.new("Ruby\0", spec.required_ruby_version), platform)

--- a/bundler/lib/bundler/resolver/spec_group.rb
+++ b/bundler/lib/bundler/resolver/spec_group.rb
@@ -54,9 +54,7 @@ module Bundler
       end
 
       def dependencies_for_activated_platforms
-        activated_platforms.map do |platform|
-          __dependencies[platform] + metadata_dependencies(platform)
-        end.flatten
+        dependencies_for(activated_platforms)
       end
 
       def ==(other)
@@ -86,6 +84,12 @@ module Bundler
       end
 
       private
+
+      def dependencies_for(platforms)
+        platforms.map do |platform|
+          __dependencies[platform] + metadata_dependencies(platform)
+        end.flatten
+      end
 
       def __dependencies
         @dependencies = Hash.new do |dependencies, platform|

--- a/bundler/lib/bundler/resolver/spec_group.rb
+++ b/bundler/lib/bundler/resolver/spec_group.rb
@@ -16,8 +16,8 @@ module Bundler
         @source = exemplary_spec.source
 
         @activated_platforms = []
-        @dependencies = Hash.new do |dependencies, platform|
-          dependencies[platform] = __dependencies(platform)
+        @dependencies = Hash.new do |dependencies, platforms|
+          dependencies[platforms] = dependencies_for(platforms)
         end
         @specs = Hash.new do |specs, platform|
           specs[platform] = select_best_platform_match(all_specs, platform)
@@ -56,7 +56,7 @@ module Bundler
       end
 
       def dependencies_for_activated_platforms
-        dependencies_for(activated_platforms)
+        @dependencies[activated_platforms]
       end
 
       def ==(other)

--- a/bundler/lib/bundler/resolver/spec_group.rb
+++ b/bundler/lib/bundler/resolver/spec_group.rb
@@ -17,7 +17,7 @@ module Bundler
 
         @activated_platforms = []
         @dependencies = nil
-        @specs        = Hash.new do |specs, platform|
+        @specs = Hash.new do |specs, platform|
           specs[platform] = select_best_platform_match(all_specs, platform)
         end
       end

--- a/bundler/lib/bundler/resolver/spec_group.rb
+++ b/bundler/lib/bundler/resolver/spec_group.rb
@@ -54,11 +54,9 @@ module Bundler
       end
 
       def dependencies_for_activated_platforms
-        dependencies = @activated_platforms.map {|p| __dependencies[p] }
-        metadata_dependencies = @activated_platforms.map do |platform|
-          metadata_dependencies(@specs[platform].first, platform)
-        end
-        dependencies.concat(metadata_dependencies).flatten
+        @activated_platforms.map do |platform|
+          __dependencies[platform] + metadata_dependencies(@specs[platform].first, platform)
+        end.flatten
       end
 
       def ==(other)

--- a/bundler/lib/bundler/resolver/spec_group.rb
+++ b/bundler/lib/bundler/resolver/spec_group.rb
@@ -55,7 +55,7 @@ module Bundler
 
       def dependencies_for_activated_platforms
         @activated_platforms.map do |platform|
-          __dependencies[platform] + metadata_dependencies(@specs[platform].first, platform)
+          __dependencies[platform] + metadata_dependencies(platform)
         end.flatten
       end
 
@@ -98,7 +98,8 @@ module Bundler
         end
       end
 
-      def metadata_dependencies(spec, platform)
+      def metadata_dependencies(platform)
+        spec = @specs[platform].first
         return [] unless spec.is_a?(Gem::Specification)
         dependencies = []
         if !spec.required_ruby_version.nil? && !spec.required_ruby_version.none?

--- a/bundler/lib/bundler/resolver/spec_group.rb
+++ b/bundler/lib/bundler/resolver/spec_group.rb
@@ -10,7 +10,7 @@ module Bundler
 
       def initialize(all_specs)
         @all_specs = all_specs
-        raise ArgumentError, "cannot initialize with an empty value" unless exemplary_spec = all_specs.first
+        exemplary_spec = all_specs.first
         @name = exemplary_spec.name
         @version = exemplary_spec.version
         @source = exemplary_spec.source

--- a/bundler/lib/bundler/resolver/spec_group.rb
+++ b/bundler/lib/bundler/resolver/spec_group.rb
@@ -23,7 +23,7 @@ module Bundler
       end
 
       def to_specs
-        @activated_platforms.map do |p|
+        activated_platforms.map do |p|
           specs = @specs[p]
           next unless specs.any?
 
@@ -54,7 +54,7 @@ module Bundler
       end
 
       def dependencies_for_activated_platforms
-        @activated_platforms.map do |platform|
+        activated_platforms.map do |platform|
           __dependencies[platform] + metadata_dependencies(platform)
         end.flatten
       end
@@ -82,7 +82,7 @@ module Bundler
       protected
 
       def sorted_activated_platforms
-        @activated_platforms.sort_by(&:to_s)
+        activated_platforms.sort_by(&:to_s)
       end
 
       private

--- a/bundler/lib/bundler/resolver/spec_group.rb
+++ b/bundler/lib/bundler/resolver/spec_group.rb
@@ -16,7 +16,9 @@ module Bundler
         @source = exemplary_spec.source
 
         @activated_platforms = []
-        @dependencies = nil
+        @dependencies = Hash.new do |dependencies, platform|
+          dependencies[platform] = __dependencies(platform)
+        end
         @specs = Hash.new do |specs, platform|
           specs[platform] = select_best_platform_match(all_specs, platform)
         end
@@ -87,19 +89,17 @@ module Bundler
 
       def dependencies_for(platforms)
         platforms.map do |platform|
-          __dependencies[platform] + metadata_dependencies(platform)
+          __dependencies(platform) + metadata_dependencies(platform)
         end.flatten
       end
 
-      def __dependencies
-        @dependencies = Hash.new do |dependencies, platform|
-          dependencies[platform] = []
-          @specs[platform].first.dependencies.each do |dep|
-            next if dep.type == :development
-            dependencies[platform] << DepProxy.get_proxy(dep, platform)
-          end
-          dependencies[platform]
+      def __dependencies(platform)
+        dependencies = []
+        @specs[platform].first.dependencies.each do |dep|
+          next if dep.type == :development
+          dependencies << DepProxy.get_proxy(dep, platform)
         end
+        dependencies
       end
 
       def metadata_dependencies(platform)

--- a/bundler/spec/bundler/gem_version_promoter_spec.rb
+++ b/bundler/spec/bundler/gem_version_promoter_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Bundler::GemVersionPromoter do
 
     def build_spec_groups(name, versions)
       versions.map do |v|
-        Bundler::Resolver::SpecGroup.new(build_spec(name, v))
+        Bundler::Resolver::SpecGroup.create_for({ Gem::Platform::RUBY => build_spec(name, v) }, [Gem::Platform::RUBY], Gem::Platform::RUBY)
       end
     end
 

--- a/bundler/spec/resolver/platform_spec.rb
+++ b/bundler/spec/resolver/platform_spec.rb
@@ -120,6 +120,157 @@ RSpec.describe "Resolving platform craziness" do
     should_resolve_as %w[foo-1.1.0]
   end
 
+  it "doesn't include gems not needed for none of the platforms" do
+    @index = build_index do
+      gem "empyrean", "0.1.0"
+      gem "coderay", "1.1.2"
+      gem "method_source", "0.9.0"
+
+      gem "spoon", "0.0.6" do
+        dep "ffi", ">= 0"
+      end
+
+      gem "pry", "0.11.3", "java" do
+        dep "coderay", "~> 1.1.0"
+        dep "method_source", "~> 0.9.0"
+        dep "spoon", "~> 0.0"
+      end
+
+      gem "pry", "0.11.3" do
+        dep "coderay", "~> 1.1.0"
+        dep "method_source", "~> 0.9.0"
+      end
+
+      gem "ffi", "1.9.23", "java"
+      gem "ffi", "1.9.23"
+    end
+
+    dep "empyrean", "0.1.0"
+    dep "pry"
+
+    platforms "ruby", "java"
+
+    should_resolve_as %w[coderay-1.1.2 empyrean-0.1.0 ffi-1.9.23-java method_source-0.9.0 pry-0.11.3 pry-0.11.3-java spoon-0.0.6]
+  end
+
+  it "includes gems needed for at least one platform" do
+    @index = build_index do
+      gem "empyrean", "0.1.0"
+      gem "coderay", "1.1.2"
+      gem "method_source", "0.9.0"
+
+      gem "spoon", "0.0.6" do
+        dep "ffi", ">= 0"
+      end
+
+      gem "pry", "0.11.3", "java" do
+        dep "coderay", "~> 1.1.0"
+        dep "method_source", "~> 0.9.0"
+        dep "spoon", "~> 0.0"
+      end
+
+      gem "pry", "0.11.3" do
+        dep "coderay", "~> 1.1.0"
+        dep "method_source", "~> 0.9.0"
+      end
+
+      gem "ffi", "1.9.23", "java"
+      gem "ffi", "1.9.23"
+
+      gem "extra", "1.0.0" do
+        dep "ffi", ">= 0"
+      end
+    end
+
+    dep "empyrean", "0.1.0"
+    dep "pry"
+    dep "extra"
+
+    platforms "ruby", "java"
+
+    should_resolve_as %w[coderay-1.1.2 empyrean-0.1.0 extra-1.0.0 ffi-1.9.23 ffi-1.9.23-java method_source-0.9.0 pry-0.11.3 pry-0.11.3-java spoon-0.0.6]
+  end
+
+  it "includes gems needed for at least one platform even when the platform specific requirement is processed earlier than the generic requirement" do
+    @index = build_index do
+      gem "empyrean", "0.1.0"
+      gem "coderay", "1.1.2"
+      gem "method_source", "0.9.0"
+
+      gem "spoon", "0.0.6" do
+        dep "ffi", ">= 0"
+      end
+
+      gem "pry", "0.11.3", "java" do
+        dep "coderay", "~> 1.1.0"
+        dep "method_source", "~> 0.9.0"
+        dep "spoon", "~> 0.0"
+      end
+
+      gem "pry", "0.11.3" do
+        dep "coderay", "~> 1.1.0"
+        dep "method_source", "~> 0.9.0"
+      end
+
+      gem "ffi", "1.9.23", "java"
+      gem "ffi", "1.9.23"
+
+      gem "extra", "1.0.0" do
+        dep "extra2", ">= 0"
+      end
+
+      gem "extra2", "1.0.0" do
+        dep "extra3", ">= 0"
+      end
+
+      gem "extra3", "1.0.0" do
+        dep "ffi", ">= 0"
+      end
+    end
+
+    dep "empyrean", "0.1.0"
+    dep "pry"
+    dep "extra"
+
+    platforms "ruby", "java"
+
+    should_resolve_as %w[coderay-1.1.2 empyrean-0.1.0 extra-1.0.0 extra2-1.0.0 extra3-1.0.0 ffi-1.9.23 ffi-1.9.23-java method_source-0.9.0 pry-0.11.3 pry-0.11.3-java spoon-0.0.6]
+  end
+
+  it "properly adds platforms when platform requirements come from different dependencies" do
+    @index = build_index do
+      gem "ffi", "1.9.14"
+      gem "ffi", "1.9.14", "universal-mingw32"
+
+      gem "gssapi", "0.1"
+      gem "gssapi", "0.2"
+      gem "gssapi", "0.3"
+      gem "gssapi", "1.2.0" do
+        dep "ffi", ">= 1.0.1"
+      end
+
+      gem "mixlib-shellout", "2.2.6"
+      gem "mixlib-shellout", "2.2.6", "universal-mingw32" do
+        dep "win32-process", "~> 0.8.2"
+      end
+
+      # we need all these versions to get the sorting the same as it would be
+      # pulling from rubygems.org
+      %w[0.8.3 0.8.2 0.8.1 0.8.0].each do |v|
+        gem "win32-process", v do
+          dep "ffi", ">= 1.0.0"
+        end
+      end
+    end
+
+    dep "mixlib-shellout"
+    dep "gssapi"
+
+    platforms "universal-mingw32", "ruby"
+
+    should_resolve_as %w[ffi-1.9.14 ffi-1.9.14-universal-mingw32 gssapi-1.2.0 mixlib-shellout-2.2.6 mixlib-shellout-2.2.6-universal-mingw32 win32-process-0.8.3]
+  end
+
   describe "with mingw32" do
     before :each do
       @index = build_index do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

It all started with https://github.com/rubygems/rubygems/issues/4275. Recent versions of bundler have caused a heavy `bundle install` performance regression, even in cases when there's a lockfile and all gems are already installed :grimacing:.

## What is your fix for the problem, implemented in this PR?

After an initial investigation of the problem, I noticed that reverting https://github.com/rubygems/bundler/pull/6495 fixed the issue. That gave me the idea that this PR fixed a resolution problem, but at an incorrect place (note how the platform filtering happens on top of the resolve (independently of whether resolution actually happened, or it was read from the lockfile).

So, the challenge was to fix that same problem inside the resolver, so that no overhead is needed in any case. The result of doing this (other than fixing this regression) is speeding up all `bundler/setup` requires. In the case of a generated default Rails application, the speed up is ~5-10% of boot time.

My first solution worked, but created an overhead on most resolutions, that would be a bit slower. The reason is that spec groups need to be modified dynamically depending on the currently activated platforms, so that whole `search_for` result for each dependency can no longer be fully memoized.

So I did a series on refactorings on the resolution process to not hurt performance. To measure results, I compiled a series of Gemfiles that have proven to be problematic in the past, and run the resolver before an after this PR. The results on my machine are as follows:

#### Before this PR

```
+-------------------------------+---------+---------------------+
|  Gemfile                      |  Steps  |  Seconds            |
+-------------------------------+---------+---------------------+
|  depfu                        |  242    |  0.985466332        |
|  solidus_shipwire             |  148    |  1.175150116        |
|  active_model_as_json_filter  |  948    |  1.262431201        |
|  simply_bussines              |  2061   |  1.623000041        |
|  tricky_groups                |  889    |  3.18565573         |
|  network_executive            |  2179   |  3.354704401        |
|  nix                          |  1087   |  4.492709607        |
|  fury-bug                     |  2471   |  4.693998945        |
|  doorkeeper-couchbase         |  8880   |  4.740346119        |
|  big                          |  1005   |  5.792436901        |
|  spree_pag_seguro             |  2192   |  8.232739329        |
|  refinerycms-photo-gallery    |  4814   |  9.35598295         |
|  activeadmin-redactor         |  4191   |  19.830266492       |
|  staple                       |  7330   |  22.273399876       |
|  mongoid_session_store_json   |  14497  |  29.598622289       |
+-------------------------------+---------+---------------------+
|  MEAN                         |  3528   |  8.039794021933334  |
+-------------------------------+---------+---------------------+
```

#### After this PR

```
+-------------------------------+---------+---------------------+
|  Gemfile                      |  Steps  |  Seconds            |
+-------------------------------+---------+---------------------+
|  depfu                        |  242    |  1.063837602        |
|  solidus_shipwire             |  148    |  1.187392968        |
|  active_model_as_json_filter  |  948    |  1.246154535        |
|  simply_bussines              |  2061   |  1.684438742        |
|  tricky_groups                |  889    |  2.785258354        |
|  doorkeeper-couchbase         |  8880   |  3.874559521        |
|  network_executive            |  2179   |  4.095082296        |
|  nix                          |  1087   |  4.098752359        |
|  big                          |  1005   |  4.958331229        |
|  fury-bug                     |  2471   |  5.048921037        |
|  spree_pag_seguro             |  2192   |  7.822267305        |
|  refinerycms-photo-gallery    |  4814   |  9.147989796        |
|  activeadmin-redactor         |  4191   |  9.24378089         |
|  staple                       |  7330   |  20.014836546       |
|  mongoid_session_store_json   |  14497  |  27.500409567       |
+-------------------------------+---------+---------------------+
|  MEAN                         |  3528   |  6.918134183133334  |
+-------------------------------+---------+---------------------+
 ```

Fixes https://github.com/rubygems/rubygems/issues/4275.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)