### PR TITLE
require bundler/setup only when Bundler is not defined

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1349,4 +1349,4 @@ require_relative "rubygems/core_ext/kernel_gem"
 require_relative "rubygems/core_ext/kernel_require"
 require_relative "rubygems/core_ext/kernel_warn"
 
-require ENV["BUNDLER_SETUP"] if ENV["BUNDLER_SETUP"]
+require ENV["BUNDLER_SETUP"] if ENV["BUNDLER_SETUP"] && !defined?(Bundler)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

"Circular require" is caused when bundler/setup is required under `--disable-gems` mode

This is a simplified case of https://github.com/ruby/ruby/commit/e5a0abc5dedfd011986b16e8f8cf5cda476984c9

```
$ bundle exec ruby -we 'system("ruby", "-w", "--disable-gems", "-e", "")'
<internal:/home/mame/work/ruby/local/lib/ruby/3.2.0+3/rubygems/core_ext/kernel_require.rb>:85: warning: <internal:/home/mame/work/ruby/local/lib/ruby/3.2.0+3/rubygems/core_ext/kernel_require.rb>:85: warning: loading in progress, circular require considered harmful - /home/mame/work/ruby/local/lib/ruby/3.2.0+3/bundler/setup.rb
```

This is a minor problem because [`--disable-gems` option must not be used](https://bugs.ruby-lang.org/issues/17684), but I think it could be fixed for the old users still using it.

## What is your fix for the problem, implemented in this PR?

This change makes rubygems.rb to require "bundler/setup" only when `Bundler` is not defined.

When bundler/setup is require'ed under --disable-gems mode, it loads rubygems by:https://github.com/rubygems/rubygems/blob/0b1f682a6d65e57b86ba4853cba23cac361c769d/bundler/lib/bundler/rubygems_integration.rb#L3
In this case, require'ing bundler/setup from rubygems.rb is circular.

So this change solves the issue.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
