### PR TITLE
Add standard option alongside rubocop to `bundle gem`

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -212,6 +212,7 @@ bundler/lib/bundler/templates/newgem/rspec.tt
 bundler/lib/bundler/templates/newgem/rubocop.yml.tt
 bundler/lib/bundler/templates/newgem/spec/newgem_spec.rb.tt
 bundler/lib/bundler/templates/newgem/spec/spec_helper.rb.tt
+bundler/lib/bundler/templates/newgem/standard.yml.tt
 bundler/lib/bundler/templates/newgem/test/minitest/test_helper.rb.tt
 bundler/lib/bundler/templates/newgem/test/minitest/test_newgem.rb.tt
 bundler/lib/bundler/templates/newgem/test/test-unit/newgem_test.rb.tt

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -591,6 +591,8 @@ module Bundler
                          :desc => "Generate a test directory for your library, either rspec, minitest or test-unit. Set a default with `bundle config set --global gem.test (rspec|minitest|test-unit)`."
     method_option :ci, :type => :string, :lazy_default => Bundler.settings["gem.ci"] || "",
                        :desc => "Generate CI configuration, either GitHub Actions, Travis CI, GitLab CI or CircleCI. Set a default with `bundle config set --global gem.ci (github|travis|gitlab|circle)`"
+    method_option :linter, :type => :string, :lazy_default => Bundler.settings["gem.linter"] || "",
+                           :desc => "Add a linter and code formatter, either RuboCop or Standard. Set a default with `bundle config set --global gem.linter (rubocop|standard)`"
 
     def gem(name)
     end

--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -162,7 +162,7 @@ module Bundler
         Bundler.ui.info "RuboCop enabled in config"
         templates.merge!("rubocop.yml.tt" => ".rubocop.yml")
       when "standard"
-        config[:linter_version] = "0.2.5" if Gem.ruby_version < Gem::Version.new("2.4.a")
+        config[:linter_version] = Gem.ruby_version < Gem::Version.new("2.4.a") ? "0.2.5" : "1.0"
         Bundler.ui.info "Standard enabled in config"
         templates.merge!("standard.yml.tt" => ".standard.yml")
       end

--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -155,15 +155,16 @@ module Bundler
         templates.merge!("CHANGELOG.md.tt" => "CHANGELOG.md")
       end
 
-      if ask_and_set(:rubocop, "Do you want to add rubocop as a dependency for gems you generate?",
-        "RuboCop is a static code analyzer that has out-of-the-box rules for many " \
-        "of the guidelines in the community style guide. " \
-        "For more information, see the RuboCop docs (https://docs.rubocop.org/en/stable/) " \
-        "and the Ruby Style Guides (https://github.com/rubocop-hq/ruby-style-guide).")
-        config[:rubocop] = true
-        config[:rubocop_version] = Gem.ruby_version < Gem::Version.new("2.4.a") ? "0.81.0" : "1.7"
+      config[:linter] = ask_and_set_linter
+      case config[:linter]
+      when "rubocop"
+        config[:linter_version] = Gem.ruby_version < Gem::Version.new("2.4.a") ? "0.81.0" : "1.7"
         Bundler.ui.info "RuboCop enabled in config"
         templates.merge!("rubocop.yml.tt" => ".rubocop.yml")
+      when "standard"
+        config[:linter_version] = "0.2.5" if Gem.ruby_version < Gem::Version.new("2.4.a")
+        Bundler.ui.info "Standard enabled in config"
+        templates.merge!("standard.yml.tt" => ".standard.yml")
       end
 
       templates.merge!("exe/newgem.tt" => "exe/#{name}") if config[:exe]
@@ -306,6 +307,58 @@ module Bundler
       end
 
       ci_template
