### PR TITLE
Cherry pick changelogs when preparing branches

### DIFF
--- a/util/release.rb
+++ b/util/release.rb
@@ -170,8 +170,8 @@ class Release
       @rubygems.bump_versions!
       system("git", "commit", "-am", "Bump Rubygems version to #{@rubygems.version}", exception: true)
     rescue StandardError
-      system("git", "checkout", initial_branch, exception: true)
-      system("git", "branch", "-D", @release_branch, exception: true)
+      system("git", "checkout", initial_branch)
+      system("git", "branch", "-D", @release_branch)
       raise
     end
   end

--- a/util/release.rb
+++ b/util/release.rb
@@ -159,6 +159,7 @@ class Release
 
       @bundler.cut_changelog!
       system("git", "commit", "-am", "Changelog for Bundler version #{@bundler.version}", exception: true)
+      bundler_changelog = `git show --no-patch --pretty=format:%h`
 
       @bundler.bump_versions!
       system("rake", "update_locked_bundler", exception: true)
@@ -166,9 +167,19 @@ class Release
 
       @rubygems.cut_changelog!
       system("git", "commit", "-am", "Changelog for Rubygems version #{@rubygems.version}", exception: true)
+      rubygems_changelog = `git show --no-patch --pretty=format:%h`
 
       @rubygems.bump_versions!
       system("git", "commit", "-am", "Bump Rubygems version to #{@rubygems.version}", exception: true)
+
+      system("git", "checkout", "-b", "cherry_pick_changelogs", "master", exception: true)
+
+      begin
+        system("git", "cherry-pick", bundler_changelog, rubygems_changelog, exception: true)
+      rescue StandardError
+        system("git", "cherry-pick", "--abort")
+        system("git", "branch", "-D", "cherry_pick_changelogs")
+      end
     rescue StandardError
       system("git", "checkout", initial_branch)
       system("git", "branch", "-D", @release_branch)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Automating more release things.

## What is your fix for the problem, implemented in this PR?

Add changelog cherry-picking to the `rake prepare_stable_branch` task that also cherry-picks the changelogs into a branch ready to merge into master.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
