### PR TITLE
Inline gemfile: change `install` to keyword argument

### DIFF
--- a/bundler/lib/bundler/inline.rb
+++ b/bundler/lib/bundler/inline.rb
@@ -42,6 +42,9 @@ def gemfile(install = false, options = {}, &gemfile)
     Bundler.instance_variable_set(:@bundle_path, Pathname.new(Gem.dir))
     old_gemfile = ENV["BUNDLE_GEMFILE"]
     Bundler::SharedHelpers.set_env "BUNDLE_GEMFILE", "Gemfile"
+    Bundler::SharedHelpers.major_deprecation 2, "The optional install parameter to the `gemfile(install = false, &block)` helper is getting"\
+    " removed because regardless of what you pass in there, it still installs missing gems."\
+    " Remove the explicit `install` parameter to get rid of this message.", :print_caller_location => true if install
 
     Bundler::Plugin.gemfile_install(&gemfile) if Bundler.feature_flag.plugins?
     builder = Bundler::Dsl.new

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -660,9 +660,10 @@ RSpec.describe "major deprecations" do
       RUBY
 
       expect(deprecations).to include \
-        "The optional install parameter to the `gemfile(install = false, &block)` helper is getting"\
+        "The positional install parameter to the `gemfile(install = false, &block)` helper is getting"\
         " removed because regardless of what you pass in there, it still installs missing gems."\
-        " Remove the explicit `install` parameter to get rid of this message. (called at -e:3)"
+        " Remove the positional parameter to get rid of this message, and optionally replace with"\
+        "   `gemfile(install: false, &block)` (called at -e:4)"
     end
 
     pending "fails with a helpful error", :bundler => "3"

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -646,4 +646,25 @@ RSpec.describe "major deprecations" do
       end
     end
   end
+
+  context "when user set install parameter of inline gem to true" do
+    it "shows platform warnings", :bundler => "< 3"do
+      ruby <<-RUBY
+
+        require "bundler/inline"
+
+        gemfile(true) do
+          source "#{file_uri_for(gem_repo1)}"
+          gem "rack", platform: :jruby
+        end
+      RUBY
+
+      expect(deprecations).to include \
+        "The optional install parameter to the `gemfile(install = false, &block)` helper is getting"\
+        " removed because regardless of what you pass in there, it still installs missing gems."\
+        " Remove the explicit `install` parameter to get rid of this message. (called at -e:3)"
+    end
+
+    pending "fails with a helpful error", :bundler => "3"
+  end
 end

--- a/bundler/spec/realworld/double_check_spec.rb
+++ b/bundler/spec/realworld/double_check_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe "double checking sources", :realworld => true do
-  it "finds already-installed gems" do
+  it "finds already-installed gems", :bundler => "< 3" do
     create_file("rails.gemspec", <<-RUBY)
       Gem::Specification.new do |s|
         s.name        = "rails"

--- a/bundler/spec/runtime/inline_spec.rb
+++ b/bundler/spec/runtime/inline_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "bundler/inline#gemfile" do
     end
   end
 
-  it "requires the gems" do
+  it "requires the gems", :bundler => "< 3" do
     script <<-RUBY
       gemfile do
         source "#{file_uri_for(gem_repo1)}"
@@ -88,12 +88,12 @@ RSpec.describe "bundler/inline#gemfile" do
     RUBY
 
     expect(out).to include("Installing activesupport")
-    err_lines = err.split("\n")
+    err_lines = err_without_deprecations.split("\n")
     err_lines.reject! {|line| line =~ /\.rb:\d+: warning: / } unless RUBY_VERSION < "2.7"
     expect(err_lines).to be_empty
   end
 
-  it "lets me use my own ui object" do
+  it "lets me use my own ui object", :bundler => "< 3" do
     script <<-RUBY, :artifice => "endpoint"
       require '#{entrypoint}'
       class MyBundlerUI < Bundler::UI::Shell
@@ -112,7 +112,7 @@ RSpec.describe "bundler/inline#gemfile" do
     expect(out).to eq("CONFIRMED!\nCONFIRMED!")
   end
 
-  it "has an option for quiet installation" do
+  it "has an option for quiet installation", :bundler => "< 3" do
     script <<-RUBY, :artifice => "endpoint"
       require '#{entrypoint}/inline'
 
@@ -264,7 +264,7 @@ RSpec.describe "bundler/inline#gemfile" do
     expect(err).to be_empty
   end
 
-  it "does not leak Gemfile.lock versions to the installation output" do
+  it "does not leak Gemfile.lock versions to the installation output", :bundler => "< 3" do
     gemfile <<-G
       source "https://notaserver.com"
       gem "rake"
@@ -295,7 +295,7 @@ RSpec.describe "bundler/inline#gemfile" do
 
     expect(out).to include("Installing rake 13.0")
     expect(out).not_to include("was 11.3.0")
-    expect(err).to be_empty
+    expect(err_without_deprecations).to be_empty
   end
 
   it "installs inline gems when frozen is set" do
@@ -355,7 +355,7 @@ RSpec.describe "bundler/inline#gemfile" do
   end
 
   context "when BUNDLE_PATH is set" do
-    it "installs inline gems to the system path regardless" do
+    it "installs inline gems to the system path regardless", :bundler => "< 3" do
       script <<-RUBY, :env => { "BUNDLE_PATH" => "./vendor/inline" }
         gemfile(true) do
           source "#{file_uri_for(gem_repo1)}"
@@ -367,9 +367,8 @@ RSpec.describe "bundler/inline#gemfile" do
     end
   end
 
-  it "skips platform warnings" do
+  it "skips platform warnings", :bundler => "< 3" do
     bundle "config set --local force_ruby_platform true"
-
     script <<-RUBY
       gemfile(true) do
         source "#{file_uri_for(gem_repo1)}"
@@ -377,7 +376,7 @@ RSpec.describe "bundler/inline#gemfile" do
       end
     RUBY
 
-    expect(err).to be_empty
+    expect(err_without_deprecations).to be_empty
   end
 
   it "still installs if the application has `bundle package` no_install config set" do
@@ -459,7 +458,7 @@ RSpec.describe "bundler/inline#gemfile" do
     expect(err).to be_empty
   end
 
-  it "when requiring fileutils after does not show redefinition warnings", :realworld do
+  it "when requiring fileutils after does not show redefinition warnings", :realworld, :bundler => "< 3" do
     dependency_installer_loads_fileutils = ruby "require 'rubygems/dependency_installer'; puts $LOADED_FEATURES.grep(/fileutils/)", :raise_on_error => false
     skip "does not work if rubygems/dependency_installer loads fileutils, which happens until rubygems 3.2.0" unless dependency_installer_loads_fileutils.empty?
 
@@ -489,6 +488,6 @@ RSpec.describe "bundler/inline#gemfile" do
       require "fileutils"
     RUBY
 
-    expect(err).to eq("The Gemfile specifies no dependencies")
+    expect(err_without_deprecations).to eq("The Gemfile specifies no dependencies")
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

PR #5844 removes the `install` positional argument, since it didn't really do anything as the gems would be installed silently anyway. It would be nice to be able to control whether or not the gems are installed automatically.

## What is your fix for the problem, implemented in this PR?

- This PR builds on the previous one to add a keyword `install` argument.
- It also converts the other keyword options to first-class keyword arguments - though I'm not sure if this creates problems with older versions of Ruby.
- Finally, it makes the default `ui.level` to be `"confirm"` which causes messages to be printed to the console only if packages are installed, but not otherwise.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
