### PR TITLE
Fix Ruby platform incorrectly removed on `bundle update`

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -888,7 +888,7 @@ module Bundler
                 Bundler.local_platform == Gem::Platform::RUBY ||
                 !platforms.include?(Gem::Platform::RUBY) ||
                 (@new_platform && platforms.last == Gem::Platform::RUBY) ||
-                !@originally_locked_specs.incomplete_ruby_specs?(dependencies)
+                !@originally_locked_specs.incomplete_ruby_specs?(expand_dependencies(dependencies))
 
       remove_platform(Gem::Platform::RUBY)
       add_current_platform


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

After the fix in #5807, now some users are experimenting the removal of the "ruby" platform in situations where it's not expected.

This is because I fail to consider the case where the `Gemfile` includes gems for other platforms that have never been added to the lockfile.

## What is your fix for the problem, implemented in this PR?

Go through `expand_dependencies`, which filters out dependencies not meant for the current platform, before checking whether the resolve for ruby is incomplete.

Fixes #5830.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
