### PR TITLE
Don't cleanup paths from gems already activated from `$LOAD_PATH`

### DIFF
--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -313,12 +313,11 @@ module Bundler
     end
 
     def clean_load_path
-      bundler_lib = bundler_ruby_lib
-
       loaded_gem_paths = Bundler.rubygems.loaded_gem_paths
 
       $LOAD_PATH.reject! do |p|
-        next if resolve_path(p).start_with?(bundler_lib)
+        resolved_path = resolve_path(p)
+        next if $LOADED_FEATURES.any? {|lf| lf.start_with?(resolved_path) }
         loaded_gem_paths.delete(p)
       end
       $LOAD_PATH.uniq!

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -1511,5 +1511,28 @@ end
 
       expect(out).to include("rack, yard")
     end
+
+    it "does not cause double loads when higher versions of default gems are activated before bundler" do
+      build_repo2 do
+        build_gem "json", "999.999.999" do |s|
+          s.write "lib/json.rb", <<~RUBY
+            module JSON
+              VERSION = "999.999.999"
+            end
+          RUBY
+        end
+      end
+
+      system_gems "json-999.999.999", :gem_repo => gem_repo2
+
+      install_gemfile "source \"#{file_uri_for(gem_repo1)}\""
+      ruby <<-RUBY
+        require "json"
+        require "bundler/setup"
+        require "json"
+      RUBY
+
+      expect(err).to be_empty
+    end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If a default gem is required before `bundler/setup` is required, and also after, there's a chance that two different versions will get activated:

* The one that gets required before `bundler/setup` will use rubygems' require and thus be the latest version installed.
* The one that gets required after `bundler/setup` will use ruby's require and thus will be the default version installed.

This will cause at redefinition warnings, or even worse, runtime errors or segfaults.

## What is your fix for the problem, implemented in this PR?

The reason this happens is that bundler, before adding all the paths for all dependencies in the Gemfile to the `$LOAD_PATH`, first cleans up paths from gems already present in the `$LOAD_PATH`. However, if paths from gems are already present there, that probably means those gems have already been required and as a result, removing those paths from the `$LOAD_PATH` will cause more harm than good.

I want to experiment with no longer doing this cleanup, so that we fix redefinition warnings caused by default gems and consistently use whatever version was required in the first place.

This solution was first suggested by @mvz at https://github.com/ruby/pathname/issues/12#issuecomment-946605635.

Closes #5108.
Closes #5016.
Closes https://github.com/ruby/pathname/issues/12.
Closes https://github.com/ruby/pathname/issues/14.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
