### PR TITLE
Improve resolver logging

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -263,10 +263,10 @@ module Bundler
         @locked_specs
       elsif !unlocking? && nothing_changed?
         if deleted_deps.any?
-          Bundler.ui.debug("Some dependencies were deleted, using a subset of the resolution from the lockfile")
+          Bundler.ui.debug "Some dependencies were deleted, using a subset of the resolution from the lockfile"
           SpecSet.new(filter_specs(@locked_specs, @dependencies - deleted_deps))
         else
-          Bundler.ui.debug("Found no changes, using resolution from the lockfile")
+          Bundler.ui.debug "Found no changes, using resolution from the lockfile"
           if @locked_gems.may_include_redundant_platform_specific_gems?
             SpecSet.new(filter_specs(@locked_specs, @dependencies))
           else
@@ -274,7 +274,7 @@ module Bundler
           end
         end
       else
-        Bundler.ui.debug("Found changes from the lockfile, re-resolving dependencies because #{change_reason}")
+        Bundler.ui.debug "Found changes from the lockfile, re-resolving dependencies because #{change_reason}"
         start_resolution
       end
     end

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -27,6 +27,17 @@ module Bundler
         remove_from_candidates(spec)
       end
 
+      @requirements = requirements
+      @packages = packages
+
+      root, logger = setup_solver
+
+      Bundler.ui.info "Resolving dependencies...", true
+
+      solve_versions(:root => root, :logger => logger)
+    end
+
+    def setup_solver
       root = Resolver::Root.new(name_for_explicit_dependency_source)
       root_version = Resolver::Candidate.new(0)
 
@@ -42,24 +53,27 @@ module Bundler
         end
       end
 
-      root_dependencies = prepare_dependencies(requirements, packages)
+      root_dependencies = prepare_dependencies(@requirements, @packages)
 
       @cached_dependencies = Hash.new do |dependencies, package|
         dependencies[package] = if package.root?
           { root_version => root_dependencies }
         else
           Hash.new do |versions, version|
-            versions[version] = to_dependency_hash(version.dependencies, packages)
+            versions[version] = to_dependency_hash(version.dependencies, @packages)
           end
         end
       end
 
       logger = Bundler::UI::Shell.new
       logger.level = debug? ? "debug" : "warn"
+
+      [root, logger]
+    end
+
+    def solve_versions(root:, logger:)
       solver = PubGrub::VersionSolver.new(:source => self, :root => root, :logger => logger)
-      before_resolution
       result = solver.solve
-      after_resolution
       result.map {|package, version| version.to_specs(package) }.flatten.uniq
     rescue PubGrub::SolveFailure => e
       incompatibility = e.incompatibility
@@ -82,8 +96,15 @@ module Bundler
         end
       end
 
+      names_to_unlock.uniq!
+
       if names_to_unlock.any?
+        Bundler.ui.debug "Found conflicts with locked dependencies. Retrying with #{names_to_unlock.join(", ")} unlocked...", true
+
         @base.unlock_names(names_to_unlock)
+
+        root, logger = setup_solver
+
         retry
       end
 
@@ -142,14 +163,6 @@ module Bundler
         ENV["DEBUG_RESOLVER"] ||
         ENV["DEBUG_RESOLVER_TREE"] ||
         false
-    end
-
-    def before_resolution
-      Bundler.ui.info "Resolving dependencies...", debug?
-    end
-
-    def after_resolution
-      Bundler.ui.info ""
     end
 
     def incompatibilities_for(package, version)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When Bundler is unable to find a solution, and conflicts include locked dependencies, Bundler unlocks those conflicting dependencies and tries again.

This is currently displayed like this:

```
$ git checkout Gemfile.lock && ~/Code/rubygems/rubygems/bundler/exe/bundle lock 
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...Resolving dependencies...Resolving dependencies...Resolving dependencies...Resolving dependencies...Resolving dependencies...
Writing lockfile to /Users/deivid/Code/activeadmin/activeadmin/Gemfile.lock
```

## What is your fix for the problem, implemented in this PR?

```
$ git checkout Gemfile.lock && ~/Code/rubygems/rubygems/bundler/exe/bundle lock 
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Found conflicts with locked dependencies. Retrying with railties, activesupport unlocked...
Found conflicts with locked dependencies. Retrying with activemodel unlocked...
Found conflicts with locked dependencies. Retrying with actionview unlocked...
Found conflicts with locked dependencies. Retrying with activerecord unlocked...
Found conflicts with locked dependencies. Retrying with actionpack unlocked...
Writing lockfile to /Users/deivid/Code/activeadmin/activeadmin/Gemfile.lock
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
