### PR TITLE
Allow using `Gem::Version` without loading the rest of rubygems

### DIFF
--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -149,6 +149,15 @@
 # For the last example, single-digit versions are automatically extended with
 # a zero to give a sensible result.
 
+# Our code style opens classes directly without opening the intermediate
+# modules. This works because tha main entrypoint `rubygems.rb`, which defines
+# the root `Gem` module, is usually required first. But in this case we want to
+# allow using `Gem::Version` without loading the rest of rubygems, so we
+# explicit define the `Gem` placeholder module first.
+module Gem; end
+
+require_relative "deprecate"
+
 class Gem::Version
   autoload :Requirement, File.expand_path('requirement', __dir__)
 

--- a/test/rubygems/test_project_sanity.rb
+++ b/test/rubygems/test_project_sanity.rb
@@ -13,7 +13,7 @@ class TestProjectSanity < Gem::TestCase
   end
 
   def test_require_rubygems_package
-    err, status = Open3.capture2e(*ruby_with_rubygems_in_load_path, "--disable-gems", "-e", "'require \"rubygems/package\"'")
+    err, status = Open3.capture2e(*ruby_with_rubygems_in_load_path, "--disable-gems", "-e", "require \"rubygems/package\"")
 
     assert status.success?, err
   end

--- a/test/rubygems/test_project_sanity.rb
+++ b/test/rubygems/test_project_sanity.rb
@@ -17,4 +17,16 @@ class TestProjectSanity < Gem::TestCase
 
     assert status.success?, err
   end
+
+  def test_require_and_use_rubygems_version
+    err, status = Open3.capture2e(
+      *ruby_with_rubygems_in_load_path,
+      "--disable-gems",
+      "-rrubygems/version",
+      "-e",
+      "Gem::Version.new('2.7.0.preview1') >= Gem::Version.new(RUBY_VERSION)"
+    )
+
+    assert status.success?, err
+  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Some users of `--disable-gems` might want to use `Gem::Version` for feature checking for example without loading the rest of RubyGems.

See https://bugs.ruby-lang.org/issues/18376 or https://github.com/mperham/connection_pool/issues/158.

## What is your fix for the problem, implemented in this PR?

Add a couple of tiny changes to make this possible.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
