### PR TITLE
Add the most recent licenses from spdx.org

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -389,6 +389,11 @@ task :check_manifest do
   end
 end
 
+desc "Update License list from SPDX.org"
+task :update_licenses do
+  load "util/generate_spdx_license_list.rb"
+end
+
 namespace :bundler do
   task :build_metadata do
     chdir('bundler') { sh "rake build_metadata" }

--- a/lib/rubygems/util/licenses.rb
+++ b/lib/rubygems/util/licenses.rb
@@ -18,6 +18,8 @@ class Gem::Licenses
     AFL-2.1
     AFL-3.0
     AGPL-1.0
+    AGPL-1.0-only
+    AGPL-1.0-or-later
     AGPL-3.0
     AGPL-3.0-only
     AGPL-3.0-or-later
@@ -25,6 +27,7 @@ class Gem::Licenses
     AML
     AMPAS
     ANTLR-PD
+    ANTLR-PD-fallback
     APAFML
     APL-1.0
     APSL-1.0
@@ -48,29 +51,41 @@ class Gem::Licenses
     BSD-2-Clause-FreeBSD
     BSD-2-Clause-NetBSD
     BSD-2-Clause-Patent
+    BSD-2-Clause-Views
     BSD-3-Clause
     BSD-3-Clause-Attribution
     BSD-3-Clause-Clear
     BSD-3-Clause-LBNL
+    BSD-3-Clause-Modification
+    BSD-3-Clause-No-Military-License
     BSD-3-Clause-No-Nuclear-License
     BSD-3-Clause-No-Nuclear-License-2014
     BSD-3-Clause-No-Nuclear-Warranty
+    BSD-3-Clause-Open-MPI
     BSD-4-Clause
+    BSD-4-Clause-Shortened
     BSD-4-Clause-UC
     BSD-Protection
     BSD-Source-Code
     BSL-1.0
+    BUSL-1.1
     Bahyph
     Barr
     Beerware
     BitTorrent-1.0
     BitTorrent-1.1
+    BlueOak-1.0.0
     Borceux
+    C-UDA-1.0
+    CAL-1.0
+    CAL-1.0-Combined-Work-Exception
     CATOSL-1.1
     CC-BY-1.0
     CC-BY-2.0
     CC-BY-2.5
     CC-BY-3.0
+    CC-BY-3.0-AT
+    CC-BY-3.0-US
     CC-BY-4.0
     CC-BY-NC-1.0
     CC-BY-NC-2.0
@@ -81,6 +96,7 @@ class Gem::Licenses
     CC-BY-NC-ND-2.0
     CC-BY-NC-ND-2.5
     CC-BY-NC-ND-3.0
+    CC-BY-NC-ND-3.0-IGO
     CC-BY-NC-ND-4.0
     CC-BY-NC-SA-1.0
     CC-BY-NC-SA-2.0
@@ -94,12 +110,17 @@ class Gem::Licenses
     CC-BY-ND-4.0
     CC-BY-SA-1.0
     CC-BY-SA-2.0
+    CC-BY-SA-2.0-UK
+    CC-BY-SA-2.1-JP
     CC-BY-SA-2.5
     CC-BY-SA-3.0
+    CC-BY-SA-3.0-AT
     CC-BY-SA-4.0
+    CC-PDDC
     CC0-1.0
     CDDL-1.0
     CDDL-1.1
+    CDL-1.0
     CDLA-Permissive-1.0
     CDLA-Sharing-1.0
     CECILL-1.0
@@ -108,6 +129,11 @@ class Gem::Licenses
     CECILL-2.1
     CECILL-B
     CECILL-C
+    CERN-OHL-1.1
+    CERN-OHL-1.2
+    CERN-OHL-P-2.0
+    CERN-OHL-S-2.0
+    CERN-OHL-W-2.0
     CNRI-Jython
     CNRI-Python
     CNRI-Python-GPL-Compatible
@@ -123,12 +149,14 @@ class Gem::Licenses
     Cube
     D-FSL-1.0
     DOC
+    DRL-1.0
     DSDP
     Dotseqn
     ECL-1.0
     ECL-2.0
     EFL-1.0
     EFL-2.0
+    EPICS
     EPL-1.0
     EPL-2.0
     EUDatagrid
@@ -144,17 +172,32 @@ class Gem::Licenses
     FTL
     Fair
     Frameworx-1.0
+    FreeBSD-DOC
     FreeImage
