### PR TITLE
Update the default bindir on macOS

### DIFF
--- a/lib/rubygems/defaults.rb
+++ b/lib/rubygems/defaults.rb
@@ -198,7 +198,7 @@ module Gem
 
   def self.default_bindir
     if defined? RUBY_FRAMEWORK_VERSION # mac framework support
-      '/usr/bin'
+      '/usr/local/bin'
     else # generic install
       RbConfig::CONFIG['bindir']
     end


### PR DESCRIPTION
Import https://opensource.apple.com/source/ruby/ruby-145.40.1/patches/lib_rubygems_defaults.rb.diff.auto.html

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
