### PR TITLE
Fix `--ext=c` generating buggy code

### DIFF
--- a/bundler/lib/bundler/templates/newgem/ext/newgem/newgem.c.tt
+++ b/bundler/lib/bundler/templates/newgem/ext/newgem/newgem.c.tt
@@ -2,8 +2,20 @@
 
 VALUE rb_m<%= config[:constant_array].join %>;
 
+VALUE rb_<%= config[:constant_array].join %>_hello(VALUE self, VALUE str);
+
 void
 Init_<%= config[:underscored_name] %>(void)
 {
   rb_m<%= config[:constant_array].join %> = rb_define_module(<%= config[:constant_name].inspect %>);
+  rb_define_singleton_method(rb_m<%= config[:constant_array].join %>, "hello", rb_<%= config[:constant_array].join %>_hello, 1);
+}
+
+VALUE
+rb_<%= config[:constant_array].join %>_hello(VALUE self, VALUE str)
+{
+  if (RB_TYPE_P(str, T_STRING) == 1) {
+    return rb_sprintf("Hello from C, %s!", StringValueCStr(str));
+  }
+  return Qnil;
 }

--- a/bundler/lib/bundler/templates/newgem/lib/newgem.rb.tt
+++ b/bundler/lib/bundler/templates/newgem/lib/newgem.rb.tt
@@ -2,7 +2,7 @@
 
 require_relative "<%= File.basename(config[:namespaced_path]) %>/version"
 <%- if config[:ext] -%>
-require_relative "<%= File.basename(config[:namespaced_path]) %>/<%= config[:underscored_name] %>"
+require "<%= File.basename(config[:namespaced_path]) %>/<%= config[:underscored_name] %>"
 <%- end -%>
 
 <%- config[:constant_array].each_with_index do |c, i| -%>

--- a/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -35,11 +35,8 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-<%- if config[:ext] == 'c' -%>
+<%- if %w[c rust].include? config[:ext] -%>
   spec.extensions = ["ext/<%= config[:underscored_name] %>/extconf.rb"]
-<%- end -%>
-<%- if config[:ext] == 'rust' -%>
-  spec.extensions = ["ext/<%= config[:underscored_name] %>/Cargo.toml"]
 <%- end -%>
 
   # Uncomment to register a new dependency of your gem


### PR DESCRIPTION
CentOS, Fedora, RHEL and so forth break without this.

Also, `Rakefile` doesn't need those options.