### PR TITLE
Generate plugin wrappers with relative requires

### DIFF
--- a/lib/rubygems/installer_uninstaller_utils.rb
+++ b/lib/rubygems/installer_uninstaller_utils.rb
@@ -6,11 +6,16 @@
 module Gem::InstallerUninstallerUtils
 
   def regenerate_plugins_for(spec, plugins_dir)
+    plugins = spec.plugins
+    return if plugins.empty?
+
+    require 'pathname'
+
     spec.plugins.each do |plugin|
       plugin_script_path = File.join plugins_dir, "#{spec.name}_plugin#{File.extname(plugin)}"
 
       File.open plugin_script_path, 'wb' do |file|
-        file.puts "require '#{plugin}'"
+        file.puts "require_relative '#{Pathname.new(plugin).relative_path_from(Pathname.new(plugins_dir))}'"
       end
 
       verbose plugin_script_path

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -821,6 +821,8 @@ gem 'other', version
 
     assert !File.exist?(system_path), 'plugin written incorrect written to system plugins_dir'
     assert File.exist?(build_root_path), 'plugin not written to build_root'
+
+    refute_includes File.read(build_root_path), build_root
   end
 
   def test_keeps_plugins_up_to_date


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When using the `--build-root` option to `gem install`, generated plugin wrappers include the `--build-root` parameter which is unexpected.

## What is your fix for the problem, implemented in this PR?

My fix is to use relative links, which shouldn't change behaviour and it fixes the issue.

Fixes https://github.com/rubygems/rubygems/issues/4261.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)