### PR TITLE
Fix crash due to `BundlerVersionFinder` not defined

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1297,7 +1297,6 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
   MARSHAL_SPEC_DIR = "quick/Marshal.#{Gem.marshal_version}/".freeze
 
-  autoload :BundlerVersionFinder, File.expand_path("rubygems/bundler_version_finder", __dir__)
   autoload :ConfigFile,         File.expand_path("rubygems/config_file", __dir__)
   autoload :Dependency,         File.expand_path("rubygems/dependency", __dir__)
   autoload :DependencyList,     File.expand_path("rubygems/dependency_list", __dir__)

--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -277,7 +277,10 @@ class Gem::Dependency
       requirement.satisfied_by?(spec.version) && env_req.satisfied_by?(spec.version)
     end.map(&:to_spec)
 
-    Gem::BundlerVersionFinder.prioritize!(matches) if prioritizes_bundler?
+    if prioritizes_bundler?
+      require_relative "bundler_version_finder"
+      Gem::BundlerVersionFinder.prioritize!(matches)
+    end
 
     if platform_only
       matches.reject! do |spec|

--- a/test/rubygems/test_gem_bundler_version_finder.rb
+++ b/test/rubygems/test_gem_bundler_version_finder.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require_relative "helper"
+require "rubygems/bundler_version_finder"
 
 class TestGemBundlerVersionFinder < Gem::TestCase
   def setup

--- a/test/rubygems/test_gem_dependency.rb
+++ b/test/rubygems/test_gem_dependency.rb
@@ -358,6 +358,8 @@ class TestGemDependency < Gem::TestCase
 
     assert_equal [b, b_1], dep.to_specs
 
+    require "rubygems/bundler_version_finder"
+
     Gem::BundlerVersionFinder.stub(:bundler_version, Gem::Version.new("1")) do
       assert_equal [b_1, b], dep.to_specs
     end

--- a/test/rubygems/test_kernel.rb
+++ b/test/rubygems/test_kernel.rb
@@ -118,6 +118,8 @@ class TestKernel < Gem::TestCase
   end
 
   def test_gem_bundler_inferred_bundler_version
+    require "rubygems/bundler_version_finder"
+
     Gem::BundlerVersionFinder.stub(:bundler_version, Gem::Version.new("1")) do
       quick_gem "bundler", "1"
       quick_gem "bundler", "2.a"

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -666,6 +666,24 @@ class TestGemRequire < Gem::TestCase
     end
   end
 
+  def test_require_does_not_crash_when_utilizing_bundler_version_finder
+    a1 = util_spec "a", "1.1", { "bundler" => ">= 0" }
+    a2 = util_spec "a", "1.2", { "bundler" => ">= 0" }
+    b1 = util_spec "bundler", "2.3.7"
+    b2 = util_spec "bundler", "2.3.24"
+    c = util_spec "c", "1", { "a" => [">= 1.1", "< 99.0"] }, "lib/test_gem_require_c.rb"
+
+    install_specs a1, a2, b1, b2, c
+
+    cmd = <<-RUBY
+      require "test_gem_require_c"
+      require "json"
+    RUBY
+    out = Gem::Util.popen({ "GEM_HOME" => @gemhome }, *ruby_with_rubygems_in_load_path, "-e", cmd)
+    puts out
+    assert $?.success?
+  end
+
   private
 
   def util_install_extension_file(name)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes, RubyGems require can crash due to the `BundlerVersionFinder` constant not being found.

## What is your fix for the problem, implemented in this PR?

This seems like some kind of autoload Ruby bug, since we do setup autoloads for both `BundlerVersionFinder` and `Dependency` at RubyGems boot.

The autoloading of `BundlerVersionFinder` should be happening during the `autoload` of `Dependency` and I guess that's something Ruby cannot handle?

I'll try to bring this to ruby-core but the easy fix for us is to remove the `BundlerVersionFinder` autoload and move it to an inline `require` which should have the same effect.

Fixes #6145.

All credit to @joshuaswett for reporting the issue, writing the test, and proposing the fix ❤️.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
