### PR TITLE
Expect to receive a non-keywords hash

### DIFF
--- a/bundler/spec/bundler/rubygems_integration_spec.rb
+++ b/bundler/spec/bundler/rubygems_integration_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Bundler::RubygemsIntegration do
 
     it "successfully downloads gem with retries" do
       expect(Bundler.rubygems).to receive(:gem_remote_fetcher).and_return(fetcher)
-      expect(fetcher).to receive(:headers=).with("X-Gemfile-Source" => "https://foo.bar")
+      expect(fetcher).to receive(:headers=).with({ "X-Gemfile-Source" => "https://foo.bar" })
       expect(Bundler::Retry).to receive(:new).with("download gem from #{uri}/").
         and_return(bundler_retry)
       expect(bundler_retry).to receive(:attempts).and_yield
@@ -69,7 +69,7 @@ RSpec.describe Bundler::RubygemsIntegration do
 
       it "sets the 'X-Gemfile-Source' header containing the original source" do
         expect(Bundler.rubygems).to receive(:gem_remote_fetcher).twice.and_return(fetcher)
-        expect(fetcher).to receive(:headers=).with("X-Gemfile-Source" => "http://zombo.com").twice
+        expect(fetcher).to receive(:headers=).with({ "X-Gemfile-Source" => "http://zombo.com" }).twice
         expect(fetcher).to receive(:fetch_path).with(uri + "specs.4.8.gz").and_return(specs_response)
         expect(fetcher).to receive(:fetch_path).with(uri + "prerelease_specs.4.8.gz").and_return(prerelease_specs_response)
         result = Bundler.rubygems.fetch_all_remote_specs(remote_with_mirror)

--- a/bundler/tool/bundler/dev_gems.rb.lock
+++ b/bundler/tool/bundler/dev_gems.rb.lock
@@ -27,7 +27,7 @@ GEM
     rspec-expectations (3.10.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
-    rspec-mocks (3.10.2)
+    rspec-mocks (3.10.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.3)


### PR DESCRIPTION
`RSpec::Mocks::ArgumentListMatcher#args_match?` fails when a non-keywords hash is passed while a keyword hash is expected.


## What was the end-user or developer problem that led to this PR?

Since a few days ago, `test-bundler` is failing on GitHub Actions.
I'm not sure why this didn't happened previously and what triggered it.

## What is your fix for the problem, implemented in this PR?

Make a non-keyword hash an explicit hash.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
