### PR TITLE
Don't show duplicate entries in `bundle outdated` output

### DIFF
--- a/bundler/lib/bundler/cli/outdated.rb
+++ b/bundler/lib/bundler/cli/outdated.rb
@@ -72,7 +72,7 @@ module Bundler
         gemfile_specs + dependency_specs
       end
 
-      specs.sort_by(&:name).each do |current_spec|
+      specs.sort_by(&:name).uniq(&:name).each do |current_spec|
         next unless gems.empty? || gems.include?(current_spec.name)
 
         active_spec = retrieve_active_spec(definition, current_spec)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`bundle outdated` show duplicated entries when a gem has multiple variants in the lockfile.

## What is your fix for the problem, implemented in this PR?

Avoid this duplicates by using `.uniq(&:name)`.

Fixes #4451.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
