### PR TITLE
Create credentials folder when setting API keys if not there yet

### DIFF
--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -320,7 +320,7 @@ if you believe they were disclosed to a third party.
     config = load_file(credentials_path).merge(host => api_key)
 
     dirname = File.dirname credentials_path
-    Dir.mkdir(dirname) unless File.exist? dirname
+    FileUtils.mkdir_p(dirname) unless File.exist? dirname
 
     Gem.load_yaml
 

--- a/test/rubygems/test_gem_commands_push_command.rb
+++ b/test/rubygems/test_gem_commands_push_command.rb
@@ -155,7 +155,6 @@ class TestGemCommandsPushCommand < Gem::TestCase
       @host => @api_key,
     }
 
-    FileUtils.mkdir_p File.dirname Gem.configuration.credentials_path
     File.open Gem.configuration.credentials_path, 'w' do |f|
       f.write keys.to_yaml
     end
@@ -190,7 +189,6 @@ class TestGemCommandsPushCommand < Gem::TestCase
       @host => @api_key,
     }
 
-    FileUtils.mkdir_p File.dirname Gem.configuration.credentials_path
     File.open Gem.configuration.credentials_path, 'w' do |f|
       f.write keys.to_yaml
     end
@@ -232,7 +230,6 @@ class TestGemCommandsPushCommand < Gem::TestCase
       :rubygems_api_key => @api_key,
     }
 
-    FileUtils.mkdir_p File.dirname Gem.configuration.credentials_path
     File.open Gem.configuration.credentials_path, 'w' do |f|
       f.write keys.to_yaml
     end
@@ -274,7 +271,6 @@ class TestGemCommandsPushCommand < Gem::TestCase
       @host => @api_key,
     }
 
-    FileUtils.mkdir_p File.dirname Gem.configuration.credentials_path
     File.open Gem.configuration.credentials_path, 'w' do |f|
       f.write keys.to_yaml
     end
@@ -305,7 +301,6 @@ class TestGemCommandsPushCommand < Gem::TestCase
       host => api_key,
     }
 
-    FileUtils.mkdir_p File.dirname Gem.configuration.credentials_path
     File.open Gem.configuration.credentials_path, 'w' do |f|
       f.write keys.to_yaml
     end

--- a/test/rubygems/test_gem_commands_signin_command.rb
+++ b/test/rubygems/test_gem_commands_signin_command.rb
@@ -26,6 +26,13 @@ class TestGemCommandsSigninCommand < Gem::TestCase
     assert_match %r{Signed in.}, sign_in_ui.output
   end
 
+  def test_execute_when_not_already_signed_in_and_not_preexisting_credentials_folder
+    FileUtils.rm Gem.configuration.credentials_path
+
+    sign_in_ui = util_capture { @cmd.execute }
+    assert_match %r{Signed in.}, sign_in_ui.output
+  end
+
   def test_execute_when_already_signed_in_with_same_host
     host = 'http://some-gemcutter-compatible-host.org'
 

--- a/test/rubygems/test_gem_gemcutter_utilities.rb
+++ b/test/rubygems/test_gem_gemcutter_utilities.rb
@@ -35,8 +35,6 @@ class TestGemGemcutterUtilities < Gem::TestCase
       "http://rubygems.engineyard.com" => "EYKEY",
     }
 
-    FileUtils.mkdir_p File.dirname Gem.configuration.credentials_path
-
     File.open Gem.configuration.credentials_path, 'w' do |f|
       f.write keys.to_yaml
     end
@@ -50,7 +48,6 @@ class TestGemGemcutterUtilities < Gem::TestCase
 
   def test_api_key
     keys = { :rubygems_api_key => 'KEY' }
-    FileUtils.mkdir_p File.dirname Gem.configuration.credentials_path
 
     File.open Gem.configuration.credentials_path, 'w' do |f|
       f.write keys.to_yaml
@@ -63,7 +60,6 @@ class TestGemGemcutterUtilities < Gem::TestCase
 
   def test_api_key_override
     keys = { :rubygems_api_key => 'KEY', :other => 'OTHER' }
-    FileUtils.mkdir_p File.dirname Gem.configuration.credentials_path
 
     File.open Gem.configuration.credentials_path, 'w' do |f|
       f.write keys.to_yaml
@@ -168,7 +164,6 @@ class TestGemGemcutterUtilities < Gem::TestCase
     api_key       = 'a5fdbb6ba150cbb83aad2bb2fede64cf040453903'
     other_api_key = 'f46dbb18bb6a9c97cdc61b5b85c186a17403cdcbf'
 
-    FileUtils.mkdir_p File.dirname(Gem.configuration.credentials_path)
     File.open Gem.configuration.credentials_path, 'w' do |f|
       f.write Hash[:other_api_key, other_api_key].to_yaml
     end
@@ -246,7 +241,6 @@ class TestGemGemcutterUtilities < Gem::TestCase
 
   def test_verify_api_key
     keys = {:other => 'a5fdbb6ba150cbb83aad2bb2fede64cf040453903'}
-    FileUtils.mkdir_p File.dirname(Gem.configuration.credentials_path)
     File.open Gem.configuration.credentials_path, 'w' do |f|
       f.write keys.to_yaml
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

On Windows, it may happen that the `~/.local/share` folder does not exist, and that will make rubygems crash on `gem push` when about to save API keys to disk.

## What is your fix for the problem, implemented in this PR?

Make sure to create that folder before using it.

Fixes #4654.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
