### PR TITLE
Make plugin installation idempotent

### DIFF
--- a/bundler/lib/bundler/plugin.rb
+++ b/bundler/lib/bundler/plugin.rb
@@ -246,9 +246,8 @@ module Bundler
     def save_plugins(plugins, specs, optional_plugins = [])
       plugins.each do |name|
         spec = specs[name]
-        validate_plugin! Pathname.new(spec.full_gem_path)
-        installed = register_plugin(name, spec, optional_plugins.include?(name))
-        Bundler.ui.info "Installed plugin #{name}" if installed
+
+        save_plugin(name, spec, optional_plugins.include?(name))
       end
     end
 
@@ -261,6 +260,20 @@ module Bundler
     def validate_plugin!(plugin_path)
       plugin_file = plugin_path.join(PLUGIN_FILE_NAME)
       raise MalformattedPlugin, "#{PLUGIN_FILE_NAME} was not found in the plugin." unless plugin_file.file?
+    end
+
+    # Validates and registers a plugin.
+    #
+    # @param [String] name the name of the plugin
+    # @param [Specification] spec of installed plugin
+    # @param [Boolean] optional_plugin, removed if there is conflict with any
+    #                     other plugin (used for default source plugins)
+    #
+    # @raise [MalformattedPlugin] if validation or registration raises any error
+    def save_plugin(name, spec, optional_plugin = false)
+      validate_plugin! Pathname.new(spec.full_gem_path)
+      installed = register_plugin(name, spec, optional_plugin)
+      Bundler.ui.info "Installed plugin #{name}" if installed
     end
 
     # Runs the plugins.rb file in an isolated namespace, records the plugin

--- a/bundler/spec/bundler/plugin_spec.rb
+++ b/bundler/spec/bundler/plugin_spec.rb
@@ -65,6 +65,8 @@ RSpec.describe Bundler::Plugin do
     end
 
     it "passes the name and options to installer" do
+      allow(index).to receive(:installed?).
+        with("new-plugin")
       allow(installer).to receive(:install).with(["new-plugin"], opts) do
         { "new-plugin" => spec }
       end.once
@@ -73,6 +75,8 @@ RSpec.describe Bundler::Plugin do
     end
 
     it "validates the installed plugin" do
+      allow(index).to receive(:installed?).
+        with("new-plugin")
       allow(subject).
         to receive(:validate_plugin!).with(lib_path("new-plugin")).once
 
@@ -80,6 +84,8 @@ RSpec.describe Bundler::Plugin do
     end
 
     it "registers the plugin with index" do
+      allow(index).to receive(:installed?).
+        with("new-plugin")
       allow(index).to receive(:register_plugin).
         with("new-plugin", lib_path("new-plugin").to_s, [lib_path("new-plugin").join("lib").to_s], []).once
       subject.install ["new-plugin"], opts
@@ -96,6 +102,7 @@ RSpec.describe Bundler::Plugin do
         end.once
 
         allow(subject).to receive(:validate_plugin!).twice
+        allow(index).to receive(:installed?).twice
         allow(index).to receive(:register_plugin).twice
         subject.install ["new-plugin", "another-plugin"], opts
       end

--- a/bundler/spec/plugins/command_spec.rb
+++ b/bundler/spec/plugins/command_spec.rb
@@ -69,12 +69,10 @@ RSpec.describe "command plugins" do
       end
     end
 
-    bundle "plugin install copycat --source #{file_uri_for(gem_repo2)}"
+    bundle "plugin install copycat --source #{file_uri_for(gem_repo2)}", :raise_on_error => false
 
     expect(out).not_to include("Installed plugin copycat")
 
-    expect(err).to include("Failed to install the following plugins: `copycat`")
-
-    expect(err).to include("Command(s) `mahcommand` declared by copycat are already registered.")
+    expect(err).to include("Failed to install plugin `copycat`, due to Bundler::Plugin::Index::CommandConflict (Command(s) `mahcommand` declared by copycat are already registered.)")
   end
 end

--- a/bundler/spec/plugins/install_spec.rb
+++ b/bundler/spec/plugins/install_spec.rb
@@ -109,9 +109,9 @@ RSpec.describe "bundler plugin install" do
         build_gem "charlie"
       end
 
-      bundle "plugin install charlie --source #{file_uri_for(gem_repo2)}"
+      bundle "plugin install charlie --source #{file_uri_for(gem_repo2)}", :raise_on_error => false
 
-      expect(err).to include("Failed to install the following plugins: `charlie`. The underlying error was: plugins.rb was not found")
+      expect(err).to include("Failed to install plugin `charlie`, due to Bundler::Plugin::MalformattedPlugin (plugins.rb was not found in the plugin.)")
 
       expect(global_plugin_gem("charlie-1.0")).not_to be_directory
 
@@ -128,7 +128,7 @@ RSpec.describe "bundler plugin install" do
         end
       end
 
-      bundle "plugin install chaplin --source #{file_uri_for(gem_repo2)}"
+      bundle "plugin install chaplin --source #{file_uri_for(gem_repo2)}", :raise_on_error => false
 
       expect(global_plugin_gem("chaplin-1.0")).not_to be_directory
 


### PR DESCRIPTION

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

When running `bundle plugin install` twice, the second time fails.

## What is your fix for the problem, implemented in this PR?

Fix is to guard for already installed plugins, and ignore those.

While working on it, I realized that plugin installation errors, while being printed, they were not resulting in a non-zero status code. I also fixed that issue that was actually preventing our specs from catching this, and also improved some error messages.

Fixes #4863.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
