### PR TITLE
Update some specs to pass ruby-head CI

### DIFF
--- a/.github/workflows/older-rubygems-bundler.yml
+++ b/.github/workflows/older-rubygems-bundler.yml
@@ -43,8 +43,10 @@ jobs:
       RUBYOPT: --disable-gems
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          path: bundler/tmp/rubygems
+          ref: ${{ matrix.rgv.value }}
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/bundler/lib/bundler/ruby_version.rb
+++ b/bundler/lib/bundler/ruby_version.rb
@@ -103,7 +103,7 @@ module Bundler
 
     def self.system
       ruby_engine = RUBY_ENGINE.dup
-      ruby_version = ENV.fetch("BUNDLER_SPEC_RUBY_VERSION") { RUBY_VERSION }.dup
+      ruby_version = RUBY_VERSION.dup
       ruby_engine_version = RUBY_ENGINE_VERSION.dup
       patchlevel = RUBY_PATCHLEVEL.to_s
 

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -519,20 +519,17 @@ RSpec.describe "bundle install with gem sources" do
     context "and using an unsupported Ruby version" do
       it "prints an error" do
         install_gemfile <<-G, :raise_on_error => false
-          ::RUBY_VERSION = '2.0.1'
-          ruby '~> 2.2'
+          ruby '~> 1.2'
           source "#{file_uri_for(gem_repo1)}"
         G
-        expect(err).to include("Your Ruby version is 2.0.1, but your Gemfile specified ~> 2.2")
+        expect(err).to include("Your Ruby version is #{RUBY_VERSION}, but your Gemfile specified ~> 1.2")
       end
     end
 
     context "and using a supported Ruby version" do
       before do
         install_gemfile <<-G
-          ::RUBY_VERSION = '2.1.3'
-          ::RUBY_PATCHLEVEL = 100
-          ruby '~> 2.1.0'
+          ruby '~> #{RUBY_VERSION}'
           source "#{file_uri_for(gem_repo1)}"
         G
       end
@@ -549,18 +546,16 @@ RSpec.describe "bundle install with gem sources" do
          DEPENDENCIES
 
          RUBY VERSION
-            ruby 2.1.3p100
+            #{Bundler::RubyVersion.system}
 
          BUNDLED WITH
             #{Bundler::VERSION}
         L
       end
 
-      it "updates Gemfile.lock with updated incompatible ruby version" do
+      it "updates Gemfile.lock with updated yet still compatible ruby version" do
         install_gemfile <<-G
-          ::RUBY_VERSION = '2.2.3'
-          ::RUBY_PATCHLEVEL = 100
-          ruby '~> 2.2.0'
+          ruby '~> #{RUBY_VERSION[0..2]}'
           source "#{file_uri_for(gem_repo1)}"
         G
 
@@ -575,7 +570,7 @@ RSpec.describe "bundle install with gem sources" do
          DEPENDENCIES
 
          RUBY VERSION
-            ruby 2.2.3p100
+            #{Bundler::RubyVersion.system}
 
          BUNDLED WITH
             #{Bundler::VERSION}

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -980,20 +980,14 @@ RSpec.describe "bundle update when a gem depends on a newer version of bundler" 
 end
 
 RSpec.describe "bundle update --ruby" do
-  before do
-    install_gemfile <<-G
-        ::RUBY_VERSION = '2.1.3'
-        ::RUBY_PATCHLEVEL = 100
-        ruby '~> 2.1.0'
-        source "#{file_uri_for(gem_repo1)}"
-    G
-  end
-
   context "when the Gemfile removes the ruby" do
     before do
+      install_gemfile <<-G
+        ruby '~> #{RUBY_VERSION}'
+        source "#{file_uri_for(gem_repo1)}"
+      G
+
       gemfile <<-G
-          ::RUBY_VERSION = '2.1.4'
-          ::RUBY_PATCHLEVEL = 222
           source "#{file_uri_for(gem_repo1)}"
       G
     end
@@ -1018,10 +1012,13 @@ RSpec.describe "bundle update --ruby" do
 
   context "when the Gemfile specified an updated Ruby version" do
     before do
+      install_gemfile <<-G
+        ruby '~> #{RUBY_VERSION}'
+        source "#{file_uri_for(gem_repo1)}"
+      G
+
       gemfile <<-G
-          ::RUBY_VERSION = '2.1.4'
-          ::RUBY_PATCHLEVEL = 222
-          ruby '~> 2.1.0'
+          ruby '~> #{RUBY_VERSION[0..2]}'
           source "#{file_uri_for(gem_repo1)}"
       G
     end
@@ -1029,6 +1026,46 @@ RSpec.describe "bundle update --ruby" do
       bundle "update --ruby"
 
       expect(lockfile).to eq <<~L
