### PR TITLE
Fallback required_rubygems_version to default in endpoint spec

### DIFF
--- a/bundler/lib/bundler/endpoint_specification.rb
+++ b/bundler/lib/bundler/endpoint_specification.rb
@@ -26,8 +26,11 @@ module Bundler
       @required_ruby_version ||= _remote_specification.required_ruby_version
     end
 
+    # A fallback is included because the original version of the specification
+    # API didn't include that field, so some marshalled specs in the index have it
+    # set to +nil+.
     def required_rubygems_version
-      @required_rubygems_version ||= _remote_specification.required_rubygems_version
+      @required_rubygems_version ||= _remote_specification.required_rubygems_version || Gem::Requirement.default
     end
 
     def fetch_platform


### PR DESCRIPTION
#5446

## What was the end-user or developer problem that led to this PR?

Fix bundle install command when using Nexus proxy. 
Bundler was crashing when specification has no required_rubygems_version specified.

## What is your fix for the problem, implemented in this PR?

I've added fallback in endpoint_specification.rb just like in remote_specification.rb

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
