### PR TITLE
Revert lib/rubygems/test_case.rb and so on

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -380,6 +380,7 @@ lib/rubygems/install_default_message.rb
 lib/rubygems/install_message.rb
 lib/rubygems/install_update_options.rb
 lib/rubygems/installer.rb
+lib/rubygems/installer_test_case.rb
 lib/rubygems/installer_uninstaller_utils.rb
 lib/rubygems/local_remote_options.rb
 lib/rubygems/mock_gem_ui.rb
@@ -394,6 +395,7 @@ lib/rubygems/package/source.rb
 lib/rubygems/package/tar_header.rb
 lib/rubygems/package/tar_reader.rb
 lib/rubygems/package/tar_reader/entry.rb
+lib/rubygems/package/tar_test_case.rb
 lib/rubygems/package/tar_writer.rb
 lib/rubygems/package_task.rb
 lib/rubygems/path_support.rb
@@ -486,6 +488,8 @@ lib/rubygems/ssl_certs/rubygems.org/GlobalSignRootCA.pem
 lib/rubygems/ssl_certs/rubygems.org/GlobalSignRootCA_R3.pem
 lib/rubygems/stub_specification.rb
 lib/rubygems/syck_hack.rb
+lib/rubygems/test_case.rb
+lib/rubygems/test_utilities.rb
 lib/rubygems/text.rb
 lib/rubygems/uninstaller.rb
 lib/rubygems/unknown_command_spell_checker.rb
@@ -526,8 +530,6 @@ test/rubygems/good_rake.rb
 test/rubygems/grandchild_cert.pem
 test/rubygems/grandchild_cert_32.pem
 test/rubygems/grandchild_key.pem
-test/rubygems/helper.rb
-test/rubygems/installer_test_case.rb
 test/rubygems/invalid_client.pem
 test/rubygems/invalid_issuer_cert.pem
 test/rubygems/invalid_issuer_cert_32.pem
@@ -537,7 +539,6 @@ test/rubygems/invalid_signer_cert_32.pem
 test/rubygems/invalidchild_cert.pem
 test/rubygems/invalidchild_cert_32.pem
 test/rubygems/invalidchild_key.pem
-test/rubygems/package/tar_test_case.rb
 test/rubygems/packages/ascii_binder-0.1.10.1.gem
 test/rubygems/packages/ill-formatted-platform-1.0.0.10.gem
 test/rubygems/plugin/exception/rubygems_plugin.rb
@@ -691,7 +692,6 @@ test/rubygems/test_kernel.rb
 test/rubygems/test_project_sanity.rb
 test/rubygems/test_remote_fetch_error.rb
 test/rubygems/test_require.rb
-test/rubygems/utilities.rb
 test/rubygems/wrong_key_cert.pem
 test/rubygems/wrong_key_cert_32.pem
 test/test_changelog_generator.rb

--- a/lib/rubygems/installer_test_case.rb
+++ b/lib/rubygems/installer_test_case.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/installer'
 
 class Gem::Installer

--- a/lib/rubygems/package/tar_test_case.rb
+++ b/lib/rubygems/package/tar_test_case.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative '../helper'
+require 'rubygems/test_case'
 require 'rubygems/package'
 
 ##

--- a/lib/rubygems/test_case.rb
+++ b/lib/rubygems/test_case.rb
@@ -52,28 +52,32 @@ require 'rubygems/mock_gem_ui'
 module Gem
 
   ##
-  # Allows setting the gem path searcher.
+  # Allows setting the gem path searcher.  This method is available when
+  # requiring 'rubygems/test_case'
 
   def self.searcher=(searcher)
     @searcher = searcher
   end
 
   ##
-  # Allows toggling Windows behavior.
+  # Allows toggling Windows behavior.  This method is available when requiring
+  # 'rubygems/test_case'
 
   def self.win_platform=(val)
     @@win_platform = val
   end
 
   ##
-  # Allows setting path to Ruby.
+  # Allows setting path to Ruby.  This method is available when requiring
+  # 'rubygems/test_case'
 
   def self.ruby=(ruby)
     @ruby = ruby
   end
 
   ##
