### PR TITLE
Fix error message when locked version of a gem does not support running Ruby

### DIFF
--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -94,7 +94,7 @@ module Bundler
             (spec.required_ruby_version.satisfied_by?(Gem.ruby_version) &&
               spec.required_rubygems_version.satisfied_by?(Gem.rubygems_version))
         end
-        search = installable_candidates.last
+        search = installable_candidates.last || same_platform_candidates.last
         search.dependencies = dependencies if search && (search.is_a?(RemoteSpecification) || search.is_a?(EndpointSpecification))
         search
       end

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -493,27 +493,25 @@ RSpec.describe "bundle lock" do
   end
 
   it "does not conflict on ruby requirements when adding new platforms" do
-    next_minor = Gem.ruby_version.segments[0..1].map.with_index {|s, i| i == 1 ? s + 1 : s }.join(".")
-
     build_repo4 do
       build_gem "raygun-apm", "1.0.78" do |s|
         s.platform = "x86_64-linux"
-        s.required_ruby_version = "< #{next_minor}.dev"
+        s.required_ruby_version = "< #{next_ruby_minor}.dev"
       end
 
       build_gem "raygun-apm", "1.0.78" do |s|
         s.platform = "universal-darwin"
-        s.required_ruby_version = "< #{next_minor}.dev"
+        s.required_ruby_version = "< #{next_ruby_minor}.dev"
       end
 
       build_gem "raygun-apm", "1.0.78" do |s|
         s.platform = "x64-mingw32"
-        s.required_ruby_version = "< #{next_minor}.dev"
+        s.required_ruby_version = "< #{next_ruby_minor}.dev"
       end
 
       build_gem "raygun-apm", "1.0.78" do |s|
         s.platform = "x64-mingw-ucrt"
-        s.required_ruby_version = "< #{next_minor}.dev"
+        s.required_ruby_version = "< #{next_ruby_minor}.dev"
       end
     end
 

--- a/bundler/spec/install/gems/resolving_spec.rb
+++ b/bundler/spec/install/gems/resolving_spec.rb
@@ -245,6 +245,43 @@ RSpec.describe "bundle install with install-time dependencies" do
         expect(the_bundle).to include_gems("rack 1.2")
       end
 
+      it "gives a meaningful error if there's a lockfile using the newer incompatible version" do
+        build_repo2 do
+          build_gem "parallel_tests", "3.7.0" do |s|
+            s.required_ruby_version = ">= #{current_ruby_minor}"
+          end
+
+          build_gem "parallel_tests", "3.8.0" do |s|
+            s.required_ruby_version = ">= #{next_ruby_minor}"
+          end
+        end
+
+        gemfile <<-G
+          source "http://localgemserver.test/"
+          gem 'parallel_tests'
+        G
+
+        lockfile <<~L
+          GEM
+            remote: http://localgemserver.test/
+            specs:
+              parallel_tests (3.8.0)
+
+          PLATFORMS
+            #{lockfile_platforms}
+
+          DEPENDENCIES
+            parallel_tests
+
+          BUNDLED WITH
+             #{Bundler::VERSION}
+        L
+
+        bundle "install --verbose", :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo2.to_s }, :raise_on_error => false
+        expect(err).to include("parallel_tests-3.8.0 requires ruby version >= #{next_ruby_minor}")
+        expect(err).not_to include("That means the author of parallel_tests (3.8.0) has removed it.")
+      end
+
       it "installs the older version under rate limiting conditions" do
         build_repo4 do
           build_gem "rack", "9001.0.0" do |s|

--- a/bundler/spec/install/yanked_spec.rb
+++ b/bundler/spec/install/yanked_spec.rb
@@ -66,7 +66,7 @@ RSpec.context "when using gem before installing" do
     bundle :list, :raise_on_error => false
 
     expect(err).to include("Could not find rack-0.9.1 in any of the sources")
-    expect(err).to_not include("Your bundle is locked to rack (0.9.1), but that version could not be found in any of the sources listed in your Gemfile.")
+    expect(err).to_not include("Your bundle is locked to rack (0.9.1) from")
     expect(err).to_not include("If you haven't changed sources, that means the author of rack (0.9.1) has removed it.")
     expect(err).to_not include("You'll need to update your bundle to a different version of rack (0.9.1) that hasn't been removed in order to install.")
   end
@@ -97,7 +97,7 @@ RSpec.context "when using gem before installing" do
 
     expect(err).to include("Could not find rack-0.9.1, rack_middleware-1.0 in any of the sources")
     expect(err).to include("Install missing gems with `bundle install`.")
-    expect(err).to_not include("Your bundle is locked to rack (0.9.1), but that version could not be found in any of the sources listed in your Gemfile.")
+    expect(err).to_not include("Your bundle is locked to rack (0.9.1) from")
     expect(err).to_not include("If you haven't changed sources, that means the author of rack (0.9.1) has removed it.")
     expect(err).to_not include("You'll need to update your bundle to a different version of rack (0.9.1) that hasn't been removed in order to install.")
   end

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -471,6 +471,10 @@ module Spec
       end
     end
 
+    def current_ruby_minor
+      Gem.ruby_version.segments[0..1].join(".")
+    end
+
     def next_ruby_minor
       Gem.ruby_version.segments[0..1].map.with_index {|s, i| i == 1 ? s + 1 : s }.join(".")
     end

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -471,6 +471,10 @@ module Spec
       end
     end
 
+    def next_ruby_minor
+      Gem.ruby_version.segments[0..1].map.with_index {|s, i| i == 1 ? s + 1 : s }.join(".")
+    end
+
     # versions providing a bundler version finder but not including
     # https://github.com/rubygems/rubygems/commit/929e92d752baad3a08f3ac92eaec162cb96aedd1
     def rubygems_version_failing_to_activate_bundler_prereleases


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes, if a `Gemfile.lock` file created with an old Ruby is used with a newer Ruby, it might happen that while the file contains a seemingly valid resolution, it's not valid for the running Ruby due to incompatible requirements on the Ruby version.

Right now Bundler gives a very confusing error in this case, stating the the gem has been yanked, which is not true.

## What is your fix for the problem, implemented in this PR?

My fix is to not completely filter out specs with non matching requirements on Ruby, but only pick them when there are no other alternatives. In that case, materialization will succeed but further `bundle install` checks will still fail and give a proper error about the mismatch.

This is a regression of https://github.com/rubygems/rubygems/commit/565549260be50a84a801093ba44e399f2fafb559 and this fix is to revert that commit.

Fixes #5435.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
