### PR TITLE
Support for pre flag in `bundle update`/`bundle lock`

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -293,7 +293,7 @@ module Bundler
     method_option "major", :type => :boolean, :banner =>
       "Prefer updating to next major version (default)"
     method_option "pre", :type => :boolean, :banner =>
-      "If updating, allow consideration of prerelease gems"
+      "Always choose the highest allowed version when updating gems, regardless of prerelease status"
     method_option "strict", :type => :boolean, :banner =>
       "Do not allow any gem to be updated past latest --patch | --minor | --major"
     method_option "conservative", :type => :boolean, :banner =>
@@ -671,7 +671,7 @@ module Bundler
     method_option "major", :type => :boolean, :banner =>
       "If updating, prefer updating to next major version (default)"
     method_option "pre", :type => :boolean, :banner =>
-      "If updating, allow consideration of prerelease gems"
+      "If updating, always choose the highest allowed version, regardless of prerelease status"
     method_option "strict", :type => :boolean, :banner =>
       "If updating, do not allow any gem to be updated past latest --patch | --minor | --major"
     method_option "conservative", :type => :boolean, :banner =>

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -292,6 +292,8 @@ module Bundler
       "Prefer updating only to next minor version"
     method_option "major", :type => :boolean, :banner =>
       "Prefer updating to next major version (default)"
+    method_option "pre", :type => :boolean, :banner =>
+      "If updating, allow consideration of prerelease gems"
     method_option "strict", :type => :boolean, :banner =>
       "Do not allow any gem to be updated past latest --patch | --minor | --major"
     method_option "conservative", :type => :boolean, :banner =>
@@ -668,6 +670,8 @@ module Bundler
       "If updating, prefer updating only to next minor version"
     method_option "major", :type => :boolean, :banner =>
       "If updating, prefer updating to next major version (default)"
+    method_option "pre", :type => :boolean, :banner =>
+      "If updating, allow consideration of prerelease gems"
     method_option "strict", :type => :boolean, :banner =>
       "If updating, do not allow any gem to be updated past latest --patch | --minor | --major"
     method_option "conservative", :type => :boolean, :banner =>

--- a/bundler/lib/bundler/cli/common.rb
+++ b/bundler/lib/bundler/cli/common.rb
@@ -111,6 +111,7 @@ module Bundler
       definition.gem_version_promoter.tap do |gvp|
         gvp.level = patch_level.first || :major
         gvp.strict = options[:strict] || options["filter-strict"]
+        gvp.pre = options[:pre]
       end
     end
 

--- a/bundler/lib/bundler/gem_version_promoter.rb
+++ b/bundler/lib/bundler/gem_version_promoter.rb
@@ -100,11 +100,11 @@ module Bundler
 
         if major?
           a <=> b
-        elsif either_version_older_than_locked(a, b, locked_version)
+        elsif either_version_older_than_locked?(a, b, locked_version)
           a <=> b
-        elsif segments_do_not_match(a, b, :major)
+        elsif segments_do_not_match?(a, b, :major)
           b <=> a
-        elsif !minor? && segments_do_not_match(a, b, :minor)
+        elsif !minor? && segments_do_not_match?(a, b, :minor)
           b <=> a
         else
           a <=> b
@@ -113,11 +113,11 @@ module Bundler
       post_sort(result, package.unlock?, locked_version)
     end
 
-    def either_version_older_than_locked(a, b, locked_version)
+    def either_version_older_than_locked?(a, b, locked_version)
       locked_version && (a.version < locked_version || b.version < locked_version)
     end
 
-    def segments_do_not_match(a, b, level)
+    def segments_do_not_match?(a, b, level)
       index = [:major, :minor].index(level)
       a.segments[index] != b.segments[index]
     end

--- a/bundler/lib/bundler/gem_version_promoter.rb
+++ b/bundler/lib/bundler/gem_version_promoter.rb
@@ -74,12 +74,11 @@ module Bundler
 
       specs.select do |spec|
         gsv = spec.version
