### PR TITLE
Fix `gem help build` output format 

### DIFF
--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -355,6 +355,8 @@ class Gem::Command
   def add_option(*opts, &handler) # :yields: value, options
     group_name = Symbol === opts.first ? opts.shift : :options
 
+    raise "Do not pass an empty string in opts" if opts.include?("")
+
     @option_groups[group_name] << [opts, handler]
   end
 

--- a/lib/rubygems/commands/build_command.rb
+++ b/lib/rubygems/commands/build_command.rb
@@ -23,7 +23,7 @@ class Gem::Commands::BuildCommand < Gem::Command
       options[:output] = value
     end
 
-    add_option '-C PATH', '', 'Run as if gem build was started in <PATH> instead of the current working directory.' do |value, options|
+    add_option '-C PATH', 'Run as if gem build was started in <PATH> instead of the current working directory.' do |value, options|
       options[:build_path] = value
     end
   end

--- a/test/rubygems/test_gem_command.rb
+++ b/test/rubygems/test_gem_command.rb
@@ -189,6 +189,18 @@ class TestGemCommand < Gem::TestCase
     assert_match %r{Usage: gem doit}, @ui.output
   end
 
+  def test_add_option
+    assert_nothing_raised RuntimeError do
+      @cmd.add_option('--force', 'skip validation of the spec') {|v,o| }
+    end
+  end
+
+  def test_add_option_with_empty
+    assert_raise RuntimeError, "Do not pass an empty string in opts" do
+      @cmd.add_option('', 'skip validation of the spec') {|v,o| }
+    end
+  end
+
   def test_option_recognition
     @cmd.add_option('-h', '--help [COMMAND]', 'Get help on COMMAND') do |value, options|
       options[:help] = true

--- a/test/rubygems/test_gem_commands_help_command.rb
+++ b/test/rubygems/test_gem_commands_help_command.rb
@@ -35,6 +35,13 @@ class TestGemCommandsHelpCommand < Gem::TestCase
     end
   end
 
+  def test_gem_help_build
+    util_gem 'build' do |out, err|
+      assert_match(/-C PATH *Run as if gem build was started in <PATH>/, out)
+      assert_equal '', err
+    end
+  end
+
   def test_gem_help_commands
     mgr = Gem::CommandManager.new
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Avoid to pass an extra string to OptionParser on build command, which was introduced in its inception (#2596) as below:

### With 3.3.0.dev (or 3.1.4)

```
$ gem help build
Usage: gem build GEMSPEC_FILE [options]

  Options:
        --force                      skip validation of the spec
        --strict                     consider warnings as errors when validating the spec
    -o, --output FILE                output gem with the given filename
    -C PATH
                                     Run as if gem build was started in <PATH> instead of the current working directory.


  Common Options:
[...]
```

### With this change

```
$ gem help build
Usage: gem build GEMSPEC_FILE [options]

  Options:
        --force                      skip validation of the spec
        --strict                     consider warnings as errors when validating the spec
    -o, --output FILE                output gem with the given filename
    -C PATH                          Run as if gem build was started in <PATH> instead of the current working directory.


  Common Options:
[...]
```

### Current implementation
```ruby
OptionParser.new do |opts|
  opts.on('-C PATH', '', 'desc') { |v| ...}
end
```

### Proposed implementation
```ruby
OptionParser.new do |opts|
  opts.on('-C PATH', 'desc') { |v| ...}
end
```

## What is your fix for the problem, implemented in this PR?

Output from `gem help build` will be improved on gem CLI as well as website.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

Closes #4612

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>