### PR TITLE
Warn (rather than crash) when setting `nil` specification versions

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2653,6 +2653,8 @@ class Gem::Specification < Gem::BasicSpecification
 
   def version=(version)
     @version = Gem::Version.create(version)
+    return if @version.nil?
+
     # skip to set required_ruby_version when pre-released rubygems.
     # It caused to raise CircularDependencyError
     if @version.prerelease? && (@name.nil? || @name.strip != "rubygems")

--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -171,9 +171,7 @@ class Gem::Version
   # True if the +version+ string matches RubyGems' requirements.
 
   def self.correct?(version)
-    unless Gem::Deprecate.skip
-      warn "nil versions are discouraged and will be deprecated in Rubygems 4" if version.nil?
-    end
+    nil_versions_are_discouraged! if version.nil?
 
     !!(version.to_s =~ ANCHORED_VERSION_PATTERN)
   end
@@ -190,6 +188,8 @@ class Gem::Version
     if self === input # check yourself before you wreck yourself
       input
     elsif input.nil?
+      nil_versions_are_discouraged!
+
       nil
     else
       new input
@@ -205,6 +205,14 @@ class Gem::Version
 
     @@all[version] ||= super
   end
+
+  def self.nil_versions_are_discouraged!
+    unless Gem::Deprecate.skip
+      warn "nil versions are discouraged and will be deprecated in Rubygems 4"
+    end
+  end
+
+  private_class_method :nil_versions_are_discouraged!
 
   ##
   # Constructs a Version from the +version+ string.  A version string is a

--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -129,7 +129,9 @@ class TestGemRequirement < Gem::TestCase
     assert_satisfied_by "1.3", r
 
     assert_raise ArgumentError do
-      assert_satisfied_by nil, r
+      Gem::Deprecate.skip_during do
+        assert_satisfied_by nil, r
+      end
     end
   end
 
@@ -141,7 +143,9 @@ class TestGemRequirement < Gem::TestCase
     refute_satisfied_by "1.3", r
 
     assert_raise ArgumentError do
-      assert_satisfied_by nil, r
+      Gem::Deprecate.skip_during do
+        assert_satisfied_by nil, r
+      end
     end
   end
 
@@ -153,7 +157,9 @@ class TestGemRequirement < Gem::TestCase
     refute_satisfied_by "1.3", r
 
     assert_raise ArgumentError do
-      assert_satisfied_by nil, r
+      Gem::Deprecate.skip_during do
+        assert_satisfied_by nil, r
+      end
     end
   end
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1220,6 +1220,15 @@ dependencies: []
     assert_equal "1.0.0.dev", spec.version.to_s
   end
 
+  def test_initialize_nil_version
+    expected = "nil versions are discouraged and will be deprecated in Rubygems 4\n"
+    actual_stdout, actual_stderr = capture_output do
+      Gem::Specification.new.version = nil
+    end
+    assert_empty actual_stdout
+    assert_equal(expected, actual_stderr)
+  end
+
   def test__dump
     @a2.platform = Gem::Platform.local
     @a2.instance_variable_set :@original_platform, "old_platform"

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -32,8 +32,15 @@ class TestGemVersion < Gem::TestCase
   def test_class_create
     real = Gem::Version.new(1.0)
 
-    assert_same  real, Gem::Version.create(real)
-    assert_nil   Gem::Version.create(nil)
+    assert_same real, Gem::Version.create(real)
+
+    expected = "nil versions are discouraged and will be deprecated in Rubygems 4\n"
+    actual_stdout, actual_stderr = capture_output do
+      assert_nil Gem::Version.create(nil)
+    end
+    assert_empty actual_stdout
+    assert_equal(expected, actual_stderr)
+
     assert_equal v("5.1"), Gem::Version.create("5.1")
 
     ver = "1.1".freeze


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

```ruby
Gem::Specification.new.version = nil
```

crashes with a confusing error

```
`version=': undefined method `prerelease?' for nil:NilClass (NoMethodError)
```

## What is your fix for the problem, implemented in this PR?

My fix is to make sure this case is handled fine, but prints a warning.

Fixes #5792.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
