### PR TITLE
Fix deployment install with duplicate path gems added to Gemfile

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -601,7 +601,7 @@ module Bundler
       deps_for_source = @dependencies.select {|s| s.source == source }
       locked_deps_for_source = @locked_deps.values.select {|dep| dep.source == locked_source }
 
-      deps_for_source.sort != locked_deps_for_source.sort
+      deps_for_source.uniq.sort != locked_deps_for_source.sort
     end
 
     def specs_for_source_changed?(source)

--- a/bundler/spec/install/deploy_spec.rb
+++ b/bundler/spec/install/deploy_spec.rb
@@ -85,6 +85,18 @@ RSpec.describe "install in deployment or frozen mode" do
     bundle :install
   end
 
+  it "works when path gems are specified twice" do
+    build_lib "foo", :path => lib_path("nested/foo")
+    gemfile <<-G
+      gem "foo", :path => "#{lib_path("nested/foo")}"
+      gem "foo", :path => "#{lib_path("nested/foo")}"
+    G
+
+    bundle :install
+    bundle "config set --local deployment true"
+    bundle :install
+  end
+
   it "works when there are credentials in the source URL" do
     install_gemfile(<<-G, :artifice => "endpoint_strict_basic_authentication", :quiet => true)
       source "http://user:pass@localgemserver.test/"


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

When adding the same path gem twice to a Gemfile, bundle install will 
succeed with deployment set to "false" but fail with deployment set to 
"true". The error message given is "The gemspecs for path gems changed". 
To fix, duplicate dependencies must be removed before checking against 
the locked dependencies.

## What is your fix for the problem, implemented in this PR?

The implementation of `Bundler::Definition#dependencies_for_source_changed?` prior to #4297 relied on using `Set.new(a) != Set.new(b)` to compare the source dependencies and lockfile dependencies.
This restores the duplicate pruning behavior of `Set` without relying on `Set` itself.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
