### PR TITLE
Rename test/rubygems/test_{case,utilities}.rb to avoid "test_" prefix

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -526,6 +526,7 @@ test/rubygems/good_rake.rb
 test/rubygems/grandchild_cert.pem
 test/rubygems/grandchild_cert_32.pem
 test/rubygems/grandchild_key.pem
+test/rubygems/helper.rb
 test/rubygems/installer_test_case.rb
 test/rubygems/invalid_client.pem
 test/rubygems/invalid_issuer_cert.pem
@@ -557,7 +558,6 @@ test/rubygems/specifications/rubyforge-0.0.1.gemspec
 test/rubygems/ssl_cert.pem
 test/rubygems/ssl_key.pem
 test/rubygems/test_bundled_ca.rb
-test/rubygems/test_case.rb
 test/rubygems/test_config.rb
 test/rubygems/test_deprecate.rb
 test/rubygems/test_gem.rb
@@ -690,7 +690,7 @@ test/rubygems/test_kernel.rb
 test/rubygems/test_project_sanity.rb
 test/rubygems/test_remote_fetch_error.rb
 test/rubygems/test_require.rb
-test/rubygems/test_utilities.rb
+test/rubygems/utilities.rb
 test/rubygems/wrong_key_cert.pem
 test/rubygems/wrong_key_cert_32.pem
 test/test_changelog_generator.rb

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -1596,4 +1596,4 @@ class Object
   end
 end
 
-require_relative 'test_utilities'
+require_relative 'utilities'

--- a/test/rubygems/installer_test_case.rb
+++ b/test/rubygems/installer_test_case.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/installer'
 
 class Gem::Installer

--- a/test/rubygems/package/tar_test_case.rb
+++ b/test/rubygems/package/tar_test_case.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative '../test_case'
+require_relative '../helper'
 require 'rubygems/package'
 
 ##

--- a/test/rubygems/test_bundled_ca.rb
+++ b/test/rubygems/test_bundled_ca.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'net/http'
 require 'rubygems/openssl'
 

--- a/test/rubygems/test_config.rb
+++ b/test/rubygems/test_config.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems'
 require 'shellwords'
 

--- a/test/rubygems/test_deprecate.rb
+++ b/test/rubygems/test_deprecate.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/deprecate'
 
 class TestDeprecate < Gem::TestCase

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1,5 +1,5 @@
 # coding: US-ASCII
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems'
 require 'rubygems/command'
 require 'rubygems/installer'

--- a/test/rubygems/test_gem_available_set.rb
+++ b/test/rubygems/test_gem_available_set.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/available_set'
 require 'rubygems/security'
 

--- a/test/rubygems/test_gem_bundler_version_finder.rb
+++ b/test/rubygems/test_gem_bundler_version_finder.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 
 class TestGemBundlerVersionFinder < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_command.rb
+++ b/test/rubygems/test_gem_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/command'
 
 class Gem::Command

--- a/test/rubygems/test_gem_command_manager.rb
+++ b/test/rubygems/test_gem_command_manager.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/command_manager'
 
 class TestGemCommandManager < Gem::TestCase

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/commands/build_command'
 require 'rubygems/package'
 

--- a/test/rubygems/test_gem_commands_cert_command.rb
+++ b/test/rubygems/test_gem_commands_cert_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/commands/cert_command'
 
 unless Gem::HAVE_OPENSSL

--- a/test/rubygems/test_gem_commands_check_command.rb
+++ b/test/rubygems/test_gem_commands_check_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/commands/check_command'
 
 class TestGemCommandsCheckCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_cleanup_command.rb
+++ b/test/rubygems/test_gem_commands_cleanup_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/commands/cleanup_command'
 require 'rubygems/installer'
 

--- a/test/rubygems/test_gem_commands_contents_command.rb
+++ b/test/rubygems/test_gem_commands_contents_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/commands/contents_command'
 
 class TestGemCommandsContentsCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_dependency_command.rb
+++ b/test/rubygems/test_gem_commands_dependency_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/commands/dependency_command'
 
 class TestGemCommandsDependencyCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_environment_command.rb
