### PR TITLE
Always consider installed specs for resolution, even if prereleases

### DIFF
--- a/lib/rubygems/request_set.rb
+++ b/lib/rubygems/request_set.rb
@@ -446,7 +446,7 @@ class Gem::RequestSet
       next if dep.type == :development && !@development
 
       match = @requests.find do |r|
-        dep.match? r.spec.name, r.spec.version, @prerelease
+        dep.match? r.spec.name, r.spec.version, r.spec.is_a?(Gem::Resolver::InstalledSpecification) || @prerelease
       end
 
       unless match

--- a/lib/rubygems/resolver/installer_set.rb
+++ b/lib/rubygems/resolver/installer_set.rb
@@ -168,10 +168,6 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
       end
     end
 
-    res.delete_if do |spec|
-      spec.version.prerelease? && !dep.prerelease?
-    end
-
     res.concat @remote_set.find_all req if consider_remote?
 
     res

--- a/test/rubygems/test_gem_resolver_installer_set.rb
+++ b/test/rubygems/test_gem_resolver_installer_set.rb
@@ -200,6 +200,18 @@ class TestGemResolverInstallerSet < Gem::TestCase
                  set.find_all(req).map {|spec| spec.full_name }.sort
   end
 
+  def test_find_all_prerelease_dependencies_with_add_local
+    activesupport_7_1_0_alpha = util_spec "activesupport", "7.1.0.alpha"
+
+    install_gem activesupport_7_1_0_alpha
+
+    set = Gem::Resolver::InstallerSet.new :both
+
+    req = Gem::Resolver::DependencyRequest.new dep("activesupport", ">= 4.2.0"), nil
+
+    assert_equal %w[activesupport-7.1.0.alpha], set.find_all(req).map {|spec| spec.full_name }
+  end
+
   def test_load_spec
     specs = spec_fetcher do |fetcher|
       fetcher.spec "a", 2


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When cloning https://github.com/rails/rails and running `bundle exec rake install`, one gets an error like this:

