### PR TITLE
In README generated by `bundle gem`, do not fill rubygems.org install commands with the gem name automatically

### DIFF
--- a/bundler/lib/bundler/templates/newgem/README.md.tt
+++ b/bundler/lib/bundler/templates/newgem/README.md.tt
@@ -1,18 +1,20 @@
 # <%= config[:constant_name] %>
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/<%= config[:namespaced_path] %>`. To experiment with that code, run `bin/console` for an interactive prompt.
+TODO: Delete this and the text below, and describe your gem
 
-TODO: Delete this and the text above, and describe your gem
+Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/<%= config[:namespaced_path] %>`. To experiment with that code, run `bin/console` for an interactive prompt.
 
 ## Installation
 
+TODO: Replace `UPDATE_WITH_YOUR_GEM_NAME_PRIOR_TO_RELEASE_TO_RUBYGEMS_ORG` with your gem name right after releasing it to RubyGems.org. Please do not do it earlier due to security reasons. Alternatively, replace this section with instructions to install your gem from git if you don't plan to release to RubyGems.org.
+
 Install the gem and add to the application's Gemfile by executing:
 
-    $ bundle add <%= config[:name] %>
+    $ bundle add UPDATE_WITH_YOUR_GEM_NAME_PRIOR_TO_RELEASE_TO_RUBYGEMS_ORG
 
 If bundler is not being used to manage dependencies, install the gem by executing:
 
-    $ gem install <%= config[:name] %>
+    $ gem install UPDATE_WITH_YOUR_GEM_NAME_PRIOR_TO_RELEASE_TO_RUBYGEMS_ORG
 
 ## Usage
 


### PR DESCRIPTION
This PR comes as part of our security work. With @simi, @indirect, and @hsbt  an increase in brandjacking attacks where the brand's origin comes from scanning GH for names defined in the README.md but not in RubyGems.

It seems that often the default flow for people is to start their gems and upload them to GitHub without actually releasing them to RubyGems. In such cases or in cases where the author does not want to publish to RubyGems at all, the package name can be taken over and used for malicious activities, hoping someone will follow along with the recommendation from the README to install from RubyGems.
