### PR TITLE
bundler: fix typo in inline RuboCop config

### DIFF
--- a/bundler/spec/support/hax.rb
+++ b/bundler/spec/support/hax.rb
@@ -15,7 +15,7 @@ module Gem
   end
 
   if ENV["BUNDLER_SPEC_WINDOWS"]
-    @@win_platform = true # rubocop:disable Sryle/ClassVars
+    @@win_platform = true # rubocop:disable Style/ClassVars
   end
 
   if ENV["BUNDLER_SPEC_PLATFORM"]


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

A developer of Bundler (or even RubyGems) would get the following warning with `$ rake rubocop` or `$ bundler/bin/rubocop` (or more precisely `cd bundler; rubocop --config ../.rubocop_bundler.yml`):

```
$ bundler/bin/rubocop
Inspecting 396 files
........................................................................................................................................................................................................................................................................................................................................................................bundler/spec/support/hax.rb: Sryle/ClassVars has the wrong namespace - should be Style
....................................

396 files inspected, no offenses detected
```
(Note: make sure you clean up cache by `rm -rf bundler/tmp/rubocop`. Otherwise 2nd execution results no warnings any more.)

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [n/a] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [n/a] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)