### PR TITLE
Fixes for the edge case when openssl library is missing

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2421,7 +2421,6 @@ class Gem::Specification < Gem::BasicSpecification
   # still have their default values are omitted.
 
   def to_ruby
-    require_relative 'openssl'
     mark_version
     result = []
     result << "# -*- encoding: utf-8 -*-"
@@ -2455,14 +2454,19 @@ class Gem::Specification < Gem::BasicSpecification
       :has_rdoc,
       :default_executable,
       :metadata,
+      :signing_key,
     ]
 
     @@attributes.each do |attr_name|
       next if handled.include? attr_name
       current_value = self.send(attr_name)
       if current_value != default_value(attr_name) || self.class.required_attribute?(attr_name)
-        result << "  s.#{attr_name} = #{ruby_code current_value}" unless defined?(OpenSSL::PKey::RSA) && current_value.is_a?(OpenSSL::PKey::RSA)
+        result << "  s.#{attr_name} = #{ruby_code current_value}"
       end
+    end
+
+    if String === signing_key
+      result << "  s.signing_key = #{signing_key.dump}.freeze"
     end
 
     if @installed_by_version

--- a/test/rubygems/test_gem_ext_rake_builder.rb
+++ b/test/rubygems/test_gem_ext_rake_builder.rb
@@ -48,6 +48,8 @@ class TestGemExtRakeBuilder < Gem::TestCase
   end
 
   def test_class_no_openssl_override
+    pend 'openssl is missing' unless Gem::HAVE_OPENSSL
+
     create_temp_mkrf_file('task :default')
 
     rake = util_spec 'rake' do |s|


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Some test cases from RubyGems are currently failing on a Ruby installation without OpenSSL support.

Most code requiring openssl library is properly handling that. Here is an attempt to fix the leftovers:

## What is your fix for the problem, implemented in this PR?

---
**Do not use openssl constants in Gem::Specification#to_ruby**

The attribute can be either a String indicating the path of the private
key file or a raw key object (an instance of OpenSSL::PKey::RSA).
Currently, the attribute is excluded from #to_ruby in the latter case.

The current code does not interact well when the openssl library is
missing. Evaluating "defined?(OpenSSL::PKey::RSA)" will attempt to
activate the openssl gem due to autoload, and that causes weird test
failures.

Since we know what type signing_key will be otherwise, which is String,
we can simply check that instead.

---
**Skip TestGemExtRakeBuilder#test_class_no_openssl_override if necessary**

It is a regression test for a bug where RubyGems' openssl.rb slipped
into LOAD_PATH. This requires the actual openssl library to be
available.

---
**Make "gem cert --help" available when OpenSSL is missing**

The entire Gem::Commands::CertCommand class is undefined when OpenSSL
is not available. This is not expected by Gem::CommandManager and
attempting to invoke the cert command fails with an unfriendly message:

        $ gem cert --help
        ERROR:  Loading command: cert (NameError)
                uninitialized constant Gem::Commands::CertCommand
        ERROR:  While executing gem ... (NoMethodError)
            undefined method `deprecated?' for nil:NilClass

Let's tweak the OptionParser construction to not use OpenSSL constants
until they are necessary.


## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
