### PR TITLE
Make sure specs are fetched from the right source when materializing

### DIFF
--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -82,9 +82,9 @@ module Bundler
       materialized.group_by(&:source).each do |source, specs|
         next unless specs.any?{|s| s.is_a?(LazySpecification) }
 
+        source.local!
         names = -> { specs.map(&:name).uniq }
         source.double_check_for(names)
-        source.local!
       end
 
       materialized.map! do |s|
@@ -108,10 +108,10 @@ module Bundler
       @specs.group_by(&:source).each do |source, specs|
         next unless specs.any?{|s| s.is_a?(LazySpecification) }
 
-        names = -> { specs.map(&:name).uniq }
-        source.double_check_for(names)
         source.local!
         source.remote!
+        names = -> { specs.map(&:name).uniq }
+        source.double_check_for(names)
       end
 
       @specs.map do |s|

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "bundle update" do
     G
   end
 
-  describe "with no arguments", :bundler => "< 3" do
+  describe "with no arguments" do
     it "updates the entire bundle" do
       update_repo2 do
         build_gem "rack", "1.2" do |s|
@@ -39,7 +39,7 @@ RSpec.describe "bundle update" do
     end
   end
 
-  describe "with --all", :bundler => "3" do
+  describe "with --all" do
     it "updates the entire bundle" do
       update_repo2 do
         build_gem "rack", "1.2" do |s|

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe "bundle update" do
-  before :each do
+  before do
     build_repo2
 
     install_gemfile <<-G
@@ -257,7 +257,7 @@ RSpec.describe "bundle update" do
     end
 
     context "when there is a source with the same name as a gem in a group" do
-      before :each do
+      before do
         build_git "foo", :path => lib_path("activesupport")
         install_gemfile <<-G
           source "#{file_uri_for(gem_repo2)}"
@@ -452,7 +452,7 @@ RSpec.describe "bundle update" do
 end
 
 RSpec.describe "bundle update in more complicated situations" do
-  before :each do
+  before do
     build_repo2
   end
 
@@ -640,7 +640,7 @@ RSpec.describe "bundle update without a Gemfile.lock" do
 end
 
 RSpec.describe "bundle update when a gem depends on a newer version of bundler" do
-  before(:each) do
+  before do
     build_repo2 do
       build_gem "rails", "3.0.1" do |s|
         s.add_dependency "bundler", Bundler::VERSION.succ

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
 RSpec.describe "bundle update" do
-  before do
-    build_repo2
-
-    install_gemfile <<-G
-      source "#{file_uri_for(gem_repo2)}"
-      gem "activesupport"
-      gem "rack-obama"
-      gem "platform_specific"
-    G
-  end
-
   describe "with no arguments" do
+    before do
+      build_repo2
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "activesupport"
+        gem "rack-obama"
+        gem "platform_specific"
+      G
+    end
+
     it "updates the entire bundle" do
       update_repo2 do
         build_gem "rack", "1.2" do |s|
@@ -40,6 +40,17 @@ RSpec.describe "bundle update" do
   end
 
   describe "with --all" do
+    before do
+      build_repo2
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "activesupport"
+        gem "rack-obama"
+        gem "platform_specific"
+      G
+    end
+
     it "updates the entire bundle" do
       update_repo2 do
         build_gem "rack", "1.2" do |s|
@@ -55,6 +66,8 @@ RSpec.describe "bundle update" do
     end
 
     it "doesn't delete the Gemfile.lock file if something goes wrong" do
+      install_gemfile ""
+
       gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "activesupport"
@@ -102,6 +115,17 @@ RSpec.describe "bundle update" do
   end
 
   describe "--quiet argument" do
+    before do
+      build_repo2
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "activesupport"
+        gem "rack-obama"
+        gem "platform_specific"
+      G
+    end
+
     it "hides UI messages" do
       bundle "update --quiet"
       expect(out).not_to include("Bundle updated!")
@@ -109,6 +133,17 @@ RSpec.describe "bundle update" do
   end
 
   describe "with a top level dependency" do
+    before do
+      build_repo2
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "activesupport"
+        gem "rack-obama"
+        gem "platform_specific"
+      G
+    end
+
     it "unlocks all child dependencies that are unrelated to other locked dependencies" do
       update_repo2 do
         build_gem "rack", "1.2" do |s|
@@ -124,6 +159,17 @@ RSpec.describe "bundle update" do
   end
 
   describe "with an unknown dependency" do
+    before do
+      build_repo2
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "activesupport"
+        gem "rack-obama"
+        gem "platform_specific"
+      G
+    end
+
     it "should inform the user" do
       bundle "update halting-problem-solver", :raise_on_error => false
       expect(err).to include "Could not find gem 'halting-problem-solver'"
@@ -135,6 +181,17 @@ RSpec.describe "bundle update" do
   end
 
   describe "with a child dependency" do
+    before do
+      build_repo2
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "activesupport"
+        gem "rack-obama"
+        gem "platform_specific"
+      G
+    end
+
     it "should update the child dependency" do
       update_repo2 do
         build_gem "rack", "1.2" do |s|
@@ -212,6 +269,17 @@ RSpec.describe "bundle update" do
   end
 
   describe "with --local option" do
+    before do
+      build_repo2
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "activesupport"
+        gem "rack-obama"
+        gem "platform_specific"
+      G
+    end
+
     it "doesn't hit repo2" do
       FileUtils.rm_rf(gem_repo2)
 
@@ -221,6 +289,10 @@ RSpec.describe "bundle update" do
   end
 
   describe "with --group option" do
+    before do
+      build_repo2
+    end
+
     it "should update only specified group gems" do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
@@ -299,6 +371,17 @@ RSpec.describe "bundle update" do
   end
 
   describe "in a frozen bundle" do
+    before do
+      build_repo2
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "activesupport"
+        gem "rack-obama"
+        gem "platform_specific"
+      G
+    end
+
     it "should fail loudly", :bundler => "< 3" do
       bundle "install --deployment"
       bundle "update", :all => true, :raise_on_error => false
@@ -324,6 +407,10 @@ RSpec.describe "bundle update" do
   end
 
   describe "with --source option" do
+    before do
+      build_repo2
+    end
+
     it "should not update gems not included in the source that happen to have the same name", :bundler => "< 3" do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes, the dependency names initially set for each source will end up not matching that actual dependency names that got fetched from each source. We fix this issue by fetching any missing specs for the source set for each spec before materializing it, to make sure they will actually be found in the source.

However, unless this "double check" is the very last manipulation of the source, it can happen that other manipulations of the source (like `source.local!` or `source.remote!`) "cancel" the extra fetches.

This is a bit of a mess right now, but I expect to improve it so that the dependency names to be fetched from each source are set correctly from the beginning, so that we no longer need to do all this dance before materializing.

## What is your fix for the problem, implemented in this PR?

For now I move the extra fetching of missing dependency names to be the last manipulation of the source before materialization to fix this issue. But I expect to completely remove the need for these manipulations by accurately setting the dependency names to be fetched from each source beforehand in the future.

Fixes #4553.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
