### PR TITLE
Fix deprecations when activating DidYouMean for misspelled command suggestions

### DIFF
--- a/lib/rubygems/exceptions.rb
+++ b/lib/rubygems/exceptions.rb
@@ -24,10 +24,14 @@ class Gem::UnknownCommandError < Gem::Exception
     return if defined?(@attached)
 
     if defined?(DidYouMean::SPELL_CHECKERS) && defined?(DidYouMean::Correctable)
-      DidYouMean::SPELL_CHECKERS['Gem::UnknownCommandError'] =
-        Gem::UnknownCommandSpellChecker
+      if DidYouMean.respond_to?(:correct_error)
+        DidYouMean.correct_error(Gem::UnknownCommandError, Gem::UnknownCommandSpellChecker)
+      else
+        DidYouMean::SPELL_CHECKERS['Gem::UnknownCommandError'] =
+          Gem::UnknownCommandSpellChecker
 
-      prepend DidYouMean::Correctable
+        prepend DidYouMean::Correctable
+      end
     end
 
     @attached = true


### PR DESCRIPTION
cc @deivid-rodriguez 

## What was the end-user or developer problem that led to this PR?

Similar to https://github.com/rubygems/rubygems/pull/5202, there is actually one more spot we have to update to make Rubygems fully compatible with the latest DidYouMean.

## What is your fix for the problem, implemented in this PR?

Fix the deprecations.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
