### PR TITLE
Backport performance fixes to patch versions

### DIFF
--- a/.changelog.yml
+++ b/.changelog.yml
@@ -23,10 +23,10 @@ patch_level_labels:
   - "rubygems: security fix"
   - "rubygems: enhancement"
   - "rubygems: bug fix"
+  - "rubygems: performance"
   - "rubygems: backport"
 
 minor_level_labels:
   - "rubygems: deprecation"
   - "rubygems: feature"
-  - "rubygems: performance"
   - "rubygems: documentation"

--- a/bundler/.changelog.yml
+++ b/bundler/.changelog.yml
@@ -21,10 +21,10 @@ patch_level_labels:
   - "bundler: security fix"
   - "bundler: enhancement"
   - "bundler: bug fix"
+  - "bundler: performance"
   - "bundler: backport"
 
 minor_level_labels:
   - "bundler: deprecation"
   - "bundler: feature"
-  - "bundler: performance"
   - "bundler: documentation"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I was expecting release scripts to backport https://github.com/rubygems/rubygems/pull/4216. However it didn't happen.

## What is your fix for the problem, implemented in this PR?

My fix is to setup PRs tagged as performance to be backported. If a performance improvement is deemed to risky/incompatible so that it needs to wait to the next minor, we can tag it as feature (for example, this was the case with the new gem layout in rubygems).

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)