### PR TITLE
Don't consider gems provided by Debian packages as deleted

### DIFF
--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -86,7 +86,7 @@ module Gem
     end
 
     def deleted_gem?
-      !default_gem? && !File.directory?(full_gem_path)
+      !default_gem? && !File.directory?(full_gem_path) && (full_gem_path !~ %r{/rubygems-integration/})
     end
 
     private


### PR DESCRIPTION
In Debian, old-style packages provide a gemspec but the actual library files
are shipped in /usr/lib/ruby/vendor_ruby/. We are converting all packages to
the Rubygems layout, but we are not finished yet.

This fixed a regression introduced in Debian by
8950631f02498195794096a8e7c28b7feac56382 ("Fix `bundle install` to force
reinstallation of deleted gems").

Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1004195

------

I'm including this patch in the Debian rubygems package. I don't expect rubygems upstream to carry this as-is, but we can use this PR to start a discussion. Maybe we don't even need to do anything, as eventually Debian will transition to having all packages using the rubygems layout and we will be able to drop this patch.

cc @deivid-rodriguez 