### PR TITLE
Fix git source cache being used as the install location 

### DIFF
--- a/bundler/lib/bundler/plugin/api/source.rb
+++ b/bundler/lib/bundler/plugin/api/source.rb
@@ -196,6 +196,7 @@ module Bundler
 
           FileUtils.rm_rf(new_cache_path)
           FileUtils.cp_r(install_path, new_cache_path)
+          FileUtils.rm_rf(app_cache_path.join(".git"))
           FileUtils.touch(app_cache_path.join(".bundlecache"))
         end
 

--- a/bundler/lib/bundler/runtime.rb
+++ b/bundler/lib/bundler/runtime.rb
@@ -140,7 +140,6 @@ module Bundler
       end
 
       Dir[cache_path.join("*/.git")].each do |git_dir|
-        FileUtils.rm_rf(git_dir)
         FileUtils.touch(File.expand_path("../.bundlecache", git_dir))
       end
 

--- a/bundler/lib/bundler/runtime.rb
+++ b/bundler/lib/bundler/runtime.rb
@@ -139,10 +139,6 @@ module Bundler
         spec.source.cache(spec, custom_path) if spec.source.respond_to?(:cache)
       end
 
-      Dir[cache_path.join("*/.git")].each do |git_dir|
-        FileUtils.touch(File.expand_path("../.bundlecache", git_dir))
-      end
-
       prune_cache(cache_path) unless Bundler.settings[:no_prune]
     end
 

--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -222,7 +222,8 @@ module Bundler
         cached!
         FileUtils.rm_rf(app_cache_path)
         git_proxy.checkout if requires_checkout?
-        git_proxy.copy_to(app_cache_path, @submodules)
+        FileUtils.cp_r("#{cache_path}/.", app_cache_path)
+        FileUtils.touch(app_cache_path.join(".bundlecache"))
       end
 
       def load_spec_files

--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -164,7 +164,8 @@ module Bundler
             "does not exist. Run `bundle config unset local.#{override_for(original_path)}` to remove the local override"
         end
 
-        set_local!(path)
+        @local = true
+        set_paths!(path)
 
         # Create a new git proxy without the cached revision
         # so the Gemfile.lock always picks up the new revision.
@@ -187,7 +188,7 @@ module Bundler
       end
 
       def specs(*)
-        set_local!(app_cache_path) if has_app_cache? && !local?
+        set_paths!(app_cache_path) if has_app_cache? && !local?
 
         if requires_checkout? && !@copied
           fetch
@@ -300,8 +301,7 @@ module Bundler
         end
       end
 
-      def set_local!(path)
-        @local       = true
+      def set_paths!(path)
         @local_specs = @git_proxy = nil
         @cache_path  = @install_path = path
       end

--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -188,7 +188,7 @@ module Bundler
       end
 
       def specs(*)
-        set_paths!(app_cache_path) if has_app_cache? && !local?
+        set_cache_path!(app_cache_path) if has_app_cache? && !local?
 
         if requires_checkout? && !@copied
           fetch
@@ -218,6 +218,7 @@ module Bundler
         app_cache_path = app_cache_path(custom_path)
         return unless Bundler.feature_flag.cache_all?
         return if install_path == app_cache_path
+        return if cache_path == app_cache_path
         cached!
         FileUtils.rm_rf(app_cache_path)
         git_proxy.checkout if requires_checkout?

--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -223,7 +223,6 @@ module Bundler
         FileUtils.rm_rf(app_cache_path)
         git_proxy.checkout if requires_checkout?
         git_proxy.copy_to(app_cache_path, @submodules)
-        serialize_gemspecs_in(app_cache_path)
       end
 
       def load_spec_files

--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -191,6 +191,7 @@ module Bundler
 
         if requires_checkout? && !@copied
           fetch
+          Bundler.ui.debug "  * Checking out revision: #{ref}"
           git_proxy.copy_to(install_path, submodules)
           serialize_gemspecs_in(install_path)
           @copied = true

--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -191,10 +191,7 @@ module Bundler
 
         if requires_checkout? && !@copied
           fetch
-          Bundler.ui.debug "  * Checking out revision: #{ref}"
-          git_proxy.copy_to(install_path, submodules)
-          serialize_gemspecs_in(install_path)
-          @copied = true
+          checkout
         end
 
         local_specs
@@ -207,10 +204,7 @@ module Bundler
         print_using_message "Using #{version_message(spec, options[:previous_spec])} from #{self}"
 
         if (requires_checkout? && !@copied) || force
-          Bundler.ui.debug "  * Checking out revision: #{ref}"
-          git_proxy.copy_to(install_path, submodules)
-          serialize_gemspecs_in(install_path)
-          @copied = true
+          checkout
         end
 
         generate_bin_options = { disable_extensions: !Bundler.rubygems.spec_missing_extensions?(spec), build_args: options[:build_args] }
@@ -270,6 +264,13 @@ module Bundler
       end
 
       private
+
+      def checkout
+        Bundler.ui.debug "  * Checking out revision: #{ref}"
+        git_proxy.copy_to(install_path, submodules)
+        serialize_gemspecs_in(install_path)
+        @copied = true
+      end
 
       def humanized_ref
         if local?

--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -302,8 +302,18 @@ module Bundler
       end
 
       def set_paths!(path)
-        @local_specs = @git_proxy = nil
-        @cache_path  = @install_path = path
+        set_cache_path!(path)
+        set_install_path!(path)
+      end
+
+      def set_cache_path!(path)
+        @git_proxy = nil
+        @cache_path = path
+      end
+
+      def set_install_path!(path)
+        @local_specs = nil
+        @install_path = path
       end
 
       def has_app_cache?

