### PR TITLE
Fix unused variable warning in RubyGems tests

### DIFF
--- a/test/rubygems/test_gem_resolver_installer_set.rb
+++ b/test/rubygems/test_gem_resolver_installer_set.rb
@@ -52,7 +52,7 @@ class TestGemResolverInstallerSet < Gem::TestCase
   end
 
   def test_add_always_install_index_spec_platform
-    a_1_local, a_1_local_gem = util_gem "a", 1 do |s|
+    _, a_1_local_gem = util_gem "a", 1 do |s|
       s.platform = Gem::Platform.local
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since #5795, running RubyGems tests print a warning at the beginning

```
/Users/deivid/Code/rubygems/rubygems/test/rubygems/test_gem_resolver_installer_set.rb:55: warning: assigned but unused variable - a_1_local
```

## What is your fix for the problem, implemented in this PR?

Don't name the unused variable.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
