### PR TITLE
Fix development gem unintentionally removed on an edge case

### DIFF
--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -388,6 +388,7 @@ RSpec.describe "bundle install with gem sources" do
       bundle :install
 
       expect(err).to be_empty
+      expect(the_bundle).to include_gems("my-private-gem 1.0")
     end
 
     it "throws an error if a gem is added twice in Gemfile when version of one dependency is not specified" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When a development dependency was duplicated inside the gemspec and
Gemfile with the same requirements, we went from printing a warning to
removing the gem altogether.

## What is your fix for the problem, implemented in this PR?

The fix is to change the logic to not return too early and miss the actual addition of the gem in this edge case.

Fixes #4748.
Fixes #4754.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
