### PR TITLE
Ignore any gemfiles in parent directories

### DIFF
--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -546,6 +546,10 @@ class Gem::TestCase < Test::Unit::TestCase
     Gem.pre_uninstall_hooks.clear
   end
 
+  def without_any_upwards_gemfiles
+    ENV["BUNDLE_GEMFILE"] = File.join(@tempdir, "Gemfile")
+  end
+
   ##
   # A git_gem is used with a gem dependencies file.  The gem created here
   # has no files, just a gem specification for the given +name+ and +version+.

--- a/test/rubygems/test_gem_bundler_version_finder.rb
+++ b/test/rubygems/test_gem_bundler_version_finder.rb
@@ -6,9 +6,8 @@ class TestGemBundlerVersionFinder < Gem::TestCase
     super
 
     @argv = ARGV.dup
-    # ignore any gemfiles in parent directories
-    ENV["BUNDLE_GEMFILE"] = @tmp + "/Gemfile"
     @dollar_0 = $0
+    without_any_upwards_gemfiles
   end
 
   def teardown

--- a/test/rubygems/test_gem_bundler_version_finder.rb
+++ b/test/rubygems/test_gem_bundler_version_finder.rb
@@ -8,12 +8,11 @@ class TestGemBundlerVersionFinder < Gem::TestCase
     @argv = ARGV.dup
     ENV.delete("BUNDLER_VERSION")
     # ignore any gemfiles in parent directories
-    ENV["BUNDLE_GEMFILE"] = Dir.mktmpdir("nobundle") + "/Gemfile"
+    ENV["BUNDLE_GEMFILE"] = @tmp + "/Gemfile"
     @dollar_0 = $0
   end
 
   def teardown
-    Dir.rmdir(File.dirname(ENV["BUNDLE_GEMFILE"]))
     ARGV.replace @argv
     $0 = @dollar_0
 

--- a/test/rubygems/test_gem_bundler_version_finder.rb
+++ b/test/rubygems/test_gem_bundler_version_finder.rb
@@ -6,7 +6,6 @@ class TestGemBundlerVersionFinder < Gem::TestCase
     super
 
     @argv = ARGV.dup
-    ENV.delete("BUNDLER_VERSION")
     # ignore any gemfiles in parent directories
     ENV["BUNDLE_GEMFILE"] = @tmp + "/Gemfile"
     @dollar_0 = $0

--- a/test/rubygems/test_gem_bundler_version_finder.rb
+++ b/test/rubygems/test_gem_bundler_version_finder.rb
@@ -6,7 +6,6 @@ class TestGemBundlerVersionFinder < Gem::TestCase
     super
 
     @argv = ARGV.dup
-    @env = ENV.to_hash.clone
     ENV.delete("BUNDLER_VERSION")
     # ignore any gemfiles in parent directories
     ENV["BUNDLE_GEMFILE"] = Dir.mktmpdir("nobundle") + "/Gemfile"
@@ -16,7 +15,6 @@ class TestGemBundlerVersionFinder < Gem::TestCase
   def teardown
     Dir.rmdir(File.dirname(ENV["BUNDLE_GEMFILE"]))
     ARGV.replace @argv
-    ENV.replace @env
     $0 = @dollar_0
 
     super

--- a/test/rubygems/test_gem_bundler_version_finder.rb
+++ b/test/rubygems/test_gem_bundler_version_finder.rb
@@ -8,10 +8,13 @@ class TestGemBundlerVersionFinder < Gem::TestCase
     @argv = ARGV.dup
     @env = ENV.to_hash.clone
     ENV.delete("BUNDLER_VERSION")
+    # ignore any gemfiles in parent directories
+    ENV["BUNDLE_GEMFILE"] = Dir.mktmpdir("nobundle") + "/Gemfile"
     @dollar_0 = $0
   end
 
   def teardown
+    Dir.rmdir(File.dirname(ENV["BUNDLE_GEMFILE"]))
     ARGV.replace @argv
     ENV.replace @env
     $0 = @dollar_0

--- a/test/rubygems/test_gem_dependency.rb
+++ b/test/rubygems/test_gem_dependency.rb
@@ -338,7 +338,7 @@ class TestGemDependency < Gem::TestCase
   end
 
   def test_to_specs_respects_bundler_version
-    ENV["BUNDLE_GEMFILE"] = Dir.mktmpdir("nobundle") + "/Gemfile"
+    ENV["BUNDLE_GEMFILE"] = @tmp + "/Gemfile"
 
     b = util_spec 'bundler', '2.0.0.pre.1'
     b_1 = util_spec 'bundler', '1'
@@ -365,8 +365,6 @@ class TestGemDependency < Gem::TestCase
     Gem::BundlerVersionFinder.stub(:bundler_version_with_reason, ["2.0.0.pre.1", "reason"]) do
       assert_equal [b], dep.to_specs
     end
-  ensure
-    Dir.rmdir(File.dirname(ENV["BUNDLE_GEMFILE"]))
   end
 
   def test_to_specs_indicates_total_gem_set_size

--- a/test/rubygems/test_gem_dependency.rb
+++ b/test/rubygems/test_gem_dependency.rb
@@ -338,6 +338,9 @@ class TestGemDependency < Gem::TestCase
   end
 
   def test_to_specs_respects_bundler_version
+    gemfile = ENV["BUNDLE_GEMFILE"]
+    ENV["BUNDLE_GEMFILE"] = Dir.mktmpdir("nobundle") + "/Gemfile"
+
     b = util_spec 'bundler', '2.0.0.pre.1'
     b_1 = util_spec 'bundler', '1'
     install_specs b, b_1
