### PR TITLE
Enable bundler-cache for GitHub Actions template

### DIFF
--- a/bundler/lib/bundler/templates/newgem/github/workflows/main.yml.tt
+++ b/bundler/lib/bundler/templates/newgem/github/workflows/main.yml.tt
@@ -11,6 +11,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: <%= RUBY_VERSION %>
+        bundler-cache: true
     - name: Run the default task
       run: |
         gem install bundler -v <%= Bundler::VERSION %>

--- a/bundler/lib/bundler/templates/newgem/github/workflows/main.yml.tt
+++ b/bundler/lib/bundler/templates/newgem/github/workflows/main.yml.tt
@@ -13,7 +13,4 @@ jobs:
         ruby-version: <%= RUBY_VERSION %>
         bundler-cache: true
     - name: Run the default task
-      run: |
-        gem install bundler -v <%= Bundler::VERSION %>
-        bundle install
-        bundle exec rake
+      run: bundle exec rake


### PR DESCRIPTION
This seems like a useful default.

Details: https://github.com/actions/cache/blob/main/examples.md#ruby---bundler