### PR TITLE
Fix edge case where gems were incorrectly removed from the lockfile

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -266,7 +266,7 @@ module Bundler
         else
           # Run a resolve against the locally available gems
           Bundler.ui.debug("Found changes from the lockfile, re-resolving dependencies because #{change_reason}")
-          expanded_dependencies = expand_dependencies(dependencies + metadata_dependencies, @remote)
+          expanded_dependencies = expand_dependencies(dependencies + metadata_dependencies, true)
           Resolver.resolve(expanded_dependencies, source_requirements, last_resolve, gem_version_promoter, additional_base_requirements_for_resolve, platforms)
         end
       end

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -249,10 +249,11 @@ module Bundler
     end
 
     def verify_gemfile_dependencies_are_found!(requirements)
-      requirements.each do |requirement|
+      requirements.map! do |requirement|
         name = requirement.name
-        next if name == "bundler"
-        next unless search_for(requirement).empty?
+        next requirement if name == "bundler"
+        next requirement unless search_for(requirement).empty?
+        next unless requirement.current_platform?
 
         if (base = @base[name]) && !base.empty?
           version = base.first.version
@@ -266,7 +267,7 @@ module Bundler
           message = gem_not_found_message(name, requirement, source_for(name))
         end
         raise GemNotFound, message
-      end
+      end.compact!
     end
 
     def gem_not_found_message(name, requirement, source, extra_message = "")

--- a/bundler/spec/commands/binstubs_spec.rb
+++ b/bundler/spec/commands/binstubs_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe "bundle binstubs <gem>" do
         end
 
         context "and the version is older and the same major" do
-          let(:system_bundler_version) { "2.3.3" }
+          let(:system_bundler_version) { "2.999.999" }
 
           before do
             lockfile lockfile.gsub(/BUNDLED WITH\n   .*$/m, "BUNDLED WITH\n   2.3.0")
@@ -191,7 +191,7 @@ RSpec.describe "bundle binstubs <gem>" do
           it "installs and runs the exact version of bundler", :rubygems => ">= 3.3.0.dev" do
             sys_exec "bin/bundle install --verbose", :artifice => "vcr"
             expect(exitstatus).not_to eq(42)
-            expect(out).to include("Bundler 2.3.3 is running, but your lockfile was generated with 2.3.0. Installing Bundler 2.3.0 and restarting using that version.")
+            expect(out).to include("Bundler 2.999.999 is running, but your lockfile was generated with 2.3.0. Installing Bundler 2.3.0 and restarting using that version.")
             expect(out).to include("Using bundler 2.3.0")
             expect(err).not_to include("Activating bundler (~> 2.3.0) failed:")
           end
@@ -199,8 +199,8 @@ RSpec.describe "bundle binstubs <gem>" do
           it "runs the available version of bundler", :rubygems => "< 3.3.0.dev" do
             sys_exec "bin/bundle install --verbose"
             expect(exitstatus).not_to eq(42)
-            expect(out).not_to include("Bundler 2.3.3 is running, but your lockfile was generated with 2.3.0. Installing Bundler 2.3.0 and restarting using that version.")
-            expect(out).to include("Using bundler 2.3.3")
+            expect(out).not_to include("Bundler 2.999.999 is running, but your lockfile was generated with 2.3.0. Installing Bundler 2.3.0 and restarting using that version.")
+            expect(out).to include("Using bundler 2.999.999")
             expect(err).not_to include("Activating bundler (~> 2.3.0) failed:")
           end
         end

--- a/bundler/spec/commands/cache_spec.rb
+++ b/bundler/spec/commands/cache_spec.rb
@@ -403,14 +403,14 @@ RSpec.describe "bundle install with gem sources" do
 
       simulate_new_machine
 
-      simulate_platform "ruby" do
-        install_gemfile <<-G
-          source "#{file_uri_for(gem_repo1)}"
-          gem "platform_specific"
-        G
-        run "require 'platform_specific' ; puts PLATFORM_SPECIFIC"
-        expect(out).to eq("1.0.0 RUBY")
-      end
+      bundle "config set --local force_ruby_platform true"
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem "platform_specific"
+      G
+      run "require 'platform_specific' ; puts PLATFORM_SPECIFIC"
+      expect(out).to eq("1.0.0 RUBY")
     end
 
     it "does not update the cache if --no-cache is passed" do

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -337,7 +337,8 @@ RSpec.describe "bundle lock" do
          #{Bundler::VERSION}
     G
 
-    simulate_platform(rb) { bundle :lock }
+    bundle "config set --local force_ruby_platform true"
+    bundle :lock
 
     expect(lockfile).to eq <<~G
       GEM

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -429,13 +429,16 @@ RSpec.describe "bundle install from an existing gemspec" do
           gemspec
         G
 
-        simulate_platform("ruby") { bundle "install" }
+        bundle "config set --local force_ruby_platform true"
+        bundle "install"
+
+        simulate_new_machine
         simulate_platform("jruby") { bundle "install" }
       end
 
       context "on ruby" do
         before do
-          simulate_platform("ruby")
+          bundle "config set --local force_ruby_platform true"
           bundle :install
         end
 
@@ -546,7 +549,7 @@ RSpec.describe "bundle install from an existing gemspec" do
     end
 
     it "installs the ruby platform gemspec" do
-      simulate_platform "ruby"
+      bundle "config set --local force_ruby_platform true"
 
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
@@ -557,7 +560,7 @@ RSpec.describe "bundle install from an existing gemspec" do
     end
 
     it "installs the ruby platform gemspec and skips dev deps with `without development` configured" do
