### PR TITLE
Fix `--quiet` flag not printing warnings

### DIFF
--- a/bundler/lib/bundler/cli/cache.rb
+++ b/bundler/lib/bundler/cli/cache.rb
@@ -9,7 +9,7 @@ module Bundler
     end
 
     def run
-      Bundler.ui.level = "error" if options[:quiet]
+      Bundler.ui.level = "warn" if options[:quiet]
       Bundler.settings.set_command_option_if_given :path, options[:path]
       Bundler.settings.set_command_option_if_given :cache_path, options["cache-path"]
 

--- a/bundler/lib/bundler/cli/doctor.rb
+++ b/bundler/lib/bundler/cli/doctor.rb
@@ -61,7 +61,7 @@ module Bundler
     end
 
     def run
-      Bundler.ui.level = "error" if options[:quiet]
+      Bundler.ui.level = "warn" if options[:quiet]
       Bundler.settings.validate!
       check!
 

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -8,7 +8,7 @@ module Bundler
     end
 
     def run
-      Bundler.ui.level = "error" if options[:quiet]
+      Bundler.ui.level = "warn" if options[:quiet]
 
       warn_if_root
 

--- a/bundler/lib/bundler/cli/update.rb
+++ b/bundler/lib/bundler/cli/update.rb
@@ -9,7 +9,7 @@ module Bundler
     end
 
     def run
-      Bundler.ui.level = "error" if options[:quiet]
+      Bundler.ui.level = "warn" if options[:quiet]
 
       Plugin.gemfile_install(Bundler.default_gemfile) if Bundler.feature_flag.plugins?
 

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -585,7 +585,20 @@ RSpec.describe "bundle install with gem sources" do
   end
 
   describe "when requesting a quiet install via --quiet" do
-    it "should be quiet" do
+    it "should be quiet if there are no warnings" do
+      bundle "config set force_ruby_platform true"
+
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem 'rack'
+      G
+
+      bundle :install, :quiet => true
+      expect(out).to be_empty
+      expect(err).to be_empty
+    end
+
+    it "should still display warnings and errors" do
       bundle "config set force_ruby_platform true"
 
       create_file("install_with_warning.rb", <<~RUBY)
@@ -611,8 +624,9 @@ RSpec.describe "bundle install with gem sources" do
       G
 
       bundle :install, :quiet => true, :raise_on_error => false, :env => { "RUBYOPT" => "-r#{bundled_app("install_with_warning.rb")}" }
+      expect(out).to be_empty
       expect(err).to include("Could not find gem 'non-existing-gem'")
-      expect(err).not_to include("BOOOOO")
+      expect(err).to include("BOOOOO")
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The problem is that the `--quiet` flag hides warnings for no good reason, and contrary to documentation. See https://github.com/rubygems/rubygems/pull/4779#discussion_r676125872.
 
## What is your fix for the problem, implemented in this PR?

Restore the behaviour prior to https://github.com/rubygems/bundler/commit/ca0676cb1c638e0b9747ea8c18f28adf82cc01de.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
