### PR TITLE
Fix `force_ruby_platform` ignored when lockfile includes current specific platform

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -496,6 +496,7 @@ module Bundler
 
     def current_ruby_platform_locked?
       return false unless generic_local_platform == Gem::Platform::RUBY
+      return false if Bundler.settings[:force_ruby_platform] && !@platforms.include?(Gem::Platform::RUBY)
 
       current_platform_locked?
     end

--- a/bundler/spec/runtime/platform_spec.rb
+++ b/bundler/spec/runtime/platform_spec.rb
@@ -232,6 +232,20 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
     expect(the_bundle).to include_gems "nokogiri 1.4.2", "platform_specific 1.0 RUBY"
   end
 
+  it "allows specifying only-ruby-platform even if the lockfile is locked to a specific compatible platform" do
+    install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
+      gem "nokogiri"
+      gem "platform_specific"
+    G
+
+    bundle "config set force_ruby_platform true"
+
+    bundle "install"
+
+    expect(the_bundle).to include_gems "nokogiri 1.4.2", "platform_specific 1.0 RUBY"
+  end
+
   it "doesn't pull platform specific gems on truffleruby", :truffleruby do
     install_gemfile <<-G
      source "#{file_uri_for(gem_repo1)}"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When lockfile includes the current real specific platform, the `force_ruby_platform` configuration is ignored. Bundler should force re-resolve using the RUBY platform instead.
 
## What is your fix for the problem, implemented in this PR?

Add the proper condition to force a re-resolve because of a new platform being considered (RUBY).

Fixes https://github.com/rubygems/rubygems/issues/4478.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
