### PR TITLE
Avoid deprecated Gem::Platform.match in Gem::Resolver::InstallerSet

### DIFF
--- a/lib/rubygems/resolver/installer_set.rb
+++ b/lib/rubygems/resolver/installer_set.rb
@@ -66,7 +66,7 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
 
     found = found.select do |s|
       Gem::Source::SpecificFile === s.source ||
-        Gem::Platform.match(s.platform)
+        Gem::Platform.match_spec?(s)
     end
 
     found = found.sort_by do |s|


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

TruffleRuby emits a warning when Gem::Platform.match is used because that ignores [the ](https://github.com/rubygems/rubygems/blob/f11febd91f1b0f9908c885aa6469d7ea0793fe04/lib/rubygems/platform.rb#L39-L40)

## What is your fix for the problem, implemented in this PR?

Use the non-deprecated method which can also use the name.
This usage was added in https://github.com/rubygems/rubygems/pull/5820

Probably we should really deprecate `Gem::Platform.match` so it's not used accidentally anymore.
Maybe it's enough to only warn about it when running RubyGems & Bundler tests?
About deprecation, see https://github.com/rubygems/rubygems/pull/3817/files#r453293031 and https://github.com/rubygems/rubygems/pull/4096
cc @deivid-rodriguez 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
