### PR TITLE
Improve `bundle platform` man page

### DIFF
--- a/bundler/lib/bundler/man/bundle-platform.1
+++ b/bundler/lib/bundler/man/bundle-platform.1
@@ -10,7 +10,7 @@
 \fBbundle platform\fR [\-\-ruby]
 .
 .SH "DESCRIPTION"
-\fBplatform\fR will display information from your Gemfile, Gemfile\.lock, and Ruby VM about your platform\.
+\fBplatform\fR displays information from your Gemfile, Gemfile\.lock, and Ruby VM about your platform\.
 .
 .P
 For instance, using this Gemfile(5):
@@ -21,7 +21,7 @@ For instance, using this Gemfile(5):
 
 source "https://rubygems\.org"
 
-ruby "1\.9\.3"
+ruby "3\.1\.2"
 
 gem "rack"
 .
@@ -30,7 +30,7 @@ gem "rack"
 .IP "" 0
 .
 .P
-If you run \fBbundle platform\fR on Ruby 1\.9\.3, it will display the following output:
+If you run \fBbundle platform\fR on Ruby 3\.1\.2, it displays the following output:
 .
 .IP "" 4
 .
@@ -39,10 +39,13 @@ If you run \fBbundle platform\fR on Ruby 1\.9\.3, it will display the following 
 Your platform is: x86_64\-linux
 
 Your app has gems that work on these platforms:
+* arm64\-darwin\-21
 * ruby
+* x64\-mingw\-ucrt
+* x86_64\-linux
 
 Your Gemfile specifies a Ruby version requirement:
-* ruby 1\.9\.3
+* ruby 3\.1\.2
 
 Your current platform satisfies the Ruby version requirement\.
 .
@@ -51,11 +54,18 @@ Your current platform satisfies the Ruby version requirement\.
 .IP "" 0
 .
 .P
-\fBplatform\fR will list all the platforms in your \fBGemfile\.lock\fR as well as the \fBruby\fR directive if applicable from your Gemfile(5)\. It will also let you know if the \fBruby\fR directive requirement has been met\. If \fBruby\fR directive doesn\'t match the running Ruby VM, it will tell you what part does not\.
+\fBplatform\fR lists all the platforms in your \fBGemfile\.lock\fR as well as the \fBruby\fR directive if applicable from your Gemfile(5)\. It also lets you know if the \fBruby\fR directive requirement has been met\. If \fBruby\fR directive doesn\'t match the running Ruby VM, it tells you what part does not\.
 .
 .SH "OPTIONS"
 .
 .TP
 \fB\-\-ruby\fR
 It will display the ruby directive information, so you don\'t have to parse it from the Gemfile(5)\.
+.
+.SH "SEE ALSO"
+.
+.IP "\(bu" 4
+bundle\-lock(1) \fIbundle\-lock\.1\.ronn\fR
+.
+.IP "" 0
 

--- a/bundler/lib/bundler/man/bundle-platform.1.ronn
+++ b/bundler/lib/bundler/man/bundle-platform.1.ronn
@@ -7,36 +7,43 @@ bundle-platform(1) -- Displays platform compatibility information
 
 ## DESCRIPTION
 
-`platform` will display information from your Gemfile, Gemfile.lock, and Ruby
+`platform` displays information from your Gemfile, Gemfile.lock, and Ruby
 VM about your platform.
 
 For instance, using this Gemfile(5):
 
     source "https://rubygems.org"
 
-    ruby "1.9.3"
+    ruby "3.1.2"
 
     gem "rack"
 
-If you run `bundle platform` on Ruby 1.9.3, it will display the following output:
+If you run `bundle platform` on Ruby 3.1.2, it displays the following output:
 
     Your platform is: x86_64-linux
 
     Your app has gems that work on these platforms:
+    * arm64-darwin-21
     * ruby
+    * x64-mingw-ucrt
+    * x86_64-linux
 
     Your Gemfile specifies a Ruby version requirement:
-    * ruby 1.9.3
+    * ruby 3.1.2
 
     Your current platform satisfies the Ruby version requirement.
 
-`platform` will list all the platforms in your `Gemfile.lock` as well as the
-`ruby` directive if applicable from your Gemfile(5). It will also let you know
+`platform` lists all the platforms in your `Gemfile.lock` as well as the
+`ruby` directive if applicable from your Gemfile(5). It also lets you know
 if the `ruby` directive requirement has been met. If `ruby` directive doesn't
-match the running Ruby VM, it will tell you what part does not.
+match the running Ruby VM, it tells you what part does not.
 
 ## OPTIONS
 
 * `--ruby`:
   It will display the ruby directive information, so you don't have to
   parse it from the Gemfile(5).
+
+## SEE ALSO
+
+* [bundle-lock(1)](bundle-lock.1.ronn)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The example is too stale, shows less information, has unusual tense in technical writing.

## What is your fix for the problem, implemented in this PR?

- Add examples with the latest Ruby (3.1.2)
- Add platforms
- Use present tense in general
- Add a link to `bundle-lock(1)`

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)