### PR TITLE
Bump vendored URI to 0.10.1

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -299,6 +299,8 @@ bundler/lib/bundler/vendor/uri/lib/uri/mailto.rb
 bundler/lib/bundler/vendor/uri/lib/uri/rfc2396_parser.rb
 bundler/lib/bundler/vendor/uri/lib/uri/rfc3986_parser.rb
 bundler/lib/bundler/vendor/uri/lib/uri/version.rb
+bundler/lib/bundler/vendor/uri/lib/uri/ws.rb
+bundler/lib/bundler/vendor/uri/lib/uri/wss.rb
 bundler/lib/bundler/vendored_fileutils.rb
 bundler/lib/bundler/vendored_molinillo.rb
 bundler/lib/bundler/vendored_persistent.rb

--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -216,10 +216,8 @@ Automatiek::RakeTask.new("net-http-persistent") do |lib|
     sublib.vendor_lib = "lib/bundler/vendor/connection_pool"
   end
 
-  # We currently include changes over the official version to require internal paths
-  # relatively.
   lib.dependency("uri") do |sublib|
-    sublib.version = "v0.10.0"
+    sublib.version = "v0.10.1"
     sublib.download = { :github => "https://github.com/ruby/uri" }
     sublib.namespace = "URI"
     sublib.prefix = "Bundler"

--- a/bundler/lib/bundler/vendor/uri/lib/uri.rb
+++ b/bundler/lib/bundler/vendor/uri/lib/uri.rb
@@ -86,7 +86,6 @@
 # License::
 #  Copyright (c) 2001 akira yamada <akira@ruby-lang.org>
 #  You can redistribute it and/or modify it under the same term as Ruby.
-# Revision:: $Id$
 #
 
 module Bundler::URI

--- a/bundler/lib/bundler/vendor/uri/lib/uri/common.rb
+++ b/bundler/lib/bundler/vendor/uri/lib/uri/common.rb
@@ -3,7 +3,6 @@
 # = uri/common.rb
 #
 # Author:: Akira Yamada <akira@ruby-lang.org>
-# Revision:: $Id$
 # License::
 #   You can redistribute it and/or modify it under the same term as Ruby.
 #
@@ -61,88 +60,26 @@ module Bundler::URI
     module_function :make_components_hash
   end
 
-  # Module for escaping unsafe characters with codes.
-  module Escape
-    #
-    # == Synopsis
-    #
-    #   Bundler::URI.escape(str [, unsafe])
-    #
-    # == Args
-    #
-    # +str+::
-    #   String to replaces in.
-    # +unsafe+::
-    #   Regexp that matches all symbols that must be replaced with codes.
-    #   By default uses <tt>UNSAFE</tt>.
-    #   When this argument is a String, it represents a character set.
-    #
-    # == Description
-    #
-    # Escapes the string, replacing all unsafe characters with codes.
-    #
-    # This method is obsolete and should not be used. Instead, use
-    # CGI.escape, Bundler::URI.encode_www_form or Bundler::URI.encode_www_form_component
-    # depending on your specific use case.
-    #
-    # == Usage
-    #
-    #   require 'bundler/vendor/uri/lib/uri'
-    #
-    #   enc_uri = Bundler::URI.escape("http://example.com/?a=\11\15")
-    #   # => "http://example.com/?a=%09%0D"
-    #
-    #   Bundler::URI.unescape(enc_uri)
-    #   # => "http://example.com/?a=\t\r"
-    #
-    #   Bundler::URI.escape("@?@!", "!?")
-    #   # => "@%3F@%21"
-    #
-    def escape(*arg)
-      warn "Bundler::URI.escape is obsolete", uplevel: 1
-      DEFAULT_PARSER.escape(*arg)
-    end
-    alias encode escape
-    #
-    # == Synopsis
-    #
-    #   Bundler::URI.unescape(str)
-    #
-    # == Args
-    #
-    # +str+::
-    #   String to unescape.
-    #
-    # == Description
-    #
-    # This method is obsolete and should not be used. Instead, use
-    # CGI.unescape, Bundler::URI.decode_www_form or Bundler::URI.decode_www_form_component
-    # depending on your specific use case.
-    #
-    # == Usage
-    #
-    #   require 'bundler/vendor/uri/lib/uri'
-    #
-    #   enc_uri = Bundler::URI.escape("http://example.com/?a=\11\15")
-    #   # => "http://example.com/?a=%09%0D"
-    #
-    #   Bundler::URI.unescape(enc_uri)
-    #   # => "http://example.com/?a=\t\r"
-    #
-    def unescape(*arg)
-      warn "Bundler::URI.unescape is obsolete", uplevel: 1
-      DEFAULT_PARSER.unescape(*arg)
-    end
-    alias decode unescape
-  end # module Escape
-
-  extend Escape
   include REGEXP
 
   @@schemes = {}
   # Returns a Hash of the defined schemes.
   def self.scheme_list
     @@schemes
