### PR TITLE
Improve lockfile dependency unlocking

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -161,6 +161,7 @@ bundler/lib/bundler/plugin/source_list.rb
 bundler/lib/bundler/process_lock.rb
 bundler/lib/bundler/remote_specification.rb
 bundler/lib/bundler/resolver.rb
+bundler/lib/bundler/resolver/base.rb
 bundler/lib/bundler/resolver/spec_group.rb
 bundler/lib/bundler/retry.rb
 bundler/lib/bundler/ruby_dsl.rb

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -485,7 +485,7 @@ module Bundler
       @resolver ||= begin
         last_resolve = converge_locked_specs
         remove_ruby_from_platforms_if_necessary!(dependencies)
-        Resolver.new(source_requirements, last_resolve, gem_version_promoter, additional_base_requirements_for_resolve, platforms)
+        Resolver.new(source_requirements, last_resolve, gem_version_promoter, additional_base_requirements_for_resolve(last_resolve), platforms)
       end
     end
 
@@ -878,9 +878,9 @@ module Bundler
       end
     end
 
-    def additional_base_requirements_for_resolve
+    def additional_base_requirements_for_resolve(last_resolve)
       return [] unless @locked_gems && unlocking? && !sources.expired_sources?(@locked_gems.sources)
-      converge_specs(@originally_locked_specs).map do |locked_spec|
+      converge_specs(@originally_locked_specs - last_resolve).map do |locked_spec|
         Dependency.new(locked_spec.name, ">= #{locked_spec.version}")
       end.uniq
     end

--- a/bundler/lib/bundler/feature_flag.rb
+++ b/bundler/lib/bundler/feature_flag.rb
@@ -39,7 +39,6 @@ module Bundler
     settings_flag(:setup_makes_kernel_gem_public) { !bundler_3_mode? }
     settings_flag(:suppress_install_using_messages) { bundler_3_mode? }
     settings_flag(:update_requires_all_flag) { bundler_4_mode? }
-    settings_flag(:use_gem_version_promoter_for_major_updates) { bundler_3_mode? }
 
     settings_option(:default_cli_command) { bundler_3_mode? ? :cli_help : :install }
 

--- a/bundler/lib/bundler/gem_version_promoter.rb
+++ b/bundler/lib/bundler/gem_version_promoter.rb
@@ -55,15 +55,15 @@ module Bundler
       @level = v
     end
 
-    # Given a Dependency and an Array of SpecGroups of available versions for a
-    # gem, this method will return the Array of SpecGroups sorted (and possibly
+    # Given a Dependency and an Array of Specifications of available versions for a
+    # gem, this method will return the Array of Specifications sorted (and possibly
     # truncated if strict is true) in an order to give preference to the current
     # level (:major, :minor or :patch) when resolution is deciding what versions
     # best resolve all dependencies in the bundle.
     # @param dep [Dependency] The Dependency of the gem.
-    # @param spec_groups [SpecGroup] An array of SpecGroups for the same gem
+    # @param spec_groups [Specification] An array of Specifications for the same gem
     #    named in the @dep param.
-    # @return [SpecGroup] A new instance of the SpecGroup Array sorted and
+    # @return [Specification] A new instance of the Specification Array sorted and
     #    possibly filtered.
     def sort_versions(dep, spec_groups)
       @sort_versions[dep] ||= begin

--- a/bundler/lib/bundler/gem_version_promoter.rb
+++ b/bundler/lib/bundler/gem_version_promoter.rb
@@ -66,8 +66,6 @@ module Bundler
     # @return [SpecGroup] A new instance of the SpecGroup Array sorted and
     #    possibly filtered.
     def sort_versions(dep, spec_groups)
-      before_result = "before sort_versions: #{debug_format_result(dep, spec_groups).inspect}" if DEBUG
-
       @sort_versions[dep] ||= begin
         gem_name = dep.name
 
@@ -79,11 +77,6 @@ module Bundler
           filter_dep_specs(spec_groups, locked_spec)
         else
           sort_dep_specs(spec_groups, locked_spec)
-        end.tap do |specs|
-          if DEBUG
-            puts before_result
-            puts " after sort_versions: #{debug_format_result(dep, specs).inspect}"
-          end
         end
       end
     end
@@ -182,13 +175,6 @@ module Bundler
     def move_version_to_end(result, version)
       move, keep = result.partition {|s| s.version.to_s == version.to_s }
       keep.concat(move)
