### PR TITLE
Fix `ruby setup.rb` with `--destdir` writing outside of `--destdir`

### DIFF
--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -361,16 +361,16 @@ By default, this RubyGems will install gem as:
 
   def install_default_bundler_gem(bin_dir)
     current_default_spec = Gem::Specification.default_stubs.find {|s| s.name == "bundler" }
-    specs_dir = if current_default_spec
+    specs_dir = if current_default_spec && default_dir == Gem.default_dir
       Gem::Specification.remove_spec current_default_spec
       loaded_from = current_default_spec.loaded_from
       File.delete(loaded_from)
       File.dirname(loaded_from)
     else
-      File.join(default_dir, "specifications", "default")
+      target_specs_dir = File.join(default_dir, "specifications", "default")
+      mkdir_p target_specs_dir, :mode => 0755
+      target_specs_dir
     end
-
-    mkdir_p specs_dir, :mode => 0755
 
     bundler_spec = Dir.chdir("bundler") { Gem::Specification.load("bundler.gemspec") }
     default_spec_path = File.join(specs_dir, "#{bundler_spec.full_name}.gemspec")

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -279,6 +279,14 @@ class TestGemCommandsSetupCommand < Gem::TestCase
 
     @cmd.install_default_bundler_gem bin_dir
 
+    # leaves other versions of bundler gemspecs on default specification directory.
+    assert_path_exist previous_bundler_specification_path
+    assert_path_not_exist new_bundler_specification_path
+
+    # installs the updated bundler gemspec to destdir
+    assert_path_not_exist prepend_destdir(destdir, previous_bundler_specification_path)
+    assert_path_exist prepend_destdir(destdir, new_bundler_specification_path)
+
     bundler_spec.executables.each do |e|
       assert_path_exist prepend_destdir(destdir, File.join(@gemhome, 'gems', bundler_spec.full_name, bundler_spec.bindir, e))
     end

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -54,7 +54,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     spec_fetcher do |fetcher|
       fetcher.download "bundler", "1.15.4"
 
-      fetcher.gem "bundler", BUNDLER_VERS
+      fetcher.gem "bundler", bundler_version
 
       fetcher.gem "bundler-audit", "1.0.0"
     end
@@ -164,10 +164,8 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     @cmd.options[:destdir] = destdir
     @cmd.execute
 
-    spec = Gem::Specification.load("bundler/bundler.gemspec")
-
-    spec.executables.each do |e|
-      assert_path_exist File.join destdir, @gemhome.gsub(/^[a-zA-Z]:/, ''), 'gems', spec.full_name, spec.bindir, e
+    bundler_spec.executables.each do |e|
+      assert_path_exist File.join destdir, @gemhome.gsub(/^[a-zA-Z]:/, ''), 'gems', bundler_spec.full_name, bundler_spec.bindir, e
     end
   end
 
@@ -199,7 +197,6 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     bin_dir = File.join(@gemhome, 'bin')
     @cmd.install_default_bundler_gem bin_dir
 
-    bundler_spec = Gem::Specification.load("bundler/bundler.gemspec")
     default_spec_path = File.join(Gem.default_specifications_dir, "#{bundler_spec.full_name}.gemspec")
     spec = Gem::Specification.load(default_spec_path)
 
@@ -219,9 +216,9 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     assert_path_exist File.join(Gem.dir, "specifications", "bundler-audit-1.0.0.gemspec")
 
     # expect to remove normal gem that was same version. because it's promoted default gems.
-    assert_path_not_exist File.join(Gem.dir, "specifications", "bundler-#{BUNDLER_VERS}.gemspec")
+    assert_path_not_exist File.join(Gem.dir, "specifications", "bundler-#{bundler_version}.gemspec")
 
-    assert_path_exist "#{Gem.dir}/gems/bundler-#{BUNDLER_VERS}"
+    assert_path_exist "#{Gem.dir}/gems/bundler-#{bundler_version}"
     assert_path_exist "#{Gem.dir}/gems/bundler-1.15.4"
     assert_path_exist "#{Gem.dir}/gems/bundler-audit-1.0.0"
   end
@@ -258,7 +255,6 @@ class TestGemCommandsSetupCommand < Gem::TestCase
 
     @cmd.install_default_bundler_gem bin_dir
 
-    bundler_spec = Gem::Specification.load("bundler/bundler.gemspec")
     default_spec_path = File.join(Gem.default_specifications_dir, "#{bundler_spec.full_name}.gemspec")
     spec = Gem::Specification.load(default_spec_path)
 
@@ -283,10 +279,8 @@ class TestGemCommandsSetupCommand < Gem::TestCase
 
     @cmd.install_default_bundler_gem bin_dir
 
-    spec = Gem::Specification.load("bundler/bundler.gemspec")
-
-    spec.executables.each do |e|
-      assert_path_exist File.join destdir, @gemhome.gsub(/^[a-zA-Z]:/, ''), 'gems', spec.full_name, spec.bindir, e
+    bundler_spec.executables.each do |e|
+      assert_path_exist File.join destdir, @gemhome.gsub(/^[a-zA-Z]:/, ''), 'gems', bundler_spec.full_name, bundler_spec.bindir, e
     end
   ensure
     FileUtils.chmod "+w", @gemhome
