### PR TITLE
Fix test: 'rack' version from other source needs to be higher

### DIFF
--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -177,8 +177,9 @@ RSpec.describe "bundle install with gems on multiple sources" do
       context "and in another source" do
         before do
           # need this to be broken to check for correct source ordering
+          # version needs to be higher to give it higher priority
           build_repo gem_repo2 do
-            build_gem "rack", "1.0.0" do |s|
+            build_gem "rack", "1.0.1" do |s|
               s.write "lib/rack.rb", "RACK = 'FAIL'"
             end
           end
@@ -484,7 +485,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
       context "and the dependency is in both the top-level and a pinned source" do
         before do
           update_repo gem_repo2 do
-            build_gem "rack", "1.0.0" do |s|
+            build_gem "rack", "1.0.1" do |s|
               s.write "lib/rack.rb", "RACK = 'FAIL'"
             end
           end


### PR DESCRIPTION
to give it higher priority. It shouldn't be selected either way, as the dependency 'depends_on_rack' is in scoped source. This is related to PR #4609. 

## What was the end-user or developer problem that led to this PR?

While backporting the fix for PR 4609 for Ruby 2.7 release (bundler 2.1.4), I did not see any test actually checking for correct behaviour (no test was failing without the fix in PR).

## What is your fix for the problem, implemented in this PR?

I've raised the version to higher one, to give the dependency in unwanted (non-scoped) source higher priority, therefore properly testing the issue.