### PR TITLE
Fix some cargo builder tests causing global side effects

### DIFF
--- a/test/rubygems/test_gem_ext_cargo_builder.rb
+++ b/test/rubygems/test_gem_ext_cargo_builder.rb
@@ -121,14 +121,15 @@ class TestGemExtCargoBuilder < Gem::TestCase
     Dir.chdir @ext do
       require 'tmpdir'
 
-      gem = [@rust_envs, *ruby_with_rubygems_in_load_path, File.expand_path('../../bin/gem', __dir__)]
+      env_for_subprocess = @rust_envs.merge("GEM_HOME" => Gem.paths.home)
+      gem = [env_for_subprocess, *ruby_with_rubygems_in_load_path, File.expand_path('../../bin/gem', __dir__)]
 
       Dir.mktmpdir("rust_ruby_example") do |dir|
         built_gem = File.expand_path(File.join(dir, "rust_ruby_example.gem"))
         Open3.capture2e(*gem, "build", "rust_ruby_example.gemspec", "--output", built_gem)
         Open3.capture2e(*gem, "install", "--verbose", "--local", built_gem, *ARGV)
 
-        stdout_and_stderr_str, status = Open3.capture2e(@rust_envs, *ruby_with_rubygems_in_load_path, "-rrust_ruby_example", "-e", "puts 'Result: ' + RustRubyExample.reverse('hello world')")
+        stdout_and_stderr_str, status = Open3.capture2e(env_for_subprocess, *ruby_with_rubygems_in_load_path, "-rrust_ruby_example", "-e", "puts 'Result: ' + RustRubyExample.reverse('hello world')")
         assert status.success?, stdout_and_stderr_str
         assert_match "Result: #{"hello world".reverse}", stdout_and_stderr_str
       end
@@ -142,7 +143,8 @@ class TestGemExtCargoBuilder < Gem::TestCase
     Dir.chdir @ext do
       require 'tmpdir'
 
-      gem = [@rust_envs, *ruby_with_rubygems_in_load_path, File.expand_path('../../bin/gem', __dir__)]
+      env_for_subprocess = @rust_envs.merge("GEM_HOME" => Gem.paths.home)
+      gem = [env_for_subprocess, *ruby_with_rubygems_in_load_path, File.expand_path('../../bin/gem', __dir__)]
 
       Dir.mktmpdir("custom_name") do |dir|
         built_gem = File.expand_path(File.join(dir, "custom_name.gem"))
@@ -150,7 +152,7 @@ class TestGemExtCargoBuilder < Gem::TestCase
         Open3.capture2e(*gem, "install", "--verbose", "--local", built_gem, *ARGV)
       end
 
-      stdout_and_stderr_str, status = Open3.capture2e(@rust_envs, *ruby_with_rubygems_in_load_path, "-rcustom_name", "-e", "puts 'Result: ' + CustomName.say_hello")
+      stdout_and_stderr_str, status = Open3.capture2e(env_for_subprocess, *ruby_with_rubygems_in_load_path, "-rcustom_name", "-e", "puts 'Result: ' + CustomName.say_hello")
 
       assert status.success?, stdout_and_stderr_str
       assert_match "Result: Hello world!", stdout_and_stderr_str


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Running these specs would leave a `rust_ruby_example` dummy gem installed to users' Ruby installation.

## What is your fix for the problem, implemented in this PR?

Prevent this kind of side effect by making sure the dummy gem is installed to the dummy GEM_HOME used for our tests.

#### Before

```
➜  rubygems git:(master) gem list rust

*** LOCAL GEMS ***


➜  rubygems git:(master) rake TESTOPTS=--name=test_full_integration
Loaded suite /Users/deivid/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/rake_test_loader
Started
gem list rust
.
Finished in 9.717763 seconds.
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1 tests, 2 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
0.10 tests/s, 0.21 assertions/s
➜  rubygems git:(master) gem list rust

*** LOCAL GEMS ***

rust_ruby_example (0.1.0)
```

#### After

```
➜  rubygems git:(fix-rust-tests-side-effects) gem list rust                           

*** LOCAL GEMS ***


➜  rubygems git:(fix-rust-tests-side-effects) rake TESTOPTS=--name=test_full_integration
Loaded suite /Users/deivid/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/rake_test_loader
Started
.
Finished in 9.300634 seconds.
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1 tests, 2 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
0.11 tests/s, 0.22 assertions/s
➜  rubygems git:(fix-rust-tests-side-effects) gem list rust                             

*** LOCAL GEMS ***


```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
