### PR TITLE
bump actions/checkout to 3 in bundler gem template

### DIFF
--- a/bundler/lib/bundler/templates/newgem/github/workflows/main.yml.tt
+++ b/bundler/lib/bundler/templates/newgem/github/workflows/main.yml.tt
@@ -17,7 +17,7 @@ jobs:
           - '<%= RUBY_VERSION %>'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
Dependabot bumped the repo's configuration in 0c996fa but it did not
bump the version in the template for `bundler gem`

## What was the end-user or developer problem that led to this PR?

Running `bundler gem --ci=github` generated a workflow with an out of date `actions/checkout` step

## What is your fix for the problem, implemented in this PR?

Update the version of `actions/checkout` in the generated workflow template

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
