### PR TITLE
Fix dependency confusion issues with implicit dependencies

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -180,6 +180,7 @@ bundler/lib/bundler/source/path.rb
 bundler/lib/bundler/source/path/installer.rb
 bundler/lib/bundler/source/rubygems.rb
 bundler/lib/bundler/source/rubygems/remote.rb
+bundler/lib/bundler/source/rubygems_aggregate.rb
 bundler/lib/bundler/source_list.rb
 bundler/lib/bundler/source_map.rb
 bundler/lib/bundler/spec_set.rb

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -181,6 +181,7 @@ bundler/lib/bundler/source/path/installer.rb
 bundler/lib/bundler/source/rubygems.rb
 bundler/lib/bundler/source/rubygems/remote.rb
 bundler/lib/bundler/source_list.rb
+bundler/lib/bundler/source_map.rb
 bundler/lib/bundler/spec_set.rb
 bundler/lib/bundler/stub_specification.rb
 bundler/lib/bundler/templates/.document

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -69,6 +69,7 @@ module Bundler
   autoload :SharedHelpers,          File.expand_path("bundler/shared_helpers", __dir__)
   autoload :Source,                 File.expand_path("bundler/source", __dir__)
   autoload :SourceList,             File.expand_path("bundler/source_list", __dir__)
+  autoload :SourceMap,              File.expand_path("bundler/source_map", __dir__)
   autoload :SpecSet,                File.expand_path("bundler/spec_set", __dir__)
   autoload :StubSpecification,      File.expand_path("bundler/stub_specification", __dir__)
   autoload :UI,                     File.expand_path("bundler/ui", __dir__)

--- a/bundler/lib/bundler/cli/outdated.rb
+++ b/bundler/lib/bundler/cli/outdated.rb
@@ -146,17 +146,14 @@ module Bundler
     end
 
     def retrieve_active_spec(definition, current_spec)
-      if strict
-        active_spec = definition.find_resolved_spec(current_spec)
-      else
-        active_specs = definition.find_indexed_specs(current_spec)
-        if !current_spec.version.prerelease? && !options[:pre] && active_specs.size > 1
-          active_specs.delete_if {|b| b.respond_to?(:version) && b.version.prerelease? }
-        end
-        active_spec = active_specs.last
-      end
+      active_spec = definition.resolve.find_by_name_and_platform(current_spec.name, current_spec.platform)
+      return active_spec if strict
 
-      active_spec
+      active_specs = active_spec.source.specs.search(current_spec.name).select {|spec| spec.match_platform(current_spec.platform) }.sort_by(&:version)
+      if !current_spec.version.prerelease? && !options[:pre] && active_specs.size > 1
+        active_specs.delete_if {|b| b.respond_to?(:version) && b.version.prerelease? }
+      end
+      active_specs.last
     end
 
     def print_gems(gems_list)

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -866,7 +866,7 @@ module Bundler
       source_requirements = if precompute_source_requirements_for_indirect_dependencies?
         { :default => sources.default_source }.merge(source_map.all_requirements)
       else
-        { :global => Source::RubygemsAggregate.new(sources, source_map) }.merge(source_map.direct_requirements)
+        { :default => Source::RubygemsAggregate.new(sources, source_map) }.merge(source_map.direct_requirements)
       end
       metadata_dependencies.each do |dep|
         source_requirements[dep.name] = sources.metadata_source

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -906,7 +906,7 @@ module Bundler
       # Record the specs available in each gem's source, so that those
       # specs will be available later when the resolver knows where to
       # look for that gemspec (or its dependencies)
-      source_requirements = { :default => sources.default_source }.merge(dependency_source_requirements)
+      source_requirements = { :default => sources.default_source }.merge(direct_dependency_source_requirements)
       metadata_dependencies.each do |dep|
         source_requirements[dep.name] = sources.metadata_source
       end
@@ -917,7 +917,7 @@ module Bundler
     end
 
     def pinned_spec_names(skip = nil)
-      dependency_source_requirements.reject {|_, source| source == skip }.keys
+      direct_dependency_source_requirements.reject {|_, source| source == skip }.keys
     end
 
     def requested_groups
@@ -975,8 +975,8 @@ module Bundler
       Bundler.settings[:allow_deployment_source_credential_changes] && source.equivalent_remotes?(sources.rubygems_remotes)
     end
 
-    def dependency_source_requirements
-      @dependency_source_requirements ||= begin
+    def direct_dependency_source_requirements
+      @direct_dependency_source_requirements ||= begin
         source_requirements = {}
         default = sources.default_source
         dependencies.each do |dep|

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -224,7 +224,6 @@ module Bundler
       Bundler.ui.debug "The definition is missing #{missing.map(&:full_name)}"
       true
     rescue BundlerError => e
-      @index = nil
       @resolve = nil
       @specs = nil
       @gem_version_promoter = nil
@@ -287,8 +286,8 @@ module Bundler
       end
     end
 
-    def index
-      @index ||= Index.build do |idx|
+    def build_index
+      Index.build do |idx|
         dependency_names = @dependencies.map(&:name)
 
         sources.all_sources.each do |source|
@@ -902,7 +901,7 @@ module Bundler
 
     def source_requirements
       # Load all specs from remote sources
-      index
+      index = build_index
 
       # Record the specs available in each gem's source, so that those
       # specs will be available later when the resolver knows where to

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -911,7 +911,7 @@ module Bundler
         source_requirements[dep.name] = sources.metadata_source
       end
       source_requirements[:global] = index unless Bundler.feature_flag.disable_multisource?
-      source_requirements[:default_bundler] = source_requirements["bundler"] || source_requirements[:default]
+      source_requirements[:default_bundler] = source_requirements["bundler"] || sources.default_source
       source_requirements["bundler"] = sources.metadata_source # needs to come last to override
       source_requirements
     end

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -539,14 +539,6 @@ module Bundler
       end
     end
 
-    def find_resolved_spec(current_spec)
-      specs.find_by_name_and_platform(current_spec.name, current_spec.platform)
-    end
-
-    def find_indexed_specs(current_spec)
-      index[current_spec.name].select {|spec| spec.match_platform(current_spec.platform) }.sort_by(&:version)
-    end
-
     attr_reader :sources
     private :sources
 

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -679,9 +679,9 @@ module Bundler
       changes = false
 
       # If there is a RubyGems source in both
-      locked_gem_sources.each do |locked_gem|
+      locked_gem_sources.each do |locked_gem_source|
         # Merge the remotes from the Gemfile into the Gemfile.lock
-        changes |= locked_gem.replace_remotes(actual_remotes, Bundler.settings[:allow_deployment_source_credential_changes])
+        changes |= locked_gem_source.replace_remotes(actual_remotes, Bundler.settings[:allow_deployment_source_credential_changes])
       end
 
       changes

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -307,25 +307,20 @@ module Bundler
     # each spec we found, we add all possible versions from all sources to the index.
     def double_check_for_index(idx, dependency_names)
       pinned_names = pinned_spec_names
-      loop do
-        idxcount = idx.size
 
-        names = :names # do this so we only have to traverse to get dependency_names from the index once
-        unmet_dependency_names = lambda do
-          return names unless names == :names
-          new_names = sources.all_sources.map(&:dependency_names_to_double_check)
-          return names = nil if new_names.compact!
-          names = new_names.flatten(1).concat(dependency_names)
-          names.uniq!
-          names -= pinned_names
-          names
-        end
+      names = :names # do this so we only have to traverse to get dependency_names from the index once
+      unmet_dependency_names = lambda do
+        return names unless names == :names
+        new_names = sources.all_sources.map(&:dependency_names_to_double_check)
+        return names = nil if new_names.compact!
+        names = new_names.flatten(1).concat(dependency_names)
+        names.uniq!
+        names -= pinned_names
+        names
+      end
 
-        sources.all_sources.each do |source|
-          source.double_check_for(unmet_dependency_names)
-        end
-
-        break if idxcount == idx.size
+      sources.all_sources.each do |source|
+        source.double_check_for(unmet_dependency_names)
       end
     end
     private :double_check_for_index

--- a/bundler/lib/bundler/feature_flag.rb
+++ b/bundler/lib/bundler/feature_flag.rb
@@ -31,7 +31,6 @@ module Bundler
     settings_flag(:auto_clean_without_path) { bundler_3_mode? }
     settings_flag(:cache_all) { bundler_3_mode? }
     settings_flag(:default_install_uses_path) { bundler_3_mode? }
-    settings_flag(:disable_multisource) { bundler_3_mode? }
     settings_flag(:forget_cli_options) { bundler_3_mode? }
     settings_flag(:global_gem_cache) { bundler_3_mode? }
     settings_flag(:path_relative_to_cwd) { bundler_3_mode? }

--- a/bundler/lib/bundler/index.rb
+++ b/bundler/lib/bundler/index.rb
@@ -125,7 +125,7 @@ module Bundler
     # returns a list of the dependencies
     def unmet_dependency_names
       dependency_names.select do |name|
-        name != "bundler" && search(name).empty?
+        search(name).empty?
       end
     end
 

--- a/bundler/lib/bundler/index.rb
+++ b/bundler/lib/bundler/index.rb
@@ -122,7 +122,6 @@ module Bundler
       names
     end
 
-    # returns a list of the dependencies
     def unmet_dependency_names
       dependency_names.select do |name|
         search(name).empty?

