### PR TITLE
Port ruby-core patch

### DIFF
--- a/test/rubygems/test_rubygems.rb
+++ b/test/rubygems/test_rubygems.rb
@@ -42,7 +42,11 @@ class GemTest < Gem::TestCase
       "require \"rubygems\"; puts Gem::Specification.stubs.map(&:full_name)",
       {:err => [:child, :out]}
     ).strip
-    assert_empty output
+    begin
+      assert_empty output
+    rescue Test::Unit::AssertionFailedError
+      pend "Temporary pending custom default_dir test"
+    end
   end
 
   private


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I reverted it accidentally when syncing our code with ruby-core because it was not contributed back.

## What is your fix for the problem, implemented in this PR?

No fix, just pick up the patch so we don't revert it again later.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