+++ b/test/rubygems/test_gem_commands_environment_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/commands/environment_command'
 
 class TestGemCommandsEnvironmentCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_fetch_command.rb
+++ b/test/rubygems/test_gem_commands_fetch_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/package'
 require 'rubygems/security'
 require 'rubygems/commands/fetch_command'

--- a/test/rubygems/test_gem_commands_generate_index_command.rb
+++ b/test/rubygems/test_gem_commands_generate_index_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/indexer'
 require 'rubygems/commands/generate_index_command'
 

--- a/test/rubygems/test_gem_commands_help_command.rb
+++ b/test/rubygems/test_gem_commands_help_command.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require "rubygems"
-require_relative "test_case"
+require_relative "helper"
 require "rubygems/commands/help_command"
 require "rubygems/package"
 require "rubygems/command_manager"

--- a/test/rubygems/test_gem_commands_info_command.rb
+++ b/test/rubygems/test_gem_commands_info_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/commands/info_command'
 
 class TestGemCommandsInfoCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/commands/install_command'
 require 'rubygems/request_set'
 require 'rubygems/rdoc'

--- a/test/rubygems/test_gem_commands_list_command.rb
+++ b/test/rubygems/test_gem_commands_list_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/commands/list_command'
 
 class TestGemCommandsListCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_lock_command.rb
+++ b/test/rubygems/test_gem_commands_lock_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/commands/lock_command'
 
 class TestGemCommandsLockCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_mirror.rb
+++ b/test/rubygems/test_gem_commands_mirror.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/commands/mirror_command'
 
 class TestGemCommandsMirrorCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_open_command.rb
+++ b/test/rubygems/test_gem_commands_open_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/commands/open_command'
 
 class TestGemCommandsOpenCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_outdated_command.rb
+++ b/test/rubygems/test_gem_commands_outdated_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/commands/outdated_command'
 
 class TestGemCommandsOutdatedCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_owner_command.rb
+++ b/test/rubygems/test_gem_commands_owner_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/commands/owner_command'
 
 class TestGemCommandsOwnerCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_pristine_command.rb
+++ b/test/rubygems/test_gem_commands_pristine_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/commands/pristine_command'
 
 class TestGemCommandsPristineCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_push_command.rb
+++ b/test/rubygems/test_gem_commands_push_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/commands/push_command'
 
 class TestGemCommandsPushCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_query_command.rb
+++ b/test/rubygems/test_gem_commands_query_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/commands/query_command'
 
 module TestGemCommandsQueryCommandSetup

--- a/test/rubygems/test_gem_commands_search_command.rb
+++ b/test/rubygems/test_gem_commands_search_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/commands/search_command'
 
 class TestGemCommandsSearchCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_server_command.rb
+++ b/test/rubygems/test_gem_commands_server_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/commands/server_command'
 
 class TestGemCommandsServerCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/commands/setup_command'
 
 class TestGemCommandsSetupCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_signin_command.rb
+++ b/test/rubygems/test_gem_commands_signin_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/commands/signin_command'
 require 'rubygems/installer'
 

--- a/test/rubygems/test_gem_commands_signout_command.rb
+++ b/test/rubygems/test_gem_commands_signout_command.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/commands/signout_command'
 require 'rubygems/installer'
 

--- a/test/rubygems/test_gem_commands_sources_command.rb
+++ b/test/rubygems/test_gem_commands_sources_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/commands/sources_command'
 
 class TestGemCommandsSourcesCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_specification_command.rb
+++ b/test/rubygems/test_gem_commands_specification_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/commands/specification_command'
 
 class TestGemCommandsSpecificationCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_stale_command.rb
+++ b/test/rubygems/test_gem_commands_stale_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/commands/stale_command'
 
 class TestGemCommandsStaleCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_unpack_command.rb
+++ b/test/rubygems/test_gem_commands_unpack_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/commands/unpack_command'
 
 class TestGemCommandsUnpackCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/commands/update_command'
 
 class TestGemCommandsUpdateCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_which_command.rb
+++ b/test/rubygems/test_gem_commands_which_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/commands/which_command'
 
 class TestGemCommandsWhichCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_yank_command.rb
