### PR TITLE
Show backtrace for all potential flakies

### DIFF
--- a/bundler/spec/install/gems/resolving_spec.rb
+++ b/bundler/spec/install/gems/resolving_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "bundle install with install-time dependencies" do
     end
 
     it "installs plugins depended on by other plugins" do
-      install_gemfile <<-G
+      install_gemfile <<-G, :env => { "DEBUG" => "1" }
         source "#{file_uri_for(gem_repo2)}"
         gem "net_a"
       G
@@ -97,7 +97,7 @@ RSpec.describe "bundle install with install-time dependencies" do
     end
 
     it "installs multiple levels of dependencies" do
-      install_gemfile <<-G
+      install_gemfile <<-G, :env => { "DEBUG" => "1" }
         source "#{file_uri_for(gem_repo2)}"
         gem "net_c"
         gem "net_e"
@@ -114,7 +114,7 @@ RSpec.describe "bundle install with install-time dependencies" do
           gem "net_e"
         G
 
-        bundle :install, :env => { "BUNDLER_DEBUG_RESOLVER" => "1" }
+        bundle :install, :env => { "BUNDLER_DEBUG_RESOLVER" => "1", "DEBUG" => "1" }
 
         expect(out).to include("BUNDLER: Starting resolution")
       end
@@ -128,7 +128,7 @@ RSpec.describe "bundle install with install-time dependencies" do
           gem "net_e"
         G
 
-        bundle :install, :env => { "DEBUG_RESOLVER" => "1" }
+        bundle :install, :env => { "DEBUG_RESOLVER" => "1", "DEBUG" => "1" }
 
         expect(out).to include("BUNDLER: Starting resolution")
       end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Some recurrent flaky spec failures.

## What is your fix for the problem, implemented in this PR?

I added the `DEBUG` env to one spec that failed some days ago. A new failure happened in another spec. The new failure confirms my suspicion that the culprit is in the rake extension compilation.

I have a potential fix, but I want to confirm the culprit first, so I'm showing a backtrace by default in all specs that use the offending dummy spec.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)