### PR TITLE
Improve gemfile-lockfile source equivalence errors

### DIFF
--- a/bundler/lib/bundler/cli/update.rb
+++ b/bundler/lib/bundler/cli/update.rb
@@ -66,7 +66,7 @@ module Bundler
 
       if locked_gems = Bundler.definition.locked_gems
         previous_locked_info = locked_gems.specs.reduce({}) do |h, s|
-          h[s.name] = { :spec => s, :version => s.version, :source => s.source.to_s }
+          h[s.name] = { :spec => s, :version => s.version, :source => s.source.identifier }
           h
         end
       end
@@ -95,7 +95,7 @@ module Bundler
           end
 
           locked_source = locked_info[:source]
-          new_source = new_spec.source.to_s
+          new_source = new_spec.source.identifier
           next if locked_source != new_source
 
           new_version = new_spec.version

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -634,15 +634,13 @@ module Bundler
     end
 
     def converge_dependencies
+      changes = false
+
       @dependencies.each do |dep|
         if dep.source
           dep.source = sources.get(dep.source)
         end
-      end
 
-      changes = false
-
-      @dependencies.each do |dep|
         unless locked_dep = @locked_deps[dep.name]
           changes = true
           next

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -396,9 +396,7 @@ module Bundler
       end
 
       added.concat new_deps.map {|d| "* #{pretty_dep(d)}" } if new_deps.any?
-      if deleted_deps.any?
-        deleted.concat deleted_deps.map {|d| "* #{pretty_dep(d)}" }
-      end
+      deleted.concat deleted_deps.map {|d| "* #{pretty_dep(d)}" } if deleted_deps.any?
 
       both_sources = Hash.new {|h, k| h[k] = [] }
       @dependencies.each {|d| both_sources[d.name][0] = d }

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -400,7 +400,7 @@ module Bundler
 
       both_sources = Hash.new {|h, k| h[k] = [] }
       @dependencies.each {|d| both_sources[d.name][0] = d }
-      @locked_deps.each  {|name, d| both_sources[name][1] = d.source }
+      locked_dependencies.each {|d| both_sources[d.name][1] = d.source }
 
       both_sources.each do |name, (dep, lock_source)|
         next if lock_source.nil? || lock_source.can_lock?(dep)

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -400,7 +400,7 @@ module Bundler
         next if lock_source.nil? || lock_source.can_lock?(dep)
         gemfile_source_name = dep.source || "no specified source"
         lockfile_source_name = lock_source
-        changed << "* #{name} from `#{gemfile_source_name}` to `#{lockfile_source_name}`"
+        changed << "* #{name} from `#{lockfile_source_name}` to `#{gemfile_source_name}`"
       end
 
       reason = change_reason

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -405,8 +405,8 @@ module Bundler
       @locked_deps.each  {|name, d| both_sources[name][1] = d.source }
 
       both_sources.each do |name, (dep, lock_source)|
-        next if lock_source.nil? || (dep && lock_source.can_lock?(dep))
-        gemfile_source_name = (dep && dep.source) || "no specified source"
+        next if lock_source.nil? || lock_source.can_lock?(dep)
+        gemfile_source_name = dep.source || "no specified source"
         lockfile_source_name = lock_source
         changed << "* #{name} from `#{gemfile_source_name}` to `#{lockfile_source_name}`"
       end

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -644,7 +644,7 @@ module Bundler
     end
 
     def converge_dependencies
-      (@dependencies + locked_dependencies).each do |dep|
+      @dependencies.each do |dep|
         if dep.source
           dep.source = sources.get(dep.source)
         end

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -379,12 +379,6 @@ module Bundler
       new_deps = @dependencies - locked_dependencies
       deleted_deps = locked_dependencies - @dependencies
 
-      # Check if it is possible that the source is only changed thing
-      if (new_deps.empty? && deleted_deps.empty?) && (!new_sources.empty? && !deleted_sources.empty?)
-        new_sources.reject! {|source| source.path? && source.path.exist? }
-        deleted_sources.reject! {|source| source.path? && source.path.exist? }
-      end
-
       if @locked_sources != gemfile_sources
         if new_sources.any?
           added.concat new_sources.map {|source| "* source: #{source}" }

--- a/bundler/lib/bundler/plugin/api/source.rb
+++ b/bundler/lib/bundler/plugin/api/source.rb
@@ -283,6 +283,7 @@ module Bundler
         def to_s
           "plugin source for #{@type} with uri #{@uri}"
         end
