### PR TITLE
fix dangling empty plugin hooks

### DIFF
--- a/bundler/lib/bundler/plugin.rb
+++ b/bundler/lib/bundler/plugin.rb
@@ -309,6 +309,8 @@ module Bundler
     #
     # @param [String] name of the plugin
     def load_plugin(name)
+      return unless name && !name.empty?
+
       # Need to ensure before this that plugin root where the rest of gems
       # are installed to be on load path to support plugin deps. Currently not
       # done to avoid conflicts

--- a/bundler/lib/bundler/plugin/index.rb
+++ b/bundler/lib/bundler/plugin/index.rb
@@ -74,7 +74,10 @@ module Bundler
       def unregister_plugin(name)
         @commands.delete_if {|_, v| v == name }
         @sources.delete_if {|_, v| v == name }
-        @hooks.each {|_, plugin_names| plugin_names.delete(name) }
+        @hooks.each do |hook, names|
+          names.delete(name)
+          @hooks.delete(hook) if names.empty?
+        end
         @plugin_paths.delete(name)
         @load_paths.delete(name)
         save_index

--- a/bundler/spec/bundler/plugin/index_spec.rb
+++ b/bundler/spec/bundler/plugin/index_spec.rb
@@ -98,6 +98,12 @@ RSpec.describe Bundler::Plugin::Index do
       expect(index.hook_plugins("after-bar")).to eq([plugin_name])
     end
 
+    it "is gone after unregistration" do
+      expect(index.index_file.read).to include("after-bar:\n  - \"new-plugin\"\n")
+      index.unregister_plugin(plugin_name)
+      expect(index.index_file.read).to_not include("after-bar:\n  - \n")
+    end
+
     context "that are not registered" do
       let(:file) { double("index-file") }
 

--- a/bundler/spec/bundler/plugin/index_spec.rb
+++ b/bundler/spec/bundler/plugin/index_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Bundler::Plugin::Index do
       expect(index.hook_plugins("after-bar")).to eq([plugin_name])
     end
 
-    context "that are not registered", :focused do
+    context "that are not registered" do
       let(:file) { double("index-file") }
 
       before do

--- a/bundler/spec/bundler/plugin_spec.rb
+++ b/bundler/spec/bundler/plugin_spec.rb
@@ -277,7 +277,7 @@ RSpec.describe Bundler::Plugin do
       Bundler::Plugin::Events.send(:define, :EVENT_2, "event-2")
 
       allow(index).to receive(:hook_plugins).with(Bundler::Plugin::Events::EVENT_1).
-        and_return(["foo-plugin"])
+        and_return(["foo-plugin", "", nil])
       allow(index).to receive(:hook_plugins).with(Bundler::Plugin::Events::EVENT_2).
         and_return(["foo-plugin"])
       allow(index).to receive(:plugin_path).with("foo-plugin").and_return(path)

--- a/bundler/tool/bundler/rubocop_gems.rb.lock
+++ b/bundler/tool/bundler/rubocop_gems.rb.lock
@@ -44,6 +44,7 @@ GEM
     unicode-display_width (2.0.0)
 
 PLATFORMS
+  arm64-darwin-20
   universal-java-11
   x86_64-linux
 

--- a/bundler/tool/bundler/standard_gems.rb.lock
+++ b/bundler/tool/bundler/standard_gems.rb.lock
@@ -50,6 +50,7 @@ GEM
     unicode-display_width (2.0.0)
 
 PLATFORMS
+  arm64-darwin-20
   universal-java-11
   x86_64-linux
 


### PR DESCRIPTION
it turns out that running `bundle plugin uninstall some-plugin` would remove that plugin from the list of hooks, but if the list of hooks for an event was now empty, we would serialize the empty array into yaml as an empty single bullet item. which would then get unserialized as a plugin with the name empty string. which we would then try to load and explode. 😬