### PR TITLE
Fix dependencies scoped to other platforms making resolver fail

### DIFF
--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -311,7 +311,16 @@ module Bundler
     def prepare_dependencies(requirements, packages)
       to_dependency_hash(requirements, packages).map do |dep_package, dep_constraint|
         name = dep_package.name
-        next if dep_package.platforms.empty?
+
+        # If a dependency is scoped to a platform different from the current
+        # one, we ignore it. However, it may reappear during resolution as a
+        # transitive dependency of another package, so we need to reset the
+        # package so the proper versions are considered if reintroduced later.
+        if dep_package.platforms.empty?
+          @packages.delete(name)
+          next
+        end
+
         next [dep_package, dep_constraint] if name == "bundler"
         next [dep_package, dep_constraint] unless versions_for(dep_package, dep_constraint.range).empty?
         next unless dep_package.current_platform?

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -572,6 +572,26 @@ RSpec.describe "bundle install with platform conditionals" do
          #{Bundler::VERSION}
     L
   end
+
+  it "resolves fine when a dependency is unused on a platform different from the current one, but reintroduced transitively" do
+    bundle "config set --local force_ruby_platform true"
+
+    build_repo4 do
+      build_gem "listen", "3.7.1" do |s|
+        s.add_dependency "ffi"
+      end
+
+      build_gem "ffi", "1.15.5"
+    end
+
+    install_gemfile <<~G
+      source "#{file_uri_for(gem_repo4)}"
+
+      gem "listen"
+      gem "ffi", :platform => :windows
+    G
+    expect(err).to be_empty
+  end
 end
 
 RSpec.describe "when a gem has no architecture" do


### PR DESCRIPTION



## What was the end-user or developer problem that led to this PR?

If we have a Gemfile like

```
source 'https://rubygems.org'

gem 'listen', '~> 3.3'
gem 'ffi', platforms: [:mingw, :x64_mingw, :mswin]
```

and resolve on a non Windows platform, previous resolver used to ignore the ffi top level dependency. However, in the case other top level dependency re-introduces the dependency (`listen` in this case), it would be properly reintroduced.

This does not happen with the new resolver.

## What is your fix for the problem, implemented in this PR?

This commit fixes the issue by properly resetting the excluded resolution package.

Fixes #6188. ~Working on a test now.~ Done!

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
