### PR TITLE
Restore the ability to manually install extension gems

### DIFF
--- a/bundler/lib/bundler/stub_specification.rb
+++ b/bundler/lib/bundler/stub_specification.rb
@@ -26,11 +26,19 @@ module Bundler
 
     # @!group Stub Delegates
 
+    def manually_installed?
+      # This is for manually installed gems which are gems that were fixed in place after a
+      # failed installation. Once the issue was resolved, the user then manually created
+      # the gem specification using the instructions provided by `gem help install`
+      installed_by_version == Gem::Version.new(0)
+    end
+
     # This is defined directly to avoid having to loading the full spec
     def missing_extensions?
       return false if default_gem?
       return false if extensions.empty?
       return false if File.exist? gem_build_complete_path
+      return false if manually_installed?
 
       true
     end

--- a/bundler/spec/bundler/stub_specification_spec.rb
+++ b/bundler/spec/bundler/stub_specification_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Bundler::StubSpecification do
       s.name = "gemname"
       s.version = "1.0.0"
       s.loaded_from = __FILE__
+      s.extensions = "ext/gemname"
     end
 
     described_class.from_stub(gemspec)
@@ -15,6 +16,32 @@ RSpec.describe Bundler::StubSpecification do
     it "returns the same stub if already a Bundler::StubSpecification" do
       stub = described_class.from_stub(with_bundler_stub_spec)
       expect(stub).to be(with_bundler_stub_spec)
+    end
+  end
+
+  describe "#manually_installed?" do
+    it "returns true if installed_by_version is nil or 0" do
+      stub = described_class.from_stub(with_bundler_stub_spec)
+      expect(stub.manually_installed?).to be true
+    end
+
+    it "returns false if installed_by_version is greater than 0" do
+      stub = described_class.from_stub(with_bundler_stub_spec)
+      stub.installed_by_version = Gem::Version.new(1)
+      expect(stub.manually_installed?).to be false
+    end
+  end
+
+  describe "#missing_extensions?" do
+    it "returns false if manually_installed?" do
+      stub = described_class.from_stub(with_bundler_stub_spec)
+      expect(stub.missing_extensions?).to be false
+    end
+
+    it "returns true if not manually_installed?" do
+      stub = described_class.from_stub(with_bundler_stub_spec)
+      stub.installed_by_version = Gem::Version.new(1)
+      expect(stub.missing_extensions?).to be true
     end
   end
 end


### PR DESCRIPTION
Update bundler to include manually_installed gems that have extensions. Manually installed gems are gems that fail to build on installation but are then fixed by hand in-place and registered with RubyGems following the instructions provided by "gem help install". This functionality was unintentionally broken by af7e4b4a.

Fixes #4375.