### PR TITLE
Fix some cached gems being unintentionally ignored when using rubygems 3.2.18

### DIFF
--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -398,10 +398,6 @@ module Bundler
             next if gemfile =~ /^bundler\-[\d\.]+?\.gem/
             s ||= Bundler.rubygems.spec_from_gem(gemfile)
             s.source = self
-            if Bundler.rubygems.spec_missing_extensions?(s, false)
-              Bundler.ui.debug "Source #{self} is ignoring #{s} because it is missing extensions"
-              next
-            end
             idx << s
           end
 

--- a/bundler/spec/commands/cache_spec.rb
+++ b/bundler/spec/commands/cache_spec.rb
@@ -317,7 +317,7 @@ RSpec.describe "bundle install with gem sources" do
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
 
-    it "does not hit the remote at all" do
+    it "does not hit the remote at all in frozen mode" do
       build_repo2
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"

--- a/bundler/spec/commands/cache_spec.rb
+++ b/bundler/spec/commands/cache_spec.rb
@@ -298,6 +298,30 @@ RSpec.describe "bundle cache" do
       expect(out).to include("frozen").or include("deployment")
     end
   end
+
+  context "with gems with extensions" do
+    before do
+      build_repo2 do
+        build_gem "racc", "2.0" do |s|
+          s.add_dependency "rake"
+          s.extensions << "Rakefile"
+          s.write "Rakefile", "task(:default) { puts 'INSTALLING rack' }"
+        end
+      end
+
+      gemfile <<~G
+        source "#{file_uri_for(gem_repo2)}"
+
+        gem "racc"
+      G
+    end
+
+    it "installs them properly from cache to a different path" do
+      bundle "cache"
+      bundle "config set --local path vendor/bundle"
+      bundle "install --local"
+    end
+  end
 end
 
 RSpec.describe "bundle install with gem sources" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Installing a bundler cache to a different path is broken in rubygems 3.2.18 if it includes gems with extensions.

## What is your fix for the problem, implemented in this PR?

[This change](https://github.com/rubygems/rubygems/pull/4260) in rubygems 3.2.18 made a incorrect condition for missing extensons when fetching cached specs start being met, and thus these gemspecs be ignored.

The solution is to remove the condition since it doesn't make sense in the first place.

Fixes #4620.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
