### PR TITLE
Add a custom SHA1 digest implementation to no longer depend on the digest gem before we know which version to activate

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -60,6 +60,7 @@ bundler/lib/bundler/dep_proxy.rb
 bundler/lib/bundler/dependency.rb
 bundler/lib/bundler/deployment.rb
 bundler/lib/bundler/deprecate.rb
+bundler/lib/bundler/digest.rb
 bundler/lib/bundler/dsl.rb
 bundler/lib/bundler/endpoint_specification.rb
 bundler/lib/bundler/env.rb

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -43,6 +43,7 @@ module Bundler
   autoload :Dependency,             File.expand_path("bundler/dependency", __dir__)
   autoload :DepProxy,               File.expand_path("bundler/dep_proxy", __dir__)
   autoload :Deprecate,              File.expand_path("bundler/deprecate", __dir__)
+  autoload :Digest,                 File.expand_path("bundler/digest", __dir__)
   autoload :Dsl,                    File.expand_path("bundler/dsl", __dir__)
   autoload :EndpointSpecification,  File.expand_path("bundler/endpoint_specification", __dir__)
   autoload :Env,                    File.expand_path("bundler/env", __dir__)

--- a/bundler/lib/bundler/digest.rb
+++ b/bundler/lib/bundler/digest.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# This code was extracted from https://github.com/Solistra/ruby-digest which is under public domain
+module Bundler
+  module Digest
+    # The initial constant values for the 32-bit constant words A, B, C, D, and
+    # E, respectively.
+    SHA1_WORDS = [0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0].freeze
+
+    # The 8-bit field used for bitwise `AND` masking. Defaults to `0xFFFFFFFF`.
+    SHA1_MASK = 0xFFFFFFFF
+
+    class << self
+      def sha1(string)
+        unless string.is_a?(String)
+          raise TypeError, "can't convert #{string.class.inspect} into String"
+        end
+
+        buffer = string.b
+
+        words = SHA1_WORDS.dup
+        generate_split_buffer(buffer) do |chunk|
+          w = []
+          chunk.each_slice(4) do |a, b, c, d|
+            w << (((a << 8 | b) << 8 | c) << 8 | d)
+          end
+          a, b, c, d, e = *words
+          (16..79).each do |i|
+            w[i] = SHA1_MASK & rotate((w[i-3] ^ w[i-8] ^ w[i-14] ^ w[i-16]), 1)
+          end
+          0.upto(79) do |i|
+            case i
+            when  0..19
+              f = ((b & c) | (~b & d))
+              k = 0x5A827999
+            when 20..39
+              f = (b ^ c ^ d)
+              k = 0x6ED9EBA1
+            when 40..59
+              f = ((b & c) | (b & d) | (c & d))
+              k = 0x8F1BBCDC
+            when 60..79
+              f = (b ^ c ^ d)
+              k = 0xCA62C1D6
+            end
+            t = SHA1_MASK & (SHA1_MASK & rotate(a, 5) + f + e + k + w[i])
+            a, b, c, d, e = t, a, SHA1_MASK & rotate(b, 30), c, d # rubocop:disable Style/ParallelAssignment
+          end
+          mutated = [a, b, c, d, e]
+          words.map!.with_index {|word, index| SHA1_MASK & (word + mutated[index]) }
+        end
+
+        words.pack("N*").unpack("H*").first
+      end
+
+      private
+
+      def generate_split_buffer(string, &block)
+        size   = string.bytesize * 8
+        buffer = string.bytes << 128
+        buffer << 0 while buffer.size % 64 != 56
+        [size].pack("Q").bytes.reverse_each {|b| buffer << b }
+        buffer.each_slice(64, &block)
+      end
+
+      def rotate(value, spaces)
+        value << spaces | value >> (32 - spaces)
+      end
+    end
+  end
+end

--- a/bundler/lib/bundler/gem_helper.rb
+++ b/bundler/lib/bundler/gem_helper.rb
@@ -107,7 +107,7 @@ module Bundler
       SharedHelpers.filesystem_access(File.join(base, "checksums")) {|p| FileUtils.mkdir_p(p) }
       file_name = "#{File.basename(built_gem_path)}.sha512"
       require "digest/sha2"
