### PR TITLE
Don't materialize resolutions when not necessary

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -166,16 +166,14 @@ module Bundler
     end
 
     def resolve_with_cache!
-      raise "Specs already loaded" if @specs
       sources.cached!
-      specs
+      resolve
     end
 
     def resolve_remotely!
-      return if @specs
       @remote = true
       sources.remote!
-      specs
+      resolve
     end
 
     # For given dependency list returns a SpecSet with Gemspec of all the required

--- a/bundler/spec/commands/outdated_spec.rb
+++ b/bundler/spec/commands/outdated_spec.rb
@@ -1,24 +1,24 @@
 # frozen_string_literal: true
 
 RSpec.describe "bundle outdated" do
-  before do
-    build_repo2 do
-      build_git "foo", :path => lib_path("foo")
-      build_git "zebra", :path => lib_path("zebra")
+  describe "with no arguments" do
+    before do
+      build_repo2 do
+        build_git "foo", :path => lib_path("foo")
+        build_git "zebra", :path => lib_path("zebra")
+      end
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "zebra", :git => "#{lib_path("zebra")}"
+        gem "foo", :git => "#{lib_path("foo")}"
+        gem "activesupport", "2.3.5"
+        gem "weakling", "~> 0.0.1"
+        gem "duradura", '7.0'
+        gem "terranova", '8'
+      G
     end
 
-    install_gemfile <<-G
-      source "#{file_uri_for(gem_repo2)}"
-      gem "zebra", :git => "#{lib_path("zebra")}"
-      gem "foo", :git => "#{lib_path("foo")}"
-      gem "activesupport", "2.3.5"
-      gem "weakling", "~> 0.0.1"
-      gem "duradura", '7.0'
-      gem "terranova", '8'
-    G
-  end
-
-  describe "with no arguments" do
     it "returns a sorted list of outdated gems" do
       update_repo2 do
         build_gem "activesupport", "3.0"
@@ -102,6 +102,23 @@ RSpec.describe "bundle outdated" do
   end
 
   describe "with --verbose option" do
+    before do
+      build_repo2 do
+        build_git "foo", :path => lib_path("foo")
+        build_git "zebra", :path => lib_path("zebra")
+      end
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "zebra", :git => "#{lib_path("zebra")}"
+        gem "foo", :git => "#{lib_path("foo")}"
+        gem "activesupport", "2.3.5"
+        gem "weakling", "~> 0.0.1"
+        gem "duradura", '7.0'
+        gem "terranova", '8'
+      G
+    end
+
     it "shows the location of the latest version's gemspec if installed" do
       bundle "config set clean false"
 
@@ -136,6 +153,11 @@ RSpec.describe "bundle outdated" do
 
   describe "with --group option" do
     before do
+      build_repo2 do
+        build_git "foo", :path => lib_path("foo")
+        build_git "zebra", :path => lib_path("zebra")
+      end
+
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
 
@@ -201,7 +223,10 @@ RSpec.describe "bundle outdated" do
 
   describe "with --groups option and outdated transitive dependencies" do
     before do
-      update_repo2 do
+      build_repo2 do
+        build_git "foo", :path => lib_path("foo")
+        build_git "zebra", :path => lib_path("zebra")
+
         build_gem "bar", %w[2.0.0]
 
         build_gem "bar_dependant", "7.0" do |s|
@@ -234,6 +259,11 @@ RSpec.describe "bundle outdated" do
 
   describe "with --groups option" do
     before do
+      build_repo2 do
+        build_git "foo", :path => lib_path("foo")
+        build_git "zebra", :path => lib_path("zebra")
+      end
+
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
 
@@ -272,6 +302,24 @@ RSpec.describe "bundle outdated" do
   end
 
   describe "with --local option" do
+    before do
+      build_repo2 do
+        build_git "foo", :path => lib_path("foo")
+        build_git "zebra", :path => lib_path("zebra")
+      end
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+
+        gem "weakling", "~> 0.0.1"
+        gem "terranova", '8'
+        group :development, :test do
+          gem 'activesupport', '2.3.5'
+          gem "duradura", '7.0'
+        end
+      G
+    end
+
     it "uses local cache to return a list of outdated gems" do
       update_repo2 do
         build_gem "activesupport", "2.3.4"
@@ -305,10 +353,23 @@ RSpec.describe "bundle outdated" do
   shared_examples_for "a minimal output is desired" do
     context "and gems are outdated" do
       before do
-        update_repo2 do
+        build_repo2 do
+          build_git "foo", :path => lib_path("foo")
+          build_git "zebra", :path => lib_path("zebra")
+
           build_gem "activesupport", "3.0"
           build_gem "weakling", "0.2"
         end
