### PR TITLE
Stop considering patchlevel in Ruby version

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -864,9 +864,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     return @ruby_version if defined? @ruby_version
     version = RUBY_VERSION.dup
 
-    if defined?(RUBY_PATCHLEVEL) && RUBY_PATCHLEVEL != -1
-      version << ".#{RUBY_PATCHLEVEL}"
-    elsif defined?(RUBY_DESCRIPTION)
+    if defined?(RUBY_DESCRIPTION)
       if RUBY_ENGINE == "ruby"
         desc = RUBY_DESCRIPTION[/\Aruby #{Regexp.quote(RUBY_VERSION)}([^ ]+) /, 1]
       else

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -657,6 +657,8 @@ class Gem::Specification < Gem::BasicSpecification
     @rdoc_options ||= []
   end
 
+  LATEST_RUBY_WITHOUT_PATCH_VERSIONS = Gem::Version.new("2.1")
+
   ##
   # The version of Ruby required by this gem.  The ruby version can be
   # specified to the patch-level:
@@ -683,6 +685,14 @@ class Gem::Specification < Gem::BasicSpecification
 
   def required_ruby_version=(req)
     @required_ruby_version = Gem::Requirement.create req
+
+    @required_ruby_version.requirements.map! do |op, v|
+      if v >= LATEST_RUBY_WITHOUT_PATCH_VERSIONS && v.release.segments.size == 4
+        [op == "~>" ? "=" : op, Gem::Version.new(v.segments.tap {|s| s.delete_at(3) }.join("."))]
+      else
+        [op, v]
+      end
+    end
   end
 
   ##

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -1098,13 +1098,12 @@ Also, a list:
     Zlib::Deflate.deflate data
   end
 
-  def util_set_RUBY_VERSION(version, patchlevel = nil, revision = nil, description = nil, engine = "ruby", engine_version = nil)
+  def util_set_RUBY_VERSION(version, revision = nil, description = nil, engine = "ruby", engine_version = nil)
     if Gem.instance_variables.include? :@ruby_version
       Gem.send :remove_instance_variable, :@ruby_version
     end
 
     @RUBY_VERSION        = RUBY_VERSION
-    @RUBY_PATCHLEVEL     = RUBY_PATCHLEVEL     if defined?(RUBY_PATCHLEVEL)
     @RUBY_REVISION       = RUBY_REVISION       if defined?(RUBY_REVISION)
     @RUBY_DESCRIPTION    = RUBY_DESCRIPTION    if defined?(RUBY_DESCRIPTION)
     @RUBY_ENGINE         = RUBY_ENGINE
@@ -1113,7 +1112,6 @@ Also, a list:
     util_clear_RUBY_VERSION
 
     Object.const_set :RUBY_VERSION,        version
-    Object.const_set :RUBY_PATCHLEVEL,     patchlevel     if patchlevel
     Object.const_set :RUBY_REVISION,       revision       if revision
     Object.const_set :RUBY_DESCRIPTION,    description    if description
     Object.const_set :RUBY_ENGINE,         engine
@@ -1124,8 +1122,6 @@ Also, a list:
     util_clear_RUBY_VERSION
 
     Object.const_set :RUBY_VERSION,        @RUBY_VERSION
-    Object.const_set :RUBY_PATCHLEVEL,     @RUBY_PATCHLEVEL  if
-      defined?(@RUBY_PATCHLEVEL)
     Object.const_set :RUBY_REVISION,       @RUBY_REVISION    if
       defined?(@RUBY_REVISION)
     Object.const_set :RUBY_DESCRIPTION,    @RUBY_DESCRIPTION if
@@ -1137,7 +1133,6 @@ Also, a list:
 
   def util_clear_RUBY_VERSION
     Object.send :remove_const, :RUBY_VERSION
-    Object.send :remove_const, :RUBY_PATCHLEVEL     if defined?(RUBY_PATCHLEVEL)
     Object.send :remove_const, :RUBY_REVISION       if defined?(RUBY_REVISION)
     Object.send :remove_const, :RUBY_DESCRIPTION    if defined?(RUBY_DESCRIPTION)
     Object.send :remove_const, :RUBY_ENGINE

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1114,14 +1114,6 @@ class TestGem < Gem::TestCase
     util_restore_RUBY_VERSION
   end
 
-  def test_self_ruby_version_with_release
-    util_set_RUBY_VERSION '1.8.6', 287
-
-    assert_equal Gem::Version.new('1.8.6.287'), Gem.ruby_version
-  ensure
-    util_restore_RUBY_VERSION
-  end
-
   def test_self_ruby_version_with_non_mri_implementations
     util_set_RUBY_VERSION '2.5.0', 0, 60928, 'jruby 9.2.0.0 (2.5.0) 2018-05-24 81156a8 OpenJDK 64-Bit Server VM 25.171-b11 on 1.8.0_171-8u171-b11-0ubuntu0.16.04.1-b11 [linux-x86_64]'
 

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1115,7 +1115,7 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_ruby_version_with_non_mri_implementations
-    util_set_RUBY_VERSION '2.5.0', 0, 60928, 'jruby 9.2.0.0 (2.5.0) 2018-05-24 81156a8 OpenJDK 64-Bit Server VM 25.171-b11 on 1.8.0_171-8u171-b11-0ubuntu0.16.04.1-b11 [linux-x86_64]'
+    util_set_RUBY_VERSION '2.5.0', 60928, 'jruby 9.2.0.0 (2.5.0) 2018-05-24 81156a8 OpenJDK 64-Bit Server VM 25.171-b11 on 1.8.0_171-8u171-b11-0ubuntu0.16.04.1-b11 [linux-x86_64]'
 
     assert_equal Gem::Version.new('2.5.0'), Gem.ruby_version
   ensure
@@ -1123,7 +1123,7 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_ruby_version_with_svn_prerelease
-    util_set_RUBY_VERSION '2.6.0', -1, 63539, 'ruby 2.6.0preview2 (2018-05-31 trunk 63539) [x86_64-linux]'
+    util_set_RUBY_VERSION '2.6.0', 63539, 'ruby 2.6.0preview2 (2018-05-31 trunk 63539) [x86_64-linux]'
 
     assert_equal Gem::Version.new('2.6.0.preview2'), Gem.ruby_version
   ensure
@@ -1131,7 +1131,7 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_ruby_version_with_git_prerelease
-    util_set_RUBY_VERSION '2.7.0', -1, 'b563439274a402e33541f5695b1bfd4ac1085638', 'ruby 2.7.0preview3 (2019-11-23 master b563439274) [x86_64-linux]'
+    util_set_RUBY_VERSION '2.7.0', 'b563439274a402e33541f5695b1bfd4ac1085638', 'ruby 2.7.0preview3 (2019-11-23 master b563439274) [x86_64-linux]'
 
     assert_equal Gem::Version.new('2.7.0.preview3'), Gem.ruby_version
   ensure
@@ -1139,7 +1139,7 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_ruby_version_with_non_mri_implementations_with_mri_prerelase_compatibility
-    util_set_RUBY_VERSION '2.6.0', -1, 63539, 'weirdjruby 9.2.0.0 (2.6.0preview2) 2018-05-24 81156a8 OpenJDK 64-Bit Server VM 25.171-b11 on 1.8.0_171-8u171-b11-0ubuntu0.16.04.1-b11 [linux-x86_64]', 'weirdjruby', '9.2.0.0'
+    util_set_RUBY_VERSION '2.6.0', 63539, 'weirdjruby 9.2.0.0 (2.6.0preview2) 2018-05-24 81156a8 OpenJDK 64-Bit Server VM 25.171-b11 on 1.8.0_171-8u171-b11-0ubuntu0.16.04.1-b11 [linux-x86_64]', 'weirdjruby', '9.2.0.0'
 
     assert_equal Gem::Version.new('2.6.0.preview2'), Gem.ruby_version
   ensure
@@ -1147,7 +1147,7 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_ruby_version_with_svn_trunk
-    util_set_RUBY_VERSION '1.9.2', -1, 23493, 'ruby 1.9.2dev (2009-05-20 trunk 23493) [x86_64-linux]'
+    util_set_RUBY_VERSION '1.9.2', 23493, 'ruby 1.9.2dev (2009-05-20 trunk 23493) [x86_64-linux]'
 
     assert_equal Gem::Version.new('1.9.2.dev'), Gem.ruby_version
   ensure
@@ -1155,7 +1155,7 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_ruby_version_with_git_master
-    util_set_RUBY_VERSION '2.7.0', -1, '5de284ec78220e75643f89b454ce999da0c1c195', 'ruby 2.7.0dev (2019-12-23T01:37:30Z master 5de284ec78) [x86_64-linux]'
+    util_set_RUBY_VERSION '2.7.0', '5de284ec78220e75643f89b454ce999da0c1c195', 'ruby 2.7.0dev (2019-12-23T01:37:30Z master 5de284ec78) [x86_64-linux]'
 
     assert_equal Gem::Version.new('2.7.0.dev'), Gem.ruby_version
   ensure


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The patchlevel component in the Ruby version is no longer necessary to discriminate different rubies since Ruby 2.1.  While I haven't seen any issues related to this on the RubyGems side, it does cause some weird error messages on the Bundler side. I need to make this changes in preparation to fix those Bundler issues at #5472.
 
## What is your fix for the problem, implemented in this PR?

This PR stops considering the patchlevel in `required_ruby_version` field when the Ruby is modern enough, and stops reporting it in `Gem.ruby_version`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
