### PR TITLE
Unset ENV set by official Ruby docker images for specs

### DIFF
--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -74,6 +74,8 @@ RSpec.configure do |config|
     ENV["BUNDLER_SPEC_RUN"] = "true"
     ENV["BUNDLER_NO_OLD_RUBYGEMS_WARNING"] = "true"
     ENV["BUNDLE_USER_CONFIG"] = ENV["BUNDLE_USER_CACHE"] = ENV["BUNDLE_USER_PLUGIN"] = nil
+    ENV["BUNDLE_APP_CONFIG"] = nil
+    ENV["BUNDLE_SILENCE_ROOT_WARNING"] = nil
     ENV["RUBYGEMS_GEMDEPS"] = nil
     ENV["XDG_CONFIG_HOME"] = nil
     ENV["GEMRC"] = nil


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Running bundler specs under docker causes a lot of issues due to some non default configuration being enabled in the official Ruby images through ENV variables.

## What is your fix for the problem, implemented in this PR?

Reset those ENV variables so that they don't interfere with our specs.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
