### PR TITLE
Prevent downgrades to untested rubygems versions

### DIFF
--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -81,7 +81,7 @@ command to remove old versions.
 
   def check_oldest_rubygems(version) # :nodoc:
     if oldest_supported_version > version
-      alert_error "rubygems #{version} is not supported. The oldest supported version is #{oldest_supported_version}"
+      alert_error "rubygems #{version} is not supported on #{RUBY_VERSION}. The oldest version supported by this ruby is #{oldest_supported_version}"
       terminate_interaction 1
     end
   end
@@ -327,8 +327,26 @@ command to remove old versions.
 
   private
 
+  #
+  # Oldest version we support downgrading to. This is the version that
+  # originally ships with the first patch version of each ruby, because we never
+  # test each ruby against older rubygems, so we can't really guarantee it
+  # works. Version list can be checked here: https://stdgems.org/rubygems
+  #
   def oldest_supported_version
-    # for Ruby 2.3
-    @oldest_supported_version ||= Gem::Version.new("2.5.2")
+    @oldest_supported_version ||=
+      if Gem.ruby_version > Gem::Version.new("3.0.a")
+        Gem::Version.new("3.2.3")
+      elsif Gem.ruby_version > Gem::Version.new("2.7.a")
+        Gem::Version.new("3.1.2")
+      elsif Gem.ruby_version > Gem::Version.new("2.6.a")
+        Gem::Version.new("3.0.1")
+      elsif Gem.ruby_version > Gem::Version.new("2.5.a")
+        Gem::Version.new("2.7.3")
+      elsif Gem.ruby_version > Gem::Version.new("2.4.a")
+        Gem::Version.new("2.6.8")
+      else
+        Gem::Version.new("2.5.2")
+      end
   end
 end

--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -168,6 +168,15 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
     @cmd.options[:args]          = []
     @cmd.options[:system]        = "2.5.1"
 
+    oldest_version_mod = Module.new do
+      def oldest_supported_version
+        Gem::Version.new("2.5.2")
+      end
+      private :oldest_supported_version
+    end
+
+    @cmd.extend(oldest_version_mod)
+
     assert_raises Gem::MockGemUi::TermError do
       use_ui @ui do
         @cmd.execute
@@ -175,7 +184,7 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
     end
 
     assert_empty @ui.output
-    assert_equal "ERROR:  rubygems 2.5.1 is not supported. The oldest supported version is 2.5.2\n", @ui.error
+    assert_equal "ERROR:  rubygems 2.5.1 is not supported on #{RUBY_VERSION}. The oldest version supported by this ruby is 2.5.2\n", @ui.error
   end
 
   def test_execute_system_specific_older_than_3_2_removes_plugins_dir
@@ -184,6 +193,15 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
         s.files = %w[setup.rb]
       end
     end
+
+    oldest_version_mod = Module.new do
+      def oldest_supported_version
+        Gem::Version.new("2.5.2")
+      end
+      private :oldest_supported_version
+    end
+
+    @cmd.extend(oldest_version_mod)
 
     @cmd.options[:args]          = []
     @cmd.options[:system]        = "3.1"
@@ -202,6 +220,15 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
         s.files = %w[setup.rb]
       end
     end
+
+    oldest_version_mod = Module.new do
+      def oldest_supported_version
+        Gem::Version.new("2.5.2")
+      end
+      private :oldest_supported_version
+    end
+
+    @cmd.extend(oldest_version_mod)
 
     @cmd.options[:args]          = []
     @cmd.options[:system]        = "3.2.a"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Downgrading rubygems can actually make your ruby installation no longer usable.

## What is your fix for the problem, implemented in this PR?

My fix is to prevent downgrading to ruby-rubygems combinations that are never tested.

Fixes #4397.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