-      checksum = Digest::SHA512.new.hexdigest(built_gem_path.to_s)
+      checksum = ::Digest::SHA512.new.hexdigest(built_gem_path.to_s)
       target = File.join(base, "checksums", file_name)
       File.write(target, checksum)
       Bundler.ui.confirm "#{name} #{version} checksum written to checksums/#{file_name}."

--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -307,7 +307,9 @@ module Bundler
           # If there is no URI scheme, assume it is an ssh/git URI
           input = uri
         end
-        SharedHelpers.digest(:SHA1).hexdigest(input)
+        # We use SHA1 here for historical reason and to preserve backward compatibility.
+        # But a transition to a simpler mangling algorithm would be welcome.
+        Bundler::Digest.sha1(input)
       end
 
       def cached_revision

--- a/bundler/spec/bundler/digest_spec.rb
+++ b/bundler/spec/bundler/digest_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "digest"
+require "bundler/digest"
+
+RSpec.describe Bundler::Digest do
+  context "SHA1" do
+    subject { Bundler::Digest }
+    let(:stdlib) { ::Digest::SHA1 }
+
+    it "is compatible with stdlib" do
+      ["foo", "skfjsdlkfjsdf", "3924m", "ldskfj"].each do |payload|
+        expect(subject.sha1(payload)).to be == stdlib.hexdigest(payload)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/17873

Ruby 3.1. is making `digest` a default gem, because of this if bundler
depends on it, it might cause already activated issues.

This currently happens if your Gemfile contains a git gem, because
the GitSource makes an SHA1 of the repository URL.

## What was the end-user or developer problem that led to this PR?

Currently it is very complicated if not impossible to use a gem that has `digest` in its dependencies if you also have a gitst gem.

```ruby
source "https://rubygems.org"

gem "net-imap"
gem "bootsnap", github: "Shopify/bootsnap"
```

```
$ ruby -v 
ruby 3.1.0dev (2021-10-06T06:42:37Z master d53493715c) [x86_64-darwin20]
$ bundle
Using msgpack 1.4.2
Using bootsnap 1.9.1 from https://github.com/Shopify/bootsnap.git
Using bundler 2.2.25
Using digest 3.0.0
Using io-wait 0.1.0
Using timeout 0.2.0
Using net-protocol 0.1.1
Using strscan 3.0.0
Using net-imap 0.2.2
Bundle complete! 2 Gemfile dependencies, 9 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
$ bundle exec ruby -r bundler/setup -r digest -e 'p :hello'
gems/bundler-2.2.25/lib/bundler/runtime.rb:309:in `check_for_activated_spec!': You have already activated digest 3.1.0.pre2, but your Gemfile requires digest 3.0.0. Prepending `bundle exec` to your command may solve this. (Gem::LoadError)
	from gems/bundler-2.2.25/lib/bundler/runtime.rb:25:in `block in setup'
	from gems/bundler-2.2.25/lib/bundler/spec_set.rb:136:in `each'
	from gems/bundler-2.2.25/lib/bundler/spec_set.rb:136:in `each'
	from gems/bundler-2.2.25/lib/bundler/runtime.rb:24:in `map'
	from gems/bundler-2.2.25/lib/bundler/runtime.rb:24:in `setup'
	from gems/bundler-2.2.25/lib/bundler.rb:149:in `setup'
	from gems/bundler-2.2.25/lib/bundler/setup.rb:10:in `block in <top (required)>'
	from gems/bundler-2.2.25/lib/bundler/ui/shell.rb:136:in `with_level'
	from gems/bundler-2.2.25/lib/bundler/ui/shell.rb:88:in `silence'
	from gems/bundler-2.2.25/lib/bundler/setup.rb:10:in `<top (required)>'
	from <internal:/opt/rubies/3.1.0-dev/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from <internal:/opt/rubies/3.1.0-dev/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
```

## What is your fix for the problem, implemented in this PR?

I found https://github.com/Solistra/ruby-digest which is under public domain and could be vendored. It conveniently implement the 3 hash algorithms used by bundler. 

This is a rough first draft, it could certainly be cleaned a bit more. 

@deivid-rodriguez how does this sound?