### PR TITLE
Map 'universal' to the real arch in Bundler for prebuilt gem selection

### DIFF
--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -310,7 +310,7 @@ module Gem
 
   # On universal Rubies, resolve the "universal" arch to the real CPU arch, without changing the extension directory.
   class Specification
-    if /^universal\.(?<arch>.*?)-/ =~ RUBY_PLATFORM
+    if /^universal\.(?<arch>.*?)-/ =~ (CROSS_COMPILING || RUBY_PLATFORM)
       local_platform = Platform.local
       if local_platform.cpu == "universal"
         ORIGINAL_LOCAL_PLATFORM = local_platform.to_s.freeze

--- a/bundler/spec/support/hax.rb
+++ b/bundler/spec/support/hax.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+if ENV["BUNDLER_SPEC_RUBY_PLATFORM"]
+  Object.send(:remove_const, :RUBY_PLATFORM)
+  RUBY_PLATFORM = ENV["BUNDLER_SPEC_RUBY_PLATFORM"]
+end
+
 module Gem
   def self.ruby=(ruby)
     @ruby = ruby

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -432,6 +432,14 @@ module Spec
       pristine_system_gems :bundler
     end
 
+    def simulate_ruby_platform(ruby_platform)
+      old = ENV["BUNDLER_SPEC_RUBY_PLATFORM"]
+      ENV["BUNDLER_SPEC_RUBY_PLATFORM"] = ruby_platform.to_s
+      yield
+    ensure
+      ENV["BUNDLER_SPEC_RUBY_PLATFORM"] = old
+    end
+
     def simulate_platform(platform)
       old = ENV["BUNDLER_SPEC_PLATFORM"]
       ENV["BUNDLER_SPEC_PLATFORM"] = platform.to_s


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

#4234 - Bundler may choose the wrong prebuilt gem architecture for universal Ruby builds

## What is your fix for the problem, implemented in this PR?

The fix is to adjust `Gem:Platform.local` to change the `universal` CPU to the real architecture, so it will pick the correct prebuilt gem. If the gem is available as a universal build, it will still be able to pick that.

I did so while retaining the value of `extensions_dir`. This is so the default extension directory for that Ruby is unchanged (still `universal-darwin-XX`), which will retain compatibility should anything be executed outside of Bundler.

This fix can be ported to Rubygems too if desired. I personally don't need to however.

In regards to "arm64e", I suppose an alternative fix there would've been to incorporate that in `Gem::Platform` somewhere, like how `i386` is mapped to `x86`. Technically arm64e is a different ABI to arm64, but they are interoperable and this the different is largely irrelevant for now because there should be no `arm64e-darwin*` gems on rubygems.org yet as only Apple-provided system binaries can run that architecture at the moment without jumping through boot arg hoops.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
