### PR TITLE
Let `Dir.tmpdir` use the standard path for tests

### DIFF
--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -334,8 +334,6 @@ class Gem::TestCase < Test::Unit::TestCase
     # capture output
     Gem::DefaultUserInteraction.ui = Gem::MockGemUi.new
 
-    ENV["TMPDIR"] = @tempdir
-
     @orig_SYSTEM_WIDE_CONFIG_FILE = Gem::ConfigFile::SYSTEM_WIDE_CONFIG_FILE
     Gem::ConfigFile.send :remove_const, :SYSTEM_WIDE_CONFIG_FILE
     Gem::ConfigFile.send :const_set, :SYSTEM_WIDE_CONFIG_FILE,


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We're not fully in control of this folder, even when running our own tests, because MJIT creates some temp folders there when invoking GC.

This bite tests running in ruby-core when making the behavior of `FileUtils.rm_rf` more strict, because these extra files could not be removed.

More details can be found at https://bugs.ruby-lang.org/issues/18784.

## What is your fix for the problem, implemented in this PR?

Since this was originally added due to some failures on systems with non standard permissions on tmp folders, but I can no longer reproduce those, I'll remove it.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
