### PR TITLE
Fix missing locked specs when depended on another platform

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -751,7 +751,7 @@ module Bundler
           s.dependencies.replace(new_spec.dependencies)
         end
 
-        if dep.nil? && @dependencies.find {|d| s.name == d.name }
+        if dep.nil? && requested_dependencies.find {|d| s.name == d.name }
           @unlock[:gems] << s.name
         else
           converged << s


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When bundling a Gemfile with a top-level dependency for a different platform than the current one. For example, including something like

```
platforms :mingw, :x64_mingw, :mswin, :jruby do
  gem "tzinfo", "~> 1.2"
end
```

but when the `Gemfile.lock` also has that same dependency locked as a transitive dependency of a gem for the current platform, then bundler would end up ignoring the dependency and crashing.

This is a regression of https://github.com/rubygems/rubygems/pull/5068/commits/7a47c01a86af152d09aaa14d8cad6253e80c1c41.

## What is your fix for the problem, implemented in this PR?

When considering whether we should unlock a locked spec, or keep it locked, use a helper that excludes dependencies for other platforms.

Fixes #5088.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
