### PR TITLE
Optimistically exclude prereleases from initial resolution

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -484,7 +484,7 @@ module Bundler
       @resolution_packages ||= begin
         last_resolve = converge_locked_specs
         remove_ruby_from_platforms_if_necessary!(current_dependencies)
-        packages = Resolver::Base.new(source_requirements, expanded_dependencies, last_resolve, @platforms, :locked_specs => @originally_locked_specs, :unlock => @unlock[:gems])
+        packages = Resolver::Base.new(source_requirements, expanded_dependencies, last_resolve, @platforms, :locked_specs => @originally_locked_specs, :unlock => @unlock[:gems], :prerelease => gem_version_promoter.pre?)
         additional_base_requirements_for_resolve(packages, last_resolve)
       end
     end

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -473,11 +473,7 @@ module Bundler
     private
 
     def resolver
-      @resolver ||= begin
-        last_resolve = converge_locked_specs
-        remove_ruby_from_platforms_if_necessary!(current_dependencies)
-        Resolver.new(source_requirements, last_resolve, gem_version_promoter, additional_base_requirements_for_resolve(last_resolve))
-      end
+      @resolver ||= Resolver.new(resolution_packages, gem_version_promoter)
     end
 
     def expanded_dependencies
@@ -486,18 +482,10 @@ module Bundler
 
     def resolution_packages
       @resolution_packages ||= begin
-        packages = Hash.new do |h, k|
-          h[k] = Resolver::Package.new(k, @platforms, @originally_locked_specs, @unlock[:gems])
-        end
-
-        expanded_dependencies.each do |dep|
-          name = dep.name
-          platforms = dep.gem_platforms(@platforms)
-
-          packages[name] = Resolver::Package.new(name, platforms, @originally_locked_specs, @unlock[:gems], :dependency => dep)
-        end
-
-        packages
+        last_resolve = converge_locked_specs
+        remove_ruby_from_platforms_if_necessary!(current_dependencies)
+        packages = Resolver::Base.new(source_requirements, expanded_dependencies, last_resolve, @platforms, :locked_specs => @originally_locked_specs, :unlock => @unlock[:gems])
+        additional_base_requirements_for_resolve(packages, last_resolve)
       end
     end
 
@@ -531,13 +519,14 @@ module Bundler
         break if incomplete_specs.empty?
 
         Bundler.ui.debug("The lockfile does not have all gems needed for the current platform though, Bundler will still re-resolve dependencies")
-        @resolve = start_resolution(:exclude_specs => incomplete_specs)
+        resolution_packages.delete(incomplete_specs)
+        @resolve = start_resolution
         specs = resolve.materialize(dependencies)
 
         still_incomplete_specs = specs.incomplete_specs
 
         if still_incomplete_specs == incomplete_specs
-          package = resolution_packages[incomplete_specs.first.name]
+          package = resolution_packages.get_package(incomplete_specs.first.name)
           resolver.raise_not_found! package
         end
 
@@ -550,8 +539,8 @@ module Bundler
       specs
     end
 
-    def start_resolution(exclude_specs: [])
-      result = resolver.start(expanded_dependencies, resolution_packages, :exclude_specs => exclude_specs)
+    def start_resolution
+      result = resolver.start(expanded_dependencies)
 
       SpecSet.new(SpecSet.new(result).for(dependencies, false, @platforms))
     end
@@ -885,11 +874,12 @@ module Bundler
       current == proposed
     end
 
-    def additional_base_requirements_for_resolve(last_resolve)
-      return [] unless @locked_gems && unlocking? && !sources.expired_sources?(@locked_gems.sources)
-      converge_specs(@originally_locked_specs - last_resolve).map do |locked_spec|
-        Dependency.new(locked_spec.name, ">= #{locked_spec.version}")
-      end.uniq
+    def additional_base_requirements_for_resolve(resolution_packages, last_resolve)
+      return resolution_packages unless @locked_gems && unlocking? && !sources.expired_sources?(@locked_gems.sources)
+      converge_specs(@originally_locked_specs - last_resolve).each do |locked_spec|
+        resolution_packages.base_requirements[locked_spec.name] = Gem::Requirement.new(">= #{locked_spec.version}")
+      end
+      resolution_packages
     end
 
     def remove_ruby_from_platforms_if_necessary!(dependencies)

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -9,26 +9,21 @@ module Bundler
   class Resolver
     require_relative "vendored_pub_grub"
     require_relative "resolver/base"
-    require_relative "resolver/package"
     require_relative "resolver/candidate"
     require_relative "resolver/incompatibility"
     require_relative "resolver/root"
 
     include GemHelpers
 
