### PR TITLE
Don't let bundler retry on non-network error

### DIFF
--- a/bundler/lib/bundler/fetcher.rb
+++ b/bundler/lib/bundler/fetcher.rb
@@ -115,7 +115,7 @@ module Bundler
 
     # return the specs in the bundler format as an index with retries
     def specs_with_retry(gem_names, source)
-      Bundler::Retry.new("fetcher", FAIL_ERRORS).attempts do
+      Bundler::Retry.new("fetcher", HTTP_ERRORS).attempts do
         specs(gem_names, source)
       end
     end

--- a/bundler/lib/bundler/fetcher/dependency.rb
+++ b/bundler/lib/bundler/fetcher/dependency.rb
@@ -28,7 +28,7 @@ module Bundler
 
         return last_spec_list if query_list.empty?
 
-        spec_list, deps_list = Bundler::Retry.new("dependency api", FAIL_ERRORS).attempts do
+        spec_list, deps_list = Bundler::Retry.new("dependency api", Bundler::Fetcher::HTTP_ERRORS).attempts do
           dependency_specs(query_list)
         end
 

--- a/bundler/lib/bundler/retry.rb
+++ b/bundler/lib/bundler/retry.rb
@@ -19,7 +19,7 @@ module Bundler
     def initialize(name, exceptions = nil, retries = self.class.default_retries)
       @name = name
       @retries = retries
-      @exceptions = Array(exceptions) || []
+      @exceptions = Array(exceptions) || [] # Allow list of exceptions
       @total_runs = @retries + 1 # will run once, then upto attempts.times
     end
 
@@ -44,7 +44,7 @@ module Bundler
 
     def fail_attempt(e)
       @failed = true
-      if last_attempt? || @exceptions.any? {|k| e.is_a?(k) }
+      if last_attempt? || allow_error?(e)
         Bundler.ui.info "" unless Bundler.ui.debug?
         raise e
       end
@@ -61,6 +61,11 @@ module Bundler
 
     def last_attempt?
       current_run >= total_runs
+    end
+
+    def allow_error?(e)
+      # Just allow errors that are part of the allowlist of exceptions
+      !@exceptions.empty? && @exceptions.none? {|k| e.is_a?(k) }
     end
   end
 end

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -494,7 +494,8 @@ module Bundler
       uri = Bundler.settings.mirror_for(uri)
       fetcher = gem_remote_fetcher
       fetcher.headers = { "X-Gemfile-Source" => spec.remote.original_uri.to_s } if spec.remote.original_uri
-      Bundler::Retry.new("download gem from #{uri}").attempts do
+      retry_download = Bundler::Retry.new("download gem from #{uri}")
+      retry_download.attempts do
         gem_file_name = spec.file_name
         local_gem_path = File.join cache_dir, gem_file_name
         return if File.exist? local_gem_path
@@ -506,14 +507,24 @@ module Bundler
           SharedHelpers.filesystem_access(local_gem_path) do
             fetcher.cache_update_path remote_gem_path, local_gem_path
           end
-        rescue Gem::RemoteFetcher::FetchError
-          raise if spec.original_platform == spec.platform
+        rescue StandardError => e
+          if e.is_a? Gem::RemoteFetcher::FetchError
+            raise if spec.original_platform == spec.platform
 
-          original_gem_file_name = "#{spec.original_name}.gem"
-          raise if gem_file_name == original_gem_file_name
+            original_gem_file_name = "#{spec.original_name}.gem"
+            raise if gem_file_name == original_gem_file_name
 
-          gem_file_name = original_gem_file_name
-          retry
+            gem_file_name = original_gem_file_name
+            retry
+          end
+
+          raise e if Bundler::Fetcher::HTTP_ERRORS.any? {|k| e.is_a?(k) }
+
+          # If error is not a network error, don't retry
+          # This is not the most elegant way to break the loop and
+          # keep track of the error
+          retry_download.current_run = retry_download.total_runs
+          raise e
         end
       end
     rescue Gem::RemoteFetcher::FetchError => e

