### PR TITLE
Changelogs for RubyGems 3.3.23 and Bundler 2.3.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+# 3.3.23 / 2022-10-05
+
+## Enhancements:
+
+* Add better error handling for permanent redirect responses. Pull request
+  #5931 by jenshenny
+* Installs bundler 2.3.23 as a default gem.
+
+## Bug fixes:
+
+* Fix generic arm platform matching against runtime arm platforms with
+  eabi modifiers. Pull request #5957 by deivid-rodriguez
+* Fix `Gem::Platform.match` not handling String argument properly. Pull
+  request #5939 by flavorjones
+* Fix resolution on non-musl platforms. Pull request #5915 by
+  deivid-rodriguez
+* Mask the file mode when extracting files. Pull request #5906 by
+  kddnewton
+
 # 3.3.22 / 2022-09-07
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 2.3.23 (October 5, 2022)
+
+## Enhancements:
+
+  - Update GitLab CI template with new one [#5944](https://github.com/rubygems/rubygems/pull/5944)
+
+## Bug fixes:
+
+  - Fix `bundle init` not respecting umask in generated gem's Gemfile [#5947](https://github.com/rubygems/rubygems/pull/5947)
+
+## Performance:
+
+  - Further speed up Bundler by not sorting specs unnecessarily [#5868](https://github.com/rubygems/rubygems/pull/5868)
+
+## Documentation:
+
+  - Update Bundler new feature instructions [#5912](https://github.com/rubygems/rubygems/pull/5912)
+
 # 2.3.22 (September 7, 2022)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.3.23 and Bundler 2.3.23 into master.