### PR TITLE
Use main as default branch for Bundler specs

### DIFF
--- a/bundler/spec/bundler/gem_helper_spec.rb
+++ b/bundler/spec/bundler/gem_helper_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Bundler::GemHelper do
   before(:each) do
     global_config "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__COC" => "false", "BUNDLE_GEM__LINTER" => "false",
                   "BUNDLE_GEM__CI" => "false", "BUNDLE_GEM__CHANGELOG" => "false"
+    sys_exec("git config --global init.defaultBranch main")
     bundle "gem #{app_name}"
     prepare_gemspec(app_gemspec_path)
   end
@@ -295,7 +296,7 @@ RSpec.describe Bundler::GemHelper do
             mock_confirm_message "Tagged v#{app_version}."
             mock_confirm_message "Pushed git commits and release tag."
 
-            sys_exec("git push -u origin master", :dir => app_path)
+            sys_exec("git push -u origin main", :dir => app_path)
           end
 
           it "calls rubygem_push with proper arguments" do
@@ -336,7 +337,7 @@ RSpec.describe Bundler::GemHelper do
             mock_build_message app_name, app_version
             mock_confirm_message "Pushed git commits and release tag."
 
-            sys_exec("git push -u origin master", :dir => app_path)
+            sys_exec("git push -u origin main", :dir => app_path)
             expect(subject).to receive(:rubygem_push).with(app_gem_path.to_s)
           end
 

--- a/bundler/spec/cache/git_spec.rb
+++ b/bundler/spec/cache/git_spec.rb
@@ -15,7 +15,7 @@ end
 RSpec.describe "bundle cache with git" do
   it "copies repository to vendor cache and uses it" do
     git = build_git "foo"
-    ref = git.ref_for("master", 11)
+    ref = git.ref_for("main", 11)
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -34,7 +34,7 @@ RSpec.describe "bundle cache with git" do
 
   it "copies repository to vendor cache and uses it even when configured with `path`" do
     git = build_git "foo"
-    ref = git.ref_for("master", 11)
+    ref = git.ref_for("main", 11)
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -72,7 +72,7 @@ RSpec.describe "bundle cache with git" do
 
   it "tracks updates" do
     git = build_git "foo"
-    old_ref = git.ref_for("master", 11)
+    old_ref = git.ref_for("main", 11)
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -86,7 +86,7 @@ RSpec.describe "bundle cache with git" do
       s.write "lib/foo.rb", "puts :CACHE"
     end
 
-    ref = git.ref_for("master", 11)
+    ref = git.ref_for("main", 11)
     expect(ref).not_to eq(old_ref)
 
     bundle "update", :all => true
@@ -103,7 +103,7 @@ RSpec.describe "bundle cache with git" do
 
   it "tracks updates when specifying the gem" do
     git = build_git "foo"
-    old_ref = git.ref_for("master", 11)
+    old_ref = git.ref_for("main", 11)
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -117,7 +117,7 @@ RSpec.describe "bundle cache with git" do
       s.write "lib/foo.rb", "puts :CACHE"
     end
 
-    ref = git.ref_for("master", 11)
+    ref = git.ref_for("main", 11)
     expect(ref).not_to eq(old_ref)
 
     bundle "update foo"
@@ -132,11 +132,11 @@ RSpec.describe "bundle cache with git" do
 
   it "uses the local repository to generate the cache" do
     git = build_git "foo"
