### PR TITLE
Respect running ruby when resolving platforms

### DIFF
--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -73,7 +73,12 @@ module Bundler
         same_platform_candidates = candidates.select do |spec|
           MatchPlatform.platforms_match?(spec.platform, platform_object)
         end
-        search = same_platform_candidates.last
+        installable_candidates = same_platform_candidates.select do |spec|
+          !spec.is_a?(RemoteSpecification) &&
+            spec.required_ruby_version.satisfied_by?(Gem.ruby_version) &&
+            spec.required_rubygems_version.satisfied_by?(Gem.rubygems_version)
+        end
+        search = installable_candidates.last || same_platform_candidates.last
         search.dependencies = dependencies if search && (search.is_a?(RemoteSpecification) || search.is_a?(EndpointSpecification))
         search
       end

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -73,7 +73,7 @@ module Bundler
         same_platform_candidates = candidates.select do |spec|
           MatchPlatform.platforms_match?(spec.platform, platform_object)
         end
-        search = same_platform_candidates.last || candidates.last
+        search = same_platform_candidates.last
         search.dependencies = dependencies if search && (search.is_a?(RemoteSpecification) || search.is_a?(EndpointSpecification))
         search
       end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If the lockfile is only locked to RUBY, we take that as a sign that it was either generated with an old version that didn't lock platforms, or that the user is intentionally not locking platforms. That means we need to run in "legacy mode" and do platform resolution "lazily" at materialization time.

This late resolution does not consider metadata requirements, so it can happen that bundler chooses a platform specific variant not compatible with the running ruby, when the pure ruby platform is.

## What is your fix for the problem, implemented in this PR?

To fix the issue, we need to consider metadata requirements in this late resolution step.

Unfortunately, if running in the "new mode" with a lockfile including specific platforms, this late resolution step doesn't happen and only information from the lockfile is used, and there's no lazy platform resolution at all. So to fix this issue in that
case we'll need to include metadata requirements in the lockfile. But that's for another time.

Fixes #4282.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
