### PR TITLE
Give better conflict resolution advice

### DIFF
--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -395,7 +395,7 @@ module Bundler
             o << %(\n  Current #{name} version:\n    #{SharedHelpers.pretty_dependency(@metadata_requirements.find {|req| req.name == name })}\n\n)
           elsif conflict.locked_requirement
             o << "\n"
-            o << %(Running `bundle update` will rebuild your snapshot from scratch, using only\n)
+            o << %(Deleting your #{name_for_locking_dependency_source} file and running `bundle install` will rebuild your snapshot from scratch, using only\n)
             o << %(the gems in your Gemfile, which may resolve the conflict.\n)
           elsif !conflict.existing
             o << "\n"

--- a/bundler/spec/install/gems/flex_spec.rb
+++ b/bundler/spec/install/gems/flex_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe "bundle flex_install" do
     end
   end
 
-  describe "when Gemfile conflicts with lockfile" do
+  describe "when running bundle install and Gemfile conflicts with lockfile" do
     before(:each) do
       build_repo2
       install_gemfile <<-G
@@ -190,7 +190,7 @@ RSpec.describe "bundle flex_install" do
       expect(err).to match(/could not find gem 'rack-obama/i)
     end
 
-    it "suggests bundle update when the Gemfile requires different versions than the lock" do
+    it "suggests deleting the Gemfile.lock file when the Gemfile requires different versions than the lock" do
       bundle "config set force_ruby_platform true"
 
       nice_error = <<-E.strip.gsub(/^ {8}/, "")
@@ -205,11 +205,72 @@ RSpec.describe "bundle flex_install" do
             rack_middleware was resolved to 1.0, which depends on
               rack (= 0.9.1)
 
-        Running `bundle update` will rebuild your snapshot from scratch, using only
+        Deleting your Gemfile.lock file and running `bundle install` will rebuild your snapshot from scratch, using only
         the gems in your Gemfile, which may resolve the conflict.
       E
 
       bundle :install, :retry => 0, :raise_on_error => false
+      expect(err).to end_with(nice_error)
+    end
+  end
+
+  describe "when running bundle update and Gemfile conflicts with lockfile" do
+    before(:each) do
+      build_repo4 do
+        build_gem "jekyll-feed", "0.16.0"
+        build_gem "jekyll-feed", "0.15.1"
+
+        build_gem "github-pages", "226" do |s|
+          s.add_dependency "jekyll-feed", "0.15.1"
+        end
+      end
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo4)}"
+        gem "jekyll-feed", "~> 0.12"
+      G
+
+      puts lockfile
+      lockfile <<-L
+        GEM
+          remote: #{file_uri_for(gem_repo4)}/
+          specs:
+            jekyll-feed (0.16.0)
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          jekyll-feed
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo4)}"
+        gem "github-pages", "~> 226"
+        gem "jekyll-feed", "~> 0.12"
+      G
+    end
+
+    it "suggests deleting the Gemfile.lock file when the Gemfile requires different versions than the lock" do
+      nice_error = <<-E.strip.gsub(/^ {8}/, "")
+        Bundler could not find compatible versions for gem "jekyll-feed":
+          In snapshot (Gemfile.lock):
+            jekyll-feed (>= 0.16.0)
+
+          In Gemfile:
+            jekyll-feed (~> 0.12)
+
+            github-pages (~> 226) was resolved to 226, which depends on
+              jekyll-feed (= 0.15.1)
+
+        Deleting your Gemfile.lock file and running `bundle install` will rebuild your snapshot from scratch, using only
+        the gems in your Gemfile, which may resolve the conflict.
+      E
+
+      bundle :update, :raise_on_error => false
       expect(err).to end_with(nice_error)
     end
   end


### PR DESCRIPTION

## What was the end-user or developer problem that led to this PR?

Under some circumstances, a user running `bundle update` and getting a resolution conflict might be given the absurd advice of running `bundle update` again.

## What is your fix for the problem, implemented in this PR?

My fix is to recommend deleting the `Gemfile.lock` and running `bundle install` instead.

This alternative really uses only the Gemfile, and can never end up being absurd, because it will never be suggested when there's no lockfile, and it suggests deleting the lockfile.

Fixes #5555.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
