### PR TITLE
Load "bundler/setup" in lib/rubygems.rb

### DIFF
--- a/bundler/lib/bundler/environment_preserver.rb
+++ b/bundler/lib/bundler/environment_preserver.rb
@@ -7,6 +7,7 @@ module Bundler
       BUNDLE_BIN_PATH
       BUNDLE_GEMFILE
       BUNDLER_VERSION
+      BUNDLER_SETUP
       GEM_HOME
       GEM_PATH
       MANPATH

--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -284,6 +284,7 @@ module Bundler
       Bundler::SharedHelpers.set_env "BUNDLE_BIN_PATH", exe_file
       Bundler::SharedHelpers.set_env "BUNDLE_GEMFILE", find_gemfile.to_s
       Bundler::SharedHelpers.set_env "BUNDLER_VERSION", Bundler::VERSION
+      Bundler::SharedHelpers.set_env "BUNDLER_SETUP", File.expand_path("setup", __dir__)
     end
 
     def set_path

--- a/bundler/spec/bundler/shared_helpers_spec.rb
+++ b/bundler/spec/bundler/shared_helpers_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe Bundler::SharedHelpers do
     end
 
     shared_examples_for "ENV['BUNDLER_SETUP'] gets set correctly" do
-      it "ensures bundler/setup is set in ENV['BUNDLE_SETUP']" do
+      it "ensures bundler/setup is set in ENV['BUNDLER_SETUP']" do
         subject.set_bundle_environment
         expect(ENV["BUNDLER_SETUP"]).to eq("#{source_lib_dir}/bundler/setup")
       end

--- a/bundler/spec/bundler/shared_helpers_spec.rb
+++ b/bundler/spec/bundler/shared_helpers_spec.rb
@@ -246,6 +246,13 @@ RSpec.describe Bundler::SharedHelpers do
       end
     end
 
+    shared_examples_for "ENV['BUNDLER_SETUP'] gets set correctly" do
+      it "ensures bundler/setup is set in ENV['BUNDLE_SETUP']" do
+        subject.set_bundle_environment
+        expect(ENV["BUNDLER_SETUP"]).to eq("#{source_lib_dir}/bundler/setup")
+      end
+    end
+
     shared_examples_for "ENV['RUBYLIB'] gets set correctly" do
       let(:ruby_lib_path) { "stubbed_ruby_lib_dir" }
 

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1348,3 +1348,5 @@ Gem::Specification.load_defaults
 require_relative "rubygems/core_ext/kernel_gem"
 require_relative "rubygems/core_ext/kernel_require"
 require_relative "rubygems/core_ext/kernel_warn"
+
+require ENV["BUNDLER_SETUP"] if ENV["BUNDLER_SETUP"]


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Currently, we cannot specify the version of did_you_mean by using Gemfile.

For example, Ruby master bundles with did_you_mean 1.6.1 by default:

```
$ ruby -e 'p DidYouMean::VERSION'
"1.6.1"
```

Consider that we want to use did_you_mean 1.5.0 with this version of ruby:

```
$ cat Gemfile
source "https://rubygems.org"
gem "did_you_mean", "= 1.5.0"
```

But the attempt fails:

```
$ bundle exec ruby -e 'p DidYouMean::VERSION'
/home/mame/work/ruby/local/lib/ruby/gems/3.2.0+3/gems/bundler-2.3.19/lib/bundler/runtime.rb:308:in `check_for_activated_spec!': You have already activated did_you_mean 1.6.1, but your Gemfile requires did_you_mean 1.5.0. Since did_you_mean is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports did_you_mean as a default gem. (Gem::LoadError)
...
```

This issue is not only with did_you_mean, but also with error_highlight and syntax_suggest which are automatically loaded at the interpreter startup.

This example is specifying an older version of did_you_mean, but typically you will want to specify a newer version. Actually, in https://github.com/rails/rails/pull/45818, I wanted to use error_highlight 0.4.0 with Ruby 3.1. (Note that Ruby 3.1 bundles with error_highlight 0.3.0.)

The cause of this problem is that `bundle exec` makes the interpreter load `bundler/setup` using `RUBYOPT=-rbundler/setup`, but this load is too late.

## What is your fix for the problem, implemented in this PR?

When ruby is invoked via `bundle exec`, rubygems.rb should `require "bundler/setup"` (i.e., before the special gems are loaded).

More specifically: `bundle exec` sets an environment variable `BUNDLER_SETUP`, and rubygems.rb requires the variable if defined.

(I am not particular about the name of this environment variable. I will be happy to change it if you prefer another name.)

See also: https://bugs.ruby-lang.org/issues/19089

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
