### PR TITLE
Gracefully handle gem activation conflicts in inline mode

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -519,7 +519,7 @@ module Bundler
     end
 
     def write_lock(file, preserve_unknown_sections)
-      return if Definition.no_lock
+      return if Definition.no_lock || file.nil?
 
       contents = to_lock
 

--- a/bundler/lib/bundler/inline.rb
+++ b/bundler/lib/bundler/inline.rb
@@ -50,7 +50,6 @@ def gemfile(install = false, options = {}, &gemfile)
 
     Bundler.settings.temporary(deployment: false, frozen: false) do
       definition = builder.to_definition(nil, true)
-      def definition.lock(*); end
       definition.validate_runtime!
 
       if install || definition.missing_specs?

--- a/bundler/lib/bundler/inline.rb
+++ b/bundler/lib/bundler/inline.rb
@@ -71,6 +71,7 @@ def gemfile(install = false, options = {}, &gemfile)
           "The #{name} gem was resolved to #{version}, but #{activated_version} was activated by Bundler while installing it, causing a conflict. " \
           "Bundler will now retry resolving with #{activated_version} instead."
 
+        builder.dependencies.delete_if {|d| d.name == name }
         builder.instance_eval { gem name, activated_version }
         definition = builder.to_definition(nil, true)
 

--- a/bundler/lib/bundler/inline.rb
+++ b/bundler/lib/bundler/inline.rb
@@ -46,7 +46,6 @@ def gemfile(install = false, options = {}, &gemfile)
     Bundler::Plugin.gemfile_install(&gemfile) if Bundler.feature_flag.plugins?
     builder = Bundler::Dsl.new
     builder.instance_eval(&gemfile)
-    builder.check_primary_source_safety
 
     Bundler.settings.temporary(deployment: false, frozen: false) do
       definition = builder.to_definition(nil, true)

--- a/bundler/spec/runtime/inline_spec.rb
+++ b/bundler/spec/runtime/inline_spec.rb
@@ -656,7 +656,7 @@ RSpec.describe "bundler/inline#gemfile" do
     expect(out).to include("after: [\"Test_Variable\"]")
   end
 
-  it "does not load specified version of psych and stringio" do
+  it "does not load specified version of psych and stringio", :ruby_repo do
     build_repo4 do
       build_gem "psych", "999"
       build_gem "stringio", "999"

--- a/bundler/spec/runtime/inline_spec.rb
+++ b/bundler/spec/runtime/inline_spec.rb
@@ -655,4 +655,27 @@ RSpec.describe "bundler/inline#gemfile" do
     expect(out).to include("before: [\"Test_Variable\"]")
     expect(out).to include("after: [\"Test_Variable\"]")
   end
+
+  it "does not load specified version of psych and stringio" do
+    build_repo4 do
+      build_gem "psych", "999"
+      build_gem "stringio", "999"
+    end
+
+    script <<-RUBY, env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+      require "bundler/inline"
+
+      gemfile(true) do
+        source "https://gem.repo4"
+
+        gem "psych"
+        gem "stringio"
+      end
+    RUBY
+
+    expect(out).to include("Installing psych 999")
+    expect(out).to include("Installing stringio 999")
+    expect(out).to include("The psych gem was resolved to 999")
+    expect(out).to include("The stringio gem was resolved to 999")
+  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Bundler's "inline" mode resolves gems, installs them, and activates them on the fly. This is handy but in particular our install code still uses some gems (like `psych`). When that happens, the activated version of those gems might not match the resolved version in the inline `Gemfile`, causing a conflict.

## What is your fix for the problem, implemented in this PR?

The real fix to this issue is to completely stop depending on any gems. That's ongoing work that has been going on for years, but it's hard specially since new libraries get gemified.

This add some ad-hoc code to `bundler/inline` to recover from this kind of issue, by retrying with an extra requirement on the exact gem version that got activated, to ensure that there's no mismatch the second time.

This is a less invasive (I think) alternative to #5529.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
