### PR TITLE
Improve `include_gems` matcher

### DIFF
--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -22,7 +22,7 @@ jobs:
           - { name: "2.6", value: 2.6.6 }
           - { name: "2.7", value: 2.7.2 }
           - { name: "3.0", value: 3.0.0 }
-          - { name: jruby-9.2, value: jruby-9.2.14.0 }
+          - { name: jruby-9.2, value: jruby-9.2.16.0 }
           - { name: truffleruby-20.3, value: truffleruby-20.3.0 }
         openssl:
           - { name: "openssl", value: true }
@@ -79,7 +79,7 @@ jobs:
       matrix:
         ruby:
           - { name: "3.0", value: 3.0.0 }
-          - { name: jruby-9.2, value: jruby-9.2.14.0 }
+          - { name: jruby-9.2, value: jruby-9.2.16.0 }
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby

--- a/.github/workflows/jruby-bundler.yml
+++ b/.github/workflows/jruby-bundler.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: jruby-9.2.14.0
+          ruby-version: jruby-9.2.16.0
           bundler: none
       - name: Prepare dependencies
         run: |

--- a/.github/workflows/ubuntu-rubygems.yml
+++ b/.github/workflows/ubuntu-rubygems.yml
@@ -22,7 +22,7 @@ jobs:
           - { name: "2.6", value: 2.6.6 }
           - { name: "2.7", value: 2.7.2 }
           - { name: "3.0", value: 3.0.0 }
-          - { name: jruby-9.2, value: jruby-9.2.14.0 }
+          - { name: jruby-9.2, value: jruby-9.2.16.0 }
           - { name: truffleruby-20.3, value: truffleruby-20.3.0 }
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/windows-bundler.yml
+++ b/.github/workflows/windows-bundler.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - { name: jruby-9.2, value: jruby-9.2.14.0 }
+          - { name: jruby-9.2, value: jruby-9.2.16.0 }
           - { name: ruby-2.4, value: 2.4.10 }
           - { name: ruby-2.5, value: 2.5.8 }
           - { name: ruby-2.6, value: 2.6.6 }

--- a/bundler/spec/realworld/fixtures/warbler/Gemfile.lock
+++ b/bundler/spec/realworld/fixtures/warbler/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    jruby-jars (9.2.14.0)
+    jruby-jars (9.2.16.0)
     jruby-rack (1.1.21)
     rake (13.0.1)
     rubyzip (1.3.0)

--- a/bundler/spec/realworld/fixtures/warbler/Gemfile.lock
+++ b/bundler/spec/realworld/fixtures/warbler/Gemfile.lock
@@ -19,6 +19,7 @@ GEM
 PLATFORMS
   java
   ruby
+  universal-java-11
 
 DEPENDENCIES
   demo!
@@ -26,4 +27,4 @@ DEPENDENCIES
   warbler (~> 2.0)
 
 BUNDLED WITH
-   2.2.0.rc.2
+   2.3.0.dev

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -130,7 +130,7 @@ module Spec
 
     def ruby(ruby, options = {})
       ruby_cmd = build_ruby_cmd
-      escaped_ruby = RUBY_PLATFORM == "java" ? ruby.shellescape.dump : ruby.shellescape
+      escaped_ruby = ruby.shellescape
       sys_exec(%(#{ruby_cmd} -w -e #{escaped_ruby}), options)
     end
 

--- a/bundler/spec/support/matchers.rb
+++ b/bundler/spec/support/matchers.rb
@@ -114,30 +114,49 @@ module Spec
       match do
         opts = names.last.is_a?(Hash) ? names.pop : {}
         source = opts.delete(:source)
-        groups = Array(opts[:groups])
+        groups = Array(opts.delete(:groups)).map(&:inspect).join(", ")
         opts[:raise_on_error] = false
-        groups << opts
-        @errors = names.map do |name|
-          name, version, platform = name.split(/\s+/)
+        @errors = names.map do |full_name|
+          name, version, platform = full_name.split(/\s+/)
           require_path = name == "bundler" ? "#{lib_dir}/bundler" : name.tr("-", "/")
           version_const = name == "bundler" ? "Bundler::VERSION" : Spec::Builders.constantize(name)
-          code = []
-          code << "require '#{require_path}.rb'"
-          code << "puts #{version_const}"
-          run code.join("; "), *groups
-          actual_version, actual_platform = out.strip.split(/\s+/, 2)
-          unless Gem::Version.new(actual_version) == Gem::Version.new(version)
+          source_const = "#{Spec::Builders.constantize(name)}_SOURCE"
+          ruby <<~R, opts
+            require '#{lib_dir}/bundler'
+            Bundler.setup(#{groups})
+
+            require '#{require_path}.rb'
+            actual_version, actual_platform = #{version_const}.split(/\s+/, 2)
+            unless Gem::Version.new(actual_version) == Gem::Version.new('#{version}')
+              puts actual_version
+              exit 64
+            end
+            unless actual_platform.to_s == '#{platform}'
+              puts actual_platform
+              exit 65
+            end
+            require '#{require_path}/source'
+            exit 0 if #{source.nil?}
+            actual_source = #{source_const}
+            unless actual_source == '#{source}'
+              puts actual_source
+              exit 66
+            end
+          R
+          next if exitstatus == 0
+          if exitstatus == 64
+            actual_version = out.split("\n").last
             next "#{name} was expected to be at version #{version} but was #{actual_version}"
           end
-          unless actual_platform == platform
+          if exitstatus == 65
+            actual_platform = out.split("\n").last
             next "#{name} was expected to be of platform #{platform} but was #{actual_platform}"
           end
-          next unless source
-          source_const = "#{Spec::Builders.constantize(name)}_SOURCE"
-          run "require '#{require_path}/source'; puts #{source_const}", *groups
-          unless out.strip == source
-            next "Expected #{name} (#{version}) to be installed from `#{source}`, was actually from `#{out}`"
+          if exitstatus == 66
+            actual_source = out.split("\n").last
+            next "Expected #{name} (#{version}) to be installed from `#{source}`, was actually from `#{actual_source}`"
           end
+          next "Command to check forgem inclusion of gem #{full_name} failed"
         end.compact
 
         @errors.empty?


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The `include_gems` matcher relies on the output of a bundler subshell to work. This can get broken with weird errors if you introduce debugging output while developing bundler.

## What is your fix for the problem, implemented in this PR?

Rely on process status instead, and also do all checks in a single subprocess instead of many for efficiency.

This is a follow up to #4388, but for the `include_gems` "positive" matcher.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
