### PR TITLE
Ignore `RUBYGEMS_GEMDEPS` for the bundler gem

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -249,9 +249,6 @@ module Gem
   # you to specify specific gem versions.
 
   def self.bin_path(name, exec_name = nil, *requirements)
-    # TODO: fails test_self_bin_path_bin_file_gone_in_latest
-    # Gem::Specification.find_by_name(name, *requirements).bin_file exec_name
-
     requirements = Gem::Requirement.default if
       requirements.empty?
 

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1121,7 +1121,6 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
       ensure
         Gem::DefaultUserInteraction.ui.close
       end
-      @gemdeps.requested_specs.map(&:to_spec).sort_by(&:name)
     end
 
   rescue => e

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1350,5 +1350,3 @@ Gem::Specification.load_defaults
 require 'rubygems/core_ext/kernel_gem'
 require 'rubygems/core_ext/kernel_require'
 require 'rubygems/core_ext/kernel_warn'
-
-Gem.use_gemdeps

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1122,7 +1122,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
       end
     rescue Bundler::BundlerError => e
       warn e.message
-      warn "You may need to `gem install -g` to install missing gems"
+      warn "You may need to `bundle install` to install missing gems"
       warn ""
     end
   end

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1109,21 +1109,22 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
     ENV["BUNDLE_GEMFILE"] ||= File.expand_path(path)
     require 'rubygems/user_interaction'
-    Gem::DefaultUserInteraction.use_ui(ui) do
-      require "bundler"
-      begin
-        Bundler.ui.silence do
-          @gemdeps = Bundler.setup
+    require "bundler"
+    begin
+      Gem::DefaultUserInteraction.use_ui(ui) do
+        begin
+          Bundler.ui.silence do
+            @gemdeps = Bundler.setup
+          end
+        ensure
+          Gem::DefaultUserInteraction.ui.close
         end
-      ensure
-        Gem::DefaultUserInteraction.ui.close
       end
+    rescue Bundler::BundlerError => e
+      warn e.message
+      warn "You may need to `gem install -g` to install missing gems"
+      warn ""
     end
-
-  rescue Gem::LoadError, Gem::UnsatisfiableDependencyError, (defined?(Bundler::GemNotFound) ? Bundler::GemNotFound : Gem::LoadError) => e
-    warn e.message
-    warn "You may need to `gem install -g` to install missing gems"
-    warn ""
   end
 
   ##

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1120,15 +1120,10 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
       end
     end
 
-  rescue => e
-    case e
-    when Gem::LoadError, Gem::UnsatisfiableDependencyError, (defined?(Bundler::GemNotFound) ? Bundler::GemNotFound : Gem::LoadError)
-      warn e.message
-      warn "You may need to `gem install -g` to install missing gems"
-      warn ""
-    else
-      raise
-    end
+  rescue Gem::LoadError, Gem::UnsatisfiableDependencyError, (defined?(Bundler::GemNotFound) ? Bundler::GemNotFound : Gem::LoadError) => e
+    warn e.message
+    warn "You may need to `gem install -g` to install missing gems"
+    warn ""
   end
 
   ##

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -761,9 +761,7 @@ class Gem::Installer
 #
 
 require 'rubygems'
-
-Gem.use_gemdeps
-
+#{gemdeps_load(spec.name)}
 version = "#{Gem::Requirement.default_prerelease}"
 
 str = ARGV.first
