### PR TITLE
Fix `gem install` vs `gem fetch` inconsistency

### DIFF
--- a/lib/rubygems/commands/fetch_command.rb
+++ b/lib/rubygems/commands/fetch_command.rb
@@ -60,7 +60,7 @@ then repackaging it.
         specs_and_sources = filtered unless filtered.empty?
       end
 
-      spec, source = specs_and_sources.max_by {|s,| s.version }
+      spec, source = specs_and_sources.max_by {|s,| s }
 
       if spec.nil?
         show_lookup_failure gem_name, version, errors, options[:domain]

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -1082,17 +1082,21 @@ Also, a list:
       @fetcher.data["#{@gem_repo}latest_specs.#{v}.gz"]     = l_zip
       @fetcher.data["#{@gem_repo}prerelease_specs.#{v}.gz"] = p_zip
 
-      v = Gem.marshal_version
-
-      all_specs.each do |spec|
-        path = "#{@gem_repo}quick/Marshal.#{v}/#{spec.original_name}.gemspec.rz"
-        data = Marshal.dump spec
-        data_deflate = Zlib::Deflate.deflate data
-        @fetcher.data[path] = data_deflate
-      end
+      write_marshalled_gemspecs(*all_specs)
     end
 
     nil # force errors
+  end
+
+  def write_marshalled_gemspecs(*all_specs)
+    v = Gem.marshal_version
+
+    all_specs.each do |spec|
+      path = "#{@gem_repo}quick/Marshal.#{v}/#{spec.original_name}.gemspec.rz"
+      data = Marshal.dump spec
+      data_deflate = Zlib::Deflate.deflate data
+      @fetcher.data[path] = data_deflate
+    end
   end
 
   ##


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Running `gem fetch` and `gem install` against a `geminabox` server results in different fetched/installed gems when there are platform specific gems involved.

## What is your fix for the problem, implemented in this PR?

Use the same sort criteria in `gem fetch` used elsewhere.

Fixes https://github.com/rubygems/rubygems/issues/1629.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