@@ -303,10 +297,8 @@ class TestGemCommandsSetupCommand < Gem::TestCase
 
     @cmd.install_default_bundler_gem bin_dir
 
-    spec = Gem::Specification.load("bundler/bundler.gemspec")
-
-    spec.executables.each do |e|
-      assert_path_exist File.join destdir, 'gems', spec.full_name, spec.bindir, e
+    bundler_spec.executables.each do |e|
+      assert_path_exist File.join destdir, 'gems', bundler_spec.full_name, bundler_spec.bindir, e
     end
   end
 
@@ -464,6 +456,14 @@ class TestGemCommandsSetupCommand < Gem::TestCase
   end
 
   def new_bundler_specification_path
-    File.join(Gem.default_specifications_dir, "bundler-#{BUNDLER_VERS}.gemspec")
+    File.join(Gem.default_specifications_dir, "bundler-#{bundler_version}.gemspec")
+  end
+
+  def bundler_spec
+    Gem::Specification.load("bundler/bundler.gemspec")
+  end
+
+  def bundler_version
+    bundler_spec.version
   end
 end unless Gem.java_platform?

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -165,7 +165,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     @cmd.execute
 
     bundler_spec.executables.each do |e|
-      assert_path_exist File.join destdir, @gemhome.gsub(/^[a-zA-Z]:/, ''), 'gems', bundler_spec.full_name, bundler_spec.bindir, e
+      assert_path_exist prepend_destdir(destdir, File.join(@gemhome, 'gems', bundler_spec.full_name, bundler_spec.bindir, e))
     end
   end
 
@@ -280,7 +280,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     @cmd.install_default_bundler_gem bin_dir
 
     bundler_spec.executables.each do |e|
-      assert_path_exist File.join destdir, @gemhome.gsub(/^[a-zA-Z]:/, ''), 'gems', bundler_spec.full_name, bundler_spec.bindir, e
+      assert_path_exist prepend_destdir(destdir, File.join(@gemhome, 'gems', bundler_spec.full_name, bundler_spec.bindir, e))
     end
   ensure
     FileUtils.chmod "+w", @gemhome
@@ -465,5 +465,9 @@ class TestGemCommandsSetupCommand < Gem::TestCase
 
   def bundler_version
     bundler_spec.version
+  end
+
+  def prepend_destdir(destdir, path)
+    File.join(destdir, path.gsub(/^[a-zA-Z]:/, ''))
   end
 end unless Gem.java_platform?

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -211,11 +211,9 @@ class TestGemCommandsSetupCommand < Gem::TestCase
       assert_path_exist File.join bin_dir, e
     end
 
-    default_dir = Gem.default_specifications_dir
-
     # expect to remove other versions of bundler gemspecs on default specification directory.
-    assert_path_not_exist File.join(default_dir, "bundler-1.15.4.gemspec")
-    assert_path_exist File.join(default_dir, "bundler-#{BUNDLER_VERS}.gemspec")
+    assert_path_not_exist previous_bundler_specification_path
+    assert_path_exist new_bundler_specification_path
 
     # expect to not remove bundler-* gemspecs.
     assert_path_exist File.join(Gem.dir, "specifications", "bundler-audit-1.0.0.gemspec")
@@ -239,11 +237,9 @@ class TestGemCommandsSetupCommand < Gem::TestCase
 
     @cmd.install_default_bundler_gem bin_dir
 
-    default_dir = Gem.default_specifications_dir
-
     # expect to remove other versions of bundler gemspecs on default specification directory.
-    assert_path_not_exist File.join(default_dir, "bundler-1.15.4.gemspec")
-    assert_path_exist File.join(default_dir, "bundler-#{BUNDLER_VERS}.gemspec")
+    assert_path_not_exist previous_bundler_specification_path
+    assert_path_exist new_bundler_specification_path
   end
 
   def test_install_default_bundler_gem_with_force_flag
@@ -461,5 +457,13 @@ class TestGemCommandsSetupCommand < Gem::TestCase
 
   def default_bundler_bin_path
     File.join RbConfig::CONFIG['bindir'], 'bundler'
+  end
+
+  def previous_bundler_specification_path
+    File.join(Gem.default_specifications_dir, "bundler-1.15.4.gemspec")
+  end
+
+  def new_bundler_specification_path
+    File.join(Gem.default_specifications_dir, "bundler-#{BUNDLER_VERS}.gemspec")
   end
 end unless Gem.java_platform?


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I found this bug while working on #5728. When using the `--destdir` option for a RubyGems upgrade, Bundler specification files will be added/removed outside of `--destdir`.

## What is your fix for the problem, implemented in this PR?

If `--destdir` is passed, the currently loaded Bundler specification should never be considered, and we should always work on "destdir-aware" directories.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
