### PR TITLE
Slightly speed up `bundler/setup`

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -240,17 +240,11 @@ module Bundler
     end
 
     def requested_specs
-      @requested_specs ||= begin
-        groups = requested_groups
-        groups.map!(&:to_sym)
-        specs_for(groups)
-      end
+      @requested_specs ||= specs_for(requested_groups)
     end
 
     def requested_dependencies
-      groups = requested_groups
-      groups.map!(&:to_sym)
-      dependencies_for(groups)
+      dependencies_for(requested_groups)
     end
 
     def current_dependencies
@@ -265,6 +259,7 @@ module Bundler
     end
 
     def dependencies_for(groups)
+      groups.map!(&:to_sym)
       current_dependencies.reject do |d|
         (d.groups & groups).empty?
       end

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -254,6 +254,7 @@ module Bundler
     end
 
     def specs_for(groups)
+      groups = requested_groups if groups.empty?
       deps = dependencies_for(groups)
       SpecSet.new(specs.for(expand_dependencies(deps)))
     end

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -240,7 +240,7 @@ module Bundler
     end
 
     def requested_specs
-      @requested_specs ||= specs_for(requested_groups)
+      specs_for(requested_groups)
     end
 
     def requested_dependencies

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -190,25 +190,15 @@ module Bundler
     #
     # @return [Bundler::SpecSet]
     def specs
-      @specs ||= begin
-        begin
-          specs = resolve.materialize(requested_dependencies)
-        rescue GemNotFound => e # Handle yanked gem
-          gem_name, gem_version = extract_gem_info(e)
-          locked_gem = @locked_specs[gem_name].last
-          raise if locked_gem.nil? || locked_gem.version.to_s != gem_version || !@remote
-          raise GemNotFound, "Your bundle is locked to #{locked_gem} from #{locked_gem.source}, but that version can " \
-                             "no longer be found in that source. That means the author of #{locked_gem} has removed it. " \
-                             "You'll need to update your bundle to a version other than #{locked_gem} that hasn't been " \
-                             "removed in order to install."
-        end
-        unless specs["bundler"].any?
-          bundler = sources.metadata_source.specs.search(Gem::Dependency.new("bundler", VERSION)).last
-          specs["bundler"] = bundler
-        end
-
-        specs
-      end
+      @specs ||= add_bundler_to(resolve.materialize(requested_dependencies))
+    rescue GemNotFound => e # Handle yanked gem
+      gem_name, gem_version = extract_gem_info(e)
+      locked_gem = @locked_specs[gem_name].last
+      raise if locked_gem.nil? || locked_gem.version.to_s != gem_version || !@remote
+      raise GemNotFound, "Your bundle is locked to #{locked_gem} from #{locked_gem.source}, but that version can " \
+                         "no longer be found in that source. That means the author of #{locked_gem} has removed it. " \
+                         "You'll need to update your bundle to a version other than #{locked_gem} that hasn't been " \
+                         "removed in order to install."
     end
 
     def new_specs
@@ -509,6 +499,15 @@ module Bundler
     end
 
     private
+
+    def add_bundler_to(specs)
+      unless specs["bundler"].any?
+        bundler = sources.metadata_source.specs.search(Gem::Dependency.new("bundler", VERSION)).last
+        specs["bundler"] = bundler
+      end
+
+      specs
+    end
 
     def precompute_source_requirements_for_indirect_dependencies?
       sources.non_global_rubygems_sources.all?(&:dependency_api_available?) && !sources.aggregate_global_source?

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -246,7 +246,7 @@ module Bundler
     def specs_for(groups)
       groups = requested_groups if groups.empty?
       deps = dependencies_for(groups)
-      SpecSet.new(specs.for(expand_dependencies(deps)))
+      add_bundler_to(resolve.materialize(expand_dependencies(deps)))
     end
 
     def dependencies_for(groups)

