### PR TITLE
Fix gems sometimes being pulled from irrelevant sources

### DIFF
--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -46,15 +46,17 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: rubygems/rubygems
-      - name: Test RubyGems
+      - name: Sync tools
         run: |
           ruby tool/sync_default_gems.rb rubygems
-          make -j2 -s test-all TESTS="rubygems --no-retry"
+          ruby tool/sync_default_gems.rb bundler
+        working-directory: ruby/ruby
+      - name: Test RubyGems
+        run: make -j2 -s test-all TESTS="rubygems --no-retry"
         working-directory: ruby/ruby
         if: matrix.target == 'Rubygems'
       - name: Test Bundler
         run: |
-          ruby tool/sync_default_gems.rb bundler
           git checkout lib/bundler/bundler.gemspec
           git add .
           make test-bundler-parallel

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -904,9 +904,9 @@ module Bundler
       source_requirements = { :default => default }
       default = nil unless Bundler.feature_flag.disable_multisource?
       dependencies.each do |dep|
-        source = dep.source || default
-        next unless source
-        source_requirements[dep.name] = source
+        dep_source = dep.source || default
+        next unless dep_source
+        source_requirements[dep.name] = dep_source
       end
       metadata_dependencies.each do |dep|
         source_requirements[dep.name] = sources.metadata_source

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -918,7 +918,7 @@ module Bundler
     def pinned_spec_names(skip = nil)
       pinned_names = []
       default = Bundler.feature_flag.disable_multisource? && sources.default_source
-      @dependencies.each do |dep|
+      dependencies.each do |dep|
         dep_source = dep.source || default
         next unless dep_source
         next if dep_source == skip

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -973,10 +973,9 @@ module Bundler
     def dependency_source_requirements
       @dependency_source_requirements ||= begin
         source_requirements = {}
-        default = Bundler.feature_flag.disable_multisource? && sources.default_source
+        default = sources.default_source
         dependencies.each do |dep|
           dep_source = dep.source || default
-          next unless dep_source
           source_requirements[dep.name] = dep_source
         end
         source_requirements

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -663,19 +663,20 @@ module Bundler
     def converge_rubygems_sources
       return false if Bundler.feature_flag.disable_multisource?
 
-      changes = false
-
       # Get the RubyGems sources from the Gemfile.lock
       locked_gem_sources = @locked_sources.select {|s| s.is_a?(Source::Rubygems) }
+      return false if locked_gem_sources.empty?
+
       # Get the RubyGems remotes from the Gemfile
       actual_remotes = sources.rubygems_remotes
+      return false if actual_remotes.empty?
+
+      changes = false
 
       # If there is a RubyGems source in both
-      if !locked_gem_sources.empty? && !actual_remotes.empty?
-        locked_gem_sources.each do |locked_gem|
-          # Merge the remotes from the Gemfile into the Gemfile.lock
-          changes |= locked_gem.replace_remotes(actual_remotes, Bundler.settings[:allow_deployment_source_credential_changes])
-        end
+      locked_gem_sources.each do |locked_gem|
+        # Merge the remotes from the Gemfile into the Gemfile.lock
+        changes |= locked_gem.replace_remotes(actual_remotes, Bundler.settings[:allow_deployment_source_credential_changes])
       end
 
       changes

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -900,9 +900,8 @@ module Bundler
       # Record the specs available in each gem's source, so that those
       # specs will be available later when the resolver knows where to
       # look for that gemspec (or its dependencies)
-      default = sources.default_source
-      source_requirements = { :default => default }
-      default = nil unless Bundler.feature_flag.disable_multisource?
+      source_requirements = { :default => sources.default_source }
+      default = Bundler.feature_flag.disable_multisource? && sources.default_source
       dependencies.each do |dep|
         dep_source = dep.source || default
         next unless dep_source

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -269,7 +269,7 @@ module Bundler
           # Run a resolve against the locally available gems
           Bundler.ui.debug("Found changes from the lockfile, re-resolving dependencies because #{change_reason}")
           expanded_dependencies = expand_dependencies(dependencies + metadata_dependencies, @remote)
-          Resolver.resolve(expanded_dependencies, index, source_requirements, last_resolve, gem_version_promoter, additional_base_requirements_for_resolve, platforms)
+          Resolver.resolve(expanded_dependencies, source_requirements, last_resolve, gem_version_promoter, additional_base_requirements_for_resolve, platforms)
         end
       end
     end
