### PR TITLE
Better error when installing a lockfile with git sources and git is not installed

### DIFF
--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -56,7 +56,6 @@ module Bundler
           @ref      = ref
           @revision = revision
           @git      = git
-          raise GitNotInstalledError.new if allow? && !Bundler.git_present?
         end
 
         def revision
@@ -208,7 +207,11 @@ module Bundler
         end
 
         def allow?
-          @git ? @git.allow_git_ops? : true
+          allowed = @git ? @git.allow_git_ops? : true
+
+          raise GitNotInstalledError.new if allowed && !Bundler.git_present?
+
+          allowed
         end
 
         def with_path(&blk)

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -1436,7 +1436,44 @@ In Gemfile:
   end
 
   describe "without git installed" do
-    it "prints a better error message" do
+    it "prints a better error message when installing" do
+      build_git "foo"
+
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+
+        gem "rake", git: "https://github.com/ruby/rake"
+      G
+
+      lockfile <<-L
+        GIT
+          remote: https://github.com/ruby/rake
+          revision: 5c60da8644a9e4f655e819252e3b6ca77f42b7af
+          specs:
+            rake (13.0.6)
+
+        GEM
+          remote: https://rubygems.org/
+          specs:
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          rake!
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      with_path_as("") do
+        bundle "install", :raise_on_error => false
+      end
+      expect(err).
+        to include("You need to install git to be able to use gems from git repositories. For help installing git, please refer to GitHub's tutorial at https://help.github.com/articles/set-up-git")
+    end
+
+    it "prints a better error message when updating" do
       build_git "foo"
 
       install_gemfile <<-G


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Currently, we print the bug report template when trying to install a lockfile with `git` sources on a system without `git` installed.

## What is your fix for the problem, implemented in this PR?

Print the proper error about `git` not being present instead.

Fixes #5023.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
