### PR TITLE
Introduce bundle-help(1) man

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -109,6 +109,8 @@ bundler/lib/bundler/man/bundle-exec.1
 bundler/lib/bundler/man/bundle-exec.1.ronn
 bundler/lib/bundler/man/bundle-gem.1
 bundler/lib/bundler/man/bundle-gem.1.ronn
+bundler/lib/bundler/man/bundle-help.1
+bundler/lib/bundler/man/bundle-help.1.ronn
 bundler/lib/bundler/man/bundle-info.1
 bundler/lib/bundler/man/bundle-info.1.ronn
 bundler/lib/bundler/man/bundle-init.1

--- a/bundler/lib/bundler/man/bundle-help.1
+++ b/bundler/lib/bundler/man/bundle-help.1
@@ -1,0 +1,13 @@
+.\" generated with Ronn/v0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
+.
+.TH "BUNDLE\-HELP" "1" "August 2022" "" ""
+.
+.SH "NAME"
+\fBbundle\-help\fR \- Displays detailed help for each subcommand
+.
+.SH "SYNOPSIS"
+\fBbundle help\fR [COMMAND]
+.
+.SH "DESCRIPTION"
+Displays detailed help for the given subcommand\. You can specify a single \fBCOMMAND\fR at the same time\. When \fBCOMMAND\fR is omitted, help for \fBhelp\fR command will be displayed\.

--- a/bundler/lib/bundler/man/bundle-help.1.ronn
+++ b/bundler/lib/bundler/man/bundle-help.1.ronn
@@ -1,0 +1,12 @@
+bundle-help(1) -- Displays detailed help for each subcommand
+============================================================
+
+## SYNOPSIS
+
+`bundle help` [COMMAND]
+
+## DESCRIPTION
+
+Displays detailed help for the given subcommand.
+You can specify a single `COMMAND` at the same time.
+When `COMMAND` is omitted, help for `help` command will be displayed.

--- a/bundler/lib/bundler/man/bundle.1
+++ b/bundler/lib/bundler/man/bundle.1
@@ -55,7 +55,7 @@ Execute a script in the current bundle
 Specify and read configuration options for Bundler
 .
 .TP
-\fBbundle help(1)\fR
+\fBbundle help(1)\fR \fIbundle\-help\.1\.html\fR
 Display detailed help for each subcommand
 .
 .SH "UTILITIES"

--- a/bundler/lib/bundler/man/bundle.1.ronn
+++ b/bundler/lib/bundler/man/bundle.1.ronn
@@ -46,7 +46,7 @@ We divide `bundle` subcommands into primary commands and utilities:
 * [`bundle config(1)`](bundle-config.1.html):
   Specify and read configuration options for Bundler
 
-* `bundle help(1)`:
+* [`bundle help(1)`](bundle-help.1.html):
   Display detailed help for each subcommand
 
 ## UTILITIES

--- a/bundler/lib/bundler/man/index.txt
+++ b/bundler/lib/bundler/man/index.txt
@@ -9,6 +9,7 @@ bundle-config(1)      bundle-config.1
 bundle-doctor(1)      bundle-doctor.1
 bundle-exec(1)        bundle-exec.1
 bundle-gem(1)         bundle-gem.1
+bundle-help(1)        bundle-help.1
 bundle-info(1)        bundle-info.1
 bundle-init(1)        bundle-init.1
 bundle-inject(1)      bundle-inject.1


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

While `bundle help` exists for a long time, document for it has been available on https://bundler.io and man page was generated by Thor.

## What is your fix for the problem, implemented in this PR?

Introduces bundle-help(1) man. This will replace https://bundler.io/v2.3/bundle_help.html and `bundle help` automatically generated by Thor.

Relates to https://github.com/rubygems/bundler-site/issues/878

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [n/a] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)