### PR TITLE
Bundler: re-format bundle-config.1 synposis

### DIFF
--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -10,10 +10,10 @@
 \fBbundle config\fR list
 .
 .P
-\fBbundle config\fR[ get] NAME
+\fBbundle config\fR [get] NAME
 .
 .P
-\fBbundle config\fR[ set] NAME VALUE
+\fBbundle config\fR [set] NAME VALUE
 .
 .P
 \fBbundle config\fR unset NAME

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -5,9 +5,9 @@ bundle-config(1) -- Set bundler configuration options
 
 `bundle config` list
 
-`bundle config`[ get] NAME
+`bundle config` [get] NAME
 
-`bundle config`[ set] NAME VALUE
+`bundle config` [set] NAME VALUE
 
 `bundle config` unset NAME
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We do not have no space in bundle-config(1) synopsis updated in #5854.

## What is your fix for the problem, implemented in this PR?

Adds spaces before parentheses in bundle-config(1) synopsis.


## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>
