### PR TITLE
Bundler: avoid use of "can not" in spec literals

### DIFF
--- a/bundler/spec/commands/init_spec.rb
+++ b/bundler/spec/commands/init_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "bundle init" do
   context "when the dir is not writable by the current user" do
     let(:subdir) { "child_dir" }
 
-    it "notifies the user that it can not write to it" do
+    it "notifies the user that it cannot write to it" do
       FileUtils.mkdir bundled_app(subdir)
       # chmod a-w it
       mode = File.stat(bundled_app(subdir)).mode ^ 0o222

--- a/bundler/spec/commands/remove_spec.rb
+++ b/bundler/spec/commands/remove_spec.rb
@@ -522,7 +522,7 @@ RSpec.describe "bundle remove" do
       end
     end
 
-    context "when gems can not be removed from other gemfile" do
+    context "when gems cannot be removed from other gemfile" do
       it "shows error" do
         create_file "Gemfile-other", <<-G
           gem "rails"; gem "rack"
@@ -574,7 +574,7 @@ RSpec.describe "bundle remove" do
     end
 
     context "when gem present in gemfiles but could not be removed from one from one of them" do
-      it "removes gem which can be removed and shows warning for file from which it can not be removed" do
+      it "removes gem which can be removed and shows warning for file from which it cannot be removed" do
         create_file "Gemfile-other", <<-G
           gem "rack"
         G


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

"can not"s in the literals in Bundler's spec were misused.

Part of #5859

## What is your fix for the problem, implemented in this PR?

Verifies all "can not"s and simply replaces each of them with "cannot".

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
