### PR TITLE
Remove LoadError message in regards to requiring a relative file

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -653,10 +653,6 @@ EOF
     rescue ScriptError, StandardError => e
       msg = "There was an error while loading `#{path.basename}`: #{e.message}"
 
-      if e.is_a?(LoadError)
-        msg += "\nDoes it try to require a relative path? That's been removed in Ruby 1.9"
-      end
-
       raise GemspecError, Dsl::DSLError.new(msg, path, e.backtrace, contents)
     end
 

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -1066,7 +1066,6 @@ end
 
       expect(err.lines.map(&:chomp)).to include(
         a_string_starting_with("[!] There was an error while loading `bar.gemspec`:"),
-        a_string_starting_with("Does it try to require a relative path? That's been removed in Ruby 1.9."),
         " #  from #{default_bundle_path "bundler", "gems", "bar-1.0-#{ref[0, 12]}", "bar.gemspec"}:1",
         " >  require 'foobarbaz'"
       )


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When Bundler isn't able to load a required file, it will show the following error:

> Does it try to require a relative path? That's been removed in Ruby 1.9. Bundler cannot continue.  

## What is your fix for the problem, implemented in this PR?

Removing that message.

### Context

Ruby 1.9.2 removed "." from LOAD_PATH for robustness and security reasons.

This code was introduced by https://github.com/rubygems/rubygems/commit/56fc830e19a573a5905eba7f4714ad1f21ed1927 commit to helping users understand the issue and had a guard condition to include the message for `RUBY_VERSION >= "1.9"`.
However, the guard condition was removed as part of the "Ruby version leftover" cleanup by https://github.com/rubygems/rubygems/commit/8c9cf76e419fbd8ba83144d701b24ca388813b14

Ruby 1.9 development was ended a long time ago and this message is not useful anymore.

Closes https://github.com/rubygems/rubygems/issues/4769.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
