### PR TITLE
Update GitLab CI template with new one

### DIFF
--- a/bundler/lib/bundler/templates/newgem/gitlab-ci.yml.tt
+++ b/bundler/lib/bundler/templates/newgem/gitlab-ci.yml.tt
@@ -1,8 +1,9 @@
-image: ruby:<%= RUBY_VERSION %>
+default:
+  image: ruby:<%= RUBY_VERSION %>
 
-before_script:
-  - gem install bundler -v <%= Bundler::VERSION %>
-  - bundle install
+  before_script:
+    - gem install bundler -v <%= Bundler::VERSION %>
+    - bundle install
 
 example_job:
   script:


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`.gitlab-ci.yml` generated with `bundle init` with the choice of `GitLab CI` by Bundler 2.3.x or earlier, will not be used in a near future.

- https://docs.gitlab.com/ee/ci/yaml/#default

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

## What is your fix for the problem, implemented in this PR?

GitLab CI now needs the `default` keyword on specification of `image` and `before_script`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [n/a] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
