### PR TITLE
Fix crash when when no platform specific matches exist and show a proper error

### DIFF
--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -360,8 +360,7 @@ module Bundler
             o << SharedHelpers.pretty_dependency(conflict.requirement)
             o << "'" unless metadata_requirement
             if conflict.requirement_trees.first.size > 1
-              o << ", which is required by "
-              o << "gem '#{SharedHelpers.pretty_dependency(conflict.requirement_trees.first[-2])}',"
+              o << ", which is required by gem '#{SharedHelpers.pretty_dependency(conflict.requirement_trees.first[-2])}',"
             end
             o << " "
 

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -287,7 +287,12 @@ module Bundler
       end
 
       message = String.new("Could not find gem '#{requirement_label}'#{extra_message} in #{source}#{cache_message}.\n")
-      message << "The source contains the following gems matching '#{matching_part}': #{specs.map(&:full_name).join(", ")}" if specs.any?
+
+      if specs.any?
+        message << "\nThe source contains the following gems matching '#{matching_part}':\n"
+        message << specs.map {|s| "  * #{s.full_name}" }.join("\n")
+      end
+
       message
     end
 

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -264,28 +264,16 @@ module Bundler
         else
           source = source_for(name)
           specs = source.specs.search(name)
-          versions_with_platforms = specs.map {|s| [s.version, s.platform] }
           cache_message = begin
                               " or in gems cached in #{Bundler.settings.app_cache_path}" if Bundler.app_cache.exist?
                             rescue GemfileNotFound
                               nil
                             end
           message = String.new("Could not find gem '#{SharedHelpers.pretty_dependency(requirement)}' in #{source}#{cache_message}.\n")
-          message << "The source contains the following versions of '#{name}': #{formatted_versions_with_platforms(versions_with_platforms)}" if versions_with_platforms.any?
+          message << "The source contains the following gems matching '#{name}': #{specs.map(&:full_name).join(", ")}" if specs.any?
         end
         raise GemNotFound, message
       end
-    end
-
-    def formatted_versions_with_platforms(versions_with_platforms)
-      version_platform_strs = versions_with_platforms.map do |vwp|
-        version = vwp.first
-        platform = vwp.last
-        version_platform_str = String.new(version.to_s)
-        version_platform_str << " #{platform}" unless platform.nil? || platform == Gem::Platform::RUBY
-        version_platform_str
-      end
-      version_platform_strs.join(", ")
     end
 
     def version_conflict_message(e)

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -134,6 +134,7 @@ module Bundler
           end
           nested.reduce([]) do |groups, (version, specs)|
             next groups if locked_requirement && !locked_requirement.satisfied_by?(version)
+            next groups unless specs.any? {|spec| spec.match_platform(platform) }
 
             specs_by_platform = Hash.new do |current_specs, current_platform|
               current_specs[current_platform] = select_best_platform_match(specs, current_platform)
@@ -145,7 +146,7 @@ module Bundler
             next groups if @resolving_only_for_ruby
 
             spec_group = SpecGroup.create_for(specs_by_platform, @platforms, platform)
-            groups << spec_group if spec_group
+            groups << spec_group
 
             groups
           end

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -867,7 +867,7 @@ RSpec.describe "bundle exec" do
       let(:expected) { "" }
       let(:expected_err) { <<-EOS.strip }
 Could not find gem 'rack (= 2)' in locally installed gems.
-The source contains the following versions of 'rack': 0.9.1, 1.0.0
+The source contains the following gems matching 'rack': rack-0.9.1, rack-1.0.0
 Run `bundle install` to install missing gems.
       EOS
 
@@ -894,7 +894,7 @@ Run `bundle install` to install missing gems.
       let(:expected) { "" }
       let(:expected_err) { <<-EOS.strip }
 Could not find gem 'rack (= 2)' in locally installed gems.
-The source contains the following versions of 'rack': 1.0.0
+The source contains the following gems matching 'rack': rack-1.0.0
 Run `bundle install` to install missing gems.
       EOS
 

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -867,7 +867,10 @@ RSpec.describe "bundle exec" do
       let(:expected) { "" }
       let(:expected_err) { <<-EOS.strip }
 Could not find gem 'rack (= 2)' in locally installed gems.
