### PR TITLE
Don't corrupt lockfile when user moves a gem that's already in the lockfile to an incorrect source by mistake

### DIFF
--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -19,7 +19,7 @@ module Bundler
     end
 
     def full_name
-      if platform == Gem::Platform::RUBY || platform.nil?
+      if platform == Gem::Platform::RUBY
         "#{@name}-#{@version}"
       else
         "#{@name}-#{@version}-#{platform}"
@@ -61,7 +61,7 @@ module Bundler
     def to_lock
       out = String.new
 
-      if platform == Gem::Platform::RUBY || platform.nil?
+      if platform == Gem::Platform::RUBY
         out << "    #{name} (#{version})\n"
       else
         out << "    #{name} (#{version}-#{platform})\n"
@@ -105,7 +105,7 @@ module Bundler
     end
 
     def to_s
-      @__to_s ||= if platform == Gem::Platform::RUBY || platform.nil?
+      @__to_s ||= if platform == Gem::Platform::RUBY
         "#{name} (#{version})"
       else
         "#{name} (#{version}-#{platform})"

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -84,7 +84,7 @@ module Bundler
         else
           ruby_platform_materializes_to_ruby_platform? ? self : Dependency.new(name, version)
         end
-        platform_object = ruby_platform_materializes_to_ruby_platform? ? Gem::Platform.new(platform) : Bundler.local_platform
+        platform_object = ruby_platform_materializes_to_ruby_platform? ? platform : Bundler.local_platform
         candidates = source.specs.search(search_object)
         same_platform_candidates = candidates.select do |spec|
           MatchPlatform.platforms_match?(spec.platform, platform_object)

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -75,7 +75,17 @@ module Bundler
       out
     end
 
-    def __materialize__
+    def materialize_for_installation
+      __materialize__(ruby_platform_materializes_to_ruby_platform? ? platform : Bundler.local_platform)
+    end
+
+    def materialize_for_resolution
+      return self unless Gem::Platform.match_spec?(self)
+
+      __materialize__(platform)
+    end
+
+    def __materialize__(platform)
       @specification = if source.is_a?(Source::Gemspec) && source.gemspec.name == name
         source.gemspec.tap {|s| s.source = source }
       else
@@ -84,10 +94,9 @@ module Bundler
         else
           ruby_platform_materializes_to_ruby_platform? ? self : Dependency.new(name, version)
         end
-        platform_object = ruby_platform_materializes_to_ruby_platform? ? platform : Bundler.local_platform
         candidates = source.specs.search(search_object)
         same_platform_candidates = candidates.select do |spec|
-          MatchPlatform.platforms_match?(spec.platform, platform_object)
+          MatchPlatform.platforms_match?(spec.platform, platform)
         end
         installable_candidates = same_platform_candidates.select do |spec|
           spec.is_a?(StubSpecification) ||

--- a/bundler/lib/bundler/remote_specification.rb
+++ b/bundler/lib/bundler/remote_specification.rb
@@ -16,7 +16,8 @@ module Bundler
     def initialize(name, version, platform, spec_fetcher)
       @name         = name
       @version      = Gem::Version.create version
-      @platform     = platform || Gem::Platform::RUBY
+      @original_platform = platform || Gem::Platform::RUBY
+      @platform     = Gem::Platform.new(platform)
       @spec_fetcher = spec_fetcher
       @dependencies = nil
     end
@@ -35,10 +36,10 @@ module Bundler
     end
 
     def full_name
-      if platform == Gem::Platform::RUBY
+      if @original_platform == Gem::Platform::RUBY
         "#{@name}-#{@version}"
       else
-        "#{@name}-#{@version}-#{platform}"
+        "#{@name}-#{@version}-#{@original_platform}"
       end
     end
 
@@ -105,7 +106,7 @@ module Bundler
     end
 
     def _remote_specification
-      @_remote_specification ||= @spec_fetcher.fetch_spec([@name, @version, @platform])
+      @_remote_specification ||= @spec_fetcher.fetch_spec([@name, @version, @original_platform])
       @_remote_specification || raise(GemspecError, "Gemspec data for #{full_name} was" \
         " missing from the server! Try installing with `--full-index` as a workaround.")
     end

--- a/bundler/lib/bundler/remote_specification.rb
+++ b/bundler/lib/bundler/remote_specification.rb
@@ -16,7 +16,7 @@ module Bundler
     def initialize(name, version, platform, spec_fetcher)
       @name         = name
       @version      = Gem::Version.create version
