### PR TITLE
Fix bundler hitting the network in some cases where not allowed

### DIFF
--- a/bundler/lib/bundler/cli/check.rb
+++ b/bundler/lib/bundler/cli/check.rb
@@ -15,7 +15,7 @@ module Bundler
       definition.validate_runtime!
 
       begin
-        definition.resolve_only_locally!
+        definition.resolve_with_cache!
         not_installed = definition.missing_specs
       rescue GemNotFound, VersionConflict
         Bundler.ui.error "Bundler can't satisfy your Gemfile's dependencies."

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -512,7 +512,7 @@ module Bundler
     end
 
     def precompute_source_requirements_for_indirect_dependencies?
-      sources.non_global_rubygems_sources.all?(&:dependency_api_available?) && !sources.aggregate_global_source?
+      @remote && sources.non_global_rubygems_sources.all?(&:dependency_api_available?) && !sources.aggregate_global_source?
     end
 
     def current_ruby_platform_locked?

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -166,12 +166,6 @@ module Bundler
       @multisource_allowed
     end
 
-    def resolve_only_locally!
-      @remote = false
-      sources.local_only!
-      resolve
-    end
-
     def resolve_with_cache!
       sources.cached!
       resolve

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -273,11 +273,7 @@ module Bundler
           specs = source.specs.search(name)
           versions_with_platforms = specs.map {|s| [s.version, s.platform] }
           message = String.new("Could not find gem '#{SharedHelpers.pretty_dependency(requirement)}' in #{source}#{cache_message}.\n")
-          message << if versions_with_platforms.any?
-            "The source contains the following versions of '#{name}': #{formatted_versions_with_platforms(versions_with_platforms)}"
-          else
-            "The source does not contain any versions of '#{name}'"
-          end
+          message << "The source contains the following versions of '#{name}': #{formatted_versions_with_platforms(versions_with_platforms)}" if versions_with_platforms.any?
         else
           message = "Could not find gem '#{SharedHelpers.pretty_dependency(requirement)}' in any of the gem sources " \
             "listed in your Gemfile#{cache_message}."

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -255,12 +255,6 @@ module Bundler
         next if name == "bundler"
         next unless search_for(requirement).empty?
 
-        cache_message = begin
-                            " or in gems cached in #{Bundler.settings.app_cache_path}" if Bundler.app_cache.exist?
-                          rescue GemfileNotFound
-                            nil
-                          end
-
         if (base = @base[name]) && !base.empty?
           version = base.first.version
           message = "You have requested:\n" \
@@ -273,6 +267,11 @@ module Bundler
           source = source_for(name)
           specs = source.specs.search(name)
           versions_with_platforms = specs.map {|s| [s.version, s.platform] }
+          cache_message = begin
+                              " or in gems cached in #{Bundler.settings.app_cache_path}" if Bundler.app_cache.exist?
+                            rescue GemfileNotFound
+                              nil
+                            end
           message = String.new("Could not find gem '#{SharedHelpers.pretty_dependency(requirement)}' in #{source}#{cache_message}.\n")
           message << "The source contains the following versions of '#{name}': #{formatted_versions_with_platforms(versions_with_platforms)}" if versions_with_platforms.any?
         end

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -269,14 +269,12 @@ module Bundler
             "Try running `bundle update #{name}`\n\n" \
             "If you are updating multiple gems in your Gemfile at once,\n" \
             "try passing them all to `bundle update`"
-        elsif source = @source_requirements[name]
+        else
+          source = source_for(name)
           specs = source.specs.search(name)
           versions_with_platforms = specs.map {|s| [s.version, s.platform] }
           message = String.new("Could not find gem '#{SharedHelpers.pretty_dependency(requirement)}' in #{source}#{cache_message}.\n")
           message << "The source contains the following versions of '#{name}': #{formatted_versions_with_platforms(versions_with_platforms)}" if versions_with_platforms.any?
-        else
-          message = "Could not find gem '#{SharedHelpers.pretty_dependency(requirement)}' in any of the gem sources " \
-            "listed in your Gemfile#{cache_message}."
         end
         raise GemNotFound, message
       end

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -272,7 +272,7 @@ module Bundler
                             rescue GemfileNotFound
                               nil
                             end
