### PR TITLE
Enhance the error handling for loading the `rubygems/defaults/operating_system` file

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -691,6 +691,7 @@ test/rubygems/test_kernel.rb
 test/rubygems/test_project_sanity.rb
 test/rubygems/test_remote_fetch_error.rb
 test/rubygems/test_require.rb
+test/rubygems/test_rubygems.rb
 test/rubygems/utilities.rb
 test/rubygems/wrong_key_cert.pem
 test/rubygems/wrong_key_cert_32.pem

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1339,7 +1339,12 @@ begin
 rescue LoadError
   # Ignored
 rescue Exception => e
-  raise e.class, "#{e.message}\nThis is not expected so please report this issue to your OS support and ask for help."
+  msg = "#{e.message}\n" \
+    "Loading the rubygems/defaults/operating_system.rb file caused an error. " \
+    "This file is owned by your OS, not by rubygems upstream. " \
+    "Please find out which OS package this file belongs to and follow the guidelines from your OS to report " \
+    "the problem and ask for help."
+  raise e.class, msg
 end
 
 begin

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1337,6 +1337,9 @@ begin
 
   require 'rubygems/defaults/operating_system'
 rescue LoadError
+  # Ignored
+rescue Exception => e
+  raise e.class, "#{e.message}\nThis is not expected so please report this issue to your OS support and ask for help."
 end
 
 begin

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1338,7 +1338,7 @@ begin
   require 'rubygems/defaults/operating_system'
 rescue LoadError
   # Ignored
-rescue Exception => e
+rescue StandardError => e
   msg = "#{e.message}\n" \
     "Loading the rubygems/defaults/operating_system.rb file caused an error. " \
     "This file is owned by your OS, not by rubygems upstream. " \

--- a/test/rubygems/test_rubygems.rb
+++ b/test/rubygems/test_rubygems.rb
@@ -7,6 +7,8 @@ class GemTest < Gem::TestCase
   end
 
   def test_operating_system_other_exceptions
+    pend "does not apply to truffleruby" if RUBY_ENGINE == 'truffleruby'
+
     path = util_install_operating_system_rb <<-RUBY
       intentional synt'ax error
     RUBY

--- a/test/rubygems/test_rubygems.rb
+++ b/test/rubygems/test_rubygems.rb
@@ -10,12 +10,12 @@ class GemTest < Gem::TestCase
     pend "does not apply to truffleruby" if RUBY_ENGINE == 'truffleruby'
 
     path = util_install_operating_system_rb <<-RUBY
-      intentional synt'ax error
+      intentionally_not_implemented_method
     RUBY
 
     output = Gem::Util.popen(*ruby_with_rubygems_and_fake_operating_system_in_load_path(path), '-e', "'require \"rubygems\"'", {:err => [:child, :out]}).strip
     assert !$?.success?
-    assert_includes output, "unterminated string meets end of file (SyntaxError)"
+    assert_includes output, "undefined local variable or method `intentionally_not_implemented_method'"
     assert_includes output, "Loading the rubygems/defaults/operating_system.rb file caused an error. " \
     "This file is owned by your OS, not by rubygems upstream. " \
     "Please find out which OS package this file belongs to and follow the guidelines from your OS to report " \

--- a/test/rubygems/test_rubygems.rb
+++ b/test/rubygems/test_rubygems.rb
@@ -15,7 +15,11 @@ class GemTest < Gem::TestCase
 
     output = Gem::Util.popen(*ruby_with_rubygems_and_fake_operating_system_in_load_path(path), '-e', "'require \"rubygems\"'", {:err => [:child, :out]}).strip
     assert !$?.success?
-    assert_includes output, "This is not expected so please report this issue to your OS support and ask for help"
+    assert_includes output, "unterminated string meets end of file (SyntaxError)"
+    assert_includes output, "Loading the rubygems/defaults/operating_system.rb file caused an error. " \
+    "This file is owned by your OS, not by rubygems upstream. " \
+    "Please find out which OS package this file belongs to and follow the guidelines from your OS to report " \
+    "the problem and ask for help."
   end
 
   private

--- a/test/rubygems/test_rubygems.rb
+++ b/test/rubygems/test_rubygems.rb
@@ -1,0 +1,38 @@
+require_relative 'helper'
+
+class GemTest < Gem::TestCase
+  def test_rubygems_normal_behaviour
+    _ = Gem::Util.popen(*ruby_with_rubygems_in_load_path, '-e', "'require \"rubygems\"'", {:err => [:child, :out]}).strip
+    assert $?.success?
+  end
+
+  def test_operating_system_other_exceptions
+    path = util_install_operating_system_rb <<-RUBY
+      intentional synt'ax error
+    RUBY
+
+    output = Gem::Util.popen(*ruby_with_rubygems_and_fake_operating_system_in_load_path(path), '-e', "'require \"rubygems\"'", {:err => [:child, :out]}).strip
+    assert !$?.success?
+    assert_includes output, "This is not expected so please report this issue to your OS support and ask for help"
+  end
+
+  private
+
+  def util_install_operating_system_rb(content)
+    dir_lib = Dir.mktmpdir("test_operating_system_lib", @tempdir)
+    dir_lib_arg = File.join dir_lib
+
+    dir_lib_rubygems_defaults_arg = File.join dir_lib_arg, "lib", "rubygems", "defaults"
+    FileUtils.mkdir_p dir_lib_rubygems_defaults_arg
+
+    operating_system_rb = File.join dir_lib_rubygems_defaults_arg, "operating_system.rb"
+
+    File.open(operating_system_rb, 'w') {|f| f.write content }
+
+    File.join dir_lib_arg, "lib"
+  end
+
+  def ruby_with_rubygems_and_fake_operating_system_in_load_path(operating_system_path)
+    [Gem.ruby, "-I", operating_system_path, "-I" , $LOAD_PATH.find{|p| p == File.dirname($LOADED_FEATURES.find{|f| f.end_with?("/rubygems.rb") }) }]
+  end
+end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Issue #4585 

> My current problem is that we keep getting issues that we can't really fix, because they happen inside operating_system.rb, which is not under our control, but on the OS packager's side.
>
> Let's at least rescue any errors inside operating_system.rb and display a message making it clear where the problem is and where it should be reported, as suggested by @simi at #3831 (comment), so that at least we can save people some time.

## What is your fix for the problem, implemented in this PR?

When loading `rubygems/defaults/operating_system`
- we want to keep it silent if the raised exception is a LoadError
- we want to print a message in other cases and ask users to report the issue to their OS support.

Ruby 3 comes with special error handling for loading `rubygems` and it will show a warning when LoadError exception is raised for requiring 'rubygem'.
Because of that, we decided to leave the LoadError scenario as it is.
Reference: https://github.com/ruby/ruby/blob/d1998d8767affe58be0bd09ec536dae9198a7fbd/gem_prelude.rb#L1-L5

Closes #4585.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
