### PR TITLE
Don't leave temporary directory around when building extensions to improve build reproducibility

### DIFF
--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -23,11 +23,11 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
     # spaces do not work.
     #
     # Details: https://github.com/rubygems/rubygems/issues/977#issuecomment-171544940
-    tmp_dest = get_relative_path(tmp_dest, extension_dir)
+    tmp_dest_relative = get_relative_path(tmp_dest.clone, extension_dir)
 
     Tempfile.open %w[siteconf .rb], extension_dir do |siteconf|
       siteconf.puts "require 'rbconfig'"
-      siteconf.puts "dest_path = #{tmp_dest.dump}"
+      siteconf.puts "dest_path = #{tmp_dest_relative.dump}"
       %w[sitearchdir sitelibdir].each do |dir|
         siteconf.puts "RbConfig::MAKEFILE_CONFIG['#{dir}'] = dest_path"
         siteconf.puts "RbConfig::CONFIG['#{dir}'] = dest_path"
@@ -63,8 +63,8 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
 
         make dest_path, results, extension_dir
 
-        if tmp_dest
-          full_tmp_dest = File.join(extension_dir, tmp_dest)
+        if tmp_dest_relative
+          full_tmp_dest = File.join(extension_dir, tmp_dest_relative)
 
           # TODO remove in RubyGems 3
           if Gem.install_extension_in_lib and lib_dir

--- a/test/rubygems/test_gem_ext_ext_conf_builder.rb
+++ b/test/rubygems/test_gem_ext_ext_conf_builder.rb
@@ -41,6 +41,7 @@ class TestGemExtExtConfBuilder < Gem::TestCase
     assert_contains_make_command '', output[7]
     assert_contains_make_command 'install', output[10]
     assert_empty Dir.glob(File.join(@ext, 'siteconf*.rb'))
+    assert_empty Dir.glob(File.join(@ext, '.gem.*'))
   end
 
   def test_class_build_rbconfig_make_prog


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

rubygems was leaving empty directories like:
```
lib/ruby/gems/2.7.0/gems/racc-1.5.2/ext/racc/cparse/.gem.20210503-6-csuqdb
```

Because those files contains the date, this hinders build-reproducibility efforts.

This is related to the issue https://github.com/NixOS/nixpkgs/issues/123718 over at NixOS.

## What is your fix for the problem, implemented in this PR?

tmp_dest is rewritten which makes it impossible to collect.

fixup: b97ec2a16 use relative path for siteconf in case of space and update relevant tests

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