-  # Sets the default user interaction to a MockGemUi.
+  # When rubygems/test_case is required the default user interaction is a
+  # MockGemUi.
 
   module DefaultUserInteraction
     @ui = Gem::MockGemUi.new
@@ -84,7 +88,8 @@ require "rubygems/command"
 
 class Gem::Command
   ##
-  # Allows resetting the hash of specific args per command.
+  # Allows resetting the hash of specific args per command.  This method is
+  # available when requiring 'rubygems/test_case'
 
   def self.specific_extra_args_hash=(value)
     @specific_extra_args_hash = value
@@ -105,6 +110,8 @@ class Gem::TestCase < Test::Unit::TestCase
   attr_accessor :gem_repo # :nodoc:
 
   attr_accessor :uri # :nodoc:
+
+  TEST_PATH = ENV.fetch('RUBYGEMS_TEST_PATH', File.expand_path('../../../test/rubygems', __FILE__))
 
   def assert_activate(expected, *specs)
     specs.each do |spec|
@@ -1295,7 +1302,7 @@ Also, a list:
   end
 
   def ruby_with_rubygems_in_load_path
-    [Gem.ruby, "-I", $LOAD_PATH.find{|p| p == File.dirname($LOADED_FEATURES.find{|f| f.end_with?("/rubygems.rb") }) }]
+    [Gem.ruby, "-I", File.expand_path("..", __dir__)]
   end
 
   def with_clean_path_to_ruby
@@ -1326,8 +1333,8 @@ Also, a list:
     end
   end
 
-  @@good_rake = "#{rubybin} #{escape_path(__dir__, 'good_rake.rb')}"
-  @@bad_rake = "#{rubybin} #{escape_path(__dir__, 'bad_rake.rb')}"
+  @@good_rake = "#{rubybin} #{escape_path(TEST_PATH, 'good_rake.rb')}"
+  @@bad_rake = "#{rubybin} #{escape_path(TEST_PATH, 'bad_rake.rb')}"
 
   ##
   # Construct a new Gem::Dependency.
@@ -1514,12 +1521,12 @@ Also, a list:
 
   def self.cert_path(cert_name)
     if 32 == (Time.at(2**32) rescue 32)
-      cert_file = "#{__dir__}/#{cert_name}_cert_32.pem"
+      cert_file = "#{TEST_PATH}/#{cert_name}_cert_32.pem"
 
       return cert_file if File.exist? cert_file
     end
 
-    "#{__dir__}/#{cert_name}_cert.pem"
+    "#{TEST_PATH}/#{cert_name}_cert.pem"
   end
 
   ##
@@ -1537,7 +1544,7 @@ Also, a list:
   # Returns the path to the key named +key_name+ from <tt>test/rubygems</tt>
 
   def self.key_path(key_name)
-    "#{__dir__}/#{key_name}_key.pem"
+    "#{TEST_PATH}/#{key_name}_key.pem"
   end
 
   # :stopdoc:
@@ -1598,4 +1605,4 @@ class Object
   end
 end
 
-require_relative 'utilities'
+require 'rubygems/test_utilities'

--- a/lib/rubygems/test_utilities.rb
+++ b/lib/rubygems/test_utilities.rb
@@ -348,6 +348,8 @@ end
 # A StringIO duck-typed class that uses Tempfile instead of String as the
 # backing store.
 #
+# This is available when rubygems/test_utilities is required.
+#--
 # This class was added to flush out problems in Rubinius' IO implementation.
 
 class TempIO < Tempfile

--- a/test/rubygems/test_bundled_ca.rb
+++ b/test/rubygems/test_bundled_ca.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'net/http'
 require 'rubygems/openssl'
 

--- a/test/rubygems/test_config.rb
+++ b/test/rubygems/test_config.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems'
 require 'shellwords'
 

--- a/test/rubygems/test_deprecate.rb
+++ b/test/rubygems/test_deprecate.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/deprecate'
 
 class TestDeprecate < Gem::TestCase

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1,5 +1,5 @@
 # coding: US-ASCII
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems'
 require 'rubygems/command'
 require 'rubygems/installer'

