### PR TITLE
Fix generated standalone script when it includes default gems

### DIFF
--- a/bundler/lib/bundler/stub_specification.rb
+++ b/bundler/lib/bundler/stub_specification.rb
@@ -64,9 +64,7 @@ module Bundler
     end
 
     def full_gem_path
-      # deleted gems can have their stubs return nil, so in that case grab the
-      # expired path from the full spec
-      stub.full_gem_path || method_missing(:full_gem_path)
+      stub.full_gem_path
     end
 
     def full_require_paths

--- a/bundler/lib/bundler/stub_specification.rb
+++ b/bundler/lib/bundler/stub_specification.rb
@@ -67,6 +67,10 @@ module Bundler
       stub.full_gem_path
     end
 
+    def full_gem_path=(path)
+      stub.full_gem_path = path
+    end
+
     def full_require_paths
       stub.full_require_paths
     end

--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -147,9 +147,16 @@ RSpec.shared_examples "bundle install --standalone" do
       bundle "lock", :dir => cwd, :artifice => "compact_index"
     end
 
-    it "works" do
+    it "works and points to the vendored copies, not to the default copies" do
       bundle "config set --local path #{bundled_app("bundle")}"
       bundle :install, :standalone => true, :dir => cwd, :artifice => "compact_index", :env => { "BUNDLER_GEM_DEFAULT_DIR" => system_gem_path.to_s }
+
+      load_path_lines = bundled_app("bundle/bundler/setup.rb").read.split("\n").select {|line| line.start_with?("$:.unshift") }
+
+      expect(load_path_lines).to eq [
+        '$:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{RbConfig::CONFIG["ruby_version"]}/gems/bar-1.0.0/lib")',
+        '$:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{RbConfig::CONFIG["ruby_version"]}/gems/foo-1.0.0/lib")',
+      ]
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When running `bundle install --standalone`, if the resolution includes default gems, the generated standalone script will point to the system default gems, not to their vendored copies.

## What is your fix for the problem, implemented in this PR?

Bundler is changing `full_gem_path` to match the installed gem to achieve this, right after installing gems:

https://github.com/rubygems/rubygems/blob/765996dde91e3b8e8108d5e6d9ff155425888ecb/bundler/lib/bundler/source/rubygems.rb#L205

However, this accessor was not working properly for `StubSpecification`'s.
 
Fixes #5493.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
