### PR TITLE
Re-exec prepending command with `Gem.ruby` if `$PROGRAM_NAME` is not executable

### DIFF
--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -26,7 +26,7 @@ jobs:
           - { name: "2.6", value: 2.6.9 }
           - { name: "2.7", value: 2.7.5 }
           - { name: "3.0", value: 3.0.3 }
-          - { name: jruby-9.3, value: jruby-9.3.1.0 }
+          - { name: jruby-9.3, value: jruby-9.3.2.0 }
           - { name: truffleruby-21, value: truffleruby-21.2.0 }
         openssl:
           - { name: "openssl", value: true }
@@ -88,7 +88,7 @@ jobs:
       matrix:
         ruby:
           - { name: "3.0", value: 3.0.3 }
-          - { name: jruby-9.3, value: jruby-9.3.1.0 }
+          - { name: jruby-9.3, value: jruby-9.3.2.0 }
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby

--- a/.github/workflows/jruby-bundler.yml
+++ b/.github/workflows/jruby-bundler.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: jruby-9.3.1.0
+          ruby-version: jruby-9.3.2.0
           bundler: none
       - name: Prepare dependencies
         run: |

--- a/.github/workflows/ubuntu-rubygems.yml
+++ b/.github/workflows/ubuntu-rubygems.yml
@@ -26,7 +26,7 @@ jobs:
           - { name: "2.6", value: 2.6.9 }
           - { name: "2.7", value: 2.7.5 }
           - { name: "3.0", value: 3.0.3 }
-          - { name: jruby-9.3, value: jruby-9.3.1.0 }
+          - { name: jruby-9.3, value: jruby-9.3.2.0 }
           - { name: truffleruby-21, value: truffleruby-21.2.0 }
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/windows-bundler.yml
+++ b/.github/workflows/windows-bundler.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - { name: jruby-9.3, value: jruby-9.3.1.0 }
+          - { name: jruby-9.3, value: jruby-9.3.2.0 }
           - { name: ruby-2.5, value: 2.5.9 }
           - { name: ruby-3.0, value: 3.0.3 }
 

--- a/bundler/lib/bundler/self_manager.rb
+++ b/bundler/lib/bundler/self_manager.rb
@@ -39,10 +39,13 @@ module Bundler
       configured_gem_home = ENV["GEM_HOME"]
       configured_gem_path = ENV["GEM_PATH"]
 
+      cmd = [$PROGRAM_NAME, *ARGV]
+      cmd.unshift(Gem.ruby) unless File.executable?($PROGRAM_NAME)
+
       Bundler.with_original_env do
         Kernel.exec(
           { "GEM_HOME" => configured_gem_home, "GEM_PATH" => configured_gem_path, "BUNDLER_VERSION" => lockfile_version },
-          $PROGRAM_NAME, *ARGV
+          *cmd
         )
       end
     end

--- a/bundler/spec/runtime/gem_tasks_spec.rb
+++ b/bundler/spec/runtime/gem_tasks_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
   end
 
   it "includes the relevant tasks" do
-    with_gem_path_as(base_system_gems.to_s) do
+    with_gem_path_as(base_system_gem_path.to_s) do
       sys_exec "#{rake} -T", :env => { "GEM_HOME" => system_gem_path.to_s }
     end
 
@@ -44,7 +44,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
   end
 
   it "defines a working `rake install` task", :ruby_repo do
-    with_gem_path_as(base_system_gems.to_s) do
+    with_gem_path_as(base_system_gem_path.to_s) do
       sys_exec "#{rake} install", :env => { "GEM_HOME" => system_gem_path.to_s }
     end
 
@@ -98,7 +98,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
   end
 
   it "adds 'pkg' to rake/clean's CLOBBER" do
