### PR TITLE
require yaml in fetcher

### DIFF
--- a/bundler/lib/bundler/fetcher.rb
+++ b/bundler/lib/bundler/fetcher.rb
@@ -5,6 +5,7 @@ require "cgi"
 require "securerandom"
 require "zlib"
 require "rubygems/request"
+require "yaml"
 
 module Bundler
   # Handles all the fetching with the rubygems server


### PR DESCRIPTION
This is needed to parse some gemspecs.  See #5405

## What was the end-user or developer problem that led to this PR?

#5405 found a gemspec that was not parsable because of the requirement of yaml.

## What is your fix for the problem, implemented in this PR?
require yaml

## Make sure the following tasks are checked

- [x ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ x] Write code to solve the problem
- [x ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
