### PR TITLE
Try fix file locking issues on Windows

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -788,9 +788,11 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
   def self.open_with_flock(path, flags, &block)
     File.open(path, flags) do |io|
-      begin
-        io.flock(File::LOCK_EX)
-      rescue Errno::ENOSYS, Errno::ENOTSUP
+      unless java_platform?
+        begin
+          io.flock(File::LOCK_EX)
+        rescue Errno::ENOSYS, Errno::ENOTSUP
+        end
       end
       yield io
     end

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1116,7 +1116,7 @@ class Gem::Specification < Gem::BasicSpecification
     file = file.dup.tap(&Gem::UNTAINT)
     return unless File.file?(file)
 
-    code = File.read file, :mode => 'r:UTF-8:-'
+    code = Gem.open_with_flock(file, 'r:UTF-8:-', &:read)
 
     code.tap(&Gem::UNTAINT)
 

--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -110,7 +110,7 @@ class Gem::StubSpecification < Gem::BasicSpecification
       begin
         saved_lineno = $.
 
-        File.open loaded_from, OPEN_MODE do |file|
+        Gem.open_with_flock loaded_from, OPEN_MODE do |file|
           begin
             file.readline # discard encoding line
             stubline = file.readline.chomp


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We're getting a quite frequent flaky test failure on Windows.

## What is your fix for the problem, implemented in this PR?

I think we should try to acquire the file lock before trying to read stub specifications, to avoid accessing a file that's already opened. Let's see if CI agrees.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
