### PR TITLE
Changelogs for rubygems 3.2.13 and bundler 2.2.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.2.13 / 2021-03-03
+
+## Bug fixes:
+
+* Support non-gnu libc linux platforms. Pull request #4082 by lloeki
+
 # 3.2.12 / 2021-03-01
 
 ## Bug fixes:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 2.2.13 (March 3, 2021)
+
+## Enhancements:
+
+  - Respect user configured default branch in README links in new generated gems [#4303](https://github.com/rubygems/rubygems/pull/4303)
+
+## Bug fixes:
+
+  - Fix gems sometimes being pulled from irrelevant sources [#4418](https://github.com/rubygems/rubygems/pull/4418)
+
 # 2.2.12 (March 1, 2021)
 
 ## Bug fixes:


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Cherry-picking changelogs from the version I'm about to release into master.