### PR TITLE
Fix sporadic warnings about `nil` gemspec on install/update and make those faster

### DIFF
--- a/bundler/lib/bundler/installer.rb
+++ b/bundler/lib/bundler/installer.rb
@@ -89,6 +89,8 @@ module Bundler
         end
         install(options)
 
+        Gem::Specification.reset # invalidate gem specification cache so that installed gems are immediately available
+
         lock unless Bundler.frozen_bundle?
         Standalone.new(options[:standalone], @definition).generate if options[:standalone]
       end

--- a/bundler/lib/bundler/rubygems_gem_installer.rb
+++ b/bundler/lib/bundler/rubygems_gem_installer.rb
@@ -8,6 +8,53 @@ module Bundler
       # Bundler needs to install gems regardless of binstub overwriting
     end
 
+    def install
+      pre_install_checks
+
+      run_pre_install_hooks
+
+      spec.loaded_from = spec_file
+
+      # Completely remove any previous gem files
+      FileUtils.rm_rf gem_dir
+      FileUtils.rm_rf spec.extension_dir
+
+      FileUtils.mkdir_p gem_dir, :mode => 0o755
+
+      extract_files
+
+      build_extensions
+      write_build_info_file
+      run_post_build_hooks
+
+      generate_bin
+      generate_plugins
+
+      write_spec
+      write_cache_file
+
+      say spec.post_install_message unless spec.post_install_message.nil?
+
+      run_post_install_hooks
+
+      spec
+    end
+
+    def generate_plugins
+      return unless Gem::Installer.instance_methods(false).include?(:generate_plugins)
+
+      latest = Gem::Specification.stubs_for(spec.name).first
+      return if latest && latest.version > spec.version
+
+      ensure_writable_dir @plugins_dir
+
+      if spec.plugins.empty?
+        remove_plugins_for(spec, @plugins_dir)
+      else
+        regenerate_plugins_for(spec, @plugins_dir)
+      end
+    end
+
     def pre_install_checks
       super && validate_bundler_checksum(options[:bundler_expected_checksum])
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The problem is that sometimes running `bundle update` ends up printing some annoying warnings about `nil` gemspecs like

```
[/home/runner/work/rubygems/rubygems/bundler/tmp/2/gems/system/specifications/zeitwerk-2.4.2.gemspec] isn't a Gem::Specification (NilClass instead).
```

## What is your fix for the problem, implemented in this PR?

The fix is to completely override rubygems installer to get rid of the places where it accessed and modified shared gem specification cache. In particular

* Stop calling `Gem::Specification.reset` after each gem installation and instead move it to the main thread, after installation of all gems has finished.
* Stop using rubygems implementation of `Gem::Specification.latest_spec_for(name)` in favour of `Gem::Specification.stubs_for(name).first`, which does the same thing but without traversing and potentially loading all specifications.
* Remove all the other code that's not actually necessary for bundler.

Technically only the first point would be necessary to fix the race condition but I figured since I needed to overwrite the method I would only include what's needed, and make it faster.

As a result, `bundle install` is noticiably faster now.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
