### PR TITLE
Show backtrace if gem install fails in CI

### DIFF
--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -67,7 +67,7 @@ jobs:
         run: if grep -q 'GET http' output.txt; then false; else true; fi
         working-directory: ./bundler
       - name: Check rails can be installed
-        run: gem install rails
+        run: gem install rails --verbose
         if: matrix.ruby.name != 'truffleruby-20.3'
     timeout-minutes: 10
 

--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -61,13 +61,13 @@ jobs:
         run: gem build bundler.gemspec
         working-directory: ./bundler
       - name: Install built bundler
-        run: gem install bundler-*.gem --verbose > output.txt
+        run: gem install bundler-*.gem --verbose --backtrace > output.txt
         working-directory: ./bundler
       - name: Check bundler install didn't hit the network
         run: if grep -q 'GET http' output.txt; then false; else true; fi
         working-directory: ./bundler
       - name: Check rails can be installed
-        run: gem install rails --verbose
+        run: gem install rails --verbose --backtrace
         if: matrix.ruby.name != 'truffleruby-20.3'
     timeout-minutes: 10
 


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

We got a flaky failure in the stable branch: https://github.com/rubygems/rubygems/pull/4298/checks?check_run_id=1722470640.

Well, I _hope_ it's flaky, I'll restart the CI now to double check.

## What is your fix for the problem, implemented in this PR?

No fix, but show a backtrace when it happens again to help figuring it out.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
