### PR TITLE
Fix unintended double spaces in DSL documentation

### DIFF
--- a/bundler/lib/bundler/man/gemfile.5
+++ b/bundler/lib/bundler/man/gemfile.5
@@ -100,7 +100,7 @@ Each application \fImay\fR specify a Ruby engine version\. If an engine version 
 .
 .nf
 
-ruby "1\.8\.7", engine:  "jruby", engine_version:  "1\.6\.7"
+ruby "1\.8\.7", engine: "jruby", engine_version: "1\.6\.7"
 .
 .fi
 .
@@ -113,7 +113,7 @@ Each application \fImay\fR specify a Ruby patchlevel\.
 .
 .nf
 
-ruby "2\.0\.0", patchlevel:  "247"
+ruby "2\.0\.0", patchlevel: "247"
 .
 .fi
 .
@@ -156,9 +156,9 @@ Each \fIgem\fR \fBMAY\fR specify files that should be used when autorequiring vi
 .
 .nf
 
-gem "redis", require:  ["redis/connection/hiredis", "redis"]
-gem "webmock", require:  false
-gem "byebug", require:  true
+gem "redis", require: ["redis/connection/hiredis", "redis"]
+gem "webmock", require: false
+gem "byebug", require: true
 .
 .fi
 .
@@ -172,8 +172,8 @@ The argument defaults to the name of the gem\. For example, these are identical:
 .nf
 
 gem "nokogiri"
-gem "nokogiri", require:  "nokogiri"
-gem "nokogiri", require:  true
+gem "nokogiri", require: "nokogiri"
+gem "nokogiri", require: true
 .
 .fi
 .
@@ -186,8 +186,8 @@ Each \fIgem\fR \fBMAY\fR specify membership in one or more groups\. Any \fIgem\f
 .
 .nf
 
-gem "rspec", group:  :test
-gem "wirble", groups:  [:development, :test]
+gem "rspec", group: :test
+gem "wirble", groups: [:development, :test]
 .
 .fi
 .
@@ -320,9 +320,9 @@ As with groups, you can specify one or more platforms:
 .
 .nf
 
-gem "weakling",   platforms:  :jruby
-gem "ruby\-debug", platforms:  :mri_18
-gem "nokogiri",   platforms:  [:mri_18, :jruby]
+gem "weakling",   platforms: :jruby
+gem "ruby\-debug", platforms: :mri_18
+gem "nokogiri",   platforms: [:mri_18, :jruby]
 .
 .fi
 .
@@ -338,7 +338,7 @@ You can select an alternate Rubygems repository for a gem using the \':source\' 
 .
 .nf
 
-gem "some_internal_gem", source:  "https://gems\.example\.com"
+gem "some_internal_gem", source: "https://gems\.example\.com"
 .
 .fi
 .
@@ -393,7 +393,7 @@ If a git repository does have a \fB\.gemspec\fR for the gem you attached it to, 
 .
 .nf
 
-gem "rails", "2\.3\.8", git:  "https://github\.com/rails/rails\.git"
+gem "rails", "2\.3\.8", git: "https://github\.com/rails/rails\.git"
 # bundle install will fail, because the \.gemspec in the rails
 # repository\'s master branch specifies version 3\.0\.0
 .
@@ -454,7 +454,7 @@ A custom git source can be defined via the \fBgit_source\fR method\. Provide the
 .nf
 
 git_source(:stash){ |repo_name| "https://stash\.corp\.acme\.pl/#{repo_name}\.git" }
-gem \'rails\', stash:  \'forks/rails\'
+gem \'rails\', stash: \'forks/rails\'
 .
 .fi
 .
@@ -467,7 +467,7 @@ In addition, if you wish to choose a specific branch:
 .
 .nf
 
-gem "rails", stash:  "forks/rails", branch:  "branch_name"
+gem "rails", stash: "forks/rails", branch: "branch_name"
 .
 .fi
 .
@@ -483,8 +483,8 @@ If the git repository you want to use is hosted on GitHub and is public, you can
 .
 .nf
 
