### PR TITLE
Avoid warnings for duplicated methods definition

### DIFF
--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -1595,7 +1595,7 @@ class Object
     metaclass.send :undef_method, name
     metaclass.send :alias_method, name, new_name
     metaclass.send :undef_method, new_name
-  end
+  end unless method_defined?(:stub) # lib/resolv/test_dns.rb also has the same method definition
 end
 
 require_relative 'utilities'


### PR DESCRIPTION
https://github.com/ruby/ruby/commit/ff609eee98dc5c20f68b7befac147537e640aad1