### PR TITLE
Fix longstanding `gem install` failure on JRuby

### DIFF
--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -190,9 +190,6 @@ class Gem::StubSpecification < Gem::BasicSpecification
               end
 
     @spec ||= Gem::Specification.load(loaded_from)
-    @spec.ignored = @ignored if @spec
-
-    @spec
   end
 
   ##

--- a/test/rubygems/test_gem_stub_specification.rb
+++ b/test/rubygems/test_gem_stub_specification.rb
@@ -180,22 +180,6 @@ class TestStubSpecification < Gem::TestCase
     assert bar.to_spec
   end
 
-  def test_to_spec_activated
-    assert @foo.to_spec.is_a?(Gem::Specification)
-    assert_equal "foo", @foo.to_spec.name
-    refute @foo.to_spec.instance_variable_get :@ignored
-  end
-
-  def test_to_spec_missing_extensions
-    stub = stub_with_extension
-
-    capture_output do
-      stub.contains_requirable_file? 'nonexistent'
-    end
-
-    assert stub.to_spec.instance_variable_get :@ignored
-  end
-
   def stub_with_version
     spec = File.join @gemhome, 'specifications', 'stub_e-2.gemspec'
     File.open spec, 'w' do |io|


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

On JRuby, sometimes we get the following error in CI when running a realworld test that checks that `gem install rails` succeeds:

```
ERROR:  While executing gem ... (NoMethodError)
    undefined method `ignored=' for nil:NilClass
	/home/runner/.rubies/jruby-9.3.2.0/lib/ruby/stdlib/rubygems/stub_specification.rb:193:in `to_spec'
	org/jruby/RubyArray.java:2642:in `map'
	/home/runner/.rubies/jruby-9.3.2.0/lib/ruby/stdlib/rubygems/specification.rb:758:in `_all'
	/home/runner/.rubies/jruby-9.3.2.0/lib/ruby/stdlib/rubygems/specification.rb:956:in `each'
	org/jruby/RubyEnumerable.java:1710:in `any?'
	/home/runner/.rubies/jruby-9.3.2.0/lib/ruby/stdlib/rubygems/resolver/activation_request.rb:111:in `installed?'
	/home/runner/.rubies/jruby-9.3.2.0/lib/ruby/stdlib/rubygems/request_set.rb:173:in `block in install'
```

## What is your fix for the problem, implemented in this PR?

I'm not sure how this error is happening, but I think there's no need to copy the `@ignored` instance variable when materializing stub specifications. This instance variable is used to not print a warning about missing extensions more than once for each gem upon gem activation, but as far as I can see, it's only used by methods that work on specification stubs. Once specifications are materialized, I think it can be safely ignored.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
