### PR TITLE
Use `caller_locations` instead of splitting `caller`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -179,6 +179,10 @@ Style/BlockDelimiters:
 Style/PercentLiteralDelimiters:
   Enabled: true
 
+Style/SafeNavigation:
+  Enabled: true
+  MaxChainLength: 1
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 

--- a/.rubocop_bundler.yml
+++ b/.rubocop_bundler.yml
@@ -765,6 +765,10 @@ Style/RescueModifier:
 Style/RescueStandardError:
   Enabled: true
 
+Style/SafeNavigation:
+  Enabled: true
+  MaxChainLength: 1
+
 Style/Sample:
   Enabled: true
 

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -537,7 +537,7 @@ EOF
       @gemspec_cache[key] ||= load_gemspec_uncached(file, validate)
       # Protect against caching side-effected gemspecs by returning a
       # new instance each time.
-      @gemspec_cache[key].dup if @gemspec_cache[key]
+      @gemspec_cache[key]&.dup
     end
 
     def load_gemspec_uncached(file, validate = false)

--- a/bundler/lib/bundler/cli/binstubs.rb
+++ b/bundler/lib/bundler/cli/binstubs.rb
@@ -11,7 +11,7 @@ module Bundler
     def run
       Bundler.definition.validate_runtime!
       path_option = options["path"]
-      path_option = nil if path_option && path_option.empty?
+      path_option = nil if path_option&.empty?
       Bundler.settings.set_command_option :bin, path_option if options["path"]
       Bundler.settings.set_command_option_if_given :shebang, options["shebang"]
       installer = Installer.new(Bundler.root, Bundler.definition)

--- a/bundler/lib/bundler/cli/info.rb
+++ b/bundler/lib/bundler/cli/info.rb
@@ -33,7 +33,7 @@ module Bundler
     def default_gem_spec(gem_name)
       return unless Gem::Specification.respond_to?(:find_all_by_name)
       gem_spec = Gem::Specification.find_all_by_name(gem_name).last
-      return gem_spec if gem_spec && gem_spec.respond_to?(:default_gem?) && gem_spec.default_gem?
+      return gem_spec if gem_spec&.default_gem?
     end
 
     def spec_not_found(gem_name)

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -154,7 +154,7 @@ module Bundler
       end
 
       bin_option = options["binstubs"]
-      bin_option = nil if bin_option && bin_option.empty?
+      bin_option = nil if bin_option&.empty?
       Bundler.settings.set_command_option :bin, bin_option if options["binstubs"]
 
       Bundler.settings.set_command_option_if_given :shebang, options["shebang"]

--- a/bundler/lib/bundler/cli/outdated.rb
+++ b/bundler/lib/bundler/cli/outdated.rb
@@ -194,7 +194,7 @@ module Bundler
       end
       current_version = "#{current_spec.version}#{current_spec.git_version}"
 
