### PR TITLE
Changelogs for rubygems 3.3.12 and bundler 2.3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# 3.3.12 / 2022-04-20
+
+## Enhancements:
+
+* Less error swallowing when installing gems. Pull request #5475 by
+  deivid-rodriguez
+* Stop considering `RUBY_PATCHLEVEL` for resolution. Pull request #5472 by
+  deivid-rodriguez
+* Bump vendored optparse to latest master. Pull request #5466 by
+  deivid-rodriguez
+* Installs bundler 2.3.12 as a default gem.
+
+## Documentation:
+
+* Fix formatting in docs. Pull request #5470 by peterzhu2118
+* Fix a typo. Pull request #5401 by znz
+
 # 3.3.11 / 2022-04-07
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2.3.12 (April 20, 2022)
+
+## Enhancements:
+
+  - Improve Ruby version resolution conflicts [#5474](https://github.com/rubygems/rubygems/pull/5474)
+  - Stop considering `RUBY_PATCHLEVEL` for resolution [#5472](https://github.com/rubygems/rubygems/pull/5472)
+  - Add modern rubies as valid platform values in Gemfile DSL [#5469](https://github.com/rubygems/rubygems/pull/5469)
+
 # 2.3.11 (April 7, 2022)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking change logs from future rubygems 3.3.12 and bundler 2.3.12 into master.