### PR TITLE
Ignore to generate the documentation from vendored libraries

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -225,6 +225,7 @@ bundler/lib/bundler/ui/rg_proxy.rb
 bundler/lib/bundler/ui/shell.rb
 bundler/lib/bundler/ui/silent.rb
 bundler/lib/bundler/uri_credentials_filter.rb
+bundler/lib/bundler/vendor/.document
 bundler/lib/bundler/vendor/connection_pool/LICENSE
 bundler/lib/bundler/vendor/connection_pool/lib/connection_pool.rb
 bundler/lib/bundler/vendor/connection_pool/lib/connection_pool/timed_stack.rb
@@ -397,6 +398,7 @@ lib/rubygems/mock_gem_ui.rb
 lib/rubygems/name_tuple.rb
 lib/rubygems/openssl.rb
 lib/rubygems/optparse.rb
+lib/rubygems/optparse/.document
 lib/rubygems/optparse/COPYING
 lib/rubygems/optparse/lib/optionparser.rb
 lib/rubygems/optparse/lib/optparse.rb
@@ -509,6 +511,7 @@ lib/rubygems/ssl_certs/rubygems.org/GlobalSignRootCA_R3.pem
 lib/rubygems/stub_specification.rb
 lib/rubygems/text.rb
 lib/rubygems/tsort.rb
+lib/rubygems/tsort/.document
 lib/rubygems/tsort/LICENSE.txt
 lib/rubygems/tsort/lib/tsort.rb
 lib/rubygems/uninstaller.rb

--- a/bundler/lib/bundler/vendor/.document
+++ b/bundler/lib/bundler/vendor/.document
@@ -1,0 +1,1 @@
+# Vendored files do not need to be documented

--- a/lib/rubygems/optparse/.document
+++ b/lib/rubygems/optparse/.document
@@ -1,0 +1,1 @@
+# Vendored files do not need to be documented

--- a/lib/rubygems/tsort/.document
+++ b/lib/rubygems/tsort/.document
@@ -1,0 +1,1 @@
+# Vendored files do not need to be documented


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When users generated the documentation of rubygems and bundler by rdoc, They got the duplicated entries with the standard library of Ruby. 

But I'm not sure we enabled the documentation of non-standard libraries like `connection_pool`. Maybe we will ignore only the following librraries.

* optparse
* tsort
* fileutils
* tmpdir
* uri

## What is your fix for the problem, implemented in this PR?

Ignore to generate them.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
