### PR TITLE
Fix TruffleRuby no longer installing some lockfiles correctly

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -74,6 +74,7 @@ bundler/lib/bundler/fetcher/compact_index.rb
 bundler/lib/bundler/fetcher/dependency.rb
 bundler/lib/bundler/fetcher/downloader.rb
 bundler/lib/bundler/fetcher/index.rb
+bundler/lib/bundler/force_platform.rb
 bundler/lib/bundler/friendly_errors.rb
 bundler/lib/bundler/gem_helper.rb
 bundler/lib/bundler/gem_helpers.rb

--- a/bundler/lib/bundler/dependency.rb
+++ b/bundler/lib/bundler/dependency.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 require "rubygems/dependency"
+require_relative "force_platform"
 require_relative "shared_helpers"
 require_relative "rubygems_ext"
 
 module Bundler
   class Dependency < Gem::Dependency
+    include ForcePlatform
+
     attr_reader :autorequire
     attr_reader :groups, :platforms, :gemfile, :git, :github, :branch, :ref, :force_ruby_platform
 
@@ -158,18 +161,6 @@ module Bundler
       super
     rescue NoMethodError
       requirement != ">= 0"
-    end
-
-    private
-
-    # The `:force_ruby_platform` attribute is `false` by default, except for
-    # TruffleRuby. TruffleRuby generally needs to force the RUBY platform
-    # variant unless the name is explicitly allowlisted.
-
-    def default_force_ruby_platform
-      return false unless Bundler.current_ruby.truffleruby?
-
-      !Gem::Platform::REUSE_AS_BINARY_ON_TRUFFLERUBY.include?(name)
     end
   end
 end

--- a/bundler/lib/bundler/force_platform.rb
+++ b/bundler/lib/bundler/force_platform.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Bundler
+  module ForcePlatform
+    private
+
+    # The `:force_ruby_platform` value used by dependencies for resolution, and
+    # by locked specifications for materialization is `false` by default, except
+    # for TruffleRuby. TruffleRuby generally needs to force the RUBY platform
+    # variant unless the name is explicitly allowlisted.
+
+    def default_force_ruby_platform
+      return false unless Bundler.current_ruby.truffleruby?
+
+      !Gem::Platform::REUSE_AS_BINARY_ON_TRUFFLERUBY.include?(name)
+    end
+  end
+end

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -1,13 +1,16 @@
 # frozen_string_literal: true
 
+require_relative "force_platform"
 require_relative "match_platform"
 
 module Bundler
   class LazySpecification
+    include ForcePlatform
     include MatchPlatform
 
     attr_reader :name, :version, :dependencies, :platform
-    attr_accessor :source, :remote, :force_ruby_platform
+    attr_writer :force_ruby_platform
+    attr_accessor :source, :remote
 
     def initialize(name, version, platform, source = nil)
       @name          = name
@@ -16,6 +19,7 @@ module Bundler
       @platform      = platform || Gem::Platform::RUBY
       @source        = source
       @specification = nil
+      @force_ruby_platform = nil
     end
 
     def full_name
@@ -24,6 +28,12 @@ module Bundler
       else
         "#{@name}-#{@version}-#{platform}"
       end
+    end
+
+    def force_ruby_platform
+      return @force_ruby_platform unless @force_ruby_platform.nil?
+
+      default_force_ruby_platform
     end
 
     def ==(other)

--- a/bundler/spec/runtime/platform_spec.rb
+++ b/bundler/spec/runtime/platform_spec.rb
@@ -255,6 +255,66 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
     expect(the_bundle).to include_gems "platform_specific 1.0 RUBY"
   end
 
+  it "doesn't pull platform specific gems on truffleruby (except when whitelisted) even if lockfile was generated with an older version that declared RUBY as platform", :truffleruby_only do
+    gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
+      gem "platform_specific"
+    G
+
+    lockfile <<-L
+      GEM
+        remote: #{file_uri_for(gem_repo1)}/
+        specs:
+          platform_specific (1.0)
+
+      PLATFORMS
+        ruby
+
+      DEPENDENCIES
+        platform_specific
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+    bundle "install"
+
+    expect(the_bundle).to include_gems "platform_specific 1.0 RUBY"
+
+    build_repo4 do
+      build_gem "libv8"
+
+      build_gem "libv8" do |s|
+        s.platform = Bundler.local_platform
+      end
+    end
+
+    gemfile <<-G
+      source "#{file_uri_for(gem_repo4)}"
+      gem "libv8"
+    G
+
+    lockfile <<-L
+      GEM
+        remote: #{file_uri_for(gem_repo4)}/
+        specs:
+          libv8 (1.0)
+
+      PLATFORMS
+        ruby
+
+      DEPENDENCIES
+        libv8
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+    bundle "install"
+
+    expect(the_bundle).to include_gems "libv8 1.0 #{Bundler.local_platform}"
+  end
+
   it "allows specifying only-ruby-platform on windows with dependency platforms" do
     simulate_windows do
       install_gemfile <<-G


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Until 2.3.17, would always use the RUBY platform for Truffleruby, so the RUBY platform would always be used in lockfiles generated on Truffleruby.

From 2.3.18, Bundler will consider `Gem::Platform.local` as Truffleruby's platform, just like CRuby, and use that inside lockfiles.

But we need to properly deal with old lockfiles that used the RUBY platform, because currently Bundler tries to install the most specific variant available and that's usually not expected on Truffleruby.

## What is your fix for the problem, implemented in this PR?

My fix is to use TruffleRuby platform selection logic (according to the gem name) not only for resolution but also for materialization, to make sure we never materialize a lockfile into an incorrect platform specific gem.

Closes #5691.
 
## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
