### PR TITLE
Add platform alias `:windows` to Gemfile DSL

### DIFF
--- a/bundler/lib/bundler/current_ruby.rb
+++ b/bundler/lib/bundler/current_ruby.rb
@@ -36,17 +36,18 @@ module Bundler
       rbx
       ruby
       truffleruby
+      windows
       x64_mingw
     ].freeze
 
     def ruby?
       return true if Bundler::GemHelpers.generic_local_platform == Gem::Platform::RUBY
 
-      !mswin? && (RUBY_ENGINE == "ruby" || RUBY_ENGINE == "rbx" || RUBY_ENGINE == "maglev" || RUBY_ENGINE == "truffleruby")
+      !windows? && (RUBY_ENGINE == "ruby" || RUBY_ENGINE == "rbx" || RUBY_ENGINE == "maglev" || RUBY_ENGINE == "truffleruby")
     end
 
     def mri?
-      !mswin? && RUBY_ENGINE == "ruby"
+      !windows? && RUBY_ENGINE == "ruby"
     end
 
     def rbx?
@@ -65,16 +66,24 @@ module Bundler
       RUBY_ENGINE == "truffleruby"
     end
 
-    def mswin?
+    def windows?
       Gem.win_platform?
     end
 
+    def mswin?
+      # For backwards compatibility
+      windows?
+
+      # TODO: This should correctly be:
+      # windows? && Bundler.local_platform != Gem::Platform::RUBY && Bundler.local_platform.os == "mswin32" && Bundler.local_platform.cpu == "x86"
+    end
+
     def mswin64?
-      Gem.win_platform? && Bundler.local_platform != Gem::Platform::RUBY && Bundler.local_platform.os == "mswin64" && Bundler.local_platform.cpu == "x64"
+      windows? && Bundler.local_platform != Gem::Platform::RUBY && Bundler.local_platform.os == "mswin64" && Bundler.local_platform.cpu == "x64"
     end
 
     def mingw?
-      Gem.win_platform? && Bundler.local_platform != Gem::Platform::RUBY && Bundler.local_platform.os == "mingw32" && Bundler.local_platform.cpu != "x64"
+      windows? && Bundler.local_platform != Gem::Platform::RUBY && Bundler.local_platform.os == "mingw32" && Bundler.local_platform.cpu != "x64"
     end
 
     def x64_mingw?

--- a/bundler/lib/bundler/dependency.rb
+++ b/bundler/lib/bundler/dependency.rb
@@ -42,6 +42,7 @@ module Bundler
       :jruby    => Gem::Platform::JAVA,
       :jruby_18 => Gem::Platform::JAVA,
       :jruby_19 => Gem::Platform::JAVA,
+      :windows  => Gem::Platform::WINDOWS,
       :mswin    => Gem::Platform::MSWIN,
       :mswin_18 => Gem::Platform::MSWIN,
       :mswin_19 => Gem::Platform::MSWIN,

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -237,6 +237,7 @@ module Gem
     MINGW = Gem::Platform.new("x86-mingw32")
     X64_MINGW = [Gem::Platform.new("x64-mingw32"),
                  Gem::Platform.new("x64-mingw-ucrt")].freeze
+    WINDOWS = [MSWIN, MSWIN64, MINGW, X64_MINGW].flatten.freeze
 
     if Gem::Platform.new("x86_64-linux-musl") === Gem::Platform.new("x86_64-linux")
       remove_method :===

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -285,7 +285,7 @@ RSpec.describe "bundle install with gem sources" do
       end
 
       it "installs gems for windows" do
-        simulate_platform mswin
+        simulate_platform x86_mswin32
 
         install_gemfile <<-G
           source "#{file_uri_for(gem_repo1)}"
@@ -293,7 +293,7 @@ RSpec.describe "bundle install with gem sources" do
         G
 
         run "require 'platform_specific' ; puts PLATFORM_SPECIFIC"
