### PR TITLE
Fix system man pages no longer working after bundler overrides `MANPATH`

### DIFF
--- a/bundler/lib/bundler/runtime.rb
+++ b/bundler/lib/bundler/runtime.rb
@@ -265,7 +265,7 @@ module Bundler
 
       return if manuals.empty?
       Bundler::SharedHelpers.set_env "MANPATH", manuals.concat(
-        ENV["MANPATH"].to_s.split(File::PATH_SEPARATOR)
+        ENV["MANPATH"] ? ENV["MANPATH"].to_s.split(File::PATH_SEPARATOR) : [""]
       ).uniq.join(File::PATH_SEPARATOR)
     end
 

--- a/bundler/spec/support/filters.rb
+++ b/bundler/spec/support/filters.rb
@@ -34,6 +34,7 @@ RSpec.configure do |config|
   config.filter_run_excluding :readline => Gem.win_platform?
   config.filter_run_excluding :jruby => RUBY_ENGINE != "jruby"
   config.filter_run_excluding :truffleruby => RUBY_ENGINE != "truffleruby"
+  config.filter_run_excluding :man => Gem.win_platform?
 
   config.filter_run_when_matching :focus unless ENV["CI"]
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When a gem is shipping man pages, bundler overrides MANPATH in a way that system man pages no longer work.

## What is your fix for the problem, implemented in this PR?

Leave ":" in front of the MANPATH. I found it on https://askubuntu.com/a/693612/100732.

EDIT: In the end, we're appending ":" to `MANPATH` to still give priority to man pages from gems, while defaulting to system man pages otherwise.

Fixes #5038.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
