### PR TITLE
Warn on empty or open required_ruby_version specification attribute.

### DIFF
--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -103,6 +103,8 @@ class Gem::SpecificationPolicy
 
     validate_dependencies
 
+    validate_required_ruby_version
+
     validate_extensions
 
     validate_removed_attributes
@@ -224,6 +226,12 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
     end
     if warning_messages.any?
       warning_messages.each {|warning_message| warning warning_message }
+    end
+  end
+
+  def validate_required_ruby_version
+    if @specification.required_ruby_version.requirements == [Gem::Requirement::DefaultRequirement]
+      warning "make sure you specify the oldest ruby version constraint (like \">= 3.0\") that you want your gem to support by setting the `required_ruby_version` gemspec attribute"
     end
   end
 

--- a/test/rubygems/specifications/rubyforge-0.0.1.gemspec
+++ b/test/rubygems/specifications/rubyforge-0.0.1.gemspec
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
 Gem::Specification.new do |s|
-  s.name              = "rubyforge"
-  s.version           = "0.0.1"
-  s.platform          = "ruby"
-  s.require_paths     = ["lib"]
-  s.summary           = "A very bar gem"
-  s.authors           = ["unknown"]
-  s.license           = "MIT"
-  s.homepage          = "http://example.com"
-  s.files             = ["README.md"]
-  s.rubyforge_project = "abc"
+  s.name                  = "rubyforge"
+  s.version               = "0.0.1"
+  s.platform              = "ruby"
+  s.require_paths         = ["lib"]
+  s.summary               = "A very bar gem"
+  s.authors               = ["unknown"]
+  s.license               = "MIT"
+  s.homepage              = "http://example.com"
+  s.files                 = ["README.md"]
+  s.rubyforge_project     = "abc"
+  s.required_ruby_version = ">= 1.9.3"
 end

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -28,6 +28,7 @@ class TestGemCommandsBuildCommand < Gem::TestCase
     @gem = util_spec "some_gem" do |s|
       s.license = "AGPL-3.0-only"
       s.files = ["README.md"]
+      s.required_ruby_version = "2.3.0"
     end
 
     @cmd = Gem::Commands::BuildCommand.new
@@ -178,6 +179,7 @@ class TestGemCommandsBuildCommand < Gem::TestCase
   def test_execute_strict_with_warnings
     bad_gem = util_spec "some_bad_gem" do |s|
       s.files = ["README.md"]
+      s.required_ruby_version = ">= 1.9.3"
     end
 
     gemspec_file = File.join(@tempdir, bad_gem.spec_name)

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -90,6 +90,7 @@ end
     Gem.instance_variable_set(:'@default_source_date_epoch', nil)
 
     @a1 = util_spec "a", "1" do |s|
+      s.required_ruby_version = ">= 2.3.0"
       s.executable = "exec"
       s.test_file = "test/suite.rb"
       s.requirements << "A working computer"
@@ -2707,6 +2708,53 @@ duplicate dependency on c (>= 1.2.3, development), (~> 1.2) use:
     end
   end
 
+  def test_validate_no_required_ruby_versions
+    util_setup_validate
+
+    Dir.chdir @tempdir do
+      use_ui @ui do
+        @a1.required_ruby_version = nil # reset
+        @a1.validate
+      end
+
+      assert_equal <<-EXPECTED, @ui.error
+#{w}:  make sure you specify the oldest ruby version constraint (like \">= 3.0\") that you want your gem to support by setting the `required_ruby_version` gemspec attribute
+#{w}:  See https://guides.rubygems.org/specification-reference/ for help
+      EXPECTED
+    end
+  end
+
+  def test_validate_open_required_ruby_versions
+    util_setup_validate
+
+    Dir.chdir @tempdir do
+      @a1.required_ruby_version = ">= 0"
+
+      use_ui @ui do
+        @a1.validate
+      end
+
+      assert_equal <<-EXPECTED, @ui.error
+#{w}:  make sure you specify the oldest ruby version constraint (like \">= 3.0\") that you want your gem to support by setting the `required_ruby_version` gemspec attribute
+#{w}:  See https://guides.rubygems.org/specification-reference/ for help
+      EXPECTED
+    end
+  end
+
+  def test_validate_valid_required_ruby_versions
+    util_setup_validate
+
+    Dir.chdir @tempdir do
+      @a1.required_ruby_version = ">= 2.3.0"
+
+      use_ui @ui do
+        @a1.validate
+      end
+
+      assert_equal "", @ui.error, "warning"
+    end
+  end
+
   def test_validate_prerelease_dependencies_with_prerelease_version
     util_setup_validate
 
@@ -3683,6 +3731,7 @@ Did you mean 'Ruby'?
 
     Dir.chdir @tempdir do
       @m2 = quick_gem "m", "2" do |s|
+        s.required_ruby_version = ">= 2.3.0"
         s.files = %w[lib/code.rb]
         s.licenses = "BSD-2-Clause"
         s.metadata = {


### PR DESCRIPTION
This is just concept what we can do to improve situation of filled in `required_ruby_version` value to prevent problems described in https://github.com/rubygems/rfcs/issues/34.

I have used placeholder text for now. Feel free to suggest better. We can also use different text for different situations.

:information_source: `required_ruby_version` is already part of `bundle gem` template based on this logic.

https://github.com/rubygems/rubygems/blob/2f48d60afe050862258212d0c68530f39fb5fdfa/bundler/lib/bundler/cli/gem.rb#L407-L414

Later on we can move this attribute to required. It could be also possible to warn on "potentially misused values". For example when newer Ruby is used to build gem (then the minimal), we can inform user to ensure it is good idea to check if gem is still compatible with minimal Ruby version.

related to https://github.com/rubygems/guides/pull/295, https://github.com/rubygems/rfcs/issues/34 and https://github.com/rubygems/rfcs/pull/26

/cc @marcandre 