--- a/test/rubygems/test_gem_available_set.rb
+++ b/test/rubygems/test_gem_available_set.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/available_set'
 require 'rubygems/security'
 

--- a/test/rubygems/test_gem_bundler_version_finder.rb
+++ b/test/rubygems/test_gem_bundler_version_finder.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 
 class TestGemBundlerVersionFinder < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_command.rb
+++ b/test/rubygems/test_gem_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/command'
 
 class Gem::Command

--- a/test/rubygems/test_gem_command_manager.rb
+++ b/test/rubygems/test_gem_command_manager.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/command_manager'
 
 class TestGemCommandManager < Gem::TestCase

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/commands/build_command'
 require 'rubygems/package'
 

--- a/test/rubygems/test_gem_commands_cert_command.rb
+++ b/test/rubygems/test_gem_commands_cert_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/commands/cert_command'
 
 unless Gem::HAVE_OPENSSL

--- a/test/rubygems/test_gem_commands_check_command.rb
+++ b/test/rubygems/test_gem_commands_check_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/commands/check_command'
 
 class TestGemCommandsCheckCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_cleanup_command.rb
+++ b/test/rubygems/test_gem_commands_cleanup_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/commands/cleanup_command'
 require 'rubygems/installer'
 

--- a/test/rubygems/test_gem_commands_contents_command.rb
+++ b/test/rubygems/test_gem_commands_contents_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/commands/contents_command'
 
 class TestGemCommandsContentsCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_dependency_command.rb
+++ b/test/rubygems/test_gem_commands_dependency_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/commands/dependency_command'
 
 class TestGemCommandsDependencyCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_environment_command.rb
+++ b/test/rubygems/test_gem_commands_environment_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/commands/environment_command'
 
 class TestGemCommandsEnvironmentCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_fetch_command.rb
+++ b/test/rubygems/test_gem_commands_fetch_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/package'
 require 'rubygems/security'
 require 'rubygems/commands/fetch_command'

--- a/test/rubygems/test_gem_commands_generate_index_command.rb
+++ b/test/rubygems/test_gem_commands_generate_index_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/indexer'
 require 'rubygems/commands/generate_index_command'
 

--- a/test/rubygems/test_gem_commands_help_command.rb
+++ b/test/rubygems/test_gem_commands_help_command.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require "rubygems"
-require_relative "helper"
+require "rubygems/test_case"
 require "rubygems/commands/help_command"
 require "rubygems/package"
 require "rubygems/command_manager"

--- a/test/rubygems/test_gem_commands_info_command.rb
+++ b/test/rubygems/test_gem_commands_info_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/commands/info_command'
 
 class TestGemCommandsInfoCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/commands/install_command'
 require 'rubygems/request_set'
 require 'rubygems/rdoc'

--- a/test/rubygems/test_gem_commands_list_command.rb
+++ b/test/rubygems/test_gem_commands_list_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/commands/list_command'
 
 class TestGemCommandsListCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_lock_command.rb
+++ b/test/rubygems/test_gem_commands_lock_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/commands/lock_command'
 
 class TestGemCommandsLockCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_mirror.rb
+++ b/test/rubygems/test_gem_commands_mirror.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/commands/mirror_command'
 
 class TestGemCommandsMirrorCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_open_command.rb
+++ b/test/rubygems/test_gem_commands_open_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/commands/open_command'
 
 class TestGemCommandsOpenCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_outdated_command.rb
+++ b/test/rubygems/test_gem_commands_outdated_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/commands/outdated_command'
 
 class TestGemCommandsOutdatedCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_owner_command.rb
+++ b/test/rubygems/test_gem_commands_owner_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/commands/owner_command'
 
 class TestGemCommandsOwnerCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_pristine_command.rb
+++ b/test/rubygems/test_gem_commands_pristine_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/commands/pristine_command'
 
 class TestGemCommandsPristineCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_push_command.rb
+++ b/test/rubygems/test_gem_commands_push_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/commands/push_command'
 
 class TestGemCommandsPushCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_query_command.rb
+++ b/test/rubygems/test_gem_commands_query_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/commands/query_command'
 
 module TestGemCommandsQueryCommandSetup

