### PR TITLE
Update bundle-exec man page to not use deprecated `Bundler.with_clean_env`

### DIFF
--- a/bundler/lib/bundler/man/bundle-exec.1
+++ b/bundler/lib/bundler/man/bundle-exec.1
@@ -74,13 +74,13 @@ Finally, \fBbundle exec\fR also implicitly modifies \fBGemfile\.lock\fR if the l
 By default, when attempting to \fBbundle exec\fR to a file with a ruby shebang, Bundler will \fBKernel\.load\fR that file instead of using \fBKernel\.exec\fR\. For the vast majority of cases, this is a performance improvement\. In a rare few cases, this could cause some subtle side\-effects (such as dependence on the exact contents of \fB$0\fR or \fB__FILE__\fR) and the optimization can be disabled by enabling the \fBdisable_exec_load\fR setting\.
 .
 .SS "Shelling out"
-Any Ruby code that opens a subshell (like \fBsystem\fR, backticks, or \fB%x{}\fR) will automatically use the current Bundler environment\. If you need to shell out to a Ruby command that is not part of your current bundle, use the \fBwith_clean_env\fR method with a block\. Any subshells created inside the block will be given the environment present before Bundler was activated\. For example, Homebrew commands run Ruby, but don\'t work inside a bundle:
+Any Ruby code that opens a subshell (like \fBsystem\fR, backticks, or \fB%x{}\fR) will automatically use the current Bundler environment\. If you need to shell out to a Ruby command that is not part of your current bundle, use the \fBwith_unbundled_env\fR method with a block\. Any subshells created inside the block will be given the environment present before Bundler was activated\. For example, Homebrew commands run Ruby, but don\'t work inside a bundle:
 .
 .IP "" 4
 .
 .nf
 
-Bundler\.with_clean_env do
+Bundler\.with_unbundled_env do
   `brew install wget`
 end
 .
@@ -89,13 +89,13 @@ end
 .IP "" 0
 .
 .P
-Using \fBwith_clean_env\fR is also necessary if you are shelling out to a different bundle\. Any Bundler commands run in a subshell will inherit the current Gemfile, so commands that need to run in the context of a different bundle also need to use \fBwith_clean_env\fR\.
+Using \fBwith_unbundled_env\fR is also necessary if you are shelling out to a different bundle\. Any Bundler commands run in a subshell will inherit the current Gemfile, so commands that need to run in the context of a different bundle also need to use \fBwith_unbundled_env\fR\.
 .
 .IP "" 4
 .
 .nf
 
-Bundler\.with_clean_env do
+Bundler\.with_unbundled_env do
   Dir\.chdir "/other/bundler/project" do
     `bundle exec \./script`
   end

--- a/bundler/lib/bundler/man/bundle-exec.1.ronn
+++ b/bundler/lib/bundler/man/bundle-exec.1.ronn
@@ -84,20 +84,20 @@ the `disable_exec_load` setting.
 Any Ruby code that opens a subshell (like `system`, backticks, or `%x{}`) will
 automatically use the current Bundler environment. If you need to shell out to
 a Ruby command that is not part of your current bundle, use the
-`with_clean_env` method with a block. Any subshells created inside the block
+`with_unbundled_env` method with a block. Any subshells created inside the block
 will be given the environment present before Bundler was activated. For
 example, Homebrew commands run Ruby, but don't work inside a bundle:
 
-    Bundler.with_clean_env do
+    Bundler.with_unbundled_env do
       `brew install wget`
     end
 
-Using `with_clean_env` is also necessary if you are shelling out to a different
+Using `with_unbundled_env` is also necessary if you are shelling out to a different
 bundle. Any Bundler commands run in a subshell will inherit the current
 Gemfile, so commands that need to run in the context of a different bundle also
-need to use `with_clean_env`.
+need to use `with_unbundled_env`.
 
-    Bundler.with_clean_env do
+    Bundler.with_unbundled_env do
       Dir.chdir "/other/bundler/project" do
         `bundle exec ./script`
       end


### PR DESCRIPTION
`with_clean_env` has been deprecated in `with_unbundled_env`. It already generates a deprecation warning when it uses, but this man page was still referring to it.

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

If a user follows the instructions from `bundle exec --help` and uses `Bundler.with_clean_env`, they will get a deprecated message to use `Bundler.with_unbundled_env`

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

Update the .ronn and .man pages

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
