### PR TITLE
Changelogs for rubygems 3.3.5 and bundler 2.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+# 3.3.5 / 2022-01-12
+
+## Enhancements:
+
+* Don't activate `yaml` gem from RubyGems. Pull request #5266 by
+  deivid-rodriguez
+* Let `gem fetch` understand `<gem>:<version>` syntax and
+  `--[no-]suggestions` flag. Pull request #5242 by ximenasandoval
+* Installs bundler 2.3.5 as a default gem.
+
+## Bug fixes:
+
+* Fix `gem install <non-existent-gem> --force` crash. Pull request #5262
+  by deivid-rodriguez
+* Fix longstanding `gem install` failure on JRuby. Pull request #5228 by
+  deivid-rodriguez
+
+## Documentation:
+
+* Markup `Gem::Specification` documentation with RDoc notations. Pull
+  request #5268 by nobu
+
 # 3.3.4 / 2021-12-29
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 2.3.5 (January 12, 2022)
+
+## Enhancements:
+
+  - Make `bundle update --bundler` actually lock to the latest bundler version (even if not yet installed) [#5182](https://github.com/rubygems/rubygems/pull/5182)
+  - Use thor-1.2.1 [#5260](https://github.com/rubygems/rubygems/pull/5260)
+  - Exclude bin directory for newgem template [#5259](https://github.com/rubygems/rubygems/pull/5259)
+
+## Bug fixes:
+
+  - Fix metadata requirements being bypassed when custom gem servers are used [#5256](https://github.com/rubygems/rubygems/pull/5256)
+  - Fix `rake build:checksum` writing checksum of package path, not package contents [#5250](https://github.com/rubygems/rubygems/pull/5250)
+
 # 2.3.4 (December 29, 2021)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking changelogs from future rubygems 3.3.5 and bundler 2.3.5 into master.