### PR TITLE
Add better specification policy error description

### DIFF
--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -124,6 +124,7 @@ class Gem::SpecificationPolicy
     end
 
     metadata.each do |key, value|
+      entry = "metadata['#{key}']"
       if !key.kind_of?(String)
         error "metadata keys must be a String"
       end
@@ -133,16 +134,16 @@ class Gem::SpecificationPolicy
       end
 
       if !value.kind_of?(String)
-        error "metadata values must be a String"
+        error "#{entry} value must be a String"
       end
 
       if value.size > 1024
-        error "metadata value too large (#{value.size} > 1024)"
+        error "#{entry} value too large (#{value.size} > 1024)"
       end
 
       if METADATA_LINK_KEYS.include? key
         if value !~ VALID_URI_PATTERN
-          error "metadata['#{key}'] has invalid link: #{value.inspect}"
+          error "#{entry} has invalid link: #{value.inspect}"
         end
       end
     end

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -130,7 +130,7 @@ class Gem::SpecificationPolicy
       end
 
       if key.size > 128
-        error "metadata key too large (#{key.size} > 128)"
+        error "metadata key is too large (#{key.size} > 128)"
       end
 
       if !value.kind_of?(String)
@@ -138,7 +138,7 @@ class Gem::SpecificationPolicy
       end
 
       if value.size > 1024
-        error "#{entry} value too large (#{value.size} > 1024)"
+        error "#{entry} value is too large (#{value.size} > 1024)"
       end
 
       if METADATA_LINK_KEYS.include? key

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3629,7 +3629,7 @@ Did you mean 'Ruby'?
         @m2.validate
       end
 
-      assert_equal "metadata values must be a String", e.message
+      assert_equal "metadata['fail'] value must be a String", e.message
     end
   end
 
@@ -3646,7 +3646,7 @@ Did you mean 'Ruby'?
         @m2.validate
       end
 
-      assert_equal "metadata value too large (1025 > 1024)", e.message
+      assert_equal "metadata['fail'] value too large (1025 > 1024)", e.message
     end
   end
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3612,7 +3612,7 @@ Did you mean 'Ruby'?
         @m2.validate
       end
 
-      assert_equal "metadata key too large (129 > 128)", e.message
+      assert_equal "metadata key is too large (129 > 128)", e.message
     end
   end
 
@@ -3646,7 +3646,7 @@ Did you mean 'Ruby'?
         @m2.validate
       end
 
-      assert_equal "metadata['fail'] value too large (1025 > 1024)", e.message
+      assert_equal "metadata['fail'] value is too large (1025 > 1024)", e.message
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Make easier find what key of metadata from `gemspec` is invalid. 

## What is your fix for the problem, implemented in this PR?

Print `metadata['#{key}']` for string type and length value checks like for link keys.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
