### PR TITLE
Do not use IO#flock on Solaris

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -788,7 +788,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
   def self.open_with_flock(path, flags, &block)
     File.open(path, flags) do |io|
-      unless java_platform?
+      if !java_platform? && !solaris_platform?
         begin
           io.flock(File::LOCK_EX)
         rescue Errno::ENOSYS, Errno::ENOTSUP
@@ -1013,6 +1013,13 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
   def self.java_platform?
     RUBY_PLATFORM == "java"
+  end
+
+  ##
+  # Is this platform Solaris?
+
+  def self.solaris_platform?
+    RUBY_PLATFORM =~ /solaris/
   end
 
   ##


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`make install` of the ruby package fails on Solaris.

## What is your fix for the problem, implemented in this PR?

`io.flock(File::LOCK_EX)` fails on Solaris when the io is opened as
read-only. This change avoids the lock mechanism on Solaris.

See also my comments https://github.com/rubygems/rubygems/pull/5208#issuecomment-1000640090

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
