### PR TITLE
Fix another case of not properly falling back to ruby variant when materializing

### DIFF
--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -89,7 +89,7 @@ module Bundler
 
         installable_candidates = GemHelpers.select_best_platform_match(matching_specs, target_platform)
 
-        specification = __materialize__(installable_candidates)
+        specification = __materialize__(installable_candidates, :fallback_to_non_installable => false)
         return specification unless specification.nil?
 
         if target_platform != platform
@@ -102,13 +102,13 @@ module Bundler
       __materialize__(candidates)
     end
 
-    def __materialize__(candidates)
+    def __materialize__(candidates, fallback_to_non_installable: Bundler.frozen_bundle?)
       search = candidates.reverse.find do |spec|
         spec.is_a?(StubSpecification) ||
           (spec.matches_current_ruby? &&
             spec.matches_current_rubygems?)
       end
-      if search.nil? && Bundler.frozen_bundle?
+      if search.nil? && fallback_to_non_installable
         search = candidates.last
       else
         search.dependencies = dependencies if search && search.full_name == full_name && (search.is_a?(RemoteSpecification) || search.is_a?(EndpointSpecification))

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -102,6 +102,11 @@ module Bundler
       __materialize__(candidates)
     end
 
+    # If in frozen mode, we fallback to a non-installable candidate because by
+    # doing this we avoid re-resolving and potentially end up changing the
+    # lock file, which is not allowed. In that case, we will give a proper error
+    # about the mismatch higher up the stack, right before trying to install the
+    # bad gem.
     def __materialize__(candidates, fallback_to_non_installable: Bundler.frozen_bundle?)
       search = candidates.reverse.find do |spec|
         spec.is_a?(StubSpecification) ||

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -6,10 +6,8 @@ RSpec.describe "bundle install with specific platforms" do
     gem "google-protobuf"
   G
 
-  context "when on a darwin machine" do
-    before { simulate_platform "x86_64-darwin-15" }
-
-    it "locks to the specific darwin platform" do
+  it "locks to the specific darwin platform" do
+    simulate_platform "x86_64-darwin-15" do
       setup_multiplatform_gem
       install_gemfile(google_protobuf)
       allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
@@ -19,8 +17,10 @@ RSpec.describe "bundle install with specific platforms" do
         google-protobuf-3.0.0.alpha.5.0.5.1-universal-darwin
       ])
     end
+  end
 
-    it "understands that a non-platform specific gem in a old lockfile doesn't necessarily mean installing the non-specific variant" do
+  it "understands that a non-platform specific gem in a old lockfile doesn't necessarily mean installing the non-specific variant" do
+    simulate_platform "x86_64-darwin-15" do
       setup_multiplatform_gem
 
       system_gems "bundler-2.1.4"
@@ -53,8 +53,10 @@ RSpec.describe "bundle install with specific platforms" do
       # make sure the platform that got actually installed with the old bundler is used
       expect(the_bundle).to include_gem("google-protobuf 3.0.0.alpha.5.0.5.1 universal-darwin")
     end
+  end
 
-    it "understands that a non-platform specific gem in a new lockfile locked only to RUBY doesn't necessarily mean installing the non-specific variant" do
+  it "understands that a non-platform specific gem in a new lockfile locked only to RUBY doesn't necessarily mean installing the non-specific variant" do
+    simulate_platform "x86_64-darwin-15" do
       setup_multiplatform_gem
 
       system_gems "bundler-2.1.4"
@@ -103,49 +105,51 @@ RSpec.describe "bundle install with specific platforms" do
            #{Bundler::VERSION}
       L
     end
+  end
 
-    it "still installs the generic RUBY variant if necessary even when running on a legacy lockfile locked only to RUBY" do
-      build_repo4 do
-        build_gem "nokogiri", "1.3.10"
-        build_gem "nokogiri", "1.3.10" do |s|
-          s.platform = "arm64-darwin"
-          s.required_ruby_version = "< #{Gem.ruby_version}"
-        end
-
-        build_gem "bundler", "2.1.4"
+  it "still installs the generic RUBY variant if necessary even when running on a legacy lockfile locked only to RUBY" do
+    build_repo4 do
+      build_gem "nokogiri", "1.3.10"
+      build_gem "nokogiri", "1.3.10" do |s|
+        s.platform = "arm64-darwin"
+        s.required_ruby_version = "< #{Gem.ruby_version}"
       end
 
-      gemfile <<~G
-        source "#{file_uri_for(gem_repo4)}"
-
-        gem "nokogiri"
-      G
-
-      lockfile <<-L
-        GEM
-          remote: #{file_uri_for(gem_repo4)}/
-          specs:
-            nokogiri (1.3.10)
-
-        PLATFORMS
-          ruby
-
-        DEPENDENCIES
-          nokogiri
-
-        RUBY VERSION
-          2.5.3p105
-
-        BUNDLED WITH
-           2.1.4
-      L
-
-      simulate_platform "arm64-darwin-22" do
-        bundle "update --bundler", :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
-      end
+      build_gem "bundler", "2.1.4"
     end
 
