### PR TITLE
Revert "Support running specs with asdf version manager"

### DIFF
--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -78,19 +78,10 @@ RSpec.configure do |config|
     ENV["XDG_CONFIG_HOME"] = nil
     ENV["GEMRC"] = nil
 
-    extend(Spec::Helpers)
-
-    # Ruby-core needs RUBYLIB set, leave any "internal" RUBYLIB entries to avoid
-    # resetting that, but reset anything else to avoid external stuff like asdf
-    # hooks from interfering with our specs
-
-    rubylib = ENV["RUBYLIB"]
-    rubylib = rubylib.split(File::PATH_SEPARATOR).select {|p| p.start_with?(git_root.to_s) }.join(File::PATH_SEPARATOR) if rubylib
-    ENV["RUBYLIB"] = rubylib
-
     # Don't wrap output in tests
     ENV["THOR_COLUMNS"] = "10000"
 
+    extend(Spec::Helpers)
     system_gems :bundler, :path => pristine_system_gem_path
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

#5557 seems to have broken ruby/ruby CI: https://github.com/ruby/ruby/runs/6896688462.

## What is your fix for the problem, implemented in this PR?

Revert until we can reevaluate why, and why our CI didn't catch it.

Reopens https://github.com/rubygems/rubygems/issues/5240.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
