### PR TITLE
Use SilentUI in "setup"/"update --system" commands with --silent flag.

### DIFF
--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -148,6 +148,7 @@ By default, this RubyGems will install gem as:
 
   def execute
     @verbose = Gem.configuration.really_verbose
+    self.ui = Gem::SilentUI.new if options[:silent]
 
     install_destdir = options[:destdir]
 

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -139,6 +139,15 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     assert_equal "\t#{default_bundler_bin_path}", out.shift
   end
 
+  def test_execute_silent
+    @cmd.options[:document] = []
+    @cmd.options[:silent] = true
+
+    @cmd.execute
+
+    assert_kind_of Gem::SilentUI, @cmd.ui
+  end
+
   def test_env_shebang_flag
     gem_bin_path = gem_install 'a'
     write_file gem_bin_path do |io|


### PR DESCRIPTION
related to https://github.com/rubygems/rubygems/issues/4355

With this change `ruby setup.rb` (or `gem update --system`) uses `SilentUI` when --silent option is passed.

## before

```
$ ruby setup.rb --silent
  Successfully built RubyGem
  Name: bundler
  Version: 2.3.0.dev
  File: bundler-2.3.0.dev.gem
Bundler 2.3.0.dev installed
RubyGems 3.3.0.dev installed
Regenerating binstubs
Regenerating plugins
Parsing documentation for rubygems-3.3.0.dev
Installing ri documentation for rubygems-3.3.0.dev



------------------------------------------------------------------------------

RubyGems installed the following executables:
        /home/retro/.rubies/ruby-2.7.2/bin/gem
        /home/retro/.rubies/ruby-2.7.2/bin/bundle
        /home/retro/.rubies/ruby-2.7.2/bin/bundler

Ruby Interactive (ri) documentation was installed. ri is kind of like man 
pages for Ruby libraries. You may access it like this:
  ri Classname
  ri Classname.class_method
  ri Classname#instance_method
If you do not wish to install this documentation in the future, use the
--no-document flag, or set it as the default in your ~/.gemrc file. See
'gem help env' for details.

```

## after

```
[retro@retro  rubygems (silent-setup %=)]❤ ruby setup.rb --silent
[retro@retro  rubygems (silent-setup %=)]❤ echo $?
0

```