### PR TITLE
Allow setting `--otp` via `GEM_HOST_OTP_CODE`

### DIFF
--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -52,6 +52,13 @@ module Gem::GemcutterUtilities
   end
 
   ##
+  # The OTP code from the command options or from the user's configuration.
+
+  def otp
+    options[:otp] || ENV["GEM_HOST_OTP_CODE"]
+  end
+
+  ##
   # The host to connect to either from the RUBYGEMS_HOST environment variable
   # or from the user's configuration
 
@@ -126,7 +133,7 @@ module Gem::GemcutterUtilities
     response = rubygems_api_request(:put, "api/v1/api_key",
                                     sign_in_host, scope: scope) do |request|
       request.basic_auth email, password
-      request["OTP"] = options[:otp] if options[:otp]
+      request["OTP"] = otp if otp
       request.body = URI.encode_www_form({:api_key => api_key }.merge(update_scope_params))
     end
 
@@ -159,7 +166,7 @@ module Gem::GemcutterUtilities
     response = rubygems_api_request(:post, "api/v1/api_key",
                                     sign_in_host, scope: scope) do |request|
       request.basic_auth email, password
-      request["OTP"] = options[:otp] if options[:otp]
+      request["OTP"] = otp if otp
       request.body = URI.encode_www_form({ name: key_name }.merge(scope_params))
     end
 
@@ -224,7 +231,7 @@ module Gem::GemcutterUtilities
     request_method = Net::HTTP.const_get method.to_s.capitalize
 
     Gem::RemoteFetcher.fetcher.request(uri, request_method) do |req|
-      req["OTP"] = options[:otp] if options[:otp]
+      req["OTP"] = otp if otp
       block.call(req)
     end
   end

--- a/test/rubygems/test_gem_gemcutter_utilities.rb
+++ b/test/rubygems/test_gem_gemcutter_utilities.rb
@@ -14,6 +14,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
     Gem.configuration.disable_default_gem_server = nil
 
     ENV['RUBYGEMS_HOST'] = nil
+    ENV['GEM_HOST_OTP_CODE'] = nil
     Gem.configuration.rubygems_api_key = nil
 
     @cmd = Gem::Command.new '', 'summary'
@@ -22,6 +23,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
 
   def teardown
     ENV['RUBYGEMS_HOST'] = nil
+    ENV['GEM_HOST_OTP_CODE'] = nil
     Gem.configuration.rubygems_api_key = nil
 
     credential_teardown
@@ -184,6 +186,16 @@ class TestGemGemcutterUtilities < Gem::TestCase
 
     assert_match %r{Enter your RubyGems.org credentials.}, @sign_in_ui.output
     assert_match %r{Access Denied.}, @sign_in_ui.output
+  end
+
+  def test_signin_with_env_otp_code
+    ENV['GEM_HOST_OTP_CODE'] = '111111'
+    api_key = 'a5fdbb6ba150cbb83aad2bb2fede64cf040453903'
+
+    util_sign_in [api_key, 200, 'OK']
+
+    assert_match 'Signed in with API key:', @sign_in_ui.output
+    assert_equal '111111', @fetcher.last_request['OTP']
   end
 
   def test_sign_in_with_correct_otp_code


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

For release automation it can be nice to want to pass in the OTP via
some UI (e.g. a workflow_dispatch input on GitHub Actions) and then just
be able to run `rake release` to publish to rubygems.

## What is your fix for the problem, implemented in this PR?

This introduces a new environment variable `GEM_HOST_OTP_CODE` which
will take precendence over `--otp` command line options, allowing for
automated releases with OTP.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
