### PR TITLE
Offline realworld specs

### DIFF
--- a/bundler/spec/realworld/edgecases_spec.rb
+++ b/bundler/spec/realworld/edgecases_spec.rb
@@ -196,21 +196,6 @@ RSpec.describe "real world edgecases", :realworld => true do
     expect(lockfile).to include(rubygems_version("paperclip", "~> 5.1.0"))
   end
 
-  # https://github.com/rubygems/bundler/issues/1500
-  it "does not fail install because of gem plugins" do
-    realworld_system_gems("open_gem --version 1.4.2", "rake --version 0.9.2")
-    gemfile <<-G
-      source "https://rubygems.org"
-
-      gem 'rack', '1.0.1'
-    G
-
-    bundle "config set --local path vendor/bundle"
-    bundle :install
-    expect(err).not_to include("Could not find rake")
-    expect(err).to be_empty
-  end
-
   it "outputs a helpful error message when gems have invalid gemspecs" do
     install_gemfile <<-G, :standalone => true, :raise_on_error => false
       source 'https://rubygems.org'

--- a/bundler/spec/support/artifice/vcr.rb
+++ b/bundler/spec/support/artifice/vcr.rb
@@ -133,6 +133,19 @@ class BundlerVCRHTTP < Net::HTTP
     end
   end
 
+  def start_with_vcr
+    if ENV["BUNDLER_SPEC_PRE_RECORDED"]
+      raise IOError, "HTTP session already opened" if @started
+      @socket = nil
+      @started = true
+    else
+      start_without_vcr
+    end
+  end
+
+  alias_method :start_without_vcr, :start
+  alias_method :start, :start_with_vcr
+
   def request_with_vcr(request, *args, &block)
     handler = request.instance_eval do
       remove_instance_variable(:@__vcr_request_handler) if defined?(@__vcr_request_handler)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes, we get realworld spec failures due to temporary network connection issues on our CI. See https://github.com/rubygems/rubygems/pull/4732/checks?check_run_id=3007981821 for an example. Failures look like this in case the log becomes unavailable:

