### PR TITLE
Run linters before tests and compilation

### DIFF
--- a/bundler/lib/bundler/templates/newgem/Rakefile.tt
+++ b/bundler/lib/bundler/templates/newgem/Rakefile.tt
@@ -27,17 +27,6 @@ require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:spec)
 
 <% end -%>
-<% if config[:linter] == "rubocop" -%>
-<% default_task_names << :rubocop -%>
-require "rubocop/rake_task"
-
-RuboCop::RakeTask.new
-
-<% elsif config[:linter] == "standard" -%>
-<% default_task_names << :standard -%>
-require "standard/rake"
-
-<% end -%>
 <% if config[:ext] -%>
 <% default_task_names.unshift(:clobber, :compile) -%>
 require "rake/extensiontask"
@@ -47,6 +36,17 @@ task build: :compile
 Rake::ExtensionTask.new("<%= config[:underscored_name] %>") do |ext|
   ext.lib_dir = "lib/<%= config[:namespaced_path] %>"
 end
+
+<% end -%>
+<% if config[:linter] == "rubocop" -%>
+<% default_task_names.unshift(:rubocop) -%>
+require "rubocop/rake_task"
+
+RuboCop::RakeTask.new
+
+<% elsif config[:linter] == "standard" -%>
+<% default_task_names.unshift(:standard) -%>
+require "standard/rake"
 
 <% end -%>
 <% if default_task_names.size == 1 -%>


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Currently, `bundler gem` generates `Rakefile` with default task running linters as the last step, which is not the best UX.

## What is your fix for the problem, implemented in this PR?

This PR updates `Rakefile.tt` to make linters run first.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
