### PR TITLE
Fix Bundler not choosing the platform specific version for libv8-node and other allowlisted gems

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -73,6 +73,7 @@ bundler/lib/bundler/fetcher/compact_index.rb
 bundler/lib/bundler/fetcher/dependency.rb
 bundler/lib/bundler/fetcher/downloader.rb
 bundler/lib/bundler/fetcher/index.rb
+bundler/lib/bundler/force_platform.rb
 bundler/lib/bundler/friendly_errors.rb
 bundler/lib/bundler/gem_helper.rb
 bundler/lib/bundler/gem_helpers.rb

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -463,7 +463,7 @@ EOF
     end
 
     def local_platform
-      return Gem::Platform::RUBY if settings[:force_ruby_platform] || Gem.platforms == [Gem::Platform::RUBY]
+      return Gem::Platform::RUBY if settings[:force_ruby_platform]
       Gem::Platform.local
     end
 

--- a/bundler/lib/bundler/dependency.rb
+++ b/bundler/lib/bundler/dependency.rb
@@ -7,7 +7,7 @@ require_relative "rubygems_ext"
 module Bundler
   class Dependency < Gem::Dependency
     attr_reader :autorequire
-    attr_reader :groups, :platforms, :gemfile, :path, :git, :github, :branch, :ref, :force_ruby_platform
+    attr_reader :groups, :platforms, :gemfile, :path, :git, :github, :branch, :ref
 
     ALL_RUBY_VERSIONS = ((18..27).to_a + (30..31).to_a).freeze
     PLATFORM_MAP = {
@@ -42,7 +42,7 @@ module Bundler
       @env            = options["env"]
       @should_include = options.fetch("should_include", true)
       @gemfile        = options["gemfile"]
-      @force_ruby_platform = options["force_ruby_platform"]
+      @force_ruby_platform = options["force_ruby_platform"] if options.key?("force_ruby_platform")
 
       @autorequire = Array(options["require"] || []) if options.key?("require")
     end
@@ -50,7 +50,7 @@ module Bundler
     # Returns the platforms this dependency is valid for, in the same order as
     # passed in the `valid_platforms` parameter
     def gem_platforms(valid_platforms)
-      return [Gem::Platform::RUBY] if @force_ruby_platform
+      return [Gem::Platform::RUBY] if force_ruby_platform
       return valid_platforms if @platforms.empty?
 
       valid_platforms.select {|p| expanded_platforms.include?(GemHelpers.generic(p)) }

--- a/bundler/lib/bundler/force_platform.rb
+++ b/bundler/lib/bundler/force_platform.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Bundler
+  module ForcePlatform
+    private
+
+    # The `:force_ruby_platform` value used by dependencies for resolution, and
+    # by locked specifications for materialization is `false` by default, except
+    # for TruffleRuby. TruffleRuby generally needs to force the RUBY platform
+    # variant unless the name is explicitly allowlisted.
+
+    def default_force_ruby_platform
+      return false unless RUBY_ENGINE == "truffleruby"
+
+      !Gem::Platform::REUSE_AS_BINARY_ON_TRUFFLERUBY.include?(name)
+    end
+  end
+end

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
+require_relative "force_platform"
+
 module Bundler
   class LazySpecification
     include MatchPlatform
+    include ForcePlatform
 
     attr_reader :name, :version, :dependencies, :platform
     attr_accessor :source, :remote, :force_ruby_platform
@@ -14,6 +17,7 @@ module Bundler
       @platform      = platform || Gem::Platform::RUBY
       @source        = source
       @specification = nil
+      @force_ruby_platform = default_force_ruby_platform
     end
 
     def full_name

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -16,6 +16,7 @@ require "rubygems/specification"
 require "rubygems/source"
 
 require_relative "match_metadata"
+require_relative "force_platform"
 require_relative "match_platform"
 
 # Cherry-pick fixes to `Gem.ruby_version` to be useful for modern Bundler
@@ -153,12 +154,16 @@ module Gem
   end
 
   class Dependency
+    include ::Bundler::ForcePlatform
+
     attr_accessor :source, :groups
 
     alias_method :eql?, :==
 
     def force_ruby_platform
-      false
+      return @force_ruby_platform if defined?(@force_ruby_platform) && !@force_ruby_platform.nil?
+
+      @force_ruby_platform = default_force_ruby_platform
     end
 
     def encode_with(coder)
@@ -276,6 +281,10 @@ module Gem
 
         without_gnu_nor_abi_modifiers
       end
+    end
+
+    if RUBY_ENGINE == "truffleruby" && !defined?(REUSE_AS_BINARY_ON_TRUFFLERUBY)
+      REUSE_AS_BINARY_ON_TRUFFLERUBY = %w[libv8 libv8-node sorbet-static].freeze
     end
   end
 

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -190,12 +190,10 @@ module Bundler
 
     def specs_for_dependency(dep, platform)
       specs_for_name = lookup[dep.name]
-      if platform.nil?
-        matching_specs = specs_for_name.map {|s| s.materialize_for_installation if Gem::Platform.match_spec?(s) }.compact
-        GemHelpers.sort_best_platform_match(matching_specs, Bundler.local_platform)
-      else
-        GemHelpers.select_best_platform_match(specs_for_name, dep.force_ruby_platform ? Gem::Platform::RUBY : platform)
-      end
+      target_platform = dep.force_ruby_platform ? Gem::Platform::RUBY : (platform || Bundler.local_platform)
+      matching_specs = GemHelpers.select_best_platform_match(specs_for_name, target_platform)
+      matching_specs.map!(&:materialize_for_installation).compact! if platform.nil?
+      matching_specs
     end
 
     def tsort_each_child(s)

--- a/bundler/spec/support/hax.rb
+++ b/bundler/spec/support/hax.rb
@@ -24,10 +24,13 @@ module Gem
   end
 
   if ENV["BUNDLER_SPEC_PLATFORM"]
+    previous_platforms = @platforms
+    previous_local = Platform.local
+
     class Platform
       @local = new(ENV["BUNDLER_SPEC_PLATFORM"])
     end
-    @platforms = [Gem::Platform::RUBY, Gem::Platform.local]
+    @platforms = previous_platforms.map {|platform| platform == previous_local ? Platform.local : platform }
   end
 
   if ENV["BUNDLER_SPEC_GEM_SOURCES"]

--- a/bundler/spec/support/matchers.rb
+++ b/bundler/spec/support/matchers.rb
@@ -162,7 +162,7 @@ module Spec
           end
           if exitstatus == 65
             actual_platform = out.split("\n").last
-            next "#{name} was expected to be of platform #{platform} but was #{actual_platform}"
+            next "#{name} was expected to be of platform #{platform || "ruby"} but was #{actual_platform || "ruby"}"
           end
           if exitstatus == 66
             actual_source = out.split("\n").last


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This was supposed to have been fixed, but Bundler was still not able to choose the precompiled version of those gems that truffleruby has deemed as having precompiled versions that work fine with truffleruby.

This reintroduces the approach in https://github.com/rubygems/rubygems/pull/4049/commits/6085de09c711f072ddd9fa06d125a6da65ebc501, which was reverted at https://github.com/rubygems/rubygems/pull/5711 because it caused some issues. Unfortunately the revert created the original problem again, due to a problem with the spec initially added that was not able to properly cover the fix.

## What is your fix for the problem, implemented in this PR?

Reintroduce the same approach of setting a proper default value for the `:force_ruby_platform` dependency attribute, and to locked specifications. This approach no longer seem to cause any issues.

Also fix our specs to properly cover the issue.

Fixes #6165.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] ~Write~ Fix [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
