### PR TITLE
Add support for platform `:x64_mingw` to correctly lookup "x64-mingw-ucrt"

### DIFF
--- a/bundler/lib/bundler/current_ruby.rb
+++ b/bundler/lib/bundler/current_ruby.rb
@@ -78,7 +78,7 @@ module Bundler
     end
 
     def x64_mingw?
-      Gem.win_platform? && Bundler.local_platform != Gem::Platform::RUBY && Bundler.local_platform.os == "mingw32" && Bundler.local_platform.cpu == "x64"
+      Gem.win_platform? && Bundler.local_platform != Gem::Platform::RUBY && Bundler.local_platform.os.start_with?("mingw") && Bundler.local_platform.cpu == "x64"
     end
 
     (KNOWN_MINOR_VERSIONS + KNOWN_MAJOR_VERSIONS).each do |version|

--- a/bundler/lib/bundler/dependency.rb
+++ b/bundler/lib/bundler/dependency.rb
@@ -122,7 +122,7 @@ module Bundler
     end
 
     def expanded_platforms
-      @expanded_platforms ||= @platforms.map {|pl| PLATFORM_MAP[pl] }.compact.uniq
+      @expanded_platforms ||= @platforms.map {|pl| PLATFORM_MAP[pl] }.compact.flatten.uniq
     end
 
     def should_include?

--- a/bundler/lib/bundler/gem_helpers.rb
+++ b/bundler/lib/bundler/gem_helpers.rb
@@ -10,6 +10,7 @@ module Bundler
       [Gem::Platform.new("universal-mingw32"), Gem::Platform.new("universal-mingw32")],
       [Gem::Platform.new("x64-mingw32"), Gem::Platform.new("x64-mingw32")],
       [Gem::Platform.new("x86_64-mingw32"), Gem::Platform.new("x64-mingw32")],
+      [Gem::Platform.new("x64-mingw-ucrt"), Gem::Platform.new("x64-mingw-ucrt")],
       [Gem::Platform.new("mingw32"), Gem::Platform.new("x86-mingw32")],
     ].freeze
 

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -216,11 +216,11 @@ module Gem
   require "rubygems/platform"
 
   class Platform
-    JAVA  = Gem::Platform.new("java") unless defined?(JAVA)
-    MSWIN = Gem::Platform.new("mswin32") unless defined?(MSWIN)
-    MSWIN64 = Gem::Platform.new("mswin64") unless defined?(MSWIN64)
-    MINGW = Gem::Platform.new("x86-mingw32") unless defined?(MINGW)
-    X64_MINGW = Gem::Platform.new("x64-mingw32") unless defined?(X64_MINGW)
+    JAVA  = Gem::Platform.new("java")
+    MSWIN = Gem::Platform.new("mswin32")
+    MSWIN64 = Gem::Platform.new("mswin64")
+    MINGW = Gem::Platform.new("x86-mingw32")
+    X64_MINGW = Gem::Platform.new("x64-mingw32")
   end
 
   Platform.singleton_class.module_eval do

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -220,7 +220,8 @@ module Gem
     MSWIN = Gem::Platform.new("mswin32")
     MSWIN64 = Gem::Platform.new("mswin64")
     MINGW = Gem::Platform.new("x86-mingw32")
-    X64_MINGW = Gem::Platform.new("x64-mingw32")
+    X64_MINGW = [Gem::Platform.new("x64-mingw32"),
+                 Gem::Platform.new("x64-mingw-ucrt")].freeze
   end
 
   Platform.singleton_class.module_eval do

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -8,6 +8,26 @@ RSpec.describe "bundle install from an existing gemspec" do
     end
   end
 
