### PR TITLE
Skip setting `BUNDLER_SETUP` on Ruby 2.6

### DIFF
--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -284,7 +284,7 @@ module Bundler
       Bundler::SharedHelpers.set_env "BUNDLE_BIN_PATH", exe_file
       Bundler::SharedHelpers.set_env "BUNDLE_GEMFILE", find_gemfile.to_s
       Bundler::SharedHelpers.set_env "BUNDLER_VERSION", Bundler::VERSION
-      Bundler::SharedHelpers.set_env "BUNDLER_SETUP", File.expand_path("setup", __dir__)
+      Bundler::SharedHelpers.set_env "BUNDLER_SETUP", File.expand_path("setup", __dir__) unless RUBY_VERSION < "2.7"
     end
 
     def set_path

--- a/bundler/spec/bundler/shared_helpers_spec.rb
+++ b/bundler/spec/bundler/shared_helpers_spec.rb
@@ -248,6 +248,8 @@ RSpec.describe Bundler::SharedHelpers do
 
     shared_examples_for "ENV['BUNDLER_SETUP'] gets set correctly" do
       it "ensures bundler/setup is set in ENV['BUNDLER_SETUP']" do
+        skip "Does not play well with DidYouMean being a bundled gem instead of a default gem in Ruby 2.6" if RUBY_VERSION < "2.7"
+
         subject.set_bundle_environment
         expect(ENV["BUNDLER_SETUP"]).to eq("#{source_lib_dir}/bundler/setup")
       end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Setting `BUNDLER_SETUP` on `bundle exec` so that RubyGems can setup the bundle early in the subprocess breaks loading DidYouMean on Ruby 2.6, since it was a bundled (not default) gem there, and thus gets "erased" by `bundler/setup`.
 
## What is your fix for the problem, implemented in this PR?

Skip this feature on Ruby 2.6.

Closes #6251.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