@@ -781,6 +779,15 @@ else
 gem #{spec.name.dump}, version
 load Gem.bin_path(#{spec.name.dump}, #{bin_file_name.dump}, version)
 end
+TEXT
+  end
+
+  def gemdeps_load(name)
+    return '' if name == "bundler"
+
+    <<-TEXT
+
+Gem.use_gemdeps
 TEXT
   end
 

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -762,6 +762,8 @@ class Gem::Installer
 
 require 'rubygems'
 
+Gem.use_gemdeps
+
 version = "#{Gem::Requirement.default_prerelease}"
 
 str = ARGV.first

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -1295,7 +1295,11 @@ Also, a list:
   end
 
   def ruby_with_rubygems_in_load_path
-    [Gem.ruby, "-I", $LOAD_PATH.find{|p| p == File.dirname($LOADED_FEATURES.find{|f| f.end_with?("/rubygems.rb") }) }]
+    [Gem.ruby, "-I", rubygems_path]
+  end
+
+  def rubygems_path
+    $LOAD_PATH.find{|p| p == File.dirname($LOADED_FEATURES.find{|f| f.end_with?("/rubygems.rb") }) }
   end
 
   def with_clean_path_to_ruby

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -674,7 +674,9 @@ class TestGem < Gem::TestCase
     begin
       Dir.chdir 'detect/a/b'
 
-      assert_equal add_bundler_full_name([]), Gem.use_gemdeps.map(&:full_name)
+      Gem.use_gemdeps
+
+      assert_equal add_bundler_full_name([]), loaded_spec_names
     ensure
       Dir.chdir @tempdir
     end
@@ -1713,8 +1715,11 @@ class TestGem < Gem::TestCase
 
     ENV['RUBYGEMS_GEMDEPS'] = "-"
 
-    expected_specs = [a, b, util_spec("bundler", Bundler::VERSION), c].compact
-    assert_equal expected_specs, Gem.use_gemdeps.sort_by {|s| s.name }
+    expected_specs = [a, b, util_spec("bundler", Bundler::VERSION), c].compact.map(&:full_name)
+
+    Gem.use_gemdeps
+
+    assert_equal expected_specs, loaded_spec_names
   end
 
   BUNDLER_LIB_PATH = File.expand_path $LOAD_PATH.find {|lp| File.file?(File.join(lp, "bundler.rb")) }

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -540,7 +540,6 @@ class TestGem < Gem::TestCase
       s.executables = []
     end
     install_specs spec
-    # Should not find a-10's non-abin (bug)
     assert_equal @abin_path, Gem.bin_path('a', 'abin')
   end
 

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1975,7 +1975,7 @@ class TestGem < Gem::TestCase
 
       expected = <<-EXPECTED
 Could not find gem 'a' in locally installed gems.
-You may need to `gem install -g` to install missing gems
+You may need to `bundle install` to install missing gems
 
       EXPECTED
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -33,6 +33,8 @@ class TestGemInstaller < Gem::InstallerTestCase
 
 require 'rubygems'
 
+Gem.use_gemdeps
+
 version = \">= 0.a\"
 
 str = ARGV.first


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We have an experimental "no bundle exec needed" mode under the `RUBYGEMS_GEMDEPS` environment variable. If you set this variable to `-`, it will automatically look for a `Gemfile`, and activate the proper bundle by requiring `bundler/setup` when `rubygems` is first required. This removes the need for using `bundle exec` at all.

However, it has the gotcha that it also tries to setup the bundle when the bundler gem itself is activated, resulting in chicken-and-egg issues because now `bundle install` requires `bundle/setup`, but `bundler/setup` requires a successful `bundle install` before it can succeed. So you'll get errors like this:

```
$ bundle install
Could not find rails-6.1.4, sqlite3-1.4.2, puma-5.4.0, sass-rails-6.0.0, webpacker-5.4.0, turbolinks-5.2.1, jbuilder-2.11.2, bootsnap-1.7.6, byebug-11.1.3, web-console-4.1.0, rack-mini-profiler-2.3.2, listen-3.6.0, spring-2.1.1, capybara-3.35.3, selenium-webdriver-3.142.7, webdrivers-4.6.0, actioncable-6.1.4, actionmailbox-6.1.4, actionmailer-6.1.4, actionpack-6.1.4, actiontext-6.1.4, actionview-6.1.4, activejob-6.1.4, activemodel-6.1.4, activerecord-6.1.4, activestorage-6.1.4, activesupport-6.1.4, railties-6.1.4, sprockets-rails-3.2.2, nio4r-2.5.7, sassc-rails-2.1.2, rack-proxy-0.7.0, semantic_range-3.0.0, turbolinks-source-5.2.0, msgpack-1.4.2, bindex-0.8.1, rack-2.2.3, rb-fsevent-0.11.0, rb-inotify-0.10.1, addressable-2.8.0, mini_mime-1.1.0, nokogiri-1.11.7-x86_64-linux, rack-test-1.1.0, regexp_parser-2.1.1, xpath-3.2.0, childprocess-3.0.0, rubyzip-2.3.2, websocket-driver-0.7.5, mail-2.7.1, rails-dom-testing-2.0.3, rails-html-sanitizer-1.3.0, builder-3.2.4, erubi-1.10.0, globalid-0.5.1, marcel-1.0.1, concurrent-ruby-1.1.9, i18n-1.8.10, minitest-5.14.4, tzinfo-2.0.4, zeitwerk-2.4.2, method_source-1.0.0, rake-13.0.6, thor-1.1.0, sprockets-4.0.2, sassc-2.4.0, tilt-2.0.10, ffi-1.15.3, public_suffix-4.0.6, racc-1.5.2, websocket-extensions-0.1.5, loofah-2.10.0, crass-1.0.6 in any of the sources
You may need to `gem install -g` to install missing gems

/home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems/resolver.rb:233:in `search_for': Unable to resolve dependency: user requested 'bundler (= 2.2.25)' (Gem::UnsatisfiableDependencyError)
	from /home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems/resolver.rb:288:in `block in sort_dependencies'
	from /home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems/resolver.rb:282:in `each'
	from /home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems/resolver.rb:282:in `sort_by'
	from /home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems/resolver.rb:282:in `with_index'
	from /home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems/resolver.rb:282:in `sort_dependencies'
	from /home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems/resolver/molinillo/lib/molinillo/delegates/specification_provider.rb:60:in `block in sort_dependencies'
	from /home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems/resolver/molinillo/lib/molinillo/delegates/specification_provider.rb:77:in `with_no_such_dependency_error_handling'
	from /home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems/resolver/molinillo/lib/molinillo/delegates/specification_provider.rb:59:in `sort_dependencies'
	from /home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:754:in `push_state_for_requirements'
	from /home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:288:in `push_initial_state'
	from /home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:210:in `start_resolution'
	from /home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:168:in `resolve'
	from /home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems/resolver/molinillo/lib/molinillo/resolver.rb:43:in `resolve'
	from /home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems/resolver.rb:190:in `resolve'
	from /home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems/request_set.rb:411:in `resolve'
	from /home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems/request_set.rb:423:in `resolve_current'
	from /home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems.rb:240:in `finish_resolve'
	from /home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems.rb:303:in `block in activate_bin_path'
	from /home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems.rb:301:in `synchronize'
	from /home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems.rb:301:in `activate_bin_path'
	from /home/deivid/.rbenv/versions/3.0.2/bin/bundle:23:in `<main>'
```
## What is your fix for the problem, implemented in this PR?

My fix is to move the `bundler/setup` require to binstubs, instead of requiring it inside `rubygems.rb` unconditionally, and to skip it when activating the `bundler` gem itself.

Fixes https://github.com/rubygems/rubygems/issues/3142.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
