### PR TITLE
Changelogs for rubygems 3.3.13 and bundler 2.3.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 3.3.13 / 2022-05-04
+
+## Enhancements:
+
+* Installs bundler 2.3.13 as a default gem.
+
+## Bug fixes:
+
+* Fix regression when resolving ruby constraints. Pull request #5486 by
+  deivid-rodriguez
+
+## Documentation:
+
+* Clarify description of owner-flags. Pull request #5497 by kronn
+
 # 3.3.12 / 2022-04-20
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 2.3.13 (May 4, 2022)
+
+## Bug fixes:
+
+  - Fix missing required rubygems version when using old APIs [#5496](https://github.com/rubygems/rubygems/pull/5496)
+  - Fix crash when gem used twice in Gemfile under different platforms [#5187](https://github.com/rubygems/rubygems/pull/5187)
+
+## Performance:
+
+  - Speed up `bundler/setup` time [#5503](https://github.com/rubygems/rubygems/pull/5503)
+
 # 2.3.12 (April 20, 2022)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking change logs from future rubygems 3.3.13 and bundler 2.3.13 into master.
