### PR TITLE
Correctly redact credentials when using x-oauth-basic 

### DIFF
--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -419,7 +419,7 @@ module Bundler
       elsif is_credential(key)
         "[REDACTED]"
       elsif is_userinfo(converted)
-        username, pass = converted.split(":")
+        username, pass = converted.split(":", 2)
 
         if pass == "x-oauth-basic"
           username = "[REDACTED]"

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -419,7 +419,15 @@ module Bundler
       elsif is_credential(key)
         "[REDACTED]"
       elsif is_userinfo(converted)
-        converted.gsub(/:.*$/, ":[REDACTED]")
+        username, pass = converted.split(":")
+
+        if pass == "x-oauth-basic"
+          username = "[REDACTED]"
+        else
+          pass = "[REDACTED]"
+        end
+
+        [username, pass].join(":")
       else
         converted
       end

--- a/bundler/spec/bundler/env_spec.rb
+++ b/bundler/spec/bundler/env_spec.rb
@@ -127,6 +127,20 @@ RSpec.describe Bundler::Env do
       end
     end
 
+    context "when there's bundler config with OAuth token credentials" do
+      before do
+        bundle "config set https://localgemserver.test/ api_token:x-oauth-basic"
+      end
+
+      let(:output) { described_class.report(:print_gemfile => true) }
+
+      it "prints the config with redacted values" do
+        expect(output).to include("https://localgemserver.test")
+        expect(output).to include("[REDACTED]:x-oauth-basic")
+        expect(output).to_not include("api_token:x-oauth-basic")
+      end
+    end
+
     context "when Gemfile contains a gemspec and print_gemspecs is true" do
       let(:gemspec) do
         strip_whitespace(<<-GEMSPEC)

--- a/bundler/spec/commands/config_spec.rb
+++ b/bundler/spec/commands/config_spec.rb
@@ -440,6 +440,14 @@ E
       expect(out).to eq "gems.myserver.com=user:password\nspec_run=true"
     end
 
+    it "list with API token credentials" do
+      bundle "config list", :env => { "BUNDLE_GEMS__MYSERVER__COM" => "api_token:x-oauth-basic" }
+      expect(out).to eq "Settings are listed in order of priority. The top value will be used.\ngems.myserver.com\nSet via BUNDLE_GEMS__MYSERVER__COM: \"[REDACTED]:x-oauth-basic\"\n\nspec_run\nSet via BUNDLE_SPEC_RUN: \"true\""
+
+      bundle "config list", :parseable => true, :env => { "BUNDLE_GEMS__MYSERVER__COM" => "api_token:x-oauth-basic" }
+      expect(out).to eq "gems.myserver.com=api_token:x-oauth-basic\nspec_run=true"
+    end
+
     it "get" do
       ENV["BUNDLE_BAR"] = "bar_val"
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?
When setting credentials for Github Package Registry, Github allows 2 separate formats:

* `<username>:<token>`
* `<token>:x-oauth_basic`

In the latter case, Bundler fails to redact the OAuth token.

## What is your fix for the problem, implemented in this PR?
When redacting, check if the password is `x-oauth_basic`, in which case assume the username is the actual value to redact.
