### PR TITLE
Show exception cause in bug report template

### DIFF
--- a/bundler/lib/bundler/friendly_errors.rb
+++ b/bundler/lib/bundler/friendly_errors.rb
@@ -65,8 +65,7 @@ module Bundler
         --- ERROR REPORT TEMPLATE -------------------------------------------------------
 
         ```
-        #{e.class}: #{e.message}
-          #{e.backtrace && e.backtrace.join("\n          ").chomp}
+        #{exception_message(e)}
         ```
 
         #{Bundler::Env.report}
@@ -82,6 +81,21 @@ module Bundler
         #{issues_url(e)}
 
         If there aren't any reports for this error yet, please fill in the new issue form located at #{new_issue_url}, and copy and paste the report template above in there.
+      EOS
+    end
+
+    def exception_message(error)
+      message = serialized_exception_for(error)
+      cause = error.cause
+      return message unless cause
+
+      message + serialized_exception_for(cause)
+    end
+
+    def serialized_exception_for(e)
+      <<-EOS.gsub(/^ {8}/, "")
+        #{e.class}: #{e.message}
+          #{e.backtrace && e.backtrace.join("\n          ").chomp}
       EOS
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If the exception making the bug report template show up has `#cause` (exceptions raised when handling other exceptions), bundler will omit to display the cause, making the bug report less useful and more confusing.

## What is your fix for the problem, implemented in this PR?

My fix is to display the cause if it's there.

This should improve the error message reported at #5556.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
