### PR TITLE
Fix pub grub crash on circular dependencies

### DIFF
--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -156,12 +156,6 @@ module Bundler
       package_deps = @cached_dependencies[package]
       sorted_versions = @sorted_versions[package]
       package_deps[version].map do |dep_package, dep_constraint|
-        unless dep_constraint
-          # falsey indicates this dependency was invalid
-          cause = PubGrub::Incompatibility::InvalidDependency.new(dep_package, dep_constraint.constraint_string)
-          return [PubGrub::Incompatibility.new([PubGrub::Term.new(self_constraint, true)], :cause => cause)]
-        end
-
         low = high = sorted_versions.index(version)
 
         # find version low such that all >= low share the same dep

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -191,12 +191,13 @@ module Bundler
         self_constraint = PubGrub::VersionConstraint.new(package, :range => range)
 
         dep_term = PubGrub::Term.new(dep_constraint, false)
+        self_term = PubGrub::Term.new(self_constraint, true)
 
         custom_explanation = if dep_package.meta? && package.root?
           "current #{dep_package} version is #{dep_constraint.constraint_string}"
         end
 
-        PubGrub::Incompatibility.new([PubGrub::Term.new(self_constraint, true), dep_term], :cause => :dependency, :custom_explanation => custom_explanation)
+        PubGrub::Incompatibility.new([self_term, dep_term], :cause => :dependency, :custom_explanation => custom_explanation)
       end
     end
 

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -156,6 +156,11 @@ module Bundler
       package_deps = @cached_dependencies[package]
       sorted_versions = @sorted_versions[package]
       package_deps[version].map do |dep_package, dep_constraint|
+        if package == dep_package
+          cause = PubGrub::Incompatibility::CircularDependency.new(dep_package, dep_constraint.constraint_string)
+          return [PubGrub::Incompatibility.new([PubGrub::Term.new(dep_constraint, true)], :cause => cause)]
+        end
+
         low = high = sorted_versions.index(version)
 
         # find version low such that all >= low share the same dep

--- a/bundler/lib/bundler/vendor/pub_grub/lib/pub_grub/incompatibility.rb
+++ b/bundler/lib/bundler/vendor/pub_grub/lib/pub_grub/incompatibility.rb
@@ -8,6 +8,9 @@ module Bundler::PubGrub
     InvalidDependency = Struct.new(:package, :constraint) do
     end
 
+    CircularDependency = Struct.new(:package, :constraint) do
+    end
+
     NoVersions = Struct.new(:constraint) do
     end
 
@@ -63,6 +66,8 @@ module Bundler::PubGrub
         "#{terms[0].to_s(allow_every: true)} depends on #{terms[1].invert}"
       when Bundler::PubGrub::Incompatibility::InvalidDependency
         "#{terms[0].to_s(allow_every: true)} depends on unknown package #{cause.package}"
