### PR TITLE
Prefer canonical qualified names for classes under Thread

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -37,7 +37,7 @@ module Bundler
   environment_preserver = EnvironmentPreserver.from_env
   ORIGINAL_ENV = environment_preserver.restore
   environment_preserver.replace_with_backup
-  SUDO_MUTEX = Mutex.new
+  SUDO_MUTEX = Thread::Mutex.new
 
   autoload :Definition,             File.expand_path("bundler/definition", __dir__)
   autoload :Dependency,             File.expand_path("bundler/dependency", __dir__)

--- a/bundler/lib/bundler/compact_index_client.rb
+++ b/bundler/lib/bundler/compact_index_client.rb
@@ -5,7 +5,7 @@ require "set"
 
 module Bundler
   class CompactIndexClient
-    DEBUG_MUTEX = Mutex.new
+    DEBUG_MUTEX = Thread::Mutex.new
     def self.debug
       return unless ENV["DEBUG_COMPACT_INDEX"]
       DEBUG_MUTEX.synchronize { warn("[#{self}] #{yield}") }
@@ -25,7 +25,7 @@ module Bundler
       @endpoints = Set.new
       @info_checksums_by_name = {}
       @parsed_checksums = false
-      @mutex = Mutex.new
+      @mutex = Thread::Mutex.new
     end
 
     def execution_mode=(block)

--- a/bundler/lib/bundler/vendor/connection_pool/lib/connection_pool/monotonic_time.rb
+++ b/bundler/lib/bundler/vendor/connection_pool/lib/connection_pool/monotonic_time.rb
@@ -27,7 +27,7 @@ class Bundler::ConnectionPool
 
       # @!visibility private
       def initialize
-        @mutex = Mutex.new
+        @mutex = Thread::Mutex.new
         @last_time = Time.now.to_f
       end
 

--- a/bundler/lib/bundler/vendor/connection_pool/lib/connection_pool/timed_stack.rb
+++ b/bundler/lib/bundler/vendor/connection_pool/lib/connection_pool/timed_stack.rb
@@ -39,8 +39,8 @@ class Bundler::ConnectionPool::TimedStack
     @created = 0
     @que = []
     @max = size
-    @mutex = Mutex.new
-    @resource = ConditionVariable.new
+    @mutex = Thread::Mutex.new
+    @resource = Thread::ConditionVariable.new
     @shutdown_block = nil
   end
 

--- a/bundler/lib/bundler/worker.rb
+++ b/bundler/lib/bundler/worker.rb
@@ -21,8 +21,8 @@ module Bundler
     # @param func [Proc] job to run in inside the worker pool
     def initialize(size, name, func)
       @name = name
-      @request_queue = Queue.new
-      @response_queue = Queue.new
+      @request_queue = Thread::Queue.new
+      @response_queue = Thread::Queue.new
       @func = func
       @size = size
       @threads = nil

--- a/bundler/spec/support/artifice/compact_index_rate_limited.rb
+++ b/bundler/spec/support/artifice/compact_index_rate_limited.rb
@@ -7,7 +7,7 @@ Artifice.deactivate
 class CompactIndexRateLimited < CompactIndexAPI
   class RequestCounter
     def self.queue
-      @queue ||= Queue.new
+      @queue ||= Thread::Queue.new
     end
 
     def self.size

--- a/bundler/spec/support/artifice/endpoint.rb
+++ b/bundler/spec/support/artifice/endpoint.rb
@@ -8,7 +8,7 @@ require "artifice"
 require "sinatra/base"
 
 ALL_REQUESTS = [] # rubocop:disable Style/MutableConstant
-ALL_REQUESTS_MUTEX = Mutex.new
+ALL_REQUESTS_MUTEX = Thread::Mutex.new
 
 at_exit do
   if expected = ENV["BUNDLER_SPEC_ALL_REQUESTS"]

--- a/bundler/tool/turbo_tests/runner.rb
+++ b/bundler/tool/turbo_tests/runner.rb
@@ -31,7 +31,7 @@ module TurboTests
       @failure_count = 0
       @runtime_log = "tmp/parallel_runtime_rspec.log"
 
