### PR TITLE
Make cloning git repos faster

### DIFF
--- a/bundler/lib/bundler/env.rb
+++ b/bundler/lib/bundler/env.rb
@@ -75,7 +75,7 @@ module Bundler
     end
 
     def self.git_version
-      Bundler::Source::Git::GitProxy.new(nil, nil, nil).full_version
+      Bundler::Source::Git::GitProxy.new(nil, nil).full_version
     rescue Bundler::Source::Git::GitNotInstalledError
       "not installed"
     end

--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -141,7 +141,7 @@ module Bundler
 
         # Create a new git proxy without the cached revision
         # so the Gemfile.lock always picks up the new revision.
-        @git_proxy = GitProxy.new(path, uri, ref)
+        @git_proxy = GitProxy.new(path, uri, options)
 
         if current_branch != branch && !Bundler.settings[:disable_local_branch_check]
           raise GitError, "Local override for #{name} at #{path} is using branch " \
@@ -229,7 +229,7 @@ module Bundler
       end
 
       def current_branch
-        git_proxy.branch
+        git_proxy.current_branch
       end
 
       def allow_git_ops?
@@ -317,7 +317,7 @@ module Bundler
       end
 
       def git_proxy
-        @git_proxy ||= GitProxy.new(cache_path, uri, ref, cached_revision, self)
+        @git_proxy ||= GitProxy.new(cache_path, uri, options, cached_revision, self)
       end
 
       def fetch

--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -72,7 +72,7 @@ module Bundler
           elsif ref
             ref
           else
-            git_proxy.branch
+            current_branch
           end
 
           rev = "at #{at}@#{shortref_for_display(revision)}"
@@ -143,9 +143,9 @@ module Bundler
         # so the Gemfile.lock always picks up the new revision.
         @git_proxy = GitProxy.new(path, uri, ref)
 
-        if git_proxy.branch != branch && !Bundler.settings[:disable_local_branch_check]
+        if current_branch != branch && !Bundler.settings[:disable_local_branch_check]
           raise GitError, "Local override for #{name} at #{path} is using branch " \
-            "#{git_proxy.branch} but Gemfile specifies #{branch}"
+            "#{current_branch} but Gemfile specifies #{branch}"
         end
 
         changed = cached_revision && cached_revision != git_proxy.revision
@@ -226,6 +226,10 @@ module Bundler
 
       def revision
         git_proxy.revision
+      end
+
+      def current_branch
+        git_proxy.branch
       end
 
       def allow_git_ops?

--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -126,7 +126,7 @@ module Bundler
         path = Pathname.new(path)
         path = path.expand_path(Bundler.root) unless path.relative?
 
-        unless options["branch"] || Bundler.settings[:disable_local_branch_check]
+        unless branch || Bundler.settings[:disable_local_branch_check]
           raise GitError, "Cannot use local override for #{name} at #{path} because " \
             ":branch is not specified in Gemfile. Specify a branch or run " \
             "`bundle config unset local.#{override_for(original_path)}` to remove the local override"
@@ -143,9 +143,9 @@ module Bundler
         # so the Gemfile.lock always picks up the new revision.
         @git_proxy = GitProxy.new(path, uri, ref)
 
-        if git_proxy.branch != options["branch"] && !Bundler.settings[:disable_local_branch_check]
+        if git_proxy.branch != branch && !Bundler.settings[:disable_local_branch_check]
           raise GitError, "Local override for #{name} at #{path} is using branch " \
-            "#{git_proxy.branch} but Gemfile specifies #{options["branch"]}"
+            "#{git_proxy.branch} but Gemfile specifies #{branch}"
         end
 
         changed = cached_revision && cached_revision != git_proxy.revision

--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -84,7 +84,7 @@ module Bundler
         end
 
         def checkout
-          return if path.exist? && has_revision_cached?
+          return if has_revision_cached?
           extra_ref = "#{ref}:#{ref}" if ref && ref.start_with?("refs/")
 
           Bundler.ui.info "Fetching #{credential_filtered_uri}"
@@ -166,8 +166,8 @@ module Bundler
         end
 
         def has_revision_cached?
