### PR TITLE
Fix regression when resolving ruby constraints

### DIFF
--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -542,6 +542,40 @@ RSpec.describe "bundle lock" do
     bundle "lock --add-platform x86_64-linux", :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
   end
 
+  it "respects lower bound ruby requirements" do
+    skip "this spec does not work with prereleases because their version is actually lower than their reported `RUBY_VERSION`" if ruby_core?
+
+    build_repo4 do
+      build_gem "our_private_gem", "0.1.0" do |s|
+        s.required_ruby_version = ">= #{RUBY_VERSION}"
+      end
+    end
+
+    gemfile <<-G
+      source "https://localgemserver.test"
+
+      gem "our_private_gem"
+    G
+
+    lockfile <<-L
+      GEM
+        remote: https://localgemserver.test/
+        specs:
+          our_private_gem (0.1.0)
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        our_private_gem
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+    bundle "install", :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+  end
+
   context "when an update is available" do
     let(:repo) { gem_repo2 }
 

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -864,12 +864,14 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     return @ruby_version if defined? @ruby_version
     version = RUBY_VERSION.dup
 
-    if RUBY_ENGINE == "ruby"
-      desc = RUBY_DESCRIPTION[/\Aruby #{Regexp.quote(RUBY_VERSION)}([^ ]+) /, 1]
-    else
-      desc = RUBY_DESCRIPTION[/\A#{RUBY_ENGINE} #{Regexp.quote(RUBY_ENGINE_VERSION)} \(#{RUBY_VERSION}([^ ]+)\) /, 1]
+    unless defined?(RUBY_PATCHLEVEL) && RUBY_PATCHLEVEL != -1
+      if RUBY_ENGINE == "ruby"
+        desc = RUBY_DESCRIPTION[/\Aruby #{Regexp.quote(RUBY_VERSION)}([^ ]+) /, 1]
+      else
+        desc = RUBY_DESCRIPTION[/\A#{RUBY_ENGINE} #{Regexp.quote(RUBY_ENGINE_VERSION)} \(#{RUBY_VERSION}([^ ]+)\) /, 1]
+      end
+      version << ".#{desc}" if desc
     end
-    version << ".#{desc}" if desc
 
     @ruby_version = Gem::Version.new version
   end

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -864,14 +864,12 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     return @ruby_version if defined? @ruby_version
     version = RUBY_VERSION.dup
 
-    if defined?(RUBY_DESCRIPTION)
-      if RUBY_ENGINE == "ruby"
-        desc = RUBY_DESCRIPTION[/\Aruby #{Regexp.quote(RUBY_VERSION)}([^ ]+) /, 1]
-      else
-        desc = RUBY_DESCRIPTION[/\A#{RUBY_ENGINE} #{Regexp.quote(RUBY_ENGINE_VERSION)} \(#{RUBY_VERSION}([^ ]+)\) /, 1]
-      end
-      version << ".#{desc}" if desc
+    if RUBY_ENGINE == "ruby"
+      desc = RUBY_DESCRIPTION[/\Aruby #{Regexp.quote(RUBY_VERSION)}([^ ]+) /, 1]
+    else
+      desc = RUBY_DESCRIPTION[/\A#{RUBY_ENGINE} #{Regexp.quote(RUBY_ENGINE_VERSION)} \(#{RUBY_VERSION}([^ ]+)\) /, 1]
     end
+    version << ".#{desc}" if desc
 
     @ruby_version = Gem::Version.new version
   end

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -1098,12 +1098,13 @@ Also, a list:
     Zlib::Deflate.deflate data
   end
 
-  def util_set_RUBY_VERSION(version, revision = nil, description = nil, engine = "ruby", engine_version = nil)
+  def util_set_RUBY_VERSION(version, patchlevel = nil, revision = nil, description = nil, engine = "ruby", engine_version = nil)
     if Gem.instance_variables.include? :@ruby_version
       Gem.send :remove_instance_variable, :@ruby_version
     end
 
     @RUBY_VERSION        = RUBY_VERSION
+    @RUBY_PATCHLEVEL     = RUBY_PATCHLEVEL     if defined?(RUBY_PATCHLEVEL)
     @RUBY_REVISION       = RUBY_REVISION       if defined?(RUBY_REVISION)
     @RUBY_DESCRIPTION    = RUBY_DESCRIPTION    if defined?(RUBY_DESCRIPTION)
     @RUBY_ENGINE         = RUBY_ENGINE
@@ -1112,6 +1113,7 @@ Also, a list:
     util_clear_RUBY_VERSION
 
     Object.const_set :RUBY_VERSION,        version
+    Object.const_set :RUBY_PATCHLEVEL,     patchlevel     if patchlevel
     Object.const_set :RUBY_REVISION,       revision       if revision
     Object.const_set :RUBY_DESCRIPTION,    description    if description
     Object.const_set :RUBY_ENGINE,         engine
@@ -1122,6 +1124,8 @@ Also, a list:
     util_clear_RUBY_VERSION
 
     Object.const_set :RUBY_VERSION,        @RUBY_VERSION
+    Object.const_set :RUBY_PATCHLEVEL,     @RUBY_PATCHLEVEL  if
+      defined?(@RUBY_PATCHLEVEL)
     Object.const_set :RUBY_REVISION,       @RUBY_REVISION    if
       defined?(@RUBY_REVISION)
     Object.const_set :RUBY_DESCRIPTION,    @RUBY_DESCRIPTION if
@@ -1133,6 +1137,7 @@ Also, a list:
 
   def util_clear_RUBY_VERSION
     Object.send :remove_const, :RUBY_VERSION
+    Object.send :remove_const, :RUBY_PATCHLEVEL     if defined?(RUBY_PATCHLEVEL)
     Object.send :remove_const, :RUBY_REVISION       if defined?(RUBY_REVISION)
     Object.send :remove_const, :RUBY_DESCRIPTION    if defined?(RUBY_DESCRIPTION)
     Object.send :remove_const, :RUBY_ENGINE

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -1098,7 +1098,7 @@ Also, a list:
     Zlib::Deflate.deflate data
   end
 
-  def util_set_RUBY_VERSION(version, patchlevel = nil, revision = nil, description = nil, engine = "ruby", engine_version = nil)
+  def util_set_RUBY_VERSION(version, patchlevel, revision, description, engine = "ruby", engine_version = nil)
     if Gem.instance_variables.include? :@ruby_version
       Gem.send :remove_instance_variable, :@ruby_version
     end
@@ -1106,16 +1106,16 @@ Also, a list:
     @RUBY_VERSION        = RUBY_VERSION
     @RUBY_PATCHLEVEL     = RUBY_PATCHLEVEL     if defined?(RUBY_PATCHLEVEL)
     @RUBY_REVISION       = RUBY_REVISION       if defined?(RUBY_REVISION)
-    @RUBY_DESCRIPTION    = RUBY_DESCRIPTION    if defined?(RUBY_DESCRIPTION)
+    @RUBY_DESCRIPTION    = RUBY_DESCRIPTION
     @RUBY_ENGINE         = RUBY_ENGINE
     @RUBY_ENGINE_VERSION = RUBY_ENGINE_VERSION if defined?(RUBY_ENGINE_VERSION)
 
     util_clear_RUBY_VERSION
 
     Object.const_set :RUBY_VERSION,        version
-    Object.const_set :RUBY_PATCHLEVEL,     patchlevel     if patchlevel
-    Object.const_set :RUBY_REVISION,       revision       if revision
-    Object.const_set :RUBY_DESCRIPTION,    description    if description
+    Object.const_set :RUBY_PATCHLEVEL,     patchlevel
+    Object.const_set :RUBY_REVISION,       revision
+    Object.const_set :RUBY_DESCRIPTION,    description
     Object.const_set :RUBY_ENGINE,         engine
     Object.const_set :RUBY_ENGINE_VERSION, engine_version if engine_version
   end
@@ -1128,8 +1128,7 @@ Also, a list:
       defined?(@RUBY_PATCHLEVEL)
     Object.const_set :RUBY_REVISION,       @RUBY_REVISION    if
       defined?(@RUBY_REVISION)
-    Object.const_set :RUBY_DESCRIPTION,    @RUBY_DESCRIPTION if
-      defined?(@RUBY_DESCRIPTION)
+    Object.const_set :RUBY_DESCRIPTION,    @RUBY_DESCRIPTION
     Object.const_set :RUBY_ENGINE,         @RUBY_ENGINE
     Object.const_set :RUBY_ENGINE_VERSION, @RUBY_ENGINE_VERSION if
       defined?(@RUBY_ENGINE_VERSION)

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1106,14 +1106,6 @@ class TestGem < Gem::TestCase
     assert_equal Gem::Requirement.default, Gem.env_requirement('qux')
   end
 
-  def test_self_ruby_version_with_patchlevel_less_ancient_rubies
-    util_set_RUBY_VERSION '1.8.5'
-
-    assert_equal Gem::Version.new('1.8.5'), Gem.ruby_version
-  ensure
-    util_restore_RUBY_VERSION
-  end
-
   def test_self_ruby_version_with_non_mri_implementations
     util_set_RUBY_VERSION '2.5.0', 0, 60928, 'jruby 9.2.0.0 (2.5.0) 2018-05-24 81156a8 OpenJDK 64-Bit Server VM 25.171-b11 on 1.8.0_171-8u171-b11-0ubuntu0.16.04.1-b11 [linux-x86_64]'
 

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1115,7 +1115,7 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_ruby_version_with_non_mri_implementations
-    util_set_RUBY_VERSION '2.5.0', 60928, 'jruby 9.2.0.0 (2.5.0) 2018-05-24 81156a8 OpenJDK 64-Bit Server VM 25.171-b11 on 1.8.0_171-8u171-b11-0ubuntu0.16.04.1-b11 [linux-x86_64]'
+    util_set_RUBY_VERSION '2.5.0', 0, 60928, 'jruby 9.2.0.0 (2.5.0) 2018-05-24 81156a8 OpenJDK 64-Bit Server VM 25.171-b11 on 1.8.0_171-8u171-b11-0ubuntu0.16.04.1-b11 [linux-x86_64]'
 
     assert_equal Gem::Version.new('2.5.0'), Gem.ruby_version
   ensure
@@ -1123,7 +1123,7 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_ruby_version_with_svn_prerelease
-    util_set_RUBY_VERSION '2.6.0', 63539, 'ruby 2.6.0preview2 (2018-05-31 trunk 63539) [x86_64-linux]'
+    util_set_RUBY_VERSION '2.6.0', -1, 63539, 'ruby 2.6.0preview2 (2018-05-31 trunk 63539) [x86_64-linux]'
 
     assert_equal Gem::Version.new('2.6.0.preview2'), Gem.ruby_version
   ensure
@@ -1131,7 +1131,7 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_ruby_version_with_git_prerelease
-    util_set_RUBY_VERSION '2.7.0', 'b563439274a402e33541f5695b1bfd4ac1085638', 'ruby 2.7.0preview3 (2019-11-23 master b563439274) [x86_64-linux]'
+    util_set_RUBY_VERSION '2.7.0', -1, 'b563439274a402e33541f5695b1bfd4ac1085638', 'ruby 2.7.0preview3 (2019-11-23 master b563439274) [x86_64-linux]'
 
     assert_equal Gem::Version.new('2.7.0.preview3'), Gem.ruby_version
   ensure
@@ -1139,7 +1139,7 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_ruby_version_with_non_mri_implementations_with_mri_prerelase_compatibility
-    util_set_RUBY_VERSION '2.6.0', 63539, 'weirdjruby 9.2.0.0 (2.6.0preview2) 2018-05-24 81156a8 OpenJDK 64-Bit Server VM 25.171-b11 on 1.8.0_171-8u171-b11-0ubuntu0.16.04.1-b11 [linux-x86_64]', 'weirdjruby', '9.2.0.0'
+    util_set_RUBY_VERSION '2.6.0', -1, 63539, 'weirdjruby 9.2.0.0 (2.6.0preview2) 2018-05-24 81156a8 OpenJDK 64-Bit Server VM 25.171-b11 on 1.8.0_171-8u171-b11-0ubuntu0.16.04.1-b11 [linux-x86_64]', 'weirdjruby', '9.2.0.0'
 
     assert_equal Gem::Version.new('2.6.0.preview2'), Gem.ruby_version
   ensure
@@ -1147,7 +1147,7 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_ruby_version_with_svn_trunk
-    util_set_RUBY_VERSION '1.9.2', 23493, 'ruby 1.9.2dev (2009-05-20 trunk 23493) [x86_64-linux]'
+    util_set_RUBY_VERSION '1.9.2', -1, 23493, 'ruby 1.9.2dev (2009-05-20 trunk 23493) [x86_64-linux]'
 
     assert_equal Gem::Version.new('1.9.2.dev'), Gem.ruby_version
   ensure
@@ -1155,7 +1155,7 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_ruby_version_with_git_master
-    util_set_RUBY_VERSION '2.7.0', '5de284ec78220e75643f89b454ce999da0c1c195', 'ruby 2.7.0dev (2019-12-23T01:37:30Z master 5de284ec78) [x86_64-linux]'
+    util_set_RUBY_VERSION '2.7.0', -1, '5de284ec78220e75643f89b454ce999da0c1c195', 'ruby 2.7.0dev (2019-12-23T01:37:30Z master 5de284ec78) [x86_64-linux]'
 
     assert_equal Gem::Version.new('2.7.0.dev'), Gem.ruby_version
   ensure


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In #5473, we stopped using patch levels for resolution, since they are no longer meaningful in any way. However, I failed to remove patch level from `Gem.ruby_version` and to make things worse, I made it report it preceded with the "p" character, tripping RubyGems into thinking they were prereleases :(

## What is your fix for the problem, implemented in this PR?

My fix is to properly remove the patch level segment from `Gem.ruby_version`.

Closes #5485.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
