### PR TITLE
Get ruby-core CI back to green

### DIFF
--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -692,6 +692,28 @@ class Gem::TestCase < Test::Unit::TestCase
     path
   end
 
+  ##
+  # Load a YAML string, the psych 3 way
+
+  def load_yaml(yaml)
+    if YAML.respond_to?(:unsafe_load)
+      YAML.unsafe_load(yaml)
+    else
+      YAML.load(yaml)
+    end
+  end
+
+  ##
+  # Load a YAML file, the psych 3 way
+
+  def load_yaml_file(file)
+    if YAML.respond_to?(:unsafe_load_file)
+      YAML.unsafe_load_file(file)
+    else
+      YAML.load_file(file)
+    end
+  end
+
   def all_spec_names
     Gem::Specification.map(&:full_name)
   end

--- a/test/rubygems/test_gem_commands_signin_command.rb
+++ b/test/rubygems/test_gem_commands_signin_command.rb
@@ -30,10 +30,10 @@ class TestGemCommandsSigninCommand < Gem::TestCase
     host = 'http://some-gemcutter-compatible-host.org'
 
     util_capture(nil, host) { @cmd.execute }
-    old_credentials = YAML.load_file Gem.configuration.credentials_path
+    old_credentials = load_yaml_file Gem.configuration.credentials_path
 
     util_capture(nil, host) { @cmd.execute }
-    new_credentials = YAML.load_file Gem.configuration.credentials_path
+    new_credentials = load_yaml_file Gem.configuration.credentials_path
 
     assert_equal old_credentials[host], new_credentials[host]
   end
@@ -45,7 +45,7 @@ class TestGemCommandsSigninCommand < Gem::TestCase
     host = 'http://some-gemcutter-compatible-host.org'
 
     util_capture(nil, host, api_key) { @cmd.execute }
-    credentials = YAML.load_file Gem.configuration.credentials_path
+    credentials = load_yaml_file Gem.configuration.credentials_path
 
     assert_equal credentials[:rubygems_api_key], api_key
 
@@ -60,7 +60,7 @@ class TestGemCommandsSigninCommand < Gem::TestCase
     assert_match %r{Signed in.}, sign_in_ui.output
 
     api_key     = 'a5fdbb6ba150cbb83aad2bb2fede64cf040453903'
-    credentials = YAML.load_file Gem.configuration.credentials_path
+    credentials = load_yaml_file Gem.configuration.credentials_path
     assert_equal api_key, credentials[host]
   end
 
@@ -68,7 +68,7 @@ class TestGemCommandsSigninCommand < Gem::TestCase
     util_capture { @cmd.execute }
 
     api_key     = 'a5fdbb6ba150cbb83aad2bb2fede64cf040453903'
-    credentials = YAML.load_file Gem.configuration.credentials_path
+    credentials = load_yaml_file Gem.configuration.credentials_path
 
     assert_equal api_key, credentials[:rubygems_api_key]
   end
@@ -94,7 +94,7 @@ class TestGemCommandsSigninCommand < Gem::TestCase
     assert_match "show_dashboard [y/N]", key_name_ui.output
     assert_equal "name=test-key&push_rubygem=true", fetcher.last_request.body
 
-    credentials = YAML.load_file Gem.configuration.credentials_path
+    credentials = load_yaml_file Gem.configuration.credentials_path
     assert_equal api_key, credentials[:rubygems_api_key]
   end
 

--- a/test/rubygems/test_gem_commands_specification_command.rb
+++ b/test/rubygems/test_gem_commands_specification_command.rb
@@ -114,7 +114,7 @@ class TestGemCommandsSpecificationCommand < Gem::TestCase
       @cmd.execute
     end
 
-    assert_equal "foo", YAML.load(@ui.output)
+    assert_equal "foo", load_yaml(@ui.output)
   end
 
   def test_execute_file
@@ -230,7 +230,7 @@ class TestGemCommandsSpecificationCommand < Gem::TestCase
     assert_match %r{\A--- !ruby/object:Gem::Specification}, @ui.output
     assert_match %r{name: foo}, @ui.output
 
-    spec = YAML.load @ui.output
+    spec = load_yaml @ui.output
 
     assert_equal Gem::Version.new("2.0.0"), spec.version
   end
