### PR TITLE
Changelogs for RubyGems 3.3.26 and Bundler 2.3.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 3.3.26 / 2022-11-16
+
+## Enhancements:
+
+* Upgrade rb-sys to 0.9.37. Pull request #6047 by ianks
+* Installs bundler 2.3.26 as a default gem.
+
 # 3.3.25 / 2022-11-02
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 2.3.26 (November 16, 2022)
+
+## Enhancements:
+
+  - Map 'universal' to the real arch in Bundler for prebuilt gem selection [#5978](https://github.com/rubygems/rubygems/pull/5978)
+
+## Documentation:
+
+  - Fix '--force' option documentation of 'bundle clean' [#6050](https://github.com/rubygems/rubygems/pull/6050)
+
 # 2.3.25 (November 2, 2022)
 
 ## Bug fixes:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.3.26 and Bundler 2.3.26 into master.