@@ -904,6 +904,7 @@ module Bundler
       metadata_dependencies.each do |dep|
         source_requirements[dep.name] = sources.metadata_source
       end
+      source_requirements[:global] = index unless Bundler.feature_flag.disable_multisource?
       source_requirements[:default_bundler] = source_requirements["bundler"] || source_requirements[:default]
       source_requirements["bundler"] = sources.metadata_source # needs to come last to override
       source_requirements

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -904,7 +904,8 @@ module Bundler
       source_requirements = { :default => default }
       default = nil unless Bundler.feature_flag.disable_multisource?
       dependencies.each do |dep|
-        next unless source = dep.source || default
+        source = dep.source || default
+        next unless source
         source_requirements[dep.name] = source
       end
       metadata_dependencies.each do |dep|
@@ -919,7 +920,8 @@ module Bundler
       pinned_names = []
       default = Bundler.feature_flag.disable_multisource? && sources.default_source
       @dependencies.each do |dep|
-        next unless dep_source = dep.source || default
+        dep_source = dep.source || default
+        next unless dep_source
         next if dep_source == skip
         pinned_names << dep.name
       end

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -192,7 +192,6 @@ module Bundler
               "      gem 'rails'\n" \
               "    end\n\n"
 
-        raise DeprecatedError, msg if Bundler.feature_flag.disable_multisource?
         SharedHelpers.major_deprecation(2, msg.strip)
       end
 

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -446,11 +446,8 @@ repo_name ||= user_name
       if Bundler.feature_flag.disable_multisource?
         msg = "This Gemfile contains multiple primary sources. " \
           "Each source after the first must include a block to indicate which gems " \
-          "should come from that source"
-        unless Bundler.feature_flag.bundler_2_mode?
-          msg += ". To downgrade this error to a warning, run " \
-            "`bundle config unset disable_multisource`"
-        end
+          "should come from that source. To downgrade this error to a warning, run " \
+          "`bundle config unset disable_multisource`"
         raise GemfileEvalError, msg
       else
         Bundler::SharedHelpers.major_deprecation 2, "Your Gemfile contains multiple primary sources. " \

--- a/bundler/lib/bundler/inline.rb
+++ b/bundler/lib/bundler/inline.rb
@@ -50,6 +50,7 @@ def gemfile(install = false, options = {}, &gemfile)
     Bundler::Plugin.gemfile_install(&gemfile) if Bundler.feature_flag.plugins?
     builder = Bundler::Dsl.new
     builder.instance_eval(&gemfile)
+    builder.check_primary_source_safety
 
     Bundler.settings.temporary(:frozen => false) do
       definition = builder.to_definition(nil, true)

--- a/bundler/lib/bundler/lockfile_parser.rb
+++ b/bundler/lib/bundler/lockfile_parser.rb
@@ -64,8 +64,6 @@ module Bundler
       @state        = nil
       @specs        = {}
 
-      @rubygems_aggregate = Source::Rubygems.new
-
       if lockfile.match(/<<<<<<<|=======|>>>>>>>|\|\|\|\|\|\|\|/)
         raise LockfileError, "Your #{Bundler.default_lockfile.relative_path_from(SharedHelpers.pwd)} contains merge conflicts.\n" \
           "Run `git checkout HEAD -- #{Bundler.default_lockfile.relative_path_from(SharedHelpers.pwd)}` first to get a clean lock."
@@ -138,9 +136,9 @@ module Bundler
             @current_source = TYPES[@type].from_lock(@opts)
           else
             Array(@opts["remote"]).each do |url|
-              @rubygems_aggregate.add_remote(url)
+              rubygems_aggregate.add_remote(url)
             end
-            @current_source = @rubygems_aggregate
+            @current_source = rubygems_aggregate
           end
 
           @sources << @current_source
@@ -244,6 +242,10 @@ module Bundler
 
     def parse_ruby(line)
       @ruby_version = line.strip
+    end
+
+    def rubygems_aggregate
+      @rubygems_aggregate ||= Source::Rubygems.new
     end
   end
 end

--- a/bundler/lib/bundler/lockfile_parser.rb
+++ b/bundler/lib/bundler/lockfile_parser.rb
@@ -89,7 +89,6 @@ module Bundler
           send("parse_#{@state}", line)
         end
       end