+
+        install_gemfile <<-G
+          source "#{file_uri_for(gem_repo2)}"
+          gem "zebra", :git => "#{lib_path("zebra")}"
+          gem "foo", :git => "#{lib_path("foo")}"
+          gem "activesupport", "2.3.5"
+          gem "weakling", "~> 0.0.1"
+          gem "duradura", '7.0'
+          gem "terranova", '8'
+        G
       end
 
       it "outputs a sorted list of outdated gems with a more minimal format" do
@@ -341,6 +402,21 @@ RSpec.describe "bundle outdated" do
 
   describe "with specified gems" do
     it "returns list of outdated gems" do
+      build_repo2 do
+        build_git "foo", :path => lib_path("foo")
+        build_git "zebra", :path => lib_path("zebra")
+      end
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "zebra", :git => "#{lib_path("zebra")}"
+        gem "foo", :git => "#{lib_path("foo")}"
+        gem "activesupport", "2.3.5"
+        gem "weakling", "~> 0.0.1"
+        gem "duradura", '7.0'
+        gem "terranova", '8'
+      G
+
       update_repo2 do
         build_gem "activesupport", "3.0"
         update_git "foo", :path => lib_path("foo")
@@ -358,6 +434,23 @@ RSpec.describe "bundle outdated" do
   end
 
   describe "pre-release gems" do
+    before do
+      build_repo2 do
+        build_git "foo", :path => lib_path("foo")
+        build_git "zebra", :path => lib_path("zebra")
+      end
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "zebra", :git => "#{lib_path("zebra")}"
+        gem "foo", :git => "#{lib_path("foo")}"
+        gem "activesupport", "2.3.5"
+        gem "weakling", "~> 0.0.1"
+        gem "duradura", '7.0'
+        gem "terranova", '8'
+      G
+    end
+
     context "without the --pre option" do
       it "ignores pre-release versions" do
         update_repo2 do
@@ -413,6 +506,23 @@ RSpec.describe "bundle outdated" do
 
   filter_strict_option = Bundler.feature_flag.bundler_2_mode? ? :"filter-strict" : :strict
   describe "with --#{filter_strict_option} option" do
+    before do
+      build_repo2 do
+        build_git "foo", :path => lib_path("foo")
+        build_git "zebra", :path => lib_path("zebra")
+      end
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "zebra", :git => "#{lib_path("zebra")}"
+        gem "foo", :git => "#{lib_path("foo")}"
+        gem "activesupport", "2.3.5"
+        gem "weakling", "~> 0.0.1"
+        gem "duradura", '7.0'
+        gem "terranova", '8'
+      G
+    end
+
     it "only reports gems that have a newer version that matches the specified dependency version requirements" do
       update_repo2 do
         build_gem "activesupport", "3.0"
@@ -521,6 +631,23 @@ RSpec.describe "bundle outdated" do
   end
 
   describe "with invalid gem name" do
+    before do
+      build_repo2 do
+        build_git "foo", :path => lib_path("foo")
+        build_git "zebra", :path => lib_path("zebra")
+      end
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "zebra", :git => "#{lib_path("zebra")}"
+        gem "foo", :git => "#{lib_path("foo")}"
+        gem "activesupport", "2.3.5"
+        gem "weakling", "~> 0.0.1"
+        gem "duradura", '7.0'
+        gem "terranova", '8'
+      G
+    end
+
     it "returns could not find gem name" do
       bundle "outdated invalid_gem_name", :raise_on_error => false
       expect(err).to include("Could not find gem 'invalid_gem_name'.")
@@ -546,12 +673,16 @@ RSpec.describe "bundle outdated" do
 
   context "after bundle install --deployment", :bundler => "< 3" do
     before do
-      install_gemfile <<-G, :deployment => true, :raise_on_error => false
+      build_repo2
+
+      gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
 
         gem "rack"
         gem "foo"
       G
+      bundle :lock
+      bundle :install, :deployment => true
     end
 
     it "outputs a helpful message about being in deployment mode" do
@@ -568,6 +699,11 @@ RSpec.describe "bundle outdated" do
 
   context "after bundle config set --local deployment true" do
     before do
+      build_repo2 do
+        build_git "foo", :path => lib_path("foo")
+        build_git "zebra", :path => lib_path("zebra")
+      end
+
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
 
@@ -591,6 +727,8 @@ RSpec.describe "bundle outdated" do
 
   context "update available for a gem on a different platform" do
     before do
+      build_repo2
+
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "laduradura", '= 5.15.2'
@@ -604,6 +742,10 @@ RSpec.describe "bundle outdated" do
   end
 
   context "update available for a gem on the same platform while multiple platforms used for gem" do
