### PR TITLE
Improve `bundle info` error when gem is on a "disabled" group

### DIFF
--- a/bundler/lib/bundler/cli/common.rb
+++ b/bundler/lib/bundler/cli/common.rb
@@ -36,6 +36,7 @@ module Bundler
     def self.without_groups_message(command)
       command_in_past_tense = command == :install ? "installed" : "updated"
       groups = Bundler.settings[:without]
+      groups.map!{|g| "'#{g}'" }
       group_list = [groups[0...-1].join(", "), groups[-1..-1]].
         reject {|s| s.to_s.empty? }.join(" and ")
       group_str = groups.size == 1 ? "group" : "groups"

--- a/bundler/lib/bundler/cli/common.rb
+++ b/bundler/lib/bundler/cli/common.rb
@@ -36,11 +36,15 @@ module Bundler
     def self.without_groups_message(command)
       command_in_past_tense = command == :install ? "installed" : "updated"
       groups = Bundler.settings[:without]
+      "Gems in the #{verbalize_groups(groups)} were not #{command_in_past_tense}."
+    end
+
+    def self.verbalize_groups(groups)
       groups.map!{|g| "'#{g}'" }
       group_list = [groups[0...-1].join(", "), groups[-1..-1]].
         reject {|s| s.to_s.empty? }.join(" and ")
       group_str = groups.size == 1 ? "group" : "groups"
-      "Gems in the #{group_str} #{group_list} were not #{command_in_past_tense}."
+      "#{group_str} #{group_list}"
     end
 
     def self.select_spec(name, regex_match = nil)
@@ -54,7 +58,13 @@ module Bundler
 
       case specs.count
       when 0
-        raise GemNotFound, gem_not_found_message(name, Bundler.definition.dependencies)
+        dep_in_other_group = Bundler.definition.current_dependencies.find {|dep|dep.name == name }
+
+        if dep_in_other_group
+          raise GemNotFound, "Could not find gem '#{name}', because it's in the #{verbalize_groups(dep_in_other_group.groups)}, configured to be ignored."
+        else
+          raise GemNotFound, gem_not_found_message(name, Bundler.definition.dependencies)
+        end
       when 1
         specs.first
       else

--- a/bundler/spec/commands/info_spec.rb
+++ b/bundler/spec/commands/info_spec.rb
@@ -182,4 +182,18 @@ RSpec.describe "bundle info" do
       expect(err).to include("Could not find gem '#{invalid_regexp}'.")
     end
   end
+
+  context "with without configured" do
+    it "does not find the gem, but gives a helpful error" do
+      bundle "config without test"
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rails", group: :test
+      G
+
+      bundle "info rails", :raise_on_error => false
+      expect(err).to include("Could not find gem 'rails', because it's in the group 'test', configured to be ignored.")
+    end
+  end
 end

--- a/bundler/spec/commands/post_bundle_message_spec.rb
+++ b/bundler/spec/commands/post_bundle_message_spec.rb
@@ -32,21 +32,21 @@ RSpec.describe "post bundle message" do
       bundle "config set --local without emo"
       bundle :install
       expect(out).to include(bundle_show_message)
-      expect(out).to include("Gems in the group emo were not installed")
+      expect(out).to include("Gems in the group 'emo' were not installed")
       expect(out).to include(bundle_complete_message)
       expect(out).to include(installed_gems_stats)
 
       bundle "config set --local without emo test"
       bundle :install
       expect(out).to include(bundle_show_message)
-      expect(out).to include("Gems in the groups emo and test were not installed")
+      expect(out).to include("Gems in the groups 'emo' and 'test' were not installed")
       expect(out).to include(bundle_complete_message)
       expect(out).to include("4 Gemfile dependencies, 3 gems now installed.")
 
       bundle "config set --local without emo obama test"
       bundle :install
       expect(out).to include(bundle_show_message)
