### PR TITLE
Add login & logout alias for the signin & signout commands

### DIFF
--- a/lib/rubygems/command_manager.rb
+++ b/lib/rubygems/command_manager.rb
@@ -73,7 +73,9 @@ class Gem::CommandManager
   ].freeze
 
   ALIAS_COMMANDS = {
-    'i' => 'install',
+    'i'      => 'install',
+    'login'  => 'signin',
+    'logout' => 'signout',
   }.freeze
 
   ##

--- a/test/rubygems/test_gem_command_manager.rb
+++ b/test/rubygems/test_gem_command_manager.rb
@@ -36,6 +36,18 @@ class TestGemCommandManager < Gem::TestCase
     assert_kind_of Gem::Commands::InstallCommand, command
   end
 
+  def test_find_login_alias_command
+    command = @command_manager.find_command 'login'
+
+    assert_kind_of Gem::Commands::SigninCommand, command
+  end
+
+  def test_find_logout_alias_comamnd
+    command = @command_manager.find_command 'logout'
+
+    assert_kind_of Gem::Commands::SignoutCommand, command
+  end
+
   def test_find_command_ambiguous_exact
     ins_command = Class.new
     Gem::Commands.send :const_set, :InsCommand, ins_command


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I can never remember the commands to "sign into RubyGems" & "logout of RubyGems" the first time. I always try using `login` & `logout` first, but then have to lookup the command to remember that it's actually `signin` & `signout`.

## What is your fix for the problem, implemented in this PR?

I wish to add an alias to allow both options so people don't have to remember which set is specifically needed.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
