### PR TITLE
Fix pending Windows specs

### DIFF
--- a/.github/workflows/jruby-bundler.yml
+++ b/.github/workflows/jruby-bundler.yml
@@ -33,7 +33,7 @@ jobs:
         working-directory: ./bundler
       - name: Run Test
         run: |
-          bin/parallel_rspec --tag jruby
+          bin/parallel_rspec --tag jruby_only --tag jruby
         working-directory: ./bundler
       - name: Install local bundler
         run: |

--- a/.github/workflows/truffleruby-bundler.yml
+++ b/.github/workflows/truffleruby-bundler.yml
@@ -30,5 +30,5 @@ jobs:
         working-directory: ./bundler
       - name: Run Test
         run: |
-          bin/parallel_rspec --tag truffleruby
+          bin/parallel_rspec --tag truffleruby_only --tag truffleruby
         working-directory: ./bundler

--- a/bundler/spec/bundler/definition_spec.rb
+++ b/bundler/spec/bundler/definition_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe Bundler::Definition do
             only_java (1.1-java)
 
         PLATFORMS
-          #{lockfile_platforms_for(["java"] + local_platforms)}
+          #{lockfile_platforms_for(["java", specific_local_platform])}
 
         DEPENDENCIES
           only_java

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe "bundle lock" do
 
     allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
     lockfile = Bundler::LockfileParser.new(read_lockfile)
-    expect(lockfile.platforms).to match_array(local_platforms.unshift(java, mingw).uniq)
+    expect(lockfile.platforms).to match_array([java, mingw, specific_local_platform].uniq)
   end
 
   it "supports adding new platforms with force_ruby_platform = true" do
@@ -249,7 +249,7 @@ RSpec.describe "bundle lock" do
 
     allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
     lockfile = Bundler::LockfileParser.new(read_lockfile)
-    expect(lockfile.platforms).to match_array(local_platforms.unshift("ruby").uniq)
+    expect(lockfile.platforms).to match_array(["ruby", specific_local_platform].uniq)
   end
 
   it "warns when adding an unknown platform" do
@@ -262,16 +262,16 @@ RSpec.describe "bundle lock" do
 
     allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
     lockfile = Bundler::LockfileParser.new(read_lockfile)
-    expect(lockfile.platforms).to match_array(local_platforms.unshift(java, mingw).uniq)
+    expect(lockfile.platforms).to match_array([java, mingw, specific_local_platform].uniq)
 
     bundle "lock --remove-platform java"
 
     lockfile = Bundler::LockfileParser.new(read_lockfile)
-    expect(lockfile.platforms).to match_array(local_platforms.unshift(mingw).uniq)
+    expect(lockfile.platforms).to match_array([mingw, specific_local_platform].uniq)
   end
 
   it "errors when removing all platforms" do
-    bundle "lock --remove-platform #{local_platforms.join(" ")}", :raise_on_error => false
+    bundle "lock --remove-platform #{specific_local_platform}", :raise_on_error => false
     expect(err).to include("Removing all platforms from the bundle is not allowed")
   end
 

--- a/bundler/spec/commands/outdated_spec.rb
+++ b/bundler/spec/commands/outdated_spec.rb
@@ -821,7 +821,7 @@ RSpec.describe "bundle outdated" do
       expect(out).to end_with("Bundle up to date!")
     end
 
-    it "reports that updates are available if the JRuby platform is used", :jruby do
+    it "reports that updates are available if the JRuby platform is used", :jruby_only do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "laduradura", '= 5.15.2', :platforms => [:ruby, :jruby]

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -665,7 +665,7 @@ RSpec.describe "bundle install from an existing gemspec" do
             railties (6.1.4)
 
         PLATFORMS
-          #{lockfile_platforms_for(["java"] + local_platforms)}
+          #{lockfile_platforms_for(["java", specific_local_platform])}
 
         DEPENDENCIES
           activeadmin!

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -329,8 +329,6 @@ RSpec.describe "bundle install from an existing gemspec" do
     let(:source_uri) { "http://localgemserver.test" }
 
     before do
-      skip "not installing for some reason" if Gem.win_platform?
-
       build_lib("foo", :path => tmp.join("foo")) do |s|
         s.add_dependency "rack", "=1.0.0"
       end
