### PR TITLE
Use thor-1.2.1

### DIFF
--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -171,12 +171,9 @@ Automatiek::RakeTask.new("molinillo") do |lib|
   end
 end
 
-# We currently include the official version as of
-# https://github.com/rails/thor/commit/5c666b4c25e748e57eec2d529d94c5059030979e
-# with a change on top to support did_you_mean-1.6.0.
 desc "Vendor a specific version of thor"
 Automatiek::RakeTask.new("thor") do |lib|
-  lib.version = "master"
+  lib.version = "v1.2.1"
   lib.download = { :github => "https://github.com/erikhuda/thor" }
   lib.namespace = "Thor"
   lib.prefix = "Bundler"

--- a/bundler/lib/bundler/vendor/thor/lib/thor/actions/inject_into_file.rb
+++ b/bundler/lib/bundler/vendor/thor/lib/thor/actions/inject_into_file.rb
@@ -107,10 +107,7 @@ class Bundler::Thor
       #
       def replace!(regexp, string, force)
         content = File.read(destination)
-        before, after = content.split(regexp, 2)
-        snippet = (behavior == :after ? after : before).to_s
-
-        if force || !snippet.include?(replacement)
+        if force || !content.include?(replacement)
           success = content.gsub!(regexp, string)
 
           File.open(destination, "wb") { |file| file.write(content) } unless pretend?

--- a/bundler/lib/bundler/vendor/thor/lib/thor/version.rb
+++ b/bundler/lib/bundler/vendor/thor/lib/thor/version.rb
@@ -1,3 +1,3 @@
 class Bundler::Thor
-  VERSION = "1.1.0"
+  VERSION = "1.2.1"
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Thor-1.2.1 fixes the regression with `insert_into_file`.

https://github.com/rails/thor/releases/tag/v1.2.1

## What is your fix for the problem, implemented in this PR?

Run `rake vendor:thor[v1.2.1]`

But I wonder why the current version is `1.1.0`. I think we already updated thor-1.2.0 with this diff.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