-        expect(out).to eq("1.0.0 MSWIN")
+        expect(out).to eq("1.0 x86-mswin32")
       end
     end
 

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe "bundle lock" do
 
     allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
     lockfile = Bundler::LockfileParser.new(read_lockfile)
-    expect(lockfile.platforms).to match_array([java, mingw, specific_local_platform].uniq)
+    expect(lockfile.platforms).to match_array([java, x86_mingw32, specific_local_platform].uniq)
   end
 
   it "supports adding new platforms with force_ruby_platform = true" do
@@ -241,7 +241,7 @@ RSpec.describe "bundle lock" do
 
     allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
     lockfile = Bundler::LockfileParser.new(read_lockfile)
-    expect(lockfile.platforms).to contain_exactly(rb, linux, java, mingw)
+    expect(lockfile.platforms).to contain_exactly(rb, linux, java, x86_mingw32)
   end
 
   it "supports adding the `ruby` platform" do
@@ -262,12 +262,12 @@ RSpec.describe "bundle lock" do
 
     allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
     lockfile = Bundler::LockfileParser.new(read_lockfile)
-    expect(lockfile.platforms).to match_array([java, mingw, specific_local_platform].uniq)
+    expect(lockfile.platforms).to match_array([java, x86_mingw32, specific_local_platform].uniq)
 
     bundle "lock --remove-platform java"
 
     lockfile = Bundler::LockfileParser.new(read_lockfile)
-    expect(lockfile.platforms).to match_array([mingw, specific_local_platform].uniq)
+    expect(lockfile.platforms).to match_array([x86_mingw32, specific_local_platform].uniq)
   end
 
   it "errors when removing all platforms" do
@@ -280,7 +280,7 @@ RSpec.describe "bundle lock" do
     build_repo4 do
       build_gem "ffi", "1.9.14"
       build_gem "ffi", "1.9.14" do |s|
-        s.platform = mingw
+        s.platform = x86_mingw32
       end
 
       build_gem "gssapi", "0.1"
@@ -312,7 +312,7 @@ RSpec.describe "bundle lock" do
       gem "gssapi"
     G
 
-    simulate_platform(mingw) { bundle :lock }
+    simulate_platform(x86_mingw32) { bundle :lock }
 
     expect(lockfile).to eq <<~G
       GEM

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -436,7 +436,7 @@ RSpec.describe "bundle install from an existing gemspec" do
 
         simulate_new_machine
         simulate_platform("jruby") { bundle "install" }
-        simulate_platform(x64_mingw) { bundle "install" }
+        simulate_platform(x64_mingw32) { bundle "install" }
       end
 
       context "on ruby" do

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -501,7 +501,7 @@ end
 
 RSpec.describe "when a gem has no architecture" do
   it "still installs correctly" do
-    simulate_platform mswin
+    simulate_platform x86_mswin32
 
     build_repo2 do
       # The rcov gem is platform mswin32, but has no arch

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -227,9 +227,9 @@ RSpec.describe "bundle install with specific platforms" do
       it "adds the foreign platform" do
         setup_multiplatform_gem
         install_gemfile(google_protobuf)
-        bundle "lock --add-platform=#{x64_mingw}"
+        bundle "lock --add-platform=#{x64_mingw32}"
 
