### PR TITLE
Bundler lockfile checksums

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -21,6 +21,7 @@ bundler/lib/bundler.rb
 bundler/lib/bundler/.document
 bundler/lib/bundler/build_metadata.rb
 bundler/lib/bundler/capistrano.rb
+bundler/lib/bundler/checksum.rb
 bundler/lib/bundler/cli.rb
 bundler/lib/bundler/cli/add.rb
 bundler/lib/bundler/cli/binstubs.rb

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -49,6 +49,7 @@ module Bundler
     end
   end
 
+  autoload :Checksum,               File.expand_path("bundler/checksum", __dir__)
   autoload :Definition,             File.expand_path("bundler/definition", __dir__)
   autoload :Dependency,             File.expand_path("bundler/dependency", __dir__)
   autoload :Deprecate,              File.expand_path("bundler/deprecate", __dir__)

--- a/bundler/lib/bundler/checksum.rb
+++ b/bundler/lib/bundler/checksum.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Bundler
+  class Checksum
+    attr_reader :name, :version, :platform
+    attr_accessor :checksum
+
+    def initialize(name, version, platform, checksum = nil)
+      @name     = name
+      @version  = version
+      @platform = platform || Gem::Platform::RUBY
+      @checksum = checksum
+    end
+
+    def match_spec?(spec)
+      name == spec.name &&
+        version == spec.version &&
+        platform.to_s == spec.platform.to_s
+    end
+
+    def to_lock
+      out = String.new
+
+      if platform == Gem::Platform::RUBY
+        out << "  #{name} (#{version})\n"
+      else
+        out << "  #{name} (#{version}-#{platform})\n"
+      end
+
+      out << "    #{checksum}\n" if checksum
+
+      out
+    end
+  end
+end

--- a/bundler/lib/bundler/checksum.rb
+++ b/bundler/lib/bundler/checksum.rb
@@ -5,7 +5,7 @@ module Bundler
     attr_reader :name, :version, :platform
     attr_accessor :checksum
 
-    SHA256 = /\Asha256-[a-z0-9]{64}\z/.freeze
+    SHA256 = /\Asha256-([a-z0-9]{64}|[A-Za-z0-9+\/=]{44})\z/.freeze
 
     def initialize(name, version, platform, checksum = nil)
       @name     = name

--- a/bundler/lib/bundler/checksum.rb
+++ b/bundler/lib/bundler/checksum.rb
@@ -5,11 +5,17 @@ module Bundler
     attr_reader :name, :version, :platform
     attr_accessor :checksum
 
+    SHA256 = /\Asha256-[a-z0-9]{64}\z/.freeze
+
     def initialize(name, version, platform, checksum = nil)
       @name     = name
       @version  = version
       @platform = platform || Gem::Platform::RUBY
       @checksum = checksum
+
+      if @checksum && @checksum !~ SHA256
+        raise ArgumentError, "invalid checksum (#{@checksum})"
+      end
     end
 
     def match_spec?(spec)
@@ -22,12 +28,13 @@ module Bundler
       out = String.new
 
       if platform == Gem::Platform::RUBY
-        out << "  #{name} (#{version})\n"
+        out << "  #{name} (#{version})"
       else
-        out << "  #{name} (#{version}-#{platform})\n"
+        out << "  #{name} (#{version}-#{platform})"
       end
 
-      out << "    #{checksum}\n" if checksum
+      out << " #{checksum}" if checksum
+      out << "\n"
 
       out
     end

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -15,6 +15,7 @@ module Bundler
       :dependencies,
       :locked_deps,
       :locked_gems,
+      :locked_checksums,
       :platforms,
       :ruby_version,
       :lockfile,
@@ -88,6 +89,7 @@ module Bundler
         @locked_bundler_version = @locked_gems.bundler_version
         @locked_ruby_version = @locked_gems.ruby_version
         @originally_locked_specs = SpecSet.new(@locked_gems.specs)
+        @locked_checksums = @locked_gems.checksums
 
         if unlock != true
           @locked_deps    = @locked_gems.dependencies
@@ -108,6 +110,7 @@ module Bundler
         @originally_locked_specs = @locked_specs
         @locked_sources = []
         @locked_platforms = []
+        @locked_checksums = []
       end
 
       locked_gem_sources = @locked_sources.select {|s| s.is_a?(Source::Rubygems) }

--- a/bundler/lib/bundler/endpoint_specification.rb
+++ b/bundler/lib/bundler/endpoint_specification.rb
@@ -108,6 +108,11 @@ module Bundler
       @remote_specification = spec
     end
 
+    def to_checksum
+      digest = "sha256-#{checksum}" if checksum
+      Bundler::Checksum.new(name, version, platform, digest)
+    end
+
     private
 
     def _remote_specification

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -133,42 +133,15 @@ module Bundler
     def to_checksum
       return nil unless @specification
 
-      # If a spec started off as a generic ruby platform, and is resolved
-      # to something more specific on install time, we skip recording the
-      # checksum.
-      # For example if we have:
       #
-      #     specs:
-      #       pry (0.11.3)
+      # See comment about #ruby_platform_materializes_to_ruby_platform?
+      # If the old lockfile format is present where there is no specific
+      # platform, then we should skip locking checksums as it is not
+      # deterministic which platform variant is locked.
       #
-      #   PLATFORMS
-      #     ruby
-      #     java
-      #
-      # Recording the checksum for ruby does not make sense, because we
-      # will end up with something like:
-      #
-      #     specs:
-      #       pry (0.11.3)
-      #
-      #   CHECKSUMS
-      #     pry(0.11.3-java)
-      #       1f0bd9ce0282e8a20151011e4677746206a0c84b648e0a1c981b3232bb47a3b9
-      #     pry(0.11.3-java)
-      #       1f0bd9ce0282e8a20151011e4677746206a0c84b648e0a1c981b3232bb47a3b9
-      #
-      #   PLATFORMS
-      #     ruby
-      #     java
-      return nil if generic_platform_with_specific_installed_platform?
+      return nil unless ruby_platform_materializes_to_ruby_platform?
 
       @specification.to_checksum
-    end
-
-    def generic_platform_with_specific_installed_platform?
-      raise "LazySpecification has not been materialized yet" unless @specification
-
-      !ruby_platform_materializes_to_ruby_platform? && @specification.platform != platform
     end
 
     private

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -77,6 +77,18 @@ module Bundler
       out
     end
 
+    #def materialize_for_checksum
+      #if @specification
+        #yield
+      #else
+        #materialize_for_installation
+
+        #yield
+
+        #@specification = nil
+      #end
+    #end
+
     def materialize_for_installation
       source.local!
 

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -130,6 +130,47 @@ module Bundler
       " #{source.revision[0..6]}"
     end
 
+    def to_checksum
+      return nil unless @specification
+
+      # If a spec started off as a generic ruby platform, and is resolved
+      # to something more specific on install time, we skip recording the
+      # checksum.
+      # For example if we have:
+      #
+      #     specs:
+      #       pry (0.11.3)
+      #
+      #   PLATFORMS
+      #     ruby
+      #     java
+      #
+      # Recording the checksum for ruby does not make sense, because we
+      # will end up with something like:
+      #
+      #     specs:
+      #       pry (0.11.3)
+      #
+      #   CHECKSUMS
+      #     pry(0.11.3-java)
+      #       1f0bd9ce0282e8a20151011e4677746206a0c84b648e0a1c981b3232bb47a3b9
+      #     pry(0.11.3-java)
+      #       1f0bd9ce0282e8a20151011e4677746206a0c84b648e0a1c981b3232bb47a3b9
+      #
+      #   PLATFORMS
+      #     ruby
+      #     java
+      return nil if generic_platform_with_specific_installed_platform?
+
+      @specification.to_checksum
+    end
+
+    def generic_platform_with_specific_installed_platform?
+      raise "LazySpecification has not been materialized yet" unless @specification
+
+      !ruby_platform_materializes_to_ruby_platform? && @specification.platform != platform
+    end
+
     private
 
     def to_ary

--- a/bundler/lib/bundler/lockfile_generator.rb
+++ b/bundler/lib/bundler/lockfile_generator.rb
@@ -72,6 +72,12 @@ module Bundler
       definition.resolve.sort_by(&:full_name).each do |spec|
         checksum = spec.to_checksum if spec.respond_to?(:to_checksum)
 
+        #if spec.is_a?(LazySpecification)
+          #spec.materialize_for_checksum do
+            #checksum ||= spec.to_checksum if spec.respond_to?(:to_checksum)
+          #end
+        #end
+
         checksum ||= definition.locked_checksums.find {|c| c.match_spec?(spec) }
 
         out << checksum.to_lock if checksum

--- a/bundler/lib/bundler/lockfile_generator.rb
+++ b/bundler/lib/bundler/lockfile_generator.rb
@@ -19,6 +19,7 @@ module Bundler
       add_sources
       add_platforms
       add_dependencies
+      add_checksums
       add_locked_ruby_version
       add_bundled_with
 
@@ -62,6 +63,19 @@ module Bundler
         next if handled.include?(dep.name)
         out << dep.to_lock << "\n"
         handled << dep.name
+      end
+    end
+
+    def add_checksums
+      out << "\nCHECKSUMS\n"
+
+      definition.resolve.sort_by(&:full_name).each do |spec|
+        if spec.respond_to?(:to_checksum)
+          out << spec.to_checksum.to_lock
+        else
+          locked_checksum = definition.locked_checksums.find {|c| c.match_spec?(spec) }
+          out << locked_checksum.to_lock if locked_checksum
+        end
       end
     end
 

--- a/bundler/lib/bundler/lockfile_generator.rb
+++ b/bundler/lib/bundler/lockfile_generator.rb
@@ -70,12 +70,11 @@ module Bundler
       out << "\nCHECKSUMS\n"
 
       definition.resolve.sort_by(&:full_name).each do |spec|
-        if spec.respond_to?(:to_checksum)
-          out << spec.to_checksum.to_lock
-        else
-          locked_checksum = definition.locked_checksums.find {|c| c.match_spec?(spec) }
-          out << locked_checksum.to_lock if locked_checksum
-        end
+        checksum = spec.to_checksum if spec.respond_to?(:to_checksum)
+
+        checksum ||= definition.locked_checksums.find {|c| c.match_spec?(spec) }
+
+        out << checksum.to_lock if checksum
       end
     end
 

--- a/bundler/lib/bundler/lockfile_parser.rb
+++ b/bundler/lib/bundler/lockfile_parser.rb
@@ -16,7 +16,6 @@ module Bundler
     SPECS        = "  specs:"
     OPTIONS      = /^  ([a-z]+): (.*)$/i.freeze
     SOURCE       = [GIT, GEM, PATH, PLUGIN].freeze
-    CHECKSUM_LINE = /^    ([a-z0-9]+)$/i.freeze
 
     SECTIONS_BY_VERSION_INTRODUCED = {
       Gem::Version.create("1.0") => [DEPENDENCIES, PLATFORMS, GIT, GEM, PATH].freeze,
@@ -159,6 +158,7 @@ module Bundler
       (?:#{space}\(([^-]*)                               # Space, followed by version
       (?:-(.*))?\))?                                     # Optional platform
       (!)?                                               # Optional pinned marker
