### PR TITLE
Prevent nested gem uri instances

### DIFF
--- a/lib/rubygems/request.rb
+++ b/lib/rubygems/request.rb
@@ -26,7 +26,7 @@ class Gem::Request
   end
 
   def initialize(uri, request_class, last_modified, pool)
-    @uri = uri
+    @uri = Gem::Uri.new(uri)
     @request_class = request_class
     @last_modified = last_modified
     @requests = Hash.new 0
@@ -191,7 +191,7 @@ class Gem::Request
     begin
       @requests[connection.object_id] += 1
 
-      verbose "#{request.method} #{Gem::Uri.new(@uri).redacted}"
+      verbose "#{request.method} #{@uri.redacted}"
 
       file_name = File.basename(@uri.path)
       # perform download progress reporter only for gems

--- a/lib/rubygems/uri.rb
+++ b/lib/rubygems/uri.rb
@@ -45,7 +45,7 @@ class Gem::Uri
 
   protected
 
-  # Add a protected reader for the cloned instance to access the original object's parsed uri
+  # A protected reader for other Gem::Uri instances to access @parsed_uri
   attr_reader :parsed_uri
 
   private
@@ -74,6 +74,7 @@ class Gem::Uri
   # Parses the #uri, returning the original uri if it's invalid
 
   def parse(uri)
+    return uri.parsed_uri if uri.is_a?(Gem::Uri)
     return uri unless uri.is_a?(String)
 
     parse!(uri)

--- a/test/rubygems/test_gem_request.rb
+++ b/test/rubygems/test_gem_request.rb
@@ -184,7 +184,19 @@ class TestGemRequest < Gem::TestCase
     assert_nil request.proxy_uri
   end
 
-  def test_fetch
+  def test_fetch_with_uri
+    uri = URI.parse "#{@gem_repo}/specs.#{Gem.marshal_version}"
+    response = util_stub_net_http(:body => :junk, :code => 200) do
+      @request = make_request(uri, Net::HTTP::Get, nil, nil)
+
+      @request.fetch
+    end
+
+    assert_equal 200, response.code
+    assert_equal :junk, response.body
+  end
+
+  def test_fetch_with_gem_uri
     uri = Gem::Uri.new(URI.parse "#{@gem_repo}/specs.#{Gem.marshal_version}")
     response = util_stub_net_http(:body => :junk, :code => 200) do
       @request = make_request(uri, Net::HTTP::Get, nil, nil)

--- a/test/rubygems/test_gem_uri.rb
+++ b/test/rubygems/test_gem_uri.rb
@@ -36,4 +36,9 @@ class TestUri < Gem::TestCase
     assert_equal 'https://user:REDACTED@example.com', uri.redacted.to_s
     assert_equal url, uri.to_s
   end
+
+  def test_no_nested_instances
+    uri = Gem::Uri.new(Gem::Uri.new("https://www.example.com"))
+    assert uri.instance_variable_get(:@parsed_uri).is_a?(URI)
+  end
 end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

I had previously fixed an issue ([now reverted](https://github.com/rubygems/rubygems/pull/4929)) where a `Gem::Uri` instance was being passed into `Gem::Uri.new` creating a nested instance.  This was happening because there are places where both `URI` and `Gem::Uri` instances are being passed into `Gem::Request`.  This bug was not causing any issues because of the `method_missing?` flow in the `Gem::Uri` class.  However, fixing the nested instance issue and treating all uri's passed into `Gem::Request` as `Gem::Uri` instances created issues when other parts of the code base pass in `URI`.  

As a stopgap measure, these changes will stop the nesting of `Gem::Uri` instances to prevent any possible issues that may arise from that, while also forcing all uri's passed into `Gem::Request` to be wrapped in a `Gem::Uri` class so that the code can be clearer about what the uri is expected to be.

## What is your fix for the problem, implemented in this PR?

`# Gem::Uri`
* If a `Gem::Uri` is passed into `Gem::Uri.new`, the `parse` method will return the `parsed_uri` in the passed in `Gem::Uri` instance.

`# Gem::Request`
* Always wrap the passed in uri in a `Gem::Uri` instance.

A better solution in my mind would probably be to go through the code base and make sure only one type of uri is passed into `Gem::Request` and add an argument error if the other type is used to prevent this kind of multi type handling from being necessary.  I'm not confident that I would be able to find all these places to solidify one pattern over the other, so as a secondary alternative this will allow for flexibility and should prevent issues where either type is used.  

Since the original nested `Gem::Uri` instance bug was not causing issues however, feel free to close and keep the current behavior (although I believe it should be fixed since it seems to be unintended).

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
