### PR TITLE
Bundler: change error/warning message for multiple global sources

### DIFF
--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -465,12 +465,12 @@ module Bundler
 
     def multiple_global_source_warning
       if Bundler.feature_flag.bundler_3_mode?
-        msg = "This Gemfile contains multiple primary sources. " \
+        msg = "This Gemfile contains multiple global sources. " \
           "Each source after the first must include a block to indicate which gems " \
           "should come from that source"
         raise GemfileEvalError, msg
       else
-        Bundler::SharedHelpers.major_deprecation 2, "Your Gemfile contains multiple primary sources. " \
+        Bundler::SharedHelpers.major_deprecation 2, "Your Gemfile contains multiple global sources. " \
           "Using `source` more than once without a block is a security risk, and " \
           "may result in installing unexpected gems. To resolve this warning, use " \
           "a block to indicate which gems should come from the secondary source."

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -414,7 +414,7 @@ RSpec.describe "major deprecations" do
 
     it "shows a deprecation", :bundler => "< 3" do
       expect(deprecations).to include(
-        "Your Gemfile contains multiple primary sources. " \
+        "Your Gemfile contains multiple global sources. " \
         "Using `source` more than once without a block is a security risk, and " \
         "may result in installing unexpected gems. To resolve this warning, use " \
         "a block to indicate which gems should come from the secondary source."
@@ -425,7 +425,7 @@ RSpec.describe "major deprecations" do
       bundle "install"
 
       expect(deprecations).to include(
-        "Your Gemfile contains multiple primary sources. " \
+        "Your Gemfile contains multiple global sources. " \
         "Using `source` more than once without a block is a security risk, and " \
         "may result in installing unexpected gems. To resolve this warning, use " \
         "a block to indicate which gems should come from the secondary source."
@@ -438,7 +438,7 @@ RSpec.describe "major deprecations" do
       bundle "install"
 
       expect(deprecations).to include(
-        "Your Gemfile contains multiple primary sources. " \
+        "Your Gemfile contains multiple global sources. " \
         "Using `source` more than once without a block is a security risk, and " \
         "may result in installing unexpected gems. To resolve this warning, use " \
         "a block to indicate which gems should come from the secondary source."


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Error/warning messages when multiple global (primary) sources are specified include "multiple primary sources", which is different from [the man 5 gemfile](https://bundler.io/man/gemfile.5.html).

## What is your fix for the problem, implemented in this PR?

Replaces "multiple primary sources" in error/warning messages with "multiple global sources".

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)