### PR TITLE
Add sha256 checksum to rake build:checksum

### DIFF
--- a/bundler/lib/bundler/gem_helper.rb
+++ b/bundler/lib/bundler/gem_helper.rb
@@ -2,13 +2,12 @@
 
 require_relative "../bundler"
 require "shellwords"
-require "digest/sha2"
 
 module Bundler
   class GemHelper
     CHECKSUMS = {
-      "sha256" => ::Digest::SHA256,
-      "sha512" => ::Digest::SHA512,
+      "sha256" => "::Digest::SHA256",
+      "sha512" => "::Digest::SHA512",
     }.freeze
     include Rake::DSL if defined? Rake::DSL
 
@@ -109,8 +108,9 @@ module Bundler
 
     def build_checksums(built_gem_path = nil)
       built_gem_path ||= build_gem
-      CHECKSUMS.each do |extension, type|
-        write_checksum(built_gem_path, extension, type)
+      require "digest/sha2"
+      CHECKSUMS.each do |extension, digest_klass|
+        write_checksum(built_gem_path, extension, Object.const_get(digest_klass))
       end
     end
 

--- a/bundler/tool/bundler/release_gems.rb.lock
+++ b/bundler/tool/bundler/release_gems.rb.lock
@@ -59,7 +59,9 @@ PLATFORMS
   arm64-darwin-21
   universal-java-11
   universal-java-18
+  x86_64-darwin-19
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/bundler/tool/bundler/rubocop23_gems.rb.lock
+++ b/bundler/tool/bundler/rubocop23_gems.rb.lock
@@ -49,6 +49,7 @@ PLATFORMS
   universal-java-18
   x86_64-darwin-19
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/bundler/tool/bundler/rubocop24_gems.rb.lock
+++ b/bundler/tool/bundler/rubocop24_gems.rb.lock
@@ -51,6 +51,7 @@ PLATFORMS
   universal-java-18
   x86_64-darwin-19
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/bundler/tool/bundler/standard23_gems.rb.lock
+++ b/bundler/tool/bundler/standard23_gems.rb.lock
@@ -54,6 +54,7 @@ PLATFORMS
   universal-java-18
   x86_64-darwin-19
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/bundler/tool/bundler/standard24_gems.rb.lock
+++ b/bundler/tool/bundler/standard24_gems.rb.lock
@@ -57,6 +57,7 @@ PLATFORMS
   universal-java-18
   x86_64-darwin-19
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
… in addition to the existing SHA512

## What was the end-user or developer problem that led to this PR?

- Until now Rubygems.org has publicly displayed `SHA256` checksum for published gems, but has only created the `SHA512` checksum for the package via `rake build:checksum` task
- This will allow more gem authors to easily verify integrity of published gems with an existing Rubygems.org feature
- See #5942 for details on the problem

## What is your fix for the problem, implemented in this PR?

Create a SHA256 checksum, in addition to the current SHA512 checksum.

Note that I've changed the Gem helper method from `build_checksum` to `build_checksums`.  Certainly could keep it the same if that's a problem, but it felt good to be grammatically correct with it.  Not sure if internal or external API.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Tests - Have been updated
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
