### PR TITLE
Remove encoding pragma from specification.rb

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# -*- coding: utf-8 -*-
+#
 #--
 # Copyright 2006 by Chad Fowler, Rich Kilmer, Jim Weirich and others.
 # All rights reserved.


### PR DESCRIPTION
- it is not used since it is not at the top of the file
- it is not useful anymore

requested by @nobu at https://github.com/rubygems/rubygems/commit/0a0663ff6a341c62edbaf5c3143024f3bef04076#r65077065