### PR TITLE
Get `Gem::Specification#extensions_dir` documented

### DIFF
--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -351,9 +351,8 @@ module Gem
         end
 
         def extensions_dir
-          Gem.default_ext_dir_for(base_dir) ||
-            File.join(base_dir, "extensions", ORIGINAL_LOCAL_PLATFORM,
-                      Gem.extension_api_version)
+          @extensions_dir ||=
+            Gem.default_ext_dir_for(base_dir) || File.join(base_dir, "extensions", ORIGINAL_LOCAL_PLATFORM, Gem.extension_api_version)
         end
       end
     end

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -531,13 +531,6 @@ class Gem::Specification < Gem::BasicSpecification
   attr_reader :required_rubygems_version
 
   ##
-  # The version of RubyGems used to create this gem.
-  #
-  # Do not set this, it is set automatically when the gem is packaged.
-
-  attr_accessor :rubygems_version
-
-  ##
   # The key used to sign this gem.  See Gem::Security for details.
 
   attr_accessor :signing_key
@@ -722,6 +715,21 @@ class Gem::Specification < Gem::BasicSpecification
 
   def test_files=(files) # :nodoc:
     @test_files = Array files
+  end
+
+  ######################################################################
+  # :section: Read-only attributes
+
+  ##
+  # The version of RubyGems used to create this gem.
+
+  attr_accessor :rubygems_version
+
+  ##
+  # The path where this gem installs its extensions.
+
+  def extensions_dir
+    @extensions_dir ||= super
   end
 
   ######################################################################


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We should make `Gem::Specification#extensions_dir` documented at https://guides.rubygems.org/specification-reference/.

## What is your fix for the problem, implemented in this PR?

Unfortunately the scripts for generating the site are [a bit weird](https://github.com/rubygems/guides/blob/cade28179dc3b47836660a39bf0b69d7020dca6f/rdoc/generator/template/jekdoc/classpage.rhtml).

This change changes `Gem::Specification` hopefully in a harmless way, so that the method appears documented on our site.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
