### PR TITLE
Remove `RUBYGEMS_GEMDEPS` warning

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -73,14 +73,6 @@ module Bundler
       Bundler.ui = UI::Shell.new(options)
       Bundler.ui.level = "debug" if options["verbose"]
       unprinted_warnings.each {|w| Bundler.ui.warn(w) }
-
-      if ENV["RUBYGEMS_GEMDEPS"] && !ENV["RUBYGEMS_GEMDEPS"].empty?
-        Bundler.ui.warn(
-          "The RUBYGEMS_GEMDEPS environment variable is set. This enables RubyGems' " \
-          "experimental Gemfile mode, which may conflict with Bundler and cause unexpected errors. " \
-          "To remove this warning, unset RUBYGEMS_GEMDEPS.", :wrap => true
-        )
-      end
     end
 
     check_unknown_options!(:except => [:config, :exec])

--- a/bundler/spec/bundler/cli_spec.rb
+++ b/bundler/spec/bundler/cli_spec.rb
@@ -111,22 +111,6 @@ RSpec.describe "bundle executable" do
     end
   end
 
-  context "when ENV['RUBYGEMS_GEMDEPS'] is set" do
-    it "displays a warning" do
-      gemfile bundled_app_gemfile, <<-G
-        source "#{file_uri_for(gem_repo1)}"
-        gem 'rack'
-      G
-
-      bundle :install, :env => { "RUBYGEMS_GEMDEPS" => "foo" }
-      expect(err).to include("RUBYGEMS_GEMDEPS")
-      expect(err).to include("conflict with Bundler")
-
-      bundle :install, :env => { "RUBYGEMS_GEMDEPS" => "" }
-      expect(err).not_to include("RUBYGEMS_GEMDEPS")
-    end
-  end
-
   context "with --verbose" do
     it "prints the running command" do
       gemfile "source \"#{file_uri_for(gem_repo1)}\""


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When setting the `RUBYGEMS_GEMDEPS` environment variable to allow skipping `bundle exec`, `bundler` will print a warning about potential incompatibility.

Initially the `RUBYGEMS_GEMDEPS` variable used a completely different (re)implementation of `bundler` functionality. That
implementation was not battle tested and could potentially differ in behaviour from what `bundler` does. That's why print a warning.

However, these days, all `rubygems` does when `RUBYGEMS_GEMDEPS` is set is to require `bundler/setup`, so there's no risk of any incompatibility, since that's just plain `bundler`.

## What is your fix for the problem, implemented in this PR?

Completely remove the warning.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
