### PR TITLE
Ignore `Errno::EROFS` errors when creating `bundler.lock`

### DIFF
--- a/bundler/lib/bundler/process_lock.rb
+++ b/bundler/lib/bundler/process_lock.rb
@@ -12,7 +12,7 @@ module Bundler
         yield
         f.flock(File::LOCK_UN)
       end
-    rescue Errno::EACCES, Errno::ENOLCK, Errno::ENOTSUP, Errno::EPERM
+    rescue Errno::EACCES, Errno::ENOLCK, Errno::ENOTSUP, Errno::EPERM, Errno::EROFS
       # In the case the user does not have access to
       # create the lock file or is using NFS where
       # locks are not available we skip locking.

--- a/bundler/spec/install/process_lock_spec.rb
+++ b/bundler/spec/install/process_lock_spec.rb
@@ -42,5 +42,16 @@ RSpec.describe "process lock spec" do
         expect(processed).to eq true
       end
     end
+
+    context "when creating a lock raises Errno::EROFS" do
+      before { allow(File).to receive(:open).and_raise(Errno::EROFS) }
+
+      it "skips creating the lock file and yields" do
+        processed = false
+        Bundler::ProcessLock.lock(default_bundle_path) { processed = true }
+
+        expect(processed).to eq true
+      end
+    end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Apparently old versions of MacOS would set `GEM_HOME` to a `/System` folder, and trying to create a file there raises `Errno::EROFS`. I think this is the equivalent error to the one fixed by #5579, but on older versions of MacOS, which I guess didn't have the System Integrity Protection feature.

## What is your fix for the problem, implemented in this PR?

The fix is the same as #5579, ignore the error like it's done for other permission errors.

Fixes #5349.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
