### PR TITLE
Fix incorrect password redaction when there's an error in `gem source -a`

### DIFF
--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -261,7 +261,7 @@ You can use `i` command instead of `install`.
       return unless Gem::SourceFetchProblem === x
 
       require_relative "../uri"
-      msg = "Unable to pull data from '#{Gem::Uri.new(x.source.uri).redacted}': #{x.error.message}"
+      msg = "Unable to pull data from '#{Gem::Uri.redact(x.source.uri)}': #{x.error.message}"
 
       alert_warning msg
     end

--- a/lib/rubygems/commands/sources_command.rb
+++ b/lib/rubygems/commands/sources_command.rb
@@ -62,7 +62,7 @@ class Gem::Commands::SourcesCommand < Gem::Command
       say "#{source_uri} is not a URI"
       terminate_interaction 1
     rescue Gem::RemoteFetcher::FetchError => e
-      say "Error fetching #{source_uri}:\n\t#{e.message}"
+      say "Error fetching #{Gem::Uri.redact(source.uri)}:\n\t#{e.message}"
       terminate_interaction 1
     end
   end

--- a/lib/rubygems/errors.rb
+++ b/lib/rubygems/errors.rb
@@ -168,7 +168,7 @@ module Gem
     # An English description of the error.
 
     def wordy
-      "Unable to download data from #{Gem::Uri.new(@source.uri).redacted} - #{@error.message}"
+      "Unable to download data from #{Gem::Uri.redact(@source.uri)} - #{@error.message}"
     end
 
     ##

--- a/lib/rubygems/request.rb
+++ b/lib/rubygems/request.rb
@@ -193,7 +193,7 @@ class Gem::Request
     begin
       @requests[connection.object_id] += 1
 
-      verbose "#{request.method} #{Gem::Uri.new(@uri).redacted}"
+      verbose "#{request.method} #{Gem::Uri.redact(@uri)}"
 
       file_name = File.basename(@uri.path)
       # perform download progress reporter only for gems

--- a/lib/rubygems/source.rb
+++ b/lib/rubygems/source.rb
@@ -26,15 +26,8 @@ class Gem::Source
   # Creates a new Source which will use the index located at +uri+.
 
   def initialize(uri)
-    begin
-      unless uri.kind_of? URI
-        uri = URI.parse(uri.to_s)
-      end
-    rescue URI::InvalidURIError
-      raise if Gem::Source == self.class
-    end
-
-    @uri = uri
+    require_relative "uri"
+    @uri = Gem::Uri.parse!(uri)
     @update_cache = nil
   end
 

--- a/lib/rubygems/source/git.rb
+++ b/lib/rubygems/source/git.rb
@@ -49,8 +49,8 @@ class Gem::Source::Git < Gem::Source
   # will be checked out when the gem is installed.
 
   def initialize(name, repository, reference, submodules = false)
-    super repository
-
+    require_relative "../uri"
+    @uri = Gem::Uri.parse(repository)
     @name            = name
     @repository      = repository
     @reference       = reference

--- a/lib/rubygems/source_list.rb
+++ b/lib/rubygems/source_list.rb
@@ -48,15 +48,11 @@ class Gem::SourceList
   # String.
 
   def <<(obj)
-    require "uri"
-
     src = case obj
-    when URI
-      Gem::Source.new(obj)
     when Gem::Source
       obj
     else
-      Gem::Source.new(URI.parse(obj))
+      Gem::Source.new(obj)
     end
 
     @sources << src unless @sources.include?(src)

--- a/lib/rubygems/uri.rb
+++ b/lib/rubygems/uri.rb
@@ -64,7 +64,7 @@ class Gem::Uri
   end
 
   def redact_credentials_from(text)
-    return text unless valid_uri? && password?
+    return text unless valid_uri? && password? && text.include?(to_s)
 
     text.sub(password, 'REDACTED')
   end

--- a/lib/rubygems/uri.rb
+++ b/lib/rubygems/uri.rb
@@ -5,6 +5,37 @@
 #
 
 class Gem::Uri
+  ##
+  # Parses uri, raising if it's invalid
+
+  def self.parse!(uri)
+    require "uri"
+
+    raise URI::InvalidURIError unless uri
+
+    return uri unless uri.is_a?(String)
+
+    # Always escape URI's to deal with potential spaces and such
+    # It should also be considered that source_uri may already be
+    # a valid URI with escaped characters. e.g. "{DESede}" is encoded
+    # as "%7BDESede%7D". If this is escaped again the percentage
+    # symbols will be escaped.
+    begin
+      URI.parse(uri)
+    rescue URI::InvalidURIError
+      URI.parse(URI::DEFAULT_PARSER.escape(uri))
+    end
+  end
+
+  ##
+  # Parses uri, returning the original uri if it's invalid
+
+  def self.parse(uri)
+    parse!(uri)
+  rescue URI::InvalidURIError
+    uri
+  end
+
   def initialize(source_uri)
     @parsed_uri = parse(source_uri)
   end
@@ -50,35 +81,12 @@ class Gem::Uri
 
   private
 
-  ##
-  # Parses the #uri, raising if it's invalid
-
   def parse!(uri)
-    require "uri"
-
-    raise URI::InvalidURIError unless uri
-
-    # Always escape URI's to deal with potential spaces and such
-    # It should also be considered that source_uri may already be
-    # a valid URI with escaped characters. e.g. "{DESede}" is encoded
-    # as "%7BDESede%7D". If this is escaped again the percentage
-    # symbols will be escaped.
-    begin
-      URI.parse(uri)
-    rescue URI::InvalidURIError
-      URI.parse(URI::DEFAULT_PARSER.escape(uri))
-    end
+    self.class.parse!(uri)
   end
 