+++ b/test/rubygems/test_gem_commands_yank_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/commands/yank_command'
 
 class TestGemCommandsYankCommand < Gem::TestCase

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/config_file'
 
 class TestGemConfigFile < Gem::TestCase

--- a/test/rubygems/test_gem_dependency.rb
+++ b/test/rubygems/test_gem_dependency.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/dependency'
 
 class TestGemDependency < Gem::TestCase

--- a/test/rubygems/test_gem_dependency_installer.rb
+++ b/test/rubygems/test_gem_dependency_installer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/dependency_installer'
 require 'rubygems/security'
 

--- a/test/rubygems/test_gem_dependency_list.rb
+++ b/test/rubygems/test_gem_dependency_list.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/dependency_list'
 
 class TestGemDependencyList < Gem::TestCase

--- a/test/rubygems/test_gem_dependency_resolution_error.rb
+++ b/test/rubygems/test_gem_dependency_resolution_error.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 
 class TestGemDependencyResolutionError < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_doctor.rb
+++ b/test/rubygems/test_gem_doctor.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/doctor'
 
 class TestGemDoctor < Gem::TestCase

--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/ext'
 require 'rubygems/installer'
 

--- a/test/rubygems/test_gem_ext_cmake_builder.rb
+++ b/test/rubygems/test_gem_ext_cmake_builder.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/ext'
 
 class TestGemExtCmakeBuilder < Gem::TestCase

--- a/test/rubygems/test_gem_ext_configure_builder.rb
+++ b/test/rubygems/test_gem_ext_configure_builder.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/ext'
 
 class TestGemExtConfigureBuilder < Gem::TestCase

--- a/test/rubygems/test_gem_ext_ext_conf_builder.rb
+++ b/test/rubygems/test_gem_ext_ext_conf_builder.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/ext'
 
 class TestGemExtExtConfBuilder < Gem::TestCase

--- a/test/rubygems/test_gem_ext_rake_builder.rb
+++ b/test/rubygems/test_gem_ext_rake_builder.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/ext'
 
 class TestGemExtRakeBuilder < Gem::TestCase

--- a/test/rubygems/test_gem_gem_runner.rb
+++ b/test/rubygems/test_gem_gem_runner.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 
 class TestGemGemRunner < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_gemcutter_utilities.rb
+++ b/test/rubygems/test_gem_gemcutter_utilities.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems'
 require 'rubygems/command'
 require 'rubygems/gemcutter_utilities'

--- a/test/rubygems/test_gem_impossible_dependencies_error.rb
+++ b/test/rubygems/test_gem_impossible_dependencies_error.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 
 class TestGemImpossibleDependenciesError < Gem::TestCase
   def test_message_conflict

--- a/test/rubygems/test_gem_indexer.rb
+++ b/test/rubygems/test_gem_indexer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/indexer'
 
 class TestGemIndexer < Gem::TestCase

--- a/test/rubygems/test_gem_local_remote_options.rb
+++ b/test/rubygems/test_gem_local_remote_options.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/local_remote_options'
 require 'rubygems/command'
 

--- a/test/rubygems/test_gem_name_tuple.rb
+++ b/test/rubygems/test_gem_name_tuple.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/name_tuple'
 
 class TestGemNameTuple < Gem::TestCase

--- a/test/rubygems/test_gem_package_old.rb
+++ b/test/rubygems/test_gem_package_old.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 
 unless Gem.java_platform? # jruby can't require the simple_gem file
   require 'rubygems/simple_gem'

--- a/test/rubygems/test_gem_package_task.rb
+++ b/test/rubygems/test_gem_package_task.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems'
 
 begin

--- a/test/rubygems/test_gem_path_support.rb
+++ b/test/rubygems/test_gem_path_support.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems'
 require 'fileutils'
 

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/platform'
 require 'rbconfig'
 

--- a/test/rubygems/test_gem_rdoc.rb
+++ b/test/rubygems/test_gem_rdoc.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require 'rubygems'
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/rdoc'
 
 class TestGemRDoc < Gem::TestCase

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 
 require 'webrick'
 require 'webrick/https' if Gem::HAVE_OPENSSL

