### PR TITLE
Improve RubyGems tests isolation

### DIFF
--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -2,21 +2,11 @@
 
 require "rubygems"
 
-# If bundler gemspec exists, add to stubs
-bundler_gemspec = File.expand_path("../../bundler/bundler.gemspec", __dir__)
-if File.exist?(bundler_gemspec)
-  Gem::Specification.dirs.unshift File.dirname(bundler_gemspec)
-  Gem::Specification.class_variable_set :@@stubs, nil
-  Gem::Specification.stubs
-  Gem::Specification.dirs.shift
-end
-
 begin
   gem "test-unit", "~> 3.0"
 rescue Gem::LoadError
 end
 
-require "bundler"
 require "test/unit"
 
 ENV["JARS_SKIP"] = "true" if Gem.java_platform? # avoid unnecessary and noisy `jar-dependencies` post install hook
@@ -404,7 +394,6 @@ class Gem::TestCase < Test::Unit::TestCase
     Gem.loaded_specs.clear
     Gem.instance_variable_set(:@activated_gem_paths, 0)
     Gem.clear_default_specs
-    Bundler.reset!
 
     Gem.configuration.verbose = true
     Gem.configuration.update_sources = true
@@ -460,7 +449,7 @@ class Gem::TestCase < Test::Unit::TestCase
 
     FileUtils.rm_rf @tempdir
 
-    ENV.replace(@orig_env)
+    restore_env
 
     Gem::ConfigFile.send :remove_const, :SYSTEM_WIDE_CONFIG_FILE
     Gem::ConfigFile.send :const_set, :SYSTEM_WIDE_CONFIG_FILE,
@@ -1581,6 +1570,23 @@ Also, a list:
     PUBLIC_KEY  = nil
     PUBLIC_CERT = nil
   end if Gem::HAVE_OPENSSL
+
+  private
+
+  def restore_env
+    unless Gem.win_platform?
+      ENV.replace(@orig_env)
+      return
+    end
+
+    # Fallback logic for Windows below to workaround
+    # https://bugs.ruby-lang.org/issues/16798. Can be dropped once all
+    # supported rubies include the fix for that.
+
+    ENV.clear
+
+    @orig_env.each {|k, v| ENV[k] = v }
+  end
 end
 
 # https://github.com/seattlerb/minitest/blob/13c48a03d84a2a87855a4de0c959f96800100357/lib/minitest/mock.rb#L192

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -1297,6 +1297,10 @@ Also, a list:
     $LOAD_PATH.find {|p| p == File.dirname($LOADED_FEATURES.find {|f| f.end_with?("/rubygems.rb") }) }
   end
 
+  def bundler_path
+    $LOAD_PATH.find {|p| p == File.dirname($LOADED_FEATURES.find {|f| f.end_with?("/bundler.rb") }) }
+  end
+
   def with_clean_path_to_ruby
     orig_ruby = Gem.ruby
 

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -16,12 +16,7 @@ begin
 rescue Gem::LoadError
 end
 
-if File.exist?(bundler_gemspec)
-  require_relative "../../bundler/lib/bundler"
-else
-  require "bundler"
-end
-
+require "bundler"
 require "test/unit"
 
 ENV["JARS_SKIP"] = "true" if Gem.java_platform? # avoid unnecessary and noisy `jar-dependencies` post install hook

--- a/test/rubygems/rubygems_plugin.rb
+++ b/test/rubygems/rubygems_plugin.rb
@@ -1,15 +1,6 @@
 # frozen_string_literal: true
 require "rubygems/command_manager"
 
-##
-# This is an example of exactly what NOT to do.
-#
-# DO NOT include code like this in your rubygems_plugin.rb
-
-module Gem::Commands
-  remove_const(:InterruptCommand) if defined?(InterruptCommand)
-end
-
 class Gem::Commands::InterruptCommand < Gem::Command
   def initialize
     super("interrupt", "Raises an Interrupt Exception", {})

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -804,7 +804,6 @@ class TestGem < Gem::TestCase
 
     assert_equal expected, Gem.find_files("sff/discover").sort
     assert_equal expected, Gem.find_files("sff/**.rb").sort, "[ruby-core:31730]"
-  ensure
     assert_equal cwd, actual_load_path.shift
   end
 

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1678,10 +1678,9 @@ class TestGem < Gem::TestCase
   end
 
   BUNDLER_LIB_PATH = File.expand_path $LOAD_PATH.find {|lp| File.file?(File.join(lp, "bundler.rb")) }
-  BUNDLER_FULL_NAME = "bundler-#{Bundler::VERSION}".freeze
 
   def add_bundler_full_name(names)
-    names << BUNDLER_FULL_NAME
+    names << "bundler-#{Bundler::VERSION}".freeze
     names.sort!
     names
   end

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -807,7 +807,7 @@ class TestGem < Gem::TestCase
     assert_equal expected, Gem.find_files("sff/discover").sort
     assert_equal expected, Gem.find_files("sff/**.rb").sort, "[ruby-core:31730]"
   ensure
-    assert_equal cwd, actual_load_path.shift unless Gem.java_platform?
+    assert_equal cwd, actual_load_path.shift
   end
 
   def test_self_find_latest_files
@@ -1335,12 +1335,10 @@ class TestGem < Gem::TestCase
       refute Gem.try_activate "nonexistent"
     end
 
-    unless Gem.java_platform?
-      expected = "Ignoring ext-1 because its extensions are not built. " +
-                 "Try: gem pristine ext --version 1\n"
+    expected = "Ignoring ext-1 because its extensions are not built. " +
+               "Try: gem pristine ext --version 1\n"
 
