### PR TITLE
Don't silently persist `BUNDLE_WITH` and `BUNDLE_WITHOUT` envs locally

### DIFF
--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -154,7 +154,7 @@ module Bundler
       # need to nil them out first to get around validation for backwards compatibility
       Bundler.settings.set_command_option :without, nil
       Bundler.settings.set_command_option :with,    nil
-      Bundler.settings.set_command_option :without, without - with
+      Bundler.settings.set_command_option :without, without
       Bundler.settings.set_command_option :with,    with
     end
 

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -140,21 +140,11 @@ module Bundler
 
       check_for_group_conflicts_in_cli_options
 
-      with = options.fetch(:with, [])
-      with |= Bundler.settings[:with].map(&:to_s)
-      with -= options[:without] if options[:without]
-      with = nil if options[:with] == []
-
-      without = options.fetch(:without, [])
-      without |= Bundler.settings[:without].map(&:to_s)
-      without -= options[:with] if options[:with]
-      without = nil if options[:without] == []
-
       # need to nil them out first to get around validation for backwards compatibility
       Bundler.settings.set_command_option :without, nil
       Bundler.settings.set_command_option :with,    nil
-      Bundler.settings.set_command_option :without, without
-      Bundler.settings.set_command_option :with,    with
+      Bundler.settings.set_command_option :without, options[:without]
+      Bundler.settings.set_command_option :with,    options[:with]
     end
 
     def normalize_settings

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -140,16 +140,15 @@ module Bundler
 
       check_for_group_conflicts_in_cli_options
 
-      Bundler.settings.set_command_option :with, nil if options[:with] == []
-      Bundler.settings.set_command_option :without, nil if options[:without] == []
-
       with = options.fetch(:with, [])
       with |= Bundler.settings[:with].map(&:to_s)
       with -= options[:without] if options[:without]
+      with = nil if options[:with] == []
 
       without = options.fetch(:without, [])
       without |= Bundler.settings[:without].map(&:to_s)
       without -= options[:with] if options[:with]
+      without = nil if options[:without] == []
 
       # need to nil them out first to get around validation for backwards compatibility
       Bundler.settings.set_command_option :without, nil

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -154,13 +154,11 @@ module Bundler
       options[:with]    = with
       options[:without] = without
 
-      unless Bundler.settings[:without] == options[:without] && Bundler.settings[:with] == options[:with]
-        # need to nil them out first to get around validation for backwards compatibility
-        Bundler.settings.set_command_option :without, nil
-        Bundler.settings.set_command_option :with,    nil
-        Bundler.settings.set_command_option :without, options[:without] - options[:with]
-        Bundler.settings.set_command_option :with,    options[:with]
-      end
+      # need to nil them out first to get around validation for backwards compatibility
+      Bundler.settings.set_command_option :without, nil
+      Bundler.settings.set_command_option :with,    nil
+      Bundler.settings.set_command_option :without, options[:without] - options[:with]
+      Bundler.settings.set_command_option :with,    options[:with]
     end
 
     def normalize_settings
@@ -184,7 +182,7 @@ module Bundler
 
       Bundler.settings.set_command_option_if_given :clean, options["clean"]
 
-      normalize_groups
+      normalize_groups if options[:without] || options[:with]
 
       options[:force] = options[:redownload]
     end

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -151,14 +151,11 @@ module Bundler
       without |= Bundler.settings[:without].map(&:to_s)
       without -= options[:with] if options[:with]
 
-      options[:with]    = with
-      options[:without] = without
-
       # need to nil them out first to get around validation for backwards compatibility
       Bundler.settings.set_command_option :without, nil
       Bundler.settings.set_command_option :with,    nil
-      Bundler.settings.set_command_option :without, options[:without] - options[:with]
-      Bundler.settings.set_command_option :with,    options[:with]
+      Bundler.settings.set_command_option :without, without - with
+      Bundler.settings.set_command_option :with,    with
     end
 
     def normalize_settings

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -135,9 +135,6 @@ module Bundler
     end
 
     def normalize_groups
-      options[:with] &&= options[:with].join(":").tr(" ", ":").split(":")
-      options[:without] &&= options[:without].join(":").tr(" ", ":").split(":")
-
       check_for_group_conflicts_in_cli_options
 
       # need to nil them out first to get around validation for backwards compatibility

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -367,7 +367,7 @@ module Bundler
 
     def to_array(value)
       return [] unless value
-      value.split(":").map(&:to_sym)
+      value.tr(" ", ":").split(":").map(&:to_sym)
     end
 
     def array_to_s(array)

--- a/bundler/spec/install/gemfile/groups_spec.rb
+++ b/bundler/spec/install/gemfile/groups_spec.rb
@@ -91,16 +91,7 @@ RSpec.describe "bundle install with groups" do
         expect(the_bundle).to include_gems "rack 1.0.0", :groups => [:default]
       end
 
-      it "respects global `without` configuration, and saves it locally", :bundler => "< 3" do
-        bundle "config set --global without emo"
-        bundle :install
-        expect(the_bundle).to include_gems "rack 1.0.0", :groups => [:default]
-        bundle "config list"
-        expect(out).to include("Set for your local app (#{bundled_app(".bundle/config")}): [:emo]")
-        expect(out).to include("Set for the current user (#{home(".bundle/config")}): [:emo]")
-      end
-
-      it "respects global `without` configuration, but does not save it locally", :bundler => "3" do
+      it "respects global `without` configuration, but does not save it locally" do
         bundle "config set --global without emo"
         bundle :install
         expect(the_bundle).to include_gems "rack 1.0.0", :groups => [:default]


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`BUNDLE_WITH` and `BUNDLE_WITHOUT` environment variables, are silently persisted to local configuration.

## What is your fix for the problem, implemented in this PR?

Fix is to refactor `bundle install` option handling to not do this.

This PR reintroduces #3666, which was reverted by https://github.com/rubygems/rubygems/pull/4154, because it should no longer have any unexpected consequences, since configuration is now local by default if inside an application.

Fixes #3708.
Fixes #4835.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