-    it "doesn't discard previously installed platform specific gem and fall back to ruby on subsequent bundles" do
+    gemfile <<~G
+      source "#{file_uri_for(gem_repo4)}"
+
+      gem "nokogiri"
+    G
+
+    lockfile <<-L
+      GEM
+        remote: #{file_uri_for(gem_repo4)}/
+        specs:
+          nokogiri (1.3.10)
+
+      PLATFORMS
+        ruby
+
+      DEPENDENCIES
+        nokogiri
+
+      RUBY VERSION
+        2.5.3p105
+
+      BUNDLED WITH
+         2.1.4
+    L
+
+    simulate_platform "arm64-darwin-22" do
+      bundle "update --bundler", :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+    end
+  end
+
+  it "doesn't discard previously installed platform specific gem and fall back to ruby on subsequent bundles" do
+    simulate_platform "x86_64-darwin-15" do
       build_repo2 do
         build_gem("libv8", "8.4.255.0")
         build_gem("libv8", "8.4.255.0") {|s| s.platform = "universal-darwin" }
@@ -188,8 +192,10 @@ RSpec.describe "bundle install with specific platforms" do
       bundle "add mini_racer --verbose", :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo2.to_s }
       expect(out).to include("Using libv8 8.4.255.0 (universal-darwin)")
     end
+  end
 
-    it "chooses platform specific gems even when resolving upon materialization and the API returns more specific platforms first" do
+  it "chooses platform specific gems even when resolving upon materialization and the API returns more specific platforms first" do
+    simulate_platform "x86_64-darwin-15" do
       build_repo4 do
         build_gem("grpc", "1.50.0")
         build_gem("grpc", "1.50.0") {|s| s.platform = "universal-darwin" }
@@ -220,8 +226,10 @@ RSpec.describe "bundle install with specific platforms" do
       bundle "install --verbose", :artifice => "compact_index_precompiled_before", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
       expect(out).to include("Installing grpc 1.50.0 (universal-darwin)")
     end
+  end
 
-    it "caches the universal-darwin gem when --all-platforms is passed and properly picks it up on further bundler invocations" do
+  it "caches the universal-darwin gem when --all-platforms is passed and properly picks it up on further bundler invocations" do
+    simulate_platform "x86_64-darwin-15" do
       setup_multiplatform_gem
       gemfile(google_protobuf)
       bundle "cache --all-platforms"
@@ -230,8 +238,10 @@ RSpec.describe "bundle install with specific platforms" do
       bundle "install --verbose"
       expect(err).to be_empty
     end
+  end
 
-    it "caches the universal-darwin gem when cache_all_platforms is configured and properly picks it up on further bundler invocations" do
+  it "caches the universal-darwin gem when cache_all_platforms is configured and properly picks it up on further bundler invocations" do
+    simulate_platform "x86_64-darwin-15" do
       setup_multiplatform_gem
       gemfile(google_protobuf)
       bundle "config set --local cache_all_platforms true"
@@ -241,44 +251,46 @@ RSpec.describe "bundle install with specific platforms" do
       bundle "install --verbose"
       expect(err).to be_empty
     end
+  end
 
-    it "caches multiplatform git gems with a single gemspec when --all-platforms is passed" do
-      git = build_git "pg_array_parser", "1.0"
+  it "caches multiplatform git gems with a single gemspec when --all-platforms is passed" do
+    git = build_git "pg_array_parser", "1.0"
 
-      gemfile <<-G
-        source "#{file_uri_for(gem_repo1)}"
-        gem "pg_array_parser", :git => "#{lib_path("pg_array_parser-1.0")}"
-      G
+    gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
+      gem "pg_array_parser", :git => "#{lib_path("pg_array_parser-1.0")}"
+    G
 
-      lockfile <<-L
-        GIT
-          remote: #{lib_path("pg_array_parser-1.0")}
-          revision: #{git.ref_for("main")}
-          specs:
-            pg_array_parser (1.0-java)
-            pg_array_parser (1.0)
+    lockfile <<-L
+      GIT
+        remote: #{lib_path("pg_array_parser-1.0")}
+        revision: #{git.ref_for("main")}
+        specs:
+          pg_array_parser (1.0-java)
+          pg_array_parser (1.0)
 
-        GEM
-          specs:
+      GEM
+        specs:
 
-        PLATFORMS
-          java
-          #{lockfile_platforms}
+      PLATFORMS
+        java
+        #{lockfile_platforms}
 
