### PR TITLE
Allow upcoming JRuby to pass keywords to Kernel#warn

### DIFF
--- a/lib/rubygems/core_ext/kernel_warn.rb
+++ b/lib/rubygems/core_ext/kernel_warn.rb
@@ -16,7 +16,7 @@ if RUBY_VERSION >= "2.5" && !Gem::KERNEL_WARN_IGNORES_INTERNAL_ENTRIES
 
     module_function define_method(:warn) {|*messages, **kw|
       unless uplevel = kw[:uplevel]
-        if Gem.java_platform?
+        if Gem.java_platform? && RUBY_VERSION < "3.1"
           return original_warn.bind(self).call(*messages)
         else
           return original_warn.bind(self).call(*messages, **kw)


### PR DESCRIPTION

## What was the end-user or developer problem that led to this PR?

rubtygems monkey patches Kernel#warn making it impossible for JRuby to pass any Ruby warning category features (or uplevel).

## What is your fix for the problem, implemented in this PR?

jruby-head (which will be JRuby 9.4.0.0) can now properly process the keywords to Kernel#warn.  I cannot think of any capability based test for this so I constrained it using a version guard.  Only JRuby will ever hit the version guard.

## Make sure the following tasks are checked

- [ x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ x] Write code to solve the problem
- [ x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

JRuby internal tests do not work with this monkey patch stripping off keywords.  I did not make a test for this change in this repository but JRuby itself has lots of test coverage for the behavior of warn.
