### PR TITLE
Also load user installed rubygems plugins

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1050,7 +1050,9 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   # Find rubygems plugin files in the standard location and load them
 
   def self.load_plugins
-    load_plugin_files Gem::Util.glob_files_in_dir("*#{Gem.plugin_suffix_pattern}", plugindir)
+    Gem.path.each do |gem_path|
+      load_plugin_files Gem::Util.glob_files_in_dir("*#{Gem.plugin_suffix_pattern}", plugindir(gem_path))
+    end
   end
 
   ##

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1578,6 +1578,31 @@ class TestGem < Gem::TestCase
     assert_equal %w[plugin], PLUGINS_LOADED
   end
 
+  def test_load_user_installed_plugins
+    plugin_path = File.join "lib", "rubygems_plugin.rb"
+
+    Dir.chdir @tempdir do
+      FileUtils.mkdir_p 'lib'
+      File.open plugin_path, "w" do |fp|
+        fp.puts "class TestGem; PLUGINS_LOADED << 'plugin'; end"
+      end
+
+      foo = util_spec 'foo', '1' do |s|
+        s.files << plugin_path
+      end
+
+      install_gem_user foo
+    end
+
+    Gem.paths = { "GEM_PATH" => [Gem.dir, Gem.user_dir].join(File::PATH_SEPARATOR) }
+
+    gem 'foo'
+
+    Gem.load_plugins
+
+    assert_equal %w[plugin], PLUGINS_LOADED
+  end
+
   def test_load_env_plugins
     with_plugin('load') { Gem.load_env_plugins }
     assert_equal :loaded, TEST_PLUGIN_LOAD rescue nil


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since the refactoring to make rubygems plugin loading faster in rubygems 3.2, user installed plugins are no longer loaded.

## What is your fix for the problem, implemented in this PR?

Load plugins from well-known locations in all configured gem paths.

Fixes #4823.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
