### PR TITLE
Ask user to otp at webauthn verification url

### DIFF
--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -82,7 +82,7 @@ module Gem::GemcutterUtilities
   #
   # If +allowed_push_host+ metadata is present, then it will only allow that host.
 
-  def rubygems_api_request(method, path, host = nil, allowed_push_host = nil, scope: nil, &block)
+  def rubygems_api_request(method, path, host = nil, allowed_push_host = nil, scope: nil, credentials: {}, &block)
     require "net/http"
 
     self.host = host if host
@@ -105,7 +105,7 @@ module Gem::GemcutterUtilities
     response = request_with_otp(method, uri, &block)
 
     if mfa_unauthorized?(response)
-      ask_otp
+      ask_otp(credentials)
       response = request_with_otp(method, uri, &block)
     end
 
@@ -167,11 +167,12 @@ module Gem::GemcutterUtilities
     mfa_params   = get_mfa_params(profile)
     all_params   = scope_params.merge(mfa_params)
     warning      = profile["warning"]
+    credentials  = { email: email, password: password }
 
     say "#{warning}\n" if warning
 
     response = rubygems_api_request(:post, "api/v1/api_key",
-                                    sign_in_host, scope: scope) do |request|
+                                    sign_in_host, credentials: credentials, scope: scope) do |request|
       request.basic_auth email, password
       request["OTP"] = otp if otp
       request.body = URI.encode_www_form({ name: key_name }.merge(all_params))
@@ -250,9 +251,26 @@ module Gem::GemcutterUtilities
     end
   end
 
-  def ask_otp
-    say "You have enabled multi-factor authentication. Please enter OTP code."
+  def ask_otp(credentials)
+    webauthn_url = webauthn_verification_url(credentials)
+    unless webauthn_url
+      say "You have enabled multi-factor authentication. Please enter OTP code."
+    else
+      say "You have enabled multi-factor authentication. Please enter OTP code from your security device by visiting #{webauthn_url} or your authenticator app."
+    end
+
     options[:otp] = ask "Code: "
+  end
+
+  def webauthn_verification_url(credentials)
+    response = rubygems_api_request(:post, "api/v1/webauthn_verification") do |request|
+      if credentials
+        request.basic_auth credentials[:email], credentials[:password]
+      else
+        request.add_field "Authorization", api_key
+      end
+    end
+    response.is_a?(Net::HTTPSuccess) ? response.body : nil
   end
 
   def pretty_host(host)

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -253,10 +253,10 @@ module Gem::GemcutterUtilities
 
   def ask_otp(credentials)
     webauthn_url = webauthn_verification_url(credentials)
-    unless webauthn_url
-      say "You have enabled multi-factor authentication. Please enter OTP code."
+    if webauthn_url
+      say "You have enabled multi-factor authentication. Please enter OTP code from your security device by visiting #{webauthn_url}."
     else
-      say "You have enabled multi-factor authentication. Please enter OTP code from your security device by visiting #{webauthn_url} or your authenticator app."
+      say "You have enabled multi-factor authentication. Please enter OTP code."
     end
 
     options[:otp] = ask "Code: "

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -252,8 +252,7 @@ module Gem::GemcutterUtilities
   end
 
   def ask_otp(credentials)
-    webauthn_url = webauthn_verification_url(credentials)
-    if webauthn_url
+    if webauthn_url = webauthn_verification_url(credentials)
       say "You have enabled multi-factor authentication. Please enter OTP code from your security device by visiting #{webauthn_url}."
     else
       say "You have enabled multi-factor authentication. Please enter OTP code."

--- a/test/rubygems/test_gem_commands_owner_command.rb
+++ b/test/rubygems/test_gem_commands_owner_command.rb
@@ -330,6 +330,8 @@ EOF
       HTTPResponseFactory.create(body: response_fail, code: 401, msg: "Unauthorized"),
       HTTPResponseFactory.create(body: response_success, code: 200, msg: "OK"),
     ]
+    @stub_fetcher.data["#{Gem.host}/api/v1/webauthn_verification"] =
+      HTTPResponseFactory.create(body: "You don't have any security devices", code: 422, msg: "Unprocessable Entity")
 
     @otp_ui = Gem::MockGemUi.new "111111\n"
     use_ui @otp_ui do
@@ -345,6 +347,8 @@ EOF
   def test_otp_verified_failure
     response = "You have enabled multifactor authentication but your request doesn't have the correct OTP code. Please check it and retry."
     @stub_fetcher.data["#{Gem.host}/api/v1/gems/freewill/owners"] = HTTPResponseFactory.create(body: response, code: 401, msg: "Unauthorized")
