### PR TITLE
Handle inline gemfile activated gem conflicts

### DIFF
--- a/bundler/lib/bundler/inline.rb
+++ b/bundler/lib/bundler/inline.rb
@@ -68,7 +68,7 @@ def gemfile(install = false, options = {}, &gemfile)
       end
 
       runtime = Bundler::Runtime.new(nil, definition)
-      runtime.setup.require
+      runtime.setup(:allow_compatible_activated_specs => true).require
     end
   ensure
     if bundler_module

--- a/bundler/spec/runtime/inline_spec.rb
+++ b/bundler/spec/runtime/inline_spec.rb
@@ -355,6 +355,26 @@ RSpec.describe "bundler/inline#gemfile" do
     expect(out).to include("BUNDLE_GEMFILE is empty")
   end
 
+  it "uses already activated specs if they satisfy dependencies" do
+    script <<-RUBY
+      gemfile do
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rack", "0.9.1"
+      end
+
+      gemfile(true) do
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rack", "<= 1.0.0"
+      end
+
+      puts RACK
+    RUBY
+
+    expect(out).to include("Installing rack 1.0.0")
+    expect(out.lines.last).to eq("0.9.1")
+    expect(err).to be_empty
+  end
+
   it "does not error out if library requires optional dependencies" do
     Dir.mkdir tmp("path_without_gemfile")
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When using an inline gemfile that performs installation (i.e. `gemfile(true) {}`), newly installed gems can conflict with gems already activated by Bundler.

For example, when running [this Rails bug report template](https://github.com/rails/rails/blob/88c0e2c9507f0725bdffea9ada405f4d36756d42/guides/bug_report_templates/action_controller_gem.rb) with `strscan` v3.0.1 (but not v3.0.2) installed, `strscan` v3.0.1 will be activated, then v3.0.2 will be installed as a transitive dependency, then Bundler will try to activate v3.0.2 and raise an error.  If you then run the script a 2nd time, it will work (because it immediately activates `strscan` v3.0.2, installed by the 1st run).

This is currently causing the [Rails build to fail](https://buildkite.com/rails/rails/builds/86305#9be4d24a-2944-4660-b5f0-03aac7992131/1158-1265) (see also rails/rails#45052).

## What is your fix for the problem, implemented in this PR?

I was working on this solution, but then I realized that [`@definition.dependencies`](https://github.com/jonathanhefner/rubygems/commit/98be36a95b450522f61354e78fae8cc55f792d50#diff-4a2872c36bdaa433a9d117937197a04fe83603a9c045349677dba5a9e1faf2a2R292) is not recursive.  I am not familiar enough with the Bundler codebase to know what the best solution would be.  Here are possible some alternatives:

1. Don't install gems that have already been activated.  This solution is difficult because the installation process itself activates gems.  Namely, [`Bundler::Installer.install`](https://github.com/rubygems/rubygems/blob/3f39b2fc2dcd68e0b7f0adc84cfa08c2794747be/bundler/lib/bundler/inline.rb#L63) appears to activate `strscan`.  (In the version of Bundler I had installed, it was via an eventual call to [`require_relative "psyched_yaml"`](https://github.com/rubygems/rubygems/blob/84fd3ca03e9b1bc9d32c08cf7468bc2bf8e936cc~1/bundler/lib/bundler/rubygems_integration.rb#L108).)

2. Change the [error message](https://github.com/rubygems/rubygems/blob/3f39b2fc2dcd68e0b7f0adc84cfa08c2794747be/bundler/lib/bundler/runtime.rb#L294-L302) to suggest re-running the script when an inline gemfile performs installation.

3. Downgrade the error to a warning when the spec is for a gem that was just installed by an inline gemfile.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
