### PR TITLE
Don't use `extra_rdoc_files` with md files in gemspec to make installing bundler with docs faster

### DIFF
--- a/bundler/bundler.gemspec
+++ b/bundler/bundler.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   # include the gemspec itself because warbler breaks w/o it
   s.files += %w[bundler.gemspec]
 
-  s.extra_rdoc_files = %w[CHANGELOG.md LICENSE.md README.md]
+  s.files += %w[CHANGELOG.md LICENSE.md README.md]
   s.bindir        = "exe"
   s.executables   = %w[bundle bundler]
   s.require_paths = ["lib"]


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

RDoc takes forever to process these.

## What is your fix for the problem, implemented in this PR?

They were never processed until bundler 2.2.18, and everything was fine, so let's go back to that.

Closes #4626.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
