### PR TITLE
Fix bin/bundle path suggestion for local setup

### DIFF
--- a/bundler/doc/development/SETUP.md
+++ b/bundler/doc/development/SETUP.md
@@ -30,7 +30,7 @@ To work on Bundler, you'll probably want to do a couple of things:
 
 * Set up a shell alias to run Bundler from your clone, e.g. a Bash alias ([follow these instructions](https://www.moncefbelyamani.com/create-aliases-in-bash-profile-to-assign-shortcuts-for-common-terminal-commands/) for adding aliases to your `~/.bashrc` profile):
 
-        $ alias dbundle='/path/to/bundler/repo/bin/bundle'
+        $ alias dbundle='ruby /path/to/bundler/repo/spec/support/bundle.rb'
 
 ## Debugging with `pry`
 


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

In trying to test out #4805 locally, I was confused by how to reference my local version of the bundler executable. In https://github.com/rubygems/rubygems/commit/ecf7dc53d975f64ade0d36d99f2be52c8f5df7ab this moved to the spec directory.

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

This changes the hint to use an alias that will reference the right path. We also need to make the file executable again.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