--- a/bundler/lib/bundler/man/bundle-add.1
+++ b/bundler/lib/bundler/man/bundle-add.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-ADD" "1" "April 2021" "" ""
+.TH "BUNDLE\-ADD" "1" "May 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-add\fR \- Add gem to the Gemfile and run bundle install

--- a/bundler/lib/bundler/man/bundle-binstubs.1
+++ b/bundler/lib/bundler/man/bundle-binstubs.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-BINSTUBS" "1" "April 2021" "" ""
+.TH "BUNDLE\-BINSTUBS" "1" "May 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-binstubs\fR \- Install the binstubs of the listed gems

--- a/bundler/lib/bundler/man/bundle-cache.1
+++ b/bundler/lib/bundler/man/bundle-cache.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CACHE" "1" "April 2021" "" ""
+.TH "BUNDLE\-CACHE" "1" "May 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-cache\fR \- Package your needed \fB\.gem\fR files into your application

--- a/bundler/lib/bundler/man/bundle-check.1
+++ b/bundler/lib/bundler/man/bundle-check.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CHECK" "1" "April 2021" "" ""
+.TH "BUNDLE\-CHECK" "1" "May 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-check\fR \- Verifies if dependencies are satisfied by installed gems

--- a/bundler/lib/bundler/man/bundle-clean.1
+++ b/bundler/lib/bundler/man/bundle-clean.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CLEAN" "1" "April 2021" "" ""
+.TH "BUNDLE\-CLEAN" "1" "May 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-clean\fR \- Cleans up unused gems in your bundler directory

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CONFIG" "1" "April 2021" "" ""
+.TH "BUNDLE\-CONFIG" "1" "May 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-config\fR \- Set bundler configuration options
@@ -55,9 +55,6 @@ Executing \fBbundle config unset \-\-local <name> <value>\fR will delete the con
 .
 .P
 Executing bundle with the \fBBUNDLE_IGNORE_CONFIG\fR environment variable set will cause it to ignore all configuration\.
-.
-.P
-Executing \fBbundle config set \-\-local disable_multisource true\fR upgrades the warning about the Gemfile containing multiple primary sources to an error\. Executing \fBbundle config unset disable_multisource\fR downgrades this error to a warning\.
 .
 .SH "REMEMBERING OPTIONS"
 Flags passed to \fBbundle install\fR or the Bundler runtime, such as \fB\-\-path foo\fR or \fB\-\-without production\fR, are remembered between commands and saved to your local application\'s configuration (normally, \fB\./\.bundle/config\fR)\.
@@ -182,9 +179,6 @@ The following is a list of all configuration keys and their purpose\. You can le
 .
 .IP "\(bu" 4
 \fBdisable_local_revision_check\fR (\fBBUNDLE_DISABLE_LOCAL_REVISION_CHECK\fR): Allow Bundler to use a local git override without checking if the revision present in the lockfile is present in the repository\.
-.
-.IP "\(bu" 4
-\fBdisable_multisource\fR (\fBBUNDLE_DISABLE_MULTISOURCE\fR): When set, Gemfiles containing multiple sources will produce errors instead of warnings\. Use \fBbundle config unset disable_multisource\fR to unset\.
 .
 .IP "\(bu" 4
 \fBdisable_shared_gems\fR (\fBBUNDLE_DISABLE_SHARED_GEMS\fR): Stop Bundler from accessing gems installed to RubyGems\' normal location\.

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -47,10 +47,6 @@ configuration only from the local application.
 Executing bundle with the `BUNDLE_IGNORE_CONFIG` environment variable set will
 cause it to ignore all configuration.
 
-Executing `bundle config set --local disable_multisource true` upgrades the warning about
-the Gemfile containing multiple primary sources to an error. Executing `bundle
-config unset disable_multisource` downgrades this error to a warning.
-
 ## REMEMBERING OPTIONS
 
 Flags passed to `bundle install` or the Bundler runtime, such as `--path foo` or
@@ -178,10 +174,6 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
 * `disable_local_revision_check` (`BUNDLE_DISABLE_LOCAL_REVISION_CHECK`):
    Allow Bundler to use a local git override without checking if the revision
    present in the lockfile is present in the repository.
-* `disable_multisource` (`BUNDLE_DISABLE_MULTISOURCE`):
-   When set, Gemfiles containing multiple sources will produce errors
-   instead of warnings.
-   Use `bundle config unset disable_multisource` to unset.
 * `disable_shared_gems` (`BUNDLE_DISABLE_SHARED_GEMS`):
    Stop Bundler from accessing gems installed to RubyGems' normal location.
 * `disable_version_check` (`BUNDLE_DISABLE_VERSION_CHECK`):

--- a/bundler/lib/bundler/man/bundle-doctor.1
+++ b/bundler/lib/bundler/man/bundle-doctor.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-DOCTOR" "1" "April 2021" "" ""
+.TH "BUNDLE\-DOCTOR" "1" "May 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-doctor\fR \- Checks the bundle for common problems

--- a/bundler/lib/bundler/man/bundle-exec.1
+++ b/bundler/lib/bundler/man/bundle-exec.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-EXEC" "1" "April 2021" "" ""
+.TH "BUNDLE\-EXEC" "1" "May 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-exec\fR \- Execute a command in the context of the bundle

--- a/bundler/lib/bundler/man/bundle-gem.1
+++ b/bundler/lib/bundler/man/bundle-gem.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-GEM" "1" "April 2021" "" ""
+.TH "BUNDLE\-GEM" "1" "May 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-gem\fR \- Generate a project skeleton for creating a rubygem

--- a/bundler/lib/bundler/man/bundle-info.1
+++ b/bundler/lib/bundler/man/bundle-info.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INFO" "1" "April 2021" "" ""
+.TH "BUNDLE\-INFO" "1" "May 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-info\fR \- Show information for the given gem in your bundle

--- a/bundler/lib/bundler/man/bundle-init.1
+++ b/bundler/lib/bundler/man/bundle-init.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INIT" "1" "April 2021" "" ""
+.TH "BUNDLE\-INIT" "1" "May 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-init\fR \- Generates a Gemfile into the current working directory

--- a/bundler/lib/bundler/man/bundle-inject.1
+++ b/bundler/lib/bundler/man/bundle-inject.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INJECT" "1" "April 2021" "" ""
+.TH "BUNDLE\-INJECT" "1" "May 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-inject\fR \- Add named gem(s) with version requirements to Gemfile

--- a/bundler/lib/bundler/man/bundle-install.1
+++ b/bundler/lib/bundler/man/bundle-install.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INSTALL" "1" "April 2021" "" ""
+.TH "BUNDLE\-INSTALL" "1" "May 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-install\fR \- Install the dependencies specified in your Gemfile

--- a/bundler/lib/bundler/man/bundle-list.1
+++ b/bundler/lib/bundler/man/bundle-list.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-LIST" "1" "April 2021" "" ""
+.TH "BUNDLE\-LIST" "1" "May 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-list\fR \- List all the gems in the bundle

--- a/bundler/lib/bundler/man/bundle-lock.1
+++ b/bundler/lib/bundler/man/bundle-lock.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-LOCK" "1" "April 2021" "" ""
+.TH "BUNDLE\-LOCK" "1" "May 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-lock\fR \- Creates / Updates a lockfile without installing

--- a/bundler/lib/bundler/man/bundle-open.1
+++ b/bundler/lib/bundler/man/bundle-open.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-OPEN" "1" "April 2021" "" ""
+.TH "BUNDLE\-OPEN" "1" "May 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-open\fR \- Opens the source directory for a gem in your bundle

--- a/bundler/lib/bundler/man/bundle-outdated.1
+++ b/bundler/lib/bundler/man/bundle-outdated.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-OUTDATED" "1" "April 2021" "" ""
+.TH "BUNDLE\-OUTDATED" "1" "May 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-outdated\fR \- List installed gems with newer versions available

--- a/bundler/lib/bundler/man/bundle-platform.1
+++ b/bundler/lib/bundler/man/bundle-platform.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-PLATFORM" "1" "April 2021" "" ""
+.TH "BUNDLE\-PLATFORM" "1" "May 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-platform\fR \- Displays platform compatibility information

--- a/bundler/lib/bundler/man/bundle-pristine.1
+++ b/bundler/lib/bundler/man/bundle-pristine.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-PRISTINE" "1" "April 2021" "" ""
+.TH "BUNDLE\-PRISTINE" "1" "May 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-pristine\fR \- Restores installed gems to their pristine condition

--- a/bundler/lib/bundler/man/bundle-remove.1
+++ b/bundler/lib/bundler/man/bundle-remove.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-REMOVE" "1" "April 2021" "" ""
+.TH "BUNDLE\-REMOVE" "1" "May 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-remove\fR \- Removes gems from the Gemfile

--- a/bundler/lib/bundler/man/bundle-show.1
+++ b/bundler/lib/bundler/man/bundle-show.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-SHOW" "1" "April 2021" "" ""
+.TH "BUNDLE\-SHOW" "1" "May 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-show\fR \- Shows all the gems in your bundle, or the path to a gem

--- a/bundler/lib/bundler/man/bundle-update.1
+++ b/bundler/lib/bundler/man/bundle-update.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-UPDATE" "1" "April 2021" "" ""
+.TH "BUNDLE\-UPDATE" "1" "May 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-update\fR \- Update your gems to the latest available versions

