### PR TITLE
Stop considering `RUBY_PATCHLEVEL` for resolution

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -746,17 +746,8 @@ module Bundler
 
     def ruby_version_requirements(ruby_version)
       return [] unless ruby_version
-      if ruby_version.patchlevel
-        [ruby_version.to_gem_version_with_patchlevel]
-      else
-        ruby_version.versions.map do |version|
-          requirement = Gem::Requirement.new(version)
-          if requirement.exact?
-            "~> #{version}.0"
-          else
-            requirement
-          end
-        end
+      ruby_version.versions.map do |version|
+        Gem::Requirement.new(version)
       end
     end
 

--- a/bundler/lib/bundler/resolver/spec_group.rb
+++ b/bundler/lib/bundler/resolver/spec_group.rb
@@ -97,10 +97,10 @@ module Bundler
         spec = @specs[platform].first
         return [] if spec.is_a?(LazySpecification)
         dependencies = []
-        if !spec.required_ruby_version.nil? && !spec.required_ruby_version.none?
+        unless spec.required_ruby_version.none?
           dependencies << DepProxy.get_proxy(Gem::Dependency.new("Ruby\0", spec.required_ruby_version), platform)
         end
-        if !spec.required_rubygems_version.nil? && !spec.required_rubygems_version.none?
+        unless spec.required_rubygems_version.none?
           dependencies << DepProxy.get_proxy(Gem::Dependency.new("RubyGems\0", spec.required_rubygems_version), platform)
         end
         dependencies

--- a/bundler/lib/bundler/ruby_version.rb
+++ b/bundler/lib/bundler/ruby_version.rb
@@ -110,14 +110,6 @@ module Bundler
       @ruby_version ||= RubyVersion.new(ruby_version, patchlevel, ruby_engine, ruby_engine_version)
     end
 
-    def to_gem_version_with_patchlevel
-      @gem_version_with_patch ||= begin
-        Gem::Version.create("#{@gem_version}.#{@patchlevel}")
-      rescue ArgumentError
-        @gem_version
-      end
-    end
-
     def exact?
       return @exact if defined?(@exact)
       @exact = versions.all? {|v| Gem::Requirement.create(v).exact? }

--- a/bundler/lib/bundler/ruby_version.rb
+++ b/bundler/lib/bundler/ruby_version.rb
@@ -110,11 +110,6 @@ module Bundler
       @ruby_version ||= RubyVersion.new(ruby_version, patchlevel, ruby_engine, ruby_engine_version)
     end
 
-    def exact?
-      return @exact if defined?(@exact)
-      @exact = versions.all? {|v| Gem::Requirement.create(v).exact? }
-    end
-
     private
 
     def matches?(requirements, version)

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -67,6 +67,23 @@ module Gem
       full_gem_path
     end
 
+    unless const_defined?(:LATEST_RUBY_WITHOUT_PATCH_VERSIONS)
+      LATEST_RUBY_WITHOUT_PATCH_VERSIONS = Gem::Version.new("2.1")
+
+      alias_method :rg_required_ruby_version=, :required_ruby_version=
+      def required_ruby_version=(req)
+        self.rg_required_ruby_version = req
+
+        @required_ruby_version.requirements.map! do |op, v|
+          if v >= LATEST_RUBY_WITHOUT_PATCH_VERSIONS && v.release.segments.size == 4
+            [op == "~>" ? "=" : op, Gem::Version.new(v.segments.tap {|s| s.delete_at(3) }.join("."))]
+          else
+            [op, v]
+          end
+        end
+      end
+    end
+
     def groups
       @groups ||= []
     end

--- a/bundler/lib/bundler/source/metadata.rb
+++ b/bundler/lib/bundler/source/metadata.rb
@@ -5,7 +5,7 @@ module Bundler
     class Metadata < Source
       def specs
         @specs ||= Index.build do |idx|