+       GEM
+         remote: #{file_uri_for(gem_repo1)}/
+         specs:
+
+       PLATFORMS
+         #{lockfile_platforms}
+
+       DEPENDENCIES
+
+       RUBY VERSION
+          #{Bundler::RubyVersion.system}
+
+       BUNDLED WITH
+          #{Bundler::VERSION}
+      L
+    end
+  end
+
+  context "when a different Ruby is being used than has been versioned" do
+    before do
+      install_gemfile <<-G
+        ruby '~> #{RUBY_VERSION}'
+        source "#{file_uri_for(gem_repo1)}"
+      G
+
+      gemfile <<-G
+          ruby '~> 2.1.0'
+          source "#{file_uri_for(gem_repo1)}"
+      G
+    end
+    it "shows a helpful error message" do
+      bundle "update --ruby", :raise_on_error => false
+
+      expect(err).to include("Your Ruby version is #{Bundler::RubyVersion.system.gem_version}, but your Gemfile specified ~> 2.1.0")
+    end
+  end
+
+  context "when updating Ruby version and Gemfile `ruby`" do
+    before do
+      lockfile <<~L
        GEM
          remote: #{file_uri_for(gem_repo1)}/
          specs:
@@ -1044,31 +1081,9 @@ RSpec.describe "bundle update --ruby" do
        BUNDLED WITH
           #{Bundler::VERSION}
       L
-    end
-  end
 
-  context "when a different Ruby is being used than has been versioned" do
-    before do
       gemfile <<-G
-          ::RUBY_VERSION = '2.2.2'
-          ::RUBY_PATCHLEVEL = 505
-          ruby '~> 2.1.0'
-          source "#{file_uri_for(gem_repo1)}"
-      G
-    end
-    it "shows a helpful error message" do
-      bundle "update --ruby", :raise_on_error => false
-
-      expect(err).to include("Your Ruby version is 2.2.2, but your Gemfile specified ~> 2.1.0")
-    end
-  end
-
-  context "when updating Ruby version and Gemfile `ruby`" do
-    before do
-      gemfile <<-G
-          ::RUBY_VERSION = '1.8.3'
-          ::RUBY_PATCHLEVEL = 55
-          ruby '~> 1.8.0'
+          ruby '~> #{RUBY_VERSION}'
           source "#{file_uri_for(gem_repo1)}"
       G
     end
@@ -1086,7 +1101,7 @@ RSpec.describe "bundle update --ruby" do
        DEPENDENCIES
 
        RUBY VERSION
-          ruby 1.8.3p55
+          #{Bundler::RubyVersion.system}
 
        BUNDLED WITH
           #{Bundler::VERSION}

--- a/bundler/spec/install/gemfile/ruby_spec.rb
+++ b/bundler/spec/install/gemfile/ruby_spec.rb
@@ -46,18 +46,16 @@ RSpec.describe "ruby requirement" do
   it "allows changing the ruby version requirement to something compatible" do
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
-      ruby ">= 1.0.0"
+      ruby ">= #{RUBY_VERSION[0..2]}.0"
       gem "rack"
     G
 
     allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
     expect(locked_ruby_version).to eq(Bundler::RubyVersion.system)
 
-    simulate_ruby_version "5100"
-
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
-      ruby ">= 1.0.1"
+      ruby ">= #{RUBY_VERSION}"
       gem "rack"
     G
 
@@ -72,19 +70,35 @@ RSpec.describe "ruby requirement" do
       gem "rack"
     G
 
-    allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
-    expect(locked_ruby_version).to eq(Bundler::RubyVersion.system)
+    lockfile <<~L
+      GEM
+        remote: #{file_uri_for(gem_repo1)}/
+        specs:
+          rack (1.0.0)
 
-    simulate_ruby_version "5100"
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        rack
+
+      RUBY VERSION
+         ruby 2.1.4p422
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+    allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
-      ruby ">= 5000.0"
+      ruby ">= #{RUBY_VERSION[0..2]}.0"
       gem "rack"
     G
 
     expect(the_bundle).to include_gems "rack 1.0.0"
-    expect(locked_ruby_version.versions).to eq(["5100"])
+    expect(locked_ruby_version).to eq(Bundler::RubyVersion.system)
   end
 
   it "allows requirements with trailing whitespace" do

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -448,15 +448,6 @@ module Spec
       ENV["BUNDLER_SPEC_PLATFORM"] = old if block_given?
     end
 
-    def simulate_ruby_version(version)
-      return if version == RUBY_VERSION
-      old = ENV["BUNDLER_SPEC_RUBY_VERSION"]
-      ENV["BUNDLER_SPEC_RUBY_VERSION"] = version
-      yield if block_given?
-    ensure
-      ENV["BUNDLER_SPEC_RUBY_VERSION"] = old if block_given?
-    end
-
     def simulate_windows(platform = mswin)
       simulate_platform platform do
         simulate_bundler_version_when_missing_prerelease_default_gem_activation do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

These specs were monkeypatching `RUBY_VERSION`, but that obviously doesn't change the running ruby to behave any different.

The removal of some features, in particular, `String#untaint`, made these specs fail, because untaint is no longer available under ruby-core and Bundler calls `untaint` when `RUBY_VERSION` is less than "2.7", which these specs were overwriting it to be.

## What is your fix for the problem, implemented in this PR?

Rewrite these specs to not overwrite `RUBY_VERSION` but still test the same things.

NOTE: I also included in this PR an optimization to repository checkout in the workflow that tests Bundler against different versions of RubyGems.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
