### PR TITLE
Fix incorrect logic for filtering metadata matching candidates

### DIFF
--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -74,9 +74,9 @@ module Bundler
           MatchPlatform.platforms_match?(spec.platform, platform_object)
         end
         installable_candidates = same_platform_candidates.select do |spec|
-          !spec.is_a?(RemoteSpecification) &&
-            spec.required_ruby_version.satisfied_by?(Gem.ruby_version) &&
-            spec.required_rubygems_version.satisfied_by?(Gem.rubygems_version)
+          !spec.is_a?(EndpointSpecification) ||
+            (spec.required_ruby_version.satisfied_by?(Gem.ruby_version) &&
+              spec.required_rubygems_version.satisfied_by?(Gem.rubygems_version))
         end
         search = installable_candidates.last || same_platform_candidates.last
         search.dependencies = dependencies if search && (search.is_a?(RemoteSpecification) || search.is_a?(EndpointSpecification))


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The problem is that when bundling a bundler 2.1 lockfile (without platforms locked), we want to resolve platforms at materialization time for backwards compatibility. However, since https://github.com/rubygems/rubygems/pull/4449, the logic to do this is incorrect and can lead to the standard variant being preferred over a platform specific variant as explained at https://github.com/rubygems/rubygems/issues/4370#issuecomment-807952686.

## What is your fix for the problem, implemented in this PR?

The previous logic was discarding both specs coming from the old dependency API (`RemoteSpecification`'s), and installed specifications (`StubSpecification`, which inherit from `RemoteSpecification`).

We don't actually want to discard any of those. In particular, discarding already installed specifications can cause another not platform specific variant to be chosen in the end, which is unexpected.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
