### PR TITLE
Give better errors when materialization fails

### DIFF
--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -84,7 +84,7 @@ module Bundler
 
       Bundler::CLI::Common.output_fund_metadata_summary
     rescue GemNotFound
-      if options[:local] && Bundler.app_cache.exist?
+      if options[:local]
         Bundler.ui.warn "Some gems seem to be missing from your #{Bundler.settings.app_cache_path} directory."
       end
 

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -60,7 +60,7 @@ module Bundler
       installer = Installer.install(Bundler.root, definition, options)
 
       Bundler.settings.temporary(:cache_all_platforms => options[:local] ? false : Bundler.settings[:cache_all_platforms]) do
-        Bundler.load.cache if Bundler.app_cache.exist? && !options["no-cache"] && !Bundler.frozen_bundle?
+        Bundler.load.cache(nil, options[:local]) if Bundler.app_cache.exist? && !options["no-cache"] && !Bundler.frozen_bundle?
       end
 
       Bundler.ui.confirm "Bundle complete! #{dependencies_count_for(definition)}, #{gems_installed_for(definition)}."
@@ -83,12 +83,6 @@ module Bundler
       end
 
       Bundler::CLI::Common.output_fund_metadata_summary
-    rescue GemNotFound
-      if options[:local]
-        Bundler.ui.warn "Some gems seem to be missing from your #{Bundler.settings.app_cache_path} directory."
-      end
-
-      raise
     rescue Gem::InvalidSpecificationException
       Bundler.ui.warn "You have one or more invalid gemspecs that need to be fixed."
       raise

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -83,15 +83,15 @@ module Bundler
       end
 
       Bundler::CLI::Common.output_fund_metadata_summary
-    rescue GemNotFound => e
+    rescue GemNotFound
       if options[:local] && Bundler.app_cache.exist?
         Bundler.ui.warn "Some gems seem to be missing from your #{Bundler.settings.app_cache_path} directory."
       end
 
-      raise e
-    rescue Gem::InvalidSpecificationException => e
+      raise
+    rescue Gem::InvalidSpecificationException
       Bundler.ui.warn "You have one or more invalid gemspecs that need to be fixed."
-      raise e
+      raise
     end
 
     private

--- a/bundler/lib/bundler/cli/list.rb
+++ b/bundler/lib/bundler/cli/list.rb
@@ -16,7 +16,13 @@ module Bundler
       specs = if @only_group.any? || @without_group.any?
         filtered_specs_by_groups
       else
-        Bundler.load.specs
+        begin
+          Bundler.load.specs
+        rescue GemNotFound => e
+          Bundler.ui.error e.message
+          Bundler.ui.warn "Install missing gems with `bundle install`."
+          exit 1
+        end
       end.reject {|s| s.name == "bundler" }.sort_by(&:name)
 
       return Bundler.ui.info "No gems in the Gemfile" if specs.empty?

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -190,7 +190,7 @@ module Bundler
     #
     # @return [Bundler::SpecSet]
     def specs
-      @specs ||= add_bundler_to(resolve.materialize(requested_dependencies))
+      @specs ||= materialize(requested_dependencies)
     rescue GemNotFound => e # Handle yanked gem
       gem_name, gem_version = extract_gem_info(e)
       locked_gem = @locked_specs[gem_name].last
@@ -246,7 +246,7 @@ module Bundler
     def specs_for(groups)
       groups = requested_groups if groups.empty?
       deps = dependencies_for(groups)
-      add_bundler_to(resolve.materialize(expand_dependencies(deps)))
+      materialize(expand_dependencies(deps))
     end
 
     def dependencies_for(groups)
@@ -496,7 +496,9 @@ module Bundler
 
     private
 
-    def add_bundler_to(specs)
+    def materialize(dependencies)
+      specs = resolve.materialize(dependencies)
+
       unless specs["bundler"].any?
         bundler = sources.metadata_source.specs.search(Gem::Dependency.new("bundler", VERSION)).last
         specs["bundler"] = bundler

