### PR TITLE
Use https for cloning during release tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -215,7 +215,7 @@ task :upload => %w[upload_to_github upload_to_s3]
 
 directory '../guides.rubygems.org' do
   sh 'git', 'clone',
-     'git@github.com:rubygems/guides.git',
+     'https://github.com/rubygems/guides.git',
      '../guides.rubygems.org'
 end
 
@@ -265,7 +265,7 @@ end
 
 directory '../blog.rubygems.org' do
   sh 'git', 'clone',
-     'git@github.com:rubygems/rubygems.github.io.git',
+    'https://github.com/rubygems/rubygems.github.io.git',
      '../blog.rubygems.org'
 end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I was releasing from a new machine, and the blog and guides publishing tasks failed for me because I haven't yet setup ssh keys on this machine.

## What is your fix for the problem, implemented in this PR?

I think using https is easier to setup and more straightforward to setup.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