+  let(:x64_mingw_archs) do
+    if RUBY_PLATFORM == "x64-mingw-ucrt"
+      if Gem.rubygems_version >= Gem::Version.new("3.2.28")
+        ["x64-mingw-ucrt", "x64-mingw32"]
+      else
+        ["x64-mingw32", "x64-unknown"]
+      end
+    else
+      ["x64-mingw32"]
+    end
+  end
+
+  let(:x64_mingw_gems) do
+    x64_mingw_archs.map {|p| "platform_specific (1.0-#{p})" }.join("\n    ")
+  end
+
+  let(:x64_mingw_platforms) do
+    x64_mingw_archs.join("\n  ")
+  end
+
   it "should install runtime and development dependencies" do
     build_lib("foo", :path => tmp.join("foo")) do |s|
       s.write("Gemfile", "source :rubygems\ngemspec")
@@ -440,12 +460,12 @@ RSpec.describe "bundle install from an existing gemspec" do
                 specs:
                   platform_specific (1.0)
                   platform_specific (1.0-java)
-                  platform_specific (1.0-x64-mingw32)
+                  #{x64_mingw_gems}
 
               PLATFORMS
                 java
                 ruby
-                x64-mingw32
+                #{x64_mingw_platforms}
 
               DEPENDENCIES
                 foo!
@@ -472,12 +492,12 @@ RSpec.describe "bundle install from an existing gemspec" do
                 specs:
                   platform_specific (1.0)
                   platform_specific (1.0-java)
-                  platform_specific (1.0-x64-mingw32)
+                  #{x64_mingw_gems}
 
               PLATFORMS
                 java
                 ruby
-                x64-mingw32
+                #{x64_mingw_platforms}
 
               DEPENDENCIES
                 foo!
@@ -508,12 +528,12 @@ RSpec.describe "bundle install from an existing gemspec" do
                     platform_specific
                   platform_specific (1.0)
                   platform_specific (1.0-java)
-                  platform_specific (1.0-x64-mingw32)
+                  #{x64_mingw_gems}
 
               PLATFORMS
                 java
                 ruby
-                x64-mingw32
+                #{x64_mingw_platforms}
 
               DEPENDENCIES
                 foo!
@@ -597,7 +617,7 @@ RSpec.describe "bundle install from an existing gemspec" do
 
         PLATFORMS
           ruby
-          x64-mingw32
+          #{x64_mingw_platforms}
           x86-mingw32
 
         DEPENDENCIES

--- a/bundler/spec/other/ext_spec.rb
+++ b/bundler/spec/other/ext_spec.rb
@@ -44,6 +44,10 @@ RSpec.describe "Bundler::GemHelpers#generic" do
     expect(generic(pl("x64-mingw32"))).to eq(pl("x64-mingw32"))
     expect(generic(pl("x86_64-mingw32"))).to eq(pl("x64-mingw32"))
   end
+
+  it "converts 64-bit mingw UCRT platform variants into x64-mingw-ucrt" do
+    expect(generic(pl("x64-mingw-ucrt"))).to eq(pl("x64-mingw-ucrt"))
+  end
 end
 
 RSpec.describe "Gem::SourceIndex#refresh!" do

--- a/bundler/spec/resolver/platform_spec.rb
+++ b/bundler/spec/resolver/platform_spec.rb
@@ -291,7 +291,7 @@ RSpec.describe "Resolving platform craziness" do
   describe "with mingw32" do
     before :each do
       @index = build_index do
-        platforms "mingw32 mswin32 x64-mingw32" do |platform|
+        platforms "mingw32 mswin32 x64-mingw32 x64-mingw-ucrt" do |platform|
           gem "thin", "1.2.7", platform
         end
         gem "win32-api", "1.5.1", "universal-mingw32"
@@ -312,7 +312,7 @@ RSpec.describe "Resolving platform craziness" do
       should_resolve_as %w[thin-1.2.7-mingw32]
     end
 
-    it "finds x64-mingw gems" do
+    it "finds x64-mingw32 gems" do
       platforms "x64-mingw32"
       dep "thin"
       should_resolve_as %w[thin-1.2.7-x64-mingw32]
