### PR TITLE
Fix `BUNDLE_USER_CONFIG` no longer respected as config location

### DIFF
--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -428,6 +428,8 @@ module Bundler
     def global_config_file
       if ENV["BUNDLE_CONFIG"] && !ENV["BUNDLE_CONFIG"].empty?
         Pathname.new(ENV["BUNDLE_CONFIG"])
+      elsif ENV["BUNDLE_USER_CONFIG"] && !ENV["BUNDLE_USER_CONFIG"].empty?
+        Pathname.new(ENV["BUNDLE_USER_CONFIG"])
       elsif Bundler.rubygems.user_home && !Bundler.rubygems.user_home.empty?
         Pathname.new(Bundler.rubygems.user_home).join(".bundle/config")
       end

--- a/bundler/spec/commands/config_spec.rb
+++ b/bundler/spec/commands/config_spec.rb
@@ -76,6 +76,20 @@ RSpec.describe ".bundle/config" do
     end
   end
 
+  describe "config location" do
+    let(:bundle_user_config) { File.join(Dir.home, ".config/bundler") }
+
+    before do
+      Dir.mkdir File.dirname(bundle_user_config)
+    end
+
+    it "can be configured through BUNDLE_USER_CONFIG" do
+      bundle "config set path vendor", :env => { "BUNDLE_USER_CONFIG" => bundle_user_config }
+      bundle "config get path", :env => { "BUNDLE_USER_CONFIG" => bundle_user_config }
+      expect(out).to include("Set for the current user (#{bundle_user_config}): \"vendor\"")
+    end
+  end
+
   describe "global" do
     before(:each) do
       install_gemfile <<-G


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I recent regression made `BUNDLE_USER_CONFIG` no longer respected as the config location.

## What is your fix for the problem, implemented in this PR?

Consider this environment variable again.

Fixes #4793.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
