### PR TITLE
Improve error message when changing Gemfile to a mistyped git ref

### DIFF
--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -46,7 +46,7 @@ module Bundler
       # All actions required by the Git source is encapsulated in this
       # object.
       class GitProxy
-        attr_accessor :path, :uri, :branch, :tag, :ref
+        attr_accessor :path, :uri, :branch, :tag, :ref, :explicit_ref
         attr_writer :revision
 
         def initialize(path, uri, options = {}, revision = nil, git = nil)
@@ -55,6 +55,7 @@ module Bundler
           @branch   = options["branch"]
           @tag      = options["tag"]
           @ref      = options["ref"]
+          @explicit_ref = branch || tag || ref
           @revision = revision
           @git      = git
         end
@@ -247,10 +248,9 @@ module Bundler
         end
 
         def find_local_revision
-          options_ref = branch || tag || ref
-          return head_revision if options_ref.nil?
+          return head_revision if explicit_ref.nil?
 
-          find_revision_for(options_ref)
+          find_revision_for(explicit_ref)
         end
 
         def head_revision

--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -31,7 +31,6 @@ module Bundler
           msg = String.new
           msg << "Git error: command `#{command}` in directory #{path} has failed."
           msg << "\n#{extra_info}" if extra_info
-          msg << "\nIf this error persists you could try removing the cache directory '#{path}'" if path.exist?
           super msg
         end
       end

--- a/bundler/spec/lock/git_spec.rb
+++ b/bundler/spec/lock/git_spec.rb
@@ -22,6 +22,17 @@ RSpec.describe "bundle lock with git gems" do
     expect(err).to be_empty
   end
 
+  it "prints a proper error when changing a locked Gemfile to point to a bad branch" do
+    gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
+      gem 'foo', :git => "#{lib_path("foo-1.0")}", :branch => "bad"
+    G
+
+    bundle "lock --update foo", :raise_on_error => false
+
+    expect(err).to include("Revision bad does not exist in the repository")
+  end
+
   it "locks a git source to the current ref" do
     update_git "foo"
     bundle :install


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Before #4475, changing a locked git source in the Gemfile with a bad reference name would saw a helpful error saying that the reference does not exist remotely:

```
$ bundle install
Fetching https://github.com/rails/rails.git
fatal: Needed a single revision
Git error: command `git rev-parse --verify bad` in directory
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/cache/bundler/git/rails-fcf0202857b07db1a0f6220dae5ca99319ca0f32 has failed.
Revision bad does not exist in the repository https://github.com/rails/rails.git. Maybe you misspelled it?
If this error persists you could try removing the cache directory
'/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/cache/bundler/git/rails-fcf0202857b07db1a0f6220dae5ca99319ca0f32'
```

To be honest, the error was not ideal but at least the culprit is mentioned `Revision bad does not exist in the repository https://github.com/rails/rails.git. Maybe you misspelled it?`

After #4475, the error is in my opinion worse:

```
$ bundle install
Fetching https://github.com/rails/rails.git
fatal: couldn't find remote ref refs/heads/bad

Retrying `git fetch --force --quiet --no-tags --depth 1 -- https://github.com/rails/rails.git refs/heads/bad:refs/heads/bad` at /Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/cache/bundler/git/rails-fcf0202857b07db1a0f6220dae5ca99319ca0f32 due to error (2/4): Bundler::Source::Git::GitCommandError Git error: command `git fetch --force --quiet --no-tags --depth 1 -- https://github.com/rails/rails.git refs/heads/bad:refs/heads/bad` in directory /Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/cache/bundler/git/rails-fcf0202857b07db1a0f6220dae5ca99319ca0f32 has failed.

If this error persists you could try removing the cache directory '/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/cache/bundler/git/rails-fcf0202857b07db1a0f6220dae5ca99319ca0f32'

Retrying `git fetch --force --quiet --no-tags --depth 1 -- https://github.com/rails/rails.git refs/heads/bad:refs/heads/bad` at /Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/cache/bundler/git/rails-fcf0202857b07db1a0f6220dae5ca99319ca0f32 due to error (3/4): Bundler::Source::Git::GitCommandError Git error: command `git fetch --force --quiet --no-tags --depth 1 -- https://github.com/rails/rails.git refs/heads/bad:refs/heads/bad` in directory /Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/cache/bundler/git/rails-fcf0202857b07db1a0f6220dae5ca99319ca0f32 has failed.

If this error persists you could try removing the cache directory '/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/cache/bundler/git/rails-fcf0202857b07db1a0f6220dae5ca99319ca0f32'

Retrying `git fetch --force --quiet --no-tags --depth 1 -- https://github.com/rails/rails.git refs/heads/bad:refs/heads/bad` at /Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/cache/bundler/git/rails-fcf0202857b07db1a0f6220dae5ca99319ca0f32 due to error (4/4): Bundler::Source::Git::GitCommandError Git error: command `git fetch --force --quiet --no-tags --depth 1 -- https://github.com/rails/rails.git refs/heads/bad:refs/heads/bad` in directory /Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/cache/bundler/git/rails-fcf0202857b07db1a0f6220dae5ca99319ca0f32 has failed.

If this error persists you could try removing the cache directory '/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/cache/bundler/git/rails-fcf0202857b07db1a0f6220dae5ca99319ca0f32'

Git error: command `git fetch --force --quiet --no-tags --depth 1 -- https://github.com/rails/rails.git refs/heads/bad:refs/heads/bad` in directory
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/cache/bundler/git/rails-fcf0202857b07db1a0f6220dae5ca99319ca0f32 has failed.

If this error persists you could try removing the cache directory
'/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/cache/bundler/git/rails-fcf0202857b07db1a0f6220dae5ca99319ca0f32'
```

The culprit is still mentioned `fatal: couldn't find remote ref refs/heads/bad`, but the error is flooded with other unhelpful information.

## What is your fix for the problem, implemented in this PR?

My fix is to refactor things and show a better error in this situation:

```
$ bundle install
Fetching https://github.com/rails/rails.git

Git error: command `git fetch --force --quiet --no-tags --depth 1 -- https://github.com/rails/rails.git refs/heads/bad:refs/heads/bad` in directory
/Users/deivid/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/cache/bundler/git/rails-fcf0202857b07db1a0f6220dae5ca99319ca0f32 has failed.
Revision bad does not exist in the repository https://github.com/rails/rails.git. Maybe you misspelled it?
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
