### PR TITLE
Fix `assert_contains_make_command` on `make` defined by environment variable.

### DIFF
--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -246,7 +246,7 @@ class Gem::TestCase < Test::Unit::TestCase
   end
 
   def parse_make_command_line(line)
-    command, *args = line.shellsplit
+    args = line.sub(/^#{Regexp.escape make_command}/, "").shellsplit
 
     targets = []
     macros = {}
@@ -263,7 +263,7 @@ class Gem::TestCase < Test::Unit::TestCase
     targets << '' if targets.empty?
 
     {
-      :command => command,
+      :command => make_command,
       :targets => targets,
       :macros => macros,
     }

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -290,7 +290,6 @@ class Gem::TestCase < Test::Unit::TestCase
       make = parse_make_command_line(line)
 
       if make[:targets].include?(target)
-        yield make, line if block_given?
         true
       else
         false

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -245,16 +245,14 @@ class Gem::TestCase < Test::Unit::TestCase
     output.scan(/^#{Regexp.escape make_command}(?:[[:blank:]].*)?$/)
   end
 
-  def parse_make_command_line(line)
+  def parse_make_command_line_targets(line)
     args = line.sub(/^#{Regexp.escape make_command}/, "").shellsplit
 
     targets = []
-    macros = {}
 
     args.each do |arg|
       case arg
       when /\A(\w+)=/
-        macros[$1] = $'
       else
         targets << arg
       end
@@ -262,11 +260,7 @@ class Gem::TestCase < Test::Unit::TestCase
 
     targets << '' if targets.empty?
 
-    {
-      :command => make_command,
-      :targets => targets,
-      :macros => macros,
-    }
+    targets
   end
 
   def assert_contains_make_command(target, output, msg = nil)
@@ -287,9 +281,9 @@ class Gem::TestCase < Test::Unit::TestCase
     end
 
     assert scan_make_command_lines(output).any? {|line|
-      make = parse_make_command_line(line)
+      targets = parse_make_command_line_targets(line)
 
-      if make[:targets].include?(target)
+      if targets.include?(target)
         true
       else
         false

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -279,7 +279,7 @@ class Gem::TestCase < Test::Unit::TestCase
       )
     else
       msg = build_message(msg,
-        'Expected make command "%s": %s' % [
+        'Expected make command "%s", but was "%s"' % [
           ('%s %s' % [make_command, target]).rstrip,
           output,
         ]

--- a/test/rubygems/test_gem_ext_ext_conf_builder.rb
+++ b/test/rubygems/test_gem_ext_ext_conf_builder.rb
@@ -66,8 +66,11 @@ class TestGemExtExtConfBuilder < Gem::TestCase
     end
   end
 
-  def test_class_build_env_make
-    env_make = ENV.delete 'MAKE'
+  def test_class_build_env_MAKE
+    env_make = ENV.delete 'make'
+    ENV['make'] = nil
+
+    env_MAKE = ENV.delete 'MAKE'
     ENV['MAKE'] = 'anothermake'
 
     if java_platform?
@@ -89,7 +92,8 @@ class TestGemExtExtConfBuilder < Gem::TestCase
       assert_contains_make_command 'clean', output[4]
     end
   ensure
-    ENV['MAKE'] = env_make
+    ENV['MAKE'] = env_MAKE
+    ENV['make'] = env_make
   end
 
   def test_class_build_extconf_fail


### PR DESCRIPTION
This PR fixes #4921.

The `parse_make_command_line` in `assert_contains_make_command` fails to get
targets correctly, when the make command is set with make options by
environment variable such as `export make='make -j2'` at
lib/rubygems/ext/builder.rb::make. In this case, it's hard to get the make
targets identifying make options. So, just parse the make arguments,
and check if the arguments include the given target.

Enhance test/rubygems/test_gem_ext_ext_conf_builder.rb#test_class_build_env_make
to test `assert_contains_make_command` with the make command with options and
to pass on `export make='make -j2'.

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

The rubygems tests fails on `export make='make -j2'`.

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

The `parse_make_command_line` method currently does not get the make target considering the make options from the make command. So, I changed how to check a make target is included in the make command, parsing both make arguments (make options and make targets).

I also considered the case on the `make` environment variable is set such as `export make=`make -j2`. In this case, the test fails. So, I modified it.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

I checked the code on my local.

```
$ bundler/bin/rubocop -a
Inspecting 388 files
....................................................................................................................................................................................................................................................................................................................................................................................................

388 files inspected, no offenses detected
```
