### PR TITLE
Fix `bundle install --local` hitting the network when `cache_all_platforms` configured

### DIFF
--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -58,7 +58,10 @@ module Bundler
       definition.validate_runtime!
 
       installer = Installer.install(Bundler.root, definition, options)
-      Bundler.load.cache if Bundler.app_cache.exist? && !options["no-cache"] && !Bundler.frozen_bundle?
+
+      Bundler.settings.temporary(:cache_all_platforms => options[:local] ? false : Bundler.settings[:cache_all_platforms]) do
+        Bundler.load.cache if Bundler.app_cache.exist? && !options["no-cache"] && !Bundler.frozen_bundle?
+      end
 
       Bundler.ui.confirm "Bundle complete! #{dependencies_count_for(definition)}, #{gems_installed_for(definition)}."
       Bundler::CLI::Common.output_without_groups_message(:install)

--- a/bundler/spec/commands/cache_spec.rb
+++ b/bundler/spec/commands/cache_spec.rb
@@ -358,6 +358,24 @@ RSpec.describe "bundle install with gem sources" do
       expect(the_bundle).to include_gems "rack 1.0.0"
     end
 
+    it "does not hit the remote at all when cache_all_platforms configured" do
+      build_repo2
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "rack"
+      G
+
+      bundle :cache
+      simulate_new_machine
+      FileUtils.rm_rf gem_repo2
+
+      bundle "config set --local cache_all_platforms true"
+      bundle "config set --local path vendor/bundle"
+      bundle "install --local"
+      expect(out).not_to include("Fetching gem metadata")
+      expect(the_bundle).to include_gems "rack 1.0.0"
+    end
+
     it "does not reinstall already-installed gems" do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`bundle install --local` hits the network.

## What is your fix for the problem, implemented in this PR?

Avoid this, even in the case of `cache_all_platforms` being configured.

Fixes #4675.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
