### PR TITLE
Consistent capitalization of changelog entries

### DIFF
--- a/util/changelog.rb
+++ b/util/changelog.rb
@@ -129,7 +129,7 @@ class Changelog
 
   def format_entry_for(pull)
     new_entry = entry_template
-      .gsub(/%pull_request_title/, pull.title.strip.delete_suffix("."))
+      .gsub(/%pull_request_title/, pull.title.strip.delete_suffix(".").tap {|s| s[0] = s[0].upcase })
       .gsub(/%pull_request_number/, pull.number.to_s)
       .gsub(/%pull_request_url/, pull.html_url)
       .gsub(/%pull_request_author/, pull.user.name || pull.user.login)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Just a tiny change to make capitalization of changelog entries consistent regardless of actual PR title.

## What is your fix for the problem, implemented in this PR?

Nah, just my nitpickyness.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
