### PR TITLE
Filter outdated gems to the current version of Ruby

### DIFF
--- a/bundler/lib/bundler/cli/outdated.rb
+++ b/bundler/lib/bundler/cli/outdated.rb
@@ -153,6 +153,12 @@ module Bundler
         if !current_spec.version.prerelease? && !options[:pre] && active_specs.size > 1
           active_specs.delete_if {|b| b.respond_to?(:version) && b.version.prerelease? }
         end
+
+        active_specs.delete_if do |spec|
+          spec.respond_to?(:required_ruby_version) &&
+            !spec.required_ruby_version.satisfied_by?(Gem.ruby_version)
+        end
+
         active_spec = active_specs.last
       end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Previously, `bundle outdated` would show the latest version of a gem, but it didn't check whether this gem could be used in the current version of Ruby. This resulted in some false-positives.

## What is your fix for the problem, implemented in this PR?

This PR filters out those gems that cannot be used on the current version of Ruby.

It's not foolproof, however, because we're only checking the requirements of the gem and not its dependencies. This means that we may still show versions that couldn't be installed on this version of Ruby. For example, the `factory_bot_rails` gem doesn't specify a required Ruby version, even though its dependency `factory_bot` specifies one.

## Is there more work to be done?

I didn't know how to write a test for this feature. Specifically, I didn't know how to adapt the code in `outdated_spec` to add a dependency that requires a specific version of Ruby. I'd appreciate your help with this.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
