### PR TITLE
Don't use deprecated `Gem::Dependency.new` with a Regexp

### DIFF
--- a/lib/rubygems/commands/dependency_command.rb
+++ b/lib/rubygems/commands/dependency_command.rb
@@ -162,14 +162,6 @@ use with other commands.
     response
   end
 
-  def remote_specs(dependency) # :nodoc:
-    fetcher = Gem::SpecFetcher.fetcher
-
-    ss, _ = fetcher.spec_for_dependency dependency
-
-    ss.map {|s,o| s }
-  end
-
   def reverse_dependencies(specs) # :nodoc:
     reverse = Hash.new {|h, k| h[k] = [] }
 

--- a/lib/rubygems/commands/dependency_command.rb
+++ b/lib/rubygems/commands/dependency_command.rb
@@ -53,39 +53,39 @@ use with other commands.
     "#{program_name} REGEXP"
   end
 
-  def fetch_remote_specs(dependency) # :nodoc:
+  def fetch_remote_specs(name, requirement, prerelease) # :nodoc:
     fetcher = Gem::SpecFetcher.fetcher
 
-    ss, = fetcher.spec_for_dependency dependency
+    specs_type = prerelease ? :complete : :released
 
-    ss.map {|spec, _| spec }
+    ss = if name.nil?
+      fetcher.detect(specs_type) { true }
+    else
+      fetcher.detect(specs_type) do |name_tuple|
+        name === name_tuple.name && requirement.satisfied_by?(name_tuple.version)
+      end
+    end
+
+    ss.map {|tuple, source| source.fetch_spec(tuple) }
   end
 
-  def fetch_specs(name_pattern, dependency) # :nodoc:
+  def fetch_specs(name_pattern, requirement, prerelease) # :nodoc:
     specs = []
 
     if local?
       specs.concat Gem::Specification.stubs.find_all {|spec|
-        name_pattern =~ spec.name and
-          dependency.requirement.satisfied_by? spec.version
+        name_matches = name_pattern ? name_pattern =~ spec.name : true
+        version_matches = requirement.satisfied_by?(spec.version)
+
+        name_matches and version_matches
       }.map(&:to_spec)
     end
 
-    specs.concat fetch_remote_specs dependency if remote?
+    specs.concat fetch_remote_specs name_pattern, requirement, prerelease if remote?
 
     ensure_specs specs
 
     specs.uniq.sort
-  end
-
-  def gem_dependency(pattern, version, prerelease) # :nodoc:
-    dependency = Gem::Deprecate.skip_during do
-      Gem::Dependency.new pattern, version
-    end
-
-    dependency.prerelease = prerelease
-
-    dependency
   end
 
   def display_pipe(specs) # :nodoc:
@@ -119,11 +119,9 @@ use with other commands.
     ensure_local_only_reverse_dependencies
 
     pattern = name_pattern options[:args]
+    requirement = Gem::Requirement.new options[:version]
 
-    dependency =
-      gem_dependency pattern, options[:version], options[:prerelease]
-
-    specs = fetch_specs pattern, dependency
+    specs = fetch_specs pattern, requirement, options[:prerelease]
 
     reverse = reverse_dependencies specs
 
@@ -197,7 +195,7 @@ use with other commands.
   private
 
   def name_pattern(args)
-    args << '' if args.empty?
+    return if args.empty?
 
     if args.length == 1 and args.first =~ /\A(.*)(i)?\z/m
       flags = $2 ? Regexp::IGNORECASE : nil

--- a/lib/rubygems/commands/list_command.rb
+++ b/lib/rubygems/commands/list_command.rb
@@ -10,7 +10,7 @@ class Gem::Commands::ListCommand < Gem::Command
 
   def initialize
     super 'list', 'Display local gems whose name matches REGEXP',
-         :name => //, :domain => :local, :details => false, :versions => true,
+         :domain => :local, :details => false, :versions => true,
          :installed => nil, :version => Gem::Requirement.default
 
     add_query_options

--- a/lib/rubygems/commands/query_command.rb
+++ b/lib/rubygems/commands/query_command.rb
@@ -20,7 +20,7 @@ class Gem::Commands::QueryCommand < Gem::Command
   def initialize(name = 'query',
                  summary = 'Query gem information in local or remote repositories')
     super name, summary,