-The source contains the following gems matching 'rack': rack-0.9.1, rack-1.0.0
+
+The source contains the following gems matching 'rack':
+  * rack-0.9.1
+  * rack-1.0.0
 Run `bundle install` to install missing gems.
       EOS
 
@@ -894,7 +897,9 @@ Run `bundle install` to install missing gems.
       let(:expected) { "" }
       let(:expected_err) { <<-EOS.strip }
 Could not find gem 'rack (= 2)' in locally installed gems.
-The source contains the following gems matching 'rack': rack-1.0.0
+
+The source contains the following gems matching 'rack':
+  * rack-1.0.0
 Run `bundle install` to install missing gems.
       EOS
 

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "bundle install with git sources" do
         gem "foo", "1.1", :git => "#{lib_path("foo-1.0")}"
       G
 
-      expect(err).to include("The source contains the following gems matching 'foo': foo-1.0")
+      expect(err).to include("The source contains the following gems matching 'foo':\n  * foo-1.0")
     end
 
     it "complains with version and platform if pinned specs don't exist in the git repo" do
@@ -106,7 +106,7 @@ RSpec.describe "bundle install with git sources" do
         end
       G
 
-      expect(err).to include("The source contains the following gems matching 'only_java': only_java-1.0-java")
+      expect(err).to include("The source contains the following gems matching 'only_java':\n  * only_java-1.0-java")
     end
 
     it "complains with multiple versions and platforms if pinned specs don't exist in the git repo" do
@@ -128,7 +128,7 @@ RSpec.describe "bundle install with git sources" do
         end
       G
 
-      expect(err).to include("The source contains the following gems matching 'only_java': only_java-1.0-java, only_java-1.1-java")
+      expect(err).to include("The source contains the following gems matching 'only_java':\n  * only_java-1.0-java\n  * only_java-1.1-java")
     end
 
     it "still works after moving the application directory" do

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "bundle install with git sources" do
         gem "foo", "1.1", :git => "#{lib_path("foo-1.0")}"
       G
 
-      expect(err).to include("The source contains the following versions of 'foo': 1.0")
+      expect(err).to include("The source contains the following gems matching 'foo': foo-1.0")
     end
 
     it "complains with version and platform if pinned specs don't exist in the git repo" do
@@ -106,7 +106,7 @@ RSpec.describe "bundle install with git sources" do
         end
       G
 
-      expect(err).to include("The source contains the following versions of 'only_java': 1.0 java")
+      expect(err).to include("The source contains the following gems matching 'only_java': only_java-1.0-java")
     end
 
     it "complains with multiple versions and platforms if pinned specs don't exist in the git repo" do
@@ -128,7 +128,7 @@ RSpec.describe "bundle install with git sources" do
         end
       G
 
-      expect(err).to include("The source contains the following versions of 'only_java': 1.0 java, 1.1 java")
+      expect(err).to include("The source contains the following gems matching 'only_java': only_java-1.0-java, only_java-1.1-java")
     end
 
     it "still works after moving the application directory" do

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -298,8 +298,13 @@ RSpec.describe "bundle install with specific platforms" do
       bundle "install", :raise_on_error => false
     end
 
-    expect(err).to include("Could not find gem 'sorbet-static (= 0.5.6433) arm64-darwin-21' in rubygems repository #{file_uri_for(gem_repo2)}/ or installed locally.")
-    expect(err).to include("The source contains the following gems matching 'sorbet-static (= 0.5.6433)': sorbet-static-0.5.6433-universal-darwin-20, sorbet-static-0.5.6433-x86_64-linux")
+    expect(err).to include <<~ERROR.rstrip
+      Could not find gem 'sorbet-static (= 0.5.6433) arm64-darwin-21' in rubygems repository #{file_uri_for(gem_repo2)}/ or installed locally.
+
+      The source contains the following gems matching 'sorbet-static (= 0.5.6433)':
+        * sorbet-static-0.5.6433-universal-darwin-20
+        * sorbet-static-0.5.6433-x86_64-linux
+    ERROR
   end
 
   it "does not resolve if the current platform does not match any of available platform specific variants for a transitive dependency" do
