### PR TITLE
Add require parameter to `bundle add`

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -367,6 +367,7 @@ module Bundler
     method_option "version", :aliases => "-v", :type => :string
     method_option "group", :aliases => "-g", :type => :string
     method_option "source", :aliases => "-s", :type => :string
+    method_option "require", :aliases => "-r", :type => :string, :banner => "Adds require path to gem. Provide false, or a path as a string."
     method_option "git", :type => :string
     method_option "branch", :type => :string
     method_option "skip-install", :type => :boolean, :banner =>

--- a/bundler/lib/bundler/injector.rb
+++ b/bundler/lib/bundler/injector.rb
@@ -113,8 +113,9 @@ module Bundler
         source = ", :source => \"#{d.source}\"" unless d.source.nil?
         git = ", :git => \"#{d.git}\"" unless d.git.nil?
         branch = ", :branch => \"#{d.branch}\"" unless d.branch.nil?
+        require_path = ", :require => #{convert_autorequire(d.autorequire)}" unless d.autorequire.nil?
 
-        %(gem #{name}#{requirement}#{group}#{source}#{git}#{branch})
+        %(gem #{name}#{requirement}#{group}#{source}#{git}#{branch}#{require_path})
       end.join("\n")
     end
 
@@ -268,6 +269,12 @@ module Bundler
 
     def show_warning(message)
       Bundler.ui.info Bundler.ui.add_color(message, :yellow)
+    end
+
+    def convert_autorequire(autorequire)
+      autorequire = autorequire.first
+      return autorequire if autorequire == "false"
+      autorequire.inspect
     end
   end
 end

--- a/bundler/spec/commands/add_spec.rb
+++ b/bundler/spec/commands/add_spec.rb
@@ -68,6 +68,18 @@ RSpec.describe "bundle add" do
     end
   end
 
+  describe "with --require" do
+    it "adds the require param for the gem" do
+      bundle "add 'foo' --require=foo/engine"
+      expect(bundled_app_gemfile.read).to match(%r{gem "foo",(?: .*,) :require => "foo\/engine"})
+    end
+
+    it "converts false to a boolean" do
+      bundle "add 'foo' --require=false"
+      expect(bundled_app_gemfile.read).to match(/gem "foo",(?: .*,) :require => false/)
+    end
+  end
+
   describe "with --group" do
     it "adds dependency for the specified group" do
       bundle "add 'foo' --group='development'"


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

`bundle add` does not allow setting the `require` parameter in a gem declaration. #5017

## What is your fix for the problem, implemented in this PR?

Adds an option to the CLI, and updates the part of the code that writes the gem declaration to the Gemfile to include the `require` parameter.

Closes #5017.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes

I can't find tests for the `CLI` and `Injector` classes.

- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

TODO:

- [x] Ensure that if a boolean value is passed, it isn't surrounded by quotes
