### PR TITLE
Remove unnecessary string concatenation from `Gem::Specification.reset`

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1240,8 +1240,7 @@ class Gem::Specification < Gem::BasicSpecification
     clear_load_cache
     unresolved = unresolved_deps
     unless unresolved.empty?
-      w = "W" + "ARN"
-      warn "#{w}: Unresolved or ambiguous specs during Gem::Specification.reset:"
+      warn "WARN: Unresolved or ambiguous specs during Gem::Specification.reset:"
       unresolved.values.each do |dep|
         warn "      #{dep}"
 
@@ -1251,7 +1250,7 @@ class Gem::Specification < Gem::BasicSpecification
           versions.each {|s| warn "      - #{s.version}" }
         end
       end
-      warn "#{w}: Clearing out unresolved specs. Try 'gem cleanup <gem>'"
+      warn "WARN: Clearing out unresolved specs. Try 'gem cleanup <gem>'"
       warn "Please report a bug if this causes problems."
       unresolved.clear
     end


### PR DESCRIPTION
Sort of a followup to https://github.com/rubygems/rubygems/issues/5597, in which we discover that the reset method specification.rb has a goofy string construction that was originally written that way just to avoid syntax highlighting.

We don't need the word "WARN" (or in this case "W" + "ARN"), it's already using Ruby's `warn`.