### PR TITLE
Further speed up Bundler by not sorting specs unnecessarily

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -106,6 +106,7 @@ module Bundler
         @locked_gems    = nil
         @locked_deps    = {}
         @locked_specs   = SpecSet.new([])
+        @originally_locked_specs = @locked_specs
         @locked_sources = []
         @locked_platforms = []
       end
@@ -149,18 +150,7 @@ module Bundler
     end
 
     def gem_version_promoter
-      @gem_version_promoter ||= begin
-        locked_specs =
-          if unlocking? && @locked_specs.empty? && !@lockfile_contents.empty?
-            # Definition uses an empty set of locked_specs to indicate all gems
-            # are unlocked, but GemVersionPromoter needs the locked_specs
-            # for conservative comparison.
-            Bundler::SpecSet.new(@locked_gems.specs)
-          else
-            @locked_specs
-          end
-        GemVersionPromoter.new(locked_specs, @unlock[:gems])
-      end
+      @gem_version_promoter ||= GemVersionPromoter.new(@originally_locked_specs, @unlock[:gems])
     end
 
     def resolve_only_locally!

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -67,7 +67,6 @@ module Bundler
 
       gemspecs = Gem::Util.glob_files_in_dir("{,*}.gemspec", expanded_path).map {|g| Bundler.load_gemspec(g) }.compact
       gemspecs.reject! {|s| s.name != name } if name
-      Index.sort_specs(gemspecs)
       specs_by_name_and_version = gemspecs.group_by {|s| [s.name, s.version] }
 
       case specs_by_name_and_version.size

--- a/bundler/lib/bundler/index.rb
+++ b/bundler/lib/bundler/index.rb
@@ -78,15 +78,11 @@ module Bundler
     end
     protected :unsorted_search
 
-    def self.sort_specs(specs)
+    def sort_specs(specs)
       specs.sort_by do |s|
         platform_string = s.platform.to_s
         [s.version, platform_string == RUBY ? NULL : platform_string]
       end
-    end
-
-    def sort_specs(specs)
-      self.class.sort_specs(specs)
     end
 
     def local_search(query)

--- a/bundler/lib/bundler/index.rb
+++ b/bundler/lib/bundler/index.rb
@@ -58,19 +58,12 @@ module Bundler
     # about, returning all of the results.
     def search(query)
       results = local_search(query)
-
-      seen = results.map(&:full_name).uniq unless @sources.empty?
+      return results unless @sources.any?
 
       @sources.each do |source|
-        source.search(query).each do |spec|
-          next if seen.include?(spec.full_name)
-
-          seen << spec.full_name
-          results << spec
-        end
+        results.concat(source.search(query))
       end
-
-      results
+      results.uniq(&:full_name)
     end
 
     def local_search(query)

--- a/bundler/lib/bundler/index.rb
+++ b/bundler/lib/bundler/index.rb
@@ -57,16 +57,12 @@ module Bundler
     # Search this index's specs, and any source indexes that this index knows
     # about, returning all of the results.
     def search(query)
-      sort_specs(unsorted_search(query))
-    end
-
-    def unsorted_search(query)
       results = local_search(query)
 
       seen = results.map(&:full_name).uniq unless @sources.empty?
 
       @sources.each do |source|
-        source.unsorted_search(query).each do |spec|
+        source.search(query).each do |spec|
           next if seen.include?(spec.full_name)
 
           seen << spec.full_name
@@ -75,14 +71,6 @@ module Bundler
       end
 
       results
-    end
-    protected :unsorted_search
-
-    def sort_specs(specs)
-      specs.sort_by do |s|
-        platform_string = s.platform.to_s
-        [s.version, platform_string == RUBY ? NULL : platform_string]
-      end
     end
 
     def local_search(query)

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -127,13 +127,6 @@ module Bundler
         results = results_for(dependency) + locked_results
         results = results.select {|spec| requirement_satisfied_by?(locked_requirement, nil, spec) } if locked_requirement
 
-        if !@prerelease_specified[name] && locked_results.empty?
-          # Move prereleases to the beginning of the list, so they're considered
-          # last during resolution.
-          pre, results = results.partition {|spec| spec.version.prerelease? }
-          results = pre + results
-        end
-
         if results.any?
           results = @gem_version_promoter.sort_versions(dependency, results)
 

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -284,7 +284,7 @@ module Bundler
     end
 
     def gem_not_found_message(name, requirement, source, extra_message = "")
-      specs = source.specs.search(name)
+      specs = source.specs.search(name).sort_by {|s| [s.version, s.platform.to_s] }
       matching_part = name
       requirement_label = SharedHelpers.pretty_dependency(requirement)
       cache_message = begin

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -42,8 +42,7 @@ module Bundler
         remove_from_candidates(spec)
       end
 
-      @gem_version_promoter.prerelease_specified = @prerelease_specified = {}
-      requirements.each {|dep| @prerelease_specified[dep.name] ||= dep.prerelease? }
+      requirements.each {|dep| prerelease_specified[dep.name] ||= dep.prerelease? }
 
       verify_gemfile_dependencies_are_found!(requirements)
       result = @resolver.resolve(requirements).
@@ -214,6 +213,10 @@ module Bundler
       @base.base_requirements
     end
 
+    def prerelease_specified
+      @gem_version_promoter.prerelease_specified
+    end
+
     def remove_from_candidates(spec)
       @base.delete(spec)
 
@@ -248,7 +251,7 @@ module Bundler
           all - 1_000_000
         else
           search = search_for(dependency)
-          search = @prerelease_specified[dependency.name] ? search.count : search.count {|s| !s.version.prerelease? }
+          search = prerelease_specified[dependency.name] ? search.count : search.count {|s| !s.version.prerelease? }
           search - all
         end
       end

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -176,7 +176,7 @@ module Bundler
     def lookup
       @lookup ||= begin
         lookup = Hash.new {|h, k| h[k] = [] }
-        Index.sort_specs(@specs).reverse_each do |s|
+        @specs.each do |s|
           lookup[s.name] << s
         end
         lookup


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Trying to make Bundler faster and simplify code at the same time.

## What is your fix for the problem, implemented in this PR?

Improve `bundler/setup` time by ~2% in the big Gemfile I commonly use for testing performance (https://github.com/technicalpickles/big-gemfile), although it does not improve simpler setups like a brand new Rails app.

```
✗ hyperfine 'BUNDLER_VERSION=2.3.22 ruby -rbundler/setup -e1' 'BUNDLER_VERSION=2.4.0.dev ruby -rbundler/setup -e1'  --warmup 3
Benchmark 1: BUNDLER_VERSION=2.3.22 ruby -rbundler/setup -e1
  Time (mean ± σ):     141.4 ms ±   1.0 ms    [User: 112.5 ms, System: 27.6 ms]
  Range (min … max):   139.9 ms … 143.1 ms    20 runs
 
Benchmark 2: BUNDLER_VERSION=2.4.0.dev ruby -rbundler/setup -e1
  Time (mean ± σ):     139.0 ms ±   2.4 ms    [User: 109.4 ms, System: 27.6 ms]
  Range (min … max):   136.8 ms … 147.6 ms    21 runs
 
Summary
  'BUNDLER_VERSION=2.4.0.dev ruby -rbundler/setup -e1' ran
    1.02 ± 0.02 times faster than 'BUNDLER_VERSION=2.3.22 ruby -rbundler/setup -e1'
```

The main idea is to not sort specs unnecessarily when not needed although there are other misc improvements in the PR.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
