### PR TITLE
Show original error and backtrace directly on `bundle install` errors instead of a more brittle `gem install` hint

### DIFF
--- a/bundler/lib/bundler/installer/gem_installer.rb
+++ b/bundler/lib/bundler/installer/gem_installer.rb
@@ -31,7 +31,7 @@ module Bundler
 
     def specific_failure_message(e)
       message = "#{e.class}: #{e.message}\n"
-      message += "  " + e.backtrace.join("\n  ") + "\n\n" if Bundler.ui.debug?
+      message += "  " + e.backtrace.join("\n  ") + "\n\n"
       message = message.lines.first + Bundler.ui.add_color(message.lines.drop(1).join, :clear)
       message + Bundler.ui.add_color(failure_message, :red)
     end

--- a/bundler/lib/bundler/installer/gem_installer.rb
+++ b/bundler/lib/bundler/installer/gem_installer.rb
@@ -37,23 +37,11 @@ module Bundler
     end
 
     def failure_message
-      return install_error_message if spec.source.options["git"]
-      "#{install_error_message}\n#{gem_install_message}"
+      install_error_message
     end
 
     def install_error_message
       "An error occurred while installing #{spec.name} (#{spec.version}), and Bundler cannot continue."
-    end
-
-    def gem_install_message
-      source = spec.source
-      return unless source.respond_to?(:remotes)
-
-      if source.remotes.size == 1
-        "Make sure that `gem install #{spec.name} -v '#{spec.version}' --source '#{source.remotes.first}'` succeeds before bundling."
-      else
-        "Make sure that `gem install #{spec.name} -v '#{spec.version}'` succeeds before bundling."
-      end
     end
 
     def spec_settings

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -448,7 +448,7 @@ RSpec.describe "bundle install with gem sources" do
 
       expect(last_command.stdboth).not_to match(/Error Report/i)
       expect(err).to include("An error occurred while installing ajp-rails (0.0.0), and Bundler cannot continue.").
-        and include("Make sure that `gem install ajp-rails -v '0.0.0' --source '#{file_uri_for(gem_repo2)}/'` succeeds before bundling.")
+        and include("Bundler::APIResponseInvalidDependenciesError")
     end
 
     it "doesn't blow up when the local .bundle/config is empty" do

--- a/bundler/spec/install/failure_spec.rb
+++ b/bundler/spec/install/failure_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "bundle install" do
   context "installing a gem fails" do
-    it "prints out why that gem was being installed" do
+    it "prints out why that gem was being installed and the underlying error" do
       build_repo2 do
         build_gem "activesupport", "2.3.2" do |s|
           s.extensions << "Rakefile"
@@ -18,102 +18,9 @@ RSpec.describe "bundle install" do
         source "#{file_uri_for(gem_repo2)}"
         gem "rails"
       G
+      expect(err).to start_with("Gem::Ext::BuildError: ERROR: Failed to build gem native extension.")
       expect(err).to end_with(<<-M.strip)
 An error occurred while installing activesupport (2.3.2), and Bundler cannot continue.
-Make sure that `gem install activesupport -v '2.3.2' --source '#{file_uri_for(gem_repo2)}/'` succeeds before bundling.
-
-In Gemfile:
-  rails was resolved to 2.3.2, which depends on
-    actionmailer was resolved to 2.3.2, which depends on
-      activesupport
-                     M
-    end
-
-    context "when installing a git gem" do
-      it "does not tell the user to run 'gem install'" do
-        build_git "activesupport", "2.3.2", :path => lib_path("activesupport") do |s|
-          s.extensions << "Rakefile"
-          s.write "Rakefile", <<-RUBY
-            task :default do
-              abort "make installing activesupport-2.3.2 fail"
-            end
-          RUBY
-        end
-
-        install_gemfile <<-G, :raise_on_error => false
-          source "#{file_uri_for(gem_repo1)}"
-          gem "rails"
-          gem "activesupport", :git => "#{lib_path("activesupport")}"
-        G
-
-        expect(err).to end_with(<<-M.strip)
-An error occurred while installing activesupport (2.3.2), and Bundler cannot continue.
-
-In Gemfile:
-  rails was resolved to 2.3.2, which depends on
-    actionmailer was resolved to 2.3.2, which depends on
-      activesupport
-                     M
-      end
-    end
-
-    context "when installing a gem using a git block" do
-      it "does not tell the user to run 'gem install'" do
-        build_git "activesupport", "2.3.2", :path => lib_path("activesupport") do |s|
-          s.extensions << "Rakefile"
-          s.write "Rakefile", <<-RUBY
-            task :default do
-              abort "make installing activesupport-2.3.2 fail"
-            end
-          RUBY
-        end
-
-        install_gemfile <<-G, :raise_on_error => false
-          source "#{file_uri_for(gem_repo1)}"
-          gem "rails"
-
-          git "#{lib_path("activesupport")}" do
-            gem "activesupport"
-          end
-        G
-
-        expect(err).to end_with(<<-M.strip)
-An error occurred while installing activesupport (2.3.2), and Bundler cannot continue.
-
-
-In Gemfile:
-  rails was resolved to 2.3.2, which depends on
-    actionmailer was resolved to 2.3.2, which depends on
-      activesupport
-                     M
-      end
-    end
-
-    it "prints out the hint for the remote source when available" do
-      build_repo2 do
-        build_gem "activesupport", "2.3.2" do |s|
-          s.extensions << "Rakefile"
-          s.write "Rakefile", <<-RUBY
-            task :default do
-              abort "make installing activesupport-2.3.2 fail"
-            end
-          RUBY
-        end
-      end
-
-      build_repo4 do
-        build_gem "a"
-      end
-
-      install_gemfile <<-G, :raise_on_error => false
-        source "#{file_uri_for(gem_repo4)}"
-        source "#{file_uri_for(gem_repo2)}" do
-          gem "rails"
-        end
-      G
-      expect(err).to end_with(<<-M.strip)
-An error occurred while installing activesupport (2.3.2), and Bundler cannot continue.
-Make sure that `gem install activesupport -v '2.3.2' --source '#{file_uri_for(gem_repo2)}/'` succeeds before bundling.
 
 In Gemfile:
   rails was resolved to 2.3.2, which depends on


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When `bundle install` fails to install a specific gem (most common case, extension compilation fails), it will suggest and alternative `gem install` command that might make it easier to figure out the culprit. However, it's hard to reproduce the exact environment where the installation failed as a fresh pristine command, and sometimes the suggested `gem install` command will succeed while `bundle install` will keep failing.

## What is your fix for the problem, implemented in this PR?

My fix is to completely remove the `gem install` suggestion and show the original error with a backtrace instead.

Fixes https://github.com/rubygems/rubygems/issues/3321.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
