### PR TITLE
Improve performance of installing gems from gem server sources

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -251,9 +251,7 @@ module Bundler
       remembered_negative_flag_deprecation("no-deployment")
 
       require_relative "cli/install"
-      Bundler.settings.temporary(:no_install => false) do
-        Install.new(options.dup).run
-      end
+      Install.new(options.dup).run
     end
 
     map aliases_for("install")
@@ -299,9 +297,7 @@ module Bundler
     def update(*gems)
       SharedHelpers.major_deprecation(2, "The `--force` option has been renamed to `--redownload`") if ARGV.include?("--force")
       require_relative "cli/update"
-      Bundler.settings.temporary(:no_install => false) do
-        Update.new(options, gems).run
-      end
+      Update.new(options, gems).run
     end
 
     desc "show GEM [OPTIONS]", "Shows all gems that are part of the bundle, or the path to a given gem"

--- a/bundler/lib/bundler/cli/cache.rb
+++ b/bundler/lib/bundler/cli/cache.rb
@@ -14,7 +14,7 @@ module Bundler
       Bundler.settings.set_command_option_if_given :cache_path, options["cache-path"]
 
       setup_cache_all
-      install
+      install unless Bundler.settings[:no_install]
 
       # TODO: move cache contents here now that all bundles are locked
       custom_path = Bundler.settings[:path] if options[:path]

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -161,8 +161,6 @@ module Bundler
 
       Bundler.settings.set_command_option_if_given :no_prune, options["no-prune"]
 
-      Bundler.settings.set_command_option_if_given :no_install, options["no-install"]
-
       Bundler.settings.set_command_option_if_given :clean, options["clean"]
 
       normalize_groups if options[:without] || options[:with]

--- a/bundler/lib/bundler/rubygems_gem_installer.rb
+++ b/bundler/lib/bundler/rubygems_gem_installer.rb
@@ -90,6 +90,14 @@ module Bundler
       end
     end
 
+    def spec
+      if Bundler.rubygems.provides?("< 3.3.12") # RubyGems implementation rescues and re-raises errors before 3.3.12 and we don't want that
+        @package.spec
+      else
+        super
+      end
+    end
+
     private
 
     def strict_rm_rf(dir)

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -206,16 +206,10 @@ module Bundler
     def spec_from_gem(path, policy = nil)
       require "psych"
       gem_from_path(path, security_policies[policy]).spec
-    rescue Exception, Gem::Exception, Gem::Security::Exception => e # rubocop:disable Lint/RescueException
-      if e.is_a?(Gem::Security::Exception) ||
-          e.message =~ /unknown trust policy|unsigned gem/i ||
-          e.message =~ /couldn't verify (meta)?data signature/i
-        raise SecurityError,
-          "The gem #{File.basename(path, ".gem")} can't be installed because " \
-          "the security policy didn't allow it, with the message: #{e.message}"
-      else
-        raise e
-      end
+    rescue Gem::Security::Exception => e
+      raise SecurityError,
+        "The gem #{File.basename(path, ".gem")} can't be installed because " \
+        "the security policy didn't allow it, with the message: #{e.message}"
     end
 
     def build_gem(gem_dir, spec)

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -204,7 +204,6 @@ module Bundler
     end
 
     def spec_from_gem(path, policy = nil)
-      require "rubygems/security"
       require "psych"
       gem_from_path(path, security_policies[policy]).spec
     rescue Exception, Gem::Exception, Gem::Security::Exception => e # rubocop:disable Lint/RescueException

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -205,10 +205,6 @@ module Bundler
 
     def spec_from_gem(path, policy = nil)
       gem_from_path(path, security_policies[policy]).spec
-    rescue Gem::Security::Exception => e
-      raise SecurityError,
-        "The gem #{File.basename(path, ".gem")} can't be installed because " \
-        "the security policy didn't allow it, with the message: #{e.message}"
     end
 
     def build_gem(gem_dir, spec)

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -204,7 +204,6 @@ module Bundler
     end
 
     def spec_from_gem(path, policy = nil)
-      require "psych"
       gem_from_path(path, security_policies[policy]).spec
     rescue Gem::Security::Exception => e
       raise SecurityError,

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -203,8 +203,9 @@ module Bundler
       EXT_LOCK
     end
 
-    def spec_from_gem(path, policy = nil)
-      gem_from_path(path, security_policies[policy]).spec
+    def spec_from_gem(path)
+      require "rubygems/package"
+      Gem::Package.new(path).spec
     end
 
     def build_gem(gem_dir, spec)
