### PR TITLE
Fix missing rdoc for Gem::Version

### DIFF
--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+require_relative "deprecate"
+
 ##
 # The Version class processes string versions into comparable
 # values. A version string should normally be a series of numbers
@@ -148,8 +151,6 @@
 #
 # For the last example, single-digit versions are automatically extended with
 # a zero to give a sensible result.
-
-require_relative "deprecate"
 
 class Gem::Version
   autoload :Requirement, File.expand_path('requirement', __dir__)


### PR DESCRIPTION
The rdoc for Gem::Version is available here:
* https://docs.ruby-lang.org/en/3.0/Gem/Version.html

However it is currently missing from:
* https://ruby-doc.org/stdlib-3.1.0/libdoc/rubygems/rdoc/Gem/Version.html
* https://docs.ruby-lang.org/en/3.1/Gem/Version.html
* https://docs.ruby-lang.org/en/master/Gem/Version.html
* `ri Gem::Version`
  with `ri --version` => 6.4.0 and `gem --version` => 3.3.5
* `yard ri Gem::Version` with `yard --version` => 0.9.27
