### PR TITLE
Fix error message when underscore selection can't find bundler

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -275,7 +275,7 @@ module Gem
 
     unless spec = specs.first
       msg = "can't find gem #{dep} with executable #{exec_name}"
-      if name == "bundler" && bundler_message = Gem::BundlerVersionFinder.missing_version_message
+      if dep.filters_bundler? && bundler_message = Gem::BundlerVersionFinder.missing_version_message
         msg = bundler_message
       end
       raise Gem::GemNotFoundException, msg

--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -277,7 +277,7 @@ class Gem::Dependency
       requirement.satisfied_by?(spec.version) && env_req.satisfied_by?(spec.version)
     end.map(&:to_spec)
 
-    Gem::BundlerVersionFinder.filter!(matches) if name == "bundler".freeze && !requirement.specific?
+    Gem::BundlerVersionFinder.filter!(matches) if name == "bundler".freeze && !specific?
 
     if platform_only
       matches.reject! do |spec|

--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -277,7 +277,7 @@ class Gem::Dependency
       requirement.satisfied_by?(spec.version) && env_req.satisfied_by?(spec.version)
     end.map(&:to_spec)
 
-    Gem::BundlerVersionFinder.filter!(matches) if name == "bundler".freeze && !specific?
+    Gem::BundlerVersionFinder.filter!(matches) if filters_bundler?
 
     if platform_only
       matches.reject! do |spec|
@@ -293,6 +293,10 @@ class Gem::Dependency
 
   def specific?
     @requirement.specific?
+  end
+
+  def filters_bundler?
+    name == "bundler".freeze && !specific?
   end
 
   def to_specs

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -468,6 +468,32 @@ class TestGem < Gem::TestCase
     assert_equal %w[bundler-1.17.3], loaded_spec_names
   end
 
+  def test_activate_bin_path_gives_proper_error_for_bundler_when_underscore_selection_given
+    File.open("Gemfile.lock", "w") do |f|
+      f.write <<-L.gsub(/ {8}/, "")
+        GEM
+          remote: https://rubygems.org/
+          specs:
+
+        PLATFORMS
+          ruby
+
+        DEPENDENCIES
+
+        BUNDLED WITH
+          2.1.4
+      L
+    end
+
+    File.open("Gemfile", "w") {|f| f.puts('source "https://rubygems.org"') }
+
+    e = assert_raises Gem::GemNotFoundException do
+      load Gem.activate_bin_path("bundler", "bundle", "= 2.2.8")
+    end
+
+    assert_equal "can't find gem bundler (= 2.2.8) with executable bundle", e.message
+  end
+
   def test_self_bin_path_no_exec_name
     e = assert_raises ArgumentError do
       Gem.bin_path 'a'


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If underscore version selection is given to the gem CLI, like `bundle _2.2.8_ install`, and the given version can't be found, rubygems will erroneously mentioned the `BUNDLED WITH` version in the lockfile if present, rather than the version given in the CLI.

```console
$ bundle _2.2.8_ install

Gem::GemNotFoundException: Could not find 'bundler' (2.1.4) required by your /home/deivid/Code/playground/zookeeper/Gemfile.lock.
To update to the latest version installed on your system, run `bundle update --bundler`.
To install the missing version, run `gem install bundler:2.1.4`

  find_spec_for_exe at /home/deivid/.rbenv/versions/jruby-9.2.14.0/lib/ruby/stdlib/rubygems.rb:281
  activate_bin_path at /home/deivid/.rbenv/versions/jruby-9.2.14.0/lib/ruby/stdlib/rubygems.rb:300
             <main> at /home/deivid/.rbenv/versions/jruby-9.2.14.0/bin/bundle:23

```

## What is your fix for the problem, implemented in this PR?

Use the same special bundler logic for error messages too.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)