+    before do
+      build_repo2
+    end
+
     it "reports that updates are available if the Ruby platform is used" do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
@@ -643,6 +785,21 @@ RSpec.describe "bundle outdated" do
 
   shared_examples_for "major version updates are detected" do
     before do
+      build_repo2 do
+        build_git "foo", :path => lib_path("foo")
+        build_git "zebra", :path => lib_path("zebra")
+      end
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "zebra", :git => "#{lib_path("zebra")}"
+        gem "foo", :git => "#{lib_path("foo")}"
+        gem "activesupport", "2.3.5"
+        gem "weakling", "~> 0.0.1"
+        gem "duradura", '7.0'
+        gem "terranova", '8'
+      G
+
       update_repo2 do
         build_gem "activesupport", "3.3.5"
         build_gem "weakling", "0.8.0"
@@ -654,6 +811,21 @@ RSpec.describe "bundle outdated" do
 
   context "when on a new machine" do
     before do
+      build_repo2 do
+        build_git "foo", :path => lib_path("foo")
+        build_git "zebra", :path => lib_path("zebra")
+      end
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "zebra", :git => "#{lib_path("zebra")}"
+        gem "foo", :git => "#{lib_path("foo")}"
+        gem "activesupport", "2.3.5"
+        gem "weakling", "~> 0.0.1"
+        gem "duradura", '7.0'
+        gem "terranova", '8'
+      G
+
       simulate_new_machine
 
       update_git "foo", :path => lib_path("foo")
@@ -669,6 +841,21 @@ RSpec.describe "bundle outdated" do
 
   shared_examples_for "minor version updates are detected" do
     before do
+      build_repo2 do
+        build_git "foo", :path => lib_path("foo")
+        build_git "zebra", :path => lib_path("zebra")
+      end
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "zebra", :git => "#{lib_path("zebra")}"
+        gem "foo", :git => "#{lib_path("foo")}"
+        gem "activesupport", "2.3.5"
+        gem "weakling", "~> 0.0.1"
+        gem "duradura", '7.0'
+        gem "terranova", '8'
+      G
+
       update_repo2 do
         build_gem "activesupport", "2.7.5"
         build_gem "weakling", "2.0.1"
@@ -680,6 +867,21 @@ RSpec.describe "bundle outdated" do
 
   shared_examples_for "patch version updates are detected" do
     before do
+      build_repo2 do
+        build_git "foo", :path => lib_path("foo")
+        build_git "zebra", :path => lib_path("zebra")
+      end
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "zebra", :git => "#{lib_path("zebra")}"
+        gem "foo", :git => "#{lib_path("foo")}"
+        gem "activesupport", "2.3.5"
+        gem "weakling", "~> 0.0.1"
+        gem "duradura", '7.0'
+        gem "terranova", '8'
+      G
+
       update_repo2 do
         build_gem "activesupport", "2.3.7"
         build_gem "weakling", "0.3.1"
@@ -698,6 +900,21 @@ RSpec.describe "bundle outdated" do
 
   shared_examples_for "major version is ignored" do
     before do
+      build_repo2 do
+        build_git "foo", :path => lib_path("foo")
+        build_git "zebra", :path => lib_path("zebra")
+      end
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "zebra", :git => "#{lib_path("zebra")}"
+        gem "foo", :git => "#{lib_path("foo")}"
+        gem "activesupport", "2.3.5"
+        gem "weakling", "~> 0.0.1"
+        gem "duradura", '7.0'
+        gem "terranova", '8'
+      G
+
       update_repo2 do
         build_gem "activesupport", "3.3.5"
         build_gem "weakling", "1.0.1"
@@ -709,6 +926,21 @@ RSpec.describe "bundle outdated" do
 
   shared_examples_for "minor version is ignored" do
     before do
+      build_repo2 do
+        build_git "foo", :path => lib_path("foo")
+        build_git "zebra", :path => lib_path("zebra")
+      end
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "zebra", :git => "#{lib_path("zebra")}"
+        gem "foo", :git => "#{lib_path("foo")}"
+        gem "activesupport", "2.3.5"
+        gem "weakling", "~> 0.0.1"
+        gem "duradura", '7.0'
+        gem "terranova", '8'
+      G
+
       update_repo2 do
         build_gem "activesupport", "2.4.5"
         build_gem "weakling", "0.3.1"
@@ -720,6 +952,21 @@ RSpec.describe "bundle outdated" do
 
   shared_examples_for "patch version is ignored" do
     before do
