### PR TITLE
Kill threads after we found a reachable host or timeout

### DIFF
--- a/lib/rubygems/core_ext/tcpsocket_init.rb
+++ b/lib/rubygems/core_ext/tcpsocket_init.rb
@@ -13,12 +13,13 @@ module CoreExtensions
       def initialize(host, serv, *rest)
         mutex = Mutex.new
         addrs = []
+        threads = []
         cond_var = ConditionVariable.new
 
         Addrinfo.foreach(host, serv, nil, :STREAM) do |addr|
           Thread.report_on_exception = false if defined? Thread.report_on_exception = ()
 
-          Thread.new(addr) do
+          threads << Thread.new(addr) do
             # give head start to ipv6 addresses
             sleep IPV4_DELAY_SECONDS if addr.ipv4?
 
@@ -39,6 +40,8 @@ module CoreExtensions
 
           host = addrs.shift unless addrs.empty?
         end
+
+        threads.each {|t| t.kill.join if t.alive? }
 
         super(host, serv, *rest)
       end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

Fixes following failing test on ruby:
```
Leaked thread: TestSocket_BasicSocket#test_close_read:
/Users/runner/work/ruby/ruby/src/lib/rubygems/core_ext/tcpsocket_init.rb:22
sleep>
2021-03-02T17:56:07.5713410Z Leaked thread:
TestSocket_BasicSocket#test_close_write: #<Thread:0x00007f99aae2f590
/Users/runner/work/ruby/ruby/src/lib/rubygems/core_ext/tcpsocket_init.rb:22
sleep>
2021-03-02T17:56:07.5813750Z Finished thread:
TestSocket_BasicSocket#test_for_fd: #<Thread:0x00007f99ab45c508
/Users/runner/work/ruby/ruby/src/lib/rubygems/core_ext/tcpsocket_init.rb:22
dead>
```
I tried running macos workflow for ruby on my fork, 1,2 and 5 are with this patch (passed) and 3,4 are without (failed). https://github.com/sonalkr132/ruby/actions

## What is your fix for the problem, implemented in this PR?

kills threads after we found a reachable host or timeout

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
