### PR TITLE
Fix `bundle outdated` edge case

### DIFF
--- a/bundler/lib/bundler/cli/outdated.rb
+++ b/bundler/lib/bundler/cli/outdated.rb
@@ -147,6 +147,8 @@ module Bundler
 
     def retrieve_active_spec(definition, current_spec)
       active_spec = definition.resolve.find_by_name_and_platform(current_spec.name, current_spec.platform)
+      return unless active_spec
+
       return active_spec if strict
 
       active_specs = active_spec.source.specs.search(current_spec.name).select {|spec| spec.match_platform(current_spec.platform) }.sort_by(&:version)

--- a/bundler/spec/commands/outdated_spec.rb
+++ b/bundler/spec/commands/outdated_spec.rb
@@ -1292,4 +1292,53 @@ RSpec.describe "bundle outdated" do
       expect(out).to end_with(expected_output)
     end
   end
+
+  context "when a gem is no longer a dependency after a full update" do
+    before do
+      build_repo4 do
+        build_gem "mini_portile2", "2.5.2" do |s|
+          s.add_dependency "net-ftp", "~> 0.1"
+        end
+
+        build_gem "mini_portile2", "2.5.3"
+
+        build_gem "net-ftp", "0.1.2"
+      end
+
+      gemfile <<~G
+        source "#{file_uri_for(gem_repo4)}"
+
+        gem "mini_portile2"
+      G
+
+      lockfile <<~L
+        GEM
+          remote: #{file_uri_for(gem_repo4)}/
+          specs:
+            mini_portile2 (2.5.2)
+              net-ftp (~> 0.1)
+            net-ftp (0.1.2)
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          mini_portile2
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+    end
+
+    it "works" do
+      bundle "outdated", :raise_on_error => false
+
+      expected_output = <<~TABLE.strip
+        Gem            Current  Latest  Requested  Groups
+        mini_portile2  2.5.2    2.5.3   >= 0       default
+      TABLE
+
+      expect(out).to end_with(expected_output)
+    end
+  end
 end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

When a gem is no longer a dependency after a full update, `bundle outdated` would crash due to a missing early return to cover that edge case.

## What is your fix for the problem, implemented in this PR?

Add the missing early return for this case. This was most likely introduced by 1d1d8a8f0816c9734cd0500da49df68cfa50bdc5.

Fixes #4646.
 
## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)