### PR TITLE
Provide distinguished name which will be correctly parsed.

### DIFF
--- a/lib/rubygems/security.rb
+++ b/lib/rubygems/security.rb
@@ -510,9 +510,10 @@ module Gem::Security
 
     dcs = dcs.split '.'
 
-    name = "CN=#{cn}/#{dcs.map {|dc| "DC=#{dc}" }.join '/'}"
-
-    OpenSSL::X509::Name.parse name
+    OpenSSL::X509::Name.new([
+      ["CN", cn],
+      *dcs.map {|dc| ["DC", dc] },
+    ])
   end
 
   ##

--- a/test/rubygems/test_gem_security.rb
+++ b/test/rubygems/test_gem_security.rb
@@ -196,7 +196,7 @@ class TestGemSecurity < Gem::TestCase
 
   def test_class_sign
     issuer = PUBLIC_CERT.subject
-    signee = OpenSSL::X509::Name.parse "/CN=signee/DC=example"
+    signee = OpenSSL::X509::Name.new([["CN", "signee"], ["DC", "example"]])
 
     key  = PRIVATE_KEY
     cert = OpenSSL::X509::Certificate.new


### PR DESCRIPTION
It seems that since ruby openssl 2.1.0 [[1]], the distinguished name submitted to `OpenSSL::X509::Name.parse` is not correctly parsed if it does not contain the first slash:

~~~
$ ruby -v
ruby 3.0.2p107 (2021-07-07 revision 0db68f0233) [x86_64-linux]

$ gem list | grep openssl
openssl (default: 2.2.0)

$ irb -r openssl
irb(main):001:0> OpenSSL::X509::Name.parse("CN=nobody/DC=example").to_s(OpenSSL::X509::Name::ONELINE)
=> "CN = nobody/DC=example"
irb(main):002:0> OpenSSL::X509::Name.parse("/CN=nobody/DC=example").to_s(OpenSSL::X509::Name::ONELINE)
=> "CN = nobody, DC = example"
~~~

I have discovered the issue during testing against OpenSSL 3.x, where this seems to be reason for the following test failures:

~~~
TestGemSecurity#test_class_create_cert_email
TestGemSecurity#test_class_email_to_name
TestGemSecurity#test_class_sign_AltName
~~~

which I have already noted in #4986. Unfortunately, I don't really understand yet what have changed, that the slash is escaped now:

~~~
[ 2/15] TestGemSecurity#test_class_create_cert_email = 0.01 s    
  1) Failure:
TestGemSecurity#test_class_create_cert_email [/builddir/build/BUILD/ruby-3.0.2/test/rubygems/test_gem_security.rb:83]:
<"/CN=nobody/DC=example"> expected but was
<"/CN=nobody\\/DC=example">.
~~~

I'll report this against ruby/openssl anyway, since it seems that the `OpenSSL::X509::Name.parse` should better cope (fire error?) with such cases.

Also please note that I am not expert on RFC2253, so I might be completely wrong ;)

[1]: https://github.com/ruby/openssl/commit/19c67cd10c57f3ab7b13966c36431ebc3fdd653b