-      expect(out).to include("Gems in the groups emo, obama and test were not installed")
+      expect(out).to include("Gems in the groups 'emo', 'obama' and 'test' were not installed")
       expect(out).to include(bundle_complete_message)
       expect(out).to include("4 Gemfile dependencies, 2 gems now installed.")
     end
@@ -65,21 +65,21 @@ RSpec.describe "post bundle message" do
         bundle "config set --local without emo"
         bundle :install
         expect(out).to include(bundle_show_path_message)
-        expect(out).to include("Gems in the group emo were not installed")
+        expect(out).to include("Gems in the group 'emo' were not installed")
         expect(out).to include(bundle_complete_message)
 
         bundle "config set --local path vendor"
         bundle "config set --local without emo test"
         bundle :install
         expect(out).to include(bundle_show_path_message)
-        expect(out).to include("Gems in the groups emo and test were not installed")
+        expect(out).to include("Gems in the groups 'emo' and 'test' were not installed")
         expect(out).to include(bundle_complete_message)
 
         bundle "config set --local path vendor"
         bundle "config set --local without emo obama test"
         bundle :install
         expect(out).to include(bundle_show_path_message)
-        expect(out).to include("Gems in the groups emo, obama and test were not installed")
+        expect(out).to include("Gems in the groups 'emo', 'obama' and 'test' were not installed")
         expect(out).to include(bundle_complete_message)
       end
     end
@@ -156,7 +156,7 @@ The source does not contain any versions of 'not-a-gem'
       bundle "install --without emo"
       bundle :install
       expect(out).to include(bundle_show_message)
-      expect(out).to include("Gems in the group emo were not installed")
+      expect(out).to include("Gems in the group 'emo' were not installed")
       expect(out).to include(bundle_complete_message)
       expect(out).to include(installed_gems_stats)
     end
@@ -165,7 +165,7 @@ The source does not contain any versions of 'not-a-gem'
       bundle "install --without emo test"
       bundle :install
       expect(out).to include(bundle_show_message)
-      expect(out).to include("Gems in the groups emo and test were not installed")
+      expect(out).to include("Gems in the groups 'emo' and 'test' were not installed")
       expect(out).to include(bundle_complete_message)
     end
 
@@ -173,7 +173,7 @@ The source does not contain any versions of 'not-a-gem'
       bundle "install --without emo obama test"
       bundle :install
       expect(out).to include(bundle_show_message)
-      expect(out).to include("Gems in the groups emo, obama and test were not installed")
+      expect(out).to include("Gems in the groups 'emo', 'obama' and 'test' were not installed")
       expect(out).to include(bundle_complete_message)
     end
   end
@@ -187,19 +187,19 @@ The source does not contain any versions of 'not-a-gem'
       bundle "config set --local without emo"
       bundle :install
       bundle :update, :all => true
-      expect(out).to include("Gems in the group emo were not updated")
+      expect(out).to include("Gems in the group 'emo' were not updated")
       expect(out).to include(bundle_updated_message)
 
       bundle "config set --local without emo test"
       bundle :install
       bundle :update, :all => true
-      expect(out).to include("Gems in the groups emo and test were not updated")
+      expect(out).to include("Gems in the groups 'emo' and 'test' were not updated")
       expect(out).to include(bundle_updated_message)
 
       bundle "config set --local without emo obama test"
       bundle :install
       bundle :update, :all => true
-      expect(out).to include("Gems in the groups emo, obama and test were not updated")
+      expect(out).to include("Gems in the groups 'emo', 'obama' and 'test' were not updated")
       expect(out).to include(bundle_updated_message)
     end
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I run `bundle info jasmine` on my library, and got this:

```
$ bundle info jasmine
Could not find gem 'jasmine'.
Did you mean jasmine?
```

## What is your fix for the problem, implemented in this PR?

```
$ bundle info jasmine
Could not find gem 'jasmine', because it's in the group 'test', configured to be ignored.
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
