### PR TITLE
Don't unlock dependencies of a gemspec when its version changes

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -806,12 +806,13 @@ module Bundler
           end
 
           new_spec = new_specs[s].first
-
-          # If the spec is no longer in the path source, unlock it. This
-          # commonly happens if the version changed in the gemspec
-          next unless new_spec
-
-          s.dependencies.replace(new_spec.dependencies)
+          if new_spec
+            s.dependencies.replace(new_spec.dependencies)
+          else
+            # If the spec is no longer in the path source, unlock it. This
+            # commonly happens if the version changed in the gemspec
+            @unlock[:gems] << s.name
+          end
         end
 
         if dep.nil? && requested_dependencies.find {|d| s.name == d.name }

--- a/bundler/spec/install/gemfile/path_spec.rb
+++ b/bundler/spec/install/gemfile/path_spec.rb
@@ -92,13 +92,11 @@ RSpec.describe "bundle install with explicit source paths" do
     build_lib "demo", :path => lib_path("demo")
     build_lib "aaa", :path => lib_path("demo/aaa")
 
-    gemfile = <<-G
+    gemfile lib_path("demo/Gemfile"), <<-G
       source "#{file_uri_for(gem_repo1)}"
       gemspec
       gem "aaa", :path => "./aaa"
     G
-
-    File.open(lib_path("demo/Gemfile"), "w") {|f| f.puts gemfile }
 
     lockfile = <<~L
       PATH
@@ -314,12 +312,10 @@ RSpec.describe "bundle install with explicit source paths" do
       s.add_dependency "rack", "1.0"
     end
 
-    gemfile = <<-G
+    gemfile lib_path("foo/Gemfile"), <<-G
       source "#{file_uri_for(gem_repo1)}"
       gemspec
     G
-
-    File.open(lib_path("foo/Gemfile"), "w") {|f| f.puts gemfile }
 
     bundle "install", :dir => lib_path("foo")
     expect(the_bundle).to include_gems "foo 1.0", :dir => lib_path("foo")
@@ -791,13 +787,11 @@ RSpec.describe "bundle install with explicit source paths" do
   describe "when there are both a gemspec and remote gems" do
     it "doesn't query rubygems for local gemspec name" do
       build_lib "private_lib", "2.2", :path => lib_path("private_lib")
-      gemfile = <<-G
+      gemfile lib_path("private_lib/Gemfile"), <<-G
         source "http://localgemserver.test"
         gemspec
         gem 'rack'
       G
-      File.open(lib_path("private_lib/Gemfile"), "w") {|f| f.puts gemfile }
-
       bundle :install, :env => { "DEBUG" => "1" }, :artifice => "endpoint", :dir => lib_path("private_lib")
       expect(out).to match(%r{^HTTP GET http://localgemserver\.test/api/v1/dependencies\?gems=rack$})
       expect(out).not_to match(/^HTTP GET.*private_lib/)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When working with a gem locally with a Gemfile like

```ruby
# frozen_string_literal: true

source "https://rubygems.org"

# Specify your gem's dependencies in bundler_bug_repro.gemspec
gemspec
```

Changing the version in the `.gemspec` file and running `bundle install` results in dependencies defined in the gemspec being unlocked and possibly bumped in the `Gemfile.lock` file.

## What is your fix for the problem, implemented in this PR?

My fix is to accomodate the logic for finding the set of specs that need to be locked during resolution to do the right thing in this situation.

Fixes #6182.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
