### PR TITLE
Fix some gems being unintentionally locked under multiple lockfile sections

### DIFF
--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -73,7 +73,7 @@ module Bundler
 
       def can_lock?(spec)
         return super unless multiple_remotes?
-        spec.source.is_a?(Rubygems)
+        include?(spec.source)
       end
 
       def options

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -247,6 +247,30 @@ RSpec.describe "bundle install with gems on multiple sources" do
           bundle :install, :artifice => "compact_index"
           expect(err).to include("Warning: the gem 'rack' was found in multiple sources.")
           expect(err).to include("Installed from: https://gem.repo2")
+
+          expect(lockfile).to eq <<~L
+            GEM
+              remote: https://gem.repo1/
+              remote: https://gem.repo2/
+              specs:
+                rack (1.0.0)
+
+            GEM
+              remote: https://gem.repo3/
+              specs:
+                depends_on_rack (1.0.1)
+                  rack
+
+            PLATFORMS
+              #{specific_local_platform}
+
+            DEPENDENCIES
+              depends_on_rack!
+
+            BUNDLED WITH
+               #{Bundler::VERSION}
+          L
+
           expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0")
         end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The end user problem was that when a gemfile uses multiple global gem sources and scoped sources, some gems would be incorrectly locked under multiple GEM sections. This was detected by CI when introducing [another bug fix](https://github.com/rubygems/rubygems/pull/4700).
 
## What is your fix for the problem, implemented in this PR?

My fix is to change the logic that decides under which section each gem should be locked to account for the case where there are GEM sources with multiple remotes, but also other different GEM sources.
 
## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