-         :name => //, :domain => :local, :details => false, :versions => true,
+         :domain => :local, :details => false, :versions => true,
          :installed => nil, :version => Gem::Requirement.default
 
     add_option('-n', '--name-matches REGEXP',

--- a/lib/rubygems/commands/search_command.rb
+++ b/lib/rubygems/commands/search_command.rb
@@ -7,7 +7,7 @@ class Gem::Commands::SearchCommand < Gem::Command
 
   def initialize
     super 'search', 'Display remote gems whose name matches REGEXP',
-         :name => //, :domain => :remote, :details => false, :versions => true,
+         :domain => :remote, :details => false, :versions => true,
          :installed => nil, :version => Gem::Requirement.default
 
     add_query_options

--- a/lib/rubygems/query_utils.rb
+++ b/lib/rubygems/query_utils.rb
@@ -58,10 +58,10 @@ module Gem::QueryUtils
   end
 
   def execute
-    gem_names = Array(options[:name])
-
-    if !args.empty?
-      gem_names = options[:exact] ? args.map{|arg| /\A#{Regexp.escape(arg)}\Z/ } : args.map{|arg| /#{arg}/i }
+    gem_names = if args.empty?
+      Array(options[:name])
+    else
+      options[:exact] ? args.map{|arg| /\A#{Regexp.escape(arg)}\Z/ } : args.map{|arg| /#{arg}/i }
     end
 
     terminate_interaction(check_installed_gems(gem_names)) if check_installed_gems?

--- a/lib/rubygems/query_utils.rb
+++ b/lib/rubygems/query_utils.rb
@@ -54,12 +54,12 @@ module Gem::QueryUtils
   end
 
   def defaults_str # :nodoc:
-    "--local --name-matches // --no-details --versions --no-installed"
+    "--local --no-details --versions --no-installed"
   end
 
   def execute
     gem_names = if args.empty?
-      Array(options[:name])
+      [options[:name]]
     else
       options[:exact] ? args.map{|arg| /\A#{Regexp.escape(arg)}\Z/ } : args.map{|arg| /#{arg}/i }
     end
@@ -96,7 +96,7 @@ module Gem::QueryUtils
   end
 
   def gem_name?
-    !options[:name].source.empty?
+    !options[:name].nil?
   end
 
   def prerelease
@@ -129,12 +129,10 @@ module Gem::QueryUtils
     display_header("LOCAL")
 
     specs = Gem::Specification.find_all do |s|
-      s.name =~ name and req =~ s.version
-    end
+      name_matches = name ? s.name =~ name : true
+      version_matches = show_prereleases? || !s.version.prerelease?
 
-    dep = Gem::Deprecate.skip_during { Gem::Dependency.new name, req }
-    specs.select! do |s|
-      dep.match?(s.name, s.version, show_prereleases?)
+      name_matches and version_matches
     end
 
     spec_tuples = specs.map do |spec|
@@ -149,7 +147,7 @@ module Gem::QueryUtils
 
     fetcher = Gem::SpecFetcher.fetcher
 
-    spec_tuples = if name.respond_to?(:source) && name.source.empty?
+    spec_tuples = if name.nil?
       fetcher.detect(specs_type) { true }
     else
       fetcher.detect(specs_type) do |name_tuple|

--- a/test/rubygems/test_gem_command_manager.rb
+++ b/test/rubygems/test_gem_command_manager.rb
@@ -252,7 +252,7 @@ class TestGemCommandManager < Gem::TestCase
     Gem::Deprecate.skip_during do
       @command_manager.process_args %w[query]
     end
-    assert_equal(//, check_options[:name])
+    assert_nil(check_options[:name])
     assert_equal :local, check_options[:domain]
     assert_equal false, check_options[:details]
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I was surprised when observing that we use ourselves functionality that we have deprecated.

## What is your fix for the problem, implemented in this PR?

Rewrite code to not use the functionality we have deprecated. With these changes, `Gem::Deprecation.skip_during` is no longer used inside RubyGems code.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
