### PR TITLE
Improve error messages when dependency on bundler conflicts with running version

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -920,6 +920,7 @@ module Bundler
       metadata_dependencies.each do |dep|
         source_requirements[dep.name] = sources.metadata_source
       end
+      source_requirements[:default_bundler] = source_requirements["bundler"] || source_requirements[:default]
       source_requirements["bundler"] = sources.metadata_source # needs to come last to override
       source_requirements
     end

--- a/bundler/lib/bundler/feature_flag.rb
+++ b/bundler/lib/bundler/feature_flag.rb
@@ -27,7 +27,6 @@ module Bundler
 
     (1..10).each {|v| define_method("bundler_#{v}_mode?") { major_version >= v } }
 
-    settings_flag(:allow_bundler_dependency_conflicts) { bundler_3_mode? }
     settings_flag(:allow_offline_install) { bundler_3_mode? }
     settings_flag(:auto_clean_without_path) { bundler_3_mode? }
     settings_flag(:cache_all) { bundler_3_mode? }

--- a/bundler/lib/bundler/fetcher.rb
+++ b/bundler/lib/bundler/fetcher.rb
@@ -137,7 +137,6 @@ module Bundler
       end
 
       specs.each do |name, version, platform, dependencies, metadata|
-        next if name == "bundler"
         spec = if dependencies
           EndpointSpecification.new(name, version, platform, dependencies, metadata)
         else

--- a/bundler/lib/bundler/installer.rb
+++ b/bundler/lib/bundler/installer.rb
@@ -82,7 +82,6 @@ module Bundler
 
         if resolve_if_needed(options)
           ensure_specs_are_compatible!
-          warn_on_incompatible_bundler_deps
           load_plugins
           options.delete(:jobs)
         else
@@ -261,22 +260,6 @@ module Bundler
         unless required_rubygems_version.satisfied_by?(rubygems_version)
           raise InstallError, "#{spec.full_name} requires rubygems version #{required_rubygems_version}, " \
             "which is incompatible with the current version, #{rubygems_version}"
-        end
-      end
-    end
-
-    def warn_on_incompatible_bundler_deps
-      bundler_version = Gem::Version.create(Bundler::VERSION)
-      @definition.specs.each do |spec|
-        spec.dependencies.each do |dep|
-          next if dep.type == :development
-          next unless dep.name == "bundler".freeze
-          next if dep.requirement.satisfied_by?(bundler_version)
-
-          Bundler.ui.warn "#{spec.name} (#{spec.version}) has dependency" \
-            " #{SharedHelpers.pretty_dependency(dep)}" \
-            ", which is unsatisfied by the current bundler version #{VERSION}" \
-            ", so the dependency is being ignored"
         end
       end
     end

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -136,9 +136,6 @@ Any periods in the configuration keys must be replaced with two underscores when
 The following is a list of all configuration keys and their purpose\. You can learn more about their operation in bundle install(1) \fIbundle\-install\.1\.html\fR\.
 .
 .IP "\(bu" 4
-\fBallow_bundler_dependency_conflicts\fR (\fBBUNDLE_ALLOW_BUNDLER_DEPENDENCY_CONFLICTS\fR): Allow resolving to specifications that have dependencies on \fBbundler\fR that are incompatible with the running Bundler version\.
-.
-.IP "\(bu" 4
 \fBallow_deployment_source_credential_changes\fR (\fBBUNDLE_ALLOW_DEPLOYMENT_SOURCE_CREDENTIAL_CHANGES\fR): When in deployment mode, allow changing the credentials to a gem\'s source\. Ex: \fBhttps://some\.host\.com/gems/path/\fR \-> \fBhttps://user_name:password@some\.host\.com/gems/path\fR
 .
 .IP "\(bu" 4

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -133,9 +133,6 @@ the environment variable `BUNDLE_LOCAL__RACK`.
 The following is a list of all configuration keys and their purpose. You can
 learn more about their operation in [bundle install(1)](bundle-install.1.html).
 