--- a/bundler/spec/bundler/fetcher/dependency_spec.rb
+++ b/bundler/spec/bundler/fetcher/dependency_spec.rb
@@ -66,15 +66,15 @@ RSpec.describe Bundler::Fetcher::Dependency do
     let(:gem_names)            { %w[foo bar] }
     let(:full_dependency_list) { ["bar"] }
     let(:last_spec_list)       { [["boulder", gem_version1, "ruby", resque]] }
-    let(:fail_errors)          { double(:fail_errors) }
+    let(:network_errors)       { double(:network_errors) }
     let(:bundler_retry)        { double(:bundler_retry) }
     let(:gem_version1)         { double(:gem_version1) }
     let(:resque)               { double(:resque) }
     let(:remote_uri)           { "http://remote-uri.org" }
 
     before do
-      stub_const("Bundler::Fetcher::FAIL_ERRORS", fail_errors)
-      allow(Bundler::Retry).to receive(:new).with("dependency api", fail_errors).and_return(bundler_retry)
+      stub_const("Bundler::Fetcher::HTTP_ERRORS", network_errors)
+      allow(Bundler::Retry).to receive(:new).with("dependency api", network_errors).and_return(bundler_retry)
       allow(bundler_retry).to receive(:attempts) {|&block| block.call }
       allow(subject).to receive(:log_specs) {}
       allow(subject).to receive(:remote_uri).and_return(remote_uri)

--- a/bundler/spec/bundler/retry_spec.rb
+++ b/bundler/spec/bundler/retry_spec.rb
@@ -38,7 +38,43 @@ RSpec.describe Bundler::Retry do
     error = Bundler::GemfileNotFound
     attempts = 0
     expect do
-      Bundler::Retry.new(nil, error).attempt do
+      Bundler::Retry.new(nil, Bundler::Fetcher::HTTP_ERRORS).attempt do
+        attempts += 1
+        raise error
+      end
+    end.to raise_error(error)
+    expect(attempts).to eq(1)
+  end
+
+  it "raises exceptions with 4 attempts, no exceptions array" do
+    error = Bundler::GemfileNotFound
+    attempts = 0
+    expect do
+      Bundler::Retry.new(nil).attempt do
+        attempts += 1
+        raise error
+      end
+    end.to raise_error(error)
+    expect(attempts).to eq(4)
+  end
+
+  it "raises exceptions with 4 attempts with exceptions array" do
+    error = Bundler::GemfileNotFound
+    attempts = 0
+    expect do
+      Bundler::Retry.new(nil, [Bundler::GemfileNotFound]).attempt do
+        attempts += 1
+        raise error
+      end
+    end.to raise_error(error)
+    expect(attempts).to eq(4)
+  end
+
+  it "raises exceptions with 1 attempt with exceptions array" do
+    error = Bundler::GemfileNotFound
+    attempts = 0
+    expect do
+      Bundler::Retry.new(nil, Bundler::Fetcher::HTTP_ERRORS).attempt do
         attempts += 1
         raise error
       end

--- a/bundler/spec/bundler/rubygems_integration_spec.rb
+++ b/bundler/spec/bundler/rubygems_integration_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Bundler::RubygemsIntegration do
     it "successfully downloads gem with retries" do
       expect(Bundler.rubygems).to receive(:gem_remote_fetcher).and_return(fetcher)
       expect(fetcher).to receive(:headers=).with("X-Gemfile-Source" => "https://foo.bar")
-      expect(Bundler::Retry).to receive(:new).with("download gem from #{uri}/").
+      expect(Bundler::Retry).to receive(:new).with("download gem from #{uri}/", Bundler::Fetcher::HTTP_ERRORS).
         and_return(bundler_retry)
       expect(bundler_retry).to receive(:attempts).and_yield
       expect(fetcher).to receive(:cache_update_path)


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

As described in #5161, `bundle` will retry on any error, even if it isn't a network error.

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?
If an error occurs when attempting to download a gem we check if the error is network-related. If it isn't, we don't keep retrying the operation.
In order to show the correct error, we tell the `Retry` object that it's on its last attempt. This will print the correct error report format (This may not be the most elegant way to exit the loop and keep track of the error for later display). The allowlist for the network errors was taken from the `Bundler::Fetcher` class.

Fixes #5161.

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
