### PR TITLE
Revert disable_multisource changes

### DIFF
--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -46,17 +46,15 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: rubygems/rubygems
-      - name: Sync tools
+      - name: Test RubyGems
         run: |
           ruby tool/sync_default_gems.rb rubygems
-          ruby tool/sync_default_gems.rb bundler
-        working-directory: ruby/ruby
-      - name: Test RubyGems
-        run: make -j2 -s test-all TESTS="rubygems --no-retry"
+          make -j2 -s test-all TESTS="rubygems --no-retry"
         working-directory: ruby/ruby
         if: matrix.target == 'Rubygems'
       - name: Test Bundler
         run: |
+          ruby tool/sync_default_gems.rb bundler
           git checkout lib/bundler/bundler.gemspec
           git add .
           make test-bundler-parallel

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -111,19 +111,6 @@ module Bundler
         @locked_platforms = []
       end
 
-      @locked_gem_sources = @locked_sources.select {|s| s.is_a?(Source::Rubygems) }
-      @disable_multisource = !Bundler.frozen_bundle? || @locked_gem_sources.none? {|s| s.remotes.size > 1 }
-
-      unless @disable_multisource
-        msg = "Your lockfile contains a single rubygems source section with multiple remotes, which is insecure. " \
-          "You should regenerate your lockfile in a non frozen environment."
-
-        Bundler::SharedHelpers.major_deprecation 2, msg
-
-        @sources.allow_multisource!
-        @locked_gem_sources.each(&:allow_multisource!)
-      end
-
       @unlock[:gems] ||= []
       @unlock[:sources] ||= []
       @unlock[:ruby] ||= if @ruby_version && locked_ruby_version_object
@@ -161,14 +148,6 @@ module Bundler
           end
         GemVersionPromoter.new(locked_specs, @unlock[:gems])
       end
-    end
-
-    def disable_multisource?
-      @disable_multisource
-    end
-
-    def allow_multisource!
-      @disable_multisource = false
     end
 
     def resolve_with_cache!
@@ -290,7 +269,7 @@ module Bundler
           # Run a resolve against the locally available gems
           Bundler.ui.debug("Found changes from the lockfile, re-resolving dependencies because #{change_reason}")
           expanded_dependencies = expand_dependencies(dependencies + metadata_dependencies, @remote)
-          Resolver.resolve(expanded_dependencies, source_requirements, last_resolve, gem_version_promoter, additional_base_requirements_for_resolve, platforms)
+          Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve, gem_version_promoter, additional_base_requirements_for_resolve, platforms)
         end
       end
     end
@@ -558,9 +537,6 @@ module Bundler
     attr_reader :sources
     private :sources
 
-    attr_reader :locked_gem_sources
-    private :locked_gem_sources
-
     def nothing_changed?
       !@source_changes && !@dependency_changes && !@new_platform && !@path_changes && !@local_changes && !@locked_specs_incomplete_for_platform
     end
@@ -685,20 +661,21 @@ module Bundler
     end
 
     def converge_rubygems_sources
-      return false if disable_multisource?
-
-      return false if locked_gem_sources.empty?
-
-      # Get the RubyGems remotes from the Gemfile
-      actual_remotes = sources.rubygems_remotes
-      return false if actual_remotes.empty?
+      return false if Bundler.feature_flag.disable_multisource?
 
       changes = false
 
+      # Get the RubyGems sources from the Gemfile.lock
+      locked_gem_sources = @locked_sources.select {|s| s.is_a?(Source::Rubygems) }
+      # Get the RubyGems remotes from the Gemfile
+      actual_remotes = sources.rubygems_remotes
+
       # If there is a RubyGems source in both
-      locked_gem_sources.each do |locked_gem|
-        # Merge the remotes from the Gemfile into the Gemfile.lock
-        changes |= locked_gem.replace_remotes(actual_remotes, Bundler.settings[:allow_deployment_source_credential_changes])
+      if !locked_gem_sources.empty? && !actual_remotes.empty?
+        locked_gem_sources.each do |locked_gem|
+          # Merge the remotes from the Gemfile into the Gemfile.lock
+          changes |= locked_gem.replace_remotes(actual_remotes, Bundler.settings[:allow_deployment_source_credential_changes])
+        end
       end
 
       changes
@@ -923,18 +900,30 @@ module Bundler
       # Record the specs available in each gem's source, so that those
       # specs will be available later when the resolver knows where to
       # look for that gemspec (or its dependencies)
-      source_requirements = { :default => sources.default_source }.merge(dependency_source_requirements)
+      default = sources.default_source
+      source_requirements = { :default => default }
+      default = nil unless Bundler.feature_flag.disable_multisource?
+      dependencies.each do |dep|
+        next unless source = dep.source || default
+        source_requirements[dep.name] = source
+      end
       metadata_dependencies.each do |dep|
         source_requirements[dep.name] = sources.metadata_source
       end
