### PR TITLE
Fix edge case where `bundler/inline` unintentionally skips install

### DIFF
--- a/bundler/lib/bundler/inline.rb
+++ b/bundler/lib/bundler/inline.rb
@@ -54,7 +54,7 @@ def gemfile(install = false, options = {}, &gemfile)
 
       Bundler.ui = install ? ui : Bundler::UI::Silent.new
       if install || definition.missing_specs?
-        Bundler.settings.temporary(:inline => true) do
+        Bundler.settings.temporary(:inline => true, :no_install => false) do
           installer = Bundler::Installer.install(Bundler.root, definition, :system => true)
           installer.post_install_messages.each do |name, message|
             Bundler.ui.info "Post-install message from #{name}:\n#{message}"

--- a/bundler/spec/runtime/inline_spec.rb
+++ b/bundler/spec/runtime/inline_spec.rb
@@ -355,6 +355,20 @@ RSpec.describe "bundler/inline#gemfile" do
     expect(err).to be_empty
   end
 
+  it "still installs if the application has `bundle package` no_install config set" do
+    bundle "config set --local no_install true"
+
+    script <<-RUBY
+      gemfile do
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rack"
+      end
+    RUBY
+
+    expect(last_command).to be_success
+    expect(system_gem_path("gems/rack-1.0.0")).to exist
+  end
+
   it "preserves previous BUNDLE_GEMFILE value" do
     ENV["BUNDLE_GEMFILE"] = ""
     script <<-RUBY


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If the application has the `no_install` setting set for `bundle package`, then `bundler/inline` would silently skip installing any gems.

## What is your fix for the problem, implemented in this PR?

Set `no_install` temporarily to `false` for `bundler/inline`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
