### PR TITLE
Test against Ruby 3.1

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -29,6 +29,7 @@ jobs:
           - { name: ruby-2.6, value: 2.6.9 }
           - { name: ruby-2.7, value: 2.7.5 }
           - { name: ruby-3.0, value: 3.0.3 }
+          - { name: ruby-3.1, value: 3.1.0 }
 
         bundler:
           - { name: 2, value: '' }
@@ -43,6 +44,7 @@ jobs:
         include:
           - { os: { name: MacOS, value: macos-11 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.5 } }
           - { os: { name: MacOS, value: macos-11 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.3 } }
+          - { os: { name: MacOS, value: macos-11 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.0 } }
     env:
       RGV: ..
       RUBYOPT: --disable-gems

--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -38,9 +38,10 @@ jobs:
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.3, value: 2.3.8 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.4, value: 2.4.10 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.5, value: 2.5.9 } }
+          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.6, value: 2.6.9 } }
 
         include:
-          - { os: { name: MacOS, value: macos-11 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-2.6, value: 2.6.9 } }
+          - { os: { name: MacOS, value: macos-11 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.5 } }
           - { os: { name: MacOS, value: macos-11 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.3 } }
     env:
       RGV: ..

--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -26,6 +26,7 @@ jobs:
           - { name: "2.6", value: 2.6.9 }
           - { name: "2.7", value: 2.7.5 }
           - { name: "3.0", value: 3.0.3 }
+          - { name: "3.1", value: 3.1.0 }
           - { name: jruby-9.3, value: jruby-9.3.2.0 }
           - { name: truffleruby-21, value: truffleruby-21.2.0 }
         openssl:
@@ -43,7 +44,7 @@ jobs:
           ruby -Ilib -S rake install 2> errors.txt || (cat errors.txt && exit 1)
           test ! -s errors.txt || (cat errors.txt && exit 1)
       - name: Check downgrading
-        run: gem update --system 3.2.32
+        run: gem update --system 3.3.3
       - name: Check installing fileutils
         run: gem install fileutils
       - name: Check installing with upgraded fileutils
@@ -87,7 +88,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - { name: "3.0", value: 3.0.3 }
+          - { name: "3.1", value: 3.1.0 }
           - { name: jruby-9.3, value: jruby-9.3.2.0 }
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/macos-rubygems.yml
+++ b/.github/workflows/macos-rubygems.yml
@@ -25,6 +25,7 @@ jobs:
           - { name: "2.6", value: 2.6.9 }
           - { name: "2.7", value: 2.7.5 }
           - { name: "3.0", value: 3.0.3 }
+          - { name: "3.1", value: 3.1.0 }
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby

--- a/.github/workflows/older-rubygems-bundler.yml
+++ b/.github/workflows/older-rubygems-bundler.yml
@@ -35,7 +35,6 @@ jobs:
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.5 }, rgv: { name: rgv-3.1, value: v3.1.5 } }
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.5 }, rgv: { name: rgv-3.2, value: v3.2.32 } }
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.3 }, rgv: { name: rgv-3.2, value: v3.2.32 } }
-          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.6, value: 2.6.9 }, rgv: { name: rgv-3.2, value: v3.2.32 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.7, value: 2.7.5 }, rgv: { name: rgv-3.2, value: v3.2.32 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.0, value: 3.0.3 }, rgv: { name: rgv-3.2, value: v3.2.32 } }
     env:

--- a/.github/workflows/older-rubygems-bundler.yml
+++ b/.github/workflows/older-rubygems-bundler.yml
@@ -25,17 +25,12 @@ jobs:
       matrix:
         include:
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.3, value: 2.3.8 }, rgv: { name: rgv-2.5, value: v2.5.2 } }
-          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.3, value: 2.3.8 }, rgv: { name: rgv-3.2, value: v3.2.32 } }
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.4, value: 2.4.10 }, rgv: { name: rgv-2.6, value: v2.6.14 } }
-          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.4, value: 2.4.10 }, rgv: { name: rgv-3.2, value: v3.2.32 } }
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.5, value: 2.5.9 }, rgv: { name: rgv-2.7, value: v2.7.11 } }
-          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.5, value: 2.5.9 }, rgv: { name: rgv-3.2, value: v3.2.32 } }
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.6, value: 2.6.9 }, rgv: { name: rgv-3.0, value: v3.0.9 } }
-          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.6, value: 2.6.9 }, rgv: { name: rgv-3.2, value: v3.2.30 } }
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.5 }, rgv: { name: rgv-3.1, value: v3.1.5 } }
-          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.5 }, rgv: { name: rgv-3.2, value: v3.2.32 } }
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.3 }, rgv: { name: rgv-3.2, value: v3.2.32 } }
-          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.7, value: 2.7.5 }, rgv: { name: rgv-3.2, value: v3.2.32 } }
+          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.7, value: 2.7.5 }, rgv: { name: rgv-3.1, value: v3.1.5 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.0, value: 3.0.3 }, rgv: { name: rgv-3.2, value: v3.2.32 } }
     env:
       RGV: ${{ matrix.rgv.value }}

