### PR TITLE
Fix incorrect warning about duplicated gems in the Gemfile

### DIFF
--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -102,28 +102,26 @@ module Bundler
       # if there's already a dependency with this name we try to prefer one
       if current = @dependencies.find {|d| d.name == dep.name }
         deleted_dep = @dependencies.delete(current) if current.type == :development
+        return if deleted_dep
 
         if current.requirement != dep.requirement
-          unless deleted_dep
-            return if dep.type == :development
+          return if dep.type == :development
 
-            update_prompt = ""
+          update_prompt = ""
 
-            if File.basename(@gemfile) == Injector::INJECTED_GEMS
-              if dep.requirements_list.include?(">= 0") && !current.requirements_list.include?(">= 0")
-                update_prompt = ". Gem already added"
-              else
-                update_prompt = ". If you want to update the gem version, run `bundle update #{current.name}`"
+          if File.basename(@gemfile) == Injector::INJECTED_GEMS
+            if dep.requirements_list.include?(">= 0") && !current.requirements_list.include?(">= 0")
+              update_prompt = ". Gem already added"
+            else
+              update_prompt = ". If you want to update the gem version, run `bundle update #{current.name}`"
 
-                update_prompt += ". You may also need to change the version requirement specified in the Gemfile if it's too restrictive." unless current.requirements_list.include?(">= 0")
-              end
+              update_prompt += ". You may also need to change the version requirement specified in the Gemfile if it's too restrictive." unless current.requirements_list.include?(">= 0")
             end
-
-            raise GemfileError, "You cannot specify the same gem twice with different version requirements.\n" \
-                            "You specified: #{current.name} (#{current.requirement}) and #{dep.name} (#{dep.requirement})" \
-                             "#{update_prompt}"
           end
 
+          raise GemfileError, "You cannot specify the same gem twice with different version requirements.\n" \
+                          "You specified: #{current.name} (#{current.requirement}) and #{dep.name} (#{dep.requirement})" \
+                           "#{update_prompt}"
         else
           Bundler.ui.warn "Your Gemfile lists the gem #{current.name} (#{current.requirement}) more than once.\n" \
                           "You should probably keep only one of them.\n" \
@@ -132,12 +130,10 @@ module Bundler
         end
 
         if current.source != dep.source
-          unless deleted_dep
-            return if dep.type == :development
-            raise GemfileError, "You cannot specify the same gem twice coming from different sources.\n" \
-                            "You specified that #{dep.name} (#{dep.requirement}) should come from " \
-                            "#{current.source || "an unspecified source"} and #{dep.source}\n"
-          end
+          return if dep.type == :development
+          raise GemfileError, "You cannot specify the same gem twice coming from different sources.\n" \
+                          "You specified that #{dep.name} (#{dep.requirement}) should come from " \
+                          "#{current.source || "an unspecified source"} and #{dep.source}\n"
         end
       end
 

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -344,54 +344,50 @@ RSpec.describe "bundle install with gem sources" do
       expect(File.exist?(bundled_app_lock)).to eq(true)
     end
 
-    context "throws a warning if a gem is added twice in Gemfile" do
-      it "without version requirements" do
-        install_gemfile <<-G, :raise_on_error => false
-          source "#{file_uri_for(gem_repo2)}"
-          gem "rack"
-          gem "rack"
-        G
+    it "throws a warning if a gem is added twice in Gemfile without version requirements" do
+      install_gemfile <<-G, :raise_on_error => false
+        source "#{file_uri_for(gem_repo2)}"
+        gem "rack"
+        gem "rack"
+      G
 
-        expect(err).to include("Your Gemfile lists the gem rack (>= 0) more than once.")
-        expect(err).to include("Remove any duplicate entries and specify the gem only once.")
-        expect(err).to include("While it's not a problem now, it could cause errors if you change the version of one of them later.")
-      end
-
-      it "with same versions" do
-        install_gemfile <<-G, :raise_on_error => false
-          source "#{file_uri_for(gem_repo2)}"
-          gem "rack", "1.0"
-          gem "rack", "1.0"
-        G
-
-        expect(err).to include("Your Gemfile lists the gem rack (= 1.0) more than once.")
-        expect(err).to include("Remove any duplicate entries and specify the gem only once.")
-        expect(err).to include("While it's not a problem now, it could cause errors if you change the version of one of them later.")
-      end
+      expect(err).to include("Your Gemfile lists the gem rack (>= 0) more than once.")
+      expect(err).to include("Remove any duplicate entries and specify the gem only once.")
+      expect(err).to include("While it's not a problem now, it could cause errors if you change the version of one of them later.")
     end
 
