### PR TITLE
Fix crash when gem used twice in Gemfile under different platforms

### DIFF
--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -364,7 +364,9 @@ RSpec.describe "bundle install with gem sources" do
     end
 
     it "throws a warning if a gem is added twice in Gemfile without version requirements" do
-      install_gemfile <<-G, :raise_on_error => false
+      build_repo2
+
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "rack"
         gem "rack"
@@ -376,7 +378,9 @@ RSpec.describe "bundle install with gem sources" do
     end
 
     it "throws a warning if a gem is added twice in Gemfile with same versions" do
-      install_gemfile <<-G, :raise_on_error => false
+      build_repo2
+
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "rack", "1.0"
         gem "rack", "1.0"

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -391,6 +391,22 @@ RSpec.describe "bundle install with gem sources" do
       expect(err).to include("While it's not a problem now, it could cause errors if you change the version of one of them later.")
     end
 
+    it "throws a warning if a gem is added twice under different platforms and does not crash when using the generated lockfile" do
+      build_repo2
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "rack", :platform => :jruby
+        gem "rack"
+      G
+
+      bundle "install"
+
+      expect(err).to include("Your Gemfile lists the gem rack (>= 0) more than once.")
+      expect(err).to include("Remove any duplicate entries and specify the gem only once.")
+      expect(err).to include("While it's not a problem now, it could cause errors if you change the version of one of them later.")
+    end
+
     it "does not throw a warning if a gem is added once in Gemfile and also inside a gemspec as a development dependency" do
       build_lib "my-gem", :path => bundled_app do |s|
         s.add_development_dependency "my-private-gem"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

A [recent refactoring](https://github.com/rubygems/rubygems/commit/afaf868b68d68aa4eb98d19a2bb520c0d69b5ed2) shipped with bundler 2.2.32 broken bundling the following (deprecated) each case

```ruby
source 'https://rubygems.org'

platforms :jruby do
  gem 'railties'
end

gem 'railties'
```

## What is your fix for the problem, implemented in this PR?

Revert https://github.com/rubygems/rubygems/commit/afaf868b68d68aa4eb98d19a2bb520c0d69b5ed2, adapting it to how the code looks today.

Fixes #5183.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
