### PR TITLE
Better defaults for GitHub Actions template generated by `bundle gem`

### DIFF
--- a/bundler/lib/bundler/templates/newgem/github/workflows/main.yml.tt
+++ b/bundler/lib/bundler/templates/newgem/github/workflows/main.yml.tt
@@ -9,12 +9,18 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ruby:
+          - <%= RUBY_VERSION %>
+
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: <%= RUBY_VERSION %>
+        ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
     - name: Run the default task
       run: bundle exec rake

--- a/bundler/lib/bundler/templates/newgem/github/workflows/main.yml.tt
+++ b/bundler/lib/bundler/templates/newgem/github/workflows/main.yml.tt
@@ -1,6 +1,10 @@
 name: Ruby
 
-on: [push,pull_request]
+on:
+  push:
+    - <%= config[:git_default_branch] %>
+
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Some room for improvement on the default github actions template.

## What is your fix for the problem, implemented in this PR?

As the CI was running two times in a row, once for push and once
again for pull, we decided to make different section for each event.
We're using matrix as it makes it easier to add versions and also using
the default main branch in the git config from now by the use of the
:git_default_branch key...

Fixes #4230.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
