### PR TITLE
Create minitest file to underscored path in "bundle gem" command with dashed gem name

### DIFF
--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -38,6 +38,7 @@ module Bundler
       namespaced_path = name.tr("-", "/")
       constant_name = name.gsub(/-[_-]*(?![_-]|$)/) { "::" }.gsub(/([_-]+|(::)|^)(.|$)/) { $2.to_s + $3.upcase }
       constant_array = constant_name.split("::")
+      minitest_constant_name = constant_array.clone.tap {|a| a[-1] = "Test#{a[-1]}" }.join("::") # Foo::Bar => Foo::TestBar
 
       use_git = Bundler.git_present? && options[:git]
 
@@ -69,6 +70,7 @@ module Bundler
         :git              => use_git,
         :github_username  => github_username.empty? ? "[USERNAME]" : github_username,
         :required_ruby_version => required_ruby_version,
+        :minitest_constant_name => minitest_constant_name,
       }
       ensure_safe_gem_name(name, constant_array)
 

--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -104,9 +104,17 @@ module Bundler
           )
           config[:test_task] = :spec
         when "minitest"
+          # Generate path for minitest target file (FileList["test/**/test_*.rb"])
+          #   foo     => test/test_foo.rb
+          #   foo-bar => test/foo/test_bar.rb
+          #   foo_bar => test/test_foo_bar.rb
+          paths = namespaced_path.rpartition("/")
+          paths[2] = "test_#{paths[2]}"
+          minitest_namespaced_path = paths.join("")
+
           templates.merge!(
             "test/minitest/test_helper.rb.tt" => "test/test_helper.rb",
-            "test/minitest/test_newgem.rb.tt" => "test/test_#{underscored_name}.rb"
+            "test/minitest/test_newgem.rb.tt" => "test/#{minitest_namespaced_path}.rb"
           )
           config[:test_task] = :test
         when "test-unit"

--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -106,7 +106,7 @@ module Bundler
         when "minitest"
           templates.merge!(
             "test/minitest/test_helper.rb.tt" => "test/test_helper.rb",
-            "test/minitest/test_newgem.rb.tt" => "test/test_#{namespaced_path}.rb"
+            "test/minitest/test_newgem.rb.tt" => "test/test_#{underscored_name}.rb"
           )
           config[:test_task] = :test
         when "test-unit"

--- a/bundler/lib/bundler/templates/newgem/test/minitest/test_newgem.rb.tt
+++ b/bundler/lib/bundler/templates/newgem/test/minitest/test_newgem.rb.tt
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class Test<%= config[:constant_name] %> < Minitest::Test
+class Test<%= config[:constant_name].gsub('::', '') %> < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::<%= config[:constant_name] %>::VERSION
   end

--- a/bundler/lib/bundler/templates/newgem/test/minitest/test_newgem.rb.tt
+++ b/bundler/lib/bundler/templates/newgem/test/minitest/test_newgem.rb.tt
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class Test<%= config[:constant_name].gsub('::', '') %> < Minitest::Test
+class <%= config[:minitest_constant_name] %> < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::<%= config[:constant_name] %>::VERSION
   end

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -696,18 +696,22 @@ RSpec.describe "bundle gem" do
     end
 
     context "gem.test setting set to rspec and --test is set to minitest" do
+      let(:underscored_require_path) { require_path.tr("/", "_") }
+
       before do
         bundle "config set gem.test rspec"
         bundle "gem #{gem_name} --test=minitest"
       end
 
       it "builds spec skeleton" do
-        expect(bundled_app("#{gem_name}/test/test_#{require_path}.rb")).to exist
+        expect(bundled_app("#{gem_name}/test/test_#{underscored_require_path}.rb")).to exist
         expect(bundled_app("#{gem_name}/test/test_helper.rb")).to exist
       end
     end
 
     context "--test parameter set to minitest" do
+      let(:underscored_require_path) { require_path.tr("/", "_") }
+
       before do
         bundle "gem #{gem_name} --test=minitest"
       end
@@ -722,7 +726,7 @@ RSpec.describe "bundle gem" do
       end
 
       it "builds spec skeleton" do
-        expect(bundled_app("#{gem_name}/test/test_#{require_path}.rb")).to exist
+        expect(bundled_app("#{gem_name}/test/test_#{underscored_require_path}.rb")).to exist
         expect(bundled_app("#{gem_name}/test/test_helper.rb")).to exist
       end
 
