### PR TITLE
Changelogs for RubyGems 3.3.18 and Bundler 2.3.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 3.3.18 / 2022-07-13
+
+## Enhancements:
+
+* Make platform `universal-mingw32` match "x64-mingw-ucrt". Pull request
+  #5655 by johnnyshields
+* Add more descriptive messages when `gem update` fails to update some
+  gems. Pull request #5676 by brianleshopify
+* Installs bundler 2.3.18 as a default gem.
+
+## Bug fixes:
+
+* Make sure RubyGems prints no warnings when loading plugins. Pull request
+  #5607 by deivid-rodriguez
+
 # 3.3.17 / 2022-06-29
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,23 @@
+# 2.3.18 (July 13, 2022)
+
+## Enhancements:
+
+  - Extend `gem` DSL with a `force_ruby_platform` option [#4049](https://github.com/rubygems/rubygems/pull/4049)
+
+## Bug fixes:
+
+  - Fix TruffleRuby no longer able to install lockfiles generated with other implementations [#5711](https://github.com/rubygems/rubygems/pull/5711)
+  - Fix TruffleRuby no longer installing lockfiles using "ruby" platform correctly [#5694](https://github.com/rubygems/rubygems/pull/5694)
+  - Fix crash when updating vendor cache of default gems [#5679](https://github.com/rubygems/rubygems/pull/5679)
+
+## Performance:
+
+  - Speed up `bundler/setup` by using the raw `Gemfile.lock` information without extra processing whenever possible [#5695](https://github.com/rubygems/rubygems/pull/5695)
+
+## Documentation:
+
+  - Use modern style hashes in Gemfile DSL docs [#5674](https://github.com/rubygems/rubygems/pull/5674)
+
 # 2.3.17 (June 29, 2022)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.3.18 and Bundler 2.3.18 into master.