### PR TITLE
Changelogs for rubygems 3.2.15 and bundler 2.2.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 3.2.15 / 2021-03-19
+
+## Enhancements:
+
+* Prevent downgrades to untested rubygems versions. Pull request #4460 by
+  deivid-rodriguez
+
+## Bug fixes:
+
+* Fix missing require breaking `gem cert`. Pull request #4464 by lukehinds
+
 # 3.2.14 / 2021-03-08
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 2.2.15 (March 19, 2021)
+
+## Enhancements:
+
+  - Add a hint about bundler installing executables for path gems [#4461](https://github.com/rubygems/rubygems/pull/4461)
+  - Warn lockfiles with incorrect resolutions [#4459](https://github.com/rubygems/rubygems/pull/4459)
+  - Don't generate duplicate redundant sources in the lockfile [#4456](https://github.com/rubygems/rubygems/pull/4456)
+
+## Bug fixes:
+
+  - Respect running ruby when resolving platforms [#4449](https://github.com/rubygems/rubygems/pull/4449)
+
 # 2.2.14 (March 8, 2021)
 
 ## Security fixes:


### PR DESCRIPTION
Cherry-picking changelogs from the version I'm about to release into master.
