### PR TITLE
Reverse rubygems require mixin with bundler standalone

### DIFF
--- a/bundler/lib/bundler/installer/standalone.rb
+++ b/bundler/lib/bundler/installer/standalone.rb
@@ -15,6 +15,7 @@ module Bundler
         file.puts "ruby_engine = RUBY_ENGINE"
         file.puts "ruby_version = RbConfig::CONFIG[\"ruby_version\"]"
         file.puts "path = File.expand_path('..', __FILE__)"
+        file.puts reverse_rubygems_kernel_mixin
         paths.each do |path|
           file.puts %($:.unshift File.expand_path("\#{path}/#{path}"))
         end
@@ -47,6 +48,19 @@ module Bundler
     rescue TypeError
       error_message = "#{spec.name} #{spec.version} has an invalid gemspec"
       raise Gem::InvalidSpecificationException.new(error_message)
+    end
+
+    def reverse_rubygems_kernel_mixin
+      <<~END
+      kernel = (class << ::Kernel; self; end)
+      [kernel, ::Kernel].each do |k|
+        if k.private_method_defined?(:gem_original_require)
+          k.send(:remove_method, :require)
+          k.send(:define_method, :require, k.instance_method(:gem_original_require))
+          k.send(:private, :require)
+        end
+      end
+      END
     end
   end
 end

--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -7,6 +7,12 @@ RSpec.shared_examples "bundle install --standalone" do
       expect(the_bundle).to include_gems(*args)
     end
 
+    it "still makes system gems unavailable to normal bundler" do
+      system_gems "rack-1.0.0"
+
+      expect(the_bundle).to_not include_gems("rack")
+    end
+
     it "generates a bundle/bundler/setup.rb" do
       expect(bundled_app("bundle/bundler/setup.rb")).to exist
     end
@@ -24,6 +30,24 @@ RSpec.shared_examples "bundle install --standalone" do
       ruby testrb
 
       expect(out).to eq(expected_gems.values.join("\n"))
+    end
+
+    it "makes system gems unavailable without bundler" do
+      system_gems "rack-1.0.0"
+
+      testrb = String.new <<-RUBY
+        $:.unshift File.expand_path("bundle")
+        require "bundler/setup"
+
+        begin
+          require "rack"
+        rescue LoadError
+          puts "LoadError"
+        end
+      RUBY
+      ruby testrb
+
+      expect(out).to eq("LoadError")
     end
 
     it "works on a different system" do


### PR DESCRIPTION
Fixes #4294

Short of looking for the text, I'm not sure of the best way to test this. It's covered by the existing bundle standalone tests.