### PR TITLE
If GEM_HOME isn't set AND default gem home isn't writable, set `Gem.paths.home` to `Gem.user_dir`.

### DIFF
--- a/bundler/spec/commands/doctor_spec.rb
+++ b/bundler/spec/commands/doctor_spec.rb
@@ -40,8 +40,9 @@ RSpec.describe "bundle doctor" do
       allow(File).to receive(:readable?).with(unwritable_file) { true }
 
       # The following 2 lines are for `Gem::PathSupport#initialize`.
-      allow(File).to receive(:exist?).with(Gem.paths.send(:default_home_dir))
-      allow(File).to receive(:writable?).with(Gem.paths.send(:default_home_dir))
+      allow(File).to receive(:exist?).with(Gem.default_dir)
+      allow(File).to receive(:writable?).with(Gem.default_dir)
+      allow(File).to receive(:writable?).with(File.expand_path("..", Gem.default_dir))
     end
 
     it "exits with no message if the installed gem has no C extensions" do

--- a/bundler/spec/commands/doctor_spec.rb
+++ b/bundler/spec/commands/doctor_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "bundle doctor" do
       allow(File).to receive(:writable?).with(unwritable_file) { true }
       allow(File).to receive(:readable?).with(unwritable_file) { true }
 
-      # The following 2 lines are for `Gem::PathSupport#initialize`.
+      # The following lines are for `Gem::PathSupport#initialize`.
       allow(File).to receive(:exist?).with(Gem.default_dir)
       allow(File).to receive(:writable?).with(Gem.default_dir)
       allow(File).to receive(:writable?).with(File.expand_path("..", Gem.default_dir))

--- a/bundler/spec/commands/doctor_spec.rb
+++ b/bundler/spec/commands/doctor_spec.rb
@@ -38,6 +38,10 @@ RSpec.describe "bundle doctor" do
       allow(stat).to receive(:uid) { Process.uid }
       allow(File).to receive(:writable?).with(unwritable_file) { true }
       allow(File).to receive(:readable?).with(unwritable_file) { true }
+
+      # The following 2 lines are for `Gem::PathSupport#initialize`.
+      allow(File).to receive(:exist?).with(Gem.paths.send(:default_home_dir))
+      allow(File).to receive(:writable?).with(Gem.paths.send(:default_home_dir))
     end
 
     it "exits with no message if the installed gem has no C extensions" do

--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -324,7 +324,7 @@ class Gem::Command
       @when_invoked.call options
     else
       if Gem.paths.auto_user_install && !options[:install_dir] && !options[:user_install]
-        self.ui.say "Defaulting to user installation because default GEM_HOME (#{Gem.default_dir}) is not writable."
+        self.ui.say "Defaulting to user installation because default installation directory (#{Gem.default_dir}) is not writable."
       end
 
       execute

--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -323,6 +323,10 @@ class Gem::Command
     elsif @when_invoked
       @when_invoked.call options
     else
+      if Gem.paths.auto_user_install && !options[:install_dir] && !options[:user_install]
+        self.ui.say "Defaulting to user installation because default GEM_HOME (#{Gem.default_dir}) is not writable."
+      end
+
       execute
     end
   ensure

--- a/lib/rubygems/install_update_options.rb
+++ b/lib/rubygems/install_update_options.rb
@@ -185,9 +185,24 @@ module Gem::InstallUpdateOptions
   # Default options for the gem install and update commands.
 
   def install_update_options
