### PR TITLE
Fix `bundle outdated --strict` showing too many outdated gems

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -401,9 +401,9 @@ module Bundler
       "Do not attempt to fetch gems remotely and use the gem cache instead"
     method_option "pre", :type => :boolean, :banner => "Check for newer pre-release gems"
     method_option "source", :type => :array, :banner => "Check against a specific source"
-    method_option "filter-strict", :type => :boolean, :banner =>
+    method_option "filter-strict", :type => :boolean, :aliases => "--strict", :banner =>
       "Only list newer versions allowed by your Gemfile requirements"
-    method_option "strict", :type => :boolean, :aliases => "--update-strict", :banner =>
+    method_option "update-strict", :type => :boolean, :banner =>
       "Strict conservative resolution, do not allow any gem to be updated past latest --patch | --minor | --major"
     method_option "minor", :type => :boolean, :banner => "Prefer updating only to next minor version"
     method_option "major", :type => :boolean, :banner => "Prefer updating to next major version (default)"

--- a/bundler/lib/bundler/cli/outdated.rb
+++ b/bundler/lib/bundler/cli/outdated.rb
@@ -46,7 +46,7 @@ module Bundler
 
       Bundler::CLI::Common.configure_gem_version_promoter(
         Bundler.definition,
-        options
+        options.merge(:strict => @strict)
       )
 
       definition_resolution = proc do

--- a/bundler/spec/commands/outdated_spec.rb
+++ b/bundler/spec/commands/outdated_spec.rb
@@ -604,6 +604,22 @@ RSpec.describe "bundle outdated" do
       expect(out).to end_with(expected_output)
     end
 
+    it "only reports gems that have a newer version that matches the specified dependency version requirements, using --strict alias" do
+      update_repo2 do
+        build_gem "activesupport", "3.0"
+        build_gem "weakling", "0.0.5"
+      end
+
+      bundle :outdated, :strict => true, :raise_on_error => false
+
+      expected_output = <<~TABLE.strip
+        Gem       Current  Latest  Requested  Groups
+        weakling  0.0.3    0.0.5   ~> 0.0.1   default
+      TABLE
+
+      expect(out).to end_with(expected_output)
+    end
+
     it "doesn't crash when some deps unused on the current platform" do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"

--- a/bundler/spec/commands/outdated_spec.rb
+++ b/bundler/spec/commands/outdated_spec.rb
@@ -1098,127 +1098,125 @@ RSpec.describe "bundle outdated" do
   end
 
   context "conservative updates" do
-    context "without --strict" do
-      before do
-        build_repo4 do
-          build_gem "patch", %w[1.0.0 1.0.1]
-          build_gem "minor", %w[1.0.0 1.0.1 1.1.0]
-          build_gem "major", %w[1.0.0 1.0.1 1.1.0 2.0.0]
-        end
-
-        # establish a lockfile set to 1.0.0
-        install_gemfile <<-G
-          source "#{file_uri_for(gem_repo4)}"
-          gem 'patch', '1.0.0'
-          gem 'minor', '1.0.0'
-          gem 'major', '1.0.0'
-        G
-
-        # remove all version requirements
-        gemfile <<-G
-          source "#{file_uri_for(gem_repo4)}"
-          gem 'patch'
-          gem 'minor'
-          gem 'major'
-        G
+    before do
+      build_repo4 do
+        build_gem "patch", %w[1.0.0 1.0.1]
+        build_gem "minor", %w[1.0.0 1.0.1 1.1.0]
+        build_gem "major", %w[1.0.0 1.0.1 1.1.0 2.0.0]
       end
 
-      it "shows nothing when patching and filtering to minor" do
-        bundle "outdated --patch --filter-minor"
+      # establish a lockfile set to 1.0.0
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo4)}"
+        gem 'patch', '1.0.0'
+        gem 'minor', '1.0.0'
+        gem 'major', '1.0.0'
+      G
 
-        expect(out).to end_with("No minor updates to display.")
-      end
-
-      it "shows all gems when patching and filtering to patch" do
-        bundle "outdated --patch --filter-patch", :raise_on_error => false
-
-        expected_output = <<~TABLE.strip
-          Gem    Current  Latest  Requested  Groups
-          major  1.0.0    1.0.1   >= 0       default
-          minor  1.0.0    1.0.1   >= 0       default
-          patch  1.0.0    1.0.1   >= 0       default
-        TABLE
-
-        expect(out).to end_with(expected_output)
-      end
-
-      it "shows minor and major when updating to minor and filtering to patch and minor" do
-        bundle "outdated --minor --filter-minor", :raise_on_error => false
-
-        expected_output = <<~TABLE.strip
-          Gem    Current  Latest  Requested  Groups
-          major  1.0.0    1.1.0   >= 0       default
-          minor  1.0.0    1.1.0   >= 0       default
-        TABLE
-
-        expect(out).to end_with(expected_output)
-      end
-
-      it "shows minor when updating to major and filtering to minor with parseable" do
-        bundle "outdated --major --filter-minor --parseable", :raise_on_error => false
-
-        expect(out).not_to include("patch (newest")
-        expect(out).to include("minor (newest")
-        expect(out).not_to include("major (newest")
-      end
+      # remove all version requirements
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo4)}"
+        gem 'patch'
+        gem 'minor'
+        gem 'major'
+      G
     end
 
