### PR TITLE
Fix crash when updating vendor cache of default gems

### DIFF
--- a/bundler/lib/bundler/runtime.rb
+++ b/bundler/lib/bundler/runtime.rb
@@ -125,7 +125,6 @@ module Bundler
       specs_to_cache.each do |spec|
         next if spec.name == "bundler"
         next if spec.source.is_a?(Source::Gemspec)
-        spec.source.send(:fetch_gem, spec) if Bundler.settings[:cache_all_platforms] && spec.source.respond_to?(:fetch_gem, true)
         spec.source.cache(spec, custom_path) if spec.source.respond_to?(:cache)
       end
 

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -242,7 +242,7 @@ module Bundler
       end
 
       def cache(spec, custom_path = nil)
-        cached_path = cached_gem(spec)
+        cached_path = Bundler.settings[:cache_all_platforms] ? fetch_gem(spec) : cached_gem(spec)
         raise GemNotFound, "Missing gem file '#{spec.file_name}'." unless cached_path
         return if File.dirname(cached_path) == Bundler.app_cache.to_s
         Bundler.ui.info "  * #{File.basename(cached_path)}"

--- a/bundler/spec/cache/gems_spec.rb
+++ b/bundler/spec/cache/gems_spec.rb
@@ -118,6 +118,18 @@ RSpec.describe "bundle cache" do
       expect(bundled_app("vendor/cache/json-#{default_json_version}.gem")).to exist
     end
 
+    it "caches builtin gems when cache_all_platforms is set" do
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo2)}"
+        gem "json"
+      G
+
+      bundle "config set cache_all_platforms true"
+
+      bundle :cache
+      expect(bundled_app("vendor/cache/json-#{default_json_version}.gem")).to exist
+    end
+
     it "doesn't make remote request after caching the gem" do
       build_gem "builtin_gem_2", "1.0.2", :path => bundled_app("vendor/cache") do |s|
         s.summary = "This builtin_gem is bundled with Ruby"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Recent refactorings in rubygems source did not take into account that default gems don't have a remote and need to be searched manually.

## What is your fix for the problem, implemented in this PR?

Consider this again and add a regression spec to not regress.

Fixes #5675.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