--- a/bundler/lib/bundler/installer/standalone.rb
+++ b/bundler/lib/bundler/installer/standalone.rb
@@ -3,7 +3,7 @@
 module Bundler
   class Standalone
     def initialize(groups, definition)
-      @specs = groups.empty? ? definition.requested_specs : definition.specs_for(groups.map(&:to_sym))
+      @specs = groups.empty? ? definition.requested_specs : definition.specs_for(groups)
     end
 
     def generate

--- a/bundler/lib/bundler/installer/standalone.rb
+++ b/bundler/lib/bundler/installer/standalone.rb
@@ -3,7 +3,7 @@
 module Bundler
   class Standalone
     def initialize(groups, definition)
-      @specs = groups.empty? ? definition.requested_specs : definition.specs_for(groups)
+      @specs = definition.specs_for(groups)
     end
 
     def generate

--- a/bundler/lib/bundler/runtime.rb
+++ b/bundler/lib/bundler/runtime.rb
@@ -15,7 +15,7 @@ module Bundler
       # Has to happen first
       clean_load_path
 
-      specs = groups.any? ? @definition.specs_for(groups) : requested_specs
+      specs = @definition.specs_for(groups)
 
       SharedHelpers.set_bundle_environment
       Bundler.rubygems.replace_entrypoints(specs)

--- a/bundler/lib/bundler/runtime.rb
+++ b/bundler/lib/bundler/runtime.rb
@@ -12,8 +12,6 @@ module Bundler
     def setup(*groups)
       @definition.ensure_equivalent_gemfile_and_lockfile if Bundler.frozen_bundle?
 
-      groups.map!(&:to_sym)
-
       # Has to happen first
       clean_load_path
 

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -18,7 +18,7 @@ module Bundler
 
       loop do
         break unless dep = deps.shift
-        next if handled.any?{|d| d.name == dep.name && (match_current_platform || d.__platform == dep.__platform) }
+        next if handled.any?{|d| d.name == dep.name && (match_current_platform || d.__platform == dep.__platform) } || dep.name == "bundler"
 
         handled << dep
 
@@ -42,7 +42,7 @@ module Bundler
       end
 
       if spec = lookup["bundler"].first
-        specs |= [spec]
+        specs << spec
       end
 
       check ? true : specs

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -18,13 +18,13 @@ module Bundler
 
       loop do
         break unless dep = deps.shift
-        next if handled.include?(dep)
+        next if handled.any?{|d| d.name == dep.name && (match_current_platform || d.__platform == dep.__platform) }
 
         handled << dep
 
         specs_for_dep = spec_for_dependency(dep, match_current_platform)
         if specs_for_dep.any?
-          specs |= specs_for_dep
+          specs += specs_for_dep
 
           specs_for_dep.first.dependencies.each do |d|
             next if d.type == :development


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We should be making `bundler/setup` as fast as we can.

## What is your fix for the problem, implemented in this PR?

Refactor some stuff to reduce the work we need to do setup the bundle.

It fixes a small performance regression introduced by #4749 (still unreleased), but the final result should also be ~5-10% faster than the latest release.

On a brand new rails application, I get this:

```
$ hyperfine --warmup 1 'ruby -rbundler/setup -e1' 'BUNDLER_VERSION=2.2.23 ruby -rbundler/setup -e1' 
Benchmark #1: ruby -rbundler/setup -e1
  Time (mean ± σ):     205.1 ms ±   1.8 ms    [User: 185.7 ms, System: 21.6 ms]
  Range (min … max):   202.7 ms … 209.1 ms    14 runs
 
Benchmark #2: BUNDLER_VERSION=2.2.23 ruby -rbundler/setup -e1
  Time (mean ± σ):     219.4 ms ±   1.5 ms    [User: 196.3 ms, System: 25.4 ms]
  Range (min … max):   217.5 ms … 223.3 ms    13 runs
 
Summary
  'ruby -rbundler/setup -e1' ran
    1.07 ± 0.01 times faster than 'BUNDLER_VERSION=2.2.23 ruby -rbundler/setup -e1'
```  
## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
