### PR TITLE
Fix locked bundler not installed to the right path when `deployment` is set

### DIFF
--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -165,9 +165,6 @@ module Bundler
 
     def normalize_settings
       Bundler.settings.set_command_option :path, nil if options[:system]
-      Bundler.settings.temporary(:path_relative_to_cwd => false) do
-        Bundler.settings.set_command_option :path, "vendor/bundle" if Bundler.settings[:deployment] && Bundler.settings[:path].nil?
-      end
       Bundler.settings.set_command_option_if_given :path, options[:path]
       Bundler.settings.temporary(:path_relative_to_cwd => false) do
         Bundler.settings.set_command_option :path, "bundle" if options["standalone"] && Bundler.settings[:path].nil?

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -219,6 +219,7 @@ module Bundler
     def path
       configs.each do |_level, settings|
         path = value_for("path", settings)
+        path = "vendor/bundle" if value_for("deployment", settings) && path.nil?
         path_system = value_for("path.system", settings)
         disabled_shared_gems = value_for("disable_shared_gems", settings)
         next if path.nil? && path_system.nil? && disabled_shared_gems.nil?

--- a/bundler/spec/runtime/self_management_spec.rb
+++ b/bundler/spec/runtime/self_management_spec.rb
@@ -61,6 +61,28 @@ RSpec.describe "Self management", :rubygems => ">= 3.3.0.dev" do
       expect(out).not_to include("Bundler #{Bundler::VERSION} is running, but your lockfile was generated with #{next_minor}. Installing Bundler #{next_minor} and restarting using that version.")
     end
 
+    it "installs locked version when using deployment option and uses it" do
+      lockfile_bundled_with(next_minor)
+
+      bundle "config set --local deployment true"
+      bundle "install", :env => { "BUNDLER_SPEC_GEM_SOURCES" => file_uri_for(gem_repo2).to_s }
+      expect(out).to include("Bundler #{Bundler::VERSION} is running, but your lockfile was generated with #{next_minor}. Installing Bundler #{next_minor} and restarting using that version.")
+      expect(vendored_gems("gems/bundler-#{next_minor}")).to exist
+
+      # It does not uninstall the locked bundler
+      bundle "clean"
+      expect(out).to be_empty
+
+      # App now uses locked version
+      bundle "-v"
+      expect(out).to end_with(next_minor[0] == "2" ? "Bundler version #{next_minor}" : next_minor)
+
+      # Subsequent installs use the locked version without reinstalling
+      bundle "install --verbose"
+      expect(out).to include("Using bundler #{next_minor}")
+      expect(out).not_to include("Bundler #{Bundler::VERSION} is running, but your lockfile was generated with #{next_minor}. Installing Bundler #{next_minor} and restarting using that version.")
+    end
+
     it "does not try to install a development version" do
       lockfile_bundled_with("#{next_minor}.dev")
 

--- a/bundler/spec/runtime/self_management_spec.rb
+++ b/bundler/spec/runtime/self_management_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe "Self management", :rubygems => ">= 3.3.0.dev" do
       bundle "config set --local path vendor/bundle"
       bundle "install", :env => { "BUNDLER_SPEC_GEM_SOURCES" => file_uri_for(gem_repo2).to_s }
       expect(out).to include("Bundler #{Bundler::VERSION} is running, but your lockfile was generated with #{next_minor}. Installing Bundler #{next_minor} and restarting using that version.")
+      expect(vendored_gems("gems/bundler-#{next_minor}")).to exist
 
       # It does not uninstall the locked bundler
       bundle "clean"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The `deployment` option sets `vendor/bundle` under the hood as the path to install gems to, but it's not then properly used when actually looking for installed gems. Honestly I'm not sure how the `deployment` option was working at all unless people is always also explicitly configuring `path`.

## What is your fix for the problem, implemented in this PR?

My fix is to make sure `vendor/bundle` is also configured as the `GEM_HOME` when `deployment` is set.

Fixes #5215.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
