### PR TITLE
Cancel `deployment_means_frozen` change

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -197,7 +197,7 @@ module Bundler
 
     def frozen_bundle?
       frozen = settings[:deployment]
-      frozen ||= settings[:frozen] unless feature_flag.deployment_means_frozen?
+      frozen ||= settings[:frozen]
       frozen
     end
 

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -33,12 +33,8 @@ module Bundler
 
         options[:local] = true if Bundler.app_cache.exist?
 
-        if Bundler.feature_flag.deployment_means_frozen?
-          Bundler.settings.set_command_option :deployment, true
-        else
-          Bundler.settings.set_command_option :deployment, true if options[:deployment]
-          Bundler.settings.set_command_option :frozen, true if options[:frozen]
-        end
+        Bundler.settings.set_command_option :deployment, true if options[:deployment]
+        Bundler.settings.set_command_option :frozen, true if options[:frozen]
       end
 
       # When install is called with --no-deployment, disable deployment mode

--- a/bundler/lib/bundler/feature_flag.rb
+++ b/bundler/lib/bundler/feature_flag.rb
@@ -31,7 +31,6 @@ module Bundler
     settings_flag(:auto_clean_without_path) { bundler_3_mode? }
     settings_flag(:cache_all) { bundler_3_mode? }
     settings_flag(:default_install_uses_path) { bundler_3_mode? }
-    settings_flag(:deployment_means_frozen) { bundler_3_mode? }
     settings_flag(:disable_multisource) { bundler_3_mode? }
     settings_flag(:forget_cli_options) { bundler_3_mode? }
     settings_flag(:global_gem_cache) { bundler_3_mode? }

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -15,7 +15,6 @@ module Bundler
       cache_all_platforms
       default_install_uses_path
       deployment
-      deployment_means_frozen
       disable_checksum_validation
       disable_exec_load
       disable_local_branch_check

--- a/bundler/spec/quality_spec.rb
+++ b/bundler/spec/quality_spec.rb
@@ -169,7 +169,6 @@ RSpec.describe "The library itself" do
 
   it "documents all used settings" do
     exemptions = %w[
-      deployment_means_frozen
       forget_cli_options
       gem.coc
       gem.mit


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We have the following change scheduled for bundler 3:

* Remove the `frozen` setting.
* Change the current `deployment` setting to mean what the `frozen` setting means today.

I think this is not a good change to do now, because:

* It does not have a clean deprecation/migration path: we can't deprecate frozen and give an alternative, because `deployment` does not an work today as it will work in bundler 3.

* When removing `frozen` was proposed, one of the motivations was that there was no `deployment` setting, only a `--deployment` flag. Today we do have a `deployment` setting so that makes the migration path harder.

I do understand that a `deployment` setting that means `frozen` + `path=vendor/bundle` might be kind of obscure/unnecessary, specially on bundler 3 where bundler will install locally, not globally, by default. But I think we have sufficient breaking changes for bundler 3, like the change to install locally instead of globally which will be big, so I prefer to cancel this one, and maybe consider it for later (once bundler 3 is settled and the `deployment` setting _is_ actually unnecessary most of the times).

## What is your fix for the problem, implemented in this PR?

My fix is to completely cancel the breaking change for the moment.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
