### PR TITLE
Fix `--conservative` flag unexpectedly updating indirect dependencies 

### DIFF
--- a/bundler/lib/bundler/cli/lock.rb
+++ b/bundler/lib/bundler/cli/lock.rb
@@ -21,9 +21,13 @@ module Bundler
       Bundler::Fetcher.disable_endpoint = options["full-index"]
 
       update = options[:update]
+      conservative = options[:conservative]
+
       if update.is_a?(Array) # unlocking specific gems
         Bundler::CLI::Common.ensure_all_gems_in_lockfile!(update)
-        update = { :gems => update, :conservative => options[:conservative] }
+        update = { :gems => update, :conservative => conservative }
+      elsif update
+        update = { :conservative => conservative } if conservative
       end
       definition = Bundler.definition(update)
 

--- a/bundler/lib/bundler/cli/lock.rb
+++ b/bundler/lib/bundler/cli/lock.rb
@@ -23,7 +23,7 @@ module Bundler
       update = options[:update]
       if update.is_a?(Array) # unlocking specific gems
         Bundler::CLI::Common.ensure_all_gems_in_lockfile!(update)
-        update = { :gems => update, :lock_shared_dependencies => options[:conservative] }
+        update = { :gems => update, :conservative => options[:conservative] }
       end
       definition = Bundler.definition(update)
 

--- a/bundler/lib/bundler/cli/update.rb
+++ b/bundler/lib/bundler/cli/update.rb
@@ -28,7 +28,6 @@ module Bundler
       end
 
       if full_update
-        # We're doing a full update
         Bundler.definition(true)
       else
         unless Bundler.default_lockfile.exist?

--- a/bundler/lib/bundler/cli/update.rb
+++ b/bundler/lib/bundler/cli/update.rb
@@ -27,8 +27,14 @@ module Bundler
         raise InvalidOption, "Cannot specify --all along with specific options."
       end
 
+      conservative = options[:conservative]
+
       if full_update
-        Bundler.definition(true)
+        if conservative
+          Bundler.definition(:lock_shared_dependencies => conservative)
+        else
+          Bundler.definition(true)
+        end
       else
         unless Bundler.default_lockfile.exist?
           raise GemfileLockNotFound, "This Bundle hasn't been installed yet. " \
@@ -42,7 +48,7 @@ module Bundler
         end
 
         Bundler.definition(:gems => gems, :sources => sources, :ruby => options[:ruby],
-                           :lock_shared_dependencies => options[:conservative],
+                           :lock_shared_dependencies => conservative,
                            :bundler => options[:bundler])
       end
 

--- a/bundler/lib/bundler/cli/update.rb
+++ b/bundler/lib/bundler/cli/update.rb
@@ -31,7 +31,7 @@ module Bundler
 
       if full_update
         if conservative
-          Bundler.definition(:lock_shared_dependencies => conservative)
+          Bundler.definition(:conservative => conservative)
         else
           Bundler.definition(true)
         end
@@ -48,7 +48,7 @@ module Bundler
         end
 
         Bundler.definition(:gems => gems, :sources => sources, :ruby => options[:ruby],
-                           :lock_shared_dependencies => conservative,
+                           :conservative => conservative,
                            :bundler => options[:bundler])
       end
 

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -136,7 +136,7 @@ module Bundler
       @path_changes = converge_paths
       @source_changes = converge_sources
 
-      if @unlock[:lock_shared_dependencies]
+      if @unlock[:conservative]
         @unlock[:gems] ||= @dependencies.map(&:name)
       else
         eager_unlock = expand_dependencies(@unlock[:gems] || [], true)

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -749,8 +749,6 @@ module Bundler
         end
       end
 
-      unlock_source_unlocks_spec = Bundler.feature_flag.unlock_source_unlocks_spec?
-
       converged = []
       @locked_specs.each do |s|
         # Replace the locked dependency's source with the equivalent source from the Gemfile
@@ -761,11 +759,6 @@ module Bundler
         # if you change a Git gem to RubyGems.
         next if s.source.nil?
         next if @unlock[:sources].include?(s.source.name)
