### PR TITLE
Simplify finding target version in `gem update --system`

### DIFF
--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -163,8 +163,7 @@ command to remove old versions.
     spec_tuples = fetch_remote_gems spec
 
     highest_remote_gem = spec_tuples.max
-
-    highest_remote_gem ||= [Gem::NameTuple.null]
+    return unless highest_remote_gem
 
     highest_remote_gem.first
   end
@@ -209,30 +208,22 @@ command to remove old versions.
     version = options[:system]
     update_latest = version == true
 
-    if update_latest
-      version     = Gem::Version.new     Gem::VERSION
-      requirement = Gem::Requirement.new ">= #{Gem::VERSION}"
-    else
+    unless update_latest
       version     = Gem::Version.new     version
       requirement = Gem::Requirement.new version
+
+      return version, requirement
     end
+
+    version     = Gem::Version.new     Gem::VERSION
+    requirement = Gem::Requirement.new ">= #{Gem::VERSION}"
 
     rubygems_update         = Gem::Specification.new
     rubygems_update.name    = 'rubygems-update'
     rubygems_update.version = version
 
-    hig = {
-      'rubygems-update' => rubygems_update,
-    }
-
-    gems_to_update = which_to_update hig, options[:args], :system
-    up_ver = gems_to_update.first.version
-
-    target = if update_latest
-      up_ver
-    else
-      version
-    end
+    highest_remote_tup = highest_remote_name_tuple(rubygems_update)
+    target = highest_remote_tup ? highest_remote_tup.version : version
 
     return target, requirement
   end
@@ -303,7 +294,7 @@ command to remove old versions.
     args
   end
 
-  def which_to_update(highest_installed_gems, gem_names, system = false)
+  def which_to_update(highest_installed_gems, gem_names)
     result = []
 
     highest_installed_gems.each do |l_name, l_spec|
@@ -311,12 +302,9 @@ command to remove old versions.
               gem_names.none? {|name| name == l_spec.name }
 
       highest_remote_tup = highest_remote_name_tuple l_spec
-      highest_remote_ver = highest_remote_tup.version
-      highest_installed_ver = l_spec.version
+      next unless highest_remote_tup
 
-      if system or (highest_installed_ver < highest_remote_ver)
-        result << Gem::NameTuple.new(l_spec.name, [highest_installed_ver, highest_remote_ver].max, highest_remote_tup.platform)
-      end
+      result << highest_remote_tup
     end
 
     result

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -162,11 +162,7 @@ command to remove old versions.
   def highest_remote_name_tuple(spec) # :nodoc:
     spec_tuples = fetch_remote_gems spec
 
-    matching_gems = spec_tuples.select do |g,_|
-      g.name == spec.name and g.match_platform?
-    end
-
-    highest_remote_gem = matching_gems.max
+    highest_remote_gem = spec_tuples.max
 
     highest_remote_gem ||= [Gem::NameTuple.null]
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The `gem update --system` code is sometimes too complicated and performs unnecessary stuff. 

## What is your fix for the problem, implemented in this PR?

Simplify the code.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
