### PR TITLE
Avoid unnecessary `shellwords` require on newer rubygems

### DIFF
--- a/bundler/lib/bundler/rubygems_gem_installer.rb
+++ b/bundler/lib/bundler/rubygems_gem_installer.rb
@@ -67,7 +67,7 @@ module Bundler
     def build_extensions
       extension_cache_path = options[:bundler_extension_cache_path]
       unless extension_cache_path && extension_dir = spec.extension_dir
-        require "shellwords" # compensate missing require in rubygems before version 3.2.25
+        require "shellwords" unless Bundler.rubygems.provides?(">= 3.2.25")
         return super
       end
 

--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -116,7 +116,7 @@ RSpec.shared_examples "bundle install --standalone" do
       realworld_system_gems "fiddle --version 1.0.8", "tsort --version 0.1.0"
 
       necessary_system_gems = ["optparse --version 0.1.1", "psych --version 3.3.2", "yaml --version 0.1.1", "logger --version 1.4.3", "etc --version 1.2.0", "stringio --version 3.0.0"]
-      necessary_system_gems += ["shellwords --version 0.1.0", "base64 --version 0.1.0", "resolv --version 0.2.1"] if Gem.rubygems_version < Gem::Version.new("3.3.3.a")
+      necessary_system_gems += ["shellwords --version 0.1.0", "base64 --version 0.1.0", "resolv --version 0.2.1"] if Gem.rubygems_version < Gem::Version.new("3.3.a")
       realworld_system_gems(*necessary_system_gems, :path => scoped_gem_path(bundled_app("bundle")))
 
       build_gem "foo", "1.0.0", :to_system => true, :default => true do |s|


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Just some small spec issues.

## What is your fix for the problem, implemented in this PR?

Fix a typo and relax the condition to run some specs, so that they are checked again.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
