### PR TITLE
Fix some errors in "Writing docs for man pages"

### DIFF
--- a/bundler/doc/documentation/WRITING.md
+++ b/bundler/doc/documentation/WRITING.md
@@ -41,7 +41,7 @@ To preview your changes as they will print out for Bundler users, you'll need to
 ```
 $ rake spec:deps
 $ rake man:build
-$ man man/bundle-cookies.1
+$ man ./lib/bundler/man/bundle-cookies.1
 ```
 
 If you make more changes to `bundle-cookies.1.ronn`, you'll need to run the `rake man:build` again before previewing.

--- a/bundler/doc/documentation/WRITING.md
+++ b/bundler/doc/documentation/WRITING.md
@@ -59,7 +59,7 @@ $ bin/rspec ./spec/quality_spec.rb
 
 If you'd like to submit a pull request for any of the primary commands or utilities on [the Bundler documentation site](https://bundler.io), please follow the instructions above for writing documentation for man pages from the `rubygems/rubygems` repository. They are the same in each case.
 
-Note: Editing `.ronn` files from the `rubygems/rubygems` repository for the primary commands and utilities documentation is all you need 🎉. There is no need to manually change anything in the `rubygems/bundler-site` repository, because the man pages and the docs for primary commands and utilities on [the Bundler documentation site](https://bundler.io) are one in the same. They are generated automatically from the `rubygems/rubygems` repository's `.ronn` files from the `rake man/build` command.
+Note: Editing `.ronn` files from the `rubygems/rubygems` repository for the primary commands and utilities documentation is all you need 🎉. There is no need to manually change anything in the `rubygems/bundler-site` repository, because the man pages and the docs for primary commands and utilities on [the Bundler documentation site](https://bundler.io) are one in the same. They are generated automatically from the `rubygems/rubygems` repository's `.ronn` files from the `rake man:build` command.
 
 Additionally, if you'd like to add a guide or tutorial: in the `rubygems/bundler-site` repository, go to `/bundler-site/source/current_version_of_bundler/guides` and add [a new Markdown file](https://guides.github.com/features/mastering-markdown/) (with an extension ending in `.md`). Be sure to correctly format the title of your new guide, like so:
 ```


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

While reading this doc I found some errors::
1. In the previewing section, the `/rubygems/bundler/man` directory is used to access the man pages, but the correct directory is `/rubygems/bundler/lib/bundler/man`;
2. In the section about writing docs for the Bundler documentation site, there is a typo with the `rake man:build` command.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
