### PR TITLE
Remove bundle show from obsolete commands

### DIFF
--- a/bundler/lib/bundler/man/bundle.1
+++ b/bundler/lib/bundler/man/bundle.1
@@ -129,8 +129,5 @@ These commands are obsolete and should no longer be used:
 .IP "\(bu" 4
 \fBbundle cache(1)\fR
 .
-.IP "\(bu" 4
-\fBbundle show(1)\fR
-.
 .IP "" 0
 

--- a/bundler/lib/bundler/man/bundle.1.ronn
+++ b/bundler/lib/bundler/man/bundle.1.ronn
@@ -108,4 +108,3 @@ and execute it, passing down any extra arguments to it.
 These commands are obsolete and should no longer be used:
 
 * `bundle cache(1)`
-* `bundle show(1)`


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

There is `bundle show` in the obsolete subcommand section while we already have `bundle-show`, e.g., https://bundler.io/v2.3/man/bundle-show.1.html.

## What is your fix for the problem, implemented in this PR?

Just remove an entry of `show`. We do not need to move it to Utilities section since we already have one.

Closes #5752

Follows up #4586

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)