### PR TITLE
Skip installation if resolved version is already installed as a default gem

### DIFF
--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -197,6 +197,14 @@ You can use `i` command instead of `install`.
 
     request_set = dinst.resolve_dependencies name, req
 
+    resolved_spec = request_set.always_install.first
+    matching_spec = Gem::Dependency.new(resolved_spec.name, resolved_spec.version).matching_specs.first
+
+    if matching_spec && matching_spec.default_gem?
+      say "Skipping installation of #{resolved_spec.full_name} because it's already a default gem"
+      return
+    end
+
     if options[:explain]
       say "Gems to install:"
 

--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -187,11 +187,11 @@ You can use `i` command instead of `install`.
     terminate_interaction
   end
 
-  def install_gem(name, version) # :nodoc:
+  def install_gem(name, requirement) # :nodoc:
     return if options[:conservative] &&
-              !Gem::Dependency.new(name, version).matching_specs.empty?
+              !Gem::Dependency.new(name, requirement).matching_specs.empty?
 
-    req = Gem::Requirement.create(version)
+    req = Gem::Requirement.create(requirement)
 
     dinst = Gem::DependencyInstaller.new options
 

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -957,6 +957,31 @@ ERROR:  Possible alternatives: non_existent_with_hint
     assert_match "1 gem installed", @ui.output
   end
 
+  def test_execute_default_gem
+    spec_fetcher do |fetcher|
+      fetcher.download 'bundler', '2.2.32'
+    end
+
+    bundler_2_2_32 = new_default_spec 'bundler', '2.2.32'
+    install_default_gems bundler_2_2_32
+
+    assert_includes Gem::Specification.all_names, 'bundler-2.2.32'
+
+    @cmd.options[:args] = %w[bundler]
+
+    use_ui @ui do
+      assert_raise Gem::MockGemUi::SystemExitException do
+        @cmd.execute
+      end
+    end
+
+    assert_equal %w[bundler-2.2.32], Gem::Specification.all_names.sort
+
+    output = @ui.output.split "\n"
+
+    assert_equal 'Skipping installation of bundler-2.2.32 because it\'s already a default gem', output.shift
+  end
+
   def test_install_gem_ignore_dependencies_both
     done_installing = false
     Gem.done_installing do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Running `gem install <name>:<version>` where `<name>-<version>` is a default gem has the potential to break things because of little divergences on how ruby-core installs default gems vs how rubygems installs default gems.
    
For example, the `bundler` gem installed by ruby-core has its executables installed on a "libexec" folder inside the gem installation folder (it's the only thing included there because the other files belong in the stdlib core folder). However, when installed as a regular gem this folder is called "exe". If we allow overwriting the default gem with a regular installation, the "libexec" folder will be renamed to "exe", but the default gemspec will still point to the original "libexec" folder. This can cause issues when changing `GEM_PATH` and `GEM_HOME` (ignoring the regular gem installed), because the "libexec" folder will no longer be found.

## What is your fix for the problem, implemented in this PR?

The easiest way to prevent this mess seems to skip installation of gems if the same resolved version is already installed as a default gem.

Closes #5098.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
