### PR TITLE
Fix `bundle package --no-install` no longer skipping install

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -251,7 +251,9 @@ module Bundler
       remembered_negative_flag_deprecation("no-deployment")
 
       require_relative "cli/install"
-      Install.new(options.dup).run
+      Bundler.settings.temporary(:no_install => false) do
+        Install.new(options.dup).run
+      end
     end
 
     map aliases_for("install")
@@ -297,7 +299,9 @@ module Bundler
     def update(*gems)
       SharedHelpers.major_deprecation(2, "The `--force` option has been renamed to `--redownload`") if ARGV.include?("--force")
       require_relative "cli/update"
-      Update.new(options, gems).run
+      Bundler.settings.temporary(:no_install => false) do
+        Update.new(options, gems).run
+      end
     end
 
     desc "show GEM [OPTIONS]", "Shows all gems that are part of the bundle, or the path to a given gem"

--- a/bundler/lib/bundler/cli/cache.rb
+++ b/bundler/lib/bundler/cli/cache.rb
@@ -14,7 +14,7 @@ module Bundler
       Bundler.settings.set_command_option_if_given :cache_path, options["cache-path"]
 
       setup_cache_all
-      install unless Bundler.settings[:no_install]
+      install
 
       # TODO: move cache contents here now that all bundles are locked
       custom_path = Bundler.settings[:path] if options[:path]

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -161,6 +161,8 @@ module Bundler
 
       Bundler.settings.set_command_option_if_given :no_prune, options["no-prune"]
 
+      Bundler.settings.set_command_option_if_given :no_install, options["no-install"]
+
       Bundler.settings.set_command_option_if_given :clean, options["clean"]
 
       normalize_groups if options[:without] || options[:with]

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -160,6 +160,8 @@ module Bundler
           raise GemNotFound, "Could not find #{spec.file_name} for installation" unless path
         end
 
+        return if Bundler.settings[:no_install]
+
         if requires_sudo?
           install_path = Bundler.tmp(spec.full_name)
           bin_path     = install_path.join("bin")

--- a/bundler/spec/support/matchers.rb
+++ b/bundler/spec/support/matchers.rb
@@ -178,7 +178,7 @@ module Spec
 
             begin
               require '#{name}'
-              name_constant = '#{Spec::Builders.constantize(name)}'
+              name_constant = #{Spec::Builders.constantize(name)}
               if #{version.nil?} || name_constant == '#{version}'
                 exit 64
               else


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since cf749f8ffabdfb60cf9c8e17689199e6ea45b6e2, `bundle package --no-install` no longer skips installation.

## What is your fix for the problem, implemented in this PR?

My fix is to revert the offending commit, and also to fix the negative spec matcher bug that allowed the regression to be introduced in the first place.

Fixes https://github.com/rubygems/rubygems/pull/5614#issuecomment-1161721321.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
