### PR TITLE
Make `ruby -r` work with `bundle exec`

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -512,14 +512,18 @@ EOF
     end
 
     def which(executable)
+      exts = (RbConfig::CONFIG["EXECUTABLE_EXTS"]&.split || []) | [RbConfig::CONFIG["EXEEXT"]]
+
       if File.file?(executable) && File.executable?(executable)
         executable
       elsif paths = ENV["PATH"]
         quote = '"'.freeze
         paths.split(File::PATH_SEPARATOR).find do |path|
           path = path[1..-2] if path.start_with?(quote) && path.end_with?(quote)
-          executable_path = File.expand_path(executable, path)
-          return executable_path if File.file?(executable_path) && File.executable?(executable_path)
+          exts.find do |ext|
+            executable_path = File.expand_path(executable + ext, path)
+            return executable_path if File.file?(executable_path) && File.executable?(executable_path)
+          end
         end
       end
     end

--- a/bundler/lib/bundler/cli/exec.rb
+++ b/bundler/lib/bundler/cli/exec.rb
@@ -27,6 +27,7 @@ module Bundler
         if !Bundler.settings[:disable_exec_load] && ruby_shebang?(bin_path)
           return kernel_load(bin_path, *args)
         end
+        args.unshift("-r#{File.expand_path("../setup.rb", __dir__)}") if bin_path == Gem.ruby
         kernel_exec(bin_path, *args)
       else
         # exec using the given command

--- a/bundler/spec/bundler/bundler_spec.rb
+++ b/bundler/spec/bundler/bundler_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe Bundler do
     context "when the executable in inside a quoted path" do
       let(:expected) do
         if Gem.win_platform?
-          "C:/e/executable"
+          "C:/e/executable.cmd"
         else
           "/e/executable"
         end

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -2,11 +2,9 @@
 
 RSpec.describe "bundle exec" do
   let(:system_gems_to_install) { %w[rack-1.0.0 rack-0.9.1] }
-  before :each do
-    system_gems(system_gems_to_install, :path => default_bundle_path)
-  end
 
   it "works with --gemfile flag" do
+    system_gems(system_gems_to_install, :path => default_bundle_path)
     create_file "CustomGemfile", <<-G
       gem "rack", "1.0.0"
     G
@@ -16,6 +14,7 @@ RSpec.describe "bundle exec" do
   end
 
   it "activates the correct gem" do
+    system_gems(system_gems_to_install, :path => default_bundle_path)
     gemfile <<-G
       gem "rack", "0.9.1"
     G
@@ -25,6 +24,7 @@ RSpec.describe "bundle exec" do
   end
 
   it "works when the bins are in ~/.bundle" do
+    system_gems(system_gems_to_install, :path => default_bundle_path)
     install_gemfile <<-G
       gem "rack"
     G
@@ -34,6 +34,7 @@ RSpec.describe "bundle exec" do
   end
 
   it "works when running from a random directory" do
+    system_gems(system_gems_to_install, :path => default_bundle_path)
     install_gemfile <<-G
       gem "rack"
     G
@@ -44,30 +45,35 @@ RSpec.describe "bundle exec" do
   end
 
   it "works when exec'ing something else" do
+    system_gems(system_gems_to_install, :path => default_bundle_path)
     install_gemfile 'gem "rack"'
     bundle "exec echo exec"
     expect(out).to eq("exec")
   end
 
   it "works when exec'ing to ruby" do
+    system_gems(system_gems_to_install, :path => default_bundle_path)
     install_gemfile 'gem "rack"'
     bundle "exec ruby -e 'puts %{hi}'"
     expect(out).to eq("hi")
   end
 
   it "works when exec'ing to rubygems" do
+    system_gems(system_gems_to_install, :path => default_bundle_path)
     install_gemfile 'gem "rack"'
     bundle "exec #{gem_cmd} --version"
     expect(out).to eq(Gem::VERSION)
   end
 
   it "works when exec'ing to rubygems through sh -c" do
+    system_gems(system_gems_to_install, :path => default_bundle_path)
     install_gemfile 'gem "rack"'
     bundle "exec sh -c '#{gem_cmd} --version'"
     expect(out).to eq(Gem::VERSION)
   end
 
   it "works when exec'ing back to bundler with a lockfile that doesn't include the current platform" do
+    system_gems(system_gems_to_install, :path => default_bundle_path)
     install_gemfile <<-G
       gem "rack", "0.9.1"
     G
@@ -107,12 +113,14 @@ RSpec.describe "bundle exec" do
   end
 
   it "accepts --verbose" do