--- a/.github/workflows/older-rubygems-bundler.yml
+++ b/.github/workflows/older-rubygems-bundler.yml
@@ -28,9 +28,9 @@ jobs:
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.4, value: 2.4.10 }, rgv: { name: rgv-2.6, value: v2.6.14 } }
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.5, value: 2.5.9 }, rgv: { name: rgv-2.7, value: v2.7.11 } }
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.6, value: 2.6.9 }, rgv: { name: rgv-3.0, value: v3.0.9 } }
-          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.5 }, rgv: { name: rgv-3.1, value: v3.1.5 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.5 }, rgv: { name: rgv-3.1, value: v3.1.5 } } # Not using 3.1.6 because it's not tagged on GitHub for some reason
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.3 }, rgv: { name: rgv-3.2, value: v3.2.33 } }
-          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.7, value: 2.7.5 }, rgv: { name: rgv-3.1, value: v3.1.5 } }
+          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.7, value: 2.7.5 }, rgv: { name: rgv-3.1, value: v3.1.5 } } # Not using 3.1.6 because it's not tagged on GitHub for some reason
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.0, value: 3.0.3 }, rgv: { name: rgv-3.2, value: v3.2.33 } }
     env:
       RGV: ${{ matrix.rgv.value }}

--- a/.github/workflows/older-rubygems-bundler.yml
+++ b/.github/workflows/older-rubygems-bundler.yml
@@ -30,8 +30,10 @@ jobs:
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.6, value: 2.6.9 }, rgv: { name: rgv-3.0, value: v3.0.9 } }
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.5 }, rgv: { name: rgv-3.1, value: v3.1.5 } } # Not using 3.1.6 because it's not tagged on GitHub for some reason
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.3 }, rgv: { name: rgv-3.2, value: v3.2.33 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.0 }, rgv: { name: rgv-3.3, value: v3.3.5 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.7, value: 2.7.5 }, rgv: { name: rgv-3.1, value: v3.1.5 } } # Not using 3.1.6 because it's not tagged on GitHub for some reason
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.0, value: 3.0.3 }, rgv: { name: rgv-3.2, value: v3.2.33 } }
+          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.1, value: 3.1.0 }, rgv: { name: rgv-3.3, value: v3.3.5 } }
     env:
       RGV: ${{ matrix.rgv.value }}
       RUBYOPT: --disable-gems

--- a/.github/workflows/older-rubygems-bundler.yml
+++ b/.github/workflows/older-rubygems-bundler.yml
@@ -29,9 +29,9 @@ jobs:
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.5, value: 2.5.9 }, rgv: { name: rgv-2.7, value: v2.7.11 } }
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.6, value: 2.6.9 }, rgv: { name: rgv-3.0, value: v3.0.9 } }
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.5 }, rgv: { name: rgv-3.1, value: v3.1.5 } }
-          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.3 }, rgv: { name: rgv-3.2, value: v3.2.32 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.3 }, rgv: { name: rgv-3.2, value: v3.2.33 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.7, value: 2.7.5 }, rgv: { name: rgv-3.1, value: v3.1.5 } }
-          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.0, value: 3.0.3 }, rgv: { name: rgv-3.2, value: v3.2.32 } }
+          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.0, value: 3.0.3 }, rgv: { name: rgv-3.2, value: v3.2.33 } }
     env:
       RGV: ${{ matrix.rgv.value }}
       RUBYOPT: --disable-gems

--- a/.github/workflows/ubuntu-rubygems.yml
+++ b/.github/workflows/ubuntu-rubygems.yml
@@ -26,6 +26,7 @@ jobs:
           - { name: "2.6", value: 2.6.9 }
           - { name: "2.7", value: 2.7.5 }
           - { name: "3.0", value: 3.0.3 }
+          - { name: "3.1", value: 3.1.0 }
           - { name: jruby-9.3, value: jruby-9.3.2.0 }
           - { name: truffleruby-21, value: truffleruby-21.2.0 }
     steps:

