### PR TITLE
Fix `wordy` method in `SourceFetchProblem` changing the password of source

### DIFF
--- a/lib/rubygems/errors.rb
+++ b/lib/rubygems/errors.rb
@@ -171,8 +171,7 @@ module Gem
     # An English description of the error.
 
     def wordy
-      @source.uri.password = 'REDACTED' unless @source.uri.password.nil?
-      "Unable to download data from #{@source.uri} - #{@error.message}"
+      "Unable to download data from #{Gem::Uri.new(@source.uri).redacted} - #{@error.message}"
     end
 
     ##

--- a/test/rubygems/test_gem_source_fetch_problem.rb
+++ b/test/rubygems/test_gem_source_fetch_problem.rb
@@ -23,4 +23,14 @@ class TestGemSourceFetchProblem < Gem::TestCase
 
     refute_match sf.wordy, 'secret'
   end
+
+  def test_source_password_no_redacted
+    source = Gem::Source.new 'https://username:secret@gemsource.com'
+    error  = RuntimeError.new 'test'
+
+    sf = Gem::SourceFetchProblem.new source, error
+    sf.wordy
+
+    assert_match 'secret', source.uri.to_s
+  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Just a potential issue, but some error code was modifiying the original source which was not expected.

## What is your fix for the problem, implemented in this PR?

Do not change the password of the input parameter source during anonymization, instead create a copy of the URL for anonymization.

Fixes #4908.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