@@ -252,7 +252,7 @@ class TestGemCommandsSpecificationCommand < Gem::TestCase
     assert_match %r{\A--- !ruby/object:Gem::Specification}, @ui.output
     assert_match %r{name: foo}, @ui.output
 
-    spec = YAML.load @ui.output
+    spec = load_yaml @ui.output
 
     assert_equal Gem::Version.new("2.0.1.pre"), spec.version
   end

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -354,7 +354,7 @@ if you believe they were disclosed to a third party.
       :rubygems_api_key => 'x',
     }
 
-    assert_equal expected, YAML.load_file(@cfg.credentials_path)
+    assert_equal expected, load_yaml_file(@cfg.credentials_path)
 
     unless win_platform?
       stat = File.stat @cfg.credentials_path
@@ -378,7 +378,7 @@ if you believe they were disclosed to a third party.
       :rubygems_api_key => 'x',
     }
 
-    assert_equal expected, YAML.load_file(@cfg.credentials_path)
+    assert_equal expected, load_yaml_file(@cfg.credentials_path)
 
     stat = File.stat @cfg.credentials_path
 

--- a/test/rubygems/test_gem_gemcutter_utilities.rb
+++ b/test/rubygems/test_gem_gemcutter_utilities.rb
@@ -101,7 +101,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
     assert @fetcher.last_request["authorization"]
     assert_match %r{Signed in.}, @sign_in_ui.output
 
-    credentials = YAML.load_file Gem.configuration.credentials_path
+    credentials = load_yaml_file Gem.configuration.credentials_path
     assert_equal api_key, credentials[:rubygems_api_key]
   end
 
@@ -115,7 +115,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
     assert @fetcher.last_request["authorization"]
     assert_match %r{Signed in.}, @sign_in_ui.output
 
-    credentials = YAML.load_file Gem.configuration.credentials_path
+    credentials = load_yaml_file Gem.configuration.credentials_path
     assert_equal api_key, credentials['http://example.com']
   end
 
@@ -129,7 +129,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
     assert @fetcher.last_request["authorization"]
     assert_match %r{Signed in.}, @sign_in_ui.output
 
-    credentials = YAML.load_file Gem.configuration.credentials_path
+    credentials = load_yaml_file Gem.configuration.credentials_path
     assert_equal api_key, credentials[:rubygems_api_key]
   end
 
@@ -142,7 +142,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
     assert @fetcher.last_request["authorization"]
     assert_match %r{Signed in.}, @sign_in_ui.output
 
-    credentials = YAML.load_file Gem.configuration.credentials_path
+    credentials = load_yaml_file Gem.configuration.credentials_path
     assert_equal api_key, credentials['http://example.com']
   end
 
@@ -177,7 +177,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
     assert_match %r{Enter your RubyGems.org credentials.}, @sign_in_ui.output
     assert_match %r{Signed in.}, @sign_in_ui.output
 
-    credentials = YAML.load_file Gem.configuration.credentials_path
+    credentials = load_yaml_file Gem.configuration.credentials_path
     assert_equal api_key, credentials[:rubygems_api_key]
     assert_equal other_api_key, credentials[:other_api_key]
   end

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -98,7 +98,7 @@ class TestGemPackage < Gem::Package::TarTestCase
       },
     }
 
-    assert_equal expected, YAML.load(checksums)
+    assert_equal expected, load_yaml(checksums)
   end
 
   def test_build_time_uses_source_date_epoch

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2649,7 +2649,7 @@ end
 
     yaml_str = @a1.to_yaml
 
-    same_spec = YAML.load yaml_str
+    same_spec = load_yaml yaml_str
 
     assert_equal Gem::Platform.new('powerpc-darwin7'), same_spec.platform
     assert_equal 'powerpc-darwin7.9.0', same_spec.original_platform


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Our CI job testing with ruby-core environment is broken.

## What is your fix for the problem, implemented in this PR?

* Port https://github.com/ruby/ruby/commit/8e91b969df08b7a2eb27a5d6d38733eea42dc7ad from ruby-core, and make it compatible with psych 3 (our environment) and psych 4 (ruby-core environment).

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
