### PR TITLE
Fix test_install_location_extra_slash on alpine

### DIFF
--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -737,9 +737,7 @@ class TestGemPackage < Gem::Package::TarTestCase
     file = 'foo//file.rb'.dup
     file.taint if RUBY_VERSION < '2.7'
 
-    destination = @destination.sub '/', '//'
-
-    destination = package.install_location file, destination
+    destination = package.install_location file, @destination
 
     assert_equal File.join(@destination, 'foo', 'file.rb'), destination
     refute destination.tainted? if RUBY_VERSION < '2.7'


### PR DESCRIPTION
Under POSIX behavior of leading // is implementation defined. Musl does
preserve it in realpath, glibc does not. That means the test was failing
when executed on alpine linux. Original issue #508 was about // in the
path, not about leading ones. When executed in such environment, the
test will still test what it should when the explicit mangling of the
path is not done.

Fixes #5652