-          message = String.new("Could not find gem '#{SharedHelpers.pretty_dependency(requirement)}' in #{source}#{cache_message}.\n")
+          message = String.new("Could not find gem '#{SharedHelpers.pretty_dependency(requirement)}' in #{source.to_err}#{cache_message}.\n")
           message << "The source contains the following versions of '#{name}': #{formatted_versions_with_platforms(versions_with_platforms)}" if versions_with_platforms.any?
         end
         raise GemNotFound, message
@@ -371,7 +371,7 @@ module Bundler
             o << if metadata_requirement
               "is not available in #{relevant_source}"
             else
-              "in #{relevant_source}.\n"
+              "in #{relevant_source.to_err}.\n"
             end
           end
         end,

--- a/bundler/lib/bundler/source.rb
+++ b/bundler/lib/bundler/source.rb
@@ -67,6 +67,10 @@ module Bundler
       "#<#{self.class}:0x#{object_id} #{self}>"
     end
 
+    def to_err
+      to_s
+    end
+
     def path?
       instance_of?(Bundler::Source::Path)
     end

--- a/bundler/lib/bundler/source.rb
+++ b/bundler/lib/bundler/source.rb
@@ -36,8 +36,6 @@ module Bundler
 
     def local!; end
 
-    def local_only!; end
-
     def cached!; end
 
     def remote!; end

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -96,11 +96,22 @@ module Bundler
         out << "  specs:\n"
       end
 
+      def to_err
+        if remotes.empty?
+          "locally installed gems"
+        elsif @allow_remote
+          "rubygems repository #{remote_names} or installed locally"
+        elsif @allow_cached
+          "cached gems from rubygems repository #{remote_names} or installed locally"
+        else
+          "locally installed gems"
+        end
+      end
+
       def to_s
         if remotes.empty?
           "locally installed gems"
         else
-          remote_names = remotes.map(&:to_s).join(", ")
           "rubygems repository #{remote_names} or installed locally"
         end
       end
@@ -318,6 +329,10 @@ module Bundler
       end
 
       protected
+
+      def remote_names
+        remotes.map(&:to_s).join(", ")
+      end
 
       def credless_remotes
         remotes.map(&method(:suppress_configured_credentials))

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -50,6 +50,7 @@ module Bundler
         return if @allow_cached
 
         @specs = nil
+        @allow_local = true
         @allow_cached = true
       end
 

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -26,12 +26,6 @@ module Bundler
         Array(options["remotes"]).reverse_each {|r| add_remote(r) }
       end
 
-      def local_only!
-        @specs = nil
-        @allow_local = true
-        @allow_remote = false
-      end
-
       def local!
         return if @allow_local
 

--- a/bundler/lib/bundler/source/rubygems_aggregate.rb
+++ b/bundler/lib/bundler/source/rubygems_aggregate.rb
@@ -16,6 +16,10 @@ module Bundler
         @index
       end
 
+      def to_err
+        to_s
+      end
+
       def to_s
         "any of the sources"
       end

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -136,10 +136,6 @@ module Bundler
       different_sources?(lock_sources, replacement_sources)
     end
 
-    def local_only!
-      all_sources.each(&:local_only!)
-    end
-
     def cached!
       all_sources.each(&:cached!)
     end

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -836,7 +836,7 @@ RSpec.describe "bundle exec" do
       let(:exit_code) { Bundler::GemNotFound.new.status_code }
       let(:expected) { "" }
       let(:expected_err) { <<-EOS.strip }
-Could not find gem 'rack (= 2)' in rubygems repository #{file_uri_for(gem_repo1)}/ or installed locally.
+Could not find gem 'rack (= 2)' in locally installed gems.
 The source contains the following versions of 'rack': 0.9.1, 1.0.0
 Run `bundle install` to install missing gems.
       EOS
@@ -863,7 +863,7 @@ Run `bundle install` to install missing gems.
       let(:exit_code) { Bundler::GemNotFound.new.status_code }
       let(:expected) { "" }
       let(:expected_err) { <<-EOS.strip }
