### PR TITLE
Restore ability to fetch unreachable locked refs

### DIFF
--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -187,7 +187,7 @@ module Bundler
         def refspec
           return ref if pinned_to_full_sha?
 
-          ref_to_fetch = fully_qualified_ref
+          ref_to_fetch = @revision || fully_qualified_ref
 
           ref_to_fetch ||= if ref.include?("~")
             ref.split("~").first

--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -185,24 +185,23 @@ module Bundler
         end
 
         def refspec
-          if fully_qualified_ref
-            "#{fully_qualified_ref}:#{fully_qualified_ref}"
-          elsif ref.include?("~")
-            parsed_ref = ref.split("~").first
-            "#{parsed_ref}:#{parsed_ref}"
+          return ref if pinned_to_full_sha?
+
+          ref_to_fetch = fully_qualified_ref
+
+          ref_to_fetch ||= if ref.include?("~")
+            ref.split("~").first
           elsif ref.start_with?("refs/")
-            "#{ref}:#{ref}"
-          elsif pinned_to_full_sha?
             ref
           else
-            "refs/*:refs/*"
+            "refs/*"
           end
+
+          "#{ref_to_fetch}:#{ref_to_fetch}"
         end
 
         def fully_qualified_ref
-          return @fully_qualified_ref if defined?(@fully_qualified_ref)
-
-          @fully_qualified_ref = if branch
+          if branch
             "refs/heads/#{branch}"
           elsif tag
             "refs/tags/#{tag}"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If a user is locked to a commit SHA that exists in the remote but has become unreachable from any branches/tags, after the recent speed ups to git sources, their `Gemfile.lock` can no longer be used.

## What is your fix for the problem, implemented in this PR?

My fix is to make sure to explicitly fetch the locked ref in this case.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