-    {
+    default_options = {
       :document => %w[ri],
     }
+
+    # If Gem.paths.home exists, but we can't write to it,
+    # fall back to a user installation.
+    if File.exist?(Gem.paths.home) && !File.writable?(Gem.paths.home)
+      default_options[:user_install] = true
+
+      alert_warning "The default GEM_HOME (#{Gem.paths.home}) is not" \
+                    " writable, so rubygems is falling back to installing" \
+                    " under your home folder. To get rid of this warning" \
+                    " permanently either fix your GEM_HOME folder permissions" \
+                    " or add the following to your ~/.gemrc file:\n" \
+                    "    gem: --user-install"
+    end
+
+    default_options
   end
 
   ##

--- a/lib/rubygems/install_update_options.rb
+++ b/lib/rubygems/install_update_options.rb
@@ -185,24 +185,9 @@ module Gem::InstallUpdateOptions
   # Default options for the gem install and update commands.
 
   def install_update_options
-    default_options = {
+    {
       :document => %w[ri],
     }
-
-    # If Gem.paths.home exists, but we can't write to it,
-    # fall back to a user installation.
-    if File.exist?(Gem.paths.home) && !File.writable?(Gem.paths.home)
-      default_options[:user_install] = true
-
-      alert_warning "The default GEM_HOME (#{Gem.paths.home}) is not" \
-                    " writable, so rubygems is falling back to installing" \
-                    " under your home folder. To get rid of this warning" \
-                    " permanently either fix your GEM_HOME folder permissions" \
-                    " or add the following to your ~/.gemrc file:\n" \
-                    "    gem: --user-install"
-    end
-
-    default_options
   end
 
   ##

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -196,9 +196,10 @@ class Gem::Installer
     end
 
     if @gem_home == Gem.user_dir
-      # If we get here, then:
-      # 1. `--user-install` was specified, or
-      # 2. GEM_HOME was not writable, and `Gem::PathSupport` fell back to `Gem.user_dir`.
+      # If we get here, then one of the following likely happened:
+      # - `--user-install` was specified
+      # - `Gem::PathSupport#home` fell back to `Gem.user_dir`
+      # - GEM_HOME was manually set to `Gem.user_dir`
 
       check_that_user_bin_dir_is_in_path
     end

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -193,6 +193,13 @@ class Gem::Installer
       @gem_home = Gem.user_dir
       @bin_dir = Gem.bindir gem_home unless options[:bin_dir]
       @plugins_dir = Gem.plugindir(gem_home)
+    end
+
+    if @gem_home == Gem.user_dir
+      # If we get here, then:
+      # 1. `--user-install` was specified, or
+      # 2. GEM_HOME was not writable, and `Gem::PathSupport` fell back to `Gem.user_dir`.
+
       check_that_user_bin_dir_is_in_path
     end
   end

--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -19,6 +19,10 @@ class Gem::PathSupport
   attr_reader :spec_cache_dir # :nodoc:
 
   ##
+  # Whether or `Gem.paths.home` defaulted to a user install.
+  attr_reader :auto_user_install
+
+  ##
   #
   # Constructor. Takes a single argument which is to be treated like a
   # hashtable, or defaults to ENV, the system environment.
@@ -38,9 +42,8 @@ class Gem::PathSupport
       @home = normalize_home_dir(Gem.default_dir)
     else
       # If `GEM_HOME` is not set AND we can't use `Gem.default_dir`,
-      # default to a user installation and print a message about this.
-      puts "Defaulting to user installation because default GEM_HOME (#{Gem.default_dir}) is not writable."
-
+      # default to a user installation and set `@auto_user_install`.
+      @auto_user_install = true
       @home = normalize_home_dir(Gem.user_dir)
     end
 

--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -32,6 +32,19 @@ class Gem::PathSupport
 
     @home = expand(@home)
 
+    # If @home (aka Gem.paths.home) exists, but we can't write to it,
+    # fall back to Gem.user_dir (the directory used for user installs).
+    if File.exist?(@home) && !File.writable?(@home)
+      warn "The default GEM_HOME (#{@home}) is not" \
+            " writable, so rubygems is falling back to installing" \
+            " under your home folder. To get rid of this warning" \
+            " permanently either fix your GEM_HOME folder permissions" \
+            " or add the following to your ~/.gemrc file:\n" \
+            "    gem: --install-dir #{Gem.user_dir}"
+
+      @home = Gem.user_dir
+    end
+
     @path = split_gem_path env["GEM_PATH"], @home
 
     @spec_cache_dir = env["GEM_SPEC_CACHE"] || Gem.default_spec_cache_dir

--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -19,7 +19,7 @@ class Gem::PathSupport
   attr_reader :spec_cache_dir # :nodoc:
 
   ##
-  # Whether or `Gem.paths.home` defaulted to a user install.
+  # Whether `Gem.paths.home` defaulted to a user install or not.
   attr_reader :auto_user_install
 
   ##

--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -24,13 +24,7 @@ class Gem::PathSupport
   # hashtable, or defaults to ENV, the system environment.
   #
   def initialize(env)
-    @home = env["GEM_HOME"] || Gem.default_dir
-
-    if File::ALT_SEPARATOR
-      @home = @home.gsub(File::ALT_SEPARATOR, File::SEPARATOR)
-    end
-
-    @home = expand(@home)
+    @home = default_home_dir(env)
 
     # If @home (aka Gem.paths.home) exists, but we can't write to it,
     # fall back to Gem.user_dir (the directory used for user installs).
@@ -53,6 +47,20 @@ class Gem::PathSupport
   end
 
   private
+
+  ##
+  # The default home directory.
+  # This function was broken out to accommodate tests in `bundler/spec/commands/doctor_spec.rb`.
+
+  def default_home_dir(env)
+    home = env["GEM_HOME"] || Gem.default_dir
+
+    if File::ALT_SEPARATOR
+      home = home.gsub(File::ALT_SEPARATOR, File::SEPARATOR)
+    end
+
+    expand(home)
+  end
 
   ##
   # Split the Gem search path (as reported by Gem.path).

--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -56,10 +56,6 @@ class Gem::PathSupport
 
   private
 
-  ##
-  # The default home directory.
-  # This function was broken out to accommodate tests in `bundler/spec/commands/doctor_spec.rb`.
-
   def normalize_home_dir(home)
     if File::ALT_SEPARATOR
       home = home.gsub(File::ALT_SEPARATOR, File::SEPARATOR)

--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -30,15 +30,12 @@ class Gem::PathSupport
   def initialize(env)
     # Current implementation of @home, which is exposed as `Gem.paths.home`:
     # 1. If `env["GEM_HOME"]` is defined in the environment: `env["GEM_HOME"]`.
-    # 2. If `Gem.default_dir` is writable OR it does not exist and it's parent
-    #    directory is writable: `Gem.default_dir`.
+    # 2. If `Gem.default_dir` is writable: `Gem.default_dir`.
     # 3. Otherwise: `Gem.user_dir`.
 
     if env.key?("GEM_HOME")
       @home = normalize_home_dir(env["GEM_HOME"])
-    elsif File.writable?(Gem.default_dir) || \
-          (!File.exist?(Gem.default_dir) && File.writable?(File.expand_path("..", Gem.default_dir)))
-
+    elsif File.writable?(Gem.default_dir)
       @home = normalize_home_dir(Gem.default_dir)
     else
       # If `GEM_HOME` is not set AND we can't use `Gem.default_dir`,

--- a/test/rubygems/test_gem_install_update_options.rb
+++ b/test/rubygems/test_gem_install_update_options.rb
@@ -159,9 +159,9 @@ class TestGemInstallUpdateOptions < Gem::InstallerTestCase
     FileUtils.chmod 0o755, @gemhome
   end
 
-  def test_auto_user_install_unless_gem_home_writable
+  def test_auto_install_dir_unless_gem_home_writable
     if Process.uid.zero?
-      pend("test_auto_user_install_unless_gem_home_writable test skipped in root privilege")
+      pend("test_auto_install_dir_unless_gem_home_writable test skipped in root privilege")
       return
     end
 
@@ -174,14 +174,14 @@ class TestGemInstallUpdateOptions < Gem::InstallerTestCase
 
     @cmd.handle_options %w[]
 
-    refute @cmd.options[:user_install]
+    assert_not_equal Gem.paths.home, Gem.user_dir
 
     FileUtils.chmod 0o755, @userhome
     FileUtils.chmod 0o000, @gemhome
 
     Gem.use_paths @gemhome, @userhome
 
-    @cmd.install_update_options.include?(:user_install)
+    assert_equal Gem.paths.home, Gem.user_dir
   ensure
     FileUtils.chmod 0o755, @gemhome
   end

--- a/test/rubygems/test_gem_install_update_options.rb
+++ b/test/rubygems/test_gem_install_update_options.rb
@@ -151,7 +151,7 @@ class TestGemInstallUpdateOptions < Gem::InstallerTestCase
 
       Gem.use_paths @gemhome, @userhome
 
-      assert_raise(Gem::FilePermissionError, Errno::EACCES) do
+      assert_raise(Gem::FilePermissionError) do
         Gem::Installer.at(@gem, @cmd.options).install
       end
     end

--- a/test/rubygems/test_gem_install_update_options.rb
+++ b/test/rubygems/test_gem_install_update_options.rb
@@ -176,14 +176,14 @@ class TestGemInstallUpdateOptions < Gem::InstallerTestCase
 
     refute @cmd.options[:user_install]
 
-    FileUtils.chmod 0755, @userhome
-    FileUtils.chmod 0000, @gemhome
+    FileUtils.chmod 0o755, @userhome
+    FileUtils.chmod 0o000, @gemhome
 
     Gem.use_paths @gemhome, @userhome
 
     @cmd.install_update_options.include?(:user_install)
   ensure
-    FileUtils.chmod 0755, @gemhome
+    FileUtils.chmod 0o755, @gemhome
   end
 
   def test_vendor

--- a/test/rubygems/test_gem_install_update_options.rb
+++ b/test/rubygems/test_gem_install_update_options.rb
@@ -165,6 +165,9 @@ class TestGemInstallUpdateOptions < Gem::InstallerTestCase
       return
     end
 
+    orig_gem_home = ENV["GEM_HOME"]
+    ENV.delete("GEM_HOME")
+
     @spec = quick_gem "a" do |spec|
       util_make_exec spec
     end
@@ -179,11 +182,12 @@ class TestGemInstallUpdateOptions < Gem::InstallerTestCase
     FileUtils.chmod 0o755, @userhome
     FileUtils.chmod 0o000, @gemhome
 
-    Gem.use_paths @gemhome, @userhome
+    Gem.use_paths nil, @userhome
 
     assert_equal Gem.paths.home, Gem.user_dir
   ensure
     FileUtils.chmod 0o755, @gemhome
+    ENV["GEM_HOME"] = orig_gem_home if orig_gem_home
   end
 
   def test_vendor

--- a/test/rubygems/test_gem_install_update_options.rb
+++ b/test/rubygems/test_gem_install_update_options.rb
@@ -151,7 +151,7 @@ class TestGemInstallUpdateOptions < Gem::InstallerTestCase
 
       Gem.use_paths @gemhome, @userhome
 
-      assert_raise(Gem::FilePermissionError) do
+      assert_raise(Gem::FilePermissionError, Errno::EACCES) do
         Gem::Installer.at(@gem, @cmd.options).install
       end
     end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

RubyGems should not do a system install by default, for the reasons discussed in #1394, #2847, and #4031.

This was originally based on #2847 by @hsbt.

Fixes #1394.
Replaces #2847.

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

Revise the logic for setting `Gem.paths.home` such that the priority is:

1. `GEM_HOME`, if specified.
2. `Gem.default_dir`, if it is writable OR it doesn't exist and its parent directory is writable.
3. `Gem.user_dir`, in all other cases.

This is what the output looks like now, if `GEM_HOME` is not defined AND `Gem.default_dir` can't be used:

```shellsession
puppy@orthrus$ gem install boop
Defaulting to user installation because default GEM_HOME (/usr/local/lib/ruby/gems/3.1) is not writable.
Successfully installed boop-0.5.0
1 gem installed
puppy@orthrus$ 
```

Previously this situation would've resulted in a permissions error.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
