### PR TITLE
Remove ruby repo specific hacks

### DIFF
--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -1334,31 +1334,8 @@ end
         expect(out).to eq("The Gemfile's dependencies are satisfied")
       end
 
-      # bundler respects paths specified directly in RUBYLIB or RUBYOPT, and
-      # that happens when running ruby from the ruby-core setup. To
-      # workaround, we manually remove those for these tests when they would
-      # override the default gem.
-      def load_path_exclusions_hack_for(name)
-        if ruby_core?
-          ext_folder = source_root.join(".ext/common")
-          require_name = name.tr("-", "/")
-          if File.exist?(ext_folder.join("#{require_name}.rb"))
-            { :exclude_from_load_path => ext_folder.to_s }
-          else
-            lib_folder = source_lib_dir
-            if File.exist?(lib_folder.join("#{require_name}.rb"))
-              { :exclude_from_load_path => lib_folder.to_s }
-            else
-              {}
-            end
-          end
-        else
-          {}
-        end
-      end
-
       Gem::Specification.select(&:default_gem?).map(&:name).each do |g|
-        it "activates newer versions of #{g}" do
+        it "activates newer versions of #{g}", :ruby_repo do
           skip if exemptions.include?(g)
 
           build_repo4 do
@@ -1370,11 +1347,10 @@ end
             gem "#{g}", "999999"
           G
 
-          opts = { :env => { "RUBYOPT" => activation_warning_hack_rubyopt } }
-          expect(the_bundle).to include_gem("#{g} 999999", opts.merge(load_path_exclusions_hack_for(g)))
+          expect(the_bundle).to include_gem("#{g} 999999", :env => { "RUBYOPT" => activation_warning_hack_rubyopt })
         end
 
-        it "activates older versions of #{g}" do
+        it "activates older versions of #{g}", :ruby_repo do
           skip if exemptions.include?(g)
 
           build_repo4 do
@@ -1386,8 +1362,7 @@ end
             gem "#{g}", "0.0.0.a"
           G
 
-          opts = { :env => { "RUBYOPT" => activation_warning_hack_rubyopt } }
-          expect(the_bundle).to include_gem("#{g} 0.0.0.a", opts.merge(load_path_exclusions_hack_for(g)))
+          expect(the_bundle).to include_gem("#{g} 0.0.0.a", :env => { "RUBYOPT" => activation_warning_hack_rubyopt })
         end
       end
     end

--- a/bundler/spec/support/matchers.rb
+++ b/bundler/spec/support/matchers.rb
@@ -115,7 +115,6 @@ module Spec
         opts = names.last.is_a?(Hash) ? names.pop : {}
         source = opts.delete(:source)
         groups = Array(opts[:groups])
-        exclude_from_load_path = opts.delete(:exclude_from_load_path)
         opts[:raise_on_error] = false
         groups << opts
         @errors = names.map do |name|
@@ -123,7 +122,6 @@ module Spec
           require_path = name == "bundler" ? "#{lib_dir}/bundler" : name.tr("-", "/")
           version_const = name == "bundler" ? "Bundler::VERSION" : Spec::Builders.constantize(name)
           code = []
-          code << "$LOAD_PATH.delete '#{exclude_from_load_path}'" if exclude_from_load_path
           code << "require '#{require_path}.rb'"
           code << "puts #{version_const}"
           run code.join("; "), *groups


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The problem is that ruby-core developers have trouble keeping our CI green, and we have trouble keeping our code in sync with ruby-core.

## What is your fix for the problem, implemented in this PR?

The fix is to try to minimize the amount of friction.

In particular, I added these workarounds a while ago trying to maximize the number of passing tests when run from the ruby-core repository.

However, they don't add much really, the only thing they do is simulate the ruby core repository is setup in a way that it isn't.

Given that running tests inside ruby-core has never ever detected an actual issue in bundler, and that it creates this constant friction, let's remove these hacks since they hurt more than help.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)