-gem "rails", github:  "rails/rails"
-gem "rails", github:  "rails"
+gem "rails", github: "rails/rails"
+gem "rails", github: "rails"
 .
 .fi
 .
@@ -497,7 +497,7 @@ Are both equivalent to
 .
 .nf
 
-gem "rails", git:  "git://github\.com/rails/rails\.git"
+gem "rails", git: "git://github\.com/rails/rails\.git"
 .
 .fi
 .
@@ -513,7 +513,7 @@ You can also directly pass a pull request URL:
 .
 .nf
 
-gem "rails", github:  "https://github\.com/rails/rails/pull/43753"
+gem "rails", github: "https://github\.com/rails/rails/pull/43753"
 .
 .fi
 .
@@ -526,7 +526,7 @@ Which is equivalent to:
 .
 .nf
 
-gem "rails", github:  "rails/rails", branch: "refs/pull/43753/head"
+gem "rails", github: "rails/rails", branch: "refs/pull/43753/head"
 .
 .fi
 .
@@ -539,7 +539,7 @@ If the git repository you want to use is hosted as a GitHub Gist and is public, 
 .
 .nf
 
-gem "the_hatch", gist:  "4815162342"
+gem "the_hatch", gist: "4815162342"
 .
 .fi
 .
@@ -552,7 +552,7 @@ Is equivalent to:
 .
 .nf
 
-gem "the_hatch", git:  "https://gist\.github\.com/4815162342\.git"
+gem "the_hatch", git: "https://gist\.github\.com/4815162342\.git"
 .
 .fi
 .
@@ -568,8 +568,8 @@ If the git repository you want to use is hosted on Bitbucket and is public, you 
 .
 .nf
 
-gem "rails", bitbucket:  "rails/rails"
-gem "rails", bitbucket:  "rails"
+gem "rails", bitbucket: "rails/rails"
+gem "rails", bitbucket: "rails"
 .
 .fi
 .
@@ -582,7 +582,7 @@ Are both equivalent to
 .
 .nf
 
-gem "rails", git:  "https://rails@bitbucket\.org/rails/rails\.git"
+gem "rails", git: "https://rails@bitbucket\.org/rails/rails\.git"
 .
 .fi
 .
@@ -604,7 +604,7 @@ Unlike \fB:git\fR, bundler does not compile C extensions for gems specified as p
 .
 .nf
 
-gem "rails", path:  "vendor/rails"
+gem "rails", path: "vendor/rails"
 .
 .fi
 .
@@ -648,7 +648,7 @@ platforms :ruby do
   gem "sqlite3"
 end
 
-group :development, optional:  true do
+group :development, optional: true do
   gem "wirble"
   gem "faker"
 end

--- a/bundler/lib/bundler/man/gemfile.5.ronn
+++ b/bundler/lib/bundler/man/gemfile.5.ronn
@@ -91,13 +91,13 @@ Each application _may_ specify a Ruby engine version. If an engine version is
 specified, an engine _must_ also be specified. If the engine is "ruby" the
 engine version specified _must_ match the Ruby version.
 
-    ruby "1.8.7", engine:  "jruby", engine_version:  "1.6.7"
+    ruby "1.8.7", engine: "jruby", engine_version: "1.6.7"
 
 ### PATCHLEVEL
 
 Each application _may_ specify a Ruby patchlevel.
 
-    ruby "2.0.0", patchlevel:  "247"
+    ruby "2.0.0", patchlevel: "247"
 
 ## GEMS
 
@@ -124,23 +124,23 @@ Each _gem_ `MAY` specify files that should be used when autorequiring via
 you want `required` has the same name as _gem_ or `false` to
 prevent any file from being autorequired.
 
-    gem "redis", require:  ["redis/connection/hiredis", "redis"]
-    gem "webmock", require:  false
-    gem "byebug", require:  true
+    gem "redis", require: ["redis/connection/hiredis", "redis"]
+    gem "webmock", require: false
+    gem "byebug", require: true
 
 The argument defaults to the name of the gem. For example, these are identical:
 
     gem "nokogiri"
