### PR TITLE
Changelogs for rubygems 3.2.21 and bundler 2.2.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 3.2.21 / 2021-06-23
+
+## Enhancements:
+
+* Fix typo in OpenSSL detection. Pull request #4679 by osyoyu
+* Add the most recent licenses from spdx.org. Pull request #4662 by nobu
+* Simplify setup.rb code to allow installing rubygems from source on
+  truffleruby 21.0 and 21.1. Pull request #4624 by deivid-rodriguez
+
+## Bug fixes:
+
+* Create credentials folder when setting API keys if not there yet. Pull
+  request #4665 by deivid-rodriguez
+
 # 3.2.20 / 2021-06-11
 
 ## Security fixes:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 2.2.21 (June 23, 2021)
+
+## Security fixes:
+
+  - Auto-update insecure lockfile to split GEM source sections whenever possible [#4647](https://github.com/rubygems/rubygems/pull/4647)
+
+## Enhancements:
+
+  - Use a more limited number of threads when fetching in parallel from the Compact Index API [#4670](https://github.com/rubygems/rubygems/pull/4670)
+  - Update TODO link in bundle gem template to https [#4671](https://github.com/rubygems/rubygems/pull/4671)
+
+## Bug fixes:
+
+  - Fix `bundle install --local` hitting the network when `cache_all_platforms` configured [#4677](https://github.com/rubygems/rubygems/pull/4677)
+
 # 2.2.20 (June 11, 2021)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking changelogs from future rubygems 3.2.21 and bundler 2.2.21 into master.
