### PR TITLE
Unhide RDoc documentation from top level `Gem` module

### DIFF
--- a/lib/rubygems/compatibility.rb
+++ b/lib/rubygems/compatibility.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# :stopdoc:
 
 #--
 # This file contains all sorts of little compatibility hacks that we've
@@ -8,10 +7,13 @@
 #
 # Ruby 1.9.x has introduced some things that are awkward, and we need to
 # support them, so we define some constants to use later.
+#
+# TODO remove at RubyGems 4
 #++
 
-# TODO remove at RubyGems 4
 module Gem
+  # :stopdoc:
+
   RubyGemsVersion = VERSION
   deprecate_constant(:RubyGemsVersion)
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The `Gem` module is not listed in the “Class and Module Index” at all.

## What is your fix for the problem, implemented in this PR?

Move `:stopdoc:` directive at the top level in lib/rubygems/compatibility.rb in the module block.
If this is at the top level, it stops the documentation of the entire module, but not only the part in this file.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
