### PR TITLE
Unify loading `Gem::Requirement`

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1303,6 +1303,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   autoload :NameTuple,          File.expand_path('rubygems/name_tuple', __dir__)
   autoload :PathSupport,        File.expand_path('rubygems/path_support', __dir__)
   autoload :RequestSet,         File.expand_path('rubygems/request_set', __dir__)
+  autoload :Requirement,        File.expand_path('rubygems/requirement', __dir__)
   autoload :Resolver,           File.expand_path('rubygems/resolver', __dir__)
   autoload :Source,             File.expand_path('rubygems/source', __dir__)
   autoload :SourceList,         File.expand_path('rubygems/source_list', __dir__)

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -10,7 +10,6 @@ require_relative 'deprecate'
 require_relative 'basic_specification'
 require_relative 'stub_specification'
 require_relative 'platform'
-require_relative 'requirement'
 require_relative 'util/list'
 
 ##

--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -153,8 +153,6 @@ require_relative "deprecate"
 # a zero to give a sensible result.
 
 class Gem::Version
-  autoload :Requirement, File.expand_path('requirement', __dir__)
-
   include Comparable
 
   VERSION_PATTERN = '[0-9]+(?>\.[0-9a-zA-Z]+)*(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?'.freeze # :nodoc:


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Setting an `autoload` inside a module different from where the constant is expected to be defined might be deprecated in the future. See https://github.com/ruby/ruby/pull/5949.

## What is your fix for the problem, implemented in this PR?

Unify loading `Gem::Requirement` with an `autoload` at the proper place.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
