### PR TITLE
Fix `bundle update --bundler` no longer updating lockfile

### DIFF
--- a/bundler/lib/bundler/self_manager.rb
+++ b/bundler/lib/bundler/self_manager.rb
@@ -69,7 +69,12 @@ module Bundler
         SharedHelpers.in_bundle? &&
         lockfile_version &&
         !lockfile_version.end_with?(".dev") &&
-        lockfile_version != current_version
+        lockfile_version != current_version &&
+        !updating?
+    end
+
+    def updating?
+      "update".start_with?(ARGV.first || " ") && ARGV[1..-1].any? {|a| a.start_with?("--bundler") }
     end
 
     def installed?


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`bundle update --bundler` no longer updates the lockfile if the locked version is already installed.

## What is your fix for the problem, implemented in this PR?

Add `bundle update --bundler` being run as another condition for not auto switching.

Fixes #5221.

NOTE: currently built on top of #5205, I'll rebase after merging that one.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
