### PR TITLE
Fix `bundle info` sometimes claiming that bundler has been deleted

### DIFF
--- a/bundler/lib/bundler/cli/info.rb
+++ b/bundler/lib/bundler/cli/info.rb
@@ -70,7 +70,7 @@ module Bundler
       gem_info << "\tPath: #{spec.full_gem_path}\n"
       gem_info << "\tDefault Gem: yes" if spec.respond_to?(:default_gem?) && spec.default_gem?
 
-      if spec.deleted_gem?
+      if name != "bundler" && spec.deleted_gem?
         return Bundler.ui.warn "The gem #{name} has been deleted. Gemspec information is still available though:\n#{gem_info}"
       end
 

--- a/bundler/spec/commands/info_spec.rb
+++ b/bundler/spec/commands/info_spec.rb
@@ -50,6 +50,14 @@ RSpec.describe "bundle info" do
       expect(out).to eq(root.to_s)
     end
 
+    it "doesn't claim that bundler has been deleted, even if using a custom path without bundler there" do
+      bundle "config set --local path vendor/bundle"
+      bundle "install"
+      bundle "info bundler"
+      expect(out).to include("\tPath: #{root}")
+      expect(err).not_to match(/The gem bundler has been deleted/i)
+    end
+
     it "complains if gem not in bundle" do
       bundle "info missing", :raise_on_error => false
       expect(err).to eq("Could not find gem 'missing'.")


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Under some circumstances, `bundle info bundler` will claim that bundler has been deleted.

## What is your fix for the problem, implemented in this PR?

Special case bundler, like it's done for `bundle info bundler --path`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
