### PR TITLE
Improve Ruby version resolution conflicts

### DIFF
--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -159,9 +159,11 @@ end
 load "../util/automatiek.rake"
 
 # We currently ship Molinillo master branch as of
-# https://github.com/CocoaPods/Molinillo/commit/b4a510349e6893486b9eb44a71734c05a8034256,
-# with one change on top to require tsort relatively to use our vendored
-# version.
+# https://github.com/CocoaPods/Molinillo/commit/b4a510349e6893486b9eb44a71734c05a8034256
+# plus the following patches:
+# * Require `tsort` relatively to use our vendored version.
+# * Allow full customization of Molinillo's conflict error message
+#   (https://github.com/CocoaPods/Molinillo/pull/164).
 desc "Vendor a specific version of molinillo"
 Automatiek::RakeTask.new("molinillo") do |lib|
   lib.version = "master"

--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -159,7 +159,7 @@ end
 load "../util/automatiek.rake"
 
 # We currently ship Molinillo master branch as of
-# https://github.com/CocoaPods/Molinillo/commit/7cc27a355e861bdf593e2cde7bf1bca3daae4303
+# https://github.com/CocoaPods/Molinillo/commit/bb368fdc1071a8cfeeb8afe83ee6b7cb785f938a
 desc "Vendor a specific version of molinillo"
 Automatiek::RakeTask.new("molinillo") do |lib|
   lib.version = "master"

--- a/bundler/Rakefile
+++ b/bundler/Rakefile
@@ -159,7 +159,9 @@ end
 load "../util/automatiek.rake"
 
 # We currently ship Molinillo master branch as of
-# https://github.com/CocoaPods/Molinillo/commit/bb368fdc1071a8cfeeb8afe83ee6b7cb785f938a
+# https://github.com/CocoaPods/Molinillo/commit/b4a510349e6893486b9eb44a71734c05a8034256,
+# with one change on top to require tsort relatively to use our vendored
+# version.
 desc "Vendor a specific version of molinillo"
 Automatiek::RakeTask.new("molinillo") do |lib|
   lib.version = "master"

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -736,18 +736,10 @@ module Bundler
 
     def metadata_dependencies
       @metadata_dependencies ||= begin
-        ruby_versions = ruby_version_requirements(@ruby_version)
         [
-          Dependency.new("Ruby\0", ruby_versions),
+          Dependency.new("Ruby\0", RubyVersion.system.gem_version),
           Dependency.new("RubyGems\0", Gem::VERSION),
         ]
-      end
-    end
-
-    def ruby_version_requirements(ruby_version)
-      return [] unless ruby_version
-      ruby_version.versions.map do |version|
-        Gem::Requirement.new(version)
       end
     end
 

--- a/bundler/lib/bundler/vendor/molinillo/lib/molinillo/dependency_graph.rb
+++ b/bundler/lib/bundler/vendor/molinillo/lib/molinillo/dependency_graph.rb
@@ -32,7 +32,7 @@ module Bundler::Molinillo
     #   all belong to the same graph.
     # @return [Array<Vertex>] The sorted vertices.
     def self.tsort(vertices)
