### PR TITLE
Avoid crash in test teardown

### DIFF
--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -302,6 +302,7 @@ class Gem::TestCase < Test::Unit::TestCase
   # or <tt>i686-darwin8.10.1</tt> otherwise.
 
   def setup
+    @orig_hooks = {}
     @orig_env = ENV.to_hash
     @tmp = File.expand_path("tmp")
 
@@ -426,7 +427,6 @@ class Gem::TestCase < Test::Unit::TestCase
       util_set_arch 'i686-darwin8.10.1'
     end
 
-    @orig_hooks = {}
     %w[post_install_hooks done_installing_hooks post_uninstall_hooks pre_uninstall_hooks pre_install_hooks pre_reset_hooks post_reset_hooks post_build_hooks].each do |name|
       @orig_hooks[name] = Gem.send(name).dup
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If an exception happens during test `setup` method, the `teardown` method will still be run for cleaning up, but if some other errors occurs then, it will hide the original error.

This is happening sometimes in CI where restoring original gem hooks is failing because the error in `setup` happened before the variable holding the original hooks was initialized.

This is an example CI failure due to this issue: https://github.com/rubygems/rubygems/runs/5665870906?check_suite_focus=true.

```
  NoMethodError: undefined method `each' for nil:NilClass
(See full trace by running task with --trace)
  
      @orig_hooks.each do |name, hooks|
<internal:D:/a/rubygems/rubygems/lib/rubygems/core_ext/kernel_require.rb>:85:in `require': Interrupt
                 ^^^^^
	from <internal:D:/a/rubygems/rubygems/lib/rubygems/core_ext/kernel_require.rb>:85:in `require'
D:/a/rubygems/rubygems/test/rubygems/helper.rb:486:in `teardown'
	from D:/a/rubygems/rubygems/lib/rubygems/source_list.rb:51:in `<<'
===============================================================================
	from D:/a/rubygems/rubygems/lib/rubygems/source_list.rb:74:in `block in replace'

	from D:/a/rubygems/rubygems/lib/rubygems/source_list.rb:73:in `each'
Finished in 393.4183001 seconds.
	from D:/a/rubygems/rubygems/lib/rubygems/source_list.rb:73:in `replace'
-------------------------------------------------------------------------------
	from D:/a/rubygems/rubygems/test/rubygems/helper.rb:416:in `setup'
```

I think the original error is some issue while requiring `uri`, but this problem is hiding it.

## What is your fix for the problem, implemented in this PR?

This commit moves initialization of `@orig_hooks` to the beginning of the `setup` method to avoid this issue.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
