### PR TITLE
Let `gem fetch` understand `<gem>:<version>` syntax and `--[no-]suggestions` flag

### DIFF
--- a/lib/rubygems/commands/fetch_command.rb
+++ b/lib/rubygems/commands/fetch_command.rb
@@ -18,6 +18,10 @@ class Gem::Commands::FetchCommand < Gem::Command
     add_version_option
     add_platform_option
     add_prerelease_option
+
+    add_option '--[no-]suggestions', 'Suggest alternates when gems are not found' do |value, options|
+      options[:suggest_alternate] = true
+    end
   end
 
   def arguments # :nodoc:
@@ -42,15 +46,27 @@ then repackaging it.
     "#{program_name} GEMNAME [GEMNAME ...]"
   end
 
+  def check_version # :nodoc:
+    if options[:version] and options[:version] != Gem::Requirement.default and
+         get_all_gem_names.size > 1
+      alert_error "Can't use --version with multiple gems. You can specify multiple gems with" \
+                  " version requirements using `gem fetch 'my_gem:1.0.0' 'my_other_gem:~>2.0.0'`"
+      terminate_interaction 1
+    end
+  end
+
   def execute
-    version = options[:version] || Gem::Requirement.default
+    check_version
+    version = options[:version]
 
     platform  = Gem.platforms.last
-    gem_names = get_all_gem_names
+    gem_names = get_all_gem_names_and_versions
 
-    gem_names.each do |gem_name|
-      dep = Gem::Dependency.new gem_name, version
+    gem_names.each do |gem_name, gem_version|
+      gem_version ||= version
+      dep = Gem::Dependency.new gem_name, gem_version
       dep.prerelease = options[:prerelease]
+      suppress_suggestions = options[:suggest_alternate]
 
       specs_and_sources, errors =
         Gem::SpecFetcher.fetcher.spec_for_dependency dep
@@ -63,12 +79,10 @@ then repackaging it.
       spec, source = specs_and_sources.max_by {|s,| s }
 
       if spec.nil?
-        show_lookup_failure gem_name, version, errors, options[:domain]
+        show_lookup_failure gem_name, gem_version, errors, suppress_suggestions, options[:domain]
         next
       end
-
       source.download spec
-
       say "Downloaded #{spec.full_name}"
     end
   end

--- a/lib/rubygems/commands/fetch_command.rb
+++ b/lib/rubygems/commands/fetch_command.rb
@@ -8,7 +8,12 @@ class Gem::Commands::FetchCommand < Gem::Command
   include Gem::VersionOption
 
   def initialize
-    super 'fetch', 'Download a gem and place it in the current directory'
+    defaults = {
+      :suggest_alternate => true,
+      :version           => Gem::Requirement.default,
+    }
+
+    super 'fetch', 'Download a gem and place it in the current directory', defaults
 
     add_bulk_threshold_option
     add_proxy_option
@@ -20,7 +25,7 @@ class Gem::Commands::FetchCommand < Gem::Command
     add_prerelease_option
 
     add_option '--[no-]suggestions', 'Suggest alternates when gems are not found' do |value, options|
-      options[:suggest_alternate] = true
+      options[:suggest_alternate] = value
     end
   end
 
@@ -47,7 +52,7 @@ then repackaging it.
   end
 
   def check_version # :nodoc:
-    if options[:version] and options[:version] != Gem::Requirement.default and
+    if options[:version] != Gem::Requirement.default and
          get_all_gem_names.size > 1
       alert_error "Can't use --version with multiple gems. You can specify multiple gems with" \
                   " version requirements using `gem fetch 'my_gem:1.0.0' 'my_other_gem:~>2.0.0'`"
@@ -66,7 +71,7 @@ then repackaging it.
       gem_version ||= version
       dep = Gem::Dependency.new gem_name, gem_version
       dep.prerelease = options[:prerelease]
-      suppress_suggestions = options[:suggest_alternate]
+      suppress_suggestions = !options[:suggest_alternate]
 
       specs_and_sources, errors =
         Gem::SpecFetcher.fetcher.spec_for_dependency dep

