### PR TITLE
Enable mfa on specific keys during gem signin

### DIFF
--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -260,8 +260,8 @@ module Gem::GemcutterUtilities
     else
       say "Please select scopes you want to enable for the API key (y/n)"
       API_SCOPES.each do |scope|
-        selected = ask "#{scope} [y/N]: "
-        scope_params[scope] = true if selected =~ /^[yY](es)?$/
+        selected = ask_yes_no("#{scope}", false)
+        scope_params[scope] = true if selected
       end
       say "\n"
     end
@@ -279,8 +279,8 @@ module Gem::GemcutterUtilities
     mfa_level = get_user_mfa_level(email, password)
     params = {}
     if mfa_level == "ui_only" || mfa_level == "ui_and_gem_signin"
-      selected = ask "Would you like to enable MFA for this key? [Y/n]"
-      params["mfa"] = true unless selected =~ /^[nN](o)?$/
+      selected = ask_yes_no("Would you like to enable MFA for this key? (strongly recommended)")
+      params["mfa"] = true if selected
     end
     params
   end

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -165,12 +165,14 @@ module Gem::GemcutterUtilities
     key_name     = get_key_name(scope)
     scope_params = get_scope_params(scope)
     mfa_params   = get_mfa_params(email, password)
+    all_params   = scope_params.merge(mfa_params)
+
 
     response = rubygems_api_request(:post, "api/v1/api_key",
                                     sign_in_host, scope: scope) do |request|
       request.basic_auth email, password
       request["OTP"] = otp if otp
-      request.body = URI.encode_www_form({ name: key_name }.merge(scope_params, mfa_params))
+      request.body = URI.encode_www_form({ name: key_name }.merge(all_params))
     end
 
     with_response response do |resp|

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require_relative 'remote_fetcher'
 require_relative 'text'
-require 'json'
 
 ##
 # Utility methods for using the RubyGems API.
@@ -283,11 +282,12 @@ module Gem::GemcutterUtilities
   end
 
   def get_user_mfa_level(email, password)
-    response = rubygems_api_request(:get, "api/v1/profile/me") do |request|
+    response = rubygems_api_request(:get, "api/v1/profile/me.yaml") do |request|
       request.basic_auth email, password
     end
     with_response response do |resp|
-      JSON.parse(resp.body)["mfa"]
+      body = Gem::SafeYAML.load clean_text(resp.body)
+      body["mfa"]
     end
   end
 

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -271,6 +271,8 @@ module Gem::GemcutterUtilities
   end
 
   def get_mfa_params(email, password)
+    return {} unless self.host == Gem::DEFAULT_HOST
+
     mfa_level = get_user_mfa_level(email, password)
     params = {}
     if mfa_level == "ui_only" || mfa_level == "ui_and_gem_signin"

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -281,7 +281,7 @@ module Gem::GemcutterUtilities
   end
 
   def get_user_mfa_level(email, password)
-    response = rubygems_api_request(:get, "api/v1/profile") do |request|
+    response = rubygems_api_request(:get, "api/v1/profile/me") do |request|
       request.basic_auth email, password
     end
     with_response response do |resp|

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -272,11 +272,9 @@ module Gem::GemcutterUtilities
   def get_mfa_params(email, password)
     mfa_level = get_user_mfa_level(email, password)
     params = {}
-    if mfa_level == "ui_only" || mfa_level == "ui_and_gem_sign"
+    if mfa_level == "ui_only" || mfa_level == "ui_and_gem_signin"
       selected = ask "Would you like to enable MFA for this key? [y/N]"
       params["mfa"] = true if selected =~ /^[yY](es)?$/
-    elsif mfa_level == "ui_and_api"
-      params["mfa"] = true
     end
     params
   end

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -221,7 +221,7 @@ module Gem::GemcutterUtilities
   # +response+ text and no otp provided by options.
 
   def set_api_key(host, key)
-    if host == Gem::DEFAULT_HOST
+    if default_host?
       Gem.configuration.rubygems_api_key = key
     else
       Gem.configuration.set_api_key host, key
