### PR TITLE
Make `--strict` flag of `update` and `outdated` commands consistent

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -391,7 +391,7 @@ module Bundler
       are up to date, Bundler will exit with a status of 0. Otherwise, it will exit 1.
 
       For more information on patch level options (--major, --minor, --patch,
-      --update-strict) see documentation on the same options on the update command.
+      --strict) see documentation on the same options on the update command.
     D
     method_option "group", :type => :string, :banner => "List gems from a specific group"
     method_option "groups", :type => :boolean, :banner => "List gems organized by groups"
@@ -399,10 +399,9 @@ module Bundler
       "Do not attempt to fetch gems remotely and use the gem cache instead"
     method_option "pre", :type => :boolean, :banner => "Check for newer pre-release gems"
     method_option "source", :type => :array, :banner => "Check against a specific source"
-    strict_is_update = Bundler.feature_flag.forget_cli_options?
-    method_option "filter-strict", :type => :boolean, :aliases => strict_is_update ? [] : %w[--strict], :banner =>
+    method_option "filter-strict", :type => :boolean, :banner =>
       "Only list newer versions allowed by your Gemfile requirements"
-    method_option "update-strict", :type => :boolean, :aliases => strict_is_update ? %w[--strict] : [], :banner =>
+    method_option "strict", :type => :boolean, :aliases => "--update-strict", :banner =>
       "Strict conservative resolution, do not allow any gem to be updated past latest --patch | --minor | --major"
     method_option "minor", :type => :boolean, :banner => "Prefer updating only to next minor version"
     method_option "major", :type => :boolean, :banner => "Prefer updating to next major version (default)"

--- a/bundler/lib/bundler/cli/common.rb
+++ b/bundler/lib/bundler/cli/common.rb
@@ -109,7 +109,7 @@ module Bundler
 
       definition.gem_version_promoter.tap do |gvp|
         gvp.level = patch_level.first || :major
-        gvp.strict = options[:strict] || options["update-strict"] || options["filter-strict"]
+        gvp.strict = options[:strict] || options["filter-strict"]
       end
     end
 

--- a/bundler/lib/bundler/man/bundle-add.1
+++ b/bundler/lib/bundler/man/bundle-add.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-ADD" "1" "February 2022" "" ""
+.TH "BUNDLE\-ADD" "1" "March 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-add\fR \- Add gem to the Gemfile and run bundle install

--- a/bundler/lib/bundler/man/bundle-binstubs.1
+++ b/bundler/lib/bundler/man/bundle-binstubs.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-BINSTUBS" "1" "February 2022" "" ""
+.TH "BUNDLE\-BINSTUBS" "1" "March 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-binstubs\fR \- Install the binstubs of the listed gems

--- a/bundler/lib/bundler/man/bundle-cache.1
+++ b/bundler/lib/bundler/man/bundle-cache.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CACHE" "1" "February 2022" "" ""
+.TH "BUNDLE\-CACHE" "1" "March 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-cache\fR \- Package your needed \fB\.gem\fR files into your application

--- a/bundler/lib/bundler/man/bundle-check.1
+++ b/bundler/lib/bundler/man/bundle-check.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CHECK" "1" "February 2022" "" ""
+.TH "BUNDLE\-CHECK" "1" "March 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-check\fR \- Verifies if dependencies are satisfied by installed gems

--- a/bundler/lib/bundler/man/bundle-clean.1
+++ b/bundler/lib/bundler/man/bundle-clean.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CLEAN" "1" "February 2022" "" ""
+.TH "BUNDLE\-CLEAN" "1" "March 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-clean\fR \- Cleans up unused gems in your bundler directory

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CONFIG" "1" "February 2022" "" ""
+.TH "BUNDLE\-CONFIG" "1" "March 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-config\fR \- Set bundler configuration options

--- a/bundler/lib/bundler/man/bundle-doctor.1
+++ b/bundler/lib/bundler/man/bundle-doctor.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-DOCTOR" "1" "February 2022" "" ""
+.TH "BUNDLE\-DOCTOR" "1" "March 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-doctor\fR \- Checks the bundle for common problems

--- a/bundler/lib/bundler/man/bundle-exec.1
+++ b/bundler/lib/bundler/man/bundle-exec.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-EXEC" "1" "February 2022" "" ""
+.TH "BUNDLE\-EXEC" "1" "March 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-exec\fR \- Execute a command in the context of the bundle

--- a/bundler/lib/bundler/man/bundle-gem.1
+++ b/bundler/lib/bundler/man/bundle-gem.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-GEM" "1" "February 2022" "" ""
+.TH "BUNDLE\-GEM" "1" "March 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-gem\fR \- Generate a project skeleton for creating a rubygem

