### PR TITLE
Pickup changelog from rubygems 3.2.10 and bundler 2.2.10 from the stable branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 3.2.10 / 2021-02-15
+
+## Documentation:
+
+* Add a `gem push` example to `gem help`. Pull request #4373 by
+  deivid-rodriguez
+* Improve documentation for `required_ruby_version`. Pull request #4343 by
+  AlexWayfer
+
 # 3.2.9 / 2021-02-08
 
 ## Bug fixes:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 2.2.10 (February 15, 2021)
+
+## Security fixes:
+
+  - Fix source priority for transitive dependencies and split lockfile rubygems source sections [#3655](https://github.com/rubygems/rubygems/pull/3655)
+
+## Bug fixes:
+
+  - Fix adding platforms to lockfile sometimes conflicting on ruby requirements [#4371](https://github.com/rubygems/rubygems/pull/4371)
+  - Fix bundler sometimes choosing ruby variants over java ones [#4367](https://github.com/rubygems/rubygems/pull/4367)
+
+## Documentation:
+
+  - Update man pages to reflect to new default for bundle install jobs [#4188](https://github.com/rubygems/rubygems/pull/4188)
+
 # 2.2.9 (February 8, 2021)
 
 ## Enhancements:


### PR DESCRIPTION
Just getting the changelog in sync with the stable branch.