### PR TITLE
Get specs green on arm64-darwin-20

### DIFF
--- a/bundler/spec/bundler/definition_spec.rb
+++ b/bundler/spec/bundler/definition_spec.rb
@@ -136,8 +136,7 @@ RSpec.describe Bundler::Definition do
             only_java (1.1-java)
 
         PLATFORMS
-          java
-          #{lockfile_platforms}
+          #{lockfile_platforms_for(["java"] + local_platforms)}
 
         DEPENDENCIES
           only_java

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -984,8 +984,7 @@ RSpec.describe "the lockfile format" do
           rack (1.0.0)
 
       PLATFORMS
-        java
-        #{lockfile_platforms}
+        #{lockfile_platforms_for(["java"] + local_platforms)}
 
       DEPENDENCIES
         rack

--- a/bundler/spec/runtime/platform_spec.rb
+++ b/bundler/spec/runtime/platform_spec.rb
@@ -86,8 +86,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
           racc (1.5.2)
 
       PLATFORMS
-        ruby
-        #{Bundler.local_platform}
+        #{lockfile_platforms_for(["ruby"] + local_platforms)}
 
       DEPENDENCIES
         nokogiri (~> 1.11)

--- a/bundler/spec/support/platforms.rb
+++ b/bundler/spec/support/platforms.rb
@@ -90,7 +90,11 @@ module Spec
     end
 
     def lockfile_platforms
-      local_platforms.map(&:to_s).sort.join("\n  ")
+      lockfile_platforms_for(local_platforms)
+    end
+
+    def lockfile_platforms_for(platforms)
+      platforms.map(&:to_s).sort.join("\n  ")
     end
 
     def local_platforms


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

RubyTogether kindly sent me an OS X machine, and I found that specs were not green there.

## What is your fix for the problem, implemented in this PR?

Make sure a few tests put ordered platforms in the lockfile.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
