### PR TITLE
Deprecate `sitedir` parameter to `Gem::Ext::Builder.make`

### DIFF
--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -19,7 +19,14 @@ class Gem::Ext::Builder
     $1.downcase
   end
 
-  def self.make(dest_path, results, make_dir = Dir.pwd, sitedir = nil, targets = ["clean", "", "install"])
+  def self.make(dest_path, results, make_dir = Dir.pwd, targets_or_sitedir = ["clean", "", "install"], old_targets = ["clean", "", "install"])
+    if !targets_or_sitedir.is_a?(Array)
+      verbose { "sitedir parameter to Gem::Ext::Builder.make is getting ignored. sitearchdir and sitelibdir are now always set to the first argument passed to this method. Please stop passing this parameter" }
+      targets = old_targets
+    else
+      targets = targets_or_sitedir
+    end
+
     unless File.exist? File.join(make_dir, "Makefile")
       raise Gem::InstallError, "Makefile not found"
     end
@@ -35,10 +42,8 @@ class Gem::Ext::Builder
 
     env = [destdir]
 
-    if sitedir
-      env << format("sitearchdir=%s", sitedir)
-      env << format("sitelibdir=%s", sitedir)
-    end
+    env << format("sitearchdir=%s", dest_path)
+    env << format("sitelibdir=%s", dest_path)
 
     targets.each do |target|
       # Pass DESTDIR via command line to override what's in MAKEFLAGS

--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -9,15 +9,6 @@
 class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
   def self.build(extension, dest_path, results, args=[], lib_dir=nil, extension_dir=Dir.pwd)
     require "fileutils"
-    require "tempfile"
-
-    tmp_dest = Dir.mktmpdir(".gem.", extension_dir)
-
-    # Some versions of `mktmpdir` return absolute paths, which will break make
-    # if the paths contain spaces.
-    #
-    # As such, we convert to a relative path.
-    tmp_dest_relative = get_relative_path(tmp_dest.clone, extension_dir)
 
     destdir = ENV["DESTDIR"]
 
@@ -39,35 +30,31 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
 
       ENV["DESTDIR"] = nil
 
-      make dest_path, results, extension_dir, tmp_dest_relative
-
-      full_tmp_dest = File.join(extension_dir, tmp_dest_relative)
+      rel_dest_path = get_relative_path(dest_path, extension_dir)
+      make rel_dest_path, results, extension_dir
 
       # TODO: remove in RubyGems 4
       if Gem.install_extension_in_lib && lib_dir
         FileUtils.mkdir_p lib_dir
-        entries = Dir.entries(full_tmp_dest) - %w[. ..]
-        entries = entries.map {|entry| File.join full_tmp_dest, entry }
+        entries = Dir.entries(dest_path) - %w[. ..]
+        entries = entries.map {|entry| File.join dest_path, entry }
         FileUtils.cp_r entries, lib_dir, remove_destination: true
       end
 
-      FileUtils::Entry_.new(full_tmp_dest).traverse do |ent|
-        destent = ent.class.new(dest_path, ent.rel)
-        destent.exist? || FileUtils.mv(ent.path, destent.path)
-      end
-
-      make dest_path, results, extension_dir, tmp_dest_relative, ["clean"]
+      make dest_path, results, extension_dir, ["clean"]
     ensure
       ENV["DESTDIR"] = destdir
     end
 
     results
-  ensure
-    FileUtils.rm_rf tmp_dest if tmp_dest
   end
 
   def self.get_relative_path(path, base)
-    path[0..base.length - 1] = "." if path.start_with?(base)
-    path
+    path.split("/").zip(base.split("/")).inject(String.new) do |result, (path_component, base_component)|
+      next result if path_component == base_component
+      result.prepend("../") if base_component
+      result.concat("#{path_component}/") if path_component
+      result
+    end
   end
 end

--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -48,9 +48,9 @@ install:
 
     results = results.join("\n").b
 
-    assert_match(/DESTDIR\\=#{ENV["DESTDIR"]} clean$/,   results)
-    assert_match(/DESTDIR\\=#{ENV["DESTDIR"]}$/,         results)
-    assert_match(/DESTDIR\\=#{ENV["DESTDIR"]} install$/, results)
+    assert_match(/DESTDIR\\=#{ENV["DESTDIR"]} sitearchdir\\=#{@dest_path} sitelibdir\\=#{@dest_path} clean$/, results)
+    assert_match(/DESTDIR\\=#{ENV["DESTDIR"]} sitearchdir\\=#{@dest_path} sitelibdir\\=#{@dest_path}$/, results)
+    assert_match(/DESTDIR\\=#{ENV["DESTDIR"]} sitearchdir\\=#{@dest_path} sitelibdir\\=#{@dest_path} install/, results)
 
     unless results.include?("nmake")
       assert_match(/^clean: destination$/,   results)
@@ -77,9 +77,9 @@ install:
 
     results = results.join("\n").b
 
-    assert_match(/DESTDIR\\=#{ENV["DESTDIR"]} clean$/,   results)
-    assert_match(/DESTDIR\\=#{ENV["DESTDIR"]}$/,         results)
-    assert_match(/DESTDIR\\=#{ENV["DESTDIR"]} install$/, results)
+    assert_match(/DESTDIR\\=#{ENV["DESTDIR"]} sitearchdir\\=#{@dest_path} sitelibdir\\=#{@dest_path} clean$/, results)
+    assert_match(/DESTDIR\\=#{ENV["DESTDIR"]} sitearchdir\\=#{@dest_path} sitelibdir\\=#{@dest_path}$/, results)
+    assert_match(/DESTDIR\\=#{ENV["DESTDIR"]} sitearchdir\\=#{@dest_path} sitelibdir\\=#{@dest_path} install$/, results)
   end
 
   def test_custom_make_with_options

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1652,19 +1652,6 @@ end
         installer.install
       end
       assert_path_exist so
-    rescue StandardError
-      puts "-" * 78
-      puts File.read File.join(@gemhome, "gems", "a-2", "Makefile")
-      puts "-" * 78
-
-      path = File.join(@gemhome, "gems", "a-2", "gem_make.out")
-
-      if File.exist?(path)
-        puts File.read(path)
-        puts "-" * 78
-      end
-
-      raise
     end
   end
 


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

## What was the end-user or developer problem that led to this PR?

Extension building code is complicated.

## What is your fix for the problem, implemented in this PR?

Simplifying things. We were doing what `make install` should be doing ourselves. By passing a relative dest_path and feeding that as `sitelibdir` and `sitearchdir`, we can get `make install` to install there directly, rather than getting `make install` to install to a temporary location, and then manually copying files in there to final final installation path.

This PR can't be merged at the moment because for some reason Ruby 2.6 and 2.7 on Windows don't like it. It sounds like some bug recently fixed since Ruby 3.0 and 3.1 are fine.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
