### PR TITLE
Use random order by default for RSpec

### DIFF
--- a/bundler/lib/bundler/templates/newgem/rspec.tt
+++ b/bundler/lib/bundler/templates/newgem/rspec.tt
@@ -1,3 +1,4 @@
---format documentation
 --color
+--format documentation
+--order random
 --require spec_helper


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

As a dev, when creating gems sometimes I forget to set the order of the tests to be random.

## What is your fix for the problem, implemented in this PR?

I think there is consensus in the community that tests can't depend on their order, so that's why I'm proposing to add `--order random` by default when creating the `.rspec` file on a new gem.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [ ] Write [tests] (https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes - I didn't find tests for the rest of the configs, so I guess they are not needed?
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
