### PR TITLE
Fix usage messages to reflect the current POSIX-compatible behaviour

### DIFF
--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -130,7 +130,7 @@ You can use `i` command instead of `install`.
   end
 
   def usage # :nodoc:
-    "#{program_name} GEMNAME [GEMNAME ...] [options] -- --build-flags"
+    "#{program_name} [options] GEMNAME [GEMNAME ...] -- --build-flags"
   end
 
   def check_install_dir # :nodoc:

--- a/lib/rubygems/commands/open_command.rb
+++ b/lib/rubygems/commands/open_command.rb
@@ -36,7 +36,7 @@ class Gem::Commands::OpenCommand < Gem::Command
   end
 
   def usage # :nodoc:
-    "#{program_name} GEMNAME [-e COMMAND]"
+    "#{program_name} [-e COMMAND] GEMNAME"
   end
 
   def get_env_editor

--- a/lib/rubygems/commands/yank_command.rb
+++ b/lib/rubygems/commands/yank_command.rb
@@ -24,7 +24,7 @@ data you will need to change them immediately and yank your gem.
   end
 
   def usage # :nodoc:
-    "#{program_name} GEM -v VERSION [-p PLATFORM] [--key KEY_NAME] [--host HOST]"
+    "#{program_name} -v VERSION [-p PLATFORM] [--key KEY_NAME] [--host HOST] GEM"
   end
 
   def initialize


### PR DESCRIPTION
When POSIXLY_CORRECT environment variable is set, the argument parsing
tries to behave in POSIX-compatible manner. That is fine, but leads to
usage messages no longer being accurate:

    $ POSIXLY_CORRECT= gem open foo -e nano
    ERROR:  While executing gem ... (Gem::CommandLineError)
        Too many gem names (foo, -e, nano); please specify only one

Correct invocation would be:

    $ POSIXLY_CORRECT= gem open -e nano foo
    Unable to find gem 'foo'

However, usage help says nothing about that. This commit therefore
shuffles the usage order to make it always correct.

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

Closes #4538.

## What is your fix for the problem, implemented in this PR?

Described in the commit message.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [?] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
  -> I'm not sure what to do about this. There are no existing tests that break with this and introducing new just for checking if correct message is printed seems weird.
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
