### PR TITLE
Enable `Layout/MultilineOperationIndentation` with default style

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -158,6 +158,9 @@ Style/MethodDefParentheses:
 Style/MultilineIfThen:
   Enabled: true
 
+Layout/MultilineOperationIndentation:
+  Enabled: true
+
 Style/MutableConstant:
   Enabled: true
 

--- a/.rubocop_bundler.yml
+++ b/.rubocop_bundler.yml
@@ -350,7 +350,6 @@ Layout/MultilineMethodDefinitionBraceLayout:
 
 Layout/MultilineOperationIndentation:
   Enabled: true
-  EnforcedStyle: indented
 
 Layout/SpaceBeforeComma:
   Enabled: true

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -238,7 +238,7 @@ module Bundler
       "Install to the system location ($BUNDLE_PATH or $GEM_HOME) even if the bundle was previously installed somewhere else for this application"
     method_option "trust-policy", :alias => "P", :type => :string, :banner =>
       "Gem trust policy (like gem install -P). Must be one of " +
-        Bundler.rubygems.security_policy_keys.join("|")
+      Bundler.rubygems.security_policy_keys.join("|")
     method_option "without", :type => :array, :banner =>
       "Exclude gems that are part of the specified named group."
     method_option "with", :type => :array, :banner =>

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -885,10 +885,10 @@ module Bundler
 
     def remove_ruby_from_platforms_if_necessary!(dependencies)
       return if Bundler.frozen_bundle? ||
-        Bundler.local_platform == Gem::Platform::RUBY ||
-        !platforms.include?(Gem::Platform::RUBY) ||
-        (@new_platform && platforms.last == Gem::Platform::RUBY) ||
-        !@originally_locked_specs.incomplete_ruby_specs?(dependencies)
+                Bundler.local_platform == Gem::Platform::RUBY ||
+                !platforms.include?(Gem::Platform::RUBY) ||
+                (@new_platform && platforms.last == Gem::Platform::RUBY) ||
+                !@originally_locked_specs.incomplete_ruby_specs?(dependencies)
 
       remove_platform(Gem::Platform::RUBY)
       add_current_platform

--- a/bundler/lib/bundler/fetcher.rb
+++ b/bundler/lib/bundler/fetcher.rb
@@ -240,8 +240,8 @@ module Bundler
     def connection
       @connection ||= begin
         needs_ssl = remote_uri.scheme == "https" ||
-          Bundler.settings[:ssl_verify_mode] ||
-          Bundler.settings[:ssl_client_cert]
+                    Bundler.settings[:ssl_verify_mode] ||
+                    Bundler.settings[:ssl_client_cert]
         raise SSLError if needs_ssl && !defined?(OpenSSL::SSL)
 
         con = PersistentHTTP.new :name => "bundler", :proxy => :ENV
@@ -256,8 +256,8 @@ module Bundler
         end
 
         ssl_client_cert = Bundler.settings[:ssl_client_cert] ||
-          (Gem.configuration.ssl_client_cert if
-            Gem.configuration.respond_to?(:ssl_client_cert))
+                          (Gem.configuration.ssl_client_cert if
+                            Gem.configuration.respond_to?(:ssl_client_cert))
         if ssl_client_cert
           pem = File.read(ssl_client_cert)
           con.cert = OpenSSL::X509::Certificate.new(pem)
@@ -288,8 +288,8 @@ module Bundler
     def bundler_cert_store
       store = OpenSSL::X509::Store.new
       ssl_ca_cert = Bundler.settings[:ssl_ca_cert] ||
-        (Gem.configuration.ssl_ca_cert if
-          Gem.configuration.respond_to?(:ssl_ca_cert))
+                    (Gem.configuration.ssl_ca_cert if
+                      Gem.configuration.respond_to?(:ssl_ca_cert))
       if ssl_ca_cert
         if File.directory? ssl_ca_cert
           store.add_path ssl_ca_cert

