### PR TITLE
Fix changelog script crash

### DIFF
--- a/util/changelog.rb
+++ b/util/changelog.rb
@@ -169,10 +169,10 @@ class Changelog
     pull = entry.pull_request
 
     if pull
-      new_entry
-        .gsub!(/%pull_request_number/, pull.number.to_s)
-        .gsub!(/%pull_request_url/, pull.html_url)
-        .gsub!(/%pull_request_author/, pull.user.name || pull.user.login)
+      new_entry = new_entry
+        .gsub(/%pull_request_number/, pull.number.to_s)
+        .gsub(/%pull_request_url/, pull.html_url)
+        .gsub(/%pull_request_author/, pull.user.name || pull.user.login)
     end
 
     new_entry = wrap(new_entry, entry_wrapping, 2) if entry_wrapping


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Changelog generation scripts crashed.

## What is your fix for the problem, implemented in this PR?

`String#gsub!` will return nil if no replacement was performed as opposed to `String#gsub` which returns the original string. That means we can't chain `String#gsub!` safely.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
