### PR TITLE
Changelogs for rubygems 3.3.11 and bundler 2.3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 3.3.11 / 2022-04-07
+
+## Enhancements:
+
+* Enable mfa on specific keys during gem signin. Pull request #5305 by
+  aellispierce
+* Prefer `__dir__` to `__FILE__`. Pull request #5444 by deivid-rodriguez
+* Add cargo builder for rust extensions. Pull request #5175 by ianks
+* Installs bundler 2.3.11 as a default gem.
+
+## Documentation:
+
+* Improve RDoc setup. Pull request #5398 by deivid-rodriguez
+
 # 3.3.10 / 2022-03-23
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 2.3.11 (April 7, 2022)
+
+## Enhancements:
+
+  - Bump actions/checkout to 3 in bundler gem template [#5445](https://github.com/rubygems/rubygems/pull/5445)
+  - Prefer `__dir__` to `__FILE__` [#5444](https://github.com/rubygems/rubygems/pull/5444)
+
+## Documentation:
+
+  - Update bundler documentation to reflect bundle config scope changes [#5441](https://github.com/rubygems/rubygems/pull/5441)
+
 # 2.3.10 (March 23, 2022)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking change logs from future rubygems 3.3.11 and bundler 2.3.11 into master.