### PR TITLE
Unskip one spec that's actually passing

### DIFF
--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -761,8 +761,6 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   it "performs partial update with a non-empty range" do
-    skip "HTTP_RANGE not set" if Gem.win_platform?
-
     gemfile <<-G
       source "#{source_uri}"
       gem 'rack', '0.9.1'


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This spec is skipped, but it's actually passing.

## What is your fix for the problem, implemented in this PR?

Unskip it.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
