### PR TITLE
Resolve cleaned-up error with temporary gemhome

### DIFF
--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -274,6 +274,8 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     spec.executables.each do |e|
       assert_path_exist File.join destdir, @gemhome.gsub(/^[a-zA-Z]:/, ''), 'gems', spec.full_name, spec.bindir, e
     end
+  ensure
+    FileUtils.chmod "+w", @gemhome
   end
 
   def test_install_default_bundler_gem_with_destdir_and_prefix_flags


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The current test method of `test_install_default_bundler_gem_with_destdir_flag` keeps `0666` directory for the dummy gemhome. It can't delete by the current user like this.

```
$ rm -rf tmp/test_rubygems_20220128-70598-lzfijy
rm: cannot remove 'tmp/test_rubygems_20220128-70598-lzfijy/gemhome/specifications': Permission denied
rm: cannot remove 'tmp/test_rubygems_20220128-70598-lzfijy/gemhome/cache': Permission denied
rm: cannot remove 'tmp/test_rubygems_20220128-70598-lzfijy/gemhome/plugins': Permission denied
rm: cannot remove 'tmp/test_rubygems_20220128-70598-lzfijy/gemhome/extensions': Permission denied
rm: cannot remove 'tmp/test_rubygems_20220128-70598-lzfijy/gemhome/build_info': Permission denied
rm: cannot remove 'tmp/test_rubygems_20220128-70598-lzfijy/gemhome/doc': Permission denied
rm: cannot remove 'tmp/test_rubygems_20220128-70598-lzfijy/gemhome/gems': Permission denied
```

## What is your fix for the problem, implemented in this PR?

Keep writable permission at the end of test method.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
