### PR TITLE
Fix `bundle cache` with an up-to-date lockfile and specs not already installed

### DIFF
--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -78,10 +78,10 @@ module Bundler
 
     def materialize(deps, missing_specs = nil)
       materialized = self.for(deps, [], false, true, !missing_specs).to_a
-      deps = materialized.map(&:name).uniq
+      names = materialized.map(&:name).uniq
       materialized.map! do |s|
         next s unless s.is_a?(LazySpecification)
-        s.source.dependency_names = deps if s.source.respond_to?(:dependency_names=)
+        s.source.dependency_names = names if s.source.respond_to?(:dependency_names=)
         s.source.local!
         spec = s.__materialize__
         unless spec

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -78,11 +78,17 @@ module Bundler
 
     def materialize(deps, missing_specs = nil)
       materialized = self.for(deps, [], false, true, !missing_specs).to_a
-      names = materialized.map(&:name).uniq
+
+      materialized.group_by(&:source).each do |source, specs|
+        next unless specs.any?{|s| s.is_a?(LazySpecification) }
+
+        names = specs.map(&:name).uniq
+        source.dependency_names = names if source.respond_to?(:dependency_names)
+        source.local!
+      end
+
       materialized.map! do |s|
         next s unless s.is_a?(LazySpecification)
-        s.source.dependency_names = names if s.source.respond_to?(:dependency_names=)
-        s.source.local!
         spec = s.__materialize__
         unless spec
           unless missing_specs
@@ -99,12 +105,17 @@ module Bundler
     # This is in contrast to how for does platform filtering (and specifically different from how `materialize` calls `for` only for the current platform)
     # @return [Array<Gem::Specification>]
     def materialized_for_all_platforms
-      names = @specs.map(&:name).uniq
+      @specs.group_by(&:source).each do |source, specs|
+        next unless specs.any?{|s| s.is_a?(LazySpecification) }
+
+        names = specs.map(&:name).uniq
+        source.dependency_names = names if source.respond_to?(:dependency_names)
+        source.local!
+        source.remote!
+      end
+
       @specs.map do |s|
         next s unless s.is_a?(LazySpecification)
-        s.source.dependency_names = names if s.source.respond_to?(:dependency_names=)
-        s.source.local!
-        s.source.remote!
         spec = s.__materialize__
         raise GemNotFound, "Could not find #{s.full_name} in any of the sources" unless spec
         spec

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -82,8 +82,8 @@ module Bundler
       materialized.group_by(&:source).each do |source, specs|
         next unless specs.any?{|s| s.is_a?(LazySpecification) }
 
-        names = specs.map(&:name).uniq
-        source.dependency_names = names if source.respond_to?(:dependency_names)
+        names = -> { specs.map(&:name).uniq }
+        source.double_check_for(names)
         source.local!
       end
 
@@ -108,8 +108,8 @@ module Bundler
       @specs.group_by(&:source).each do |source, specs|
         next unless specs.any?{|s| s.is_a?(LazySpecification) }
 
-        names = specs.map(&:name).uniq
-        source.dependency_names = names if source.respond_to?(:dependency_names)
+        names = -> { specs.map(&:name).uniq }
+        source.double_check_for(names)
         source.local!
         source.remote!
       end

--- a/bundler/spec/commands/cache_spec.rb
+++ b/bundler/spec/commands/cache_spec.rb
@@ -255,6 +255,21 @@ RSpec.describe "bundle cache" do
       expect(the_bundle).to include_gem "rack 1.0"
       expect(the_bundle).not_to include_gems "weakling", "uninstallable"
     end
+
+    it "does not fail to cache gems in excluded groups when there's a lockfile but gems not previously installed" do
+      bundle "config set --local without wo"
+      gemfile <<-G
+        source "https://my.gem.repo.1"
+        gem "rack"
+        group :wo do
+          gem "weakling"
+        end
+      G
+
+      bundle :lock, :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo1.to_s }
+      bundle :cache, "all-platforms" => true, :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo1.to_s }
+      expect(bundled_app("vendor/cache/weakling-0.0.3.gem")).to exist
+    end
   end
 
   context "with frozen configured" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When running `bundle cache` with excluded groups and a pre-existing lockfile, first `bundle install` is run excluding gems in the excluded groups. After that, the whole set of gems should be cached including those from excluded groups.

In the case where the lockfile is up to date and specs are not previously installed, we're only dealing with `LazySpecification`
objects built from information in the lockfile. These need to be materialized into real specifications that can be fetched.

Materializing these specs happens twice in this case, first when fetching gems for installation, then when fetching gems for caching. In the case of installation, we don't want to fetch excluded gems, but when caching we want to fetch them. This means the second time we materialize the set of specs, the dependency names to be fetched from the main
source have changed, and we need to make sure to fetch any new specifications that might be missing. It sounds like this is what
setting `dependency_names` was trying to do here, but this has no effect on spec fetching.

## What is your fix for the problem, implemented in this PR?

The fix is to replace setting `#dependency_names` with another index method, `double_check_for(names)` that actually re-fetches any names that might be missing in the source.

The PR also includes other fix to only re-fetch dependency names that are supposed to be picked up from the source, instead of fetching all names involved in the bundle.

Fixes #4547.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
