### PR TITLE
Introduce bundle-plugin(1) man

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -127,6 +127,8 @@ bundler/lib/bundler/man/bundle-outdated.1
 bundler/lib/bundler/man/bundle-outdated.1.ronn
 bundler/lib/bundler/man/bundle-platform.1
 bundler/lib/bundler/man/bundle-platform.1.ronn
+bundler/lib/bundler/man/bundle-plugin.1
+bundler/lib/bundler/man/bundle-plugin.1.ronn
 bundler/lib/bundler/man/bundle-pristine.1
 bundler/lib/bundler/man/bundle-pristine.1.ronn
 bundler/lib/bundler/man/bundle-remove.1

--- a/bundler/lib/bundler/man/bundle-plugin.1
+++ b/bundler/lib/bundler/man/bundle-plugin.1
@@ -1,0 +1,81 @@
+.\" generated with Ronn/v0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
+.
+.TH "BUNDLE\-PLUGIN" "1" "July 2022" "" ""
+.
+.SH "NAME"
+\fBbundle\-plugin\fR \- Manage Bundler plugins
+.
+.SH "SYNOPSIS"
+\fBbundle plugin\fR install PLUGINS [\-\-source=\fISOURCE\fR] [\-\-version=\fIversion\fR] [\-\-git|\-\-local_git=\fIgit\-url\fR] [\-\-branch=\fIbranch\fR] [\-\-ref=\fIrev\fR]
+.
+.P
+\fBbundle plugin\fR uninstall PLUGINS
+.
+.P
+\fBbundle plugin\fR list
+.
+.P
+\fBbundle plugin\fR help [COMMAND]
+.
+.SH "DESCRIPTION"
+You can install, uninstall, and list plugin(s) with this command to extend functionalities of Bundler\.
+.
+.SH "SUB\-COMMANDS"
+.
+.SS "install"
+Install the given plugin(s)\.
+.
+.IP "\(bu" 4
+\fBbundle plugin install bundler\-graph\fR: Install bundler\-graph gem from RubyGems\.org\. The global source, specified in source in Gemfile is ignored\.
+.
+.IP "\(bu" 4
+\fBbundle plugin install bundler\-graph \-\-source https://example\.com\fR: Install bundler\-graph gem from example\.com\. The global source, specified in source in Gemfile is not considered\.
+.
+.IP "\(bu" 4
+\fBbundle plugin install bundler\-graph \-\-version 0\.2\.1\fR: You can specify the version of the gem via \fB\-\-version\fR\.
+.
+.IP "\(bu" 4
+\fBbundle plugin install bundler\-graph \-\-git https://github\.com/rubygems/bundler\-graph\fR: Install bundler\-graph gem from Git repository\. \fB\-\-git\fR can be replaced with \fB\-\-local\-git\fR\. You cannot use both \fB\-\-git\fR and \fB\-\-local\-git\fR\. You can use standard Git URLs like:
+.
+.IP "\(bu" 4
+\fBssh://[user@]host\.xz[:port]/path/to/repo\.git\fR
+.
+.IP "\(bu" 4
+\fBhttp[s]://host\.xz[:port]/path/to/repo\.git\fR
+.
+.IP "\(bu" 4
+\fB/path/to/repo\fR
+.
+.IP "\(bu" 4
+\fBfile:///path/to/repo\fR
+.
+.IP "" 0
+.
+.IP
+When you specify \fB\-\-git\fR/\fB\-\-local\-git\fR, you can use \fB\-\-branch\fR or \fB\-\-ref\fR to specify any branch, tag, or commit hash (revision) to use\. When you specify both, only the latter is used\.
+.
+.IP "" 0
+.
+.SS "uninstall"
+Uninstall the plugin(s) specified in PLUGINS\.
+.
+.SS "list"
+List the installed plugins and available commands\.
+.
+.P
+No options\.
+.
+.SS "help"
+Describe subcommands or one specific subcommand\.
+.
+.P
+No options\.
+.
+.SH "SEE ALSO"
+.
+.IP "\(bu" 4
+How to write a Bundler plugin \fIhttps://bundler\.io/guides/bundler_plugins\.html\fR
+.
+.IP "" 0
+