--- a/test/rubygems/test_gem_request.rb
+++ b/test/rubygems/test_gem_request.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/request'
 require 'ostruct'
 require 'base64'

--- a/test/rubygems/test_gem_request_connection_pools.rb
+++ b/test/rubygems/test_gem_request_connection_pools.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/request'
 require 'timeout'
 

--- a/test/rubygems/test_gem_request_set.rb
+++ b/test/rubygems/test_gem_request_set.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/request_set'
 
 class TestGemRequestSet < Gem::TestCase

--- a/test/rubygems/test_gem_request_set_gem_dependency_api.rb
+++ b/test/rubygems/test_gem_request_set_gem_dependency_api.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/request_set'
 
 class TestGemRequestSetGemDependencyAPI < Gem::TestCase

--- a/test/rubygems/test_gem_request_set_lockfile.rb
+++ b/test/rubygems/test_gem_request_set_lockfile.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/request_set'
 require 'rubygems/request_set/lockfile'
 

--- a/test/rubygems/test_gem_request_set_lockfile_parser.rb
+++ b/test/rubygems/test_gem_request_set_lockfile_parser.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/request_set'
 require 'rubygems/request_set/lockfile'
 require 'rubygems/request_set/lockfile/tokenizer'

--- a/test/rubygems/test_gem_request_set_lockfile_tokenizer.rb
+++ b/test/rubygems/test_gem_request_set_lockfile_tokenizer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/request_set'
 require 'rubygems/request_set/lockfile'
 require 'rubygems/request_set/lockfile/tokenizer'

--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require "rubygems/requirement"
 
 class TestGemRequirement < Gem::TestCase

--- a/test/rubygems/test_gem_resolver.rb
+++ b/test/rubygems/test_gem_resolver.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 
 class TestGemResolver < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_resolver_activation_request.rb
+++ b/test/rubygems/test_gem_resolver_activation_request.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 
 class TestGemResolverActivationRequest < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_resolver_api_set.rb
+++ b/test/rubygems/test_gem_resolver_api_set.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 
 class TestGemResolverAPISet < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_resolver_api_specification.rb
+++ b/test/rubygems/test_gem_resolver_api_specification.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 
 class TestGemResolverAPISpecification < Gem::TestCase
   def test_initialize

--- a/test/rubygems/test_gem_resolver_best_set.rb
+++ b/test/rubygems/test_gem_resolver_best_set.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 
 class TestGemResolverBestSet < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_resolver_composed_set.rb
+++ b/test/rubygems/test_gem_resolver_composed_set.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 
 class TestGemResolverComposedSet < Gem::TestCase
   def test_errors

--- a/test/rubygems/test_gem_resolver_conflict.rb
+++ b/test/rubygems/test_gem_resolver_conflict.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 
 class TestGemResolverConflict < Gem::TestCase
   def test_explanation

--- a/test/rubygems/test_gem_resolver_dependency_request.rb
+++ b/test/rubygems/test_gem_resolver_dependency_request.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 
 class TestGemResolverDependencyRequest < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_resolver_git_set.rb
+++ b/test/rubygems/test_gem_resolver_git_set.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 
 class TestGemResolverGitSet < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_resolver_git_specification.rb
+++ b/test/rubygems/test_gem_resolver_git_specification.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/installer'
 
 class TestGemResolverGitSpecification < Gem::TestCase

--- a/test/rubygems/test_gem_resolver_index_set.rb
+++ b/test/rubygems/test_gem_resolver_index_set.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 
 class TestGemResolverIndexSet < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_resolver_index_specification.rb
+++ b/test/rubygems/test_gem_resolver_index_specification.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/available_set'
 
 class TestGemResolverIndexSpecification < Gem::TestCase

--- a/test/rubygems/test_gem_resolver_installed_specification.rb
+++ b/test/rubygems/test_gem_resolver_installed_specification.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 
 class TestGemResolverInstalledSpecification < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_resolver_installer_set.rb
+++ b/test/rubygems/test_gem_resolver_installer_set.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 
 class TestGemResolverInstallerSet < Gem::TestCase
   def test_add_always_install