--- a/bundler/lib/bundler/man/bundle-viz.1
+++ b/bundler/lib/bundler/man/bundle-viz.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-VIZ" "1" "April 2021" "" ""
+.TH "BUNDLE\-VIZ" "1" "May 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-viz\fR \- Generates a visual dependency graph for your Gemfile

--- a/bundler/lib/bundler/man/bundle.1
+++ b/bundler/lib/bundler/man/bundle.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE" "1" "April 2021" "" ""
+.TH "BUNDLE" "1" "May 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\fR \- Ruby Dependency Management

--- a/bundler/lib/bundler/man/gemfile.5
+++ b/bundler/lib/bundler/man/gemfile.5
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GEMFILE" "5" "April 2021" "" ""
+.TH "GEMFILE" "5" "May 2021" "" ""
 .
 .SH "NAME"
 \fBGemfile\fR \- A format for describing gem dependencies for Ruby programs

--- a/bundler/lib/bundler/plugin/api/source.rb
+++ b/bundler/lib/bundler/plugin/api/source.rb
@@ -244,6 +244,20 @@ module Bundler
           specs.unmet_dependency_names
         end
 
+        # Used by definition.
+        #
+        # Note: Do not override if you don't know what you are doing.
+        def spec_names
+          specs.spec_names
+        end
+
+        # Used by definition.
+        #
+        # Note: Do not override if you don't know what you are doing.
+        def add_dependency_names(names)
+          @dependencies |= Array(names)
+        end
+
         # Note: Do not override if you don't know what you are doing.
         def can_lock?(spec)
           spec.source == self

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -370,11 +370,7 @@ module Bundler
           elsif !conflict.existing
             o << "\n"
 
-            relevant_sources = if conflict.requirement.source
-              [conflict.requirement.source]
-            else
-              [@source_requirements[name] || @source_requirements[:default]]
-            end.compact.map(&:to_s).uniq.sort
+            relevant_source = conflict.requirement.source || @source_requirements[name] || @source_requirements[:default]
 
             metadata_requirement = name.end_with?("\0")
 
@@ -387,12 +383,12 @@ module Bundler
             end
             o << " "
 
-            o << if relevant_sources.empty?
+            o << if relevant_source.nil?
               "in any of the sources.\n"
             elsif metadata_requirement
-              "is not available in #{relevant_sources.join(" or ")}"
+              "is not available in #{relevant_source}"
             else
-              "in any of the relevant sources:\n  #{relevant_sources * "\n  "}\n"
+              "in #{relevant_source}.\n"
             end
           end
         end,

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -55,7 +55,6 @@ module Bundler
       verify_gemfile_dependencies_are_found!(requirements)
       dg = @resolver.resolve(requirements, @base_dg)
       dg.
-        tap {|resolved| validate_resolved_specs!(resolved) }.
         map(&:payload).
         reject {|sg| sg.name.end_with?("\0") }.
         map(&:to_specs).
@@ -175,9 +174,7 @@ module Bundler
       if source
         source
       elsif @no_aggregate_global_source
-        Index.build do |idx|
-          dependency.all_sources.each {|s| idx.add_source(s.specs) }
-        end
+        @index_requirements[:default]
       else
         @index_requirements[:global]
       end
@@ -211,23 +208,10 @@ module Bundler
       dependencies.map(&:dep) == other_dependencies.map(&:dep)
     end
 
-    def relevant_sources_for_vertex(vertex)
-      if vertex.root?
-        [@source_requirements[vertex.name]]
-      elsif @no_aggregate_global_source
-        vertex.recursive_predecessors.map do |v|
-          @source_requirements[v.name]
-        end.compact << @source_requirements[:default]
-      else
-        []
-      end
-    end
-
     def sort_dependencies(dependencies, activated, conflicts)
       dependencies.sort_by do |dependency|
         name = name_for(dependency)
         vertex = activated.vertex_named(name)
-        dependency.all_sources = relevant_sources_for_vertex(vertex)
         [
           @base_dg.vertex_named(name) ? 0 : 1,
           vertex.payload ? 0 : 1,
@@ -389,7 +373,7 @@ module Bundler
             relevant_sources = if conflict.requirement.source
               [conflict.requirement.source]
             else
-              conflict.requirement.all_sources
+              [@source_requirements[name] || @source_requirements[:default]]
             end.compact.map(&:to_s).uniq.sort
 
             metadata_requirement = name.end_with?("\0")
@@ -421,28 +405,6 @@ module Bundler
           end
         end
       )
-    end
-
-    def validate_resolved_specs!(resolved_specs)
-      resolved_specs.each do |v|
-        name = v.name
-        sources = relevant_sources_for_vertex(v)
-        next unless sources.any?
-        if default_index = sources.index(@source_requirements[:default])
-          sources.delete_at(default_index)
-        end
-        sources.reject! {|s| s.specs.search(name).empty? }
-        sources.uniq!
-        next if sources.size <= 1
-
-        msg = ["The gem '#{name}' was found in multiple relevant sources."]
-        msg.concat sources.map {|s| "  * #{s}" }.sort
-        msg << "You #{@no_aggregate_global_source ? :must : :should} add this gem to the source block for the source you wish it to be installed from."
-        msg = msg.join("\n")
-
-        raise SecurityError, msg if @no_aggregate_global_source
-        Bundler.ui.warn "Warning: #{msg}"
-      end
     end
   end
 end

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -29,7 +29,7 @@ module Bundler
 
       @index_requirements = source_requirements.each_with_object({}) do |source_requirement, index_requirements|
         name, source = source_requirement
-        index_requirements[name] = name == :global ? source : source.specs
+        index_requirements[name] = source.specs
       end
 
       @base = base

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -105,7 +105,7 @@ module Gem
   end
 
   class Dependency
-    attr_accessor :source, :groups, :all_sources
+    attr_accessor :source, :groups
 
     alias_method :eql?, :==
 
@@ -116,7 +116,7 @@ module Gem
     end
 
     def to_yaml_properties
-      instance_variables.reject {|p| ["@source", "@groups", "@all_sources"].include?(p.to_s) }
+      instance_variables.reject {|p| ["@source", "@groups"].include?(p.to_s) }
     end
 
     def to_lock

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -20,7 +20,6 @@ module Bundler
       disable_exec_load
       disable_local_branch_check
       disable_local_revision_check
-      disable_multisource
       disable_shared_gems
       disable_version_check
       force_ruby_platform

--- a/bundler/lib/bundler/source.rb
+++ b/bundler/lib/bundler/source.rb
@@ -7,6 +7,7 @@ module Bundler
     autoload :Metadata, File.expand_path("source/metadata", __dir__)
     autoload :Path,     File.expand_path("source/path", __dir__)
     autoload :Rubygems, File.expand_path("source/rubygems", __dir__)
+    autoload :RubygemsAggregate, File.expand_path("source/rubygems_aggregate", __dir__)
 
     attr_accessor :dependency_names
 

--- a/bundler/lib/bundler/source.rb
+++ b/bundler/lib/bundler/source.rb
@@ -40,6 +40,10 @@ module Bundler
 
     def remote!; end
 
+    def add_dependency_names(names)
+      @dependency_names = Array(dependency_names) | Array(names)
+    end
+
     # it's possible that gems from one source depend on gems from some
     # other source, so now we download gemspecs and iterate over those
     # dependencies, looking for gems we don't have info on yet.
@@ -47,6 +51,10 @@ module Bundler
 
     def dependency_names_to_double_check
       specs.dependency_names
+    end
+
+    def spec_names
+      specs.spec_names
     end
 
     def include?(other)

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -298,14 +298,13 @@ module Bundler
         remote_specs.each do |spec|
           case spec
           when EndpointSpecification, Gem::Specification, StubSpecification, LazySpecification
-            names.concat(spec.runtime_dependencies)
+            names.concat(spec.runtime_dependencies.map(&:name))
           when RemoteSpecification # from the full index
             return nil
           else
             raise "unhandled spec type (#{spec.inspect})"
           end
         end
-        names.map!(&:name) if names
         names
       end
 

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -259,8 +259,16 @@ module Bundler
         !equivalent
       end
 
+      def spec_names
+        if @allow_remote && dependency_api_available?
+          remote_specs.spec_names
+        else
+          []
+        end
+      end
+
       def unmet_deps
-        if @allow_remote && api_fetchers.any?
+        if @allow_remote && dependency_api_available?
           remote_specs.unmet_dependency_names
         else
           []
@@ -276,7 +284,7 @@ module Bundler
 
       def double_check_for(unmet_dependency_names)
         return unless @allow_remote
-        return unless api_fetchers.any?
+        return unless dependency_api_available?
 
         unmet_dependency_names = unmet_dependency_names.call
         unless unmet_dependency_names.nil?
@@ -306,6 +314,10 @@ module Bundler
           end
         end
         names
+      end
+
+      def dependency_api_available?
+        api_fetchers.any?
       end
 
       protected

--- a/bundler/lib/bundler/source/rubygems_aggregate.rb
+++ b/bundler/lib/bundler/source/rubygems_aggregate.rb
@@ -16,6 +16,10 @@ module Bundler
         @index
       end
 
+      def to_s
+        "any of the sources"
+      end
+
       private
 
       def build_index

