### PR TITLE
Fix `gem update --system` crashing when latest version not supported

### DIFF
--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -288,7 +288,9 @@ command to remove old versions.
 
     installed_gems = Gem::Specification.find_all_by_name 'rubygems-update', requirement
     installed_gems = update_gem('rubygems-update', version) if installed_gems.empty?
-    version        = installed_gems.first.version
+    return if installed_gems.empty?
+
+    version = installed_gems.first.version
 
     install_rubygems version
   end

--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -106,6 +106,31 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
     assert_empty out
   end
 
+  def test_execute_system_when_latest_does_not_support_your_ruby
+    spec_fetcher do |fetcher|
+      fetcher.download 'rubygems-update', 9 do |s|
+        s.files = %w[setup.rb]
+        s.required_ruby_version = '> 9'
+      end
+    end
+
+    @cmd.options[:args]          = []
+    @cmd.options[:system]        = true
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    out = @ui.output.split "\n"
+    assert_equal "Updating rubygems-update", out.shift
+    assert_empty out
+
+    err = @ui.error.split "\n"
+    assert_equal "ERROR:  Error installing rubygems-update:", err.shift
+    assert_equal "\trubygems-update-9 requires Ruby version > 9. The current ruby version is #{Gem.ruby_version}.", err.shift
+    assert_empty err
+  end
+
   def test_execute_system_multiple
     spec_fetcher do |fetcher|
       fetcher.download 'rubygems-update', 8 do |s|


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Currently, if we released a new rubygems version dropping support for old rubies, `gem update --system` would start crashing calling a `version` method on `nil`.

## What is your fix for the problem, implemented in this PR?

This first solution is not perfect (it could be improved by falling back to updating as far as possible), but at least avoids the crash, still exists with a 0 status, and still shows an error about the problem. It matches the current behavior of `gem update <gem>` when the latest version of `<gem>` has this issue.
 
## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
