### PR TITLE
Fix `bundler/inline` not resolving properly if gems not preinstalled

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -557,7 +557,7 @@ module Bundler
     end
 
     def precompute_source_requirements_for_indirect_dependencies?
-      @remote && sources.non_global_rubygems_sources.all?(&:dependency_api_available?) && !sources.aggregate_global_source?
+      sources.non_global_rubygems_sources.all?(&:dependency_api_available?) && !sources.aggregate_global_source?
     end
 
     def pin_locally_available_names(source_requirements)

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -292,7 +292,7 @@ module Bundler
       end
 
       def dependency_api_available?
-        api_fetchers.any?
+        @allow_remote && api_fetchers.any?
       end
 
       protected

--- a/bundler/spec/runtime/inline_spec.rb
+++ b/bundler/spec/runtime/inline_spec.rb
@@ -168,6 +168,29 @@ RSpec.describe "bundler/inline#gemfile" do
     expect(err).to be_empty
   end
 
+  it "installs subdependencies quietly if necessary when the install option is not set" do
+    build_repo4 do
+      build_gem "rack" do |s|
+        s.add_dependency "rackdep"
+      end
+
+      build_gem "rackdep", "1.0.0"
+    end
+
+    script <<-RUBY
+      gemfile do
+        source "#{file_uri_for(gem_repo4)}"
+        gem "rack"
+      end
+
+      require "rackdep"
+      puts RACKDEP
+    RUBY
+
+    expect(out).to eq("1.0.0")
+    expect(err).to be_empty
+  end
+
   it "installs quietly from git if necessary when the install option is not set" do
     build_git "foo", "1.0.0"
     baz_ref = build_git("baz", "2.0.0").ref_for("HEAD")


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

After 2.4.4, some `bundler/inline` cases no longer work.

## What is your fix for the problem, implemented in this PR?

In inline mode, we resolve twice. First, we do a local resolution, and if that fails (local resolution failed, some resolved spec is not installed), we try again remotely.

Due to a recent refactoring, we were eagerly passing source requirements for resolution to a resolution context that would be reused for both of the above resolutions. However, the source requirements are different in the above two modes, so we need to make sure to calculate source requirements lazily when resolving.

However, that solution caused some issues with git sources, because it turns out during calculation of source requirements, we sort sources based on their `to_s` representation, and calling `#to_s` on git sources actually causes side effects: the displayed revision is memoized in the source. That was causing git sources to no longer be updated correctly. I changed this sorting of sources to not rely on `#to_s` to fix this derivated problem.

Closes #6281.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
