### PR TITLE
Enable `Style/AndOr` cop in RubyGems

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -160,6 +160,9 @@ Style/MutableConstant:
 Style/NilComparison:
   Enabled: true
 
+Style/Not:
+  Enabled: true
+
 Style/BlockDelimiters:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -128,6 +128,10 @@ Performance/StringReplacement:
 Security/Open:
   Enabled: true
 
+Style/AndOr:
+  Enabled: true
+  EnforcedStyle: always
+
 Style/Dir:
   Enabled: true
 

--- a/.rubocop_bundler.yml
+++ b/.rubocop_bundler.yml
@@ -14,6 +14,7 @@ AllCops:
   Exclude:
     - bin/*
     - pkg/**/*
+    - tmp/**/*
     - util/**/*
     - bundler/tmp/**/*
     - bundler/lib/bundler/vendor/**/*

--- a/bin/update_rubygems
+++ b/bin/update_rubygems
@@ -7,7 +7,7 @@
 
 require "rubygems"
 
-if ARGV.include? "-h" or ARGV.include? "--help"
+if ARGV.include?("-h") || ARGV.include?("--help")
   $stderr.puts "rubygems_update [options]"
   $stderr.puts
   $stderr.puts "This will install the latest version of RubyGems."

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -944,7 +944,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
                    ".rb",
                    *%w[DLEXT DLEXT2].map do |key|
                      val = RbConfig::CONFIG[key]
-                     next unless val and not val.empty?
+                     next unless val and !val.empty?
                      ".#{val}"
                    end,
                   ].compact.uniq

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -741,8 +741,8 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   def self.prefix
     prefix = File.dirname RUBYGEMS_DIR
 
-    if prefix != File.expand_path(RbConfig::CONFIG["sitelibdir"]) and
-       prefix != File.expand_path(RbConfig::CONFIG["libdir"]) and
+    if prefix != File.expand_path(RbConfig::CONFIG["sitelibdir"]) &&
+       prefix != File.expand_path(RbConfig::CONFIG["libdir"]) &&
        "lib" == File.basename(RUBYGEMS_DIR)
       prefix
     end
@@ -845,8 +845,8 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   # Returns the latest release version of RubyGems.
 
   def self.latest_rubygems_version
-    latest_version_for("rubygems-update") or
-      raise "Can't find 'rubygems-update' in any repo. Check `gem source list`."
+    latest_version_for("rubygems-update") ||
+      raise("Can't find 'rubygems-update' in any repo. Check `gem source list`.")
   end
 
   ##
@@ -854,7 +854,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
   def self.latest_version_for(name)
     spec = latest_spec_for name
-    spec and spec.version
+    spec && spec.version
   end
 
   ##
@@ -944,7 +944,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
                    ".rb",
                    *%w[DLEXT DLEXT2].map do |key|
                      val = RbConfig::CONFIG[key]
-                     next unless val and !val.empty?
+                     next unless val && !val.empty?
                      ".#{val}"
                    end,
                   ].compact.uniq

--- a/lib/rubygems/available_set.rb
+++ b/lib/rubygems/available_set.rb
@@ -26,7 +26,7 @@ class Gem::AvailableSet
       s = o.set
     when Array
       s = o.map do |sp,so|
-        if !sp.kind_of?(Gem::Specification) or !so.kind_of?(Gem::Source)
+        if !sp.kind_of?(Gem::Specification) || !so.kind_of?(Gem::Source)
           raise TypeError, "Array must be in [[spec, source], ...] form"
         end
 
@@ -149,8 +149,8 @@ class Gem::AvailableSet
     @set.reject! do |t|
       # already locally installed
       Gem::Specification.any? do |installed_spec|
-        dep.name == installed_spec.name and
-          dep.requirement.satisfied_by? installed_spec.version
+        dep.name == installed_spec.name &&
+          dep.requirement.satisfied_by?(installed_spec.version)
       end
     end
 

--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -131,7 +131,7 @@ class Gem::BasicSpecification
   # default Ruby platform.
 
   def full_name
-    if platform == Gem::Platform::RUBY or platform.nil?
+    if platform == Gem::Platform::RUBY || platform.nil?
       "#{name}-#{version}".dup.tap(&Gem::UNTAINT)
     else
       "#{name}-#{version}-#{platform}".dup.tap(&Gem::UNTAINT)

--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -159,11 +159,11 @@ class Gem::Command
     gem = "'#{gem_name}' (#{version})"
     msg = String.new "Could not find a valid gem #{gem}"
 
-    if errors and !errors.empty?
+    if errors && !errors.empty?
       msg << ", here is why:\n"
       errors.each {|x| msg << "          #{x.wordy}\n" }
     else
-      if required_by and gem != required_by
+      if required_by && gem != required_by
         msg << " (required by #{required_by}) in any repository"
       else
         msg << " in any repository"
@@ -186,7 +186,7 @@ class Gem::Command
   def get_all_gem_names
     args = options[:args]
 
-    if args.nil? or args.empty?
+    if args.nil? || args.empty?
       raise Gem::CommandLineError,
             "Please specify at least one gem name (e.g. gem build GEMNAME)"
     end
@@ -216,7 +216,7 @@ class Gem::Command
   def get_one_gem_name
     args = options[:args]
 
-    if args.nil? or args.empty?
+    if args.nil? || args.empty?
       raise Gem::CommandLineError,
             "Please specify a gem name on the command line (e.g. gem build GEMNAME)"
     end
@@ -554,7 +554,7 @@ class Gem::Command
   end
 
   def configure_options(header, option_list)
-    return if option_list.nil? or option_list.empty?
+    return if option_list.nil? || option_list.empty?
 
     header = header.to_s.empty? ? "" : "#{header} "
     @parser.separator "  #{header}Options:"
@@ -586,7 +586,7 @@ class Gem::Command
   add_common_option("-V", "--[no-]verbose",
                     "Set the verbose level of output") do |value, options|
     # Set us to "really verbose" so the progress meter works
-    if Gem.configuration.verbose and value
+    if Gem.configuration.verbose && value
       Gem.configuration.verbose = 1
     else
       Gem.configuration.verbose = value

--- a/lib/rubygems/commands/cleanup_command.rb
+++ b/lib/rubygems/commands/cleanup_command.rb
@@ -149,7 +149,7 @@ If no gems are named all gems in GEM_HOME are cleaned.
     @primary_gems = {}
 
     Gem::Specification.each do |spec|
-      if @primary_gems[spec.name].nil? or
+      if @primary_gems[spec.name].nil? ||
          @primary_gems[spec.name].version < spec.version
         @primary_gems[spec.name] = spec
       end

--- a/lib/rubygems/commands/contents_command.rb
+++ b/lib/rubygems/commands/contents_command.rb
@@ -77,7 +77,7 @@ prefix or only the files that are requireable.
           gem_contents name
         end
 
-      terminate_interaction 1 unless found or names.length > 1
+      terminate_interaction 1 unless found || names.length > 1
     end
   end
 

--- a/lib/rubygems/commands/dependency_command.rb
+++ b/lib/rubygems/commands/dependency_command.rb
@@ -77,7 +77,7 @@ use with other commands.
         name_matches = name_pattern ? name_pattern =~ spec.name : true
         version_matches = requirement.satisfied_by?(spec.version)
 
-        name_matches and version_matches
+        name_matches && version_matches
       }.map(&:to_spec)
     end
 
@@ -133,7 +133,7 @@ use with other commands.
   end
 
   def ensure_local_only_reverse_dependencies # :nodoc:
-    if options[:reverse_dependencies] and remote? and !local?
+    if options[:reverse_dependencies] && remote? && !local?
       alert_error "Only reverse dependencies for local gems are supported."
       terminate_interaction 1
     end
@@ -182,7 +182,7 @@ use with other commands.
       sp.dependencies.each do |dep|
         dep = Gem::Dependency.new(*dep) unless Gem::Dependency === dep
 
-        if spec.name == dep.name and
+        if spec.name == dep.name &&
            dep.requirement.satisfied_by?(spec.version)
           result << [sp.full_name, dep]
         end
@@ -197,7 +197,7 @@ use with other commands.
   def name_pattern(args)
     return if args.empty?
 
-    if args.length == 1 and args.first =~ /\A(.*)(i)?\z/m
+    if args.length == 1 && args.first =~ /\A(.*)(i)?\z/m
       flags = $2 ? Regexp::IGNORECASE : nil
       Regexp.new $1, flags
     else

--- a/lib/rubygems/commands/dependency_command.rb
+++ b/lib/rubygems/commands/dependency_command.rb
@@ -133,7 +133,7 @@ use with other commands.
   end
 
   def ensure_local_only_reverse_dependencies # :nodoc:
-    if options[:reverse_dependencies] and remote? and not local?
+    if options[:reverse_dependencies] and remote? and !local?
       alert_error "Only reverse dependencies for local gems are supported."
       terminate_interaction 1
     end

--- a/lib/rubygems/commands/fetch_command.rb
+++ b/lib/rubygems/commands/fetch_command.rb
@@ -52,7 +52,7 @@ then repackaging it.
   end
 
   def check_version # :nodoc:
-    if options[:version] != Gem::Requirement.default and
+    if options[:version] != Gem::Requirement.default &&
          get_all_gem_names.size > 1
       alert_error "Can't use --version with multiple gems. You can specify multiple gems with" \
                   " version requirements using `gem fetch 'my_gem:1.0.0' 'my_other_gem:~>2.0.0'`"

--- a/lib/rubygems/commands/generate_index_command.rb
+++ b/lib/rubygems/commands/generate_index_command.rb
@@ -68,7 +68,7 @@ Marshal::MINOR_VERSION constants.  It is used to ensure compatibility.
     # This is always true because it's the only way now.
     options[:build_modern] = true
 
-    if !File.exist?(options[:directory]) or
+    if !File.exist?(options[:directory]) ||
        !File.directory?(options[:directory])
       alert_error "unknown directory name #{options[:directory]}."
       terminate_interaction 1

--- a/lib/rubygems/commands/generate_index_command.rb
+++ b/lib/rubygems/commands/generate_index_command.rb
@@ -68,8 +68,8 @@ Marshal::MINOR_VERSION constants.  It is used to ensure compatibility.
     # This is always true because it's the only way now.
     options[:build_modern] = true
 
-    if not File.exist?(options[:directory]) or
-       not File.directory?(options[:directory])
+    if !File.exist?(options[:directory]) or
+       !File.directory?(options[:directory])
       alert_error "unknown directory name #{options[:directory]}."
       terminate_interaction 1
     else

--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -134,14 +134,14 @@ You can use `i` command instead of `install`.
   end
 
   def check_install_dir # :nodoc:
-    if options[:install_dir] and options[:user_install]
+    if options[:install_dir] && options[:user_install]
       alert_error "Use --install-dir or --user-install but not both"
       terminate_interaction 1
     end
   end
 
   def check_version # :nodoc:
