### PR TITLE
Fix `bundle check` incorrectly considering cached gems

### DIFF
--- a/bundler/lib/bundler/cli/check.rb
+++ b/bundler/lib/bundler/cli/check.rb
@@ -15,7 +15,7 @@ module Bundler
       definition.validate_runtime!
 
       begin
-        definition.resolve_with_cache!
+        definition.resolve_only_locally!
         not_installed = definition.missing_specs
       rescue GemNotFound, VersionConflict
         Bundler.ui.error "Bundler can't satisfy your Gemfile's dependencies."

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -166,6 +166,12 @@ module Bundler
       @multisource_allowed
     end
 
+    def resolve_only_locally!
+      @remote = false
+      sources.local_only!
+      resolve
+    end
+
     def resolve_with_cache!
       sources.cached!
       resolve

--- a/bundler/lib/bundler/source.rb
+++ b/bundler/lib/bundler/source.rb
@@ -36,6 +36,8 @@ module Bundler
 
     def local!; end
 
+    def local_only!; end
+
     def cached!; end
 
     def remote!; end

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -29,6 +29,7 @@ module Bundler
       def local_only!
         @specs = nil
         @allow_local = true
+        @allow_cached = false
         @allow_remote = false
       end
 

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -26,6 +26,12 @@ module Bundler
         Array(options["remotes"]).reverse_each {|r| add_remote(r) }
       end
 
+      def local_only!
+        @specs = nil
+        @allow_local = true
+        @allow_remote = false
+      end
+
       def local!
         return if @allow_local
 

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -136,6 +136,10 @@ module Bundler
       different_sources?(lock_sources, replacement_sources)
     end
 
+    def local_only!
+      all_sources.each(&:local_only!)
+    end
+
     def cached!
       all_sources.each(&:cached!)
     end

--- a/bundler/spec/commands/check_spec.rb
+++ b/bundler/spec/commands/check_spec.rb
@@ -137,6 +137,22 @@ RSpec.describe "bundle check" do
     expect(exitstatus).to eq(1)
   end
 
+  it "ensures that gems are actually installed and not just cached in applications' cache" do
+    gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
+      gem "rack"
+    G
+
+    bundle "config set --local path vendor/bundle"
+    bundle :cache
+
+    gem_command "uninstall rack", :env => { "GEM_HOME" => vendored_gems.to_s }
+
+    bundle "check", :raise_on_error => false
+    expect(err).to include("* rack (1.0.0)")
+    expect(exitstatus).to eq(1)
+  end
+
   it "ignores missing gems restricted to other platforms" do
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I broke `bundle check` with https://github.com/rubygems/rubygems/commit/d74830d00bb541883377992f56818620a78930b0.

## What is your fix for the problem, implemented in this PR?

Revert that commit, since it made no sense: the code is necessary.

Fixes #4852.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