-
-        # XXX This is a backwards-compatibility fix to preserve the ability to
-        # unlock a single gem by passing its name via `--source`. See issue #3759
-        # TODO: delete in Bundler 2
-        next if unlock_source_unlocks_spec && @unlock[:sources].include?(s.name)
 
         # If the spec is from a path source and it doesn't exist anymore
         # then we unlock it.

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -262,7 +262,7 @@ module Bundler
 
     def specs_for(groups)
       deps = dependencies_for(groups)
-      specs.for(expand_dependencies(deps))
+      SpecSet.new(specs.for(expand_dependencies(deps)))
     end
 
     def dependencies_for(groups)
@@ -797,7 +797,7 @@ module Bundler
 
       resolve = SpecSet.new(converged)
       @locked_specs_incomplete_for_platform = !resolve.for(expand_dependencies(requested_dependencies & deps), @unlock[:gems], true, true)
-      resolve = resolve.for(expand_dependencies(deps, true), @unlock[:gems], false, false, false)
+      resolve = SpecSet.new(resolve.for(expand_dependencies(deps, true), @unlock[:gems], false, false, false))
       diff    = nil
 
       # Now, we unlock any sources that do not have anymore gems pinned to it

--- a/bundler/lib/bundler/feature_flag.rb
+++ b/bundler/lib/bundler/feature_flag.rb
@@ -38,7 +38,6 @@ module Bundler
     settings_flag(:print_only_version_number) { bundler_3_mode? }
     settings_flag(:setup_makes_kernel_gem_public) { !bundler_3_mode? }
     settings_flag(:suppress_install_using_messages) { bundler_3_mode? }
-    settings_flag(:unlock_source_unlocks_spec) { !bundler_3_mode? }
     settings_flag(:update_requires_all_flag) { bundler_4_mode? }
     settings_flag(:use_gem_version_promoter_for_major_updates) { bundler_3_mode? }
 

--- a/bundler/lib/bundler/man/bundle-add.1
+++ b/bundler/lib/bundler/man/bundle-add.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-ADD" "1" "May 2021" "" ""
+.TH "BUNDLE\-ADD" "1" "June 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-add\fR \- Add gem to the Gemfile and run bundle install

--- a/bundler/lib/bundler/man/bundle-binstubs.1
+++ b/bundler/lib/bundler/man/bundle-binstubs.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-BINSTUBS" "1" "May 2021" "" ""
+.TH "BUNDLE\-BINSTUBS" "1" "June 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-binstubs\fR \- Install the binstubs of the listed gems

--- a/bundler/lib/bundler/man/bundle-cache.1
+++ b/bundler/lib/bundler/man/bundle-cache.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CACHE" "1" "May 2021" "" ""
+.TH "BUNDLE\-CACHE" "1" "June 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-cache\fR \- Package your needed \fB\.gem\fR files into your application

--- a/bundler/lib/bundler/man/bundle-check.1
+++ b/bundler/lib/bundler/man/bundle-check.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CHECK" "1" "May 2021" "" ""
+.TH "BUNDLE\-CHECK" "1" "June 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-check\fR \- Verifies if dependencies are satisfied by installed gems

--- a/bundler/lib/bundler/man/bundle-clean.1
+++ b/bundler/lib/bundler/man/bundle-clean.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CLEAN" "1" "May 2021" "" ""
+.TH "BUNDLE\-CLEAN" "1" "June 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-clean\fR \- Cleans up unused gems in your bundler directory

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -274,9 +274,6 @@ The following is a list of all configuration keys and their purpose\. You can le
 \fBtimeout\fR (\fBBUNDLE_TIMEOUT\fR): The seconds allowed before timing out for network requests\. Defaults to \fB10\fR\.
 .
 .IP "\(bu" 4
