### PR TITLE
Restore using branches or tags as `:ref` value

### DIFF
--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -176,15 +176,11 @@ module Bundler
 
           @depth = if !supports_fetching_unreachable_refs?
             nil
-          elsif not_pinned?
+          elsif not_pinned? || pinned_to_full_sha?
             1
           elsif ref.include?("~")
             parsed_depth = ref.split("~").last
             parsed_depth.to_i + 1
-          elsif abbreviated_ref?
-            nil
-          else
-            1
           end
         end
 
@@ -196,10 +192,10 @@ module Bundler
             "#{parsed_ref}:#{parsed_ref}"
           elsif ref.start_with?("refs/")
             "#{ref}:#{ref}"
-          elsif abbreviated_ref?
-            nil
-          else
+          elsif pinned_to_full_sha?
             ref
+          else
+            "refs/*:refs/*"
           end
         end
 
@@ -219,8 +215,8 @@ module Bundler
           branch || tag || ref.nil?
         end
 
-        def abbreviated_ref?
-          ref =~ /\A\h+\z/ && ref !~ /\A\h{40}\z/
+        def pinned_to_full_sha?
+          ref =~ /\A\h{40}\z/
         end
 
         def legacy_locked_revision?

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -235,6 +235,29 @@ RSpec.describe "bundle install with git sources" do
       G
     end
 
+    it "works when a tag that does not look like a commit hash is used as the value of :ref" do
+      build_git "foo"
+      @remote = build_git("bar", :bare => true)
+      update_git "foo", :remote => file_uri_for(@remote.path)
+      update_git "foo", :push => "main"
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem 'foo', :git => "#{@remote.path}"
+      G
+
+      # Create a new tag on the remote that needs fetching
+      update_git "foo", :tag => "v1.0.0"
+      update_git "foo", :push => "v1.0.0"
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem 'foo', :git => "#{@remote.path}", :ref => "v1.0.0"
+      G
+
+      expect(err).to be_empty
+    end
+
     it "works when the revision is a non-head ref" do
       # want to ensure we don't fallback to main
       update_git "foo", :path => lib_path("foo-1.0") do |s|


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The recent speed up of git sources create this regression, where we can no longer specify tag or branches under `:ref`.

## What is your fix for the problem, implemented in this PR?

If we have a shallow clone, and we change the Gemfile to use something like `:ref => "v1.0.0"`, two issues happen:

* The clone is not unshallowed even if v1.0.0 has not been fetched. This is because we were only unshallowing when `ref` was an "abbreviated ref" (hex chars only, but not exactly 40). Instead, we need to always unshallow unless `ref` is a full commit sha (40 hex chars).
* Even if unshallowing the clone properly, we were failing to fetch the ref, since we were passing just `v1.0.0` to `git fetch` and that does not create the remote tag locally. We need to pass a proper refspec for that. Since we don't know whether the given value to `:ref` is a tag or a branch, we fetch all tags and branches in that case by passing `refs/*:refs/*`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
