### PR TITLE
Deprecate Gemfile without an explicit global source

### DIFF
--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -83,18 +83,11 @@ module Bundler
       end
 
       Bundler::CLI::Common.output_fund_metadata_summary
-    rescue GemNotFound, VersionConflict => e
+    rescue GemNotFound => e
       if options[:local] && Bundler.app_cache.exist?
         Bundler.ui.warn "Some gems seem to be missing from your #{Bundler.settings.app_cache_path} directory."
       end
 
-      unless Bundler.definition.has_rubygems_remotes?
-        Bundler.ui.warn <<-WARN, :wrap => true
-          Your Gemfile has no gem server sources. If you need gems that are \
-          not already on your machine, add a line like this to your Gemfile:
-          source 'https://rubygems.org'
-        WARN
-      end
       raise e
     rescue Gem::InvalidSpecificationException => e
       Bundler.ui.warn "You have one or more invalid gemspecs that need to be fixed."

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -279,10 +279,6 @@ module Bundler
       end
     end
 
-    def has_rubygems_remotes?
-      sources.rubygems_sources.any? {|s| s.remotes.any? }
-    end
-
     def spec_git_paths
       sources.git_sources.map {|s| File.realpath(s.path) if File.exist?(s.path) }.compact
     end

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -447,6 +447,13 @@ repo_name ||= user_name
     end
 
     def check_rubygems_source_safety
+      if @sources.implicit_global_source?
+        Bundler::SharedHelpers.major_deprecation 2, "This Gemfile does not include an explicit global source. " \
+          "Not using an explicit global source may result in a different lockfile being generated depending on " \
+          "the gems you have installed locally before bundler is run." \
+          "Instead, define a global source in your Gemfile like this: source \"https://rubygems.org\"."
+      end
+
       return unless @sources.aggregate_global_source?
 
       if Bundler.feature_flag.bundler_3_mode?

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -448,14 +448,20 @@ repo_name ||= user_name
 
     def check_rubygems_source_safety
       if @sources.implicit_global_source?
-        Bundler::SharedHelpers.major_deprecation 2, "This Gemfile does not include an explicit global source. " \
-          "Not using an explicit global source may result in a different lockfile being generated depending on " \
-          "the gems you have installed locally before bundler is run." \
-          "Instead, define a global source in your Gemfile like this: source \"https://rubygems.org\"."
+        implicit_global_source_warning
+      elsif @sources.aggregate_global_source?
+        multiple_global_source_warning
       end
+    end
 
-      return unless @sources.aggregate_global_source?
+    def implicit_global_source_warning
+      Bundler::SharedHelpers.major_deprecation 2, "This Gemfile does not include an explicit global source. " \
+        "Not using an explicit global source may result in a different lockfile being generated depending on " \
+        "the gems you have installed locally before bundler is run." \
+        "Instead, define a global source in your Gemfile like this: source \"https://rubygems.org\"."
+    end
 
+    def multiple_global_source_warning
       if Bundler.feature_flag.bundler_3_mode?
         msg = "This Gemfile contains multiple primary sources. " \
           "Each source after the first must include a block to indicate which gems " \

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -71,6 +71,10 @@ module Bundler
         @remotes.size > 1
       end
 
+      def no_remotes?
+        @remotes.size == 0
+      end
+
       def can_lock?(spec)
         return super unless multiple_remotes?
         include?(spec.source)

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -37,6 +37,10 @@ module Bundler
       global_rubygems_source.multiple_remotes?
     end
 
+    def implicit_global_source?
+      global_rubygems_source.no_remotes?
+    end
+
     def add_path_source(options = {})
       if options["gemspec"]
         add_source_to_list Source::Gemspec.new(options), path_sources

--- a/bundler/spec/bundler/cli_spec.rb
+++ b/bundler/spec/bundler/cli_spec.rb
@@ -129,18 +129,18 @@ RSpec.describe "bundle executable" do
 
   context "with --verbose" do
     it "prints the running command" do
-      gemfile ""
+      gemfile "source \"#{file_uri_for(gem_repo1)}\""
       bundle "info bundler", :verbose => true
       expect(out).to start_with("Running `bundle info bundler --verbose` with bundler #{Bundler::VERSION}")
     end
 
     it "doesn't print defaults" do
-      install_gemfile "", :verbose => true
+      install_gemfile "source \"#{file_uri_for(gem_repo1)}\"", :verbose => true
       expect(out).to start_with("Running `bundle install --verbose` with bundler #{Bundler::VERSION}")
     end
 
     it "doesn't print defaults" do
-      install_gemfile "", :verbose => true
+      install_gemfile "source \"#{file_uri_for(gem_repo1)}\"", :verbose => true
       expect(out).to start_with("Running `bundle install --verbose` with bundler #{Bundler::VERSION}")
     end
   end

--- a/bundler/spec/bundler/dsl_spec.rb
+++ b/bundler/spec/bundler/dsl_spec.rb
@@ -245,7 +245,7 @@ RSpec.describe Bundler::Dsl do
   describe "#check_primary_source_safety" do
     context "when a global source is not defined implicitly" do
       it "will raise a major deprecation warning" do
-        not_a_global_source = double("not-a-global-source", no_remotes?: true, multiple_remotes?: false)
+        not_a_global_source = double("not-a-global-source", :no_remotes? => true)
         allow(Bundler::Source::Rubygems).to receive(:new).and_return(not_a_global_source)
 
         warning = "This Gemfile does not include an explicit global source. " \

--- a/bundler/spec/bundler/dsl_spec.rb
+++ b/bundler/spec/bundler/dsl_spec.rb
@@ -241,4 +241,21 @@ RSpec.describe Bundler::Dsl do
       end
     end
   end
+
+  describe "#check_primary_source_safety" do
+    context "when a global source is not defined implicitly" do
+      it "will raise a major deprecation warning" do
+        not_a_global_source = double("not-a-global-source", no_remotes?: true, multiple_remotes?: false)
+        allow(Bundler::Source::Rubygems).to receive(:new).and_return(not_a_global_source)
+
+        warning = "This Gemfile does not include an explicit global source. " \
+          "Not using an explicit global source may result in a different lockfile being generated depending on " \
+          "the gems you have installed locally before bundler is run." \
+          "Instead, define a global source in your Gemfile like this: source \"https://rubygems.org\"."
+        expect(Bundler::SharedHelpers).to receive(:major_deprecation).with(2, warning)
+
+        subject.check_primary_source_safety
+      end
+    end
+  end
 end

--- a/bundler/spec/bundler/env_spec.rb
+++ b/bundler/spec/bundler/env_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Bundler::Env do
 
     context "when there is a Gemfile and a lockfile and print_gemfile is true" do
       before do
-        gemfile "gem 'rack', '1.0.0'"
+        gemfile "source \"#{file_uri_for(gem_repo1)}\"; gem 'rack', '1.0.0'"
 
         lockfile <<-L
           GEM
@@ -138,7 +138,7 @@ RSpec.describe Bundler::Env do
       end
 
       before do
-        gemfile("gemspec")
+        gemfile("source \"#{file_uri_for(gem_repo1)}\"; gemspec")
 
         File.open(bundled_app.join("foo.gemspec"), "wb") do |f|
           f.write(gemspec)

--- a/bundler/spec/bundler/plugin/index_spec.rb
+++ b/bundler/spec/bundler/plugin/index_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Bundler::Plugin::Index do
 
   before do
     allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
-    gemfile ""
+    gemfile "source \"#{file_uri_for(gem_repo1)}\""
     path = lib_path(plugin_name)
     index.register_plugin("new-plugin", path.to_s, [path.join("lib").to_s], commands, sources, hooks)
   end

--- a/bundler/spec/bundler/source/rubygems_spec.rb
+++ b/bundler/spec/bundler/source/rubygems_spec.rb
@@ -30,4 +30,18 @@ RSpec.describe Bundler::Source::Rubygems do
       end
     end
   end
+
+  describe "#no_remotes?" do
+    context "when no remote provided" do
+      it "returns a truthy value" do
+        expect(described_class.new("remotes" => []).no_remotes?).to be_truthy
+      end
+    end
+
+    context "when a remote provided" do
+      it "returns a falsey value" do
+        expect(described_class.new("remotes" => ["https://rubygems.org"]).no_remotes?).to be_falsey
+      end
+    end
+  end
 end

--- a/bundler/spec/bundler/source_list_spec.rb
+++ b/bundler/spec/bundler/source_list_spec.rb
@@ -441,4 +441,19 @@ RSpec.describe Bundler::SourceList do
       source_list.remote!
     end
   end
+
+  describe "implicit_global_source?" do
+    context "when a global rubygem source provided" do
+      it "returns a falsy value" do
+        source_list.add_global_rubygems_remote("https://rubygems.org")
+
+        expect(source_list.implicit_global_source?).to be_falsey
+      end
+    end
+    context "when no global rubygem source provided" do
+      it "returns a truthy value" do
+        expect(source_list.implicit_global_source?).to be_truthy
+      end
+    end
+  end
 end

--- a/bundler/spec/cache/gems_spec.rb
+++ b/bundler/spec/cache/gems_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe "bundle cache" do
   shared_examples_for "when there are only gemsources" do
     before :each do
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
       G
 
@@ -39,6 +40,7 @@ RSpec.describe "bundle cache" do
       end
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 
@@ -49,6 +51,7 @@ RSpec.describe "bundle cache" do
       system_gems "rack-1.0.0", :path => default_bundle_path
 
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 
@@ -64,6 +67,7 @@ RSpec.describe "bundle cache" do
       cache_gems "rack-1.0.0"
 
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 
@@ -100,7 +104,7 @@ RSpec.describe "bundle cache" do
 
     it "uses builtin gems when installing to system gems" do
       bundle "config set path.system true"
-      install_gemfile %(gem 'builtin_gem', '1.0.2')
+      install_gemfile %(source "#{file_uri_for(gem_repo1)}"; gem 'builtin_gem', '1.0.2')
       expect(the_bundle).to include_gems("builtin_gem 1.0.2")
     end
 
@@ -134,6 +138,7 @@ RSpec.describe "bundle cache" do
       bundle "config set path.system true"
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem 'builtin_gem', '1.0.2'
       G
 
@@ -302,6 +307,7 @@ RSpec.describe "bundle cache" do
         :path => bundled_app("vendor/cache")
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo-bundler"
       G
 

--- a/bundler/spec/cache/git_spec.rb
+++ b/bundler/spec/cache/git_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe "bundle cache with git" do
     ref = git.ref_for("master", 11)
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :git => '#{lib_path("foo-1.0")}'
     G
 
@@ -36,6 +37,7 @@ RSpec.describe "bundle cache with git" do
     ref = git.ref_for("master", 11)
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :git => '#{lib_path("foo-1.0")}'
     G
 
