### PR TITLE
Improve release scripts for minor releases

### DIFF
--- a/.changelog.yml
+++ b/.changelog.yml
@@ -13,7 +13,7 @@ release_date_format: "%Y-%m-%d"
 entry_wrapping: 74
 
 changelog_label_mapping:
-  "rubygems: security fix": "## Security fixes:"
+  "rubygems: security": "## Security:"
   "rubygems: breaking change": "## Breaking changes:"
   "rubygems: deprecation": "## Deprecations:"
   "rubygems: feature": "## Features:"
@@ -24,7 +24,7 @@ changelog_label_mapping:
   "rubygems: backport": null
 
 patch_level_labels:
-  - "rubygems: security fix"
+  - "rubygems: security"
   - "rubygems: deprecation"
   - "rubygems: enhancement"
   - "rubygems: bug fix"

--- a/POLICIES.md
+++ b/POLICIES.md
@@ -102,14 +102,16 @@ and not get any conflicts.
 
 *   Confirm all PRs that you want listed in changelogs are properly tagged with
     `rubygems: <type>` or `bundler: <type>` labels at GitHub.
-*   Run `rake prepare_release[<target_version>]`.
-*   Add the new stable branch `x.y` where `x.y` are the first two components of
-    the rubygems version being released to the CI workflows as an extra commit
-    on top of what the `prepare_release` task generated.
-*   Create a PR to the main branch, and merge it once CI passes.
-*   From the main branch, cut a new stable branch with `git pull && git checkout
-    -b x.y`.
-*   Push the stable branch and wait for CI to be green.
+*   Run `rake prepare_release[<target_version>]`. This will create a new stable
+    branch off the master branch, and create a PR to it with the proper version
+    bumps and changelogs. It will also create a PR to merge release changelogs
+    into master.
+*   Replace the stable branch in the workflows with the new stable branch, and
+    push that change to the release PR.
+*   Replace version numbers with the next ".dev" version, and push that change
+    to the master PR.
+*   Once CI passes, merge the release PR, switch to  the stable branch and pull
+    the PR just merged.
 *   Release `bundler` with `(cd bundler && bin/rake release)`.
 *   Release `rubygems` with `rake release`.
 

--- a/bundler/.changelog.yml
+++ b/bundler/.changelog.yml
@@ -7,7 +7,7 @@ entry_template: "  - %title [#%pull_request_number](%pull_request_url)"
 release_date_format: "%B %-d, %Y"
 
 changelog_label_mapping:
-  "bundler: security fix": "## Security fixes:"
+  "bundler: security": "## Security:"
   "bundler: breaking change": "## Breaking changes:"
   "bundler: deprecation": "## Deprecations:"
   "bundler: feature": "## Features:"
@@ -18,7 +18,7 @@ changelog_label_mapping:
   "bundler: backport": null
 
 patch_level_labels:
-  - "bundler: security fix"
+  - "bundler: security"
   - "bundler: deprecation"
   - "bundler: enhancement"
   - "bundler: bug fix"

--- a/util/release.rb
+++ b/util/release.rb
@@ -186,8 +186,6 @@ class Release
       @rubygems.bump_versions!
       system("git", "commit", "-am", "Bump Rubygems version to #{@rubygems.version}", exception: true)
 
-      return if @level == :minor_or_major
-
       system("git", "push", exception: true)
 
       gh_client.create_pull_request(

--- a/util/release.rb
+++ b/util/release.rb
@@ -136,7 +136,6 @@ class Release
     @level = segments[2] != 0 ? :patch : :minor_or_major
 
     @stable_branch = segments[0, 2].join(".")
-    @base_branch = @level == :minor_or_major ? "master" : @stable_branch
     @previous_stable_branch = @level == :minor_or_major ? "#{segments[0]}.#{segments[1] - 1}" : @stable_branch
 
     rubygems_version = segments.join(".")
@@ -159,7 +158,12 @@ class Release
   def prepare!
     initial_branch = `git rev-parse --abbrev-ref HEAD`.strip
 
-    system("git", "checkout", "-b", @release_branch, @base_branch, exception: true)
+    if @level == :minor_or_major
+      system("git", "checkout", "-b", @stable_branch, "master", exception: true)
+      system("git", "push", "origin", @stable_branch, exception: true)
+    end
+
+    system("git", "checkout", "-b", @release_branch, @stable_branch, exception: true)
 
     begin
       @bundler.set_relevant_pull_requests_from(unreleased_pull_requests)
@@ -188,7 +192,7 @@ class Release
 
       gh_client.create_pull_request(
         "rubygems/rubygems",
-        @base_branch,
+        @stable_branch,
         @release_branch,
         "Prepare RubyGems #{@rubygems.version} and Bundler #{@bundler.version}",
         "It's release day!"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We want to progressively automate minor releases too.

## What is your fix for the problem, implemented in this PR?

Automatically create and push a new stable branch when releasing minors, and create a PR to it with the proper version bumps and changelogs, and also a PR to master with only changelogs.

Also update minor release documentation.

Also change "Security fixes" label in changelogs to just "Security" because I want to include generic security enhancements in there that don't necessarily come with an associated CVE.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
