### PR TITLE
Show better error when previous installation fails to be removed

### DIFF
--- a/bundler/lib/bundler/errors.rb
+++ b/bundler/lib/bundler/errors.rb
@@ -79,10 +79,6 @@ module Bundler
       case @permission_type
       when :create
         "executable permissions for all parent directories and write permissions for `#{parent_folder}`"
-      when :delete
-        permissions = "executable permissions for all parent directories and write permissions for `#{parent_folder}`"
-        permissions += ", and the same thing for all subdirectories inside #{@path}" if File.directory?(@path)
-        permissions
       else
         "#{@permission_type} permissions for that path"
       end
@@ -171,5 +167,17 @@ module Bundler
     end
 
     status_code(32)
+  end
+
+  class DirectoryRemovalError < BundlerError
+    def initialize(orig_exception, msg)
+      full_message = "#{msg}.\n" \
+                     "The underlying error was #{orig_exception.class}: #{orig_exception.message}, with backtrace:\n" \
+                     "  #{orig_exception.backtrace.join("\n  ")}\n\n" \
+                     "Bundler Error Backtrace:"
+      super(full_message)
+    end
+
+    status_code(36)
   end
 end

--- a/bundler/lib/bundler/rubygems_gem_installer.rb
+++ b/bundler/lib/bundler/rubygems_gem_installer.rb
@@ -93,14 +93,9 @@ module Bundler
     private
 
     def strict_rm_rf(dir)
-      # FileUtils.rm_rf should probably rise in case of permission issues like
-      # `rm -rf` does. However, it fails to delete the folder silently due to
-      # https://github.com/ruby/fileutils/issues/57. It should probably be fixed
-      # inside `fileutils` but for now I`m checking whether the folder was
-      # removed after it completes, and raising otherwise.
-      FileUtils.rm_rf dir
-
-      raise PermissionError.new(dir, :delete) if File.directory?(dir)
+      Bundler.rm_rf dir
+    rescue Errno::ENOTEMPTY => e
+      raise DirectoryRemovalError.new(e.cause, "Could not delete previous installation of `#{dir}`")
     end
 
     def validate_bundler_checksum(checksum)

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -755,12 +755,8 @@ RSpec.describe "bundle install with gem sources" do
       end
 
       expect(err).not_to include("ERROR REPORT TEMPLATE")
-
-      expect(err).to include(
-        "There was an error while trying to delete `#{foo_path}`. " \
-        "It is likely that you need to grant executable permissions for all parent directories " \
-        "and write permissions for `#{gems_path}`, and the same thing for all subdirectories inside #{foo_path}."
-      )
+      expect(err).to include("Could not delete previous installation of `#{foo_path}`.")
+      expect(err).to include("The underlying error was Errno::EACCES")
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

A [while ago](https://github.com/rubygems/rubygems/pull/4965) we improved our handling of permission issues, but detecting when a preexisting installation of a gem fails to be removed, and raise an error, instead of silently ignoring the issue and crash with a more confusing error somewhere else.

I've seen the new error in the wild, and although better, it doesn't make it clear what the original error was that prevented Bundler from being able to delete the folder.
 
## What is your fix for the problem, implemented in this PR?

My fix is to use a better helper for deleting folder, that does not swallow any errors, and properly report the underlying issue when errors happen.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
