### PR TITLE
Fix `bundle plugin install --help` showing `bundle install`'s help

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -14,6 +14,7 @@ module Bundler
     COMMAND_ALIASES = {
       "check" => "c",
       "install" => "i",
+      "plugin" => "",
       "list" => "ls",
       "exec" => ["e", "ex", "exe"],
       "cache" => ["package", "pack"],

--- a/bundler/spec/plugins/install_spec.rb
+++ b/bundler/spec/plugins/install_spec.rb
@@ -29,6 +29,12 @@ RSpec.describe "bundler plugin install" do
     plugin_should_be_installed("foo")
   end
 
+  it "shows help when --help flag is given" do
+    bundle "plugin install --help"
+
+    expect(out).to include("bundle plugin install PLUGINS    # Install the plugin from the source")
+  end
+
   context "plugin is already installed" do
     before do
       bundle "plugin install foo --source #{file_uri_for(gem_repo2)}"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`bundle plugin install --help` is showing `bundle install`'s help.

## What is your fix for the problem, implemented in this PR?

Add `plugin` to the list of known commands, so that the `--help` flag is properly "redirected" to those commands help.

Fixes #4753.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
