### PR TITLE
Introduce bundle-version(1) man

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -139,6 +139,8 @@ bundler/lib/bundler/man/bundle-show.1
 bundler/lib/bundler/man/bundle-show.1.ronn
 bundler/lib/bundler/man/bundle-update.1
 bundler/lib/bundler/man/bundle-update.1.ronn
+bundler/lib/bundler/man/bundle-version.1
+bundler/lib/bundler/man/bundle-version.1.ronn
 bundler/lib/bundler/man/bundle-viz.1
 bundler/lib/bundler/man/bundle-viz.1.ronn
 bundler/lib/bundler/man/bundle.1

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -517,7 +517,7 @@ module Bundler
       end
     end
 
-    desc "version", "Prints the bundler's version information"
+    desc "version", "Prints Bundler version information"
     def version
       cli_help = current_command.name == "cli_help"
       if cli_help || ARGV.include?("version")

--- a/bundler/lib/bundler/man/bundle-add.1
+++ b/bundler/lib/bundler/man/bundle-add.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-ADD" "1" "August 2022" "" ""
+.TH "BUNDLE\-ADD" "1" "September 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-add\fR \- Add gem to the Gemfile and run bundle install

--- a/bundler/lib/bundler/man/bundle-binstubs.1
+++ b/bundler/lib/bundler/man/bundle-binstubs.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-BINSTUBS" "1" "August 2022" "" ""
+.TH "BUNDLE\-BINSTUBS" "1" "September 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-binstubs\fR \- Install the binstubs of the listed gems

--- a/bundler/lib/bundler/man/bundle-cache.1
+++ b/bundler/lib/bundler/man/bundle-cache.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CACHE" "1" "August 2022" "" ""
+.TH "BUNDLE\-CACHE" "1" "September 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-cache\fR \- Package your needed \fB\.gem\fR files into your application

--- a/bundler/lib/bundler/man/bundle-check.1
+++ b/bundler/lib/bundler/man/bundle-check.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CHECK" "1" "August 2022" "" ""
+.TH "BUNDLE\-CHECK" "1" "September 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-check\fR \- Verifies if dependencies are satisfied by installed gems

--- a/bundler/lib/bundler/man/bundle-clean.1
+++ b/bundler/lib/bundler/man/bundle-clean.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CLEAN" "1" "August 2022" "" ""
+.TH "BUNDLE\-CLEAN" "1" "September 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-clean\fR \- Cleans up unused gems in your bundler directory

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CONFIG" "1" "August 2022" "" ""
+.TH "BUNDLE\-CONFIG" "1" "September 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-config\fR \- Set bundler configuration options

--- a/bundler/lib/bundler/man/bundle-doctor.1
+++ b/bundler/lib/bundler/man/bundle-doctor.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-DOCTOR" "1" "August 2022" "" ""
+.TH "BUNDLE\-DOCTOR" "1" "September 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-doctor\fR \- Checks the bundle for common problems

--- a/bundler/lib/bundler/man/bundle-exec.1
+++ b/bundler/lib/bundler/man/bundle-exec.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-EXEC" "1" "August 2022" "" ""
+.TH "BUNDLE\-EXEC" "1" "September 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-exec\fR \- Execute a command in the context of the bundle

--- a/bundler/lib/bundler/man/bundle-gem.1
+++ b/bundler/lib/bundler/man/bundle-gem.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-GEM" "1" "August 2022" "" ""
+.TH "BUNDLE\-GEM" "1" "September 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-gem\fR \- Generate a project skeleton for creating a rubygem

--- a/bundler/lib/bundler/man/bundle-help.1
+++ b/bundler/lib/bundler/man/bundle-help.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-HELP" "1" "August 2022" "" ""
+.TH "BUNDLE\-HELP" "1" "September 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-help\fR \- Displays detailed help for each subcommand

--- a/bundler/lib/bundler/man/bundle-info.1
+++ b/bundler/lib/bundler/man/bundle-info.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INFO" "1" "August 2022" "" ""
+.TH "BUNDLE\-INFO" "1" "September 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-info\fR \- Show information for the given gem in your bundle

--- a/bundler/lib/bundler/man/bundle-init.1
+++ b/bundler/lib/bundler/man/bundle-init.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INIT" "1" "August 2022" "" ""
+.TH "BUNDLE\-INIT" "1" "September 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-init\fR \- Generates a Gemfile into the current working directory

--- a/bundler/lib/bundler/man/bundle-inject.1
+++ b/bundler/lib/bundler/man/bundle-inject.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INJECT" "1" "August 2022" "" ""
+.TH "BUNDLE\-INJECT" "1" "September 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-inject\fR \- Add named gem(s) with version requirements to Gemfile

