### PR TITLE
Don't require bundler absolutely when running specs

### DIFF
--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -104,7 +104,7 @@ module Bundler
     private
 
     def warn_if_root
-      return if Bundler.settings[:silence_root_warning] || Bundler::WINDOWS || !Process.uid.zero?
+      return if Bundler.settings[:silence_root_warning] || Gem.win_platform? || !Process.uid.zero?
       Bundler.ui.warn "Don't run Bundler as root. Bundler can ask for sudo " \
         "if it is needed, and installing your bundle as root will break this " \
         "application for all non-root users on this machine.", :wrap => true

--- a/bundler/lib/bundler/current_ruby.rb
+++ b/bundler/lib/bundler/current_ruby.rb
@@ -65,19 +65,19 @@ module Bundler
     end
 
     def mswin?
-      Bundler::WINDOWS
+      Gem.win_platform?
     end
 
     def mswin64?
-      Bundler::WINDOWS && Bundler.local_platform != Gem::Platform::RUBY && Bundler.local_platform.os == "mswin64" && Bundler.local_platform.cpu == "x64"
+      Gem.win_platform? && Bundler.local_platform != Gem::Platform::RUBY && Bundler.local_platform.os == "mswin64" && Bundler.local_platform.cpu == "x64"
     end
 
     def mingw?
-      Bundler::WINDOWS && Bundler.local_platform != Gem::Platform::RUBY && Bundler.local_platform.os == "mingw32" && Bundler.local_platform.cpu != "x64"
+      Gem.win_platform? && Bundler.local_platform != Gem::Platform::RUBY && Bundler.local_platform.os == "mingw32" && Bundler.local_platform.cpu != "x64"
     end
 
     def x64_mingw?
-      Bundler::WINDOWS && Bundler.local_platform != Gem::Platform::RUBY && Bundler.local_platform.os == "mingw32" && Bundler.local_platform.cpu == "x64"
+      Gem.win_platform? && Bundler.local_platform != Gem::Platform::RUBY && Bundler.local_platform.os == "mingw32" && Bundler.local_platform.cpu == "x64"
     end
 
     (KNOWN_MINOR_VERSIONS + KNOWN_MAJOR_VERSIONS).each do |version|

--- a/bundler/lib/bundler/installer.rb
+++ b/bundler/lib/bundler/installer.rb
@@ -135,7 +135,7 @@ module Bundler
           next
         end
 
-        mode = Bundler::WINDOWS ? "wb:UTF-8" : "w"
+        mode = Gem.win_platform? ? "wb:UTF-8" : "w"
         require "erb"
         content = if RUBY_VERSION >= "2.6"
           ERB.new(template, :trim_mode => "-").result(binding)
@@ -144,7 +144,7 @@ module Bundler
         end
 
         File.write(binstub_path, content, :mode => mode, :perm => 0o777 & ~File.umask)
-        if Bundler::WINDOWS || options[:all_platforms]
+        if Gem.win_platform? || options[:all_platforms]
           prefix = "@ruby -x \"%~f0\" %*\n@exit /b %ERRORLEVEL%\n\n"
           File.write("#{binstub_path}.cmd", prefix + content, :mode => mode)
         end
@@ -182,7 +182,7 @@ module Bundler
         executable_path = Pathname(spec.full_gem_path).join(spec.bindir, executable).relative_path_from(bin_path)
         executable_path = executable_path
 
-        mode = Bundler::WINDOWS ? "wb:UTF-8" : "w"
+        mode = Gem.win_platform? ? "wb:UTF-8" : "w"
         require "erb"
         content = if RUBY_VERSION >= "2.6"
           ERB.new(template, :trim_mode => "-").result(binding)
@@ -191,7 +191,7 @@ module Bundler
         end
 
         File.write("#{bin_path}/#{executable}", content, :mode => mode, :perm => 0o755)
-        if Bundler::WINDOWS || options[:all_platforms]
+        if Gem.win_platform? || options[:all_platforms]
           prefix = "@ruby -x \"%~f0\" %*\n@exit /b %ERRORLEVEL%\n\n"
           File.write("#{bin_path}/#{executable}.cmd", prefix + content, :mode => mode)
         end

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -399,7 +399,7 @@ The checksum of /versions does not match the checksum provided by the server! So
 
     api_request_limit = low_api_request_limit_for(gem_repo2)
 
