### PR TITLE
Use the latest URLs for RFCs to avoid extra redirections

### DIFF
--- a/bundler/README.md
+++ b/bundler/README.md
@@ -44,7 +44,7 @@ To get in touch with the Bundler core team and other Bundler users, please join 
 
 If you'd like to contribute to Bundler, that's awesome, and we <3 you. We've put together [the Bundler contributor guide](https://github.com/rubygems/rubygems/blob/master/bundler/doc/contributing/README.md) with all of the information you need to get started.
 
-If you'd like to request a substantial change to Bundler or its documentation, refer to the [Bundler RFC process](https://github.com/bundler/rfcs) for more information.
+If you'd like to request a substantial change to Bundler or its documentation, refer to the [Bundler RFC process](https://github.com/rubygems/rfcs) for more information.
 
 While some Bundler contributors are compensated by Ruby Together, the project maintainers make decisions independent of Ruby Together. As a project, we welcome contributions regardless of the author's affiliation with Ruby Together.
 

--- a/bundler/doc/POLICIES.md
+++ b/bundler/doc/POLICIES.md
@@ -62,7 +62,7 @@ Every pull request should explain:
 
 ### RFC guidelines
 
-Large changes often benefit from being written out more completely, read by others, and discussed. The [Bundler RFC repo](https://github.com/bundler/rfcs) is the preferred place for that to happen.
+Large changes often benefit from being written out more completely, read by others, and discussed. The [Bundler RFC repo](https://github.com/rubygems/rfcs) is the preferred place for that to happen.
 
 ### Maintainer team guidelines
 

--- a/bundler/doc/contributing/README.md
+++ b/bundler/doc/contributing/README.md
@@ -11,7 +11,7 @@ And be sure to [set up your development environment](https://github.com/rubygems
 
 ## Feature Requests
 
-To request substantial changes to Bundler and/or Bundler documentation, please refer to the [README](https://github.com/bundler/rfcs/blob/master/README.md) in the [RFC repository](https://github.com/bundler/rfcs) for instructions.
+To request substantial changes to Bundler and/or Bundler documentation, please refer to the [README](https://github.com/rubygems/rfcs/blob/master/README.md) in the [RFC repository](https://github.com/rubygems/rfcs) for instructions.
 
 ## Contributing to Bundler
 

--- a/bundler/doc/development/NEW_FEATURES.md
+++ b/bundler/doc/development/NEW_FEATURES.md
@@ -9,4 +9,4 @@ If you would like to add a new feature to Bundler, please follow these steps:
 
 If you don't hear back immediately, don't get discouraged! We all have day jobs, but we respond to most tickets within a day or two.
 
-If you'd like to add a substantial feature to Bundler, refer to the [Bundler RFC process](https://github.com/bundler/rfcs) for more information.
+If you'd like to add a substantial feature to Bundler, refer to the [Bundler RFC process](https://github.com/rubygems/rfcs) for more information.


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Links to rubygems RFCs are still old while #3157 merged both repos. While redirections still work as of writing, we can improve user experience by removing extra redirection and reduce the possibilities of becoming dead. 

## What is your fix for the problem, implemented in this PR?

Related to #5912

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [n/a] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)
