### PR TITLE
replace git.io link

### DIFF
--- a/lib/rubygems/text.rb
+++ b/lib/rubygems/text.rb
@@ -51,7 +51,7 @@ module Gem::Text
 
   # Returns a value representing the "cost" of transforming str1 into str2
   # Vendored version of DidYouMean::Levenshtein.distance from the ruby/did_you_mean gem @ 1.4.0
-  # https://git.io/JJgZI
+  # https://github.com/ruby/did_you_mean/blob/2ddf39b874808685965dbc47d344cf6c7651807c/lib/did_you_mean/levenshtein.rb#L7-L37
   def levenshtein_distance(str1, str2)
     n = str1.length
     m = str2.length


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Included a link to git.io, which is being deprecated.
https://github.blog/changelog/2022-04-25-git-io-deprecation/

## What is your fix for the problem, implemented in this PR?

Replaced git.io link with redirect to.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)