### PR TITLE
Make `--standalone` play nice with `--local`

### DIFF
--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -147,8 +147,11 @@ module Bundler
     def normalize_settings
       Bundler.settings.set_command_option :path, nil if options[:system]
       Bundler.settings.set_command_option_if_given :path, options[:path]
-      Bundler.settings.temporary(:path_relative_to_cwd => false) do
-        Bundler.settings.set_command_option :path, "bundle" if options["standalone"] && Bundler.settings[:path].nil?
+
+      if options["standalone"] && Bundler.settings[:path].nil?
+        Bundler.settings.temporary(:path_relative_to_cwd => false) do
+          Bundler.settings.set_command_option :path, "bundle"
+        end
       end
 
       bin_option = options["binstubs"]

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -148,7 +148,7 @@ module Bundler
       Bundler.settings.set_command_option :path, nil if options[:system]
       Bundler.settings.set_command_option_if_given :path, options[:path]
 
-      if options["standalone"] && Bundler.settings[:path].nil?
+      if options["standalone"] && Bundler.settings[:path].nil? && !options["local"]
         Bundler.settings.temporary(:path_relative_to_cwd => false) do
           Bundler.settings.set_command_option :path, "bundle"
         end

--- a/bundler/lib/bundler/installer/standalone.rb
+++ b/bundler/lib/bundler/installer/standalone.rb
@@ -47,7 +47,7 @@ module Bundler
     end
 
     def bundler_path
-      Bundler.root.join(Bundler.settings[:path], "bundler")
+      Bundler.root.join(Bundler.settings[:path].to_s, "bundler")
     end
 
     def gem_path(path, spec)

--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -461,3 +461,31 @@ RSpec.describe "bundle install --standalone run in a subdirectory" do
 
   include_examples("bundle install --standalone")
 end
+
+RSpec.describe "bundle install --standalone --local" do
+  before do
+    gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
+      gem "rack"
+    G
+
+    system_gems "rack-1.0.0", :path => default_bundle_path
+  end
+
+  it "generates script pointing to system gems" do
+    bundle "install --standalone --local --verbose"
+
+    expect(out).to include("Using rack 1.0.0")
+
+    load_error_ruby <<-RUBY, "spec"
+      require "./bundler/setup"
+
+      require "rack"
+      puts RACK
+      require "spec"
+    RUBY
+
+    expect(out).to eq("1.0.0")
+    expect(err).to eq("ZOMG LOAD ERROR")
+  end
+end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The problem is that `bundle install --standalone --local` does not work. Currently it prints an error. Instead, it should generate a `bundler/setup.rb` script setting up the `$LOAD_PATH` pointing to all locally installed resolved dependencies.

## What is your fix for the problem, implemented in this PR?

My fix is to make sure we don't mess with changing the `path` settings, letting gems be picked up from the default location, when `--local` is given.

Fixes https://github.com/rubygems/rubygems/issues/4445.

I'm not sure if it's best in this case to use relative paths, since it makes the script not movable but that can be improved later.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
