### PR TITLE
Remove support for deprecated OS

### DIFF
--- a/bundler/lib/bundler/vendor/thor/lib/thor/shell/basic.rb
+++ b/bundler/lib/bundler/vendor/thor/lib/thor/shell/basic.rb
@@ -425,7 +425,7 @@ class Bundler::Thor
       end
 
       def unix?
-        RUBY_PLATFORM =~ /(aix|darwin|linux|(net|free|open)bsd|cygwin|solaris|irix)/i
+        RUBY_PLATFORM =~ /(aix|darwin|linux|(net|free|open)bsd|cygwin|solaris)/i
       end
 
       def truncate(string, width)

--- a/bundler/lib/bundler/vendor/thor/lib/thor/shell/basic.rb
+++ b/bundler/lib/bundler/vendor/thor/lib/thor/shell/basic.rb
@@ -425,7 +425,7 @@ class Bundler::Thor
       end
 
       def unix?
-        RUBY_PLATFORM =~ /(aix|darwin|linux|(net|free|open)bsd|cygwin|solaris|irix|hpux)/i
+        RUBY_PLATFORM =~ /(aix|darwin|linux|(net|free|open)bsd|cygwin|solaris|irix)/i
       end
 
       def truncate(string, width)

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -97,7 +97,6 @@ class Gem::Platform
       when /darwin(\d+)?/ then          [ "darwin",    $1  ]
       when /^macruby$/ then             [ "macruby",   nil ]
       when /freebsd(\d+)?/ then         [ "freebsd",   $1  ]
-      when /hpux(\d+)?/ then            [ "hpux",      $1  ]
       when /^java$/, /^jruby$/ then     [ "java",      nil ]
       when /^java([\d.]*)/ then         [ "java",      $1  ]
       when /^dalvik(\d+)?$/ then        [ "dalvik",    $1  ]

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -111,7 +111,6 @@ class Gem::Platform
         [os, version]
       when /netbsdelf/ then             [ "netbsdelf", nil ]
       when /openbsd(\d+\.\d+)?/ then    [ "openbsd",   $1  ]
-      when /bitrig(\d+\.\d+)?/ then     [ "bitrig",    $1  ]
       when /solaris(\d+\.\d+)?/ then    [ "solaris",   $1  ]
       # test
       when /^(\w+_platform)(\d+)?/ then [ $1,          $2  ]

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -86,7 +86,6 @@ class TestGemPlatform < Gem::TestCase
   def test_initialize
     test_cases = {
       "amd64-freebsd6" => ["amd64",     "freebsd", "6"],
-      "hppa2.0w-hpux11.31" => ["hppa2.0w", "hpux", "11"],
       "java" => [nil,         "java", nil],
       "jruby" => [nil, "java", nil],
       "universal-dotnet" => ["universal", "dotnet", nil],

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -85,8 +85,8 @@ class TestGemPlatform < Gem::TestCase
 
   def test_initialize
     test_cases = {
-      "amd64-freebsd6" => ["amd64",     "freebsd", "6"],
-      "java" => [nil,         "java", nil],
+      "amd64-freebsd6" => ["amd64", "freebsd", "6"],
+      "java" => [nil, "java", nil],
       "jruby" => [nil, "java", nil],
       "universal-dotnet" => ["universal", "dotnet", nil],
       "universal-dotnet2.0" => ["universal", "dotnet",  "2.0"],


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

- Support for HP-UX was dropped in ruby/ruby#5457.
- The bitrig OS is no longer maintained with the last release being 7 years ago.
- The IRIX OS is no longer maintained with the last release being 16 years ago.

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

Removed support for these OSes.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
