### PR TITLE
Re-enable `default_ignores` option for standard

### DIFF
--- a/bundler/lib/bundler/templates/newgem/standard.yml.tt
+++ b/bundler/lib/bundler/templates/newgem/standard.yml.tt
@@ -1,4 +1,2 @@
 # For available configuration options, see:
 #   https://github.com/testdouble/standard
-
-default_ignores: false


### PR DESCRIPTION
I am not sure why this flag was turned off (it wasn't explained in my commit message in 0365dc852767ae589376a7aad1fb129738e408b0 or in my PR in #4411). 

Whatever the reason, without `default_ignores` turned on, most default CI configurations will immediately fail, as they most likely vendor and cache their dependencies under `vendor`, which will cause standard to run against all the vendored gems and (most likely) fail. I think we should remove this before this feature is released.