-    def initialize(source_requirements, base, gem_version_promoter, additional_base_requirements)
-      @source_requirements = source_requirements
-      @base = Resolver::Base.new(base, additional_base_requirements)
+    def initialize(base, gem_version_promoter)
+      @source_requirements = base.source_requirements
+      @base = base
       @gem_version_promoter = gem_version_promoter
     end
 
-    def start(requirements, packages, exclude_specs: [])
-      exclude_specs.each do |spec|
-        remove_from_candidates(spec)
-      end
-
+    def start(requirements)
       @requirements = requirements
-      @packages = packages
+      @packages = @base.packages
 
       root, logger = setup_solver
 
@@ -302,10 +297,6 @@ module Bundler
 
     def base_requirements
       @base.base_requirements
-    end
-
-    def remove_from_candidates(spec)
-      @base.delete(spec)
     end
 
     def prepare_dependencies(requirements, packages)

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -73,33 +73,26 @@ module Bundler
     rescue PubGrub::SolveFailure => e
       incompatibility = e.incompatibility
 
-      names_to_unlock = []
-      extended_explanation = nil
+      names_to_unlock, names_to_allow_prereleases_for, extended_explanation = find_names_to_relax(incompatibility)
 
-      while incompatibility.conflict?
-        cause = incompatibility.cause
-        incompatibility = cause.incompatibility
+      names_to_relax = names_to_unlock + names_to_allow_prereleases_for
 
-        incompatibility.terms.each do |term|
-          name = term.package.name
-          names_to_unlock << name if base_requirements[name]
+      if names_to_relax.any?
+        if names_to_unlock.any?
+          Bundler.ui.debug "Found conflicts with locked dependencies. Will retry with #{names_to_unlock.join(", ")} unlocked...", true
 
-          no_versions_incompat = [cause.incompatibility, cause.satisfier].find {|incompat| incompat.cause.is_a?(PubGrub::Incompatibility::NoVersions) }
-          next unless no_versions_incompat
-
-          extended_explanation = no_versions_incompat.extended_explanation
+          @base.unlock_names(names_to_unlock)
         end
-      end
 
-      names_to_unlock.uniq!
+        if names_to_allow_prereleases_for.any?
+          Bundler.ui.debug "Found conflicts with dependencies with prereleases. Will retrying considering prereleases for #{names_to_allow_prereleases_for.join(", ")}...", true
 
-      if names_to_unlock.any?
-        Bundler.ui.debug "Found conflicts with locked dependencies. Retrying with #{names_to_unlock.join(", ")} unlocked...", true
-
-        @base.unlock_names(names_to_unlock)
+          @base.include_prereleases(names_to_allow_prereleases_for)
+        end
 
         root, logger = setup_solver
 
+        Bundler.ui.debug "Retrying resolution...", true
         retry
       end
 
@@ -111,6 +104,35 @@ module Bundler
       end
 
       raise SolveFailure.new(explanation)
+    end
+
+    def find_names_to_relax(incompatibility)
+      names_to_unlock = []
+      names_to_allow_prereleases_for = []
+      extended_explanation = nil
+
+      while incompatibility.conflict?
+        cause = incompatibility.cause
+        incompatibility = cause.incompatibility
+
+        incompatibility.terms.each do |term|
+          package = term.package
+          name = package.name
+
+          if base_requirements[name]
+            names_to_unlock << name
+          elsif package.ignores_prereleases?
+            names_to_allow_prereleases_for << name
+          end
+
+          no_versions_incompat = [cause.incompatibility, cause.satisfier].find {|incompat| incompat.cause.is_a?(PubGrub::Incompatibility::NoVersions) }
+          next unless no_versions_incompat
+
+          extended_explanation = no_versions_incompat.extended_explanation
+        end
+      end
+
+      [names_to_unlock.uniq, names_to_allow_prereleases_for.uniq, extended_explanation]
     end
 
     def parse_dependency(package, dependency)
@@ -210,7 +232,7 @@ module Bundler
 
     def all_versions_for(package)
       name = package.name
-      results = (@base[name] + @all_specs[name]).uniq {|spec| [spec.version.hash, spec.platform] }
+      results = (@base[name] + filter_prereleases(@all_specs[name], package)).uniq {|spec| [spec.version.hash, spec.platform] }
       locked_requirement = base_requirements[name]
       results = filter_matching_specs(results, locked_requirement) if locked_requirement
 
@@ -279,6 +301,12 @@ module Bundler
       end
     end
 
