### PR TITLE
Fix test failures if cargo not present

### DIFF
--- a/test/rubygems/test_gem_ext_cargo_builder.rb
+++ b/test/rubygems/test_gem_ext_cargo_builder.rb
@@ -4,14 +4,12 @@ require 'rubygems/ext'
 
 class TestGemExtCargoBuilder < Gem::TestCase
   def setup
-    @orig_env = ENV.to_hash
+    super
 
     @rust_envs = {
       'CARGO_HOME' => File.join(@orig_env['HOME'], '.cargo'),
       'RUSTUP_HOME' => File.join(@orig_env['HOME'], '.rustup'),
     }
-
-    super
 
     system(@rust_envs, 'cargo', '-V', out: IO::NULL, err: [:child, :out])
     pend 'cargo not present' unless $?.success?

--- a/test/rubygems/test_gem_ext_cargo_builder.rb
+++ b/test/rubygems/test_gem_ext_cargo_builder.rb
@@ -11,10 +11,10 @@ class TestGemExtCargoBuilder < Gem::TestCase
       'RUSTUP_HOME' => File.join(@orig_env['HOME'], '.rustup'),
     }
 
+    super
+
     system(@rust_envs, 'cargo', '-V', out: IO::NULL, err: [:child, :out])
     pend 'cargo not present' unless $?.success?
-
-    super
   end
 
   def setup_rust_gem(name)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Issues when trying to backport rust extensions support to ruby-core. See https://github.com/ruby/ruby/pull/5669#issuecomment-1085798870. From the link mentioned there:

```
Run options: 
  --seed=11958
  "--ruby=./miniruby -I./lib -I. -I.ext/common  ./tool/runruby.rb --extout=.ext  -- --disable-gems"
  --excludes-dir=./test/excludes
  --name=!/memory_leak/
  -q
  --color=always
  --tty=no

# Running tests:


Retrying...
�[36;7m[1/5]�[m TestGemExtCargoBuilder#test_full_integration = 0.00 s
�[36;7m[2/5]�[m TestGemExtCargoBuilder#test_build_fail = 0.00 s
�[36;7m[3/5]�[m TestGemExtCargoBuilder#test_build_cdylib = 0.00 s
�[36;7m[4/5]�[m TestGemExtCargoBuilder#test_build_staticlib = 0.00 s
�[36;7m[5/5]�[m TestGemExtCargoBuilder#test_custom_name = 0.00 s

  1) Error:
TestGemExtCargoBuilder#test_full_integration:
TypeError: no implicit conversion of nil into String
    /tmp/cirrus-ci-build/test/rubygems/helper.rb:460:in `chdir'
    /tmp/cirrus-ci-build/test/rubygems/helper.rb:460:in `teardown'

  2) Error:
TestGemExtCargoBuilder#test_build_fail:
TypeError: no implicit conversion of nil into String
    /tmp/cirrus-ci-build/test/rubygems/helper.rb:460:in `chdir'
    /tmp/cirrus-ci-build/test/rubygems/helper.rb:460:in `teardown'

  3) Error:
TestGemExtCargoBuilder#test_build_cdylib:
TypeError: no implicit conversion of nil into String
    /tmp/cirrus-ci-build/test/rubygems/helper.rb:460:in `chdir'
    /tmp/cirrus-ci-build/test/rubygems/helper.rb:460:in `teardown'

  4) Error:
TestGemExtCargoBuilder#test_build_staticlib:
TypeError: no implicit conversion of nil into String
    /tmp/cirrus-ci-build/test/rubygems/helper.rb:460:in `chdir'
    /tmp/cirrus-ci-build/test/rubygems/helper.rb:460:in `teardown'

  5) Error:
TestGemExtCargoBuilder#test_custom_name:
TypeError: no implicit conversion of nil into String
    /tmp/cirrus-ci-build/test/rubygems/helper.rb:460:in `chdir'
    /tmp/cirrus-ci-build/test/rubygems/helper.rb:460:in `teardown'

Finished tests in 101.138584s, 213.3607 tests/s, 27356.0880 assertions/s.
21579 tests, 2766756 assertions, 0 failures, 5 errors, 201 skips

ruby -v: ruby 3.2.0dev (2022-03-24) [aarch64-linux]
make: *** [uncommon.mk:823: yes-test-all] Error 5

Exit status: 2
```

Currently our tests try to detect whether `cargo` is installed or not, and if not, set tests that need `cargo` as pending.
    
 However, when this happens that test `setup` method is completely skipped, meaning that the `teardown` method will blow up when trying to switch back to the original folder, since it was not set.

## What is your fix for the problem, implemented in this PR?

Make sure test setup is also run in this case.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
