### PR TITLE
Add deprecation notice of `bundle viz` to man pages

### DIFF
--- a/bundler/lib/bundler/man/bundle-viz.1
+++ b/bundler/lib/bundler/man/bundle-viz.1
@@ -15,6 +15,9 @@
 .P
 The associated gems must also be installed via \fBbundle install(1)\fR \fIbundle\-install\.1\.html\fR\.
 .
+.P
+\fBviz\fR command was deprecated in Bundler 2\.2\. Use bundler\-graph plugin \fIhttps://github\.com/rubygems/bundler\-graph\fR instead\.
+.
 .SH "OPTIONS"
 .
 .TP

--- a/bundler/lib/bundler/man/bundle-viz.1.ronn
+++ b/bundler/lib/bundler/man/bundle-viz.1.ronn
@@ -16,6 +16,8 @@ bundle-viz(1) -- Generates a visual dependency graph for your Gemfile
 
 The associated gems must also be installed via [`bundle install(1)`](bundle-install.1.html).
 
+`viz` command was deprecated in Bundler 2.2. Use [bundler-graph plugin](https://github.com/rubygems/bundler-graph) instead.
+
 ## OPTIONS
 
 * `--file`, `-f`:

--- a/bundler/lib/bundler/man/bundle.1
+++ b/bundler/lib/bundler/man/bundle.1
@@ -93,7 +93,7 @@ Open an installed gem in the editor
 Generate a lockfile for your dependencies
 .
 .TP
-\fBbundle viz(1)\fR \fIbundle\-viz\.1\.html\fR
+\fBbundle viz(1)\fR \fIbundle\-viz\.1\.html\fR (deprecated)
 Generate a visual representation of your dependencies
 .
 .TP

--- a/bundler/lib/bundler/man/bundle.1.ronn
+++ b/bundler/lib/bundler/man/bundle.1.ronn
@@ -76,7 +76,7 @@ We divide `bundle` subcommands into primary commands and utilities:
 * [`bundle lock(1)`](bundle-lock.1.html):
   Generate a lockfile for your dependencies
 
-* [`bundle viz(1)`](bundle-viz.1.html):
+* [`bundle viz(1)`](bundle-viz.1.html) (deprecated):
   Generate a visual representation of your dependencies
 
 * [`bundle init(1)`](bundle-init.1.html):


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Readers of [`bundle-viz(1)`](https://bundler.io/v2.3/man/bundle-viz.1.html) cannot see the deprecation of `viz` in favor of `graph`.

Closes #5749

## What is your fix for the problem, implemented in this PR?

Add the deprecation notice in [`bundle-viz(1)`](https://bundler.io/v2.3/man/bundle-viz.1.html) as well as [`bundle(1)`](https://bundler.io/v2.3/man/bundle.1.html).

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)
