### PR TITLE
Changelogs for RubyGems 3.3.24 and Bundler 2.3.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.3.24 / 2022-10-17
+
+## Enhancements:
+
+* Installs bundler 2.3.24 as a default gem.
+
 # 3.3.23 / 2022-10-05
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 2.3.24 (October 17, 2022)
+
+## Enhancements:
+
+  - Only add extra resolver spec group for Ruby platform when needed [#5698](https://github.com/rubygems/rubygems/pull/5698)
+  - Fix little UI issue when bundler shows duplicated gems in a list [#5965](https://github.com/rubygems/rubygems/pull/5965)
+
+## Bug fixes:
+
+  - Fix incorrect materialization on Windows [#5975](https://github.com/rubygems/rubygems/pull/5975)
+
 # 2.3.23 (October 5, 2022)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.3.24 and Bundler 2.3.24 into master.