--- a/bundler/lib/bundler/man/bundle-info.1
+++ b/bundler/lib/bundler/man/bundle-info.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INFO" "1" "February 2022" "" ""
+.TH "BUNDLE\-INFO" "1" "March 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-info\fR \- Show information for the given gem in your bundle

--- a/bundler/lib/bundler/man/bundle-init.1
+++ b/bundler/lib/bundler/man/bundle-init.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INIT" "1" "February 2022" "" ""
+.TH "BUNDLE\-INIT" "1" "March 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-init\fR \- Generates a Gemfile into the current working directory

--- a/bundler/lib/bundler/man/bundle-inject.1
+++ b/bundler/lib/bundler/man/bundle-inject.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INJECT" "1" "February 2022" "" ""
+.TH "BUNDLE\-INJECT" "1" "March 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-inject\fR \- Add named gem(s) with version requirements to Gemfile

--- a/bundler/lib/bundler/man/bundle-install.1
+++ b/bundler/lib/bundler/man/bundle-install.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INSTALL" "1" "February 2022" "" ""
+.TH "BUNDLE\-INSTALL" "1" "March 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-install\fR \- Install the dependencies specified in your Gemfile

--- a/bundler/lib/bundler/man/bundle-list.1
+++ b/bundler/lib/bundler/man/bundle-list.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-LIST" "1" "February 2022" "" ""
+.TH "BUNDLE\-LIST" "1" "March 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-list\fR \- List all the gems in the bundle

--- a/bundler/lib/bundler/man/bundle-lock.1
+++ b/bundler/lib/bundler/man/bundle-lock.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-LOCK" "1" "February 2022" "" ""
+.TH "BUNDLE\-LOCK" "1" "March 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-lock\fR \- Creates / Updates a lockfile without installing

--- a/bundler/lib/bundler/man/bundle-open.1
+++ b/bundler/lib/bundler/man/bundle-open.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-OPEN" "1" "February 2022" "" ""
+.TH "BUNDLE\-OPEN" "1" "March 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-open\fR \- Opens the source directory for a gem in your bundle

--- a/bundler/lib/bundler/man/bundle-outdated.1
+++ b/bundler/lib/bundler/man/bundle-outdated.1
@@ -1,13 +1,13 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-OUTDATED" "1" "February 2022" "" ""
+.TH "BUNDLE\-OUTDATED" "1" "March 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-outdated\fR \- List installed gems with newer versions available
 .
 .SH "SYNOPSIS"
-\fBbundle outdated\fR [GEM] [\-\-local] [\-\-pre] [\-\-source] [\-\-strict] [\-\-parseable | \-\-porcelain] [\-\-group=GROUP] [\-\-groups] [\-\-update\-strict] [\-\-patch|\-\-minor|\-\-major] [\-\-filter\-major] [\-\-filter\-minor] [\-\-filter\-patch] [\-\-only\-explicit]
+\fBbundle outdated\fR [GEM] [\-\-local] [\-\-pre] [\-\-source] [\-\-strict] [\-\-parseable | \-\-porcelain] [\-\-group=GROUP] [\-\-groups] [\-\-patch|\-\-minor|\-\-major] [\-\-filter\-major] [\-\-filter\-minor] [\-\-filter\-patch] [\-\-only\-explicit]
 .
 .SH "DESCRIPTION"
 Outdated lists the names and versions of gems that have a newer version available in the given source\. Calling outdated with [GEM [GEM]] will only check for newer versions of the given gems\. Prerelease gems are ignored by default\. If your gems are up to date, Bundler will exit with a status of 0\. Otherwise, it will exit 1\.
@@ -28,7 +28,7 @@ Check against a specific source\.
 .
 .TP
 \fB\-\-strict\fR
-Only list newer versions allowed by your Gemfile requirements\.
+Only list newer versions allowed by your Gemfile requirements, also respecting conservative update flags (\-\-patch, \-\-minor, \-\-major)\.
 .
 .TP
 \fB\-\-parseable\fR, \fB\-\-porcelain\fR
@@ -41,10 +41,6 @@ List gems from a specific group\.
 .TP
 \fB\-\-groups\fR
 List gems organized by groups\.
-.
-.TP
-\fB\-\-update\-strict\fR
-Strict conservative resolution, do not allow any gem to be updated past latest \-\-patch | \-\-minor| \-\-major\.
 .
 .TP
 \fB\-\-minor\fR
@@ -76,9 +72,6 @@ Only list gems specified in your Gemfile, not their dependencies\.
 .
 .SH "PATCH LEVEL OPTIONS"
 See bundle update(1) \fIbundle\-update\.1\.html\fR for details\.
