### PR TITLE
Stop installing everything under "lib" at the top in all tests

### DIFF
--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -15,6 +15,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     super
 
     @cmd = Gem::Commands::SetupCommand.new
+    @cmd.options[:document] = []
 
     filelist = %w[
       bin/gem
@@ -66,7 +67,6 @@ class TestGemCommandsSetupCommand < Gem::TestCase
       io.puts "I changed it!"
     end
 
-    @cmd.options[:document] = []
     @cmd.execute
 
     assert_match %r{\A#!}, File.read(gem_bin_path)
@@ -78,7 +78,6 @@ class TestGemCommandsSetupCommand < Gem::TestCase
       io.puts "I changed it!"
     end
 
-    @cmd.options[:document] = []
     @cmd.options[:regenerate_binstubs] = false
     @cmd.execute
 
@@ -91,7 +90,6 @@ class TestGemCommandsSetupCommand < Gem::TestCase
       io.puts "I changed it!"
     end
 
-    @cmd.options[:document] = []
     @cmd.execute
 
     assert_match %r{\Arequire}, File.read(gem_plugin_path)
@@ -103,7 +101,6 @@ class TestGemCommandsSetupCommand < Gem::TestCase
       io.puts "I changed it!"
     end
 
-    @cmd.options[:document] = []
     @cmd.options[:regenerate_plugins] = false
     @cmd.execute
 
@@ -116,15 +113,12 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     # Simulate gem installed with an older rubygems without a plugins layout
     FileUtils.rm_rf Gem.plugindir
 
-    @cmd.options[:document] = []
     @cmd.execute
 
     assert_match %r{\Arequire}, File.read(gem_plugin_path)
   end
 
   def test_execute_informs_about_installed_executables
-    @cmd.options[:document] = []
-
     use_ui @ui do
       @cmd.execute
     end
@@ -143,7 +137,6 @@ class TestGemCommandsSetupCommand < Gem::TestCase
       io.puts "I changed it!"
     end
 
-    @cmd.options[:document] = []
     @cmd.options[:env_shebang] = true
     @cmd.execute
 


### PR DESCRIPTION
`TestGemCommandsSetupCommand#test_destdir_flag_does_not_try_to_write_to_the_default_gem_home` installs everything under  "lib" at the top, and this causes [warning from rdoc](https://github.com/ruby/ruby/actions/runs/3544846277/jobs/5952482848#step:16:99) in ruby/ruby.
>   Couldn't find file to include 'doc/net-http/examples.rdoc' from lib/net/http.rb
>   Couldn't find file to include 'doc/net-http/examples.rdoc' from lib/net/http/header.rb
>   Couldn't find file to include 'doc/net-http/examples.rdoc' from lib/net/http/response.rb

Also this takes about 10 seconds.

## What was the end-user or developer problem that led to this PR?

Remove warnings and reduce test times.

## What is your fix for the problem, implemented in this PR?

Since other tests in the same file clears the `:document` option already, clears it in `setup`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