-          idx << Gem::Specification.new("Ruby\0", RubyVersion.system.to_gem_version_with_patchlevel)
+          idx << Gem::Specification.new("Ruby\0", RubyVersion.system.gem_version)
           idx << Gem::Specification.new("RubyGems\0", Gem::VERSION) do |s|
             s.required_rubygems_version = Gem::Requirement.default
           end

--- a/bundler/spec/bundler/ruby_version_spec.rb
+++ b/bundler/spec/bundler/ruby_version_spec.rb
@@ -498,31 +498,5 @@ RSpec.describe "Bundler::RubyVersion and its subclasses" do
         end
       end
     end
-
-    describe "#to_gem_version_with_patchlevel" do
-      shared_examples_for "the patchlevel is omitted" do
-        it "does not include a patch level" do
-          expect(subject.to_gem_version_with_patchlevel.to_s).to eq(version)
-        end
-      end
-
-      context "with nil patch number" do
-        let(:patchlevel) { nil }
-
-        it_behaves_like "the patchlevel is omitted"
-      end
-
-      context "with negative patch number" do
-        let(:patchlevel) { -1 }
-
-        it_behaves_like "the patchlevel is omitted"
-      end
-
-      context "with a valid patch number" do
-        it "uses the specified patchlevel as patchlevel" do
-          expect(subject.to_gem_version_with_patchlevel.to_s).to eq("#{version}.#{patchlevel}")
-        end
-      end
-    end
   end
 end

--- a/bundler/spec/install/gems/resolving_spec.rb
+++ b/bundler/spec/install/gems/resolving_spec.rb
@@ -301,7 +301,7 @@ RSpec.describe "bundle install with install-time dependencies" do
       end
 
       let(:ruby_requirement) { %("#{RUBY_VERSION}") }
-      let(:error_message_requirement) { "~> #{RUBY_VERSION}.0" }
+      let(:error_message_requirement) { "= #{RUBY_VERSION}" }
 
       shared_examples_for "ruby version conflicts" do
         it "raises an error during resolution" do

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -864,9 +864,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     return @ruby_version if defined? @ruby_version
     version = RUBY_VERSION.dup
 
