### PR TITLE
Refactor installer thread safety protections

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -67,8 +67,6 @@ class Gem::Installer
 
   @path_warning = false
 
-  @install_lock = Thread::Mutex.new
-
   class << self
     #
     # Changes in rubygems to lazily loading `rubygems/command` (in order to
@@ -91,12 +89,6 @@ class Gem::Installer
     # True if we've warned about PATH not including Gem.bindir
 
     attr_accessor :path_warning
-
-    ##
-    # Certain aspects of the install process are not thread-safe. This lock is
-    # used to allow multiple threads to install Gems at the same time.
-
-    attr_reader :install_lock
 
     ##
     # Overrides the executable format.
@@ -342,7 +334,7 @@ class Gem::Installer
 
     say spec.post_install_message if options[:post_install_message] && !spec.post_install_message.nil?
 
-    Gem::Installer.install_lock.synchronize { Gem::Specification.reset }
+    Gem::Specification.reset
 
     run_post_install_hooks
 
@@ -527,7 +519,7 @@ class Gem::Installer
   end
 
   def generate_plugins # :nodoc:
-    latest = Gem::Installer.install_lock.synchronize { Gem::Specification.latest_spec_for(spec.name) }
+    latest = Gem::Specification.latest_spec_for(spec.name)
     return if latest && latest.version > spec.version
 
     ensure_writable_dir @plugins_dir

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -182,14 +182,19 @@ class Gem::Specification < Gem::BasicSpecification
     @@default_value[k].nil?
   end
 
-  @@all = nil
-  @@stubs = nil
-  @@stubs_by_name = {}
+  def self.clear_specs # :nodoc:
+    @@all = nil
+    @@stubs = nil
+    @@stubs_by_name = {}
+    @@spec_with_requirable_file = {}
+    @@active_stub_with_requirable_file = {}
+  end
+  private_class_method :clear_specs
+
+  clear_specs
 
   # Sentinel object to represent "not found" stubs
   NOT_FOUND = Struct.new(:to_spec, :this).new # :nodoc:
-  @@spec_with_requirable_file = {}
-  @@active_stub_with_requirable_file = {}
 
   # Tracking removed method calls to warn users during build time.
   REMOVED_METHODS = [:rubyforge_project=].freeze # :nodoc:
@@ -1223,11 +1228,7 @@ class Gem::Specification < Gem::BasicSpecification
   def self.reset
     @@dirs = nil
     Gem.pre_reset_hooks.each {|hook| hook.call }
-    @@all = nil
-    @@stubs = nil
-    @@stubs_by_name = {}
-    @@spec_with_requirable_file = {}
-    @@active_stub_with_requirable_file = {}
+    clear_specs
     clear_load_cache
     unresolved = unresolved_deps
     unless unresolved.empty?

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -749,10 +749,7 @@ class Gem::Specification < Gem::BasicSpecification
   attr_accessor :specification_version
 
   def self._all # :nodoc:
-    unless @@all
-      @@all = Gem.loaded_specs.values | stubs.map(&:to_spec)
-    end
-    @@all
+    @@all ||= Gem.loaded_specs.values | stubs.map(&:to_spec)
   end
 
   def self._clear_load_cache # :nodoc:

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -179,13 +179,17 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   def self.clear_specs # :nodoc:
-    @@all = nil
-    @@stubs = nil
-    @@stubs_by_name = {}
-    @@spec_with_requirable_file = {}
-    @@active_stub_with_requirable_file = {}
+    @@all_specs_mutex.synchronize do
+      @@all = nil
+      @@stubs = nil
+      @@stubs_by_name = {}
+      @@spec_with_requirable_file = {}
+      @@active_stub_with_requirable_file = {}
+    end
   end
   private_class_method :clear_specs
+
+  @@all_specs_mutex = Thread::Mutex.new
 
   clear_specs
 
@@ -750,7 +754,7 @@ class Gem::Specification < Gem::BasicSpecification
   attr_accessor :specification_version
 
   def self._all # :nodoc:
-    @@all ||= Gem.loaded_specs.values | stubs.map(&:to_spec)
+    @@all_specs_mutex.synchronize { @@all ||= Gem.loaded_specs.values | stubs.map(&:to_spec) }
   end
 
   def self.clear_load_cache # :nodoc:

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -752,11 +752,12 @@ class Gem::Specification < Gem::BasicSpecification
     @@all ||= Gem.loaded_specs.values | stubs.map(&:to_spec)
   end
 
-  def self._clear_load_cache # :nodoc:
+  def self.clear_load_cache # :nodoc:
     LOAD_CACHE_MUTEX.synchronize do
       LOAD_CACHE.clear
     end
   end
+  private_class_method :clear_load_cache
 
   def self.each_gemspec(dirs) # :nodoc:
     dirs.each do |dir|
@@ -1227,7 +1228,7 @@ class Gem::Specification < Gem::BasicSpecification
     @@stubs_by_name = {}
     @@spec_with_requirable_file = {}
     @@active_stub_with_requirable_file = {}
-    _clear_load_cache
+    clear_load_cache
     unresolved = unresolved_deps
     unless unresolved.empty?
       w = "W" + "ARN"

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -750,13 +750,7 @@ class Gem::Specification < Gem::BasicSpecification
 
   def self._all # :nodoc:
     unless @@all
-      @@all = stubs.map(&:to_spec)
-
-      # After a reset, make sure already loaded specs
-      # are still marked as activated.
-      specs = {}
-      Gem.loaded_specs.each_value{|s| specs[s] = true }
-      @@all.each{|s| s.activated = true if specs[s] }
+      @@all = Gem.loaded_specs.values | stubs.map(&:to_spec)
     end
     @@all
   end

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -182,6 +182,7 @@ class Gem::Specification < Gem::BasicSpecification
     @@default_value[k].nil?
   end
 
+  @@all = nil
   @@stubs = nil
   @@stubs_by_name = {}
 
@@ -748,7 +749,7 @@ class Gem::Specification < Gem::BasicSpecification
   attr_accessor :specification_version
 
   def self._all # :nodoc:
-    unless defined?(@@all) && @@all
+    unless @@all
       @@all = stubs.map(&:to_spec)
 
       # After a reset, make sure already loaded specs

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -480,7 +480,6 @@ class Gem::TestCase < Test::Unit::TestCase
       Gem.instance_variable_set :@default_dir, nil
     end
 
-    Gem::Specification._clear_load_cache
     Gem::Specification.unresolved_deps.clear
     Gem::refresh
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes `gem install` on `jruby` may crash with an error that could some some thread safety issue. But I don't think `gem install` installs gems from different threads, so that might not be it 🤷‍♂️. It could also be some jruby bug?

## What is your fix for the problem, implemented in this PR?

No fix, but I tried to refactor gem installer thread safety protections to work at a finer level. I think they were trying to protect concurrent access to the `@@all` variable which holds the set of all specifications rubygems knows about. So I moved the protections there to emphasize that.

Maybe with this refactoring the problem is no longer triggered.

Closes #5047.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
