### PR TITLE
Lazily load `shellwords` library

### DIFF
--- a/bundler/lib/bundler/cli/open.rb
+++ b/bundler/lib/bundler/cli/open.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "shellwords"
-
 module Bundler
   class CLI::Open
     attr_reader :options, :name
@@ -19,6 +17,7 @@ module Bundler
       else
         path = spec.full_gem_path
         Dir.chdir(path) do
+          require "shellwords"
           command = Shellwords.split(editor) + [path]
           Bundler.with_original_env do
             system(*command)

--- a/bundler/lib/bundler/installer/gem_installer.rb
+++ b/bundler/lib/bundler/installer/gem_installer.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "shellwords"
-
 module Bundler
   class GemInstaller
     attr_reader :spec, :standalone, :worker, :force, :installer
@@ -47,6 +45,7 @@ module Bundler
     def spec_settings
       # Fetch the build settings, if there are any
       if settings = Bundler.settings["build.#{spec.name}"]
+        require "shellwords"
         Shellwords.shellsplit(settings)
       end
     end

--- a/bundler/lib/bundler/rubygems_gem_installer.rb
+++ b/bundler/lib/bundler/rubygems_gem_installer.rb
@@ -61,7 +61,10 @@ module Bundler
 
     def build_extensions
       extension_cache_path = options[:bundler_extension_cache_path]
-      return super unless extension_cache_path && extension_dir = spec.extension_dir
+      unless extension_cache_path && extension_dir = spec.extension_dir
+        require "shellwords" # compensate missing require in rubygems before version 3.2.25
+        return super
+      end
 
       extension_dir = Pathname.new(extension_dir)
       build_complete = SharedHelpers.filesystem_access(extension_cache_path.join("gem.build_complete"), :read, &:file?)
@@ -71,6 +74,7 @@ module Bundler
           FileUtils.cp_r extension_cache_path, spec.extension_dir
         end
       else
+        require "shellwords" # compensate missing require in rubygems before version 3.2.25
         super
         if extension_dir.directory? # not made for gems without extensions
           SharedHelpers.filesystem_access(extension_cache_path.parent, &:mkpath)

--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "shellwords"
-
 module Bundler
   class Source
     class Git
@@ -224,6 +222,7 @@ module Bundler
         end
 
         def check_allowed(command)
+          require "shellwords"
           command_with_no_credentials = URICredentialsFilter.credential_filtered_string("git #{command.shelljoin}", uri)
           raise GitNotAllowedError.new(command_with_no_credentials) unless allow?
           command_with_no_credentials


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This PR is analogous to #4783, but for `bundler`. Motivation is the same as lazily loading in `rubygems`.

## What is your fix for the problem, implemented in this PR?

Move requires inline.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