-    install_gemfile <<-G, :artifice => "compact_index_extra_missing", :env => { "BUNDLER_SPEC_API_REQUEST_LIMIT" => api_request_limit.to_s }.merge(env_for_missing_prerelease_default_gem_activation)
+    install_gemfile <<-G, :artifice => "compact_index_extra_missing", :requires => [api_request_limit_hack_file], :env => { "BUNDLER_SPEC_API_REQUEST_LIMIT" => api_request_limit.to_s }.merge(env_for_missing_prerelease_default_gem_activation)
       source "#{source_uri}"
       source "#{source_uri}/extra" do
         gem "back_deps"
@@ -421,7 +421,7 @@ The checksum of /versions does not match the checksum provided by the server! So
 
     api_request_limit = low_api_request_limit_for(gem_repo4)
 
-    install_gemfile <<-G, :artifice => "compact_index_extra_api_missing", :env => { "BUNDLER_SPEC_API_REQUEST_LIMIT" => api_request_limit.to_s }.merge(env_for_missing_prerelease_default_gem_activation)
+    install_gemfile <<-G, :artifice => "compact_index_extra_api_missing", :requires => [api_request_limit_hack_file], :env => { "BUNDLER_SPEC_API_REQUEST_LIMIT" => api_request_limit.to_s }.merge(env_for_missing_prerelease_default_gem_activation)
       source "#{source_uri}"
       source "#{source_uri}/extra" do
         gem "back_deps"

--- a/bundler/spec/install/gems/dependency_api_spec.rb
+++ b/bundler/spec/install/gems/dependency_api_spec.rb
@@ -371,7 +371,7 @@ RSpec.describe "gemcutter's dependency API" do
 
     api_request_limit = low_api_request_limit_for(gem_repo2)
 
-    install_gemfile <<-G, :artifice => "endpoint_extra_missing", :env => { "BUNDLER_SPEC_API_REQUEST_LIMIT" => api_request_limit.to_s }.merge(env_for_missing_prerelease_default_gem_activation)
+    install_gemfile <<-G, :artifice => "endpoint_extra_missing", :requires => [api_request_limit_hack_file], :env => { "BUNDLER_SPEC_API_REQUEST_LIMIT" => api_request_limit.to_s }.merge(env_for_missing_prerelease_default_gem_activation)
       source "#{source_uri}"
       source "#{source_uri}/extra"
       gem "back_deps"
@@ -392,7 +392,7 @@ RSpec.describe "gemcutter's dependency API" do
 
     api_request_limit = low_api_request_limit_for(gem_repo2)
 
-    install_gemfile <<-G, :artifice => "endpoint_extra_missing", :env => { "BUNDLER_SPEC_API_REQUEST_LIMIT" => api_request_limit.to_s }.merge(env_for_missing_prerelease_default_gem_activation)
+    install_gemfile <<-G, :artifice => "endpoint_extra_missing", :requires => [api_request_limit_hack_file], :env => { "BUNDLER_SPEC_API_REQUEST_LIMIT" => api_request_limit.to_s }.merge(env_for_missing_prerelease_default_gem_activation)
       source "#{source_uri}"
       source "#{source_uri}/extra" do
         gem "back_deps"

--- a/bundler/spec/install/global_cache_spec.rb
+++ b/bundler/spec/install/global_cache_spec.rb
@@ -181,8 +181,11 @@ RSpec.describe "global gem caching" do
         bundle :install, :artifice => "compact_index_no_gem", :dir => bundled_app2
 
         # activesupport is installed and both are in the global cache
-        expect(the_bundle).not_to include_gems "rack 1.0.0", :dir => bundled_app2
-        expect(the_bundle).to include_gems "activesupport 2.3.5", :dir => bundled_app2
+        simulate_bundler_version_when_missing_prerelease_default_gem_activation do
+          expect(the_bundle).not_to include_gems "rack 1.0.0", :dir => bundled_app2
+          expect(the_bundle).to include_gems "activesupport 2.3.5", :dir => bundled_app2
+        end
+
         expect(source_global_cache("rack-1.0.0.gem")).to exist
         expect(source_global_cache("activesupport-2.3.5.gem")).to exist
       end

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -1326,7 +1326,10 @@ RSpec.describe "the lockfile format" do
 
         expect { bundle "update", :all => true }.to change { File.mtime(bundled_app_lock) }
         expect(File.read(bundled_app_lock)).to match("\r\n")
-        expect(the_bundle).to include_gems "rack 1.2"
+
+        simulate_bundler_version_when_missing_prerelease_default_gem_activation do
+          expect(the_bundle).to include_gems "rack 1.2"
+        end
       end
     end
 

