### PR TITLE
Fix adding platforms to lockfile sometimes conflicting on ruby requirements

### DIFF
--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -43,7 +43,7 @@ module Bundler
       @lockfile_uses_separate_rubygems_sources = Bundler.feature_flag.disable_multisource?
 
       @variant_specific_names = []
-      @generic_names = []
+      @generic_names = ["Ruby\0", "RubyGems\0"]
     end
 
     def start(requirements)

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -491,6 +491,51 @@ RSpec.describe "bundle lock" do
     end
   end
 
+  it "does not conflict on ruby requirements when adding new platforms" do
+    next_minor = Gem.ruby_version.segments[0..1].map.with_index {|s, i| i == 1 ? s + 1 : s }.join(".")
+
+    build_repo4 do
+      build_gem "raygun-apm", "1.0.78" do |s|
+        s.platform = "x86_64-linux"
+        s.required_ruby_version = "< #{next_minor}.dev"
+      end
+
+      build_gem "raygun-apm", "1.0.78" do |s|
+        s.platform = "universal-darwin"
+        s.required_ruby_version = "< #{next_minor}.dev"
+      end
+
+      build_gem "raygun-apm", "1.0.78" do |s|
+        s.platform = "x64-mingw32"
+        s.required_ruby_version = "< #{next_minor}.dev"
+      end
+    end
+
+    gemfile <<-G
+      source "https://localgemserver.test"
+
+      gem "raygun-apm"
+    G
+
+    lockfile <<-L
+      GEM
+        remote: https://localgemserver.test/
+        specs:
+          raygun-apm (1.0.78-universal-darwin)
+
+      PLATFORMS
+        x86_64-darwin-19
+
+      DEPENDENCIES
+        raygun-apm
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+    bundle "lock --add-platform x86_64-linux", :artifice => :compact_index, :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+  end
+
   context "when an update is available" do
     let(:repo) { gem_repo2 }
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since https://github.com/rubygems/rubygems/commit/1f7797a1b24b3aa5d14086415289d55b57be89e1, adding platforms to lockfiles sometimes conflicts on ruby version requirements.

## What is your fix for the problem, implemented in this PR?

Our previous logic for selecting platform specific dependencies was applying to metadata dependencies, which is unexpected. So consider metadata dependencies as generic, so that their spec groups never get platforms activated/deactivated dinamically.

Fixes https://github.com/rubygems/rubygems/issues/4366.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)