### PR TITLE
Raise if ruby platform is forced and there are no ruby variants

### DIFF
--- a/bundler/lib/bundler/index.rb
+++ b/bundler/lib/bundler/index.rb
@@ -192,11 +192,7 @@ module Bundler
         specs += base if base
         found = specs.select do |spec|
           next true if spec.source.is_a?(Source::Gemspec)
-          if base # allow all platforms when searching from a lockfile
-            dependency.matches_spec?(spec)
-          else
-            dependency.matches_spec?(spec) && Gem::Platform.match_spec?(spec)
-          end
+          dependency.matches_spec?(spec)
         end
 
         found

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -84,7 +84,7 @@ module Bundler
         else
           ruby_platform_materializes_to_ruby_platform? ? self : Dependency.new(name, version)
         end
-        platform_object = Gem::Platform.new(platform)
+        platform_object = ruby_platform_materializes_to_ruby_platform? ? Gem::Platform.new(platform) : Gem::Platform.local
         candidates = source.specs.search(search_object)
         same_platform_candidates = candidates.select do |spec|
           MatchPlatform.platforms_match?(spec.platform, platform_object)
@@ -152,7 +152,7 @@ module Bundler
     # explicitly add a more specific platform.
     #
     def ruby_platform_materializes_to_ruby_platform?
-      !Bundler.most_specific_locked_platform?(Gem::Platform::RUBY) || Bundler.settings[:force_ruby_platform]
+      !Bundler.most_specific_locked_platform?(generic_local_platform) || Bundler.settings[:force_ruby_platform]
     end
   end
 end

--- a/bundler/lib/bundler/match_platform.rb
+++ b/bundler/lib/bundler/match_platform.rb
@@ -15,7 +15,6 @@ module Bundler
       return true if Gem::Platform::RUBY == gemspec_platform
       return true if local_platform == gemspec_platform
       gemspec_platform = Gem::Platform.new(gemspec_platform)
-      return true if GemHelpers.generic(gemspec_platform) === local_platform
       return true if gemspec_platform === local_platform
 
       false

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -284,7 +284,7 @@ module Bundler
       if specs_matching_requirement.any?
         specs = specs_matching_requirement
         matching_part = requirement_label
-        requirement_label = "#{requirement_label} #{requirement.__platform}"
+        requirement_label = "#{requirement_label}' with platform '#{requirement.__platform}"
       end
 
       message = String.new("Could not find gem '#{requirement_label}'#{extra_message} in #{source}#{cache_message}.\n")

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -174,11 +174,12 @@ module Bundler
     end
 
     def specs_for_dependency(dep, match_current_platform)
-      specs_for_platforms = lookup[dep.name]
+      specs_for_name = lookup[dep.name]
       if match_current_platform
-        GemHelpers.select_best_platform_match(specs_for_platforms.select {|s| Gem::Platform.match_spec?(s) }, Bundler.local_platform)
+        GemHelpers.select_best_platform_match(specs_for_name.select {|s| Gem::Platform.match_spec?(s) }, Bundler.local_platform)
       else
-        GemHelpers.select_best_platform_match(specs_for_platforms, dep.__platform)
+        specs_for_name_and_platform = GemHelpers.select_best_platform_match(specs_for_name, dep.__platform)
+        specs_for_name_and_platform.any? ? specs_for_name_and_platform : specs_for_name
       end
     end
 

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -24,7 +24,7 @@ module Bundler
         # use a hash here to ensure constant lookup time in the `any?` call above
         handled[dep.name] << dep
 
-        specs_for_dep = spec_for_dependency(dep, match_current_platform)
+        specs_for_dep = specs_for_dependency(dep, match_current_platform)
         if specs_for_dep.any?
           specs.concat(specs_for_dep)
 
@@ -173,7 +173,7 @@ module Bundler
       @specs.sort_by(&:name).each {|s| yield s }
     end
 
-    def spec_for_dependency(dep, match_current_platform)
+    def specs_for_dependency(dep, match_current_platform)
       specs_for_platforms = lookup[dep.name]
       if match_current_platform
         GemHelpers.select_best_platform_match(specs_for_platforms.select {|s| Gem::Platform.match_spec?(s) }, Bundler.local_platform)

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -295,7 +295,7 @@ RSpec.describe "bundle install with specific platforms" do
     G
 
     error_message = <<~ERROR.strip
