### PR TITLE
Add missing `require 'fileutils'` in `Gem::ConfigFile`

### DIFF
--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -320,7 +320,8 @@ if you believe they were disclosed to a third party.
     config = load_file(credentials_path).merge(host => api_key)
 
     dirname = File.dirname credentials_path
-    FileUtils.mkdir_p(dirname) unless File.exist? dirname
+    require 'fileutils'
+    FileUtils.mkdir_p(dirname)
 
     Gem.load_yaml
 
@@ -457,9 +458,8 @@ if you believe they were disclosed to a third party.
 
   # Writes out this config file, replacing its source.
   def write
-    unless File.exist?(File.dirname(config_file_name))
-      FileUtils.mkdir_p File.dirname(config_file_name)
-    end
+    require 'fileutils'
+    FileUtils.mkdir_p File.dirname(config_file_name)
 
     File.open config_file_name, 'w' do |io|
       io.write to_yaml


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

Fix #4761 

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

This PR aims to fix potential `NameError` for `FileUtils` when executing the `gem signin` command.

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

Adding `require 'fileutils'` before using `FileUtils`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
