### PR TITLE
Report Github Actions CI provider within user agent string

### DIFF
--- a/bundler/lib/bundler/fetcher.rb
+++ b/bundler/lib/bundler/fetcher.rb
@@ -226,6 +226,7 @@ module Bundler
         "GO_SERVER_URL" => "go",
         "SNAP_CI" => "snap",
         "GITLAB_CI" => "gitlab",
+        "GITHUB_ACTIONS" => "github",
         "CI_NAME" => ENV["CI_NAME"],
         "CI" => "ci",
       }


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

No stats about Github Actions usage at https://ecosystem.rubytogether.org

## What is your fix for the problem, implemented in this PR?

Report Github Actions as a CI provider within user agent string, by checking the `GITHUB_ACTIONS` environment Variable (see
https://docs.github.com/es/actions/learn-github-actions/environment-variables#default-environment-variables).

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