-\fBunlock_source_unlocks_spec\fR (\fBBUNDLE_UNLOCK_SOURCE_UNLOCKS_SPEC\fR): Whether running \fBbundle update \-\-source NAME\fR unlocks a gem with the given name\. Defaults to \fBtrue\fR\.
-.
-.IP "\(bu" 4
 \fBupdate_requires_all_flag\fR (\fBBUNDLE_UPDATE_REQUIRES_ALL_FLAG\fR): Require passing \fB\-\-all\fR to \fBbundle update\fR when everything should be updated, and disallow passing no options to \fBbundle update\fR\.
 .
 .IP "\(bu" 4

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CONFIG" "1" "May 2021" "" ""
+.TH "BUNDLE\-CONFIG" "1" "June 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-config\fR \- Set bundler configuration options

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -260,9 +260,6 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    The location where RubyGems installs binstubs. Defaults to `Gem.bindir`.
 * `timeout` (`BUNDLE_TIMEOUT`):
    The seconds allowed before timing out for network requests. Defaults to `10`.
-* `unlock_source_unlocks_spec` (`BUNDLE_UNLOCK_SOURCE_UNLOCKS_SPEC`):
-   Whether running `bundle update --source NAME` unlocks a gem with the given
-   name. Defaults to `true`.
 * `update_requires_all_flag` (`BUNDLE_UPDATE_REQUIRES_ALL_FLAG`):
    Require passing `--all` to `bundle update` when everything should be updated,
    and disallow passing no options to `bundle update`.

--- a/bundler/lib/bundler/man/bundle-doctor.1
+++ b/bundler/lib/bundler/man/bundle-doctor.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-DOCTOR" "1" "May 2021" "" ""
+.TH "BUNDLE\-DOCTOR" "1" "June 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-doctor\fR \- Checks the bundle for common problems

--- a/bundler/lib/bundler/man/bundle-exec.1
+++ b/bundler/lib/bundler/man/bundle-exec.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-EXEC" "1" "May 2021" "" ""
+.TH "BUNDLE\-EXEC" "1" "June 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-exec\fR \- Execute a command in the context of the bundle

--- a/bundler/lib/bundler/man/bundle-gem.1
+++ b/bundler/lib/bundler/man/bundle-gem.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-GEM" "1" "May 2021" "" ""
+.TH "BUNDLE\-GEM" "1" "June 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-gem\fR \- Generate a project skeleton for creating a rubygem

--- a/bundler/lib/bundler/man/bundle-info.1
+++ b/bundler/lib/bundler/man/bundle-info.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INFO" "1" "May 2021" "" ""
+.TH "BUNDLE\-INFO" "1" "June 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-info\fR \- Show information for the given gem in your bundle

--- a/bundler/lib/bundler/man/bundle-init.1
+++ b/bundler/lib/bundler/man/bundle-init.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INIT" "1" "May 2021" "" ""
+.TH "BUNDLE\-INIT" "1" "June 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-init\fR \- Generates a Gemfile into the current working directory

--- a/bundler/lib/bundler/man/bundle-inject.1
+++ b/bundler/lib/bundler/man/bundle-inject.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INJECT" "1" "May 2021" "" ""
+.TH "BUNDLE\-INJECT" "1" "June 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-inject\fR \- Add named gem(s) with version requirements to Gemfile

--- a/bundler/lib/bundler/man/bundle-install.1
+++ b/bundler/lib/bundler/man/bundle-install.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INSTALL" "1" "May 2021" "" ""
+.TH "BUNDLE\-INSTALL" "1" "June 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-install\fR \- Install the dependencies specified in your Gemfile

--- a/bundler/lib/bundler/man/bundle-list.1
+++ b/bundler/lib/bundler/man/bundle-list.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-LIST" "1" "May 2021" "" ""
+.TH "BUNDLE\-LIST" "1" "June 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-list\fR \- List all the gems in the bundle

--- a/bundler/lib/bundler/man/bundle-lock.1
+++ b/bundler/lib/bundler/man/bundle-lock.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-LOCK" "1" "May 2021" "" ""
+.TH "BUNDLE\-LOCK" "1" "June 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-lock\fR \- Creates / Updates a lockfile without installing

--- a/bundler/lib/bundler/man/bundle-open.1
+++ b/bundler/lib/bundler/man/bundle-open.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-OPEN" "1" "May 2021" "" ""
+.TH "BUNDLE\-OPEN" "1" "June 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-open\fR \- Opens the source directory for a gem in your bundle

