### PR TITLE
Close then unlink tempfiles on Windows

### DIFF
--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -153,15 +153,13 @@ class Gem::TestCase < Test::Unit::TestCase
 
         return captured_stdout.read, captured_stderr.read
       ensure
-        captured_stdout.unlink
-        captured_stderr.unlink
         $stdout.reopen orig_stdout
         $stderr.reopen orig_stderr
 
         orig_stdout.close
         orig_stderr.close
-        captured_stdout.close
-        captured_stderr.close
+        captured_stdout.close!
+        captured_stderr.close!
       end
     end
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In ruby/ruby test actions, number of "leaked tempfile" messages are shown on Windows.

## What is your fix for the problem, implemented in this PR?

As Windows disallows removing open files, `Tempfile#unlink` fails silently before `#close`.
Close then unlink by `#close!` instead.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