-    with_gem_path_as(base_system_gems.to_s) do
+    with_gem_path_as(base_system_gem_path.to_s) do
       sys_exec %(#{rake} -e 'load "Rakefile"; puts CLOBBER.inspect'), :env => { "GEM_HOME" => system_gem_path.to_s }
     end
     expect(out).to eq '["pkg"]'

--- a/bundler/spec/support/artifice/compact_index.rb
+++ b/bundler/spec/support/artifice/compact_index.rb
@@ -2,7 +2,7 @@
 
 require_relative "endpoint"
 
-$LOAD_PATH.unshift Dir[Spec::Path.base_system_gems.join("gems/compact_index*/lib")].first.to_s
+$LOAD_PATH.unshift Dir[Spec::Path.base_system_gem_path.join("gems/compact_index*/lib")].first.to_s
 require "compact_index"
 
 class CompactIndexAPI < Endpoint

--- a/bundler/spec/support/artifice/endpoint.rb
+++ b/bundler/spec/support/artifice/endpoint.rb
@@ -2,7 +2,7 @@
 
 require_relative "../path"
 
-$LOAD_PATH.unshift(*Dir[Spec::Path.base_system_gems.join("gems/{artifice,mustermann,rack,tilt,sinatra,ruby2_keywords}-*/lib")].map(&:to_s))
+$LOAD_PATH.unshift(*Dir[Spec::Path.base_system_gem_path.join("gems/{artifice,mustermann,rack,tilt,sinatra,ruby2_keywords}-*/lib")].map(&:to_s))
 
 require "artifice"
 require "sinatra/base"

--- a/bundler/spec/support/artifice/endpoint_500.rb
+++ b/bundler/spec/support/artifice/endpoint_500.rb
@@ -2,7 +2,7 @@
 
 require_relative "../path"
 
-$LOAD_PATH.unshift(*Dir[Spec::Path.base_system_gems.join("gems/{artifice,mustermann,rack,tilt,sinatra,ruby2_keywords}-*/lib")].map(&:to_s))
+$LOAD_PATH.unshift(*Dir[Spec::Path.base_system_gem_path.join("gems/{artifice,mustermann,rack,tilt,sinatra,ruby2_keywords}-*/lib")].map(&:to_s))
 
 require "artifice"
 require "sinatra/base"

--- a/bundler/spec/support/artifice/windows.rb
+++ b/bundler/spec/support/artifice/windows.rb
@@ -2,7 +2,7 @@
 
 require_relative "../path"
 
-$LOAD_PATH.unshift(*Dir[Spec::Path.base_system_gems.join("gems/{artifice,mustermann,rack,tilt,sinatra,ruby2_keywords}-*/lib")].map(&:to_s))
+$LOAD_PATH.unshift(*Dir[Spec::Path.base_system_gem_path.join("gems/{artifice,mustermann,rack,tilt,sinatra,ruby2_keywords}-*/lib")].map(&:to_s))
 
 require "artifice"
 require "sinatra/base"

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -259,7 +259,7 @@ module Spec
       @_build_path = "#{path}/gems"
       @_build_repo = File.basename(path)
       yield
-      with_gem_path_as Path.base_system_gems do
+      with_gem_path_as Path.base_system_gem_path do
         gem_command :generate_index, :dir => path
       end
     ensure

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -545,7 +545,7 @@ module Spec
     def require_rack
       # need to hack, so we can require rack
       old_gem_home = ENV["GEM_HOME"]
-      ENV["GEM_HOME"] = Spec::Path.base_system_gems.to_s
+      ENV["GEM_HOME"] = Spec::Path.base_system_gem_path.to_s
       require "rack"
       ENV["GEM_HOME"] = old_gem_home
     end

--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -146,6 +146,10 @@ module Spec
       bundled_app("Gemfile.lock")
     end
 
+    def base_system_gem_path
+      scoped_gem_path(base_system_gems)
+    end
+
     def base_system_gems
       tmp.join("gems/base")
     end

--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -59,15 +59,13 @@ module Spec
       Gem.clear_paths
 
       ENV["BUNDLE_PATH"] = nil
-      ENV["GEM_HOME"] = ENV["GEM_PATH"] = Path.base_system_gems.to_s
+      ENV["GEM_HOME"] = ENV["GEM_PATH"] = Path.base_system_gem_path.to_s
       ENV["PATH"] = [Path.system_gem_path.join("bin"), ENV["PATH"]].join(File::PATH_SEPARATOR)
       ENV["PATH"] = [Path.bindir, ENV["PATH"]].join(File::PATH_SEPARATOR) if Path.ruby_core?
     end
 
     def install_test_deps
-      setup_test_paths
-
-      install_gems(test_gemfile)
+      install_gems(test_gemfile, Path.base_system_gems.to_s)
       install_gems(rubocop_gemfile, Path.rubocop_gems.to_s)
       install_gems(standard_gemfile, Path.standard_gems.to_s)
     end

--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -109,7 +109,9 @@ module Spec
 
     def install_gems(gemfile, path = nil)
       old_gemfile = ENV["BUNDLE_GEMFILE"]
+      old_orig_gemfile = ENV["BUNDLER_ORIG_BUNDLE_GEMFILE"]
       ENV["BUNDLE_GEMFILE"] = gemfile.to_s
+      ENV["BUNDLER_ORIG_BUNDLE_GEMFILE"] = nil
 
       if path
         old_path = ENV["BUNDLE_PATH"]
@@ -128,6 +130,7 @@ module Spec
         ENV["BUNDLE_PATH__SYSTEM"] = old_path__system
       end
 
+      ENV["BUNDLER_ORIG_BUNDLE_GEMFILE"] = old_orig_gemfile
       ENV["BUNDLE_GEMFILE"] = old_gemfile
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We have some failures in bundler 3 mode.

The problem is caused by the re-execing feature being triggered in bundler 3 mode, because our development lock files are locked to bundler 2.

There's two issues:

* Running bundler as `ruby <stub_not_directly_executable_that_loads_bundler>` is not handled properly.
* When reexecing to `bundler` from within a `bundler` context, and passing some custom bundler variables like we are doing in our test helper when setting up development dependencies (for example, `BUNDLE_GEMFILE`), we now need to reset the backup (`BUNDLER_ORIG_BUNDLE_GEMFILE`). This is due to bundler re-execing using `Bundler.with_original_env`, which seems conceptually correct, but I'm afraid it could cause issues for end users doing similar things. 

## What is your fix for the problem, implemented in this PR?

This PR fixes the first issue by prepending `Gem.ruby` to the re-exec'ed command if `$PROGRAM_NAME` is not executable.

It also fixes the second issue to get CI green by properly resetting the previous environment variable backup when running bundler in a subprocess with modified environment variables. I'm worried about this second issue potentially biting end users, and I'm considering not using `Bundler.with_original_env` when re-execing bundler. But I'm not 100% sure so I won't be taking any further action there for now.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
