### PR TITLE
Fix little UI issue when bundler shows duplicated gems in a list

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -140,7 +140,7 @@ module Bundler
         @unlock[:gems] ||= @dependencies.map(&:name)
       else
         eager_unlock = expand_dependencies(@unlock[:gems] || [], true)
-        @unlock[:gems] = @locked_specs.for(eager_unlock, false, platforms).map(&:name)
+        @unlock[:gems] = @locked_specs.for(eager_unlock, false, platforms).map(&:name).uniq
       end
 
       @dependency_changes = converge_dependencies

--- a/bundler/spec/bundler/definition_spec.rb
+++ b/bundler/spec/bundler/definition_spec.rb
@@ -82,6 +82,24 @@ RSpec.describe Bundler::Definition do
       G
     end
 
+    it "with an explicit update" do
+      build_repo4 do
+        build_gem("ffi", "1.9.23") {|s| s.platform = "java" }
+        build_gem("ffi", "1.9.23")
+      end
+
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo4)}"
+        gem "ffi"
+      G
+
+      bundle "lock --add-platform java"
+
+      bundle "update ffi", :env => { "DEBUG" => "1" }
+
+      expect(out).to match(/because bundler is unlocking gems: \(ffi\)/)
+    end
+
     it "for a path gem with deps and no changes" do
       build_lib "foo", "1.0", :path => lib_path("foo") do |s|
         s.add_dependency "rack", "1.0"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes, when explicitly updating a dependency locked under multiple platforms, Bundler will show the following logs:

```
$ bundle update ffi --verbose
Running `bundle update ffi` with bundler 2.4.0.dev
Found changes from the lockfile, re-resolving dependencies because bundler is unlocking gems: (ffi, ffi)
(...)
```

Not the duplicated ffi name.

## What is your fix for the problem, implemented in this PR?

My fix is to deduplicate this list.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
