### PR TITLE
Don't redownload `rubygems-update` package if already there

### DIFF
--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -119,7 +119,7 @@ module Spec
         ENV["BUNDLE_PATH__SYSTEM"] = "true"
       end
 
-      output = `#{Gem.ruby} #{File.expand_path("support/bundle.rb", Path.spec_dir)} install`
+      output = `#{Gem.ruby} #{File.expand_path("support/bundle.rb", Path.spec_dir)} install --verbose`
       raise "Error when installing gems in #{gemfile}: #{output}" unless $?.success?
     ensure
       if path

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -286,9 +286,8 @@ command to remove old versions.
 
     check_oldest_rubygems version
 
-    update_gem 'rubygems-update', version
-
     installed_gems = Gem::Specification.find_all_by_name 'rubygems-update', requirement
+    installed_gems = update_gem('rubygems-update', version) if installed_gems.empty?
     version        = installed_gems.first.version
 
     install_rubygems version


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Currently `gem update --system` always redownloads the target rubygems version, even if the package is already there locally.

## What is your fix for the problem, implemented in this PR?

My fix is to avoid redownloading if it's already there locally. This could improve performance in some cases, but the main goal of doing this is to allow testing the upgrade process more easily. If you want to simulate `gem update --system` to some version, you can build and install the target `rubygems-update` package locally, and `gem update --system` will pick it up.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
