### PR TITLE
Fix generic arm platform matching against runtime arm platforms with eabi modifiers

### DIFF
--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -261,7 +261,7 @@ module Gem
           # version
           (
             (@os != "linux" && (@version.nil? || other.version.nil?)) ||
-            (@os == "linux" && (normalized_linux_version_ext == other.normalized_linux_version_ext || other.version == "musl#{@version}" || other.version == "musleabi#{@version}")) ||
+            (@os == "linux" && (normalized_linux_version_ext == other.normalized_linux_version_ext || ["musl#{@version}", "musleabi#{@version}", "musleabihf#{@version}"].include?(other.version))) ||
             @version == other.version
           )
       end
@@ -271,7 +271,7 @@ module Gem
       def normalized_linux_version_ext
         return nil unless @version
 
-        without_gnu_nor_abi_modifiers = @version.sub(/\Agnu/, "").sub(/eabi\Z/, "")
+        without_gnu_nor_abi_modifiers = @version.sub(/\Agnu/, "").sub(/eabi(hf)?\Z/, "")
         return nil if without_gnu_nor_abi_modifiers.empty?
 
         without_gnu_nor_abi_modifiers

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -261,9 +261,20 @@ module Gem
           # version
           (
             (@os != "linux" && (@version.nil? || other.version.nil?)) ||
-            (@os == "linux" && (other.version == "gnu#{@version}" || other.version == "musl#{@version}" || @version == "gnu#{other.version}")) ||
+            (@os == "linux" && (normalized_linux_version_ext == other.normalized_linux_version_ext || other.version == "musl#{@version}")) ||
             @version == other.version
           )
+      end
+
+      # This is a copy of RubyGems 3.3.23 or higher `normalized_linux_method`.
+      # Once only 3.3.23 is supported, we can use the method in RubyGems.
+      def normalized_linux_version_ext
+        return nil unless @version
+
+        without_gnu = @version.sub(/\Agnu/, "")
+        return nil if without_gnu.empty?
+
+        without_gnu
       end
     end
   end

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -261,7 +261,7 @@ module Gem
           # version
           (
             (@os != "linux" && (@version.nil? || other.version.nil?)) ||
-            (@os == "linux" && (normalized_linux_version_ext == other.normalized_linux_version_ext || other.version == "musl#{@version}")) ||
+            (@os == "linux" && (normalized_linux_version_ext == other.normalized_linux_version_ext || other.version == "musl#{@version}" || other.version == "musleabi#{@version}")) ||
             @version == other.version
           )
       end
@@ -271,10 +271,10 @@ module Gem
       def normalized_linux_version_ext
         return nil unless @version
 
-        without_gnu = @version.sub(/\Agnu/, "")
-        return nil if without_gnu.empty?
+        without_gnu_nor_abi_modifiers = @version.sub(/\Agnu/, "").sub(/eabi\Z/, "")
+        return nil if without_gnu_nor_abi_modifiers.empty?
 
-        without_gnu
+        without_gnu_nor_abi_modifiers
       end
     end
   end

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -181,7 +181,7 @@ class Gem::Platform
       # version
       (
         (@os != "linux" && (@version.nil? || other.version.nil?)) ||
-        (@os == "linux" && (normalized_linux_version == other.normalized_linux_version || other.version == "musl#{@version}" || other.version == "musleabi#{@version}")) ||
+        (@os == "linux" && (normalized_linux_version == other.normalized_linux_version || ["musl#{@version}", "musleabi#{@version}", "musleabihf#{@version}"].include?(other.version))) ||
         @version == other.version
       )
   end
@@ -189,7 +189,7 @@ class Gem::Platform
   def normalized_linux_version
     return nil unless @version
 
-    without_gnu_nor_abi_modifiers = @version.sub(/\Agnu/, "").sub(/eabi\Z/, "")
+    without_gnu_nor_abi_modifiers = @version.sub(/\Agnu/, "").sub(/eabi(hf)?\Z/, "")
     return nil if without_gnu_nor_abi_modifiers.empty?
 
     without_gnu_nor_abi_modifiers

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -163,6 +163,9 @@ class Gem::Platform
   # runtime platform "no version" stands for 'gnu'. To be able to disinguish
   # these, the method receiver is the gem platform, while the argument is
   # the runtime platform.
+  #
+  #--
+  # NOTE: Until it can be removed, changes to this method must also be reflected in `bundler/lib/bundler/rubygems_ext.rb`
 
   def ===(other)
     return nil unless Gem::Platform === other
@@ -185,6 +188,9 @@ class Gem::Platform
         @version == other.version
       )
   end
+
+  #--
+  # NOTE: Until it can be removed, changes to this method must also be reflected in `bundler/lib/bundler/rubygems_ext.rb`
 
   def normalized_linux_version
     return nil unless @version

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -181,7 +181,7 @@ class Gem::Platform
       # version
       (
         (@os != "linux" && (@version.nil? || other.version.nil?)) ||
-        (@os == "linux" && (normalized_linux_version == other.normalized_linux_version || other.version == "musl#{@version}")) ||
+        (@os == "linux" && (normalized_linux_version == other.normalized_linux_version || other.version == "musl#{@version}" || other.version == "musleabi#{@version}")) ||
         @version == other.version
       )
   end
