### PR TITLE
Fix race conditions when reading & writing gemspecs concurrently

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -800,11 +800,11 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   ##
   # Safely write a file in binary mode on all platforms.
   def self.write_binary(path, data)
+    File.open(path, File::RDWR | File::CREAT | File::BINARY | File::LOCK_EX) do |io|
+      io.write data
+    end
+  rescue *WRITE_BINARY_ERRORS
     File.open(path, 'wb') do |io|
-      begin
-        io.flock(File::LOCK_EX)
-      rescue *WRITE_BINARY_ERRORS
-      end
       io.write data
     end
   rescue Errno::ENOLCK # NFS

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -293,8 +293,6 @@ class Gem::Installer
   def install
     pre_install_checks
 
-    FileUtils.rm_f File.join gem_home, 'specifications', spec.spec_name
-
     run_pre_install_hooks
 
     # Set loaded_from to ensure extension_dir is correct

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -446,13 +446,9 @@ class Gem::Installer
   # specifications directory.
 
   def write_spec
-    File.open spec_file, 'w' do |file|
-      spec.installed_by_version = Gem.rubygems_version
+    spec.installed_by_version = Gem.rubygems_version
 
-      file.puts spec.to_ruby_for_cache
-
-      file.fsync rescue nil # for filesystems without fsync(2)
-    end
+    Gem.write_binary(spec_file, spec.to_ruby_for_cache)
   end
 
   ##
@@ -460,9 +456,7 @@ class Gem::Installer
   # specifications/default directory.
 
   def write_default_spec
-    File.open(default_spec_file, "w") do |file|
-      file.puts spec.to_ruby
-    end
+    Gem.write_binary(default_spec_file, spec.to_ruby)
   end
 
   ##

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1237,7 +1237,11 @@ gem 'other', version
   end
 
   def test_install_post_build_false
-    installer = setup_base_installer
+    @spec = util_spec 'a'
+
+    util_build_gem @spec
+
+    installer = util_installer @spec, @gemhome
 
     Gem.post_build do
       false
@@ -1279,7 +1283,11 @@ gem 'other', version
   end
 
   def test_install_pre_install_false
-    installer = setup_base_installer
+    @spec = util_spec 'a'
+
+    util_build_gem @spec
+
+    installer = util_installer @spec, @gemhome
 
     Gem.pre_install do
       false

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -948,7 +948,6 @@ gem 'other', version
 
     Gem.pre_install do
       assert_path_not_exist cache_file, 'cache file must not exist yet'
-      assert_path_not_exist spec_file,  'spec file must not exist yet'
       true
     end
 
@@ -956,13 +955,11 @@ gem 'other', version
       assert_path_exist gemdir, 'gem install dir must exist'
       assert_path_exist rakefile, 'gem executable must exist'
       assert_path_not_exist stub_exe, 'gem executable must not exist'
-      assert_path_not_exist spec_file, 'spec file must not exist yet'
       true
     end
 
     Gem.post_install do
       assert_path_exist cache_file, 'cache file must exist'
-      assert_path_exist spec_file,  'spec file must exist'
     end
 
     @newspec = nil

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -288,6 +288,33 @@ gem 'other', version
                  "(SyntaxError)", e.message
   end
 
+  def test_ensure_no_race_conditions_between_installing_and_loading_gemspecs
+    a, a_gem = util_gem 'a', 2
+
+    Gem::Installer.at(a_gem).install
+
+    t1 = Thread.new do
+      5.times do
+        Gem::Installer.at(a_gem).install
+        sleep 0.1
+      end
+    end
+
+    t2 = Thread.new do
+      _, err = capture_output do
+        20.times do
+          Gem::Specification.load(a.spec_file)
+          Gem::Specification.send(:clear_load_cache)
+        end
+      end
+
+      assert_empty err
+    end
+
+    t1.join
+    t2.join
+  end
+
   def test_ensure_loadable_spec_security_policy
     pend 'openssl is missing' unless Gem::HAVE_OPENSSL
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

While working on #4381, I added a spec that failed sporadically because of several warnings being printed about read gemspecs being `nil`.

Since I had seen this issue many times in the past, having a spec reproducing seemed like a good opportunity to look at it.

## What is your fix for the problem, implemented in this PR?

The problem was that gemspec writes were not protected by file locks, and even when protected file locks were added after the file was created, not during creation, so race conditions still appeared.

Another issue with concurrent gemspec reads and installations, is that rubygems installer would remove the gemspec if present at the beginning on the installation, and then install the new gemspec in the end. This was introduced at https://github.com/rubygems/rubygems/commit/af604436d8141c34cb2e1e645b9b0d47bfd55a55 to fix some [hangs when running two `gem install` commands in a row](https://github.com/rubygems/rubygems/issues/750). But that issue was never reproducible, and it still isn't, so I'm reverting it so that I can get my regression test green.
## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
