### PR TITLE
Increase timeout when testing RubyGems on Windows and MacOS

### DIFF
--- a/.github/workflows/macos-rubygems.yml
+++ b/.github/workflows/macos-rubygems.yml
@@ -40,4 +40,4 @@ jobs:
         run: rake setup
       - name: Run Test
         run: rake test
-    timeout-minutes: 15
+    timeout-minutes: 20

--- a/.github/workflows/windows-rubygems.yml
+++ b/.github/workflows/windows-rubygems.yml
@@ -63,4 +63,4 @@ jobs:
           rake test
         env:
           BUNDLE_WITHOUT: lint
-    timeout-minutes: 15
+    timeout-minutes: 20


### PR DESCRIPTION


## What was the end-user or developer problem that led to this PR?

Since we added it, this job has been sporadically timing out. See for example https://github.com/rubygems/rubygems/runs/6094008084?check_suite_focus=true.

## What is your fix for the problem, implemented in this PR?

. Given the little frequency when it happens, I guess 5 more minutes is enough.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
