### PR TITLE
Auto-heal lockfile when it's missing specs

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -16,7 +16,6 @@ module Bundler
       :locked_deps,
       :locked_gems,
       :platforms,
-      :requires,
       :ruby_version,
       :lockfile,
       :gemfiles
@@ -145,8 +144,6 @@ module Bundler
 
       @dependency_changes = converge_dependencies
       @local_changes = converge_locals
-
-      @requires = compute_requires
     end
 
     def gem_version_promoter
@@ -869,17 +866,6 @@ module Bundler
         proposed = proposed.gsub(pattern, "\n").gsub(whitespace_cleanup, "\n\n").strip
       end
       current == proposed
-    end
-
-    def compute_requires
-      dependencies.reduce({}) do |requires, dep|
-        next requires unless dep.should_include?
-        requires[dep.name] = Array(dep.autorequire || dep.name).map do |file|
-          # Allow `require: true` as an alias for `require: <name>`
-          file == true ? dep.name : file
-        end
-        requires
-      end
     end
 
     def additional_base_requirements_for_resolve(last_resolve)

--- a/bundler/spec/bundler/installer/parallel_installer_spec.rb
+++ b/bundler/spec/bundler/installer/parallel_installer_spec.rb
@@ -11,40 +11,6 @@ RSpec.describe Bundler::ParallelInstaller do
 
   subject { described_class.new(installer, all_specs, size, standalone, force) }
 
-  context "when dependencies that are not on the overall installation list are the only ones not installed" do
-    let(:all_specs) do
-      [
-        build_spec("alpha", "1.0") {|s| s.runtime "a", "1" },
-      ].flatten
-    end
-
-    it "prints a warning" do
-      expect(Bundler.ui).to receive(:warn).with(<<-W.strip)
-Your lockfile was created by an old Bundler that left some things out.
-You can fix this by adding the missing gems to your Gemfile, running bundle install, and then removing the gems from your Gemfile.
-The missing gems are:
-* a depended upon by alpha
-      W
-      subject.check_for_corrupt_lockfile
-    end
-
-    context "when size > 1" do
-      let(:size) { 500 }
-
-      it "prints a warning and sets size to 1" do
-        expect(Bundler.ui).to receive(:warn).with(<<-W.strip)
-Your lockfile was created by an old Bundler that left some things out.
-Because of the missing DEPENDENCIES, we can only install gems one at a time, instead of installing 500 at a time.
-You can fix this by adding the missing gems to your Gemfile, running bundle install, and then removing the gems from your Gemfile.
-The missing gems are:
-* a depended upon by alpha
-        W
-        subject.check_for_corrupt_lockfile
-        expect(subject.size).to eq(1)
-      end
-    end
-  end
-
   context "when the spec set is not a valid resolution" do
     let(:all_specs) do
       [


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If a lockfile is missing some specs (meaning, it includes some dependencies but not specs for those dependencies), then Bundler currently happily accepts the lockfile and crashes when it's about to install it.

We have a check for a corrupt lockfile right before installing. However, the check accounted for locked specs not satisfying locked dependencies, but not for locked specs missing for some locked dependencies.

I still need to investigate _why_ this kind of lockfile was generated in the first place, but that shouldn't block this PR.

## What is your fix for the problem, implemented in this PR?

Instead of fixing this check, I decided to remove it in favor of automatically detecting the situation and re-resolve to automatically fix the lockfile rather than printing a warning but leave the problem there.

Fixes #6124.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
