### PR TITLE
Prevent a warning: `*' interpreted as argument prefix

### DIFF
--- a/test/rubygems/test_gem_ext_cargo_builder/custom_name/build.rb
+++ b/test/rubygems/test_gem_ext_cargo_builder/custom_name/build.rb
@@ -15,7 +15,7 @@ gemspec = File.expand_path('custom_name.gemspec', __dir__)
 
 Dir.mktmpdir("custom_name") do |dir|
   built_gem = File.expand_path(File.join(dir, "custom_name.gem"))
-  system *gem, "build", gemspec, "--output", built_gem
-  system *gem, "install", "--verbose", "--local", built_gem, *ARGV
+  system(*gem, "build", gemspec, "--output", built_gem)
+  system(*gem, "install", "--verbose", "--local", built_gem, *ARGV)
   system %q(ruby -rcustom_name -e "puts 'Result: ' + CustomName.say_hello")
 end


### PR DESCRIPTION
http://rubyci.s3.amazonaws.com/ubuntu2004-arm/ruby-master/log/20220630T063003Z.log.html.gz
```
[19606/21662] TestAst#test_not_cared:test/rubygems/test_gem_ext_cargo_builder/custom_name/build.rb(none):18: warning: `*' interpreted as argument prefix
(none):19: warning: `*' interpreted as argument prefix
 = 0.00 s
```
