### PR TITLE
Small tweak to play nice with packaging setups

### DIFF
--- a/test/rubygems/test_case.rb
+++ b/test/rubygems/test_case.rb
@@ -1293,7 +1293,7 @@ Also, a list:
   end
 
   def ruby_with_rubygems_in_load_path
-    [Gem.ruby, "-I", File.expand_path("../../lib", __dir__)]
+    [Gem.ruby, "-I", $LOAD_PATH.find{|p| p == File.dirname($LOADED_FEATURES.find{|f| f.end_with?("/rubygems.rb") }) }]
   end
 
   def with_clean_path_to_ruby


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Apparently it's common for packaging that `lib/` and `test/` are split and don't share a common folder. So packagers give me the feedback that it's helpful for them to not assume a specific relativeness between `lib/` and `test/`. Now that we moved the base test classes to `test`, this is the only place making this assumption.

## What is your fix for the problem, implemented in this PR?

We can avoid it by finding the currently loaded `rubygems.rb` file, and put its folder in the `$LOAD_PATH` of the ruby subprocess.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
