### PR TITLE
Include glob information in Bundler::Source::Git#to_s

### DIFF
--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -42,7 +42,7 @@ module Bundler
         %w[ref branch tag submodules].each do |opt|
           out << "  #{opt}: #{options[opt]}\n" if options[opt]
         end
-        out << "  glob: #{@glob}\n" unless @glob == DEFAULT_GLOB
+        out << "  glob: #{@glob}\n" unless default_glob?
         out << "  specs:\n"
       end
 
@@ -75,12 +75,20 @@ module Bundler
             git_proxy.branch
           end
 
-          rev = " (at #{at}@#{shortref_for_display(revision)})"
+          rev = "at #{at}@#{shortref_for_display(revision)}"
         rescue GitError
           ""
         end
 
-        "#{@safe_uri}#{rev}"
+        specifiers = [rev, glob_for_display].compact
+        suffix =
+          if specifiers.any?
+            " (#{specifiers.join(", ")})"
+          else
+            ""
+          end
+
+        "#{@safe_uri}#{suffix}"
       end
 
       def name
@@ -280,6 +288,14 @@ module Bundler
 
       def shortref_for_path(ref)
         ref[0..11]
+      end
+
+      def glob_for_display
+        default_glob? ? nil : "glob: #{@glob}"
+      end
+
+      def default_glob?
+        @glob == DEFAULT_GLOB
       end
 
       def uri_hash

--- a/bundler/spec/bundler/source/git_spec.rb
+++ b/bundler/spec/bundler/source/git_spec.rb
@@ -24,5 +24,50 @@ RSpec.describe Bundler::Source::Git do
         expect(subject.to_s).to eq "https://x-oauth-basic@github.com/foo/bar.git"
       end
     end
+
+    context "when the source has a glob specifier" do
+      let(:glob) { "bar/baz/*.gemspec" }
+      let(:options) do
+        { "uri" => uri, "glob" => glob }
+      end
+
+      it "includes it" do
+        expect(subject.to_s).to eq "https://github.com/foo/bar.git (glob: bar/baz/*.gemspec)"
+      end
+    end
+
+    context "when the source has a reference" do
+      let(:git_proxy_stub) do
+        instance_double(Bundler::Source::Git::GitProxy, :revision => "123abc", :branch => "v1.0.0")
+      end
+      let(:options) do
+        { "uri" => uri, "ref" => "v1.0.0" }
+      end
+
+      before do
+        allow(Bundler::Source::Git::GitProxy).to receive(:new).and_return(git_proxy_stub)
+      end
+
+      it "includes it" do
+        expect(subject.to_s).to eq "https://github.com/foo/bar.git (at v1.0.0@123abc)"
+      end
+    end
+
+    context "when the source has both reference and glob specifiers" do
+      let(:git_proxy_stub) do
+        instance_double(Bundler::Source::Git::GitProxy, :revision => "123abc", :branch => "v1.0.0")
+      end
+      let(:options) do
+        { "uri" => uri, "ref" => "v1.0.0", "glob" => "gems/foo/*.gemspec" }
+      end
+
+      before do
+        allow(Bundler::Source::Git::GitProxy).to receive(:new).and_return(git_proxy_stub)
+      end
+
+      it "includes both" do
+        expect(subject.to_s).to eq "https://github.com/foo/bar.git (at v1.0.0@123abc, glob: gems/foo/*.gemspec)"
+      end
+    end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This fixes the issue described in https://github.com/rubygems/rubygems/issues/4943, where multiple gems in a single repo identified by separate glob lead to non-deterministic lockfile generation.

## What is your fix for the problem, implemented in this PR?

The changes here make it so a glob is included in `Bundler::Source::Git#to_s` which in turn makes the Lockfile generation (more) deterministic when including multiple gems from the same git repo with different globs. 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
