### PR TITLE
Remove hard errors when matching major bundler not found

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -272,9 +272,6 @@ module Gem
 
     unless spec = specs.first
       msg = "can't find gem #{dep} with executable #{exec_name}"
-      if dep.filters_bundler? && bundler_message = Gem::BundlerVersionFinder.missing_version_message
-        msg = bundler_message
-      end
       raise Gem::GemNotFoundException, msg
     end
 

--- a/lib/rubygems/bundler_version_finder.rb
+++ b/lib/rubygems/bundler_version_finder.rb
@@ -2,48 +2,18 @@
 
 module Gem::BundlerVersionFinder
   def self.bundler_version
-    version, _ = bundler_version_with_reason
+    v = ENV["BUNDLER_VERSION"]
 
-    return unless version
+    v ||= bundle_update_bundler_version
+    return if v == true
 
-    Gem::Version.new(version)
+    v ||= lockfile_version
+    return unless v
+
+    Gem::Version.new(v)
   end
 
-  def self.bundler_version_with_reason
-    if v = ENV["BUNDLER_VERSION"]
-      return [v, "`$BUNDLER_VERSION`"]
-    end
-    if v = bundle_update_bundler_version
-      return if v == true
-      return [v, "`bundle update --bundler`"]
-    end
-    v, lockfile = lockfile_version
-    if v
-      return [v, "your #{lockfile}"]
-    end
-  end
-
-  def self.missing_version_message
-    return unless vr = bundler_version_with_reason
-    <<-EOS
-Could not find 'bundler' (#{vr.first}) required by #{vr.last}.
-To update to the latest version installed on your system, run `bundle update --bundler`.
-To install the missing version, run `gem install bundler:#{vr.first}`
-    EOS
-  end
-
-  def self.compatible?(spec)
-    return true unless spec.name == "bundler".freeze
-    return true unless bundler_version = self.bundler_version
-
-    spec.version.segments.first == bundler_version.segments.first
-  end
-
-  def self.filter!(specs)
-    return unless bundler_version = self.bundler_version
-
-    specs.reject! {|spec| spec.version.segments.first != bundler_version.segments.first }
-
+  def self.prioritize!(specs)
     exact_match_index = specs.find_index {|spec| spec.version == bundler_version }
     return unless exact_match_index
 
@@ -68,12 +38,10 @@ To install the missing version, run `gem install bundler:#{vr.first}`
   private_class_method :bundle_update_bundler_version
 
   def self.lockfile_version
-    return unless lockfile = lockfile_contents
-    lockfile, contents = lockfile
-    lockfile ||= "lockfile"
+    return unless contents = lockfile_contents
     regexp = /\n\nBUNDLED WITH\n\s{2,}(#{Gem::Version::VERSION_PATTERN})\n/
     return unless contents =~ regexp
-    [$1, lockfile]
+    $1
   end
   private_class_method :lockfile_version
 
@@ -103,7 +71,7 @@ To install the missing version, run `gem install bundler:#{vr.first}`
 
     return unless File.file?(lockfile)
 
-    [lockfile, File.read(lockfile)]
+    File.read(lockfile)
   end
   private_class_method :lockfile_contents
 end

--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -325,11 +325,11 @@ class Gem::Dependency
     active = matches.find {|spec| spec.activated? }
     return active if active
 
-    return matches.first if prerelease?
-
-    # Move prereleases to the end of the list for >= 0 requirements
-    pre, matches = matches.partition {|spec| spec.version.prerelease? }
-    matches += pre if requirement == Gem::Requirement.default
+    unless prerelease?
+      # Move prereleases to the end of the list for >= 0 requirements
+      pre, matches = matches.partition {|spec| spec.version.prerelease? }
+      matches += pre if requirement == Gem::Requirement.default
+    end
 
     matches.first
   end

--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -277,7 +277,7 @@ class Gem::Dependency
       requirement.satisfied_by?(spec.version) && env_req.satisfied_by?(spec.version)
     end.map(&:to_spec)
 
-    Gem::BundlerVersionFinder.filter!(matches) if filters_bundler?
+    Gem::BundlerVersionFinder.prioritize!(matches) if prioritizes_bundler?
 
     if platform_only
       matches.reject! do |spec|
@@ -295,7 +295,7 @@ class Gem::Dependency
     @requirement.specific?
   end
 
-  def filters_bundler?
+  def prioritizes_bundler?
     name == "bundler".freeze && !specific?
   end
 

--- a/lib/rubygems/errors.rb
+++ b/lib/rubygems/errors.rb
@@ -59,9 +59,6 @@ module Gem
     private
 
     def build_message
-      if name == "bundler" && message = Gem::BundlerVersionFinder.missing_version_message
-        return message
-      end
       names = specs.map(&:full_name)
       "Could not find '#{name}' (#{requirement}) - did find: [#{names.join ','}]\n"
     end

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -995,7 +995,6 @@ class Gem::Specification < Gem::BasicSpecification
   def self.find_by_path(path)
     path = path.dup.freeze
     spec = @@spec_with_requirable_file[path] ||= (stubs.find do |s|
-      next unless Gem::BundlerVersionFinder.compatible?(s)
       s.contains_requirable_file? path
     end || NOT_FOUND)
     spec.to_spec
@@ -1008,7 +1007,6 @@ class Gem::Specification < Gem::BasicSpecification
   def self.find_inactive_by_path(path)
     stub = stubs.find do |s|
       next if s.activated?
-      next unless Gem::BundlerVersionFinder.compatible?(s)
       s.contains_requirable_file? path
     end
     stub && stub.to_spec

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -354,41 +354,6 @@ class TestGem < Gem::TestCase
     assert status.success?, output
   end
 
-  def test_activate_bin_path_gives_proper_error_for_bundler
-    bundler = util_spec 'bundler', '2' do |s|
-      s.executables = ['bundle']
-    end
-
-    install_specs bundler
-
-    File.open("Gemfile.lock", "w") do |f|
-      f.write <<-L.gsub(/ {8}/, "")
-        GEM
-          remote: https://rubygems.org/
-          specs:
-
-        PLATFORMS
-          ruby
-
-        DEPENDENCIES
-
-        BUNDLED WITH
-          9999
-      L
-    end
-
-    File.open("Gemfile", "w") {|f| f.puts('source "https://rubygems.org"') }
-
-    e = assert_raise Gem::GemNotFoundException do
-      load Gem.activate_bin_path("bundler", "bundle", ">= 0.a")
-    end
-
-    assert_includes e.message, "Could not find 'bundler' (9999) required by your #{File.expand_path("Gemfile.lock")}."
-    assert_includes e.message, "To update to the latest version installed on your system, run `bundle update --bundler`."
-    assert_includes e.message, "To install the missing version, run `gem install bundler:9999`"
-    refute_includes e.message, "can't find gem bundler (>= 0.a) with executable bundle"
-  end
-
   def test_activate_bin_path_selects_exact_bundler_version_if_present
     bundler_latest = util_spec 'bundler', '2.0.1' do |s|
       s.executables = ['bundle']

--- a/test/rubygems/test_gem_bundler_version_finder.rb
+++ b/test/rubygems/test_gem_bundler_version_finder.rb
@@ -119,28 +119,28 @@ class TestGemBundlerVersionFinder < Gem::TestCase
     versions = %w[1 1.0 1.0.1.1 2 2.a 2.0 2.1.1 3 3.a 3.0 3.1.1]
     specs = versions.map {|v| util_spec("bundler", v) }
 
-    assert_equal %w[1 1.0 1.0.1.1 2 2.a 2.0 2.1.1 3 3.a 3.0 3.1.1], util_filter_specs(specs).map(&:version).map(&:to_s)
+    assert_equal %w[1 1.0 1.0.1.1 2 2.a 2.0 2.1.1 3 3.a 3.0 3.1.1], util_filter_specs(specs)
 
     bvf.stub(:bundler_version, v("2.1.1.1")) do
-      assert_equal %w[2 2.a 2.0 2.1.1], util_filter_specs(specs).map(&:version).map(&:to_s)
+      assert_equal %w[2 2.a 2.0 2.1.1], util_filter_specs(specs)
     end
     bvf.stub(:bundler_version, v("1.1.1.1")) do
-      assert_equal %w[1 1.0 1.0.1.1], util_filter_specs(specs).map(&:version).map(&:to_s)
+      assert_equal %w[1 1.0 1.0.1.1], util_filter_specs(specs)
     end
     bvf.stub(:bundler_version, v("1")) do
-      assert_equal %w[1 1.0 1.0.1.1], util_filter_specs(specs).map(&:version).map(&:to_s)
+      assert_equal %w[1 1.0 1.0.1.1], util_filter_specs(specs)
     end
     bvf.stub(:bundler_version, v("2.a")) do
-      assert_equal %w[2.a 2 2.0 2.1.1], util_filter_specs(specs).map(&:version).map(&:to_s)
+      assert_equal %w[2.a 2 2.0 2.1.1], util_filter_specs(specs)
     end
     bvf.stub(:bundler_version, v("3")) do
-      assert_equal %w[3 3.a 3.0 3.1.1], util_filter_specs(specs).map(&:version).map(&:to_s)
+      assert_equal %w[3 3.a 3.0 3.1.1], util_filter_specs(specs)
     end
   end
 
   def util_filter_specs(specs)
     specs = specs.dup
     bvf.filter!(specs)
-    specs
+    specs.map(&:version).map(&:to_s)
   end
 end

--- a/test/rubygems/test_gem_bundler_version_finder.rb
+++ b/test/rubygems/test_gem_bundler_version_finder.rb
@@ -48,30 +48,31 @@ class TestGemBundlerVersionFinder < Gem::TestCase
   end
 
   def test_bundler_version_with_lockfile
-    bvf.stub(:lockfile_contents, [nil, ""]) do
+    bvf.stub(:lockfile_contents, "") do
       assert_nil bvf.bundler_version
     end
-    bvf.stub(:lockfile_contents, [nil, "\n\nBUNDLED WITH\n   1.1.1.1\n"]) do
+    bvf.stub(:lockfile_contents, "\n\nBUNDLED WITH\n   1.1.1.1\n") do
       assert_equal v("1.1.1.1"), bvf.bundler_version
     end
-    bvf.stub(:lockfile_contents, [nil, "\n\nBUNDLED WITH\n   fjdkslfjdkslfjsldk\n"]) do
+    bvf.stub(:lockfile_contents, "\n\nBUNDLED WITH\n   fjdkslfjdkslfjsldk\n") do
       assert_nil bvf.bundler_version
     end
   end
 
-  def test_bundler_version_with_reason
-    assert_nil bvf.bundler_version_with_reason
-    bvf.stub(:lockfile_contents, [nil, "\n\nBUNDLED WITH\n   1.1.1.1\n"]) do
-      assert_equal ["1.1.1.1", "your lockfile"], bvf.bundler_version_with_reason
+  def test_bundler_version
+    assert_nil bvf.bundler_version
+    bvf.stub(:lockfile_contents, "\n\nBUNDLED WITH\n   1.1.1.1\n") do
+      assert_equal "1.1.1.1", bvf.bundler_version.to_s
 
       $0 = "bundle"
       ARGV.replace %w[update --bundler]
-      assert_nil bvf.bundler_version_with_reason
+      assert_nil bvf.bundler_version
+
       ARGV.replace %w[update --bundler=1.1.1.2]
-      assert_equal ["1.1.1.2", "`bundle update --bundler`"], bvf.bundler_version_with_reason
+      assert_equal "1.1.1.2",  bvf.bundler_version.to_s
 
       ENV["BUNDLER_VERSION"] = "1.1.1.3"
-      assert_equal ["1.1.1.3", "`$BUNDLER_VERSION`"], bvf.bundler_version_with_reason
+      assert_equal "1.1.1.3", bvf.bundler_version.to_s
     end
   end
 
@@ -90,57 +91,35 @@ class TestGemBundlerVersionFinder < Gem::TestCase
       Dir.chdir(orig_dir)
     end
 
-    assert_nil bvf.bundler_version_with_reason
+    assert_nil bvf.bundler_version
   end
 
-  def test_compatible
-    assert bvf.compatible?(util_spec("foo"))
-    assert bvf.compatible?(util_spec("bundler", 1.1))
-
-    bvf.stub(:bundler_version, v("1.1.1.1")) do
-      assert bvf.compatible?(util_spec("foo"))
-      assert bvf.compatible?(util_spec("bundler", "1.1.1.1"))
-      assert bvf.compatible?(util_spec("bundler", "1.1.1.a"))
-      assert bvf.compatible?(util_spec("bundler", "1.999"))
-      refute bvf.compatible?(util_spec("bundler", "2.999"))
-    end
-
-    bvf.stub(:bundler_version, v("2.1.1.1")) do
-      assert bvf.compatible?(util_spec("foo"))
-      assert bvf.compatible?(util_spec("bundler", "2.1.1.1"))
-      assert bvf.compatible?(util_spec("bundler", "2.1.1.a"))
-      assert bvf.compatible?(util_spec("bundler", "2.999"))
-      refute bvf.compatible?(util_spec("bundler", "1.999"))
-      refute bvf.compatible?(util_spec("bundler", "3.0.0"))
-    end
-  end
-
-  def test_filter
+  def test_prioritize
     versions = %w[1 1.0 1.0.1.1 2 2.a 2.0 2.1.1 3 3.a 3.0 3.1.1]
     specs = versions.map {|v| util_spec("bundler", v) }
 
-    assert_equal %w[1 1.0 1.0.1.1 2 2.a 2.0 2.1.1 3 3.a 3.0 3.1.1], util_filter_specs(specs)
+    assert_equal %w[1 1.0 1.0.1.1 2 2.a 2.0 2.1.1 3 3.a 3.0 3.1.1], util_prioritize_specs(specs)
 
     bvf.stub(:bundler_version, v("2.1.1.1")) do
-      assert_equal %w[2 2.a 2.0 2.1.1], util_filter_specs(specs)
+      assert_equal %w[1 1.0 1.0.1.1 2 2.a 2.0 2.1.1 3 3.a 3.0 3.1.1], util_prioritize_specs(specs)
     end
     bvf.stub(:bundler_version, v("1.1.1.1")) do
-      assert_equal %w[1 1.0 1.0.1.1], util_filter_specs(specs)
+      assert_equal %w[1 1.0 1.0.1.1 2 2.a 2.0 2.1.1 3 3.a 3.0 3.1.1], util_prioritize_specs(specs)
     end
     bvf.stub(:bundler_version, v("1")) do
-      assert_equal %w[1 1.0 1.0.1.1], util_filter_specs(specs)
+      assert_equal %w[1 1.0 1.0.1.1 2 2.a 2.0 2.1.1 3 3.a 3.0 3.1.1], util_prioritize_specs(specs)
     end
     bvf.stub(:bundler_version, v("2.a")) do
-      assert_equal %w[2.a 2 2.0 2.1.1], util_filter_specs(specs)
+      assert_equal %w[2.a 1 1.0 1.0.1.1 2 2.0 2.1.1 3 3.a 3.0 3.1.1], util_prioritize_specs(specs)
     end
     bvf.stub(:bundler_version, v("3")) do
-      assert_equal %w[3 3.a 3.0 3.1.1], util_filter_specs(specs)
+      assert_equal %w[3 1 1.0 1.0.1.1 2 2.a 2.0 2.1.1 3.a 3.0 3.1.1], util_prioritize_specs(specs)
     end
   end
 
-  def util_filter_specs(specs)
+  def util_prioritize_specs(specs)
     specs = specs.dup
-    bvf.filter!(specs)
+    bvf.prioritize!(specs)
     specs.map(&:version).map(&:to_s)
   end
 end

--- a/test/rubygems/test_gem_dependency.rb
+++ b/test/rubygems/test_gem_dependency.rb
@@ -358,16 +358,12 @@ class TestGemDependency < Gem::TestCase
 
     assert_equal [b, b_1], dep.to_specs
 
-    Gem::BundlerVersionFinder.stub(:bundler_version_with_reason, ["3.5", "reason"]) do
-      e = assert_raise Gem::MissingSpecVersionError do
-        dep.to_specs
-      end
-
-      assert_match "Could not find 'bundler' (3.5) required by reason.\nTo update to the latest version installed on your system, run `bundle update --bundler`.\nTo install the missing version, run `gem install bundler:3.5`\n", e.message
+    Gem::BundlerVersionFinder.stub(:bundler_version, Gem::Version.new("1")) do
+      assert_equal [b_1, b], dep.to_specs
     end
 
-    Gem::BundlerVersionFinder.stub(:bundler_version_with_reason, ["2.0.0.pre.1", "reason"]) do
-      assert_equal [b], dep.to_specs
+    Gem::BundlerVersionFinder.stub(:bundler_version, Gem::Version.new("2.0.0.pre.1")) do
+      assert_equal [b, b_1], dep.to_specs
     end
   end
 

--- a/test/rubygems/test_kernel.rb
+++ b/test/rubygems/test_kernel.rb
@@ -117,20 +117,8 @@ class TestKernel < Gem::TestCase
     assert $:.any? {|p| %r{bundler-1/lib} =~ p }
   end
 
-  def test_gem_bundler_missing_bundler_version
-    Gem::BundlerVersionFinder.stub(:bundler_version_with_reason, ["55", "reason"]) do
-      quick_gem 'bundler', '1'
-      quick_gem 'bundler', '2.a'
-
-      e = assert_raise Gem::MissingSpecVersionError do
-        gem('bundler')
-      end
-      assert_match "Could not find 'bundler' (55) required by reason.", e.message
-    end
-  end
-
   def test_gem_bundler_inferred_bundler_version
-    Gem::BundlerVersionFinder.stub(:bundler_version_with_reason, ["1", "reason"]) do
+    Gem::BundlerVersionFinder.stub(:bundler_version, Gem::Version.new("1")) do
       quick_gem 'bundler', '1'
       quick_gem 'bundler', '2.a'
 

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -596,31 +596,6 @@ class TestGemRequire < Gem::TestCase
     assert_empty unresolved_names
   end
 
-  def test_require_bundler_missing_bundler_version
-    Gem::BundlerVersionFinder.stub(:bundler_version_with_reason, ["55", "reason"]) do
-      b1 = util_spec('bundler', '1.999999999', nil, "lib/bundler/setup.rb")
-      b2a = util_spec('bundler', '2.a', nil, "lib/bundler/setup.rb")
-      install_specs b1, b2a
-
-      e = assert_raise Gem::MissingSpecVersionError do
-        gem('bundler')
-      end
-      assert_match "Could not find 'bundler' (55) required by reason.", e.message
-    end
-  end
-
-  def test_require_bundler_with_bundler_version
-    Gem::BundlerVersionFinder.stub(:bundler_version_with_reason, ["1", "reason"]) do
-      b1 = util_spec('bundler', '1.999999999', nil, "lib/bundler/setup.rb")
-      b2 = util_spec('bundler', '2', nil, "lib/bundler/setup.rb")
-      install_specs b1, b2
-
-      $:.clear
-      assert_require 'bundler/setup'
-      assert_equal %w[bundler-1.999999999], loaded_spec_names
-    end
-  end
-
   # uplevel is 2.5+ only
   if RUBY_VERSION >= "2.5"
     ["", "Kernel."].each do |prefix|


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since we will now have auto-installing and auto-switching to the `BUNDLED WITH` version in the lockfike, we can completely remove these hard error from RubyGems.
 
## What is your fix for the problem, implemented in this PR?

Remove all the code that we no longer need.

Fixes #2671.
Supersedes #2696.
Closes #2800.
Fixes #3275.
Fixes #3283.
Fixes #3334.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
