### PR TITLE
Add a note about private data in `bundle env` output

### DIFF
--- a/.github/ISSUE_TEMPLATE/bundler-related-issue.md
+++ b/.github/ISSUE_TEMPLATE/bundler-related-issue.md
@@ -52,4 +52,4 @@ Ideally, we recommend you to set up the list of steps as a [Dockerfile](https://
 
 ### If not included with the output of your command, run `bundle env` and paste the output below
 
-<!-- Replace this with the result of `bundle env`. -->
+<!-- Replace this with the result of `bundle env`. Don't forget to anonymize any private data! -->


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

A user could have private data configured, which is currently printed by `bundle env`, and could potentially blindly copy-paste `bundle env` output into a public github issue.

## What is your fix for the problem, implemented in this PR?

Remember them to anonymize any private data before posting it.

References #4414.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
