### PR TITLE
Backport non gnu libc linux support from RubyGems

### DIFF
--- a/bundler/spec/support/indexes.rb
+++ b/bundler/spec/support/indexes.rb
@@ -33,6 +33,10 @@ module Spec
       Bundler::Resolver.resolve(deps, source_requirements, *args)
     end
 
+    def should_not_resolve
+      expect { resolve }.to raise_error(Bundler::GemNotFound)
+    end
+
     def should_resolve_as(specs)
       got = resolve
       got = got.map(&:full_name).sort


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

See #3174, #4082, #4425. 

## What is your fix for the problem, implemented in this PR?

Implement the non-ideal but pragmatic behaviour we agreed upon:

- "the previous state of things" i.e `nil` version in gems is a wildcard (i.e a `linux` gem it can be picked by Rubies on `linux` and `linux-musl`)
- with the exception that if there's a `linux-musl` variant, it should always be preferred on Alpine (i.e a `linux-musl` Ruby)
- and a mirror constraint that on a `linux` Ruby it should never pick `linux-musl` gems

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
