### PR TITLE
Fix lockfile losing some dependencies when globally installed gemspecs include incorrect dependency information

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -299,7 +299,7 @@ module Bundler
 
       if @locked_bundler_version
         locked_major = @locked_bundler_version.segments.first
-        current_major = Gem::Version.create(Bundler::VERSION).segments.first
+        current_major = Bundler.gem_version.segments.first
 
         updating_major = locked_major < current_major
       end
@@ -516,7 +516,7 @@ module Bundler
         specs = resolve.materialize(dependencies)
       end
 
-      bundler = sources.metadata_source.specs.search(Gem::Dependency.new("bundler", VERSION)).last
+      bundler = sources.metadata_source.specs.search(["bundler", Bundler.gem_version]).last
       specs["bundler"] = bundler
 
       specs

--- a/bundler/lib/bundler/index.rb
+++ b/bundler/lib/bundler/index.rb
@@ -70,7 +70,7 @@ module Bundler
       case query
       when Gem::Specification, RemoteSpecification, LazySpecification, EndpointSpecification then search_by_spec(query)
       when String then specs_by_name(query)
-      when Gem::Dependency then search_by_dependency(query)
+      when Array then specs_by_name_and_version(*query)
       else
         raise "You can't search for a #{query.inspect}."
       end
@@ -157,20 +157,12 @@ module Bundler
 
     private
 
-    def specs_by_name(name)
-      @specs[name].values
+    def specs_by_name_and_version(name, version)
+      specs_by_name(name).select {|spec| spec.version == version }
     end
 
-    def search_by_dependency(dependency)
-      @cache[dependency] ||= begin
-        specs = specs_by_name(dependency.name)
-        found = specs.select do |spec|
-          next true if spec.source.is_a?(Source::Gemspec)
-          dependency.matches_spec?(spec)
-        end
-
-        found
-      end
+    def specs_by_name(name)
+      @specs[name].values
     end
 
     EMPTY_SEARCH = [].freeze

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -79,7 +79,7 @@ module Bundler
       candidates = if source.is_a?(Source::Path) || !ruby_platform_materializes_to_ruby_platform?
         target_platform = ruby_platform_materializes_to_ruby_platform? ? platform : local_platform
 
