### PR TITLE
Use modern style hashes in Gemfile DSL docs

### DIFF
--- a/bundler/lib/bundler/man/bundle-add.1
+++ b/bundler/lib/bundler/man/bundle-add.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-ADD" "1" "May 2022" "" ""
+.TH "BUNDLE\-ADD" "1" "June 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-add\fR \- Add gem to the Gemfile and run bundle install

--- a/bundler/lib/bundler/man/bundle-binstubs.1
+++ b/bundler/lib/bundler/man/bundle-binstubs.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-BINSTUBS" "1" "May 2022" "" ""
+.TH "BUNDLE\-BINSTUBS" "1" "June 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-binstubs\fR \- Install the binstubs of the listed gems

--- a/bundler/lib/bundler/man/bundle-cache.1
+++ b/bundler/lib/bundler/man/bundle-cache.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CACHE" "1" "May 2022" "" ""
+.TH "BUNDLE\-CACHE" "1" "June 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-cache\fR \- Package your needed \fB\.gem\fR files into your application

--- a/bundler/lib/bundler/man/bundle-check.1
+++ b/bundler/lib/bundler/man/bundle-check.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CHECK" "1" "May 2022" "" ""
+.TH "BUNDLE\-CHECK" "1" "June 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-check\fR \- Verifies if dependencies are satisfied by installed gems

--- a/bundler/lib/bundler/man/bundle-clean.1
+++ b/bundler/lib/bundler/man/bundle-clean.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CLEAN" "1" "May 2022" "" ""
+.TH "BUNDLE\-CLEAN" "1" "June 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-clean\fR \- Cleans up unused gems in your bundler directory

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CONFIG" "1" "May 2022" "" ""
+.TH "BUNDLE\-CONFIG" "1" "June 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-config\fR \- Set bundler configuration options

--- a/bundler/lib/bundler/man/bundle-doctor.1
+++ b/bundler/lib/bundler/man/bundle-doctor.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-DOCTOR" "1" "May 2022" "" ""
+.TH "BUNDLE\-DOCTOR" "1" "June 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-doctor\fR \- Checks the bundle for common problems

--- a/bundler/lib/bundler/man/bundle-exec.1
+++ b/bundler/lib/bundler/man/bundle-exec.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-EXEC" "1" "May 2022" "" ""
+.TH "BUNDLE\-EXEC" "1" "June 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-exec\fR \- Execute a command in the context of the bundle

--- a/bundler/lib/bundler/man/bundle-gem.1
+++ b/bundler/lib/bundler/man/bundle-gem.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-GEM" "1" "May 2022" "" ""
+.TH "BUNDLE\-GEM" "1" "June 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-gem\fR \- Generate a project skeleton for creating a rubygem

--- a/bundler/lib/bundler/man/bundle-info.1
+++ b/bundler/lib/bundler/man/bundle-info.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INFO" "1" "May 2022" "" ""
+.TH "BUNDLE\-INFO" "1" "June 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-info\fR \- Show information for the given gem in your bundle

--- a/bundler/lib/bundler/man/bundle-init.1
+++ b/bundler/lib/bundler/man/bundle-init.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INIT" "1" "May 2022" "" ""
+.TH "BUNDLE\-INIT" "1" "June 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-init\fR \- Generates a Gemfile into the current working directory

--- a/bundler/lib/bundler/man/bundle-inject.1
+++ b/bundler/lib/bundler/man/bundle-inject.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INJECT" "1" "May 2022" "" ""
+.TH "BUNDLE\-INJECT" "1" "June 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-inject\fR \- Add named gem(s) with version requirements to Gemfile

--- a/bundler/lib/bundler/man/bundle-install.1
+++ b/bundler/lib/bundler/man/bundle-install.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INSTALL" "1" "May 2022" "" ""
+.TH "BUNDLE\-INSTALL" "1" "June 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-install\fR \- Install the dependencies specified in your Gemfile

--- a/bundler/lib/bundler/man/bundle-list.1
+++ b/bundler/lib/bundler/man/bundle-list.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-LIST" "1" "May 2022" "" ""
+.TH "BUNDLE\-LIST" "1" "June 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-list\fR \- List all the gems in the bundle

--- a/bundler/lib/bundler/man/bundle-lock.1
+++ b/bundler/lib/bundler/man/bundle-lock.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-LOCK" "1" "May 2022" "" ""
+.TH "BUNDLE\-LOCK" "1" "June 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-lock\fR \- Creates / Updates a lockfile without installing

