### PR TITLE
Use simpler notation for generated `required_ruby_version`

### DIFF
--- a/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
 <%- if config[:mit] -%>
   spec.license = "MIT"
 <%- end -%>
-  spec.required_ruby_version = Gem::Requirement.new(">= <%= config[:required_ruby_version] %>")
+  spec.required_ruby_version = ">= <%= config[:required_ruby_version] %>"
 
   spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I noticed this issue when I stumped across https://github.com/dependabot/dependabot-core/issues/2963. We can't really fix that dependabot issue ourselves, but we can generate new gemspecs without any dependencies on this class.

## What is your fix for the problem, implemented in this PR?

There's no need to reference an internal rubygems class, even though this is a core class that will probably never be renamed/removed, but still it's unnecessary to depend on it here. Use the simpler notation for `required_ruby_version`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