@@ -245,7 +245,7 @@ module Gem::GemcutterUtilities
   end
 
   def pretty_host(host)
-    if Gem::DEFAULT_HOST == host
+    if default_host?
       'RubyGems.org'
     else
       host
@@ -269,8 +269,12 @@ module Gem::GemcutterUtilities
     scope_params
   end
 
+  def default_host?
+    self.host == Gem::DEFAULT_HOST
+  end
+
   def get_mfa_params(email, password)
-    return {} unless self.host == Gem::DEFAULT_HOST
+    return {} unless default_host?
 
     mfa_level = get_user_mfa_level(email, password)
     params = {}
@@ -285,6 +289,7 @@ module Gem::GemcutterUtilities
     response = rubygems_api_request(:get, "api/v1/profile/me.yaml") do |request|
       request.basic_auth email, password
     end
+
     with_response response do |resp|
       body = Gem::SafeYAML.load clean_text(resp.body)
       body["mfa"]

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -167,7 +167,6 @@ module Gem::GemcutterUtilities
     mfa_params   = get_mfa_params(email, password)
     all_params   = scope_params.merge(mfa_params)
 
-
     response = rubygems_api_request(:post, "api/v1/api_key",
                                     sign_in_host, scope: scope) do |request|
       request.basic_auth email, password

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -273,8 +273,8 @@ module Gem::GemcutterUtilities
     mfa_level = get_user_mfa_level(email, password)
     params = {}
     if mfa_level == "ui_only" || mfa_level == "ui_and_gem_signin"
-      selected = ask "Would you like to enable MFA for this key? [y/N]"
-      params["mfa"] = true if selected =~ /^[yY](es)?$/
+      selected = ask "Would you like to enable MFA for this key? [Y/n]"
+      params["mfa"] = true unless selected =~ /^[nN](o)?$/
     end
     params
   end

--- a/test/rubygems/test_gem_commands_push_command.rb
+++ b/test/rubygems/test_gem_commands_push_command.rb
@@ -446,7 +446,7 @@ class TestGemCommandsPushCommand < Gem::TestCase
       ["", 200, "OK"],
     ]
 
