### PR TITLE
Introduce man for aliased bundle-package(1)

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -126,6 +126,8 @@ bundler/lib/bundler/man/bundle-open.1
 bundler/lib/bundler/man/bundle-open.1.ronn
 bundler/lib/bundler/man/bundle-outdated.1
 bundler/lib/bundler/man/bundle-outdated.1.ronn
+bundler/lib/bundler/man/bundle-package.1
+bundler/lib/bundler/man/bundle-package.1.ronn
 bundler/lib/bundler/man/bundle-platform.1
 bundler/lib/bundler/man/bundle-platform.1.ronn
 bundler/lib/bundler/man/bundle-pristine.1

--- a/bundler/lib/bundler/man/bundle-package.1
+++ b/bundler/lib/bundler/man/bundle-package.1
@@ -1,0 +1,13 @@
+.\" generated with Ronn/v0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
+.
+.TH "BUNDLE\-PACKAGE" "1" "July 2022" "" ""
+.
+.SH "NAME"
+\fBbundle\-package\fR \- Renamed command\. See \fBbundle\-cache(1)\fR
+.
+.SH "SYNOPSIS"
+\fBbundle package\fR
+.
+.SH "DESCRIPTION"
+This command was renamed to \fBbundle cache\fR in Bundler 2\.1 and now is an alias of \fBbundle\-cache(1)\fR \fIbundle\-cache\.1\.html\fR\.

--- a/bundler/lib/bundler/man/bundle-package.1.ronn
+++ b/bundler/lib/bundler/man/bundle-package.1.ronn
@@ -1,0 +1,11 @@
+bundle-package(1) -- Renamed command. See `bundle-cache(1)`
+===========================================================
+
+## SYNOPSIS
+
+`bundle package`
+
+## DESCRIPTION
+
+This command was renamed to `bundle cache` in Bundler 2.1 and now is an alias
+of [`bundle-cache(1)`](bundle-cache.1.html).

--- a/bundler/lib/bundler/man/index.txt
+++ b/bundler/lib/bundler/man/index.txt
@@ -17,6 +17,7 @@ bundle-list(1)        bundle-list.1
 bundle-lock(1)        bundle-lock.1
 bundle-open(1)        bundle-open.1
 bundle-outdated(1)    bundle-outdated.1
+bundle-package(1)     bundle-package.1
 bundle-platform(1)    bundle-platform.1
 bundle-pristine(1)    bundle-pristine.1
 bundle-remove(1)      bundle-remove.1


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Closes #5781

Follows up https://github.com/rubygems/bundler/pull/7249

## What is your fix for the problem, implemented in this PR?

No man/Website for `bundle-package(1)` has been available since Bundler 2.2.0.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)
