### PR TITLE
Fix `github` DSL docs to mention they use https protocol over git under the hood

### DIFF
--- a/bundler/lib/bundler/man/bundle-add.1
+++ b/bundler/lib/bundler/man/bundle-add.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-ADD" "1" "September 2022" "" ""
+.TH "BUNDLE\-ADD" "1" "October 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-add\fR \- Add gem to the Gemfile and run bundle install

--- a/bundler/lib/bundler/man/bundle-binstubs.1
+++ b/bundler/lib/bundler/man/bundle-binstubs.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-BINSTUBS" "1" "September 2022" "" ""
+.TH "BUNDLE\-BINSTUBS" "1" "October 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-binstubs\fR \- Install the binstubs of the listed gems

--- a/bundler/lib/bundler/man/bundle-cache.1
+++ b/bundler/lib/bundler/man/bundle-cache.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CACHE" "1" "September 2022" "" ""
+.TH "BUNDLE\-CACHE" "1" "October 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-cache\fR \- Package your needed \fB\.gem\fR files into your application

--- a/bundler/lib/bundler/man/bundle-check.1
+++ b/bundler/lib/bundler/man/bundle-check.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CHECK" "1" "September 2022" "" ""
+.TH "BUNDLE\-CHECK" "1" "October 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-check\fR \- Verifies if dependencies are satisfied by installed gems

--- a/bundler/lib/bundler/man/bundle-clean.1
+++ b/bundler/lib/bundler/man/bundle-clean.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CLEAN" "1" "September 2022" "" ""
+.TH "BUNDLE\-CLEAN" "1" "October 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-clean\fR \- Cleans up unused gems in your bundler directory

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CONFIG" "1" "September 2022" "" ""
+.TH "BUNDLE\-CONFIG" "1" "October 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-config\fR \- Set bundler configuration options

--- a/bundler/lib/bundler/man/bundle-console.1
+++ b/bundler/lib/bundler/man/bundle-console.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CONSOLE" "1" "September 2022" "" ""
+.TH "BUNDLE\-CONSOLE" "1" "October 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-console\fR \- Deprecated way to open an IRB session with the bundle pre\-loaded

--- a/bundler/lib/bundler/man/bundle-doctor.1
+++ b/bundler/lib/bundler/man/bundle-doctor.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-DOCTOR" "1" "September 2022" "" ""
+.TH "BUNDLE\-DOCTOR" "1" "October 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-doctor\fR \- Checks the bundle for common problems

--- a/bundler/lib/bundler/man/bundle-exec.1
+++ b/bundler/lib/bundler/man/bundle-exec.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-EXEC" "1" "September 2022" "" ""
+.TH "BUNDLE\-EXEC" "1" "October 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-exec\fR \- Execute a command in the context of the bundle

--- a/bundler/lib/bundler/man/bundle-gem.1
+++ b/bundler/lib/bundler/man/bundle-gem.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-GEM" "1" "September 2022" "" ""
+.TH "BUNDLE\-GEM" "1" "October 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-gem\fR \- Generate a project skeleton for creating a rubygem

--- a/bundler/lib/bundler/man/bundle-help.1
+++ b/bundler/lib/bundler/man/bundle-help.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-HELP" "1" "September 2022" "" ""
+.TH "BUNDLE\-HELP" "1" "October 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-help\fR \- Displays detailed help for each subcommand

--- a/bundler/lib/bundler/man/bundle-info.1
+++ b/bundler/lib/bundler/man/bundle-info.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INFO" "1" "September 2022" "" ""
+.TH "BUNDLE\-INFO" "1" "October 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-info\fR \- Show information for the given gem in your bundle

--- a/bundler/lib/bundler/man/bundle-init.1
+++ b/bundler/lib/bundler/man/bundle-init.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INIT" "1" "September 2022" "" ""
+.TH "BUNDLE\-INIT" "1" "October 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-init\fR \- Generates a Gemfile into the current working directory

--- a/bundler/lib/bundler/man/bundle-inject.1
+++ b/bundler/lib/bundler/man/bundle-inject.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INJECT" "1" "September 2022" "" ""
+.TH "BUNDLE\-INJECT" "1" "October 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-inject\fR \- Add named gem(s) with version requirements to Gemfile

--- a/bundler/lib/bundler/man/bundle-install.1
+++ b/bundler/lib/bundler/man/bundle-install.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INSTALL" "1" "September 2022" "" ""
+.TH "BUNDLE\-INSTALL" "1" "October 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-install\fR \- Install the dependencies specified in your Gemfile

--- a/bundler/lib/bundler/man/bundle-list.1
+++ b/bundler/lib/bundler/man/bundle-list.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-LIST" "1" "September 2022" "" ""
+.TH "BUNDLE\-LIST" "1" "October 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-list\fR \- List all the gems in the bundle

--- a/bundler/lib/bundler/man/bundle-lock.1
+++ b/bundler/lib/bundler/man/bundle-lock.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-LOCK" "1" "September 2022" "" ""
+.TH "BUNDLE\-LOCK" "1" "October 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-lock\fR \- Creates / Updates a lockfile without installing

