### PR TITLE
Improve some resolution messages when some platform gems are missing

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -168,6 +168,7 @@ bundler/lib/bundler/remote_specification.rb
 bundler/lib/bundler/resolver.rb
 bundler/lib/bundler/resolver/base.rb
 bundler/lib/bundler/resolver/candidate.rb
+bundler/lib/bundler/resolver/incompatibility.rb
 bundler/lib/bundler/resolver/package.rb
 bundler/lib/bundler/resolver/root.rb
 bundler/lib/bundler/resolver/spec_group.rb

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -115,11 +115,12 @@ module Bundler
 
     def no_versions_incompatibility_for(package, unsatisfied_term)
       cause = PubGrub::Incompatibility::NoVersions.new(unsatisfied_term)
+      constraint = unsatisfied_term.constraint
 
       custom_explanation = if package.name == "bundler"
-        "the current Bundler version (#{Bundler::VERSION}) does not satisfy #{cause.constraint}"
+        "the current Bundler version (#{Bundler::VERSION}) does not satisfy #{constraint}"
       else
-        "#{cause.constraint} could not be found in #{repository_for(package)}"
+        "#{constraint} could not be found in #{repository_for(package)}"
       end
 
       PubGrub::Incompatibility.new([unsatisfied_term], :cause => cause, :custom_explanation => custom_explanation)

--- a/bundler/lib/bundler/resolver/incompatibility.rb
+++ b/bundler/lib/bundler/resolver/incompatibility.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Bundler
+  class Resolver
+    class Incompatibility < PubGrub::Incompatibility
+      attr_reader :extended_explanation
+
+      def initialize(terms, cause:, custom_explanation: nil, extended_explanation: nil)
+        @extended_explanation = extended_explanation
+
+        super(terms, :cause => cause, :custom_explanation => custom_explanation)
+      end
+    end
+  end
+end

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -363,21 +363,17 @@ RSpec.describe "bundle install with specific platforms" do
     G
 
     error_message = <<~ERROR.strip
-      Could not find gem 'sorbet-static (= 0.5.6433)' with platform 'arm64-darwin-21', which is required by gem 'sorbet (= 0.5.6433)', in rubygems repository #{file_uri_for(gem_repo4)}/ or installed locally.
+      Could not find compatible versions
+
+      Because every version of sorbet depends on sorbet-static = 0.5.6433
+        and sorbet-static = 0.5.6433 could not be found in rubygems repository #{file_uri_for(gem_repo4)}/ or installed locally for any resolution platforms (arm64-darwin-21),
+        every version of sorbet is forbidden.
+      So, because Gemfile depends on sorbet = 0.5.6433,
+        version solving has failed.
 
       The source contains the following gems matching 'sorbet-static (= 0.5.6433)':
         * sorbet-static-0.5.6433-universal-darwin-20
         * sorbet-static-0.5.6433-x86_64-linux
-    ERROR
-
-    error_message = <<~ERROR.strip
-      Could not find compatible versions
-
-      Because every version of sorbet depends on sorbet-static = 0.5.6433
-        and sorbet-static = 0.5.6433 could not be found in rubygems repository #{file_uri_for(gem_repo4)}/ or installed locally,
-        every version of sorbet is forbidden.
-      So, because Gemfile depends on sorbet = 0.5.6433,
-        version solving has failed.
     ERROR
 
     simulate_platform "arm64-darwin-21" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This should've been part of the initial PubGrub work, but I took a shortcut to get a green baseline and in the end I forgot to get the related spec passing the way I wanted.

To spec is the following. The first message is the old one given by Molinillo, the second is the one given by PubGrub.

https://github.com/rubygems/rubygems/blob/7ff32ade207cb35ce4d46b8d571d1b4e1545792c/bundler/spec/install/gemfile/specific_platform_spec.rb#L365-L382

The idea is to give a hint like we did before when resolution failed because we couldn't find specs matching the requirements for some resolution platform. The current message does not give any hint about this, so it's confusing.

## What is your fix for the problem, implemented in this PR?

My fix is to allow further customization of PubGrub incompatibilities to be able to give an extra hint about this edge case.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
