### PR TITLE
Allow gem activation from `operating_system.rb`

### DIFF
--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -38,10 +38,10 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby.value }}
           bundler: none
-      - name: Install rubygems
-        run: ruby -Ilib -S rake install 2> errors.txt || (cat errors.txt && exit 1)
-      - name: Check rubygems install produced no warnings
-        run: test ! -s errors.txt || (cat errors.txt && exit 1)
+      - name: Check successful install without warnings
+        run: |
+          ruby -Ilib -S rake install 2> errors.txt || (cat errors.txt && exit 1)
+          test ! -s errors.txt || (cat errors.txt && exit 1)
       - name: Run a local rubygems command
         run: gem list bundler
         env:

--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -97,5 +97,10 @@ jobs:
       - name: Check we can install a Gemfile with git sources
         run: bundle init && bundle add fileutils --git https://github.com/ruby/fileutils
         shell: bash
+      - name: Check the latest available fiddle version gets activated
+        run: |
+          gem install fiddle:1.1.0
+          ruby -rfiddle -e "exit Fiddle::VERSION == '1.1.0'"
+        if: matrix.ruby.name != 'jruby-9.3'
 
     timeout-minutes: 10

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1327,22 +1327,6 @@ require_relative 'rubygems/exceptions'
 # REFACTOR: This should be pulled out into some kind of hacks file.
 begin
   ##
-  # Defaults the operating system (or packager) wants to provide for RubyGems.
-
-  require 'rubygems/defaults/operating_system'
-rescue LoadError
-  # Ignored
-rescue StandardError => e
-  msg = "#{e.message}\n" \
-    "Loading the rubygems/defaults/operating_system.rb file caused an error. " \
-    "This file is owned by your OS, not by rubygems upstream. " \
-    "Please find out which OS package this file belongs to and follow the guidelines from your OS to report " \
-    "the problem and ask for help."
-  raise e.class, msg
-end
-
-begin
-  ##
   # Defaults the Ruby implementation wants to provide for RubyGems
 
   require "rubygems/defaults/#{RUBY_ENGINE}"
@@ -1356,3 +1340,19 @@ Gem::Specification.load_defaults
 require_relative 'rubygems/core_ext/kernel_gem'
 require_relative 'rubygems/core_ext/kernel_require'
 require_relative 'rubygems/core_ext/kernel_warn'
+
+begin
+  ##
+  # Defaults the operating system (or packager) wants to provide for RubyGems.
+
+  require 'rubygems/defaults/operating_system'
+rescue LoadError
+  # Ignored
+rescue StandardError => e
+  msg = "#{e.message}\n" \
+    "Loading the rubygems/defaults/operating_system.rb file caused an error. " \
+    "This file is owned by your OS, not by rubygems upstream. " \
+    "Please find out which OS package this file belongs to and follow the guidelines from your OS to report " \
+    "the problem and ask for help."
+  raise e.class, msg
+end

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -467,7 +467,7 @@ class TestGemRequire < Gem::TestCase
 
   def test_realworld_default_gem
     testing_ruby_repo = !ENV["GEM_COMMAND"].nil?
-    pend "this test can't work under ruby-core setup" if testing_ruby_repo
+    omit "this test can't work under ruby-core setup" if testing_ruby_repo
 
     cmd = <<-RUBY
       $stderr = $stdout
@@ -481,7 +481,7 @@ class TestGemRequire < Gem::TestCase
 
   def test_realworld_upgraded_default_gem
     testing_ruby_repo = !ENV["GEM_COMMAND"].nil?
-    pend "this test can't work under ruby-core setup" if testing_ruby_repo
+    omit "this test can't work under ruby-core setup" if testing_ruby_repo
 
     newer_json = util_spec("json", "999.99.9", nil, ["lib/json.rb"])
     install_gem newer_json

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -466,8 +466,7 @@ class TestGemRequire < Gem::TestCase
   end
 
   def test_realworld_default_gem
-    testing_ruby_repo = !ENV["GEM_COMMAND"].nil?
-    omit "this test can't work under ruby-core setup" if testing_ruby_repo
+    omit "this test can't work under ruby-core setup" if testing_ruby_repo?
 
     cmd = <<-RUBY
       $stderr = $stdout
@@ -480,8 +479,7 @@ class TestGemRequire < Gem::TestCase
   end
 
   def test_realworld_upgraded_default_gem
-    testing_ruby_repo = !ENV["GEM_COMMAND"].nil?
-    omit "this test can't work under ruby-core setup" if testing_ruby_repo
+    omit "this test can't work under ruby-core setup" if testing_ruby_repo?
 
     newer_json = util_spec("json", "999.99.9", nil, ["lib/json.rb"])
     install_gem newer_json
@@ -719,6 +717,10 @@ class TestGemRequire < Gem::TestCase
   end
 
   private
+
+  def testing_ruby_repo?
+    !ENV["GEM_COMMAND"].nil?
+  end
 
   def silence_warnings
     old_verbose, $VERBOSE = $VERBOSE, false

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -467,7 +467,7 @@ class TestGemRequire < Gem::TestCase
 
   def test_realworld_default_gem
     testing_ruby_repo = !ENV["GEM_COMMAND"].nil?
-    pend "this test can't work under ruby-core setup" if testing_ruby_repo || java_platform?
+    pend "this test can't work under ruby-core setup" if testing_ruby_repo
 
     cmd = <<-RUBY
       $stderr = $stdout


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The Windows distribution of ruby loads `fiddle` here: https://github.com/oneclick/rubyinstaller2/blob/206753b4eec6dc96f65898c7dff66eef9d63110a/lib/ruby_installer/build/dll_directory.rb#L1.

At that point, `Kernel.require` monkey patches are not yet in-place. That means `fiddle` is loaded but not activated as a gem, and thus any user code requiring `fiddle` might activate a different version of `fiddle` causing (at best) redefinition warnings.

## What is your fix for the problem, implemented in this PR?

Make sure `Kernel.require` monkeypatches are in place before OS customizations to rubygems have been loaded, since they might need to load default gems.

Fixes #5043.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
