### PR TITLE
Memoize materialized specs when requiring `bundler/setup`

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -143,7 +143,7 @@ module Bundler
       @dependency_changes = converge_dependencies
       @local_changes = converge_locals
 
-      @locked_specs_incomplete_for_platform = !@locked_specs.for(expand_dependencies(requested_dependencies & locked_dependencies), true, true)
+      @locked_specs_incomplete_for_platform = !@locked_specs.for(requested_dependencies & expand_dependencies(locked_dependencies), true, true)
 
       @requires = compute_requires
     end
@@ -239,16 +239,17 @@ module Bundler
     end
 
     def specs_for(groups)
-      groups = requested_groups if groups.empty?
+      return specs if groups.empty?
       deps = dependencies_for(groups)
-      materialize(expand_dependencies(deps))
+      materialize(deps)
     end
 
     def dependencies_for(groups)
       groups.map!(&:to_sym)
-      current_dependencies.reject do |d|
+      deps = current_dependencies.reject do |d|
         (d.groups & groups).empty?
       end
+      expand_dependencies(deps)
     end
 
     # Resolve all the dependencies specified in Gemfile. It ensures that

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -1468,5 +1468,21 @@ end
 
       expect(last_command.stdboth).to eq("true")
     end
+
+    it "memoizes initial set of specs when requiring bundler/setup, so that even if further code mutates dependencies, Bundler.definition.specs is not affected" do
+      install_gemfile <<~G
+        source "#{file_uri_for(gem_repo1)}"
+        gem "yard"
+        gem "rack", :group => :test
+      G
+
+      ruby <<-RUBY, :raise_on_error => false
+        require "bundler/setup"
+        Bundler.require(:test).select! {|d| (d.groups & [:test]).any? }
+        puts Bundler.definition.specs.map(&:name).join(", ")
+      RUBY
+
+      expect(out).to include("rack, yard")
+    end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When calling `Bundler.definition.specs` the set of materialized specs would be memoized. Requiring `bundler/setup`, however, ends up materializing the same set of specs, but does not memoize them.
 
## What is your fix for the problem, implemented in this PR?

This change makes `Definition#specs_for` go through `Definition#specs` so that we can get a consistent behaviour here. While at it, I also removed one unnecessary dependency expansion.

This PR provides a workaround for #5022.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
