### PR TITLE
Fix casing typo when resetting `RbConfig::CONFIG["ENABLE_SHARED"]` in tests

### DIFF
--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -171,9 +171,9 @@ class Gem::TestCase < Test::Unit::TestCase
     yield
   ensure
     if enable_shared
-      RbConfig::CONFIG['enable_shared'] = enable_shared
+      RbConfig::CONFIG['ENABLE_SHARED'] = enable_shared
     else
-      RbConfig::CONFIG.delete 'enable_shared'
+      RbConfig::CONFIG.delete 'ENABLE_SHARED'
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Failures when CI running on #4017 that were not happening locally.

## What is your fix for the problem, implemented in this PR?

The problem was that previous tests were failing to reset `RbConfig::CONFIG["ENABLE_SHARED"]`, so tests would fail depending on order.

Use the proper casing for the configuration.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
