### PR TITLE
Make sure link to new issue uses the proper template

### DIFF
--- a/bundler/lib/bundler/friendly_errors.rb
+++ b/bundler/lib/bundler/friendly_errors.rb
@@ -112,7 +112,7 @@ module Bundler
         #{issues_url(e)}
 
         If there aren't any reports for this error yet, please create copy and paste the report template above into a new issue. Don't forget to anonymize any private data! The new issue form is located at:
-        https://github.com/rubygems/rubygems/issues/new?labels=Bundler
+        https://github.com/rubygems/rubygems/issues/new?labels=Bundler&template=bundler-related-issue.md
       EOS
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes users report issues with very little information when they get a crash. I think this might not be entirely user's fault, but also our fault because we link to an empty template that does not include all the information included in our issue template.

## What is your fix for the problem, implemented in this PR?

Change to link so that all the information in the issue template appear.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
