### PR TITLE
Debug compact index misses

### DIFF
--- a/bundler/lib/bundler/fetcher/compact_index.rb
+++ b/bundler/lib/bundler/fetcher/compact_index.rb
@@ -69,8 +69,6 @@ module Bundler
 
       def available?
         return nil unless SharedHelpers.md5_available?
-        user_home = Bundler.user_home
-        return nil unless user_home.directory? && user_home.writable?
         # Read info file checksums out of /versions, so we can know if gems are up to date
         fetch_uri.scheme != "file" && compact_index_client.update_and_parse_checksums!
       rescue CompactIndexClient::Updater::MisMatchedChecksumError => e

--- a/bundler/lib/bundler/fetcher/compact_index.rb
+++ b/bundler/lib/bundler/fetcher/compact_index.rb
@@ -68,7 +68,10 @@ module Bundler
       compact_index_request :fetch_spec
 
       def available?
-        return nil unless SharedHelpers.md5_available?
+        unless SharedHelpers.md5_available?
+          Bundler.ui.debug("FIPS mode is enabled, bundler can't use the CompactIndex API")
+          return nil
+        end
         # Read info file checksums out of /versions, so we can know if gems are up to date
         fetch_uri.scheme != "file" && compact_index_client.update_and_parse_checksums!
       rescue CompactIndexClient::Updater::MisMatchedChecksumError => e

--- a/bundler/lib/bundler/fetcher/compact_index.rb
+++ b/bundler/lib/bundler/fetcher/compact_index.rb
@@ -72,8 +72,12 @@ module Bundler
           Bundler.ui.debug("FIPS mode is enabled, bundler can't use the CompactIndex API")
           return nil
         end
+        if fetch_uri.scheme == "file"
+          Bundler.ui.debug("Using a local server, bundler won't use the CompactIndex API")
+          return false
+        end
         # Read info file checksums out of /versions, so we can know if gems are up to date
-        fetch_uri.scheme != "file" && compact_index_client.update_and_parse_checksums!
+        compact_index_client.update_and_parse_checksums!
       rescue CompactIndexClient::Updater::MisMatchedChecksumError => e
         Bundler.ui.debug(e.message)
         nil

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -87,9 +87,11 @@ module Spec
       env = options.delete(:env) || {}
 
       requires = options.delete(:requires) || []
+      realworld = RSpec.current_example.metadata[:realworld]
+      options[:verbose] = true if options[:verbose].nil? && realworld
 
       artifice = options.delete(:artifice) do
-        if RSpec.current_example.metadata[:realworld]
+        if realworld
           "vcr"
         else
           "fail"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We're recently getting realworld spec flaky failures due to bundler unexpectedly falling back to the old dependency API, for which we have no recorded VCR responses.

## What is your fix for the problem, implemented in this PR?

No fix yet, but I'm adding some debugging code, so that we can know why we're falling back unexpectedly.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