-    context "throws an error if a gem is added twice in Gemfile" do
-      it "when version of one dependency is not specified" do
-        install_gemfile <<-G, :raise_on_error => false
-          source "#{file_uri_for(gem_repo2)}"
-          gem "rack"
-          gem "rack", "1.0"
-        G
+    it "throws a warning if a gem is added twice in Gemfile with same versions" do
+      install_gemfile <<-G, :raise_on_error => false
+        source "#{file_uri_for(gem_repo2)}"
+        gem "rack", "1.0"
+        gem "rack", "1.0"
+      G
 
-        expect(err).to include("You cannot specify the same gem twice with different version requirements")
-        expect(err).to include("You specified: rack (>= 0) and rack (= 1.0).")
-      end
+      expect(err).to include("Your Gemfile lists the gem rack (= 1.0) more than once.")
+      expect(err).to include("Remove any duplicate entries and specify the gem only once.")
+      expect(err).to include("While it's not a problem now, it could cause errors if you change the version of one of them later.")
+    end
 
-      it "when different versions of both dependencies are specified" do
-        install_gemfile <<-G, :raise_on_error => false
-          source "#{file_uri_for(gem_repo2)}"
-          gem "rack", "1.0"
-          gem "rack", "1.1"
-        G
+    it "throws an error if a gem is added twice in Gemfile when version of one dependency is not specified" do
+      install_gemfile <<-G, :raise_on_error => false
+        source "#{file_uri_for(gem_repo2)}"
+        gem "rack"
+        gem "rack", "1.0"
+      G
 
-        expect(err).to include("You cannot specify the same gem twice with different version requirements")
-        expect(err).to include("You specified: rack (= 1.0) and rack (= 1.1).")
-      end
+      expect(err).to include("You cannot specify the same gem twice with different version requirements")
+      expect(err).to include("You specified: rack (>= 0) and rack (= 1.0).")
+    end
+
+    it "throws an error if a gem is added twice in Gemfile when different versions of both dependencies are specified" do
+      install_gemfile <<-G, :raise_on_error => false
+        source "#{file_uri_for(gem_repo2)}"
+        gem "rack", "1.0"
+        gem "rack", "1.1"
+      G
+
+      expect(err).to include("You cannot specify the same gem twice with different version requirements")
+      expect(err).to include("You specified: rack (= 1.0) and rack (= 1.1).")
     end
 
     it "gracefully handles error when rubygems server is unavailable" do

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -368,6 +368,28 @@ RSpec.describe "bundle install with gem sources" do
       expect(err).to include("While it's not a problem now, it could cause errors if you change the version of one of them later.")
     end
 
+    it "does not throw a warning if a gem is added once in Gemfile and also inside a gemspec as a development dependency" do
+      build_lib "my-gem", :path => bundled_app do |s|
+        s.add_development_dependency "my-private-gem"
+      end
+
+      build_repo2 do
+        build_gem "my-private-gem"
+      end
+
+      gemfile <<~G
+        source "#{file_uri_for(gem_repo2)}"
+
+        gemspec
+
+        gem "my-private-gem", :group => :development
+      G
+
+      bundle :install
+
+      expect(err).to be_empty
+    end
+
     it "throws an error if a gem is added twice in Gemfile when version of one dependency is not specified" do
       install_gemfile <<-G, :raise_on_error => false
         source "#{file_uri_for(gem_repo2)}"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

An incorrect warning when a gem is a development dependency of a local gemspec, and also specified in the Gemfile with compatible requirements.

# What is your fix for the problem, implemented in this PR?

Skip the warning in this case.

Fixes #4481.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
