### PR TITLE
Remove `bundle cache` from deprecated commands list, and consistently link to `bundle cache` in man pages

### DIFF
--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -298,7 +298,7 @@ The following is a list of all configuration keys and their purpose\. You can le
 .IP "" 0
 .
 .P
-In general, you should set these settings per\-application by using the applicable flag to the bundle install(1) \fIbundle\-install\.1\.html\fR or bundle package(1) \fIbundle\-package\.1\.html\fR command\.
+In general, you should set these settings per\-application by using the applicable flag to the bundle install(1) \fIbundle\-install\.1\.html\fR or bundle cache(1) \fIbundle\-cache\.1\.html\fR command\.
 .
 .P
 You can set them globally either via environment variables or \fBbundle config\fR, whichever is preferable for your setup\. If you use both, environment variables will take preference over global settings\.

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -280,7 +280,7 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    A `:`-separated list of groups whose gems bundler should not install.
 
 In general, you should set these settings per-application by using the applicable
-flag to the [bundle install(1)](bundle-install.1.html) or [bundle package(1)](bundle-package.1.html) command.
+flag to the [bundle install(1)](bundle-install.1.html) or [bundle cache(1)](bundle-cache.1.html) command.
 
 You can set them globally either via environment variables or `bundle config`,
 whichever is preferable for your setup. If you use both, environment variables

--- a/bundler/lib/bundler/man/bundle.1
+++ b/bundler/lib/bundler/man/bundle.1
@@ -43,8 +43,8 @@ Install the gems specified by the \fBGemfile\fR or \fBGemfile\.lock\fR
 Update dependencies to their latest versions
 .
 .TP
-\fBbundle package(1)\fR \fIbundle\-package\.1\.html\fR
-Package the \.gem files required by your application into the \fBvendor/cache\fR directory
+\fBbundle cache(1)\fR \fIbundle\-cache\.1\.html\fR
+Package the \.gem files required by your application into the \fBvendor/cache\fR directory (aliases: \fBbundle package\fR, \fBbundle pack\fR)
 .
 .TP
 \fBbundle exec(1)\fR \fIbundle\-exec\.1\.html\fR
@@ -125,9 +125,6 @@ When running a command that isn\'t listed in PRIMARY COMMANDS or UTILITIES, Bund
 .
 .SH "OBSOLETE"
 These commands are obsolete and should no longer be used:
-.
-.IP "\(bu" 4
-\fBbundle cache(1)\fR
 .
 .IP "\(bu" 4
 \fBbundle inject(1)\fR

--- a/bundler/lib/bundler/man/bundle.1.ronn
+++ b/bundler/lib/bundler/man/bundle.1.ronn
@@ -36,9 +36,9 @@ We divide `bundle` subcommands into primary commands and utilities:
 * [`bundle update(1)`](bundle-update.1.html):
   Update dependencies to their latest versions
 
-* [`bundle package(1)`](bundle-package.1.html):
+* [`bundle cache(1)`](bundle-cache.1.html):
   Package the .gem files required by your application into the
-  `vendor/cache` directory
+  `vendor/cache` directory (aliases: `bundle package`, `bundle pack`)
 
 * [`bundle exec(1)`](bundle-exec.1.html):
   Execute a script in the current bundle
@@ -107,5 +107,4 @@ and execute it, passing down any extra arguments to it.
 
 These commands are obsolete and should no longer be used:
 
-* `bundle cache(1)`
 * `bundle inject(1)`


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

There are dead links to deprecated `bundle-package(1)` with `bundler-cache(1)` in man pages.

See also #5781

Follows up https://github.com/rubygems/bundler/pull/7249

## What is your fix for the problem, implemented in this PR?

Fix these dead links to deprecated `bundle-package(1)` with `bundler-cache(1)` in man pages.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)