### PR TITLE
Changelogs for rubygems 3.3.6 and bundler 2.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 3.3.6 / 2022-01-26
+
+## Enhancements:
+
+* Forbid downgrading past the originally shipped version on Ruby 3.1. Pull
+  request #5301 by deivid-rodriguez
+* Support `--enable-load-relative` inside binstubs. Pull request #2929 by
+  deivid-rodriguez
+* Let `Version#<=>` accept a String. Pull request #5275 by amatsuda
+* Installs bundler 2.3.6 as a default gem.
+
+## Bug fixes:
+
+* Avoid `flock` on non Windows systems, since it causing issues on NFS
+  file systems. Pull request #5278 by deivid-rodriguez
+* Fix `gem update --system`  for already installed version of
+  `rubygems-update`. Pull request #5285 by loadkpi
+
 # 3.3.5 / 2022-01-12
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 2.3.6 (January 26, 2022)
+
+## Enhancements:
+
+  - Use `Gem::Platform.local` instead of `RUBY_PLATFORM` when displaying local platform [#5306](https://github.com/rubygems/rubygems/pull/5306)
+  - Lock standard.yml to the required ruby version [#5284](https://github.com/rubygems/rubygems/pull/5284)
+  - Use `Fiddle` in `bundle doctor` to check for dynamic library presence [#5173](https://github.com/rubygems/rubygems/pull/5173)
+
+## Bug fixes:
+
+  - Fix edge case where gems were incorrectly removed from the lockfile [#5302](https://github.com/rubygems/rubygems/pull/5302)
+  - Fix `force_ruby_platform` ignored when lockfile includes current specific platform [#5304](https://github.com/rubygems/rubygems/pull/5304)
+  - Create minitest file to underscored path in "bundle gem" command with dashed gem name [#5273](https://github.com/rubygems/rubygems/pull/5273)
+  - Fix regression with old marshaled specs having null `required_rubygems_version` [#5291](https://github.com/rubygems/rubygems/pull/5291)
+
 # 2.3.5 (January 12, 2022)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking changelogs from future rubygems 3.3.6 and bundler 2.3.6 into master.