### PR TITLE
Fix Metadata loaded_from

### DIFF
--- a/bundler/lib/bundler/source/metadata.rb
+++ b/bundler/lib/bundler/source/metadata.rb
@@ -22,7 +22,7 @@ module Bundler
             s.summary  = "The best way to manage your application's dependencies"
             s.executables = %w[bundle]
             # can't point to the actual gemspec or else the require paths will be wrong
-            s.loaded_from = File.expand_path("..", __FILE__)
+            s.loaded_from = File.expand_path("../../../../", __FILE__)
           end
 
           if local_spec = Bundler.rubygems.find_name("bundler").find {|s| s.version.to_s == VERSION }


### PR DESCRIPTION
Ok, so I don't think I fully grasp the entire problem, but I dug down and this fixes my problem. I have no idea wether the fix is correct, I even quite doubt so, but I figured a diff would be a better discussion starter

### Problem

I'm having a double bundler load issue on one of my apps, symptoms are similar to https://github.com/rubygems/rubygems/issues/3284 (`ArgumentError: Trying to register Bundler::GemfileError for status code 4 but Bundler::GemfileError is already registered`)

This happens if I use `bundle exec rake environment`, but can be worked around by removing the `bundle exec`

### Versions and paths

<details>
<summary>`gem environment`</summary>
```
RubyGems Environment:
  - RUBYGEMS VERSION: 3.1.4
  - RUBY VERSION: 2.7.2 (2020-10-01 patchlevel 137) [x86_64-linux]
  - INSTALLATION DIRECTORY: /usr/local/lib/ruby/gems/2.7.0
  - USER INSTALLATION DIRECTORY: /app/.gem/ruby/2.7.0
  - RUBY EXECUTABLE: /usr/local/bin/ruby
  - GIT EXECUTABLE: /usr/bin/git
  - EXECUTABLE DIRECTORY: /usr/local/bin
  - SPEC CACHE DIRECTORY: /app/.gem/specs
  - SYSTEM CONFIGURATION DIRECTORY: /usr/local/etc
  - RUBYGEMS PLATFORMS:
    - ruby
    - x86_64-linux
  - GEM PATHS:
     - /usr/local/lib/ruby/gems/2.7.0
     - /app/.gem/ruby/2.7.0
  - GEM CONFIGURATION:
     - :update_sources => true
     - :verbose => true
     - :backtrace => false
     - :bulk_threshold => 1000
  - REMOTE SOURCES:
     - https://rubygems.org/
  - SHELL PATH:
     - /usr/local/sbin
     - /usr/local/bin
     - /usr/sbin
     - /usr/bin
     - /sbin
     - /bin
     - /usr/games
     - /usr/local/games
     - /snap/bin
```
</details>


<details>
<summary>`bundle exec env`</summary>

