### PR TITLE
Add `github` and `ref` options to `bundle add`

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -369,7 +369,9 @@ module Bundler
     method_option "source", :aliases => "-s", :type => :string
     method_option "require", :aliases => "-r", :type => :string, :banner => "Adds require path to gem. Provide false, or a path as a string."
     method_option "git", :type => :string
+    method_option "github", :type => :string
     method_option "branch", :type => :string
+    method_option "ref", :type => :string
     method_option "skip-install", :type => :boolean, :banner =>
       "Adds gem to the Gemfile but does not install it"
     method_option "optimistic", :type => :boolean, :banner => "Adds optimistic declaration of version to gem"

--- a/bundler/lib/bundler/dependency.rb
+++ b/bundler/lib/bundler/dependency.rb
@@ -7,7 +7,7 @@ require_relative "rubygems_ext"
 module Bundler
   class Dependency < Gem::Dependency
     attr_reader :autorequire
-    attr_reader :groups, :platforms, :gemfile, :git, :branch
+    attr_reader :groups, :platforms, :gemfile, :git, :github, :branch, :ref
 
     PLATFORM_MAP = {
       :ruby     => Gem::Platform::RUBY,
@@ -82,7 +82,9 @@ module Bundler
       @groups         = Array(options["group"] || :default).map(&:to_sym)
       @source         = options["source"]
       @git            = options["git"]
+      @github         = options["github"]
       @branch         = options["branch"]
+      @ref            = options["ref"]
       @platforms      = Array(options["platforms"])
       @env            = options["env"]
       @should_include = options.fetch("should_include", true)

--- a/bundler/lib/bundler/injector.rb
+++ b/bundler/lib/bundler/injector.rb
@@ -112,10 +112,12 @@ module Bundler
 
         source = ", :source => \"#{d.source}\"" unless d.source.nil?
         git = ", :git => \"#{d.git}\"" unless d.git.nil?
+        github = ", :github => \"#{d.github}\"" unless d.github.nil?
         branch = ", :branch => \"#{d.branch}\"" unless d.branch.nil?
+        ref = ", :ref => \"#{d.ref}\"" unless d.ref.nil?
         require_path = ", :require => #{convert_autorequire(d.autorequire)}" unless d.autorequire.nil?
 
-        %(gem #{name}#{requirement}#{group}#{source}#{git}#{branch}#{require_path})
+        %(gem #{name}#{requirement}#{group}#{source}#{git}#{github}#{branch}#{ref}#{require_path})
       end.join("\n")
     end
 

--- a/bundler/lib/bundler/man/bundle-add.1
+++ b/bundler/lib/bundler/man/bundle-add.1
@@ -7,7 +7,7 @@
 \fBbundle\-add\fR \- Add gem to the Gemfile and run bundle install
 .
 .SH "SYNOPSIS"
-\fBbundle add\fR \fIGEM_NAME\fR [\-\-group=GROUP] [\-\-version=VERSION] [\-\-source=SOURCE] [\-\-git=GIT] [\-\-branch=BRANCH] [\-\-skip\-install] [\-\-strict] [\-\-optimistic]
+\fBbundle add\fR \fIGEM_NAME\fR [\-\-group=GROUP] [\-\-version=VERSION] [\-\-source=SOURCE] [\-\-git=GIT] [\-\-github=GITHUB] [\-\-branch=BRANCH] [\-\-ref=REF] [\-\-skip\-install] [\-\-strict] [\-\-optimistic]
 .
 .SH "DESCRIPTION"
 Adds the named gem to the Gemfile and run \fBbundle install\fR\. \fBbundle install\fR can be avoided by using the flag \fB\-\-skip\-install\fR\.
@@ -49,8 +49,16 @@ Specify the source for the added gem\.
 Specify the git source for the added gem\.
 .
 .TP
+\fB\-\-github\fR
+Specify the github source for the added gem\.
+.
+.TP
 \fB\-\-branch\fR
 Specify the git branch for the added gem\.
+.
+.TP
+\fB\-\-ref\fR
+Specify the git ref for the added gem\.
 .
 .TP
 \fB\-\-skip\-install\fR

--- a/bundler/lib/bundler/man/bundle-add.1.ronn
+++ b/bundler/lib/bundler/man/bundle-add.1.ronn
@@ -3,7 +3,7 @@ bundle-add(1) -- Add gem to the Gemfile and run bundle install
 
 ## SYNOPSIS
 
-`bundle add` <GEM_NAME> [--group=GROUP] [--version=VERSION] [--source=SOURCE] [--git=GIT] [--branch=BRANCH] [--skip-install] [--strict] [--optimistic]
+`bundle add` <GEM_NAME> [--group=GROUP] [--version=VERSION] [--source=SOURCE] [--git=GIT] [--github=GITHUB] [--branch=BRANCH] [--ref=REF] [--skip-install] [--strict] [--optimistic]
 
 ## DESCRIPTION
 Adds the named gem to the Gemfile and run `bundle install`. `bundle install` can be avoided by using the flag `--skip-install`.
@@ -33,8 +33,14 @@ bundle add rails --group "development, test"
 * `--git`:
   Specify the git source for the added gem.
 
+* `--github`:
+  Specify the github source for the added gem.
+
 * `--branch`:
   Specify the git branch for the added gem.
+
+* `--ref`:
+  Specify the git ref for the added gem.
 
 * `--skip-install`:
   Adds the gem to the Gemfile but does not install it.

--- a/bundler/spec/commands/add_spec.rb
+++ b/bundler/spec/commands/add_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe "bundle add" do
   end
 
   describe "with --git" do
-    it "adds dependency with specified github source" do
+    it "adds dependency with specified git source" do
       bundle "add foo --git=#{lib_path("foo-2.0")}"
 
       expect(bundled_app_gemfile.read).to match(/gem "foo", "~> 2.0", :git => "#{lib_path("foo-2.0")}"/)
@@ -117,11 +117,44 @@ RSpec.describe "bundle add" do
       update_git "foo", "2.0", :branch => "test"
     end
 
-    it "adds dependency with specified github source and branch" do
+    it "adds dependency with specified git source and branch" do
       bundle "add foo --git=#{lib_path("foo-2.0")} --branch=test"
 
       expect(bundled_app_gemfile.read).to match(/gem "foo", "~> 2.0", :git => "#{lib_path("foo-2.0")}", :branch => "test"/)
       expect(the_bundle).to include_gems "foo 2.0"
+    end
+  end
+
+  describe "with --git and --ref" do
+    it "adds dependency with specified git source and branch" do
+      bundle "add foo --git=#{lib_path("foo-2.0")} --ref=#{revision_for(lib_path("foo-2.0"))}"
+
+      expect(bundled_app_gemfile.read).to match(/gem "foo", "~> 2\.0", :git => "#{lib_path("foo-2.0")}", :ref => "#{revision_for(lib_path("foo-2.0"))}"/)
+      expect(the_bundle).to include_gems "foo 2.0"
+    end
+  end
+
+  describe "with --github" do
+    it "adds dependency with specified github source" do
+      bundle "add rake --github=ruby/rake"
+
+      expect(bundled_app_gemfile.read).to match(%r{gem "rake", "~> 13\.0", :github => "ruby\/rake"})
+    end
+  end
+
+  describe "with --github and --branch" do
+    it "adds dependency with specified github source and branch" do
+      bundle "add rake --github=ruby/rake --branch=master"
+
+      expect(bundled_app_gemfile.read).to match(%r{gem "rake", "~> 13\.0", :github => "ruby\/rake", :branch => "master"})
+    end
+  end
+
+  describe "with --github and --ref" do
+    it "adds dependency with specified github source and ref" do
+      bundle "add rake --github=ruby/rake --ref=5c60da8"
+
+      expect(bundled_app_gemfile.read).to match(%r{gem "rake", "~> 13\.0", :github => "ruby\/rake", :ref => "5c60da8"})
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`bundle add` doesn't support the `--github` and `--ref` flags.

## What is your fix for the problem, implemented in this PR?

I added the flags to the CLI and updated `Bundler::Injector` to support those new flags. Everything is done in according with this PR: https://github.com/rubygems/bundler/pull/7127

Closes #4740.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
