### PR TITLE
Fix edge case combination of DSL methods and duplicated sources causing gems to not be found

### DIFF
--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -45,7 +45,6 @@ module Bundler
       @gemfiles << expanded_gemfile_path
       contents ||= Bundler.read_file(@gemfile.to_s)
       instance_eval(contents.dup.tap{|x| x.untaint if RUBY_VERSION < "2.7" }, gemfile.to_s, 1)
-      check_primary_source_safety
     rescue Exception => e # rubocop:disable Lint/RescueException
       message = "There was an error " \
         "#{e.is_a?(GemfileEvalError) ? "evaluating" : "parsing"} " \
@@ -219,6 +218,7 @@ module Bundler
     end
 
     def to_definition(lockfile, unlock)
+      check_primary_source_safety
       Definition.new(lockfile, @dependencies, @sources, unlock, @ruby_version, @optional_groups, @gemfiles)
     end
 

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -24,9 +24,6 @@ module Bundler
     def initialize
       @source               = nil
       @sources              = SourceList.new
-
-      @global_rubygems_sources = []
-
       @git_sources          = {}
       @dependencies         = []
       @groups               = []
@@ -168,7 +165,7 @@ module Bundler
       elsif block_given?
         with_source(@sources.add_rubygems_source("remotes" => source), &blk)
       else
-        @global_rubygems_sources << source
+        @sources.add_rubygems_remote(source)
       end
     end
 
@@ -453,12 +450,7 @@ repo_name ||= user_name
     end
 
     def check_rubygems_source_safety
-      @sources.global_rubygems_source = @global_rubygems_sources.shift
-      return if @global_rubygems_sources.empty?
-
-      @global_rubygems_sources.each do |source|
-        @sources.add_rubygems_remote(source)
-      end
+      return unless @sources.aggregate_global_source?
 
       if Bundler.feature_flag.bundler_3_mode?
         msg = "This Gemfile contains multiple primary sources. " \

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -164,7 +164,7 @@ module Bundler
       elsif block_given?
         with_source(@sources.add_rubygems_source("remotes" => source), &blk)
       else
-        @sources.add_rubygems_remote(source)
+        @sources.add_global_rubygems_remote(source)
       end
     end
 

--- a/bundler/lib/bundler/plugin/installer.rb
+++ b/bundler/lib/bundler/plugin/installer.rb
@@ -77,7 +77,7 @@ module Bundler
         source_list = SourceList.new
 
         source_list.add_git_source(git_source_options) if git_source_options
-        source_list.add_rubygems_remote(rubygems_source) if rubygems_source
+        source_list.add_global_rubygems_remote(rubygems_source) if rubygems_source
 
         deps = names.map {|name| Dependency.new name, version }
 

--- a/bundler/lib/bundler/plugin/installer.rb
+++ b/bundler/lib/bundler/plugin/installer.rb
@@ -77,7 +77,7 @@ module Bundler
         source_list = SourceList.new
 
         source_list.add_git_source(git_source_options) if git_source_options
-        source_list.global_rubygems_source = rubygems_source if rubygems_source
+        source_list.add_rubygems_remote(rubygems_source) if rubygems_source
 
         deps = names.map {|name| Dependency.new name, version }
 

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -63,7 +63,7 @@ module Bundler
       add_source_to_list Plugin.source(source).new(options), @plugin_sources
     end
 
-    def add_rubygems_remote(uri)
+    def add_global_rubygems_remote(uri)
       global_rubygems_source.add_remote(uri)
       global_rubygems_source
     end

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -53,15 +53,14 @@ module Bundler
     end
 
     def add_rubygems_source(options = {})
-      add_source_to_list Source::Rubygems.new(options), @rubygems_sources
+      new_source = Source::Rubygems.new(options)
+      return @global_rubygems_source if @global_rubygems_source == new_source
+
+      add_source_to_list new_source, @rubygems_sources
     end
 
     def add_plugin_source(source, options = {})
       add_source_to_list Plugin.source(source).new(options), @plugin_sources
-    end
-
-    def global_rubygems_source=(uri)
-      @global_rubygems_source ||= rubygems_aggregate_class.new("remotes" => uri, "allow_local" => true)
     end
 
     def add_rubygems_remote(uri)

--- a/bundler/spec/bundler/definition_spec.rb
+++ b/bundler/spec/bundler/definition_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe Bundler::Definition do
       context "eager unlock" do
         let(:source_list) do
           Bundler::SourceList.new.tap do |source_list|
-            source_list.add_rubygems_remote(file_uri_for(gem_repo4))
+            source_list.add_global_rubygems_remote(file_uri_for(gem_repo4))
           end
         end
 