-      Could not find gem 'sorbet-static (= 0.5.6433) arm64-darwin-21' in rubygems repository #{file_uri_for(gem_repo2)}/ or installed locally.
+      Could not find gem 'sorbet-static (= 0.5.6433)' with platform 'arm64-darwin-21' in rubygems repository #{file_uri_for(gem_repo2)}/ or installed locally.
 
       The source contains the following gems matching 'sorbet-static (= 0.5.6433)':
         * sorbet-static-0.5.6433-universal-darwin-20
@@ -331,7 +331,7 @@ RSpec.describe "bundle install with specific platforms" do
     G
 
     error_message = <<~ERROR.strip
-      Could not find gem 'sorbet-static (= 0.5.6433) arm64-darwin-21', which is required by gem 'sorbet (= 0.5.6433)', in rubygems repository #{file_uri_for(gem_repo2)}/ or installed locally.
+      Could not find gem 'sorbet-static (= 0.5.6433)' with platform 'arm64-darwin-21', which is required by gem 'sorbet (= 0.5.6433)', in rubygems repository #{file_uri_for(gem_repo2)}/ or installed locally.
 
       The source contains the following gems matching 'sorbet-static (= 0.5.6433)':
         * sorbet-static-0.5.6433-universal-darwin-20

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -283,19 +283,19 @@ RSpec.describe "bundle install with specific platforms" do
   end
 
   it "does not resolve if the current platform does not match any of available platform specific variants for a top level dependency" do
-    build_repo2 do
+    build_repo4 do
       build_gem("sorbet-static", "0.5.6433") {|s| s.platform = "x86_64-linux" }
       build_gem("sorbet-static", "0.5.6433") {|s| s.platform = "universal-darwin-20" }
     end
 
     gemfile <<~G
-      source "#{file_uri_for(gem_repo2)}"
+      source "#{file_uri_for(gem_repo4)}"
 
       gem "sorbet-static", "0.5.6433"
     G
 
     error_message = <<~ERROR.strip
-      Could not find gem 'sorbet-static (= 0.5.6433)' with platform 'arm64-darwin-21' in rubygems repository #{file_uri_for(gem_repo2)}/ or installed locally.
+      Could not find gem 'sorbet-static (= 0.5.6433)' with platform 'arm64-darwin-21' in rubygems repository #{file_uri_for(gem_repo4)}/ or installed locally.
 
       The source contains the following gems matching 'sorbet-static (= 0.5.6433)':
         * sorbet-static-0.5.6433-universal-darwin-20
@@ -318,20 +318,20 @@ RSpec.describe "bundle install with specific platforms" do
   end
 
   it "does not resolve if the current platform does not match any of available platform specific variants for a transitive dependency" do
-    build_repo2 do
+    build_repo4 do
       build_gem("sorbet", "0.5.6433") {|s| s.add_dependency "sorbet-static", "= 0.5.6433" }
       build_gem("sorbet-static", "0.5.6433") {|s| s.platform = "x86_64-linux" }
       build_gem("sorbet-static", "0.5.6433") {|s| s.platform = "universal-darwin-20" }
     end
 
     gemfile <<~G
-      source "#{file_uri_for(gem_repo2)}"
+      source "#{file_uri_for(gem_repo4)}"
 
       gem "sorbet", "0.5.6433"
     G
 
     error_message = <<~ERROR.strip
-      Could not find gem 'sorbet-static (= 0.5.6433)' with platform 'arm64-darwin-21', which is required by gem 'sorbet (= 0.5.6433)', in rubygems repository #{file_uri_for(gem_repo2)}/ or installed locally.
+      Could not find gem 'sorbet-static (= 0.5.6433)' with platform 'arm64-darwin-21', which is required by gem 'sorbet (= 0.5.6433)', in rubygems repository #{file_uri_for(gem_repo4)}/ or installed locally.
 
       The source contains the following gems matching 'sorbet-static (= 0.5.6433)':
         * sorbet-static-0.5.6433-universal-darwin-20

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -303,7 +303,7 @@ RSpec.describe "bundle install with specific platforms" do
     ERROR
 
     simulate_platform "arm64-darwin-21" do
