### PR TITLE
Don't generate duplicate redundant sources in the lockfile

### DIFF
--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -88,7 +88,7 @@ module Bundler
     def lock_sources
       lock_sources = (path_sources + git_sources + plugin_sources).sort_by(&:to_s)
       if disable_multisource?
-        lock_sources + rubygems_sources.sort_by(&:to_s)
+        lock_sources + rubygems_sources.sort_by(&:to_s).uniq
       else
         lock_sources << combine_rubygems_sources
       end

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -641,6 +641,30 @@ RSpec.describe "the lockfile format" do
     G
   end
 
+  it "removes redundant sources" do
+    install_gemfile <<-G
+      source "#{file_uri_for(gem_repo2)}/"
+
+      gem "rack", :source => "#{file_uri_for(gem_repo2)}/"
+    G
+
+    lockfile_should_be <<-G
+      GEM
+        remote: #{file_uri_for(gem_repo2)}/
+        specs:
+          rack (1.0.0)
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        rack!
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    G
+  end
+
   it "lists gems alphabetically" do
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}/"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since we lock separate rubygems sources in the lockfile, it can happen that we generate duplicate redundant sources. It doesn't seem to cause specific issues, but it makes the lockfile harder to review.

## What is your fix for the problem, implemented in this PR?

Avoid this by adding a `uniq` call when generating the rubyems source list to use for writing the lockfile.

Fixes #4448.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
