### PR TITLE
Add a note in the changelog about `bundle update --source <gem>`

### DIFF
--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -107,7 +107,7 @@
   - Fix `bundle doctor` crashing when finding a broken symlink [#4707](https://github.com/rubygems/rubygems/pull/4707)
   - Fix incorrect re-resolve edge case [#4700](https://github.com/rubygems/rubygems/pull/4700)
   - Fix some gems being unintentionally locked under multiple lockfile sections [#4701](https://github.com/rubygems/rubygems/pull/4701)
-  - Fix `--conservative` flag unexpectedly updating indirect dependencies [#4692](https://github.com/rubygems/rubygems/pull/4692)
+  - Fix `--conservative` flag unexpectedly updating indirect dependencies. NOTE: As part of this bug fix, some undocumented, unintentional code causing `bundle update --source <gem>` to update conservatively was fixed. Use the documented `bundle update --conservative <gem>` instead [#4692](https://github.com/rubygems/rubygems/pull/4692)
 
 # 2.2.21 (June 23, 2021)
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Even if I don't acknowledge this command no longer updating conservatively as a
breaking change, since is has a completely different documented meaning, the
reality is the reality isthat some people used it to update conservatively, so it's
worth mentioning it.

## What is your fix for the problem, implemented in this PR?

Together with the `--conservative` fix, mention also that the hack no longer works.

References #4995.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