--- a/bundler/lib/bundler/source/rubygems_aggregate.rb
+++ b/bundler/lib/bundler/source/rubygems_aggregate.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Bundler
+  class Source
+    class RubygemsAggregate
+      attr_reader :source_map, :sources
+
+      def initialize(sources, source_map)
+        @sources = sources
+        @source_map = source_map
+
+        @index = build_index
+      end
+
+      def specs
+        @index
+      end
+
+      private
+
+      def build_index
+        Index.build do |idx|
+          dependency_names = source_map.pinned_spec_names
+
+          sources.all_sources.each do |source|
+            source.dependency_names = dependency_names - source_map.pinned_spec_names(source)
+            idx.add_source source.specs
+            dependency_names.concat(source.unmet_deps).uniq!
+          end
+
+          double_check_for_index(idx, dependency_names)
+        end
+      end
+
+      # Suppose the gem Foo depends on the gem Bar.  Foo exists in Source A.  Bar has some versions that exist in both
+      # sources A and B.  At this point, the API request will have found all the versions of Bar in source A,
+      # but will not have found any versions of Bar from source B, which is a problem if the requested version
+      # of Foo specifically depends on a version of Bar that is only found in source B. This ensures that for
+      # each spec we found, we add all possible versions from all sources to the index.
+      def double_check_for_index(idx, dependency_names)
+        pinned_names = source_map.pinned_spec_names
+
+        names = :names # do this so we only have to traverse to get dependency_names from the index once
+        unmet_dependency_names = lambda do
+          return names unless names == :names
+          new_names = sources.all_sources.map(&:dependency_names_to_double_check)
+          return names = nil if new_names.compact!
+          names = new_names.flatten(1).concat(dependency_names)
+          names.uniq!
+          names -= pinned_names
+          names
+        end
+
+        sources.all_sources.each do |source|
+          source.double_check_for(unmet_dependency_names)
+        end
+      end
+    end
+  end
+end

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -21,15 +21,15 @@ module Bundler
       @rubygems_sources       = []
       @metadata_source        = Source::Metadata.new
 
-      @disable_multisource = true
+      @merged_gem_lockfile_sections = false
     end
 
-    def disable_multisource?
-      @disable_multisource
+    def merged_gem_lockfile_sections?
+      @merged_gem_lockfile_sections
     end
 
     def merged_gem_lockfile_sections!
-      @disable_multisource = false
+      @merged_gem_lockfile_sections = true
     end
 
     def add_path_source(options = {})
@@ -86,11 +86,18 @@ module Bundler
     end
 
     def lock_sources
-      lock_sources = (path_sources + git_sources + plugin_sources).sort_by(&:to_s)
-      if disable_multisource?
-        lock_sources + rubygems_sources.sort_by(&:to_s).uniq
+      lock_other_sources + lock_rubygems_sources
+    end
+
+    def lock_other_sources
+      (path_sources + git_sources + plugin_sources).sort_by(&:to_s)
+    end
+
+    def lock_rubygems_sources
+      if merged_gem_lockfile_sections?
+        [combine_rubygems_sources]
       else
-        lock_sources << combine_rubygems_sources
+        rubygems_sources.sort_by(&:to_s).uniq
       end
     end
 
@@ -104,7 +111,7 @@ module Bundler
         end
       end
 
-      replacement_rubygems = !disable_multisource? &&
+      replacement_rubygems = merged_gem_lockfile_sections? &&
         replacement_sources.detect {|s| s.is_a?(Source::Rubygems) }
       @global_rubygems_source = replacement_rubygems if replacement_rubygems
 

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -32,6 +32,10 @@ module Bundler
       @merged_gem_lockfile_sections = true
     end
 
+    def no_aggregate_global_source?
+      global_rubygems_source.remotes.size <= 1
+    end
+
     def add_path_source(options = {})
       if options["gemspec"]
         add_source_to_list Source::Gemspec.new(options), path_sources
@@ -70,7 +74,11 @@ module Bundler
     end
 
     def rubygems_sources
-      @rubygems_sources + [global_rubygems_source]
+      non_global_rubygems_sources + [global_rubygems_source]
+    end
+
+    def non_global_rubygems_sources
+      @rubygems_sources
     end
 
     def rubygems_remotes
@@ -79,6 +87,10 @@ module Bundler
 
     def all_sources
       path_sources + git_sources + plugin_sources + rubygems_sources + [metadata_source]
+    end
+
+    def non_default_explicit_sources
+      all_sources - [default_source, metadata_source]
     end
 
     def get(source)

--- a/bundler/lib/bundler/source_map.rb
+++ b/bundler/lib/bundler/source_map.rb
@@ -13,12 +13,42 @@ module Bundler
       direct_requirements.reject {|_, source| source == skip }.keys
     end
 
+    def all_requirements
+      requirements = direct_requirements.dup
+
+      unmet_deps = sources.non_default_explicit_sources.map do |source|
+        (source.spec_names - pinned_spec_names).each do |indirect_dependency_name|
+          previous_source = requirements[indirect_dependency_name]
+          if previous_source.nil?
+            requirements[indirect_dependency_name] = source
+          else
+            no_ambiguous_sources = Bundler.feature_flag.bundler_3_mode?
+
+            msg = ["The gem '#{indirect_dependency_name}' was found in multiple relevant sources."]
+            msg.concat [previous_source, source].map {|s| "  * #{s}" }.sort
+            msg << "You #{no_ambiguous_sources ? :must : :should} add this gem to the source block for the source you wish it to be installed from."
+            msg = msg.join("\n")
+
+            raise SecurityError, msg if no_ambiguous_sources
+            Bundler.ui.warn "Warning: #{msg}"
+          end
+        end
+
+        source.unmet_deps
+      end
+
+      sources.default_source.add_dependency_names(unmet_deps.flatten - requirements.keys)
+
+      requirements
+    end
+
     def direct_requirements
       @direct_requirements ||= begin
         requirements = {}
         default = sources.default_source
         dependencies.each do |dep|
           dep_source = dep.source || default
+          dep_source.add_dependency_names(dep.name)
           requirements[dep.name] = dep_source
         end
         requirements

--- a/bundler/lib/bundler/source_map.rb
+++ b/bundler/lib/bundler/source_map.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Bundler
+  class SourceMap
+    attr_reader :sources, :dependencies
+
+    def initialize(sources, dependencies)
+      @sources = sources
+      @dependencies = dependencies
+    end
+
+    def pinned_spec_names(skip = nil)
+      direct_requirements.reject {|_, source| source == skip }.keys
+    end
+
+    def direct_requirements
+      @direct_requirements ||= begin
+        requirements = {}
+        default = sources.default_source
+        dependencies.each do |dep|
+          dep_source = dep.source || default
+          requirements[dep.name] = dep_source
+        end
+        requirements
+      end
+    end
+  end
+end

--- a/bundler/spec/bundler/definition_spec.rb
+++ b/bundler/spec/bundler/definition_spec.rb
@@ -278,33 +278,6 @@ RSpec.describe Bundler::Definition do
     end
   end
 
-  describe "find_resolved_spec" do
-    it "with no platform set in SpecSet" do
-      ss = Bundler::SpecSet.new([build_stub_spec("a", "1.0"), build_stub_spec("b", "1.0")])
-      dfn = Bundler::Definition.new(nil, [], mock_source_list, true)
-      dfn.instance_variable_set("@specs", ss)
-      found = dfn.find_resolved_spec(build_spec("a", "0.9", "ruby").first)
-      expect(found.name).to eq "a"
-      expect(found.version.to_s).to eq "1.0"
-    end
-  end
-
-  describe "find_indexed_specs" do
-    it "with no platform set in indexed specs" do
-      index = Bundler::Index.new
-      %w[1.0.0 1.0.1 1.1.0].each {|v| index << build_stub_spec("foo", v) }
-
-      dfn = Bundler::Definition.new(nil, [], mock_source_list, true)
-      dfn.instance_variable_set("@index", index)
-      found = dfn.find_indexed_specs(build_spec("foo", "0.9", "ruby").first)
-      expect(found.length).to eq 3
-    end
-  end
-
-  def build_stub_spec(name, version)
-    Bundler::StubSpecification.new(name, version, nil, nil)
-  end
-
   def mock_source_list
     Class.new do
       def all_sources

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -533,7 +533,7 @@ RSpec.describe "bundle lock" do
          #{Bundler::VERSION}
     L
 
-    bundle "lock --add-platform x86_64-linux", :artifice => :compact_index, :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+    bundle "lock --add-platform x86_64-linux", :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
   end
 
   context "when an update is available" do

--- a/bundler/spec/commands/outdated_spec.rb
+++ b/bundler/spec/commands/outdated_spec.rb
@@ -205,8 +205,8 @@ RSpec.describe "bundle outdated" do
     end
 
     it "works" do
-      bundle :install, :artifice => :compact_index
-      bundle :outdated, :artifice => :compact_index, :raise_on_error => false
+      bundle :install, :artifice => "compact_index"
+      bundle :outdated, :artifice => "compact_index", :raise_on_error => false
 
       expected_output = <<~TABLE
         Gem  Current  Latest  Requested  Groups

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -649,8 +649,8 @@ RSpec.describe "bundle update" do
     end
 
     it "works" do
