### PR TITLE
Properly handle incompatibilities on platform specific gems

### DIFF
--- a/bundler/lib/bundler/resolver/candidate.rb
+++ b/bundler/lib/bundler/resolver/candidate.rb
@@ -88,9 +88,7 @@ module Bundler
       end
 
       def to_s
-        return @version.to_s if @platforms.empty? || @ruby_only
-
-        "#{@version} (#{@platforms.join(", ")})"
+        @version.to_s
       end
     end
   end

--- a/bundler/lib/bundler/resolver/candidate.rb
+++ b/bundler/lib/bundler/resolver/candidate.rb
@@ -26,7 +26,7 @@ module Bundler
 
       def initialize(version, specs: [])
         @spec_group = Resolver::SpecGroup.new(specs)
-        @platforms = specs.map(&:platform).sort_by(&:to_s).uniq
+        @platforms = specs.map(&:platform).uniq
         @version = Gem::Version.new(version)
         @ruby_only = @platforms == [Gem::Platform::RUBY]
       end

--- a/bundler/lib/bundler/resolver/candidate.rb
+++ b/bundler/lib/bundler/resolver/candidate.rb
@@ -26,9 +26,8 @@ module Bundler
 
       def initialize(version, specs: [])
         @spec_group = Resolver::SpecGroup.new(specs)
-        @platforms = specs.map(&:platform).uniq
         @version = Gem::Version.new(version)
-        @ruby_only = @platforms == [Gem::Platform::RUBY]
+        @ruby_only = specs.map(&:platform).uniq == [Gem::Platform::RUBY]
       end
 
       def dependencies

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -768,159 +768,159 @@ RSpec.describe "bundle lock" do
            #{Bundler::VERSION}
       L
     end
+  end
 
-    it "properly shows resolution errors including OR requirements" do
-      build_repo4 do
-        build_gem "activeadmin", "2.13.1" do |s|
-          s.add_dependency "railties", ">= 6.1", "< 7.1"
-        end
-        build_gem "actionpack", "6.1.4"
-        build_gem "actionpack", "7.0.3.1"
-        build_gem "actionpack", "7.0.4"
-        build_gem "railties", "6.1.4" do |s|
-          s.add_dependency "actionpack", "6.1.4"
-        end
-        build_gem "rails", "7.0.3.1" do |s|
-          s.add_dependency "railties", "7.0.3.1"
-        end
-        build_gem "rails", "7.0.4" do |s|
-          s.add_dependency "railties", "7.0.4"
-        end
+  it "properly shows resolution errors including OR requirements" do
+    build_repo4 do
+      build_gem "activeadmin", "2.13.1" do |s|
+        s.add_dependency "railties", ">= 6.1", "< 7.1"
       end
-
-      gemfile <<~G
-        source "#{file_uri_for(gem_repo4)}"
-
-        gem "rails", ">= 7.0.3.1"
-        gem "activeadmin", "2.13.1"
-      G
-
-      bundle "lock", :raise_on_error => false
-
-      expect(err).to eq <<~ERR.strip
-        Could not find compatible versions
-
-        Because rails >= 7.0.4 depends on railties = 7.0.4
-          and rails < 7.0.4 depends on railties = 7.0.3.1,
-          railties = 7.0.3.1 OR = 7.0.4 is required.
-        So, because railties = 7.0.3.1 OR = 7.0.4 could not be found in rubygems repository #{file_uri_for(gem_repo4)}/ or installed locally,
-          version solving has failed.
-      ERR
+      build_gem "actionpack", "6.1.4"
+      build_gem "actionpack", "7.0.3.1"
+      build_gem "actionpack", "7.0.4"
+      build_gem "railties", "6.1.4" do |s|
+        s.add_dependency "actionpack", "6.1.4"
+      end
+      build_gem "rails", "7.0.3.1" do |s|
+        s.add_dependency "railties", "7.0.3.1"
+      end
+      build_gem "rails", "7.0.4" do |s|
+        s.add_dependency "railties", "7.0.4"
+      end
     end
 
-    it "is able to display some explanation on crazy irresolvable cases" do
-      build_repo4 do
-        build_gem "activeadmin", "2.13.1" do |s|
-          s.add_dependency "ransack", "= 3.1.0"
-        end
+    gemfile <<~G
+      source "#{file_uri_for(gem_repo4)}"
 
-        # Activemodel is missing as a dependency in lockfile
-        build_gem "ransack", "3.1.0" do |s|
-          s.add_dependency "activemodel", ">= 6.0.4"
-          s.add_dependency "activesupport", ">= 6.0.4"
-        end
+      gem "rails", ">= 7.0.3.1"
+      gem "activeadmin", "2.13.1"
+    G
 
-        %w[6.0.4 7.0.2.3 7.0.3.1 7.0.4].each do |version|
-          build_gem "activesupport", version
+    bundle "lock", :raise_on_error => false
 
