### PR TITLE
Deprecate `bundle cache --path`

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -475,6 +475,12 @@ module Bundler
         "do in future versions. Instead please use `bundle config set cache_all true`, " \
         "and stop using this flag" if ARGV.include?("--all")
 
+      SharedHelpers.major_deprecation 2,
+        "The `--path` flag is deprecated because its semantics are unclear. " \
+        "Use `bundle config cache_path` to configure the path of your cache of gems, " \
+        "and `bundle config path` to configure the path where your gems are installed, " \
+        "and stop using this flag" if ARGV.include?("--path")
+
       require_relative "cli/cache"
       Cache.new(options).run
     end

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -165,6 +165,28 @@ RSpec.describe "major deprecations" do
     pending "fails with a helpful error", :bundler => "3"
   end
 
+  context "bundle cache --path" do
+    before do
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rack"
+      G
+
+      bundle "cache --path foo", :raise_on_error => false
+    end
+
+    it "should print a deprecation warning", :bundler => "< 3" do
+      expect(deprecations).to include(
+        "The `--path` flag is deprecated because its semantics are unclear. " \
+        "Use `bundle config cache_path` to configure the path of your cache of gems, " \
+        "and `bundle config path` to configure the path where your gems are installed, " \
+        "and stop using this flag"
+      )
+    end
+
+    pending "fails with a helpful error", :bundler => "3"
+  end
+
   describe "bundle config" do
     describe "old list interface" do
       before do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The semantics of `bundle cache --path` are confusing at least, probably just wrong. What the `--path` flag to `bundle cache` does is to actually configure `BUNDLE_PATH`, not the cache path, and then generate the cache relatively to this folder, not to the root folder as usual. This makes the cache not ever be hit.

## What is your fix for the problem, implemented in this PR?

My fix is to depreacte `bundle cache --path`, and recommend proper alternatives.

Fixes #3232.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
