### PR TITLE
Simplify extension builder

### DIFF
--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -17,7 +17,7 @@ class Gem::Ext::Builder
     $1.downcase
   end
 
-  def self.make(dest_path, results, make_dir = Dir.pwd)
+  def self.make(dest_path, results, make_dir = Dir.pwd, sitedir = nil)
     unless File.exist? File.join(make_dir, 'Makefile')
       raise Gem::InstallError, 'Makefile not found'
     end
@@ -33,11 +33,18 @@ class Gem::Ext::Builder
     # The installation of the bundled gems is failed when DESTDIR is empty in mswin platform.
     destdir = (/\bnmake/i !~ make_program_name || ENV['DESTDIR'] && ENV['DESTDIR'] != "") ? 'DESTDIR=%s' % ENV['DESTDIR'] : ''
 
+    env = [destdir]
+
+    if sitedir
+      env << 'sitearchdir=%s' % sitedir
+      env << 'sitelibdir=%s' % sitedir
+    end
+
     ['clean', '', 'install'].each do |target|
       # Pass DESTDIR via command line to override what's in MAKEFLAGS
       cmd = [
         *make_program,
-        destdir,
+        *env,
         target,
       ].reject(&:empty?)
       begin

--- a/lib/rubygems/ext/cargo_builder.rb
+++ b/lib/rubygems/ext/cargo_builder.rb
@@ -278,19 +278,17 @@ class Gem::Ext::CargoBuilder < Gem::Ext::Builder
       # Details: https://github.com/rubygems/rubygems/issues/977#issuecomment-171544940
       tmp_dest_relative = get_relative_path(tmp_dest.clone, extension_dir)
 
-      if tmp_dest_relative
-        full_tmp_dest = File.join(extension_dir, tmp_dest_relative)
+      full_tmp_dest = File.join(extension_dir, tmp_dest_relative)
 
-        # TODO: remove in RubyGems 3
-        if Gem.install_extension_in_lib && lib_dir
-          FileUtils.mkdir_p lib_dir
-          FileUtils.cp_r ext_path, lib_dir, remove_destination: true
-        end
+      # TODO: remove in RubyGems 3
+      if Gem.install_extension_in_lib && lib_dir
+        FileUtils.mkdir_p lib_dir
+        FileUtils.cp_r ext_path, lib_dir, remove_destination: true
+      end
 
-        FileUtils::Entry_.new(full_tmp_dest).traverse do |ent|
-          destent = ent.class.new(dest_path, ent.rel)
-          destent.exist? || FileUtils.mv(ent.path, destent.path)
-        end
+      FileUtils::Entry_.new(full_tmp_dest).traverse do |ent|
+        destent = ent.class.new(dest_path, ent.rel)
+        destent.exist? || FileUtils.mv(ent.path, destent.path)
       end
     ensure
       FileUtils.rm_rf tmp_dest if tmp_dest

--- a/lib/rubygems/ext/cargo_builder.rb
+++ b/lib/rubygems/ext/cargo_builder.rb
@@ -268,14 +268,9 @@ class Gem::Ext::CargoBuilder < Gem::Ext::Builder
       tmp_dest = Dir.mktmpdir(".gem.", extension_dir)
 
       # Some versions of `mktmpdir` return absolute paths, which will break make
-      # if the paths contain spaces. However, on Ruby 1.9.x on Windows, relative
-      # paths cause all C extension builds to fail.
+      # if the paths contain spaces.
       #
-      # As such, we convert to a relative path unless we are using Ruby 1.9.x on
-      # Windows. This means that when using Ruby 1.9.x on Windows, paths with
-      # spaces do not work.
-      #
-      # Details: https://github.com/rubygems/rubygems/issues/977#issuecomment-171544940
+      # As such, we convert to a relative path.
       tmp_dest_relative = get_relative_path(tmp_dest.clone, extension_dir)
 
       full_tmp_dest = File.join(extension_dir, tmp_dest_relative)

--- a/lib/rubygems/ext/cargo_builder.rb
+++ b/lib/rubygems/ext/cargo_builder.rb
@@ -275,7 +275,7 @@ class Gem::Ext::CargoBuilder < Gem::Ext::Builder
 
       full_tmp_dest = File.join(extension_dir, tmp_dest_relative)
 