+        alias_method :identifier, :to_s
 
         # Note: Do not override if you don't know what you are doing.
         def include?(other)

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -270,7 +270,7 @@ module Bundler
                             rescue GemfileNotFound
                               nil
                             end
-          message = String.new("Could not find gem '#{SharedHelpers.pretty_dependency(requirement)}' in #{source.to_err}#{cache_message}.\n")
+          message = String.new("Could not find gem '#{SharedHelpers.pretty_dependency(requirement)}' in #{source}#{cache_message}.\n")
           message << "The source contains the following versions of '#{name}': #{formatted_versions_with_platforms(versions_with_platforms)}" if versions_with_platforms.any?
         end
         raise GemNotFound, message
@@ -369,7 +369,7 @@ module Bundler
             o << if metadata_requirement
               "is not available in #{relevant_source}"
             else
-              "in #{relevant_source.to_err}.\n"
+              "in #{relevant_source}.\n"
             end
           end
         end,

--- a/bundler/lib/bundler/source.rb
+++ b/bundler/lib/bundler/source.rb
@@ -67,7 +67,7 @@ module Bundler
       "#<#{self.class}:0x#{object_id} #{self}>"
     end
 
-    def to_err
+    def identifier
       to_s
     end
 

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -98,26 +98,30 @@ module Bundler
         out << "  specs:\n"
       end
 
-      def to_err
+      def to_s
         if remotes.empty?
           "locally installed gems"
-        elsif @allow_remote
+        elsif @allow_remote && @allow_cached && @allow_local
+          "rubygems repository #{remote_names}, cached gems or installed locally"
+        elsif @allow_remote && @allow_local
           "rubygems repository #{remote_names} or installed locally"
-        elsif @allow_cached
-          "cached gems from rubygems repository #{remote_names} or installed locally"
+        elsif @allow_remote
+          "rubygems repository #{remote_names}"
+        elsif @allow_cached && @allow_local
+          "cached gems or installed locally"
         else
           "locally installed gems"
         end
       end
 
-      def to_s
+      def identifier
         if remotes.empty?
           "locally installed gems"
         else
-          "rubygems repository #{remote_names} or installed locally"
+          "rubygems repository #{remote_names}"
         end
       end
-      alias_method :name, :to_s
+      alias_method :name, :identifier
 
       def specs
         @specs ||= begin

--- a/bundler/lib/bundler/source/rubygems_aggregate.rb
+++ b/bundler/lib/bundler/source/rubygems_aggregate.rb
@@ -16,7 +16,7 @@ module Bundler
         @index
       end
 
-      def to_err
+      def identifier
         to_s
       end
 

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -106,14 +106,14 @@ module Bundler
     end
 
     def lock_other_sources
-      (path_sources + git_sources + plugin_sources).sort_by(&:to_s)
+      (path_sources + git_sources + plugin_sources).sort_by(&:identifier)
     end
 
     def lock_rubygems_sources
       if merged_gem_lockfile_sections?
         [combine_rubygems_sources]
       else
-        rubygems_sources.sort_by(&:to_s)
+        rubygems_sources.sort_by(&:identifier)
       end
     end
 
@@ -211,7 +211,7 @@ module Bundler
     end
 
     def equivalent_sources?(lock_sources, replacement_sources)
-      lock_sources.sort_by(&:to_s) == replacement_sources.sort_by(&:to_s)
+      lock_sources.sort_by(&:identifier) == replacement_sources.sort_by(&:identifier)
     end
 
     def equivalent_source?(source, other_source)

--- a/bundler/spec/install/deploy_spec.rb
+++ b/bundler/spec/install/deploy_spec.rb
@@ -379,7 +379,7 @@ RSpec.describe "install in deployment or frozen mode" do
       expect(err).to include("deployment mode")
       expect(err).to include("You have deleted from the Gemfile:\n* source: #{lib_path("rack-1.0")}")
       expect(err).not_to include("You have added to the Gemfile")
-      expect(err).not_to include("You have changed in the Gemfile")
+      expect(err).to include("You have changed in the Gemfile:\n* rack from `#{lib_path("rack-1.0")}` to `no specified source`")
     end
 
     it "explodes if you unpin a source, leaving it pinned somewhere else" do

