### PR TITLE
Fix confusing inline mode install output

### DIFF
--- a/bundler/lib/bundler/installer.rb
+++ b/bundler/lib/bundler/installer.rb
@@ -13,7 +13,7 @@ module Bundler
       Installer.ambiguous_gems = []
     end
 
-    attr_reader :post_install_messages
+    attr_reader :post_install_messages, :definition
 
     # Begins the installation process for Bundler.
     # For more information see the #run method on this class.

--- a/bundler/lib/bundler/installer/gem_installer.rb
+++ b/bundler/lib/bundler/installer/gem_installer.rb
@@ -51,7 +51,20 @@ module Bundler
     end
 
     def install
-      spec.source.install(spec, :force => force, :ensure_builtin_gems_cached => standalone, :build_args => Array(spec_settings))
+      spec.source.install(
+        spec,
+        :force => force,
+        :ensure_builtin_gems_cached => standalone,
+        :build_args => Array(spec_settings),
+        :previous_spec => previous_spec,
+      )
+    end
+
+    def previous_spec
+      locked_gems = installer.definition.locked_gems
+      return unless locked_gems
+
+      locked_gems.specs.find {|s| s.name == spec.name }
     end
 
     def out_of_space_message

--- a/bundler/lib/bundler/plugin/installer/git.rb
+++ b/bundler/lib/bundler/plugin/installer/git.rb
@@ -20,10 +20,6 @@ module Bundler
           end
         end
 
-        def version_message(spec)
-          "#{spec.name} #{spec.version}"
-        end
-
         def root
           Plugin.root
         end

--- a/bundler/lib/bundler/plugin/installer/rubygems.rb
+++ b/bundler/lib/bundler/plugin/installer/rubygems.rb
@@ -4,10 +4,6 @@ module Bundler
   module Plugin
     class Installer
       class Rubygems < Bundler::Source::Rubygems
-        def version_message(spec)
-          "#{spec.name} #{spec.version}"
-        end
-
         private
 
         def requires_sudo?

--- a/bundler/lib/bundler/source.rb
+++ b/bundler/lib/bundler/source.rb
@@ -15,13 +15,12 @@ module Bundler
       specs.unmet_dependency_names
     end
 
-    def version_message(spec)
+    def version_message(spec, locked_spec = nil)
       message = "#{spec.name} #{spec.version}"
       message += " (#{spec.platform})" if spec.platform != Gem::Platform::RUBY && !spec.platform.nil?
 
-      if Bundler.locked_gems
-        locked_spec = Bundler.locked_gems.specs.find {|s| s.name == spec.name }
-        locked_spec_version = locked_spec.version if locked_spec
+      if locked_spec
+        locked_spec_version = locked_spec.version
         if locked_spec_version && spec.version != locked_spec_version
           message += Bundler.ui.add_color(" (was #{locked_spec_version})", version_color(spec.version, locked_spec_version))
         end

--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -181,7 +181,7 @@ module Bundler
       def install(spec, options = {})
         force = options[:force]
 
-        print_using_message "Using #{version_message(spec)} from #{self}"
+        print_using_message "Using #{version_message(spec, options[:previous_spec])} from #{self}"
 
         if (requires_checkout? && !@copied) || force
           Bundler.ui.debug "  * Checking out revision: #{ref}"

--- a/bundler/lib/bundler/source/path.rb
+++ b/bundler/lib/bundler/source/path.rb
@@ -82,7 +82,7 @@ module Bundler
       end
 
       def install(spec, options = {})
-        using_message = "Using #{version_message(spec)} from #{self}"
+        using_message = "Using #{version_message(spec, options[:previous_spec])} from #{self}"
         using_message += " and installing its executables" unless spec.executables.empty?
         print_using_message using_message
         generate_bin(spec, :disable_extensions => true)

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -162,7 +162,7 @@ module Bundler
           uris.uniq!
           Installer.ambiguous_gems << [spec.name, *uris] if uris.length > 1
 
-          path = fetch_gem(spec)
+          path = fetch_gem(spec, options[:previous_spec])
           begin
             s = Bundler.rubygems.spec_from_gem(path, Bundler.settings["trust-policy"])
             spec.__swap__(s)
@@ -173,7 +173,7 @@ module Bundler
         end
 
         unless Bundler.settings[:no_install]
-          message = "Installing #{version_message(spec)}"
+          message = "Installing #{version_message(spec, options[:previous_spec])}"
           message += " with native extensions" if spec.extensions.any?
           Bundler.ui.confirm message
 
