### PR TITLE
Restore support for configuration keys with dashes

### DIFF
--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -441,7 +441,20 @@ module Bundler
         valid_file = file.exist? && !file.size.zero?
         return {} unless valid_file
         require_relative "yaml_serializer"
-        YAMLSerializer.load file.read
+        YAMLSerializer.load(file.read).inject({}) do |config, (k, v)|
+          new_k = k
+
+          if k.include?("-")
+            Bundler.ui.warn "Your #{file} config includes `#{k}`, which contains the dash character (`-`).\n" \
+              "This is deprecated, because configuration through `ENV` should be possible, but `ENV` keys cannot include dashes.\n" \
+              "Please edit #{file} and replace any dashes in configuration keys with a triple underscore (`___`)."
+
+            new_k = k.gsub("-", "___")
+          end
+
+          config[new_k] = v
+          config
+        end
       end
     end
 

--- a/bundler/spec/bundler/settings_spec.rb
+++ b/bundler/spec/bundler/settings_spec.rb
@@ -322,6 +322,16 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
       expect(settings["mirror.https://rubygems.org/"]).to eq("http://rubygems-mirror.org")
     end
 
+    it "converts older keys with dashes" do
+      config("BUNDLE_MY-PERSONAL-SERVER__ORG" => "my-personal-server.org")
+      expect(Bundler.ui).to receive(:warn).with(
+        "Your #{bundled_app(".bundle/config")} config includes `BUNDLE_MY-PERSONAL-SERVER__ORG`, which contains the dash character (`-`).\n" \
+        "This is deprecated, because configuration through `ENV` should be possible, but `ENV` keys cannot include dashes.\n" \
+        "Please edit #{bundled_app(".bundle/config")} and replace any dashes in configuration keys with a triple underscore (`___`)."
+      )
+      expect(settings["my-personal-server.org"]).to eq("my-personal-server.org")
+    end
+
     it "reads newer keys format properly" do
       config("BUNDLE_MIRROR__HTTPS://RUBYGEMS__ORG/" => "http://rubygems-mirror.org")
       expect(settings["mirror.https://rubygems.org/"]).to eq("http://rubygems-mirror.org")

--- a/bundler/spec/bundler/settings_spec.rb
+++ b/bundler/spec/bundler/settings_spec.rb
@@ -312,12 +312,12 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
   describe "BUNDLE_ keys format" do
     let(:settings) { described_class.new(bundled_app(".bundle")) }
 
-    it "converts older keys without double dashes" do
+    it "converts older keys without double underscore" do
       config("BUNDLE_MY__PERSONAL.RACK" => "~/Work/git/rack")
       expect(settings["my.personal.rack"]).to eq("~/Work/git/rack")
     end
 
-    it "converts older keys without trailing slashes and double dashes" do
+    it "converts older keys without trailing slashes and double underscore" do
       config("BUNDLE_MIRROR__HTTPS://RUBYGEMS.ORG" => "http://rubygems-mirror.org")
       expect(settings["mirror.https://rubygems.org/"]).to eq("http://rubygems-mirror.org")
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In #4571, I broke support for configuration files generated with previous bundler versions including keys with dashes.

## What is your fix for the problem, implemented in this PR?

My fix is to properly deprecate these instead of hard breaking it.

Fixes #4581.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