-      simulate_platform "ruby"
+      bundle "config set --local force_ruby_platform true"
 
       bundle "config set --local without development"
       install_gemfile <<-G

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -625,4 +625,64 @@ RSpec.describe "bundle install from an existing gemspec" do
       expect(lockfile).to eq initial_lockfile
     end
   end
+
+  context "with multiple locked platforms" do
+    before do
+      build_lib("activeadmin", :path => tmp.join("activeadmin")) do |s|
+        s.version = "2.9.0"
+        s.add_dependency "railties", ">= 5.2", "< 6.2"
+      end
+
+      build_repo4 do
+        build_gem "railties", "6.1.4"
+
+        build_gem "jruby-openssl", "0.10.7" do |s|
+          s.platform = "java"
+        end
+      end
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo4)}"
+        gemspec :path => "../activeadmin"
+        gem "jruby-openssl", :platform => :jruby
+      G
+
+      bundle "lock --add-platform java"
+    end
+
+    it "does not remove the platform specific specs from the lockfile when re-resolving due to gemspec changes" do
+      expect(lockfile).to eq <<~L
+        PATH
+          remote: ../activeadmin
+          specs:
+            activeadmin (2.9.0)
+              railties (>= 5.2, < 6.2)
+
+        GEM
+          remote: #{file_uri_for(gem_repo4)}/
+          specs:
+            jruby-openssl (0.10.7-java)
+            railties (6.1.4)
+
+        PLATFORMS
+          #{lockfile_platforms_for(["java"] + local_platforms)}
+
+        DEPENDENCIES
+          activeadmin!
+          jruby-openssl
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      gemspec = tmp.join("activeadmin/activeadmin.gemspec")
+      File.write(gemspec, File.read(gemspec).sub(">= 5.2", ">= 6.0"))
+
+      previous_lockfile = lockfile
+
+      bundle "install --local"
+
+      expect(lockfile).to eq(previous_lockfile.sub(">= 5.2", ">= 6.0"))
+    end
+  end
 end

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -92,9 +92,7 @@ RSpec.describe "bundle install with git sources" do
       expect(err).to include("The source contains the following gems matching 'foo':\n  * foo-1.0")
     end
 
-    it "complains with version and platform if pinned specs don't exist in the git repo" do
-      simulate_platform "java"
-
+    it "complains with version and platform if pinned specs don't exist in the git repo", :jruby do
       build_git "only_java" do |s|
         s.platform = "java"
       end
@@ -109,9 +107,7 @@ RSpec.describe "bundle install with git sources" do
       expect(err).to include("The source contains the following gems matching 'only_java':\n  * only_java-1.0-java")
     end
 
-    it "complains with multiple versions and platforms if pinned specs don't exist in the git repo" do
-      simulate_platform "java"
-
+    it "complains with multiple versions and platforms if pinned specs don't exist in the git repo", :jruby do
       build_git "only_java", "1.0" do |s|
         s.platform = "java"
       end

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -86,13 +86,13 @@ RSpec.describe "bundle install across platforms" do
     expect(the_bundle).to include_gems "nokogiri 1.4.2 JAVA", "weakling 0.0.3"
 
     simulate_new_machine
-
-    simulate_platform "ruby"
+    bundle "config set --local force_ruby_platform true"
     bundle "install"
 
     expect(the_bundle).to include_gems "nokogiri 1.4.2"
     expect(the_bundle).not_to include_gems "weakling"
 
+    simulate_new_machine
     simulate_platform "java"
     bundle "install"
 
@@ -453,7 +453,7 @@ RSpec.describe "bundle install with platform conditionals" do
   end
 
   it "does not attempt to install gems from :rbx when using --local" do
-    simulate_platform "ruby"
+    bundle "config set --local force_ruby_platform true"
 
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -465,7 +465,7 @@ RSpec.describe "bundle install with platform conditionals" do
   end
 
   it "does not attempt to install gems from other rubies when using --local" do
-    simulate_platform "ruby"
+    bundle "config set --local force_ruby_platform true"
     other_ruby_version_tag = RUBY_VERSION =~ /^1\.8/ ? :ruby_19 : :ruby_18
 
     gemfile <<-G
@@ -478,7 +478,7 @@ RSpec.describe "bundle install with platform conditionals" do
   end
 
   it "does not print a warning when a dependency is unused on a platform different from the current one" do
-    simulate_platform "ruby"
+    bundle "config set --local force_ruby_platform true"
 
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"

--- a/bundler/spec/runtime/inline_spec.rb
+++ b/bundler/spec/runtime/inline_spec.rb
@@ -309,7 +309,7 @@ RSpec.describe "bundler/inline#gemfile" do
   end
 
   it "skips platform warnings" do
-    simulate_platform "ruby"
+    bundle "config set --local force_ruby_platform true"
 
     script <<-RUBY
       gemfile(true) do

--- a/bundler/spec/support/hax.rb
+++ b/bundler/spec/support/hax.rb
@@ -19,16 +19,6 @@ module Gem
       @local = new(ENV["BUNDLER_SPEC_PLATFORM"])
     end
     @platforms = [Gem::Platform::RUBY, Gem::Platform.local]
-
-    if ENV["BUNDLER_SPEC_PLATFORM"] == "ruby"
-      class << self
-        remove_method :finish_resolve
-
-        def finish_resolve
-          []
-        end
-      end
-    end
   end
 
   if ENV["BUNDLER_SPEC_GEM_SOURCES"]


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

While working on ActiveAdmin, I noticed that after make a dependency change in the gemspec, bundler was removing some unrelated platform specific gems from the lockfile.

## What is your fix for the problem, implemented in this PR?

The fix is to make sure that, even if resolving locally, information in the lockfile about other platforms is still preserved.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
