### PR TITLE
Easier gemspec syncing with ruby-core

### DIFF
--- a/bundler/bundler.gemspec
+++ b/bundler/bundler.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = ">= 2.3.0"
   s.required_rubygems_version = ">= 2.5.2"
 
-  s.files = Dir.glob("lib/**/*", File::FNM_DOTMATCH).reject {|f| File.directory?(f) }
+  s.files = Dir.glob("lib/bundler{.rb,/**/*}", File::FNM_DOTMATCH).reject {|f| File.directory?(f) }
 
   # Include the CHANGELOG.md, LICENSE.md, README.md manually
   s.files += %w[CHANGELOG.md LICENSE.md README.md]

--- a/bundler/bundler.gemspec
+++ b/bundler/bundler.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = ">= 2.3.0"
   s.required_rubygems_version = ">= 2.5.2"
 
-  s.files = Dir.glob("{lib,exe}/**/*", File::FNM_DOTMATCH).reject {|f| File.directory?(f) }
+  s.files = Dir.glob("lib/**/*", File::FNM_DOTMATCH).reject {|f| File.directory?(f) }
 
   # Include the CHANGELOG.md, LICENSE.md, README.md manually
   s.files += %w[CHANGELOG.md LICENSE.md README.md]

--- a/bundler/bundler.gemspec
+++ b/bundler/bundler.gemspec
@@ -36,11 +36,10 @@ Gem::Specification.new do |s|
 
   s.files = Dir.glob("lib/bundler{.rb,/**/*}", File::FNM_DOTMATCH).reject {|f| File.directory?(f) }
 
-  # Include the CHANGELOG.md, LICENSE.md, README.md manually
-  s.files += %w[CHANGELOG.md LICENSE.md README.md]
   # include the gemspec itself because warbler breaks w/o it
   s.files += %w[bundler.gemspec]
 
+  s.extra_rdoc_files = %w[CHANGELOG.md LICENSE.md README.md]
   s.bindir        = "exe"
   s.executables   = %w[bundle bundler]
   s.require_paths = ["lib"]

--- a/bundler/spec/quality_spec.rb
+++ b/bundler/spec/quality_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe "The library itself" do
   end
 
   it "ships the correct set of files" do
-    git_list = git_ls_files(ruby_core? ? "lib/bundler lib/bundler.rb man/bundle* man/gemfile* libexec/bundle*" : "lib man exe CHANGELOG.md LICENSE.md README.md bundler.gemspec")
+    git_list = git_ls_files(ruby_core? ? "lib/bundler lib/bundler.rb libexec/bundle*" : "lib exe CHANGELOG.md LICENSE.md README.md bundler.gemspec")
 
     gem_list = loaded_gemspec.files
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Syncying bundler with ruby-core is tricky. After https://github.com/ruby/ruby/commit/0d9496f924d36534bd524791554d49dc0026b0e0, it can be done through `ruby tool/sync_defaullt_gems.rb bundler` without manual modifications, but if we make changes to the gemspec, it won't be ported properly. For example, bumping the minimum required ruby version or other similar changes.


## What is your fix for the problem, implemented in this PR?

With these tweaks to our gemspec, and a patch to the ruby sync tool (https://github.com/ruby/ruby/blob/26888d5e032202328e10881550477fd036c8e805/tool/sync_default_gems.rb#L97-L108) like this:

```diff
diff --git a/tool/sync_default_gems.rb b/tool/sync_default_gems.rb
index 9c8afecf10..3a250cc075 100644
--- a/tool/sync_default_gems.rb
+++ b/tool/sync_default_gems.rb
@@ -98,12 +98,18 @@ def sync_default_gems(gem)
     rm_rf(%w[lib/bundler lib/bundler.rb libexec/bundler libexec/bundle spec/bundler tool/bundler/*])
     cp_r(Dir.glob("#{upstream}/bundler/lib/bundler*"), "lib")
     cp_r(Dir.glob("#{upstream}/bundler/exe/bundle*"), "libexec")
-    cp_r("#{upstream}/bundler/bundler.gemspec", "lib/bundler")
+
+    gemspec_content = File.readlines("#{upstream}/bundler/bundler.gemspec").map do |line|
+      next if line =~ /extra_rdoc_files/
+
+      line.gsub("bundler.gemspec", "lib/bundler/bundler.gemspec").gsub('"exe"', '"libexec"')
+    end.compact.join
+    File.write("lib/bundler/bundler.gemspec", gemspec_content)
+
     cp_r("#{upstream}/bundler/spec", "spec/bundler")
     cp_r(Dir.glob("#{upstream}/bundler/tool/bundler/test_gems*"), "tool/bundler")
     cp_r(Dir.glob("#{upstream}/bundler/tool/bundler/rubocop_gems*"), "tool/bundler")
     cp_r(Dir.glob("#{upstream}/bundler/tool/bundler/standard_gems*"), "tool/bundler")
-    `git checkout lib/bundler/bundler.gemspec`
     rm_rf(%w[spec/bundler/support/artifice/vcr_cassettes])
```

I expect the syncronization to never require manual intervention.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
