### PR TITLE
Fix broken brew formula due to loading `operating_system.rb` customizations too late

### DIFF
--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -105,10 +105,5 @@ jobs:
       - name: Check we can install a Gemfile with git sources
         run: bundle init && bundle add fileutils --git https://github.com/ruby/fileutils
         shell: bash
-      - name: Check the latest available fiddle version gets activated
-        run: |
-          gem install fiddle:1.1.0
-          ruby -rfiddle -e "exit Fiddle::VERSION == '1.1.0'"
-        if: matrix.ruby.name != 'jruby-9.3'
 
     timeout-minutes: 10

--- a/bundler/spec/commands/clean_spec.rb
+++ b/bundler/spec/commands/clean_spec.rb
@@ -638,7 +638,7 @@ RSpec.describe "bundle clean" do
       s.executables = "irb"
     end
 
-    realworld_system_gems "fiddle --version 1.0.6", "tsort --version 0.1.0", "pathname --version 0.1.0", "set --version 1.0.1"
+    realworld_system_gems "fiddle --version 1.0.8", "tsort --version 0.1.0", "pathname --version 0.1.0", "set --version 1.0.1"
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}"

--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -113,7 +113,7 @@ RSpec.shared_examples "bundle install --standalone" do
       skip "does not work on rubygems versions where `--install_dir` doesn't respect --default" unless Gem::Installer.for_spec(loaded_gemspec, :install_dir => "/foo").default_spec_file == "/foo/specifications/default/bundler-#{Bundler::VERSION}.gemspec" # Since rubygems 3.2.0.rc.2
       skip "does not work on old rubies because the realworld gems that need to be installed don't support them" if RUBY_VERSION < "2.7.0"
 
-      realworld_system_gems "fiddle --version 1.0.6", "tsort --version 0.1.0"
+      realworld_system_gems "fiddle --version 1.0.8", "tsort --version 0.1.0"
 
       necessary_system_gems = ["optparse --version 0.1.1", "psych --version 3.3.2", "yaml --version 0.1.1", "logger --version 1.4.3", "etc --version 1.2.0", "stringio --version 3.0.0"]
       necessary_system_gems += ["shellwords --version 0.1.0", "base64 --version 0.1.0", "resolv --version 0.2.1"] if Gem.rubygems_version < Gem::Version.new("3.3.3.a")

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1293,7 +1293,12 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     end
 
     def default_gem_load_paths
-      @default_gem_load_paths ||= $LOAD_PATH[load_path_insert_index..-1]
+      @default_gem_load_paths ||= $LOAD_PATH[load_path_insert_index..-1].map do |lp|
+        expanded = File.expand_path(lp)
+        next expanded unless File.exist?(expanded)
+
+        File.realpath(expanded)
+      end
     end
   end
 

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1310,19 +1310,17 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   autoload :Licenses,           File.expand_path('rubygems/util/licenses', __dir__)
   autoload :NameTuple,          File.expand_path('rubygems/name_tuple', __dir__)
   autoload :PathSupport,        File.expand_path('rubygems/path_support', __dir__)
-  autoload :Platform,           File.expand_path('rubygems/platform', __dir__)
   autoload :RequestSet,         File.expand_path('rubygems/request_set', __dir__)
-  autoload :Requirement,        File.expand_path('rubygems/requirement', __dir__)
   autoload :Resolver,           File.expand_path('rubygems/resolver', __dir__)
   autoload :Source,             File.expand_path('rubygems/source', __dir__)
   autoload :SourceList,         File.expand_path('rubygems/source_list', __dir__)
   autoload :SpecFetcher,        File.expand_path('rubygems/spec_fetcher', __dir__)
-  autoload :Specification,      File.expand_path('rubygems/specification', __dir__)
   autoload :Util,               File.expand_path('rubygems/util', __dir__)
   autoload :Version,            File.expand_path('rubygems/version', __dir__)
 end
 
 require_relative 'rubygems/exceptions'
+require_relative 'rubygems/specification'
 
 # REFACTOR: This should be pulled out into some kind of hacks file.
 begin

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1325,22 +1325,6 @@ require_relative 'rubygems/specification'
 # REFACTOR: This should be pulled out into some kind of hacks file.
 begin
   ##
-  # Defaults the Ruby implementation wants to provide for RubyGems
-
-  require "rubygems/defaults/#{RUBY_ENGINE}"
-rescue LoadError
-end
-
-##
-# Loads the default specs.
-Gem::Specification.load_defaults
-
-require_relative 'rubygems/core_ext/kernel_gem'
-require_relative 'rubygems/core_ext/kernel_require'
-require_relative 'rubygems/core_ext/kernel_warn'
-
-begin
-  ##
   # Defaults the operating system (or packager) wants to provide for RubyGems.
 
   require 'rubygems/defaults/operating_system'
@@ -1354,3 +1338,19 @@ rescue StandardError => e
     "the problem and ask for help."
   raise e.class, msg
 end
+
+begin
+  ##
+  # Defaults the Ruby implementation wants to provide for RubyGems
+
+  require "rubygems/defaults/#{RUBY_ENGINE}"
+rescue LoadError
+end
+
+##
+# Loads the default specs.
+Gem::Specification.load_defaults
+
+require_relative 'rubygems/core_ext/kernel_gem'
+require_relative 'rubygems/core_ext/kernel_require'
+require_relative 'rubygems/core_ext/kernel_warn'

--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_relative "deprecate"
+require_relative "version"
 
 ##
 # A Requirement is a set of one or more version restrictions. It supports a

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -9,6 +9,8 @@
 require_relative 'deprecate'
 require_relative 'basic_specification'
 require_relative 'stub_specification'
+require_relative 'platform'
+require_relative 'requirement'
 require_relative 'specification_policy'
 require_relative 'util/list'
 

--- a/test/rubygems/test_rubygems.rb
+++ b/test/rubygems/test_rubygems.rb
@@ -22,6 +22,29 @@ class GemTest < Gem::TestCase
     "the problem and ask for help."
   end
 
+  def test_operating_system_customizing_default_dir
+    pend "does not apply to truffleruby" if RUBY_ENGINE == 'truffleruby'
+    pend "loads a custom defaults/jruby file that gets in the middle" if RUBY_ENGINE == 'jruby'
+
+    # On a non existing default dir, there should be no gems
+
+    path = util_install_operating_system_rb <<-RUBY
+      module Gem
+        def self.default_dir
+          File.expand_path("foo")
+        end
+      end
+    RUBY
+
+    output = Gem::Util.popen(
+      *ruby_with_rubygems_and_fake_operating_system_in_load_path(path),
+      '-e',
+      "require \"rubygems\"; puts Gem::Specification.stubs.map(&:full_name)",
+      {:err => [:child, :out]}
+    ).strip
+    assert_empty output
+  end
+
   private
 
   def util_install_operating_system_rb(content)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Hombrew ruby formula no longer works since #5044 .

## What is your fix for the problem, implemented in this PR?

The problem is that setting up default gems needs `Gem.default_dir`, which is something commonly customized in this file. So if we setup default gems before loading `operating_system.rb` customizations, we will setup the wrong default gems.

Unfortunately fixing this requires reverting #5044, but I wasn't even sure that enhancement was the right thing to do, and the culprit ended up being something else, so we should fix the real culprit there instead.

Fixes #5151.
Fixes #5043.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