@@ -55,6 +57,7 @@ RSpec.describe "bundle cache with git" do
     build_git "foo"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :git => '#{lib_path("foo-1.0")}'
     G
 
@@ -72,6 +75,7 @@ RSpec.describe "bundle cache with git" do
     old_ref = git.ref_for("master", 11)
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :git => '#{lib_path("foo-1.0")}'
     G
 
@@ -102,6 +106,7 @@ RSpec.describe "bundle cache with git" do
     old_ref = git.ref_for("master", 11)
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :git => '#{lib_path("foo-1.0")}'
     G
 
@@ -130,6 +135,7 @@ RSpec.describe "bundle cache with git" do
     ref = git.ref_for("master", 11)
 
     gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :git => '#{lib_path("foo-invalid")}', :branch => :master
     G
 
@@ -160,6 +166,7 @@ RSpec.describe "bundle cache with git" do
     sys_exec "git commit -m \"submodulator\"", :dir => lib_path("has_submodule-1.0")
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       git "#{lib_path("has_submodule-1.0")}", :submodules => true do
         gem "has_submodule"
       end
@@ -183,6 +190,7 @@ RSpec.describe "bundle cache with git" do
     update_git("foo") {|s| s.write "foo.gemspec", spec_lines.join("\n") }
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :git => '#{lib_path("foo-1.0")}'
     G
     bundle "config set cache_all true"
@@ -197,6 +205,7 @@ RSpec.describe "bundle cache with git" do
     build_git "foo"
 
     gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :git => '#{lib_path("foo-1.0")}'
     G
     bundle "config set cache_all true"

--- a/bundler/spec/cache/path_spec.rb
+++ b/bundler/spec/cache/path_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "bundle cache with path" do
     build_lib "foo", :path => bundled_app("lib/foo")
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :path => '#{bundled_app("lib/foo")}'
     G
 
@@ -18,6 +19,7 @@ RSpec.describe "bundle cache with path" do
     build_lib "foo"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :path => '#{lib_path("foo-1.0")}'
     G
 
@@ -36,6 +38,7 @@ RSpec.describe "bundle cache with path" do
     build_lib libname, :path => libpath
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "#{libname}", :path => '#{libpath}'
     G
 
@@ -51,6 +54,7 @@ RSpec.describe "bundle cache with path" do
     build_lib "foo"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :path => '#{lib_path("foo-1.0")}'
     G
 
@@ -73,6 +77,7 @@ RSpec.describe "bundle cache with path" do
     build_lib "foo"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :path => '#{lib_path("foo-1.0")}'
     G
 
@@ -84,6 +89,7 @@ RSpec.describe "bundle cache with path" do
     build_lib "bar"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "bar", :path => '#{lib_path("bar-1.0")}'
     G
 
@@ -95,6 +101,7 @@ RSpec.describe "bundle cache with path" do
     build_lib "foo"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :path => '#{lib_path("foo-1.0")}'
     G
 
@@ -107,6 +114,7 @@ RSpec.describe "bundle cache with path" do
     build_lib "foo"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :path => '#{lib_path("foo-1.0")}'
     G
 
@@ -119,6 +127,7 @@ RSpec.describe "bundle cache with path" do
     build_lib "foo"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :path => '#{lib_path("foo-1.0")}'
     G
 
@@ -127,6 +136,7 @@ RSpec.describe "bundle cache with path" do
     build_lib "bar"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :path => '#{lib_path("foo-1.0")}'
       gem "bar", :path => '#{lib_path("bar-1.0")}'
     G
@@ -139,6 +149,7 @@ RSpec.describe "bundle cache with path" do
     build_lib "foo"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :path => '#{lib_path("foo-1.0")}'
     G
 
@@ -147,6 +158,7 @@ RSpec.describe "bundle cache with path" do
     build_lib "baz"
 
     gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :path => '#{lib_path("foo-1.0")}'
       gem "baz", :path => '#{lib_path("baz-1.0")}'
     G

--- a/bundler/spec/commands/binstubs_spec.rb
+++ b/bundler/spec/commands/binstubs_spec.rb
@@ -261,6 +261,7 @@ RSpec.describe "bundle binstubs <gem>" do
         s.executables = %w[foo]
       end
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :git => "#{lib_path("foo")}"
       G
 
@@ -276,6 +277,7 @@ RSpec.describe "bundle binstubs <gem>" do
         s.executables = %w[foo]
       end
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :path => "#{lib_path("foo")}"
       G
 

--- a/bundler/spec/commands/check_spec.rb
+++ b/bundler/spec/commands/check_spec.rb
@@ -319,6 +319,7 @@ RSpec.describe "bundle check" do
   describe "when using only scoped rubygems sources" do
     before do
       gemfile <<~G
+        source "#{file_uri_for(gem_repo2)}"
         source "#{file_uri_for(gem_repo1)}" do
           gem "rack"
         end
@@ -343,6 +344,7 @@ RSpec.describe "bundle check" do
       end
 
       gemfile <<~G
+        source "#{file_uri_for(gem_repo1)}"
         source "#{file_uri_for(gem_repo4)}" do
           gem "depends_on_rack"
         end
@@ -355,6 +357,7 @@ RSpec.describe "bundle check" do
       expect(out).to include("The Gemfile's dependencies are satisfied")
       expect(lockfile).to eq <<~L
         GEM
+          remote: #{file_uri_for(gem_repo1)}/
           specs:
 
         GEM

--- a/bundler/spec/commands/clean_spec.rb
+++ b/bundler/spec/commands/clean_spec.rb
@@ -261,6 +261,7 @@ RSpec.describe "bundle clean" do
     revision = revision_for(lib_path("rails"))
 
     gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "activesupport", :git => "#{lib_path("rails")}", :ref => '#{revision}'
     G
 
@@ -869,6 +870,7 @@ RSpec.describe "bundle clean" do
     expect(very_simple_binary_extensions_dir).to exist
 
     gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "very_simple_git_binary", :git => "#{lib_path("very_simple_git_binary-1.0")}", :ref => "#{revision}"
     G
 
@@ -878,6 +880,7 @@ RSpec.describe "bundle clean" do
     expect(very_simple_binary_extensions_dir).to exist
 
     gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
     G
 
     bundle "install"

--- a/bundler/spec/commands/config_spec.rb
+++ b/bundler/spec/commands/config_spec.rb
@@ -321,7 +321,7 @@ E
   end
 
   describe "quoting" do
-    before(:each) { gemfile "# no gems" }
+    before(:each) { gemfile "source \"#{file_uri_for(gem_repo1)}\"" }
     let(:long_string) do
       "--with-xml2-include=/usr/pkg/include/libxml2 --with-xml2-lib=/usr/pkg/lib " \
       "--with-xslt-dir=/usr/pkg"

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "bundle exec" do
 
   it "works with --gemfile flag" do
     create_file "CustomGemfile", <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack", "1.0.0"
     G
 
@@ -17,6 +18,7 @@ RSpec.describe "bundle exec" do
 
   it "activates the correct gem" do
     gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack", "0.9.1"
     G
 
@@ -26,6 +28,7 @@ RSpec.describe "bundle exec" do
 
   it "works and prints no warnings when HOME is not writable" do
     gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack", "0.9.1"
     G
 
@@ -36,6 +39,7 @@ RSpec.describe "bundle exec" do
 
   it "works when the bins are in ~/.bundle" do
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G
 
@@ -45,6 +49,7 @@ RSpec.describe "bundle exec" do
 
   it "works when running from a random directory" do
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G
 
@@ -54,37 +59,39 @@ RSpec.describe "bundle exec" do
   end
 
   it "works when exec'ing something else" do
-    install_gemfile 'gem "rack"'
+    install_gemfile "source \"#{file_uri_for(gem_repo1)}\"; gem \"rack\""
     bundle "exec echo exec"
     expect(out).to eq("exec")
   end
 
   it "works when exec'ing to ruby" do
-    install_gemfile 'gem "rack"'
+    install_gemfile "source \"#{file_uri_for(gem_repo1)}\"; gem \"rack\""
     bundle "exec ruby -e 'puts %{hi}'"
     expect(out).to eq("hi")
   end
 
   it "works when exec'ing to rubygems" do
-    install_gemfile 'gem "rack"'
+    install_gemfile "source \"#{file_uri_for(gem_repo1)}\"; gem \"rack\""
     bundle "exec #{gem_cmd} --version"
     expect(out).to eq(Gem::VERSION)
   end
 
   it "works when exec'ing to rubygems through sh -c" do
-    install_gemfile 'gem "rack"'
+    install_gemfile "source \"#{file_uri_for(gem_repo1)}\"; gem \"rack\""
     bundle "exec sh -c '#{gem_cmd} --version'"
     expect(out).to eq(Gem::VERSION)
   end
 
   it "works when exec'ing back to bundler with a lockfile that doesn't include the current platform" do
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack", "0.9.1"
     G
 
     # simulate lockfile generated with old version not including specific platform
     lockfile <<-L
       GEM
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
           rack (0.9.1)
 
@@ -110,20 +117,20 @@ RSpec.describe "bundle exec" do
       Process.setproctitle("1-2-3-4-5-6-7")
       puts `ps -ocommand= -p#{$$}`
     RUBY
-    create_file "Gemfile"
+    create_file "Gemfile", "source \"#{file_uri_for(gem_repo1)}\""
     create_file "a.rb", script_that_changes_its_own_title_and_checks_if_picked_up_by_ps_unix_utility
     bundle "exec ruby a.rb"
     expect(out).to eq("1-2-3-4-5-6-7")
   end
 
   it "accepts --verbose" do
-    install_gemfile 'gem "rack"'
+    install_gemfile "source \"#{file_uri_for(gem_repo1)}\"; gem \"rack\""
     bundle "exec --verbose echo foobar"
     expect(out).to eq("foobar")
   end
 
   it "passes --verbose to command if it is given after the command" do
-    install_gemfile 'gem "rack"'
+    install_gemfile "source \"#{file_uri_for(gem_repo1)}\"; gem \"rack\""
     bundle "exec echo --verbose"
     expect(out).to eq("--verbose")
   end
@@ -147,7 +154,7 @@ RSpec.describe "bundle exec" do
       end
     G
 
-    install_gemfile ""
+    install_gemfile "source \"#{file_uri_for(gem_repo1)}\""
     sys_exec "#{Gem.ruby} #{command.path}"
 
     expect(out).to be_empty
@@ -155,7 +162,7 @@ RSpec.describe "bundle exec" do
   end
 
   it "accepts --keep-file-descriptors" do
-    install_gemfile ""
+    install_gemfile "source \"#{file_uri_for(gem_repo1)}\""
     bundle "exec --keep-file-descriptors echo foobar"
 
     expect(err).to be_empty
