### PR TITLE
Allow Bundler to run on old RubyGems + Ruby 2.7 without warnings

### DIFF
--- a/bundler/exe/bundle
+++ b/bundler/exe/bundle
@@ -15,7 +15,7 @@ else
   require "bundler"
 end
 
-if Gem.rubygems_version < Gem::Version.new("3.2.3") && Gem.ruby_version < Gem::Version.new("3.0.a") && !ENV["BUNDLER_NO_OLD_RUBYGEMS_WARNING"]
+if Gem.rubygems_version < Gem::Version.new("3.2.3") && Gem.ruby_version < Gem::Version.new("2.7.a") && !ENV["BUNDLER_NO_OLD_RUBYGEMS_WARNING"]
   Bundler.ui.warn \
     "Your RubyGems version (#{Gem::VERSION}) has a bug that prevents " \
     "`required_ruby_version` from working for Bundler. Any scripts that use " \


### PR DESCRIPTION

## What was the end-user or developer problem that led to this PR?

We may have been a little too aggressive here. Users running Ruby 2.7 which is still supported for a few months are getting this warning.

## What is your fix for the problem, implemented in this PR?

Don't show the warning on Ruby 2.7. We can reintroduce this once Ruby 2.7 reaches end of life.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
