### PR TITLE
`bundle exec --allow-gems=GEMS` to enable GEMS regardless of Gemfile

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -469,6 +469,7 @@ module Bundler
 
     desc "exec [OPTIONS]", "Run the command in context of the bundle"
     method_option :keep_file_descriptors, :type => :boolean, :default => false
+    method_option :allow_gems, :type => :string, :required => false
     method_option :gemfile, :type => :string, :required => false
     long_desc <<-D
       Exec runs a command, providing it access to the gems in the bundle. While using

--- a/bundler/lib/bundler/cli/exec.rb
+++ b/bundler/lib/bundler/cli/exec.rb
@@ -22,7 +22,7 @@ module Bundler
 
     def run
       validate_cmd!
-      SharedHelpers.set_bundle_environment
+      SharedHelpers.set_bundle_environment(@options.allow_gems.to_s.split(","))
       if bin_path = Bundler.which(cmd)
         if !Bundler.settings[:disable_exec_load] && ruby_shebang?(bin_path)
           return kernel_load(bin_path, *args)

--- a/bundler/lib/bundler/environment_preserver.rb
+++ b/bundler/lib/bundler/environment_preserver.rb
@@ -6,6 +6,7 @@ module Bundler
     BUNDLER_KEYS = %w[
       BUNDLE_BIN_PATH
       BUNDLE_GEMFILE
+      BUNDLE_ALLOW_GEMS
       BUNDLER_VERSION
       GEM_HOME
       GEM_PATH

--- a/bundler/lib/bundler/man/bundle-exec.1
+++ b/bundler/lib/bundler/man/bundle-exec.1
@@ -7,7 +7,7 @@
 \fBbundle\-exec\fR \- Execute a command in the context of the bundle
 .
 .SH "SYNOPSIS"
-\fBbundle exec\fR [\-\-keep\-file\-descriptors] \fIcommand\fR
+\fBbundle exec\fR [\-\-keep\-file\-descriptors] [\-\-allow\-gems=GEM_NAMES] \fIcommand\fR
 .
 .SH "DESCRIPTION"
 This command executes the command, making all gems specified in the [\fBGemfile(5)\fR][Gemfile(5)] available to \fBrequire\fR in Ruby programs\.
@@ -23,6 +23,10 @@ Note that \fBbundle exec\fR does not require that an executable is available on 
 .TP
 \fB\-\-keep\-file\-descriptors\fR
 Exec in Ruby 2\.0 began discarding non\-standard file descriptors\. When this flag is passed, exec will revert to the 1\.9 behaviour of passing all file descriptors to the new process\.
+.
+.TP
+\fB\-\-allow\-gems\fR
+Allow the specified gems to be required regardless of Gemfile\. Multiple gem should be separated by commas\.
 .
 .SH "BUNDLE INSTALL \-\-BINSTUBS"
 If you use the \fB\-\-binstubs\fR flag in bundle install(1) \fIbundle\-install\.1\.html\fR, Bundler will automatically create a directory (which defaults to \fBapp_root/bin\fR) containing all of the executables available from gems in the bundle\.

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -589,6 +589,10 @@ module Bundler
       Gem::Specification.stubs_for(name).map(&:to_spec)
     end
 
+    def find_name_latest(name)
+      Gem::Specification.latest_spec_for(name)
+    end
+
     if Gem::Specification.respond_to?(:default_stubs)
       def default_stubs
         Gem::Specification.default_stubs("*.gemspec")

--- a/bundler/lib/bundler/runtime.rb
+++ b/bundler/lib/bundler/runtime.rb
@@ -19,6 +19,12 @@ module Bundler
 
       specs = groups.any? ? @definition.specs_for(groups) : requested_specs
 
+      (ENV["BUNDLE_ALLOW_GEMS"] || "").split(",").each do |gem_name|
+        if specs[gem_name].empty?
+          specs[gem_name] = Bundler.rubygems.find_name_latest(gem_name)
+        end
+      end
+
       SharedHelpers.set_bundle_environment
       Bundler.rubygems.replace_entrypoints(specs)
 

--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -72,8 +72,8 @@ module Bundler
       keys.each {|key| ENV[key] = old_env[key] }
     end
 
-    def set_bundle_environment
-      set_bundle_variables
+    def set_bundle_environment(allowed_gems = [])
+      set_bundle_variables(allowed_gems)
       set_path
       set_rubyopt
       set_rubylib
@@ -279,7 +279,7 @@ module Bundler
     end
     public :set_env
 
-    def set_bundle_variables
+    def set_bundle_variables(allowed_gems = [])
       # bundler exe & lib folders have same root folder, typical gem installation
       exe_file = File.expand_path("../../../exe/bundle", __FILE__)
 
@@ -292,6 +292,7 @@ module Bundler
       Bundler::SharedHelpers.set_env "BUNDLE_BIN_PATH", exe_file
       Bundler::SharedHelpers.set_env "BUNDLE_GEMFILE", find_gemfile.to_s
       Bundler::SharedHelpers.set_env "BUNDLER_VERSION", Bundler::VERSION
+      Bundler::SharedHelpers.set_env "BUNDLE_ALLOW_GEMS", allowed_gems.join(",")
     end
 
     def set_path

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -151,6 +151,13 @@ RSpec.describe "bundle exec" do
     expect(err).to be_empty
   end
 
+  it "handles --allow-gems=rack" do
+    install_gemfile ""
+    bundle "exec --allow-gems=rack rackup"
+
+    expect(out).to eq("1.0.0")
+  end
+
   it "can run a command named --verbose" do
     skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I want to enable some tooling gems temporarily even if they are not written in Gemfile. See #4649 in detail.

## What is your fix for the problem, implemented in this PR?

This changeset adds `--allow-gems=GEMS` option to `bundle exec`.
The option makes the speficied gems available even if the gems are not
listed in Gemfile. This is supposed to be used for some tooling gems
(like stackprof) which is needed just temporarily.

If the gem specified by `--allow-gems` is not listed in Gemfile, the
installed latest version of the gem is picked up. If the gem is listed
in Gemfile, the option is just ignored and Gemfile's specification is
respected.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
