### PR TITLE
Backport Ruby master changes

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -18,6 +18,7 @@ bundler/bundler.gemspec
 bundler/exe/bundle
 bundler/exe/bundler
 bundler/lib/bundler.rb
+bundler/lib/bundler/.document
 bundler/lib/bundler/build_metadata.rb
 bundler/lib/bundler/capistrano.rb
 bundler/lib/bundler/cli.rb

--- a/bundler/lib/bundler/.document
+++ b/bundler/lib/bundler/.document
@@ -1,0 +1,1 @@
+# not in RDoc

--- a/test/rubygems/test_gem_stream_ui.rb
+++ b/test/rubygems/test_gem_stream_ui.rb
@@ -5,7 +5,7 @@ require 'timeout'
 
 class TestGemStreamUI < Gem::TestCase
   # increase timeout with MJIT for --jit-wait testing
-  mjit_enabled = defined?(RubyVM::JIT) ? RubyVM::JIT.enabled? : defined?(RubyVM::MJIT) && RubyVM::MJIT.enabled?
+  mjit_enabled = defined?(RubyVM::MJIT) ? RubyVM::MJIT.enabled? : defined?(RubyVM::MJIT) && RubyVM::MJIT.enabled?
   SHORT_TIMEOUT = (RUBY_ENGINE == "ruby" && !mjit_enabled) ? 0.1 : 1.0
 
   module IsTty


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

* Rdoc will generate only `Bundler` namespace, We should ignore that.
* Ruby 3.1 changes `JIT` to `MJIT` again.

## What is your fix for the problem, implemented in this PR?

* Put `.document` under the `lib/bundler`.
* Rename `JIT` to `MJIT`

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