-      TSort.tsort(
+      Bundler::TSort.tsort(
         lambda { |b| vertices.each(&b) },
         lambda { |v, &b| (v.successors & vertices).each(&b) }
       )

--- a/bundler/lib/bundler/vendor/molinillo/lib/molinillo/gem_metadata.rb
+++ b/bundler/lib/bundler/vendor/molinillo/lib/molinillo/gem_metadata.rb
@@ -2,5 +2,5 @@
 
 module Bundler::Molinillo
   # The version of Bundler::Molinillo.
-  VERSION = '0.7.0'.freeze
+  VERSION = '0.8.0'.freeze
 end

--- a/bundler/lib/bundler/vendor/tsort/lib/tsort.rb
+++ b/bundler/lib/bundler/vendor/tsort/lib/tsort.rb
@@ -6,24 +6,24 @@
 #
 
 #
-# TSort implements topological sorting using Tarjan's algorithm for
+# Bundler::TSort implements topological sorting using Tarjan's algorithm for
 # strongly connected components.
 #
-# TSort is designed to be able to be used with any object which can be
+# Bundler::TSort is designed to be able to be used with any object which can be
 # interpreted as a directed graph.
 #
-# TSort requires two methods to interpret an object as a graph,
+# Bundler::TSort requires two methods to interpret an object as a graph,
 # tsort_each_node and tsort_each_child.
 #
 # * tsort_each_node is used to iterate for all nodes over a graph.
 # * tsort_each_child is used to iterate for child nodes of a given node.
 #
 # The equality of nodes are defined by eql? and hash since
-# TSort uses Hash internally.
+# Bundler::TSort uses Hash internally.
 #
 # == A Simple Example
 #
-# The following example demonstrates how to mix the TSort module into an
+# The following example demonstrates how to mix the Bundler::TSort module into an
 # existing class (in this case, Hash). Here, we're treating each key in
 # the hash as a node in the graph, and so we simply alias the required
 # #tsort_each_node method to Hash's #each_key method. For each key in the
@@ -32,10 +32,10 @@
 # method, which fetches the array of child nodes and then iterates over that
 # array using the user-supplied block.
 #
-#   require 'tsort'
+#   require 'bundler/vendor/tsort/lib/tsort'
 #
 #   class Hash
-#     include TSort
+#     include Bundler::TSort
 #     alias tsort_each_node each_key
 #     def tsort_each_child(node, &block)
 #       fetch(node).each(&block)
@@ -52,7 +52,7 @@
 #
 # A very simple `make' like tool can be implemented as follows:
 #
-#   require 'tsort'
+#   require 'bundler/vendor/tsort/lib/tsort'
 #
 #   class Make
 #     def initialize
@@ -70,7 +70,7 @@
 #       each_strongly_connected_component_from(target) {|ns|
 #         if ns.length != 1
 #           fs = ns.delete_if {|n| Array === n}
-#           raise TSort::Cyclic.new("cyclic dependencies: #{fs.join ', '}")
+#           raise Bundler::TSort::Cyclic.new("cyclic dependencies: #{fs.join ', '}")
 #         end
 #         n = ns.first
 #         if Array === n
@@ -93,7 +93,7 @@
 #     def tsort_each_child(node, &block)
 #       @dep[node].each(&block)
 #     end
-#     include TSort
+#     include Bundler::TSort
 #   end
 #
 #   def command(arg)
@@ -120,334 +120,333 @@
 # R. E. Tarjan, "Depth First Search and Linear Graph Algorithms",
 # <em>SIAM Journal on Computing</em>, Vol. 1, No. 2, pp. 146-160, June 1972.
 #
-module Bundler
-  module TSort
-    class Cyclic < StandardError
-    end
 
-    # Returns a topologically sorted array of nodes.
-    # The array is sorted from children to parents, i.e.
-    # the first element has no child and the last node has no parent.
-    #
-    # If there is a cycle, TSort::Cyclic is raised.
-    #
-    #   class G
-    #     include TSort
-    #     def initialize(g)
-    #       @g = g
-    #     end
-    #     def tsort_each_child(n, &b) @g[n].each(&b) end
-    #     def tsort_each_node(&b) @g.each_key(&b) end
-    #   end
-    #
-    #   graph = G.new({1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]})
-    #   p graph.tsort #=> [4, 2, 3, 1]
-    #
-    #   graph = G.new({1=>[2], 2=>[3, 4], 3=>[2], 4=>[]})
-    #   p graph.tsort # raises TSort::Cyclic
-    #
-    def tsort
-      each_node = method(:tsort_each_node)
-      each_child = method(:tsort_each_child)
-      TSort.tsort(each_node, each_child)
-    end
+module Bundler::TSort
+  class Cyclic < StandardError
+  end
 
-    # Returns a topologically sorted array of nodes.
-    # The array is sorted from children to parents, i.e.
-    # the first element has no child and the last node has no parent.
-    #
-    # The graph is represented by _each_node_ and _each_child_.
-    # _each_node_ should have +call+ method which yields for each node in the graph.
-    # _each_child_ should have +call+ method which takes a node argument and yields for each child node.
-    #
-    # If there is a cycle, TSort::Cyclic is raised.
-    #
-    #   g = {1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]}
-    #   each_node = lambda {|&b| g.each_key(&b) }
-    #   each_child = lambda {|n, &b| g[n].each(&b) }
-    #   p TSort.tsort(each_node, each_child) #=> [4, 2, 3, 1]
-    #
-    #   g = {1=>[2], 2=>[3, 4], 3=>[2], 4=>[]}
-    #   each_node = lambda {|&b| g.each_key(&b) }
-    #   each_child = lambda {|n, &b| g[n].each(&b) }
-    #   p TSort.tsort(each_node, each_child) # raises TSort::Cyclic
-    #
-    def TSort.tsort(each_node, each_child)
-      TSort.tsort_each(each_node, each_child).to_a
-    end
+  # Returns a topologically sorted array of nodes.
+  # The array is sorted from children to parents, i.e.
+  # the first element has no child and the last node has no parent.
+  #
+  # If there is a cycle, Bundler::TSort::Cyclic is raised.
+  #
+  #   class G
+  #     include Bundler::TSort
+  #     def initialize(g)
+  #       @g = g
+  #     end
+  #     def tsort_each_child(n, &b) @g[n].each(&b) end
+  #     def tsort_each_node(&b) @g.each_key(&b) end
+  #   end
+  #
+  #   graph = G.new({1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]})
+  #   p graph.tsort #=> [4, 2, 3, 1]
+  #
+  #   graph = G.new({1=>[2], 2=>[3, 4], 3=>[2], 4=>[]})
+  #   p graph.tsort # raises Bundler::TSort::Cyclic
+  #
+  def tsort
+    each_node = method(:tsort_each_node)
+    each_child = method(:tsort_each_child)
+    Bundler::TSort.tsort(each_node, each_child)
+  end
 
-    # The iterator version of the #tsort method.
-    # <tt><em>obj</em>.tsort_each</tt> is similar to <tt><em>obj</em>.tsort.each</tt>, but
-    # modification of _obj_ during the iteration may lead to unexpected results.
-    #
-    # #tsort_each returns +nil+.
-    # If there is a cycle, TSort::Cyclic is raised.
-    #
-    #   class G
-    #     include TSort
-    #     def initialize(g)
-    #       @g = g
-    #     end
-    #     def tsort_each_child(n, &b) @g[n].each(&b) end
-    #     def tsort_each_node(&b) @g.each_key(&b) end
-    #   end
-    #
-    #   graph = G.new({1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]})
-    #   graph.tsort_each {|n| p n }
-    #   #=> 4
-    #   #   2
-    #   #   3
-    #   #   1
-    #
-    def tsort_each(&block) # :yields: node
-      each_node = method(:tsort_each_node)
-      each_child = method(:tsort_each_child)
-      TSort.tsort_each(each_node, each_child, &block)
-    end
+  # Returns a topologically sorted array of nodes.
+  # The array is sorted from children to parents, i.e.
+  # the first element has no child and the last node has no parent.
+  #
+  # The graph is represented by _each_node_ and _each_child_.
+  # _each_node_ should have +call+ method which yields for each node in the graph.
+  # _each_child_ should have +call+ method which takes a node argument and yields for each child node.
+  #
+  # If there is a cycle, Bundler::TSort::Cyclic is raised.
+  #
+  #   g = {1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]}
+  #   each_node = lambda {|&b| g.each_key(&b) }
+  #   each_child = lambda {|n, &b| g[n].each(&b) }
+  #   p Bundler::TSort.tsort(each_node, each_child) #=> [4, 2, 3, 1]
+  #
+  #   g = {1=>[2], 2=>[3, 4], 3=>[2], 4=>[]}
+  #   each_node = lambda {|&b| g.each_key(&b) }
+  #   each_child = lambda {|n, &b| g[n].each(&b) }
+  #   p Bundler::TSort.tsort(each_node, each_child) # raises Bundler::TSort::Cyclic
+  #
+  def self.tsort(each_node, each_child)
+    tsort_each(each_node, each_child).to_a
+  end
 
-    # The iterator version of the TSort.tsort method.
-    #
-    # The graph is represented by _each_node_ and _each_child_.
-    # _each_node_ should have +call+ method which yields for each node in the graph.
-    # _each_child_ should have +call+ method which takes a node argument and yields for each child node.
-    #
-    #   g = {1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]}
-    #   each_node = lambda {|&b| g.each_key(&b) }
-    #   each_child = lambda {|n, &b| g[n].each(&b) }
-    #   TSort.tsort_each(each_node, each_child) {|n| p n }
-    #   #=> 4
-    #   #   2
-    #   #   3
-    #   #   1
-    #
-    def TSort.tsort_each(each_node, each_child) # :yields: node
-      return to_enum(__method__, each_node, each_child) unless block_given?
+  # The iterator version of the #tsort method.
+  # <tt><em>obj</em>.tsort_each</tt> is similar to <tt><em>obj</em>.tsort.each</tt>, but
+  # modification of _obj_ during the iteration may lead to unexpected results.
+  #
+  # #tsort_each returns +nil+.
+  # If there is a cycle, Bundler::TSort::Cyclic is raised.
+  #
+  #   class G
+  #     include Bundler::TSort
+  #     def initialize(g)
+  #       @g = g
+  #     end
+  #     def tsort_each_child(n, &b) @g[n].each(&b) end
+  #     def tsort_each_node(&b) @g.each_key(&b) end
+  #   end
+  #
+  #   graph = G.new({1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]})
+  #   graph.tsort_each {|n| p n }
+  #   #=> 4
+  #   #   2
+  #   #   3
+  #   #   1
+  #
+  def tsort_each(&block) # :yields: node
+    each_node = method(:tsort_each_node)
+    each_child = method(:tsort_each_child)
+    Bundler::TSort.tsort_each(each_node, each_child, &block)
+  end
 
-      TSort.each_strongly_connected_component(each_node, each_child) {|component|
-        if component.size == 1
-          yield component.first
-        else
-          raise Cyclic.new("topological sort failed: #{component.inspect}")
-        end
-      }
-    end
+  # The iterator version of the Bundler::TSort.tsort method.
+  #
+  # The graph is represented by _each_node_ and _each_child_.
+  # _each_node_ should have +call+ method which yields for each node in the graph.
+  # _each_child_ should have +call+ method which takes a node argument and yields for each child node.
+  #
+  #   g = {1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]}
+  #   each_node = lambda {|&b| g.each_key(&b) }
+  #   each_child = lambda {|n, &b| g[n].each(&b) }
+  #   Bundler::TSort.tsort_each(each_node, each_child) {|n| p n }
+  #   #=> 4
+  #   #   2
+  #   #   3
+  #   #   1
+  #
+  def self.tsort_each(each_node, each_child) # :yields: node
+    return to_enum(__method__, each_node, each_child) unless block_given?
 
-    # Returns strongly connected components as an array of arrays of nodes.
-    # The array is sorted from children to parents.
-    # Each elements of the array represents a strongly connected component.
-    #
-    #   class G
-    #     include TSort
-    #     def initialize(g)
-    #       @g = g
-    #     end
-    #     def tsort_each_child(n, &b) @g[n].each(&b) end
-    #     def tsort_each_node(&b) @g.each_key(&b) end
-    #   end
-    #
-    #   graph = G.new({1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]})
-    #   p graph.strongly_connected_components #=> [[4], [2], [3], [1]]
-    #
-    #   graph = G.new({1=>[2], 2=>[3, 4], 3=>[2], 4=>[]})
-    #   p graph.strongly_connected_components #=> [[4], [2, 3], [1]]
-    #
-    def strongly_connected_components
-      each_node = method(:tsort_each_node)
-      each_child = method(:tsort_each_child)
-      TSort.strongly_connected_components(each_node, each_child)
-    end
+    each_strongly_connected_component(each_node, each_child) {|component|
+      if component.size == 1
+        yield component.first
+      else
+        raise Cyclic.new("topological sort failed: #{component.inspect}")
+      end
+    }
+  end
 
-    # Returns strongly connected components as an array of arrays of nodes.
-    # The array is sorted from children to parents.
-    # Each elements of the array represents a strongly connected component.
-    #
-    # The graph is represented by _each_node_ and _each_child_.
-    # _each_node_ should have +call+ method which yields for each node in the graph.
-    # _each_child_ should have +call+ method which takes a node argument and yields for each child node.
-    #
-    #   g = {1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]}
-    #   each_node = lambda {|&b| g.each_key(&b) }
-    #   each_child = lambda {|n, &b| g[n].each(&b) }
-    #   p TSort.strongly_connected_components(each_node, each_child)
-    #   #=> [[4], [2], [3], [1]]
-    #
-    #   g = {1=>[2], 2=>[3, 4], 3=>[2], 4=>[]}
-    #   each_node = lambda {|&b| g.each_key(&b) }
-    #   each_child = lambda {|n, &b| g[n].each(&b) }
-    #   p TSort.strongly_connected_components(each_node, each_child)
-    #   #=> [[4], [2, 3], [1]]
-    #
-    def TSort.strongly_connected_components(each_node, each_child)
-      TSort.each_strongly_connected_component(each_node, each_child).to_a
-    end
+  # Returns strongly connected components as an array of arrays of nodes.
+  # The array is sorted from children to parents.
+  # Each elements of the array represents a strongly connected component.
+  #
+  #   class G
+  #     include Bundler::TSort
+  #     def initialize(g)
+  #       @g = g
+  #     end
+  #     def tsort_each_child(n, &b) @g[n].each(&b) end
+  #     def tsort_each_node(&b) @g.each_key(&b) end
+  #   end
+  #
+  #   graph = G.new({1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]})
+  #   p graph.strongly_connected_components #=> [[4], [2], [3], [1]]
+  #
+  #   graph = G.new({1=>[2], 2=>[3, 4], 3=>[2], 4=>[]})
+  #   p graph.strongly_connected_components #=> [[4], [2, 3], [1]]
+  #
+  def strongly_connected_components
+    each_node = method(:tsort_each_node)
+    each_child = method(:tsort_each_child)
+    Bundler::TSort.strongly_connected_components(each_node, each_child)
+  end
 
-    # The iterator version of the #strongly_connected_components method.
-    # <tt><em>obj</em>.each_strongly_connected_component</tt> is similar to
-    # <tt><em>obj</em>.strongly_connected_components.each</tt>, but
-    # modification of _obj_ during the iteration may lead to unexpected results.
-    #
-    # #each_strongly_connected_component returns +nil+.
-    #
-    #   class G
-    #     include TSort
-    #     def initialize(g)
-    #       @g = g
-    #     end
-    #     def tsort_each_child(n, &b) @g[n].each(&b) end
-    #     def tsort_each_node(&b) @g.each_key(&b) end
-    #   end
-    #
-    #   graph = G.new({1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]})
-    #   graph.each_strongly_connected_component {|scc| p scc }
-    #   #=> [4]
-    #   #   [2]
-    #   #   [3]
-    #   #   [1]
-    #
-    #   graph = G.new({1=>[2], 2=>[3, 4], 3=>[2], 4=>[]})
-    #   graph.each_strongly_connected_component {|scc| p scc }
-    #   #=> [4]
-    #   #   [2, 3]
-    #   #   [1]
-    #
-    def each_strongly_connected_component(&block) # :yields: nodes
-      each_node = method(:tsort_each_node)
-      each_child = method(:tsort_each_child)
-      TSort.each_strongly_connected_component(each_node, each_child, &block)
-    end
+  # Returns strongly connected components as an array of arrays of nodes.
+  # The array is sorted from children to parents.
+  # Each elements of the array represents a strongly connected component.
+  #
+  # The graph is represented by _each_node_ and _each_child_.
+  # _each_node_ should have +call+ method which yields for each node in the graph.
+  # _each_child_ should have +call+ method which takes a node argument and yields for each child node.
+  #
+  #   g = {1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]}
+  #   each_node = lambda {|&b| g.each_key(&b) }
+  #   each_child = lambda {|n, &b| g[n].each(&b) }
+  #   p Bundler::TSort.strongly_connected_components(each_node, each_child)
+  #   #=> [[4], [2], [3], [1]]
+  #
+  #   g = {1=>[2], 2=>[3, 4], 3=>[2], 4=>[]}
+  #   each_node = lambda {|&b| g.each_key(&b) }
+  #   each_child = lambda {|n, &b| g[n].each(&b) }
+  #   p Bundler::TSort.strongly_connected_components(each_node, each_child)
+  #   #=> [[4], [2, 3], [1]]
+  #
+  def self.strongly_connected_components(each_node, each_child)
+    each_strongly_connected_component(each_node, each_child).to_a
+  end
 
-    # The iterator version of the TSort.strongly_connected_components method.
-    #
-    # The graph is represented by _each_node_ and _each_child_.
-    # _each_node_ should have +call+ method which yields for each node in the graph.
-    # _each_child_ should have +call+ method which takes a node argument and yields for each child node.
-    #
-    #   g = {1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]}
-    #   each_node = lambda {|&b| g.each_key(&b) }
-    #   each_child = lambda {|n, &b| g[n].each(&b) }
-    #   TSort.each_strongly_connected_component(each_node, each_child) {|scc| p scc }
-    #   #=> [4]
-    #   #   [2]
-    #   #   [3]
-    #   #   [1]
-    #
-    #   g = {1=>[2], 2=>[3, 4], 3=>[2], 4=>[]}
-    #   each_node = lambda {|&b| g.each_key(&b) }
-    #   each_child = lambda {|n, &b| g[n].each(&b) }
-    #   TSort.each_strongly_connected_component(each_node, each_child) {|scc| p scc }
-    #   #=> [4]
-    #   #   [2, 3]
-    #   #   [1]
-    #
-    def TSort.each_strongly_connected_component(each_node, each_child) # :yields: nodes
-      return to_enum(__method__, each_node, each_child) unless block_given?
+  # The iterator version of the #strongly_connected_components method.
+  # <tt><em>obj</em>.each_strongly_connected_component</tt> is similar to
+  # <tt><em>obj</em>.strongly_connected_components.each</tt>, but
+  # modification of _obj_ during the iteration may lead to unexpected results.
+  #
+  # #each_strongly_connected_component returns +nil+.
+  #
+  #   class G
+  #     include Bundler::TSort
+  #     def initialize(g)
+  #       @g = g
+  #     end
+  #     def tsort_each_child(n, &b) @g[n].each(&b) end
+  #     def tsort_each_node(&b) @g.each_key(&b) end
+  #   end
+  #
+  #   graph = G.new({1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]})
+  #   graph.each_strongly_connected_component {|scc| p scc }
+  #   #=> [4]
+  #   #   [2]
+  #   #   [3]
+  #   #   [1]
+  #
+  #   graph = G.new({1=>[2], 2=>[3, 4], 3=>[2], 4=>[]})
+  #   graph.each_strongly_connected_component {|scc| p scc }
+  #   #=> [4]
+  #   #   [2, 3]
+  #   #   [1]
+  #
+  def each_strongly_connected_component(&block) # :yields: nodes
+    each_node = method(:tsort_each_node)
+    each_child = method(:tsort_each_child)
+    Bundler::TSort.each_strongly_connected_component(each_node, each_child, &block)
+  end
 
-      id_map = {}
-      stack = []
-      each_node.call {|node|
-        unless id_map.include? node
-          TSort.each_strongly_connected_component_from(node, each_child, id_map, stack) {|c|
+  # The iterator version of the Bundler::TSort.strongly_connected_components method.
+  #
+  # The graph is represented by _each_node_ and _each_child_.
+  # _each_node_ should have +call+ method which yields for each node in the graph.
+  # _each_child_ should have +call+ method which takes a node argument and yields for each child node.
+  #
+  #   g = {1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]}
+  #   each_node = lambda {|&b| g.each_key(&b) }
+  #   each_child = lambda {|n, &b| g[n].each(&b) }
+  #   Bundler::TSort.each_strongly_connected_component(each_node, each_child) {|scc| p scc }
+  #   #=> [4]
+  #   #   [2]
+  #   #   [3]
+  #   #   [1]
+  #
+  #   g = {1=>[2], 2=>[3, 4], 3=>[2], 4=>[]}
+  #   each_node = lambda {|&b| g.each_key(&b) }
+  #   each_child = lambda {|n, &b| g[n].each(&b) }
+  #   Bundler::TSort.each_strongly_connected_component(each_node, each_child) {|scc| p scc }
+  #   #=> [4]
+  #   #   [2, 3]
+  #   #   [1]
+  #
+  def self.each_strongly_connected_component(each_node, each_child) # :yields: nodes
+    return to_enum(__method__, each_node, each_child) unless block_given?
+
+    id_map = {}
+    stack = []
+    each_node.call {|node|
+      unless id_map.include? node
+        each_strongly_connected_component_from(node, each_child, id_map, stack) {|c|
+          yield c
+        }
+      end
+    }
+    nil
+  end
+
+  # Iterates over strongly connected component in the subgraph reachable from
+  # _node_.
+  #
+  # Return value is unspecified.
+  #
+  # #each_strongly_connected_component_from doesn't call #tsort_each_node.
+  #
+  #   class G
+  #     include Bundler::TSort
+  #     def initialize(g)
+  #       @g = g
+  #     end
+  #     def tsort_each_child(n, &b) @g[n].each(&b) end
+  #     def tsort_each_node(&b) @g.each_key(&b) end
+  #   end
+  #
+  #   graph = G.new({1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]})
+  #   graph.each_strongly_connected_component_from(2) {|scc| p scc }
+  #   #=> [4]
+  #   #   [2]
+  #
+  #   graph = G.new({1=>[2], 2=>[3, 4], 3=>[2], 4=>[]})
+  #   graph.each_strongly_connected_component_from(2) {|scc| p scc }
+  #   #=> [4]
+  #   #   [2, 3]
+  #
+  def each_strongly_connected_component_from(node, id_map={}, stack=[], &block) # :yields: nodes
+    Bundler::TSort.each_strongly_connected_component_from(node, method(:tsort_each_child), id_map, stack, &block)
+  end
+
+  # Iterates over strongly connected components in a graph.
+  # The graph is represented by _node_ and _each_child_.
+  #
+  # _node_ is the first node.
+  # _each_child_ should have +call+ method which takes a node argument
+  # and yields for each child node.
+  #
+  # Return value is unspecified.
+  #
+  # #Bundler::TSort.each_strongly_connected_component_from is a class method and
+  # it doesn't need a class to represent a graph which includes Bundler::TSort.
+  #
+  #   graph = {1=>[2], 2=>[3, 4], 3=>[2], 4=>[]}
+  #   each_child = lambda {|n, &b| graph[n].each(&b) }
+  #   Bundler::TSort.each_strongly_connected_component_from(1, each_child) {|scc|
+  #     p scc
+  #   }
+  #   #=> [4]
+  #   #   [2, 3]
+  #   #   [1]
+  #
+  def self.each_strongly_connected_component_from(node, each_child, id_map={}, stack=[]) # :yields: nodes
+    return to_enum(__method__, node, each_child, id_map, stack) unless block_given?
+
+    minimum_id = node_id = id_map[node] = id_map.size
+    stack_length = stack.length
+    stack << node
+
+    each_child.call(node) {|child|
+      if id_map.include? child
+        child_id = id_map[child]
+        minimum_id = child_id if child_id && child_id < minimum_id
+      else
+        sub_minimum_id =
+          each_strongly_connected_component_from(child, each_child, id_map, stack) {|c|
             yield c
           }
-        end
-      }
-      nil
-    end
-
-    # Iterates over strongly connected component in the subgraph reachable from
-    # _node_.
-    #
-    # Return value is unspecified.
-    #
-    # #each_strongly_connected_component_from doesn't call #tsort_each_node.
-    #
-    #   class G
-    #     include TSort
-    #     def initialize(g)
-    #       @g = g
-    #     end
-    #     def tsort_each_child(n, &b) @g[n].each(&b) end
-    #     def tsort_each_node(&b) @g.each_key(&b) end
-    #   end
-    #
-    #   graph = G.new({1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]})
-    #   graph.each_strongly_connected_component_from(2) {|scc| p scc }
-    #   #=> [4]
-    #   #   [2]
-    #
-    #   graph = G.new({1=>[2], 2=>[3, 4], 3=>[2], 4=>[]})
-    #   graph.each_strongly_connected_component_from(2) {|scc| p scc }
-    #   #=> [4]
-    #   #   [2, 3]
-    #
-    def each_strongly_connected_component_from(node, id_map={}, stack=[], &block) # :yields: nodes
-      TSort.each_strongly_connected_component_from(node, method(:tsort_each_child), id_map, stack, &block)
-    end
-
-    # Iterates over strongly connected components in a graph.
-    # The graph is represented by _node_ and _each_child_.
-    #
-    # _node_ is the first node.
-    # _each_child_ should have +call+ method which takes a node argument
-    # and yields for each child node.
-    #
-    # Return value is unspecified.
-    #
-    # #TSort.each_strongly_connected_component_from is a class method and
-    # it doesn't need a class to represent a graph which includes TSort.
-    #
-    #   graph = {1=>[2], 2=>[3, 4], 3=>[2], 4=>[]}
-    #   each_child = lambda {|n, &b| graph[n].each(&b) }
-    #   TSort.each_strongly_connected_component_from(1, each_child) {|scc|
-    #     p scc
-    #   }
-    #   #=> [4]
-    #   #   [2, 3]
-    #   #   [1]
-    #
-    def TSort.each_strongly_connected_component_from(node, each_child, id_map={}, stack=[]) # :yields: nodes
-      return to_enum(__method__, node, each_child, id_map, stack) unless block_given?
-
-      minimum_id = node_id = id_map[node] = id_map.size
-      stack_length = stack.length
-      stack << node
-
-      each_child.call(node) {|child|
-        if id_map.include? child
-          child_id = id_map[child]
-          minimum_id = child_id if child_id && child_id < minimum_id
-        else
-          sub_minimum_id =
-            TSort.each_strongly_connected_component_from(child, each_child, id_map, stack) {|c|
-              yield c
-            }
-          minimum_id = sub_minimum_id if sub_minimum_id < minimum_id
-        end
-      }
-
-      if node_id == minimum_id
-        component = stack.slice!(stack_length .. -1)
-        component.each {|n| id_map[n] = nil}
-        yield component
+        minimum_id = sub_minimum_id if sub_minimum_id < minimum_id
       end
+    }
 
-      minimum_id
+    if node_id == minimum_id
+      component = stack.slice!(stack_length .. -1)
+      component.each {|n| id_map[n] = nil}
+      yield component
     end
 
-    # Should be implemented by a extended class.
-    #
-    # #tsort_each_node is used to iterate for all nodes over a graph.
-    #
-    def tsort_each_node # :yields: node
-      raise NotImplementedError.new
-    end
+    minimum_id
+  end
 
-    # Should be implemented by a extended class.
-    #
-    # #tsort_each_child is used to iterate for child nodes of _node_.
-    #
-    def tsort_each_child(node) # :yields: child
-      raise NotImplementedError.new
-    end
+  # Should be implemented by a extended class.
+  #
+  # #tsort_each_node is used to iterate for all nodes over a graph.
+  #
+  def tsort_each_node # :yields: node
+    raise NotImplementedError.new
+  end
+
+  # Should be implemented by a extended class.
+  #
+  # #tsort_each_child is used to iterate for child nodes of _node_.
+  #
+  def tsort_each_child(node) # :yields: child
+    raise NotImplementedError.new
   end
 end

--- a/bundler/spec/install/gems/resolving_spec.rb
+++ b/bundler/spec/install/gems/resolving_spec.rb
@@ -303,6 +303,27 @@ RSpec.describe "bundle install with install-time dependencies" do
       let(:ruby_requirement) { %("#{RUBY_VERSION}") }
       let(:error_message_requirement) { "= #{RUBY_VERSION}" }
 
+      it "raises a proper error that mentions the current Ruby version during resolution" do
+        install_gemfile <<-G, :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo2.to_s }, :raise_on_error => false
+          source "http://localgemserver.test/"
+          gem 'require_ruby'
+        G
+
+        expect(out).to_not include("Gem::InstallError: require_ruby requires Ruby version > 9000")
+
+        nice_error = strip_whitespace(<<-E).strip
+          Bundler found conflicting requirements for the Ruby\0 version:
+            In Gemfile:
+              require_ruby was resolved to 1.0, which depends on
+                Ruby\0 (> 9000)
+
+            Current Ruby\0 version:
+              Ruby\0 (#{error_message_requirement})
+
+        E
+        expect(err).to end_with(nice_error)
+      end
+
       shared_examples_for "ruby version conflicts" do
         it "raises an error during resolution" do
           install_gemfile <<-G, :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo2.to_s }, :raise_on_error => false
@@ -316,10 +337,12 @@ RSpec.describe "bundle install with install-time dependencies" do
           nice_error = strip_whitespace(<<-E).strip
             Bundler found conflicting requirements for the Ruby\0 version:
               In Gemfile:
-                Ruby\0 (#{error_message_requirement})
-
                 require_ruby was resolved to 1.0, which depends on
                   Ruby\0 (> 9000)
+
+              Current Ruby\0 version:
+                Ruby\0 (#{error_message_requirement})
+
           E
           expect(err).to end_with(nice_error)
         end
@@ -329,7 +352,6 @@ RSpec.describe "bundle install with install-time dependencies" do
 
       describe "with a < requirement" do
         let(:ruby_requirement) { %("< 5000") }
-        let(:error_message_requirement) { "< 5000" }
 
         it_behaves_like "ruby version conflicts"
       end
@@ -337,7 +359,6 @@ RSpec.describe "bundle install with install-time dependencies" do
       describe "with a compound requirement" do
         let(:reqs) { ["> 0.1", "< 5000"] }
         let(:ruby_requirement) { reqs.map(&:dump).join(", ") }
-        let(:error_message_requirement) { Gem::Requirement.new(reqs).to_s }
 
         it_behaves_like "ruby version conflicts"
       end
@@ -361,10 +382,12 @@ RSpec.describe "bundle install with install-time dependencies" do
       nice_error = strip_whitespace(<<-E).strip
         Bundler found conflicting requirements for the RubyGems\0 version:
           In Gemfile:
-            RubyGems\0 (= #{Gem::VERSION})
-
             require_rubygems was resolved to 1.0, which depends on
               RubyGems\0 (> 9000)
+
+          Current RubyGems\0 version:
+            RubyGems\0 (= #{Gem::VERSION})
+
       E
       expect(err).to end_with(nice_error)
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Right now, if Bundler can't find a version of a requirement whose `required_ruby_version` satisfies the running Ruby version, it will print a resolution error. However, this error is quite confusing because even if there's no `ruby` directive in the `Gemfile`, it will read like this:

```
Bundler found conflicting requirements for the Ruby version:
  In Gemfile:
    activeadmin was resolved to 2.11.2, which depends on
      Ruby (>= 3.1)

    Ruby
```

There's two issues here:

* The error mentions that the requirement on the Ruby version is set in the `Gemfile`. However, that's not always the case.
* The error does not mention the current Ruby version at all, which is the real culprit.

## What is your fix for the problem, implemented in this PR?

This PR fixes the issue by:

* Always passing the current Ruby version explicitly to the resolver, so that errors always include that.
* Customizing Molinillo's error building logic to not mention the `Gemfile` at all when the conflict happened with a "metadata" dependency. This requires an extra feature to Molinillo which I will propose separately upstream.

Now the error reads like this

```
Bundler found conflicting requirements for the Ruby version:
  In Gemfile:
    activeadmin was resolved to 2.11.2, which depends on
      Ruby (>= 3.1)

  Current Ruby version:
    Ruby (= 2.7.5)
```
 
## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
