### PR TITLE
Make SpecificationPolicy autoload constant

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1316,6 +1316,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   autoload :Source,             File.expand_path('rubygems/source', __dir__)
   autoload :SourceList,         File.expand_path('rubygems/source_list', __dir__)
   autoload :SpecFetcher,        File.expand_path('rubygems/spec_fetcher', __dir__)
+  autoload :SpecificationPolicy, File.expand_path('rubygems/specification_policy', __dir__)
   autoload :Util,               File.expand_path('rubygems/util', __dir__)
   autoload :Version,            File.expand_path('rubygems/version', __dir__)
 end

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -11,7 +11,6 @@ require_relative 'basic_specification'
 require_relative 'stub_specification'
 require_relative 'platform'
 require_relative 'requirement'
-require_relative 'specification_policy'
 require_relative 'util/list'
 
 ##


### PR DESCRIPTION

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

RubyGems consumes 2-3 MB of memory by just launching `ruby` command.
For example, the RSSs have 2736kb difference.

```
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
pocke    1503888  0.1  0.0  81160 14640 pts/67   S+   16:22   0:00 ruby -e sleep
pocke    1504176  1.0  0.0  78708 11904 pts/69   S+   16:23   0:00 ruby --disable-gems -e sleep
```

I realized it with an article (written in Japanese).
https://qiita.com/kwatch/items/1c590df6a1c5345e2d68
This article describes the memory usage of each Ruby version. It is increasing year by year, and RubyGems looks a large part of the memory usage.



## What is your fix for the problem, implemented in this PR?


Make SpecificationPolicy autoload constant. The class is only necessary to validate gemspec, so usually it is not necessary to execute Ruby script.

### Benchmark

It reduces memory usage about 206kb (1.4%).


#### Benchmark script

```ruby
def rss
  pid = spawn('ruby', '-Ilib', '-e', 'sleep', 2 => '/dev/null')
  sleep 0.1
  # It prints the following (with header):
  # USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
  # root           1  0.0  0.0 165332 11072 ?        Ss   Dec03   0:10 /sbin/init
  rss = `ps u --no-headers --pid #{pid}`.split(' ')[5].to_i
  Process.kill :INT, pid
  rss
end

N = 100
mems = N.times.map { rss }.sort
puts "avg: #{mems.sum.to_f / N}, mid: #{mems[N/2]}, min: #{mems.first}, max: #{mems.last}"
```

#### result



before:

```
avg: 14303.28, mid: 14292, min: 14176, max: 14408
```

after:

```
avg: 14097.28, mid: 14072, min: 14008, max: 14208
```



#### environment

```
$ ruby -v
ruby 3.0.3p157 (2021-11-24 revision 3fb7d2cadc) [x86_64-linux]
```


## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