@@ -328,6 +328,14 @@ RSpec.describe "Resolving platform craziness" do
       platform "x64-mingw32"
       dep "win32-api"
       should_resolve_as %w[win32-api-1.5.1-universal-mingw32]
+    end
+
+    if Gem.rubygems_version >= Gem::Version.new("3.2.28")
+      it "finds x64-mingw-ucrt gems" do
+        platforms "x64-mingw-ucrt"
+        dep "thin"
+        should_resolve_as %w[thin-1.2.7-x64-mingw-ucrt]
+      end
     end
   end
 

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -122,6 +122,10 @@ module Spec
         end
 
         build_gem "platform_specific" do |s|
+          s.platform = "x64-mingw-ucrt"
+        end
+
+        build_gem "platform_specific" do |s|
           s.platform = "x86-darwin-100"
           s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0.0 x86-darwin-100'"
         end

--- a/bundler/spec/support/platforms.rb
+++ b/bundler/spec/support/platforms.rb
@@ -55,7 +55,7 @@ module Spec
     def local_tag
       if RUBY_PLATFORM == "java"
         :jruby
-      elsif RUBY_PLATFORM == "x64-mingw32"
+      elsif ["x64-mingw32", "x64-mingw-ucrt"].include?(RUBY_PLATFORM)
         :x64_mingw
       else
         :ruby

--- a/bundler/tool/bundler/dev_gems.rb.lock
+++ b/bundler/tool/bundler/dev_gems.rb.lock
@@ -34,6 +34,7 @@ PLATFORMS
   ruby
   universal-java-11
   universal-java-18
+  x64-mingw-ucrt
   x64-mingw32
   x86_64-darwin-20
   x86_64-linux

--- a/bundler/tool/bundler/lint_gems.rb.lock
+++ b/bundler/tool/bundler/lint_gems.rb.lock
@@ -29,6 +29,7 @@ PLATFORMS
   java
   ruby
   universal-java-11
+  x64-mingw-ucrt
   x64-mingw32
   x86_64-darwin-20
   x86_64-linux

--- a/bundler/tool/bundler/rubocop_gems.rb.lock
+++ b/bundler/tool/bundler/rubocop_gems.rb.lock
@@ -48,6 +48,7 @@ PLATFORMS
   arm64-darwin-21
   universal-java-11
   universal-java-18
+  x64-mingw-ucrt
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-linux

--- a/bundler/tool/bundler/standard_gems.rb.lock
+++ b/bundler/tool/bundler/standard_gems.rb.lock
@@ -54,6 +54,7 @@ PLATFORMS
   arm64-darwin-21
   universal-java-11
   universal-java-18
+  x64-mingw-ucrt
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-linux

--- a/bundler/tool/bundler/test_gems.rb.lock
+++ b/bundler/tool/bundler/test_gems.rb.lock
@@ -27,6 +27,7 @@ PLATFORMS
   ruby
   universal-java-11
   universal-java-18
+  x64-mingw-ucrt
   x64-mingw32
   x86_64-darwin-20
   x86_64-linux


### PR DESCRIPTION
Fixes https://github.com/rubygems/rubygems/issues/5269

I've implemented it in such a way that platform `:x64_mingw` resolves to either `x64-mingw32` or `x64-mingw-ucrt`.

Note [this comment from larskanis](https://github.com/rubygems/rubygems/issues/5269#issuecomment-1010869946):

> [deivid-rodriguez](https://github.com/deivid-rodriguez) > So, as an alternative to adding a new platform, you'd prefer that the current x64_mingw platform value resolved to urct variants, right?
[larskanis](https://github.com/larskanis) >Yes. The platforms x64-mingw32 and x64-mingw-ucrt are ABI incompatible - that's why we introduced a new platform string for RUBY_PLATFORM and Rubygems. But there is little to no difference between them, when it comes to enabling/disabling gems from a Gemfile.