### PR TITLE
Fix resolver hanging in crazy cases

### DIFF
--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -202,7 +202,7 @@ module Bundler
 
     def all_versions_for(package)
       name = package.name
-      results = @base[name] + @all_specs[name]
+      results = (@base[name] + @all_specs[name]).uniq(&:full_name)
       locked_requirement = base_requirements[name]
       results = filter_matching_specs(results, locked_requirement) if locked_requirement
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I stumbled upon a crazy resolving situation where Bundler would hang, because PubGrub would get stuck in an infinite loop while printing a conflict:

```
  conflict: rails >= 7.0.3, < 7.0.3.1 depends on activemodel = 7.0.3
       ! rails >= 7.0.3, < 7.0.3.1 is partially satisfied by not rails >= 7.0.2.4, < 7.0.3
       ! which is caused by rails >= 7.0.2.4, < 7.0.3 depends on activemodel = 7.0.2.4
       ! thus rails >= 7.0.2.4, < 7.0.3.1 requires activemodel = 7.0.2.4 OR = 7.0.3
       ! rails >= 7.0.2.4, < 7.0.3.1 is partially satisfied by not rails >= 7.0.2.3, < 7.0.2.4
       ! which is caused by rails >= 7.0.2.3, < 7.0.2.4 depends on activemodel = 7.0.2.3
       ! thus rails >= 7.0.2.3, < 7.0.3.1 requires activemodel = 7.0.2.3 OR = 7.0.2.4 OR = 7.0.3
       ! rails >= 7.0.2.3, < 7.0.3.1 is partially satisfied by not rails >= 7.0.3.1, < 7.0.4
       ! which is caused by rails >= 7.0.3.1, < 7.0.4 depends on activemodel = 7.0.3.1
       ! thus rails >= 7.0.2.3, < 7.0.4 requires activemodel = 7.0.2.3 OR = 7.0.2.4 OR = 7.0.3 OR = 7.0.3.1
       ! not activemodel = 7.0.2.3 OR = 7.0.2.4 OR = 7.0.3 OR = 7.0.3.1 is partially satisfied by not activemodel != 7.0.2.3
       ! which is caused by activemodel != 7.0.2.3 is incompatible with rails >= 7.0.2.3, < 7.0.4
       ! thus rails >= 7.0.2.3, < 7.0.4 requires activemodel = 7.0.2.3
       ! not activemodel = 7.0.2.3 is partially satisfied by not activemodel != 7.0.2.3
       ! which is caused by activemodel != 7.0.2.3 is incompatible with rails >= 7.0.2.3, < 7.0.4
       ! thus rails >= 7.0.2.3, < 7.0.4 requires activemodel = 7.0.2.3
       ! not activemodel = 7.0.2.3 is partially satisfied by not activemodel != 7.0.2.3
       ! which is caused by activemodel != 7.0.2.3 is incompatible with rails >= 7.0.2.3, < 7.0.4

(... and forever ...)
```

## What is your fix for the problem, implemented in this PR?

I was fixing this by adding loop detection to PubGrub, but while reducing a test case I noticed that Bundler was artificially considering some gems first, because they were being counted twice, and that was resulting in the hang.

So I made resolver candidates uniq to avoid this hang.

But we'll probably want to also follow up with detecting this kind of loop inside PubGrub too.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
