### PR TITLE
Properly Handle Optional gemspec fields

### DIFF
--- a/bundler/lib/bundler/match_remote_metadata.rb
+++ b/bundler/lib/bundler/match_remote_metadata.rb
@@ -2,8 +2,11 @@
 
 module Bundler
   module FetchMetadata
+    # A fallback is included because the original version of the specification
+    # API didn't include that field, so some marshalled specs in the index have it
+    # set to +nil+.
     def matches_current_ruby?
-      @required_ruby_version ||= _remote_specification.required_ruby_version
+      @required_ruby_version ||= _remote_specification.required_ruby_version || Gem::Requirement.default
 
       super
     end

--- a/bundler/spec/bundler/endpoint_specification_spec.rb
+++ b/bundler/spec/bundler/endpoint_specification_spec.rb
@@ -48,6 +48,33 @@ RSpec.describe Bundler::EndpointSpecification do
     end
   end
 
+  describe "#required_ruby_version" do
+    context "required_ruby_version is already set on endpoint specification" do
+      existing_value = "already set value"
+      let(:required_ruby_version) { existing_value }
+
+      it "should return the current value when already set on endpoint specification" do
+        remote_spec = double(:remote_spec, :required_ruby_version => "remote_value", :required_rubygems_version => nil)
+
+        expect(spec.required_ruby_version). eql?(existing_value)
+      end
+    end
+
+    it "should return the remote spec value when not set on endpoint specification and remote spec has one" do
+      remote_value = "remote_value"
+      remote_spec = double(:remote_spec, :required_ruby_version => remote_value, :required_rubygems_version => nil)
+      allow(spec_fetcher).to receive(:fetch_spec).and_return(remote_spec)
+
+      expect(spec.required_ruby_version). eql?(remote_value)
+    end
+
+    it "should use the default Gem Requirement value when not set on endpoint specification and not set on remote spec" do
+      remote_spec = double(:remote_spec, :required_ruby_version => nil, :required_rubygems_version => nil)
+      allow(spec_fetcher).to receive(:fetch_spec).and_return(remote_spec)
+      expect(spec.required_ruby_version). eql?(Gem::Requirement.default)
+    end
+  end
+
   it "supports equality comparison" do
     remote_spec = double(:remote_spec, :required_ruby_version => nil, :required_rubygems_version => nil)
     allow(spec_fetcher).to receive(:fetch_spec).and_return(remote_spec)

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -1470,6 +1470,59 @@ RSpec.describe "bundle install with gems on multiple sources" do
     end
   end
 
+  context "when default source includes old gems with nil required_ruby_version" do
+    before do
+      build_repo2 do
+        build_gem "ruport", "1.7.0.3" do |s|
+          s.add_dependency "pdf-writer", "1.1.8"
+        end
+      end
+
+      build_repo gem_repo4 do
+        build_gem "pdf-writer", "1.1.8"
+      end
+
+      path = "#{gem_repo4}/#{Gem::MARSHAL_SPEC_DIR}/pdf-writer-1.1.8.gemspec.rz"
+      spec = Marshal.load(Bundler.rubygems.inflate(File.binread(path)))
+      spec.instance_variable_set(:@required_ruby_version, nil)
+      File.open(path, "wb") do |f|
+        f.write Gem.deflate(Marshal.dump(spec))
+      end
+
+      gemfile <<~G
+        source "https://localgemserver.test"
+
+        gem "ruport", "= 1.7.0.3", :source => "https://localgemserver.test/extra"
+      G
+    end
+
+    it "handles that fine" do
+      bundle "install", :artifice => "compact_index_extra", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+
+      expect(lockfile).to eq <<~L
+        GEM
+          remote: https://localgemserver.test/
+          specs:
+            pdf-writer (1.1.8)
+
+        GEM
+          remote: https://localgemserver.test/extra/
+          specs:
+            ruport (1.7.0.3)
+              pdf-writer (= 1.1.8)
+
+        PLATFORMS
+          #{specific_local_platform}
+
+        DEPENDENCIES
+          ruport (= 1.7.0.3)!
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+    end
+  end
+
   context "when default source includes old gems with nil required_rubygems_version" do
     before do
       build_repo2 do

