### PR TITLE
Require fileutils more lazily when installing gems

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -442,8 +442,6 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     old_umask = File.umask
     File.umask old_umask | 002
 
-    require 'fileutils'
-
     options = {}
 
     options[:mode] = mode if mode
@@ -451,6 +449,9 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     subdirs.each do |name|
       subdir = File.join dir, name
       next if File.exist? subdir
+
+      require 'fileutils'
+
       begin
         FileUtils.mkdir_p subdir, **options
       rescue SystemCallError


### PR DESCRIPTION
If directories are already created (the common case), fileutils won't be
required at all.


## What was the end-user or developer problem that led to this PR?

A flaky test failure, here: https://github.com/rubygems/rubygems/runs/7388366239?check_suite_focus=true.

The error reads like this:

```
#<Thread:0x00007fe586647bc0 /Users/runner/work/rubygems/rubygems/lib/rubygems/request_set.rb:167 run> terminated with exception (report_on_exception is true):
/Users/runner/work/rubygems/rubygems/lib/rubygems/core_ext/kernel_require.rb:167:in `require': CRITICAL: RUBYGEMS_ACTIVATION_MONITOR.owned?: before false -> after false (RuntimeError)
  from /Users/runner/work/rubygems/rubygems/lib/rubygems.rb:445:in `ensure_subdirectories'
  from /Users/runner/work/rubygems/rubygems/lib/rubygems.rb:425:in `ensure_gem_subdirectories'
.......................E
  from /Users/runner/work/rubygems/rubygems/lib/rubygems/resolver/specification.rb:110:in `download'
===============================================================================
  from /Users/runner/work/rubygems/rubygems/lib/rubygems/request_set.rb:173:in `block (2 levels) in install'
Error: test_install_from_gemdeps_lockfile(TestGemRequestSet): RuntimeError: CRITICAL: RUBYGEMS_ACTIVATION_MONITOR.owned?: before false -> after false
/Users/runner/work/rubygems/rubygems/lib/rubygems/core_ext/kernel_require.rb:167:in `require'
/Users/runner/work/rubygems/rubygems/lib/rubygems.rb:445:in `ensure_subdirectories'
/Users/runner/work/rubygems/rubygems/lib/rubygems.rb:425:in `ensure_gem_subdirectories'
/Users/runner/work/rubygems/rubygems/lib/rubygems/resolver/specification.rb:110:in `download'
/Users/runner/work/rubygems/rubygems/lib/rubygems/request_set.rb:173:in `block (2 levels) in install'
===============================================================================
...............................................................................
```

## What is your fix for the problem, implemented in this PR?

I'm not sure of the underlying culprit, but requiring `fileutils` more lazily seems like an easy change that might fix it.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
