### PR TITLE
Changelogs for RubyGems 3.4.1 and Bundler 2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.4.1 / 2022-12-24
+
+## Enhancements:
+
+* Installs bundler 2.4.1 as a default gem.
+
 # 3.4.0 / 2022-12-24
 
 ## Breaking changes:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 2.4.1 (December 24, 2022)
+
+## Enhancements:
+
+  - Allow Bundler to run on old RubyGems + Ruby 2.7 without warnings [#6187](https://github.com/rubygems/rubygems/pull/6187)
+
+## Bug fixes:
+
+  - Fix dependencies scoped to other platforms making resolver fail [#6189](https://github.com/rubygems/rubygems/pull/6189)
+  - Restore annotated git tag support [#6186](https://github.com/rubygems/rubygems/pull/6186)
+
 # 2.4.0 (December 24, 2022)
 
 ## Security:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.4.1 and Bundler 2.4.1 into master.