### PR TITLE
Fix encoding issue on compact index updater

### DIFF
--- a/bundler/lib/bundler/compact_index_client/updater.rb
+++ b/bundler/lib/bundler/compact_index_client/updater.rb
@@ -54,7 +54,7 @@ module Bundler
             if response.is_a?(Net::HTTPPartialContent) && local_temp_path.size.nonzero?
               local_temp_path.open("a") {|f| f << slice_body(content, 1..-1) }
             else
-              local_temp_path.open("w") {|f| f << content }
+              local_temp_path.open("wb") {|f| f << content }
             end
           end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes bundler crashes with an encoding error: https://github.com/rubygems/rubygems/issues/4360.

## What is your fix for the problem, implemented in this PR?

We should write versions file binarily so that no transcoding happens when the encoding of the file being created and the encoding of the data don't match.

I'm not sure whether this problem was introduced with https://github.com/rubygems/rubygems/pull/4081 or not, though. It seems to me that it should reproduce either way.

Fixes #4360.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
