### PR TITLE
Speed up resolution by properly merging incompatibility ranges

### DIFF
--- a/bundler/lib/bundler/vendor/pub_grub/lib/pub_grub/version_constraint.rb
+++ b/bundler/lib/bundler/vendor/pub_grub/lib/pub_grub/version_constraint.rb
@@ -20,6 +20,10 @@ module Bundler::PubGrub
         range.eql?(other.range)
     end
 
+    def ==(other)
+      package == other.package && range == other.range
+    end
+
     class << self
       def exact(package, version)
         range = VersionRange.new(min: version, max: version, include_min: true, include_max: true)

--- a/bundler/spec/realworld/edgecases_spec.rb
+++ b/bundler/spec/realworld/edgecases_spec.rb
@@ -219,7 +219,7 @@ RSpec.describe "real world edgecases", :realworld => true do
   end
 
   it "doesn't hang on big gemfile" do
-    skip "Only for ruby 2.7" if !RUBY_VERSION.start_with?("2.7") || RUBY_PLATFORM.include?("darwin")
+    skip "Only for ruby 2.7" unless RUBY_VERSION.start_with?("2.7")
 
     gemfile <<~G
       # frozen_string_literal: true
@@ -331,7 +331,7 @@ RSpec.describe "real world edgecases", :realworld => true do
   end
 
   it "doesn't hang on tricky gemfile" do
-    skip "Only for ruby 2.7" if !RUBY_VERSION.start_with?("2.7") || RUBY_PLATFORM.include?("darwin")
+    skip "Only for ruby 2.7" unless RUBY_VERSION.start_with?("2.7")
 
     gemfile <<~G
       source 'https://rubygems.org'
@@ -353,7 +353,7 @@ RSpec.describe "real world edgecases", :realworld => true do
   end
 
   it "doesn't hang on nix gemfile" do
-    skip "Only for ruby 3.0" if !RUBY_VERSION.start_with?("3.0") || RUBY_PLATFORM.include?("darwin")
+    skip "Only for ruby 3.0" unless RUBY_VERSION.start_with?("3.0")
 
     gemfile <<~G
       source "https://rubygems.org"

--- a/bundler/spec/realworld/edgecases_spec.rb
+++ b/bundler/spec/realworld/edgecases_spec.rb
@@ -323,7 +323,7 @@ RSpec.describe "real world edgecases", :realworld => true do
     if Bundler.feature_flag.bundler_3_mode?
       # Conflicts on bundler version, so we count attempts differently
       bundle :lock, :env => { "DEBUG_RESOLVER" => "1" }, :raise_on_error => false
-      expect(out.split("\n").grep(/backtracking to/).count).to eq(15)
+      expect(out.split("\n").grep(/backtracking to/).count).to eq(8)
     else
       bundle :lock, :env => { "DEBUG_RESOLVER" => "1" }
       expect(out).to include("Solution found after 7 attempts")
@@ -349,11 +349,7 @@ RSpec.describe "real world edgecases", :realworld => true do
 
     bundle :lock, :env => { "DEBUG_RESOLVER" => "1" }
 
-    if Bundler.feature_flag.bundler_3_mode?
-      expect(out).to include("Solution found after 14 attempts")
-    else
-      expect(out).to include("Solution found after 18 attempts")
-    end
+    expect(out).to include("Solution found after 6 attempts")
   end
 
   it "doesn't hang on nix gemfile" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes PubGrub is very slow, like with this Gemfile:

https://github.com/rubygems/rubygems/blob/e1540e4bf64adcb9c98494e79f692762b3027f4d/bundler/spec/realworld/edgecases_spec.rb#L359-L519

Sometimes it also hangs while propagating incompatibilities, like with the Gemfile reported [here](https://github.com/rubygems/rubygems/issues/6210#issuecomment-1367360624).

## What is your fix for the problem, implemented in this PR?

While PubGrub's builtin package source relies only on comparing requirement strings for merging incompatibility ranges, our custom package source relies on comparing full `VersionContraint` instances.

This patch should speed things up. As an example, the nix Gemfile above takes on my machine about 30 seconds to resolve with this patch, and about 7 minutes without it.

It should also give more compact explanations. For example, the weird explanation (with a lot of tiny version ranges) reported at https://github.com/rubygems/rubygems/issues/6188 should now be much simpler (although that case now resolves fine since the issue is fixed, but just to give an example).

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