-  ##
-  # Parses the #uri, returning the original uri if it's invalid
-
   def parse(uri)
-    return uri unless uri.is_a?(String)
-
-    parse!(uri)
-  rescue URI::InvalidURIError
-    uri
+    self.class.parse(uri)
   end
 
   def with_redacted_user

--- a/lib/rubygems/uri.rb
+++ b/lib/rubygems/uri.rb
@@ -6,6 +6,13 @@
 
 class Gem::Uri
   ##
+  # Parses and redacts uri
+
+  def self.redact(uri)
+    new(uri).redacted
+  end
+
+  ##
   # Parses uri, raising if it's invalid
 
   def self.parse!(uri)

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -1191,7 +1191,7 @@ Also, a list:
   # Is this test being run on a ruby/ruby repository?
   #
 
-  def testing_ruby_repo?
+  def ruby_repo?
     !ENV["GEM_COMMAND"].nil?
   end
 

--- a/test/rubygems/test_gem_commands_sources_command.rb
+++ b/test/rubygems/test_gem_commands_sources_command.rb
@@ -226,6 +226,31 @@ Error fetching https://u:REDACTED@example.com:
     assert_equal '', @ui.error
   end
 
+  def test_execute_add_existent_source_invalid_uri_with_error_by_chance_including_the_uri_password
+    spec_fetcher
+
+    uri = "https://u:secret@example.com/specs.#{@marshal_version}.gz"
+
+    @cmd.handle_options %w[--add https://u:secret@example.com]
+    @fetcher.data[uri] = proc do
+      raise Gem::RemoteFetcher::FetchError.new('it secretly died', uri)
+    end
+
+    use_ui @ui do
+      assert_raise Gem::MockGemUi::TermError do
+        @cmd.execute
+      end
+    end
+
+    expected = <<-EOF
+Error fetching https://u:REDACTED@example.com:
+\tit secretly died (https://u:REDACTED@example.com/specs.#{@marshal_version}.gz)
+    EOF
+
+    assert_equal expected, @ui.output
+    assert_equal '', @ui.error
+  end
+
   def test_execute_add_redundant_source
     spec_fetcher
 

--- a/test/rubygems/test_gem_commands_sources_command.rb
+++ b/test/rubygems/test_gem_commands_sources_command.rb
@@ -201,6 +201,31 @@ Error fetching http://beta-gems.example.com:
     assert_equal '', @ui.error
   end
 
+  def test_execute_add_existent_source_invalid_uri
+    spec_fetcher
+
+    uri = "https://u:p@example.com/specs.#{@marshal_version}.gz"
+
+    @cmd.handle_options %w[--add https://u:p@example.com]
+    @fetcher.data[uri] = proc do
+      raise Gem::RemoteFetcher::FetchError.new('it died', uri)
+    end
+
+    use_ui @ui do
+      assert_raise Gem::MockGemUi::TermError do
+        @cmd.execute
+      end
+    end
+
+    expected = <<-EOF
+Error fetching https://u:REDACTED@example.com:
+\tit died (https://u:REDACTED@example.com/specs.#{@marshal_version}.gz)
+    EOF
+
+    assert_equal expected, @ui.output
+    assert_equal '', @ui.error
+  end
+
   def test_execute_add_redundant_source
     spec_fetcher
 

--- a/test/rubygems/test_gem_ext_cargo_builder.rb
+++ b/test/rubygems/test_gem_ext_cargo_builder.rb
@@ -167,7 +167,7 @@ class TestGemExtCargoBuilder < Gem::TestCase
     pend "mswin not supported (yet)" if /mswin/ =~ RUBY_PLATFORM && ENV.key?('GITHUB_ACTIONS')
     system(@rust_envs, 'cargo', '-V', out: IO::NULL, err: [:child, :out])
     pend 'cargo not present' unless $?.success?
-    pend "ruby.h is not provided by ruby repo" if testing_ruby_repo?
+    pend "ruby.h is not provided by ruby repo" if ruby_repo?
   end
 
   def assert_ffi_handle(bundle, name)

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -444,7 +444,7 @@ class TestGemRequire < Gem::TestCase
   end
 
   def test_realworld_default_gem
-    omit "this test can't work under ruby-core setup" if testing_ruby_repo?
+    omit "this test can't work under ruby-core setup" if ruby_repo?
 
     cmd = <<-RUBY
       $stderr = $stdout
@@ -457,7 +457,7 @@ class TestGemRequire < Gem::TestCase
   end
 
   def test_realworld_upgraded_default_gem
-    omit "this test can't work under ruby-core setup" if testing_ruby_repo?
+    omit "this test can't work under ruby-core setup" if ruby_repo?
 
     newer_json = util_spec("json", "999.99.9", nil, ["lib/json.rb"])
     install_gem newer_json


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When there's an error when `gem source -a` tries to add a new source, if the target url includes a password, it will be incorrectly redacted in the error message. There are two issues here:

* Part of the error will include the url with the non-redacted password.
* If the error message includes by chance the password, which could happen for very weak passwords, that specific part of the error will actually be incorrectly redacted.

Both errors are illustrated by the following screenshot, originally posted at https://github.com/rubygems/rubygems/issues/5360#issue-1140483463.

![redaction-errors](https://user-images.githubusercontent.com/2887858/173370797-042495f8-260a-4a06-9a15-ba406c5e4297.png)

## What is your fix for the problem, implemented in this PR?

This PR fixes both issues by:

* For the first issue, make sure our URI redaction logic is actually used when building this error.
* For the second issue, make sure our URI redaction logic only redacts the actual uri inside the error message, not the whole copy of the error.

Since I was at it, I also refactored some duplicated logic to centralize it at `Gem::Uri`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
