### PR TITLE
Revert addition of support for `musl` variants

### DIFF
--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -66,7 +66,7 @@ class Gem::Platform
     when String then
       arch = arch.split '-'
 
-      if arch.length > 2 and arch.last !~ /\d+(\.\d+)?$/ # reassemble x86-linux-{libc}
+      if arch.length > 2 and arch.last !~ /\d/ # reassemble x86-linux-gnu
         extra = arch.pop
         arch.last << "-#{extra}"
       end
@@ -146,8 +146,7 @@ class Gem::Platform
   ##
   # Does +other+ match this platform?  Two platforms match if they have the
   # same CPU, or either has a CPU of 'universal', they have the same OS, and
-  # they have the same version, or either has no version (except for 'linux'
-  # where the version is the libc name, with no version standing for 'gnu')
+  # they have the same version, or either has no version.
   #
   # Additionally, the platform will match if the local CPU is 'arm' and the
   # other CPU starts with "arm" (for generic ARM family support).
@@ -163,10 +162,7 @@ class Gem::Platform
     @os == other.os and
 
     # version
-    (
-      (@os != 'linux' and (@version.nil? or other.version.nil?)) or
-      @version == other.version
-    )
+    (@version.nil? or other.version.nil? or @version == other.version)
   end
 
   ##

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -134,9 +134,7 @@ class TestGemPlatform < Gem::TestCase
       'i386-solaris2.8'        => ['x86',       'solaris',   '2.8'],
       'mswin32'                => ['x86',       'mswin32',   nil],
       'x86_64-linux'           => ['x86_64',    'linux',     nil],
-      'x86_64-linux-gnu'       => ['x86_64',    'linux',     nil],
       'x86_64-linux-musl'      => ['x86_64',    'linux',     'musl'],
-      'x86_64-linux-uclibc'    => ['x86_64',    'linux',     'uclibc'],
       'x86_64-openbsd3.9'      => ['x86_64',    'openbsd',   '3.9'],
       'x86_64-openbsd4.0'      => ['x86_64',    'openbsd',   '4.0'],
       'x86_64-openbsd'         => ['x86_64',    'openbsd',   nil],
@@ -145,7 +143,6 @@ class TestGemPlatform < Gem::TestCase
     test_cases.each do |arch, expected|
       platform = Gem::Platform.new arch
       assert_equal expected, platform.to_a, arch.inspect
-      assert_equal expected, Gem::Platform.new(platform.to_s).to_a, arch.inspect
     end
   end
 
@@ -262,32 +259,6 @@ class TestGemPlatform < Gem::TestCase
     assert((with_uni_arch === with_nil_arch), 'universal =~ nil')
     assert((with_nil_arch === with_x86_arch), 'nil =~ x86')
     assert((with_x86_arch === with_nil_arch), 'x86 =~ nil')
-  end
-
-  def test_nil_version_is_treated_as_any_version
-    x86_darwin_8 = Gem::Platform.new 'i686-darwin8.0'
-    x86_darwin_nil = Gem::Platform.new 'i686-darwin'
-
-    assert((x86_darwin_8 === x86_darwin_nil), '8.0 =~ nil')
-    assert((x86_darwin_nil === x86_darwin_8), 'nil =~ 8.0')
-  end
-
-  def test_nil_version_is_stricter_for_linux_os
-    x86_linux = Gem::Platform.new 'i686-linux'
-    x86_linux_gnu = Gem::Platform.new 'i686-linux-gnu'
-    x86_linux_musl = Gem::Platform.new 'i686-linux-musl'
-    x86_linux_uclibc = Gem::Platform.new 'i686-linux-uclibc'
-
-    assert((x86_linux === x86_linux_gnu), 'linux =~ linux-gnu')
-    assert((x86_linux_gnu === x86_linux), 'linux-gnu =~ linux')
-    assert(!(x86_linux_gnu === x86_linux_musl), 'linux-gnu =~ linux-musl')
-    assert(!(x86_linux_musl === x86_linux_gnu), 'linux-musl =~ linux-gnu')
-    assert(!(x86_linux_uclibc === x86_linux_musl), 'linux-uclibc =~ linux-musl')
-    assert(!(x86_linux_musl === x86_linux_uclibc), 'linux-musl =~ linux-uclibc')
-    assert(!(x86_linux === x86_linux_musl), 'linux =~ linux-musl')
-    assert(!(x86_linux_musl === x86_linux), 'linux-musl =~ linux')
-    assert(!(x86_linux === x86_linux_uclibc), 'linux =~ linux-uclibc')
-    assert(!(x86_linux_uclibc === x86_linux), 'linux-uclibc =~ linux')
   end
 
   def test_equals3_cpu_arm


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Adding support for non-gnu libc linux platforms caused issues for gems where the gnu variant was working just fine.  

## What is your fix for the problem, implemented in this PR?

For now this reverts commit ce4e3f5ff83a13e8d1d510cfc49f764e9e6e4b1f, reversing changes made to 8a712a0dd52e661ea973845b70681da09ce75edd.

We plan to introduce this improvement, but with a better fallback behavior where `linux-musl` variants are never installed on standard linux, and `linux` variants are picked up as a fallback on Alpine.

Closes #4425.
Reopens #3174.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
