### PR TITLE
Changelogs for RubyGems 3.4.3 and Bundler 2.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 3.4.3 / 2023-01-06
+
+## Enhancements:
+
+* Installs bundler 2.4.3 as a default gem.
+
+## Documentation:
+
+* Fix several typos. Pull request #6224 by jdufresne
+
 # 3.4.2 / 2023-01-01
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 2.4.3 (January 6, 2023)
+
+## Enhancements:
+
+  - Enhance `bundle open` command to allow opening subdir/file of gem [#6146](https://github.com/rubygems/rubygems/pull/6146)
+
+## Bug fixes:
+
+  - Fix pointing GitHub sources to PRs [#6241](https://github.com/rubygems/rubygems/pull/6241)
+  - Fix version ranges incorrectly handling platforms [#6240](https://github.com/rubygems/rubygems/pull/6240)
+  - Cleanup unnecessary gems when removing lockfile platforms [#6234](https://github.com/rubygems/rubygems/pull/6234)
+  - When auto-removing RUBY platform don't add specific platform if not needed [#6233](https://github.com/rubygems/rubygems/pull/6233)
+  - Fallback to selecting installable candidates if possible when materializing specs [#6225](https://github.com/rubygems/rubygems/pull/6225)
+
+## Documentation:
+
+  - Fix several typos [#6224](https://github.com/rubygems/rubygems/pull/6224)
+
 # 2.4.2 (January 1, 2023)
 
 ## Performance:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.4.3 and Bundler 2.4.3 into master.