### PR TITLE
Markup `Gem::Specification` documentation with RDoc notations

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -225,7 +225,7 @@ class Gem::Specification < Gem::BasicSpecification
   attr_reader :version
 
   ##
-  # A short summary of this gem's description.  Displayed in `gem list -d`.
+  # A short summary of this gem's description.  Displayed in <tt>gem list -d</tt>.
   #
   # The #description should be more detailed than the summary.
   #
@@ -271,7 +271,7 @@ class Gem::Specification < Gem::BasicSpecification
   # A list of authors for this gem.
   #
   # Alternatively, a single author can be specified by assigning a string to
-  # `spec.author`
+  # +spec.author+
   #
   # Usage:
   #


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In the generated HTML file `Gem/Specification.html`, the codes are not shown as expected.

## What is your fix for the problem, implemented in this PR?

Use correct RDoc notations for code.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
