### PR TITLE
Improve `bundle pristine` error if `BUNDLE_GEMFILE` does not exist

### DIFF
--- a/bundler/lib/bundler/cli/common.rb
+++ b/bundler/lib/bundler/cli/common.rb
@@ -94,6 +94,8 @@ module Bundler
     end
 
     def self.ensure_all_gems_in_lockfile!(names, locked_gems = Bundler.locked_gems)
+      return unless locked_gems
+
       locked_names = locked_gems.specs.map(&:name).uniq
       names.-(locked_names).each do |g|
         raise GemNotFound, gem_not_found_message(g, locked_names)

--- a/bundler/spec/commands/pristine_spec.rb
+++ b/bundler/spec/commands/pristine_spec.rb
@@ -203,6 +203,16 @@ RSpec.describe "bundle pristine", :ruby_repo do
     end
   end
 
+  context "when BUNDLE_GEMFILE doesn't exist" do
+    before do
+      bundle "pristine", :env => { "BUNDLE_GEMFILE" => "does/not/exist" }, :raise_on_error => false
+    end
+
+    it "shows a meaninful error" do
+      expect(err).to eq("#{bundled_app("does/not/exist")} not found")
+    end
+  end
+
   def find_spec(name)
     without_env_side_effects do
       Bundler.definition.specs[name].first


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If you make a mistake and set `BUNDLE_GEMFILE` to a path that does not exist, `bundle pristine` would crash calling a method on `nil`, like this:

```
/path/to/lib/bundler/cli/common.rb:97:in `ensure_all_gems_in_lockfile!': undefined method `specs' for nil:NilClass (NoMethodError)
  from /path/to/lib/bundler/cli/pristine.rb:10:in `run'
  from /path/to/lib/bundler/cli.rb:728:in `pristine'
  from /path/to/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
  from /path/to/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
  from /path/to/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
  from /path/to/lib/bundler/cli.rb:30:in `dispatch'
  from /path/to/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
  from /path/to/lib/bundler/cli.rb:24:in `start'
  from /path/to/exe/bundle:49:in `block in <top (required)>'
  from /path/to/lib/bundler/friendly_errors.rb:130:in `with_friendly_errors'
  from /path/to/exe/bundle:37:in `<top (required)>'
  from /path/to/bin/bundle:23:in `load'
  from /path/to/bin/bundle:23:in `<main>'
```

## What is your fix for the problem, implemented in this PR?

Avoid the previous error, so that `bundler` ends up showing a better error like:

```
/path/to/wrong/gemfile not found
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
