### PR TITLE
blade is hosted under ruby-lang.org now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5387,11 +5387,11 @@ annoying issues involving other libraries that RubyGems depends upon.
 0.8.3 contains some workarounds for these issues.  In particular:
 
 * Added workaround for the null byte in Dir string issue. (see
-  http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/121702).
+  https://blade.ruby-lang.org/ruby-talk/121702).
   (Thanks to Mauricio Fernández for the quick response on this one).
 * Added workaround for old version of Zlib on windows that caused
   Ruwiki to fail to install. (see
-  http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/121770)
+  https://blade.ruby-lang.org/ruby-talk/121770)
 * Added workaround for large YAML file issues.  (We dynamically cut
   down the size of the source index YAML file and seem to have worked
   around immediate issues.

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -528,7 +528,7 @@ class Gem::Installer
   #--
   # The Windows script is generated in addition to the regular one due to a
   # bug or misfeature in the Windows shell's pipe.  See
-  # http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/193379
+  # https://blade.ruby-lang.org/ruby-talk/193379
 
   def generate_bin_script(filename, bindir)
     bin_script_path = File.join bindir, formatted_program_filename(filename)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`blade.nagaokaut.ac.jp` is down now. 

## What is your fix for the problem, implemented in this PR?

It should be used `blade.ruby-lang.org`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
