### PR TITLE
Fix another regression affecting the sorbet family of gems

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -484,15 +484,13 @@ module Bundler
     def resolver
       @resolver ||= begin
         last_resolve = converge_locked_specs
+        remove_ruby_from_platforms_if_necessary!(dependencies)
         Resolver.new(source_requirements, last_resolve, gem_version_promoter, additional_base_requirements_for_resolve, platforms)
       end
     end
 
     def expanded_dependencies
-      @expanded_dependencies ||= begin
-        remove_ruby_from_platforms_if_necessary!(dependencies)
-        expand_dependencies(dependencies + metadata_dependencies, true)
-      end
+      @expanded_dependencies ||= expand_dependencies(dependencies + metadata_dependencies, true)
     end
 
     def filter_specs(specs, deps)
@@ -896,7 +894,6 @@ module Bundler
 
       remove_platform(Gem::Platform::RUBY)
       add_current_platform
-      resolver.platforms = @platforms
     end
 
     def source_map

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -7,8 +7,6 @@ module Bundler
 
     include GemHelpers
 
-    attr_writer :platforms
-
     # Figures out the best possible configuration of gems that satisfies
     # the list of passed dependencies and any child dependencies without
     # causing any gem activation errors.


### PR DESCRIPTION

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

Recently a changed was introduced to update the resolver platforms after it has been created, in order to remove the "ruby" platform from it if it's to be removed from the lockfile. However, it did not update the `@resolving_only_for_ruby` instance variable in that case, so the resolver was not properly doing the right thing anymore.

## What is your fix for the problem, implemented in this PR?

To fix this, I tweaked the code to restore not changing resolver platforms after the resolver has been instantiated.

Fixes #5873.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
