### PR TITLE
Make `#to_lock` consistent between `Gem::Dependency` and `Bundler::Dependency`

### DIFF
--- a/bundler/lib/bundler/dependency.rb
+++ b/bundler/lib/bundler/dependency.rb
@@ -151,7 +151,7 @@ module Bundler
     def to_lock
       out = super
       out << "!" if source
-      out << "\n"
+      out
     end
 
     def specific?

--- a/bundler/lib/bundler/lockfile_generator.rb
+++ b/bundler/lib/bundler/lockfile_generator.rb
@@ -60,7 +60,7 @@ module Bundler
       handled = []
       definition.dependencies.sort_by(&:to_s).each do |dep|
         next if handled.include?(dep.name)
-        out << dep.to_lock
+        out << dep.to_lock << "\n"
         handled << dep.name
       end
     end

--- a/bundler/spec/bundler/dependency_spec.rb
+++ b/bundler/spec/bundler/dependency_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe Bundler::Dependency do
+  let(:options) do
+    {}
+  end
+  let(:dependency) do
+    described_class.new(
+      "test_gem",
+      "1.0.0",
+      options
+    )
+  end
+
+  describe "to_lock" do
+    it "returns formatted string" do
+      expect(dependency.to_lock).to eq("  test_gem (= 1.0.0)")
+    end
+
+    it "matches format of Gem::Dependency#to_lock" do
+      gem_dependency = Gem::Dependency.new("test_gem", "1.0.0")
+      expect(dependency.to_lock).to eq(gem_dependency.to_lock)
+    end
+
+    context "when source is passed" do
+      let(:options) do
+        {
+          "source" => Bundler::Source::Git.new({}),
+        }
+      end
+
+      it "returns formatted string with exclamation mark" do
+        expect(dependency.to_lock).to eq("  test_gem (= 1.0.0)!")
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

We're extending Bundler for our custom purposes, specifically we're buidling a monorepo support on top of Bundler.

There are two classes `Gem::Dependency` and `Bundler::Dependency`. The latter is inherited from the former. Also Bundler extends `Gem::Dependency`.

`Bundler::Dependency` provides `to_lock` method and Bundler extends `Gem::Dependency` to have one either.

https://github.com/rubygems/rubygems/blob/6ec214feb51102dfbfd94d685a43f8945addeb2e/bundler/lib/bundler/dependency.rb#L151-L155

https://github.com/rubygems/rubygems/blob/6ec214feb51102dfbfd94d685a43f8945addeb2e/bundler/lib/bundler/rubygems_ext.rb#L174-L181

There is an inconsistency between how `to_lock` method works for these two classes.

In `Gem::Dependency` it returns a string without a newline `\n` while in `Bundler::Dependency` it returns a string with a newline.

It doesn't hurt Bundler implementation because these classes are used in different places. But in our extensions in manifested itself because we started seeing extra newlines added when we used `to_lock` of `Bundler::Dependency`.

## What is your fix for the problem, implemented in this PR?

I removed the extra newline from the `to_lock` method of `Bundler::Dependency` and added the newline in `Bundler::LockfileGenerator#add_dependencies` where the `Bundler::Dependency` instances are used.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] ~~Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes~~ I don't think additional tests are needed, this is a refactoring and the existing tests make sure it works fine
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