-          # Activemodel is only available on 6.0.4
-          if version == "6.0.4"
-            build_gem "activemodel", version do |s|
-              s.add_dependency "activesupport", version
-            end
-          end
+    expect(err).to eq <<~ERR.strip
+      Could not find compatible versions
 
-          build_gem "rails", version do |s|
-            # Depednencies of Rails 7.0.2.3 are in reverse order
-            if version == "7.0.2.3"
-              s.add_dependency "activesupport", version
-              s.add_dependency "activemodel", version
-            else
-              s.add_dependency "activemodel", version
-              s.add_dependency "activesupport", version
-            end
+      Because rails >= 7.0.4 depends on railties = 7.0.4
+        and rails < 7.0.4 depends on railties = 7.0.3.1,
+        railties = 7.0.3.1 OR = 7.0.4 is required.
+      So, because railties = 7.0.3.1 OR = 7.0.4 could not be found in rubygems repository #{file_uri_for(gem_repo4)}/ or installed locally,
+        version solving has failed.
+    ERR
+  end
+
+  it "is able to display some explanation on crazy irresolvable cases" do
+    build_repo4 do
+      build_gem "activeadmin", "2.13.1" do |s|
+        s.add_dependency "ransack", "= 3.1.0"
+      end
+
+      # Activemodel is missing as a dependency in lockfile
+      build_gem "ransack", "3.1.0" do |s|
+        s.add_dependency "activemodel", ">= 6.0.4"
+        s.add_dependency "activesupport", ">= 6.0.4"
+      end
+
+      %w[6.0.4 7.0.2.3 7.0.3.1 7.0.4].each do |version|
+        build_gem "activesupport", version
+
+        # Activemodel is only available on 6.0.4
+        if version == "6.0.4"
+          build_gem "activemodel", version do |s|
+            s.add_dependency "activesupport", version
           end
         end
-      end
 
-      gemfile <<~G
-        source "#{file_uri_for(gem_repo4)}"
-
-        gem "rails", ">= 7.0.2.3"
-        gem "activeadmin", "= 2.13.1"
-      G
-
-      lockfile <<~L
-        GEM
-          remote: #{file_uri_for(gem_repo4)}/
-          specs:
-            activeadmin (2.13.1)
-              ransack (= 3.1.0)
-            ransack (3.1.0)
-              activemodel (>= 6.0.4)
-
-        PLATFORMS
-          #{lockfile_platforms}
-
-        DEPENDENCIES
-          activeadmin (= 2.13.1)
-          ransack (= 3.1.0)
-
-        BUNDLED WITH
-           #{Bundler::VERSION}
-      L
-
-      bundle "lock", :raise_on_error => false
-
-      expect(err).to eq <<~ERR.strip
-        Could not find compatible versions
-
-            Because every version of activemodel depends on activesupport = 6.0.4
-              and rails >= 7.0.2.3, < 7.0.3.1 depends on activesupport = 7.0.2.3,
-              every version of activemodel is incompatible with rails >= 7.0.2.3, < 7.0.3.1.
-            And because rails >= 7.0.2.3, < 7.0.3.1 depends on activemodel = 7.0.2.3,
-              rails >= 7.0.2.3, < 7.0.3.1 is forbidden.
-        (1) So, because rails >= 7.0.3.1, < 7.0.4 depends on activemodel = 7.0.3.1
-              and rails >= 7.0.4 depends on activemodel = 7.0.4,
-              rails >= 7.0.2.3 requires activemodel = 7.0.3.1 OR = 7.0.4.
-
-            Because rails >= 7.0.2.3, < 7.0.3.1 depends on activemodel = 7.0.2.3
-              and rails >= 7.0.3.1, < 7.0.4 depends on activesupport = 7.0.3.1,
-              rails >= 7.0.2.3, < 7.0.4 requires activemodel = 7.0.2.3 or activesupport = 7.0.3.1.
-            And because rails >= 7.0.4 depends on activesupport = 7.0.4
-              and every version of activemodel depends on activesupport = 6.0.4,
-              activemodel != 7.0.2.3 is incompatible with rails >= 7.0.2.3.
-            And because rails >= 7.0.2.3 requires activemodel = 7.0.3.1 OR = 7.0.4 (1),
-              rails >= 7.0.2.3 is forbidden.
-            So, because Gemfile depends on rails >= 7.0.2.3,
-              version solving has failed.
-      ERR
-    end
-
-    it "does not accidentally resolves to prereleases" do
-      build_repo4 do
-        build_gem "autoproj", "2.0.3" do |s|
-          s.add_dependency "autobuild", ">= 1.10.0.a"
-          s.add_dependency "tty-prompt"
-        end
-
-        build_gem "tty-prompt", "0.6.0"
-        build_gem "tty-prompt", "0.7.0"
-
-        build_gem "autobuild", "1.10.0.b3"
-        build_gem "autobuild", "1.10.1" do |s|
-          s.add_dependency "tty-prompt", "~> 0.6.0"
+        build_gem "rails", version do |s|
+          # Depednencies of Rails 7.0.2.3 are in reverse order
+          if version == "7.0.2.3"
+            s.add_dependency "activesupport", version
+            s.add_dependency "activemodel", version
+          else
+            s.add_dependency "activemodel", version
+            s.add_dependency "activesupport", version
+          end
         end
       end
