### PR TITLE
Make Windows RubyGems workflow a little bit less flaky

### DIFF
--- a/.github/workflows/windows-rubygems.yml
+++ b/.github/workflows/windows-rubygems.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           toolchain: ${{ matrix.cargo.toolchain }}-${{ matrix.cargo.target }}
           default: true
-      - name: Fix clang dep for rust-bindgen (see https://github.com/rubygems/rubygems/pull/5175#discussion_r794873977) 
+      - name: Add missing clang dep for rust-bindgen (see https://github.com/rubygems/rubygems/pull/5175#discussion_r794873977)
         if: ${{ matrix.ruby.name != 'mswin' }}
         run: |
           pacman --sync --noconfirm --needed $ENV:MINGW_PACKAGE_PREFIX-clang

--- a/.github/workflows/windows-rubygems.yml
+++ b/.github/workflows/windows-rubygems.yml
@@ -62,4 +62,4 @@ jobs:
           rake test
         env:
           BUNDLE_WITHOUT: lint
-    timeout-minutes: 20
+    timeout-minutes: 25

--- a/.github/workflows/windows-rubygems.yml
+++ b/.github/workflows/windows-rubygems.yml
@@ -44,7 +44,6 @@ jobs:
       - name: Fix clang dep for rust-bindgen (see https://github.com/rubygems/rubygems/pull/5175#discussion_r794873977) 
         if: ${{ matrix.ruby.name != 'mswin' }}
         run: |
-          pacman --remove --cascade mingw-w64-x86_64-clang
           pacman --sync --noconfirm --needed $ENV:MINGW_PACKAGE_PREFIX-clang
       - name: Print debugging info
         run: |


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes this workflow is very slow and times out.

## What is your fix for the problem, implemented in this PR?

Increase timeout a bit, and remove some unnecessary stuff that was taking up some seconds.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
