### PR TITLE
Discard partial range responses without etag

### DIFF
--- a/bundler/lib/bundler/compact_index_client/updater.rb
+++ b/bundler/lib/bundler/compact_index_client/updater.rb
@@ -50,16 +50,20 @@ module Bundler
 
           content = response.body
 
-          SharedHelpers.filesystem_access(local_temp_path) do
+          etag = (response["ETag"] || "").gsub(%r{\AW/}, "")
+          correct_response = SharedHelpers.filesystem_access(local_temp_path) do
             if response.is_a?(Net::HTTPPartialContent) && local_temp_path.size.nonzero?
               local_temp_path.open("a") {|f| f << slice_body(content, 1..-1) }
+
+              etag_for(local_temp_path) == etag
             else
               local_temp_path.open("wb") {|f| f << content }
+
+              etag.length.zero? || etag_for(local_temp_path) == etag
             end
           end
 
-          etag = (response["ETag"] || "").gsub(%r{\AW/}, "")
-          if etag.length.zero? || etag_for(local_temp_path) == etag
+          if correct_response
             SharedHelpers.filesystem_access(local_path) do
               FileUtils.mv(local_temp_path, local_path)
             end

--- a/bundler/spec/bundler/compact_index_client/updater_spec.rb
+++ b/bundler/spec/bundler/compact_index_client/updater_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe Bundler::CompactIndexClient::Updater do
 
   context "when bundler doesn't have permissions on Dir.tmpdir" do
     it "Errno::EACCES is raised" do
-      local_path # create local path before stubbing mktmpdir
       allow(Bundler::Dir).to receive(:mktmpdir) { raise Errno::EACCES }
 
       expect do

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -826,6 +826,28 @@ The checksum of /versions does not match the checksum provided by the server! So
     expect(the_bundle).to include_gems "rack 1.0.0"
   end
 
+  it "performs full update if server endpoints serve partial content responses but don't have incremental content and provide no Etag" do
+    build_repo4 do
+      build_gem "rack", "0.9.1"
+    end
+
+    install_gemfile <<-G, :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+      source "#{source_uri}"
+      gem 'rack', '0.9.1'
+    G
+
+    update_repo4 do
+      build_gem "rack", "1.0.0"
+    end
+
+    install_gemfile <<-G, :artifice => "compact_index_partial_update_no_etag_not_incremental", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+      source "#{source_uri}"
+      gem 'rack', '1.0.0'
+    G
+
+    expect(the_bundle).to include_gems "rack 1.0.0"
+  end
+
   it "performs full update of compact index info cache if range is not satisfiable" do
     gemfile <<-G
       source "#{source_uri}"

--- a/bundler/spec/support/artifice/compact_index_partial_update_no_etag_not_incremental.rb
+++ b/bundler/spec/support/artifice/compact_index_partial_update_no_etag_not_incremental.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative "compact_index"
+
+Artifice.deactivate
+
+class CompactIndexPartialUpdateNoEtagNotIncremental < CompactIndexAPI
+  def partial_update_no_etag
+    response_body = yield
+    headers "Surrogate-Control" => "max-age=2592000, stale-while-revalidate=60"
+    content_type "text/plain"
+    requested_range_for(response_body)
+  end
+
+  get "/versions" do
+    partial_update_no_etag do
+      file = tmp("versions.list")
+      FileUtils.rm_f(file)
+      file = CompactIndex::VersionsFile.new(file.to_s)
+      file.create(gems)
+      lines = file.contents([], :calculate_info_checksums => true).split("\n")
+      name, versions, checksum = lines.last.split(" ")
+
+      # shuffle versions so new versions are not appended to the end
+      [*lines[0..-2], [name, versions.split(",").reverse.join(","), checksum].join(" ")].join("\n")
+    end
+  end
+
+  get "/info/:name" do
+    partial_update_no_etag do
+      gem = gems.find {|g| g.name == params[:name] }
+      lines = CompactIndex.info(gem ? gem.versions : []).split("\n")
+
+      # shuffle versions so new versions are not appended to the end
+      [lines.first, lines.last, *lines[1..-2]].join("\n")
+    end
+  end
+end
+
+Artifice.activate_with(CompactIndexPartialUpdateNoEtagNotIncremental)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Some custom gem servers (at least sidekiq's pro one) don't support "incremental API content", yet they respond to partial range responses, providing no Etag.

Previously bundler would handle this just fine, because it would discard the response given and retry a "full range request" in this case.

However, in #3865 we changed bundler to accept the response in this case, which would be appended to the existing response. However, since new versions are not appended to the remote versions file (no "incremental API content"), this would result in a bad response being written to the local client compact index cache. This should be the reason for the problems reported in #4514.

## What is your fix for the problem, implemented in this PR?

My fix, for now, is to revert #3865. But as a further improvement, we can keep the "accept the response if no etag" idea, but only if we get a 200 response, not a partial content (206) response.

If we did the latter, sidekiq-pro can fix their server code to always serve full responses, even when requested partial ranges, and things will work in a more efficient way, since it wouldn't require double fallback requests.

EDIT: Extra improvement was also implemented :+1:.

Closes #4514.
Closes #4543.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
