### PR TITLE
Fix extension paths in generated standalone script

### DIFF
--- a/bundler/lib/bundler/installer/standalone.rb
+++ b/bundler/lib/bundler/installer/standalone.rb
@@ -29,7 +29,9 @@ module Bundler
       @specs.map do |spec|
         next if spec.name == "bundler"
         Array(spec.require_paths).map do |path|
-          gem_path(path, spec).sub(version_dir, '#{RUBY_ENGINE}/#{RbConfig::CONFIG["ruby_version"]}')
+          gem_path(path, spec).
+            sub(version_dir, '#{RUBY_ENGINE}/#{RbConfig::CONFIG["ruby_version"]}').
+            sub(extensions_dir, 'extensions/\k<platform>/#{RbConfig::CONFIG["ruby_version"]}')
           # This is a static string intentionally. It's interpolated at a later time.
         end
       end.flatten.compact
@@ -37,6 +39,10 @@ module Bundler
 
     def version_dir
       "#{RUBY_ENGINE}/#{RbConfig::CONFIG["ruby_version"]}"
+    end
+
+    def extensions_dir
+      %r{extensions/(?<platform>[^/]+)/#{RbConfig::CONFIG["ruby_version"]}}
     end
 
     def bundler_path

--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -202,8 +202,9 @@ RSpec.shared_examples "bundle install --standalone" do
     it "generates a bundle/bundler/setup.rb with the proper paths" do
       expected_path = bundled_app("bundle/bundler/setup.rb")
       extension_line = File.read(expected_path).each_line.find {|line| line.include? "/extensions/" }.strip
+      platform = Gem::Platform.local
       expect(extension_line).to start_with '$:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{RbConfig::CONFIG["ruby_version"]}/extensions/'
-      expect(extension_line).to end_with '/very_simple_binary-1.0")'
+      expect(extension_line).to end_with platform.to_s + '/#{RbConfig::CONFIG["ruby_version"]}/very_simple_binary-1.0")'
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The paths for extensions of gems would contain the hardcoded ruby version on which the extension was built.  That's inconsistent with the parent ruby version directory.  It also makes the generated script incompatible with different ruby versions.

## What is your fix for the problem, implemented in this PR?

I replaced the static ruby version with runtime ruby version like the parent version directory.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