+    end
+
+    def ask_and_set_linter
+      linter_template = options[:linter] || Bundler.settings["gem.linter"]
+      linter_template = deprecated_rubocop_option if linter_template.nil?
+
+      if linter_template.to_s.empty?
+        Bundler.ui.confirm "Do you want to add a code linter and formatter to your gem? " \
+          "Supported Linters:\n" \
+          "* RuboCop:       https://rubocop.org\n" \
+          "* Standard:      https://github.com/testdouble/standard\n" \
+          "\n"
+        Bundler.ui.info hint_text("linter")
+
+        result = Bundler.ui.ask "Enter a linter. rubocop/standard/(none):"
+        if result =~ /rubocop|standard/
+          linter_template = result
+        else
+          linter_template = false
+        end
+      end
+
+      if Bundler.settings["gem.linter"].nil?
+        Bundler.settings.set_global("gem.linter", linter_template)
+      end
+
+      # Once gem.linter safely set, unset the deprecated gem.rubocop
+      unless Bundler.settings["gem.rubocop"].nil?
+        Bundler.settings.set_global("gem.rubocop", nil)
+      end
+
+      if options[:linter] == Bundler.settings["gem.linter"]
+        Bundler.ui.info "#{options[:linter]} is already configured, ignoring --linter flag."
+      end
+
+      linter_template
+    end
+
+    def deprecated_rubocop_option
+      if !options[:rubocop].nil?
+        if options[:rubocop]
+          Bundler::SharedHelpers.major_deprecation 2, "--rubocop is deprecated, use --linter=rubocop"
+          "rubocop"
+        else
+          Bundler::SharedHelpers.major_deprecation 2, "--no-rubocop is deprecated, use --linter"
+          false
+        end
+      elsif !Bundler.settings["gem.rubocop"].nil?
+        Bundler::SharedHelpers.major_deprecation 2,
+          "config gem.rubocop is deprecated; we've updated your config to use gem.linter instead"
+        Bundler.settings["gem.rubocop"] ? "rubocop" : false
+      end
     end
 
     def bundler_dependency_version

--- a/bundler/lib/bundler/man/bundle-gem.1
+++ b/bundler/lib/bundler/man/bundle-gem.1
@@ -90,6 +90,19 @@ When Bundler is configured to not generate CI files, an interactive prompt will 
 When Bundler is unconfigured, an interactive prompt will be displayed and the answer will be saved in Bundler\'s global config for future \fBbundle gem\fR use\.
 .
 .TP
+\fB\-\-linter\fR, \fB\-\-linter=rubocop\fR, \fB\-\-linter=standard\fR
+Specify the linter and code formatter that Bundler should add to the project\'s development dependencies\. Acceptable values are \fBrubocop\fR and \fBstandard\fR\. A configuration file will be generated in the project directory\. Given no option is specified:
+.
+.IP
+When Bundler is configured to add a linter, this defaults to Bundler\'s global config setting \fBgem\.linter\fR\.
+.
+.IP
+When Bundler is configured not to add a linter, an interactive prompt will be displayed and the answer will be used for the current rubygem project\.
+.
+.IP
+When Bundler is unconfigured, an interactive prompt will be displayed and the answer will be saved in Bundler\'s global config for future \fBbundle gem\fR use\.
+.
+.TP
 \fB\-e\fR, \fB\-\-edit[=EDITOR]\fR
 Open the resulting GEM_NAME\.gemspec in EDITOR, or the default editor if not specified\. The default is \fB$BUNDLER_EDITOR\fR, \fB$VISUAL\fR, or \fB$EDITOR\fR\.
 .

--- a/bundler/lib/bundler/man/bundle-gem.1.ronn
+++ b/bundler/lib/bundler/man/bundle-gem.1.ronn
@@ -92,6 +92,22 @@ configuration file using the following names:
   the answer will be saved in Bundler's global config for future `bundle gem`
   use.
 
+* `--linter`, `--linter=rubocop`, `--linter=standard`:
+  Specify the linter and code formatter that Bundler should add to the
+  project's development dependencies. Acceptable values are `rubocop` and
+  `standard`. A configuration file will be generated in the project directory.
+  Given no option is specified:
+
+  When Bundler is configured to add a linter, this defaults to Bundler's
+  global config setting `gem.linter`.
+
+  When Bundler is configured not to add a linter, an interactive prompt
+  will be displayed and the answer will be used for the current rubygem project.
+
+  When Bundler is unconfigured, an interactive prompt will be displayed and
+  the answer will be saved in Bundler's global config for future `bundle gem`
+  use.
+
 * `-e`, `--edit[=EDITOR]`:
   Open the resulting GEM_NAME.gemspec in EDITOR, or the default editor if not
   specified. The default is `$BUNDLER_EDITOR`, `$VISUAL`, or `$EDITOR`.

