### PR TITLE
Never downgrade indirect dependencies when running `bundle update`

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -911,14 +911,13 @@ module Bundler
     end
 
     def additional_base_requirements_for_resolve
-      return [] unless @locked_gems
+      return [] unless @locked_gems && unlocking?
       dependencies_by_name = dependencies.inject({}) {|memo, dep| memo.update(dep.name => dep) }
       @locked_gems.specs.reduce({}) do |requirements, locked_spec|
         name = locked_spec.name
         dependency = dependencies_by_name[name]
-        next requirements unless dependency
         next requirements if @locked_gems.dependencies[name] != dependency
-        next requirements if dependency.source.is_a?(Source::Path)
+        next requirements if dependency && dependency.source.is_a?(Source::Path)
         dep = Gem::Dependency.new(name, ">= #{locked_spec.version}")
         requirements[name] = DepProxy.get_proxy(dep, locked_spec.platform)
         requirements

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -61,10 +61,8 @@ module Bundler
         @unlocking_bundler = false
         @unlocking = unlock
       else
-        unlock = unlock.dup
         @unlocking_bundler = unlock.delete(:bundler)
-        unlock.delete_if {|_k, v| Array(v).empty? }
-        @unlocking = !unlock.empty?
+        @unlocking = unlock.any? {|_k, v| !Array(v).empty? }
       end
 
       @dependencies    = dependencies

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -241,6 +241,66 @@ RSpec.describe "bundle update" do
       expect(the_bundle).to include_gems("slim 3.0.9", "slim-rails 3.1.3", "slim_lint 0.16.1")
     end
 
+    it "does not go to an older version, even if the version upgrade that could cause another gem to downgrade is activated first" do
+      build_repo4 do
+        # countries is processed before country_select by the resolver due to having less spec groups (groups of versions with the same dependencies) (2 vs 3)
+
+        build_gem "countries", "2.1.4"
+        build_gem "countries", "3.1.0"
+
+        build_gem "countries", "4.0.0" do |s|
+          s.add_dependency "sixarm_ruby_unaccent", "~> 1.1"
+        end
+
+        build_gem "country_select", "1.2.0"
+
+        build_gem "country_select", "2.1.4" do |s|
+          s.add_dependency "countries", "~> 2.0"
+        end
+        build_gem "country_select", "3.1.1" do |s|
+          s.add_dependency "countries", "~> 2.0"
+        end
+
+        build_gem "country_select", "5.1.0" do |s|
+          s.add_dependency "countries", "~> 3.0"
+        end
+
+        build_gem "sixarm_ruby_unaccent", "1.1.0"
+      end
+
+      gemfile <<~G
+        source "#{file_uri_for(gem_repo4)}"
+
+        gem "country_select"
+        gem "countries"
+      G
+
+      lockfile <<~L
+        GEM
+          remote: #{file_uri_for(gem_repo4)}/
+          specs:
+            countries (3.1.0)
+            country_select (5.1.0)
+              countries (~> 3.0)
+
+        PLATFORMS
+          #{specific_local_platform}
+
+        DEPENDENCIES
+          countries
+          country_select
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      previous_lockfile = lockfile
+
+      bundle "lock --update"
+
+      expect(lockfile).to eq(previous_lockfile)
+    end
+
     it "does not downgrade indirect dependencies unnecessarily" do
       build_repo4 do
         build_gem "a" do |s|


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes `bundle update` will downgrade some indirect dependencies unnecessarily.

## What is your fix for the problem, implemented in this PR?

My fix is to provide an alternative fix to the issue that caused this regression: https://github.com/rubygems/rubygems/pull/3692. With the new approach, we add extra lower bound requirements for all dependencies (including indirect dependencies), but we do it _only_ when unlocking (running `bundle update`).

Fixes https://github.com/rubygems/rubygems/issues/4462.
  
## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
