### PR TITLE
Lock standard.yml to the required ruby version

### DIFF
--- a/bundler/lib/bundler/templates/newgem/standard.yml.tt
+++ b/bundler/lib/bundler/templates/newgem/standard.yml.tt
@@ -1,2 +1,3 @@
 # For available configuration options, see:
 #   https://github.com/testdouble/standard
+ruby_version: <%= ::Gem::Version.new(config[:required_ruby_version]).segments[0..1].join(".") %>


### PR DESCRIPTION
Hey @deivid-rodriguez, I think you'll be immediately familiar with the problem here.

I just used the standard generator for the first time with Bundler 2.3.3. (🙌) and noticed an oversight that I made when I implemented it. I hadn't realized that the `spec.required_ruby_version` would default to 2.6 for newly generated projects, which means that we definitely want to lock Standard's rules & fixing behavior to 2.6 as well in the `standard.yml.tt` template.

I cribbed this snipped directly from the [RuboCop template](https://github.com/rubygems/rubygems/blob/master/bundler/lib/bundler/templates/newgem/rubocop.yml.tt#L2). I don't have a local development environment for gems/bundler at the moment, so I didn't pull down and verify this works myself but looking at [this source](https://github.com/rubygems/rubygems/blob/c5884b2a80474678087d2ecf676c7950b67fa60f/bundler/lib/bundler/cli/gem.rb#L169-L177) it seems like it should behave the same way RuboCop does.