### PR TITLE
Changelogs for rubygems 3.2.22 and bundler 2.2.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 3.2.22 / 2021-07-06
+
+## Enhancements:
+
+* Allow setting `--otp` via `GEM_HOST_OTP_CODE`. Pull request #4697 by
+  CGA1123
+* Fixes for the edge case when openssl library is missing. Pull request
+  #4695 by rhenium
+
 # 3.2.21 / 2021-06-23
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,19 @@
+# 2.2.22 (July 6, 2021)
+
+## Enhancements:
+
+  - Never downgrade indirect dependencies when running `bundle update` [#4713](https://github.com/rubygems/rubygems/pull/4713)
+  - Fix `getaddrinfo` errors not treated as fatal on non darwin platforms [#4703](https://github.com/rubygems/rubygems/pull/4703)
+
+## Bug fixes:
+
+  - Fix `bundle update <gem>` sometimes hanging and `bundle lock --update` not being able to update an insecure lockfile to the new format if it requires downgrades [#4652](https://github.com/rubygems/rubygems/pull/4652)
+  - Fix edge case combination of DSL methods and duplicated sources causing gems to not be found [#4711](https://github.com/rubygems/rubygems/pull/4711)
+  - Fix `bundle doctor` crashing when finding a broken symlink [#4707](https://github.com/rubygems/rubygems/pull/4707)
+  - Fix incorrect re-resolve edge case [#4700](https://github.com/rubygems/rubygems/pull/4700)
+  - Fix some gems being unintentionally locked under multiple lockfile sections [#4701](https://github.com/rubygems/rubygems/pull/4701)
+  - Fix `--conservative` flag unexpectedly updating indirect dependencies [#4692](https://github.com/rubygems/rubygems/pull/4692)
+
 # 2.2.21 (June 23, 2021)
 
 ## Security fixes:


### PR DESCRIPTION
Cherry-picking changelogs from future rubygems 3.2.22 and bundler 2.2.22 into master.