### PR TITLE
When auto-removing RUBY platform don't add specific platform if not needed

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -129,7 +129,7 @@ module Bundler
       end
       @unlocking ||= @unlock[:ruby] ||= (!@locked_ruby_version ^ !@ruby_version)
 
-      add_current_platform unless current_ruby_platform_locked? || Bundler.frozen_bundle?
+      add_current_platform unless Bundler.frozen_bundle?
 
       converge_path_sources_to_gemspec_sources
       @path_changes = converge_paths
@@ -584,6 +584,8 @@ module Bundler
     end
 
     def add_current_platform
+      return if current_ruby_platform_locked?
+
       add_platform(local_platform)
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes, Bundler removes RUBY platform from the Gemfile.lock because it needs to, but it also adds the current specific platform to it, when it's not necessary.

## What is your fix for the problem, implemented in this PR?

If there's a more specific platform than "ruby", but more generic that the current specific platform, leave that one in the lockfile and don't add the specific platform to it.

Fixes #6232.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
