### PR TITLE
Don't load `resolv` unnecessarily

### DIFF
--- a/bundler/lib/bundler/fetcher/index.rb
+++ b/bundler/lib/bundler/fetcher/index.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative "base"
-require "rubygems/remote_fetcher"
 
 module Bundler
   class Fetcher

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -529,10 +529,8 @@ module Bundler
     end
 
     def gem_remote_fetcher
-      require "resolv"
       proxy = configuration[:http_proxy]
-      dns = Resolv::DNS.new
-      Gem::RemoteFetcher.new(proxy, dns)
+      Gem::RemoteFetcher.new(proxy)
     end
 
     def gem_from_path(path, policy = nil)

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -529,6 +529,7 @@ module Bundler
     end
 
     def gem_remote_fetcher
+      require "rubygems/remote_fetcher"
       proxy = configuration[:http_proxy]
       Gem::RemoteFetcher.new(proxy)
     end

--- a/bundler/spec/bundler/fetcher/index_spec.rb
+++ b/bundler/spec/bundler/fetcher/index_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rubygems/remote_fetcher"
+
 RSpec.describe Bundler::Fetcher::Index do
   let(:downloader)  { nil }
   let(:remote)      { nil }


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Bundler loads the `resolv` library unnecessarily, and that could cause issues with default gems, and maybe others like #4605.

## What is your fix for the problem, implemented in this PR?

Don't load `resolv`. This will be followed by another PR to rubygems to do the samething. Splitting just so that each PR gets its own separated changelog entry.

I think this should either fix #4605 or at least change it to throw a different error, so I'll set this PR to close that ticket.

Closes #4605.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
