### PR TITLE
Fix `bundler/inline` not skipping installation when gems already there, when used more than once

### DIFF
--- a/bundler/lib/bundler/inline.rb
+++ b/bundler/lib/bundler/inline.rb
@@ -31,6 +31,7 @@
 #
 def gemfile(install = false, options = {}, &gemfile)
   require_relative "../bundler"
+  Bundler.reset!
 
   opts = options.dup
   ui = opts.delete(:ui) { Bundler::UI::Shell.new }


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Using `bundler/inline` multiple times causes gems mentioned in the second and subsequent uses to be reinstalled on every invocation, even if they were already installed.

## What is your fix for the problem, implemented in this PR?

- Added tests to show the problem.
- Added a call to `Bundler.reset!` to `gemfile` method which fixes the problem, but I am not sure if this is the correct approach.
- ~~I had another problem that I can't work out how to write a test for, where extensions were not being compiled correctly when installed in this manner. Wrapping the body of the `gemfile` method in `Bundler.with_unbundled_env` fixed it.~~ (Moved to #6306)

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
