### PR TITLE
Speed up `bundler/setup` time

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -680,13 +680,10 @@ module Bundler
     end
 
     def converge_specs(specs)
-      deps = []
       converged = []
 
-      @dependencies.each do |dep|
-        if specs[dep].any? {|s| s.satisfies?(dep) && (!dep.source || s.source.include?(dep.source)) }
-          deps << dep
-        end
+      deps = @dependencies.select do |dep|
+        specs[dep].any? {|s| s.satisfies?(dep) && (!dep.source || s.source.include?(dep.source)) }
       end
 
       specs.each do |s|

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -256,14 +256,14 @@ module Bundler
     # @return [SpecSet] resolved dependencies
     def resolve
       @resolve ||= begin
-        last_resolve = converge_locked_specs
         if Bundler.frozen_bundle?
           Bundler.ui.debug "Frozen, using resolution from the lockfile"
-          last_resolve
+          @locked_specs
         elsif !unlocking? && nothing_changed?
           Bundler.ui.debug("Found no changes, using resolution from the lockfile")
-          last_resolve
+          converge_locked_specs
         else
+          last_resolve = converge_locked_specs
           # Run a resolve against the locally available gems
           Bundler.ui.debug("Found changes from the lockfile, re-resolving dependencies because #{change_reason}")
           expanded_dependencies = expand_dependencies(dependencies + metadata_dependencies, true)
@@ -693,7 +693,7 @@ module Bundler
         # Replace the locked dependency's source with the equivalent source from the Gemfile
         dep = @dependencies.find {|d| s.satisfies?(d) }
 
-        s.source = (dep && dep.source) || sources.get(s.source) || sources.default_source unless Bundler.frozen_bundle?
+        s.source = (dep && dep.source) || sources.get(s.source) || sources.default_source
 
         next if @unlock[:sources].include?(s.source.name)
 

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -261,7 +261,7 @@ module Bundler
           @locked_specs
         elsif !unlocking? && nothing_changed?
           Bundler.ui.debug("Found no changes, using resolution from the lockfile")
-          converge_locked_specs
+          SpecSet.new(filter_specs(@locked_specs, @dependencies.select{|dep| @locked_specs[dep].any? }))
         else
           last_resolve = converge_locked_specs
           # Run a resolve against the locally available gems
@@ -464,6 +464,10 @@ module Bundler
     end
 
     private
+
+    def filter_specs(specs, deps)
+      SpecSet.new(specs).for(expand_dependencies(deps, true), false, false)
+    end
 
     def materialize(dependencies)
       specs = resolve.materialize(dependencies)
@@ -727,8 +731,7 @@ module Bundler
         end
       end
 
-      resolve = SpecSet.new(converged)
-      SpecSet.new(resolve.for(expand_dependencies(deps, true), false, false).reject{|s| @unlock[:gems].include?(s.name) })
+      SpecSet.new(filter_specs(converged, deps).reject{|s| @unlock[:gems].include?(s.name) })
     end
 
     def metadata_dependencies

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -216,7 +216,7 @@ RSpec.describe "bundle install across platforms" do
         pry
 
       BUNDLED WITH
-        #{Bundler::VERSION}
+         #{Bundler::VERSION}
     L
 
     aggregate_failures do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We should make `bundler/setup` as fast as possible.

## What is your fix for the problem, implemented in this PR?

Avoid unnecessary work of figuring out which specs should be kept locked from the lockfile and which ones should be discarded for resolving, whenever possible (in frozen mode, or when no changes detected).

This speeds up `bundler/setup` time of `rails/rails` Gemfile on my machine by about 30%.

```
✗ hyperfine 'BUNDLER_VERSION=2.3.12 ruby -rbundler/setup -e1' 'BUNDLER_VERSION=2.4.0.dev ruby -rbundler/setup -e1'
Benchmark 1: BUNDLER_VERSION=2.3.12 ruby -rbundler/setup -e1
  Time (mean ± σ):     368.9 ms ±  10.7 ms    [User: 309.4 ms, System: 46.9 ms]
  Range (min … max):   360.4 ms … 395.4 ms    10 runs
 
Benchmark 2: BUNDLER_VERSION=2.4.0.dev ruby -rbundler/setup -e1
  Time (mean ± σ):     267.3 ms ±   3.2 ms    [User: 212.3 ms, System: 44.8 ms]
  Range (min … max):   263.9 ms … 272.1 ms    10 runs
 
Summary
  'BUNDLER_VERSION=2.4.0.dev ruby -rbundler/setup -e1' ran
    1.38 ± 0.04 times faster than 'BUNDLER_VERSION=2.3.12 ruby -rbundler/setup -e1'
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
