### PR TITLE
Fix compatibility with OpenSSL 3.0

### DIFF
--- a/lib/rubygems/security.rb
+++ b/lib/rubygems/security.rb
@@ -424,6 +424,8 @@ module Gem::Security
   # Gets the right public key from a PKey instance
 
   def self.get_public_key(key)
+    # Ruby 3.0 (Ruby/OpenSSL 2.2) or later
+    return OpenSSL::PKey.read(key.public_to_der) if key.respond_to?(:public_to_der)
     return key.public_key unless key.is_a?(OpenSSL::PKey::EC)
 
     ec_key = OpenSSL::PKey::EC.new(key.group.curve_name)

--- a/lib/rubygems/security.rb
+++ b/lib/rubygems/security.rb
@@ -531,7 +531,7 @@ module Gem::Security
     raise Gem::Security::Exception,
           "incorrect signing key for re-signing " +
           "#{expired_certificate.subject}" unless
-      expired_certificate.public_key.to_pem == get_public_key(private_key).to_pem
+      expired_certificate.check_private_key(private_key)
 
     unless expired_certificate.subject.to_s ==
            expired_certificate.issuer.to_s

--- a/lib/rubygems/security.rb
+++ b/lib/rubygems/security.rb
@@ -490,9 +490,13 @@ module Gem::Security
       when 'rsa'
         OpenSSL::PKey::RSA.new(RSA_DSA_KEY_LENGTH)
       when 'ec'
-        domain_key = OpenSSL::PKey::EC.new(EC_NAME)
-        domain_key.generate_key
-        domain_key
+        if RUBY_VERSION >= "2.4.0"
+          OpenSSL::PKey::EC.generate(EC_NAME)
+        else
+          domain_key = OpenSSL::PKey::EC.new(EC_NAME)
+          domain_key.generate_key
+          domain_key
+        end
       else
         raise Gem::Security::Exception,
         "#{algorithm} algorithm not found. RSA, DSA, and EC algorithms are supported."

--- a/lib/rubygems/security/policy.rb
+++ b/lib/rubygems/security/policy.rb
@@ -115,11 +115,9 @@ class Gem::Security::Policy
       raise Gem::Security::Exception, 'missing key or signature'
     end
 
-    public_key = Gem::Security.get_public_key(key)
-
     raise Gem::Security::Exception,
       "certificate #{signer.subject} does not match the signing key" unless
-        signer.public_key.to_pem == public_key.to_pem
+        signer.check_private_key(key)
 
     true
   end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->
Gem::Security uses `openssl`'s features that are incompatible with OpenSSL 3.0. As reported in #5192, it can be observed as a test failure.

This only affects Ruby 3.1 (or later) since stdlib `openssl` in previous versions doesn't support OpenSSL 3.0.

## What is your fix for the problem, implemented in this PR?

RubyGems uses the following two methods. They modify the receiver object which is not possible if `openssl` is built against OpenSSL 3.0.

 - `OpenSSL::PKey::EC#public_key=`
 - `OpenSSL::PKey::EC#generate_key`
<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

Fixes https://github.com/rubygems/rubygems/issues/5192.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