@@ -164,7 +171,7 @@ RSpec.describe "bundle exec" do
   it "can run a command named --verbose" do
     skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
 
-    install_gemfile 'gem "rack"'
+    install_gemfile "source \"#{file_uri_for(gem_repo1)}\"; gem \"rack\""
     File.open(bundled_app("--verbose"), "w") do |f|
       f.puts "#!/bin/sh"
       f.puts "echo foobar"
@@ -210,7 +217,7 @@ RSpec.describe "bundle exec" do
       before do
         skip "irb isn't a default gem" if default_irb_version.empty?
 
-        install_gemfile ""
+        install_gemfile "source \"#{file_uri_for(gem_repo1)}\""
       end
 
       it "uses version provided by ruby" do
@@ -325,6 +332,7 @@ RSpec.describe "bundle exec" do
     skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G
 
@@ -343,6 +351,7 @@ RSpec.describe "bundle exec" do
     skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G
 
@@ -359,6 +368,7 @@ RSpec.describe "bundle exec" do
 
   it "errors nicely when the argument doesn't exist" do
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G
 
@@ -370,6 +380,7 @@ RSpec.describe "bundle exec" do
 
   it "errors nicely when the argument is not executable" do
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G
 
@@ -381,6 +392,7 @@ RSpec.describe "bundle exec" do
 
   it "errors nicely when no arguments are passed" do
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack"
     G
 
@@ -412,6 +424,7 @@ RSpec.describe "bundle exec" do
           skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
 
           install_gemfile <<-G
+            source "#{file_uri_for(gem_repo1)}"
             gem "rack"
           G
 
@@ -496,6 +509,7 @@ RSpec.describe "bundle exec" do
     describe "run from a random directory" do
       before(:each) do
         install_gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack"
         G
       end
@@ -519,6 +533,7 @@ RSpec.describe "bundle exec" do
         end
 
         install_gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
           gem "fizz", :path => "#{File.expand_path(home("fizz"))}"
         G
       end
@@ -543,6 +558,7 @@ RSpec.describe "bundle exec" do
         end
 
         install_gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
           gem "fizz_git", :git => "#{lib_path("fizz_git-1.0")}"
         G
       end
@@ -566,6 +582,7 @@ RSpec.describe "bundle exec" do
         end
 
         install_gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
           gem "fizz_no_gemspec", "1.0", :git => "#{lib_path("fizz_no_gemspec-1.0")}"
         G
       end
@@ -612,6 +629,7 @@ RSpec.describe "bundle exec" do
       end
 
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :path => "#{lib_path("foo-1.0")}"
       G
 
@@ -627,6 +645,8 @@ RSpec.describe "bundle exec" do
       skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
 
       gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
+
       module Monkey
         def bin_path(a,b,c)
           raise Gem::GemNotFoundException.new('Fail')
@@ -660,6 +680,7 @@ RSpec.describe "bundle exec" do
       bundled_app(path).chmod(0o755)
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
     end
@@ -806,6 +827,7 @@ RSpec.describe "bundle exec" do
     context "when Bundler.setup fails", :bundler => "< 3" do
       before do
         gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
           gem 'rack', '2'
         G
         ENV["BUNDLER_FORCE_TTY"] = "true"
@@ -814,7 +836,7 @@ RSpec.describe "bundle exec" do
       let(:exit_code) { Bundler::GemNotFound.new.status_code }
       let(:expected) { "" }
       let(:expected_err) { <<-EOS.strip }
