### PR TITLE
Better way to join path components in VCR specs

### DIFF
--- a/bundler/spec/support/artifice/vcr.rb
+++ b/bundler/spec/support/artifice/vcr.rb
@@ -69,7 +69,7 @@ class BundlerVCRHTTP < Net::HTTP
     end
 
     def file_name_for_key(key)
-      key.join("/").gsub(/[\:*?"<>|]/, "-")
+      File.join(*key).gsub(/[\:*?"<>|]/, "-")
     end
 
     def request_pair_paths


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The current way works, but error messages show duplicate "/" in paths, which is weird.

## What is your fix for the problem, implemented in this PR?

Join using `File.join`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