-      @messages = Queue.new
+      @messages = Thread::Queue.new
       @threads = []
     end
 

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -178,7 +178,7 @@ module Gem
   @configuration = nil
   @gemdeps = nil
   @loaded_specs = {}
-  LOADED_SPECS_MUTEX = Mutex.new
+  LOADED_SPECS_MUTEX = Thread::Mutex.new
   @path_to_default_spec_map = {}
   @platforms = []
   @ruby = nil

--- a/lib/rubygems/core_ext/tcpsocket_init.rb
+++ b/lib/rubygems/core_ext/tcpsocket_init.rb
@@ -11,10 +11,10 @@ module CoreExtensions
       IPV4_DELAY_SECONDS = 0.1
 
       def initialize(host, serv, *rest)
-        mutex = Mutex.new
+        mutex = Thread::Mutex.new
         addrs = []
         threads = []
-        cond_var = ConditionVariable.new
+        cond_var = Thread::ConditionVariable.new
 
         Addrinfo.foreach(host, serv, nil, :STREAM) do |addr|
           Thread.report_on_exception = false if defined? Thread.report_on_exception = ()

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -68,7 +68,7 @@ class Gem::Installer
 
   @path_warning = false
 
-  @install_lock = Mutex.new
+  @install_lock = Thread::Mutex.new
 
   class << self
     ##

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -88,7 +88,7 @@ class Gem::RemoteFetcher
 
     @proxy = proxy
     @pools = {}
-    @pool_lock = Mutex.new
+    @pool_lock = Thread::Mutex.new
     @cert_files = Gem::Request.get_cert_files
 
     @headers = headers

--- a/lib/rubygems/request/connection_pools.rb
+++ b/lib/rubygems/request/connection_pools.rb
@@ -11,7 +11,7 @@ class Gem::Request::ConnectionPools # :nodoc:
     @proxy_uri  = proxy_uri
     @cert_files = cert_files
     @pools      = {}
-    @pool_mutex = Mutex.new
+    @pool_mutex = Thread::Mutex.new
   end
 
   def pool_for(uri)

--- a/lib/rubygems/request/http_pool.rb
+++ b/lib/rubygems/request/http_pool.rb
@@ -12,7 +12,7 @@ class Gem::Request::HTTPPool # :nodoc:
     @http_args  = http_args
     @cert_files = cert_files
     @proxy_uri  = proxy_uri
-    @queue      = SizedQueue.new 1
+    @queue      = Thread::SizedQueue.new 1
     @queue << nil
   end
 

--- a/lib/rubygems/request_set.rb
+++ b/lib/rubygems/request_set.rb
@@ -151,7 +151,7 @@ class Gem::RequestSet
     @prerelease = options[:prerelease]
 
     requests = []
-    download_queue = Queue.new
+    download_queue = Thread::Queue.new
 
     # Create a thread-safe list of gems to download
     sorted_requests.each do |req|

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -105,7 +105,7 @@ class Gem::Specification < Gem::BasicSpecification
   # rubocop:disable Style/MutableConstant
   LOAD_CACHE = {} # :nodoc:
   # rubocop:enable Style/MutableConstant
-  LOAD_CACHE_MUTEX = Mutex.new
+  LOAD_CACHE_MUTEX = Thread::Mutex.new
 
   private_constant :LOAD_CACHE if defined? private_constant
 

--- a/lib/rubygems/user_interaction.rb
+++ b/lib/rubygems/user_interaction.rb
@@ -543,7 +543,7 @@ class Gem::StreamUI
   # A progress reporter that behaves nicely with threaded downloading.
 
   class ThreadedDownloadReporter
-    MUTEX = Mutex.new
+    MUTEX = Thread::Mutex.new
 
     ##
     # The current file name being displayed


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since ruby 2.2, these classes (`Mutex`, `Queue`, `SizedQueue`, `ConditionVariable`) are built-in and under `Thread`.

```
$ ruby2.2 -v -e 'p ConditionVariable'
ruby 2.2.10p489 (2018-03-28 revision 63023) [x86_64-darwin19]
Thread::ConditionVariable
```

No problems right now actually, but they might be deprecated in future.

## What is your fix for the problem, implemented in this PR?

Prefixed with `Thread::`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
