### PR TITLE
Don't unlock dependencies when running `bundle install` after changing global source

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -163,10 +163,6 @@ module Bundler
       end
     end
 
-    def multisource_allowed?
-      @multisource_allowed
-    end
-
     def resolve_only_locally!
       @remote = false
       sources.local_only!
@@ -718,7 +714,7 @@ module Bundler
           deps << dep
         end
 
-        s.source = (dep && dep.source) || sources.get(s.source) unless multisource_allowed?
+        s.source = (dep && dep.source) || sources.get(s.source) unless Bundler.frozen_bundle?
 
         # Don't add a spec to the list if its source is expired. For example,
         # if you change a Git gem to RubyGems.

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -714,11 +714,8 @@ module Bundler
           deps << dep
         end
 
-        s.source = (dep && dep.source) || sources.get(s.source) unless Bundler.frozen_bundle?
+        s.source = (dep && dep.source) || sources.get(s.source) || sources.default_source unless Bundler.frozen_bundle?
 
-        # Don't add a spec to the list if its source is expired. For example,
-        # if you change a Git gem to RubyGems.
-        next if s.source.nil?
         next if @unlock[:sources].include?(s.source.name)
 
         # If the spec is from a path source and it doesn't exist anymore

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -381,8 +381,8 @@ module Bundler
 
       # Check if it is possible that the source is only changed thing
       if (new_deps.empty? && deleted_deps.empty?) && (!new_sources.empty? && !deleted_sources.empty?)
-        new_sources.reject! {|source| (source.path? && source.path.exist?) || equivalent_rubygems_remotes?(source) }
-        deleted_sources.reject! {|source| (source.path? && source.path.exist?) || equivalent_rubygems_remotes?(source) }
+        new_sources.reject! {|source| source.path? && source.path.exist? }
+        deleted_sources.reject! {|source| source.path? && source.path.exist? }
       end
 
       if @locked_sources != gemfile_sources
@@ -850,12 +850,6 @@ module Bundler
         dep = Gem::Dependency.new(name, ">= #{locked_spec.version}")
         DepProxy.get_proxy(dep, locked_spec.platform)
       end
-    end
-
-    def equivalent_rubygems_remotes?(source)
-      return false unless source.is_a?(Source::Rubygems)
-
-      Bundler.settings[:allow_deployment_source_credential_changes] && source.equivalent_remotes?(sources.rubygems_remotes)
     end
 
     def source_map

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -30,10 +30,8 @@ module Bundler
       @resolver = Molinillo::Resolver.new(self, self)
       @search_for = {}
       @base_dg = Molinillo::DependencyGraph.new
-      aggregate_global_source = @source_requirements[:default].is_a?(Source::RubygemsAggregate)
       @base.each do |ls|
         dep = Dependency.new(ls.name, ls.version)
-        ls.source = source_for(ls.name) unless aggregate_global_source
         @base_dg.add_vertex(ls.name, DepProxy.get_proxy(dep, ls.platform), true)
       end
       additional_base_requirements.each {|d| @base_dg.add_vertex(d.name, d) }

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -262,10 +262,6 @@ module Bundler
         @remotes.unshift(uri) unless @remotes.include?(uri)
       end
 
-      def equivalent_remotes?(other_remotes)
-        other_remotes.map(&method(:remove_auth)) == @remotes.map(&method(:remove_auth))
-      end
-
       def spec_names
         if @allow_remote && dependency_api_available?
           remote_specs.spec_names
@@ -334,7 +330,11 @@ module Bundler
       end
 
       def credless_remotes
-        remotes.map(&method(:suppress_configured_credentials))
+        if Bundler.settings[:allow_deployment_source_credential_changes]
+          remotes.map(&method(:remove_auth))
+        else
+          remotes.map(&method(:suppress_configured_credentials))
+        end
       end
 
       def remotes_for_spec(spec)

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -98,7 +98,7 @@ module Bundler
     end
 
     def get(source)
-      source_list_for(source).find {|s| equal_source?(source, s) || equivalent_source?(source, s) }
+      source_list_for(source).find {|s| equivalent_source?(source, s) }
     end
 
     def lock_sources
@@ -173,7 +173,7 @@ module Bundler
     end
 
     def different_sources?(lock_sources, replacement_sources)
-      !equal_sources?(lock_sources, replacement_sources) && !equivalent_sources?(lock_sources, replacement_sources)
+      !equivalent_sources?(lock_sources, replacement_sources)
     end
 
     def rubygems_aggregate_class
@@ -210,34 +210,12 @@ module Bundler
       end
     end
 
-    def equal_sources?(lock_sources, replacement_sources)
+    def equivalent_sources?(lock_sources, replacement_sources)
       lock_sources.sort_by(&:to_s) == replacement_sources.sort_by(&:to_s)
     end
 
-    def equal_source?(source, other_source)
-      return source.include?(other_source) if source.is_a?(Source::Rubygems) && other_source.is_a?(Source::Rubygems)
-
-      source == other_source
-    end
-
     def equivalent_source?(source, other_source)
-      return false unless Bundler.settings[:allow_deployment_source_credential_changes] && source.is_a?(Source::Rubygems)
-
-      equivalent_rubygems_sources?([source], [other_source])
-    end
-
-    def equivalent_sources?(lock_sources, replacement_sources)
-      return false unless Bundler.settings[:allow_deployment_source_credential_changes]
-
-      lock_rubygems_sources, lock_other_sources = lock_sources.partition {|s| s.is_a?(Source::Rubygems) }
-      replacement_rubygems_sources, replacement_other_sources = replacement_sources.partition {|s| s.is_a?(Source::Rubygems) }
-
-      equivalent_rubygems_sources?(lock_rubygems_sources, replacement_rubygems_sources) && equal_sources?(lock_other_sources, replacement_other_sources)
-    end
-
-    def equivalent_rubygems_sources?(lock_sources, replacement_sources)
-      actual_remotes = replacement_sources.map(&:remotes).flatten.uniq
-      lock_sources.all? {|s| s.equivalent_remotes?(actual_remotes) }
+      source == other_source
     end
   end
 end

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -1250,8 +1250,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
       G
     end
 
-    it "installs the higher version in the new repo" do
-      expect(the_bundle).to include_gems("rack 1.2")
+    it "conservatively installs the existing locked version" do
+      expect(the_bundle).to include_gems("rack 1.0.0")
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If you change the global source in your `Gemfile`, and then run `bundle install`, bundler will unlock all dependencies not pinned to non global sources. Instead, `bundle install` should behave conservatively as it always does and try to preserve existing locked versions.

This is admittedly a small bug, since it's not very common to change the global source. But it also allows us to delete code, which makes me happy. Bug was introduced recently, by the way, with 2.2.18 (when dependency confusion issues were fixed).

## What is your fix for the problem, implemented in this PR?

Previously in this particular case bundler would update the locked source to the new global source, but don't add the spec to the set of converged specs because it would exit the loop early. Instead, do update the source in this case, and remove the early exit of the loop so that the spec gets locked.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
