### PR TITLE
Lazily load `shellwords` library

### DIFF
--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -57,6 +57,7 @@ class Gem::Ext::Builder
         p(command)
       end
       results << "current directory: #{dir}"
+      require "shellwords"
       results << command.shelljoin
 
       require "open3"

--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -5,8 +5,6 @@
 # See LICENSE.txt for permissions.
 #++
 
-require 'shellwords'
-
 class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
   def self.build(extension, dest_path, results, args=[], lib_dir=nil, extension_dir=Dir.pwd)
     require 'fileutils'
@@ -40,6 +38,7 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
       begin
         # workaround for https://github.com/oracle/truffleruby/issues/2115
         siteconf_path = RUBY_ENGINE == "truffleruby" ? siteconf.path.dup : siteconf.path
+        require "shellwords"
         cmd = Gem.ruby.shellsplit << "-I" << File.expand_path("../../..", __FILE__) <<
               "-r" << get_relative_path(siteconf_path, extension_dir) << File.basename(extension)
         cmd.push(*args)

--- a/lib/rubygems/ext/rake_builder.rb
+++ b/lib/rubygems/ext/rake_builder.rb
@@ -5,8 +5,6 @@
 # See LICENSE.txt for permissions.
 #++
 
-require "shellwords"
-
 class Gem::Ext::RakeBuilder < Gem::Ext::Builder
   def self.build(extension, dest_path, results, args=[], lib_dir=nil, extension_dir=Dir.pwd)
     if File.basename(extension) =~ /mkrf_conf/i
@@ -16,6 +14,7 @@ class Gem::Ext::RakeBuilder < Gem::Ext::Builder
     rake = ENV['rake']
 
     if rake
+      require "shellwords"
       rake = rake.shellsplit
     else
       begin


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Rubygems load `shellwords` and may activate it as a gem unnecessarily.

## What is your fix for the problem, implemented in this PR?

Load it only when really needed.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
