### PR TITLE
Reduce CI jobs

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -37,8 +37,6 @@ jobs:
 
         include:
           - { os: { name: MacOS, value: macos-10.15 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-2.5, value: 2.5.9 } }
-          - { os: { name: MacOS, value: macos-10.15 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-2.6, value: 2.6.7 } }
-          - { os: { name: MacOS, value: macos-10.15 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.3 } }
           - { os: { name: MacOS, value: macos-10.15 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.1 } }
     env:
       RGV: ..

--- a/.github/workflows/windows-bundler.yml
+++ b/.github/workflows/windows-bundler.yml
@@ -22,10 +22,7 @@ jobs:
       matrix:
         ruby:
           - { name: jruby-9.2, value: jruby-9.2.16.0 }
-          - { name: ruby-2.4, value: 2.4.10 }
           - { name: ruby-2.5, value: 2.5.9 }
-          - { name: ruby-2.6, value: 2.6.7 }
-          - { name: ruby-2.7, value: 2.7.3 }
           - { name: ruby-3.0, value: 3.0.1 }
 
     steps:


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

CI feedback is slow, and quite flaky on MacOS.

## What is your fix for the problem, implemented in this PR?

Make some compromise and reduce some CI jobs that are very unlikely to detect issues, based on the experience in recent years.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
