### PR TITLE
Don't load system rubygems during tests

### DIFF
--- a/test/rubygems/test_gem_commands_open_command.rb
+++ b/test/rubygems/test_gem_commands_open_command.rb
@@ -21,7 +21,7 @@ class TestGemCommandsOpenCommand < Gem::TestCase
 
   def test_execute
     @cmd.options[:args] = %w[foo]
-    @cmd.options[:editor] = "#{Gem.ruby} -eexit --"
+    @cmd.options[:editor] = "#{ruby_with_rubygems_in_load_path} -eexit --"
 
     gem 'foo', '1.0.0'
     spec = gem 'foo', '1.0.1'


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Very minor, but while debugging another issue I noticed that this particular test is using the rubygems version installed globally in the system, not the one we are testing.

## What is your fix for the problem, implemented in this PR?

Setup the proper load path to exercise the version we want to exercise.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
