### PR TITLE
Fix triple spacing when generating lockfile

### DIFF
--- a/bundler/lib/bundler/lockfile_generator.rb
+++ b/bundler/lib/bundler/lockfile_generator.rb
@@ -86,7 +86,7 @@ module Bundler
           out << "  #{key}: #{val}\n"
         end
       when String
-        out << "   #{value}\n"
+        out << "  #{value}\n"
       else
         raise ArgumentError, "#{value.inspect} can't be serialized in a lockfile"
       end

--- a/bundler/spec/bundler/definition_spec.rb
+++ b/bundler/spec/bundler/definition_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Bundler::Definition do
           foo!
 
         BUNDLED WITH
-           #{Bundler::VERSION}
+          #{Bundler::VERSION}
       G
     end
 
@@ -115,7 +115,7 @@ RSpec.describe Bundler::Definition do
           foo!
 
         BUNDLED WITH
-           #{Bundler::VERSION}
+          #{Bundler::VERSION}
       G
     end
 
@@ -143,7 +143,7 @@ RSpec.describe Bundler::Definition do
           only_java
 
         BUNDLED WITH
-           #{Bundler::VERSION}
+          #{Bundler::VERSION}
       G
     end
 
@@ -169,7 +169,7 @@ RSpec.describe Bundler::Definition do
           foo
 
         BUNDLED WITH
-           #{Bundler::VERSION}
+          #{Bundler::VERSION}
       G
     end
   end
@@ -239,7 +239,7 @@ RSpec.describe Bundler::Definition do
               isolated_owner
 
             BUNDLED WITH
-               1.13.0
+              1.13.0
           L
 
           allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)

--- a/bundler/spec/bundler/env_spec.rb
+++ b/bundler/spec/bundler/env_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Bundler::Env do
             rack
 
           BUNDLED WITH
-             1.10.0
+            1.10.0
         L
 
         allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)

--- a/bundler/spec/bundler/lockfile_parser_spec.rb
+++ b/bundler/spec/bundler/lockfile_parser_spec.rb
@@ -23,10 +23,10 @@ RSpec.describe Bundler::LockfileParser do
       rake
 
     RUBY VERSION
-       ruby 2.1.3p242
+      ruby 2.1.3p242
 
     BUNDLED WITH
-       1.12.0.rc.2
+      1.12.0.rc.2
   L
 
   describe ".sections_in_lockfile" do

--- a/bundler/spec/commands/binstubs_spec.rb
+++ b/bundler/spec/commands/binstubs_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe "bundle binstubs <gem>" do
           let(:system_bundler_version) { "55" }
 
           before do
-            lockfile lockfile.gsub(/BUNDLED WITH\n   .*$/m, "BUNDLED WITH\n   44.0")
+            lockfile lockfile.gsub(/BUNDLED WITH\n  .*$/m, "BUNDLED WITH\n  44.0")
           end
 
           it "runs the correct version of bundler" do
@@ -185,7 +185,7 @@ RSpec.describe "bundle binstubs <gem>" do
           let(:system_bundler_version) { "55.1" }
 
           before do
-            lockfile lockfile.gsub(/BUNDLED WITH\n   .*$/m, "BUNDLED WITH\n   55.0")
+            lockfile lockfile.gsub(/BUNDLED WITH\n  .*$/m, "BUNDLED WITH\n  55.0")
           end
 
           it "runs the available version of bundler when the version is older and the same major" do
@@ -199,7 +199,7 @@ RSpec.describe "bundle binstubs <gem>" do
           let(:system_bundler_version) { "55" }
 
           before do
-            lockfile lockfile.gsub(/BUNDLED WITH\n   .*$/m, "BUNDLED WITH\n   2.12.0.a")
+            lockfile lockfile.gsub(/BUNDLED WITH\n  .*$/m, "BUNDLED WITH\n  2.12.0.a")
           end
 
           it "runs the correct version of bundler when the version is a pre-release" do

--- a/bundler/spec/commands/check_spec.rb
+++ b/bundler/spec/commands/check_spec.rb
@@ -447,7 +447,7 @@ RSpec.describe "bundle check" do
       L
 
       if bundler_version
-        lock += "\n        BUNDLED WITH\n           #{bundler_version}\n"
+        lock += "\n        BUNDLED WITH\n          #{bundler_version}\n"
       end
 
       lock

