### PR TITLE
Fix handling prereleases of 0 versions, like 0.0.0.dev or 0.0.0.SNAPSHOT

### DIFF
--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -39,7 +39,7 @@ module Bundler
     end
 
     def satisfies?(dependency)
-      effective_requirement = dependency.requirement == Gem::Requirement.default ? Gem::Requirement.default_prerelease : dependency.requirement
+      effective_requirement = dependency.requirement == Gem::Requirement.default ? Gem::Requirement.new(">= 0.A") : dependency.requirement
 
       @name == dependency.name && effective_requirement.satisfied_by?(Gem::Version.new(@version))
     end

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -38,6 +38,20 @@ module Bundler
       identifier.hash
     end
 
+    ##
+    # Does this locked specification satisfy +dependency+?
+    #
+    # NOTE: Rubygems default requirement is ">= 0", which doesn't match
+    # prereleases of 0 versions, like "0.0.0.dev" or "0.0.0.SNAPSHOT". However,
+    # bundler users expect those to work. We need to make sure that Gemfile
+    # dependencies without explicit requirements (which use ">= 0" under the
+    # hood by default) are still valid for locked specs using this kind of
+    # versions. The method implements an ad-hoc fix for that. A better solution
+    # might be to change default rubygems requirement of dependencies to be ">=
+    # 0.A" but that's a major refactoring likely to break things. Hopefully we
+    # can attempt it in the future.
+    #
+
     def satisfies?(dependency)
       effective_requirement = dependency.requirement == Gem::Requirement.default ? Gem::Requirement.new(">= 0.A") : dependency.requirement
 

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -39,7 +39,9 @@ module Bundler
     end
 
     def satisfies?(dependency)
-      @name == dependency.name && dependency.requirement.satisfied_by?(Gem::Version.new(@version))
+      effective_requirement = dependency.requirement == Gem::Requirement.default ? Gem::Requirement.default_prerelease : dependency.requirement
+
+      @name == dependency.name && effective_requirement.satisfied_by?(Gem::Version.new(@version))
     end
 
     def to_lock

--- a/bundler/spec/install/gemfile/path_spec.rb
+++ b/bundler/spec/install/gemfile/path_spec.rb
@@ -216,6 +216,39 @@ RSpec.describe "bundle install with explicit source paths" do
     expect(the_bundle).to include_gems "foo 0.0.0.dev"
   end
 
+  it "works when using uppercase prereleases of 0.0.0" do
+    build_lib "foo", "0.0.0.SNAPSHOT", :path => lib_path("foo")
+
+    gemfile <<~G
+      source "#{file_uri_for(gem_repo1)}"
+      gem "foo", :path => "#{lib_path("foo")}"
+    G
+
+    lockfile <<~L
+      PATH
+        remote: #{lib_path("foo")}
+        specs:
+          foo (0.0.0.SNAPSHOT)
+
+      GEM
+        remote: #{file_uri_for(gem_repo1)}/
+        specs:
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        foo!
+
+      BUNDLED WITH
+        #{Bundler::VERSION}
+    L
+
+    bundle :install
+
+    expect(the_bundle).to include_gems "foo 0.0.0.SNAPSHOT"
+  end
+
   it "handles downgrades" do
     build_lib "omg", "2.0", :path => lib_path("omg")
 

--- a/bundler/spec/install/gemfile/path_spec.rb
+++ b/bundler/spec/install/gemfile/path_spec.rb
@@ -183,6 +183,39 @@ RSpec.describe "bundle install with explicit source paths" do
     expect(the_bundle).to include_gems "foo 1.0"
   end
 
+  it "works when using prereleases of 0.0.0" do
+    build_lib "foo", "0.0.0.dev", :path => lib_path("foo")
+
+    gemfile <<~G
+      source "#{file_uri_for(gem_repo1)}"
+      gem "foo", :path => "#{lib_path("foo")}"
+    G
+
+    lockfile <<~L
+      PATH
+        remote: #{lib_path("foo")}
+        specs:
+          foo (0.0.0.dev)
+
+      GEM
+        remote: #{file_uri_for(gem_repo1)}/
+        specs:
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        foo!
+
+      BUNDLED WITH
+        #{Bundler::VERSION}
+    L
+
+    bundle :install
+
+    expect(the_bundle).to include_gems "foo 0.0.0.dev"
+  end
+
   it "handles downgrades" do
     build_lib "omg", "2.0", :path => lib_path("omg")
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since recent refactoring and fixes in `Bundler::Definition`, bundler can no longer deal with prereleases of 0 versions, like 0.0.0.dev or 0.0.0.SNAPSHOT.

## What is your fix for the problem, implemented in this PR?

The proper fix would probably be to change rubygems default requirement of dependencies to be ">= 0.A" instead of ">= 0". However, that's a major refactoring that breaks a lot of things, so instead I'm adding an ad-hoc fix for the particular cases that got broken in bundler after releasing 2.2.32.

Fixes #5095.
Fixes #5113.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