-
-      gemfile <<~G
-        source "#{file_uri_for(gem_repo4)}"
-        gem "autoproj", ">= 2.0.0"
-      G
-
-      bundle "lock"
-      expect(lockfile).to_not include("autobuild (1.10.0.b3)")
-      expect(lockfile).to include("autobuild (1.10.1)")
     end
+
+    gemfile <<~G
+      source "#{file_uri_for(gem_repo4)}"
+
+      gem "rails", ">= 7.0.2.3"
+      gem "activeadmin", "= 2.13.1"
+    G
+
+    lockfile <<~L
+      GEM
+        remote: #{file_uri_for(gem_repo4)}/
+        specs:
+          activeadmin (2.13.1)
+            ransack (= 3.1.0)
+          ransack (3.1.0)
+            activemodel (>= 6.0.4)
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        activeadmin (= 2.13.1)
+        ransack (= 3.1.0)
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+    bundle "lock", :raise_on_error => false
+
+    expect(err).to eq <<~ERR.strip
+      Could not find compatible versions
+
+          Because every version of activemodel depends on activesupport = 6.0.4
+            and rails >= 7.0.2.3, < 7.0.3.1 depends on activesupport = 7.0.2.3,
+            every version of activemodel is incompatible with rails >= 7.0.2.3, < 7.0.3.1.
+          And because rails >= 7.0.2.3, < 7.0.3.1 depends on activemodel = 7.0.2.3,
+            rails >= 7.0.2.3, < 7.0.3.1 is forbidden.
+      (1) So, because rails >= 7.0.3.1, < 7.0.4 depends on activemodel = 7.0.3.1
+            and rails >= 7.0.4 depends on activemodel = 7.0.4,
+            rails >= 7.0.2.3 requires activemodel = 7.0.3.1 OR = 7.0.4.
+
+          Because rails >= 7.0.2.3, < 7.0.3.1 depends on activemodel = 7.0.2.3
+            and rails >= 7.0.3.1, < 7.0.4 depends on activesupport = 7.0.3.1,
+            rails >= 7.0.2.3, < 7.0.4 requires activemodel = 7.0.2.3 or activesupport = 7.0.3.1.
+          And because rails >= 7.0.4 depends on activesupport = 7.0.4
+            and every version of activemodel depends on activesupport = 6.0.4,
+            activemodel != 7.0.2.3 is incompatible with rails >= 7.0.2.3.
+          And because rails >= 7.0.2.3 requires activemodel = 7.0.3.1 OR = 7.0.4 (1),
+            rails >= 7.0.2.3 is forbidden.
+          So, because Gemfile depends on rails >= 7.0.2.3,
+            version solving has failed.
+    ERR
+  end
+
+  it "does not accidentally resolves to prereleases" do
+    build_repo4 do
+      build_gem "autoproj", "2.0.3" do |s|
+        s.add_dependency "autobuild", ">= 1.10.0.a"
+        s.add_dependency "tty-prompt"
+      end
+
+      build_gem "tty-prompt", "0.6.0"
+      build_gem "tty-prompt", "0.7.0"
+
+      build_gem "autobuild", "1.10.0.b3"
+      build_gem "autobuild", "1.10.1" do |s|
+        s.add_dependency "tty-prompt", "~> 0.6.0"
+      end
+    end
+
+    gemfile <<~G
+      source "#{file_uri_for(gem_repo4)}"
+      gem "autoproj", ">= 2.0.0"
+    G
+
+    bundle "lock"
+    expect(lockfile).to_not include("autobuild (1.10.0.b3)")
+    expect(lockfile).to include("autobuild (1.10.1)")
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When creating incompatibilities for requirements with no matching versions here:

https://github.com/rubygems/rubygems/blob/9abd8acdb11378d7c4a97d6e252360cb60e88ec6/bundler/lib/bundler/resolver.rb#L154-L176

We receive a pub grub version range, and need to convert it to a "standard" requirement. We parse the string representation of the version range for that. However, if the version range includes platform specific candidates, those were include the platform under parenthesis, making the string representation unparseable.

## What is your fix for the problem, implemented in this PR?

To fix the bug, we use only the string representation of the underlying version as the string representation of a candidate. Error messages already include the resolution platforms separately so it should not degrade with end users see or make any messages less clear.

Fixes #6267.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