--- a/bundler/lib/bundler/ruby_dsl.rb
+++ b/bundler/lib/bundler/ruby_dsl.rb
@@ -9,7 +9,7 @@ module Bundler
       raise GemfileError, "Please define :engine" if options[:engine_version] && options[:engine].nil?
 
       if options[:engine] == "ruby" && options[:engine_version] &&
-          ruby_version != Array(options[:engine_version])
+         ruby_version != Array(options[:engine_version])
         raise GemfileEvalError, "ruby_version must match the :engine_version for MRI"
       end
       @ruby_version = RubyVersion.new(ruby_version, options[:patchlevel], options[:engine], options[:engine_version])

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -121,7 +121,7 @@ module Gem
 
   # When https://bugs.ruby-lang.org/issues/17259 is available, there is no need to override Kernel#warn
   KERNEL_WARN_IGNORES_INTERNAL_ENTRIES = RUBY_ENGINE == "truffleruby" ||
-      (RUBY_ENGINE == "ruby" && RUBY_VERSION >= "3.0")
+                                         (RUBY_ENGINE == "ruby" && RUBY_VERSION >= "3.0")
 
   ##
   # An Array of Regexps that match windows Ruby platforms.

--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -77,7 +77,7 @@ class Gem::BasicSpecification
 
       if Gem::Platform::RUBY == platform || Gem::Platform.local === platform
         warn "Ignoring #{full_name} because its extensions are not built. " +
-          "Try: gem pristine #{name} --version #{version}"
+             "Try: gem pristine #{name} --version #{version}"
       end
 
       return false

--- a/lib/rubygems/commands/cert_command.rb
+++ b/lib/rubygems/commands/cert_command.rb
@@ -152,7 +152,7 @@ class Gem::Commands::CertCommand < Gem::Command
 
   def build_cert(email, key) # :nodoc:
     expiration_length_days = options[:expiration_length_days] ||
