### PR TITLE
[DOC] Enable Gem::Package example

### DIFF
--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -3,7 +3,12 @@
 # Copyright (C) 2004 Mauricio Julio Fernández Pradier
 # See LICENSE.txt for additional licensing information.
 #++
-#
+
+require_relative "../rubygems"
+require_relative 'security'
+require_relative 'user_interaction'
+
+##
 # Example using a Gem::Package
 #
 # Builds a .gem file given a Gem::Specification. A .gem file is a tarball
@@ -40,10 +45,6 @@
 #
 # #files are the files in the .gem tar file, not the Ruby files in the gem
 # #extract_files and #contents automatically call #verify
-
-require_relative "../rubygems"
-require_relative 'security'
-require_relative 'user_interaction'
 
 class Gem::Package
   include Gem::UserInteraction


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The document of `Gem::Package` is not shown in the generated file.
https://docs.ruby-lang.org/en/master/Gem/Package.html

## What is your fix for the problem, implemented in this PR?

Other code must not be between the doc and class definition.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
