### PR TITLE
Deprecate `--install` flag to `bundle remove` and trigger install by default

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -184,6 +184,7 @@ module Bundler
     method_option "install", :type => :boolean, :banner =>
       "Runs 'bundle install' after removing the gems from the Gemfile"
     def remove(*gems)
+      SharedHelpers.major_deprecation(2, "The `--install` flag has been deprecated. `bundle install` is triggered by default.") if ARGV.include?("--install")
       require_relative "cli/remove"
       Remove.new(gems, options).run
     end

--- a/bundler/lib/bundler/cli/remove.rb
+++ b/bundler/lib/bundler/cli/remove.rb
@@ -11,8 +11,7 @@ module Bundler
       raise InvalidOption, "Please specify gems to remove." if @gems.empty?
 
       Injector.remove(@gems, {})
-
-      Installer.install(Bundler.root, Bundler.definition) if @options["install"]
+      Installer.install(Bundler.root, Bundler.definition)
     end
   end
 end

--- a/bundler/spec/commands/remove_spec.rb
+++ b/bundler/spec/commands/remove_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "bundle remove" do
     end
   end
 
-  context "when --install flag is specified" do
+  context "when --install flag is specified", :bundler => "< 3" do
     it "removes gems from .bundle" do
       gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
@@ -40,6 +40,7 @@ RSpec.describe "bundle remove" do
         bundle "remove rack"
 
         expect(out).to include("rack was removed.")
+        expect(the_bundle).to_not include_gems "rack"
         gemfile_should_be <<-G
           source "#{file_uri_for(gem_repo1)}"
         G

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -624,6 +624,25 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
     end
   end
 
+  context "bundle remove" do
+    before do
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rack"
+      G
+    end
+
+    context "with --install" do
+      it "shows a deprecation warning", :bundler => "< 3" do
+        bundle "remove rack --install"
+
+        expect(err).to include "[DEPRECATED] The `--install` flag has been deprecated. `bundle install` is triggered by default."
+      end
+
+      pending "fails with a helpful message", :bundler => "3"
+    end
+  end
+
   context "bundle console" do
     before do
       bundle "console", :raise_on_error => false

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -35,6 +35,11 @@ module Spec
       build_repo gem_repo1 do
         FileUtils.cp rake_path, "#{gem_repo1}/gems/"
 
+        build_gem "coffee-script-source"
+        build_gem "git"
+        build_gem "puma"
+        build_gem "minitest"
+
         build_gem "rack", %w[0.9.1 1.0.0] do |s|
           s.executables = "rackup"
           s.post_install_message = "Rack's post install message"


### PR DESCRIPTION
Closes https://github.com/rubygems/rubygems/issues/4889

## What was the end-user or developer problem that led to this PR?

`bundle remove` does not update lockfile.

## What is your fix for the problem, implemented in this PR?

- Trigger `install` command by default on `bundle remove`
- Remove option `--install` from the cli


