### PR TITLE
Add newline to validate_platforms! message when platform is missing

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -433,7 +433,7 @@ module Bundler
 
       raise ProductionError, "Your bundle only supports platforms #{@platforms.map(&:to_s)} " \
         "but your local platform is #{Bundler.local_platform}. " \
-        "Add the current platform to the lockfile with `bundle lock --add-platform #{Bundler.local_platform}` and try again."
+        "Add the current platform to the lockfile with\n`bundle lock --add-platform #{Bundler.local_platform}` and try again."
     end
 
     def add_platform(platform)

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -856,7 +856,7 @@ RSpec.describe "bundle install with gem sources" do
 
       expect(err).to eq(
         "Your bundle only supports platforms [\"x86_64-darwin-19\"] but your local platform is x86_64-linux. " \
-        "Add the current platform to the lockfile with `bundle lock --add-platform x86_64-linux` and try again."
+        "Add the current platform to the lockfile with\n`bundle lock --add-platform x86_64-linux` and try again."
       )
     end
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When I run bundle install with BUNDLE_DEPLOYMENT=true in the environment
on a different platform than I usually do development, I get the
following output to the console (wrapped exactly as shown):

    Your bundle only supports platforms ["x86_64-darwin-19"] but your local platform
    is x86_64-linux. Add the current platform to the lockfile with `bundle lock
    --add-platform x86_64-linux` and try again.

Because the way the message wraps, its not as simple as copying the
suggested command to the clipboard because it contains a newline:

    $ bundle lock
    Writing lockfile to [...]/Gemfile.lock
    $ --add-platform x86_64-linux


## What is your fix for the problem, implemented in this PR?

Adding a newline right before the command forces the command in the
error message to be on the same line, which facilitates copy-pasting the
command in the message.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
