### PR TITLE
Don't create broken symlinks when a gem includes them, but print a warning instead

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -490,15 +490,7 @@ class Gem::Installer
     spec.executables.each do |filename|
       filename.tap(&Gem::UNTAINT)
       bin_path = File.join gem_dir, spec.bindir, filename
-
-      unless File.exist? bin_path
-        if File.symlink? bin_path
-          alert_warning "`#{bin_path}` is dangling symlink pointing to `#{File.readlink bin_path}`"
-        else
-          alert_warning "`#{bin_path}` does not exist, maybe `gem pristine #{spec.name}` will fix it?"
-        end
-        next
-      end
+      next unless File.exist? bin_path
 
       mode = File.stat(bin_path).mode
       dir_mode = options[:prog_mode] || (mode | 0111)

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -411,15 +411,16 @@ EOM
     directories = []
     open_tar_gz io do |tar|
       tar.each do |entry|
-        next unless File.fnmatch pattern, entry.full_name, File::FNM_DOTMATCH
+        full_name = entry.full_name
+        next unless File.fnmatch pattern, full_name, File::FNM_DOTMATCH
 
-        destination = install_location entry.full_name, destination_dir
+        destination = install_location full_name, destination_dir
 
         if entry.symlink?
           link_target = entry.header.linkname
           real_destination = link_target.start_with?("/") ? link_target : File.expand_path(link_target, File.dirname(destination))
 
-          raise Gem::Package::SymlinkError.new(entry.full_name, real_destination, destination_dir) unless
+          raise Gem::Package::SymlinkError.new(full_name, real_destination, destination_dir) unless
             normalize_path(real_destination).start_with? normalize_path(destination_dir + "/")
         end
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -756,7 +756,10 @@ gem 'other', version
       end
     end
 
-    assert_match %r{bin/ascii_binder` is dangling symlink pointing to `bin/asciibinder`}, @ui.error
+    errors = @ui.error.split("\n")
+    assert_equal "WARNING:  ascii_binder-0.1.10.1 ships with a dangling symlink named bin/ascii_binder pointing to missing bin/asciibinder file. Ignoring", errors.shift
+    assert_empty errors
+
     assert_empty @ui.output
   end
 

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -529,6 +529,7 @@ class TestGemPackage < Gem::Package::TarTestCase
 
   def test_extract_tar_gz_symlink_relative_path
     package = Gem::Package.new @gem
+    package.verify
 
     tgz_io = util_tar_gz do |tar|
       tar.add_file "relative.rb", 0644 do |io|
@@ -555,6 +556,27 @@ class TestGemPackage < Gem::Package::TarTestCase
                  File.readlink(extracted)
     assert_equal "hi",
                  File.read(extracted)
+  end
+
+  def test_extract_tar_gz_symlink_broken_relative_path
+    package = Gem::Package.new @gem
+    package.verify
+
+    tgz_io = util_tar_gz do |tar|
+      tar.mkdir       "lib", 0755
+      tar.add_symlink "lib/foo.rb", "../broken.rb", 0644
+    end
+
+    ui = Gem::MockGemUi.new
+
+    use_ui ui do
+      package.extract_tar_gz tgz_io, @destination
+    end
+
+    assert_equal "WARNING:  a-2 ships with a dangling symlink named lib/foo.rb pointing to missing ../broken.rb file. Ignoring\n", ui.error
+
+    extracted = File.join @destination, "lib/foo.rb"
+    assert_path_not_exist extracted
   end
 
   def test_extract_symlink_parent


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If a gem includes broken symlinks, RubyGems installs the broken symlinks. Except on Windows, where it crashes if user is not capable of creating symlinks.

## What is your fix for the problem, implemented in this PR?

A broken symlink is useless, so I think RubyGems can detect whether the symlink is broken and print a warning instead of installing it. We were already doing this for executables, but I think this makes sense for all files in a gem.

Incidentally, doing this fixes the particular case of #5768 because RubyGems will no longer try to install the symlink at all, and thus will not crash on Windows.

Closes #5768.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
