### PR TITLE
Fix redacted credentials being sent to gemserver

### DIFF
--- a/lib/rubygems/request.rb
+++ b/lib/rubygems/request.rb
@@ -191,7 +191,7 @@ class Gem::Request
     begin
       @requests[connection.object_id] += 1
 
-      verbose "#{request.method} #{Gem::Uri.new(@uri).redacted}"
+      verbose "#{request.method} #{@uri.redacted}"
 
       file_name = File.basename(@uri.path)
       # perform download progress reporter only for gems

--- a/lib/rubygems/uri.rb
+++ b/lib/rubygems/uri.rb
@@ -43,6 +43,11 @@ class Gem::Uri
     @parsed_uri.respond_to?(method_name, include_private) || super
   end
 
+  protected
+
+  # Add a protected reader for the cloned instance to access the original object's parsed uri
+  attr_reader :parsed_uri
+
   private
 
   ##
@@ -98,5 +103,9 @@ class Gem::Uri
 
   def token?
     !user.nil? && password.nil?
+  end
+
+  def initialize_copy(original)
+    @parsed_uri = original.parsed_uri.clone
   end
 end

--- a/test/rubygems/test_gem_request.rb
+++ b/test/rubygems/test_gem_request.rb
@@ -185,7 +185,7 @@ class TestGemRequest < Gem::TestCase
   end
 
   def test_fetch
-    uri = URI.parse "#{@gem_repo}/specs.#{Gem.marshal_version}"
+    uri = Gem::Uri.new(URI.parse "#{@gem_repo}/specs.#{Gem.marshal_version}")
     response = util_stub_net_http(:body => :junk, :code => 200) do
       @request = make_request(uri, Net::HTTP::Get, nil, nil)
 
@@ -198,7 +198,7 @@ class TestGemRequest < Gem::TestCase
 
   def test_fetch_basic_auth
     Gem.configuration.verbose = :really
-    uri = URI.parse "https://user:pass@example.rubygems/specs.#{Gem.marshal_version}"
+    uri = Gem::Uri.new(URI.parse "https://user:pass@example.rubygems/specs.#{Gem.marshal_version}")
     conn = util_stub_net_http(:body => :junk, :code => 200) do |c|
       use_ui @ui do
         @request = make_request(uri, Net::HTTP::Get, nil, nil)
@@ -214,7 +214,7 @@ class TestGemRequest < Gem::TestCase
 
   def test_fetch_basic_auth_encoded
     Gem.configuration.verbose = :really
-    uri = URI.parse "https://user:%7BDEScede%7Dpass@example.rubygems/specs.#{Gem.marshal_version}"
+    uri = Gem::Uri.new(URI.parse "https://user:%7BDEScede%7Dpass@example.rubygems/specs.#{Gem.marshal_version}")
 
     conn = util_stub_net_http(:body => :junk, :code => 200) do |c|
       use_ui @ui do
@@ -231,7 +231,7 @@ class TestGemRequest < Gem::TestCase
 
   def test_fetch_basic_oauth_encoded
     Gem.configuration.verbose = :really
-    uri = URI.parse "https://%7BDEScede%7Dpass:x-oauth-basic@example.rubygems/specs.#{Gem.marshal_version}"
+    uri = Gem::Uri.new(URI.parse "https://%7BDEScede%7Dpass:x-oauth-basic@example.rubygems/specs.#{Gem.marshal_version}")
 
     conn = util_stub_net_http(:body => :junk, :code => 200) do |c|
       use_ui @ui do
@@ -247,7 +247,7 @@ class TestGemRequest < Gem::TestCase
   end
 
   def test_fetch_head
-    uri = URI.parse "#{@gem_repo}/specs.#{Gem.marshal_version}"
+    uri = Gem::Uri.new(URI.parse "#{@gem_repo}/specs.#{Gem.marshal_version}")
     response = util_stub_net_http(:body => '', :code => 200) do |conn|
       @request = make_request(uri, Net::HTTP::Get, nil, nil)
       @request.fetch
@@ -258,7 +258,7 @@ class TestGemRequest < Gem::TestCase
   end
 
   def test_fetch_unmodified
-    uri = URI.parse "#{@gem_repo}/specs.#{Gem.marshal_version}"
+    uri = Gem::Uri.new(URI.parse "#{@gem_repo}/specs.#{Gem.marshal_version}")
     t = Time.utc(2013, 1, 2, 3, 4, 5)
     conn, response = util_stub_net_http(:body => '', :code => 304) do |c|
       @request = make_request(uri, Net::HTTP::Get, t, nil)

--- a/test/rubygems/test_gem_uri.rb
+++ b/test/rubygems/test_gem_uri.rb
@@ -29,4 +29,11 @@ class TestUri < Gem::TestCase
   def test_redacted_with_invalid_uri
     assert_equal "https://www.example.com:80index", Gem::Uri.new("https://www.example.com:80index").redacted.to_s
   end
+
+  def test_redacted_does_not_modify_uri
+    url = 'https://user:password@example.com'
+    uri = Gem::Uri.new(url)
+    assert_equal 'https://user:REDACTED@example.com', uri.redacted.to_s
+    assert_equal url, uri.to_s
+  end
 end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

When using a `username:password` remote source for a private gem server, the credentials redaction process was modifying the original remote uri resulting in subsequent requests being rejected with a 401.  The issue is detailed here: https://github.com/rubygems/rubygems/issues/4906

Also fixed a small bug I stumbled onto that did not seem to be causing problems.  A `Gem::Uri` instance was being passed into `Gem::Uri.new` unnecessarily, which created a nested instance.  This did not seem to be causing issues because of the `method_missing` flow in the `Gem::Uri` class, but I updated the `Gem::Uri.new` call as this behavior did not seem like it was intended.

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

I was able to reproduce the issue and examine the web traffic using charles as detailed here: https://github.com/rubygems/rubygems/issues/4906#issuecomment-914492070
The credentials being sent to the gem server were `username:REDACTED` instead of `username:password`.

The issue was that the `Gem::Uri` class used shallow cloning when redacting the password for logging purposes, but this resulted in modifying the uri that would then go on to be used in the request.  To fix this issue I used `initialize_copy` to implement deep cloning to make sure the uri that is used for redacting credentials is a copy, not the original.

Thanks @pindell-matt for the help!

Fixes #4906.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