+    def filter_prereleases(specs, package)
+      return specs unless package.ignores_prereleases?
+
+      specs.reject {|s| s.version.prerelease? }
+    end
+
     def requirement_satisfied_by?(requirement, spec)
       requirement.satisfied_by?(spec.version) || spec.source.is_a?(Source::Gemspec)
     end
@@ -313,7 +341,15 @@ module Bundler
         end
 
         next [dep_package, dep_constraint] if name == "bundler"
-        next [dep_package, dep_constraint] unless versions_for(dep_package, dep_constraint.range).empty?
+
+        versions = versions_for(dep_package, dep_constraint.range)
+        if versions.empty? && dep_package.ignores_prereleases?
+          @sorted_versions.delete(dep_package)
+          dep_package.consider_prereleases!
+          versions = versions_for(dep_package, dep_constraint.range)
+        end
+        next [dep_package, dep_constraint] unless versions.empty?
+
         next unless dep_package.current_platform?
 
         raise_not_found!(dep_package)

--- a/bundler/lib/bundler/resolver/base.rb
+++ b/bundler/lib/bundler/resolver/base.rb
@@ -49,6 +49,12 @@ module Bundler
         end
       end
 
+      def include_prereleases(names)
+        names.each do |name|
+          get_package(name).consider_prereleases!
+        end
+      end
+
       private
 
       def build_base_requirements

--- a/bundler/lib/bundler/resolver/base.rb
+++ b/bundler/lib/bundler/resolver/base.rb
@@ -1,19 +1,40 @@
 # frozen_string_literal: true
 
+require_relative "package"
+
 module Bundler
   class Resolver
     class Base
-      def initialize(base, additional_base_requirements)
+      attr_reader :packages, :source_requirements
+
+      def initialize(source_requirements, dependencies, base, platforms, options)
+        @source_requirements = source_requirements
+
         @base = base
-        @additional_base_requirements = additional_base_requirements
+
+        @packages = Hash.new do |hash, name|
+          hash[name] = Package.new(name, platforms, **options)
+        end
+
+        dependencies.each do |dep|
+          name = dep.name
+
+          @packages[name] = Package.new(name, dep.gem_platforms(platforms), **options.merge(:dependency => dep))
+        end
       end
 
       def [](name)
         @base[name]
       end
 
-      def delete(spec)
-        @base.delete(spec)
+      def delete(specs)
+        specs.each do |spec|
+          @base.delete(spec)
+        end
+      end
+
+      def get_package(name)
+        @packages[name]
       end
 
       def base_requirements
@@ -24,10 +45,8 @@ module Bundler
         names.each do |name|
           @base.delete_by_name(name)
 
-          @additional_base_requirements.reject! {|dep| dep.name == name }
+          @base_requirements.delete(name)
         end
-
-        @base_requirements = nil
       end
 
       private
@@ -38,7 +57,6 @@ module Bundler
           req = Gem::Requirement.new(ls.version)
           base_requirements[ls.name] = req
         end
-        @additional_base_requirements.each {|d| base_requirements[d.name] = d.requirement }
         base_requirements
       end
     end

--- a/bundler/lib/bundler/resolver/package.rb
+++ b/bundler/lib/bundler/resolver/package.rb
@@ -15,7 +15,7 @@ module Bundler
     class Package
       attr_reader :name, :platforms, :dependency, :locked_version
 
-      def initialize(name, platforms, locked_specs, unlock, dependency: nil)
+      def initialize(name, platforms, locked_specs:, unlock:, dependency: nil)
         @name = name
         @platforms = platforms
         @locked_version = locked_specs[name].first&.version

--- a/bundler/lib/bundler/resolver/package.rb
+++ b/bundler/lib/bundler/resolver/package.rb
@@ -15,12 +15,13 @@ module Bundler
     class Package
       attr_reader :name, :platforms, :dependency, :locked_version
 
-      def initialize(name, platforms, locked_specs:, unlock:, dependency: nil)
+      def initialize(name, platforms, locked_specs:, unlock:, prerelease: false, dependency: nil)
         @name = name
         @platforms = platforms
         @locked_version = locked_specs[name].first&.version
         @unlock = unlock
         @dependency = dependency || Dependency.new(name, @locked_version)
+        @prerelease = @dependency.prerelease? || @locked_version&.prerelease? || prerelease ? :consider_first : :ignore
       end
 
       def to_s
@@ -47,8 +48,16 @@ module Bundler
         @unlock.empty? || @unlock.include?(name)
       end
 
+      def ignores_prereleases?
+        @prerelease == :ignore
+      end
+
       def prerelease_specified?
