### PR TITLE
Use safe Marshal deserialization for dependency API response.

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -39,6 +39,16 @@ module Bundler
   environment_preserver.replace_with_backup
   SUDO_MUTEX = Thread::Mutex.new
 
+  SAFE_MARSHAL_CLASSES = [Symbol, TrueClass, String, Array, Hash].freeze
+  SAFE_MARSHAL_ERROR = "Unexpected class %s present in marshaled data. Only %s are allowed.".freeze
+  SAFE_MARSHAL_PROC = proc do |object|
+    object.tap do
+      unless SAFE_MARSHAL_CLASSES.include?(object.class)
+        raise TypeError, format(SAFE_MARSHAL_ERROR, object.class, SAFE_MARSHAL_CLASSES.join(", "))
+      end
+    end
+  end
+
   autoload :Definition,             File.expand_path("bundler/definition", __dir__)
   autoload :Dependency,             File.expand_path("bundler/dependency", __dir__)
   autoload :Deprecate,              File.expand_path("bundler/deprecate", __dir__)
@@ -511,8 +521,12 @@ EOF
       end
     end
 
-    def load_marshal(data)
-      Marshal.load(data)
+    def safe_load_marshal(data)
+      load_marshal(data, :marshal_proc => SAFE_MARSHAL_PROC)
+    end
+
+    def load_marshal(data, marshal_proc: nil)
+      Marshal.load(data, marshal_proc)
     rescue TypeError => e
       raise MarshalError, "#{e.class}: #{e.message}"
     end

--- a/bundler/lib/bundler/fetcher/dependency.rb
+++ b/bundler/lib/bundler/fetcher/dependency.rb
@@ -55,7 +55,7 @@ module Bundler
         gem_list = []
         gem_names.each_slice(Source::Rubygems::API_REQUEST_SIZE) do |names|
           marshalled_deps = downloader.fetch(dependency_api_uri(names)).body
-          gem_list.concat(Bundler.load_marshal(marshalled_deps))
+          gem_list.concat(Bundler.safe_load_marshal(marshalled_deps))
         end
         gem_list
       end

--- a/bundler/spec/bundler/bundler_spec.rb
+++ b/bundler/spec/bundler/bundler_spec.rb
@@ -4,6 +4,26 @@ require "bundler"
 require "tmpdir"
 
 RSpec.describe Bundler do
+  describe "#load_marshal" do
+    it "loads any data" do
+      data = Marshal.dump(Bundler)
+      expect(Bundler.load_marshal(data)).to eq(Bundler)
+    end
+  end
+
+  describe "#safe_load_marshal" do
+    it "fails on unexpected class" do
+      data = Marshal.dump(Bundler)
+      expect { Bundler.safe_load_marshal(data) }.to raise_error(Bundler::MarshalError)
+    end
+
+    it "loads simple structure" do
+      simple_structure = { "name" => [:abc] }
+      data = Marshal.dump(simple_structure)
+      expect(Bundler.safe_load_marshal(data)).to eq(simple_structure)
+    end
+  end
+
   describe "#load_gemspec_uncached" do
     let(:app_gemspec_path) { tmp("test.gemspec") }
     subject { Bundler.load_gemspec_uncached(app_gemspec_path) }

--- a/bundler/spec/bundler/fetcher/dependency_spec.rb
+++ b/bundler/spec/bundler/fetcher/dependency_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe Bundler::Fetcher::Dependency do
     it "should fetch dependencies from RubyGems and unmarshal them" do
       expect(gem_names).to receive(:each_slice).with(rubygems_limit).and_call_original
       expect(downloader).to receive(:fetch).with(dep_api_uri).and_return(fetch_response)
-      expect(Bundler).to receive(:load_marshal).with(fetch_response.body).and_return([unmarshalled_gems])
+      expect(Bundler).to receive(:safe_load_marshal).with(fetch_response.body).and_return([unmarshalled_gems])
       expect(subject.unmarshalled_dep_gems(gem_names)).to eq([unmarshalled_gems])
     end
   end


### PR DESCRIPTION
:information_source: I'm looking at introducing real-word spec to cover the real response from Dependency API as well.