### PR TITLE
Remove git from new gem gemspec template

### DIFF
--- a/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -23,12 +23,7 @@ Gem::Specification.new do |spec|
   spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
 
   # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files = Dir.chdir(__dir__) do
-    `git ls-files -z`.split("\x0").reject do |f|
-      (f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features)/|\.(?:git|travis|circleci)|appveyor)})
-    end
-  end
+  spec.files = Dir["lib/**/*.rb", "LICENSE.txt", "README.md"]
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
I work with the Debian Ruby team to package various ruby software for Debian. When we build gems, having git in gempsec would mean that we would need to git as a build dependency for every gem which isn't quite necessary. Until now Debian contributors have been making PRs to upstream maintainers to remove git and use something like `Dir`. The upstream maintainers were all very kind and understanding, so they merge the changes.

Most of these maintainers use this method to specify files in gemspec because it is how it was by default in the files generated with `bundle gem`. I am aware that even if we change the template, a developer can just use git and in that case we (Debian contributors) can patch it when we use it. That being said not using git in the default files created by `bundle gem` would prevent it from getting into new gems and save us a bunch of time. [More info](https://docs.rubocop.org/rubocop-packaging/cops_packaging.html#packaginggemspecgit)

Lastly, specifying individual files/folders would mean that only necessary files (that an end user would care about) are shipped in the gem, which is overall a good thing.

Please let me know what you folks think! Thanks for the amazing work.