+    GD
     GFDL-1.1
+    GFDL-1.1-invariants-only
+    GFDL-1.1-invariants-or-later
+    GFDL-1.1-no-invariants-only
+    GFDL-1.1-no-invariants-or-later
     GFDL-1.1-only
     GFDL-1.1-or-later
     GFDL-1.2
+    GFDL-1.2-invariants-only
+    GFDL-1.2-invariants-or-later
+    GFDL-1.2-no-invariants-only
+    GFDL-1.2-no-invariants-or-later
     GFDL-1.2-only
     GFDL-1.2-or-later
     GFDL-1.3
+    GFDL-1.3-invariants-only
+    GFDL-1.3-invariants-or-later
+    GFDL-1.3-no-invariants-only
+    GFDL-1.3-no-invariants-or-later
     GFDL-1.3-only
     GFDL-1.3-or-later
     GL2PS
+    GLWTPL
     GPL-1.0
     GPL-1.0+
     GPL-1.0-only
@@ -178,7 +221,10 @@ class Gem::Licenses
     Glide
     Glulxe
     HPND
+    HPND-sell-variant
+    HTMLTIDY
     HaskellReport
+    Hippocratic-2.1
     IBM-pibs
     ICU
     IJG
@@ -191,6 +237,7 @@ class Gem::Licenses
     Intel
     Intel-ACPI
     Interbase-1.0
+    JPNIC
     JSON
     JasPer-2.0
     LAL-1.2
@@ -221,11 +268,15 @@ class Gem::Licenses
     LiLiQ-R-1.1
     LiLiQ-Rplus-1.1
     Libpng
+    Linux-OpenIB
     MIT
+    MIT-0
     MIT-CMU
+    MIT-Modern-Variant
     MIT-advertising
     MIT-enna
     MIT-feh
+    MIT-open-group
     MITNFA
     MPL-1.0
     MPL-1.1
@@ -237,12 +288,18 @@ class Gem::Licenses
     MakeIndex
     MirOS
     Motosoto
+    MulanPSL-1.0
+    MulanPSL-2.0
     Multics
     Mup
+    NAIST-2003
     NASA-1.3
     NBPL-1.0
+    NCGL-UK-2.0
     NCSA
     NGPL
+    NIST-PD
+    NIST-PD-fallback
     NLOD-1.0
     NLPL
     NOSL
@@ -251,6 +308,7 @@ class Gem::Licenses
     NPOSL-3.0
     NRL
     NTP
+    NTP-0
     Naumen
     Net-SNMP
     NetCDF
@@ -258,11 +316,23 @@ class Gem::Licenses
     Nokia
     Noweb
     Nunit
+    O-UDA-1.0
     OCCT-PL
     OCLC-2.0
+    ODC-By-1.0
     ODbL-1.0
     OFL-1.0
+    OFL-1.0-RFN
+    OFL-1.0-no-RFN
     OFL-1.1
+    OFL-1.1-RFN
+    OFL-1.1-no-RFN
+    OGC-1.0
+    OGDL-Taiwan-1.0
+    OGL-Canada-2.0
+    OGL-UK-1.0
+    OGL-UK-2.0
+    OGL-UK-3.0
     OGTSL
     OLDAP-1.1
     OLDAP-1.2
@@ -292,7 +362,12 @@ class Gem::Licenses
     PDDL-1.0
     PHP-3.0
     PHP-3.01
+    PSF-2.0
+    Parity-6.0.0
+    Parity-7.0.0
     Plexus
+    PolyForm-Noncommercial-1.0.0
+    PolyForm-Small-Business-1.0.0
     PostgreSQL
     Python-2.0
     QPL-1.0
@@ -310,15 +385,21 @@ class Gem::Licenses
     SGI-B-1.0
     SGI-B-1.1
     SGI-B-2.0
+    SHL-0.5
+    SHL-0.51
     SISSL
     SISSL-1.2
     SMLNJ
     SMPPL
     SNIA
     SPL-1.0
+    SSH-OpenSSH
+    SSH-short
+    SSPL-1.0
     SWL
     Saxpath
     Sendmail
+    Sendmail-8.23
     SimPL-2.0
     Sleepycat
     Spencer-86
@@ -326,11 +407,15 @@ class Gem::Licenses
     Spencer-99
     StandardML-NJ
     SugarCRM-1.1.3
+    TAPR-OHL-1.0
     TCL
     TCP-wrappers
     TMate
     TORQUE-1.1
     TOSL