-\e[31mCould not find gem 'rack (= 2)' in locally installed gems.
+\e[31mCould not find gem 'rack (= 2)' in rubygems repository #{file_uri_for(gem_repo1)}/ or installed locally.
 The source contains the following versions of 'rack': 0.9.1, 1.0.0\e[0m
 \e[33mRun `bundle install` to install missing gems.\e[0m
       EOS
@@ -832,6 +854,7 @@ The source contains the following versions of 'rack': 0.9.1, 1.0.0\e[0m
     context "when Bundler.setup fails", :bundler => "3" do
       before do
         gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
           gem 'rack', '2'
         G
         ENV["BUNDLER_FORCE_TTY"] = "true"
@@ -840,7 +863,7 @@ The source contains the following versions of 'rack': 0.9.1, 1.0.0\e[0m
       let(:exit_code) { Bundler::GemNotFound.new.status_code }
       let(:expected) { "" }
       let(:expected_err) { <<-EOS.strip }
-\e[31mCould not find gem 'rack (= 2)' in locally installed gems.
+\e[31mCould not find gem 'rack (= 2)' in rubygems repository #{file_uri_for(gem_repo1)}/ or installed locally.
 The source contains the following versions of 'rack': 1.0.0\e[0m
 \e[33mRun `bundle install` to install missing gems.\e[0m
       EOS
@@ -1020,7 +1043,7 @@ __FILE__: #{path.to_s.inspect}
       before do
         skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
 
-        install_gemfile ""
+        install_gemfile "source \"#{file_uri_for(gem_repo1)}\""
       end
 
       it "does not undo the monkeypatches" do
@@ -1079,7 +1102,7 @@ __FILE__: #{path.to_s.inspect}
         RUBY
 
         # A Gemfile needs to be in the root to trick bundler's root resolution
-        create_file(bundled_app("Gemfile"))
+        create_file(bundled_app("Gemfile"), "source \"#{file_uri_for(gem_repo1)}\"")
 
         bundle "install"
       end
@@ -1110,7 +1133,7 @@ __FILE__: #{path.to_s.inspect}
         skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
         skip "openssl isn't a default gem" if expected.empty?
 
-        install_gemfile "" # must happen before installing the broken system gem
+        install_gemfile "source \"#{file_uri_for(gem_repo1)}\"" # must happen before installing the broken system gem
 
         build_repo4 do
           build_gem "openssl", openssl_version do |s|
@@ -1151,6 +1174,7 @@ __FILE__: #{path.to_s.inspect}
         build_git "simple_git_binary", &:add_c_extension
         bundle "config set --local path .bundle"
         install_gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
           gem "simple_git_binary", :git => '#{lib_path("simple_git_binary-1.0")}'
         G
       end

--- a/bundler/spec/commands/info_spec.rb
+++ b/bundler/spec/commands/info_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe "bundle info" do
 
     it "prints out git info" do
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :git => "#{lib_path("foo-1.0")}"
       G
       expect(the_bundle).to include_gems "foo 1.0"
@@ -126,6 +127,7 @@ RSpec.describe "bundle info" do
       @revision = revision_for(lib_path("foo-1.0"))[0...6]
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :git => "#{lib_path("foo-1.0")}", :branch => "omg"
       G
       expect(the_bundle).to include_gems "foo 1.0.omg"
@@ -137,6 +139,7 @@ RSpec.describe "bundle info" do
     it "doesn't print the branch when tied to a ref" do
       sha = revision_for(lib_path("foo-1.0"))
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :git => "#{lib_path("foo-1.0")}", :ref => "#{sha}"
       G
 
@@ -147,6 +150,7 @@ RSpec.describe "bundle info" do
     it "handles when a version is a '-' prerelease" do
       @git = build_git("foo", "1.0.0-beta.1", :path => lib_path("foo"))
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", "1.0.0-beta.1", :git => "#{lib_path("foo")}"
       G
       expect(the_bundle).to include_gems "foo 1.0.0.pre.beta.1"

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -331,11 +331,13 @@ RSpec.describe "bundle install with gem sources" do
 
     it "gives a useful error if no sources are set" do
       install_gemfile <<-G, :raise_on_error => false
-        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 
-      expect(err).to include("Your Gemfile has no gem server sources")
+      expect(err).to include("This Gemfile does not include an explicit global source. " \
+        "Not using an explicit global source may result in a different lockfile being generated depending on " \
+        "the gems you have installed locally before bundler is run." \
+        "Instead, define a global source in your Gemfile like this: source \"https://rubygems.org\".")
     end
 
     it "creates a Gemfile.lock on a blank Gemfile" do

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -331,6 +331,7 @@ RSpec.describe "bundle install with gem sources" do
 
     it "gives a useful error if no sources are set" do
       install_gemfile <<-G, :raise_on_error => false
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
 
@@ -339,6 +340,7 @@ RSpec.describe "bundle install with gem sources" do
 
     it "creates a Gemfile.lock on a blank Gemfile" do
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
       G
 
       expect(File.exist?(bundled_app_lock)).to eq(true)
@@ -482,6 +484,7 @@ RSpec.describe "bundle install with gem sources" do
         install_gemfile <<-G, :raise_on_error => false
           ::RUBY_VERSION = '2.0.1'
           ruby '~> 2.2'
+          source "#{file_uri_for(gem_repo1)}"
         G
         expect(err).to include("Your Ruby version is 2.0.1, but your Gemfile specified ~> 2.2")
       end
@@ -493,12 +496,14 @@ RSpec.describe "bundle install with gem sources" do
           ::RUBY_VERSION = '2.1.3'
           ::RUBY_PATCHLEVEL = 100
           ruby '~> 2.1.0'
+          source "#{file_uri_for(gem_repo1)}"
         G
       end
 
       it "writes current Ruby version to Gemfile.lock" do
         lockfile_should_be <<-L
          GEM
+           remote: #{file_uri_for(gem_repo1)}/
            specs:
 
          PLATFORMS
@@ -519,10 +524,12 @@ RSpec.describe "bundle install with gem sources" do
           ::RUBY_VERSION = '2.2.3'
           ::RUBY_PATCHLEVEL = 100
           ruby '~> 2.2.0'
+          source "#{file_uri_for(gem_repo1)}"
         G
 
         lockfile_should_be <<-L
          GEM
+           remote: #{file_uri_for(gem_repo1)}/
            specs:
 
          PLATFORMS
@@ -540,6 +547,7 @@ RSpec.describe "bundle install with gem sources" do
 
       it "does not crash when unlocking" do
         gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
           ruby '>= 2.1.0'
         G
 
@@ -558,6 +566,7 @@ RSpec.describe "bundle install with gem sources" do
 
       build_lib "foo"
       gemfile = <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem 'foo', :path => "#{lib_path("foo-1.0")}"
       G
       File.open("#{root_dir}/Gemfile", "w") do |file|
@@ -574,6 +583,7 @@ RSpec.describe "bundle install with gem sources" do
 
       build_lib "foo", :path => root_dir
       gemfile = <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gemspec
       G
       File.open("#{root_dir}/Gemfile", "w") do |file|

--- a/bundler/spec/commands/open_spec.rb
+++ b/bundler/spec/commands/open_spec.rb
@@ -105,6 +105,7 @@ RSpec.describe "bundle open" do
       skip "No default gems available on this test run" if default_gems.empty?
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "json"
       G
     end

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "bundle update" do
     end
 
     it "doesn't delete the Gemfile.lock file if something goes wrong" do
-      install_gemfile ""
+      install_gemfile "source \"#{file_uri_for(gem_repo1)}\""
 
       gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
@@ -96,19 +96,19 @@ RSpec.describe "bundle update" do
     before { bundle "config set update_requires_all_flag true" }
 
     it "errors when passed nothing" do
-      install_gemfile ""
+      install_gemfile "source \"#{file_uri_for(gem_repo1)}\""
       bundle :update, :raise_on_error => false
       expect(err).to eq("To update everything, pass the `--all` flag.")
     end
 
     it "errors when passed --all and another option" do
-      install_gemfile ""
+      install_gemfile "source \"#{file_uri_for(gem_repo1)}\""
       bundle "update --all foo", :raise_on_error => false
       expect(err).to eq("Cannot specify --all along with specific options.")
     end
 
     it "updates everything when passed --all" do
-      install_gemfile ""
+      install_gemfile "source \"#{file_uri_for(gem_repo1)}\""
       bundle "update --all"
       expect(out).to include("Bundle updated!")
     end
@@ -753,6 +753,7 @@ RSpec.describe "bundle update in more complicated situations" do
     build_git "foo"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :git => '#{lib_path("foo-1.0")}'
     G
 
@@ -769,6 +770,7 @@ RSpec.describe "bundle update in more complicated situations" do
     build_git "rack"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo2)}"
       gem "rack", :git => '#{lib_path("rack-1.0")}'
     G
 
@@ -922,6 +924,7 @@ RSpec.describe "bundle update --ruby" do
         ::RUBY_VERSION = '2.1.3'
         ::RUBY_PATCHLEVEL = 100
         ruby '~> 2.1.0'
+        source "#{file_uri_for(gem_repo1)}"
     G
   end
 
@@ -930,6 +933,7 @@ RSpec.describe "bundle update --ruby" do
       gemfile <<-G
           ::RUBY_VERSION = '2.1.4'
           ::RUBY_PATCHLEVEL = 222
+          source "#{file_uri_for(gem_repo1)}"
       G
     end
     it "removes the Ruby from the Gemfile.lock" do
@@ -937,6 +941,7 @@ RSpec.describe "bundle update --ruby" do
 
       lockfile_should_be <<-L
        GEM
+         remote: #{file_uri_for(gem_repo1)}/
          specs:
 
        PLATFORMS
@@ -956,6 +961,7 @@ RSpec.describe "bundle update --ruby" do
           ::RUBY_VERSION = '2.1.4'
           ::RUBY_PATCHLEVEL = 222
           ruby '~> 2.1.0'
+          source "#{file_uri_for(gem_repo1)}"
       G
     end
     it "updates the Gemfile.lock with the latest version" do
@@ -963,6 +969,7 @@ RSpec.describe "bundle update --ruby" do
 
       lockfile_should_be <<-L
        GEM
+         remote: #{file_uri_for(gem_repo1)}/
          specs:
 
        PLATFORMS
@@ -985,6 +992,7 @@ RSpec.describe "bundle update --ruby" do
           ::RUBY_VERSION = '2.2.2'
           ::RUBY_PATCHLEVEL = 505
           ruby '~> 2.1.0'
+          source "#{file_uri_for(gem_repo1)}"
       G
     end
     it "shows a helpful error message" do
@@ -1000,6 +1008,7 @@ RSpec.describe "bundle update --ruby" do
           ::RUBY_VERSION = '1.8.3'
           ::RUBY_PATCHLEVEL = 55
           ruby '~> 1.8.0'
+          source "#{file_uri_for(gem_repo1)}"
       G
     end
     it "updates the Gemfile.lock with the latest version" do
@@ -1007,6 +1016,7 @@ RSpec.describe "bundle update --ruby" do
 
       lockfile_should_be <<-L
        GEM
+         remote: #{file_uri_for(gem_repo1)}/
          specs:
 
        PLATFORMS
@@ -1248,7 +1258,7 @@ RSpec.describe "bundle update conservative" do
 
   context "error handling" do
     before do
-      gemfile ""
+      gemfile "source \"#{file_uri_for(gem_repo1)}\""
     end
 
     it "raises if too many flags are provided" do

--- a/bundler/spec/install/allow_offline_install_spec.rb
+++ b/bundler/spec/install/allow_offline_install_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe "bundle install with :allow_offline_install" do
       git = build_git "a", "1.0.0", :path => lib_path("a")
       update_git("a", :path => git.path, :branch => "new_branch")
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "a", :git => #{git.path.to_s.dump}
       G
 
@@ -84,6 +85,7 @@ RSpec.describe "bundle install with :allow_offline_install" do
 
       break_git_remote_ops! do
         install_gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
           gem "a", :git => #{git.path.to_s.dump}, :branch => "new_branch"
         G
       end

--- a/bundler/spec/install/deploy_spec.rb
+++ b/bundler/spec/install/deploy_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe "install in deployment or frozen mode" do
   it "works if you exclude a group with a git gem" do
     build_git "foo"
     gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       group :test do
         gem "foo", :git => "#{lib_path("foo-1.0")}"
       end
@@ -76,6 +77,7 @@ RSpec.describe "install in deployment or frozen mode" do
     build_lib "foo", :path => lib_path("nested/foo")
     build_lib "bar", :path => lib_path("nested/bar")
     gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", "1.0", :path => "#{lib_path("nested")}"
       gem "bar", :path => "#{lib_path("nested")}"
     G
@@ -88,6 +90,7 @@ RSpec.describe "install in deployment or frozen mode" do
   it "works when path gems are specified twice" do
     build_lib "foo", :path => lib_path("nested/foo")
     gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :path => "#{lib_path("nested/foo")}"
       gem "foo", :path => "#{lib_path("nested/foo")}"
     G
@@ -110,6 +113,7 @@ RSpec.describe "install in deployment or frozen mode" do
 
   it "works with sources given by a block" do
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       source "#{file_uri_for(gem_repo1)}" do
         gem "rack"
       end
@@ -431,6 +435,7 @@ You have deleted from the Gemfile:
     it "works fine after bundle package and bundle install --local" do
       build_lib "foo", :path => lib_path("foo")
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :path => "#{lib_path("foo")}"
       G
 

--- a/bundler/spec/install/gemfile/eval_gemfile_spec.rb
+++ b/bundler/spec/install/gemfile/eval_gemfile_spec.rb
@@ -11,12 +11,14 @@ RSpec.describe "bundle install with gemfile that uses eval_gemfile" do
   context "eval-ed Gemfile points to an internal gemspec" do
     before do
       create_file "Gemfile-other", <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gemspec :path => 'gems/gunks'
       G
     end
 
     it "installs the gemspec specified gem" do
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         eval_gemfile 'Gemfile-other'
       G
       expect(out).to include("Resolving dependencies")
@@ -35,6 +37,8 @@ RSpec.describe "bundle install with gemfile that uses eval_gemfile" do
       end
 
       create_file bundled_app("gems/Gemfile"), <<-G
+        source "#{file_uri_for(gem_repo2)}"
+
         gemspec :path => "\#{__dir__}/gunks"
 
         source "#{file_uri_for(gem_repo2)}" do
@@ -62,10 +66,12 @@ RSpec.describe "bundle install with gemfile that uses eval_gemfile" do
     before do
       build_lib("a", :path => bundled_app("gems/a"))
       create_file bundled_app("nested/Gemfile-nested"), <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "a", :path => "../gems/a"
       G
 
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         eval_gemfile "nested/Gemfile-nested"
       G
     end
@@ -89,6 +95,7 @@ RSpec.describe "bundle install with gemfile that uses eval_gemfile" do
 
     it "installs the gemspec specified gem" do
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         eval_gemfile 'other/Gemfile-other'
         gemspec :path => 'gems/gunks'
       G

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -210,6 +210,7 @@ RSpec.describe "bundle install from an existing gemspec" do
     end
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gemspec
     G
 
@@ -263,6 +264,7 @@ RSpec.describe "bundle install from an existing gemspec" do
     build_lib "omg", "2.0", :path => lib_path("omg")
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gemspec :path => "#{lib_path("omg")}"
     G
 

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe "bundle install with git sources" do
       update_git "foo"
 
       install_gemfile bundled_app2("Gemfile"), <<-G, :dir => bundled_app2
+        source "#{file_uri_for(gem_repo1)}"
         git "#{lib_path("foo-1.0")}" do
           gem 'foo'
         end
@@ -84,6 +85,7 @@ RSpec.describe "bundle install with git sources" do
       build_git "foo"
 
       install_gemfile <<-G, :raise_on_error => false
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", "1.1", :git => "#{lib_path("foo-1.0")}"
       G
 
@@ -98,6 +100,7 @@ RSpec.describe "bundle install with git sources" do
       end
 
       install_gemfile <<-G, :raise_on_error => false
+        source "#{file_uri_for(gem_repo1)}"
         platforms :jruby do
           gem "only_java", "1.2", :git => "#{lib_path("only_java-1.0-java")}"
         end
@@ -119,6 +122,7 @@ RSpec.describe "bundle install with git sources" do
       end
 
       install_gemfile <<-G, :raise_on_error => false
+        source "#{file_uri_for(gem_repo1)}"
         platforms :jruby do
           gem "only_java", "1.2", :git => "#{lib_path("only_java-1.1-java")}"
         end
@@ -187,6 +191,7 @@ RSpec.describe "bundle install with git sources" do
 
     it "works" do
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         git "#{lib_path("foo-1.0")}", :ref => "#{@revision}" do
           gem "foo"
         end
@@ -202,6 +207,7 @@ RSpec.describe "bundle install with git sources" do
 
     it "works when the revision is a symbol" do
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         git "#{lib_path("foo-1.0")}", :ref => #{@revision.to_sym.inspect} do
           gem "foo"
         end
@@ -230,6 +236,7 @@ RSpec.describe "bundle install with git sources" do
       end
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         git "#{lib_path("foo-1.0")}", :ref => "refs/bundler/1" do
           gem "foo"
         end
@@ -246,6 +253,7 @@ RSpec.describe "bundle install with git sources" do
 
     it "works when the revision is a non-head ref and it was previously downloaded" do
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         git "#{lib_path("foo-1.0")}" do
           gem "foo"
         end
@@ -264,6 +272,7 @@ RSpec.describe "bundle install with git sources" do
       end
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         git "#{lib_path("foo-1.0")}", :ref => "refs/bundler/1" do
           gem "foo"
         end
@@ -284,6 +293,7 @@ RSpec.describe "bundle install with git sources" do
       bundle "config set global_gem_cache true"
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         git "#{lib_path("foo-1.0")}" do
           gem "foo"
         end
@@ -306,6 +316,7 @@ RSpec.describe "bundle install with git sources" do
       update_git("foo", :path => repo, :branch => branch)
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         git "#{repo}", :branch => #{branch.dump} do
           gem "foo"
         end
@@ -322,6 +333,7 @@ RSpec.describe "bundle install with git sources" do
         update_git("foo", :path => repo, :branch => branch)
 
         install_gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
           git "#{repo}", :branch => #{branch.dump} do
             gem "foo"
           end
@@ -339,6 +351,7 @@ RSpec.describe "bundle install with git sources" do
         update_git("foo", :path => repo, :branch => branch)
 
         install_gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
           git "#{repo}", :branch => #{branch.dump} do
             gem "foo"
           end
@@ -357,6 +370,7 @@ RSpec.describe "bundle install with git sources" do
       update_git("foo", :path => repo, :tag => tag)
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         git "#{repo}", :tag => #{tag.dump} do
           gem "foo"
         end
@@ -373,6 +387,7 @@ RSpec.describe "bundle install with git sources" do
         update_git("foo", :path => repo, :tag => tag)
 
         install_gemfile <<-G
+         source "#{file_uri_for(gem_repo1)}"
           git "#{repo}", :tag => #{tag.dump} do
             gem "foo"
           end
@@ -390,6 +405,7 @@ RSpec.describe "bundle install with git sources" do
         update_git("foo", :path => repo, :tag => tag)
 
         install_gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
           git "#{repo}", :tag => #{tag.dump} do
             gem "foo"
           end
@@ -705,6 +721,7 @@ RSpec.describe "bundle install with git sources" do
       build_lib "hi2u", :path => lib_path("hi2u")
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         path "#{lib_path("hi2u")}" do
           gem "omg"
           gem "hi2u"
@@ -721,6 +738,7 @@ RSpec.describe "bundle install with git sources" do
     update_git "foo"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :git => "#{lib_path("foo-1.0")}", :ref => "#{@revision}"
     G
 
@@ -785,6 +803,7 @@ RSpec.describe "bundle install with git sources" do
     build_git "foo", "1.0"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", "1.0", :git => "#{lib_path("foo-1.0")}"
     G
 
@@ -806,6 +825,7 @@ RSpec.describe "bundle install with git sources" do
 
   it "catches git errors and spits out useful output" do
     gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", "1.0", :git => "omgomg"
     G
 
@@ -820,6 +840,7 @@ RSpec.describe "bundle install with git sources" do
     build_git "foo", :path => lib_path("foo space-1.0")
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :git => "#{lib_path("foo space-1.0")}"
     G
 
@@ -830,6 +851,7 @@ RSpec.describe "bundle install with git sources" do
     build_git "forced", "1.0"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       git "#{lib_path("forced-1.0")}" do
         gem 'forced'
       end
@@ -858,6 +880,7 @@ RSpec.describe "bundle install with git sources" do
     sys_exec "git commit -m \"submodulator\"", :dir => lib_path("has_submodule-1.0")
 
     install_gemfile <<-G, :raise_on_error => false
+      source "#{file_uri_for(gem_repo1)}"
       git "#{lib_path("has_submodule-1.0")}" do
         gem "has_submodule"
       end
@@ -876,6 +899,7 @@ RSpec.describe "bundle install with git sources" do
     sys_exec "git commit -m \"submodulator\"", :dir => lib_path("has_submodule-1.0")
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       git "#{lib_path("has_submodule-1.0")}", :submodules => true do
         gem "has_submodule"
       end
@@ -892,6 +916,7 @@ RSpec.describe "bundle install with git sources" do
     sys_exec "git commit -m \"submodulator\"", :dir => lib_path("has_submodule-1.0")
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       git "#{lib_path("has_submodule-1.0")}" do
         gem "has_submodule"
       end
@@ -906,6 +931,7 @@ RSpec.describe "bundle install with git sources" do
     git = build_git "foo"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       git "#{lib_path("foo-1.0")}" do
         gem "foo"
       end
@@ -915,6 +941,7 @@ RSpec.describe "bundle install with git sources" do
     update_git "foo"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       git "#{lib_path("foo-1.0")}", :ref => "#{git.ref_for("HEAD^")}" do
         gem "foo"
       end
@@ -932,6 +959,7 @@ RSpec.describe "bundle install with git sources" do
     build_git "foo"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :git => "#{lib_path("foo-1.0")}"
     G
 
@@ -945,6 +973,7 @@ RSpec.describe "bundle install with git sources" do
     build_git "foo"
 
     gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :git => "#{lib_path("foo-1.0")}"
     G
 
@@ -959,6 +988,7 @@ RSpec.describe "bundle install with git sources" do
     FileUtils.touch(default_bundle_path("bundler"))
 
     install_gemfile <<-G, :raise_on_error => false
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :git => "#{lib_path("foo-1.0")}"
     G
 
@@ -976,6 +1006,7 @@ RSpec.describe "bundle install with git sources" do
     build_git "bar", :path => lib_path("nested")
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :git => "#{lib_path("nested")}"
       gem "bar", :git => "#{lib_path("nested")}"
     G
@@ -1033,6 +1064,7 @@ RSpec.describe "bundle install with git sources" do
       build_git "valim"
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "valim", :git => "#{file_uri_for(lib_path("valim-1.0"))}"
       G
 
@@ -1058,11 +1090,13 @@ RSpec.describe "bundle install with git sources" do
       revision = revision_for(lib_path("foo-1.0"))
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :git => "#{file_uri_for(lib_path("foo-1.0"))}", :ref => "#{revision}"
       G
       expect(out).to_not match(/Revision.*does not exist/)
 
       install_gemfile <<-G, :raise_on_error => false
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :git => "#{file_uri_for(lib_path("foo-1.0"))}", :ref => "deadbeef"
       G
       expect(err).to include("Revision deadbeef does not exist in the repository")
@@ -1089,6 +1123,7 @@ RSpec.describe "bundle install with git sources" do
     it "runs pre-install hooks" do
       build_git "foo"
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :git => "#{lib_path("foo-1.0")}"
       G
 
@@ -1108,6 +1143,7 @@ RSpec.describe "bundle install with git sources" do
     it "runs post-install hooks" do
       build_git "foo"
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :git => "#{lib_path("foo-1.0")}"
       G
 
@@ -1127,6 +1163,7 @@ RSpec.describe "bundle install with git sources" do
     it "complains if the install hook fails" do
       build_git "foo"
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :git => "#{lib_path("foo-1.0")}"
       G
 
@@ -1403,6 +1440,7 @@ In Gemfile:
       build_git "foo"
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         git "#{lib_path("foo-1.0")}" do
           gem 'foo'
         end
@@ -1419,6 +1457,7 @@ In Gemfile:
       build_git "foo"
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         git "#{lib_path("foo-1.0")}" do
           gem 'foo'
         end
@@ -1448,6 +1487,7 @@ In Gemfile:
         build_git "foo", "1.0", :path => lib_path("foo")
 
         gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
           gem "foo", :git => "#{lib_path("foo")}", :branch => "master"
         G
 
@@ -1463,6 +1503,7 @@ In Gemfile:
 
       it "does not display the password" do
         install_gemfile <<-G, :raise_on_error => false
+          source "#{file_uri_for(gem_repo1)}"
           git "https://#{credentials}@github.com/company/private-repo" do
             gem "foo"
           end
@@ -1478,6 +1519,7 @@ In Gemfile:
 
       it "displays the oauth scheme but not the oauth token" do
         install_gemfile <<-G, :raise_on_error => false
+          source "#{file_uri_for(gem_repo1)}"
           git "https://#{credentials}:x-oauth-basic@github.com/company/private-repo" do
             gem "foo"
           end

--- a/bundler/spec/install/gemfile/path_spec.rb
+++ b/bundler/spec/install/gemfile/path_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "bundle install with explicit source paths" do
     build_lib "foo"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       path "#{lib_path("foo-1.0")}" do
         gem 'foo'
       end
@@ -28,6 +29,7 @@ RSpec.describe "bundle install with explicit source paths" do
     build_lib "foo"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem 'foo', :path => "#{lib_path("foo-1.0")}"
     G
 
@@ -40,6 +42,7 @@ RSpec.describe "bundle install with explicit source paths" do
     relative_path = lib_path("foo-1.0").relative_path_from(bundled_app)
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem 'foo', :path => "#{relative_path}"
     G
 
@@ -52,6 +55,7 @@ RSpec.describe "bundle install with explicit source paths" do
     relative_path = lib_path("foo-1.0").relative_path_from(Pathname.new("~").expand_path)
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem 'foo', :path => "~/#{relative_path}"
     G
 
@@ -66,6 +70,7 @@ RSpec.describe "bundle install with explicit source paths" do
     relative_path = lib_path("foo-1.0").relative_path_from(Pathname.new("/home/#{username}").expand_path)
 
     install_gemfile <<-G, :raise_on_error => false
+      source "#{file_uri_for(gem_repo1)}"
       gem 'foo', :path => "~#{username}/#{relative_path}"
     G
     expect(err).to match("There was an error while trying to use the path `~#{username}/#{relative_path}`.")
@@ -76,6 +81,7 @@ RSpec.describe "bundle install with explicit source paths" do
     build_lib "foo", :path => bundled_app("foo-1.0")
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem 'foo', :path => "./foo-1.0"
     G
 
@@ -87,6 +93,7 @@ RSpec.describe "bundle install with explicit source paths" do
     build_lib "aaa", :path => lib_path("demo/aaa")
 
     gemfile = <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gemspec
       gem "aaa", :path => "./aaa"
     G
@@ -105,6 +112,7 @@ RSpec.describe "bundle install with explicit source paths" do
           aaa (1.0)
 
       GEM
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
 
       PLATFORMS
@@ -128,6 +136,7 @@ RSpec.describe "bundle install with explicit source paths" do
     build_lib "foo", :path => bundled_app("foo-1.0")
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem 'foo', :path => File.expand_path("../foo-1.0", __FILE__)
     G
 
@@ -167,6 +176,7 @@ RSpec.describe "bundle install with explicit source paths" do
     build_lib "foo", "1.0.0", :path => lib_path("omg/foo")
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "omg", :path => "#{lib_path("omg")}"
     G
 
@@ -177,6 +187,7 @@ RSpec.describe "bundle install with explicit source paths" do
     build_lib "omg", "2.0", :path => lib_path("omg")
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "omg", :path => "#{lib_path("omg")}"
     G
 
@@ -200,6 +211,7 @@ RSpec.describe "bundle install with explicit source paths" do
     end
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "premailer", :path => "#{lib_path("premailer")}"
     G
 
@@ -221,6 +233,7 @@ RSpec.describe "bundle install with explicit source paths" do
     end
 
     install_gemfile <<-G, :raise_on_error => false
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :path => "#{lib_path("foo-1.0")}"
     G
 
@@ -304,6 +317,7 @@ RSpec.describe "bundle install with explicit source paths" do
     end
 
     install_gemfile <<-G, :raise_on_error => false
+      source "#{file_uri_for(gem_repo1)}"
       gemspec :path => "#{lib_path("foo")}"
     G
 
@@ -317,6 +331,7 @@ RSpec.describe "bundle install with explicit source paths" do
     end
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gemspec :path => "#{lib_path("foo")}", :name => "foo"
     G
 
@@ -329,6 +344,7 @@ RSpec.describe "bundle install with explicit source paths" do
     end
 
     install_gemfile <<-G, :verbose => true
+      source "#{file_uri_for(gem_repo1)}"
       path "#{lib_path("foo-1.0")}" do
         gem 'foo'
       end
@@ -346,6 +362,7 @@ RSpec.describe "bundle install with explicit source paths" do
     lib_path("foo-1.0").join("bin/performance").mkpath
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem 'foo', '1.0', :path => "#{lib_path("foo-1.0")}"
     G
     expect(err).to be_empty
@@ -355,6 +372,7 @@ RSpec.describe "bundle install with explicit source paths" do
     build_lib "foo"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem 'foo', :path => "#{lib_path("foo-1.0")}"
     G
 
@@ -367,6 +385,7 @@ RSpec.describe "bundle install with explicit source paths" do
       build_lib "hi2u"
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         path "#{lib_path}" do
           gem "omg"
           gem "hi2u"
@@ -385,6 +404,7 @@ RSpec.describe "bundle install with explicit source paths" do
     end
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :path => "#{lib_path("foo")}"
       gem "omg", :path => "#{lib_path("omg")}"
     G
@@ -396,6 +416,7 @@ RSpec.describe "bundle install with explicit source paths" do
     build_lib "foo", :gemspec => false
 
     gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", "1.0", :path => "#{lib_path("foo-1.0")}"
     G
 
@@ -411,12 +432,13 @@ RSpec.describe "bundle install with explicit source paths" do
         specs:
 
       GEM
-        remote: http://rubygems.org
+        remote: http://rubygems.org/
     L
 
     FileUtils.mkdir_p(bundled_app("vendor/bar"))
 
     install_gemfile <<-G
+      source "http://rubygems.org"
       gem "bar", "1.0.0", path: "vendor/bar", require: "bar/nyard"
     G
   end
@@ -461,6 +483,7 @@ RSpec.describe "bundle install with explicit source paths" do
     end
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :path => "#{lib_path("foo-1.0")}"
     G
 
@@ -476,6 +499,7 @@ RSpec.describe "bundle install with explicit source paths" do
       build_lib "bar", "1.0", :path => lib_path("foo/bar")
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :path => "#{lib_path("foo")}"
       G
     end
@@ -720,6 +744,7 @@ RSpec.describe "bundle install with explicit source paths" do
     it "runs pre-install hooks" do
       build_git "foo"
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :git => "#{lib_path("foo-1.0")}"
       G
 
@@ -739,6 +764,7 @@ RSpec.describe "bundle install with explicit source paths" do
     it "runs post-install hooks" do
       build_git "foo"
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :git => "#{lib_path("foo-1.0")}"
       G
 
@@ -758,6 +784,7 @@ RSpec.describe "bundle install with explicit source paths" do
     it "complains if the install hook fails" do
       build_git "foo"
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :git => "#{lib_path("foo-1.0")}"
       G
 
@@ -788,6 +815,7 @@ RSpec.describe "bundle install with explicit source paths" do
       end
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :path => "#{lib_path("foo-1.0")}"
         gem "bar", :path => "#{lib_path("bar-1.0")}"
       G

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -400,6 +400,7 @@ RSpec.describe "bundle install with platform conditionals" do
     build_git "foo"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       platform :#{not_local_tag} do
         gem "foo", :git => "#{lib_path("foo-1.0")}"
       end

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -1074,6 +1074,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
         build_lib "foo"
 
         gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
           gem "rack", :source => "https://gem.repo1"
           gem "foo", :path => "#{lib_path("foo-1.0")}"
         G
@@ -1309,6 +1310,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
       end
 
       install_gemfile <<-G, :artifice => "compact_index", :raise_on_error => false
+        source "#{file_uri_for(gem_repo1)}"
+
         source "https://gem.repo4" do
           gem "depends_on_rack"
         end
@@ -1338,6 +1341,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
       end
 
       install_gemfile <<-G, :artifice => "compact_index", :raise_on_error => false
+        source "#{file_uri_for(gem_repo1)}"
         source "https://gem.repo4" do
           gem "depends_on_rack"
         end

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -173,6 +173,7 @@ RSpec.describe "bundle install with specific platforms" do
       git = build_git "pg_array_parser", "1.0"
 
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "pg_array_parser", :git => "#{lib_path("pg_array_parser-1.0")}"
       G
 

--- a/bundler/spec/install/gemfile_spec.rb
+++ b/bundler/spec/install/gemfile_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe "bundle install" do
   context "with duplicated gems" do
     it "will display a warning" do
       install_gemfile <<-G, :raise_on_error => false
+        source "#{file_uri_for(gem_repo1)}"
+
         gem 'rails', '~> 4.0.0'
         gem 'rails', '~> 4.0.0'
       G
@@ -54,6 +56,8 @@ RSpec.describe "bundle install" do
   context "with deprecated features" do
     it "reports that lib is an invalid option" do
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+
         gem "rack", :lib => "rack"
       G
 
@@ -86,6 +90,8 @@ RSpec.describe "bundle install" do
   context "with a Gemfile containing non-US-ASCII characters" do
     it "reads the Gemfile with the UTF-8 encoding by default" do
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+
         str = "Il était une fois ..."
         puts "The source encoding is: " + str.encoding.name
       G
@@ -99,6 +105,8 @@ RSpec.describe "bundle install" do
       # NOTE: This works thanks to #eval interpreting the magic encoding comment
       install_gemfile <<-G
         # encoding: iso-8859-1
+        source "#{file_uri_for(gem_repo1)}"
+
         str = "Il #{"\xE9".dup.force_encoding("binary")}tait une fois ..."
         puts "The source encoding is: " + str.encoding.name
       G

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -930,6 +930,7 @@ Either installing with `--full-index` or running `bundle update rails` should fi
 
   it "does not duplicate specs in the lockfile when updating and a dependency is not installed" do
     install_gemfile <<-G, :artifice => "compact_index"
+      source "#{file_uri_for(gem_repo1)}"
       source "#{source_uri}" do
         gem "rails"
         gem "activemerchant"

--- a/bundler/spec/install/gems/native_extensions_spec.rb
+++ b/bundler/spec/install/gems/native_extensions_spec.rb
@@ -78,6 +78,7 @@ RSpec.describe "installing a gem with native extensions", :ruby_repo do
     bundle "config set build.c_extension --with-c_extension=hello"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "c_extension", :git => #{lib_path("c_extension-1.0").to_s.dump}
     G
 
@@ -126,11 +127,13 @@ RSpec.describe "installing a gem with native extensions", :ruby_repo do
 
     # 1st time, require only one gem -- only one of the extensions gets built.
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "c_extension_one", :git => #{lib_path("gems").to_s.dump}
     G
 
     # 2nd time, require both gems -- we need both extensions to be built now.
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "c_extension_one", :git => #{lib_path("gems").to_s.dump}
       gem "c_extension_two", :git => #{lib_path("gems").to_s.dump}
     G
@@ -171,6 +174,7 @@ RSpec.describe "installing a gem with native extensions", :ruby_repo do
     bundle "config set build.c_extension --with-c_extension=hello --with-c_extension_bundle-dir=hola"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "c_extension", :git => #{lib_path("c_extension-1.0").to_s.dump}
     G
 

--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -146,6 +146,7 @@ RSpec.shared_examples "bundle install --standalone" do
       end
       bundle "config set --local path #{bundled_app("bundle")}"
       install_gemfile <<-G, :standalone => true, :dir => cwd, :raise_on_error => false
+        source "#{file_uri_for(gem_repo1)}"
         gem "bar", :git => "#{lib_path("bar-1.0")}"
       G
     end

--- a/bundler/spec/install/gemspecs_spec.rb
+++ b/bundler/spec/install/gemspecs_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe "bundle install" do
       build_lib "yaml_spec", :gemspec => :yaml
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem 'yaml_spec', :path => "#{lib_path("yaml_spec-1.0")}"
       G
       expect(err).to be_empty
@@ -57,6 +58,7 @@ RSpec.describe "bundle install" do
     G
 
     install_gemfile <<-G, :env => { "LANG" => "C" }
+      source "#{file_uri_for(gem_repo1)}"
       gemspec
     G
 
@@ -82,6 +84,7 @@ RSpec.describe "bundle install" do
     G
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gemspec
     G
 
@@ -96,6 +99,7 @@ RSpec.describe "bundle install" do
 
       install_gemfile <<-G
         ruby '#{RUBY_VERSION}', :engine_version => '#{RUBY_VERSION}', :engine => 'ruby'
+        source "#{file_uri_for(gem_repo1)}"
         gemspec
       G
       expect(the_bundle).to include_gems "foo 1.0"
@@ -109,6 +113,7 @@ RSpec.describe "bundle install" do
 
       install_gemfile <<-G, :raise_on_error => false
         ruby '#{RUBY_VERSION}', :engine_version => '#{RUBY_VERSION}', :engine => 'ruby', :patchlevel => '#{RUBY_PATCHLEVEL}'
+        source "#{file_uri_for(gem_repo1)}"
         gemspec
       G
       expect(the_bundle).to include_gems "foo 1.0"
@@ -123,6 +128,7 @@ RSpec.describe "bundle install" do
 
       install_gemfile <<-G, :raise_on_error => false
         ruby '#{RUBY_VERSION}', :engine_version => '#{RUBY_VERSION}', :engine => 'ruby', :patchlevel => '#{patchlevel}'
+        source "#{file_uri_for(gem_repo1)}"
         gemspec
       G
 
@@ -140,6 +146,7 @@ RSpec.describe "bundle install" do
 
       install_gemfile <<-G, :raise_on_error => false
         ruby '#{version}', :engine_version => '#{version}', :engine => 'ruby'
+        source "#{file_uri_for(gem_repo1)}"
         gemspec
       G
 

--- a/bundler/spec/install/git_spec.rb
+++ b/bundler/spec/install/git_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "bundle install" do
       build_git "foo", "1.0", :path => lib_path("foo")
 
       install_gemfile <<-G, :verbose => true
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :git => "#{file_uri_for(lib_path("foo"))}"
       G
 
@@ -17,6 +18,7 @@ RSpec.describe "bundle install" do
       build_git "foo", "1.0", :path => lib_path("foo"), :default_branch => "main"
 
       install_gemfile <<-G, :verbose => true
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :git => "#{file_uri_for(lib_path("foo"))}"
       G
 
@@ -34,6 +36,7 @@ RSpec.describe "bundle install" do
       update_git "foo", "3.0", :path => lib_path("foo"), :gemspec => true
 
       install_gemfile <<-G, :verbose => true
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :git => "#{file_uri_for(lib_path("foo"))}", :ref => "master~2"
       G
 
@@ -51,6 +54,7 @@ RSpec.describe "bundle install" do
       revision = build_git("foo").ref_for("HEAD")
 
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :git => "#{file_uri_for(lib_path("foo-1.0"))}", :group => :development
       G
 

--- a/bundler/spec/install/redownload_spec.rb
+++ b/bundler/spec/install/redownload_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe "bundle install" do
 
       before do
         gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
           gem "foo", :git => "#{lib_path("foo-1.0")}"
         G
       end

--- a/bundler/spec/lock/git_spec.rb
+++ b/bundler/spec/lock/git_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "bundle lock with git gems" do
     build_git "foo"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem 'foo', :git => "#{lib_path("foo-1.0")}"
     G
   end

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -322,6 +322,8 @@ RSpec.describe "the lockfile format" do
     bundle "config set http://localgemserver.test/ user:pass"
 
     install_gemfile(<<-G, :artifice => "endpoint_strict_basic_authentication", :quiet => true)
+      source "#{file_uri_for(gem_repo1)}"
+
       source "http://localgemserver.test/" do
 
       end
@@ -333,6 +335,7 @@ RSpec.describe "the lockfile format" do
 
     lockfile_should_be <<-G
       GEM
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
 
       GEM
@@ -388,6 +391,7 @@ RSpec.describe "the lockfile format" do
     git = build_git "foo"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :git => "#{lib_path("foo-1.0")}"
     G
 
@@ -399,6 +403,7 @@ RSpec.describe "the lockfile format" do
           foo (1.0)
 
       GEM
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
 
       PLATFORMS
@@ -455,6 +460,7 @@ RSpec.describe "the lockfile format" do
     git = build_git "foo"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       git "#{lib_path("foo-1.0")}" do
         gem "foo"
       end
@@ -468,6 +474,7 @@ RSpec.describe "the lockfile format" do
           foo (1.0)
 
       GEM
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
 
       PLATFORMS
@@ -486,6 +493,7 @@ RSpec.describe "the lockfile format" do
     update_git "foo", :branch => "omg"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :git => "#{lib_path("foo-1.0")}", :branch => "omg"
     G
 
@@ -498,6 +506,7 @@ RSpec.describe "the lockfile format" do
           foo (1.0)
 
       GEM
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
 
       PLATFORMS
@@ -516,6 +525,7 @@ RSpec.describe "the lockfile format" do
     update_git "foo", :tag => "omg"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :git => "#{lib_path("foo-1.0")}", :tag => "omg"
     G
 
@@ -528,6 +538,7 @@ RSpec.describe "the lockfile format" do
           foo (1.0)
 
       GEM
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
 
       PLATFORMS
@@ -545,6 +556,7 @@ RSpec.describe "the lockfile format" do
     build_lib "foo"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :path => "#{lib_path("foo-1.0")}"
     G
 
@@ -555,6 +567,7 @@ RSpec.describe "the lockfile format" do
           foo (1.0)
 
       GEM
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
 
       PLATFORMS
@@ -572,6 +585,7 @@ RSpec.describe "the lockfile format" do
     build_lib "foo"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :path => "#{lib_path("foo-1.0")}"
     G
 
@@ -586,6 +600,7 @@ RSpec.describe "the lockfile format" do
           foo (1.0)
 
       GEM
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
 
       PLATFORMS
@@ -821,6 +836,7 @@ RSpec.describe "the lockfile format" do
     build_lib "foo", :path => bundled_app("foo")
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       path "foo" do
         gem "foo"
       end
@@ -833,6 +849,7 @@ RSpec.describe "the lockfile format" do
           foo (1.0)
 
       GEM
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
 
       PLATFORMS
@@ -850,6 +867,7 @@ RSpec.describe "the lockfile format" do
     build_lib "foo", :path => bundled_app(File.join("..", "foo"))
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       path "../foo" do
         gem "foo"
       end
@@ -862,6 +880,7 @@ RSpec.describe "the lockfile format" do
           foo (1.0)
 
       GEM
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
 
       PLATFORMS
@@ -879,6 +898,7 @@ RSpec.describe "the lockfile format" do
     build_lib "foo", :path => bundled_app("foo")
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       path File.expand_path("../foo", __FILE__) do
         gem "foo"
       end
@@ -891,6 +911,7 @@ RSpec.describe "the lockfile format" do
           foo (1.0)
 
       GEM
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
 
       PLATFORMS
@@ -908,6 +929,7 @@ RSpec.describe "the lockfile format" do
     build_lib("foo", :path => tmp.join("foo"))
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gemspec :path => "../foo"
     G
 
@@ -918,6 +940,7 @@ RSpec.describe "the lockfile format" do
           foo (1.0)
 
       GEM
+        remote: #{file_uri_for(gem_repo1)}/
         specs:
 
       PLATFORMS

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -333,7 +333,7 @@ RSpec.describe "major deprecations" do
     end
 
     it "should print a proper warning, and use gems.rb" do
-      create_file "gems.rb"
+      create_file "gems.rb", "source \"#{file_uri_for(gem_repo1)}\""
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
@@ -484,7 +484,7 @@ RSpec.describe "major deprecations" do
 
   context "when Bundler.setup is run in a ruby script" do
     before do
-      create_file "gems.rb"
+      create_file "gems.rb", "source \"#{file_uri_for(gem_repo1)}\""
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rack", :group => :test
@@ -629,7 +629,7 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
     before do
       graphviz_version = RUBY_VERSION >= "2.4" ? "1.2.5" : "1.2.4"
       realworld_system_gems "ruby-graphviz --version #{graphviz_version}"
-      create_file "gems.rb"
+      create_file "gems.rb", "source \"#{file_uri_for(gem_repo1)}\""
       bundle "viz"
     end
 

--- a/bundler/spec/other/platform_spec.rb
+++ b/bundler/spec/other/platform_spec.rb
@@ -213,11 +213,13 @@ G
 
     it "handles when there is a locked requirement" do
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         ruby "< 1.8.7"
       G
 
       lockfile <<-L
         GEM
+          remote: #{file_uri_for(gem_repo1)}/
           specs:
 
         PLATFORMS
@@ -238,6 +240,7 @@ G
 
     it "handles when there is a requirement in the gemfile" do
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         ruby ">= 1.8.7"
       G
 
@@ -247,6 +250,7 @@ G
 
     it "handles when there are multiple requirements in the gemfile" do
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         ruby ">= 1.8.7", "< 2.0.0"
       G
 
@@ -685,6 +689,7 @@ G
 
     it "copies the .gem file to vendor/cache when ruby version matches" do
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
 
         #{ruby_version_correct}
@@ -708,6 +713,7 @@ G
 
     it "fails if the ruby version doesn't match" do
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
 
         #{ruby_version_incorrect}
@@ -719,6 +725,7 @@ G
 
     it "fails if the engine doesn't match" do
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
 
         #{engine_incorrect}
@@ -730,6 +737,7 @@ G
 
     it "fails if the engine version doesn't match", :jruby do
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
 
         #{engine_version_incorrect}
@@ -762,6 +770,7 @@ G
 
     it "copies the .gem file to vendor/cache when ruby version matches" do
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
 
         #{ruby_version_correct}
@@ -785,6 +794,7 @@ G
 
     it "fails if the ruby version doesn't match" do
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
 
         #{ruby_version_incorrect}
@@ -796,6 +806,7 @@ G
 
     it "fails if the engine doesn't match" do
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
 
         #{engine_incorrect}
@@ -807,6 +818,7 @@ G
 
     it "fails if the engine version doesn't match", :jruby do
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
 
         #{engine_version_incorrect}
@@ -837,6 +849,7 @@ G
 
     it "activates the correct gem when ruby version matches" do
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", "0.9.1"
 
         #{ruby_version_correct}
@@ -849,6 +862,7 @@ G
     it "activates the correct gem when ruby version matches any engine", :jruby do
       system_gems "rack-1.0.0", "rack-0.9.1", :path => default_bundle_path
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", "0.9.1"
 
         #{ruby_version_correct_engineless}
@@ -860,6 +874,7 @@ G
 
     it "fails when the ruby version doesn't match" do
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", "0.9.1"
 
         #{ruby_version_incorrect}
@@ -871,6 +886,7 @@ G
 
     it "fails when the engine doesn't match" do
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", "0.9.1"
 
         #{engine_incorrect}

--- a/bundler/spec/plugins/install_spec.rb
+++ b/bundler/spec/plugins/install_spec.rb
@@ -214,6 +214,7 @@ RSpec.describe "bundler plugin install" do
       end
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         plugin 'ga-plugin', :git => "#{lib_path("ga-plugin-1.0")}"
       G
 
@@ -227,6 +228,7 @@ RSpec.describe "bundler plugin install" do
       end
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         plugin 'ga-plugin', :path => "#{lib_path("ga-plugin-1.0")}"
       G
 

--- a/bundler/spec/runtime/executable_spec.rb
+++ b/bundler/spec/runtime/executable_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe "Running bin/* commands" do
     end
 
     gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "rack", :path => "#{lib_path("rack")}"
     G
 

--- a/bundler/spec/runtime/inline_spec.rb
+++ b/bundler/spec/runtime/inline_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe "bundler/inline#gemfile" do
   it "requires the gems" do
     script <<-RUBY
       gemfile do
+        source "#{file_uri_for(gem_repo1)}"
         path "#{lib_path}" do
           gem "two"
         end
@@ -58,6 +59,7 @@ RSpec.describe "bundler/inline#gemfile" do
 
     script <<-RUBY, :raise_on_error => false
       gemfile do
+        source "#{file_uri_for(gem_repo1)}"
         path "#{lib_path}" do
           gem "eleven"
         end
@@ -139,6 +141,7 @@ RSpec.describe "bundler/inline#gemfile" do
       require '#{entrypoint}'
       options = { :ui => Bundler::UI::Shell.new }
       gemfile(false, options) do
+        source "#{file_uri_for(gem_repo1)}"
         path "#{lib_path}" do
           gem "two"
         end
@@ -168,6 +171,7 @@ RSpec.describe "bundler/inline#gemfile" do
     baz_ref = build_git("baz", "2.0.0").ref_for("HEAD")
     script <<-RUBY
       gemfile do
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :git => #{lib_path("foo-1.0.0").to_s.dump}
         gem "baz", :git => #{lib_path("baz-2.0.0").to_s.dump}, :ref => #{baz_ref.dump}
       end
@@ -184,12 +188,14 @@ RSpec.describe "bundler/inline#gemfile" do
     script <<-RUBY
       gemfile do
         path "#{lib_path}" do
+          source "#{file_uri_for(gem_repo1)}"
           gem "two"
         end
       end
 
       gemfile do
         path "#{lib_path}" do
+          source "#{file_uri_for(gem_repo1)}"
           gem "four"
         end
       end
@@ -367,6 +373,7 @@ RSpec.describe "bundler/inline#gemfile" do
 
     script <<-RUBY, :dir => tmp("path_without_gemfile")
       gemfile do
+        source "#{file_uri_for(gem_repo2)}"
         path "#{lib_path}" do
           gem "foo", require: false
         end

--- a/bundler/spec/runtime/require_spec.rb
+++ b/bundler/spec/runtime/require_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe "Bundler.require" do
     end
 
     gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       path "#{lib_path}" do
         gem "one", :group => :bar, :require => %w[baz qux]
         gem "two"
@@ -112,6 +113,7 @@ RSpec.describe "Bundler.require" do
 
   it "raises an exception if a require is specified but the file does not exist" do
     gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       path "#{lib_path}" do
         gem "two", :require => 'fail'
       end
@@ -130,6 +132,7 @@ RSpec.describe "Bundler.require" do
     end
 
     gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       path "#{lib_path}" do
         gem "faulty"
       end
@@ -146,6 +149,7 @@ RSpec.describe "Bundler.require" do
     end
 
     gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       path "#{lib_path}" do
         gem "loadfuuu"
       end
@@ -172,6 +176,7 @@ RSpec.describe "Bundler.require" do
 
     it "requires gem names that are namespaced" do
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         path '#{lib_path}' do
           gem 'jquery-rails'
         end
@@ -186,6 +191,8 @@ RSpec.describe "Bundler.require" do
         s.write "lib/brcrypt.rb", "BCrypt = '1.0.0'"
       end
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+
         path "#{lib_path}" do
           gem "bcrypt-ruby"
         end
@@ -202,6 +209,7 @@ RSpec.describe "Bundler.require" do
 
     it "does not mangle explicitly given requires" do
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         path "#{lib_path}" do
           gem 'jquery-rails', :require => 'jquery-rails'
         end
@@ -219,6 +227,7 @@ RSpec.describe "Bundler.require" do
       end
 
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         path "#{lib_path}" do
           gem "load-fuuu"
         end
@@ -242,6 +251,7 @@ RSpec.describe "Bundler.require" do
       end
 
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         path "#{lib_path}" do
           gem "load-fuuu"
         end
@@ -300,6 +310,7 @@ RSpec.describe "Bundler.require" do
 
     it "works when the gems are in the Gemfile in the correct order" do
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         path "#{lib_path}" do
           gem "two"
           gem "one"
@@ -318,6 +329,7 @@ RSpec.describe "Bundler.require" do
         end
 
         install_gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
           gem "multi_gem", :require => "one", :group => :one
           gem "multi_gem", :require => "two", :group => :two
         G
@@ -341,6 +353,7 @@ RSpec.describe "Bundler.require" do
 
     it "fails when the gems are in the Gemfile in the wrong order" do
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         path "#{lib_path}" do
           gem "one"
           gem "two"
@@ -358,6 +371,7 @@ RSpec.describe "Bundler.require" do
         end
 
         install_gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
           gem "busted_require"
         G
 
@@ -396,6 +410,7 @@ RSpec.describe "Bundler.require" do
     build_git "foo"
 
     install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "foo", :git => "#{lib_path("foo-1.0")}"
     G
 

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -430,6 +430,7 @@ RSpec.describe "Bundler.setup" do
       build_git "rack", "1.0.0"
 
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "rack", :git => "#{lib_path("rack-1.0.0")}"
       G
     end
@@ -857,7 +858,7 @@ end
     end
 
     it "should not remove itself from the LOAD_PATH and require a different copy of 'bundler/setup'" do
-      install_gemfile ""
+      install_gemfile "source \"#{file_uri_for(gem_repo1)}\""
 
       ruby <<-R, :env => { "GEM_PATH" => symlinked_gem_home }
         TracePoint.trace(:class) do |tp|
@@ -906,6 +907,7 @@ end
       FileUtils.rm(File.join(path, "foo.gemspec"))
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem 'foo', '1.2.3', :path => 'vendor/foo'
       G
 
@@ -926,6 +928,7 @@ end
       FileUtils.rm(File.join(absolute_path, "foo.gemspec"))
 
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem 'foo', '1.2.3', :path => '#{relative_path}'
       G
 
@@ -944,6 +947,7 @@ end
       build_git "no_gemspec", :gemspec => false
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "no_gemspec", "1.0", :git => "#{lib_path("no_gemspec-1.0")}"
       G
     end
@@ -1046,6 +1050,7 @@ end
       end
 
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "bar", :git => "#{lib_path("bar-1.0")}"
       G
     end
@@ -1092,6 +1097,7 @@ end
   describe "when Bundler is bundled" do
     it "doesn't blow up" do
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "bundler", :path => "#{root}"
       G
 
@@ -1223,7 +1229,7 @@ end
 
   describe "with gemified standard libraries" do
     it "does not load Psych" do
-      gemfile ""
+      gemfile "source \"#{file_uri_for(gem_repo1)}\""
       ruby <<-RUBY
         require '#{entrypoint}/setup'
         puts defined?(Psych::VERSION) ? Psych::VERSION : "undefined"
@@ -1236,7 +1242,7 @@ end
     end
 
     it "does not load openssl" do
-      install_gemfile ""
+      install_gemfile "source \"#{file_uri_for(gem_repo1)}\""
       ruby <<-RUBY
         require "bundler/setup"
         puts defined?(OpenSSL) || "undefined"
@@ -1295,13 +1301,13 @@ end
       RUBY
 
       it "activates no gems with -rbundler/setup" do
-        install_gemfile ""
+        install_gemfile "source \"#{file_uri_for(gem_repo1)}\""
         ruby code, :env => { "RUBYOPT" => activation_warning_hack_rubyopt + " -rbundler/setup" }
         expect(out).to eq("{}")
       end
 
       it "activates no gems with bundle exec" do
-        install_gemfile ""
+        install_gemfile "source \"#{file_uri_for(gem_repo1)}\""
         create_file("script.rb", code)
         bundle "exec ruby ./script.rb", :env => { "RUBYOPT" => activation_warning_hack_rubyopt }
         expect(out).to eq("{}")
@@ -1310,7 +1316,7 @@ end
       it "activates no gems with bundle exec that is loaded" do
         skip "not executable" if Gem.win_platform?
 
-        install_gemfile ""
+        install_gemfile "source \"#{file_uri_for(gem_repo1)}\""
         create_file("script.rb", "#!/usr/bin/env ruby\n\n#{code}")
         FileUtils.chmod(0o777, bundled_app("script.rb"))
         bundle "exec ./script.rb", :artifice => nil, :env => { "RUBYOPT" => activation_warning_hack_rubyopt }

--- a/bundler/spec/runtime/with_unbundled_env_spec.rb
+++ b/bundler/spec/runtime/with_unbundled_env_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Bundler.with_env helpers" do
 
   def build_bundler_context(options = {})
     bundle "config set path vendor/bundle"
-    gemfile ""
+    gemfile "source \"#{file_uri_for(gem_repo1)}\""
     bundle "install", options
   end
 

--- a/bundler/spec/update/git_spec.rb
+++ b/bundler/spec/update/git_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "bundle update" do
       update_git "foo", :branch => "omg"
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         git "#{lib_path("foo-1.0")}", :branch => "omg" do
           gem 'foo'
         end
@@ -28,6 +29,7 @@ RSpec.describe "bundle update" do
       end
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "rails", :git => "#{file_uri_for(lib_path("rails"))}"
       G
 
@@ -40,6 +42,7 @@ RSpec.describe "bundle update" do
       update_git "foo", :branch => "omg", :path => lib_path("foo")
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         git "#{lib_path("foo")}", :branch => "omg" do
           gem 'foo'
         end
@@ -61,6 +64,7 @@ RSpec.describe "bundle update" do
       end
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :git => "#{file_uri_for(lib_path("foo"))}"
         gem "bar"
       G
@@ -79,12 +83,14 @@ RSpec.describe "bundle update" do
       build_git "foo", :path => lib_path("foo_two")
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", "1.0", :git => "#{file_uri_for(lib_path("foo_one"))}"
       G
 
       FileUtils.rm_rf lib_path("foo_one")
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", "1.0", :git => "#{file_uri_for(lib_path("foo_two"))}"
       G
 
@@ -100,6 +106,7 @@ RSpec.describe "bundle update" do
       update_git "foo", :push => "master"
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem 'foo', :git => "#{@remote.path}"
       G
 
@@ -108,6 +115,7 @@ RSpec.describe "bundle update" do
       update_git "foo", :push => "fubar"
 
       gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem 'foo', :git => "#{@remote.path}", :tag => "fubar"
       G
 
@@ -183,6 +191,7 @@ RSpec.describe "bundle update" do
       build_git "foo", "1.0"
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "foo", :git => "#{file_uri_for(lib_path("foo-1.0"))}"
       G
 
@@ -214,6 +223,7 @@ RSpec.describe "bundle update" do
       build_git "rails", "2.3.2", :path => lib_path("rails")
 
       install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
         gem "rails", :git => "#{file_uri_for(lib_path("rails"))}"
       G
 

--- a/bundler/spec/update/path_spec.rb
+++ b/bundler/spec/update/path_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "path sources" do
       build_lib "activesupport", "2.3.5", :path => lib_path("rails/activesupport")
 
       install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
       gem "activesupport", :path => "#{lib_path("rails/activesupport")}"
       G
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Issue: #4759 

## What is your fix for the problem, implemented in this PR?

Deprecate Gemfile without an explicit global source 

Fixes #4759.

#### Example

Gemfile:
```gemspec
source 'https://rubygems.org' do
  gem "my-gem"
end
```

Execute the following command:
```bash
$ bundle install
```

Will **output** the following warning when using Bundler 2.x:
```
[DEPRECATED] This Gemfile does not include an explicit global source. Not using an explicit global source may result in a different lockfile being generated depending on the gems you have installed locally before bundler is run.Instead, define a global source in your Gemfile like this: source "https://rubygems.org".
```

For Bundler 3.x will raise an **error** with the same message.

Screenshot:

<img width="889" alt="Screen Shot 2021-07-25 at 3 21 36 am" src="https://user-images.githubusercontent.com/1641461/126876324-3cc2084f-7a83-4307-842f-8a56239bc9a6.png">


## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
