### PR TITLE
Revert "Fix an issue causing nested Gem::Uri instances"

### DIFF
--- a/lib/rubygems/request.rb
+++ b/lib/rubygems/request.rb
@@ -191,7 +191,7 @@ class Gem::Request
     begin
       @requests[connection.object_id] += 1
 
-      verbose "#{request.method} #{@uri.redacted}"
+      verbose "#{request.method} #{Gem::Uri.new(@uri).redacted}"
 
       file_name = File.basename(@uri.path)
       # perform download progress reporter only for gems


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Commit 6589f7bcc7a63a47cb73f58a290c1e1ac42bba99 caused issues since sometimes the `uri` passed to `Gem::Request` is not a `Gem::Uri` but a standard `URI`, so we can't call `#redacted` on it.

I discovered this when trying to release bundler 2.2.28 using the (still unreleased) 3.2.28 version of rubygems and getting the following crash:

```
bundler 2.2.28 built to pkg/bundler-2.2.28.gem.
Pushing gem to https://rubygems.org...
ERROR:  While executing gem ... (NoMethodError)
    undefined method `redacted' for #<URI::HTTPS https://rubygems.org/api/v1/gems>
	/home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems/request.rb:194:in `perform_request'
	/home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems/request.rb:152:in `fetch'
	/home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems/remote_fetcher.rb:309:in `request'
	/home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems/gemcutter_utilities.rb:234:in `request_with_otp'
	/home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems/gemcutter_utilities.rb:105:in `rubygems_api_request'
	/home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems/commands/push_command.rb:89:in `send_push_request'
	/home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems/commands/push_command.rb:81:in `send_gem'
	/home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems/commands/push_command.rb:66:in `execute'
	/home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems/command.rb:323:in `invoke_with_build_args'
	/home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems/command_manager.rb:178:in `process_args'
	/home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems/command_manager.rb:147:in `run'
	/home/deivid/.rbenv/versions/3.0.2/lib/ruby/site_ruby/3.0.0/rubygems/gem_runner.rb:53:in `run'
	/home/deivid/.rbenv/versions/3.0.2/bin/gem:15:in `<main>'
```
## What is your fix for the problem, implemented in this PR?

Revert the commit, since in addition to causing issues, it was unrelated to the fix in #4919.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