--- a/test/rubygems/test_gem_resolver_local_specification.rb
+++ b/test/rubygems/test_gem_resolver_local_specification.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/available_set'
 
 class TestGemResolverLocalSpecification < Gem::TestCase

--- a/test/rubygems/test_gem_resolver_lock_set.rb
+++ b/test/rubygems/test_gem_resolver_lock_set.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 
 class TestGemResolverLockSet < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_resolver_lock_specification.rb
+++ b/test/rubygems/test_gem_resolver_lock_specification.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/installer'
 require 'rubygems/resolver'
 

--- a/test/rubygems/test_gem_resolver_requirement_list.rb
+++ b/test/rubygems/test_gem_resolver_requirement_list.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 
 class TestGemResolverRequirementList < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_resolver_specification.rb
+++ b/test/rubygems/test_gem_resolver_specification.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 
 class TestGemResolverSpecification < Gem::TestCase
   class TestSpec < Gem::Resolver::Specification

--- a/test/rubygems/test_gem_resolver_vendor_set.rb
+++ b/test/rubygems/test_gem_resolver_vendor_set.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 
 class TestGemResolverVendorSet < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_resolver_vendor_specification.rb
+++ b/test/rubygems/test_gem_resolver_vendor_specification.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 
 class TestGemResolverVendorSpecification < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_security.rb
+++ b/test/rubygems/test_gem_security.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/security'
 
 unless Gem::HAVE_OPENSSL

--- a/test/rubygems/test_gem_security_policy.rb
+++ b/test/rubygems/test_gem_security_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'test_case'
+require_relative 'helper'
 
 unless Gem::HAVE_OPENSSL
   warn 'Skipping Gem::Security::Policy tests.  openssl not found.'

--- a/test/rubygems/test_gem_security_signer.rb
+++ b/test/rubygems/test_gem_security_signer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 
 unless Gem::HAVE_OPENSSL
   warn 'Skipping Gem::Security::Signer tests.  openssl not found.'

--- a/test/rubygems/test_gem_security_trust_dir.rb
+++ b/test/rubygems/test_gem_security_trust_dir.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 
 unless Gem::HAVE_OPENSSL
   warn 'Skipping Gem::Security::TrustDir tests.  openssl not found.'

--- a/test/rubygems/test_gem_server.rb
+++ b/test/rubygems/test_gem_server.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/server'
 require 'stringio'
 

--- a/test/rubygems/test_gem_silent_ui.rb
+++ b/test/rubygems/test_gem_silent_ui.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/user_interaction'
 require 'timeout'
 

--- a/test/rubygems/test_gem_source.rb
+++ b/test/rubygems/test_gem_source.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/source'
 require 'rubygems/indexer'
 

--- a/test/rubygems/test_gem_source_fetch_problem.rb
+++ b/test/rubygems/test_gem_source_fetch_problem.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 
 class TestGemSourceFetchProblem < Gem::TestCase
   def test_exception

--- a/test/rubygems/test_gem_source_git.rb
+++ b/test/rubygems/test_gem_source_git.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/source'
 
 class TestGemSourceGit < Gem::TestCase

--- a/test/rubygems/test_gem_source_installed.rb
+++ b/test/rubygems/test_gem_source_installed.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/source'
 
 class TestGemSourceInstalled < Gem::TestCase

--- a/test/rubygems/test_gem_source_list.rb
+++ b/test/rubygems/test_gem_source_list.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rubygems'
 require 'rubygems/source_list'
-require_relative 'test_case'
+require_relative 'helper'
 
 class TestGemSourceList < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_source_local.rb
+++ b/test/rubygems/test_gem_source_local.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/source'
 
 require 'fileutils'

--- a/test/rubygems/test_gem_source_lock.rb
+++ b/test/rubygems/test_gem_source_lock.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 
 class TestGemSourceLock < Gem::TestCase
   def test_fetch_spec

--- a/test/rubygems/test_gem_source_specific_file.rb
+++ b/test/rubygems/test_gem_source_specific_file.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/source'
 
 class TestGemSourceSpecificFile < Gem::TestCase