-        lsv = locked_version
 
         must_match = minor? ? [0] : [0, 1]
 
-        matches = must_match.map {|idx| gsv.segments[idx] == lsv.segments[idx] }
-        matches.uniq == [true] ? (gsv >= lsv) : false
+        all_match = must_match.all? {|idx| gsv.segments[idx] == locked_version.segments[idx] }
+        all_match && gsv >= locked_version
       end
     end
 

--- a/bundler/lib/bundler/gem_version_promoter.rb
+++ b/bundler/lib/bundler/gem_version_promoter.rb
@@ -70,19 +70,16 @@ module Bundler
 
     def filter_dep_specs(specs, package)
       locked_version = package.locked_version
+      return specs if locked_version.nil? || major?
 
       specs.select do |spec|
-        if locked_version && !major?
-          gsv = spec.version
-          lsv = locked_version
+        gsv = spec.version
+        lsv = locked_version
 
-          must_match = minor? ? [0] : [0, 1]
+        must_match = minor? ? [0] : [0, 1]
 
-          matches = must_match.map {|idx| gsv.segments[idx] == lsv.segments[idx] }
-          matches.uniq == [true] ? (gsv >= lsv) : false
-        else
-          true
-        end
+        matches = must_match.map {|idx| gsv.segments[idx] == lsv.segments[idx] }
+        matches.uniq == [true] ? (gsv >= lsv) : false
       end
     end
 

--- a/bundler/lib/bundler/gem_version_promoter.rb
+++ b/bundler/lib/bundler/gem_version_promoter.rb
@@ -8,6 +8,7 @@ module Bundler
   # to the resolution engine to select the best version.
   class GemVersionPromoter
     attr_reader :level
+    attr_accessor :pre
 
     # By default, strict is false, meaning every available version of a gem
     # is returned from sort_versions. The order gives preference to the
@@ -28,6 +29,7 @@ module Bundler
     def initialize
       @level = :major
       @strict = false
+      @pre = false
     end
 
     # @param value [Symbol] One of three Symbols: :major, :minor or :patch.
@@ -66,6 +68,11 @@ module Bundler
       level == :minor
     end
 
+    # @return [bool] Convenience method for testing value of pre variable.
+    def pre?
+      pre == true
+    end
+
     private
 
     def filter_dep_specs(specs, package)
@@ -86,7 +93,7 @@ module Bundler
       locked_version = package.locked_version
 
       result = specs.sort do |a, b|
-        unless locked_version && package.prerelease_specified?
+        unless locked_version && (package.prerelease_specified? || pre?)
           a_pre = a.prerelease?
           b_pre = b.prerelease?
 

--- a/bundler/lib/bundler/gem_version_promoter.rb
+++ b/bundler/lib/bundler/gem_version_promoter.rb
@@ -13,7 +13,7 @@ module Bundler
     # By default, strict is false, meaning every available version of a gem
     # is returned from sort_versions. The order gives preference to the
     # requested level (:patch, :minor, :major) but in complicated requirement
-    # cases some gems will by necessity by promoted past the requested level,
+    # cases some gems will by necessity be promoted past the requested level,
     # or even reverted to older versions.
     #
     # If strict is set to true, the results from sort_versions will be

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -176,7 +176,10 @@ RSpec.describe "bundle lock" do
         build_gem "foo", %w[1.5.1] do |s|
           s.add_dependency "bar", "~> 3.0"
         end
-        build_gem "bar", %w[2.0.3 2.0.4 2.0.5 2.1.0 2.1.1 3.0.0]
+        build_gem "foo", %w[2.0.0.pre] do |s|
+          s.add_dependency "bar"
+        end
+        build_gem "bar", %w[2.0.3 2.0.4 2.0.5 2.1.0 2.1.1 2.1.2.pre 3.0.0 3.1.0.pre 4.0.0.pre]
         build_gem "qux", %w[1.0.0 1.0.1 1.1.0 2.0.0]
       end
 
