### PR TITLE
Fix gemspec truncation

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -797,11 +797,11 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   ##
   # Safely write a file in binary mode on all platforms.
   def self.write_binary(path, data)
-    File.open(path, File::RDWR | File::CREAT | File::LOCK_EX, binmode: true) do |io|
-      io.write data
-    end
-  rescue *WRITE_BINARY_ERRORS
     File.open(path, 'wb') do |io|
+      begin
+        io.flock(File::LOCK_EX)
+      rescue *WRITE_BINARY_ERRORS
+      end
       io.write data
     end
   rescue Errno::ENOLCK # NFS

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -782,6 +782,39 @@ ERROR:  Possible alternatives: non_existent_with_hint
     assert_match "1 gem installed", @ui.output
   end
 
+  def test_execute_remote_truncates_existing_gemspecs
+    spec_fetcher do |fetcher|
+      fetcher.gem 'a', 1
+    end
+
+    @cmd.options[:domain] = :remote
+
+    @cmd.options[:args] = %w[a]
+
+    use_ui @ui do
+      assert_raise Gem::MockGemUi::SystemExitException, @ui.error do
+        @cmd.execute
+      end
+    end
+
+    assert_equal %w[a-1], @cmd.installed_specs.map {|spec| spec.full_name }
+    assert_match "1 gem installed", @ui.output
+
+    a1_gemspec = File.join(@gemhome, 'specifications', "a-1.gemspec")
+
+    initial_a1_gemspec_content = File.read(a1_gemspec)
+    modified_a1_gemspec_content = initial_a1_gemspec_content + "\n  # AAAAAAA\n"
+    File.write(a1_gemspec, modified_a1_gemspec_content)
+
+    use_ui @ui do
+      assert_raise Gem::MockGemUi::SystemExitException, @ui.error do
+        @cmd.execute
+      end
+    end
+
+    assert_equal initial_a1_gemspec_content, File.read(a1_gemspec)
+  end
+
   def test_execute_remote_ignores_files
     specs = spec_fetcher do |fetcher|
       fetcher.gem 'a', 1

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -288,33 +288,6 @@ gem 'other', version
                  "(SyntaxError)", e.message
   end
 
-  def test_ensure_no_race_conditions_between_installing_and_loading_gemspecs
-    a, a_gem = util_gem 'a', 2
-
-    Gem::Installer.at(a_gem).install
-
-    t1 = Thread.new do
-      5.times do
-        Gem::Installer.at(a_gem).install
-        sleep 0.1
-      end
-    end
-
-    t2 = Thread.new do
-      _, err = capture_output do
-        20.times do
-          Gem::Specification.load(a.spec_file)
-          Gem::Specification.send(:clear_load_cache)
-        end
-      end
-
-      assert_empty err
-    end
-
-    t1.join
-    t2.join
-  end
-
   def test_ensure_loadable_spec_security_policy
     pend 'openssl is missing' unless Gem::HAVE_OPENSSL
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since https://github.com/rubygems/rubygems/commit/a672e7555c, writing gemspecs would no longer truncate existing gemspec files, because I missed the `File::TRUNC` integer flag.

## What is your fix for the problem, implemented in this PR?

It seems like the only thing that made the test added by a672e7555c actually pass was stopping truncating the files (namely, a bug), so I just reverted a672e7555c since it's unclear that it fixed any realworld user issue (it came up after seeing some flaky failures in CI, but I think they might've been unrelated). Concurrent `gem install` commands are not thread safe, with or without this.

I also added a test to make sure this doesn't regress again.

Fixes #5203.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
