### PR TITLE
Make sure `bundle check` shows uniq missing gems

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -138,7 +138,7 @@ module Bundler
         @unlock[:gems] ||= @dependencies.map(&:name)
       else
         eager_unlock = expand_dependencies(@unlock[:gems] || [], true)
-        @unlock[:gems] = @locked_specs.for(eager_unlock, [], false, false, false).map(&:name)
+        @unlock[:gems] = @locked_specs.for(eager_unlock, false, false, false).map(&:name)
       end
 
       @dependency_changes = converge_dependencies
@@ -742,7 +742,7 @@ module Bundler
             # if we won't need the source (according to the lockfile),
             # don't error if the path/git source isn't available
             next if @locked_specs.
-                    for(requested_dependencies, [], false, true, false).
+                    for(requested_dependencies, false, true, false).
                     none? {|locked_spec| locked_spec.source == s.source }
 
             raise
@@ -761,8 +761,8 @@ module Bundler
       end
 
       resolve = SpecSet.new(converged)
-      @locked_specs_incomplete_for_platform = !resolve.for(expand_dependencies(requested_dependencies & deps), @unlock[:gems], true, true)
-      resolve = SpecSet.new(resolve.for(expand_dependencies(deps, true), [], false, false, false).reject{|s| @unlock[:gems].include?(s.name) })
+      @locked_specs_incomplete_for_platform = !resolve.for(expand_dependencies(requested_dependencies & deps), true, true)
+      resolve = SpecSet.new(resolve.for(expand_dependencies(deps, true), false, false, false).reject{|s| @unlock[:gems].include?(s.name) })
       diff    = nil
 
       # Now, we unlock any sources that do not have anymore gems pinned to it

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -15,17 +15,16 @@ module Bundler
       handled = []
       deps = dependencies.dup
       specs = []
-      skip = ["bundler"]
 
       loop do
         break unless dep = deps.shift
-        next if handled.include?(dep) || skip.include?(dep.name)
+        next if handled.include?(dep)
 
         handled << dep
 
         specs_for_dep = spec_for_dependency(dep, match_current_platform)
         if specs_for_dep.any?
-          specs += specs_for_dep
+          specs |= specs_for_dep
 
           specs_for_dep.first.dependencies.each do |d|
             next if d.type == :development
@@ -43,7 +42,7 @@ module Bundler
       end
 
       if spec = lookup["bundler"].first
-        specs << spec
+        specs |= [spec]
       end
 
       check ? true : specs

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -11,11 +11,11 @@ module Bundler
       @specs = specs
     end
 
-    def for(dependencies, skip = [], check = false, match_current_platform = false, raise_on_missing = true)
+    def for(dependencies, check = false, match_current_platform = false, raise_on_missing = true)
       handled = []
       deps = dependencies.dup
       specs = []
-      skip += ["bundler"]
+      skip = ["bundler"]
 
       loop do
         break unless dep = deps.shift
@@ -73,7 +73,7 @@ module Bundler
     end
 
     def materialize(deps, missing_specs = nil)
-      materialized = self.for(deps, [], false, true, !missing_specs)
+      materialized = self.for(deps, false, true, !missing_specs)
 
       materialized.group_by(&:source).each do |source, specs|
         next unless specs.any?{|s| s.is_a?(LazySpecification) }


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`bundle check` displaying duplicated missing gems.

## What is your fix for the problem, implemented in this PR?

Make sure `SpecSet#for` returns uniq gems.

Fixes #4746.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