-    context "with --strict" do
-      before do
-        build_repo4 do
-          build_gem "foo", %w[1.4.3 1.4.4] do |s|
-            s.add_dependency "bar", "~> 2.0"
-          end
-          build_gem "foo", %w[1.4.5 1.5.0] do |s|
-            s.add_dependency "bar", "~> 2.1"
-          end
-          build_gem "foo", %w[1.5.1] do |s|
-            s.add_dependency "bar", "~> 3.0"
-          end
-          build_gem "bar", %w[2.0.3 2.0.4 2.0.5 2.1.0 2.1.1 3.0.0]
-          build_gem "qux", %w[1.0.0 1.1.0 2.0.0]
+    it "shows nothing when patching and filtering to minor" do
+      bundle "outdated --patch --filter-minor"
+
+      expect(out).to end_with("No minor updates to display.")
+    end
+
+    it "shows all gems when patching and filtering to patch" do
+      bundle "outdated --patch --filter-patch", :raise_on_error => false
+
+      expected_output = <<~TABLE.strip
+        Gem    Current  Latest  Requested  Groups
+        major  1.0.0    1.0.1   >= 0       default
+        minor  1.0.0    1.0.1   >= 0       default
+        patch  1.0.0    1.0.1   >= 0       default
+      TABLE
+
+      expect(out).to end_with(expected_output)
+    end
+
+    it "shows minor and major when updating to minor and filtering to patch and minor" do
+      bundle "outdated --minor --filter-minor", :raise_on_error => false
+
+      expected_output = <<~TABLE.strip
+        Gem    Current  Latest  Requested  Groups
+        major  1.0.0    1.1.0   >= 0       default
+        minor  1.0.0    1.1.0   >= 0       default
+      TABLE
+
+      expect(out).to end_with(expected_output)
+    end
+
+    it "shows minor when updating to major and filtering to minor with parseable" do
+      bundle "outdated --major --filter-minor --parseable", :raise_on_error => false
+
+      expect(out).not_to include("patch (newest")
+      expect(out).to include("minor (newest")
+      expect(out).not_to include("major (newest")
+    end
+  end
+
+  context "tricky conservative updates" do
+    before do
+      build_repo4 do
+        build_gem "foo", %w[1.4.3 1.4.4] do |s|
+          s.add_dependency "bar", "~> 2.0"
         end
-
-        # establish a lockfile set to 1.4.3
-        install_gemfile <<-G
-          source "#{file_uri_for(gem_repo4)}"
-          gem 'foo', '1.4.3'
-          gem 'bar', '2.0.3'
-          gem 'qux', '1.0.0'
-        G
-
-        # remove 1.4.3 requirement and bar altogether
-        # to setup update specs below
-        gemfile <<-G
-          source "#{file_uri_for(gem_repo4)}"
-          gem 'foo'
-          gem 'qux'
-        G
+        build_gem "foo", %w[1.4.5 1.5.0] do |s|
+          s.add_dependency "bar", "~> 2.1"
+        end
+        build_gem "foo", %w[1.5.1] do |s|
+          s.add_dependency "bar", "~> 3.0"
+        end
+        build_gem "bar", %w[2.0.3 2.0.4 2.0.5 2.1.0 2.1.1 3.0.0]
+        build_gem "qux", %w[1.0.0 1.1.0 2.0.0]
       end
 
-      it "shows gems with --strict updating to patch and filtering to patch" do
-        bundle "outdated --patch --strict --filter-patch", :raise_on_error => false
+      # establish a lockfile set to 1.4.3
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo4)}"
+        gem 'foo', '1.4.3'
+        gem 'bar', '2.0.3'
+        gem 'qux', '1.0.0'
+      G
 
-        expected_output = <<~TABLE.strip
-          Gem  Current  Latest  Requested  Groups
-          bar  2.0.3    2.0.5
-          foo  1.4.3    1.4.4   >= 0       default
-        TABLE
+      # remove 1.4.3 requirement and bar altogether
+      # to setup update specs below
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo4)}"
+        gem 'foo'
+        gem 'qux'
+      G
+    end
 
-        expect(out).to end_with(expected_output)
-      end
+    it "shows gems updating to patch and filtering to patch" do
+      bundle "outdated --patch --filter-patch", :raise_on_error => false, :env => { "DEBUG_RESOLVER" => "1" }
 
-      it "shows gems with --strict updating to patch and filtering to patch, in debug mode" do
-        bundle "outdated --patch --strict --filter-patch", :raise_on_error => false, :env => { "DEBUG" => "1" }
+      expected_output = <<~TABLE.strip
+        Gem  Current  Latest  Requested  Groups
+        bar  2.0.3    2.0.5
+        foo  1.4.3    1.4.4   >= 0       default
+      TABLE
 
-        expected_output = <<~TABLE.strip
-          Gem  Current  Latest  Requested  Groups   Path
-          bar  2.0.3    2.0.5
-          foo  1.4.3    1.4.4   >= 0       default
-        TABLE
+      expect(out).to end_with(expected_output)
+    end
 
-        expect(out).to end_with(expected_output)
-      end
+    it "shows gems updating to patch and filtering to patch, in debug mode" do
+      bundle "outdated --patch --filter-patch", :raise_on_error => false, :env => { "DEBUG" => "1" }
+
+      expected_output = <<~TABLE.strip
+        Gem  Current  Latest  Requested  Groups   Path
+        bar  2.0.3    2.0.5
+        foo  1.4.3    1.4.4   >= 0       default
+      TABLE
+
+      expect(out).to end_with(expected_output)
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`bundle outdated --strict` is behaving like `bundle outdated`. Instead, it should only show outdated gems allowed by Gemfile requirements.

## What is your fix for the problem, implemented in this PR?

My fix is to make `--strict` and alias of `--filter-strict`. Previously it was an alias to `--update-strict` which is a legacy flag with no associated special behavior.

Fixes #5717.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
