### PR TITLE
Make some new gem specs less brittle

### DIFF
--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -307,42 +307,42 @@ RSpec.describe "bundle gem" do
     skip "ruby_core has an 'ast.rb' file that gets in the middle and breaks this spec" if ruby_core?
     bundle "gem #{gem_name} --linter=rubocop"
     bundle_exec_rubocop
-    expect(err).to be_empty
+    expect(last_command).to be_success
   end
 
   it "has no rubocop offenses when using --ext and --linter=rubocop flag", :readline do
     skip "ruby_core has an 'ast.rb' file that gets in the middle and breaks this spec" if ruby_core?
     bundle "gem #{gem_name} --ext --linter=rubocop"
     bundle_exec_rubocop
-    expect(err).to be_empty
+    expect(last_command).to be_success
   end
 
   it "has no rubocop offenses when using --ext, --test=minitest, and --linter=rubocop flag", :readline do
     skip "ruby_core has an 'ast.rb' file that gets in the middle and breaks this spec" if ruby_core?
     bundle "gem #{gem_name} --ext --test=minitest --linter=rubocop"
     bundle_exec_rubocop
-    expect(err).to be_empty
+    expect(last_command).to be_success
   end
 
   it "has no rubocop offenses when using --ext, --test=rspec, and --linter=rubocop flag", :readline do
     skip "ruby_core has an 'ast.rb' file that gets in the middle and breaks this spec" if ruby_core?
     bundle "gem #{gem_name} --ext --test=rspec --linter=rubocop"
     bundle_exec_rubocop
-    expect(err).to be_empty
+    expect(last_command).to be_success
   end
 
   it "has no rubocop offenses when using --ext, --ext=test-unit, and --linter=rubocop flag", :readline do
     skip "ruby_core has an 'ast.rb' file that gets in the middle and breaks this spec" if ruby_core?
     bundle "gem #{gem_name} --ext --test=test-unit --linter=rubocop"
     bundle_exec_rubocop
-    expect(err).to be_empty
+    expect(last_command).to be_success
   end
 
   it "has no standard offenses when using --linter=standard flag", :readline do
     skip "ruby_core has an 'ast.rb' file that gets in the middle and breaks this spec" if ruby_core?
     bundle "gem #{gem_name} --linter=standard"
     bundle_exec_standardrb
-    expect(err).to be_empty
+    expect(last_command).to be_success
   end
 
   shared_examples_for "CI config is absent" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Tiny changes in the ruby patch level make some new gem specs fail.

## What is your fix for the problem, implemented in this PR?

Check for command status rather than error output, so that warnings about mismatches between parser version and ruby patch level version (unrelated to the specs), don't make them fail.

Fixes #4633.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