-    if defined?(RUBY_PATCHLEVEL) && RUBY_PATCHLEVEL != -1
-      version << ".#{RUBY_PATCHLEVEL}"
-    elsif defined?(RUBY_DESCRIPTION)
+    if defined?(RUBY_DESCRIPTION)
       if RUBY_ENGINE == "ruby"
         desc = RUBY_DESCRIPTION[/\Aruby #{Regexp.quote(RUBY_VERSION)}([^ ]+) /, 1]
       else

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -657,6 +657,8 @@ class Gem::Specification < Gem::BasicSpecification
     @rdoc_options ||= []
   end
 
+  LATEST_RUBY_WITHOUT_PATCH_VERSIONS = Gem::Version.new("2.1")
+
   ##
   # The version of Ruby required by this gem.  The ruby version can be
   # specified to the patch-level:
@@ -683,6 +685,14 @@ class Gem::Specification < Gem::BasicSpecification
 
   def required_ruby_version=(req)
     @required_ruby_version = Gem::Requirement.create req
+
+    @required_ruby_version.requirements.map! do |op, v|
+      if v >= LATEST_RUBY_WITHOUT_PATCH_VERSIONS && v.release.segments.size == 4
+        [op == "~>" ? "=" : op, Gem::Version.new(v.segments.tap {|s| s.delete_at(3) }.join("."))]
+      else
+        [op, v]
+      end
+    end
   end
 
   ##

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -1098,13 +1098,12 @@ Also, a list:
     Zlib::Deflate.deflate data
   end
 
-  def util_set_RUBY_VERSION(version, patchlevel = nil, revision = nil, description = nil, engine = "ruby", engine_version = nil)
+  def util_set_RUBY_VERSION(version, revision = nil, description = nil, engine = "ruby", engine_version = nil)
     if Gem.instance_variables.include? :@ruby_version
       Gem.send :remove_instance_variable, :@ruby_version
     end
 
     @RUBY_VERSION        = RUBY_VERSION
-    @RUBY_PATCHLEVEL     = RUBY_PATCHLEVEL     if defined?(RUBY_PATCHLEVEL)
     @RUBY_REVISION       = RUBY_REVISION       if defined?(RUBY_REVISION)
     @RUBY_DESCRIPTION    = RUBY_DESCRIPTION    if defined?(RUBY_DESCRIPTION)
     @RUBY_ENGINE         = RUBY_ENGINE
@@ -1113,7 +1112,6 @@ Also, a list:
     util_clear_RUBY_VERSION
 
     Object.const_set :RUBY_VERSION,        version
-    Object.const_set :RUBY_PATCHLEVEL,     patchlevel     if patchlevel
     Object.const_set :RUBY_REVISION,       revision       if revision
     Object.const_set :RUBY_DESCRIPTION,    description    if description
     Object.const_set :RUBY_ENGINE,         engine
@@ -1124,8 +1122,6 @@ Also, a list:
     util_clear_RUBY_VERSION
 
     Object.const_set :RUBY_VERSION,        @RUBY_VERSION
-    Object.const_set :RUBY_PATCHLEVEL,     @RUBY_PATCHLEVEL  if
-      defined?(@RUBY_PATCHLEVEL)
     Object.const_set :RUBY_REVISION,       @RUBY_REVISION    if
       defined?(@RUBY_REVISION)
     Object.const_set :RUBY_DESCRIPTION,    @RUBY_DESCRIPTION if
@@ -1137,7 +1133,6 @@ Also, a list:
 
   def util_clear_RUBY_VERSION
     Object.send :remove_const, :RUBY_VERSION
-    Object.send :remove_const, :RUBY_PATCHLEVEL     if defined?(RUBY_PATCHLEVEL)
     Object.send :remove_const, :RUBY_REVISION       if defined?(RUBY_REVISION)
     Object.send :remove_const, :RUBY_DESCRIPTION    if defined?(RUBY_DESCRIPTION)
     Object.send :remove_const, :RUBY_ENGINE

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1114,14 +1114,6 @@ class TestGem < Gem::TestCase
     util_restore_RUBY_VERSION
   end
 
-  def test_self_ruby_version_with_release
-    util_set_RUBY_VERSION '1.8.6', 287
-
-    assert_equal Gem::Version.new('1.8.6.287'), Gem.ruby_version
-  ensure
-    util_restore_RUBY_VERSION
-  end
-
   def test_self_ruby_version_with_non_mri_implementations
     util_set_RUBY_VERSION '2.5.0', 0, 60928, 'jruby 9.2.0.0 (2.5.0) 2018-05-24 81156a8 OpenJDK 64-Bit Server VM 25.171-b11 on 1.8.0_171-8u171-b11-0ubuntu0.16.04.1-b11 [linux-x86_64]'
 

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1115,7 +1115,7 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_ruby_version_with_non_mri_implementations
-    util_set_RUBY_VERSION '2.5.0', 0, 60928, 'jruby 9.2.0.0 (2.5.0) 2018-05-24 81156a8 OpenJDK 64-Bit Server VM 25.171-b11 on 1.8.0_171-8u171-b11-0ubuntu0.16.04.1-b11 [linux-x86_64]'
+    util_set_RUBY_VERSION '2.5.0', 60928, 'jruby 9.2.0.0 (2.5.0) 2018-05-24 81156a8 OpenJDK 64-Bit Server VM 25.171-b11 on 1.8.0_171-8u171-b11-0ubuntu0.16.04.1-b11 [linux-x86_64]'
 
     assert_equal Gem::Version.new('2.5.0'), Gem.ruby_version
   ensure
@@ -1123,7 +1123,7 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_ruby_version_with_svn_prerelease
-    util_set_RUBY_VERSION '2.6.0', -1, 63539, 'ruby 2.6.0preview2 (2018-05-31 trunk 63539) [x86_64-linux]'
+    util_set_RUBY_VERSION '2.6.0', 63539, 'ruby 2.6.0preview2 (2018-05-31 trunk 63539) [x86_64-linux]'
 
     assert_equal Gem::Version.new('2.6.0.preview2'), Gem.ruby_version
   ensure
@@ -1131,7 +1131,7 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_ruby_version_with_git_prerelease
-    util_set_RUBY_VERSION '2.7.0', -1, 'b563439274a402e33541f5695b1bfd4ac1085638', 'ruby 2.7.0preview3 (2019-11-23 master b563439274) [x86_64-linux]'
+    util_set_RUBY_VERSION '2.7.0', 'b563439274a402e33541f5695b1bfd4ac1085638', 'ruby 2.7.0preview3 (2019-11-23 master b563439274) [x86_64-linux]'
 
     assert_equal Gem::Version.new('2.7.0.preview3'), Gem.ruby_version
   ensure
@@ -1139,7 +1139,7 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_ruby_version_with_non_mri_implementations_with_mri_prerelase_compatibility
-    util_set_RUBY_VERSION '2.6.0', -1, 63539, 'weirdjruby 9.2.0.0 (2.6.0preview2) 2018-05-24 81156a8 OpenJDK 64-Bit Server VM 25.171-b11 on 1.8.0_171-8u171-b11-0ubuntu0.16.04.1-b11 [linux-x86_64]', 'weirdjruby', '9.2.0.0'
+    util_set_RUBY_VERSION '2.6.0', 63539, 'weirdjruby 9.2.0.0 (2.6.0preview2) 2018-05-24 81156a8 OpenJDK 64-Bit Server VM 25.171-b11 on 1.8.0_171-8u171-b11-0ubuntu0.16.04.1-b11 [linux-x86_64]', 'weirdjruby', '9.2.0.0'
 
     assert_equal Gem::Version.new('2.6.0.preview2'), Gem.ruby_version
   ensure
@@ -1147,7 +1147,7 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_ruby_version_with_svn_trunk
-    util_set_RUBY_VERSION '1.9.2', -1, 23493, 'ruby 1.9.2dev (2009-05-20 trunk 23493) [x86_64-linux]'
+    util_set_RUBY_VERSION '1.9.2', 23493, 'ruby 1.9.2dev (2009-05-20 trunk 23493) [x86_64-linux]'
 
     assert_equal Gem::Version.new('1.9.2.dev'), Gem.ruby_version
   ensure
@@ -1155,7 +1155,7 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_ruby_version_with_git_master
-    util_set_RUBY_VERSION '2.7.0', -1, '5de284ec78220e75643f89b454ce999da0c1c195', 'ruby 2.7.0dev (2019-12-23T01:37:30Z master 5de284ec78) [x86_64-linux]'
+    util_set_RUBY_VERSION '2.7.0', '5de284ec78220e75643f89b454ce999da0c1c195', 'ruby 2.7.0dev (2019-12-23T01:37:30Z master 5de284ec78) [x86_64-linux]'
 
     assert_equal Gem::Version.new('2.7.0.dev'), Gem.ruby_version
   ensure


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Bundler still has some code that considers `RUBY_PATCHLEVEL` during resolution. However, this number is no longer meaningful since Ruby 2.1 when Ruby started release patch level versions. Now the `RUBY_VERSION` properly identifies a given Ruby release so it's no longer necessary to consider the patchlevel.

This generally doesn't cause any issues, but the patchlevel does leak to some error messages, which makes them quite confusing. For example, if you set `ruby "3.1.1"` in your `Gemfile`, you may end up with an error message including the following

```
Bundler found conflicting requirements for the Ruby version:
  In Gemfile:
    Ruby (~> 3.1.1.0)

  ...
```

## What is your fix for the problem, implemented in this PR?

My fix is to stop considering patchlevels for modern rubies. With this patch, the above error now reads better

```
Bundler found conflicting requirements for the Ruby version:
  In Gemfile:
    Ruby (= 3.1.1)

  ...
``` 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