--- a/bundler/spec/commands/check_spec.rb
+++ b/bundler/spec/commands/check_spec.rb
@@ -357,7 +357,7 @@ RSpec.describe "bundle check" do
           rack
 
         BUNDLED WITH
-           #{Bundler::VERSION}
+          #{Bundler::VERSION}
       L
     end
 
@@ -426,7 +426,7 @@ RSpec.describe "bundle check" do
           depends_on_rack!
 
         BUNDLED WITH
-           #{Bundler::VERSION}
+          #{Bundler::VERSION}
       L
     end
   end

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe "bundle exec" do
         rack (= 0.9.1)
 
       BUNDLED WITH
-          2.1.4
+        2.1.4
     L
 
     bundle "exec bundle cache", :env => { "BUNDLER_VERSION" => Bundler::VERSION }

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -517,7 +517,7 @@ RSpec.describe "bundle install with gem sources" do
             ruby 2.1.3p100
 
          BUNDLED WITH
-            #{Bundler::VERSION}
+           #{Bundler::VERSION}
         L
       end
 
@@ -543,7 +543,7 @@ RSpec.describe "bundle install with gem sources" do
             ruby 2.2.3p100
 
          BUNDLED WITH
-            #{Bundler::VERSION}
+           #{Bundler::VERSION}
         L
       end
 

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -514,7 +514,7 @@ RSpec.describe "bundle install with gem sources" do
          DEPENDENCIES
 
          RUBY VERSION
-            ruby 2.1.3p100
+           ruby 2.1.3p100
 
          BUNDLED WITH
            #{Bundler::VERSION}
@@ -540,7 +540,7 @@ RSpec.describe "bundle install with gem sources" do
          DEPENDENCIES
 
          RUBY VERSION
-            ruby 2.2.3p100
+           ruby 2.2.3p100
 
          BUNDLED WITH
            #{Bundler::VERSION}

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -744,7 +744,7 @@ RSpec.describe "bundle install with gem sources" do
           libv8
 
         BUNDLED WITH
-           #{Bundler::VERSION}
+          #{Bundler::VERSION}
       L
 
       bundle "config set --local deployment true"

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "bundle lock" do
         weakling
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     L
   end
 
@@ -107,7 +107,7 @@ RSpec.describe "bundle lock" do
         foo
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     L
     bundle "lock --gemfile CustomGemfile"
 
@@ -334,7 +334,7 @@ RSpec.describe "bundle lock" do
         mixlib-shellout
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
 
     simulate_platform(rb) { bundle :lock }
@@ -362,7 +362,7 @@ RSpec.describe "bundle lock" do
         mixlib-shellout
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -399,7 +399,7 @@ RSpec.describe "bundle lock" do
         libv8
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
 
     simulate_platform(Gem::Platform.new("x86_64-darwin-19")) { bundle "lock --update" }
@@ -440,7 +440,7 @@ RSpec.describe "bundle lock" do
         libv8
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -475,7 +475,7 @@ RSpec.describe "bundle lock" do
         libv8
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
 
     previous_lockfile = lockfile
@@ -530,7 +530,7 @@ RSpec.describe "bundle lock" do
         raygun-apm
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     L
 
     bundle "lock --add-platform x86_64-linux", :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }

--- a/bundler/spec/commands/outdated_spec.rb
+++ b/bundler/spec/commands/outdated_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe "bundle outdated" do
           vcr!
 
         BUNDLED WITH
-           #{Bundler::VERSION}
+          #{Bundler::VERSION}
       L
     end
 
@@ -1272,7 +1272,7 @@ RSpec.describe "bundle outdated" do
           nokogiri
 
         BUNDLED WITH
-           #{Bundler::VERSION}
+          #{Bundler::VERSION}
       L
 
       gemfile <<-G
@@ -1326,7 +1326,7 @@ RSpec.describe "bundle outdated" do
           mini_portile2
 
         BUNDLED WITH
-           #{Bundler::VERSION}
+          #{Bundler::VERSION}
       L
     end
 

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -978,7 +978,7 @@ RSpec.describe "bundle update --ruby" do
        DEPENDENCIES
 
        RUBY VERSION
-          ruby 2.1.4p222
+         ruby 2.1.4p222
 
        BUNDLED WITH
          #{Bundler::VERSION}
@@ -1025,7 +1025,7 @@ RSpec.describe "bundle update --ruby" do
        DEPENDENCIES
 
        RUBY VERSION
