### PR TITLE
Make `rake` available to other gems' installers right after it's installed

### DIFF
--- a/bundler/lib/bundler/installer/parallel_installer.rb
+++ b/bundler/lib/bundler/installer/parallel_installer.rb
@@ -88,6 +88,11 @@ module Bundler
     def call
       check_for_corrupt_lockfile
 
+      if @rake
+        do_install(@rake, 0)
+        Gem::Specification.reset
+      end
+
       if @size > 1
         install_with_worker
       else
@@ -212,8 +217,6 @@ module Bundler
     # are installed.
     def enqueue_specs
       @specs.select(&:ready_to_enqueue?).each do |spec|
-        next if @rake && !@rake.installed? && spec.name != @rake.name
-
         if spec.dependencies_installed? @specs
           spec.state = :enqueued
           worker_pool.enq spec

--- a/bundler/lib/bundler/installer/parallel_installer.rb
+++ b/bundler/lib/bundler/installer/parallel_installer.rb
@@ -27,13 +27,8 @@ module Bundler
         state == :failed
       end
 
-      def installation_attempted?
-        installed? || failed?
-      end
-
-      # Only true when spec in neither installed nor already enqueued
       def ready_to_enqueue?
-        !enqueued? && !installation_attempted?
+        state == :none
       end
 
       def has_post_install_message?

--- a/bundler/spec/install/gems/resolving_spec.rb
+++ b/bundler/spec/install/gems/resolving_spec.rb
@@ -81,6 +81,25 @@ RSpec.describe "bundle install with install-time dependencies" do
     expect(out).to eq("YES\nYES")
   end
 
+  it "installs gems with implicit rake dependencies without rake previously installed" do
+    with_path_as("") do
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "with_implicit_rake_dep"
+        gem "another_implicit_rake_dep"
+        gem "rake"
+      G
+    end
+
+    run <<-R
+      require 'implicit_rake_dep'
+      require 'another_implicit_rake_dep'
+      puts IMPLICIT_RAKE_DEP
+      puts ANOTHER_IMPLICIT_RAKE_DEP
+    R
+    expect(out).to eq("YES\nYES")
+  end
+
   it "installs gems with a dependency with no type" do
     skip "incorrect data check error" if Gem.win_platform?
 

--- a/bundler/spec/install/gems/resolving_spec.rb
+++ b/bundler/spec/install/gems/resolving_spec.rb
@@ -3,6 +3,32 @@
 RSpec.describe "bundle install with install-time dependencies" do
   before do
     build_repo2 do
+      build_gem "with_implicit_rake_dep" do |s|
+        s.extensions << "Rakefile"
+        s.write "Rakefile", <<-RUBY
+          task :default do
+            path = File.expand_path("../lib", __FILE__)
+            FileUtils.mkdir_p(path)
+            File.open("\#{path}/implicit_rake_dep.rb", "w") do |f|
+              f.puts "IMPLICIT_RAKE_DEP = 'YES'"
+            end
+          end
+        RUBY
+      end
+
+      build_gem "another_implicit_rake_dep" do |s|
+        s.extensions << "Rakefile"
+        s.write "Rakefile", <<-RUBY
+          task :default do
+            path = File.expand_path("../lib", __FILE__)
+            FileUtils.mkdir_p(path)
+            File.open("\#{path}/another_implicit_rake_dep.rb", "w") do |f|
+              f.puts "ANOTHER_IMPLICIT_RAKE_DEP = 'YES'"
+            end
+          end
+        RUBY
+      end
+
       # Test complicated gem dependencies for install
       build_gem "net_a" do |s|
         s.add_dependency "net_b"

--- a/bundler/spec/install/gems/sudo_spec.rb
+++ b/bundler/spec/install/gems/sudo_spec.rb
@@ -49,8 +49,23 @@ RSpec.describe "when using sudo", :sudo => true do
     end
 
     it "installs rake and a gem dependent on rake in the same session" do
+      build_repo2 do
+        build_gem "another_implicit_rake_dep" do |s|
+          s.extensions << "Rakefile"
+          s.write "Rakefile", <<-RUBY
+            task :default do
+              path = File.expand_path("../lib", __FILE__)
+              FileUtils.mkdir_p(path)
+              File.open("\#{path}/another_implicit_rake_dep.rb", "w") do |f|
+                f.puts "ANOTHER_IMPLICIT_RAKE_DEP = 'YES'"
+              end
+            end
+          RUBY
+        end
+      end
+
       gemfile <<-G
