### PR TITLE
Fix '--force' option documentation of 'bundle clean'

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -620,7 +620,7 @@ module Bundler
     method_option "dry-run", :type => :boolean, :default => false, :banner =>
       "Only print out changes, do not clean gems"
     method_option "force", :type => :boolean, :default => false, :banner =>
-      "Forces clean even if system location is used"
+      "Forces cleaning up unused gems even if Bundler is configured to use globally installed gems. As a consequence, removes all system gems except for the ones in the current application."
     def clean
       require_relative "cli/clean"
       Clean.new(options.dup).run

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -620,7 +620,7 @@ module Bundler
     method_option "dry-run", :type => :boolean, :default => false, :banner =>
       "Only print out changes, do not clean gems"
     method_option "force", :type => :boolean, :default => false, :banner =>
-      "Forces clean even if --path is not set"
+      "Forces clean even if system location is used"
     def clean
       require_relative "cli/clean"
       Clean.new(options.dup).run

--- a/bundler/lib/bundler/man/bundle-clean.1
+++ b/bundler/lib/bundler/man/bundle-clean.1
@@ -20,5 +20,5 @@ Print the changes, but do not clean the unused gems\.
 .
 .TP
 \fB\-\-force\fR
-Force a clean even if system location is used\.
+Forces cleaning up unused gems even if Bundler is configured to use globally installed gems\. As a consequence, removes all system gems except for the ones in the current application\.
 

--- a/bundler/lib/bundler/man/bundle-clean.1
+++ b/bundler/lib/bundler/man/bundle-clean.1
@@ -20,5 +20,5 @@ Print the changes, but do not clean the unused gems\.
 .
 .TP
 \fB\-\-force\fR
-Force a clean even if \fB\-\-path\fR is not set\.
+Force a clean even if system location is used\.
 

--- a/bundler/lib/bundler/man/bundle-clean.1.ronn
+++ b/bundler/lib/bundler/man/bundle-clean.1.ronn
@@ -15,4 +15,4 @@ useful when you have made many changes to your gem dependencies.
 * `--dry-run`:
   Print the changes, but do not clean the unused gems.
 * `--force`:
-  Force a clean even if system location is used.
+  Forces cleaning up unused gems even if Bundler is configured to use globally installed gems. As a consequence, removes all system gems except for the ones in the current application.

--- a/bundler/lib/bundler/man/bundle-clean.1.ronn
+++ b/bundler/lib/bundler/man/bundle-clean.1.ronn
@@ -15,4 +15,4 @@ useful when you have made many changes to your gem dependencies.
 * `--dry-run`:
   Print the changes, but do not clean the unused gems.
 * `--force`:
-  Force a clean even if `--path` is not set.
+  Force a clean even if system location is used.


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

`--force` option documentation of `bundle clean` is wrong. Because `--path` option is no longer used. The following code checks if system location is used or not.

https://github.com/syohex/rubygems/blob/clean-doc/bundler/lib/bundler/cli/clean.rb#L19

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

Fix the documentation according to the current implementation.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
