### PR TITLE
Fix platform specific gems removed from the lockfile

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -159,13 +159,6 @@ module Bundler
       resolve
     end
 
-    def resolve_prefering_local!
-      @prefer_local = true
-      @remote = true
-      sources.remote!
-      resolve
-    end
-
     def resolve_with_cache!
       sources.cached!
       resolve
@@ -175,6 +168,23 @@ module Bundler
       @remote = true
       sources.remote!
       resolve
+    end
+
+    def resolution_mode=(options)
+      if options["local"]
+        @remote = false
+      else
+        @remote = true
+        @prefer_local = options["prefer-local"]
+      end
+    end
+
+    def setup_sources_for_resolve
+      if @remote == false
+        sources.cached!
+      else
+        sources.remote!
+      end
     end
 
     # For given dependency list returns a SpecSet with Gemspec of all the required
@@ -519,6 +529,7 @@ module Bundler
         break if incomplete_specs.empty?
 
         Bundler.ui.debug("The lockfile does not have all gems needed for the current platform though, Bundler will still re-resolve dependencies")
+        setup_sources_for_resolve
         resolution_packages.delete(incomplete_specs)
         @resolve = start_resolution
         specs = resolve.materialize(dependencies)

--- a/bundler/lib/bundler/installer.rb
+++ b/bundler/lib/bundler/installer.rb
@@ -249,17 +249,13 @@ module Bundler
 
     # returns whether or not a re-resolve was needed
     def resolve_if_needed(options)
+      @definition.resolution_mode = options
+
       if !@definition.unlocking? && !options["force"] && !Bundler.settings[:inline] && Bundler.default_lockfile.file?
         return false if @definition.nothing_changed? && !@definition.missing_specs?
       end
 
-      if options["local"]
-        @definition.resolve_with_cache!
-      elsif options["prefer-local"]
-        @definition.resolve_prefering_local!
-      else
-        @definition.resolve_remotely!
-      end
+      @definition.setup_sources_for_resolve
 
       true
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If we have a lockfile missing a specific gem for the current platform, and that gem happens to be already installed locally, then Bundler will initially try to use "local mode" and use the existing lockfile exclusively. But then when materializing it will realize that it's missing platform gems and try to re-resolve to fill them in. However, since we initially used "local mode", this resolution will only consider local gems and will result in gems for other platforms being  lost.

## What is your fix for the problem, implemented in this PR?

To fix this, we need to save the resolution mode in the definition early and make sure we set up sources using that mode before re-resolving.

Fixes #6263.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
