### PR TITLE
Make `bundle exec` keep file descriptors by default

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -469,7 +469,7 @@ module Bundler
     map aliases_for("cache")
 
     desc "exec [OPTIONS]", "Run the command in context of the bundle"
-    method_option :keep_file_descriptors, :type => :boolean, :default => false
+    method_option :keep_file_descriptors, :type => :boolean, :default => true
     method_option :gemfile, :type => :string, :required => false
     long_desc <<-D
       Exec runs a command, providing it access to the gems in the bundle. While using

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -477,6 +477,10 @@ module Bundler
       into the system wide RubyGems repository.
     D
     def exec(*args)
+      if ARGV.include?("--no-keep-file-descriptors")
+        SharedHelpers.major_deprecation(2, "The `--no-keep-file-descriptors` has been deprecated. `bundle exec` no longer mess with your file descriptors. Close them in the exec'd script if you need to")
+      end
+
       require_relative "cli/exec"
       Exec.new(options, args).run
     end

--- a/bundler/lib/bundler/cli/exec.rb
+++ b/bundler/lib/bundler/cli/exec.rb
@@ -12,12 +12,7 @@ module Bundler
       @options = options
       @cmd = args.shift
       @args = args
-
-      if !Bundler.current_ruby.jruby?
-        @args << { :close_others => !options.keep_file_descriptors? }
-      elsif options.keep_file_descriptors?
-        Bundler.ui.warn "Ruby version #{RUBY_VERSION} defaults to keeping non-standard file descriptors on Kernel#exec."
-      end
+      @args << { :close_others => !options.keep_file_descriptors? } unless Bundler.current_ruby.jruby?
     end
 
     def run

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -92,6 +92,18 @@ RSpec.describe "major deprecations" do
     end
   end
 
+  describe "bundle exec --no-keep-file-descriptors" do
+    before do
+      bundle "exec --no-keep-file-descriptors -e 1", :raise_on_error => false
+    end
+
+    it "is deprecated", :bundler => "< 3" do
+      expect(deprecations).to include "The `--no-keep-file-descriptors` has been deprecated. `bundle exec` no longer mess with your file descriptors. Close them in the exec'd script if you need to"
+    end
+
+    pending "is removed and shows a helpful error message about it", :bundler => "3"
+  end
+
   describe "bundle update --quiet" do
     it "does not print any deprecations" do
       bundle :update, :quiet => true, :raise_on_error => false


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In my opinion, this should be the default, non-configurable, behaviour.
 
## What is your fix for the problem, implemented in this PR?

Change the default, and deprecated `--no-keep-file-descriptors`.

Closes #3254.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
