### PR TITLE
Add missing prerequisite for `prepare_release_branch`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -162,7 +162,7 @@ task :install_release_dependencies do
 end
 
 desc "Prepare stable branch"
-task :prepare_stable_branch, [:version] do |_t, opts|
+task :prepare_stable_branch, [:version] => [:install_release_dependencies] do |_t, opts|
   require_relative "util/release"
 
   Release.new(opts[:version] || v.to_s).prepare!


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I run into a little issue while running this task because I was missing dependencies.

## What is your fix for the problem, implemented in this PR?

Add release dependencies as a prerequisite for this task too.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
