### PR TITLE
Fix version ranges incorrectly handling platforms

### DIFF
--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -337,7 +337,8 @@ module Bundler
 
     def requirement_to_range(requirement)
       ranges = requirement.requirements.map do |(op, version)|
-        ver = Resolver::Candidate.new(version)
+        ver = Resolver::Candidate.new(version).generic!
+        platform_ver = Resolver::Candidate.new(version).platform_specific!
 
         case op
         when "~>"
@@ -345,17 +346,17 @@ module Bundler
           bump = Resolver::Candidate.new(version.bump.to_s + ".A")
           PubGrub::VersionRange.new(:name => name, :min => ver, :max => bump, :include_min => true)
         when ">"
-          PubGrub::VersionRange.new(:min => ver)
+          PubGrub::VersionRange.new(:min => platform_ver)
         when ">="
           PubGrub::VersionRange.new(:min => ver, :include_min => true)
         when "<"
           PubGrub::VersionRange.new(:max => ver)
         when "<="
-          PubGrub::VersionRange.new(:max => ver, :include_max => true)
+          PubGrub::VersionRange.new(:max => platform_ver, :include_max => true)
         when "="
-          PubGrub::VersionRange.new(:min => ver, :max => ver, :include_min => true, :include_max => true)
+          PubGrub::VersionRange.new(:min => ver, :max => platform_ver, :include_min => true, :include_max => true)
         when "!="
-          PubGrub::VersionRange.new(:min => ver, :max => ver, :include_min => true, :include_max => true).invert
+          PubGrub::VersionRange.new(:min => ver, :max => platform_ver, :include_min => true, :include_max => true).invert
         else
           raise "bad version specifier: #{op}"
         end

--- a/bundler/lib/bundler/resolver/candidate.rb
+++ b/bundler/lib/bundler/resolver/candidate.rb
@@ -41,6 +41,18 @@ module Bundler
         @spec_group.to_specs(package.force_ruby_platform?)
       end
 
+      def generic!
+        @ruby_only = true
+
+        self
+      end
+
+      def platform_specific!
+        @ruby_only = false
+
+        self
+      end
+
       def prerelease?
         @version.prerelease?
       end
@@ -53,27 +65,20 @@ module Bundler
         [@version, @ruby_only ? -1 : 1]
       end
 
-      def canonical?
-        !@spec_group.empty?
-      end
-
       def <=>(other)
         return unless other.is_a?(self.class)
-        return @version <=> other.version unless canonical? && other.canonical?
 
         sort_obj <=> other.sort_obj
       end
 
       def ==(other)
         return unless other.is_a?(self.class)
-        return @version == other.version unless canonical? && other.canonical?
 
         sort_obj == other.sort_obj
       end
 
       def eql?(other)
         return unless other.is_a?(self.class)
-        return @version.eql?(other.version) unless canonical? || other.canonical?
 
         sort_obj.eql?(other.sort_obj)
       end

--- a/bundler/lib/bundler/vendor/pub_grub/lib/pub_grub/version_range.rb
+++ b/bundler/lib/bundler/vendor/pub_grub/lib/pub_grub/version_range.rb
@@ -397,7 +397,7 @@ module Bundler::PubGrub
 
     def constraints
       return ["any"] if any?
-      return ["= #{min}"] if min == max
+      return ["= #{min}"] if min.to_s == max.to_s
 
       c = []
       c << "#{include_min ? ">=" : ">"} #{min}" if min

--- a/bundler/lib/bundler/vendor/pub_grub/lib/pub_grub/version_union.rb
+++ b/bundler/lib/bundler/vendor/pub_grub/lib/pub_grub/version_union.rb
@@ -148,7 +148,7 @@ module Bundler::PubGrub
       while !ranges.empty?
         ne = []
         range = ranges.shift
-        while !ranges.empty? && ranges[0].min == range.max
+        while !ranges.empty? && ranges[0].min.to_s == range.max.to_s
           ne << range.max
           range = range.span(ranges.shift)
         end

--- a/bundler/spec/bundler/resolver/candidate_spec.rb
+++ b/bundler/spec/bundler/resolver/candidate_spec.rb
@@ -3,8 +3,19 @@
 RSpec.describe Bundler::Resolver::Candidate do
   it "compares fine" do
     version1 = described_class.new("1.12.5", :specs => [Gem::Specification.new("foo", "1.12.5") {|s| s.platform = Gem::Platform::RUBY }])
