### PR TITLE
Fix `bundle update <gem>` sometimes hanging and `bundle lock --update` not being able to update an insecure lockfile to the new format if it requires downgrades

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -109,8 +109,8 @@ module Bundler
         @locked_platforms = []
       end
 
-      @locked_gem_sources = @locked_sources.select {|s| s.is_a?(Source::Rubygems) }
-      @multisource_allowed = @locked_gem_sources.any?(&:multiple_remotes?) && Bundler.frozen_bundle?
+      locked_gem_sources = @locked_sources.select {|s| s.is_a?(Source::Rubygems) }
+      @multisource_allowed = locked_gem_sources.any?(&:multiple_remotes?) && Bundler.frozen_bundle?
 
       if @multisource_allowed
         unless sources.aggregate_global_source?
@@ -503,9 +503,6 @@ module Bundler
 
     attr_reader :sources
     private :sources
-
-    attr_reader :locked_gem_sources
-    private :locked_gem_sources
 
     def nothing_changed?
       !@source_changes && !@dependency_changes && !@new_platform && !@path_changes && !@local_changes && !@locked_specs_incomplete_for_platform

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -119,7 +119,7 @@ module Bundler
           Bundler::SharedHelpers.major_deprecation 2, msg
         end
 
-        @sources.merged_gem_lockfile_sections!
+        @sources.merged_gem_lockfile_sections!(locked_gem_sources.first)
       end
 
       @unlock[:sources] ||= []

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -634,35 +634,11 @@ module Bundler
       end
     end
 
-    def converge_rubygems_sources
-      return false unless multisource_allowed?
-
-      return false if locked_gem_sources.empty?
-
-      # Get the RubyGems remotes from the Gemfile
-      actual_remotes = sources.rubygems_remotes
-      return false if actual_remotes.empty?
-
-      changes = false
-
-      # If there is a RubyGems source in both
-      locked_gem_sources.each do |locked_gem_source|
-        # Merge the remotes from the Gemfile into the Gemfile.lock
-        changes |= locked_gem_source.replace_remotes(actual_remotes, Bundler.settings[:allow_deployment_source_credential_changes])
-      end
-
-      changes
-    end
-
     def converge_sources
-      changes = false
-
-      changes |= converge_rubygems_sources
-
       # Replace the sources from the Gemfile with the sources from the Gemfile.lock,
       # if they exist in the Gemfile.lock and are `==`. If you can't find an equivalent
       # source in the Gemfile.lock, use the one from the Gemfile.
-      changes |= sources.replace_sources!(@locked_sources)
+      changes = sources.replace_sources!(@locked_sources)
 
       sources.all_sources.each do |source|
         # If the source is unlockable and the current command allows an unlock of

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -884,7 +884,7 @@ module Bundler
     end
 
     def additional_base_requirements_for_resolve
-      return [] unless @locked_gems && unlocking?
+      return [] unless @locked_gems && unlocking? && !sources.expired_sources?(@locked_gems.sources)
       dependencies_by_name = dependencies.inject({}) {|memo, dep| memo.update(dep.name => dep) }
       @locked_gems.specs.reduce({}) do |requirements, locked_spec|
         name = locked_spec.name

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -110,7 +110,7 @@ module Bundler
       end
 
       locked_gem_sources = @locked_sources.select {|s| s.is_a?(Source::Rubygems) }
-      @multisource_allowed = locked_gem_sources.any?(&:multiple_remotes?) && Bundler.frozen_bundle?
+      @multisource_allowed = locked_gem_sources.size == 1 && locked_gem_sources.first.multiple_remotes? && Bundler.frozen_bundle?
 
       if @multisource_allowed
         unless sources.aggregate_global_source?

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -252,19 +252,6 @@ module Bundler
         other_remotes.map(&method(:remove_auth)) == @remotes.map(&method(:remove_auth))
       end
 
-      def replace_remotes(other_remotes, allow_equivalent = false)
-        return false if other_remotes == @remotes
-
-        equivalent = allow_equivalent && equivalent_remotes?(other_remotes)
-
-        @remotes = []
-        other_remotes.reverse_each do |r|
-          add_remote r.to_s
-        end
-
-        !equivalent
-      end
-
       def spec_names
         if @allow_remote && dependency_api_available?
           remote_specs.spec_names

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -108,7 +108,7 @@ module Bundler
       if merged_gem_lockfile_sections?
         [combine_rubygems_sources]
       else
-        rubygems_sources.sort_by(&:to_s).uniq
+        rubygems_sources.sort_by(&:to_s)
       end
     end
 

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -117,8 +117,8 @@ module Bundler
     def replace_sources!(replacement_sources)
       return false if replacement_sources.empty?
 
-      [path_sources, git_sources, plugin_sources].each do |source_list|
-        source_list.map! do |source|
+      [path_sources, git_sources, plugin_sources].each do |sources|
+        sources.map! do |source|
           replacement_sources.find {|s| s == source } || source
         end
       end

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -115,7 +115,7 @@ module Bundler
 
     # Returns true if there are changes
     def replace_sources!(replacement_sources)
-      return true if replacement_sources.empty?
+      return false if replacement_sources.empty?
 
       [path_sources, git_sources, plugin_sources].each do |source_list|
         source_list.map! do |source|

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -123,9 +123,7 @@ module Bundler
         end
       end
 
-      return true if !equal_sources?(lock_sources, replacement_sources) && !equivalent_sources?(lock_sources, replacement_sources)
-
-      false
+      !equal_sources?(lock_sources, replacement_sources) && !equivalent_sources?(lock_sources, replacement_sources)
     end
 
     def local_only!

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -28,8 +28,9 @@ module Bundler
       @merged_gem_lockfile_sections
     end
 
-    def merged_gem_lockfile_sections!
+    def merged_gem_lockfile_sections!(replacement_source)
       @merged_gem_lockfile_sections = true
+      @global_rubygems_source = replacement_source
     end
 
     def aggregate_global_source?
@@ -121,10 +122,6 @@ module Bundler
           replacement_sources.find {|s| s == source } || source
         end
       end
-
-      replacement_rubygems = merged_gem_lockfile_sections? &&
-        replacement_sources.detect {|s| s.is_a?(Source::Rubygems) }
-      @global_rubygems_source = replacement_rubygems if replacement_rubygems
 
       return true if !equal_sources?(lock_sources, replacement_sources) && !equivalent_sources?(lock_sources, replacement_sources)
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

While investigating issues discussed at https://github.com/rubygems/rubygems/pull/4642 with upgrading the new lockfile format, I found this issue caused by the extra additional requirements bundler adds to avoid downgrading gems.

I was trying to tweak the code to still pass these additional requirements, but then I noticed that no specs fail if I completely stop doing that. Given that we started doing this by default only very recently (since bundler 2.2.16), but nobody has actually complained about this for a long time, I tend to think this has actually been fixed somewhere else, maybe in the resolver itself.

## What is your fix for the problem, implemented in this PR?

Since it causes other problems and removing it seems to cause no specs to fail, I'm considering to remove it.

NOTE: This PR also fixes #4596 as a side effect, not totally sure why, but we might want to add an extra realworld spec to cover that?

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