--- a/bundler/lib/bundler/man/bundle-install.1
+++ b/bundler/lib/bundler/man/bundle-install.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INSTALL" "1" "August 2022" "" ""
+.TH "BUNDLE\-INSTALL" "1" "September 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-install\fR \- Install the dependencies specified in your Gemfile

--- a/bundler/lib/bundler/man/bundle-list.1
+++ b/bundler/lib/bundler/man/bundle-list.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-LIST" "1" "August 2022" "" ""
+.TH "BUNDLE\-LIST" "1" "September 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-list\fR \- List all the gems in the bundle

--- a/bundler/lib/bundler/man/bundle-lock.1
+++ b/bundler/lib/bundler/man/bundle-lock.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-LOCK" "1" "August 2022" "" ""
+.TH "BUNDLE\-LOCK" "1" "September 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-lock\fR \- Creates / Updates a lockfile without installing

--- a/bundler/lib/bundler/man/bundle-open.1
+++ b/bundler/lib/bundler/man/bundle-open.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-OPEN" "1" "August 2022" "" ""
+.TH "BUNDLE\-OPEN" "1" "September 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-open\fR \- Opens the source directory for a gem in your bundle

--- a/bundler/lib/bundler/man/bundle-outdated.1
+++ b/bundler/lib/bundler/man/bundle-outdated.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-OUTDATED" "1" "August 2022" "" ""
+.TH "BUNDLE\-OUTDATED" "1" "September 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-outdated\fR \- List installed gems with newer versions available

--- a/bundler/lib/bundler/man/bundle-platform.1
+++ b/bundler/lib/bundler/man/bundle-platform.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-PLATFORM" "1" "August 2022" "" ""
+.TH "BUNDLE\-PLATFORM" "1" "September 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-platform\fR \- Displays platform compatibility information

--- a/bundler/lib/bundler/man/bundle-plugin.1
+++ b/bundler/lib/bundler/man/bundle-plugin.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-PLUGIN" "1" "August 2022" "" ""
+.TH "BUNDLE\-PLUGIN" "1" "September 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-plugin\fR \- Manage Bundler plugins

--- a/bundler/lib/bundler/man/bundle-pristine.1
+++ b/bundler/lib/bundler/man/bundle-pristine.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-PRISTINE" "1" "August 2022" "" ""
+.TH "BUNDLE\-PRISTINE" "1" "September 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-pristine\fR \- Restores installed gems to their pristine condition

--- a/bundler/lib/bundler/man/bundle-remove.1
+++ b/bundler/lib/bundler/man/bundle-remove.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-REMOVE" "1" "August 2022" "" ""
+.TH "BUNDLE\-REMOVE" "1" "September 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-remove\fR \- Removes gems from the Gemfile

--- a/bundler/lib/bundler/man/bundle-show.1
+++ b/bundler/lib/bundler/man/bundle-show.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-SHOW" "1" "August 2022" "" ""
+.TH "BUNDLE\-SHOW" "1" "September 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-show\fR \- Shows all the gems in your bundle, or the path to a gem

--- a/bundler/lib/bundler/man/bundle-update.1
+++ b/bundler/lib/bundler/man/bundle-update.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-UPDATE" "1" "August 2022" "" ""
+.TH "BUNDLE\-UPDATE" "1" "September 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-update\fR \- Update your gems to the latest available versions

--- a/bundler/lib/bundler/man/bundle-version.1
+++ b/bundler/lib/bundler/man/bundle-version.1
@@ -1,0 +1,35 @@
+.\" generated with Ronn/v0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
+.
+.TH "BUNDLE\-VERSION" "1" "September 2022" "" ""
+.
+.SH "NAME"
+\fBbundle\-version\fR \- Prints Bundler version information
+.
+.SH "SYNOPSIS"
+\fBbundle version\fR
+.
+.SH "DESCRIPTION"
+Prints Bundler version information\.
+.
+.SH "OPTIONS"
+No options\.
+.
+.SH "EXAMPLE"
+Print the version of Bundler with build date and commit hash of the in the Git source\.
+.
+.IP "" 4
+.
+.nf
+
+bundle version
+.
+.fi
+.
+.IP "" 0
+.
+.P
+shows \fBBundler version 2\.3\.21 (2022\-08\-24 commit d54be5fdd8)\fR for example\.
+.
+.P
+cf\. \fBbundle \-\-version\fR shows \fBBundler version 2\.3\.21\fR\.

