### PR TITLE
Stop removing existing platforms when force_ruby_platform is true

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -87,11 +87,7 @@ module Bundler
         @lockfile_contents = Bundler.read_file(lockfile)
         @locked_gems = LockfileParser.new(@lockfile_contents)
         @locked_platforms = @locked_gems.platforms
-        if Bundler.settings[:force_ruby_platform]
-          @platforms = [Gem::Platform::RUBY]
-        else
-          @platforms = @locked_platforms.dup
-        end
+        @platforms = @locked_platforms.dup
         @locked_bundler_version = @locked_gems.bundler_version
         @locked_ruby_version = @locked_gems.ruby_version
 

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -220,6 +220,30 @@ RSpec.describe "bundle lock" do
     expect(lockfile.platforms).to match_array(local_platforms.unshift(java, mingw).uniq)
   end
 
+  it "supports adding new platforms with force_ruby_platform = true" do
+    lockfile <<-L
+      GEM
+        remote: #{file_uri_for(gem_repo1)}/
+        specs:
+          platform_specific (1.0)
+          platform_specific (1.0-x86-linux)
+
+      PLATFORMS
+        ruby
+        x86-linux
+
+      DEPENDENCIES
+        platform_specific
+    L
+
+    bundle "config set force_ruby_platform true"
+    bundle "lock --add-platform java x86-mingw32"
+
+    allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+    lockfile = Bundler::LockfileParser.new(read_lockfile)
+    expect(lockfile.platforms).to contain_exactly(rb, linux, java, mingw)
+  end
+
   it "supports adding the `ruby` platform" do
     bundle "lock --add-platform ruby"
 

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -299,6 +299,48 @@ RSpec.describe "bundle install across platforms" do
     bundle :install
     expect(vendored_gems("gems/rack-1.0.0")).to exist
   end
+
+  it "keeps existing platforms when installing with force_ruby_platform" do
+    lockfile <<-G
+      GEM
+        remote: #{file_uri_for(gem_repo1)}/
+        specs:
+          platform_specific (1.0-java)
+
+      PLATFORMS
+        java
+
+      DEPENDENCIES
+        platform_specific
+    G
+
+    bundle "config set --local force_ruby_platform true"
+
+    install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
+      gem "platform_specific"
+    G
+
+    expect(the_bundle).to include_gem "platform_specific 1.0 RUBY"
+
+    lockfile_should_be <<-G
+      GEM
+        remote: #{file_uri_for(gem_repo1)}/
+        specs:
+          platform_specific (1.0)
+          platform_specific (1.0-java)
+
+      PLATFORMS
+        java
+        ruby
+
+      DEPENDENCIES
+        platform_specific
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    G
+  end
 end
 
 RSpec.describe "bundle install with platform conditionals" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Fixes #4125 - `force_ruby_platform` strips platforms from Gemfile.lock, which causes surprising behaviour when running `bundle lock --add-platform`

## What is your fix for the problem, implemented in this PR?

Stop resetting the bundle definition's platforms to `[ruby]` when `force_ruby_platform` is set. This means that `force_ruby_platform` just special-cases the user's local platform to `ruby`, and the behaviour is the same as when running on any platform that doesn't already exist in the lockfile.


## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