-      source_requirements[:global] = index unless disable_multisource?
       source_requirements[:default_bundler] = source_requirements["bundler"] || source_requirements[:default]
       source_requirements["bundler"] = sources.metadata_source # needs to come last to override
       source_requirements
     end
 
     def pinned_spec_names(skip = nil)
-      dependency_source_requirements.reject {|_, source| source == skip }.keys
+      pinned_names = []
+      default = Bundler.feature_flag.disable_multisource? && sources.default_source
+      @dependencies.each do |dep|
+        next unless dep_source = dep.source || default
+        next if dep_source == skip
+        pinned_names << dep.name
+      end
+      pinned_names
     end
 
     def requested_groups
@@ -990,19 +979,6 @@ module Bundler
       return false unless source.is_a?(Source::Rubygems)
 
       Bundler.settings[:allow_deployment_source_credential_changes] && source.equivalent_remotes?(sources.rubygems_remotes)
-    end
-
-    def dependency_source_requirements
-      @dependency_source_requirements ||= begin
-        source_requirements = {}
-        default = disable_multisource? && sources.default_source
-        dependencies.each do |dep|
-          dep_source = dep.source || default
-          next unless dep_source
-          source_requirements[dep.name] = dep_source
-        end
-        source_requirements
-      end
     end
   end
 end

--- a/bundler/lib/bundler/feature_flag.rb
+++ b/bundler/lib/bundler/feature_flag.rb
@@ -32,6 +32,7 @@ module Bundler
     settings_flag(:cache_all) { bundler_3_mode? }
     settings_flag(:default_install_uses_path) { bundler_3_mode? }
     settings_flag(:deployment_means_frozen) { bundler_3_mode? }
+    settings_flag(:disable_multisource) { bundler_3_mode? }
     settings_flag(:forget_cli_options) { bundler_3_mode? }
     settings_flag(:global_gem_cache) { bundler_3_mode? }
     settings_flag(:only_update_to_newer_versions) { bundler_3_mode? }

--- a/bundler/lib/bundler/inline.rb
+++ b/bundler/lib/bundler/inline.rb
@@ -50,7 +50,6 @@ def gemfile(install = false, options = {}, &gemfile)
     Bundler::Plugin.gemfile_install(&gemfile) if Bundler.feature_flag.plugins?
     builder = Bundler::Dsl.new
     builder.instance_eval(&gemfile)
-    builder.check_primary_source_safety
 
     Bundler.settings.temporary(:frozen => false) do
       definition = builder.to_definition(nil, true)

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -56,6 +56,9 @@ Executing \fBbundle config unset \-\-local <name> <value>\fR will delete the con
 .P
 Executing bundle with the \fBBUNDLE_IGNORE_CONFIG\fR environment variable set will cause it to ignore all configuration\.
 .
+.P
+Executing \fBbundle config set \-\-local disable_multisource true\fR upgrades the warning about the Gemfile containing multiple primary sources to an error\. Executing \fBbundle config unset disable_multisource\fR downgrades this error to a warning\.
+.
 .SH "REMEMBERING OPTIONS"
 Flags passed to \fBbundle install\fR or the Bundler runtime, such as \fB\-\-path foo\fR or \fB\-\-without production\fR, are remembered between commands and saved to your local application\'s configuration (normally, \fB\./\.bundle/config\fR)\.
 .
@@ -179,6 +182,9 @@ The following is a list of all configuration keys and their purpose\. You can le
 .
 .IP "\(bu" 4
 \fBdisable_local_revision_check\fR (\fBBUNDLE_DISABLE_LOCAL_REVISION_CHECK\fR): Allow Bundler to use a local git override without checking if the revision present in the lockfile is present in the repository\.
+.
+.IP "\(bu" 4
+\fBdisable_multisource\fR (\fBBUNDLE_DISABLE_MULTISOURCE\fR): When set, Gemfiles containing multiple sources will produce errors instead of warnings\. Use \fBbundle config unset disable_multisource\fR to unset\.
 .
 .IP "\(bu" 4
 \fBdisable_shared_gems\fR (\fBBUNDLE_DISABLE_SHARED_GEMS\fR): Stop Bundler from accessing gems installed to RubyGems\' normal location\.

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -47,6 +47,10 @@ configuration only from the local application.
 Executing bundle with the `BUNDLE_IGNORE_CONFIG` environment variable set will
 cause it to ignore all configuration.
 
+Executing `bundle config set --local disable_multisource true` upgrades the warning about
+the Gemfile containing multiple primary sources to an error. Executing `bundle
+config unset disable_multisource` downgrades this error to a warning.
+
 ## REMEMBERING OPTIONS
 
 Flags passed to `bundle install` or the Bundler runtime, such as `--path foo` or
