### PR TITLE
Spare meaningless warning on read-only bundle invocations

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -236,8 +236,9 @@ module Bundler
         end
 
         if warning
-          user_home = tmp_home_path(warning)
-          Bundler.ui.warn "#{warning}\nBundler will use `#{user_home}' as your home directory temporarily.\n"
+          Bundler.ui.warn "#{warning}\n"
+          user_home = tmp_home_path
+          Bundler.ui.warn "Bundler will use `#{user_home}' as your home directory temporarily.\n"
           user_home
         else
           Pathname.new(home)
@@ -684,15 +685,13 @@ EOF
       Bundler.rubygems.clear_paths
     end
 
-    def tmp_home_path(warning)
+    def tmp_home_path
       Kernel.send(:require, "tmpdir")
       SharedHelpers.filesystem_access(Dir.tmpdir) do
         path = Bundler.tmp
         at_exit { Bundler.rm_rf(path) }
         path
       end
-    rescue RuntimeError => e
-      raise e.exception("#{warning}\nBundler also failed to create a temporary home directory':\n#{e}")
     end
 
     # @param env [Hash]

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -428,12 +428,8 @@ module Bundler
     def global_config_file
       if ENV["BUNDLE_CONFIG"] && !ENV["BUNDLE_CONFIG"].empty?
         Pathname.new(ENV["BUNDLE_CONFIG"])
-      else
-        begin
-          Bundler.user_bundle_path("config")
-        rescue PermissionError, GenericSystemCallError
-          nil
-        end
+      elsif Bundler.rubygems.user_home && !Bundler.rubygems.user_home.empty?
+        Pathname.new(Bundler.rubygems.user_home).join(".bundle/config")
       end
     end
 

--- a/bundler/spec/bundler/bundler_spec.rb
+++ b/bundler/spec/bundler/bundler_spec.rb
@@ -249,11 +249,8 @@ EOF
           allow(Bundler.rubygems).to receive(:user_home).and_return(path)
           allow(File).to receive(:directory?).with(path).and_return false
           allow(Bundler).to receive(:tmp).and_return(Pathname.new("/tmp/trulyrandom"))
-          message = <<EOF
-`/home/oggy` is not a directory.
-Bundler will use `/tmp/trulyrandom' as your home directory temporarily.
-EOF
-          expect(Bundler.ui).to receive(:warn).with(message)
+          expect(Bundler.ui).to receive(:warn).with("`/home/oggy` is not a directory.\n")
+          expect(Bundler.ui).to receive(:warn).with("Bundler will use `/tmp/trulyrandom' as your home directory temporarily.\n")
           expect(Bundler.user_home).to eq(Pathname("/tmp/trulyrandom"))
         end
       end
@@ -268,11 +265,8 @@ EOF
           allow(File).to receive(:writable?).with(path).and_return false
           allow(File).to receive(:directory?).with(dotbundle).and_return false
           allow(Bundler).to receive(:tmp).and_return(Pathname.new("/tmp/trulyrandom"))
-          message = <<EOF
-`/home/oggy` is not writable.
-Bundler will use `/tmp/trulyrandom' as your home directory temporarily.
-EOF
-          expect(Bundler.ui).to receive(:warn).with(message)
+          expect(Bundler.ui).to receive(:warn).with("`/home/oggy` is not writable.\n")
+          expect(Bundler.ui).to receive(:warn).with("Bundler will use `/tmp/trulyrandom' as your home directory temporarily.\n")
           expect(Bundler.user_home).to eq(Pathname("/tmp/trulyrandom"))
         end
 
@@ -293,11 +287,8 @@ EOF
       it "should issue warning and return a temporary user home" do
         allow(Bundler.rubygems).to receive(:user_home).and_return(nil)
         allow(Bundler).to receive(:tmp).and_return(Pathname.new("/tmp/trulyrandom"))
-        message = <<EOF
-Your home directory is not set.
-Bundler will use `/tmp/trulyrandom' as your home directory temporarily.
-EOF
-        expect(Bundler.ui).to receive(:warn).with(message)
+        expect(Bundler.ui).to receive(:warn).with("Your home directory is not set.\n")
+        expect(Bundler.ui).to receive(:warn).with("Bundler will use `/tmp/trulyrandom' as your home directory temporarily.\n")
         expect(Bundler.user_home).to eq(Pathname("/tmp/trulyrandom"))
       end
     end

--- a/bundler/spec/bundler/settings_spec.rb
+++ b/bundler/spec/bundler/settings_spec.rb
@@ -64,13 +64,10 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
 
   describe "#global_config_file" do
     context "when $HOME is not accessible" do
-      context "when $TMPDIR is not writable" do
-        it "does not raise" do
-          expect(Bundler.rubygems).to receive(:user_home).twice.and_return(nil)
-          expect(Bundler).to receive(:tmp).twice.and_raise(Errno::EROFS, "Read-only file system @ dir_s_mkdir - /tmp/bundler")
+      it "does not raise" do
+        expect(Bundler.rubygems).to receive(:user_home).twice.and_return(nil)
 
-          expect(subject.send(:global_config_file)).to be_nil
-        end
+        expect(subject.send(:global_config_file)).to be_nil
       end
     end
   end

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -24,6 +24,16 @@ RSpec.describe "bundle exec" do
     expect(out).to eq("0.9.1")
   end
 
+  it "works and prints no warnings when HOME is not writable" do
+    gemfile <<-G
+      gem "rack", "0.9.1"
+    G
+
+    bundle "exec rackup", :env => { "HOME" => "/" }
+    expect(out).to eq("0.9.1")
+    expect(err).to be_empty
+  end
+
   it "works when the bins are in ~/.bundle" do
     install_gemfile <<-G
       gem "rack"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes bundler complains about home not being writable without any need, because bundler doesn't really need to write to the filesystem.

The problem is that resolving the user's home to figure out where the global settings file lives prints this warning, and bundler checks setting essentially every time it is run.

## What is your fix for the problem, implemented in this PR?

My fix is to ignore global settings when user's home is not set, and only raise when we need to write configuration but not in other cases. Using a "temporary home fallback" for settings doesn't make sense anyways, because settings are supposed to be permanent, but this temporary home is generated at a random location at `tmp` so whatever we would write there would not be accessible the next time bundler is run because we don't know the exact location.

Fixes #3358.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
