### PR TITLE
Fix crash when showing some resolution errors

### DIFF
--- a/bundler/lib/bundler/vendor/pub_grub/lib/pub_grub/version_union.rb
+++ b/bundler/lib/bundler/vendor/pub_grub/lib/pub_grub/version_union.rb
@@ -77,7 +77,7 @@ module Bundler::PubGrub
           return true
         end
 
-        if !my_range.max || (other_range.max && other_range.max < my_range.max)
+        if !my_range.max || other_range.empty? || (other_range.max && other_range.max < my_range.max)
           other_range = other_ranges.shift
         else
           my_range = my_ranges.shift
@@ -119,7 +119,7 @@ module Bundler::PubGrub
       while my_range && other_range
         new_ranges << my_range.intersect(other_range)
 
-        if !my_range.max || (other_range.max && other_range.max < my_range.max)
+        if !my_range.max || other_range.empty? || (other_range.max && other_range.max < my_range.max)
           other_range = other_ranges.shift
         else
           my_range = my_ranges.shift


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If the conflict explanation includes empty ranges and version unions, Pub Grub was crashing.

## What is your fix for the problem, implemented in this PR?

I fixed it by adding a guard in the proper place.

Upstream PR is here: https://github.com/jhawthorn/pub_grub/pull/20.

Tests are included in the upstream PR.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