-* `allow_bundler_dependency_conflicts` (`BUNDLE_ALLOW_BUNDLER_DEPENDENCY_CONFLICTS`):
-   Allow resolving to specifications that have dependencies on `bundler` that
-   are incompatible with the running Bundler version.
 * `allow_deployment_source_credential_changes` (`BUNDLE_ALLOW_DEPLOYMENT_SOURCE_CREDENTIAL_CHANGES`):
    When in deployment mode, allow changing the credentials to a gem's source.
    Ex: `https://some.host.com/gems/path/` -> `https://user_name:password@some.host.com/gems/path`

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -37,7 +37,6 @@ module Bundler
       additional_base_requirements.each {|d| @base_dg.add_vertex(d.name, d) }
       @platforms = platforms
       @gem_version_promoter = gem_version_promoter
-      @allow_bundler_dependency_conflicts = Bundler.feature_flag.allow_bundler_dependency_conflicts?
       @use_gvp = Bundler.feature_flag.use_gem_version_promoter_for_major_updates? || !@gem_version_promoter.major?
       @lockfile_uses_separate_rubygems_sources = Bundler.feature_flag.disable_multisource?
     end
@@ -138,7 +137,6 @@ module Bundler
           nested.reduce([]) do |groups, (version, specs)|
             next groups if locked_requirement && !locked_requirement.satisfied_by?(version)
             spec_group = SpecGroup.new(specs)
