### PR TITLE
Properly sort specs when materializing

### DIFF
--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -79,9 +79,7 @@ module Bundler
       candidates = if source.is_a?(Source::Path) || !ruby_platform_materializes_to_ruby_platform?
         target_platform = ruby_platform_materializes_to_ruby_platform? ? platform : local_platform
 
-        source.specs.search(Dependency.new(name, version)).select do |spec|
-          MatchPlatform.platforms_match?(spec.platform, target_platform)
-        end
+        GemHelpers.select_best_platform_match(source.specs.search(Dependency.new(name, version)), target_platform)
       else
         source.specs.search(self)
       end

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -148,6 +148,38 @@ RSpec.describe "bundle install with specific platforms" do
       expect(out).to include("Using libv8 8.4.255.0 (universal-darwin)")
     end
 
+    it "chooses platform specific gems even when resolving upon materialization and the API returns more specific plaforms first" do
+      build_repo4 do
+        build_gem("grpc", "1.50.0")
+        build_gem("grpc", "1.50.0") {|s| s.platform = "universal-darwin" }
+      end
+
+      gemfile <<-G
+        source "https://localgemserver.test"
+        gem "grpc"
+      G
+
+      # simulate lockfile created with old bundler, which only locks for ruby platform
+      lockfile <<-L
+        GEM
+          remote: https://localgemserver.test/
+          specs:
+            grpc (1.50.0)
+
+        PLATFORMS
+          ruby
+
+        DEPENDENCIES
+          grpc
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      bundle "install --verbose", :artifice => "compact_index_precompiled_before", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+      expect(out).to include("Installing grpc 1.50.0 (universal-darwin)")
+    end
+
     it "caches the universal-darwin gem when --all-platforms is passed and properly picks it up on further bundler invocations" do
       setup_multiplatform_gem
       gemfile(google_protobuf)

--- a/bundler/spec/support/artifice/compact_index_precompiled_before.rb
+++ b/bundler/spec/support/artifice/compact_index_precompiled_before.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative "compact_index"
+
+Artifice.deactivate
+
+class CompactIndexPrecompiledBefore < CompactIndexAPI
+  get "/info/:name" do
+    etag_response do
+      gem = gems.find {|g| g.name == params[:name] }
+      move_ruby_variant_to_the_end(CompactIndex.info(gem ? gem.versions : []))
+    end
+  end
+
+  private
+
+  def move_ruby_variant_to_the_end(response)
+    lines = response.split("\n")
+    ruby = lines.find {|line| /\A\d+\.\d+\.\d* \|/.match(line) }
+    lines.delete(ruby)
+    lines.push(ruby).join("\n")
+  end
+end
+
+Artifice.activate_with(CompactIndexPrecompiledBefore)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When a Gemfile.lock file is locked only to the "ruby" platform, we still do some resolution of the best platform to install when materializing specs. But these specs come from the API without any specific ordering, so since we recently stopped always sorting specs, we may end up choosing an incorrect variant now.

## What is your fix for the problem, implemented in this PR?

Make sure the proper priority is used here, so that we always prefer a precompiled gem if available.

Fixes #6008.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
