### PR TITLE
Fix `include_gems` negated matcher to not rely on subprocess output

### DIFF
--- a/bundler/spec/install/bundler_spec.rb
+++ b/bundler/spec/install/bundler_spec.rb
@@ -21,12 +21,12 @@ RSpec.describe "bundle install" do
       expect(the_bundle).to include_gems "bundler #{Bundler::VERSION}"
     end
 
-    it "are not added if not already present" do
+    it "are forced to the current bundler version even if not already present" do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
-      expect(the_bundle).not_to include_gems "bundler #{Bundler::VERSION}"
+      expect(the_bundle).to include_gems "bundler #{Bundler::VERSION}"
     end
 
     it "causes a conflict if explicitly requesting a different version of bundler" do

--- a/bundler/spec/install/deploy_spec.rb
+++ b/bundler/spec/install/deploy_spec.rb
@@ -401,7 +401,7 @@ RSpec.describe "install in deployment or frozen mode" do
         gem "rack-obama"
       G
 
-      expect(the_bundle).not_to include_gems "rack 1.0.0"
+      run "require 'rack'", :raise_on_error => false
       expect(err).to include strip_whitespace(<<-E).strip
 The dependencies in your gemfile changed
 

--- a/bundler/spec/support/matchers.rb
+++ b/bundler/spec/support/matchers.rb
@@ -145,23 +145,34 @@ module Spec
 
       match_when_negated do
         opts = names.last.is_a?(Hash) ? names.pop : {}
-        groups = Array(opts[:groups])
+        groups = Array(opts.delete(:groups)).map(&:inspect).join(", ")
         opts[:raise_on_error] = false
         @errors = names.map do |name|
           name, version = name.split(/\s+/, 2)
-          run <<-R, *(groups + [opts])
+          ruby <<-R, opts
+            begin
+              require '#{lib_dir}/bundler'
+              Bundler.setup(#{groups})
+            rescue Bundler::GemNotFound, Bundler::GitError
+              exit 0
+            end
+
             begin
               require '#{name}'
-              puts #{Spec::Builders.constantize(name)}
+              name_constant = '#{Spec::Builders.constantize(name)}'
+              if #{version.nil?} || name_constant == '#{version}'
+                exit 64
+              else
+                exit 0
+              end
             rescue LoadError, NameError
-              puts "WIN"
+              exit 0
             end
           R
-          next if out == "WIN"
+          next if exitstatus == 0
+          next "command to check version of #{name} installed failed" unless exitstatus == 64
           next "expected #{name} to not be installed, but it was" if version.nil?
-          if Gem::Version.new(out) == Gem::Version.new(version)
-            next "expected #{name} (#{version}) not to be installed, but it was"
-          end
+          next "expected #{name} (#{version}) not to be installed, but it was"
         end.compact
 
         @errors.empty?

--- a/bundler/spec/support/matchers.rb
+++ b/bundler/spec/support/matchers.rb
@@ -145,7 +145,7 @@ module Spec
 
       match_when_negated do
         opts = names.last.is_a?(Hash) ? names.pop : {}
-        groups = Array(opts[:groups]) || []
+        groups = Array(opts[:groups])
         opts[:raise_on_error] = false
         @errors = names.map do |name|
           name, version = name.split(/\s+/, 2)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I've been bothered by this for a long time. This matcher uses the output from a bundler subprocess. This is very brittle because when you add debugging output to bundler, this usually breaks with a weird crash.

## What is your fix for the problem, implemented in this PR?

Rely on the process exit code instead.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)