-    gem "nokogiri", require:  "nokogiri"
-    gem "nokogiri", require:  true
+    gem "nokogiri", require: "nokogiri"
+    gem "nokogiri", require: true
 
 ### GROUPS
 
 Each _gem_ `MAY` specify membership in one or more groups. Any _gem_ that does
 not specify membership in any group is placed in the `default` group.
 
-    gem "rspec", group:  :test
-    gem "wirble", groups:  [:development, :test]
+    gem "rspec", group: :test
+    gem "wirble", groups: [:development, :test]
 
 The Bundler runtime allows its two main methods, `Bundler.setup` and
 `Bundler.require`, to limit their impact to particular groups.
@@ -223,9 +223,9 @@ The full list of platforms and supported versions includes:
 
 As with groups, you can specify one or more platforms:
 
-    gem "weakling",   platforms:  :jruby
-    gem "ruby-debug", platforms:  :mri_18
-    gem "nokogiri",   platforms:  [:mri_18, :jruby]
+    gem "weakling",   platforms: :jruby
+    gem "ruby-debug", platforms: :mri_18
+    gem "nokogiri",   platforms: [:mri_18, :jruby]
 
 All operations involving groups ([`bundle install`](bundle-install.1.html), `Bundler.setup`,
 `Bundler.require`) behave exactly the same as if any groups not
@@ -236,7 +236,7 @@ matching the current platform were explicitly excluded.
 You can select an alternate Rubygems repository for a gem using the ':source'
 option.
 
-    gem "some_internal_gem", source:  "https://gems.example.com"
+    gem "some_internal_gem", source: "https://gems.example.com"
 
 This forces the gem to be loaded from this source and ignores any global sources
 declared at the top level of the file. If the gem does not exist in this source,
@@ -263,11 +263,11 @@ git repository using the `:git` parameter. The repository can be accessed via
 several protocols:
 
   * `HTTP(S)`:
-    gem "rails", git:  "https://github.com/rails/rails.git"
+    gem "rails", git: "https://github.com/rails/rails.git"
   * `SSH`:
-    gem "rails", git:  "git@github.com:rails/rails.git"
+    gem "rails", git: "git@github.com:rails/rails.git"
   * `git`:
-    gem "rails", git:  "git://github.com/rails/rails.git"
+    gem "rails", git: "git://github.com/rails/rails.git"
 
 If using SSH, the user that you use to run `bundle install` `MUST` have the
 appropriate keys available in their `$HOME/.ssh`.
@@ -295,7 +295,7 @@ to, a version specifier, if provided, means that the git repository is
 only valid if the `.gemspec` specifies a version matching the version
 specifier. If not, bundler will print a warning.
 
-    gem "rails", "2.3.8", git:  "https://github.com/rails/rails.git"
+    gem "rails", "2.3.8", git: "https://github.com/rails/rails.git"
     # bundle install will fail, because the .gemspec in the rails
     # repository's master branch specifies version 3.0.0
 
@@ -307,18 +307,18 @@ Git repositories support a number of additional options.
 
   * `branch`, `tag`, and `ref`:
     You `MUST` only specify at most one of these options. The default
-    is `branch:  "master"`.  For example:
+    is `branch: "master"`.  For example:
 
-      gem "rails", git:  "https://github.com/rails/rails.git", branch:  "5-0-stable"
+      gem "rails", git: "https://github.com/rails/rails.git", branch: "5-0-stable"
 
-      gem "rails", git:  "https://github.com/rails/rails.git", tag:  "v5.0.0"
+      gem "rails", git: "https://github.com/rails/rails.git", tag: "v5.0.0"
 
-      gem "rails", git:  "https://github.com/rails/rails.git", ref:  "4aded"
+      gem "rails", git: "https://github.com/rails/rails.git", ref: "4aded"
 
   * `submodules`:
     For reference, a [git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules)
     lets you have another git repository within a subfolder of your repository.