+      when Bundler::PubGrub::Incompatibility::CircularDependency
+        "#{terms[0].to_s(allow_every: true)} depends on itself"
       when Bundler::PubGrub::Incompatibility::NoVersions
         "no versions satisfy #{cause.constraint}"
       when Bundler::PubGrub::Incompatibility::ConflictCause


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Found PubGrub crashing with an unhelpful error on a [pathological repository](https://github.com/dependabot-fixtures/rubygems-circular-dependency/blob/master/rubygems-circular-dependency.gemspec) with circular dependencies.

## What is your fix for the problem, implemented in this PR?

Previously a runtime error like the following was being raised

````
$ ~/Code/rubygems/rubygems/bundler/exe/bundle lock --update rubygems-circular-dependency --conservative 
Fetching https://github.com/dependabot-fixtures/rubygems-circular-dependency
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...--- ERROR REPORT TEMPLATE -------------------------------------------------------

```
ArgumentError: a dependency Incompatibility must have exactly two terms. Got [#<Bundler::PubGrub::Term rubygems-circular-dependency < 0>]
  /Users/deivid/Code/rubygems/rubygems/bundler/lib/bundler/vendor/pub_grub/lib/pub_grub/incompatibility.rb:22:in `initialize'
  /Users/deivid/Code/rubygems/rubygems/bundler/lib/bundler/resolver.rb:199:in `new'
  /Users/deivid/Code/rubygems/rubygems/bundler/lib/bundler/resolver.rb:199:in `block in incompatibilities_for'
  /Users/deivid/Code/rubygems/rubygems/bundler/lib/bundler/resolver.rb:158:in `each'
  /Users/deivid/Code/rubygems/rubygems/bundler/lib/bundler/resolver.rb:158:in `map'
  /Users/deivid/Code/rubygems/rubygems/bundler/lib/bundler/resolver.rb:158:in `incompatibilities_for'
  /Users/deivid/Code/rubygems/rubygems/bundler/lib/bundler/vendor/pub_grub/lib/pub_grub/version_solver.rb:136:in `choose_package_version'
  /Users/deivid/Code/rubygems/rubygems/bundler/lib/bundler/vendor/pub_grub/lib/pub_grub/version_solver.rb:41:in `work'
  /Users/deivid/Code/rubygems/rubygems/bundler/lib/bundler/vendor/pub_grub/lib/pub_grub/version_solver.rb:58:in `solve'
  /Users/deivid/Code/rubygems/rubygems/bundler/lib/bundler/resolver.rb:61:in `start'
  /Users/deivid/Code/rubygems/rubygems/bundler/lib/bundler/definition.rb:552:in `start_resolution'
  /Users/deivid/Code/rubygems/rubygems/bundler/lib/bundler/definition.rb:279:in `resolve'
  /Users/deivid/Code/rubygems/rubygems/bundler/lib/bundler/definition.rb:177:in `resolve_remotely!'
  /Users/deivid/Code/rubygems/rubygems/bundler/lib/bundler/cli/lock.rb:53:in `run'
  /Users/deivid/Code/rubygems/rubygems/bundler/lib/bundler/cli.rb:677:in `lock'
  /Users/deivid/Code/rubygems/rubygems/bundler/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
  /Users/deivid/Code/rubygems/rubygems/bundler/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
  /Users/deivid/Code/rubygems/rubygems/bundler/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
  /Users/deivid/Code/rubygems/rubygems/bundler/lib/bundler/cli.rb:31:in `dispatch'
  /Users/deivid/Code/rubygems/rubygems/bundler/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
  /Users/deivid/Code/rubygems/rubygems/bundler/lib/bundler/cli.rb:25:in `start'
  /Users/deivid/Code/rubygems/rubygems/bundler/exe/bundle:45:in `block in <main>'
  /Users/deivid/Code/rubygems/rubygems/bundler/lib/bundler/friendly_errors.rb:120:in `with_friendly_errors'
  /Users/deivid/Code/rubygems/rubygems/bundler/exe/bundle:33:in `<main>'

```

## Environment

```
Bundler       2.4.0.dev
  Platforms   ruby, arm64-darwin-22
Ruby          3.1.3p185 (2022-11-24 revision 1a6b16756e0ba6b95ab71a441357ed5484e33498) [arm64-darwin-22]
  Full Path   /Users/deivid/.asdf/installs/ruby/3.1.3/bin/ruby
  Config Dir  /Users/deivid/.asdf/installs/ruby/3.1.3/etc
RubyGems      3.4.0.dev
  Gem Home    /Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0
  Gem Path    /Users/deivid/.gem/ruby/3.1.0:/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0
  User Home   /Users/deivid
  User Path   /Users/deivid/.gem/ruby/3.1.0
  Bin Dir     /Users/deivid/.asdf/installs/ruby/3.1.3/bin
OpenSSL       
  Compiled    OpenSSL 3.0.7 1 Nov 2022
  Loaded      OpenSSL 3.0.7 1 Nov 2022
  Cert File   /Users/deivid/.asdf/installs/ruby/3.1.3/openssl/ssl/cert.pem
  Cert Dir    /Users/deivid/.asdf/installs/ruby/3.1.3/openssl/ssl/certs
Tools         
  Git         2.37.1 (Apple Git-137.1)
  RVM         not installed
  rbenv       not installed
  chruby      not installed
```

## Bundler Build Metadata

```
Built At          2022-12-13
Git SHA           9205b2a356
Released Version  false
```

## Bundler settings

```
build.mysql2
  Set for the current user (/Users/deivid/.bundle/config): "--with-opt-dir=/opt/homebrew/opt/zstd"
default_cli_command
  Set for the current user (/Users/deivid/.bundle/config): "install"
gem.changelog
  Set for the current user (/Users/deivid/.bundle/config): true
gem.ci
  Set for the current user (/Users/deivid/.bundle/config): "github"
gem.coc
  Set for the current user (/Users/deivid/.bundle/config): true
gem.github_username
  Set for the current user (/Users/deivid/.bundle/config): "deivid-rodriguez"
gem.linter
  Set for the current user (/Users/deivid/.bundle/config): "rubocop"
gem.mit
  Set for the current user (/Users/deivid/.bundle/config): true
gem.test
  Set for the current user (/Users/deivid/.bundle/config): "rspec"
path_relative_to_cwd
  Set for the current user (/Users/deivid/.bundle/config): true
```

## Gemfile

### Gemfile

```ruby
# frozen_string_literal: true
source "https://rubygems.org"

gem "rubygems-circular-dependency", git: "https://github.com/dependabot-fixtures/rubygems-circular-dependency"
gem "business"
```

### Gemfile.lock

```
GIT
  remote: https://github.com/dependabot-fixtures/rubygems-circular-dependency
  revision: 3c85f0bd8d6977b4dfda6a12acf93a282c4f5bf1
  specs:
    rubygems-circular-dependency (0.0.1)

GEM
  remote: https://rubygems.org/
  specs:
    business (1.4.0)

PLATFORMS
  ruby

DEPENDENCIES
  business
  rubygems-circular-dependency!

BUNDLED WITH
   2.2.0
```

--- TEMPLATE END ----------------------------------------------------------------

Unfortunately, an unexpected error occurred, and Bundler cannot continue.

First, try this link to see if there are any existing issue reports for this error:
https://github.com/rubygems/rubygems/search?q=a+dependency+Incompatibility+must+have+exactly+two+terms.+Got+%5B%23%3CBundler++PubGrub++Term+rubygems-circular-dependency+%3C+0%3E%5D&type=Issues

If there aren't any reports for this error yet, please fill in the new issue form located at https://github.com/rubygems/rubygems/issues/new?labels=Bundler&template=bundler-related-issue.md, and copy and paste the report template above in there.
````

With this patch we explicitly detect this situation and raise a helpful error instead:

```
$ ~/Code/rubygems/rubygems/bundler/exe/bundle lock --update rubygems-circular-dependency --conservative 
Fetching https://github.com/dependabot-fixtures/rubygems-circular-dependency
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...Resolving dependencies...Could not find compatible versions

Because rubygems-circular-dependency >= 0 depends on itself
  and Gemfile depends on rubygems-circular-dependency >= 0,
  version solving has failed.
```

I will contribute an upstream patch but I want to verify that it's all good on our repo first.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
