### PR TITLE
Fix rubygems update when non default `--install-dir` is configured

### DIFF
--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -173,10 +173,11 @@ command to remove old versions.
     highest_remote_gem.first
   end
 
-  def install_rubygems(version) # :nodoc:
+  def install_rubygems(spec) # :nodoc:
     args = update_rubygems_arguments
+    version = spec.version
 
-    update_dir = File.join Gem.dir, 'gems', "rubygems-update-#{version}"
+    update_dir = File.join spec.base_dir, 'gems', "rubygems-update-#{version}"
 
     Dir.chdir update_dir do
       say "Installing RubyGems #{version}" unless options[:silent]
@@ -290,9 +291,7 @@ command to remove old versions.
     installed_gems = update_gem('rubygems-update', version) if installed_gems.empty? || installed_gems.first.version != version
     return if installed_gems.empty?
 
-    version = installed_gems.first.version
-
-    install_rubygems version
+    install_rubygems installed_gems.first
   end
 
   def update_rubygems_arguments # :nodoc:


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If RubyGems is configured with a non default `--install-dir`, `gem update --system` will fail because it tries to switching to the `rubygems-update` installation folder in the default gem dir, and the gem is not there.

## What is your fix for the problem, implemented in this PR?

Use `spec.base_dir` of the installed updater gem, instead of always using `Gem.dir`.

Fixes https://github.com/rubygems/rubygems/issues/5541.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
