### PR TITLE
Fix `bundle check` showing duplicated gems when multiple platforms are locked

### DIFF
--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -24,7 +24,7 @@ module Bundler
 
         specs_for_dep = spec_for_dependency(dep, match_current_platform)
         if specs_for_dep.any?
-          specs += specs_for_dep
+          match_current_platform ? specs += specs_for_dep : specs |= specs_for_dep
 
           specs_for_dep.first.dependencies.each do |d|
             next if d.type == :development

--- a/bundler/spec/commands/check_spec.rb
+++ b/bundler/spec/commands/check_spec.rb
@@ -316,6 +316,42 @@ RSpec.describe "bundle check" do
     end
   end
 
+  describe "when locked under multiple platforms" do
+    before :each do
+      build_repo4 do
+        build_gem "rack"
+      end
+
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo4)}"
+        gem "rack"
+      G
+
+      lockfile <<-L
+        GEM
+          remote: #{file_uri_for(gem_repo4)}/
+          specs:
+            rack (1.0)
+
+        PLATFORMS
+          ruby
+          #{specific_local_platform}
+
+        DEPENDENCIES
+          rack
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+    end
+
+    it "shows what is missing with the current Gemfile without duplications" do
+      bundle :check, :raise_on_error => false
+      expect(err).to match(/The following gems are missing/)
+      expect(err).to include("* rack (1.0").once
+    end
+  end
+
   describe "when using only scoped rubygems sources" do
     before do
       gemfile <<~G


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If the lockfile contains multiple platforms, `bundle check` would show duplicated missing gems.

## What is your fix for the problem, implemented in this PR?

Ensure uniqueness in this case.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