@@ -363,6 +366,9 @@ class TestGemDependency < Gem::TestCase
     Gem::BundlerVersionFinder.stub(:bundler_version_with_reason, ["2.0.0.pre.1", "reason"]) do
       assert_equal [b], dep.to_specs
     end
+  ensure
+    Dir.rmdir(File.dirname(ENV["BUNDLE_GEMFILE"]))
+    ENV["BUNDLE_GEMFILE"] = gemfile
   end
 
   def test_to_specs_indicates_total_gem_set_size

--- a/test/rubygems/test_gem_dependency.rb
+++ b/test/rubygems/test_gem_dependency.rb
@@ -338,7 +338,6 @@ class TestGemDependency < Gem::TestCase
   end
 
   def test_to_specs_respects_bundler_version
-    gemfile = ENV["BUNDLE_GEMFILE"]
     ENV["BUNDLE_GEMFILE"] = Dir.mktmpdir("nobundle") + "/Gemfile"
 
     b = util_spec 'bundler', '2.0.0.pre.1'
@@ -368,7 +367,6 @@ class TestGemDependency < Gem::TestCase
     end
   ensure
     Dir.rmdir(File.dirname(ENV["BUNDLE_GEMFILE"]))
-    ENV["BUNDLE_GEMFILE"] = gemfile
   end
 
   def test_to_specs_indicates_total_gem_set_size

--- a/test/rubygems/test_gem_dependency.rb
+++ b/test/rubygems/test_gem_dependency.rb
@@ -3,6 +3,12 @@ require_relative 'helper'
 require 'rubygems/dependency'
 
 class TestGemDependency < Gem::TestCase
+  def setup
+    super
+
+    without_any_upwards_gemfiles
+  end
+
   def test_initialize
     d = dep "pkg", "> 1.0"
 
@@ -338,8 +344,6 @@ class TestGemDependency < Gem::TestCase
   end
 
   def test_to_specs_respects_bundler_version
-    ENV["BUNDLE_GEMFILE"] = @tmp + "/Gemfile"
-
     b = util_spec 'bundler', '2.0.0.pre.1'
     b_1 = util_spec 'bundler', '1'
     install_specs b, b_1

--- a/test/rubygems/test_kernel.rb
+++ b/test/rubygems/test_kernel.rb
@@ -108,11 +108,17 @@ class TestKernel < Gem::TestCase
   end
 
   def test_gem_bundler
+    gemfile = ENV["BUNDLE_GEMFILE"]
+    ENV["BUNDLE_GEMFILE"] = Dir.mktmpdir("nobundle") + "/Gemfile"
+
     quick_gem 'bundler', '1'
     quick_gem 'bundler', '2.a'
 
     assert gem('bundler')
     assert $:.any? {|p| %r{bundler-1/lib} =~ p }
+  ensure
+    Dir.rmdir(File.dirname(ENV["BUNDLE_GEMFILE"]))
+    ENV["BUNDLE_GEMFILE"] = gemfile
   end
 
   def test_gem_bundler_missing_bundler_version

--- a/test/rubygems/test_kernel.rb
+++ b/test/rubygems/test_kernel.rb
@@ -108,7 +108,6 @@ class TestKernel < Gem::TestCase
   end
 
   def test_gem_bundler
-    gemfile = ENV["BUNDLE_GEMFILE"]
     ENV["BUNDLE_GEMFILE"] = Dir.mktmpdir("nobundle") + "/Gemfile"
 
     quick_gem 'bundler', '1'
@@ -118,7 +117,6 @@ class TestKernel < Gem::TestCase
     assert $:.any? {|p| %r{bundler-1/lib} =~ p }
   ensure
     Dir.rmdir(File.dirname(ENV["BUNDLE_GEMFILE"]))
-    ENV["BUNDLE_GEMFILE"] = gemfile
   end
 
   def test_gem_bundler_missing_bundler_version

--- a/test/rubygems/test_kernel.rb
+++ b/test/rubygems/test_kernel.rb
@@ -108,15 +108,13 @@ class TestKernel < Gem::TestCase
   end
 
   def test_gem_bundler
-    ENV["BUNDLE_GEMFILE"] = Dir.mktmpdir("nobundle") + "/Gemfile"
+    ENV["BUNDLE_GEMFILE"] = @tmp + "/Gemfile"
 
     quick_gem 'bundler', '1'
     quick_gem 'bundler', '2.a'
 
     assert gem('bundler')
     assert $:.any? {|p| %r{bundler-1/lib} =~ p }
-  ensure
-    Dir.rmdir(File.dirname(ENV["BUNDLE_GEMFILE"]))
   end
 
   def test_gem_bundler_missing_bundler_version

--- a/test/rubygems/test_kernel.rb
+++ b/test/rubygems/test_kernel.rb
@@ -8,6 +8,8 @@ class TestKernel < Gem::TestCase
     @old_path = $:.dup
 
     util_make_gems
+
+    without_any_upwards_gemfiles
   end
 
   def teardown
@@ -108,8 +110,6 @@ class TestKernel < Gem::TestCase
   end
 
   def test_gem_bundler
-    ENV["BUNDLE_GEMFILE"] = @tmp + "/Gemfile"
-
     quick_gem 'bundler', '1'
     quick_gem 'bundler', '2.a'
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When `Gemfile` and its lockfile exist in any upper directories, e.g., `~/Gemfile.lock`, the lockfile's content is read and the `Gem::BundlerVersionFinder` related tests fail.

## What is your fix for the problem, implemented in this PR?

By setting `ENV["BUNDLE_GEMFILE"]` to an nonexistent file path under an empty directory, skip to traverse parent directories.

## Make sure the following tasks are checked

Because this is a bug-fix of tests, no new tests.

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