@@ -496,13 +497,6 @@ module Bundler
       require "rubygems/remote_fetcher"
       proxy = Gem.configuration[:http_proxy]
       Gem::RemoteFetcher.new(proxy)
-    end
-
-    def gem_from_path(path, policy = nil)
-      require "rubygems/package"
-      p = Gem::Package.new(path)
-      p.security_policy = policy if policy
-      p
     end
 
     def build(spec, skip_validation = false)

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -462,6 +462,7 @@ module Bundler
 
         cache_path = download_cache_path(spec) || default_cache_path_for(rubygems_dir)
         gem_path = "#{cache_path}/#{spec.file_name}"
+        return gem_path if File.exist?(gem_path)
 
         if requires_sudo?
           download_path = Bundler.tmp(spec.full_name)

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -157,6 +157,10 @@ module Bundler
           path = fetch_gem(spec, options[:previous_spec])
           begin
             s = Bundler.rubygems.spec_from_gem(path, Bundler.settings["trust-policy"])
+          rescue Gem::Security::Exception => e
+            raise SecurityError,
+              "The gem #{File.basename(path, ".gem")} can't be installed because " \
+              "the security policy didn't allow it, with the message: #{e.message}"
           rescue Gem::Package::FormatError
             Bundler.rm_rf(path)
             raise

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -168,6 +168,9 @@ module Bundler
             Bundler.rm_rf(path)
             raise
           end
+        else
+          path = cached_gem(spec)
+          raise GemNotFound, "Could not find #{spec.file_name} for installation" unless path
         end
 
         unless Bundler.settings[:no_install]
@@ -175,8 +178,6 @@ module Bundler
           message += " with native extensions" if spec.extensions.any?
           Bundler.ui.confirm message
 
-          path = cached_gem(spec)
-          raise GemNotFound, "Could not find #{spec.file_name} for installation" unless path
           if requires_sudo?
             install_path = Bundler.tmp(spec.full_name)
             bin_path     = install_path.join("bin")

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -157,9 +157,7 @@ module Bundler
         # by rubygems.org are broken and wrong.
         if spec.remote
           # Check for this spec from other sources
-          uris = [spec.remote.anonymized_uri]
-          uris += remotes_for_spec(spec).map(&:anonymized_uri)
-          uris.uniq!
+          uris = [spec.remote, *remotes_for_spec(spec)].map(&:anonymized_uri).uniq
           Installer.ambiguous_gems << [spec.name, *uris] if uris.length > 1
 
           path = fetch_gem(spec, options[:previous_spec])

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -457,8 +457,6 @@ module Bundler
       end
 
       def fetch_gem(spec, previous_spec = nil)
-        return false unless spec.remote
-
         spec.fetch_platform
 
         cache_path = download_cache_path(spec) || default_cache_path_for(rubygems_dir)

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -139,13 +139,9 @@ module Bundler
         force = options[:force]
         ensure_builtin_gems_cached = options[:ensure_builtin_gems_cached]
 
-        if ensure_builtin_gems_cached && spec.default_gem?
-          if !cached_path(spec)
-            cached_built_in_gem(spec) unless spec.remote
-            force = true
-          else
-            spec.loaded_from = loaded_from(spec)
-          end
+        if ensure_builtin_gems_cached && spec.default_gem? && !cached_path(spec)
+          cached_built_in_gem(spec) unless spec.remote
+          force = true
         end
 
         if installed?(spec) && !force
@@ -201,6 +197,7 @@ module Bundler
           :bundler_extension_cache_path => extension_cache_path(spec)
         ).install
         spec.full_gem_path = installed_spec.full_gem_path
+        spec.loaded_from = installed_spec.loaded_from
 
         # SUDO HAX
         if requires_sudo?
@@ -226,8 +223,6 @@ module Bundler
             Bundler.sudo "cp -R #{install_path}/bin/#{exe} #{Bundler.system_bindir}/"
           end
         end
-        installed_spec.loaded_from = loaded_from(spec)
-        spec.loaded_from = loaded_from(spec)
 
         spec.post_install_message
       ensure
@@ -343,10 +338,6 @@ module Bundler
           uris << s.remote if s.remote
           uris
         end
-      end
-
-      def loaded_from(spec)
-        "#{rubygems_dir}/specifications/#{spec.full_name}.gemspec"
       end
 
       def cached_gem(spec)

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -361,8 +361,12 @@ module Bundler
         global_cache_path = download_cache_path(spec)
         @caches << global_cache_path if global_cache_path
 