@@ -390,17 +388,13 @@ RSpec.describe "bundle install from an existing gemspec" do
       end
     end
 
-    context "using Windows" do
-      it "should install" do
-        simulate_windows do
-          results = bundle "install", :artifice => "endpoint"
-          expect(results).to include("Installing rack 1.0.0")
-          expect(the_bundle).to include_gems "rack 1.0.0"
-        end
-      end
+    it "should install" do
+      results = bundle "install", :artifice => "endpoint"
+      expect(results).to include("Installing rack 1.0.0")
+      expect(the_bundle).to include_gems "rack 1.0.0"
     end
 
-    context "bundled for ruby and jruby" do
+    context "bundled for multiple platforms" do
       let(:platform_specific_type) { :runtime }
       let(:dependency) { "platform_specific" }
       before do
@@ -430,6 +424,7 @@ RSpec.describe "bundle install from an existing gemspec" do
 
         simulate_new_machine
         simulate_platform("jruby") { bundle "install" }
+        simulate_platform(x64_mingw) { bundle "install" }
       end
 
       context "on ruby" do
@@ -439,7 +434,7 @@ RSpec.describe "bundle install from an existing gemspec" do
         end
 
         context "as a runtime dependency" do
-          it "keeps java dependencies in the lockfile" do
+          it "keeps all platform dependencies in the lockfile" do
             expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 RUBY"
             expect(lockfile).to eq strip_whitespace(<<-L)
               PATH
@@ -453,10 +448,12 @@ RSpec.describe "bundle install from an existing gemspec" do
                 specs:
                   platform_specific (1.0)
                   platform_specific (1.0-java)
+                  platform_specific (1.0-x64-mingw32)
 
               PLATFORMS
                 java
                 ruby
+                x64-mingw32
 
               DEPENDENCIES
                 foo!
@@ -470,7 +467,7 @@ RSpec.describe "bundle install from an existing gemspec" do
         context "as a development dependency" do
           let(:platform_specific_type) { :development }
 
-          it "keeps java dependencies in the lockfile" do
+          it "keeps all platform dependencies in the lockfile" do
             expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 RUBY"
             expect(lockfile).to eq strip_whitespace(<<-L)
               PATH
@@ -483,10 +480,12 @@ RSpec.describe "bundle install from an existing gemspec" do
                 specs:
                   platform_specific (1.0)
                   platform_specific (1.0-java)
+                  platform_specific (1.0-x64-mingw32)
 
               PLATFORMS
                 java
                 ruby
+                x64-mingw32
 
               DEPENDENCIES
                 foo!
@@ -502,7 +501,7 @@ RSpec.describe "bundle install from an existing gemspec" do
           let(:platform_specific_type) { :development }
           let(:dependency) { "indirect_platform_specific" }
 
-          it "keeps java dependencies in the lockfile" do
+          it "keeps all platform dependencies in the lockfile" do
             expect(the_bundle).to include_gems "foo 1.0", "indirect_platform_specific 1.0", "platform_specific 1.0 RUBY"
             expect(lockfile).to eq strip_whitespace(<<-L)
               PATH
@@ -517,10 +516,12 @@ RSpec.describe "bundle install from an existing gemspec" do
                     platform_specific
                   platform_specific (1.0)
                   platform_specific (1.0-java)
+                  platform_specific (1.0-x64-mingw32)
 
               PLATFORMS
                 java
                 ruby
+                x64-mingw32
 
               DEPENDENCIES
                 foo!

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe "bundle install from an existing gemspec" do
     expect(out.scan(message).size).to eq(1)
   end
 
-  it "should match a lockfile on non-ruby platforms with a transitive platform dependency", :jruby do
+  it "should match a lockfile on non-ruby platforms with a transitive platform dependency", :jruby_only do
     build_lib("foo", :path => tmp.join("foo")) do |s|
       s.add_dependency "platform_specific"
     end
@@ -361,7 +361,7 @@ RSpec.describe "bundle install from an existing gemspec" do
       L
     end
 
