### PR TITLE
Prefer File.open instead of Kernel#open

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -813,7 +813,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   ##
   # Safely write a file in binary mode on all platforms.
   def self.write_binary(path, data)
-    open(path, 'wb') do |io|
+    File.open(path, 'wb') do |io|
       begin
         io.flock(File::LOCK_EX)
       rescue *WRITE_BINARY_ERRORS
@@ -824,7 +824,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     if Thread.main != Thread.current
       raise
     else
-      open(path, 'wb') do |io|
+      File.open(path, 'wb') do |io|
         io.write data
       end
     end

--- a/lib/rubygems/indexer.rb
+++ b/lib/rubygems/indexer.rb
@@ -136,7 +136,7 @@ class Gem::Indexer
     say "Generating #{name} index"
 
     Gem.time "Generated #{name} index" do
-      open(file, 'wb') do |io|
+      File.open(file, 'wb') do |io|
         specs = index.map do |*spec|
           # We have to splat here because latest_specs is an array, while the
           # others are hashes.

--- a/lib/rubygems/test_utilities.rb
+++ b/lib/rubygems/test_utilities.rb
@@ -76,7 +76,7 @@ class Gem::FakeFetcher
 
   def cache_update_path(uri, path = nil, update = true)
     if data = fetch_path(uri)
-      open(path, 'wb') {|io| io.write data } if path and update
+      File.open(path, 'wb') {|io| io.write data } if path and update
       data
     else
       Gem.read_binary(path) if path


### PR DESCRIPTION
... because Kernel#open may allow unintentional command injection.
At present, I don't know how to exploit these usages of Kernel#open, but
I'm afraid if they may be used with untrusted user input accidentally in
future. As far as I see, there is no reason to use Kernel#open.