### PR TITLE
Fix some failing Bundler tests with old Git.

### DIFF
--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -554,7 +554,7 @@ module Spec
           raise "You can't specify `master` as the branch" if branch == "master"
           escaped_branch = Shellwords.shellescape(branch)
 
-          if @context.git("branch -l #{escaped_branch}", libpath).empty?
+          if @context.git("branch --list #{escaped_branch}", libpath).empty?
             @context.git("branch #{escaped_branch}", libpath)
           end
 


### PR DESCRIPTION
This PR fixes #4850 .

Use the `git branch --list` rather than `git branch -l` for better compatibility.
Because in an old Git 1.8.3.1, the `git branch -l` is used to create a new branch.

```
$ git --version
git version 1.8.3.1

$ git branch --help
...
SYNOPSIS
       git branch [--color[=<when>] | --no-color] [-r | -a]
               [--list] [-v [--abbrev=<length> | --no-abbrev]]
               [--column[=<options>] | --no-column]
               [(--merged | --no-merged | --contains) [<commit>]] [<pattern>...]
       git branch [--set-upstream | --track | --no-track] [-l] [-f] <branchname> [<start-point>]
...
       --list
           Activate the list mode.  git branch <pattern> would try to create a branch, use git branch
           --list <pattern> to list matching branches.
...
       -l, --create-reflog
           Create the branch's reflog. This activates recording of all changes made to the branch ref,
           enabling use of date based sha1 expressions such as "<branchname>@{yesterday}". Note that in
           non-bare repositories, reflogs are usually enabled by default by the core.logallrefupdates
           config option.
...
```

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

Some Bundler tests are failing with old version Git 1.8.3.1 installed on RHEL 7 / CentOS 7.

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

The fix is to use `git branch --list <branch name>` instead of `git branch -l <branch name>` in the tests. Because the ``git branch -l <branch name>`` creates a new branch on Git 1.8.3.1.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

for writing tets, as I wrote #4850 , I couldn't run the `bin/rake spec:parallel_deps` on Ruby 2.0.0 on RHEL 7 / CentOS 7. But I am not sure we should fix this issue because the Ruby 2.0.0 is very old.

```
[root@5df411ad9293 bundler]# bin/rake spec:parallel_deps
bin/rake:4:in `require_relative': /rubygems/bundler/spec/support/rubygems_ext.rb:75: syntax error, unexpected ',' (SyntaxError)
    def check_source_control_changes(success_message:, error_message:)
                                                      ^
/rubygems/bundler/spec/support/rubygems_ext.rb:106: syntax error, unexpected '.'
...file)).dependencies[gem_name]&.requirement
...                               ^
/rubygems/bundler/spec/support/rubygems_ext.rb:158: syntax error, unexpected keyword_end, expecting end-of-input
  from bin/rake:4:in `<main>'
```

I checked code formatting.

```
$ bin/rubocop -a
Inspecting 386 files
..................................................................................................................................................................................................................................................................................................................................................................................................

386 files inspected, no offenses detected
```

I wrote meaningful commit message explaining this issue.

