### PR TITLE
Enable full RSpec backtraces

### DIFF
--- a/bundler/.rspec
+++ b/bundler/.rspec
@@ -1,4 +1,5 @@
 --color
 --warnings
+--backtrace
 --require spec_helper
 --order random


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I sometimes need to manually use this option because backtraces don't give me the full info. I'd like to get this by default. I think this is not the default because Rails backtraces can get very big but I believe for our case full backtraces are fine.

## What is your fix for the problem, implemented in this PR?

Enable the flag by default.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
