### PR TITLE
Changelogs for rubygems 3.2.19 and bundler 2.2.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.2.19 / 2021-05-31
+
+## Enhancements:
+
+* Fix `gem help build` output format. Pull request #4613 by tnir
+
 # 3.2.18 / 2021-05-25
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.2.19 (May 31, 2021)
+
+## Bug fixes:
+
+  - Restore support for configuration keys with dashes [#4582](https://github.com/rubygems/rubygems/pull/4582)
+  - Fix some cached gems being unintentionally ignored when using rubygems 3.2.18 [#4623](https://github.com/rubygems/rubygems/pull/4623)
+
 # 2.2.18 (May 25, 2021)
 
 ## Security fixes:


### PR DESCRIPTION
Cherry-picking changelogs from future rubygems 3.2.19 and bundler 2.2.19 into master.