### PR TITLE
Changelogs for rubygems 3.2.31 and bundler 2.2.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+# 3.2.31 / 2021-11-08
+
+## Enhancements:
+
+* Don't pass empty `DESTDIR` to `nmake` since it works differently from
+  standard `make`. Pull request #5057 by hsbt
+* Fix `gem install` vs `gem fetch` inconsistency. Pull request #5037 by
+  deivid-rodriguez
+* Lazily load and vendor `optparse`. Pull request #4881 by
+  deivid-rodriguez
+* Use a vendored copy of `tsort` internally. Pull request #5027 by
+  deivid-rodriguez
+
+## Bug fixes:
+
+* Fix `ruby setup.rb` when `--prefix` is passed. Pull request #5051 by
+  deivid-rodriguez
+* Don't apply `--destdir` twice when running `setup.rb`. Pull request
+  #2768 by alyssais
+
 # 3.2.30 / 2021-10-26
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,20 @@
+# 2.2.31 (November 8, 2021)
+
+## Enhancements:
+
+  - Link to working `bundler-graph` plugin in `bundle viz` deprecation message [#5061](https://github.com/rubygems/rubygems/pull/5061)
+  - Memoize materialized specs when requiring `bundler/setup` [#5033](https://github.com/rubygems/rubygems/pull/5033)
+  - Allow custom LicenseRef [#5013](https://github.com/rubygems/rubygems/pull/5013)
+  - Better error when installing a lockfile with git sources and git is not installed [#5036](https://github.com/rubygems/rubygems/pull/5036)
+  - Only delete cached gem when it's corrupted [#5031](https://github.com/rubygems/rubygems/pull/5031)
+  - Support gemified `tsort` [#5032](https://github.com/rubygems/rubygems/pull/5032)
+  - Add standard option alongside rubocop to `bundle gem` [#4411](https://github.com/rubygems/rubygems/pull/4411)
+
+## Bug fixes:
+
+  - Fix system man pages no longer working after bundler overrides `MANPATH` [#5039](https://github.com/rubygems/rubygems/pull/5039)
+  - Don't warn when a lockfile is locked to a dev version [#5018](https://github.com/rubygems/rubygems/pull/5018)
+
 # 2.2.30 (October 26, 2021)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking changelogs from future rubygems 3.2.31 and bundler 2.2.31 into master.