### PR TITLE
CI - windows-rubygems.yml - use x86_64-pc-windows-msvc target for mswin Ruby

### DIFF
--- a/.github/workflows/windows-rubygems.yml
+++ b/.github/workflows/windows-rubygems.yml
@@ -32,17 +32,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby-pkgs@v1
         with:
           ruby-version: ${{ matrix.ruby.value }}
           bundler: none
+          mingw: clang
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.cargo.toolchain }}-${{ matrix.cargo.target }}
           default: true
-      - name: Add missing clang dep for rust-bindgen (see https://github.com/rubygems/rubygems/pull/5175#discussion_r794873977)
-        run: |
-          pacman --sync --noconfirm --needed $ENV:MINGW_PACKAGE_PREFIX-clang
       - name: Print debugging info
         run: |
           echo "RbConfig::MAKEFILE_CONFIG"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Current CI (windows-rubygems.yml) uses `x86_64-pc-windows-gnu` for the Rust/Cargo target for all Windows Rubies.  The mswin build is better tested against the `x86_64-pc-windows-msvc` target, which is the version installed on the Windows images.

## What is your fix for the problem, implemented in this PR?

#### Two commits:

**'windows-rubygems.yml - adjust cargo setup, add Ruby head'** - Fix the above and add Ruby head build to the matrix

**'windows-rubygems.yml - use ruby/setup-ruby-pkgs'** - rather than adding a step to install the MSYS2 clang package, use `ruby/setup-ruby-pkgs`.  This isn't needed here, but it's good practice, as installing packages after `ruby/setup-ruby` can cause problems in workflows that are running `bundle install` in that action.  

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