@@ -174,6 +178,10 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
 * `disable_local_revision_check` (`BUNDLE_DISABLE_LOCAL_REVISION_CHECK`):
    Allow Bundler to use a local git override without checking if the revision
    present in the lockfile is present in the repository.
+* `disable_multisource` (`BUNDLE_DISABLE_MULTISOURCE`):
+   When set, Gemfiles containing multiple sources will produce errors
+   instead of warnings.
+   Use `bundle config unset disable_multisource` to unset.
 * `disable_shared_gems` (`BUNDLE_DISABLE_SHARED_GEMS`):
    Stop Bundler from accessing gems installed to RubyGems' normal location.
 * `disable_version_check` (`BUNDLE_DISABLE_VERSION_CHECK`):

--- a/bundler/lib/bundler/plugin.rb
+++ b/bundler/lib/bundler/plugin.rb
@@ -105,7 +105,6 @@ module Bundler
         else
           builder.eval_gemfile(gemfile)
         end
-        builder.check_primary_source_safety
         definition = builder.to_definition(nil, true)
 
         return if definition.dependencies.empty?

--- a/bundler/lib/bundler/plugin/installer.rb
+++ b/bundler/lib/bundler/plugin/installer.rb
@@ -16,13 +16,15 @@ module Bundler
 
         version = options[:version] || [">= 0"]
 
-        if options[:git]
-          install_git(names, version, options)
-        elsif options[:local_git]
-          install_local_git(names, version, options)
-        else
-          sources = options[:source] || Bundler.rubygems.sources
-          install_rubygems(names, version, sources)
+        Bundler.settings.temporary(:disable_multisource => false) do
+          if options[:git]
+            install_git(names, version, options)
+          elsif options[:local_git]
+            install_local_git(names, version, options)
+          else
+            sources = options[:source] || Bundler.rubygems.sources
+            install_rubygems(names, version, sources)
+          end
         end
       end
 
@@ -82,7 +84,6 @@ module Bundler
         deps = names.map {|name| Dependency.new name, version }
 
         definition = Definition.new(nil, deps, source_list, true)
-        definition.allow_multisource!
         install_definition(definition)
       end
 

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -20,6 +20,7 @@ module Bundler
       disable_exec_load
       disable_local_branch_check
       disable_local_revision_check
+      disable_multisource
       disable_shared_gems
       disable_version_check
       force_ruby_platform

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -21,7 +21,6 @@ module Bundler
         @allow_remote = false
         @allow_cached = false
         @caches = [cache_path, *Bundler.rubygems.gem_cache]
-        @disable_multisource = true
 
         Array(options["remotes"] || []).reverse_each {|r| add_remote(r) }
       end
@@ -50,16 +49,8 @@ module Bundler
         o.is_a?(Rubygems) && (o.credless_remotes - credless_remotes).empty?
       end
 
-      def disable_multisource?
-        @disable_multisource
-      end
-
-      def allow_multisource!
-        @disable_multisource = false
-      end
-
       def can_lock?(spec)
-        return super if disable_multisource?
+        return super if Bundler.feature_flag.disable_multisource?
         spec.source.is_a?(Rubygems)
       end
 

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -5,41 +5,24 @@ module Bundler
     attr_reader :path_sources,
       :git_sources,
       :plugin_sources,
-      :global_path_source,
-      :metadata_source,
-      :disable_multisource
-
-    def global_rubygems_source
-      @global_rubygems_source ||= rubygems_aggregate_class.new
-    end
+      :global_rubygems_source,
+      :metadata_source
 
     def initialize
       @path_sources           = []
       @git_sources            = []
       @plugin_sources         = []
       @global_rubygems_source = nil
-      @global_path_source     = nil
+      @rubygems_aggregate     = rubygems_aggregate_class.new
       @rubygems_sources       = []
       @metadata_source        = Source::Metadata.new
-      @disable_multisource    = true
-    end
-
-    def disable_multisource?
-      @disable_multisource
-    end
-
-    def allow_multisource!
-      rubygems_sources.map(&:allow_multisource!)
-      @disable_multisource = false
     end
 
     def add_path_source(options = {})
       if options["gemspec"]
         add_source_to_list Source::Gemspec.new(options), path_sources
       else
-        path_source = add_source_to_list Source::Path.new(options), path_sources
-        @global_path_source ||= path_source if options["global"]
-        path_source
+        add_source_to_list Source::Path.new(options), path_sources
       end
     end
 
@@ -58,20 +41,24 @@ module Bundler
     end
 
     def global_rubygems_source=(uri)