@@ -189,10 +189,10 @@ class Gem::Platform
   def normalized_linux_version
     return nil unless @version
 
-    without_gnu = @version.sub(/\Agnu/, "")
-    return nil if without_gnu.empty?
+    without_gnu_nor_abi_modifiers = @version.sub(/\Agnu/, "").sub(/eabi\Z/, "")
+    return nil if without_gnu_nor_abi_modifiers.empty?
 
-    without_gnu
+    without_gnu_nor_abi_modifiers
   end
 
   ##

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -181,9 +181,18 @@ class Gem::Platform
       # version
       (
         (@os != "linux" && (@version.nil? || other.version.nil?)) ||
-        (@os == "linux" && (other.version == "gnu#{@version}" || other.version == "musl#{@version}" || @version == "gnu#{other.version}")) ||
+        (@os == "linux" && (normalized_linux_version == other.normalized_linux_version || other.version == "musl#{@version}")) ||
         @version == other.version
       )
+  end
+
+  def normalized_linux_version
+    return nil unless @version
+
+    without_gnu = @version.sub(/\Agnu/, "")
+    return nil if without_gnu.empty?
+
+    without_gnu
   end
 
   ##

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -336,21 +336,29 @@ class TestGemPlatform < Gem::TestCase
   def test_eabi_and_nil_version_combination_strictness
     arm_linux = Gem::Platform.new "arm-linux"
     arm_linux_eabi = Gem::Platform.new "arm-linux-eabi"
+    arm_linux_eabihf = Gem::Platform.new "arm-linux-eabihf"
     arm_linux_gnueabi = Gem::Platform.new "arm-linux-gnueabi"
+    arm_linux_gnueabihf = Gem::Platform.new "arm-linux-gnueabihf"
     arm_linux_musleabi = Gem::Platform.new "arm-linux-musleabi"
+    arm_linux_musleabihf = Gem::Platform.new "arm-linux-musleabihf"
     arm_linux_uclibceabi = Gem::Platform.new "arm-linux-uclibceabi"
+    arm_linux_uclibceabihf = Gem::Platform.new "arm-linux-uclibceabihf"
 
     # generic arm host runtime with eabi modifier accepts generic arm gems
     assert(arm_linux === arm_linux_eabi, "arm-linux =~ arm-linux-eabi")
+    assert(arm_linux === arm_linux_eabihf, "arm-linux =~ arm-linux-eabihf")
 
     # explicit gnu arm host runtime with eabi modifier accepts generic arm gems
     assert(arm_linux === arm_linux_gnueabi, "arm-linux =~ arm-linux-gnueabi")
+    assert(arm_linux === arm_linux_gnueabihf, "arm-linux =~ arm-linux-gnueabihf")
 
     # musl arm host runtime accepts libc-generic or statically linked gems...
     assert(arm_linux === arm_linux_musleabi, "arm-linux =~ arm-linux-musleabi")
+    assert(arm_linux === arm_linux_musleabihf, "arm-linux =~ arm-linux-musleabihf")
 
     # other libc arm hosts are not glibc compatible
     refute(arm_linux === arm_linux_uclibceabi, "arm-linux =~ arm-linux-uclibceabi")
+    refute(arm_linux === arm_linux_uclibceabihf, "arm-linux =~ arm-linux-uclibceabihf")
   end
 
   def test_equals3_cpu_arm

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -333,6 +333,26 @@ class TestGemPlatform < Gem::TestCase
     refute(arm_linux_uclibceabi === arm_linux_eabi, "linux-uclibceabi =~ linux-eabi")
   end
 
+  def test_eabi_and_nil_version_combination_strictness
+    arm_linux = Gem::Platform.new "arm-linux"
+    arm_linux_eabi = Gem::Platform.new "arm-linux-eabi"
+    arm_linux_gnueabi = Gem::Platform.new "arm-linux-gnueabi"
+    arm_linux_musleabi = Gem::Platform.new "arm-linux-musleabi"
+    arm_linux_uclibceabi = Gem::Platform.new "arm-linux-uclibceabi"
+
+    # generic arm host runtime with eabi modifier accepts generic arm gems
+    assert(arm_linux === arm_linux_eabi, "arm-linux =~ arm-linux-eabi")
+
+    # explicit gnu arm host runtime with eabi modifier accepts generic arm gems
+    assert(arm_linux === arm_linux_gnueabi, "arm-linux =~ arm-linux-gnueabi")
+
+    # musl arm host runtime accepts libc-generic or statically linked gems...
+    assert(arm_linux === arm_linux_musleabi, "arm-linux =~ arm-linux-musleabi")
+
+    # other libc arm hosts are not glibc compatible
+    refute(arm_linux === arm_linux_uclibceabi, "arm-linux =~ arm-linux-uclibceabi")
+  end
+
   def test_equals3_cpu_arm
     arm   = Gem::Platform.new "arm-linux"
     armv5 = Gem::Platform.new "armv5-linux"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since RubyGems 3.3.20, arm platforms with eabi modifiers no longer accept generic `arm-linux` gems.

## What is your fix for the problem, implemented in this PR?

My fix is to refactor platform comparison so that eabi modifiers are properly ignored, except for the musl special case.

Fixes #5940.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
