### PR TITLE
Bundler::DepProxy#name performance improvement.

### DIFF
--- a/bundler/lib/bundler/dep_proxy.rb
+++ b/bundler/lib/bundler/dep_proxy.rb
@@ -13,6 +13,9 @@ module Bundler
     def initialize(dep, platform)
       @dep = dep
       @__platform = platform
+
+      # save the name to save a method call to the dep's name
+      @name = dep.name
     end
 
     private_class_method :new
@@ -24,7 +27,7 @@ module Bundler
     end
 
     def name
-      @dep.name
+      @name
     end
 
     def requirement


### PR DESCRIPTION

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

Looking for ways to speed up `require 'bundler/setup'`
<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

Looking over flamegraphs for `require 'bundler/setup'`, I'm seeing
`Bundler::DepProxy#name` show up quite often. The method itself is really
simple, delegating to the dependency's proxy. It's taking up to 1ms sometimes.


![Screen Shot 2022-05-13 at 4 57 23 PM](https://user-images.githubusercontent.com/159/168388672-0a3b7300-4d55-49c4-adac-fe715a56bb32.png)


I suspect it is getting called enough that memoizing the value improves
will improve performance by saving a method call, in exchange for saving
the value in memory.

When testing with this patch plus https://github.com/rubygems/rubygems/pull/5533
I saw time go from 0.92s to 0.75s.




<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
