### PR TITLE
Pickup changelog from rubygems 3.2.9 and bundler 2.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 3.2.9 / 2021-02-08
+
+## Bug fixes:
+
+* Fix error message when underscore selection can't find bundler. Pull
+  request #4363 by deivid-rodriguez
+* Fix `Gem::Specification.stubs_for` returning wrong named specs. Pull
+  request #4356 by tompng
+* Don't error out when activating a binstub unless necessary. Pull request
+  #4351 by deivid-rodriguez
+* Fix `gem outdated` incorrectly handling platform specific gems. Pull
+  request #4248 by deivid-rodriguez
+
 # 3.2.8 / 2021-02-02
 
 ## Bug fixes:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 2.2.9 (February 8, 2021)
+
+## Enhancements:
+
+  - Stop removing existing platforms when force_ruby_platform is true [#4336](https://github.com/rubygems/rubygems/pull/4336)
+
+## Bug fixes:
+
+  - Don't install platform specific gems on truffleruby [#4333](https://github.com/rubygems/rubygems/pull/4333)
+
 # 2.2.8 (February 2, 2021)
 
 ## Enhancements:


### PR DESCRIPTION
Sync the changelog from the stable branch.