### PR TITLE
Error tracing should be printed to stderr

### DIFF
--- a/bundler/lib/bundler/ui/shell.rb
+++ b/bundler/lib/bundler/ui/shell.rb
@@ -81,7 +81,7 @@ module Bundler
       def trace(e, newline = nil, force = false)
         return unless debug? || force
         msg = "#{e.class}: #{e.message}\n#{e.backtrace.join("\n  ")}"
-        tell_me(msg, nil, newline)
+        tell_err(msg, nil, newline)
       end
 
       def silence(&blk)

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -922,7 +922,8 @@ The checksum of /versions does not match the checksum provided by the server! So
             Gem::Dependency.new("activerecord", "= 2.3.2"),
             Gem::Dependency.new("actionmailer", "= 2.3.2"),
             Gem::Dependency.new("activeresource", "= 2.3.2")]
-    expect(out).to include(<<-E.strip).and include("rails-2.3.2 from rubygems remote at #{source_uri}/ has either corrupted API or lockfile dependencies")
+    expect(out).to include("rails-2.3.2 from rubygems remote at #{source_uri}/ has either corrupted API or lockfile dependencies")
+    expect(err).to include(<<-E.strip)
 Bundler::APIResponseMismatchError: Downloading rails-2.3.2 revealed dependencies not in the API or the lockfile (#{deps.map(&:to_s).join(", ")}).
 Either installing with `--full-index` or running `bundle update rails` should fix the problem.
     E

--- a/bundler/spec/realworld/mirror_probe_spec.rb
+++ b/bundler/spec/realworld/mirror_probe_spec.rb
@@ -89,7 +89,10 @@ RSpec.describe "fetching dependencies with a not available mirror", :realworld =
       bundle :install, :artifice => nil, :raise_on_error => false
 
       expect(out).to include "Fetching source index from #{mirror}/"
-      expect(err.split("\n").count).to eq(4)
+      expect(err).to include "Retrying fetcher due to error (2/4): Bundler::HTTPError Could not fetch specs from #{mirror}/ due to underlying error <Errno::ECONNREFUSED: Failed to open TCP connection to #{host}:#{@mirror_port} (Connection refused - connect(2)"
+      expect(err).to include "Retrying fetcher due to error (3/4): Bundler::HTTPError Could not fetch specs from #{mirror}/ due to underlying error <Errno::ECONNREFUSED: Failed to open TCP connection to #{host}:#{@mirror_port} (Connection refused - connect(2)"
+      expect(err).to include "Retrying fetcher due to error (4/4): Bundler::HTTPError Could not fetch specs from #{mirror}/ due to underlying error <Errno::ECONNREFUSED: Failed to open TCP connection to #{host}:#{@mirror_port} (Connection refused - connect(2)"
+      expect(err).to include "Could not fetch specs from #{mirror}/ due to underlying error <Errno::ECONNREFUSED: Failed to open TCP connection to #{host}:#{@mirror_port} (Connection refused - connect(2)"
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When writing a spec checking for some error messages, the error message couldn't be found on stderr.

## What is your fix for the problem, implemented in this PR?

When tracing exceptions, print to stderr.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
