### PR TITLE
Fix display of previous gem version when previously downloaded already

### DIFF
--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -145,7 +145,7 @@ module Bundler
         end
 
         if installed?(spec) && !force
-          print_using_message "Using #{version_message(spec)}"
+          print_using_message "Using #{version_message(spec, options[:previous_spec])}"
           return nil # no post-install message
         end
 

--- a/bundler/spec/install/bundler_spec.rb
+++ b/bundler/spec/install/bundler_spec.rb
@@ -210,6 +210,33 @@ RSpec.describe "bundle install" do
       expect(err).to be_empty
     end
 
+    it "prints the previous version when switching to a previously downloaded gem" do
+      build_repo4 do
+        build_gem "rails", "7.0.3"
+        build_gem "rails", "7.0.4"
+      end
+
+      bundle "config set path.system true"
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo4)}"
+        gem 'rails', "7.0.4"
+      G
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo4)}"
+        gem 'rails', "7.0.3"
+      G
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo4)}"
+        gem 'rails', "7.0.4"
+      G
+
+      expect(out).to include("Using rails 7.0.4 (was 7.0.3)")
+      expect(err).to be_empty
+    end
+
     it "can install dependencies with newer bundler version with system gems" do
       bundle "config set path.system true"
 


### PR DESCRIPTION

## What was the end-user or developer problem that led to this PR?

`bundle update` is no longer showing the green ` (was: x.y.z)` suffix for updated gems that were already installed (eg: by another app).

This displayed in bundler <= 2.3.13 and went missing in 2.3.14.

## What is your fix for the problem, implemented in this PR?

This PR reenables the "was..." suffix, which matches what was displayed both in bundler <= 2.3.13 and as still displayed in the current version for newly downloaded gems and for sources other than Rubygems.

In <= 2.3.13 and again with this PR:
```
Using rails 7.0.4 (was 7.0.3)
```
In 2.3.14+:
```
Using rails 7.0.4
```

## Background

A number of changes surrounding tracking of the previous gem version were made in #5530, which was part of bundler 2.3.14. It appears those changes simply missed passing the previous spec info to the newly enhanced `version_message` method in the described case.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
