### PR TITLE
Forbid downgrading past the originally shipped version on Ruby 3.1

### DIFF
--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -336,7 +336,9 @@ command to remove old versions.
   #
   def oldest_supported_version
     @oldest_supported_version ||=
-      if Gem.ruby_version > Gem::Version.new("3.0.a")
+      if Gem.ruby_version > Gem::Version.new("3.1.a")
+        Gem::Version.new("3.3.3")
+      elsif Gem.ruby_version > Gem::Version.new("3.0.a")
         Gem::Version.new("3.2.3")
       elsif Gem.ruby_version > Gem::Version.new("2.7.a")
         Gem::Version.new("3.1.2")


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We do this for all the other versions and it has been working fine so far. I downgraded to 3.3.0 for some testing and a reintroduced a 3.3.0 regression that we addressed before final 3.1 Ruby release.

## What is your fix for the problem, implemented in this PR?

Add a lower bound like with the other rubies.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
