### PR TITLE
Redact credentials from `bundle env` and `bundle config`

### DIFF
--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -470,6 +470,9 @@ export BUNDLE_GITHUB__COM=abcd0123generatedtoken:x\-oauth\-basic
 .
 .IP "" 0
 .
+.P
+Note that any configured credentials will be redacted by informative commands such as \fBbundle config list\fR or \fBbundle config get\fR, unless you use the \fB\-\-parseable\fR flag\. This is to avoid unintentially leaking credentials when copy\-pasting bundler output\.
+.
 .SH "CONFIGURE BUNDLER DIRECTORIES"
 Bundler\'s home, config, cache and plugin directories are able to be configured through environment variables\. The default location for Bundler\'s home directory is \fB~/\.bundle\fR, which all directories inherit from by default\. The following outlines the available environment variables and their default values
 .

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -376,6 +376,10 @@ where you can use personal OAuth tokens:
 
     export BUNDLE_GITHUB__COM=abcd0123generatedtoken:x-oauth-basic
 
+Note that any configured credentials will be redacted by informative commands
+such as `bundle config list` or `bundle config get`, unless you use the
+`--parseable` flag. This is to avoid unintentially leaking credentials when
+copy-pasting bundler output.
 
 ## CONFIGURE BUNDLER DIRECTORIES
 

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -13,6 +13,7 @@ module Bundler
       auto_install
       cache_all
       cache_all_platforms
+      clean
       default_install_uses_path
       deployment
       disable_checksum_validation
@@ -25,11 +26,14 @@ module Bundler
       force_ruby_platform
       forget_cli_options
       frozen
+      gem.changelog
       gem.coc
       gem.mit
+      git.allow_insecure
       global_gem_cache
       ignore_messages
       init_gems_rb
+      inline
       no_install
       no_prune
       path_relative_to_cwd

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -129,7 +129,7 @@ module Bundler
 
       keys.map do |key|
         key.sub(/^BUNDLE_/, "").gsub(/__/, ".").downcase
-      end
+      end.sort
     end
 
     def local_overrides

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -63,6 +63,22 @@ module Bundler
       without
     ].freeze
 