-      assert_equal expected, err
-    end
+    assert_equal expected, err
   end
 
   def test_self_use_paths_with_nils
@@ -1695,8 +1693,6 @@ class TestGem < Gem::TestCase
   end
 
   def test_looks_for_gemdeps_files_automatically_from_binstubs
-    pend "Requiring bundler messes things up" if Gem.java_platform?
-
     a = util_spec "a", "1" do |s|
       s.executables = %w[foo]
       s.bindir = "exe"
@@ -1744,7 +1740,7 @@ class TestGem < Gem::TestCase
   end
 
   def test_looks_for_gemdeps_files_automatically_from_binstubs_in_parent_dir
-    pend "Requiring bundler messes things up" if Gem.java_platform?
+    pend "IO.popen has issues on JRuby when passed :chdir" if Gem.java_platform?
 
     a = util_spec "a", "1" do |s|
       s.executables = %w[foo]

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1676,8 +1676,6 @@ class TestGem < Gem::TestCase
     end
   end
 
-  BUNDLER_LIB_PATH = File.expand_path $LOAD_PATH.find {|lp| File.file?(File.join(lp, "bundler.rb")) }
-
   def add_bundler_full_name(names)
     names << "bundler-#{Bundler::VERSION}".freeze
     names.sort!
@@ -1708,7 +1706,7 @@ class TestGem < Gem::TestCase
 
     with_rubygems_gemdeps("-") do
       new_PATH = [File.join(path, "bin"), ENV["PATH"]].join(File::PATH_SEPARATOR)
-      new_RUBYOPT = "-I#{rubygems_path} -I#{BUNDLER_LIB_PATH}"
+      new_RUBYOPT = "-I#{rubygems_path} -I#{bundler_path}"
 
       path = File.join @tempdir, "gem.deps.rb"
 
@@ -1759,7 +1757,7 @@ class TestGem < Gem::TestCase
       Dir.mkdir "sub1"
 
       new_PATH = [File.join(path, "bin"), ENV["PATH"]].join(File::PATH_SEPARATOR)
-      new_RUBYOPT = "-I#{rubygems_path} -I#{BUNDLER_LIB_PATH}"
+      new_RUBYOPT = "-I#{rubygems_path} -I#{bundler_path}"
 
       path = File.join @tempdir, "gem.deps.rb"
 

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -20,8 +20,6 @@ class TestGem < Gem::TestCase
     common_installer_setup
 
     @additional = %w[a b].map {|d| File.join @tempdir, d }
-
-    util_remove_interrupt_command
   end
 
   def test_self_finish_resolve
@@ -1547,13 +1545,9 @@ class TestGem < Gem::TestCase
     with_plugin("load") { Gem.load_env_plugins }
     assert_equal :loaded, TEST_PLUGIN_LOAD rescue nil
 
-    util_remove_interrupt_command
-
     # Should attempt to cause a StandardError
     with_plugin("standarderror") { Gem.load_env_plugins }
     assert_equal :loaded, TEST_PLUGIN_STANDARDERROR rescue nil
-
-    util_remove_interrupt_command
 
     # Should attempt to cause an Exception
     with_plugin("exception") { Gem.load_env_plugins }
@@ -2077,11 +2071,6 @@ You may need to `bundle install` to install missing gems
     @exec_path = File.join spec.full_gem_path, spec.bindir, "exec"
     @abin_path = File.join spec.full_gem_path, spec.bindir, "abin"
     spec
-  end
-
-  def util_remove_interrupt_command
-    Gem::Commands.send :remove_const, :InterruptCommand if
-      Gem::Commands.const_defined? :InterruptCommand
   end
 
   def util_cache_dir

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -252,9 +252,9 @@ class TestGemRequire < Gem::TestCase
     # Activates a-1, but not b-1 and b-2
     assert_require "test_gem_require_a"
     assert_equal %w[a-1], loaded_spec_names
-    assert $LOAD_PATH.include? a1.load_paths[0]
-    refute $LOAD_PATH.include? b1.load_paths[0]
-    refute $LOAD_PATH.include? b2.load_paths[0]
+    assert $LOAD_PATH.include? a1.full_require_paths[0]
+    refute $LOAD_PATH.include? b1.full_require_paths[0]
+    refute $LOAD_PATH.include? b2.full_require_paths[0]
 
     assert_equal unresolved_names, ["b (>= 1)"]
 
@@ -265,13 +265,13 @@ class TestGemRequire < Gem::TestCase
     # and as a result #gem_original_require returns false.
     refute require("benchmark"), "the benchmark stdlib should be recognized as already loaded"
 
-    assert_includes $LOAD_PATH, b2.load_paths[0]
+    assert_includes $LOAD_PATH, b2.full_require_paths[0]
     assert_includes $LOAD_PATH, rubylibdir
     message = proc {
       "this test relies on the b-2 gem lib/ to be before stdlib to make sense\n" +
         $LOAD_PATH.pretty_inspect
     }
-    assert_operator $LOAD_PATH.index(b2.load_paths[0]), :<, $LOAD_PATH.index(rubylibdir), message
+    assert_operator $LOAD_PATH.index(b2.full_require_paths[0]), :<, $LOAD_PATH.index(rubylibdir), message
 
     # We detected that we should activate b-2, so we did so, but
     # then #gem_original_require decided "I've already got some benchmark.rb" loaded.


### PR DESCRIPTION

## What was the end-user or developer problem that led to this PR?

Currently RubyGems tests load Bundler, and Bundler monkeypatches RubyGems, so we're actually testing Bundler monkeypatches, not RubyGems in isolation.

## What is your fix for the problem, implemented in this PR?

No fix, but this changeset tries to improve the situation.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
