### PR TITLE
Include documentation fixes in patch level releases

### DIFF
--- a/.changelog.yml
+++ b/.changelog.yml
@@ -24,9 +24,9 @@ patch_level_labels:
   - "rubygems: enhancement"
   - "rubygems: bug fix"
   - "rubygems: performance"
+  - "rubygems: documentation"
   - "rubygems: backport"
 
 minor_level_labels:
   - "rubygems: deprecation"
   - "rubygems: feature"
-  - "rubygems: documentation"

--- a/bundler/.changelog.yml
+++ b/bundler/.changelog.yml
@@ -22,9 +22,9 @@ patch_level_labels:
   - "bundler: enhancement"
   - "bundler: bug fix"
   - "bundler: performance"
+  - "bundler: documentation"
   - "bundler: backport"
 
 minor_level_labels:
   - "bundler: deprecation"
   - "bundler: feature"
-  - "bundler: documentation"


### PR DESCRIPTION


<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

I wanted to include #4373 with rubygems 3.2.10, but our release scripts did not include it.

## What is your fix for the problem, implemented in this PR?

Documentation for new features will be included with the new feature PR, and tagged as "feature", but PRs tagged with "documentation" are usually fixes and improvements for existing docs, so there's no reason to not include them with patch releases.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
