### PR TITLE
Remove special handling of some `LoadError` and `NoMethodError`

### DIFF
--- a/bundler/lib/bundler/fetcher/downloader.rb
+++ b/bundler/lib/bundler/fetcher/downloader.rb
@@ -61,9 +61,6 @@ module Bundler
           req.basic_auth(user, password)
         end
         connection.request(uri, req)
-      rescue NoMethodError => e
-        raise unless ["undefined method", "use_ssl="].all? {|snippet| e.message.include? snippet }
-        raise LoadError.new("cannot load such file -- openssl")
       rescue OpenSSL::SSL::SSLError
         raise CertificateFailureError.new(uri)
       rescue *HTTP_ERRORS => e

--- a/bundler/lib/bundler/friendly_errors.rb
+++ b/bundler/lib/bundler/friendly_errors.rb
@@ -36,9 +36,6 @@ module Bundler
         end
       when Thor::Error
         Bundler.ui.error error.message
-      when LoadError
-        raise error unless /cannot load such file -- openssl|openssl.so|libcrypto.so/.match?(error.message)
-        Bundler.ui.error "\nCould not load OpenSSL. #{error.class}: #{error}\n#{error.backtrace.join("\n  ")}"
       when Interrupt
         Bundler.ui.error "\nQuitting..."
         Bundler.ui.trace error

--- a/bundler/spec/bundler/fetcher/downloader_spec.rb
+++ b/bundler/spec/bundler/fetcher/downloader_spec.rb
@@ -178,26 +178,6 @@ RSpec.describe Bundler::Fetcher::Downloader do
       end
     end
 
-    context "when the request response causes a NoMethodError" do
-      before { allow(connection).to receive(:request).with(uri, net_http_get) { raise NoMethodError.new(message) } }
-
-      context "and the error message is about use_ssl=" do
-        let(:message) { "undefined method 'use_ssl='" }
-
-        it "should raise a LoadError about openssl" do
-          expect { subject.request(uri, options) }.to raise_error(LoadError, "cannot load such file -- openssl")
-        end
-      end
-
-      context "and the error message is not about use_ssl=" do
-        let(:message) { "undefined method 'undefined_method_call'" }
-
-        it "should raise the original NoMethodError" do
-          expect { subject.request(uri, options) }.to raise_error(NoMethodError, /undefined method 'undefined_method_call'/)
-        end
-      end
-    end
-
     context "when the request response causes a OpenSSL::SSL::SSLError" do
       before { allow(connection).to receive(:request).with(uri, net_http_get) { raise OpenSSL::SSL::SSLError.new } }
 

--- a/bundler/spec/bundler/friendly_errors_spec.rb
+++ b/bundler/spec/bundler/friendly_errors_spec.rb
@@ -110,19 +110,6 @@ RSpec.describe Bundler, "friendly errors" do
       it_behaves_like "Bundler.ui receive error", Bundler::Thor::Error.new
     end
 
-    context "LoadError" do
-      let(:error) { LoadError.new("cannot load such file -- openssl") }
-
-      before do
-        allow(error).to receive(:backtrace).and_return(["backtrace"])
-      end
-
-      it "Bundler.ui receive error" do
-        expect(Bundler.ui).to receive(:error).with("\nCould not load OpenSSL. LoadError: cannot load such file -- openssl\nbacktrace")
-        Bundler::FriendlyErrors.log_error(error)
-      end
-    end
-
     context "Interrupt" do
       it "Bundler.ui receive error" do
         expect(Bundler.ui).to receive(:error).with("\nQuitting...")

--- a/bundler/spec/support/artifice/fail.rb
+++ b/bundler/spec/support/artifice/fail.rb
@@ -4,7 +4,7 @@ require "net/http"
 
 # We can't use artifice here because it uses rack
 
-module Artifice; end # for < 2.0, Net::HTTP::Persistent::SSLReuse
+module Artifice; end
 
 class Fail < Net::HTTP
   # Net::HTTP uses a @newimpl instance variable to decide whether


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

No real end user problem but relying on specific wording of error messages is brittle. See https://github.com/ruby/ruby/pull/6908/.

## What is your fix for the problem, implemented in this PR?

I think `LoadError` has `#path` these days, so we could potentially switch to that. However, this defensive code was introduced [a long time ago](https://github.com/rubygems/bundler/issues/4054), and the original issue has most likely been fixed, so I'd go with completely removing this special handling.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
