### PR TITLE
Unskip some now green Windows specs

### DIFF
--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -647,8 +647,6 @@ RSpec.describe "bundle install with git sources" do
     end
 
     it "installs dependencies from git even if a newer gem is available elsewhere" do
-      skip "override is not winning" if Gem.win_platform?
-
       system_gems "rack-1.0.0"
 
       build_lib "rack", "1.0", :path => lib_path("nested/bar") do |s|

--- a/bundler/spec/install/gemfile/path_spec.rb
+++ b/bundler/spec/install/gemfile/path_spec.rb
@@ -136,8 +136,6 @@ RSpec.describe "bundle install with explicit source paths" do
   end
 
   it "installs dependencies from the path even if a newer gem is available elsewhere" do
-    skip "override is not winning" if Gem.win_platform?
-
     system_gems "rack-1.0.0"
 
     build_lib "rack", "1.0", :path => lib_path("nested/bar") do |s|
@@ -701,8 +699,6 @@ RSpec.describe "bundle install with explicit source paths" do
 
   describe "when there are both a gemspec and remote gems" do
     it "doesn't query rubygems for local gemspec name" do
-      skip "platform issues" if Gem.win_platform?
-
       build_lib "private_lib", "2.2", :path => lib_path("private_lib")
       gemfile = <<-G
         source "http://localgemserver.test"

--- a/bundler/spec/install/gems/resolving_spec.rb
+++ b/bundler/spec/install/gems/resolving_spec.rb
@@ -160,10 +160,6 @@ RSpec.describe "bundle install with install-time dependencies" do
 
   describe "when a required ruby version" do
     context "allows only an older version" do
-      before do
-        skip "gem not found" if Gem.win_platform?
-      end
-
       it "installs the older version" do
         build_repo2 do
           build_gem "rack", "1.2" do |s|

--- a/bundler/spec/install/gemspecs_spec.rb
+++ b/bundler/spec/install/gemspecs_spec.rb
@@ -28,8 +28,6 @@ RSpec.describe "bundle install" do
   end
 
   it "should use gemspecs in the system cache when available" do
-    skip "weird incompatible marshal file format error" if Gem.win_platform?
-
     gemfile <<-G
       source "http://localtestserver.gem"
       gem 'rack'

--- a/bundler/spec/runtime/inline_spec.rb
+++ b/bundler/spec/runtime/inline_spec.rb
@@ -46,8 +46,6 @@ RSpec.describe "bundler/inline#gemfile" do
   end
 
   it "requires the gems" do
-    skip "gems not found" if Gem.win_platform?
-
     script <<-RUBY
       gemfile do
         path "#{lib_path}" do
@@ -94,8 +92,6 @@ RSpec.describe "bundler/inline#gemfile" do
   end
 
   it "lets me use my own ui object" do
-    skip "prints just one CONFIRMED" if Gem.win_platform?
-
     script <<-RUBY, :artifice => "endpoint"
       require '#{lib_dir}/bundler'
       class MyBundlerUI < Bundler::UI::Silent


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Make a quick test locally and these specs seem green now?

## What is your fix for the problem, implemented in this PR?

Unskip them.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
