### PR TITLE
Fix bundler sometimes choosing ruby variants over java ones

### DIFF
--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -36,7 +36,7 @@ module Bundler
         @base_dg.add_vertex(ls.name, DepProxy.get_proxy(dep, ls.platform), true)
       end
       additional_base_requirements.each {|d| @base_dg.add_vertex(d.name, d) }
-      @platforms = platforms
+      @platforms = platforms.reject {|p| (platforms - [p]).any? {|pl| generic(pl) == p } }
       @resolving_only_for_ruby = platforms == [Gem::Platform::RUBY]
       @gem_version_promoter = gem_version_promoter
       @use_gvp = Bundler.feature_flag.use_gem_version_promoter_for_major_updates? || !@gem_version_promoter.major?

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -36,7 +36,7 @@ module Bundler
         @base_dg.add_vertex(ls.name, DepProxy.get_proxy(dep, ls.platform), true)
       end
       additional_base_requirements.each {|d| @base_dg.add_vertex(d.name, d) }
-      @platforms = platforms.reject {|p| (platforms - [p]).any? {|pl| generic(pl) == p } }
+      @platforms = platforms.reject {|p| p != Gem::Platform::RUBY && (platforms - [p]).any? {|pl| generic(pl) == p } }
       @resolving_only_for_ruby = platforms == [Gem::Platform::RUBY]
       @gem_version_promoter = gem_version_promoter
       @use_gvp = Bundler.feature_flag.use_gem_version_promoter_for_major_updates? || !@gem_version_promoter.major?

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -92,6 +92,11 @@ RSpec.describe "bundle install across platforms" do
 
     expect(the_bundle).to include_gems "nokogiri 1.4.2"
     expect(the_bundle).not_to include_gems "weakling"
+
+    simulate_platform "java"
+    bundle "install"
+
+    expect(the_bundle).to include_gems "nokogiri 1.4.2 JAVA", "weakling 0.0.3"
   end
 
   it "does not keep unneeded platforms for gems that are used" do
@@ -235,20 +240,6 @@ RSpec.describe "bundle install across platforms" do
       bundle :lock
       lockfile_should_be good_lockfile
     end
-  end
-
-  it "works the other way with gems that have different dependencies" do
-    simulate_platform "ruby"
-    install_gemfile <<-G
-      source "#{file_uri_for(gem_repo1)}"
-
-      gem "nokogiri"
-    G
-
-    simulate_platform "java"
-    bundle "install"
-
-    expect(the_bundle).to include_gems "nokogiri 1.4.2 JAVA", "weakling 0.0.3"
   end
 
   it "works with gems with platform-specific dependency having different requirements order" do

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -88,11 +88,7 @@ RSpec.describe "bundle install across platforms" do
     simulate_new_machine
 
     simulate_platform "ruby"
-    install_gemfile <<-G
-      source "#{file_uri_for(gem_repo1)}"
-
-      gem "nokogiri"
-    G
+    bundle "install"
 
     expect(the_bundle).to include_gems "nokogiri 1.4.2"
     expect(the_bundle).not_to include_gems "weakling"

--- a/bundler/spec/resolver/platform_spec.rb
+++ b/bundler/spec/resolver/platform_spec.rb
@@ -28,6 +28,23 @@ RSpec.describe "Resolving platform craziness" do
     end
   end
 
+  it "resolves multiplatform gems with redundant platforms correctly" do
+    @index = build_index do
+      gem "zookeeper", "1.4.11"
+      gem "zookeeper", "1.4.11", "java" do
+        dep "slyphon-log4j", "= 1.2.15"
+        dep "slyphon-zookeeper_jar", "= 3.3.5"
+      end
+      gem "slyphon-log4j", "1.2.15"
+      gem "slyphon-zookeeper_jar", "3.3.5", "java"
+    end
+
+    dep "zookeeper"
+    platforms "java", "ruby", "universal-java-11"
+
+    should_resolve_as %w[zookeeper-1.4.11 zookeeper-1.4.11-java slyphon-log4j-1.2.15 slyphon-zookeeper_jar-3.3.5-java]
+  end
+
   it "takes the latest ruby gem, even if an older platform specific version is available" do
     @index = build_index do
       gem "foo", "1.0.0"

--- a/bundler/spec/runtime/platform_spec.rb
+++ b/bundler/spec/runtime/platform_spec.rb
@@ -57,6 +57,57 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
     expect(the_bundle).to include_gems "nokogiri 1.4.2"
   end
 
+  it "will keep both platforms when both ruby and a specific ruby platform are locked and the bundle is unlocked" do
+    build_repo4 do
+      build_gem "nokogiri", "1.11.1" do |s|
+        s.add_dependency "mini_portile2", "~> 2.5.0"
+        s.add_dependency "racc", "~> 1.4"
+      end
+
+      build_gem "nokogiri", "1.11.1" do |s|
+        s.platform = Bundler.local_platform
+        s.add_dependency "racc", "~> 1.4"
+      end
+
+      build_gem "mini_portile2", "2.5.0"
+      build_gem "racc", "1.5.2"
+    end
+
+    good_lockfile = <<~L
+      GEM
+        remote: #{file_uri_for(gem_repo4)}/
+        specs:
+          mini_portile2 (2.5.0)
+          nokogiri (1.11.1)
+            mini_portile2 (~> 2.5.0)
+            racc (~> 1.4)
+          nokogiri (1.11.1-#{Bundler.local_platform})
+            racc (~> 1.4)
+          racc (1.5.2)
+
+      PLATFORMS
+        ruby
+        #{Bundler.local_platform}
+
+      DEPENDENCIES
+        nokogiri (~> 1.11)
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+    gemfile <<-G
+      source "#{file_uri_for(gem_repo4)}"
+      gem "nokogiri", "~> 1.11"
+    G
+
+    lockfile good_lockfile
+
+    bundle "update nokogiri"
+
+    expect(lockfile).to eq(good_lockfile)
+  end
+
   it "will use the java platform if both generic java and generic ruby platforms are locked", :jruby do
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"

--- a/bundler/spec/runtime/platform_spec.rb
+++ b/bundler/spec/runtime/platform_spec.rb
@@ -57,6 +57,38 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
     expect(the_bundle).to include_gems "nokogiri 1.4.2"
   end
 
+  it "will use the java platform if both generic java and generic ruby platforms are locked", :jruby do
+    gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
+      gem "nokogiri"
+    G
+
+    lockfile <<-G
+      GEM
+        remote: #{file_uri_for(gem_repo1)}/
+        specs:
+          nokogiri (1.4.2)
+          nokogiri (1.4.2-java)
+            weakling (>= 0.0.3)
+          weakling (0.0.3)
+
+      PLATFORMS
+        java
+        ruby
+
+      DEPENDENCIES
+        nokogiri
+
+      BUNDLED WITH
+        2.1.4
+    G
+
+    bundle "install"
+
+    expect(out).to include("Fetching nokogiri 1.4.2 (java)")
+    expect(the_bundle).to include_gems "nokogiri 1.4.2 JAVA"
+  end
+
   it "will add the resolve for the current platform" do
     lockfile <<-G
       GEM


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes we resolve to the RUBY variant of gems under JRUBY, when we should resolve to the JAVA variant.

## What is your fix for the problem, implemented in this PR?

The problem happens when we resolve against JAVA and a specific JAVA platform at the same time. Since dependencies are only expanded to DependencyProxy object for the most specific platform, resolving for both of these platforms sometimes don't lead to the correct result.

To fix it, we filter out the generic JAVA platform if a more specific java platform is present before resolving.

Fixes https://github.com/rubygems/rubygems/issues/4354.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)