### PR TITLE
Clarify description of owner-flags

### DIFF
--- a/lib/rubygems/commands/owner_command.rb
+++ b/lib/rubygems/commands/owner_command.rb
@@ -15,6 +15,10 @@ The owner command lets you add and remove owners of a gem on a push
 server (the default is https://rubygems.org). Multiple owners can be
 added or removed at the same time, if the flag is given multiple times.
 
+The supported user identifiers are dependant on the push server.
+For rubygems.org, both e-mail and handle are supported, even though the
+user identifier field is called "email".
+
 The owner of a gem has the permission to push new versions, yank existing
 versions or edit the HTML page of the gem.  Be careful of who you give push
 permission to.
@@ -36,11 +40,11 @@ permission to.
     add_otp_option
     defaults.merge! :add => [], :remove => []
 
-    add_option '-a', '--add NEW_OWNER', 'Add an owner by email or handle' do |value, options|
+    add_option '-a', '--add NEW_OWNER', 'Add an owner by user identifier' do |value, options|
       options[:add] << value
     end
 
-    add_option '-r', '--remove OLD_OWNER', 'Remove an owner by email or handle' do |value, options|
+    add_option '-r', '--remove OLD_OWNER', 'Remove an owner by user identifier' do |value, options|
       options[:remove] << value
     end
 

--- a/lib/rubygems/commands/owner_command.rb
+++ b/lib/rubygems/commands/owner_command.rb
@@ -12,7 +12,8 @@ class Gem::Commands::OwnerCommand < Gem::Command
   def description # :nodoc:
     <<-EOF
 The owner command lets you add and remove owners of a gem on a push
-server (the default is https://rubygems.org).
+server (the default is https://rubygems.org). Multiple owners can be
+added or removed at the same time, if the flag is given multiple times.
 
 The owner of a gem has the permission to push new versions, yank existing
 versions or edit the HTML page of the gem.  Be careful of who you give push
@@ -35,11 +36,11 @@ permission to.
     add_otp_option
     defaults.merge! :add => [], :remove => []
 
-    add_option '-a', '--add EMAIL', 'Add an owner' do |value, options|
+    add_option '-a', '--add NEW_OWNER', 'Add an owner by email or handle' do |value, options|
       options[:add] << value
     end
 
-    add_option '-r', '--remove EMAIL', 'Remove an owner' do |value, options|
+    add_option '-r', '--remove OLD_OWNER', 'Remove an owner by email or handle' do |value, options|
       options[:remove] << value
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I wanted to add a coworker as owner to a gem and was confused by the help-output. In the end, I tried to add the new owner by rubygems-handle and it worked. The docs and description only mention using an e-mail address.

I remember that other experienced developers also confused that and were asking for e-mails when the handle would have been sufficient.

## What is your fix for the problem, implemented in this PR?

I changed the help-output to clarify what is accepted as argument to the respective flags. I did not write tests because the behavior has not been changed.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