-    context "using JRuby with explicit platform", :jruby do
+    context "using JRuby with explicit platform", :jruby_only do
       before do
         create_file(
           tmp.join("foo", "foo-java.gemspec"),
@@ -380,15 +380,7 @@ RSpec.describe "bundle install from an existing gemspec" do
       end
     end
 
-    context "using JRuby", :jruby do
-      it "should install" do
-        results = bundle "install", :artifice => "endpoint"
-        expect(results).to include("Installing rack 1.0.0")
-        expect(the_bundle).to include_gems "rack 1.0.0"
-      end
-    end
-
-    it "should install" do
+    it "should install", :jruby do
       results = bundle "install", :artifice => "endpoint"
       expect(results).to include("Installing rack 1.0.0")
       expect(the_bundle).to include_gems "rack 1.0.0"

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "bundle install with git sources" do
       expect(err).to include("The source contains the following gems matching 'foo':\n  * foo-1.0")
     end
 
-    it "complains with version and platform if pinned specs don't exist in the git repo", :jruby do
+    it "complains with version and platform if pinned specs don't exist in the git repo", :jruby_only do
       build_git "only_java" do |s|
         s.platform = "java"
       end
@@ -107,7 +107,7 @@ RSpec.describe "bundle install with git sources" do
       expect(err).to include("The source contains the following gems matching 'only_java':\n  * only_java-1.0-java")
     end
 
-    it "complains with multiple versions and platforms if pinned specs don't exist in the git repo", :jruby do
+    it "complains with multiple versions and platforms if pinned specs don't exist in the git repo", :jruby_only do
       build_git "only_java", "1.0" do |s|
         s.platform = "java"
       end

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "bundle install across platforms" do
     expect(the_bundle).to include_gems "platform_specific 1.0 JAVA"
   end
 
-  it "pulls the pure ruby version on jruby if the java platform is not present in the lockfile and bundler is run in frozen mode", :jruby do
+  it "pulls the pure ruby version on jruby if the java platform is not present in the lockfile and bundler is run in frozen mode", :jruby_only do
     lockfile <<-G
       GEM
         remote: #{file_uri_for(gem_repo1)}

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -332,8 +332,6 @@ end
 
 RSpec.describe "bundle install with platform conditionals" do
   it "installs gems tagged w/ the current platforms" do
-    skip "platform issues" if Gem.win_platform?
-
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
 
@@ -402,8 +400,6 @@ RSpec.describe "bundle install with platform conditionals" do
   end
 
   it "installs gems tagged w/ the current platforms inline" do
-    skip "platform issues" if Gem.win_platform?
-
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
       gem "nokogiri", :platforms => :#{local_tag}
@@ -422,8 +418,6 @@ RSpec.describe "bundle install with platform conditionals" do
   end
 
   it "installs gems tagged w/ the current platform inline" do
-    skip "platform issues" if Gem.win_platform?
-
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
       gem "nokogiri", :platform => :#{local_tag}

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -250,10 +250,11 @@ RSpec.describe "bundle install with specific platforms" do
     end
   end
 
-  it "installs sorbet-static, which does not provide a pure ruby variant, just fine on truffleruby", :truffleruby do
+  it "installs sorbet-static, which does not provide a pure ruby variant, just fine", :truffleruby do
+    skip "does not apply to Windows" if Gem.win_platform?
+
     build_repo2 do
-      build_gem("sorbet-static", "0.5.6403") {|s| s.platform = "x86_64-linux" }
-      build_gem("sorbet-static", "0.5.6403") {|s| s.platform = "universal-darwin-20" }
+      build_gem("sorbet-static", "0.5.6403") {|s| s.platform = Bundler.local_platform }
     end
 
     gemfile <<~G
@@ -266,8 +267,7 @@ RSpec.describe "bundle install with specific platforms" do
       GEM
         remote: #{file_uri_for(gem_repo2)}/
         specs:
-          sorbet-static (0.5.6403-universal-darwin-20)
-          sorbet-static (0.5.6403-x86_64-linux)
+          sorbet-static (0.5.6403-#{Bundler.local_platform})
 
       PLATFORMS
         ruby

--- a/bundler/spec/install/gemfile_spec.rb
+++ b/bundler/spec/install/gemfile_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "bundle install" do
     end
   end
 
-  context "with engine specified in symbol", :jruby do
+  context "with engine specified in symbol", :jruby_only do
     it "does not raise any error parsing Gemfile" do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"

--- a/bundler/spec/install/gems/resolving_spec.rb
+++ b/bundler/spec/install/gems/resolving_spec.rb
@@ -187,11 +187,7 @@ RSpec.describe "bundle install with install-time dependencies" do
 
         bundle :install, :env => { "DEBUG_RESOLVER_TREE" => "1", "DEBUG" => "1" }
 
-        activated_groups = if local_platforms.any?
-          "net_b (1.0) (ruby), net_b (1.0) (#{local_platforms.join(", ")})"
-        else
-          "net_b (1.0) (ruby)"
-        end
+        activated_groups = "net_b (1.0) (ruby), net_b (1.0) (#{specific_local_platform})"
 
         expect(out).to include(" net_b").
           and include("BUNDLER: Starting resolution").

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -982,7 +982,7 @@ RSpec.describe "the lockfile format" do
           rack (1.0.0)
 
       PLATFORMS
-        #{lockfile_platforms_for(["java"] + local_platforms)}
+        #{lockfile_platforms_for(["java", specific_local_platform])}
 
       DEPENDENCIES
         rack

--- a/bundler/spec/other/platform_spec.rb
+++ b/bundler/spec/other/platform_spec.rb
@@ -301,7 +301,7 @@ G
       expect(bundled_app_lock).to exist
     end
 
-    it "installs fine with any engine", :jruby do
+    it "installs fine with any engine", :jruby_only do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
@@ -347,7 +347,7 @@ G
       should_be_engine_incorrect
     end
 
-    it "doesn't install when engine version doesn't match", :jruby do
+    it "doesn't install when engine version doesn't match", :jruby_only do
       install_gemfile <<-G, :raise_on_error => false
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
@@ -390,7 +390,7 @@ G
       expect(out).to match(/\AResolving dependencies\.\.\.\.*\nThe Gemfile's dependencies are satisfied\z/)
     end
 
-    it "checks fine with any engine", :jruby do
+    it "checks fine with any engine", :jruby_only do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
@@ -441,7 +441,7 @@ G
       should_be_engine_incorrect
     end
 
-    it "fails when engine version doesn't match", :jruby do
+    it "fails when engine version doesn't match", :jruby_only do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
@@ -507,7 +507,7 @@ G
       expect(the_bundle).to include_gems "rack 1.2", "rack-obama 1.0", "activesupport 3.0"
     end
 
-    it "updates fine with any engine", :jruby do
+    it "updates fine with any engine", :jruby_only do
       gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "activesupport"
@@ -543,7 +543,7 @@ G
       should_be_ruby_version_incorrect
     end
 
-    it "fails when ruby engine doesn't match", :jruby do
+    it "fails when ruby engine doesn't match", :jruby_only do
       gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "activesupport"
@@ -559,7 +559,7 @@ G
       should_be_engine_incorrect
     end
 
-    it "fails when ruby engine version doesn't match", :jruby do
+    it "fails when ruby engine version doesn't match", :jruby_only do
       gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "activesupport"
@@ -611,7 +611,7 @@ G
       expect(out).to eq(default_bundle_path("gems", "rails-2.3.2").to_s)
     end
 
-    it "prints path if ruby version is correct for any engine", :jruby do
+    it "prints path if ruby version is correct for any engine", :jruby_only do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rails"
@@ -647,7 +647,7 @@ G
       should_be_engine_incorrect
     end
 
-    it "fails if engine version doesn't match", :bundler => "< 3", :jruby => true do
+    it "fails if engine version doesn't match", :bundler => "< 3", :jruby_only => true do
       gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rails"
@@ -695,7 +695,7 @@ G
       expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
     end
 
-    it "copies the .gem file to vendor/cache when ruby version matches for any engine", :jruby do
+    it "copies the .gem file to vendor/cache when ruby version matches for any engine", :jruby_only do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
@@ -731,7 +731,7 @@ G
       should_be_engine_incorrect
     end
 
-    it "fails if the engine version doesn't match", :jruby do
+    it "fails if the engine version doesn't match", :jruby_only do
       gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
@@ -776,7 +776,7 @@ G
       expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
     end
 
-    it "copies the .gem file to vendor/cache when ruby version matches any engine", :jruby do
+    it "copies the .gem file to vendor/cache when ruby version matches any engine", :jruby_only do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
@@ -812,7 +812,7 @@ G
       should_be_engine_incorrect
     end
 
-    it "fails if the engine version doesn't match", :jruby do
+    it "fails if the engine version doesn't match", :jruby_only do
       gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
@@ -855,7 +855,7 @@ G
       expect(out).to include("0.9.1")
     end
 
-    it "activates the correct gem when ruby version matches any engine", :jruby do
+    it "activates the correct gem when ruby version matches any engine", :jruby_only do
       system_gems "rack-1.0.0", "rack-0.9.1", :path => default_bundle_path
       gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
@@ -892,7 +892,7 @@ G
       should_be_engine_incorrect
     end
 
-    # it "fails when the engine version doesn't match", :jruby do
+    # it "fails when the engine version doesn't match", :jruby_only do
     #   gemfile <<-G
     #     gem "rack", "0.9.1"
     #
@@ -943,7 +943,7 @@ G
       expect(out).to include("0.9.1")
     end
 
-    it "starts IRB with the default group loaded when ruby version matches", :readline, :jruby do
+    it "starts IRB with the default group loaded when ruby version matches", :readline, :jruby_only do
       gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
@@ -988,7 +988,7 @@ G
       should_be_engine_incorrect
     end
 
-    it "fails when engine version doesn't match", :jruby do
+    it "fails when engine version doesn't match", :jruby_only do
       gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
@@ -1043,7 +1043,7 @@ G
       expect(bundled_app_lock).to exist
     end
 
-    it "makes a Gemfile.lock if setup succeeds for any engine", :jruby do
+    it "makes a Gemfile.lock if setup succeeds for any engine", :jruby_only do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "yard"
@@ -1092,7 +1092,7 @@ G
       should_be_engine_incorrect
     end
 
-    it "fails when engine version doesn't match", :jruby do
+    it "fails when engine version doesn't match", :jruby_only do
       install_gemfile <<-G, :raise_on_error => false
         source "#{file_uri_for(gem_repo1)}"
         gem "yard"
@@ -1165,7 +1165,7 @@ G
       expect(out).to match(Regexp.new(expected_output))
     end
 
-    it "returns list of outdated gems when the ruby version matches for any engine", :jruby do
+    it "returns list of outdated gems when the ruby version matches for any engine", :jruby_only do
       bundle :install
       update_repo2 do
         build_gem "activesupport", "3.0"
@@ -1227,7 +1227,7 @@ G
       should_be_engine_incorrect
     end
 
-    it "fails when the engine version doesn't match", :jruby do
+    it "fails when the engine version doesn't match", :jruby_only do
       update_repo2 do
         build_gem "activesupport", "3.0"
         update_git "foo", :path => lib_path("foo")
@@ -1245,7 +1245,7 @@ G
       should_be_engine_version_incorrect
     end
 
-    it "fails when the patchlevel doesn't match", :jruby do
+    it "fails when the patchlevel doesn't match", :jruby_only do
       update_repo2 do
         build_gem "activesupport", "3.0"
         update_git "foo", :path => lib_path("foo")
@@ -1263,7 +1263,7 @@ G
       should_be_patchlevel_incorrect
     end
 
-    it "fails when the patchlevel is a fixnum", :jruby do
+    it "fails when the patchlevel is a fixnum", :jruby_only do
       update_repo2 do
         build_gem "activesupport", "3.0"
         update_git "foo", :path => lib_path("foo")

--- a/bundler/spec/other/platform_spec.rb
+++ b/bundler/spec/other/platform_spec.rb
@@ -2,10 +2,6 @@
 
 RSpec.describe "bundle platform" do
   context "without flags" do
-    let(:bundle_platform_platforms_string) do
-      local_platforms.reverse.map {|pl| "* #{pl}" }.join("\n")
-    end
-
     it "returns all the output" do
       gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
@@ -20,7 +16,7 @@ RSpec.describe "bundle platform" do
 Your platform is: #{Gem::Platform.local}
 
 Your app has gems that work on these platforms:
-#{bundle_platform_platforms_string}
+* #{specific_local_platform}
 
 Your Gemfile specifies a Ruby version requirement:
 * ruby #{RUBY_VERSION}
@@ -43,7 +39,7 @@ G
 Your platform is: #{Gem::Platform.local}
 
 Your app has gems that work on these platforms:
-#{bundle_platform_platforms_string}
+* #{specific_local_platform}
 
 Your Gemfile specifies a Ruby version requirement:
 * ruby #{RUBY_VERSION}p#{RUBY_PATCHLEVEL}
@@ -64,7 +60,7 @@ G
 Your platform is: #{Gem::Platform.local}
 
 Your app has gems that work on these platforms:
-#{bundle_platform_platforms_string}
+* #{specific_local_platform}
 
 Your Gemfile does not specify a Ruby version requirement.
 G
@@ -84,7 +80,7 @@ G
 Your platform is: #{Gem::Platform.local}
 
 Your app has gems that work on these platforms:
-#{bundle_platform_platforms_string}
+* #{specific_local_platform}
 
 Your Gemfile specifies a Ruby version requirement:
 * ruby #{not_local_ruby_version}

--- a/bundler/spec/runtime/platform_spec.rb
+++ b/bundler/spec/runtime/platform_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
     expect(the_bundle).not_to include_gems "nokogiri 1.11.1 #{Bundler.local_platform}"
   end
 
-  it "will use the java platform if both generic java and generic ruby platforms are locked", :jruby do
+  it "will use the java platform if both generic java and generic ruby platforms are locked", :jruby_only do
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
       gem "nokogiri"
@@ -204,7 +204,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
     expect(the_bundle).to include_gems "nokogiri 1.4.2", "platform_specific 1.0 x86-darwin-100"
   end
 
-  it "allows specifying only-ruby-platform on jruby", :jruby do
+  it "allows specifying only-ruby-platform on jruby", :jruby_only do
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
       gem "nokogiri"

--- a/bundler/spec/runtime/platform_spec.rb
+++ b/bundler/spec/runtime/platform_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
           racc (1.5.2)
 
       PLATFORMS
-        #{lockfile_platforms_for(["ruby"] + local_platforms)}
+        #{lockfile_platforms_for(["ruby", specific_local_platform])}
 
       DEPENDENCIES
         nokogiri (~> 1.11)

--- a/bundler/spec/runtime/platform_spec.rb
+++ b/bundler/spec/runtime/platform_spec.rb
@@ -246,7 +246,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
     expect(the_bundle).to include_gems "nokogiri 1.4.2", "platform_specific 1.0 RUBY"
   end
 
-  it "doesn't pull platform specific gems on truffleruby", :truffleruby do
+  it "doesn't pull platform specific gems on truffleruby", :truffleruby_only do
     install_gemfile <<-G
      source "#{file_uri_for(gem_repo1)}"
      gem "platform_specific"

--- a/bundler/spec/runtime/require_spec.rb
+++ b/bundler/spec/runtime/require_spec.rb
@@ -449,8 +449,6 @@ RSpec.describe "Bundler.require with platform specific dependencies" do
   end
 
   it "requires gems pinned to multiple platforms, including the current one" do
-    skip "platform issues" if Gem.win_platform?
-
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
 

--- a/bundler/spec/support/filters.rb
+++ b/bundler/spec/support/filters.rb
@@ -33,7 +33,7 @@ RSpec.configure do |config|
   config.filter_run_excluding :no_color_tty => Gem.win_platform? || !ENV["GITHUB_ACTION"].nil?
   config.filter_run_excluding :permissions => Gem.win_platform?
   config.filter_run_excluding :readline => Gem.win_platform?
-  config.filter_run_excluding :jruby => RUBY_ENGINE != "jruby"
+  config.filter_run_excluding :jruby_only => RUBY_ENGINE != "jruby"
   config.filter_run_excluding :truffleruby => RUBY_ENGINE != "truffleruby"
   config.filter_run_excluding :man => Gem.win_platform?
 

--- a/bundler/spec/support/filters.rb
+++ b/bundler/spec/support/filters.rb
@@ -34,7 +34,7 @@ RSpec.configure do |config|
   config.filter_run_excluding :permissions => Gem.win_platform?
   config.filter_run_excluding :readline => Gem.win_platform?
   config.filter_run_excluding :jruby_only => RUBY_ENGINE != "jruby"
-  config.filter_run_excluding :truffleruby => RUBY_ENGINE != "truffleruby"
+  config.filter_run_excluding :truffleruby_only => RUBY_ENGINE != "truffleruby"
   config.filter_run_excluding :man => Gem.win_platform?
 
   config.filter_run_when_matching :focus unless ENV["CI"]

--- a/bundler/spec/support/platforms.rb
+++ b/bundler/spec/support/platforms.rb
@@ -55,13 +55,15 @@ module Spec
     def local_tag
       if RUBY_PLATFORM == "java"
         :jruby
+      elsif RUBY_PLATFORM == "x64-mingw32"
+        :x64_mingw
       else
         :ruby
       end
     end
 
     def not_local_tag
-      [:ruby, :jruby].find {|tag| tag != local_tag }
+      [:jruby, :x64_mingw, :ruby].find {|tag| tag != local_tag }
     end
 
     def local_ruby_engine
@@ -74,7 +76,7 @@ module Spec
 
     def not_local_engine_version
       case not_local_tag
-      when :ruby
+      when :ruby, :x64_mingw
         not_local_ruby_version
       when :jruby
         "1.6.1"

--- a/bundler/spec/support/platforms.rb
+++ b/bundler/spec/support/platforms.rb
@@ -90,15 +90,11 @@ module Spec
     end
 
     def lockfile_platforms
-      lockfile_platforms_for(local_platforms)
+      lockfile_platforms_for([specific_local_platform])
     end
 
     def lockfile_platforms_for(platforms)
       platforms.map(&:to_s).sort.join("\n  ")
-    end
-
-    def local_platforms
-      [specific_local_platform]
     end
   end
 end

--- a/bundler/tool/bundler/dev_gems.rb.lock
+++ b/bundler/tool/bundler/dev_gems.rb.lock
@@ -33,6 +33,7 @@ PLATFORMS
   java
   ruby
   universal-java-11
+  universal-java-18
   x64-mingw32
   x86_64-darwin-20
   x86_64-linux

--- a/bundler/tool/bundler/release_gems.rb.lock
+++ b/bundler/tool/bundler/release_gems.rb.lock
@@ -58,6 +58,7 @@ PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
   universal-java-11
+  universal-java-18
   x86_64-darwin-20
   x86_64-linux
 

--- a/bundler/tool/bundler/rubocop23_gems.rb.lock
+++ b/bundler/tool/bundler/rubocop23_gems.rb.lock
@@ -45,6 +45,7 @@ PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
   universal-java-11
+  universal-java-18
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-linux

--- a/bundler/tool/bundler/rubocop24_gems.rb.lock
+++ b/bundler/tool/bundler/rubocop24_gems.rb.lock
@@ -47,6 +47,7 @@ PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
   universal-java-11
+  universal-java-18
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-linux

--- a/bundler/tool/bundler/rubocop_gems.rb.lock
+++ b/bundler/tool/bundler/rubocop_gems.rb.lock
@@ -47,6 +47,7 @@ PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
   universal-java-11
+  universal-java-18
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-linux

--- a/bundler/tool/bundler/standard23_gems.rb.lock
+++ b/bundler/tool/bundler/standard23_gems.rb.lock
@@ -50,6 +50,7 @@ PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
   universal-java-11
+  universal-java-18
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-linux

--- a/bundler/tool/bundler/standard24_gems.rb.lock
+++ b/bundler/tool/bundler/standard24_gems.rb.lock
@@ -53,6 +53,7 @@ PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
   universal-java-11
+  universal-java-18
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-linux

--- a/bundler/tool/bundler/standard_gems.rb.lock
+++ b/bundler/tool/bundler/standard_gems.rb.lock
@@ -53,6 +53,7 @@ PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
   universal-java-11
+  universal-java-18
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-linux

--- a/bundler/tool/bundler/test_gems.rb.lock
+++ b/bundler/tool/bundler/test_gems.rb.lock
@@ -26,6 +26,7 @@ PLATFORMS
   java
   ruby
   universal-java-11
+  universal-java-18
   x64-mingw32
   x86_64-darwin-20
   x86_64-linux


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Just trying to get all specs related to platforms green on Windows. Since I was at it, I also refactored some specs to not be duplicated under the different platforms they are run.

## What is your fix for the problem, implemented in this PR?

Properly consider that the `:ruby` platform tag in the `Gemfile` is not supposed to include Windows.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