-      @sources << @rubygems_aggregate unless Bundler.feature_flag.disable_multisource?
       @specs = @specs.values.sort_by(&:identifier)
       warn_for_outdated_bundler_version
     rescue ArgumentError => e
@@ -137,13 +136,14 @@ module Bundler
           if Bundler.feature_flag.disable_multisource?
             @opts["remotes"] = @opts.delete("remote")
             @current_source = TYPES[@type].from_lock(@opts)
-            @sources << @current_source
           else
             Array(@opts["remote"]).each do |url|
               @rubygems_aggregate.add_remote(url)
             end
             @current_source = @rubygems_aggregate
           end
+
+          @sources << @current_source
         when PLUGIN
           @current_source = Plugin.source_from_lock(@opts)
           @sources << @current_source

--- a/bundler/lib/bundler/lockfile_parser.rb
+++ b/bundler/lib/bundler/lockfile_parser.rb
@@ -131,11 +131,13 @@ module Bundler
             @sources << @current_source
           end
         when GEM
-          if Bundler.feature_flag.disable_multisource?
+          source_remotes = Array(@opts["remote"])
+
+          if source_remotes.size == 1
             @opts["remotes"] = @opts.delete("remote")
             @current_source = TYPES[@type].from_lock(@opts)
           else
-            Array(@opts["remote"]).each do |url|
+            source_remotes.each do |url|
               rubygems_aggregate.add_remote(url)
             end
             @current_source = rubygems_aggregate

--- a/bundler/lib/bundler/plugin.rb
+++ b/bundler/lib/bundler/plugin.rb
@@ -105,6 +105,7 @@ module Bundler
         else
           builder.eval_gemfile(gemfile)
         end
+        builder.check_primary_source_safety
         definition = builder.to_definition(nil, true)
 
         return if definition.dependencies.empty?

--- a/bundler/lib/bundler/plugin/installer.rb
+++ b/bundler/lib/bundler/plugin/installer.rb
@@ -16,15 +16,13 @@ module Bundler
 
         version = options[:version] || [">= 0"]
 
-        Bundler.settings.temporary(:disable_multisource => false) do
-          if options[:git]
-            install_git(names, version, options)
-          elsif options[:local_git]
-            install_local_git(names, version, options)
-          else
-            sources = options[:source] || Bundler.rubygems.sources
-            install_rubygems(names, version, sources)
-          end
+        if options[:git]
+          install_git(names, version, options)
+        elsif options[:local_git]
+          install_local_git(names, version, options)
+        else
+          sources = options[:source] || Bundler.rubygems.sources
+          install_rubygems(names, version, sources)
         end
       end
 
@@ -79,7 +77,7 @@ module Bundler
         source_list = SourceList.new
 
         source_list.add_git_source(git_source_options) if git_source_options
-        source_list.add_rubygems_source("remotes" => rubygems_source) if rubygems_source
+        source_list.global_rubygems_source = rubygems_source if rubygems_source
 
         deps = names.map {|name| Dependency.new name, version }
 

--- a/bundler/lib/bundler/plugin/source_list.rb
+++ b/bundler/lib/bundler/plugin/source_list.rb
@@ -17,6 +17,10 @@ module Bundler
         path_sources + git_sources + rubygems_sources + [metadata_source]
       end
 
+      def default_source
+        git_sources.first || global_rubygems_source
+      end
+
       private
 
       def rubygems_aggregate_class

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -457,7 +457,6 @@ module Bundler
         name = v.name
         sources = relevant_sources_for_vertex(v)
         next unless sources.any?
-        sources.compact!
         if default_index = sources.index(@source_requirements[:default])
           sources.delete_at(default_index)
         end

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -329,7 +329,7 @@ module Bundler
             "The source does not contain any versions of '#{name}'"
           end
         else
-          message = "Could not find gem '#{requirement}' in any of the gem sources " \
+          message = "Could not find gem '#{SharedHelpers.pretty_dependency(requirement)}' in any of the gem sources " \
             "listed in your Gemfile#{cache_message}."
         end
         raise GemNotFound, message

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -314,7 +314,7 @@ module Bundler
             "If you are updating multiple gems in your Gemfile at once,\n" \
             "try passing them all to `bundle update`"
         elsif source = @source_requirements[name]
