### PR TITLE
Use inline codeblock for sh commands

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -11,5 +11,5 @@
 ## Install from source
 
 *   Download from: https://rubygems.org/pages/download
-*   Unpack into a directory and cd there
-*   Install with: ruby setup.rb
+*   Unpack into a directory and `cd` there
+*   Install with: `ruby setup.rb`


### PR DESCRIPTION
Improves consistency of documentation and wraps code/commands in markdown code blocks.

## What was the end-user or developer problem that led to this PR?
Developer.  Calling this a problem seems petty. Just noticed an opportunity for prettier docs and was happy to edit in place.

## What is your fix for the problem, implemented in this PR?
Use inline code blocks vice plain text

## Make sure the following tasks are checked
- [x] Describe the problem / feature
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
