### PR TITLE
Optimize some requires

### DIFF
--- a/bundler/lib/bundler/installer.rb
+++ b/bundler/lib/bundler/installer.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "rubygems/dependency_installer"
 require_relative "worker"
 require_relative "installer/parallel_installer"
 require_relative "installer/standalone"

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -34,10 +34,12 @@ module Bundler
     end
 
     def build_args
+      require "rubygems/command"
       Gem::Command.build_args
     end
 
     def build_args=(args)
+      require "rubygems/command"
       Gem::Command.build_args = args
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes `bundler` was unnecessarily loading `optparse` through an unnecessary top level require of `rubygems/dependency_installer`.

## What is your fix for the problem, implemented in this PR?

Remove the unnecessary require, and replace it with lazy requires of the functionality that's strictly needed.

This is the "bundler" part of #4881 extracted to a separate PR.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
