### PR TITLE
Clean built artifacts after building extensions

### DIFF
--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -17,7 +17,7 @@ class Gem::Ext::Builder
     $1.downcase
   end
 
-  def self.make(dest_path, results, make_dir = Dir.pwd, sitedir = nil)
+  def self.make(dest_path, results, make_dir = Dir.pwd, sitedir = nil, targets = ["clean", "", "install"])
     unless File.exist? File.join(make_dir, "Makefile")
       raise Gem::InstallError, "Makefile not found"
     end
@@ -40,7 +40,7 @@ class Gem::Ext::Builder
       env << "sitelibdir=%s" % sitedir
     end
 
-    ["clean", "", "install"].each do |target|
+    targets.each do |target|
       # Pass DESTDIR via command line to override what's in MAKEFLAGS
       cmd = [
         *make_program,

--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -55,6 +55,8 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
         destent = ent.class.new(dest_path, ent.rel)
         destent.exist? || FileUtils.mv(ent.path, destent.path)
       end
+
+      make dest_path, results, extension_dir, tmp_dest_relative, ["clean"]
     ensure
       ENV["DESTDIR"] = destdir
     end

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1584,6 +1584,41 @@ gem 'other', version
     end
   end
 
+  def test_install_extension_clean_intermediate_files
+    pend "extensions don't quite work on jruby" if Gem.java_platform?
+    @spec = setup_base_spec
+    @spec.require_paths = ["."]
+    @spec.extensions << "extconf.rb"
+
+    File.write File.join(@tempdir, "extconf.rb"), <<-RUBY
+      require "mkmf"
+      CONFIG['CC'] = '$(TOUCH) $@ ||'
+      CONFIG['LDSHARED'] = '$(TOUCH) $@ ||'
+      $ruby = '#{Gem.ruby}'
+      create_makefile("#{@spec.name}")
+    RUBY
+
+    # empty depend file for no auto dependencies
+    @spec.files += %W[depend #{@spec.name}.c].each do |file|
+      write_file File.join(@tempdir, file)
+    end
+
+    shared_object = "#{@spec.name}.#{RbConfig::CONFIG["DLEXT"]}"
+    extension_file = File.join @spec.extension_dir, shared_object
+    intermediate_file = File.join @spec.gem_dir, shared_object
+
+    assert_path_not_exist extension_file, "no before installing"
+    use_ui @ui do
+      path = Gem::Package.build @spec
+
+      installer = Gem::Installer.at path
+      installer.install
+    end
+
+    assert_path_exist extension_file, "installed"
+    assert_path_not_exist intermediate_file
+  end
+
   def test_installation_satisfies_dependency_eh
     installer = setup_base_installer
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1559,7 +1559,7 @@ gem 'other', version
         write_file File.join(@tempdir, file)
       end
 
-      so = File.join(@spec.gem_dir, "#{@spec.name}.#{RbConfig::CONFIG["DLEXT"]}")
+      so = File.join(@spec.extension_dir, "#{@spec.name}.#{RbConfig::CONFIG["DLEXT"]}")
       assert_path_not_exist so
       use_ui @ui do
         path = Gem::Package.build @spec

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -691,13 +691,13 @@ class TestGemRequire < Gem::TestCase
 
     spec.files += ["extconf.rb", "depend", "#{name}.c"]
 
-    so = File.join(spec.extension_dir, "#{name}.#{RbConfig::CONFIG["DLEXT"]}")
-    assert_path_not_exist so
+    extension_file = File.join(spec.extension_dir, "#{name}.#{RbConfig::CONFIG["DLEXT"]}")
+    assert_path_not_exist extension_file
 
     path = Gem::Package.build spec
     installer = Gem::Installer.at path
     installer.install
-    assert_path_exist so
+    assert_path_exist extension_file
 
     spec.gem_dir
   end

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -691,7 +691,7 @@ class TestGemRequire < Gem::TestCase
 
     spec.files += ["extconf.rb", "depend", "#{name}.c"]
 
-    so = File.join(spec.gem_dir, "#{name}.#{RbConfig::CONFIG["DLEXT"]}")
+    so = File.join(spec.extension_dir, "#{name}.#{RbConfig::CONFIG["DLEXT"]}")
     assert_path_not_exist so
 
     path = Gem::Package.build spec


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Currently installing extensions leaves around intermediary files that may end up taking a lot of disk space.

## What is your fix for the problem, implemented in this PR?

Add a clean step after installing the extension.

This PR is based on the useful work by @eloyesp at #4017.

Fixes #3958.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