+      build_repo2 do
+        build_git "foo", :path => lib_path("foo")
+        build_git "zebra", :path => lib_path("zebra")
+      end
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "zebra", :git => "#{lib_path("zebra")}"
+        gem "foo", :git => "#{lib_path("foo")}"
+        gem "activesupport", "2.3.5"
+        gem "weakling", "~> 0.0.1"
+        gem "duradura", '7.0'
+        gem "terranova", '8'
+      G
+
       update_repo2 do
         build_gem "activesupport", "2.3.6"
         build_gem "weakling", "0.0.4"

--- a/bundler/spec/commands/outdated_spec.rb
+++ b/bundler/spec/commands/outdated_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe "bundle outdated" do
-  before :each do
+  before do
     build_repo2 do
       build_git "foo", :path => lib_path("foo")
       build_git "zebra", :path => lib_path("zebra")

--- a/bundler/spec/commands/outdated_spec.rb
+++ b/bundler/spec/commands/outdated_spec.rb
@@ -151,6 +151,72 @@ RSpec.describe "bundle outdated" do
     end
   end
 
+  describe "with multiple, duplicated sources, with lockfile in old format", :bundler => "< 3" do
+    before do
+      build_repo2 do
+        build_gem "dotenv", "2.7.6"
+
+        build_gem "oj", "3.11.3"
+        build_gem "oj", "3.11.5"
+
+        build_gem "vcr", "6.0.0"
+      end
+
+      build_repo gem_repo3 do
+        build_gem "pkg-gem-flowbyte-with-dep", "1.0.0" do |s|
+          s.add_dependency "oj"
+        end
+      end
+
+      gemfile <<~G
+        source "https://gem.repo2"
+
+        gem "dotenv"
+
+        source "https://gem.repo3" do
+          gem 'pkg-gem-flowbyte-with-dep'
+        end
+
+        gem "vcr",source: "https://gem.repo2"
+      G
+
+      lockfile <<~L
+        GEM
+          remote: https://gem.repo2/
+          remote: https://gem.repo3/
+          specs:
+            dotenv (2.7.6)
+            oj (3.11.3)
+            pkg-gem-flowbyte-with-dep (1.0.0)
+              oj
+            vcr (6.0.0)
+
+        PLATFORMS
+          #{specific_local_platform}
+
+        DEPENDENCIES
+          dotenv
+          pkg-gem-flowbyte-with-dep!
+          vcr!
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+    end
+
+    it "works" do
+      bundle :install, :artifice => :compact_index
+      bundle :outdated, :artifice => :compact_index, :raise_on_error => false
+
+      expected_output = <<~TABLE
+        Gem  Current  Latest  Requested  Groups
+        oj   3.11.3   3.11.5
+      TABLE
+
+      expect(out).to include(expected_output.strip)
+    end
+  end
+
   describe "with --group option" do
     before do
       build_repo2 do

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -974,7 +974,10 @@ RSpec.describe "bundle install with gems on multiple sources" do
   context "re-resolving" do
     context "when there is a mix of sources in the gemfile" do
       before do
-        build_repo3
+        build_repo gem_repo3 do
+          build_gem "rack"
+        end
+
         build_lib "path1"
         build_lib "path2"
         build_git "git1"

--- a/bundler/spec/install/prereleases_spec.rb
+++ b/bundler/spec/install/prereleases_spec.rb
@@ -38,7 +38,11 @@ RSpec.describe "bundle install" do
 
   describe "when prerelease gems are not available" do
     it "still works" do
-      build_repo3
+      build_repo gem_repo3 do
+        build_gem "rack"
+      end
+      FileUtils.rm_rf Dir[gem_repo3("prerelease*")]
+
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo3)}"
         gem "rack"

--- a/bundler/spec/support/artifice/compact_index.rb
+++ b/bundler/spec/support/artifice/compact_index.rb
@@ -62,7 +62,7 @@ class CompactIndexAPI < Endpoint
       body.byteslice(range)
     end
 
-    def gems(gem_repo = GEM_REPO)
+    def gems(gem_repo = default_gem_repo)
       @gems ||= {}
       @gems[gem_repo] ||= begin
         specs = Bundler::Deprecate.skip_during do
@@ -80,7 +80,7 @@ class CompactIndexAPI < Endpoint
               CompactIndex::Dependency.new(d.name, reqs)
             end
             checksum = begin
-                         Digest(:SHA256).file("#{GEM_REPO}/gems/#{spec.original_name}.gem").base64digest
+                         Digest(:SHA256).file("#{gem_repo}/gems/#{spec.original_name}.gem").base64digest
                        rescue StandardError
                          nil
                        end

