### PR TITLE
Fix `bundle check` with scoped rubygems sources

### DIFF
--- a/bundler/lib/bundler/cli/check.rb
+++ b/bundler/lib/bundler/cli/check.rb
@@ -15,6 +15,7 @@ module Bundler
       definition.validate_runtime!
 
       begin
+        definition.resolve_only_locally!
         not_installed = definition.missing_specs
       rescue GemNotFound, VersionConflict
         Bundler.ui.error "Bundler can't satisfy your Gemfile's dependencies."

--- a/bundler/lib/bundler/cli/check.rb
+++ b/bundler/lib/bundler/cli/check.rb
@@ -11,9 +11,10 @@ module Bundler
     def run
       Bundler.settings.set_command_option_if_given :path, options[:path]
 
+      definition = Bundler.definition
+      definition.validate_runtime!
+
       begin
-        definition = Bundler.definition
-        definition.validate_runtime!
         not_installed = definition.missing_specs
       rescue GemNotFound, VersionConflict
         Bundler.ui.error "Bundler can't satisfy your Gemfile's dependencies."

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -165,6 +165,12 @@ module Bundler
       @disable_multisource
     end
 
+    def resolve_only_locally!
+      @remote = false
+      sources.local_only!
+      resolve
+    end
+
     def resolve_with_cache!
       sources.cached!
       resolve

--- a/bundler/lib/bundler/source.rb
+++ b/bundler/lib/bundler/source.rb
@@ -36,6 +36,8 @@ module Bundler
 
     def local!; end
 
+    def local_only!; end
+
     def cached!; end
 
     def remote!; end

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -26,6 +26,12 @@ module Bundler
         Array(options["remotes"]).reverse_each {|r| add_remote(r) }
       end
 
+      def local_only!
+        @specs = nil
+        @allow_local = true
+        @allow_remote = false
+      end
+
       def local!
         return if @allow_local
 

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -132,6 +132,10 @@ module Bundler
       false
     end
 
+    def local_only!
+      all_sources.each(&:local_only!)
+    end
+
     def cached!
       all_sources.each(&:cached!)
     end

--- a/bundler/spec/commands/check_spec.rb
+++ b/bundler/spec/commands/check_spec.rb
@@ -288,6 +288,66 @@ RSpec.describe "bundle check" do
     end
   end
 
+  describe "when using only scoped rubygems sources" do
+    before do
+      gemfile <<~G
+        source "#{file_uri_for(gem_repo1)}" do
+          gem "rack"
+        end
+      G
+    end
+
+    it "returns success when the Gemfile is satisfied" do
+      system_gems "rack-1.0.0", :path => default_bundle_path
+      bundle :check
+      expect(out).to include("The Gemfile's dependencies are satisfied")
+    end
+  end
+
+  describe "when using only scoped rubygems sources with indirect dependencies" do
+    before do
+      build_repo4 do
+        build_gem "depends_on_rack" do |s|
+          s.add_dependency "rack"
+        end
+
+        build_gem "rack"
+      end
+
+      gemfile <<~G
+        source "#{file_uri_for(gem_repo4)}" do
+          gem "depends_on_rack"
+        end
+      G
+    end
+
+    it "returns success when the Gemfile is satisfied and generates a correct lockfile" do
+      system_gems "depends_on_rack-1.0", "rack-1.0", :gem_repo => gem_repo4, :path => default_bundle_path
+      bundle :check
+      expect(out).to include("The Gemfile's dependencies are satisfied")
+      expect(lockfile).to eq <<~L
+        GEM
+          specs:
+
+        GEM
+          remote: #{file_uri_for(gem_repo4)}/
+          specs:
+            depends_on_rack (1.0)
+              rack
+            rack (1.0)
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          depends_on_rack!
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+    end
+  end
+
   describe "BUNDLED WITH" do
     def lock_with(bundler_version = nil)
       lock = <<-L


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The problem is that in recent versions, we have forbidden considering locally installed specifications for resolution for any sources other that the global one.

When running `bundle check` though, we want to keep considering only local sources like we did before, since that's the whole point of `bundle check`: resolving using only locally installed gems.

## What is your fix for the problem, implemented in this PR?

Make sure `bundle check` does a "local-only resolve" like it used to

Fixes #4635.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
