### PR TITLE
Fix `--standalone` installation of default gems

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -721,7 +721,7 @@ module Bundler
       @locked_specs.each do |s|
         # Replace the locked dependency's source with the equivalent source from the Gemfile
         dep = @dependencies.find {|d| s.satisfies?(d) }
-        s.source = (dep && dep.source) || sources.get(s.source)
+        s.source = (dep && dep.source) || sources.get(s.source) unless multisource_allowed?
 
         # Don't add a spec to the list if its source is expired. For example,
         # if you change a Git gem to RubyGems.

--- a/bundler/lib/bundler/lockfile_parser.rb
+++ b/bundler/lib/bundler/lockfile_parser.rb
@@ -195,6 +195,7 @@ module Bundler
         platform = platform ? Gem::Platform.new(platform) : Gem::Platform::RUBY
         @current_spec = LazySpecification.new(name, version, platform)
         @current_spec.source = @current_source
+        @current_source.add_dependency_names(name)
 
         @specs[@current_spec.identifier] = @current_spec
       elsif spaces.size == 6

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -121,7 +121,8 @@ module Bundler
     def replace_sources!(replacement_sources)
       return false if replacement_sources.empty?
 
-      @path_sources, @git_sources, @plugin_sources = map_sources(replacement_sources)
+      @rubygems_sources, @path_sources, @git_sources, @plugin_sources = map_sources(replacement_sources)
+      @global_rubygems_source = global_replacement_source(replacement_sources)
 
       different_sources?(lock_sources, replacement_sources)
     end
@@ -156,11 +157,19 @@ module Bundler
     end
 
     def map_sources(replacement_sources)
-      [path_sources, git_sources, plugin_sources].map do |sources|
+      [@rubygems_sources, @path_sources, @git_sources, @plugin_sources].map do |sources|
         sources.map do |source|
           replacement_sources.find {|s| s == source } || source
         end
       end
+    end
+
+    def global_replacement_source(replacement_sources)
+      replacement_source = replacement_sources.find {|s| s == global_rubygems_source }
+      return global_rubygems_source unless replacement_source
+
+      replacement_source.local!
+      replacement_source
     end
 
     def different_sources?(lock_sources, replacement_sources)

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -215,7 +215,7 @@ module Bundler
     end
 
     def equal_source?(source, other_source)
-      return source.include?(other_source) if source.is_a?(Source::Rubygems) && other_source.is_a?(Source::Rubygems) && !merged_gem_lockfile_sections?
+      return source.include?(other_source) if source.is_a?(Source::Rubygems) && other_source.is_a?(Source::Rubygems)
 
       source == other_source
     end

--- a/bundler/spec/commands/clean_spec.rb
+++ b/bundler/spec/commands/clean_spec.rb
@@ -633,11 +633,9 @@ RSpec.describe "bundle clean" do
     default_irb_version = ruby "gem 'irb', '< 999999'; require 'irb'; puts IRB::VERSION", :raise_on_error => false
     skip "irb isn't a default gem" if default_irb_version.empty?
 
-    build_repo2 do
-      # simulate executable for default gem
-      build_gem "irb", default_irb_version, :to_system => true, :default => true do |s|
-        s.executables = "irb"
-      end
+    # simulate executable for default gem
+    build_gem "irb", default_irb_version, :to_system => true, :default => true do |s|
+      s.executables = "irb"
     end
 
     realworld_system_gems "fiddle --version 1.0.0"

--- a/bundler/spec/commands/clean_spec.rb
+++ b/bundler/spec/commands/clean_spec.rb
@@ -626,7 +626,7 @@ RSpec.describe "bundle clean" do
   end
 
   it "when using --force, it doesn't remove default gem binaries" do
-    skip "does not work on ruby 3.0 because it changes the path to look for default gems, tsort is a default gem there, and we can't install it either like we do with fiddle because it doesn't yet exist" unless RUBY_VERSION < "3.0.0"
+    skip "does not work on old rubies because the realworld gems that need to be installed don't support them" if RUBY_VERSION < "2.7.0"
 
     skip "does not work on rubygems versions where `--install_dir` doesn't respect --default" unless Gem::Installer.for_spec(loaded_gemspec, :install_dir => "/foo").default_spec_file == "/foo/specifications/default/bundler-#{Bundler::VERSION}.gemspec" # Since rubygems 3.2.0.rc.2
 
@@ -638,7 +638,7 @@ RSpec.describe "bundle clean" do
       s.executables = "irb"
     end
 
-    realworld_system_gems "fiddle --version 1.0.0"
+    realworld_system_gems "fiddle --version 1.0.6", "tsort --version 0.1.0", "pathname --version 0.1.0", "set --version 1.0.1"
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since recent versions, `bundle install --standalone` will fail if your Gemfile includes default gems.

## What is your fix for the problem, implemented in this PR?

Source replacement in `Bundler::Definition` is the process that decides whether sources from the lockfile can be used directly or whether sources from the `Gemfile` include changes over the lockfile and need to be considered instead.

This process was not happening correctly for rubygems sources, meaning that sometimes the chosen sources to pick up specs from were not correctly setup and failed to fetch some gems. We were workarounding the issue by "fixing" the incorrect sources at materialization time, but the workaround was not working for this particular case.

This PR fixes the root of the issue and allows us to remove all the workarounds at materialization time (which should also result in less unnecessary network activity).  

Fixes #4760.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
