### PR TITLE
Support the change of did_you_mean about Exception#detailed_message

### DIFF
--- a/lib/rubygems/command_manager.rb
+++ b/lib/rubygems/command_manager.rb
@@ -148,7 +148,12 @@ class Gem::CommandManager
   def run(args, build_args=nil)
     process_args(args, build_args)
   rescue StandardError, Timeout::Error => ex
-    alert_error clean_text("While executing gem ... (#{ex.class})\n    #{ex}")
+    if ex.respond_to?(:detailed_message)
+      msg = ex.detailed_message(highlight: false).sub(/\A(.*?)(?: \(.+?\))/) { $1 }
+    else
+      msg = ex.message
+    end
+    alert_error clean_text("While executing gem ... (#{ex.class})\n    #{msg}")
     ui.backtrace ex
 
     terminate_interaction(1)

--- a/test/rubygems/test_gem_command_manager.rb
+++ b/test/rubygems/test_gem_command_manager.rb
@@ -80,7 +80,13 @@ class TestGemCommandManager < Gem::TestCase
       message << "\nDid you mean?  \"push\""
     end
 
-    assert_equal message, e.message
+    if e.respond_to?(:detailed_message)
+      actual_message = e.detailed_message(highlight: false).sub(/\A(.*?)(?: \(.+?\))/) { $1 }
+    else
+      actual_message = e.message
+    end
+
+    assert_equal message, actual_message
   end
 
   def test_run_interrupt


### PR DESCRIPTION
I am asking did_you_mean to use Exception#detailed_message to add
"Did you mean?" suggestion instead of overriding #message method.

https://github.com/ruby/did_you_mean/pull/177

Unfortunately, the change will affect Gem::UnknownCommandError, which
excepts did_you_mean to override #message method.

This PR absorbs the change of did_you_mean.
Gem::CommandManager now calls #detailed_message method to get a message
string with "Did you mean?" suggestion from an exception.

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
