### PR TITLE
Improve error message when `operating_system.rb` fails to load

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1323,8 +1323,9 @@ begin
 rescue LoadError
   # Ignored
 rescue StandardError => e
+  path = e.backtrace_locations.reverse.find {|l| l.path.end_with?("rubygems/defaults/operating_system.rb") }.path
   msg = "#{e.message}\n" \
-    "Loading the rubygems/defaults/operating_system.rb file caused an error. " \
+    "Loading the #{path} file caused an error. " \
     "This file is owned by your OS, not by rubygems upstream. " \
     "Please find out which OS package this file belongs to and follow the guidelines from your OS to report " \
     "the problem and ask for help."

--- a/test/rubygems/test_rubygems.rb
+++ b/test/rubygems/test_rubygems.rb
@@ -16,7 +16,7 @@ class GemTest < Gem::TestCase
     output = Gem::Util.popen(*ruby_with_rubygems_and_fake_operating_system_in_load_path(path), '-e', "'require \"rubygems\"'", { :err => [:child, :out] }).strip
     assert !$?.success?
     assert_includes output, "undefined local variable or method `intentionally_not_implemented_method'"
-    assert_includes output, "Loading the rubygems/defaults/operating_system.rb file caused an error. " \
+    assert_includes output, "Loading the #{operating_system_rb_at(path)} file caused an error. " \
     "This file is owned by your OS, not by rubygems upstream. " \
     "Please find out which OS package this file belongs to and follow the guidelines from your OS to report " \
     "the problem and ask for help."
@@ -53,16 +53,19 @@ class GemTest < Gem::TestCase
 
   def util_install_operating_system_rb(content)
     dir_lib = Dir.mktmpdir("test_operating_system_lib", @tempdir)
-    dir_lib_arg = File.join dir_lib
+    dir_lib_arg = File.join dir_lib, "lib"
 
-    dir_lib_rubygems_defaults_arg = File.join dir_lib_arg, "lib", "rubygems", "defaults"
-    FileUtils.mkdir_p dir_lib_rubygems_defaults_arg
+    operating_system_rb = operating_system_rb_at(dir_lib_arg)
 
-    operating_system_rb = File.join dir_lib_rubygems_defaults_arg, "operating_system.rb"
+    FileUtils.mkdir_p File.dirname(operating_system_rb)
 
     File.open(operating_system_rb, 'w') {|f| f.write content }
 
-    File.join dir_lib_arg, "lib"
+    dir_lib_arg
+  end
+
+  def operating_system_rb_at(dir)
+    File.join dir, "rubygems", "defaults", "operating_system.rb"
   end
 
   def ruby_with_rubygems_and_fake_operating_system_in_load_path(operating_system_path)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This error could be more helpful, in particular, showing an absolute path to the bad file, instead of an unhelpful relative path.

## What is your fix for the problem, implemented in this PR?

Show an absolute path.

~In addition, I stopped showing the original error message, since Ruby displays the exception cause by default.~

Fixes #5334.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
