### PR TITLE
Fix `ruby` DSL requirement matching for head and prerelease rubies

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -765,7 +765,7 @@ module Bundler
 
     def metadata_dependencies
       @metadata_dependencies ||= [
-        Dependency.new("Ruby\0", RubyVersion.system.gem_version),
+        Dependency.new("Ruby\0", Gem.ruby_version),
         Dependency.new("RubyGems\0", Gem::VERSION),
       ]
     end

--- a/bundler/lib/bundler/ruby_version.rb
+++ b/bundler/lib/bundler/ruby_version.rb
@@ -32,12 +32,12 @@ module Bundler
       @engine             = engine && engine.to_s || "ruby"
       @engine_versions    = (engine_version && Array(engine_version)) || @versions
       @engine_gem_version = Gem::Requirement.create(@engine_versions.first).requirements.first.last
-      @patchlevel         = patchlevel
+      @patchlevel         = patchlevel || (@gem_version.prerelease? ? "-1" : nil)
     end
 
     def to_s(versions = self.versions)
       output = String.new("ruby #{versions_string(versions)}")
-      output << "p#{patchlevel}" if patchlevel
+      output << "p#{patchlevel}" if patchlevel && patchlevel != "-1"
       output << " (#{engine} #{versions_string(engine_versions)})" unless engine == "ruby"
 
       output
@@ -46,7 +46,7 @@ module Bundler
     # @private
     PATTERN = /
       ruby\s
-      ([\d.]+) # ruby version
+      (\d+\.\d+\.\d+(?:\.\S+)?) # ruby version
       (?:p(-?\d+))? # optional patchlevel
       (?:\s\((\S+)\s(.+)\))? # optional engine info
     /xo.freeze
@@ -103,8 +103,8 @@ module Bundler
 
     def self.system
       ruby_engine = RUBY_ENGINE.dup
-      ruby_version = RUBY_VERSION.dup
-      ruby_engine_version = RUBY_ENGINE_VERSION.dup
+      ruby_version = Gem.ruby_version.to_s
+      ruby_engine_version = RUBY_ENGINE == "ruby" ? ruby_version : RUBY_ENGINE_VERSION.dup
       patchlevel = RUBY_PATCHLEVEL.to_s
 
       @ruby_version ||= RubyVersion.new(ruby_version, patchlevel, ruby_engine, ruby_engine_version)

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -17,6 +17,15 @@ require "rubygems/source"
 
 require_relative "match_platform"
 
+# Cherry-pick fixes to `Gem.ruby_version` to be useful for modern Bundler
+# versions and ignore patchlevels
+# (https://github.com/rubygems/rubygems/pull/5472,
+# https://github.com/rubygems/rubygems/pull/5486). May be removed once RubyGems
+# 3.3.12 support is dropped.
+unless Gem.ruby_version.to_s == RUBY_VERSION || RUBY_PATCHLEVEL == -1
+  Gem.instance_variable_set(:@ruby_version, Gem::Version.new(RUBY_VERSION))
+end
+
 module Gem
   class Specification
     include ::Bundler::MatchPlatform

--- a/bundler/lib/bundler/source/metadata.rb
+++ b/bundler/lib/bundler/source/metadata.rb
@@ -5,7 +5,7 @@ module Bundler
     class Metadata < Source
       def specs
         @specs ||= Index.build do |idx|
-          idx << Gem::Specification.new("Ruby\0", RubyVersion.system.gem_version)
+          idx << Gem::Specification.new("Ruby\0", Gem.ruby_version)
           idx << Gem::Specification.new("RubyGems\0", Gem::VERSION) do |s|
             s.required_rubygems_version = Gem::Requirement.default
           end

--- a/bundler/spec/bundler/ruby_version_spec.rb
+++ b/bundler/spec/bundler/ruby_version_spec.rb
@@ -427,9 +427,8 @@ RSpec.describe "Bundler::RubyVersion and its subclasses" do
       end
 
       describe "#version" do
-        it "should return a copy of the value of RUBY_VERSION" do
-          expect(subject.versions).to eq([RUBY_VERSION])
-          expect(subject.versions.first).to_not be(RUBY_VERSION)
+        it "should return the value of Gem.ruby_version as a string" do
+          expect(subject.versions).to eq([Gem.ruby_version.to_s])
         end
       end
 
@@ -446,13 +445,12 @@ RSpec.describe "Bundler::RubyVersion and its subclasses" do
       describe "#engine_version" do
         context "engine is ruby" do
           before do
-            stub_const("RUBY_ENGINE_VERSION", "2.2.4")
+            allow(Gem).to receive(:ruby_version).and_return(Gem::Version.new("2.2.4"))
             stub_const("RUBY_ENGINE", "ruby")
           end
 
