### PR TITLE
Changelogs for rubygems 3.3.2 and bundler 2.3.2 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 3.3.2 / 2021-12-23
+
+## Enhancements:
+
+* Fix deprecations when activating DidYouMean for misspelled command
+  suggestions. Pull request #5211 by yuki24
+* Installs bundler 2.3.2 as a default gem.
+
+## Bug fixes:
+
+* Fix gemspec truncation. Pull request #5208 by deivid-rodriguez
+
 # 3.3.1 / 2021-12-22
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.3.2 (December 23, 2021)
+
+## Enhancements:
+
+  - Remove unnecessary lockfile upgrade warning [#5209](https://github.com/rubygems/rubygems/pull/5209)
+
 # 2.3.1 (December 22, 2021)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking changelogs from future rubygems 3.3.2 and bundler 2.3.2 into master.