### PR TITLE
Fix flaky spec failure when sorting materialized specs

### DIFF
--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -92,7 +92,7 @@ module Bundler
     end
 
     def missing_specs
-      select {|s| s.is_a?(LazySpecification) }
+      @specs.select {|s| s.is_a?(LazySpecification) }
     end
 
     def merge(set)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We got a strange flaky test failure at https://github.com/rubygems/rubygems/pull/4792. URI of the error is now expired but I copied it over and it looks like this:

```
Failures:

  1) [TEST_ENV_NUMBER=1] Bundler.setup with multi platform stuff allows specifying only-ruby-platform on windows with gemspec dependency
     Failure/Error:
               raise <<~ERROR

                 Invoking `#{cmd}` failed with output:
                 ----------------------------------------------------------------------
                 #{command_execution.stdboth}
                 ----------------------------------------------------------------------
               ERROR

     RuntimeError:


       Commands:
       $ /opt/hostedtoolcache/Ruby/3.0.2/x64/bin/ruby -I/home/runner/work/rubygems/rubygems/bundler/spec -r/home/runner/work/rubygems/rubygems/bundler/spec/support/artifice/fail.rb -r/home/runner/work/rubygems/rubygems/bundler/spec/support/hax.rb /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/bin/bundle lock
       Resolving dependencies...Fetching source index from file:///home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/remote1/

       Writing lockfile to /home/runner/work/rubygems/rubygems/bundler/tmp/1/bundled_app/Gemfile.lock
       # $? => 0

       $ /opt/hostedtoolcache/Ruby/3.0.2/x64/bin/ruby -I/home/runner/work/rubygems/rubygems/bundler/spec -r/home/runner/work/rubygems/rubygems/bundler/spec/support/artifice/fail.rb -r/home/runner/work/rubygems/rubygems/bundler/spec/support/hax.rb /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/bin/bundle config set force_ruby_platform true
       # $? => 0

       Invoking `/opt/hostedtoolcache/Ruby/3.0.2/x64/bin/ruby -I/home/runner/work/rubygems/rubygems/bundler/spec -r/home/runner/work/rubygems/rubygems/bundler/spec/support/artifice/fail.rb -r/home/runner/work/rubygems/rubygems/bundler/spec/support/hax.rb /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/bin/bundle install` failed with output:
       ----------------------------------------------------------------------
       --- ERROR REPORT TEMPLATE -------------------------------------------------------
       # Error Report

       ## Questions

       Please fill out answers to these questions, it'll help us figure out
       why things are going wrong.

       - **What did you do?**

         I ran the command `/home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/bin/bundle install`

       - **What did you expect to happen?**

         I expected Bundler to...

       - **What happened instead?**

         Instead, what happened was...

       - **Have you tried any solutions posted on similar issues in our issue tracker, stack overflow, or google?**

         I tried...

       - **Have you read our issues document, https://github.com/rubygems/rubygems/blob/master/bundler/doc/contributing/ISSUES.md?**

         ...

       ## Backtrace

       ```
       NoMethodError: undefined method `identifier' for #<Gem::Specification:0x000055983c62e3f8 @extension_dir=nil, @full_gem_path=nil, @gem_dir=nil, @ignored=nil, @bin_dir=nil, @cache_dir=nil, @cache_file=nil, @doc_dir=nil, @ri_dir=nil, @spec_dir=nil, @spec_file=nil, @gems_dir=nil, @base_dir=nil, @loaded=false, @activated=false, @loaded_from="/home/runner/work/rubygems/rubygems/bundler/tmp/1/bundled_app/foo.gemspec", @original_platform=nil, @installed_by_version=nil, @autorequire=nil, @date=2021-07-29 00:00:00 UTC, @description="This is a completely fake gem, for testing purposes.", @email="foo@bar.baz", @homepage="http://example.com", @name="foo", @post_install_message=nil, @signing_key=nil, @summary="This is just a fake gem for testing", @version=#<Gem::Version "1.0">, @authors=["no one"], @bindir="bin", @cert_chain=[], @dependencies=[<Gem::Dependency type=:runtime name="rack" requirements=">= 0">], @executables=[], @extensions=[], @extra_rdoc_files=[], @files=["foo.gemspec", "lib/foo.rb", "lib/foo/source.rb"], @licenses=["MIT"], @metadata={}, @platform="ruby", @rdoc_options=[], @require_paths=["lib"], @required_ruby_version=#<Gem::Requirement:0x000055983c62f870 @requirements=[[">=", #<Gem::Version "0">]]>, @required_rubygems_version=#<Gem::Requirement:0x000055983c62f528 @requirements=[[">=", #<Gem::Version "0">]]>, @requirements=[], @rubygems_version="3.2.24", @specification_version=4, @test_files=[], @new_platform="ruby", @full_name="foo-1.0", @source=#<Bundler::Source::Gemspec:0x1680 source at `.`> foo-1.0>
         /home/runner/work/rubygems/rubygems/bundler/tmp/rubygems/lib/rubygems/specification.rb:2120:in `method_missing'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/lazy_specification.rb:34:in `eql?'
         /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/3.0.0/tsort.rb:416:in `include?'
         /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/3.0.0/tsort.rb:416:in `block in each_strongly_connected_component_from'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/spec_set.rb:198:in `block (2 levels) in tsort_each_child'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/spec_set.rb:198:in `each'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/spec_set.rb:198:in `block in tsort_each_child'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/spec_set.rb:196:in `each'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/spec_set.rb:196:in `tsort_each_child'
         /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/3.0.0/tsort.rb:415:in `call'
         /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/3.0.0/tsort.rb:415:in `each_strongly_connected_component_from'
         /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/3.0.0/tsort.rb:349:in `block in each_strongly_connected_component'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/spec_set.rb:183:in `block in tsort_each_node'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/spec_set.rb:183:in `each'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/spec_set.rb:183:in `tsort_each_node'
         /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/3.0.0/tsort.rb:347:in `call'
         /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/3.0.0/tsort.rb:347:in `each_strongly_connected_component'
         /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/3.0.0/tsort.rb:226:in `tsort_each'
         /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/3.0.0/tsort.rb:176:in `each'
         /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/3.0.0/tsort.rb:176:in `to_a'
         /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/3.0.0/tsort.rb:176:in `tsort'
         /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/3.0.0/tsort.rb:152:in `tsort'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/spec_set.rb:158:in `sorted'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/spec_set.rb:150:in `each'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/spec_set.rb:109:in `select'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/spec_set.rb:109:in `missing_specs'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/definition.rb:205:in `missing_specs'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/definition.rb:209:in `missing_specs?'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/installer.rb:281:in `resolve_if_needed'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/installer.rb:83:in `block in run'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/process_lock.rb:12:in `block in lock'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/process_lock.rb:9:in `open'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/process_lock.rb:9:in `lock'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/installer.rb:72:in `run'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/installer.rb:24:in `install'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/cli/install.rb:60:in `run'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/cli.rb:260:in `block in install'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/settings.rb:131:in `temporary'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/cli.rb:259:in `install'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/cli.rb:31:in `dispatch'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/cli.rb:25:in `start'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/exe/bundle:49:in `block in <top (required)>'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/lib/bundler/friendly_errors.rb:128:in `with_friendly_errors'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-3.0.0/exe/bundle:37:in `<top (required)>'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/bin/bundle:23:in `load'
         /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/bin/bundle:23:in `<main>'
       ```

       ## Environment

       ```
       Bundler       3.0.0
         Platforms   ruby, x86-mswin32
       Ruby          3.0.2p107 (2021-07-07 revision 0db68f023372b634603c74fca94588b457be084c) [x86_64-linux]
         Full Path   /opt/hostedtoolcache/Ruby/3.0.2/x64/bin/ruby
         Config Dir  /opt/hostedtoolcache/Ruby/3.0.2/x64/etc
       RubyGems      3.2.24
         Gem Home    /home/runner/work/rubygems/rubygems/bundler/tmp/1/bundled_app/.bundle/ruby/3.0.0
         Gem Path    /home/runner/work/rubygems/rubygems/bundler/tmp/1/bundled_app/.bundle/ruby/3.0.0
         User Home   /home/runner/work/rubygems/rubygems/bundler/tmp/1/home
         User Path   /home/runner/work/rubygems/rubygems/bundler/tmp/1/home/.local/share/gem/ruby/3.0.0
         Bin Dir     /home/runner/work/rubygems/rubygems/bundler/tmp/1/bundled_app/.bundle/ruby/3.0.0/bin
       OpenSSL       
         Compiled    OpenSSL 1.1.1f  31 Mar 2020
         Loaded      OpenSSL 1.1.1f  31 Mar 2020
         Cert File   /usr/lib/ssl/cert.pem
         Cert Dir    /usr/lib/ssl/certs
       Tools         
         Git         2.32.0
         RVM         not installed
         rbenv       not installed
         chruby      not installed
       ```

       ## Bundler Build Metadata

       ```
       Built At          2021-07-29
       Git SHA           5c0ed67fd1
       Released Version  true
       ```

       ## Bundler settings

       ```
       force_ruby_platform
         Set for the current user (/home/runner/work/rubygems/rubygems/bundler/tmp/1/home/.bundle/config): true
       spec_run
         Set via BUNDLE_SPEC_RUN: "true"
       ```

       ## Gemfile

       ### Gemfile

       ```ruby
       source "file:///home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/remote1"
       gemspec
       ```

       ### Gemfile.lock

       ```
       PATH
         remote: .
         specs:
           foo (1.0)
             rack

       GEM
         remote: file:///home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/remote1/
         specs:
           rack (1.0.0)

       PLATFORMS
         x86_64-linux

       DEPENDENCIES
         foo!

       BUNDLED WITH
          3.0.0
       ```

       ## Gemspecs

       ### foo.gemspec

       ```ruby
       # -*- encoding: utf-8 -*-
       # stub: foo 1.0 ruby lib

       Gem::Specification.new do |s|
         s.name = "foo".freeze
         s.version = "1.0"

         s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
         s.require_paths = ["lib".freeze]
         s.authors = ["no one".freeze]
         s.date = "2021-07-29"
         s.description = "This is a completely fake gem, for testing purposes.".freeze
         s.email = "foo@bar.baz".freeze
         s.files = ["foo.gemspec".freeze, "lib/foo.rb".freeze, "lib/foo/source.rb".freeze]
         s.homepage = "http://example.com".freeze
         s.licenses = ["MIT".freeze]
         s.rubygems_version = "3.2.24".freeze
         s.summary = "This is just a fake gem for testing".freeze

         if s.respond_to? :specification_version then
           s.specification_version = 4
         end

         if s.respond_to? :add_runtime_dependency then
           s.add_runtime_dependency(%q<rack>.freeze, [">= 0"])
         else
           s.add_dependency(%q<rack>.freeze, [">= 0"])
         end
       end
       ```

       --- TEMPLATE END ----------------------------------------------------------------

       Unfortunately, an unexpected error occurred, and Bundler cannot continue.

       First, try this link to see if there are any existing issue reports for this error:
       https://github.com/rubygems/rubygems/search?q=undefined+method+%60identifier%27+for+%23%3CGem++Specification+0x000055983c62e3f8+%40extension_dir%3Dnil%2C+%40full_gem_path%3Dnil%2C+%40gem_dir%3Dnil%2C+%40ignored%3Dnil%2C+%40bin_dir%3Dnil%2C+%40cache_dir%3Dnil%2C+%40cache_file%3Dnil%2C+%40doc_dir%3Dnil%2C+%40ri_dir%3Dnil%2C+%40spec_dir%3Dnil%2C+%40spec_file%3Dnil%2C+%40gems_dir%3Dnil%2C+%40base_dir%3Dnil%2C+%40loaded%3Dfalse%2C+%40activated%3Dfalse%2C+%40loaded_from%3D%22%2Fhome%2Frunner%2Fwork%2Frubygems%2Frubygems%2Fbundler%2Ftmp%2F1%2Fbundled_app%2Ffoo.gemspec%22%2C+%40original_platform%3Dnil%2C+%40installed_by_version%3Dnil%2C+%40autorequire%3Dnil%2C+%40date%3D2021-07-29+00+00+00+UTC%2C+%40description%3D%22This+is+a+completely+fake+gem%2C+for+testing+purposes.%22%2C+%40email%3D%22foo%40bar.baz%22%2C+%40homepage%3D%22http+%2F%2Fexample.com%22%2C+%40name%3D%22foo%22%2C+%40post_install_message%3Dnil%2C+%40signing_key%3Dnil%2C+%40summary%3D%22This+is+just+a+fake+gem+for+testing%22%2C+%40version%3D%23%3CGem++Version+%221.0%22%3E%2C+%40authors%3D%5B%22no+one%22%5D%2C+%40bindir%3D%22bin%22%2C+%40cert_chain%3D%5B%5D%2C+%40dependencies%3D%5B%3CGem++Dependency+type%3D+runtime+name%3D%22rack%22+requirements%3D%22%3E%3D+0%22%3E%5D%2C+%40executables%3D%5B%5D%2C+%40extensions%3D%5B%5D%2C+%40extra_rdoc_files%3D%5B%5D%2C+%40files%3D%5B%22foo.gemspec%22%2C+%22lib%2Ffoo.rb%22%2C+%22lib%2Ffoo%2Fsource.rb%22%5D%2C+%40licenses%3D%5B%22MIT%22%5D%2C+%40metadata%3D%7B%7D%2C+%40platform%3D%22ruby%22%2C+%40rdoc_options%3D%5B%5D%2C+%40require_paths%3D%5B%22lib%22%5D%2C+%40required_ruby_version%3D%23%3CGem++Requirement+0x000055983c62f870+%40requirements%3D%5B%5B%22%3E%3D%22%2C+%23%3CGem++Version+%220%22%3E%5D%5D%3E%2C+%40required_rubygems_version%3D%23%3CGem++Requirement+0x000055983c62f528+%40requirements%3D%5B%5B%22%3E%3D%22%2C+%23%3CGem++Version+%220%22%3E%5D%5D%3E%2C+%40requirements%3D%5B%5D%2C+%40rubygems_version%3D%223.2.24%22%2C+%40specification_version%3D4%2C+%40test_files%3D%5B%5D%2C+%40new_platform%3D%22ruby%22%2C+%40full_name%3D%22foo-1.0%22%2C+%40source%3D%23%3CBundler++Source++Gemspec+0x1680+source+at+%60.%60%3E+foo-1.0%3E&type=Issues

       If there aren't any reports for this error yet, please copy and paste the report template above into a new issue. Don't forget to anonymize any private data! The new issue form is located at:
       https://github.com/rubygems/rubygems/issues/new?labels=Bundler&template=bundler-related-issue.md
       ----------------------------------------------------------------------
     # ./spec/support/helpers.rb:208:in `sys_exec'
     # ./spec/support/helpers.rb:125:in `bundle'
     # ./spec/runtime/platform_spec.rb:275:in `block (3 levels) in <top (required)>'
     # ./spec/support/helpers.rb:462:in `block (2 levels) in simulate_windows'
     # ./spec/support/helpers.rb:468:in `simulate_bundler_version_when_missing_prerelease_default_gem_activation'
     # ./spec/support/helpers.rb:461:in `block in simulate_windows'
     # ./spec/support/helpers.rb:445:in `simulate_platform'
     # ./spec/support/helpers.rb:460:in `simulate_windows'
     # ./spec/runtime/platform_spec.rb:273:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:99:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:99:in `block (3 levels) in <top (required)>'
     # ./spec/support/helpers.rb:352:in `block in with_gem_path_as'
     # ./spec/support/helpers.rb:366:in `without_env_side_effects'
     # ./spec/support/helpers.rb:348:in `with_gem_path_as'
     # ./spec/spec_helper.rb:98:in `block (2 levels) in <top (required)>'
     # ./spec/support/rubygems_ext.rb:99:in `load'
     # ./spec/support/rubygems_ext.rb:99:in `gem_load_and_activate'
     # ./spec/support/rubygems_ext.rb:18:in `gem_load'

Finished in 19 minutes 40 seconds (files took 0 seconds to load)
3047 examples, 1 failure, 49 pending

Failed examples:

rspec ./spec/runtime/platform_spec.rb:262 # [TEST_ENV_NUMBER=1] Bundler.setup with multi platform stuff allows specifying only-ruby-platform on windows with gemspec dependency
```

The `SpecSet#missing_specs` method in that backtrace will be introduced with the next release, so there's chances that this indicates a new regression.

## What is your fix for the problem, implemented in this PR?

Not sure whether the underlying issue represents a real end user issue, but we can avoid this particular error by not sorting materialized specs at all in this case, since it's unnecessary.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
