### PR TITLE
Avoid loading the `digest` gem unnecessarily

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -274,10 +274,9 @@ namespace 'blog' do
   checksums = ''
 
   task 'checksums' => 'package' do
-    require 'digest'
     require 'net/http'
     Dir['pkg/*{tgz,zip,gem}'].each do |file|
-      digest = Digest::SHA256.file(file).hexdigest
+      digest = OpenSSL::Digest::SHA256.file(file).hexdigest
       basename = File.basename(file)
 
       checksums << "* #{basename}  \n"
@@ -287,7 +286,7 @@ namespace 'blog' do
       response = Net::HTTP.get_response(release_url)
 
       if response.is_a?(Net::HTTPSuccess)
-        released_digest = Digest::SHA256.hexdigest(response.body)
+        released_digest = OpenSSL::Digest::SHA256.hexdigest(response.body)
 
         if digest != released_digest
           abort "Checksum of #{file} (#{digest}) doesn't match checksum of released package at #{release_url} (#{released_digest})"

--- a/lib/rubygems/s3_uri_signer.rb
+++ b/lib/rubygems/s3_uri_signer.rb
@@ -1,4 +1,3 @@
-require 'digest'
 require_relative 'openssl'
 
 ##
@@ -87,7 +86,7 @@ class Gem::S3URISigner
       "AWS4-HMAC-SHA256",
       date_time,
       credential_info,
-      Digest::SHA256.hexdigest(canonical_request),
+      OpenSSL::Digest::SHA256.hexdigest(canonical_request),
     ].join("\n")
   end
 

--- a/lib/rubygems/source/git.rb
+++ b/lib/rubygems/source/git.rb
@@ -225,7 +225,7 @@ class Gem::Source::Git < Gem::Source
   # A hash for the git gem based on the git repository URI.
 
   def uri_hash # :nodoc:
-    require 'digest'
+    require_relative '../openssl'
 
     normalized =
       if @repository =~ %r{^\w+://(\w+@)?}
@@ -235,6 +235,6 @@ class Gem::Source::Git < Gem::Source
         @repository
       end
 
-    Digest::SHA1.hexdigest normalized
+    OpenSSL::Digest::SHA1.hexdigest normalized
   end
 end

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'package/tar_test_case'
-require 'digest'
+require 'rubygems/openssl'
 
 class TestGemPackage < Gem::Package::TarTestCase
   def setup
@@ -84,17 +84,17 @@ class TestGemPackage < Gem::Package::TarTestCase
       io.write spec.to_yaml
     end
 
-    metadata_sha256 = Digest::SHA256.hexdigest s.string
-    metadata_sha512 = Digest::SHA512.hexdigest s.string
+    metadata_sha256 = OpenSSL::Digest::SHA256.hexdigest s.string
+    metadata_sha512 = OpenSSL::Digest::SHA512.hexdigest s.string
 
     expected = {
       'SHA512' => {
         'metadata.gz' => metadata_sha512,
-        'data.tar.gz' => Digest::SHA512.hexdigest(tar),
+        'data.tar.gz' => OpenSSL::Digest::SHA512.hexdigest(tar),
       },
       'SHA256' => {
         'metadata.gz' => metadata_sha256,
-        'data.tar.gz' => Digest::SHA256.hexdigest(tar),
+        'data.tar.gz' => OpenSSL::Digest::SHA256.hexdigest(tar),
       },
     }
 
@@ -857,7 +857,7 @@ class TestGemPackage < Gem::Package::TarTestCase
         io.write metadata_gz
       end
 
-      digest = Digest::SHA1.new
+      digest = OpenSSL::Digest::SHA1.new
       digest << metadata_gz
 
       checksums = {
@@ -1016,7 +1016,7 @@ class TestGemPackage < Gem::Package::TarTestCase
         bogus_data = Gem::Util.gzip 'hello'
         fake_signer = Class.new do
           def digest_name; 'SHA512'; end
-          def digest_algorithm; Digest(:SHA512).new; end
+          def digest_algorithm; OpenSSL::Digest(:SHA512).new; end
           def key; 'key'; end
           def sign(*); 'fake_sig'; end
         end


### PR DESCRIPTION
OpenSSL includes what we need.

## What was the end-user or developer problem that led to this PR?

Some double loading issues related to the `digest` gem. See comments at https://github.com/ruby/digest/commit/16172612d56ac42f57e5788465791329303ac5d0.

## What is your fix for the problem, implemented in this PR?

Use `OpenSSL::Digest` instead.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