--- a/bundler/tool/bundler/release_gems.rb.lock
+++ b/bundler/tool/bundler/release_gems.rb.lock
@@ -55,6 +55,7 @@ GEM
       faraday (> 0.8, < 2.0)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-20
   arm64-darwin-21
   universal-java-11

--- a/bundler/tool/bundler/rubocop23_gems.rb.lock
+++ b/bundler/tool/bundler/rubocop23_gems.rb.lock
@@ -42,6 +42,7 @@ GEM
     unicode-display_width (1.8.0)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-20
   arm64-darwin-21
   universal-java-11

--- a/bundler/tool/bundler/rubocop24_gems.rb.lock
+++ b/bundler/tool/bundler/rubocop24_gems.rb.lock
@@ -44,6 +44,7 @@ GEM
     unicode-display_width (2.1.0)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-20
   arm64-darwin-21
   universal-java-11

--- a/bundler/tool/bundler/rubocop_gems.rb.lock
+++ b/bundler/tool/bundler/rubocop_gems.rb.lock
@@ -44,6 +44,7 @@ GEM
     unicode-display_width (2.1.0)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-20
   arm64-darwin-21
   universal-java-11

--- a/bundler/tool/bundler/standard23_gems.rb.lock
+++ b/bundler/tool/bundler/standard23_gems.rb.lock
@@ -47,6 +47,7 @@ GEM
     unicode-display_width (1.6.1)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-20
   arm64-darwin-21
   universal-java-11

--- a/bundler/tool/bundler/standard24_gems.rb.lock
+++ b/bundler/tool/bundler/standard24_gems.rb.lock
@@ -50,6 +50,7 @@ GEM
     unicode-display_width (2.1.0)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-20
   arm64-darwin-21
   universal-java-11

--- a/bundler/tool/bundler/standard_gems.rb.lock
+++ b/bundler/tool/bundler/standard_gems.rb.lock
@@ -50,6 +50,7 @@ GEM
     unicode-display_width (2.1.0)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-20
   arm64-darwin-21
   universal-java-11


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

