### PR TITLE
Fix regression with old marshaled specs having null `required_rubygems_version`

### DIFF
--- a/bundler/lib/bundler/remote_specification.rb
+++ b/bundler/lib/bundler/remote_specification.rb
@@ -27,6 +27,13 @@ module Bundler
       @platform = _remote_specification.platform
     end
 
+    # A fallback is included because the original version of the specification
+    # API didn't include that field, so some marshalled specs in the index have it
+    # set to +nil+.
+    def required_rubygems_version
+      @required_rubygems_version ||= _remote_specification.required_rubygems_version || Gem::Requirement.default
+    end
+
     def full_name
       if platform == Gem::Platform::RUBY || platform.nil?
         "#{@name}-#{@version}"

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -1443,4 +1443,57 @@ RSpec.describe "bundle install with gems on multiple sources" do
       L
     end
   end
+
+  context "when default source includes old gems with nil required_rubygems_version" do
+    before do
+      build_repo2 do
+        build_gem "ruport", "1.7.0.3" do |s|
+          s.add_dependency "pdf-writer", "1.1.8"
+        end
+      end
+
+      build_repo gem_repo4 do
+        build_gem "pdf-writer", "1.1.8"
+      end
+
+      path = "#{gem_repo4}/#{Gem::MARSHAL_SPEC_DIR}/pdf-writer-1.1.8.gemspec.rz"
+      spec = Marshal.load(Bundler.rubygems.inflate(File.binread(path)))
+      spec.instance_variable_set(:@required_rubygems_version, nil)
+      File.open(path, "wb") do |f|
+        f.write Gem.deflate(Marshal.dump(spec))
+      end
+
+      gemfile <<~G
+        source "https://localgemserver.test"
+
+        gem "ruport", "= 1.7.0.3", :source => "https://localgemserver.test/extra"
+      G
+    end
+
+    it "handles that fine" do
+      bundle "install", :artifice => "compact_index_extra", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+
+      expect(lockfile).to eq <<~L
+        GEM
+          remote: https://localgemserver.test/
+          specs:
+            pdf-writer (1.1.8)
+
+        GEM
+          remote: https://localgemserver.test/extra/
+          specs:
+            ruport (1.7.0.3)
+              pdf-writer (= 1.1.8)
+
+        PLATFORMS
+          #{specific_local_platform}
+
+        DEPENDENCIES
+          ruport (= 1.7.0.3)!
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+    end
+  end
 end

--- a/bundler/spec/install/gems/resolving_spec.rb
+++ b/bundler/spec/install/gems/resolving_spec.rb
@@ -101,8 +101,6 @@ RSpec.describe "bundle install with install-time dependencies" do
   end
 
   it "installs gems with a dependency with no type" do
-    skip "incorrect data check error" if Gem.win_platform?
-
     build_repo2
 
     path = "#{gem_repo2}/#{Gem::MARSHAL_SPEC_DIR}/actionpack-2.3.2.gemspec.rz"
@@ -110,7 +108,7 @@ RSpec.describe "bundle install with install-time dependencies" do
     spec.dependencies.each do |d|
       d.instance_variable_set(:@type, :fail)
     end
-    File.open(path, "w") do |f|
+    File.open(path, "wb") do |f|
       f.write Gem.deflate(Marshal.dump(spec))
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I made [a commit](https://github.com/rubygems/rubygems/commit/ab0a1c16c9e92e175e50e2e386105725a5c7cc87) that failed to consider that some old marshaled specs may have `required_rubygems_version` set to `nil`.

## What is your fix for the problem, implemented in this PR?

Add a fallback for this edge case.

Fixes #5290.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
