### PR TITLE
Auto-update insecure lockfile to split GEM source sections whenever possible

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -112,7 +112,7 @@ module Bundler
       end
 
       @locked_gem_sources = @locked_sources.select {|s| s.is_a?(Source::Rubygems) }
-      @disable_multisource = @locked_gem_sources.all?(&:disable_multisource?)
+      @disable_multisource = @locked_gem_sources.all?(&:disable_multisource?) || (sources.no_aggregate_global_source? && !Bundler.frozen_bundle?)
 
       unless @disable_multisource
         msg = "Your lockfile contains a single rubygems source section with multiple remotes, which is insecure. You should run `bundle update` or generate your lockfile from scratch."

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -30,8 +30,10 @@ module Bundler
       @resolver = Molinillo::Resolver.new(self, self)
       @search_for = {}
       @base_dg = Molinillo::DependencyGraph.new
+      aggregate_global_source = @source_requirements[:default].is_a?(Source::RubygemsAggregate)
       @base.each do |ls|
         dep = Dependency.new(ls.name, ls.version)
+        ls.source = source_for(ls.name) unless aggregate_global_source
         @base_dg.add_vertex(ls.name, DepProxy.get_proxy(dep, ls.platform), true)
       end
       additional_base_requirements.each {|d| @base_dg.add_vertex(d.name, d) }

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -185,6 +185,8 @@ module Bundler
     end
 
     def equal_source?(source, other_source)
+      return source.include?(other_source) if source.is_a?(Source::Rubygems) && other_source.is_a?(Source::Rubygems) && !merged_gem_lockfile_sections?
+
       source == other_source
     end
 

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -612,9 +612,66 @@ RSpec.describe "bundle install with gems on multiple sources" do
         L
       end
 
-      it "does not install newer versions or generate lockfile changes when running bundle install, and warns", :bundler => "< 3" do
+      it "does not install newer versions but updates the lockfile format when running bundle install in non frozen mode, and doesn't warn" do
+        bundle :install, :artifice => "compact_index"
+        expect(err).to be_empty
+
+        expect(the_bundle).to include_gems("activesupport 6.0.3.4")
+        expect(the_bundle).not_to include_gems("activesupport 6.1.2.1")
+        expect(the_bundle).to include_gems("tzinfo 1.2.9")
+        expect(the_bundle).not_to include_gems("tzinfo 2.0.4")
+        expect(the_bundle).to include_gems("concurrent-ruby 1.1.8")
+        expect(the_bundle).not_to include_gems("concurrent-ruby 1.1.9")
+
+        expect(lockfile).to eq <<~L
+          GEM
+            remote: https://gem.repo2/
+            specs:
+              activesupport (6.0.3.4)
+                concurrent-ruby (~> 1.0, >= 1.0.2)
+                i18n (>= 0.7, < 2)
+                minitest (~> 5.1)
+                tzinfo (~> 1.1)
+                zeitwerk (~> 2.2, >= 2.2.2)
+              concurrent-ruby (1.1.8)
+              connection_pool (2.2.3)
+              i18n (1.8.9)
+                concurrent-ruby (~> 1.0)
+              minitest (5.14.3)
+              rack (2.2.3)
+              redis (4.2.5)
+              sidekiq (6.1.3)
+                connection_pool (>= 2.2.2)
+                rack (~> 2.0)
+                redis (>= 4.2.0)
+              thread_safe (0.3.6)
+              tzinfo (1.2.9)
+                thread_safe (~> 0.1)
+              zeitwerk (2.4.2)
+
+          GEM
+            remote: https://gem.repo3/
+            specs:
+              sidekiq-pro (5.2.1)
+                connection_pool (>= 2.2.3)
+                sidekiq (>= 6.1.0)
+
+          PLATFORMS
+            #{specific_local_platform}
+
+          DEPENDENCIES
+            activesupport
+            sidekiq-pro!
+
+          BUNDLED WITH
+             #{Bundler::VERSION}
+        L
+      end
+
+      it "does not install newer versions or generate lockfile changes when running bundle install in frozen mode, and warns", :bundler => "< 3" do
         initial_lockfile = lockfile
 
