### PR TITLE
Make `gem install` support non gnu libc linux

### DIFF
--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -151,10 +151,17 @@ class Gem::Platform
   ##
   # Does +other+ match this platform?  Two platforms match if they have the
   # same CPU, or either has a CPU of 'universal', they have the same OS, and
-  # they have the same version, or either has no version.
+  # they have the same version, or either one has no version
   #
   # Additionally, the platform will match if the local CPU is 'arm' and the
   # other CPU starts with "arm" (for generic ARM family support).
+  #
+  # Of note, this method is not commutative. Indeed the OS 'linux' has a
+  # special case: the version is the libc name, yet while "no version" stands
+  # as a wildcard for a binary gem platform (as for other OSes), for the
+  # runtime platform "no version" stands for 'gnu'. To be able to disinguish
+  # these, the method receiver is the gem platform, while the argument is
+  # the runtime platform.
 
   def ===(other)
     return nil unless Gem::Platform === other
@@ -171,7 +178,11 @@ class Gem::Platform
       @os == other.os &&
 
       # version
-      (@version.nil? || other.version.nil? || @version == other.version)
+      (
+        (@os != "linux" && (@version.nil? || other.version.nil?)) ||
+        (@os == "linux" && (@version.nil? && !other.version.nil?)) ||
+        @version == other.version
+      )
   end
 
   ##

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -70,7 +70,7 @@ class Gem::Platform
     when String then
       arch = arch.split "-"
 
-      if arch.length > 2 && arch.last !~ (/\d/) # reassemble x86-linux-gnu
+      if arch.length > 2 && arch.last !~ /\d+(\.\d+)?$/ # reassemble x86-linux-{libc}
         extra = arch.pop
         arch.last << "-#{extra}"
       end

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -102,7 +102,7 @@ class Gem::Platform
       when /^dalvik(\d+)?$/ then        [ "dalvik",    $1  ]
       when /^dotnet$/ then              [ "dotnet",    nil ]
       when /^dotnet([\d.]*)/ then       [ "dotnet",    $1  ]
-      when /linux-?((?!gnu)\w+)?/ then  [ "linux",     $1  ]
+      when /linux-?(\w+)?/ then         [ "linux",     $1  ]
       when /mingw32/ then               [ "mingw32",   nil ]
       when /mingw-?(\w+)?/ then         [ "mingw",     $1  ]
       when /(mswin\d+)(\_(\d+))?/ then
@@ -180,7 +180,7 @@ class Gem::Platform
       # version
       (
         (@os != "linux" && (@version.nil? || other.version.nil?)) ||
-        (@os == "linux" && (@version.nil? && !other.version.nil?)) ||
+        (@os == "linux" && ((@version.nil? && ["gnu", "musl"].include?(other.version)) || (@version == "gnu" && other.version.nil?))) ||
         @version == other.version
       )
   end

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -25,7 +25,7 @@ class Gem::Platform
     platforms.any? do |local_platform|
       platform.nil? ||
         local_platform == platform ||
-        (local_platform != Gem::Platform::RUBY && local_platform =~ platform)
+        (local_platform != Gem::Platform::RUBY && platform =~ local_platform)
     end
   end
   private_class_method :match_platforms?

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -144,6 +144,7 @@ class TestGemPlatform < Gem::TestCase
     test_cases.each do |arch, expected|
       platform = Gem::Platform.new arch
       assert_equal expected, platform.to_a, arch.inspect
+      assert_equal expected, Gem::Platform.new(platform.to_s).to_a, arch.inspect
     end
   end
 

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -119,8 +119,8 @@ class TestGemPlatform < Gem::TestCase
       "i586-linux"             => ["x86",       "linux",     nil],
       "i486-linux"             => ["x86",       "linux",     nil],
       "i386-linux"             => ["x86",       "linux",     nil],
-      "i586-linux-gnu"         => ["x86",       "linux",     nil],
-      "i386-linux-gnu"         => ["x86",       "linux",     nil],
+      "i586-linux-gnu"         => ["x86",       "linux",     "gnu"],
+      "i386-linux-gnu"         => ["x86",       "linux",     "gnu"],
       "i386-mingw32"           => ["x86",       "mingw32",   nil],
       "x64-mingw-ucrt"         => ["x64",       "mingw",     "ucrt"],
       "i386-mswin32"           => ["x86",       "mswin32",   nil],
@@ -135,7 +135,7 @@ class TestGemPlatform < Gem::TestCase
       "i386-solaris2.8"        => ["x86",       "solaris",   "2.8"],
       "mswin32"                => ["x86",       "mswin32",   nil],
       "x86_64-linux"           => ["x86_64",    "linux",     nil],
