### PR TITLE
Prefer `RbConfig::CONFIG['EXEEXT']` over hardcorded '.exe'

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -550,7 +550,7 @@ EOF
 
     def git_present?
       return @git_present if defined?(@git_present)
-      @git_present = Bundler.which("git") || Bundler.which("git.exe")
+      @git_present = Bundler.which("git#{RbConfig::CONFIG["EXEEXT"]}")
     end
 
     def feature_flag

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -337,7 +337,7 @@ class Gem::TestCase < Test::Unit::TestCase
       ruby
     end
 
-    @git = ENV["GIT"] || (win_platform? ? "git.exe" : "git")
+    @git = ENV["GIT"] || "git#{RbConfig::CONFIG['EXEEXT']}"
 
     Gem.ensure_gem_subdirectories @gemhome
     Gem.ensure_default_gem_subdirectories @gemhome
@@ -1263,7 +1263,7 @@ Also, a list:
     ruby = ENV["RUBY"]
     return ruby if ruby
     ruby = "ruby"
-    rubyexe = "#{ruby}.exe"
+    rubyexe = "#{ruby}#{RbConfig::CONFIG['EXEEXT']}"
 
     3.times do
       if File.exist?(ruby) && File.executable?(ruby) && !File.directory?(ruby)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

As the title.

## What is your fix for the problem, implemented in this PR?

As the title.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