-      @global_rubygems_source ||= rubygems_aggregate_class.new("remotes" => uri)
+      if Bundler.feature_flag.disable_multisource?
+        @global_rubygems_source ||= rubygems_aggregate_class.new("remotes" => uri)
+      end
+      add_rubygems_remote(uri)
     end
 
     def add_rubygems_remote(uri)
-      global_rubygems_source.add_remote(uri)
-      global_rubygems_source
+      return if Bundler.feature_flag.disable_multisource?
+      @rubygems_aggregate.add_remote(uri)
+      @rubygems_aggregate
     end
 
     def default_source
-      global_path_source || global_rubygems_source
+      global_rubygems_source || @rubygems_aggregate
     end
 
     def rubygems_sources
-      @rubygems_sources + [global_rubygems_source]
+      @rubygems_sources + [default_source]
     end
 
     def rubygems_remotes
@@ -88,7 +75,7 @@ module Bundler
 
     def lock_sources
       lock_sources = (path_sources + git_sources + plugin_sources).sort_by(&:to_s)
-      if disable_multisource?
+      if Bundler.feature_flag.disable_multisource?
         lock_sources + rubygems_sources.sort_by(&:to_s)
       else
         lock_sources << combine_rubygems_sources
@@ -105,9 +92,9 @@ module Bundler
         end
       end
 
-      replacement_rubygems = !disable_multisource? &&
+      replacement_rubygems = !Bundler.feature_flag.disable_multisource? &&
         replacement_sources.detect {|s| s.is_a?(Source::Rubygems) }
-      @global_rubygems_source = replacement_rubygems if replacement_rubygems
+      @rubygems_aggregate = replacement_rubygems if replacement_rubygems
 
       return true if !equal_sources?(lock_sources, replacement_sources) && !equivalent_sources?(lock_sources, replacement_sources)
       return true if replacement_rubygems && rubygems_remotes.sort_by(&:to_s) != replacement_rubygems.remotes.sort_by(&:to_s)
@@ -121,6 +108,10 @@ module Bundler
 
     def remote!
       all_sources.each(&:remote!)
+    end
+
+    def rubygems_primary_remotes
+      @rubygems_aggregate.remotes
     end
 
     private
@@ -145,9 +136,7 @@ module Bundler
     end
 
     def combine_rubygems_sources
-      aggregate_source = Source::Rubygems.new("remotes" => rubygems_remotes)
-      aggregate_source.allow_multisource! unless disable_multisource?
-      aggregate_source
+      Source::Rubygems.new("remotes" => rubygems_remotes)
     end
 
     def warn_on_git_protocol(source)

--- a/bundler/spec/bundler/dsl_spec.rb
+++ b/bundler/spec/bundler/dsl_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Bundler::Dsl do
       expect { subject.git_source(:example) }.to raise_error(Bundler::InvalidOption)
     end
 
-    context "default hosts", :bundler => "< 3" do
+    context "default hosts", :bundler => "2" do
       it "converts :github to URI using https" do
         subject.gem("sparks", :github => "indirect/sparks")
         github_uri = "https://github.com/indirect/sparks.git"
@@ -195,6 +195,19 @@ RSpec.describe Bundler::Dsl do
     #   gem 'spree_api'
     #   gem 'spree_backend'
     # end
+    describe "#github", :bundler => "< 3" do
+      it "from github" do
+        spree_gems = %w[spree_core spree_api spree_backend]
+        subject.github "spree" do
+          spree_gems.each {|spree_gem| subject.send :gem, spree_gem }
+        end
+
+        subject.dependencies.each do |d|
+          expect(d.source.uri).to eq("https://github.com/spree/spree.git")
+        end
+      end
+    end
+
     describe "#github" do
       it "from github" do
         spree_gems = %w[spree_core spree_api spree_backend]

--- a/bundler/spec/bundler/plugin_spec.rb
+++ b/bundler/spec/bundler/plugin_spec.rb
@@ -110,7 +110,6 @@ RSpec.describe Bundler::Plugin do
     before do
       allow(Plugin::DSL).to receive(:new) { builder }
       allow(builder).to receive(:eval_gemfile).with(gemfile)
-      allow(builder).to receive(:check_primary_source_safety)
       allow(builder).to receive(:to_definition) { definition }
       allow(builder).to receive(:inferred_plugins) { [] }
     end

--- a/bundler/spec/bundler/source_list_spec.rb
+++ b/bundler/spec/bundler/source_list_spec.rb
@@ -372,7 +372,26 @@ RSpec.describe Bundler::SourceList do
       source_list.add_git_source("uri" => "git://first-git.org/path.git")
     end
 
