### PR TITLE
Enable parallel installation on Windows by default

### DIFF
--- a/bundler/lib/bundler/installer.rb
+++ b/bundler/lib/bundler/installer.rb
@@ -219,9 +219,6 @@ module Bundler
         return jobs
       end
 
-      # Parallelization has some issues on Windows, so it's not yet the default
-      return 1 if Gem.win_platform?
-
       Bundler.settings.processor_count
     end
 

--- a/bundler/lib/bundler/man/bundle-add.1
+++ b/bundler/lib/bundler/man/bundle-add.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-ADD" "1" "June 2021" "" ""
+.TH "BUNDLE\-ADD" "1" "August 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-add\fR \- Add gem to the Gemfile and run bundle install

--- a/bundler/lib/bundler/man/bundle-binstubs.1
+++ b/bundler/lib/bundler/man/bundle-binstubs.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-BINSTUBS" "1" "June 2021" "" ""
+.TH "BUNDLE\-BINSTUBS" "1" "August 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-binstubs\fR \- Install the binstubs of the listed gems

--- a/bundler/lib/bundler/man/bundle-cache.1
+++ b/bundler/lib/bundler/man/bundle-cache.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CACHE" "1" "June 2021" "" ""
+.TH "BUNDLE\-CACHE" "1" "August 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-cache\fR \- Package your needed \fB\.gem\fR files into your application

--- a/bundler/lib/bundler/man/bundle-check.1
+++ b/bundler/lib/bundler/man/bundle-check.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CHECK" "1" "June 2021" "" ""
+.TH "BUNDLE\-CHECK" "1" "August 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-check\fR \- Verifies if dependencies are satisfied by installed gems

--- a/bundler/lib/bundler/man/bundle-clean.1
+++ b/bundler/lib/bundler/man/bundle-clean.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CLEAN" "1" "June 2021" "" ""
+.TH "BUNDLE\-CLEAN" "1" "August 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-clean\fR \- Cleans up unused gems in your bundler directory

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CONFIG" "1" "June 2021" "" ""
+.TH "BUNDLE\-CONFIG" "1" "August 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-config\fR \- Set bundler configuration options
@@ -211,7 +211,7 @@ The following is a list of all configuration keys and their purpose\. You can le
 \fBinit_gems_rb\fR (\fBBUNDLE_INIT_GEMS_RB\fR): Generate a \fBgems\.rb\fR instead of a \fBGemfile\fR when running \fBbundle init\fR\.
 .
 .IP "\(bu" 4
-\fBjobs\fR (\fBBUNDLE_JOBS\fR): The number of gems Bundler can install in parallel\. Defaults to 1 on Windows, and to the the number of processors on other platforms\.
+\fBjobs\fR (\fBBUNDLE_JOBS\fR): The number of gems Bundler can install in parallel\. Defaults to the number of available processors\.
 .
 .IP "\(bu" 4
 \fBno_install\fR (\fBBUNDLE_NO_INSTALL\fR): Whether \fBbundle package\fR should skip installing gems\.

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -208,8 +208,8 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
 * `init_gems_rb` (`BUNDLE_INIT_GEMS_RB`):
    Generate a `gems.rb` instead of a `Gemfile` when running `bundle init`.
 * `jobs` (`BUNDLE_JOBS`):
-   The number of gems Bundler can install in parallel. Defaults to 1 on Windows,
-   and to the the number of processors on other platforms.
+   The number of gems Bundler can install in parallel. Defaults to the number of
+   available processors.
 * `no_install` (`BUNDLE_NO_INSTALL`):
    Whether `bundle package` should skip installing gems.
 * `no_prune` (`BUNDLE_NO_PRUNE`):

--- a/bundler/lib/bundler/man/bundle-doctor.1
+++ b/bundler/lib/bundler/man/bundle-doctor.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-DOCTOR" "1" "June 2021" "" ""
+.TH "BUNDLE\-DOCTOR" "1" "August 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-doctor\fR \- Checks the bundle for common problems

