### PR TITLE
Merge changelog from rubygems 3.2.6 and bundler 2.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 3.2.6 / 2021-01-18
+
+## Enhancements:
+
+* Fix `Gem::Platform#inspect` showing duplicate information. Pull request
+  #4276 by deivid-rodriguez
+
+## Bug fixes:
+
+* Swallow any system call error in `ensure_gem_subdirs` to support jruby
+  embedded paths. Pull request #4291 by kares
+* Restore accepting custom make command with extra options as the `make`
+  env variable. Pull request #4271 by terceiro
+
 # 3.2.5 / 2021-01-11
 
 ## Bug fixes:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 2.2.6 (January 18, 2021)
+
+## Enhancements:
+
+  - Improve resolver debugging [#4288](https://github.com/rubygems/rubygems/pull/4288)
+
+## Bug fixes:
+
+  - Fix dependency locking for path source [#4293](https://github.com/rubygems/rubygems/pull/4293)
+
+## Performance:
+
+  - Speed up complex dependency resolves by creating DepProxy factory and cache [#4216](https://github.com/rubygems/rubygems/pull/4216)
+
 # 2.2.5 (January 11, 2021)
 
 ## Enhancements:


### PR DESCRIPTION
I forgot to do this after the previous release.