--- a/bundler/lib/bundler/templates/newgem/Gemfile.tt
+++ b/bundler/lib/bundler/templates/newgem/Gemfile.tt
@@ -14,7 +14,10 @@ gem "rake-compiler"
 
 gem "<%= config[:test] %>", "~> <%= config[:test_framework_version] %>"
 <%- end -%>
-<%- if config[:rubocop] -%>
+<%- if config[:linter] == "rubocop" -%>
 
-gem "rubocop", "~> <%= config[:rubocop_version] %>"
+gem "rubocop", "~> <%= config[:linter_version] %>"
+<%- elsif config[:linter] == "standard" -%>
+
+gem "standard"<%= ", \"~> #{config[:linter_version]}\"" if config[:linter_version] %>
 <%- end -%>

--- a/bundler/lib/bundler/templates/newgem/Gemfile.tt
+++ b/bundler/lib/bundler/templates/newgem/Gemfile.tt
@@ -19,5 +19,5 @@ gem "<%= config[:test] %>", "~> <%= config[:test_framework_version] %>"
 gem "rubocop", "~> <%= config[:linter_version] %>"
 <%- elsif config[:linter] == "standard" -%>
 
-gem "standard"<%= ", \"~> #{config[:linter_version]}\"" if config[:linter_version] %>
+gem "standard", "~> <%= config[:linter_version] %>"
 <%- end -%>

--- a/bundler/lib/bundler/templates/newgem/Rakefile.tt
+++ b/bundler/lib/bundler/templates/newgem/Rakefile.tt
@@ -27,11 +27,15 @@ require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:spec)
 
 <% end -%>
-<% if config[:rubocop] -%>
+<% if config[:linter] == "rubocop" -%>
 <% default_task_names << :rubocop -%>
 require "rubocop/rake_task"
 
 RuboCop::RakeTask.new
+
+<% elsif config[:linter] == "standard" -%>
+<% default_task_names << :standard -%>
+require "standard/rake"
 
 <% end -%>
 <% if config[:ext] -%>

--- a/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -3,16 +3,16 @@
 require_relative "lib/<%=config[:namespaced_path]%>/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = <%= config[:name].inspect %>
-  spec.version       = <%= config[:constant_name] %>::VERSION
-  spec.authors       = [<%= config[:author].inspect %>]
-  spec.email         = [<%= config[:email].inspect %>]
+  spec.name = <%= config[:name].inspect %>
+  spec.version = <%= config[:constant_name] %>::VERSION
+  spec.authors = [<%= config[:author].inspect %>]
+  spec.email = [<%= config[:email].inspect %>]
 
-  spec.summary       = "TODO: Write a short summary, because RubyGems requires one."
-  spec.description   = "TODO: Write a longer description or delete this line."
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.summary = "TODO: Write a short summary, because RubyGems requires one."
+  spec.description = "TODO: Write a longer description or delete this line."
+  spec.homepage = "TODO: Put your gem's website or public repo URL here."
 <%- if config[:mit] -%>
-  spec.license       = "MIT"
+  spec.license = "MIT"
 <%- end -%>
   spec.required_ruby_version = Gem::Requirement.new(">= <%= config[:required_ruby_version] %>")
 
@@ -29,11 +29,11 @@ Gem::Specification.new do |spec|
       f.match(%r{\A(?:(?:test|spec|features)/|\.(?:git|travis|circleci)|appveyor)})
     end
   end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
+  spec.bindir = "exe"
+  spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 <%- if config[:ext] -%>
-  spec.extensions    = ["ext/<%= config[:underscored_name] %>/extconf.rb"]
+  spec.extensions = ["ext/<%= config[:underscored_name] %>/extconf.rb"]
 <%- end -%>
 
   # Uncomment to register a new dependency of your gem

--- a/bundler/lib/bundler/templates/newgem/standard.yml.tt
+++ b/bundler/lib/bundler/templates/newgem/standard.yml.tt
@@ -1,0 +1,4 @@
+# For available configuration options, see:
+#   https://github.com/testdouble/standard
+
+default_ignores: false

--- a/bundler/spec/bundler/gem_helper_spec.rb
+++ b/bundler/spec/bundler/gem_helper_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Bundler::GemHelper do
   let(:app_gemspec_path) { app_path.join("#{app_name}.gemspec") }
 
   before(:each) do
