### PR TITLE
Bump `rb-sys` to 0.9.18

### DIFF
--- a/.github/workflows/daily-rubygems.yml
+++ b/.github/workflows/daily-rubygems.yml
@@ -3,6 +3,7 @@ name: daily-rubygems
 on:
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
 
 jobs:
   daily_rubygems:

--- a/test/rubygems/test_gem_ext_cargo_builder/custom_name/Cargo.lock
+++ b/test/rubygems/test_gem_ext_cargo_builder/custom_name/Cargo.lock
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.15"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "104c5bcb9fa23bf3823124c003c516b22664fef50c4a481ff2d0e21b76e0f92c"
+checksum = "0ebbf80acc7a283f70eaeecde5eca8d503e0aaf23f737117398328048cd70077"
 dependencies = [
  "bindgen",
  "linkify",
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.15"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cdf919b75ba95aa480159f3b20070cbec110d6c8a7af86b35844270069a4cb3"
+checksum = "d48277d27ff861590af07c8e1fd76de3aff5a37a227b745a4f42f40f914e62bc"
 dependencies = [
  "regex",
  "shell-words",

--- a/test/rubygems/test_gem_ext_cargo_builder/custom_name/Cargo.toml
+++ b/test/rubygems/test_gem_ext_cargo_builder/custom_name/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-rb-sys = { version = "0.9.15", features = ["gem"] }
+rb-sys = { version = "0.9.18", features = ["gem"] }

--- a/test/rubygems/test_gem_ext_cargo_builder/rust_ruby_example/Cargo.lock
+++ b/test/rubygems/test_gem_ext_cargo_builder/rust_ruby_example/Cargo.lock
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.15"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "104c5bcb9fa23bf3823124c003c516b22664fef50c4a481ff2d0e21b76e0f92c"
+checksum = "0ebbf80acc7a283f70eaeecde5eca8d503e0aaf23f737117398328048cd70077"
 dependencies = [
  "bindgen",
  "linkify",
@@ -164,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.15"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cdf919b75ba95aa480159f3b20070cbec110d6c8a7af86b35844270069a4cb3"
+checksum = "d48277d27ff861590af07c8e1fd76de3aff5a37a227b745a4f42f40f914e62bc"
 dependencies = [
  "regex",
  "shell-words",

--- a/test/rubygems/test_gem_ext_cargo_builder/rust_ruby_example/Cargo.toml
+++ b/test/rubygems/test_gem_ext_cargo_builder/rust_ruby_example/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-rb-sys = { version = "0.9.15", features = ["gem"] }
+rb-sys = { version = "0.9.18", features = ["gem"] }


### PR DESCRIPTION
Addressing https://github.com/rubygems/rubygems/actions/runs/2586659865