### PR TITLE
Speed up `bundler/setup` by using the raw `Gemfile.lock` information without extra processing whenever possible

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -235,6 +235,14 @@ module Bundler
       @locked_deps.values
     end
 
+    def new_deps
+      @new_deps ||= @dependencies - locked_dependencies
+    end
+
+    def deleted_deps
+      @deleted_deps ||= locked_dependencies - @dependencies
+    end
+
     def specs_for(groups)
       return specs if groups.empty?
       deps = dependencies_for(groups)
@@ -259,8 +267,13 @@ module Bundler
         Bundler.ui.debug "Frozen, using resolution from the lockfile"
         @locked_specs
       elsif !unlocking? && nothing_changed?
-        Bundler.ui.debug("Found no changes, using resolution from the lockfile")
-        SpecSet.new(filter_specs(@locked_specs, @dependencies.select {|dep| @locked_specs[dep].any? }))
+        if deleted_deps.any?
+          Bundler.ui.debug("Some dependencies were deleted, using a subset of the resolution from the lockfile")
+          SpecSet.new(filter_specs(@locked_specs, @dependencies - deleted_deps))
+        else
+          Bundler.ui.debug("Found no changes, using resolution from the lockfile")
+          SpecSet.new(filter_specs(@locked_specs, @dependencies))
+        end
       else
         last_resolve = converge_locked_specs
         # Run a resolve against the locally available gems
@@ -358,9 +371,6 @@ module Bundler
       deleted_platforms = @locked_platforms - @platforms
       added.concat new_platforms.map {|p| "* platform: #{p}" }
       deleted.concat deleted_platforms.map {|p| "* platform: #{p}" }
-
-      new_deps = @dependencies - locked_dependencies
-      deleted_deps = locked_dependencies - @dependencies
 
       added.concat new_deps.map {|d| "* #{pretty_dep(d)}" } if new_deps.any?
       deleted.concat deleted_deps.map {|d| "* #{pretty_dep(d)}" } if deleted_deps.any?

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -272,7 +272,11 @@ module Bundler
           SpecSet.new(filter_specs(@locked_specs, @dependencies - deleted_deps))
         else
           Bundler.ui.debug("Found no changes, using resolution from the lockfile")
-          SpecSet.new(filter_specs(@locked_specs, @dependencies))
+          if @locked_gems.may_include_redundant_platform_specific_gems?
+            SpecSet.new(filter_specs(@locked_specs, @dependencies))
+          else
+            @locked_specs
+          end
         end
       else
         last_resolve = converge_locked_specs

--- a/bundler/lib/bundler/lockfile_parser.rb
+++ b/bundler/lib/bundler/lockfile_parser.rb
@@ -93,6 +93,10 @@ module Bundler
         "and then `bundle install` to generate a new lockfile."
     end
 
+    def may_include_redundant_platform_specific_gems?
+      bundler_version.nil? || bundler_version < Gem::Version.new("1.16.2")
+    end
+
     private
 
     TYPES = {

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -216,28 +216,28 @@ RSpec.describe "bundle install across platforms" do
         pry
 
       BUNDLED WITH
-         #{Bundler::VERSION}
+         1.16.1
     L
 
     aggregate_failures do
       lockfile bad_lockfile
-      bundle :install
+      bundle :install, :env => { "BUNDLER_VERSION" => Bundler::VERSION }
       expect(lockfile).to eq good_lockfile
 
       lockfile bad_lockfile
-      bundle :update, :all => true
+      bundle :update, :all => true, :env => { "BUNDLER_VERSION" => Bundler::VERSION }
       expect(lockfile).to eq good_lockfile
 
       lockfile bad_lockfile
-      bundle "update ffi"
+      bundle "update ffi", :env => { "BUNDLER_VERSION" => Bundler::VERSION }
       expect(lockfile).to eq good_lockfile
 
       lockfile bad_lockfile
-      bundle "update empyrean"
+      bundle "update empyrean", :env => { "BUNDLER_VERSION" => Bundler::VERSION }
       expect(lockfile).to eq good_lockfile
 
       lockfile bad_lockfile
-      bundle :lock
+      bundle :lock, :env => { "BUNDLER_VERSION" => Bundler::VERSION }
       expect(lockfile).to eq good_lockfile
     end
   end

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -637,6 +637,22 @@ RSpec.describe "Bundler.setup" do
       expect(err).to be_empty
     end
 
+    it "doesn't re-resolve when deleting dependencies" do
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rack"
+        gem "actionpack"
+      G
+
+      install_gemfile <<-G, :verbose => true
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rack"
+      G
+
+      expect(out).to include("Some dependencies were deleted, using a subset of the resolution from the lockfile")
+      expect(err).to be_empty
+    end
+
     it "remembers --without and does not include groups passed to Bundler.setup" do
       bundle "config set --local without rails"
       install_gemfile <<-G


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We should make `bundler/setup` as fast as possible, since it's the cost that all scripts using Bundler to select versions of dependencies pay.

## What is your fix for the problem, implemented in this PR?

I noticed that even in the case where the `Gemfile` has no changes over the `Gemfile.lock` file, we're still doing some processing over the raw `Gemfile.lock` recorded resolution that did not seem necessary.

Further investigation revealed that this is only done for two edge cases:

* When dependencies are deleted from the Gemfile. In this case, we don't need to re-resolve, only to select the proper subset of the existing lockfile resolution.
* When the lockfile has redundant platform specific gems recorded. This can only happen to lockfiles generated with versions of Bundler prior to 1.16.1, due to [this bug](https://github.com/rubygems/bundler/issues/6491).

So my fix is to explicitly detect the above two situations and only do the extra processing there. Otherwise, use the raw lockfile.

This speeds bundling the Gemfile in https://github.com/technicalpickles/big-gemfile by about 5%, but should speed up all invocations of `bundler/setup` that don't need a re-resolve, the more dependencies, the more speed up.

```
➜  big-gemfile git:(main) ✗ hyperfine 'BUNDLER_VERSION=2.4.0.dev ruby -rbundler/setup -e1' 'BUNDLER_VERSION=2.3.17 ruby -rbundler/setup -e1'  
Benchmark 1: BUNDLER_VERSION=2.4.0.dev ruby -rbundler/setup -e1
  Time (mean ± σ):     146.3 ms ±   0.9 ms    [User: 121.6 ms, System: 23.3 ms]
  Range (min … max):   144.5 ms … 148.4 ms    19 runs
 
Benchmark 2: BUNDLER_VERSION=2.3.17 ruby -rbundler/setup -e1
  Time (mean ± σ):     153.2 ms ±   0.7 ms    [User: 128.9 ms, System: 22.9 ms]
  Range (min … max):   151.5 ms … 154.3 ms    19 runs
 
Summary
  'BUNDLER_VERSION=2.4.0.dev ruby -rbundler/setup -e1' ran
    1.05 ± 0.01 times faster than 'BUNDLER_VERSION=2.3.17 ruby -rbundler/setup -e1'
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
