### PR TITLE
Use `File.open` consistently and enable `Security/Open`cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -106,6 +106,9 @@ Performance/StartWith:
 Performance/StringReplacement:
   Enabled: true
 
+Security/Open:
+  Enabled: true
+
 Style/Encoding:
   Enabled: true
   Exclude:

--- a/.rubocop_bundler.yml
+++ b/.rubocop_bundler.yml
@@ -492,6 +492,9 @@ Performance/UriDefaultParser:
 Security/JSONLoad:
   Enabled: true
 
+Security/Open:
+  Enabled: true
+
 # Style
 
 Style/Alias:

--- a/Rakefile
+++ b/Rakefile
@@ -274,7 +274,7 @@ namespace 'blog' do
     Dir['pkg/*{tgz,zip,gem}'].map do |file|
       digest = Digest::SHA256.new
 
-      open file, 'rb' do |io|
+      File.open file, 'rb' do |io|
         while chunk = io.read(65536) do
           digest.update chunk
         end

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -48,7 +48,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
       io.puts gemspec.to_ruby
     end
 
-    open(File.join(Gem.default_specifications_dir, "bundler-1.15.4.gemspec"), 'w') do |io|
+    File.open(File.join(Gem.default_specifications_dir, "bundler-1.15.4.gemspec"), 'w') do |io|
       gemspec.version = "1.15.4"
       io.puts gemspec.to_ruby
     end

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -730,7 +730,7 @@ gem 'other', version
     installer.generate_bin
 
     default_shebang = Gem.ruby
-    shebang_line = open("#{@gemhome}/bin/executable") {|f| f.readlines.first }
+    shebang_line = File.open("#{@gemhome}/bin/executable") {|f| f.readlines.first }
     assert_match(/\A#!/, shebang_line)
     assert_match(/#{default_shebang}/, shebang_line)
   end

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -937,7 +937,7 @@ class TestGemPackage < Gem::Package::TarTestCase
     build = Gem::Package.new @gem
     build.spec = @spec
     build.setup_signer
-    open @gem, 'wb' do |gem_io|
+    File.open @gem, 'wb' do |gem_io|
       Gem::Package::TarWriter.new gem_io do |gem|
         build.add_metadata gem
         build.add_contents gem

--- a/test/rubygems/test_gem_server.rb
+++ b/test/rubygems/test_gem_server.rb
@@ -365,7 +365,7 @@ class TestGemServer < Gem::TestCase
     specs_dir = File.join dir, 'specifications'
     FileUtils.mkdir_p specs_dir
 
-    open File.join(specs_dir, spec.spec_name), 'w' do |io|
+    File.open File.join(specs_dir, spec.spec_name), 'w' do |io|
       io.write spec.to_ruby
     end
 
@@ -420,7 +420,7 @@ class TestGemServer < Gem::TestCase
     specs_dir = File.join dir, 'specifications'
     FileUtils.mkdir_p specs_dir
 
-    open File.join(specs_dir, spec.spec_name), 'w' do |io|
+    File.open File.join(specs_dir, spec.spec_name), 'w' do |io|
       io.write spec.to_ruby
     end
 
@@ -475,7 +475,7 @@ class TestGemServer < Gem::TestCase
     specs_dir = File.join dir, 'specifications'
     FileUtils.mkdir_p specs_dir
 
-    open File.join(specs_dir, spec.spec_name), 'w' do |io|
+    File.open File.join(specs_dir, spec.spec_name), 'w' do |io|
       io.write spec.to_ruby
     end
 
@@ -502,7 +502,7 @@ class TestGemServer < Gem::TestCase
     specs_dir = File.join dir, 'specifications'
     FileUtils.mkdir_p specs_dir
 
-    open File.join(specs_dir, spec.spec_name), 'w' do |io|
+    File.open File.join(specs_dir, spec.spec_name), 'w' do |io|
       io.write spec.to_ruby
     end
 

--- a/util/create_encrypted_key.rb
+++ b/util/create_encrypted_key.rb
@@ -11,6 +11,6 @@ cipher = OpenSSL::Cipher.new 'DES-CBC'
 
 encrypted_key_path = "#{test_path}/encrypted_private_key.pem"
 
-open encrypted_key_path, 'w' do |io|
+File.open encrypted_key_path, 'w' do |io|
   io.write key.to_pem cipher, 'Foo bar'
 end

--- a/util/update_bundled_ca_certificates.rb
+++ b/util/update_bundled_ca_certificates.rb
@@ -107,7 +107,7 @@ def write_certificates(certificates)
 
     warn "overwriting certificate #{name}" if File.exist? destination
 
-    open destination, 'w' do |io|
+    File.open destination, 'w' do |io|
       io.write certificate.to_pem
     end
   end
@@ -115,7 +115,7 @@ end
 
 io =
   if ARGV.empty?
-    open OpenSSL::X509::DEFAULT_CERT_FILE
+    File.open OpenSSL::X509::DEFAULT_CERT_FILE
   else
     ARGF
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Just another follow up to #4529, to make sure we don't reintroduce `Kernel#open` unintentionally.

## What is your fix for the problem, implemented in this PR?

Use rubocop!

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
