### PR TITLE
 Changelogs for rubygems 3.2.24 and bundler 2.2.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 3.2.24 / 2021-07-15
+
+## Bug fixes:
+
+* Fix contradictory message about deletion of default gem. Pull request
+  #4739 by jaredbeck
+
+## Documentation:
+
+* Add a description about `GEM_HOST_OTP_CODE` to help text. Pull request
+  #4742 by ybiquitous
+
 # 3.2.23 / 2021-07-09
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 2.2.24 (July 15, 2021)
+
+## Bug fixes:
+
+  - Fix development gem unintentionally removed on an edge case [#4751](https://github.com/rubygems/rubygems/pull/4751)
+  - Fix dangling empty plugin hooks [#4755](https://github.com/rubygems/rubygems/pull/4755)
+  - Fix `bundle plugin install --help` showing `bundle install`'s help [#4756](https://github.com/rubygems/rubygems/pull/4756)
+  - Make sure `bundle check` shows uniq missing gems [#4749](https://github.com/rubygems/rubygems/pull/4749)
+
+## Performance:
+
+  - Slightly speed up `bundler/setup` [#4750](https://github.com/rubygems/rubygems/pull/4750)
+
 # 2.2.23 (July 9, 2021)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking changelogs from future rubygems 3.2.24 and bundler 2.2.24 into master.