--- a/test/rubygems/test_gem_commands_search_command.rb
+++ b/test/rubygems/test_gem_commands_search_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/commands/search_command'
 
 class TestGemCommandsSearchCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_server_command.rb
+++ b/test/rubygems/test_gem_commands_server_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/commands/server_command'
 
 class TestGemCommandsServerCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/commands/setup_command'
 
 class TestGemCommandsSetupCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_signin_command.rb
+++ b/test/rubygems/test_gem_commands_signin_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/commands/signin_command'
 require 'rubygems/installer'
 

--- a/test/rubygems/test_gem_commands_signout_command.rb
+++ b/test/rubygems/test_gem_commands_signout_command.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/commands/signout_command'
 require 'rubygems/installer'
 

--- a/test/rubygems/test_gem_commands_sources_command.rb
+++ b/test/rubygems/test_gem_commands_sources_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/commands/sources_command'
 
 class TestGemCommandsSourcesCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_specification_command.rb
+++ b/test/rubygems/test_gem_commands_specification_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/commands/specification_command'
 
 class TestGemCommandsSpecificationCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_stale_command.rb
+++ b/test/rubygems/test_gem_commands_stale_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/commands/stale_command'
 
 class TestGemCommandsStaleCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_uninstall_command.rb
+++ b/test/rubygems/test_gem_commands_uninstall_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'installer_test_case'
+require 'rubygems/installer_test_case'
 require 'rubygems/commands/uninstall_command'
 
 class TestGemCommandsUninstallCommand < Gem::InstallerTestCase

--- a/test/rubygems/test_gem_commands_unpack_command.rb
+++ b/test/rubygems/test_gem_commands_unpack_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/commands/unpack_command'
 
 class TestGemCommandsUnpackCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/commands/update_command'
 
 class TestGemCommandsUpdateCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_which_command.rb
+++ b/test/rubygems/test_gem_commands_which_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/commands/which_command'
 
 class TestGemCommandsWhichCommand < Gem::TestCase

--- a/test/rubygems/test_gem_commands_yank_command.rb
+++ b/test/rubygems/test_gem_commands_yank_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/commands/yank_command'
 
 class TestGemCommandsYankCommand < Gem::TestCase

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/config_file'
 
 class TestGemConfigFile < Gem::TestCase

--- a/test/rubygems/test_gem_dependency.rb
+++ b/test/rubygems/test_gem_dependency.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/dependency'
 
 class TestGemDependency < Gem::TestCase

--- a/test/rubygems/test_gem_dependency_installer.rb
+++ b/test/rubygems/test_gem_dependency_installer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/dependency_installer'
 require 'rubygems/security'
 

--- a/test/rubygems/test_gem_dependency_list.rb
+++ b/test/rubygems/test_gem_dependency_list.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/dependency_list'
 
 class TestGemDependencyList < Gem::TestCase

--- a/test/rubygems/test_gem_dependency_resolution_error.rb
+++ b/test/rubygems/test_gem_dependency_resolution_error.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 
 class TestGemDependencyResolutionError < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_doctor.rb
+++ b/test/rubygems/test_gem_doctor.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/doctor'
 
 class TestGemDoctor < Gem::TestCase

--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/ext'
 require 'rubygems/installer'
 

--- a/test/rubygems/test_gem_ext_cmake_builder.rb
+++ b/test/rubygems/test_gem_ext_cmake_builder.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/ext'
 
 class TestGemExtCmakeBuilder < Gem::TestCase

--- a/test/rubygems/test_gem_ext_configure_builder.rb
+++ b/test/rubygems/test_gem_ext_configure_builder.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/ext'
 
 class TestGemExtConfigureBuilder < Gem::TestCase

--- a/test/rubygems/test_gem_ext_ext_conf_builder.rb
+++ b/test/rubygems/test_gem_ext_ext_conf_builder.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/ext'
 
 class TestGemExtExtConfBuilder < Gem::TestCase

--- a/test/rubygems/test_gem_ext_rake_builder.rb
+++ b/test/rubygems/test_gem_ext_rake_builder.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/ext'
 
 class TestGemExtRakeBuilder < Gem::TestCase