+    STRING_KEYS = %w[
+      bin
+      cache_path
+      console
+      gem.ci
+      gem.github_username
+      gem.linter
+      gem.rubocop
+      gem.test
+      gemfile
+      path
+      shebang
+      system_bindir
+      trust-policy
+    ].freeze
+
     DEFAULT_CONFIG = {
       "BUNDLE_SILENCE_DEPRECATIONS" => false,
       "BUNDLE_DISABLE_VERSION_CHECK" => true,
@@ -175,19 +191,19 @@ module Bundler
       locations = []
 
       if value = @temporary[key]
-        locations << "Set for the current command: #{converted_value(value, exposed_key).inspect}"
+        locations << "Set for the current command: #{printable_value(value, exposed_key).inspect}"
       end
 
       if value = @local_config[key]
-        locations << "Set for your local app (#{local_config_file}): #{converted_value(value, exposed_key).inspect}"
+        locations << "Set for your local app (#{local_config_file}): #{printable_value(value, exposed_key).inspect}"
       end
 
       if value = @env_config[key]
-        locations << "Set via #{key}: #{converted_value(value, exposed_key).inspect}"
+        locations << "Set via #{key}: #{printable_value(value, exposed_key).inspect}"
       end
 
       if value = @global_config[key]
-        locations << "Set for the current user (#{global_config_file}): #{converted_value(value, exposed_key).inspect}"
+        locations << "Set for the current user (#{global_config_file}): #{printable_value(value, exposed_key).inspect}"
       end
 
       return ["You have not configured a value for `#{exposed_key}`"] if locations.empty?
@@ -316,6 +332,10 @@ module Bundler
       BOOL_KEYS.include?(name.to_s) || BOOL_KEYS.include?(parent_setting_for(name.to_s))
     end
 
+    def is_string(name)
+      STRING_KEYS.include?(name.to_s) || name.to_s.start_with?("local.") || name.to_s.start_with?("mirror.") || name.to_s.start_with?("build.")
+    end
+
     def to_bool(value)
       case value
       when nil, /\A(false|f|no|n|0|)\z/i, false
@@ -331,6 +351,14 @@ module Bundler
 
     def is_array(key)
       ARRAY_KEYS.include?(key.to_s)
+    end
+
+    def is_credential(key)
+      key == "gem.push_key"
+    end
+
+    def is_userinfo(value)
+      value.include?(":")
     end
 
     def to_array(value)
@@ -376,6 +404,21 @@ module Bundler
         value.to_i
       else
         value.to_s
+      end
+    end
+
+    def printable_value(value, key)
+      converted = converted_value(value, key)
+      return converted unless converted.is_a?(String)
+
+      if is_string(key)
+        converted
+      elsif is_credential(key)
+        "[REDACTED]"
+      elsif is_userinfo(converted)
+        converted.gsub(/:.*$/, ":[REDACTED]")
+      else
+        converted
       end
     end
 

--- a/bundler/spec/bundler/env_spec.rb
+++ b/bundler/spec/bundler/env_spec.rb
@@ -113,6 +113,20 @@ RSpec.describe Bundler::Env do
       end
     end
 
+    context "when there's bundler config with credentials" do
+      before do
+        bundle "config set https://localgemserver.test/ user:pass"
+      end
+
+      let(:output) { described_class.report(:print_gemfile => true) }
+
+      it "prints the config with redacted values" do
+        expect(output).to include("https://localgemserver.test")
+        expect(output).to include("user:[REDACTED]")
+        expect(output).to_not include("user:pass")
+      end
+    end
+
     context "when Gemfile contains a gemspec and print_gemspecs is true" do
       let(:gemspec) do
         strip_whitespace(<<-GEMSPEC)

--- a/bundler/spec/commands/config_spec.rb
+++ b/bundler/spec/commands/config_spec.rb
@@ -408,6 +408,14 @@ E
       expect(out).to eq "spec_run=true"
     end
 
+    it "list with credentials" do
+      bundle "config list", :env => { "BUNDLE_GEMS__MYSERVER__COM" => "user:password" }
+      expect(out).to eq "Settings are listed in order of priority. The top value will be used.\ngems.myserver.com\nSet via BUNDLE_GEMS__MYSERVER__COM: \"user:[REDACTED]\"\n\nspec_run\nSet via BUNDLE_SPEC_RUN: \"true\""
+
+      bundle "config list", :parseable => true, :env => { "BUNDLE_GEMS__MYSERVER__COM" => "user:password" }
+      expect(out).to eq "gems.myserver.com=user:password\nspec_run=true"
+    end
+
     it "get" do
       ENV["BUNDLE_BAR"] = "bar_val"
 

--- a/bundler/spec/quality_spec.rb
+++ b/bundler/spec/quality_spec.rb
@@ -170,8 +170,10 @@ RSpec.describe "The library itself" do
   it "documents all used settings" do
     exemptions = %w[
       forget_cli_options
+      gem.changelog
       gem.coc
       gem.mit
+      git.allow_insecure
       inline
       use_gem_version_promoter_for_major_updates
     ]

--- a/bundler/spec/quality_spec.rb
+++ b/bundler/spec/quality_spec.rb
@@ -171,10 +171,15 @@ RSpec.describe "The library itself" do
     exemptions = %w[
       forget_cli_options
       gem.changelog
+      gem.ci
       gem.coc
+      gem.linter
       gem.mit
+      gem.rubocop
+      gem.test
       git.allow_insecure
       inline
+      trust-policy
       use_gem_version_promoter_for_major_updates
     ]
 
@@ -184,6 +189,7 @@ RSpec.describe "The library itself" do
     Bundler::Settings::BOOL_KEYS.each {|k| all_settings[k] << "in Bundler::Settings::BOOL_KEYS" }
     Bundler::Settings::NUMBER_KEYS.each {|k| all_settings[k] << "in Bundler::Settings::NUMBER_KEYS" }
     Bundler::Settings::ARRAY_KEYS.each {|k| all_settings[k] << "in Bundler::Settings::ARRAY_KEYS" }
+    Bundler::Settings::STRING_KEYS.each {|k| all_settings[k] << "in Bundler::Settings::STRING_KEYS" }
 
     key_pattern = /([a-z\._-]+)/i
     lib_tracked_files.each do |filename|


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Currently `bundle env`  and `bundle config` prints any credentials configured. Users may blindly copy-paste this output, for example to a bundler issue, unintentionally leaking their credentials.

## What is your fix for the problem, implemented in this PR?

Redact any credentials from `bundle env` and `bundle config` output.

Closes https://github.com/rubygems/rubygems/issues/4414.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