@@ -458,7 +458,7 @@ module Bundler
         end
       end
 
-      def fetch_gem(spec)
+      def fetch_gem(spec, previous_spec = nil)
         return false unless spec.remote
 
         spec.fetch_platform
@@ -476,7 +476,7 @@ module Bundler
         SharedHelpers.filesystem_access(download_cache_path) do |p|
           FileUtils.mkdir_p(p)
         end
-        download_gem(spec, download_cache_path)
+        download_gem(spec, download_cache_path, previous_spec)
 
         if requires_sudo?
           SharedHelpers.filesystem_access(cache_path) do |p|
@@ -521,9 +521,12 @@ module Bundler
       # @param  [String] download_cache_path
       #         the local directory the .gem will end up in.
       #
-      def download_gem(spec, download_cache_path)
+      # @param  [Specification] previous_spec
+      #         the spec previously locked
+      #
+      def download_gem(spec, download_cache_path, previous_spec = nil)
         uri = spec.remote.uri
-        Bundler.ui.confirm("Fetching #{version_message(spec)}")
+        Bundler.ui.confirm("Fetching #{version_message(spec, previous_spec)}")
         Bundler.rubygems.download_gem(spec, uri, download_cache_path)
       end
 

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -135,9 +135,9 @@ module Bundler
         end
       end
 
-      def install(spec, opts = {})
-        force = opts[:force]
-        ensure_builtin_gems_cached = opts[:ensure_builtin_gems_cached]
+      def install(spec, options = {})
+        force = options[:force]
+        ensure_builtin_gems_cached = options[:ensure_builtin_gems_cached]
 
         if ensure_builtin_gems_cached && spec.default_gem?
           if !cached_path(spec)
@@ -198,7 +198,7 @@ module Bundler
             :ignore_dependencies => true,
             :wrappers            => true,
             :env_shebang         => true,
-            :build_args          => opts[:build_args],
+            :build_args          => options[:build_args],
             :bundler_expected_checksum => spec.respond_to?(:checksum) && spec.checksum,
             :bundler_extension_cache_path => extension_cache_path(spec)
           ).install

--- a/bundler/spec/bundler/installer/gem_installer_spec.rb
+++ b/bundler/spec/bundler/installer/gem_installer_spec.rb
@@ -3,7 +3,8 @@
 require "bundler/installer/gem_installer"
 
 RSpec.describe Bundler::GemInstaller do
-  let(:installer) { instance_double("Installer") }
+  let(:definition) { instance_double("Definition", :locked_gems => nil) }
+  let(:installer) { instance_double("Installer", :definition => definition) }
   let(:spec_source) { instance_double("SpecSource") }
   let(:spec) { instance_double("Specification", :name => "dummy", :version => "0.0.1", :loaded_from => "dummy", :source => spec_source) }
 
@@ -11,7 +12,7 @@ RSpec.describe Bundler::GemInstaller do
 
   context "spec_settings is nil" do
     it "invokes install method with empty build_args" do
-      allow(spec_source).to receive(:install).with(spec, :force => false, :ensure_builtin_gems_cached => false, :build_args => [])
+      allow(spec_source).to receive(:install).with(spec, :force => false, :ensure_builtin_gems_cached => false, :build_args => [], :previous_spec => nil)
       subject.install_from_spec
     end
   end
@@ -22,7 +23,7 @@ RSpec.describe Bundler::GemInstaller do
       allow(Bundler.settings).to receive(:[]).with(:inline)
       allow(Bundler.settings).to receive(:[]).with(:forget_cli_options)
       allow(Bundler.settings).to receive(:[]).with("build.dummy").and_return("--with-dummy-config=dummy")
-      expect(spec_source).to receive(:install).with(spec, :force => false, :ensure_builtin_gems_cached => false, :build_args => ["--with-dummy-config=dummy"])
+      expect(spec_source).to receive(:install).with(spec, :force => false, :ensure_builtin_gems_cached => false, :build_args => ["--with-dummy-config=dummy"], :previous_spec => nil)
       subject.install_from_spec
     end
   end
@@ -33,7 +34,13 @@ RSpec.describe Bundler::GemInstaller do
       allow(Bundler.settings).to receive(:[]).with(:inline)
       allow(Bundler.settings).to receive(:[]).with(:forget_cli_options)
       allow(Bundler.settings).to receive(:[]).with("build.dummy").and_return("--with-dummy-config=dummy --with-another-dummy-config")