-    global_config "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__COC" => "false", "BUNDLE_GEM__RUBOCOP" => "false",
+    global_config "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__COC" => "false", "BUNDLE_GEM__LINTER" => "false",
                   "BUNDLE_GEM__CI" => "false", "BUNDLE_GEM__CHANGELOG" => "false"
     bundle "gem #{app_name}"
     prepare_gemspec(app_gemspec_path)

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -21,6 +21,16 @@ RSpec.describe "bundle gem" do
     bundle "exec rubocop --debug --config .rubocop.yml", :dir => bundled_app(gem_name)
   end
 
+  def bundle_exec_standardrb
+    prepare_gemspec(bundled_app(gem_name, "#{gem_name}.gemspec"))
+    standard_version = RUBY_VERSION > "2.4" ? "" : " -v 0.2.5"
+    gems = ["minitest", "rake", "rake-compiler", "rspec", "standard#{standard_version}", "test-unit"]
+    gems.unshift "parallel -v 1.19.2" if RUBY_VERSION < "2.5"
+    path = Bundler.feature_flag.default_install_uses_path? ? local_gem_path(:base => bundled_app(gem_name)) : system_gem_path
+    realworld_system_gems gems, :path => path
+    bundle "exec standardrb --debug", :dir => bundled_app(gem_name)
+  end
+
   let(:generated_gemspec) { Bundler.load_gemspec_uncached(bundled_app(gem_name).join("#{gem_name}.gemspec")) }
 
   let(:gem_name) { "mygem" }
@@ -147,8 +157,68 @@ RSpec.describe "bundle gem" do
   end
 
   shared_examples_for "--rubocop flag" do
+    context "is deprecated", :bundler => "< 3" do
+      before do
+        bundle "gem #{gem_name} --rubocop"
+      end
+
+      it "generates a gem skeleton with rubocop" do
+        gem_skeleton_assertions
+        expect(bundled_app("test-gem/Rakefile")).to read_as(
+          include("# frozen_string_literal: true").
+          and(include('require "rubocop/rake_task"').
+          and(include("RuboCop::RakeTask.new").
+          and(match(/default:.+:rubocop/))))
+        )
+      end
+
+      it "includes rubocop in generated Gemfile" do
+        allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+        builder = Bundler::Dsl.new
+        builder.eval_gemfile(bundled_app("#{gem_name}/Gemfile"))
+        builder.dependencies
+        rubocop_dep = builder.dependencies.find {|d| d.name == "rubocop" }
+        expect(rubocop_dep).not_to be_nil
+      end
+
+      it "generates a default .rubocop.yml" do
+        expect(bundled_app("#{gem_name}/.rubocop.yml")).to exist
+      end
+    end
+  end
+
+  shared_examples_for "--no-rubocop flag" do
+    context "is deprecated", :bundler => "< 3" do
+      define_negated_matcher :exclude, :include
+
+      before do
+        bundle "gem #{gem_name} --no-rubocop"
+      end
+
+      it "generates a gem skeleton without rubocop" do
+        gem_skeleton_assertions
+        expect(bundled_app("test-gem/Rakefile")).to read_as(exclude("rubocop"))
+        expect(bundled_app("test-gem/#{gem_name}.gemspec")).to read_as(exclude("rubocop"))
+      end
+
+      it "does not include rubocop in generated Gemfile" do
+        allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+        builder = Bundler::Dsl.new
+        builder.eval_gemfile(bundled_app("#{gem_name}/Gemfile"))
+        builder.dependencies
+        rubocop_dep = builder.dependencies.find {|d| d.name == "rubocop" }
+        expect(rubocop_dep).to be_nil
+      end
+
+      it "doesn't generate a default .rubocop.yml" do
+        expect(bundled_app("#{gem_name}/.rubocop.yml")).to_not exist
+      end
+    end
+  end
+
+  shared_examples_for "--linter=rubocop flag" do
     before do
-      bundle "gem #{gem_name} --rubocop"
+      bundle "gem #{gem_name} --linter=rubocop"
     end
 
     it "generates a gem skeleton with rubocop" do
@@ -175,11 +245,38 @@ RSpec.describe "bundle gem" do
     end
   end
 
