### PR TITLE
Separate binary and script files

### DIFF
--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -136,7 +136,7 @@ install:
     assert_path_exist @spec.extension_dir
     assert_path_exist @spec.gem_build_complete_path
     assert_path_exist File.join @spec.extension_dir, 'gem_make.out'
-    assert_path_exist File.join @spec.extension_dir, 'a.rb'
+    assert_path_not_exist File.join @spec.extension_dir, 'a.rb'
     assert_path_exist File.join @spec.gem_dir, 'lib', 'a.rb'
     assert_path_exist File.join @spec.gem_dir, 'lib', 'a', 'b.rb'
   end
@@ -194,7 +194,7 @@ install:
     assert_path_exist @spec.extension_dir
     assert_path_exist @spec.gem_build_complete_path
     assert_path_exist File.join @spec.extension_dir, 'gem_make.out'
-    assert_path_exist File.join @spec.extension_dir, 'a.rb'
+    assert_path_not_exist File.join @spec.extension_dir, 'a.rb'
     assert_path_not_exist File.join @spec.gem_dir, 'lib', 'a.rb'
     assert_path_not_exist File.join @spec.gem_dir, 'lib', 'a', 'b.rb'
   ensure

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1558,7 +1558,7 @@ gem 'other', version
         write_file File.join(@tempdir, file)
       end
 
-      so = File.join(@spec.gem_dir, "#{@spec.name}.#{RbConfig::CONFIG["DLEXT"]}")
+      so = File.join(@spec.extension_dir, "#{@spec.name}.#{RbConfig::CONFIG["DLEXT"]}")
       assert_path_not_exist so
       use_ui @ui do
         path = Gem::Package.build @spec
@@ -1567,6 +1567,7 @@ gem 'other', version
         installer.install
       end
       assert_path_exist so
+      assert_path_not_exist File.join(@spec.gem_dir, "#{@spec.name}.#{RbConfig::CONFIG["DLEXT"]}")
     rescue
       puts '-' * 78
       puts File.read File.join(@gemhome, 'gems', 'a-2', 'Makefile')

--- a/test/rubygems/test_gem_resolver_git_specification.rb
+++ b/test/rubygems/test_gem_resolver_git_specification.rb
@@ -92,7 +92,7 @@ class TestGemResolverGitSpecification < Gem::TestCase
 
     git_spec.install({})
 
-    assert_path_exist File.join git_spec.spec.extension_dir, 'b.rb'
+    assert_path_exist File.join git_spec.spec.gem_dir, 'lib/b.rb'
   end
 
   def test_install_installed

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -698,13 +698,14 @@ class TestGemRequire < Gem::TestCase
 
     spec.files += ["extconf.rb", "depend", "#{name}.c"]
 
-    so = File.join(spec.gem_dir, "#{name}.#{RbConfig::CONFIG["DLEXT"]}")
+    so = File.join(spec.extension_dir, "#{name}.#{RbConfig::CONFIG["DLEXT"]}")
     assert_path_not_exist so
 
     path = Gem::Package.build spec
     installer = Gem::Installer.at path
     installer.install
     assert_path_exist so
+    assert_path_not_exist File.join(spec.gem_dir, "#{name}.#{RbConfig::CONFIG["DLEXT"]}")
 
     spec.gem_dir
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Considering multi-architecture systems, it is obvious that architecture-independent library directories should not contain architecture-dependent binary files.
Mixing such files often results in trying to load inproper files.

## What is your fix for the problem, implemented in this PR?

Separate `sitearchdir` and `sitelibdir` in `Gem::Ext::ExtConfBuilder.build`, and copy them to each directory.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
