### PR TITLE
gem which command now recognize packages like actioncable 

### DIFF
--- a/lib/rubygems/commands/which_command.rb
+++ b/lib/rubygems/commands/which_command.rb
@@ -51,9 +51,7 @@ requiring to see why it does not behave as you expect.
           dirs = $LOAD_PATH + spec.full_require_paths
         end
       end
-
       paths = find_paths arg, dirs
-
       if paths.empty?
         alert_error "Can't find Ruby library file or shared library #{arg}"
         found = false
@@ -69,12 +67,21 @@ requiring to see why it does not behave as you expect.
     result = []
 
     dirs.each do |dir|
+      possible_entry_files = Dir.entries(dir).select { |f| File.file? File.join(dir, f) }
       Gem.suffixes.each do |ext|
         full_path = File.join dir, "#{package_name}#{ext}"
         if File.exist? full_path and not File.directory? full_path
           result << full_path
           return result unless options[:show_all]
         end
+        possible_entry_files.each do |possible_entry_file|
+          possible_entry_file_without_underscore =  possible_entry_file.tr("_", "")
+          possible_entry_full_path = File.join dir, possible_entry_file
+          if ("#{package_name}#{ext}" == possible_entry_file_without_underscore) and not File.directory? possible_entry_full_path
+            result << possible_entry_full_path
+            return result unless options[:show_all]
+          end
+        end 
       end
     end
 


### PR DESCRIPTION
gem which command now recognize packages like actioncable that has entry point with underscore like action_cable.rb

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

1. Run `gem list`
Output:
```
$ gem list

*** LOCAL GEMS ***

activesupport (6.1.4)
bigdecimal (default: 1.3.4)
cmath (default: 1.0.0)
coderay (1.1.3)
concurrent-ruby (1.1.9)
csv (default: 1.0.0)

```
2. Run `gem which activesupport`
Output:
```
$ gem which activesupport
ERROR:  Can't find Ruby library file or shared library activesupport
```

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

After the fix:
```
$  gem which activesupport
/usr/local/bundle/gems/activesupport-5.2.6/lib/active_support.rb
```
Same goes for all packages that has "_" in entry point file like: actioncable, actionmailer, actionpack and more.

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