-  shared_examples_for "--no-rubocop flag" do
+  shared_examples_for "--linter=standard flag" do
+    before do
+      bundle "gem #{gem_name} --linter=standard"
+    end
+
+    it "generates a gem skeleton with standard" do
+      gem_skeleton_assertions
+      expect(bundled_app("test-gem/Rakefile")).to read_as(
+        include('require "standard/rake"').
+        and(match(/default:.+:standard/))
+      )
+    end
+
+    it "includes standard in generated Gemfile" do
+      allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+      builder = Bundler::Dsl.new
+      builder.eval_gemfile(bundled_app("#{gem_name}/Gemfile"))
+      builder.dependencies
+      standard_dep = builder.dependencies.find {|d| d.name == "standard" }
+      expect(standard_dep).not_to be_nil
+    end
+
+    it "generates a default .standard.yml" do
+      expect(bundled_app("#{gem_name}/.standard.yml")).to exist
+    end
+  end
+
+  shared_examples_for "--linter=none flag" do
     define_negated_matcher :exclude, :include
 
     before do
-      bundle "gem #{gem_name} --no-rubocop"
+      bundle "gem #{gem_name} --linter=none"
     end
 
     it "generates a gem skeleton without rubocop" do
@@ -197,43 +294,63 @@ RSpec.describe "bundle gem" do
       expect(rubocop_dep).to be_nil
     end
 
+    it "does not include standard in generated Gemfile" do
+      allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+      builder = Bundler::Dsl.new
+      builder.eval_gemfile(bundled_app("#{gem_name}/Gemfile"))
+      builder.dependencies
+      standard_dep = builder.dependencies.find {|d| d.name == "standard" }
+      expect(standard_dep).to be_nil
+    end
+
     it "doesn't generate a default .rubocop.yml" do
       expect(bundled_app("#{gem_name}/.rubocop.yml")).to_not exist
     end
+
+    it "doesn't generate a default .standard.yml" do
+      expect(bundled_app("#{gem_name}/.standard.yml")).to_not exist
+    end
   end
 
-  it "has no rubocop offenses when using --rubocop flag", :readline do
+  it "has no rubocop offenses when using --linter=rubocop flag", :readline do
     skip "ruby_core has an 'ast.rb' file that gets in the middle and breaks this spec" if ruby_core?
-    bundle "gem #{gem_name} --rubocop"
+    bundle "gem #{gem_name} --linter=rubocop"
     bundle_exec_rubocop
     expect(err).to be_empty
   end
 
-  it "has no rubocop offenses when using --ext and --rubocop flag", :readline do
+  it "has no rubocop offenses when using --ext and --linter=rubocop flag", :readline do
     skip "ruby_core has an 'ast.rb' file that gets in the middle and breaks this spec" if ruby_core?
-    bundle "gem #{gem_name} --ext --rubocop"
+    bundle "gem #{gem_name} --ext --linter=rubocop"
     bundle_exec_rubocop
     expect(err).to be_empty
   end
 
-  it "has no rubocop offenses when using --ext, --test=minitest, and --rubocop flag", :readline do
+  it "has no rubocop offenses when using --ext, --test=minitest, and --linter=rubocop flag", :readline do
     skip "ruby_core has an 'ast.rb' file that gets in the middle and breaks this spec" if ruby_core?
-    bundle "gem #{gem_name} --ext --test=minitest --rubocop"
+    bundle "gem #{gem_name} --ext --test=minitest --linter=rubocop"
     bundle_exec_rubocop
     expect(err).to be_empty
   end
 
-  it "has no rubocop offenses when using --ext, --test=rspec, and --rubocop flag", :readline do
+  it "has no rubocop offenses when using --ext, --test=rspec, and --linter=rubocop flag", :readline do
     skip "ruby_core has an 'ast.rb' file that gets in the middle and breaks this spec" if ruby_core?
-    bundle "gem #{gem_name} --ext --test=rspec --rubocop"
+    bundle "gem #{gem_name} --ext --test=rspec --linter=rubocop"
     bundle_exec_rubocop
     expect(err).to be_empty
   end
 
