### PR TITLE
Changelogs for rubygems 3.3.10 and bundler 2.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 3.3.10 / 2022-03-23
+
+## Enhancements:
+
+* Installs bundler 2.3.10 as a default gem.
+
+## Documentation:
+
+* Enable `Gem::Package` example in RDoc documentation. Pull request #5399
+  by nobu
+* Unhide RDoc documentation from top level `Gem` module. Pull request
+  #5396 by nobu
+
 # 3.3.9 / 2022-03-09
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2.3.10 (March 23, 2022)
+
+## Enhancements:
+
+  - More helpful reporting of marshal loading issues [#5416](https://github.com/rubygems/rubygems/pull/5416)
+  - Report Github Actions CI provider within user agent string [#5400](https://github.com/rubygems/rubygems/pull/5400)
+  - Remove extra closing bracket in version warning [#5397](https://github.com/rubygems/rubygems/pull/5397)
+
 # 2.3.9 (March 9, 2022)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking changelogs from future rubygems 3.3.10 and bundler 2.3.10 into master.