### PR TITLE
Let resolver deal with legacy gems with equivalent version and different dependencies

### DIFF
--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -215,7 +215,7 @@ module Bundler
 
     def all_versions_for(package)
       name = package.name
-      results = (@base[name] + @all_specs[name]).uniq(&:full_name)
+      results = (@base[name] + @all_specs[name]).uniq {|spec| [spec.version.hash, spec.platform] }
       locked_requirement = base_requirements[name]
       results = filter_matching_specs(results, locked_requirement) if locked_requirement
 

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -1076,4 +1076,31 @@ RSpec.describe "bundle install with gem sources" do
       G
     end
   end
+
+  context "when a gem has equivalent versions with inconsistent dependencies" do
+    before do
+      build_repo4 do
+        build_gem "autobuild", "1.10.rc2" do |s|
+          s.add_dependency "utilrb", ">= 1.6.0"
+        end
+
+        build_gem "autobuild", "1.10.0.rc2" do |s|
+          s.add_dependency "utilrb", ">= 2.0"
+        end
+      end
+    end
+
+    it "does not crash unexpectedly" do
+      gemfile <<~G
+        source "#{file_uri_for(gem_repo4)}"
+
+        gem "autobuild", "1.10.rc2"
+      G
+
+      bundle "install --jobs 1", :raise_on_error => false
+
+      expect(err).not_to include("ERROR REPORT TEMPLATE")
+      expect(err).to include("Could not find compatible versions")
+    end
+  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Some legacy gems could have equivalent versions like 1.10.rc2 and 1.10.0.rc2 with different dependencies.

This makes our new resolver crash.

## What is your fix for the problem, implemented in this PR?

My fix is to make our deduplication of version candidates deal with this.

Not totally sold we should do anything about this though.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
