### PR TITLE
Update guides for the released version after releasing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -246,15 +246,12 @@ namespace 'guides' do
   desc 'Updates and publishes the guides for the just-released RubyGems'
   task 'publish'
 
-  on_master = `git branch --list master`.strip == '* master'
-  on_master = true if ENV['FORCE']
-
   task 'publish' => %w[
     guides:pull
     guides:update
     guides:commit
     guides:push
-  ] if on_master
+  ]
 end
 
 directory '../blog.rubygems.org' do


### PR DESCRIPTION

## What was the end-user or developer problem that led to this PR?

Guides fall out of date when we release new versions of rubygems.

## What is your fix for the problem, implemented in this PR?

Regenerate guides using the released version after each release. I don't see any reason why this should happen only when releasing from master.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