--- a/test/rubygems/test_gem_commands_fetch_command.rb
+++ b/test/rubygems/test_gem_commands_fetch_command.rb
@@ -242,7 +242,7 @@ ERROR:  Possible alternatives: foo
     end
 
     @cmd.options[:args] = %w[foo:2]
-    @cmd.options[:suggest_alternate] = true
+    @cmd.options[:suggest_alternate] = false
 
     use_ui @ui do
       @cmd.execute

--- a/test/rubygems/test_gem_commands_fetch_command.rb
+++ b/test/rubygems/test_gem_commands_fetch_command.rb
@@ -157,4 +157,101 @@ class TestGemCommandsFetchCommand < Gem::TestCase
     assert_path_exist(File.join(@tempdir, a1.file_name),
                        "#{a1.full_name} not fetched")
   end
+
+  def test_execute_version_specified_by_colon
+    specs = spec_fetcher do |fetcher|
+      fetcher.gem 'a', 1
+    end
+
+    @cmd.options[:args] = %w[a:1]
+
+    use_ui @ui do
+      Dir.chdir @tempdir do
+        @cmd.execute
+      end
+    end
+
+    a1 = specs['a-1']
+
+    assert_path_exist(File.join(@tempdir, a1.file_name),
+                       "#{a1.full_name} not fetched")
+  end
+
+  def test_execute_two_version
+    @cmd.options[:args] = %w[a b]
+    @cmd.options[:version] = Gem::Requirement.new '1'
+
+    use_ui @ui do
+      assert_raise Gem::MockGemUi::TermError, @ui.error do
+        @cmd.execute
+      end
+    end
+
+    msg = "ERROR:  Can't use --version with multiple gems. You can specify multiple gems with" \
+      " version requirements using `gem fetch 'my_gem:1.0.0' 'my_other_gem:~>2.0.0'`"
+
+    assert_empty @ui.output
+    assert_equal msg, @ui.error.chomp
+  end
+
+  def test_execute_two_version_specified_by_colon
+    specs = spec_fetcher do |fetcher|
+      fetcher.gem 'a', 1
+      fetcher.gem 'b', 1
+    end
+
+    @cmd.options[:args] = %w[a:1 b:1]
+
+    use_ui @ui do
+      Dir.chdir @tempdir do
+        @cmd.execute
+      end
+    end
+
+    a1 = specs['a-1']
+    b1 = specs['b-1']
+
+    assert_path_exist(File.join(@tempdir, a1.file_name),
+                       "#{a1.full_name} not fetched")
+    assert_path_exist(File.join(@tempdir, b1.file_name),
+                       "#{b1.full_name} not fetched")
+  end
+
+  def test_execute_version_nonexistent
+    spec_fetcher do |fetcher|
+      fetcher.spec 'foo', 1
+    end
+
+    @cmd.options[:args] = %w[foo:2]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    expected = <<-EXPECTED
+ERROR:  Could not find a valid gem 'foo' (2) in any repository
+ERROR:  Possible alternatives: foo
+    EXPECTED
+
+    assert_equal expected, @ui.error
+  end
+
+  def test_execute_nonexistent_hint_disabled
+    spec_fetcher do |fetcher|
+      fetcher.spec 'foo', 1
+    end
+
+    @cmd.options[:args] = %w[foo:2]
+    @cmd.options[:suggest_alternate] = true
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    expected = <<-EXPECTED
+ERROR:  Could not find a valid gem 'foo' (2) in any repository
+    EXPECTED
+
+    assert_equal expected, @ui.error
+  end
 end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->
When running `gem install <gem>:<version>` we can install the given gem at the given version, but running `gem fetch <gem>:<version>` is not supported and makes this an inconsistent behavior, as described in #5166.

## What is your fix for the problem, implemented in this PR?
The problem was in the `get_all_gem_names` function, which was taking the string `<gem>:<version>` as the entire name of the gem.
To fix it, now we get the names of the gems alongside the specified versions with `get_all_gem_names_and_versions` (similar to the `install` command) and check if there are multiple gems to be fetched and the `--version` flag to output an error message. 

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