-      @platform     = platform
+      @platform     = platform || Gem::Platform::RUBY
       @spec_fetcher = spec_fetcher
       @dependencies = nil
     end
@@ -35,7 +35,7 @@ module Bundler
     end
 
     def full_name
-      if platform == Gem::Platform::RUBY || platform.nil?
+      if platform == Gem::Platform::RUBY
         "#{@name}-#{@version}"
       else
         "#{@name}-#{@version}-#{platform}"

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -28,11 +28,10 @@ module Bundler
     def initialize(source_requirements, base, gem_version_promoter, additional_base_requirements, platforms, metadata_requirements)
       @source_requirements = source_requirements
       @metadata_requirements = metadata_requirements
-      @base = base
       @resolver = Molinillo::Resolver.new(self, self)
       @search_for = {}
       @base_dg = Molinillo::DependencyGraph.new
-      @base.each do |ls|
+      @base = base.materialized_for_resolution do |ls|
         dep = Dependency.new(ls.name, ls.version)
         @base_dg.add_vertex(ls.name, DepProxy.get_proxy(dep, ls.platform), true)
       end

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -71,7 +71,7 @@ module Bundler
       materialized.map! do |s|
         next s unless s.is_a?(LazySpecification)
         s.source.local!
-        s.__materialize__ || s
+        s.materialize_for_installation || s
       end
       SpecSet.new(materialized)
     end
@@ -84,10 +84,19 @@ module Bundler
         next s unless s.is_a?(LazySpecification)
         s.source.local!
         s.source.remote!
-        spec = s.__materialize__
+        spec = s.materialize_for_installation
         raise GemNotFound, "Could not find #{s.full_name} in any of the sources" unless spec
         spec
       end
+    end
+
+    def materialized_for_resolution
+      materialized = @specs.map do |s|
+        spec = s.materialize_for_resolution
+        yield spec if spec
+        spec
+      end.compact
+      SpecSet.new(materialized)
     end
 
     def missing_specs

--- a/bundler/spec/install/yanked_spec.rb
+++ b/bundler/spec/install/yanked_spec.rb
@@ -15,7 +15,7 @@ RSpec.context "when installing a bundle that includes yanked gems" do
            foo (10.0.0)
 
        PLATFORMS
-         ruby
+         #{lockfile_platforms}
 
        DEPENDENCIES
          foo (= 10.0.0)
@@ -57,7 +57,7 @@ RSpec.context "when using gem before installing" do
           rack (0.9.1)
 
       PLATFORMS
-        ruby
+        #{lockfile_platforms}
 
       DEPENDENCIES
         rack (= 0.9.1)
@@ -86,7 +86,7 @@ RSpec.context "when using gem before installing" do
           rack_middleware (1.0)
 
       PLATFORMS
-        ruby
+        #{lockfile_platforms}
 
       DEPENDENCIES
         rack (= 0.9.1)

--- a/bundler/spec/resolver/basic_spec.rb
+++ b/bundler/spec/resolver/basic_spec.rb
@@ -233,7 +233,7 @@ Bundler could not find compatible versions for gem "a":
     it "resolves foo only to latest patch - changing dependency declared case" do
       # bar is locked AND a declared dependency in the Gemfile, so it will not move, and therefore
       # foo can only move up to 1.4.4.
-      @base << build_spec("bar", "2.0.3").first
+      @base << Bundler::LazySpecification.new("bar", "2.0.3", nil)
       should_conservative_resolve_and_include :patch, ["foo"], %w[foo-1.4.4 bar-2.0.3]
     end
 

--- a/bundler/spec/support/indexes.rb
+++ b/bundler/spec/support/indexes.rb
@@ -26,6 +26,7 @@ module Spec
         end
       end
       args[0] ||= [] # base
+      args[0].each {|ls| ls.source = default_source }
       args[1] ||= Bundler::GemVersionPromoter.new # gem_version_promoter
       args[2] ||= [] # additional_base_requirements
       args[3] ||= @platforms # platforms


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

A mistake by a user editing a Gemfile could make bundler generate a bad lockfile, and a situation quite tricky to workaround.

## What is your fix for the problem, implemented in this PR?

At the beginning of resolution, where we make sure that all top level dependencies are available, make sure we ignore locked specs.

Fixes #5067.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
