### PR TITLE
Small tweak to release script

### DIFF
--- a/util/release.rb
+++ b/util/release.rb
@@ -161,10 +161,10 @@ class Release
 
     system("git", "checkout", "-b", @release_branch, @base_branch, exception: true)
 
-    @bundler.set_relevant_pull_requests_from(unreleased_pull_requests)
-    @rubygems.set_relevant_pull_requests_from(unreleased_pull_requests)
-
     begin
+      @bundler.set_relevant_pull_requests_from(unreleased_pull_requests)
+      @rubygems.set_relevant_pull_requests_from(unreleased_pull_requests)
+
       cherry_pick_pull_requests if @level == :patch
 
       @bundler.cut_changelog!


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Got a network error while release and that left me with an unusable release branch.

## What is your fix for the problem, implemented in this PR?

Move a couple of lines subject to errors to inside the `begin-rescue` block, so that things are cleaned up before erroring out.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
