### PR TITLE
[Rakefile] Add support for bsdtar, so `rake package` works on FreeBSD and macOS.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -177,7 +177,14 @@ file "pkg/rubygems-#{v}.tgz" => "pkg/rubygems-#{v}" do
       sh "7z a -ttar  rubygems-#{v}.tar rubygems-#{v}"
       sh "7z a -tgzip rubygems-#{v}.tgz rubygems-#{v}.tar"
     else
-      sh "tar -czf rubygems-#{v}.tgz --owner=rubygems:0 --group=rubygems:0 rubygems-#{v}"
+      tar_version = `tar --version`
+      if tar_version =~ /bsdtar/
+        # bsdtar, as used by at least FreeBSD and macOS, uses `--uname` and `--gname`.
+        sh "tar -czf rubygems-#{v}.tgz --uname=rubygems:0 --gname=rubygems:0 rubygems-#{v}"
+      else # If a third variant is added, change this line to: elsif tar_version =~ /GNU tar/
+        # GNU Tar, as used by many Linux distros, uses `--owner` and `--group`.
+        sh "tar -czf rubygems-#{v}.tgz --owner=rubygems:0 --group=rubygems:0 rubygems-#{v}"
+      end
     end
   end
 end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

Closes #4912.

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

The `rake pkg/rubygems-<version>.tgz` task (which is required by `rake package` and `rake install`) did not work on FreeBSD, which uses bsdtar instead of GNU Tar, due to a slightly different command-line interface. This problem exists anywhere bsdtar is used as the `tar` implementation, which includes macOS.

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

I modified the Rakefile so if `tar` is bsdtar it'll use the appropriate flags, and otherwise it assumes it's using GNU Tar.

The only other alternative I know if is creating the tar file using Ruby. We could probably do this, but it felt excessive.

There are other tar implementations &mdash; namely _Solaris tar_ and _Schily tar_ &mdash; but it seems unnecessary to add support for tar versions before anyone tries using `rake package`/`rake install` with them. If anyone runs into a problem due to this, we can add another branch to the if/else statement or revisit creating the tar file using Ruby.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