-      expect(spec_source).to receive(:install).with(spec, :force => false, :ensure_builtin_gems_cached => false, :build_args => ["--with-dummy-config=dummy", "--with-another-dummy-config"])
+      expect(spec_source).to receive(:install).with(
+        spec,
+        :force => false,
+        :ensure_builtin_gems_cached => false,
+        :build_args => ["--with-dummy-config=dummy", "--with-another-dummy-config"],
+        :previous_spec => nil
+      )
       subject.install_from_spec
     end
   end

--- a/bundler/spec/bundler/source_spec.rb
+++ b/bundler/spec/bundler/source_spec.rb
@@ -30,17 +30,7 @@ RSpec.describe Bundler::Source do
     end
 
     context "when there are locked gems" do
-      let(:locked_gems) { double(:locked_gems) }
-
-      before { allow(Bundler).to receive(:locked_gems).and_return(locked_gems) }
-
       context "that contain the relevant gem spec" do
-        before do
-          specs = double(:specs)
-          allow(locked_gems).to receive(:specs).and_return(specs)
-          allow(specs).to receive(:find).and_return(locked_gem)
-        end
-
         context "without a version" do
           let(:locked_gem) { double(:locked_gem, :name => "nokogiri", :version => nil) }
 
@@ -62,7 +52,7 @@ RSpec.describe Bundler::Source do
             end
 
             it "should return a string with the spec name and version and locked spec version" do
-              expect(subject.version_message(spec)).to eq("nokogiri >= 1.6\e[32m (was < 1.5)\e[0m")
+              expect(subject.version_message(spec, locked_gem)).to eq("nokogiri >= 1.6\e[32m (was < 1.5)\e[0m")
             end
           end
 
@@ -74,7 +64,7 @@ RSpec.describe Bundler::Source do
             end
 
             it "should return a string with the spec name and version and locked spec version" do
-              expect(subject.version_message(spec)).to eq("nokogiri >= 1.6 (was < 1.5)")
+              expect(subject.version_message(spec, locked_gem)).to eq("nokogiri >= 1.6 (was < 1.5)")
             end
           end
         end
@@ -89,7 +79,7 @@ RSpec.describe Bundler::Source do
             end
 
             it "should return a string with the locked spec version in yellow" do
-              expect(subject.version_message(spec)).to eq("nokogiri 1.6.1\e[33m (was 1.7.0)\e[0m")
+              expect(subject.version_message(spec, locked_gem)).to eq("nokogiri 1.6.1\e[33m (was 1.7.0)\e[0m")
             end
           end
 
@@ -101,7 +91,7 @@ RSpec.describe Bundler::Source do
             end
 
             it "should return a string with the locked spec version in yellow" do
-              expect(subject.version_message(spec)).to eq("nokogiri 1.6.1 (was 1.7.0)")
+              expect(subject.version_message(spec, locked_gem)).to eq("nokogiri 1.6.1 (was 1.7.0)")
             end
           end
         end
@@ -116,7 +106,7 @@ RSpec.describe Bundler::Source do
             end
 
             it "should return a string with the locked spec version in green" do
-              expect(subject.version_message(spec)).to eq("nokogiri 1.7.1\e[32m (was 1.7.0)\e[0m")
+              expect(subject.version_message(spec, locked_gem)).to eq("nokogiri 1.7.1\e[32m (was 1.7.0)\e[0m")
             end
           end
 
@@ -128,27 +118,11 @@ RSpec.describe Bundler::Source do
             end
 
             it "should return a string with the locked spec version in yellow" do
-              expect(subject.version_message(spec)).to eq("nokogiri 1.7.1 (was 1.7.0)")
+              expect(subject.version_message(spec, locked_gem)).to eq("nokogiri 1.7.1 (was 1.7.0)")
             end
           end
         end
       end
-
-      context "that do not contain the relevant gem spec" do
-        before do
-          specs = double(:specs)
-          allow(locked_gems).to receive(:specs).and_return(specs)
-          allow(specs).to receive(:find).and_return(nil)
-        end
-
-        it_behaves_like "the lockfile specs are not relevant"
-      end
-    end
-
-    context "when there are no locked gems" do
-      before { allow(Bundler).to receive(:locked_gems).and_return(nil) }
-
-      it_behaves_like "the lockfile specs are not relevant"
     end
   end
 

