### PR TITLE
Lock GEM sources separately and fix locally installed specs confusing bundler

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -111,6 +111,17 @@ module Bundler
         @locked_platforms = []
       end
 
+      @locked_gem_sources = @locked_sources.select {|s| s.is_a?(Source::Rubygems) }
+      @disable_multisource = @locked_gem_sources.all?(&:disable_multisource?)
+
+      unless @disable_multisource
+        msg = "Your lockfile contains a single rubygems source section with multiple remotes, which is insecure. You should run `bundle update` or generate your lockfile from scratch."
+
+        Bundler::SharedHelpers.major_deprecation 2, msg
+
+        @sources.merged_gem_lockfile_sections!
+      end
+
       @unlock[:gems] ||= []
       @unlock[:sources] ||= []
       @unlock[:ruby] ||= if @ruby_version && locked_ruby_version_object
@@ -148,6 +159,10 @@ module Bundler
           end
         GemVersionPromoter.new(locked_specs, @unlock[:gems])
       end
+    end
+
+    def disable_multisource?
+      @disable_multisource
     end
 
     def resolve_with_cache!
@@ -537,6 +552,9 @@ module Bundler
     attr_reader :sources
     private :sources
 
+    attr_reader :locked_gem_sources
+    private :locked_gem_sources
+
     def nothing_changed?
       !@source_changes && !@dependency_changes && !@new_platform && !@path_changes && !@local_changes && !@locked_specs_incomplete_for_platform
     end
@@ -661,10 +679,8 @@ module Bundler
     end
 
     def converge_rubygems_sources
-      return false if Bundler.feature_flag.disable_multisource?
+      return false if disable_multisource?
 
-      # Get the RubyGems sources from the Gemfile.lock
-      locked_gem_sources = @locked_sources.select {|s| s.is_a?(Source::Rubygems) }
       return false if locked_gem_sources.empty?
 
       # Get the RubyGems remotes from the Gemfile

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -460,19 +460,16 @@ repo_name ||= user_name
         @sources.add_rubygems_remote(source)
       end
 
-      if Bundler.feature_flag.disable_multisource?
+      if Bundler.feature_flag.bundler_3_mode?
         msg = "This Gemfile contains multiple primary sources. " \
           "Each source after the first must include a block to indicate which gems " \
-          "should come from that source. To downgrade this error to a warning, run " \
-          "`bundle config unset disable_multisource`"
+          "should come from that source"
         raise GemfileEvalError, msg
       else
         Bundler::SharedHelpers.major_deprecation 2, "Your Gemfile contains multiple primary sources. " \
           "Using `source` more than once without a block is a security risk, and " \
           "may result in installing unexpected gems. To resolve this warning, use " \
-          "a block to indicate which gems should come from the secondary source. " \
-          "To upgrade this warning to an error, run `bundle config set --local " \
-          "disable_multisource true`."
+          "a block to indicate which gems should come from the secondary source."
       end
     end
 

--- a/bundler/lib/bundler/lockfile_parser.rb
+++ b/bundler/lib/bundler/lockfile_parser.rb
@@ -131,18 +131,8 @@ module Bundler
             @sources << @current_source
           end
         when GEM
-          source_remotes = Array(@opts["remote"])
-
-          if source_remotes.size == 1
-            @opts["remotes"] = @opts.delete("remote")
-            @current_source = TYPES[@type].from_lock(@opts)
-          else
-            source_remotes.each do |url|
-              rubygems_aggregate.add_remote(url)
-            end
-            @current_source = rubygems_aggregate
-          end
-
+          @opts["remotes"] = Array(@opts.delete("remote")).reverse
+          @current_source = TYPES[@type].from_lock(@opts)
           @sources << @current_source
         when PLUGIN
           @current_source = Plugin.source_from_lock(@opts)
@@ -244,10 +234,6 @@ module Bundler
 
     def parse_ruby(line)
       @ruby_version = line.strip
-    end
-
-    def rubygems_aggregate
-      @rubygems_aggregate ||= Source::Rubygems.new
     end
   end
 end

--- a/bundler/lib/bundler/plugin/api/source.rb
+++ b/bundler/lib/bundler/plugin/api/source.rb
@@ -140,6 +140,13 @@ module Bundler
           end
         end
 
+        # Set internal representation to fetch the gems/specs locally.
+        #
+        # When this is called, the source should try to fetch the specs and
+        # install from the local system.
+        def local!
+        end
+
         # Set internal representation to fetch the gems/specs from remote.
         #
         # When this is called, the source should try to fetch the specs and

