### PR TITLE
Try using default Rust in CI

### DIFF
--- a/.github/workflows/macos-rubygems.yml
+++ b/.github/workflows/macos-rubygems.yml
@@ -33,9 +33,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby.value }}
           bundler: none
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
       - name: Install Dependencies
         run: rake setup
       - name: Run Test

--- a/.github/workflows/ubuntu-rubygems.yml
+++ b/.github/workflows/ubuntu-rubygems.yml
@@ -36,9 +36,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby.value }}
           bundler: none
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
       - name: Install Dependencies
         run: rake setup
       - name: Run Test


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The action that we use to install Rust is quite unstable. We get network errors many times when trying to install Rust.

## What is your fix for the problem, implemented in this PR?

We could try use the Rust version that comes by default.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
