### PR TITLE
Use `Gem::Platform.local` instead of `RUBY_PLATFORM` when displaying local platform

### DIFF
--- a/bundler/lib/bundler/cli/platform.rb
+++ b/bundler/lib/bundler/cli/platform.rb
@@ -23,7 +23,7 @@ module Bundler
           output << "No ruby version specified"
         end
       else
-        output << "Your platform is: #{RUBY_PLATFORM}"
+        output << "Your platform is: #{Gem::Platform.local}"
         output << "Your app has gems that work on these platforms:\n#{platforms.join("\n")}"
 
         if ruby_version

--- a/bundler/lib/bundler/env.rb
+++ b/bundler/lib/bundler/env.rb
@@ -71,7 +71,7 @@ module Bundler
     def self.ruby_version
       str = String.new(RUBY_VERSION)
       str << "p#{RUBY_PATCHLEVEL}" if defined? RUBY_PATCHLEVEL
-      str << " (#{RUBY_RELEASE_DATE} revision #{RUBY_REVISION}) [#{RUBY_PLATFORM}]"
+      str << " (#{RUBY_RELEASE_DATE} revision #{RUBY_REVISION}) [#{Gem::Platform.local}]"
     end
 
     def self.git_version

--- a/bundler/spec/other/platform_spec.rb
+++ b/bundler/spec/other/platform_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "bundle platform" do
 
       bundle "platform"
       expect(out).to eq(<<-G.chomp)
-Your platform is: #{RUBY_PLATFORM}
+Your platform is: #{Gem::Platform.local}
 
 Your app has gems that work on these platforms:
 #{bundle_platform_platforms_string}
@@ -40,7 +40,7 @@ G
 
       bundle "platform"
       expect(out).to eq(<<-G.chomp)
-Your platform is: #{RUBY_PLATFORM}
+Your platform is: #{Gem::Platform.local}
 
 Your app has gems that work on these platforms:
 #{bundle_platform_platforms_string}
@@ -61,7 +61,7 @@ G
 
       bundle "platform"
       expect(out).to eq(<<-G.chomp)
-Your platform is: #{RUBY_PLATFORM}
+Your platform is: #{Gem::Platform.local}
 
 Your app has gems that work on these platforms:
 #{bundle_platform_platforms_string}
@@ -81,7 +81,7 @@ G
 
       bundle "platform"
       expect(out).to eq(<<-G.chomp)
-Your platform is: #{RUBY_PLATFORM}
+Your platform is: #{Gem::Platform.local}
 
 Your app has gems that work on these platforms:
 #{bundle_platform_platforms_string}


### PR DESCRIPTION
In certain places, we want to display the platform name with `Gem::Platform.local` instead of `RUBY_PLATFORM`.

Fixes https://github.com/rubygems/rubygems/issues/5264

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

https://github.com/rubygems/rubygems/issues/5264

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

Use `Gem::Platform.local` instead of `RUBY_PLATFORM`.

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
