### PR TITLE
[CurrentRuby] Add 3.0 as a known minor

### DIFF
--- a/bundler/lib/bundler/current_ruby.rb
+++ b/bundler/lib/bundler/current_ruby.rb
@@ -20,6 +20,7 @@ module Bundler
       2.5
       2.6
       2.7
+      3.0
     ].freeze
 
     KNOWN_MAJOR_VERSIONS = KNOWN_MINOR_VERSIONS.map {|v| v.split(".", 2).first }.uniq.freeze


### PR DESCRIPTION
This is an update similar to https://github.com/rubygems/rubygems/commit/5b24c2d.

## What was the end-user or developer problem that led to this PR?

### Before

```consle
% ruby -v
ruby 3.0.1p64 (2021-04-05 revision 0fb782ee38) [x86_64-darwin19]
```

```ruby
Bundler.current_ruby.ruby_30?
#=> undefined method `ruby_30?' for #<Bundler::CurrentRuby:0x00007fb0b984f500> (NoMethodError)
```

## What is your fix for the problem, implemented in this PR?

### After

```ruby
Bundler.current_ruby.ruby_30?
#=> true
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
