### PR TITLE
Fix `ruby setup.rb` trying to write outside of `--destdir`

### DIFF
--- a/lib/rubygems/commands/pristine_command.rb
+++ b/lib/rubygems/commands/pristine_command.rb
@@ -50,6 +50,11 @@ class Gem::Commands::PristineCommand < Gem::Command
       options[:env_shebang] = value
     end
 
+    add_option('-i', '--install-dir DIR',
+               'Gem repository to get binstubs and plugins installed') do |value, options|
+      options[:install_dir] = File.expand_path(value)
+    end
+
     add_option('-n', '--bindir DIR',
                'Directory where executables are',
                'located') do |value, options|
@@ -163,11 +168,12 @@ extensions will be restored.
         end
 
       bin_dir = options[:bin_dir] if options[:bin_dir]
+      install_dir = options[:install_dir] if options[:install_dir]
 
       installer_options = {
         :wrappers => true,
         :force => true,
-        :install_dir => spec.base_dir,
+        :install_dir => install_dir || spec.base_dir,
         :env_shebang => env_shebang,
         :build_args => spec.build_args,
         :bin_dir => bin_dir,
@@ -177,7 +183,7 @@ extensions will be restored.
         installer = Gem::Installer.for_spec(spec, installer_options)
         installer.generate_bin
       elsif options[:only_plugins]
-        installer = Gem::Installer.for_spec(spec)
+        installer = Gem::Installer.for_spec(spec, installer_options)
         installer.generate_plugins
       else
         installer = Gem::Installer.at(gem, installer_options)

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -610,6 +610,7 @@ abort "#{deprecation_message}"
 
     args = %w[--all --only-plugins --silent]
     args << "--bindir=#{bindir}"
+    args << "--install-dir=#{default_dir}"
 
     command = Gem::Commands::PristineCommand.new
     command.invoke(*args)

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -418,6 +418,7 @@ By default, this RubyGems will install gem as:
           force: options[:force],
           install_as_default: true,
           bin_dir: bin_dir,
+          install_dir: default_dir,
           wrappers: true
         ).install
       ensure

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -411,8 +411,15 @@ By default, this RubyGems will install gem as:
     Dir.chdir("bundler") do
       built_gem = Gem::Package.build(bundler_spec)
       begin
-        installer = Gem::Installer.at(built_gem, env_shebang: options[:env_shebang], format_executable: options[:format_executable], force: options[:force], install_as_default: true, bin_dir: bin_dir, wrappers: true)
-        installer.install
+        Gem::Installer.at(
+          built_gem,
+          env_shebang: options[:env_shebang],
+          format_executable: options[:format_executable],
+          force: options[:force],
+          install_as_default: true,
+          bin_dir: bin_dir,
+          wrappers: true
+        ).install
       ensure
         FileUtils.rm_f built_gem
       end

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -182,8 +182,8 @@ By default, this RubyGems will install gem as:
 
     say "RubyGems #{Gem::VERSION} installed"
 
-    regenerate_binstubs if options[:regenerate_binstubs]
-    regenerate_plugins if options[:regenerate_plugins]
+    regenerate_binstubs(bin_dir) if options[:regenerate_binstubs]
+    regenerate_plugins(bin_dir) if options[:regenerate_plugins]
 
     uninstall_old_gemcutter
 
@@ -582,11 +582,12 @@ abort "#{deprecation_message}"
   rescue Gem::InstallError
   end
 
-  def regenerate_binstubs
+  def regenerate_binstubs(bindir)
     require_relative "pristine_command"
     say "Regenerating binstubs"
 
     args = %w[--all --only-executables --silent]
+    args << "--bindir=#{bindir}"
     if options[:env_shebang]
       args << "--env-shebang"
     end
@@ -595,11 +596,12 @@ abort "#{deprecation_message}"
     command.invoke(*args)
   end
 
-  def regenerate_plugins
+  def regenerate_plugins(bindir)
     require_relative "pristine_command"
     say "Regenerating plugins"
 
     args = %w[--all --only-plugins --silent]
+    args << "--bindir=#{bindir}"
 
     command = Gem::Commands::PristineCommand.new
     command.invoke(*args)

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -245,6 +245,8 @@ class TestGemCommandsSetupCommand < Gem::TestCase
   def test_install_default_bundler_gem_with_destdir_flag
     @cmd.extend FileUtils
 
+    FileUtils.chmod "-w", @gemhome
+
     destdir = File.join(@tempdir, 'foo')
     bin_dir = File.join(destdir, 'bin')
 

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -156,6 +156,21 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     assert_match %r{\A#!\s*#{bin_env}#{ruby_exec}}, File.read(gem_bin_path)
   end
 
+  def test_destdir_flag_does_not_try_to_write_to_the_default_gem_home
+    FileUtils.chmod "-w", File.join(@gemhome, "plugins")
+
+    destdir = File.join(@tempdir, 'foo')
+
+    @cmd.options[:destdir] = destdir
+    @cmd.execute
+
+    spec = Gem::Specification.load("bundler/bundler.gemspec")
+
+    spec.executables.each do |e|
+      assert_path_exist File.join destdir, @gemhome.gsub(/^[a-zA-Z]:/, ''), 'gems', spec.full_name, spec.bindir, e
+    end
+  end
+
   def test_files_in
     assert_equal %w[rubygems.rb rubygems/requirement.rb rubygems/ssl_certs/rubygems.org/foo.pem],
                  @cmd.files_in('lib').sort


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Installation of the default bundler gem when `--destdir` is passed would complain if the default GEM_HOME (outside of `--destdir` is not writable).

## What is your fix for the problem, implemented in this PR?

Pass the proper `--install-dir` to the default bundler installer.

Fixes #2370.
Fixes #4508.

NOTE: This PR is currently built on top of #5051 since it requires some fixes from there.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
