### PR TITLE
Avoid `flock` on non Windows systems, since it causing issues on NFS file systems

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -781,7 +781,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
   def self.open_with_flock(path, flags, &block)
     File.open(path, flags) do |io|
-      if !java_platform? && !solaris_platform?
+      if !java_platform? && win_platform?
         begin
           io.flock(File::LOCK_EX)
         rescue Errno::ENOSYS, Errno::ENOTSUP

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -759,11 +759,11 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   # Safely read a file in binary mode on all platforms.
 
   def self.read_binary(path)
-    open_with_flock(path, 'rb+') do |io|
+    open_file(path, 'rb+') do |io|
       io.read
     end
   rescue Errno::EACCES, Errno::EROFS
-    open_with_flock(path, 'rb') do |io|
+    open_file(path, 'rb') do |io|
       io.read
     end
   end
@@ -771,15 +771,15 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   ##
   # Safely write a file in binary mode on all platforms.
   def self.write_binary(path, data)
-    open_with_flock(path, 'wb') do |io|
+    open_file(path, 'wb') do |io|
       io.write data
     end
   end
 
   ##
-  # Open a file with given flags, and protect access with flock
+  # Open a file with given flags, and on Windows protect access with flock
 
-  def self.open_with_flock(path, flags, &block)
+  def self.open_file(path, flags, &block)
     File.open(path, flags) do |io|
       if !java_platform? && win_platform?
         begin

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1115,7 +1115,7 @@ class Gem::Specification < Gem::BasicSpecification
     file = file.dup.tap(&Gem::UNTAINT)
     return unless File.file?(file)
 
-    code = Gem.open_with_flock(file, 'r:UTF-8:-', &:read)
+    code = Gem.open_file(file, 'r:UTF-8:-', &:read)
 
     code.tap(&Gem::UNTAINT)
 

--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -110,7 +110,7 @@ class Gem::StubSpecification < Gem::BasicSpecification
       begin
         saved_lineno = $.
 
-        Gem.open_with_flock loaded_from, OPEN_MODE do |file|
+        Gem.open_file loaded_from, OPEN_MODE do |file|
           begin
             file.readline # discard encoding line
             stubline = file.readline.chomp


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Apparently our recent changes in `flock` usage cause issues on NFS filesystems.

## What is your fix for the problem, implemented in this PR?

Since recent changes were only introduced to fix some race conditions on Windows, I'm limiting `flock` usage to that OS.

Fixes #5257.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
