### PR TITLE
Avoid error reporting relative path when validating frozen

### DIFF
--- a/bundler/lib/bundler/cli/check.rb
+++ b/bundler/lib/bundler/cli/check.rb
@@ -29,7 +29,7 @@ module Bundler
         Bundler.ui.warn "Install missing gems with `bundle install`"
         exit 1
       elsif !Bundler.default_lockfile.file? && Bundler.frozen_bundle?
-        Bundler.ui.error "This bundle has been frozen, but there is no #{Bundler.default_lockfile.relative_path_from(SharedHelpers.pwd)} present"
+        Bundler.ui.error "This bundle has been frozen, but there is no #{SharedHelpers.relative_lockfile_path} present"
         exit 1
       else
         Bundler.load.lock(:preserve_unknown_sections => true) unless options[:"dry-run"]

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -28,7 +28,7 @@ module Bundler
           flag   = "--deployment flag" if options[:deployment]
           flag ||= "--frozen flag"     if options[:frozen]
           flag ||= "deployment setting"
-          raise ProductionError, "The #{flag} requires a #{Bundler.default_lockfile.relative_path_from(SharedHelpers.pwd)}. Please make " \
+          raise ProductionError, "The #{flag} requires a lockfile. Please make " \
                                  "sure you have checked your #{Bundler.default_lockfile.relative_path_from(SharedHelpers.pwd)} into version control " \
                                  "before deploying."
         end

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -29,7 +29,7 @@ module Bundler
           flag ||= "--frozen flag"     if options[:frozen]
           flag ||= "deployment setting"
           raise ProductionError, "The #{flag} requires a lockfile. Please make " \
-                                 "sure you have checked your #{Bundler.default_lockfile.relative_path_from(SharedHelpers.pwd)} into version control " \
+                                 "sure you have checked your #{SharedHelpers.relative_lockfile_path} into version control " \
                                  "before deploying."
         end
 

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -405,13 +405,13 @@ module Bundler
       msg << "\n\nYou have added to the Gemfile:\n" << added.join("\n") if added.any?
       msg << "\n\nYou have deleted from the Gemfile:\n" << deleted.join("\n") if deleted.any?
       msg << "\n\nYou have changed in the Gemfile:\n" << changed.join("\n") if changed.any?
-      msg << "\n\nRun `bundle install` elsewhere and add the updated #{Bundler.default_lockfile.relative_path_from(SharedHelpers.pwd)} to version control.\n"
+      msg << "\n\nRun `bundle install` elsewhere and add the updated #{SharedHelpers.relative_gemfile_path} to version control.\n"
 
       unless explicit_flag
         suggested_command = unless Bundler.settings.locations("frozen").keys.include?(:env)
           "bundle config set frozen false"
         end
-        msg << "If this is a development machine, remove the #{Bundler.default_gemfile.relative_path_from(SharedHelpers.pwd)} " \
+        msg << "If this is a development machine, remove the #{SharedHelpers.relative_lockfile_path} " \
                "freeze by running `#{suggested_command}`." if suggested_command
       end
 

--- a/bundler/lib/bundler/env.rb
+++ b/bundler/lib/bundler/env.rb
@@ -40,11 +40,11 @@ module Bundler
 
         out << "\n## Gemfile\n"
         gemfiles.each do |gemfile|
-          out << "\n### #{Pathname.new(gemfile).relative_path_from(SharedHelpers.pwd)}\n\n"
+          out << "\n### #{SharedHelpers.relative_path_to(gemfile)}\n\n"
           out << "```ruby\n" << read_file(gemfile).chomp << "\n```\n"
         end
 
-        out << "\n### #{Bundler.default_lockfile.relative_path_from(SharedHelpers.pwd)}\n\n"
+        out << "\n### #{SharedHelpers.relative_path_to(Bundler.default_lockfile)}\n\n"
         out << "```\n" << read_file(Bundler.default_lockfile).chomp << "\n```\n"
       end
 

--- a/bundler/lib/bundler/installer/standalone.rb
+++ b/bundler/lib/bundler/installer/standalone.rb
@@ -55,18 +55,11 @@ module Bundler
       if spec.source.instance_of?(Source::Path) && spec.source.path.absolute?
         full_path
       else
-        relative_path_from(Bundler.root.join(bundler_path), :to => full_path) || full_path
+        SharedHelpers.relative_path_to(full_path, :from => Bundler.root.join(bundler_path))
       end
     rescue TypeError
       error_message = "#{spec.name} #{spec.version} has an invalid gemspec"
       raise Gem::InvalidSpecificationException.new(error_message)
-    end
-
-    def relative_path_from(source, to:)
-      Pathname.new(to).relative_path_from(source).to_s
-    rescue ArgumentError
-      # on Windows, if source and destination are on different drivers, there's no relative path from one to the other
-      nil
     end
 
     def define_path_helpers

--- a/bundler/lib/bundler/lockfile_parser.rb
+++ b/bundler/lib/bundler/lockfile_parser.rb
@@ -67,7 +67,7 @@ module Bundler
       @specs        = {}
 
       if lockfile.match?(/<<<<<<<|=======|>>>>>>>|\|\|\|\|\|\|\|/)
