### PR TITLE
Enhance `bundle open` command to allow opening subdir/file of gem

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -509,6 +509,7 @@ module Bundler
     subcommand "config", Config
 
     desc "open GEM", "Opens the source directory of the given bundled gem"
+    method_option "path", :type => :string, :banner => "Open relative path of the gem source."
     def open(name)
       require_relative "cli/open"
       Open.new(options, name).run

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -509,7 +509,7 @@ module Bundler
     subcommand "config", Config
 
     desc "open GEM", "Opens the source directory of the given bundled gem"
-    method_option "path", :type => :string, :banner => "Open relative path of the gem source."
+    method_option "path", :type => :string, :lazy_default => "", :banner => "Open relative path of the gem source."
     def open(name)
       require_relative "cli/open"
       Open.new(options, name).run

--- a/bundler/lib/bundler/cli/open.rb
+++ b/bundler/lib/bundler/cli/open.rb
@@ -10,6 +10,7 @@ module Bundler
     end
 
     def run
+      raise InvalidOption, "Cannot specify `--path` option without a value" if !@path.nil? && @path.empty?
       editor = [ENV["BUNDLER_EDITOR"], ENV["VISUAL"], ENV["EDITOR"]].find {|e| !e.nil? && !e.empty? }
       return Bundler.ui.info("To open a bundled gem, set $EDITOR or $BUNDLER_EDITOR") unless editor
       return unless spec = Bundler::CLI::Common.select_spec(name, :regex_match)

--- a/bundler/lib/bundler/cli/open.rb
+++ b/bundler/lib/bundler/cli/open.rb
@@ -2,10 +2,11 @@
 
 module Bundler
   class CLI::Open
-    attr_reader :options, :name
+    attr_reader :options, :name, :path
     def initialize(options, name)
       @options = options
       @name = name
+      @path = options[:path] unless options[:path].nil?
     end
 
     def run
@@ -15,10 +16,10 @@ module Bundler
       if spec.default_gem?
         Bundler.ui.info "Unable to open #{name} because it's a default gem, so the directory it would normally be installed to does not exist."
       else
-        path = spec.full_gem_path
-        Dir.chdir(path) do
+        root_path = spec.full_gem_path
+        Dir.chdir(root_path) do
           require "shellwords"
-          command = Shellwords.split(editor) + [path]
+          command = Shellwords.split(editor) << File.join([root_path, path].compact)
           Bundler.with_original_env do
             system(*command)
           end || Bundler.ui.info("Could not run '#{command.join(" ")}'")

--- a/bundler/lib/bundler/man/bundle-open.1
+++ b/bundler/lib/bundler/man/bundle-open.1
@@ -7,7 +7,7 @@
 \fBbundle\-open\fR \- Opens the source directory for a gem in your bundle
 .
 .SH "SYNOPSIS"
-\fBbundle open\fR [GEM]
+\fBbundle open\fR [GEM] [\-\-path=PATH]
 .
 .SH "DESCRIPTION"
 Opens the source directory of the provided GEM in your editor\.
@@ -30,3 +30,23 @@ bundle open \'rack\'
 .
 .P
 Will open the source directory for the \'rack\' gem in your bundle\.
+.
+.IP "" 4
+.
+.nf
+
+bundle open \'rack\' \-\-path \'README\.md\'
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Will open the README\.md file of the \'rack\' gem source in your bundle\.
+.
+.SH "OPTIONS"
+.
+.TP
+\fB\-\-path\fR
+Specify GEM source relative path to open\.
+

--- a/bundler/lib/bundler/man/bundle-open.1.ronn
+++ b/bundler/lib/bundler/man/bundle-open.1.ronn
@@ -3,7 +3,7 @@ bundle-open(1) -- Opens the source directory for a gem in your bundle
 
 ## SYNOPSIS
 
-`bundle open` [GEM]
+`bundle open` [GEM] [--path=PATH]
 
 ## DESCRIPTION
 
@@ -17,3 +17,11 @@ Example:
     bundle open 'rack'
 
 Will open the source directory for the 'rack' gem in your bundle.
+
+    bundle open 'rack' --path 'README.md'
+
+Will open the README.md file of the 'rack' gem source in your bundle.
+
+## OPTIONS
+* `--path`:
+  Specify GEM source relative path to open.

--- a/bundler/spec/commands/open_spec.rb
+++ b/bundler/spec/commands/open_spec.rb
@@ -58,6 +58,59 @@ RSpec.describe "bundle open" do
       expect(out).to include("bundler_editor #{default_bundle_path("gems", "activerecord-2.3.2")}")
     end
 