-            spec_group.ignores_bundler_dependencies = @allow_bundler_dependency_conflicts
             groups << spec_group
           end
         else

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -367,13 +367,14 @@ module Bundler
           if name == "bundler"
             o << %(\n  Current Bundler version:\n    bundler (#{Bundler::VERSION}))
             other_bundler_required = !conflict.requirement.requirement.satisfied_by?(Gem::Version.new(Bundler::VERSION))
+
+            if other_bundler_required
+              o << "\n"
+              o << "This Gemfile requires a different version of Bundler.\n"
+              o << "Perhaps you need to update Bundler by running `gem install bundler`?\n"
+            end
           end
 
-          if name == "bundler" && other_bundler_required
-            o << "\n"
-            o << "This Gemfile requires a different version of Bundler.\n"
-            o << "Perhaps you need to update Bundler by running `gem install bundler`?\n"
-          end
           if conflict.locked_requirement
             o << "\n"
             o << %(Running `bundle update` will rebuild your snapshot from scratch, using only\n)

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -329,10 +329,16 @@ module Bundler
     def version_conflict_message(e)
       # only show essential conflicts, if possible
       conflicts = e.conflicts.dup
-      conflicts.delete_if do |_name, conflict|
-        deps = conflict.requirement_trees.map(&:last).flatten(1)
-        !Bundler::VersionRanges.empty?(*Bundler::VersionRanges.for_many(deps.map(&:requirement)))
+
+      if conflicts["bundler"]
+        conflicts.replace("bundler" => conflicts["bundler"])
+      else
+        conflicts.delete_if do |_name, conflict|
+          deps = conflict.requirement_trees.map(&:last).flatten(1)
+          !Bundler::VersionRanges.empty?(*Bundler::VersionRanges.for_many(deps.map(&:requirement)))
+        end
       end
+
       e = Molinillo::VersionConflict.new(conflicts, e.specification_provider) unless conflicts.empty?
 
       solver_name = "Bundler"

--- a/bundler/lib/bundler/resolver/spec_group.rb
+++ b/bundler/lib/bundler/resolver/spec_group.rb
@@ -6,7 +6,7 @@ module Bundler
       include GemHelpers
 
       attr_accessor :name, :version, :source
-      attr_accessor :ignores_bundler_dependencies, :activated_platforms
+      attr_accessor :activated_platforms
 
       def initialize(all_specs)
         @all_specs = all_specs
@@ -20,7 +20,6 @@ module Bundler
         @specs        = Hash.new do |specs, platform|
           specs[platform] = select_best_platform_match(all_specs, platform)
         end
-        @ignores_bundler_dependencies = true
       end
 
       def to_specs
@@ -41,7 +40,6 @@ module Bundler
         return unless platforms.any?
 
         copied_sg = self.class.new(@all_specs)
-        copied_sg.ignores_bundler_dependencies = @ignores_bundler_dependencies
         copied_sg.activated_platforms = platforms
         copied_sg
       end
@@ -98,7 +96,6 @@ module Bundler
           if spec = specs.first
             spec.dependencies.each do |dep|
               next if dep.type == :development
-              next if @ignores_bundler_dependencies && dep.name == "bundler".freeze
               dependencies[platform] << DepProxy.get_proxy(dep, platform)
             end
           end

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -7,7 +7,6 @@ module Bundler
     autoload :Validator, File.expand_path("settings/validator", __dir__)
 
     BOOL_KEYS = %w[
-      allow_bundler_dependency_conflicts
       allow_deployment_source_credential_changes
       allow_offline_install
       auto_clean_without_path

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -353,7 +353,6 @@ module Bundler
       def installed_specs
         @installed_specs ||= Index.build do |idx|
           Bundler.rubygems.all_specs.reverse_each do |spec|
-            next if spec.name == "bundler"
             spec.source = self
             if Bundler.rubygems.spec_missing_extensions?(spec, false)
               Bundler.ui.debug "Source #{self} is ignoring #{spec} because it is missing extensions"

--- a/bundler/spec/bundler/cli_spec.rb
+++ b/bundler/spec/bundler/cli_spec.rb
@@ -138,12 +138,12 @@ RSpec.describe "bundle executable" do
 
     it "doesn't print defaults" do
       install_gemfile "", :verbose => true
-      expect(out).to start_with("Running `bundle install --retry 0 --verbose` with bundler #{Bundler::VERSION}")
+      expect(out).to start_with("Running `bundle install --verbose` with bundler #{Bundler::VERSION}")
     end
 
     it "doesn't print defaults" do
       install_gemfile "", :verbose => true
-      expect(out).to start_with("Running `bundle install --retry 0 --verbose` with bundler #{Bundler::VERSION}")
+      expect(out).to start_with("Running `bundle install --verbose` with bundler #{Bundler::VERSION}")
     end
   end
 

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -651,6 +651,8 @@ RSpec.describe "bundle update when a gem depends on a newer version of bundler" 
       build_gem "rails", "3.0.1" do |s|
         s.add_dependency "bundler", Bundler::VERSION.succ
       end
+
+      build_gem "bundler", Bundler::VERSION.succ
     end
 
     gemfile <<-G
@@ -663,7 +665,7 @@ RSpec.describe "bundle update when a gem depends on a newer version of bundler" 
     bundle "update", :all => true, :raise_on_error => false
     expect(last_command.stdboth).not_to match(/in snapshot/i)
     expect(err).to match(/current Bundler version/i).
-      and match(/perhaps you need to update bundler/i)
+      and match(/Install the necessary version with `gem install bundler:#{Bundler::VERSION.succ}`/i)
   end
 end
 

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -659,18 +659,11 @@ RSpec.describe "bundle update when a gem depends on a newer version of bundler" 
     G
   end
 
-  it "should explain that bundler conflicted", :bundler => "< 3" do
+  it "should explain that bundler conflicted and how to resolve the conflict" do
     bundle "update", :all => true, :raise_on_error => false
     expect(last_command.stdboth).not_to match(/in snapshot/i)
     expect(err).to match(/current Bundler version/i).
       and match(/perhaps you need to update bundler/i)
-  end
-
-  it "should warn that the newer version of Bundler would conflict", :bundler => "3" do
-    bundle "update", :all => true
-    expect(err).to include("rails (3.0.1) has dependency bundler").
-      and include("so the dependency is being ignored")
-    expect(the_bundle).to include_gem "rails 3.0.1"
   end
 end
 

--- a/bundler/spec/install/bundler_spec.rb
+++ b/bundler/spec/install/bundler_spec.rb
@@ -29,9 +29,49 @@ RSpec.describe "bundle install" do
       expect(the_bundle).not_to include_gems "bundler #{Bundler::VERSION}"
     end
 
-    it "causes a conflict if explicitly requesting a different version" do
-      bundle "config set force_ruby_platform true"
+    it "causes a conflict if explicitly requesting a different version of bundler" do
+      install_gemfile <<-G, :raise_on_error => false
+        source "#{file_uri_for(gem_repo2)}"
+        gem "rails", "3.0"
+        gem "bundler", "0.9.1"
+      G
 
+      nice_error = <<-E.strip.gsub(/^ {8}/, "")
+        Bundler could not find compatible versions for gem "bundler":
+          In Gemfile:
+            bundler (= 0.9.1)
+
+          Current Bundler version:
+            bundler (#{Bundler::VERSION})
+
+        Your bundle requires a different version of Bundler than the one you're running.
+        Install the necessary version with `gem install bundler:0.9.1` and rerun bundler using `bundle _0.9.1_ install`
+        E
+      expect(err).to include(nice_error)
+    end
+
+    it "causes a conflict if explicitly requesting a non matching requirement on bundler" do
+      install_gemfile <<-G, :raise_on_error => false
+        source "#{file_uri_for(gem_repo2)}"
+        gem "rails", "3.0"
+        gem "bundler", "~> 0.8"
+      G
+
+      nice_error = <<-E.strip.gsub(/^ {8}/, "")
+        Bundler could not find compatible versions for gem "bundler":
+          In Gemfile:
+            bundler (~> 0.8)
+
+          Current Bundler version:
+            bundler (#{Bundler::VERSION})
+
+        Your bundle requires a different version of Bundler than the one you're running.
+        Install the necessary version with `gem install bundler:0.9.1` and rerun bundler using `bundle _0.9.1_ install`
+        E
+      expect(err).to include(nice_error)
+    end
+
+    it "causes a conflict if explicitly requesting a version of bundler that doesn't exist" do
       install_gemfile <<-G, :raise_on_error => false
         source "#{file_uri_for(gem_repo2)}"
         gem "rails", "3.0"
@@ -45,10 +85,8 @@ RSpec.describe "bundle install" do
 
           Current Bundler version:
             bundler (#{Bundler::VERSION})
-        This Gemfile requires a different version of Bundler.
-        Perhaps you need to update Bundler by running `gem install bundler`?
 
-        Could not find gem 'bundler (= 0.9.2)' in any
+        Your bundle requires a different version of Bundler than the one you're running, and that version could not be found.
         E
       expect(err).to include(nice_error)
     end

--- a/bundler/spec/install/bundler_spec.rb
+++ b/bundler/spec/install/bundler_spec.rb
@@ -197,27 +197,5 @@ RSpec.describe "bundle install" do
       bundle "check"
       expect(out).to include("The Gemfile's dependencies are satisfied")
     end
-
-    context "with allow_bundler_dependency_conflicts set" do
-      before { bundle "config set allow_bundler_dependency_conflicts true" }
-
-      it "are forced to the current bundler version with warnings when no compatible version is found" do
-        build_repo4 do
-          build_gem "requires_nonexistant_bundler" do |s|
-            s.add_runtime_dependency "bundler", "99.99.99.99"
-          end
-        end
-
-        install_gemfile <<-G
-          source "#{file_uri_for(gem_repo4)}"
-          gem "requires_nonexistant_bundler"
-        G
-
-        expect(err).to include "requires_nonexistant_bundler (1.0) has dependency bundler (= 99.99.99.99), " \
-                               "which is unsatisfied by the current bundler version #{Bundler::VERSION}, so the dependency is being ignored"
-
-        expect(the_bundle).to include_gems "bundler #{Bundler::VERSION}", "requires_nonexistant_bundler 1.0"
-      end
-    end
   end
 end

--- a/bundler/spec/realworld/edgecases_spec.rb
+++ b/bundler/spec/realworld/edgecases_spec.rb
@@ -64,6 +64,8 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
   it "is able to update a top-level dependency when there is a conflict on a shared transitive child" do
     # from https://github.com/rubygems/bundler/issues/5031
 
+    system_gems "bundler-2.99.0"
+
     gemfile <<-G
       source "https://rubygems.org"
       gem 'rails', '~> 4.2.7.1'
@@ -189,7 +191,7 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
         rails (~> 4.2.7.1)
     L
 
-    bundle "lock --update paperclip"
+    bundle "lock --update paperclip", :env => { "BUNDLER_VERSION" => "2.99.0" }
 
     expect(lockfile).to include(rubygems_version("paperclip", "~> 5.1.0"))
   end
@@ -448,11 +450,12 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
       end
     G
 
-    bundle :lock, :env => { "DEBUG_RESOLVER" => "1" }
-
     if Bundler.feature_flag.bundler_3_mode?
-      expect(out).to include("BUNDLER: Finished resolution (1336 steps)")
+      # Conflicts on bundler version, so fails earlier
+      bundle :lock, :env => { "DEBUG_RESOLVER" => "1" }, :raise_on_error => false
+      expect(out).to include("BUNDLER: Finished resolution (211 steps)")
     else
+      bundle :lock, :env => { "DEBUG_RESOLVER" => "1" }
       expect(out).to include("BUNDLER: Finished resolution (1395 steps)")
     end
   end
@@ -477,7 +480,7 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
     bundle :lock, :env => { "DEBUG_RESOLVER" => "1" }
 
     if Bundler.feature_flag.bundler_3_mode?
-      expect(out).to include("BUNDLER: Finished resolution (366 steps)")
+      expect(out).to include("BUNDLER: Finished resolution (369 steps)")
     else
       expect(out).to include("BUNDLER: Finished resolution (372 steps)")
     end

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -275,14 +275,12 @@ module Spec
     def install_gemfile(*args)
       gemfile(*args)
       opts = args.last.is_a?(Hash) ? args.last : {}
-      opts[:retry] ||= 0
       bundle :install, opts
     end
 
     def lock_gemfile(*args)
       gemfile(*args)
       opts = args.last.is_a?(Hash) ? args.last : {}
-      opts[:retry] ||= 0
       bundle :lock, opts
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The problem is that sometimes bundler can give very misleading errors when a dependency on bundler conflicts with the running version.

Even when it shows that the bundler version conflicted, the error could be better.

## What is your fix for the problem, implemented in this PR?

My fix is, when there's a conflict between the bundler dependency and the running version, show only that conflict, and include remediation steps.

With the Gemfile given in https://github.com/rubygems/rubygems/issues/3930, these are the results before and after:

### Before this PR

```
$ bundle
Fetching https://github.com/barthalion/middleman-matomo.git
Fetching gem metadata from http://rubygems.org/............
Fetching gem metadata from http://rubygems.org/.
Resolving dependencies.....................................................
Bundler could not find compatible versions for gem "middleman-sprockets":
  In Gemfile:
    middleman-sprockets (~> 3.1.2) x86_64-linux

    middleman (~> 3) x86_64-linux was resolved to 3.0.1.pre, which depends on
      middleman-sprockets (= 3.0.1.pre) x86_64-linux
```

### After this PR

```
$ bundle
Fetching https://github.com/barthalion/middleman-matomo.git
Fetching gem metadata from http://rubygems.org/............
Resolving dependencies........................................................
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    middleman (~> 3) was resolved to 3.1.0.beta.2, which depends on
      middleman-core (= 3.1.0.beta.2) was resolved to 3.1.0.beta.2, which depends on
        bundler (~> 1.1)

  Current Bundler version:
    bundler (2.3.0.dev)

Your bundle requires a different version of Bundler than the one you're running.
Install the necessary version with `gem install bundler:1.17.3` and rerun bundler using `bundle _1.17.3_`
```

In addition to this, I removed a future change in behaviour where bundler would start allowing conflicts of this kind, because I don't think it's a good move and now it's a good time to cancel it.

Fixes https://github.com/rubygems/rubygems/issues/3930.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)