### PR TITLE
Remove unnecessary lockfile upgrade warning

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -293,10 +293,7 @@ module Bundler
         locked_major = @locked_bundler_version.segments.first
         current_major = Gem::Version.create(Bundler::VERSION).segments.first
 
-        if updating_major = locked_major < current_major
-          Bundler.ui.warn "Warning: the lockfile is being updated to Bundler #{current_major}, " \
-                          "after which you will be unable to return to Bundler #{locked_major}."
-        end
+        updating_major = locked_major < current_major
       end
 
       preserve_unknown_sections ||= !updating_major && (Bundler.frozen_bundle? || !(unlocking? || @unlocking_bundler))

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe "the lockfile format" do
     G
   end
 
-  it "warns when updating bundler major version" do
+  it "update the bundler major version just fine" do
     current_version = Bundler::VERSION
     older_major = previous_major(current_version)
 
@@ -253,10 +253,7 @@ RSpec.describe "the lockfile format" do
       gem "rack"
     G
 
-    expect(err).to include(
-      "Warning: the lockfile is being updated to Bundler " \
-      "#{current_version.split(".").first}, after which you will be unable to return to Bundler #{older_major.split(".").first}."
-    )
+    expect(err).to be_empty
 
     expect(lockfile).to eq <<~G
       GEM


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since we can auto switch bundler versions, this is not necessary. And it was never true that you can't go back anyways.

We may need a specific warning if we introduced lockfile breaking changes in the future, but as is it seems just scary.

## What is your fix for the problem, implemented in this PR?

Remove the warning.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
