### PR TITLE
Rescue when RDoc is absent

### DIFF
--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -261,7 +261,10 @@ class Gem::Uninstaller
 
     safe_delete { FileUtils.rm_r gem }
 
-    Gem::RDoc.new(spec).remove
+    begin
+      Gem::RDoc.new(spec).remove
+    rescue NameError
+    end
 
     gemspec = spec.spec_file
 


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?
Fixes #4690.
<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?
Added a rescue block to allow the uninstall script to run regardless of RDoc's presence.
<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
