### PR TITLE
Point to ruby-core repo in CI again

### DIFF
--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -29,8 +29,7 @@ jobs:
         run: echo "REF=$(ruby -v | cut -d')' -f1 | cut -d' ' -f5)" >> $GITHUB_ENV
       - uses: actions/checkout@v2
         with:
-          repository: deivid-rodriguez/ruby
-          ref: fix-bundler-ci
+          repository: ruby/ruby
           path: ruby/ruby
           fetch-depth: 10
       - name: Checkout the latest buildable revision


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We're pointing to my personal fork of Ruby in CI.

## What is your fix for the problem, implemented in this PR?

Point back to official repo, now that the necessary changes have been incorporated.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
