### PR TITLE
Fix `bundle install` on truffleruby selecting incorrect variant for `sorbet-static` gem

### DIFF
--- a/.github/workflows/truffleruby-bundler.yml
+++ b/.github/workflows/truffleruby-bundler.yml
@@ -13,9 +13,6 @@ jobs:
     name: Bundler (Truffleruby)
     runs-on: ubuntu-20.04
 
-    env:
-      RGV: ..
-
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby

--- a/.github/workflows/truffleruby-bundler.yml
+++ b/.github/workflows/truffleruby-bundler.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: truffleruby-21.1.0
+          ruby-version: truffleruby-head # Until 21.2.0 is released (20th of July, 2021)
           bundler: none
       - name: Prepare dependencies
         run: |

--- a/bundler/lib/bundler/index.rb
+++ b/bundler/lib/bundler/index.rb
@@ -195,11 +195,7 @@ module Bundler
           if base # allow all platforms when searching from a lockfile
             dependency.matches_spec?(spec)
           else
-            if Gem::Platform.respond_to? :match_spec?
-              dependency.matches_spec?(spec) && Gem::Platform.match_spec?(spec)
-            else
-              dependency.matches_spec?(spec) && Gem::Platform.match(spec.platform)
-            end
+            dependency.matches_spec?(spec) && Gem::Platform.match_spec?(spec)
           end
         end
 

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -176,12 +176,36 @@ module Gem
     end
   end
 
+  require "rubygems/platform"
+
   class Platform
     JAVA  = Gem::Platform.new("java") unless defined?(JAVA)
     MSWIN = Gem::Platform.new("mswin32") unless defined?(MSWIN)
     MSWIN64 = Gem::Platform.new("mswin64") unless defined?(MSWIN64)
     MINGW = Gem::Platform.new("x86-mingw32") unless defined?(MINGW)
     X64_MINGW = Gem::Platform.new("x64-mingw32") unless defined?(X64_MINGW)
+  end
+
+  Platform.singleton_class.module_eval do
+    unless Platform.singleton_methods.include?(:match_spec?)
+      def match_spec?(spec)
+        match_gem?(spec.platform, spec.name)
+      end
+
+      def match_gem?(platform, gem_name)
+        match_platforms?(platform, Gem.platforms)
+      end
+
+      private
+
+      def match_platforms?(platform, platforms)
+        platforms.any? do |local_platform|
+          platform.nil? ||
+            local_platform == platform ||
+            (local_platform != Gem::Platform::RUBY && local_platform =~ platform)
+        end
+      end
+    end
   end
 
   require "rubygems/util"

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -182,14 +182,6 @@ module Gem
     MSWIN64 = Gem::Platform.new("mswin64") unless defined?(MSWIN64)
     MINGW = Gem::Platform.new("x86-mingw32") unless defined?(MINGW)
     X64_MINGW = Gem::Platform.new("x64-mingw32") unless defined?(X64_MINGW)
-
-    undef_method :hash if method_defined? :hash
-    def hash
-      @cpu.hash ^ @os.hash ^ @version.hash
-    end
-
-    undef_method :eql? if method_defined? :eql?
-    alias_method :eql?, :==
   end
 
   require "rubygems/util"

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -195,7 +195,7 @@ module Bundler
     def spec_for_dependency(dep, match_current_platform)
       specs_for_platforms = lookup[dep.name]
       if match_current_platform
-        GemHelpers.select_best_platform_match(specs_for_platforms, Bundler.local_platform)
+        GemHelpers.select_best_platform_match(specs_for_platforms.select{|s| Gem::Platform.match_spec?(s) }, Bundler.local_platform)
       else
         GemHelpers.select_best_platform_match(specs_for_platforms, dep.__platform)
       end

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -249,6 +249,38 @@ RSpec.describe "bundle install with specific platforms" do
     end
   end
 
+  it "installs sorbet-static, which does not provide a pure ruby variant, just fine on truffleruby", :truffleruby do
+    build_repo2 do
+      build_gem("sorbet-static", "0.5.6403") {|s| s.platform = "x86_64-linux" }
+      build_gem("sorbet-static", "0.5.6403") {|s| s.platform = "universal-darwin-20" }
+    end
+
+    gemfile <<~G
+      source "#{file_uri_for(gem_repo2)}"
+
+      gem "sorbet-static", "0.5.6403"
+    G
+
+    lockfile <<~L
+      GEM
+        remote: #{file_uri_for(gem_repo2)}/
+        specs:
+          sorbet-static (0.5.6403-universal-darwin-20)
+          sorbet-static (0.5.6403-x86_64-linux)
+
+      PLATFORMS
+        ruby
+
+      DEPENDENCIES
+        sorbet-static (= 0.5.6403)
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+    bundle "install --verbose"
+  end
+
   private
 
   def setup_multiplatform_gem


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Bundler selecting incorrect variants on truffleruby.

## What is your fix for the problem, implemented in this PR?

Make sure we go through custom truffleruby logic: https://github.com/oracle/truffleruby/blob/72ce69ec079618a3c0513da968262a4484633834/lib/mri/rubygems/platform.rb#L44.

Fixes https://github.com/rubygems/rubygems/issues/4588.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
