### PR TITLE
Make `bundle info` show a proper warning every time it finds a deleted gem

### DIFF
--- a/bundler/lib/bundler/cli/info.rb
+++ b/bundler/lib/bundler/cli/info.rb
@@ -55,8 +55,10 @@ module Bundler
 
     def print_gem_info(spec)
       metadata = spec.metadata
+      name = spec.name
+      path = spec.full_gem_path
       gem_info = String.new
-      gem_info << "  * #{spec.name} (#{spec.version}#{spec.git_version})\n"
+      gem_info << "  * #{name} (#{spec.version}#{spec.git_version})\n"
       gem_info << "\tSummary: #{spec.summary}\n" if spec.summary
       gem_info << "\tHomepage: #{spec.homepage}\n" if spec.homepage
       gem_info << "\tDocumentation: #{metadata["documentation_uri"]}\n" if metadata.key?("documentation_uri")
@@ -66,8 +68,13 @@ module Bundler
       gem_info << "\tChangelog: #{metadata["changelog_uri"]}\n" if metadata.key?("changelog_uri")
       gem_info << "\tBug Tracker: #{metadata["bug_tracker_uri"]}\n" if metadata.key?("bug_tracker_uri")
       gem_info << "\tMailing List: #{metadata["mailing_list_uri"]}\n" if metadata.key?("mailing_list_uri")
-      gem_info << "\tPath: #{spec.full_gem_path}\n"
+      gem_info << "\tPath: #{path}\n"
       gem_info << "\tDefault Gem: yes" if spec.respond_to?(:default_gem?) && spec.default_gem?
+
+      unless File.directory?(path)
+        return Bundler.ui.warn "The gem #{name} has been deleted. Gemspec information is still available though:\n#{gem_info}"
+      end
+
       Bundler.ui.info gem_info
     end
   end

--- a/bundler/spec/commands/info_spec.rb
+++ b/bundler/spec/commands/info_spec.rb
@@ -66,6 +66,10 @@ RSpec.describe "bundle info" do
       bundle "info rail --path"
       expect(err).to match(/The gem rails has been deleted/i)
       expect(err).to match(default_bundle_path("gems", "rails-2.3.2").to_s)
+
+      bundle "info rails"
+      expect(err).to match(/The gem rails has been deleted/i)
+      expect(err).to match(default_bundle_path("gems", "rails-2.3.2").to_s)
     end
 
     context "given a default gem shippped in ruby", :ruby_repo do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes `bundle info` fails to report that a gem has been deleted.

## What is your fix for the problem, implemented in this PR?

While implemented for `bundle info <gem_name> --path`, it was failing to report the problem when using `bundle info <gem_name>` and it was showing an incorrect message when using `bundle info <gem_regexp>`. The solution is to add the proper checks the account for all cases correctly.

Fixes the first problem reported at #4954.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
