### PR TITLE
Changelogs for RubyGems 3.4.2 and Bundler 2.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 3.4.2 / 2023-01-01
+
+## Enhancements:
+
+* Add global flag (`-C`) to change execution directory. Pull request #6180
+  by gustavothecoder
+* Installs bundler 2.4.2 as a default gem.
+
 # 3.4.1 / 2022-12-24
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 2.4.2 (January 1, 2023)
+
+## Performance:
+
+  - Speed up resolution by properly merging incompatibility ranges [#6215](https://github.com/rubygems/rubygems/pull/6215)
+
+## Documentation:
+
+  - Remove stray word in `bundle config` man page [#6220](https://github.com/rubygems/rubygems/pull/6220)
+
 # 2.4.1 (December 24, 2022)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.4.2 and Bundler 2.4.2 into master.