### PR TITLE
Fix `gem update --system`  for already installed version of `rubygems-update`

### DIFF
--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -287,7 +287,7 @@ command to remove old versions.
     check_oldest_rubygems version
 
     installed_gems = Gem::Specification.find_all_by_name 'rubygems-update', requirement
-    installed_gems = update_gem('rubygems-update', version) if installed_gems.empty?
+    installed_gems = update_gem('rubygems-update', version) if installed_gems.empty? || installed_gems.first.version != version
     return if installed_gems.empty?
 
     version = installed_gems.first.version

--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -157,6 +157,40 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
     assert_empty out
   end
 
+  def test_execute_system_update_installed
+    spec_fetcher do |fetcher|
+      fetcher.download 'rubygems-update', 8 do |s|
+        s.files = %w[setup.rb]
+      end
+    end
+
+    @cmd.options[:args]          = []
+    @cmd.options[:system]        = true
+
+    @cmd.execute
+
+    spec_fetcher do |fetcher|
+      fetcher.download 'rubygems-update', 9 do |s|
+        s.files = %w[setup.rb]
+      end
+    end
+
+    @cmd = Gem::Commands::UpdateCommand.new
+    @cmd.options[:args]          = []
+    @cmd.options[:system]        = true
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    out = @ui.output.split "\n"
+    assert_equal "Updating rubygems-update", out.shift
+    assert_equal "Installing RubyGems 9", out.shift
+    assert_equal "RubyGems system software updated", out.shift
+
+    assert_empty out
+  end
+
   def test_execute_system_specific
     spec_fetcher do |fetcher|
       fetcher.download 'rubygems-update', 8 do |s|


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

After https://github.com/rubygems/rubygems/pull/5230 `gem update --system` command doesn't update `rubygems-update` version if it already installed locally.

```
$ gem update --system 3.3.4 --no-document
Updating rubygems-update
Fetching rubygems-update-3.3.4.gem
Successfully installed rubygems-update-3.3.4
Installing RubyGems 3.3.4
  Successfully built RubyGem
  Name: bundler
  Version: 2.3.4
  File: bundler-2.3.4.gem
Bundler 2.3.4 installed
RubyGems 3.3.4 installed
Regenerating binstubs
Regenerating plugins

$ gem --version
3.3.4

$ gem update --system --no-document
Installing RubyGems 3.3.4
  Successfully built RubyGem
  Name: bundler
  Version: 2.3.4
  File: bundler-2.3.4.gem
Bundler 2.3.4 installed
RubyGems 3.3.4 installed
Regenerating binstubs
Regenerating plugins

$ gem --version
3.3.4

$ gem search rubygems-update

*** REMOTE GEMS ***

rubygems-update (3.3.5)
```

## What is your fix for the problem, implemented in this PR?

- re-download `rubygems-update` package if it's installed version is not equal to the target version

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
