### PR TITLE
missing gems in case the remote source is the same as the main source

### DIFF
--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -33,7 +33,10 @@ module Bundler
       aggregate_global_source = @source_requirements[:default].is_a?(Source::RubygemsAggregate)
       @base.each do |ls|
         dep = Dependency.new(ls.name, ls.version)
-        ls.source = source_for(ls.name) unless aggregate_global_source
+        unless aggregate_global_source
+          source = source_for(ls.name)
+          ls.source = source_for(ls.name) if source != @source_requirements[:default]
+        end
         @base_dg.add_vertex(ls.name, DepProxy.get_proxy(dep, ls.platform), true)
       end
       additional_base_requirements.each {|d| @base_dg.add_vertex(d.name, d) }


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?
I have a Gemfile like this
```
source 'https://rubygems.org'
gem 'rails'

source 'https://rubygems.org' do
  gem 'zip-zip'
end
```

after upgrading to 2.2.18+, my builds start failing on activation (rails commands), bundle install works fine
```
Could not find zip-zip-0.3 in any of the sources
Run `bundle install` to install missing gems.
```
gems inside a block are not recognized anymore, but they do exist even locally.
```
gem list zip-zip
*** LOCAL GEMS ***
zip-zip (0.3)
```

the block isn't necessary, because it's the same as the main source. If I just remove the block it works fine again.
```
source 'https://rubygems.org'
gem 'rails'
gem 'zip-zip'
```

I bisected the breaking change to https://github.com/rubygems/rubygems/pull/4609

is it unintentional behavior or just a corner case?

## What is your fix for the problem, implemented in this PR?
I probably won't be able to add a test case, but this change fixes the bug for me.

It could help someone who's more familiar with bundler sources to fix the problem properly. Feel free to close it if it's intentional.

Thanks!

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