-        GemHelpers.select_best_platform_match(source.specs.search(Dependency.new(name, version)), target_platform)
+        GemHelpers.select_best_platform_match(source.specs.search([name, version]), target_platform)
       else
         source.specs.search(self)
       end

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -340,21 +340,17 @@ module Bundler
             o << %(\n  Current Bundler version:\n    bundler (#{Bundler::VERSION}))
 
             conflict_dependency = conflict.requirement
-            conflict_requirement = conflict_dependency.requirement
-            other_bundler_required = !conflict_requirement.satisfied_by?(Gem::Version.new(Bundler::VERSION))
 
-            if other_bundler_required
-              o << "\n\n"
+            o << "\n\n"
 
-              candidate_specs = source_for(:default_bundler).specs.search(conflict_dependency)
-              if candidate_specs.any?
-                target_version = candidate_specs.last.version
-                new_command = [File.basename($PROGRAM_NAME), "_#{target_version}_", *ARGV].join(" ")
-                o << "Your bundle requires a different version of Bundler than the one you're running.\n"
-                o << "Install the necessary version with `gem install bundler:#{target_version}` and rerun bundler using `#{new_command}`\n"
-              else
-                o << "Your bundle requires a different version of Bundler than the one you're running, and that version could not be found.\n"
-              end
+            candidate_specs = source_for(:default_bundler).specs.search(conflict_dependency)
+            if candidate_specs.any?
+              target_version = candidate_specs.last.version
+              new_command = [File.basename($PROGRAM_NAME), "_#{target_version}_", *ARGV].join(" ")
+              o << "Your bundle requires a different version of Bundler than the one you're running.\n"
+              o << "Install the necessary version with `gem install bundler:#{target_version}` and rerun bundler using `#{new_command}`\n"
+            else
+              o << "Your bundle requires a different version of Bundler than the one you're running, and that version could not be found.\n"
             end
           elsif name.end_with?("\0")
             o << %(\n  Current #{name} version:\n    #{SharedHelpers.pretty_dependency(@metadata_requirements.find {|req| req.name == name })}\n\n)

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -103,9 +103,8 @@ module Bundler
     def search_for(dependency)
       @search_for[dependency] ||= begin
         name = dependency.name
-        locked_results = @base[name].select {|spec| requirement_satisfied_by?(dependency, nil, spec) }
+        results = (@base[name] + results_for(name)).select {|spec| requirement_satisfied_by?(dependency, nil, spec) }
         locked_requirement = base_requirements[name]
-        results = results_for(dependency) + locked_results
         results = results.select {|spec| requirement_satisfied_by?(locked_requirement, nil, spec) } if locked_requirement
         dep_platforms = dependency.gem_platforms(@platforms)
 
@@ -133,16 +132,16 @@ module Bundler
       end
     end
 
-    def index_for(dependency)
-      source_for(dependency.name).specs
+    def index_for(name)
+      source_for(name).specs
     end
 
     def source_for(name)
       @source_requirements[name] || @source_requirements[:default]
     end
 
-    def results_for(dependency)
-      @results_for[dependency] ||= index_for(dependency).search(dependency)
+    def results_for(name)
+      @results_for[name] ||= index_for(name).search(name)
     end
 
     def name_for(dependency)
@@ -187,10 +186,10 @@ module Bundler
     def remove_from_candidates(spec)
       @base.delete(spec)
 
-      @results_for.keys.each do |dep|
-        next unless dep.name == spec.name
+      @results_for.keys.each do |name|
+        next unless name == spec.name
 
-        @results_for[dep].reject {|s| s.name == spec.name && s.version == spec.version }
+        @results_for[name].reject {|s| s.version == spec.version }
       end
 
       reset_spec_cache
@@ -212,7 +211,7 @@ module Bundler
       @amount_constrained[dependency.name] ||= if (base = @base[dependency.name]) && !base.empty?
         dependency.requirement.satisfied_by?(base.first.version) ? 0 : 1
       else
-        all = index_for(dependency).search(dependency.name).size
+        all = results_for(dependency.name).size
 
         if all <= 1
           all - 1_000_000
@@ -343,7 +342,7 @@ module Bundler
 
             o << "\n\n"
 
-            candidate_specs = source_for(:default_bundler).specs.search(conflict_dependency)
+            candidate_specs = source_for(:default_bundler).specs.search(name).select {|spec| requirement_satisfied_by?(conflict_dependency, nil, spec) }
             if candidate_specs.any?
               target_version = candidate_specs.last.version
               new_command = [File.basename($PROGRAM_NAME), "_#{target_version}_", *ARGV].join(" ")

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -108,7 +108,7 @@ module Bundler
         results = results.select {|spec| requirement_satisfied_by?(locked_requirement, nil, spec) } if locked_requirement
         dep_platforms = dependency.gem_platforms(@platforms)
 
-        @gem_version_promoter.sort_versions(dependency, results).group_by(&:version).reduce([]) do |groups, (_, specs)|
+        spec_groups = results.group_by(&:version).reduce([]) do |groups, (_, specs)|
           relevant_platforms = dep_platforms.select {|platform| specs.any? {|spec| spec.match_platform(platform) } }
           next groups unless relevant_platforms.any?
 
@@ -129,6 +129,8 @@ module Bundler
 
           groups
         end
+
+        @gem_version_promoter.sort_versions(dependency, spec_groups)
       end
     end
 

--- a/bundler/lib/bundler/version.rb
+++ b/bundler/lib/bundler/version.rb
@@ -6,4 +6,8 @@ module Bundler
   def self.bundler_major_version
     @bundler_major_version ||= VERSION.split(".").first.to_i
   end
+
+  def self.gem_version
+    @gem_version ||= Gem::Version.create(VERSION)
+  end
 end

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -595,4 +595,74 @@ RSpec.describe "bundle lock" do
       expect(read_lockfile).to eq(@lockfile.sub("foo (1.0)", "foo (2.0)").sub(/foo$/, "foo (= 2.0)"))
     end
   end
+
+  context "when a system gem has incorrect dependencies, different from the lockfile" do
+    before do
+      build_repo4 do
+        build_gem "debug", "1.6.3" do |s|
+          s.add_dependency "irb", ">= 1.3.6"
+        end
+
+        build_gem "irb", "1.5.0"
+      end
+
+      system_gems "irb-1.5.0", :gem_repo => gem_repo4
+      system_gems "debug-1.6.3", :gem_repo => gem_repo4
+
+      # simulate gemspec with wrong empty dependencies
+      debug_gemspec_path = system_gem_path("specifications/debug-1.6.3.gemspec")
+      debug_gemspec = Gem::Specification.load(debug_gemspec_path.to_s)
+      debug_gemspec.instance_variable_set(:@dependencies, [])
+      File.write(debug_gemspec_path, debug_gemspec.to_ruby)
+    end
+
+    it "respects the existing lockfile, even when reresolving" do
+      gemfile <<~G
+        source "#{file_uri_for(gem_repo4)}"
+
+        gem "debug"
+      G
+
+      lockfile <<~L
+        GEM
+          remote: #{file_uri_for(gem_repo4)}/
+          specs:
+            debug (1.6.3)
+              irb (>= 1.3.6)
+            irb (1.5.0)
+
+        PLATFORMS
+          x86_64-linux
+
+        DEPENDENCIES
+          debug
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      simulate_platform "arm64-darwin-22" do
+        bundle "lock"
+      end
+
+      expect(lockfile).to eq <<~L
+        GEM
+          remote: #{file_uri_for(gem_repo4)}/
+          specs:
+            debug (1.6.3)
+              irb (>= 1.3.6)
+            irb (1.5.0)
+
+        PLATFORMS
+          arm64-darwin-22
+          x86_64-linux
+
+        DEPENDENCIES
+          debug
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+    end
+  end
 end

--- a/bundler/spec/realworld/edgecases_spec.rb
+++ b/bundler/spec/realworld/edgecases_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe "real world edgecases", :realworld => true do
         source = Bundler::Source::Rubygems::Remote.new(Bundler::URI("https://rubygems.org"))
         fetcher = Bundler::Fetcher.new(source)
         index = fetcher.specs([#{name.dump}], nil)
-        index.search(Gem::Dependency.new(#{name.dump}, #{requirement.dump})).last
+        requirement = Gem::Requirement.create(#{requirement.dump})
+        index.search(#{name.dump}).select {|spec| requirement.satisfied_by?(spec.version) }.last
       end
       if rubygem.nil?
         raise "Could not find #{name} (#{requirement}) on rubygems.org!\n" \


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If a globally installed gemspec includes incorrect dependency information, this mistake may be leaked into the lockfile, making it lose some information.

## What is your fix for the problem, implemented in this PR?

My fix is to backport the change that fixed it from master into our stable branch, so that I can release Bundler 2.3.27 with this fix.

Also added a regression spec which I will forward port to master later.

Fixes #6082.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
