### PR TITLE
Fix `bundle plugin install` detection of already installed plugins

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -660,16 +660,11 @@ EOF
     end
 
     def configure_gem_path(env = ENV)
-      blank_home = env["GEM_HOME"].nil? || env["GEM_HOME"].empty?
-      if !use_system_gems?
+      unless use_system_gems?
         # this needs to be empty string to cause
         # PathSupport.split_gem_path to only load up the
         # Bundler --path setting as the GEM_PATH.
         env["GEM_PATH"] = ""
-      elsif blank_home
-        possibles = [Bundler.rubygems.gem_dir, Bundler.rubygems.gem_path]
-        paths = possibles.flatten.compact.uniq.reject(&:empty?)
-        env["GEM_PATH"] = paths.join(File::PATH_SEPARATOR)
       end
     end
 

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -657,7 +657,6 @@ EOF
     def configure_gem_home_and_path
       configure_gem_path
       configure_gem_home
-      bundle_path
     end
 
     def configure_gem_path(env = ENV)

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -669,7 +669,7 @@ EOF
     end
 
     def configure_gem_home
-      Bundler::SharedHelpers.set_env "GEM_HOME", File.expand_path(bundle_path, root)
+      Bundler::SharedHelpers.set_env "GEM_HOME", bundle_path.to_s
       Bundler.rubygems.clear_paths
     end
 

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -636,6 +636,12 @@ EOF
       @rubygems = nil
     end
 
+    def configure_gem_home_and_path(path = bundle_path)
+      configure_gem_path
+      configure_gem_home(path)
+      Bundler.rubygems.clear_paths
+    end
+
     private
 
     def eval_yaml_gemspec(path, contents)
@@ -654,12 +660,6 @@ EOF
       raise GemspecError, Dsl::DSLError.new(msg, path, e.backtrace, contents)
     end
 
-    def configure_gem_home_and_path
-      configure_gem_path
-      configure_gem_home
-      Bundler.rubygems.clear_paths
-    end
-
     def configure_gem_path
       unless use_system_gems?
         # this needs to be empty string to cause
@@ -669,8 +669,8 @@ EOF
       end
     end
 
-    def configure_gem_home
-      Bundler::SharedHelpers.set_env "GEM_HOME", bundle_path.to_s
+    def configure_gem_home(path)
+      Bundler::SharedHelpers.set_env "GEM_HOME", path.to_s
     end
 
     def tmp_home_path

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -657,6 +657,7 @@ EOF
     def configure_gem_home_and_path
       configure_gem_path
       configure_gem_home
+      Bundler.rubygems.clear_paths
     end
 
     def configure_gem_path
@@ -670,7 +671,6 @@ EOF
 
     def configure_gem_home
       Bundler::SharedHelpers.set_env "GEM_HOME", bundle_path.to_s
-      Bundler.rubygems.clear_paths
     end
 
     def tmp_home_path

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -659,12 +659,12 @@ EOF
       configure_gem_home
     end
 
-    def configure_gem_path(env = ENV)
+    def configure_gem_path
       unless use_system_gems?
         # this needs to be empty string to cause
         # PathSupport.split_gem_path to only load up the
         # Bundler --path setting as the GEM_PATH.
-        env["GEM_PATH"] = ""
+        Bundler::SharedHelpers.set_env "GEM_PATH", ""
       end
     end
 

--- a/bundler/lib/bundler/plugin/installer.rb
+++ b/bundler/lib/bundler/plugin/installer.rb
@@ -81,6 +81,8 @@ module Bundler
 
         deps = names.map {|name| Dependency.new name, version }
 
+        Bundler.configure_gem_home_and_path(Plugin.root)
+
         definition = Definition.new(nil, deps, source_list, true)
         install_definition(definition)
       end

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -144,7 +144,7 @@ module Bundler
           end
         end
 
-        if (installed?(spec) || Plugin.installed?(spec.name)) && !force
+        if installed?(spec) && !force
           print_using_message "Using #{version_message(spec)}"
           return nil # no post-install message
         end

--- a/bundler/spec/bundler/bundler_spec.rb
+++ b/bundler/spec/bundler/bundler_spec.rb
@@ -152,11 +152,9 @@ RSpec.describe Bundler do
   describe "configuration" do
     context "disable_shared_gems" do
       it "should unset GEM_PATH with empty string" do
-        env = {}
         expect(Bundler).to receive(:use_system_gems?).and_return(false)
-        Bundler.send(:configure_gem_path, env)
-        expect(env.keys).to include("GEM_PATH")
-        expect(env["GEM_PATH"]).to eq ""
+        Bundler.send(:configure_gem_path)
+        expect(ENV["GEM_PATH"]).to eq ""
       end
     end
   end

--- a/bundler/spec/plugins/install_spec.rb
+++ b/bundler/spec/plugins/install_spec.rb
@@ -69,6 +69,21 @@ RSpec.describe "bundler plugin install" do
     plugin_should_be_installed("foo", "kung-foo")
   end
 
+  it "installs the latest version if not installed" do
+    update_repo2 do
+      build_plugin "foo", "1.1"
+    end
+
+    bundle "plugin install foo --version 1.0 --source #{file_uri_for(gem_repo2)} --verbose"
+    expect(out).to include("Installing foo 1.0")
+
+    bundle "plugin install foo --source #{file_uri_for(gem_repo2)} --verbose"
+    expect(out).to include("Installing foo 1.1")
+
+    bundle "plugin install foo --source #{file_uri_for(gem_repo2)} --verbose"
+    expect(out).to include("Using foo 1.1")
+  end
+
   it "works with different load paths" do
     build_repo2 do
       build_plugin "testing" do |s|


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If you install a version of a plugin, say diffend 0.2.49, and then the latest version, 0.2.50, `bundler` will incorrectly think that 0.2.50 is already installed, and skip installation.

```
$ bundle plugin install diffend --version 0.2.49
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Using bundler 2.3.0.dev
Installing diffend 0.2.49
Installed plugin diffend

$ bundle plugin install diffend
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Using bundler 2.3.0.dev
Using diffend 0.2.50
```

## What is your fix for the problem, implemented in this PR?

Plugins are regular gems, but they are installed to their own `GEM_HOME`. My fix is to set the proper `GEM_HOME` used for plugins, so that the detection of whether a specific version is already installed works in the same way it works for regular gems.

Fixes https://github.com/rubygems/rubygems/pull/4864#issuecomment-901872855.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
