### PR TITLE
Fix `rake build:checksum` writing checksum of package path, not package contents

### DIFF
--- a/bundler/lib/bundler/gem_helper.rb
+++ b/bundler/lib/bundler/gem_helper.rb
@@ -107,7 +107,7 @@ module Bundler
       SharedHelpers.filesystem_access(File.join(base, "checksums")) {|p| FileUtils.mkdir_p(p) }
       file_name = "#{File.basename(built_gem_path)}.sha512"
       require "digest/sha2"
-      checksum = ::Digest::SHA512.new.hexdigest(built_gem_path.to_s)
+      checksum = ::Digest::SHA512.file(built_gem_path).hexdigest
       target = File.join(base, "checksums", file_name)
       File.write(target, checksum)
       Bundler.ui.confirm "#{name} #{version} checksum written to checksums/#{file_name}."

--- a/bundler/lib/bundler/gem_helper.rb
+++ b/bundler/lib/bundler/gem_helper.rb
@@ -109,7 +109,7 @@ module Bundler
       require "digest/sha2"
       checksum = ::Digest::SHA512.file(built_gem_path).hexdigest
       target = File.join(base, "checksums", file_name)
-      File.write(target, checksum)
+      File.write(target, checksum + "\n")
       Bundler.ui.confirm "#{name} #{version} checksum written to checksums/#{file_name}."
     end
 

--- a/bundler/spec/bundler/gem_helper_spec.rb
+++ b/bundler/spec/bundler/gem_helper_spec.rb
@@ -170,9 +170,11 @@ RSpec.describe Bundler::GemHelper do
 
     describe "#build_checksum" do
       it "calculates SHA512 of the content" do
-        subject.build_checksum(Pathname(IO::NULL))
-        sha_path = app_path.join("checksums", "#{File.basename(IO::NULL)}.sha512")
-        expect(File.read(sha_path).chomp).to eql(Digest::SHA512.hexdigest(""))
+        FileUtils.mkdir_p(app_gem_dir)
+        File.write(app_gem_path, "")
+        mock_checksum_message app_name, app_version
+        subject.build_checksum(app_gem_path)
+        expect(File.read(app_sha_path).chomp).to eql(Digest::SHA512.hexdigest(""))
       end
 
       context "when build was successful" do

--- a/bundler/spec/bundler/gem_helper_spec.rb
+++ b/bundler/spec/bundler/gem_helper_spec.rb
@@ -169,6 +169,12 @@ RSpec.describe Bundler::GemHelper do
     end
 
     describe "#build_checksum" do
+      it "calculates SHA512 of the content" do
+        subject.build_checksum(Pathname(IO::NULL))
+        sha_path = app_path.join("checksums", "#{File.basename(IO::NULL)}.sha512")
+        expect(File.read(sha_path)).to eql(Digest::SHA512.hexdigest(""))
+      end
+
       context "when build was successful" do
         it "creates .sha512 file" do
           mock_build_message app_name, app_version

--- a/bundler/spec/bundler/gem_helper_spec.rb
+++ b/bundler/spec/bundler/gem_helper_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe Bundler::GemHelper do
       it "calculates SHA512 of the content" do
         subject.build_checksum(Pathname(IO::NULL))
         sha_path = app_path.join("checksums", "#{File.basename(IO::NULL)}.sha512")
-        expect(File.read(sha_path)).to eql(Digest::SHA512.hexdigest(""))
+        expect(File.read(sha_path).chomp).to eql(Digest::SHA512.hexdigest(""))
       end
 
       context "when build was successful" do

--- a/bundler/spec/bundler/gem_helper_spec.rb
+++ b/bundler/spec/bundler/gem_helper_spec.rb
@@ -66,6 +66,10 @@ RSpec.describe Bundler::GemHelper do
       mock_confirm_message message
     end
 
+    def sha512_hexdigest(path)
+      Digest::SHA512.file(path).hexdigest
+    end
+
     subject! { Bundler::GemHelper.new(app_path) }
     let(:app_version) { "0.1.0" }
     let(:app_gem_dir) { app_path.join("pkg") }
@@ -183,6 +187,7 @@ RSpec.describe Bundler::GemHelper do
           mock_checksum_message app_name, app_version
           subject.build_checksum
           expect(app_sha_path).to exist
+          expect(File.read(app_sha_path).chomp).to eql(sha512_hexdigest(app_gem_path))
         end
       end
       context "when building in the current working directory" do
@@ -193,6 +198,7 @@ RSpec.describe Bundler::GemHelper do
             Bundler::GemHelper.new.build_checksum
           end
           expect(app_sha_path).to exist
+          expect(File.read(app_sha_path).chomp).to eql(sha512_hexdigest(app_gem_path))
         end
       end
       context "when building in a location relative to the current working directory" do
@@ -203,6 +209,7 @@ RSpec.describe Bundler::GemHelper do
             Bundler::GemHelper.new(File.basename(app_path)).build_checksum
           end
           expect(app_sha_path).to exist
+          expect(File.read(app_sha_path).chomp).to eql(sha512_hexdigest(app_gem_path))
         end
       end
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`rake build:checksum` calculates the checksum of the full pathname of the built gem file, not its content.
This means the file has a wrong value and checks by downloaded users will always fail.
Fix up #4156.

## What is your fix for the problem, implemented in this PR?

Calculate the checksum of the content.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
