### PR TITLE
Fix bad unfreeze recommendation

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -357,7 +357,7 @@ module Bundler
           "bundle config unset deployment"
         end
         msg << "\n\nIf this is a development machine, remove the #{Bundler.default_gemfile} " \
-               "freeze \nby running `#{suggested_command}`."
+               "freeze \nby running `#{suggested_command}`." if suggested_command
       end
 
       added =   []

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -613,6 +613,12 @@ RSpec.describe "bundle update" do
       expect(err).to match(/You are trying to install in deployment mode after changing.your Gemfile/m).
         and match(/freeze \nby running `bundle config unset deployment`./m)
     end
+
+    it "should not suggest any command to unfreeze bundler if frozen is set through ENV" do
+      bundle "update", :all => true, :raise_on_error => false, :env => { "BUNDLE_FROZEN" => "true" }
+      expect(err).to match(/You are trying to install in deployment mode after changing.your Gemfile/m)
+      expect(err).not_to match(/by running/)
+    end
   end
 
   describe "with --source option" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If failing because lockfile changed while in frozen mode, Bundler recommends to run a command in development to temporarily unfreeze Bundler and regenerate the lockfile.

That recommendation does not make sense, however, if Bundler is frozen through ENV, and it currently results in a meaningless advice reading:

```
If this is a development machine, remove the /path/to/Gemfile freeze by running ``
```

## What is your fix for the problem, implemented in this PR?

This commit fixes the issue by avoiding displaying any recommendation in this case.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
