### PR TITLE
Get some more Windows specs passing

### DIFF
--- a/bundler/lib/bundler/dependency.rb
+++ b/bundler/lib/bundler/dependency.rb
@@ -96,9 +96,7 @@ module Bundler
     def gem_platforms(valid_platforms)
       return valid_platforms if @platforms.empty?
 
-      valid_generic_platforms = valid_platforms.map {|p| [p, GemHelpers.generic(p)] }.to_h
-      filtered_generic_platforms = valid_generic_platforms.values & expanded_platforms
-      valid_generic_platforms.select {|_, v| filtered_generic_platforms.include?(v) }.keys
+      valid_platforms.select {|p| expanded_platforms.include?(GemHelpers.generic(p)) }
     end
 
     def expanded_platforms

--- a/bundler/lib/bundler/dependency.rb
+++ b/bundler/lib/bundler/dependency.rb
@@ -97,14 +97,12 @@ module Bundler
       return valid_platforms if @platforms.empty?
 
       valid_generic_platforms = valid_platforms.map {|p| [p, GemHelpers.generic(p)] }.to_h
-      @gem_platforms ||= expanded_platforms.compact.uniq
-
-      filtered_generic_platforms = valid_generic_platforms.values & @gem_platforms
+      filtered_generic_platforms = valid_generic_platforms.values & expanded_platforms
       valid_generic_platforms.select {|_, v| filtered_generic_platforms.include?(v) }.keys
     end
 
     def expanded_platforms
-      @platforms.map {|pl| PLATFORM_MAP[pl] }
+      @expanded_platforms ||= @platforms.map {|pl| PLATFORM_MAP[pl] }.compact.uniq
     end
 
     def should_include?

--- a/bundler/spec/commands/cache_spec.rb
+++ b/bundler/spec/commands/cache_spec.rb
@@ -234,11 +234,11 @@ RSpec.describe "bundle cache" do
 
       bundle "config set --local without wo"
       install_gemfile <<-G
-        source "file:#{gem_repo1}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
         group :wo do
           gem "weakling"
-          gem "uninstallable", :source => "file:#{gem_repo4}"
+          gem "uninstallable", :source => "#{file_uri_for(gem_repo4)}"
         end
       G
 

--- a/bundler/spec/commands/cache_spec.rb
+++ b/bundler/spec/commands/cache_spec.rb
@@ -211,11 +211,9 @@ RSpec.describe "bundle cache" do
   end
 
   context "with --all-platforms" do
-    before do
-      skip "doesn't put gems where it should" if Gem.win_platform?
-    end
-
     it "puts the gems in vendor/cache even for other rubies" do
+      skip "doesn't put gems where it should" if Gem.win_platform?
+
       gemfile <<-D
         source "#{file_uri_for(gem_repo1)}"
         gem 'rack', :platforms => :ruby_19

--- a/bundler/spec/commands/cache_spec.rb
+++ b/bundler/spec/commands/cache_spec.rb
@@ -212,11 +212,9 @@ RSpec.describe "bundle cache" do
 
   context "with --all-platforms" do
     it "puts the gems in vendor/cache even for other rubies" do
-      skip "doesn't put gems where it should" if Gem.win_platform?
-
       gemfile <<-D
         source "#{file_uri_for(gem_repo1)}"
-        gem 'rack', :platforms => :ruby_19
+        gem 'rack', :platforms => [:ruby_20, :x64_mingw_20]
       D
 
       bundle "cache --all-platforms"

--- a/bundler/spec/commands/clean_spec.rb
+++ b/bundler/spec/commands/clean_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe "bundle clean" do
     revision = revision_for(git_path)
 
     gemfile <<-G
-      source "file://#{gem_repo1}"
+      source "#{file_uri_for(gem_repo1)}"
 
       gem "rack", "1.0.0"
       git "#{git_path}", :ref => "#{revision}" do

--- a/bundler/spec/runtime/inline_spec.rb
+++ b/bundler/spec/runtime/inline_spec.rb
@@ -293,7 +293,7 @@ RSpec.describe "bundler/inline#gemfile" do
     it "installs inline gems to the system path regardless" do
       script <<-RUBY, :env => { "BUNDLE_PATH" => "./vendor/inline" }
         gemfile(true) do
-          source "file://#{gem_repo1}"
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack"
         end
       RUBY


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We still have some skipped specs on Windows. I investigated one of them.

## What is your fix for the problem, implemented in this PR?

The fix consists of adding the proper platform to the spec, so that it also passes on Windows. While investigating the issue, I ended up adding some refactorings too.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
