### PR TITLE
Fix locale dependent spec failure

### DIFF
--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -774,7 +774,7 @@ end
       run <<~RUBY
         puts ENV['MANPATH']
         require "open3"
-        puts Open3.capture2e("man", "ls")[0]
+        puts Open3.capture2e({ "LC_ALL" => "C" }, "man", "ls")[0]
       RUBY
 
       lines = out.split("\n")


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I setup a new Debian system, and run bundler specs there. Due to my default locale, `man ls` is translated into Spanish, and that makes this spec fail.

## What is your fix for the problem, implemented in this PR?

Pass the `LC_ALL=C` environment variable to make `man ls` output, and thus this spec, locale independent.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
