### PR TITLE
Fix unintentional downgrades when gemspec DSL is used

### DIFF
--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -161,11 +161,17 @@ module Bundler
     end
 
     def map_sources(replacement_sources)
-      [@rubygems_sources, @path_sources, @git_sources, @plugin_sources].map do |sources|
+      rubygems, git, plugin = [@rubygems_sources, @git_sources, @plugin_sources].map do |sources|
         sources.map do |source|
           replacement_sources.find {|s| s == source } || source
         end
       end
+
+      path = @path_sources.map do |source|
+        replacement_sources.find {|s| s == (source.is_a?(Source::Gemspec) ? source.as_path_source : source) } || source
+      end
+
+      [rubygems, path, git, plugin]
     end
 
     def global_replacement_source(replacement_sources)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Bundler sets `>= <locked_version>` additional resolution requirements for all direct dependencies, in order to avoid downgrades.

Those are passed on to the resolver through this array here:

https://github.com/rubygems/rubygems/blob/084f7d1f21f6fc3e2bb685b7bda3653fb2891c6e/bundler/lib/bundler/definition.rb#L885-L891

In this case thought, an empty array is being passed (so no additional lower bound requirements due to `sources.expired_sources?(@locked_gems.sources)` being `true`.

That accounts for the case when the user changes Gemfile sources, expiring those in the lock file. In that case, it's possible that a gem in the new source needs to be downgraded, so lower bound requirements are not passed.

Here, however, nobody is changing any sources, and that method is still returning `true`. That's the bug. Closer inspection reveals that the `Source::Path` source included in `Gemfile.lock` is being considered different to the `Source::Gemspec` source included in the `Gemfile`. They are actually the same thing though.

## What is your fix for the problem, implemented in this PR?

This commit fixes the issue by properly normalizing `Gemspec` and `Path` sources so that they can be properly compared.

Fixes #6129.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
