### PR TITLE
Fix `bundle doctor` crashing when finding a broken symlink

### DIFF
--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -13,7 +13,7 @@ require "bundler"
 require "rspec/core"
 require "rspec/expectations"
 require "rspec/mocks"
-require "diff/lcs"
+require "rspec/support/differ"
 
 require_relative "support/builders"
 require_relative "support/build_metadata"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The `bundle doctor` command crashes when it finds a broken symlink.

## What is your fix for the problem, implemented in this PR?

Check for file existance and keep track of broken symlinks too.

Fixes https://github.com/rubygems/rubygems/issues/3242.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
