### PR TITLE
Changelogs for rubygems 3.3.4 and bundler 2.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# 3.3.4 / 2021-12-29
+
+## Enhancements:
+
+* Don't redownload `rubygems-update` package if already there. Pull
+  request #5230 by deivid-rodriguez
+* Installs bundler 2.3.4 as a default gem.
+
+## Bug fixes:
+
+* Fix `gem update --system` crashing when latest version not supported.
+  Pull request #5191 by deivid-rodriguez
+
+## Performance:
+
+* Make SpecificationPolicy autoload constant. Pull request #5222 by pocke
+
 # 3.3.3 / 2021-12-24
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 2.3.4 (December 29, 2021)
+
+## Enhancements:
+
+  - Improve error message when `BUNDLED WITH` version does not exist [#5205](https://github.com/rubygems/rubygems/pull/5205)
+
+## Bug fixes:
+
+  - Fix `bundle update --bundler` no longer updating lockfile [#5224](https://github.com/rubygems/rubygems/pull/5224)
+
 # 2.3.3 (December 24, 2021)
 
 ## Bug fixes:


### PR DESCRIPTION
Cherry-picking changelogs from future rubygems 3.3.4 and bundler 2.3.4 into master.