-          specs = source.specs[name]
+          specs = source.specs.search(name)
           versions_with_platforms = specs.map {|s| [s.version, s.platform] }
           message = String.new("Could not find gem '#{SharedHelpers.pretty_dependency(requirement)}' in #{source}#{cache_message}.\n")
           message << if versions_with_platforms.any?
@@ -452,7 +452,7 @@ module Bundler
         if default_index = sources.index(@source_requirements[:default])
           sources.delete_at(default_index)
         end
-        sources.reject! {|s| s.specs[name].empty? }
+        sources.reject! {|s| s.specs.search(name).empty? }
         sources.uniq!
         next if sources.size <= 1
 

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -248,9 +248,9 @@ module Bundler
 
     def sort_dependencies(dependencies, activated, conflicts)
       dependencies.sort_by do |dependency|
-        dependency.all_sources = relevant_sources_for_vertex(activated.vertex_named(dependency.name))
         name = name_for(dependency)
         vertex = activated.vertex_named(name)
+        dependency.all_sources = relevant_sources_for_vertex(vertex)
         [
           @base_dg.vertex_named(name) ? 0 : 1,
           vertex.payload ? 0 : 1,

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -457,14 +457,12 @@ module Bundler
         sources.uniq!
         next if sources.size <= 1
 
-        multisource_disabled = Bundler.feature_flag.disable_multisource?
-
         msg = ["The gem '#{name}' was found in multiple relevant sources."]
         msg.concat sources.map {|s| "  * #{s}" }.sort
-        msg << "You #{multisource_disabled ? :must : :should} add this gem to the source block for the source you wish it to be installed from."
+        msg << "You #{@lockfile_uses_separate_rubygems_sources ? :must : :should} add this gem to the source block for the source you wish it to be installed from."
         msg = msg.join("\n")
 
-        raise SecurityError, msg if multisource_disabled
+        raise SecurityError, msg if @lockfile_uses_separate_rubygems_sources
         Bundler.ui.warn "Warning: #{msg}"
       end
     end

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -130,8 +130,7 @@ module Bundler
       dependency = dependency_proxy.dep
       name = dependency.name
       search_result = @search_for[dependency_proxy] ||= begin
-        index = index_for(dependency)
-        results = index.search(dependency, @base[name])
+        results = results_for(dependency, @base[name])
 
         if vertex = @base_dg.vertex_named(name)
           locked_requirement = vertex.payload.requirement
@@ -211,6 +210,10 @@ module Bundler
       else
         @index_requirements[:global]
       end
+    end
+
+    def results_for(dependency, base)
+      index_for(dependency).search(dependency, base)
     end
 
     def name_for(dependency)

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -205,7 +205,7 @@ module Bundler
         source
       elsif @no_aggregate_global_source
         Index.build do |idx|
-          dependency.all_sources.each {|s| idx.add_source(s.specs) if s }
+          dependency.all_sources.each {|s| idx.add_source(s.specs) }
         end
       else
         @index_requirements[:global]
@@ -246,7 +246,7 @@ module Bundler
       elsif @no_aggregate_global_source
         vertex.recursive_predecessors.map do |v|
           @source_requirements[v.name]
-        end << @source_requirements[:default]
+        end.compact << @source_requirements[:default]
       else
         []
       end

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -99,7 +99,6 @@ module Bundler
       @global_rubygems_source = replacement_rubygems if replacement_rubygems
 
       return true if !equal_sources?(lock_sources, replacement_sources) && !equivalent_sources?(lock_sources, replacement_sources)
-      return true if replacement_rubygems && rubygems_remotes.sort_by(&:to_s) != replacement_rubygems.remotes.sort_by(&:to_s)
 
       false
     end

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -110,10 +110,6 @@ module Bundler
       all_sources.each(&:remote!)
     end
 
-    def rubygems_primary_remotes
-      @rubygems_aggregate.remotes
-    end
-
     private
 
     def rubygems_aggregate_class

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -5,6 +5,7 @@ module Bundler
     attr_reader :path_sources,
       :git_sources,
       :plugin_sources,
+      :global_path_source,
       :metadata_source
 
     def global_rubygems_source
@@ -16,6 +17,7 @@ module Bundler
       @git_sources            = []
       @plugin_sources         = []
       @global_rubygems_source = nil
+      @global_path_source     = nil
       @rubygems_sources       = []
       @metadata_source        = Source::Metadata.new
     end
@@ -24,7 +26,9 @@ module Bundler
       if options["gemspec"]
         add_source_to_list Source::Gemspec.new(options), path_sources
       else
-        add_source_to_list Source::Path.new(options), path_sources
+        path_source = add_source_to_list Source::Path.new(options), path_sources
+        @global_path_source ||= path_source if options["global"]
+        path_source
       end
     end
 

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -56,11 +56,11 @@ module Bundler
     end
 
     def default_source
-      global_rubygems_source
+      global_path_source || global_rubygems_source
     end
 
     def rubygems_sources
-      @rubygems_sources + [default_source]
+      @rubygems_sources + [global_rubygems_source]
     end
 
     def rubygems_remotes

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -5,15 +5,17 @@ module Bundler
     attr_reader :path_sources,
       :git_sources,
       :plugin_sources,
-      :global_rubygems_source,
       :metadata_source
+
+    def global_rubygems_source
+      @global_rubygems_source ||= rubygems_aggregate_class.new
+    end
 
     def initialize
       @path_sources           = []
       @git_sources            = []
       @plugin_sources         = []
       @global_rubygems_source = nil
-      @rubygems_aggregate     = rubygems_aggregate_class.new
       @rubygems_sources       = []
       @metadata_source        = Source::Metadata.new
     end
@@ -49,12 +51,12 @@ module Bundler
     end
 
     def add_rubygems_remote(uri)
-      @rubygems_aggregate.add_remote(uri)
-      @rubygems_aggregate
+      global_rubygems_source.add_remote(uri)
+      global_rubygems_source
     end
 
     def default_source
-      global_rubygems_source || @rubygems_aggregate
+      global_rubygems_source
     end
 
     def rubygems_sources
@@ -94,7 +96,7 @@ module Bundler
 
       replacement_rubygems = !Bundler.feature_flag.disable_multisource? &&
         replacement_sources.detect {|s| s.is_a?(Source::Rubygems) }
-      @rubygems_aggregate = replacement_rubygems if replacement_rubygems
+      @global_rubygems_source = replacement_rubygems if replacement_rubygems
 
       return true if !equal_sources?(lock_sources, replacement_sources) && !equivalent_sources?(lock_sources, replacement_sources)
       return true if replacement_rubygems && rubygems_remotes.sort_by(&:to_s) != replacement_rubygems.remotes.sort_by(&:to_s)

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -47,11 +47,7 @@ module Bundler
     end
 
     def global_rubygems_source=(uri)
-      if Bundler.feature_flag.disable_multisource?
-        @global_rubygems_source ||= rubygems_aggregate_class.new("remotes" => uri)
-      else
-        add_rubygems_remote(uri)
-      end
+      @global_rubygems_source ||= rubygems_aggregate_class.new("remotes" => uri)
     end
 
     def add_rubygems_remote(uri)

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -43,12 +43,12 @@ module Bundler
     def global_rubygems_source=(uri)
       if Bundler.feature_flag.disable_multisource?
         @global_rubygems_source ||= rubygems_aggregate_class.new("remotes" => uri)
+      else
+        add_rubygems_remote(uri)
       end
-      add_rubygems_remote(uri)
     end
 
     def add_rubygems_remote(uri)
-      return if Bundler.feature_flag.disable_multisource?
       @rubygems_aggregate.add_remote(uri)
       @rubygems_aggregate
     end

--- a/bundler/spec/bundler/plugin_spec.rb
+++ b/bundler/spec/bundler/plugin_spec.rb
@@ -110,6 +110,7 @@ RSpec.describe Bundler::Plugin do
     before do
       allow(Plugin::DSL).to receive(:new) { builder }
       allow(builder).to receive(:eval_gemfile).with(gemfile)
+      allow(builder).to receive(:check_primary_source_safety)
       allow(builder).to receive(:to_definition) { definition }
       allow(builder).to receive(:inferred_plugins) { [] }
     end

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -804,7 +804,8 @@ RSpec.describe "bundle exec" do
       let(:exit_code) { Bundler::GemNotFound.new.status_code }
       let(:expected) { "" }
       let(:expected_err) { <<-EOS.strip }
-\e[31mCould not find gem 'rack (= 2)' in any of the gem sources listed in your Gemfile.\e[0m
+\e[31mCould not find gem 'rack (= 2)' in locally installed gems.
+The source contains the following versions of 'rack': 0.9.1, 1.0.0\e[0m
 \e[33mRun `bundle install` to install missing gems.\e[0m
       EOS
 

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -668,29 +668,40 @@ RSpec.describe "bundle exec" do
 
     subject { bundle "exec #{path} arg1 arg2", :raise_on_error => false }
 
-    shared_examples_for "it runs" do
-      it "like a normally executed executable" do
-        skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
+    it "runs" do
+      skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
 
-        subject
-        expect(exitstatus).to eq(exit_code)
-        expect(err).to eq(expected_err)
-        expect(out).to eq(expected)
-      end
+      subject
+      expect(exitstatus).to eq(exit_code)
+      expect(err).to eq(expected_err)
+      expect(out).to eq(expected)
     end
-
-    it_behaves_like "it runs"
 
     context "the executable exits explicitly" do
       let(:executable) { super() << "\nexit #{exit_code}\nputs 'POST_EXIT'\n" }
 
       context "with exit 0" do
-        it_behaves_like "it runs"
+        it "runs" do
+          skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
+
+          subject
+          expect(exitstatus).to eq(exit_code)
+          expect(err).to eq(expected_err)
+          expect(out).to eq(expected)
+        end
       end
 
       context "with exit 99" do
         let(:exit_code) { 99 }
-        it_behaves_like "it runs"
+
+        it "runs" do
+          skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
+
+          subject
+          expect(exitstatus).to eq(exit_code)
+          expect(err).to eq(expected_err)
+          expect(out).to eq(expected)
+        end
       end
     end
 
@@ -707,7 +718,15 @@ RSpec.describe "bundle exec" do
         # this is specified by C99
         128 + 15
       end
-      it_behaves_like "it runs"
+
+      it "runs" do
+        skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
+
+        subject
+        expect(exitstatus).to eq(exit_code)
+        expect(err).to eq(expected_err)
+        expect(out).to eq(expected)
+      end
     end
 
     context "the executable is empty" do
@@ -716,7 +735,15 @@ RSpec.describe "bundle exec" do
       let(:exit_code) { 0 }
       let(:expected_err) { "#{path} is empty" }
       let(:expected) { "" }
-      it_behaves_like "it runs"
+
+      it "runs" do
+        skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
+
+        subject
+        expect(exitstatus).to eq(exit_code)
+        expect(err).to eq(expected_err)
+        expect(out).to eq(expected)
+      end
     end
 
     context "the executable raises" do
@@ -743,12 +770,27 @@ RSpec.describe "bundle exec" do
       let(:expected_err) { "bundler: failed to load command: #{path} (#{path})\n#{system_gem_path("bin/bundle")}: Err (Err)" }
       let(:expected) { super() }
 
-      it_behaves_like "it runs"
+      it "runs" do
+        skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
+
+        subject
+        expect(exitstatus).to eq(exit_code)
+        expect(err).to eq(expected_err)
+        expect(out).to eq(expected)
+      end
     end
 
     context "when the file uses the current ruby shebang" do
       let(:shebang) { "#!#{Gem.ruby}" }
-      it_behaves_like "it runs"
+
+      it "runs" do
+        skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
+
+        subject
+        expect(exitstatus).to eq(exit_code)
+        expect(err).to eq(expected_err)
+        expect(out).to eq(expected)
+      end
     end
 
     context "when Bundler.setup fails", :bundler => "< 3" do
@@ -766,7 +808,14 @@ RSpec.describe "bundle exec" do
 \e[33mRun `bundle install` to install missing gems.\e[0m
       EOS
 
-      it_behaves_like "it runs"
+      it "runs" do
+        skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
+
+        subject
+        expect(exitstatus).to eq(exit_code)
+        expect(err).to eq(expected_err)
+        expect(out).to eq(expected)
+      end
     end
 
     context "when Bundler.setup fails", :bundler => "3" do
@@ -785,14 +834,28 @@ The source contains the following versions of 'rack': 1.0.0\e[0m
 \e[33mRun `bundle install` to install missing gems.\e[0m
       EOS
 
-      it_behaves_like "it runs"
+      it "runs" do
+        skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
+
+        subject
+        expect(exitstatus).to eq(exit_code)
+        expect(err).to eq(expected_err)
+        expect(out).to eq(expected)
+      end
     end
 
     context "when the executable exits non-zero via at_exit" do
       let(:executable) { super() + "\n\nat_exit { $! ? raise($!) : exit(1) }" }
       let(:exit_code) { 1 }
 
-      it_behaves_like "it runs"
+      it "runs" do
+        skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
+
+        subject
+        expect(exitstatus).to eq(exit_code)
+        expect(err).to eq(expected_err)
+        expect(out).to eq(expected)
+      end
     end
 
     context "when disable_exec_load is set" do
@@ -803,7 +866,14 @@ The source contains the following versions of 'rack': 1.0.0\e[0m
         bundle "config set disable_exec_load true"
       end
 
-      it_behaves_like "it runs"
+      it "runs" do
+        skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
+
+        subject
+        expect(exitstatus).to eq(exit_code)
+        expect(err).to eq(expected_err)
+        expect(out).to eq(expected)
+      end
     end
 
     context "regarding $0 and __FILE__" do
@@ -819,12 +889,26 @@ $0: #{path.to_s.inspect}
 __FILE__: #{path.to_s.inspect}
       EOS
 
-      it_behaves_like "it runs"
+      it "runs" do
+        skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
+
+        subject
+        expect(exitstatus).to eq(exit_code)
+        expect(err).to eq(expected_err)
+        expect(out).to eq(expected)
+      end
 
       context "when the path is relative" do
         let(:path) { super().relative_path_from(bundled_app) }
 
-        it_behaves_like "it runs"
+        it "runs" do
+          skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
+
+          subject
+          expect(exitstatus).to eq(exit_code)
+          expect(err).to eq(expected_err)
+          expect(out).to eq(expected)
+        end
       end
 
       context "when the path is relative with a leading ./" do

--- a/bundler/spec/commands/post_bundle_message_spec.rb
+++ b/bundler/spec/commands/post_bundle_message_spec.rb
@@ -113,16 +113,7 @@ RSpec.describe "post bundle message" do
         bundle "config set force_ruby_platform true"
       end
 
-      it "should report a helpful error message", :bundler => "< 3" do
-        install_gemfile <<-G, :raise_on_error => false
-          source "#{file_uri_for(gem_repo1)}"
-          gem "rack"
-          gem "not-a-gem", :group => :development
-        G
-        expect(err).to include("Could not find gem 'not-a-gem' in any of the gem sources listed in your Gemfile.")
-      end
-
-      it "should report a helpful error message", :bundler => "3" do
+      it "should report a helpful error message" do
         install_gemfile <<-G, :raise_on_error => false
           source "#{file_uri_for(gem_repo1)}"
           gem "rack"

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -422,14 +422,13 @@ RSpec.describe "bundle install from an existing gemspec" do
           end
         end
 
-        %w[ruby jruby].each do |platform|
-          simulate_platform(platform) do
-            install_gemfile <<-G
-              source "#{file_uri_for(gem_repo2)}"
-              gemspec
-            G
-          end
-        end
+        gemfile <<-G
+          source "#{file_uri_for(gem_repo2)}"
+          gemspec
+        G
+
+        simulate_platform("ruby") { bundle "install" }
+        simulate_platform("jruby") { bundle "install" }
       end
 
       context "on ruby" do

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -187,25 +187,19 @@ RSpec.describe "bundle install with gems on multiple sources" do
             end
           end
 
-          context "when disable_multisource is set" do
-            before do
-              bundle "config set disable_multisource true"
-            end
+          it "installs from the same source without any warning" do
+            bundle :install
 
-            it "installs from the same source without any warning" do
-              bundle :install
+            expect(err).not_to include("Warning: the gem 'rack' was found in multiple sources.")
+            expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0", :source => "remote3")
 
-              expect(err).not_to include("Warning: the gem 'rack' was found in multiple sources.")
-              expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0", :source => "remote3")
+            # In https://github.com/bundler/bundler/issues/3585 this failed
+            # when there is already a lock file, and the gems are missing, so try again
+            system_gems []
+            bundle :install
 
-              # In https://github.com/bundler/bundler/issues/3585 this failed
-              # when there is already a lock file, and the gems are missing, so try again
-              system_gems []
-              bundle :install
-
-              expect(err).not_to include("Warning: the gem 'rack' was found in multiple sources.")
-              expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0", :source => "remote3")
-            end
+            expect(err).not_to include("Warning: the gem 'rack' was found in multiple sources.")
+            expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0", :source => "remote3")
           end
         end
       end

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
           it "installs from the same source without any warning" do
             bundle :install
             expect(err).not_to include("Warning")
-            expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0")
+            expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0", :source => "remote3")
           end
         end
 
@@ -196,7 +196,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
               bundle :install
 
               expect(err).not_to include("Warning: the gem 'rack' was found in multiple sources.")
-              expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0")
+              expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0", :source => "remote3")
 
               # In https://github.com/bundler/bundler/issues/3585 this failed
               # when there is already a lock file, and the gems are missing, so try again
@@ -204,7 +204,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
               bundle :install
 
               expect(err).not_to include("Warning: the gem 'rack' was found in multiple sources.")
-              expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0")
+              expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0", :source => "remote3")
             end
           end
         end

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -295,6 +295,33 @@ RSpec.describe "bundle install with gems on multiple sources" do
       end
     end
 
+    context "when a top-level gem can only be found in an scoped source" do
+      before do
+        build_repo2
+
+        build_repo gem_repo3 do
+          build_gem "private_gem_1", "1.0.0"
+          build_gem "private_gem_2", "1.0.0"
+        end
+
+        gemfile <<-G
+          source "#{file_uri_for(gem_repo2)}"
+
+          gem "private_gem_1"
+
+          source "#{file_uri_for(gem_repo3)}" do
+            gem "private_gem_2"
+          end
+        G
+      end
+
+      it "fails" do
+        bundle :install, :raise_on_error => false
+        expect(err).to include("Could not find gem 'private_gem_1' in rubygems repository #{file_uri_for(gem_repo2)}/ or installed locally.")
+        expect(err).to include("The source does not contain any versions of 'private_gem_1'")
+      end
+    end
+
     context "when a top-level gem has an indirect dependency" do
       context "when disable_multisource is set" do
         before do

--- a/bundler/spec/support/indexes.rb
+++ b/bundler/spec/support/indexes.rb
@@ -30,7 +30,7 @@ module Spec
       args[1] ||= Bundler::GemVersionPromoter.new # gem_version_promoter
       args[2] ||= [] # additional_base_requirements
       args[3] ||= @platforms # platforms
-      Bundler::Resolver.resolve(deps, @index, source_requirements, *args)
+      Bundler::Resolver.resolve(deps, source_requirements, *args)
     end
 
     def should_resolve_as(specs)

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1958,15 +1958,8 @@ class TestGem < Gem::TestCase
       io.write 'gem "a"'
     end
 
-    platform = Bundler::GemHelpers.generic_local_platform
-    if platform == Gem::Platform::RUBY
-      platform = ''
-    else
-      platform = " #{platform}"
-    end
-
     expected = <<-EXPECTED
-Could not find gem 'a#{platform}' in any of the gem sources listed in your Gemfile.
+Could not find gem 'a' in any of the gem sources listed in your Gemfile.
 You may need to `gem install -g` to install missing gems
 
     EXPECTED

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1959,7 +1959,8 @@ class TestGem < Gem::TestCase
     end
 
     expected = <<-EXPECTED
-Could not find gem 'a' in any of the gem sources listed in your Gemfile.
+Could not find gem 'a' in locally installed gems.
+The source does not contain any versions of 'a'
 You may need to `gem install -g` to install missing gems
 
     EXPECTED


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The end user problem is that we have several issues with the sources where each dependency is pulled for resolution. In 2.2.10 I rushed too much and tried to fix all those issues at once, but that caused problems and had to be reverted. This time I want to make small improvements, one at a time.

In this PR, I improve the following:

Previously with the following Gemfile:

```ruby
source "https://source1" # doesn't include lib1 nor lib2

gem "lib1"

source "https://source2" do # includes lib1 and lib2
  gem "lib2"
end
```

bundler would resolve "fine" by pulling "lib1" from `https://source2`. I don't see how that would be expected. Bundler should look for "lib1" exclusively in the default source (`https://source1`) and print an error because the gem could not be found there. This PR fixes that issue.

## What is your fix for the problem, implemented in this PR?

The fix is to not use a "global merged source" that mixes all sources in the Gemfile for top-level dependencies. Instead, set the default source exclusively for them as one would expect. 

In addition to a spec for the fixed issue, I also added several specs to make sure that none of the refactorings I made here would make any of the previous issues in the bundler 2.2.10 release regress.

These changes were extracted from #4381, just to minimize the number of changes and try to introduce improvements one at a time.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
