### PR TITLE
Document `gem env` argument aliases and add `gem env userhome`

### DIFF
--- a/lib/rubygems/commands/environment_command.rb
+++ b/lib/rubygems/commands/environment_command.rb
@@ -8,8 +8,8 @@ class Gem::Commands::EnvironmentCommand < Gem::Command
 
   def arguments # :nodoc:
     args = <<-EOF
-          gemdir          display the path where gems are installed
-          gempath         display path used to search for gems
+          home            display the path where gems are installed
+          path            display path used to search for gems
           version         display the gem format version
           remotesources   display the remote gem servers
           platform        display the supported gem platforms

--- a/lib/rubygems/commands/environment_command.rb
+++ b/lib/rubygems/commands/environment_command.rb
@@ -10,6 +10,7 @@ class Gem::Commands::EnvironmentCommand < Gem::Command
     args = <<-EOF
           home            display the path where gems are installed. Aliases: gemhome, gemdir, GEM_HOME
           path            display path used to search for gems. Aliases: gempath, GEM_PATH
+          user_gemhome    display the path where gems are installed when `--user-install` is given. Aliases: user_gemdir
           version         display the gem format version
           remotesources   display the remote gem servers
           platform        display the supported gem platforms
@@ -80,6 +81,8 @@ lib/rubygems/defaults/operating_system.rb
         Gem.dir
       when /^gempath/, /^path/, /^GEM_PATH/ then
         Gem.path.join(File::PATH_SEPARATOR)
+      when /^user_gemdir/, /^user_gemhome/ then
+        Gem.user_dir
       when /^remotesources/ then
         Gem.sources.to_a.join("\n")
       when /^platform/ then

--- a/lib/rubygems/commands/environment_command.rb
+++ b/lib/rubygems/commands/environment_command.rb
@@ -8,8 +8,8 @@ class Gem::Commands::EnvironmentCommand < Gem::Command
 
   def arguments # :nodoc:
     args = <<-EOF
-          home            display the path where gems are installed
-          path            display path used to search for gems
+          home            display the path where gems are installed. Aliases: gemhome, gemdir, GEM_HOME
+          path            display path used to search for gems. Aliases: gempath, GEM_PATH
           version         display the gem format version
           remotesources   display the remote gem servers
           platform        display the supported gem platforms

--- a/test/rubygems/test_gem_commands_environment_command.rb
+++ b/test/rubygems/test_gem_commands_environment_command.rb
@@ -65,6 +65,28 @@ class TestGemCommandsEnvironmentCommand < Gem::TestCase
     assert_equal '', @ui.error
   end
 
+  def test_execute_user_gemdir
+    @cmd.send :handle_options, %w[user_gemdir]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    assert_equal "#{Gem.user_dir}\n", @ui.output
+    assert_equal '', @ui.error
+  end
+
+  def test_execute_user_gemhome
+    @cmd.send :handle_options, %w[user_gemhome]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    assert_equal "#{Gem.user_dir}\n", @ui.output
+    assert_equal '', @ui.error
+  end
+
   def test_execute_gempath
     @cmd.send :handle_options, %w[gempath]
 

--- a/test/rubygems/test_gem_commands_environment_command.rb
+++ b/test/rubygems/test_gem_commands_environment_command.rb
@@ -25,6 +25,8 @@ class TestGemCommandsEnvironmentCommand < Gem::TestCase
     assert_match %r{RUBY VERSION: \d+\.\d+\.\d+ \(.*\) \[.*\]}, @ui.output
     assert_match %r{INSTALLATION DIRECTORY: #{Regexp.escape @gemhome}},
                  @ui.output
+    assert_match %r{USER INSTALLATION DIRECTORY: #{Regexp.escape Gem.user_dir}},
+                 @ui.output
     assert_match %r{RUBYGEMS PREFIX: }, @ui.output
     assert_match %r{RUBY EXECUTABLE:.*#{RbConfig::CONFIG['ruby_install_name']}},
                  @ui.output


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Nothing really, just making `gem env` goodies more visible, and also adding support for `gem env userhome`.

## What is your fix for the problem, implemented in this PR?

Implement the above.

Also made `gem env home` and `gem env path` more prominent since they read very well :)

Closes #5366.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
