### PR TITLE
Avoid another crash in test `teardown`

### DIFF
--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -308,6 +308,9 @@ class Gem::TestCase < Test::Unit::TestCase
 
     FileUtils.mkdir_p @tmp
 
+    @tempdir = Dir.mktmpdir("test_rubygems_", @tmp)
+    @tempdir.tap(&Gem::UNTAINT)
+
     ENV['GEM_VENDOR'] = nil
     ENV['GEMRC'] = nil
     ENV['XDG_CACHE_HOME'] = nil
@@ -324,9 +327,6 @@ class Gem::TestCase < Test::Unit::TestCase
     # This needs to be a new instance since we call use_ui(@ui) when we want to
     # capture output
     Gem::DefaultUserInteraction.ui = Gem::MockGemUi.new
-
-    @tempdir = Dir.mktmpdir("test_rubygems_", @tmp)
-    @tempdir.tap(&Gem::UNTAINT)
 
     ENV["TMPDIR"] = @tempdir
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Confusing errors in CI when some problem happens during test setup. See for example https://github.com/rubygems/rubygems/actions/runs/2104061533/attempts/1. This is quite similar to #5424.

## What is your fix for the problem, implemented in this PR?

Avoid the crash in `teardown` by making sure the `@tempdir` variable is set as early as possible.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
