### PR TITLE
Redact all sources in verbose mode

### DIFF
--- a/bundler/lib/bundler/fetcher/downloader.rb
+++ b/bundler/lib/bundler/fetcher/downloader.rb
@@ -14,8 +14,10 @@ module Bundler
       def fetch(uri, headers = {}, counter = 0)
         raise HTTPError, "Too many redirects" if counter >= redirect_limit
 
+        filtered_uri = URICredentialsFilter.credential_filtered_uri(uri)
+
         response = request(uri, headers)
-        Bundler.ui.debug("HTTP #{response.code} #{response.message} #{uri}")
+        Bundler.ui.debug("HTTP #{response.code} #{response.message} #{filtered_uri}")
 
         case response
         when Net::HTTPSuccess, Net::HTTPNotModified
@@ -40,7 +42,7 @@ module Bundler
           raise BadAuthenticationError, uri.host if uri.userinfo
           raise AuthenticationRequiredError, uri.host
         when Net::HTTPNotFound
-          raise FallbackError, "Net::HTTPNotFound: #{URICredentialsFilter.credential_filtered_uri(uri)}"
+          raise FallbackError, "Net::HTTPNotFound: #{filtered_uri}"
         else
           raise HTTPError, "#{response.class}#{": #{response.body}" unless response.body.empty?}"
         end
@@ -49,7 +51,9 @@ module Bundler
       def request(uri, headers)
         validate_uri_scheme!(uri)
 
-        Bundler.ui.debug "HTTP GET #{uri}"
+        filtered_uri = URICredentialsFilter.credential_filtered_uri(uri)
+
+        Bundler.ui.debug "HTTP GET #{filtered_uri}"
         req = Net::HTTP::Get.new uri.request_uri, headers
         if uri.user
           user = CGI.unescape(uri.user)
@@ -69,7 +73,7 @@ module Bundler
           raise NetworkDownError, "Could not reach host #{uri.host}. Check your network " \
             "connection and try again."
         else
-          raise HTTPError, "Network error while fetching #{URICredentialsFilter.credential_filtered_uri(uri)}" \
+          raise HTTPError, "Network error while fetching #{filtered_uri}" \
             " (#{e})"
         end
       end

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -423,11 +423,11 @@ module Bundler
       def fetch_names(fetchers, dependency_names, index, override_dupes)
         fetchers.each do |f|
           if dependency_names
-            Bundler.ui.info "Fetching gem metadata from #{f.uri}", Bundler.ui.debug?
+            Bundler.ui.info "Fetching gem metadata from #{URICredentialsFilter.credential_filtered_uri(f.uri)}", Bundler.ui.debug?
             index.use f.specs_with_retry(dependency_names, self), override_dupes
             Bundler.ui.info "" unless Bundler.ui.debug? # new line now that the dots are over
           else
-            Bundler.ui.info "Fetching source index from #{f.uri}"
+            Bundler.ui.info "Fetching source index from #{URICredentialsFilter.credential_filtered_uri(f.uri)}"
             index.use f.specs_with_retry(nil, self), override_dupes
           end
         end

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -614,6 +614,17 @@ The checksum of /versions does not match the checksum provided by the server! So
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
 
+    it "passes basic authentication details and strips out creds also in verbose mode" do
+      gemfile <<-G
+        source "#{basic_auth_source_uri}"
+        gem "rack"
+      G
+
+      bundle :install, :verbose => true, :artifice => "compact_index_basic_authentication"
+      expect(out).not_to include("#{user}:#{password}")
+      expect(the_bundle).to include_gems "rack 1.0.0"
+    end
+
     it "strips http basic auth creds when warning about ambiguous sources", :bundler => "< 3" do
       gemfile <<-G
         source "#{basic_auth_source_uri}"

--- a/bundler/spec/install/gems/dependency_api_spec.rb
+++ b/bundler/spec/install/gems/dependency_api_spec.rb
@@ -586,6 +586,17 @@ RSpec.describe "gemcutter's dependency API" do
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
 
+    it "passes basic authentication details and strips out creds also in verbose mode" do
+      gemfile <<-G
+        source "#{basic_auth_source_uri}"
+        gem "rack"
+      G
+
+      bundle :install, :verbose => true, :artifice => "endpoint_basic_authentication"
+      expect(out).not_to include("#{user}:#{password}")
+      expect(the_bundle).to include_gems "rack 1.0.0"
+    end
+
     it "strips http basic authentication creds for modern index" do
       gemfile <<-G
         source "#{basic_auth_source_uri}"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Bundler prints credentials when run in verbose mode.

## What is your fix for the problem, implemented in this PR?

Redact credentials from authenticated sources also in verbose mode.

Closes https://github.com/rubygems/rubygems/issues/3178.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
