### PR TITLE
Fix `bundle outdated` crash in debug mode

### DIFF
--- a/bundler/lib/bundler/cli/outdated.rb
+++ b/bundler/lib/bundler/cli/outdated.rb
@@ -129,6 +129,12 @@ module Bundler
 
     private
 
+    def loaded_from_for(spec)
+      return unless spec.respond_to?(:loaded_from)
+
+      spec.loaded_from
+    end
+
     def groups_text(group_text, groups)
       "#{group_text}#{groups.split(",").size > 1 ? "s" : ""} \"#{groups}\""
     end
@@ -184,7 +190,10 @@ module Bundler
 
     def print_gem(current_spec, active_spec, dependency, groups)
       spec_version = "#{active_spec.version}#{active_spec.git_version}"
-      spec_version += " (from #{active_spec.loaded_from})" if Bundler.ui.debug? && active_spec.loaded_from
+      if Bundler.ui.debug?
+        loaded_from = loaded_from_for(active_spec)
+        spec_version += " (from #{loaded_from})" if loaded_from
+      end
       current_version = "#{current_spec.version}#{current_spec.git_version}"
 
       if dependency && dependency.specific?
@@ -211,7 +220,7 @@ module Bundler
       dependency = dependency.requirement if dependency
 
       ret_val = [active_spec.name, current_version, spec_version, dependency.to_s, groups.to_s]
-      ret_val << active_spec.loaded_from.to_s if Bundler.ui.debug?
+      ret_val << loaded_from_for(active_spec).to_s if Bundler.ui.debug?
       ret_val
     end
 

--- a/bundler/spec/commands/outdated_spec.rb
+++ b/bundler/spec/commands/outdated_spec.rb
@@ -1207,6 +1207,18 @@ RSpec.describe "bundle outdated" do
 
         expect(out).to end_with(expected_output)
       end
+
+      it "shows gems with --strict updating to patch and filtering to patch, in debug mode" do
+        bundle "outdated --patch --strict --filter-patch", :raise_on_error => false, :env => { "DEBUG" => "1" }
+
+        expected_output = <<~TABLE.strip
+          Gem  Current  Latest  Requested  Groups   Path
+          bar  2.0.3    2.0.5
+          foo  1.4.3    1.4.4   >= 0       default
+        TABLE
+
+        expect(out).to end_with(expected_output)
+      end
     end
   end
 

--- a/bundler/spec/commands/outdated_spec.rb
+++ b/bundler/spec/commands/outdated_spec.rb
@@ -1114,8 +1114,7 @@ RSpec.describe "bundle outdated" do
           gem 'major', '1.0.0'
         G
 
-        # remove 1.4.3 requirement and bar altogether
-        # to setup update specs below
+        # remove all version requirements
         gemfile <<-G
           source "#{file_uri_for(gem_repo4)}"
           gem 'patch'


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Running `bundle outdated` in debug mode (with `DEBUG` environment variable set) would crash like this

    $ /Users/deivid/.asdf/installs/ruby/3.1.2/bin/ruby -I/Users/deivid/Code/rubygems/rubygems/bundler/spec -r/Users/deivid/Code/rubygems/rubygems/bundler/spec/support/artifice/fail.rb -r/Users/deivid/Code/rubygems/rubygems/bundler/spec/support/hax.rb /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/bin/bundle outdated --patch --strict --filter-patch
    Running `bundle outdated --filter-patch --patch --strict` with bundler 2.4.0.dev
    Found changes from the lockfile, re-resolving dependencies because bundler is unlocking Using a local server, bundler won't use the CompactIndex API
    Fetching source index from file:///Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/remote4/
    Resolving dependencies...
    --- ERROR REPORT TEMPLATE -------------------------------------------------------
    
    ```
    RuntimeError: LazySpecification has not been materialized yet (calling :loaded_from [])
      /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/lazy_specification.rb:147:in `method_missing'
      /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/cli/outdated.rb:214:in `gem_column_for'
      /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/cli/outdated.rb:174:in `block in print_gems_table'
      /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/cli/outdated.rb:173:in `map'
      /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/cli/outdated.rb:173:in `print_gems_table'
      /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/cli/outdated.rb:123:in `run'
      /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/cli.rb:420:in `outdated'
      /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
      /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
      /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
      /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/cli.rb:31:in `dispatch'
      /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
      /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/cli.rb:25:in `start'
      /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/exe/bundle:48:in `block in <top (required)>'
      /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/friendly_errors.rb:120:in `with_friendly_errors'
      /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/exe/bundle:36:in `<top (required)>'
      /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/bin/bundle:25:in `load'
      /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/bin/bundle:25:in `<main>'
    ```

## What is your fix for the problem, implemented in this PR?

Correctly handle the case when dealing with specifications not loaded from file system.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
