### PR TITLE
Use pend instead of skip in the absence of git in test helper

### DIFF
--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -595,7 +595,7 @@ class Gem::TestCase < Test::Unit::TestCase
   def have_git?
     return if in_path? @git
 
-    skip 'cannot find git executable, use GIT environment variable to set'
+    pend 'cannot find git executable, use GIT environment variable to set'
   end
 
   def in_path?(executable) # :nodoc:


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In Debian, we build rubygems without git and almost 40 tests failed because the `skip` method is missing. Checking other cases, for instance where tests depending on cmake are skipped, the `skip` method is not used but `pend`.

## What is your fix for the problem, implemented in this PR?

Use `pend` instead of `skip` in `have_git?` method.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [-] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
