### PR TITLE
Bundler: fix man page for bundle-add

### DIFF
--- a/bundler/lib/bundler/man/bundle-add.1
+++ b/bundler/lib/bundler/man/bundle-add.1
@@ -41,7 +41,7 @@ Specify version requirements(s) for the added gem\.
 Specify the group(s) for the added gem\. Multiple groups should be separated by commas\.
 .
 .TP
-\fB\-\-source\fR, , \fB\-s\fR
+\fB\-\-source\fR, \fB\-s\fR
 Specify the source for the added gem\.
 .
 .TP

--- a/bundler/lib/bundler/man/bundle-add.1.ronn
+++ b/bundler/lib/bundler/man/bundle-add.1.ronn
@@ -27,7 +27,7 @@ bundle add rails --group "development, test"
 * `--group`, `-g`:
   Specify the group(s) for the added gem. Multiple groups should be separated by commas.
 
-* `--source`, , `-s`:
+* `--source`, `-s`:
   Specify the source for the added gem.
 
 * `--require`, `-r`:


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Man page for `bundle-add`, or https://bundler.io/man/bundle-add.1.html and https://bundler.io/v2.3/man/bundle-add.1.html is not well-formatted.

## What is your fix for the problem, implemented in this PR?

Bundler: fix man page for `bundle-add`: https://bundler.io/man/bundle-add.1.html and https://bundler.io/v2.3/man/bundle-add.1.html

Fixes up https://github.com/rubygems/bundler/pull/5610

As `rake man:check` was used instead of `rake man:build`, the date was not updated.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [n/a] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [n/a] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>
