### PR TITLE
Use https protocol for URLs for config mirror in bundler man

### DIFF
--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -342,13 +342,13 @@ bundle config set \-\-global mirror\.SOURCE_URL MIRROR_URL
 .IP "" 0
 .
 .P
-For example, to use a mirror of rubygems\.org hosted at rubygems\-mirror\.org:
+For example, to use a mirror of https://rubygems\.org hosted at https://example\.org:
 .
 .IP "" 4
 .
 .nf
 
-bundle config set \-\-global mirror\.http://rubygems\.org http://rubygems\-mirror\.org
+bundle config set \-\-global mirror\.https://rubygems\.org https://example\.org
 .
 .fi
 .

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -321,9 +321,9 @@ mirror to fetch gems.
 
     bundle config set --global mirror.SOURCE_URL MIRROR_URL
 
-For example, to use a mirror of rubygems.org hosted at rubygems-mirror.org:
+For example, to use a mirror of https://rubygems.org hosted at https://example.org:
 
-    bundle config set --global mirror.http://rubygems.org http://rubygems-mirror.org
+    bundle config set --global mirror.https://rubygems.org https://example.org
 
 Each mirror also provides a fallback timeout setting. If the mirror does not
 respond within the fallback timeout, Bundler will try to use the original


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When a user follows the instructions in [Bundler's man: `bundle config`](https://bundler.io/man/bundle-config.1.html#MIRRORS-OF-GEM-SOURCES), `bundle config set --global mirror.http://rubygems.org http://rubygems-mirror.org` looks changing the mirror, but actually does not with RubyGems 3.3 (= latest) through 2.0.3.

It also suggests users to make access to a potential third-party domain <rubygems-mirror.org>.

## What is your fix for the problem, implemented in this PR?

Use `https` protocol instead of `http` for URLs for config mirror in [Bundler's man: `bundle config`](https://bundler.io/man/bundle-config.1.html#MIRRORS-OF-GEM-SOURCES) as per fae84e56552bf1e4e063ce381924c4c38a2cd1f9.
Also example.org is used mirror URL as an example, not to make access to a potential third-party domain.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [n/a] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [n/a] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)
