### PR TITLE
Changelogs for RubyGems 3.3.25 and Bundler 2.3.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 3.3.25 / 2022-11-02
+
+## Enhancements:
+
+* Github source should default to secure protocol. Pull request #6026 by
+  jasonkarns
+* Allow upcoming JRuby to pass keywords to Kernel#warn. Pull request #6002
+  by enebo
+* Installs bundler 2.3.25 as a default gem.
+
 # 3.3.24 / 2022-10-17
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 2.3.25 (November 2, 2022)
+
+## Bug fixes:
+
+  - Properly sort specs when materializing [#6015](https://github.com/rubygems/rubygems/pull/6015)
+  - Fix bad unfreeze recommendation [#6013](https://github.com/rubygems/rubygems/pull/6013)
+
+## Documentation:
+
+  - Bring docs for gemfile(5) manpage up to date [#6007](https://github.com/rubygems/rubygems/pull/6007)
+  - Fix `github` DSL docs to mention they use https protocol over git under the hood [#5993](https://github.com/rubygems/rubygems/pull/5993)
+
 # 2.3.24 (October 17, 2022)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.3.25 and Bundler 2.3.25 into master.