### PR TITLE
newgem templ: Avoid Float 3.0 -> "3" in GH Action

### DIFF
--- a/bundler/lib/bundler/templates/newgem/github/workflows/main.yml.tt
+++ b/bundler/lib/bundler/templates/newgem/github/workflows/main.yml.tt
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '<%= RUBY_VERSION %>'
+          - '<%= RUBY_VERSION.split(".").take(2).join(".") %>'
 
     steps:
     - uses: actions/checkout@v2

--- a/bundler/lib/bundler/templates/newgem/github/workflows/main.yml.tt
+++ b/bundler/lib/bundler/templates/newgem/github/workflows/main.yml.tt
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Ruby ${{ matrix.ruby }} 
+    name: Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
         ruby:

--- a/bundler/lib/bundler/templates/newgem/github/workflows/main.yml.tt
+++ b/bundler/lib/bundler/templates/newgem/github/workflows/main.yml.tt
@@ -10,11 +10,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    name: Ruby ${{ matrix.ruby }} 
     strategy:
       matrix:
         ruby:
-          - <%= RUBY_VERSION %>
+          - '<%= RUBY_VERSION %>'
 
     steps:
     - uses: actions/checkout@v2

--- a/bundler/lib/bundler/templates/newgem/github/workflows/main.yml.tt
+++ b/bundler/lib/bundler/templates/newgem/github/workflows/main.yml.tt
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '<%= RUBY_VERSION.split(".").take(2).join(".") %>'
+          - '<%= RUBY_VERSION %>'
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This is a very small change, but which avoids a Float-to-String loss of characters.

An example (not from this project) of what it can look like before this change, in this picture:

<img width="376" alt="bild" src="https://user-images.githubusercontent.com/211/119782378-6ad6cd00-becc-11eb-9e13-9a425adaa054.png">

Read more details, if you like: https://github.com/actions/runner/issues/849

## What is your fix for the problem, implemented in this PR?

This change avoids a YAML Float-to-String conversion, which turns a 3.0 into a "3". That can make names of builds less clear.

In order to use this new capability, I added a "name" descriptor to the matrix-created Job.

**Maybe**: Perhaps it is also wise to chop off the patch version of the version string, so that only "3.0" is listed, there? **Thought together**: No, let's not.


## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
