### PR TITLE
Changelogs for rubygems 3.2.32 and bundler 2.2.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 3.2.32 / 2021-11-23
+
+## Enhancements:
+
+* Refactor installer thread safety protections. Pull request #5050 by
+  deivid-rodriguez
+* Allow gem activation from `operating_system.rb`. Pull request #5044 by
+  deivid-rodriguez
+* Installs bundler 2.2.32 as a default gem.
+
 # 3.2.31 / 2021-11-08
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 2.2.32 (November 23, 2021)
+
+## Enhancements:
+
+  - Clarify `bundle viz` deprecation [#5083](https://github.com/rubygems/rubygems/pull/5083)
+  - Unlock dependencies that no longer match lockfile [#5068](https://github.com/rubygems/rubygems/pull/5068)
+  - Use `shellsplit` instead of array of strings for git push [#5062](https://github.com/rubygems/rubygems/pull/5062)
+  - Re-enable `default_ignores` option for standard [#5003](https://github.com/rubygems/rubygems/pull/5003)
+
+## Bug fixes:
+
+  - Fix downgrading dependencies by changing the `Gemfile` and running `bundle update` [#5078](https://github.com/rubygems/rubygems/pull/5078)
+
 # 2.2.31 (November 8, 2021)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking changelogs from future rubygems 3.2.32 and bundler 2.2.32 into master.