### PR TITLE
Remove pointer to RVM documentation

### DIFF
--- a/bundler/lib/bundler/fetcher.rb
+++ b/bundler/lib/bundler/fetcher.rb
@@ -40,8 +40,7 @@ module Bundler
       def initialize(msg = nil)
         super msg || "Could not load OpenSSL.\n" \
             "You must recompile Ruby with OpenSSL support or change the sources in your " \
-            "Gemfile from 'https' to 'http'. Instructions for compiling with OpenSSL " \
-            "using RVM are available at rvm.io/packages/openssl."
+            "Gemfile from 'https' to 'http'."
       end
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Ran `bundle outdated` and received an error message about openssl.

```
$ bundle outdated
Could not load OpenSSL.
You must recompile Ruby with OpenSSL support or change the sources in your Gemfile from 'https' to 'http'. Instructions for compiling with OpenSSL using
RVM are available at rvm.io/packages/openssl.
```

## What is your fix for the problem, implemented in this PR?

Remove the pointer to the RVM documentation. I don't have RVM and the link doesn't provide instructions on how to fix the openssl issue.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
