### PR TITLE
Fix incorrect materialization on Windows

### DIFF
--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -121,5 +121,8 @@ jobs:
       - name: Check we can install a Gemfile with git sources
         run: bundle init && bundle add fileutils --git https://github.com/ruby/fileutils
         shell: bash
+      - name: Generate a Rails application
+        run: gem install rails && rails new foo
+        shell: bash
 
     timeout-minutes: 10

--- a/bundler/lib/bundler/gem_helpers.rb
+++ b/bundler/lib/bundler/gem_helpers.rb
@@ -5,7 +5,6 @@ module Bundler
     GENERIC_CACHE = { Gem::Platform::RUBY => Gem::Platform::RUBY } # rubocop:disable Style/MutableConstant
     GENERICS = [
       [Gem::Platform.new("java"), Gem::Platform.new("java")],
-      [Gem::Platform.new("universal-java"), Gem::Platform.new("java")],
       [Gem::Platform.new("mswin32"), Gem::Platform.new("mswin32")],
       [Gem::Platform.new("mswin64"), Gem::Platform.new("mswin64")],
       [Gem::Platform.new("universal-mingw32"), Gem::Platform.new("universal-mingw32")],

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -77,7 +77,7 @@ module Bundler
       source.local!
 
       candidates = if source.is_a?(Source::Path) || !ruby_platform_materializes_to_ruby_platform?
-        target_platform = ruby_platform_materializes_to_ruby_platform? ? platform : Bundler.local_platform
+        target_platform = ruby_platform_materializes_to_ruby_platform? ? platform : local_platform
 
         source.specs.search(Dependency.new(name, version)).select do |spec|
           MatchPlatform.platforms_match?(spec.platform, target_platform)

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -144,7 +144,8 @@ module Bundler
 
     #
     # For backwards compatibility with existing lockfiles, if the most specific
-    # locked platform is RUBY, we keep the previous behaviour of resolving the
+    # locked platform is not a specific platform like x86_64-linux or
+    # universal-java-11, then we keep the previous behaviour of resolving the
     # best platform variant at materiliazation time. For previous bundler
     # versions (before 2.2.0) this was always the case (except when the lockfile
     # only included non-ruby platforms), but we're also keeping this behaviour
@@ -152,7 +153,9 @@ module Bundler
     # explicitly add a more specific platform.
     #
     def ruby_platform_materializes_to_ruby_platform?
-      !Bundler.most_specific_locked_platform?(generic_local_platform) || force_ruby_platform || Bundler.settings[:force_ruby_platform]
+      generic_platform = generic_local_platform == Gem::Platform::JAVA ? Gem::Platform::JAVA : Gem::Platform::RUBY
+
+      !Bundler.most_specific_locked_platform?(generic_platform) || force_ruby_platform || Bundler.settings[:force_ruby_platform]
     end
   end
 end

--- a/bundler/lib/bundler/remote_specification.rb
+++ b/bundler/lib/bundler/remote_specification.rb
@@ -30,14 +30,14 @@ module Bundler
     end
 
     def identifier
-      @__identifier ||= [name, version, @original_platform.to_s]
+      @__identifier ||= [name, version, @platform.to_s]
     end
 
     def full_name
-      if @original_platform == Gem::Platform::RUBY
+      if @platform == Gem::Platform::RUBY
         "#{@name}-#{@version}"
       else
-        "#{@name}-#{@version}-#{@original_platform}"
+        "#{@name}-#{@version}-#{@platform}"
       end
     end
 

--- a/bundler/spec/bundler/remote_specification_spec.rb
+++ b/bundler/spec/bundler/remote_specification_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Bundler::RemoteSpecification do
       let(:platform) { "jruby" }
 
       it "should return the spec name, version, and platform" do
-        expect(subject.full_name).to eq("foo-1.0.0-jruby")
+        expect(subject.full_name).to eq("foo-1.0.0-java")
       end
     end
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I did some cleanups recently to avoid unnecessary sorting and speed things up at #5868. But [one change in particular](https://github.com/rubygems/rubygems/pull/5868/commits/3cea25a39de30b3025e2dddc6a07bf3f216e92e0) caused issues on Windows.

## What is your fix for the problem, implemented in this PR?

I identified this code here: https://github.com/rubygems/rubygems/blob/629e08d34d14f60fe3398e40fc72f4f171ffc582/bundler/lib/bundler/lazy_specification.rb#L82-L84 was relying on the index search returning a particular order.

I think we'll probably need to revert that commit but I also found that this code should not be being hit by default on Windows, since it's only a fallback for backwards compatibility with lockfiles using `ruby` or `java` as their main platform, and that's not the case on Windows.

This commit fixes that latter issue and adds a realworld CI test that installs Rails and generates a dummy application on Windows, to hopefully avoid this kind of widespread issues on Windows in the future.

Fixes #5970.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
