### PR TITLE
Tag specs that use the internet as realworld

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,10 @@ To run the entire bundler test suite in parallel (it takes a while):
 
     bin/parallel_rspec
 
+There are some realworld higher level specs run in CI, but not run by `bin/parallel_rspec`. You can run those with:
+
+    bin/rake spec:realworld
+
 To run an individual test file location for example in `spec/install/gems/standalone_spec.rb` you can use:
 
     bin/rspec spec/install/gems/standalone_spec.rb

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,10 +80,6 @@ To run the entire bundler test suite in parallel (it takes a while):
 
     bin/parallel_rspec
 
-To run the entire bundler test suite sequentially (get a coffee because it's very slow):
-
-    bin/rspec
-
 To run an individual test file location for example in `spec/install/gems/standalone_spec.rb` you can use:
 
     bin/rspec spec/install/gems/standalone_spec.rb

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,15 +56,15 @@ To run commands like `bundle install` from the repo:
 
 ### Running Tests
 
-To run the entire test suite you can use: 
+To run the entire test suite you can use:
 
     rake test
 
-To run an individual test file located for example in `test/rubygems/test_deprecate.rb` you can use: 
+To run an individual test file located for example in `test/rubygems/test_deprecate.rb` you can use:
 
     ruby -Ilib:test:bundler/lib test/rubygems/test_deprecate.rb
-    
-And to run an individual test method named `test_default` within a test file, you can use: 
+
+And to run an individual test method named `test_default` within a test file, you can use:
 
     ruby -Ilib:test:bundler/lib test/rubygems/test_deprecate.rb -n /test_default/
 

--- a/bundler/spec/commands/add_spec.rb
+++ b/bundler/spec/commands/add_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe "bundle add" do
   end
 
   describe "with --github" do
-    it "adds dependency with specified github source" do
+    it "adds dependency with specified github source", :realworld do
       bundle "add rake --github=ruby/rake"
 
       expect(bundled_app_gemfile.read).to match(%r{gem "rake", "~> 13\.0", :github => "ruby\/rake"})
@@ -152,7 +152,7 @@ RSpec.describe "bundle add" do
   end
 
   describe "with --github and --branch" do
-    it "adds dependency with specified github source and branch" do
+    it "adds dependency with specified github source and branch", :realworld do
       bundle "add rake --github=ruby/rake --branch=master"
 
       expect(bundled_app_gemfile.read).to match(%r{gem "rake", "~> 13\.0", :github => "ruby\/rake", :branch => "master"})
@@ -160,7 +160,7 @@ RSpec.describe "bundle add" do
   end
 
   describe "with --github and --ref" do
-    it "adds dependency with specified github source and ref" do
+    it "adds dependency with specified github source and ref", :realworld do
       bundle "add rake --github=ruby/rake --ref=5c60da8"
 
       expect(bundled_app_gemfile.read).to match(%r{gem "rake", "~> 13\.0", :github => "ruby\/rake", :ref => "5c60da8"})

--- a/bundler/spec/commands/binstubs_spec.rb
+++ b/bundler/spec/commands/binstubs_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe "bundle binstubs <gem>" do
             lockfile lockfile.gsub(/BUNDLED WITH\n   .*$/m, "BUNDLED WITH\n   2.3.0")
           end
 
-          it "installs and runs the exact version of bundler", :rubygems => ">= 3.3.0.dev" do
+          it "installs and runs the exact version of bundler", :rubygems => ">= 3.3.0.dev", :realworld => true do
             sys_exec "bin/bundle install --verbose", :artifice => "vcr"
             expect(exitstatus).not_to eq(42)
             expect(out).to include("Bundler 2.999.999 is running, but your lockfile was generated with 2.3.0. Installing Bundler 2.3.0 and restarting using that version.")
@@ -224,7 +224,7 @@ RSpec.describe "bundle binstubs <gem>" do
       context "when update --bundler is called" do
         before { lockfile.gsub(system_bundler_version, "1.1.1") }
 
-        it "calls through to the latest bundler version" do
+        it "calls through to the latest bundler version", :realworld do
           sys_exec "bin/bundle update --bundler", :env => { "DEBUG" => "1" }
           using_bundler_line = /Using bundler ([\w\.]+)\n/.match(out)
           expect(using_bundler_line).to_not be_nil

--- a/bundler/spec/commands/clean_spec.rb
+++ b/bundler/spec/commands/clean_spec.rb
@@ -625,7 +625,7 @@ RSpec.describe "bundle clean" do
     expect(out).to eq("1.0")
   end
 
-  it "when using --force, it doesn't remove default gem binaries" do
+  it "when using --force, it doesn't remove default gem binaries", :realworld do
     skip "does not work on old rubies because the realworld gems that need to be installed don't support them" if RUBY_VERSION < "2.7.0"
 
     skip "does not work on rubygems versions where `--install_dir` doesn't respect --default" unless Gem::Installer.for_spec(loaded_gemspec, :install_dir => "/foo").default_spec_file == "/foo/specifications/default/bundler-#{Bundler::VERSION}.gemspec" # Since rubygems 3.2.0.rc.2

--- a/bundler/spec/commands/viz_spec.rb
+++ b/bundler/spec/commands/viz_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "bundle viz", :bundler => "< 3", :if => Bundler.which("dot") do
+RSpec.describe "bundle viz", :bundler => "< 3", :if => Bundler.which("dot"), :realworld => true do
   before do
     realworld_system_gems "ruby-graphviz --version 1.2.5"
   end

--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -157,7 +157,7 @@ RSpec.shared_examples "bundle install --standalone" do
       bundle "lock", :dir => cwd, :artifice => "compact_index"
     end
 
-    it "works and points to the vendored copies, not to the default copies" do
+    it "works and points to the vendored copies, not to the default copies", :realworld do
       bundle "config set --local path #{bundled_app("bundle")}"
       bundle :install, :standalone => true, :dir => cwd, :artifice => "compact_index", :env => { "BUNDLER_GEM_DEFAULT_DIR" => system_gem_path.to_s }
 

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -587,7 +587,7 @@ RSpec.describe "major deprecations" do
     pending "fails with a helpful message", :bundler => "3"
   end
 
-  context "bundle viz" do
+  context "bundle viz", :realworld do
     before do
       realworld_system_gems "ruby-graphviz --version 1.2.5"
       create_file "gems.rb", "source \"#{file_uri_for(gem_repo1)}\""

--- a/bundler/spec/runtime/inline_spec.rb
+++ b/bundler/spec/runtime/inline_spec.rb
@@ -436,7 +436,7 @@ RSpec.describe "bundler/inline#gemfile" do
     expect(err).to be_empty
   end
 
-  it "when requiring fileutils after does not show redefinition warnings" do
+  it "when requiring fileutils after does not show redefinition warnings", :realworld do
     dependency_installer_loads_fileutils = ruby "require 'rubygems/dependency_installer'; puts $LOADED_FEATURES.grep(/fileutils/)", :raise_on_error => false
     skip "does not work if rubygems/dependency_installer loads fileutils, which happens until rubygems 3.2.0" unless dependency_installer_loads_fileutils.empty?
 


### PR DESCRIPTION
Now, after a successful run of `bin/rake spec:parallel_deps` (with internet), `bin/parallel_rspec` should fully pass (without internet).


## What was the end-user or developer problem that led to this PR?

This is no big deal but when I work from a train in Bundler, it's nice that specs pass without internet.

## What is your fix for the problem, implemented in this PR?

This PR tries to tag the few specs that currently need an internet connection as realworld, so that the base `bin/parallel_rspec` task passes without internet.

Closes https://github.com/rubygems/rubygems/issues/5178.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