+    @stub_fetcher.data["#{Gem.host}/api/v1/webauthn_verification"] =
+      HTTPResponseFactory.create(body: "You don't have any security devices", code: 422, msg: "Unprocessable Entity")
 
     @otp_ui = Gem::MockGemUi.new "111111\n"
     use_ui @otp_ui do
@@ -354,6 +358,28 @@ EOF
     assert_match response, @otp_ui.output
     assert_match "You have enabled multi-factor authentication. Please enter OTP code.", @otp_ui.output
     assert_match "Code: ", @otp_ui.output
+    assert_equal "111111", @stub_fetcher.last_request["OTP"]
+  end
+
+  def test_webauthn_otp_verified_success
+    webauthn_verification_url = "rubygems.org/api/v1/webauthn_verification/odow34b93t6aPCdY"
+    response_fail = "You have enabled multifactor authentication but your request doesn't have the correct OTP code. Please check it and retry."
+    response_success = "Owner added successfully."
+
+    @stub_fetcher.data["#{Gem.host}/api/v1/webauthn_verification"] = HTTPResponseFactory.create(body: webauthn_verification_url, code: 200, msg: "OK")
+    @stub_fetcher.data["#{Gem.host}/api/v1/gems/freewill/owners"] = [
+      HTTPResponseFactory.create(body: response_fail, code: 401, msg: "Unauthorized"),
+      HTTPResponseFactory.create(body: response_success, code: 200, msg: "OK"),
+    ]
+
+    @otp_ui = Gem::MockGemUi.new "111111\n"
+    use_ui @otp_ui do
+      @cmd.add_owners("freewill", ["user-new1@example.com"])
+    end
+
+    assert_match "You have enabled multi-factor authentication. Please enter OTP code from your security device by visiting #{webauthn_verification_url}", @otp_ui.output
+    assert_match "Code: ", @otp_ui.output
+    assert_match response_success, @otp_ui.output
     assert_equal "111111", @stub_fetcher.last_request["OTP"]
   end
 

--- a/test/rubygems/test_gem_commands_push_command.rb
+++ b/test/rubygems/test_gem_commands_push_command.rb
@@ -391,6 +391,8 @@ class TestGemCommandsPushCommand < Gem::TestCase
       HTTPResponseFactory.create(body: response_fail, code: 401, msg: "Unauthorized"),
       HTTPResponseFactory.create(body: response_success, code: 200, msg: "OK"),
     ]
+    @fetcher.data["#{Gem.host}/api/v1/webauthn_verification"] =
+      HTTPResponseFactory.create(body: "You don't have any security devices", code: 422, msg: "Unprocessable Entity")
 
     @otp_ui = Gem::MockGemUi.new "111111\n"
     use_ui @otp_ui do
@@ -406,6 +408,8 @@ class TestGemCommandsPushCommand < Gem::TestCase
   def test_otp_verified_failure
     response = "You have enabled multifactor authentication but your request doesn't have the correct OTP code. Please check it and retry."
     @fetcher.data["#{Gem.host}/api/v1/gems"] = HTTPResponseFactory.create(body: response, code: 401, msg: "Unauthorized")
+    @fetcher.data["#{Gem.host}/api/v1/webauthn_verification"] =
+      HTTPResponseFactory.create(body: "You don't have any security devices", code: 422, msg: "Unprocessable Entity")
 
     @otp_ui = Gem::MockGemUi.new "111111\n"
     assert_raise Gem::MockGemUi::TermError do
@@ -420,6 +424,28 @@ class TestGemCommandsPushCommand < Gem::TestCase
     assert_equal "111111", @fetcher.last_request["OTP"]
   end
 
+  def test_webauthn_otp_verified_success
+    webauthn_verification_url = "#{Gem.host}/api/v1/webauthn_verification/odow34b93t6aPCdY"
+    response_fail = "You have enabled multifactor authentication but your request doesn't have the correct OTP code. Please check it and retry."
+    response_success = "Successfully registered gem: freewill (1.0.0)"
+
+    @fetcher.data["#{Gem.host}/api/v1/gems"] = [
+      HTTPResponseFactory.create(body: response_fail, code: 401, msg: "Unauthorized"),
+      HTTPResponseFactory.create(body: response_success, code: 200, msg: "OK"),
+    ]
+    @fetcher.data["#{Gem.host}/api/v1/webauthn_verification"] = HTTPResponseFactory.create(body: webauthn_verification_url, code: 200, msg: "OK")
+
+    @otp_ui = Gem::MockGemUi.new "111111\n"
+    use_ui @otp_ui do
+      @cmd.send_gem(@path)
+    end
+
+    assert_match "You have enabled multi-factor authentication. Please enter OTP code from your security device by visiting #{webauthn_verification_url}", @otp_ui.output
+    assert_match "Code: ", @otp_ui.output
+    assert_match response_success, @otp_ui.output
+    assert_equal "111111", @fetcher.last_request["OTP"]
+  end
+
   def test_sending_gem_unathorized_api_key_with_mfa_enabled
     response_mfa_enabled = "You have enabled multifactor authentication but your request doesn't have the correct OTP code. Please check it and retry."
     response_forbidden = "The API key doesn't have access"