-          return unless @revision
-          with_path { git("cat-file", "-e", @revision, :dir => path) }
+          return unless @revision && path.exist?
+          git("cat-file", "-e", @revision, :dir => path)
           true
         rescue GitError
           false

--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -111,7 +111,7 @@ module Bundler
               SharedHelpers.filesystem_access(destination) do |p|
                 FileUtils.rm_rf(p)
               end
-              git_retry "clone", "--no-checkout", "--quiet", path.to_s, destination.to_s
+              git "clone", "--no-checkout", "--quiet", path.to_s, destination.to_s
               File.chmod(((File.stat(destination).mode | 0o777) & ~File.umask), destination)
             rescue Errno::EEXIST => e
               file_path = e.message[%r{.*?((?:[a-zA-Z]:)?/.*)}, 1]
@@ -121,7 +121,7 @@ module Bundler
             end
           end
 
-          git_retry "fetch", "--force", "--quiet", "--tags", path.to_s, :dir => destination
+          git "fetch", "--force", "--quiet", "--tags", path.to_s, :dir => destination
 
           begin
             git "reset", "--hard", @revision, :dir => destination

--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -105,7 +105,6 @@ module Bundler
         end
 
         def copy_to(destination, submodules = false)
-          # method 1
           unless File.exist?(destination.join(".git"))
             begin
               SharedHelpers.filesystem_access(destination.dirname) do |p|
@@ -123,7 +122,7 @@ module Bundler
                 "this file and try again."
             end
           end
-          # method 2
+
           git_retry "fetch", "--force", "--quiet", "--tags", path.to_s, :dir => destination
 
           begin

--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -76,11 +76,11 @@ module Bundler
         end
 
         def version
-          git("--version").match(/(git version\s*)?((\.?\d+)+).*/)[2]
+          @version ||= full_version.match(/((\.?\d+)+).*/)[1]
         end
 
         def full_version
-          git("--version").sub("git version", "").strip
+          @full_version ||= git("--version").sub(/git version\s*/, "").strip
         end
 
         def checkout

--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -191,7 +191,7 @@ module Bundler
           raise MissingGitRevisionError.new(e.command, path, ref, URICredentialsFilter.credential_filtered_uri(uri))
         end
 
-        # Adds credentials to the URI as Fetcher#configured_uri_for does
+        # Adds credentials to the URI
         def configured_uri_for(uri)
           if /https?:/ =~ uri
             remote = Bundler::URI(uri)

--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -237,10 +237,6 @@ module Bundler
           false
         end
 
-        def remove_cache
-          FileUtils.rm_rf(path)
-        end
-
         def find_local_revision
           allowed_with_path do
             git("rev-parse", "--verify", branch || tag || ref || "HEAD", :dir => path).strip

--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -98,7 +98,10 @@ module Bundler
             return unless extra_ref
           end
 
-          git_retry(*["fetch", "--force", "--quiet", "--no-tags", *extra_fetch_args, "--", configured_uri, refspec].compact, :dir => path)
+          fetch_args = extra_fetch_args
+          fetch_args.unshift("--unshallow") if path.join("shallow").exist? && full_clone?
+
+          git_retry(*["fetch", "--force", "--quiet", "--no-tags", *fetch_args, "--", configured_uri, refspec].compact, :dir => path)
         end
 
         def copy_to(destination, submodules = false)

--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -121,11 +121,7 @@ module Bundler
 
           git "fetch", "--force", "--quiet", "--tags", path.to_s, :dir => destination
 
-          begin
-            git "reset", "--hard", @revision, :dir => destination
-          rescue GitCommandError => e
-            raise MissingGitRevisionError.new(e.command, destination, @revision, credential_filtered_uri)
-          end
+          git "reset", "--hard", @revision, :dir => destination
 
           if submodules
             git_retry "submodule", "update", "--init", "--recursive", :dir => destination

--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -99,9 +99,7 @@ module Bundler
             return unless extra_ref
           end
 