--- a/bundler/lib/bundler/man/bundle-open.1
+++ b/bundler/lib/bundler/man/bundle-open.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-OPEN" "1" "May 2022" "" ""
+.TH "BUNDLE\-OPEN" "1" "June 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-open\fR \- Opens the source directory for a gem in your bundle

--- a/bundler/lib/bundler/man/bundle-outdated.1
+++ b/bundler/lib/bundler/man/bundle-outdated.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-OUTDATED" "1" "May 2022" "" ""
+.TH "BUNDLE\-OUTDATED" "1" "June 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-outdated\fR \- List installed gems with newer versions available

--- a/bundler/lib/bundler/man/bundle-platform.1
+++ b/bundler/lib/bundler/man/bundle-platform.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-PLATFORM" "1" "May 2022" "" ""
+.TH "BUNDLE\-PLATFORM" "1" "June 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-platform\fR \- Displays platform compatibility information

--- a/bundler/lib/bundler/man/bundle-pristine.1
+++ b/bundler/lib/bundler/man/bundle-pristine.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-PRISTINE" "1" "May 2022" "" ""
+.TH "BUNDLE\-PRISTINE" "1" "June 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-pristine\fR \- Restores installed gems to their pristine condition

--- a/bundler/lib/bundler/man/bundle-remove.1
+++ b/bundler/lib/bundler/man/bundle-remove.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-REMOVE" "1" "May 2022" "" ""
+.TH "BUNDLE\-REMOVE" "1" "June 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-remove\fR \- Removes gems from the Gemfile

--- a/bundler/lib/bundler/man/bundle-show.1
+++ b/bundler/lib/bundler/man/bundle-show.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-SHOW" "1" "May 2022" "" ""
+.TH "BUNDLE\-SHOW" "1" "June 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-show\fR \- Shows all the gems in your bundle, or the path to a gem

--- a/bundler/lib/bundler/man/bundle-update.1
+++ b/bundler/lib/bundler/man/bundle-update.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-UPDATE" "1" "May 2022" "" ""
+.TH "BUNDLE\-UPDATE" "1" "June 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-update\fR \- Update your gems to the latest available versions

--- a/bundler/lib/bundler/man/bundle-viz.1
+++ b/bundler/lib/bundler/man/bundle-viz.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-VIZ" "1" "May 2022" "" ""
+.TH "BUNDLE\-VIZ" "1" "June 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-viz\fR \- Generates a visual dependency graph for your Gemfile

--- a/bundler/lib/bundler/man/bundle.1
+++ b/bundler/lib/bundler/man/bundle.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE" "1" "May 2022" "" ""
+.TH "BUNDLE" "1" "June 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\fR \- Ruby Dependency Management

--- a/bundler/lib/bundler/man/gemfile.5
+++ b/bundler/lib/bundler/man/gemfile.5
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GEMFILE" "5" "May 2022" "" ""
+.TH "GEMFILE" "5" "June 2022" "" ""
 .
 .SH "NAME"
 \fBGemfile\fR \- A format for describing gem dependencies for Ruby programs
@@ -100,7 +100,7 @@ Each application \fImay\fR specify a Ruby engine version\. If an engine version 
 .
 .nf
 
-ruby "1\.8\.7", :engine => "jruby", :engine_version => "1\.6\.7"
+ruby "1\.8\.7", engine:  "jruby", engine_version:  "1\.6\.7"
 .
 .fi
 .
@@ -113,7 +113,7 @@ Each application \fImay\fR specify a Ruby patchlevel\.
 .
 .nf
 
-ruby "2\.0\.0", :patchlevel => "247"
+ruby "2\.0\.0", patchlevel:  "247"
 .
 .fi
 .
@@ -156,9 +156,9 @@ Each \fIgem\fR \fBMAY\fR specify files that should be used when autorequiring vi
 .
 .nf
 
-gem "redis", :require => ["redis/connection/hiredis", "redis"]
-gem "webmock", :require => false
-gem "byebug", :require => true
+gem "redis", require:  ["redis/connection/hiredis", "redis"]
+gem "webmock", require:  false
+gem "byebug", require:  true
 .
 .fi
 .
@@ -172,8 +172,8 @@ The argument defaults to the name of the gem\. For example, these are identical:
 .nf
 
 gem "nokogiri"
