### PR TITLE
Fix check for missing spec in check_for_unmet_dependencies

### DIFF
--- a/bundler/lib/bundler/installer/parallel_installer.rb
+++ b/bundler/lib/bundler/installer/parallel_installer.rb
@@ -121,7 +121,12 @@ module Bundler
 
       unmet_dependencies.each do |spec, unmet_spec_dependencies|
         unmet_spec_dependencies.each do |unmet_spec_dependency|
-          warning << "* #{unmet_spec_dependency}, depended upon #{spec.full_name}, unsatisfied by #{@specs.find {|s| s.name == unmet_spec_dependency.name && !unmet_spec_dependency.matches_spec?(s.spec) }.full_name}"
+          existing_spec_with_violation = @specs.find {|s| s.name == unmet_spec_dependency.name && !unmet_spec_dependency.matches_spec?(s.spec) }
+
+          warning_message = "* #{unmet_spec_dependency}, depended upon #{spec.full_name}"
+          warning_message += existing_spec_with_violation ? ", unsatisfied by #{existing_spec_with_violation.full_name}" : ", #{unmet_spec_dependency.name} missing in lockfile"
+
+          warning << warning_message
         end
       end
 

--- a/bundler/spec/bundler/installer/parallel_installer_spec.rb
+++ b/bundler/spec/bundler/installer/parallel_installer_spec.rb
@@ -26,6 +26,14 @@ The missing gems are:
 * a depended upon by alpha
       W
       subject.check_for_corrupt_lockfile
+
+      expect(Bundler.ui).to receive(:warn).with(<<-W.strip)
+Your lockfile doesn't include a valid resolution.
+You can fix this by regenerating your lockfile or trying to manually editing the bad locked gems to a version that satisfies all dependencies.
+The unmet dependencies are:
+* a (= 1), depended upon alpha-1.0, a missing in lockfile
+      W
+      subject.check_for_unmet_dependencies
     end
 
     context "when size > 1" do


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

See #5422

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

Add a check that catches the condition and handles it properly, see https://github.com/rubygems/rubygems/issues/5422#issuecomment-1106434053

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
