### PR TITLE
Exclude `Rakefile` file from new gems

### DIFF
--- a/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(__dir__) do
     `git ls-files -z`.split("\x0").reject do |f|
-      (f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features)/|\.(?:git|travis|circleci)|appveyor)})
+      (f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features)/|\.(?:git|travis|circleci)|appveyor|Rakefile)})
     end
   end
   spec.bindir = "exe"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Often unused files after installation are included in gem files.

## What is your fix for the problem, implemented in this PR?

Exclude files for `rake`.

All `[A-Z]\w+file` may be unnecessary.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
