### PR TITLE
CI - Windows JRuby - use pre-installed JDK 17

### DIFF
--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -101,17 +101,13 @@ jobs:
           - { name: jruby-9.3, value: jruby-9.3.4.0 }
     steps:
       - uses: actions/checkout@v3
+      # set JDK version, see https://github.com/actions/runner-images
+      - run: echo JAVA_HOME=$env:JAVA_HOME_17_X64 >> $env:GITHUB_ENV
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby.value }}
           bundler: none
-      - name: Setup java
-        uses: actions/setup-java@v3.4.1
-        with:
-          distribution: temurin
-          java-version: 18.0.0
-        if: startsWith(matrix.ruby.name, 'jruby')
       - name: Install rubygems
         run: ruby setup.rb
         shell: bash

--- a/.github/workflows/windows-bundler.yml
+++ b/.github/workflows/windows-bundler.yml
@@ -32,17 +32,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      # set JDK version, see https://github.com/actions/runner-images
+      - run: echo JAVA_HOME=$env:JAVA_HOME_17_X64 >> $env:GITHUB_ENV
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby.value }}
           bundler: none
-      - name: Setup java
-        uses: actions/setup-java@v3.4.1
-        with:
-          distribution: temurin
-          java-version: 18.0.0
-        if: startsWith(matrix.ruby.name, 'jruby')
       - name: Install dependencies
         run: |
           bin/rake spec:parallel_deps


### PR DESCRIPTION
Some Windows Actions jobs are using `setup-java` to install Java.  Actions Windows images typically have the most recent 'LTS' version installed.  Adjust `JAVA_HOME` to use it, and remove `setup-java`.

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
