### PR TITLE
Include backtrace with crashes by default

### DIFF
--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -39,7 +39,7 @@ require "rbconfig"
 class Gem::ConfigFile
   include Gem::UserInteraction
 
-  DEFAULT_BACKTRACE = false
+  DEFAULT_BACKTRACE = true
   DEFAULT_BULK_THRESHOLD = 1000
   DEFAULT_VERBOSITY = true
   DEFAULT_UPDATE_SOURCES = true

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -35,7 +35,7 @@ class TestGemConfigFile < Gem::TestCase
   def test_initialize
     assert_equal @temp_conf, @cfg.config_file_name
 
-    assert_equal false, @cfg.backtrace
+    assert_equal true, @cfg.backtrace
     assert_equal true, @cfg.update_sources
     assert_equal Gem::ConfigFile::DEFAULT_BULK_THRESHOLD, @cfg.bulk_threshold
     assert_equal true, @cfg.verbose
@@ -239,6 +239,12 @@ if you believe they were disclosed to a third party.
   end
 
   def test_handle_arguments_backtrace
+    File.open @temp_conf, "w" do |fp|
+      fp.puts ":backtrace: false"
+    end
+
+    util_config_file %W[--config-file=#{@temp_conf}]
+
     assert_equal false, @cfg.backtrace
 
     args = %w[--backtrace]
@@ -275,6 +281,12 @@ if you believe they were disclosed to a third party.
   end
 
   def test_handle_arguments_traceback
+    File.open @temp_conf, "w" do |fp|
+      fp.puts ":backtrace: false"
+    end
+
+    util_config_file %W[--config-file=#{@temp_conf}]
+
     assert_equal false, @cfg.backtrace
 
     args = %w[--traceback]
@@ -288,7 +300,7 @@ if you believe they were disclosed to a third party.
     assert_equal @temp_conf, @cfg.config_file_name
 
     File.open @temp_conf, "w" do |fp|
-      fp.puts ":backtrace: true"
+      fp.puts ":backtrace: false"
       fp.puts ":update_sources: false"
       fp.puts ":bulk_threshold: 10"
       fp.puts ":verbose: false"
@@ -300,7 +312,7 @@ if you believe they were disclosed to a third party.
 
     util_config_file args
 
-    assert_equal false, @cfg.backtrace
+    assert_equal true, @cfg.backtrace
     assert_equal true, @cfg.update_sources
     assert_equal Gem::ConfigFile::DEFAULT_BULK_THRESHOLD, @cfg.bulk_threshold
     assert_equal true, @cfg.verbose
@@ -386,7 +398,7 @@ if you believe they were disclosed to a third party.
   end
 
   def test_write
-    @cfg.backtrace = true
+    @cfg.backtrace = false
     @cfg.update_sources = false
     @cfg.bulk_threshold = 10
     @cfg.verbose = false
@@ -398,7 +410,7 @@ if you believe they were disclosed to a third party.
     util_config_file
 
     # These should not be written out to the config file.
-    assert_equal false, @cfg.backtrace, "backtrace"
+    assert_equal true, @cfg.backtrace, "backtrace"
     assert_equal Gem::ConfigFile::DEFAULT_BULK_THRESHOLD, @cfg.bulk_threshold,
                  "bulk_threshold"
     assert_equal true, @cfg.update_sources, "update_sources"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

As opposed to Bundler, which reports a lot of very useful information when it crashes, every time a user reports a RubyGems crash, I have to tell them to rerun the command with the `--backtrace` flag, because errors without the `--backtrace` flag are very unhelpful and lack context. And sometimes, depending on where the error happened, rerunning might not be that easy.

## What is your fix for the problem, implemented in this PR?

My fix is to start showing backtraces with errors by default.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