--- a/bundler/spec/install/deploy_spec.rb
+++ b/bundler/spec/install/deploy_spec.rb
@@ -401,7 +401,7 @@ RSpec.describe "install in deployment or frozen mode" do
       bundle "config set --local deployment true"
       bundle :install, :raise_on_error => false
       expect(err).to include("deployment mode")
-      expect(err).to include("You have changed in the Gemfile:\n* rack from `no specified source` to `#{lib_path("rack")}`")
+      expect(err).to include("You have changed in the Gemfile:\n* rack from `#{lib_path("rack")}` to `no specified source`")
       expect(err).not_to include("You have added to the Gemfile")
       expect(err).not_to include("You have deleted from the Gemfile")
     end

--- a/bundler/spec/install/deploy_spec.rb
+++ b/bundler/spec/install/deploy_spec.rb
@@ -357,11 +357,11 @@ RSpec.describe "install in deployment or frozen mode" do
       bundle "config set --local deployment true"
       bundle :install, :raise_on_error => false
       expect(err).to include("deployment mode")
-      expect(err).to include("You have added to the Gemfile:\n* source: git://hubz.com")
-      expect(err).not_to include("You have changed in the Gemfile")
+      expect(err).not_to include("You have added to the Gemfile")
+      expect(err).to include("You have changed in the Gemfile:\n* rack from `no specified source` to `git://hubz.com`")
     end
 
-    it "explodes if you unpin a source" do
+    it "explodes if you change a source" do
       build_git "rack"
 
       install_gemfile <<-G
@@ -377,12 +377,12 @@ RSpec.describe "install in deployment or frozen mode" do
       bundle "config set --local deployment true"
       bundle :install, :raise_on_error => false
       expect(err).to include("deployment mode")
-      expect(err).to include("You have deleted from the Gemfile:\n* source: #{lib_path("rack-1.0")}")
+      expect(err).not_to include("You have deleted from the Gemfile")
       expect(err).not_to include("You have added to the Gemfile")
       expect(err).to include("You have changed in the Gemfile:\n* rack from `#{lib_path("rack-1.0")}` to `no specified source`")
     end
 
-    it "explodes if you unpin a source, leaving it pinned somewhere else" do
+    it "explodes if you change a source" do
       build_lib "foo", :path => lib_path("rack/foo")
       build_git "rack", :path => lib_path("rack")
 

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -1336,8 +1336,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
       G
       expect(err).to eq strip_whitespace(<<-EOS).strip
         Warning: The gem 'rack' was found in multiple relevant sources.
-          * rubygems repository https://gem.repo1/ or installed locally
-          * rubygems repository https://gem.repo4/ or installed locally
+          * rubygems repository https://gem.repo1/
+          * rubygems repository https://gem.repo4/
         You should add this gem to the source block for the source you wish it to be installed from.
       EOS
       expect(last_command).to be_success
@@ -1366,8 +1366,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
       expect(last_command).to be_failure
       expect(err).to eq strip_whitespace(<<-EOS).strip
         The gem 'rack' was found in multiple relevant sources.
-          * rubygems repository https://gem.repo1/ or installed locally
-          * rubygems repository https://gem.repo4/ or installed locally
+          * rubygems repository https://gem.repo1/
+          * rubygems repository https://gem.repo4/
         You must add this gem to the source block for the source you wish it to be installed from.
       EOS
       expect(the_bundle).not_to be_locked

--- a/bundler/spec/support/indexes.rb
+++ b/bundler/spec/support/indexes.rb
@@ -17,7 +17,7 @@ module Spec
     def resolve(args = [])
       @platforms ||= ["ruby"]
       deps = []
-      default_source = instance_double("Bundler::Source::Rubygems", :specs => @index, :to_err => "locally install gems")
+      default_source = instance_double("Bundler::Source::Rubygems", :specs => @index, :to_s => "locally install gems")
       source_requirements = { :default => default_source }
       @deps.each do |d|
         source_requirements[d.name] = d.source = default_source


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When checking whether a `Gemfile` is equivalent to the `Gemfile.lock` in frozen mode, `bundler` prints some messages about sources being added or removed from the Gemfile that I believe could be improved. Specially since we have a single global source, I don't think it makes much sense to talk about "This source was added to the Gemfile" or "This source was removed from the Gemfile". Instead, I think it's simpler to say "This dependency's source has changed from this source to this other source".

## What is your fix for the problem, implemented in this PR?

My fix implements the above, which allows to remove a fair amount of new unneecessary code.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
