### PR TITLE
Replace "iff" with "whether" and "if and only if"

### DIFF
--- a/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/vertex.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/vertex.rb
@@ -128,7 +128,7 @@ module Gem::Resolver::Molinillo
 
       # Is there a path from `self` to `other` following edges in the
       # dependency graph?
-      # @return true iff there is a path following edges within this {#graph}
+      # @return whether there is a path following edges within this {#graph}
       def path_to?(other)
         _path_to?(other)
       end

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/errors.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/errors.rb
@@ -34,7 +34,7 @@ module Gem::Resolver::Molinillo
 
   # An error caused by attempting to fulfil a dependency that was circular
   #
-  # @note This exception will be thrown iff a {Vertex} is added to a
+  # @note This exception will be thrown if and only if a {Vertex} is added to a
   #   {DependencyGraph} that has a {DependencyGraph::Vertex#path_to?} an
   #   existing {DependencyGraph::Vertex}
   class CircularDependencyError < ResolverError


### PR DESCRIPTION
Rubygems part of https://github.com/ruby/ruby/pull/4035, except the vendored code.

## What was the end-user or developer problem that led to this PR?

iff means if and only if, but readers without that knowledge might
assume this to be a spelling mistake. To me, this seems like
exclusionary language that is unnecessary.

## What is your fix for the problem, implemented in this PR?

Simply using "if and only if" or "whether" should suffice.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