-    @fetcher.data["#{@host}/api/v1/profile"] = [
+    @fetcher.data["#{@host}/api/v1/profile/me"] = [
       [response_profile, 200, "OK"],
     ]
 

--- a/test/rubygems/test_gem_commands_push_command.rb
+++ b/test/rubygems/test_gem_commands_push_command.rb
@@ -435,6 +435,7 @@ class TestGemCommandsPushCommand < Gem::TestCase
 
     response_mfa_enabled = "You have enabled multifactor authentication but your request doesn't have the correct OTP code. Please check it and retry."
     response_success     = 'Successfully registered gem: freewill (1.0.0)'
+    response_profile     = {"mfa" => "disabled"}.to_json
 
     @fetcher.data["#{@host}/api/v1/gems"] = [
       [response_success, 200, "OK"],
@@ -443,6 +444,10 @@ class TestGemCommandsPushCommand < Gem::TestCase
     @fetcher.data["#{@host}/api/v1/api_key"] = [
       [response_mfa_enabled, 401, 'Unauthorized'],
       ["", 200, "OK"],
+    ]
+
+    @fetcher.data["#{@host}/api/v1/profile"] = [
+      [response_profile, 200, "OK"],
     ]
 
     @cmd.instance_variable_set :@scope, :push_rubygem

--- a/test/rubygems/test_gem_commands_push_command.rb
+++ b/test/rubygems/test_gem_commands_push_command.rb
@@ -435,7 +435,7 @@ class TestGemCommandsPushCommand < Gem::TestCase
 
     response_mfa_enabled = "You have enabled multifactor authentication but your request doesn't have the correct OTP code. Please check it and retry."
     response_success     = 'Successfully registered gem: freewill (1.0.0)'
-    response_profile     = {"mfa" => "disabled"}.to_json
+    response_profile     = "mfa: disabled\n"
 
     @fetcher.data["#{@host}/api/v1/gems"] = [
       [response_success, 200, "OK"],
@@ -446,7 +446,7 @@ class TestGemCommandsPushCommand < Gem::TestCase
       ["", 200, "OK"],
     ]
 
-    @fetcher.data["#{@host}/api/v1/profile/me"] = [
+    @fetcher.data["#{@host}/api/v1/profile/me.yaml"] = [
       [response_profile, 200, "OK"],
     ]
 

--- a/test/rubygems/test_gem_commands_signin_command.rb
+++ b/test/rubygems/test_gem_commands_signin_command.rb
@@ -92,13 +92,13 @@ class TestGemCommandsSigninCommand < Gem::TestCase
     user = ENV["USER"] || ENV["USERNAME"]
 
     assert_match "API Key name [#{Socket.gethostname}-#{user}", key_name_ui.output
-    assert_match "index_rubygems [y/N]", key_name_ui.output
-    assert_match "push_rubygem [y/N]", key_name_ui.output
-    assert_match "yank_rubygem [y/N]", key_name_ui.output
-    assert_match "add_owner [y/N]", key_name_ui.output
-    assert_match "remove_owner [y/N]", key_name_ui.output
-    assert_match "access_webhooks [y/N]", key_name_ui.output
-    assert_match "show_dashboard [y/N]", key_name_ui.output
+    assert_match "index_rubygems [yN]", key_name_ui.output
+    assert_match "push_rubygem [yN]", key_name_ui.output
+    assert_match "yank_rubygem [yN]", key_name_ui.output
+    assert_match "add_owner [yN]", key_name_ui.output
+    assert_match "remove_owner [yN]", key_name_ui.output
+    assert_match "access_webhooks [yN]", key_name_ui.output
+    assert_match "show_dashboard [yN]", key_name_ui.output
     assert_equal "name=test-key&push_rubygem=true", fetcher.last_request.body
 
     credentials = load_yaml_file Gem.configuration.credentials_path
@@ -118,14 +118,14 @@ class TestGemCommandsSigninCommand < Gem::TestCase
     user = ENV["USER"] || ENV["USERNAME"]
 
     assert_match "API Key name [#{Socket.gethostname}-#{user}", key_name_ui.output
-    assert_match "index_rubygems [y/N]", key_name_ui.output
-    assert_match "push_rubygem [y/N]", key_name_ui.output
-    assert_match "yank_rubygem [y/N]", key_name_ui.output
-    assert_match "add_owner [y/N]", key_name_ui.output
-    assert_match "remove_owner [y/N]", key_name_ui.output
-    assert_match "access_webhooks [y/N]", key_name_ui.output
-    assert_match "show_dashboard [y/N]", key_name_ui.output
-    assert_match "Would you like to enable MFA for this key? [Y/n]", key_name_ui.output
+    assert_match "index_rubygems [yN]", key_name_ui.output
+    assert_match "push_rubygem [yN]", key_name_ui.output
+    assert_match "yank_rubygem [yN]", key_name_ui.output
+    assert_match "add_owner [yN]", key_name_ui.output
+    assert_match "remove_owner [yN]", key_name_ui.output
+    assert_match "access_webhooks [yN]", key_name_ui.output
+    assert_match "show_dashboard [yN]", key_name_ui.output
+    assert_match "Would you like to enable MFA for this key? (strongly recommended) [yn]", key_name_ui.output
     assert_equal "name=test-key&push_rubygem=true&mfa=true", fetcher.last_request.body
 
     credentials = load_yaml_file Gem.configuration.credentials_path
@@ -145,14 +145,14 @@ class TestGemCommandsSigninCommand < Gem::TestCase
     user = ENV["USER"] || ENV["USERNAME"]
 
     assert_match "API Key name [#{Socket.gethostname}-#{user}", key_name_ui.output
-    assert_match "index_rubygems [y/N]", key_name_ui.output
-    assert_match "push_rubygem [y/N]", key_name_ui.output
-    assert_match "yank_rubygem [y/N]", key_name_ui.output
-    assert_match "add_owner [y/N]", key_name_ui.output
-    assert_match "remove_owner [y/N]", key_name_ui.output
-    assert_match "access_webhooks [y/N]", key_name_ui.output
-    assert_match "show_dashboard [y/N]", key_name_ui.output
-    assert_match "Would you like to enable MFA for this key? [Y/n]", key_name_ui.output
+    assert_match "index_rubygems [yN]", key_name_ui.output
+    assert_match "push_rubygem [yN]", key_name_ui.output
+    assert_match "yank_rubygem [yN]", key_name_ui.output
+    assert_match "add_owner [yN]", key_name_ui.output
+    assert_match "remove_owner [yN]", key_name_ui.output
+    assert_match "access_webhooks [yN]", key_name_ui.output
+    assert_match "show_dashboard [yN]", key_name_ui.output
+    assert_match "Would you like to enable MFA for this key? (strongly recommended) [yn]", key_name_ui.output
     assert_equal "name=test-key&push_rubygem=true&mfa=true", fetcher.last_request.body
 
     credentials = load_yaml_file Gem.configuration.credentials_path
@@ -181,13 +181,13 @@ class TestGemCommandsSigninCommand < Gem::TestCase
     user = ENV["USER"] || ENV["USERNAME"]
 
     assert_match "API Key name [#{Socket.gethostname}-#{user}", key_name_ui.output
-    assert_match "index_rubygems [y/N]", key_name_ui.output
-    assert_match "push_rubygem [y/N]", key_name_ui.output
-    assert_match "yank_rubygem [y/N]", key_name_ui.output
-    assert_match "add_owner [y/N]", key_name_ui.output
-    assert_match "remove_owner [y/N]", key_name_ui.output
-    assert_match "access_webhooks [y/N]", key_name_ui.output
-    assert_match "show_dashboard [y/N]", key_name_ui.output
+    assert_match "index_rubygems [yN]", key_name_ui.output
+    assert_match "push_rubygem [yN]", key_name_ui.output
+    assert_match "yank_rubygem [yN]", key_name_ui.output
+    assert_match "add_owner [yN]", key_name_ui.output
+    assert_match "remove_owner [yN]", key_name_ui.output
+    assert_match "access_webhooks [yN]", key_name_ui.output
+    assert_match "show_dashboard [yN]", key_name_ui.output
     assert_equal "name=test-key&push_rubygem=true", fetcher.last_request.body
   end
 

--- a/test/rubygems/test_gem_commands_signin_command.rb
+++ b/test/rubygems/test_gem_commands_signin_command.rb
@@ -105,18 +105,71 @@ class TestGemCommandsSigninCommand < Gem::TestCase
     assert_equal api_key, credentials[:rubygems_api_key]
   end
 
+  def test_execute_with_key_name_scope_and_mfa
+    email     = 'you@example.com'
+    password  = 'secret'
+    api_key   = '1234'
+    fetcher   = Gem::RemoteFetcher.fetcher
+
+    key_name_ui = Gem::MockGemUi.new "#{email}\n#{password}\ntest-key\n\ny\n\n\n\n\n\ny"
+    util_capture_with_mfa_enabled(key_name_ui, nil, api_key, fetcher) { @cmd.execute }
+
+    user = ENV["USER"] || ENV["USERNAME"]
+
+    assert_match "API Key name [#{Socket.gethostname}-#{user}", key_name_ui.output
+    assert_match "index_rubygems [y/N]", key_name_ui.output
+    assert_match "push_rubygem [y/N]", key_name_ui.output
+    assert_match "yank_rubygem [y/N]", key_name_ui.output
+    assert_match "add_owner [y/N]", key_name_ui.output
+    assert_match "remove_owner [y/N]", key_name_ui.output
+    assert_match "access_webhooks [y/N]", key_name_ui.output
+    assert_match "show_dashboard [y/N]", key_name_ui.output
+    assert_match "Would you like to enable MFA for this key? [y/N]", key_name_ui.output
+    assert_equal "name=test-key&push_rubygem=true&mfa=true", fetcher.last_request.body
+
+    credentials = load_yaml_file Gem.configuration.credentials_path
+    assert_equal api_key, credentials[:rubygems_api_key]
+  end
+
   # Utility method to capture IO/UI within the block passed
 
   def util_capture(ui_stub = nil, host = nil, api_key = nil, fetcher = Gem::FakeFetcher.new)
-    api_key ||= 'a5fdbb6ba150cbb83aad2bb2fede64cf040453903'
-    response  = [api_key, 200, 'OK']
-    email     = 'you@example.com'
-    password  = 'secret'
+    api_key        ||= 'a5fdbb6ba150cbb83aad2bb2fede64cf040453903'
+    response         = [api_key, 200, 'OK']
+    profile_response =[{"mfa" => "disabled"}.to_json, 200, 'OK']
+    email            = 'you@example.com'
+    password         = 'secret'
 
     # Set the expected response for the Web-API supplied
     ENV['RUBYGEMS_HOST']       = host || Gem::DEFAULT_HOST
     data_key                   = "#{ENV['RUBYGEMS_HOST']}/api/v1/api_key"
     fetcher.data[data_key]     = response
+    profile                    = "#{ENV['RUBYGEMS_HOST']}/api/v1/profile"
+    fetcher.data[profile]      = profile_response
+    Gem::RemoteFetcher.fetcher = fetcher
+
+    sign_in_ui = ui_stub || Gem::MockGemUi.new("#{email}\n#{password}\n\n\n\n\n\n\n\n\n")
+
+    use_ui sign_in_ui do
+      yield
+    end
+
+    sign_in_ui
+  end
+
+  def util_capture_with_mfa_enabled(ui_stub = nil, host = nil, api_key = nil, fetcher = Gem::FakeFetcher.new)
+    api_key        ||= 'a5fdbb6ba150cbb83aad2bb2fede64cf040453903'
+    response         = [api_key, 200, 'OK']
+    profile_response =[{"mfa" => "ui_only"}.to_json, 200, 'OK']
+    email            = 'you@example.com'
+    password         = 'secret'
+
+    # Set the expected response for the Web-API supplied
+    ENV['RUBYGEMS_HOST']       = host || Gem::DEFAULT_HOST
+    data_key                   = "#{ENV['RUBYGEMS_HOST']}/api/v1/api_key"
+    fetcher.data[data_key]     = response
+    profile                    = "#{ENV['RUBYGEMS_HOST']}/api/v1/profile"
+    fetcher.data[profile]      = profile_response
     Gem::RemoteFetcher.fetcher = fetcher
 
     sign_in_ui = ui_stub || Gem::MockGemUi.new("#{email}\n#{password}\n\n\n\n\n\n\n\n\n")

--- a/test/rubygems/test_gem_commands_signin_command.rb
+++ b/test/rubygems/test_gem_commands_signin_command.rb
@@ -105,14 +105,42 @@ class TestGemCommandsSigninCommand < Gem::TestCase
     assert_equal api_key, credentials[:rubygems_api_key]
   end
 
-  def test_execute_with_key_name_scope_and_mfa
+  def test_execute_with_key_name_scope_and_mfa_level_of_ui_only
     email     = 'you@example.com'
     password  = 'secret'
     api_key   = '1234'
     fetcher   = Gem::RemoteFetcher.fetcher
+    mfa_level = "ui_only"
 
     key_name_ui = Gem::MockGemUi.new "#{email}\n#{password}\ntest-key\n\ny\n\n\n\n\n\ny"
-    util_capture_with_mfa_enabled(key_name_ui, nil, api_key, fetcher) { @cmd.execute }
+    util_capture(key_name_ui, nil, api_key, fetcher, mfa_level) { @cmd.execute }
+
+    user = ENV["USER"] || ENV["USERNAME"]
+
+    assert_match "API Key name [#{Socket.gethostname}-#{user}", key_name_ui.output
+    assert_match "index_rubygems [y/N]", key_name_ui.output
+    assert_match "push_rubygem [y/N]", key_name_ui.output
+    assert_match "yank_rubygem [y/N]", key_name_ui.output
+    assert_match "add_owner [y/N]", key_name_ui.output
+    assert_match "remove_owner [y/N]", key_name_ui.output
+    assert_match "access_webhooks [y/N]", key_name_ui.output
+    assert_match "show_dashboard [y/N]", key_name_ui.output
+    assert_match "Would you like to enable MFA for this key? [y/N]", key_name_ui.output
+    assert_equal "name=test-key&push_rubygem=true&mfa=true", fetcher.last_request.body
+
+    credentials = load_yaml_file Gem.configuration.credentials_path
+    assert_equal api_key, credentials[:rubygems_api_key]
+  end
+
+  def test_execute_with_key_name_scope_and_mfa_level_of_gem_signin
+    email     = 'you@example.com'
+    password  = 'secret'
+    api_key   = '1234'
+    fetcher   = Gem::RemoteFetcher.fetcher
+    mfa_level = "ui_and_gem_signin"
+
+    key_name_ui = Gem::MockGemUi.new "#{email}\n#{password}\ntest-key\n\ny\n\n\n\n\n\ny"
+    util_capture(key_name_ui, nil, api_key, fetcher, mfa_level) { @cmd.execute }
 
     user = ENV["USER"] || ENV["USERNAME"]
 
@@ -133,34 +161,10 @@ class TestGemCommandsSigninCommand < Gem::TestCase
 
   # Utility method to capture IO/UI within the block passed
 
-  def util_capture(ui_stub = nil, host = nil, api_key = nil, fetcher = Gem::FakeFetcher.new)
+  def util_capture(ui_stub = nil, host = nil, api_key = nil, fetcher = Gem::FakeFetcher.new, mfa_level = "disabled")
     api_key        ||= 'a5fdbb6ba150cbb83aad2bb2fede64cf040453903'
     response         = [api_key, 200, 'OK']
-    profile_response =[{"mfa" => "disabled"}.to_json, 200, 'OK']
-    email            = 'you@example.com'
-    password         = 'secret'
-
-    # Set the expected response for the Web-API supplied
-    ENV['RUBYGEMS_HOST']       = host || Gem::DEFAULT_HOST
-    data_key                   = "#{ENV['RUBYGEMS_HOST']}/api/v1/api_key"
-    fetcher.data[data_key]     = response
-    profile                    = "#{ENV['RUBYGEMS_HOST']}/api/v1/profile"
-    fetcher.data[profile]      = profile_response
-    Gem::RemoteFetcher.fetcher = fetcher
-
-    sign_in_ui = ui_stub || Gem::MockGemUi.new("#{email}\n#{password}\n\n\n\n\n\n\n\n\n")
-
-    use_ui sign_in_ui do
-      yield
-    end
-
-    sign_in_ui
-  end
-
-  def util_capture_with_mfa_enabled(ui_stub = nil, host = nil, api_key = nil, fetcher = Gem::FakeFetcher.new)
-    api_key        ||= 'a5fdbb6ba150cbb83aad2bb2fede64cf040453903'
-    response         = [api_key, 200, 'OK']
-    profile_response =[{"mfa" => "ui_only"}.to_json, 200, 'OK']
+    profile_response =[{"mfa" => mfa_level}.to_json, 200, 'OK']
     email            = 'you@example.com'
     password         = 'secret'
 

--- a/test/rubygems/test_gem_commands_signin_command.rb
+++ b/test/rubygems/test_gem_commands_signin_command.rb
@@ -172,7 +172,7 @@ class TestGemCommandsSigninCommand < Gem::TestCase
     ENV['RUBYGEMS_HOST']       = host || Gem::DEFAULT_HOST
     data_key                   = "#{ENV['RUBYGEMS_HOST']}/api/v1/api_key"
     fetcher.data[data_key]     = response
-    profile                    = "#{ENV['RUBYGEMS_HOST']}/api/v1/profile"
+    profile                    = "#{ENV['RUBYGEMS_HOST']}/api/v1/profile/me"
     fetcher.data[profile]      = profile_response
     Gem::RemoteFetcher.fetcher = fetcher
 

--- a/test/rubygems/test_gem_commands_signin_command.rb
+++ b/test/rubygems/test_gem_commands_signin_command.rb
@@ -164,7 +164,7 @@ class TestGemCommandsSigninCommand < Gem::TestCase
   def util_capture(ui_stub = nil, host = nil, api_key = nil, fetcher = Gem::FakeFetcher.new, mfa_level = "disabled")
     api_key        ||= 'a5fdbb6ba150cbb83aad2bb2fede64cf040453903'
     response         = [api_key, 200, 'OK']
-    profile_response =[{"mfa" => mfa_level}.to_json, 200, 'OK']
+    profile_response = [{"mfa" => mfa_level}.to_json, 200, 'OK']
     email            = 'you@example.com'
     password         = 'secret'
 

--- a/test/rubygems/test_gem_commands_signin_command.rb
+++ b/test/rubygems/test_gem_commands_signin_command.rb
@@ -125,7 +125,7 @@ class TestGemCommandsSigninCommand < Gem::TestCase
     assert_match "remove_owner [y/N]", key_name_ui.output
     assert_match "access_webhooks [y/N]", key_name_ui.output
     assert_match "show_dashboard [y/N]", key_name_ui.output
-    assert_match "Would you like to enable MFA for this key? [y/N]", key_name_ui.output
+    assert_match "Would you like to enable MFA for this key? [Y/n]", key_name_ui.output
     assert_equal "name=test-key&push_rubygem=true&mfa=true", fetcher.last_request.body
 
     credentials = load_yaml_file Gem.configuration.credentials_path
@@ -152,7 +152,7 @@ class TestGemCommandsSigninCommand < Gem::TestCase
     assert_match "remove_owner [y/N]", key_name_ui.output
     assert_match "access_webhooks [y/N]", key_name_ui.output
     assert_match "show_dashboard [y/N]", key_name_ui.output
-    assert_match "Would you like to enable MFA for this key? [y/N]", key_name_ui.output
+    assert_match "Would you like to enable MFA for this key? [Y/n]", key_name_ui.output
     assert_equal "name=test-key&push_rubygem=true&mfa=true", fetcher.last_request.body
 
     credentials = load_yaml_file Gem.configuration.credentials_path

--- a/test/rubygems/test_gem_commands_signin_command.rb
+++ b/test/rubygems/test_gem_commands_signin_command.rb
@@ -196,7 +196,7 @@ class TestGemCommandsSigninCommand < Gem::TestCase
   def util_capture(ui_stub = nil, host = nil, api_key = nil, fetcher = Gem::FakeFetcher.new, mfa_level = "disabled")
     api_key        ||= 'a5fdbb6ba150cbb83aad2bb2fede64cf040453903'
     response         = [api_key, 200, 'OK']
-    profile_response = [{"mfa" => mfa_level}.to_json, 200, 'OK']
+    profile_response = [ "mfa: #{mfa_level}\n" , 200, 'OK']
     email            = 'you@example.com'
     password         = 'secret'
 
@@ -204,7 +204,7 @@ class TestGemCommandsSigninCommand < Gem::TestCase
     ENV['RUBYGEMS_HOST']       = host || Gem::DEFAULT_HOST
     data_key                   = "#{ENV['RUBYGEMS_HOST']}/api/v1/api_key"
     fetcher.data[data_key]     = response
-    profile                    = "#{ENV['RUBYGEMS_HOST']}/api/v1/profile/me"
+    profile                    = "#{ENV['RUBYGEMS_HOST']}/api/v1/profile/me.yaml"
     fetcher.data[profile]      = profile_response
     Gem::RemoteFetcher.fetcher = fetcher
 

--- a/test/rubygems/test_gem_gemcutter_utilities.rb
+++ b/test/rubygems/test_gem_gemcutter_utilities.rb
@@ -227,9 +227,9 @@ class TestGemGemcutterUtilities < Gem::TestCase
   end
 
   def util_sign_in(response, host = nil, args = [], extra_input = '')
-    email    = 'you@example.com'
-    password = 'secret'
-    profile_response =[{"mfa" => "disabled"}.to_json, 200, 'OK']
+    email            = 'you@example.com'
+    password         = 'secret'
+    profile_response = [{"mfa" => "disabled"}.to_json, 200, 'OK']
 
     if host
       ENV['RUBYGEMS_HOST'] = host

--- a/test/rubygems/test_gem_gemcutter_utilities.rb
+++ b/test/rubygems/test_gem_gemcutter_utilities.rb
@@ -229,7 +229,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
   def util_sign_in(response, host = nil, args = [], extra_input = '')
     email            = 'you@example.com'
     password         = 'secret'
-    profile_response = [{"mfa" => "disabled"}.to_json, 200, 'OK']
+    profile_response = [ "mfa: disabled\n" , 200, 'OK']
 
     if host
       ENV['RUBYGEMS_HOST'] = host
@@ -239,7 +239,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
 
     @fetcher = Gem::FakeFetcher.new
     @fetcher.data["#{host}/api/v1/api_key"] = response
-    @fetcher.data["#{host}/api/v1/profile/me"] = profile_response
+    @fetcher.data["#{host}/api/v1/profile/me.yaml"] = profile_response
     Gem::RemoteFetcher.fetcher = @fetcher
 
     @sign_in_ui = Gem::MockGemUi.new("#{email}\n#{password}\n\n\n\n\n\n\n\n\n" + extra_input)

--- a/test/rubygems/test_gem_gemcutter_utilities.rb
+++ b/test/rubygems/test_gem_gemcutter_utilities.rb
@@ -229,6 +229,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
   def util_sign_in(response, host = nil, args = [], extra_input = '')
     email    = 'you@example.com'
     password = 'secret'
+    profile_response =[{"mfa" => "disabled"}.to_json, 200, 'OK']
 
     if host
       ENV['RUBYGEMS_HOST'] = host
@@ -238,6 +239,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
 
     @fetcher = Gem::FakeFetcher.new
     @fetcher.data["#{host}/api/v1/api_key"] = response
+    @fetcher.data["#{host}/api/v1/profile"] = profile_response
     Gem::RemoteFetcher.fetcher = @fetcher
 
     @sign_in_ui = Gem::MockGemUi.new("#{email}\n#{password}\n\n\n\n\n\n\n\n\n" + extra_input)

--- a/test/rubygems/test_gem_gemcutter_utilities.rb
+++ b/test/rubygems/test_gem_gemcutter_utilities.rb
@@ -239,7 +239,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
 
     @fetcher = Gem::FakeFetcher.new
     @fetcher.data["#{host}/api/v1/api_key"] = response
-    @fetcher.data["#{host}/api/v1/profile"] = profile_response
+    @fetcher.data["#{host}/api/v1/profile/me"] = profile_response
     Gem::RemoteFetcher.fetcher = @fetcher
 
     @sign_in_ui = Gem::MockGemUi.new("#{email}\n#{password}\n\n\n\n\n\n\n\n\n" + extra_input)


### PR DESCRIPTION
Part of: https://github.com/rubygems/rubygems.org/issues/2755
Follow up to https://github.com/rubygems/rubygems.org/pull/2922

**What does this change do:**
- Requests the users mfa level from the server on gem signin
- If the user has an mfa level of `ui_only` or `ui_and_gem_sign`, asks the user if they would like to enable mfa on the key they are creating
- If the user has an mfa level of `ui_and_api`, turns mfa on for the key without asking 

**Why is this necessary:**

MFA can be enabled on specific API keys through the UI (ref: https://github.com/rubygems/rubygems.org/pull/2846), so a user should also be able to enable it on keys that they create during `gem signin` in the CLI.

We only want to ask a user if they would like to enable mfa on new keys if they have account mfa levels of `ui_only` or `ui_and_gem_sign`. Users that have MFA disabled or those that have it  enabled for `ui_and_api ` should not be prompted, as it should be auto enabled or disabled for those levels.
