### PR TITLE
Improve release scripts to support releasing minors & majors

### DIFF
--- a/.changelog.yml
+++ b/.changelog.yml
@@ -31,6 +31,3 @@ patch_level_labels:
   - "rubygems: performance"
   - "rubygems: documentation"
   - "rubygems: backport"
-
-minor_level_labels:
-  - "rubygems: feature"

--- a/POLICIES.md
+++ b/POLICIES.md
@@ -55,16 +55,30 @@ smooth and no needed steps are missed.
 *   Continue with the regular release process below.
 
 
-### Steps for all releases
+### Steps for patch releases
 
 *   Confirm all PRs that you want backported are properly tagged with `rubygems:
-    <type>` labels at GitHub.
+    <type>` or `bundler: <type>` labels at GitHub.
 *   Run `rake prepare_release[<target_version>]`, create a PR and merge it
     to the stable branch once CI passes.
-*   Create and push git tag
-*   Create and push `rubygems-update` gem and tgz
-*   Publish blog post
+*   Switch to the stable branch and pull the PR just merged.
+*   Release `bundler` with `(cd bundler && bin/rake release)`.
+*   Release `rubygems` with `rake release`.
 
+### Steps for minor and major releases
+
+*   Confirm all PRs that you want listed in changelogs are properly tagged with
+    `rubygems: <type>` or `bundler: <type>` labels at GitHub.
+*   Run `rake prepare_release[<target_version>]`.
+*   Add the new stable branch `x.y` where `x.y` are the first two components of
+    the rubygems version being released to the CI workflows as an extra commit
+    on top of what the `prepare_release` task generated.
+*   Create a PR to the main branch, and merge it once CI passes.
+*   From the main branch, cut a new stable branch with `git pull && git checkout
+    -b x.y`.
+*   Push the stable branch and wait for CI to be green.
+*   Release `bundler` with `(cd bundler && bin/rake release)`.
+*   Release `rubygems` with `rake release`.
 
 ## Committer Access
 

--- a/POLICIES.md
+++ b/POLICIES.md
@@ -59,7 +59,7 @@ smooth and no needed steps are missed.
 
 *   Confirm all PRs that you want backported are properly tagged with `rubygems:
     <type>` labels at GitHub.
-*   Run `rake prepare_stable_branch[<target_version>]`, create a PR and merge it
+*   Run `rake prepare_release[<target_version>]`, create a PR and merge it
     to the stable branch once CI passes.
 *   Create and push git tag
 *   Create and push `rubygems-update` gem and tgz

--- a/POLICIES.md
+++ b/POLICIES.md
@@ -45,7 +45,7 @@ at version 2.7, so when RubyGems 2.8 is released, it will only support Ruby
 Releases of new versions should follow these steps, to ensure the process is
 smooth and no needed steps are missed.
 
-### Steps for security releases
+### Recommendations for security releases
 
 *   Obtain CVE numbers as needed from HackerOne or Red Hat.
 *   Agree on a release date with ruby-core, so patches can be backported to

--- a/Rakefile
+++ b/Rakefile
@@ -161,8 +161,8 @@ task :install_release_dependencies do
   Release.install_dependencies!
 end
 
-desc "Prepare stable branch"
-task :prepare_stable_branch, [:version] => [:install_release_dependencies] do |_t, opts|
+desc "Prepare a release"
+task :prepare_release, [:version] => [:install_release_dependencies] do |_t, opts|
   require_relative "util/release"
 
   Release.new(opts[:version] || v.to_s).prepare!

--- a/bundler/.changelog.yml
+++ b/bundler/.changelog.yml
@@ -25,6 +25,3 @@ patch_level_labels:
   - "bundler: performance"
   - "bundler: documentation"
   - "bundler: backport"
-
-minor_level_labels:
-  - "bundler: feature"

--- a/util/changelog.rb
+++ b/util/changelog.rb
@@ -56,13 +56,7 @@ class Changelog
     @version = Gem::Version.new(version)
     @file = File.expand_path(file)
     @config = YAML.load_file("#{File.dirname(file)}/.changelog.yml")
-    @level = if @version.segments[1..2] == [0, 0]
-               :major
-             elsif @version.segments[2] == 0
-               :minor
-             else
-               :patch
-             end
+    @level = @version.segments[2] != 0 ? :patch : :minor
   end
 
   def release_notes
@@ -235,8 +229,6 @@ class Changelog
   def relevant_changelog_label_mapping
     if @level == :patch
       changelog_label_mapping.slice(*patch_level_labels)
-    elsif @level == :minor
-      changelog_label_mapping.slice(*patch_level_labels + minor_level_labels)
     else
       changelog_label_mapping
     end
@@ -296,9 +288,5 @@ class Changelog
 
   def patch_level_labels
     @config["patch_level_labels"]
-  end
-
-  def minor_level_labels
-    @config["minor_level_labels"]
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since we manage changelings automatically, we have never released a minor.

## What is your fix for the problem, implemented in this PR?

Update the scripts to also handle minor and major versions.

Minor and major versions are handled similarly to patch version in regards to the changelog, but are cut directly from the main branch and don't need any cherry-picking.

Since we're actually shipping some changes that could be considered mildly incompatible, I'm not making any distinction semantically between minors and majors. The only different is the subjective assessments of how breaking and important they are.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
