### PR TITLE
Fix repeated `by` on CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,7 @@ where it is in the process from being submitted to being closed.  These are
 listed in rough  progression order from submitted to closed.
 
 *   **triage** - This is an issue or pull request that needs to be properly
-    labeled by by a maintainer.
+    labeled by a maintainer.
 *   **confirmed** - This issue/pull request has been accepted as valid, but is
     not yet immediately ready for work.
 *   **ready** - An issue that is available for collaboration. This issue


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

There is an error in CONTRIBUTING.md, `by` is repeated.

## What is your fix for the problem, implemented in this PR?

I removed the repetition

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] ~Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes~ 
- [ ] ~Write code to solve the problem~
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
