### PR TITLE
Move required_ruby_version gemspec attribute to recommended section.

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -288,6 +288,15 @@ class Gem::Specification < Gem::BasicSpecification
   # :section: Recommended gemspec attributes
 
   ##
+  # The version of Ruby required by this gem
+  #
+  # Usage:
+  #
+  #   spec.required_ruby_version = '>= 2.7.0'
+
+  attr_reader :required_ruby_version
+
+  ##
   # A long description of this gem
   #
   # The description should be more detailed than the summary but not
@@ -521,11 +530,6 @@ class Gem::Specification < Gem::BasicSpecification
   def require_paths=(val)
     @require_paths = Array(val)
   end
-
-  ##
-  # The version of Ruby required by this gem
-
-  attr_reader :required_ruby_version
 
   ##
   # The RubyGems version required by this gem


### PR DESCRIPTION
originally part of https://github.com/rubygems/guides/pull/295

I have added also example of usage.

:information_source: @marcandre 