### PR TITLE
Set `BUNDLER_VERSION` when `bundle _<version>_` is passed

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -768,7 +768,7 @@ str = ARGV.first
 if str
   str = str.b[/\\A_(.*)_\\z/, 1]
   if str and Gem::Version.correct?(str)
-    version = str
+    #{explicit_version_requirement(spec.name)}
     ARGV.shift
   end
 end
@@ -788,6 +788,16 @@ TEXT
     <<-TEXT
 
 Gem.use_gemdeps
+TEXT
+  end
+
+  def explicit_version_requirement(name)
+    code = "version = str"
+    return code unless name == "bundler"
+
+    code += <<-TEXT
+
+    ENV['BUNDLER_VERSION'] = str
 TEXT
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This is a small enhancement in rubygems needed to keep supporting choosing specific versions of `bundler` through `bundle _<version>_` while being able to add add support for installing and re-execing to the `BUNDLED WITH` version when `bundle install` is run with a lockfile.

## What is your fix for the problem, implemented in this PR?

Any implementation of the above feature in bundler needs to respect the escape hatch of using `bundle _<version>`, in which case, not installation or re-execution should happen. However, since binstubs completely remove the `_<version>_` argument after processing it, `bundler` has no way to figure out whether it was originally passed or not.

To fix this issue, set the `BUNDLER_VERSION` environment variable when `bundle _<version>_` is used, which can be easily checked form the `bundler` side.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