@@ -430,6 +456,8 @@ class TestGemCommandsPushCommand < Gem::TestCase
       HTTPResponseFactory.create(body: response_forbidden, code: 403, msg: "Forbidden"),
       HTTPResponseFactory.create(body: response_success, code: 200, msg: "OK"),
     ]
+    @fetcher.data["#{@host}/api/v1/webauthn_verification"] =
+      HTTPResponseFactory.create(body: "You don't have any security devices", code: 422, msg: "Unprocessable Entity")
 
     @fetcher.data["#{@host}/api/v1/api_key"] = HTTPResponseFactory.create(body: "", code: 200, msg: "OK")
     @cmd.instance_variable_set :@host, @host
@@ -470,6 +498,8 @@ class TestGemCommandsPushCommand < Gem::TestCase
     @fetcher.data["#{@host}/api/v1/profile/me.yaml"] = [
       HTTPResponseFactory.create(body: response_profile, code: 200, msg: "OK"),
     ]
+    @fetcher.data["#{@host}/api/v1/webauthn_verification"] =
+      HTTPResponseFactory.create(body: "You don't have any security devices", code: 422, msg: "Unprocessable Entity")
 
     @cmd.instance_variable_set :@scope, :push_rubygem
     @cmd.options[:args] = [@path]

--- a/test/rubygems/test_gem_commands_yank_command.rb
+++ b/test/rubygems/test_gem_commands_yank_command.rb
@@ -72,6 +72,9 @@ class TestGemCommandsYankCommand < Gem::TestCase
       HTTPResponseFactory.create(body: response_fail, code: 401, msg: "Unauthorized"),
       HTTPResponseFactory.create(body: "Successfully yanked", code: 200, msg: "OK"),
     ]
+    webauthn_uri = "http://example/api/v1/webauthn_verification"
+    @fetcher.data[webauthn_uri] =
+      HTTPResponseFactory.create(body: "You don't have any security devices", code: 422, msg: "Unprocessable Entity")
 
     @cmd.options[:args]           = %w[a]
     @cmd.options[:added_platform] = true
@@ -93,6 +96,9 @@ class TestGemCommandsYankCommand < Gem::TestCase
     response = "You have enabled multifactor authentication but your request doesn't have the correct OTP code. Please check it and retry."
     yank_uri = "http://example/api/v1/gems/yank"
     @fetcher.data[yank_uri] = HTTPResponseFactory.create(body: response, code: 401, msg: "Unauthorized")
+    webauthn_uri = "http://example/api/v1/webauthn_verification"
+    @fetcher.data[webauthn_uri] =
+      HTTPResponseFactory.create(body: "You don't have any security devices", code: 422, msg: "Unprocessable Entity")
 
     @cmd.options[:args]           = %w[a]
     @cmd.options[:added_platform] = true
@@ -106,6 +112,33 @@ class TestGemCommandsYankCommand < Gem::TestCase
     assert_match "You have enabled multi-factor authentication. Please enter OTP code.", @otp_ui.output
     assert_match response, @otp_ui.output
     assert_match "Code: ", @otp_ui.output
