### PR TITLE
Fix downgrading dependencies by changing the `Gemfile` and running `bundle update`

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -853,7 +853,7 @@ module Bundler
     def additional_base_requirements_for_resolve
       return [] unless @locked_gems && unlocking? && !sources.expired_sources?(@locked_gems.sources)
       dependencies_by_name = dependencies.inject({}) {|memo, dep| memo.update(dep.name => dep) }
-      @locked_gems.specs.reduce({}) do |requirements, locked_spec|
+      converge_specs(@locked_gems.specs).reduce({}) do |requirements, locked_spec|
         name = locked_spec.name
         dependency = dependencies_by_name[name]
         next requirements if @locked_gems.dependencies[name] != dependency

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -852,16 +852,11 @@ module Bundler
 
     def additional_base_requirements_for_resolve
       return [] unless @locked_gems && unlocking? && !sources.expired_sources?(@locked_gems.sources)
-      dependencies_by_name = dependencies.inject({}) {|memo, dep| memo.update(dep.name => dep) }
-      converge_specs(@locked_gems.specs).reduce({}) do |requirements, locked_spec|
+      converge_specs(@locked_gems.specs).map do |locked_spec|
         name = locked_spec.name
-        dependency = dependencies_by_name[name]
-        next requirements if @locked_gems.dependencies[name] != dependency
-        next requirements if dependency && dependency.source.is_a?(Source::Path)
         dep = Gem::Dependency.new(name, ">= #{locked_spec.version}")
-        requirements[name] = DepProxy.get_proxy(dep, locked_spec.platform)
-        requirements
-      end.values
+        DepProxy.get_proxy(dep, locked_spec.platform)
+      end
     end
 
     def equivalent_rubygems_remotes?(source)

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -354,6 +354,67 @@ RSpec.describe "bundle update" do
 
       expect(the_bundle).to include_gems("a 1.0", "b 1.0")
     end
+
+    it "should still downgrade if forced by the Gemfile, when transitive dependencies also need downgrade" do
+      build_repo4 do
+        build_gem "activesupport", "6.1.4.1" do |s|
+          s.add_dependency "tzinfo", "~> 2.0"
+        end
+
+        build_gem "activesupport", "6.0.4.1" do |s|
+          s.add_dependency "tzinfo", "~> 1.1"
+        end
+
+        build_gem "tzinfo", "2.0.4"
+        build_gem "tzinfo", "1.2.9"
+      end
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo4)}"
+        gem "activesupport", "~> 6.1.0"
+      G
+
+      expect(the_bundle).to include_gems("activesupport 6.1.4.1", "tzinfo 2.0.4")
+
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo4)}"
+        gem "activesupport", "~> 6.0.0"
+      G
+
+      original_lockfile = lockfile
+
+      expected_lockfile = <<~L
+        GEM
+          remote: #{file_uri_for(gem_repo4)}/
+          specs:
+            activesupport (6.0.4.1)
+              tzinfo (~> 1.1)
+            tzinfo (1.2.9)
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          activesupport (~> 6.0.0)
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      bundle "update activesupport"
+      expect(the_bundle).to include_gems("activesupport 6.0.4.1", "tzinfo 1.2.9")
+      expect(lockfile).to eq(expected_lockfile)
+
+      lockfile original_lockfile
+      bundle "update"
+      expect(the_bundle).to include_gems("activesupport 6.0.4.1", "tzinfo 1.2.9")
+      expect(lockfile).to eq(expected_lockfile)
+
+      lockfile original_lockfile
+      bundle "lock --update"
+      expect(the_bundle).to include_gems("activesupport 6.0.4.1", "tzinfo 1.2.9")
+      expect(lockfile).to eq(expected_lockfile)
+    end
   end
 
   describe "with --local option" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Due to a recent regression, one cannot downgrade the version constraint of a gem in the Gemfile, and then run `bundle update` to get it resolved and installed.

## What is your fix for the problem, implemented in this PR?

My fix involves resolving the same set of locked specs that it's used as a base when resolving normally, but change them to be `>= <locked_version>` instead of exact requirements.

By using the same logic used to converged locked specifications, we get this edge case fixed, but maybe more.

Fixes #5066.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
