### PR TITLE
Update lockfile for testing

### DIFF
--- a/bundler/tool/bundler/rubocop_gems.rb.lock
+++ b/bundler/tool/bundler/rubocop_gems.rb.lock
@@ -47,6 +47,7 @@ PLATFORMS
   aarch64-linux
   arm64-darwin-20
   arm64-darwin-21
+  arm64-darwin-22
   universal-java-11
   universal-java-18
   x64-mingw-ucrt

--- a/bundler/tool/bundler/rubocop_gems.rb.lock
+++ b/bundler/tool/bundler/rubocop_gems.rb.lock
@@ -53,6 +53,7 @@ PLATFORMS
   x64-mingw-ucrt
   x86_64-darwin-19
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/bundler/tool/bundler/standard_gems.rb.lock
+++ b/bundler/tool/bundler/standard_gems.rb.lock
@@ -53,6 +53,7 @@ PLATFORMS
   aarch64-linux
   arm64-darwin-20
   arm64-darwin-21
+  arm64-darwin-22
   universal-java-11
   universal-java-18
   x64-mingw-ucrt

--- a/bundler/tool/bundler/standard_gems.rb.lock
+++ b/bundler/tool/bundler/standard_gems.rb.lock
@@ -59,6 +59,7 @@ PLATFORMS
   x64-mingw-ucrt
   x86_64-darwin-19
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`rubocop_gems.rb.lock` and `standard_gems.rb.lock` are used by rspec of bundler. When I invoked test suite of bundler, they are updated because I used Ventura Beta. 

And the users of Intel mac with macOS 12.x also faced the same situation.

## What is your fix for the problem, implemented in this PR?

I added their platforms.

off-topic: I'm not sure why we use `XXX-darwin-YY` format instead of `XXX-darwin`. A number of `YY` seems unnecessary. 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
