### PR TITLE
Added permission restrictions for GitHub actions

### DIFF
--- a/.github/workflows/daily-bundler.yml
+++ b/.github/workflows/daily-bundler.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   daily_bundler:
     name: Bundler (ruby-head)

--- a/.github/workflows/daily-rubygems.yml
+++ b/.github/workflows/daily-rubygems.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   daily_rubygems:
     name: Rubygems (${{ matrix.ruby }})

--- a/.github/workflows/windows-rubygems.yml
+++ b/.github/workflows/windows-rubygems.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ci-${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   windows_rubygems:
     name: Rubygems on Windows (${{ matrix.ruby.name }})


### PR DESCRIPTION
## What is your fix for the problem, implemented in this PR?

https://github.com/rubygems/rubygems/pull/6077 missed to add the permission configurations for the some of workflows. I added it to them.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
