### PR TITLE
Remove `GETTING_HELP.md` document

### DIFF
--- a/bundler/README.md
+++ b/bundler/README.md
@@ -38,7 +38,7 @@ Still stuck? Try [filing an issue](https://github.com/rubygems/rubygems/issues/n
 
 To see what has changed in recent versions of Bundler, see the [CHANGELOG](CHANGELOG.md).
 
-To get in touch with the Bundler core team and other Bundler users, please see [getting help](doc/contributing/GETTING_HELP.md).
+To get in touch with the Bundler core team and other Bundler users, please join [the Bundler slack](https://slack.bundler.io).
 
 ### Contributing
 

--- a/bundler/doc/README.md
+++ b/bundler/doc/README.md
@@ -11,7 +11,7 @@ If you'd like to help make Bundler better, you totally rock! Thanks for helping 
 * [Overview & getting started](contributing/README.md)
 * [How you can help: your first contributions!](contributing/HOW_YOU_CAN_HELP.md)
 * [Bug triage](contributing/BUG_TRIAGE.md)
-* [Getting help](contributing/GETTING_HELP.md)
+* [Getting help](https://slack.bundler.io)
 * [Filing issues](https://github.com/rubygems/rubygems/issues/new?labels=Bundler&template=bundler-related-issue.md)
 * [Community](contributing/COMMUNITY.md)
 

--- a/bundler/doc/contributing/GETTING_HELP.md
+++ b/bundler/doc/contributing/GETTING_HELP.md
@@ -1,9 +1,0 @@
-# Getting help
-
-If you have any questions after reading the documentation for contributing, please feel free to contact either [@indirect](https://github.com/indirect), [@segiddins](https://github.com/segiddins), or [@RochesterinNYC](https://github.com/RochesterinNYC). They are all happy to provide help working through your first bug fix or thinking through the problem you're trying to resolve.
-
-The best ways to get in touch are:
-
-* [Bundler Slack](https://bundler.slack.com).
-  * Not a member of the Slack? Join the Bundler team slack [here](https://slack.bundler.io/)!
-* [Bundler mailing list](https://groups.google.com/group/ruby-bundler)

--- a/bundler/doc/contributing/HOW_YOU_CAN_HELP.md
+++ b/bundler/doc/contributing/HOW_YOU_CAN_HELP.md
@@ -2,7 +2,7 @@
 
 If you're interested in contributing to Bundler, that's awesome! We'd love your help.
 
-If at any point you get stuck, here's how to [get in touch with the Bundler team for help](GETTING_HELP.md).
+If at any point you get stuck, here's how to [get in touch with the Bundler team for help](https://slack.bundler.io).
 
 ## First contribution suggestions
 

--- a/bundler/doc/documentation/README.md
+++ b/bundler/doc/documentation/README.md
@@ -14,7 +14,7 @@ Not sure where to write documentation? In general, follow these guidelines:
 * For an explanation of a specific Bundler command (ex: `bundle clean`): make changes to the man pages
 * For longer explanations or usage guides (ex: "Using Bundler with Rails"): create new documentation within the [bundler-site](https://github.com/rubygems/bundler-site) repository
 
-If you are unsure where to begin, ping [@feministy](https://github.com/feministy) or [@indirect](https://github.com/indirect) in the Bundler Slack ([get an invite here](../contributing/GETTING_HELP.md)).
+If you are unsure where to begin, ping [@feministy](https://github.com/feministy) or [@indirect](https://github.com/indirect) in [the Bundler Slack](https://slack.bundler.io).
 
 ## [Writing docs for man pages](WRITING.md)
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The `GETTING_HELP.md` document links a mostly dead Google Group, and advices to ping individual
maintainers that are no longer active.

## What is your fix for the problem, implemented in this PR?

Unify everything pointing at Slack.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
