### PR TITLE
Fully lock rake version in CI

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -61,13 +61,13 @@ jobs:
       - name: Install graphviz (MacOS)
         run: brew install graphviz
         if: matrix.bundler.value == '' && matrix.os.name == 'MacOS'
+      - name: Prepare dependencies
+        run: |
+          bin/rake spec:parallel_deps
+        working-directory: ./bundler
       - name: Replace version
         run: BUNDLER_SPEC_SUB_VERSION=${{ matrix.bundler.value }} bin/rake override_version
         if: matrix.bundler.value != ''
-        working-directory: ./bundler
-      - name: Prepare dependencies
-        run: |
-          rake spec:parallel_deps
         working-directory: ./bundler
       - name: Run Test
         run: |

--- a/.github/workflows/daily-bundler.yml
+++ b/.github/workflows/daily-bundler.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Prepare dependencies
         run: |
           sudo apt-get install graphviz -y
-          rake spec:parallel_deps
+          bin/rake spec:parallel_deps
         working-directory: ./bundler
 
       - name: Run Test

--- a/.github/workflows/jruby-bundler.yml
+++ b/.github/workflows/jruby-bundler.yml
@@ -29,7 +29,7 @@ jobs:
           bundler: none
       - name: Prepare dependencies
         run: |
-          rake spec:parallel_deps
+          bin/rake spec:parallel_deps
         working-directory: ./bundler
       - name: Run Test
         run: |

--- a/.github/workflows/older-rubygems-bundler.yml
+++ b/.github/workflows/older-rubygems-bundler.yml
@@ -51,13 +51,13 @@ jobs:
       - name: Install graphviz
         run: sudo apt-get install graphviz -y
         if: matrix.bundler.value == ''
+      - name: Prepare dependencies
+        run: |
+          bin/rake spec:parallel_deps
+        working-directory: ./bundler
       - name: Replace version
         run: BUNDLER_SPEC_SUB_VERSION=${{ matrix.bundler.value }} bin/rake override_version
         if: matrix.bundler.value != ''
-        working-directory: ./bundler
-      - name: Prepare dependencies
-        run: |
-          rake spec:parallel_deps
         working-directory: ./bundler
       - name: Run Test
         run: |

--- a/.github/workflows/truffleruby-bundler.yml
+++ b/.github/workflows/truffleruby-bundler.yml
@@ -26,7 +26,7 @@ jobs:
           bundler: none
       - name: Prepare dependencies
         run: |
-          rake spec:parallel_deps
+          bin/rake spec:parallel_deps
         working-directory: ./bundler
       - name: Run Test
         run: |

--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Generate docs
         run: rake docs
       - name: Install & Check Dependencies
-        run: rake dev:frozen_deps
+        run: bin/rake dev:frozen_deps
         working-directory: ./bundler
       - name: Misc checks
         run: bin/rake check_rvm_integration man:check check_rubygems_integration

--- a/.github/workflows/windows-bundler.yml
+++ b/.github/workflows/windows-bundler.yml
@@ -45,7 +45,7 @@ jobs:
         if: startsWith(matrix.ruby.name, 'jruby')
       - name: Install dependencies
         run: |
-          rake spec:parallel_deps
+          bin/rake spec:parallel_deps
         working-directory: ./bundler
         shell: bash
       - name: Run specs

--- a/bundler/bin/rake
+++ b/bundler/bin/rake
@@ -3,4 +3,8 @@
 
 require_relative "../spec/support/rubygems_ext"
 
-Spec::Rubygems.gem_load("rake", "rake")
+if ["dev:deps", "dev:frozen_deps", "spec:deps", "spec:parallel_deps"].include?(ARGV[0])
+  Spec::Rubygems.gem_load_and_possibly_install("rake", "rake")
+else
+  Spec::Rubygems.gem_load("rake", "rake")
+end

--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -18,6 +18,12 @@ module Spec
       gem_load_and_activate(gem_name, bin_container)
     end
 
+    def gem_load_and_possibly_install(gem_name, bin_container)
+      require_relative "switch_rubygems"
+
+      gem_load_activate_and_possibly_install(gem_name, bin_container)
+    end
+
     def gem_require(gem_name)
       gem_activate(gem_name)
       require gem_name
@@ -99,9 +105,21 @@ module Spec
       abort "We couldn't activate #{gem_name} (#{e.requirement}). Run `gem install #{gem_name}:'#{e.requirement}'`"
     end
 
+    def gem_load_activate_and_possibly_install(gem_name, bin_container)
+      gem_activate_and_possibly_install(gem_name)
+      load Gem.bin_path(gem_name, bin_container)
+    end
+
+    def gem_activate_and_possibly_install(gem_name)
+      gem_activate(gem_name)
+    rescue Gem::LoadError => e
+      Gem.install(gem_name, e.requirement)
+      retry
+    end
+
     def gem_activate(gem_name)
       require "bundler"
-      gem_requirement = Bundler::LockfileParser.new(File.read(dev_lockfile)).dependencies[gem_name]&.requirement
+      gem_requirement = Bundler::LockfileParser.new(File.read(dev_lockfile)).specs.find{|spec| spec.name == gem_name }.version
       gem gem_name, gem_requirement
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Our CI and local development commands would inconsistently be run through `bin/rake` or `rake`. This is because we can't use `bin/rake` for tasks that install dependencies, because the exact `rake` version they need might not yet be installed.


## What is your fix for the problem, implemented in this PR?

This PR adds some magic to `bin/rake`, when tasks to install dependencies are run, so that the locked version of `rake` is also installed automatically if not present.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
