### PR TITLE
Fix `gem install <non-existent-gem> --force` crash

### DIFF
--- a/lib/rubygems/resolver/installer_set.rb
+++ b/lib/rubygems/resolver/installer_set.rb
@@ -76,21 +76,21 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
 
     newest = found.last
 
+    unless newest
+      exc = Gem::UnsatisfiableDependencyError.new request
+      exc.errors = errors
+
+      raise exc
+    end
+
     unless @force
       found_matching_metadata = found.reverse.find do |spec|
         metadata_satisfied?(spec)
       end
 
       if found_matching_metadata.nil?
-        if newest
-          ensure_required_ruby_version_met(newest.spec)
-          ensure_required_rubygems_version_met(newest.spec)
-        else
-          exc = Gem::UnsatisfiableDependencyError.new request
-          exc.errors = errors
-
-          raise exc
-        end
+        ensure_required_ruby_version_met(newest.spec)
+        ensure_required_rubygems_version_met(newest.spec)
       else
         newest = found_matching_metadata
       end

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -277,6 +277,22 @@ ERROR:  Could not find a valid gem 'bar' (= 0.5) (required by 'foo' (>= 0)) in a
     assert_match(/ould not find a valid gem 'nonexistent'/, @ui.error)
   end
 
+  def test_execute_nonexistent_force
+    spec_fetcher
+
+    @cmd.options[:args] = %w[nonexistent]
+    @cmd.options[:force] = true
+
+    use_ui @ui do
+      e = assert_raise Gem::MockGemUi::TermError do
+        @cmd.execute
+      end
+      assert_equal 2, e.exit_code
+    end
+
+    assert_match(/ould not find a valid gem 'nonexistent'/, @ui.error)
+  end
+
   def test_execute_dependency_nonexistent
     spec_fetcher do |fetcher|
       fetcher.spec 'foo', 2, 'bar' => '0.5'


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I run `gem install <mistyped-gem> --force` and got a crash.

```
$ gem install sfdsfdsfsdide --force
ERROR:  While executing gem ... (NoMethodError)
    undefined method `spec' for nil:NilClass

    @always_install << newest.spec
                             ^^^^^
```

## What is your fix for the problem, implemented in this PR?

Move bailing out when there are no valid candidates for the name to be outside of the block that's skipped by `--force`, so that it still behaves as expected in this case.

With that change in place, it behaves as expected:

```
$ gem install sfdsfdsfsdide --force
ERROR:  Could not find a valid gem 'sfdsfdsfsdide' (>= 0) in any repository
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
