### PR TITLE
Refactor Ruby platform priority condition to its own method

### DIFF
--- a/lib/rubygems/name_tuple.rb
+++ b/lib/rubygems/name_tuple.rb
@@ -89,9 +89,8 @@ class Gem::NameTuple
   alias to_s inspect # :nodoc:
 
   def <=>(other)
-    [@name, @version, @platform == Gem::Platform::RUBY ? -1 : 1] <=>
-      [other.name, other.version,
-       other.platform == Gem::Platform::RUBY ? -1 : 1]
+    [@name, @version, Gem::Platform.sort_priority(@platform)] <=>
+      [other.name, other.version, Gem::Platform.sort_priority(other.platform)]
   end
 
   include Comparable

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -40,6 +40,10 @@ class Gem::Platform
     match_platforms?(platform, Gem.platforms)
   end
 
+  def self.sort_priority(platform)
+    platform == Gem::Platform::RUBY ? -1 : 1
+  end
+
   def self.installable?(spec)
     if spec.respond_to? :installable_platform?
       spec.installable_platform?

--- a/lib/rubygems/resolver/installer_set.rb
+++ b/lib/rubygems/resolver/installer_set.rb
@@ -71,7 +71,7 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
     end
 
     found = found.sort_by do |s|
-      [s.version, s.platform == Gem::Platform::RUBY ? -1 : 1]
+      [s.version, Gem::Platform.sort_priority(s.platform)]
     end
 
     newest = found.last

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -855,7 +855,7 @@ class Gem::Specification < Gem::BasicSpecification
       next names if names.nonzero?
       versions = b.version <=> a.version
       next versions if versions.nonzero?
-      b.platform == Gem::Platform::RUBY ? -1 : 1
+      Gem::Platform.sort_priority(b.platform)
     end
   end
 
@@ -2333,7 +2333,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Returns an object you can use to sort specifications in #sort_by.
 
   def sort_obj
-    [@name, @version, @new_platform == Gem::Platform::RUBY ? -1 : 1]
+    [@name, @version, Gem::Platform.sort_priority(@new_platform)]
   end
 
   ##


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

_Changes in this PR will not affect the end-user._

## What is your fix for the problem, implemented in this PR?

_Changes in this PR will not affect the end-user._

## Context

The `Gem::Platform::RUBY ? -1 : 1` has been used multiple times in different places and could be refactored to a method (DRY).

## Change

Refactor `Gem::Platform::RUBY ? -1 : 1` to its own method `Gem::Platform.sort_priority(platform)`

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
