### PR TITLE
Fix `force_ruby_platform` no longer being respected

### DIFF
--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -140,7 +140,7 @@ module Bundler
     # explicitly add a more specific platform.
     #
     def ruby_platform_materializes_to_ruby_platform?
-      !Bundler.most_specific_locked_platform?(Gem::Platform::RUBY)
+      !Bundler.most_specific_locked_platform?(Gem::Platform::RUBY) || Bundler.settings[:force_ruby_platform]
     end
   end
 end

--- a/bundler/spec/runtime/platform_spec.rb
+++ b/bundler/spec/runtime/platform_spec.rb
@@ -84,9 +84,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
     expect(the_bundle).to include_gems "nokogiri 1.4.2", "platform_specific 1.0 x86-darwin-100"
   end
 
-  it "allows specifying only-ruby-platform" do
-    simulate_platform "java"
-
+  it "allows specifying only-ruby-platform", :jruby do
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
       gem "nokogiri"

--- a/bundler/spec/runtime/platform_spec.rb
+++ b/bundler/spec/runtime/platform_spec.rb
@@ -84,8 +84,22 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
     expect(the_bundle).to include_gems "nokogiri 1.4.2", "platform_specific 1.0 x86-darwin-100"
   end
 
-  it "allows specifying only-ruby-platform", :jruby do
+  it "allows specifying only-ruby-platform on jruby", :jruby do
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
+      gem "nokogiri"
+      gem "platform_specific"
+    G
+
+    bundle "config set force_ruby_platform true"
+
+    bundle "install"
+
+    expect(the_bundle).to include_gems "nokogiri 1.4.2", "platform_specific 1.0 RUBY"
+  end
+
+  it "allows specifying only-ruby-platform" do
+    gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
       gem "nokogiri"
       gem "platform_specific"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since 2.2.3, `force_ruby_platform` is no longer being respected.

## What is your fix for the problem, implemented in this PR?

In 2.2.3, I added some backwards compatibility code to restore pre bundler 2.2.0 behaviour of choosing the best matching platform at installation time rather than at resolution time like it's done now.

However, I missed to exclude `force_ruby_platform` from that since in this case we never what to select any platform specific gems at all.

Fixes #4296.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)