### PR TITLE
Fix install crash when lockfile has missing dependencies for the current platform

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -78,7 +78,6 @@ module Bundler
       @lockfile_contents      = String.new
       @locked_bundler_version = nil
       @locked_ruby_version    = nil
-      @locked_specs_incomplete_for_platform = false
       @new_platform = nil
 
       if lockfile && File.exist?(lockfile)
@@ -143,6 +142,8 @@ module Bundler
 
       @dependency_changes = converge_dependencies
       @local_changes = converge_locals
+
+      @locked_specs_incomplete_for_platform = !@locked_specs.for(expand_dependencies(requested_dependencies & locked_dependencies), true, true)
 
       @requires = compute_requires
     end
@@ -762,7 +763,6 @@ module Bundler
       end
 
       resolve = SpecSet.new(converged)
-      @locked_specs_incomplete_for_platform = !@locked_specs.for(expand_dependencies(requested_dependencies & locked_dependencies), true, true)
       resolve = SpecSet.new(resolve.for(expand_dependencies(deps, true), false, false).reject{|s| @unlock[:gems].include?(s.name) })
       diff    = nil
 

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -775,6 +775,101 @@ RSpec.describe "bundle install with gem sources" do
     end
   end
 
+  context "with missing platform specific gems in lockfile" do
+    before do
+      build_repo4 do
+        build_gem "racc", "1.5.2"
+
+        build_gem "nokogiri", "1.12.4" do |s|
+          s.platform = "x86_64-darwin"
+          s.add_runtime_dependency "racc", "~> 1.4"
+        end
+
+        build_gem "nokogiri", "1.12.4" do |s|
+          s.platform = "x86_64-linux"
+          s.add_runtime_dependency "racc", "~> 1.4"
+        end
+
+        build_gem "crass", "1.0.6"
+
+        build_gem "loofah", "2.12.0" do |s|
+          s.add_runtime_dependency "crass", "~> 1.0.2"
+          s.add_runtime_dependency "nokogiri", ">= 1.5.9"
+        end
+      end
+
+      gemfile <<-G
+        source "https://gem.repo4"
+
+        ruby "#{RUBY_VERSION}"
+
+        gem "loofah", "~> 2.12.0"
+      G
+
+      lockfile <<-L
+        GEM
+          remote: https://gem.repo4/
+          specs:
+            crass (1.0.6)
+            loofah (2.12.0)
+              crass (~> 1.0.2)
+              nokogiri (>= 1.5.9)
+            nokogiri (1.12.4-x86_64-darwin)
+              racc (~> 1.4)
+            racc (1.5.2)
+
+        PLATFORMS
+          x86_64-darwin-20
+          x86_64-linux
+
+        DEPENDENCIES
+          loofah (~> 2.12.0)
+
+        RUBY VERSION
+           #{Bundler::RubyVersion.system}
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+    end
+
+    it "automatically fixes the lockfile" do
+      bundle "config set --local path vendor/bundle"
+
+      simulate_platform "x86_64-linux" do
+        bundle "install", :artifice => "compact_index"
+      end
+
+      expect(lockfile).to eq <<~L
+        GEM
+          remote: https://gem.repo4/
+          specs:
+            crass (1.0.6)
+            loofah (2.12.0)
+              crass (~> 1.0.2)
+              nokogiri (>= 1.5.9)
+            nokogiri (1.12.4-x86_64-darwin)
+              racc (~> 1.4)
+            nokogiri (1.12.4-x86_64-linux)
+              racc (~> 1.4)
+            racc (1.5.2)
+
+        PLATFORMS
+          x86_64-darwin-20
+          x86_64-linux
+
+        DEPENDENCIES
+          loofah (~> 2.12.0)
+
+        RUBY VERSION
+           #{Bundler::RubyVersion.system}
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+    end
+  end
+
   context "with --local flag" do
     before do
       system_gems "rack-1.0.0", :path => default_bundle_path


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Running `bundle install` on a lockfile apparently generated with new rails applications causes bundler to crash.

## What is your fix for the problem, implemented in this PR?

My fix is to refactor `Definition` to make sure that the case of missing gems in the lockfile for the current platform is properly detected and a re-resolve is triggered to fix the situation.

Fixes #4922.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