--- a/bundler/lib/bundler/man/bundle-exec.1
+++ b/bundler/lib/bundler/man/bundle-exec.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-EXEC" "1" "June 2021" "" ""
+.TH "BUNDLE\-EXEC" "1" "August 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-exec\fR \- Execute a command in the context of the bundle

--- a/bundler/lib/bundler/man/bundle-gem.1
+++ b/bundler/lib/bundler/man/bundle-gem.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-GEM" "1" "June 2021" "" ""
+.TH "BUNDLE\-GEM" "1" "August 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-gem\fR \- Generate a project skeleton for creating a rubygem

--- a/bundler/lib/bundler/man/bundle-info.1
+++ b/bundler/lib/bundler/man/bundle-info.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INFO" "1" "June 2021" "" ""
+.TH "BUNDLE\-INFO" "1" "August 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-info\fR \- Show information for the given gem in your bundle

--- a/bundler/lib/bundler/man/bundle-init.1
+++ b/bundler/lib/bundler/man/bundle-init.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INIT" "1" "June 2021" "" ""
+.TH "BUNDLE\-INIT" "1" "August 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-init\fR \- Generates a Gemfile into the current working directory

--- a/bundler/lib/bundler/man/bundle-inject.1
+++ b/bundler/lib/bundler/man/bundle-inject.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INJECT" "1" "June 2021" "" ""
+.TH "BUNDLE\-INJECT" "1" "August 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-inject\fR \- Add named gem(s) with version requirements to Gemfile

--- a/bundler/lib/bundler/man/bundle-install.1
+++ b/bundler/lib/bundler/man/bundle-install.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INSTALL" "1" "June 2021" "" ""
+.TH "BUNDLE\-INSTALL" "1" "August 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-install\fR \- Install the dependencies specified in your Gemfile
@@ -63,7 +63,7 @@ The location of the Gemfile(5) which Bundler should use\. This defaults to a Gem
 .
 .TP
 \fB\-\-jobs=[<number>]\fR, \fB\-j[<number>]\fR
-The maximum number of parallel download and install jobs\. The default is \fB1\fR\.
+The maximum number of parallel download and install jobs\. The default is the number of available processors\.
 .
 .TP
 \fB\-\-local\fR

--- a/bundler/lib/bundler/man/bundle-install.1.ronn
+++ b/bundler/lib/bundler/man/bundle-install.1.ronn
@@ -100,8 +100,8 @@ automatically and that requires `bundler` to silently remember them. Since
   to this location.
 
 * `--jobs=[<number>]`, `-j[<number>]`:
-  The maximum number of parallel download and install jobs. The default
-  is `1`.
+  The maximum number of parallel download and install jobs. The default is the
+  number of available processors.
 
 * `--local`:
   Do not attempt to connect to `rubygems.org`. Instead, Bundler will use the

--- a/bundler/lib/bundler/man/bundle-list.1
+++ b/bundler/lib/bundler/man/bundle-list.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-LIST" "1" "June 2021" "" ""
+.TH "BUNDLE\-LIST" "1" "August 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-list\fR \- List all the gems in the bundle

--- a/bundler/lib/bundler/man/bundle-lock.1
+++ b/bundler/lib/bundler/man/bundle-lock.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-LOCK" "1" "June 2021" "" ""
+.TH "BUNDLE\-LOCK" "1" "August 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-lock\fR \- Creates / Updates a lockfile without installing

--- a/bundler/lib/bundler/man/bundle-open.1
+++ b/bundler/lib/bundler/man/bundle-open.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-OPEN" "1" "June 2021" "" ""
+.TH "BUNDLE\-OPEN" "1" "August 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-open\fR \- Opens the source directory for a gem in your bundle

--- a/bundler/lib/bundler/man/bundle-outdated.1
+++ b/bundler/lib/bundler/man/bundle-outdated.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-OUTDATED" "1" "June 2021" "" ""
+.TH "BUNDLE\-OUTDATED" "1" "August 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-outdated\fR \- List installed gems with newer versions available