-          with_path do
-            git_retry(*["fetch", "--force", "--quiet", "--tags", "--", configured_uri, "refs/heads/*:refs/heads/*", extra_ref].compact, :dir => path)
-          end
+          git_retry(*["fetch", "--force", "--quiet", "--tags", "--", configured_uri, "refs/heads/*:refs/heads/*", extra_ref].compact, :dir => path)
         end
 
         def copy_to(destination, submodules = false)

--- a/bundler/spec/bundler/env_spec.rb
+++ b/bundler/spec/bundler/env_spec.rb
@@ -4,7 +4,7 @@ require "bundler/settings"
 require "openssl"
 
 RSpec.describe Bundler::Env do
-  let(:git_proxy_stub) { Bundler::Source::Git::GitProxy.new(nil, nil, nil) }
+  let(:git_proxy_stub) { Bundler::Source::Git::GitProxy.new(nil, nil) }
 
   describe "#report" do
     it "prints the environment" do

--- a/bundler/spec/bundler/source/git/git_proxy_spec.rb
+++ b/bundler/spec/bundler/source/git/git_proxy_spec.rb
@@ -11,21 +11,24 @@ RSpec.describe Bundler::Source::Git::GitProxy do
   context "with configured credentials" do
     it "adds username and password to URI" do
       Bundler.settings.temporary(uri => "u:p") do
-        expect(subject).to receive(:git_retry).with("clone", "--bare", "--no-hardlinks", "--quiet", "--", "https://u:p@github.com/rubygems/rubygems.git", path.to_s)
+        allow(subject).to receive(:git).with("--version").and_return("git version 2.14.0")
+        expect(subject).to receive(:git_retry).with("clone", "--bare", "--no-hardlinks", "--quiet", "--no-tags", "--depth", "1", "--single-branch", "--", "https://u:p@github.com/rubygems/rubygems.git", path.to_s)
         subject.checkout
       end
     end
 
     it "adds username and password to URI for host" do
       Bundler.settings.temporary("github.com" => "u:p") do
-        expect(subject).to receive(:git_retry).with("clone", "--bare", "--no-hardlinks", "--quiet", "--", "https://u:p@github.com/rubygems/rubygems.git", path.to_s)
+        allow(subject).to receive(:git).with("--version").and_return("git version 2.14.0")
+        expect(subject).to receive(:git_retry).with("clone", "--bare", "--no-hardlinks", "--quiet", "--no-tags", "--depth", "1", "--single-branch", "--", "https://u:p@github.com/rubygems/rubygems.git", path.to_s)
         subject.checkout
       end
     end
 
     it "does not add username and password to mismatched URI" do
       Bundler.settings.temporary("https://u:p@github.com/rubygems/rubygems-mismatch.git" => "u:p") do
-        expect(subject).to receive(:git_retry).with("clone", "--bare", "--no-hardlinks", "--quiet", "--", uri, path.to_s)
+        allow(subject).to receive(:git).with("--version").and_return("git version 2.14.0")
+        expect(subject).to receive(:git_retry).with("clone", "--bare", "--no-hardlinks", "--quiet", "--no-tags", "--depth", "1", "--single-branch", "--", uri, path.to_s)
         subject.checkout
       end
     end
@@ -34,7 +37,8 @@ RSpec.describe Bundler::Source::Git::GitProxy do
       Bundler.settings.temporary("github.com" => "u:p") do
         original = "https://orig:info@github.com/rubygems/rubygems.git"
         subject = described_class.new(Pathname("path"), original, "HEAD")
-        expect(subject).to receive(:git_retry).with("clone", "--bare", "--no-hardlinks", "--quiet", "--", original, path.to_s)
+        allow(subject).to receive(:git).with("--version").and_return("git version 2.14.0")
+        expect(subject).to receive(:git_retry).with("clone", "--bare", "--no-hardlinks", "--quiet", "--no-tags", "--depth", "1", "--single-branch", "--", original, path.to_s)
         subject.checkout
       end
     end

--- a/bundler/spec/bundler/source/git/git_proxy_spec.rb
+++ b/bundler/spec/bundler/source/git/git_proxy_spec.rb
@@ -122,33 +122,6 @@ RSpec.describe Bundler::Source::Git::GitProxy do
     end
   end
 
