### PR TITLE
Undeprecate bundle show

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -308,39 +308,19 @@ module Bundler
       end
     end
 
-    unless Bundler.feature_flag.bundler_3_mode?
-      desc "show GEM [OPTIONS]", "Shows all gems that are part of the bundle, or the path to a given gem"
-      long_desc <<-D
-        Show lists the names and versions of all gems that are required by your Gemfile.
-        Calling show with [GEM] will list the exact location of that gem on your machine.
-      D
-      method_option "paths", :type => :boolean,
-                             :banner => "List the paths of all gems that are required by your Gemfile."
-      method_option "outdated", :type => :boolean,
-                                :banner => "Show verbose output including whether gems are outdated."
-      def show(gem_name = nil)
-        if ARGV[0] == "show"
-          rest = ARGV[1..-1]
-
-          if flag = rest.find{|arg| ["--verbose", "--outdated"].include?(arg) }
-            Bundler::SharedHelpers.major_deprecation(2, "the `#{flag}` flag to `bundle show` was undocumented and will be removed without replacement")
-          else
-            new_command = rest.find {|arg| !arg.start_with?("--") } ? "info" : "list"
-
-            new_arguments = rest.map do |arg|
-              next arg if arg != "--paths"
-              next "--path" if new_command == "info"
-            end
-
-            old_argv = ARGV.join(" ")
-            new_argv = [new_command, *new_arguments.compact].join(" ")
-
-            Bundler::SharedHelpers.major_deprecation(2, "use `bundle #{new_argv}` instead of `bundle #{old_argv}`")
-          end
-        end
-        require_relative "cli/show"
-        Show.new(options, gem_name).run
-      end
+    desc "show GEM [OPTIONS]", "Shows all gems that are part of the bundle, or the path to a given gem"
+    long_desc <<-D
+      Show lists the names and versions of all gems that are required by your Gemfile.
+      Calling show with [GEM] will list the exact location of that gem on your machine.
+    D
+    method_option "paths", :type => :boolean,
+                           :banner => "List the paths of all gems that are required by your Gemfile."
+    method_option "outdated", :type => :boolean,
+                              :banner => "Show verbose output including whether gems are outdated."
+    def show(gem_name = nil)
+      SharedHelpers.major_deprecation(2, "the `--outdated` flag to `bundle show` was undocumented and will be removed without replacement") if ARGV.include?("--outdated")
+      require_relative "cli/show"
+      Show.new(options, gem_name).run
     end
 
     desc "list", "List all gems in the bundle"

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -569,18 +569,6 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
       G
     end
 
-    context "without flags" do
-      before do
-        bundle :show
-      end
-
-      it "prints a deprecation warning recommending `bundle list`", :bundler => "< 3" do
-        expect(deprecations).to include("use `bundle list` instead of `bundle show`")
-      end
-
-      pending "fails with a helpful message", :bundler => "3"
-    end
-
     context "with --outdated flag" do
       before do
         bundle "show --outdated"
@@ -588,54 +576,6 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
 
       it "prints a deprecation warning informing about its removal", :bundler => "< 3" do
         expect(deprecations).to include("the `--outdated` flag to `bundle show` was undocumented and will be removed without replacement")
-      end
-
-      pending "fails with a helpful message", :bundler => "3"
-    end
-
-    context "with --verbose flag" do
-      before do
-        bundle "show --verbose"
-      end
-
-      it "prints a deprecation warning informing about its removal", :bundler => "< 3" do
-        expect(deprecations).to include("the `--verbose` flag to `bundle show` was undocumented and will be removed without replacement")
-      end
-
-      pending "fails with a helpful message", :bundler => "3"
-    end
-
-    context "with a gem argument" do
-      before do
-        bundle "show rack"
-      end
-
-      it "prints a deprecation warning recommending `bundle info`", :bundler => "< 3" do
-        expect(deprecations).to include("use `bundle info rack` instead of `bundle show rack`")
-      end
-
-      pending "fails with a helpful message", :bundler => "3"
-    end
-
-    context "with the --paths option" do
-      before do
-        bundle "show --paths"
-      end
-
-      it "prints a deprecation warning recommending `bundle list`", :bundler => "< 3" do
-        expect(deprecations).to include("use `bundle list` instead of `bundle show --paths`")
-      end
-
-      pending "fails with a helpful message", :bundler => "3"
-    end
-
-    context "with a gem argument and the --paths option" do
-      before do
-        bundle "show rack --paths"
-      end
-
-      it "prints deprecation warning recommending `bundle info`", :bundler => "< 3" do
-        expect(deprecations).to include("use `bundle info rack --path` instead of `bundle show rack --paths`")
       end
 
       pending "fails with a helpful message", :bundler => "3"


### PR DESCRIPTION
The timeline of how show got deprecated is on this issue's comment: https://github.com/rubygems/rubygems/issues/3243#issuecomment-780379254. We eventually decided to undeprecate show as no apparent reason was give
to deprecate it.

## What was the end-user or developer problem that led to this PR?

`bundle show` was deprecated for no apparent reason.
timeline (see [here](https://github.com/rubygems/rubygems/issues/3243#issuecomment-780379254))

## What is your fix for the problem, implemented in this PR?

`bundle show` has been undeprecated.

Closes #3243.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
