### PR TITLE
Bundler: update command example in bundle-exec(1)

### DIFF
--- a/bundler/lib/bundler/man/bundle-exec.1
+++ b/bundler/lib/bundler/man/bundle-exec.1
@@ -155,7 +155,7 @@ You can find a list of all the gems containing gem plugins by running
 .
 .nf
 
-ruby \-rrubygems \-e "puts Gem\.find_files(\'rubygems_plugin\.rb\')"
+ruby \-e "puts Gem\.find_files(\'rubygems_plugin\.rb\')"
 .
 .fi
 .

--- a/bundler/lib/bundler/man/bundle-exec.1.ronn
+++ b/bundler/lib/bundler/man/bundle-exec.1.ronn
@@ -145,7 +145,7 @@ their plugins.
 You can find a list of all the gems containing gem plugins
 by running
 
-    ruby -rrubygems -e "puts Gem.find_files('rubygems_plugin.rb')"
+    ruby -e "puts Gem.find_files('rubygems_plugin.rb')"
 
 At the very least, you should remove all but the newest
 version of each gem plugin, and also remove all gem plugins


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

A user sees the legacy notation while a user do not need to load `rubygems` in Ruby 1.9 or later.

## What is your fix for the problem, implemented in this PR?

Remove the option for loading `rubygems` from `bundle-exec(1)`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)