### PR TITLE
Fix multisource lockfile warning message

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -112,7 +112,7 @@ module Bundler
       end
 
       @locked_gem_sources = @locked_sources.select {|s| s.is_a?(Source::Rubygems) }
-      @multisource_allowed = @locked_gem_sources.any?(&:multisource_allowed?) && (sources.aggregate_global_source? || Bundler.frozen_bundle?)
+      @multisource_allowed = @locked_gem_sources.any?(&:multiple_remotes?) && (sources.aggregate_global_source? || Bundler.frozen_bundle?)
 
       if @multisource_allowed
         unless sources.aggregate_global_source?

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -115,9 +115,11 @@ module Bundler
       @disable_multisource = @locked_gem_sources.all?(&:disable_multisource?) || (sources.no_aggregate_global_source? && !Bundler.frozen_bundle?)
 
       unless @disable_multisource
-        msg = "Your lockfile contains a single rubygems source section with multiple remotes, which is insecure. You should run `bundle update` or generate your lockfile from scratch."
+        if sources.no_aggregate_global_source?
+          msg = "Your lockfile contains a single rubygems source section with multiple remotes, which is insecure. Make sure you run `bundle install` in non frozen mode and commit the result to make your lockfile secure."
 
-        Bundler::SharedHelpers.major_deprecation 2, msg
+          Bundler::SharedHelpers.major_deprecation 2, msg
+        end
 
         @sources.merged_gem_lockfile_sections!
       end

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -67,12 +67,12 @@ module Bundler
         o.is_a?(Rubygems) && (o.credless_remotes - credless_remotes).empty?
       end
 
-      def disable_multisource?
-        @remotes.size <= 1
+      def multisource_allowed?
+        @remotes.size > 1
       end
 
       def can_lock?(spec)
-        return super if disable_multisource?
+        return super unless multisource_allowed?
         spec.source.is_a?(Rubygems)
       end
 

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -67,12 +67,12 @@ module Bundler
         o.is_a?(Rubygems) && (o.credless_remotes - credless_remotes).empty?
       end
 
-      def multisource_allowed?
+      def multiple_remotes?
         @remotes.size > 1
       end
 
       def can_lock?(spec)
-        return super unless multisource_allowed?
+        return super unless multiple_remotes?
         spec.source.is_a?(Rubygems)
       end
 

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -33,7 +33,7 @@ module Bundler
     end
 
     def aggregate_global_source?
-      global_rubygems_source.remotes.size > 1
+      global_rubygems_source.multiple_remotes?
     end
 
     def add_path_source(options = {})

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -32,8 +32,8 @@ module Bundler
       @merged_gem_lockfile_sections = true
     end
 
-    def no_aggregate_global_source?
-      global_rubygems_source.remotes.size <= 1
+    def aggregate_global_source?
+      global_rubygems_source.remotes.size > 1
     end
 
     def add_path_source(options = {})

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -409,6 +409,34 @@ RSpec.describe "major deprecations" do
       )
     end
 
+    it "doesn't show lockfile deprecations if there's a lockfile", :bundler => "< 3" do
+      bundle "install"
+
+      expect(deprecations).to include(
+        "Your Gemfile contains multiple primary sources. " \
+        "Using `source` more than once without a block is a security risk, and " \
+        "may result in installing unexpected gems. To resolve this warning, use " \
+        "a block to indicate which gems should come from the secondary source."
+      )
+      expect(deprecations).not_to include(
+        "Your lockfile contains a single rubygems source section with multiple remotes, which is insecure. " \
+        "Make sure you run `bundle install` in non frozen mode and commit the result to make your lockfile secure."
+      )
+      bundle "config set --local frozen true"
+      bundle "install"
+
+      expect(deprecations).to include(
+        "Your Gemfile contains multiple primary sources. " \
+        "Using `source` more than once without a block is a security risk, and " \
+        "may result in installing unexpected gems. To resolve this warning, use " \
+        "a block to indicate which gems should come from the secondary source."
+      )
+      expect(deprecations).not_to include(
+        "Your lockfile contains a single rubygems source section with multiple remotes, which is insecure. " \
+        "Make sure you run `bundle install` in non frozen mode and commit the result to make your lockfile secure."
+      )
+    end
+
     pending "fails with a helpful error", :bundler => "3"
   end
 
@@ -448,7 +476,7 @@ RSpec.describe "major deprecations" do
     it "shows a deprecation", :bundler => "< 3" do
       bundle "install"
 
-      expect(deprecations).to include("Your lockfile contains a single rubygems source section with multiple remotes, which is insecure. You should run `bundle update` or generate your lockfile from scratch.")
+      expect(deprecations).to include("Your lockfile contains a single rubygems source section with multiple remotes, which is insecure. Make sure you run `bundle install` in non frozen mode and commit the result to make your lockfile secure.")
     end
 
     pending "fails with a helpful error", :bundler => "3"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This is a follow up to https://github.com/rubygems/rubygems/pull/4647.

In that PR, we fixed our logic to automatically update the lockfile format to have split GEM sections when necessary.

So, there's only two cases when this warning is printed now:

* When the Gemfile has multiple global sources. In this case, the warning is not really necessary because we already display a deprecation warning about the `Gemfile`, and once that's fixed, the lockfile format will be automatically upgraded.

* When we are in frozen mode, because we're not allowed to write to the lockfile.

## What is your fix for the problem, implemented in this PR?

This PR changes bundler so that the warning is not printed in the first case, and so that the warning gives proper resolution steps for the second case.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
