### PR TITLE
Use macos-11 in CI

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -40,8 +40,8 @@ jobs:
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.5, value: 2.5.9 } }
 
         include:
-          - { os: { name: MacOS, value: macos-10.15 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-2.5, value: 2.5.9 } }
-          - { os: { name: MacOS, value: macos-10.15 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.2 } }
+          - { os: { name: MacOS, value: macos-11 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-2.5, value: 2.5.9 } }
+          - { os: { name: MacOS, value: macos-11 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.2 } }
     env:
       RGV: ..
       RUBYOPT: --disable-gems

--- a/.github/workflows/macos-rubygems.yml
+++ b/.github/workflows/macos-rubygems.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   macos_rubygems:
     name: Rubygems on MacOS (${{ matrix.ruby.name }})
-    runs-on: macos-10.15
+    runs-on: macos-11
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

None, really, just making sure to use the latest infra from Github Actions.

Github Actions is displaying some warnings about the upcoming change in the default version of MacOS.

We are locked to macos-10.15, so the change shouldn't affect us at all, but I guess the change in the default indicates that the new version is stable enough so let's try it.

## What is your fix for the problem, implemented in this PR?

Update our workflow files.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