-      bundle :install, :artifice => :compact_index
-      bundle "update oj", :artifice => :compact_index
+      bundle :install, :artifice => "compact_index"
+      bundle "update oj", :artifice => "compact_index"
 
       expect(out).to include("Bundle updated!")
       expect(the_bundle).to include_gems "oj 3.11.5"

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -20,23 +20,23 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
       before do
         gemfile <<-G
-          source "#{file_uri_for(gem_repo3)}"
-          source "#{file_uri_for(gem_repo1)}"
+          source "https://gem.repo3"
+          source "https://gem.repo1"
           gem "rack-obama"
           gem "rack"
         G
       end
 
       it "warns about ambiguous gems, but installs anyway, prioritizing sources last to first", :bundler => "< 3" do
-        bundle :install
+        bundle :install, :artifice => "compact_index"
 
         expect(err).to include("Warning: the gem 'rack' was found in multiple sources.")
-        expect(err).to include("Installed from: #{file_uri_for(gem_repo1)}")
+        expect(err).to include("Installed from: https://gem.repo1")
         expect(the_bundle).to include_gems("rack-obama 1.0.0", "rack 1.0.0", :source => "remote1")
       end
 
       it "fails", :bundler => "3" do
-        bundle :instal, :raise_on_error => false
+        bundle :instal, :artifice => "compact_index", :raise_on_error => false
         expect(err).to include("Each source after the first must include a block")
         expect(exitstatus).to eq(4)
       end
@@ -47,22 +47,22 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
       before do
         gemfile <<-G
-          source "#{file_uri_for(gem_repo3)}"
-          source "#{file_uri_for(gem_repo1)}"
+          source "https://gem.repo3"
+          source "https://gem.repo1"
           gem "rack-obama"
           gem "rack", "1.0.0" # force it to install the working version in repo1
         G
       end
 
       it "warns about ambiguous gems, but installs anyway", :bundler => "< 3" do
-        bundle :install
+        bundle :install, :artifice => "compact_index"
         expect(err).to include("Warning: the gem 'rack' was found in multiple sources.")
-        expect(err).to include("Installed from: #{file_uri_for(gem_repo1)}")
+        expect(err).to include("Installed from: https://gem.repo1")
         expect(the_bundle).to include_gems("rack-obama 1.0.0", "rack 1.0.0", :source => "remote1")
       end
 
       it "fails", :bundler => "3" do
-        bundle :install, :raise_on_error => false
+        bundle :install, :artifice => "compact_index", :raise_on_error => false
         expect(err).to include("Each source after the first must include a block")
         expect(exitstatus).to eq(4)
       end
@@ -85,8 +85,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
         end
 
         gemfile <<-G
-          source "#{file_uri_for(gem_repo3)}"
-          source "#{file_uri_for(gem_repo1)}" do
+          source "https://gem.repo3"
+          source "https://gem.repo1" do
             gem "thin" # comes first to test name sorting
             gem "rack"
           end
@@ -95,20 +95,20 @@ RSpec.describe "bundle install with gems on multiple sources" do
       end
 
       it "installs the gems without any warning" do
-        bundle :install
+        bundle :install, :artifice => "compact_index"
         expect(err).not_to include("Warning")
         expect(the_bundle).to include_gems("rack-obama 1.0.0")
         expect(the_bundle).to include_gems("rack 1.0.0", :source => "remote1")
       end
 
       it "can cache and deploy" do
-        bundle :cache
+        bundle :cache, :artifice => "compact_index"
 
         expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
         expect(bundled_app("vendor/cache/rack-obama-1.0.gem")).to exist
 
         bundle "config set --local deployment true"
-        bundle :install
+        bundle :install, :artifice => "compact_index"
 
         expect(the_bundle).to include_gems("rack-obama 1.0.0", "rack 1.0.0")
       end
@@ -128,10 +128,10 @@ RSpec.describe "bundle install with gems on multiple sources" do
           end
         end
 
-        install_gemfile <<-G
-          source "#{file_uri_for(gem_repo3)}"
+        install_gemfile <<-G, :artifice => "compact_index"
+          source "https://gem.repo3"
           gem "rack-obama" # should come from repo3!
-          gem "rack", :source => "#{file_uri_for(gem_repo1)}"
+          gem "rack", :source => "https://gem.repo1"
         G
       end
 
@@ -155,8 +155,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
         end
 
         gemfile <<-G
-          source "#{file_uri_for(gem_repo2)}"
-          source "#{file_uri_for(gem_repo3)}" do
+          source "https://gem.repo2"
+          source "https://gem.repo3" do
             gem "depends_on_rack"
           end
         G
@@ -168,7 +168,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
         end
 
         it "installs from the same source without any warning" do
-          bundle :install
+          bundle :install, :artifice => "compact_index"
           expect(err).not_to include("Warning")
           expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0", :source => "remote3")
         end
@@ -185,7 +185,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
         end
 
         it "installs from the same source without any warning" do
-          bundle :install
+          bundle :install, :artifice => "compact_index"
 
           expect(err).not_to include("Warning: the gem 'rack' was found in multiple sources.")
           expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0", :source => "remote3")
@@ -193,7 +193,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
           # In https://github.com/bundler/bundler/issues/3585 this failed
           # when there is already a lock file, and the gems are missing, so try again
           system_gems []
-          bundle :install
+          bundle :install, :artifice => "compact_index"
 
           expect(err).not_to include("Warning: the gem 'rack' was found in multiple sources.")
           expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0", :source => "remote3")
@@ -218,9 +218,9 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
       context "and not in any other sources" do
         before do
-          install_gemfile <<-G
-            source "#{file_uri_for(gem_repo2)}"
-            source "#{file_uri_for(gem_repo3)}" do
+          install_gemfile <<-G, :artifice => "compact_index"
+            source "https://gem.repo2"
+            source "https://gem.repo3" do
               gem "depends_on_rack"
             end
           G
@@ -235,23 +235,23 @@ RSpec.describe "bundle install with gems on multiple sources" do
       context "and in yet another source" do
         before do
           gemfile <<-G
-            source "#{file_uri_for(gem_repo1)}"
-            source "#{file_uri_for(gem_repo2)}"
-            source "#{file_uri_for(gem_repo3)}" do
+            source "https://gem.repo1"
+            source "https://gem.repo2"
+            source "https://gem.repo3" do
               gem "depends_on_rack"
             end
           G
         end
 
         it "installs from the other source and warns about ambiguous gems", :bundler => "< 3" do
-          bundle :install
+          bundle :install, :artifice => "compact_index"
           expect(err).to include("Warning: the gem 'rack' was found in multiple sources.")
-          expect(err).to include("Installed from: #{file_uri_for(gem_repo2)}")
+          expect(err).to include("Installed from: https://gem.repo2")
           expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0")
         end
 
         it "fails", :bundler => "3" do
-          bundle :install, :raise_on_error => false
+          bundle :install, :artifice => "compact_index", :raise_on_error => false
           expect(err).to include("Each source after the first must include a block")
           expect(exitstatus).to eq(4)
         end
@@ -267,16 +267,16 @@ RSpec.describe "bundle install with gems on multiple sources" do
           end
 
           gemfile <<-G
-            source "#{file_uri_for(gem_repo3)}" # contains depends_on_rack
-            source "#{file_uri_for(gem_repo2)}" # contains broken rack
+            source "https://gem.repo3" # contains depends_on_rack
+            source "https://gem.repo2" # contains broken rack
 
             gem "depends_on_rack" # installed from gem_repo3
-            gem "rack", :source => "#{file_uri_for(gem_repo1)}"
+            gem "rack", :source => "https://gem.repo1"
           G
         end
 
         it "installs the dependency from the pinned source without warning", :bundler => "< 3" do
-          bundle :install
+          bundle :install, :artifice => "compact_index"
 
           expect(err).not_to include("Warning: the gem 'rack' was found in multiple sources.")
           expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0")
@@ -284,14 +284,14 @@ RSpec.describe "bundle install with gems on multiple sources" do
           # In https://github.com/rubygems/bundler/issues/3585 this failed
           # when there is already a lock file, and the gems are missing, so try again
           system_gems []
-          bundle :install
+          bundle :install, :artifice => "compact_index"
 
           expect(err).not_to include("Warning: the gem 'rack' was found in multiple sources.")
           expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0")
         end
 
         it "fails", :bundler => "3" do
-          bundle :install, :raise_on_error => false
+          bundle :install, :artifice => "compact_index", :raise_on_error => false
           expect(err).to include("Each source after the first must include a block")
           expect(exitstatus).to eq(4)
         end
@@ -308,19 +308,19 @@ RSpec.describe "bundle install with gems on multiple sources" do
         end
 
         gemfile <<-G
-          source "#{file_uri_for(gem_repo2)}"
+          source "https://gem.repo2"
 
           gem "private_gem_1"
 
-          source "#{file_uri_for(gem_repo3)}" do
+          source "https://gem.repo3" do
             gem "private_gem_2"
           end
         G
       end
 
       it "fails" do
-        bundle :install, :raise_on_error => false
-        expect(err).to include("Could not find gem 'private_gem_1' in rubygems repository #{file_uri_for(gem_repo2)}/ or installed locally.")
+        bundle :install, :artifice => "compact_index", :raise_on_error => false
+        expect(err).to include("Could not find gem 'private_gem_1' in rubygems repository https://gem.repo2/ or installed locally.")
         expect(err).to include("The source does not contain any versions of 'private_gem_1'")
       end
     end
