### PR TITLE
Improve resolver debugging

### DIFF
--- a/bundler/lib/bundler/gem_version_promoter.rb
+++ b/bundler/lib/bundler/gem_version_promoter.rb
@@ -81,8 +81,8 @@ module Bundler
           sort_dep_specs(spec_groups, locked_spec)
         end.tap do |specs|
           if DEBUG
-            warn before_result
-            warn " after sort_versions: #{debug_format_result(dep, specs).inspect}"
+            puts before_result
+            puts " after sort_versions: #{debug_format_result(dep, specs).inspect}"
           end
         end
       end

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -75,7 +75,7 @@ module Bundler
       return unless debug?
       debug_info = yield
       debug_info = debug_info.inspect unless debug_info.is_a?(String)
-      puts debug_info.split("\n").map {|s| "BUNDLER: " + "  " * depth + s }
+      puts debug_info.split("\n").map {|s| depth == 0 ? "BUNDLER: #{s}" : "BUNDLER(#{depth}): #{s}" }
     end
 
     def debug?


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Scanning through the output of `DEBUG_RESOLVER` is usually hard.

## What is your fix for the problem, implemented in this PR?

Add a couple of tweaks to make it easier:

* Print gem version promoter debugging to STDOUT, just like the other debugging information, so that when specs that activate resolver mode fail, they show all the debug information properly interlaced in the correct order.
* Show current depth as a number instead of with leading spaces, which usually gets out of hand very quickly.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)