+  end
+
+  #
+  # Construct a Bundler::URI instance, using the scheme to detect the appropriate class
+  # from +Bundler::URI.scheme_list+.
+  #
+  def self.for(scheme, *arguments, default: Generic)
+    if scheme
+      uri_class = @@schemes[scheme.upcase] || default
+    else
+      uri_class = default
+    end
+
+    return uri_class.new(scheme, *arguments)
   end
 
   #
@@ -315,7 +252,7 @@ module Bundler::URI
   #
   # Returns a Regexp object which matches to Bundler::URI-like strings.
   # The Regexp object returned by this method includes arbitrary
-  # number of capture group (parentheses).  Never rely on it's number.
+  # number of capture group (parentheses).  Never rely on its number.
   #
   # == Usage
   #
@@ -362,7 +299,7 @@ module Bundler::URI
   # If +enc+ is given, convert +str+ to the encoding before percent encoding.
   #
   # This is an implementation of
-  # http://www.w3.org/TR/2013/CR-html5-20130806/forms.html#url-encoded-form-data.
+  # https://www.w3.org/TR/2013/CR-html5-20130806/forms.html#url-encoded-form-data.
   #
   # See Bundler::URI.decode_www_form_component, Bundler::URI.encode_www_form.
   def self.encode_www_form_component(str, enc=nil)
@@ -403,7 +340,7 @@ module Bundler::URI
   # This method doesn't handle files.  When you send a file, use
   # multipart/form-data.
   #
-  # This refers http://url.spec.whatwg.org/#concept-urlencoded-serializer
+  # This refers https://url.spec.whatwg.org/#concept-urlencoded-serializer
   #
   #    Bundler::URI.encode_www_form([["q", "ruby"], ["lang", "en"]])
   #    #=> "q=ruby&lang=en"

--- a/bundler/lib/bundler/vendor/uri/lib/uri/ftp.rb
+++ b/bundler/lib/bundler/vendor/uri/lib/uri/ftp.rb
@@ -3,7 +3,6 @@
 #
 # Author:: Akira Yamada <akira@ruby-lang.org>
 # License:: You can redistribute it and/or modify it under the same term as Ruby.
-# Revision:: $Id$
 #
 # See Bundler::URI for general documentation
 #

--- a/bundler/lib/bundler/vendor/uri/lib/uri/generic.rb
+++ b/bundler/lib/bundler/vendor/uri/lib/uri/generic.rb
@@ -4,7 +4,6 @@
 #
 # Author:: Akira Yamada <akira@ruby-lang.org>
 # License:: You can redistribute it and/or modify it under the same term as Ruby.
-# Revision:: $Id$
 #
 # See Bundler::URI for general documentation
 #
@@ -1098,7 +1097,7 @@ module Bundler::URI
     #   # => "http://my.example.com/main.rbx?page=1"
     #
     def merge(oth)
-      rel = parser.send(:convert_to_uri, oth)
+      rel = parser.__send__(:convert_to_uri, oth)
 
       if rel.absolute?
         #raise BadURIError, "both Bundler::URI are absolute" if absolute?
@@ -1183,7 +1182,7 @@ module Bundler::URI
 
     # :stopdoc:
     def route_from0(oth)
-      oth = parser.send(:convert_to_uri, oth)
+      oth = parser.__send__(:convert_to_uri, oth)
       if self.relative?
         raise BadURIError,
           "relative Bundler::URI: #{self}"
@@ -1291,7 +1290,7 @@ module Bundler::URI
     #   #=> #<Bundler::URI::Generic /main.rbx?page=1>
     #
     def route_to(oth)
-      parser.send(:convert_to_uri, oth).route_from(self)
+      parser.__send__(:convert_to_uri, oth).route_from(self)
     end
 
     #
@@ -1405,7 +1404,7 @@ module Bundler::URI
     # Returns an Array of the components defined from the COMPONENT Array.
     def component_ary
       component.collect do |x|
-        self.send(x)
+        self.__send__(x)
       end
     end
     protected :component_ary
@@ -1430,7 +1429,7 @@ module Bundler::URI
     def select(*components)
       components.collect do |c|
         if component.include?(c)
-          self.send(c)
+          self.__send__(c)
         else
           raise ArgumentError,
             "expected of components of #{self.class} (#{self.class.component.join(', ')})"

