### PR TITLE
Add global flag (`-C`) to change execution directory

### DIFF
--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -630,7 +630,11 @@ RubyGems is a package manager for Ruby.
   Usage:
     gem -h/--help
     gem -v/--version
-    gem command [arguments...] [options...]
+    gem [global options...] command [arguments...] [options...]
+
+  Global options:
+    -C PATH                      run as if gem was started in <PATH>
+                                 instead of the current working directory
 
   Examples:
     gem install rake

--- a/lib/rubygems/command_manager.rb
+++ b/lib/rubygems/command_manager.rb
@@ -175,14 +175,20 @@ class Gem::CommandManager
     when "-v", "--version" then
       say Gem::VERSION
       terminate_interaction 0
+    when "-C" then
+      args.shift
+      start_point = args.shift
+      if Dir.exist?(start_point)
+        Dir.chdir(start_point) { invoke_command(args, build_args) }
+      else
+        alert_error clean_text("#{start_point} isn't a directory.")
+        terminate_interaction 1
+      end
     when /^-/ then
       alert_error clean_text("Invalid option: #{args.first}. See 'gem --help'.")
       terminate_interaction 1
     else
-      cmd_name = args.shift.downcase
-      cmd = find_command cmd_name
-      cmd.deprecation_warning if cmd.deprecated?
-      cmd.invoke_with_build_args args, build_args
+      invoke_command(args, build_args)
     end
   end
 
@@ -236,5 +242,12 @@ class Gem::CommandManager
       alert_error clean_text("Loading command: #{command_name} (#{e.class})\n\t#{e}")
       ui.backtrace e
     end
+  end
+
+  def invoke_command(args, build_args)
+    cmd_name = args.shift.downcase
+    cmd = find_command cmd_name
+    cmd.deprecation_warning if cmd.deprecated?
+    cmd.invoke_with_build_args args, build_args
   end
 end

--- a/lib/rubygems/commands/build_command.rb
+++ b/lib/rubygems/commands/build_command.rb
@@ -26,6 +26,9 @@ class Gem::Commands::BuildCommand < Gem::Command
     add_option "-C PATH", "Run as if gem build was started in <PATH> instead of the current working directory." do |value, options|
       options[:build_path] = value
     end
+    deprecate_option "-C",
+                     version: "4.0",
+                     extra_msg: "-C is a global flag now. Use `gem -C PATH build GEMSPEC_FILE [options]` instead"
   end
 
   def arguments # :nodoc:

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -41,6 +41,16 @@ class TestGemCommandsBuildCommand < Gem::TestCase
     assert_includes Gem.platforms, Gem::Platform.local
   end
 
+  def test_handle_deprecated_options
+    use_ui @ui do
+      @cmd.handle_options %w[-C ./test/dir]
+    end
+
+    assert_equal "WARNING:  The \"-C\" option has been deprecated and will be removed in Rubygems 4.0. " \
+                 "-C is a global flag now. Use `gem -C PATH build GEMSPEC_FILE [options]` instead\n",
+                 @ui.error
+  end
+
   def test_options_filename
     gemspec_file = File.join(@tempdir, @gem.spec_name)
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`gem install`, when installing a `.gemspec` file directly, looks for dependencies of the gemspec in other gemspec files present in the CWD. This works when the target `.gemspec` is in the CWD but not if it's somewhere else.

So if I have `a.gemspec` and `b.gemspec`, where `b` is a dependency if `a`, at folder `foo/bar`, then `cd foo/bar; gem install a.gemspec` works but `gem install foo/bar/a.gemspec` does not work.

## What is your fix for the problem, implemented in this PR?

This PR does not fix the issue per se, but introduces a `-C` flag to simplify making this work, by running, `gem -C foo/bar a.gemspec`. So we'll make this PR tentatively close #448 and wait for feedback in case someone still needs #448 itself after this.

As discussed before (#448 and #4058), and explained above, this solution introduces a flag (`-C`) that gives users the ability to change the execution directory from the current one to another. This flag was inspired by [git -C](https://git-scm.com/docs/git#Documentation/git.txt--Cltpathgt) and [ruby -C](https://linux.die.net/man/1/ruby).

Although the problem reported in #448 is related to `gem install`, implementing `-C` as a global flag provides consistency with other command line tools and exposes this feature to other commands.

`gem build` already has this same option, so I added a deprecation warning for it.

Closes #448.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
