### PR TITLE
Fix formatting in docs

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -48,7 +48,7 @@ require_relative 'rubygems/errors'
 # special location and loaded on boot.
 #
 # For an example plugin, see the {Graph gem}[https://github.com/seattlerb/graph]
-# which adds a `gem graph` command.
+# which adds a <tt>gem graph</tt> command.
 #
 # == RubyGems Defaults, Packaging
 #
@@ -581,8 +581,8 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   end
 
   ##
-  # The number of paths in the `$LOAD_PATH` from activated gems. Used to
-  # prioritize `-I` and `ENV['RUBYLIB']` entries during `require`.
+  # The number of paths in the +$LOAD_PATH+ from activated gems. Used to
+  # prioritize +-I+ and +ENV['RUBYLIB']+ entries during +require+.
 
   def self.activated_gem_paths
     @activated_gem_paths ||= 0
@@ -1120,7 +1120,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
   ##
   # If the SOURCE_DATE_EPOCH environment variable is set, returns it's value.
-  # Otherwise, returns the time that `Gem.source_date_epoch_string` was
+  # Otherwise, returns the time that +Gem.source_date_epoch_string+ was
   # first called in the same format as SOURCE_DATE_EPOCH.
   #
   # NOTE(@duckinator): The implementation is a tad weird because we want to:


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

rdoc uses + for typewriter font rather than backticks. This causes incorrect formatting in the generated docs.

## What is your fix for the problem, implemented in this PR?

Use + instead of backticks.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
