### PR TITLE
Changelogs for rubygems 3.2.14 and bundler 2.2.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 3.2.14 / 2021-03-08
+
+## Enhancements:
+
+* Less wrapping of network errors. Pull request #4064 by deivid-rodriguez
+
+## Bug fixes:
+
+* Revert addition of support for `musl` variants to restore graceful
+  fallback on Alpine. Pull request #4434 by deivid-rodriguez
+
 # 3.2.13 / 2021-03-03
 
 ## Bug fixes:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 2.2.14 (March 8, 2021)
+
+## Security fixes:
+
+  - Lock GEM sources separately and fix locally installed specs confusing bundler [#4381](https://github.com/rubygems/rubygems/pull/4381)
+
+## Bug fixes:
+
+  - Make `rake` available to other gems' installers right after it's installed [#4428](https://github.com/rubygems/rubygems/pull/4428)
+  - Fix encoding issue on compact index updater [#4362](https://github.com/rubygems/rubygems/pull/4362)
+
 # 2.2.13 (March 3, 2021)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking changelogs from the version I'm about to release into master.
