### PR TITLE
Changelogs for RubyGems 3.3.17 and Bundler 2.3.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 3.3.17 / 2022-06-29
+
+## Enhancements:
+
+* Document `gem env` argument aliases and add `gem env user_gemhome` and
+  `gem env user_gemdir`. Pull request #5644 by deivid-rodriguez
+* Improve error message when `operating_system.rb` fails to load. Pull
+  request #5658 by deivid-rodriguez
+* Clean up temporary directory after `generate_index --update`. Pull
+  request #5653 by graywolf-at-work
+* Simplify extension builder. Pull request #5626 by deivid-rodriguez
+* Installs bundler 2.3.17 as a default gem.
+
+## Documentation:
+
+* Modify RubyGems issue template to be like the one for Bundler. Pull
+  request #5643 by deivid-rodriguez
+
 # 3.3.16 / 2022-06-15
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,24 @@
+# 2.3.17 (June 29, 2022)
+
+## Enhancements:
+
+  - Add support for platform `:x64_mingw` to correctly lookup "x64-mingw-ucrt" [#5649](https://github.com/rubygems/rubygems/pull/5649)
+  - Fix some errors being printed twice in `--verbose` mode [#5654](https://github.com/rubygems/rubygems/pull/5654)
+  - Fix extension paths in generated standalone script [#5632](https://github.com/rubygems/rubygems/pull/5632)
+
+## Bug fixes:
+
+  - Raise if ruby platform is forced and there are no ruby variants [#5495](https://github.com/rubygems/rubygems/pull/5495)
+  - Fix `bundle package --no-install` no longer skipping install [#5639](https://github.com/rubygems/rubygems/pull/5639)
+
+## Performance:
+
+  - Improve performance of `Bundler::SpecSet#for` by using hash lookup of handled deps [#5537](https://github.com/rubygems/rubygems/pull/5537)
+
+## Documentation:
+
+  - Fix formatting issue in `bundle add` man page [#5642](https://github.com/rubygems/rubygems/pull/5642)
+
 # 2.3.16 (June 15, 2022)
 
 ## Performance:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.3.17 and bundler 2.3.17 into master.