### PR TITLE
Fix conservative update downgrading top level gems

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -719,7 +719,9 @@ module Bundler
     # commonly happen if the Gemfile has changed since the lockfile was last
     # generated
     def converge_locked_specs
-      resolve = converge_specs(@locked_specs)
+      converged = converge_specs(@locked_specs)
+
+      resolve = SpecSet.new(converged.reject {|s| @unlock[:gems].include?(s.name) })
 
       diff = nil
 
@@ -792,7 +794,7 @@ module Bundler
         end
       end
 
-      SpecSet.new(filter_specs(converged, deps).reject {|s| @unlock[:gems].include?(s.name) })
+      filter_specs(converged, deps)
     end
 
     def metadata_dependencies


### PR DESCRIPTION


## What was the end-user or developer problem that led to this PR?

Sometimes, when `--conservative` is used, `bundle update` may end up downgrading top level gems, which is always wrong.

## What is your fix for the problem, implemented in this PR?

When `--conservative` is passed, explicit unlocks are set for top level gems via `@unlock[:gems]`, so that only those particular gems are allowed to be updated.

When we compute the "base resolve" from the lockfile (the set of gems whose versions should be kept pinned by the resolver), we always exclude gems explicitly unlocked through `@unlock[:gems]` from it. This is done by the `converge_specs` method.

However, the `converge_specs` method is also used for figuring out additional lower bound requirements from the lockfile. But in this case, even if gems are explicitly unlock in `@unlock[:gems]`, we still want to add the additional requirement, so that gems are not downgraded by the resolver.

So the solution is to move the line filtering out gems in `@unlock[:gems]` from the `converged_specs` method out of that method, so that it only applies for computing the "base resolve", but not the additional lower bound requirements.

Fixes #5842.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
