### PR TITLE
Remove no longer necessary workaround

### DIFF
--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -55,7 +55,6 @@ jobs:
       - name: Sync tools
         run: |
           ruby tool/sync_default_gems.rb rubygems
-          rm lib/bundler/vendor/fileutils/lib/fileutils.rb~ # previous script leaves a backup file around for some reason
         working-directory: ruby/ruby
       - name: Test RubyGems
         run: make -j2 -s test-all TESTS="rubygems --no-retry"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I added this line to workaround a ruby-core issue, but it's no longer necessary.

## What is your fix for the problem, implemented in this PR?

Remove the workaround, since the culprit was fixed by https://github.com/ruby/ruby/pull/6907.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
