### PR TITLE
Bump main branch to `.dev` versions again

### DIFF
--- a/bundler/lib/bundler/version.rb
+++ b/bundler/lib/bundler/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
 
 module Bundler
-  VERSION = "2.3.0".freeze
+  VERSION = "2.4.0.dev".freeze
 
   def self.bundler_major_version
     @bundler_major_version ||= VERSION.split(".").first.to_i

--- a/bundler/spec/realworld/fixtures/warbler/Gemfile.lock
+++ b/bundler/spec/realworld/fixtures/warbler/Gemfile.lock
@@ -27,4 +27,4 @@ DEPENDENCIES
   warbler (~> 2.0)
 
 BUNDLED WITH
-   2.3.0.dev
+   2.4.0.dev

--- a/bundler/tool/bundler/rubocop23_gems.rb.lock
+++ b/bundler/tool/bundler/rubocop23_gems.rb.lock
@@ -59,4 +59,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   2.3.0
+   2.4.0.dev

--- a/bundler/tool/bundler/rubocop24_gems.rb.lock
+++ b/bundler/tool/bundler/rubocop24_gems.rb.lock
@@ -62,4 +62,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   2.3.0
+   2.4.0.dev

--- a/bundler/tool/bundler/rubocop_gems.rb.lock
+++ b/bundler/tool/bundler/rubocop_gems.rb.lock
@@ -60,4 +60,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   2.3.0
+   2.4.0.dev

--- a/bundler/tool/bundler/standard23_gems.rb.lock
+++ b/bundler/tool/bundler/standard23_gems.rb.lock
@@ -64,4 +64,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   2.3.0
+   2.4.0.dev

--- a/bundler/tool/bundler/standard24_gems.rb.lock
+++ b/bundler/tool/bundler/standard24_gems.rb.lock
@@ -68,4 +68,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   2.3.0
+   2.4.0.dev

--- a/bundler/tool/bundler/standard_gems.rb.lock
+++ b/bundler/tool/bundler/standard_gems.rb.lock
@@ -66,4 +66,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   2.3.0
+   2.4.0.dev

--- a/bundler/tool/bundler/test_gems.rb.lock
+++ b/bundler/tool/bundler/test_gems.rb.lock
@@ -41,4 +41,4 @@ DEPENDENCIES
   webrick (= 1.7.0)
 
 BUNDLED WITH
-   2.3.0
+   2.4.0.dev

--- a/dev_gems.rb.lock
+++ b/dev_gems.rb.lock
@@ -70,4 +70,4 @@ DEPENDENCIES
   webrick (~> 1.6)
 
 BUNDLED WITH
-   2.3.0
+   2.4.0.dev

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -8,7 +8,7 @@
 require 'rbconfig'
 
 module Gem
-  VERSION = "3.3.0".freeze
+  VERSION = "3.4.0.dev".freeze
 end
 
 # Must be first since it unloads the prelude from 1.9.2

--- a/release_gems.rb.lock
+++ b/release_gems.rb.lock
@@ -62,4 +62,4 @@ DEPENDENCIES
   octokit (~> 4.18)
 
 BUNDLED WITH
-   2.3.0
+   2.4.0.dev

--- a/rubygems-update.gemspec
+++ b/rubygems-update.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "rubygems-update"
-  s.version = "3.3.0"
+  s.version = "3.4.0.dev"
   s.authors = ["Jim Weirich", "Chad Fowler", "Eric Hodel", "Luis Lavena", "Aaron Patterson", "Samuel Giddins", "André Arko", "Evan Phoenix", "Hiroshi SHIBATA"]
   s.email = ["", "", "drbrain@segment7.net", "luislavena@gmail.com", "aaron@tenderlovemaking.com", "segiddins@segiddins.me", "andre@arko.net", "evan@phx.io", "hsbt@ruby-lang.org"]
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Master branch now has released versions in it. it's usually good to make the main branch a development version.

## What is your fix for the problem, implemented in this PR?

Bump version to `.dev` versions again.

As I side effect, I think this will fix CI because auto switching will be skipped.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
