### PR TITLE
Cherry-pick recent changelogs from stable branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 3.2.12 / 2021-03-01
+
+## Bug fixes:
+
+* Restore the ability to manually install extension gems. Pull request
+  #4384 by cfis
+
 # 3.2.11 / 2021-02-17
 
 ## Enhancements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 3.2.11 / 2021-02-17
+
+## Enhancements:
+
+* Optionally fallback to IPv4 when IPv6 is unreachable. Pull request #2662
+  by sonalkr132
+
 # 3.2.10 / 2021-02-15
 
 ## Documentation:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.2.11 (February 17, 2021)
+
+## Bug fixes:
+
+  - Revert disable_multisource changes [#4385](https://github.com/rubygems/rubygems/pull/4385)
+
 # 2.2.10 (February 15, 2021)
 
 ## Security fixes:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.2.12 (March 1, 2021)
+
+## Bug fixes:
+
+  - Fix sporadic warnings about `nil` gemspec on install/update and make those faster [#4409](https://github.com/rubygems/rubygems/pull/4409)
+  - Fix deployment install with duplicate path gems added to Gemfile [#4410](https://github.com/rubygems/rubygems/pull/4410)
+
 # 2.2.11 (February 17, 2021)
 
 ## Bug fixes:


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Just getting changelogs in sync with the stable branch.