### PR TITLE
Clarify release level naming in changelog and release scripts

### DIFF
--- a/util/changelog.rb
+++ b/util/changelog.rb
@@ -56,7 +56,7 @@ class Changelog
     @version = Gem::Version.new(version)
     @file = File.expand_path(file)
     @config = YAML.load_file("#{File.dirname(file)}/.changelog.yml")
-    @level = @version.segments[2] != 0 ? :patch : :minor
+    @level = @version.segments[2] != 0 ? :patch : :minor_or_major
   end
 
   def release_notes

--- a/util/release.rb
+++ b/util/release.rb
@@ -136,11 +136,11 @@ class Release
   def initialize(version)
     segments = Gem::Version.new(version).segments
 
-    @level = segments[2] != 0 ? :patch : :minor
+    @level = segments[2] != 0 ? :patch : :minor_or_major
 
     @stable_branch = segments[0, 2].join(".")
-    @base_branch = @level == :minor ? "master" : @stable_branch
-    @previous_stable_branch = @level == :minor ? "#{segments[0]}.#{segments[1] - 1}" : @stable_branch
+    @base_branch = @level == :minor_or_major ? "master" : @stable_branch
+    @previous_stable_branch = @level == :minor_or_major ? "#{segments[0]}.#{segments[1] - 1}" : @stable_branch
 
     rubygems_version = segments.join(".")
     @rubygems = Rubygems.new(rubygems_version, @stable_branch)
@@ -185,7 +185,7 @@ class Release
       @rubygems.bump_versions!
       system("git", "commit", "-am", "Bump Rubygems version to #{@rubygems.version}", exception: true)
 
-      return if @level == :minor
+      return if @level == :minor_or_major
 
       system("git", "checkout", "-b", "cherry_pick_changelogs", "master", exception: true)
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

From current naming it was not clear whether our scripts support releasing major versions.

## What is your fix for the problem, implemented in this PR?

With respect to release and changelog scripts, major and minor releases are equivalent: they are cut from the main branch (and thus require no backporting), can include any type of changes.

This change clarify that.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
