### PR TITLE
Remove MacOS specific gem layout

### DIFF
--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -462,20 +462,8 @@ By default, this RubyGems will install gem as:
       lib_dir = RbConfig::CONFIG[site_or_vendor]
       bin_dir = RbConfig::CONFIG['bindir']
     else
-      # Apple installed RubyGems into libdir, and RubyGems <= 1.1.0 gets
-      # confused about installation location, so switch back to
-      # sitelibdir/vendorlibdir.
-      if defined?(APPLE_GEM_HOME) and
-        # just in case Apple and RubyGems don't get this patched up proper.
-        (prefix == RbConfig::CONFIG['libdir'] or
-         # this one is important
-         prefix == File.join(RbConfig::CONFIG['libdir'], 'ruby'))
-        lib_dir = RbConfig::CONFIG[site_or_vendor]
-        bin_dir = RbConfig::CONFIG['bindir']
-      else
-        lib_dir = File.join prefix, 'lib'
-        bin_dir = File.join prefix, 'bin'
-      end
+      lib_dir = File.join prefix, 'lib'
+      bin_dir = File.join prefix, 'bin'
     end
 
     unless install_destdir.empty?

--- a/lib/rubygems/defaults.rb
+++ b/lib/rubygems/defaults.rb
@@ -34,21 +34,7 @@ module Gem
   # specified in the environment
 
   def self.default_dir
-    path = if defined? RUBY_FRAMEWORK_VERSION
-             [
-               File.dirname(RbConfig::CONFIG['sitedir']),
-               'Gems',
-               RbConfig::CONFIG['ruby_version'],
-             ]
-           else
-             [
-               RbConfig::CONFIG['rubylibprefix'],
-               'gems',
-               RbConfig::CONFIG['ruby_version'],
-             ]
-           end
-
-    @default_dir ||= File.join(*path)
+    @default_dir ||= File.join(RbConfig::CONFIG['rubylibprefix'], 'gems', RbConfig::CONFIG['ruby_version'])
   end
 
   ##
@@ -197,11 +183,7 @@ module Gem
   # The default directory for binaries
 
   def self.default_bindir
-    if defined? RUBY_FRAMEWORK_VERSION # mac framework support
-      '/usr/local/bin'
-    else # generic install
-      RbConfig::CONFIG['bindir']
-    end
+    RbConfig::CONFIG['bindir']
   end
 
   def self.ruby_engine

--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -72,12 +72,7 @@ class Gem::PathSupport
 
   # Return the default Gem path
   def default_path
-    gem_path = Gem.default_path + [@home]
-
-    if defined?(APPLE_GEM_HOME)
-      gem_path << APPLE_GEM_HOME
-    end
-    gem_path
+    Gem.default_path + [@home]
   end
 
   def expand(path)

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -943,44 +943,9 @@ class TestGem < Gem::TestCase
   def test_self_path_default
     util_path
 
-    if defined?(APPLE_GEM_HOME)
-      orig_APPLE_GEM_HOME = APPLE_GEM_HOME
-      Object.send :remove_const, :APPLE_GEM_HOME
-    end
-
     Gem.instance_variable_set :@paths, nil
 
     assert_equal [Gem.default_path, Gem.dir].flatten.uniq, Gem.path
-  ensure
-    Object.const_set :APPLE_GEM_HOME, orig_APPLE_GEM_HOME if orig_APPLE_GEM_HOME
-  end
-
-  unless win_platform?
-    def test_self_path_APPLE_GEM_HOME
-      util_path
-
-      Gem.clear_paths
-      apple_gem_home = File.join @tempdir, 'apple_gem_home'
-
-      old, $-w = $-w, nil
-      Object.const_set :APPLE_GEM_HOME, apple_gem_home
-      $-w = old
-
-      assert_includes Gem.path, apple_gem_home
-    ensure
-      Object.send :remove_const, :APPLE_GEM_HOME
-    end
-
-    def test_self_path_APPLE_GEM_HOME_GEM_PATH
-      Gem.clear_paths
-      ENV['GEM_PATH'] = @gemhome
-      apple_gem_home = File.join @tempdir, 'apple_gem_home'
-      Gem.const_set :APPLE_GEM_HOME, apple_gem_home
-
-      refute Gem.path.include?(apple_gem_home)
-    ensure
-      Gem.send :remove_const, :APPLE_GEM_HOME
-    end
   end
 
   def test_self_path_ENV_PATH

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -931,17 +931,13 @@ class TestGem < Gem::TestCase
     assert_equal true, Gem.loaded_specs.keys.include?('foo')
   end
 
-  def util_path
-    ENV.delete "GEM_HOME"
-    ENV.delete "GEM_PATH"
-  end
-
   def test_self_path
     assert_equal [Gem.dir], Gem.path
   end
 
   def test_self_path_default
-    util_path
+    ENV.delete "GEM_HOME"
+    ENV.delete "GEM_PATH"
 
     Gem.instance_variable_set :@paths, nil
 

--- a/test/rubygems/test_gem_path_support.rb
+++ b/test/rubygems/test_gem_path_support.rb
@@ -16,7 +16,7 @@ class TestGemPathSupport < Gem::TestCase
 
     assert_equal ENV["GEM_HOME"], ps.home
 
-    expected = util_path
+    expected = ENV["GEM_PATH"].split(File::PATH_SEPARATOR)
     assert_equal expected, ps.path, "defaults to GEM_PATH"
   end
 
@@ -25,7 +25,7 @@ class TestGemPathSupport < Gem::TestCase
 
     assert_equal File.join(@tempdir, "foo"), ps.home
 
-    expected = util_path + [File.join(@tempdir, 'foo')]
+    expected = ENV["GEM_PATH"].split(File::PATH_SEPARATOR) + [File.join(@tempdir, 'foo')]
     assert_equal expected, ps.path
   end
 
@@ -100,10 +100,6 @@ class TestGemPathSupport < Gem::TestCase
       expected = [File.join(@tempdir, 'foo'), File.join(@tempdir, 'bar')]
       assert_equal expected, ps.path
     end
-  end
-
-  def util_path
-    ENV["GEM_PATH"].split(File::PATH_SEPARATOR)
   end
 
   def test_initialize_spec


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

MacOS should properly configure Ruby. They should not expect us to maintain a different layout just for them.

## What is your fix for the problem, implemented in this PR?

Don't maintain a specific default layout just for MacOS.

Closes #2890.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