-  it "has no rubocop offenses when using --ext, --ext=test-unit, and --rubocop flag", :readline do
+  it "has no rubocop offenses when using --ext, --ext=test-unit, and --linter=rubocop flag", :readline do
     skip "ruby_core has an 'ast.rb' file that gets in the middle and breaks this spec" if ruby_core?
-    bundle "gem #{gem_name} --ext --test=test-unit --rubocop"
+    bundle "gem #{gem_name} --ext --test=test-unit --linter=rubocop"
     bundle_exec_rubocop
+    expect(err).to be_empty
+  end
+
+  it "has no standard offenses when using --linter=standard flag", :readline do
+    skip "ruby_core has an 'ast.rb' file that gets in the middle and breaks this spec" if ruby_core?
+    bundle "gem #{gem_name} --linter=standard"
+    bundle_exec_standardrb
     expect(err).to be_empty
   end
 
@@ -841,6 +958,127 @@ RSpec.describe "bundle gem" do
       end
     end
 
+    context "--linter with no argument" do
+      it "does not generate any linter config" do
+        bundle "gem #{gem_name}"
+
+        expect(bundled_app("#{gem_name}/.rubocop.yml")).to_not exist
+        expect(bundled_app("#{gem_name}/.standard.yml")).to_not exist
+      end
+    end
+
+    context "--linter set to rubocop" do
+      it "generates a RuboCop config" do
+        bundle "gem #{gem_name} --linter=rubocop"
+
+        expect(bundled_app("#{gem_name}/.rubocop.yml")).to exist
+        expect(bundled_app("#{gem_name}/.standard.yml")).to_not exist
+      end
+    end
+
+    context "--linter set to standard" do
+      it "generates a Standard config" do
+        bundle "gem #{gem_name} --linter=standard"
+
+        expect(bundled_app("#{gem_name}/.standard.yml")).to exist
+        expect(bundled_app("#{gem_name}/.rubocop.yml")).to_not exist
+      end
+    end
+
+    context "gem.linter setting set to none" do
+      it "doesn't generate any linter config" do
+        bundle "gem #{gem_name}"
+
+        expect(bundled_app("#{gem_name}/.rubocop.yml")).to_not exist
+        expect(bundled_app("#{gem_name}/.standard.yml")).to_not exist
+      end
+    end
+
+    context "gem.linter setting set to rubocop" do
+      it "generates a RuboCop config file" do
+        bundle "config set gem.linter rubocop"
+        bundle "gem #{gem_name}"
+
+        expect(bundled_app("#{gem_name}/.rubocop.yml")).to exist
+      end
+    end
+
+    context "gem.linter setting set to standard" do
+      it "generates a Standard config file" do
+        bundle "config set gem.linter standard"
+        bundle "gem #{gem_name}"
+
+        expect(bundled_app("#{gem_name}/.standard.yml")).to exist
+      end
+    end
+
+    context "gem.rubocop setting set to true", :bundler => "< 3" do
+      before do
+        bundle "config set gem.rubocop true"
+        bundle "gem #{gem_name}"
+      end
+
+      it "generates rubocop config" do
+        expect(bundled_app("#{gem_name}/.rubocop.yml")).to exist
+      end
+
+      it "unsets gem.rubocop" do
+        bundle "config gem.rubocop"
+        expect(out).to include("You have not configured a value for `gem.rubocop`")
+      end
+
+      it "sets gem.linter=rubocop instead" do
+        bundle "config gem.linter"
+        expect(out).to match(/Set for the current user .*: "rubocop"/)
+      end
+    end
+
+    context "gem.linter set to rubocop and --linter with no arguments", :hint_text do
+      before do
+        bundle "config set gem.linter rubocop"
+        bundle "gem #{gem_name} --linter"
+      end
+
+      it "generates a RuboCop config file" do
+        expect(bundled_app("#{gem_name}/.rubocop.yml")).to exist
+      end
+
+      it "hints that --linter is already configured" do
+        expect(out).to match("rubocop is already configured, ignoring --linter flag.")
+      end
+    end
+
+    context "gem.linter setting set to false and --linter with no arguments", :hint_text do
+      before do
+        bundle "config set gem.linter false"
+        bundle "gem #{gem_name} --linter"
+      end
+
+      it "asks to setup a linter" do
+        expect(out).to match("Do you want to add a code linter and formatter to your gem?")
+      end
+
+      it "hints that the choice will only be applied to the current gem" do
+        expect(out).to match("Your choice will only be applied to this gem.")
+      end
+    end
+
+    context "gem.linter setting not set and --linter with no arguments", :hint_text do
+      before do
+        bundle "gem #{gem_name} --linter"
+      end
+
+      it "asks to setup a linter" do
+        expect(out).to match("Do you want to add a code linter and formatter to your gem?")
+      end
+
+      it "hints that the choice will be applied to future bundle gem calls" do
+        hint = "Future `bundle gem` calls will use your choice. " \
+               "This setting can be changed anytime with `bundle config gem.linter`."
+        expect(out).to match(hint)
+      end
+    end
+
     context "--edit option" do
       it "opens the generated gemspec in the user's text editor" do
         output = bundle "gem #{gem_name} --edit=echo"
