### PR TITLE
Bump vendored deps

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -123,16 +123,15 @@ if File.exist?("util/automatiek.rake")
     lib.prefix = "Gem::Resolver"
     lib.vendor_lib = "lib/rubygems/resolver/molinillo"
     lib.license_path = "LICENSE"
-  end
 
-  desc "Vendor a specific version of tsort"
-  Automatiek::RakeTask.new("tsort") do |lib|
-    lib.version = "master"
-    lib.download = { :github => "https://github.com/ruby/tsort" }
-    lib.namespace = "TSort"
-    lib.prefix = "Gem"
-    lib.vendor_lib = "lib/rubygems/tsort"
-    lib.license_path = "LICENSE.txt"
+    lib.dependency("tsort") do |sublib|
+      sublib.version = "v0.1.1"
+      sublib.download = { :github => "https://github.com/ruby/tsort" }
+      sublib.namespace = "TSort"
+      sublib.prefix = "Gem"
+      sublib.vendor_lib = "lib/rubygems/tsort"
+      sublib.license_path = "LICENSE.txt"
+    end
   end
 
   # We currently ship optparse 0.2.0 plus the following changes:

--- a/Rakefile
+++ b/Rakefile
@@ -134,19 +134,15 @@ if File.exist?("util/automatiek.rake")
     end
   end
 
-  # We currently ship optparse 0.2.0 plus the following changes:
+  # We currently ship optparse 0.3.0 plus the following changes:
   # * Remove top aliasing the `::OptParse` constant to `OptionParser`, since we
   #   don't need it and it triggers redefinition warnings since the default
   #   optparse gem also does the aliasing.
-  # * Restore support for old versions of `did_you_mean` so that our vendored
-  #   copy works consistently in all supported rubies. This one can be removed
-  #   once we drop ruby 2.4 support, since newer versions include a version of
-  #   `did_you_mean` that does not require any changes.
   # * Add an empty .document file to the library's root path to hint RDoc that
   #   this library should not be documented.
   desc "Vendor a specific version of optparse"
   Automatiek::RakeTask.new("optparse") do |lib|
-    lib.version = "master"
+    lib.version = "v0.3.0"
     lib.download = { :github => "https://github.com/ruby/optparse" }
     lib.namespace = "OptionParser"
     lib.prefix = "Gem"

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph.rb
@@ -32,7 +32,7 @@ module Gem::Resolver::Molinillo
     #   all belong to the same graph.
     # @return [Array<Vertex>] The sorted vertices.
     def self.tsort(vertices)