-    if options[:version] != Gem::Requirement.default and
+    if options[:version] != Gem::Requirement.default &&
          get_all_gem_names.size > 1
       alert_error "Can't use --version with multiple gems. You can specify multiple gems with" \
                   " version requirements using `gem install 'my_gem:1.0.0' 'my_other_gem:~>2.0.0'`"
@@ -191,7 +191,7 @@ You can use `i` command instead of `install`.
   end
 
   def install_gem(name, version) # :nodoc:
-    return if options[:conservative] and
+    return if options[:conservative] &&
       !Gem::Dependency.new(name, version).matching_specs.empty?
 
     req = Gem::Requirement.create(version)

--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -192,7 +192,7 @@ You can use `i` command instead of `install`.
 
   def install_gem(name, version) # :nodoc:
     return if options[:conservative] and
-      not Gem::Dependency.new(name, version).matching_specs.empty?
+      !Gem::Dependency.new(name, version).matching_specs.empty?
 
     req = Gem::Requirement.create(version)
 

--- a/lib/rubygems/commands/pristine_command.rb
+++ b/lib/rubygems/commands/pristine_command.rb
@@ -105,7 +105,7 @@ extensions will be restored.
     elsif options[:extensions_set] and
                   options[:extensions] and options[:args].empty?
       Gem::Specification.select do |spec|
-        spec.extensions and not spec.extensions.empty?
+        spec.extensions and !spec.extensions.empty?
       end
     else
       get_all_gem_names.sort.map do |gem_name|

--- a/lib/rubygems/commands/pristine_command.rb
+++ b/lib/rubygems/commands/pristine_command.rb
@@ -102,10 +102,10 @@ extensions will be restored.
 
     # `--extensions` must be explicitly given to pristine only gems
     # with extensions.
-    elsif options[:extensions_set] and
-                  options[:extensions] and options[:args].empty?
+    elsif options[:extensions_set] &&
+                  options[:extensions] && options[:args].empty?
       Gem::Specification.select do |spec|
-        spec.extensions and !spec.extensions.empty?
+        spec.extensions && !spec.extensions.empty?
       end
     else
       get_all_gem_names.sort.map do |gem_name|
@@ -135,14 +135,14 @@ extensions will be restored.
         end
       end
 
-      unless spec.extensions.empty? or options[:extensions] or options[:only_executables] or options[:only_plugins]
+      unless spec.extensions.empty? || options[:extensions] || options[:only_executables] || options[:only_plugins]
         say "Skipped #{spec.full_name}, it needs to compile an extension"
         next
       end
 
       gem = spec.cache_file
 
-      unless File.exist? gem or options[:only_executables] or options[:only_plugins]
+      unless File.exist?(gem) || options[:only_executables] || options[:only_plugins]
         require_relative "../remote_fetcher"
 
         say "Cached gem for #{spec.full_name} not found, attempting to fetch..."

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -329,9 +329,9 @@ By default, this RubyGems will install gem as:
       # ignore
     end
 
-    if File.writable? gem_doc_dir and
-       (!File.exist? rubygems_doc_dir or
-        File.writable? rubygems_doc_dir)
+    if File.writable?(gem_doc_dir) &&
+       (!File.exist?(rubygems_doc_dir) ||
+        File.writable?(rubygems_doc_dir))
       say "Removing old RubyGems RDoc and ri" if @verbose
       Dir[File.join(Gem.dir, "doc", "rubygems-[0-9]*")].each do |dir|
         rm_rf dir
@@ -559,7 +559,7 @@ abort "#{deprecation_message}"
 
         history_string = ""
 
-        until versions.length == 0 or
+        until versions.length == 0 ||
               versions.shift <= options[:previous_version] do
           history_string += version_lines.shift + text.shift
         end

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -330,7 +330,7 @@ By default, this RubyGems will install gem as:
     end
 
     if File.writable? gem_doc_dir and
