### PR TITLE
Allow custom LicenseRef

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -324,17 +324,21 @@ class Gem::Specification < Gem::BasicSpecification
   # This should just be the name of your license. The full text of the license
   # should be inside of the gem (at the top level) when you build it.
   #
-  # The simplest way, is to specify the standard SPDX ID
+  # The simplest way is to specify the standard SPDX ID
   # https://spdx.org/licenses/ for the license.
-  # Ideally you should pick one that is OSI (Open Source Initiative)
+  # Ideally, you should pick one that is OSI (Open Source Initiative)
   # http://opensource.org/licenses/alphabetical approved.
   #
-  # The most commonly used OSI approved licenses are MIT and Apache-2.0.
+  # The most commonly used OSI-approved licenses are MIT and Apache-2.0.
   # GitHub also provides a license picker at http://choosealicense.com/.
   #
+  # You can also use a custom license file along with your gemspec and specify
+  # a LicenseRef-<idstring>, where idstring is the name of the file containing
+  # the license text.
+  #
   # You should specify a license for your gem so that people know how they are
-  # permitted to use it, and any restrictions you're placing on it.  Not
-  # specifying a license means all rights are reserved; others have no rights
+  # permitted to use it and any restrictions you're placing on it.  Not
+  # specifying a license means all rights are reserved; others have no right
   # to use the code for any purpose.
   #
   # You can set multiple licenses with #licenses=

--- a/lib/rubygems/util/licenses.rb
+++ b/lib/rubygems/util/licenses.rb
@@ -5,6 +5,7 @@ class Gem::Licenses
   extend Gem::Text
 
   NONSTANDARD = 'Nonstandard'.freeze
+  LICENSE_REF = 'LicenseRef-.+'.freeze
 
   # Software Package Data Exchange (SPDX) standard open-source software
   # license identifiers
@@ -523,6 +524,7 @@ class Gem::Licenses
       \+?
       (?:\s WITH \s #{Regexp.union(EXCEPTION_IDENTIFIERS)})?
       | #{NONSTANDARD}
+      | #{LICENSE_REF}
     )
     \Z
   }ox.freeze

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3066,6 +3066,17 @@ http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
     WARNING
   end
 
+  def test_validate_license_ref
+    util_setup_validate
+
+    use_ui @ui do
+      @a1.licenses = ['LicenseRef-LICENSE.md']
+      @a1.validate
+    end
+
+    assert_empty @ui.error
+  end
+
   def test_validate_license_values_plus
     util_setup_validate
 

--- a/util/generate_spdx_license_list.rb
+++ b/util/generate_spdx_license_list.rb
@@ -25,6 +25,7 @@ class Gem::Licenses
   extend Gem::Text
 
   NONSTANDARD = 'Nonstandard'.freeze
+  LICENSE_REF = 'LicenseRef-.+'.freeze
 
   # Software Package Data Exchange (SPDX) standard open-source software
   # license identifiers
@@ -44,6 +45,7 @@ class Gem::Licenses
       \\+?
       (?:\\s WITH \\s \#{Regexp.union(EXCEPTION_IDENTIFIERS)})?
       | \#{NONSTANDARD}
+      | \#{LICENSE_REF}
     )
     \\Z
   }ox.freeze


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Resolves: https://github.com/rubygems/rubygems/issues/5012

## What is your fix for the problem, implemented in this PR?

Allow's custom LicenseRef in gemspec's `license` / `licenses`.

> Sometimes standard SPDX licenses do not cover the intent of a gem. For instance, an internal and proprietary gem probably won't match any SPDX license. The Nonstandard keyword does not cover all use-cases. We use LicenseFinder to pre-approve some license values, and define all Nonstandard gems as pre-approved open a door for unexpected gems to be pre-approved.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
