### PR TITLE
Only delete cached gem when it's corrupted

### DIFF
--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -162,7 +162,7 @@ module Bundler
           begin
             s = Bundler.rubygems.spec_from_gem(path, Bundler.settings["trust-policy"])
             spec.__swap__(s)
-          rescue StandardError
+          rescue Gem::Package::FormatError
             Bundler.rm_rf(path)
             raise
           end


### PR DESCRIPTION

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

Rescuing all errors here might end up hiding other errors if the deletion of the cached gem itself raises an error for some reason.

## What is your fix for the problem, implemented in this PR?

Be more conservative and rescue only errors that indicate that the cached gem is corrupted which is the original point of https://github.com/rubygems/bundler/pull/6010.

Closes #5028 (it doesn't really fix the problem, but hopefully will allow the underlying error to be reported).

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