```
SHELL=/bin/bash
HOSTNAME=1eec6d0f64b6
PWD=/app
LOGNAME=appuser
REVISION=fbecbedef7d0b20189118f91fbc6a96401673cf7
HOME=/app
LS_COLORS=rs=0:di=01;34:ln=01;36:mh=00:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=40;31;01:mi=00:su=37;41:sg=30;43:ca=30;41:tw=30;42:ow=34;42:st=37;44:ex=01;32:*.tar=01;31:*.tgz=01;31:*.arc=01;31:*.arj=01;31:*.taz=01;31:*.lha=01;31:*.lz4=01;31:*.lzh=01;31:*.lzma=01;31:*.tlz=01;31:*.txz=01;31:*.tzo=01;31:*.t7z=01;31:*.zip=01;31:*.z=01;31:*.dz=01;31:*.gz=01;31:*.lrz=01;31:*.lz=01;31:*.lzo=01;31:*.xz=01;31:*.zst=01;31:*.tzst=01;31:*.bz2=01;31:*.bz=01;31:*.tbz=01;31:*.tbz2=01;31:*.tz=01;31:*.deb=01;31:*.rpm=01;31:*.jar=01;31:*.war=01;31:*.ear=01;31:*.sar=01;31:*.rar=01;31:*.alz=01;31:*.ace=01;31:*.zoo=01;31:*.cpio=01;31:*.7z=01;31:*.rz=01;31:*.cab=01;31:*.wim=01;31:*.swm=01;31:*.dwm=01;31:*.esd=01;31:*.jpg=01;35:*.jpeg=01;35:*.mjpg=01;35:*.mjpeg=01;35:*.gif=01;35:*.bmp=01;35:*.pbm=01;35:*.pgm=01;35:*.ppm=01;35:*.tga=01;35:*.xbm=01;35:*.xpm=01;35:*.tif=01;35:*.tiff=01;35:*.png=01;35:*.svg=01;35:*.svgz=01;35:*.mng=01;35:*.pcx=01;35:*.mov=01;35:*.mpg=01;35:*.mpeg=01;35:*.m2v=01;35:*.mkv=01;35:*.webm=01;35:*.ogm=01;35:*.mp4=01;35:*.m4v=01;35:*.mp4v=01;35:*.vob=01;35:*.qt=01;35:*.nuv=01;35:*.wmv=01;35:*.asf=01;35:*.rm=01;35:*.rmvb=01;35:*.flc=01;35:*.avi=01;35:*.fli=01;35:*.flv=01;35:*.gl=01;35:*.dl=01;35:*.xcf=01;35:*.xwd=01;35:*.yuv=01;35:*.cgm=01;35:*.emf=01;35:*.ogv=01;35:*.ogx=01;35:*.aac=00;36:*.au=00;36:*.flac=00;36:*.m4a=00;36:*.mid=00;36:*.midi=00;36:*.mka=00;36:*.mp3=00;36:*.mpc=00;36:*.ogg=00;36:*.ra=00;36:*.wav=00;36:*.oga=00;36:*.opus=00;36:*.spx=00;36:*.xspf=00;36:
LESSCLOSE=/usr/bin/lesspipe %s %s
TERM=xterm
LESSOPEN=| /usr/bin/lesspipe %s
USER=appuser
SHLVL=2
PATH=/artifacts/bundle/ruby/2.7.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin
MAIL=/var/mail/appuser
DEBIAN_FRONTEND=noninteractive
_=/usr/local/bin/bundle
BUNDLER_ORIG_BUNDLE_BIN_PATH=BUNDLER_ENVIRONMENT_PRESERVER_INTENTIONALLY_NIL
BUNDLER_ORIG_BUNDLE_GEMFILE=BUNDLER_ENVIRONMENT_PRESERVER_INTENTIONALLY_NIL
BUNDLER_ORIG_BUNDLER_VERSION=BUNDLER_ENVIRONMENT_PRESERVER_INTENTIONALLY_NIL
BUNDLER_ORIG_GEM_HOME=BUNDLER_ENVIRONMENT_PRESERVER_INTENTIONALLY_NIL
BUNDLER_ORIG_GEM_PATH=BUNDLER_ENVIRONMENT_PRESERVER_INTENTIONALLY_NIL
BUNDLER_ORIG_MANPATH=BUNDLER_ENVIRONMENT_PRESERVER_INTENTIONALLY_NIL
BUNDLER_ORIG_PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin
BUNDLER_ORIG_RB_USER_INSTALL=BUNDLER_ENVIRONMENT_PRESERVER_INTENTIONALLY_NIL
BUNDLER_ORIG_RUBYLIB=BUNDLER_ENVIRONMENT_PRESERVER_INTENTIONALLY_NIL
BUNDLER_ORIG_RUBYOPT=BUNDLER_ENVIRONMENT_PRESERVER_INTENTIONALLY_NIL
BUNDLE_BIN_PATH=/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/exe/bundle
BUNDLE_GEMFILE=/app/Gemfile
BUNDLER_VERSION=2.2.11
RUBYOPT=-r/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/lib/bundler/setup
RUBYLIB=/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/lib
```
</details>