-          it "should return a copy of the value of RUBY_ENGINE_VERSION" do
+          it "should return the value of Gem.ruby_version as a string" do
             expect(bundler_system_ruby_version.engine_versions).to eq(["2.2.4"])
-            expect(bundler_system_ruby_version.engine_versions.first).to_not be(RUBY_ENGINE_VERSION)
           end
         end
 

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -522,14 +522,14 @@ RSpec.describe "bundle install with gem sources" do
           ruby '~> 1.2'
           source "#{file_uri_for(gem_repo1)}"
         G
-        expect(err).to include("Your Ruby version is #{RUBY_VERSION}, but your Gemfile specified ~> 1.2")
+        expect(err).to include("Your Ruby version is #{Gem.ruby_version}, but your Gemfile specified ~> 1.2")
       end
     end
 
     context "and using a supported Ruby version" do
       before do
         install_gemfile <<-G
-          ruby '~> #{RUBY_VERSION}'
+          ruby '~> #{Gem.ruby_version}'
           source "#{file_uri_for(gem_repo1)}"
         G
       end
@@ -555,7 +555,7 @@ RSpec.describe "bundle install with gem sources" do
 
       it "updates Gemfile.lock with updated yet still compatible ruby version" do
         install_gemfile <<-G
-          ruby '~> #{RUBY_VERSION[0..2]}'
+          ruby '~> #{current_ruby_minor}'
           source "#{file_uri_for(gem_repo1)}"
         G
 
@@ -913,7 +913,7 @@ RSpec.describe "bundle install with gem sources" do
       gemfile <<-G
         source "https://gem.repo4"
 
-        ruby "#{RUBY_VERSION}"
+        ruby "#{Gem.ruby_version}"
 
         gem "loofah", "~> 2.12.0"
       G

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -541,11 +541,9 @@ RSpec.describe "bundle lock" do
   end
 
   it "respects lower bound ruby requirements" do
-    skip "this spec does not work with prereleases because their version is actually lower than their reported `RUBY_VERSION`" if RUBY_PATCHLEVEL == -1
-
     build_repo4 do
       build_gem "our_private_gem", "0.1.0" do |s|
-        s.required_ruby_version = ">= #{RUBY_VERSION}"
+        s.required_ruby_version = ">= #{Gem.ruby_version}"
       end
     end
 

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -983,7 +983,7 @@ RSpec.describe "bundle update --ruby" do
   context "when the Gemfile removes the ruby" do
     before do
       install_gemfile <<-G
-        ruby '~> #{RUBY_VERSION}'
+        ruby '~> #{Gem.ruby_version}'
         source "#{file_uri_for(gem_repo1)}"
       G
 
@@ -1013,12 +1013,12 @@ RSpec.describe "bundle update --ruby" do
   context "when the Gemfile specified an updated Ruby version" do
     before do
       install_gemfile <<-G
-        ruby '~> #{RUBY_VERSION}'
+        ruby '~> #{Gem.ruby_version}'
         source "#{file_uri_for(gem_repo1)}"
       G
 
       gemfile <<-G
-          ruby '~> #{RUBY_VERSION[0..2]}'
+          ruby '~> #{current_ruby_minor}'
           source "#{file_uri_for(gem_repo1)}"
       G
     end
@@ -1047,7 +1047,7 @@ RSpec.describe "bundle update --ruby" do
   context "when a different Ruby is being used than has been versioned" do
     before do
       install_gemfile <<-G
-        ruby '~> #{RUBY_VERSION}'
+        ruby '~> #{Gem.ruby_version}'
         source "#{file_uri_for(gem_repo1)}"
       G
 
@@ -1083,7 +1083,7 @@ RSpec.describe "bundle update --ruby" do
       L
 
       gemfile <<-G
-          ruby '~> #{RUBY_VERSION}'
+          ruby '~> #{Gem.ruby_version}'
           source "#{file_uri_for(gem_repo1)}"
       G
     end

--- a/bundler/spec/install/gemfile/ruby_spec.rb
+++ b/bundler/spec/install/gemfile/ruby_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe "ruby requirement" do
   it "allows adding gems" do
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
-      ruby "#{RUBY_VERSION}"
+      ruby "#{Gem.ruby_version}"
       gem "rack"
     G
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
-      ruby "#{RUBY_VERSION}"
+      ruby "#{Gem.ruby_version}"
       gem "rack"
       gem "rack-obama"
     G
@@ -28,7 +28,7 @@ RSpec.describe "ruby requirement" do
   it "allows removing the ruby version requirement" do
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
-      ruby "~> #{RUBY_VERSION}"
+      ruby "~> #{Gem.ruby_version}"
       gem "rack"
     G
 
