### PR TITLE
Enabled auto-update cargo dependencies by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,11 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+  - package-ecosystem: 'cargo'
+    directory: '/test/rubygems/test_gem_ext_cargo_builder/custom_name/'
+    schedule:
+      interval: 'weekly'
+  - package-ecosystem: 'cargo'
+    directory: '/test/rubygems/test_gem_ext_cargo_builder/rust_ruby_example/'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

followed up https://github.com/rubygems/rubygems/pull/5477

## What is your fix for the problem, implemented in this PR?

We can update cargo depends by dependabot.

I also try to add under the `bundler/tool/bundler`. But `dependabot-core` supports only `Gemfile`, `.gemspec` and `gems.rb`. 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