--- a/bundler/lib/bundler/man/bundle-open.1
+++ b/bundler/lib/bundler/man/bundle-open.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-OPEN" "1" "September 2022" "" ""
+.TH "BUNDLE\-OPEN" "1" "October 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-open\fR \- Opens the source directory for a gem in your bundle

--- a/bundler/lib/bundler/man/bundle-outdated.1
+++ b/bundler/lib/bundler/man/bundle-outdated.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-OUTDATED" "1" "September 2022" "" ""
+.TH "BUNDLE\-OUTDATED" "1" "October 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-outdated\fR \- List installed gems with newer versions available

--- a/bundler/lib/bundler/man/bundle-platform.1
+++ b/bundler/lib/bundler/man/bundle-platform.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-PLATFORM" "1" "September 2022" "" ""
+.TH "BUNDLE\-PLATFORM" "1" "October 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-platform\fR \- Displays platform compatibility information

--- a/bundler/lib/bundler/man/bundle-plugin.1
+++ b/bundler/lib/bundler/man/bundle-plugin.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-PLUGIN" "1" "September 2022" "" ""
+.TH "BUNDLE\-PLUGIN" "1" "October 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-plugin\fR \- Manage Bundler plugins

--- a/bundler/lib/bundler/man/bundle-pristine.1
+++ b/bundler/lib/bundler/man/bundle-pristine.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-PRISTINE" "1" "September 2022" "" ""
+.TH "BUNDLE\-PRISTINE" "1" "October 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-pristine\fR \- Restores installed gems to their pristine condition

--- a/bundler/lib/bundler/man/bundle-remove.1
+++ b/bundler/lib/bundler/man/bundle-remove.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-REMOVE" "1" "September 2022" "" ""
+.TH "BUNDLE\-REMOVE" "1" "October 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-remove\fR \- Removes gems from the Gemfile

--- a/bundler/lib/bundler/man/bundle-show.1
+++ b/bundler/lib/bundler/man/bundle-show.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-SHOW" "1" "September 2022" "" ""
+.TH "BUNDLE\-SHOW" "1" "October 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-show\fR \- Shows all the gems in your bundle, or the path to a gem

--- a/bundler/lib/bundler/man/bundle-update.1
+++ b/bundler/lib/bundler/man/bundle-update.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-UPDATE" "1" "September 2022" "" ""
+.TH "BUNDLE\-UPDATE" "1" "October 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-update\fR \- Update your gems to the latest available versions

--- a/bundler/lib/bundler/man/bundle-version.1
+++ b/bundler/lib/bundler/man/bundle-version.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-VERSION" "1" "September 2022" "" ""
+.TH "BUNDLE\-VERSION" "1" "October 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-version\fR \- Prints Bundler version information

--- a/bundler/lib/bundler/man/bundle-viz.1
+++ b/bundler/lib/bundler/man/bundle-viz.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-VIZ" "1" "September 2022" "" ""
+.TH "BUNDLE\-VIZ" "1" "October 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\-viz\fR \- Generates a visual dependency graph for your Gemfile

--- a/bundler/lib/bundler/man/bundle.1
+++ b/bundler/lib/bundler/man/bundle.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE" "1" "September 2022" "" ""
+.TH "BUNDLE" "1" "October 2022" "" ""
 .
 .SH "NAME"
 \fBbundle\fR \- Ruby Dependency Management

--- a/bundler/lib/bundler/man/gemfile.5
+++ b/bundler/lib/bundler/man/gemfile.5
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GEMFILE" "5" "September 2022" "" ""
+.TH "GEMFILE" "5" "October 2022" "" ""
 .
 .SH "NAME"
 \fBGemfile\fR \- A format for describing gem dependencies for Ruby programs
@@ -497,7 +497,7 @@ Are both equivalent to
 .
 .nf
 
-gem "rails", git: "git://github\.com/rails/rails\.git"
+gem "rails", git: "https://github\.com/rails/rails\.git"
 .
 .fi
 .

--- a/bundler/lib/bundler/man/gemfile.5.ronn
+++ b/bundler/lib/bundler/man/gemfile.5.ronn
@@ -369,7 +369,7 @@ same, you can omit one.
 
 Are both equivalent to
 
-    gem "rails", git: "git://github.com/rails/rails.git"
+    gem "rails", git: "https://github.com/rails/rails.git"
 
 Since the `github` method is a specialization of `git_source`, it accepts a `:branch` named argument.
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`github` option in `gem` in `Gemfile` has meant using `https://github.com` (`https` protocol) instead of `git://github.com` (`git` protocol), which was made in Bundler 2.2.0, but the document https://bundler.io/v2.3/man/gemfile.5.html#GITHUB is obsolete.

## What is your fix for the problem, implemented in this PR?

Fixes the document for `Gemfile(5)` to align with the implementation on Bundler 2.2 or higher. This changes only Bundler 2.3 docs and backporting to [docs for Bundler 2.2](https://bundler.io/v2.2/man/gemfile.5.html#GITHUB) is not expected as this is minor.

- Follows up https://github.com/rubygems/bundler/pull/7142

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [n/a] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