--- a/bundler/lib/bundler/source.rb
+++ b/bundler/lib/bundler/source.rb
@@ -33,6 +33,8 @@ module Bundler
       spec.source == self
     end
 
+    def local!; end
+
     def cached!; end
 
     def remote!; end

--- a/bundler/lib/bundler/source.rb
+++ b/bundler/lib/bundler/source.rb
@@ -33,6 +33,10 @@ module Bundler
       spec.source == self
     end
 
+    def cached!; end
+
+    def remote!; end
+
     # it's possible that gems from one source depend on gems from some
     # other source, so now we download gemspecs and iterate over those
     # dependencies, looking for gems we don't have info on yet.

--- a/bundler/lib/bundler/source/metadata.rb
+++ b/bundler/lib/bundler/source/metadata.rb
@@ -33,10 +33,6 @@ module Bundler
         end
       end
 
-      def cached!; end
-
-      def remote!; end
-
       def options
         {}
       end

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -22,7 +22,7 @@ module Bundler
         @allow_cached = false
         @caches = [cache_path, *Bundler.rubygems.gem_cache]
 
-        Array(options["remotes"] || []).reverse_each {|r| add_remote(r) }
+        Array(options["remotes"]).reverse_each {|r| add_remote(r) }
       end
 
       def remote!

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -20,9 +20,17 @@ module Bundler
         @dependency_names = []
         @allow_remote = false
         @allow_cached = false
+        @allow_local = options["allow_local"] || false
         @caches = [cache_path, *Bundler.rubygems.gem_cache]
 
         Array(options["remotes"]).reverse_each {|r| add_remote(r) }
+      end
+
+      def local!
+        return if @allow_local
+
+        @specs = nil
+        @allow_local = true
       end
 
       def remote!
@@ -95,7 +103,7 @@ module Bundler
           # small_idx.use large_idx.
           idx = @allow_remote ? remote_specs.dup : Index.new
           idx.use(cached_specs, :override_dupes) if @allow_cached || @allow_remote
-          idx.use(installed_specs, :override_dupes)
+          idx.use(installed_specs, :override_dupes) if @allow_local
           idx
         end
       end
@@ -373,7 +381,7 @@ module Bundler
 
       def cached_specs
         @cached_specs ||= begin
-          idx = installed_specs.dup
+          idx = @allow_local ? installed_specs.dup : Index.new
 
           Dir["#{cache_path}/*.gem"].each do |gemfile|
             next if gemfile =~ /^bundler\-[\d\.]+?\.gem/

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -49,8 +49,12 @@ module Bundler
         o.is_a?(Rubygems) && (o.credless_remotes - credless_remotes).empty?
       end
 
+      def disable_multisource?
+        @remotes.size <= 1
+      end
+
       def can_lock?(spec)
-        return super if Bundler.feature_flag.disable_multisource?
+        return super if disable_multisource?
         spec.source.is_a?(Rubygems)
       end
 

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -26,11 +26,15 @@ module Bundler
       end
 
       def remote!
+        return if @allow_remote
+
         @specs = nil
         @allow_remote = true
       end
 
       def cached!
+        return if @allow_cached
+
         @specs = nil
         @allow_cached = true
       end

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -20,6 +20,16 @@ module Bundler
       @global_path_source     = nil
       @rubygems_sources       = []
       @metadata_source        = Source::Metadata.new
+
+      @disable_multisource = true
+    end
+
+    def disable_multisource?
+      @disable_multisource
+    end
+
+    def merged_gem_lockfile_sections!
+      @disable_multisource = false
     end
 
     def add_path_source(options = {})
@@ -77,7 +87,7 @@ module Bundler
 
     def lock_sources
       lock_sources = (path_sources + git_sources + plugin_sources).sort_by(&:to_s)
-      if Bundler.feature_flag.disable_multisource?
+      if disable_multisource?
         lock_sources + rubygems_sources.sort_by(&:to_s)
       else
         lock_sources << combine_rubygems_sources
@@ -94,7 +104,7 @@ module Bundler
         end
       end
 
-      replacement_rubygems = !Bundler.feature_flag.disable_multisource? &&
+      replacement_rubygems = !disable_multisource? &&
         replacement_sources.detect {|s| s.is_a?(Source::Rubygems) }
       @global_rubygems_source = replacement_rubygems if replacement_rubygems
 

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -9,7 +9,7 @@ module Bundler
       :metadata_source
 
     def global_rubygems_source
