### PR TITLE
Let `Version#<=>` accept a String

### DIFF
--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -341,9 +341,11 @@ class Gem::Version
   # Compares this version with +other+ returning -1, 0, or 1 if the
   # other version is larger, the same, or smaller than this
   # one. Attempts to compare to something that's not a
-  # <tt>Gem::Version</tt> return +nil+.
+  # <tt>Gem::Version</tt> or a valid version String return +nil+.
 
   def <=>(other)
+    return self <=> self.class.new(other) if (String === other) && self.class.correct?(other)
+
     return unless Gem::Version === other
     return 0 if @version == other._version || canonical_segments == other.canonical_segments
 

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -154,6 +154,10 @@ class TestGemVersion < Gem::TestCase
     assert_equal(-1, v("5.a") <=> v("5.0.0.rc2"))
     assert_equal(1, v("5.x") <=> v("5.0.0.rc2"))
 
+    assert_equal(0, v("1.9.3")  <=> "1.9.3")
+    assert_equal(1, v("1.9.3")  <=> "1.9.2.99")
+    assert_equal(-1, v("1.9.3") <=> "1.9.3.1")
+
     assert_nil v("1.0") <=> "whatever"
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Currently, `Gem::Version#<=>` accepts Gem::Version instance only. But in my experience, the major use case for comparing gem versions is that we just want to ask via String. And I want to do this in a simpler way.

For instance, when we need to know if Bundler version is version 1 or 2:

```ruby
bundler = Gem.loaded_specs['bundler']
```

we have to write some clumsy code with `Gem::Version.new` like this.

```ruby
if bundler.version > Gem::Version.new('2')
  ...
end
```

## What is your fix for the problem, implemented in this PR?

So here's a patch that extends `Version#<=>` to accept a String parameter. It's nothing but just a syntax sugar, but the previous example became much easier to read and write now.

```ruby
if bundler.version > '2'
  ...
end
```

Even after this patch, if an invalid version String is given:
```ruby
if bundler.version > 'hello'
  ...
end
```

it raises an ArgumentError `comparison of Gem::Version with String failed`. This behavior is unchanged.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