--- a/test/rubygems/test_gem_gem_runner.rb
+++ b/test/rubygems/test_gem_gem_runner.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 
 class TestGemGemRunner < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_gemcutter_utilities.rb
+++ b/test/rubygems/test_gem_gemcutter_utilities.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems'
 require 'rubygems/command'
 require 'rubygems/gemcutter_utilities'

--- a/test/rubygems/test_gem_impossible_dependencies_error.rb
+++ b/test/rubygems/test_gem_impossible_dependencies_error.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 
 class TestGemImpossibleDependenciesError < Gem::TestCase
   def test_message_conflict

--- a/test/rubygems/test_gem_indexer.rb
+++ b/test/rubygems/test_gem_indexer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/indexer'
 
 class TestGemIndexer < Gem::TestCase

--- a/test/rubygems/test_gem_install_update_options.rb
+++ b/test/rubygems/test_gem_install_update_options.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'installer_test_case'
+require 'rubygems/installer_test_case'
 require 'rubygems/install_update_options'
 require 'rubygems/command'
 require 'rubygems/dependency_installer'

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'installer_test_case'
+require 'rubygems/installer_test_case'
 
 class TestGemInstaller < Gem::InstallerTestCase
   def setup

--- a/test/rubygems/test_gem_local_remote_options.rb
+++ b/test/rubygems/test_gem_local_remote_options.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/local_remote_options'
 require 'rubygems/command'
 

--- a/test/rubygems/test_gem_name_tuple.rb
+++ b/test/rubygems/test_gem_name_tuple.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/name_tuple'
 
 class TestGemNameTuple < Gem::TestCase

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'package/tar_test_case'
+require 'rubygems/package/tar_test_case'
 require 'digest'
 
 class TestGemPackage < Gem::Package::TarTestCase

--- a/test/rubygems/test_gem_package_old.rb
+++ b/test/rubygems/test_gem_package_old.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 
 unless Gem.java_platform? # jruby can't require the simple_gem file
   require 'rubygems/simple_gem'

--- a/test/rubygems/test_gem_package_tar_header.rb
+++ b/test/rubygems/test_gem_package_tar_header.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'package/tar_test_case'
+require 'rubygems/package/tar_test_case'
 require 'rubygems/package'
 
 class TestGemPackageTarHeader < Gem::Package::TarTestCase

--- a/test/rubygems/test_gem_package_tar_reader.rb
+++ b/test/rubygems/test_gem_package_tar_reader.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'package/tar_test_case'
+require 'rubygems/package/tar_test_case'
 require 'rubygems/package'
 
 class TestGemPackageTarReader < Gem::Package::TarTestCase

--- a/test/rubygems/test_gem_package_tar_reader_entry.rb
+++ b/test/rubygems/test_gem_package_tar_reader_entry.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'package/tar_test_case'
+require 'rubygems/package/tar_test_case'
 require 'rubygems/package'
 
 class TestGemPackageTarReaderEntry < Gem::Package::TarTestCase

--- a/test/rubygems/test_gem_package_tar_writer.rb
+++ b/test/rubygems/test_gem_package_tar_writer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'package/tar_test_case'
+require 'rubygems/package/tar_test_case'
 require 'rubygems/package/tar_writer'
 
 class TestGemPackageTarWriter < Gem::Package::TarTestCase

--- a/test/rubygems/test_gem_package_task.rb
+++ b/test/rubygems/test_gem_package_task.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems'
 
 begin

--- a/test/rubygems/test_gem_path_support.rb
+++ b/test/rubygems/test_gem_path_support.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems'
 require 'fileutils'
 

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/platform'
 require 'rbconfig'
 

--- a/test/rubygems/test_gem_rdoc.rb
+++ b/test/rubygems/test_gem_rdoc.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require 'rubygems'
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/rdoc'
 
 class TestGemRDoc < Gem::TestCase

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 
 require 'webrick'
 require 'webrick/https' if Gem::HAVE_OPENSSL

--- a/test/rubygems/test_gem_request.rb
+++ b/test/rubygems/test_gem_request.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/request'
 require 'ostruct'
 require 'base64'

