### PR TITLE
Make sure RubyGems prints no warnings when loading plugins

### DIFF
--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -62,6 +62,13 @@ jobs:
       - name: Run a remote rubygems command
         run: gem outdated
         if: matrix.openssl.value == true
+      - name: Check command in presence of a plugin that leaves unresolved dependencies prints no warnings
+        run: |
+          gem install attempt:0.6.2 rspec:3.10.0 rspec:3.11.0
+          mkdir -p tmp/plugin-home
+          echo "require 'attempt'" > tmp/plugin-home/rubygems_plugin.rb
+          RUBYOPT=-Itmp/plugin-home gem env version 2> errors.txt || (cat errors.txt && exit 1)
+          test ! -s errors.txt || (cat errors.txt && exit 1)
       - name: Run bundler installed as a default gem
         run: bundle --version
       - name: Check bundler man pages were installed and are properly picked up

--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -62,12 +62,14 @@ jobs:
       - name: Run a remote rubygems command
         run: gem outdated
         if: matrix.openssl.value == true
-      - name: Check command in presence of a plugin that leaves unresolved dependencies prints no warnings
+      - name: Check commands in presence of a plugin that leaves unresolved dependencies print no warnings
         run: |
           gem install attempt:0.6.2 rspec:3.10.0 rspec:3.11.0
           mkdir -p tmp/plugin-home
           echo "require 'attempt'" > tmp/plugin-home/rubygems_plugin.rb
           RUBYOPT=-Itmp/plugin-home gem env version 2> errors.txt || (cat errors.txt && exit 1)
+          test ! -s errors.txt || (cat errors.txt && exit 1)
+          RUBYOPT=-Itmp/plugin-home gem install sys-admin:1.8.1 2> errors.txt || (cat errors.txt && exit 1)
           test ! -s errors.txt || (cat errors.txt && exit 1)
       - name: Run bundler installed as a default gem
         run: bundle --version

--- a/lib/rubygems/gem_runner.rb
+++ b/lib/rubygems/gem_runner.rb
@@ -10,11 +10,6 @@ require_relative 'command_manager'
 require_relative 'deprecate'
 
 ##
-# Load additional plugins from $LOAD_PATH
-
-Gem.load_env_plugins rescue nil
-
-##
 # Run an instance of the gem program.
 #
 # Gem::GemRunner is only intended for internal use by RubyGems itself.  It
@@ -36,6 +31,9 @@ class Gem::GemRunner
     build_args = extract_build_args args
 
     do_configuration args
+
+    Gem.load_env_plugins rescue nil
+    Gem.load_plugins
 
     cmd = @command_manager_class.instance
 
@@ -75,5 +73,3 @@ class Gem::GemRunner
     Gem::Command.extra_args = Gem.configuration[:gem]
   end
 end
-
-Gem.load_plugins

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -340,7 +340,7 @@ class Gem::Installer
 
     say spec.post_install_message if options[:post_install_message] && !spec.post_install_message.nil?
 
-    Gem::Specification.reset
+    Gem::Specification.add_spec(spec)
 
     run_post_install_hooks
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -883,6 +883,21 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   ##
+  # Adds +spec+ to the known specifications, keeping the collection
+  # properly sorted.
+
+  def self.add_spec(spec)
+    return if _all.include? spec
+
+    _all << spec
+    stubs << spec
+    (@@stubs_by_name[spec.name] ||= []) << spec
+
+    _resort!(@@stubs_by_name[spec.name])
+    _resort!(stubs)
+  end
+
+  ##
   # Returns all specifications. This method is discouraged from use.
   # You probably want to use one of the Enumerable methods instead.
 

--- a/test/rubygems/test_gem_commands_pristine_command.rb
+++ b/test/rubygems/test_gem_commands_pristine_command.rb
@@ -412,6 +412,7 @@ class TestGemCommandsPristineCommand < Gem::TestCase
 
     install_gem specs["b-1"]
     FileUtils.rm File.join(gemhome2, 'cache', 'b-1.gem')
+    Gem::Specification.reset
 
     @cmd.options[:args] = %w[a b]
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3676,6 +3676,8 @@ end
 
     install_specs b
 
+    Gem::Specification.reset
+
     assert Gem::Specification.find_by_name "b"
 
     assert_raise Gem::MissingSpecVersionError do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Under some cirscumstances, RubyGems may print a warning about unresolved specifications when it doesn't seem like anything wrong is happening. This is because RubyGems calls `Gem::Specification.reset` too much.

## What is your fix for the problem, implemented in this PR?

My fix is to avoid calling `Gem::Specification.reset` when not necessary, and also delaying it a bit to happen after plugins are loaded when necessary. In particular:

* When initializing the `gem` CLI and setting the default `GEM_HOME` and `GEM_PATH`, `Gem::Specification.reset` is called. Make sure this happens _before_ loading RubyGems plugins and potentially activating gems.
* After installing gems, `Gem::Specification.reset` is called so that specification caches are invalidated, and the next time they are used, the gem just installed is also picked up. Make sure, instead, to manually add the installed gem to specification caches.

Fixes #5597.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
