### PR TITLE
Solve the problem of undefined method satisfied_by?' for nil:NilClass`

### DIFF
--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -263,10 +263,15 @@ class Gem::Resolver
   def requirement_satisfied_by?(requirement, activated, spec)
     matches_spec = requirement.matches_spec? spec
     return matches_spec if @soft_missing
-
+  
+    rubygems_v = spec.spec.required_rubygems_version
+    if rubygems_v.nil?
+      rubygems_v = Gem::Requirement.new(">= 0.0.0")
+    end
+  
     matches_spec &&
       spec.spec.required_ruby_version.satisfied_by?(Gem.ruby_version) &&
-      spec.spec.required_rubygems_version.satisfied_by?(Gem.rubygems_version)
+      rubygems_v.satisfied_by?(Gem.rubygems_version)
   end
 
   def name_for(dependency)


### PR DESCRIPTION
Solve the problem of `ERROR: While executing gem ... (NoMethodError) undefined method ``'satisfied_by?' for nil:NilClass` caused by old gems that are not compatible with Ruby 3.0.0 configuration

When the made gem depends on `mechanize`, execute `rake install --trace`, and finally output the following log
```ruby
ERROR:  While executing gem ... (NoMethodError)
    undefined method `satisfied_by?' for nil:NilClass
        /Users/$(whoami)/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/rubygems/resolver.rb:269:in `requirement_satisfied_by?'
        /Users/$(whoami)/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/rubygems/resolver/molinillo/lib/molinillo/delegates/specification_provider.rb:25:in `block in requirement_satisfied_by?'
        /Users/$(whoami)/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/rubygems/resolver/molinillo/lib/molinillo/delegates/specification_provider.rb:70:in `with_no_such_dependency_error_handling'
        /Users/$(whoami)/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/rubygems/resolver/molinillo/lib/molinillo/delegates/specification_provider.rb:24:in `requirement_satisfied_by?'
        /Users/$(whoami)/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:672:in `block in attempt_to_activate'
        /Users/$(whoami)/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:671:in `select!'
        /Users/$(whoami)/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:671:in `attempt_to_activate'
        /Users/$(whoami)/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:254:in `process_topmost_state'
        /Users/$(whoami)/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:182:in `resolve'
        /Users/$(whoami)/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/rubygems/resolver/molinillo/lib/molinillo/resolver.rb:43:in `resolve'
        /Users/$(whoami)/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/rubygems/resolver.rb:190:in `resolve'
        /Users/$(whoami)/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/rubygems/request_set.rb:411:in `resolve'
        /Users/$(whoami)/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/rubygems/dependency_installer.rb:333:in `resolve_dependencies'
        /Users/$(whoami)/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/rubygems/commands/install_command.rb:198:in `install_gem'
        /Users/$(whoami)/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/rubygems/commands/install_command.rb:223:in `block in install_gems'
        /Users/$(whoami)/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/rubygems/commands/install_command.rb:216:in `each'
        /Users/$(whoami)/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/rubygems/commands/install_command.rb:216:in `install_gems'
        /Users/$(whoami)/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/rubygems/commands/install_command.rb:164:in `execute'
        /Users/$(whoami)/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/rubygems/command.rb:323:in `invoke_with_build_args'
        /Users/$(whoami)/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/rubygems/command_manager.rb:178:in `process_args'
        /Users/$(whoami)/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/rubygems/command_manager.rb:147:in `run'
        /Users/$(whoami)/.rvm/rubies/ruby-3.0.0/lib/ruby/3.0.0/rubygems/gem_runner.rb:53:in `run'
        /Users/$(whoami)/.rvm/rubies/ruby-3.0.0/bin/gem:21:in `<main>'
```
Here is the detailed story, if you can read Chinese
https://www.yuque.com/runscode/ruby/tkdmn5