### PR TITLE
Simplify and remove some unused code

### DIFF
--- a/bundler/lib/bundler/installer/gem_installer.rb
+++ b/bundler/lib/bundler/installer/gem_installer.rb
@@ -13,7 +13,7 @@ module Bundler
     end
 
     def install_from_spec
-      post_install_message = spec_settings ? install_with_settings : install
+      post_install_message = install
       Bundler.ui.debug "#{worker}:  #{spec.name} (#{spec.version}) from #{spec.loaded_from}"
       generate_executable_stubs
       return true, post_install_message
@@ -52,11 +52,6 @@ module Bundler
 
     def install
       spec.source.install(spec, :force => force, :ensure_builtin_gems_cached => standalone, :build_args => Array(spec_settings))
-    end
-
-    def install_with_settings
-      # Build arguments are global, so this is mutexed
-      Bundler.rubygems.install_with_build_args([spec_settings]) { install }
     end
 
     def out_of_space_message

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -232,18 +232,6 @@ module Bundler
       EXT_LOCK
     end
 
-    def with_build_args(args)
-      ext_lock.synchronize do
-        old_args = build_args
-        begin
-          self.build_args = args
-          yield
-        ensure
-          self.build_args = old_args
-        end
-      end
-    end
-
     def spec_from_gem(path, policy = nil)
       require "rubygems/security"
       require_relative "psyched_yaml"
@@ -548,10 +536,6 @@ module Bundler
 
     def repository_subdirectories
       Gem::REPOSITORY_SUBDIRECTORIES
-    end
-
-    def install_with_build_args(args)
-      yield
     end
 
     def path_separator


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I was working on removing some custom bundler patches we had in our codebase, and I ran across what seemed to be some dead code in bundler.

## What is your fix for the problem, implemented in this PR?

When `install_with_build_args` was added in https://github.com/rubygems/rubygems/commit/be96283985cb49c023112117b2ac2dea0d9becf1, there were two versions of the method: the default version in the base class that still used the locking `with_build_args`, and an override in the `Future` class (for Rubygems 2.0 and up) that yielded without calling `with_build_args`.

The `with_build_args` version of the method was removed in https://github.com/rubygems/rubygems/commit/8a5b71e3e8072c64a0f3cab838ba330f5e87e37a while removing a bunch of the old Rubygems compatibility code.

This commit removes `with_build_args`, since it no longer appears to be used (the build args are passed as a keyword argument to `spec.source.install` instead, since https://github.com/rubygems/rubygems/commit/be96283985cb49c023112117b2ac2dea0d9becf1).

The commit also removes `install_with_build_args` and the conditional around it, since the method wasn't doing anything different than `install`, and it had a comment that was no longer accurate.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
