### PR TITLE
Fix crash when showing resolution errors with OR requirements

### DIFF
--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -117,7 +117,8 @@ module Bundler
       cause = PubGrub::Incompatibility::NoVersions.new(unsatisfied_term)
       name = package.name
       constraint = unsatisfied_term.constraint
-      requirement = Gem::Requirement.new(constraint.constraint_string.split(","))
+      constraint_string = constraint.constraint_string
+      requirement = Gem::Requirement.new(constraint_string.split(","))
 
       if name == "bundler"
         custom_explanation = "the current Bundler version (#{Bundler::VERSION}) does not satisfy #{constraint}"
@@ -128,8 +129,7 @@ module Bundler
         platforms_explanation = specs_matching_other_platforms.any? ? " for any resolution platforms (#{package.platforms.join(", ")})" : ""
         custom_explanation = "#{constraint} could not be found in #{repository_for(package)}#{platforms_explanation}"
 
-        dependency = Dependency.new(name, requirement)
-        label = SharedHelpers.pretty_dependency(dependency)
+        label = "#{name} (#{constraint_string})"
         extended_explanation = other_specs_matching_message(specs_matching_other_platforms, label) if specs_matching_other_platforms.any?
       end
 

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -693,5 +693,44 @@ RSpec.describe "bundle lock" do
            #{Bundler::VERSION}
       L
     end
+
+    it "properly shows resolution errors including OR requirements" do
+      build_repo4 do
+        build_gem "activeadmin", "2.13.1" do |s|
+          s.add_dependency "railties", ">= 6.1", "< 7.1"
+        end
+        build_gem "actionpack", "6.1.4"
+        build_gem "actionpack", "7.0.3.1"
+        build_gem "actionpack", "7.0.4"
+        build_gem "railties", "6.1.4" do |s|
+          s.add_dependency "actionpack", "6.1.4"
+        end
+        build_gem "rails", "7.0.3.1" do |s|
+          s.add_dependency "railties", "7.0.3.1"
+        end
+        build_gem "rails", "7.0.4" do |s|
+          s.add_dependency "railties", "7.0.4"
+        end
+      end
+
+      gemfile <<~G
+        source "#{file_uri_for(gem_repo4)}"
+
+        gem "rails", ">= 7.0.3.1"
+        gem "activeadmin", "2.13.1"
+      G
+
+      bundle "lock", :raise_on_error => false
+
+      expect(err).to eq <<~ERR.strip
+        Could not find compatible versions
+
+        Because rails >= 7.0.4 depends on railties = 7.0.4
+          and rails < 7.0.4 depends on railties = 7.0.3.1,
+          railties = 7.0.3.1 OR = 7.0.4 is required.
+        So, because railties = 7.0.3.1 OR = 7.0.4 could not be found in rubygems repository #{file_uri_for(gem_repo4)}/ or installed locally,
+          version solving has failed.
+      ERR
+    end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If Pub Grub concludes with a resolution error, and the explanation for the error includes "OR" requirements, Bundler crashes.

## What is your fix for the problem, implemented in this PR?

Support PubGrub's `VersionUnion` when building our error messages.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
