### PR TITLE
Show a proper error if extension dir is not writable

### DIFF
--- a/bundler/lib/bundler/rubygems_gem_installer.rb
+++ b/bundler/lib/bundler/rubygems_gem_installer.rb
@@ -67,7 +67,7 @@ module Bundler
     def build_extensions
       extension_cache_path = options[:bundler_extension_cache_path]
       unless extension_cache_path && extension_dir = spec.extension_dir
-        require "shellwords" unless Bundler.rubygems.provides?(">= 3.2.25")
+        prepare_extension_build
         return super
       end
 
@@ -79,7 +79,7 @@ module Bundler
           FileUtils.cp_r extension_cache_path, spec.extension_dir
         end
       else
-        require "shellwords" # compensate missing require in rubygems before version 3.2.25
+        prepare_extension_build
         super
         SharedHelpers.filesystem_access(extension_cache_path.parent, &:mkpath)
         SharedHelpers.filesystem_access(extension_cache_path) do
@@ -97,6 +97,10 @@ module Bundler
     end
 
     private
+
+    def prepare_extension_build
+      require "shellwords" unless Bundler.rubygems.provides?(">= 3.2.25")
+    end
 
     def strict_rm_rf(dir)
       Bundler.rm_rf dir

--- a/bundler/lib/bundler/rubygems_gem_installer.rb
+++ b/bundler/lib/bundler/rubygems_gem_installer.rb
@@ -25,7 +25,7 @@ module Bundler
 
       extract_files
 
-      build_extensions
+      build_extensions if spec.extensions.any?
       write_build_info_file
       run_post_build_hooks
 
@@ -81,11 +81,9 @@ module Bundler
       else
         require "shellwords" # compensate missing require in rubygems before version 3.2.25
         super
-        if extension_dir.directory? # not made for gems without extensions
-          SharedHelpers.filesystem_access(extension_cache_path.parent, &:mkpath)
-          SharedHelpers.filesystem_access(extension_cache_path) do
-            FileUtils.cp_r extension_dir, extension_cache_path
-          end
+        SharedHelpers.filesystem_access(extension_cache_path.parent, &:mkpath)
+        SharedHelpers.filesystem_access(extension_cache_path) do
+          FileUtils.cp_r extension_dir, extension_cache_path
         end
       end
     end

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -723,6 +723,36 @@ RSpec.describe "bundle install with gem sources" do
     end
   end
 
+  describe "when bundle extensions path does not have write access", :permissions do
+    let(:extensions_path) { bundled_app("vendor/#{Bundler.ruby_scope}/extensions/#{Gem::Platform.local}/#{Gem.extension_api_version}") }
+
+    before do
+      FileUtils.mkdir_p(extensions_path)
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem 'simple_binary'
+      G
+    end
+
+    it "should display a proper message to explain the problem" do
+      FileUtils.chmod("-x", extensions_path)
+      bundle "config set --local path vendor"
+
+      begin
+        bundle :install, :raise_on_error => false
+      ensure
+        FileUtils.chmod("+x", extensions_path)
+      end
+
+      expect(err).not_to include("ERROR REPORT TEMPLATE")
+
+      expect(err).to include(
+        "There was an error while trying to create `#{extensions_path.join("simple_binary-1.0")}`. " \
+        "It is likely that you need to grant executable permissions for all parent directories and write permissions for `#{extensions_path}`."
+      )
+    end
+  end
+
   describe "when the path of a specific gem is not writable", :permissions do
     let(:gems_path) { bundled_app("vendor/#{Bundler.ruby_scope}/gems") }
     let(:foo_path) { gems_path.join("foo-1.0.0") }


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When installing a gem with extensions, if the extensions directory is not writable, Bundler will print the bug report template which tells the user to report a bug to Bundler. But this is not a Bundler bug, so we should instead give a better error that explains the issue and how to fix it, and does not tell the user to report a bug to us.

## What is your fix for the problem, implemented in this PR?

My fix is to wrap the creation of the folder that fails to be created with `SharedHelpers.filesystem_access` which already includes logic to do this.

This PR is equivalent to https://github.com/rubygems/rubygems/pull/4965, but for the extensions directory.

Closes #5721.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
