### PR TITLE
Lazily check incomplete lockfile to improve performance

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -53,6 +53,7 @@ module Bundler
   autoload :GemHelpers,             File.expand_path("bundler/gem_helpers", __dir__)
   autoload :GemVersionPromoter,     File.expand_path("bundler/gem_version_promoter", __dir__)
   autoload :Graph,                  File.expand_path("bundler/graph", __dir__)
+  autoload :IncompleteSpecification, File.expand_path("bundler/incomplete_specification", __dir__)
   autoload :Index,                  File.expand_path("bundler/index", __dir__)
   autoload :Injector,               File.expand_path("bundler/injector", __dir__)
   autoload :Installer,              File.expand_path("bundler/installer", __dir__)

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -264,7 +264,6 @@ module Bundler
           SpecSet.new(filter_specs(@locked_specs, @dependencies.select {|dep| @locked_specs[dep].any? }))
         else
           last_resolve = converge_locked_specs
-          # Run a resolve against the locally available gems
           Bundler.ui.debug("Found changes from the lockfile, re-resolving dependencies because #{change_reason}")
           expanded_dependencies = expand_dependencies(dependencies + metadata_dependencies, true)
           Resolver.resolve(expanded_dependencies, source_requirements, last_resolve, gem_version_promoter, additional_base_requirements_for_resolve, platforms)

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -138,13 +138,13 @@ module Bundler
         @unlock[:gems] ||= @dependencies.map(&:name)
       else
         eager_unlock = expand_dependencies(@unlock[:gems] || [], true)
-        @unlock[:gems] = @locked_specs.for(eager_unlock, false, false).map(&:name)
+        @unlock[:gems] = @locked_specs.for(eager_unlock, false, platforms).map(&:name)
       end
 
       @dependency_changes = converge_dependencies
       @local_changes = converge_locals
 
-      @locked_specs_incomplete_for_platform = !@locked_specs.for(requested_dependencies & expand_dependencies(locked_dependencies), true, true)
+      @locked_specs_incomplete_for_platform = !@locked_specs.for(requested_dependencies & expand_dependencies(locked_dependencies), true)
 
       @requires = compute_requires
     end
@@ -466,7 +466,7 @@ module Bundler
     private
 
     def filter_specs(specs, deps)
-      SpecSet.new(specs).for(expand_dependencies(deps, true), false, false)
+      SpecSet.new(specs).for(expand_dependencies(deps, true), false, platforms)
     end
 
     def materialize(dependencies)
@@ -709,7 +709,7 @@ module Bundler
             # if we won't need the source (according to the lockfile),
             # don't error if the path/git source isn't available
             next if specs.
-                    for(requested_dependencies, false, true).
+                    for(requested_dependencies, false).
                     none? {|locked_spec| locked_spec.source == s.source }
 
             raise

--- a/bundler/lib/bundler/incomplete_specification.rb
+++ b/bundler/lib/bundler/incomplete_specification.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Bundler
+  class IncompleteSpecification
+    attr_reader :name, :platform
+
+    def initialize(name, platform)
+      @name = name
+      @platform = platform
+    end
+  end
+end

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -21,7 +21,7 @@ module Bundler
       base = SpecSet.new(base) unless base.is_a?(SpecSet)
       resolver = new(source_requirements, base, gem_version_promoter, additional_base_requirements, platforms)
       result = resolver.start(requirements)
-      SpecSet.new(SpecSet.new(result).for(requirements.reject {|dep| dep.name.end_with?("\0") }))
+      SpecSet.new(SpecSet.new(result).for(requirements.reject {|dep| dep.name.end_with?("\0") }, false, platforms))
     end
 
     def initialize(source_requirements, base, gem_version_promoter, additional_base_requirements, platforms)

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -40,8 +40,6 @@ module Bundler
         specs << spec
       end
 
-      specs.uniq! unless match_current_platform
-
       check ? true : specs
     end
 
@@ -69,7 +67,7 @@ module Bundler
     end
 
     def materialize(deps)
-      materialized = self.for(deps, false, true)
+      materialized = self.for(deps, false, true).uniq
 
       materialized.map! do |s|
         next s unless s.is_a?(LazySpecification)

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -31,7 +31,7 @@ module Bundler
             deps << [d.name, dep[1]]
           end
         elsif check
-          return false
+          specs << IncompleteSpecification.new(*dep)
         end
       end
 
@@ -39,7 +39,7 @@ module Bundler
         specs << spec
       end
 
-      check ? true : specs
+      specs
     end
 
     def [](key)
@@ -66,7 +66,7 @@ module Bundler
     end
 
     def materialize(deps)
-      materialized = self.for(deps, false).uniq
+      materialized = self.for(deps, true).uniq
 
       materialized.map! do |s|
         next s unless s.is_a?(LazySpecification)
@@ -92,6 +92,10 @@ module Bundler
 
     def missing_specs
       @specs.select {|s| s.is_a?(LazySpecification) }
+    end
+
+    def incomplete_specs
+      @specs.select {|s| s.is_a?(IncompleteSpecification) }
     end
 
     def merge(set)

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -635,6 +635,7 @@ RSpec.describe "Bundler.setup" do
 
       ruby "require '#{system_gem_path("gems/bundler-9.99.9.beta1/lib/bundler.rb")}'; Bundler.setup", :env => { "DEBUG" => "1" }
       expect(out).to include("Found no changes, using resolution from the lockfile")
+      expect(out).not_to include("lockfile does not have all gems needed for the current platform")
       expect(err).to be_empty
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We have some code that checks whether the lockfile has incomplete specs for the current platform, i.e., when even if the current platform is locked, the lockfile is missing some specs for it.

I think this check was introduced due to some bug in Bundler that generated some incomplete lockfiles, but it should be a very edge case. However, we check this every time `bundler/setup` is required, so all usages have to pay the cost of trying to gracefully handle this edge case.

## What is your fix for the problem, implemented in this PR?

Checking this edge case involves actually resolving the locked specs for the current platform, which is something we need to do later anyways. So my approach is to assume this edge case does not happen, and when going ahead and materializing the actual set of specifications, check whether it actually happened. If that's the case, then go ahead and re-resolve.

This should reduce the number of times `bundler/setup` calls `Bundler::SpecSet#for` from 3 to 2.

The benefit on performance is unfortunately more moderate than I was expecting, about 1% on a fresh new rails application and about 2% on `rails/rails` repository Gemfile. But I would expect it to be better for bigger Gemfiles.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
