### PR TITLE
Restore annotated git tag support

### DIFF
--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -58,6 +58,7 @@ module Bundler
           @explicit_ref = branch || tag || ref
           @revision = revision
           @git      = git
+          @commit_ref = nil
         end
 
         def revision
@@ -116,7 +117,7 @@ module Bundler
             end
           end
 
-          git "fetch", "--force", "--quiet", *extra_fetch_args, :dir => destination
+          git "fetch", "--force", "--quiet", *extra_fetch_args, :dir => destination if @commit_ref
 
           git "reset", "--hard", @revision, :dir => destination
 
@@ -185,11 +186,16 @@ module Bundler
         end
 
         def refspec
-          return ref if pinned_to_full_sha?
+          commit = pinned_to_full_sha? ? ref : @revision
 
-          ref_to_fetch = @revision || fully_qualified_ref
+          if commit
+            @commit_ref = "refs/#{commit}-sha"
+            return "#{commit}:#{@commit_ref}"
+          end
 
-          ref_to_fetch ||= if ref.include?("~")
+          reference = fully_qualified_ref
+
+          reference ||= if ref.include?("~")
             ref.split("~").first
           elsif ref.start_with?("refs/")
             ref
@@ -197,7 +203,7 @@ module Bundler
             "refs/*"
           end
 
-          "#{ref_to_fetch}:#{ref_to_fetch}"
+          "#{reference}:#{reference}"
         end
 
         def fully_qualified_ref
@@ -216,10 +222,6 @@ module Bundler
 
         def pinned_to_full_sha?
           ref =~ /\A\h{40}\z/
-        end
-
-        def legacy_locked_revision?
-          !@revision.nil? && @revision =~ /\A\h{7}\z/
         end
 
         def git_null(*command, dir: nil)
@@ -362,7 +364,7 @@ module Bundler
 
         def extra_fetch_args
           extra_args = [path.to_s, *depth_args]
-          extra_args.push(revision) unless legacy_locked_revision?
+          extra_args.push(@commit_ref)
           extra_args
         end
 

--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -241,9 +241,9 @@ module Bundler
 
           out, err, status = capture(command, dir)
 
-          Bundler.ui.warn err unless err.empty?
+          raise GitCommandError.new(command_with_no_credentials, dir || SharedHelpers.pwd, err) unless status.success?
 
-          raise GitCommandError.new(command_with_no_credentials, dir || SharedHelpers.pwd, out) unless status.success?
+          Bundler.ui.warn err unless err.empty?
 
           out
         end

--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -344,9 +344,10 @@ module Bundler
         end
 
         def extra_clone_args
-          return [] if full_clone?
+          args = depth_args
+          return [] if args.empty?
 
-          args = ["--depth", depth.to_s, "--single-branch"]
+          args += ["--single-branch"]
           args.unshift("--no-tags") if supports_cloning_with_no_tags?
 
           args += ["--branch", branch || tag] if branch || tag

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -193,6 +193,7 @@ RSpec.describe "bundle install with git sources" do
           gem "foo"
         end
       G
+      expect(err).to be_empty
 
       run <<-RUBY
         require 'foo'


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

After #4475, we lost support for using annotated git tags in Bundler. These tags have commit SHA's associated that are a bit special for git. In particular, you cannot `git fetch <annotated-tag-commit-sha>`.

## What is your fix for the problem, implemented in this PR?

Restore support for these by creating special git references when Bundler needs to deal with explicit SHAs, no matter whether they are standard SHAs or SHAs associated to annotated git tags. 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
