### PR TITLE
Use `Time.stub :now` to avoid a random failure

### DIFF
--- a/test/rubygems/test_gem_package_tar_writer.rb
+++ b/test/rubygems/test_gem_package_tar_writer.rb
@@ -27,58 +27,67 @@ class TestGemPackageTarWriter < Gem::Package::TarTestCase
   end
 
   def test_add_file
-    @tar_writer.add_file 'x', 0644 do |f|
-      f.write 'a' * 10
-    end
+    Time.stub :now, Time.at(1458518157) do
+      @tar_writer.add_file 'x', 0644 do |f|
+        f.write 'a' * 10
+      end
 
-    assert_headers_equal(tar_file_header('x', '', 0644, 10, Time.now),
+      assert_headers_equal(tar_file_header('x', '', 0644, 10, Time.now),
                          @io.string[0, 512])
+    end
     assert_equal "aaaaaaaaaa#{"\0" * 502}", @io.string[512, 512]
     assert_equal 1024, @io.pos
   end
 
   def test_add_file_source_date_epoch
     ENV["SOURCE_DATE_EPOCH"] = "123456789"
-    @tar_writer.mkdir 'foo', 0644
+    Time.stub :now, Time.at(1458518157) do
+      @tar_writer.mkdir 'foo', 0644
 
-    assert_headers_equal tar_dir_header('foo', '', 0644, Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc),
-                         @io.string[0, 512]
+      assert_headers_equal tar_dir_header('foo', '', 0644, Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc),
+                           @io.string[0, 512]
+    end
   end
 
   def test_add_symlink
-    @tar_writer.add_symlink 'x', 'y', 0644
+    Time.stub :now, Time.at(1458518157) do
+      @tar_writer.add_symlink 'x', 'y', 0644
 
-    assert_headers_equal(tar_symlink_header('x', '', 0644, Time.now, 'y'),
+      assert_headers_equal(tar_symlink_header('x', '', 0644, Time.now, 'y'),
                          @io.string[0, 512])
+    end
     assert_equal 512, @io.pos
   end
 
   def test_add_symlink_source_date_epoch
     ENV["SOURCE_DATE_EPOCH"] = "123456789"
-    @tar_writer.add_symlink 'x', 'y', 0644
+    Time.stub :now, Time.at(1458518157) do
+      @tar_writer.add_symlink 'x', 'y', 0644
 
-    assert_headers_equal(tar_symlink_header('x', '', 0644, Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc, 'y'),
+      assert_headers_equal(tar_symlink_header('x', '', 0644, Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc, 'y'),
                          @io.string[0, 512])
+    end
   end
 
   def test_add_file_digest
     digest_algorithms = Digest::SHA1.new, Digest::SHA512.new
 
-    digests = @tar_writer.add_file_digest 'x', 0644, digest_algorithms do |io|
-      io.write 'a' * 10
-    end
+    Time.stub :now, Time.at(1458518157) do
+      digests = @tar_writer.add_file_digest 'x', 0644, digest_algorithms do |io|
+        io.write 'a' * 10
+      end
 
-    assert_equal '3495ff69d34671d1e15b33a63c1379fdedd3a32a',
-                 digests['SHA1'].hexdigest
-    assert_equal '4714870aff6c97ca09d135834fdb58a6389a50c1' \
-                 '1fef8ec4afef466fb60a23ac6b7a9c92658f14df' \
-                 '4993d6b40a4e4d8424196afc347e97640d68de61' \
-                 'e1cf14b0',
-                 digests['SHA512'].hexdigest
+      assert_equal '3495ff69d34671d1e15b33a63c1379fdedd3a32a',
+                   digests['SHA1'].hexdigest
+      assert_equal '4714870aff6c97ca09d135834fdb58a6389a50c1' \
+                   '1fef8ec4afef466fb60a23ac6b7a9c92658f14df' \
+                   '4993d6b40a4e4d8424196afc347e97640d68de61' \
+                   'e1cf14b0',
+                   digests['SHA512'].hexdigest
 
-    assert_headers_equal(tar_file_header('x', '', 0644, 10, Time.now),
+      assert_headers_equal(tar_file_header('x', '', 0644, 10, Time.now),
                          @io.string[0, 512])
-
+    end
     assert_equal "aaaaaaaaaa#{"\0" * 502}", @io.string[512, 512]
     assert_equal 1024, @io.pos
   end
@@ -86,21 +95,22 @@ class TestGemPackageTarWriter < Gem::Package::TarTestCase
   def test_add_file_digest_multiple
     digest_algorithms = [Digest::SHA1.new, Digest::SHA512.new]
 
-    digests = @tar_writer.add_file_digest 'x', 0644, digest_algorithms do |io|
-      io.write 'a' * 10
+    Time.stub :now, Time.at(1458518157) do
+      digests = @tar_writer.add_file_digest 'x', 0644, digest_algorithms do |io|
+        io.write 'a' * 10
+      end
+
+      assert_equal '3495ff69d34671d1e15b33a63c1379fdedd3a32a',
+                   digests['SHA1'].hexdigest
+      assert_equal '4714870aff6c97ca09d135834fdb58a6389a50c1' \
+                   '1fef8ec4afef466fb60a23ac6b7a9c92658f14df' \
+                   '4993d6b40a4e4d8424196afc347e97640d68de61' \
+                   'e1cf14b0',
+                   digests['SHA512'].hexdigest
+
+      assert_headers_equal(tar_file_header('x', '', 0644, 10, Time.now),
+                           @io.string[0, 512])
     end
-
-    assert_equal '3495ff69d34671d1e15b33a63c1379fdedd3a32a',
-                 digests['SHA1'].hexdigest
-    assert_equal '4714870aff6c97ca09d135834fdb58a6389a50c1' \
-                 '1fef8ec4afef466fb60a23ac6b7a9c92658f14df' \
-                 '4993d6b40a4e4d8424196afc347e97640d68de61' \
-                 'e1cf14b0',
-                 digests['SHA512'].hexdigest
-
-    assert_headers_equal(tar_file_header('x', '', 0644, 10, Time.now),
-                         @io.string[0, 512])
-
     assert_equal "aaaaaaaaaa#{"\0" * 502}", @io.string[512, 512]
     assert_equal 1024, @io.pos
   end
@@ -110,70 +120,80 @@ class TestGemPackageTarWriter < Gem::Package::TarTestCase
 
     signer = Gem::Security::Signer.new PRIVATE_KEY, [PUBLIC_CERT]
 
-    @tar_writer.add_file_signed 'x', 0644, signer do |io|
-      io.write 'a' * 10
+    Time.stub :now, Time.at(1458518157) do
+      @tar_writer.add_file_signed 'x', 0644, signer do |io|
+        io.write 'a' * 10
+      end
+
+      assert_headers_equal(tar_file_header('x', '', 0644, 10, Time.now),
+                           @io.string[0, 512])
+
+      assert_equal "aaaaaaaaaa#{"\0" * 502}", @io.string[512, 512]
+
+      digest = signer.digest_algorithm.new
+      digest.update 'a' * 10
+
+      signature = signer.sign digest.digest
+
+      assert_headers_equal(tar_file_header('x.sig', '', 0444, signature.length,
+                                           Time.now),
+                           @io.string[1024, 512])
+      assert_equal "#{signature}#{"\0" * (512 - signature.length)}",
+                   @io.string[1536, 512]
+
+      assert_equal 2048, @io.pos
     end
-
-    assert_headers_equal(tar_file_header('x', '', 0644, 10, Time.now),
-                         @io.string[0, 512])
-
-    assert_equal "aaaaaaaaaa#{"\0" * 502}", @io.string[512, 512]
-
-    digest = signer.digest_algorithm.new
-    digest.update 'a' * 10
-
-    signature = signer.sign digest.digest
-
-    assert_headers_equal(tar_file_header('x.sig', '', 0444, signature.length,
-                                         Time.now),
-                         @io.string[1024, 512])
-    assert_equal "#{signature}#{"\0" * (512 - signature.length)}",
-                 @io.string[1536, 512]
-
-    assert_equal 2048, @io.pos
   end
 
   def test_add_file_signer_empty
     signer = Gem::Security::Signer.new nil, nil
 
-    @tar_writer.add_file_signed 'x', 0644, signer do |io|
-      io.write 'a' * 10
-    end
+    Time.stub :now, Time.at(1458518157) do
+      @tar_writer.add_file_signed 'x', 0644, signer do |io|
+        io.write 'a' * 10
+      end
 
-    assert_headers_equal(tar_file_header('x', '', 0644, 10, Time.now),
-                         @io.string[0, 512])
+      assert_headers_equal(tar_file_header('x', '', 0644, 10, Time.now),
+                           @io.string[0, 512])
+    end
     assert_equal "aaaaaaaaaa#{"\0" * 502}", @io.string[512, 512]
 
     assert_equal 1024, @io.pos
   end
 
   def test_add_file_simple
-    @tar_writer.add_file_simple 'x', 0644, 10 do |io|
-      io.write "a" * 10
+    Time.stub :now, Time.at(1458518157) do
+      @tar_writer.add_file_simple 'x', 0644, 10 do |io|
+        io.write "a" * 10
+      end
+
+      assert_headers_equal(tar_file_header('x', '', 0644, 10, Time.now),
+                           @io.string[0, 512])
+
+      assert_equal "aaaaaaaaaa#{"\0" * 502}", @io.string[512, 512]
+      assert_equal 1024, @io.pos
     end
-
-    assert_headers_equal(tar_file_header('x', '', 0644, 10, Time.now),
-                       @io.string[0, 512])
-
-    assert_equal "aaaaaaaaaa#{"\0" * 502}", @io.string[512, 512]
-    assert_equal 1024, @io.pos
   end
 
   def test_add_file_simple_source_date_epoch
     ENV["SOURCE_DATE_EPOCH"] = "123456789"
-    @tar_writer.add_file_simple 'x', 0644, 10 do |io|
-      io.write "a" * 10
-    end
+    Time.stub :now, Time.at(1458518157) do
+      @tar_writer.add_file_simple 'x', 0644, 10 do |io|
+        io.write "a" * 10
+      end
 
-    assert_headers_equal(tar_file_header('x', '', 0644, 10, Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc),
-                         @io.string[0, 512])
+      assert_headers_equal(tar_file_header('x', '', 0644, 10, Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc),
+                           @io.string[0, 512])
+    end
   end
 
   def test_add_file_simple_padding
-    @tar_writer.add_file_simple 'x', 0, 100
+    Time.stub :now, Time.at(1458518157) do
+      @tar_writer.add_file_simple 'x', 0, 100
 
-    assert_headers_equal tar_file_header('x', '', 0, 100, Time.now),
-                       @io.string[0, 512]
+      assert_headers_equal tar_file_header('x', '', 0, 100, Time.now),
+        @io.string[0, 512]
+    end
 
     assert_equal "\0" * 512, @io.string[512, 512]
   end
@@ -226,20 +246,24 @@ class TestGemPackageTarWriter < Gem::Package::TarTestCase
   end
 
   def test_mkdir
-    @tar_writer.mkdir 'foo', 0644
+    Time.stub :now, Time.at(1458518157) do
+      @tar_writer.mkdir 'foo', 0644
 
-    assert_headers_equal tar_dir_header('foo', '', 0644, Time.now),
-                         @io.string[0, 512]
+      assert_headers_equal tar_dir_header('foo', '', 0644, Time.now),
+                           @io.string[0, 512]
 
-    assert_equal 512, @io.pos
+      assert_equal 512, @io.pos
+    end
   end
 
   def test_mkdir_source_date_epoch
     ENV["SOURCE_DATE_EPOCH"] = "123456789"
-    @tar_writer.mkdir 'foo', 0644
+    Time.stub :now, Time.at(1458518157) do
+      @tar_writer.mkdir 'foo', 0644
 
-    assert_headers_equal tar_dir_header('foo', '', 0644, Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc),
-                         @io.string[0, 512]
+      assert_headers_equal tar_dir_header('foo', '', 0644, Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc),
+                           @io.string[0, 512]
+    end
   end
 
   def test_split_name


### PR DESCRIPTION
Essentially this reverts 45464bfcbdf9f9cfb440950bc57a27d237627a17.
The commit removed a mock of Time.now, which caused a random failure.

http://rubyci.s3.amazonaws.com/ubuntu1804/ruby-master/log/20210512T123004Z.fail.html.gz
```
  1) Failure:
TestGemPackageTarWriter#test_add_file_signer [/home/chkbuild/chkbuild/tmp/build/20210512T123004Z/ruby/test/rubygems/test_gem_package_tar_writer.rb:117]:
Field mtime of the tar header differs..
<"14046746312\u0000"> expected but was
<"14046746311\x00">.
```

Object#stub is defined at f1af59fe02ef2cc58f13e2742e4cc6cf8c2a1a20, so
now `Time.stub :now` works.