### PR TITLE
Fix a couple small typos in deprecation / error messages

### DIFF
--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -457,7 +457,7 @@ repo_name ||= user_name
     def implicit_global_source_warning
       Bundler::SharedHelpers.major_deprecation 2, "This Gemfile does not include an explicit global source. " \
         "Not using an explicit global source may result in a different lockfile being generated depending on " \
-        "the gems you have installed locally before bundler is run." \
+        "the gems you have installed locally before bundler is run. " \
         "Instead, define a global source in your Gemfile like this: source \"https://rubygems.org\"."
     end
 

--- a/bundler/lib/bundler/errors.rb
+++ b/bundler/lib/bundler/errors.rb
@@ -122,7 +122,7 @@ module Bundler
 
   class VirtualProtocolError < BundlerError
     def message
-      "There was an error relating to virtualization and file access." \
+      "There was an error relating to virtualization and file access. " \
       "It is likely that you need to grant access to or mount some file system correctly."
     end
 

--- a/bundler/spec/bundler/dsl_spec.rb
+++ b/bundler/spec/bundler/dsl_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe Bundler::Dsl do
 
         warning = "This Gemfile does not include an explicit global source. " \
           "Not using an explicit global source may result in a different lockfile being generated depending on " \
-          "the gems you have installed locally before bundler is run." \
+          "the gems you have installed locally before bundler is run. " \
           "Instead, define a global source in your Gemfile like this: source \"https://rubygems.org\"."
         expect(Bundler::SharedHelpers).to receive(:major_deprecation).with(2, warning)
 

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -336,7 +336,7 @@ RSpec.describe "bundle install with gem sources" do
 
       expect(err).to include("This Gemfile does not include an explicit global source. " \
         "Not using an explicit global source may result in a different lockfile being generated depending on " \
-        "the gems you have installed locally before bundler is run." \
+        "the gems you have installed locally before bundler is run. " \
         "Instead, define a global source in your Gemfile like this: source \"https://rubygems.org\".")
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Just typos I noticed from the "no explicit global source" deprecation. i.e. `[DEPRECATED] [...] installed locally before bundler is run.Instead, define a [...].`


## What is your fix for the problem, implemented in this PR?

Fixed typos.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