-          ruby 1.8.3p55
+         ruby 1.8.3p55
 
        BUNDLED WITH
          #{Bundler::VERSION}

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -950,7 +950,7 @@ RSpec.describe "bundle update --ruby" do
        DEPENDENCIES
 
        BUNDLED WITH
-          #{Bundler::VERSION}
+         #{Bundler::VERSION}
       L
     end
   end
@@ -981,7 +981,7 @@ RSpec.describe "bundle update --ruby" do
           ruby 2.1.4p222
 
        BUNDLED WITH
-          #{Bundler::VERSION}
+         #{Bundler::VERSION}
       L
     end
   end
@@ -1028,7 +1028,7 @@ RSpec.describe "bundle update --ruby" do
           ruby 1.8.3p55
 
        BUNDLED WITH
-          #{Bundler::VERSION}
+         #{Bundler::VERSION}
       L
     end
   end

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -291,7 +291,7 @@ RSpec.describe "bundle update" do
           country_select
 
         BUNDLED WITH
-           #{Bundler::VERSION}
+          #{Bundler::VERSION}
       L
 
       previous_lockfile = lockfile
@@ -690,7 +690,7 @@ RSpec.describe "bundle update" do
           vcr!
 
         BUNDLED WITH
-           #{Bundler::VERSION}
+          #{Bundler::VERSION}
       L
     end
 
@@ -1184,7 +1184,7 @@ RSpec.describe "bundle update conservative" do
           shared_owner_b
 
         BUNDLED WITH
-           #{Bundler::VERSION}
+          #{Bundler::VERSION}
       L
     end
 
@@ -1237,7 +1237,7 @@ RSpec.describe "bundle update conservative" do
           shared_owner_b
 
         BUNDLED WITH
-           #{Bundler::VERSION}
+          #{Bundler::VERSION}
       L
     end
 

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -362,7 +362,7 @@ RSpec.describe "bundle install from an existing gemspec" do
             foo!
 
           BUNDLED WITH
-             #{Bundler::VERSION}
+            #{Bundler::VERSION}
         L
       end
 
@@ -463,7 +463,7 @@ RSpec.describe "bundle install from an existing gemspec" do
                 foo!
 
               BUNDLED WITH
-                 #{Bundler::VERSION}
+                #{Bundler::VERSION}
             L
           end
         end
@@ -528,7 +528,7 @@ RSpec.describe "bundle install from an existing gemspec" do
                 indirect_platform_specific
 
               BUNDLED WITH
-                 #{Bundler::VERSION}
+                #{Bundler::VERSION}
             L
           end
         end
@@ -612,7 +612,7 @@ RSpec.describe "bundle install from an existing gemspec" do
           chef!
 
         BUNDLED WITH
-           #{Bundler::VERSION}
+          #{Bundler::VERSION}
       L
 
       lockfile initial_lockfile

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -494,7 +494,7 @@ RSpec.describe "bundle install from an existing gemspec" do
                 platform_specific
 
               BUNDLED WITH
-                 #{Bundler::VERSION}
+                #{Bundler::VERSION}
             L
           end
         end

--- a/bundler/spec/install/gemfile/install_if_spec.rb
+++ b/bundler/spec/install/gemfile/install_if_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "bundle install with install_if conditionals" do
         thin
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     L
   end
 end

--- a/bundler/spec/install/gemfile/path_spec.rb
+++ b/bundler/spec/install/gemfile/path_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe "bundle install with explicit source paths" do
         demo!
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     L
 
     bundle :install, :dir => lib_path("demo")
@@ -571,7 +571,7 @@ RSpec.describe "bundle install with explicit source paths" do
           foo!
 
         BUNDLED WITH
-           #{Bundler::VERSION}
+          #{Bundler::VERSION}
       G
 
       build_lib "foo", "1.0", :path => lib_path("foo") do |s|
@@ -599,7 +599,7 @@ RSpec.describe "bundle install with explicit source paths" do
           foo!
 
         BUNDLED WITH
-           #{Bundler::VERSION}
+          #{Bundler::VERSION}
       G
 
       expect(the_bundle).to include_gems "rack 0.9.1"
@@ -633,7 +633,7 @@ RSpec.describe "bundle install with explicit source paths" do
           foo!
 
         BUNDLED WITH
-           #{Bundler::VERSION}
+          #{Bundler::VERSION}
       G
 
       build_lib "foo", "1.0", :path => lib_path("foo") do |s|
@@ -664,7 +664,7 @@ RSpec.describe "bundle install with explicit source paths" do
           foo!
 
         BUNDLED WITH
