### PR TITLE
Fix `bundle platform` crash when there's a lockfile with no Ruby locked

### DIFF
--- a/bundler/lib/bundler/cli/platform.rb
+++ b/bundler/lib/bundler/cli/platform.rb
@@ -9,7 +9,7 @@ module Bundler
 
     def run
       platforms, ruby_version = Bundler.ui.silence do
-        locked_ruby_version = Bundler.locked_gems && Bundler.locked_gems.ruby_version.gsub(/p\d+\Z/, "")
+        locked_ruby_version = Bundler.locked_gems && Bundler.locked_gems.ruby_version&.gsub(/p\d+\Z/, "")
         gemfile_ruby_version = Bundler.definition.ruby_version && Bundler.definition.ruby_version.single_version_string
         [Bundler.definition.platforms.map {|p| "* #{p}" },
          locked_ruby_version || gemfile_ruby_version]

--- a/bundler/spec/commands/platform_spec.rb
+++ b/bundler/spec/commands/platform_spec.rb
@@ -234,6 +234,29 @@ G
       expect(out).to eq("ruby 1.0.0")
     end
 
+    it "handles when there is a lockfile with no requirement" do
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+      G
+
+      lockfile <<-L
+        GEM
+          remote: #{file_uri_for(gem_repo1)}/
+          specs:
+
+        PLATFORMS
+          ruby
+
+        DEPENDENCIES
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      bundle "platform --ruby"
+      expect(out).to eq("No ruby version specified")
+    end
+
     it "handles when there is a requirement in the gemfile" do
       gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`bundle platform` now crashes in presence of a lockfile without `RUBY VERSION` section. That is, many times.

It crashes like this

```
       Invoking `/Users/deivid/.asdf/installs/ruby/3.1.2/bin/ruby -I/Users/deivid/Code/rubygems/rubygems/bundler/spec -r/Users/deivid/Code/rubygems/rubygems/bundler/spec/support/artifice/fail.rb -r/Users/deivid/Code/rubygems/rubygems/bundler/spec/support/hax.rb /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/bin/bundle platform --ruby` failed with output:
       ----------------------------------------------------------------------
       --- ERROR REPORT TEMPLATE -------------------------------------------------------
     
       ```
       NoMethodError: undefined method `gsub' for nil:NilClass
     
       locked_ruby_version = Bundler.locked_gems && Bundler.locked_gems.ruby_version.gsub(/p\d+\Z/, "")
                                                                            ^^^^^
         /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/cli/platform.rb:12:in `block in run'
         /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/ui/shell.rb:136:in `with_level'
         /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/ui/shell.rb:88:in `silence'
         /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/cli/platform.rb:11:in `run'
         /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/cli.rb:633:in `platform'
         /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
         /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
         /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
         /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/cli.rb:31:in `dispatch'
         /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
         /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/cli.rb:25:in `start'
         /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/exe/bundle:48:in `block in <top (required)>'
         /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/lib/bundler/friendly_errors.rb:120:in `with_friendly_errors'
         /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/gems/bundler-2.4.0.dev/exe/bundle:36:in `<top (required)>'
         /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/bin/bundle:25:in `load'
         /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/bin/bundle:25:in `<main>'
     
       ```
     
       ## Environment
     
       ```
       Bundler       2.4.0.dev
         Platforms   ruby, arm64-darwin-21
       Ruby          3.1.2p20 (2022-04-12 revision 4491bb740a9506d76391ac44bb2fe6e483fec952) [arm64-darwin-21]
         Full Path   /Users/deivid/.asdf/installs/ruby/3.1.2/bin/ruby
         Config Dir  /Users/deivid/.asdf/installs/ruby/3.1.2/etc
       RubyGems      3.3.20
         Gem Home    /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system
         Gem Path    /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system
         User Home   /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/home
         User Path   /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/home/.local/share/gem/ruby/3.1.0
         Bin Dir     /Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/system/bin
       OpenSSL       
         Compiled    OpenSSL 1.1.1n  15 Mar 2022
         Loaded      OpenSSL 1.1.1n  15 Mar 2022
         Cert File   /Users/deivid/.asdf/installs/ruby/3.1.2/openssl/ssl/cert.pem
         Cert Dir    /Users/deivid/.asdf/installs/ruby/3.1.2/openssl/ssl/certs
       Tools         
         Git         2.32.1 (Apple Git-133)
         RVM         not installed
         rbenv       not installed
         chruby      not installed
       ```
     
       ## Bundler Build Metadata
     
       ```
       Built At          2022-08-19
       Git SHA           f8c76eae24
       Released Version  true
       ```
     
       ## Gemfile
     
       ### Gemfile
     
       ```ruby
       source "file:///Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/remote1"
       ```
     
       ### Gemfile.lock
     
       ```
       GEM
         remote: file:///Users/deivid/Code/rubygems/rubygems/bundler/tmp/1/gems/remote1/
         specs:
     
       PLATFORMS
         ruby
     
       DEPENDENCIES
     
       BUNDLED WITH
          2.4.0.dev
       ```
     
       --- TEMPLATE END ----------------------------------------------------------------
     
       Unfortunately, an unexpected error occurred, and Bundler cannot continue.
     
       First, try this link to see if there are any existing issue reports for this error:
       https://github.com/rubygems/rubygems/search?q=undefined+method+%60gsub%27+for+nil+NilClass&type=Issues
     
       If there aren't any reports for this error yet, please fill in the new issue form located at https://github.com/rubygems/rubygems/issues/new?labels=Bundler&template=bundler-related-issue.md, and copy and paste the report template above in there.
```
## What is your fix for the problem, implemented in this PR?

My fix is to check whether there's no locked Ruby version before trying to do manipulations on it.

This is a regression introduced in Bundler 2.3.20 (by https://github.com/rubygems/rubygems/pull/5793 in particular).

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
