### PR TITLE
Implement `bundle install --prefer-local`

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -218,6 +218,8 @@ module Bundler
       "Specify the number of jobs to run in parallel"
     method_option "local", :type => :boolean, :banner =>
       "Do not attempt to fetch gems remotely and use the gem cache instead"
+    method_option "prefer-local", :type => :boolean, :banner =>
+      "Only attempt to fetch gems remotely if not present locally, even if newer versions are available remotely"
     method_option "no-cache", :type => :boolean, :banner =>
       "Don't update the existing gem cache."
     method_option "redownload", :type => :boolean, :aliases => "--force", :banner =>

--- a/bundler/lib/bundler/installer.rb
+++ b/bundler/lib/bundler/installer.rb
@@ -268,7 +268,14 @@ module Bundler
         return false if @definition.nothing_changed? && !@definition.missing_specs?
       end
 
-      options["local"] ? @definition.resolve_with_cache! : @definition.resolve_remotely!
+      if options["local"]
+        @definition.resolve_with_cache!
+      elsif options["prefer-local"]
+        @definition.resolve_prefering_local!
+      else
+        @definition.resolve_remotely!
+      end
+
       true
     end
 

--- a/bundler/lib/bundler/man/bundle-install.1
+++ b/bundler/lib/bundler/man/bundle-install.1
@@ -70,6 +70,10 @@ The maximum number of parallel download and install jobs\. The default is the nu
 Do not attempt to connect to \fBrubygems\.org\fR\. Instead, Bundler will use the gems already present in Rubygems\' cache or in \fBvendor/cache\fR\. Note that if an appropriate platform\-specific gem exists on \fBrubygems\.org\fR it will not be found\.
 .
 .TP
+\fB\-\-prefer\-local\fR
+Force using locally installed gems, or gems already present in Rubygems\' cache or in \fBvendor/cache\fR, when resolving, even if newer versions are available remotely\. Only attempt to connect to \fBrubygems\.org\fR for gems that are not present locally\.
+.
+.TP
 \fB\-\-no\-cache\fR
 Do not update the cache in \fBvendor/cache\fR with the newly bundled gems\. This does not remove any gems in the cache but keeps the newly bundled gems from being cached during the install\.
 .

--- a/bundler/lib/bundler/man/bundle-install.1.ronn
+++ b/bundler/lib/bundler/man/bundle-install.1.ronn
@@ -109,6 +109,12 @@ automatically and that requires `bundler` to silently remember them. Since
   appropriate platform-specific gem exists on `rubygems.org` it will not be
   found.
 
+* `--prefer-local`:
+  Force using locally installed gems, or gems already present in Rubygems' cache
+  or in `vendor/cache`, when resolving, even if newer versions are available
+  remotely. Only attempt to connect to `rubygems.org` for gems that are not
+  present locally.
+
 * `--no-cache`:
   Do not update the cache in `vendor/cache` with the newly bundled gems. This
   does not remove any gems in the cache but keeps the newly bundled gems from

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -1020,6 +1020,30 @@ RSpec.describe "bundle install with gem sources" do
     end
   end
 
+  context "with --prefer-local flag" do
+    before do
+      build_repo4 do
+        build_gem "foo", "1.0.1"
+        build_gem "foo", "1.0.0"
+        build_gem "bar", "1.0.0"
+      end
+
+      system_gems "foo-1.0.0", :path => default_bundle_path, :gem_repo => gem_repo4
+    end
+
+    it "fetches remote sources only when not available locally" do
+      install_gemfile <<-G, :"prefer-local" => true, :verbose => true
+        source "#{file_uri_for(gem_repo4)}"
+
+        gem "foo"
+        gem "bar"
+      G
+
+      expect(out).to include("Using foo 1.0.0").and include("Fetching bar 1.0.0").and include("Installing bar 1.0.0")
+      expect(last_command).to be_success
+    end
+  end
+
   context "with a symlinked configured as bundle path and a gem with symlinks" do
     before do
       symlinked_bundled_app = tmp("bundled_app-symlink")


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

OS packagers generally prefer that Bundler uses all gems available locally (specifically packaged for the OS), and regardless of newer versions being available at rubygems.org, they want to version specifically packaged to be used.

However, if a gem has not yet been packaged for the OS, it's useful to allow it to be fetched from rubygems.org temporarily.

## What is your fix for the problem, implemented in this PR?

This PR introduces `bundle install --prefer-local` that implements this mode of functioning.

Closes #5657.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
