### PR TITLE
Fix typo in `bundle pristine` spec

### DIFF
--- a/bundler/spec/commands/pristine_spec.rb
+++ b/bundler/spec/commands/pristine_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe "bundle pristine", :ruby_repo do
       bundle "pristine", :env => { "BUNDLE_GEMFILE" => "does/not/exist" }, :raise_on_error => false
     end
 
-    it "shows a meaninful error" do
+    it "shows a meaningful error" do
       expect(err).to eq("#{bundled_app("does/not/exist")} not found")
     end
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

A typo.

## What is your fix for the problem, implemented in this PR?

Porting the fix from https://github.com/ruby/ruby/pull/4367.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
