### PR TITLE
Add deprecation notice of bundle inject

### DIFF
--- a/bundler/lib/bundler/man/bundle-inject.1
+++ b/bundler/lib/bundler/man/bundle-inject.1
@@ -30,4 +30,7 @@ bundle inject \'rack\' \'> 0\'
 .IP "" 0
 .
 .P
-This will inject the \'rack\' gem with a version greater than 0 in your [\fBGemfile(5)\fR][Gemfile(5)] and Gemfile\.lock
+This will inject the \'rack\' gem with a version greater than 0 in your [\fBGemfile(5)\fR][Gemfile(5)] and Gemfile\.lock\.
+.
+.P
+The \fBbundle inject\fR command was deprecated in Bundler 2\.1 and will be removed in Bundler 3\.0\.

--- a/bundler/lib/bundler/man/bundle-inject.1.ronn
+++ b/bundler/lib/bundler/man/bundle-inject.1.ronn
@@ -19,4 +19,6 @@ Example:
     bundle inject 'rack' '> 0'
 
 This will inject the 'rack' gem with a version greater than 0 in your
-[`Gemfile(5)`][Gemfile(5)] and Gemfile.lock
+[`Gemfile(5)`][Gemfile(5)] and Gemfile.lock.
+
+The `bundle inject` command was deprecated in Bundler 2.1 and will be removed in Bundler 3.0.

--- a/bundler/lib/bundler/man/bundle.1
+++ b/bundler/lib/bundler/man/bundle.1
@@ -129,5 +129,8 @@ These commands are obsolete and should no longer be used:
 .IP "\(bu" 4
 \fBbundle cache(1)\fR
 .
+.IP "\(bu" 4
+\fBbundle inject(1)\fR
+.
 .IP "" 0
 

--- a/bundler/lib/bundler/man/bundle.1.ronn
+++ b/bundler/lib/bundler/man/bundle.1.ronn
@@ -108,3 +108,4 @@ and execute it, passing down any extra arguments to it.
 These commands are obsolete and should no longer be used:
 
 * `bundle cache(1)`
+* `bundle inject(1)`


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)

## What was the end-user or developer problem that led to this PR?

`bundler` CLI has warned users on running `bundle inject` due to https://github.com/rubygems/bundler/commit/e82cebae494d953400b3099bb5b51eac8347c004 and https://github.com/rubygems/bundler/pull/7295, but Bundler Website and Bundler man does not warn them.

## What is your fix for the problem, implemented in this PR?


As per https://github.com/rubygems/bundler/commit/e82cebae494d953400b3099bb5b51eac8347c004 and https://github.com/rubygems/bundler/pull/7295, adds the deprecation notice of `bundler inject` in man `bundle-inject(1)` and `bundle(1)`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
