### PR TITLE
Don't activate `yaml` gem from RubyGems

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -606,17 +606,10 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   def self.load_yaml
     return if @yaml_loaded
 
-    begin
-      # Try requiring the gem version *or* stdlib version of psych.
-      require 'psych'
-    rescue ::LoadError
-      # If we can't load psych, that's fine, go on.
-    else
-      require_relative 'rubygems/psych_additions'
-      require_relative 'rubygems/psych_tree'
-    end
+    require 'psych'
+    require_relative 'rubygems/psych_additions'
+    require_relative 'rubygems/psych_tree'
 
-    require 'yaml'
     require_relative 'rubygems/safe_yaml'
 
     @yaml_loaded = true

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -230,7 +230,7 @@ class Gem::Package
 
     tar.add_file_signed 'checksums.yaml.gz', 0444, @signer do |io|
       gzip_to io do |gz_io|
-        YAML.dump checksums_by_algorithm, gz_io
+        Psych.dump checksums_by_algorithm, gz_io
       end
     end
   end

--- a/lib/rubygems/package/old.rb
+++ b/lib/rubygems/package/old.rb
@@ -145,7 +145,7 @@ class Gem::Package::Old < Gem::Package
 
     begin
       @spec = Gem::Specification.from_yaml yaml
-    rescue YAML::SyntaxError
+    rescue Psych::SyntaxError
       raise Gem::Exception, "Failed to parse gem specification out of gem file"
     end
   rescue ArgumentError

--- a/lib/rubygems/psych_additions.rb
+++ b/lib/rubygems/psych_additions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 # This exists just to satisfy bugs in marshal'd gemspecs that
-# contain a reference to YAML::PrivateType. We prune these out
+# contain a reference to Psych::PrivateType. We prune these out
 # in Specification._load, but if we don't have the constant, Marshal
 # blows up.
 

--- a/lib/rubygems/safe_yaml.rb
+++ b/lib/rubygems/safe_yaml.rb
@@ -24,33 +24,33 @@ module Gem
       runtime
     ].freeze
 
-    if ::YAML.respond_to? :safe_load
+    if ::Psych.respond_to? :safe_load
       def self.safe_load(input)
         if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0.pre1')
-          ::YAML.safe_load(input, permitted_classes: PERMITTED_CLASSES, permitted_symbols: PERMITTED_SYMBOLS, aliases: true)
+          ::Psych.safe_load(input, permitted_classes: PERMITTED_CLASSES, permitted_symbols: PERMITTED_SYMBOLS, aliases: true)
         else
-          ::YAML.safe_load(input, PERMITTED_CLASSES, PERMITTED_SYMBOLS, true)
+          ::Psych.safe_load(input, PERMITTED_CLASSES, PERMITTED_SYMBOLS, true)
         end
       end
 
       def self.load(input)
         if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0.pre1')
-          ::YAML.safe_load(input, permitted_classes: [::Symbol])
+          ::Psych.safe_load(input, permitted_classes: [::Symbol])
         else
-          ::YAML.safe_load(input, [::Symbol])
+          ::Psych.safe_load(input, [::Symbol])
         end
       end
     else
       unless Gem::Deprecate.skip
-        warn "YAML safe loading is not available. Please upgrade psych to a version that supports safe loading (>= 2.0)."
+        warn "Psych safe loading is not available. Please upgrade psych to a version that supports safe loading (>= 2.0)."
       end
 
       def self.safe_load(input, *args)
-        ::YAML.load input
+        ::Psych.load input
       end
 
       def self.load(input)
-        ::YAML.load input
+        ::Psych.load input
       end
     end
   end

--- a/lib/rubygems/security.rb
+++ b/lib/rubygems/security.rb
@@ -261,7 +261,7 @@ require_relative 'openssl'
 # 2. Grab the public key from the gemspec
 #
 #      gem spec some_signed_gem-1.0.gem cert_chain | \