--- a/bundler/spec/runtime/inline_spec.rb
+++ b/bundler/spec/runtime/inline_spec.rb
@@ -239,6 +239,40 @@ RSpec.describe "bundler/inline#gemfile" do
     expect(err).to be_empty
   end
 
+  it "does not leak Gemfile.lock versions to the installation output" do
+    gemfile <<-G
+      source "https://notaserver.com"
+      gem "rake"
+    G
+
+    lockfile <<-G
+      GEM
+        remote: https://rubygems.org/
+        specs:
+          rake (11.3.0)
+
+      PLATFORMS
+        ruby
+
+      DEPENDENCIES
+        rake
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    G
+
+    script <<-RUBY
+      gemfile(true) do
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rake", "~> 13.0"
+      end
+    RUBY
+
+    expect(out).to include("Installing rake 13.0")
+    expect(out).not_to include("was 11.3.0")
+    expect(err).to be_empty
+  end
+
   it "installs inline gems when frozen is set" do
     script <<-RUBY, :env => { "BUNDLE_FROZEN" => "true" }
       gemfile do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

While having a look at #5529, I saw Bundler printing information about previously locked gems. This makes the output very confusing because inline mode does not use a lockfile at all. For example

```
$ ruby guides/bug_report_templates/action_controller_gem.rb
Fetching gem metadata from https://rubygems.org/...........
Resolving dependencies...
Using rake 13.0.6
Using concurrent-ruby 1.1.10 (was 1.1.9)
Using minitest 5.15.0
Using erubi 1.10.0
Using racc 1.6.0
Using crass 1.0.6
Using rack 2.2.3
Fetching strscan 3.0.3 (was 3.0.2)
Using nio4r 2.5.8
Using bundler 2.3.13
Using timeout 0.2.0
Using thor 1.2.1
Using zeitwerk 2.5.4 (was 2.5.3)
Using i18n 1.10.0 (was 1.8.11)
Using tzinfo 2.0.4
Using nokogiri 1.13.6 (arm64-darwin) (was 1.13.3)
Using rack-test 1.1.0
Using method_source 1.0.0
Using activesupport 7.0.3 (was 7.1.0.alpha)
Using loofah 2.17.0 (was 2.13.0)
Using net-protocol 0.1.3
Using builder 3.2.4
Using websocket-extensions 0.1.5
Using marcel 1.0.2
Using mini_mime 1.1.2
Using digest 3.1.0
Using rails-dom-testing 2.0.3
Using rails-html-sanitizer 1.4.2
Using globalid 1.0.0
Using activemodel 7.0.3 (was 7.1.0.alpha)
Using mail 2.7.1
Using net-pop 0.1.1
Using websocket-driver 0.7.5
Using net-smtp 0.3.1
Using activejob 7.0.3 (was 7.1.0.alpha)
Using activerecord 7.0.3 (was 7.1.0.alpha)
Using actionview 7.0.3 (was 7.1.0.alpha)
Using actionpack 7.0.3 (was 7.1.0.alpha)
Using activestorage 7.0.3 (was 7.1.0.alpha)
Using railties 7.0.3 (was 7.1.0.alpha)
Using actioncable 7.0.3 (was 7.1.0.alpha)
Using actiontext 7.0.3 (was 7.1.0.alpha)
Installing strscan 3.0.3 (was 3.0.2) with native extensions
Using net-imap 0.2.3 (was 0.2.2)
Using actionmailbox 7.0.3 (was 7.1.0.alpha)
Using actionmailer 7.0.3 (was 7.1.0.alpha)
Using rails 7.0.3 (was 7.1.0.alpha)
/Users/deivid/.rbenv/versions/3.1.2/lib/ruby/site_ruby/3.1.0/bundler/runtime.rb:309:in `check_for_activated_spec!': You have already activated strscan 3.0.1, but your Gemfile requires strscan 3.0.3. Since strscan is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports strscan as a default gem. (Gem::LoadError)
	from /Users/deivid/.rbenv/versions/3.1.2/lib/ruby/site_ruby/3.1.0/bundler/runtime.rb:25:in `block in setup'
	from /Users/deivid/.rbenv/versions/3.1.2/lib/ruby/site_ruby/3.1.0/bundler/spec_set.rb:136:in `each'
	from /Users/deivid/.rbenv/versions/3.1.2/lib/ruby/site_ruby/3.1.0/bundler/spec_set.rb:136:in `each'
	from /Users/deivid/.rbenv/versions/3.1.2/lib/ruby/site_ruby/3.1.0/bundler/runtime.rb:24:in `map'
	from /Users/deivid/.rbenv/versions/3.1.2/lib/ruby/site_ruby/3.1.0/bundler/runtime.rb:24:in `setup'
	from /Users/deivid/.rbenv/versions/3.1.2/lib/ruby/site_ruby/3.1.0/bundler/inline.rb:71:in `block in gemfile'
	from /Users/deivid/.rbenv/versions/3.1.2/lib/ruby/site_ruby/3.1.0/bundler/settings.rb:131:in `temporary'
	from /Users/deivid/.rbenv/versions/3.1.2/lib/ruby/site_ruby/3.1.0/bundler/inline.rb:55:in `gemfile'
	from guides/bug_report_templates/action_controller_gem.rb:5:in `<main>'
```

