### PR TITLE
Fix misleading error if compact index cannot be copied

### DIFF
--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -163,6 +163,25 @@ The checksum of /versions does not match the checksum provided by the server! So
     expect(the_bundle).to include_gems "rack 1.0.0"
   end
 
+  it "shows proper path when permission errors happen", :permissions do
+    gemfile <<-G
+      source "#{source_uri}"
+      gem "rack"
+    G
+
+    versions = File.join(Bundler.rubygems.user_home, ".bundle", "cache", "compact_index",
+      "localgemserver.test.80.dd34752a738ee965a2a4298dc16db6c5", "versions")
+    FileUtils.mkdir_p(File.dirname(versions))
+    FileUtils.touch(versions)
+    FileUtils.chmod("-r", versions)
+
+    bundle :install, :artifice => "compact_index", :raise_on_error => false
+
+    expect(err).to include(
+      "There was an error while trying to read from `#{versions}`. It is likely that you need to grant read permissions for that path."
+    )
+  end
+
   it "falls back when the user's home directory does not exist or is not writable" do
     ENV["HOME"] = tmp("missing_home").to_s
 


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

Previously if `~/.bundle/cache/compact_index/rubygems.org.*/version`
were owned by root with read-only access, `bundle install` would fail
with a misleading error message. For example:

```
There was an error while trying to write to `/tmp/bundler-compact-index-20220711-1823-npllre/versions`. It is
likely that you need to grant write permissions for that path.
```

This happened because the EACCESS error was caught by
`SharedHelpers.filesystem_access`, which makes it look like the target
directory is at fault instead of the source.

## What is your fix for the problem, implemented in this PR?

Dropping this guard appears to make `bundle install` report the right
error:

<details>
<pre>
Bundler::PermissionError: There was an error while trying to read from `/home/git/.bundle/cache/compact_index/rubygems.org.443.29b0360b937aa4d161703e6160654e47/versions`. It is likely that you need to grant read permissions for that path.
/usr/local/lib/ruby/site_ruby/2.7.0/bundler/shared_helpers.rb:105:in `rescue in filesystem_access'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/shared_helpers.rb:102:in `filesystem_access'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/compact_index_client/cache.rb:83:in `lines'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/compact_index_client/cache.rb:55:in `checksums'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/compact_index_client.rb:80:in `update_and_parse_checksums!'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/fetcher/compact_index.rb:70:in `available?'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/fetcher/compact_index.rb:16:in `call'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/fetcher/compact_index.rb:16:in `block in compact_index_request'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/fetcher.rb:162:in `use_api'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/source/rubygems.rb:431:in `block in api_fetchers'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/source/rubygems.rb:431:in `select'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/source/rubygems.rb:431:in `api_fetchers'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/source/rubygems.rb:436:in `block in remote_specs'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/index.rb:9:in `build'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/source/rubygems.rb:435:in `remote_specs'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/source/rubygems.rb:131:in `specs'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/resolver.rb:169:in `index_for'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/resolver.rb:177:in `results_for'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/resolver.rb:114:in `search_for'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/resolver.rb:255:in `block in verify_gemfile_dependencies_are_found!'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/resolver.rb:252:in `map!'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/resolver.rb:252:in `verify_gemfile_dependencies_are_found!'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/resolver.rb:50:in `start'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/resolver.rb:24:in `resolve'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/definition.rb:269:in `resolve'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/definition.rb:181:in `resolve_remotely!'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/installer.rb:271:in `resolve_if_needed'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/installer.rb:82:in `block in run'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/process_lock.rb:19:in `rescue in lock'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/process_lock.rb:15:in `lock'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/installer.rb:71:in `run'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/installer.rb:23:in `install'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/cli/install.rb:62:in `run'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/cli.rb:255:in `block in install'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/settings.rb:131:in `temporary'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/cli.rb:254:in `install'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/cli.rb:31:in `dispatch'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/cli.rb:25:in `start'
  /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.3.17/exe/bundle:48:in `block in <top (required)>'
  /usr/local/lib/ruby/site_ruby/2.7.0/bundler/friendly_errors.rb:120:in `with_friendly_errors'
  /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.3.17/exe/bundle:36:in `<top (required)>'
  /usr/local/bin/bundle:25:in `load'
  /usr/local/bin/bundle:25:in `<main>'
</pre>
</details>

We can't simply drop this guard because that causes the opposite
problem: the permission error appears to come from the the source
instead of the target, since `CompactIndexClient::Cache#lines` also
wraps read access errors.

Instead, we attempt a read of the source so that we can raise the
proper error.

Closes #5707

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
