### PR TITLE
Add `mswin` support for cargo builder

### DIFF
--- a/.github/workflows/windows-rubygems.yml
+++ b/.github/workflows/windows-rubygems.yml
@@ -23,13 +23,16 @@ jobs:
       fail-fast: false
       matrix:
         cargo:
-          - target: x86_64-pc-windows-gnu
+          - target: x86_64-pc-windows-gnu # mingw
             toolchain: stable
         ruby:
           - { name: "2.6", value: 2.6.10 }
           - { name: "2.7", value: 2.7.6 }
           - { name: "3.0", value: 3.0.4 }
           - { name: "3.1", value: 3.1.2 }
+        include:
+          - ruby: { name: "mswin", value: "mswin" }
+            cargo: { target: x86_64-pc-windows-msvc, toolchain: stable } # mswin
     steps:
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
       - name: Setup ruby
@@ -53,6 +56,13 @@ jobs:
           echo "========================="
           uname -a
           echo "========================="
+      # Taken from https://github.com/oxidize-rb/actions/blob/0d21ce09c5500315bc61815440f8c4211530f413/setup-ruby-and-rust/action.yml#LL300-L305C116
+      - name: Configure bindgen
+        if: contains(matrix.cargo.target, 'msvc')
+        shell: pwsh
+        run: |
+          echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
+          echo "BINDGEN_EXTRA_CLANG_ARGS=$((gcm clang).source -replace "bin\clang.exe","include")" >> $env:GITHUB_ENV
       - name: Install Dependencies and Run Test
         run: |
           rake setup

--- a/lib/rubygems/ext/cargo_builder/link_flag_converter.rb
+++ b/lib/rubygems/ext/cargo_builder/link_flag_converter.rb
@@ -3,20 +3,24 @@
 class Gem::Ext::CargoBuilder < Gem::Ext::Builder
   # Converts Ruby link flags into something cargo understands
   class LinkFlagConverter
+    FILTERED_PATTERNS = [
+      /compress-debug-sections/, # Not supported by all linkers, and not required for Rust
+    ].freeze
+
     def self.convert(arg)
+      return [] if FILTERED_PATTERNS.any? {|p| p.match?(arg) }
+
       case arg.chomp
       when /^-L\s*(.+)$/
         ["-L", "native=#{$1}"]
       when /^--library=(\w+\S+)$/, /^-l\s*(\w+\S+)$/
         ["-l", $1]
-      when /^-l\s*:lib(\S+).a$/
-        ["-l", "static=#{$1}"]
-      when /^-l\s*:lib(\S+).(so|dylib|dll)$/
-        ["-l", "dylib=#{$1}"]
+      when /^-l\s*([^:\s])+/ # -lfoo, but not -l:libfoo.a
+        ["-l", $1]
       when /^-F\s*(.*)$/
         ["-l", "framework=#{$1}"]
       else
-        ["-C", "link_arg=#{arg}"]
+        ["-C", "link-args=#{arg}"]
       end
     end
   end

--- a/test/rubygems/test_gem_ext_cargo_builder/rust_ruby_example/src/lib.rs
+++ b/test/rubygems/test_gem_ext_cargo_builder/rust_ruby_example/src/lib.rs
@@ -21,6 +21,18 @@ unsafe extern "C" fn pub_reverse(_klass: VALUE, mut input: VALUE) -> VALUE {
     rb_utf8_str_new(reversed_cstring.as_ptr(), size)
 }
 
+#[cfg(rubygems)]
+#[no_mangle]
+pub extern "C" fn hello_from_rubygems() {}
+
+#[cfg(rubygems_0_0_0)]
+#[no_mangle]
+pub extern "C" fn should_never_exist() {}
+
+#[cfg(rubygems_x_x_x)]
+#[no_mangle]
+pub extern "C" fn hello_from_rubygems_version() {}
+
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn Init_rust_ruby_example() {

--- a/test/rubygems/test_gem_ext_cargo_builder_link_flag_converter.rb
+++ b/test/rubygems/test_gem_ext_cargo_builder_link_flag_converter.rb
@@ -12,15 +12,15 @@ class TestGemExtCargoBuilderLinkFlagConverter < Gem::TestCase
     test_lib_with_nonascii: ["-lws2_32", ["-l", "ws2_32"]],
     test_simple_lib_space: ["-l foo", ["-l", "foo"]],
     test_verbose_lib_space: ["--library=foo", ["-l", "foo"]],
-    test_libstatic_with_colon: ["-l:libssp.a", ["-l", "static=ssp"]],
-    test_libstatic_with_colon_space: ["-l :libssp.a", ["-l", "static=ssp"]],
-    test_unconventional_lib_with_colon: ["-l:ssp.a", ["-C", "link_arg=-l:ssp.a"]],
-    test_dylib_with_colon_space: ["-l :libssp.dylib", ["-l", "dylib=ssp"]],
-    test_so_with_colon_space: ["-l :libssp.so", ["-l", "dylib=ssp"]],
-    test_dll_with_colon_space: ["-l :libssp.dll", ["-l", "dylib=ssp"]],
+    test_libstatic_with_colon: ["-l:libssp.a", ["-C", "link-args=-l:libssp.a"]],
+    test_libstatic_with_colon_space: ["-l :libssp.a", ["-C", "link-args=-l :libssp.a"]],
+    test_unconventional_lib_with_colon: ["-l:ssp.a", ["-C", "link-args=-l:ssp.a"]],
+    test_dylib_with_colon_space: ["-l :libssp.dylib", ["-C", "link-args=-l :libssp.dylib"]],
+    test_so_with_colon_space: ["-l :libssp.so", ["-C", "link-args=-l :libssp.so"]],
+    test_dll_with_colon_space: ["-l :libssp.dll", ["-C", "link-args=-l :libssp.dll"]],
     test_framework: ["-F/some/path", ["-l", "framework=/some/path"]],
     test_framework_space: ["-F /some/path", ["-l", "framework=/some/path"]],
-    test_non_lib_dash_l: ["test_rubygems_20220413-976-lemgf9/prefix", ["-C", "link_arg=test_rubygems_20220413-976-lemgf9/prefix"]],
+    test_non_lib_dash_l: ["test_rubygems_20220413-976-lemgf9/prefix", ["-C", "link-args=test_rubygems_20220413-976-lemgf9/prefix"]],
   }.freeze
 
   CASES.each do |test_name, (arg, expected)|


### PR DESCRIPTION
- Integrates some changes from `rb-sys` to make CargoBuilder work properly on mswin
- Handle some linking edge cases where cargo fails
- Pass along `--cfg rubygems` and `--cfg rubygems_X_X_X` as cargo config for integration points