### PR TITLE
Unkip binstub permissions spec on Windows

### DIFF
--- a/bundler/spec/commands/binstubs_spec.rb
+++ b/bundler/spec/commands/binstubs_spec.rb
@@ -287,8 +287,6 @@ RSpec.describe "bundle binstubs <gem>" do
     end
 
     it "sets correct permissions for binstubs" do
-      skip "https://github.com/rubygems/rubygems/issues/3352" if Gem.win_platform?
-
       with_umask(0o002) do
         install_gemfile <<-G
           source "#{file_uri_for(gem_repo1)}"
@@ -297,7 +295,7 @@ RSpec.describe "bundle binstubs <gem>" do
 
         bundle "binstubs rack"
         binary = bundled_app("bin/rackup")
-        expect(File.stat(binary).mode.to_s(8)).to eq("100775")
+        expect(File.stat(binary).mode.to_s(8)).to eq(Gem.win_platform? ? "100644" : "100775")
       end
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

One skipped spec on Windows.

## What is your fix for the problem, implemented in this PR?

Expect the right permissions on Windows, which is different from other platforms since Windows doesn't have the executable bit.

Closes #3352.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
