### PR TITLE
Fix `gem install` with `--platform` flag not matching simulated platform correctly

### DIFF
--- a/lib/rubygems/resolver/installer_set.rb
+++ b/lib/rubygems/resolver/installer_set.rb
@@ -66,8 +66,7 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
 
     found = found.select do |s|
       Gem::Source::SpecificFile === s.source ||
-        Gem::Platform::RUBY == s.platform ||
-        Gem::Platform.local === s.platform
+        Gem::Platform.match(s.platform)
     end
 
     found = found.sort_by do |s|

--- a/test/rubygems/test_gem_resolver_installer_set.rb
+++ b/test/rubygems/test_gem_resolver_installer_set.rb
@@ -51,6 +51,25 @@ class TestGemResolverInstallerSet < Gem::TestCase
     assert_equal %w[a-1], set.always_install.map {|s| s.full_name }
   end
 
+  def test_add_always_install_platform_if_gem_platforms_modified_by_platform_flag
+    freebsd = Gem::Platform.new "x86-freebsd-9"
+
+    spec_fetcher do |fetcher|
+      fetcher.download "a", 1
+      fetcher.download "a", 1 do |s|
+        s.platform = freebsd
+      end
+    end
+
+    # equivalent to --platform=x86-freebsd-9
+    Gem.platforms << freebsd
+    set = Gem::Resolver::InstallerSet.new :both
+
+    set.add_always_install dep("a")
+
+    assert_equal %w[a-1-x86-freebsd-9], set.always_install.map {|s| s.full_name }
+  end
+
   def test_add_always_install_index_spec_platform
     _, a_1_local_gem = util_gem "a", 1 do |s|
       s.platform = Gem::Platform.local


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

```
$ gem install sorbet-static -v 0.5.5460 --platform universal-darwin-19
ERROR:  Could not find a valid gem 'sorbet-static' (= 0.5.5460) in any repository
ERROR:  Possible alternatives: sorbet-static
```

## What is your fix for the problem, implemented in this PR?

Make sure platform matching uses `Gem.platforms` correctly, which is what `--platform` modifies.

After this PR:

```
$ ruby -Ilib bin/gem install sorbet-static -v 0.5.5460 --platform universal-darwin-19 --backtrace
Successfully installed sorbet-static-0.5.5460-universal-darwin-19
1 gem installed
```

Closes https://github.com/rubygems/rubygems/issues/4510, the only real issue in RubyGems or Bundler reported there.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
