### PR TITLE
Fix unused variable warning

### DIFF
--- a/bundler/spec/bundler/endpoint_specification_spec.rb
+++ b/bundler/spec/bundler/endpoint_specification_spec.rb
@@ -54,8 +54,6 @@ RSpec.describe Bundler::EndpointSpecification do
       let(:required_ruby_version) { existing_value }
 
       it "should return the current value when already set on endpoint specification" do
-        remote_spec = double(:remote_spec, :required_ruby_version => "remote_value", :required_rubygems_version => nil)
-
         expect(spec.required_ruby_version). eql?(existing_value)
       end
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since https://github.com/rubygems/rubygems/pull/5824, the following warning is printed when running specs:

```
/Users/deivid/Code/rubygems/rubygems/bundler/spec/bundler/endpoint_specification_spec.rb:57: warning: assigned but unused variable - remote_spec
```

## What is your fix for the problem, implemented in this PR?

Remove the unused line.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