--- a/bundler/spec/support/api_request_limit_hax.rb
+++ b/bundler/spec/support/api_request_limit_hax.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+if ENV["BUNDLER_SPEC_API_REQUEST_LIMIT"]
+  require_relative "path"
+  require "bundler/source"
+  require "bundler/source/rubygems"
+
+  module Bundler
+    class Source
+      class Rubygems < Source
+        remove_const :API_REQUEST_LIMIT
+        API_REQUEST_LIMIT = ENV["BUNDLER_SPEC_API_REQUEST_LIMIT"].to_i
+      end
+    end
+  end
+end

--- a/bundler/spec/support/hax.rb
+++ b/bundler/spec/support/hax.rb
@@ -36,16 +36,6 @@ module Gem
   end
 end
 
-if ENV["BUNDLER_SPEC_WINDOWS"] == "true"
-  require_relative "path"
-  require "bundler/constants"
-
-  module Bundler
-    remove_const :WINDOWS if defined?(WINDOWS)
-    WINDOWS = true
-  end
-end
-
 if ENV["BUNDLER_SPEC_API_REQUEST_LIMIT"]
   require_relative "path"
   require "bundler/source"

--- a/bundler/spec/support/hax.rb
+++ b/bundler/spec/support/hax.rb
@@ -35,18 +35,3 @@ module Gem
     end
   end
 end
-
-if ENV["BUNDLER_SPEC_API_REQUEST_LIMIT"]
-  require_relative "path"
-  require "bundler/source"
-  require "bundler/source/rubygems"
-
-  module Bundler
-    class Source
-      class Rubygems < Source
-        remove_const :API_REQUEST_LIMIT
-        API_REQUEST_LIMIT = ENV["BUNDLER_SPEC_API_REQUEST_LIMIT"].to_i
-      end
-    end
-  end
-end

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -457,15 +457,11 @@ module Spec
     end
 
     def simulate_windows(platform = mswin)
-      old = ENV["BUNDLER_SPEC_WINDOWS"]
-      ENV["BUNDLER_SPEC_WINDOWS"] = "true"
       simulate_platform platform do
         simulate_bundler_version_when_missing_prerelease_default_gem_activation do
           yield
         end
       end
-    ensure
-      ENV["BUNDLER_SPEC_WINDOWS"] = old
     end
 
     def simulate_bundler_version_when_missing_prerelease_default_gem_activation

--- a/bundler/spec/support/matchers.rb
+++ b/bundler/spec/support/matchers.rb
@@ -118,14 +118,14 @@ module Spec
         opts[:raise_on_error] = false
         @errors = names.map do |full_name|
           name, version, platform = full_name.split(/\s+/)
-          require_path = name == "bundler" ? "#{lib_dir}/bundler" : name.tr("-", "/")
+          require_path = name.tr("-", "/")
           version_const = name == "bundler" ? "Bundler::VERSION" : Spec::Builders.constantize(name)
           source_const = "#{Spec::Builders.constantize(name)}_SOURCE"
           ruby <<~R, opts
-            require '#{lib_dir}/bundler'
+            require 'bundler'
             Bundler.setup(#{groups})
 
-            require '#{require_path}.rb'
+            require '#{require_path}'
             actual_version, actual_platform = #{version_const}.split(/\s+/, 2)
             unless Gem::Version.new(actual_version) == Gem::Version.new('#{version}')
               puts actual_version
@@ -170,7 +170,7 @@ module Spec
           name, version = name.split(/\s+/, 2)
           ruby <<-R, opts
             begin
-              require '#{lib_dir}/bundler'
+              require 'bundler'
               Bundler.setup(#{groups})
             rescue Bundler::GemNotFound, Bundler::GitError
               exit 0

--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -71,6 +71,10 @@ module Spec
       @spec_dir ||= source_root.join(ruby_core? ? "spec/bundler" : "spec")
     end
 
+    def api_request_limit_hack_file
+      spec_dir.join("support/api_request_limit_hax.rb")
+    end
+
     def man_dir
       @man_dir ||= lib_dir.join("bundler/man")
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

All specs except the ones using this matcher require bundler without an absolute path like it's done in the realworld. By doing that, we also make sure rubygems code that activates the proper bundler version is also exercised.

## What is your fix for the problem, implemented in this PR?

This commit changes this matcher to be consistent with the rest of the specs.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