-gem "nokogiri", :require => "nokogiri"
-gem "nokogiri", :require => true
+gem "nokogiri", require:  "nokogiri"
+gem "nokogiri", require:  true
 .
 .fi
 .
@@ -186,8 +186,8 @@ Each \fIgem\fR \fBMAY\fR specify membership in one or more groups\. Any \fIgem\f
 .
 .nf
 
-gem "rspec", :group => :test
-gem "wirble", :groups => [:development, :test]
+gem "rspec", group:  :test
+gem "wirble", groups:  [:development, :test]
 .
 .fi
 .
@@ -320,9 +320,9 @@ As with groups, you can specify one or more platforms:
 .
 .nf
 
-gem "weakling",   :platforms => :jruby
-gem "ruby\-debug", :platforms => :mri_18
-gem "nokogiri",   :platforms => [:mri_18, :jruby]
+gem "weakling",   platforms:  :jruby
+gem "ruby\-debug", platforms:  :mri_18
+gem "nokogiri",   platforms:  [:mri_18, :jruby]
 .
 .fi
 .
@@ -338,7 +338,7 @@ You can select an alternate Rubygems repository for a gem using the \':source\' 
 .
 .nf
 
-gem "some_internal_gem", :source => "https://gems\.example\.com"
+gem "some_internal_gem", source:  "https://gems\.example\.com"
 .
 .fi
 .
@@ -361,15 +361,15 @@ If necessary, you can specify that a gem is located at a particular git reposito
 .
 .TP
 \fBHTTP(S)\fR
-gem "rails", :git => "https://github\.com/rails/rails\.git"
+gem "rails", git: "https://github\.com/rails/rails\.git"
 .
 .TP
 \fBSSH\fR
-gem "rails", :git => "git@github\.com:rails/rails\.git"
+gem "rails", git: "git@github\.com:rails/rails\.git"
 .
 .TP
 \fBgit\fR
-gem "rails", :git => "git://github\.com/rails/rails\.git"
+gem "rails", git: "git://github\.com/rails/rails\.git"
 .
 .P
 If using SSH, the user that you use to run \fBbundle install\fR \fBMUST\fR have the appropriate keys available in their \fB$HOME/\.ssh\fR\.
@@ -393,7 +393,7 @@ If a git repository does have a \fB\.gemspec\fR for the gem you attached it to, 
 .
 .nf
 
-gem "rails", "2\.3\.8", :git => "https://github\.com/rails/rails\.git"
+gem "rails", "2\.3\.8", git:  "https://github\.com/rails/rails\.git"
 # bundle install will fail, because the \.gemspec in the rails
 # repository\'s master branch specifies version 3\.0\.0
 .
@@ -409,20 +409,20 @@ Git repositories support a number of additional options\.
 .
 .TP
 \fBbranch\fR, \fBtag\fR, and \fBref\fR
-You \fBMUST\fR only specify at most one of these options\. The default is \fB:branch => "master"\fR\. For example:
+You \fBMUST\fR only specify at most one of these options\. The default is \fBbranch: "master"\fR\. For example:
 .
 .IP
-gem "rails", :git => "https://github\.com/rails/rails\.git", :branch => "5\-0\-stable"
+gem "rails", git: "https://github\.com/rails/rails\.git", branch: "5\-0\-stable"
 .
 .IP
-gem "rails", :git => "https://github\.com/rails/rails\.git", :tag => "v5\.0\.0"
+gem "rails", git: "https://github\.com/rails/rails\.git", tag: "v5\.0\.0"
 .
 .IP
-gem "rails", :git => "https://github\.com/rails/rails\.git", :ref => "4aded"
+gem "rails", git: "https://github\.com/rails/rails\.git", ref: "4aded"
 .
 .TP
 \fBsubmodules\fR
-For reference, a git submodule \fIhttps://git\-scm\.com/book/en/v2/Git\-Tools\-Submodules\fR lets you have another git repository within a subfolder of your repository\. Specify \fB:submodules => true\fR to cause bundler to expand any submodules included in the git repository
+For reference, a git submodule \fIhttps://git\-scm\.com/book/en/v2/Git\-Tools\-Submodules\fR lets you have another git repository within a subfolder of your repository\. Specify \fBsubmodules: true\fR to cause bundler to expand any submodules included in the git repository
 .
 .P
 If a git repository contains multiple \fB\.gemspecs\fR, each \fB\.gemspec\fR represents a gem located at the same place in the file system as the \fB\.gemspec\fR\.
