### PR TITLE
Fix releasing from a not yet pushed branch

### DIFF
--- a/bundler/lib/bundler/gem_helper.rb
+++ b/bundler/lib/bundler/gem_helper.rb
@@ -116,19 +116,21 @@ module Bundler
 
     def git_push(remote = nil)
       remote ||= default_remote
-      perform_git_push remote
+      perform_git_push "#{remote} refs/heads/#{current_branch}"
       perform_git_push "#{remote} refs/tags/#{version_tag}"
       Bundler.ui.confirm "Pushed git commits and release tag."
     end
 
     def default_remote
+      remote_for_branch, status = sh_with_status(%W[git config --get branch.#{current_branch}.remote])
+      return "origin" unless status.success?
+
+      remote_for_branch.strip
+    end
+
+    def current_branch
       # We can replace this with `git branch --show-current` once we drop support for git < 2.22.0
-      current_branch = sh(%w[git rev-parse --abbrev-ref HEAD]).gsub(%r{\Aheads/}, "").strip
-
-      remote_for_branch = sh(%W[git config --get branch.#{current_branch}.remote]).strip
-      return "origin" if remote_for_branch.empty?
-
-      remote_for_branch
+      sh(%w[git rev-parse --abbrev-ref HEAD]).gsub(%r{\Aheads/}, "").strip
     end
 
     def allowed_push_host

--- a/bundler/spec/bundler/gem_helper_spec.rb
+++ b/bundler/spec/bundler/gem_helper_spec.rb
@@ -266,6 +266,14 @@ RSpec.describe Bundler::GemHelper do
 
             Rake.application["release"].invoke
           end
+
+          it "also works with releasing from a branch not yet pushed" do
+            sys_exec("git checkout -b module_function", :dir => app_path)
+
+            expect(subject).to receive(:rubygem_push).with(app_gem_path.to_s)
+
+            Rake.application["release"].invoke
+          end
         end
 
         context "on releasing with a custom tag prefix" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The problem is that since recent versions, releasing from an unpushed branch no longer works.

## What is your fix for the problem, implemented in this PR?

My fix is to always give an explicit branch and remote to git push.

There's a bit of yet missing logic to infer the remote. In particular, we should check `branch.<name>.pushRemote` with the most priority, and also `push.defaultRemote` with more priority than "origin".

But I focused on fixing the issue on this PR and will reticket the other stuff.

Fixes https://github.com/rubygems/rubygems/issues/4307.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)