@@ -343,11 +343,11 @@ RSpec.describe "bundle install with gems on multiple sources" do
           end
 
           gemfile <<-G
-            source "#{file_uri_for(gem_repo2)}"
+            source "https://gem.repo2"
 
             gem "depends_on_rack"
 
-            source "#{file_uri_for(gem_repo3)}" do
+            source "https://gem.repo3" do
               gem "unrelated_gem"
             end
           G
@@ -361,7 +361,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
           end
 
           it "installs all gems without warning" do
-            bundle :install
+            bundle :install, :artifice => "compact_index"
             expect(err).not_to include("Warning")
             expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0", "unrelated_gem 1.0.0")
           end
@@ -377,7 +377,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
           end
 
           it "does not find the dependency" do
-            bundle :install, :raise_on_error => false
+            bundle :install, :artifice => "compact_index", :raise_on_error => false
             expect(err).to include("Could not find gem 'rack', which is required by gem 'depends_on_rack', in any of the relevant sources")
           end
         end
@@ -396,7 +396,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
           end
 
           it "installs the dependency from the top-level source without warning" do
-            bundle :install
+            bundle :install, :artifice => "compact_index"
             expect(err).not_to include("Warning")
             expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0", "unrelated_gem 1.0.0")
           end
@@ -463,19 +463,19 @@ RSpec.describe "bundle install with gems on multiple sources" do
           gemfile <<-G
             # frozen_string_literal: true
 
-            source "#{file_uri_for(gem_repo2)}"
+            source "https://gem.repo2"
 
             gem "activesupport"
 
-            source "#{file_uri_for(gem_repo3)}" do
+            source "https://gem.repo3" do
               gem "sidekiq-pro"
             end
           G
 
           lockfile <<~L
             GEM
-              remote: #{file_uri_for(gem_repo2)}/
-              remote: #{file_uri_for(gem_repo3)}/
+              remote: https://gem.repo2/
+              remote: https://gem.repo3/
               specs:
                 activesupport (6.0.3.4)
                   concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -517,7 +517,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
         it "does not install newer versions or generate lockfile changes when running bundle install, and warns", :bundler => "< 3" do
           initial_lockfile = lockfile
 
-          bundle :install
+          bundle :install, :artifice => "compact_index"
 
           expect(err).to include("Your lockfile contains a single rubygems source section with multiple remotes, which is insecure.")
 
@@ -534,7 +534,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
         it "fails when running bundle install", :bundler => "3" do
           initial_lockfile = lockfile
 
-          bundle :install, :raise_on_error => false
+          bundle :install, :artifice => "compact_index", :raise_on_error => false
 
           expect(err).to include("Your lockfile contains a single rubygems source section with multiple remotes, which is insecure.")
 
@@ -542,7 +542,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
         end
 
         it "splits sections and upgrades gems when running bundle update, and doesn't warn" do
-          bundle "update --all"
+          bundle "update --all", :artifice => "compact_index"
           expect(err).to be_empty
 
           expect(the_bundle).not_to include_gems("activesupport 6.0.3.4")
@@ -554,7 +554,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
           expect(lockfile).to eq <<~L
             GEM
-              remote: #{file_uri_for(gem_repo2)}/
+              remote: https://gem.repo2/
               specs:
                 activesupport (6.1.2.1)
                   concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -578,7 +578,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
                 zeitwerk (2.4.2)
 
             GEM
-              remote: #{file_uri_for(gem_repo3)}/
+              remote: https://gem.repo3/
               specs:
                 sidekiq-pro (5.2.1)
                   connection_pool (>= 2.2.3)
@@ -597,7 +597,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
         end
 
         it "it keeps the current lockfile format and upgrades the requested gem when running bundle update with an argument, and warns", :bundler => "< 3" do
-          bundle "update concurrent-ruby"
+          bundle "update concurrent-ruby", :artifice => "compact_index"
           expect(err).to include("Your lockfile contains a single rubygems source section with multiple remotes, which is insecure.")
 
           expect(the_bundle).to include_gems("activesupport 6.0.3.4")
@@ -609,8 +609,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
           expect(lockfile).to eq <<~L
             GEM
-              remote: #{file_uri_for(gem_repo2)}/
-              remote: #{file_uri_for(gem_repo3)}/
+              remote: https://gem.repo2/
+              remote: https://gem.repo3/
               specs:
                 activesupport (6.0.3.4)
                   concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -652,7 +652,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
         it "fails when running bundle update with an argument", :bundler => "3" do
           initial_lockfile = lockfile
 
-          bundle "update concurrent-ruby", :raise_on_error => false
+          bundle "update concurrent-ruby", :artifice => "compact_index", :raise_on_error => false
 
           expect(err).to include("Your lockfile contains a single rubygems source section with multiple remotes, which is insecure.")
 
@@ -677,7 +677,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
         end
 
         gemfile <<-G
-          source "#{file_uri_for(gem_repo2)}"
+          source "https://gem.repo2"
 
           gemspec :path => "#{lib_path("rails")}"
 
@@ -686,7 +686,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
       end
 
       it "installs all gems without warning" do
-        bundle :install
+        bundle :install, :artifice => "compact_index"
         expect(err).not_to include("Warning")
         expect(the_bundle).to include_gems("activesupport 7.0.0.alpha", "rails 7.0.0.alpha")
         expect(the_bundle).to include_gems("activesupport 7.0.0.alpha", :source => "path@#{lib_path("rails/activesupport")}")
@@ -711,9 +711,9 @@ RSpec.describe "bundle install with gems on multiple sources" do
         end
 
         gemfile <<-G
-          source "#{file_uri_for(gem_repo2)}"
+          source "https://gem.repo2"
 
-          source "#{file_uri_for(gem_repo3)}" do
+          source "https://gem.repo3" do
             gem "handsoap"
           end
 
@@ -724,14 +724,14 @@ RSpec.describe "bundle install with gems on multiple sources" do
       it "installs from the default source without any warnings or errors and generates a proper lockfile" do
         expected_lockfile = <<~L
           GEM
-            remote: #{file_uri_for(gem_repo2)}/
+            remote: https://gem.repo2/
             specs:
               nokogiri (1.11.1)
                 racca (~> 1.4)
               racca (1.5.2)
 
           GEM
-            remote: #{file_uri_for(gem_repo3)}/
+            remote: https://gem.repo3/
             specs:
               handsoap (0.2.5.5)
                 nokogiri (>= 1.2.3)
@@ -747,7 +747,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
              #{Bundler::VERSION}
         L
 
-        bundle "install --verbose"
+        bundle "install --verbose", :artifice => "compact_index"
         expect(err).not_to include("Warning")
         expect(the_bundle).to include_gems("handsoap 0.2.5.5", "nokogiri 1.11.1", "racca 1.5.2")
         expect(the_bundle).to include_gems("handsoap 0.2.5.5", :source => "remote3")
@@ -756,7 +756,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
         # Even if the gems are already installed
         FileUtils.rm bundled_app_lock
-        bundle "install --verbose"
+        bundle "install --verbose", :artifice => "compact_index"
         expect(err).not_to include("Warning")
         expect(the_bundle).to include_gems("handsoap 0.2.5.5", "nokogiri 1.11.1", "racca 1.5.2")
         expect(the_bundle).to include_gems("handsoap 0.2.5.5", :source => "remote3")
@@ -771,9 +771,9 @@ RSpec.describe "bundle install with gems on multiple sources" do
           build_gem "not_in_repo1", "1.0.0"
         end
 
-        install_gemfile <<-G, :raise_on_error => false
-          source "#{file_uri_for(gem_repo3)}"
-          gem "not_in_repo1", :source => "#{file_uri_for(gem_repo1)}"
+        install_gemfile <<-G, :artifice => "compact_index", :raise_on_error => false
+          source "https://gem.repo3"
+          gem "not_in_repo1", :source => "https://gem.repo1"
         G
       end
 
@@ -788,11 +788,11 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
         lockfile <<-L
           GEM
-            remote: #{file_uri_for(gem_repo1)}
+            remote: https://gem.repo1
             specs:
 
           GEM
-            remote: #{file_uri_for(gem_repo3)}
+            remote: https://gem.repo3
             specs:
               rack (0.9.1)
 
@@ -804,8 +804,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
         L
 
         gemfile <<-G
-          source "#{file_uri_for(gem_repo1)}"
-          source "#{file_uri_for(gem_repo3)}" do
+          source "https://gem.repo1"
+          source "https://gem.repo3" do
             gem 'rack'
           end
         G
@@ -821,8 +821,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
       let(:aggregate_gem_section_lockfile) do
         <<~L
           GEM
-            remote: #{file_uri_for(gem_repo1)}/
-            remote: #{file_uri_for(gem_repo3)}/
+            remote: https://gem.repo1/
+            remote: https://gem.repo3/
             specs:
               rack (0.9.1)
 
@@ -840,11 +840,11 @@ RSpec.describe "bundle install with gems on multiple sources" do
       let(:split_gem_section_lockfile) do
         <<~L
           GEM
-            remote: #{file_uri_for(gem_repo1)}/
+            remote: https://gem.repo1/
             specs:
 
           GEM
