### PR TITLE
Fix a MJIT warning

### DIFF
--- a/test/rubygems/test_gem_stream_ui.rb
+++ b/test/rubygems/test_gem_stream_ui.rb
@@ -5,7 +5,7 @@ require 'timeout'
 
 class TestGemStreamUI < Gem::TestCase
   # increase timeout with MJIT for --jit-wait testing
-  mjit_enabled = defined?(RubyVM::MJIT) && RubyVM::MJIT.enabled?
+  mjit_enabled = defined?(RubyVM::JIT) ? RubyVM::JIT.enabled? : defined?(RubyVM::MJIT) && RubyVM::MJIT.enabled?
   SHORT_TIMEOUT = (RUBY_ENGINE == "ruby" && !mjit_enabled) ? 0.1 : 1.0
 
   module IsTty


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`RubyVM::MJIT` has been renamed as `RubyVM::JIT`.

```
.../test/rubygems/test_gem_stream_ui.rb:8: warning: constant RubyVM::MJIT is deprecated
```

## What is your fix for the problem, implemented in this PR?

Refer the new name `RubyVM::JIT` before `RubyVM::MJIT`

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
