### PR TITLE
Less error swallowing when installing gems

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -285,8 +285,6 @@ class Gem::Installer
 
   def spec
     @package.spec
-  rescue Gem::Package::Error => e
-    raise Gem::InstallError, "invalid gem: #{e.message}"
   end
 
   ##

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1221,15 +1221,13 @@ gem 'other', version
   def test_install_missing_dirs
     installer = setup_base_installer
 
-    FileUtils.rm_f File.join(Gem.dir, 'cache')
-    FileUtils.rm_f File.join(Gem.dir, 'doc')
-    FileUtils.rm_f File.join(Gem.dir, 'specifications')
+    FileUtils.rm_rf File.join(Gem.dir, 'doc')
+    FileUtils.rm_rf File.join(Gem.dir, 'specifications')
 
     use_ui @ui do
       installer.install
     end
 
-    assert_directory_exists File.join(Gem.dir, 'cache')
     assert_directory_exists File.join(Gem.dir, 'doc')
     assert_directory_exists File.join(Gem.dir, 'specifications')
 
@@ -2237,7 +2235,7 @@ gem 'other', version
   def test_default_gem_without_wrappers
     installer = setup_base_installer
 
-    FileUtils.rm_f File.join(Gem.dir, 'specifications')
+    FileUtils.rm_rf File.join(Gem.default_dir, 'specifications')
 
     installer.wrappers = false
     installer.options[:install_as_default] = true


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I'm working on some changes to `fileutils` to not swallow meaningful errors from `FileUtils.rm_f` and `FileUtils.rm_rf` at https://github.com/ruby/fileutils/pull/58.

Trying that PR against RubyGems tests made some errors (mostly likely typos where `FileUtils.rm_f` instead of `FileUtils.rm_rf` was used).

## What is your fix for the problem, implemented in this PR?

Use the proper call so that the folders are actually removed, and fix the issues caused by that.

While debugging those errors, I also removed one `rescue` that felt unnecessary and helped me track down the original culprit of the error.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