@@ -46,7 +46,7 @@ RSpec.describe "ruby requirement" do
   it "allows changing the ruby version requirement to something compatible" do
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
-      ruby ">= #{RUBY_VERSION[0..2]}.0"
+      ruby ">= #{current_ruby_minor}"
       gem "rack"
     G
 
@@ -55,7 +55,7 @@ RSpec.describe "ruby requirement" do
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
-      ruby ">= #{RUBY_VERSION}"
+      ruby ">= #{Gem.ruby_version}"
       gem "rack"
     G
 
@@ -93,7 +93,7 @@ RSpec.describe "ruby requirement" do
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
-      ruby ">= #{RUBY_VERSION[0..2]}.0"
+      ruby ">= #{current_ruby_minor}"
       gem "rack"
     G
 
@@ -104,7 +104,7 @@ RSpec.describe "ruby requirement" do
   it "allows requirements with trailing whitespace" do
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
-      ruby "#{RUBY_VERSION}\\n \t\\n"
+      ruby "#{Gem.ruby_version}\\n \t\\n"
       gem "rack"
     G
 

--- a/bundler/spec/install/gems/resolving_spec.rb
+++ b/bundler/spec/install/gems/resolving_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe "bundle install with install-time dependencies" do
         end
 
         install_gemfile <<-G, :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo2.to_s }
-          ruby "#{RUBY_VERSION}"
+          ruby "#{Gem.ruby_version}"
           source "http://localgemserver.test/"
           gem 'rack'
         G
@@ -232,7 +232,7 @@ RSpec.describe "bundle install with install-time dependencies" do
         end
 
         install_gemfile <<-G, :artifice => "endpoint", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo2.to_s }
-          ruby "#{RUBY_VERSION}"
+          ruby "#{Gem.ruby_version}"
           source "http://localgemserver.test/"
           gem 'rack'
         G
@@ -309,7 +309,7 @@ RSpec.describe "bundle install with install-time dependencies" do
         end
 
         install_gemfile <<-G, :artifice => "compact_index_rate_limited", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
-          ruby "#{RUBY_VERSION}"
+          ruby "#{Gem.ruby_version}"
           source "http://localgemserver.test/"
           gem 'rack'
           gem 'foo1'
@@ -333,7 +333,7 @@ RSpec.describe "bundle install with install-time dependencies" do
 
         simulate_platform mingw do
           install_gemfile <<-G, :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
-            ruby "#{RUBY_VERSION}"
+            ruby "#{Gem.ruby_version}"
             source "http://localgemserver.test/"
             gem 'rack'
           G
@@ -354,8 +354,8 @@ RSpec.describe "bundle install with install-time dependencies" do
         end
       end
 
-      let(:ruby_requirement) { %("#{RUBY_VERSION}") }
-      let(:error_message_requirement) { "= #{RUBY_VERSION}" }
+      let(:ruby_requirement) { %("#{Gem.ruby_version}") }
+      let(:error_message_requirement) { "= #{Gem.ruby_version}" }
 
       it "raises a proper error that mentions the current Ruby version during resolution" do
         install_gemfile <<-G, :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo2.to_s }, :raise_on_error => false

--- a/bundler/spec/install/gemspecs_spec.rb
+++ b/bundler/spec/install/gemspecs_spec.rb
@@ -94,7 +94,8 @@ RSpec.describe "bundle install" do
   end
 
   context "when ruby version is specified in gemspec and gemfile" do
-    it "installs when patch level is not specified and the version matches" do
+    it "installs when patch level is not specified and the version matches",
+      :if => RUBY_PATCHLEVEL >= 0 do
       build_lib("foo", :path => bundled_app) do |s|
         s.required_ruby_version = "~> #{RUBY_VERSION}.0"
       end

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -1174,7 +1174,7 @@ RSpec.describe "the lockfile format" do
   it "captures the Ruby version in the lockfile" do
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}/"
-      ruby '#{RUBY_VERSION}'
+      ruby '#{Gem.ruby_version}'
       gem "rack", "> 0.9", "< 1.0"
     G
 
@@ -1191,7 +1191,7 @@ RSpec.describe "the lockfile format" do
         rack (> 0.9, < 1.0)
 
       RUBY VERSION
-         ruby #{RUBY_VERSION}p#{RUBY_PATCHLEVEL}
+         #{Bundler::RubyVersion.system}
 
       BUNDLED WITH
          #{Bundler::VERSION}

--- a/bundler/spec/other/platform_spec.rb
+++ b/bundler/spec/other/platform_spec.rb
@@ -19,7 +19,7 @@ Your app has gems that work on these platforms:
 * #{specific_local_platform}
 
 Your Gemfile specifies a Ruby version requirement:
-* ruby #{RUBY_VERSION}
+* ruby #{Gem.ruby_version}
 
 Your current platform satisfies the Ruby version requirement.
 G
