### PR TITLE
Cleanup old legacy code

### DIFF
--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -283,11 +283,7 @@ module Bundler
 
           e = Gem::LoadError.new(message)
           e.name = dep.name
-          if e.respond_to?(:requirement=)
-            e.requirement = dep.requirement
-          elsif e.respond_to?(:version_requirement=)
-            e.version_requirement = dep.requirement
-          end
+          e.requirement = dep.requirement
           raise e
         end
 

--- a/bundler/lib/bundler/runtime.rb
+++ b/bundler/lib/bundler/runtime.rb
@@ -301,11 +301,7 @@ module Bundler
       e = Gem::LoadError.new "You have already activated #{activated_spec.name} #{activated_spec.version}, " \
                              "but your Gemfile requires #{spec.name} #{spec.version}. #{suggestion}"
       e.name = spec.name
-      if e.respond_to?(:requirement=)
-        e.requirement = Gem::Requirement.new(spec.version.to_s)
-      else
-        e.version_requirement = Gem::Requirement.new(spec.version.to_s)
-      end
+      e.requirement = Gem::Requirement.new(spec.version.to_s)
       raise e
     end
   end

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -341,19 +341,6 @@ RSpec.describe "Bundler.setup" do
         expect(out).to eq("WIN")
       end
 
-      it "version_requirement is now deprecated in rubygems 1.4.0+ when gem is missing" do
-        run <<-R
-          begin
-            gem "activesupport"
-            puts "FAIL"
-          rescue LoadError
-            puts "WIN"
-          end
-        R
-
-        expect(err).to be_empty
-      end
-
       it "replaces #gem but raises when the version is wrong" do
         run <<-R
           begin
@@ -365,19 +352,6 @@ RSpec.describe "Bundler.setup" do
         R
 
         expect(out).to eq("WIN")
-      end
-
-      it "version_requirement is now deprecated in rubygems 1.4.0+ when the version is wrong" do
-        run <<-R
-          begin
-            gem "rack", "1.0.0"
-            puts "FAIL"
-          rescue LoadError
-            puts "WIN"
-          end
-        R
-
-        expect(err).to be_empty
       end
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This code was first added a long time ago (Bundler 1.0.8), because we were using a deprecated RubyGems method that was printing warnings that confused users. The relevant commit is https://github.com/rubygems/bundler/commit/fb3a08191f78c0b56742526f4fc454291aea8988.

## What is your fix for the problem, implemented in this PR?

The old method is now long gone since https://github.com/rubygems/rubygems/commit/1bff87f83b8de70a13cae92087fdc636cb4549d2 (RubyGems 1.6.0, 11 years ago), so this is now dead code. Also the tests (at least in their current wording) no longer test anything meaningful since the method producing the old warnings is gone, so I went ahead and removed them too.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
