### PR TITLE
Add space after open curly bracket in Gemfile and gems.rb template

### DIFF
--- a/.rubocop_bundler.yml
+++ b/.rubocop_bundler.yml
@@ -373,6 +373,9 @@ Layout/SpaceInsideArrayPercentLiteral:
 Layout/SpaceInsideBlockBraces:
   Enabled: true
   SpaceBeforeBlockParameters: false
+  Exclude:
+  - bundler/lib/bundler/templates/Gemfile
+  - bundler/lib/bundler/templates/gems.rb
 
 Layout/SpaceInsideHashLiteralBraces:
   Enabled: true

--- a/bundler/lib/bundler/templates/Gemfile
+++ b/bundler/lib/bundler/templates/Gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # gem "rails"

--- a/bundler/lib/bundler/templates/gems.rb
+++ b/bundler/lib/bundler/templates/gems.rb
@@ -3,6 +3,6 @@
 # A sample gems.rb
 source "https://rubygems.org"
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # gem "rails"


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

When generate `Gemfile` there is no space after left curl bracket

Current `Gemfile` and `gems.rb` templates contain:

```rb
git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
```

The most popular Ruby code style standard is this:

https://rubystyle.guide/#spaces-braces

> Use spaces around `{` and before `}`.

## What is your fix for the problem, implemented in this PR?

`Gemfile` and `gems.rb` templates proposed by this PR:

```rb
git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
