### PR TITLE
Respect --no-install option for git: sources

### DIFF
--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -173,6 +173,7 @@ module Bundler
       end
 
       def install(spec, options = {})
+        return if Bundler.settings[:no_install]
         force = options[:force]
 
         print_using_message "Using #{version_message(spec, options[:previous_spec])} from #{self}"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Currently, the --no-install option to `bundle package` is totally ignored for git sources. This can have very strange effects if you have:

- a git-sourced gem,
- with native extensions,
- whose extconf.rb script depends on another gem,
- which is installed from Rubygems in the gemfile.

In that circumstance, `bundle package --no-install --all` will download the Rubygems dependencies to `vendor/cache` but NOT install them. It will also check out the git gems to `vendor/cache` (good), and attempt to build their native extensions (bad!).

The native extension build will fail because the extconf.rb script crashes, since the dependency it needs is missing.


## What is your fix for the problem, implemented in this PR?
I implemented a fix for this in `source/git.rb` as an early return if `Bundle.settings[:no_install]`, since this is analogous to what's happening in `source/rubygems.rb`.

I do admit though the whole thing is a little strange though - an "install" method that.... proceeds to look at a global flag to not install anything.

At this point, if you think this is the right solution for the problem, I can whip up a test and then get this merged. If you think there's a better way to factor this package functionality though I'm all ears.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
