### PR TITLE
Remove windows extra methods

### DIFF
--- a/bundler/lib/bundler/current_ruby.rb
+++ b/bundler/lib/bundler/current_ruby.rb
@@ -29,15 +29,11 @@ module Bundler
     KNOWN_PLATFORMS = %w[
       jruby
       maglev
-      mingw
       mri
-      mswin
-      mswin64
       rbx
       ruby
       truffleruby
       windows
-      x64_mingw
     ].freeze
 
     def ruby?
@@ -68,26 +64,6 @@ module Bundler
 
     def windows?
       Gem.win_platform?
-    end
-
-    def mswin?
-      # For backwards compatibility
-      windows?
-
-      # TODO: This should correctly be:
-      # windows? && Bundler.local_platform != Gem::Platform::RUBY && Bundler.local_platform.os == "mswin32" && Bundler.local_platform.cpu == "x86"
-    end
-
-    def mswin64?
-      windows? && Bundler.local_platform != Gem::Platform::RUBY && Bundler.local_platform.os == "mswin64" && Bundler.local_platform.cpu == "x64"
-    end
-
-    def mingw?
-      windows? && Bundler.local_platform != Gem::Platform::RUBY && Bundler.local_platform.os == "mingw32" && Bundler.local_platform.cpu != "x64"
-    end
-
-    def x64_mingw?
-      Gem.win_platform? && Bundler.local_platform != Gem::Platform::RUBY && Bundler.local_platform.os.start_with?("mingw") && Bundler.local_platform.cpu == "x64"
     end
 
     (KNOWN_MINOR_VERSIONS + KNOWN_MAJOR_VERSIONS).each do |version|


### PR DESCRIPTION
[Recently we added](https://github.com/rubygems/rubygems/pull/5650) `CurrentRuby#windows?` and Ruby-version specific methods e.g. `CurrentRuby#windows_30?`

This PR removes the following methods from `CurrentRuby` class:

```
CurrentRuby#mswin?
CurrentRuby#mswin64?
CurrentRuby#mingw?
CurrentRuby#x64_mingw?

and version-specific CurrentRuby#mingw_30? etc
```

These methods are not used internally and I doubt they are widely-used externally. They can certainly be replaced with `windows?`. Maybe good to merge this for Bundler 4.0 to be on the safe side.