### PR TITLE
Don't error out when activating a binstub unless necessary

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2550,7 +2550,7 @@ class Gem::Specification < Gem::BasicSpecification
     begin
       dependencies.each do |dep|
         next unless dep.runtime?
-        dep.to_specs.each do |dep_spec|
+        dep.matching_specs(true).each do |dep_spec|
           next if visited.has_key?(dep_spec)
           visited[dep_spec] = true
           trail.push(dep_spec)

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -297,6 +297,58 @@ class TestGem < Gem::TestCase
     assert_equal %w[a-1 b-2 c-1], loaded_spec_names
   end
 
+  def test_activate_bin_path_does_not_error_if_a_gem_thats_not_finally_activated_has_orphaned_dependencies
+    a1 = util_spec 'a', '1' do |s|
+      s.executables = ['exec']
+      s.add_dependency 'b'
+    end
+
+    b1 = util_spec 'b', '1' do |s|
+      s.add_dependency 'c', '1'
+    end
+
+    b2 = util_spec 'b', '2' do |s|
+      s.add_dependency 'c', '2'
+    end
+
+    c2 = util_spec 'c', '2'
+
+    install_specs c2, b1, b2, a1
+
+    # c1 is missing, but not needed for activation, so we should not get any errors here
+
+    Gem.activate_bin_path("a", "exec", ">= 0")
+
+    assert_equal %w[a-1 b-2 c-2], loaded_spec_names
+  end
+
+  def test_activate_bin_path_raises_a_meaningful_error_if_a_gem_thats_finally_activated_has_orphaned_dependencies
+    a1 = util_spec 'a', '1' do |s|
+      s.executables = ['exec']
+      s.add_dependency 'b'
+    end
+
+    b1 = util_spec 'b', '1' do |s|
+      s.add_dependency 'c', '1'
+    end
+
+    b2 = util_spec 'b', '2' do |s|
+      s.add_dependency 'c', '2'
+    end
+
+    c1 = util_spec 'c', '1'
+
+    install_specs c1, b1, b2, a1
+
+    # c2 is missing, and b2 which has it as a dependency will be activated, so we should get an error about the orphaned dependency
+
+    e = assert_raises Gem::UnsatisfiableDependencyError do
+      load Gem.activate_bin_path("a", "exec", ">= 0")
+    end
+
+    assert_equal "Unable to resolve dependency: 'b (>= 0)' requires 'c (= 2)'", e.message
+  end
+
   def test_activate_bin_path_in_debug_mode
     a1 = util_spec 'a', '1' do |s|
       s.executables = ['exec']


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When activating an executable from a gem, rubygems will find the spec corresponding to the rubygems binstub, it will then activate it, and they it will finish resolving all of its dependencies, and properly setting up the load path and activate them.

However, if during this process "orphaned gems" are detected (installed gems without valid dependencies installed), rubygems will crash with a very strange error, even if the orphan gem will not end up being activated and used in the end.

The error will look like this:

```
$ rails s
[138376, #<Thread:0x000055e5400bad58 run>, #<Gem::MissingSpecVersionError: Gem::MissingSpecVersionError>, ["/home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/dependency.rb:309:in `to_specs'", "/home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/specification.rb:2553:in `block in traverse'", "/home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/specification.rb:2551:in `each'", "/home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/specification.rb:2551:in `traverse'", "/home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/specification.rb:1031:in `block in find_in_unresolved_tree'", "/home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/specification.rb:1030:in `each'", "/home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/specification.rb:1030:in `find_in_unresolved_tree'", "/home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:114:in `require'", "/home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems.rb:236:in `finish_resolve'", "/home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems.rb:303:in `block in activate_bin_path'", "/home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems.rb:301:in `synchronize'", "/home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems.rb:301:in `activate_bin_path'", "/home/deivid/.rbenv/versions/2.7.2/bin/rails:23:in `<main>'"]]
Traceback (most recent call last):
	12: from /home/deivid/.rbenv/versions/2.7.2/bin/rails:23:in `<main>'
	11: from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems.rb:301:in `activate_bin_path'
	10: from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems.rb:301:in `synchronize'
	 9: from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems.rb:303:in `block in activate_bin_path'
	 8: from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems.rb:236:in `finish_resolve'
	 7: from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:114:in `require'
	 6: from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/specification.rb:1030:in `find_in_unresolved_tree'
	 5: from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/specification.rb:1030:in `each'
	 4: from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/specification.rb:1031:in `block in find_in_unresolved_tree'
	 3: from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/specification.rb:2551:in `traverse'
	 2: from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/specification.rb:2551:in `each'
	 1: from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/specification.rb:2553:in `block in traverse'
/home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/dependency.rb:309:in `to_specs': Could not find 'mini_portile2' (~> 2.4.0) - did find: [mini_portile2-2.5.0] (Gem::MissingSpecVersionError)
Checked in 'GEM_PATH=/home/deivid/.gem/ruby/2.7.0:/home/deivid/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0' , execute `gem env` for more information
	6: from /home/deivid/.rbenv/versions/2.7.2/bin/rails:23:in `<main>'
	5: from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems.rb:301:in `activate_bin_path'
	4: from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems.rb:301:in `synchronize'
	3: from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems.rb:303:in `block in activate_bin_path'
	2: from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems.rb:236:in `finish_resolve'
	1: from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:167:in `require'
/home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:167:in `ensure in require': CRITICAL: RUBYGEMS_ACTIVATION_MONITOR.owned?: before false -> after true (RuntimeError)
```

## What is your fix for the problem, implemented in this PR?

This is a really unhelpful error and in many cases, it's not necesary to raise it.

For example, in my case, the underlying problem was that I had this list of versions of nokogiri on my system:

```
$ gem list nokogiri

*** LOCAL GEMS ***

nokogiri (1.11.1 x86_64-linux, 1.11.0 x86_64-linux, 1.10.8, 1.10.1)
```

And one of them, 1.10.8, had orphaned dependencies:

```
$ gem specification nokogiri -v 1.10.8 --ruby|grep runtime_dependency.*mini_portile
    s.add_runtime_dependency(%q<mini_portile2>.freeze, ["~> 2.4.0"])

$ gem list mini_portile2

*** LOCAL GEMS ***

mini_portile2 (2.5.0)
```

This gem version is irrelevant to this case, since a higher version will be activated, so there's no need to crash with such a weird error.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)