--- a/bundler/lib/bundler/vendor/uri/lib/uri/https.rb
+++ b/bundler/lib/bundler/vendor/uri/lib/uri/https.rb
@@ -3,7 +3,6 @@
 #
 # Author:: Akira Yamada <akira@ruby-lang.org>
 # License:: You can redistribute it and/or modify it under the same term as Ruby.
-# Revision:: $Id$
 #
 # See Bundler::URI for general documentation
 #

--- a/bundler/lib/bundler/vendor/uri/lib/uri/ldap.rb
+++ b/bundler/lib/bundler/vendor/uri/lib/uri/ldap.rb
@@ -7,7 +7,6 @@
 # License::
 #   Bundler::URI::LDAP is copyrighted free software by Takaaki Tateishi and Akira Yamada.
 #   You can redistribute it and/or modify it under the same term as Ruby.
-# Revision:: $Id$
 #
 # See Bundler::URI for general documentation
 #
@@ -119,6 +118,7 @@ module Bundler::URI
 
     # Private method to cleanup +dn+ from using the +path+ component attribute.
     def parse_dn
+      raise InvalidURIError, 'bad LDAP URL' unless @path
       @dn = @path[1..-1]
     end
     private :parse_dn

--- a/bundler/lib/bundler/vendor/uri/lib/uri/mailto.rb
+++ b/bundler/lib/bundler/vendor/uri/lib/uri/mailto.rb
@@ -3,7 +3,6 @@
 #
 # Author:: Akira Yamada <akira@ruby-lang.org>
 # License:: You can redistribute it and/or modify it under the same term as Ruby.
-# Revision:: $Id$
 #
 # See Bundler::URI for general documentation
 #

--- a/bundler/lib/bundler/vendor/uri/lib/uri/rfc2396_parser.rb
+++ b/bundler/lib/bundler/vendor/uri/lib/uri/rfc2396_parser.rb
@@ -3,7 +3,6 @@
 # = uri/common.rb
 #
 # Author:: Akira Yamada <akira@ruby-lang.org>
-# Revision:: $Id$
 # License::
 #   You can redistribute it and/or modify it under the same term as Ruby.
 #
@@ -208,20 +207,8 @@ module Bundler::URI
     #   #=> #<Bundler::URI::LDAP ldap://ldap.example.com/dc=example?user=john>
     #
     def parse(uri)
-      scheme, userinfo, host, port,
-        registry, path, opaque, query, fragment = self.split(uri)
-
-      if scheme && Bundler::URI.scheme_list.include?(scheme.upcase)
-        Bundler::URI.scheme_list[scheme.upcase].new(scheme, userinfo, host, port,
-                                           registry, path, opaque, query,
-                                           fragment, self)
-      else
-        Generic.new(scheme, userinfo, host, port,
-                    registry, path, opaque, query,
-                    fragment, self)
-      end
+      Bundler::URI.for(*self.split(uri), self)
     end
-
 
     #
     # == Args

--- a/bundler/lib/bundler/vendor/uri/lib/uri/rfc3986_parser.rb
+++ b/bundler/lib/bundler/vendor/uri/lib/uri/rfc3986_parser.rb
@@ -69,18 +69,7 @@ module Bundler::URI
     end
 
     def parse(uri) # :nodoc:
-      scheme, userinfo, host, port,
-        registry, path, opaque, query, fragment = self.split(uri)
-      scheme_list = Bundler::URI.scheme_list
-      if scheme && scheme_list.include?(uc = scheme.upcase)
-        scheme_list[uc].new(scheme, userinfo, host, port,
-                            registry, path, opaque, query,
-                            fragment, self)
-      else
-        Generic.new(scheme, userinfo, host, port,
-                    registry, path, opaque, query,
-                    fragment, self)
-      end
+      Bundler::URI.for(*self.split(uri), self)
     end
 
 

--- a/bundler/lib/bundler/vendor/uri/lib/uri/version.rb
+++ b/bundler/lib/bundler/vendor/uri/lib/uri/version.rb
@@ -1,6 +1,6 @@
 module Bundler::URI
   # :stopdoc:
-  VERSION_CODE = '001000'.freeze
+  VERSION_CODE = '001001'.freeze
   VERSION = VERSION_CODE.scan(/../).collect{|n| n.to_i}.join('.').freeze
   # :startdoc:
 end

--- a/bundler/lib/bundler/vendor/uri/lib/uri/ws.rb
+++ b/bundler/lib/bundler/vendor/uri/lib/uri/ws.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
-# = uri/http.rb
+# = uri/ws.rb
 #
