### PR TITLE
Make sure RSpec diffs don't omit the different part

### DIFF
--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -58,6 +58,8 @@ RSpec.configure do |config|
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
+
+    c.max_formatted_output_length = 1000
   end
 
   config.mock_with :rspec do |mocks|


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We sometimes check assertions on lockfile contents, which involves comparing a reasonably long string. Sometimes RSpec is not able to show the part of the string that's actually different, making it hard to figure out the issue.

## What is your fix for the problem, implemented in this PR?

Configuring this setting should fix the issue in most cases.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
