### PR TITLE
Followed up CVE-2022-39253 for bundler examples

### DIFF
--- a/bundler/spec/cache/git_spec.rb
+++ b/bundler/spec/cache/git_spec.rb
@@ -156,6 +156,9 @@ RSpec.describe "bundle cache with git" do
   end
 
   it "copies repository to vendor cache, including submodules" do
+    # CVE-2022-39253: https://lore.kernel.org/lkml/xmqq4jw1uku5.fsf@gitster.g/
+    system(*%W[git config --global protocol.file.allow always])
+
     build_git "submodule", "1.0"
 
     git = build_git "has_submodule", "1.0" do |s|

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -865,6 +865,9 @@ RSpec.describe "bundle install with git sources" do
   end
 
   it "ignores submodules if :submodule is not passed" do
+    # CVE-2022-39253: https://lore.kernel.org/lkml/xmqq4jw1uku5.fsf@gitster.g/
+    system(*%W[git config --global protocol.file.allow always])
+
     build_git "submodule", "1.0"
     build_git "has_submodule", "1.0" do |s|
       s.add_dependency "submodule"
@@ -884,6 +887,9 @@ RSpec.describe "bundle install with git sources" do
   end
 
   it "handles repos with submodules" do
+    # CVE-2022-39253: https://lore.kernel.org/lkml/xmqq4jw1uku5.fsf@gitster.g/
+    system(*%W[git config --global protocol.file.allow always])
+
     build_git "submodule", "1.0"
     build_git "has_submodule", "1.0" do |s|
       s.add_dependency "submodule"
@@ -902,6 +908,9 @@ RSpec.describe "bundle install with git sources" do
   end
 
   it "does not warn when deiniting submodules" do
+    # CVE-2022-39253: https://lore.kernel.org/lkml/xmqq4jw1uku5.fsf@gitster.g/
+    system(*%W[git config --global protocol.file.allow always])
+
     build_git "submodule", "1.0"
     build_git "has_submodule", "1.0"
 

--- a/bundler/spec/update/git_spec.rb
+++ b/bundler/spec/update/git_spec.rb
@@ -124,6 +124,9 @@ RSpec.describe "bundle update" do
 
     describe "with submodules" do
       before :each do
+        # CVE-2022-39253: https://lore.kernel.org/lkml/xmqq4jw1uku5.fsf@gitster.g/
+        system(*%W[git config --global protocol.file.allow always])
+
         build_repo4 do
           build_gem "submodule" do |s|
             s.write "lib/submodule.rb", "puts 'GEM'"


### PR DESCRIPTION
We need to resolve the bundler examples same as https://github.com/rubygems/rubygems/pull/5998