### PR TITLE
Fix interrupt handling in Bundler workers

### DIFF
--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -145,13 +145,6 @@ module Bundler
       Bundler.ui.warn message
     end
 
-    def trap(signal, override = false, &block)
-      prior = Signal.trap(signal) do
-        block.call
-        prior.call unless override
-      end
-    end
-
     def ensure_same_dependencies(spec, old_deps, new_deps)
       new_deps = new_deps.reject {|d| d.type == :development }
       old_deps = old_deps.reject {|d| d.type == :development }

--- a/bundler/lib/bundler/worker.rb
+++ b/bundler/lib/bundler/worker.rb
@@ -26,7 +26,7 @@ module Bundler
       @func = func
       @size = size
       @threads = nil
-      SharedHelpers.trap("INT") { abort_threads }
+      @previous_interrupt_handler = nil
     end
 
     # Enqueue a request to be executed in the worker pool
@@ -68,13 +68,16 @@ module Bundler
     # so as worker threads after retrieving it, shut themselves down
     def stop_threads
       return unless @threads
+
       @threads.each { @request_queue.enq POISON }
       @threads.each(&:join)
+
+      remove_interrupt_handler
+
       @threads = nil
     end
 
     def abort_threads
-      return unless @threads
       Bundler.ui.debug("\n#{caller.join("\n")}")
       @threads.each(&:exit)
       exit 1
@@ -94,11 +97,23 @@ module Bundler
         end
       end.compact
 
+      add_interrupt_handler unless @threads.empty?
+
       return if creation_errors.empty?
 
       message = "Failed to create threads for the #{name} worker: #{creation_errors.map(&:to_s).uniq.join(", ")}"
       raise ThreadCreationError, message if @threads.empty?
       Bundler.ui.info message
+    end
+
+    def add_interrupt_handler
+      @previous_interrupt_handler = trap("INT") { abort_threads }
+    end
+
+    def remove_interrupt_handler
+      return unless @previous_interrupt_handler
+
+      trap "INT", @previous_interrupt_handler
     end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Fixes #4764.

The existing interrupt handling using `SharedHelpers.trap` fails when the previous handler for a signal is not callable (for example, when it is the string "DEFAULT").

## What is your fix for the problem, implemented in this PR?

Instead, we now handle interrupts by aborting the process when worker threads are running, and restore the previous handler after worker threads are finished.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