-        DEPENDENCIES
-          pg_array_parser!
+      DEPENDENCIES
+        pg_array_parser!
 
-        BUNDLED WITH
-           #{Bundler::VERSION}
-      L
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
 
-      bundle "config set --local cache_all true"
-      bundle "cache --all-platforms"
+    bundle "config set --local cache_all true"
+    bundle "cache --all-platforms"
 
-      expect(err).to be_empty
-    end
+    expect(err).to be_empty
+  end
 
-    it "uses the platform-specific gem with extra dependencies" do
+  it "uses the platform-specific gem with extra dependencies" do
+    simulate_platform "x86_64-darwin-15" do
       setup_multiplatform_gem_with_different_dependencies_per_platform
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo2)}"
@@ -291,13 +303,15 @@ RSpec.describe "bundle install with specific platforms" do
       expect(the_bundle.locked_gems.specs.map(&:full_name)).to eq(["CFPropertyList-1.0",
                                                                    "facter-2.4.6-universal-darwin"])
     end
+  end
 
-    context "when adding a platform via lock --add_platform" do
-      before do
-        allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
-      end
+  context "when adding a platform via lock --add_platform" do
+    before do
+      allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+    end
 
-      it "adds the foreign platform" do
+    it "adds the foreign platform" do
+      simulate_platform "x86_64-darwin-15" do
         setup_multiplatform_gem
         install_gemfile(google_protobuf)
         bundle "lock --add-platform=#{x64_mingw32}"
@@ -308,8 +322,10 @@ RSpec.describe "bundle install with specific platforms" do
           google-protobuf-3.0.0.alpha.5.0.5.1-x64-mingw32
         ])
       end
+    end
 
-      it "falls back on plain ruby when that version doesn't have a platform-specific gem" do
+    it "falls back on plain ruby when that version doesn't have a platform-specific gem" do
+      simulate_platform "x86_64-darwin-15" do
         setup_multiplatform_gem
         install_gemfile(google_protobuf)
         bundle "lock --add-platform=#{java}"

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -107,44 +107,52 @@ RSpec.describe "bundle install with specific platforms" do
     end
   end
 
-  it "still installs the generic RUBY variant if necessary even when running on a legacy lockfile locked only to RUBY" do
-    build_repo4 do
-      build_gem "nokogiri", "1.3.10"
-      build_gem "nokogiri", "1.3.10" do |s|
-        s.platform = "arm64-darwin"
-        s.required_ruby_version = "< #{Gem.ruby_version}"
+  context "when running on a legacy lockfile locked only to RUBY" do
+    around do |example|
+      build_repo4 do
+        build_gem "nokogiri", "1.3.10"
+        build_gem "nokogiri", "1.3.10" do |s|
+          s.platform = "arm64-darwin"
+          s.required_ruby_version = "< #{Gem.ruby_version}"
+        end
+
+        build_gem "bundler", "2.1.4"
       end
 
-      build_gem "bundler", "2.1.4"
+      gemfile <<~G
+        source "#{file_uri_for(gem_repo4)}"
+
+        gem "nokogiri"
+      G
+
+      lockfile <<-L
+        GEM
+          remote: #{file_uri_for(gem_repo4)}/
+          specs:
+            nokogiri (1.3.10)
+
+        PLATFORMS
+          ruby
+
+        DEPENDENCIES
+          nokogiri
+
+        RUBY VERSION
+          2.5.3p105
+
+        BUNDLED WITH
+           2.1.4
+      L
+
+      simulate_platform "arm64-darwin-22", &example
     end
 
-    gemfile <<~G
-      source "#{file_uri_for(gem_repo4)}"
-
-      gem "nokogiri"
-    G
-
-    lockfile <<-L
-      GEM
-        remote: #{file_uri_for(gem_repo4)}/
-        specs:
-          nokogiri (1.3.10)
-
-      PLATFORMS
-        ruby
-
-      DEPENDENCIES
-        nokogiri
-
-      RUBY VERSION
-        2.5.3p105
-
-      BUNDLED WITH
-         2.1.4
-    L
-
-    simulate_platform "arm64-darwin-22" do
+    it "still installs the generic RUBY variant if necessary" do
       bundle "update --bundler", :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+    end
+
+    it "still installs the generic RUBY variant if necessary, even in frozen mode" do
+      bundle "update --bundler", :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s, "BUNDLE_FROZEN" => "true" }
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In https://github.com/rubygems/rubygems.org/pull/3332, another case where Bundler is not properly falling back to the generic version of nokogiri was surfaced. It's very similar to #6221, but in frozen mode.

## What is your fix for the problem, implemented in this PR?

My fix is to not materialize to a non installable version in frozen mode when verifying whether we need to fallback to the generic platform.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