-  describe "#copy_to" do
-    let(:cache) { tmpdir("cache_path") }
-    let(:destination) { tmpdir("copy_to_path") }
-    let(:submodules) { false }
-
-    context "when given a SHA as a revision" do
-      let(:revision) { "abcd" * 10 }
-      let(:command) { ["reset", "--hard", revision] }
-      let(:command_for_display) { "git #{command.shelljoin}" }
-
-      it "fails gracefully when resetting to the revision fails" do
-        expect(subject).to receive(:git).with("clone", any_args) { destination.mkpath }
-        expect(subject).to receive(:git).with("fetch", any_args, :dir => destination)
-        expect(subject).to receive(:git).with(*command, :dir => destination).and_raise(Bundler::Source::Git::GitCommandError.new(command_for_display, destination))
-        expect(subject).not_to receive(:git)
-
-        expect { subject.copy_to(destination, submodules) }.
-          to raise_error(
-            Bundler::Source::Git::MissingGitRevisionError,
-            "Git error: command `#{command_for_display}` in directory #{destination} has failed.\n" \
-            "Revision #{revision} does not exist in the repository #{uri}. Maybe you misspelled it?\n" \
-            "If this error persists you could try removing the cache directory '#{destination}'"
-          )
-      end
-    end
-  end
-
   it "doesn't allow arbitrary code execution through Gemfile uris with a leading dash" do
     gemfile <<~G
       gem "poc", git: "-u./pay:load.sh"

--- a/bundler/spec/bundler/source/git/git_proxy_spec.rb
+++ b/bundler/spec/bundler/source/git/git_proxy_spec.rb
@@ -133,8 +133,8 @@ RSpec.describe Bundler::Source::Git::GitProxy do
       let(:command_for_display) { "git #{command.shelljoin}" }
 
       it "fails gracefully when resetting to the revision fails" do
-        expect(subject).to receive(:git_retry).with("clone", any_args) { destination.mkpath }
-        expect(subject).to receive(:git_retry).with("fetch", any_args, :dir => destination)
+        expect(subject).to receive(:git).with("clone", any_args) { destination.mkpath }
+        expect(subject).to receive(:git).with("fetch", any_args, :dir => destination)
         expect(subject).to receive(:git).with(*command, :dir => destination).and_raise(Bundler::Source::Git::GitCommandError.new(command_for_display, destination))
         expect(subject).not_to receive(:git)
 

--- a/bundler/spec/cache/git_spec.rb
+++ b/bundler/spec/cache/git_spec.rb
@@ -90,7 +90,6 @@ RSpec.describe "bundle cache with git" do
     expect(ref).not_to eq(old_ref)
 
     bundle "update", :all => true
-    bundle "config set cache_all true"
     bundle :cache
 
     expect(bundled_app("vendor/cache/foo-1.0-#{ref}")).to exist

--- a/bundler/spec/install/allow_offline_install_spec.rb
+++ b/bundler/spec/install/allow_offline_install_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "bundle install with :allow_offline_install" do
       File.open(tmp("broken_path/git"), "w", 0o755) do |f|
         f.puts strip_whitespace(<<-RUBY)
           #!/usr/bin/env ruby
