### PR TITLE
Fix `gem info` with explicit `--version`

### DIFF
--- a/lib/rubygems/query_utils.rb
+++ b/lib/rubygems/query_utils.rb
@@ -151,7 +151,7 @@ module Gem::QueryUtils
       fetcher.detect(specs_type) { true }
     else
       fetcher.detect(specs_type) do |name_tuple|
-        name === name_tuple.name
+        name === name_tuple.name && options[:version].satisfied_by?(name_tuple.version)
       end
     end
 
@@ -159,7 +159,7 @@ module Gem::QueryUtils
   end
 
   def specs_type
-    if options[:all]
+    if options[:all] || options[:version].specific?
       if options[:prerelease]
         :complete
       else

--- a/test/rubygems/test_gem_commands_info_command.rb
+++ b/test/rubygems/test_gem_commands_info_command.rb
@@ -40,4 +40,30 @@ class TestGemCommandsInfoCommand < Gem::TestCase
     assert_match %r{#{@gem.summary}\n}, @ui.output
     assert_match "", @ui.error
   end
+
+  def test_execute_with_version_flag
+    spec_fetcher do |fetcher|
+      fetcher.spec "coolgem", "1.0"
+      fetcher.spec "coolgem", "2.0"
+    end
+
+    @cmd.handle_options %w[coolgem --remote --version 1.0]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    expected = <<-EOF
+
+*** REMOTE GEMS ***
+
+coolgem (1.0)
+    Author: A User
+    Homepage: http://example.com
+
+    this is a summary
+    EOF
+
+    assert_equal expected, @ui.output
+  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Bug related to gem info using flag version not being applied correctly, as mentioned in #5755.

## What is your fix for the problem, implemented in this PR?

~First, it was added an error handler if gem version not exist. Second, it will be added a fix to the bug itself~

Make sure we request all versions from API when a specific version is specified, and then select only the one matching it.

Fixes #5755.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
