### PR TITLE
Swallow any system call error in `ensure_gem_subdirs`

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -469,7 +469,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
       next if File.exist? subdir
       begin
         FileUtils.mkdir_p subdir, **options
-      rescue Errno::EACCES, Errno::ENOTDIR
+      rescue SystemCallError
       end
     end
   ensure

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -469,7 +469,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
       next if File.exist? subdir
       begin
         FileUtils.mkdir_p subdir, **options
-      rescue Errno::EACCES
+      rescue Errno::EACCES, Errno::ENOTDIR
       end
     end
   ensure

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -692,6 +692,11 @@ class TestGem < Gem::TestCase
     ensure
       FileUtils.chmod 0600, parent
     end
+
+    def test_self_ensure_gem_directories_non_existent_paths
+      Gem.ensure_gem_subdirectories '/proc/0123456789/bogus' # should not raise
+      Gem.ensure_gem_subdirectories 'classpath:/bogus/x' # JRuby embed scenario
+    end
   end
 
   def test_self_extension_dir_shared


### PR DESCRIPTION
https://github.com/rubygems/rubygems/pull/4286 (with added asserts)

JRuby expects the method to not raise with embed paths (and is blocking a 3.2 update).
This has changed in RGs 3.2 to only handle EACCESS: 0c85553