+    it "opens subpath of the gem" do
+      bundle "open activerecord --path lib/activerecord", :env => { "EDITOR" => "echo editor", "VISUAL" => "", "BUNDLER_EDITOR" => "" }
+      expect(out).to include("editor #{default_bundle_path("gems", "activerecord-2.3.2")}/lib/activerecord")
+    end
+
+    it "opens subpath file of the gem" do
+      bundle "open activerecord --path lib/version.rb", :env => { "EDITOR" => "echo editor", "VISUAL" => "", "BUNDLER_EDITOR" => "" }
+      expect(out).to include("editor #{default_bundle_path("gems", "activerecord-2.3.2")}/lib/version.rb")
+    end
+
+    it "opens deep subpath of the gem" do
+      bundle "open activerecord --path lib/active_record", :env => { "EDITOR" => "echo editor", "VISUAL" => "", "BUNDLER_EDITOR" => "" }
+      expect(out).to include("editor #{default_bundle_path("gems", "activerecord-2.3.2")}/lib/active_record")
+    end
+
+    it "suggests alternatives for similar-sounding gems when using subpath" do
+      bundle "open Rails --path README.md", :env => { "EDITOR" => "echo editor", "VISUAL" => "", "BUNDLER_EDITOR" => "" }, :raise_on_error => false
+      expect(err).to match(/did you mean rails\?/i)
+    end
+
+    it "suggests alternatives for similar-sounding gems when using deep subpath" do
+      bundle "open Rails --path some/path/here", :env => { "EDITOR" => "echo editor", "VISUAL" => "", "BUNDLER_EDITOR" => "" }, :raise_on_error => false
+      expect(err).to match(/did you mean rails\?/i)
+    end
+
+    it "opens subpath of the short worded gem" do
+      bundle "open rec --path CHANGELOG.md", :env => { "EDITOR" => "echo editor", "VISUAL" => "", "BUNDLER_EDITOR" => "" }
+      expect(out).to include("editor #{default_bundle_path("gems", "activerecord-2.3.2")}/CHANGELOG.md")
+    end
+
+    it "opens deep subpath of the short worded gem" do
+      bundle "open rec --path lib/activerecord", :env => { "EDITOR" => "echo editor", "VISUAL" => "", "BUNDLER_EDITOR" => "" }
+      expect(out).to include("editor #{default_bundle_path("gems", "activerecord-2.3.2")}/lib/activerecord")
+    end
+
+    it "opens subpath of the selected matching gem", :readline do
+      env = { "EDITOR" => "echo editor", "VISUAL" => "echo visual", "BUNDLER_EDITOR" => "echo bundler_editor" }
+      bundle "open active --path CHANGELOG.md", :env => env do |input, _, _|
+        input.puts "2"
+      end
+
+      expect(out).to match(%r{bundler_editor #{default_bundle_path('gems', 'activerecord-2.3.2')}/CHANGELOG\.md\z})
+    end
+
+    it "opens deep subpath of the selected matching gem", :readline do
+      env = { "EDITOR" => "echo editor", "VISUAL" => "echo visual", "BUNDLER_EDITOR" => "echo bundler_editor" }
+      bundle "open active --path lib/activerecord/version.rb", :env => env do |input, _, _|
+        input.puts "2"
+      end
+
+      expect(out).to match(%r{bundler_editor #{default_bundle_path('gems', 'activerecord-2.3.2')}/lib/activerecord/version\.rb\z})
+    end
+
     it "select the gem from many match gems", :readline do
       env = { "EDITOR" => "echo editor", "VISUAL" => "echo visual", "BUNDLER_EDITOR" => "echo bundler_editor" }
       bundle "open active", :env => env do |input, _, _|

--- a/bundler/spec/commands/open_spec.rb
+++ b/bundler/spec/commands/open_spec.rb
@@ -73,6 +73,11 @@ RSpec.describe "bundle open" do
       expect(out).to include("editor #{default_bundle_path("gems", "activerecord-2.3.2")}/lib/active_record")
     end
 
+    it "requires value for --path arg" do
+      bundle "open activerecord --path", :env => { "EDITOR" => "echo editor", "VISUAL" => "", "BUNDLER_EDITOR" => "" }, :raise_on_error => false
+      expect(err).to eq "Cannot specify `--path` option without a value"
+    end
+
     it "suggests alternatives for similar-sounding gems when using subpath" do
       bundle "open Rails --path README.md", :env => { "EDITOR" => "echo editor", "VISUAL" => "", "BUNDLER_EDITOR" => "" }, :raise_on_error => false
       expect(err).to match(/did you mean rails\?/i)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I had an development workflow halt when vscode + remote containers combo was used. The scenario was following:

I wanted to open up specific gems specific file, but as remote containers use filesystem from within the docker container I could not use bundle open command to be able to see within a specific file of a gem. 

Even though remote containers does not allow easy "mount n+1 dirs" mechanisms, it would have been sufficient enough to be able to scope my bundle open command to a specific file that my tests were failing at.

I had the expectation that `bundle open` command would have allowed to open specific file with some syntax, but my expectations were not met.

## What is your fix for the problem, implemented in this PR?

As the first intuitive command to open a specific file was to try `bundle open GEM/some/file.rb` this is what was implemented.

I did try out adding second argument too, so that `bundle open GEM some/file.rb` would have worked, but that felt kind of off.

So, wrote the tests for the core of this enhancement and tests that make sure all the other fuzz matching & "did you mean" features would work just like they've been working before this enhancement.

## Make sure the following tasks are checked

- [x ] Describe the problem / feature
- [ x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ x] Write code to solve the problem
- [ x] Make sure you follow the [current code style]