### PR TITLE
Restore ability to fresh clone outdated locked references

### DIFF
--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -148,7 +148,7 @@ module Bundler
             "#{current_branch} but Gemfile specifies #{branch}"
         end
 
-        changed = cached_revision && cached_revision != git_proxy.revision
+        changed = cached_revision && cached_revision != revision
 
         if !Bundler.settings[:disable_local_revision_check] && changed && !@unlocked && !git_proxy.contains?(cached_revision)
           raise GitError, "The Gemfile lock is pointing to revision #{shortref_for_display(cached_revision)} " \

--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -160,7 +160,7 @@ module Bundler
         def depth
           return @depth if defined?(@depth)
 
-          @depth = if legacy_locked_revision? || !supports_fetching_unreachable_refs?
+          @depth = if !supports_fetching_unreachable_refs?
             nil
           elsif not_pinned?
             1

--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -91,9 +91,9 @@ module Bundler
           Bundler.ui.info "Fetching #{credential_filtered_uri}"
 
           extra_fetch_needed = clone_needs_extra_fetch?
-          return unless extra_fetch_needed
-
           unshallow_needed = clone_needs_unshallow?
+          return unless extra_fetch_needed || unshallow_needed
+
           fetch_args = unshallow_needed ? ["--unshallow"] : depth_args
 
           git_retry(*["fetch", "--force", "--quiet", "--no-tags", *fetch_args, "--", configured_uri, refspec].compact, :dir => path)
@@ -144,7 +144,10 @@ module Bundler
         end
 
         def clone_needs_unshallow?
-          path.join("shallow").exist? && full_clone?
+          return false unless path.join("shallow").exist?
+          return true if full_clone?
+
+          @revision && @revision != head_revision
         end
 
         def extra_ref

--- a/bundler/spec/lock/git_spec.rb
+++ b/bundler/spec/lock/git_spec.rb
@@ -34,6 +34,13 @@ RSpec.describe "bundle lock with git gems" do
     expect(out).to eq("WIN")
   end
 
+  it "properly clones a git source locked to an out of date ref" do
+    update_git "foo"
+
+    bundle :install, :env => { "BUNDLE_PATH" => "foo" }
+    expect(err).to be_empty
+  end
+
   it "provides correct #full_gem_path" do
     run <<-RUBY
       puts Bundler.rubygems.find_name('foo').first.full_gem_path


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This PR fixes an unreleased regression introduced by #4475.

When having an unpinned git source in the `Gemfile` (no explicit `:ref` given) and a `Gemfile.lock` file including a revision that's no longer the HEAD of the git source, we can no longer `bundle install`, getting an error like the following:

```
$ bundle _2.4.0.dev_
Fetching https://github.com/dependabot-fixtures/rubygems-circular-dependency
fatal: git upload-pack: not our ref 3c85f0bd8d6977b4dfda6a12acf93a282c4f5bf1
fatal: remote error: upload-pack: not our ref 3c85f0bd8d6977b4dfda6a12acf93a282c4f5bf1
Git error: command `git fetch --force --quiet --depth 1
/Users/deivid/Code/dependabot/dependabot-core/bundler/spec/fixtures/projects/bundler2/git_source_circular/foo/ruby/3.1.0/cache/bundler/git/rubygems-circular-dependency-83c94dab73b0289666e761df3503fb48c746780e
3c85f0bd8d6977b4dfda6a12acf93a282c4f5bf1` in directory
/Users/deivid/Code/dependabot/dependabot-core/bundler/spec/fixtures/projects/bundler2/git_source_circular/foo/ruby/3.1.0/bundler/gems/rubygems-circular-dependency-3c85f0bd8d69
has failed.

If this error persists you could try removing the cache directory
'/Users/deivid/Code/dependabot/dependabot-core/bundler/spec/fixtures/projects/bundler2/git_source_circular/foo/ruby/3.1.0/bundler/gems/rubygems-circular-dependency-3c85f0bd8d69'
```

## What is your fix for the problem, implemented in this PR?

This PR fixes the problem by detecting whether the locked revision is no longer the HEAD of the repository, and `--unshallow`'ing the repo in that case, so that all refs are reachable.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
