### PR TITLE
Fx link in bundle-platform man page

### DIFF
--- a/bundler/lib/bundler/man/bundle-platform.1
+++ b/bundler/lib/bundler/man/bundle-platform.1
@@ -65,7 +65,7 @@ It will display the ruby directive information, so you don\'t have to parse it f
 .SH "SEE ALSO"
 .
 .IP "\(bu" 4
-bundle\-lock(1) \fIbundle\-lock\.1\.ronn\fR
+bundle\-lock(1) \fIbundle\-lock\.1\.html\fR
 .
 .IP "" 0
 

--- a/bundler/lib/bundler/man/bundle-platform.1.ronn
+++ b/bundler/lib/bundler/man/bundle-platform.1.ronn
@@ -46,4 +46,4 @@ match the running Ruby VM, it tells you what part does not.
 
 ## SEE ALSO
 
-* [bundle-lock(1)](bundle-lock.1.ronn)
+* [bundle-lock(1)](bundle-lock.1.html)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

At the end of the page https://bundler.io/man/bundle-platform.1.html , the link to `bundle-lock(1)` points to `https://bundler.io/man/bundle-lock.1.ronn`, which is not correct.

## What is your fix for the problem, implemented in this PR?

Internal links should use `.html` extension, instead of `.ronn`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