--- a/bundler/lib/bundler/runtime.rb
+++ b/bundler/lib/bundler/runtime.rb
@@ -22,10 +22,6 @@ module Bundler
 
       # Activate the specs
       load_paths = specs.map do |spec|
-        unless spec.loaded_from
-          raise GemNotFound, "#{spec.full_name} is missing. Run `bundle install` to get it."
-        end
-
         check_for_activated_spec!(spec)
 
         Bundler.rubygems.mark_loaded(spec)

--- a/bundler/lib/bundler/setup.rb
+++ b/bundler/lib/bundler/setup.rb
@@ -9,10 +9,10 @@ if Bundler::SharedHelpers.in_bundle?
     begin
       Bundler.ui.silence { Bundler.setup }
     rescue Bundler::BundlerError => e
-      Bundler.ui.warn "\e[31m#{e.message}\e[0m"
+      Bundler.ui.error e.message
       Bundler.ui.warn e.backtrace.join("\n") if ENV["DEBUG"]
       if e.is_a?(Bundler::GemNotFound)
-        Bundler.ui.warn "\e[33mRun `bundle install` to install missing gems.\e[0m"
+        Bundler.ui.warn "Run `bundle install` to install missing gems."
       end
       exit e.status_code
     end

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -11,7 +11,7 @@ module Bundler
       @specs = specs
     end
 
-    def for(dependencies, check = false, match_current_platform = false, raise_on_missing = true)
+    def for(dependencies, check = false, match_current_platform = false)
       handled = []
       deps = dependencies.dup
       specs = []
@@ -33,11 +33,6 @@ module Bundler
           end
         elsif check
           return false
-        elsif raise_on_missing
-          others = lookup[dep.name] if match_current_platform
-          message = "Unable to find a spec satisfying #{dep} in the set. Perhaps the lockfile is corrupted?"
-          message += " Found #{others.join(", ")} that did not match the current platform." if others && !others.empty?
-          raise GemNotFound, message
         end
       end
 
@@ -71,8 +66,8 @@ module Bundler
       lookup.dup
     end
 
-    def materialize(deps, missing_specs = nil)
-      materialized = self.for(deps, false, true, !missing_specs)
+    def materialize(deps)
+      materialized = self.for(deps, false, true)
 
       materialized.group_by(&:source).each do |source, specs|
         next unless specs.any?{|s| s.is_a?(LazySpecification) }
@@ -84,16 +79,9 @@ module Bundler
 
       materialized.map! do |s|
         next s unless s.is_a?(LazySpecification)
-        spec = s.__materialize__
-        unless spec
-          unless missing_specs
-            raise GemNotFound, "Could not find #{s.full_name} in any of the sources"
-          end
-          missing_specs << s
-        end
-        spec
+        s.__materialize__ || s
       end
-      SpecSet.new(missing_specs ? materialized.compact : materialized)
+      SpecSet.new(materialized)
     end
 
     # Materialize for all the specs in the spec set, regardless of what platform they're for
@@ -115,6 +103,10 @@ module Bundler
         raise GemNotFound, "Could not find #{s.full_name} in any of the sources" unless spec
         spec
       end
+    end
+
+    def missing_specs
+      select {|s| s.is_a?(LazySpecification) }
     end
 
     def merge(set)

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -836,9 +836,9 @@ RSpec.describe "bundle exec" do
       let(:exit_code) { Bundler::GemNotFound.new.status_code }
       let(:expected) { "" }
       let(:expected_err) { <<-EOS.strip }
