### PR TITLE
Deprecate Gem::List

### DIFF
--- a/lib/rubygems/util/list.rb
+++ b/lib/rubygems/util/list.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 module Gem
-  class List
+  # The Gem::List class is currently unused and will be removed in the next major rubygems version
+  class List # :nodoc:
     include Enumerable
     attr_accessor :value, :tail
 
@@ -34,4 +35,5 @@ module Gem
       List.new value, list
     end
   end
+  deprecate_constant :List
 end

--- a/test/rubygems/test_gem_util.rb
+++ b/test/rubygems/test_gem_util.rb
@@ -55,14 +55,6 @@ class TestGemUtil < Gem::TestCase
     FileUtils.chmod(0775, "d/e") unless win_platform? || java_platform?
   end
 
-  def test_linked_list_find
-    list = [1,2,3,4,5].inject(Gem::List.new(0)) do |m,o|
-      Gem::List.new o, m
-    end
-    assert_equal 5, list.find {|x| x == 5 }
-    assert_equal 4, list.find {|x| x == 4 }
-  end
-
   def test_glob_files_in_dir
     FileUtils.mkdir_p "g"
     FileUtils.touch File.join("g", "h.rb")


### PR DESCRIPTION
It is unused, we will remove it in the next major version