-        expect(the_bundle.locked_gems.platforms).to eq([x64_mingw, pl("x86_64-darwin-15")])
+        expect(the_bundle.locked_gems.platforms).to eq([x64_mingw32, pl("x86_64-darwin-15")])
         expect(the_bundle.locked_gems.specs.map(&:full_name)).to eq(%w[
           google-protobuf-3.0.0.alpha.5.0.5.1-universal-darwin
           google-protobuf-3.0.0.alpha.5.0.5.1-x64-mingw32

--- a/bundler/spec/install/gems/dependency_api_spec.rb
+++ b/bundler/spec/install/gems/dependency_api_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe "gemcutter's dependency API" do
   end
 
   it "falls back when the API errors out" do
-    simulate_platform mswin
+    simulate_platform x86_mswin32
 
     build_repo2 do
       # The rcov gem is platform mswin32, but has no arch

--- a/bundler/spec/install/gems/resolving_spec.rb
+++ b/bundler/spec/install/gems/resolving_spec.rb
@@ -423,13 +423,13 @@ RSpec.describe "bundle install with install-time dependencies" do
             s.required_ruby_version = "> 9000"
           end
           build_gem "rack", "1.2" do |s|
-            s.platform = mingw
+            s.platform = x86_mingw32
             s.required_ruby_version = "> 9000"
           end
           build_gem "rack", "1.2"
         end
 
-        simulate_platform mingw do
+        simulate_platform x86_mingw32 do
           install_gemfile <<-G, :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
             ruby "#{Gem.ruby_version}"
             source "http://localgemserver.test/"

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -110,19 +110,27 @@ module Spec
 
         build_gem "platform_specific" do |s|
           s.platform = "x86-mswin32"
-          s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0.0 MSWIN'"
+          s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0 x86-mswin32'"
+        end
+
+        build_gem "platform_specific" do |s|
+          s.platform = "x64-mswin64"
+          s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0 x64-mswin64'"
         end
 
         build_gem "platform_specific" do |s|
           s.platform = "x86-mingw32"
+          s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0 x86-mingw32'"
         end
 
         build_gem "platform_specific" do |s|
           s.platform = "x64-mingw32"
+          s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0 x64-mingw32'"
         end
 
         build_gem "platform_specific" do |s|
           s.platform = "x64-mingw-ucrt"
+          s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0 x64-mingw-ucrt'"
         end
 
         build_gem "platform_specific" do |s|

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -445,7 +445,7 @@ module Spec
       ENV["BUNDLER_SPEC_PLATFORM"] = old if block_given?
     end
 
-    def simulate_windows(platform = mswin)
+    def simulate_windows(platform = x86_mswin32)
       old = ENV["BUNDLER_SPEC_WINDOWS"]
       ENV["BUNDLER_SPEC_WINDOWS"] = "true"
       simulate_platform platform do

--- a/bundler/spec/support/platforms.rb
+++ b/bundler/spec/support/platforms.rb
@@ -24,20 +24,32 @@ module Spec
       Gem::Platform.new(["x86", "linux", nil])
     end
 
-    def mswin
+    def x86_mswin32
       Gem::Platform.new(["x86", "mswin32", nil])
     end
 
-    def mingw
+    def x64_mswin64
+      Gem::Platform.new(["x64", "mswin64", nil])
+    end
+
+    def x86_mingw32
       Gem::Platform.new(["x86", "mingw32", nil])
     end
 
-    def x64_mingw
+    def x64_mingw32
       Gem::Platform.new(["x64", "mingw32", nil])
     end
 
+    def x64_mingw_ucrt
+      Gem::Platform.new(["x64", "mingw", "ucrt"])
+    end
+
+    def windows_platforms
+      [x86_mswin32, x64_mswin64, x86_mingw32, x64_mingw32, x64_mingw_ucrt]
+    end
+
     def all_platforms
-      [rb, java, linux, mswin, mingw, x64_mingw]
+      [rb, java, linux, windows_platforms].flatten
     end
 
     def local


### PR DESCRIPTION
You'll typically see this in the Gemfile of a Windows user:

```ruby
platforms :mswin, :mswin64, :mingw, :x64_mingw do
  gem 'tzinfo-data'
  gem 'wdm', '>= 0.1.0'
end
```

This is quite silly. Let's make it possible to do this:

```ruby
platforms :windows do
  gem 'tzinfo-data'
  gem 'wdm', '>= 0.1.0'
end
```

In addition, this PR includes some changes to Bunder.current_ruby. I'll break those out into another PR probably.

This PR includes the changes from #5649. It does not change/break any existing platform behavior (aside from what has changed in #5649.)