-    Specify `submodules:  true` to cause bundler to expand any
+    Specify `submodules: true` to cause bundler to expand any
     submodules included in the git repository
 
 If a git repository contains multiple `.gemspecs`, each `.gemspec`
@@ -346,11 +346,11 @@ as an argument, and a block which receives a single argument and interpolates it
 string to return the full repo address:
 
     git_source(:stash){ |repo_name| "https://stash.corp.acme.pl/#{repo_name}.git" }
-    gem 'rails', stash:  'forks/rails'
+    gem 'rails', stash: 'forks/rails'
 
 In addition, if you wish to choose a specific branch:
 
-    gem "rails", stash:  "forks/rails", branch:  "branch_name"
+    gem "rails", stash: "forks/rails", branch: "branch_name"
 
 ### GITHUB
 
@@ -363,33 +363,33 @@ If the git repository you want to use is hosted on GitHub and is public, you can
 trailing ".git"), separated by a slash. If both the username and repository name are the
 same, you can omit one.
 
-    gem "rails", github:  "rails/rails"
-    gem "rails", github:  "rails"
+    gem "rails", github: "rails/rails"
+    gem "rails", github: "rails"
 
 Are both equivalent to
 
-    gem "rails", git:  "git://github.com/rails/rails.git"
+    gem "rails", git: "git://github.com/rails/rails.git"
 
 Since the `github` method is a specialization of `git_source`, it accepts a `:branch` named argument.
 
 You can also directly pass a pull request URL:
 
-    gem "rails", github:  "https://github.com/rails/rails/pull/43753"
+    gem "rails", github: "https://github.com/rails/rails/pull/43753"
 
 Which is equivalent to:
 
-    gem "rails", github:  "rails/rails", branch: "refs/pull/43753/head"
+    gem "rails", github: "rails/rails", branch: "refs/pull/43753/head"
 
 ### GIST
 
 If the git repository you want to use is hosted as a GitHub Gist and is public, you can use
 the :gist shorthand to specify the gist identifier (without the trailing ".git").
 
-    gem "the_hatch", gist:  "4815162342"
+    gem "the_hatch", gist: "4815162342"
 
 Is equivalent to:
 
-    gem "the_hatch", git:  "https://gist.github.com/4815162342.git"
+    gem "the_hatch", git: "https://gist.github.com/4815162342.git"
 
 Since the `gist` method is a specialization of `git_source`, it accepts a `:branch` named argument.
 
@@ -400,12 +400,12 @@ If the git repository you want to use is hosted on Bitbucket and is public, you 
 trailing ".git"), separated by a slash. If both the username and repository name are the
 same, you can omit one.
 
-    gem "rails", bitbucket:  "rails/rails"
-    gem "rails", bitbucket:  "rails"
+    gem "rails", bitbucket: "rails/rails"
+    gem "rails", bitbucket: "rails"
 
 Are both equivalent to
 
-    gem "rails", git:  "https://rails@bitbucket.org/rails/rails.git"
+    gem "rails", git: "https://rails@bitbucket.org/rails/rails.git"
 
 Since the `bitbucket` method is a specialization of `git_source`, it accepts a `:branch` named argument.
 
@@ -423,7 +423,7 @@ version that bundler should use.
 Unlike `:git`, bundler does not compile C extensions for
 gems specified as paths.
 
-    gem "rails", path:  "vendor/rails"
+    gem "rails", path: "vendor/rails"
 
 If you would like to use multiple local gems directly from the filesystem, you can set a global `path` option to the path containing the gem's files. This will automatically load gemspec files from subdirectories.
 
@@ -452,7 +452,7 @@ applied to a group of gems by using block form.
       gem "sqlite3"
     end
 
-    group :development, optional:  true do
+    group :development, optional: true do
       gem "wirble"
       gem "faker"
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I accidentally introduced double spaces when changing our Gemfile DSL documentation to use modern hash notation.

## What is your fix for the problem, implemented in this PR?

Replace duplicated spaces with a single space.

Fixes https://github.com/rubygems/rubygems/pull/5674#discussion_r910368102.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