-.
-.P
-One difference between the patch level options in \fBbundle update\fR and here is the \fB\-\-strict\fR option\. \fB\-\-strict\fR was already an option on outdated before the patch level options were added\. \fB\-\-strict\fR wasn\'t altered, and the \fB\-\-update\-strict\fR option on \fBoutdated\fR reflects what \fB\-\-strict\fR does on \fBbundle update\fR\.
 .
 .SH "FILTERING OUTPUT"
 The 3 filtering options do not affect the resolution of versions, merely what versions are shown in the output\.

--- a/bundler/lib/bundler/man/bundle-outdated.1.ronn
+++ b/bundler/lib/bundler/man/bundle-outdated.1.ronn
@@ -10,7 +10,6 @@ bundle-outdated(1) -- List installed gems with newer versions available
                         [--parseable | --porcelain]
                         [--group=GROUP]
                         [--groups]
-                        [--update-strict]
                         [--patch|--minor|--major]
                         [--filter-major]
                         [--filter-minor]
@@ -36,7 +35,7 @@ are up to date, Bundler will exit with a status of 0. Otherwise, it will exit 1.
   Check against a specific source.
 
 * `--strict`:
-  Only list newer versions allowed by your Gemfile requirements.
+  Only list newer versions allowed by your Gemfile requirements, also respecting conservative update flags (--patch, --minor, --major).
 
 * `--parseable`, `--porcelain`:
    Use minimal formatting for more parseable output.
@@ -46,9 +45,6 @@ are up to date, Bundler will exit with a status of 0. Otherwise, it will exit 1.
 
 * `--groups`:
   List gems organized by groups.
-
-* `--update-strict`:
-  Strict conservative resolution, do not allow any gem to be updated past latest --patch | --minor| --major.
 
 * `--minor`:
   Prefer updating only to next minor version.
@@ -74,11 +70,6 @@ are up to date, Bundler will exit with a status of 0. Otherwise, it will exit 1.
 ## PATCH LEVEL OPTIONS
 
 See [bundle update(1)](bundle-update.1.html) for details.
-
-One difference between the patch level options in `bundle update` and here is the `--strict` option.
-`--strict` was already an option on outdated before the patch level options were added. `--strict`
-wasn't altered, and the `--update-strict` option on `outdated` reflects what `--strict` does on
-`bundle update`.
 
 ## FILTERING OUTPUT
 

--- a/bundler/lib/bundler/man/bundle-platform.1
+++ b/bundler/lib/bundler/man/bundle-platform.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-PLATFORM" "1" "February 2022" "" ""
+.TH "BUNDLE\-PLATFORM" "1" "March 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-platform\fR \- Displays platform compatibility information

--- a/bundler/lib/bundler/man/bundle-pristine.1
+++ b/bundler/lib/bundler/man/bundle-pristine.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-PRISTINE" "1" "February 2022" "" ""
+.TH "BUNDLE\-PRISTINE" "1" "March 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-pristine\fR \- Restores installed gems to their pristine condition

--- a/bundler/lib/bundler/man/bundle-remove.1
+++ b/bundler/lib/bundler/man/bundle-remove.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-REMOVE" "1" "February 2022" "" ""
+.TH "BUNDLE\-REMOVE" "1" "March 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-remove\fR \- Removes gems from the Gemfile

--- a/bundler/lib/bundler/man/bundle-show.1
+++ b/bundler/lib/bundler/man/bundle-show.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-SHOW" "1" "February 2022" "" ""
+.TH "BUNDLE\-SHOW" "1" "March 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-show\fR \- Shows all the gems in your bundle, or the path to a gem

--- a/bundler/lib/bundler/man/bundle-update.1
+++ b/bundler/lib/bundler/man/bundle-update.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-UPDATE" "1" "February 2022" "" ""
+.TH "BUNDLE\-UPDATE" "1" "March 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-update\fR \- Update your gems to the latest available versions

--- a/bundler/lib/bundler/man/bundle-viz.1
+++ b/bundler/lib/bundler/man/bundle-viz.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-VIZ" "1" "February 2022" "" ""
+.TH "BUNDLE\-VIZ" "1" "March 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-viz\fR \- Generates a visual dependency graph for your Gemfile

--- a/bundler/lib/bundler/man/bundle.1
+++ b/bundler/lib/bundler/man/bundle.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE" "1" "February 2022" "" ""
+.TH "BUNDLE" "1" "March 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\fR \- Ruby Dependency Management

--- a/bundler/lib/bundler/man/gemfile.5
+++ b/bundler/lib/bundler/man/gemfile.5
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GEMFILE" "5" "February 2022" "" ""
+.TH "GEMFILE" "5" "March 2022" "" ""
 .
 .SH "NAME"
 \fBGemfile\fR \- A format for describing gem dependencies for Ruby programs