@@ -454,7 +454,7 @@ A custom git source can be defined via the \fBgit_source\fR method\. Provide the
 .nf
 
 git_source(:stash){ |repo_name| "https://stash\.corp\.acme\.pl/#{repo_name}\.git" }
-gem \'rails\', :stash => \'forks/rails\'
+gem \'rails\', stash:  \'forks/rails\'
 .
 .fi
 .
@@ -467,7 +467,7 @@ In addition, if you wish to choose a specific branch:
 .
 .nf
 
-gem "rails", :stash => "forks/rails", :branch => "branch_name"
+gem "rails", stash:  "forks/rails", branch:  "branch_name"
 .
 .fi
 .
@@ -483,8 +483,8 @@ If the git repository you want to use is hosted on GitHub and is public, you can
 .
 .nf
 
-gem "rails", :github => "rails/rails"
-gem "rails", :github => "rails"
+gem "rails", github:  "rails/rails"
+gem "rails", github:  "rails"
 .
 .fi
 .
@@ -497,7 +497,7 @@ Are both equivalent to
 .
 .nf
 
-gem "rails", :git => "git://github\.com/rails/rails\.git"
+gem "rails", git:  "git://github\.com/rails/rails\.git"
 .
 .fi
 .
@@ -513,7 +513,7 @@ You can also directly pass a pull request URL:
 .
 .nf
 
-gem "rails", :github => "https://github\.com/rails/rails/pull/43753"
+gem "rails", github:  "https://github\.com/rails/rails/pull/43753"
 .
 .fi
 .
@@ -526,7 +526,7 @@ Which is equivalent to:
 .
 .nf
 
-gem "rails", :github => "rails/rails", branch: "refs/pull/43753/head"
+gem "rails", github:  "rails/rails", branch: "refs/pull/43753/head"
 .
 .fi
 .
@@ -539,7 +539,7 @@ If the git repository you want to use is hosted as a GitHub Gist and is public, 
 .
 .nf
 
-gem "the_hatch", :gist => "4815162342"
+gem "the_hatch", gist:  "4815162342"
 .
 .fi
 .
@@ -552,7 +552,7 @@ Is equivalent to:
 .
 .nf
 
-gem "the_hatch", :git => "https://gist\.github\.com/4815162342\.git"
+gem "the_hatch", git:  "https://gist\.github\.com/4815162342\.git"
 .
 .fi
 .
@@ -568,8 +568,8 @@ If the git repository you want to use is hosted on Bitbucket and is public, you 
 .
 .nf
 
-gem "rails", :bitbucket => "rails/rails"
-gem "rails", :bitbucket => "rails"
+gem "rails", bitbucket:  "rails/rails"
+gem "rails", bitbucket:  "rails"
 .
 .fi
 .
@@ -582,7 +582,7 @@ Are both equivalent to
 .
 .nf
 
-gem "rails", :git => "https://rails@bitbucket\.org/rails/rails\.git"
+gem "rails", git:  "https://rails@bitbucket\.org/rails/rails\.git"
 .
 .fi
 .
@@ -604,7 +604,7 @@ Unlike \fB:git\fR, bundler does not compile C extensions for gems specified as p
 .
 .nf
 
-gem "rails", :path => "vendor/rails"
+gem "rails", path:  "vendor/rails"
 .
 .fi
 .
@@ -648,7 +648,7 @@ platforms :ruby do
   gem "sqlite3"
 end
 
-group :development, :optional => true do
+group :development, optional:  true do
   gem "wirble"
   gem "faker"
 end

--- a/bundler/lib/bundler/man/gemfile.5.ronn
+++ b/bundler/lib/bundler/man/gemfile.5.ronn
@@ -91,13 +91,13 @@ Each application _may_ specify a Ruby engine version. If an engine version is
 specified, an engine _must_ also be specified. If the engine is "ruby" the
 engine version specified _must_ match the Ruby version.
 
-    ruby "1.8.7", :engine => "jruby", :engine_version => "1.6.7"
+    ruby "1.8.7", engine:  "jruby", engine_version:  "1.6.7"
 
 ### PATCHLEVEL
 
 Each application _may_ specify a Ruby patchlevel.
 
-    ruby "2.0.0", :patchlevel => "247"
+    ruby "2.0.0", patchlevel:  "247"
 
 ## GEMS
 
