### PR TITLE
Let original `Errno::EACCES` error be raised in compact index updater

### DIFF
--- a/bundler/lib/bundler/compact_index_client/updater.rb
+++ b/bundler/lib/bundler/compact_index_client/updater.rb
@@ -76,11 +76,6 @@ module Bundler
 
           update(local_path, remote_path, :retrying)
         end
-      rescue Errno::EACCES
-        raise Bundler::PermissionError,
-          "Bundler does not have write access to create a temp directory " \
-          "within #{Dir.tmpdir}. Bundler must have write access to your " \
-          "systems temp directory to function properly. "
       rescue Zlib::GzipFile::Error
         raise Bundler::HTTPError
       end

--- a/bundler/spec/bundler/compact_index_client/updater_spec.rb
+++ b/bundler/spec/bundler/compact_index_client/updater_spec.rb
@@ -36,16 +36,6 @@ RSpec.describe Bundler::CompactIndexClient::Updater do
     end
   end
 
-  context "when bundler doesn't have permissions on Dir.tmpdir" do
-    it "Errno::EACCES is raised" do
-      allow(Bundler::Dir).to receive(:mktmpdir) { raise Errno::EACCES }
-
-      expect do
-        updater.update(local_path, remote_path)
-      end.to raise_error(Bundler::PermissionError)
-    end
-  end
-
   context "when receiving non UTF-8 data and default internal encoding set to ASCII" do
     let(:response) { double(:response, :body => "\x8B".b) }
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Apparently this error is sometimes a false positive, not due to any problem when creating a temporary directory.

## What is your fix for the problem, implemented in this PR?

* This block of code already wraps file operations with `SharedHelpers.filesystem_access`, which rescues and re-raises more friendly errors.
* Creating a temporary directory through `tmpdir` does not raise `Errno::EACCES`. Instead it looks for several potential candidates (in ENV or the CWD as the last resort) with proper permissions to be the temporary directory, and if none is found, it raises an `ArgumentError`.
* Finally, this rescue block apparently leads to some false positives when firewall is blocking the ruby executable on Windows, or at least that's what we've got reported.

In any case, I think it's best to let the original error be raised.

Closes #5105.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
