### PR TITLE
Make script generated by `bundle install --standalone` resilient to moving the application to a differently nested folder when `path` sources are used

### DIFF
--- a/bundler/lib/bundler/installer/standalone.rb
+++ b/bundler/lib/bundler/installer/standalone.rb
@@ -12,7 +12,6 @@ module Bundler
       end
       File.open File.join(bundler_path, "setup.rb"), "w" do |file|
         file.puts "require 'rbconfig'"
-        file.puts "ruby_engine = RUBY_ENGINE"
         file.puts "ruby_version = RbConfig::CONFIG[\"ruby_version\"]"
         file.puts reverse_rubygems_kernel_mixin
         paths.each do |path|
@@ -27,7 +26,7 @@ module Bundler
       @specs.map do |spec|
         next if spec.name == "bundler"
         Array(spec.require_paths).map do |path|
-          gem_path(path, spec).sub(version_dir, '#{ruby_engine}/#{ruby_version}')
+          gem_path(path, spec).sub(version_dir, '#{RUBY_ENGINE}/#{ruby_version}')
           # This is a static string intentionally. It's interpolated at a later time.
         end
       end.flatten.compact

--- a/bundler/lib/bundler/installer/standalone.rb
+++ b/bundler/lib/bundler/installer/standalone.rb
@@ -31,7 +31,7 @@ module Bundler
           gem_path(path, spec).sub(version_dir, '#{ruby_engine}/#{ruby_version}')
           # This is a static string intentionally. It's interpolated at a later time.
         end
-      end.flatten
+      end.flatten.compact
     end
 
     def version_dir

--- a/bundler/lib/bundler/installer/standalone.rb
+++ b/bundler/lib/bundler/installer/standalone.rb
@@ -12,7 +12,6 @@ module Bundler
       end
       File.open File.join(bundler_path, "setup.rb"), "w" do |file|
         file.puts "require 'rbconfig'"
-        file.puts "ruby_version = RbConfig::CONFIG[\"ruby_version\"]"
         file.puts reverse_rubygems_kernel_mixin
         paths.each do |path|
           file.puts %($:.unshift File.expand_path("\#{__dir__}/#{path}"))
@@ -26,7 +25,7 @@ module Bundler
       @specs.map do |spec|
         next if spec.name == "bundler"
         Array(spec.require_paths).map do |path|
-          gem_path(path, spec).sub(version_dir, '#{RUBY_ENGINE}/#{ruby_version}')
+          gem_path(path, spec).sub(version_dir, '#{RUBY_ENGINE}/#{RbConfig::CONFIG["ruby_version"]}')
           # This is a static string intentionally. It's interpolated at a later time.
         end
       end.flatten.compact

--- a/bundler/lib/bundler/installer/standalone.rb
+++ b/bundler/lib/bundler/installer/standalone.rb
@@ -33,7 +33,7 @@ module Bundler
     end
 
     def version_dir
-      "#{Bundler::RubyVersion.system.engine}/#{RbConfig::CONFIG["ruby_version"]}"
+      "#{RUBY_ENGINE}/#{RbConfig::CONFIG["ruby_version"]}"
     end
 
     def bundler_path

--- a/bundler/lib/bundler/installer/standalone.rb
+++ b/bundler/lib/bundler/installer/standalone.rb
@@ -14,10 +14,9 @@ module Bundler
         file.puts "require 'rbconfig'"
         file.puts "ruby_engine = RUBY_ENGINE"
         file.puts "ruby_version = RbConfig::CONFIG[\"ruby_version\"]"
-        file.puts "path = File.expand_path('..', __FILE__)"
         file.puts reverse_rubygems_kernel_mixin
         paths.each do |path|
-          file.puts %($:.unshift File.expand_path("\#{path}/#{path}"))
+          file.puts %($:.unshift File.expand_path("\#{__dir__}/#{path}"))
         end
       end
     end

--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -147,6 +147,36 @@ RSpec.shared_examples "bundle install --standalone" do
     end
   end
 
+  describe "with Gemfiles using path sources and resulting bundle moved to a folder hierarchy with different nesting" do
+    before do
+      build_lib "minitest", "1.0.0", :path => lib_path("minitest")
+
+      Dir.mkdir bundled_app("app")
+
+      gemfile bundled_app("app/Gemfile"), <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem "minitest", :path => "#{lib_path("minitest")}"
+      G
+
+      bundle "install", :standalone => true, :dir => bundled_app("app")
+
+      Dir.mkdir tmp("one_more_level")
+      FileUtils.mv bundled_app, tmp("one_more_level")
+    end
+
+    it "also works" do
+      ruby <<-RUBY, :dir => tmp("one_more_level/bundled_app/app")
+        require "./bundle/bundler/setup"
+
+        require "minitest"
+        puts MINITEST
+      RUBY
+
+      expect(out).to eq("1.0.0")
+      expect(err).to be_empty
+    end
+  end
+
   describe "with gems with native extension", :ruby_repo do
     before do
       bundle "config set --local path #{bundled_app("bundle")}"

--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -159,7 +159,7 @@ RSpec.shared_examples "bundle install --standalone" do
     it "generates a bundle/bundler/setup.rb with the proper paths" do
       expected_path = bundled_app("bundle/bundler/setup.rb")
       extension_line = File.read(expected_path).each_line.find {|line| line.include? "/extensions/" }.strip
-      expect(extension_line).to start_with '$:.unshift File.expand_path("#{path}/../#{ruby_engine}/#{ruby_version}/extensions/'
+      expect(extension_line).to start_with '$:.unshift File.expand_path("#{__dir__}/../#{ruby_engine}/#{ruby_version}/extensions/'
       expect(extension_line).to end_with '/very_simple_binary-1.0")'
     end
   end

--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -159,7 +159,7 @@ RSpec.shared_examples "bundle install --standalone" do
     it "generates a bundle/bundler/setup.rb with the proper paths" do
       expected_path = bundled_app("bundle/bundler/setup.rb")
       extension_line = File.read(expected_path).each_line.find {|line| line.include? "/extensions/" }.strip
-      expect(extension_line).to start_with '$:.unshift File.expand_path("#{__dir__}/../#{ruby_engine}/#{ruby_version}/extensions/'
+      expect(extension_line).to start_with '$:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{ruby_version}/extensions/'
       expect(extension_line).to end_with '/very_simple_binary-1.0")'
     end
   end

--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -159,7 +159,7 @@ RSpec.shared_examples "bundle install --standalone" do
     it "generates a bundle/bundler/setup.rb with the proper paths" do
       expected_path = bundled_app("bundle/bundler/setup.rb")
       extension_line = File.read(expected_path).each_line.find {|line| line.include? "/extensions/" }.strip
-      expect(extension_line).to start_with '$:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{ruby_version}/extensions/'
+      expect(extension_line).to start_with '$:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{RbConfig::CONFIG["ruby_version"]}/extensions/'
       expect(extension_line).to end_with '/very_simple_binary-1.0")'
     end
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When a `Gemfile` using path sources, and `bundle install --standalone` is run, the generated script won't work if the application is moved to a folder with a different "folder depth".

## What is your fix for the problem, implemented in this PR?

The fix is, if path sources point to an absolute path, add it to `$LOAD_PATH` directly, so that the generated script doesn't depend on how depely nested the application is with respect to the path source.  

Fixes #4758.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
