### PR TITLE
Fix `getaddrinfo` errors not treated as fatal on non darwin platforms

### DIFF
--- a/bundler/lib/bundler/fetcher/downloader.rb
+++ b/bundler/lib/bundler/fetcher/downloader.rb
@@ -68,8 +68,7 @@ module Bundler
         raise CertificateFailureError.new(uri)
       rescue *HTTP_ERRORS => e
         Bundler.ui.trace e
-        case e.message
-        when /host down:/, /getaddrinfo: nodename nor servname provided/
+        if e.is_a?(SocketError) || e.message =~ /host down:/
           raise NetworkDownError, "Could not reach host #{uri.host}. Check your network " \
             "connection and try again."
         else

--- a/bundler/spec/bundler/fetcher/downloader_spec.rb
+++ b/bundler/spec/bundler/fetcher/downloader_spec.rb
@@ -231,16 +231,7 @@ RSpec.describe Bundler::Fetcher::Downloader do
         end
       end
 
-      context "when error message is about getaddrinfo issues" do
-        let(:message) { "getaddrinfo: nodename nor servname provided for http://www.uri-to-fetch.com" }
-
-        it "should raise a Bundler::Fetcher::NetworkDownError" do
-          expect { subject.request(uri, options) }.to raise_error(Bundler::Fetcher::NetworkDownError,
-            /Could not reach host www.uri-to-fetch.com/)
-        end
-      end
-
-      context "when error message is about neither host down or getaddrinfo" do
+      context "when error message is not about host down" do
         let(:message) { "other error about network" }
 
         it "should raise a Bundler::HTTPError" do

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -1280,6 +1280,25 @@ RSpec.describe "bundle install with gems on multiple sources" do
     expect(out).to include("Using example 0.1.0")
   end
 
+  it "fails inmmediately with a helpful error when a non retriable network error happens while resolving sources" do
+    gemfile <<-G
+      source "https://gem.repo1"
+
+      source "https://gem.repo4" do
+        gem "example"
+      end
+    G
+
+    simulate_bundler_version_when_missing_prerelease_default_gem_activation do
+      ruby <<~R, :raise_on_error => false
+        require 'bundler/setup'
+      R
+    end
+
+    expect(last_command).to be_failure
+    expect(err).to include("Could not reach host gem.repo4. Check your network connection and try again.")
+  end
+
   context "when an indirect dependency is available from multiple ambiguous sources", :bundler => "< 3" do
     it "succeeds but warns, suggesting a source block" do
       build_repo4 do

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -971,7 +971,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
               rack (0.9.1)
 
           PLATFORMS
-            ruby
+            #{specific_local_platform}
 
           DEPENDENCIES
             rack!

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -486,9 +486,10 @@ module Spec
       end
     end
 
-    # versions not including https://github.com/rubygems/rubygems/commit/929e92d752baad3a08f3ac92eaec162cb96aedd1
+    # versions providing a bundler version finder but not including
+    # https://github.com/rubygems/rubygems/commit/929e92d752baad3a08f3ac92eaec162cb96aedd1
     def rubygems_version_failing_to_activate_bundler_prereleases
-      Gem.rubygems_version < Gem::Version.new("3.1.0.pre.1")
+      Gem.rubygems_version < Gem::Version.new("3.1.0.pre.1") && Gem.rubygems_version >= Gem::Version.new("2.7.0")
     end
 
     def revision_for(path)

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -468,9 +468,8 @@ module Spec
       ENV["BUNDLER_SPEC_WINDOWS"] = old
     end
 
-    # workaround for missing https://github.com/rubygems/rubygems/commit/929e92d752baad3a08f3ac92eaec162cb96aedd1
     def simulate_bundler_version_when_missing_prerelease_default_gem_activation
-      return yield unless Gem.rubygems_version < Gem::Version.new("3.1.0.pre.1")
+      return yield unless rubygems_version_failing_to_activate_bundler_prereleases
 
       old = ENV["BUNDLER_VERSION"]
       ENV["BUNDLER_VERSION"] = Bundler::VERSION
@@ -479,13 +478,17 @@ module Spec
       ENV["BUNDLER_VERSION"] = old
     end
 
-    # workaround for missing https://github.com/rubygems/rubygems/commit/929e92d752baad3a08f3ac92eaec162cb96aedd1
     def env_for_missing_prerelease_default_gem_activation
-      if Gem.rubygems_version < Gem::Version.new("3.1.0.pre.1")
+      if rubygems_version_failing_to_activate_bundler_prereleases
         { "BUNDLER_VERSION" => Bundler::VERSION }
       else
         {}
       end
+    end
+
+    # versions not including https://github.com/rubygems/rubygems/commit/929e92d752baad3a08f3ac92eaec162cb96aedd1
+    def rubygems_version_failing_to_activate_bundler_prereleases
+      Gem.rubygems_version < Gem::Version.new("3.1.0.pre.1")
     end
 
     def revision_for(path)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If a `getaddrinfo` error happens during network resolution, we expect to fail inmediatly with a proper error. Instead, we were treating the error as retryable and eventually failing later with a more obscure error.

The problem is specific to platforms different from MacOS, because we were matching `getaddrinfo` errors by their wording and the wording is slightly different on other platforms.
 
## What is your fix for the problem, implemented in this PR?

My fix is to instead match the error by its class.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
