### PR TITLE
Improve authentication required error message to include an alternative using `ENV`

### DIFF
--- a/bundler/lib/bundler/fetcher.rb
+++ b/bundler/lib/bundler/fetcher.rb
@@ -47,7 +47,8 @@ module Bundler
         remote_uri = filter_uri(remote_uri)
         super "Authentication is required for #{remote_uri}.\n" \
           "Please supply credentials for this source. You can do this by running:\n" \
-          " bundle config set --global #{remote_uri} username:password"
+          "`bundle config set --global #{remote_uri} username:password`\n" \
+          "or by storing the credentials in the `#{Settings.key_for(remote_uri)}` environment variable"
       end
     end
     # This error is raised if HTTP authentication is provided, but incorrect.

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -295,9 +295,7 @@ module Bundler
     end
 
     def key_for(key)
-      key = Settings.normalize_uri(key).to_s if key.is_a?(String) && /https?:/ =~ key
-      key = key.to_s.gsub(".", "__").gsub("-", "___").upcase
-      "BUNDLE_#{key}"
+      self.class.key_for(key)
     end
 
     private
@@ -460,6 +458,12 @@ module Bundler
         (\.#{Regexp.union(PER_URI_OPTIONS)})? # optional suffix key
         \z
       /ix.freeze
+
+    def self.key_for(key)
+      key = normalize_uri(key).to_s if key.is_a?(String) && /https?:/ =~ key
+      key = key.to_s.gsub(".", "__").gsub("-", "___").upcase
+      "BUNDLE_#{key}"
+    end
 
     # TODO: duplicates Rubygems#normalize_uri
     # TODO: is this the correct place to validate mirror URIs?

--- a/bundler/spec/bundler/fetcher/downloader_spec.rb
+++ b/bundler/spec/bundler/fetcher/downloader_spec.rb
@@ -83,6 +83,11 @@ RSpec.describe Bundler::Fetcher::Downloader do
           /Authentication is required for www.uri-to-fetch.com/)
       end
 
+      it "should raise a Bundler::Fetcher::AuthenticationRequiredError with advices" do
+        expect { subject.fetch(uri, options, counter) }.to raise_error(Bundler::Fetcher::AuthenticationRequiredError,
+          /`bundle config set --global www\.uri-to-fetch\.com username:password`.*`BUNDLE_WWW__URI___TO___FETCH__COM`/m)
+      end
+
       context "when the there are credentials provided in the request" do
         let(:uri) { Bundler::URI("http://user:password@www.uri-to-fetch.com") }
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The convention for environment variables and credentials is tricky, and it can be hard to figure out the name of the environment variable that needs to be set.

## What is your fix for the problem, implemented in this PR?

Include the specific environment variable that needs to be set with the error message.

Closes https://github.com/rubygems/rubygems/issues/3255.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
