### PR TITLE
Force "master" in tests to be used regardless of `init.defaultBranch` config

### DIFF
--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -575,6 +575,7 @@ class Gem::TestCase < Test::Unit::TestCase
     Dir.chdir directory do
       unless File.exist? ".git"
         system @git, "init", "--quiet"
+        system @git, "checkout", "-b", "master", "--quiet"
         system @git, "config", "user.name",  "RubyGems Tests"
         system @git, "config", "user.email", "rubygems@example"
       end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Recently RubyGems tests started failing locally for me. The reason is that I have git configured as `init.defaultBranch main`. That doesn't fully explain why now though, because I've had this configuration for a long time. I believe it has to do with me recently switching from `hub` to `gh` for "GitHub things".

Anways, failures read like this:

```
============================================================================================================================================================================================================
Error: test_checkout_submodules(TestGemSourceGit): Gem::Exception: unable to find reference master in /Users/deivid/Code/rubygems/rubygems/tmp/test_rubygems_20220928-13878-xog1je/git/a
/Users/deivid/Code/rubygems/rubygems/lib/rubygems/source/git.rb:188:in `rev_parse'
/Users/deivid/Code/rubygems/rubygems/lib/rubygems/source/git.rb:143:in `dir_shortref'
/Users/deivid/Code/rubygems/rubygems/lib/rubygems/source/git.rb:158:in `install_dir'
/Users/deivid/Code/rubygems/rubygems/lib/rubygems/source/git.rb:94:in `checkout'
/Users/deivid/Code/rubygems/rubygems/test/rubygems/test_gem_source_git.rb:78:in `test_checkout_submodules'
     75:       system @git, "commit", "--quiet", "-m", "add submodule b"
     76:     end
     77:
  => 78:     source.checkout
     79:
     80:     assert_path_exist File.join source.install_dir, "a.gemspec"
     81:     assert_path_exist File.join source.install_dir, "b/b.gemspec"
============================================================================================================================================================================================================
fatal: ambiguous argument 'master': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
fatal: ambiguous argument 'master': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
E
```

## What is your fix for the problem, implemented in this PR?

My fix is to explicitly create a "master" branch right after cloning.

In the future, I'd like to change things to use "main", but the straighforward fix now is to keep "master" and make the running environment's git configuration not get in the middle.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
