### PR TITLE
Changelogs for rubygems 3.3.3 and bundler 2.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 3.3.3 / 2021-12-24
+
+## Enhancements:
+
+* Installs bundler 2.3.3 as a default gem.
+
+## Bug fixes:
+
+* Fix gem installation failing in Solaris due to bad `IO#flock` usage.
+  Pull request #5216 by mame
+
 # 3.3.2 / 2021-12-23
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.3.3 (December 24, 2021)
+
+## Bug fixes:
+
+  - Fix locked bundler not installed to the right path when `deployment` is set [#5217](https://github.com/rubygems/rubygems/pull/5217)
+
 # 2.3.2 (December 23, 2021)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking changelogs from future rubygems 3.3.3 and bundler 2.3.3 into master.