-       (not File.exist? rubygems_doc_dir or
+       (!File.exist? rubygems_doc_dir or
         File.writable? rubygems_doc_dir)
       say "Removing old RubyGems RDoc and ri" if @verbose
       Dir[File.join(Gem.dir, "doc", "rubygems-[0-9]*")].each do |dir|

--- a/lib/rubygems/commands/sources_command.rb
+++ b/lib/rubygems/commands/sources_command.rb
@@ -215,9 +215,9 @@ To remove a source use the --remove argument:
   def remove_cache_file(desc, path) # :nodoc:
     FileUtils.rm_rf path
 
-    if not File.exist?(path)
+    if !File.exist?(path)
       say "*** Removed #{desc} source cache ***"
-    elsif not File.writable?(path)
+    elsif !File.writable?(path)
       say "*** Unable to remove #{desc} source cache (write protected) ***"
     else
       say "*** Unable to remove #{desc} source cache ***"

--- a/lib/rubygems/commands/sources_command.rb
+++ b/lib/rubygems/commands/sources_command.rb
@@ -82,7 +82,7 @@ Do you want to add this source?
   def check_rubygems_https(source_uri) # :nodoc:
     uri = URI source_uri
 
-    if uri.scheme and uri.scheme.downcase == "http" and
+    if uri.scheme && uri.scheme.downcase == "http" &&
        uri.host.downcase == "rubygems.org"
       question = <<-QUESTION.chomp
 https://rubygems.org is recommended for security over #{uri}

--- a/lib/rubygems/commands/specification_command.rb
+++ b/lib/rubygems/commands/specification_command.rb
@@ -88,7 +88,7 @@ Specific fields in the specification can be extracted in YAML format:
       raise Gem::CommandLineError, "Unsupported version type: '#{v}'"
     end
 
-    if !req.none? and options[:all]
+    if !req.none? && options[:all]
       alert_error "Specify --all or -v, not both"
       terminate_interaction 1
     end
@@ -102,7 +102,7 @@ Specific fields in the specification can be extracted in YAML format:
     field = get_one_optional_argument
 
     raise Gem::CommandLineError, "--ruby and FIELD are mutually exclusive" if
-      field and options[:format] == :ruby
+      field && options[:format] == :ruby
 
     if local?
       if File.exist? gem

--- a/lib/rubygems/commands/uninstall_command.rb
+++ b/lib/rubygems/commands/uninstall_command.rb
@@ -114,7 +114,7 @@ that is a dependency of an existing gem.  You can use the
   end
 
   def check_version # :nodoc:
-    if options[:version] != Gem::Requirement.default and
+    if options[:version] != Gem::Requirement.default &&
          get_all_gem_names.size > 1
       alert_error "Can't use --version with multiple gems. You can specify multiple gems with" \
                   " version requirements using `gem uninstall 'my_gem:1.0.0' 'my_other_gem:~>2.0.0'`"
@@ -125,7 +125,7 @@ that is a dependency of an existing gem.  You can use the
   def execute
     check_version
 
-    if options[:all] and !options[:args].empty?
+    if options[:all] && !options[:args].empty?
       uninstall_specific
     elsif options[:all]
       uninstall_all

--- a/lib/rubygems/commands/uninstall_command.rb
+++ b/lib/rubygems/commands/uninstall_command.rb
@@ -125,7 +125,7 @@ that is a dependency of an existing gem.  You can use the
   def execute
     check_version
 
-    if options[:all] and not options[:args].empty?
+    if options[:all] and !options[:args].empty?
       uninstall_specific
     elsif options[:all]
       uninstall_all

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -301,7 +301,7 @@ command to remove old versions.
     result = []
 
     highest_installed_gems.each do |l_name, l_spec|
-      next if not gem_names.empty? and
+      next if !gem_names.empty? and
               gem_names.none? {|name| name == l_spec.name }
 
       highest_remote_tup = highest_remote_name_tuple l_spec

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -155,7 +155,7 @@ command to remove old versions.
     Gem::Specification.dirs = Gem.user_dir if options[:user_install]
 
     Gem::Specification.each do |spec|
-      if hig[spec.name].nil? or hig[spec.name].version < spec.version
+      if hig[spec.name].nil? || hig[spec.name].version < spec.version
         hig[spec.name] = spec
       end
     end
@@ -292,7 +292,7 @@ command to remove old versions.
     args << "--no-document" unless options[:document].include?("rdoc") || options[:document].include?("ri")
     args << "--no-format-executable" if options[:no_format_executable]
     args << "--previous-version" << Gem::VERSION if
-      options[:system] == true or
+      options[:system] == true ||
         Gem::Version.new(options[:system]) >= Gem::Version.new(2)
     args
   end
@@ -301,7 +301,7 @@ command to remove old versions.
     result = []
 
     highest_installed_gems.each do |l_name, l_spec|
-      next if !gem_names.empty? and
+      next if !gem_names.empty? &&
               gem_names.none? {|name| name == l_spec.name }
 
       highest_remote_tup = highest_remote_name_tuple l_spec

--- a/lib/rubygems/commands/which_command.rb
+++ b/lib/rubygems/commands/which_command.rb
@@ -71,7 +71,7 @@ requiring to see why it does not behave as you expect.
     dirs.each do |dir|
       Gem.suffixes.each do |ext|
         full_path = File.join dir, "#{package_name}#{ext}"
-        if File.exist? full_path and !File.directory? full_path
+        if File.exist?(full_path) && !File.directory?(full_path)
           result << full_path
           return result unless options[:show_all]
         end

--- a/lib/rubygems/commands/which_command.rb
+++ b/lib/rubygems/commands/which_command.rb
@@ -71,7 +71,7 @@ requiring to see why it does not behave as you expect.
     dirs.each do |dir|
       Gem.suffixes.each do |ext|
         full_path = File.join dir, "#{package_name}#{ext}"
-        if File.exist? full_path and not File.directory? full_path
+        if File.exist? full_path and !File.directory? full_path
           result << full_path
           return result unless options[:show_all]
         end

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -368,7 +368,7 @@ if you believe they were disclosed to a third party.
 
   # True if the backtrace option has been specified, or debug is on.
   def backtrace
-    @backtrace or $DEBUG
+    @backtrace || $DEBUG
   end
 
   # The name of the configuration file.
@@ -477,11 +477,11 @@ if you believe they were disclosed to a third party.
   end
 
   def ==(other) # :nodoc:
-    self.class === other and
-      @backtrace == other.backtrace and
-      @bulk_threshold == other.bulk_threshold and
-      @verbose == other.verbose and
-      @update_sources == other.update_sources and
+    self.class === other &&
+      @backtrace == other.backtrace &&
+      @bulk_threshold == other.bulk_threshold &&
+      @verbose == other.verbose &&
+      @update_sources == other.update_sources &&
       @hash == other.hash
   end
 

--- a/lib/rubygems/core_ext/kernel_warn.rb
+++ b/lib/rubygems/core_ext/kernel_warn.rb
@@ -39,7 +39,7 @@ if RUBY_VERSION >= "2.5" && !Gem::KERNEL_WARN_IGNORES_INTERNAL_ENTRIES
           start += 1
 
           if path = loc.path
-            unless path.start_with?(rubygems_path) or path.start_with?("<internal:")
+            unless path.start_with?(rubygems_path) || path.start_with?("<internal:")
               # Non-rubygems frames
               uplevel -= 1
             end

--- a/lib/rubygems/defaults.rb
+++ b/lib/rubygems/defaults.rb
@@ -161,7 +161,7 @@ module Gem
     path = []
     path << user_dir if user_home && File.exist?(user_home)
     path << default_dir
-    path << vendor_dir if vendor_dir and File.directory? vendor_dir
+    path << vendor_dir if vendor_dir && File.directory?(vendor_dir)
     path
   end
 

--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -230,10 +230,10 @@ class Gem::Dependency
 
     version = Gem::Version.new version
 
-    return true if requirement.none? and not version.prerelease?
+    return true if requirement.none? and !version.prerelease?
     return false if version.prerelease? and
-                    not allow_prerelease and
-                    not prerelease?
+                    !allow_prerelease and
+                    !prerelease?
 
     requirement.satisfied_by? version
   end

--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -115,7 +115,7 @@ class Gem::Dependency
   # What does this dependency require?
 
   def requirement
-    return @requirement if defined?(@requirement) and @requirement
+    return @requirement if defined?(@requirement) && @requirement
 
     # @version_requirements and @version_requirement are legacy ivar
     # names, and supported here because older gems need to keep
@@ -230,9 +230,9 @@ class Gem::Dependency
 
     version = Gem::Version.new version
 
-    return true if requirement.none? and !version.prerelease?
-    return false if version.prerelease? and
-                    !allow_prerelease and
+    return true if requirement.none? && !version.prerelease?
+    return false if version.prerelease? &&
+                    !allow_prerelease &&
                     !prerelease?
 
     requirement.satisfied_by? version

--- a/lib/rubygems/dependency_installer.rb
+++ b/lib/rubygems/dependency_installer.rb
@@ -109,7 +109,7 @@ class Gem::DependencyInstaller
   # gems should be considered.
 
   def consider_local?
-    @domain == :both or @domain == :local
+    @domain == :both || @domain == :local
   end
 
   ##
@@ -117,7 +117,7 @@ class Gem::DependencyInstaller
   # gems should be considered.
 
   def consider_remote?
-    @domain == :both or @domain == :remote
+    @domain == :both || @domain == :remote
   end
 
   ##
@@ -197,7 +197,7 @@ class Gem::DependencyInstaller
 
   def in_background(what) # :nodoc:
     fork_happened = false
-    if @build_docs_in_background and Process.respond_to?(:fork)
+    if @build_docs_in_background && Process.respond_to?(:fork)
       begin
         Process.fork do
           yield
@@ -268,7 +268,7 @@ class Gem::DependencyInstaller
   end
 
   def install_development_deps # :nodoc:
-    if @development and @dev_shallow
+    if @development && @dev_shallow
       :shallow
     elsif @development
       :all
@@ -289,7 +289,7 @@ class Gem::DependencyInstaller
     installer_set.force = @force
 
     if consider_local?
-      if dep_or_name =~ /\.gem$/ and File.file? dep_or_name
+      if dep_or_name =~ /\.gem$/ && File.file?(dep_or_name)
         src = Gem::Source::SpecificFile.new dep_or_name
         installer_set.add_local dep_or_name, src.spec, src
         version = src.spec.version if version == Gem::Requirement.default

--- a/lib/rubygems/dependency_list.rb
+++ b/lib/rubygems/dependency_list.rb
@@ -119,11 +119,11 @@ class Gem::DependencyList
     each do |spec|
       spec.runtime_dependencies.each do |dep|
         inst = Gem::Specification.any? do |installed_spec|
-          dep.name == installed_spec.name and
-            dep.requirement.satisfied_by? installed_spec.version
+          dep.name == installed_spec.name &&
+            dep.requirement.satisfied_by?(installed_spec.version)
         end
 
-        unless inst or @specs.find {|s| s.satisfies_requirement? dep }
+        unless inst || @specs.find {|s| s.satisfies_requirement? dep }
           unsatisfied[spec.name] << dep
           return unsatisfied if quick
         end
@@ -175,7 +175,7 @@ class Gem::DependencyList
   def remove_specs_unsatisfied_by(dependencies)
     specs.reject! do |spec|
       dep = dependencies[spec.name]
-      dep and !dep.requirement.satisfied_by? spec.version
+      dep && !dep.requirement.satisfied_by?(spec.version)
     end
   end
 

--- a/lib/rubygems/dependency_list.rb
+++ b/lib/rubygems/dependency_list.rb
@@ -175,7 +175,7 @@ class Gem::DependencyList
   def remove_specs_unsatisfied_by(dependencies)
     specs.reject! do |spec|
       dep = dependencies[spec.name]
-      dep and not dep.requirement.satisfied_by? spec.version
+      dep and !dep.requirement.satisfied_by? spec.version
     end
   end
 

--- a/lib/rubygems/doctor.rb
+++ b/lib/rubygems/doctor.rb
@@ -59,7 +59,7 @@ class Gem::Doctor
   # Are we doctoring a gem repository?
 
   def gem_repository?
-    not installed_specs.empty?
+    !installed_specs.empty?
   end
 
   ##

--- a/lib/rubygems/doctor.rb
+++ b/lib/rubygems/doctor.rb
@@ -111,8 +111,8 @@ class Gem::Doctor
       basename = File.basename(child, extension)
       next if installed_specs.include? basename
       next if /^rubygems-\d/ =~ basename
-      next if "specifications" == sub_directory and "default" == basename
-      next if "plugins" == sub_directory and Gem.plugin_suffix_regexp =~ basename
+      next if "specifications" == sub_directory && "default" == basename
+      next if "plugins" == sub_directory && Gem.plugin_suffix_regexp =~ (basename)
 
       type = File.directory?(child) ? "directory" : "file"
 

--- a/lib/rubygems/exceptions.rb
+++ b/lib/rubygems/exceptions.rb
@@ -252,7 +252,7 @@ class Gem::UnsatisfiableDependencyError < Gem::DependencyError
   # Gem::Resolver::DependencyRequest +dep+
 
   def initialize(dep, platform_mismatch=nil)
-    if platform_mismatch and !platform_mismatch.empty?
+    if platform_mismatch && !platform_mismatch.empty?
       plats = platform_mismatch.map {|x| x.platform.to_s }.sort.uniq
       super "Unable to resolve dependency: No match for '#{dep}' on this platform. Found: #{plats.join(', ')}"
     else

--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -44,7 +44,7 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
       full_tmp_dest = File.join(extension_dir, tmp_dest_relative)
 
       # TODO remove in RubyGems 4
-      if Gem.install_extension_in_lib and lib_dir
+      if Gem.install_extension_in_lib && lib_dir
         FileUtils.mkdir_p lib_dir
         entries = Dir.entries(full_tmp_dest) - %w[. ..]
         entries = entries.map {|entry| File.join full_tmp_dest, entry }
@@ -53,7 +53,7 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
 
       FileUtils::Entry_.new(full_tmp_dest).traverse do |ent|
         destent = ent.class.new(dest_path, ent.rel)
-        destent.exist? or FileUtils.mv(ent.path, destent.path)
+        destent.exist? || FileUtils.mv(ent.path, destent.path)
       end
     ensure
       ENV["DESTDIR"] = destdir

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -71,7 +71,7 @@ module Gem::GemcutterUtilities
       begin
         env_rubygems_host = ENV["RUBYGEMS_HOST"]
         env_rubygems_host = nil if
-          env_rubygems_host and env_rubygems_host.empty?
+          env_rubygems_host && env_rubygems_host.empty?
 
         env_rubygems_host || configured_host
       end

--- a/lib/rubygems/indexer.rb
+++ b/lib/rubygems/indexer.rb
@@ -296,7 +296,7 @@ class Gem::Indexer
     files = @files
     files.delete @quick_marshal_dir if files.include? @quick_dir
 
-    if files.include? @quick_marshal_dir and not files.include? @quick_dir
+    if files.include? @quick_marshal_dir and !files.include? @quick_dir
       files.delete @quick_marshal_dir
 
       dst_name = File.join(@dest_directory, @quick_marshal_dir_base)

--- a/lib/rubygems/indexer.rb
+++ b/lib/rubygems/indexer.rb
@@ -149,7 +149,7 @@ class Gem::Indexer
             next
           end
 
-          platform = Gem::Platform::RUBY if platform.nil? or platform.empty?
+          platform = Gem::Platform::RUBY if platform.nil? || platform.empty?
           [spec.name, spec.version, platform]
         end
 
@@ -296,7 +296,7 @@ class Gem::Indexer
     files = @files
     files.delete @quick_marshal_dir if files.include? @quick_dir
 
-    if files.include? @quick_marshal_dir and !files.include? @quick_dir
+    if files.include?(@quick_marshal_dir) && !files.include?(@quick_dir)
       files.delete @quick_marshal_dir
 
       dst_name = File.join(@dest_directory, @quick_marshal_dir_base)
@@ -414,7 +414,7 @@ class Gem::Indexer
 
     index.each do |spec|
       platform = spec.original_platform
-      platform = Gem::Platform::RUBY if platform.nil? or platform.empty?
+      platform = Gem::Platform::RUBY if platform.nil? || platform.empty?
       specs_index << [spec.name, spec.version, platform]
     end
 

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -251,7 +251,7 @@ class Gem::Installer
     return if spec.name == existing
 
     # somebody has written to RubyGems' directory, overwrite, too bad
-    return if Gem.default_bindir != @bin_dir and !ruby_executable
+    return if Gem.default_bindir != @bin_dir && !ruby_executable
 
     question = "#{spec.name}'s executable \"#{filename}\" conflicts with ".dup
 
@@ -418,7 +418,7 @@ class Gem::Installer
   # True if the gems in the system satisfy +dependency+.
 
   def installation_satisfies_dependency?(dependency)
-    return true if @options[:development] and dependency.type == :development
+    return true if @options[:development] && dependency.type == :development
     return true if installed_specs.detect {|s| dependency.matches_spec? s }
     return false if @only_install_dir
     !dependency.matching_specs.empty?
@@ -483,7 +483,7 @@ class Gem::Installer
   end
 
   def generate_bin # :nodoc:
-    return if spec.executables.nil? or spec.executables.empty?
+    return if spec.executables.nil? || spec.executables.empty?
 
     ensure_writable_dir @bin_dir
 

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -251,7 +251,7 @@ class Gem::Installer
     return if spec.name == existing
 
     # somebody has written to RubyGems' directory, overwrite, too bad
-    return if Gem.default_bindir != @bin_dir and not ruby_executable
+    return if Gem.default_bindir != @bin_dir and !ruby_executable
 
     question = "#{spec.name}'s executable \"#{filename}\" conflicts with ".dup
 
@@ -421,7 +421,7 @@ class Gem::Installer
     return true if @options[:development] and dependency.type == :development
     return true if installed_specs.detect {|s| dependency.matches_spec? s }
     return false if @only_install_dir
-    not dependency.matching_specs.empty?
+    !dependency.matching_specs.empty?
   end
 
   ##

--- a/lib/rubygems/name_tuple.rb
+++ b/lib/rubygems/name_tuple.rb
@@ -10,7 +10,7 @@ class Gem::NameTuple
     @version = version
 
     unless platform.kind_of? Gem::Platform
-      platform = "ruby" if !platform or platform.empty?
+      platform = "ruby" if !platform || platform.empty?
     end
 
     @platform = platform
@@ -102,8 +102,8 @@ class Gem::NameTuple
   def ==(other)
     case other
     when self.class
-      @name == other.name and
-        @version == other.version and
+      @name == other.name &&
+        @version == other.version &&
         @platform == other.platform
     when Array
       to_a == other

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -687,7 +687,7 @@ EOM
               "package content (data.tar.gz) is missing", @gem
     end
 
-    if duplicates = @files.group_by {|f| f }.select {|k,v| v.size > 1 }.map(&:first) and duplicates.any?
+    if (duplicates = @files.group_by {|f| f }.select {|k,v| v.size > 1 }.map(&:first)) && duplicates.any?
       raise Gem::Security::Exception, "duplicate files in the package: (#{duplicates.map(&:inspect).join(', ')})"
     end
   end

--- a/lib/rubygems/package/tar_header.rb
+++ b/lib/rubygems/package/tar_header.rb
@@ -173,22 +173,22 @@ class Gem::Package::TarHeader
   end
 
   def ==(other) # :nodoc:
-    self.class === other and
-    @checksum == other.checksum and
-    @devmajor == other.devmajor and
-    @devminor == other.devminor and
-    @gid      == other.gid      and
-    @gname    == other.gname    and
-    @linkname == other.linkname and
-    @magic    == other.magic    and
-    @mode     == other.mode     and
-    @mtime    == other.mtime    and
-    @name     == other.name     and
-    @prefix   == other.prefix   and
-    @size     == other.size     and
-    @typeflag == other.typeflag and
-    @uid      == other.uid      and
-    @uname    == other.uname    and
+    self.class === other &&
+    @checksum == other.checksum &&
+    @devmajor == other.devmajor &&
+    @devminor == other.devminor &&
+    @gid      == other.gid      &&
+    @gname    == other.gname    &&
+    @linkname == other.linkname &&
+    @magic    == other.magic    &&
+    @mode     == other.mode     &&
+    @mtime    == other.mtime    &&
+    @name     == other.name     &&
+    @prefix   == other.prefix   &&
+    @size     == other.size     &&
+    @typeflag == other.typeflag &&
+    @uid      == other.uid      &&
+    @uname    == other.uname    &&
     @version  == other.version
   end
 

--- a/lib/rubygems/package/tar_writer.rb
+++ b/lib/rubygems/package/tar_writer.rb
@@ -314,7 +314,7 @@ class Gem::Package::TarWriter
         prefix = parts.join("/")
       end
 
-      if name.bytesize > 100 or prefix.empty?
+      if name.bytesize > 100 || prefix.empty?
         raise Gem::Package::TooLongFileName.new("File \"#{prefix}/#{name}\" has a too long name (should be 100 or less)")
       end
 

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -23,9 +23,9 @@ class Gem::Platform
 
   def self.match_platforms?(platform, platforms)
     platforms.any? do |local_platform|
-      platform.nil? or
-        local_platform == platform or
-        (local_platform != Gem::Platform::RUBY and local_platform =~ platform)
+      platform.nil? ||
+        local_platform == platform ||
+        (local_platform != Gem::Platform::RUBY && local_platform =~ platform)
     end
   end
   private_class_method :match_platforms?
@@ -70,7 +70,7 @@ class Gem::Platform
     when String then
       arch = arch.split "-"
 
-      if arch.length > 2 and arch.last !~ /\d/ # reassemble x86-linux-gnu
+      if arch.length > 2 && arch.last !~ (/\d/) # reassemble x86-linux-gnu
         extra = arch.pop
         arch.last << "-#{extra}"
       end
@@ -82,7 +82,7 @@ class Gem::Platform
       else cpu
       end
 
-      if arch.length == 2 and arch.last =~ /^\d+(\.\d+)?$/ # for command-line
+      if arch.length == 2 && arch.last =~ /^\d+(\.\d+)?$/ # for command-line
         @os, @version = arch
         return
       end
@@ -107,7 +107,7 @@ class Gem::Platform
       when /mingw-?(\w+)?/ then         [ "mingw",     $1  ]
       when /(mswin\d+)(\_(\d+))?/ then
         os, version = $1, $3
-        @cpu = "x86" if @cpu.nil? and os =~ /32$/
+        @cpu = "x86" if @cpu.nil? && os =~ /32$/
         [os, version]
       when /netbsdelf/ then             [ "netbsdelf", nil ]
       when /openbsd(\d+\.\d+)?/ then    [ "openbsd",   $1  ]
@@ -139,7 +139,7 @@ class Gem::Platform
   # the same CPU, OS and version.
 
   def ==(other)
-    self.class === other and to_a == other.to_a
+    self.class === other && to_a == other.to_a
   end
 
   alias :eql? :==
@@ -160,18 +160,18 @@ class Gem::Platform
     return nil unless Gem::Platform === other
 
     # universal-mingw32 matches x64-mingw-ucrt
-    return true if (@cpu == "universal" or other.cpu == "universal") and
-                   @os.start_with?("mingw") and other.os.start_with?("mingw")
+    return true if (@cpu == "universal" || other.cpu == "universal") &&
+                   @os.start_with?("mingw") && other.os.start_with?("mingw")
 
     # cpu
-    ([nil,"universal"].include?(@cpu) or [nil, "universal"].include?(other.cpu) or @cpu == other.cpu or
-    (@cpu == "arm" and other.cpu.start_with?("arm"))) and
+    ([nil,"universal"].include?(@cpu) || [nil, "universal"].include?(other.cpu) || @cpu == other.cpu ||
+    (@cpu == "arm" && other.cpu.start_with?("arm"))) &&
 
     # os
-    @os == other.os and
+    @os == other.os &&
 
     # version
-    (@version.nil? or other.version.nil? or @version == other.version)
+    (@version.nil? || other.version.nil? || @version == other.version)
   end
 
   ##

--- a/lib/rubygems/query_utils.rb
+++ b/lib/rubygems/query_utils.rb
@@ -112,7 +112,7 @@ module Gem::QueryUtils
   end
 
   def display_header(type)
-    if (ui.outs.tty? and Gem.configuration.verbose) or both?
+    if (ui.outs.tty? && Gem.configuration.verbose) || both?
       say
       say "*** #{type} GEMS ***"
       say
@@ -132,7 +132,7 @@ module Gem::QueryUtils
       name_matches = name ? s.name =~ name : true
       version_matches = show_prereleases? || !s.version.prerelease?
 
-      name_matches and version_matches
+      name_matches && version_matches
     end
 
     spec_tuples = specs.map do |spec|
@@ -176,7 +176,7 @@ module Gem::QueryUtils
   # Check if gem +name+ version +version+ is installed.
 
   def installed?(name, req = Gem::Requirement.default)
-    Gem::Specification.any? {|s| s.name =~ name and req =~ s.version }
+    Gem::Specification.any? {|s| s.name =~ name && req =~ s.version }
   end
 
   def output_query_results(spec_tuples)
@@ -242,7 +242,7 @@ module Gem::QueryUtils
     return unless options[:versions]
 
     list =
-      if platforms.empty? or options[:details]
+      if platforms.empty? || options[:details]
         name_tuples.map {|n| n.version }.uniq
       else
         platforms.sort.reverse.map do |version, pls|
@@ -289,13 +289,13 @@ module Gem::QueryUtils
   end
 
   def spec_homepage(entry, spec)
-    return if spec.homepage.nil? or spec.homepage.empty?
+    return if spec.homepage.nil? || spec.homepage.empty?
 
     entry << "\n" << format_text("Homepage: #{spec.homepage}", 68, 4)
   end
 
   def spec_license(entry, spec)
-    return if spec.license.nil? or spec.license.empty?
+    return if spec.license.nil? || spec.license.empty?
 
     licenses = "License#{spec.licenses.length > 1 ? 's' : ''}: ".dup
     licenses << spec.licenses.join(", ")

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -114,7 +114,7 @@ class Gem::RemoteFetcher
     cache_dir =
       if Dir.pwd == install_dir # see fetch_command
         install_dir
-      elsif File.writable?(install_cache_dir) || (File.writable?(install_dir) && (not File.exist?(install_cache_dir)))
+      elsif File.writable?(install_cache_dir) || (File.writable?(install_dir) && (!File.exist?(install_cache_dir)))
         install_cache_dir
       else
         File.join Gem.user_dir, "cache"

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -247,7 +247,7 @@ class Gem::RemoteFetcher
 
     data = send "fetch_#{uri.scheme}", uri, mtime, head
 
-    if data and !head and uri.to_s.end_with?(".gz")
+    if data && !head && uri.to_s.end_with?(".gz")
       begin
         data = Gem::Util.gunzip data
       rescue Zlib::GzipFile::Error
@@ -288,7 +288,7 @@ class Gem::RemoteFetcher
       return Gem.read_binary(path)
     end
 
-    if update and path
+    if update && path
       Gem.write_binary(path, data)
     end
 

--- a/lib/rubygems/request.rb
+++ b/lib/rubygems/request.rb
@@ -173,7 +173,7 @@ class Gem::Request
     require "uri"
     uri = URI(Gem::UriFormatter.new(env_proxy).normalize)
 
-    if uri and uri.user.nil? and uri.password.nil?
+    if uri && uri.user.nil? && uri.password.nil?
       user     = ENV["#{_scheme}_proxy_user"] || ENV["#{_SCHEME}_PROXY_USER"]
       password = ENV["#{_scheme}_proxy_pass"] || ENV["#{_SCHEME}_PROXY_PASS"]
 

--- a/lib/rubygems/request/connection_pools.rb
+++ b/lib/rubygems/request/connection_pools.rb
@@ -39,7 +39,7 @@ class Gem::Request::ConnectionPools # :nodoc:
   def get_no_proxy_from_env
     env_no_proxy = ENV["no_proxy"] || ENV["NO_PROXY"]
 
-    return [] if env_no_proxy.nil? or env_no_proxy.empty?
+    return [] if env_no_proxy.nil? || env_no_proxy.empty?
 
     env_no_proxy.split(/\s*,\s*/)
   end
@@ -78,7 +78,7 @@ class Gem::Request::ConnectionPools # :nodoc:
 
     no_proxy = get_no_proxy_from_env
 
-    if proxy_uri and !no_proxy?(hostname, no_proxy)
+    if proxy_uri && !no_proxy?(hostname, no_proxy)
       proxy_hostname = proxy_uri.respond_to?(:hostname) ? proxy_uri.hostname : proxy_uri.host
       net_http_args + [
         proxy_hostname,

--- a/lib/rubygems/request/connection_pools.rb
+++ b/lib/rubygems/request/connection_pools.rb
@@ -78,7 +78,7 @@ class Gem::Request::ConnectionPools # :nodoc:
 
     no_proxy = get_no_proxy_from_env
 
-    if proxy_uri and not no_proxy?(hostname, no_proxy)
+    if proxy_uri and !no_proxy?(hostname, no_proxy)
       proxy_hostname = proxy_uri.respond_to?(:hostname) ? proxy_uri.hostname : proxy_uri.host
       net_http_args + [
         proxy_hostname,

--- a/lib/rubygems/request/http_pool.rb
+++ b/lib/rubygems/request/http_pool.rb
@@ -26,7 +26,7 @@ class Gem::Request::HTTPPool # :nodoc:
 
   def close_all
     until @queue.empty?
-      if connection = @queue.pop(true) and connection.started?
+      if (connection = @queue.pop(true)) && connection.started?
         connection.finish
       end
     end

--- a/lib/rubygems/request_set.rb
+++ b/lib/rubygems/request_set.rb
@@ -443,7 +443,7 @@ class Gem::RequestSet
 
   def tsort_each_child(node) # :nodoc:
     node.spec.dependencies.each do |dep|
-      next if dep.type == :development and not @development
+      next if dep.type == :development and !@development
 
       match = @requests.find do |r|
         dep.match? r.spec.name, r.spec.version, @prerelease

--- a/lib/rubygems/request_set.rb
+++ b/lib/rubygems/request_set.rb
@@ -443,14 +443,14 @@ class Gem::RequestSet
 
   def tsort_each_child(node) # :nodoc:
     node.spec.dependencies.each do |dep|
-      next if dep.type == :development and !@development
+      next if dep.type == :development && !@development
 
       match = @requests.find do |r|
         dep.match? r.spec.name, r.spec.version, @prerelease
       end
 
       unless match
-        next if dep.type == :development and @development_shallow
+        next if dep.type == :development && @development_shallow
         next if @soft_missing
         raise Gem::DependencyError,
               "Unresolved dependency found during sorting - #{dep} (requested by #{node.spec.full_name})"

--- a/lib/rubygems/request_set/gem_dependency_api.rb
+++ b/lib/rubygems/request_set/gem_dependency_api.rb
@@ -371,7 +371,7 @@ class Gem::RequestSet::GemDependencyAPI
     duplicate = @dependencies.include? name
 
     @dependencies[name] =
-      if requirements.empty? and not source_set
+      if requirements.empty? and !source_set
         Gem::Requirement.default
       elsif source_set
         Gem::Requirement.source_set
@@ -789,7 +789,7 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
 
     raise ArgumentError,
           "You must specify engine_version along with the Ruby engine" if
-            engine and not engine_version
+            engine and !engine_version
 
     return true if @installing
 

--- a/lib/rubygems/request_set/gem_dependency_api.rb
+++ b/lib/rubygems/request_set/gem_dependency_api.rb
@@ -371,7 +371,7 @@ class Gem::RequestSet::GemDependencyAPI
     duplicate = @dependencies.include? name
 
     @dependencies[name] =
-      if requirements.empty? and !source_set
+      if requirements.empty? && !source_set
         Gem::Requirement.default
       elsif source_set
         Gem::Requirement.source_set
@@ -789,7 +789,7 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
 
     raise ArgumentError,
           "You must specify engine_version along with the Ruby engine" if
-            engine and !engine_version
+            engine && !engine_version
 
     return true if @installing
 
@@ -800,7 +800,7 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
       raise Gem::RubyVersionMismatch, message
     end
 
-    if engine and engine != Gem.ruby_engine
+    if engine && engine != Gem.ruby_engine
       message = "Your Ruby engine is #{Gem.ruby_engine}, " +
                 "but your #{gem_deps_file} requires #{engine}"
 

--- a/lib/rubygems/request_set/lockfile/parser.rb
+++ b/lib/rubygems/request_set/lockfile/parser.rb
@@ -30,7 +30,7 @@ class Gem::RequestSet::Lockfile::Parser
         when "PLATFORMS" then
           parse_PLATFORMS
         else
-          token = get until @tokens.empty? or peek.first == :section
+          token = get until @tokens.empty? || peek.first == :section
         end
       else
         raise "BUG: unhandled token #{token.type} (#{token.value.inspect}) at line #{token.line} column #{token.column}"
@@ -44,7 +44,7 @@ class Gem::RequestSet::Lockfile::Parser
   def get(expected_types = nil, expected_value = nil) # :nodoc:
     token = @tokens.shift
 
-    if expected_types and !Array(expected_types).include? token.type
+    if expected_types && !Array(expected_types).include?(token.type)
       unget token
 
       message = "unexpected token [#{token.type.inspect}, #{token.value.inspect}], " +
@@ -53,7 +53,7 @@ class Gem::RequestSet::Lockfile::Parser
       raise Gem::RequestSet::Lockfile::ParseError.new message, token.column, token.line, @filename
     end
 
-    if expected_value and expected_value != token.value
+    if expected_value && expected_value != token.value
       unget token
 
       message = "unexpected token [#{token.type.inspect}, #{token.value.inspect}], " +
@@ -67,7 +67,7 @@ class Gem::RequestSet::Lockfile::Parser
   end
 
   def parse_DEPENDENCIES # :nodoc:
-    while !@tokens.empty? and :text == peek.type do
+    while !@tokens.empty? && :text == peek.type do
       token = get :text
 
       requirements = []
@@ -127,7 +127,7 @@ class Gem::RequestSet::Lockfile::Parser
     set = Gem::Resolver::LockSet.new sources
     last_specs = nil
 
-    while !@tokens.empty? and :text == peek.type do
+    while !@tokens.empty? && :text == peek.type do
       token = get :text
       name = token.value
       column = token.column
@@ -144,7 +144,7 @@ class Gem::RequestSet::Lockfile::Parser
         type = token.type
         data = token.value
 
-        if type == :text and column == 4
+        if type == :text && column == 4
           version, platform = data.split "-", 2
 
           platform =
@@ -183,7 +183,7 @@ class Gem::RequestSet::Lockfile::Parser
 
     type = peek.type
     value = peek.value
-    if type == :entry and %w[branch ref tag].include? value
+    if type == :entry && %w[branch ref tag].include?(value)
       get
       get :text
 
@@ -199,7 +199,7 @@ class Gem::RequestSet::Lockfile::Parser
 
     last_spec = nil
 
-    while !@tokens.empty? and :text == peek.type do
+    while !@tokens.empty? && :text == peek.type do
       token = get :text
       name = token.value
       column = token.column
@@ -214,7 +214,7 @@ class Gem::RequestSet::Lockfile::Parser
         type = token.type
         data = token.value
 
-        if type == :text and column == 4
+        if type == :text && column == 4
           last_spec = set.add_git_spec name, data, repository, revision, true
         else
           dependency = parse_dependency name, data
@@ -246,7 +246,7 @@ class Gem::RequestSet::Lockfile::Parser
     set = Gem::Resolver::VendorSet.new
     last_spec = nil
 
-    while !@tokens.empty? and :text == peek.first do
+    while !@tokens.empty? && :text == peek.first do
       token = get :text
       name = token.value
       column = token.column
@@ -261,7 +261,7 @@ class Gem::RequestSet::Lockfile::Parser
         type = token.type
         data = token.value
 
-        if type == :text and column == 4
+        if type == :text && column == 4
           last_spec = set.add_vendor_gem name, directory
         else
           dependency = parse_dependency name, data
@@ -281,7 +281,7 @@ class Gem::RequestSet::Lockfile::Parser
   end
 
   def parse_PLATFORMS # :nodoc:
-    while !@tokens.empty? and :text == peek.first do
+    while !@tokens.empty? && :text == peek.first do
       name = get(:text).value
 
       @platforms << name

--- a/lib/rubygems/request_set/lockfile/parser.rb
+++ b/lib/rubygems/request_set/lockfile/parser.rb
@@ -44,7 +44,7 @@ class Gem::RequestSet::Lockfile::Parser
   def get(expected_types = nil, expected_value = nil) # :nodoc:
     token = @tokens.shift
 
-    if expected_types and not Array(expected_types).include? token.type
+    if expected_types and !Array(expected_types).include? token.type
       unget token
 
       message = "unexpected token [#{token.type.inspect}, #{token.value.inspect}], " +
@@ -67,7 +67,7 @@ class Gem::RequestSet::Lockfile::Parser
   end
 
   def parse_DEPENDENCIES # :nodoc:
-    while not @tokens.empty? and :text == peek.type do
+    while !@tokens.empty? and :text == peek.type do
       token = get :text
 
       requirements = []
@@ -127,7 +127,7 @@ class Gem::RequestSet::Lockfile::Parser
     set = Gem::Resolver::LockSet.new sources
     last_specs = nil
 
-    while not @tokens.empty? and :text == peek.type do
+    while !@tokens.empty? and :text == peek.type do
       token = get :text
       name = token.value
       column = token.column
@@ -199,7 +199,7 @@ class Gem::RequestSet::Lockfile::Parser
 
     last_spec = nil
 
-    while not @tokens.empty? and :text == peek.type do
+    while !@tokens.empty? and :text == peek.type do
       token = get :text
       name = token.value
       column = token.column
@@ -246,7 +246,7 @@ class Gem::RequestSet::Lockfile::Parser
     set = Gem::Resolver::VendorSet.new
     last_spec = nil
 
-    while not @tokens.empty? and :text == peek.first do
+    while !@tokens.empty? and :text == peek.first do
       token = get :text
       name = token.value
       column = token.column
@@ -281,7 +281,7 @@ class Gem::RequestSet::Lockfile::Parser
   end
 
   def parse_PLATFORMS # :nodoc:
-    while not @tokens.empty? and :text == peek.first do
+    while !@tokens.empty? and :text == peek.first do
       name = get(:text).value
 
       @platforms << name

--- a/lib/rubygems/request_set/lockfile/tokenizer.rb
+++ b/lib/rubygems/request_set/lockfile/tokenizer.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#) frozen_string_literal: true
 require_relative "parser"
 
 class Gem::RequestSet::Lockfile::Tokenizer
@@ -26,7 +26,7 @@ class Gem::RequestSet::Lockfile::Tokenizer
   end
 
   def skip(type)
-    @tokens.shift while !@tokens.empty? and peek.type == type
+    @tokens.shift while !@tokens.empty? && peek.type == type
   end
 
   ##

--- a/lib/rubygems/request_set/lockfile/tokenizer.rb
+++ b/lib/rubygems/request_set/lockfile/tokenizer.rb
@@ -26,7 +26,7 @@ class Gem::RequestSet::Lockfile::Tokenizer
   end
 
   def skip(type)
-    @tokens.shift while not @tokens.empty? and peek.type == type
+    @tokens.shift while !@tokens.empty? and peek.type == type
   end
 
   ##

--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -253,7 +253,7 @@ class Gem::Requirement
   def specific?
     return true if @requirements.length > 1 # GIGO, > 1, > 2 is silly
 
-    not %w[> >=].include? @requirements.first.first # grab the operator
+    !%w[> >=].include? @requirements.first.first # grab the operator
   end
 
   def to_s # :nodoc:

--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -153,10 +153,10 @@ class Gem::Resolver
     s.fetch_development_dependencies if @development
 
     s.dependencies.reverse_each do |d|
-      next if d.type == :development and !@development
-      next if d.type == :development and @development_shallow and
+      next if d.type == :development && !@development
+      next if d.type == :development && @development_shallow &&
               act.development?
-      next if d.type == :development and @development_shallow and
+      next if d.type == :development && @development_shallow &&
               act.parent
 
       reqs << Gem::Resolver::DependencyRequest.new(d, act)
@@ -192,7 +192,7 @@ class Gem::Resolver
     conflict = e.conflicts.values.first
     raise Gem::DependencyResolutionError, Conflict.new(conflict.requirement_trees.first.first, conflict.existing, conflict.requirement)
   ensure
-    @output.close if defined?(@output) and !debug?
+    @output.close if defined?(@output) && !debug?
   end
 
   ##

--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -153,7 +153,7 @@ class Gem::Resolver
     s.fetch_development_dependencies if @development
 
     s.dependencies.reverse_each do |d|
-      next if d.type == :development and not @development
+      next if d.type == :development and !@development
       next if d.type == :development and @development_shallow and
               act.development?
       next if d.type == :development and @development_shallow and

--- a/lib/rubygems/resolver/api_specification.rb
+++ b/lib/rubygems/resolver/api_specification.rb
@@ -40,10 +40,10 @@ class Gem::Resolver::APISpecification < Gem::Resolver::Specification
   end
 
   def ==(other) # :nodoc:
-    self.class === other and
-      @set          == other.set and
-      @name         == other.name and
-      @version      == other.version and
+    self.class === other &&
+      @set          == other.set &&
+      @name         == other.name &&
+      @version      == other.version &&
       @platform     == other.platform
   end
 

--- a/lib/rubygems/resolver/best_set.rb
+++ b/lib/rubygems/resolver/best_set.rb
@@ -25,7 +25,7 @@ class Gem::Resolver::BestSet < Gem::Resolver::ComposedSet
   end
 
   def find_all(req) # :nodoc:
-    pick_sets if @remote and @sets.empty?
+    pick_sets if @remote && @sets.empty?
 
     super
   rescue Gem::RemoteFetcher::FetchError => e
@@ -35,7 +35,7 @@ class Gem::Resolver::BestSet < Gem::Resolver::ComposedSet
   end
 
   def prefetch(reqs) # :nodoc:
-    pick_sets if @remote and @sets.empty?
+    pick_sets if @remote && @sets.empty?
 
     super
   end
@@ -63,7 +63,7 @@ class Gem::Resolver::BestSet < Gem::Resolver::ComposedSet
     uri = uri + "."
 
     raise error unless api_set = @sets.find do |set|
-      Gem::Resolver::APISet === set and set.dep_uri == uri
+      Gem::Resolver::APISet === set && set.dep_uri == uri
     end
 
     index_set = Gem::Resolver::IndexSet.new api_set.source

--- a/lib/rubygems/resolver/conflict.rb
+++ b/lib/rubygems/resolver/conflict.rb
@@ -27,9 +27,9 @@ class Gem::Resolver::Conflict
   end
 
   def ==(other) # :nodoc:
-    self.class === other and
-      @dependency == other.dependency and
-      @activated  == other.activated  and
+    self.class === other &&
+      @dependency == other.dependency &&
+      @activated  == other.activated  &&
       @failed_dep == other.failed_dep
   end
 

--- a/lib/rubygems/resolver/git_specification.rb
+++ b/lib/rubygems/resolver/git_specification.rb
@@ -6,9 +6,9 @@
 
 class Gem::Resolver::GitSpecification < Gem::Resolver::SpecSpecification
   def ==(other) # :nodoc:
-    self.class === other and
-      @set  == other.set and
-      @spec == other.spec and
+    self.class === other &&
+      @set  == other.set &&
+      @spec == other.spec &&
       @source == other.source
   end
 

--- a/lib/rubygems/resolver/installed_specification.rb
+++ b/lib/rubygems/resolver/installed_specification.rb
@@ -5,8 +5,8 @@
 
 class Gem::Resolver::InstalledSpecification < Gem::Resolver::SpecSpecification
   def ==(other) # :nodoc:
-    self.class === other and
-      @set  == other.set and
+    self.class === other &&
+      @set  == other.set &&
       @spec == other.spec
   end
 

--- a/lib/rubygems/resolver/installer_set.rb
+++ b/lib/rubygems/resolver/installer_set.rb
@@ -61,7 +61,7 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
     found = find_all request
 
     found.delete_if do |s|
-      s.version.prerelease? and not s.local?
+      s.version.prerelease? and !s.local?
     end unless dependency.prerelease?
 
     found = found.select do |s|
@@ -169,7 +169,7 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
     end
 
     res.delete_if do |spec|
-      spec.version.prerelease? and not dep.prerelease?
+      spec.version.prerelease? and !dep.prerelease?
     end
 
     res.concat @remote_set.find_all req if consider_remote?

--- a/lib/rubygems/resolver/installer_set.rb
+++ b/lib/rubygems/resolver/installer_set.rb
@@ -61,12 +61,12 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
     found = find_all request
 
     found.delete_if do |s|
-      s.version.prerelease? and !s.local?
+      s.version.prerelease? && !s.local?
     end unless dependency.prerelease?
 
     found = found.select do |s|
-      Gem::Source::SpecificFile === s.source or
-        Gem::Platform::RUBY == s.platform or
+      Gem::Source::SpecificFile === s.source ||
+        Gem::Platform::RUBY == s.platform ||
         Gem::Platform.local === s.platform
     end
 
@@ -111,14 +111,14 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
   # Should local gems should be considered?
 
   def consider_local? # :nodoc:
-    @domain == :both or @domain == :local
+    @domain == :both || @domain == :local
   end
 
   ##
   # Should remote gems should be considered?
 
   def consider_remote? # :nodoc:
-    @domain == :both or @domain == :remote
+    @domain == :both || @domain == :remote
   end
 
   ##
@@ -137,7 +137,7 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
 
     dep = req.dependency
 
-    return res if @ignore_dependencies and
+    return res if @ignore_dependencies &&
               @always_install.none? {|spec| dep.match? spec }
 
     name = dep.name
@@ -169,7 +169,7 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
     end
 
     res.delete_if do |spec|
-      spec.version.prerelease? and !dep.prerelease?
+      spec.version.prerelease? && !dep.prerelease?
     end
 
     res.concat @remote_set.find_all req if consider_remote?

--- a/lib/rubygems/resolver/lock_set.rb
+++ b/lib/rubygems/resolver/lock_set.rb
@@ -54,7 +54,7 @@ class Gem::Resolver::LockSet < Gem::Resolver::Set
     dep = Gem::Dependency.new name, version
 
     found = @specs.find do |spec|
-      dep.matches_spec? spec and spec.platform == platform
+      dep.matches_spec?(spec) && spec.platform == platform
     end
 
     tuple = Gem::NameTuple.new found.name, found.version, found.platform

--- a/lib/rubygems/resolver/lock_specification.rb
+++ b/lib/rubygems/resolver/lock_specification.rb
@@ -71,7 +71,7 @@ class Gem::Resolver::LockSpecification < Gem::Resolver::Specification
 
   def spec
     @spec ||= Gem::Specification.find do |spec|
-      spec.name == @name and spec.version == @version
+      spec.name == @name && spec.version == @version
     end
 
     @spec ||= Gem::Specification.new do |s|

--- a/lib/rubygems/resolver/vendor_specification.rb
+++ b/lib/rubygems/resolver/vendor_specification.rb
@@ -6,9 +6,9 @@
 
 class Gem::Resolver::VendorSpecification < Gem::Resolver::SpecSpecification
   def ==(other) # :nodoc:
-    self.class === other and
-      @set  == other.set and
-      @spec == other.spec and
+    self.class === other &&
+      @set  == other.set &&
+      @spec == other.spec &&
       @source == other.source
   end
 

--- a/lib/rubygems/security.rb
+++ b/lib/rubygems/security.rb
@@ -618,7 +618,7 @@ module Gem::Security
     path = File.expand_path path
 
     File.open path, "wb", permissions do |io|
-      if passphrase and cipher
+      if passphrase && cipher
         io.write pemmable.to_pem cipher, passphrase
       else
         io.write pemmable.to_pem

--- a/lib/rubygems/security/policy.rb
+++ b/lib/rubygems/security/policy.rb
@@ -88,16 +88,16 @@ class Gem::Security::Policy
 
     message = "certificate #{signer.subject}"
 
-    if not_before = signer.not_before and not_before > time
+    if (not_before = signer.not_before) && not_before > time
       raise Gem::Security::Exception,
             "#{message} not valid before #{not_before}"
     end
 
-    if not_after = signer.not_after and not_after < time
+    if (not_after = signer.not_after) && not_after < time
       raise Gem::Security::Exception, "#{message} not valid after #{not_after}"
     end
 
-    if issuer and !signer.verify issuer.public_key
+    if issuer && !signer.verify(issuer.public_key)
       raise Gem::Security::Exception,
             "#{message} was not issued by #{issuer.subject}"
     end
@@ -109,7 +109,7 @@ class Gem::Security::Policy
   # Ensures the public key of +key+ matches the public key in +signer+
 
   def check_key(signer, key)
-    unless signer and key
+    unless signer && key
       return true unless @only_signed
 
       raise Gem::Security::Exception, "missing key or signature"
@@ -231,7 +231,7 @@ class Gem::Security::Policy
 
     if @verify_data
       raise Gem::Security::Exception, "no digests provided (probable bug)" if
-        signer_digests.nil? or signer_digests.empty?
+        signer_digests.nil? || signer_digests.empty?
     else
       signer_digests = {}
     end
@@ -248,7 +248,7 @@ class Gem::Security::Policy
 
     if @only_trusted
       check_trust chain, digester, trust_dir
-    elsif signatures.empty? and digests.empty?
+    elsif signatures.empty? && digests.empty?
       # trust is irrelevant if there's no signatures to verify
     else
       alert_warning "#{subject signer} is not trusted for #{full_name}"

--- a/lib/rubygems/security/policy.rb
+++ b/lib/rubygems/security/policy.rb
@@ -97,7 +97,7 @@ class Gem::Security::Policy
       raise Gem::Security::Exception, "#{message} not valid after #{not_after}"
     end
 
-    if issuer and not signer.verify issuer.public_key
+    if issuer and !signer.verify issuer.public_key
       raise Gem::Security::Exception,
             "#{message} was not issued by #{issuer.subject}"
     end

--- a/lib/rubygems/security/signer.rb
+++ b/lib/rubygems/security/signer.rb
@@ -141,7 +141,7 @@ class Gem::Security::Signer
 
     raise Gem::Security::Exception, "no certs provided" if @cert_chain.empty?
 
-    if @cert_chain.length == 1 and @cert_chain.last.not_after < Time.now
+    if @cert_chain.length == 1 && @cert_chain.last.not_after < Time.now
       alert("Your certificate has expired, trying to re-sign it...")
 
       re_sign_key(

--- a/lib/rubygems/source.rb
+++ b/lib/rubygems/source.rb
@@ -62,7 +62,7 @@ class Gem::Source
   end
 
   def ==(other) # :nodoc:
-    self.class === other and @uri == other.uri
+    self.class === other && @uri == other.uri
   end
 
   alias_method :eql?, :== # :nodoc:

--- a/lib/rubygems/source/git.rb
+++ b/lib/rubygems/source/git.rb
@@ -76,10 +76,10 @@ class Gem::Source::Git < Gem::Source
   end
 
   def ==(other) # :nodoc:
-    super and
-      @name            == other.name and
-      @repository      == other.repository and
-      @reference       == other.reference and
+    super &&
+      @name            == other.name &&
+      @repository      == other.repository &&
+      @reference       == other.reference &&
       @need_submodules == other.need_submodules
   end
 

--- a/lib/rubygems/spec_fetcher.rb
+++ b/lib/rubygems/spec_fetcher.rb
@@ -98,7 +98,7 @@ class Gem::SpecFetcher
 
       found[source] = specs.select do |tup|
         if dependency.match?(tup)
-          if matching_platform and !Gem::Platform.match_gem?(tup.platform, tup.name)
+          if matching_platform && !Gem::Platform.match_gem?(tup.platform, tup.name)
             pm = (
               rejected_specs[dependency] ||= \
                 Gem::PlatformMismatch.new(tup.name, tup.version))

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1668,7 +1668,7 @@ class Gem::Specification < Gem::BasicSpecification
     conflicts = {}
     self.runtime_dependencies.each do |dep|
       spec = Gem.loaded_specs[dep.name]
-      if spec and not spec.satisfies_requirement? dep
+      if spec and !spec.satisfies_requirement? dep
         (conflicts[spec] ||= []) << dep
       end
     end
@@ -1695,7 +1695,7 @@ class Gem::Specification < Gem::BasicSpecification
     self.dependencies.any? do |dep|
       if dep.runtime?
         spec = Gem.loaded_specs[dep.name]
-        spec and not spec.satisfies_requirement? dep
+        spec and !spec.satisfies_requirement? dep
       else
         false
       end
@@ -1987,7 +1987,7 @@ class Gem::Specification < Gem::BasicSpecification
   # True if this gem has files in test_files
 
   def has_unit_tests? # :nodoc:
-    not test_files.empty?
+    !test_files.empty?
   end
 
   # :stopdoc:

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -473,7 +473,7 @@ class Gem::Specification < Gem::BasicSpecification
   #   spec.platform = Gem::Platform.local
 
   def platform=(platform)
-    if @original_platform.nil? or
+    if @original_platform.nil? ||
        @original_platform == Gem::Platform::RUBY
       @original_platform = platform
     end
@@ -1046,7 +1046,7 @@ class Gem::Specification < Gem::BasicSpecification
 
   def self.find_active_stub_by_path(path)
     stub = @@active_stub_with_requirable_file[path] ||= (stubs.find do |s|
-      s.activated? and s.contains_requirable_file? path
+      s.activated? && s.contains_requirable_file?(path)
     end || NOT_FOUND)
     stub.this
   end
@@ -1234,7 +1234,7 @@ class Gem::Specification < Gem::BasicSpecification
       latest_remote = remotes.sort.last
 
       yield [local_spec, latest_remote] if
-        latest_remote and local_spec.version < latest_remote
+        latest_remote && local_spec.version < latest_remote
     end
 
     nil
@@ -1556,7 +1556,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Singular reader for #authors.  Returns the first author in the list
 
   def author
-    val = authors and val.first
+    (val = authors) && val.first
   end
 
   ##
@@ -1668,7 +1668,7 @@ class Gem::Specification < Gem::BasicSpecification
     conflicts = {}
     self.runtime_dependencies.each do |dep|
       spec = Gem.loaded_specs[dep.name]
-      if spec and !spec.satisfies_requirement? dep
+      if spec && !spec.satisfies_requirement?(dep)
         (conflicts[spec] ||= []) << dep
       end
     end
@@ -1695,7 +1695,7 @@ class Gem::Specification < Gem::BasicSpecification
     self.dependencies.any? do |dep|
       if dep.runtime?
         spec = Gem.loaded_specs[dep.name]
-        spec and !spec.satisfies_requirement? dep
+        spec && !spec.satisfies_requirement?(dep)
       else
         false
       end
@@ -1716,7 +1716,7 @@ class Gem::Specification < Gem::BasicSpecification
 
   DateLike = Object.new # :nodoc:
   def DateLike.===(obj) # :nodoc:
-    defined?(::Date) and Date === obj
+    defined?(::Date) && Date === obj
   end
 
   DateTimeFormat = # :nodoc:
@@ -1756,9 +1756,9 @@ class Gem::Specification < Gem::BasicSpecification
   # executable now.  See Gem.bin_path.
 
   def default_executable # :nodoc:
-    if defined?(@default_executable) and @default_executable
+    if defined?(@default_executable) && @default_executable
       result = @default_executable
-    elsif @executables and @executables.size == 1
+    elsif @executables && @executables.size == 1
       result = Array(@executables).first
     else
       result = nil
@@ -1875,7 +1875,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Singular accessor for #executables
 
   def executable
-    val = executables and val.first
+    (val = executables) && val.first
   end
 
   ##
@@ -2040,7 +2040,7 @@ class Gem::Specification < Gem::BasicSpecification
     self.name = name if name
     self.version = version if version
 
-    if platform = Gem.platforms.last and platform != Gem::Platform::RUBY and platform != Gem::Platform.local
+    if (platform = Gem.platforms.last) && platform != Gem::Platform::RUBY && platform != Gem::Platform.local
       self.platform = platform
     end
 
@@ -2155,7 +2155,7 @@ class Gem::Specification < Gem::BasicSpecification
       return
     end
 
-    if @specification_version > CURRENT_SPECIFICATION_VERSION and
+    if @specification_version > CURRENT_SPECIFICATION_VERSION &&
       sym.to_s.end_with?("=")
       warn "ignoring #{sym} loading #{full_name}" if $DEBUG
     else
@@ -2182,7 +2182,7 @@ class Gem::Specification < Gem::BasicSpecification
   #   file list.
 
   def normalize
-    if defined?(@extra_rdoc_files) and @extra_rdoc_files
+    if defined?(@extra_rdoc_files) && @extra_rdoc_files
       @extra_rdoc_files.uniq!
       @files ||= []
       @files.concat(@extra_rdoc_files)
@@ -2207,7 +2207,7 @@ class Gem::Specification < Gem::BasicSpecification
   # platform.  For use with legacy gems.
 
   def original_name # :nodoc:
-    if platform == Gem::Platform::RUBY or platform.nil?
+    if platform == Gem::Platform::RUBY || platform.nil?
       "#{@name}-#{@version}"
     else
       "#{@name}-#{@version}-#{@original_platform}"
@@ -2240,8 +2240,8 @@ class Gem::Specification < Gem::BasicSpecification
       attributes.each do |attr_name|
         current_value = self.send attr_name
         current_value = current_value.sort if %i[files test_files].include? attr_name
-        if current_value != default_value(attr_name) or
-           self.class.required_attribute? attr_name
+        if current_value != default_value(attr_name) ||
+           self.class.required_attribute?(attr_name)
 
           q.text "s.#{attr_name} = "
 
@@ -2299,7 +2299,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Singular accessor for #require_paths
 
   def require_path
-    val = require_paths and val.first
+    (val = require_paths) && val.first
   end
 
   ##
@@ -2428,7 +2428,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Singular accessor for #test_files
 
   def test_file # :nodoc:
-    val = test_files and val.first
+    (val = test_files) && val.first
   end
 
   ##
@@ -2450,7 +2450,7 @@ class Gem::Specification < Gem::BasicSpecification
       @test_files = [@test_suite_file].flatten
       @test_suite_file = nil
     end
-    if defined?(@test_files) and @test_files
+    if defined?(@test_files) && @test_files
       @test_files
     else
       @test_files = []
@@ -2474,13 +2474,13 @@ class Gem::Specification < Gem::BasicSpecification
 
     result << "  s.name = #{ruby_code name}"
     result << "  s.version = #{ruby_code version}"
-    unless platform.nil? or platform == Gem::Platform::RUBY
+    unless platform.nil? || platform == Gem::Platform::RUBY
       result << "  s.platform = #{ruby_code original_platform}"
     end
     result << ""
     result << "  s.required_rubygems_version = #{ruby_code required_rubygems_version} if s.respond_to? :required_rubygems_version="
 
-    if metadata and !metadata.empty?
+    if metadata && !metadata.empty?
       result << "  s.metadata = #{ruby_code metadata} if s.respond_to? :metadata="
     end
     result << "  s.require_paths = #{ruby_code raw_require_paths}"

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -188,7 +188,7 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
           prerelease_dep && !@specification.version.prerelease?
 
       open_ended = dep.requirement.requirements.all? do |op, version|
-        !version.prerelease? and (op == ">" or op == ">=")
+        !version.prerelease? && (op == ">" || op == ">=")
       end
 
       if open_ended
@@ -203,7 +203,7 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
         else
           bugfix = if op == ">"
             ", '> #{dep_version}'"
-          elsif op == ">=" and base != segments
+          elsif op == ">=" && base != segments
             ", '>= #{dep_version}'"
           end
 
@@ -338,7 +338,7 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
       String
     end
 
-    unless Array === val and val.all? {|x| x.kind_of?(klass) }
+    unless Array === val && val.all? {|x| x.kind_of?(klass) }
       error "#{field} must be an Array of #{klass}"
     end
   end
@@ -404,7 +404,7 @@ http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard li
     homepage = @specification.homepage
 
     # Make sure a homepage is valid HTTP/HTTPS URI
-    if homepage and !homepage.empty?
+    if homepage && !homepage.empty?
       require "uri"
       begin
         homepage_uri = URI.parse(homepage)

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -188,7 +188,7 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
           prerelease_dep && !@specification.version.prerelease?
 
       open_ended = dep.requirement.requirements.all? do |op, version|
-        not version.prerelease? and (op == ">" or op == ">=")
+        !version.prerelease? and (op == ">" or op == ">=")
       end
 
       if open_ended
@@ -404,7 +404,7 @@ http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard li
     homepage = @specification.homepage
 
     # Make sure a homepage is valid HTTP/HTTPS URI
-    if homepage and not homepage.empty?
+    if homepage and !homepage.empty?
       require "uri"
       begin
         homepage_uri = URI.parse(homepage)

--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -105,8 +105,8 @@ class Gem::Uninstaller
     @default_specs_matching_uninstall_params = default_specs
 
     list, other_repo_specs = list.partition do |spec|
-      @gem_home == spec.base_dir or
-        (@user_install and spec.base_dir == Gem.user_dir)
+      @gem_home == spec.base_dir ||
+        (@user_install && spec.base_dir == Gem.user_dir)
     end
 
     list.sort!
@@ -239,8 +239,8 @@ class Gem::Uninstaller
   # spec:: the spec of the gem to be uninstalled
 
   def remove(spec)
-    unless path_ok?(@gem_home, spec) or
-           (@user_install and path_ok?(Gem.user_dir, spec))
+    unless path_ok?(@gem_home, spec) ||
+           (@user_install && path_ok?(Gem.user_dir, spec))
       e = Gem::GemNotInHomeException.new \
             "Gem '#{spec.full_name}' is not installed in directory #{@gem_home}"
       e.spec = spec

--- a/lib/rubygems/user_interaction.rb
+++ b/lib/rubygems/user_interaction.rb
@@ -284,7 +284,7 @@ class Gem::StreamUI
   # Ask a question.  Returns an answer if connected to a tty, nil otherwise.
 
   def ask(question)
-    return nil if not tty?
+    return nil if !tty?
 
     @outs.print(question + "  ")
     @outs.flush
@@ -298,7 +298,7 @@ class Gem::StreamUI
   # Ask for a password. Does not echo response to terminal.
 
   def ask_for_password(question)
-    return nil if not tty?
+    return nil if !tty?
 
     @outs.print(question, "  ")
     @outs.flush

--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -252,7 +252,7 @@ class Gem::Version
   # same precision. Version "1.0" is not the same as version "1".
 
   def eql?(other)
-    self.class === other and @version == other._version
+    self.class === other && @version == other._version
   end
 
   def hash # :nodoc:

--- a/setup.rb
+++ b/setup.rb
@@ -7,7 +7,7 @@
 #++
 
 # Make sure rubygems isn't already loaded.
-if ENV["RUBYOPT"] or defined? Gem
+if ENV["RUBYOPT"] || defined? Gem
   ENV.delete "RUBYOPT"
 
   require "rbconfig"

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -1592,7 +1592,7 @@ class Object
 
     metaclass = class << self; self; end
 
-    if respond_to? name and not methods.map(&:to_s).include? name.to_s
+    if respond_to? name and !methods.map(&:to_s).include? name.to_s
       metaclass.send :define_method, name do |*args|
         super(*args)
       end

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -599,7 +599,7 @@ class Gem::TestCase < Test::Unit::TestCase
   end
 
   def in_path?(executable) # :nodoc:
-    return true if %r{\A([A-Z]:|/)} =~ executable and File.exist? executable
+    return true if %r{\A([A-Z]:|/)} =~ executable && File.exist?(executable)
 
     ENV["PATH"].split(File::PATH_SEPARATOR).any? do |directory|
       File.exist? File.join directory, executable
@@ -849,7 +849,7 @@ class Gem::TestCase < Test::Unit::TestCase
   # or a +block+ can be given for full customization of the specification.
 
   def util_spec(name, version = 2, deps = nil, *files) # :yields: specification
-    raise "deps or block, not both" if deps and block_given?
+    raise "deps or block, not both" if deps && block_given?
 
     spec = Gem::Specification.new do |s|
       s.platform    = Gem::Platform::RUBY
@@ -1279,10 +1279,10 @@ Also, a list:
     rubyexe = "#{ruby}.exe"
 
     3.times do
-      if File.exist? ruby and File.executable? ruby and !File.directory? ruby
+      if File.exist?(ruby) && File.executable?(ruby) && !File.directory?(ruby)
         return File.expand_path(ruby)
       end
-      if File.exist? rubyexe and File.executable? rubyexe
+      if File.exist?(rubyexe) && File.executable?(rubyexe)
         return File.expand_path(rubyexe)
       end
       ruby = File.join("..", ruby)
@@ -1592,7 +1592,7 @@ class Object
 
     metaclass = class << self; self; end
 
-    if respond_to? name and !methods.map(&:to_s).include? name.to_s
+    if respond_to?(name) && !methods.map(&:to_s).include?(name.to_s)
       metaclass.send :define_method, name do |*args|
         super(*args)
       end

--- a/test/rubygems/test_gem_dependency_installer.rb
+++ b/test/rubygems/test_gem_dependency_installer.rb
@@ -1051,8 +1051,8 @@ class TestGemDependencyInstaller < Gem::TestCase
 
     releases = set.all_specs
 
-    assert releases.any? {|s| s.name == "a" and s.version.to_s == "1" }
-    refute releases.any? {|s| s.name == "a" and s.version.to_s == "1.a" }
+    assert releases.any? {|s| s.name == "a" && s.version.to_s == "1" }
+    refute releases.any? {|s| s.name == "a" && s.version.to_s == "1.a" }
 
     dependency.prerelease = true
 

--- a/test/rubygems/test_gem_ext_cargo_builder/custom_name/build.rb
+++ b/test/rubygems/test_gem_ext_cargo_builder/custom_name/build.rb
@@ -1,4 +1,4 @@
-if ENV["RUBYOPT"] or defined? Gem
+if ENV["RUBYOPT"] || defined? Gem
   ENV.delete "RUBYOPT"
 
   require "rbconfig"

--- a/test/rubygems/test_gem_ext_cargo_builder/rust_ruby_example/build.rb
+++ b/test/rubygems/test_gem_ext_cargo_builder/rust_ruby_example/build.rb
@@ -1,4 +1,4 @@
-if ENV["RUBYOPT"] or defined? Gem
+if ENV["RUBYOPT"] || defined? Gem
   ENV.delete "RUBYOPT"
 
   require "rbconfig"

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -473,7 +473,7 @@ gem 'other', version
       end
     end
   ensure
-    FileUtils.chmod 0755, util_inst_bindir unless ($DEBUG or win_platform?)
+    FileUtils.chmod 0755, util_inst_bindir unless ($DEBUG || win_platform?)
   end
 
   def test_generate_bin_script_no_shebang
@@ -577,7 +577,7 @@ gem 'other', version
       end
     end
   ensure
-    FileUtils.chmod 0755, util_inst_bindir unless ($DEBUG or win_platform?)
+    FileUtils.chmod 0755, util_inst_bindir unless ($DEBUG || win_platform?)
   end
 
   def test_generate_bin_symlink_update_newer

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -796,7 +796,7 @@ dependencies: []
     assert_equal File.join(@tempdir, "a-2.gemspec"), spec.loaded_from
   end
 
-  if RUBY_ENGINE == "ruby" and RUBY_VERSION < "2.7"
+  if RUBY_ENGINE == "ruby" && RUBY_VERSION < "2.7"
     def test_self_load_tainted
       full_path = @a2.spec_file
       write_file full_path do |io|
@@ -1450,7 +1450,7 @@ dependencies: []
     @ext.build_extensions
     assert_path_not_exist @ext.extension_dir
   ensure
-    unless ($DEBUG or win_platform? or Process.uid.zero? or Gem.java_platform?)
+    unless ($DEBUG || win_platform? || Process.uid.zero? || Gem.java_platform?)
       FileUtils.chmod 0755, File.join(@ext.base_dir, "extensions")
       FileUtils.chmod 0755, @ext.base_dir
     end

--- a/test/rubygems/utilities.rb
+++ b/test/rubygems/utilities.rb
@@ -39,9 +39,9 @@ class Gem::FakeFetcher
   end
 
   def find_data(path)
-    return Gem.read_binary path.path if URI === path and "file" == path.scheme
+    return Gem.read_binary path.path if URI === path && "file" == path.scheme
 
-    if URI === path and "URI::#{path.scheme.upcase}" != path.class.name
+    if URI === path && "URI::#{path.scheme.upcase}" != path.class.name
       raise ArgumentError,
         "mismatch for scheme #{path.scheme} and class #{path.class}"
     end
@@ -67,7 +67,7 @@ class Gem::FakeFetcher
     if data.respond_to?(:call)
       data.call
     else
-      if path.to_s.end_with?(".gz") and !data.nil? and !data.empty?
+      if path.to_s.end_with?(".gz") && !data.nil? && !data.empty?
         data = Gem::Util.gunzip data
       end
       data
@@ -76,7 +76,7 @@ class Gem::FakeFetcher
 
   def cache_update_path(uri, path = nil, update = true)
     if data = fetch_path(uri)
-      File.open(path, "wb") {|io| io.write data } if path and update
+      File.open(path, "wb") {|io| io.write data } if path && update
       data
     else
       Gem.read_binary(path) if path

--- a/test/rubygems/utilities.rb
+++ b/test/rubygems/utilities.rb
@@ -67,7 +67,7 @@ class Gem::FakeFetcher
     if data.respond_to?(:call)
       data.call
     else
-      if path.to_s.end_with?(".gz") and not data.nil? and not data.empty?
+      if path.to_s.end_with?(".gz") and !data.nil? and !data.empty?
         data = Gem::Util.gunzip data
       end
       data


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In #4488 I need to backport the whole `Gem::Platform#===` method to Bundler, so that platform fixes work across more RubyGems versions. However, code style in RubyGems and Bundler differ a lot because RubyGems uses "English" logical operators. This makes it a bit harder to keep the duplicated code in sync.

In addition to that, I always found it very weird how RubyGems uses these operators rather than the symbolic ones for plain logical operations.

## What is your fix for the problem, implemented in this PR?

Enable `Style/AndOr` in RubyGems.

In theory the auto-correction of this cop is unsafe due to the different precedence, but this cop seems to have been battle tested a lot and the corrections are really smart. I will give it a manual review if this is accepted though (and if CI passes, of course).

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
