### PR TITLE
Stop using `/dev/null` for silent ui for WASI platform

### DIFF
--- a/lib/rubygems/user_interaction.rb
+++ b/lib/rubygems/user_interaction.rb
@@ -616,18 +616,11 @@ class Gem::SilentUI < Gem::StreamUI
   # The SilentUI has no arguments as it does not use any stream.
 
   def initialize
-    reader, writer = nil, nil
-
-    reader = File.open(IO::NULL, 'r')
-    writer = File.open(IO::NULL, 'w')
-
-    super reader, writer, writer, false
+    io = NullIO.new
+    super io, io, io, false
   end
 
   def close
-    super
-    @ins.close
-    @outs.close
   end
 
   def download_reporter(*args) # :nodoc:
@@ -636,5 +629,26 @@ class Gem::SilentUI < Gem::StreamUI
 
   def progress_reporter(*args) # :nodoc:
     SilentProgressReporter.new(@outs, *args)
+  end
+
+  ##
+  # An absolutely silent IO.
+
+  class NullIO
+    def puts(*args)
+    end
+
+    def print(*args)
+    end
+
+    def flush
+    end
+
+    def gets(*args)
+    end
+
+    def tty?
+      false
+    end
   end
 end

--- a/test/rubygems/test_gem_silent_ui.rb
+++ b/test/rubygems/test_gem_silent_ui.rb
@@ -113,4 +113,10 @@ class TestGemSilentUI < Gem::TestCase
     assert_empty out, 'No output'
     assert_empty err, 'No output'
   end
+
+  def test_new_without_dev_null
+    File.stub(:open, ->(path, mode) { raise Errno::ENOTCAPABLE if path == IO::NULL }) do
+      Gem::SilentUI.new
+    end
+  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

WASI doesn't guarantee that `/dev/null` is present.
So before this patch, we needed to mount host's `/dev` directory to WASI guest process to avoid `ENOTCAPABLE` error while `require "bundler/setup"`

Here is how to reproduce the problem.

```bash
# Download prebuilt ruby
curl -LO https://github.com/ruby/ruby.wasm/releases/download/2022-05-11-a/ruby-head-wasm32-unknown-wasi-full.tar.gz
tar xfz ruby-head-wasm32-unknown-wasi-full.tar.gz

# Install the same version of native ruby to avoid bundler version mismatch in "BUNDLED WITH" of Gemfile.lock
rbenv install 3.2.0-dev
rbenv local 3.2.0-dev

# Setup Gemfile
bundle init
bundle add syntax_tree

# Install gems in vendor/bundle to mount it on WASI
bundle config set --local path 'vendor/bundle'
bundle install

cat <<EOS > my_app.rb
require "bundler/setup"
require "syntax_tree"

pp SyntaxTree.parse("1 + 1")
EOS

# Options:
# --mapdir /usr::./head-wasm32-unknown-wasi-full/usr    Map ruby directory
# --mapdir /root::./                                    Map user script directory
# --env BUNDLE_GEMFILE=/root/Gemfile                    Tell bundler where the Gemfile located because WASI has no PWD concept
wasmtime run \
  --mapdir /usr::./head-wasm32-unknown-wasi-full/usr \
  --mapdir /root::./ \
  --env BUNDLE_GEMFILE=/root/Gemfile \
  head-wasm32-unknown-wasi-full/usr/local/bin/ruby -- /root/my_app.rb
/usr/local/lib/ruby/3.2.0+1/rubygems/user_interaction.rb:621:in `initialize': Capabilities insufficient @ rb_sysopen - /dev/null (Errno::ENOTCAPABLE)
        from /usr/local/lib/ruby/3.2.0+1/rubygems/user_interaction.rb:621:in `open'
        from /usr/local/lib/ruby/3.2.0+1/rubygems/user_interaction.rb:621:in `initialize'
        from /usr/local/lib/ruby/3.2.0+1/bundler/ui/rg_proxy.rb:11:in `initialize'
        from /usr/local/lib/ruby/3.2.0+1/bundler.rb:91:in `new'
        from /usr/local/lib/ruby/3.2.0+1/bundler.rb:91:in `ui='
        from /usr/local/lib/ruby/3.2.0+1/bundler.rb:87:in `ui'
        from /usr/local/lib/ruby/3.2.0+1/bundler/setup.rb:10:in `<top (required)>'
        from <internal:/usr/local/lib/ruby/3.2.0+1/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from <internal:/usr/local/lib/ruby/3.2.0+1/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from /root/my_app.rb:2:in `<main>'
```

If you add `--mapdir /dev::/dev` option to wasmtime command as a workaround, it runs expectedly.

## What is your fix for the problem, implemented in this PR?

This patch removes the use of `/dev/null` in `Gem::SilentUI` to avoid the workaround.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
