### PR TITLE
Disallow both `--branch` and `--ref` at the same time in bundle-plugin

### DIFF
--- a/bundler/lib/bundler/man/bundle-plugin.1
+++ b/bundler/lib/bundler/man/bundle-plugin.1
@@ -7,7 +7,7 @@
 \fBbundle\-plugin\fR \- Manage Bundler plugins
 .
 .SH "SYNOPSIS"
-\fBbundle plugin\fR install PLUGINS [\-\-source=\fISOURCE\fR] [\-\-version=\fIversion\fR] [\-\-git|\-\-local_git=\fIgit\-url\fR] [\-\-branch=\fIbranch\fR] [\-\-ref=\fIrev\fR]
+\fBbundle plugin\fR install PLUGINS [\-\-source=\fISOURCE\fR] [\-\-version=\fIversion\fR] [\-\-git|\-\-local_git=\fIgit\-url\fR] [\-\-branch=\fIbranch\fR|\-\-ref=\fIrev\fR]
 .
 .P
 \fBbundle plugin\fR uninstall PLUGINS

--- a/bundler/lib/bundler/man/bundle-plugin.1.ronn
+++ b/bundler/lib/bundler/man/bundle-plugin.1.ronn
@@ -4,7 +4,7 @@ bundle-plugin(1) -- Manage Bundler plugins
 ## SYNOPSIS
 
 `bundle plugin` install PLUGINS [--source=<SOURCE>] [--version=<version>]
-                              [--git|--local_git=<git-url>] [--branch=<branch>] [--ref=<rev>]
+                              [--git|--local_git=<git-url>] [--branch=<branch>|--ref=<rev>]
 
 `bundle plugin` uninstall PLUGINS
 

--- a/bundler/lib/bundler/plugin.rb
+++ b/bundler/lib/bundler/plugin.rb
@@ -36,6 +36,8 @@ module Bundler
     # @param [Hash] options various parameters as described in description.
     #               Refer to cli/plugin for available options
     def install(names, options)
+      raise InvalidOption, "You cannot specify `--branch` and `--ref` at the same time." if options["branch"] && options["ref"]
+
       specs = Installer.new.install(names, options)
 
       save_plugins names, specs

--- a/bundler/spec/plugins/install_spec.rb
+++ b/bundler/spec/plugins/install_spec.rb
@@ -85,6 +85,26 @@ RSpec.describe "bundler plugin install" do
     expect(out).to include("Using foo 1.1")
   end
 
+  it "installs when --branch specified" do
+    bundle "plugin install foo --branch main --source #{file_uri_for(gem_repo2)}"
+
+    expect(out).to include("Installed plugin foo")
+  end
+
+  it "installs when --ref specified" do
+    bundle "plugin install foo --ref v1.2.3 --source #{file_uri_for(gem_repo2)}"
+
+    expect(out).to include("Installed plugin foo")
+  end
+
+  it "raises error when both --branch and --ref options are specified" do
+    bundle "plugin install foo --source #{file_uri_for(gem_repo2)} --branch main --ref v1.2.3", :raise_on_error => false
+
+    expect(out).not_to include("Installed plugin foo")
+
+    expect(err).to include("You cannot specify `--branch` and `--ref` at the same time.")
+  end
+
   it "works with different load paths" do
     build_repo2 do
       build_plugin "testing" do |s|


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Allowing both --branch and --ref at the same time for `bundle-plugin` makes its behavior unstable by order.

Closes #5845

Updates #5853

## What is your fix for the problem, implemented in this PR?

Raises an error when `--branch` and `--ref` are specified at the same time in `bundle plugin`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)