### PR TITLE
Fix upgrade crashing when multiple versions of `fileutils` installed

### DIFF
--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -42,6 +42,14 @@ jobs:
         run: |
           ruby -Ilib -S rake install 2> errors.txt || (cat errors.txt && exit 1)
           test ! -s errors.txt || (cat errors.txt && exit 1)
+      - name: Check downgrading
+        run: gem update --system 3.2.32
+      - name: Check installing fileutils
+        run: gem install fileutils
+      - name: Check installing with upgraded fileutils
+        run: |
+          ruby -Ilib -S rake install 2> errors.txt || (cat errors.txt && exit 1)
+          test ! -s errors.txt || (cat errors.txt && exit 1)
       - name: Run a local rubygems command
         run: gem list bundler
         env:

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -12,8 +12,6 @@ class Gem::Commands::SetupCommand < Gem::Command
   ENV_PATHS = %w[/usr/bin/env /bin/env].freeze
 
   def initialize
-    require 'tmpdir'
-
     super 'setup', 'Install RubyGems',
           :format_executable => false, :document => %w[ri],
           :force => true,
@@ -252,6 +250,8 @@ By default, this RubyGems will install gem as:
 
       Dir.chdir path do
         bin_file = "gem"
+
+        require 'tmpdir'
 
         dest_file = target_bin_path(bin_dir, bin_file)
         bin_tmp_file = File.join Dir.tmpdir, "#{bin_file}.#{$$}"

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -179,17 +179,13 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   def self.clear_specs # :nodoc:
-    @@all_specs_mutex.synchronize do
-      @@all = nil
-      @@stubs = nil
-      @@stubs_by_name = {}
-      @@spec_with_requirable_file = {}
-      @@active_stub_with_requirable_file = {}
-    end
+    @@all = nil
+    @@stubs = nil
+    @@stubs_by_name = {}
+    @@spec_with_requirable_file = {}
+    @@active_stub_with_requirable_file = {}
   end
   private_class_method :clear_specs
-
-  @@all_specs_mutex = Thread::Mutex.new
 
   clear_specs
 
@@ -758,7 +754,7 @@ class Gem::Specification < Gem::BasicSpecification
   attr_accessor :specification_version
 
   def self._all # :nodoc:
-    @@all_specs_mutex.synchronize { @@all ||= Gem.loaded_specs.values | stubs.map(&:to_spec) }
+    @@all ||= Gem.loaded_specs.values | stubs.map(&:to_spec)
   end
 
   def self.clear_load_cache # :nodoc:

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1086,7 +1086,7 @@ class Gem::Specification < Gem::BasicSpecification
   # +prerelease+ is true.
 
   def self.latest_specs(prerelease = false)
-    _latest_specs Gem::Specification._all, prerelease
+    _latest_specs Gem::Specification.stubs, prerelease
   end
 
   ##

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -944,7 +944,7 @@ dependencies: []
   end
 
   def test_self_outdated_and_latest_remotes
-    specs = spec_fetcher do |fetcher|
+    spec_fetcher do |fetcher|
       fetcher.download 'a', 4
       fetcher.download 'b', 3
 
@@ -953,8 +953,8 @@ dependencies: []
     end
 
     expected = [
-      [specs['a-3.a'], v(4)],
-      [specs['b-2'],   v(3)],
+      [Gem::Specification.stubs.find {|s| s.full_name == 'a-3.a' }, v(4)],
+      [Gem::Specification.stubs.find {|s| s.full_name == 'b-2' }, v(3)],
     ]
 
     assert_equal expected, Gem::Specification.outdated_and_latest_version.to_a


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If you have multiple versions of `fileutils` installed on a ruby where fileutils is a default gem, upgrading rubygems partially fails with an error like this.

```
$ ruby setup.rb             
  Successfully built RubyGem
  Name: bundler
  Version: 2.3.0.dev
  File: bundler-2.3.0.dev.gem
ERROR:  While executing gem ... (NoMethodError)
    undefined method `name' for nil:NilClass
```
 
## What is your fix for the problem, implemented in this PR?

The issue is tricky.  There's 3 relevant moments:

* When first loading the `update` command,  `tmpdir` is required. This require causes the `Gem::Specification.stubs` array to be loaded, because since there are more than one version of `fileutils`, which is a `tmpdir` dependency, `rubygems` needs to figure out which one to require, and needs to load stubs from disk for that.
* Later on, when installing the upgraded default bundler gem, the upgrader first deletes the existing default bundler gemspec from disk before installing the upgraded version.
* Finally, when plugins are being regenerated specification stubs are materialized into actual `Gem::Specification`'s, but since one of them is no longer on disk, it results on a `nil` specification being loaded, causing a runtime error later on when calling a specification method on it.
    
I can think of several ways of fixing this issue:
* Delete the existing spec after installing the new one, not before.
* Require `tmpdir` lazily.
* Don't materialize specs at all when regenerating plugins, since I don't think it's needed. All we need is their versions and names, which stubs already provide.
 
The PR implements the second and third solution. Since I was at it, I removed the specification mutex that I think it was no longer necessary after the third solution. In any case, it was added to support multiple concurrent `gem install` commands, but that has never really been supported, because the gem installer first completely wipes out any existing installation, and then unpackages files from scratch, and that's obviously not thread safe.

As a consequence of this PR, upgrading rubygems should be faster. On my system, it shows a consistent 3% speed up but that's with no gems installed, I guess it could be bigger with many gems installed.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
