### PR TITLE
Improve our SHA1 implementation

### DIFF
--- a/bundler/lib/bundler/digest.rb
+++ b/bundler/lib/bundler/digest.rb
@@ -43,7 +43,7 @@ module Bundler
               f = (b ^ c ^ d)
               k = 0xCA62C1D6
             end
-            t = SHA1_MASK & (SHA1_MASK & rotate(a, 5) + f + e + k + w[i])
+            t = SHA1_MASK & rotate(a, 5) + f + e + k + w[i]
             a, b, c, d, e = t, a, SHA1_MASK & rotate(b, 30), c, d # rubocop:disable Style/ParallelAssignment
           end
           mutated = [a, b, c, d, e]

--- a/bundler/spec/bundler/digest_spec.rb
+++ b/bundler/spec/bundler/digest_spec.rb
@@ -9,8 +9,15 @@ RSpec.describe Bundler::Digest do
     let(:stdlib) { ::Digest::SHA1 }
 
     it "is compatible with stdlib" do
-      ["foo", "skfjsdlkfjsdf", "3924m", "ldskfj"].each do |payload|
-        expect(subject.sha1(payload)).to be == stdlib.hexdigest(payload)
+      random_strings = ["foo", "skfjsdlkfjsdf", "3924m", "ldskfj"]
+
+      # https://datatracker.ietf.org/doc/html/rfc3174#section-7.3
+      rfc3174_test_cases = ["abc", "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq", "a", "01234567" * 8]
+
+      (random_strings + rfc3174_test_cases).each do |payload|
+        sha1 = subject.sha1(payload)
+        sha1_stdlib = stdlib.hexdigest(payload)
+        expect(sha1).to be == sha1_stdlib, "#{payload}'s sha1 digest (#{sha1}) did not match stlib's result (#{sha1_stdlib})"
       end
     end
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

It was noted that there's a redundant bitwise AND, and also I found that the bitwise AND here

https://github.com/rubygems/rubygems/blob/7e5765a66c9fe5187b167f619f34db5db121f2df/bundler/lib/bundler/digest.rb#L50

was not covered by any specs.

## What is your fix for the problem, implemented in this PR?

Fix both issues by removing the redundant `&` and by adding more specs from the RFC.

Closes #5591.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