--- a/bundler/spec/commands/outdated_spec.rb
+++ b/bundler/spec/commands/outdated_spec.rb
@@ -570,8 +570,7 @@ RSpec.describe "bundle outdated" do
     end
   end
 
-  filter_strict_option = Bundler.feature_flag.bundler_2_mode? ? :"filter-strict" : :strict
-  describe "with --#{filter_strict_option} option" do
+  describe "with --filter-strict option" do
     before do
       build_repo2 do
         build_git "foo", :path => lib_path("foo")
@@ -595,7 +594,7 @@ RSpec.describe "bundle outdated" do
         build_gem "weakling", "0.0.5"
       end
 
-      bundle :outdated, filter_strict_option => true, :raise_on_error => false
+      bundle :outdated, :"filter-strict" => true, :raise_on_error => false
 
       expected_output = <<~TABLE.strip
         Gem       Current  Latest  Requested  Groups
@@ -611,7 +610,7 @@ RSpec.describe "bundle outdated" do
         gem "activesupport", platforms: [:ruby_22]
       G
 
-      bundle :outdated, filter_strict_option => true
+      bundle :outdated, :"filter-strict" => true
 
       expect(out).to end_with("Bundle up to date!")
     end
@@ -622,7 +621,7 @@ RSpec.describe "bundle outdated" do
         gem "rack_middleware", "1.0"
       G
 
-      bundle :outdated, filter_strict_option => true
+      bundle :outdated, :"filter-strict" => true
 
       expect(out).to end_with("Bundle up to date!")
     end
@@ -640,7 +639,7 @@ RSpec.describe "bundle outdated" do
           build_gem "weakling", "0.0.5"
         end
 
-        bundle :outdated, filter_strict_option => true, "filter-patch" => true, :raise_on_error => false
+        bundle :outdated, :"filter-strict" => true, "filter-patch" => true, :raise_on_error => false
 
         expected_output = <<~TABLE.strip
           Gem       Current  Latest  Requested  Groups
@@ -662,7 +661,7 @@ RSpec.describe "bundle outdated" do
           build_gem "weakling", "0.1.5"
         end
 
-        bundle :outdated, filter_strict_option => true, "filter-minor" => true, :raise_on_error => false
+        bundle :outdated, :"filter-strict" => true, "filter-minor" => true, :raise_on_error => false
 
         expected_output = <<~TABLE.strip
           Gem       Current  Latest  Requested  Groups
@@ -684,7 +683,7 @@ RSpec.describe "bundle outdated" do
           build_gem "weakling", "1.1.5"
         end
 
-        bundle :outdated, filter_strict_option => true, "filter-major" => true, :raise_on_error => false
+        bundle :outdated, :"filter-strict" => true, "filter-major" => true, :raise_on_error => false
 
         expected_output = <<~TABLE.strip
           Gem       Current  Latest  Requested  Groups
@@ -1099,7 +1098,7 @@ RSpec.describe "bundle outdated" do
   end
 
   context "conservative updates" do
-    context "without update-strict" do
+    context "without --strict" do
       before do
         build_repo4 do
           build_gem "patch", %w[1.0.0 1.0.1]
@@ -1165,7 +1164,7 @@ RSpec.describe "bundle outdated" do
       end
     end
 
-    context "with update-strict" do
+    context "with --strict" do
       before do
         build_repo4 do
           build_gem "foo", %w[1.4.3 1.4.4] do |s|
@@ -1198,8 +1197,8 @@ RSpec.describe "bundle outdated" do
         G
       end
 
-      it "shows gems with update-strict updating to patch and filtering to patch" do
-        bundle "outdated --patch --update-strict --filter-patch", :raise_on_error => false
+      it "shows gems with --strict updating to patch and filtering to patch" do
+        bundle "outdated --patch --strict --filter-patch", :raise_on_error => false
 
         expected_output = <<~TABLE.strip
           Gem  Current  Latest  Requested  Groups


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

To be honest, the "problem" is only tangentially related to this issue. While working on #3963, I noticed that sometimes we use settings too early, before we have even processed the `--gemfile` option, which is currently used to resolve the settings root (path where configuration should be looked for). This is one particular case of that, where we use settings to decide whether `bundle outdated --strict` is an alias of `bundle outdated --filter-strict` or `bundle oudated --update-strict`.

I'm looking into fixing this issue in general right into Thor, by allowing some stuff to be specified lazily so that we don't need to use settings before we know where to find them. But in this particular case, I don't think we need to do this at all.

## What is your fix for the problem, implemented in this PR?

The correct behavior for `bundle outdated --strict` is the one implemented by `bundle outdated --update-strict`, since that's what `bundle update --strict` allows updating to. So it should behave like that. I will also deprecate `bundle outdated --update-strict` later.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
