### PR TITLE
Fix `Gem::Specification.stubs_for` returning wrong named specs

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -830,7 +830,9 @@ class Gem::Specification < Gem::BasicSpecification
     if @@stubs
       @@stubs_by_name[name] || []
     else
-      @@stubs_by_name[name] ||= stubs_for_pattern("#{name}-*.gemspec")
+      @@stubs_by_name[name] ||= stubs_for_pattern("#{name}-*.gemspec").select do |s|
+        s.name == name
+      end
     end
   end
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1208,6 +1208,16 @@ dependencies: []
     Gem.platforms = orig_platform
   end
 
+  def test_self_stubs_returns_only_specified_named_specs
+    dir_standard_specs = File.join Gem.dir, 'specifications'
+
+    save_gemspec('a-1', '1', dir_standard_specs){|s| s.name = 'a' }
+    save_gemspec('a-2', '2', dir_standard_specs){|s| s.name = 'a' }
+    save_gemspec('a-a', '3', dir_standard_specs){|s| s.name = 'a-a' }
+
+    assert_equal ['a-1', 'a-2'], Gem::Specification.stubs_for('a').map(&:full_name).sort
+  end
+
   def test_handles_private_null_type
     path = File.expand_path "../data/null-type.gemspec.rz", __FILE__
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Gem::Specification.find_all_by_name returns wrong specs
```ruby
Gem::Specification.reset
p Gem::Specification.stubs_for('pry').map(&:name) #=> ['pry', 'pry-doc']
p Gem::Specification.find_all_by_name('pry').map(&:name) #=> ['pry', 'pry-doc']
Gem::Specification.stubs
p Gem::Specification.stubs_for('pry').map(&:name) #=> ['pry']
p Gem::Specification.find_all_by_name('pry').map(&:name) #=> ['pry']
```

## What is your fix for the problem, implemented in this PR?

```ruby
# in Gem::Specification.stubs_for
@@stubs_by_name[name] ||= stubs_for_pattern("#{name}-*.gemspec")
```
`stubs_for_pattern('pry')` returns `pry`, `pry-doc`, `pry-foo`, `pry-bar`.
this PR rejects `pry-doc`, `pry-foo`, `pry-bar`, which name does not match.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
