### PR TITLE
Avoid showing platforms with requirements in error messages

### DIFF
--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -151,7 +151,8 @@ end
 load "task/automatiek.rake"
 
 # We currently ship Molinillo master branch as of
-# https://github.com/CocoaPods/Molinillo/commit/0f3d33d004214f5e3a426c3382c4af37bc3f27e5
+# https://github.com/CocoaPods/Molinillo/commit/0f3d33d004214f5e3a426c3382c4af37bc3f27e5,
+# plus a fix to properly print requirements.
 desc "Vendor a specific version of molinillo"
 Automatiek::RakeTask.new("molinillo") do |lib|
   lib.version = "master"

--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -150,12 +150,11 @@ end
 
 load "task/automatiek.rake"
 
-# We currently ship Molinillo 0.7.0 with a patch on top to make use of `Array#-`
-# instead of `Array#&` on hot resolution code paths because it performs a lot
-# better.
+# We currently ship Molinillo master branch as of
+# https://github.com/CocoaPods/Molinillo/commit/0f3d33d004214f5e3a426c3382c4af37bc3f27e5
 desc "Vendor a specific version of molinillo"
 Automatiek::RakeTask.new("molinillo") do |lib|
-  lib.version = "0.7.0"
+  lib.version = "master"
   lib.download = { :github => "https://github.com/CocoaPods/Molinillo" }
   lib.namespace = "Molinillo"
   lib.prefix = "Bundler"

--- a/bundler/lib/bundler/vendor/molinillo/lib/molinillo/errors.rb
+++ b/bundler/lib/bundler/vendor/molinillo/lib/molinillo/errors.rb
@@ -121,7 +121,7 @@ module Bundler::Molinillo
           t = ''.dup
           depth = 2
           tree.each do |req|
-            t << '  ' * depth << req.to_s
+            t << '  ' * depth << printable_requirement.call(req)
             unless tree.last == req
               if spec = conflict.activated_by_name[name_for(req)]
                 t << %( was resolved to #{version_for_spec.call(spec)}, which)

--- a/bundler/spec/install/gems/resolving_spec.rb
+++ b/bundler/spec/install/gems/resolving_spec.rb
@@ -242,7 +242,6 @@ RSpec.describe "bundle install with install-time dependencies" do
 
       let(:ruby_requirement) { %("#{RUBY_VERSION}") }
       let(:error_message_requirement) { "~> #{RUBY_VERSION}.0" }
-      let(:error_message_platform) { Bundler.local_platform }
 
       shared_examples_for "ruby version conflicts" do
         it "raises an error during resolution" do
@@ -259,10 +258,10 @@ RSpec.describe "bundle install with install-time dependencies" do
           nice_error = strip_whitespace(<<-E).strip
             Bundler found conflicting requirements for the Ruby\0 version:
               In Gemfile:
-                Ruby\0 (#{error_message_requirement}) #{error_message_platform}
+                Ruby\0 (#{error_message_requirement})
 
-                require_ruby #{error_message_platform} was resolved to 1.0, which depends on
-                  Ruby\0 (> 9000) #{error_message_platform}
+                require_ruby was resolved to 1.0, which depends on
+                  Ruby\0 (> 9000)
 
             Ruby\0 (> 9000), which is required by gem 'require_ruby', is not available in the local ruby installation
           E


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When conflicts in dependencies happens, bundler shows the platform next to the
requirement. This is not helpful in general and it has confused me a few times,
so I fixed it.

## What is your fix for the problem, implemented in this PR?

The platform was being printed because Molinillo was ignoring the proc we passed
it to customize how requirements are printed. I fixed Molinillo to respect it.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)