### PR TITLE
Make deprecate method support ruby3's keyword arguments

### DIFF
--- a/lib/rubygems/deprecate.rb
+++ b/lib/rubygems/deprecate.rb
@@ -66,6 +66,7 @@ module Gem::Deprecate
         warn "#{msg.join}." unless Gem::Deprecate.skip
         send old, *args, &block
       end
+      ruby2_keywords name if respond_to?(:ruby2_keywords, true)
     end
   end
 
@@ -90,6 +91,7 @@ module Gem::Deprecate
         warn "#{msg.join}." unless Gem::Deprecate.skip
         send old, *args, &block
       end
+      ruby2_keywords name if respond_to?(:ruby2_keywords, true)
     end
   end
 

--- a/test/rubygems/test_deprecate.rb
+++ b/test/rubygems/test_deprecate.rb
@@ -49,6 +49,22 @@ class TestDeprecate < Gem::TestCase
       @message = "bar"
     end
     rubygems_deprecate :foo, :bar
+
+    def foo_arg(msg)
+      @message = "foo" + msg
+    end
+    def bar_arg(msg)
+      @message = "bar" + msg
+    end
+    rubygems_deprecate :foo_arg, :bar_arg
+
+    def foo_kwarg(message:)
+      @message = "foo" + message
+    end
+    def bar_kwarg(message:)
+      @message = "bar" + message
+    end
+    rubygems_deprecate :foo_kwarg, :bar_kwarg
   end
 
   class OtherThing
@@ -61,6 +77,22 @@ class TestDeprecate < Gem::TestCase
       @message = "bar"
     end
     deprecate :foo, :bar, 2099, 3
+
+    def foo_arg(msg)
+      @message = "foo" + msg
+    end
+    def bar_arg(msg)
+      @message = "bar" + msg
+    end
+    deprecate :foo_arg, :bar_arg, 2099, 3
+
+    def foo_kwarg(message:)
+      @message = "foo" + message
+    end
+    def bar_kwarg(message:)
+      @message = "bar" + message
+    end
+    deprecate :foo_kwarg, :bar_kwarg, 2099, 3
   end
 
   def test_deprecated_method_calls_the_old_method
@@ -68,6 +100,10 @@ class TestDeprecate < Gem::TestCase
       thing = Thing.new
       thing.foo
       assert_equal "foo", thing.message
+      thing.foo_arg("msg")
+      assert_equal "foomsg", thing.message
+      thing.foo_kwarg(message: "msg")
+      assert_equal "foomsg", thing.message
     end
   end
 
@@ -75,10 +111,14 @@ class TestDeprecate < Gem::TestCase
     out, err = capture_io do
       thing = Thing.new
       thing.foo
+      thing.foo_arg("msg")
+      thing.foo_kwarg(message: "msg")
     end
 
     assert_equal "", out
     assert_match(/Thing#foo is deprecated; use bar instead\./, err)
+    assert_match(/Thing#foo_arg is deprecated; use bar_arg instead\./, err)
+    assert_match(/Thing#foo_kwarg is deprecated; use bar_kwarg instead\./, err)
     assert_match(/in Rubygems [0-9]+/, err)
   end
 
@@ -104,10 +144,14 @@ class TestDeprecate < Gem::TestCase
     out, err = capture_io do
       thing = OtherThing.new
       thing.foo
+      thing.foo_arg("msg")
+      thing.foo_kwarg(message: "msg")
     end
 
     assert_equal "", out
-    assert_match(/Thing#foo is deprecated; use bar instead\./, err)
+    assert_match(/OtherThing#foo is deprecated; use bar instead\./, err)
+    assert_match(/OtherThing#foo_arg is deprecated; use bar_arg instead\./, err)
+    assert_match(/OtherThing#foo_kwarg is deprecated; use bar_kwarg instead\./, err)
     assert_match(/on or after 2099-03-01/, err)
   end
 end


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/17824