### PR TITLE
Fix platform matching for index specs

### DIFF
--- a/lib/rubygems/resolver/index_specification.rb
+++ b/lib/rubygems/resolver/index_specification.rb
@@ -21,7 +21,8 @@ class Gem::Resolver::IndexSpecification < Gem::Resolver::Specification
     @name = name
     @version = version
     @source = source
-    @platform = platform.to_s
+    @platform = Gem::Platform.new(platform.to_s)
+    @original_platform = platform.to_s
 
     @spec = nil
   end
@@ -91,7 +92,7 @@ class Gem::Resolver::IndexSpecification < Gem::Resolver::Specification
   def spec # :nodoc:
     @spec ||=
       begin
-        tuple = Gem::NameTuple.new @name, @version, @platform
+        tuple = Gem::NameTuple.new @name, @version, @original_platform
 
         @source.fetch_spec tuple
       end

--- a/test/rubygems/test_gem_resolver_index_specification.rb
+++ b/test/rubygems/test_gem_resolver_index_specification.rb
@@ -26,7 +26,7 @@ class TestGemResolverIndexSpecification < Gem::TestCase
     spec = Gem::Resolver::IndexSpecification.new(
       set, "rails", version, source, Gem::Platform.local)
 
-    assert_equal Gem::Platform.local.to_s, spec.platform
+    assert_equal Gem::Platform.local, spec.platform
   end
 
   def test_install

--- a/test/rubygems/test_gem_resolver_installer_set.rb
+++ b/test/rubygems/test_gem_resolver_installer_set.rb
@@ -51,6 +51,19 @@ class TestGemResolverInstallerSet < Gem::TestCase
     assert_equal %w[a-1], set.always_install.map {|s| s.full_name }
   end
 
+  def test_add_always_install_index_spec_platform
+    a_1_local, a_1_local_gem = util_gem "a", 1 do |s|
+      s.platform = Gem::Platform.local
+    end
+
+    FileUtils.mv a_1_local_gem, @tempdir
+
+    set = Gem::Resolver::InstallerSet.new :both
+    set.add_always_install dep("a")
+
+    assert_equal [Gem::Platform.local], set.always_install.map {|s| s.platform }
+  end
+
   def test_add_always_install_prerelease
     spec_fetcher do |fetcher|
       fetcher.gem "a", 1


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Using s3 bucket to serve gem with multiple platforms leads to "Could not find a valid gem" error (see #5780)

## What is your fix for the problem, implemented in this PR?

Replace `String` platform with `Gem::Platform` in `Gem::Resolver::IndexSpecification` so  `===` check doesn't fail because of class mismatch.

Fixes #5780.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
