### PR TITLE
Revision is now considered within the eql? comparator for a Source::Git object

### DIFF
--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -47,14 +47,19 @@ module Bundler
       end
 
       def hash
-        [self.class, uri, ref, branch, name, version, glob, submodules].hash
+        [self.class, uri, ref, branch, name, version, glob, submodules, safe_revision].hash
       end
 
       def eql?(other)
         other.is_a?(Git) && uri == other.uri && ref == other.ref &&
           branch == other.branch && name == other.name &&
           version == other.version && glob == other.glob &&
-          submodules == other.submodules
+          submodules == other.submodules && eql_revision?(other)
+      end
+
+      def eql_revision?(other)
+        return true if safe_revision.nil? || other.safe_revision.nil?
+        safe_revision == other.safe_revision
       end
 
       alias_method :==, :eql?
@@ -230,6 +235,12 @@ module Bundler
 
       def app_cache_dirname
         "#{base_name}-#{shortref_for_path(cached_revision || revision)}"
+      end
+
+      def safe_revision
+        revision
+      rescue StandardError
+        nil
       end
 
       def revision


### PR DESCRIPTION
Preface: this PR is a proof of concept and is mainly just to gain insight in the design decision behind why `revision` isn't currently included in the `eql?` comparator for a `Source::Git` object.

## Description of the problem

This PR will add the `revision` attribute to the `eql?` method for a `Source::Git` object. We have a work around for this on our application, but are looking to upstream this fix through this PR. 


For `Source::Git` objects, the [eql?](
https://github.com/rubygems/rubygems/blob/ea8a61cf621fab4df6848f9a80eba0c8a0ce60da/bundler/lib/bundler/source/git.rb#L53-58) method does not consider `revision` when comparing two `Source::Git` objects. Hence, when two gemfile.lock with different revisions are compared the `eql?` method will return true. Is `revision` being ignored intentionally?

## Reproducible case
In one of our Rails applications, we use the following on the `Gemfile`:

```ruby
gem "rails", github: "rails/rails", branch: "main"
```

That translates to a Git source section that looks like this, on the `Gemfile.lock`:

**Gemfile.lock (v1)**

```ruby
GIT
  remote: https://github.com/rails/rails.git
  revision: a7320e6de7dcab0ee33adc652934998ef5b7324a
  branch: main
  specs:
    actioncable (7.0.0.alpha2)
      actionpack (= 7.0.0.alpha2)
...
```
This would under the current implementation, be equal when converted to a `Source::Git` object to another `Gemfile.lock` with a different revision under the same gem.

**Gemfile.lock (v2)**

```ruby
GIT
  remote: https://github.com/rails/rails.git
  revision: dea5603dffc19db6fbf94d506f087549c014efec
  branch: main
  specs:
    actioncable (7.0.0.alpha2)
      actionpack (= 7.0.0.alpha2)
...
```