### PR TITLE
Only disallow FIXME/TODO for first word of gemspec description

### DIFF
--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -381,7 +381,7 @@ http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard li
   end
 
   LAZY = '"FIxxxXME" or "TOxxxDO"'.gsub(/xxx/, '')
-  LAZY_PATTERN = /^FI XME|^TO DO/x.freeze
+  LAZY_PATTERN = /\AFI XME|\ATO DO/x.freeze
   HOMEPAGE_URI_PATTERN = /\A[a-z][a-z\d+.-]*:/i.freeze
 
   def validate_lazy_metadata

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2795,6 +2795,20 @@ duplicate dependency on c (>= 1.2.3, development), (~> 1.2) use:
       assert_nothing_raised do
         @a1.validate
       end
+
+      # Adding #{f} at the start of the second or later line should be fine.
+      @a1.description = "(some description)\n#{f}"
+
+      assert_nothing_raised do
+        @a1.validate
+      end
+
+      # Adding #{t} at the start of the second or later line should be fine.
+      @a1.description = "(some description)\n#{t}"
+
+      assert_nothing_raised do
+        @a1.validate
+      end
     end
   end
 


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

As @nobu pointed out in 7890c98, #4841 — my fix for #4808 — used `^` in the regex, which matched every line. Using `\A` to match the beginning of the entire string makes more sense.

## What is your fix for the problem, implemented in this PR?

I used `\A` instead of `^`.

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