@@ -891,6 +1129,9 @@ RSpec.describe "bundle gem" do
       before do
         global_config "BUNDLE_GEM__RUBOCOP" => "true"
       end
+      it_behaves_like "--linter=rubocop flag"
+      it_behaves_like "--linter=standard flag"
+      it_behaves_like "--linter=none flag"
       it_behaves_like "--rubocop flag"
       it_behaves_like "--no-rubocop flag"
     end
@@ -899,8 +1140,38 @@ RSpec.describe "bundle gem" do
       before do
         global_config "BUNDLE_GEM__RUBOCOP" => "false"
       end
+      it_behaves_like "--linter=rubocop flag"
+      it_behaves_like "--linter=standard flag"
+      it_behaves_like "--linter=none flag"
       it_behaves_like "--rubocop flag"
       it_behaves_like "--no-rubocop flag"
+    end
+
+    context "with linter option in bundle config settings set to rubocop" do
+      before do
+        global_config "BUNDLE_GEM__LINTER" => "rubocop"
+      end
+      it_behaves_like "--linter=rubocop flag"
+      it_behaves_like "--linter=standard flag"
+      it_behaves_like "--linter=none flag"
+    end
+
+    context "with linter option in bundle config settings set to standard" do
+      before do
+        global_config "BUNDLE_GEM__LINTER" => "standard"
+      end
+      it_behaves_like "--linter=rubocop flag"
+      it_behaves_like "--linter=standard flag"
+      it_behaves_like "--linter=none flag"
+    end
+
+    context "with linter option in bundle config settings set to false" do
+      before do
+        global_config "BUNDLE_GEM__LINTER" => "false"
+      end
+      it_behaves_like "--linter=rubocop flag"
+      it_behaves_like "--linter=standard flag"
+      it_behaves_like "--linter=none flag"
     end
 
     context "with changelog option in bundle config settings set to true" do
@@ -1073,7 +1344,7 @@ Usage: "bundle gem NAME [OPTIONS]"
     end
 
     it "asks about CI service" do
-      global_config "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__COC" => "false", "BUNDLE_GEM__RUBOCOP" => "false"
+      global_config "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__COC" => "false", "BUNDLE_GEM__LINTER" => "false"
 
       bundle "gem foobar" do |input, _, _|
         input.puts "github"
@@ -1083,7 +1354,7 @@ Usage: "bundle gem NAME [OPTIONS]"
     end
 
     it "asks about MIT license" do
-      global_config "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__COC" => "false", "BUNDLE_GEM__CI" => "false", "BUNDLE_GEM__RUBOCOP" => "false"
+      global_config "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__COC" => "false", "BUNDLE_GEM__CI" => "false", "BUNDLE_GEM__LINTER" => "false"
 
       bundle "config list"
 
@@ -1095,7 +1366,7 @@ Usage: "bundle gem NAME [OPTIONS]"
     end
 
     it "asks about CoC" do
-      global_config "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__CI" => "false", "BUNDLE_GEM__RUBOCOP" => "false"
+      global_config "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__CI" => "false", "BUNDLE_GEM__LINTER" => "false"
 
       bundle "gem foobar" do |input, _, _|
         input.puts "yes"
@@ -1105,7 +1376,7 @@ Usage: "bundle gem NAME [OPTIONS]"
     end
 
     it "asks about CHANGELOG" do
