### PR TITLE
Add package/pack aliases to man pages for cache

### DIFF
--- a/bundler/lib/bundler/man/bundle-cache.1
+++ b/bundler/lib/bundler/man/bundle-cache.1
@@ -9,6 +9,9 @@
 .SH "SYNOPSIS"
 \fBbundle cache\fR
 .
+.P
+alias: \fBpackage\fR, \fBpack\fR
+.
 .SH "DESCRIPTION"
 Copy all of the \fB\.gem\fR files needed to run the application into the \fBvendor/cache\fR directory\. In the future, when running [bundle install(1)][bundle\-install], use the gems in the cache in preference to the ones on \fBrubygems\.org\fR\.
 .
@@ -53,3 +56,6 @@ One way to be sure that you have the right platformed versions of all your gems 
 .
 .P
 By default, bundle cache(1) \fIbundle\-cache\.1\.html\fR fetches and also installs the gems to the default location\. To package the dependencies to \fBvendor/cache\fR without installing them to the local install location, you can run \fBbundle cache \-\-no\-install\fR\.
+.
+.SH "HISTORY"
+In Bundler 2\.1, \fBcache\fR took in the functionalities of \fBpackage\fR and now \fBpackage\fR and \fBpack\fR are aliases of \fBcache\fR\.

--- a/bundler/lib/bundler/man/bundle-cache.1.ronn
+++ b/bundler/lib/bundler/man/bundle-cache.1.ronn
@@ -5,6 +5,8 @@ bundle-cache(1) -- Package your needed `.gem` files into your application
 
 `bundle cache`
 
+alias: `package`, `pack`
+
 ## DESCRIPTION
 
 Copy all of the `.gem` files needed to run the application into the
@@ -70,3 +72,8 @@ By default, [bundle cache(1)](bundle-cache.1.html) fetches and also
 installs the gems to the default location. To package the
 dependencies to `vendor/cache` without installing them to the
 local install location, you can run `bundle cache --no-install`.
+
+## HISTORY
+
+In Bundler 2.1, `cache` took in the functionalities of `package` and now
+`package` and `pack` are aliases of `cache`.


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Closes #5781

## What is your fix for the problem, implemented in this PR?

Add aliases of `package` and `pack` to `cache` in man pages.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

Partially replaces #5782

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)