### PR TITLE
Fix `Gem::Platform.match` not handling String argument properly

### DIFF
--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -22,6 +22,7 @@ class Gem::Platform
   end
 
   def self.match_platforms?(platform, platforms)
+    platform = Gem::Platform.new(platform) unless platform.is_a?(Gem::Platform)
     platforms.any? do |local_platform|
       platform.nil? ||
         local_platform == platform ||

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -452,6 +452,13 @@ class TestGemPlatform < Gem::TestCase
     assert_equal 1, result.scan(/@version=/).size
   end
 
+  def test_gem_platform_match_with_string_argument
+    util_set_arch "x86_64-linux-musl"
+
+    assert(Gem::Platform.match(Gem::Platform.new("x86_64-linux")), "should match Gem::Platform")
+    assert(Gem::Platform.match("x86_64-linux"), "should match String platform")
+  end
+
   def assert_local_match(name)
     assert_match Gem::Platform.local, name
   end


### PR DESCRIPTION
Previously 9eead86 introduced non-commutativity of platforms, and later commit 1b9f7f50 changed the behavior of `Gem::Platform.match` to ensure the callee of `#=~` was the gem platform.

However, when the platform argument is a String, then the callee and argument of `#=~` are flipped (see docs for `String#=~`), which works against the fix from 1b9f7f50.

Closes #5938


## What was the end-user or developer problem that led to this PR?

See #5938 


## What is your fix for the problem, implemented in this PR?

Coerce the `Gem::Platform.match` argument to a `Gem::Platform` object


## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
