### PR TITLE
Fallback to selecting installable candidates if possible when materializing specs

### DIFF
--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -125,10 +125,6 @@ module Bundler
 
     private
 
-    def to_ary
-      nil
-    end
-
     #
     # For backwards compatibility with existing lockfiles, if the most specific
     # locked platform is not a specific platform like x86_64-linux or

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -87,7 +87,16 @@ module Bundler
       else
         target_platform = ruby_platform_materializes_to_ruby_platform? ? platform : local_platform
 
-        GemHelpers.select_best_platform_match(matching_specs, target_platform)
+        installable_candidates = GemHelpers.select_best_platform_match(matching_specs, target_platform)
+
+        specification = __materialize__(installable_candidates)
+        return specification unless specification.nil?
+
+        if target_platform != platform
+          installable_candidates = GemHelpers.select_best_platform_match(matching_specs, platform)
+        end
+
+        installable_candidates
       end
 
       __materialize__(candidates)

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -104,6 +104,47 @@ RSpec.describe "bundle install with specific platforms" do
       L
     end
 
+    it "still installs the generic RUBY variant if necessary even when running on a legacy lockfile locked only to RUBY" do
+      build_repo4 do
+        build_gem "nokogiri", "1.3.10"
+        build_gem "nokogiri", "1.3.10" do |s|
+          s.platform = "arm64-darwin"
+          s.required_ruby_version = "< #{Gem.ruby_version}"
+        end
+
+        build_gem "bundler", "2.1.4"
+      end
+
+      gemfile <<~G
+        source "#{file_uri_for(gem_repo4)}"
+
+        gem "nokogiri"
+      G
+
+      lockfile <<-L
+        GEM
+          remote: #{file_uri_for(gem_repo4)}/
+          specs:
+            nokogiri (1.3.10)
+
+        PLATFORMS
+          ruby
+
+        DEPENDENCIES
+          nokogiri
+
+        RUBY VERSION
+          2.5.3p105
+
+        BUNDLED WITH
+           2.1.4
+      L
+
+      simulate_platform "arm64-darwin-22" do
+        bundle "update --bundler", :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+      end
+    end
+
     it "doesn't discard previously installed platform specific gem and fall back to ruby on subsequent bundles" do
       build_repo2 do
         build_gem("libv8", "8.4.255.0")


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When running in legacy lockfile mode (only RUBY platform locked in Gemfile.lock), it may happen that we select a platform specific version, only to later find that it's not installable because of not matching ruby version requirements.

This is the case when having `nokogiri-1.3.10` in this kind of lockfile. This version of `nokogiri` only supports Ruby 3.2 in its [generic version](https://rubygems.org/gems/nokogiri/versions/1.13.10) (though a "Ruby >= 2.6" requirement), but there are no yet precompiled versions for Ruby 3.2, so those don't support Ruby 3.2 (they use a [">= 2.6, < 3.2.DEV"](https://rubygems.org/gems/nokogiri/versions/1.13.10-arm64-darwin) requirement).

So when upgrading such a lockfile to Ruby 3.2, we would incorrectly select a precompiled version, and fail to materialize it.

## What is your fix for the problem, implemented in this PR?

Check the above situation before-hand so that we can fallback to the generic version.

Closes #6221.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