@@ -124,23 +124,23 @@ Each _gem_ `MAY` specify files that should be used when autorequiring via
 you want `required` has the same name as _gem_ or `false` to
 prevent any file from being autorequired.
 
-    gem "redis", :require => ["redis/connection/hiredis", "redis"]
-    gem "webmock", :require => false
-    gem "byebug", :require => true
+    gem "redis", require:  ["redis/connection/hiredis", "redis"]
+    gem "webmock", require:  false
+    gem "byebug", require:  true
 
 The argument defaults to the name of the gem. For example, these are identical:
 
     gem "nokogiri"
-    gem "nokogiri", :require => "nokogiri"
-    gem "nokogiri", :require => true
+    gem "nokogiri", require:  "nokogiri"
+    gem "nokogiri", require:  true
 
 ### GROUPS
 
 Each _gem_ `MAY` specify membership in one or more groups. Any _gem_ that does
 not specify membership in any group is placed in the `default` group.
 
-    gem "rspec", :group => :test
-    gem "wirble", :groups => [:development, :test]
+    gem "rspec", group:  :test
+    gem "wirble", groups:  [:development, :test]
 
 The Bundler runtime allows its two main methods, `Bundler.setup` and
 `Bundler.require`, to limit their impact to particular groups.
@@ -223,9 +223,9 @@ The full list of platforms and supported versions includes:
 
 As with groups, you can specify one or more platforms:
 
-    gem "weakling",   :platforms => :jruby
-    gem "ruby-debug", :platforms => :mri_18
-    gem "nokogiri",   :platforms => [:mri_18, :jruby]
+    gem "weakling",   platforms:  :jruby
+    gem "ruby-debug", platforms:  :mri_18
+    gem "nokogiri",   platforms:  [:mri_18, :jruby]
 
 All operations involving groups ([`bundle install`](bundle-install.1.html), `Bundler.setup`,
 `Bundler.require`) behave exactly the same as if any groups not
@@ -236,7 +236,7 @@ matching the current platform were explicitly excluded.
 You can select an alternate Rubygems repository for a gem using the ':source'
 option.
 
-    gem "some_internal_gem", :source => "https://gems.example.com"
+    gem "some_internal_gem", source:  "https://gems.example.com"
 
 This forces the gem to be loaded from this source and ignores any global sources
 declared at the top level of the file. If the gem does not exist in this source,
@@ -263,11 +263,11 @@ git repository using the `:git` parameter. The repository can be accessed via
 several protocols:
 
   * `HTTP(S)`:
-    gem "rails", :git => "https://github.com/rails/rails.git"
+    gem "rails", git:  "https://github.com/rails/rails.git"
   * `SSH`:
-    gem "rails", :git => "git@github.com:rails/rails.git"
+    gem "rails", git:  "git@github.com:rails/rails.git"
   * `git`:
-    gem "rails", :git => "git://github.com/rails/rails.git"
+    gem "rails", git:  "git://github.com/rails/rails.git"
 
 If using SSH, the user that you use to run `bundle install` `MUST` have the
 appropriate keys available in their `$HOME/.ssh`.
@@ -295,7 +295,7 @@ to, a version specifier, if provided, means that the git repository is
 only valid if the `.gemspec` specifies a version matching the version
 specifier. If not, bundler will print a warning.
 
-    gem "rails", "2.3.8", :git => "https://github.com/rails/rails.git"
+    gem "rails", "2.3.8", git:  "https://github.com/rails/rails.git"
     # bundle install will fail, because the .gemspec in the rails
     # repository's master branch specifies version 3.0.0
 
@@ -307,18 +307,18 @@ Git repositories support a number of additional options.
 
   * `branch`, `tag`, and `ref`:
     You `MUST` only specify at most one of these options. The default
-    is `:branch => "master"`.  For example:
+    is `branch:  "master"`.  For example:
 
-      gem "rails", :git => "https://github.com/rails/rails.git", :branch => "5-0-stable"
+      gem "rails", git:  "https://github.com/rails/rails.git", branch:  "5-0-stable"
 
-      gem "rails", :git => "https://github.com/rails/rails.git", :tag => "v5.0.0"
+      gem "rails", git:  "https://github.com/rails/rails.git", tag:  "v5.0.0"
 
