### PR TITLE
Revert stuff about `Gem::Version` availability

### DIFF
--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -223,7 +223,7 @@ Automatiek::RakeTask.new("net-http-persistent") do |lib|
   lib.license_path = "README.rdoc"
 
   # We currently include the official version as of
-  # https://github.com/mperham/connection_pool/commit/204d9f24b1fff7f893baf9d26e509bf79ed53083.
+  # https://github.com/mperham/connection_pool/commit/813c271e41be0714334834d6517ce68ca1357fc0.
   lib.dependency("connection_pool") do |sublib|
     sublib.version = "master"
     sublib.download = { :github => "https://github.com/mperham/connection_pool" }

--- a/bundler/lib/bundler/vendor/connection_pool/lib/connection_pool/wrapper.rb
+++ b/bundler/lib/bundler/vendor/connection_pool/lib/connection_pool/wrapper.rb
@@ -32,13 +32,13 @@ class Bundler::ConnectionPool
 
     # rubocop:disable Style/MethodMissingSuper
     # rubocop:disable Style/MissingRespondToMissing
-    if ::Gem.ruby_version >= ::Gem::Version.new("3.0.0")
+    if ::RUBY_VERSION >= "3.0.0"
       def method_missing(name, *args, **kwargs, &block)
         with do |connection|
           connection.send(name, *args, **kwargs, &block)
         end
       end
-    elsif ::Gem.ruby_version >= ::Gem::Version.new("2.7.0")
+    elsif ::RUBY_VERSION >= "2.7.0"
       ruby2_keywords def method_missing(name, *args, &block)
         with do |connection|
           connection.send(name, *args, &block)

--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -149,13 +149,6 @@
 # For the last example, single-digit versions are automatically extended with
 # a zero to give a sensible result.
 
-# Our code style opens classes directly without opening the intermediate
-# modules. This works because tha main entrypoint `rubygems.rb`, which defines
-# the root `Gem` module, is usually required first. But in this case we want to
-# allow using `Gem::Version` without loading the rest of rubygems, so we
-# explicit define the `Gem` placeholder module first.
-module Gem; end
-
 require_relative "deprecate"
 
 class Gem::Version

--- a/test/rubygems/test_project_sanity.rb
+++ b/test/rubygems/test_project_sanity.rb
@@ -17,16 +17,4 @@ class TestProjectSanity < Gem::TestCase
 
     assert status.success?, err
   end
-
-  def test_require_and_use_rubygems_version
-    err, status = Open3.capture2e(
-      *ruby_with_rubygems_in_load_path,
-      "--disable-gems",
-      "-rrubygems/version",
-      "-e",
-      "Gem::Version.new('2.7.0.preview1') >= Gem::Version.new(RUBY_VERSION)"
-    )
-
-    assert status.success?, err
-  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

No problem, really, but just reverting a couple of things to keep affected parties happy.

## What is your fix for the problem, implemented in this PR?

* Revert #5112, because the upstream change was reverted. I'll leave a "won't fix" note at the related ticket.
* Partially revert #5136, because a better solution to provide built-in version comparison functionality is being discussed.
 
## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
