### PR TITLE
Add Ruby 3.2 to CI

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -34,6 +34,7 @@ jobs:
           - { name: ruby-2.7, value: 2.7.7 }
           - { name: ruby-3.0, value: 3.0.5 }
           - { name: ruby-3.1, value: 3.1.3 }
+          - { name: ruby-3.2, value: 3.2.0 }
 
         bundler:
           - { name: 2, value: '' }
@@ -46,10 +47,12 @@ jobs:
           - { os: { name: MacOS, value: macos-12 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.7 }, timeout: 90 }
           - { os: { name: MacOS, value: macos-12 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.5 }, timeout: 90 }
           - { os: { name: MacOS, value: macos-12 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.3 }, timeout: 90 }
+          - { os: { name: MacOS, value: macos-12 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.2, value: 3.2.0 }, timeout: 90 }
 
           - { os: { name: Windows, value: windows-2022 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.7 }, timeout: 150 }
           - { os: { name: Windows, value: windows-2022 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.5 }, timeout: 150 }
           - { os: { name: Windows, value: windows-2022 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.3 }, timeout: 150 }
+          - { os: { name: Windows, value: windows-2022 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.2, value: 3.2.0 }, timeout: 150 }
 
     env:
       RGV: ..

--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -124,4 +124,4 @@ jobs:
         run: gem install rails && rails new foo ${{ matrix.ruby.rails-args }}
         shell: bash
 
-    timeout-minutes: 10
+    timeout-minutes: 20

--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -26,6 +26,7 @@ jobs:
           - { name: "2.7", value: 2.7.7 }
           - { name: "3.0", value: 3.0.5 }
           - { name: "3.1", value: 3.1.3 }
+          - { name: "3.2", value: 3.2.0 }
           - { name: jruby-9.3, value: jruby-9.3.9.0 }
           - { name: truffleruby-22, value: truffleruby-22.3.0 }
         openssl:
@@ -97,6 +98,7 @@ jobs:
       matrix:
         ruby:
           - { name: "3.1", value: 3.1.3 } # Rails 7
+          - { name: "3.2", value: 3.2.0 } # Rails 7
           - { name: jruby-9.3, value: jruby-9.3.9.0, rails-args: "--skip-webpack-install" } # Rails 6
     steps:
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0

--- a/.github/workflows/realworld-bundler.yml
+++ b/.github/workflows/realworld-bundler.yml
@@ -29,6 +29,7 @@ jobs:
           - { name: ruby-2.7, value: 2.7.7 }
           - { name: ruby-3.0, value: 3.0.5 }
           - { name: ruby-3.1, value: 3.1.3 }
+          - { name: ruby-3.2, value: 3.2.0 }
 
         bundler:
           - { name: 2, value: '' }
@@ -41,6 +42,7 @@ jobs:
           - { os: { name: MacOS, value: macos-12 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.7 } }
           - { os: { name: MacOS, value: macos-12 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.5 } }
           - { os: { name: MacOS, value: macos-12 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.3 } }
+          - { os: { name: MacOS, value: macos-12 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.2, value: 3.2.0 } }
     env:
       RGV: ..
       RUBYOPT: --disable-gems
@@ -79,9 +81,11 @@ jobs:
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.7 } }
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.5 } }
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.3 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.2, value: 3.2.0 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.7, value: 2.7.7 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.0, value: 3.0.5 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.1, value: 3.1.3 } }
+          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.2, value: 3.2.0 } }
     steps:
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
       - name: Setup ruby
@@ -115,7 +119,7 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@09c10210cc6e998d842ce8433cd9d245933cd797 # v1.133.0
         with:
-          ruby-version: 3.1.3
+          ruby-version: 3.2.0
           bundler: none
       - name: Download all used cassettes as artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/rubygems.yml
+++ b/.github/workflows/rubygems.yml
@@ -31,6 +31,7 @@ jobs:
           - { name: "2.7", value: 2.7.7 }
           - { name: "3.0", value: 3.0.5 }
           - { name: "3.1", value: 3.1.3 }
+          - { name: "3.2", value: 3.2.0 }
 
         include:
           - ruby: { name: jruby-9.3, value: jruby-9.3.9.0 }
@@ -80,7 +81,7 @@ jobs:
         if: "!startsWith(matrix.ruby.name, 'truffleruby') && !startsWith(matrix.ruby.name, 'jruby')"
       - name: Run Test isolatedly
         run: rake test:isolated
-        if: matrix.ruby.name == '3.1' && matrix.os.name != 'Windows'
+        if: matrix.ruby.name == '3.2' && matrix.os.name != 'Windows'
       - name: Run Test (JRuby)
         run: JRUBY_OPTS=--debug rake test
         if: startsWith(matrix.ruby.name, 'jruby')

--- a/.github/workflows/system-rubygems-bundler.yml
+++ b/.github/workflows/system-rubygems-bundler.yml
@@ -35,9 +35,11 @@ jobs:
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.7 } }
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.5 } }
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.3 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.2, value: 3.2.0 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.7, value: 2.7.7 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.0, value: 3.0.5 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.1, value: 3.1.3 } }
+          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.2, value: 3.2.0 } }
     steps:
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
       - name: Setup ruby

--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@09c10210cc6e998d842ce8433cd9d245933cd797 # v1.133.0
         with:
-          ruby-version: 3.1.3
+          ruby-version: 3.2.0
           bundler: none
       - name: Install Dependencies
         run: rake setup


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Ruby 3.2 has been released for a few weeks now. We should test against it.

## What is your fix for the problem, implemented in this PR?

Add Ruby 3.2 to our CI workflows.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
