### PR TITLE
Make rubocop script use in-tree Bundler

### DIFF
--- a/util/rubocop
+++ b/util/rubocop
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+$LOAD_PATH.unshift(File.expand_path("../bundler/lib", __dir__))
+
 ENV["BUNDLE_GEMFILE"] = File.expand_path("../bundler/tool/bundler/lint_gems.rb", __dir__)
 require "bundler/setup"
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

On a system with Bundler 1 installed (e.g. default macOS), `rake rubocop` will error:

```
Using ast 2.4.2
Using bundler 2.4.0.dev
Using parallel 1.22.1
Using parser 3.1.2.0
Using rainbow 3.1.1
Using regexp_parser 2.5.0
Using rexml 3.2.5
Using rubocop-ast 1.18.0
Using ruby-progressbar 1.11.0
Using unicode-display_width 2.1.0
Using rubocop 1.30.1
Using rubocop-performance 1.14.2
Bundle complete! 2 Gemfile dependencies, 12 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
You must use Bundler 2 or greater with this lockfile.
rake aborted!
Command failed with status (20): [util/rubocop...]
```

## What is your fix for the problem, implemented in this PR?

Considering the lockfiles are created and installed by the in-tree Bundler, the fix was to make it so the `util/rubocop` script invoked the in-tree `bundler/setup` too.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