--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -216,7 +216,7 @@ module Bundler
       def cache(spec, custom_path = nil)
         app_cache_path = app_cache_path(custom_path)
         return unless Bundler.feature_flag.cache_all?
-        return if path == app_cache_path
+        return if install_path == app_cache_path
         cached!
         FileUtils.rm_rf(app_cache_path)
         git_proxy.checkout if requires_checkout?

--- a/bundler/spec/cache/git_spec.rb
+++ b/bundler/spec/cache/git_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe "bundle cache with git" do
     bundle "config set cache_all true"
     bundle :cache
     expect(bundled_app("vendor/cache/foo-1.0-#{ref}")).to exist
-    expect(bundled_app("vendor/cache/foo-1.0-#{ref}/.git")).not_to exist
     expect(bundled_app("vendor/cache/foo-1.0-#{ref}/.bundlecache")).to be_file
 
     FileUtils.rm_rf lib_path("foo-1.0")
@@ -47,7 +46,6 @@ RSpec.describe "bundle cache with git" do
     bundle :cache
 
     expect(bundled_app("vendor/cache/foo-1.0-#{ref}")).to exist
-    expect(bundled_app("vendor/cache/foo-1.0-#{ref}/.git")).not_to exist
 
     FileUtils.rm_rf lib_path("foo-1.0")
     expect(the_bundle).to include_gems "foo 1.0"

--- a/bundler/spec/cache/git_spec.rb
+++ b/bundler/spec/cache/git_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe "bundle cache with git" do
     bundle "config set cache_all true"
     bundle :cache
     expect(bundled_app("vendor/cache/foo-1.0-#{ref}")).to exist
+    expect(bundled_app("vendor/cache/foo-1.0-#{ref}/.git")).not_to exist
     expect(bundled_app("vendor/cache/foo-1.0-#{ref}/.bundlecache")).to be_file
 
     FileUtils.rm_rf lib_path("foo-1.0")
@@ -46,6 +47,7 @@ RSpec.describe "bundle cache with git" do
     bundle :cache
 
     expect(bundled_app("vendor/cache/foo-1.0-#{ref}")).to exist
+    expect(bundled_app("vendor/cache/foo-1.0-#{ref}/.git")).not_to exist
 
     FileUtils.rm_rf lib_path("foo-1.0")
     expect(the_bundle).to include_gems "foo 1.0"
@@ -209,7 +211,7 @@ RSpec.describe "bundle cache with git" do
     expect(the_bundle).to include_gem "foo 1.0"
   end
 
-  it "copies repository to vendor cache, including submodules" do
+  it "copies repository to vendor cache" do
     # CVE-2022-39253: https://lore.kernel.org/lkml/xmqq4jw1uku5.fsf@gitster.g/
     system(*%W[git config --global protocol.file.allow always])
 
@@ -234,7 +236,6 @@ RSpec.describe "bundle cache with git" do
     bundle :cache
 
     expect(bundled_app("vendor/cache/has_submodule-1.0-#{ref}")).to exist
-    expect(bundled_app("vendor/cache/has_submodule-1.0-#{ref}/submodule-1.0")).to exist
     expect(the_bundle).to include_gems "has_submodule 1.0"
   end
 

--- a/bundler/spec/cache/git_spec.rb
+++ b/bundler/spec/cache/git_spec.rb
@@ -238,26 +238,6 @@ RSpec.describe "bundle cache with git" do
     expect(the_bundle).to include_gems "has_submodule 1.0"
   end
 
-  it "caches pre-evaluated gemspecs" do
-    git = build_git "foo"
-
-    # Insert a gemspec method that shells out
-    spec_lines = lib_path("foo-1.0/foo.gemspec").read.split("\n")
-    spec_lines.insert(-2, "s.description = `echo bob`")
-    update_git("foo") {|s| s.write "foo.gemspec", spec_lines.join("\n") }
-
-    install_gemfile <<-G
-      source "https://gem.repo1"
-      gem "foo", :git => '#{lib_path("foo-1.0")}'
-    G
-    bundle "config set cache_all true"
-    bundle :cache
-
-    ref = git.ref_for("main", 11)
-    gemspec = bundled_app("vendor/cache/foo-1.0-#{ref}/foo.gemspec").read
-    expect(gemspec).to_not match("`echo bob`")
-  end
-
   it "can install after bundle cache with git not installed" do
     build_git "foo"
 

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -1549,7 +1549,7 @@ In Gemfile:
         to include("You need to install git to be able to use gems from git repositories. For help installing git, please refer to GitHub's tutorial at https://help.github.com/articles/set-up-git")
     end
 
-    it "installs a packaged git gem successfully" do
+    it "doesn't need git in the new machine if an installed git gem is copied to another machine" do
       build_git "foo"
 
       install_gemfile <<-G
@@ -1558,8 +1558,8 @@ In Gemfile:
           gem 'foo'
         end
       G
-      bundle "config set cache_all true"
-      bundle :cache
+      bundle "config set --global path vendor/bundle"
+      bundle :install
       simulate_new_machine
 
       bundle "install", env: { "PATH" => "" }


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Bundler app-cache of git gems behaving unexpectedly.

## What is your fix for the problem, implemented in this PR?

Make cache for git gems behave like a proper cache. This means that now git gems are properly installed in presence of a project gem cache (for example, extension gems get properly compiled). Since the cache now acts as a cache, we no longer need to keep full clones in cache and a bare clone is enough.

Fixes #3204.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
