### PR TITLE
Fix hang when a lockfile gem does not resolve on the current platform

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -524,13 +524,22 @@ module Bundler
         raise GemNotFound, "Could not find #{missing_specs_list.join(" nor ")}"
       end
 
+      incomplete_specs = specs.incomplete_specs
       loop do
-        incomplete_specs = specs.incomplete_specs
         break if incomplete_specs.empty?
 
         Bundler.ui.debug("The lockfile does not have all gems needed for the current platform though, Bundler will still re-resolve dependencies")
         @resolve = start_resolution(:exclude_specs => incomplete_specs)
         specs = resolve.materialize(dependencies)
+
+        still_incomplete_specs = specs.incomplete_specs
+
+        if still_incomplete_specs == incomplete_specs
+          package = resolution_packages[incomplete_specs.first.name]
+          resolver.raise_not_found! package
+        end
+
+        incomplete_specs = still_incomplete_specs
       end
 
       bundler = sources.metadata_source.specs.search(["bundler", Bundler.gem_version]).last

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -271,11 +271,11 @@ module Bundler
         next [dep_package, dep_constraint] unless versions_for(dep_package, dep_constraint.range).empty?
         next unless dep_package.current_platform?
 
-        raise GemNotFound, gem_not_found_message(dep_package, dep_constraint)
+        raise GemNotFound, gem_not_found_message(dep_package)
       end.compact.to_h
     end
 
-    def gem_not_found_message(package, requirement)
+    def gem_not_found_message(package)
       name = package.name
       source = source_for(name)
       specs = @all_specs[name]

--- a/bundler/lib/bundler/resolver/package.rb
+++ b/bundler/lib/bundler/resolver/package.rb
@@ -13,14 +13,14 @@ module Bundler
     # * The dependency explicit set in the Gemfile for this gem (if any).
     #
     class Package
-      attr_reader :name, :platforms, :dependency
+      attr_reader :name, :platforms, :dependency, :locked_version
 
       def initialize(name, platforms, locked_specs, unlock, dependency: nil)
         @name = name
         @platforms = platforms
-        @locked_specs = locked_specs
+        @locked_version = locked_specs[name].first&.version
         @unlock = unlock
-        @dependency = dependency
+        @dependency = dependency || Dependency.new(name, @locked_version)
       end
 
       def to_s
@@ -43,24 +43,20 @@ module Bundler
         @name.hash
       end
 
-      def locked_version
-        @locked_specs[name].first&.version
-      end
-
       def unlock?
         @unlock.empty? || @unlock.include?(name)
       end
 
       def prerelease_specified?
-        @dependency&.prerelease?
+        @dependency.prerelease?
       end
 
       def force_ruby_platform?
-        @dependency&.force_ruby_platform
+        @dependency.force_ruby_platform
       end
 
       def current_platform?
-        @dependency&.current_platform?
+        @dependency.current_platform?
       end
     end
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If the lock file has incomplete gems for the current platform, and that are impossible to complete, Bundler currently hangs in an infinite loop.

## What is your fix for the problem, implemented in this PR?

This fix detects the infinite loop and raises a proper resolution error.

Fixes #6054.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
