### PR TITLE
Make platform `universal-mingw32` match "x64-mingw-ucrt"

### DIFF
--- a/bundler/spec/resolver/platform_spec.rb
+++ b/bundler/spec/resolver/platform_spec.rb
@@ -337,6 +337,14 @@ RSpec.describe "Resolving platform craziness" do
         should_resolve_as %w[thin-1.2.7-x64-mingw-ucrt]
       end
     end
+
+    if Gem.rubygems_version >= Gem::Version.new("3.3.18")
+      it "finds universal-mingw gems on x64-mingw-ucrt" do
+        platform "x64-mingw-ucrt"
+        dep "win32-api"
+        should_resolve_as %w[win32-api-1.5.1-universal-mingw32]
+      end
+    end
   end
 
   describe "with conflicting cases" do

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -159,6 +159,10 @@ class Gem::Platform
   def ===(other)
     return nil unless Gem::Platform === other
 
+    # universal-mingw32 matches x64-mingw-ucrt
+    return true if (@cpu == 'universal' or other.cpu == 'universal') and
+                   @os.start_with?('mingw') and other.os.start_with?('mingw')
+
     # cpu
     ([nil,'universal'].include?(@cpu) or [nil, 'universal'].include?(other.cpu) or @cpu == other.cpu or
     (@cpu == 'arm' and other.cpu.start_with?("arm"))) and

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -280,6 +280,22 @@ class TestGemPlatform < Gem::TestCase
     refute((Gem::Platform.local === arm), 'armv7 === arm')
   end
 
+  def test_equals3_universal_mingw
+    uni_mingw  = Gem::Platform.new 'universal-mingw'
+    mingw32    = Gem::Platform.new 'x64-mingw32'
+    mingw_ucrt = Gem::Platform.new 'x64-mingw-ucrt'
+
+    util_set_arch 'x64-mingw32'
+    assert((uni_mingw === Gem::Platform.local), 'uni_mingw === mingw32')
+    assert((mingw32 === Gem::Platform.local), 'mingw32 === mingw32')
+    refute((mingw_ucrt === Gem::Platform.local), 'mingw32 === mingw_ucrt')
+
+    util_set_arch 'x64-mingw-ucrt'
+    assert((uni_mingw === Gem::Platform.local), 'uni_mingw === mingw32')
+    assert((mingw_ucrt === Gem::Platform.local), 'mingw_ucrt === mingw_ucrt')
+    refute((mingw32 === Gem::Platform.local), 'mingw32 === mingw_ucrt')
+  end
+
   def test_equals3_version
     util_set_arch 'i686-darwin8'
 


### PR DESCRIPTION
This is a follow-up to https://github.com/rubygems/rubygems/pull/5649.

@larskanis please confirm this change is correct.

In order to do this change, we need to modify `Gem::Platform#===` with the following special logic:

```
    # universal-mingw32 matches x64-mingw-ucrt
    return true if (@cpu == 'universal' or other.cpu == 'universal') and
                   @os.start_with?('mingw') and other.os.start_with?('mingw')
```

The reason we can't so something simpler like adding `.start_with?('mingw')` to the existing OS conditions is that it will cause `x64-mingw32` to match with `x64-mingw-ucrt`, which we don't want.