### PR TITLE
Changelogs for rubygems 3.2.28 and bundler 2.2.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 3.2.28 / 2021-09-22
+
+## Enhancements:
+
+* Support MINGW-UCRT. Pull request #4925 by hsbt
+* Only check if descriptions *start with* FIXME/TODO. Pull request #4841
+  by duckinator
+* Avoid loading `uri` unnecessarily when activating gems. Pull request
+  #4897 by deivid-rodriguez
+
+## Bug fixes:
+
+* Fix redacted credentials being sent to gemserver. Pull request #4919 by
+  jdliss
+
 # 3.2.27 / 2021-09-03
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.2.28 (September 22, 2021)
+
+## Enhancements:
+
+  - Use example.com in new gem template, since it will never have a potentially dangerous backing website [#4918](https://github.com/rubygems/rubygems/pull/4918)
+  - Deprecate `--install` flag to `bundle remove` and trigger install by default [#4891](https://github.com/rubygems/rubygems/pull/4891)
+
 # 2.2.27 (September 3, 2021)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking changelogs from future rubygems 3.2.28 and bundler 2.2.28 into master.