### PR TITLE
Don't instruct people to switch from https to http

### DIFF
--- a/bundler/lib/bundler/fetcher.rb
+++ b/bundler/lib/bundler/fetcher.rb
@@ -29,9 +29,7 @@ module Bundler
           " is a chance you are experiencing a man-in-the-middle attack, but" \
           " most likely your system doesn't have the CA certificates needed" \
           " for verification. For information about OpenSSL certificates, see" \
-          " https://railsapps.github.io/openssl-certificate-verify-failed.html." \
-          " To connect without using SSL, edit your Gemfile" \
-          " sources and change 'https' to 'http'."
+          " https://railsapps.github.io/openssl-certificate-verify-failed.html."
       end
     end
 
@@ -39,9 +37,9 @@ module Bundler
     class SSLError < HTTPError
       def initialize(msg = nil)
         super msg || "Could not load OpenSSL.\n" \
-            "You must recompile Ruby with OpenSSL support or change the sources in your " \
-            "Gemfile from 'https' to 'http'. Instructions for compiling with OpenSSL " \
-            "using RVM are available at rvm.io/packages/openssl."
+            "You must recompile Ruby with OpenSSL support. Instructions for " \
+            "compiling with OpenSSL using RVM are available at " \
+            "rvm.io/packages/openssl."
       end
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Ran `bundle outdated` and was instructed to change sources in Gemfile to http.

```
$ bundle outdated
Could not load OpenSSL.
You must recompile Ruby with OpenSSL support or change the sources in your Gemfile from
'https' to 'http'. Instructions for compiling with OpenSSL using RVM are available at
rvm.io/packages/openssl.
```

## What is your fix for the problem, implemented in this PR?

Don't instruct people to switch from https to http

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
