### PR TITLE
Update api_key configuration precedence

### DIFF
--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -40,12 +40,12 @@ module Gem::GemcutterUtilities
   # The API key from the command options or from the user's configuration.
 
   def api_key
-    if ENV["GEM_HOST_API_KEY"]
-      ENV["GEM_HOST_API_KEY"]
-    elsif options[:key]
+    if options[:key]
       verify_api_key options[:key]
     elsif Gem.configuration.api_keys.key?(host)
       Gem.configuration.api_keys[host]
+    elsif ENV["GEM_HOST_API_KEY"]
+      ENV["GEM_HOST_API_KEY"]
     else
       Gem.configuration.rubygems_api_key
     end

--- a/test/rubygems/test_gem_gemcutter_utilities.rb
+++ b/test/rubygems/test_gem_gemcutter_utilities.rb
@@ -14,6 +14,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
     Gem.configuration.disable_default_gem_server = nil
 
     ENV['RUBYGEMS_HOST'] = nil
+    ENV['GEM_HOST_API_KEY'] = nil
     Gem.configuration.rubygems_api_key = nil
 
     @cmd = Gem::Command.new '', 'summary'
@@ -22,6 +23,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
 
   def teardown
     ENV['RUBYGEMS_HOST'] = nil
+    ENV['GEM_HOST_API_KEY'] = nil
     Gem.configuration.rubygems_api_key = nil
 
     credential_teardown
@@ -71,6 +73,33 @@ class TestGemGemcutterUtilities < Gem::TestCase
     @cmd.handle_options %w[--key other]
 
     assert_equal 'OTHER', @cmd.api_key
+  end
+
+  def test_api_key_env_override
+    ENV['GEM_HOST_API_KEY'] = 'ENV'
+
+    keys = { :rubygems_api_key => 'KEY', :other => 'OTHER' }
+
+    File.open Gem.configuration.credentials_path, 'w' do |f|
+      f.write keys.to_yaml
+    end
+
+    Gem.configuration.load_api_keys
+
+    @cmd.add_key_option
+    @cmd.handle_options %w[--key other]
+
+    assert_equal 'OTHER', @cmd.api_key
+  end
+
+  def test_api_key_from_env
+    ENV['GEM_HOST_API_KEY'] = 'ENV'
+
+    Gem.configuration.load_api_keys
+
+    @cmd.add_key_option
+
+    assert_equal 'ENV', @cmd.api_key
   end
 
   def test_host


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

During review of #4697 it was realised that the precedence order for the `api_key` option was not as expected.
CLI option inputted by a user should take precedence over environment variables.

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

Updates the precedence order for where to look for an API key to be the
following:
- The api_key as passed in via the `--api-key` CLI option
- The api_key as configured for the current host in `.gems/credentials`
- The api_key as configured by GEM_HOST_API_KEY env var
- The api_key as configured in `.gems/credentials` for rubygems.org

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
