### PR TITLE
Add a hint about bundler installing executables for path gems

### DIFF
--- a/bundler/lib/bundler/source/path.rb
+++ b/bundler/lib/bundler/source/path.rb
@@ -82,7 +82,9 @@ module Bundler
       end
 
       def install(spec, options = {})
-        print_using_message "Using #{version_message(spec)} from #{self}"
+        using_message = "Using #{version_message(spec)} from #{self}"
+        using_message += " and installing its executables" unless spec.executables.empty?
+        print_using_message using_message
         generate_bin(spec, :disable_extensions => true)
         nil # no post-install message
       end

--- a/bundler/lib/bundler/source/path/installer.rb
+++ b/bundler/lib/bundler/source/path/installer.rb
@@ -35,7 +35,7 @@ module Bundler
             run_hooks(:post_build)
           end
 
-          generate_bin unless spec.executables.nil? || spec.executables.empty?
+          generate_bin unless spec.executables.empty?
 
           run_hooks(:post_install)
         ensure

--- a/bundler/spec/install/gemfile/path_spec.rb
+++ b/bundler/spec/install/gemfile/path_spec.rb
@@ -328,11 +328,12 @@ RSpec.describe "bundle install with explicit source paths" do
       s.executables = "foobar"
     end
 
-    install_gemfile <<-G
+    install_gemfile <<-G, :verbose => true
       path "#{lib_path("foo-1.0")}" do
         gem 'foo'
       end
     G
+    expect(out).to include("Using foo 1.0 from source at `#{lib_path("foo-1.0")}` and installing its executables")
     expect(the_bundle).to include_gems "foo 1.0"
 
     bundle "exec foobar"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Bundler actually installs executables for path gems, but this is non obvious and can be confusing.

## What is your fix for the problem, implemented in this PR?

Add a hint during `bundle install` about this behaviour.

Closes https://github.com/rubygems/rubygems/issues/3286.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