-# Author:: Akira Yamada <akira@ruby-lang.org>
+# Author:: Matt Muller <mamuller@amazon.com>
 # License:: You can redistribute it and/or modify it under the same term as Ruby.
 #
 # See Bundler::URI for general documentation
@@ -12,49 +12,46 @@ require_relative 'generic'
 module Bundler::URI
 
   #
-  # The syntax of HTTP URIs is defined in RFC1738 section 3.3.
+  # The syntax of WS URIs is defined in RFC6455 section 3.
   #
-  # Note that the Ruby Bundler::URI library allows HTTP URLs containing usernames and
+  # Note that the Ruby Bundler::URI library allows WS URLs containing usernames and
   # passwords. This is not legal as per the RFC, but used to be
   # supported in Internet Explorer 5 and 6, before the MS04-004 security
   # update. See <URL:http://support.microsoft.com/kb/834489>.
   #
-  class HTTP < Generic
-    # A Default port of 80 for Bundler::URI::HTTP.
+  class WS < Generic
+    # A Default port of 80 for Bundler::URI::WS.
     DEFAULT_PORT = 80
 
-    # An Array of the available components for Bundler::URI::HTTP.
+    # An Array of the available components for Bundler::URI::WS.
     COMPONENT = %i[
       scheme
       userinfo host port
       path
       query
-      fragment
     ].freeze
 
     #
     # == Description
     #
-    # Creates a new Bundler::URI::HTTP object from components, with syntax checking.
+    # Creates a new Bundler::URI::WS object from components, with syntax checking.
     #
-    # The components accepted are userinfo, host, port, path, query, and
-    # fragment.
+    # The components accepted are userinfo, host, port, path, and query.
     #
     # The components should be provided either as an Array, or as a Hash
     # with keys formed by preceding the component names with a colon.
     #
     # If an Array is used, the components must be passed in the
-    # order <code>[userinfo, host, port, path, query, fragment]</code>.
+    # order <code>[userinfo, host, port, path, query]</code>.
     #
     # Example:
     #
-    #     uri = Bundler::URI::HTTP.build(host: 'www.example.com', path: '/foo/bar')
+    #     uri = Bundler::URI::WS.build(host: 'www.example.com', path: '/foo/bar')
     #
-    #     uri = Bundler::URI::HTTP.build([nil, "www.example.com", nil, "/path",
-    #       "query", 'fragment'])
+    #     uri = Bundler::URI::WS.build([nil, "www.example.com", nil, "/path", "query"])
     #
     # Currently, if passed userinfo components this method generates
-    # invalid HTTP URIs as per RFC 1738.
+    # invalid WS URIs as per RFC 1738.
     #
     def self.build(args)
       tmp = Util.make_components_hash(self, args)
@@ -64,14 +61,14 @@ module Bundler::URI
     #
     # == Description
     #
-    # Returns the full path for an HTTP request, as required by Net::HTTP::Get.
+    # Returns the full path for a WS Bundler::URI, as required by Net::HTTP::Get.
     #
     # If the Bundler::URI contains a query, the full path is Bundler::URI#path + '?' + Bundler::URI#query.
     # Otherwise, the path is simply Bundler::URI#path.
     #
     # Example:
     #
-    #     uri = Bundler::URI::HTTP.build(path: '/foo/bar', query: 'test=true')
+    #     uri = Bundler::URI::WS.build(path: '/foo/bar', query: 'test=true')
     #     uri.request_uri #  => "/foo/bar?test=true"
     #
     def request_uri
@@ -82,6 +79,6 @@ module Bundler::URI
     end
   end
 
-  @@schemes['HTTP'] = HTTP
+  @@schemes['WS'] = WS
 
 end

--- a/bundler/lib/bundler/vendor/uri/lib/uri/wss.rb
+++ b/bundler/lib/bundler/vendor/uri/lib/uri/wss.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: false
+# = uri/wss.rb
+#
+# Author:: Matt Muller <mamuller@amazon.com>
+# License:: You can redistribute it and/or modify it under the same term as Ruby.
+#
+# See Bundler::URI for general documentation
+#
+
+require_relative 'ws'
+
+module Bundler::URI
+
+  # The default port for WSS URIs is 443, and the scheme is 'wss:' rather
+  # than 'ws:'. Other than that, WSS URIs are identical to WS URIs;
+  # see Bundler::URI::WS.
+  class WSS < WS
+    # A Default port of 443 for Bundler::URI::WSS
+    DEFAULT_PORT = 443
+  end
+  @@schemes['WSS'] = WSS
+end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Nothing but I noticed some custom patches we were using inside our copy have already been released as 0.10.1.

## What is your fix for the problem, implemented in this PR?

Upgrade so that we use a copy that matches a released version exactly.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