+    assert_equal "111111", @fetcher.last_request["OTP"]
+  end
+
+  def test_execute_with_webauthn_otp_success
+    webauthn_verification_url = "http://example/api/v1/webauthn_verification/odow34b93t6aPCdY"
+    response_fail = "You have enabled multifactor authentication but your request doesn't have the correct OTP code. Please check it and retry."
+    yank_uri = "http://example/api/v1/gems/yank"
+    webauthn_uri = "http://example/api/v1/webauthn_verification"
+    @fetcher.data[webauthn_uri] = HTTPResponseFactory.create(body: webauthn_verification_url, code: 200, msg: "OK")
+    @fetcher.data[yank_uri] = [
+      HTTPResponseFactory.create(body: response_fail, code: 401, msg: "Unauthorized"),
+      HTTPResponseFactory.create(body: "Successfully yanked", code: 200, msg: "OK"),
+    ]
+
+    @cmd.options[:args]           = %w[a]
+    @cmd.options[:added_platform] = true
+    @cmd.options[:version]        = req("= 1.0")
+
+    @otp_ui = Gem::MockGemUi.new "111111\n"
+    use_ui @otp_ui do
+      @cmd.execute
+    end
+
+    assert_match "You have enabled multi-factor authentication. Please enter OTP code from your security device by visiting #{webauthn_verification_url}", @otp_ui.output
+    assert_match "Code: ", @otp_ui.output
+    assert_match %r{Yanking gem from http://example}, @otp_ui.output
+    assert_match %r{Successfully yanked}, @otp_ui.output
     assert_equal "111111", @fetcher.last_request["OTP"]
   end
 

--- a/test/rubygems/test_gem_gemcutter_utilities.rb
+++ b/test/rubygems/test_gem_gemcutter_utilities.rb
@@ -230,10 +230,33 @@ class TestGemGemcutterUtilities < Gem::TestCase
     assert_equal "111111", @fetcher.last_request["OTP"]
   end
 
-  def util_sign_in(response, host = nil, args = [], extra_input = "")
-    email            = "you@example.com"
-    password         = "secret"
-    profile_response = HTTPResponseFactory.create(body: "mfa: disabled\n", code: 200, msg: "OK")
+  def test_sign_in_with_webauthn_otp
+    webauthn_verification_url = "rubygems.org/api/v1/webauthn_verification/odow34b93t6aPCdY"
+    api_key       = "a5fdbb6ba150cbb83aad2bb2fede64cf040453903"
+    response_fail = "You have enabled multifactor authentication"
+
+    util_sign_in(proc do
+      @call_count ||= 0
+      if (@call_count += 1).odd?
+        HTTPResponseFactory.create(body: response_fail, code: 401, msg: "Unauthorized")
+      else
+        HTTPResponseFactory.create(body: api_key, code: 200, msg: "OK")
+      end
+    end, nil, [], "111111\n", webauthn_verification_url)
+
+    assert_match "You have enabled multi-factor authentication. Please enter OTP code from your security device by visiting #{webauthn_verification_url}", @sign_in_ui.output
+  end
+
+  def util_sign_in(response, host = nil, args = [], extra_input = "", webauthn_url = nil)
+    email             = "you@example.com"
+    password          = "secret"
+    profile_response  = HTTPResponseFactory.create(body: "mfa: disabled\n", code: 200, msg: "OK")
+    webauthn_response =
+      if webauthn_url
+        HTTPResponseFactory.create(body: webauthn_url, code: 200, msg: "OK")
+      else
+        HTTPResponseFactory.create(body: "You don't have any security devices", code: 422, msg: "Unprocessable Entity")
+      end
 
     if host
       ENV["RUBYGEMS_HOST"] = host
@@ -244,6 +267,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
     @fetcher = Gem::FakeFetcher.new
     @fetcher.data["#{host}/api/v1/api_key"] = response
     @fetcher.data["#{host}/api/v1/profile/me.yaml"] = profile_response
+    @fetcher.data["#{host}/api/v1/webauthn_verification"] = webauthn_response
     Gem::RemoteFetcher.fetcher = @fetcher
 
     @sign_in_ui = Gem::MockGemUi.new("#{email}\n#{password}\n\n\n\n\n\n\n\n\n" + extra_input)

--- a/test/rubygems/test_gem_gemcutter_utilities.rb
+++ b/test/rubygems/test_gem_gemcutter_utilities.rb
@@ -232,8 +232,8 @@ class TestGemGemcutterUtilities < Gem::TestCase
 
   def test_sign_in_with_webauthn_otp
     webauthn_verification_url = "rubygems.org/api/v1/webauthn_verification/odow34b93t6aPCdY"
-    api_key       = "a5fdbb6ba150cbb83aad2bb2fede64cf040453903"
     response_fail = "You have enabled multifactor authentication"
+    api_key       = "a5fdbb6ba150cbb83aad2bb2fede64cf040453903"
 
     util_sign_in(proc do
       @call_count ||= 0


### PR DESCRIPTION
_**NOTE:** This is being merged into a feature branch, not main, so that work may continue to be developed in small pieces as we built out webauthn for the CLI_

## What was the end-user or developer problem that led to this PR?
Users with MFA enabled would like to use security devices (yubikey, touch id, etc) for logging in with WebAuthn on the CLI

## What is your fix for the problem, implemented in this PR?

- For users with MFA enabled, we request a webauthn verification url from rubygems.org on sensitive actions (sign in, yank, push, add/remove owners). 
- If the user _does not_ have a webauthn device enabled, there is no change in the user interaction. The api would respond with a 403 and we would continue to ask for a regular OTP code as normal.
- For users that do have webauthn enabled, the api would respond with the webauthn verification url. Users would then verify at that link, receive an OTP code, and then input that here. 
- This is **just** the first step, receiving the link and displaying it to users, the actual verification will happen in follow up PRs on the client and CLI. 

.org feature branch: https://github.com/rubygems/rubygems.org/pull/3298
Matching .org work: https://github.com/rubygems/rubygems.org/pull/3305


## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