--- a/bundler/lib/bundler/man/bundle-platform.1
+++ b/bundler/lib/bundler/man/bundle-platform.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-PLATFORM" "1" "June 2021" "" ""
+.TH "BUNDLE\-PLATFORM" "1" "August 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-platform\fR \- Displays platform compatibility information

--- a/bundler/lib/bundler/man/bundle-pristine.1
+++ b/bundler/lib/bundler/man/bundle-pristine.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-PRISTINE" "1" "June 2021" "" ""
+.TH "BUNDLE\-PRISTINE" "1" "August 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-pristine\fR \- Restores installed gems to their pristine condition

--- a/bundler/lib/bundler/man/bundle-remove.1
+++ b/bundler/lib/bundler/man/bundle-remove.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-REMOVE" "1" "June 2021" "" ""
+.TH "BUNDLE\-REMOVE" "1" "August 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-remove\fR \- Removes gems from the Gemfile

--- a/bundler/lib/bundler/man/bundle-show.1
+++ b/bundler/lib/bundler/man/bundle-show.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-SHOW" "1" "June 2021" "" ""
+.TH "BUNDLE\-SHOW" "1" "August 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-show\fR \- Shows all the gems in your bundle, or the path to a gem

--- a/bundler/lib/bundler/man/bundle-update.1
+++ b/bundler/lib/bundler/man/bundle-update.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-UPDATE" "1" "June 2021" "" ""
+.TH "BUNDLE\-UPDATE" "1" "August 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-update\fR \- Update your gems to the latest available versions
@@ -47,7 +47,7 @@ Fall back to using the single\-file index of all gems\.
 .
 .TP
 \fB\-\-jobs=[<number>]\fR, \fB\-j[<number>]\fR
-Specify the number of jobs to run in parallel\. The default is \fB1\fR\.
+Specify the number of jobs to run in parallel\. The default is the number of available processors\.
 .
 .TP
 \fB\-\-retry=[<number>]\fR

--- a/bundler/lib/bundler/man/bundle-update.1.ronn
+++ b/bundler/lib/bundler/man/bundle-update.1.ronn
@@ -56,7 +56,8 @@ gem.
   Fall back to using the single-file index of all gems.
 
 * `--jobs=[<number>]`, `-j[<number>]`:
-  Specify the number of jobs to run in parallel. The default is `1`.
+  Specify the number of jobs to run in parallel. The default is the number of
+  available processors.
 
 * `--retry=[<number>]`:
   Retry failed network or git requests for <number> times.

--- a/bundler/lib/bundler/man/bundle-viz.1
+++ b/bundler/lib/bundler/man/bundle-viz.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-VIZ" "1" "June 2021" "" ""
+.TH "BUNDLE\-VIZ" "1" "August 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\-viz\fR \- Generates a visual dependency graph for your Gemfile

--- a/bundler/lib/bundler/man/bundle.1
+++ b/bundler/lib/bundler/man/bundle.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE" "1" "June 2021" "" ""
+.TH "BUNDLE" "1" "August 2021" "" ""
 .
 .SH "NAME"
 \fBbundle\fR \- Ruby Dependency Management

--- a/bundler/lib/bundler/man/gemfile.5
+++ b/bundler/lib/bundler/man/gemfile.5
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GEMFILE" "5" "June 2021" "" ""
+.TH "GEMFILE" "5" "August 2021" "" ""
 .
 .SH "NAME"
 \fBGemfile\fR \- A format for describing gem dependencies for Ruby programs


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We never enabled parallel installation of gems on Windows by default because we kept getting random CI failures that seemed like something end users could also get.

However:

* I run this PR a few times and we got no CI flakies.
* We never got any reports about `bundle install --jobs <more_than_one>` misbehaving on Windows.

So it's possible that we might've fixed this at some point.

## What is your fix for the problem, implemented in this PR?

Enable parallel installation by default on Windows.

For now I will merge this but not yet release it. Once CI is confirmed to be stable I will release it.

Closes #3719.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