- OS: ubuntu-20.04 docker image
- Ruby `2.7.2` (in `/usr/local/`)
- Rubygems: `3.1.4` (bundled with 
- Bundler `2.2.11` installed with `gem install --no-document --user-install bundler -v 2.2.11` at `/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/`
- "System" bundler `2.1.4` at `/usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/`

### Failure

```
$ bundle exec rake environment
/usr/local/lib/ruby/2.7.0/bundler/version.rb:4: warning: already initialized constant Bundler::VERSION
/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/lib/bundler/version.rb:4: warning: previous definition of VERSION was here
/usr/local/lib/ruby/2.7.0/bundler/constants.rb:4: warning: already initialized constant Bundler::WINDOWS
/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/lib/bundler/constants.rb:4: warning: previous definition of WINDOWS was here
/usr/local/lib/ruby/2.7.0/bundler/constants.rb:5: warning: already initialized constant Bundler::FREEBSD
/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/lib/bundler/constants.rb:5: warning: previous definition of FREEBSD was here
/usr/local/lib/ruby/2.7.0/bundler/constants.rb:6: warning: already initialized constant Bundler::NULL
/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/lib/bundler/constants.rb:6: warning: previous definition of NULL was here
/usr/local/lib/ruby/2.7.0/bundler/rubygems_integration.rb:8: warning: already initialized constant Bundler::RubygemsIntegration::EXT_LOCK
/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/lib/bundler/rubygems_integration.rb:12: warning: previous definition of EXT_LOCK was here
/usr/local/lib/ruby/2.7.0/bundler/current_ruby.rb:12: warning: already initialized constant Bundler::CurrentRuby::KNOWN_MINOR_VERSIONS
/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/lib/bundler/current_ruby.rb:12: warning: previous definition of KNOWN_MINOR_VERSIONS was here
/usr/local/lib/ruby/2.7.0/bundler/current_ruby.rb:25: warning: already initialized constant Bundler::CurrentRuby::KNOWN_MAJOR_VERSIONS
/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/lib/bundler/current_ruby.rb:25: warning: previous definition of KNOWN_MAJOR_VERSIONS was here
/usr/local/lib/ruby/2.7.0/bundler/current_ruby.rb:27: warning: already initialized constant Bundler::CurrentRuby::KNOWN_PLATFORMS
/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/lib/bundler/current_ruby.rb:27: warning: previous definition of KNOWN_PLATFORMS was here
/usr/local/lib/ruby/2.7.0/bundler/vendor/fileutils/lib/fileutils.rb:105: warning: already initialized constant Bundler::FileUtils::VERSION
/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/lib/bundler/vendor/fileutils/lib/fileutils.rb:105: warning: previous definition of VERSION was here
/usr/local/lib/ruby/2.7.0/bundler/vendor/fileutils/lib/fileutils.rb:1284: warning: already initialized constant Bundler::FileUtils::Entry_::S_IF_DOOR
/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/lib/bundler/vendor/fileutils/lib/fileutils.rb:1284: warning: previous definition of S_IF_DOOR was here
/usr/local/lib/ruby/2.7.0/bundler/vendor/fileutils/lib/fileutils.rb:1568: warning: already initialized constant Bundler::FileUtils::Entry_::DIRECTORY_TERM
/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/lib/bundler/vendor/fileutils/lib/fileutils.rb:1568: warning: previous definition of DIRECTORY_TERM was here
/usr/local/lib/ruby/2.7.0/bundler/vendor/fileutils/lib/fileutils.rb:1626: warning: already initialized constant Bundler::FileUtils::OPT_TABLE
/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/lib/bundler/vendor/fileutils/lib/fileutils.rb:1626: warning: previous definition of OPT_TABLE was here
/usr/local/lib/ruby/2.7.0/bundler/vendor/fileutils/lib/fileutils.rb:1685: warning: already initialized constant Bundler::FileUtils::LOW_METHODS
/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/lib/bundler/vendor/fileutils/lib/fileutils.rb:1685: warning: previous definition of LOW_METHODS was here
/usr/local/lib/ruby/2.7.0/bundler/vendor/fileutils/lib/fileutils.rb:1692: warning: already initialized constant Bundler::FileUtils::METHODS
/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/lib/bundler/vendor/fileutils/lib/fileutils.rb:1692: warning: previous definition of METHODS was here
rake aborted!
ArgumentError: Trying to register Bundler::GemfileError for status code 4 but Bundler::GemfileError is already registered
/app/config/boot.rb:4:in `require'
/app/config/boot.rb:4:in `<top (required)>'
/app/config/application.rb:2:in `require_relative'
/app/config/application.rb:2:in `<top (required)>'
/app/Rakefile:6:in `require_relative'
/app/Rakefile:6:in `<top (required)>'
/artifacts/bundle/ruby/2.7.0/gems/rake-13.0.3/exe/rake:27:in `<top (required)>'
/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/lib/bundler/cli/exec.rb:63:in `load'
/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/lib/bundler/cli/exec.rb:63:in `kernel_load'
/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/lib/bundler/cli/exec.rb:28:in `run'
/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/lib/bundler/cli.rb:494:in `exec'
/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/lib/bundler/cli.rb:30:in `dispatch'
/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/lib/bundler/cli.rb:24:in `start'
/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/exe/bundle:49:in `block in <top (required)>'
/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/lib/bundler/friendly_errors.rb:130:in `with_friendly_errors'
/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/exe/bundle:37:in `<top (required)>'
/app/bin/bundle:5:in `load'
/app/bin/bundle:5:in `<main>'
(See full trace by running task with --trace)
```

### Observations

By putting a breakpoint in `lib/bundler/runtime.rb`, I noticed the following:

```ruby
>> specs.select { |s| s.name == 'bundler' }.first.send(:loaded_from)
=> "/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/lib/bundler/source"
>> specs.select { |s| s.name == 'bundler' }.first.send(:load_paths)
=> ["/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/lib/gems/bundler-2.2.11/lib"]
```

Which seems wrong to me and ultimately cause the `$LOAD_PATH` to contain:

```ruby
"/app/.gem/ruby/2.7.0/gems/bundler-2.2.11/lib/gems/bundler-2.2.11/lib"
```

So when `require "bundler/setup"` happens, the user installed gem is missed, and it fallbacks to loading the one bundled with ruby, which cause the double loading issue etc.