### PR TITLE
Respect `BUNDLE_USER_HOME` env when choosing config location

### DIFF
--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -430,6 +430,8 @@ module Bundler
         Pathname.new(ENV["BUNDLE_CONFIG"])
       elsif ENV["BUNDLE_USER_CONFIG"] && !ENV["BUNDLE_USER_CONFIG"].empty?
         Pathname.new(ENV["BUNDLE_USER_CONFIG"])
+      elsif ENV["BUNDLE_USER_HOME"] && !ENV["BUNDLE_USER_HOME"].empty?
+        Pathname.new(ENV["BUNDLE_USER_HOME"]).join("config")
       elsif Bundler.rubygems.user_home && !Bundler.rubygems.user_home.empty?
         Pathname.new(Bundler.rubygems.user_home).join(".bundle/config")
       end

--- a/bundler/spec/commands/config_spec.rb
+++ b/bundler/spec/commands/config_spec.rb
@@ -88,6 +88,16 @@ RSpec.describe ".bundle/config" do
       bundle "config get path", :env => { "BUNDLE_USER_CONFIG" => bundle_user_config }
       expect(out).to include("Set for the current user (#{bundle_user_config}): \"vendor\"")
     end
+
+    context "when not explicitly configured, but BUNDLE_USER_HOME set" do
+      let(:bundle_user_home) { bundled_app(".bundle").to_s }
+
+      it "uses the right location" do
+        bundle "config set path vendor", :env => { "BUNDLE_USER_HOME" => bundle_user_home }
+        bundle "config get path", :env => { "BUNDLE_USER_HOME" => bundle_user_home }
+        expect(out).to include("Set for the current user (#{bundle_user_home}/config): \"vendor\"")
+      end
+    end
   end
 
   describe "global" do

--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -73,6 +73,7 @@ RSpec.configure do |config|
     Spec::Rubygems.test_setup
     ENV["BUNDLE_SPEC_RUN"] = "true"
     ENV["BUNDLE_USER_CONFIG"] = ENV["BUNDLE_USER_CACHE"] = ENV["BUNDLE_USER_PLUGIN"] = nil
+    ENV["RUBYGEMS_GEMDEPS"] = nil
     ENV["XDG_CONFIG_HOME"] = nil
     ENV["GEMRC"] = nil
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`BUNDLE_USER_HOME` is no longer respected when resolving the location for the configuration file.

## What is your fix for the problem, implemented in this PR?

Consider it with the proper priority.

Fixes #4826.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
