### PR TITLE
Fix configuring ENV for a gem server with a name including dashes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,12 +7,12 @@ require 'psych'
 
 desc "Setup Rubygems dev environment"
 task :setup do
-  sh "ruby", "bundler/spec/support/bundle.rb", "install", "--gemfile=dev_gems.rb"
+  sh "ruby", "-I", "lib", "bundler/spec/support/bundle.rb", "install", "--gemfile=dev_gems.rb"
 end
 
 desc "Update Rubygems dev environment"
 task :update do |_, args|
-  sh "ruby", "bundler/spec/support/bundle.rb", "update", *args, "--gemfile=dev_gems.rb"
+  sh "ruby", "-I", "lib", "bundler/spec/support/bundle.rb", "update", *args, "--gemfile=dev_gems.rb"
 end
 
 desc "Update the locked bundler version in dev environment"

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -473,6 +473,20 @@ export BUNDLE_GITHUB__COM=abcd0123generatedtoken:x\-oauth\-basic
 .P
 Note that any configured credentials will be redacted by informative commands such as \fBbundle config list\fR or \fBbundle config get\fR, unless you use the \fB\-\-parseable\fR flag\. This is to avoid unintentially leaking credentials when copy\-pasting bundler output\.
 .
+.P
+Also note that to guarantee a sane mapping between valid environment variable names and valid host names, bundler makes the following transformations:
+.
+.IP "\(bu" 4
+Any \fB\-\fR characters in a host name are mapped to a triple dash (\fB___\fR) in the corresponding enviroment variable\.
+.
+.IP "\(bu" 4
+Any \fB\.\fR characters in a host name are mapped to a double dash (\fB__\fR) in the corresponding environment variable\.
+.
+.IP "" 0
+.
+.P
+This means that if you have a gem server named \fBmy\.gem\-host\.com\fR, you\'ll need to use the \fBBUNDLE_MY__GEM___HOST__COM\fR variable to configure credentials for it through ENV\.
+.
 .SH "CONFIGURE BUNDLER DIRECTORIES"
 Bundler\'s home, config, cache and plugin directories are able to be configured through environment variables\. The default location for Bundler\'s home directory is \fB~/\.bundle\fR, which all directories inherit from by default\. The following outlines the available environment variables and their default values
 .

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -381,6 +381,19 @@ such as `bundle config list` or `bundle config get`, unless you use the
 `--parseable` flag. This is to avoid unintentially leaking credentials when
 copy-pasting bundler output.
 
+Also note that to guarantee a sane mapping between valid environment variable
+names and valid host names, bundler makes the following transformations:
+
+* Any `-` characters in a host name are mapped to a triple dash (`___`) in the
+  corresponding enviroment variable.
+
+* Any `.` characters in a host name are mapped to a double dash (`__`) in the
+  corresponding environment variable.
+
+This means that if you have a gem server named `my.gem-host.com`, you'll need to
+use the `BUNDLE_MY__GEM___HOST__COM` variable to configure credentials for it
+through ENV.
+
 ## CONFIGURE BUNDLER DIRECTORIES
 
 Bundler's home, config, cache and plugin directories are able to be configured

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -144,7 +144,7 @@ module Bundler
       keys = @temporary.keys | @global_config.keys | @local_config.keys | @env_config.keys
 
       keys.map do |key|
-        key.sub(/^BUNDLE_/, "").gsub(/__/, ".").downcase
+        key.sub(/^BUNDLE_/, "").gsub(/___/, "-").gsub(/__/, ".").downcase
       end.sort
     end
 
@@ -296,7 +296,7 @@ module Bundler
 
     def key_for(key)
       key = Settings.normalize_uri(key).to_s if key.is_a?(String) && /https?:/ =~ key
-      key = key.to_s.gsub(".", "__").upcase
+      key = key.to_s.gsub(".", "__").gsub("-", "___").upcase
       "BUNDLE_#{key}"
     end
 

--- a/bundler/spec/install/gems/dependency_api_spec.rb
+++ b/bundler/spec/install/gems/dependency_api_spec.rb
@@ -641,6 +641,22 @@ RSpec.describe "gemcutter's dependency API" do
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
 
+    describe "with host including dashes" do
+      before do
+        gemfile <<-G
+          source "http://local-gemserver.test"
+          gem "rack"
+        G
+      end
+
+      it "reads authentication details from a valid ENV variable" do
+        bundle :install, :artifice => "endpoint_strict_basic_authentication", :env => { "BUNDLE_LOCAL___GEMSERVER__TEST" => "#{user}:#{password}" }
+
+        expect(out).to include("Fetching gem metadata from http://local-gemserver.test")
+        expect(the_bundle).to include_gems "rack 1.0.0"
+      end
+    end
+
     describe "with authentication details in bundle config" do
       before do
         gemfile <<-G


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The previous mapping would lead to invalid ENV variable names, as pointed out by https://github.com/rubygems/rubygems/pull/4565#discussion_r621174703.

## What is your fix for the problem, implemented in this PR?

Fix is to also convert dashes in the host name to a series of underscores in the ENV variable name, to avoid invalid variable names.

Also added some docs for this conversion.
 
## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