-           #{Bundler::VERSION}
+          #{Bundler::VERSION}
       G
 
       expect(the_bundle).to include_gems "rack 0.9.1"

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe "bundle install across platforms" do
         pry
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     L
 
     bundle "lock --add-platform ruby"
@@ -183,7 +183,7 @@ RSpec.describe "bundle install across platforms" do
         pry
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     L
 
     lockfile_should_be good_lockfile
@@ -325,7 +325,7 @@ RSpec.describe "bundle install across platforms" do
         platform_specific
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 end
@@ -459,7 +459,7 @@ RSpec.describe "bundle install with platform conditionals" do
         rack
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     L
   end
 end

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
               depends_on_rack!
 
             BUNDLED WITH
-               #{Bundler::VERSION}
+              #{Bundler::VERSION}
           L
 
           previous_lockfile = lockfile
@@ -633,7 +633,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
             sidekiq-pro!
 
           BUNDLED WITH
-             #{Bundler::VERSION}
+            #{Bundler::VERSION}
         L
       end
 
@@ -689,7 +689,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
             sidekiq-pro!
 
           BUNDLED WITH
-             #{Bundler::VERSION}
+            #{Bundler::VERSION}
         L
       end
 
@@ -773,7 +773,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
             sidekiq-pro!
 
           BUNDLED WITH
-             #{Bundler::VERSION}
+            #{Bundler::VERSION}
         L
       end
 
@@ -829,7 +829,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
             sidekiq-pro!
 
           BUNDLED WITH
-             #{Bundler::VERSION}
+            #{Bundler::VERSION}
         L
       end
     end
@@ -917,7 +917,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
             nokogiri
 
           BUNDLED WITH
-             #{Bundler::VERSION}
+            #{Bundler::VERSION}
         L
 
         bundle "install --verbose", :artifice => "compact_index"
@@ -1006,7 +1006,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
             rack!
 
           BUNDLED WITH
-             #{Bundler::VERSION}
+            #{Bundler::VERSION}
         L
       end
 
@@ -1028,7 +1028,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
             rack!
 
           BUNDLED WITH
-             #{Bundler::VERSION}
+            #{Bundler::VERSION}
         L
       end
 
@@ -1439,7 +1439,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
           mime-types (~> 3.0)!
 
         BUNDLED WITH
-           #{Bundler::VERSION}
+          #{Bundler::VERSION}
       L
     end
   end

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "bundle install with specific platforms" do
           google-protobuf
 
         BUNDLED WITH
-           2.1.4
+          2.1.4
       L
 
       # force strict usage of the lock file by setting frozen mode
@@ -78,7 +78,7 @@ RSpec.describe "bundle install with specific platforms" do
           google-protobuf
 
         BUNDLED WITH
-           2.1.4
+          2.1.4
       L
 
       bundle "update", :env => { "BUNDLER_VERSION" => Bundler::VERSION }
@@ -100,7 +100,7 @@ RSpec.describe "bundle install with specific platforms" do
           google-protobuf
 
         BUNDLED WITH
-           #{Bundler::VERSION}
+          #{Bundler::VERSION}
       L
     end
 
@@ -138,7 +138,7 @@ RSpec.describe "bundle install with specific platforms" do
           libv8
 
         BUNDLED WITH
-           2.1.4
+          2.1.4
       L
 
       bundle "install --verbose", :artifice => "compact_index", :env => { "BUNDLER_VERSION" => "2.1.4", "BUNDLER_SPEC_GEM_REPO" => gem_repo2.to_s }
@@ -196,7 +196,7 @@ RSpec.describe "bundle install with specific platforms" do
           pg_array_parser!
 
         BUNDLED WITH
-           #{Bundler::VERSION}
+          #{Bundler::VERSION}
       L
 
       bundle "config set --local cache_all true"
@@ -276,7 +276,7 @@ RSpec.describe "bundle install with specific platforms" do
         sorbet-static (= 0.5.6403)
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     L
 
     bundle "install --verbose"

--- a/bundler/spec/install/gems/flex_spec.rb
+++ b/bundler/spec/install/gems/flex_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe "bundle flex_install" do
         rack
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
       L
     end
   end

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "the lockfile format" do
         rack
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -61,7 +61,7 @@ RSpec.describe "the lockfile format" do
         rack
 
       BUNDLED WITH
-         1.8.2
+        1.8.2
     L
 
     install_gemfile <<-G, :env => { "BUNDLER_VERSION" => Bundler::VERSION }