-      TSort.tsort(
+      Gem::TSort.tsort(
         lambda { |b| vertices.each(&b) },
         lambda { |v, &b| (v.successors & vertices).each(&b) }
       )

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/errors.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/errors.rb
@@ -107,36 +107,42 @@ module Gem::Resolver::Molinillo
         end
       end
 
-      conflicts.sort.reduce(''.dup) do |o, (name, conflict)|
-        o << "\n" << incompatible_version_message_for_conflict.call(name, conflict) << "\n"
-        if conflict.locked_requirement
-          o << %(  In snapshot (#{name_for_locking_dependency_source}):\n)
-          o << %(    #{printable_requirement.call(conflict.locked_requirement)}\n)
-          o << %(\n)
-        end
-        o << %(  In #{name_for_explicit_dependency_source}:\n)
-        trees = reduce_trees.call(conflict.requirement_trees)
-
-        o << trees.map do |tree|
-          t = ''.dup
-          depth = 2
-          tree.each do |req|
-            t << '  ' * depth << printable_requirement.call(req)
-            unless tree.last == req
-              if spec = conflict.activated_by_name[name_for(req)]
-                t << %( was resolved to #{version_for_spec.call(spec)}, which)
-              end
-              t << %( depends on)
-            end
-            t << %(\n)
-            depth += 1
+      full_message_for_conflict = opts.delete(:full_message_for_conflict) do
+        proc do |name, conflict|
+          o = "\n".dup << incompatible_version_message_for_conflict.call(name, conflict) << "\n"
+          if conflict.locked_requirement
+            o << %(  In snapshot (#{name_for_locking_dependency_source}):\n)
+            o << %(    #{printable_requirement.call(conflict.locked_requirement)}\n)
+            o << %(\n)
           end
-          t
-        end.join("\n")
+          o << %(  In #{name_for_explicit_dependency_source}:\n)
+          trees = reduce_trees.call(conflict.requirement_trees)
 
-        additional_message_for_conflict.call(o, name, conflict)
+          o << trees.map do |tree|
+            t = ''.dup
+            depth = 2
+            tree.each do |req|
+              t << '  ' * depth << printable_requirement.call(req)
+              unless tree.last == req
+                if spec = conflict.activated_by_name[name_for(req)]
+                  t << %( was resolved to #{version_for_spec.call(spec)}, which)
+                end
+                t << %( depends on)
+              end
+              t << %(\n)
+              depth += 1
+            end
+            t
+          end.join("\n")
 
-        o
+          additional_message_for_conflict.call(o, name, conflict)
+
+          o
+        end
+      end
+
+      conflicts.sort.reduce(''.dup) do |o, (name, conflict)|
+        o << full_message_for_conflict.call(name, conflict)
       end.strip
     end
   end

--- a/lib/rubygems/resolver/molinillo/lib/molinillo/gem_metadata.rb
+++ b/lib/rubygems/resolver/molinillo/lib/molinillo/gem_metadata.rb
@@ -2,5 +2,5 @@
 
 module Gem::Resolver::Molinillo
   # The version of Gem::Resolver::Molinillo.
-  VERSION = '0.7.0'.freeze
+  VERSION = '0.8.0'.freeze
 end

--- a/lib/rubygems/tsort/lib/tsort.rb
+++ b/lib/rubygems/tsort/lib/tsort.rb
@@ -121,334 +121,332 @@
 # <em>SIAM Journal on Computing</em>, Vol. 1, No. 2, pp. 146-160, June 1972.
 #
 
-module Gem
-  module TSort
-    class Cyclic < StandardError
-    end
+module Gem::TSort
+  class Cyclic < StandardError
+  end
 
-    # Returns a topologically sorted array of nodes.
-    # The array is sorted from children to parents, i.e.
-    # the first element has no child and the last node has no parent.
-    #
-    # If there is a cycle, Gem::TSort::Cyclic is raised.
-    #
-    #   class G
-    #     include Gem::TSort
-    #     def initialize(g)
-    #       @g = g
-    #     end
-    #     def tsort_each_child(n, &b) @g[n].each(&b) end
-    #     def tsort_each_node(&b) @g.each_key(&b) end
-    #   end
-    #
-    #   graph = G.new({1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]})
-    #   p graph.tsort #=> [4, 2, 3, 1]
-    #
-    #   graph = G.new({1=>[2], 2=>[3, 4], 3=>[2], 4=>[]})
-    #   p graph.tsort # raises Gem::TSort::Cyclic
-    #
-    def tsort
-      each_node = method(:tsort_each_node)
-      each_child = method(:tsort_each_child)
-      Gem::TSort.tsort(each_node, each_child)
-    end
+  # Returns a topologically sorted array of nodes.
+  # The array is sorted from children to parents, i.e.
+  # the first element has no child and the last node has no parent.
+  #
+  # If there is a cycle, Gem::TSort::Cyclic is raised.
+  #
+  #   class G
+  #     include Gem::TSort
+  #     def initialize(g)
+  #       @g = g
+  #     end
+  #     def tsort_each_child(n, &b) @g[n].each(&b) end
+  #     def tsort_each_node(&b) @g.each_key(&b) end
+  #   end
+  #
+  #   graph = G.new({1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]})
+  #   p graph.tsort #=> [4, 2, 3, 1]
+  #
+  #   graph = G.new({1=>[2], 2=>[3, 4], 3=>[2], 4=>[]})
+  #   p graph.tsort # raises Gem::TSort::Cyclic
+  #
+  def tsort
+    each_node = method(:tsort_each_node)
+    each_child = method(:tsort_each_child)
+    Gem::TSort.tsort(each_node, each_child)
+  end
 
-    # Returns a topologically sorted array of nodes.
-    # The array is sorted from children to parents, i.e.
-    # the first element has no child and the last node has no parent.
-    #
-    # The graph is represented by _each_node_ and _each_child_.
-    # _each_node_ should have +call+ method which yields for each node in the graph.
-    # _each_child_ should have +call+ method which takes a node argument and yields for each child node.
-    #
-    # If there is a cycle, Gem::TSort::Cyclic is raised.
-    #
-    #   g = {1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]}
-    #   each_node = lambda {|&b| g.each_key(&b) }
-    #   each_child = lambda {|n, &b| g[n].each(&b) }
-    #   p Gem::TSort.tsort(each_node, each_child) #=> [4, 2, 3, 1]
-    #
-    #   g = {1=>[2], 2=>[3, 4], 3=>[2], 4=>[]}
-    #   each_node = lambda {|&b| g.each_key(&b) }
-    #   each_child = lambda {|n, &b| g[n].each(&b) }
-    #   p Gem::TSort.tsort(each_node, each_child) # raises Gem::TSort::Cyclic
-    #
-    def TSort.tsort(each_node, each_child)
-      Gem::TSort.tsort_each(each_node, each_child).to_a
-    end
+  # Returns a topologically sorted array of nodes.
+  # The array is sorted from children to parents, i.e.
+  # the first element has no child and the last node has no parent.
+  #
+  # The graph is represented by _each_node_ and _each_child_.
+  # _each_node_ should have +call+ method which yields for each node in the graph.
+  # _each_child_ should have +call+ method which takes a node argument and yields for each child node.
+  #
+  # If there is a cycle, Gem::TSort::Cyclic is raised.
+  #
+  #   g = {1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]}
+  #   each_node = lambda {|&b| g.each_key(&b) }
+  #   each_child = lambda {|n, &b| g[n].each(&b) }
+  #   p Gem::TSort.tsort(each_node, each_child) #=> [4, 2, 3, 1]
+  #
+  #   g = {1=>[2], 2=>[3, 4], 3=>[2], 4=>[]}
+  #   each_node = lambda {|&b| g.each_key(&b) }
+  #   each_child = lambda {|n, &b| g[n].each(&b) }
+  #   p Gem::TSort.tsort(each_node, each_child) # raises Gem::TSort::Cyclic
+  #
+  def self.tsort(each_node, each_child)
+    tsort_each(each_node, each_child).to_a
+  end
 
-    # The iterator version of the #tsort method.
-    # <tt><em>obj</em>.tsort_each</tt> is similar to <tt><em>obj</em>.tsort.each</tt>, but
-    # modification of _obj_ during the iteration may lead to unexpected results.
-    #
-    # #tsort_each returns +nil+.
-    # If there is a cycle, Gem::TSort::Cyclic is raised.
-    #
-    #   class G
-    #     include Gem::TSort
-    #     def initialize(g)
-    #       @g = g
-    #     end
-    #     def tsort_each_child(n, &b) @g[n].each(&b) end
-    #     def tsort_each_node(&b) @g.each_key(&b) end
-    #   end
-    #
-    #   graph = G.new({1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]})
-    #   graph.tsort_each {|n| p n }
-    #   #=> 4
-    #   #   2
-    #   #   3
-    #   #   1
-    #
-    def tsort_each(&block) # :yields: node
-      each_node = method(:tsort_each_node)
-      each_child = method(:tsort_each_child)
-      Gem::TSort.tsort_each(each_node, each_child, &block)
-    end
+  # The iterator version of the #tsort method.
+  # <tt><em>obj</em>.tsort_each</tt> is similar to <tt><em>obj</em>.tsort.each</tt>, but
+  # modification of _obj_ during the iteration may lead to unexpected results.
+  #
+  # #tsort_each returns +nil+.
+  # If there is a cycle, Gem::TSort::Cyclic is raised.
+  #
+  #   class G
+  #     include Gem::TSort
+  #     def initialize(g)
+  #       @g = g
+  #     end
+  #     def tsort_each_child(n, &b) @g[n].each(&b) end
+  #     def tsort_each_node(&b) @g.each_key(&b) end
+  #   end
+  #
+  #   graph = G.new({1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]})
+  #   graph.tsort_each {|n| p n }
+  #   #=> 4
+  #   #   2
+  #   #   3
+  #   #   1
+  #
+  def tsort_each(&block) # :yields: node
+    each_node = method(:tsort_each_node)
+    each_child = method(:tsort_each_child)
+    Gem::TSort.tsort_each(each_node, each_child, &block)
+  end
 
-    # The iterator version of the Gem::TSort.tsort method.
-    #
-    # The graph is represented by _each_node_ and _each_child_.
-    # _each_node_ should have +call+ method which yields for each node in the graph.
-    # _each_child_ should have +call+ method which takes a node argument and yields for each child node.
-    #
-    #   g = {1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]}
-    #   each_node = lambda {|&b| g.each_key(&b) }
-    #   each_child = lambda {|n, &b| g[n].each(&b) }
-    #   Gem::TSort.tsort_each(each_node, each_child) {|n| p n }
-    #   #=> 4
-    #   #   2
-    #   #   3
-    #   #   1
-    #
-    def TSort.tsort_each(each_node, each_child) # :yields: node
-      return to_enum(__method__, each_node, each_child) unless block_given?
+  # The iterator version of the Gem::TSort.tsort method.
+  #
+  # The graph is represented by _each_node_ and _each_child_.
+  # _each_node_ should have +call+ method which yields for each node in the graph.
+  # _each_child_ should have +call+ method which takes a node argument and yields for each child node.
+  #
+  #   g = {1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]}
+  #   each_node = lambda {|&b| g.each_key(&b) }
+  #   each_child = lambda {|n, &b| g[n].each(&b) }
+  #   Gem::TSort.tsort_each(each_node, each_child) {|n| p n }
+  #   #=> 4
+  #   #   2
+  #   #   3
+  #   #   1
+  #
+  def self.tsort_each(each_node, each_child) # :yields: node
+    return to_enum(__method__, each_node, each_child) unless block_given?
 
-      Gem::TSort.each_strongly_connected_component(each_node, each_child) {|component|
-        if component.size == 1
-          yield component.first
-        else
-          raise Cyclic.new("topological sort failed: #{component.inspect}")
-        end
-      }
-    end
+    each_strongly_connected_component(each_node, each_child) {|component|
+      if component.size == 1
+        yield component.first
+      else
+        raise Cyclic.new("topological sort failed: #{component.inspect}")
+      end
+    }
+  end
 
-    # Returns strongly connected components as an array of arrays of nodes.
-    # The array is sorted from children to parents.
-    # Each elements of the array represents a strongly connected component.
-    #
-    #   class G
-    #     include Gem::TSort
-    #     def initialize(g)
-    #       @g = g
-    #     end
-    #     def tsort_each_child(n, &b) @g[n].each(&b) end
-    #     def tsort_each_node(&b) @g.each_key(&b) end
-    #   end
-    #
-    #   graph = G.new({1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]})
-    #   p graph.strongly_connected_components #=> [[4], [2], [3], [1]]
-    #
-    #   graph = G.new({1=>[2], 2=>[3, 4], 3=>[2], 4=>[]})
-    #   p graph.strongly_connected_components #=> [[4], [2, 3], [1]]
-    #
-    def strongly_connected_components
-      each_node = method(:tsort_each_node)
-      each_child = method(:tsort_each_child)
-      Gem::TSort.strongly_connected_components(each_node, each_child)
-    end
+  # Returns strongly connected components as an array of arrays of nodes.
+  # The array is sorted from children to parents.
+  # Each elements of the array represents a strongly connected component.
+  #
+  #   class G
+  #     include Gem::TSort
+  #     def initialize(g)
+  #       @g = g
+  #     end
+  #     def tsort_each_child(n, &b) @g[n].each(&b) end
+  #     def tsort_each_node(&b) @g.each_key(&b) end
+  #   end
+  #
+  #   graph = G.new({1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]})
+  #   p graph.strongly_connected_components #=> [[4], [2], [3], [1]]
+  #
+  #   graph = G.new({1=>[2], 2=>[3, 4], 3=>[2], 4=>[]})
+  #   p graph.strongly_connected_components #=> [[4], [2, 3], [1]]
+  #
+  def strongly_connected_components
+    each_node = method(:tsort_each_node)
+    each_child = method(:tsort_each_child)
+    Gem::TSort.strongly_connected_components(each_node, each_child)
+  end
 
-    # Returns strongly connected components as an array of arrays of nodes.
-    # The array is sorted from children to parents.
-    # Each elements of the array represents a strongly connected component.
-    #
-    # The graph is represented by _each_node_ and _each_child_.
-    # _each_node_ should have +call+ method which yields for each node in the graph.
-    # _each_child_ should have +call+ method which takes a node argument and yields for each child node.
-    #
-    #   g = {1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]}
-    #   each_node = lambda {|&b| g.each_key(&b) }
-    #   each_child = lambda {|n, &b| g[n].each(&b) }
-    #   p Gem::TSort.strongly_connected_components(each_node, each_child)
-    #   #=> [[4], [2], [3], [1]]
-    #
-    #   g = {1=>[2], 2=>[3, 4], 3=>[2], 4=>[]}
-    #   each_node = lambda {|&b| g.each_key(&b) }
-    #   each_child = lambda {|n, &b| g[n].each(&b) }
-    #   p Gem::TSort.strongly_connected_components(each_node, each_child)
-    #   #=> [[4], [2, 3], [1]]
-    #
-    def TSort.strongly_connected_components(each_node, each_child)
-      Gem::TSort.each_strongly_connected_component(each_node, each_child).to_a
-    end
+  # Returns strongly connected components as an array of arrays of nodes.
+  # The array is sorted from children to parents.
+  # Each elements of the array represents a strongly connected component.
+  #
+  # The graph is represented by _each_node_ and _each_child_.
+  # _each_node_ should have +call+ method which yields for each node in the graph.
+  # _each_child_ should have +call+ method which takes a node argument and yields for each child node.
+  #
+  #   g = {1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]}
+  #   each_node = lambda {|&b| g.each_key(&b) }
+  #   each_child = lambda {|n, &b| g[n].each(&b) }
+  #   p Gem::TSort.strongly_connected_components(each_node, each_child)
+  #   #=> [[4], [2], [3], [1]]
+  #
+  #   g = {1=>[2], 2=>[3, 4], 3=>[2], 4=>[]}
+  #   each_node = lambda {|&b| g.each_key(&b) }
+  #   each_child = lambda {|n, &b| g[n].each(&b) }
+  #   p Gem::TSort.strongly_connected_components(each_node, each_child)
+  #   #=> [[4], [2, 3], [1]]
+  #
+  def self.strongly_connected_components(each_node, each_child)
+    each_strongly_connected_component(each_node, each_child).to_a
+  end
 
-    # The iterator version of the #strongly_connected_components method.
-    # <tt><em>obj</em>.each_strongly_connected_component</tt> is similar to
-    # <tt><em>obj</em>.strongly_connected_components.each</tt>, but
-    # modification of _obj_ during the iteration may lead to unexpected results.
-    #
-    # #each_strongly_connected_component returns +nil+.
-    #
-    #   class G
-    #     include Gem::TSort
-    #     def initialize(g)
-    #       @g = g
-    #     end
-    #     def tsort_each_child(n, &b) @g[n].each(&b) end
-    #     def tsort_each_node(&b) @g.each_key(&b) end
-    #   end
-    #
-    #   graph = G.new({1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]})
-    #   graph.each_strongly_connected_component {|scc| p scc }
-    #   #=> [4]
-    #   #   [2]
-    #   #   [3]
-    #   #   [1]
-    #
-    #   graph = G.new({1=>[2], 2=>[3, 4], 3=>[2], 4=>[]})
-    #   graph.each_strongly_connected_component {|scc| p scc }
-    #   #=> [4]
-    #   #   [2, 3]
-    #   #   [1]
-    #
-    def each_strongly_connected_component(&block) # :yields: nodes
-      each_node = method(:tsort_each_node)
-      each_child = method(:tsort_each_child)
-      Gem::TSort.each_strongly_connected_component(each_node, each_child, &block)
-    end
+  # The iterator version of the #strongly_connected_components method.
+  # <tt><em>obj</em>.each_strongly_connected_component</tt> is similar to
+  # <tt><em>obj</em>.strongly_connected_components.each</tt>, but
+  # modification of _obj_ during the iteration may lead to unexpected results.
+  #
+  # #each_strongly_connected_component returns +nil+.
+  #
+  #   class G
+  #     include Gem::TSort
+  #     def initialize(g)
+  #       @g = g
+  #     end
+  #     def tsort_each_child(n, &b) @g[n].each(&b) end
+  #     def tsort_each_node(&b) @g.each_key(&b) end
+  #   end
+  #
+  #   graph = G.new({1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]})
+  #   graph.each_strongly_connected_component {|scc| p scc }
+  #   #=> [4]
+  #   #   [2]
+  #   #   [3]
+  #   #   [1]
+  #
+  #   graph = G.new({1=>[2], 2=>[3, 4], 3=>[2], 4=>[]})
+  #   graph.each_strongly_connected_component {|scc| p scc }
+  #   #=> [4]
+  #   #   [2, 3]
+  #   #   [1]
+  #
+  def each_strongly_connected_component(&block) # :yields: nodes
+    each_node = method(:tsort_each_node)
+    each_child = method(:tsort_each_child)
+    Gem::TSort.each_strongly_connected_component(each_node, each_child, &block)
+  end
 
-    # The iterator version of the Gem::TSort.strongly_connected_components method.
-    #
-    # The graph is represented by _each_node_ and _each_child_.
-    # _each_node_ should have +call+ method which yields for each node in the graph.
-    # _each_child_ should have +call+ method which takes a node argument and yields for each child node.
-    #
-    #   g = {1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]}
-    #   each_node = lambda {|&b| g.each_key(&b) }
-    #   each_child = lambda {|n, &b| g[n].each(&b) }
-    #   Gem::TSort.each_strongly_connected_component(each_node, each_child) {|scc| p scc }
-    #   #=> [4]
-    #   #   [2]
-    #   #   [3]
-    #   #   [1]
-    #
-    #   g = {1=>[2], 2=>[3, 4], 3=>[2], 4=>[]}
-    #   each_node = lambda {|&b| g.each_key(&b) }
-    #   each_child = lambda {|n, &b| g[n].each(&b) }
-    #   Gem::TSort.each_strongly_connected_component(each_node, each_child) {|scc| p scc }
-    #   #=> [4]
-    #   #   [2, 3]
-    #   #   [1]
-    #
-    def TSort.each_strongly_connected_component(each_node, each_child) # :yields: nodes
-      return to_enum(__method__, each_node, each_child) unless block_given?
+  # The iterator version of the Gem::TSort.strongly_connected_components method.
+  #
+  # The graph is represented by _each_node_ and _each_child_.
+  # _each_node_ should have +call+ method which yields for each node in the graph.
+  # _each_child_ should have +call+ method which takes a node argument and yields for each child node.
+  #
+  #   g = {1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]}
+  #   each_node = lambda {|&b| g.each_key(&b) }
+  #   each_child = lambda {|n, &b| g[n].each(&b) }
+  #   Gem::TSort.each_strongly_connected_component(each_node, each_child) {|scc| p scc }
+  #   #=> [4]
+  #   #   [2]
+  #   #   [3]
+  #   #   [1]
+  #
+  #   g = {1=>[2], 2=>[3, 4], 3=>[2], 4=>[]}
+  #   each_node = lambda {|&b| g.each_key(&b) }
+  #   each_child = lambda {|n, &b| g[n].each(&b) }
+  #   Gem::TSort.each_strongly_connected_component(each_node, each_child) {|scc| p scc }
+  #   #=> [4]
+  #   #   [2, 3]
+  #   #   [1]
+  #
+  def self.each_strongly_connected_component(each_node, each_child) # :yields: nodes
+    return to_enum(__method__, each_node, each_child) unless block_given?
 
-      id_map = {}
-      stack = []
-      each_node.call {|node|
-        unless id_map.include? node
-          Gem::TSort.each_strongly_connected_component_from(node, each_child, id_map, stack) {|c|
+    id_map = {}
+    stack = []
+    each_node.call {|node|
+      unless id_map.include? node
+        each_strongly_connected_component_from(node, each_child, id_map, stack) {|c|
+          yield c
+        }
+      end
+    }
+    nil
+  end
+
+  # Iterates over strongly connected component in the subgraph reachable from
+  # _node_.
+  #
+  # Return value is unspecified.
+  #
+  # #each_strongly_connected_component_from doesn't call #tsort_each_node.
+  #
+  #   class G
+  #     include Gem::TSort
+  #     def initialize(g)
+  #       @g = g
+  #     end
+  #     def tsort_each_child(n, &b) @g[n].each(&b) end
+  #     def tsort_each_node(&b) @g.each_key(&b) end
+  #   end
+  #
+  #   graph = G.new({1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]})
+  #   graph.each_strongly_connected_component_from(2) {|scc| p scc }
+  #   #=> [4]
+  #   #   [2]
+  #
+  #   graph = G.new({1=>[2], 2=>[3, 4], 3=>[2], 4=>[]})
+  #   graph.each_strongly_connected_component_from(2) {|scc| p scc }
+  #   #=> [4]
+  #   #   [2, 3]
+  #
+  def each_strongly_connected_component_from(node, id_map={}, stack=[], &block) # :yields: nodes
+    Gem::TSort.each_strongly_connected_component_from(node, method(:tsort_each_child), id_map, stack, &block)
+  end
+
+  # Iterates over strongly connected components in a graph.
+  # The graph is represented by _node_ and _each_child_.
+  #
+  # _node_ is the first node.
+  # _each_child_ should have +call+ method which takes a node argument
+  # and yields for each child node.
+  #
+  # Return value is unspecified.
+  #
+  # #Gem::TSort.each_strongly_connected_component_from is a class method and
+  # it doesn't need a class to represent a graph which includes Gem::TSort.
+  #
+  #   graph = {1=>[2], 2=>[3, 4], 3=>[2], 4=>[]}
+  #   each_child = lambda {|n, &b| graph[n].each(&b) }
+  #   Gem::TSort.each_strongly_connected_component_from(1, each_child) {|scc|
+  #     p scc
+  #   }
+  #   #=> [4]
+  #   #   [2, 3]
+  #   #   [1]
+  #
+  def self.each_strongly_connected_component_from(node, each_child, id_map={}, stack=[]) # :yields: nodes
+    return to_enum(__method__, node, each_child, id_map, stack) unless block_given?
+
+    minimum_id = node_id = id_map[node] = id_map.size
+    stack_length = stack.length
+    stack << node
+
+    each_child.call(node) {|child|
+      if id_map.include? child
+        child_id = id_map[child]
+        minimum_id = child_id if child_id && child_id < minimum_id
+      else
+        sub_minimum_id =
+          each_strongly_connected_component_from(child, each_child, id_map, stack) {|c|
             yield c
           }
-        end
-      }
-      nil
-    end
-
-    # Iterates over strongly connected component in the subgraph reachable from
-    # _node_.
-    #
-    # Return value is unspecified.
-    #
-    # #each_strongly_connected_component_from doesn't call #tsort_each_node.
-    #
-    #   class G
-    #     include Gem::TSort
-    #     def initialize(g)
-    #       @g = g
-    #     end
-    #     def tsort_each_child(n, &b) @g[n].each(&b) end
-    #     def tsort_each_node(&b) @g.each_key(&b) end
-    #   end
-    #
-    #   graph = G.new({1=>[2, 3], 2=>[4], 3=>[2, 4], 4=>[]})
-    #   graph.each_strongly_connected_component_from(2) {|scc| p scc }
-    #   #=> [4]
-    #   #   [2]
-    #
-    #   graph = G.new({1=>[2], 2=>[3, 4], 3=>[2], 4=>[]})
-    #   graph.each_strongly_connected_component_from(2) {|scc| p scc }
-    #   #=> [4]
-    #   #   [2, 3]
-    #
-    def each_strongly_connected_component_from(node, id_map={}, stack=[], &block) # :yields: nodes
-      Gem::TSort.each_strongly_connected_component_from(node, method(:tsort_each_child), id_map, stack, &block)
-    end
-
-    # Iterates over strongly connected components in a graph.
-    # The graph is represented by _node_ and _each_child_.
-    #
-    # _node_ is the first node.
-    # _each_child_ should have +call+ method which takes a node argument
-    # and yields for each child node.
-    #
-    # Return value is unspecified.
-    #
-    # #Gem::TSort.each_strongly_connected_component_from is a class method and
-    # it doesn't need a class to represent a graph which includes Gem::TSort.
-    #
-    #   graph = {1=>[2], 2=>[3, 4], 3=>[2], 4=>[]}
-    #   each_child = lambda {|n, &b| graph[n].each(&b) }
-    #   Gem::TSort.each_strongly_connected_component_from(1, each_child) {|scc|
-    #     p scc
-    #   }
-    #   #=> [4]
-    #   #   [2, 3]
-    #   #   [1]
-    #
-    def TSort.each_strongly_connected_component_from(node, each_child, id_map={}, stack=[]) # :yields: nodes
-      return to_enum(__method__, node, each_child, id_map, stack) unless block_given?
-
-      minimum_id = node_id = id_map[node] = id_map.size
-      stack_length = stack.length
-      stack << node
-
-      each_child.call(node) {|child|
-        if id_map.include? child
-          child_id = id_map[child]
-          minimum_id = child_id if child_id && child_id < minimum_id
-        else
-          sub_minimum_id =
-            Gem::TSort.each_strongly_connected_component_from(child, each_child, id_map, stack) {|c|
-              yield c
-            }
-          minimum_id = sub_minimum_id if sub_minimum_id < minimum_id
-        end
-      }
-
-      if node_id == minimum_id
-        component = stack.slice!(stack_length .. -1)
-        component.each {|n| id_map[n] = nil}
-        yield component
+        minimum_id = sub_minimum_id if sub_minimum_id < minimum_id
       end
+    }
 
-      minimum_id
+    if node_id == minimum_id
+      component = stack.slice!(stack_length .. -1)
+      component.each {|n| id_map[n] = nil}
+      yield component
     end
 
-    # Should be implemented by a extended class.
-    #
-    # #tsort_each_node is used to iterate for all nodes over a graph.
-    #
-    def tsort_each_node # :yields: node
-      raise NotImplementedError.new
-    end
+    minimum_id
+  end
 
-    # Should be implemented by a extended class.
-    #
-    # #tsort_each_child is used to iterate for child nodes of _node_.
-    #
-    def tsort_each_child(node) # :yields: child
-      raise NotImplementedError.new
-    end
+  # Should be implemented by a extended class.
+  #
+  # #tsort_each_node is used to iterate for all nodes over a graph.
+  #
+  def tsort_each_node # :yields: node
+    raise NotImplementedError.new
+  end
+
+  # Should be implemented by a extended class.
+  #
+  # #tsort_each_child is used to iterate for child nodes of _node_.
+  #
+  def tsort_each_child(node) # :yields: child
+    raise NotImplementedError.new
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

No real user problem, but I figured our new year's release is a good moment to bump these.

## What is your fix for the problem, implemented in this PR?

Bump versions of TSort, Molinillo, and optparse, vendored by RubyGems.

The recent support drop for old Rubies allows us to remove a custom patch to optparse. 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
