### PR TITLE
Fix packages for external platforms being introduced in lockfile when Bundler retries resolution

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -487,7 +487,7 @@ module Bundler
     end
 
     def expanded_dependencies
-      @expanded_dependencies ||= dependencies + metadata_dependencies
+      dependencies + metadata_dependencies
     end
 
     def resolution_packages

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -551,7 +551,7 @@ module Bundler
     end
 
     def start_resolution
-      result = resolver.start(expanded_dependencies)
+      result = resolver.start
 
       SpecSet.new(SpecSet.new(result).for(dependencies, false, @platforms))
     end

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -21,8 +21,8 @@ module Bundler
       @gem_version_promoter = gem_version_promoter
     end
 
-    def start(requirements)
-      @requirements = requirements
+    def start
+      @requirements = @base.requirements
       @packages = @base.packages
 
       root, logger = setup_solver
@@ -330,18 +330,6 @@ module Bundler
     def prepare_dependencies(requirements, packages)
       to_dependency_hash(requirements, packages).map do |dep_package, dep_constraint|
         name = dep_package.name
-
-        # If a dependency is scoped to a platform different from the current
-        # one, we ignore it. However, it may reappear during resolution as a
-        # transitive dependency of another package, so we need to reset the
-        # package so the proper versions are considered if reintroduced later.
-        # We also need to delete the dependency itself so that it's not
-        # reintroduced if we retry resolving under different conditions.
-        if dep_package.platforms.empty?
-          packages.delete(name)
-          requirements.reject! {|requirement| requirement.name == name }
-          next
-        end
 
         next [dep_package, dep_constraint] if name == "bundler"
 

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -336,7 +336,7 @@ module Bundler
         # transitive dependency of another package, so we need to reset the
         # package so the proper versions are considered if reintroduced later.
         if dep_package.platforms.empty?
-          @packages.delete(name)
+          packages.delete(name)
           next
         end
 

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -335,8 +335,11 @@ module Bundler
         # one, we ignore it. However, it may reappear during resolution as a
         # transitive dependency of another package, so we need to reset the
         # package so the proper versions are considered if reintroduced later.
+        # We also need to delete the dependency itself so that it's not
+        # reintroduced if we retry resolving under different conditions.
         if dep_package.platforms.empty?
           packages.delete(name)
+          requirements.reject! {|requirement| requirement.name == name }
           next
         end
 

--- a/bundler/spec/support/indexes.rb
+++ b/bundler/spec/support/indexes.rb
@@ -28,7 +28,7 @@ module Spec
         source_requirements[name] = d.source = default_source
       end
       packages = Bundler::Resolver::Base.new(source_requirements, @deps, base, @platforms, :locked_specs => originally_locked, :unlock => unlock)
-      Bundler::Resolver.new(packages, gem_version_promoter).start(@deps)
+      Bundler::Resolver.new(packages, gem_version_promoter).start
     end
 
     def should_not_resolve


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

After we started ignoring prereleases and only considering them if we can't resolve without them at #6246, we got reports that Bundler was sometimes introducing gems for external platforms in the lockfile. For example, when using `gem "tzinfo-data", platform: :windows` on non Windows platforms.

## What is your fix for the problem, implemented in this PR?

The problem was that while on initial resolution we were properly ignoring these dependencies, they were not being properly ignored when Bundler had to resort to re-resolving including prereleases (and that's the case of Rails main branch).

The fix is to properly remove the dependency so that it's not considered on retries either.

Another improvement we can do here, but I'll leave that for another PR, is to not exclude prereleases from gems configured to use a gemspec/path source. But this bug fix is independent from that enhancement.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