--- a/bundler/spec/support/artifice/endpoint.rb
+++ b/bundler/spec/support/artifice/endpoint.rb
@@ -41,7 +41,18 @@ class Endpoint < Sinatra::Base
     include Spec::Path
 
     def default_gem_repo
-      Pathname.new(ENV["BUNDLER_SPEC_GEM_REPO"] || Spec::Path.gem_repo1)
+      if ENV["BUNDLER_SPEC_GEM_REPO"]
+        Pathname.new(ENV["BUNDLER_SPEC_GEM_REPO"])
+      else
+        case request.host
+        when "gem.repo2"
+          Spec::Path.gem_repo2
+        when "gem.repo3"
+          Spec::Path.gem_repo3
+        else
+          Spec::Path.gem_repo1
+        end
+      end
     end
 
     def dependencies_for(gem_names, gem_repo = default_gem_repo)

--- a/bundler/spec/support/artifice/endpoint.rb
+++ b/bundler/spec/support/artifice/endpoint.rb
@@ -26,7 +26,6 @@ class Endpoint < Sinatra::Base
     @all_requests ||= []
   end
 
-  GEM_REPO = Pathname.new(ENV["BUNDLER_SPEC_GEM_REPO"] || Spec::Path.gem_repo1)
   set :raise_errors, true
   set :show_exceptions, false
 
@@ -41,7 +40,11 @@ class Endpoint < Sinatra::Base
   helpers do
     include Spec::Path
 
-    def dependencies_for(gem_names, gem_repo = GEM_REPO)
+    def default_gem_repo
+      Pathname.new(ENV["BUNDLER_SPEC_GEM_REPO"] || Spec::Path.gem_repo1)
+    end
+
+    def dependencies_for(gem_names, gem_repo = default_gem_repo)
       return [] if gem_names.nil? || gem_names.empty?
 
       all_specs = %w[specs.4.8 prerelease_specs.4.8].map do |filename|
@@ -74,11 +77,11 @@ class Endpoint < Sinatra::Base
   end
 
   get "/fetch/actual/gem/:id" do
-    File.binread("#{GEM_REPO}/quick/Marshal.4.8/#{params[:id]}")
+    File.binread("#{default_gem_repo}/quick/Marshal.4.8/#{params[:id]}")
   end
 
   get "/gems/:id" do
-    File.binread("#{GEM_REPO}/gems/#{params[:id]}")
+    File.binread("#{default_gem_repo}/gems/#{params[:id]}")
   end
 
   get "/api/v1/dependencies" do
@@ -86,11 +89,11 @@ class Endpoint < Sinatra::Base
   end
 
   get "/specs.4.8.gz" do
-    File.binread("#{GEM_REPO}/specs.4.8.gz")
+    File.binread("#{default_gem_repo}/specs.4.8.gz")
   end
 
   get "/prerelease_specs.4.8.gz" do
-    File.binread("#{GEM_REPO}/prerelease_specs.4.8.gz")
+    File.binread("#{default_gem_repo}/prerelease_specs.4.8.gz")
   end
 end
 

--- a/bundler/spec/support/artifice/windows.rb
+++ b/bundler/spec/support/artifice/windows.rb
@@ -14,7 +14,7 @@ class Windows < Sinatra::Base
   set :show_exceptions, false
 
   helpers do
-    def gem_repo
+    def default_gem_repo
       Pathname.new(ENV["BUNDLER_SPEC_GEM_REPO"] || Spec::Path.gem_repo1)
     end
   end
@@ -26,7 +26,7 @@ class Windows < Sinatra::Base
 
   files.each do |file|
     get "/#{file}" do
-      File.binread gem_repo.join(file)
+      File.binread default_gem_repo.join(file)
     end
   end
 

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -192,13 +192,6 @@ module Spec
       update_repo2(&blk) if block_given?
     end
 
-    def build_repo3
-      build_repo gem_repo3 do
-        build_gem "rack"
-      end
-      FileUtils.rm_rf Dir[gem_repo3("prerelease*")]
-    end
-
     # A repo that has no pre-installed gems included. (The caller completely
     # determines the contents with the block.)
     def build_repo4(&blk)


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

Sometimes we only need to resolve, but we don't need to transform the set of resolved specs into real specifications that can be actually installed. This is the case of `bundle outdated`, or `bundle lock`, for example.

## What is your fix for the problem, implemented in this PR?

My fix is to change `definition#resolve_with_cache!` and `definition.resolve_remotely!` to only do what one would expect: resolve.

This change, in addition to making things faster by not doing unnecessary work, also fixes potential materialization problem as a side effect. For example, it fixes the `bundle outdated` problem in #4553.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