-    version2 = described_class.new("1.12.5")
+    version2 = described_class.new("1.12.5") # passing no specs creates a platform specific candidate, so sorts higher
 
-    expect(version1 >= version2).to be true
+    expect(version2 >= version1).to be true
+
+    expect(version1.generic! == version2.generic!).to be true
+    expect(version1.platform_specific! == version2.platform_specific!).to be true
+
+    expect(version1.platform_specific! >= version2.generic!).to be true
+    expect(version2.platform_specific! >= version1.generic!).to be true
+
+    version1 = described_class.new("1.12.5", :specs => [Gem::Specification.new("foo", "1.12.5") {|s| s.platform = Gem::Platform::RUBY }])
+    version2 = described_class.new("1.12.5", :specs => [Gem::Specification.new("foo", "1.12.5") {|s| s.platform = Gem::Platform::X64_LINUX }])
+
+    expect(version2 >= version1).to be true
   end
 end

--- a/bundler/spec/resolver/platform_spec.rb
+++ b/bundler/spec/resolver/platform_spec.rb
@@ -155,21 +155,32 @@ RSpec.describe "Resolving platform craziness" do
     end
   end
 
-  it "takes the latest ruby gem if the platform specific gem doesn't match the required_ruby_version" do
-    @index = build_index do
-      gem "foo", "1.0.0"
-      gem "foo", "1.0.0", "x64-mingw32"
-      gem "foo", "1.1.0"
-      gem "foo", "1.1.0", "x64-mingw32" do |s|
-        s.required_ruby_version = [">= 2.0", "< 2.4"]
+  context "when the platform specific gem doesn't match the required_ruby_version" do
+    before do
+      @index = build_index do
+        gem "foo", "1.0.0"
+        gem "foo", "1.0.0", "x64-mingw32"
+        gem "foo", "1.1.0"
+        gem "foo", "1.1.0", "x64-mingw32" do |s|
+          s.required_ruby_version = [">= 2.0", "< 2.4"]
+        end
+        gem "Ruby\0", "2.5.1"
       end
-      gem "Ruby\0", "2.5.1"
+      dep "Ruby\0", "2.5.1"
+      platforms "x64-mingw32"
     end
-    dep "foo"
-    dep "Ruby\0", "2.5.1"
-    platforms "x64-mingw32"
 
-    should_resolve_as %w[foo-1.1.0]
+    it "takes the latest ruby gem" do
+      dep "foo"
+
+      should_resolve_as %w[foo-1.1.0]
+    end
+
+    it "takes the latest ruby gem, even if requirement does not match previous versions with the same ruby requirement" do
+      dep "foo", "1.1.0"
+
+      should_resolve_as %w[foo-1.1.0]
+    end
   end
 
   it "takes the latest ruby gem with required_ruby_version if the platform specific gem doesn't match the required_ruby_version" do

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -298,10 +298,6 @@ module Spec
       end
     end
 
-    def build_dep(name, requirements = Gem::Requirement.default, type = :runtime)
-      Bundler::Dependency.new(name, :version => requirements)
-    end
-
     def build_lib(name, *args, &blk)
       build_with(LibBuilder, name, args, &blk)
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In certain cases, for example, when exactly pinning `nokogiri` in a `Gemfile` to `1.13.10`, on Ruby 3.2, Bundler would not be able to properly fallback to the generic Ruby version when necessary (like here).

We did have some specs checking this, but not this particular situation. For example, in a similar situation, but using an open requirement instead of an exact requirement, Bundler does properly fallback, and we do have tests for that.

## What is your fix for the problem, implemented in this PR?

For this kind of platform fallback, we use the trick of considering `1.13.10` and `1.13.10-x86_64-linux` as separate versions, and the latter being "higher" than the former, in the sense that it's considered for resolution first even if they both have the same version.

However, we were considering these two separate resolution candidates when retrieving all possible versions for a gem, but not when creating version ranges for dependencies.

This PR ammends version range creation for dependencies, so that the ranges created properly include both generic variants and platform specific variants.

Fixes #6237.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