--- a/test/rubygems/test_gem_request_connection_pools.rb
+++ b/test/rubygems/test_gem_request_connection_pools.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/request'
 require 'timeout'
 

--- a/test/rubygems/test_gem_request_set.rb
+++ b/test/rubygems/test_gem_request_set.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/request_set'
 
 class TestGemRequestSet < Gem::TestCase

--- a/test/rubygems/test_gem_request_set_gem_dependency_api.rb
+++ b/test/rubygems/test_gem_request_set_gem_dependency_api.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/request_set'
 
 class TestGemRequestSetGemDependencyAPI < Gem::TestCase

--- a/test/rubygems/test_gem_request_set_lockfile.rb
+++ b/test/rubygems/test_gem_request_set_lockfile.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/request_set'
 require 'rubygems/request_set/lockfile'
 

--- a/test/rubygems/test_gem_request_set_lockfile_parser.rb
+++ b/test/rubygems/test_gem_request_set_lockfile_parser.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/request_set'
 require 'rubygems/request_set/lockfile'
 require 'rubygems/request_set/lockfile/tokenizer'

--- a/test/rubygems/test_gem_request_set_lockfile_tokenizer.rb
+++ b/test/rubygems/test_gem_request_set_lockfile_tokenizer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/request_set'
 require 'rubygems/request_set/lockfile'
 require 'rubygems/request_set/lockfile/tokenizer'

--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require "rubygems/requirement"
 
 class TestGemRequirement < Gem::TestCase

--- a/test/rubygems/test_gem_resolver.rb
+++ b/test/rubygems/test_gem_resolver.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 
 class TestGemResolver < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_resolver_activation_request.rb
+++ b/test/rubygems/test_gem_resolver_activation_request.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 
 class TestGemResolverActivationRequest < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_resolver_api_set.rb
+++ b/test/rubygems/test_gem_resolver_api_set.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 
 class TestGemResolverAPISet < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_resolver_api_specification.rb
+++ b/test/rubygems/test_gem_resolver_api_specification.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 
 class TestGemResolverAPISpecification < Gem::TestCase
   def test_initialize

--- a/test/rubygems/test_gem_resolver_best_set.rb
+++ b/test/rubygems/test_gem_resolver_best_set.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 
 class TestGemResolverBestSet < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_resolver_composed_set.rb
+++ b/test/rubygems/test_gem_resolver_composed_set.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 
 class TestGemResolverComposedSet < Gem::TestCase
   def test_errors

--- a/test/rubygems/test_gem_resolver_conflict.rb
+++ b/test/rubygems/test_gem_resolver_conflict.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 
 class TestGemResolverConflict < Gem::TestCase
   def test_explanation

--- a/test/rubygems/test_gem_resolver_dependency_request.rb
+++ b/test/rubygems/test_gem_resolver_dependency_request.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 
 class TestGemResolverDependencyRequest < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_resolver_git_set.rb
+++ b/test/rubygems/test_gem_resolver_git_set.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 
 class TestGemResolverGitSet < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_resolver_git_specification.rb
+++ b/test/rubygems/test_gem_resolver_git_specification.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/installer'
 
 class TestGemResolverGitSpecification < Gem::TestCase

--- a/test/rubygems/test_gem_resolver_index_set.rb
+++ b/test/rubygems/test_gem_resolver_index_set.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 
 class TestGemResolverIndexSet < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_resolver_index_specification.rb
+++ b/test/rubygems/test_gem_resolver_index_specification.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/available_set'
 
 class TestGemResolverIndexSpecification < Gem::TestCase

--- a/test/rubygems/test_gem_resolver_installed_specification.rb
+++ b/test/rubygems/test_gem_resolver_installed_specification.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 
 class TestGemResolverInstalledSpecification < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_resolver_installer_set.rb
+++ b/test/rubygems/test_gem_resolver_installer_set.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 
 class TestGemResolverInstallerSet < Gem::TestCase
   def test_add_always_install

--- a/test/rubygems/test_gem_resolver_local_specification.rb
+++ b/test/rubygems/test_gem_resolver_local_specification.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/available_set'
 
 class TestGemResolverLocalSpecification < Gem::TestCase

