### PR TITLE
Limit MacOS jobs

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -17,7 +17,6 @@ jobs:
       matrix:
         os:
           - { name: Ubuntu, value: ubuntu-20.04 }
-          - { name: MacOS, value: macos-10.15 }
 
         ruby:
           - { name: ruby-2.3, value: 2.3.8 }
@@ -35,6 +34,12 @@ jobs:
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.3, value: 2.3.8 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.4, value: 2.4.10 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.5, value: 2.5.9 } }
+
+        include:
+          - { os: { name: MacOS, value: macos-10.15 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-2.5, value: 2.5.9 } }
+          - { os: { name: MacOS, value: macos-10.15 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-2.6, value: 2.6.7 } }
+          - { os: { name: MacOS, value: macos-10.15 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.3 } }
+          - { os: { name: MacOS, value: macos-10.15 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.1 } }
     env:
       RGV: ..
       RUBYOPT: --disable-gems


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

After merging #4245, we got a CI failure with this log:

> 2021-07-01T10:08:49.5189122Z The agent pool assigned to this job has hit their MacOs concurrency limits
> 2021-07-01T10:08:49.5532238Z Found online and idle hosted runner(s) in the current repository's organization account that matches the required labels: 'macos-10.15'
> 2021-07-01T10:08:49.5532347Z Waiting for a hosted runner in 'organization' to pick this job...

The job ended up waiting too much until it timed out, apparently. 

## What is your fix for the problem, implemented in this PR?

My fix is to run less jobs on MacOS.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
