### PR TITLE
Don't install HEAD ruby at `ruby-core` workflow

### DIFF
--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -43,13 +43,8 @@ jobs:
       - name: Build Ruby
         run: |
           autoconf
-          ./configure -C --disable-install-doc --prefix="$HOME/.rubies/ruby-$REF"
+          ./configure -C --disable-install-doc
           make -j2
-
-          # need to install so the ruby.h header is put in the right place
-          chmod 755 $HOME
-          mkdir -p ~/.rubies # https://github.com/ruby/ruby-dev-builder/blob/master/.github/workflows/build.yml#L100
-          make install
         working-directory: ruby/ruby
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The problem is that this workflow is failing in the CI stable branch.

## What is your fix for the problem, implemented in this PR?

My fix is to revert https://github.com/rubygems/rubygems/commit/6c9f18f90055c65348f204a69c4093923361fb4f, because it doesn't seem necessary and it fixes the issue.

In reality, I don't think this workflow should be run as-is in the stable branch (so I'll be changing it later to something more meaningful), and I don't understand either why it doesn't fail in the same way as it fails now after reverting this commit. But I'll dig into those things later.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
