### PR TITLE
Add `bundle lock --update --bundler`

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -672,6 +672,8 @@ module Bundler
       "If updating, do not allow any gem to be updated past latest --patch | --minor | --major"
     method_option "conservative", :type => :boolean, :banner =>
       "If updating, use bundle install conservative update behavior and do not allow shared dependencies to be updated"
+    method_option "bundler", :type => :string, :lazy_default => "> 0.a", :banner =>
+      "Update the locked version of bundler"
     def lock
       require_relative "cli/lock"
       Lock.new(options).run

--- a/bundler/lib/bundler/cli/lock.rb
+++ b/bundler/lib/bundler/cli/lock.rb
@@ -22,12 +22,15 @@ module Bundler
 
       update = options[:update]
       conservative = options[:conservative]
+      bundler = options[:bundler]
 
       if update.is_a?(Array) # unlocking specific gems
         Bundler::CLI::Common.ensure_all_gems_in_lockfile!(update)
         update = { :gems => update, :conservative => conservative }
-      elsif update
-        update = { :conservative => conservative } if conservative
+      elsif update && conservative
+        update = { :conservative => conservative }
+      elsif update && bundler
+        update = { :bundler => bundler }
       end
       definition = Bundler.definition(update)
 


### PR DESCRIPTION
This PR resurrects https://github.com/rubygems/bundler/pull/6925 by @alyssais from the old repo.

## What was the end-user or developer problem that led to this PR?

From that PR description:

> `bundle lock --update` can do everything that `bundle update` can do, but it doesn't actually install gems. This is especially useful for generating a lockfile on a machine that doesn't have the libraries available to be able to build native extensions.

But, there was no parallel for `bundle update --bundler`. So let's add one.

## What is your fix for the problem, implemented in this PR?

Implement `bundle lock --update --bundler`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
