### PR TITLE
Improve older rubygems workflow performance

### DIFF
--- a/.github/workflows/older-rubygems-bundler.yml
+++ b/.github/workflows/older-rubygems-bundler.yml
@@ -43,8 +43,8 @@ jobs:
       RUBYOPT: --disable-gems
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+      - name: Fetch target rubygems
+        run: git fetch origin refs/tags/${{ matrix.rgv.value }}
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/older-rubygems-bundler.yml
+++ b/.github/workflows/older-rubygems-bundler.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/checkout@v2
         with:
-          path: tmp/rubygems
+          path: bundler/tmp/rubygems
           ref: ${{ matrix.rgv.value }}
       - name: Setup ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/older-rubygems-bundler.yml
+++ b/.github/workflows/older-rubygems-bundler.yml
@@ -43,6 +43,10 @@ jobs:
       RUBYOPT: --disable-gems
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+        with:
+          path: tmp/rubygems
+          ref: ${{ matrix.rgv.value }}
       - name: Fetch target rubygems
         run: git fetch origin refs/tags/${{ matrix.rgv.value }}
       - name: Setup ruby

--- a/.github/workflows/older-rubygems-bundler.yml
+++ b/.github/workflows/older-rubygems-bundler.yml
@@ -47,8 +47,6 @@ jobs:
         with:
           path: tmp/rubygems
           ref: ${{ matrix.rgv.value }}
-      - name: Fetch target rubygems
-        run: git fetch origin refs/tags/${{ matrix.rgv.value }}
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The current implementation fetches the whole repository and that is painfully slow, resulting in some jobs timing out because of spending almost one hour fetching the repository.

See how https://github.com/rubygems/rubygems/runs/4636403035?check_suite_focus=true spends almost one hour just in the `actions/checkout` step 😲.

## What is your fix for the problem, implemented in this PR?

Just experimenting with fixing this.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
