### PR TITLE
Skip duplicated dependency warning for gemspec dev deps

### DIFF
--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -124,18 +124,16 @@ module Bundler
             raise GemfileError, "You cannot specify the same gem twice with different version requirements.\n" \
                             "You specified: #{current.name} (#{current.requirement}) and #{dep.name} (#{dep.requirement})" \
                              "#{update_prompt}"
+          elsif current.source != dep.source
+            return if dep.type == :development
+            raise GemfileError, "You cannot specify the same gem twice coming from different sources.\n" \
+                            "You specified that #{dep.name} (#{dep.requirement}) should come from " \
+                            "#{current.source || "an unspecified source"} and #{dep.source}\n"
           else
             Bundler.ui.warn "Your Gemfile lists the gem #{current.name} (#{current.requirement}) more than once.\n" \
                             "You should probably keep only one of them.\n" \
                             "Remove any duplicate entries and specify the gem only once.\n" \
                             "While it's not a problem now, it could cause errors if you change the version of one of them later."
-          end
-
-          if current.source != dep.source
-            return if dep.type == :development
-            raise GemfileError, "You cannot specify the same gem twice coming from different sources.\n" \
-                            "You specified that #{dep.name} (#{dep.requirement}) should come from " \
-                            "#{current.source || "an unspecified source"} and #{dep.source}\n"
           end
         end
       end

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -1255,6 +1255,32 @@ RSpec.describe "bundle install with gems on multiple sources" do
     end
   end
 
+  context "when Gemfile overrides a gemspec development dependency to change the default source" do
+    before do
+      build_repo4 do
+        build_gem "bar"
+      end
+
+      build_lib("gemspec_test", :path => tmp.join("gemspec_test")) do |s|
+        s.add_development_dependency "bar"
+      end
+
+      install_gemfile <<-G, :artifice => "compact_index"
+        source "https://gem.repo1"
+
+        source "https://gem.repo4" do
+          gem "bar"
+        end
+
+        gemspec :path => "#{tmp.join("gemspec_test")}"
+      G
+    end
+
+    it "does not print warnings" do
+      expect(err).to be_empty
+    end
+  end
+
   it "doesn't update version when a gem uses a source block but a higher version from another source is already installed locally" do
     build_repo2 do
       build_gem "example", "0.1.0"


### PR DESCRIPTION
Generally this warning is skipped for gemspec development dependencies.
I think because it's common to override them in the Gemfile to change
the source, for example.

But the order of conditions was not correct and the warning was still
being printed in one case.



## What was the end-user or developer problem that led to this PR?

Under some circumstances, a user may get a warning about a dependency duplicated in the Gemfile, it's only overriding one dependency in the gemspec, which is common to change the source for example.

## What is your fix for the problem, implemented in this PR?

My fix is to change the order of conditions, so that this warning is skipped in this case too.

Fixes #5450.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
