### PR TITLE
Fix `bundle outdated` with both `--groups` and `--parseable` flags 

### DIFF
--- a/bundler/lib/bundler/cli/outdated.rb
+++ b/bundler/lib/bundler/cli/outdated.rb
@@ -111,9 +111,7 @@ module Bundler
           end.compact
 
           if options[:parseable]
-            relevant_outdated_gems.each do |gems|
-              print_gems(gems)
-            end
+            print_gems(relevant_outdated_gems)
           else
             print_gems_table(relevant_outdated_gems)
           end

--- a/bundler/spec/bundler/cli_spec.rb
+++ b/bundler/spec/bundler/cli_spec.rb
@@ -129,6 +129,52 @@ RSpec.describe "bundle executable" do
     end
   end
 
+  describe "bundle outdated" do
+    let(:run_command) do
+      bundle "install"
+
+      bundle "outdated #{flags}", :raise_on_error => false
+    end
+
+    before do
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rack", '0.9.1'
+      G
+    end
+
+    context "with --groups flag" do
+      let(:flags) { "--groups" }
+
+      it "prints a message when there are outdated gems" do
+        run_command
+
+        expect(out).to include("Gem   Current  Latest  Requested  Groups")
+        expect(out).to include("rack  0.9.1    1.0.0   = 0.9.1    default")
+      end
+    end
+
+    context "with --parseable" do
+      let(:flags) { "--parseable" }
+
+      it "prints a message when there are outdated gems" do
+        run_command
+
+        expect(out).to include("rack (newest 1.0.0, installed 0.9.1, requested = 0.9.1)")
+      end
+    end
+
+    context "with --groups and --parseable" do
+      let(:flags) { "--groups --parseable" }
+
+      it "prints a simplified message when there are outdated gems" do
+        run_command
+
+        expect(out).to include("rack (newest 1.0.0, installed 0.9.1, requested = 0.9.1)")
+      end
+    end
+  end
+
   describe "printing the outdated warning" do
     shared_examples_for "no warning" do
       it "prints no warning" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The `bundle outdated` command blows up when combining `--groups` and `--parseable` options

## What is your fix for the problem, implemented in this PR?
Add a spec to replicate and fix the argument passed to the `print_gems` method. 

Explanation: it seems this behaviour was untested and broken.

Fixes #6147.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