## What is your fix for the problem, implemented in this PR?

This PR adds some plumbing so that we can avoid to print this information in inline mode. Now the output is like this:

```
$ ruby guides/bug_report_templates/action_controller_gem.rb
Fetching gem metadata from https://rubygems.org/...........
Resolving dependencies...
Using rake 13.0.6
Using concurrent-ruby 1.1.10
Using minitest 5.15.0
Using builder 3.2.4
Using erubi 1.10.0
Using racc 1.6.0
Using crass 1.0.6
Using rack 2.2.3
Using nio4r 2.5.8
Using websocket-extensions 0.1.5
Using marcel 1.0.2
Using mini_mime 1.1.2
Using digest 3.1.0
Using i18n 1.10.0
Using tzinfo 2.0.4
Using nokogiri 1.13.6 (arm64-darwin)
Fetching strscan 3.0.3
Using timeout 0.2.0
Using mail 2.7.1
Using loofah 2.17.0
Using zeitwerk 2.5.4
Using activesupport 7.0.3
Using rails-html-sanitizer 1.4.2
Using net-protocol 0.1.3
Using bundler 2.4.0.dev
Using method_source 1.0.0
Using rack-test 1.1.0
Using rails-dom-testing 2.0.3
Using globalid 1.0.0
Using activemodel 7.0.3
Using net-pop 0.1.1
Using net-smtp 0.3.1
Using thor 1.2.1
Using websocket-driver 0.7.5
Using actionview 7.0.3
Using activejob 7.0.3
Using activerecord 7.0.3
Using actionpack 7.0.3
Using actioncable 7.0.3
Using activestorage 7.0.3
Using railties 7.0.3
Using actiontext 7.0.3
Installing strscan 3.0.3 with native extensions
Using net-imap 0.2.3
Using actionmailbox 7.0.3
Using actionmailer 7.0.3
Using rails 7.0.3
/Users/deivid/.rbenv/versions/3.1.2/lib/ruby/site_ruby/3.1.0/bundler/runtime.rb:305:in `check_for_activated_spec!': You have already activated strscan 3.0.1, but your Gemfile requires strscan 3.0.3. Since strscan is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports strscan as a default gem. (Gem::LoadError)
	from /Users/deivid/.rbenv/versions/3.1.2/lib/ruby/site_ruby/3.1.0/bundler/runtime.rb:25:in `block in setup'
	from /Users/deivid/.rbenv/versions/3.1.2/lib/ruby/site_ruby/3.1.0/bundler/spec_set.rb:136:in `each'
	from /Users/deivid/.rbenv/versions/3.1.2/lib/ruby/site_ruby/3.1.0/bundler/spec_set.rb:136:in `each'
	from /Users/deivid/.rbenv/versions/3.1.2/lib/ruby/site_ruby/3.1.0/bundler/runtime.rb:24:in `map'
	from /Users/deivid/.rbenv/versions/3.1.2/lib/ruby/site_ruby/3.1.0/bundler/runtime.rb:24:in `setup'
	from /Users/deivid/.rbenv/versions/3.1.2/lib/ruby/site_ruby/3.1.0/bundler/inline.rb:71:in `block in gemfile'
	from /Users/deivid/.rbenv/versions/3.1.2/lib/ruby/site_ruby/3.1.0/bundler/settings.rb:131:in `temporary'
	from /Users/deivid/.rbenv/versions/3.1.2/lib/ruby/site_ruby/3.1.0/bundler/inline.rb:55:in `gemfile'
	from guides/bug_report_templates/action_controller_gem.rb:5:in `<main>'
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
