### PR TITLE
Test Bundler against bundled RubyGems for each Ruby

### DIFF
--- a/.github/workflows/realworld-bundler.yml
+++ b/.github/workflows/realworld-bundler.yml
@@ -68,29 +68,22 @@ jobs:
           path: ./bundler/spec/support/artifice/used_cassettes.txt
     timeout-minutes: 20
 
-  older_rubygems_bundler:
-    name: Realworld Bundler ${{ matrix.bundler.name }} against old Rubygems (${{ matrix.ruby.name }}, ${{ matrix.rgv.name }})
+  system_rubygems_bundler:
+    name: Realworld Bundler ${{ matrix.bundler.name }} against system Rubygems (${{ matrix.ruby.name }})
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.6, value: 2.6.10 }, rgv: { name: rgv-3.0, value: v3.0.9 } }
-          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.7 }, rgv: { name: rgv-3.1, value: v3.1.6 } }
-          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.5 }, rgv: { name: rgv-3.2, value: v3.2.33 } }
-          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.3 }, rgv: { name: rgv-3.3, value: v3.3.5 } }
-          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.7, value: 2.7.7 }, rgv: { name: rgv-3.1, value: v3.1.6 } }
-          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.0, value: 3.0.5 }, rgv: { name: rgv-3.2, value: v3.2.33 } }
-          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.1, value: 3.1.3 }, rgv: { name: rgv-3.3, value: v3.3.5 } }
-    env:
-      RGV: ${{ matrix.rgv.value }}
-      RUBYOPT: --disable-gems
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.6, value: 2.6.10 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.7 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.5 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.3 } }
+          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.7, value: 2.7.7 } }
+          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.0, value: 3.0.5 } }
+          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.1, value: 3.1.3 } }
     steps:
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
-      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
-        with:
-          path: bundler/tmp/rubygems
-          ref: ${{ matrix.rgv.value }}
       - name: Setup ruby
         uses: ruby/setup-ruby@09c10210cc6e998d842ce8433cd9d245933cd797 # v1.133.0
         with:
@@ -109,13 +102,13 @@ jobs:
       - name: Upload used cassettes as artifact
         uses: actions/upload-artifact@v3
         with:
-          name: cassettes-old-rubygems-bundler-${{ matrix.bundler.name }}-${{ matrix.rgv.name }}-${{ matrix.ruby.name }}
+          name: cassettes-system-rubygems-bundler-${{ matrix.bundler.name }}-${{ matrix.ruby.name }}
           path: ./bundler/spec/support/artifice/used_cassettes.txt
     timeout-minutes: 20
 
   check_unused_cassettes:
     name: Check unused cassettes
-    needs: [bundler, older_rubygems_bundler]
+    needs: [bundler, system_rubygems_bundler]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0

--- a/.github/workflows/system-rubygems-bundler.yml
+++ b/.github/workflows/system-rubygems-bundler.yml
@@ -1,10 +1,10 @@
-name: older-rubygems-bundler
+name: system-rubygems-bundler
 
 on:
   pull_request:
     paths:
       - bundler/**
-      - .github/workflows/older-rubygems-bundler.yml
+      - .github/workflows/system-rubygems-bundler.yml
       - .rubocop_bundler.yml
 
   push:
@@ -24,29 +24,22 @@ defaults:
     working-directory: ./bundler
 
 jobs:
-  older_rubygems_bundler:
-    name: Bundler ${{ matrix.bundler.name }} against old Rubygems (${{ matrix.ruby.name }}, ${{ matrix.rgv.name }})
+  system_rubygems_bundler:
+    name: Bundler ${{ matrix.bundler.name }} against system Rubygems (${{ matrix.ruby.name }})
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.6, value: 2.6.10 }, rgv: { name: rgv-3.0, value: v3.0.9 } }
-          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.7 }, rgv: { name: rgv-3.1, value: v3.1.6 } }
-          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.5 }, rgv: { name: rgv-3.2, value: v3.2.33 } }
-          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.3 }, rgv: { name: rgv-3.3, value: v3.3.5 } }
-          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.7, value: 2.7.7 }, rgv: { name: rgv-3.1, value: v3.1.6 } }
-          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.0, value: 3.0.5 }, rgv: { name: rgv-3.2, value: v3.2.33 } }
-          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.1, value: 3.1.3 }, rgv: { name: rgv-3.3, value: v3.3.5 } }
-    env:
-      RGV: ${{ matrix.rgv.value }}
-      RUBYOPT: --disable-gems
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.6, value: 2.6.10 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.7 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.5 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.3 } }
+          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.7, value: 2.7.7 } }
+          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.0, value: 3.0.5 } }
+          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.1, value: 3.1.3 } }
     steps:
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
-      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
-        with:
-          path: bundler/tmp/rubygems
-          ref: ${{ matrix.rgv.value }}
       - name: Setup ruby
         uses: ruby/setup-ruby@09c10210cc6e998d842ce8433cd9d245933cd797 # v1.133.0
         with:
@@ -64,6 +57,14 @@ jobs:
       - name: Run Test
         run: |
           bin/parallel_rspec
+      - name: Save system RubyGems version to ENV
+        run: |
+          RGV=$(ruby -e 'puts Gem::VERSION.split(".")[0..2].join(".")')
+          echo "RGV=v$RGV" >> $GITHUB_ENV
+      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+        with:
+          path: bundler/tmp/rubygems
+          ref: ${{ env.RGV }}
       - name: Run Rubygems Requirement tests against local bundler, to make sure bundler monkeypatches preserve the behaviour
         run: |
           ruby -I../../lib:lib:test test/rubygems/test_gem_requirement.rb


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We've been testing against fixed RubyGems versions that match the version of RubyGems that comes by default with each Ruby version.
    
I think it's easier and more realistic to test directly against the system version.

## What is your fix for the problem, implemented in this PR?

Just let the default RubyGems that comes with Ruby be used for these tests.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
