### PR TITLE
Avoid writing private registry credentials to logs

### DIFF
--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -494,7 +494,13 @@ module Bundler
       uri = Bundler.settings.mirror_for(uri)
       fetcher = gem_remote_fetcher
       fetcher.headers = { "X-Gemfile-Source" => spec.remote.original_uri.to_s } if spec.remote.original_uri
-      Bundler::Retry.new("download gem from #{uri}").attempts do
+
+      uri_for_print = uri.dup
+
+      uri_for_print.user = "**FILTERED**" if uri_for_print.user
+      uri_for_print.password = "**FILTERED**" if uri_for_print.password
+
+      Bundler::Retry.new("download gem from #{uri_for_print}").attempts do
         gem_file_name = spec.file_name
         local_gem_path = File.join cache_dir, gem_file_name
         return if File.exist? local_gem_path
@@ -517,7 +523,7 @@ module Bundler
         end
       end
     rescue Gem::RemoteFetcher::FetchError => e
-      raise Bundler::HTTPError, "Could not download gem from #{uri} due to underlying error <#{e.message}>"
+      raise Bundler::HTTPError, "Could not download gem from #{uri_for_print} due to underlying error <#{e.message}>"
     end
 
     def gem_remote_fetcher


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

username and password of a private registry that was configured as an environment variable like `BUNDLE_GITHUB__COM` are visible when the bundle install command has errors

## What is your fix for the problem, implemented in this PR?

We duplicated the printed URI to the logs and escaped the username/password from this duplicated URI to be **FILTERED**

Fixes #5281.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
