### PR TITLE
Fix `gem update --system` crash while regenerating binstubs

### DIFF
--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -365,10 +365,11 @@ By default, this RubyGems will install gem as:
 
     bundler_spec = Dir.chdir("bundler") { Gem::Specification.load("bundler.gemspec") }
 
-    # Remove bundler-*.gemspec in default specification directory.
-    Dir.entries(specs_dir).
-      select {|gs| gs.start_with?("bundler-") }.
-      each {|gs| File.delete(File.join(specs_dir, gs)) }
+    current_default_spec = Gem::Specification.default_stubs.find {|s| s.name == "bundler" }
+    if current_default_spec
+      File.delete(current_default_spec.loaded_from)
+      Gem::Specification.remove_spec current_default_spec
+    end
 
     default_spec_path = File.join(specs_dir, "#{bundler_spec.full_name}.gemspec")
     Gem.write_binary(default_spec_path, bundler_spec.to_ruby)

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -898,6 +898,15 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   ##
+  # Removes +spec+ from the known specs.
+
+  def self.remove_spec(spec)
+    _all.delete spec.to_spec
+    stubs.delete spec
+    (@@stubs_by_name[spec.name] || []).delete spec
+  end
+
+  ##
   # Returns all specifications. This method is discouraged from use.
   # You probably want to use one of the Enumerable methods instead.
 


### PR DESCRIPTION



## What was the end-user or developer problem that led to this PR?

When I was about to release, I found a little regression in `gem update --system` (I say little because even if it crashes, everything upgrades fine except that binstubs are not properly regenerated).

Since a few commits ago, we no longer call `Gem::Specification.reset` after each invocation of `Gem::Installer#install`. This means we don't call it when the default Bundler is installed during `gem update --system`. This causes no issues until the end of the upgrade process when:

* The previous default Bundler spec is removed from disk.
* All specification stubs are turned into real specifications by loading
  them from disk. But the one for Bundler no longer exists so
  materializes to `nil` and regenerating binstubs crashes like this:

  ```
  Bundler 2.4.0.dev installed
  RubyGems 3.4.0.dev installed
  Regenerating binstubs
  ERROR:  While executing gem ... (NoMethodError)
      undefined method `platform' for nil:NilClass
    /Users/deivid/Code/rubygems/rubygems/lib/rubygems/commands/pristine_command.rb:116:in `block in execute'
    /Users/deivid/Code/rubygems/rubygems/lib/rubygems/specification.rb:981:in `block in each'
    /Users/deivid/Code/rubygems/rubygems/lib/rubygems/specification.rb:980:in `each'
    /Users/deivid/Code/rubygems/rubygems/lib/rubygems/specification.rb:980:in `each'
    /Users/deivid/Code/rubygems/rubygems/lib/rubygems/commands/pristine_command.rb:116:in `map'
    /Users/deivid/Code/rubygems/rubygems/lib/rubygems/commands/pristine_command.rb:116:in `each'
    /Users/deivid/Code/rubygems/rubygems/lib/rubygems/commands/pristine_command.rb:116:in `select'
    /Users/deivid/Code/rubygems/rubygems/lib/rubygems/commands/pristine_command.rb:116:in `execute'
    /Users/deivid/Code/rubygems/rubygems/lib/rubygems/command.rb:323:in `invoke_with_build_args'
    /Users/deivid/Code/rubygems/rubygems/lib/rubygems/command.rb:301:in `invoke'
    /Users/deivid/Code/rubygems/rubygems/lib/rubygems/commands/setup_command.rb:604:in `regenerate_binstubs'
    /Users/deivid/Code/rubygems/rubygems/lib/rubygems/commands/setup_command.rb:183:in `execute'
    /Users/deivid/Code/rubygems/rubygems/lib/rubygems/command.rb:323:in `invoke_with_build_args'
    /Users/deivid/Code/rubygems/rubygems/lib/rubygems/command_manager.rb:185:in `process_args'
    /Users/deivid/Code/rubygems/rubygems/lib/rubygems/command_manager.rb:149:in `run'
    /Users/deivid/Code/rubygems/rubygems/lib/rubygems/gem_runner.rb:51:in `run'
  setup.rb:33:in `<main>'
  ```

## What is your fix for the problem, implemented in this PR?

My fix is to more carefully managing the removal of the previous default Bundler gem.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
