### PR TITLE
Don't warn when a lockfile is locked to a dev version

### DIFF
--- a/bundler/lib/bundler/lockfile_parser.rb
+++ b/bundler/lib/bundler/lockfile_parser.rb
@@ -86,6 +86,7 @@ module Bundler
 
     def warn_for_outdated_bundler_version
       return unless bundler_version
+      return if bundler_version.segments.last == "dev"
       prerelease_text = bundler_version.prerelease? ? " --pre" : ""
       current_version = Gem::Version.create(Bundler::VERSION)
       return unless current_version < bundler_version


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When bundler is locked to a dev version, and the running version of bundler is older, bundler will print a warning and suggest a command to fix it that doesn't work, because dev versions are not released to rubygems.org

## What is your fix for the problem, implemented in this PR?

Since the warning suggest a non working command, and it doesn't make much sense here anyways, given that dev versions are non deterministic at the moment (2.3.0.dev could be many different actual source codes), skip the warning in this particular case.

Fixes #4953.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
