### PR TITLE
Give a better error when trying to write the lock file on a read-only filesystem

### DIFF
--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -1656,4 +1656,35 @@ end
     expect(err).to be_empty
     expect(out).to include("Installing myrack 1.0.0")
   end
+
+  context "in a read-only filesystem" do
+    before do
+      gemfile <<-G
+        source "https://gem.repo4"
+      G
+
+      lockfile <<-L
+        GEM
+          remote: https://gem.repo4/
+
+        PLATFORMS
+          x86_64-darwin-19
+
+        DEPENDENCIES
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+    end
+
+    it "should fail loudly if the lockfile platforms don't include the current platform" do
+      simulate_platform "x86_64-linux" do
+        ruby <<-RUBY, raise_on_error: false, env: { "BUNDLER_SPEC_READ_ONLY" => "true", "BUNDLER_FORCE_TTY" => "true" }
+          require "bundler/setup"
+        RUBY
+      end
+
+      expect(err).to include("Your lockfile does not include the current platform, but the lockfile can't be updated because file system is read-only")
+    end
+  end
 end

--- a/bundler/spec/support/hax.rb
+++ b/bundler/spec/support/hax.rb
@@ -37,4 +37,18 @@ module Gem
   if ENV["BUNDLER_SPEC_GEM_SOURCES"]
     self.sources = [ENV["BUNDLER_SPEC_GEM_SOURCES"]]
   end
+
+  if ENV["BUNDLER_SPEC_READ_ONLY"]
+    module ReadOnly
+      def open(file, mode)
+        if file != IO::NULL && mode == "wb"
+          raise Errno::EROFS
+        else
+          super
+        end
+      end
+    end
+
+    File.singleton_class.prepend ReadOnly
+  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If `bundle exec` tries to write to the lock file on a read-only filesystem, Bundler will fail but it's unclear why.

## What is your fix for the problem, implemented in this PR?

Suggest a solution to fix the problem.

Closes #5893.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
