### PR TITLE
Fix typo in major_ deprecation message

### DIFF
--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -141,7 +141,7 @@ module Bundler
       end
       return unless multiple_gemfiles
       message = "Multiple gemfiles (gems.rb and Gemfile) detected. " \
-                "Make sure you remove Gemfile and Gemfile.lock since bundler is ignoring them in favor of gems.rb and gems.rb.locked."
+                "Make sure you remove Gemfile and Gemfile.lock since bundler is ignoring them in favor of gems.rb and gems.locked."
       Bundler.ui.warn message
     end
 


### PR DESCRIPTION
Using the newer "gems" file names convention, the [lockfile is expected to have the `.rb` extension replaced with `.locked`](https://github.com/rubygems/rubygems/blob/a9e305432955f56b847881187a7e01a97b6901e3/bundler/lib/bundler/shared_helpers.rb#L29)
