### PR TITLE
Improve `bundler/setup` performance again

### DIFF
--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -24,7 +24,7 @@ module Bundler
 
         specs_for_dep = spec_for_dependency(dep, match_current_platform)
         if specs_for_dep.any?
-          specs += specs_for_dep
+          specs.concat(specs_for_dep)
 
           specs_for_dep.first.dependencies.each do |d|
             next if d.type == :development

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -24,7 +24,7 @@ module Bundler
 
         specs_for_dep = spec_for_dependency(dep, match_current_platform)
         if specs_for_dep.any?
-          match_current_platform ? specs += specs_for_dep : specs |= specs_for_dep
+          specs += specs_for_dep
 
           specs_for_dep.first.dependencies.each do |d|
             next if d.type == :development
@@ -39,6 +39,8 @@ module Bundler
       if spec = lookup["bundler"].first
         specs << spec
       end
+
+      specs.uniq! unless match_current_platform
 
       check ? true : specs
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The performance of `bundler/setup` is still slow.

## What is your fix for the problem, implemented in this PR?

On a [different patch](https://github.com/rubygems/rubygems/pull/5532), it was noticed by @ngan that we are calling `LazySpecification#hash` many times, and simply memoizing that led to a very considerable performance improvement in his app.

I noticed though that we shouldn't be calling `LazySpecification#hash` that many times, and I located the culprit at `SpecSet#for` where we were deduplicating the partial aggregated result on every iteration. It is enough to do it just once at the end.

This leads on a 12% speedup on Rails repository Gemfile vs the previous 8% I was getting from memoizing `LazySpecification#hash`. Also, after this patch memoizing `LazySpecification#hash` has no effect in performance anymore.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