@@ -319,8 +324,13 @@ RSpec.describe "bundle install with specific platforms" do
       bundle "install", :raise_on_error => false
     end
 
-    expect(err).to include("Could not find gem 'sorbet-static (= 0.5.6433) arm64-darwin-21', which is required by gem 'sorbet (= 0.5.6433)', in rubygems repository #{file_uri_for(gem_repo2)}/ or installed locally.")
-    expect(err).to include("The source contains the following gems matching 'sorbet-static (= 0.5.6433)': sorbet-static-0.5.6433-universal-darwin-20, sorbet-static-0.5.6433-x86_64-linux")
+    expect(err).to include <<~ERROR.rstrip
+      Could not find gem 'sorbet-static (= 0.5.6433) arm64-darwin-21', which is required by gem 'sorbet (= 0.5.6433)', in rubygems repository #{file_uri_for(gem_repo2)}/ or installed locally.
+
+      The source contains the following gems matching 'sorbet-static (= 0.5.6433)':
+        * sorbet-static-0.5.6433-universal-darwin-20
+        * sorbet-static-0.5.6433-x86_64-linux
+    ERROR
   end
 
   private

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -282,6 +282,26 @@ RSpec.describe "bundle install with specific platforms" do
     bundle "install --verbose"
   end
 
+  it "does not resolve if the current platform does not match any of available platform specific variants for a top level dependency" do
+    build_repo2 do
+      build_gem("sorbet-static", "0.5.6433") {|s| s.platform = "x86_64-linux" }
+      build_gem("sorbet-static", "0.5.6433") {|s| s.platform = "universal-darwin-20" }
+    end
+
+    gemfile <<~G
+      source "#{file_uri_for(gem_repo2)}"
+
+      gem "sorbet-static", "0.5.6433"
+    G
+
+    simulate_platform "arm64-darwin-21" do
+      bundle "install", :raise_on_error => false
+    end
+
+    expect(err).to include("Could not find gem 'sorbet-static (= 0.5.6433) arm64-darwin-21' in rubygems repository #{file_uri_for(gem_repo2)}/ or installed locally.")
+    expect(err).to include("The source contains the following gems matching 'sorbet-static (= 0.5.6433)': sorbet-static-0.5.6433-universal-darwin-20, sorbet-static-0.5.6433-x86_64-linux")
+  end
+
   private
 
   def setup_multiplatform_gem


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When a gem only has platform specific variants and none of them matches the current platform, the resolver would incorrectly allow this case, and we would get an error later down the line since that specific gem can't be materialized.

See https://github.com/rubygems/rubygems/issues/5088#issuecomment-993472000.

## What is your fix for the problem, implemented in this PR?

My fix is to properly detect this case and don't consider any candidates suffering from this problem, resulting in a proper resolution error rather than a crash.

Also took the chance to improve the error message in this case.

So, now, instead of the previous output with a runtime crash and the bug report template, we get an informative message, like this

```console
$ bundle install
Fetching gem metadata from https://rubygems.org/........
Resolving dependencies...
Bundler could not find compatible versions for gem "sorbet-static":
  In Gemfile:
    sorbet (= 0.5.6433) was resolved to 0.5.6433, which depends on
      sorbet-static (= 0.5.6433)

Could not find gem 'sorbet-static (= 0.5.6433) arm64-darwin-21', which is required by gem 'sorbet (= 0.5.6433)', in rubygems repository https://rubygems.org/ or installed locally.

The source contains the following gems matching 'sorbet-static (= 0.5.6433)':
  * sorbet-static-0.5.6433-java
  * sorbet-static-0.5.6433-universal-darwin-14
  * sorbet-static-0.5.6433-universal-darwin-15
  * sorbet-static-0.5.6433-universal-darwin-16
  * sorbet-static-0.5.6433-universal-darwin-17
  * sorbet-static-0.5.6433-universal-darwin-18
  * sorbet-static-0.5.6433-universal-darwin-19
  * sorbet-static-0.5.6433-universal-darwin-20
  * sorbet-static-0.5.6433-x86_64-linux
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
