### PR TITLE
Cleanup unnecessary gems when removing lockfile platforms

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -79,6 +79,7 @@ module Bundler
       @locked_bundler_version = nil
       @locked_ruby_version    = nil
       @new_platform = nil
+      @removed_platform = nil
 
       if lockfile && File.exist?(lockfile)
         @lockfile_contents = Bundler.read_file(lockfile)
@@ -267,7 +268,7 @@ module Bundler
           SpecSet.new(filter_specs(@locked_specs, @dependencies - deleted_deps))
         else
           Bundler.ui.debug "Found no changes, using resolution from the lockfile"
-          if @locked_gems.may_include_redundant_platform_specific_gems?
+          if @removed_platform || @locked_gems.may_include_redundant_platform_specific_gems?
             SpecSet.new(filter_specs(@locked_specs, @dependencies))
           else
             @locked_specs
@@ -446,7 +447,9 @@ module Bundler
     end
 
     def remove_platform(platform)
-      return if @platforms.delete(Gem::Platform.new(platform))
+      removed_platform = @platforms.delete(Gem::Platform.new(platform))
+      @removed_platform ||= removed_platform
+      return if removed_platform
       raise InvalidOption, "Unable to remove the platform `#{platform}` since the only platforms are #{@platforms.join ", "}"
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When removing lockfile platforms, unnecessary lockfile gems are not cleaned up, and then they are confusingly lost in subsequent commands.

This used to work fine, but when we introduced https://github.com/rubygems/rubygems/pull/5695 for speed, this feature was lost.

## What is your fix for the problem, implemented in this PR?

Restore the feature by remembering when platforms have been removed, so that we don't reintroduce any performance penalty in the general case.

Fixes #6231.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
