### PR TITLE
Don't deduplicate materialization unnecessarily

### DIFF
--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -64,7 +64,7 @@ module Bundler
     end
 
     def materialize(deps)
-      materialized = self.for(deps, true).uniq
+      materialized = self.for(deps, true)
 
       SpecSet.new(materialized)
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

A flaky test failure: https://github.com/rubygems/rubygems/runs/7628667512?check_suite_focus=true.

## What is your fix for the problem, implemented in this PR?

I'm not sure about the root cause, but I think we can remove the code causing it altogether.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