--- a/test/rubygems/test_gem_resolver_lock_set.rb
+++ b/test/rubygems/test_gem_resolver_lock_set.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 
 class TestGemResolverLockSet < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_resolver_lock_specification.rb
+++ b/test/rubygems/test_gem_resolver_lock_specification.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/installer'
 require 'rubygems/resolver'
 

--- a/test/rubygems/test_gem_resolver_requirement_list.rb
+++ b/test/rubygems/test_gem_resolver_requirement_list.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 
 class TestGemResolverRequirementList < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_resolver_specification.rb
+++ b/test/rubygems/test_gem_resolver_specification.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 
 class TestGemResolverSpecification < Gem::TestCase
   class TestSpec < Gem::Resolver::Specification

--- a/test/rubygems/test_gem_resolver_vendor_set.rb
+++ b/test/rubygems/test_gem_resolver_vendor_set.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 
 class TestGemResolverVendorSet < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_resolver_vendor_specification.rb
+++ b/test/rubygems/test_gem_resolver_vendor_specification.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 
 class TestGemResolverVendorSpecification < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_security.rb
+++ b/test/rubygems/test_gem_security.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/security'
 
 unless Gem::HAVE_OPENSSL

--- a/test/rubygems/test_gem_security_policy.rb
+++ b/test/rubygems/test_gem_security_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'helper'
+require 'rubygems/test_case'
 
 unless Gem::HAVE_OPENSSL
   warn 'Skipping Gem::Security::Policy tests.  openssl not found.'

--- a/test/rubygems/test_gem_security_signer.rb
+++ b/test/rubygems/test_gem_security_signer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 
 unless Gem::HAVE_OPENSSL
   warn 'Skipping Gem::Security::Signer tests.  openssl not found.'

--- a/test/rubygems/test_gem_security_trust_dir.rb
+++ b/test/rubygems/test_gem_security_trust_dir.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 
 unless Gem::HAVE_OPENSSL
   warn 'Skipping Gem::Security::TrustDir tests.  openssl not found.'

--- a/test/rubygems/test_gem_server.rb
+++ b/test/rubygems/test_gem_server.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/server'
 require 'stringio'
 

--- a/test/rubygems/test_gem_silent_ui.rb
+++ b/test/rubygems/test_gem_silent_ui.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/user_interaction'
 require 'timeout'
 

--- a/test/rubygems/test_gem_source.rb
+++ b/test/rubygems/test_gem_source.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/source'
 require 'rubygems/indexer'
 

--- a/test/rubygems/test_gem_source_fetch_problem.rb
+++ b/test/rubygems/test_gem_source_fetch_problem.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 
 class TestGemSourceFetchProblem < Gem::TestCase
   def test_exception

--- a/test/rubygems/test_gem_source_git.rb
+++ b/test/rubygems/test_gem_source_git.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/source'
 
 class TestGemSourceGit < Gem::TestCase

--- a/test/rubygems/test_gem_source_installed.rb
+++ b/test/rubygems/test_gem_source_installed.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/source'
 
 class TestGemSourceInstalled < Gem::TestCase

--- a/test/rubygems/test_gem_source_list.rb
+++ b/test/rubygems/test_gem_source_list.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rubygems'
 require 'rubygems/source_list'
-require_relative 'helper'
+require 'rubygems/test_case'
 
 class TestGemSourceList < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_source_local.rb
+++ b/test/rubygems/test_gem_source_local.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/source'
 
 require 'fileutils'

--- a/test/rubygems/test_gem_source_lock.rb
+++ b/test/rubygems/test_gem_source_lock.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 
 class TestGemSourceLock < Gem::TestCase
   def test_fetch_spec

--- a/test/rubygems/test_gem_source_specific_file.rb
+++ b/test/rubygems/test_gem_source_specific_file.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/source'
 
 class TestGemSourceSpecificFile < Gem::TestCase

--- a/test/rubygems/test_gem_source_subpath_problem.rb
+++ b/test/rubygems/test_gem_source_subpath_problem.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/source'
 
 class TestGemSourceSubpathProblem < Gem::TestCase

