### PR TITLE
Fix `simulate_windows` spec helper

### DIFF
--- a/bundler/spec/support/hax.rb
+++ b/bundler/spec/support/hax.rb
@@ -14,6 +14,10 @@ module Gem
     @default_specifications_dir = nil
   end
 
+  if ENV["BUNDLER_SPEC_WINDOWS"]
+    @@win_platform = true # rubocop:disable Sryle/ClassVars
+  end
+
   if ENV["BUNDLER_SPEC_PLATFORM"]
     class Platform
       @local = new(ENV["BUNDLER_SPEC_PLATFORM"])

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -446,11 +446,15 @@ module Spec
     end
 
     def simulate_windows(platform = mswin)
+      old = ENV["BUNDLER_SPEC_WINDOWS"]
+      ENV["BUNDLER_SPEC_WINDOWS"] = "true"
       simulate_platform platform do
         simulate_bundler_version_when_missing_prerelease_default_gem_activation do
           yield
         end
       end
+    ensure
+      ENV["BUNDLER_SPEC_WINDOWS"] = old
     end
 
     def simulate_bundler_version_when_missing_prerelease_default_gem_activation


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This helper was causing issues for me at #5690 and also for @johnnyshields at #5650.

## What is your fix for the problem, implemented in this PR?

I first considered removing the helper, but I think it may be useful for simulating Windows platform where we don't currently test, so I fixed it.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
