### PR TITLE
Small tweak to yank message

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -192,10 +192,10 @@ module Bundler
           gem_name, gem_version = extract_gem_info(e)
           locked_gem = @locked_specs[gem_name].last
           raise if locked_gem.nil? || locked_gem.version.to_s != gem_version || !@remote
-          raise GemNotFound, "Your bundle is locked to #{locked_gem}, but that version could not " \
-                             "be found in any of the sources listed in your Gemfile. If you haven't changed sources, " \
-                             "that means the author of #{locked_gem} has removed it. You'll need to update your bundle " \
-                             "to a version other than #{locked_gem} that hasn't been removed in order to install."
+          raise GemNotFound, "Your bundle is locked to #{locked_gem} from #{locked_gem.source}, but that version can " \
+                             "no longer be found in that source. That means the author of #{locked_gem} has removed it. " \
+                             "You'll need to update your bundle to a version other than #{locked_gem} that hasn't been " \
+                             "removed in order to install."
         end
         unless specs["bundler"].any?
           bundler = sources.metadata_source.specs.search(Gem::Dependency.new("bundler", VERSION)).last


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

No problem, just trying to make the message about gems being yanked a bit more clear.

## What is your fix for the problem, implemented in this PR?

I don't think the part about changing sources makes much sense, so I removed it to make the message simpler to understand.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
