### PR TITLE
Changelogs for rubygems 3.3.7 and bundler 2.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 3.3.7 / 2022-02-09
+
+## Enhancements:
+
+* Installs bundler 2.3.7 as a default gem.
+
+## Documentation:
+
+* Fix missing rdoc for `Gem::Version`. Pull request #5299 by nevans
+
 # 3.3.6 / 2022-01-26
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 2.3.7 (February 9, 2022)
+
+## Enhancements:
+
+  - Don't activate `yaml` gem from Bundler [#5277](https://github.com/rubygems/rubygems/pull/5277)
+  - Add Reverse Dependencies section to info command [#3966](https://github.com/rubygems/rubygems/pull/3966)
+
+## Bug fixes:
+
+  - Don't silently persist `BUNDLE_WITH` and `BUNDLE_WITHOUT` envs locally [#5335](https://github.com/rubygems/rubygems/pull/5335)
+  - Fix `bundle config` inside an application saving configuration globally [#4152](https://github.com/rubygems/rubygems/pull/4152)
+
 # 2.3.6 (January 26, 2022)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking changelogs from future rubygems 3.3.7 and bundler 2.3.7 into master.