### PR TITLE
Upgrade rb-sys to 0.9.37

### DIFF
--- a/bundler/tool/bundler/release_gems.rb.lock
+++ b/bundler/tool/bundler/release_gems.rb.lock
@@ -57,6 +57,7 @@ PLATFORMS
   aarch64-linux
   arm64-darwin-20
   arm64-darwin-21
+  arm64-darwin-22
   universal-java-11
   universal-java-18
   x86_64-darwin-20

--- a/bundler/tool/bundler/rubocop23_gems.rb.lock
+++ b/bundler/tool/bundler/rubocop23_gems.rb.lock
@@ -45,6 +45,7 @@ PLATFORMS
   aarch64-linux
   arm64-darwin-20
   arm64-darwin-21
+  arm64-darwin-22
   universal-java-11
   universal-java-18
   x86_64-darwin-19

--- a/bundler/tool/bundler/rubocop24_gems.rb.lock
+++ b/bundler/tool/bundler/rubocop24_gems.rb.lock
@@ -47,6 +47,7 @@ PLATFORMS
   aarch64-linux
   arm64-darwin-20
   arm64-darwin-21
+  arm64-darwin-22
   universal-java-11
   universal-java-18
   x86_64-darwin-19

--- a/bundler/tool/bundler/standard23_gems.rb.lock
+++ b/bundler/tool/bundler/standard23_gems.rb.lock
@@ -50,6 +50,7 @@ PLATFORMS
   aarch64-linux
   arm64-darwin-20
   arm64-darwin-21
+  arm64-darwin-22
   universal-java-11
   universal-java-18
   x86_64-darwin-19

--- a/bundler/tool/bundler/standard24_gems.rb.lock
+++ b/bundler/tool/bundler/standard24_gems.rb.lock
@@ -53,6 +53,7 @@ PLATFORMS
   aarch64-linux
   arm64-darwin-20
   arm64-darwin-21
+  arm64-darwin-22
   universal-java-11
   universal-java-18
   x86_64-darwin-19

--- a/lib/rubygems/ext/cargo_builder.rb
+++ b/lib/rubygems/ext/cargo_builder.rb
@@ -37,6 +37,7 @@ class Gem::Ext::CargoBuilder < Gem::Ext::Builder
   def build_env
     build_env = rb_config_env
     build_env["RUBY_STATIC"] = "true" if ruby_static? && ENV.key?("RUBY_STATIC")
+    build_env["RUSTFLAGS"] = "#{ENV["RUSTFLAGS"]} --cfg=rb_sys_gem".strip
     build_env
   end
 
@@ -92,6 +93,9 @@ class Gem::Ext::CargoBuilder < Gem::Ext::Builder
       # run on one that isn't the missing libraries will cause the extension
       # to fail on start.
       flags += ["-C", "link-arg=-static-libgcc"]
+    elsif darwin_target?
+      # Ventura does not always have this flag enabled
+      flags += ["-C", "link-arg=-Wl,-undefined,dynamic_lookup"]
     end
 
     flags

--- a/test/rubygems/test_gem_ext_cargo_builder/custom_name/Cargo.lock
+++ b/test/rubygems/test_gem_ext_cargo_builder/custom_name/Cargo.lock
@@ -160,18 +160,18 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.35"
+version = "0.9.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2bde30824a18f2e68cd1c8004cec16656764c6efc385bc1c7fb4c904b276a5"
+checksum = "5ba942b6777ea18ded013b267023a9c98994557e6539e43740de9e75084cb124"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.35"
+version = "0.9.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ff5d3ba92624df9c66bf0d1f0251d96284f08ac9773b7723d370e3f225c1d38"
+checksum = "d35109e1a11ef8d1a988db242ab2ba2e80170f9f5a28f88ab30184a2cea8e09b"
 dependencies = [
  "bindgen",
  "linkify",

--- a/test/rubygems/test_gem_ext_cargo_builder/custom_name/Cargo.toml
+++ b/test/rubygems/test_gem_ext_cargo_builder/custom_name/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-rb-sys = { version = "0.9.35", features = ["gem"] }
+rb-sys = "0.9.37"

--- a/test/rubygems/test_gem_ext_cargo_builder/rust_ruby_example/Cargo.lock
+++ b/test/rubygems/test_gem_ext_cargo_builder/rust_ruby_example/Cargo.lock
@@ -153,18 +153,18 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.35"
+version = "0.9.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2bde30824a18f2e68cd1c8004cec16656764c6efc385bc1c7fb4c904b276a5"
+checksum = "5ba942b6777ea18ded013b267023a9c98994557e6539e43740de9e75084cb124"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.35"
+version = "0.9.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ff5d3ba92624df9c66bf0d1f0251d96284f08ac9773b7723d370e3f225c1d38"
+checksum = "d35109e1a11ef8d1a988db242ab2ba2e80170f9f5a28f88ab30184a2cea8e09b"
 dependencies = [
  "bindgen",
  "linkify",

--- a/test/rubygems/test_gem_ext_cargo_builder/rust_ruby_example/Cargo.toml
+++ b/test/rubygems/test_gem_ext_cargo_builder/rust_ruby_example/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-rb-sys = { version = "0.9.35", features = ["gem"] }
+rb-sys = "0.9.37"


### PR DESCRIPTION
This PR upgrades rb-sys to 0.9.37, which adjusts how linking behavior for gems is inferred. This makes its easier for dependents (such as [magnus](https://github.com/matsadler/magnus)) to use as a library. The main difference is that rb-sys now expects an explicit `--cfg=rb_sys_gem` flag rather than a feature flag.