### PR TITLE
Prioritise gems with higher version for fetching metadata, and stop fetching once we find a valid candidate

### DIFF
--- a/lib/rubygems/resolver/installer_set.rb
+++ b/lib/rubygems/resolver/installer_set.rb
@@ -77,11 +77,11 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
     newest = found.last
 
     unless @force
-      found_matching_metadata = found.select do |spec|
+      found_matching_metadata = found.reverse.find do |spec|
         metadata_satisfied?(spec)
       end
 
-      if found_matching_metadata.empty?
+      if found_matching_metadata.nil?
         if newest
           ensure_required_ruby_version_met(newest.spec)
           ensure_required_rubygems_version_met(newest.spec)
@@ -92,7 +92,7 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
           raise exc
         end
       else
-        newest = found_matching_metadata.last
+        newest = found_matching_metadata
       end
     end
 

--- a/test/rubygems/test_gem_resolver_installer_set.rb
+++ b/test/rubygems/test_gem_resolver_installer_set.rb
@@ -64,6 +64,24 @@ class TestGemResolverInstallerSet < Gem::TestCase
     assert_equal %w[a-1], set.always_install.map {|s| s.full_name }
   end
 
+  def test_add_always_install_prerelease_github_problem
+    spec_fetcher do |fetcher|
+      fetcher.gem 'a', 1
+    end
+
+    # Github has an issue in which it will generate a misleading prerelease output in its RubyGems server API and
+    # returns a 0 version for the gem while it doesn't exist.
+    @fetcher.data["#{@gem_repo}prerelease_specs.#{Gem.marshal_version}.gz"] = util_gzip(Marshal.dump([
+      Gem::NameTuple.new('a', Gem::Version.new(0), 'ruby'),
+    ]))
+
+    set = Gem::Resolver::InstallerSet.new :both
+
+    set.add_always_install dep('a')
+
+    assert_equal %w[a-1], set.always_install.map {|s| s.full_name }
+  end
+
   def test_add_always_install_prerelease_only
     spec_fetcher do |fetcher|
       fetcher.gem 'a', '3.a'


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Github has an issue in which it will generate a misleading prerelease output in its RubyGems server API and returns a 0 version for the gem while it doesn't exist.

## What is your fix for the problem, implemented in this PR?

Verifying metadata (which needs a network request to fetch the full gemspec) in order of priority until a valid gem is found, instead of fetching all gemspec candidates unconditionally, avoids the issue.

Fixes #4603.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