-        raise LockfileError, "Your #{Bundler.default_lockfile.relative_path_from(SharedHelpers.pwd)} contains merge conflicts.\n" \
+        raise LockfileError, "Your lockfile contains merge conflicts.\n" \
           "Run `git checkout HEAD -- #{Bundler.default_lockfile.relative_path_from(SharedHelpers.pwd)}` first to get a clean lock."
       end
 

--- a/bundler/lib/bundler/lockfile_parser.rb
+++ b/bundler/lib/bundler/lockfile_parser.rb
@@ -68,7 +68,7 @@ module Bundler
 
       if lockfile.match?(/<<<<<<<|=======|>>>>>>>|\|\|\|\|\|\|\|/)
         raise LockfileError, "Your lockfile contains merge conflicts.\n" \
-          "Run `git checkout HEAD -- #{Bundler.default_lockfile.relative_path_from(SharedHelpers.pwd)}` first to get a clean lock."
+          "Run `git checkout HEAD -- #{SharedHelpers.relative_lockfile_path}` first to get a clean lock."
       end
 
       lockfile.split(/(?:\r?\n)+/) do |line|
@@ -92,7 +92,7 @@ module Bundler
       @specs = @specs.values.sort_by!(&:full_name)
     rescue ArgumentError => e
       Bundler.ui.debug(e)
-      raise LockfileError, "Your lockfile is unreadable. Run `rm #{Bundler.default_lockfile.relative_path_from(SharedHelpers.pwd)}` " \
+      raise LockfileError, "Your lockfile is unreadable. Run `rm #{SharedHelpers.relative_lockfile_path}` " \
         "and then `bundle install` to generate a new lockfile."
     end
 

--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -197,6 +197,21 @@ module Bundler
       filesystem_access(gemfile_path) {|g| File.open(g, "w") {|file| file.puts contents } }
     end
 
+    def relative_gemfile_path
+      relative_path_to(Bundler.default_gemfile)
+    end
+
+    def relative_lockfile_path
+      relative_path_to(Bundler.default_lockfile)
+    end
+
+    def relative_path_to(destination, from: pwd)
+      Pathname.new(destination).relative_path_from(from).to_s
+    rescue ArgumentError
+      # on Windows, if source and destination are on different drivers, there's no relative path from one to the other
+      destination
+    end
+
     private
 
     def validate_bundle_path

--- a/bundler/spec/install/deploy_spec.rb
+++ b/bundler/spec/install/deploy_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe "install in deployment or frozen mode" do
   context "with CLI flags", :bundler => "< 3" do
     it "fails without a lockfile and says that --deployment requires a lock" do
       bundle "install --deployment", :raise_on_error => false
-      expect(err).to include("The --deployment flag requires a Gemfile.lock")
+      expect(err).to include("The --deployment flag requires a lockfile")
     end
 
     it "fails without a lockfile and says that --frozen requires a lock" do
       bundle "install --frozen", :raise_on_error => false
-      expect(err).to include("The --frozen flag requires a Gemfile.lock")
+      expect(err).to include("The --frozen flag requires a lockfile")
     end
 
     it "disallows --deployment --system" do

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -1584,7 +1584,7 @@ RSpec.describe "the lockfile format" do
       gem "rack"
     G
 
-    expect(err).to match(/your Gemfile.lock contains merge conflicts/i)
+    expect(err).to match(/your lockfile contains merge conflicts/i)
     expect(err).to match(/git checkout HEAD -- Gemfile.lock/i)
   end
 


### PR DESCRIPTION
When invoking `Bundler::Runtiume::setup` on a frozen bundle, and there is no
relative path from PWD to our default lockfile, our attempt to pre-generate a
helpful message results in an `ArgumentError`.

This is more likely to occur on Windows, for example if PWD is on the `C:`
volume and our project is on the `D:` volume, our application entry-point is
invoked using an absolute path, and our application invokes `Bundler::setup`.

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

A customer invoking Logstash 7.15.x using an absolute path `D:\logstash-7.15.0\bin\logstash` from a shell whose PWD was on the `C:\` volume resulted in an `ArgumentError` propagating up from `Bundler::Definition#ensure_equivalent_gemfile_and_lockfile`. Logstash invokes `Bundler` directly in code with `:frozen` attribute set to `true`.

## What is your fix for the problem, implemented in this PR?

Stdlib's `Pathname#relative_path_from` raises an `ArgumentError` if it cannot give a relative path.

Since Bundler's usage doesn't actually require a relative path but is only meant to provide helpful guidance to the user should our invocation eventually fail, it makes sense to rescue the `ArgumentError` and simply use the absolute path when a relative path can't be built.

I would appreciate guidance on how to write a test for this. `Bundler::Definition#ensure_equivalent_gemfile_and_lockfile` does not appear to be covered at all in unit tests, and in any case there are likely to be OS-specific instructions for what constitutes a different base (on my POSIX machine running jruby, I cannot get `Pathname#relative_path_from` to produce the same `ArgumentError`).

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
