### PR TITLE
Fix `bundle init` not respecting umask in generated gem's Gemfile

### DIFF
--- a/bundler/lib/bundler/cli/init.rb
+++ b/bundler/lib/bundler/cli/init.rb
@@ -32,7 +32,11 @@ module Bundler
           file << spec.to_gemfile
         end
       else
-        FileUtils.cp(File.expand_path("../templates/#{gemfile}", __dir__), gemfile)
+        File.open(File.expand_path("../templates/#{gemfile}", __dir__), "r") do |template|
+          File.open(gemfile, "wb") do |destination|
+            IO.copy_stream(template, destination)
+          end
+        end
       end
 
       puts "Writing new #{gemfile} to #{SharedHelpers.pwd}/#{gemfile}"

--- a/bundler/spec/commands/init_spec.rb
+++ b/bundler/spec/commands/init_spec.rb
@@ -7,6 +7,29 @@ RSpec.describe "bundle init" do
     expect(bundled_app_gemfile).to be_file
   end
 
+  context "with a template with permission flags not matching current process umask" do
+    let(:template_file) do
+      gemfile = Bundler.preferred_gemfile_name
+      templates_dir.join(gemfile)
+    end
+
+    let(:target_dir) { bundled_app("init_permissions_test") }
+
+    around do |example|
+      old_chmod = File.stat(template_file).mode
+      FileUtils.chmod(old_chmod | 0o111, template_file) # chmod +x
+      example.run
+      FileUtils.chmod(old_chmod, template_file)
+    end
+
+    it "honours the current process umask when generating from a template" do
+      FileUtils.mkdir(target_dir)
+      bundle :init, :dir => target_dir
+      generated_mode = File.stat(File.join(target_dir, "Gemfile")).mode & 0o111
+      expect(generated_mode).to be_zero
+    end
+  end
+
   context "when a Gemfile already exists" do
     before do
       create_file "Gemfile", <<-G

--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -312,6 +312,10 @@ module Spec
       source_root.join("tool/bundler")
     end
 
+    def templates_dir
+      lib_dir.join("bundler", "templates")
+    end
+
     extend self
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

On a clean Ruby 3 installation (through Homebrew), I noticed that `Gemfile`s created through `bundler init` had different permission than the one provided by umask.
This was due to Bundler copying the template from the source directory (which has a mode `0444`) instead of piping the template's contents into the destination Gemfile:

From my installation:

```
$ pwd
/opt/homebrew/opt/ruby/lib/ruby/3.1.0/bundler/templates

$ stat Gemfile
16777234 11017035 -r--r--r-- 1 victorgama admin 0 76 "May 19 22:51:10 2022" "Apr 12 08:11:17 2022" "May 19 22:51:12 2022" "Apr 12 08:11:17 2022" 4096 8 0 Gemfile
```

Searching this repo's issues/pull requests I was unable to find anything discussing this specific behaviour.

## What is your fix for the problem, implemented in this PR?

Instead of leveraging `FileUtils#cp`, the fix leverages `File#open` on both the template and destination file, and `IO#copy_stream` to respect the current umask.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
> Notice: Maintainers, I couldn't come up with a spec for this specific scenario.

- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
