### PR TITLE
Don't warn on `bundle binstubs --standalone --all`

### DIFF
--- a/bundler/lib/bundler/cli/binstubs.rb
+++ b/bundler/lib/bundler/cli/binstubs.rb
@@ -40,7 +40,11 @@ module Bundler
         end
 
         if options[:standalone]
-          next Bundler.ui.warn("Sorry, Bundler can only be run via RubyGems.") if gem_name == "bundler"
+          if gem_name == "bundler"
+            Bundler.ui.warn("Sorry, Bundler can only be run via RubyGems.") unless options[:all]
+            next
+          end
+
           Bundler.settings.temporary(:path => (Bundler.settings[:path] || Bundler.root)) do
             installer.generate_standalone_bundler_executable_stubs(spec, installer_opts)
           end

--- a/bundler/spec/commands/binstubs_spec.rb
+++ b/bundler/spec/commands/binstubs_spec.rb
@@ -369,6 +369,7 @@ RSpec.describe "bundle binstubs <gem>" do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
+        gem "rails"
       G
     end
 
@@ -394,6 +395,26 @@ RSpec.describe "bundle binstubs <gem>" do
         bundle "binstubs rack --standalone --all-platforms"
         expect(bundled_app("bin/rackup")).to exist
         expect(bundled_app("bin/rackup.cmd")).to exist
+      end
+    end
+
+    context "when the gem is bundler" do
+      it "warns without generating a standalone binstub" do
+        bundle "binstubs bundler --standalone"
+        expect(bundled_app("bin/bundle")).not_to exist
+        expect(bundled_app("bin/bundler")).not_to exist
+        expect(err).to include("Sorry, Bundler can only be run via RubyGems.")
+      end
+    end
+
+    context "when specified --all option" do
+      it "generates standalone binstubs for all gems except bundler" do
+        bundle "binstubs --standalone --all"
+        expect(bundled_app("bin/rackup")).to exist
+        expect(bundled_app("bin/rails")).to exist
+        expect(bundled_app("bin/bundle")).not_to exist
+        expect(bundled_app("bin/bundler")).not_to exist
+        expect(err).not_to include("Sorry, Bundler can only be run via RubyGems.")
       end
     end
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Prior to this commit `bundle binstubs --standalone --all` would output a warning about not being able to generate a standalone binstub for bundler.

This warning predates the `--all` option, and I don't think it makes sense in this context. The warning makes good sense when explicitly trying to generate a bundler standalone binstub with `bundle binstubs bundler --standalone`, since that command won't do what the user might have expected. But `--all` is not specifically asking for bundler, and having it report each time that the bundler binstubs could not be generated does not seem particularly helpful. The only way to make that warning go away would be to stop using `--standalone --all`.

## What is your fix for the problem, implemented in this PR?

This commit skips the warning when running with the `--all` option.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