--- a/test/rubygems/test_gem_source_vendor.rb
+++ b/test/rubygems/test_gem_source_vendor.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/source'
 
 class TestGemSourceVendor < Gem::TestCase

--- a/test/rubygems/test_gem_spec_fetcher.rb
+++ b/test/rubygems/test_gem_spec_fetcher.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/spec_fetcher'
 
 class TestGemSpecFetcher < Gem::TestCase

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require 'benchmark'
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'date'
 require 'pathname'
 require 'stringio'

--- a/test/rubygems/test_gem_stream_ui.rb
+++ b/test/rubygems/test_gem_stream_ui.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/user_interaction'
 require 'timeout'
 

--- a/test/rubygems/test_gem_stub_specification.rb
+++ b/test/rubygems/test_gem_stub_specification.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative "helper"
+require "rubygems/test_case"
 require "rubygems/stub_specification"
 
 class TestStubSpecification < Gem::TestCase

--- a/test/rubygems/test_gem_text.rb
+++ b/test/rubygems/test_gem_text.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require "rubygems/text"
 
 class TestGemText < Gem::TestCase

--- a/test/rubygems/test_gem_uninstaller.rb
+++ b/test/rubygems/test_gem_uninstaller.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'installer_test_case'
+require 'rubygems/installer_test_case'
 require 'rubygems/uninstaller'
 
 class TestGemUninstaller < Gem::InstallerTestCase

--- a/test/rubygems/test_gem_unsatisfiable_dependency_error.rb
+++ b/test/rubygems/test_gem_unsatisfiable_dependency_error.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 
 class TestGemUnsatisfiableDependencyError < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_uri_formatter.rb
+++ b/test/rubygems/test_gem_uri_formatter.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/uri_formatter'
 
 class TestGemUriFormatter < Gem::TestCase

--- a/test/rubygems/test_gem_util.rb
+++ b/test/rubygems/test_gem_util.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/util'
 
 class TestGemUtil < Gem::TestCase

--- a/test/rubygems/test_gem_validator.rb
+++ b/test/rubygems/test_gem_validator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "helper"
+require "rubygems/test_case"
 require "rubygems/validator"
 
 class TestGemValidator < Gem::TestCase

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require "rubygems/version"
 
 class TestGemVersion < Gem::TestCase

--- a/test/rubygems/test_gem_version_option.rb
+++ b/test/rubygems/test_gem_version_option.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems/command'
 require 'rubygems/version_option'
 

--- a/test/rubygems/test_kernel.rb
+++ b/test/rubygems/test_kernel.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 
 class TestKernel < Gem::TestCase
   def setup

--- a/test/rubygems/test_project_sanity.rb
+++ b/test/rubygems/test_project_sanity.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "helper"
+require "rubygems/test_case"
 require "open3"
 
 class TestProjectSanity < Gem::TestCase

--- a/test/rubygems/test_remote_fetch_error.rb
+++ b/test/rubygems/test_remote_fetch_error.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 
 class TestRemoteFetchError < Gem::TestCase
   def test_password_redacted

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative 'helper'
+require 'rubygems/test_case'
 require 'rubygems'
 
 class TestGemRequire < Gem::TestCase


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

These files are a part of the public interface, and the removal has broken tests of rdoc.

## What is your fix for the problem, implemented in this PR?

This reverts commits:

* 2904fc8a4b725bc0ffac41d0fc0a521c928365cc

  Small tweak to play nice with packaging setups

* 6460e018df3741f0a70a8366a958105504d76e10

  Rename test/rubygems/test_{case,utilities}.rb to avoid "test_" prefix

* 0efb894c3b8930c0563b407a5e280be4562e6d40

  Remove no longer needed `RUBYGEMS_TEST_PATH` env variable

* 393f269e8feb87f10ba3dd6f1507624f55bb2626

  Resolve to missing `Gem::TestCase` issue with random order tests

* 8dfe1e30b5ed4a9006c74368a41bf2872af47836

  Remove no longer relevant commentsº

* c77868a555d05ea6699a23b73b32eac1cfd22494

  Require the new files in `test/` relatively

* aa390a3500ff1fe9803ba9ec982c5ea6edd4f85f

  Copy files specific to testing rubygems to `test`

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