+      (?:#{space}(.*))?                                  # Optional checksum
       $                                                  # Line end
     /xo.freeze
 
@@ -192,20 +192,17 @@ module Bundler
     end
 
     def parse_checksum(line)
-      if line =~ CHECKSUM_LINE
-        checksum = $1
-        @current_checksum.checksum = checksum
-      elsif line =~ NAME_VERSION
+      if line =~ NAME_VERSION
         spaces = $1
         return unless spaces.size == 2
         name = $2
         version = $3
         platform = $4
+        checksum = $6
 
         version = Gem::Version.new(version)
         platform = platform ? Gem::Platform.new(platform) : Gem::Platform::RUBY
-        @current_checksum = Bundler::Checksum.new(name, version, platform)
-        @checksums << @current_checksum
+        @checksums << Bundler::Checksum.new(name, version, platform, checksum)
       end
     end
 

--- a/bundler/lib/bundler/lockfile_parser.rb
+++ b/bundler/lib/bundler/lockfile_parser.rb
@@ -2,10 +2,11 @@
 
 module Bundler
   class LockfileParser
-    attr_reader :sources, :dependencies, :specs, :platforms, :bundler_version, :ruby_version
+    attr_reader :sources, :dependencies, :specs, :platforms, :bundler_version, :ruby_version, :checksums
 
     BUNDLED      = "BUNDLED WITH"
     DEPENDENCIES = "DEPENDENCIES"
+    CHECKSUMS    = "CHECKSUMS"
     PLATFORMS    = "PLATFORMS"
     RUBY         = "RUBY VERSION"
     GIT          = "GIT"
@@ -15,12 +16,14 @@ module Bundler
     SPECS        = "  specs:"
     OPTIONS      = /^  ([a-z]+): (.*)$/i.freeze
     SOURCE       = [GIT, GEM, PATH, PLUGIN].freeze
+    CHECKSUM_LINE = /^    ([a-z0-9]+)$/i.freeze
 
     SECTIONS_BY_VERSION_INTRODUCED = {
       Gem::Version.create("1.0") => [DEPENDENCIES, PLATFORMS, GIT, GEM, PATH].freeze,
       Gem::Version.create("1.10") => [BUNDLED].freeze,
       Gem::Version.create("1.12") => [RUBY].freeze,
       Gem::Version.create("1.13") => [PLUGIN].freeze,
+      Gem::Version.create("2.4.0") => [CHECKSUMS].freeze,
     }.freeze
 
     KNOWN_SECTIONS = SECTIONS_BY_VERSION_INTRODUCED.values.flatten.freeze
@@ -60,6 +63,7 @@ module Bundler
       @platforms    = []
       @sources      = []
       @dependencies = {}
+      @checksums    = []
       @state        = nil
       @specs        = {}
 
@@ -74,6 +78,8 @@ module Bundler
           parse_source(line)
         elsif line == DEPENDENCIES
           @state = :dependency
+        elsif line == CHECKSUMS
+          @state = :checksum
         elsif line == PLATFORMS
           @state = :platform
         elsif line == RUBY
@@ -183,6 +189,24 @@ module Bundler
       end
 
       @dependencies[dep.name] = dep
+    end
+
+    def parse_checksum(line)
+      if line =~ CHECKSUM_LINE
+        checksum = $1
+        @current_checksum.checksum = checksum
+      elsif line =~ NAME_VERSION
+        spaces = $1
+        return unless spaces.size == 2
+        name = $2
+        version = $3
+        platform = $4
+
+        version = Gem::Version.new(version)
+        platform = platform ? Gem::Platform.new(platform) : Gem::Platform::RUBY
+        @current_checksum = Bundler::Checksum.new(name, version, platform)
+        @checksums << @current_checksum
+      end
     end
 
     def parse_spec(line)

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -115,6 +115,18 @@ module Gem
       gemfile
     end
 
+    def to_checksum
+      digest = if File.exist?(cache_file)
+        File.open(cache_file) do |f|
+          digest = Bundler::SharedHelpers.digest(:SHA256).new
+          digest << f.read(16_384) until f.eof?
+          digest.hexdigest!
+        end
+      end
+
+      Bundler::Checksum.new(name, version, platform, digest)
+    end
+
     # Backfill missing YAML require when not defined. Fixed since 3.1.0.pre1.
     module YamlBackfiller
       def to_yaml(opts = {})

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -115,19 +115,6 @@ module Gem
       gemfile
     end
 
-    def to_checksum
-      digest = if File.exist?(cache_file)
-        File.open(cache_file) do |f|
-          digest = Bundler::SharedHelpers.digest(:SHA256).new
-          digest << f.read(16_384) until f.eof?
-
-          "sha256-#{digest.hexdigest!}"
-        end
-      end
-
-      Bundler::Checksum.new(name, version, platform, digest)
-    end
-
     # Backfill missing YAML require when not defined. Fixed since 3.1.0.pre1.
     module YamlBackfiller
       def to_yaml(opts = {})

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -120,7 +120,8 @@ module Gem
         File.open(cache_file) do |f|
           digest = Bundler::SharedHelpers.digest(:SHA256).new
           digest << f.read(16_384) until f.eof?
-          digest.hexdigest!
+
+          "sha256-#{digest.hexdigest!}"
         end
       end
 

--- a/bundler/spec/bundler/definition_spec.rb
+++ b/bundler/spec/bundler/definition_spec.rb
@@ -77,6 +77,10 @@ RSpec.describe Bundler::Definition do
         DEPENDENCIES
           foo!
 
+        CHECKSUMS
+          foo (1.0)
+          #{checksum_for_repo_gem gem_repo1, "rack", "1.0.0"}
+
         BUNDLED WITH
            #{Bundler::VERSION}
       G
@@ -132,6 +136,10 @@ RSpec.describe Bundler::Definition do
         DEPENDENCIES
           foo!
 
+        CHECKSUMS
+          foo (1.0)
+          #{checksum_for_repo_gem gem_repo1, "rack", "1.0.0"}
+
         BUNDLED WITH
            #{Bundler::VERSION}
       G
@@ -159,6 +167,8 @@ RSpec.describe Bundler::Definition do
         DEPENDENCIES
           only_java
 
+        CHECKSUMS
+
         BUNDLED WITH
            #{Bundler::VERSION}
       G
@@ -184,6 +194,9 @@ RSpec.describe Bundler::Definition do
 
         DEPENDENCIES
           foo
+
+        CHECKSUMS
+          #{checksum_for_repo_gem gem_repo1, "foo", "1.0"}
 
         BUNDLED WITH
            #{Bundler::VERSION}

--- a/bundler/spec/bundler/lockfile_parser_spec.rb
+++ b/bundler/spec/bundler/lockfile_parser_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Bundler::LockfileParser do
 
       it "returns the same as > 1.0" do
         expect(subject).to contain_exactly(
-          described_class::BUNDLED, described_class::RUBY, described_class::PLUGIN
+          described_class::BUNDLED, described_class::CHECKSUMS, described_class::RUBY, described_class::PLUGIN
         )
       end
     end
@@ -70,7 +70,7 @@ RSpec.describe Bundler::LockfileParser do
 
       it "returns the same as for the release version" do
         expect(subject).to contain_exactly(
-          described_class::RUBY, described_class::PLUGIN
+          described_class::CHECKSUMS, described_class::RUBY, described_class::PLUGIN
         )
       end
     end

--- a/bundler/spec/commands/check_spec.rb
+++ b/bundler/spec/commands/check_spec.rb
@@ -425,6 +425,10 @@ RSpec.describe "bundle check" do
         DEPENDENCIES
           depends_on_rack!
 
+        CHECKSUMS
+          #{checksum_for_repo_gem gem_repo4, "depends_on_rack", "1.0"}
+          #{checksum_for_repo_gem gem_repo4, "rack", "1.0"}
+
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -487,6 +491,11 @@ RSpec.describe "bundle check" do
         DEPENDENCIES
           bundle-check-issue!
           dex-dispatch-engine!
+
+        CHECKSUMS
+          #{checksum_for_repo_gem gem_repo4, "awesome_print", "1.0"}
+          bundle-check-issue (9999)
+          #{checksum_for_repo_gem gem_repo2, "dex-dispatch-engine", "1.0"}
 
         BUNDLED WITH
            #{Bundler::VERSION}

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -545,6 +545,8 @@ RSpec.describe "bundle install with gem sources" do
 
          DEPENDENCIES
 
+         CHECKSUMS
+
          RUBY VERSION
             #{Bundler::RubyVersion.system}
 
@@ -568,6 +570,8 @@ RSpec.describe "bundle install with gem sources" do
            #{lockfile_platforms}
 
          DEPENDENCIES
+
+         CHECKSUMS
 
          RUBY VERSION
             #{Bundler::RubyVersion.system}
@@ -918,6 +922,13 @@ RSpec.describe "bundle install with gem sources" do
         gem "loofah", "~> 2.12.0"
       G
 
+      checksums = construct_checksum_section do |c|
+        c.repo_gem gem_repo4, "crass", "1.0.6"
+        c.repo_gem gem_repo4, "loofah", "2.12.0"
+        c.repo_gem gem_repo4, "nokogiri", "1.12.4", "x86_64-darwin"
+        c.repo_gem gem_repo4, "racc", "1.5.2"
+      end
+
       lockfile <<-L
         GEM
           remote: https://gem.repo4/
@@ -937,6 +948,9 @@ RSpec.describe "bundle install with gem sources" do
         DEPENDENCIES
           loofah (~> 2.12.0)
 
+        CHECKSUMS
+          #{checksums}
+
         RUBY VERSION
            #{Bundler::RubyVersion.system}
 
@@ -950,6 +964,14 @@ RSpec.describe "bundle install with gem sources" do
 
       simulate_platform "x86_64-linux" do
         bundle "install", :artifice => "compact_index"
+      end
+
+      expected_checksums = construct_checksum_section do |c|
+        c.repo_gem gem_repo4, "crass", "1.0.6"
+        c.repo_gem gem_repo4, "loofah", "2.12.0"
+        c.repo_gem gem_repo4, "nokogiri", "1.12.4", "x86_64-darwin"
+        c.repo_gem gem_repo4, "nokogiri", "1.12.4", "x86_64-linux"
+        c.repo_gem gem_repo4, "racc", "1.5.2"
       end
 
       expect(lockfile).to eq <<~L
@@ -972,6 +994,9 @@ RSpec.describe "bundle install with gem sources" do
 
         DEPENDENCIES
           loofah (~> 2.12.0)
+
+        CHECKSUMS
+          #{expected_checksums}
 
         RUBY VERSION
            #{Bundler::RubyVersion.system}

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -894,16 +894,16 @@ RSpec.describe "bundle install with gem sources" do
   context "with missing platform specific gems in lockfile" do
     before do
       build_repo4 do
-        build_gem "racc", "1.5.2"
+        build_gem "racca", "1.5.2"
 
         build_gem "nokogiri", "1.12.4" do |s|
           s.platform = "x86_64-darwin"
-          s.add_runtime_dependency "racc", "~> 1.4"
+          s.add_runtime_dependency "racca", "~> 1.4"
         end
 
         build_gem "nokogiri", "1.12.4" do |s|
           s.platform = "x86_64-linux"
-          s.add_runtime_dependency "racc", "~> 1.4"
+          s.add_runtime_dependency "racca", "~> 1.4"
         end
 
         build_gem "crass", "1.0.6"
@@ -926,7 +926,7 @@ RSpec.describe "bundle install with gem sources" do
         c.repo_gem gem_repo4, "crass", "1.0.6"
         c.repo_gem gem_repo4, "loofah", "2.12.0"
         c.repo_gem gem_repo4, "nokogiri", "1.12.4", "x86_64-darwin"
-        c.repo_gem gem_repo4, "racc", "1.5.2"
+        c.repo_gem gem_repo4, "racca", "1.5.2"
       end
 
       lockfile <<-L
@@ -938,8 +938,8 @@ RSpec.describe "bundle install with gem sources" do
               crass (~> 1.0.2)
               nokogiri (>= 1.5.9)
             nokogiri (1.12.4-x86_64-darwin)
-              racc (~> 1.4)
-            racc (1.5.2)
+              racca (~> 1.4)
+            racca (1.5.2)
 
         PLATFORMS
           x86_64-darwin-20
@@ -971,7 +971,7 @@ RSpec.describe "bundle install with gem sources" do
         c.repo_gem gem_repo4, "loofah", "2.12.0"
         c.repo_gem gem_repo4, "nokogiri", "1.12.4", "x86_64-darwin"
         c.repo_gem gem_repo4, "nokogiri", "1.12.4", "x86_64-linux"
-        c.repo_gem gem_repo4, "racc", "1.5.2"
+        c.repo_gem gem_repo4, "racca", "1.5.2"
       end
 
       expect(lockfile).to eq <<~L
@@ -983,10 +983,10 @@ RSpec.describe "bundle install with gem sources" do
               crass (~> 1.0.2)
               nokogiri (>= 1.5.9)
             nokogiri (1.12.4-x86_64-darwin)
-              racc (~> 1.4)
+              racca (~> 1.4)
             nokogiri (1.12.4-x86_64-linux)
-              racc (~> 1.4)
-            racc (1.5.2)
+              racca (~> 1.4)
+            racca (1.5.2)
 
         PLATFORMS
           x86_64-darwin-20

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -50,6 +50,8 @@ RSpec.describe "bundle lock" do
         rails
         weakling
 
+      CHECKSUMS
+
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -106,6 +108,8 @@ RSpec.describe "bundle lock" do
       DEPENDENCIES
         foo
 
+      CHECKSUMS
+
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -128,8 +132,58 @@ RSpec.describe "bundle lock" do
     bundle "install"
     bundle "lock --lockfile=lock"
 
+    expected_checksums = construct_checksum_section do |c|
+      c.repo_gem repo, "actionmailer", "2.3.2"
+      c.repo_gem repo, "actionpack", "2.3.2"
+      c.repo_gem repo, "activerecord", "2.3.2"
+      c.repo_gem repo, "activeresource", "2.3.2"
+      c.repo_gem repo, "activesupport", "2.3.2"
+      c.repo_gem repo, "foo", "1.0"
+      c.repo_gem repo, "rails", "2.3.2"
+      c.repo_gem repo, "rake", "13.0.1"
+      c.repo_gem repo, "weakling", "0.0.3"
+    end
+
+    lockfile = strip_lockfile(<<-L)
+      GEM
+        remote: #{file_uri_for(repo)}/
+        specs:
+          actionmailer (2.3.2)
+            activesupport (= 2.3.2)
+          actionpack (2.3.2)
+            activesupport (= 2.3.2)
+          activerecord (2.3.2)
+            activesupport (= 2.3.2)
+          activeresource (2.3.2)
+            activesupport (= 2.3.2)
+          activesupport (2.3.2)
+          foo (1.0)
+          rails (2.3.2)
+            actionmailer (= 2.3.2)
+            actionpack (= 2.3.2)
+            activerecord (= 2.3.2)
+            activeresource (= 2.3.2)
+            rake (= 13.0.1)
+          rake (13.0.1)
+          weakling (0.0.3)
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        foo
+        rails
+        weakling
+
+      CHECKSUMS
+        #{expected_checksums}
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
     expect(out).to match(/Writing lockfile to.+lock/)
-    expect(read_lockfile("lock")).to eq(@lockfile)
+    expect(read_lockfile("lock")).to eq(lockfile)
   end
 
   it "update specific gems using --update" do
@@ -382,6 +436,8 @@ RSpec.describe "bundle lock" do
         gssapi
         mixlib-shellout
 
+      CHECKSUMS
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -410,6 +466,8 @@ RSpec.describe "bundle lock" do
       DEPENDENCIES
         gssapi
         mixlib-shellout
+
+      CHECKSUMS
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -489,6 +547,8 @@ RSpec.describe "bundle lock" do
       DEPENDENCIES
         libv8
 
+      CHECKSUMS
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -523,6 +583,10 @@ RSpec.describe "bundle lock" do
 
       DEPENDENCIES
         libv8
+
+      CHECKSUMS
+        #{checksum_for_repo_gem gem_repo4, "libv8", "8.4.255.0", "x86_64-darwin-19"}
+        #{checksum_for_repo_gem gem_repo4, "libv8", "8.4.255.0", "x86_64-darwin-20"}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -686,6 +750,8 @@ RSpec.describe "bundle lock" do
         DEPENDENCIES
           debug
 
+        CHECKSUMS
+
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -708,6 +774,8 @@ RSpec.describe "bundle lock" do
 
         DEPENDENCIES
           debug
+
+        CHECKSUMS
 
         BUNDLED WITH
            #{Bundler::VERSION}

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -290,6 +290,8 @@ RSpec.describe "bundle update" do
           countries
           country_select
 
+        CHECKSUMS
+
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -505,6 +507,11 @@ RSpec.describe "bundle update" do
 
       original_lockfile = lockfile
 
+      expected_checksums = construct_checksum_section do |c|
+        c.repo_gem gem_repo4, "activesupport", "6.0.4.1"
+        c.repo_gem gem_repo4, "tzinfo", "1.2.9"
+      end
+
       expected_lockfile = <<~L
         GEM
           remote: #{file_uri_for(gem_repo4)}/
@@ -518,6 +525,9 @@ RSpec.describe "bundle update" do
 
         DEPENDENCIES
           activesupport (~> 6.0.0)
+
+        CHECKSUMS
+          #{expected_checksums}
 
         BUNDLED WITH
            #{Bundler::VERSION}
@@ -535,7 +545,25 @@ RSpec.describe "bundle update" do
       lockfile original_lockfile
       bundle "lock --update"
       expect(the_bundle).to include_gems("activesupport 6.0.4.1", "tzinfo 1.2.9")
-      expect(lockfile).to eq(expected_lockfile)
+      expect(lockfile).to eq <<~L
+        GEM
+          remote: #{file_uri_for(gem_repo4)}/
+          specs:
+            activesupport (6.0.4.1)
+              tzinfo (~> 1.1)
+            tzinfo (1.2.9)
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          activesupport (~> 6.0.0)
+
+        CHECKSUMS
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
     end
   end
 
@@ -1132,6 +1160,8 @@ RSpec.describe "bundle update --ruby" do
 
        DEPENDENCIES
 
+       CHECKSUMS
+
        BUNDLED WITH
           #{Bundler::VERSION}
       L
@@ -1162,6 +1192,8 @@ RSpec.describe "bundle update --ruby" do
          #{lockfile_platforms}
 
        DEPENDENCIES
+
+       CHECKSUMS
 
        RUBY VERSION
           #{Bundler::RubyVersion.system}
@@ -1203,6 +1235,8 @@ RSpec.describe "bundle update --ruby" do
 
        DEPENDENCIES
 
+       CHECKSUMS
+
        RUBY VERSION
           ruby 2.1.4p222
 
@@ -1228,6 +1262,8 @@ RSpec.describe "bundle update --ruby" do
 
        DEPENDENCIES
 
+       CHECKSUMS
+
        RUBY VERSION
           #{Bundler::RubyVersion.system}
 
@@ -1250,6 +1286,8 @@ RSpec.describe "bundle update --bundler" do
     G
     lockfile lockfile.sub(/(^\s*)#{Bundler::VERSION}($)/, '\11.0.0\2')
 
+    excepted_checksum = checksum_for_repo_gem(gem_repo4, "rack", "1.0")
+
     FileUtils.rm_r gem_repo4
 
     bundle :update, :bundler => true, :artifice => "compact_index", :verbose => true
@@ -1266,6 +1304,9 @@ RSpec.describe "bundle update --bundler" do
 
       DEPENDENCIES
         rack
+
+      CHECKSUMS
+        #{excepted_checksum}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -1301,6 +1342,9 @@ RSpec.describe "bundle update --bundler" do
 
       DEPENDENCIES
         rack
+
+      CHECKSUMS
+        #{checksum_for_repo_gem(gem_repo4, "rack", "1.0")}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -1405,6 +1449,9 @@ RSpec.describe "bundle update --bundler" do
         DEPENDENCIES
           rack
 
+        CHECKSUMS
+          #{checksum_for_repo_gem(gem_repo4, "rack", "1.0")}
+
         BUNDLED WITH
            2.3.0.dev
       L
@@ -1443,6 +1490,9 @@ RSpec.describe "bundle update --bundler" do
 
         DEPENDENCIES
           rack
+
+        CHECKSUMS
+          #{checksum_for_repo_gem(gem_repo4, "rack", "1.0")}
 
         BUNDLED WITH
            2.3.9
@@ -1609,6 +1659,8 @@ RSpec.describe "bundle update conservative" do
           shared_owner_a
           shared_owner_b
 
+        CHECKSUMS
+
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -1661,6 +1713,8 @@ RSpec.describe "bundle update conservative" do
           isolated_owner
           shared_owner_a
           shared_owner_b
+
+        CHECKSUMS
 
         BUNDLED WITH
            #{Bundler::VERSION}

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -451,7 +451,6 @@ RSpec.describe "bundle install from an existing gemspec" do
 
             expected_checksums = construct_checksum_section do |c|
               c.repo_gem gem_repo2, "platform_specific", "1.0"
-              c.repo_gem gem_repo2, "platform_specific", "1.0", "java"
               c.repo_gem gem_repo2, "platform_specific", "1.0", x64_mingw32
             end
 
@@ -495,7 +494,6 @@ RSpec.describe "bundle install from an existing gemspec" do
 
             expected_checksums = construct_checksum_section do |c|
               c.repo_gem gem_repo2, "platform_specific", "1.0"
-              c.repo_gem gem_repo2, "platform_specific", "1.0", "java"
               c.repo_gem gem_repo2, "platform_specific", "1.0", x64_mingw32
             end
 
@@ -541,7 +539,6 @@ RSpec.describe "bundle install from an existing gemspec" do
             expected_checksums = construct_checksum_section do |c|
               c.repo_gem gem_repo2, "indirect_platform_specific", "1.0"
               c.repo_gem gem_repo2, "platform_specific", "1.0"
-              c.repo_gem gem_repo2, "platform_specific", "1.0", "java"
               c.repo_gem gem_repo2, "platform_specific", "1.0", x64_mingw32
             end
 

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -448,6 +448,13 @@ RSpec.describe "bundle install from an existing gemspec" do
         context "as a runtime dependency" do
           it "keeps all platform dependencies in the lockfile" do
             expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 RUBY"
+
+            expected_checksums = construct_checksum_section do |c|
+              c.repo_gem gem_repo2, "platform_specific", "1.0"
+              c.repo_gem gem_repo2, "platform_specific", "1.0", "java"
+              c.repo_gem gem_repo2, "platform_specific", "1.0", x64_mingw32
+            end
+
             expect(lockfile).to eq strip_whitespace(<<-L)
               PATH
                 remote: .
@@ -470,6 +477,10 @@ RSpec.describe "bundle install from an existing gemspec" do
               DEPENDENCIES
                 foo!
 
+              CHECKSUMS
+                foo (1.0)
+                #{expected_checksums}
+
               BUNDLED WITH
                  #{Bundler::VERSION}
             L
@@ -481,6 +492,13 @@ RSpec.describe "bundle install from an existing gemspec" do
 
           it "keeps all platform dependencies in the lockfile" do
             expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 RUBY"
+
+            expected_checksums = construct_checksum_section do |c|
+              c.repo_gem gem_repo2, "platform_specific", "1.0"
+              c.repo_gem gem_repo2, "platform_specific", "1.0", "java"
+              c.repo_gem gem_repo2, "platform_specific", "1.0", x64_mingw32
+            end
+
             expect(lockfile).to eq strip_whitespace(<<-L)
               PATH
                 remote: .
@@ -503,6 +521,10 @@ RSpec.describe "bundle install from an existing gemspec" do
                 foo!
                 platform_specific
 
+              CHECKSUMS
+                foo (1.0)
+                #{expected_checksums}
+
               BUNDLED WITH
                  #{Bundler::VERSION}
             L
@@ -515,6 +537,14 @@ RSpec.describe "bundle install from an existing gemspec" do
 
           it "keeps all platform dependencies in the lockfile" do
             expect(the_bundle).to include_gems "foo 1.0", "indirect_platform_specific 1.0", "platform_specific 1.0 RUBY"
+
+            expected_checksums = construct_checksum_section do |c|
+              c.repo_gem gem_repo2, "indirect_platform_specific", "1.0"
+              c.repo_gem gem_repo2, "platform_specific", "1.0"
+              c.repo_gem gem_repo2, "platform_specific", "1.0", "java"
+              c.repo_gem gem_repo2, "platform_specific", "1.0", x64_mingw32
+            end
+
             expect(lockfile).to eq strip_whitespace(<<-L)
               PATH
                 remote: .
@@ -538,6 +568,10 @@ RSpec.describe "bundle install from an existing gemspec" do
               DEPENDENCIES
                 foo!
                 indirect_platform_specific
+
+              CHECKSUMS
+                foo (1.0)
+                #{expected_checksums}
 
               BUNDLED WITH
                  #{Bundler::VERSION}
@@ -623,6 +657,11 @@ RSpec.describe "bundle install from an existing gemspec" do
         DEPENDENCIES
           chef!
 
+        CHECKSUMS
+          chef (17.1.17)
+          chef (17.1.17-universal-mingw32)
+          #{checksum_for_repo_gem gem_repo4, "win32-api", "1.5.3", "universal-mingw32"}
+
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -679,6 +718,10 @@ RSpec.describe "bundle install from an existing gemspec" do
         DEPENDENCIES
           activeadmin!
           jruby-openssl
+
+        CHECKSUMS
+          activeadmin (2.9.0)
+          #{checksum_for_repo_gem gem_repo4, "railties", "6.1.4"}
 
         BUNDLED WITH
            #{Bundler::VERSION}

--- a/bundler/spec/install/gemfile/install_if_spec.rb
+++ b/bundler/spec/install/gemfile/install_if_spec.rb
@@ -37,6 +37,10 @@ RSpec.describe "bundle install with install_if conditionals" do
         rack
         thin
 
+      CHECKSUMS
+        #{checksum_for_repo_gem gem_repo1, "activesupport", "2.3.5"}
+        #{checksum_for_repo_gem gem_repo1, "rack", "1.0.0"}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     L

--- a/bundler/spec/install/gemfile/path_spec.rb
+++ b/bundler/spec/install/gemfile/path_spec.rb
@@ -120,6 +120,10 @@ RSpec.describe "bundle install with explicit source paths" do
         aaa!
         demo!
 
+      CHECKSUMS
+        aaa (1.0)
+        demo (1.0)
+
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -358,6 +362,10 @@ RSpec.describe "bundle install with explicit source paths" do
 
       DEPENDENCIES
         foo!
+
+      CHECKSUMS
+        foo (0.1.0)
+        #{checksum_for_repo_gem gem_repo4, "graphql", "2.0.15"}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -683,6 +691,10 @@ RSpec.describe "bundle install with explicit source paths" do
         DEPENDENCIES
           foo!
 
+        CHECKSUMS
+          foo (1.0)
+          #{checksum_for_repo_gem gem_repo1, "rack", "0.9.1"}
+
         BUNDLED WITH
            #{Bundler::VERSION}
       G
@@ -710,6 +722,10 @@ RSpec.describe "bundle install with explicit source paths" do
 
         DEPENDENCIES
           foo!
+
+        CHECKSUMS
+          foo (1.0)
+          #{checksum_for_repo_gem gem_repo1, "rack", "0.9.1"}
 
         BUNDLED WITH
            #{Bundler::VERSION}
@@ -745,6 +761,10 @@ RSpec.describe "bundle install with explicit source paths" do
         DEPENDENCIES
           foo!
 
+        CHECKSUMS
+          foo (1.0)
+          #{checksum_for_repo_gem gem_repo1, "rack", "0.9.1"}
+
         BUNDLED WITH
            #{Bundler::VERSION}
       G
@@ -775,6 +795,11 @@ RSpec.describe "bundle install with explicit source paths" do
 
         DEPENDENCIES
           foo!
+
+        CHECKSUMS
+          foo (1.0)
+          #{checksum_for_repo_gem gem_repo1, "rack", "0.9.1"}
+          #{checksum_for_repo_gem gem_repo1, "rake", "13.0.1"}
 
         BUNDLED WITH
            #{Bundler::VERSION}

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -203,15 +203,6 @@ RSpec.describe "bundle install across platforms" do
       gem "pry"
     G
 
-    expected_checksums = construct_checksum_section do |c|
-      c.repo_gem gem_repo4, "coderay", "1.1.2"
-      c.repo_gem gem_repo4, "empyrean", "0.1.0"
-      c.repo_gem gem_repo4, "ffi", "1.9.23", "java"
-      c.repo_gem gem_repo4, "method_source", "0.9.0"
-      c.repo_gem gem_repo4, "pry", "0.11.3", "java"
-      c.repo_gem gem_repo4, "spoon", "0.0.6"
-    end
-
     expect(lockfile).to eq <<~L
       GEM
         remote: #{file_uri_for(gem_repo4)}/
@@ -235,7 +226,6 @@ RSpec.describe "bundle install across platforms" do
         pry
 
       CHECKSUMS
-        #{expected_checksums}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -270,7 +260,6 @@ RSpec.describe "bundle install across platforms" do
         pry
 
       CHECKSUMS
-        #{expected_checksums}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -306,7 +295,6 @@ RSpec.describe "bundle install across platforms" do
         pry
 
       CHECKSUMS
-        #{expected_checksums}
 
       BUNDLED WITH
          1.16.1

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -203,6 +203,15 @@ RSpec.describe "bundle install across platforms" do
       gem "pry"
     G
 
+    expected_checksums = construct_checksum_section do |c|
+      c.repo_gem gem_repo4, "coderay", "1.1.2"
+      c.repo_gem gem_repo4, "empyrean", "0.1.0"
+      c.repo_gem gem_repo4, "ffi", "1.9.23", "java"
+      c.repo_gem gem_repo4, "method_source", "0.9.0"
+      c.repo_gem gem_repo4, "pry", "0.11.3", "java"
+      c.repo_gem gem_repo4, "spoon", "0.0.6"
+    end
+
     expect(lockfile).to eq <<~L
       GEM
         remote: #{file_uri_for(gem_repo4)}/
@@ -224,6 +233,9 @@ RSpec.describe "bundle install across platforms" do
       DEPENDENCIES
         empyrean (= 0.1.0)
         pry
+
+      CHECKSUMS
+        #{expected_checksums}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -257,6 +269,9 @@ RSpec.describe "bundle install across platforms" do
         empyrean (= 0.1.0)
         pry
 
+      CHECKSUMS
+        #{expected_checksums}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -289,6 +304,9 @@ RSpec.describe "bundle install across platforms" do
       DEPENDENCIES
         empyrean (= 0.1.0)
         pry
+
+      CHECKSUMS
+        #{expected_checksums}
 
       BUNDLED WITH
          1.16.1
@@ -398,6 +416,9 @@ RSpec.describe "bundle install across platforms" do
 
       DEPENDENCIES
         platform_specific
+
+      CHECKSUMS
+        #{checksum_for_repo_gem(gem_repo1, "platform_specific", "1.0")}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -567,6 +588,8 @@ RSpec.describe "bundle install with platform conditionals" do
 
       DEPENDENCIES
         rack
+
+      CHECKSUMS
 
       BUNDLED WITH
          #{Bundler::VERSION}

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -248,6 +248,11 @@ RSpec.describe "bundle install with gems on multiple sources" do
           expect(err).to include("Warning: the gem 'rack' was found in multiple sources.")
           expect(err).to include("Installed from: https://gem.repo2")
 
+          expected_checksums = construct_checksum_section do |c|
+            c.repo_gem gem_repo3, "depends_on_rack", "1.0.1"
+            c.repo_gem gem_repo2, "rack", "1.0.0"
+          end
+
           expect(lockfile).to eq <<~L
             GEM
               remote: https://gem.repo1/
@@ -266,6 +271,9 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
             DEPENDENCIES
               depends_on_rack!
+
+            CHECKSUMS
+              #{expected_checksums}
 
             BUNDLED WITH
                #{Bundler::VERSION}
@@ -662,6 +670,21 @@ RSpec.describe "bundle install with gems on multiple sources" do
         expect(the_bundle).to include_gems("concurrent-ruby 1.1.8")
         expect(the_bundle).not_to include_gems("concurrent-ruby 1.1.9")
 
+        expected_checksums = construct_checksum_section do |c|
+          c.repo_gem gem_repo2, "activesupport", "6.0.3.4"
+          c.repo_gem gem_repo2, "concurrent-ruby", "1.1.8"
+          c.repo_gem gem_repo2, "connection_pool", "2.2.3"
+          c.repo_gem gem_repo2, "i18n", "1.8.9"
+          c.repo_gem gem_repo2, "minitest", "5.14.3"
+          c.repo_gem gem_repo2, "rack", "2.2.3"
+          c.repo_gem gem_repo2, "redis", "4.2.5"
+          c.repo_gem gem_repo2, "sidekiq", "6.1.3"
+          c.repo_gem gem_repo3, "sidekiq-pro", "5.2.1"
+          c.repo_gem gem_repo2, "thread_safe", "0.3.6"
+          c.repo_gem gem_repo2, "tzinfo", "1.2.9"
+          c.repo_gem gem_repo2, "zeitwerk", "2.4.2"
+        end
+
         expect(lockfile).to eq <<~L
           GEM
             remote: https://gem.repo2/
@@ -701,6 +724,9 @@ RSpec.describe "bundle install with gems on multiple sources" do
           DEPENDENCIES
             activesupport
             sidekiq-pro!
+
+          CHECKSUMS
+            #{expected_checksums}
 
           BUNDLED WITH
              #{Bundler::VERSION}
@@ -747,6 +773,20 @@ RSpec.describe "bundle install with gems on multiple sources" do
         expect(the_bundle).not_to include_gems("concurrent-ruby 1.1.8")
         expect(the_bundle).to include_gems("concurrent-ruby 1.1.9")
 
+        expected_checksums = construct_checksum_section do |c|
+          c.repo_gem gem_repo2, "activesupport", "6.1.2.1"
+          c.repo_gem gem_repo2, "concurrent-ruby", "1.1.9"
+          c.repo_gem gem_repo2, "connection_pool", "2.2.3"
+          c.repo_gem gem_repo2, "i18n", "1.8.9"
+          c.repo_gem gem_repo2, "minitest", "5.14.3"
+          c.repo_gem gem_repo2, "rack", "2.2.3"
+          c.repo_gem gem_repo2, "redis", "4.2.5"
+          c.repo_gem gem_repo2, "sidekiq", "6.1.3"
+          c.repo_gem gem_repo3, "sidekiq-pro", "5.2.1"
+          c.repo_gem gem_repo2, "tzinfo", "2.0.4"
+          c.repo_gem gem_repo2, "zeitwerk", "2.4.2"
+        end
+
         expect(lockfile).to eq <<~L
           GEM
             remote: https://gem.repo2/
@@ -786,6 +826,9 @@ RSpec.describe "bundle install with gems on multiple sources" do
             activesupport
             sidekiq-pro!
 
+          CHECKSUMS
+            #{expected_checksums}
+
           BUNDLED WITH
              #{Bundler::VERSION}
         L
@@ -801,6 +844,21 @@ RSpec.describe "bundle install with gems on multiple sources" do
         expect(the_bundle).not_to include_gems("tzinfo 2.0.4")
         expect(the_bundle).to include_gems("concurrent-ruby 1.1.9")
         expect(the_bundle).not_to include_gems("concurrent-ruby 1.1.8")
+
+        expected_checksums = construct_checksum_section do |c|
+          c.repo_gem gem_repo2, "activesupport", "6.0.3.4"
+          c.repo_gem gem_repo2, "concurrent-ruby", "1.1.9"
+          c.repo_gem gem_repo2, "connection_pool", "2.2.3"
+          c.repo_gem gem_repo2, "i18n", "1.8.9"
+          c.repo_gem gem_repo2, "minitest", "5.14.3"
+          c.repo_gem gem_repo2, "rack", "2.2.3"
+          c.repo_gem gem_repo2, "redis", "4.2.5"
+          c.repo_gem gem_repo2, "sidekiq", "6.1.3"
+          c.repo_gem gem_repo3, "sidekiq-pro", "5.2.1"
+          c.repo_gem gem_repo2, "thread_safe", "0.3.6"
+          c.repo_gem gem_repo2, "tzinfo", "1.2.9"
+          c.repo_gem gem_repo2, "zeitwerk", "2.4.2"
+        end
 
         expect(lockfile).to eq <<~L
           GEM
@@ -841,6 +899,9 @@ RSpec.describe "bundle install with gems on multiple sources" do
           DEPENDENCIES
             activesupport
             sidekiq-pro!
+
+          CHECKSUMS
+            #{expected_checksums}
 
           BUNDLED WITH
              #{Bundler::VERSION}
@@ -909,6 +970,12 @@ RSpec.describe "bundle install with gems on multiple sources" do
       end
 
       it "installs from the default source without any warnings or errors and generates a proper lockfile" do
+        expected_checksums = construct_checksum_section do |c|
+          c.repo_gem gem_repo3, "handsoap", "0.2.5.5"
+          c.repo_gem gem_repo2, "nokogiri", "1.11.1"
+          c.repo_gem gem_repo2, "racca", "1.5.2"
+        end
+
         expected_lockfile = <<~L
           GEM
             remote: https://gem.repo2/
@@ -929,6 +996,9 @@ RSpec.describe "bundle install with gems on multiple sources" do
           DEPENDENCIES
             handsoap!
             nokogiri
+
+          CHECKSUMS
+            #{expected_checksums}
 
           BUNDLED WITH
              #{Bundler::VERSION}
@@ -1453,6 +1523,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
         DEPENDENCIES
           capybara (~> 2.5.0)
           mime-types (~> 3.0)!
+
+        CHECKSUMS
       L
     end
 
@@ -1477,6 +1549,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
         DEPENDENCIES
           capybara (~> 2.5.0)
           mime-types (~> 3.0)!
+
+        CHECKSUMS
 
         BUNDLED WITH
            #{Bundler::VERSION}
@@ -1531,6 +1605,10 @@ RSpec.describe "bundle install with gems on multiple sources" do
         DEPENDENCIES
           ruport (= 1.7.0.3)!
 
+        CHECKSUMS
+          #{checksum_for_repo_gem gem_repo4, "pdf-writer", "1.1.8"}
+          #{checksum_for_repo_gem gem_repo2, "ruport", "1.7.0.3"}
+
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -1566,6 +1644,11 @@ RSpec.describe "bundle install with gems on multiple sources" do
     it "handles that fine" do
       bundle "install", :artifice => "compact_index_extra", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
 
+      expected_checksums = construct_checksum_section do |c|
+        c.repo_gem gem_repo4, "pdf-writer", "1.1.8"
+        c.repo_gem gem_repo2, "ruport", "1.7.0.3"
+      end
+
       expect(lockfile).to eq <<~L
         GEM
           remote: https://localgemserver.test/
@@ -1583,6 +1666,9 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
         DEPENDENCIES
           ruport (= 1.7.0.3)!
+
+        CHECKSUMS
+          #{expected_checksums}
 
         BUNDLED WITH
            #{Bundler::VERSION}
@@ -1613,6 +1699,10 @@ RSpec.describe "bundle install with gems on multiple sources" do
     it "handles that fine" do
       bundle "install --verbose", :artifice => "endpoint", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
 
+      expected_checksums = construct_checksum_section do |c|
+        c.repo_gem gem_repo4, "pdf-writer", "1.1.8"
+      end
+
       expect(lockfile).to eq <<~L
         GEM
           remote: https://localgemserver.test/
@@ -1624,6 +1714,9 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
         DEPENDENCIES
           pdf-writer (= 1.1.8)
+
+        CHECKSUMS
+          #{expected_checksums}
 
         BUNDLED WITH
            #{Bundler::VERSION}

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -99,6 +99,9 @@ RSpec.describe "bundle install with specific platforms" do
         DEPENDENCIES
           google-protobuf
 
+        CHECKSUMS
+          #{checksum_for_repo_gem gem_repo2, "google-protobuf", "3.0.0.alpha.5.0.5.1", "universal-darwin"}
+
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -460,6 +463,13 @@ RSpec.describe "bundle install with specific platforms" do
 
     bundle "update"
 
+    expected_checksums = construct_checksum_section do |c|
+      c.repo_gem gem_repo4, "sorbet", "0.5.10160"
+      c.repo_gem gem_repo4, "sorbet-runtime", "0.5.10160"
+      c.repo_gem gem_repo4, "sorbet-static", "0.5.10160", Gem::Platform.local
+      c.repo_gem gem_repo4, "sorbet-static-and-runtime", "0.5.10160"
+    end
+
     expect(lockfile).to eq <<~L
       GEM
         remote: #{file_uri_for(gem_repo4)}/
@@ -477,6 +487,9 @@ RSpec.describe "bundle install with specific platforms" do
 
       DEPENDENCIES
         sorbet-static-and-runtime
+
+      CHECKSUMS
+        #{expected_checksums}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -531,6 +544,13 @@ RSpec.describe "bundle install with specific platforms" do
 
     bundle "update"
 
+    expected_checksums = construct_checksum_section do |c|
+      c.repo_gem gem_repo4, "sorbet", "0.5.10160"
+      c.repo_gem gem_repo4, "sorbet-runtime", "0.5.10160"
+      c.repo_gem gem_repo4, "sorbet-static", "0.5.10160", Gem::Platform.local
+      c.repo_gem gem_repo4, "sorbet-static-and-runtime", "0.5.10160"
+    end
+
     expect(lockfile).to eq <<~L
       GEM
         remote: #{file_uri_for(gem_repo4)}/
@@ -548,6 +568,9 @@ RSpec.describe "bundle install with specific platforms" do
 
       DEPENDENCIES
         sorbet-static-and-runtime
+
+      CHECKSUMS
+        #{expected_checksums}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -583,6 +606,8 @@ RSpec.describe "bundle install with specific platforms" do
       DEPENDENCIES
         nokogiri
         tzinfo (~> 1.2)
+
+      CHECKSUMS
 
       BUNDLED WITH
          #{Bundler::VERSION}

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -100,7 +100,6 @@ RSpec.describe "bundle install with specific platforms" do
           google-protobuf
 
         CHECKSUMS
-          #{checksum_for_repo_gem gem_repo2, "google-protobuf", "3.0.0.alpha.5.0.5.1", "universal-darwin"}
 
         BUNDLED WITH
            #{Bundler::VERSION}

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -944,6 +944,6 @@ Either installing with `--full-index` or running `bundle update rails` should fi
     G
     gem_command "uninstall activemerchant"
     bundle "update rails", :artifice => "compact_index"
-    expect(lockfile.scan(/activemerchant \(/).size).to eq(1)
+    expect(lockfile.scan(/activemerchant \(/).size).to eq(2) # Once in the specs, and once in CHECKSUMS
   end
 end

--- a/bundler/spec/install/gems/flex_spec.rb
+++ b/bundler/spec/install/gems/flex_spec.rb
@@ -283,6 +283,10 @@ RSpec.describe "bundle flex_install" do
           rack (= 0.9.1)
           rack-obama
 
+        CHECKSUMS
+          #{checksum_for_repo_gem gem_repo1, "rack", "0.9.1"}
+          #{checksum_for_repo_gem gem_repo1, "rack-obama", "1.0"}
+
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -323,6 +327,9 @@ RSpec.describe "bundle flex_install" do
 
         DEPENDENCIES
           rack
+
+        CHECKSUMS
+          #{checksum_for_repo_gem gem_repo1, "rack", "1.0.0"}
 
         BUNDLED WITH
            #{Bundler::VERSION}

--- a/bundler/spec/install/gems/resolving_spec.rb
+++ b/bundler/spec/install/gems/resolving_spec.rb
@@ -288,6 +288,9 @@ RSpec.describe "bundle install with install-time dependencies" do
             DEPENDENCIES
               parallel_tests
 
+            CHECKSUMS
+              #{checksum_for_repo_gem gem_repo2, "parallel_tests", "3.7.0"}
+
             BUNDLED WITH
                #{Bundler::VERSION}
           L
@@ -367,6 +370,10 @@ RSpec.describe "bundle install with install-time dependencies" do
 
             DEPENDENCIES
               rubocop
+
+            CHECKSUMS
+              #{checksum_for_repo_gem gem_repo2, "rubocop", "1.28.2"}
+              #{checksum_for_repo_gem gem_repo2, "rubocop-ast", "1.17.0"}
 
             BUNDLED WITH
                #{Bundler::VERSION}

--- a/bundler/spec/install/yanked_spec.rb
+++ b/bundler/spec/install/yanked_spec.rb
@@ -160,6 +160,8 @@ RSpec.context "when resolving a bundle that includes yanked gems, but unlocking 
         bar
         foo
 
+      CHECKSUMS
+
       BUNDLED WITH
          #{Bundler::VERSION}
     L

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -24,6 +24,9 @@ RSpec.describe "the lockfile format" do
       DEPENDENCIES
         rack
 
+      CHECKSUMS
+        #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -74,6 +77,9 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack
+
+      CHECKSUMS
+        #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -202,6 +208,9 @@ RSpec.describe "the lockfile format" do
       DEPENDENCIES
         rack (> 0)
 
+      CHECKSUMS
+        #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -249,6 +258,9 @@ RSpec.describe "the lockfile format" do
       DEPENDENCIES
         rack
 
+      CHECKSUMS
+        #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
+
       BUNDLED WITH
          #{current_version}
     G
@@ -260,6 +272,11 @@ RSpec.describe "the lockfile format" do
 
       gem "rack-obama"
     G
+
+    expected_checksums = construct_checksum_section do |c|
+      c.repo_gem gem_repo2, "rack", "1.0.0"
+      c.repo_gem gem_repo2, "rack-obama", "1.0"
+    end
 
     expect(lockfile).to eq <<~G
       GEM
@@ -275,6 +292,9 @@ RSpec.describe "the lockfile format" do
       DEPENDENCIES
         rack-obama
 
+      CHECKSUMS
+        #{expected_checksums}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -286,6 +306,11 @@ RSpec.describe "the lockfile format" do
 
       gem "rack-obama", ">= 1.0"
     G
+
+    expected_checksums = construct_checksum_section do |c|
+      c.repo_gem gem_repo2, "rack", "1.0.0"
+      c.repo_gem gem_repo2, "rack-obama", "1.0"
+    end
 
     expect(lockfile).to eq <<~G
       GEM
@@ -300,6 +325,9 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack-obama (>= 1.0)
+
+      CHECKSUMS
+        #{expected_checksums}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -320,6 +348,11 @@ RSpec.describe "the lockfile format" do
         gem "rack-obama", ">= 1.0"
       end
     G
+
+    expected_checksums = construct_checksum_section do |c|
+      c.repo_gem gem_repo2, "rack", "1.0.0"
+      c.repo_gem gem_repo2, "rack-obama", "1.0"
+    end
 
     expect(lockfile).to eq <<~G
       GEM
@@ -343,6 +376,9 @@ RSpec.describe "the lockfile format" do
       DEPENDENCIES
         rack-obama (>= 1.0)!
 
+      CHECKSUMS
+        #{expected_checksums}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -353,6 +389,11 @@ RSpec.describe "the lockfile format" do
       source "#{file_uri_for(gem_repo2)}/"
       gem "net-sftp"
     G
+
+    expected_checksums = construct_checksum_section do |c|
+      c.repo_gem gem_repo2, "net-sftp", "1.1.1"
+      c.repo_gem gem_repo2, "net-ssh", "1.0"
+    end
 
     expect(lockfile).to eq <<~G
       GEM
@@ -367,6 +408,9 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         net-sftp
+
+      CHECKSUMS
+        #{expected_checksums}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -399,6 +443,9 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         foo!
+
+      CHECKSUMS
+        foo (1.0)
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -471,6 +518,9 @@ RSpec.describe "the lockfile format" do
       DEPENDENCIES
         foo!
 
+      CHECKSUMS
+        foo (1.0)
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -502,6 +552,9 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         foo!
+
+      CHECKSUMS
+        foo (1.0)
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -535,6 +588,9 @@ RSpec.describe "the lockfile format" do
       DEPENDENCIES
         foo!
 
+      CHECKSUMS
+        foo (1.0)
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -563,6 +619,9 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         foo!
+
+      CHECKSUMS
+        foo (1.0)
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -596,6 +655,9 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         foo!
+
+      CHECKSUMS
+        foo (1.0)
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -639,6 +701,11 @@ RSpec.describe "the lockfile format" do
         foo!
         rack
 
+      CHECKSUMS
+        bar (1.0)
+        foo (1.0)
+        #{checksum_for_repo_gem gem_repo2, "rack", "1.0.0"}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -651,6 +718,10 @@ RSpec.describe "the lockfile format" do
       gem "rack", :source => "#{file_uri_for(gem_repo2)}/"
     G
 
+    expected_checksums = construct_checksum_section do |c|
+      c.repo_gem gem_repo2, "rack", "1.0.0"
+    end
+
     expect(lockfile).to eq <<~G
       GEM
         remote: #{file_uri_for(gem_repo2)}/
@@ -662,6 +733,9 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack!
+
+      CHECKSUMS
+        #{expected_checksums}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -676,6 +750,14 @@ RSpec.describe "the lockfile format" do
       gem "actionpack"
       gem "rack-obama"
     G
+
+    expected_checksums = construct_checksum_section do |c|
+      c.repo_gem gem_repo2, "actionpack", "2.3.2"
+      c.repo_gem gem_repo2, "activesupport", "2.3.2"
+      c.repo_gem gem_repo2, "rack", "1.0.0"
+      c.repo_gem gem_repo2, "rack-obama", "1.0"
+      c.repo_gem gem_repo2, "thin", "1.0"
+    end
 
     expect(lockfile).to eq <<~G
       GEM
@@ -698,6 +780,9 @@ RSpec.describe "the lockfile format" do
         rack-obama
         thin
 
+      CHECKSUMS
+        #{expected_checksums}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -709,6 +794,16 @@ RSpec.describe "the lockfile format" do
 
       gem "rails"
     G
+
+    expected_checksums = construct_checksum_section do |c|
+      c.repo_gem gem_repo2, "actionmailer", "2.3.2"
+      c.repo_gem gem_repo2, "actionpack", "2.3.2"
+      c.repo_gem gem_repo2, "activerecord", "2.3.2"
+      c.repo_gem gem_repo2, "activeresource", "2.3.2"
+      c.repo_gem gem_repo2, "activesupport", "2.3.2"
+      c.repo_gem gem_repo2, "rails", "2.3.2"
+      c.repo_gem gem_repo2, "rake", "13.0.1"
+    end
 
     expect(lockfile).to eq <<~G
       GEM
@@ -737,6 +832,9 @@ RSpec.describe "the lockfile format" do
       DEPENDENCIES
         rails
 
+      CHECKSUMS
+        #{expected_checksums}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -758,6 +856,11 @@ RSpec.describe "the lockfile format" do
       gem 'double_deps'
     G
 
+    expected_checksums = construct_checksum_section do |c|
+      c.repo_gem gem_repo2, "double_deps", "1.0"
+      c.repo_gem gem_repo2, "net-ssh", "1.0"
+    end
+
     expect(lockfile).to eq <<~G
       GEM
         remote: #{file_uri_for(gem_repo2)}/
@@ -773,6 +876,9 @@ RSpec.describe "the lockfile format" do
       DEPENDENCIES
         double_deps
 
+      CHECKSUMS
+        #{expected_checksums}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -784,6 +890,11 @@ RSpec.describe "the lockfile format" do
 
       gem "rack-obama", ">= 1.0", :require => "rack/obama"
     G
+
+    expected_checksums = construct_checksum_section do |c|
+      c.repo_gem gem_repo2, "rack", "1.0.0"
+      c.repo_gem gem_repo2, "rack-obama", "1.0"
+    end
 
     expect(lockfile).to eq <<~G
       GEM
@@ -798,6 +909,9 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack-obama (>= 1.0)
+
+      CHECKSUMS
+        #{expected_checksums}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -811,6 +925,11 @@ RSpec.describe "the lockfile format" do
       gem "rack-obama", ">= 1.0", :group => :test
     G
 
+    expected_checksums = construct_checksum_section do |c|
+      c.repo_gem gem_repo2, "rack", "1.0.0"
+      c.repo_gem gem_repo2, "rack-obama", "1.0"
+    end
+
     expect(lockfile).to eq <<~G
       GEM
         remote: #{file_uri_for(gem_repo2)}/
@@ -824,6 +943,9 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack-obama (>= 1.0)
+
+      CHECKSUMS
+        #{expected_checksums}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -856,6 +978,9 @@ RSpec.describe "the lockfile format" do
       DEPENDENCIES
         foo!
 
+      CHECKSUMS
+        foo (1.0)
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -886,6 +1011,9 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         foo!
+
+      CHECKSUMS
+        foo (1.0)
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -918,6 +1046,9 @@ RSpec.describe "the lockfile format" do
       DEPENDENCIES
         foo!
 
+      CHECKSUMS
+        foo (1.0)
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -946,6 +1077,9 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         foo!
+
+      CHECKSUMS
+        foo (1.0)
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -987,6 +1121,9 @@ RSpec.describe "the lockfile format" do
       DEPENDENCIES
         rack
 
+      CHECKSUMS
+        #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -1006,6 +1143,10 @@ RSpec.describe "the lockfile format" do
       gem "platform_specific"
     G
 
+    expected_checksums = construct_checksum_section do |c|
+      c.repo_gem gem_repo2, "platform_specific", "1.0", "universal-java-16"
+    end
+
     expect(lockfile).to eq <<~G
       GEM
         remote: #{file_uri_for(gem_repo2)}/
@@ -1017,6 +1158,9 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         platform_specific
+
+      CHECKSUMS
+        #{expected_checksums}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -1049,6 +1193,10 @@ RSpec.describe "the lockfile format" do
         activesupport
         rack
 
+      CHECKSUMS
+        #{checksum_for_repo_gem(gem_repo2, "activesupport", "2.3.5")}
+        #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -1072,6 +1220,9 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack
+
+      CHECKSUMS
+        #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -1097,6 +1248,9 @@ RSpec.describe "the lockfile format" do
       DEPENDENCIES
         rack (= 1.0)
 
+      CHECKSUMS
+        #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -1120,6 +1274,9 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack (= 1.0)
+
+      CHECKSUMS
+        #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -1166,6 +1323,9 @@ RSpec.describe "the lockfile format" do
       DEPENDENCIES
         rack (> 0.9, < 1.0)
 
+      CHECKSUMS
+        #{checksum_for_repo_gem(gem_repo2, "rack", "0.9.1")}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -1189,6 +1349,9 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack (> 0.9, < 1.0)
+
+      CHECKSUMS
+        #{checksum_for_repo_gem(gem_repo2, "rack", "0.9.1")}
 
       RUBY VERSION
          #{Bundler::RubyVersion.system}
@@ -1268,6 +1431,10 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         minitest-bisect
+
+      CHECKSUMS
+        #{checksum_for_repo_gem gem_repo4, "minitest-bisect", "1.6.0"}
+        #{checksum_for_repo_gem gem_repo4, "path_expander", "1.1.1"}
 
       BUNDLED WITH
          #{Bundler::VERSION}

--- a/bundler/spec/plugins/source/example_spec.rb
+++ b/bundler/spec/plugins/source/example_spec.rb
@@ -87,6 +87,9 @@ RSpec.describe "real source plugins" do
         DEPENDENCIES
           a-path-gem!
 
+        CHECKSUMS
+          a-path-gem (1.0)
+
         BUNDLED WITH
            #{Bundler::VERSION}
       G
@@ -353,6 +356,9 @@ RSpec.describe "real source plugins" do
 
         DEPENDENCIES
           ma-gitp-gem!
+
+        CHECKSUMS
+          ma-gitp-gem (1.0)
 
         BUNDLED WITH
            #{Bundler::VERSION}

--- a/bundler/spec/runtime/platform_spec.rb
+++ b/bundler/spec/runtime/platform_spec.rb
@@ -91,6 +91,11 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
       DEPENDENCIES
         nokogiri (~> 1.11)
 
+      CHECKSUMS
+        nokogiri (1.11.1)
+        #{checksum_for_repo_gem gem_repo4, "nokogiri", "1.11.1", Bundler.local_platform}
+        #{checksum_for_repo_gem gem_repo4, "racc", "1.5.2"}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     L

--- a/bundler/spec/runtime/platform_spec.rb
+++ b/bundler/spec/runtime/platform_spec.rb
@@ -61,16 +61,16 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
     build_repo4 do
       build_gem "nokogiri", "1.11.1" do |s|
         s.add_dependency "mini_portile2", "~> 2.5.0"
-        s.add_dependency "racc", "~> 1.5.2"
+        s.add_dependency "racca", "~> 1.5.2"
       end
 
       build_gem "nokogiri", "1.11.1" do |s|
         s.platform = Bundler.local_platform
-        s.add_dependency "racc", "~> 1.4"
+        s.add_dependency "racca", "~> 1.4"
       end
 
       build_gem "mini_portile2", "2.5.0"
-      build_gem "racc", "1.5.2"
+      build_gem "racca", "1.5.2"
     end
 
     good_lockfile = <<~L
@@ -80,10 +80,10 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
           mini_portile2 (2.5.0)
           nokogiri (1.11.1)
             mini_portile2 (~> 2.5.0)
-            racc (~> 1.5.2)
+            racca (~> 1.5.2)
           nokogiri (1.11.1-#{Bundler.local_platform})
-            racc (~> 1.4)
-          racc (1.5.2)
+            racca (~> 1.4)
+          racca (1.5.2)
 
       PLATFORMS
         #{lockfile_platforms_for(["ruby", specific_local_platform])}
@@ -94,7 +94,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
       CHECKSUMS
         nokogiri (1.11.1)
         #{checksum_for_repo_gem gem_repo4, "nokogiri", "1.11.1", Bundler.local_platform}
-        #{checksum_for_repo_gem gem_repo4, "racc", "1.5.2"}
+        #{checksum_for_repo_gem gem_repo4, "racca", "1.5.2"}
 
       BUNDLED WITH
          #{Bundler::VERSION}

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -1195,6 +1195,9 @@ end
 
         DEPENDENCIES
           rack
+
+        CHECKSUMS
+          #{checksum_for_repo_gem gem_repo1, "rack", "1.0.0"}
       L
 
       if ruby_version

--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -17,6 +17,7 @@ require "rspec/support/differ"
 
 require_relative "support/builders"
 require_relative "support/build_metadata"
+require_relative "support/checksums"
 require_relative "support/filters"
 require_relative "support/helpers"
 require_relative "support/indexes"
@@ -34,6 +35,7 @@ end
 
 RSpec.configure do |config|
   config.include Spec::Builders
+  config.include Spec::Checksums
   config.include Spec::Helpers
   config.include Spec::Indexes
   config.include Spec::Matchers

--- a/bundler/spec/support/artifice/helpers/compact_index.rb
+++ b/bundler/spec/support/artifice/helpers/compact_index.rb
@@ -80,7 +80,7 @@ class CompactIndexAPI < Endpoint
               CompactIndex::Dependency.new(d.name, reqs)
             end
             checksum = begin
-                         Digest(:SHA256).file("#{gem_repo}/gems/#{spec.original_name}.gem").base64digest
+                         Digest(:SHA256).file("#{gem_repo}/gems/#{spec.original_name}.gem").hexdigest
                        rescue StandardError
                          nil
                        end

--- a/bundler/spec/support/checksums.rb
+++ b/bundler/spec/support/checksums.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Spec
+  module Checksums
+    class ChecksumsBuilder
+      def initialize
+        @checksums = []
+      end
+
+      def repo_gem(gem_repo, gem_name, gem_version, platform = nil)
+        gem_file = if platform
+          "#{gem_repo}/gems/#{gem_name}-#{gem_version}-#{platform}.gem"
+        else
+          "#{gem_repo}/gems/#{gem_name}-#{gem_version}.gem"
+        end
+
+        checksum = sha256_checksum(gem_file)
+        @checksums << Bundler::Checksum.new(gem_name, gem_version, platform, checksum)
+      end
+
+      def to_lock
+        @checksums.map(&:to_lock).join.strip
+      end
+
+      private
+
+      def sha256_checksum(file)
+        File.open(file) do |f|
+          digest = Bundler::SharedHelpers.digest(:SHA256).new
+          digest << f.read(16_384) until f.eof?
+          digest.hexdigest!
+        end
+      end
+    end
+
+    def construct_checksum_section
+      checksums = ChecksumsBuilder.new
+
+      yield checksums
+
+      checksums.to_lock
+    end
+
+    def checksum_for_repo_gem(gem_repo, gem_name, gem_version, platform = nil)
+      construct_checksum_section do |c|
+        c.repo_gem(gem_repo, gem_name, gem_version, platform)
+      end
+    end
+  end
+end

--- a/bundler/spec/support/checksums.rb
+++ b/bundler/spec/support/checksums.rb
@@ -28,7 +28,8 @@ module Spec
         File.open(file) do |f|
           digest = Bundler::SharedHelpers.digest(:SHA256).new
           digest << f.read(16_384) until f.eof?
-          digest.hexdigest!
+
+          "sha256-#{digest.hexdigest!}"
         end
       end
     end

--- a/bundler/spec/update/git_spec.rb
+++ b/bundler/spec/update/git_spec.rb
@@ -328,6 +328,10 @@ RSpec.describe "bundle update" do
           foo!
           rack
 
+        CHECKSUMS
+          foo (2.0)
+          #{checksum_for_repo_gem gem_repo2, "rack", "1.0.0"}
+
         BUNDLED WITH
            #{Bundler::VERSION}
       G

--- a/bundler/tool/bundler/dev_gems.rb.lock
+++ b/bundler/tool/bundler/dev_gems.rb.lock
@@ -18,7 +18,7 @@ GEM
       rdiscount (>= 1.5.8)
     rspec-core (3.12.0)
       rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.0)
+    rspec-expectations (3.12.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-mocks (3.12.1)
@@ -35,8 +35,8 @@ PLATFORMS
   ruby
   universal-java-11
   universal-java-18
-  x64-mingw-ucrt
   x64-mingw32
+  x64-unknown
   x86_64-darwin-20
   x86_64-linux
 
@@ -52,6 +52,25 @@ DEPENDENCIES
   test-unit (~> 3.0)
   uri (~> 0.12.0)
   webrick (~> 1.6)
+
+CHECKSUMS
+  diff-lcs (1.5.0) sha256-49b934001c8c6aedb37ba19daec5c634da27b318a7a3c654ae979d6ba1929b67
+  hpricot (0.8.6) sha256-dfe8f4b3414ba8377d7626030f3aa605caadee9de87cffbeadf8a50359eac8ca
+  mustache (1.1.1) sha256-90891fdd50b53919ca334c8c1031eada1215e78d226d5795e523d6123a2717d0
+  parallel (1.22.1) sha256-ebdf1f0c51f182df38522f70ba770214940bef998cdb6e00f36492b29699761f
+  parallel_tests (2.32.0) sha256-f1d3470b169e365642ec12d2a8c7fbab2d3cfa14df0574c2c7087ba9b59d7e6e
+  power_assert (2.0.2) sha256-1d3e2d70e9bfd7afc5bacdc75f3d9ee69c3e81c50a29de3ca4028509d822dd9f
+  rake (13.0.6) sha256-5ce4bf5037b4196c24ac62834d8db1ce175470391026bd9e557d669beeb19097
+  rb_sys (0.9.52) sha256-4e7950f9e60405ae13b88bb65a00eb6fee535db091eae50edc8fdd90e0529bf1
+  rdiscount (2.2.7) sha256-ce2ead92bd012de244f8f6fa1c03356db32611f460a092ee39ffbc8059dbeba1
+  ronn (0.7.3) sha256-82df6fd4a3aa91734866710d2811a6387e50a7513fc528ce6c7d95ee7ad7f41e
+  rspec-core (3.12.0) sha256-c466f4137966526e177d2156ca45c249eeecc7ed519b23ae2fb80c4675406bc5
+  rspec-expectations (3.12.1) sha256-808b29f7f3ef4535fc897c10235b662bb6b58219406fec56158623b3a8e06c9e
+  rspec-mocks (3.12.1) sha256-e0dd725c7d1c1417c3a1715ccc4e41c124fab6c05b2de5a91ce22d74ee301801
+  rspec-support (3.12.0) sha256-dd4d44b247ff679b95b5607ac5641d197a5f9b1d33f916123cb98fc5f917c58b
+  test-unit (3.5.5) sha256-2c24596882077421cccec1f1291c392efd1d18de96cde0d7744cdf810de1d746
+  uri (0.12.0) sha256-de78451db9d3f646d6cc58dc09a819105794ac39efe679082ba4a19873b18485
+  webrick (1.7.0) sha256-87e9b8e39947b7925338a5eb55427b11ce1f2b25a3645770ec9f39d8ebdb8cb4
 
 BUNDLED WITH
    2.5.0.dev

--- a/bundler/tool/bundler/lint_gems.rb.lock
+++ b/bundler/tool/bundler/lint_gems.rb.lock
@@ -38,5 +38,18 @@ DEPENDENCIES
   rubocop (~> 1.30)
   rubocop-performance (~> 1.14)
 
+CHECKSUMS
+  ast (2.4.2) sha256-1e280232e6a33754cde542bc5ef85520b74db2aac73ec14acef453784447cc12
+  parallel (1.22.1) sha256-ebdf1f0c51f182df38522f70ba770214940bef998cdb6e00f36492b29699761f
+  parser (3.1.2.0) sha256-eda4d7b49bbfddad3b6ca9cdfb23302eec6cf73c2e808b6d5b0cc9161f7c0e76
+  rainbow (3.1.1) sha256-039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
+  regexp_parser (2.5.0) sha256-a076d2d35ab8d11feab5fecf8aa09ec6df68c2429810748cba079f7b021ecde5
+  rexml (3.2.5) sha256-a33c3bf95fda7983ec7f05054f3a985af41dbc25a0339843bd2479e93cabb123
+  rubocop (1.30.1) sha256-e1fcbed368d823ff8bbda00819f0abf0d522a914dfe62499884fcb6df0ff1d21
+  rubocop-ast (1.18.0) sha256-f4fa69a90e9c75145e344c5c4be3f0306a483932c5970a37c27e4a643c2777ac
+  rubocop-performance (1.14.2) sha256-551afc2df245c3d745d69296707e0b0192ea2b593574f7b264404be30f86ccb4
+  ruby-progressbar (1.11.0) sha256-cc127db3866dc414ffccbf92928a241e585b3aa2b758a5563e74a6ee0f57d50a
+  unicode-display_width (2.1.0) sha256-b6ff8c329fdbfcf67e4e6de642ba3df0f5e1e05935be9a2203333a0875aa5233
+
 BUNDLED WITH
    2.5.0.dev

--- a/bundler/tool/bundler/release_gems.rb.lock
+++ b/bundler/tool/bundler/release_gems.rb.lock
@@ -48,5 +48,7 @@ DEPENDENCIES
   aws-sdk-s3 (~> 1.87)
   octokit (~> 4.18)
 
+CHECKSUMS
+
 BUNDLED WITH
    2.5.0.dev

--- a/bundler/tool/bundler/rubocop_gems.rb.lock
+++ b/bundler/tool/bundler/rubocop_gems.rb.lock
@@ -23,7 +23,7 @@ GEM
       rspec-mocks (~> 3.12.0)
     rspec-core (3.12.0)
       rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.0)
+    rspec-expectations (3.12.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-mocks (3.12.1)
@@ -54,7 +54,7 @@ PLATFORMS
   arm64-darwin-22
   universal-java-11
   universal-java-18
-  x64-mingw-ucrt
+  x64-unknown
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21
@@ -68,6 +68,30 @@ DEPENDENCIES
   rspec
   rubocop (~> 1.7)
   test-unit
+
+CHECKSUMS
+  ast (2.4.2) sha256-1e280232e6a33754cde542bc5ef85520b74db2aac73ec14acef453784447cc12
+  diff-lcs (1.5.0) sha256-49b934001c8c6aedb37ba19daec5c634da27b318a7a3c654ae979d6ba1929b67
+  json (2.6.3) sha256-86aaea16adf346a2b22743d88f8dcceeb1038843989ab93cda44b5176c845459
+  minitest (5.16.3) sha256-60f81ad96ca5518e1457bd29eb826db60f86fbbdf8c05eac63b4824ef1f52614
+  parallel (1.22.1) sha256-ebdf1f0c51f182df38522f70ba770214940bef998cdb6e00f36492b29699761f
+  parser (3.1.3.0) sha256-4593da6a6c0dc1b0a0b47b68aa79c36655e19b9d8636f7c27d02a76cb7840e9f
+  power_assert (2.0.2) sha256-1d3e2d70e9bfd7afc5bacdc75f3d9ee69c3e81c50a29de3ca4028509d822dd9f
+  rainbow (3.1.1) sha256-039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
+  rake (13.0.6) sha256-5ce4bf5037b4196c24ac62834d8db1ce175470391026bd9e557d669beeb19097
+  rake-compiler (1.2.0) sha256-e02bcf56d2f3d80cb878b760268e8f13dc8e4251c9fba080ded779b167ae6ff5
+  rb_sys (0.9.52) sha256-4e7950f9e60405ae13b88bb65a00eb6fee535db091eae50edc8fdd90e0529bf1
+  regexp_parser (2.6.1) sha256-4e7b6a95c3b207c2d5274ff5f6334e7a564bf4f0e871028137dccd751eeb4766
+  rexml (3.2.5) sha256-a33c3bf95fda7983ec7f05054f3a985af41dbc25a0339843bd2479e93cabb123
+  rspec (3.12.0) sha256-ccc41799a43509dc0be84070e3f0410ac95cbd480ae7b6c245543eb64162399c
+  rspec-core (3.12.0) sha256-c466f4137966526e177d2156ca45c249eeecc7ed519b23ae2fb80c4675406bc5
+  rspec-mocks (3.12.1) sha256-e0dd725c7d1c1417c3a1715ccc4e41c124fab6c05b2de5a91ce22d74ee301801
+  rspec-support (3.12.0) sha256-dd4d44b247ff679b95b5607ac5641d197a5f9b1d33f916123cb98fc5f917c58b
+  rubocop (1.40.0) sha256-031881f824594fdb08713d5187c7bf07a11ff83fda869a7dd2d7765f92846a35
+  rubocop-ast (1.24.0) sha256-a917dc38015ccfa4397d34e71adaca2187ec7f2adc903f1af909fb6b097a136b
+  ruby-progressbar (1.11.0) sha256-cc127db3866dc414ffccbf92928a241e585b3aa2b758a5563e74a6ee0f57d50a
+  test-unit (3.5.5) sha256-2c24596882077421cccec1f1291c392efd1d18de96cde0d7744cdf810de1d746
+  unicode-display_width (2.3.0) sha256-4796ca01137fe8cf59cada263b74ebe6bb9583c555ec2239be4cb97c91064765
 
 BUNDLED WITH
    2.5.0.dev

--- a/bundler/tool/bundler/standard_gems.rb.lock
+++ b/bundler/tool/bundler/standard_gems.rb.lock
@@ -62,7 +62,7 @@ PLATFORMS
   arm64-darwin-22
   universal-java-11
   universal-java-18
-  x64-mingw-ucrt
+  x64-unknown
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21
@@ -76,6 +76,34 @@ DEPENDENCIES
   rspec
   standard (~> 1.0)
   test-unit
+
+CHECKSUMS
+  ast (2.4.2) sha256-1e280232e6a33754cde542bc5ef85520b74db2aac73ec14acef453784447cc12
+  diff-lcs (1.5.0) sha256-49b934001c8c6aedb37ba19daec5c634da27b318a7a3c654ae979d6ba1929b67
+  json (2.6.3) sha256-86aaea16adf346a2b22743d88f8dcceeb1038843989ab93cda44b5176c845459
+  language_server-protocol (3.17.0.2) sha256-d94511853862e44e4643c13b57daf4daa28b3f5cf07c2bfcfd999683c5fd2393
+  minitest (5.16.3) sha256-60f81ad96ca5518e1457bd29eb826db60f86fbbdf8c05eac63b4824ef1f52614
+  parallel (1.22.1) sha256-ebdf1f0c51f182df38522f70ba770214940bef998cdb6e00f36492b29699761f
+  parser (3.1.3.0) sha256-4593da6a6c0dc1b0a0b47b68aa79c36655e19b9d8636f7c27d02a76cb7840e9f
+  power_assert (2.0.2) sha256-1d3e2d70e9bfd7afc5bacdc75f3d9ee69c3e81c50a29de3ca4028509d822dd9f
+  rainbow (3.1.1) sha256-039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
+  rake (13.0.6) sha256-5ce4bf5037b4196c24ac62834d8db1ce175470391026bd9e557d669beeb19097
+  rake-compiler (1.2.0) sha256-e02bcf56d2f3d80cb878b760268e8f13dc8e4251c9fba080ded779b167ae6ff5
+  rb_sys (0.9.52) sha256-4e7950f9e60405ae13b88bb65a00eb6fee535db091eae50edc8fdd90e0529bf1
+  regexp_parser (2.6.1) sha256-4e7b6a95c3b207c2d5274ff5f6334e7a564bf4f0e871028137dccd751eeb4766
+  rexml (3.2.5) sha256-a33c3bf95fda7983ec7f05054f3a985af41dbc25a0339843bd2479e93cabb123
+  rspec (3.12.0) sha256-ccc41799a43509dc0be84070e3f0410ac95cbd480ae7b6c245543eb64162399c
+  rspec-core (3.12.0) sha256-c466f4137966526e177d2156ca45c249eeecc7ed519b23ae2fb80c4675406bc5
+  rspec-expectations (3.12.0) sha256-1bd1f90040b346d4399c3042c2c46c1c253ff27bbf2ada3e2183640c65d58d62
+  rspec-mocks (3.12.1) sha256-e0dd725c7d1c1417c3a1715ccc4e41c124fab6c05b2de5a91ce22d74ee301801
+  rspec-support (3.12.0) sha256-dd4d44b247ff679b95b5607ac5641d197a5f9b1d33f916123cb98fc5f917c58b
+  rubocop (1.39.0) sha256-7ce41a7778f3b65d3b8ca9d39ea360bbe58551fe3b7b2ab2f5b5b7860c9efd3d
+  rubocop-ast (1.24.0) sha256-a917dc38015ccfa4397d34e71adaca2187ec7f2adc903f1af909fb6b097a136b
+  rubocop-performance (1.15.1) sha256-8d4f1839e7043364269d15b8191eadda29a4bb937ec29e74fdb074511d048d02
+  ruby-progressbar (1.11.0) sha256-cc127db3866dc414ffccbf92928a241e585b3aa2b758a5563e74a6ee0f57d50a
+  standard (1.19.1) sha256-f17be50174353d3ade2c0a5860087b52eb5f2738b02a1fc1eb1bda3a50910d78
+  test-unit (3.5.5) sha256-2c24596882077421cccec1f1291c392efd1d18de96cde0d7744cdf810de1d746
+  unicode-display_width (2.3.0) sha256-4796ca01137fe8cf59cada263b74ebe6bb9583c555ec2239be4cb97c91064765
 
 BUNDLED WITH
    2.5.0.dev

--- a/bundler/tool/bundler/test_gems.rb.lock
+++ b/bundler/tool/bundler/test_gems.rb.lock
@@ -26,8 +26,8 @@ PLATFORMS
   ruby
   universal-java-11
   universal-java-18
-  x64-mingw-ucrt
   x64-mingw32
+  x64-unknown
   x86_64-darwin-20
   x86_64-linux
 
@@ -40,6 +40,20 @@ DEPENDENCIES
   rb_sys
   sinatra (~> 2.0)
   webrick (= 1.7.0)
+
+CHECKSUMS
+  builder (3.2.4) sha256-99caf08af60c8d7f3a6b004029c4c3c0bdaebced6c949165fe98f1db27fbbc10
+  compact_index (0.13.0) sha256-adda43cc3c7068dea3deb171ca99953f3a6b9cdc247413c47779a1273adbd18b
+  mustermann (1.1.2) sha256-7b64de2f39ae6b623b6d4f7d2ced10d3442817ca9bb6200cf7bff3b9f6447b7e
+  rack (2.0.8) sha256-f98171fb30e104950abe1e9fb97c177d8bb5643dd649bc2ed837864eb596a0c5
+  rack-protection (2.0.8.1) sha256-d187dee7708ca93301854127e81b2675b60af86ab53532f9735087ecd649d2ff
+  rack-test (1.1.0) sha256-154161f40f162b1c009a655b7b0c5de3a3102cc6d7d2e94b64e1f46ace800866
+  rake (13.0.1) sha256-292a08eb3064e972e3e07e4c297d54a93433439ff429e58a403ae05584fad870
+  rb_sys (0.9.52) sha256-4e7950f9e60405ae13b88bb65a00eb6fee535db091eae50edc8fdd90e0529bf1
+  ruby2_keywords (0.0.5) sha256-ffd13740c573b7301cf7a2e61fc857b2a8e3d3aff32545d6f8300d8bae10e3ef
+  sinatra (2.0.8.1) sha256-b8845f060fde0157940172a4d006b757f3ba6a5ea36326c7c9352c25391c3e66
+  tilt (2.0.11) sha256-7b180fc472cbdeb186c85d31c0f2d1e61a2c0d77e1d9fd0ca28482a9d972d6a0
+  webrick (1.7.0) sha256-87e9b8e39947b7925338a5eb55427b11ce1f2b25a3645770ec9f39d8ebdb8cb4
 
 BUNDLED WITH
    2.5.0.dev


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

This mitigates issues such as cache poisoning, or dependency confusion. If the remote gem server has gems compromised via those issues, then the application installing such gems can use the locked checksum to warn
there is a potential issue. e.g. https://github.com/rubygems/rubygems.org/security/advisories/GHSA-2jmx-8mh8-pm8w

See also discussion in https://github.com/rubygems/rubygems/issues/3379

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

Lock the checksum of each gem file in the lockfile, in a new `CHECKSUMS` section

Note only installed gems will lock the checksum. Gem that are not matching the current local platform will not lock its checksum (because it was never resolved) - however if they had a previous locked checksum it should be preserved)

Once we have locked checksums, we can then later add install-time checking (not in this PR)

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)



This is still in draft, but it shows one way to add a backwards compatible Checksums section to the lockfile

TODOs:

- [x] The format can be changed. It's on two lines currently for ease of parsing so I can re-use the `NAME_VERSION` regex
- [ ] What format for path sources ?
- [x] Do we want to be explicit on what checksum type is locked (`c1191bd01cbe54c3bec85a33e16f87162f47f9ab08d0cbe6e64232b52cd84d17` vs `sha256-c1191bd01cbe54c3bec85a33e16f87162f47f9ab08d0cbe6e64232b52cd84d17`)
- [x] Some checksums need to be calculated in the spec because the gem is generated via `build_gem`
- [x] Not lock checksums on legacy lockfiles (lockfiles with only `ruby` PLATFORM)
- [x] Lots of specs still fail because the expectation needs to add `CHECKSUMS` section 
- [x] When running specs in parallel, some fail because the cached gem repositories have in-consistent checksums for the same gem file (e.g. `rack-1.0.0`)
- [ ] Check that lockfiles with multiple platforms work as expected