### PR TITLE
Use RUBYGEMS_GEMDEPS instead of BUNDLER_SETUP

### DIFF
--- a/bundler/lib/bundler/environment_preserver.rb
+++ b/bundler/lib/bundler/environment_preserver.rb
@@ -7,7 +7,7 @@ module Bundler
       BUNDLE_BIN_PATH
       BUNDLE_GEMFILE
       BUNDLER_VERSION
-      BUNDLER_SETUP
+      RUBYGEMS_GEMDEPS
       GEM_HOME
       GEM_PATH
       MANPATH

--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -284,7 +284,7 @@ module Bundler
       Bundler::SharedHelpers.set_env "BUNDLE_BIN_PATH", exe_file
       Bundler::SharedHelpers.set_env "BUNDLE_GEMFILE", find_gemfile.to_s
       Bundler::SharedHelpers.set_env "BUNDLER_VERSION", Bundler::VERSION
-      Bundler::SharedHelpers.set_env "BUNDLER_SETUP", File.expand_path("setup", __dir__)
+      Bundler::SharedHelpers.set_env "RUBYGEMS_GEMDEPS", find_gemfile.to_s
     end
 
     def set_path

--- a/bundler/spec/bundler/shared_helpers_spec.rb
+++ b/bundler/spec/bundler/shared_helpers_spec.rb
@@ -246,13 +246,6 @@ RSpec.describe Bundler::SharedHelpers do
       end
     end
 
-    shared_examples_for "ENV['BUNDLER_SETUP'] gets set correctly" do
-      it "ensures bundler/setup is set in ENV['BUNDLER_SETUP']" do
-        subject.set_bundle_environment
-        expect(ENV["BUNDLER_SETUP"]).to eq("#{source_lib_dir}/bundler/setup")
-      end
-    end
-
     shared_examples_for "ENV['RUBYLIB'] gets set correctly" do
       let(:ruby_lib_path) { "stubbed_ruby_lib_dir" }
 

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1349,4 +1349,4 @@ require_relative "rubygems/core_ext/kernel_gem"
 require_relative "rubygems/core_ext/kernel_require"
 require_relative "rubygems/core_ext/kernel_warn"
 
-require ENV["BUNDLER_SETUP"] if ENV["BUNDLER_SETUP"]
+require "bundler/setup" if ENV["RUBYGEMS_GEMDEPS"]

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1349,4 +1349,4 @@ require_relative "rubygems/core_ext/kernel_gem"
 require_relative "rubygems/core_ext/kernel_require"
 require_relative "rubygems/core_ext/kernel_warn"
 
-require "bundler/setup" if ENV["RUBYGEMS_GEMDEPS"]
+Gem.use_gemdeps


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Improvement for https://github.com/rubygems/rubygems/pull/6025 

## What is your fix for the problem, implemented in this PR?

Use existing variable that is `RUBYGEMS_GEMDEPS` instead of new variable.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
