### PR TITLE
Fix incorrect re-resolve edge case

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -112,7 +112,7 @@ module Bundler
       end
 
       @locked_gem_sources = @locked_sources.select {|s| s.is_a?(Source::Rubygems) }
-      @multisource_allowed = @locked_gem_sources.any?(&:multiple_remotes?) && (sources.aggregate_global_source? || Bundler.frozen_bundle?)
+      @multisource_allowed = @locked_gem_sources.any?(&:multiple_remotes?) && Bundler.frozen_bundle?
 
       if @multisource_allowed
         unless sources.aggregate_global_source?

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -271,7 +271,9 @@ RSpec.describe "bundle install with gems on multiple sources" do
                #{Bundler::VERSION}
           L
 
+          previous_lockfile = lockfile
           expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0")
+          expect(lockfile).to eq(previous_lockfile)
         end
 
         it "fails", :bundler => "3" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When using multiple global sources and scoped sources at the same time, bundler will initially create a correct lockfile with only the multiple global sources merged together, but then further usages of `Bundler.setup` would trigger a re-resolve and rewrite the lockfile with all sources merged together.
    
This incorrect re-resolve was causing test failures on MacOS, blocking several PRs on the ruby-core repo, and a PR in the upstream repo to add a MacOS CI.

The explanation of why this was causing test failures, and why only on MacOS, is tricky, but goes as follows:
    
* The re-resolve was making the failing specs to touch the network, which was unexpected because the specs were using fake sources like `https://gem.repo3` but not passing something like `:artifice => "compact_index"` to the bundler subprocess to mock the requests. Thi situation would create network failures during DNS resolution of the dummy server name.

* However, those network issues caused different behaviour on MacOS and other platforms, because the underlying kernel error when calling `getaddrinfo` is worded slightly differently on the different platforms, and bundler matches the error by its message, not by error class. Offending code is here:

https://github.com/rubygems/rubygems/blob/faa8cf6cccd2ae18eba7191618ff639cc0ddfd7c/bundler/lib/bundler/fetcher/downloader.rb#L69-L78
    
* The above match was being successful on MacOS, causing the error to be detected as "fatal" and failing the spec. On other platforms, the regexp on the error message was not being matched, so the error was interpreted as retriable. This would cause bundler to fallback from the compact index to the old dependency API, fail again there and eventually decide that there are no available dependency APIs, and happily run in the old mode that aggregates all rubygems sources together.

## What is your fix for the problem, implemented in this PR?

The fix is to eliminate the incorrect condition that was causing the incorrect re-resolve.

The issue of the different behaviour of MacOS and other platforms due to the different wording of `getaddrinfo` errors will be fixed as a separate PR.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
