### PR TITLE
Stop testing ruby-core CI in the stable branch

### DIFF
--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - master
-      - 3.2
 
 jobs:
   ruby_core:


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The main problem with running this workflow on the stable branch is that it's hard to get green and sometimes requires backporting development changes from master, which increases the risk of conflicts which need to be manually fixed by backporting other dependent PRs or by writing custom code. Not running it here should make our releases smaller, yet passing the stable branch's CI.

## What is your fix for the problem, implemented in this PR?

Ruby-core CI is to test the integration of the latest HEAD of ruby-core with the latest HEAD of rubygems. It doesn't make sense to run this on the stable branch. If could make some sense to run the integration against a manual build of ruby's stable branch, but not against a manual build of ruby-head. Since there are no such builds available, I think it's best to skip this job in the stable branch.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