```
$ bundle exec rake install
rm -f pkg/activesupport-7.1.0.alpha.gem
cd activesupport && bundle exec rake package && gem build activesupport.gemspec && mv activesupport-7.1.0.alpha.gem /Users/deivid/Code/rails/rails/pkg/
WARNING:  open-ended dependency on connection_pool (>= 2.2.5) is not recommended
  if connection_pool is semantically versioned, use:
    add_runtime_dependency 'connection_pool', '~> 2.2', '>= 2.2.5'
WARNING:  open-ended dependency on minitest (>= 5.1) is not recommended
  if minitest is semantically versioned, use:
    add_runtime_dependency 'minitest', '~> 5.1'
WARNING:  See https://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: activesupport
  Version: 7.1.0.alpha
  File: activesupport-7.1.0.alpha.gem
gem install --pre pkg/activesupport-7.1.0.alpha.gem
Successfully installed concurrent-ruby-1.1.10
Successfully installed activesupport-7.1.0.alpha
2 gems installed
rm -f pkg/activemodel-7.1.0.alpha.gem
cd activemodel && bundle exec rake package && gem build activemodel.gemspec && mv activemodel-7.1.0.alpha.gem /Users/deivid/Code/rails/rails/pkg/
  Successfully built RubyGem
  Name: activemodel
  Version: 7.1.0.alpha
  File: activemodel-7.1.0.alpha.gem
gem install --pre pkg/activemodel-7.1.0.alpha.gem
Successfully installed concurrent-ruby-1.1.10
Successfully installed activemodel-7.1.0.alpha
2 gems installed
rm -f pkg/activerecord-7.1.0.alpha.gem
cd activerecord && bundle exec rake package && gem build activerecord.gemspec && mv activerecord-7.1.0.alpha.gem /Users/deivid/Code/rails/rails/pkg/
  Successfully built RubyGem
  Name: activerecord
  Version: 7.1.0.alpha
  File: activerecord-7.1.0.alpha.gem
gem install --pre pkg/activerecord-7.1.0.alpha.gem
Successfully installed concurrent-ruby-1.1.10
Successfully installed activerecord-7.1.0.alpha
2 gems installed
rm -f pkg/actionview-7.1.0.alpha.gem
cd actionview && bundle exec rake package && gem build actionview.gemspec && mv actionview-7.1.0.alpha.gem /Users/deivid/Code/rails/rails/pkg/
Building assets…
[removed] lib/assets/compiled/rails-ujs.js
[created] lib/assets/compiled/rails-ujs.js
[verify] lib/assets/compiled/rails-ujs.js exists [OK]
[verify] lib/assets/compiled/rails-ujs.js is a UMD module [OK]
[verify] /Users/deivid/Code/rails/rails/actionview can be required as a module [OK]
WARNING:  open-ended dependency on rails-dom-testing (>= 2.0.3) is not recommended
  if rails-dom-testing is semantically versioned, use:
    add_runtime_dependency 'rails-dom-testing', '~> 2.0', '>= 2.0.3'
WARNING:  See https://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: actionview
  Version: 7.1.0.alpha
  File: actionview-7.1.0.alpha.gem
gem install --pre pkg/actionview-7.1.0.alpha.gem
ERROR:  While executing gem ... (Gem::DependencyResolutionError)
    conflicting dependencies activesupport (>= 4.2.0) and activesupport (= 7.1.0.alpha)
  Activated activesupport-7.1.0.alpha
  which does not match conflicting dependency (>= 4.2.0)

  Conflicting dependency chains:
    actionview (= 7.1.0.alpha), 7.1.0.alpha activated, depends on
    activesupport (= 7.1.0.alpha), 7.1.0.alpha activated

  versus:
    actionview (= 7.1.0.alpha), 7.1.0.alpha activated, depends on
    rails-dom-testing (>= 2.0.3), 2.0.3 activated, depends on
    activesupport (>= 4.2.0)

  Gems matching activesupport (>= 4.2.0):
    activesupport-7.1.0.alpha
	/Users/deivid/.asdf/installs/ruby/3.1.2/lib/ruby/site_ruby/3.1.0/rubygems/resolver.rb:193:in `rescue in resolve'
	/Users/deivid/.asdf/installs/ruby/3.1.2/lib/ruby/site_ruby/3.1.0/rubygems/resolver.rb:191:in `resolve'
	/Users/deivid/.asdf/installs/ruby/3.1.2/lib/ruby/site_ruby/3.1.0/rubygems/request_set.rb:411:in `resolve'
	/Users/deivid/.asdf/installs/ruby/3.1.2/lib/ruby/site_ruby/3.1.0/rubygems/dependency_installer.rb:333:in `resolve_dependencies'
	/Users/deivid/.asdf/installs/ruby/3.1.2/lib/ruby/site_ruby/3.1.0/rubygems/commands/install_command.rb:201:in `install_gem'
	/Users/deivid/.asdf/installs/ruby/3.1.2/lib/ruby/site_ruby/3.1.0/rubygems/commands/install_command.rb:226:in `block in install_gems'
	/Users/deivid/.asdf/installs/ruby/3.1.2/lib/ruby/site_ruby/3.1.0/rubygems/commands/install_command.rb:219:in `each'
	/Users/deivid/.asdf/installs/ruby/3.1.2/lib/ruby/site_ruby/3.1.0/rubygems/commands/install_command.rb:219:in `install_gems'
	/Users/deivid/.asdf/installs/ruby/3.1.2/lib/ruby/site_ruby/3.1.0/rubygems/commands/install_command.rb:167:in `execute'
	/Users/deivid/.asdf/installs/ruby/3.1.2/lib/ruby/site_ruby/3.1.0/rubygems/command.rb:323:in `invoke_with_build_args'
	/Users/deivid/.asdf/installs/ruby/3.1.2/lib/ruby/site_ruby/3.1.0/rubygems/command_manager.rb:185:in `process_args'
	/Users/deivid/.asdf/installs/ruby/3.1.2/lib/ruby/site_ruby/3.1.0/rubygems/command_manager.rb:149:in `run'
	/Users/deivid/.asdf/installs/ruby/3.1.2/lib/ruby/site_ruby/3.1.0/rubygems/gem_runner.rb:51:in `run'
	/Users/deivid/.asdf/installs/ruby/3.1.2/bin/gem:10:in `<main>'
rake aborted!
Command failed with status (1): [gem install --pre pkg/actionview-7.1.0.alp...]
/Users/deivid/Code/rails/rails/tasks/release.rb:98:in `block (3 levels) in <top (required)>'
/Users/deivid/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `load'
/Users/deivid/.asdf/installs/ruby/3.1.2/bin/bundle:25:in `<main>'
Tasks: TOP => install => all:install => actionview:install
(See full trace by running task with --trace)
```

## What is your fix for the problem, implemented in this PR?

The issue is that even if the task installs `activesupport-7.1.0.alpha` before trying to install `actionview-7.1.0.alpha`, it does not consider it because it's a prerelease, and some transitive dependency introduces a dependency on `active support >= 4.2.0`, which ignores `activesupport-7.1.0.alpha` because of being a prerelease. In general, prereleases should be considered last, but should be considered if they are the only possibility. And in any case, when talking about specifications already installed, they should only be considered.

So the fix is to not special case prereleases at all when filtering installed specifications.

Fixes #5393.

 ## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
