### PR TITLE
Fix `ruby setup.rb` when `--prefix` is passed

### DIFF
--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -360,7 +360,7 @@ By default, this RubyGems will install gem as:
   end
 
   def install_default_bundler_gem(bin_dir)
-    specs_dir = prepend_destdir_if_present(Gem.default_specifications_dir)
+    specs_dir = File.join(default_dir, "specifications", "default")
     mkdir_p specs_dir, :mode => 0755
 
     bundler_spec = Dir.chdir("bundler") { Gem::Specification.load("bundler.gemspec") }
@@ -388,7 +388,7 @@ By default, this RubyGems will install gem as:
     bundler_spec.instance_variable_set(:@base_dir, File.dirname(File.dirname(specs_dir)))
 
     # Remove gemspec that was same version of vendored bundler.
-    normal_gemspec = File.join(Gem.default_dir, "specifications", "bundler-#{bundler_spec.version}.gemspec")
+    normal_gemspec = File.join(default_dir, "specifications", "bundler-#{bundler_spec.version}.gemspec")
     if File.file? normal_gemspec
       File.delete normal_gemspec
     end
@@ -606,6 +606,18 @@ abort "#{deprecation_message}"
   end
 
   private
+
+  def default_dir
+    prefix = options[:prefix]
+
+    if prefix.empty?
+      dir = Gem.default_dir
+    else
+      dir = prefix
+    end
+
+    prepend_destdir_if_present(dir)
+  end
 
   def prepend_destdir_if_present(path)
     destdir = options[:destdir]

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -611,10 +611,6 @@ abort "#{deprecation_message}"
     destdir = options[:destdir]
     return path if destdir.empty?
 
-    prepend_destdir(path)
-  end
-
-  def prepend_destdir(path)
     File.join(options[:destdir], path.gsub(/^[a-zA-Z]:/, ''))
   end
 

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -149,12 +149,6 @@ By default, this RubyGems will install gem as:
   def execute
     @verbose = Gem.configuration.really_verbose
 
-    install_destdir = options[:destdir]
-
-    unless install_destdir.empty?
-      ENV['GEM_HOME'] ||= prepend_destdir(Gem.default_dir)
-    end
-
     check_ruby_version
 
     require 'fileutils'

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -397,6 +397,14 @@ class Gem::TestCase < Test::Unit::TestCase
     @orig_bindir = RbConfig::CONFIG["bindir"]
     RbConfig::CONFIG["bindir"] = File.join @gemhome, "bin"
 
+    @orig_sitelibdir = RbConfig::CONFIG["sitelibdir"]
+    new_sitelibdir = @orig_sitelibdir.sub(RbConfig::CONFIG["prefix"], @gemhome)
+    $LOAD_PATH.insert(Gem.load_path_insert_index, new_sitelibdir)
+    RbConfig::CONFIG["sitelibdir"] = new_sitelibdir
+
+    @orig_mandir = RbConfig::CONFIG["mandir"]
+    RbConfig::CONFIG["mandir"] = File.join @gemhome, "share", "man"
+
     Gem::Specification.unresolved_deps.clear
     Gem.use_paths(@gemhome)
 
@@ -468,6 +476,8 @@ class Gem::TestCase < Test::Unit::TestCase
 
     Gem.ruby = @orig_ruby if @orig_ruby
 
+    RbConfig::CONFIG['mandir'] = @orig_mandir
+    RbConfig::CONFIG['sitelibdir'] = @orig_sitelibdir
     RbConfig::CONFIG['bindir'] = @orig_bindir
 
     Gem.instance_variable_set :@default_specifications_dir, nil

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -245,9 +245,8 @@ class TestGemCommandsSetupCommand < Gem::TestCase
   def test_install_default_bundler_gem_with_destdir_flag
     @cmd.extend FileUtils
 
-    bin_dir = File.join(@gemhome, 'bin')
-
     destdir = File.join(@tempdir, 'foo')
+    bin_dir = File.join(destdir, 'bin')
 
     @cmd.options[:destdir] = destdir
 

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -256,12 +256,10 @@ class TestGemCommandsSetupCommand < Gem::TestCase
 
       @cmd.install_default_bundler_gem bin_dir
 
-      bundler_spec = Gem::Specification.load("bundler/bundler.gemspec")
-      default_spec_path = File.join(Gem.default_specifications_dir, "#{bundler_spec.full_name}.gemspec")
-      spec = Gem::Specification.load(default_spec_path)
+      spec = Gem::Specification.load("bundler/bundler.gemspec")
 
       spec.executables.each do |e|
-        assert_path_exist File.join destdir, spec.bin_dir.gsub(/^[a-zA-Z]:/, ''), e
+        assert_path_exist File.join destdir, @gemhome.gsub(/^[a-zA-Z]:/, ''), 'gems', spec.full_name, spec.bindir, e
       end
     end
   end

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -225,22 +225,20 @@ class TestGemCommandsSetupCommand < Gem::TestCase
       f.puts 'echo "hello"'
     end
 
-    bindir(bin_dir) do
-      @cmd.options[:force] = true
+    @cmd.options[:force] = true
 