```
 Failures:

  1) real world edgecases installs the latest version of gxapi_rails
     Failure/Error:
               raise <<~ERROR
       
                 Invoking `#{cmd}` failed with output:
                 ----------------------------------------------------------------------
                 #{command_execution.stdboth}
                 ----------------------------------------------------------------------
               ERROR

     RuntimeError:

       Invoking `/Users/runner/hostedtoolcache/Ruby/2.6.7/x64/bin/ruby -I/Users/runner/work/rubygems/rubygems/bundler/spec -r/Users/runner/work/rubygems/rubygems/bundler/spec/support/artifice/vcr.rb -r/Users/runner/work/rubygems/rubygems/bundler/spec/support/hax.rb /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/bin/bundle lock --verbose` failed with output:
       ----------------------------------------------------------------------
       Retrying dependency api due to error (2/4): Errno::ENOENT No such file or directory @ rb_sysopen - /Users/runner/work/rubygems/rubygems/bundler/spec/support/artifice/vcr_cassettes/realworld/index.rubygems.org//api/v1/dependencies-gems=gxapi_rails%2Crack-cache%2Crails%2Csass-rails/GET/response
       Retrying dependency api due to error (3/4): Errno::ENOENT No such file or directory @ rb_sysopen - /Users/runner/work/rubygems/rubygems/bundler/spec/support/artifice/vcr_cassettes/realworld/index.rubygems.org//api/v1/dependencies-gems=gxapi_rails%2Crack-cache%2Crails%2Csass-rails/GET/response
       Retrying dependency api due to error (4/4): Errno::ENOENT No such file or directory @ rb_sysopen - /Users/runner/work/rubygems/rubygems/bundler/spec/support/artifice/vcr_cassettes/realworld/index.rubygems.org//api/v1/dependencies-gems=gxapi_rails%2Crack-cache%2Crails%2Csass-rails/GET/response
       Retrying fetcher due to error (2/4): Errno::ENOENT No such file or directory @ rb_sysopen - /Users/runner/work/rubygems/rubygems/bundler/spec/support/artifice/vcr_cassettes/realworld/index.rubygems.org//api/v1/dependencies-gems=gxapi_rails%2Crack-cache%2Crails%2Csass-rails/GET/response
       Retrying fetcher due to error (3/4): Errno::ENOENT No such file or directory @ rb_sysopen - /Users/runner/work/rubygems/rubygems/bundler/spec/support/artifice/vcr_cassettes/realworld/index.rubygems.org//api/v1/dependencies/GET/response
       Retrying fetcher due to error (4/4): Errno::ENOENT No such file or directory @ rb_sysopen - /Users/runner/work/rubygems/rubygems/bundler/spec/support/artifice/vcr_cassettes/realworld/index.rubygems.org//api/v1/dependencies/GET/response
       --- ERROR REPORT TEMPLATE -------------------------------------------------------
       # Error Report

       ## Questions

       Please fill out answers to these questions, it'll help us figure out
       why things are going wrong.

       - **What did you do?**

         I ran the command `/Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/bin/bundle lock --verbose`

       - **What did you expect to happen?**

         I expected Bundler to...

       - **What happened instead?**

         Instead, what happened was...

       - **Have you tried any solutions posted on similar issues in our issue tracker, stack overflow, or google?**

         I tried...

       - **Have you read our issues document, https://github.com/rubygems/rubygems/blob/master/bundler/doc/contributing/ISSUES.md?**

         ...

       ## Backtrace

       ```
       Errno::ENOENT: No such file or directory @ rb_sysopen - /Users/runner/work/rubygems/rubygems/bundler/spec/support/artifice/vcr_cassettes/realworld/index.rubygems.org//api/v1/dependencies/GET/response
         /Users/runner/work/rubygems/rubygems/bundler/spec/support/artifice/vcr.rb:38:in `initialize'
         /Users/runner/work/rubygems/rubygems/bundler/spec/support/artifice/vcr.rb:38:in `open'
         /Users/runner/work/rubygems/rubygems/bundler/spec/support/artifice/vcr.rb:38:in `recorded_response'
         /Users/runner/work/rubygems/rubygems/bundler/spec/support/artifice/vcr.rb:26:in `handle_request'
         /Users/runner/work/rubygems/rubygems/bundler/spec/support/artifice/vcr.rb:141:in `request_with_vcr'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/vendor/net-http-persistent/lib/net/http/persistent.rb:876:in `block in request'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/vendored_persistent.rb:17:in `block in connection_for'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/vendor/net-http-persistent/lib/net/http/persistent.rb:608:in `connection_for'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/vendored_persistent.rb:16:in `connection_for'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/vendor/net-http-persistent/lib/net/http/persistent.rb:870:in `request'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/fetcher/downloader.rb:63:in `request'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/fetcher/downloader.rb:19:in `fetch'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/fetcher/dependency.rb:10:in `available?'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/fetcher.rb:132:in `specs'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/fetcher.rb:118:in `block in specs_with_retry'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/retry.rb:40:in `run'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/retry.rb:30:in `attempt'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/fetcher.rb:117:in `specs_with_retry'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/source/rubygems.rb:427:in `block in fetch_names'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/source/rubygems.rb:424:in `each'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/source/rubygems.rb:424:in `fetch_names'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/source/rubygems.rb:419:in `block in remote_specs'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/index.rb:9:in `build'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/source/rubygems.rb:406:in `remote_specs'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/source/rubygems.rb:110:in `specs'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/resolver.rb:168:in `index_for'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/resolver.rb:176:in `results_for'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/resolver.rb:114:in `search_for'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/resolver.rb:256:in `block in verify_gemfile_dependencies_are_found!'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/resolver.rb:253:in `each'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/resolver.rb:253:in `verify_gemfile_dependencies_are_found!'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/resolver.rb:50:in `start'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/resolver.rb:23:in `resolve'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/definition.rb:291:in `resolve'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/definition.rb:183:in `resolve_remotely!'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/cli/lock.rb:53:in `run'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/cli.rb:671:in `lock'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/cli.rb:30:in `dispatch'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/cli.rb:24:in `start'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/exe/bundle:49:in `block in <top (required)>'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/friendly_errors.rb:128:in `with_friendly_errors'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/exe/bundle:37:in `<top (required)>'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/bin/bundle:23:in `load'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/bin/bundle:23:in `<main>'
       ```

       ## Environment

       ```
       Bundler       2.3.0.dev
         Platforms   ruby, x86_64-darwin-19
       Ruby          2.6.7p197 (2021-04-05 revision 67941) [x86_64-darwin19]
         Full Path   /Users/runner/hostedtoolcache/Ruby/2.6.7/x64/bin/ruby
         Config Dir  /Users/runner/hostedtoolcache/Ruby/2.6.7/x64/etc
       RubyGems      3.3.0.dev
         Gem Home    /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system
         Gem Path    /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system
         User Home   /Users/runner/work/rubygems/rubygems/bundler/tmp/1/home
         User Path   /Users/runner/work/rubygems/rubygems/bundler/tmp/1/home/.local/share/gem/ruby/2.6.0
         Bin Dir     /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/bin
       OpenSSL       
         Compiled    OpenSSL 1.1.1j  16 Feb 2021
         Loaded      OpenSSL 1.1.1j  16 Feb 2021
         Cert File   /Users/runner/hostedtoolcache/Ruby/2.6.7/x64/openssl/ssl/cert.pem
         Cert Dir    /Users/runner/hostedtoolcache/Ruby/2.6.7/x64/openssl/ssl/certs
       Tools         
         Git         2.32.0
         RVM         not installed
         rbenv       not installed
         chruby      not installed
       ```

       ## Bundler Build Metadata

       ```
       Built At          2021-07-07
       Git SHA           235679c
       Released Version  true
       ```

       ## Bundler settings

       ```
       spec_run
         Set via BUNDLE_SPEC_RUN: "true"
       ```

       ## Gemfile

       ### Gemfile

       ```ruby
       source "https://rubygems.org"

       gem "sass-rails"
       gem "rails", "~> 5"
       gem "gxapi_rails", "< 0.1.0" # 0.1.0 was released way after the test was written
       gem 'rack-cache', '1.2.0' # last version that works on Ruby 1.9
       ```

       ### Gemfile.lock

       ```
       <No /Users/runner/work/rubygems/rubygems/bundler/tmp/1/bundled_app/Gemfile.lock found>
       ```

       --- TEMPLATE END ----------------------------------------------------------------

       Unfortunately, an unexpected error occurred, and Bundler cannot continue.

       First, try this link to see if there are any existing issue reports for this error:
       https://github.com/rubygems/rubygems/search?q=No+such+file+or+directory+%40+rb_sysopen+-+%2FUsers%2Frunner%2Fwork%2Frubygems%2Frubygems%2Fbundler%2Fspec%2Fsupport%2Fartifice%2Fvcr_cassettes%2Frealworld%2Findex.rubygems.org%2F%2Fapi%2Fv1%2Fdependencies%2FGET%2Fresponse&type=Issues

       If there aren't any reports for this error yet, please copy and paste the report template above into a new issue. Don't forget to anonymize any private data! The new issue form is located at:
       https://github.com/rubygems/rubygems/issues/new?labels=Bundler&template=bundler-related-issue.md
       Running `bundle lock --verbose` with bundler 2.3.0.dev
       Found changes from the lockfile, re-resolving dependencies because the dependencies in your gemfile changed, you added a new platform to your gemfile
       HTTP GET https://index.rubygems.org/versions
       HTTP 200 OK https://index.rubygems.org/versions
       Fetching gem metadata from https://rubygems.org/
       Looking up gems ["sass-rails", "rails", "gxapi_rails", "rack-cache"]
       HTTP GET https://index.rubygems.org/info/sass-rails
       HTTP GET https://index.rubygems.org/info/gxapi_rails
       HTTP GET https://index.rubygems.org/info/rails
       HTTP 200 OK https://index.rubygems.org/info/sass-rails
       HTTP GET https://index.rubygems.org/info/rack-cache
       HTTP 200 OK https://index.rubygems.org/info/rack-cache
       HTTP 200 OK https://index.rubygems.org/info/gxapi_rails
       Net::OpenTimeout: Net::OpenTimeout
       /Users/runner/hostedtoolcache/Ruby/2.6.7/x64/lib/ruby/2.6.0/net/protocol.rb:41:in `ssl_socket_connect'
         /Users/runner/hostedtoolcache/Ruby/2.6.7/x64/lib/ruby/2.6.0/net/http.rb:996:in `connect'
         /Users/runner/hostedtoolcache/Ruby/2.6.7/x64/lib/ruby/2.6.0/net/http.rb:930:in `do_start'
         /Users/runner/hostedtoolcache/Ruby/2.6.7/x64/lib/ruby/2.6.0/net/http.rb:925:in `start'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/vendor/net-http-persistent/lib/net/http/persistent.rb:657:in `start'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/vendor/net-http-persistent/lib/net/http/persistent.rb:597:in `connection_for'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/vendored_persistent.rb:16:in `connection_for'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/vendor/net-http-persistent/lib/net/http/persistent.rb:870:in `request'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/fetcher/downloader.rb:63:in `request'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/fetcher/downloader.rb:19:in `fetch'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/fetcher/compact_index.rb:136:in `call'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/compact_index_client/updater.rb:48:in `block in update'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/vendor/tmpdir/lib/tmpdir.rb:96:in `mktmpdir'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/compact_index_client/updater.rb:29:in `update'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/compact_index_client.rb:98:in `update'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/compact_index_client.rb:114:in `update_info'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/compact_index_client.rb:71:in `block in dependencies'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/fetcher/compact_index.rb:102:in `block (2 levels) in parallel_compact_index_client'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/worker.rb:62:in `apply_func'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/worker.rb:57:in `block in process_queue'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/worker.rb:54:in `loop'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/worker.rb:54:in `process_queue'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/worker.rb:88:in `block (2 levels) in create_threads'
       Bundler::HTTPError: Network error while fetching https://index.rubygems.org/info/rails (Net::OpenTimeout)
       /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/fetcher/downloader.rb:75:in `rescue in request'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/fetcher/downloader.rb:51:in `request'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/fetcher/downloader.rb:19:in `fetch'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/fetcher/compact_index.rb:136:in `call'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/compact_index_client/updater.rb:48:in `block in update'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/vendor/tmpdir/lib/tmpdir.rb:96:in `mktmpdir'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/compact_index_client/updater.rb:29:in `update'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/compact_index_client.rb:98:in `update'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/compact_index_client.rb:114:in `update_info'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/compact_index_client.rb:71:in `block in dependencies'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/fetcher/compact_index.rb:102:in `block (2 levels) in parallel_compact_index_client'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/worker.rb:62:in `apply_func'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/worker.rb:57:in `block in process_queue'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/worker.rb:54:in `loop'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/worker.rb:54:in `process_queue'
         /Users/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.3.0.dev/lib/bundler/worker.rb:88:in `block (2 levels) in create_threads'
       Query List: ["sass-rails", "rails", "gxapi_rails", "rack-cache"]
       Query Gemcutter Dependency Endpoint API: sass-rails,rails,gxapi_rails,rack-cache
       HTTP GET https://index.rubygems.org/api/v1/dependencies?gems=gxapi_rails%2Crack-cache%2Crails%2Csass-rails
       Query Gemcutter Dependency Endpoint API: sass-rails,rails,gxapi_rails,rack-cache
       HTTP GET https://index.rubygems.org/api/v1/dependencies?gems=gxapi_rails%2Crack-cache%2Crails%2Csass-rails
       Query Gemcutter Dependency Endpoint API: sass-rails,rails,gxapi_rails,rack-cache
       HTTP GET https://index.rubygems.org/api/v1/dependencies?gems=gxapi_rails%2Crack-cache%2Crails%2Csass-rails
       Query Gemcutter Dependency Endpoint API: sass-rails,rails,gxapi_rails,rack-cache
       HTTP GET https://index.rubygems.org/api/v1/dependencies?gems=gxapi_rails%2Crack-cache%2Crails%2Csass-rails
       HTTP GET https://index.rubygems.org/api/v1/dependencies
       HTTP GET https://index.rubygems.org/api/v1/dependencies
       HTTP GET https://index.rubygems.org/api/v1/dependencies
       ----------------------------------------------------------------------
     # ./spec/support/helpers.rb:208:in `sys_exec'
     # ./spec/support/helpers.rb:125:in `bundle'
     # ./spec/realworld/edgecases_spec.rb:46:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:99:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:99:in `block (3 levels) in <top (required)>'
     # ./spec/support/helpers.rb:352:in `block in with_gem_path_as'
     # ./spec/support/helpers.rb:366:in `without_env_side_effects'
     # ./spec/support/helpers.rb:348:in `with_gem_path_as'
     # ./spec/spec_helper.rb:98:in `block (2 levels) in <top (required)>'
     # ./spec/support/rubygems_ext.rb:99:in `load'
     # ./spec/support/rubygems_ext.rb:99:in `gem_load_and_activate'
     # ./spec/support/rubygems_ext.rb:18:in `gem_load'

Finished in 1 minute 23.26 seconds (files took 2.36 seconds to load)
21 examples, 1 failure, 3 pending

Failed examples:

rspec ./spec/realworld/edgecases_spec.rb:37 # real world edgecases installs the latest version of gxapi_rails
```

## What is your fix for the problem, implemented in this PR?

Since we're recording network requests, I think it's expected that specs can be run fully offline when in "pre-recorded" mode. Yet, the connection establishment itself was still happening and if there were network issues it would still fail.

This PR mocks the connection estabilishment too, so that realworld specs can be run fully offline.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
