### PR TITLE
Skip to set DESTDIR option when it's not provided for mswin platform

### DIFF
--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -30,7 +30,8 @@ class Gem::Ext::Builder
     end
     make_program = Shellwords.split(make_program)
 
-    destdir = 'DESTDIR=%s' % ENV['DESTDIR']
+    # The installation of the bundled gems is failed when DESTDIR is empty in mswin platform.
+    destdir = ENV['DESTDIR'] ? 'DESTDIR=%s' % ENV['DESTDIR'] : ''
 
     ['clean', '', 'install'].each do |target|
       # Pass DESTDIR via command line to override what's in MAKEFLAGS

--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -31,7 +31,7 @@ class Gem::Ext::Builder
     make_program = Shellwords.split(make_program)
 
     # The installation of the bundled gems is failed when DESTDIR is empty in mswin platform.
-    destdir = ENV['DESTDIR'] ? 'DESTDIR=%s' % ENV['DESTDIR'] : ''
+    destdir = (ENV['DESTDIR'] && ENV['DESTDIR'] != "") ? 'DESTDIR=%s' % ENV['DESTDIR'] : ''
 
     ['clean', '', 'install'].each do |target|
       # Pass DESTDIR via command line to override what's in MAKEFLAGS


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`make DESTDIR= install` is different with `make install`. Ex. It broke the installation of the bundled gems with Ruby 3.1 in mswin environment.

## What is your fix for the problem, implemented in this PR?

Skip to set `DESTDIR=` options when it's not provided.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