-#        ruby -ryaml -e 'puts YAML.load($stdin)' > public_key.crt
+#        ruby -rpsych -e 'puts Psych.load($stdin)' > public_key.crt
 #
 # 3. Generate a SHA1 hash of the data.tar.gz
 #

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1279,10 +1279,10 @@ class Gem::Specification < Gem::BasicSpecification
       raise TypeError, "invalid Gem::Specification format #{array.inspect}"
     end
 
-    # Cleanup any YAML::PrivateType. They only show up for an old bug
+    # Cleanup any Psych::PrivateType. They only show up for an old bug
     # where nil => null, so just convert them to nil based on the type.
 
-    array.map! {|e| e.kind_of?(YAML::PrivateType) ? nil : e }
+    array.map! {|e| e.kind_of?(Psych::PrivateType) ? nil : e }
 
     spec.instance_variable_set :@rubygems_version,          array[0]
     # spec version

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -685,10 +685,10 @@ class Gem::TestCase < Test::Unit::TestCase
   # Load a YAML string, the psych 3 way
 
   def load_yaml(yaml)
-    if YAML.respond_to?(:unsafe_load)
-      YAML.unsafe_load(yaml)
+    if Psych.respond_to?(:unsafe_load)
+      Psych.unsafe_load(yaml)
     else
-      YAML.load(yaml)
+      Psych.load(yaml)
     end
   end
 
@@ -696,10 +696,10 @@ class Gem::TestCase < Test::Unit::TestCase
   # Load a YAML file, the psych 3 way
 
   def load_yaml_file(file)
-    if YAML.respond_to?(:unsafe_load_file)
-      YAML.unsafe_load_file(file)
+    if Psych.respond_to?(:unsafe_load_file)
+      Psych.unsafe_load_file(file)
     else
-      YAML.load_file(file)
+      Psych.load_file(file)
     end
   end
 

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -822,7 +822,7 @@ class TestGemPackage < Gem::Package::TarTestCase
       }
       tar.add_file 'checksums.yaml.gz', 0444 do |io|
         Zlib::GzipWriter.wrap io do |gz_io|
-          gz_io.write YAML.dump bogus_checksums
+          gz_io.write Psych.dump bogus_checksums
         end
       end
     end
@@ -868,7 +868,7 @@ class TestGemPackage < Gem::Package::TarTestCase
 
       tar.add_file 'checksums.yaml.gz', 0444 do |io|
         Zlib::GzipWriter.wrap io do |gz_io|
-          gz_io.write YAML.dump checksums
+          gz_io.write Psych.dump checksums
         end
       end
 

--- a/util/changelog.rb
+++ b/util/changelog.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "yaml"
+require "psych"
 
 class ChangelogEntry
   attr_reader :title, :template, :labels, :pull_request
@@ -55,7 +55,7 @@ class Changelog
   def initialize(file, version)
     @version = Gem::Version.new(version)
     @file = File.expand_path(file)
-    @config = YAML.load_file("#{File.dirname(file)}/.changelog.yml")
+    @config = Psych.load_file("#{File.dirname(file)}/.changelog.yml")
     @level = @version.segments[2] != 0 ? :patch : :minor_or_major
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I'm not sure there's any realworld user problem related to this. My developer problem is that sometimes I need to write some specs that work on an isolated default gem location, and I have to artificially install a bunch of default gems to that location, because Bundler & RubyGems use them internally.

See this abominable spec for example

https://github.com/rubygems/rubygems/blob/a9f9341e08478426ca3aa7829b5be4534cee06c1/bundler/spec/install/gems/standalone_spec.rb#L111-L149

So the less default gems we use internally, the easier is to write this kind of spec.

## What is your fix for the problem, implemented in this PR?

If I understand correctly, activating the `yaml` gem only defines `YAML` as an alias to `Psych`. Previously we used `Psych` and `YAML` inconsistently. I think it's best to use `Psych` consistently.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