-      bundle "install", :raise_on_error => false
+      bundle "lock", :raise_on_error => false
     end
 
     expect(err).to include(error_message).once
@@ -311,7 +311,7 @@ RSpec.describe "bundle install with specific platforms" do
     # Make sure it doesn't print error twice in verbose mode
 
     simulate_platform "arm64-darwin-21" do
-      bundle "install --verbose", :raise_on_error => false
+      bundle "lock --verbose", :raise_on_error => false
     end
 
     expect(err).to include(error_message).once
@@ -339,7 +339,7 @@ RSpec.describe "bundle install with specific platforms" do
     ERROR
 
     simulate_platform "arm64-darwin-21" do
-      bundle "install", :raise_on_error => false
+      bundle "lock", :raise_on_error => false
     end
 
     expect(err).to include(error_message).once
@@ -347,7 +347,7 @@ RSpec.describe "bundle install with specific platforms" do
     # Make sure it doesn't print error twice in verbose mode
 
     simulate_platform "arm64-darwin-21" do
-      bundle "install --verbose", :raise_on_error => false
+      bundle "lock --verbose", :raise_on_error => false
     end
 
     expect(err).to include(error_message).once


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We have been reported a case where Bundler generates a lockfile when using `force_ruby_platform` that then makes Bundler crash when run on a different platform.

The case was reported by @Stex here: https://github.com/rubygems/rubygems/issues/5422#issuecomment-1106472389.

When using `force_ruby_platform` on a `Gemfile` like this:

```ruby
source "https://rubygems.org"

gem "sorbet", "0.5.9889"
```

the following `Gemfile.lock`file is generated

```

GEM
  remote: https://rubygems.org/
  specs:
    sorbet (0.5.9889)
      sorbet-static (= 0.5.9889)
    sorbet-static (0.5.9889-universal-darwin-14)
    sorbet-static (0.5.9889-universal-darwin-15)
    sorbet-static (0.5.9889-universal-darwin-16)
    sorbet-static (0.5.9889-universal-darwin-17)
    sorbet-static (0.5.9889-universal-darwin-18)
    sorbet-static (0.5.9889-universal-darwin-19)
    sorbet-static (0.5.9889-universal-darwin-20)
    sorbet-static (0.5.9889-universal-darwin-21)
    sorbet-static (0.5.9889-x86_64-linux)

PLATFORMS
  ruby

DEPENDENCIES
  sorbet (= 0.5.9889)

BUNDLED WITH
   2.3.12
```

And using that lockfile under a M1 docker container (which has platform "aarch64-linux") leads to a crash because no compatible gem can be found for that arch.

Closes #5422.

## What is your fix for the problem, implemented in this PR?

We should give a better error message when dealing with this `Gemfile.lock` file anyways, but in my opinion, the above lockfile should not be generated at all because the user is explicitly saying "I don't want platform specific gems" by specifying `force_ruby_platform`, and sorbet-static can't satisfy that.

I prepared a patch to implement the above and  was really happy because it seemed to work well and it led to removing this line:

https://github.com/rubygems/rubygems/blob/2faada63ae65d8559bcba9e083f3c35ba6c18fdc/bundler/lib/bundler/match_platform.rb#L18

Which was the specific line giving @lloeki issues when trying to add non gnu libc support at https://github.com/rubygems/rubygems/pull/4488, so this could also unblock that.

However... It does not work on truffleruby because... truffleruby needs its own special behaviour that it's hard to support. In particular, truffleruby [declares its own platform as `ruby`](https://github.com/oracle/truffleruby/blob/75d3da3737ff43c906086aaaf349b09360b10bda/lib/truffle/rubygems/defaults/truffleruby.rb#L23) (like `force_ruby_platform` does) because it's ABI incompatible with CRuby, so it doesn't want platform specific gems installed. However, [it also keeps a hardcoded list of gem names](https://github.com/oracle/truffleruby/blob/e85be2a98a5f26972c7d60739d35b659134e1ae9/lib/mri/rubygems/platform.rb#L38-L47) where platform specific gems apparently work, and it's supposed to actually install platform specific gems in those cases.

I will investigate how to keep truffleruby working fine and still be able to introduce this, but I'm opening a WIP PR for now because I'm not sure when I'll get to it.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
