### PR TITLE
Skip cargo test on ruby core repo

### DIFF
--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -1188,6 +1188,14 @@ Also, a list:
   end
 
   ##
+  # Is this test being run on a ruby/ruby repository?
+  #
+
+  def testing_ruby_repo?
+    !ENV["GEM_COMMAND"].nil?
+  end
+
+  ##
   # Returns the make command for the current platform. For versions of Ruby
   # built on MS Windows with VC++ or Borland it will return 'nmake'. On all
   # other platforms, including Cygwin, it will return 'make'.

--- a/test/rubygems/test_gem_ext_cargo_builder.rb
+++ b/test/rubygems/test_gem_ext_cargo_builder.rb
@@ -142,5 +142,6 @@ class TestGemExtCargoBuilder < Gem::TestCase
     pend "jruby not supported" if java_platform?
     pend "truffleruby not supported (yet)" if RUBY_ENGINE == 'truffleruby'
     pend "mswin not supported (yet)" if /mswin/ =~ RUBY_PLATFORM && ENV.key?('GITHUB_ACTIONS')
+    pend "ruby.h is not provided by ruby repo" if testing_ruby_repo?
   end
 end

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -671,10 +671,6 @@ class TestGemRequire < Gem::TestCase
 
   private
 
-  def testing_ruby_repo?
-    !ENV["GEM_COMMAND"].nil?
-  end
-
   def util_install_extension_file(name)
     spec = quick_gem name
     util_build_gem spec


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The current cargo builder tests are not working with ruby core repo. Because the test suite of ruby core is not provide `ruby.h` header same as installation environment. 

It blocked merging the latest HEAD to ruby/ruby repo. I'll prioritize merging them before completely support it.

## What is your fix for the problem, implemented in this PR?

Skip tests related cargo builder in ruby/ruby repo.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