--- a/bundler/lib/bundler/man/bundle-outdated.1
+++ b/bundler/lib/bundler/man/bundle-outdated.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-OUTDATED" "1" "May 2021" "" ""
+.TH "BUNDLE\-OUTDATED" "1" "June 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-outdated\fR \- List installed gems with newer versions available

--- a/bundler/lib/bundler/man/bundle-platform.1
+++ b/bundler/lib/bundler/man/bundle-platform.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-PLATFORM" "1" "May 2021" "" ""
+.TH "BUNDLE\-PLATFORM" "1" "June 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-platform\fR \- Displays platform compatibility information

--- a/bundler/lib/bundler/man/bundle-pristine.1
+++ b/bundler/lib/bundler/man/bundle-pristine.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-PRISTINE" "1" "May 2021" "" ""
+.TH "BUNDLE\-PRISTINE" "1" "June 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-pristine\fR \- Restores installed gems to their pristine condition

--- a/bundler/lib/bundler/man/bundle-remove.1
+++ b/bundler/lib/bundler/man/bundle-remove.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-REMOVE" "1" "May 2021" "" ""
+.TH "BUNDLE\-REMOVE" "1" "June 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-remove\fR \- Removes gems from the Gemfile

--- a/bundler/lib/bundler/man/bundle-show.1
+++ b/bundler/lib/bundler/man/bundle-show.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-SHOW" "1" "May 2021" "" ""
+.TH "BUNDLE\-SHOW" "1" "June 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-show\fR \- Shows all the gems in your bundle, or the path to a gem

--- a/bundler/lib/bundler/man/bundle-update.1
+++ b/bundler/lib/bundler/man/bundle-update.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-UPDATE" "1" "May 2021" "" ""
+.TH "BUNDLE\-UPDATE" "1" "June 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-update\fR \- Update your gems to the latest available versions
@@ -79,7 +79,7 @@ Do not allow any gem to be updated past latest \fB\-\-patch\fR | \fB\-\-minor\fR
 .
 .TP
 \fB\-\-conservative\fR
-Use bundle install conservative update behavior and do not allow shared dependencies to be updated\.
+Use bundle install conservative update behavior and do not allow indirect dependencies to be updated\.
 .
 .SH "UPDATING ALL GEMS"
 If you run \fBbundle update \-\-all\fR, bundler will ignore any previously installed gems and resolve all dependencies again based on the latest versions of all gems available in the sources\.
@@ -208,13 +208,13 @@ In this case, the two gems have their own set of dependencies, but they share \f
 In short, by default, when you update a gem using \fBbundle update\fR, bundler will update all dependencies of that gem, including those that are also dependencies of another gem\.
 .
 .P
-To prevent updating shared dependencies, prior to version 1\.14 the only option was the \fBCONSERVATIVE UPDATING\fR behavior in bundle install(1) \fIbundle\-install\.1\.html\fR:
+To prevent updating indirect dependencies, prior to version 1\.14 the only option was the \fBCONSERVATIVE UPDATING\fR behavior in bundle install(1) \fIbundle\-install\.1\.html\fR:
 .
 .P
 In this scenario, updating the \fBthin\fR version manually in the Gemfile(5), and then running bundle install(1) \fIbundle\-install\.1\.html\fR will only update \fBdaemons\fR and \fBeventmachine\fR, but not \fBrack\fR\. For more information, see the \fBCONSERVATIVE UPDATING\fR section of bundle install(1) \fIbundle\-install\.1\.html\fR\.
 .
 .P
-Starting with 1\.14, specifying the \fB\-\-conservative\fR option will also prevent shared dependencies from being updated\.
+Starting with 1\.14, specifying the \fB\-\-conservative\fR option will also prevent indirect dependencies from being updated\.
 .
 .SH "PATCH LEVEL OPTIONS"
 Version 1\.14 introduced 4 patch\-level options that will influence how gem versions are resolved\. One of the following options can be used: \fB\-\-patch\fR, \fB\-\-minor\fR or \fB\-\-major\fR\. \fB\-\-strict\fR can be added to further influence resolution\.