-      @cmd.install_default_bundler_gem bin_dir
+    @cmd.install_default_bundler_gem bin_dir
 
-      bundler_spec = Gem::Specification.load("bundler/bundler.gemspec")
-      default_spec_path = File.join(Gem.default_specifications_dir, "#{bundler_spec.full_name}.gemspec")
-      spec = Gem::Specification.load(default_spec_path)
+    bundler_spec = Gem::Specification.load("bundler/bundler.gemspec")
+    default_spec_path = File.join(Gem.default_specifications_dir, "#{bundler_spec.full_name}.gemspec")
+    spec = Gem::Specification.load(default_spec_path)
 
-      spec.executables.each do |e|
-        if Gem.win_platform?
-          assert_path_exist File.join(bin_dir, "#{e}.bat")
-        end
-
-        assert_path_exist File.join bin_dir, e
+    spec.executables.each do |e|
+      if Gem.win_platform?
+        assert_path_exist File.join(bin_dir, "#{e}.bat")
       end
+
+      assert_path_exist File.join bin_dir, e
     end
   end
 
@@ -249,18 +247,16 @@ class TestGemCommandsSetupCommand < Gem::TestCase
 
     bin_dir = File.join(@gemhome, 'bin')
 
-    bindir(bin_dir) do
-      destdir = File.join(@tempdir, 'foo')
+    destdir = File.join(@tempdir, 'foo')
 
-      @cmd.options[:destdir] = destdir
+    @cmd.options[:destdir] = destdir
 
-      @cmd.install_default_bundler_gem bin_dir
+    @cmd.install_default_bundler_gem bin_dir
 
-      spec = Gem::Specification.load("bundler/bundler.gemspec")
+    spec = Gem::Specification.load("bundler/bundler.gemspec")
 
-      spec.executables.each do |e|
-        assert_path_exist File.join destdir, @gemhome.gsub(/^[a-zA-Z]:/, ''), 'gems', spec.full_name, spec.bindir, e
-      end
+    spec.executables.each do |e|
+      assert_path_exist File.join destdir, @gemhome.gsub(/^[a-zA-Z]:/, ''), 'gems', spec.full_name, spec.bindir, e
     end
   end
 

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -259,6 +259,24 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     end
   end
 
+  def test_install_default_bundler_gem_with_destdir_and_prefix_flags
+    @cmd.extend FileUtils
+
+    destdir = File.join(@tempdir, 'foo')
+    bin_dir = File.join(destdir, 'bin')
+
+    @cmd.options[:destdir] = destdir
+    @cmd.options[:prefix] = "/"
+
+    @cmd.install_default_bundler_gem bin_dir
+
+    spec = Gem::Specification.load("bundler/bundler.gemspec")
+
+    spec.executables.each do |e|
+      assert_path_exist File.join destdir, 'gems', spec.full_name, spec.bindir, e
+    end
+  end
+
   def test_remove_old_lib_files
     lib                   = RbConfig::CONFIG["sitelibdir"]
     lib_rubygems          = File.join lib, 'rubygems'

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -14,9 +14,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
   def setup
     super
 
-    @install_dir = File.join @tempdir, 'install'
     @cmd = Gem::Commands::SetupCommand.new
-    @cmd.options[:prefix] = @install_dir
 
     filelist = %w[
       bin/gem
@@ -269,7 +267,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
   end
 
   def test_remove_old_lib_files
-    lib                   = File.join @install_dir, 'lib'
+    lib                   = RbConfig::CONFIG["sitelibdir"]
     lib_rubygems          = File.join lib, 'rubygems'
     lib_bundler           = File.join lib, 'bundler'
     lib_rubygems_defaults = File.join lib_rubygems, 'defaults'
@@ -300,7 +298,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
   end
 
   def test_remove_old_man_files
-    man = File.join @install_dir, 'man'
+    man = File.join RbConfig::CONFIG['mandir'], 'man'
 
     ruby_1             = File.join man, 'man1', 'ruby.1'
     bundle_b_1         = File.join man, 'man1', 'bundle-b.1'
@@ -406,14 +404,14 @@ class TestGemCommandsSetupCommand < Gem::TestCase
   end
 
   def default_gem_bin_path
-    File.join @install_dir, 'bin', 'gem'
+    File.join RbConfig::CONFIG['bindir'], 'gem'
   end
 
   def default_bundle_bin_path
-    File.join @install_dir, 'bin', 'bundle'
+    File.join RbConfig::CONFIG['bindir'], 'bundle'
   end
 
   def default_bundler_bin_path
-    File.join @install_dir, 'bin', 'bundler'
+    File.join RbConfig::CONFIG['bindir'], 'bundler'
   end
 end unless Gem.java_platform?


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The different parts of the default rubygems & bundler installer would be installed at inconstent locations when both `--destdir` and `--prefix` were passed, because `--prefix` was not being considered everywhere.

## What is your fix for the problem, implemented in this PR?

Fix is to make sure all target folders consider `--prefix`.

Closes  https://github.com/rubygems/rubygems/issues/3604.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