-Could not find gem 'rack (= 2)' in rubygems repository #{file_uri_for(gem_repo1)}/ or installed locally.
+Could not find gem 'rack (= 2)' in locally installed gems.
 The source contains the following versions of 'rack': 1.0.0
 Run `bundle install` to install missing gems.
       EOS

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -759,4 +759,22 @@ RSpec.describe "bundle install with gem sources" do
       )
     end
   end
+
+  context "with --local flag" do
+    before do
+      system_gems "rack-1.0.0", :path => default_bundle_path
+    end
+
+    it "respects installed gems without fetching any remote sources" do
+      install_gemfile <<-G, :local => true
+        source "#{file_uri_for(gem_repo1)}"
+
+        source "https://not-existing-source" do
+          gem "rack"
+        end
+      G
+
+      expect(last_command).to be_success
+    end
+  end
 end

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "bundle lock" do
   it "does not fetch remote specs when using the --local option" do
     bundle "lock --update --local", :raise_on_error => false
 
-    expect(err).to match(/installed locally/)
+    expect(err).to match(/locally installed gems/)
   end
 
   it "works with --gemfile flag" do

--- a/bundler/spec/commands/post_bundle_message_spec.rb
+++ b/bundler/spec/commands/post_bundle_message_spec.rb
@@ -121,7 +121,6 @@ RSpec.describe "post bundle message" do
         G
         expect(err).to include <<-EOS.strip
 Could not find gem 'not-a-gem' in rubygems repository #{file_uri_for(gem_repo1)}/ or installed locally.
-The source does not contain any versions of 'not-a-gem'
         EOS
       end
 

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -1280,7 +1280,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
     expect(out).to include("Using example 0.1.0")
   end
 
-  it "fails inmmediately with a helpful error when a non retriable network error happens while resolving sources" do
+  it "fails inmmediately with a helpful error when a rubygems source does not exist and bundler/setup is required" do
     gemfile <<-G
       source "https://gem.repo1"
 
@@ -1294,6 +1294,21 @@ RSpec.describe "bundle install with gems on multiple sources" do
         require 'bundler/setup'
       R
     end
+
+    expect(last_command).to be_failure
+    expect(err).to include("Could not find gem 'example' in locally installed gems.")
+  end
+
+  it "fails inmmediately with a helpful error when a non retriable network error happens while resolving sources" do
+    gemfile <<-G
+      source "https://gem.repo1"
+
+      source "https://gem.repo4" do
+        gem "example"
+      end
+    G
+
+    bundle "install", :artifice => nil, :raise_on_error => false
 
     expect(last_command).to be_failure
     expect(err).to include("Could not reach host gem.repo4. Check your network connection and try again.")

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -347,7 +347,6 @@ RSpec.describe "bundle install with gems on multiple sources" do
       it "fails" do
         bundle :install, :artifice => "compact_index", :raise_on_error => false
         expect(err).to include("Could not find gem 'private_gem_1' in rubygems repository https://gem.repo2/ or installed locally.")
-        expect(err).to include("The source does not contain any versions of 'private_gem_1'")
       end
     end
 

--- a/bundler/spec/support/indexes.rb
+++ b/bundler/spec/support/indexes.rb
@@ -17,7 +17,7 @@ module Spec
     def resolve(args = [])
       @platforms ||= ["ruby"]
       deps = []
-      default_source = instance_double("Bundler::Source::Rubygems", :specs => @index)
+      default_source = instance_double("Bundler::Source::Rubygems", :specs => @index, :to_err => "locally install gems")
       source_requirements = { :default => default_source }
       @deps.each do |d|
         source_requirements[d.name] = d.source = default_source

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1960,7 +1960,6 @@ class TestGem < Gem::TestCase
 
     expected = <<-EXPECTED
 Could not find gem 'a' in locally installed gems.
-The source does not contain any versions of 'a'
 You may need to `gem install -g` to install missing gems
 
     EXPECTED


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes running `bundle install --local` or requiring `bundler/setup` would hit the network.

## What is your fix for the problem, implemented in this PR?

Fix is, on one side, only resolve sources when we can hit the network otherwise it's not necessary because the only source to be considered is the "local source". In addition to that, allow "Definition#resolve_with_cache!` to also use locally installed gems, since this is what the `--local` flag uses for resolving.

Fixes #4799.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
