### PR TITLE
Update broken link in Bundler::Fetcher::CertificateFailureError

### DIFF
--- a/bundler/lib/bundler/fetcher.rb
+++ b/bundler/lib/bundler/fetcher.rb
@@ -28,7 +28,8 @@ module Bundler
           " is a chance you are experiencing a man-in-the-middle attack, but" \
           " most likely your system doesn't have the CA certificates needed" \
           " for verification. For information about OpenSSL certificates, see" \
-          " http://bit.ly/ruby-ssl. To connect without using SSL, edit your Gemfile" \
+          " https://railsapps.github.io/openssl-certificate-verify-failed.html." \
+          " To connect without using SSL, edit your Gemfile" \
           " sources and change 'https' to 'http'."
       end
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

While debugging an SSL issue on a personal project, I ran into a dead link in an error message that was using a link shortener. 

## What is your fix for the problem, implemented in this PR?

This PR removes the link shortener with the updated link, as detailed in [this](https://github.com/rubygems/rubygems/issues/4984) issue.

