### PR TITLE
Use `Fiddle` in `bundle doctor` to check for dynamic library presence

### DIFF
--- a/bundler/spec/commands/doctor_spec.rb
+++ b/bundler/spec/commands/doctor_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe "bundle doctor" do
       doctor = Bundler::CLI::Doctor.new({})
       expect(doctor).to receive(:bundles_for_gem).exactly(2).times.and_return ["/path/to/rack/rack.bundle"]
       expect(doctor).to receive(:dylibs).exactly(2).times.and_return ["/usr/lib/libSystem.dylib"]
-      allow(File).to receive(:exist?).with("/usr/lib/libSystem.dylib").and_return(true)
-      expect { doctor.run }.not_to(raise_error, @stdout.string)
+      allow(Fiddle).to receive(:dlopen).with("/usr/lib/libSystem.dylib").and_return(true)
+      expect { doctor.run }.not_to raise_error
       expect(@stdout.string).to be_empty
     end
 
@@ -58,7 +58,7 @@ RSpec.describe "bundle doctor" do
       doctor = Bundler::CLI::Doctor.new({})
       expect(doctor).to receive(:bundles_for_gem).exactly(2).times.and_return ["/path/to/rack/rack.bundle"]
       expect(doctor).to receive(:dylibs).exactly(2).times.and_return ["/usr/local/opt/icu4c/lib/libicui18n.57.1.dylib"]
-      allow(File).to receive(:exist?).with("/usr/local/opt/icu4c/lib/libicui18n.57.1.dylib").and_return(false)
+      allow(Fiddle).to receive(:dlopen).with("/usr/local/opt/icu4c/lib/libicui18n.57.1.dylib").and_raise(Fiddle::DLError)
       expect { doctor.run }.to raise_error(Bundler::ProductionError, strip_whitespace(<<-E).strip), @stdout.string
         The following gems are missing OS dependencies:
          * bundler: /usr/local/opt/icu4c/lib/libicui18n.57.1.dylib


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

#5114

In the `doctor` command we use `File.exists?` to check if the dynamic library presents. But in macOS Big Sur 11.0.1 a built-in dynamic linker cache of all system-provided libraries was introduced. So the dynamic libraries are stored not on the filesystem but in the cache.

## What is your fix for the problem, implemented in this PR?

I replaced the `File.exists?` with the `Fiddler.dlopen` as it was proposed in the initial issue.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
