### PR TITLE
Fix Bundler::Digest#sha1 on big-endian systems

### DIFF
--- a/bundler/lib/bundler/digest.rb
+++ b/bundler/lib/bundler/digest.rb
@@ -59,7 +59,7 @@ module Bundler
         size   = string.bytesize * 8
         buffer = string.bytes << 128
         buffer << 0 while buffer.size % 64 != 56
-        [size].pack("Q").bytes.reverse_each {|b| buffer << b }
+        buffer.concat([size].pack("Q>").bytes)
         buffer.each_slice(64, &block)
       end
 


### PR DESCRIPTION
As noticed by @nobu https://github.com/rubygems/rubygems/pull/4989#discussion_r735674633

From wikipedia: https://en.wikipedia.org/wiki/SHA-1#SHA-1_pseudocode

> append ml, the original message length in bits, as a 64-bit big-endian integer.

`Q` is native endian, so little-endian on most modern hardware.
The original code from RubyDigest reverses the bytes:
https://github.com/Solistra/ruby-digest/blob/d15f906caf09171f897efc74645c9e31373d7fd1/lib/ruby_digest.rb#L521

But that makes the code non-portable, the correct way is to directly ask
for a big-endian representation (`Q>`).

cc @deivid-rodriguez @simi 

In term of impact this isn't that huge, at least the hashing is consistent on a given hardware, and big-endian is rare nowadays. So probably not worth an immediate re-release, but better to fix it.