### PR TITLE
Add `Bundler.settings[:only]` to install gems of the specified groups

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -806,7 +806,9 @@ module Bundler
     end
 
     def requested_groups
-      groups - Bundler.settings[:without] - @optional_groups + Bundler.settings[:with]
+      values = groups - Bundler.settings[:without] - @optional_groups + Bundler.settings[:with]
+      values &= Bundler.settings[:only] unless Bundler.settings[:only].empty?
+      values
     end
 
     def lockfiles_equal?(current, proposed, preserve_unknown_sections)

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -74,6 +74,10 @@ Creates a directory (defaults to \fB~/bin\fR) and place any executables from the
 In deployment mode, Bundler will \'roll\-out\' the bundle for \fBproduction\fR use\. Please check carefully if you want to have this option enabled in \fBdevelopment\fR or \fBtest\fR environments\.
 .
 .TP
+\fBonly\fR
+A space\-separated list of groups to install only gems of the specified groups\.
+.
+.TP
 \fBpath\fR
 The location to install the specified gems to\. This defaults to Rubygems\' setting\. Bundler shares this location with Rubygems, \fBgem install \.\.\.\fR will have gem installed there, too\. Therefore, gems installed without a \fB\-\-path \.\.\.\fR setting will show up by calling \fBgem list\fR\. Accordingly, gems installed to other locations will not get listed\.
 .
@@ -218,6 +222,9 @@ The following is a list of all configuration keys and their purpose\. You can le
 .
 .IP "\(bu" 4
 \fBno_prune\fR (\fBBUNDLE_NO_PRUNE\fR): Whether Bundler should leave outdated gems unpruned when caching\.
+.
+.IP "\(bu" 4
+\fBonly\fR (\fBBUNDLE_ONLY\fR): A space\-separated list of groups to install only gems of the specified groups\.
 .
 .IP "\(bu" 4
 \fBpath\fR (\fBBUNDLE_PATH\fR): The location on disk where all gems in your bundle will be located regardless of \fB$GEM_HOME\fR or \fB$GEM_PATH\fR values\. Bundle gems not found in this location will be installed by \fBbundle install\fR\. Defaults to \fBGem\.dir\fR\. When \-\-deployment is used, defaults to vendor/bundle\.

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -74,6 +74,9 @@ The options that can be configured are:
    `production` use. Please check carefully if you want to have this option
    enabled in `development` or `test` environments.
 
+* `only`:
+   A space-separated list of groups to install only gems of the specified groups.
+
 * `path`:
    The location to install the specified gems to. This defaults to Rubygems'
    setting. Bundler shares this location with Rubygems, `gem install ...` will
@@ -216,6 +219,8 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    Whether `bundle package` should skip installing gems.
 * `no_prune` (`BUNDLE_NO_PRUNE`):
    Whether Bundler should leave outdated gems unpruned when caching.
+* `only` (`BUNDLE_ONLY`):
+   A space-separated list of groups to install only gems of the specified groups.
 * `path` (`BUNDLE_PATH`):
    The location on disk where all gems in your bundle will be located regardless
    of `$GEM_HOME` or `$GEM_PATH` values. Bundle gems not found in this location

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -57,6 +57,7 @@ module Bundler
     ].freeze
 
     ARRAY_KEYS = %w[
+      only
       with
       without
     ].freeze

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -1000,6 +1000,26 @@ RSpec.describe "bundle install with gem sources" do
     end
   end
 
+  context "with only option" do
+    before do
+      bundle "config set only a:b"
+    end
+
+    it "installs only gems of the specified groups" do
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rails"
+        gem "rack", group: :a
+        gem "rake", group: :b
+        gem "yard", group: :c
+      G
+
+      expect(out).to include("Installing rack")
+      expect(out).to include("Installing rake")
+      expect(out).not_to include("Installing yard")
+    end
+  end
+
   context "with a symlinked configured as bundle path and a gem with symlinks" do
     before do
       symlinked_bundled_app = tmp("bundled_app-symlink")


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This resolves #4048.

For example, our company's Rails application has the following `Gemfile`:

```ruby
source 'https://rubygems.org'

# ...

group(
  :group1,
  :group2,
  :group3,
  :group4,
  :group5,
  :group6,
  :group7,
) do
  # ...
end

group(
  :group1,
  :group2,
  :group3,
  :group5
) do
  # ...
end

group :rubocop do
  gem 'erbcop', require: false
  gem 'rubocop', require: false
  gem 'rubocop-performance', require: false
  gem 'rubocop-rails', require: false
  gem 'rubocop-rspec', require: false
  gem 'slimcop', require: false
end

group :danger do
  gem 'danger'
end
```

and the CI workflow to run `rubocop` is as follows:

```yaml
# .github/workflows/rubocop.yml
on:
  pull_request:
  push:
    branches:
      - main
jobs:
  rubocop:
    runs-on: ubuntu-latest
    env:
      BUNDLE_WITHOUT: danger:group1:group2:group3:group4:group5:group6:group7
    steps:
      - uses: actions/checkout@v3
      - uses: ruby/setup-ruby@v1
        with:
          bundler-cache: true
          cache-version: rubocop
      - run: bundle exec rubocop --format progress --format github
```

In the above CI workflow to run RuboCop, we only want to install gems related to RuboCop (to avoid installing unrelated 300+ gems).

To accomplish this, we need to enumerate the names of the groups we do not need in `BUNDLER_WITHOUT`. However, this would duplicate the code that enumerates such groups when preparing several workflow files, and becomes a problem when a new gem group is added to the Gemfile.

Having multiple Gemfiles for each workflow, (such as `Gemfile`, `Gemfile-rubocop`, `Gemfile-danger`, etc.) at least eliminates the need to list groups in `BUNDLER_WITHOUT`, but it creates new problems, such as code duplication and version mismatches due to forgetting to update some of their `*.lock` files.

You may be surprised to see Gemfile with so many groups, but if you look at real-world examples of large old Rails applications, this kind of code is surprisingly common.

## What is your fix for the problem, implemented in this PR?

In this PR, I added `Bundler.settings[:only]` Array option to only install gems of the specified groups.

This option can be used as follows:

```
bundle config set only rubocop
bundle install
```

or

```
BUNDLE_ONLY=rubocop bundle install
```

For example, the workflow code I mentioned above can be replaced as follows:

```diff
 env:
-  BUNDLE_WITHOUT: danger:group1:group2:group3:group4:group5:group6:group7
+  BUNDLE_ONLY: rubocop
```

## Other information

I tried it locally and confirmed that it works as expected.

![image](https://user-images.githubusercontent.com/111689/180640586-ef62b663-18ed-4ac9-992d-aef2d065534f.png)

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
