### PR TITLE
Fix regression when activating gem executables caused by Bundler monkey patches to RubyGems

### DIFF
--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install & Check Dependencies
         run: rake dev:frozen_deps
         working-directory: ./bundler
-      - name: "Check RVM integration, man:check"
-        run: bin/rake check_rvm_integration man:check
+      - name: Misc checks
+        run: bin/rake check_rvm_integration man:check check_rubygems_integration
         working-directory: ./bundler
     timeout-minutes: 15

--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -81,6 +81,14 @@ task :check_rvm_integration do
   sh("gem install rubygems-bundler rake && RUBYOPT=-Ilib rake -T")
 end
 
+desc "Check RubyGems integration"
+task :check_rubygems_integration do
+  # Bundler monkeypatches RubyGems in some ways that could potentially break gem
+  # activation. Run a non trivial binstub activation, with two different
+  # versions of a dependent gem installed.
+  sh("gem install reline:0.3.0 reline:0.3.1 irb && ruby -Ilib -rbundler -S irb --version")
+end
+
 namespace :man do
   if RUBY_ENGINE == "jruby"
     task(:build) {}

--- a/bundler/lib/bundler/plugin/api/source.rb
+++ b/bundler/lib/bundler/plugin/api/source.rb
@@ -309,12 +309,6 @@ module Bundler
         end
 
         # @private
-        # Returns true
-        def bundler_plugin_api_source?
-          true
-        end
-
-        # @private
         # This API on source might not be stable, and for now we expect plugins
         # to download all specs in `#specs`, so we implement the method for
         # compatibility purposes and leave it undocumented (and don't support)

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -4,6 +4,17 @@ require "pathname"
 
 require "rubygems/specification"
 
+# We can't let `Gem::Source` be autoloaded in the `Gem::Specification#source`
+# redefinition below, so we need to load it upfront. The reason is that if
+# Bundler monkeypatches are loaded before RubyGems activates an executable (for
+# example, through `ruby -rbundler -S irb`), gem activation might end up calling
+# the redefined `Gem::Specification#source` and triggering the `Gem::Source`
+# autoload. That would result in requiring "rubygems/source" inside another
+# require, which would trigger a monitor error and cause the `autoload` to
+# eventually fail. A better solution is probably to completely avoid autoloading
+# `Gem::Source` from the redefined `Gem::Specification#source`.
+require "rubygems/source"
+
 require_relative "match_platform"
 
 module Gem

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -22,11 +22,7 @@ module Gem
     alias_method :rg_loaded_from,   :loaded_from
 
     def full_gem_path
-      # this cannot check source.is_a?(Bundler::Plugin::API::Source)
-      # because that _could_ trip the autoload, and if there are unresolved
-      # gems at that time, this method could be called inside another require,
-      # thus raising with that constant being undefined. Better to check a method
-      if source.respond_to?(:path) || (source.respond_to?(:bundler_plugin_api_source?) && source.bundler_plugin_api_source?)
+      if source.respond_to?(:root)
         Pathname.new(loaded_from).dirname.expand_path(source.root).to_s.tap{|x| x.untaint if RUBY_VERSION < "2.7" }
       else
         rg_full_gem_path


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since https://github.com/rubygems/rubygems/commit/31bba752e712f13ad91cead739e7b96c720050ca, rubygems is crashing when activating gem executables if the following conditions are met:

* Bundler is required (and thus `Gem::Specification` monkey patches applied) before gem activation happens.
* The gem being activated has unresolved dependencies.

In that case, the `Gem::Source` autoload set by RubyGems will be triggered during a require. That "require inside require" happens during a region of code protected by a monitor, and as a result the `Gem::Source` autoload eventually fails.

## What is your fix for the problem, implemented in this PR?

Fix is to revert the commit that created the issue, going back to loading `Gem::Source` upfront when Bundler monkey patches are applied.

In addition to that, I added a more verbose explanation of the issue. Actually, the proper explanation of the issue was written as a comment in another place where a similar issue used to happen. But in that place the bad autoload was explicitly avoided in a different way. I simplified that other region of code and moved the explanation to the place where we are loading `rubygems/source`.

Fixes #5351.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