-      Gem.configuration.cert_expiration_length_days
+                             Gem.configuration.cert_expiration_length_days
 
     cert = Gem::Security.create_cert_email(
       email,

--- a/lib/rubygems/commands/fetch_command.rb
+++ b/lib/rubygems/commands/fetch_command.rb
@@ -53,7 +53,7 @@ then repackaging it.
 
   def check_version # :nodoc:
     if options[:version] != Gem::Requirement.default &&
-         get_all_gem_names.size > 1
+       get_all_gem_names.size > 1
       alert_error "Can't use --version with multiple gems. You can specify multiple gems with" \
                   " version requirements using `gem fetch 'my_gem:1.0.0' 'my_other_gem:~>2.0.0'`"
       terminate_interaction 1

--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -46,8 +46,8 @@ class Gem::Commands::InstallCommand < Gem::Command
 
   def defaults_str # :nodoc:
     "--both --version '#{Gem::Requirement.default}' --no-force\n" +
-    "--install-dir #{Gem.dir} --lock\n" +
-    install_update_defaults_str
+      "--install-dir #{Gem.dir} --lock\n" +
+      install_update_defaults_str
   end
 
   def description # :nodoc:
@@ -142,7 +142,7 @@ You can use `i` command instead of `install`.
 
   def check_version # :nodoc:
     if options[:version] != Gem::Requirement.default &&
-         get_all_gem_names.size > 1
+       get_all_gem_names.size > 1
       alert_error "Can't use --version with multiple gems. You can specify multiple gems with" \
                   " version requirements using `gem install 'my_gem:1.0.0' 'my_other_gem:~>2.0.0'`"
       terminate_interaction 1
@@ -192,7 +192,7 @@ You can use `i` command instead of `install`.
 
   def install_gem(name, version) # :nodoc:
     return if options[:conservative] &&
-      !Gem::Dependency.new(name, version).matching_specs.empty?
+              !Gem::Dependency.new(name, version).matching_specs.empty?
 
     req = Gem::Requirement.create(version)
 

--- a/lib/rubygems/commands/pristine_command.rb
+++ b/lib/rubygems/commands/pristine_command.rb
@@ -103,7 +103,7 @@ extensions will be restored.
     # `--extensions` must be explicitly given to pristine only gems
     # with extensions.
     elsif options[:extensions_set] &&
-                  options[:extensions] && options[:args].empty?
+          options[:extensions] && options[:args].empty?
       Gem::Specification.select do |spec|
         spec.extensions && !spec.extensions.empty?
       end

--- a/lib/rubygems/commands/uninstall_command.rb
+++ b/lib/rubygems/commands/uninstall_command.rb
@@ -96,7 +96,7 @@ class Gem::Commands::UninstallCommand < Gem::Command
 
   def defaults_str # :nodoc:
     "--version '#{Gem::Requirement.default}' --no-force " +
-    "--user-install"
+      "--user-install"
   end
 
   def description # :nodoc:
@@ -115,7 +115,7 @@ that is a dependency of an existing gem.  You can use the
 
   def check_version # :nodoc:
     if options[:version] != Gem::Requirement.default &&
-         get_all_gem_names.size > 1
+       get_all_gem_names.size > 1
       alert_error "Can't use --version with multiple gems. You can specify multiple gems with" \
                   " version requirements using `gem uninstall 'my_gem:1.0.0' 'my_other_gem:~>2.0.0'`"
       terminate_interaction 1

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -56,7 +56,7 @@ class Gem::Commands::UpdateCommand < Gem::Command
 
   def defaults_str # :nodoc:
     "--no-force --install-dir #{Gem.dir}\n" +
-    install_update_defaults_str
+      install_update_defaults_str
   end
 
   def description # :nodoc:
@@ -293,7 +293,7 @@ command to remove old versions.
     args << "--no-format-executable" if options[:no_format_executable]
     args << "--previous-version" << Gem::VERSION if
       options[:system] == true ||
-        Gem::Version.new(options[:system]) >= Gem::Version.new(2)
+      Gem::Version.new(options[:system]) >= Gem::Version.new(2)
     args
   end
 

--- a/lib/rubygems/doctor.rb
+++ b/lib/rubygems/doctor.rb
@@ -30,7 +30,7 @@ class Gem::Doctor
 
   missing =
     Gem::REPOSITORY_SUBDIRECTORIES.sort -
-      REPOSITORY_EXTENSION_MAP.map {|(k,_)| k }.sort
+    REPOSITORY_EXTENSION_MAP.map {|(k,_)| k }.sort
 
   raise "Update REPOSITORY_EXTENSION_MAP, missing: #{missing.join ', '}" unless
     missing.empty?

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -68,14 +68,14 @@ class Gem::Package
   class PathError < Error
     def initialize(destination, destination_dir)
       super "installing into parent path %s of %s is not allowed" %
-              [destination, destination_dir]
+        [destination, destination_dir]
     end
   end
 
   class SymlinkError < Error
     def initialize(name, destination, destination_dir)
       super "installing symlink '%s' pointing to parent path %s of %s is not allowed" %
-              [name, destination, destination_dir]
+        [name, destination, destination_dir]
     end
   end
 

--- a/lib/rubygems/package/tar_header.rb
+++ b/lib/rubygems/package/tar_header.rb
@@ -174,22 +174,22 @@ class Gem::Package::TarHeader
 
   def ==(other) # :nodoc:
     self.class === other &&
-    @checksum == other.checksum &&
-    @devmajor == other.devmajor &&
-    @devminor == other.devminor &&
-    @gid      == other.gid      &&
-    @gname    == other.gname    &&
-    @linkname == other.linkname &&
-    @magic    == other.magic    &&
-    @mode     == other.mode     &&
-    @mtime    == other.mtime    &&
-    @name     == other.name     &&
-    @prefix   == other.prefix   &&
-    @size     == other.size     &&
-    @typeflag == other.typeflag &&
-    @uid      == other.uid      &&
-    @uname    == other.uname    &&
-    @version  == other.version
+      @checksum == other.checksum &&
+      @devmajor == other.devmajor &&
+      @devminor == other.devminor &&
+      @gid      == other.gid      &&
+      @gname    == other.gname    &&
+      @linkname == other.linkname &&
+      @magic    == other.magic    &&
+      @mode     == other.mode     &&
+      @mtime    == other.mtime    &&
+      @name     == other.name     &&
+      @prefix   == other.prefix   &&
+      @size     == other.size     &&
+      @typeflag == other.typeflag &&
+      @uid      == other.uid      &&
+      @uname    == other.uname    &&
+      @version  == other.version
   end
 
   def to_s # :nodoc:

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -167,11 +167,11 @@ class Gem::Platform
     ([nil,"universal"].include?(@cpu) || [nil, "universal"].include?(other.cpu) || @cpu == other.cpu ||
     (@cpu == "arm" && other.cpu.start_with?("arm"))) &&
 
-    # os
-    @os == other.os &&
+      # os
+      @os == other.os &&
 
-    # version
-    (@version.nil? || other.version.nil? || @version == other.version)
+      # version
+      (@version.nil? || other.version.nil? || @version == other.version)
   end
 
   ##

--- a/lib/rubygems/resolver/installer_set.rb
+++ b/lib/rubygems/resolver/installer_set.rb
@@ -138,7 +138,7 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
     dep = req.dependency
 
     return res if @ignore_dependencies &&
-              @always_install.none? {|spec| dep.match? spec }
+                  @always_install.none? {|spec| dep.match? spec }
 
     name = dep.name
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2156,7 +2156,7 @@ class Gem::Specification < Gem::BasicSpecification
     end
 
     if @specification_version > CURRENT_SPECIFICATION_VERSION &&
-      sym.to_s.end_with?("=")
+       sym.to_s.end_with?("=")
       warn "ignoring #{sym} loading #{full_name}" if $DEBUG
     else
       super
@@ -2374,7 +2374,7 @@ class Gem::Specification < Gem::BasicSpecification
 
   def satisfies_requirement?(dependency)
     return @name == dependency.name &&
-      dependency.requirement.satisfied_by?(@version)
+           dependency.requirement.satisfied_by?(@version)
   end
 
   ##

--- a/test/rubygems/test_gem_package_tar_reader.rb
+++ b/test/rubygems/test_gem_package_tar_reader.rb
@@ -29,7 +29,7 @@ class TestGemPackageTarReader < Gem::Package::TarTestCase
 
     str =
       tar_file_header("lib/foo", "", 010644, content.size, Time.now) +
-        content + "\0" * (512 - content.size)
+      content + "\0" * (512 - content.size)
     str << "\0" * 1024
 
     io = TempIO.new(str)

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -269,7 +269,7 @@ class TestGemRequire < Gem::TestCase
     assert_includes $LOAD_PATH, rubylibdir
     message = proc {
       "this test relies on the b-2 gem lib/ to be before stdlib to make sense\n" +
-      $LOAD_PATH.pretty_inspect
+        $LOAD_PATH.pretty_inspect
     }
     assert_operator $LOAD_PATH.index(b2.load_paths[0]), :<, $LOAD_PATH.index(rubylibdir), message
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This is similar to #5817. I need to backport a bunch of RubyGems code to Bundler (the whole `Gem::Platform#===` method), and I want the styles to match exactly to make keeping the code in sync easier.

## What is your fix for the problem, implemented in this PR?

My fix is to enable `Layout/MultilineOperationIndentation` with default style (aligned), which is what `Gem::Platform#===` is already using and the style that matches our global style more closely, because although Bundler has a few offenses for it, RubyGems follows it more closely than the alternative "indented" style (it has ~120 offenses for that).

I also like it better and find it more consistent.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
