### PR TITLE
Print warning when running Bundler on potentially problematic RubyGems & Ruby combinations

### DIFF
--- a/bundler/exe/bundle
+++ b/bundler/exe/bundle
@@ -18,6 +18,15 @@ end
 # Workaround for non-activated bundler spec due to missing https://github.com/rubygems/rubygems/commit/4e306d7bcdee924b8d80ca9db6125aa59ee4e5a3
 gem "bundler", Bundler::VERSION if Gem.rubygems_version < Gem::Version.new("2.6.2")
 
+if Gem.rubygems_version < Gem::Version.new("3.2.3") && Gem.ruby_version < Gem::Version.new("2.6.a") && !ENV["BUNDLER_NO_OLD_RUBYGEMS_WARNING"]
+  Bundler.ui.warn \
+    "Your RubyGems version (#{Gem::VERSION})) has a bug that prevents " \
+    "`required_ruby_version` from working for Bundler. Any scripts that use " \
+    "`gem install bundler` will break as soon as Bundler drops support for " \
+    "your Ruby version. Please upgrade RubyGems to avoid future breakage " \
+    "and silence this warning by running `gem update --system 3.2.3`"
+end
+
 if File.exist?(base_path)
   require_relative "../lib/bundler/friendly_errors"
 else

--- a/bundler/exe/bundle
+++ b/bundler/exe/bundle
@@ -18,16 +18,6 @@ end
 # Workaround for non-activated bundler spec due to missing https://github.com/rubygems/rubygems/commit/4e306d7bcdee924b8d80ca9db6125aa59ee4e5a3
 gem "bundler", Bundler::VERSION if Gem.rubygems_version < Gem::Version.new("2.6.2")
 
-# Check if an older version of bundler is installed
-$LOAD_PATH.each do |path|
-  next unless path =~ %r{/bundler-0\.(\d+)} && $1.to_i < 9
-  err = String.new
-  err << "Looks like you have a version of bundler that's older than 0.9.\n"
-  err << "Please remove your old versions.\n"
-  err << "An easy way to do this is by running `gem cleanup bundler`."
-  abort(err)
-end
-
 if File.exist?(base_path)
   require_relative "../lib/bundler/friendly_errors"
 else

--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -239,7 +239,7 @@ module Bundler
       current  = File.expand_path(SharedHelpers.pwd).tap{|x| x.untaint if RUBY_VERSION < "2.7" }
 
       until !File.directory?(current) || current == previous
-        if ENV["BUNDLE_SPEC_RUN"]
+        if ENV["BUNDLER_SPEC_RUN"]
           # avoid stepping above the tmp directory when testing
           gemspec = if ENV["GEM_COMMAND"]
             # for Ruby Core

--- a/bundler/spec/commands/config_spec.rb
+++ b/bundler/spec/commands/config_spec.rb
@@ -425,27 +425,27 @@ E
 
   describe "subcommands" do
     it "list" do
-      bundle "config list"
-      expect(out).to eq "Settings are listed in order of priority. The top value will be used.\nspec_run\nSet via BUNDLE_SPEC_RUN: \"true\""
+      bundle "config list", :env => { "BUNDLE_FOO" => "bar" }
+      expect(out).to eq "Settings are listed in order of priority. The top value will be used.\nfoo\nSet via BUNDLE_FOO: \"bar\""
 
-      bundle "config list", :parseable => true
-      expect(out).to eq "spec_run=true"
+      bundle "config list", :env => { "BUNDLE_FOO" => "bar" }, :parseable => true
+      expect(out).to eq "foo=bar"
     end
 
     it "list with credentials" do
       bundle "config list", :env => { "BUNDLE_GEMS__MYSERVER__COM" => "user:password" }
-      expect(out).to eq "Settings are listed in order of priority. The top value will be used.\ngems.myserver.com\nSet via BUNDLE_GEMS__MYSERVER__COM: \"user:[REDACTED]\"\n\nspec_run\nSet via BUNDLE_SPEC_RUN: \"true\""
+      expect(out).to eq "Settings are listed in order of priority. The top value will be used.\ngems.myserver.com\nSet via BUNDLE_GEMS__MYSERVER__COM: \"user:[REDACTED]\""
 
       bundle "config list", :parseable => true, :env => { "BUNDLE_GEMS__MYSERVER__COM" => "user:password" }
-      expect(out).to eq "gems.myserver.com=user:password\nspec_run=true"
+      expect(out).to eq "gems.myserver.com=user:password"
     end
 
     it "list with API token credentials" do
       bundle "config list", :env => { "BUNDLE_GEMS__MYSERVER__COM" => "api_token:x-oauth-basic" }
-      expect(out).to eq "Settings are listed in order of priority. The top value will be used.\ngems.myserver.com\nSet via BUNDLE_GEMS__MYSERVER__COM: \"[REDACTED]:x-oauth-basic\"\n\nspec_run\nSet via BUNDLE_SPEC_RUN: \"true\""
+      expect(out).to eq "Settings are listed in order of priority. The top value will be used.\ngems.myserver.com\nSet via BUNDLE_GEMS__MYSERVER__COM: \"[REDACTED]:x-oauth-basic\""
 
       bundle "config list", :parseable => true, :env => { "BUNDLE_GEMS__MYSERVER__COM" => "api_token:x-oauth-basic" }
-      expect(out).to eq "gems.myserver.com=api_token:x-oauth-basic\nspec_run=true"
+      expect(out).to eq "gems.myserver.com=api_token:x-oauth-basic"
     end
 
     it "get" do

--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -72,6 +72,7 @@ RSpec.configure do |config|
     require_relative "support/rubygems_ext"
     Spec::Rubygems.test_setup
     ENV["BUNDLER_SPEC_RUN"] = "true"
+    ENV["BUNDLER_NO_OLD_RUBYGEMS_WARNING"] = "true"
     ENV["BUNDLE_USER_CONFIG"] = ENV["BUNDLE_USER_CACHE"] = ENV["BUNDLE_USER_PLUGIN"] = nil
     ENV["RUBYGEMS_GEMDEPS"] = nil
     ENV["XDG_CONFIG_HOME"] = nil

--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -71,7 +71,7 @@ RSpec.configure do |config|
 
     require_relative "support/rubygems_ext"
     Spec::Rubygems.test_setup
-    ENV["BUNDLE_SPEC_RUN"] = "true"
+    ENV["BUNDLER_SPEC_RUN"] = "true"
     ENV["BUNDLE_USER_CONFIG"] = ENV["BUNDLE_USER_CACHE"] = ENV["BUNDLE_USER_PLUGIN"] = nil
     ENV["RUBYGEMS_GEMDEPS"] = nil
     ENV["XDG_CONFIG_HOME"] = nil


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Users should move on and stop using old rubies, but we shouldn't abruptly drop support in `bundler`. Although doing this is generally fine to do for gems on minor versions, bundler is a bit special, because many scripts include `gem install bundler` commands, and old rubygems versions (which old rubies use by default) didn't have the ability to figure out that the latest bundler does not support the current ruby, so those `gem install bundler` commands will start failing as soon as a version of `bundler` no longer supporting old rubies is released.

## What is your fix for the problem, implemented in this PR?

In order to make sure people get ready for this, start by printing a warning when `bundler` is run on old rubies, and explain which steps users should be taking.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
