### PR TITLE
RubyGems: fix wrong information about default RubyGems source

### DIFF
--- a/lib/rubygems/commands/sources_command.rb
+++ b/lib/rubygems/commands/sources_command.rb
@@ -138,8 +138,8 @@ do not recognize you should remove them.
 RubyGems has been configured to serve gems via the following URLs through
 its history:
 
-* http://gems.rubyforge.org (RubyGems 1.3.6 and earlier)
-* https://rubygems.org/       (RubyGems 1.3.7 through 1.8.25)
+* http://gems.rubyforge.org (RubyGems 1.3.5 and earlier)
+* http://rubygems.org       (RubyGems 1.3.6 through 1.8.30, and 2.0.0)
 * https://rubygems.org      (RubyGems 2.0.1 and newer)
 
 Since all of these sources point to the same set of gems you only need one


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The default RubyGems source per versions available in [the command references of RubyGems](https://guides.rubygems.org/command-reference/#gem-sources) are incorrect.

## What is your fix for the problem, implemented in this PR?

Fixes incorrect information about the default RubyGems source per versions.

1. RubyGems 1.3.6 changed from rubyforge to rubygems.org.
   - https://my.diffend.io/gems/rubygems-update/1.3.5/1.3.6/page/4#d2h-514986
1. RubyGems 1.8.29-1.8.30 and 2.0.0 are added
   - https://my.diffend.io/gems/rubygems-update/2.0.0/2.0.2/page/2#d2h-514986
1. Reverts unintentional regression from #3056

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [n/a] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [n/a] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>
