### PR TITLE
Fix bundler binstub version selection

### DIFF
--- a/bundler/lib/bundler/templates/Executable.bundler
+++ b/bundler/lib/bundler/templates/Executable.bundler
@@ -60,16 +60,16 @@ m = Module.new do
     Regexp.last_match(1)
   end
 
-  def bundler_version
-    @bundler_version ||=
+  def bundler_requirement
+    @bundler_requirement ||=
       env_var_version || cli_arg_version ||
-        lockfile_version
+        bundler_requirement_for(lockfile_version)
   end
 
-  def bundler_requirement
-    return "#{Gem::Requirement.default}.a" unless bundler_version
+  def bundler_requirement_for(version)
+    return "#{Gem::Requirement.default}.a" unless version
 
-    bundler_gem_version = Gem::Version.new(bundler_version)
+    bundler_gem_version = Gem::Version.new(version)
 
     requirement = bundler_gem_version.approximate_recommendation
 

--- a/bundler/spec/commands/binstubs_spec.rb
+++ b/bundler/spec/commands/binstubs_spec.rb
@@ -140,8 +140,15 @@ RSpec.describe "bundle binstubs <gem>" do
         it "runs the correct version of bundler" do
           sys_exec "bin/bundle install", :env => { "BUNDLER_VERSION" => "999.999.999" }, :raise_on_error => false
           expect(exitstatus).to eq(42)
-          expect(err).to include("Activating bundler (~> 999.999) failed:").
-            and include("To install the version of bundler this project requires, run `gem install bundler -v '~> 999.999'`")
+          expect(err).to include("Activating bundler (999.999.999) failed:").
+            and include("To install the version of bundler this project requires, run `gem install bundler -v '999.999.999'`")
+        end
+
+        it "runs the correct version of bundler even if a higher version is installed" do
+          system_gems "bundler-999.999.998", "bundler-999.999.999"
+
+          sys_exec "bin/bundle install", :env => { "BUNDLER_VERSION" => "999.999.998", "DEBUG" => "1" }, :raise_on_error => false
+          expect(out).to include %(Using bundler 999.999.998\n)
         end
       end
 
@@ -215,8 +222,8 @@ RSpec.describe "bundle binstubs <gem>" do
         it "calls through to the explicit bundler version" do
           sys_exec "bin/bundle update --bundler=999.999.999", :raise_on_error => false
           expect(exitstatus).to eq(42)
-          expect(err).to include("Activating bundler (~> 999.999) failed:").
-            and include("To install the version of bundler this project requires, run `gem install bundler -v '~> 999.999'`")
+          expect(err).to include("Activating bundler (999.999.999) failed:").
+            and include("To install the version of bundler this project requires, run `gem install bundler -v '999.999.999'`")
         end
       end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`BUNDLER_VERSION` is not properly respected by bundler binstub.

## What is your fix for the problem, implemented in this PR?

To mimic built-in rubygems behaviour, only thing that should be approximated is the lockfile version. Other alternatives like `BUNDLER_VERSION` should be respected exactly.

Fixes #4774.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
