### PR TITLE
Don't discard candidates matching Ruby metadata

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -524,10 +524,8 @@ module Bundler
         end
       end
 
-      unless specs["bundler"].any?
-        bundler = sources.metadata_source.specs.search(Gem::Dependency.new("bundler", VERSION)).last
-        specs["bundler"] = bundler
-      end
+      bundler = sources.metadata_source.specs.search(Gem::Dependency.new("bundler", VERSION)).last
+      specs["bundler"] = bundler
 
       specs
     end

--- a/bundler/lib/bundler/gem_helpers.rb
+++ b/bundler/lib/bundler/gem_helpers.rb
@@ -44,6 +44,12 @@ module Bundler
 
     def select_best_platform_match(specs, platform)
       matching = specs.select {|spec| spec.match_platform(platform) }
+
+      sort_best_platform_match(matching, platform)
+    end
+    module_function :select_best_platform_match
+
+    def sort_best_platform_match(matching, platform)
       exact = matching.select {|spec| spec.platform == platform }
       return exact if exact.any?
 
@@ -52,7 +58,7 @@ module Bundler
 
       sorted_matching.take_while {|spec| same_specificity(platform, spec, exemplary_spec) && same_deps(spec, exemplary_spec) }
     end
-    module_function :select_best_platform_match
+    module_function :sort_best_platform_match
 
     class PlatformMatch
       def self.specificity_score(spec_platform, user_platform)

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -96,12 +96,11 @@ module Bundler
         else
           source.specs.search(self)
         end
-        best_installable_candidate = candidates.reverse.find do |spec|
+        search = candidates.reverse.find do |spec|
           spec.is_a?(StubSpecification) ||
             (spec.required_ruby_version.satisfied_by?(Gem.ruby_version) &&
               spec.required_rubygems_version.satisfied_by?(Gem.rubygems_version))
-        end
-        search = best_installable_candidate || candidates.last
+        end || candidates.last
         search.dependencies = dependencies if search && (search.is_a?(RemoteSpecification) || search.is_a?(EndpointSpecification))
         search
       end

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -108,7 +108,11 @@ module Bundler
             (spec.required_ruby_version.satisfied_by?(Gem.ruby_version) &&
               spec.required_rubygems_version.satisfied_by?(Gem.rubygems_version))
         end
-        search.dependencies = dependencies if search && search.full_name == full_name && (search.is_a?(RemoteSpecification) || search.is_a?(EndpointSpecification))
+        if search.nil? && Bundler.frozen_bundle?
+          search = candidates.last
+        else
+          search.dependencies = dependencies if search && search.full_name == full_name && (search.is_a?(RemoteSpecification) || search.is_a?(EndpointSpecification))
+        end
         search
       end
     end

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -88,9 +88,7 @@ module Bundler
     end
 
     def __materialize__(platform)
-      @specification = if source.is_a?(Source::Gemspec) && source.gemspec.name == name
-        source.gemspec.tap {|s| s.source = source }
-      else
+      @specification = begin
         search_object = if source.is_a?(Source::Path) || !ruby_platform_materializes_to_ruby_platform?
           Dependency.new(name, version)
         else

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -88,6 +88,8 @@ module Bundler
         source.specs.search(self)
       end
 
+      return self if candidates.empty?
+
       __materialize__(candidates)
     end
 
@@ -105,8 +107,8 @@ module Bundler
           spec.is_a?(StubSpecification) ||
             (spec.required_ruby_version.satisfied_by?(Gem.ruby_version) &&
               spec.required_rubygems_version.satisfied_by?(Gem.rubygems_version))
-        end || candidates.last
-        search.dependencies = dependencies if search && (search.is_a?(RemoteSpecification) || search.is_a?(EndpointSpecification))
+        end
+        search.dependencies = dependencies if search && search.full_name == full_name && (search.is_a?(RemoteSpecification) || search.is_a?(EndpointSpecification))
         search
       end
     end

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -76,6 +76,8 @@ module Bundler
     end
 
     def materialize_for_installation
+      source.local!
+
       __materialize__(ruby_platform_materializes_to_ruby_platform? ? platform : Bundler.local_platform)
     end
 

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -96,12 +96,12 @@ module Bundler
         else
           source.specs.search(self)
         end
-        installable_candidates = candidates.select do |spec|
+        best_installable_candidate = candidates.reverse.find do |spec|
           spec.is_a?(StubSpecification) ||
             (spec.required_ruby_version.satisfied_by?(Gem.ruby_version) &&
               spec.required_rubygems_version.satisfied_by?(Gem.rubygems_version))
         end
-        search = installable_candidates.last || candidates.last
+        search = best_installable_candidate || candidates.last
         search.dependencies = dependencies if search && (search.is_a?(RemoteSpecification) || search.is_a?(EndpointSpecification))
         search
       end

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -91,10 +91,10 @@ module Bundler
       @specification = if source.is_a?(Source::Gemspec) && source.gemspec.name == name
         source.gemspec.tap {|s| s.source = source }
       else
