### PR TITLE
Explicitly mark `eval_gemfile` as undocumented

### DIFF
--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -40,7 +40,7 @@ module Bundler
       add_git_sources
     end
 
-    def eval_gemfile(gemfile, contents = nil)
+    def eval_gemfile(gemfile, contents = nil) # :nodoc:
       expanded_gemfile_path = Pathname.new(gemfile).expand_path(@gemfile&.parent)
       original_gemfile = @gemfile
       @gemfile = expanded_gemfile_path


### PR DESCRIPTION
> **Warning**
> **This PR and rubygems/bundler-site#1081 are mutually exclusive. At most one of them should be merged.**
> I personally think documenting it is the better approach, but I have opened this as the alternative.

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

It is unclear if `eval_gemfile` should be used or not. On the one hand, it is public, and shows up in the generated API documentation. On the other hand, it is not explicitly called out in the guides.

Despite this, many projects use it, as noted in rubygems/bundler-site#1081.

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

While I _personally_ think it should be part of the public API (as it is already in use by many consumers) and would rather see rubygems/bundler-site#1081 merged, and this PR closed, if it is indeed considered private, it should be explicitly marked as undocumented, so this is clear to consumers.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- ~Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes~
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
