### PR TITLE
Add a git version guard for init.defaultBranch

### DIFF
--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -1149,7 +1149,7 @@ RSpec.describe "bundle gem" do
       it_behaves_like "--no-mit flag"
     end
 
-    context "with coc option in bundle config settings set to true" do
+    context "with coc option in bundle config settings set to true", :git => ">= 2.28.0" do
       before do
         global_config "BUNDLE_GEM__COC" => "true"
       end
@@ -1157,7 +1157,7 @@ RSpec.describe "bundle gem" do
       it_behaves_like "--no-coc flag"
     end
 
-    context "with coc option in bundle config settings set to false" do
+    context "with coc option in bundle config settings set to false", :git => ">= 2.28.0" do
       before do
         global_config "BUNDLE_GEM__COC" => "false"
       end

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe "bundle gem" do
       expect(bundled_app("#{gem_name}/README.md").read).to match(%r{https://github\.com/bundleuser/#{gem_name}/blob/.*/CODE_OF_CONDUCT.md})
     end
 
-    it "generates the README with a section for the Code of Conduct, respecting the configured git default branch", :git => "2.28.0" do
+    it "generates the README with a section for the Code of Conduct, respecting the configured git default branch", :git => ">= 2.28.0" do
       sys_exec("git config --global init.defaultBranch main")
       bundle "gem #{gem_name} --coc"
 

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe "bundle gem" do
       expect(bundled_app("#{gem_name}/README.md").read).to match(%r{https://github\.com/bundleuser/#{gem_name}/blob/.*/CODE_OF_CONDUCT.md})
     end
 
-    it "generates the README with a section for the Code of Conduct, respecting the configured git default branch" do
+    it "generates the README with a section for the Code of Conduct, respecting the configured git default branch", :git => "2.28.0" do
       sys_exec("git config --global init.defaultBranch main")
       bundle "gem #{gem_name} --coc"
 
@@ -1149,7 +1149,7 @@ RSpec.describe "bundle gem" do
       it_behaves_like "--no-mit flag"
     end
 
-    context "with coc option in bundle config settings set to true", :git => ">= 2.28.0" do
+    context "with coc option in bundle config settings set to true" do
       before do
         global_config "BUNDLE_GEM__COC" => "true"
       end
@@ -1157,7 +1157,7 @@ RSpec.describe "bundle gem" do
       it_behaves_like "--no-coc flag"
     end
 
-    context "with coc option in bundle config settings set to false", :git => ">= 2.28.0" do
+    context "with coc option in bundle config settings set to false" do
       before do
         global_config "BUNDLE_GEM__COC" => "false"
       end

--- a/bundler/spec/install/git_spec.rb
+++ b/bundler/spec/install/git_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "bundle install" do
       expect(the_bundle).to include_gems "foo 1.0", :source => "git@#{lib_path("foo")}"
     end
 
-    it "displays the correct default branch" do
+    it "displays the correct default branch", :git => ">= 2.28.0" do
       build_git "foo", "1.0", :path => lib_path("foo"), :default_branch => "main"
 
       install_gemfile <<-G, :verbose => true


### PR DESCRIPTION
Some specs use `git config --global init.defaultBranch main`, but the
configuration has been implemented since git 2.28.0.
I'm using git 2.25.1 (which is bundled in Ubuntu 20.04), so these specs
fail as follows.

```
Failures:

  1) bundle install git sources displays the correct default branch
...
       Diff:
       @@ -1,10 +1,19 @@
       -Using foo 1.0 from file:///home/mame/work/rubygems/bundler/tmp/1/libs/foo (at main@cdca7ca)
       ...
       +Using foo 1.0 from file:///home/mame/work/rubygems/bundler/tmp/1/libs/foo (at master@cdca7ca)
       ...
```

This changeset adds `:git => ">= 2.28.0"` to suppress the failures.