### PR TITLE
Allow shipping deprecations with patch releases

### DIFF
--- a/.changelog.yml
+++ b/.changelog.yml
@@ -21,6 +21,7 @@ changelog_label_mapping:
 
 patch_level_labels:
   - "rubygems: security fix"
+  - "rubygems: deprecation"
   - "rubygems: enhancement"
   - "rubygems: bug fix"
   - "rubygems: performance"
@@ -28,5 +29,4 @@ patch_level_labels:
   - "rubygems: backport"
 
 minor_level_labels:
-  - "rubygems: deprecation"
   - "rubygems: feature"

--- a/bundler/.changelog.yml
+++ b/bundler/.changelog.yml
@@ -19,6 +19,7 @@ changelog_label_mapping:
 
 patch_level_labels:
   - "bundler: security fix"
+  - "bundler: deprecation"
   - "bundler: enhancement"
   - "bundler: bug fix"
   - "bundler: performance"
@@ -26,5 +27,4 @@ patch_level_labels:
   - "bundler: backport"
 
 minor_level_labels:
-  - "bundler: deprecation"
   - "bundler: feature"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I want to make sure we ship them as soon as possible, so that people have more time to fix them. In particular, I want to ship https://github.com/rubygems/rubygems/pull/4779 now.

## What is your fix for the problem, implemented in this PR?

Allow deprecation PRs to be shipped with patch releases.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