-    ref = git.ref_for("master", 11)
+    ref = git.ref_for("main", 11)
 
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
-      gem "foo", :git => '#{lib_path("foo-invalid")}', :branch => :master
+      gem "foo", :git => '#{lib_path("foo-invalid")}', :branch => :main
     G
 
     bundle %(config set local.foo #{lib_path("foo-1.0")})
@@ -172,7 +172,7 @@ RSpec.describe "bundle cache with git" do
       end
     G
 
-    ref = git.ref_for("master", 11)
+    ref = git.ref_for("main", 11)
     bundle "config set cache_all true"
     bundle :cache
 
@@ -196,7 +196,7 @@ RSpec.describe "bundle cache with git" do
     bundle "config set cache_all true"
     bundle :cache
 
-    ref = git.ref_for("master", 11)
+    ref = git.ref_for("main", 11)
     gemspec = bundled_app("vendor/cache/foo-1.0-#{ref}/foo.gemspec").read
     expect(gemspec).to_not match("`echo bob`")
   end

--- a/bundler/spec/commands/info_spec.rb
+++ b/bundler/spec/commands/info_spec.rb
@@ -163,10 +163,10 @@ RSpec.describe "bundle info" do
       expect(the_bundle).to include_gems "foo 1.0"
 
       bundle "info foo"
-      expect(out).to include("foo (1.0 #{@git.ref_for("master", 6)}")
+      expect(out).to include("foo (1.0 #{@git.ref_for("main", 6)}")
     end
 
-    it "prints out branch names other than master" do
+    it "prints out branch names other than main" do
       update_git "foo", :branch => "omg" do |s|
         s.write "lib/foo.rb", "FOO = '1.0.omg'"
       end

--- a/bundler/spec/commands/open_spec.rb
+++ b/bundler/spec/commands/open_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "bundle open" do
 
     it "does not blow up if the gem to open does not have a Gemfile" do
       git = build_git "foo"
-      ref = git.ref_for("master", 11)
+      ref = git.ref_for("main", 11)
 
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"

--- a/bundler/spec/commands/pristine_spec.rb
+++ b/bundler/spec/commands/pristine_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "bundle pristine" do
       source "#{file_uri_for(gem_repo2)}"
       gem "weakling"
       gem "very_simple_binary"
-      gem "foo", :git => "#{lib_path("foo")}", :branch => "master"
+      gem "foo", :git => "#{lib_path("foo")}", :branch => "main"
       gem "git_with_ext", :git => "#{lib_path("git_with_ext")}"
       gem "bar", :path => "#{lib_path("bar")}"
 

--- a/bundler/spec/commands/remove_spec.rb
+++ b/bundler/spec/commands/remove_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "bundle remove" do
             gem 'git'
             gem 'rack',
                 git: "#{lib_path("rack-1.0")}",
-                branch: 'master'
+                branch: 'main'
             gem 'nokogiri'
           G
 

--- a/bundler/spec/commands/show_spec.rb
+++ b/bundler/spec/commands/show_spec.rb
@@ -100,10 +100,10 @@ RSpec.describe "bundle show", :bundler => "< 3" do
       expect(the_bundle).to include_gems "foo 1.0"
 
       bundle :show
-      expect(out).to include("foo (1.0 #{@git.ref_for("master", 6)}")
+      expect(out).to include("foo (1.0 #{@git.ref_for("main", 6)}")
     end
 
-    it "prints out branch names other than master" do
+    it "prints out branch names other than main" do
       update_git "foo", :branch => "omg" do |s|
         s.write "lib/foo.rb", "FOO = '1.0.omg'"
       end

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe "bundle install with git sources" do
-  describe "when floating on master" do
+  describe "when floating on main" do
     before :each do
       build_git "foo" do |s|
         s.executables = "foobar"
@@ -51,7 +51,7 @@ RSpec.describe "bundle install with git sources" do
 
       bundle "update foo"
 
-      sha = git.ref_for("master", 11)
+      sha = git.ref_for("main", 11)
       spec_file = default_bundle_path.join("bundler/gems/foo-1.0-#{sha}/foo.gemspec").to_s
       ruby_code = Gem::Specification.load(spec_file).to_ruby
       file_code = File.read(spec_file)
@@ -219,12 +219,12 @@ RSpec.describe "bundle install with git sources" do
     end
 
     it "works when the revision is a non-head ref" do
-      # want to ensure we don't fallback to master
+      # want to ensure we don't fallback to main
       update_git "foo", :path => lib_path("foo-1.0") do |s|
         s.write("lib/foo.rb", "raise 'FAIL'")
       end
 
-      sys_exec("git update-ref -m \"Bundler Spec!\" refs/bundler/1 master~1", :dir => lib_path("foo-1.0"))
+      sys_exec("git update-ref -m \"Bundler Spec!\" refs/bundler/1 main~1", :dir => lib_path("foo-1.0"))
 
       # want to ensure we don't fallback to HEAD
       update_git "foo", :path => lib_path("foo-1.0"), :branch => "rando" do |s|
@@ -255,12 +255,12 @@ RSpec.describe "bundle install with git sources" do
         end
       G
 
-      # want to ensure we don't fallback to master
+      # want to ensure we don't fallback to main
       update_git "foo", :path => lib_path("foo-1.0") do |s|
         s.write("lib/foo.rb", "raise 'FAIL'")
       end
 
-      sys_exec("git update-ref -m \"Bundler Spec!\" refs/bundler/1 master~1", :dir => lib_path("foo-1.0"))
+      sys_exec("git update-ref -m \"Bundler Spec!\" refs/bundler/1 main~1", :dir => lib_path("foo-1.0"))
 
       # want to ensure we don't fallback to HEAD
       update_git "foo", :path => lib_path("foo-1.0"), :branch => "rando" do |s|
@@ -284,7 +284,7 @@ RSpec.describe "bundle install with git sources" do
     end
 
     it "does not download random non-head refs" do
-      sys_exec("git update-ref -m \"Bundler Spec!\" refs/bundler/1 master~1", :dir => lib_path("foo-1.0"))
+      sys_exec("git update-ref -m \"Bundler Spec!\" refs/bundler/1 main~1", :dir => lib_path("foo-1.0"))
 
       bundle "config set global_gem_cache true"
 
@@ -420,7 +420,7 @@ RSpec.describe "bundle install with git sources" do
 
       gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
-        gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
+        gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "main"
       G
 
       bundle %(config set local.rack #{lib_path("local-rack")})
@@ -441,7 +441,7 @@ RSpec.describe "bundle install with git sources" do
 
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
-        gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
+        gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "main"
       G
 
       bundle %(config set local.rack #{lib_path("local-rack")})
@@ -461,7 +461,7 @@ RSpec.describe "bundle install with git sources" do
 
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
-        gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
+        gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "main"
       G
 
       bundle %(config set local.rack #{lib_path("local-rack")})
@@ -477,7 +477,7 @@ RSpec.describe "bundle install with git sources" do
 
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
-        gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
+        gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "main"
       G
 
       lockfile0 = File.read(bundled_app_lock)
@@ -499,7 +499,7 @@ RSpec.describe "bundle install with git sources" do
 
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
-        gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
+        gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "main"
       G
 
       lockfile0 = File.read(bundled_app_lock)
@@ -519,7 +519,7 @@ RSpec.describe "bundle install with git sources" do
 
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
-        gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
+        gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "main"
       G
 
       bundle %(config set local.rack #{lib_path("local-rack")})
@@ -583,12 +583,12 @@ RSpec.describe "bundle install with git sources" do
 
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
-        gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
+        gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "main"
       G
 
       bundle %(config set local.rack #{lib_path("local-rack")})
       bundle :install, :raise_on_error => false
-      expect(err).to match(/is using branch another but Gemfile specifies master/)
+      expect(err).to match(/is using branch another but Gemfile specifies main/)
     end
 
     it "explodes on invalid revision on install" do
@@ -600,7 +600,7 @@ RSpec.describe "bundle install with git sources" do
 
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
-        gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
+        gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "main"
       G
 
       bundle %(config set local.rack #{lib_path("local-rack")})
@@ -617,7 +617,7 @@ RSpec.describe "bundle install with git sources" do
 
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
-        gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
+        gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "main"
       G
 
       bundle %(config set local.rack #{lib_path("local-rack")})
@@ -1519,7 +1519,7 @@ In Gemfile:
 
         gemfile <<-G
           source "#{file_uri_for(gem_repo1)}"
-          gem "foo", :git => "#{lib_path("foo")}", :branch => "master"
+          gem "foo", :git => "#{lib_path("foo")}", :branch => "main"
         G
 
         bundle :install

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe "bundle install with specific platforms" do
       lockfile <<-L
         GIT
           remote: #{lib_path("pg_array_parser-1.0")}
-          revision: #{git.ref_for("master")}
+          revision: #{git.ref_for("main")}
           specs:
             pg_array_parser (1.0-java)
             pg_array_parser (1.0)

--- a/bundler/spec/install/git_spec.rb
+++ b/bundler/spec/install/git_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "bundle install" do
         gem "foo", :git => "#{file_uri_for(lib_path("foo"))}"
       G
 
-      expect(out).to include("Using foo 1.0 from #{file_uri_for(lib_path("foo"))} (at master@#{revision_for(lib_path("foo"))[0..6]})")
+      expect(out).to include("Using foo 1.0 from #{file_uri_for(lib_path("foo"))} (at main@#{revision_for(lib_path("foo"))[0..6]})")
       expect(the_bundle).to include_gems "foo 1.0", :source => "git@#{lib_path("foo")}"
     end
 
@@ -37,16 +37,16 @@ RSpec.describe "bundle install" do
 
       install_gemfile <<-G, :verbose => true
         source "#{file_uri_for(gem_repo1)}"
-        gem "foo", :git => "#{file_uri_for(lib_path("foo"))}", :ref => "master~2"
+        gem "foo", :git => "#{file_uri_for(lib_path("foo"))}", :ref => "main~2"
       G
 
-      expect(out).to include("Using foo 1.0 from #{file_uri_for(lib_path("foo"))} (at master~2@#{rev})")
+      expect(out).to include("Using foo 1.0 from #{file_uri_for(lib_path("foo"))} (at main~2@#{rev})")
       expect(the_bundle).to include_gems "foo 1.0", :source => "git@#{lib_path("foo")}"
 
       update_git "foo", "4.0", :path => lib_path("foo"), :gemspec => true
 
       bundle :update, :all => true, :verbose => true
-      expect(out).to include("Using foo 2.0 (was 1.0) from #{file_uri_for(lib_path("foo"))} (at master~2@#{rev2})")
+      expect(out).to include("Using foo 2.0 (was 1.0) from #{file_uri_for(lib_path("foo"))} (at main~2@#{rev2})")
       expect(the_bundle).to include_gems "foo 2.0", :source => "git@#{lib_path("foo")}"
     end
 

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -386,7 +386,7 @@ RSpec.describe "the lockfile format" do
     expect(lockfile).to eq <<~G
       GIT
         remote: #{lib_path("foo-1.0")}
-        revision: #{git.ref_for("master")}
+        revision: #{git.ref_for("main")}
         specs:
           foo (1.0)
 
@@ -457,7 +457,7 @@ RSpec.describe "the lockfile format" do
     expect(lockfile).to eq <<~G
       GIT
         remote: #{lib_path("foo-1.0")}
-        revision: #{git.ref_for("master")}
+        revision: #{git.ref_for("main")}
         specs:
           foo (1.0)
 
@@ -617,7 +617,7 @@ RSpec.describe "the lockfile format" do
     expect(lockfile).to eq <<~G
       GIT
         remote: #{lib_path("bar-1.0")}
-        revision: #{bar.ref_for("master")}
+        revision: #{bar.ref_for("main")}
         specs:
           bar (1.0)
 

--- a/bundler/spec/plugins/source/example_spec.rb
+++ b/bundler/spec/plugins/source/example_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe "real source plugins" do
               def initialize(opts)
                 super
 
-                @ref = options["ref"] || options["branch"] || options["tag"] || "master"
+                @ref = options["ref"] || options["branch"] || options["tag"] || "main"
                 @unlocked = false
               end
 
@@ -247,7 +247,7 @@ RSpec.describe "real source plugins" do
 
               def options_to_lock
                 opts = {"revision" => revision}
-                opts["ref"] = ref if ref != "master"
+                opts["ref"] = ref if ref != "main"
                 opts
               end
 
@@ -435,7 +435,7 @@ RSpec.describe "real source plugins" do
     describe "bundle cache with gitp" do
       it "copies repository to vendor cache and uses it" do
         git = build_git "foo"
-        ref = git.ref_for("master", 11)
+        ref = git.ref_for("main", 11)
 
         install_gemfile <<-G
           source "#{file_uri_for(gem_repo2)}" # plugin source

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -489,7 +489,7 @@ RSpec.describe "Bundler.setup" do
 
       gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
-        gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
+        gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "main"
       G
 
       bundle %(config set local.rack #{lib_path("local-rack")})
@@ -507,7 +507,7 @@ RSpec.describe "Bundler.setup" do
 
       gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
-        gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
+        gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "main"
       G
 
       bundle %(config set local.rack #{lib_path("local-rack")})
@@ -529,7 +529,7 @@ RSpec.describe "Bundler.setup" do
 
       gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
-        gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
+        gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "main"
       G
 
       bundle %(config set local.rack #{lib_path("local-rack")})
@@ -541,7 +541,7 @@ RSpec.describe "Bundler.setup" do
       G
 
       run "require 'rack'", :raise_on_error => false
-      expect(err).to match(/is using branch master but Gemfile specifies changed/)
+      expect(err).to match(/is using branch main but Gemfile specifies changed/)
     end
 
     it "explodes on refs with different branches on runtime" do
@@ -551,17 +551,17 @@ RSpec.describe "Bundler.setup" do
 
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
-        gem "rack", :git => "#{lib_path("rack-0.8")}", :ref => "master", :branch => "master"
+        gem "rack", :git => "#{lib_path("rack-0.8")}", :ref => "main", :branch => "main"
       G
 
       gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
-        gem "rack", :git => "#{lib_path("rack-0.8")}", :ref => "master", :branch => "nonexistant"
+        gem "rack", :git => "#{lib_path("rack-0.8")}", :ref => "main", :branch => "nonexistant"
       G
 
       bundle %(config set local.rack #{lib_path("local-rack")})
       run "require 'rack'", :raise_on_error => false
-      expect(err).to match(/is using branch master but Gemfile specifies nonexistant/)
+      expect(err).to match(/is using branch main but Gemfile specifies nonexistant/)
     end
   end
 

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -528,7 +528,7 @@ module Spec
 
     class GitBuilder < LibBuilder
       def _build(options)
-        default_branch = options[:default_branch] || "master"
+        default_branch = options[:default_branch] || "main"
         path = options[:path] || _default_path
         source = options[:source] || "git@#{path}"
         super(options.merge(:path => path, :source => source))

--- a/bundler/spec/update/git_spec.rb
+++ b/bundler/spec/update/git_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "bundle update" do
       expect(the_bundle).to include_gems "foo 1.1"
     end
 
-    it "floats on master when updating all gems that are pinned to the source even if you have child dependencies" do
+    it "floats on main when updating all gems that are pinned to the source even if you have child dependencies" do
       build_git "foo", :path => lib_path("foo")
       build_gem "bar", :to_bundle => true do |s|
         s.add_dependency "foo"
@@ -103,7 +103,7 @@ RSpec.describe "bundle update" do
       build_git "foo"
       @remote = build_git("bar", :bare => true)
       update_git "foo", :remote => file_uri_for(@remote.path)
-      update_git "foo", :push => "master"
+      update_git "foo", :push => "main"
 
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
@@ -211,7 +211,7 @@ RSpec.describe "bundle update" do
 
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
-        gem "rack", :git => "#{file_uri_for(lib_path("rack-0.8"))}", :branch => "master"
+        gem "rack", :git => "#{file_uri_for(lib_path("rack-0.8"))}", :branch => "main"
       G
 
       bundle %(config set local.rack #{lib_path("local-rack")})
@@ -230,7 +230,7 @@ RSpec.describe "bundle update" do
       update_git "rails", "3.0", :path => lib_path("rails"), :gemspec => true
 
       bundle "update", :all => true
-      expect(out).to include("Using rails 3.0 (was 2.3.2) from #{file_uri_for(lib_path("rails"))} (at master@#{revision_for(lib_path("rails"))[0..6]})")
+      expect(out).to include("Using rails 3.0 (was 2.3.2) from #{file_uri_for(lib_path("rails"))} (at main@#{revision_for(lib_path("rails"))[0..6]})")
     end
   end
 
@@ -301,7 +301,7 @@ RSpec.describe "bundle update" do
         s.write "foo.gemspec", spec_lines.join("\n")
       end
 
-      ref = @git.ref_for "master"
+      ref = @git.ref_for "main"
 
       bundle "update --source bar"
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Main is a better terminology than master for representing the default branch of repositories.

## What is your fix for the problem, implemented in this PR?

Unify terminology in Bundler specs.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