--- a/bundler/spec/bundler/definition_spec.rb
+++ b/bundler/spec/bundler/definition_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe Bundler::Definition do
       context "eager unlock" do
         let(:source_list) do
           Bundler::SourceList.new.tap do |source_list|
-            source_list.global_rubygems_source = file_uri_for(gem_repo4)
+            source_list.add_rubygems_remote(file_uri_for(gem_repo4))
           end
         end
 

--- a/bundler/spec/bundler/source_list_spec.rb
+++ b/bundler/spec/bundler/source_list_spec.rb
@@ -115,15 +115,15 @@ RSpec.describe Bundler::SourceList do
       end
     end
 
-    describe "#add_rubygems_remote", :bundler => "< 3" do
-      let!(:returned_source) { source_list.add_rubygems_remote("https://rubygems.org/") }
+    describe "#add_global_rubygems_remote", :bundler => "< 3" do
+      let!(:returned_source) { source_list.add_global_rubygems_remote("https://rubygems.org/") }
 
       it "returns the aggregate rubygems source" do
         expect(returned_source).to be_instance_of(Bundler::Source::Rubygems)
       end
 
       it "adds the provided remote to the beginning of the aggregate source" do
-        source_list.add_rubygems_remote("https://othersource.org")
+        source_list.add_global_rubygems_remote("https://othersource.org")
         expect(returned_source.remotes).to eq [
           Bundler::URI("https://othersource.org/"),
           Bundler::URI("https://rubygems.org/"),
@@ -212,22 +212,22 @@ RSpec.describe Bundler::SourceList do
 
   describe "#path_sources" do
     it "returns an empty array when no path sources have been added" do
-      source_list.add_rubygems_remote("https://rubygems.org")
+      source_list.add_global_rubygems_remote("https://rubygems.org")
       source_list.add_git_source("uri" => "git://host/path.git")
       expect(source_list.path_sources).to be_empty
     end
 
     it "returns path sources in the reverse order that they were added" do
       source_list.add_git_source("uri" => "git://third-git.org/path.git")
-      source_list.add_rubygems_remote("https://fifth-rubygems.org")
+      source_list.add_global_rubygems_remote("https://fifth-rubygems.org")
       source_list.add_path_source("path" => "/third/path/to/gem")
-      source_list.add_rubygems_remote("https://fourth-rubygems.org")
+      source_list.add_global_rubygems_remote("https://fourth-rubygems.org")
       source_list.add_path_source("path" => "/second/path/to/gem")
-      source_list.add_rubygems_remote("https://third-rubygems.org")
+      source_list.add_global_rubygems_remote("https://third-rubygems.org")
       source_list.add_git_source("uri" => "git://second-git.org/path.git")
-      source_list.add_rubygems_remote("https://second-rubygems.org")
+      source_list.add_global_rubygems_remote("https://second-rubygems.org")
       source_list.add_path_source("path" => "/first/path/to/gem")
-      source_list.add_rubygems_remote("https://first-rubygems.org")
+      source_list.add_global_rubygems_remote("https://first-rubygems.org")
       source_list.add_git_source("uri" => "git://first-git.org/path.git")
 
       expect(source_list.path_sources).to eq [
@@ -240,7 +240,7 @@ RSpec.describe Bundler::SourceList do
 
   describe "#git_sources" do
     it "returns an empty array when no git sources have been added" do
-      source_list.add_rubygems_remote("https://rubygems.org")
+      source_list.add_global_rubygems_remote("https://rubygems.org")
       source_list.add_path_source("path" => "/path/to/gem")
 
       expect(source_list.git_sources).to be_empty
@@ -248,15 +248,15 @@ RSpec.describe Bundler::SourceList do
 
     it "returns git sources in the reverse order that they were added" do
       source_list.add_git_source("uri" => "git://third-git.org/path.git")
-      source_list.add_rubygems_remote("https://fifth-rubygems.org")
+      source_list.add_global_rubygems_remote("https://fifth-rubygems.org")
       source_list.add_path_source("path" => "/third/path/to/gem")
-      source_list.add_rubygems_remote("https://fourth-rubygems.org")
+      source_list.add_global_rubygems_remote("https://fourth-rubygems.org")
       source_list.add_path_source("path" => "/second/path/to/gem")
-      source_list.add_rubygems_remote("https://third-rubygems.org")
+      source_list.add_global_rubygems_remote("https://third-rubygems.org")
       source_list.add_git_source("uri" => "git://second-git.org/path.git")
-      source_list.add_rubygems_remote("https://second-rubygems.org")
+      source_list.add_global_rubygems_remote("https://second-rubygems.org")
       source_list.add_path_source("path" => "/first/path/to/gem")
-      source_list.add_rubygems_remote("https://first-rubygems.org")
+      source_list.add_global_rubygems_remote("https://first-rubygems.org")
       source_list.add_git_source("uri" => "git://first-git.org/path.git")
 
       expect(source_list.git_sources).to eq [
@@ -269,7 +269,7 @@ RSpec.describe Bundler::SourceList do
 
   describe "#plugin_sources" do
     it "returns an empty array when no plugin sources have been added" do
-      source_list.add_rubygems_remote("https://rubygems.org")
+      source_list.add_global_rubygems_remote("https://rubygems.org")
       source_list.add_path_source("path" => "/path/to/gem")
 
       expect(source_list.plugin_sources).to be_empty
@@ -279,13 +279,13 @@ RSpec.describe Bundler::SourceList do
       source_list.add_plugin_source("new_source", "uri" => "https://third-git.org/path.git")
       source_list.add_git_source("https://new-git.org")
       source_list.add_path_source("path" => "/third/path/to/gem")
-      source_list.add_rubygems_remote("https://fourth-rubygems.org")
+      source_list.add_global_rubygems_remote("https://fourth-rubygems.org")
       source_list.add_path_source("path" => "/second/path/to/gem")
-      source_list.add_rubygems_remote("https://third-rubygems.org")
+      source_list.add_global_rubygems_remote("https://third-rubygems.org")
       source_list.add_plugin_source("new_source", "uri" => "git://second-git.org/path.git")
-      source_list.add_rubygems_remote("https://second-rubygems.org")
+      source_list.add_global_rubygems_remote("https://second-rubygems.org")
       source_list.add_path_source("path" => "/first/path/to/gem")
-      source_list.add_rubygems_remote("https://first-rubygems.org")
+      source_list.add_global_rubygems_remote("https://first-rubygems.org")
       source_list.add_plugin_source("new_source", "uri" => "git://first-git.org/path.git")
 
       expect(source_list.plugin_sources).to eq [
@@ -339,7 +339,7 @@ RSpec.describe Bundler::SourceList do
   describe "#get" do
     context "when it includes an equal source" do
       let(:rubygems_source) { Bundler::Source::Rubygems.new("remotes" => ["https://rubygems.org"]) }
-      before { @equal_source = source_list.add_rubygems_remote("https://rubygems.org") }
+      before { @equal_source = source_list.add_global_rubygems_remote("https://rubygems.org") }
 
       it "returns the equal source" do
         expect(source_list.get(rubygems_source)).to be @equal_source

--- a/bundler/spec/bundler/source_list_spec.rb
+++ b/bundler/spec/bundler/source_list_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Bundler::SourceList do
       end
     end
 
-    describe "#add_global_rubygems_remote", :bundler => "< 3" do
+    describe "#add_global_rubygems_remote" do
       let!(:returned_source) { source_list.add_global_rubygems_remote("https://rubygems.org/") }
 
       it "returns the aggregate rubygems source" do

--- a/bundler/spec/install/gemfile/eval_gemfile_spec.rb
+++ b/bundler/spec/install/gemfile/eval_gemfile_spec.rb
@@ -26,6 +26,38 @@ RSpec.describe "bundle install with gemfile that uses eval_gemfile" do
     end
   end
 
+  context "eval-ed Gemfile points to an internal gemspec and uses a scoped source that duplicates the main Gemfile global source" do
+    before do
+      build_repo2 do
+        build_gem "rails", "6.1.3.2"
+
+        build_gem "zip-zip", "0.3"
+      end
+
+      create_file bundled_app("gems/Gemfile"), <<-G
+        gemspec :path => "\#{__dir__}/gunks"
+
+        source "#{file_uri_for(gem_repo2)}" do
+          gem "zip-zip"
+        end
+      G
+    end
+
+    it "installs and finds gems correctly" do
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+
+        gem "rails"
+
+        eval_gemfile File.join(__dir__, "gems/Gemfile")
+      G
+      expect(out).to include("Resolving dependencies")
+      expect(out).to include("Bundle complete")
+
+      expect(the_bundle).to include_gem "rails 6.1.3.2"
+    end
+  end
+
   context "eval-ed Gemfile has relative-path gems" do
     before do
       build_lib("a", :path => bundled_app("gems/a"))


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When a certain combination of DSL methods are used (`eval_gemfile`, for example) and a scoped source duplicates a global source, `bundle install` can succeed, but the gems are not subsequently accessible. 

## What is your fix for the problem, implemented in this PR?

My fix is to make sure sources are added in the order the evaluated, and duplications between the global source and scoped sources are taken into account.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
