### PR TITLE
Unlock dependencies that no longer match lockfile

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -656,15 +656,8 @@ module Bundler
     end
 
     def converge_dependencies
-      frozen = Bundler.frozen_bundle?
       (@dependencies + locked_dependencies).each do |dep|
-        locked_source = @locked_deps[dep.name]
-        # This is to make sure that if bundler is installing in deployment mode and
-        # after locked_source and sources don't match, we still use locked_source.
-        if frozen && !locked_source.nil? &&
-            locked_source.respond_to?(:source) && locked_source.source.instance_of?(Source::Path) && locked_source.source.path.exist?
-          dep.source = locked_source.source
-        elsif dep.source
+        if dep.source
           dep.source = sources.get(dep.source)
         end
       end

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -706,17 +706,8 @@ module Bundler
       # the gem in the Gemfile.lock still satisfies it, this is fine
       # too.
       @dependencies.each do |dep|
-        locked_dep = @locked_deps[dep.name]
-
         if satisfies_locked_spec?(dep)
           deps << dep
-        elsif dep.source.is_a?(Source::Path) && dep.current_platform? && (dep != locked_dep || dep.source != locked_dep.source)
-          @locked_specs.each do |s|
-            @unlock[:gems] << s.name if s.source == dep.source
-          end
-
-          dep.source.unlock! if dep.source.respond_to?(:unlock!)
-          dep.source.specs.each {|s| @unlock[:gems] << s.name }
         end
       end
 

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -671,8 +671,8 @@ module Bundler
 
       changes = false
 
-      @dependencies.each do |dependency|
-        unless locked_dep = @locked_deps[dependency.name]
+      @dependencies.each do |dep|
+        unless locked_dep = @locked_deps[dep.name]
           changes = true
           next
         end
@@ -683,11 +683,11 @@ module Bundler
         # directive, the lockfile dependencies and resolved dependencies end up
         # with a mismatch on #type. Work around that by setting the type on the
         # dep from the lockfile.
-        locked_dep.instance_variable_set(:@type, dependency.type)
+        locked_dep.instance_variable_set(:@type, dep.type)
 
         # We already know the name matches from the hash lookup
         # so we only need to check the requirement now
-        changes ||= dependency.requirement != locked_dep.requirement
+        changes ||= dep.requirement != locked_dep.requirement
       end
 
       changes

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -739,7 +739,11 @@ module Bundler
           s.dependencies.replace(new_spec.dependencies)
         end
 
-        converged << s
+        if dep.nil? && @dependencies.find {|d| s.name == d.name }
+          @unlock[:gems] << s.name
+        else
+          converged << s
+        end
       end
 
       resolve = SpecSet.new(converged)

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -670,9 +670,7 @@ module Bundler
       end
 
       changes = false
-      # We want to know if all match, but don't want to check all entries
-      # This means we need to return false if any dependency doesn't match
-      # the lock or doesn't exist in the lock.
+
       @dependencies.each do |dependency|
         unless locked_dep = @locked_deps[dependency.name]
           changes = true

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -711,7 +711,7 @@ module Bundler
         # If the locked_dep doesn't match the dependency we're looking for then we ignore the locked_dep
         locked_dep = nil unless locked_dep == dep
 
-        if in_locked_deps?(dep, locked_dep) || satisfies_locked_spec?(dep)
+        if satisfies_locked_spec?(dep)
           deps << dep
         elsif dep.source.is_a?(Source::Path) && dep.current_platform? && (!locked_dep || dep.source != locked_dep.source)
           @locked_specs.each do |s|
@@ -778,13 +778,6 @@ module Bundler
       end
 
       resolve
-    end
-
-    def in_locked_deps?(dep, locked_dep)
-      # Because the lockfile can't link a dep to a specific remote, we need to
-      # treat sources as equivalent anytime the locked dep has all the remotes
-      # that the Gemfile dep does.
-      locked_dep && locked_dep.source && dep.source && locked_dep.source.include?(dep.source)
     end
 
     def satisfies_locked_spec?(dep)

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -708,12 +708,9 @@ module Bundler
       @dependencies.each do |dep|
         locked_dep = @locked_deps[dep.name]
 
-        # If the locked_dep doesn't match the dependency we're looking for then we ignore the locked_dep
-        locked_dep = nil unless locked_dep == dep
-
         if satisfies_locked_spec?(dep)
           deps << dep
-        elsif dep.source.is_a?(Source::Path) && dep.current_platform? && (!locked_dep || dep.source != locked_dep.source)
+        elsif dep.source.is_a?(Source::Path) && dep.current_platform? && (dep != locked_dep || dep.source != locked_dep.source)
           @locked_specs.each do |s|
             @unlock[:gems] << s.name if s.source == dep.source
           end

--- a/bundler/spec/install/gems/flex_spec.rb
+++ b/bundler/spec/install/gems/flex_spec.rb
@@ -229,14 +229,27 @@ RSpec.describe "bundle flex_install" do
       G
     end
 
-    it "does something" do
-      expect do
-        bundle "install", :raise_on_error => false
-      end.not_to change { File.read(bundled_app_lock) }
+    it "should work when you install" do
+      bundle "install"
 
-      expect(err).to include("rack = 0.9.1")
-      expect(err).to include("locked at 1.0.0")
-      expect(err).to include("bundle update rack")
+      expect(lockfile).to eq <<~L
+        GEM
+          remote: #{file_uri_for(gem_repo1)}/
+          specs:
+            rack (0.9.1)
+            rack-obama (1.0)
+              rack
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          rack (= 0.9.1)
+          rack-obama
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
     end
 
     it "should work when you update" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When you change a dependency `foo` in your `Gemfile` with a new requirement that no longer matches the version of the dependency in the lockfile, running `bundle install` will result in an error that tells you to run `bundle update foo` instead.
 
## What is your fix for the problem, implemented in this PR?

The current outcome is not terrible but it's not great either. Ideally `bundler` should automatically unlock the dependency when it detects this situation instead of printing an error. This is what this PR implements.

NOTE: In addition to fixing the issue, I also added several simplifications in the same area of the code that I was working on.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
