### PR TITLE
Fix escape of filenames in `bundle doctor`

### DIFF
--- a/bundler/lib/bundler/cli/doctor.rb
+++ b/bundler/lib/bundler/cli/doctor.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rbconfig"
+require "shellwords"
 
 module Bundler
   class CLI::Doctor
@@ -22,14 +23,14 @@ module Bundler
     end
 
     def dylibs_darwin(path)
-      output = `/usr/bin/otool -L "#{path}"`.chomp
+      output = `/usr/bin/otool -L #{path.shellescape}`.chomp
       dylibs = output.split("\n")[1..-1].map {|l| l.match(DARWIN_REGEX).captures[0] }.uniq
       # ignore @rpath and friends
       dylibs.reject {|dylib| dylib.start_with? "@" }
     end
 
     def dylibs_ldd(path)
-      output = `/usr/bin/ldd "#{path}"`.chomp
+      output = `/usr/bin/ldd #{path.shellescape}`.chomp
       output.split("\n").map do |l|
         match = l.match(LDD_REGEX)
         next if match.nil?

--- a/bundler/spec/commands/doctor_spec.rb
+++ b/bundler/spec/commands/doctor_spec.rb
@@ -133,4 +133,14 @@ RSpec.describe "bundle doctor" do
       end
     end
   end
+
+  context "when home contains filesname with special characters" do
+    it "escape filename before command execute" do
+      doctor = Bundler::CLI::Doctor.new({})
+      expect(doctor).to receive(:`).with("/usr/bin/otool -L \\$\\(date\\)\\ \\\"\\'\\\\.bundle").and_return("dummy string")
+      doctor.dylibs_darwin('$(date) "\'\.bundle')
+      expect(doctor).to receive(:`).with("/usr/bin/ldd \\$\\(date\\)\\ \\\"\\'\\\\.bundle").and_return("dummy string")
+      doctor.dylibs_ldd('$(date) "\'\.bundle')
+    end
+  end
 end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

Fixed a problem when running bundle doctor if a file name like `$(date).bundle` exists.

## What is your fix for the problem, implemented in this PR?

Added filename escaping.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
