### PR TITLE
Automatically remove "ruby" from lockfile if incomplete

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -484,6 +484,7 @@ module Bundler
 
     def reresolve
       last_resolve = converge_locked_specs
+      remove_ruby_from_platforms_if_necessary!(dependencies)
       expanded_dependencies = expand_dependencies(dependencies + metadata_dependencies, true)
       Resolver.resolve(expanded_dependencies, source_requirements, last_resolve, gem_version_promoter, additional_base_requirements_for_resolve, platforms)
     end
@@ -863,6 +864,17 @@ module Bundler
         dep = Dependency.new(name, ">= #{locked_spec.version}")
         DepProxy.get_proxy(dep, locked_spec.platform)
       end
+    end
+
+    def remove_ruby_from_platforms_if_necessary!(dependencies)
+      return if Bundler.frozen_bundle? ||
+        Bundler.local_platform == Gem::Platform::RUBY ||
+        !platforms.include?(Gem::Platform::RUBY) ||
+        (@new_platform && platforms.last == Gem::Platform::RUBY) ||
+        !@originally_locked_specs.incomplete_ruby_specs?(dependencies)
+
+      remove_platform(Gem::Platform::RUBY)
+      add_current_platform
     end
 
     def source_map

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -91,6 +91,10 @@ module Bundler
       SpecSet.new(materialized)
     end
 
+    def incomplete_ruby_specs?(deps)
+      self.class.new(self.for(deps, true, [Gem::Platform::RUBY])).incomplete_specs.any?
+    end
+
     def missing_specs
       @specs.select {|s| s.is_a?(LazySpecification) }
     end

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -374,6 +374,77 @@ RSpec.describe "bundle install with specific platforms" do
     ERROR
   end
 
+  it "automatically fixes the lockfile if RUBY platform is locked and some gem has no RUBY variant available" do
+    build_repo4 do
+      build_gem("sorbet-static-and-runtime", "0.5.10160") do |s|
+        s.add_runtime_dependency "sorbet", "= 0.5.10160"
+        s.add_runtime_dependency "sorbet-runtime", "= 0.5.10160"
+      end
+
+      build_gem("sorbet", "0.5.10160") do |s|
+        s.add_runtime_dependency "sorbet-static", "= 0.5.10160"
+      end
+
+      build_gem("sorbet-runtime", "0.5.10160")
+
+      build_gem("sorbet-static", "0.5.10160") do |s|
+        s.platform = Gem::Platform.local
+      end
+    end
+
+    gemfile <<~G
+      source "#{file_uri_for(gem_repo4)}"
+
+      gem "sorbet-static-and-runtime"
+    G
+
+    lockfile <<~L
+      GEM
+        remote: #{file_uri_for(gem_repo4)}/
+        specs:
+          sorbet (0.5.10160)
+            sorbet-static (= 0.5.10160)
+          sorbet-runtime (0.5.10160)
+          sorbet-static (0.5.10160-#{Gem::Platform.local})
+          sorbet-static-and-runtime (0.5.10160)
+            sorbet (= 0.5.10160)
+            sorbet-runtime (= 0.5.10160)
+
+      PLATFORMS
+        #{lockfile_platforms_for([specific_local_platform, "ruby"])}
+
+      DEPENDENCIES
+        sorbet-static-and-runtime
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+    bundle "update"
+
+    expect(lockfile).to eq <<~L
+      GEM
+        remote: #{file_uri_for(gem_repo4)}/
+        specs:
+          sorbet (0.5.10160)
+            sorbet-static (= 0.5.10160)
+          sorbet-runtime (0.5.10160)
+          sorbet-static (0.5.10160-#{Gem::Platform.local})
+          sorbet-static-and-runtime (0.5.10160)
+            sorbet (= 0.5.10160)
+            sorbet-runtime (= 0.5.10160)
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        sorbet-static-and-runtime
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+  end
+
   it "can fallback to a source gem when platform gems are incompatible with current ruby version" do
     setup_multiplatform_gem_with_source_gem
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

With #5495 we started being strict about lockfiles locked to "ruby" but not including exclusively gems NOT platform specific.

This was done because:

* These lockfiles were creating further issues down the road.
* The fix in the platform matching introduced there may unblock #4488.

However, with this fix, `bundle update` or `bundle outdated` can no longer be run on already existing lockfiles with the previous problem, generating a missing gems error like the following:

```
Fetching gem metadata from https://rubygems.org/...
Resolving dependencies...
Bundler could not find compatible versions for gem "sorbet-static":
  In snapshot (Gemfile.lock):
    sorbet-static (>= 0.5.10160)

  In Gemfile:
    sorbet-static-and-runtime was resolved to 0.5.10160, which depends on
      sorbet (= 0.5.10160) was resolved to 0.5.10160, which depends on
        sorbet-static (= 0.5.10160)

Deleting your Gemfile.lock file and running `bundle install` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
Bundler could not find compatible versions for gem "sorbet-static-and-runtime":
  In snapshot (Gemfile.lock):
    sorbet-static-and-runtime (>= 0.5.10160)

  In Gemfile:
    sorbet-static-and-runtime

Deleting your Gemfile.lock file and running `bundle install` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```

## What is your fix for the problem, implemented in this PR?

My fix is to automatically remove the "ruby" platform from these "corrupted" lockfiles, so that they resolve properly.

Fixes #5743.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