@@ -731,11 +735,11 @@ RSpec.describe "bundle gem" do
       end
 
       it "requires 'test_helper'" do
-        expect(bundled_app("#{gem_name}/test/test_#{require_path}.rb").read).to include(%(require "test_helper"))
+        expect(bundled_app("#{gem_name}/test/test_#{underscored_require_path}.rb").read).to include(%(require "test_helper"))
       end
 
       it "creates a default test which fails" do
-        expect(bundled_app("#{gem_name}/test/test_#{require_path}.rb").read).to include("assert false")
+        expect(bundled_app("#{gem_name}/test/test_#{underscored_require_path}.rb").read).to include("assert false")
       end
     end
 

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -30,6 +30,8 @@ RSpec.describe "bundle gem" do
 
   let(:minitest_test_file_path) { "test/test_mygem.rb" }
 
+  let(:minitest_test_class_name) { "class TestMygem < Minitest::Test" }
+
   before do
     sys_exec("git config --global user.name 'Bundler User'")
     sys_exec("git config --global user.email user@example.com")
@@ -736,6 +738,10 @@ RSpec.describe "bundle gem" do
         expect(bundled_app("#{gem_name}/#{minitest_test_file_path}").read).to include(%(require "test_helper"))
       end
 
+      it "defines valid test class name" do
+        expect(bundled_app("#{gem_name}/#{minitest_test_file_path}").read).to include(minitest_test_class_name)
+      end
+
       it "creates a default test which fails" do
         expect(bundled_app("#{gem_name}/#{minitest_test_file_path}").read).to include("assert false")
       end
@@ -1304,6 +1310,8 @@ RSpec.describe "bundle gem" do
 
     let(:minitest_test_file_path) { "test/test_test_gem.rb" }
 
+    let(:minitest_test_class_name) { "class TestTestGem < Minitest::Test" }
+
     let(:flags) { nil }
 
     it "does not nest constants" do
@@ -1360,6 +1368,8 @@ RSpec.describe "bundle gem" do
     let(:require_relative_path) { "gem" }
 
     let(:minitest_test_file_path) { "test/test/test_gem.rb" }
+
+    let(:minitest_test_class_name) { "class TestTestGem < Minitest::Test" }
 
     it "nests constants so they work" do
       bundle "gem #{gem_name}"

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -1369,7 +1369,7 @@ RSpec.describe "bundle gem" do
 
     let(:minitest_test_file_path) { "test/test/test_gem.rb" }
 
-    let(:minitest_test_class_name) { "class TestTestGem < Minitest::Test" }
+    let(:minitest_test_class_name) { "class Test::TestGem < Minitest::Test" }
 
     it "nests constants so they work" do
       bundle "gem #{gem_name}"

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe "bundle gem" do
 
   let(:require_path) { "mygem" }
 
+  let(:minitest_test_file_path) { "test/test_mygem.rb" }
+
   before do
     sys_exec("git config --global user.name 'Bundler User'")
     sys_exec("git config --global user.email user@example.com")
@@ -696,22 +698,18 @@ RSpec.describe "bundle gem" do
     end
 
     context "gem.test setting set to rspec and --test is set to minitest" do
-      let(:underscored_require_path) { require_path.tr("/", "_") }
-
       before do
         bundle "config set gem.test rspec"
         bundle "gem #{gem_name} --test=minitest"
       end
 
       it "builds spec skeleton" do
-        expect(bundled_app("#{gem_name}/test/test_#{underscored_require_path}.rb")).to exist
+        expect(bundled_app("#{gem_name}/#{minitest_test_file_path}")).to exist
         expect(bundled_app("#{gem_name}/test/test_helper.rb")).to exist
       end
     end
 
     context "--test parameter set to minitest" do
-      let(:underscored_require_path) { require_path.tr("/", "_") }
-
       before do
         bundle "gem #{gem_name} --test=minitest"
       end
@@ -726,7 +724,7 @@ RSpec.describe "bundle gem" do
       end
 
       it "builds spec skeleton" do
-        expect(bundled_app("#{gem_name}/test/test_#{underscored_require_path}.rb")).to exist
+        expect(bundled_app("#{gem_name}/#{minitest_test_file_path}")).to exist
         expect(bundled_app("#{gem_name}/test/test_helper.rb")).to exist
       end
 
@@ -735,11 +733,11 @@ RSpec.describe "bundle gem" do
       end
 
       it "requires 'test_helper'" do
