### PR TITLE
Bump vendored optparse to latest master

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -130,7 +130,7 @@ if File.exist?("util/automatiek.rake")
   #   `did_you_mean` that does not require any changes.
   desc "Vendor a specific version of optparse"
   Automatiek::RakeTask.new("optparse") do |lib|
-    lib.version = "0.2.0"
+    lib.version = "master"
     lib.download = { :github => "https://github.com/ruby/optparse" }
     lib.namespace = "OptionParser"
     lib.prefix = "Gem"

--- a/Rakefile
+++ b/Rakefile
@@ -128,6 +128,8 @@ if File.exist?("util/automatiek.rake")
   #   copy works consistently in all supported rubies. This one can be removed
   #   once we drop ruby 2.4 support, since newer versions include a version of
   #   `did_you_mean` that does not require any changes.
+  # * Add an empty .document file to the library's root path to hint RDoc that
+  #   this library should not be documented.
   desc "Vendor a specific version of optparse"
   Automatiek::RakeTask.new("optparse") do |lib|
     lib.version = "master"

--- a/lib/rubygems/optparse/lib/optparse/ac.rb
+++ b/lib/rubygems/optparse/lib/optparse/ac.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require 'rubygems/optparse/lib/optparse'
+require_relative '../optparse'
 
 class Gem::OptionParser::AC < Gem::OptionParser
   private

--- a/lib/rubygems/optparse/lib/optparse/date.rb
+++ b/lib/rubygems/optparse/lib/optparse/date.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require 'rubygems/optparse/lib/optparse'
+require_relative '../optparse'
 require 'date'
 
 Gem::OptionParser.accept(DateTime) do |s,|

--- a/lib/rubygems/optparse/lib/optparse/kwargs.rb
+++ b/lib/rubygems/optparse/lib/optparse/kwargs.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rubygems/optparse/lib/optparse'
+require_relative '../optparse'
 
 class Gem::OptionParser
   # :call-seq:

--- a/lib/rubygems/optparse/lib/optparse/shellwords.rb
+++ b/lib/rubygems/optparse/lib/optparse/shellwords.rb
@@ -2,6 +2,6 @@
 # -*- ruby -*-
 
 require 'shellwords'
-require 'rubygems/optparse/lib/optparse'
+require_relative '../optparse'
 
 Gem::OptionParser.accept(Shellwords) {|s,| Shellwords.shellwords(s)}

--- a/lib/rubygems/optparse/lib/optparse/time.rb
+++ b/lib/rubygems/optparse/lib/optparse/time.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: false
-require 'rubygems/optparse/lib/optparse'
+require_relative '../optparse'
 require 'time'
 
 Gem::OptionParser.accept(Time) do |s,|

--- a/lib/rubygems/optparse/lib/optparse/uri.rb
+++ b/lib/rubygems/optparse/lib/optparse/uri.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
 # -*- ruby -*-
 
-require 'rubygems/optparse/lib/optparse'
+require_relative '../optparse'
 require 'uri'
 
 Gem::OptionParser.accept(URI) {|s,| URI.parse(s) if s}


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I made a PR a while ago to optparse to use relative requires when possible: https://github.com/ruby/optparse/pull/28. But I never backported it here even if it was my main motivation (to have our requires fully consistent).

## What is your fix for the problem, implemented in this PR?

Get in sync with the latest changes in the upstream library.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