-        possibilities = @caches.map {|p| "#{p}/#{spec.file_name}" }
+        possibilities = @caches.map {|p| package_path(p, spec) }
         possibilities.find {|p| File.exist?(p) }
+      end
+
+      def package_path(cache_path, spec)
+        "#{cache_path}/#{spec.file_name}"
       end
 
       def normalize_uri(uri)
@@ -459,7 +463,7 @@ module Bundler
         spec.fetch_platform
 
         cache_path = download_cache_path(spec) || default_cache_path_for(rubygems_dir)
-        gem_path = "#{cache_path}/#{spec.file_name}"
+        gem_path = package_path(cache_path, spec)
         return gem_path if File.exist?(gem_path)
 
         if requires_sudo?
@@ -478,7 +482,7 @@ module Bundler
           SharedHelpers.filesystem_access(cache_path) do |p|
             Bundler.mkdir_p(p)
           end
-          Bundler.sudo "mv #{download_cache_path}/#{spec.file_name} #{gem_path}"
+          Bundler.sudo "mv #{package_path(download_cache_path, spec)} #{gem_path}"
         end
 
         gem_path

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -149,8 +149,6 @@ module Bundler
           return nil # no post-install message
         end
 
-        # Download the gem to get the spec, because some specs that are returned
-        # by rubygems.org are broken and wrong.
         if spec.remote
           # Check for this spec from other sources
           uris = [spec.remote, *remotes_for_spec(spec)].map(&:anonymized_uri).uniq

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -157,11 +157,12 @@ module Bundler
           path = fetch_gem(spec, options[:previous_spec])
           begin
             s = Bundler.rubygems.spec_from_gem(path, Bundler.settings["trust-policy"])
-            spec.__swap__(s)
           rescue Gem::Package::FormatError
             Bundler.rm_rf(path)
             raise
           end
+
+          spec.__swap__(s)
         else
           path = cached_gem(spec)
           raise GemNotFound, "Could not find #{spec.file_name} for installation" unless path


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This originally started because I wanted to do a fix involving printing a warning when certain gemspecs are unpacked from the downloaded `.gem` package and I noticed that for every gem installed, Bundler creates two `Gem::Package` instances and unpacks the specification from each of them. So the warning would be printed twice.

## What is your fix for the problem, implemented in this PR?

My fix is to make sure a single `Gem::Package` is created when installing each gem.

This turns out to provide speed and memory improvements 🎉.

For example using dependency files from the activeadmin repository at https://github.com/activeadmin/activeadmin/pull/7543 (modified to remove the `sassy-rails` dependency since otherwise it eats up most `bundle install` time, and configuring bundler to install to `vendor/bundle`), I get the following results:

```
✗ hyperfine 'BUNDLER_VERSION=2.4.0.dev bundle install' 'BUNDLER_VERSION=2.3.15 bundle install' --prepare 'rm -rf vendor/bundle'
Benchmark 1: BUNDLER_VERSION=2.4.0.dev bundle install
  Time (mean ± σ):      8.377 s ±  0.267 s    [User: 11.841 s, System: 6.485 s]
  Range (min … max):    8.017 s …  8.869 s    10 runs
 
Benchmark 2: BUNDLER_VERSION=2.3.15 bundle install
  Time (mean ± σ):      9.146 s ±  0.149 s    [User: 13.060 s, System: 7.185 s]
  Range (min … max):    8.910 s …  9.404 s    10 runs
 
Summary
  'BUNDLER_VERSION=2.4.0.dev bundle install' ran
    1.09 ± 0.04 times faster than 'BUNDLER_VERSION=2.3.15 bundle install'
```

And with memory

```
➜  activeadmin git:(add-darwin) ✗ rm -rf vendor/bundle && BUNDLER_VERSION=2.3.15 ruby-memory-profiler --pretty --no-detailed --allocated-strings=0 --retained-strings=0 /Users/deivid/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.15/exe/bundle install -- --quiet
Total allocated: 1.06 GB (5656647 objects)
Total retained:  88.13 MB (1187607 objects)

➜  activeadmin git:(add-darwin) ✗ rm -rf vendor/bundle && BUNDLER_VERSION=2.4.0.dev ruby-memory-profiler --pretty --no-detailed --allocated-strings=0 --retained-strings=0 /Users/deivid/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.4.0.dev/exe/bundle install -- --quiet
Total allocated: 918.79 MB (5373031 objects)
Total retained:  88.10 MB (1188919 objects)
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
