### PR TITLE
Changelogs for rubygems 3.2.25 and bundler 2.2.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# 3.2.25 / 2021-07-30
+
+## Enhancements:
+
+* Don't load the `base64` library since it's not used. Pull request #4785
+  by deivid-rodriguez
+* Don't load the `resolv` library since it's not used. Pull request #4784
+  by deivid-rodriguez
+* Lazily load `shellwords` library. Pull request #4783 by deivid-rodriguez
+* Check requirements class before loading marshalled requirements. Pull
+  request #4651 by nobu
+
+## Bug fixes:
+
+* Add missing `require 'fileutils'` in `Gem::ConfigFile`. Pull request
+  #4768 by ybiquitous
+
 # 3.2.24 / 2021-07-15
 
 ## Bug fixes:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,25 @@
+# 2.2.25 (July 30, 2021)
+
+## Deprecations:
+
+  - Deprecate Gemfile without an explicit global source [#4779](https://github.com/rubygems/rubygems/pull/4779)
+  - Deprecate `bundle cache --path` [#4496](https://github.com/rubygems/rubygems/pull/4496)
+
+## Enhancements:
+
+  - Give better errors when materialization fails [#4788](https://github.com/rubygems/rubygems/pull/4788)
+  - Lazily load `shellwords` library [#4786](https://github.com/rubygems/rubygems/pull/4786)
+  - Show original error and backtrace directly on `bundle install` errors instead of a more brittle `gem install` hint [#4778](https://github.com/rubygems/rubygems/pull/4778)
+  - Remove LoadError message in regards to requiring a relative file [#4772](https://github.com/rubygems/rubygems/pull/4772)
+
+## Bug fixes:
+
+  - Fix `BUNDLE_USER_CONFIG` no longer respected as config location [#4797](https://github.com/rubygems/rubygems/pull/4797)
+  - Fix `--standalone` installation of default gems [#4782](https://github.com/rubygems/rubygems/pull/4782)
+  - Fix `--quiet` flag not printing warnings [#4781](https://github.com/rubygems/rubygems/pull/4781)
+  - Fix bundler binstub version selection [#4775](https://github.com/rubygems/rubygems/pull/4775)
+  - Fix interrupt handling in Bundler workers [#4767](https://github.com/rubygems/rubygems/pull/4767)
+
 # 2.2.24 (July 15, 2021)
 
 ## Bug fixes:


### PR DESCRIPTION
Cherry-picking changelogs from future rubygems 3.2.25 and bundler 2.2.25 into master.