### PR TITLE
Use `SystemExit#status` as `exit_code`

### DIFF
--- a/lib/rubygems/exceptions.rb
+++ b/lib/rubygems/exceptions.rb
@@ -221,14 +221,12 @@ class Gem::SystemExitException < SystemExit
   ##
   # The exit code for the process
 
-  attr_accessor :exit_code
+  alias exit_code status
 
   ##
   # Creates a new SystemExitException with the given +exit_code+
 
   def initialize(exit_code)
-    @exit_code = exit_code
-
     super exit_code, "Exiting RubyGems with exit_code #{exit_code}"
   end
 end

--- a/test/rubygems/test_exit.rb
+++ b/test/rubygems/test_exit.rb
@@ -8,4 +8,10 @@ class TestExit < Gem::TestCase
     system(*ruby_with_rubygems_in_load_path, "-e", "raise Gem::SystemExitException.new(2)")
     assert_equal 2, $?.exitstatus
   end
+
+  def test_status
+    exc = Gem::SystemExitException.new(42)
+    assert_equal 42, exc.status
+    assert_equal 42, exc.exit_code
+  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

None, but no reasons to manage `Gem::SystemExitException#exit_code` and `SystemExit#status` separately.

## What is your fix for the problem, implemented in this PR?

Make `exit_code` an alias of `status`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