required_ruby_version and required_rubygems_version are recommended, but optional fields in the [gemspec specification](https://guides.rubygems.org/specification-reference/#required_ruby_version).  Currently, lazy_specification and spec_group throw exceptions if they encounter gem specifications that do not have these set

We have some really old private gems that do not set required_ruby_version in its spec so we are running into this after we bump past bundler `2.3.4`

Top part of lazy_specification stack trace
```
NoMethodError: undefined method `satisfied_by?' for nil:NilClass
  /usr/local/bundle/ruby/2.7.0/gems/bundler-2.3.11/lib/bundler/lazy_specification.rb:94:in `block in __materialize__'
  /usr/local/bundle/ruby/2.7.0/gems/bundler-2.3.11/lib/bundler/lazy_specification.rb:92:in `select'
  /usr/local/bundle/ruby/2.7.0/gems/bundler-2.3.11/lib/bundler/lazy_specification.rb:92:in `__materialize__'
  /usr/local/bundle/ruby/2.7.0/gems/bundler-2.3.11/lib/bundler/spec_set.rb:75:in `block in materialize'
  /usr/local/bundle/ruby/2.7.0/gems/bundler-2.3.11/lib/bundler/spec_set.rb:72:in `map!'
  /usr/local/bundle/ruby/2.7.0/gems/bundler-2.3.11/lib/bundler/spec_set.rb:72:in `materialize'
  /usr/local/bundle/ruby/2.7.0/gems/bundler-2.3.11/lib/bundler/definition.rb:468:in `materialize'
  /usr/local/bundle/ruby/2.7.0/gems/bundler-2.3.11/lib/bundler/definition.rb:190:in `specs'
  /usr/local/bundle/ruby/2.7.0/gems/bundler-2.3.11/lib/bundler/installer.rb:243:in `ensure_specs_are_compatible!'
  /usr/local/bundle/ruby/2.7.0/gems/bundler-2.3.11/lib/bundler/installer.rb:83:in `block in run'
  /usr/local/bundle/ruby/2.7.0/gems/bundler-2.3.11/lib/bundler/process_lock.rb:12:in `block in lock'
  /usr/local/bundle/ruby/2.7.0/gems/bundler-2.3.11/lib/bundler/process_lock.rb:9:in `open'
  /usr/local/bundle/ruby/2.7.0/gems/bundler-2.3.11/lib/bundler/process_lock.rb:9:in `lock'
  /usr/local/bundle/ruby/2.7.0/gems/bundler-2.3.11/lib/bundler/installer.rb:71:in `run'
```


Top part of the spec_group stack trace
```
NoMethodError: undefined method `none?' for nil:NilClass

unless spec.required_ruby_version.none?
                         ^^^^^^
  /usr/local/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.19/lib/bundler/resolver/spec_group.rb:101:in `metadata_dependencies'
  /usr/local/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.19/lib/bundler/resolver/spec_group.rb:84:in `block in dependencies_for'
  /usr/local/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.19/lib/bundler/resolver/spec_group.rb:83:in `map'
  /usr/local/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.19/lib/bundler/resolver/spec_group.rb:83:in `dependencies_for'
  /usr/local/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.19/lib/bundler/resolver/spec_group.rb:26:in `block in initialize'
  /usr/local/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.19/lib/bundler/resolver/spec_group.rb:51:in `dependencies_for_activated_platforms'
  /usr/local/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.19/lib/bundler/resolver.rb:105:in `dependencies_for'
  /usr/local/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.19/lib/bundler/vendor/molinillo/lib/molinillo/delegates/specification_provider.rb:18:in `block in dependencies_for'
  /usr/local/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.19/lib/bundler/vendor/molinillo/lib/molinillo/delegates/specification_provider.rb:77:in `with_no_such_dependency_error_handling'
  /usr/local/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.19/lib/bundler/vendor/molinillo/lib/molinillo/delegates/specification_provider.rb:17:in `dependencies_for'
  /usr/local/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.19/lib/bundler/vendor/molinillo/lib/molinillo/resolution.rb:809:in `block in group_possibilities'
  /usr/local/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.19/lib/bundler/vendor/molinillo/lib/molinillo/resolution.rb:808:in `reverse_each'
  /usr/local/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.19/lib/bundler/vendor/molinillo/lib/molinillo/resolution.rb:808:in `group_possibilities'
  /usr/local/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.19/lib/bundler/vendor/molinillo/lib/molinillo/resolution.rb:796:in `locked_requirement_possibility_set'
  /usr/local/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.19/lib/bundler/vendor/molinillo/lib/molinillo/resolution.rb:776:in `possibilities_for_requirement'
  /usr/local/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.19/lib/bundler/vendor/molinillo/lib/molinillo/resolution.rb:761:in `push_state_for_requirements'
  /usr/local/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.19/lib/bundler/vendor/molinillo/lib/molinillo/resolution.rb:696:in `attempt_to_filter_existing_spec'
  /usr/local/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.19/lib/bundler/vendor/molinillo/lib/molinillo/resolution.rb:672:in `attempt_to_activate'
  /usr/local/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.19/lib/bundler/vendor/molinillo/lib/molinillo/resolution.rb:254:in `process_topmost_state'
  /usr/local/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.19/lib/bundler/vendor/molinillo/lib/molinillo/resolution.rb:182:in `resolve'
  /usr/local/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.19/lib/bundler/vendor/molinillo/lib/molinillo/resolver.rb:43:in `resolve'
  /usr/local/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.19/lib/bundler/resolver.rb:50:in `start'
  /usr/local/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.19/lib/bundler/resolver.rb:24:in `resolve'
  /usr/local/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.19/lib/bundler/definition.rb:480:in `reresolve'
  ```

## What is your fix for the problem, implemented in this PR?

Reverted [this change](https://github.com/rubygems/rubygems/commit/616c866bde964b963044cffdc7bc1444521e6c15) and added the same checks to lazy_specification

There were not existing specs for the files changed and it was not immediately obvious how to set up the objects under test, so I am trusting that the existing specs test this logic indirectly.

## Make sure the following tasks are checked

- [x ] Describe the problem / feature
- [x ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ x] Write code to solve the problem
- [x ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