-\e[31mCould not find gem 'rack (= 2)' in rubygems repository #{file_uri_for(gem_repo1)}/ or installed locally.
-The source contains the following versions of 'rack': 0.9.1, 1.0.0\e[0m
-\e[33mRun `bundle install` to install missing gems.\e[0m
+Could not find gem 'rack (= 2)' in rubygems repository #{file_uri_for(gem_repo1)}/ or installed locally.
+The source contains the following versions of 'rack': 0.9.1, 1.0.0
+Run `bundle install` to install missing gems.
       EOS
 
       it "runs" do
@@ -863,9 +863,9 @@ The source contains the following versions of 'rack': 0.9.1, 1.0.0\e[0m
       let(:exit_code) { Bundler::GemNotFound.new.status_code }
       let(:expected) { "" }
       let(:expected_err) { <<-EOS.strip }
-\e[31mCould not find gem 'rack (= 2)' in rubygems repository #{file_uri_for(gem_repo1)}/ or installed locally.
-The source contains the following versions of 'rack': 1.0.0\e[0m
-\e[33mRun `bundle install` to install missing gems.\e[0m
+Could not find gem 'rack (= 2)' in rubygems repository #{file_uri_for(gem_repo1)}/ or installed locally.
+The source contains the following versions of 'rack': 1.0.0
+Run `bundle install` to install missing gems.
       EOS
 
       it "runs" do

--- a/bundler/spec/install/yanked_spec.rb
+++ b/bundler/spec/install/yanked_spec.rb
@@ -70,4 +70,34 @@ RSpec.context "when using gem before installing" do
     expect(err).to_not include("If you haven't changed sources, that means the author of rack (0.9.1) has removed it.")
     expect(err).to_not include("You'll need to update your bundle to a different version of rack (0.9.1) that hasn't been removed in order to install.")
   end
+
+  it "does not suggest the author has yanked the gem when using more than one gem, but shows all gems that couldn't be found in the source" do
+    gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
+      gem "rack", "0.9.1"
+      gem "rack_middleware", "1.0"
+    G
+
+    lockfile <<-L
+      GEM
+        remote: #{file_uri_for(gem_repo1)}
+        specs:
+          rack (0.9.1)
+          rack_middleware (1.0)
+
+      PLATFORMS
+        ruby
+
+      DEPENDENCIES
+        rack (= 0.9.1)
+        rack_middleware (1.0)
+    L
+
+    bundle :list, :raise_on_error => false
+
+    expect(err).to include("Could not find rack-0.9.1, rack_middleware-1.0 in any of the sources")
+    expect(err).to_not include("Your bundle is locked to rack (0.9.1), but that version could not be found in any of the sources listed in your Gemfile.")
+    expect(err).to_not include("If you haven't changed sources, that means the author of rack (0.9.1) has removed it.")
+    expect(err).to_not include("You'll need to update your bundle to a different version of rack (0.9.1) that hasn't been removed in order to install.")
+  end
 end

--- a/bundler/spec/install/yanked_spec.rb
+++ b/bundler/spec/install/yanked_spec.rb
@@ -96,6 +96,7 @@ RSpec.context "when using gem before installing" do
     bundle :list, :raise_on_error => false
 
     expect(err).to include("Could not find rack-0.9.1, rack_middleware-1.0 in any of the sources")
+    expect(err).to include("Install missing gems with `bundle install`.")
     expect(err).to_not include("Your bundle is locked to rack (0.9.1), but that version could not be found in any of the sources listed in your Gemfile.")
     expect(err).to_not include("If you haven't changed sources, that means the author of rack (0.9.1) has removed it.")
     expect(err).to_not include("You'll need to update your bundle to a different version of rack (0.9.1) that hasn't been removed in order to install.")


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When materialization fails, the error user gets can be confusing because it only shows the first gem that failed to be materialized. Sometimes it can be a single gem that's missing, sometimes it can be the whole bundle. Showing only the first gem that fails to materialize can lead end users into thinking there's a specific issue with that single gem, so this PR changes bundler to show the complete list of gems that failed to be materialized.

## What is your fix for the problem, implemented in this PR?

My fix is to refactor the current implementation to be able to show the full list of gems that failed to be materialized. It's a bit more work, but it only happens on errors, so definitely not a critical code path, and as a result it allows us to simplify code in `Bundler::Definition` (our main "god class") and in `Bundler::SpecSec` (another complicated class).

In addition, I added a `bundle install` hint for when this error happens when running `bundle list` before `bundle install`, like we do in other cases like `bundler/setup` or `bundle check`.

I made this work while working on #4782, but I think it's justified as a separate improvement.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
