### PR TITLE
Test against the latest 3.1.x RubyGems

### DIFF
--- a/.github/workflows/older-rubygems-bundler.yml
+++ b/.github/workflows/older-rubygems-bundler.yml
@@ -28,10 +28,10 @@ jobs:
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.4, value: 2.4.10 }, rgv: { name: rgv-2.6, value: v2.6.14 } }
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.5, value: 2.5.9 }, rgv: { name: rgv-2.7, value: v2.7.11 } }
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.6, value: 2.6.9 }, rgv: { name: rgv-3.0, value: v3.0.9 } }
-          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.5 }, rgv: { name: rgv-3.1, value: v3.1.5 } } # Not using 3.1.6 because it's not tagged on GitHub for some reason
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.5 }, rgv: { name: rgv-3.1, value: v3.1.6 } }
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.3 }, rgv: { name: rgv-3.2, value: v3.2.33 } }
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.1 }, rgv: { name: rgv-3.3, value: v3.3.5 } }
-          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.7, value: 2.7.5 }, rgv: { name: rgv-3.1, value: v3.1.5 } } # Not using 3.1.6 because it's not tagged on GitHub for some reason
+          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.7, value: 2.7.5 }, rgv: { name: rgv-3.1, value: v3.1.6 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.0, value: 3.0.3 }, rgv: { name: rgv-3.2, value: v3.2.33 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.1, value: 3.1.1 }, rgv: { name: rgv-3.3, value: v3.3.5 } }
     env:


### PR DESCRIPTION

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

When testing bundler against old versions of RubyGems, we normally test against the latest patch level version of each "yearly release". However, for RubyGems 3.1, we couldn't do it because 3.1.6 ihad not been tagged on GitHub.

## What is your fix for the problem, implemented in this PR?

Start using 3.1.6 since it has been tagged now.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