@@ -209,6 +212,32 @@ RSpec.describe "bundle lock" do
       bundle "lock --update --minor --strict"
 
       expect(the_bundle.locked_gems.specs.map(&:full_name)).to eq(%w[foo-1.5.0 bar-2.1.1 qux-1.1.0].sort)
+    end
+
+    context "pre" do
+      it "defaults to major" do
+        bundle "lock --update --pre"
+
+        expect(the_bundle.locked_gems.specs.map(&:full_name)).to eq(%w[foo-2.0.0.pre bar-4.0.0.pre qux-2.0.0].sort)
+      end
+
+      it "patch preferred" do
+        bundle "lock --update --patch --pre"
+
+        expect(the_bundle.locked_gems.specs.map(&:full_name)).to eq(%w[foo-1.4.5 bar-2.1.2.pre qux-1.0.1].sort)
+      end
+
+      it "minor preferred" do
+        bundle "lock --update --minor --pre"
+
+        expect(the_bundle.locked_gems.specs.map(&:full_name)).to eq(%w[foo-1.5.1 bar-3.1.0.pre qux-1.1.0].sort)
+      end
+
+      it "major preferred" do
+        bundle "lock --update --major --pre"
+
+        expect(the_bundle.locked_gems.specs.map(&:full_name)).to eq(%w[foo-2.0.0.pre bar-4.0.0.pre qux-2.0.0].sort)
+      end
     end
   end
 

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -1471,7 +1471,10 @@ RSpec.describe "bundle update conservative" do
         build_gem "foo", %w[1.5.1] do |s|
           s.add_dependency "bar", "~> 3.0"
         end
-        build_gem "bar", %w[2.0.3 2.0.4 2.0.5 2.1.0 2.1.1 3.0.0]
+        build_gem "foo", %w[2.0.0.pre] do |s|
+          s.add_dependency "bar"
+        end
+        build_gem "bar", %w[2.0.3 2.0.4 2.0.5 2.1.0 2.1.1 2.1.2.pre 3.0.0 3.1.0.pre 4.0.0.pre]
         build_gem "qux", %w[1.0.0 1.0.1 1.1.0 2.0.0]
       end
 
@@ -1534,6 +1537,32 @@ RSpec.describe "bundle update conservative" do
         bundle "update --minor --strict", :all => true
 
         expect(the_bundle).to include_gems "foo 1.5.0", "bar 2.1.1", "qux 1.1.0"
+      end
+    end
+
+    context "pre" do
+      it "defaults to major" do
+        bundle "update --pre foo bar"
+
+        expect(the_bundle).to include_gems "foo 2.0.0.pre", "bar 4.0.0.pre", "qux 1.0.0"
+      end
+
+      it "patch preferred" do
+        bundle "update --patch --pre foo bar"
+
+        expect(the_bundle).to include_gems "foo 1.4.5", "bar 2.1.2.pre", "qux 1.0.0"
+      end
+
+      it "minor preferred" do
+        bundle "update --minor --pre foo bar"
+
+        expect(the_bundle).to include_gems "foo 1.5.1", "bar 3.1.0.pre", "qux 1.0.0"
+      end
+
+      it "major preferred" do
+        bundle "update --major --pre foo bar"
+
+        expect(the_bundle).to include_gems "foo 2.0.0.pre", "bar 4.0.0.pre", "qux 1.0.0"
       end
     end
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

More thoroughly described in https://github.com/rubygems/rubygems/issues/5207, but essentially allowing bumps to prerelease versions of gems without specifying a version in the lockfile.

## What is your fix for the problem, implemented in this PR?

Passing this flag allows bumping to the current version, even if that
version is prerelease. This is a superset of the major flag since it
behaves the same but also considers prerelease versions.

The main alternative I see would be having pre work in concert with the currently existing flags. This would mean passing `--pre --major` would work as in this PR, but `--pre --minor` would prefer not to bump major versions.

Assuming we want the current behavior, are there any other commands I should update, or any other places I should add specs?

Closes #5207.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
