### PR TITLE
Ignore dependencies not actually locked from frozen check

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -379,7 +379,12 @@ module Bundler
 
       both_sources = Hash.new {|h, k| h[k] = [] }
       @dependencies.each {|d| both_sources[d.name][0] = d }
-      locked_dependencies.each {|d| both_sources[d.name][1] = d }
+
+      locked_dependencies.each do |d|
+        next if !Bundler.feature_flag.bundler_3_mode? && @locked_specs[d.name].empty?
+
+        both_sources[d.name][1] = d
+      end
 
       both_sources.each do |name, (dep, lock_dep)|
         next if dep.nil? || lock_dep.nil?

--- a/bundler/spec/install/deploy_spec.rb
+++ b/bundler/spec/install/deploy_spec.rb
@@ -258,6 +258,17 @@ RSpec.describe "install in deployment or frozen mode" do
       expect(out).to eq("WIN")
     end
 
+    it "works if a gem is missing, but it's on a different platform, and the Gemfile has no global source", :bundler => "< 3" do
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}" do
+          gem "rake", platform: :#{not_local_tag}
+        end
+      G
+
+      bundle :install, :env => { "BUNDLE_FROZEN" => "true" }
+      expect(last_command).to be_success
+    end
+
     it "explodes if a path gem is missing" do
       build_lib "path_gem"
       install_gemfile <<-G


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

After upgrading bundler to 2.2.33, a lockfile that used to be equivalent to its Gemfile, it will now raise in frozen mode.

## What is your fix for the problem, implemented in this PR?

Special case this particular case (no global source, and dependencies for other platform in the Gemfile) to keep things working as they did previously.

Fixes https://github.com/rubygems/rubygems/pull/5120#issuecomment-988938293.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
