### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# .git-blame-ignore-revs
+# RubyGems
+# Enable Style/StringLiterals cop
+dca5fa728437383428a593644f537aaa1020ee63
+# Bundler


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

A code contributor to RubyGems/Bundler can have difficulties to find the past commits via git blame.

Follows up #5731.

## What is your fix for the problem, implemented in this PR?

Creates `.git-blame-ignore-revs` and adds the full commit sha of the commit from #5731.

See https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view .

### before the PR or without `--ignore-revs-file .git-blame-ignore-revs`
```
$ git blame Rakefile | head
4ecbc994b7 Rakefile          (David Rodríguez   2020-05-16 15:33:08 +0200   1) RakeFileUtils.verbose_flag = false
4ecbc994b7 Rakefile          (David Rodríguez   2020-05-16 15:33:08 +0200   2) 
dca5fa7284 Rakefile          (Takuya Noguchi    2022-07-17 08:08:51 +0000   3) require "rubygems"
dca5fa7284 Rakefile          (Takuya Noguchi    2022-07-17 08:08:51 +0000   4) require "rubygems/package_task"
4f26aeeab0 Rakefile          (SHIBATA Hiroshi   2018-01-26 20:45:09 +0900   5) require "rake/testtask"
0c3d9f202b Rakefile          (Eric Hodel        2011-01-31 15:17:04 -0800   6) 
cf87a5ddaf Rakefile          (Luis Sagastume    2018-02-20 16:15:00 -0600   7) desc "Setup Rubygems dev environment"
5d3b6ae20e Rakefile          (David Rodríguez   2020-03-19 20:35:45 +0100   8) task :setup do
1d641c9fa2 Rakefile          (David Rodríguez   2022-01-31 14:26:25 +0100   9)   sh "ruby", "-I", "lib", "bundler/spec/support/bundle.rb", "install", "--gemfile=bundler/tool/bundler/dev_gems.rb"
1d641c9fa2 Rakefile          (David Rodríguez   2022-01-31 14:26:25 +0100  10)   sh "ruby", "-I", "lib", "bundler/spec/support/bundle.rb", "lock", "--gemfile=bundler/tool/bundler/release_gems.rb"
```
### after the PR and with `--ignore-revs-file .git-blame-ignore-revs`
```
$ git blame --ignore-revs-file .git-blame-ignore-revs Rakefile | head
4ecbc994b7 Rakefile          (David Rodríguez   2020-05-16 15:33:08 +0200   1) RakeFileUtils.verbose_flag = false
4ecbc994b7 Rakefile          (David Rodríguez   2020-05-16 15:33:08 +0200   2) 
cf3df74c76 rubygems/Rakefile (Jim Weirich       2003-11-29 22:27:00 +0000   3) require "rubygems"
374c6a2e5c Rakefile          (Eric Hodel        2009-04-07 02:39:44 +0000   4) require "rubygems/package_task"
4f26aeeab0 Rakefile          (SHIBATA Hiroshi   2018-01-26 20:45:09 +0900   5) require "rake/testtask"
0c3d9f202b Rakefile          (Eric Hodel        2011-01-31 15:17:04 -0800   6) 
cf87a5ddaf Rakefile          (Luis Sagastume    2018-02-20 16:15:00 -0600   7) desc "Setup Rubygems dev environment"
5d3b6ae20e Rakefile          (David Rodríguez   2020-03-19 20:35:45 +0100   8) task :setup do
1d641c9fa2 Rakefile          (David Rodríguez   2022-01-31 14:26:25 +0100   9)   sh "ruby", "-I", "lib", "bundler/spec/support/bundle.rb", "install", "--gemfile=bundler/tool/bundler/dev_gems.rb"
1d641c9fa2 Rakefile          (David Rodríguez   2022-01-31 14:26:25 +0100  10)   sh "ruby", "-I", "lib", "bundler/spec/support/bundle.rb", "lock", "--gemfile=bundler/tool/bundler/release_gems.rb"
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [n/a] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)