@@ -42,7 +42,7 @@ Your app has gems that work on these platforms:
 * #{specific_local_platform}
 
 Your Gemfile specifies a Ruby version requirement:
-* ruby #{RUBY_VERSION}p#{RUBY_PATCHLEVEL}
+* #{Bundler::RubyVersion.system.single_version_string}
 
 Your current platform satisfies the Ruby version requirement.
 G
@@ -85,7 +85,7 @@ Your app has gems that work on these platforms:
 Your Gemfile specifies a Ruby version requirement:
 * ruby #{not_local_ruby_version}
 
-Your Ruby version is #{RUBY_VERSION}, but your Gemfile specified #{not_local_ruby_version}
+Your Ruby version is #{Gem.ruby_version}, but your Gemfile specified #{not_local_ruby_version}
 G
     end
   end
@@ -255,18 +255,18 @@ G
     end
   end
 
-  let(:ruby_version_correct) { "ruby \"#{RUBY_VERSION}\", :engine => \"#{local_ruby_engine}\", :engine_version => \"#{local_engine_version}\"" }
-  let(:ruby_version_correct_engineless) { "ruby \"#{RUBY_VERSION}\"" }
+  let(:ruby_version_correct) { "ruby \"#{Gem.ruby_version}\", :engine => \"#{local_ruby_engine}\", :engine_version => \"#{local_engine_version}\"" }
+  let(:ruby_version_correct_engineless) { "ruby \"#{Gem.ruby_version}\"" }
   let(:ruby_version_correct_patchlevel) { "#{ruby_version_correct}, :patchlevel => '#{RUBY_PATCHLEVEL}'" }
   let(:ruby_version_incorrect) { "ruby \"#{not_local_ruby_version}\", :engine => \"#{local_ruby_engine}\", :engine_version => \"#{not_local_ruby_version}\"" }
-  let(:engine_incorrect) { "ruby \"#{RUBY_VERSION}\", :engine => \"#{not_local_tag}\", :engine_version => \"#{RUBY_VERSION}\"" }
-  let(:engine_version_incorrect) { "ruby \"#{RUBY_VERSION}\", :engine => \"#{local_ruby_engine}\", :engine_version => \"#{not_local_engine_version}\"" }
+  let(:engine_incorrect) { "ruby \"#{Gem.ruby_version}\", :engine => \"#{not_local_tag}\", :engine_version => \"#{Gem.ruby_version}\"" }
+  let(:engine_version_incorrect) { "ruby \"#{Gem.ruby_version}\", :engine => \"#{local_ruby_engine}\", :engine_version => \"#{not_local_engine_version}\"" }
   let(:patchlevel_incorrect) { "#{ruby_version_correct}, :patchlevel => '#{not_local_patchlevel}'" }
   let(:patchlevel_fixnum) { "#{ruby_version_correct}, :patchlevel => #{RUBY_PATCHLEVEL}1" }
 
   def should_be_ruby_version_incorrect
     expect(exitstatus).to eq(18)
-    expect(err).to be_include("Your Ruby version is #{RUBY_VERSION}, but your Gemfile specified #{not_local_ruby_version}")
+    expect(err).to be_include("Your Ruby version is #{Gem.ruby_version}, but your Gemfile specified #{not_local_ruby_version}")
   end
 
   def should_be_engine_incorrect

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -476,7 +476,7 @@ module Spec
     end
 
     def current_ruby_minor
-      Gem.ruby_version.segments[0..1].join(".")
+      Gem.ruby_version.segments.tap {|s| s.delete_at(2) }.join(".")
     end
 
     def next_ruby_minor

--- a/bundler/spec/support/platforms.rb
+++ b/bundler/spec/support/platforms.rb
@@ -71,7 +71,7 @@ module Spec
     end
 
     def local_engine_version
-      RUBY_ENGINE_VERSION
+      RUBY_ENGINE == "ruby" ? Gem.ruby_version : RUBY_ENGINE_VERSION
     end
 
     def not_local_engine_version


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

While working on #5715, my changes made this bug surface.

With the following `Gemfile`

```ruby
source "https://rubygems.org"

ruby ">= 3.2.0"
```

And

```
$ ruby -v
ruby 3.2.0preview1 (2022-04-03 master f801386f0c) [arm64-darwin21]
```

Currently Bundler is happy

```
$ bundle
The Gemfile specifies no dependencies
Resolving dependencies...
Bundle complete! 0 Gemfile dependencies, 1 gem now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
```

## What is your fix for the problem, implemented in this PR?

My fix is to pass the resolver an actual string for the current Ruby version that considers prereleases.

After this fix, the previous case gives the expected error:

```
$ bundle
Your Ruby version is 3.2.0.preview1, but your Gemfile specified >= 3.2.0
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