-      gem "rails", :git => "https://github.com/rails/rails.git", :ref => "4aded"
+      gem "rails", git:  "https://github.com/rails/rails.git", ref:  "4aded"
 
   * `submodules`:
     For reference, a [git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules)
     lets you have another git repository within a subfolder of your repository.
-    Specify `:submodules => true` to cause bundler to expand any
+    Specify `submodules:  true` to cause bundler to expand any
     submodules included in the git repository
 
 If a git repository contains multiple `.gemspecs`, each `.gemspec`
@@ -346,11 +346,11 @@ as an argument, and a block which receives a single argument and interpolates it
 string to return the full repo address:
 
     git_source(:stash){ |repo_name| "https://stash.corp.acme.pl/#{repo_name}.git" }
-    gem 'rails', :stash => 'forks/rails'
+    gem 'rails', stash:  'forks/rails'
 
 In addition, if you wish to choose a specific branch:
 
-    gem "rails", :stash => "forks/rails", :branch => "branch_name"
+    gem "rails", stash:  "forks/rails", branch:  "branch_name"
 
 ### GITHUB
 
@@ -363,33 +363,33 @@ If the git repository you want to use is hosted on GitHub and is public, you can
 trailing ".git"), separated by a slash. If both the username and repository name are the
 same, you can omit one.
 
-    gem "rails", :github => "rails/rails"
-    gem "rails", :github => "rails"
+    gem "rails", github:  "rails/rails"
+    gem "rails", github:  "rails"
 
 Are both equivalent to
 
-    gem "rails", :git => "git://github.com/rails/rails.git"
+    gem "rails", git:  "git://github.com/rails/rails.git"
 
 Since the `github` method is a specialization of `git_source`, it accepts a `:branch` named argument.
 
 You can also directly pass a pull request URL:
 
-    gem "rails", :github => "https://github.com/rails/rails/pull/43753"
+    gem "rails", github:  "https://github.com/rails/rails/pull/43753"
 
 Which is equivalent to:
 
-    gem "rails", :github => "rails/rails", branch: "refs/pull/43753/head"
+    gem "rails", github:  "rails/rails", branch: "refs/pull/43753/head"
 
 ### GIST
 
 If the git repository you want to use is hosted as a GitHub Gist and is public, you can use
 the :gist shorthand to specify the gist identifier (without the trailing ".git").
 
-    gem "the_hatch", :gist => "4815162342"
+    gem "the_hatch", gist:  "4815162342"
 
 Is equivalent to:
 
-    gem "the_hatch", :git => "https://gist.github.com/4815162342.git"
+    gem "the_hatch", git:  "https://gist.github.com/4815162342.git"
 
 Since the `gist` method is a specialization of `git_source`, it accepts a `:branch` named argument.
 
@@ -400,12 +400,12 @@ If the git repository you want to use is hosted on Bitbucket and is public, you 
 trailing ".git"), separated by a slash. If both the username and repository name are the
 same, you can omit one.
 
-    gem "rails", :bitbucket => "rails/rails"
-    gem "rails", :bitbucket => "rails"
+    gem "rails", bitbucket:  "rails/rails"
+    gem "rails", bitbucket:  "rails"
 
 Are both equivalent to
 
-    gem "rails", :git => "https://rails@bitbucket.org/rails/rails.git"
+    gem "rails", git:  "https://rails@bitbucket.org/rails/rails.git"
 
 Since the `bitbucket` method is a specialization of `git_source`, it accepts a `:branch` named argument.
 
@@ -423,7 +423,7 @@ version that bundler should use.
 Unlike `:git`, bundler does not compile C extensions for
 gems specified as paths.
 
-    gem "rails", :path => "vendor/rails"
+    gem "rails", path:  "vendor/rails"
 
 If you would like to use multiple local gems directly from the filesystem, you can set a global `path` option to the path containing the gem's files. This will automatically load gemspec files from subdirectories.
 
@@ -452,7 +452,7 @@ applied to a group of gems by using block form.
       gem "sqlite3"
     end
 
-    group :development, :optional => true do
+    group :development, optional:  true do
       gem "wirble"
       gem "faker"
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Our docs use an old and nowadays uncommon style for hashes, which can be distracting for some people.

## What is your fix for the problem, implemented in this PR?

Use the more common style, so people focus on learning the DSL, not on our documentation looking old.

Fixes https://github.com/rubygems/rubygems/pull/4049#discussion_r909497483.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