--- a/bundler/lib/bundler/man/bundle-update.1.ronn
+++ b/bundler/lib/bundler/man/bundle-update.1.ronn
@@ -80,7 +80,7 @@ gem.
   Do not allow any gem to be updated past latest `--patch` | `--minor` | `--major`.
 
 * `--conservative`:
-  Use bundle install conservative update behavior and do not allow shared dependencies to be updated.
+  Use bundle install conservative update behavior and do not allow indirect dependencies to be updated.
 
 ## UPDATING ALL GEMS
 
@@ -195,7 +195,7 @@ In short, by default, when you update a gem using `bundle update`, bundler will
 update all dependencies of that gem, including those that are also dependencies
 of another gem.
 
-To prevent updating shared dependencies, prior to version 1.14 the only option
+To prevent updating indirect dependencies, prior to version 1.14 the only option
 was the `CONSERVATIVE UPDATING` behavior in [bundle install(1)](bundle-install.1.html):
 
 In this scenario, updating the `thin` version manually in the Gemfile(5),
@@ -203,7 +203,7 @@ and then running [bundle install(1)](bundle-install.1.html) will only update `da
 but not `rack`. For more information, see the `CONSERVATIVE UPDATING` section
 of [bundle install(1)](bundle-install.1.html).
 
-Starting with 1.14, specifying the `--conservative` option will also prevent shared
+Starting with 1.14, specifying the `--conservative` option will also prevent indirect
 dependencies from being updated.
 
 ## PATCH LEVEL OPTIONS

--- a/bundler/lib/bundler/man/bundle-viz.1
+++ b/bundler/lib/bundler/man/bundle-viz.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-VIZ" "1" "May 2021" "" ""
+.TH "BUNDLE\-VIZ" "1" "June 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-viz\fR \- Generates a visual dependency graph for your Gemfile

--- a/bundler/lib/bundler/man/bundle.1
+++ b/bundler/lib/bundler/man/bundle.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE" "1" "May 2021" "" ""
+.TH "BUNDLE" "1" "June 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\fR \- Ruby Dependency Management

--- a/bundler/lib/bundler/man/gemfile.5
+++ b/bundler/lib/bundler/man/gemfile.5
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GEMFILE" "5" "May 2021" "" ""
+.TH "GEMFILE" "5" "June 2021" "" ""
 .
 .SH "NAME"
 \fBGemfile\fR \- A format for describing gem dependencies for Ruby programs

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -21,7 +21,7 @@ module Bundler
       base = SpecSet.new(base) unless base.is_a?(SpecSet)
       resolver = new(source_requirements, base, gem_version_promoter, additional_base_requirements, platforms)
       result = resolver.start(requirements)
-      SpecSet.new(result).for(requirements.reject{|dep| dep.name.end_with?("\0") })
+      SpecSet.new(SpecSet.new(result).for(requirements.reject{|dep| dep.name.end_with?("\0") }))
     end
 
     def initialize(source_requirements, base, gem_version_promoter, additional_base_requirements, platforms)

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -44,7 +44,6 @@ module Bundler
       silence_deprecations
       silence_root_warning
       suppress_install_using_messages
-      unlock_source_unlocks_spec
       update_requires_all_flag
       use_gem_version_promoter_for_major_updates
     ].freeze

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -46,7 +46,7 @@ module Bundler
         specs << spec
       end
 
-      check ? true : SpecSet.new(specs)
+      check ? true : specs
     end
 
     def [](key)
@@ -73,7 +73,7 @@ module Bundler
     end
 
     def materialize(deps, missing_specs = nil)
-      materialized = self.for(deps, [], false, true, !missing_specs).to_a
+      materialized = self.for(deps, [], false, true, !missing_specs)
 
       materialized.group_by(&:source).each do |source, specs|
         next unless specs.any?{|s| s.is_a?(LazySpecification) }

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -49,10 +49,6 @@ module Bundler
       check ? true : SpecSet.new(specs)
     end
 
-    def valid_for?(deps)
-      self.for(deps, [], true)
-    end
-
     def [](key)
       key = key.name if key.respond_to?(:name)
       lookup[key].reverse

--- a/bundler/spec/bundler/definition_spec.rb
+++ b/bundler/spec/bundler/definition_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe Bundler::Definition do
             bundled_app_lock,
             updated_deps_in_gemfile,
             source_list,
-            :gems => ["shared_owner_a"], :lock_shared_dependencies => true
+            :gems => ["shared_owner_a"], :conservative => true
           )
           locked = definition.send(:converge_locked_specs).map(&:name)
           expect(locked).to eq %w[isolated_dep isolated_owner shared_dep shared_owner_b]

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -1147,13 +1147,13 @@ RSpec.describe "bundle update conservative" do
     it "should not eagerly unlock with --conservative" do
       bundle "update --conservative shared_owner_a isolated_owner"
 
-      expect(the_bundle).to include_gems "isolated_owner 1.0.2", "isolated_dep 2.0.2", "shared_dep 5.0.1", "shared_owner_a 3.0.2", "shared_owner_b 4.0.1"
+      expect(the_bundle).to include_gems "isolated_owner 1.0.2", "isolated_dep 2.0.1", "shared_dep 5.0.1", "shared_owner_a 3.0.2", "shared_owner_b 4.0.1"
     end
 
-    it "should not update indirect dependencies when fully updating with --conservative" do
+    it "should only update direct dependencies when fully updating with --conservative" do
       bundle "update --conservative"
 
-      expect(the_bundle).to include_gems "isolated_dep 2.0.1", "shared_dep 5.0.1"
+      expect(the_bundle).to include_gems "isolated_owner 1.0.2", "isolated_dep 2.0.1", "shared_dep 5.0.1", "shared_owner_a 3.0.2", "shared_owner_b 4.0.2"
     end
 
     it "should match bundle install conservative update behavior when not eagerly unlocking" do

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -1150,6 +1150,12 @@ RSpec.describe "bundle update conservative" do
       expect(the_bundle).to include_gems "isolated_owner 1.0.2", "isolated_dep 2.0.2", "shared_dep 5.0.1", "shared_owner_a 3.0.2", "shared_owner_b 4.0.1"
     end
 
+    it "should not update indirect dependencies when fully updating with --conservative" do
+      bundle "update --conservative"
+
+      expect(the_bundle).to include_gems "isolated_dep 2.0.1", "shared_dep 5.0.1"
+    end
+
     it "should match bundle install conservative update behavior when not eagerly unlocking" do
       gemfile <<-G
         source "#{file_uri_for(gem_repo4)}"

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -1156,6 +1156,35 @@ RSpec.describe "bundle update conservative" do
       expect(the_bundle).to include_gems "isolated_owner 1.0.2", "isolated_dep 2.0.1", "shared_dep 5.0.1", "shared_owner_a 3.0.2", "shared_owner_b 4.0.2"
     end
 
+    it "should only change direct dependencies when updating the lockfile with --conservative" do
+      bundle "lock --update --conservative"
+
+      expect(lockfile).to eq <<~L
+        GEM
+          remote: #{file_uri_for(gem_repo4)}/
+          specs:
+            isolated_dep (2.0.1)
+            isolated_owner (1.0.2)
+              isolated_dep (~> 2.0)
+            shared_dep (5.0.1)
+            shared_owner_a (3.0.2)
+              shared_dep (~> 5.0)
+            shared_owner_b (4.0.2)
+              shared_dep (~> 5.0)
+
+        PLATFORMS
+          #{specific_local_platform}
+
+        DEPENDENCIES
+          isolated_owner
+          shared_owner_a
+          shared_owner_b
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+    end
+
     it "should match bundle install conservative update behavior when not eagerly unlocking" do
       gemfile <<-G
         source "#{file_uri_for(gem_repo4)}"

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -411,18 +411,7 @@ RSpec.describe "bundle update" do
       build_repo2
     end
 
-    it "should not update gems not included in the source that happen to have the same name", :bundler => "< 3" do
-      install_gemfile <<-G
-        source "#{file_uri_for(gem_repo2)}"
-        gem "activesupport"
-      G
-      update_repo2 { build_gem "activesupport", "3.0" }
-
-      bundle "update --source activesupport"
-      expect(the_bundle).to include_gem "activesupport 3.0"
-    end
-
-    it "should not update gems not included in the source that happen to have the same name", :bundler => "3" do
+    it "should not update gems not included in the source that happen to have the same name" do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "activesupport"
@@ -433,19 +422,15 @@ RSpec.describe "bundle update" do
       expect(the_bundle).not_to include_gem "activesupport 3.0"
     end
 
-    context "with unlock_source_unlocks_spec set to false" do
-      before { bundle "config set unlock_source_unlocks_spec false" }
+    it "should not update gems not included in the source that happen to have the same name" do
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "activesupport"
+      G
+      update_repo2 { build_gem "activesupport", "3.0" }
 
-      it "should not update gems not included in the source that happen to have the same name" do
-        install_gemfile <<-G
-          source "#{file_uri_for(gem_repo2)}"
-          gem "activesupport"
-        G
-        update_repo2 { build_gem "activesupport", "3.0" }
-
-        bundle "update --source activesupport"
-        expect(the_bundle).not_to include_gems "activesupport 3.0"
-      end
+      bundle "update --source activesupport"
+      expect(the_bundle).not_to include_gems "activesupport 3.0"
     end
   end
 
@@ -465,20 +450,7 @@ RSpec.describe "bundle update" do
       G
     end
 
-    it "should not update the child dependencies of a gem that has the same name as the source", :bundler => "< 3" do
-      update_repo2 do
-        build_gem "fred", "2.0"
-        build_gem "harry", "2.0" do |s|
-          s.add_dependency "fred"
-        end
-      end
-
-      bundle "update --source harry"
-      expect(the_bundle).to include_gems "harry 2.0"
-      expect(the_bundle).to include_gems "fred 1.0"
-    end
-
-    it "should not update the child dependencies of a gem that has the same name as the source", :bundler => "3" do
+    it "should not update the child dependencies of a gem that has the same name as the source" do
       update_repo2 do
         build_gem "fred", "2.0"
         build_gem "harry", "2.0" do |s|
@@ -510,21 +482,7 @@ RSpec.describe "bundle update" do
       G
     end
 
-    it "should not update the child dependencies of a gem that has the same name as the source", :bundler => "< 3" do
-      update_repo2 do
-        build_gem "george", "2.0"
-        build_gem "harry", "2.0" do |s|
-          s.add_dependency "george"
-        end
-      end
-
-      bundle "update --source harry"
-      expect(the_bundle).to include_gems "harry 2.0"
-      expect(the_bundle).to include_gems "fred 1.0"
-      expect(the_bundle).to include_gems "george 1.0"
-    end
-
-    it "should not update the child dependencies of a gem that has the same name as the source", :bundler => "3" do
+    it "should not update the child dependencies of a gem that has the same name as the source" do
       update_repo2 do
         build_gem "george", "2.0"
         build_gem "harry", "2.0" do |s|

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -1106,9 +1106,9 @@ RSpec.describe "bundle update conservative" do
         gem 'shared_owner_b'
       G
 
-      lockfile <<-L
+      lockfile <<~L
         GEM
-          remote: #{file_uri_for(gem_repo4)}
+          remote: #{file_uri_for(gem_repo4)}/
           specs:
             isolated_dep (2.0.1)
             isolated_owner (1.0.1)
@@ -1120,12 +1120,12 @@ RSpec.describe "bundle update conservative" do
               shared_dep (~> 5.0)
 
         PLATFORMS
-          ruby
+          #{specific_local_platform}
 
         DEPENDENCIES
+          isolated_owner
           shared_owner_a
           shared_owner_b
-          isolated_owner
 
         BUNDLED WITH
            #{Bundler::VERSION}


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The `--conservative` flag to `bundle update` and `bundle lock --update` was unexpectedly updating indirect dependencies.

## What is your fix for the problem, implemented in this PR?

My fix is to make sure all indirect dependencies are locked to what's in the lockfile when resolving and that the `--conservative` flag is properly fed to the definition, even if no specific gems are given in the command line.

Fixes #4319.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
