### PR TITLE
Undeprecate `bundle viz` for now

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -552,7 +552,6 @@ module Bundler
       method_option :version, :type => :boolean, :default => false, :aliases => "-v", :desc => "Set to show each gem version."
       method_option :without, :type => :array, :default => [], :aliases => "-W", :banner => "GROUP[ GROUP...]", :desc => "Exclude gems that are part of the specified named group."
       def viz
-        SharedHelpers.major_deprecation 2, "The `viz` command has been moved to the `bundle-viz` gem, see https://github.com/rubygems/bundler-viz"
         require_relative "cli/viz"
         Viz.new(options.dup).run
       end

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -656,21 +656,6 @@ The :gist git source is deprecated, and will be removed in the future. Add this 
     pending "fails with a helpful message", :bundler => "3"
   end
 
-  context "bundle viz" do
-    before do
-      graphviz_version = RUBY_VERSION >= "2.4" ? "1.2.5" : "1.2.4"
-      realworld_system_gems "ruby-graphviz --version #{graphviz_version}"
-      create_file "gems.rb", "source \"#{file_uri_for(gem_repo1)}\""
-      bundle "viz"
-    end
-
-    it "prints a deprecation warning", :bundler => "< 3" do
-      expect(deprecations).to include "The `viz` command has been moved to the `bundle-viz` gem, see https://github.com/rubygems/bundler-viz"
-    end
-
-    pending "fails with a helpful message", :bundler => "3"
-  end
-
   describe "deprecating rubocop", :readline do
     context "bundle gem --rubocop" do
       before do


### PR DESCRIPTION

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

We are showing a non existing link to our users as they new repository that they have to install to replace `bundle viz`.

## What is your fix for the problem, implemented in this PR?

In #4964 I merged a link update but didn't realize that the repository is not yet public 🙈.

Until we have a working alternative ready, let's stop showing a non accessible link to our users.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
