### PR TITLE
Prevent a "warning: assigned but unused variable - data"

### DIFF
--- a/test/rubygems/utilities.rb
+++ b/test/rubygems/utilities.rb
@@ -93,7 +93,7 @@ class Gem::FakeFetcher
 
   # Thanks, FakeWeb!
   def open_uri_or_path(path)
-    data = find_data(path)
+    find_data(path)
 
     create_response(uri)
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The test of rubygems prints a noisy warning in rubyci.org

```
$ rake
/home/mame/work/rubygems/test/rubygems/utilities.rb:96: warning: assigned but unused variable - data
...
```

## What is your fix for the problem, implemented in this PR?

Prevent the warning

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
