### PR TITLE
 Changelogs for rubygems 3.2.27 and bundler 2.2.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 3.2.27 / 2021-09-02
+
+## Enhancements:
+
+* Redact credentails when printing URI. Pull request #4868 by intuxicated
+* Prefer `require_relative` to `require` for internal requires. Pull
+  request #4858 by deivid-rodriguez
+* Prioritise gems with higher version for fetching metadata, and stop
+  fetching once we find a valid candidate. Pull request #4843 by intuxicated
+
 # 3.2.26 / 2021-08-17
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 2.2.27 (September 2, 2021)
+
+## Enhancements:
+
+  - Optimize some requires [#4887](https://github.com/rubygems/rubygems/pull/4887)
+  - Correctly redact credentials when using x-oauth-basic [#4866](https://github.com/rubygems/rubygems/pull/4866)
+
+## Bug fixes:
+
+  - Add missing key `branches:` to template for GitHub Actions [#4883](https://github.com/rubygems/rubygems/pull/4883)
+  - Fix `bundle plugin install` detection of already installed plugins [#4869](https://github.com/rubygems/rubygems/pull/4869)
+  - Fix `bundle check` showing duplicated gems when multiple platforms are locked [#4854](https://github.com/rubygems/rubygems/pull/4854)
+  - Fix `bundle check` incorrectly considering cached gems [#4853](https://github.com/rubygems/rubygems/pull/4853)
+
 # 2.2.26 (August 17, 2021)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking changelogs from future rubygems 3.2.27 and bundler 2.2.27 into master.