-      @global_rubygems_source ||= rubygems_aggregate_class.new
+      @global_rubygems_source ||= rubygems_aggregate_class.new("allow_local" => true)
     end
 
     def initialize
@@ -57,7 +57,7 @@ module Bundler
     end
 
     def global_rubygems_source=(uri)
-      @global_rubygems_source ||= rubygems_aggregate_class.new("remotes" => uri)
+      @global_rubygems_source ||= rubygems_aggregate_class.new("remotes" => uri, "allow_local" => true)
     end
 
     def add_rubygems_remote(uri)

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -82,6 +82,7 @@ module Bundler
       materialized.map! do |s|
         next s unless s.is_a?(LazySpecification)
         s.source.dependency_names = deps if s.source.respond_to?(:dependency_names=)
+        s.source.local!
         spec = s.__materialize__
         unless spec
           unless missing_specs
@@ -102,6 +103,7 @@ module Bundler
       @specs.map do |s|
         next s unless s.is_a?(LazySpecification)
         s.source.dependency_names = names if s.source.respond_to?(:dependency_names=)
+        s.source.local!
         s.source.remote!
         spec = s.__materialize__
         raise GemNotFound, "Could not find #{s.full_name} in any of the sources" unless spec

--- a/bundler/spec/bundler/source_list_spec.rb
+++ b/bundler/spec/bundler/source_list_spec.rb
@@ -372,26 +372,7 @@ RSpec.describe Bundler::SourceList do
       source_list.add_git_source("uri" => "git://first-git.org/path.git")
     end
 
