### PR TITLE
Fix corrupted lockfile when running `bundle check` and having to re-resolve locally

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -786,6 +786,7 @@ module Bundler
       else
         { :default => Source::RubygemsAggregate.new(sources, source_map) }.merge(source_map.direct_requirements)
       end
+      source_requirements.merge!(source_map.locked_requirements) unless @remote
       metadata_dependencies.each do |dep|
         source_requirements[dep.name] = sources.metadata_source
       end
@@ -832,7 +833,7 @@ module Bundler
     end
 
     def source_map
-      @source_map ||= SourceMap.new(sources, dependencies)
+      @source_map ||= SourceMap.new(sources, dependencies, @locked_specs)
     end
   end
 end

--- a/bundler/lib/bundler/source_map.rb
+++ b/bundler/lib/bundler/source_map.rb
@@ -2,11 +2,12 @@
 
 module Bundler
   class SourceMap
-    attr_reader :sources, :dependencies
+    attr_reader :sources, :dependencies, :locked_specs
 
-    def initialize(sources, dependencies)
+    def initialize(sources, dependencies, locked_specs)
       @sources = sources
       @dependencies = dependencies
+      @locked_specs = locked_specs
     end
 
     def pinned_spec_names(skip = nil)
@@ -50,6 +51,18 @@ module Bundler
           dep_source = dep.source || default
           dep_source.add_dependency_names(dep.name)
           requirements[dep.name] = dep_source
+        end
+        requirements
+      end
+    end
+
+    def locked_requirements
+      @locked_requirements ||= begin
+        requirements = {}
+        locked_specs.each do |locked_spec|
+          source = locked_spec.source
+          source.add_dependency_names(locked_spec.name)
+          requirements[locked_spec.name] = source
         end
         requirements
       end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When running `bundle check`, and re-resolving locally because the gemspec has changed, we need to make sure the sources set in the previous lockfile are preserved.

## What is your fix for the problem, implemented in this PR?

Add requirements from locked specs to source requirements when resolving locally.

Fixes #5339.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
