### PR TITLE
Use a more accurate source code uri in gemspec

### DIFF
--- a/bundler/bundler.gemspec
+++ b/bundler/bundler.gemspec
@@ -22,14 +22,12 @@ Gem::Specification.new do |s|
   s.summary     = "The best way to manage your application's dependencies"
   s.description = "Bundler manages an application's dependencies through its entire life, across many machines, systematically and repeatably"
 
-  if s.respond_to?(:metadata=)
-    s.metadata = {
-      "bug_tracker_uri" => "https://github.com/rubygems/rubygems/issues?q=is%3Aopen+is%3Aissue+label%3ABundler",
-      "changelog_uri" => "https://github.com/rubygems/rubygems/blob/master/bundler/CHANGELOG.md",
-      "homepage_uri" => "https://bundler.io/",
-      "source_code_uri" => "https://github.com/rubygems/rubygems/",
-    }
-  end
+  s.metadata = {
+    "bug_tracker_uri" => "https://github.com/rubygems/rubygems/issues?q=is%3Aopen+is%3Aissue+label%3ABundler",
+    "changelog_uri" => "https://github.com/rubygems/rubygems/blob/master/bundler/CHANGELOG.md",
+    "homepage_uri" => "https://bundler.io/",
+    "source_code_uri" => "https://github.com/rubygems/rubygems/tree/master/bundler",
+  }
 
   s.required_ruby_version     = ">= 2.3.0"
   s.required_rubygems_version = ">= 2.5.2"


### PR DESCRIPTION
Updates the bundler metadata source_code_uri
Also, since `metadata` support was [introduced](https://guides.rubygems.org/specification-reference/) in rubygems 2.0, and the required rubygems version is ">= 2.5.2", the check for `metadata=` support has been removed.

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?
Locating the `bundler` source code
<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?
Fix the link to the bundler source code within the bundler gemspec

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
