### PR TITLE
Remove extra closing bracket in version warning

### DIFF
--- a/bundler/exe/bundle
+++ b/bundler/exe/bundle
@@ -20,7 +20,7 @@ gem "bundler", Bundler::VERSION if Gem.rubygems_version < Gem::Version.new("2.6.
 
 if Gem.rubygems_version < Gem::Version.new("3.2.3") && Gem.ruby_version < Gem::Version.new("2.6.a") && !ENV["BUNDLER_NO_OLD_RUBYGEMS_WARNING"]
   Bundler.ui.warn \
-    "Your RubyGems version (#{Gem::VERSION})) has a bug that prevents " \
+    "Your RubyGems version (#{Gem::VERSION}) has a bug that prevents " \
     "`required_ruby_version` from working for Bundler. Any scripts that use " \
     "`gem install bundler` will break as soon as Bundler drops support for " \
     "your Ruby version. Please upgrade RubyGems to avoid future breakage " \


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Noticed that this warning message had an extra closing bracket after the version number: 

<img width="798" alt="Screenshot 2022-03-13 at 17 25 38" src="https://user-images.githubusercontent.com/3893573/158071605-9726018c-9a95-4686-aca7-21fb33fd75df.png">


## What is your fix for the problem, implemented in this PR?

Removed the extra closing bracket.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes (I don't think this has tests yet, `BUNDLER_NO_OLD_RUBYGEMS_WARNING` [is set to true](https://github.com/rubygems/rubygems/blob/a8e126c2e06ed6af699cc0541129c8a71e4bec5b/bundler/spec/spec_helper.rb#L75) in tests)
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)