-    it "returns all sources, without combining rubygems sources" do
+    it "combines the rubygems sources into a single instance, removing duplicate remotes from the end", :bundler => "< 3" do
+      expect(source_list.lock_sources).to eq [
+        Bundler::Source::Git.new("uri" => "git://first-git.org/path.git"),
+        Bundler::Source::Git.new("uri" => "git://second-git.org/path.git"),
+        Bundler::Source::Git.new("uri" => "git://third-git.org/path.git"),
+        ASourcePlugin.new("uri" => "https://second-plugin.org/random"),
+        ASourcePlugin.new("uri" => "https://third-bar.org/foo"),
+        Bundler::Source::Path.new("path" => "/first/path/to/gem"),
+        Bundler::Source::Path.new("path" => "/second/path/to/gem"),
+        Bundler::Source::Path.new("path" => "/third/path/to/gem"),
+        Bundler::Source::Rubygems.new("remotes" => [
+          "https://duplicate-rubygems.org",
+          "https://first-rubygems.org",
+          "https://second-rubygems.org",
+          "https://third-rubygems.org",
+        ]),
+      ]
+    end
+
+    it "returns all sources, without combining rubygems sources", :bundler => "3" do
       expect(source_list.lock_sources).to eq [
         Bundler::Source::Git.new("uri" => "git://first-git.org/path.git"),
         Bundler::Source::Git.new("uri" => "git://second-git.org/path.git"),

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -762,8 +762,7 @@ RSpec.describe "bundle exec" do
       let(:exit_code) { Bundler::GemNotFound.new.status_code }
       let(:expected) { "" }
       let(:expected_err) { <<-EOS.strip }
-\e[31mCould not find gem 'rack (= 2)' in locally installed gems.
-The source contains the following versions of 'rack': 0.9.1, 1.0.0\e[0m
+\e[31mCould not find gem 'rack (= 2)' in any of the gem sources listed in your Gemfile.\e[0m
 \e[33mRun `bundle install` to install missing gems.\e[0m
       EOS
 

--- a/bundler/spec/commands/post_bundle_message_spec.rb
+++ b/bundler/spec/commands/post_bundle_message_spec.rb
@@ -113,7 +113,16 @@ RSpec.describe "post bundle message" do
         bundle "config set force_ruby_platform true"
       end
 
-      it "should report a helpful error message" do
+      it "should report a helpful error message", :bundler => "< 3" do
+        install_gemfile <<-G, :raise_on_error => false
+          source "#{file_uri_for(gem_repo1)}"
+          gem "rack"
+          gem "not-a-gem", :group => :development
+        G
+        expect(err).to include("Could not find gem 'not-a-gem' in any of the gem sources listed in your Gemfile.")
+      end
+
+      it "should report a helpful error message", :bundler => "3" do
         install_gemfile <<-G, :raise_on_error => false
           source "#{file_uri_for(gem_repo1)}"
           gem "rack"

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -422,13 +422,14 @@ RSpec.describe "bundle install from an existing gemspec" do
           end
         end
 
-        gemfile <<-G
-          source "#{file_uri_for(gem_repo2)}"
-          gemspec
-        G
-
-        simulate_platform("ruby") { bundle "install" }
-        simulate_platform("jruby") { bundle "install" }
+        %w[ruby jruby].each do |platform|
+          simulate_platform(platform) do
+            install_gemfile <<-G
+              source "#{file_uri_for(gem_repo2)}"
+              gemspec
+            G
+          end
+        end
       end
 
       context "on ruby" do

--- a/bundler/spec/install/gems/flex_spec.rb
+++ b/bundler/spec/install/gems/flex_spec.rb
@@ -245,7 +245,37 @@ RSpec.describe "bundle flex_install" do
   end
 
   describe "when adding a new source" do
-    it "updates the lockfile" do
+    it "updates the lockfile", :bundler => "< 3" do
+      build_repo2
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rack"
+      G
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        source "#{file_uri_for(gem_repo2)}"
+        gem "rack"
+      G
+
+      lockfile_should_be <<-L
+      GEM
+        remote: #{file_uri_for(gem_repo1)}/
+        remote: #{file_uri_for(gem_repo2)}/
+        specs:
+          rack (1.0.0)
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        rack
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+      L
+    end
+
+    it "updates the lockfile", :bundler => "3" do
       build_repo2
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -318,7 +318,40 @@ RSpec.describe "the lockfile format" do
     G
   end
 
-  it "generates a lockfile without credentials for a configured source" do
+  it "generates a lockfile without credentials for a configured source", :bundler => "< 3" do
+    bundle "config set http://localgemserver.test/ user:pass"
+
+    install_gemfile(<<-G, :artifice => "endpoint_strict_basic_authentication", :quiet => true)
+      source "http://localgemserver.test/" do
+
+      end
+
+      source "http://user:pass@othergemserver.test/" do
+        gem "rack-obama", ">= 1.0"
+      end
+    G
+
+    lockfile_should_be <<-G
+      GEM
+        remote: http://localgemserver.test/
+        remote: http://user:pass@othergemserver.test/
+        specs:
+          rack (1.0.0)
+          rack-obama (1.0)
+            rack
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        rack-obama (>= 1.0)!
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    G
+  end
+
+  it "generates a lockfile without credentials for a configured source", :bundler => "3" do
     bundle "config set http://localgemserver.test/ user:pass"
 
     install_gemfile(<<-G, :artifice => "endpoint_strict_basic_authentication", :quiet => true)

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "major deprecations" do
         bundle "exec ruby -e #{source.dump}"
       end
 
-      it "is deprecated in favor of .unbundled_env", :bundler => "< 3" do
+      it "is deprecated in favor of .unbundled_env", :bundler => "2" do
         expect(deprecations).to include \
           "`Bundler.clean_env` has been deprecated in favor of `Bundler.unbundled_env`. " \
           "If you instead want the environment before bundler was originally loaded, use `Bundler.original_env` " \
@@ -33,7 +33,7 @@ RSpec.describe "major deprecations" do
         bundle "exec ruby -e #{source.dump}"
       end
 
-      it "is deprecated in favor of .unbundled_env", :bundler => "< 3" do
+      it "is deprecated in favor of .unbundled_env", :bundler => "2" do
         expect(deprecations).to include(
           "`Bundler.with_clean_env` has been deprecated in favor of `Bundler.with_unbundled_env`. " \
           "If you instead want the environment before bundler was originally loaded, use `Bundler.with_original_env` " \
@@ -50,7 +50,7 @@ RSpec.describe "major deprecations" do
         bundle "exec ruby -e #{source.dump}"
       end
 
-      it "is deprecated in favor of .unbundled_system", :bundler => "< 3" do
+      it "is deprecated in favor of .unbundled_system", :bundler => "2" do
         expect(deprecations).to include(
           "`Bundler.clean_system` has been deprecated in favor of `Bundler.unbundled_system`. " \
           "If you instead want to run the command in the environment before bundler was originally loaded, use `Bundler.original_system` " \
@@ -67,7 +67,7 @@ RSpec.describe "major deprecations" do
         bundle "exec ruby -e #{source.dump}"
       end
 
-      it "is deprecated in favor of .unbundled_exec", :bundler => "< 3" do
+      it "is deprecated in favor of .unbundled_exec", :bundler => "2" do
         expect(deprecations).to include(
           "`Bundler.clean_exec` has been deprecated in favor of `Bundler.unbundled_exec`. " \
           "If you instead want to exec to a command in the environment before bundler was originally loaded, use `Bundler.original_exec` " \
@@ -84,7 +84,7 @@ RSpec.describe "major deprecations" do
         bundle "exec ruby -e #{source.dump}"
       end
 
-      it "is deprecated in favor of .load", :bundler => "< 3" do
+      it "is deprecated in favor of .load", :bundler => "2" do
         expect(deprecations).to include "Bundler.environment has been removed in favor of Bundler.load (called at -e:1)"
       end
 
@@ -109,7 +109,7 @@ RSpec.describe "major deprecations" do
       bundle "check --path vendor/bundle", :raise_on_error => false
     end
 
-    it "should print a deprecation warning", :bundler => "< 3" do
+    it "should print a deprecation warning", :bundler => "2" do
       expect(deprecations).to include(
         "The `--path` flag is deprecated because it relies on being " \
         "remembered across bundler invocations, which bundler will no " \
@@ -118,7 +118,7 @@ RSpec.describe "major deprecations" do
       )
     end
 
-    pending "fails with a helpful error", :bundler => "3"
+    pending "should fail with a helpful error", :bundler => "3"
   end
 
   context "bundle check --path=" do
@@ -131,7 +131,7 @@ RSpec.describe "major deprecations" do
       bundle "check --path=vendor/bundle", :raise_on_error => false
     end
 
-    it "should print a deprecation warning", :bundler => "< 3" do
+    it "should print a deprecation warning", :bundler => "2" do
       expect(deprecations).to include(
         "The `--path` flag is deprecated because it relies on being " \
         "remembered across bundler invocations, which bundler will no " \
@@ -140,7 +140,7 @@ RSpec.describe "major deprecations" do
       )
     end
 
-    pending "fails with a helpful error", :bundler => "3"
+    pending "should fail with a helpful error", :bundler => "3"
   end
 
   context "bundle cache --all" do
@@ -153,7 +153,7 @@ RSpec.describe "major deprecations" do
       bundle "cache --all", :raise_on_error => false
     end
 
-    it "should print a deprecation warning", :bundler => "< 3" do
+    it "should print a deprecation warning", :bundler => "2" do
       expect(deprecations).to include(
         "The `--all` flag is deprecated because it relies on being " \
         "remembered across bundler invocations, which bundler will no " \
@@ -162,7 +162,7 @@ RSpec.describe "major deprecations" do
       )
     end
 
-    pending "fails with a helpful error", :bundler => "3"
+    pending "should fail with a helpful error", :bundler => "3"
   end
 
   describe "bundle config" do
@@ -292,7 +292,7 @@ RSpec.describe "major deprecations" do
       G
     end
 
-    it "should output a deprecation warning", :bundler => "< 3" do
+    it "should output a deprecation warning", :bundler => "2" do
       expect(deprecations).to include("The --binstubs option will be removed in favor of `bundle binstubs --all`")
     end
 
@@ -356,7 +356,7 @@ RSpec.describe "major deprecations" do
           bundle "install #{flag_name} #{value}"
         end
 
-        it "should print a deprecation warning", :bundler => "< 3" do
+        it "should print a deprecation warning", :bundler => "2" do
           expect(deprecations).to include(
             "The `#{flag_name}` flag is deprecated because it relies on " \
             "being remembered across bundler invocations, which bundler " \
@@ -365,7 +365,7 @@ RSpec.describe "major deprecations" do
           )
         end
 
-        pending "fails with a helpful error", :bundler => "3"
+        pending "should fail with a helpful error", :bundler => "3"
       end
     end
   end
@@ -378,58 +378,18 @@ RSpec.describe "major deprecations" do
       G
     end
 
-    it "shows a deprecation", :bundler => "< 3" do
+    it "shows a deprecation", :bundler => "2" do
       expect(deprecations).to include(
         "Your Gemfile contains multiple primary sources. " \
         "Using `source` more than once without a block is a security risk, and " \
         "may result in installing unexpected gems. To resolve this warning, use " \
-        "a block to indicate which gems should come from the secondary source."
+        "a block to indicate which gems should come from the secondary source. " \
+        "To upgrade this warning to an error, run `bundle config set --local " \
+        "disable_multisource true`."
       )
     end
 
-    pending "fails with a helpful error", :bundler => "3"
-  end
-
-  context "bundle install with a lockfile with a single rubygems section with multiple remotes in frozen mode" do
-    before do
-      build_repo gem_repo3 do
-        build_gem "rack", "0.9.1"
-      end
-
-      gemfile <<-G
-        source "#{file_uri_for(gem_repo1)}"
-        source "#{file_uri_for(gem_repo3)}" do
-          gem 'rack'
-        end
-      G
-
-      lockfile <<~L
-        GEM
-          remote: #{file_uri_for(gem_repo1)}/
-          remote: #{file_uri_for(gem_repo3)}/
-          specs:
-            rack (0.9.1)
-
-        PLATFORMS
-          ruby
-
-        DEPENDENCIES
-          rack!
-
-        BUNDLED WITH
-           #{Bundler::VERSION}
-      L
-
-      bundle "config set --local deployment true"
-    end
-
-    it "shows a deprecation", :bundler => "< 3" do
-      bundle "install"
-
-      expect(deprecations).to include("Your lockfile contains a single rubygems source section with multiple remotes, which is insecure. You should regenerate your lockfile in a non frozen environment.")
-    end
-
-    pending "fails with a helpful error", :bundler => "3"
+    pending "should fail with a helpful error", :bundler => "3"
   end
 
   context "when Bundler.setup is run in a ruby script" do
@@ -462,14 +422,14 @@ RSpec.describe "major deprecations" do
       RUBY
     end
 
-    it "should print a capistrano deprecation warning", :bundler => "< 3" do
+    it "should print a capistrano deprecation warning", :bundler => "2" do
       expect(deprecations).to include("Bundler no longer integrates " \
                              "with Capistrano, but Capistrano provides " \
                              "its own integration with Bundler via the " \
                              "capistrano-bundler gem. Use it instead.")
     end
 
-    pending "fails with a helpful error", :bundler => "3"
+    pending "should fail with a helpful error", :bundler => "3"
   end
 
   describe Bundler::Dsl do
@@ -479,7 +439,7 @@ RSpec.describe "major deprecations" do
     end
 
     context "with github gems" do
-      it "does not warn about removal", :bundler => "< 3" do
+      it "does not warn about removal", :bundler => "2" do
         expect(Bundler.ui).not_to receive(:warn)
         subject.gem("sparks", :github => "indirect/sparks")
         github_uri = "https://github.com/indirect/sparks.git"
@@ -501,7 +461,7 @@ The :github git source is deprecated, and will be removed in the future. Change 
     end
 
     context "with bitbucket gems" do
-      it "does not warn about removal", :bundler => "< 3" do
+      it "does not warn about removal", :bundler => "2" do
         expect(Bundler.ui).not_to receive(:warn)
         subject.gem("not-really-a-gem", :bitbucket => "mcorp/flatlab-rails")
       end
@@ -523,7 +483,7 @@ The :bitbucket git source is deprecated, and will be removed in the future. Add 
     end
 
     context "with gist gems" do
-      it "does not warn about removal", :bundler => "< 3" do
+      it "does not warn about removal", :bundler => "2" do
         expect(Bundler.ui).not_to receive(:warn)
         subject.gem("not-really-a-gem", :gist => "1234")
       end
@@ -554,7 +514,7 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
         bundle :show
       end
 
-      it "prints a deprecation warning recommending `bundle list`", :bundler => "< 3" do
+      it "prints a deprecation warning recommending `bundle list`", :bundler => "2" do
         expect(deprecations).to include("use `bundle list` instead of `bundle show`")
       end
 
@@ -566,7 +526,7 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
         bundle "show --outdated"
       end
 
-      it "prints a deprecation warning informing about its removal", :bundler => "< 3" do
+      it "prints a deprecation warning informing about its removal", :bundler => "2" do
         expect(deprecations).to include("the `--outdated` flag to `bundle show` was undocumented and will be removed without replacement")
       end
 
@@ -578,7 +538,7 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
         bundle "show --verbose"
       end
 
-      it "prints a deprecation warning informing about its removal", :bundler => "< 3" do
+      it "prints a deprecation warning informing about its removal", :bundler => "2" do
         expect(deprecations).to include("the `--verbose` flag to `bundle show` was undocumented and will be removed without replacement")
       end
 
@@ -590,7 +550,7 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
         bundle "show rack"
       end
 
-      it "prints a deprecation warning recommending `bundle info`", :bundler => "< 3" do
+      it "prints a deprecation warning recommending `bundle info`", :bundler => "2" do
         expect(deprecations).to include("use `bundle info rack` instead of `bundle show rack`")
       end
 
@@ -602,7 +562,7 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
         bundle "show --paths"
       end
 
-      it "prints a deprecation warning recommending `bundle list`", :bundler => "< 3" do
+      it "prints a deprecation warning recommending `bundle list`", :bundler => "2" do
         expect(deprecations).to include("use `bundle list` instead of `bundle show --paths`")
       end
 
@@ -614,7 +574,7 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
         bundle "show rack --paths"
       end
 
-      it "prints deprecation warning recommending `bundle info`", :bundler => "< 3" do
+      it "prints deprecation warning recommending `bundle info`", :bundler => "2" do
         expect(deprecations).to include("use `bundle info rack --path` instead of `bundle show rack --paths`")
       end
 
@@ -627,7 +587,7 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
       bundle "console", :raise_on_error => false
     end
 
-    it "prints a deprecation warning", :bundler => "< 3" do
+    it "prints a deprecation warning", :bundler => "2" do
       expect(deprecations).to include \
         "bundle console will be replaced by `bin/console` generated by `bundle gem <name>`"
     end
@@ -643,7 +603,7 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
       bundle "viz"
     end
 
-    it "prints a deprecation warning", :bundler => "< 3" do
+    it "prints a deprecation warning", :bundler => "2" do
       expect(deprecations).to include "The `viz` command has been moved to the `bundle-viz` gem, see https://github.com/bundler/bundler-viz"
     end
 

--- a/bundler/spec/support/indexes.rb
+++ b/bundler/spec/support/indexes.rb
@@ -30,7 +30,7 @@ module Spec
       args[1] ||= Bundler::GemVersionPromoter.new # gem_version_promoter
       args[2] ||= [] # additional_base_requirements
       args[3] ||= @platforms # platforms
-      Bundler::Resolver.resolve(deps, source_requirements, *args)
+      Bundler::Resolver.resolve(deps, @index, source_requirements, *args)
     end
 
     def should_resolve_as(specs)

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1958,9 +1958,15 @@ class TestGem < Gem::TestCase
       io.write 'gem "a"'
     end
 
+    platform = Bundler::GemHelpers.generic_local_platform
+    if platform == Gem::Platform::RUBY
+      platform = ''
+    else
+      platform = " #{platform}"
+    end
+
     expected = <<-EXPECTED
-Could not find gem 'a' in locally installed gems.
-The source does not contain any versions of 'a'
+Could not find gem 'a#{platform}' in any of the gem sources listed in your Gemfile.
 You may need to `gem install -g` to install missing gems
 
     EXPECTED


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We tried to push a fix to source priority in bundler 2.2.10, but we broke a lot of things.

## What is your fix for the problem, implemented in this PR?

I'm working on a fix for the raised issues, but I want do to it with less rush, so for now I'm reverting the PR to restore the previously working behaviour.

Closes #4380.
Closes #4382.
Closes #4383.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
