### PR TITLE
Raise error when gem contains capital letters

### DIFF
--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -389,8 +389,8 @@ module Bundler
     end
 
     def ensure_safe_gem_name(name, constant_array)
-      if name =~ /^\d/
-        Bundler.ui.error "Invalid gem name #{name} Please give a name which does not start with numbers."
+      if name =~ /(^\d)|[A-Z]/
+        Bundler.ui.error "Invalid gem name #{name} Please give a name which does not start with numbers nor include capital letters."
         exit 1
       end
 

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -1426,6 +1426,11 @@ Usage: "bundle gem NAME [OPTIONS]"
       it { expect(err).to include("Invalid gem name #{subject}") }
     end
 
+    context "including capital letter" do
+      subject { "CAPITAL" }
+      it { expect(err).to include("Invalid gem name #{subject}") }
+    end
+
     context "starting with an existing const name" do
       subject { "gem-somenewconstantname" }
       it { expect(err).not_to include("Invalid gem name #{subject}") }


### PR DESCRIPTION
The problem is described in https://github.com/rubygems/rubygems/issues/5431
The guide ( https://guides.rubygems.org/name-your-gem/ ) says
> DON’T USE UPPERCASE LETTERS
so `bundle gem` command should respect it.

## What was the end-user or developer problem that led to this PR?

Issue #5431 

## What is your fix for the problem, implemented in this PR?

It now raises error when gem name includes capital letters.
@simi said warning might be enough, but I thought we don't want to proceed with uppercase letters anyway, so raising error should be fine.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
