### PR TITLE
Fix CI

### DIFF
--- a/bundler/spec/commands/remove_spec.rb
+++ b/bundler/spec/commands/remove_spec.rb
@@ -48,12 +48,14 @@ RSpec.describe "bundle remove" do
 
       context "when gem is specified in multiple lines" do
         it "shows success for removed gem" do
+          build_git "rack"
+
           gemfile <<-G
             source '#{file_uri_for(gem_repo1)}'
 
             gem 'git'
             gem 'rack',
-                git: 'https://github.com/rack/rack',
+                git: "#{lib_path("rack-1.0")}",
                 branch: 'master'
             gem 'nokogiri'
           G

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -418,9 +418,6 @@ RSpec.describe "bundle install with git sources" do
 
   describe "when specifying local override" do
     it "uses the local repository instead of checking a new one out" do
-      # We don't generate it because we actually don't need it
-      # build_git "rack", "0.8"
-
       build_git "rack", "0.8", :path => lib_path("local-rack") do |s|
         s.write "lib/rack.rb", "puts :LOCAL"
       end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

One of our specs depended on the state of rack's repo master branch. They just dropped support for Ruby 2.3, so our spec broke on Ruby 2.3.

## What is your fix for the problem, implemented in this PR?

Rewrite the spec to not touch the network nor depend on the state of rack's master branch.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
