### PR TITLE
Clean up temporary directory after `generate_index --update`

### DIFF
--- a/lib/rubygems/indexer.rb
+++ b/lib/rubygems/indexer.rb
@@ -401,6 +401,8 @@ class Gem::Indexer
 
       File.utime newest_mtime, newest_mtime, dst_name
     end
+  ensure
+    FileUtils.rm_rf @directory
   end
 
   ##

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -119,6 +119,12 @@ class Gem::TestCase < Test::Unit::TestCase
     assert File.directory?(path), msg
   end
 
+  def refute_directory_exists(path, msg = nil)
+    msg = build_message(msg, "Expected path '#{path}' not to be a directory")
+    assert_path_not_exist path
+    refute File.directory?(path), msg
+  end
+
   # https://github.com/seattlerb/minitest/blob/21d9e804b63c619f602f3f4ece6c71b48974707a/lib/minitest/assertions.rb#L188
   def _synchronize
     yield

--- a/test/rubygems/test_gem_indexer.rb
+++ b/test/rubygems/test_gem_indexer.rb
@@ -103,6 +103,8 @@ class TestGemIndexer < Gem::TestCase
 
     assert_indexed @indexerdir, "latest_specs.#{@marshal_version}"
     assert_indexed @indexerdir, "latest_specs.#{@marshal_version}.gz"
+
+    refute_directory_exists @indexer.directory
   end
 
   def test_generate_index_modern
@@ -342,6 +344,8 @@ class TestGemIndexer < Gem::TestCase
 
       assert_includes pre_specs_index, @d2_1_a_tuple
       refute_includes pre_specs_index, @d2_1_tuple
+
+      refute_directory_exists @indexer.directory
     end
   end
 


### PR DESCRIPTION
While generate_index did clean up temporary directory, when running with
--update flag, that did not happen and the temporary directory was left
behind.

This commit fixes that and modifies tests in order to make sure this is
not reintroduced later on.

Fixes #5635.