### PR TITLE
Don't load the `resolv` library since it's not used

### DIFF
--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -6,7 +6,6 @@ require 'rubygems/s3_uri_signer'
 require 'rubygems/uri_formatter'
 require 'rubygems/uri_parser'
 require 'rubygems/user_interaction'
-require 'resolv'
 
 ##
 # RemoteFetcher handles the details of fetching gems and gem information from


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Rubygems loads the `resolv` library, but doesn't really use it.

## What is your fix for the problem, implemented in this PR?

Remove the unnecessary require.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