-    it "combines the rubygems sources into a single instance, removing duplicate remotes from the end", :bundler => "< 3" do
-      expect(source_list.lock_sources).to eq [
-        Bundler::Source::Git.new("uri" => "git://first-git.org/path.git"),
-        Bundler::Source::Git.new("uri" => "git://second-git.org/path.git"),
-        Bundler::Source::Git.new("uri" => "git://third-git.org/path.git"),
-        ASourcePlugin.new("uri" => "https://second-plugin.org/random"),
-        ASourcePlugin.new("uri" => "https://third-bar.org/foo"),
-        Bundler::Source::Path.new("path" => "/first/path/to/gem"),
-        Bundler::Source::Path.new("path" => "/second/path/to/gem"),
-        Bundler::Source::Path.new("path" => "/third/path/to/gem"),
-        Bundler::Source::Rubygems.new("remotes" => [
-          "https://duplicate-rubygems.org",
-          "https://first-rubygems.org",
-          "https://second-rubygems.org",
-          "https://third-rubygems.org",
-        ]),
-      ]
-    end
-
-    it "returns all sources, without combining rubygems sources", :bundler => "3" do
+    it "returns all sources, without combining rubygems sources" do
       expect(source_list.lock_sources).to eq [
         Bundler::Source::Git.new("uri" => "git://first-git.org/path.git"),
         Bundler::Source::Git.new("uri" => "git://second-git.org/path.git"),

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "bundle lock" do
   it "does not fetch remote specs when using the --local option" do
     bundle "lock --update --local", :raise_on_error => false
 
-    expect(err).to match(/sources listed in your Gemfile|installed locally/)
+    expect(err).to match(/installed locally/)
   end
 
   it "works with --gemfile flag" do

--- a/bundler/spec/install/deploy_spec.rb
+++ b/bundler/spec/install/deploy_spec.rb
@@ -126,21 +126,21 @@ RSpec.describe "install in deployment or frozen mode" do
       bundle "config set --local path vendor/bundle"
       bundle "install"
       gemfile <<-G
-      source "http://user_name:password@localgemserver.test/"
-      gem "rack"
+        source "http://user_name:password@localgemserver.test/"
+        gem "rack"
       G
 
       lockfile <<-G
-      GEM
-        remote: http://localgemserver.test/
-        specs:
-          rack (1.0.0)
+        GEM
+          remote: http://localgemserver.test/
+          specs:
+            rack (1.0.0)
 
-      PLATFORMS
-        #{local}
+        PLATFORMS
+          #{local}
 
-      DEPENDENCIES
-        rack
+        DEPENDENCIES
+          rack
       G
 
       bundle "config set --local deployment true"

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -511,9 +511,149 @@ RSpec.describe "bundle install with gems on multiple sources" do
           L
         end
 
-        it "upgrades gems when running bundle update, without printing any warnings or errors" do
+        it "does not install newer versions or generate lockfile changes when running bundle install, and warns", :bundler => "< 3" do
+          initial_lockfile = lockfile
+
+          bundle :install
+
+          expect(err).to include("Your lockfile contains a single rubygems source section with multiple remotes, which is insecure.")
+
+          expect(the_bundle).to include_gems("activesupport 6.0.3.4")
+          expect(the_bundle).not_to include_gems("activesupport 6.1.2.1")
+          expect(the_bundle).to include_gems("tzinfo 1.2.9")
+          expect(the_bundle).not_to include_gems("tzinfo 2.0.4")
+          expect(the_bundle).to include_gems("concurrent-ruby 1.1.8")
+          expect(the_bundle).not_to include_gems("concurrent-ruby 1.1.9")
+
+          expect(lockfile).to eq(initial_lockfile)
+        end
+
+        it "fails when running bundle install", :bundler => "3" do
+          initial_lockfile = lockfile
+
+          bundle :install, :raise_on_error => false
+
+          expect(err).to include("Your lockfile contains a single rubygems source section with multiple remotes, which is insecure.")
+
+          expect(lockfile).to eq(initial_lockfile)
+        end
+
+        it "splits sections and upgrades gems when running bundle update, and doesn't warn" do
           bundle "update --all"
           expect(err).to be_empty
+
+          expect(the_bundle).not_to include_gems("activesupport 6.0.3.4")
+          expect(the_bundle).to include_gems("activesupport 6.1.2.1")
+          expect(the_bundle).not_to include_gems("tzinfo 1.2.9")
+          expect(the_bundle).to include_gems("tzinfo 2.0.4")
+          expect(the_bundle).not_to include_gems("concurrent-ruby 1.1.8")
+          expect(the_bundle).to include_gems("concurrent-ruby 1.1.9")
+
+          expect(lockfile).to eq <<~L
+            GEM
+              remote: #{file_uri_for(gem_repo2)}/
+              specs:
+                activesupport (6.1.2.1)
+                  concurrent-ruby (~> 1.0, >= 1.0.2)
+                  i18n (>= 1.6, < 2)
+                  minitest (>= 5.1)
+                  tzinfo (~> 2.0)
+                  zeitwerk (~> 2.3)
+                concurrent-ruby (1.1.9)
+                connection_pool (2.2.3)
+                i18n (1.8.9)
+                  concurrent-ruby (~> 1.0)
+                minitest (5.14.3)
+                rack (2.2.3)
+                redis (4.2.5)
+                sidekiq (6.1.3)
+                  connection_pool (>= 2.2.2)
+                  rack (~> 2.0)
+                  redis (>= 4.2.0)
+                tzinfo (2.0.4)
+                  concurrent-ruby (~> 1.0)
+                zeitwerk (2.4.2)
+
+            GEM
+              remote: #{file_uri_for(gem_repo3)}/
+              specs:
+                sidekiq-pro (5.2.1)
+                  connection_pool (>= 2.2.3)
+                  sidekiq (>= 6.1.0)
+
+            PLATFORMS
+              #{specific_local_platform}
+
+            DEPENDENCIES
+              activesupport
+              sidekiq-pro!
+
+            BUNDLED WITH
+               #{Bundler::VERSION}
+          L
+        end
+
+        it "it keeps the currrent lockfile format and upgrades the requested gem when running bundle update with an argument, and warns", :bundler => "< 3" do
+          bundle "update concurrent-ruby"
+          expect(err).to include("Your lockfile contains a single rubygems source section with multiple remotes, which is insecure.")
+
+          expect(the_bundle).to include_gems("activesupport 6.0.3.4")
+          expect(the_bundle).not_to include_gems("activesupport 6.1.2.1")
+          expect(the_bundle).to include_gems("tzinfo 1.2.9")
+          expect(the_bundle).not_to include_gems("tzinfo 2.0.4")
+          expect(the_bundle).to include_gems("concurrent-ruby 1.1.9")
+          expect(the_bundle).not_to include_gems("concurrent-ruby 1.1.8")
+
+          expect(lockfile).to eq <<~L
+            GEM
+              remote: #{file_uri_for(gem_repo2)}/
+              remote: #{file_uri_for(gem_repo3)}/
+              specs:
+                activesupport (6.0.3.4)
+                  concurrent-ruby (~> 1.0, >= 1.0.2)
+                  i18n (>= 0.7, < 2)
+                  minitest (~> 5.1)
+                  tzinfo (~> 1.1)
+                  zeitwerk (~> 2.2, >= 2.2.2)
+                concurrent-ruby (1.1.9)
+                connection_pool (2.2.3)
+                i18n (1.8.9)
+                  concurrent-ruby (~> 1.0)
+                minitest (5.14.3)
+                rack (2.2.3)
+                redis (4.2.5)
+                sidekiq (6.1.3)
+                  connection_pool (>= 2.2.2)
+                  rack (~> 2.0)
+                  redis (>= 4.2.0)
+                sidekiq-pro (5.2.1)
+                  connection_pool (>= 2.2.3)
+                  sidekiq (>= 6.1.0)
+                thread_safe (0.3.6)
+                tzinfo (1.2.9)
+                  thread_safe (~> 0.1)
+                zeitwerk (2.4.2)
+
+            PLATFORMS
+              #{specific_local_platform}
+
+            DEPENDENCIES
+              activesupport
+              sidekiq-pro!
+
+            BUNDLED WITH
+               #{Bundler::VERSION}
+          L
+        end
+
+        it "fails when running bundle update with an argument", :bundler => "3" do
+          initial_lockfile = lockfile
+
+          bundle "update concurrent-ruby", :raise_on_error => false
+
+          expect(err).to include("Your lockfile contains a single rubygems source section with multiple remotes, which is insecure.")
+
+          expect(lockfile).to eq(initial_lockfile)
         end
       end
     end
@@ -619,6 +759,9 @@ RSpec.describe "bundle install with gems on multiple sources" do
         lockfile <<-L
           GEM
             remote: #{file_uri_for(gem_repo1)}
+            specs:
+
+          GEM
             remote: #{file_uri_for(gem_repo3)}
             specs:
               rack (0.9.1)
@@ -641,6 +784,84 @@ RSpec.describe "bundle install with gems on multiple sources" do
       # Reproduction of https://github.com/rubygems/bundler/issues/3298
       it "does not unlock the installed gem on exec" do
         expect(the_bundle).to include_gems("rack 0.9.1")
+      end
+    end
+
+    context "with a lockfile with aggregated rubygems sources" do
+      let(:aggregate_gem_section_lockfile) do
+        <<~L
+          GEM
+            remote: #{file_uri_for(gem_repo1)}/
+            remote: #{file_uri_for(gem_repo3)}/
+            specs:
+              rack (0.9.1)
+
+          PLATFORMS
+            #{specific_local_platform}
+
+          DEPENDENCIES
+            rack!
+
+          BUNDLED WITH
+             #{Bundler::VERSION}
+        L
+      end
+
+      let(:split_gem_section_lockfile) do
+        <<~L
+          GEM
+            remote: #{file_uri_for(gem_repo1)}/
+            specs:
+
+          GEM
+            remote: #{file_uri_for(gem_repo3)}/
+            specs:
+              rack (0.9.1)
+
+          PLATFORMS
+            #{specific_local_platform}
+
+          DEPENDENCIES
+            rack!
+
+          BUNDLED WITH
+             #{Bundler::VERSION}
+        L
+      end
+
+      before do
+        build_repo gem_repo3 do
+          build_gem "rack", "0.9.1"
+        end
+
+        gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
+          source "#{file_uri_for(gem_repo3)}" do
+            gem 'rack'
+          end
+        G
+
+        lockfile aggregate_gem_section_lockfile
+      end
+
+      it "installs the existing lockfile but prints a warning", :bundler => "< 3" do
+        bundle "config set --local deployment true"
+
+        bundle "install"
+
+        expect(lockfile).to eq(aggregate_gem_section_lockfile)
+        expect(err).to include("Your lockfile contains a single rubygems source section with multiple remotes, which is insecure.")
+        expect(the_bundle).to include_gems("rack 0.9.1", :source => "remote3")
+      end
+
+      it "refuses to install the existing lockfile and prints an error", :bundler => "3" do
+        bundle "config set --local deployment true"
+
+        bundle "install", :raise_on_error =>false
+
+        expect(lockfile).to eq(aggregate_gem_section_lockfile)
+        expect(err).to include("Your lockfile contains a single rubygems source section with multiple remotes, which is insecure.")
+        expect(out).to be_empty
       end
     end
 
@@ -825,11 +1046,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
       G
     end
 
-    it "keeps the old version", :bundler => "< 3" do
-      expect(the_bundle).to include_gems("rack 1.0.0")
-    end
-
-    it "installs the higher version in the new repo", :bundler => "3" do
+    it "installs the higher version in the new repo" do
       expect(the_bundle).to include_gems("rack 1.2")
     end
   end

--- a/bundler/spec/install/gems/flex_spec.rb
+++ b/bundler/spec/install/gems/flex_spec.rb
@@ -245,37 +245,7 @@ RSpec.describe "bundle flex_install" do
   end
 
   describe "when adding a new source" do
-    it "updates the lockfile", :bundler => "< 3" do
-      build_repo2
-      install_gemfile <<-G
-        source "#{file_uri_for(gem_repo1)}"
-        gem "rack"
-      G
-      install_gemfile <<-G
-        source "#{file_uri_for(gem_repo1)}"
-        source "#{file_uri_for(gem_repo2)}"
-        gem "rack"
-      G
-
-      lockfile_should_be <<-L
-      GEM
-        remote: #{file_uri_for(gem_repo1)}/
-        remote: #{file_uri_for(gem_repo2)}/
-        specs:
-          rack (1.0.0)
-
-      PLATFORMS
-        #{lockfile_platforms}
-
-      DEPENDENCIES
-        rack
-
-      BUNDLED WITH
-         #{Bundler::VERSION}
-      L
-    end
-
-    it "updates the lockfile", :bundler => "3" do
+    it "updates the lockfile" do
       build_repo2
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -318,40 +318,7 @@ RSpec.describe "the lockfile format" do
     G
   end
 
-  it "generates a lockfile without credentials for a configured source", :bundler => "< 3" do
-    bundle "config set http://localgemserver.test/ user:pass"
-
-    install_gemfile(<<-G, :artifice => "endpoint_strict_basic_authentication", :quiet => true)
-      source "http://localgemserver.test/" do
-
-      end
-
-      source "http://user:pass@othergemserver.test/" do
-        gem "rack-obama", ">= 1.0"
-      end
-    G
-
-    lockfile_should_be <<-G
-      GEM
-        remote: http://localgemserver.test/
-        remote: http://user:pass@othergemserver.test/
-        specs:
-          rack (1.0.0)
-          rack-obama (1.0)
-            rack
-
-      PLATFORMS
-        #{lockfile_platforms}
-
-      DEPENDENCIES
-        rack-obama (>= 1.0)!
-
-      BUNDLED WITH
-         #{Bundler::VERSION}
-    G
-  end
-
-  it "generates a lockfile without credentials for a configured source", :bundler => "3" do
+  it "generates a lockfile without credentials for a configured source" do
     bundle "config set http://localgemserver.test/ user:pass"
 
     install_gemfile(<<-G, :artifice => "endpoint_strict_basic_authentication", :quiet => true)

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -383,9 +383,7 @@ RSpec.describe "major deprecations" do
         "Your Gemfile contains multiple primary sources. " \
         "Using `source` more than once without a block is a security risk, and " \
         "may result in installing unexpected gems. To resolve this warning, use " \
-        "a block to indicate which gems should come from the secondary source. " \
-        "To upgrade this warning to an error, run `bundle config set --local " \
-        "disable_multisource true`."
+        "a block to indicate which gems should come from the secondary source."
       )
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Our latest release broke some simple cases of using multiple rubygems sources. This PR tries to reintroduce some of the fixes without breaking anything. In particular, this PR introduces separate GEM sources in the lockfile, which avoids "Dependency Confusion" for all usages with an existing lockfile. Making this change in 2.2.10 made an issue surface where already installed gems would confuse bundler and make it use gems from the wrong source (#4383). Actually, a similar issue had been [reported before](https://github.com/rubygems/rubygems/issues/4016) and it was not tied to the change of locking GEM sources separately but to the way sources work in bundler in general. This PR also fixes that issue.

## What is your fix for the problem, implemented in this PR?

Lock GEM sources separately in the lockfile making it predictable and deterministic where each gem is pulled from once you have a lockfile. To avoid the problem of unintentionally unlocking all GEM sources in existing lockfiles and thus upgrading everything (even on `bundle install`, not only on `bundle update`), we keep the current behaviour for existing lockfiles, but show a warning for lockfiles with "merged GEM sections" recommending users to run `bundle update` or  regenerate the lockfile from scratch, so that they can opt-in to lockfile GEM sources separately.

To fix the issue of locally installed gems confusing bundler, we change the existing behaviour of always falling back to locally installed specs, and restrict that fallback to the default source only.
   
Fixes #3643.
Fixes #4016.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
