### PR TITLE
Fix daily Bundler CI

### DIFF
--- a/bundler/lib/bundler/installer/standalone.rb
+++ b/bundler/lib/bundler/installer/standalone.rb
@@ -12,6 +12,7 @@ module Bundler
       end
       File.open File.join(bundler_path, "setup.rb"), "w" do |file|
         file.puts "require 'rbconfig'"
+        file.puts define_path_helpers
         file.puts reverse_rubygems_kernel_mixin
         paths.each do |path|
           if Pathname.new(path).absolute?
@@ -30,19 +31,19 @@ module Bundler
         next if spec.name == "bundler"
         Array(spec.require_paths).map do |path|
           gem_path(path, spec).
-            sub(version_dir, '#{RUBY_ENGINE}/#{RbConfig::CONFIG["ruby_version"]}').
-            sub(extensions_dir, 'extensions/\k<platform>/#{RbConfig::CONFIG["ruby_version"]}')
+            sub(version_dir, '#{RUBY_ENGINE}/#{Gem.ruby_api_version}').
+            sub(extensions_dir, 'extensions/\k<platform>/#{Gem.extension_api_version}')
           # This is a static string intentionally. It's interpolated at a later time.
         end
       end.flatten.compact
     end
 
     def version_dir
-      "#{RUBY_ENGINE}/#{RbConfig::CONFIG["ruby_version"]}"
+      "#{RUBY_ENGINE}/#{Gem.ruby_api_version}"
     end
 
     def extensions_dir
-      %r{extensions/(?<platform>[^/]+)/#{RbConfig::CONFIG["ruby_version"]}}
+      %r{extensions/(?<platform>[^/]+)/#{Regexp.escape(Gem.extension_api_version)}}
     end
 
     def bundler_path
@@ -59,6 +60,26 @@ module Bundler
     rescue TypeError
       error_message = "#{spec.name} #{spec.version} has an invalid gemspec"
       raise Gem::InvalidSpecificationException.new(error_message)
+    end
+
+    def define_path_helpers
+      <<~'END'
+        unless defined?(Gem)
+          module Gem
+            def self.ruby_api_version
+              RbConfig::CONFIG["ruby_version"]
+            end
+
+            def self.extension_api_version
+              if 'no' == RbConfig::CONFIG['ENABLE_SHARED']
+                "#{ruby_api_version}-static"
+              else
+                ruby_api_version
+              end
+            end
+          end
+        end
+      END
     end
 
     def reverse_rubygems_kernel_mixin

--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -32,6 +32,21 @@ RSpec.shared_examples "bundle install --standalone" do
       expect(out).to eq(expected_gems.values.join("\n"))
     end
 
+    it "makes the gems available without bundler nor rubygems" do
+      testrb = String.new <<-RUBY
+        $:.unshift File.expand_path("bundle")
+        require "bundler/setup"
+
+      RUBY
+      expected_gems.each do |k, _|
+        testrb << "\nrequire \"#{k}\""
+        testrb << "\nputs #{k.upcase}"
+      end
+      sys_exec %(#{Gem.ruby} --disable-gems -w -e #{testrb.shellescape})
+
+      expect(out).to eq(expected_gems.values.join("\n"))
+    end
+
     it "makes the gems available without bundler via Kernel.require" do
       testrb = String.new <<-RUBY
         $:.unshift File.expand_path("bundle")
@@ -154,8 +169,8 @@ RSpec.shared_examples "bundle install --standalone" do
       load_path_lines = bundled_app("bundle/bundler/setup.rb").read.split("\n").select {|line| line.start_with?("$:.unshift") }
 
       expect(load_path_lines).to eq [
-        '$:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{RbConfig::CONFIG["ruby_version"]}/gems/bar-1.0.0/lib")',
-        '$:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{RbConfig::CONFIG["ruby_version"]}/gems/foo-1.0.0/lib")',
+        '$:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{Gem.ruby_api_version}/gems/bar-1.0.0/lib")',
+        '$:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{Gem.ruby_api_version}/gems/foo-1.0.0/lib")',
       ]
     end
   end
@@ -201,10 +216,13 @@ RSpec.shared_examples "bundle install --standalone" do
 
     it "generates a bundle/bundler/setup.rb with the proper paths" do
       expected_path = bundled_app("bundle/bundler/setup.rb")
-      extension_line = File.read(expected_path).each_line.find {|line| line.include? "/extensions/" }.strip
+      script_content = File.read(expected_path)
+      expect(script_content).to include("def self.ruby_api_version")
+      expect(script_content).to include("def self.extension_api_version")
+      extension_line = script_content.each_line.find {|line| line.include? "/extensions/" }.strip
       platform = Gem::Platform.local
-      expect(extension_line).to start_with '$:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{RbConfig::CONFIG["ruby_version"]}/extensions/'
-      expect(extension_line).to end_with platform.to_s + '/#{RbConfig::CONFIG["ruby_version"]}/very_simple_binary-1.0")'
+      expect(extension_line).to start_with '$:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{Gem.ruby_api_version}/extensions/'
+      expect(extension_line).to end_with platform.to_s + '/#{Gem.extension_api_version}/very_simple_binary-1.0")'
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

After merging #5632, our daily Bundler CI against ruby 3.2.0-dev started failing.

The reason is that ruby 3.2.0-dev is built without shared libraries enabled, and that distinction is part of the directory name where extensions are installed (it's `3.2.0+1-static` for this Ruby), because statically and non-statically built extensions are incompatible with each other.

## What is your fix for the problem, implemented in this PR?

My fix is to amend #5632 to add support for this. RubyGems has `Gem.extension_api_version` for this, but I believe the standalone script is supposed to work without RubyGems so that required a bit of extra work.

Link to a passing daily CI is here: https://github.com/rubygems/rubygems/runs/6989422115?check_suite_focus=true.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
