### PR TITLE
Add an initial rbs template to `bundle gem` skeleton

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -211,6 +211,7 @@ bundler/lib/bundler/templates/newgem/lib/newgem/version.rb.tt
 bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
 bundler/lib/bundler/templates/newgem/rspec.tt
 bundler/lib/bundler/templates/newgem/rubocop.yml.tt
+bundler/lib/bundler/templates/newgem/sig/newgem.rbs.tt
 bundler/lib/bundler/templates/newgem/spec/newgem_spec.rb.tt
 bundler/lib/bundler/templates/newgem/spec/spec_helper.rb.tt
 bundler/lib/bundler/templates/newgem/standard.yml.tt

--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -76,6 +76,7 @@ module Bundler
         "#{Bundler.preferred_gemfile_name}.tt" => Bundler.preferred_gemfile_name,
         "lib/newgem.rb.tt" => "lib/#{namespaced_path}.rb",
         "lib/newgem/version.rb.tt" => "lib/#{namespaced_path}/version.rb",
+        "sig/newgem.rbs.tt" => "sig/#{namespaced_path}.rbs",
         "newgem.gemspec.tt" => "#{name}.gemspec",
         "Rakefile.tt" => "Rakefile",
         "README.md.tt" => "README.md",

--- a/bundler/lib/bundler/templates/newgem/sig/newgem.rbs.tt
+++ b/bundler/lib/bundler/templates/newgem/sig/newgem.rbs.tt
@@ -1,0 +1,8 @@
+<%- config[:constant_array].each_with_index do |c, i| -%>
+<%= "  " * i %>module <%= c %>
+<%- end -%>
+<%= "  " * config[:constant_array].size %>VERSION: String
+<%= "  " * config[:constant_array].size %># See the writing guide of rbs: https://github.com/ruby/rbs#guides
+<%- (config[:constant_array].size-1).downto(0) do |i| -%>
+<%= "  " * i %>end
+<%- end -%>

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -513,6 +513,7 @@ RSpec.describe "bundle gem" do
       expect(bundled_app("#{gem_name}/Rakefile")).to exist
       expect(bundled_app("#{gem_name}/lib/#{require_path}.rb")).to exist
       expect(bundled_app("#{gem_name}/lib/#{require_path}/version.rb")).to exist
+      expect(bundled_app("#{gem_name}/sig/#{require_path}.rbs")).to exist
       expect(bundled_app("#{gem_name}/.gitignore")).to exist
 
       expect(bundled_app("#{gem_name}/bin/setup")).to exist
@@ -527,6 +528,12 @@ RSpec.describe "bundle gem" do
       bundle "gem #{gem_name}"
 
       expect(bundled_app("#{gem_name}/lib/#{require_path}/version.rb").read).to match(/VERSION = "0.1.0"/)
+    end
+
+    it "declare String type for VERSION constant" do
+      bundle "gem #{gem_name}"
+
+      expect(bundled_app("#{gem_name}/sig/#{require_path}.rbs").read).to match(/VERSION: String/)
     end
 
     context "git config user.{name,email} is set" do

--- a/bundler/tool/bundler/rubocop23_gems.rb.lock
+++ b/bundler/tool/bundler/rubocop23_gems.rb.lock
@@ -45,6 +45,7 @@ PLATFORMS
   arm64-darwin-20
   universal-java-11
   x86_64-darwin-19
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES

--- a/bundler/tool/bundler/rubocop24_gems.rb.lock
+++ b/bundler/tool/bundler/rubocop24_gems.rb.lock
@@ -47,6 +47,7 @@ PLATFORMS
   arm64-darwin-20
   universal-java-11
   x86_64-darwin-19
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES

--- a/bundler/tool/bundler/rubocop_gems.rb.lock
+++ b/bundler/tool/bundler/rubocop_gems.rb.lock
@@ -47,6 +47,7 @@ PLATFORMS
   arm64-darwin-20
   universal-java-11
   x86_64-darwin-19
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES

--- a/bundler/tool/bundler/standard23_gems.rb.lock
+++ b/bundler/tool/bundler/standard23_gems.rb.lock
@@ -50,6 +50,7 @@ PLATFORMS
   arm64-darwin-20
   universal-java-11
   x86_64-darwin-19
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES

--- a/bundler/tool/bundler/standard24_gems.rb.lock
+++ b/bundler/tool/bundler/standard24_gems.rb.lock
@@ -53,6 +53,7 @@ PLATFORMS
   arm64-darwin-20
   universal-java-11
   x86_64-darwin-19
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES

--- a/bundler/tool/bundler/standard_gems.rb.lock
+++ b/bundler/tool/bundler/standard_gems.rb.lock
@@ -53,6 +53,7 @@ PLATFORMS
   arm64-darwin-20
   universal-java-11
   x86_64-darwin-19
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES

--- a/bundler/tool/bundler/test_gems.rb.lock
+++ b/bundler/tool/bundler/test_gems.rb.lock
@@ -27,6 +27,7 @@ PLATFORMS
   ruby
   universal-java-11
   x64-mingw32
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES

--- a/dev_gems.rb.lock
+++ b/dev_gems.rb.lock
@@ -52,6 +52,7 @@ PLATFORMS
   ruby
   universal-java-11
   x64-mingw32
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES

--- a/release_gems.rb.lock
+++ b/release_gems.rb.lock
@@ -52,6 +52,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-20
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

[rbs](https://github.com/ruby/rbs) is `RBS is a language to describe the structure of Ruby programs`. It's good to add it boilerplate of `bundle gem` command.

## What is your fix for the problem, implemented in this PR?

Added the initial rbs file for `newgem`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
