### PR TITLE
Don't install platform specific gems on truffleruby

### DIFF
--- a/.github/workflows/truffleruby-bundler.yml
+++ b/.github/workflows/truffleruby-bundler.yml
@@ -1,0 +1,33 @@
+name: truffleruby-bundler
+
+on:
+  pull_request:
+
+  push:
+    branches:
+      - master
+      - 3.2
+
+jobs:
+  jruby_bundler:
+    name: Bundler (Truffleruby)
+    runs-on: ubuntu-20.04
+
+    env:
+      RGV: ..
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: truffleruby-20.3.0
+          bundler: none
+      - name: Prepare dependencies
+        run: |
+          bin/rake spec:parallel_deps
+        working-directory: ./bundler
+      - name: Run Test
+        run: |
+          bin/parallel_rspec --tag truffleruby
+        working-directory: ./bundler

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -440,7 +440,7 @@ EOF
     end
 
     def local_platform
-      return Gem::Platform::RUBY if settings[:force_ruby_platform]
+      return Gem::Platform::RUBY if settings[:force_ruby_platform] || Gem.platforms == [Gem::Platform::RUBY]
       Gem::Platform.local
     end
 

--- a/bundler/spec/runtime/platform_spec.rb
+++ b/bundler/spec/runtime/platform_spec.rb
@@ -112,6 +112,15 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
     expect(the_bundle).to include_gems "nokogiri 1.4.2", "platform_specific 1.0 RUBY"
   end
 
+  it "doesn't pull platform specific gems on truffleruby", :truffleruby do
+    install_gemfile <<-G
+     source "#{file_uri_for(gem_repo1)}"
+     gem "platform_specific"
+    G
+
+    expect(the_bundle).to include_gems "platform_specific 1.0 RUBY"
+  end
+
   it "allows specifying only-ruby-platform on windows with dependency platforms" do
     simulate_windows do
       install_gemfile <<-G

--- a/bundler/spec/support/filters.rb
+++ b/bundler/spec/support/filters.rb
@@ -32,7 +32,7 @@ RSpec.configure do |config|
   config.filter_run_excluding :no_color_tty => Gem.win_platform? || !ENV["GITHUB_ACTION"].nil?
   config.filter_run_excluding :permissions => Gem.win_platform?
   config.filter_run_excluding :readline => Gem.win_platform?
-  config.filter_run_excluding :jruby => RUBY_PLATFORM != "java"
+  config.filter_run_excluding :jruby => RUBY_ENGINE != "jruby"
 
   config.filter_run_when_matching :focus unless ENV["CI"]
 end

--- a/bundler/spec/support/filters.rb
+++ b/bundler/spec/support/filters.rb
@@ -33,6 +33,7 @@ RSpec.configure do |config|
   config.filter_run_excluding :permissions => Gem.win_platform?
   config.filter_run_excluding :readline => Gem.win_platform?
   config.filter_run_excluding :jruby => RUBY_ENGINE != "jruby"
+  config.filter_run_excluding :truffleruby => RUBY_ENGINE != "truffleruby"
 
   config.filter_run_when_matching :focus unless ENV["CI"]
 end

--- a/bundler/spec/support/rubygems_version_manager.rb
+++ b/bundler/spec/support/rubygems_version_manager.rb
@@ -78,6 +78,7 @@ class RubygemsVersionManager
   end
 
   def rubygems_unrequire_needed?
+    require "rubygems"
     !$LOADED_FEATURES.include?(local_copy_path.join("lib/rubygems.rb").to_s)
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes platform specific specs are installed on truffleruby.

## What is your fix for the problem, implemented in this PR?

Handle the case where an implementation registers itself as a "pure ruby platform" by setting `Gem.platforms == [Gem::Platform::RUBY]`.

Fixes https://github.com/rubygems/rubygems/issues/4330.

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)