### PR TITLE
Add more descriptive messages when `gem update` fails to update some gems

### DIFF
--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -118,15 +118,18 @@ command to remove old versions.
 
     updated = update_gems gems_to_update
 
+    installed_names = highest_installed_gems.keys
     updated_names = updated.map {|spec| spec.name }
     not_updated_names = options[:args].uniq - updated_names
+    not_installed_names = not_updated_names - installed_names
+    up_to_date_names = not_updated_names - not_installed_names
 
     if updated.empty?
       say "Nothing to update"
     else
       say "Gems updated: #{updated_names.join(' ')}"
-      say "Gems already up-to-date: #{not_updated_names.join(' ')}" unless not_updated_names.empty?
     end
+    say "Gems already up-to-date: #{up_to_date_names.join(' ')}" unless up_to_date_names.empty?
   end
 
   def fetch_remote_gems(spec) # :nodoc:

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -130,6 +130,7 @@ command to remove old versions.
       say "Gems updated: #{updated_names.join(' ')}"
     end
     say "Gems already up-to-date: #{up_to_date_names.join(' ')}" unless up_to_date_names.empty?
+    say "Gems not currently installed: #{not_installed_names.join(' ')}" unless not_installed_names.empty?
   end
 
   def fetch_remote_gems(spec) # :nodoc:

--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -535,6 +535,7 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
     out = @ui.output.split "\n"
     assert_equal "Updating installed gems", out.shift
     assert_equal "Nothing to update", out.shift
+    assert_equal "Gems already up-to-date: a", out.shift
 
     assert_empty out
   end

--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -812,4 +812,24 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
     assert_equal "  a-2", out.shift
     assert_empty out
   end
+
+  def test_execute_named_not_installed_and_no_update
+    spec_fetcher do |fetcher|
+      fetcher.spec 'a', 2
+    end
+
+    @cmd.options[:args] = %w[a b]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    out = @ui.output.split "\n"
+    assert_equal "Updating installed gems", out.shift
+    assert_equal "Nothing to update", out.shift
+    assert_equal "Gems already up-to-date: a", out.shift
+    assert_equal "Gems not currently installed: b", out.shift
+
+    assert_empty out
+  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When running `gem update` there are points of unclarity when gems are not updated
- it is not clear which gems were not updated
- the reason why gems are not updated (already at latest version or gem isn't even installed)

## What is your fix for the problem, implemented in this PR?

- Add a more verbose message specifying which gems were updated and if some were not, specifying the reason why

Fixes https://github.com/rubygems/rubygems/issues/4306.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