-      if dependency && dependency.specific?
+      if dependency&.specific?
         dependency_version = %(, requested #{dependency.requirement})
       end
 

--- a/bundler/lib/bundler/cli/platform.rb
+++ b/bundler/lib/bundler/cli/platform.rb
@@ -10,7 +10,7 @@ module Bundler
     def run
       platforms, ruby_version = Bundler.ui.silence do
         locked_ruby_version = Bundler.locked_gems && Bundler.locked_gems.ruby_version&.gsub(/p\d+\Z/, "")
-        gemfile_ruby_version = Bundler.definition.ruby_version && Bundler.definition.ruby_version.single_version_string
+        gemfile_ruby_version = Bundler.definition.ruby_version&.single_version_string
         [Bundler.definition.platforms.map {|p| "* #{p}" },
          locked_ruby_version || gemfile_ruby_version]
       end

--- a/bundler/lib/bundler/cli/platform.rb
+++ b/bundler/lib/bundler/cli/platform.rb
@@ -8,12 +8,12 @@ module Bundler
     end
 
     def run
-      platforms, ruby_version = Bundler.ui.silence do
-        locked_ruby_version = Bundler.locked_gems && Bundler.locked_gems.ruby_version&.gsub(/p\d+\Z/, "")
-        gemfile_ruby_version = Bundler.definition.ruby_version&.single_version_string
-        [Bundler.definition.platforms.map {|p| "* #{p}" },
-         locked_ruby_version || gemfile_ruby_version]
+      ruby_version = if Bundler.locked_gems
+        Bundler.locked_gems.ruby_version&.gsub(/p\d+\Z/, "")
+      else
+        Bundler.definition.ruby_version&.single_version_string
       end
+
       output = []
 
       if options[:ruby]
@@ -23,6 +23,8 @@ module Bundler
           output << "No ruby version specified"
         end
       else
+        platforms = Bundler.definition.platforms.map {|p| "* #{p}" }
+
         output << "Your platform is: #{Gem::Platform.local}"
         output << "Your app has gems that work on these platforms:\n#{platforms.join("\n")}"
 

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -647,8 +647,8 @@ module Bundler
 
       Bundler.settings.local_overrides.map do |k, v|
         spec   = @dependencies.find {|s| s.name == k }
-        source = spec && spec.source
-        if source && source.respond_to?(:local_override!)
+        source = spec&.source
+        if source&.respond_to?(:local_override!)
           source.unlock! if @unlock[:gems].include?(spec.name)
           locals << [source, source.local_override!(v)]
         end
@@ -778,7 +778,7 @@ module Bundler
         dep = @dependencies.find {|d| s.satisfies?(d) }
 
         # Replace the locked dependency's source with the equivalent source from the Gemfile
-        s.source = if dep && dep.source
+        s.source = if dep&.source
           gemfile_source = dep.source
           lockfile_source = s.source
 

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -41,7 +41,7 @@ module Bundler
     end
 
     def eval_gemfile(gemfile, contents = nil)
-      expanded_gemfile_path = Pathname.new(gemfile).expand_path(@gemfile && @gemfile.parent)
+      expanded_gemfile_path = Pathname.new(gemfile).expand_path(@gemfile&.parent)
       original_gemfile = @gemfile
       @gemfile = expanded_gemfile_path
       @gemfiles << expanded_gemfile_path

--- a/bundler/lib/bundler/env.rb
+++ b/bundler/lib/bundler/env.rb
@@ -122,7 +122,7 @@ module Bundler
         specs = Bundler.rubygems.find_name(name)
         out << ["  #{name}", "(#{specs.map(&:version).join(",")})"] unless specs.empty?
       end
-      if (exe = caller.last.split(":").first) && exe =~ %r{(exe|bin)/bundler?\z}
+      if (exe = caller.last.split(":").first)&.match? %r{(exe|bin)/bundler?\z}
         shebang = File.read(exe).lines.first
         shebang.sub!(/^#!\s*/, "")
         unless shebang.start_with?(Gem.ruby, "/usr/bin/env ruby")

--- a/bundler/lib/bundler/env.rb
+++ b/bundler/lib/bundler/env.rb
@@ -122,7 +122,7 @@ module Bundler
         specs = Bundler.rubygems.find_name(name)
         out << ["  #{name}", "(#{specs.map(&:version).join(",")})"] unless specs.empty?
       end
-      if (exe = caller.last.split(":").first)&.match? %r{(exe|bin)/bundler?\z}
+      if (exe = caller_locations.last.absolute_path)&.match? %r{(exe|bin)/bundler?\z}
         shebang = File.read(exe).lines.first
         shebang.sub!(/^#!\s*/, "")
         unless shebang.start_with?(Gem.ruby, "/usr/bin/env ruby")

--- a/bundler/lib/bundler/fetcher/compact_index.rb
+++ b/bundler/lib/bundler/fetcher/compact_index.rb
@@ -40,7 +40,7 @@ module Bundler
           deps = begin
                    parallel_compact_index_client.dependencies(remaining_gems)
                  rescue TooManyRequestsError
-                   @bundle_worker.stop if @bundle_worker
+                   @bundle_worker&.stop
                    @bundle_worker = nil # reset it.  Not sure if necessary
                    serial_compact_index_client.dependencies(remaining_gems)
                  end
@@ -49,7 +49,7 @@ module Bundler
           complete_gems.concat(deps.map(&:first)).uniq!
           remaining_gems = next_gems - complete_gems
         end
-        @bundle_worker.stop if @bundle_worker
+        @bundle_worker&.stop
         @bundle_worker = nil # reset it.  Not sure if necessary
 
         gem_info

--- a/bundler/lib/bundler/friendly_errors.rb
+++ b/bundler/lib/bundler/friendly_errors.rb
@@ -95,7 +95,7 @@ module Bundler
     def serialized_exception_for(e)
       <<-EOS.gsub(/^ {8}/, "")
         #{e.class}: #{e.message}
-          #{e.backtrace && e.backtrace.join("\n          ").chomp}
+          #{e.backtrace&.join("\n          ")&.chomp}
       EOS
     end
 

--- a/bundler/lib/bundler/gem_helper.rb
+++ b/bundler/lib/bundler/gem_helper.rb
@@ -21,7 +21,7 @@ module Bundler
 
       def gemspec(&block)
         gemspec = instance.gemspec
-        block.call(gemspec) if block
+        block&.call(gemspec)
         gemspec
       end
     end
@@ -152,8 +152,7 @@ module Bundler
 
     def gem_push_host
       env_rubygems_host = ENV["RUBYGEMS_HOST"]
-      env_rubygems_host = nil if
-        env_rubygems_host && env_rubygems_host.empty?
+      env_rubygems_host = nil if env_rubygems_host&.empty?
 
       allowed_push_host || env_rubygems_host || "rubygems.org"
     end
@@ -218,7 +217,7 @@ module Bundler
       SharedHelpers.chdir(base) do
         outbuf = IO.popen(cmd, :err => [:child, :out], &:read)
         status = $?
-        block.call(outbuf) if status.success? && block
+        block&.call(outbuf) if status.success?
         [outbuf, status]
       end
     end

--- a/bundler/lib/bundler/installer/parallel_installer.rb
+++ b/bundler/lib/bundler/installer/parallel_installer.rb
@@ -96,7 +96,7 @@ module Bundler
       handle_error if failed_specs.any?
       @specs
     ensure
-      worker_pool && worker_pool.stop
+      worker_pool&.stop
     end
 
     def check_for_unmet_dependencies

--- a/bundler/lib/bundler/plugin/index.rb
+++ b/bundler/lib/bundler/plugin/index.rb
@@ -146,7 +146,7 @@ module Bundler
       # @param [Boolean] is the index file global index
       def load_index(index_file, global = false)
         SharedHelpers.filesystem_access(index_file, :read) do |index_f|
-          valid_file = index_f && index_f.exist? && !index_f.size.zero?
+          valid_file = index_f&.exist? && !index_f.size.zero?
           break unless valid_file
 
           data = index_f.read

--- a/bundler/lib/bundler/ruby_version.rb
+++ b/bundler/lib/bundler/ruby_version.rb
@@ -28,8 +28,8 @@ module Bundler
       end
 
       @gem_version        = Gem::Requirement.create(@versions.first).requirements.first.last
-      @input_engine       = engine && engine.to_s
-      @engine             = engine && engine.to_s || "ruby"
+      @input_engine       = engine&.to_s
+      @engine             = engine&.to_s || "ruby"
       @engine_versions    = (engine_version && Array(engine_version)) || @versions
       @engine_gem_version = Gem::Requirement.create(@engine_versions.first).requirements.first.last
       @patchlevel         = patchlevel || (@gem_version.prerelease? ? "-1" : nil)

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -243,7 +243,7 @@ module Bundler
       kernel = (class << ::Kernel; self; end)
       [kernel, ::Kernel].each do |kernel_class|
         redefine_method(kernel_class, :gem) do |dep, *reqs|
-          if executables&.include?(File.basename(caller.first.split(":").first))
+          if executables&.include?(File.basename(caller_locations(1, 1).first.path))
             break
           end
 

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -243,7 +243,7 @@ module Bundler
       kernel = (class << ::Kernel; self; end)
       [kernel, ::Kernel].each do |kernel_class|
         redefine_method(kernel_class, :gem) do |dep, *reqs|
-          if executables && executables.include?(File.basename(caller.first.split(":").first))
+          if executables&.include?(File.basename(caller.first.split(":").first))
             break
           end
 

--- a/bundler/lib/bundler/ui/rg_proxy.rb
+++ b/bundler/lib/bundler/ui/rg_proxy.rb
@@ -12,7 +12,7 @@ module Bundler
       end
 
       def say(message)
-        @ui && @ui.debug(message)
+        @ui&.debug(message)
       end
     end
   end

--- a/bundler/spec/support/artifice/vcr.rb
+++ b/bundler/spec/support/artifice/vcr.rb
@@ -42,7 +42,7 @@ class BundlerVCRHTTP < Net::HTTP
           response.uri = request.uri
 
           response.reading_body(response_io, request.response_body_permitted?) do
-            response_block.call(response) if response_block
+            response_block&.call(response)
           end
         end
       end

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -264,7 +264,7 @@ module Spec
     end
 
     def update_repo(path)
-      if path == gem_repo1 && caller.first.split(" ").last == "`build_repo`"
+      if path == gem_repo1 && caller_locations(1, 1).first.label == "build_repo"
         raise "Updating gem_repo1 is unsupported -- use gem_repo2 instead"
       end
       return unless block_given?

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -857,8 +857,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   # Returns the version of the latest release-version of gem +name+
 
   def self.latest_version_for(name)
-    spec = latest_spec_for name
-    spec && spec.version
+    latest_spec_for(name)&.version
   end
 
   ##

--- a/lib/rubygems/bundler_version_finder.rb
+++ b/lib/rubygems/bundler_version_finder.rb
@@ -47,7 +47,7 @@ module Gem::BundlerVersionFinder
 
   def self.lockfile_contents
     gemfile = ENV["BUNDLE_GEMFILE"]
-    gemfile = nil if gemfile && gemfile.empty?
+    gemfile = nil if gemfile&.empty?
 
     unless gemfile
       begin

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -70,8 +70,7 @@ module Gem::GemcutterUtilities
     @host ||=
       begin
         env_rubygems_host = ENV["RUBYGEMS_HOST"]
-        env_rubygems_host = nil if
-          env_rubygems_host && env_rubygems_host.empty?
+        env_rubygems_host = nil if env_rubygems_host&.empty?
 
         env_rubygems_host || configured_host
       end

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -616,8 +616,7 @@ EOM
 
     verify_checksums @digests, @checksums
 
-    @security_policy.verify_signatures @spec, @digests, @signatures if
-      @security_policy
+    @security_policy&.verify_signatures @spec, @digests, @signatures
 
     true
   rescue Gem::Security::Exception

--- a/lib/rubygems/request_set/lockfile/parser.rb
+++ b/lib/rubygems/request_set/lockfile/parser.rb
@@ -331,7 +331,7 @@ class Gem::RequestSet::Lockfile::Parser
       set.find_all(requirement)
     end.compact.first
 
-    specification && specification.version
+    specification&.version
   end
 
   ##

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -911,7 +911,7 @@ class Gem::Specification < Gem::BasicSpecification
   # You probably want to use one of the Enumerable methods instead.
 
   def self.all
-    warn "NOTE: Specification.all called from #{caller.first}" unless
+    warn "NOTE: Specification.all called from #{caller(1, 1).first}" unless
       Gem::Deprecate.skip
     _all
   end

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1041,7 +1041,7 @@ class Gem::Specification < Gem::BasicSpecification
       next if s.activated?
       s.contains_requirable_file? path
     end
-    stub && stub.to_spec
+    stub&.to_spec
   end
 
   def self.find_active_stub_by_path(path)
@@ -1626,7 +1626,7 @@ class Gem::Specification < Gem::BasicSpecification
         builder.build_extensions
       end
     ensure
-      ui.close if ui
+      ui&.close
       Gem::Specification.unresolved_deps.replace unresolved_deps
     end
   end

--- a/lib/rubygems/user_interaction.rb
+++ b/lib/rubygems/user_interaction.rb
@@ -290,7 +290,7 @@ class Gem::StreamUI
     @outs.flush
 
     result = @ins.gets
-    result.chomp! if result
+    result&.chomp!
     result
   end
 
@@ -305,7 +305,7 @@ class Gem::StreamUI
 
     password = _gets_noecho
     @outs.puts
-    password.chomp! if password
+    password&.chomp!
     password
   end
 

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -1612,7 +1612,7 @@ class Object
       if val_or_callable.respond_to? :call
         val_or_callable.call(*args, &blk)
       else
-        blk.call(*block_args) if blk
+        blk&.call(*block_args)
         val_or_callable
       end
     end

--- a/util/automatiek/gem.rb
+++ b/util/automatiek/gem.rb
@@ -29,7 +29,7 @@ module Automatiek
     def initialize(gem_name, &block)
       @gem_name = gem_name
       @dependencies = []
-      block.call(self) if block
+      block&.call(self)
     end
 
     def vendor!(version = nil)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Splitting `caller` is fragile, especially when paths contain a colon or space.

## What is your fix for the problem, implemented in this PR?

Use `caller_locations` method.
Also limit caller ranges not to make unnecessary backtraces.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