-      "x86_64-linux-gnu"       => ["x86_64",    "linux",     nil],
+      "x86_64-linux-gnu"       => ["x86_64",    "linux",     "gnu"],
       "x86_64-linux-musl"      => ["x86_64",    "linux",     "musl"],
       "x86_64-linux-uclibc"    => ["x86_64",    "linux",     "uclibc"],
       "x86_64-openbsd3.9"      => ["x86_64",    "openbsd",   "3.9"],
@@ -283,6 +283,10 @@ class TestGemPlatform < Gem::TestCase
     assert(x86_linux === x86_linux_gnu, "linux =~ linux-gnu")
     assert(x86_linux_gnu === x86_linux, "linux-gnu =~ linux")
 
+    # musl and explicit gnu should differ
+    refute(x86_linux_gnu === x86_linux_musl, "linux-gnu =~ linux-musl")
+    refute(x86_linux_musl === x86_linux_gnu, "linux-musl =~ linux-gnu")
+
     # explicit libc differ
     refute(x86_linux_uclibc === x86_linux_musl, "linux-uclibc =~ linux-musl")
     refute(x86_linux_musl === x86_linux_uclibc, "linux-musl =~ linux-uclibc")
@@ -291,6 +295,10 @@ class TestGemPlatform < Gem::TestCase
     assert(x86_linux === x86_linux_musl, "linux =~ linux-musl")
     # ...but implicit gnu runtime generally does not accept musl-specific gems
     refute(x86_linux_musl === x86_linux, "linux-musl =~ linux")
+
+    # other libc are not glibc compatible
+    refute(x86_linux === x86_linux_uclibc, "linux =~ linux-uclibc")
+    refute(x86_linux_uclibc === x86_linux, "linux-uclibc =~ linux")
   end
 
   def test_equals3_cpu_arm

--- a/test/rubygems/test_gem_resolver.rb
+++ b/test/rubygems/test_gem_resolver.rb
@@ -356,6 +356,41 @@ class TestGemResolver < Gem::TestCase
     assert_resolves_to [a2_p1.spec], res
   end
 
+  def test_does_not_pick_musl_variants_on_non_musl_linux
+    util_set_arch "aarch64-linux" do
+      is = Gem::Resolver::IndexSpecification
+
+      linux_musl = Gem::Platform.new("aarch64-linux-musl")
+
+      spec_fetcher do |fetcher|
+        fetcher.spec "libv8-node", "15.14.0.1" do |s|
+          s.platform = Gem::Platform.local
+        end
+
+        fetcher.spec "libv8-node", "15.14.0.1" do |s|
+          s.platform = linux_musl
+        end
+      end
+
+      v15 = v("15.14.0.1")
+      source = Gem::Source.new @gem_repo
+
+      s = set
+
+      v15_linux = is.new s, "libv8-node", v15, source, Gem::Platform.local.to_s
+      v15_linux_musl = is.new s, "libv8-node", v15, source, linux_musl.to_s
+
+      s.add v15_linux
+      s.add v15_linux_musl
+
+      ad = make_dep "libv8-node", "= 15.14.0.1"
+
+      res = Gem::Resolver.new([ad], s)
+
+      assert_resolves_to [v15_linux.spec], res
+    end
+  end
+
   def test_only_returns_spec_once
     a1 = util_spec "a", "1", "c" => "= 1"
     b1 = util_spec "b", "1", "c" => "= 1"

--- a/test/rubygems/test_gem_resolver.rb
+++ b/test/rubygems/test_gem_resolver.rb
@@ -322,16 +322,15 @@ class TestGemResolver < Gem::TestCase
   def test_picks_best_platform
     is      = Gem::Resolver::IndexSpecification
     unknown = Gem::Platform.new "unknown"
-    a2_p1   = a3_p2 = nil
 
     spec_fetcher do |fetcher|
       fetcher.spec "a", 2
 
-      a2_p1 = fetcher.spec "a", 2 do |s|
+      fetcher.spec "a", 2 do |s|
         s.platform = Gem::Platform.local
       end
 
-      a3_p2 = fetcher.spec "a", 3 do |s|
+      fetcher.spec "a", 3 do |s|
         s.platform = unknown
       end
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`gem install` may end up installing musl-specific variants on non musl platforms.

## What is your fix for the problem, implemented in this PR?

Make platform comparison and initialization support must and other non gnu lib linux.

NOTE: This is extracted from #4488, but focusing on the `gem install` issues. `bundle install` issues will be handled in #4488 by backporting these changes to Bundler.

Fixes https://github.com/rubygems/rubygems/issues/3174.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