+    TU-Berlin-1.0
+    TU-Berlin-2.0
+    UCL-1.0
     UPL-1.0
     Unicode-DFS-2015
     Unicode-DFS-2016
@@ -360,16 +445,22 @@ class Gem::Licenses
     Zimbra-1.3
     Zimbra-1.4
     Zlib
+    blessing
     bzip2-1.0.5
     bzip2-1.0.6
+    copyleft-next-0.3.0
+    copyleft-next-0.3.1
     curl
     diffmark
     dvipdfm
     eCos-2.0
     eGenix
+    etalab-2.0
     gSOAP-1.3b
     gnuplot
     iMatix
+    libpng-2.0
+    libselinux-1.0
     libtiff
     mpich2
     psfrag
@@ -395,12 +486,26 @@ class Gem::Licenses
     Font-exception-2.0
     GCC-exception-2.0
     GCC-exception-3.1
+    GPL-3.0-linking-exception
+    GPL-3.0-linking-source-exception
+    GPL-CC-1.0
+    LGPL-3.0-linking-exception
+    LLVM-exception
     LZMA-exception
     Libtool-exception
     Linux-syscall-note
     Nokia-Qt-exception-1.1
     OCCT-exception-1.0
+    OCaml-LGPL-linking-exception
+    OpenJDK-assembly-exception-1.0
+    PS-or-PDF-font-exception-20170817
+    Qt-GPL-exception-1.0
+    Qt-LGPL-exception-1.1
     Qwt-exception-1.0
+    SHL-2.0
+    SHL-2.1
+    Swift-exception
+    Universal-FOSS-exception-1.0
     WxWindows-exception-3.1
     eCos-exception-2.0
     freertos-exception-2.0

--- a/lib/rubygems/util/licenses.rb
+++ b/lib/rubygems/util/licenses.rb
@@ -413,10 +413,10 @@ class Gem::Licenses
 
   REGEXP = %r{
     \A
-    (
+    (?:
       #{Regexp.union(LICENSE_IDENTIFIERS)}
       \+?
-      (\s WITH \s #{Regexp.union(EXCEPTION_IDENTIFIERS)})?
+      (?:\s WITH \s #{Regexp.union(EXCEPTION_IDENTIFIERS)})?
       | #{NONSTANDARD}
     )
     \Z

--- a/util/generate_spdx_license_list.rb
+++ b/util/generate_spdx_license_list.rb
@@ -18,21 +18,20 @@ open 'lib/rubygems/util/licenses.rb', 'w' do |io|
 require 'rubygems/text'
 
 class Gem::Licenses
-
   extend Gem::Text
 
   NONSTANDARD = 'Nonstandard'.freeze
 
   # Software Package Data Exchange (SPDX) standard open-source software
   # license identifiers
-  LICENSE_IDENTIFIERS = %w(
+  LICENSE_IDENTIFIERS = %w[
     #{licenses.sort.join "\n    "}
-  ).freeze
+  ].freeze
 
   # exception identifiers
-  EXCEPTION_IDENTIFIERS = %w(
+  EXCEPTION_IDENTIFIERS = %w[
     #{exceptions.sort.join "\n    "}
-  ).freeze
+  ].freeze
 
   REGEXP = %r{
     \\A
@@ -57,7 +56,6 @@ class Gem::Licenses
     return unless lowest < license.size
     by_distance[lowest]
   end
-
 end
   RUBY
 end

--- a/util/generate_spdx_license_list.rb
+++ b/util/generate_spdx_license_list.rb
@@ -35,10 +35,10 @@ class Gem::Licenses
 
   REGEXP = %r{
     \\A
-    (
+    (?:
       \#{Regexp.union(LICENSE_IDENTIFIERS)}
       \\+?
-      (\\s WITH \\s \#{Regexp.union(EXCEPTION_IDENTIFIERS)})?
+      (?:\\s WITH \\s \#{Regexp.union(EXCEPTION_IDENTIFIERS)})?
       | \#{NONSTANDARD}
     )
     \\Z


### PR DESCRIPTION
The lists in `lib/rubygems/util/licenses.rb` seem outdated.

## What was the end-user or developer problem that led to this PR?

Cannot select licenses which are recently added to SPDX.

## What is your fix for the problem, implemented in this PR?

Achieve the list from SPDX repository.
As I don't guess  the list will update frequently, added the rake task to do it but not run automatically.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
