### PR TITLE
Add deprecation notice of bundle console

### DIFF
--- a/bundler/lib/bundler/man/bundle.1
+++ b/bundler/lib/bundler/man/bundle.1
@@ -81,7 +81,7 @@ Show the source location of a particular gem in the bundle
 Show all of the outdated gems in the current bundle
 .
 .TP
-\fBbundle console(1)\fR
+\fBbundle console(1)\fR (deprecated)
 Start an IRB session in the current bundle
 .
 .TP

--- a/bundler/lib/bundler/man/bundle.1.ronn
+++ b/bundler/lib/bundler/man/bundle.1.ronn
@@ -67,7 +67,7 @@ We divide `bundle` subcommands into primary commands and utilities:
 * [`bundle outdated(1)`](bundle-outdated.1.html):
   Show all of the outdated gems in the current bundle
 
-* `bundle console(1)`:
+* `bundle console(1)` (deprecated):
   Start an IRB session in the current bundle
 
 * [`bundle open(1)`](bundle-open.1.html):


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)

## What was the end-user or developer problem that led to this PR?

`bundler` CLI has warned users on running `bundle console` due to https://github.com/rubygems/bundler/pull/4741 and https://github.com/rubygems/bundler/pull/7295, but Bundler Website and Bundler man does not warn them.

## What is your fix for the problem, implemented in this PR?

As per https://github.com/rubygems/bundler/pull/4741 and https://github.com/rubygems/bundler/pull/7295, adds the deprecation notice of `bundler console` in man `bundle(1)`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