-    end
-
-    def debug_format_result(dep, spec_groups)
-      a = [dep.to_s,
-           spec_groups.map {|sg| [sg.version, sg.dependencies_for_activated_platforms.map {|dp| [dp.name, dp.requirement.to_s] }] }]
-      last_map = a.last.map {|sg_data| [sg_data.first.version, sg_data.last.map {|aa| aa.join(" ") }] }
-      [a.first, last_map, level, strict ? :strict : :not_strict]
     end
   end
 end

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -413,8 +413,8 @@ module Bundler
 
             relevant_source = conflict.requirement.source || source_for(name)
 
-            extra_message = if conflict.requirement_trees.first.size > 1
-              ", which is required by gem '#{SharedHelpers.pretty_dependency(conflict.requirement_trees.first[-2])}',"
+            extra_message = if trees.first.size > 1
+              ", which is required by gem '#{SharedHelpers.pretty_dependency(trees.first[-2])}',"
             else
               ""
             end

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -330,9 +330,10 @@ module Bundler
             String.new("Bundler could not find compatible versions for gem \"#{name}\":")
           end
           o << %(\n)
-          if conflict.locked_requirement
+          locked_requirement = conflict.locked_requirement
+          if locked_requirement
             o << %(  In snapshot (#{name_for_locking_dependency_source}):\n)
-            o << %(    #{SharedHelpers.pretty_dependency(conflict.locked_requirement)}\n)
+            o << %(    #{SharedHelpers.pretty_dependency(locked_requirement)}\n)
             o << %(\n)
           end
           o << %(  In #{name_for_explicit_dependency_source}:\n)
@@ -401,7 +402,7 @@ module Bundler
             end
           elsif name.end_with?("\0")
             o << %(\n  Current #{name} version:\n    #{SharedHelpers.pretty_dependency(@metadata_requirements.find {|req| req.name == name })}\n\n)
-          elsif conflict.locked_requirement
+          elsif locked_requirement
             o << "\n"
             o << %(Deleting your #{name_for_locking_dependency_source} file and running `bundle install` will rebuild your snapshot from scratch, using only\n)
             o << %(the gems in your Gemfile, which may resolve the conflict.\n)

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -203,7 +203,7 @@ module Bundler
         name = name_for(dependency)
         vertex = activated.vertex_named(name)
         [
-          @base_dg.vertex_named(name) ? 0 : 1,
+          @base[name].any? ? 0 : 1,
           vertex.payload ? 0 : 1,
           vertex.root? ? 0 : 1,
           amount_constrained(dependency),

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -129,16 +129,7 @@ module Bundler
         end
 
         spec_groups = if results.any?
-          nested = []
-          results.each do |spec|
-            version, specs = nested.last
-            if version == spec.version
-              specs << spec
-            else
-              nested << [spec.version, [spec]]
-            end
-          end
-          nested.reduce([]) do |groups, (_, specs)|
+          results.group_by(&:version).reduce([]) do |groups, (_, specs)|
             next groups unless specs.any? {|spec| spec.match_platform(platform) }
 
             specs_by_platform = Hash.new do |current_specs, current_platform|

--- a/bundler/lib/bundler/resolver/base.rb
+++ b/bundler/lib/bundler/resolver/base.rb
@@ -17,6 +17,26 @@ module Bundler
       end
 
       def base_requirements
+        @base_requirements ||= build_base_requirements
+      end
+
+      def unlock_deps(deps)
+        exact, lower_bound = deps.partition(&:specific?)
+
+        exact.each do |exact_dep|
+          @base.delete_by_name_and_version(exact_dep.name, exact_dep.requirement.requirements.first.last)
+        end
+
+        lower_bound.each do |lower_bound_dep|
+          @additional_base_requirements.delete(lower_bound_dep)
+        end
+
+        @base_requirements = nil
+      end
+
+      private
+
+      def build_base_requirements
         base_requirements = {}
         @base.each do |ls|
           dep = Dependency.new(ls.name, ls.version)

--- a/bundler/lib/bundler/resolver/base.rb
+++ b/bundler/lib/bundler/resolver/base.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Bundler
+  class Resolver
+    class Base
+      def initialize(base, additional_base_requirements)
+        @base = base
+        @additional_base_requirements = additional_base_requirements
+      end
+
+      def [](name)
+        @base[name]
+      end
+
+      def delete(spec)
+        @base.delete(spec)
+      end
+
+      def base_requirements
+        base_requirements = {}
+        @base.each do |ls|
+          dep = Dependency.new(ls.name, ls.version)
+          base_requirements[ls.name] = DepProxy.get_proxy(dep, ls.platform)
+        end
+        @additional_base_requirements.each {|d| base_requirements[d.name] = d }
+        base_requirements
+      end
+    end
+  end
+end

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -45,7 +45,6 @@ module Bundler
       silence_root_warning
       suppress_install_using_messages
       update_requires_all_flag
-      use_gem_version_promoter_for_major_updates
     ].freeze
 
     NUMBER_KEYS = %w[

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -114,6 +114,10 @@ module Bundler
       SpecSet.new(arr)
     end
 
+    def -(other)
+      SpecSet.new(to_a - other.to_a)
+    end
+
     def find_by_name_and_platform(name, platform)
       @specs.detect {|spec| spec.name == name && spec.match_platform(platform) }
     end

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -122,6 +122,12 @@ module Bundler
       @specs.detect {|spec| spec.name == name && spec.match_platform(platform) }
     end
 
+    def delete_by_name_and_version(name, version)
+      @specs.reject! {|spec| spec.name == name && spec.version == version }
+      @lookup = nil
+      @sorted = nil
+    end
+
     def what_required(spec)
       unless req = find {|s| s.dependencies.any? {|d| d.type == :runtime && d.name == spec.name } }
         return [spec]

--- a/bundler/spec/bundler/gem_version_promoter_spec.rb
+++ b/bundler/spec/bundler/gem_version_promoter_spec.rb
@@ -166,14 +166,5 @@ RSpec.describe Bundler::GemVersionPromoter do
         end
       end
     end
-
-    context "debug output" do
-      it "should not kerblooie on its own debug output" do
-        gvp = unlocking(:level => :patch)
-        dep = Bundler::DepProxy.get_proxy(dep("foo", "1.2.0").first, "ruby")
-        result = gvp.send(:debug_format_result, dep, build_spec_groups("foo", %w[1.2.0 1.3.0]))
-        expect(result.class).to eq Array
-      end
-    end
   end
 end

--- a/bundler/spec/install/gems/flex_spec.rb
+++ b/bundler/spec/install/gems/flex_spec.rb
@@ -243,22 +243,6 @@ RSpec.describe "bundle flex_install" do
         gem "jekyll-feed", "~> 0.12"
       G
 
-      lockfile <<-L
-        GEM
-          remote: #{file_uri_for(gem_repo4)}/
-          specs:
-            jekyll-feed (0.16.0)
-
-        PLATFORMS
-          #{lockfile_platforms}
-
-        DEPENDENCIES
-          jekyll-feed
-
-        BUNDLED WITH
-           #{Bundler::VERSION}
-      L
-
       gemfile <<-G
         source "#{file_uri_for(gem_repo4)}"
         gem "github-pages", "~> 226"

--- a/bundler/spec/install/gems/flex_spec.rb
+++ b/bundler/spec/install/gems/flex_spec.rb
@@ -212,6 +212,19 @@ RSpec.describe "bundle flex_install" do
       bundle :install, :retry => 0, :raise_on_error => false
       expect(err).to end_with(nice_error)
     end
+
+    it "does not include conflicts with a single requirement tree, because that can't possibly be a conflict" do
+      bundle "config set force_ruby_platform true"
+
+      bad_error = <<-E.strip.gsub(/^ {8}/, "")
+        Bundler could not find compatible versions for gem "rack-obama":
+          In Gemfile:
+            rack-obama (= 2.0)
+      E
+
+      bundle "update rack_middleware", :retry => 0, :raise_on_error => false
+      expect(err).not_to end_with(bad_error)
+    end
   end
 
   describe "when running bundle update and Gemfile conflicts with lockfile" do

--- a/bundler/spec/install/gems/flex_spec.rb
+++ b/bundler/spec/install/gems/flex_spec.rb
@@ -190,23 +190,15 @@ RSpec.describe "bundle flex_install" do
       expect(err).to match(/could not find gem 'rack-obama/i)
     end
 
-    it "suggests deleting the Gemfile.lock file when the Gemfile requires different versions than the lock" do
+    it "discards the locked gems when the Gemfile requires different versions than the lock" do
       bundle "config set force_ruby_platform true"
 
       nice_error = <<-E.strip.gsub(/^ {8}/, "")
-        Bundler could not find compatible versions for gem "rack":
-          In snapshot (Gemfile.lock):
-            rack (= 0.9.1)
+        Could not find gem 'rack (= 1.2)', which is required by gem 'rack-obama (= 2.0)', in rubygems repository #{file_uri_for(gem_repo2)}/ or installed locally.
 
-          In Gemfile:
-            rack-obama (= 2.0) was resolved to 2.0, which depends on
-              rack (= 1.2)
-
-            rack_middleware was resolved to 1.0, which depends on
-              rack (= 0.9.1)
-
-        Deleting your Gemfile.lock file and running `bundle install` will rebuild your snapshot from scratch, using only
-        the gems in your Gemfile, which may resolve the conflict.
+        The source contains the following gems matching 'rack':
+          * rack-0.9.1
+          * rack-1.0.0
       E
 
       bundle :install, :retry => 0, :raise_on_error => false
@@ -250,24 +242,9 @@ RSpec.describe "bundle flex_install" do
       G
     end
 
-    it "suggests deleting the Gemfile.lock file when the Gemfile requires different versions than the lock" do
-      nice_error = <<-E.strip.gsub(/^ {8}/, "")
-        Bundler could not find compatible versions for gem "jekyll-feed":
-          In snapshot (Gemfile.lock):
-            jekyll-feed (>= 0.16.0)
-
-          In Gemfile:
-            jekyll-feed (~> 0.12)
-
-            github-pages (~> 226) was resolved to 226, which depends on
-              jekyll-feed (= 0.15.1)
-
-        Deleting your Gemfile.lock file and running `bundle install` will rebuild your snapshot from scratch, using only
-        the gems in your Gemfile, which may resolve the conflict.
-      E
-
+    it "discards the conflicting lockfile information and resolves properly" do
       bundle :update, :raise_on_error => false, :all => true
-      expect(err).to end_with(nice_error)
+      expect(err).to be_empty
     end
   end
 
@@ -371,7 +348,7 @@ RSpec.describe "bundle flex_install" do
       end
     end
 
-    it "prints the correct error message" do
+    it "resolves them" do
       # install Rails 3.0.0.rc
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
@@ -380,13 +357,12 @@ RSpec.describe "bundle flex_install" do
       G
 
       # upgrade Rails to 3.0.0 and then install again
-      install_gemfile <<-G, :raise_on_error => false
+      install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
         gem "rails", "3.0.0"
         gem "capybara", "0.3.9"
       G
-
-      expect(err).to include("Gemfile.lock")
+      expect(err).to be_empty
     end
   end
 end

--- a/bundler/spec/install/gems/flex_spec.rb
+++ b/bundler/spec/install/gems/flex_spec.rb
@@ -269,7 +269,7 @@ RSpec.describe "bundle flex_install" do
         the gems in your Gemfile, which may resolve the conflict.
       E
 
-      bundle :update, :raise_on_error => false
+      bundle :update, :raise_on_error => false, :all => true
       expect(err).to end_with(nice_error)
     end
   end

--- a/bundler/spec/quality_spec.rb
+++ b/bundler/spec/quality_spec.rb
@@ -151,7 +151,6 @@ RSpec.describe "The library itself" do
       git.allow_insecure
       inline
       trust-policy
-      use_gem_version_promoter_for_major_updates
     ]
 
     all_settings = Hash.new {|h, k| h[k] = [] }


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Currently Bundler tries to avoid downgrading locked gems by setting lower bound requirements on them when you run `bundle update`. This works fine in general, but sometimes Gemfile changes can introduce new requirements that conflict with what’s already locked in the lockfile. These situations end up with resolution conflicts, and with the recommendation of removing the Gemfile.lock file and run `bundle install`.

Best explained with an example adapted from our own test suite.

Let’s say you have the following Gemfile and Gemfile.lock file

```ruby
source “https://rubygems.org”

gem "jekyll-feed", "~> 0.12"
```

```
GEM
  remote: https://rubygems.org
  specs:
    jekyll-feed (0.16.0)

PLATFORMS
  arm-darwin-21

DEPENDENCIES
  jekyll-feed

BUNDLED WITH
   2.3.21
```

And then let’s so you add `gem "github-pages", "~> 226”` to it, and run `bundle update`

The result is this:

```
Bundler could not find compatible versions for gem "jekyll-feed":
  In snapshot (Gemfile.lock):
    jekyll-feed (>= 0.16.0)

  In Gemfile:
    jekyll-feed (~> 0.12)

    github-pages (~> 226) was resolved to 226, which depends on
      jekyll-feed (= 0.15.1)

Deleting your Gemfile.lock file and running `bundle install` will rebuild your snapshot from scratch, using only the gems in your Gemfile, which may resolve the conflict.
```

Something similar happens when you run `bundle install` after changing the lockfile. But in that case, Bundler does not use lower bound requirements from the lockfile, but exact dependencies. And similarly, conflicts like the above are raised.

Another similar issue was reported at #3288.

## What is your fix for the problem, implemented in this PR?

Instead, Bundler should be able to detect that it needs to to let `jekyll-feed` be downgraded to 0.15.1, just like it would happen if you delete the lockfile and resolve again.

This is what this PR implements. Bundler will try to be conservative for starters, but if it finds conflicts, it will try unlocking locked gems until those conflicts are fixed, or all locked gems are unlocked.

Fixes #3288.
Fixes #5559.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
