### PR TITLE
Avoid unnecessary bundler 3 CI jobs

### DIFF
--- a/.github/workflows/older-rubygems-bundler.yml
+++ b/.github/workflows/older-rubygems-bundler.yml
@@ -31,7 +31,6 @@ jobs:
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.2 }, rgv: { name: rgv-3.1, value: v3.1.5 } }
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.2 }, rgv: { name: rgv-3.2, value: v3.2.4 } }
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.0 }, rgv: { name: rgv-3.2, value: v3.2.4 } }
-          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.4, value: 2.4.10 }, rgv: { name: rgv-3.2, value: v3.2.4 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.5, value: 2.5.8 }, rgv: { name: rgv-3.2, value: v3.2.4 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.6, value: 2.6.6 }, rgv: { name: rgv-3.2, value: v3.2.4 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.7, value: 2.7.2 }, rgv: { name: rgv-3.2, value: v3.2.4 } }

--- a/.github/workflows/older-rubygems-bundler.yml
+++ b/.github/workflows/older-rubygems-bundler.yml
@@ -31,7 +31,6 @@ jobs:
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.2 }, rgv: { name: rgv-3.1, value: v3.1.5 } }
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.2 }, rgv: { name: rgv-3.2, value: v3.2.4 } }
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.0 }, rgv: { name: rgv-3.2, value: v3.2.4 } }
-          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.5, value: 2.5.8 }, rgv: { name: rgv-3.2, value: v3.2.4 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.6, value: 2.6.6 }, rgv: { name: rgv-3.2, value: v3.2.4 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.7, value: 2.7.2 }, rgv: { name: rgv-3.2, value: v3.2.4 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.0, value: 3.0.0 }, rgv: { name: rgv-3.2, value: v3.2.4 } }

--- a/.github/workflows/ubuntu-bundler.yml
+++ b/.github/workflows/ubuntu-bundler.yml
@@ -30,6 +30,7 @@ jobs:
         exclude:
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.3, value: 2.3.8 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.4, value: 2.4.10 } }
+          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.5, value: 2.5.8 } }
     env:
       RGV: ..
       RUBYOPT: --disable-gems

--- a/.github/workflows/ubuntu-bundler.yml
+++ b/.github/workflows/ubuntu-bundler.yml
@@ -29,6 +29,7 @@ jobs:
 
         exclude:
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.3, value: 2.3.8 } }
+          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.4, value: 2.4.10 } }
     env:
       RGV: ..
       RUBYOPT: --disable-gems

--- a/bundler/bin/bundle3
+++ b/bundler/bin/bundle3
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 module Bundler
-  VERSION = "3.0.0.dev".freeze
+  VERSION = "3.0.0".freeze
 end
 
 load File.expand_path("../bundle", __FILE__)

--- a/bundler/task/bundler_3.rake
+++ b/bundler/task/bundler_3.rake
@@ -2,7 +2,7 @@
 
 namespace :bundler_3 do
   task :install do
-    ENV["BUNDLER_SPEC_SUB_VERSION"] = "3.0.0.dev"
+    ENV["BUNDLER_SPEC_SUB_VERSION"] = "3.0.0"
     Rake::Task["override_version"].invoke
     Rake::Task["install"].invoke
     sh("git", "checkout", "--", "lib/bundler/version.rb")


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Lots of CI jobs.

## What is your fix for the problem, implemented in this PR?

There's no plans to supoort ruby 2.4 and ruby 2.5 on bundler 3, so let's not test that combination.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)