### PR TITLE
Bump vendored `tmpdir` library copy

### DIFF
--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -171,7 +171,7 @@ Automatiek::RakeTask.new("thor") do |lib|
 end
 
 # We currently include the official version as of
-# https://github.com/ruby/tmpdir/tree/a3e06bd49829dc49c346aa10f8b91116fd7e17ad,
+# https://github.com/ruby/tmpdir/commit/c79bc7adf66a39617d0d6bae21085adc77c02b0e
 # with the following changes on top:
 # * require fileutils relatively to use our vendored version.
 # * Inherit from `Dir` so that code assuming we're inside the

--- a/bundler/lib/bundler/vendor/tmpdir/lib/tmpdir.rb
+++ b/bundler/lib/bundler/vendor/tmpdir/lib/tmpdir.rb
@@ -115,7 +115,7 @@ class Bundler::Dir < Dir
       Bundler::Dir.tmpdir
     end
 
-    UNUSABLE_CHARS = [File::SEPARATOR, File::ALT_SEPARATOR, File::PATH_SEPARATOR, ":"].uniq.join("").freeze
+    UNUSABLE_CHARS = "^,-.0-9A-Z_a-z~"
 
     class << (RANDOM = Random.new)
       MAX = 36**6 # < 0x100000000


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

A security issue was found and fixed on tmpdir and we vendor that library.

## What is your fix for the problem, implemented in this PR?

Port the fix to our vendored copy.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