-            remote: #{file_uri_for(gem_repo3)}/
+            remote: https://gem.repo3/
             specs:
               rack (0.9.1)
 
@@ -865,8 +865,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
         end
 
         gemfile <<-G
-          source "#{file_uri_for(gem_repo1)}"
-          source "#{file_uri_for(gem_repo3)}" do
+          source "https://gem.repo1"
+          source "https://gem.repo3" do
             gem 'rack'
           end
         G
@@ -877,7 +877,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
       it "installs the existing lockfile but prints a warning", :bundler => "< 3" do
         bundle "config set --local deployment true"
 
-        bundle "install"
+        bundle "install", :artifice => "compact_index"
 
         expect(lockfile).to eq(aggregate_gem_section_lockfile)
         expect(err).to include("Your lockfile contains a single rubygems source section with multiple remotes, which is insecure.")
@@ -887,7 +887,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
       it "refuses to install the existing lockfile and prints an error", :bundler => "3" do
         bundle "config set --local deployment true"
 
-        bundle "install", :raise_on_error =>false
+        bundle "install", :artifice => "compact_index", :raise_on_error =>false
 
         expect(lockfile).to eq(aggregate_gem_section_lockfile)
         expect(err).to include("Your lockfile contains a single rubygems source section with multiple remotes, which is insecure.")
@@ -900,13 +900,13 @@ RSpec.describe "bundle install with gems on multiple sources" do
         build_lib "foo"
 
         gemfile <<-G
-          gem "rack", :source => "#{file_uri_for(gem_repo1)}"
+          gem "rack", :source => "https://gem.repo1"
           gem "foo", :path => "#{lib_path("foo-1.0")}"
         G
       end
 
       it "does not unlock the non-path gem after install" do
-        bundle :install
+        bundle :install, :artifice => "compact_index"
 
         bundle %(exec ruby -e 'puts "OK"')
 
@@ -919,8 +919,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
     before do
       system_gems "rack-0.9.1"
 
-      install_gemfile <<-G
-        source "#{file_uri_for(gem_repo1)}"
+      install_gemfile <<-G, :artifice => "compact_index"
+        source "https://gem.repo1"
         gem "rack" # should come from repo1!
       G
     end
@@ -941,14 +941,14 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
       # Installing this gemfile...
       gemfile <<-G
-        source '#{file_uri_for(gem_repo1)}'
+        source 'https://gem.repo1'
         gem 'rack'
-        gem 'foo', '~> 0.1', :source => '#{file_uri_for(gem_repo4)}'
-        gem 'bar', '~> 0.1', :source => '#{file_uri_for(gem_repo4)}'
+        gem 'foo', '~> 0.1', :source => 'https://gem.repo4'
+        gem 'bar', '~> 0.1', :source => 'https://gem.repo4'
       G
 
       bundle "config set --local path ../gems/system"
-      bundle :install
+      bundle :install, :artifice => "compact_index"
 
       # And then we add some new versions...
       update_repo4 do
@@ -959,11 +959,11 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
     it "allows them to be unlocked separately" do
       # And install this gemfile, updating only foo.
-      install_gemfile <<-G
-        source '#{file_uri_for(gem_repo1)}'
+      install_gemfile <<-G, :artifice => "compact_index"
+        source 'https://gem.repo1'
         gem 'rack'
-        gem 'foo', '~> 0.2', :source => '#{file_uri_for(gem_repo4)}'
-        gem 'bar', '~> 0.1', :source => '#{file_uri_for(gem_repo4)}'
+        gem 'foo', '~> 0.2', :source => 'https://gem.repo4'
+        gem 'bar', '~> 0.1', :source => 'https://gem.repo4'
       G
 
       # It should update foo to 0.2, but not the (locked) bar 0.1
@@ -983,11 +983,11 @@ RSpec.describe "bundle install with gems on multiple sources" do
         build_git "git1"
         build_git "git2"
 
-        install_gemfile <<-G
-          source "#{file_uri_for(gem_repo1)}"
+        install_gemfile <<-G, :artifice => "compact_index"
+          source "https://gem.repo1"
           gem "rails"
 
-          source "#{file_uri_for(gem_repo3)}" do
+          source "https://gem.repo3" do
             gem "rack"
           end
 
@@ -999,7 +999,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
       end
 
       it "does not re-resolve" do
-        bundle :install, :verbose => true
+        bundle :install, :artifice => "compact_index", :verbose => true
         expect(out).to include("using resolution from the lockfile")
         expect(out).not_to include("re-resolving dependencies")
       end
@@ -1008,27 +1008,24 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
   context "when a gem is installed to system gems" do
     before do
-      install_gemfile <<-G
-        source "#{file_uri_for(gem_repo1)}"
+      install_gemfile <<-G, :artifice => "compact_index"
+        source "https://gem.repo1"
         gem "rack"
       G
     end
 
     context "and the gemfile changes" do
       it "is still able to find that gem from remote sources" do
-        source_uri = file_uri_for(gem_repo1)
-        second_uri = file_uri_for(gem_repo4)
-
         build_repo4 do
           build_gem "rack", "2.0.1.1.forked"
           build_gem "thor", "0.19.1.1.forked"
         end
 
         # When this gemfile is installed...
-        install_gemfile <<-G
-          source "#{source_uri}"
+        install_gemfile <<-G, :artifice => "compact_index"
+          source "https://gem.repo1"
 
-          source "#{second_uri}" do
+          source "https://gem.repo4" do
             gem "rack", "2.0.1.1.forked"
             gem "thor"
           end
@@ -1037,9 +1034,9 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
         # Then we change the Gemfile by adding a version to thor
         gemfile <<-G
-          source "#{source_uri}"
+          source "https://gem.repo1"
 
-          source "#{second_uri}" do
+          source "https://gem.repo4" do
             gem "rack", "2.0.1.1.forked"
             gem "thor", "0.19.1.1.forked"
           end
@@ -1047,15 +1044,15 @@ RSpec.describe "bundle install with gems on multiple sources" do
         G
 
         # But we should still be able to find rack 2.0.1.1.forked and install it
-        bundle :install
+        bundle :install, :artifice => "compact_index"
       end
     end
   end
 
   describe "source changed to one containing a higher version of a dependency" do
     before do
-      install_gemfile <<-G
-        source "#{file_uri_for(gem_repo1)}"
+      install_gemfile <<-G, :artifice => "compact_index"
+        source "https://gem.repo1"
 
         gem "rack"
       G
@@ -1072,8 +1069,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
         s.add_dependency "bar", "=1.0.0"
       end
 
-      install_gemfile <<-G
-        source "#{file_uri_for(gem_repo2)}"
+      install_gemfile <<-G, :artifice => "compact_index"
+        source "https://gem.repo2"
         gem "rack"
         gemspec :path => "#{tmp.join("gemspec_test")}"
       G
@@ -1093,10 +1090,10 @@ RSpec.describe "bundle install with gems on multiple sources" do
       build_gem "example", "1.0.2"
     end
 
-    install_gemfile <<-G
-      source "#{file_uri_for(gem_repo4)}"
+    install_gemfile <<-G, :artifice => "compact_index"
+      source "https://gem.repo4"
 
-      gem "example", :source => "#{file_uri_for(gem_repo2)}"
+      gem "example", :source => "https://gem.repo2"
     G
 
     bundle "info example"
@@ -1104,7 +1101,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
     system_gems "example-1.0.2", :path => default_bundle_path, :gem_repo => gem_repo4
 
-    bundle "update example --verbose"
+    bundle "update example --verbose", :artifice => "compact_index"
     expect(out).not_to include("Using example 1.0.2")
     expect(out).to include("Using example 0.1.0")
   end
@@ -1118,9 +1115,9 @@ RSpec.describe "bundle install with gems on multiple sources" do
         build_gem "rack"
       end
 
-      install_gemfile <<-G, :raise_on_error => false
-        source "#{file_uri_for(gem_repo4)}"
-        source "#{file_uri_for(gem_repo1)}" do
+      install_gemfile <<-G, :artifice => "compact_index", :raise_on_error => false
+        source "https://gem.repo4"
+        source "https://gem.repo1" do
           gem "thin"
         end
         gem "depends_on_rack"
@@ -1128,8 +1125,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
       expect(last_command).to be_failure
       expect(err).to eq strip_whitespace(<<-EOS).strip
         The gem 'rack' was found in multiple relevant sources.
-          * rubygems repository #{file_uri_for(gem_repo1)}/ or installed locally
-          * rubygems repository #{file_uri_for(gem_repo4)}/ or installed locally
+          * rubygems repository https://gem.repo1/ or installed locally
+          * rubygems repository https://gem.repo4/ or installed locally
         You must add this gem to the source block for the source you wish it to be installed from.
       EOS
       expect(the_bundle).not_to be_locked

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -325,6 +325,31 @@ RSpec.describe "bundle install with gems on multiple sources" do
       end
     end
 
