### PR TITLE
Reset config instance variables after each test

### DIFF
--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -364,7 +364,9 @@ class Gem::TestCase < Minitest::Test
     Dir.chdir @tempdir
 
     ENV['HOME'] = @userhome
+    Gem.instance_variable_set :@config_file, nil
     Gem.instance_variable_set :@user_home, nil
+    Gem.instance_variable_set :@config_home, nil
     Gem.instance_variable_set :@data_home, nil
     Gem.instance_variable_set :@gemdeps, nil
     Gem.instance_variable_set :@env_requirements_by_name, nil


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Rubygems leaves dummy test folders behind after tests complete.

## What is your fix for the problem, implemented in this PR?

Reset config instance variables after each test so that they are not leaked to other tests.

Fixes https://github.com/rubygems/rubygems/pull/4328#issuecomment-773036466.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