-          source "#{file_uri_for(gem_repo1)}"
+          source "#{file_uri_for(gem_repo2)}"
           gem "rake"
           gem "another_implicit_rake_dep"
       G

--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -90,6 +90,8 @@ RSpec.configure do |config|
   end
 
   config.before :all do
+    check_test_gems!
+
     build_repo1
 
     reset_paths!

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -154,32 +154,6 @@ module Spec
 
         build_gem "duradura", "7.0"
 
-        build_gem "with_implicit_rake_dep" do |s|
-          s.extensions << "Rakefile"
-          s.write "Rakefile", <<-RUBY
-            task :default do
-              path = File.expand_path("../lib", __FILE__)
-              FileUtils.mkdir_p(path)
-              File.open("\#{path}/implicit_rake_dep.rb", "w") do |f|
-                f.puts "IMPLICIT_RAKE_DEP = 'YES'"
-              end
-            end
-          RUBY
-        end
-
-        build_gem "another_implicit_rake_dep" do |s|
-          s.extensions << "Rakefile"
-          s.write "Rakefile", <<-RUBY
-            task :default do
-              path = File.expand_path("../lib", __FILE__)
-              FileUtils.mkdir_p(path)
-              File.open("\#{path}/another_implicit_rake_dep.rb", "w") do |f|
-                f.puts "ANOTHER_IMPLICIT_RAKE_DEP = 'YES'"
-              end
-            end
-          RUBY
-        end
-
         build_gem "very_simple_binary", &:add_c_extension
         build_gem "simple_binary", &:add_c_extension
 

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -255,6 +255,15 @@ module Spec
 
     def build_repo(path, &blk)
       return if File.directory?(path)
+
+      rake_path = Dir["#{Path.base_system_gems}/**/rake*.gem"].first
+      FileUtils.mkdir_p("#{path}/gems")
+      FileUtils.cp rake_path, "#{path}/gems/"
+
+      update_repo(path, &blk)
+    end
+
+    def check_test_gems!
       rake_path = Dir["#{Path.base_system_gems}/**/rake*.gem"].first
 
       if rake_path.nil?
@@ -263,14 +272,9 @@ module Spec
         rake_path = Dir["#{Path.base_system_gems}/**/rake*.gem"].first
       end
 
-      if rake_path
-        FileUtils.mkdir_p("#{path}/gems")
-        FileUtils.cp rake_path, "#{path}/gems/"
-      else
+      if rake_path.nil?
         abort "Your test gems are missing! Run `rm -rf #{tmp}` and try again."
       end
-
-      update_repo(path, &blk)
     end
 
     def update_repo(path)

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -30,7 +30,11 @@ module Spec
     end
 
     def build_repo1
+      rake_path = Dir["#{Path.base_system_gems}/**/rake*.gem"].first
+
       build_repo gem_repo1 do
+        FileUtils.cp rake_path, "#{gem_repo1}/gems/"
+
         build_gem "rack", %w[0.9.1 1.0.0] do |s|
           s.executables = "rackup"
           s.post_install_message = "Rack's post install message"
@@ -256,9 +260,7 @@ module Spec
     def build_repo(path, &blk)
       return if File.directory?(path)
 
-      rake_path = Dir["#{Path.base_system_gems}/**/rake*.gem"].first
       FileUtils.mkdir_p("#{path}/gems")
-      FileUtils.cp rake_path, "#{path}/gems/"
 
       update_repo(path, &blk)
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In #4409 I stopped calling `Gem::Specification.reset` after each gem is installed in parallel, since that changes shared state and resulted in race conditions when installing specs. Instead, we started calling it after all gems are installed, so that the gem specification cache is reset, and the gems just installed are immediately available after that.

That works fine, except for `rake`, which needs to be made available immediately after it's installed, so that other gems shipping with rake extensions can use it to install their extensions.

## What is your fix for the problem, implemented in this PR?

My fix is to manually install rake first if present, and call `Gem::Specification.reset` after that.

Fixes #4427.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
