### PR TITLE
Fix encoding mismatch issues when writing gem packages

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -800,7 +800,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   ##
   # Safely write a file in binary mode on all platforms.
   def self.write_binary(path, data)
-    File.open(path, File::RDWR | File::CREAT | File::BINARY | File::LOCK_EX) do |io|
+    File.open(path, File::RDWR | File::CREAT | File::LOCK_EX, binmode: true) do |io|
       io.write data
     end
   rescue *WRITE_BINARY_ERRORS

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -1300,6 +1300,15 @@ Also, a list:
     Gem.instance_variable_set :@ruby, orig_ruby
   end
 
+  def with_internal_encoding(encoding)
+    int_enc = Encoding.default_internal
+    silence_warnings { Encoding.default_internal = encoding }
+
+    yield
+  ensure
+    silence_warnings { Encoding.default_internal = int_enc }
+  end
+
   def silence_warnings
     old_verbose, $VERBOSE = $VERBOSE, false
     yield

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -1300,6 +1300,13 @@ Also, a list:
     Gem.instance_variable_set :@ruby, orig_ruby
   end
 
+  def silence_warnings
+    old_verbose, $VERBOSE = $VERBOSE, false
+    yield
+  ensure
+    $VERBOSE = old_verbose
+  end
+
   class << self
     # :nodoc:
     ##

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -173,6 +173,21 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     assert_equal 'hello', File.read(path)
   end
 
+  def test_cache_update_path_with_utf8_internal_encoding
+    with_internal_encoding('UTF-8') do
+      uri = URI 'http://example/file'
+      path = File.join @tempdir, 'file'
+      data = String.new("\xC8").force_encoding(Encoding::BINARY)
+
+      fetcher = util_fuck_with_fetcher data
+
+      written_data = fetcher.cache_update_path uri, path
+
+      assert_equal data, written_data
+      assert_equal data, File.binread(path)
+    end
+  end
+
   def test_cache_update_path_no_update
     uri = URI 'http://example/file'
     path = File.join @tempdir, 'file'

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -873,24 +873,21 @@ dependencies: []
   end
 
   def test_self_load_utf8_with_ascii_encoding
-    int_enc = Encoding.default_internal
-    silence_warnings { Encoding.default_internal = 'US-ASCII' }
+    with_internal_encoding('US-ASCII') do
+      spec2 = @a2.dup
+      bin = "\u5678".dup
+      spec2.authors = [bin]
+      full_path = spec2.spec_file
+      write_file full_path do |io|
+        io.write spec2.to_ruby_for_cache.force_encoding('BINARY').sub("\\u{5678}", bin.force_encoding('BINARY'))
+      end
 
-    spec2 = @a2.dup
-    bin = "\u5678".dup
-    spec2.authors = [bin]
-    full_path = spec2.spec_file
-    write_file full_path do |io|
-      io.write spec2.to_ruby_for_cache.force_encoding('BINARY').sub("\\u{5678}", bin.force_encoding('BINARY'))
+      spec = Gem::Specification.load full_path
+
+      spec2.files.clear
+
+      assert_equal spec2, spec
     end
-
-    spec = Gem::Specification.load full_path
-
-    spec2.files.clear
-
-    assert_equal spec2, spec
-  ensure
-    silence_warnings { Encoding.default_internal = int_enc }
   end
 
   def test_self_load_legacy_ruby

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3745,11 +3745,4 @@ end
       end
     end
   end
-
-  def silence_warnings
-    old_verbose, $VERBOSE = $VERBOSE, false
-    yield
-  ensure
-    $VERBOSE = old_verbose
-  end
 end

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -700,13 +700,6 @@ class TestGemRequire < Gem::TestCase
     !ENV["GEM_COMMAND"].nil?
   end
 
-  def silence_warnings
-    old_verbose, $VERBOSE = $VERBOSE, false
-    yield
-  ensure
-    $VERBOSE = old_verbose
-  end
-
   def util_install_extension_file(name)
     spec = quick_gem name
     util_build_gem spec


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

[A change](https://github.com/rubygems/rubygems/commit/a672e7555c1d04abfd07d896fcd90b147d4aa984) in how to write gem packages caused a regression when `Encoding.default_internal` is set, possibly due to a ruby bug: https://bugs.ruby-lang.org/issues/18407.

## What is your fix for the problem, implemented in this PR?

Revert to the previous implementation, since it doesn't have the issue, and it didn't really help with the problem being fixed by https://github.com/rubygems/rubygems/commit/a672e7555c1d04abfd07d896fcd90b147d4aa984 anyways.

Fixes #5160.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
