### PR TITLE
Add a description about `GEM_HOST_OTP_CODE` to help text

### DIFF
--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -31,7 +31,8 @@ module Gem::GemcutterUtilities
 
   def add_otp_option
     add_option('--otp CODE',
-               'Digit code for multifactor authentication') do |value, options|
+               'Digit code for multifactor authentication',
+               'You can also use the environment variable GEM_HOST_OTP_CODE') do |value, options|
       options[:otp] = value
     end
   end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

The environment variable `GEM_HOST_OTP_CODE` has been added via PR #4697, but users cannot know the new variable from the `gem --help` text.
I think it valuable to add a description of the variable to the help text.

## What is your fix for the problem, implemented in this PR?

I've added just an extra description to the method `#add_otp_option`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
