### PR TITLE
Auto-fix and warn gem packages including a gemspec with `require_paths` as an array of arrays

### DIFF
--- a/bundler/spec/realworld/edgecases_spec.rb
+++ b/bundler/spec/realworld/edgecases_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe "real world edgecases", :realworld => true do
     expect(lockfile).to include(rubygems_version("paperclip", "~> 5.1.0"))
   end
 
-  it "outputs a helpful error message when gems have invalid gemspecs" do
+  it "outputs a helpful error message when gems have invalid gemspecs", :rubygems => "< 3.3.16" do
     install_gemfile <<-G, :standalone => true, :raise_on_error => false, :env => { "BUNDLE_FORCE_RUBY_PLATFORM" => "1" }
       source 'https://rubygems.org'
       gem "resque-scheduler", "2.2.0"
@@ -205,6 +205,16 @@ RSpec.describe "real world edgecases", :realworld => true do
     G
     expect(err).to include("You have one or more invalid gemspecs that need to be fixed.")
     expect(err).to include("resque-scheduler 2.2.0 has an invalid gemspec")
+  end
+
+  it "outputs a helpful warning when gems have a gemspec with invalid `require_paths`", :rubygems => ">= 3.3.16" do
+    install_gemfile <<-G, :standalone => true, :env => { "BUNDLE_FORCE_RUBY_PLATFORM" => "1" }
+      source 'https://rubygems.org'
+      gem "resque-scheduler", "2.2.0"
+      gem "redis-namespace", "1.6.0" # for a consistent resolution including ruby 2.3.0
+      gem "ruby2_keywords", "0.0.5"
+    G
+    expect(err).to include("resque-scheduler 2.2.0 includes a gemspec with `require_paths` set to an array of arrays. Newer versions of this gem might've already fixed this").once
   end
 
   it "doesn't hang on big gemfile" do

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1081,6 +1081,7 @@ class Gem::Specification < Gem::BasicSpecification
 
     spec.specification_version ||= NONEXISTENT_SPECIFICATION_VERSION
     spec.reset_nil_attributes_to_default
+    spec.flatten_require_paths
 
     spec
   end
@@ -2688,6 +2689,13 @@ class Gem::Specification < Gem::BasicSpecification
     end
 
     @installed_by_version ||= nil
+  end
+
+  def flatten_require_paths # :nodoc:
+    return unless raw_require_paths.first.is_a?(Array)
+
+    warn "#{name} #{version} includes a gemspec with `require_paths` set to an array of arrays. Newer versions of this gem might've already fixed this"
+    raw_require_paths.flatten!
   end
 
   def raw_require_paths # :nodoc:


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Some old buggy gem packages include a `require_paths` field in the gemspec set to an array of arrays. This is the case of `resque-scheduler-2.2.0`:

```
$ ruby -ropen-uri -rrubygems/package -e'puts Gem::Package.new(URI.open("https://rubygems.org/downloads/resque-scheduler-2.2.0.gem")).spec.require_paths.inspect'
[["lib"]]
```

From a Bundler perspective this seems to only affect generation of `bundler/setup` scripts in standalone mode, and Bundler handled this reasonably well until Ruby 3.2, printing an error like the following.

```
$ bundle install --standalone
Fetching gem metadata from https://rubygems.org/......
Resolving dependencies...
Using bundler 2.4.0.dev
Fetching concurrent-ruby 1.1.9
Fetching mono_logger 1.1.1
Installing mono_logger 1.1.1
Fetching multi_json 1.15.0
Installing multi_json 1.15.0
Installing concurrent-ruby 1.1.9
Fetching ruby2_keywords 0.0.5
Installing ruby2_keywords 0.0.5
Fetching rack 2.2.3
Installing rack 2.2.3
Fetching redis 4.5.1
Installing redis 4.5.1
Fetching tilt 2.0.10
Installing tilt 2.0.10
Fetching mustermann 1.1.1
Installing mustermann 1.1.1
Fetching rack-protection 2.1.0
Installing rack-protection 2.1.0
Fetching vegas 0.1.11
Fetching tzinfo 2.0.4
Installing vegas 0.1.11
Installing tzinfo 2.0.4
Fetching redis-namespace 1.6.0
Installing redis-namespace 1.6.0
Fetching sinatra 2.1.0
Fetching rufus-scheduler 2.0.24
Installing sinatra 2.1.0
Installing rufus-scheduler 2.0.24
Fetching resque 1.24.1
Installing resque 1.24.1
Fetching resque-scheduler 2.2.0
Installing resque-scheduler 2.2.0
You have one or more invalid gemspecs that need to be fixed.
resque-scheduler 2.2.0 has an invalid gemspec  
```

