### PR TITLE
Fix release task checksum issues

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -7,7 +7,6 @@ MIT.txt
 Manifest.txt
 POLICIES.md
 README.md
-Rakefile
 UPGRADING.md
 bin/gem
 bin/update_rubygems

--- a/Rakefile
+++ b/Rakefile
@@ -267,13 +267,7 @@ namespace 'blog' do
   task 'checksums' => 'package' do
     require 'digest'
     Dir['pkg/*{tgz,zip,gem}'].each do |file|
-      digest = Digest::SHA256.new
-
-      File.open file, 'rb' do |io|
-        while chunk = io.read(65536) do
-          digest.update chunk
-        end
-      end
+      digest = Digest::SHA256.file(file)
 
       checksums << "* #{File.basename(file)}  \n"
       checksums << "  #{digest.hexdigest}\n"

--- a/Rakefile
+++ b/Rakefile
@@ -363,7 +363,7 @@ module Rubygems
   class ProjectFiles
     def self.all
       files = []
-      exclude = %r{\A(?:\.|dev_gems|bundler/(?!lib|exe|[^/]+\.md|bundler.gemspec)|util/)}
+      exclude = %r{\A(?:\.|dev_gems|bundler/(?!lib|exe|[^/]+\.md|bundler.gemspec)|util/|Rakefile)}
       tracked_files = `git ls-files`.split("\n")
 
       tracked_files.each do |path|

--- a/Rakefile
+++ b/Rakefile
@@ -266,7 +266,7 @@ namespace 'blog' do
 
   task 'checksums' => 'package' do
     require 'digest'
-    Dir['pkg/*{tgz,zip,gem}'].map do |file|
+    Dir['pkg/*{tgz,zip,gem}'].each do |file|
       digest = Digest::SHA256.new
 
       File.open file, 'rb' do |io|

--- a/Rakefile
+++ b/Rakefile
@@ -96,7 +96,7 @@ task rubocop: %w[rubocop:rubygems rubocop:bundler]
 # Creating a release
 
 task :prerelease => %w[clobber test bundler:build_metadata check_deprecations]
-task :postrelease => %w[bundler:build_metadata:clean upload guides:publish blog:publish]
+task :postrelease => %w[upload guides:publish blog:publish bundler:build_metadata:clean]
 
 desc "Check for deprecated methods with expired deprecation horizon"
 task :check_deprecations do

--- a/Rakefile
+++ b/Rakefile
@@ -266,11 +266,28 @@ namespace 'blog' do
 
   task 'checksums' => 'package' do
     require 'digest'
+    require 'net/http'
     Dir['pkg/*{tgz,zip,gem}'].each do |file|
-      digest = Digest::SHA256.file(file)
+      digest = Digest::SHA256.file(file).hexdigest
+      basename = File.basename(file)
 
-      checksums << "* #{File.basename(file)}  \n"
-      checksums << "  #{digest.hexdigest}\n"
+      checksums << "* #{basename}  \n"
+      checksums << "  #{digest}\n"
+
+      release_url = URI("https://rubygems.org/#{file.end_with?("gem") ? "gems" : "rubygems"}/#{basename}")
+      response = Net::HTTP.get_response(release_url)
+
+      if response.is_a?(Net::HTTPSuccess)
+        released_digest = Digest::SHA256.hexdigest(response.body)
+
+        if digest != released_digest
+          abort "Checksum of #{file} (#{digest}) doesn't match checksum of released package at #{release_url} (#{released_digest})"
+        end
+      elsif response.is_a?(Net::HTTPForbidden)
+        abort "#{basename} has not been yet uploaded to rubygems.org"
+      else
+        abort "Error fetching released package to verify checksums: #{response}\n#{response.body}"
+      end
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The end user problem is that checksums in some of our rubygems release blog posts are incorrect.

The underlying issue is that if the release task aborts at some point before the `rake blog:publish` task, but after the `rake bundler:build_metadata:clean` has run. Re-running the `rake blog:publish` manually will trigger a package rebuild _without release metadata_, and the blog post checksums will be computed from that package that doesn't match the released one.

## What is your fix for the problem, implemented in this PR?

My fix is to make sure bundler build metadata is not reset until the very end of the release task. In addition to that, I added some checks to prevent publishing blog posts with checksums not matching released packages checksums, and also removed the `Rakefile` file from the released package.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
