### PR TITLE
Prevent a warning: `*' interpreted as argument prefix

### DIFF
--- a/test/rubygems/test_gem_ext_cargo_builder/rust_ruby_example/build.rb
+++ b/test/rubygems/test_gem_ext_cargo_builder/rust_ruby_example/build.rb
@@ -15,7 +15,7 @@ gemspec = File.expand_path('rust_ruby_example.gemspec', __dir__)
 
 Dir.mktmpdir("rust_ruby_example") do |dir|
   built_gem = File.expand_path(File.join(dir, "rust_ruby_example.gem"))
-  system *gem, "build", gemspec, "--output", built_gem
-  system *gem, "install", "--verbose", "--local", built_gem, *ARGV
+  system(*gem, "build", gemspec, "--output", built_gem)
+  system(*gem, "install", "--verbose", "--local", built_gem, *ARGV)
   system %q(ruby -rrust_ruby_example -e "puts 'Result: ' + RustRubyExample.reverse('hello world')")
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The test of cargo builder shows the warnings in test suite of ruby/ruby.

## What is your fix for the problem, implemented in this PR?

I picked the fix by @mame 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