-        expect(bundled_app("#{gem_name}/test/test_#{underscored_require_path}.rb").read).to include(%(require "test_helper"))
+        expect(bundled_app("#{gem_name}/#{minitest_test_file_path}").read).to include(%(require "test_helper"))
       end
 
       it "creates a default test which fails" do
-        expect(bundled_app("#{gem_name}/test/test_#{underscored_require_path}.rb").read).to include("assert false")
+        expect(bundled_app("#{gem_name}/#{minitest_test_file_path}").read).to include("assert false")
       end
     end
 
@@ -1304,6 +1302,8 @@ RSpec.describe "bundle gem" do
 
     let(:require_relative_path) { "test_gem" }
 
+    let(:minitest_test_file_path) { "test/test_test_gem.rb" }
+
     let(:flags) { nil }
 
     it "does not nest constants" do
@@ -1358,6 +1358,8 @@ RSpec.describe "bundle gem" do
     let(:require_path) { "test/gem" }
 
     let(:require_relative_path) { "gem" }
+
+    let(:minitest_test_file_path) { "test/test/test_gem.rb" }
 
     it "nests constants so they work" do
       bundle "gem #{gem_name}"


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

In "bundle gem" command with dashed name gem (e.g. foo-bar) generates `test/test_foo/bar.rb`, but this file contains undefined class `TestFoo` and moreover, does not include in "bundle exec rake test" target.

Therefore, intentially the first test after gem created is fail, but in case of gem name contains dash character is not.

### step to reproduce

```
$ bundler --version
Bundler version 2.3.4

$ bundle gem foo-bar
Creating gem 'foo-bar'...
MIT License enabled in config
Code of conduct enabled in config
Changelog enabled in config
RuboCop enabled in config
Initializing git repo in /tmp/foo-bar
      create  foo-bar/Gemfile
      create  foo-bar/lib/foo/bar.rb
      create  foo-bar/lib/foo/bar/version.rb
      create  foo-bar/sig/foo/bar.rbs
      create  foo-bar/foo-bar.gemspec
      create  foo-bar/Rakefile
      create  foo-bar/README.md
      create  foo-bar/bin/console
      create  foo-bar/bin/setup
      create  foo-bar/.gitignore
      create  foo-bar/test/test_helper.rb
      create  foo-bar/test/test_foo/bar.rb
      create  foo-bar/.github/workflows/main.yml
      create  foo-bar/LICENSE.txt
      create  foo-bar/CODE_OF_CONDUCT.md
      create  foo-bar/CHANGELOG.md
      create  foo-bar/.rubocop.yml
Gem 'foo-bar' was successfully created. For more information on making a RubyGem visit https://bundler.io/guides/creating_gem.html

$ cd foo-bar
$ sed -i -e 's/gemspec/# gemspec/' Gemfile
$ bundle install
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Using rake 13.0.6
Using ast 2.4.2
Using parallel 1.21.0
Using minitest 5.15.0
Using parser 3.1.0.0
Using regexp_parser 2.2.0
Using rexml 3.2.5
Using ruby-progressbar 1.11.0
Using unicode-display_width 2.1.0
Using bundler 2.3.4
Using rainbow 3.0.0
Using rubocop-ast 1.15.1
Using rubocop 1.24.1
Bundle complete! 3 Gemfile dependencies, 13 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.

$ bundle exec rake test
Run options: --seed 12319

# Running:



Finished in 0.005437s, 0.0000 runs/s, 0.0000 assertions/s.

0 runs, 0 assertions, 0 failures, 0 errors, 0 skips # not fail!

$ ls -1 test/**/*
test/test_foo/bar.rb
test/test_helper.rb

test/test_foo:
bar.rb

$ mv test/test_foo/bar.rb test/test_foo_bar.rb
$ bundle exec rake test
/tmp/foo-bar/test/test_foo_bar.rb:5:in `<top (required)>': uninitialized constant TestFoo (NameError)
        from /home/unasuke/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:21:in `require'
        from /home/unasuke/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:21:in `block in <main>'
        from /home/unasuke/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:6:in `select'
        from /home/unasuke/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:6:in `<main>'
rake aborted!
Command failed with status (1)
/home/unasuke/.rbenv/versions/3.0.2/bin/bundle:23:in `load'
/home/unasuke/.rbenv/versions/3.0.2/bin/bundle:23:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)
```

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

The change doings...
(when "bundle gem foo-bar" called)

* create `test/test_foo_bar.rb`
* define `TestFooBar` class in `test/test_foo_bar.rb`


## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
