### PR TITLE
Avoid warning about repository having moved when pushing to blog

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -260,7 +260,7 @@ end
 
 directory '../blog.rubygems.org' do
   sh 'git', 'clone',
-     'git@github.com:rubygems/rubygems.github.com.git',
+     'git@github.com:rubygems/rubygems.github.io.git',
      '../blog.rubygems.org'
 end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Not much, just a warning message about using the old repository name for our blog.

## What is your fix for the problem, implemented in this PR?

Use the new repository.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