However, in Ruby 3.2, due to the [removal of `Object#=~`](https://bugs.ruby-lang.org/issues/15231), now this raises a much more unhelpful error:

````
$ bundle install --standalone
Fetching gem metadata from https://rubygems.org/......
Resolving dependencies...
Using bundler 2.4.0.dev
Fetching concurrent-ruby 1.1.9
Fetching mono_logger 1.1.1
Installing mono_logger 1.1.1
Fetching multi_json 1.15.0
Installing multi_json 1.15.0
Installing concurrent-ruby 1.1.9
Fetching ruby2_keywords 0.0.5
Installing ruby2_keywords 0.0.5
Fetching rack 2.2.3
Installing rack 2.2.3
Fetching redis 4.5.1
Installing redis 4.5.1
Fetching tilt 2.0.10
Installing tilt 2.0.10
Fetching mustermann 1.1.1
Installing mustermann 1.1.1
Fetching rack-protection 2.1.0
Installing rack-protection 2.1.0
Fetching vegas 0.1.11
Fetching tzinfo 2.0.4
Installing vegas 0.1.11
Installing tzinfo 2.0.4
Fetching redis-namespace 1.6.0
Installing redis-namespace 1.6.0
Fetching sinatra 2.1.0
Fetching rufus-scheduler 2.0.24
Installing sinatra 2.1.0
Installing rufus-scheduler 2.0.24
Fetching resque 1.24.1
Installing resque 1.24.1
Fetching resque-scheduler 2.2.0
Installing resque-scheduler 2.2.0
--- ERROR REPORT TEMPLATE -------------------------------------------------------

```
NoMethodError: undefined method `=~' for ["lib"]:Array
  /home/runner/work/rubygems/rubygems/lib/rubygems/installer.rb:728:in `block in verify_spec'
  /home/runner/work/rubygems/rubygems/lib/rubygems/installer.rb:728:in `any?'
  /home/runner/work/rubygems/rubygems/lib/rubygems/installer.rb:728:in `verify_spec'
  /home/runner/work/rubygems/rubygems/lib/rubygems/installer.rb:914:in `pre_install_checks'
  /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/rubygems_gem_installer.rb:64:in `pre_install_checks'
  /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/rubygems_gem_installer.rb:12:in `install'
  /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/source/rubygems.rb:204:in `install'
  /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/installer/gem_installer.rb:54:in `install'
  /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/installer/gem_installer.rb:16:in `install_from_spec'
  /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/installer/parallel_installer.rb:186:in `do_install'
  /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/installer/parallel_installer.rb:177:in `block in worker_pool'
  /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/worker.rb:62:in `apply_func'
  /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/worker.rb:57:in `block in process_queue'
  /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/worker.rb:54:in `loop'
  /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/worker.rb:54:in `process_queue'
  /home/runner/work/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/worker.rb:91:in `block (2 levels) in create_threads'

```

## Environment

```
Bundler       2.4.0.dev
  Platforms   ruby, x86_64-linux
Ruby          3.2.0p-1 (2022-06-11 revision 9ed9cc9852a7cf12c71114c3c65b239c7af1518b) [x86_64-linux]
  Full Path   /home/runner/.rubies/ruby-head/bin/ruby
  Config Dir  /home/runner/.rubies/ruby-head/etc
RubyGems      3.4.0.dev
  Gem Home    /home/runner/work/rubygems/rubygems/bundler/tmp/1/bundled_app/bundle/ruby/3.2.0+1
  Gem Path    /home/runner/work/rubygems/rubygems/bundler/tmp/1/bundled_app/bundle/ruby/3.2.0+1
  User Home   /home/runner/work/rubygems/rubygems/bundler/tmp/1/home
  User Path   /home/runner/work/rubygems/rubygems/bundler/tmp/1/home/.local/share/gem/ruby/3.2.0+1
  Bin Dir     /home/runner/work/rubygems/rubygems/bundler/tmp/1/bundled_app/bundle/ruby/3.2.0+1/bin
OpenSSL       
  Compiled    OpenSSL 1.1.1f  31 Mar 2020
  Loaded      OpenSSL 1.1.1f  31 Mar 2020
  Cert File   /usr/lib/ssl/cert.pem
  Cert Dir    /usr/lib/ssl/certs
Tools         
  Git         2.36.1
  RVM         not installed
  rbenv       not installed
  chruby      not installed
```

## Bundler Build Metadata

```
Built At          2022-06-11
Git SHA           f08001f
Released Version  true
```

## Bundler settings

```
force_ruby_platform
  Set via BUNDLE_FORCE_RUBY_PLATFORM: true
path
  Set for your local app (/home/runner/work/rubygems/rubygems/bundler/tmp/1/bundled_app/.bundle/config): "bundle"
```

## Gemfile

### Gemfile

```ruby
source 'https://rubygems.org'
gem "resque-scheduler", "2.2.0"
gem "redis-namespace", "1.6.0" # for a consistent resolution including ruby 2.3.0
gem "ruby2_keywords", "0.0.5"
```

### Gemfile.lock

```
<No /home/runner/work/rubygems/rubygems/bundler/tmp/1/bundled_app/Gemfile.lock found>
```

--- TEMPLATE END ----------------------------------------------------------------

Unfortunately, an unexpected error occurred, and Bundler cannot continue.

First, try this link to see if there are any existing issue reports for this error:
https://github.com/rubygems/rubygems/search?q=undefined+method+%60%3D~%27+for+%5B%22lib%22%5D+Array&type=Issues

If there aren't any reports for this error yet, please fill in the new issue form located at https://github.com/rubygems/rubygems/issues/new?labels=Bundler&template=bundler-related-issue.md, and copy and paste the report template above in there.
````

## What is your fix for the problem, implemented in this PR?

I thought about trying to restore the previous error, but it turned out to be much easier to make this just warn, and only warn the situation.

This is an improvement by itself but also gets our daily bundler CI green :)

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
