### PR TITLE
[PoC] add flag to raise an error for a multisource lockfile

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -232,6 +232,8 @@ module Bundler
       "Specify a different path than the system default ($BUNDLE_PATH or $GEM_HOME).#{" Bundler will remember this value for future installs on this machine" unless Bundler.feature_flag.forget_cli_options?}"
     method_option "quiet", :type => :boolean, :banner =>
       "Only output warnings and errors."
+    method_option "fail-on-multisource", :type => :boolean, :banner =>
+      "Fails bundle install if lockfile contains multiple primary sources"
     method_option "shebang", :type => :string, :banner =>
       "Specify a different shebang executable name than the default (usually 'ruby')"
     method_option "standalone", :type => :array, :lazy_default => [], :banner =>

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -57,6 +57,13 @@ module Bundler
       definition = Bundler.definition
       definition.validate_runtime!
 
+      if options["fail-on-multisource"] && Bundler.definition.disable_multisource?
+        msg = "This Gemfile.lock file contains multiple primary sources. " \
+          "Each source after the first must include a block to indicate which gems " \
+          "should come from that source"
+        raise GemfileEvalError, msg
+      end
+
       installer = Installer.install(Bundler.root, definition, options)
       Bundler.load.cache if Bundler.app_cache.exist? && !options["no-cache"] && !Bundler.frozen_bundle?
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Bundler 2.2.18 fixed an issue regarding dependency confusion https://github.com/rubygems/rubygems/pull/4609. However, there isn't an easy way to make sure that a Gemfile.lock file adheres to the new format. We would like the option to fail any `bundle install` that encounters the old multisource lockfile format. This is particularly useful for our CI and CD environment since it would prevent a compromised service to be deployed.

## What is your fix for the problem, implemented in this PR?

I'm introducing a new flag `fail-on-multisource`, that checks whether multiple sources have been defined for the same gems. If that is the case a failure is being raised.

Is this the best method of solving it? I saw there is [some code behind a feature flag](https://github.com/rubygems/rubygems/blob/96e5cff3df491c4d943186804c6d03b57fcb459b/bundler/lib/bundler/dsl.rb#L463-L468) that requires sources to be specified in the Gemfile. If bundler 3 is planned on deprecating the old lockfile format maybe it makes sense to [raise an issue in the definition file](https://github.com/rubygems/rubygems/blob/master/bundler/lib/bundler/definition.rb#L117-L123) by providing a feature flag?

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
