### PR TITLE
github source should default to secure protocol

### DIFF
--- a/bundler/tool/bundler/release_gems.rb.lock
+++ b/bundler/tool/bundler/release_gems.rb.lock
@@ -60,6 +60,7 @@ PLATFORMS
   universal-java-11
   universal-java-18
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/bundler/tool/bundler/rubocop23_gems.rb.lock
+++ b/bundler/tool/bundler/rubocop23_gems.rb.lock
@@ -49,6 +49,7 @@ PLATFORMS
   universal-java-18
   x86_64-darwin-19
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/bundler/tool/bundler/rubocop24_gems.rb.lock
+++ b/bundler/tool/bundler/rubocop24_gems.rb.lock
@@ -51,6 +51,7 @@ PLATFORMS
   universal-java-18
   x86_64-darwin-19
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/bundler/tool/bundler/standard23_gems.rb.lock
+++ b/bundler/tool/bundler/standard23_gems.rb.lock
@@ -54,6 +54,7 @@ PLATFORMS
   universal-java-18
   x86_64-darwin-19
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/bundler/tool/bundler/standard24_gems.rb.lock
+++ b/bundler/tool/bundler/standard24_gems.rb.lock
@@ -57,6 +57,7 @@ PLATFORMS
   universal-java-18
   x86_64-darwin-19
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/rubygems/request_set/gem_dependency_api.rb
+++ b/lib/rubygems/request_set/gem_dependency_api.rb
@@ -214,7 +214,7 @@ class Gem::RequestSet::GemDependencyAPI
     git_source :github do |repo_name|
       repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include? "/"
 
-      "git://github.com/#{repo_name}.git"
+      "https://github.com/#{repo_name}.git"
     end
 
     git_source :bitbucket do |repo_name|

--- a/test/rubygems/test_gem_request_set_gem_dependency_api.rb
+++ b/test/rubygems/test_gem_request_set_gem_dependency_api.rb
@@ -183,7 +183,7 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
 
     assert_equal [dep("a")], @set.dependencies
 
-    assert_equal %w[git://github.com/example/repository.git master],
+    assert_equal %w[https://github.com/example/repository.git master],
                  @git_set.repositories["a"]
 
     expected = { "a" => Gem::Requirement.create("!") }
@@ -196,7 +196,7 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
 
     assert_equal [dep("a")], @set.dependencies
 
-    assert_equal %w[git://github.com/example/example.git master],
+    assert_equal %w[https://github.com/example/example.git master],
                  @git_set.repositories["a"]
 
     expected = { "a" => Gem::Requirement.create("!") }


### PR DESCRIPTION
Bundler 2 switched to secure https here https://github.com/rubygems/rubygems/commit/c2e81f8ff63613871cc8b52653c5e176f8dafde3

Insecure protocols should be avoided to prevent MITM attacks.

## What was the end-user or developer problem that led to this PR?

I discovered the differing implementation that was fixed "upstream" in bundler itself. I haven't encountered a _user_ side problem to demonstrate this; it was merely a source-code detection.

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

Simple fix is the same as before: use secure protocol https and bring in-line consistently with bundler.

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
