### PR TITLE
Improve documentation about `Kernel` monkeypatches

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -119,10 +119,6 @@ module Gem
   # to avoid deprecation warnings in Ruby 2.7.
   UNTAINT = RUBY_VERSION < "2.7" ? :untaint.to_sym : proc {}
 
-  # When https://bugs.ruby-lang.org/issues/17259 is available, there is no need to override Kernel#warn
-  KERNEL_WARN_IGNORES_INTERNAL_ENTRIES = RUBY_ENGINE == "truffleruby" ||
-                                         (RUBY_ENGINE == "ruby" && RUBY_VERSION >= "3.0")
-
   ##
   # An Array of Regexps that match windows Ruby platforms.
 
@@ -1348,7 +1344,16 @@ end
 Gem::Specification.load_defaults
 
 require_relative "rubygems/core_ext/kernel_gem"
-require_relative "rubygems/core_ext/kernel_require"
-require_relative "rubygems/core_ext/kernel_warn"
+
+path = File.join(__dir__, "rubygems/core_ext/kernel_require.rb")
+# When https://bugs.ruby-lang.org/issues/17259 is available, there is no need to override Kernel#warn
+if RUBY_ENGINE == "truffleruby" ||
+   (RUBY_ENGINE == "ruby" && RUBY_VERSION >= "3.0")
+  file = "<internal:#{path}>"
+else
+  require_relative "rubygems/core_ext/kernel_warn"
+  file = path
+end
+eval File.read(path), nil, file
 
 require ENV["BUNDLER_SETUP"] if ENV["BUNDLER_SETUP"] && !defined?(Bundler)

--- a/lib/rubygems/core_ext/kernel_gem.rb
+++ b/lib/rubygems/core_ext/kernel_gem.rb
@@ -1,9 +1,4 @@
 # frozen_string_literal: true
-##
-# RubyGems adds the #gem method to allow activation of specific gem versions
-# and overrides the #require method on Kernel to make gems appear as if they
-# live on the <code>$LOAD_PATH</code>.  See the documentation of these methods
-# for further detail.
 
 module Kernel
 

--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -147,17 +147,17 @@ module Kernel
     RUBYGEMS_ACTIVATION_MONITOR.exit
     return gem_original_require(path)
   rescue LoadError => load_error
-    RUBYGEMS_ACTIVATION_MONITOR.enter
+    if load_error.path == path
+      RUBYGEMS_ACTIVATION_MONITOR.enter
 
-    begin
-      if load_error.path == path and Gem.try_activate(path)
-        require_again = true
+      begin
+        require_again = Gem.try_activate(path)
+      ensure
+        RUBYGEMS_ACTIVATION_MONITOR.exit
       end
-    ensure
-      RUBYGEMS_ACTIVATION_MONITOR.exit
-    end
 
-    return gem_original_require(path) if require_again
+      return gem_original_require(path) if require_again
+    end
 
     raise load_error
   ensure

--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -13,12 +13,12 @@ module Kernel
 
   # Make sure we have a reference to Ruby's original Kernel#require
   unless defined?(gem_original_require)
+    # :stopdoc:
     alias gem_original_require require
     private :gem_original_require
+    # :startdoc:
   end
 
-  file = Gem::KERNEL_WARN_IGNORES_INTERNAL_ENTRIES ? "<internal:#{__FILE__}>" : __FILE__
-  module_eval <<'RUBY', file, __LINE__ + 1 # rubocop:disable Style/EvalWithLocation
   ##
   # When RubyGems is required, Kernel#require is replaced with our own which
   # is capable of loading gems on demand.
@@ -33,7 +33,7 @@ module Kernel
   # The normal <tt>require</tt> functionality of returning false if
   # that file has already been loaded is preserved.
 
-  def require(path)
+  def require(path) # :doc:
     if RUBYGEMS_ACTIVATION_MONITOR.respond_to?(:mon_owned?)
       monitor_owned = RUBYGEMS_ACTIVATION_MONITOR.mon_owned?
     end
@@ -168,7 +168,6 @@ module Kernel
       end
     end
   end
-RUBY
 
   private :require
 

--- a/lib/rubygems/core_ext/kernel_warn.rb
+++ b/lib/rubygems/core_ext/kernel_warn.rb
@@ -1,53 +1,50 @@
 # frozen_string_literal: true
 
-if !Gem::KERNEL_WARN_IGNORES_INTERNAL_ENTRIES
+module Kernel
+  rubygems_path = "#{__dir__}/" # Frames to be skipped start with this path.
 
-  module Kernel
-    rubygems_path = "#{__dir__}/" # Frames to be skipped start with this path.
+  original_warn = instance_method(:warn)
 
-    original_warn = instance_method(:warn)
+  remove_method :warn
 
+  class << self
     remove_method :warn
+  end
 
-    class << self
-      remove_method :warn
+  module_function define_method(:warn) {|*messages, **kw|
+    unless uplevel = kw[:uplevel]
+      if Gem.java_platform? && RUBY_VERSION < "3.1"
+        return original_warn.bind(self).call(*messages)
+      else
+        return original_warn.bind(self).call(*messages, **kw)
+      end
     end
 
-    module_function define_method(:warn) {|*messages, **kw|
-      unless uplevel = kw[:uplevel]
-        if Gem.java_platform? && RUBY_VERSION < "3.1"
-          return original_warn.bind(self).call(*messages)
-        else
-          return original_warn.bind(self).call(*messages, **kw)
+    # Ensure `uplevel` fits a `long`
+    uplevel, = [uplevel].pack("l!").unpack("l!")
+
+    if uplevel >= 0
+      start = 0
+      while uplevel >= 0
+        loc, = caller_locations(start, 1)
+        unless loc
+          # No more backtrace
+          start += uplevel
+          break
         end
-      end
 
-      # Ensure `uplevel` fits a `long`
-      uplevel, = [uplevel].pack("l!").unpack("l!")
+        start += 1
 
-      if uplevel >= 0
-        start = 0
-        while uplevel >= 0
-          loc, = caller_locations(start, 1)
-          unless loc
-            # No more backtrace
-            start += uplevel
-            break
-          end
-
-          start += 1
-
-          if path = loc.path
-            unless path.start_with?(rubygems_path) || path.start_with?("<internal:")
-              # Non-rubygems frames
-              uplevel -= 1
-            end
+        if path = loc.path
+          unless path.start_with?(rubygems_path) || path.start_with?("<internal:")
+            # Non-rubygems frames
+            uplevel -= 1
           end
         end
-        kw[:uplevel] = start
       end
+      kw[:uplevel] = start
+    end
 
-      original_warn.bind(self).call(*messages, **kw)
-    }
-  end
+    original_warn.bind(self).call(*messages, **kw)
+  }
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

https://bugs.ruby-lang.org/issues/19285

> It seems we merge all of the docs for stdlib and core into one for docs.ruby-lang.org, this creates weirdness like [Kernel](https://docs.ruby-lang.org/en/master/Kernel.html) which includes monkey patches for rubygems for example.
> 
> > RubyGems adds the gem method to allow activation of specific gem versions and overrides the require method on Kernel to make gems appear as if they live on the $LOAD_PATH. See the documentation of these methods for further detail.

This seems an implementation detail but not for users.

## What is your fix for the problem, implemented in this PR?

Hide this comment from RDoc.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
