### PR TITLE
Don't include `p` when resolving ruby version

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -866,7 +866,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
     if defined?(RUBY_DESCRIPTION)
       if RUBY_ENGINE == "ruby"
-        desc = RUBY_DESCRIPTION[/\Aruby #{Regexp.quote(RUBY_VERSION)}([^ ]+) /, 1]
+        desc = RUBY_DESCRIPTION[/\Aruby #{Regexp.quote(RUBY_VERSION)}p([^ ]+) /, 1]
       else
         desc = RUBY_DESCRIPTION[/\A#{RUBY_ENGINE} #{Regexp.quote(RUBY_ENGINE_VERSION)} \(#{RUBY_VERSION}([^ ]+)\) /, 1]
       end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

After upgrading to rubygems 3.3.12, we started seeing this error during bundling:
```
Your bundle is locked to our_private_gem (0.1.0) from rubygems repository https://our-private-gemstash or installed locally, but that version can no longer be found in that source. That means the author
of our_private_gem (0.1.0) has removed it. You'll need to update your bundle to a version other than our_private_gem (0.1.0) that hasn't been removed in order to install
```

## What is your fix for the problem, implemented in this PR?

Restore the old `Gem.ruby_version` return value:

On Rubygems `3.3.11`:
```
irb(main):001:0> Gem.ruby_version
=> #<Gem::Version "2.7.5.203">
```

On Rubygems `3.3.12`:
```
irb(main):001:0> Gem.ruby_version
=> #<Gem::Version "2.7.5.p203">
```

It's from this change: https://github.com/rubygems/rubygems/commit/21c145cb232c5266b330d4f6df2c8c635930e23c#diff-dd90140a6483cfb50fbbc3268f0d77984cd96e17792201e53bb3c0dc7ec435f9

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