-          if %w(fetch --force --quiet --tags refs/heads/*:refs/heads/*).-(ARGV).empty? || %w(clone --bare --no-hardlinks --quiet).-(ARGV).empty?
+          if %w(fetch --force --quiet --).-(ARGV).empty? || %w(clone --bare --no-hardlinks --quiet).-(ARGV).empty?
             warn "git remote ops have been disabled"
             exit 1
           end

--- a/bundler/spec/install/allow_offline_install_spec.rb
+++ b/bundler/spec/install/allow_offline_install_spec.rb
@@ -53,7 +53,10 @@ RSpec.describe "bundle install with :allow_offline_install" do
       File.open(tmp("broken_path/git"), "w", 0o755) do |f|
         f.puts strip_whitespace(<<-RUBY)
           #!/usr/bin/env ruby
-          if %w(fetch --force --quiet --).-(ARGV).empty? || %w(clone --bare --no-hardlinks --quiet).-(ARGV).empty?
+          fetch_args = %w(fetch --force --quiet)
+          clone_args = %w(clone --bare --no-hardlinks --quiet)
+
+          if (fetch_args.-(ARGV).empty? || clone_args.-(ARGV).empty?) && ARGV.any? {|arg| arg.start_with?("file://") }
             warn "git remote ops have been disabled"
             exit 1
           end

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -219,6 +219,22 @@ RSpec.describe "bundle install with git sources" do
       expect(out).to eq("WIN")
     end
 
+    it "works when an abbreviated revision is added after an initial, potentially shallow clone" do
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        git "#{lib_path("foo-1.0")}" do
+          gem "foo"
+        end
+      G
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        git "#{lib_path("foo-1.0")}", :ref => #{@revision[0..7].inspect} do
+          gem "foo"
+        end
+      G
+    end
+
     it "works when the revision is a non-head ref" do
       # want to ensure we don't fallback to main
       update_git "foo", :path => lib_path("foo-1.0") do |s|

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -52,8 +52,9 @@ RSpec.describe "bundle install with git sources" do
       bundle "update foo"
 
       sha = git.ref_for("main", 11)
-      spec_file = default_bundle_path.join("bundler/gems/foo-1.0-#{sha}/foo.gemspec").to_s
-      ruby_code = Gem::Specification.load(spec_file).to_ruby
+      spec_file = default_bundle_path.join("bundler/gems/foo-1.0-#{sha}/foo.gemspec")
+      expect(spec_file).to exist
+      ruby_code = Gem::Specification.load(spec_file.to_s).to_ruby
       file_code = File.read(spec_file)
       expect(file_code).to eq(ruby_code)
     end

--- a/bundler/spec/lock/git_spec.rb
+++ b/bundler/spec/lock/git_spec.rb
@@ -14,6 +14,14 @@ RSpec.describe "bundle lock with git gems" do
     expect(the_bundle).to include_gems "foo 1.0.0"
   end
 
+  it "doesn't print errors even if running lock after removing the cache" do
+    FileUtils.rm_rf(Dir[default_cache_path("git/foo-1.0-*")].first)
+
+    bundle "lock --verbose"
+
+    expect(err).to be_empty
+  end
+
   it "locks a git source to the current ref" do
     update_git "foo"
     bundle :install

--- a/bundler/spec/support/filters.rb
+++ b/bundler/spec/support/filters.rb
@@ -21,7 +21,7 @@ end
 RSpec.configure do |config|
   config.filter_run_excluding :realworld => true
 
-  git_version = Bundler::Source::Git::GitProxy.new(nil, nil, nil).version
+  git_version = Bundler::Source::Git::GitProxy.new(nil, nil).version
 
   config.filter_run_excluding :git => RequirementChecker.against(git_version)
   config.filter_run_excluding :bundler => RequirementChecker.against(Bundler::VERSION.split(".")[0])

--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -118,6 +118,14 @@ module Spec
       end
     end
 
+    def default_cache_path(*path)
+      if Bundler.feature_flag.global_gem_cache?
+        home(".bundle/cache", *path)
+      else
+        default_bundle_path("cache/bundler", *path)
+      end
+    end
+
     def bundled_app(*path)
       root = tmp.join("bundled_app")
       FileUtils.mkdir_p(root)

--- a/bundler/spec/update/git_spec.rb
+++ b/bundler/spec/update/git_spec.rb
@@ -120,6 +120,7 @@ RSpec.describe "bundle update" do
       G
 
       bundle "update", :all => true
+      expect(err).to be_empty
     end
 
     describe "with submodules" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The problem was that cloning bit git repos can be very slow, because we are cloning the full history of the repo.

## What is your fix for the problem, implemented in this PR?

My fix is to use `--depth 1` for remote clones to only download what's necessary.

This approach doesn't really work and needs more work. A potential fix was suggested [here](https://github.com/rubygems/rubygems/issues/3332#issuecomment-652990815).

Fixes #3332.
Fixes #3378.
Fixes #3775.
Supersedes https://github.com/rubygems/bundler/pull/7054.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