--- a/.github/workflows/windows-bundler.yml
+++ b/.github/workflows/windows-bundler.yml
@@ -28,6 +28,7 @@ jobs:
           - { name: jruby-9.3, value: jruby-9.3.2.0 }
           - { name: ruby-2.7, value: 2.7.5 }
           - { name: ruby-3.0, value: 3.0.3 }
+          - { name: ruby-3.1, value: 3.1.0 }
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/windows-bundler.yml
+++ b/.github/workflows/windows-bundler.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         ruby:
           - { name: jruby-9.3, value: jruby-9.3.2.0 }
-          - { name: ruby-2.5, value: 2.5.9 }
+          - { name: ruby-2.7, value: 2.7.5 }
           - { name: ruby-3.0, value: 3.0.3 }
 
     steps:

--- a/.github/workflows/windows-rubygems.yml
+++ b/.github/workflows/windows-rubygems.yml
@@ -25,6 +25,7 @@ jobs:
           - { name: "2.6", value: 2.6.9 }
           - { name: "2.7", value: 2.7.5 }
           - { name: "3.0", value: 3.0.3 }
+          - { name: "3.1", value: 3.1.0 }
           - { name: mswin, value: mswin }
     steps:
       - uses: actions/checkout@v2

--- a/bundler/spec/commands/clean_spec.rb
+++ b/bundler/spec/commands/clean_spec.rb
@@ -638,7 +638,12 @@ RSpec.describe "bundle clean" do
       s.executables = "irb"
     end
 
-    realworld_system_gems "fiddle --version 1.0.8", "tsort --version 0.1.0", "pathname --version 0.1.0", "set --version 1.0.1"
+    if Gem.win_platform? && RUBY_VERSION < "3.1.0"
+      default_fiddle_version = ruby "require 'fiddle'; puts Gem.loaded_specs['fiddle'].version"
+      realworld_system_gems "fiddle --version #{default_fiddle_version}"
+    end
+
+    realworld_system_gems "tsort --version 0.1.0", "pathname --version 0.1.0", "set --version 1.0.1"
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}"

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -510,6 +510,11 @@ RSpec.describe "bundle lock" do
         s.platform = "x64-mingw32"
         s.required_ruby_version = "< #{next_minor}.dev"
       end
+
+      build_gem "raygun-apm", "1.0.78" do |s|
+        s.platform = "x64-mingw-ucrt"
+        s.required_ruby_version = "< #{next_minor}.dev"
+      end
     end
 
     gemfile <<-G

--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -113,7 +113,12 @@ RSpec.shared_examples "bundle install --standalone" do
       skip "does not work on rubygems versions where `--install_dir` doesn't respect --default" unless Gem::Installer.for_spec(loaded_gemspec, :install_dir => "/foo").default_spec_file == "/foo/specifications/default/bundler-#{Bundler::VERSION}.gemspec" # Since rubygems 3.2.0.rc.2
       skip "does not work on old rubies because the realworld gems that need to be installed don't support them" if RUBY_VERSION < "2.7.0"
 
-      realworld_system_gems "fiddle --version 1.0.8", "tsort --version 0.1.0"
+      if Gem.win_platform? && RUBY_VERSION < "3.1.0"
+        default_fiddle_version = ruby "require 'fiddle'; puts Gem.loaded_specs['fiddle'].version"
+        realworld_system_gems "fiddle --version #{default_fiddle_version}"
+      end
+
+      realworld_system_gems "tsort --version 0.1.0"
 
       necessary_system_gems = ["optparse --version 0.1.1", "psych --version 3.3.2", "yaml --version 0.1.1", "logger --version 1.4.3", "etc --version 1.2.0", "stringio --version 3.0.0"]
       necessary_system_gems += ["shellwords --version 0.1.0", "base64 --version 0.1.0", "resolv --version 0.2.1"] if Gem.rubygems_version < Gem::Version.new("3.3.a")


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Our CI should now support Ruby 3.1 on all OS, so we can start testing.

## What is your fix for the problem, implemented in this PR?

Add Ruby 3.1 to matrices, and also simplify some things to not let the matrix grow too big:

* Set Ruby 2.7 as the minimum tested Ruby on Windows, MacOS, and Bundler 3. It used to be Ruby 2.5 or Ruby 2.6, but Ruby 2.6 will reach its end of life in March, so we can probably also drop support for it next year together with 2.3, 2.4 and 2.5.
* When testing bundler against old RubyGems, only test against the oldest series supported on each version, not against the newest release. Bundler's master is already tested against RubyGems master, I think Bundler master against the latest RubyGems release provides little value, and it has never detected any issues that the master run did not detect.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
