### PR TITLE
Revert "Cleaup unnecessary code"

### DIFF
--- a/test/rubygems/rubygems_plugin.rb
+++ b/test/rubygems/rubygems_plugin.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 require "rubygems/command_manager"
 
+##
+# This is an example of exactly what NOT to do.
+#
+# DO NOT include code like this in your rubygems_plugin.rb
+
+module Gem::Commands
+  remove_const(:InterruptCommand) if defined?(InterruptCommand)
+end
+
 class Gem::Commands::InterruptCommand < Gem::Command
   def initialize
     super("interrupt", "Raises an Interrupt Exception", {})

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -20,6 +20,8 @@ class TestGem < Gem::TestCase
     common_installer_setup
 
     @additional = %w[a b].map {|d| File.join @tempdir, d }
+
+    util_remove_interrupt_command
   end
 
   def test_self_finish_resolve
@@ -1548,9 +1550,13 @@ class TestGem < Gem::TestCase
     with_plugin("load") { Gem.load_env_plugins }
     assert_equal :loaded, TEST_PLUGIN_LOAD rescue nil
 
+    util_remove_interrupt_command
+
     # Should attempt to cause a StandardError
     with_plugin("standarderror") { Gem.load_env_plugins }
     assert_equal :loaded, TEST_PLUGIN_STANDARDERROR rescue nil
+
+    util_remove_interrupt_command
 
     # Should attempt to cause an Exception
     with_plugin("exception") { Gem.load_env_plugins }
@@ -2099,6 +2105,11 @@ You may need to `bundle install` to install missing gems
     @exec_path = File.join spec.full_gem_path, spec.bindir, "exec"
     @abin_path = File.join spec.full_gem_path, spec.bindir, "abin"
     spec
+  end
+
+  def util_remove_interrupt_command
+    Gem::Commands.send :remove_const, :InterruptCommand if
+      Gem::Commands.const_defined? :InterruptCommand
   end
 
   def util_cache_dir


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Unclear why, but 2e05dadbc5dec1e87b807eca32cb6f68439f1542 created some warnings in ruby-core CI.

## What is your fix for the problem, implemented in this PR?

Revert it.

Closes #5959.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
