### PR TITLE
Remove recommendation to run bundle env

### DIFF
--- a/.github/ISSUE_TEMPLATE/bundler-related-issue.md
+++ b/.github/ISSUE_TEMPLATE/bundler-related-issue.md
@@ -50,6 +50,4 @@ Ideally, we recommend you to set up the list of steps as a [Dockerfile](https://
 
 <!-- Replace this with the actual result you got. Paste the output of your command here. -->
 
-### If not included with the output of your command, run `bundle env` and paste the output below
-
-<!-- Replace this with the result of `bundle env`. -->
+### Whatever you do, do not run `bundle env` and paste the output below as you will potentially expose secrets to the public internet


### PR DESCRIPTION
While filing an issue I pasted my bundle env in as instructed. I noticed that it had credentials in it, so I removed them before sending. It's insanely dangerous to suggest people do that.