### PR TITLE
Avoid loading `uri` unnecessarily when activating gems

### DIFF
--- a/lib/rubygems/resolver/set.rb
+++ b/lib/rubygems/resolver/set.rb
@@ -20,7 +20,6 @@ class Gem::Resolver::Set
   attr_accessor :prerelease
 
   def initialize # :nodoc:
-    require 'uri'
     @prerelease = false
     @remote     = true
     @errors     = []


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

```shell
$ ruby -e URI
-e:1:in `<main>': uninitialized constant URI (NameError)
```

will raise an uninitialized constant error, while

```
$ irb
irb(main):001:0> URI
=> URI
irb(main):002:0> 
```

will just work.

IRB and plain ruby should behave as similarly as possible, so that debugging with IRB simulates the realworld as much as possible.

## What is your fix for the problem, implemented in this PR?

Remove unnecessary require of `uri` so that user code always need to load it explicitly.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