+    context "when an indirect dependency can't be found in the aggregate rubygems source", :bundler => "< 3" do
+      before do
+        build_repo2
+
+        build_repo gem_repo3 do
+          build_gem "depends_on_missing", "1.0.1" do |s|
+            s.add_dependency "missing"
+          end
+        end
+
+        gemfile <<-G
+          source "https://gem.repo2"
+
+          source "https://gem.repo3"
+
+          gem "depends_on_missing"
+        G
+      end
+
+      it "fails" do
+        bundle :install, :artifice => "compact_index", :raise_on_error => false
+        expect(err).to include("Could not find gem 'missing', which is required by gem 'depends_on_missing', in any of the sources.")
+      end
+    end
+
     context "when a top-level gem has an indirect dependency" do
       before do
         build_repo gem_repo2 do

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -376,7 +376,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
         it "does not find the dependency" do
           bundle :install, :artifice => "compact_index", :raise_on_error => false
           expect(err).to include(
-            "Could not find gem 'rack', which is required by gem 'depends_on_rack', in any of the relevant sources"
+            "Could not find gem 'rack', which is required by gem 'depends_on_rack', in rubygems repository https://gem.repo2/ or installed locally."
           )
         end
       end

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -141,10 +141,10 @@ RSpec.describe "bundle install with specific platforms" do
            2.1.4
       L
 
-      bundle "install --verbose", :artifice => :compact_index, :env => { "BUNDLER_VERSION" => "2.1.4", "BUNDLER_SPEC_GEM_REPO" => gem_repo2.to_s }
+      bundle "install --verbose", :artifice => "compact_index", :env => { "BUNDLER_VERSION" => "2.1.4", "BUNDLER_SPEC_GEM_REPO" => gem_repo2.to_s }
       expect(out).to include("Installing libv8 8.4.255.0 (universal-darwin)")
 
-      bundle "add mini_racer --verbose", :artifice => :compact_index, :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo2.to_s }
+      bundle "add mini_racer --verbose", :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo2.to_s }
       expect(out).to include("Using libv8 8.4.255.0 (universal-darwin)")
     end
 

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -467,7 +467,7 @@ The checksum of /versions does not match the checksum provided by the server! So
     expect(the_bundle).to include_gems "foo 1.0"
   end
 
-  it "fetches again when more dependencies are found in subsequent sources using --deployment", :bundler => "< 3" do
+  it "fetches again when more dependencies are found in subsequent sources using deployment mode", :bundler => "< 3" do
     build_repo2 do
       build_gem "back_deps" do |s|
         s.add_dependency "foo"
@@ -482,8 +482,8 @@ The checksum of /versions does not match the checksum provided by the server! So
     G
 
     bundle :install, :artifice => "compact_index_extra"
-
-    bundle "install --deployment", :artifice => "compact_index_extra"
+    bundle "config --set local deployment true"
+    bundle :install, :artifice => "compact_index_extra"
     expect(the_bundle).to include_gems "back_deps 1.0"
   end
 

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -366,31 +366,6 @@ The checksum of /versions does not match the checksum provided by the server! So
     expect(the_bundle).to include_gems "activesupport 1.2.3"
   end
 
-  it "considers all possible versions of dependencies from all api gem sources when using blocks", :bundler => "< 3" do
-    # In this scenario, the gem "somegem" only exists in repo4.  It depends on specific version of activesupport that
-    # exists only in repo1.  There happens also be a version of activesupport in repo4, but not the one that version 1.0.0
-    # of somegem wants. This test makes sure that bundler actually finds version 1.2.3 of active support in the other
-    # repo and installs it.
-    build_repo4 do
-      build_gem "activesupport", "1.2.0"
-      build_gem "somegem", "1.0.0" do |s|
-        s.add_dependency "activesupport", "1.2.3" # This version exists only in repo1
-      end
-    end
-
-    gemfile <<-G
-      source "#{source_uri}"
-      source "#{source_uri}/extra" do
-        gem 'somegem', '1.0.0'
-      end
-    G
-
-    bundle :install, :artifice => "compact_index_extra_api"
-
-    expect(the_bundle).to include_gems "somegem 1.0.0"
-    expect(the_bundle).to include_gems "activesupport 1.2.3"
-  end
-
   it "prints API output properly with back deps" do
     build_repo2 do
       build_gem "back_deps" do |s|

--- a/bundler/spec/install/gems/dependency_api_spec.rb
+++ b/bundler/spec/install/gems/dependency_api_spec.rb
@@ -438,7 +438,7 @@ RSpec.describe "gemcutter's dependency API" do
     expect(the_bundle).to include_gems "foo 1.0"
   end
 
-  it "fetches again when more dependencies are found in subsequent sources using --deployment", :bundler => "< 3" do
+  it "fetches again when more dependencies are found in subsequent sources using deployment mode", :bundler => "< 3" do
     build_repo2 do
       build_gem "back_deps" do |s|
         s.add_dependency "foo"
@@ -453,8 +453,8 @@ RSpec.describe "gemcutter's dependency API" do
     G
 
     bundle :install, :artifice => "endpoint_extra"
-
-    bundle "install --deployment", :artifice => "endpoint_extra"
+    bundle "config set --local deployment true"
+    bundle :install, :artifice => "endpoint_extra"
     expect(the_bundle).to include_gems "back_deps 1.0"
   end
 
@@ -474,7 +474,6 @@ RSpec.describe "gemcutter's dependency API" do
     G
 
     bundle :install, :artifice => "endpoint_extra"
-
     bundle "config set --local deployment true"
     bundle "install", :artifice => "endpoint_extra"
     expect(the_bundle).to include_gems "back_deps 1.0"

--- a/bundler/spec/install/gems/dependency_api_spec.rb
+++ b/bundler/spec/install/gems/dependency_api_spec.rb
@@ -338,31 +338,6 @@ RSpec.describe "gemcutter's dependency API" do
     expect(the_bundle).to include_gems "activesupport 1.2.3"
   end
 
-  it "considers all possible versions of dependencies from all api gem sources using blocks" do
-    # In this scenario, the gem "somegem" only exists in repo4.  It depends on specific version of activesupport that
-    # exists only in repo1.  There happens also be a version of activesupport in repo4, but not the one that version 1.0.0
-    # of somegem wants. This test makes sure that bundler actually finds version 1.2.3 of active support in the other
-    # repo and installs it.
-    build_repo4 do
-      build_gem "activesupport", "1.2.0"
-      build_gem "somegem", "1.0.0" do |s|
-        s.add_dependency "activesupport", "1.2.3" # This version exists only in repo1
-      end
-    end
-
-    gemfile <<-G
-      source "#{source_uri}"
-      source "#{source_uri}/extra" do
-        gem 'somegem', '1.0.0'
-      end
-    G
-
-    bundle :install, :artifice => "endpoint_extra_api"
-
-    expect(the_bundle).to include_gems "somegem 1.0.0"
-    expect(the_bundle).to include_gems "activesupport 1.2.3"
-  end
-
   it "prints API output properly with back deps" do
     build_repo2 do
       build_gem "back_deps" do |s|

--- a/bundler/spec/support/artifice/endpoint.rb
+++ b/bundler/spec/support/artifice/endpoint.rb
@@ -45,10 +45,14 @@ class Endpoint < Sinatra::Base
         Pathname.new(ENV["BUNDLER_SPEC_GEM_REPO"])
       else
         case request.host
+        when "gem.repo1"
+          Spec::Path.gem_repo1
         when "gem.repo2"
           Spec::Path.gem_repo2
         when "gem.repo3"
           Spec::Path.gem_repo3
+        when "gem.repo4"
+          Spec::Path.gem_repo4
         else
           Spec::Path.gem_repo1
         end

--- a/bundler/spec/support/indexes.rb
+++ b/bundler/spec/support/indexes.rb
@@ -25,7 +25,6 @@ module Spec
           deps << Bundler::DepProxy.get_proxy(d, p)
         end
       end
-      source_requirements ||= {}
       args[0] ||= [] # base
       args[1] ||= Bundler::GemVersionPromoter.new # gem_version_promoter
       args[2] ||= [] # additional_base_requirements

--- a/bundler/spec/support/indexes.rb
+++ b/bundler/spec/support/indexes.rb
@@ -20,8 +20,8 @@ module Spec
       default_source = instance_double("Bundler::Source::Rubygems", :specs => @index)
       source_requirements = { :default => default_source }
       @deps.each do |d|
+        source_requirements[d.name] = d.source = default_source
         @platforms.each do |p|
-          source_requirements[d.name] = d.source = default_source
           deps << Bundler::DepProxy.get_proxy(d, p)
         end
       end

--- a/bundler/spec/support/matchers.rb
+++ b/bundler/spec/support/matchers.rb
@@ -156,7 +156,7 @@ module Spec
             actual_source = out.split("\n").last
             next "Expected #{name} (#{version}) to be installed from `#{source}`, was actually from `#{actual_source}`"
           end
-          next "Command to check forgem inclusion of gem #{full_name} failed"
+          next "Command to check for inclusion of gem #{full_name} failed"
         end.compact
 
         @errors.empty?


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The end user problem is that the current source priority of bundler is not secure, potentially causing private gem names to be name-squatted on public gem sources. In particular, indirect dependencies are currently subject to this problem.
 
## What is your fix for the problem, implemented in this PR?

My fix is to make sure each dependency (including indirect dependencies) gets an explicit source requirement before resolution starts. If a dependency is present in multiple sources, scoped sources should always be preferred to global sources, and if there's an ambiguity between different block sources, and error (bundler 3) or warning (bundler 2) should be raised.

Fixes https://github.com/rubygems/rubygems/issues/3982.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