--- a/test/rubygems/test_gem_source_subpath_problem.rb
+++ b/test/rubygems/test_gem_source_subpath_problem.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rubygems/test_case'
+require_relative 'helper'
 require 'rubygems/source'
 
 class TestGemSourceSubpathProblem < Gem::TestCase

--- a/test/rubygems/test_gem_source_vendor.rb
+++ b/test/rubygems/test_gem_source_vendor.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/source'
 
 class TestGemSourceVendor < Gem::TestCase

--- a/test/rubygems/test_gem_spec_fetcher.rb
+++ b/test/rubygems/test_gem_spec_fetcher.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/spec_fetcher'
 
 class TestGemSpecFetcher < Gem::TestCase

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require 'benchmark'
-require_relative 'test_case'
+require_relative 'helper'
 require 'date'
 require 'pathname'
 require 'stringio'

--- a/test/rubygems/test_gem_stream_ui.rb
+++ b/test/rubygems/test_gem_stream_ui.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/user_interaction'
 require 'timeout'
 

--- a/test/rubygems/test_gem_stub_specification.rb
+++ b/test/rubygems/test_gem_stub_specification.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative "test_case"
+require_relative "helper"
 require "rubygems/stub_specification"
 
 class TestStubSpecification < Gem::TestCase

--- a/test/rubygems/test_gem_text.rb
+++ b/test/rubygems/test_gem_text.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require "rubygems/text"
 
 class TestGemText < Gem::TestCase

--- a/test/rubygems/test_gem_unsatisfiable_dependency_error.rb
+++ b/test/rubygems/test_gem_unsatisfiable_dependency_error.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 
 class TestGemUnsatisfiableDependencyError < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_uri_formatter.rb
+++ b/test/rubygems/test_gem_uri_formatter.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/uri_formatter'
 
 class TestGemUriFormatter < Gem::TestCase

--- a/test/rubygems/test_gem_util.rb
+++ b/test/rubygems/test_gem_util.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/util'
 
 class TestGemUtil < Gem::TestCase

--- a/test/rubygems/test_gem_validator.rb
+++ b/test/rubygems/test_gem_validator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "test_case"
+require_relative "helper"
 require "rubygems/validator"
 
 class TestGemValidator < Gem::TestCase

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require "rubygems/version"
 
 class TestGemVersion < Gem::TestCase

--- a/test/rubygems/test_gem_version_option.rb
+++ b/test/rubygems/test_gem_version_option.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems/command'
 require 'rubygems/version_option'
 

--- a/test/rubygems/test_kernel.rb
+++ b/test/rubygems/test_kernel.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 
 class TestKernel < Gem::TestCase
   def setup

--- a/test/rubygems/test_project_sanity.rb
+++ b/test/rubygems/test_project_sanity.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "test_case"
+require_relative "helper"
 require "open3"
 
 class TestProjectSanity < Gem::TestCase

--- a/test/rubygems/test_remote_fetch_error.rb
+++ b/test/rubygems/test_remote_fetch_error.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 
 class TestRemoteFetchError < Gem::TestCase
   def test_password_redacted

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'test_case'
+require_relative 'helper'
 require 'rubygems'
 
 class TestGemRequire < Gem::TestCase

--- a/test/rubygems/utilities.rb
+++ b/test/rubygems/utilities.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require 'tempfile'
 require 'rubygems'
-require_relative 'test_case'
 require 'rubygems/remote_fetcher'
 
 ##


### PR DESCRIPTION
This changes "test/rubygems/test_case.rb" to "test/rubygems/helper.rb",
and "test/rubygems/test_utilities.rb" to "test/rubygems/utilities.rb".

The two files are a helper for tests, not test files. However, a file
starting with "test_" prefix is handled as a test file directly loaded
by test-unit because Rakefile specifies:

```
t.test_files = FileList['test/**/test_*.rb']
```

Directly loading test/rubygems/test_utilities.rb caused "uninitialized
constant Gem::TestCase". This issue was fixed by
59c682097197fee4052b47e4b4ab86562f3eaa9b, but the fix caused a
"circular require" warning because test_utilities.rb and test_case.rb
are now requiring each other.

Anyway, adding "test_" prefix to a test helper file is confusing, so
this changeset reverts the fix and solve the issue by renaming them.

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
