### PR TITLE
Changelogs for rubygems 3.3.1 and bundler 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 3.3.1 / 2021-12-22
+
+## Enhancements:
+
+* Fix compatibility with OpenSSL 3.0. Pull request #5196 by rhenium
+* Remove hard errors when matching major bundler not found. Pull request
+  #5181 by deivid-rodriguez
+* Installs bundler 2.3.1 as a default gem.
+
 # 3.3.0 / 2021-12-21
 
 ## Breaking changes:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2.3.1 (December 22, 2021)
+
+## Enhancements:
+
+  - Vendor latest `thor` with fixes for latest `did_you_mean` deprecations [#5202](https://github.com/rubygems/rubygems/pull/5202)
+  - Avoid unnecessary `shellwords` require on newer rubygems [#5195](https://github.com/rubygems/rubygems/pull/5195)
+  - Re-exec prepending command with `Gem.ruby` if `$PROGRAM_NAME` is not executable [#5193](https://github.com/rubygems/rubygems/pull/5193)
+
 # 2.3.0 (December 21, 2021)
 
 ## Features:


### PR DESCRIPTION
Cherry-picking changelogs from future rubygems 3.3.1 and bundler 2.3.1 into master.