-        @dependency.prerelease?
+        @prerelease == :consider_first
+      end
+
+      def consider_prereleases!
+        @prerelease = :consider_last
       end
 
       def force_ruby_platform?

--- a/bundler/spec/realworld/edgecases_spec.rb
+++ b/bundler/spec/realworld/edgecases_spec.rb
@@ -323,7 +323,7 @@ RSpec.describe "real world edgecases", :realworld => true do
     if Bundler.feature_flag.bundler_3_mode?
       # Conflicts on bundler version, so we count attempts differently
       bundle :lock, :env => { "DEBUG_RESOLVER" => "1" }, :raise_on_error => false
-      expect(out.split("\n").grep(/backtracking to/).count).to eq(8)
+      expect(out.split("\n").grep(/backtracking to/).count).to eq(16)
     else
       bundle :lock, :env => { "DEBUG_RESOLVER" => "1" }
       expect(out).to include("Solution found after 7 attempts")

--- a/bundler/spec/support/indexes.rb
+++ b/bundler/spec/support/indexes.rb
@@ -21,19 +21,14 @@ module Spec
       base = args[0] || Bundler::SpecSet.new([])
       base.each {|ls| ls.source = default_source }
       gem_version_promoter = args[1] || Bundler::GemVersionPromoter.new
-      additional_base_requirements = args[2] || []
-      originally_locked = args[3] || Bundler::SpecSet.new([])
-      unlock = args[4] || []
-      packages = Hash.new do |h, k|
-        h[k] = Bundler::Resolver::Package.new(k, @platforms, originally_locked, unlock)
-      end
+      originally_locked = args[2] || Bundler::SpecSet.new([])
+      unlock = args[3] || []
       @deps.each do |d|
         name = d.name
-        platforms = d.gem_platforms(@platforms)
         source_requirements[name] = d.source = default_source
-        packages[name] = Bundler::Resolver::Package.new(name, platforms, originally_locked, unlock, :dependency => d)
       end
-      Bundler::Resolver.new(source_requirements, base, gem_version_promoter, additional_base_requirements).start(@deps, packages)
+      packages = Bundler::Resolver::Base.new(source_requirements, @deps, base, @platforms, :locked_specs => originally_locked, :unlock => unlock)
+      Bundler::Resolver.new(packages, gem_version_promoter).start(@deps)
     end
 
     def should_not_resolve
@@ -71,7 +66,7 @@ module Spec
         s.level = opts.first
         s.strict = opts.include?(:strict)
       end
-      should_resolve_and_include specs, [@base, search, [], @locked, unlock]
+      should_resolve_and_include specs, [@base, search, @locked, unlock]
     end
 
     def an_awesome_index

--- a/bundler/spec/support/indexes.rb
+++ b/bundler/spec/support/indexes.rb
@@ -18,10 +18,10 @@ module Spec
       @platforms ||= ["ruby"]
       default_source = instance_double("Bundler::Source::Rubygems", :specs => @index, :to_s => "locally install gems")
       source_requirements = { :default => default_source }
-      args[0] ||= Bundler::SpecSet.new([]) # base
-      args[0].each {|ls| ls.source = default_source }
-      args[1] ||= Bundler::GemVersionPromoter.new # gem_version_promoter
-      args[2] ||= [] # additional_base_requirements
+      base = args[0] || Bundler::SpecSet.new([])
+      base.each {|ls| ls.source = default_source }
+      gem_version_promoter = args[1] || Bundler::GemVersionPromoter.new
+      additional_base_requirements = args[2] || []
       originally_locked = args[3] || Bundler::SpecSet.new([])
       unlock = args[4] || []
       packages = Hash.new do |h, k|
@@ -33,7 +33,7 @@ module Spec
         source_requirements[name] = d.source = default_source
         packages[name] = Bundler::Resolver::Package.new(name, platforms, originally_locked, unlock, :dependency => d)
       end
-      Bundler::Resolver.new(source_requirements, *args[0..2]).start(@deps, packages)
+      Bundler::Resolver.new(source_requirements, base, gem_version_promoter, additional_base_requirements).start(@deps, packages)
     end
 
     def should_not_resolve


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes, resolution may end up choosing a prerelease version, but normally end users do not want prereleases at all, unless they explicitly request them.

## What is your fix for the problem, implemented in this PR?

Do an optimistic first pass that resolves without prereleases. This should work in most cases, since normally resolutions don't need prereleases. Only if that fails, do a second pass considering prereleases.

This should also speed up most resolutions, since the search space is greatly reduced by default. As an example, Rails has 437 releases as of today, and 162 of them are prereleases.

Fixes #6226.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
