### PR TITLE
Use example.com in new gem template, since it will never have a potentially dangerous backing website

### DIFF
--- a/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 <%- end -%>
   spec.required_ruby_version = ">= <%= config[:required_ruby_version] %>"
 
-  spec.metadata["allowed_push_host"] = "TODO: Set to 'https://mygemserver.com'"
+  spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "TODO: Put your gem's public repo URL here."

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -563,7 +563,7 @@ RSpec.describe "bundle gem" do
       bundle "gem #{gem_name}"
 
       expect(generated_gemspec.metadata["allowed_push_host"]).
-        to match(/mygemserver\.com/)
+        to match(/example\.com/)
     end
 
     it "sets a minimum ruby version" do


### PR DESCRIPTION
example.com is the canonical stand in for domain examples and will never have a backing website.

via https://www.rfc-editor.org/rfc/rfc2606.html

## What was the end-user or developer problem that led to this PR?

possible malicious website in gemspec template

Closes #4917.