-      # TODO: remove in RubyGems 3
+      # TODO: remove in RubyGems 4
       if Gem.install_extension_in_lib && lib_dir
         FileUtils.mkdir_p lib_dir
         FileUtils.cp_r ext_path, lib_dir, remove_destination: true

--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -28,7 +28,6 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
       siteconf.puts "dest_path = #{tmp_dest_relative.dump}"
       %w[sitearchdir sitelibdir].each do |dir|
         siteconf.puts "RbConfig::MAKEFILE_CONFIG['#{dir}'] = dest_path"
-        siteconf.puts "RbConfig::CONFIG['#{dir}'] = dest_path"
       end
 
       siteconf.close

--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -43,7 +43,7 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
 
       full_tmp_dest = File.join(extension_dir, tmp_dest_relative)
 
-      # TODO remove in RubyGems 3
+      # TODO remove in RubyGems 4
       if Gem.install_extension_in_lib and lib_dir
         FileUtils.mkdir_p lib_dir
         entries = Dir.entries(full_tmp_dest) - %w[. ..]

--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -61,21 +61,19 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
 
         make dest_path, results, extension_dir
 
-        if tmp_dest_relative
-          full_tmp_dest = File.join(extension_dir, tmp_dest_relative)
+        full_tmp_dest = File.join(extension_dir, tmp_dest_relative)
 
-          # TODO remove in RubyGems 3
-          if Gem.install_extension_in_lib and lib_dir
-            FileUtils.mkdir_p lib_dir
-            entries = Dir.entries(full_tmp_dest) - %w[. ..]
-            entries = entries.map {|entry| File.join full_tmp_dest, entry }
-            FileUtils.cp_r entries, lib_dir, :remove_destination => true
-          end
+        # TODO remove in RubyGems 3
+        if Gem.install_extension_in_lib and lib_dir
+          FileUtils.mkdir_p lib_dir
+          entries = Dir.entries(full_tmp_dest) - %w[. ..]
+          entries = entries.map {|entry| File.join full_tmp_dest, entry }
+          FileUtils.cp_r entries, lib_dir, :remove_destination => true
+        end
 
-          FileUtils::Entry_.new(full_tmp_dest).traverse do |ent|
-            destent = ent.class.new(dest_path, ent.rel)
-            destent.exist? or FileUtils.mv(ent.path, destent.path)
-          end
+        FileUtils::Entry_.new(full_tmp_dest).traverse do |ent|
+          destent = ent.class.new(dest_path, ent.rel)
+          destent.exist? or FileUtils.mv(ent.path, destent.path)
         end
       ensure
         ENV["DESTDIR"] = destdir

--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -13,14 +13,9 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
     tmp_dest = Dir.mktmpdir(".gem.", extension_dir)
 
     # Some versions of `mktmpdir` return absolute paths, which will break make
-    # if the paths contain spaces. However, on Ruby 1.9.x on Windows, relative
-    # paths cause all C extension builds to fail.
+    # if the paths contain spaces.
     #
-    # As such, we convert to a relative path unless we are using Ruby 1.9.x on
-    # Windows. This means that when using Ruby 1.9.x on Windows, paths with
-    # spaces do not work.
-    #
-    # Details: https://github.com/rubygems/rubygems/issues/977#issuecomment-171544940
+    # As such, we convert to a relative path.
     tmp_dest_relative = get_relative_path(tmp_dest.clone, extension_dir)
 
     destdir = ENV["DESTDIR"]


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Makefile generation when building extensions relies on running `extconf.rb` with a modified environment where `RbConfig::CONFIG` entries are modified.

This has not generated any problems, but people has copied this strategy and that has generated some problems outside of RubyGems.
 
## What is your fix for the problem, implemented in this PR?

As stated, this is not a problem in RubyGems itself, but we can make things much simpler by passing `sitearchdir` and `sitelibdir` directly to `make` as suggested by @kou here: https://github.com/rake-compiler/rake-compiler/issues/202#issuecomment-1046163347.

And indeed doing this completely removes the need for the `siteconf` file as suggested by @larskanis here: https://github.com/rake-compiler/rake-compiler/issues/202#issuecomment-1046315109.

Fixes #5371.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
