### PR TITLE
Use prerelease-aware version comparison inside `connection_pool`

### DIFF
--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -223,7 +223,7 @@ Automatiek::RakeTask.new("net-http-persistent") do |lib|
   lib.license_path = "README.rdoc"
 
   # We currently include the official version as of
-  # https://github.com/mperham/connection_pool/commit/c5aef742642def23664c4d9c15d12f0786347fb8.
+  # https://github.com/mperham/connection_pool/commit/204d9f24b1fff7f893baf9d26e509bf79ed53083.
   lib.dependency("connection_pool") do |sublib|
     sublib.version = "master"
     sublib.download = { :github => "https://github.com/mperham/connection_pool" }

--- a/bundler/lib/bundler/vendor/connection_pool/lib/connection_pool/wrapper.rb
+++ b/bundler/lib/bundler/vendor/connection_pool/lib/connection_pool/wrapper.rb
@@ -32,13 +32,13 @@ class Bundler::ConnectionPool
 
     # rubocop:disable Style/MethodMissingSuper
     # rubocop:disable Style/MissingRespondToMissing
-    if ::RUBY_VERSION >= "3.0.0"
+    if ::Gem.ruby_version >= ::Gem::Version.new("3.0.0")
       def method_missing(name, *args, **kwargs, &block)
         with do |connection|
           connection.send(name, *args, **kwargs, &block)
         end
       end
-    elsif ::RUBY_VERSION >= "2.7.0"
+    elsif ::Gem.ruby_version >= ::Gem::Version.new("2.7.0")
       ruby2_keywords def method_missing(name, *args, &block)
         with do |connection|
           connection.send(name, *args, &block)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

A bad version comparison can cause a bad feature detection and thus a crash.

## What is your fix for the problem, implemented in this PR?

Fix the issue inside `connection_pool` and cherry-pick the change to our vendored copy.

Closes #5093.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
