### PR TITLE
Fix `Gem::Requirement#==` raising `NoMethodError` on RubyGems < 3.2.0.

### DIFF
--- a/.github/workflows/older-rubygems-bundler.yml
+++ b/.github/workflows/older-rubygems-bundler.yml
@@ -61,4 +61,8 @@ jobs:
         run: |
           bin/rake spec:all
         working-directory: ./bundler
+      - name: Run Rubygems Requirement tests against local bundler, to make sure bundler monkeypatches preserve the behaviour
+        run: |
+          ruby -I../../lib:lib:test test/rubygems/test_gem_requirement.rb
+        working-directory: ./bundler/tmp/rubygems
     timeout-minutes: 60

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -134,6 +134,8 @@ module Gem
     class Requirement
       module OrderIndependentComparison
         def ==(other)
+          return unless Gem::Requirement === other
+
           if _requirements_sorted? && other._requirements_sorted?
             super
           else


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

The following test of the Ruby 2.7.3 (bundling RubyGems vesion 3.1.6) fails with the manually backported Bundler 2.2.20. This PR fixes #4714.

```
  2) Error:
TestGemRequirement#test_equals2:
NoMethodError: undefined method `_requirements_sorted?' for #<Object:0x0000562bc2858330>
    /builddir/build/BUILD/ruby-2.7.3/lib/bundler/rubygems_ext.rb:137:in `=='
```

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

There are 2 commits in this PR.

The 1st commit is adding the test to reproduce this error by [David's suggesttion](https://github.com/rubygems/rubygems/issues/4714#issuecomment-873366206). [I was able to reproduce the error](https://github.com/junaruga/rubygems/runs/2983310897?check_suite_focus=true) on the "Bundler 2 against old Rubygems (ruby-2.7, rgv-3.1) " case on my forked repo. The test passed without the error on the "Bundler 2 against old Rubygems (ruby-2.7, rgv-3.2) " case. I don't know why.

The 2nd commit is fixing the error by [David's suggestion](https://github.com/rubygems/rubygems/issues/4714#issuecomment-872587525) adding one line to check if the argument `other` class is `Gem::Requirement`.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

I got [another error](https://gist.github.com/junaruga/9235c841a649a08cc11803be1275434b#file-rubygems-bundler-fiddle-install-error-log-L67) by running `bin/parallel_rspec`, that is about the `gem install --no-document fiddle --user` failing to install on Ruby 2.7.3.
