### PR TITLE
[WIP] Run tests with `--disable-gems`

### DIFF
--- a/.github/workflows/ubuntu-rubygems.yml
+++ b/.github/workflows/ubuntu-rubygems.yml
@@ -36,6 +36,11 @@ jobs:
       - name: Run Test
         run: rake test
         if: "!startsWith(matrix.ruby.name, 'truffleruby') && !startsWith(matrix.ruby.name, 'jruby')"
+      - name: Run Test (--disable-gems)
+        env:
+          RUBYOPT: --disable-gems
+        run: rake test
+        if: "!startsWith(matrix.ruby.name, 'truffleruby') && !startsWith(matrix.ruby.name, 'jruby')"
       - name: Run Test (JRuby)
         run: JRUBY_OPTS=--debug rake test
         if: startsWith(matrix.ruby.name, 'jruby')


### PR DESCRIPTION
This PR is related to discussion in #4429. It makes the test suite execute with `--disable-gems` option. This should help to reduce the initial footprint of loaded libraries and reduce the risk of inadvertently testing system RubyGems instead of upstream version.