@@ -83,7 +83,7 @@ RSpec.describe "the lockfile format" do
         rack
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -103,7 +103,7 @@ RSpec.describe "the lockfile format" do
         rack
 
       BUNDLED WITH
-         #{version}
+        #{version}
     L
 
     install_gemfile <<-G
@@ -125,7 +125,7 @@ RSpec.describe "the lockfile format" do
         rack
 
       BUNDLED WITH
-         #{version}
+        #{version}
     G
   end
 
@@ -162,7 +162,7 @@ RSpec.describe "the lockfile format" do
         rack (> 0)
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -183,7 +183,7 @@ RSpec.describe "the lockfile format" do
         rack
 
       BUNDLED WITH
-         #{newer_minor}
+        #{newer_minor}
     L
 
     install_gemfile <<-G
@@ -212,7 +212,7 @@ RSpec.describe "the lockfile format" do
         rack
 
       BUNDLED WITH
-         #{newer_minor}
+        #{newer_minor}
     G
   end
 
@@ -235,7 +235,7 @@ RSpec.describe "the lockfile format" do
         rack
 
       BUNDLED WITH
-         #{older_major}
+        #{older_major}
     L
 
     install_gemfile <<-G, :env => { "BUNDLER_VERSION" => Bundler::VERSION }
@@ -262,7 +262,7 @@ RSpec.describe "the lockfile format" do
         rack
 
       BUNDLED WITH
-         #{current_version}
+        #{current_version}
     G
   end
 
@@ -288,7 +288,7 @@ RSpec.describe "the lockfile format" do
         rack-obama
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -314,7 +314,7 @@ RSpec.describe "the lockfile format" do
         rack-obama (>= 1.0)
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -356,7 +356,7 @@ RSpec.describe "the lockfile format" do
         rack-obama (>= 1.0)!
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -381,7 +381,7 @@ RSpec.describe "the lockfile format" do
         net-sftp
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
 
     expect(the_bundle).to include_gems "net-sftp 1.1.1", "net-ssh 1.0.0"
@@ -413,7 +413,7 @@ RSpec.describe "the lockfile format" do
         foo!
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -449,7 +449,7 @@ RSpec.describe "the lockfile format" do
         rack
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     L
 
     bundle "install"
@@ -484,7 +484,7 @@ RSpec.describe "the lockfile format" do
         foo!
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -516,7 +516,7 @@ RSpec.describe "the lockfile format" do
         foo!
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -548,7 +548,7 @@ RSpec.describe "the lockfile format" do
         foo!
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -577,7 +577,7 @@ RSpec.describe "the lockfile format" do
         foo!
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -610,7 +610,7 @@ RSpec.describe "the lockfile format" do
         foo!
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -652,7 +652,7 @@ RSpec.describe "the lockfile format" do
         rack
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -676,7 +676,7 @@ RSpec.describe "the lockfile format" do
         rack!
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -711,7 +711,7 @@ RSpec.describe "the lockfile format" do
         thin
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -750,7 +750,7 @@ RSpec.describe "the lockfile format" do
         rails
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -776,7 +776,7 @@ RSpec.describe "the lockfile format" do
         double_deps
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -802,7 +802,7 @@ RSpec.describe "the lockfile format" do
         rack-obama (>= 1.0)
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -828,7 +828,7 @@ RSpec.describe "the lockfile format" do
         rack-obama (>= 1.0)
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -859,7 +859,7 @@ RSpec.describe "the lockfile format" do
         foo!
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -890,7 +890,7 @@ RSpec.describe "the lockfile format" do
         foo!
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -921,7 +921,7 @@ RSpec.describe "the lockfile format" do
         foo!
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -950,7 +950,7 @@ RSpec.describe "the lockfile format" do
         foo!
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -968,7 +968,7 @@ RSpec.describe "the lockfile format" do
         rack
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
 
     install_gemfile <<-G
@@ -991,7 +991,7 @@ RSpec.describe "the lockfile format" do
         rack
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -1022,7 +1022,7 @@ RSpec.describe "the lockfile format" do
         platform_specific
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -1053,7 +1053,7 @@ RSpec.describe "the lockfile format" do
         rack
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -1077,7 +1077,7 @@ RSpec.describe "the lockfile format" do
         rack
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -1101,7 +1101,7 @@ RSpec.describe "the lockfile format" do
         rack (= 1.0)
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -1125,7 +1125,7 @@ RSpec.describe "the lockfile format" do
         rack (= 1.0)
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -1170,7 +1170,7 @@ RSpec.describe "the lockfile format" do
         rack (> 0.9, < 1.0)
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -1194,10 +1194,10 @@ RSpec.describe "the lockfile format" do
         rack (> 0.9, < 1.0)
 
       RUBY VERSION
