### PR TITLE
Fix yet another TruffleRuby platform selection regression

### DIFF
--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -84,7 +84,7 @@ module Bundler
         else
           ruby_platform_materializes_to_ruby_platform? ? self : Dependency.new(name, version)
         end
-        platform_object = ruby_platform_materializes_to_ruby_platform? ? Gem::Platform.new(platform) : Gem::Platform.local
+        platform_object = ruby_platform_materializes_to_ruby_platform? ? Gem::Platform.new(platform) : Bundler.local_platform
         candidates = source.specs.search(search_object)
         same_platform_candidates = candidates.select do |spec|
           MatchPlatform.platforms_match?(spec.platform, platform_object)

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -94,8 +94,8 @@ module Spec
         end
 
         build_gem "platform_specific" do |s|
-          s.platform = Bundler.local_platform
-          s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0.0 #{Bundler.local_platform}'"
+          s.platform = Gem::Platform.local
+          s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0.0 #{Gem::Platform.local}'"
         end
 
         build_gem "platform_specific" do |s|


### PR DESCRIPTION

## What was the end-user or developer problem that led to this PR?

I got this bug reported before the 2.3.18 release. I reproduced it and confirmed that recent changes in master had already fixed the bug and also that we hada spec testing explicitly this behaviour, but noticed that the bug went uncaught because we were only testing on TruffleRuby 22.0 (the spec did not regress there), not on TruffleRuby 22.1, where the spec did start failing when the regression   was introduced.

So I called the bug fixed and upgraded our CI to use the latest TruffleRuby 22.1.

However, later I noticed another related bug that required reverting some changes aimed for TruffleRuby to fix it. Well, reverting those changes made the bug reappear again, but our spec did not catch it and apparently I did not test it in real life.

The reason the spec did not catch it is that due to how the spec was written, it would not reproduce the original scenario if `Bundler.local_platform` returns "ruby". Because in that case, the most specific variant available of the dummy spec on Linux would be "ruby", so we would no longer be testing the more complicated scenario where a platform specific variant that MUST NOT be chosen. And unfortunately the changes reverted made `Bundler.local_platform` return "ruby" again on TruffleRuby.

## What is your fix for the problem, implemented in this PR?

* Fix the spec to use `Gem::Platform.local` instead of `Bundler.local_platform`, since that always returns the "real specific platform", so that test will always include a platform specific variant.

* Fix the bug with the opposite change in lib, make sure Bundler uses "ruby" as the local platform for TruffleRuby (and thus does not pick platform
specific variants).

Closes #5691.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
