### PR TITLE
Add gem exec command

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -347,6 +347,7 @@ lib/rubygems/commands/cleanup_command.rb
 lib/rubygems/commands/contents_command.rb
 lib/rubygems/commands/dependency_command.rb
 lib/rubygems/commands/environment_command.rb
+lib/rubygems/commands/exec_command.rb
 lib/rubygems/commands/fetch_command.rb
 lib/rubygems/commands/generate_index_command.rb
 lib/rubygems/commands/help_command.rb

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -617,6 +617,7 @@ test/rubygems/test_gem_commands_cleanup_command.rb
 test/rubygems/test_gem_commands_contents_command.rb
 test/rubygems/test_gem_commands_dependency_command.rb
 test/rubygems/test_gem_commands_environment_command.rb
+test/rubygems/test_gem_commands_exec_command.rb
 test/rubygems/test_gem_commands_fetch_command.rb
 test/rubygems/test_gem_commands_generate_index_command.rb
 test/rubygems/test_gem_commands_help_command.rb

--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -201,11 +201,15 @@ class Gem::Command
   # respectively.
   def get_all_gem_names_and_versions
     get_all_gem_names.map do |name|
-      if /\A(.*):(#{Gem::Requirement::PATTERN_RAW})\z/ =~ name
-        [$1, $2]
-      else
-        [name]
-      end
+      extract_gem_name_and_version(name)
+    end
+  end
+
+  def extract_gem_name_and_version(name) # :nodoc:
+    if /\A(.*):(#{Gem::Requirement::PATTERN_RAW})\z/ =~ name
+      [$1, $2]
+    else
+      [name]
     end
   end
 

--- a/lib/rubygems/command_manager.rb
+++ b/lib/rubygems/command_manager.rb
@@ -43,6 +43,7 @@ class Gem::CommandManager
     :contents,
     :dependency,
     :environment,
+    :exec,
     :fetch,
     :generate_index,
     :help,

--- a/lib/rubygems/commands/exec_command.rb
+++ b/lib/rubygems/commands/exec_command.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require_relative "../command"
 require_relative "../dependency_installer"
+require_relative "../gem_runner"
 require_relative "../package"
 require_relative "../version_option"
 
@@ -60,7 +61,10 @@ to the same gem path as user-installed gems.
     check_executable
 
     print_command
-    if options[:conservative]
+    if options[:gem_name] == "gem" && options[:executable] == "gem"
+      Gem::GemRunner.new.run options[:args]
+      return
+    elsif options[:conservative]
       install_if_needed
     else
       install
@@ -135,15 +139,19 @@ to the same gem path as user-installed gems.
     activate!
   end
 
-  def install
-    gem_name = options[:gem_name]
-    gem_version = options[:version]
-
+  def set_gem_exec_install_paths
     home = File.join(Gem.dir, "gem_exec")
 
     ENV["GEM_PATH"] = ([home] + Gem.path).join(Gem.path_separator)
     ENV["GEM_HOME"] = home
     Gem.clear_paths
+  end
+
+  def install
+    set_gem_exec_install_paths
+
+    gem_name = options[:gem_name]
+    gem_version = options[:version]
 
     install_options = options.merge(
       minimal_deps: false,

--- a/lib/rubygems/commands/exec_command.rb
+++ b/lib/rubygems/commands/exec_command.rb
@@ -1,0 +1,186 @@
+# frozen_string_literal: true
+require_relative "../command"
+require_relative "../package"
+require_relative "../version_option"
+
+class Gem::Commands::ExecCommand < Gem::Command
+  include Gem::VersionOption
+
+  def initialize
+    super "exec", "Run a command from a gem", {
+      version: Gem::Requirement.default,
+    }
+
+    add_platform_option
+    add_version_option
+    add_prerelease_option "to be installed"
+
+    add_option "-g", "--gem GEM", "run the executable from the given gem" do |value, options|
+      options[:gem_name] = value
+    end
+
+    add_option(:"Install/Update", "--conservative",
+      "Prefer the most recent installed version, ",
+      "rather than the latest version overall") do |value, options|
+      options[:conservative] = true
+    end
+  end
+
+  def arguments # :nodoc:
+    "COMMAND  the executable command to run"
+  end
+
+  def defaults_str # :nodoc:
+    "--version '#{Gem::Requirement.default}'"
+  end
+
+  def description # :nodoc:
+    <<-EOF
+    EOF
+  end
+
+  def usage # :nodoc:
+    "#{program_name} [options --] COMMAND [args]"
+  end
+
+  def execute
+    check_executable
+
+    print_command
+    if options[:conservative]
+      install_if_needed
+    else
+      install
+      activate!
+    end
+
+    load!
+  end
+
+  private
+
+  def handle_options(args)
+    args = add_extra_args(args)
+    check_deprecated_options(args)
+    @options = Marshal.load Marshal.dump @defaults # deep copy
+    parser.order!(args) do |v|
+      # put the non-option back at the front of the list of arguments
+      args.unshift(v)
+
+      # stop parsing once we hit the first non-option,
+      # so you can call `gem exec rails --version` and it prints the rails
+      # version rather than rubygem's
+      break
+    end
+    @options[:args] = args
+
+    options[:executable], gem_version = extract_gem_name_and_version(options[:args].shift)
+    options[:gem_name] ||= options[:executable]
+    options[:version] = gem_version if gem_version
+  end
+
+  def check_executable
+    if options[:executable].nil?
+      raise Gem::CommandLineError,
+        "Please specify an executable to run (e.g. #{program_name} COMMAND)"
+    end
+  end
+
+  def print_command
+    verbose "running #{program_name} with:\n"
+    opts = options.reject {|_, v| v.nil? || Array(v).empty? }
+    max_length = opts.map {|k, _| k.size }.max
+    opts.each do |k, v|
+      next if v.nil?
+      verbose "\t#{k.to_s.rjust(max_length)}: #{v} "
+    end
+    verbose ""
+  end
+
+  def install_if_needed
+    activate!
+  rescue Gem::MissingSpecError
+    verbose "#{dependency_to_s} not available locally"
+    install
+    activate!
+  end
+
+  def install
+    gem_name = options[:gem_name]
+    gem_version = options[:version]
+
+    home = Gem.paths.home
+    home = File.join(home, "gem_exec")
+    Gem.use_paths(home, Gem.path + [home])
+
+    suppress_always_install do
+      Gem.install(gem_name, gem_version)
+    end
+  rescue Gem::InstallError => e
+    alert_error "Error installing #{gem_name}:\n\t#{e.message}"
+    terminate_interaction 1
+  rescue Gem::GemNotFoundException => e
+    show_lookup_failure e.name, e.version, e.errors, false
+
+    terminate_interaction 2
+  rescue Gem::UnsatisfiableDependencyError => e
+    show_lookup_failure e.name, e.version, e.errors, false,
+                        "'#{gem_name}' (#{gem_version})"
+
+    terminate_interaction 2
+  end
+
+  def activate!
+    gem(options[:gem_name], options[:version])
+    Gem.finish_resolve
+  end
+
+  def load!
+    argv = ARGV.clone
+    ARGV.replace options[:args]
+
+    exe = executable = options[:executable]
+
+    contains_executable = Gem.loaded_specs.values.select do |spec|
+      spec.executables.include?(executable)
+    end
+
+    if contains_executable.any? {|s| s.name == executable }
+      contains_executable.select! {|s| s.name == executable }
+    end
+
+    if contains_executable.empty?
+      if (spec = Gem.loaded_specs[executable]) && (exe = spec.executable)
+        contains_executable << spec
+      else
+        alert_error "Failed to load executable `#{executable}`," \
+              " are you sure the gem `#{options[:gem_name]}` contains it?"
+        terminate_interaction 1
+      end
+    end
+
+    if contains_executable.size > 1
+      alert_error "Ambiguous which gem `#{executable}` should come from: " \
+            "the options are #{contains_executable.map(&:name)}, " \
+            "specify one via `-g`"
+      terminate_interaction 1
+    end
+
+    load Gem.activate_bin_path(contains_executable.first.name, exe, ">= 0.a")
+  ensure
+    ARGV.replace argv
+  end
+
+  def suppress_always_install
+    name = :always_install
+    cls = ::Gem::Resolver::InstallerSet
+    method = cls.instance_method(name)
+    cls.define_method(name) { [] }
+
+    begin
+      yield
+    ensure
+      cls.define_method(name, method)
+    end
+  end
+end

--- a/lib/rubygems/commands/exec_command.rb
+++ b/lib/rubygems/commands/exec_command.rb
@@ -34,9 +34,19 @@ class Gem::Commands::ExecCommand < Gem::Command
     "--version '#{Gem::Requirement.default}'"
   end
 
-  # TODO(segiddins): add a proper description!
   def description # :nodoc:
     <<-EOF
+The exec command handles installing (if necessary) and running an executable
+from a gem, regardless of whether that gem is currently installed.
+
+The exec command can be thought of as a shortcut to running `gem install` and
+then the executable from the installed gem.
+
+For example, `gem exec rails new .` will run `rails new .` in the current
+directory, without having to manually run `gem install rails`.
+Additionally, the exec command ensures the most recent version of the gem
+is used (unless run with `--conservative`), and that the gem is not installed
+to the same gem path as user-installed gems.
     EOF
   end
 

--- a/lib/rubygems/commands/exec_command.rb
+++ b/lib/rubygems/commands/exec_command.rb
@@ -56,12 +56,13 @@ to the same gem path as user-installed gems.
   end
 
   def execute
-    gem_paths = { "GEM_HOME": Gem.paths.home, "GEM_PATH": Gem.paths.path, "GEM_SPEC_CACHE": Gem.paths.spec_cache_dir }
+    gem_paths = { "GEM_HOME" => Gem.paths.home, "GEM_PATH" => Gem.paths.path.join(Gem.path_separator), "GEM_SPEC_CACHE" => Gem.paths.spec_cache_dir }
 
     check_executable
 
     print_command
     if options[:gem_name] == "gem" && options[:executable] == "gem"
+      set_gem_exec_install_paths
       Gem::GemRunner.new.run options[:args]
       return
     elsif options[:conservative]
@@ -73,7 +74,8 @@ to the same gem path as user-installed gems.
 
     load!
   ensure
-    Gem.paths = gem_paths
+    ENV.update(gem_paths)
+    Gem.clear_paths
   end
 
   private

--- a/lib/rubygems/commands/exec_command.rb
+++ b/lib/rubygems/commands/exec_command.rb
@@ -56,7 +56,7 @@ to the same gem path as user-installed gems.
   end
 
   def execute
-    gem_paths = { "GEM_HOME" => Gem.paths.home, "GEM_PATH" => Gem.paths.path.join(Gem.path_separator), "GEM_SPEC_CACHE" => Gem.paths.spec_cache_dir }.compact
+    gem_paths = { "GEM_HOME" => Gem.paths.home, "GEM_PATH" => Gem.paths.path.join(File::PATH_SEPARATOR), "GEM_SPEC_CACHE" => Gem.paths.spec_cache_dir }.compact
 
     check_executable
 
@@ -144,7 +144,7 @@ to the same gem path as user-installed gems.
   def set_gem_exec_install_paths
     home = File.join(Gem.dir, "gem_exec")
 
-    ENV["GEM_PATH"] = ([home] + Gem.path).join(Gem.path_separator)
+    ENV["GEM_PATH"] = ([home] + Gem.path).join(File::PATH_SEPARATOR)
     ENV["GEM_HOME"] = home
     Gem.clear_paths
   end

--- a/lib/rubygems/commands/exec_command.rb
+++ b/lib/rubygems/commands/exec_command.rb
@@ -56,7 +56,7 @@ to the same gem path as user-installed gems.
   end
 
   def execute
-    gem_paths = { "GEM_HOME" => Gem.paths.home, "GEM_PATH" => Gem.paths.path.join(Gem.path_separator), "GEM_SPEC_CACHE" => Gem.paths.spec_cache_dir }
+    gem_paths = { "GEM_HOME" => Gem.paths.home, "GEM_PATH" => Gem.paths.path.join(Gem.path_separator), "GEM_SPEC_CACHE" => Gem.paths.spec_cache_dir }.compact
 
     check_executable
 
@@ -74,7 +74,7 @@ to the same gem path as user-installed gems.
 
     load!
   ensure
-    ENV.update(gem_paths)
+    ENV.update(gem_paths) if gem_paths
     Gem.clear_paths
   end
 

--- a/lib/rubygems/commands/exec_command.rb
+++ b/lib/rubygems/commands/exec_command.rb
@@ -118,7 +118,7 @@ to the same gem path as user-installed gems.
     max_length = opts.map {|k, _| k.size }.max
     opts.each do |k, v|
       next if v.nil?
-      verbose "\t#{k.to_s.rjust(max_length)}: #{v} "
+      verbose "\t#{k.to_s.rjust(max_length)}: #{v}"
     end
     verbose ""
   end
@@ -127,6 +127,7 @@ to the same gem path as user-installed gems.
     activate!
   rescue Gem::MissingSpecError
     verbose "#{Gem::Dependency.new(options[:gem_name], options[:version])} not available locally, installing from remote"
+    verbose "\t#{Gem::Specification.all_names}"
     install
     activate!
   end
@@ -135,12 +136,11 @@ to the same gem path as user-installed gems.
     gem_name = options[:gem_name]
     gem_version = options[:version]
 
-    home = Gem.paths.home
-    home = File.join(home, "gem_exec")
-    Gem.use_paths(home, Gem.path + [home])
+    home = File.join(Gem.dir, "gem_exec")
+    Gem.use_paths(home, [home] + Gem.path)
 
     suppress_always_install do
-      Gem.install(gem_name, gem_version)
+      Gem.install(gem_name, gem_version, minimal_deps: false)
     end
   rescue Gem::InstallError => e
     alert_error "Error installing #{gem_name}:\n\t#{e.message}"

--- a/test/rubygems/test_gem_commands_exec_command.rb
+++ b/test/rubygems/test_gem_commands_exec_command.rb
@@ -739,7 +739,7 @@ class TestGemCommandsExecCommand < Gem::TestCase
       assert_match /\A\s*\** LOCAL GEMS \**\s*\z/m, @ui.output
 
       invoke "gem", "env", "GEM_HOME"
-      assert_match /#{File::SEPARATOR}gem_exec$/, @ui.output
+      assert_equal "#{@gem_home}/gem_exec\n", @ui.output
     end
   end
 end

--- a/test/rubygems/test_gem_commands_exec_command.rb
+++ b/test/rubygems/test_gem_commands_exec_command.rb
@@ -10,8 +10,8 @@ class TestGemCommandsExecCommand < Gem::TestCase
     @cmd = Gem::Commands::ExecCommand.new
 
     @orig_args = Gem::Command.build_args
-
-    common_installer_setup
+    @orig_specific_extra_args = Gem::Command.specific_extra_args_hash.dup
+    @orig_extra_args = Gem::Command.extra_args.dup
 
     @gem_home = Gem.dir
     @gem_path = Gem.path
@@ -27,6 +27,8 @@ class TestGemCommandsExecCommand < Gem::TestCase
     common_installer_teardown
 
     Gem::Command.build_args = @orig_args
+    Gem::Command.specific_extra_args_hash = @orig_specific_extra_args
+    Gem::Command.extra_args = @orig_extra_args
     Gem.configuration = nil
   end
 

--- a/test/rubygems/test_gem_commands_exec_command.rb
+++ b/test/rubygems/test_gem_commands_exec_command.rb
@@ -216,6 +216,8 @@ class TestGemCommandsExecCommand < Gem::TestCase
   end
 
   def test_gem_with_platform_and_platform_dependencies
+    pend "extensions don't quite work on jruby" if Gem.java_platform?
+
     platforms = Gem.platforms.dup
 
     spec_fetcher do |fetcher|

--- a/test/rubygems/test_gem_commands_exec_command.rb
+++ b/test/rubygems/test_gem_commands_exec_command.rb
@@ -270,6 +270,7 @@ class TestGemCommandsExecCommand < Gem::TestCase
     use_ui @ui do
       util_set_arch "unknown-unknown"
       invoke "a"
+      assert_empty @ui.error
       assert_equal "Building native extensions. This could take a while...\na-2\nsometimes_used-2\nwith_platform-2\n", @ui.output
     end
 

--- a/test/rubygems/test_gem_commands_exec_command.rb
+++ b/test/rubygems/test_gem_commands_exec_command.rb
@@ -756,7 +756,7 @@ class TestGemCommandsExecCommand < Gem::TestCase
     end
 
     use_ui @ui do
-      assert_raises Gem::MockGemUi::TermError do
+      assert_raise Gem::MockGemUi::TermError do
         invoke "a"
       end
       assert_equal "ERROR:  Could not find a valid gem 'a' (>= 0) in any repository\n" +

--- a/test/rubygems/test_gem_commands_exec_command.rb
+++ b/test/rubygems/test_gem_commands_exec_command.rb
@@ -1,0 +1,463 @@
+# frozen_string_literal: true
+require_relative "helper"
+require "rubygems/commands/exec_command"
+
+class TestGemCommandsExecCommand < Gem::TestCase
+  def setup
+    super
+    common_installer_setup
+
+    @cmd = Gem::Commands::ExecCommand.new
+
+    @orig_args = Gem::Command.build_args
+
+    common_installer_setup
+  end
+
+  def teardown
+    super
+
+    common_installer_teardown
+
+    Gem::Command.build_args = @orig_args
+  end
+
+  def test_error_with_no_arguments
+    e = assert_raise Gem::CommandLineError do
+      @cmd.invoke
+    end
+    assert_equal "Please specify an executable to run (e.g. gem exec COMMAND)",
+      e.message
+  end
+
+  def test_error_with_no_executable
+    e = assert_raise Gem::CommandLineError do
+      @cmd.invoke "--verbose", "--gem", "GEM", "--version", "< 10", "--conservative"
+    end
+    assert_equal "Please specify an executable to run (e.g. gem exec COMMAND)",
+      e.message
+  end
+
+  def test_full_option_parsing
+    @cmd.when_invoked do |options|
+      assert_equal options, {
+        args: ["install", "--no-color", "--help", "--verbose"],
+        executable: "pod",
+        :explicit_prerelease => false,
+        gem_name: "cocoapods",
+        prerelease: false,
+        :version => Gem::Requirement.new(["> 1", "< 1.3"]),
+        build_args: nil,
+      }
+    end
+    @cmd.invoke "--gem", "cocoapods", "-v", "> 1", "--version", "< 1.3", "--verbose", "--", "pod", "install", "--no-color", "--help", "--verbose"
+ end
+
+  def test_single_arg_parsing
+    @cmd.when_invoked do |options|
+      assert_equal options, {
+        args: [],
+        executable: "rails",
+        gem_name: "rails",
+        :version => Gem::Requirement.new([">= 0"]),
+        build_args: nil,
+      }
+    end
+    @cmd.invoke "rails"
+  end
+
+  def test_single_arg_parsing_with_version
+    @cmd.when_invoked do |options|
+      assert_equal options, {
+        args: [],
+        executable: "rails",
+        gem_name: "rails",
+        :version => Gem::Requirement.new(["= 7.1"]),
+        build_args: nil,
+      }
+    end
+    @cmd.invoke "rails:7.1"
+  end
+
+  def test_gem_without_executable
+    spec_fetcher do |fetcher|
+      fetcher.gem "a", 2
+    end
+
+    util_clear_gems
+
+    use_ui @ui do
+      e = assert_raise Gem::MockGemUi::TermError, @ui.error do
+        @cmd.invoke "a:2"
+      end
+      assert_equal 1, e.exit_code
+      assert_equal "ERROR:  Failed to load executable `a`, are you sure the gem `a` contains it?\n", @ui.error
+    end
+  end
+
+  def test_gem_with_executable
+    spec_fetcher do |fetcher|
+      fetcher.gem "a", 2 do |s|
+        s.executables = %w[a]
+        s.files = %w[bin/a lib/a.rb]
+
+        write_file File.join(*%W[gems #{s.original_name}      bin a]) do |f|
+          f << "Gem.ui.say #{s.original_name.dump}"
+        end
+      end
+    end
+
+    util_clear_gems
+
+    use_ui @ui do
+      @cmd.invoke "a:2"
+      assert_equal "a-2\n", @ui.output
+    end
+  end
+
+  def test_gem_with_other_executable_name
+    spec_fetcher do |fetcher|
+      fetcher.gem "a", 2 do |s|
+        s.executables = %w[foo]
+        s.files = %w[bin/foo lib/a.rb]
+
+        write_file File.join(*%W[gems #{s.original_name}      bin foo]) do |f|
+          f << "Gem.ui.say #{s.original_name.dump}"
+        end
+      end
+    end
+
+    util_clear_gems
+
+    use_ui @ui do
+      @cmd.invoke "a:2"
+      assert_equal "a-2\n", @ui.output
+    end
+  end
+
+  def test_gem_with_executable_error
+    spec_fetcher do |fetcher|
+      fetcher.gem "a", 2 do |s|
+        s.executables = %w[foo]
+        s.files = %w[bin/foo lib/a.rb]
+
+        write_file File.join(*%W[gems #{s.original_name}      bin foo]) do |f|
+          f << "raise #{s.original_name.dump}"
+        end
+      end
+    end
+
+    util_clear_gems
+
+    use_ui @ui do
+      e = assert_raise RuntimeError do
+        @cmd.invoke "a:2"
+      end
+      assert_equal "a-2", e.message
+      assert_empty @ui.error
+    end
+  end
+
+  def test_gem_with_multiple_executables_one_match
+    spec_fetcher do |fetcher|
+      fetcher.gem "a", 2 do |s|
+        s.executables = %w[foo a]
+        s.files = %w[bin/foo bin/a lib/a.rb]
+
+        write_file File.join(*%W[gems #{s.original_name}      bin foo]) do |f|
+          f << "Gem.ui.say #{s.original_name.dump} + ' ' + File.basename(__FILE__)"
+        end
+
+        write_file File.join(*%W[gems #{s.original_name}      bin a]) do |f|
+          f << "Gem.ui.say #{s.original_name.dump} + ' ' + File.basename(__FILE__)"
+        end
+      end
+    end
+
+    util_clear_gems
+
+    use_ui @ui do
+      @cmd.invoke "a:2"
+      assert_equal "a-2 a\n", @ui.output
+    end
+  end
+
+  def test_gem_with_multiple_executables_no_match
+    spec_fetcher do |fetcher|
+      fetcher.gem "a", 2 do |s|
+        s.executables = %w[foo bar]
+        s.files = %w[bin/foo bin/bar lib/a.rb]
+
+        write_file File.join(*%W[gems #{s.original_name}      bin foo]) do |f|
+          f << "Gem.ui.say #{s.original_name.dump} + ' ' + File.basename(__FILE__)"
+        end
+
+        write_file File.join(*%W[gems #{s.original_name}      bin bar]) do |f|
+          f << "Gem.ui.say #{s.original_name.dump} + ' ' + File.basename(__FILE__)"
+        end
+      end
+    end
+
+    util_clear_gems
+
+    use_ui @ui do
+      @cmd.invoke "a:2"
+      assert_equal "a-2 foo\n", @ui.output
+    end
+  end
+
+  def test_gem_dependency_contains_executable
+    spec_fetcher do |fetcher|
+      fetcher.gem "a", 2 do |s|
+        s.executables = %w[]
+        s.files = %w[lib/a.rb]
+
+        s.add_dependency "b"
+      end
+
+      fetcher.gem "b", 2 do |s|
+        s.executables = %w[a]
+        s.files = %w[bin/a lib/b.rb]
+
+        write_file File.join(*%W[gems #{s.original_name}      bin a]) do |f|
+          f << "Gem.ui.say #{s.original_name.dump} + ' ' + File.basename(__FILE__)"
+        end
+      end
+    end
+
+    util_clear_gems
+
+    use_ui @ui do
+      @cmd.invoke "a:2"
+      assert_equal "b-2 a\n", @ui.output
+    end
+  end
+
+  def test_gem_dependency_contains_other_executable
+    spec_fetcher do |fetcher|
+      fetcher.gem "a", 2 do |s|
+        s.executables = %w[]
+        s.files = %w[lib/a.rb]
+
+        s.add_dependency "b"
+      end
+
+      fetcher.gem "b", 2 do |s|
+        s.executables = %w[foo]
+        s.files = %w[bin/foo lib/b.rb]
+
+        write_file File.join(*%W[gems #{s.original_name}      bin foo]) do |f|
+          f << "Gem.ui.say #{s.original_name.dump} + ' ' + File.basename(__FILE__)"
+        end
+      end
+    end
+
+    util_clear_gems
+
+    use_ui @ui do
+      e = assert_raise Gem::MockGemUi::TermError do
+        @cmd.invoke "a:2"
+      end
+      assert_equal 1, e.exit_code
+      assert_equal <<~ERR, @ui.error
+        ERROR:  Failed to load executable `a`, are you sure the gem `a` contains it?
+      ERR
+    end
+  end
+
+  def test_other_gem_contains_executable
+    spec_fetcher do |fetcher|
+      fetcher.gem "a", 2 do |s|
+        s.executables = %w[]
+        s.files = %w[lib/a.rb]
+      end
+
+      fetcher.gem "b", 2 do |s|
+        s.executables = %w[a]
+        s.files = %w[bin/a lib/b.rb]
+
+        write_file File.join(*%W[gems #{s.original_name}      bin foo]) do |f|
+          f << "Gem.ui.say #{s.original_name.dump} + ' ' + File.basename(__FILE__)"
+        end
+      end
+    end
+
+    util_clear_gems
+
+    use_ui @ui do
+      e = assert_raise Gem::MockGemUi::TermError do
+        @cmd.invoke "a:2"
+      end
+      assert_equal 1, e.exit_code
+      assert_equal <<~ERR, @ui.error
+        ERROR:  Failed to load executable `a`, are you sure the gem `a` contains it?
+      ERR
+    end
+  end
+
+  def test_missing_gem
+    spec_fetcher do |fetcher|
+    end
+
+    use_ui @ui do
+      e = assert_raise Gem::MockGemUi::TermError do
+        @cmd.invoke "a"
+      end
+      assert_equal 2, e.exit_code
+      assert_equal <<~ERR, @ui.error
+        ERROR:  Could not find a valid gem 'a' (>= 0) in any repository
+      ERR
+    end
+  end
+
+  def test_version_mismatch
+    spec_fetcher do |fetcher|
+      fetcher.gem "a", 1
+    end
+
+    util_clear_gems
+
+    use_ui @ui do
+      e = assert_raise Gem::MockGemUi::TermError do
+        @cmd.invoke "a:2"
+      end
+      assert_equal 2, e.exit_code
+      assert_equal <<~ERR, @ui.error
+        ERROR:  Could not find a valid gem 'a' (= 2) in any repository
+        ERROR:  Possible alternatives: a
+      ERR
+    end
+  end
+
+  def test_pre_argument
+    spec_fetcher do |fetcher|
+      fetcher.gem "a", 1 do |s|
+        s.executables = %w[foo]
+        s.files = %w[bin/foo lib/a.rb]
+
+        write_file File.join(*%W[gems #{s.original_name}      bin foo]) do |f|
+          f << "Gem.ui.say #{s.original_name.dump} + ' ' + File.basename(__FILE__)"
+        end
+      end
+      fetcher.gem "a", "1.1.a" do |s|
+        s.executables = %w[foo ]
+        s.files = %w[bin/foo lib/a.rb]
+
+        write_file File.join(*%W[gems #{s.original_name}      bin foo]) do |f|
+          f << "Gem.ui.say #{s.original_name.dump} + ' ' + File.basename(__FILE__)"
+        end
+      end
+    end
+
+    util_clear_gems
+
+    use_ui @ui do
+      @cmd.invoke "--pre", "a"
+      assert_equal "a-1.1.a foo\n", @ui.output
+    end
+  end
+
+  def test_pre_version_option
+    spec_fetcher do |fetcher|
+      fetcher.gem "a", 1 do |s|
+        s.executables = %w[foo]
+        s.files = %w[bin/foo lib/a.rb]
+
+        write_file File.join(*%W[gems #{s.original_name}      bin foo]) do |f|
+          f << "Gem.ui.say #{s.original_name.dump} + ' ' + File.basename(__FILE__)"
+        end
+      end
+      fetcher.gem "a", "1.1.a" do |s|
+        s.executables = %w[foo ]
+        s.files = %w[bin/foo lib/a.rb]
+
+        write_file File.join(*%W[gems #{s.original_name}      bin foo]) do |f|
+          f << "Gem.ui.say #{s.original_name.dump} + ' ' + File.basename(__FILE__)"
+        end
+      end
+    end
+
+    util_clear_gems
+
+    use_ui @ui do
+      @cmd.invoke "-v", ">= 0.a", "a"
+      assert_equal "a-1.1.a foo\n", @ui.output
+    end
+  end
+
+  def test_conservative_missing_gem
+    spec_fetcher do |fetcher|
+      fetcher.gem "a", 1 do |s|
+        s.executables = %w[foo]
+        s.files = %w[bin/foo lib/a.rb]
+
+        write_file File.join(*%W[gems #{s.original_name}      bin foo]) do |f|
+          f << "Gem.ui.say #{s.original_name.dump} + ' ' + File.basename(__FILE__)"
+        end
+      end
+    end
+
+    util_clear_gems
+
+    use_ui @ui do
+      e = assert_raise Gem::MockGemUi::TermError do
+        @cmd.invoke "--verbose", "--conservative", "a:2"
+      end
+      assert_equal 2, e.exit_code
+      assert_include @ui.output, "a (= 2) not available locally"
+      assert_equal <<~ERROR, @ui.error
+        ERROR:  Could not find a valid gem 'a' (= 2) in any repository
+        ERROR:  Possible alternatives: a
+      ERROR
+    end
+  end
+
+  def test_conservative
+    spec_fetcher do |fetcher|
+      fetcher.gem "a", 1 do |s|
+        s.executables = %w[foo]
+        s.files = %w[bin/foo lib/a.rb]
+
+        write_file File.join(*%W[gems #{s.original_name}      bin foo]) do |f|
+          f << "Gem.ui.say #{s.original_name.dump} + ' ' + File.basename(__FILE__)"
+        end
+      end
+    end
+
+    util_clear_gems
+
+    use_ui @ui do
+      @cmd.invoke "--verbose", "--conservative", "a"
+      assert_include @ui.output, "a (>= 0) not available locally"
+      assert_include @ui.output, "a-1 foo"
+    end
+
+    @ui.outs.truncate(0)
+
+    spec_fetcher do |fetcher|
+      fetcher.gem "a", 1 do |s|
+        s.executables = %w[foo]
+        s.files = %w[bin/foo lib/a.rb]
+
+        write_file File.join(*%W[gems #{s.original_name}      bin foo]) do |f|
+          f << "Gem.ui.say #{s.original_name.dump} + ' ' + File.basename(__FILE__)"
+        end
+      end
+
+      fetcher.gem "a", 2 do |s|
+        s.executables = %w[foo]
+        s.files = %w[bin/foo lib/a.rb]
+
+        write_file File.join(*%W[gems #{s.original_name}      bin foo]) do |f|
+          f << "Gem.ui.say #{s.original_name.dump} + ' ' + File.basename(__FILE__)"
+        end
+      end
+    end
+
+    use_ui @ui do
+      @cmd.invoke "--verbose", "--conservative", "a"
+      assert_not_include @ui.output, "a (>= 0) not available locally"
+      assert_include @ui.output, "a-1 foo"
+    end
+  end
+end

--- a/test/rubygems/test_gem_commands_exec_command.rb
+++ b/test/rubygems/test_gem_commands_exec_command.rb
@@ -27,6 +27,7 @@ class TestGemCommandsExecCommand < Gem::TestCase
     common_installer_teardown
 
     Gem::Command.build_args = @orig_args
+    Gem.configuration = nil
   end
 
   def invoke(*args)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Lack of an easy way to run executables from gems that may or may not be installed.

## What is your fix for the problem, implemented in this PR?

See https://github.com/rubygems/rfcs/pull/45

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
