### PR TITLE
Suggest quicker `bundle add` for installation in `README.md` generated by `bundle gem` 

### DIFF
--- a/bundler/lib/bundler/templates/newgem/README.md.tt
+++ b/bundler/lib/bundler/templates/newgem/README.md.tt
@@ -6,17 +6,11 @@ TODO: Delete this and the text above, and describe your gem
 
 ## Installation
 
-Add this line to your application's Gemfile:
+Install the gem and add to the application's Gemfile by executing:
 
-```ruby
-gem '<%= config[:name] %>'
-```
+    $ bundle add <%= config[:name] %>
 
-And then execute:
-
-    $ bundle install
-
-Or install it yourself as:
+If bundler is not being used to manage dependencies, install the gem by executing:
 
     $ gem install <%= config[:name] %>
 


### PR DESCRIPTION
Reduce the number of steps required to install a gem from two steps to one by using `bundle add`

## What was the end-user or developer problem that led to this PR?

I keep seeing 2-step installation instructions for installing gems on README's all around the internet. `bundler add` has been around long enough now where it seems safe to suggest to people installing a gem to use that command.

This will save thousands of people-hours per year and have the advantage of locking the dependency with a `~>` by default, which will save even more time.

## What is your fix for the problem, implemented in this PR?

Updated the `README.md.tt` doc to tell people how to install a gem via `bundle add` instead of the old two-step method.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
