### PR TITLE
Reset `XDG_CONFIG_HOME` for bundler specs

### DIFF
--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -73,6 +73,7 @@ RSpec.configure do |config|
     Spec::Rubygems.test_setup
     ENV["BUNDLE_SPEC_RUN"] = "true"
     ENV["BUNDLE_USER_CONFIG"] = ENV["BUNDLE_USER_CACHE"] = ENV["BUNDLE_USER_PLUGIN"] = nil
+    ENV["XDG_CONFIG_HOME"] = nil
     ENV["GEMRC"] = nil
 
     # Don't wrap output in tests


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Some spec failures under ruby-core environment.

## What is your fix for the problem, implemented in this PR?

My fix is an alternative to https://github.com/ruby/ruby/commit/50f17241a32d837403fae68dc1ed0f046506d3e8 and prior commits, which have not yet been ported to our repo.

It seems simpler and more consistent with the current setup to me. @znz what do you think?

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
