### PR TITLE
Improve Bundler setup docs for development 

### DIFF
--- a/bundler/doc/development/SETUP.md
+++ b/bundler/doc/development/SETUP.md
@@ -12,11 +12,15 @@ To work on Bundler, you'll probably want to do a couple of things:
 
         $ brew install graphviz
 
-* From the rubygems root directory change into the bundler directory:
+* Install development dependencies from the rubygems root directory:
+
+        $ rake setup
+
+* Change into the bundler directory:
 
         $ cd bundler
 
-* Install Bundler's development dependencies:
+* Install Bundler's test dependencies:
 
         $ rake spec:deps
 

--- a/bundler/doc/development/SETUP.md
+++ b/bundler/doc/development/SETUP.md
@@ -22,13 +22,9 @@ To work on Bundler, you'll probably want to do a couple of things:
 
 * Install Bundler's test dependencies:
 
-        $ rake spec:deps
+        $ bin/rake spec:parallel_deps
 
-* Run the test suite, to make sure things are working:
-
-        $ bin/rake spec
-
-* Optionally, you can run the test suite in parallel:
+* Now you can run the test suite in parallel:
 
         $ bin/parallel_rspec
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

As pointed out by @markburns at https://github.com/rubygems/rubygems/pull/6148#issuecomment-1357414360, contributors to Bundler may miss the `rake setup` step.

## What is your fix for the problem, implemented in this PR?

Add it to the proper place. Also, since I was at it, changed docs to recommend only the "parallel tests setup", since it's well battle tested now and the only thing CI runs.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
