### PR TITLE
Fix contradictory message about deletion of default gem

### DIFF
--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -70,6 +70,9 @@ class Gem::Uninstaller
     # only add user directory if install_dir is not set
     @user_install = false
     @user_install = options[:user_install] unless options[:install_dir]
+
+    # Optimization: populated during #uninstall
+    @default_specs_matching_uninstall_params = []
   end
 
   ##
@@ -98,10 +101,8 @@ class Gem::Uninstaller
     default_specs, list = list.partition do |spec|
       spec.default_gem?
     end
-
-    default_specs.each do |default_spec|
-      say "Gem #{default_spec.full_name} cannot be uninstalled because it is a default gem"
-    end
+    warn_cannot_uninstall_default_gems(default_specs - list)
+    @default_specs_matching_uninstall_params = default_specs
 
     list, other_repo_specs = list.partition do |spec|
       @gem_home == spec.base_dir or
@@ -273,7 +274,7 @@ class Gem::Uninstaller
     end
 
     safe_delete { FileUtils.rm_r gemspec }
-    say "Successfully uninstalled #{spec.full_name}"
+    announce_deletion_of(spec)
 
     Gem::Specification.reset
   end
@@ -375,5 +376,35 @@ class Gem::Uninstaller
     e.spec = @spec
 
     raise e
+  end
+
+  private
+
+  def announce_deletion_of(spec)
+    name = spec.full_name
+    say "Successfully uninstalled #{name}"
+    if default_spec_matches?(spec)
+      say(
+        "There was both a regular copy and a default copy of #{name}. The " \
+          "regular copy was successfully uninstalled, but the default copy " \
+          "was left around because default gems can't be removed."
+      )
+    end
+  end
+
+  # @return true if the specs of any default gems are `==` to the given `spec`.
+  def default_spec_matches?(spec)
+    !default_specs_that_match(spec).empty?
+  end
+
+  # @return [Array] specs of default gems that are `==` to the given `spec`.
+  def default_specs_that_match(spec)
+    @default_specs_matching_uninstall_params.select {|default_spec| spec == default_spec }
+  end
+
+  def warn_cannot_uninstall_default_gems(specs)
+    specs.each do |spec|
+      say "Gem #{spec.full_name} cannot be uninstalled because it is a default gem"
+    end
   end
 end

--- a/test/rubygems/test_gem_uninstaller.rb
+++ b/test/rubygems/test_gem_uninstaller.rb
@@ -295,8 +295,15 @@ class TestGemUninstaller < Gem::InstallerTestCase
 
     uninstaller = Gem::Uninstaller.new spec.name, :executables => true
 
-    uninstaller.uninstall
-
+    ui = Gem::MockGemUi.new "1\ny\n"
+    use_ui ui do
+      uninstaller.uninstall
+    end
+    expected = "Successfully uninstalled default-2\n" \
+      "There was both a regular copy and a default copy of default-2. The " \
+      "regular copy was successfully uninstalled, but the default copy " \
+      "was left around because default gems can't be removed.\n"
+    assert_equal expected, ui.output
     assert_path_not_exist spec.gem_dir
   end
 


### PR DESCRIPTION
[Fixes #4733]

@deivid-rodriguez I'm happy to write another test, or change the copy-writing. I'm just opening a PR to get initial feedback and make sure I'm on the right track. Thanks.

----

## What was the end-user or developer problem that led to this PR?

#4733

## What is your fix for the problem, implemented in this PR?

As discussed in #4733

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
