### PR TITLE
Changelogs for RubyGems 3.3.16 and Bundler 2.3.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# 3.3.16 / 2022-06-15
+
+## Enhancements:
+
+* Auto-fix and warn gem packages including a gemspec with `require_paths`
+  as an array of arrays. Pull request #5615 by deivid-rodriguez
+* Misc cargo builder improvements. Pull request #5459 by ianks
+* Installs bundler 2.3.16 as a default gem.
+
+## Bug fixes:
+
+* Fix incorrect password redaction when there's an error in `gem source
+  -a`. Pull request #5623 by deivid-rodriguez
+* Fix another regression when loading old marshaled specs. Pull request
+  #5610 by deivid-rodriguez
+
 # 3.3.15 / 2022-06-01
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.3.16 (June 15, 2022)
+
+## Performance:
+
+  - Improve performance of installing gems from gem server sources [#5614](https://github.com/rubygems/rubygems/pull/5614)
+
 # 2.3.15 (June 1, 2022)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.3.16 and bundler 2.3.16 into master.