-         ruby #{RUBY_VERSION}p#{RUBY_PATCHLEVEL}
+        ruby #{RUBY_VERSION}p#{RUBY_PATCHLEVEL}
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
   end
 
@@ -1322,7 +1322,7 @@ RSpec.describe "the lockfile format" do
         rack
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     L
 
     install_gemfile <<-G, :raise_on_error => false

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -479,7 +479,7 @@ RSpec.describe "major deprecations" do
           rack!
 
         BUNDLED WITH
-           #{Bundler::VERSION}
+          #{Bundler::VERSION}
       L
 
       bundle "config set --local frozen true"

--- a/bundler/spec/other/platform_spec.rb
+++ b/bundler/spec/other/platform_spec.rb
@@ -228,10 +228,10 @@ G
         DEPENDENCIES
 
         RUBY VERSION
-           ruby 1.0.0p127
+          ruby 1.0.0p127
 
         BUNDLED WITH
-           #{Bundler::VERSION}
+          #{Bundler::VERSION}
       L
 
       bundle "platform --ruby"

--- a/bundler/spec/plugins/source/example_spec.rb
+++ b/bundler/spec/plugins/source/example_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "real source plugins" do
           a-path-gem!
 
         BUNDLED WITH
-           #{Bundler::VERSION}
+          #{Bundler::VERSION}
       G
     end
 
@@ -176,7 +176,7 @@ RSpec.describe "real source plugins" do
             a-path-gem!
 
           BUNDLED WITH
-             #{Bundler::VERSION}
+            #{Bundler::VERSION}
         G
       end
 
@@ -361,7 +361,7 @@ RSpec.describe "real source plugins" do
           ma-gitp-gem!
 
         BUNDLED WITH
-           #{Bundler::VERSION}
+          #{Bundler::VERSION}
       G
     end
 
@@ -387,7 +387,7 @@ RSpec.describe "real source plugins" do
             ma-gitp-gem!
 
           BUNDLED WITH
-             #{Bundler::VERSION}
+            #{Bundler::VERSION}
         G
       end
 

--- a/bundler/spec/runtime/inline_spec.rb
+++ b/bundler/spec/runtime/inline_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe "bundler/inline#gemfile" do
         rake
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     G
 
     script <<-RUBY

--- a/bundler/spec/runtime/platform_spec.rb
+++ b/bundler/spec/runtime/platform_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
         nokogiri (~> 1.11)
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     L
 
     gemfile <<-G
@@ -136,7 +136,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
         nokogiri
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+        #{Bundler::VERSION}
     L
 
     bundle "install", :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -1189,7 +1189,7 @@ end
       lock += <<-L
 
         BUNDLED WITH
-           #{Bundler::VERSION}
+          #{Bundler::VERSION}
       L
 
       lock

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -1122,7 +1122,7 @@ end
       L
 
       if bundler_version
-        lock += "\n        BUNDLED WITH\n           #{bundler_version}\n"
+        lock += "\n        BUNDLED WITH\n          #{bundler_version}\n"
       end
 
       lock

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -1183,7 +1183,7 @@ end
       L
 
       if ruby_version
-        lock += "\n        RUBY VERSION\n           ruby #{ruby_version}\n"
+        lock += "\n        RUBY VERSION\n          ruby #{ruby_version}\n"
       end
 
       lock += <<-L

--- a/bundler/spec/update/git_spec.rb
+++ b/bundler/spec/update/git_spec.rb
@@ -325,7 +325,7 @@ RSpec.describe "bundle update" do
           rack
 
         BUNDLED WITH
-           #{Bundler::VERSION}
+          #{Bundler::VERSION}
       G
     end
 
@@ -361,7 +361,7 @@ RSpec.describe "bundle update" do
           rack
 
         BUNDLED WITH
-           #{Bundler::VERSION}
+          #{Bundler::VERSION}
       G
     end
   end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

The `BUNDLED WITH` section of the Gemfile.lock have an extra space before each line of content.

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

Remove this extra space from line 89 and close #3326.

There was a pull request on the old repository (rubygems/bundler#7236), but it was not merged to this repository. So I re-create this pull request.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