+        bundle "config set --local frozen true"
         bundle :install, :artifice => "compact_index"
 
         expect(err).to include("Your lockfile contains a single rubygems source section with multiple remotes, which is insecure.")
@@ -629,9 +686,10 @@ RSpec.describe "bundle install with gems on multiple sources" do
         expect(lockfile).to eq(initial_lockfile)
       end
 
-      it "fails when running bundle install", :bundler => "3" do
+      it "fails when running bundle install in frozen mode", :bundler => "3" do
         initial_lockfile = lockfile
 
+        bundle "config set --local frozen true"
         bundle :install, :artifice => "compact_index", :raise_on_error => false
 
         expect(err).to include("Your lockfile contains a single rubygems source section with multiple remotes, which is insecure.")
@@ -694,9 +752,9 @@ RSpec.describe "bundle install with gems on multiple sources" do
         L
       end
 
-      it "it keeps the current lockfile format and upgrades the requested gem when running bundle update with an argument, and warns", :bundler => "< 3" do
+      it "upgrades the lockfile format and upgrades the requested gem when running bundle update with an argument" do
         bundle "update concurrent-ruby", :artifice => "compact_index"
-        expect(err).to include("Your lockfile contains a single rubygems source section with multiple remotes, which is insecure.")
+        expect(err).to be_empty
 
         expect(the_bundle).to include_gems("activesupport 6.0.3.4")
         expect(the_bundle).not_to include_gems("activesupport 6.1.2.1")
@@ -708,7 +766,6 @@ RSpec.describe "bundle install with gems on multiple sources" do
         expect(lockfile).to eq <<~L
           GEM
             remote: https://gem.repo2/
-            remote: https://gem.repo3/
             specs:
               activesupport (6.0.3.4)
                 concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -727,13 +784,17 @@ RSpec.describe "bundle install with gems on multiple sources" do
                 connection_pool (>= 2.2.2)
                 rack (~> 2.0)
                 redis (>= 4.2.0)
-              sidekiq-pro (5.2.1)
-                connection_pool (>= 2.2.3)
-                sidekiq (>= 6.1.0)
               thread_safe (0.3.6)
               tzinfo (1.2.9)
                 thread_safe (~> 0.1)
               zeitwerk (2.4.2)
+
+          GEM
+            remote: https://gem.repo3/
+            specs:
+              sidekiq-pro (5.2.1)
+                connection_pool (>= 2.2.3)
+                sidekiq (>= 6.1.0)
 
           PLATFORMS
             #{specific_local_platform}
@@ -745,16 +806,6 @@ RSpec.describe "bundle install with gems on multiple sources" do
           BUNDLED WITH
              #{Bundler::VERSION}
         L
-      end
-
-      it "fails when running bundle update with an argument", :bundler => "3" do
-        initial_lockfile = lockfile
-
-        bundle "update concurrent-ruby", :artifice => "compact_index", :raise_on_error => false
-
-        expect(err).to include("Your lockfile contains a single rubygems source section with multiple remotes, which is insecure.")
-
-        expect(lockfile).to eq(initial_lockfile)
       end
     end
 

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -412,7 +412,7 @@ RSpec.describe "major deprecations" do
     pending "fails with a helpful error", :bundler => "3"
   end
 
-  context "bundle install with a lockfile with a single rubygems section with multiple remotes" do
+  context "bundle install in frozen mode with a lockfile with a single rubygems section with multiple remotes" do
     before do
       build_repo gem_repo3 do
         build_gem "rack", "0.9.1"
@@ -441,6 +441,8 @@ RSpec.describe "major deprecations" do
         BUNDLED WITH
            #{Bundler::VERSION}
       L
+
+      bundle "config set --local frozen true"
     end
 
     it "shows a deprecation", :bundler => "< 3" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

It's currently hard to update to the new lockfile format without updating all your gems at the same time. Bundler should do this for you whenever possible.

## What is your fix for the problem, implemented in this PR?

Even if the lockfile has merged GEM sections in the lockfile, we can still use separated sources and auto-update the format unless we are in frozen mode or the Gemfile actually has multiple global sources.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