-        search_object = if source.is_a?(Source::Path)
+        search_object = if source.is_a?(Source::Path) || !ruby_platform_materializes_to_ruby_platform?
           Dependency.new(name, version)
         else
-          ruby_platform_materializes_to_ruby_platform? ? self : Dependency.new(name, version)
+          self
         end
         candidates = source.specs.search(search_object)
         same_platform_candidates = candidates.select do |spec|

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -155,6 +155,10 @@ module Gem
 
     alias_method :eql?, :==
 
+    def force_ruby_platform
+      false
+    end
+
     def encode_with(coder)
       to_yaml_properties.each do |ivar|
         coder[ivar.to_s.sub(/^@/, "")] = instance_variable_get(ivar)

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -35,10 +35,6 @@ module Bundler
         end
       end
 
-      if spec = lookup["bundler"].first
-        specs << spec
-      end
-
       specs
     end
 

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -70,7 +70,6 @@ module Bundler
 
       materialized.map! do |s|
         next s unless s.is_a?(LazySpecification)
-        s.source.local!
         s.materialize_for_installation || s
       end
       SpecSet.new(materialized)
@@ -82,7 +81,6 @@ module Bundler
     def materialized_for_all_platforms
       @specs.map do |s|
         next s unless s.is_a?(LazySpecification)
-        s.source.local!
         s.source.remote!
         spec = s.materialize_for_installation
         raise GemNotFound, "Could not find #{s.full_name} in any of the sources" unless spec

--- a/bundler/spec/install/gems/resolving_spec.rb
+++ b/bundler/spec/install/gems/resolving_spec.rb
@@ -216,7 +216,7 @@ RSpec.describe "bundle install with install-time dependencies" do
           gem 'rack'
         G
 
-        expect(out).to_not include("rack-9001.0.0 requires ruby version > 9000")
+        expect(err).to_not include("rack-9001.0.0 requires ruby version > 9000")
         expect(the_bundle).to include_gems("rack 1.2")
       end
 
@@ -237,7 +237,7 @@ RSpec.describe "bundle install with install-time dependencies" do
           gem 'rack'
         G
 
-        expect(out).to_not include("rack-9001.0.0 requires ruby version > 9000")
+        expect(err).to_not include("rack-9001.0.0 requires ruby version > 9000")
         expect(the_bundle).to include_gems("rack 1.2")
       end
 
@@ -329,7 +329,7 @@ RSpec.describe "bundle install with install-time dependencies" do
           gem 'foo1'
         G
 
-        expect(out).to_not include("rack-9001.0.0 requires ruby version > 9000")
+        expect(err).to_not include("rack-9001.0.0 requires ruby version > 9000")
         expect(the_bundle).to include_gems("rack 1.2")
       end
 
@@ -353,8 +353,8 @@ RSpec.describe "bundle install with install-time dependencies" do
           G
         end
 
-        expect(out).to_not include("rack-9001.0.0 requires ruby version > 9000")
-        expect(out).to_not include("rack-1.2-#{Bundler.local_platform} requires ruby version > 9000")
+        expect(err).to_not include("rack-9001.0.0 requires ruby version > 9000")
+        expect(err).to_not include("rack-1.2-#{Bundler.local_platform} requires ruby version > 9000")
         expect(the_bundle).to include_gems("rack 1.2")
       end
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes a `Gemfile.lock` file will include a variant that matches the current Ruby, but Bundler will discard it because of not being the most platform specific one.

## What is your fix for the problem, implemented in this PR?

Bundler materializes lockfiles into real specifications in two steps. First, it filters the dependencies it needs (for example, if `BUNDLE_WITHOUT` is set or things like that), and chooses a set of specs from those. Then it converts those lockfile specifications into real specifications.

From these two steps, only the second one considered Ruby metadata, while both steps considered platform. This resulted on these candidates already discarded by the time we try to materialize specifications.

This PR merges these two steps into a single pass, so that we consider metadata and platforms at the same time. This also speeds up `require "bundler/setup"` time in our example big Gemfile by about 2-3%.

```
✗ hyperfine 'BUNDLER_VERSION=2.4.0.dev ruby -rbundler/setup -e1' 'BUNDLER_VERSION=2.3.19 ruby -rbundler/setup -e1'  
Benchmark 1: BUNDLER_VERSION=2.4.0.dev ruby -rbundler/setup -e1
  Time (mean ± σ):     135.5 ms ±   1.0 ms    [User: 112.1 ms, System: 22.1 ms]
  Range (min … max):   134.2 ms … 138.4 ms    21 runs
 
Benchmark 2: BUNDLER_VERSION=2.3.19 ruby -rbundler/setup -e1
  Time (mean ± σ):     138.9 ms ±   0.5 ms    [User: 115.6 ms, System: 21.9 ms]
  Range (min … max):   138.1 ms … 139.9 ms    21 runs
 
Summary
  'BUNDLER_VERSION=2.4.0.dev ruby -rbundler/setup -e1' ran
    1.03 ± 0.01 times faster than 'BUNDLER_VERSION=2.3.19 ruby -rbundler/setup -e1'
```

Closes #5715.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
