### PR TITLE
Fix upgrading RubyGems with a customized `Gem.default_dir`

### DIFF
--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -228,6 +228,24 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     assert_path_exist "#{Gem.dir}/gems/bundler-audit-1.0.0"
   end
 
+  def test_install_default_bundler_gem_with_default_gems_not_installed_at_default_dir
+    @cmd.extend FileUtils
+
+    gemhome2 = File.join(@tempdir, 'gemhome2')
+    Gem.instance_variable_set(:@default_dir, gemhome2)
+
+    FileUtils.mkdir_p gemhome2
+    bin_dir = File.join(gemhome2, 'bin')
+
+    @cmd.install_default_bundler_gem bin_dir
+
+    default_dir = Gem.default_specifications_dir
+
+    # expect to remove other versions of bundler gemspecs on default specification directory.
+    assert_path_not_exist File.join(default_dir, "bundler-1.15.4.gemspec")
+    assert_path_exist File.join(default_dir, "bundler-#{BUNDLER_VERS}.gemspec")
+  end
+
   def test_install_default_bundler_gem_with_force_flag
     @cmd.extend FileUtils
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

People upgrading their OS installation through `gem update --system` is getting a broken default bundler installation after upgrading.

Does this is NOT supported. However, fixing it allows to simplify some code and breaking whatever was working was not intentional so I'll fix it.

## What is your fix for the problem, implemented in this PR?

This is to look at the currently loaded default bundler specs, if it's there. If it's there, that's the place where we need to install the updated spec.

Fixes #5727.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