--- a/bundler/lib/bundler/man/bundle-plugin.1.ronn
+++ b/bundler/lib/bundler/man/bundle-plugin.1.ronn
@@ -1,0 +1,62 @@
+bundle-plugin(1) -- Manage Bundler plugins
+==========================================
+
+## SYNOPSIS
+
+`bundle plugin` install PLUGINS [--source=<SOURCE>] [--version=<version>]
+                              [--git|--local_git=<git-url>] [--branch=<branch>] [--ref=<rev>]
+
+`bundle plugin` uninstall PLUGINS
+
+`bundle plugin` list
+
+`bundle plugin` help [COMMAND]
+
+## DESCRIPTION
+
+You can install, uninstall, and list plugin(s) with this command to extend functionalities of Bundler.
+
+## SUB-COMMANDS
+
+### install
+
+Install the given plugin(s).
+
+* `bundle plugin install bundler-graph`:
+  Install bundler-graph gem from RubyGems.org. The global source, specified in source in Gemfile is ignored.
+
+* `bundle plugin install bundler-graph --source https://example.com`:
+  Install bundler-graph gem from example.com. The global source, specified in source in Gemfile is not considered.
+
+* `bundle plugin install bundler-graph --version 0.2.1`:
+  You can specify the version of the gem via `--version`.
+
+* `bundle plugin install bundler-graph --git https://github.com/rubygems/bundler-graph`:
+  Install bundler-graph gem from Git repository. `--git` can be replaced with `--local-git`. You cannot use both `--git` and `--local-git`. You can use standard Git URLs like:
+
+  * `ssh://[user@]host.xz[:port]/path/to/repo.git`
+  * `http[s]://host.xz[:port]/path/to/repo.git`
+  * `/path/to/repo`
+  * `file:///path/to/repo`
+
+  When you specify `--git`/`--local-git`, you can use `--branch` or `--ref` to specify any branch, tag, or commit hash (revision) to use. When you specify both, only the latter is used.
+
+### uninstall
+
+Uninstall the plugin(s) specified in PLUGINS.
+
+### list
+
+List the installed plugins and available commands.
+
+No options.
+
+### help
+
+Describe subcommands or one specific subcommand.
+
+No options.
+
+## SEE ALSO
+
+* [How to write a Bundler plugin](https://bundler.io/guides/bundler_plugins.html)

--- a/bundler/lib/bundler/man/bundle.1
+++ b/bundler/lib/bundler/man/bundle.1
@@ -120,6 +120,10 @@ Display warnings about common problems
 \fBbundle remove(1)\fR \fIbundle\-remove\.1\.html\fR
 Removes gems from the Gemfile
 .
+.TP
+\fBbundle plugin(1)\fR \fIbundle\-plugin\.1\.html\fR
+Manage Bundler plugins
+.
 .SH "PLUGINS"
 When running a command that isn\'t listed in PRIMARY COMMANDS or UTILITIES, Bundler will try to find an executable on your path named \fBbundler\-<command>\fR and execute it, passing down any extra arguments to it\.
 .

--- a/bundler/lib/bundler/man/bundle.1.ronn
+++ b/bundler/lib/bundler/man/bundle.1.ronn
@@ -97,6 +97,9 @@ We divide `bundle` subcommands into primary commands and utilities:
 * [`bundle remove(1)`](bundle-remove.1.html):
   Removes gems from the Gemfile
 
+* [`bundle plugin(1)`](bundle-plugin.1.html):
+  Manage Bundler plugins
+
 ## PLUGINS
 
 When running a command that isn't listed in PRIMARY COMMANDS or UTILITIES,

--- a/bundler/lib/bundler/man/index.txt
+++ b/bundler/lib/bundler/man/index.txt
@@ -18,6 +18,7 @@ bundle-lock(1)        bundle-lock.1
 bundle-open(1)        bundle-open.1
 bundle-outdated(1)    bundle-outdated.1
 bundle-platform(1)    bundle-platform.1
+bundle-plugin(1)      bundle-plugin.1
 bundle-pristine(1)    bundle-pristine.1
 bundle-remove(1)      bundle-remove.1
 bundle-show(1)        bundle-show.1

--- a/bundler/spec/plugins/install_spec.rb
+++ b/bundler/spec/plugins/install_spec.rb
@@ -32,7 +32,8 @@ RSpec.describe "bundler plugin install" do
   it "shows help when --help flag is given" do
     bundle "plugin install --help"
 
-    expect(out).to include("bundle plugin install PLUGINS    # Install the plugin from the source")
+    # The help message defined in ../../lib/bundler/man/bundle-plugin.1.ronn will be output.
+    expect(out).to include("You can install, uninstall, and list plugin(s)")
   end
 
   context "plugin is already installed" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

While `bundle plugin` was introduced before Bundler 2.3 and partial document for it has been available on https://bundler.io, now man for `bundle-plugin(1)` is included in Bundler gem.

## What is your fix for the problem, implemented in this PR?

Introduces bundle-plugin(1) man. While there was https://bundler.io/v2.3/bundle_plugin.html, the new man is fully rewritten.

Replaces https://github.com/rubygems/bundler-site/pull/860

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)