+    system_gems(system_gems_to_install, :path => default_bundle_path)
     install_gemfile 'gem "rack"'
     bundle "exec --verbose echo foobar"
     expect(out).to eq("foobar")
   end
 
   it "passes --verbose to command if it is given after the command" do
+    system_gems(system_gems_to_install, :path => default_bundle_path)
     install_gemfile 'gem "rack"'
     bundle "exec echo --verbose"
     expect(out).to eq("--verbose")
@@ -154,6 +162,7 @@ RSpec.describe "bundle exec" do
   it "can run a command named --verbose" do
     skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
 
+    system_gems(system_gems_to_install, :path => default_bundle_path)
     install_gemfile 'gem "rack"'
     File.open(bundled_app("--verbose"), "w") do |f|
       f.puts "#!/bin/sh"
@@ -314,6 +323,7 @@ RSpec.describe "bundle exec" do
   it "does not duplicate already exec'ed RUBYOPT" do
     skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
 
+    system_gems(system_gems_to_install, :path => default_bundle_path)
     install_gemfile <<-G
       gem "rack"
     G
@@ -332,6 +342,7 @@ RSpec.describe "bundle exec" do
   it "does not duplicate already exec'ed RUBYLIB" do
     skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
 
+    system_gems(system_gems_to_install, :path => default_bundle_path)
     install_gemfile <<-G
       gem "rack"
     G
@@ -348,6 +359,7 @@ RSpec.describe "bundle exec" do
   end
 
   it "errors nicely when the argument doesn't exist" do
+    system_gems(system_gems_to_install, :path => default_bundle_path)
     install_gemfile <<-G
       gem "rack"
     G
@@ -359,6 +371,7 @@ RSpec.describe "bundle exec" do
   end
 
   it "errors nicely when the argument is not executable" do
+    system_gems(system_gems_to_install, :path => default_bundle_path)
     install_gemfile <<-G
       gem "rack"
     G
@@ -370,6 +383,7 @@ RSpec.describe "bundle exec" do
   end
 
   it "errors nicely when no arguments are passed" do
+    system_gems(system_gems_to_install, :path => default_bundle_path)
     install_gemfile <<-G
       gem "rack"
     G
@@ -380,6 +394,7 @@ RSpec.describe "bundle exec" do
   end
 
   it "raises a helpful error when exec'ing to something outside of the bundle" do
+    system_gems(system_gems_to_install, :path => default_bundle_path)
     bundle "config set clean false" # want to keep the rackup binstub
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -401,6 +416,7 @@ RSpec.describe "bundle exec" do
         before(:each) do
           skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
 
+          system_gems(system_gems_to_install, :path => default_bundle_path)
           install_gemfile <<-G
             gem "rack"
           G
@@ -485,6 +501,7 @@ RSpec.describe "bundle exec" do
   describe "with gem executables" do
     describe "run from a random directory" do
       before(:each) do
+        system_gems(system_gems_to_install, :path => default_bundle_path)
         install_gemfile <<-G
           gem "rack"
         G
@@ -646,6 +663,8 @@ RSpec.describe "bundle exec" do
     RUBY
 
     before do
+      system_gems(system_gems_to_install, :path => default_bundle_path)
+
       bundled_app(path).open("w") {|f| f << executable }
       bundled_app(path).chmod(0o755)
 
@@ -696,6 +715,7 @@ RSpec.describe "bundle exec" do
 
         it "runs" do
           skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
+          system_gems(system_gems_to_install, :path => default_bundle_path)
 
           subject
           expect(exitstatus).to eq(exit_code)

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -58,6 +58,16 @@ RSpec.describe "bundle exec" do
     expect(out).to eq("hi")
   end
 
+  it "works when exec'ing to ruby and using -r flag to ruby" do
+    bundle "config set --local path vendor/bundle"
+
+    install_gemfile <<~G
+      source "#{file_uri_for(gem_repo1)}"
+      gem "rack"
+    G
+    bundle "exec ruby -rrack"
+  end
+
   it "works when exec'ing to rubygems" do
     system_gems(system_gems_to_install, :path => default_bundle_path)
     install_gemfile 'gem "rack"'


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When `bundle exec''ing to `ruby`, and using `-r` flags, requiring gems in the `Gemfile` won't work because `bundler/setup` is required through `-r` options inside `RUBYOPT`, which are processed after `-r` CLI flags.

## What is your fix for the problem, implemented in this PR?

My fix is to special case `bundle exec ruby` and prepend `-rbundler/setup` to ruby CLI flags, so that gems in the `Gemfile` are made available _before_ other `-r` options are processed.

Note: The test I wrote for this revealed an issue with `Bundler.which` under Windows, which I also fixed.

Fixes #4025.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
