### PR TITLE
Use a more limited number of threads when fetching in parallel from the Compact Index API

### DIFF
--- a/bundler/lib/bundler/fetcher/compact_index.rb
+++ b/bundler/lib/bundler/fetcher/compact_index.rb
@@ -116,7 +116,7 @@ module Bundler
       def bundle_worker(func = nil)
         @bundle_worker ||= begin
           worker_name = "Compact Index (#{display_uri.host})"
-          Bundler::Worker.new(Bundler.current_ruby.rbx? ? 1 : 25, worker_name, func)
+          Bundler::Worker.new(Bundler.settings.processor_count, worker_name, func)
         end
         @bundle_worker.tap do |worker|
           worker.instance_variable_set(:@func, func) if func

--- a/bundler/lib/bundler/installer.rb
+++ b/bundler/lib/bundler/installer.rb
@@ -222,14 +222,7 @@ module Bundler
       # Parallelization has some issues on Windows, so it's not yet the default
       return 1 if Gem.win_platform?
 
-      processor_count
-    end
-
-    def processor_count
-      require "etc"
-      Etc.nprocessors
-    rescue StandardError
-      1
+      Bundler.settings.processor_count
     end
 
     def load_plugins

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -209,6 +209,13 @@ module Bundler
       locations
     end
 
+    def processor_count
+      require "etc"
+      Etc.nprocessors
+    rescue StandardError
+      1
+    end
+
     # for legacy reasons, in Bundler 2, we do not respect :disable_shared_gems
     def path
       configs.each do |_level, settings|


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The currently hardcoded 25 is too much and seems to cause some systems to even run out of memory.

## What is your fix for the problem, implemented in this PR?

I chose the use the number of available processors here rather than an arbitrary hardcoded number.

I would expect this to fix #4666 and fix https://github.com/rubygems/rubygems/issues/4353.

It also removes the only rubinius specific code in the repository. We don't really support rubinius so it doesn't make sense to keep those different code branches.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
