### PR TITLE
Fix `bundler/inline` not properly installing gems with extensions when used more than once

### DIFF
--- a/bundler/lib/bundler/inline.rb
+++ b/bundler/lib/bundler/inline.rb
@@ -39,9 +39,8 @@ def gemfile(install = false, options = {}, &gemfile)
   Bundler.ui = ui
   raise ArgumentError, "Unknown options: #{opts.keys.join(", ")}" unless opts.empty?
 
-  begin
+  Bundler.with_unbundled_env do
     Bundler.instance_variable_set(:@bundle_path, Pathname.new(Gem.dir))
-    old_gemfile = ENV["BUNDLE_GEMFILE"]
     Bundler::SharedHelpers.set_env "BUNDLE_GEMFILE", "Gemfile"
 
     Bundler::Plugin.gemfile_install(&gemfile) if Bundler.feature_flag.plugins?
@@ -66,11 +65,9 @@ def gemfile(install = false, options = {}, &gemfile)
       runtime = Bundler::Runtime.new(nil, definition)
       runtime.setup.require
     end
-  ensure
-    if old_gemfile
-      ENV["BUNDLE_GEMFILE"] = old_gemfile
-    else
-      ENV["BUNDLE_GEMFILE"] = ""
-    end
+  end
+
+  if ENV["BUNDLE_GEMFILE"].nil?
+    ENV["BUNDLE_GEMFILE"] = ""
   end
 end

--- a/bundler/spec/runtime/inline_spec.rb
+++ b/bundler/spec/runtime/inline_spec.rb
@@ -296,6 +296,47 @@ RSpec.describe "bundler/inline#gemfile" do
     expect(err).to be_empty
   end
 
+  it "installs gems with native extensions in later gemfile calls" do
+    system_gems "rack-1.0.0"
+
+    build_git "foo" do |s|
+      s.add_dependency "rake"
+      s.extensions << "Rakefile"
+      s.write "Rakefile", <<-RUBY
+        task :default do
+          path = File.expand_path("lib", __dir__)
+          FileUtils.mkdir_p(path)
+          File.open("\#{path}/foo.rb", "w") do |f|
+            f.puts "FOO = 'YES'"
+          end
+        end
+      RUBY
+    end
+
+    script <<-RUBY
+      require '#{entrypoint}'
+      ui = Bundler::UI::Shell.new
+      ui.level = "confirm"
+      gemfile(true, ui: ui) do
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rack"
+      end
+
+      gemfile(true, ui: ui) do
+        source "#{file_uri_for(gem_repo1)}"
+        gem "foo", :git => "#{lib_path("foo-1.0")}"
+      end
+
+      require 'foo'
+      puts FOO
+      puts $:.grep(/ext/)
+    RUBY
+
+    expect(out).to include("YES")
+    expect(out).to include(Pathname.glob(default_bundle_path("bundler/gems/extensions/**/foo-1.0-*")).first.to_s)
+    expect(err).to be_empty
+  end
+
   it "installs inline gems when a Gemfile.lock is present" do
     gemfile <<-G
       source "https://notaserver.com"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The following test script fails on Windows (RubyInstaller) with Ruby 3.1 and Ruby 2.6 using Bundler 2.4.5:

```ruby
require 'bundler/inline'
gemfile(true) do
  source 'http://rubygems.org'
  gem 'bundler'
end
gemfile(true) do
  source 'http://rubygems.org'
  gem 'racc'
end
```

<details><summary>The output is as follows:</summary>

```
Resolving dependencies...
Using bundler 2.4.5
Fetching gem metadata from http://rubygems.org/.
Resolving dependencies...
Using bundler 2.4.5
Installing racc 1.6.2 with native extensions
C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/installer/parallel_installer.rb:189:in `handle_error': Gem::Ext::BuildError: ERROR: Failed to build gem native extension. (Bundler::InstallError)

    current directory: C:/Ruby31-x64/lib/ruby/gems/3.1.0/gems/racc-1.6.2/ext/racc/cparse
C:/Ruby31-x64/bin/ruby.exe -I C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0 extconf.rb
C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/definition.rb:35:in `build': C:/Ruby31-x64/lib/ruby/gems/3.1.0/gems/racc-1.6.2/ext/racc/cparse/Gemfile not found (Bundler::GemfileNotFound)
        from C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler.rb:216:in `definition'
        from C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler.rb:164:in `setup'
        from C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/setup.rb:20:in `block in <top (required)>'
        from C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/ui/shell.rb:159:in `with_level'
        from C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/ui/shell.rb:111:in `silence'
        from C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/setup.rb:20:in `<top (required)>'
        from <internal:C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from <internal:C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems.rb:1360:in `<top (required)>'
        from <internal:gem_prelude>:2:in `require'
        from <internal:gem_prelude>:2:in `<internal:gem_prelude>'

extconf failed, exit code 1

Gem files will remain installed in C:/Ruby31-x64/lib/ruby/gems/3.1.0/gems/racc-1.6.2 for inspection.
Results logged to C:/Ruby31-x64/lib/ruby/gems/3.1.0/extensions/x64-mingw-ucrt/3.1.0/racc-1.6.2/gem_make.out

  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/ext/builder.rb:102:in `run'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/ext/ext_conf_builder.rb:28:in `build'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/ext/builder.rb:171:in `build_extension'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/ext/builder.rb:205:in `block in build_extensions'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/ext/builder.rb:202:in `each'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/ext/builder.rb:202:in `build_extensions'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/installer.rb:843:in `build_extensions'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/rubygems_gem_installer.rb:72:in `build_extensions'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/rubygems_gem_installer.rb:28:in `install'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/source/rubygems.rb:200:in `install'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/installer/gem_installer.rb:54:in `install'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/installer/gem_installer.rb:16:in `install_from_spec'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/installer/parallel_installer.rb:155:in `do_install'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/installer/parallel_installer.rb:146:in `block in worker_pool'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/worker.rb:62:in `apply_func'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/worker.rb:57:in `block in process_queue'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/worker.rb:54:in `loop'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/worker.rb:54:in `process_queue'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/worker.rb:90:in `block (2 levels) in create_threads'

An error occurred while installing racc (1.6.2), and Bundler cannot continue.

In Gemfile:
  racc
        from C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/installer/parallel_installer.rb:96:in `call'
        from C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/installer/parallel_installer.rb:67:in `call'
        from C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/installer.rb:244:in `install_in_parallel'
        from C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/installer.rb:201:in `install'
        from C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/installer.rb:89:in `block in run'
        from C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/process_lock.rb:12:in `block in lock'
        from C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/process_lock.rb:9:in `open'
        from C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/process_lock.rb:9:in `lock'
        from C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/installer.rb:71:in `run'
        from C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/installer.rb:23:in `install'
        from C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/inline.rb:58:in `block (2 levels) in gemfile'
        from C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/settings.rb:131:in `temporary'
        from C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/inline.rb:57:in `block in gemfile'
        from C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/settings.rb:131:in `temporary'
        from C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/inline.rb:51:in `gemfile'
        from test.rb:9:in `<main>'
```

</details>

## What is your fix for the problem, implemented in this PR?

 Wrapping the body of the `gemfile` method in `Bundler.with_unbundled_env` fixed it.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
