### PR TITLE
Fix regression where yanked gems are now unintentionally updated when other gems are unlocked

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -747,9 +747,6 @@ module Bundler
 
         next if @unlock[:sources].include?(s.source.name)
 
-        # If the spec is from a path source and it doesn't exist anymore
-        # then we unlock it.
-
         # Path sources have special logic
         if s.source.instance_of?(Source::Path) || s.source.instance_of?(Source::Gemspec)
           new_specs = begin

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -740,9 +740,9 @@ module Bundler
       end
 
       specs.each do |s|
-        # Replace the locked dependency's source with the equivalent source from the Gemfile
         dep = @dependencies.find {|d| s.satisfies?(d) }
 
+        # Replace the locked dependency's source with the equivalent source from the Gemfile
         s.source = (dep && dep.source) || sources.get_with_fallback(s.source)
 
         next if @unlock[:sources].include?(s.source.name)

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -743,7 +743,7 @@ module Bundler
         # Replace the locked dependency's source with the equivalent source from the Gemfile
         dep = @dependencies.find {|d| s.satisfies?(d) }
 
-        s.source = (dep && dep.source) || sources.get(s.source) || sources.default_source
+        s.source = (dep && dep.source) || sources.get_with_fallback(s.source)
 
         next if @unlock[:sources].include?(s.source.name)
 

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -739,11 +739,22 @@ module Bundler
         specs[dep].any? {|s| s.satisfies?(dep) && (!dep.source || s.source.include?(dep.source)) }
       end
 
+      @specs_that_changed_sources = []
+
       specs.each do |s|
         dep = @dependencies.find {|d| s.satisfies?(d) }
 
         # Replace the locked dependency's source with the equivalent source from the Gemfile
-        s.source = (dep && dep.source) || sources.get_with_fallback(s.source)
+        s.source = if dep && dep.source
+          gemfile_source = dep.source
+          lockfile_source = s.source
+
+          @specs_that_changed_sources << s if gemfile_source != lockfile_source
+
+          gemfile_source
+        else
+          sources.get_with_fallback(s.source)
+        end
 
         next if @unlock[:sources].include?(s.source.name)
 
@@ -821,7 +832,16 @@ module Bundler
       end
       source_requirements[:default_bundler] = source_requirements["bundler"] || sources.default_source
       source_requirements["bundler"] = sources.metadata_source # needs to come last to override
+      verify_changed_sources!
       source_requirements
+    end
+
+    def verify_changed_sources!
+      @specs_that_changed_sources.each do |s|
+        if s.source.specs.search(s.name).empty?
+          raise GemNotFound, "Could not find gem '#{s.name}' in #{s.source}"
+        end
+      end
     end
 
     def requested_groups

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -93,14 +93,6 @@ module Bundler
       __materialize__(candidates)
     end
 
-    def materialize_for_resolution
-      return self unless Gem::Platform.match_spec?(self)
-
-      candidates = source.specs.search(self)
-
-      __materialize__(candidates)
-    end
-
     def __materialize__(candidates)
       @specification = begin
         search = candidates.reverse.find do |spec|

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -28,10 +28,11 @@ module Bundler
     def initialize(source_requirements, base, gem_version_promoter, additional_base_requirements, platforms, metadata_requirements)
       @source_requirements = source_requirements
       @metadata_requirements = metadata_requirements
+      @base = base
       @resolver = Molinillo::Resolver.new(self, self)
       @search_for = {}
       @base_dg = Molinillo::DependencyGraph.new
-      @base = base.materialized_for_resolution do |ls|
+      base.each do |ls|
         dep = Dependency.new(ls.name, ls.version)
         @base_dg.add_vertex(ls.name, DepProxy.get_proxy(dep, ls.platform), true)
       end

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -101,6 +101,10 @@ module Bundler
       source_list_for(source).find {|s| equivalent_source?(source, s) }
     end
 
+    def get_with_fallback(source)
+      get(source) || default_source
+    end
+
     def lock_sources
       lock_other_sources + lock_rubygems_sources
     end

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -82,15 +82,6 @@ module Bundler
       end
     end
 
-    def materialized_for_resolution
-      materialized = @specs.map do |s|
-        spec = s.materialize_for_resolution
-        yield spec if spec
-        spec
-      end.compact
-      SpecSet.new(materialized)
-    end
-
     def incomplete_ruby_specs?(deps)
       self.class.new(self.for(deps, true, [Gem::Platform::RUBY])).incomplete_specs.any?
     end

--- a/bundler/spec/resolver/basic_spec.rb
+++ b/bundler/spec/resolver/basic_spec.rb
@@ -233,7 +233,7 @@ Bundler could not find compatible versions for gem "a":
     it "resolves foo only to latest patch - changing dependency declared case" do
       # bar is locked AND a declared dependency in the Gemfile, so it will not move, and therefore
       # foo can only move up to 1.4.4.
-      @base << Bundler::LazySpecification.new("bar", "2.0.3", nil)
+      @base << build_spec("bar", "2.0.3").first
       should_conservative_resolve_and_include :patch, ["foo"], %w[foo-1.4.4 bar-2.0.3]
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

#5070 caused a regression where updating specific gems in a lockfile, for example, through `bundle lock --update foo`, would also update unrelated gems, just because their locked version is yanked.

Issue was detected by dependabot-core test suite at https://github.com/dependabot/dependabot-core/pull/5465.

## What is your fix for the problem, implemented in this PR?

My fix is to revert #5070 and take a different approach to fix the issue that does not involve coupling the resolver with materializing bare spec information into real gem specifications.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
