### PR TITLE
Fix `bundle plugin install foo` crashing

### DIFF
--- a/bundler/lib/bundler/plugin/installer.rb
+++ b/bundler/lib/bundler/plugin/installer.rb
@@ -77,7 +77,7 @@ module Bundler
         source_list = SourceList.new
 
         source_list.add_git_source(git_source_options) if git_source_options
-        source_list.add_global_rubygems_remote(rubygems_source) if rubygems_source
+        Array(rubygems_source).each {|remote| source_list.add_global_rubygems_remote(remote) } if rubygems_source
 
         deps = names.map {|name| Dependency.new name, version }
 

--- a/bundler/spec/plugins/install_spec.rb
+++ b/bundler/spec/plugins/install_spec.rb
@@ -22,6 +22,13 @@ RSpec.describe "bundler plugin install" do
     plugin_should_be_installed("foo")
   end
 
+  it "installs from sources configured as Gem.sources without any flags" do
+    bundle "plugin install foo", :env => { "BUNDLER_SPEC_GEM_SOURCES" => file_uri_for(gem_repo2).to_s }
+
+    expect(out).to include("Installed plugin foo")
+    plugin_should_be_installed("foo")
+  end
+
   context "plugin is already installed" do
     before do
       bundle "plugin install foo --source #{file_uri_for(gem_repo2)}"

--- a/bundler/spec/support/hax.rb
+++ b/bundler/spec/support/hax.rb
@@ -28,6 +28,10 @@ module Gem
     end
   end
 
+  if ENV["BUNDLER_SPEC_GEM_SOURCES"]
+    @sources = [ENV["BUNDLER_SPEC_GEM_SOURCES"]]
+  end
+
   # We only need this hack for rubygems versions without the BundlerVersionFinder
   if Gem.rubygems_version < Gem::Version.new("2.7.0")
     @path_to_default_spec_map.delete_if do |_path, spec|


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Due to a recent fix, this command got broken because while before we used `SourceList#global_rubygems_source=` which supported assigning a `Gem::SourceList` to it by converting it to an array of remotes, and adding each remote separately, that ability was lost by just changing that to use `SourceList#add_global_rubygems_remote`.

## What is your fix for the problem, implemented in this PR?

Cast the `rubygems_source` to an array of remotes, and add each remote separately.

Fixes #4730.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