-      global_config "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__CI" => "false", "BUNDLE_GEM__RUBOCOP" => "false",
+      global_config "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__CI" => "false", "BUNDLE_GEM__LINTER" => "false",
                     "BUNDLE_GEM__COC" => "false"
 
       bundle "gem foobar" do |input, _, _|

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -609,4 +609,50 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
 
     pending "fails with a helpful message", :bundler => "3"
   end
+
+  describe "deprecating rubocop", :readline do
+    context "bundle gem --rubocop" do
+      before do
+        bundle "gem my_new_gem --rubocop", :raise_on_error => false
+      end
+
+      it "prints a deprecation warning", :bundler => "< 3" do
+        expect(deprecations).to include \
+          "--rubocop is deprecated, use --linter=rubocop"
+      end
+    end
+
+    context "bundle gem --no-rubocop" do
+      before do
+        bundle "gem my_new_gem --no-rubocop", :raise_on_error => false
+      end
+
+      it "prints a deprecation warning", :bundler => "< 3" do
+        expect(deprecations).to include \
+          "--no-rubocop is deprecated, use --linter"
+      end
+    end
+
+    context "bundle gem with gem.rubocop set to true" do
+      before do
+        bundle "gem my_new_gem", :env => { "BUNDLE_GEM__RUBOCOP" => "true" }, :raise_on_error => false
+      end
+
+      it "prints a deprecation warning", :bundler => "< 3" do
+        expect(deprecations).to include \
+          "config gem.rubocop is deprecated; we've updated your config to use gem.linter instead"
+      end
+    end
+
+    context "bundle gem with gem.rubocop set to false" do
+      before do
+        bundle "gem my_new_gem", :env => { "BUNDLE_GEM__RUBOCOP" => "false" }, :raise_on_error => false
+      end
+
+      it "prints a deprecation warning", :bundler => "< 3" do
+        expect(deprecations).to include \
+          "config gem.rubocop is deprecated; we've updated your config to use gem.linter instead"
+      end
+    end
+  end
 end


### PR DESCRIPTION
This commit converts the --rubocop and --no-rubocop flags to a new --linter option. The option supports either the standard or rubocop gems, and (similar to the --ci option), it can also be set either interactively or via a new `gem.linter` global config.

I do have one outstanding question for the rubygems maintainers that should be discussed before merge, however. Currently, there are [a number of specs](https://github.com/rubygems/rubygems/blob/master/bundler/spec/commands/newgem_spec.rb#L237-L263) that ensure projects that are generated with RuboCop configurations will initially pass RuboCop. However, the default project template will _not_ pass by default:

```
standard: Use Ruby Standard Style (https://github.com/testdouble/standard)
       standard: Run `standardrb --fix` to automatically fix some problems.
         mygem.gemspec:6:12: Layout/ExtraSpacing: Unnecessary spacing detected.
         mygem.gemspec:7:15: Layout/ExtraSpacing: Unnecessary spacing detected.
         mygem.gemspec:8:15: Layout/ExtraSpacing: Unnecessary spacing detected.
         mygem.gemspec:9:13: Layout/ExtraSpacing: Unnecessary spacing detected.
         mygem.gemspec:11:15: Layout/ExtraSpacing: Unnecessary spacing detected.
         mygem.gemspec:12:19: Layout/ExtraSpacing: Unnecessary spacing detected.
         mygem.gemspec:13:16: Layout/ExtraSpacing: Unnecessary spacing detected.
         mygem.gemspec:29:14: Layout/ExtraSpacing: Unnecessary spacing detected.
         mygem.gemspec:30:19: Layout/ExtraSpacing: Unnecessary spacing detected.
```

Should we leave this as-is, or should we execute `rake standard:fix` after the project is initialized to ensure the project successfully builds without requiring users to fix it themselves?

## What was the end-user or developer problem that led to this PR?

When creating a new gem, I like to use [standard](https://github.com/testdouble/standard) for automated linting & formatting (full disclosure: I maintain standard). If you're not familiar with standard, it's built on top of rubocop and provides a fixed ruleset that is intentionally not customizable by users, for the purpose of promoting consistency across Ruby projects.

## What is your fix for the problem, implemented in this PR?

When I saw that the `bundle gem` CLI included an option for adding RuboCop, I figured it'd be neat to include Standard alongside it, similar to how the `--ci` option includes four CI service options.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

