### PR TITLE
Fix `bundle gem` on path with spaces

### DIFF
--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -192,7 +192,8 @@ module Bundler
 
       if use_git
         Bundler.ui.info "Initializing git repo in #{target}"
-        `git init #{target}`
+        require "shellwords"
+        `git init #{target.to_s.shellescape}`
 
         config[:git_default_branch] = File.read("#{target}/.git/HEAD").split("/").last.chomp
       end

--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -185,7 +185,7 @@ module Bundler
         )
       end
 
-      if File.exist?(target) && !File.directory?(target)
+      if target.exist? && !target.directory?
         Bundler.ui.error "Couldn't create a new gem named `#{gem_name}` because there's an existing file named `#{gem_name}`."
         exit Bundler::BundlerError.all_errors[Bundler::GenericSystemCallError]
       end

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -35,37 +35,22 @@ RSpec.describe "bundle gem" do
   end
 
   describe "git repo initialization" do
-    shared_examples_for "a gem with an initial git repo" do
-      before do
-        bundle "gem #{gem_name} #{flags}"
-      end
-
-      it "generates a gem skeleton with a .git folder", :readline do
-        gem_skeleton_assertions
-        expect(bundled_app("#{gem_name}/.git")).to exist
-      end
+    it "generates a gem skeleton with a .git folder", :readline do
+      bundle "gem #{gem_name}"
+      gem_skeleton_assertions
+      expect(bundled_app("#{gem_name}/.git")).to exist
     end
 
-    context "when using the default" do
-      it_behaves_like "a gem with an initial git repo" do
-        let(:flags) { "" }
-      end
+    it "generates a gem skeleton with a .git folder when passing --git", :readline do
+      bundle "gem #{gem_name} --git"
+      gem_skeleton_assertions
+      expect(bundled_app("#{gem_name}/.git")).to exist
     end
 
-    context "when explicitly passing --git" do
-      it_behaves_like "a gem with an initial git repo" do
-        let(:flags) { "--git" }
-      end
-    end
-
-    context "when passing --no-git", :readline do
-      before do
-        bundle "gem #{gem_name} --no-git"
-      end
-      it "generates a gem skeleton without a .git folder" do
-        gem_skeleton_assertions
-        expect(bundled_app("#{gem_name}/.git")).not_to exist
-      end
+    it "generates a gem skeleton without a .git folder when passing --no-git", :readline do
+      bundle "gem #{gem_name} --no-git"
+      gem_skeleton_assertions
+      expect(bundled_app("#{gem_name}/.git")).not_to exist
     end
   end
 

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -52,6 +52,17 @@ RSpec.describe "bundle gem" do
       gem_skeleton_assertions
       expect(bundled_app("#{gem_name}/.git")).not_to exist
     end
+
+    context "on a path with spaces" do
+      before do
+        Dir.mkdir(bundled_app("path with spaces"))
+      end
+
+      it "properly initializes git repo", :readline do
+        bundle "gem #{gem_name}", :dir => bundled_app("path with spaces")
+        expect(bundled_app("path with spaces/#{gem_name}/.git")).to exist
+      end
+    end
   end
 
   shared_examples_for "--mit flag" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`bundler` would fail to initialize the fresh git repository of new gems when `bundle gem` is run inside a path with spaces.

## What is your fix for the problem, implemented in this PR?

Properly shellescape target folder.

Closes #4622.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
