### PR TITLE
Fix missing required rubygems version when using old APIs

### DIFF
--- a/bundler/lib/bundler/endpoint_specification.rb
+++ b/bundler/lib/bundler/endpoint_specification.rb
@@ -26,8 +26,11 @@ module Bundler
       @required_ruby_version ||= _remote_specification.required_ruby_version
     end
 
+    # A fallback is included because the original version of the specification
+    # API didn't include that field, so some marshalled specs in the index have it
+    # set to +nil+.
     def required_rubygems_version
-      @required_rubygems_version ||= _remote_specification.required_rubygems_version
+      @required_rubygems_version ||= _remote_specification.required_rubygems_version || Gem::Requirement.default
     end
 
     def fetch_platform


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

A while ago, we fixed resolution when using old dependency endpoints to also consider metadata dependencies, by requesting the full gemspec from the marsahaled index, which includes this information as opposed to these old APIs. This has made resolution slower, but correct, but also introduced the issue that some old marshaled gemspecs don't include the `required_rubygems_version` field because they were created with a RubyGems version that predates its addition.

## What is your fix for the problem, implemented in this PR?

Use a default value in this case.

Fixes #5492.
Fixes #5446.
Closes #5447.
 
## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
