### PR TITLE
Ignore `deployment` setting in inline mode

### DIFF
--- a/bundler/lib/bundler/inline.rb
+++ b/bundler/lib/bundler/inline.rb
@@ -52,7 +52,7 @@ def gemfile(install = false, options = {}, &gemfile)
     builder.instance_eval(&gemfile)
     builder.check_primary_source_safety
 
-    Bundler.settings.temporary(:frozen => false) do
+    Bundler.settings.temporary(:deployment => false, :frozen => false) do
       definition = builder.to_definition(nil, true)
       def definition.lock(*); end
       definition.validate_runtime!

--- a/bundler/spec/runtime/inline_spec.rb
+++ b/bundler/spec/runtime/inline_spec.rb
@@ -246,6 +246,19 @@ RSpec.describe "bundler/inline#gemfile" do
     expect(last_command.stderr).to be_empty
   end
 
+  it "installs inline gems when deployment is set" do
+    script <<-RUBY, :env => { "BUNDLE_DEPLOYMENT" => "true" }
+      gemfile do
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rack"
+      end
+
+      puts RACK
+    RUBY
+
+    expect(last_command.stderr).to be_empty
+  end
+
   it "installs inline gems when BUNDLE_GEMFILE is set to an empty string" do
     ENV["BUNDLE_GEMFILE"] = ""
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The problem was that the inline mode wouldn't work if BUNDLE_DEPLOYMENT is set. This is because since we're in frozen mode, the current platform doesn't get added to the definition, and thus platform validation fails.

## What is your fix for the problem, implemented in this PR?

My fix is to temporary ignore BUNDLE_FROZEN for the inline mode. The inline mode can't really be frozen since it has no lock file.

This fix is equivalent to https://github.com/rubygems/bundler/pull/7125, but for the `deployment` setting.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
