### PR TITLE
Relax slow perf spec

### DIFF
--- a/bundler/spec/realworld/slow_perf_spec.rb
+++ b/bundler/spec/realworld/slow_perf_spec.rb
@@ -28,6 +28,6 @@ RSpec.describe "bundle install with complex dependencies", :realworld => true do
       gem 'rspec-rails'
     G
 
-    expect { bundle "lock" }.to take_less_than(18) # seconds
+    expect { bundle "lock" }.to take_less_than(30) # seconds
   end
 end


### PR DESCRIPTION

## What was the end-user or developer problem that led to this PR?

Sometimes this spec fails randomly on Ruby 3.2.

## What is your fix for the problem, implemented in this PR?

I guess it's harder on Ruby 3.2. Relax it a bit to avoid flakes.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
