### PR TITLE
Update bundler changelog to indicate breaking change

### DIFF
--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -61,6 +61,10 @@
 
 # 2.3.7 (February 9, 2022)
 
+## Breaking changes:
+
+  - Change default scope of `bundle config` inside an application from global to local [#4152](https://github.com/rubygems/rubygems/pull/4152)
+
 ## Enhancements:
 
   - Don't activate `yaml` gem from Bundler [#5277](https://github.com/rubygems/rubygems/pull/5277)
@@ -69,7 +73,6 @@
 ## Bug fixes:
 
   - Don't silently persist `BUNDLE_WITH` and `BUNDLE_WITHOUT` envs locally [#5335](https://github.com/rubygems/rubygems/pull/5335)
-  - Fix `bundle config` inside an application saving configuration globally [#4152](https://github.com/rubygems/rubygems/pull/4152)
 
 # 2.3.6 (January 26, 2022)
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

My company's application infrastructure has happened to work this way for two years:

1. Our applications start with a base docker image that installs `bundler`
2. The apps' Dockerfiles, which build the image they use in production, typically included a RUN step like this one:
`BUNDLE_WITHOUT=development:test bundle install`
3. Then, their docker-compose.yml which builds images for development environments started from that image and added an entrypoint script that ran:
`bundle config --delete without ; bundle install`

Admittedly it was a odd of us to set "without" using an env var in step 2 and the recommended method in step 3. Essentially the discrepancy was because these commands happened in different repos controlled by different teams. We had originally been using `bundle install --without` but when that was deprecated, we changed it to the env-var version in 2020. Using that particular  env var was an option that the [docs](https://bundler.io/v2.1/man/bundle-config.1.html#CONFIGURATION-KEYS) still suggest. (Side note, it might be worth updating that section of the manpage re this deprecation, but in any case, this style is officially supported until 3.x.)

Last month, we looked over the changelog for the 2.3.x series and updated `bundler` in step 1 from 2.2.29 to 2.3.11. Our development environments broke because starting with 2.3.7 [this change](https://github.com/rubygems/rubygems/pull/4152) was merged.

I approve of that change, it makes sense, but it was a breaking change for us.

The env-var command in step 2 above continued to set its config option globally, while the `bundle config --delete` in step 3 changed to only delete a local config option (which did not exist). Thus our development environments still saw the global "without" and didn't include the gems in those two groups.

This wasn't a huge bug and it only took us a few hours to find and fix. But 2.3.7 did change behavior in a way that broke our applications. It would have saved us a bit of time if there were a note in the changelog saying so.

## What is your fix for the problem, implemented in this PR?

I'm suggesting the description of this change in 2.3.7 be switched in the changelog from a bugfix to a breaking change.

I know it's not ideal to retroactively change a changelog, but it's too late to change the behavior back, and documenting the breaking change is better than ignoring it.

https://github.com/rubygems/rubygems/pull/4152 itself says,

> Someone could be relying on this, but I'm going to call this a bug, and just change the behavior

My company was one of the ones relying on this. And if we were, others probably were as well. Let's save them a bit of time when they upgrade to 2.3.7+.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