--- a/bundler/lib/bundler/man/bundle-version.1.ronn
+++ b/bundler/lib/bundler/man/bundle-version.1.ronn
@@ -1,0 +1,24 @@
+bundle-version(1) -- Prints Bundler version information
+=======================================================
+
+## SYNOPSIS
+
+`bundle version`
+
+## DESCRIPTION
+
+Prints Bundler version information.
+
+## OPTIONS
+
+No options.
+
+## EXAMPLE
+
+Print the version of Bundler with build date and commit hash of the in the Git source.
+
+    bundle version
+
+shows `Bundler version 2.3.21 (2022-08-24 commit d54be5fdd8)` for example.
+
+cf. `bundle --version` shows `Bundler version 2.3.21`.

--- a/bundler/lib/bundler/man/bundle-viz.1
+++ b/bundler/lib/bundler/man/bundle-viz.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-VIZ" "1" "August 2022" "" ""
+.TH "BUNDLE\-VIZ" "1" "September 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-viz\fR \- Generates a visual dependency graph for your Gemfile

--- a/bundler/lib/bundler/man/bundle.1
+++ b/bundler/lib/bundler/man/bundle.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE" "1" "August 2022" "" ""
+.TH "BUNDLE" "1" "September 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\fR \- Ruby Dependency Management
@@ -123,6 +123,10 @@ Removes gems from the Gemfile
 .TP
 \fBbundle plugin(1)\fR \fIbundle\-plugin\.1\.html\fR
 Manage Bundler plugins
+.
+.TP
+\fBbundle version(1)\fR \fIbundle\-version\.1\.html\fR
+Prints Bundler version information
 .
 .SH "PLUGINS"
 When running a command that isn\'t listed in PRIMARY COMMANDS or UTILITIES, Bundler will try to find an executable on your path named \fBbundler\-<command>\fR and execute it, passing down any extra arguments to it\.

--- a/bundler/lib/bundler/man/bundle.1.ronn
+++ b/bundler/lib/bundler/man/bundle.1.ronn
@@ -100,6 +100,9 @@ We divide `bundle` subcommands into primary commands and utilities:
 * [`bundle plugin(1)`](bundle-plugin.1.html):
   Manage Bundler plugins
 
+* [`bundle version(1)`](bundle-version.1.html):
+  Prints Bundler version information
+
 ## PLUGINS
 
 When running a command that isn't listed in PRIMARY COMMANDS or UTILITIES,

--- a/bundler/lib/bundler/man/gemfile.5
+++ b/bundler/lib/bundler/man/gemfile.5
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GEMFILE" "5" "August 2022" "" ""
+.TH "GEMFILE" "5" "September 2022" "" ""
 .
 .SH "NAME"
 \fBGemfile\fR \- A format for describing gem dependencies for Ruby programs

--- a/bundler/lib/bundler/man/index.txt
+++ b/bundler/lib/bundler/man/index.txt
@@ -24,4 +24,5 @@ bundle-pristine(1)    bundle-pristine.1
 bundle-remove(1)      bundle-remove.1
 bundle-show(1)        bundle-show.1
 bundle-update(1)      bundle-update.1
+bundle-version(1)     bundle-version.1
 bundle-viz(1)         bundle-viz.1

--- a/bundler/spec/commands/help_spec.rb
+++ b/bundler/spec/commands/help_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe "bundle help" do
   end
 
   it "still outputs the old help for commands that do not have man pages yet" do
-    bundle "help version"
-    expect(out).to include("Prints the bundler's version information")
+    bundle "help fund"
+    expect(out).to include("Lists information about gems seeking funding assistance")
   end
 
   it "looks for a binary and executes it with --help option if it's named bundler-<task>" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We miss bundle-version(1) man, meaning that users have one generated with Thor while we have had `https://bundler.io/v2.3/bundle_version.html` on the [website](https://bundler.io/).

Options indicated in `bundle help version` (see the below) do not work in `bundle version`:

```
$ bundle help version
Usage:
  bundle version

Options:
      [--no-color]                 # Disable colorization in output
  -r, [--retry=NUM]                # Specify the number of times you wish to attempt network commands
  -V, [--verbose], [--no-verbose]  # Enable verbose output mode

Prints the bundler's version information
```

Relates to https://github.com/rubygems/bundler-site/issues/879

## What is your fix for the problem, implemented in this PR?

Introduces bundle-version(1) man while we have had `https://bundler.io/v2.3/bundle_version.html` on the [website](https://bundler.io/).

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)


Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)