### PR TITLE
Remove require test for ipv4_fallback_enabled

### DIFF
--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -962,12 +962,6 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     end
   end
 
-  def test_tcpsocketext_require
-    with_configured_fetcher(":ipv4_fallback_enabled: true") do |fetcher|
-      refute require('rubygems/core_ext/tcpsocket_init')
-    end
-  end
-
   def with_configured_fetcher(config_str = nil, &block)
     if config_str
       temp_conf = File.join @tempdir, '.gemrc'


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

Fixes timeout of test suites on the ruby.

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

Remove the test which was overriding `TCPSocket.initialize`. The same patching passing all test on my fork https://github.com/sonalkr132/ruby/commit/d34a8bf126857ac2bb1ecbacb4e062c9bb8d0e9b

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
