### PR TITLE
Include links to pull requests in changelog

### DIFF
--- a/.changelog.yml
+++ b/.changelog.yml
@@ -2,7 +2,7 @@
 
 header_template: "# %new_version / %release_date"
 
-entry_template: "* %title. Pull request #%pull_request_number by %pull_request_author"
+entry_template: "* %title. Pull request [#%pull_request_number](%pull_request_url) by %pull_request_author"
 
 extra_entry:
   template: "* %title."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ## Documentation:
 
-* Improve documentation about `Kernel` monkeypatches. Pull request #6217
+* Improve documentation about `Kernel` monkeypatches. Pull request [#6217](https://github.com/rubygems/rubygems/pull/6217)
   by nobu
 
 # 3.4.3 / 2023-01-06
@@ -23,13 +23,13 @@
 
 ## Documentation:
 
-* Fix several typos. Pull request #6224 by jdufresne
+* Fix several typos. Pull request [#6224](https://github.com/rubygems/rubygems/pull/6224) by jdufresne
 
 # 3.4.2 / 2023-01-01
 
 ## Enhancements:
 
-* Add global flag (`-C`) to change execution directory. Pull request #6180
+* Add global flag (`-C`) to change execution directory. Pull request [#6180](https://github.com/rubygems/rubygems/pull/6180)
   by gustavothecoder
 * Installs bundler 2.4.2 as a default gem.
 
@@ -44,44 +44,44 @@
 ## Breaking changes:
 
 * Drop support for Ruby 2.3, 2.4, 2.5 and RubyGems 2.5, 2.6, 2.7. Pull
-  request #6107 by deivid-rodriguez
-* Remove support for deprecated OS. Pull request #6041 by peterzhu2118
+  request [#6107](https://github.com/rubygems/rubygems/pull/6107) by deivid-rodriguez
+* Remove support for deprecated OS. Pull request [#6041](https://github.com/rubygems/rubygems/pull/6041) by peterzhu2118
 
 ## Features:
 
-* Add 'call for update' to RubyGems install command. Pull request #5922 by
+* Add 'call for update' to RubyGems install command. Pull request [#5922](https://github.com/rubygems/rubygems/pull/5922) by
   simi
 
 ## Enhancements:
 
-* Add `mswin` support for cargo builder. Pull request #6167 by ianks
+* Add `mswin` support for cargo builder. Pull request [#6167](https://github.com/rubygems/rubygems/pull/6167) by ianks
 * Validate Cargo.lock is present for Rust based extensions. Pull request
-  #6151 by simi
-* Clean built artifacts after building extensions. Pull request #6133 by
+  [#6151](https://github.com/rubygems/rubygems/pull/6151) by simi
+* Clean built artifacts after building extensions. Pull request [#6133](https://github.com/rubygems/rubygems/pull/6133) by
   deivid-rodriguez
 * Installs bundler 2.4.0 as a default gem.
 
 ## Bug fixes:
 
-* Fix crash due to `BundlerVersionFinder` not defined. Pull request #6152
+* Fix crash due to `BundlerVersionFinder` not defined. Pull request [#6152](https://github.com/rubygems/rubygems/pull/6152)
   by deivid-rodriguez
 * Don't leave corrupted partial package download around when running out
-  of disk space. Pull request #5681 by duckinator
+  of disk space. Pull request [#5681](https://github.com/rubygems/rubygems/pull/5681) by duckinator
 
 # 3.3.26 / 2022-11-16
 
 ## Enhancements:
 
-* Upgrade rb-sys to 0.9.37. Pull request #6047 by ianks
+* Upgrade rb-sys to 0.9.37. Pull request [#6047](https://github.com/rubygems/rubygems/pull/6047) by ianks
 * Installs bundler 2.3.26 as a default gem.
 
 # 3.3.25 / 2022-11-02
 
 ## Enhancements:
 
-* Github source should default to secure protocol. Pull request #6026 by
+* Github source should default to secure protocol. Pull request [#6026](https://github.com/rubygems/rubygems/pull/6026) by
   jasonkarns
-* Allow upcoming JRuby to pass keywords to Kernel#warn. Pull request #6002
+* Allow upcoming JRuby to pass keywords to Kernel#warn. Pull request [#6002](https://github.com/rubygems/rubygems/pull/6002)
   by enebo
 * Installs bundler 2.3.25 as a default gem.
 
@@ -96,38 +96,38 @@
 ## Enhancements:
 
 * Add better error handling for permanent redirect responses. Pull request
-  #5931 by jenshenny
+  [#5931](https://github.com/rubygems/rubygems/pull/5931) by jenshenny
 * Installs bundler 2.3.23 as a default gem.
 
 ## Bug fixes:
 
 * Fix generic arm platform matching against runtime arm platforms with
-  eabi modifiers. Pull request #5957 by deivid-rodriguez
+  eabi modifiers. Pull request [#5957](https://github.com/rubygems/rubygems/pull/5957) by deivid-rodriguez
 * Fix `Gem::Platform.match` not handling String argument properly. Pull
-  request #5939 by flavorjones
-* Fix resolution on non-musl platforms. Pull request #5915 by
+  request [#5939](https://github.com/rubygems/rubygems/pull/5939) by flavorjones
+* Fix resolution on non-musl platforms. Pull request [#5915](https://github.com/rubygems/rubygems/pull/5915) by
   deivid-rodriguez
-* Mask the file mode when extracting files. Pull request #5906 by
+* Mask the file mode when extracting files. Pull request [#5906](https://github.com/rubygems/rubygems/pull/5906) by
   kddnewton
 
 # 3.3.22 / 2022-09-07
 
 ## Enhancements:
 
-* Support non gnu libc arm-linux-eabi platforms. Pull request #5889 by
+* Support non gnu libc arm-linux-eabi platforms. Pull request [#5889](https://github.com/rubygems/rubygems/pull/5889) by
   ntkme
 * Installs bundler 2.3.22 as a default gem.
 
 ## Bug fixes:
 
-* Fix `gem info` with explicit `--version`. Pull request #5884 by
+* Fix `gem info` with explicit `--version`. Pull request [#5884](https://github.com/rubygems/rubygems/pull/5884) by
   tonyaraujop
 
 # 3.3.21 / 2022-08-24
 
 ## Enhancements:
 
-* Support non gnu libc linux platforms. Pull request #5852 by
+* Support non gnu libc linux platforms. Pull request [#5852](https://github.com/rubygems/rubygems/pull/5852) by
   deivid-rodriguez
 * Installs bundler 2.3.21 as a default gem.
 
@@ -135,44 +135,44 @@
 
 ## Enhancements:
 
-* Include backtrace with crashes by default. Pull request #5811 by
+* Include backtrace with crashes by default. Pull request [#5811](https://github.com/rubygems/rubygems/pull/5811) by
   deivid-rodriguez
 * Don't create broken symlinks when a gem includes them, but print a
-  warning instead. Pull request #5801 by deivid-rodriguez
+  warning instead. Pull request [#5801](https://github.com/rubygems/rubygems/pull/5801) by deivid-rodriguez
 * Warn (rather than crash) when setting `nil` specification versions. Pull
-  request #5794 by deivid-rodriguez
+  request [#5794](https://github.com/rubygems/rubygems/pull/5794) by deivid-rodriguez
 * Installs bundler 2.3.20 as a default gem.
 
 ## Bug fixes:
 
 * Always consider installed specs for resolution, even if prereleases.
-  Pull request #5821 by deivid-rodriguez
+  Pull request [#5821](https://github.com/rubygems/rubygems/pull/5821) by deivid-rodriguez
 * Fix `gem install` with `--platform` flag not matching simulated platform
-  correctly. Pull request #5820 by deivid-rodriguez
-* Fix platform matching for index specs. Pull request #5795 by Ilushkanama
+  correctly. Pull request [#5820](https://github.com/rubygems/rubygems/pull/5820) by deivid-rodriguez
+* Fix platform matching for index specs. Pull request [#5795](https://github.com/rubygems/rubygems/pull/5795) by Ilushkanama
 
 # 3.3.19 / 2022-07-27
 
 ## Enhancements:
 
-* Display mfa warnings on `gem signin`. Pull request #5590 by aellispierce
-* Require fileutils more lazily when installing gems. Pull request #5738
+* Display mfa warnings on `gem signin`. Pull request [#5590](https://github.com/rubygems/rubygems/pull/5590) by aellispierce
+* Require fileutils more lazily when installing gems. Pull request [#5738](https://github.com/rubygems/rubygems/pull/5738)
   by deivid-rodriguez
 * Fix upgrading RubyGems with a customized `Gem.default_dir`. Pull request
-  #5728 by deivid-rodriguez
+  [#5728](https://github.com/rubygems/rubygems/pull/5728) by deivid-rodriguez
 * Stop using `/dev/null` for silent ui for WASI platform. Pull request
-  #5703 by kateinoigakukun
-* Unify loading `Gem::Requirement`. Pull request #5596 by deivid-rodriguez
+  [#5703](https://github.com/rubygems/rubygems/pull/5703) by kateinoigakukun
+* Unify loading `Gem::Requirement`. Pull request [#5596](https://github.com/rubygems/rubygems/pull/5596) by deivid-rodriguez
 * Installs bundler 2.3.19 as a default gem.
 
 ## Bug fixes:
 
 * Fix `ruby setup.rb` with `--destdir` writing outside of `--destdir`.
-  Pull request #5737 by deivid-rodriguez
+  Pull request [#5737](https://github.com/rubygems/rubygems/pull/5737) by deivid-rodriguez
 
 ## Documentation:
 
-* Fix wrong information about default RubyGems source. Pull request #5723
+* Fix wrong information about default RubyGems source. Pull request [#5723](https://github.com/rubygems/rubygems/pull/5723)
   by tnir
 
 # 3.3.18 / 2022-07-14
@@ -180,64 +180,64 @@
 ## Enhancements:
 
 * Make platform `universal-mingw32` match "x64-mingw-ucrt". Pull request
-  #5655 by johnnyshields
+  [#5655](https://github.com/rubygems/rubygems/pull/5655) by johnnyshields
 * Add more descriptive messages when `gem update` fails to update some
-  gems. Pull request #5676 by brianleshopify
+  gems. Pull request [#5676](https://github.com/rubygems/rubygems/pull/5676) by brianleshopify
 * Installs bundler 2.3.18 as a default gem.
 
 ## Bug fixes:
 
 * Make sure RubyGems prints no warnings when loading plugins. Pull request
-  #5607 by deivid-rodriguez
+  [#5607](https://github.com/rubygems/rubygems/pull/5607) by deivid-rodriguez
 
 # 3.3.17 / 2022-06-29
 
 ## Enhancements:
 
 * Document `gem env` argument aliases and add `gem env user_gemhome` and
-  `gem env user_gemdir`. Pull request #5644 by deivid-rodriguez
+  `gem env user_gemdir`. Pull request [#5644](https://github.com/rubygems/rubygems/pull/5644) by deivid-rodriguez
 * Improve error message when `operating_system.rb` fails to load. Pull
-  request #5658 by deivid-rodriguez
+  request [#5658](https://github.com/rubygems/rubygems/pull/5658) by deivid-rodriguez
 * Clean up temporary directory after `generate_index --update`. Pull
-  request #5653 by graywolf-at-work
-* Simplify extension builder. Pull request #5626 by deivid-rodriguez
+  request [#5653](https://github.com/rubygems/rubygems/pull/5653) by graywolf-at-work
+* Simplify extension builder. Pull request [#5626](https://github.com/rubygems/rubygems/pull/5626) by deivid-rodriguez
 * Installs bundler 2.3.17 as a default gem.
 
 ## Documentation:
 
 * Modify RubyGems issue template to be like the one for Bundler. Pull
-  request #5643 by deivid-rodriguez
+  request [#5643](https://github.com/rubygems/rubygems/pull/5643) by deivid-rodriguez
 
 # 3.3.16 / 2022-06-15
 
 ## Enhancements:
 
 * Auto-fix and warn gem packages including a gemspec with `require_paths`
-  as an array of arrays. Pull request #5615 by deivid-rodriguez
-* Misc cargo builder improvements. Pull request #5459 by ianks
+  as an array of arrays. Pull request [#5615](https://github.com/rubygems/rubygems/pull/5615) by deivid-rodriguez
+* Misc cargo builder improvements. Pull request [#5459](https://github.com/rubygems/rubygems/pull/5459) by ianks
 * Installs bundler 2.3.16 as a default gem.
 
 ## Bug fixes:
 
 * Fix incorrect password redaction when there's an error in `gem source
-  -a`. Pull request #5623 by deivid-rodriguez
+  -a`. Pull request [#5623](https://github.com/rubygems/rubygems/pull/5623) by deivid-rodriguez
 * Fix another regression when loading old marshaled specs. Pull request
-  #5610 by deivid-rodriguez
+  [#5610](https://github.com/rubygems/rubygems/pull/5610) by deivid-rodriguez
 
 # 3.3.15 / 2022-06-01
 
 ## Enhancements:
 
 * Support the change of did_you_mean about `Exception#detailed_message`.
-  Pull request #5560 by mame
+  Pull request [#5560](https://github.com/rubygems/rubygems/pull/5560) by mame
 * Installs bundler 2.3.15 as a default gem.
 
 ## Bug fixes:
 
 * Fix loading old marshaled specs including `YAML::PrivateType` constant.
-  Pull request #5415 by deivid-rodriguez
+  Pull request [#5415](https://github.com/rubygems/rubygems/pull/5415) by deivid-rodriguez
 * Fix rubygems update when non default `--install-dir` is configured. Pull
-  request #5566 by deivid-rodriguez
+  request [#5566](https://github.com/rubygems/rubygems/pull/5566) by deivid-rodriguez
 
 # 3.3.14 / 2022-05-18
 
@@ -253,43 +253,43 @@
 
 ## Bug fixes:
 
-* Fix regression when resolving ruby constraints. Pull request #5486 by
+* Fix regression when resolving ruby constraints. Pull request [#5486](https://github.com/rubygems/rubygems/pull/5486) by
   deivid-rodriguez
 
 ## Documentation:
 
-* Clarify description of owner-flags. Pull request #5497 by kronn
+* Clarify description of owner-flags. Pull request [#5497](https://github.com/rubygems/rubygems/pull/5497) by kronn
 
 # 3.3.12 / 2022-04-20
 
 ## Enhancements:
 
-* Less error swallowing when installing gems. Pull request #5475 by
+* Less error swallowing when installing gems. Pull request [#5475](https://github.com/rubygems/rubygems/pull/5475) by
   deivid-rodriguez
-* Stop considering `RUBY_PATCHLEVEL` for resolution. Pull request #5472 by
+* Stop considering `RUBY_PATCHLEVEL` for resolution. Pull request [#5472](https://github.com/rubygems/rubygems/pull/5472) by
   deivid-rodriguez
-* Bump vendored optparse to latest master. Pull request #5466 by
+* Bump vendored optparse to latest master. Pull request [#5466](https://github.com/rubygems/rubygems/pull/5466) by
   deivid-rodriguez
 * Installs bundler 2.3.12 as a default gem.
 
 ## Documentation:
 
-* Fix formatting in docs. Pull request #5470 by peterzhu2118
-* Fix a typo. Pull request #5401 by znz
+* Fix formatting in docs. Pull request [#5470](https://github.com/rubygems/rubygems/pull/5470) by peterzhu2118
+* Fix a typo. Pull request [#5401](https://github.com/rubygems/rubygems/pull/5401) by znz
 
 # 3.3.11 / 2022-04-07
 
 ## Enhancements:
 
-* Enable mfa on specific keys during gem signin. Pull request #5305 by
+* Enable mfa on specific keys during gem signin. Pull request [#5305](https://github.com/rubygems/rubygems/pull/5305) by
   aellispierce
-* Prefer `__dir__` to `__FILE__`. Pull request #5444 by deivid-rodriguez
-* Add cargo builder for rust extensions. Pull request #5175 by ianks
+* Prefer `__dir__` to `__FILE__`. Pull request [#5444](https://github.com/rubygems/rubygems/pull/5444) by deivid-rodriguez
+* Add cargo builder for rust extensions. Pull request [#5175](https://github.com/rubygems/rubygems/pull/5175) by ianks
 * Installs bundler 2.3.11 as a default gem.
 
 ## Documentation:
 
-* Improve RDoc setup. Pull request #5398 by deivid-rodriguez
+* Improve RDoc setup. Pull request [#5398](https://github.com/rubygems/rubygems/pull/5398) by deivid-rodriguez
 
 # 3.3.10 / 2022-03-23
 
@@ -299,10 +299,10 @@
 
 ## Documentation:
 
-* Enable `Gem::Package` example in RDoc documentation. Pull request #5399
+* Enable `Gem::Package` example in RDoc documentation. Pull request [#5399](https://github.com/rubygems/rubygems/pull/5399)
   by nobu
 * Unhide RDoc documentation from top level `Gem` module. Pull request
-  #5396 by nobu
+  [#5396](https://github.com/rubygems/rubygems/pull/5396) by nobu
 
 # 3.3.9 / 2022-03-09
 
@@ -324,64 +324,64 @@
 
 ## Documentation:
 
-* Fix missing rdoc for `Gem::Version`. Pull request #5299 by nevans
+* Fix missing rdoc for `Gem::Version`. Pull request [#5299](https://github.com/rubygems/rubygems/pull/5299) by nevans
 
 # 3.3.6 / 2022-01-26
 
 ## Enhancements:
 
 * Forbid downgrading past the originally shipped version on Ruby 3.1. Pull
-  request #5301 by deivid-rodriguez
-* Support `--enable-load-relative` inside binstubs. Pull request #2929 by
+  request [#5301](https://github.com/rubygems/rubygems/pull/5301) by deivid-rodriguez
+* Support `--enable-load-relative` inside binstubs. Pull request [#2929](https://github.com/rubygems/rubygems/pull/2929) by
   deivid-rodriguez
-* Let `Version#<=>` accept a String. Pull request #5275 by amatsuda
+* Let `Version#<=>` accept a String. Pull request [#5275](https://github.com/rubygems/rubygems/pull/5275) by amatsuda
 * Installs bundler 2.3.6 as a default gem.
 
 ## Bug fixes:
 
 * Avoid `flock` on non Windows systems, since it causing issues on NFS
-  file systems. Pull request #5278 by deivid-rodriguez
+  file systems. Pull request [#5278](https://github.com/rubygems/rubygems/pull/5278) by deivid-rodriguez
 * Fix `gem update --system`  for already installed version of
-  `rubygems-update`. Pull request #5285 by loadkpi
+  `rubygems-update`. Pull request [#5285](https://github.com/rubygems/rubygems/pull/5285) by loadkpi
 
 # 3.3.5 / 2022-01-12
 
 ## Enhancements:
 
-* Don't activate `yaml` gem from RubyGems. Pull request #5266 by
+* Don't activate `yaml` gem from RubyGems. Pull request [#5266](https://github.com/rubygems/rubygems/pull/5266) by
   deivid-rodriguez
 * Let `gem fetch` understand `<gem>:<version>` syntax and
-  `--[no-]suggestions` flag. Pull request #5242 by ximenasandoval
+  `--[no-]suggestions` flag. Pull request [#5242](https://github.com/rubygems/rubygems/pull/5242) by ximenasandoval
 * Installs bundler 2.3.5 as a default gem.
 
 ## Bug fixes:
 
-* Fix `gem install <non-existent-gem> --force` crash. Pull request #5262
+* Fix `gem install <non-existent-gem> --force` crash. Pull request [#5262](https://github.com/rubygems/rubygems/pull/5262)
   by deivid-rodriguez
-* Fix longstanding `gem install` failure on JRuby. Pull request #5228 by
+* Fix longstanding `gem install` failure on JRuby. Pull request [#5228](https://github.com/rubygems/rubygems/pull/5228) by
   deivid-rodriguez
 
 ## Documentation:
 
 * Markup `Gem::Specification` documentation with RDoc notations. Pull
-  request #5268 by nobu
+  request [#5268](https://github.com/rubygems/rubygems/pull/5268) by nobu
 
 # 3.3.4 / 2021-12-29
 
 ## Enhancements:
 
 * Don't redownload `rubygems-update` package if already there. Pull
-  request #5230 by deivid-rodriguez
+  request [#5230](https://github.com/rubygems/rubygems/pull/5230) by deivid-rodriguez
 * Installs bundler 2.3.4 as a default gem.
 
 ## Bug fixes:
 
 * Fix `gem update --system` crashing when latest version not supported.
-  Pull request #5191 by deivid-rodriguez
+  Pull request [#5191](https://github.com/rubygems/rubygems/pull/5191) by deivid-rodriguez
 
 ## Performance:
 
-* Make SpecificationPolicy autoload constant. Pull request #5222 by pocke
+* Make SpecificationPolicy autoload constant. Pull request [#5222](https://github.com/rubygems/rubygems/pull/5222) by pocke
 
 # 3.3.3 / 2021-12-24
 
@@ -392,103 +392,103 @@
 ## Bug fixes:
 
 * Fix gem installation failing in Solaris due to bad `IO#flock` usage.
-  Pull request #5216 by mame
+  Pull request [#5216](https://github.com/rubygems/rubygems/pull/5216) by mame
 
 # 3.3.2 / 2021-12-23
 
 ## Enhancements:
 
 * Fix deprecations when activating DidYouMean for misspelled command
-  suggestions. Pull request #5211 by yuki24
+  suggestions. Pull request [#5211](https://github.com/rubygems/rubygems/pull/5211) by yuki24
 * Installs bundler 2.3.2 as a default gem.
 
 ## Bug fixes:
 
-* Fix gemspec truncation. Pull request #5208 by deivid-rodriguez
+* Fix gemspec truncation. Pull request [#5208](https://github.com/rubygems/rubygems/pull/5208) by deivid-rodriguez
 
 # 3.3.1 / 2021-12-22
 
 ## Enhancements:
 
-* Fix compatibility with OpenSSL 3.0. Pull request #5196 by rhenium
+* Fix compatibility with OpenSSL 3.0. Pull request [#5196](https://github.com/rubygems/rubygems/pull/5196) by rhenium
 * Remove hard errors when matching major bundler not found. Pull request
-  #5181 by deivid-rodriguez
+  [#5181](https://github.com/rubygems/rubygems/pull/5181) by deivid-rodriguez
 * Installs bundler 2.3.1 as a default gem.
 
 # 3.3.0 / 2021-12-21
 
 ## Breaking changes:
 
-* Removed deprecated `gem server` command. Pull request #5034 by hsbt
-* Remove MacOS specific gem layout. Pull request #4833 by deivid-rodriguez
+* Removed deprecated `gem server` command. Pull request [#5034](https://github.com/rubygems/rubygems/pull/5034) by hsbt
+* Remove MacOS specific gem layout. Pull request [#4833](https://github.com/rubygems/rubygems/pull/4833) by deivid-rodriguez
 * Default `gem update` documentation format is now only `ri`. Pull request
-  #3888 by hsbt
+  [#3888](https://github.com/rubygems/rubygems/pull/3888) by hsbt
 
 ## Features:
 
 * Give command misspelled suggestions via `did_you_mean` gem. Pull request
-  #3904 by hsbt
+  [#3904](https://github.com/rubygems/rubygems/pull/3904) by hsbt
 
 ## Performance:
 
-* Avoid some unnecessary stat calls. Pull request #3887 by kares
+* Avoid some unnecessary stat calls. Pull request [#3887](https://github.com/rubygems/rubygems/pull/3887) by kares
 * Improve spell checking suggestion performance by
   vendoring`DidYouMean::Levenshtein.distance` from `did_you_mean-1.4.0`.
-  Pull request #3856 by austinpray
+  Pull request [#3856](https://github.com/rubygems/rubygems/pull/3856) by austinpray
 
 ## Enhancements:
 
 * Set `BUNDLER_VERSION` when `bundle _<version>_` is passed. Pull request
-  #5180 by deivid-rodriguez
-* Don't require `rdoc` for `gem uninstall`. Pull request #4691 by ndren
+  [#5180](https://github.com/rubygems/rubygems/pull/5180) by deivid-rodriguez
+* Don't require `rdoc` for `gem uninstall`. Pull request [#4691](https://github.com/rubygems/rubygems/pull/4691) by ndren
 * More focused rescue on extension builder exception to get more
-  information on errors. Pull request #4189 by deivid-rodriguez
+  information on errors. Pull request [#4189](https://github.com/rubygems/rubygems/pull/4189) by deivid-rodriguez
 * Installs bundler 2.3.0 as a default gem.
 
 ## Bug fixes:
 
 * Fix encoding mismatch issues when writing gem packages. Pull request
-  #5162 by deivid-rodriguez
+  [#5162](https://github.com/rubygems/rubygems/pull/5162) by deivid-rodriguez
 * Fix broken brew formula due to loading `operating_system.rb`
-  customizations too late. Pull request #5154 by deivid-rodriguez
+  customizations too late. Pull request [#5154](https://github.com/rubygems/rubygems/pull/5154) by deivid-rodriguez
 * Properly fetch `Gem#latest_spec_for` with multiple sources. Pull request
-  #2764 by kevlogan90
+  [#2764](https://github.com/rubygems/rubygems/pull/2764) by kevlogan90
 * Fix upgrade crashing when multiple versions of `fileutils` installed.
-  Pull request #5140 by deivid-rodriguez
+  Pull request [#5140](https://github.com/rubygems/rubygems/pull/5140) by deivid-rodriguez
 
 # 3.2.33 / 2021-12-07
 
 ## Deprecations:
 
-* Deprecate typo name. Pull request #5109 by nobu
+* Deprecate typo name. Pull request [#5109](https://github.com/rubygems/rubygems/pull/5109) by nobu
 
 ## Enhancements:
 
 * Add login & logout alias for the signin & signout commands. Pull request
-  #5133 by colby-swandale
+  [#5133](https://github.com/rubygems/rubygems/pull/5133) by colby-swandale
 * Fix race conditions when reading & writing gemspecs concurrently. Pull
-  request #4408 by deivid-rodriguez
+  request [#4408](https://github.com/rubygems/rubygems/pull/4408) by deivid-rodriguez
 * Installs bundler 2.2.33 as a default gem.
 
 ## Bug fixes:
 
 * Fix `ruby setup.rb` trying to write outside of `--destdir`. Pull request
-  #5053 by deivid-rodriguez
+  [#5053](https://github.com/rubygems/rubygems/pull/5053) by deivid-rodriguez
 
 ## Documentation:
 
 * Move required_ruby_version gemspec attribute to recommended section.
-  Pull request #5130 by simi
+  Pull request [#5130](https://github.com/rubygems/rubygems/pull/5130) by simi
 * Ignore to generate the documentation from vendored libraries. Pull
-  request #5118 by hsbt
+  request [#5118](https://github.com/rubygems/rubygems/pull/5118) by hsbt
 
 # 3.2.32 / 2021-11-23
 
 ## Enhancements:
 
-* Refactor installer thread safety protections. Pull request #5050 by
+* Refactor installer thread safety protections. Pull request [#5050](https://github.com/rubygems/rubygems/pull/5050) by
   deivid-rodriguez
-* Allow gem activation from `operating_system.rb`. Pull request #5044 by
+* Allow gem activation from `operating_system.rb`. Pull request [#5044](https://github.com/rubygems/rubygems/pull/5044) by
   deivid-rodriguez
 * Installs bundler 2.2.32 as a default gem.
 
@@ -497,39 +497,39 @@
 ## Enhancements:
 
 * Don't pass empty `DESTDIR` to `nmake` since it works differently from
-  standard `make`. Pull request #5057 by hsbt
-* Fix `gem install` vs `gem fetch` inconsistency. Pull request #5037 by
+  standard `make`. Pull request [#5057](https://github.com/rubygems/rubygems/pull/5057) by hsbt
+* Fix `gem install` vs `gem fetch` inconsistency. Pull request [#5037](https://github.com/rubygems/rubygems/pull/5037) by
   deivid-rodriguez
-* Lazily load and vendor `optparse`. Pull request #4881 by
+* Lazily load and vendor `optparse`. Pull request [#4881](https://github.com/rubygems/rubygems/pull/4881) by
   deivid-rodriguez
-* Use a vendored copy of `tsort` internally. Pull request #5027 by
+* Use a vendored copy of `tsort` internally. Pull request [#5027](https://github.com/rubygems/rubygems/pull/5027) by
   deivid-rodriguez
 * Install bundler 2.2.31 as a default gem.
 
 ## Bug fixes:
 
-* Fix `ruby setup.rb` when `--prefix` is passed. Pull request #5051 by
+* Fix `ruby setup.rb` when `--prefix` is passed. Pull request [#5051](https://github.com/rubygems/rubygems/pull/5051) by
   deivid-rodriguez
 * Don't apply `--destdir` twice when running `setup.rb`. Pull request
-  #2768 by alyssais
+  [#2768](https://github.com/rubygems/rubygems/pull/2768) by alyssais
 
 # 3.2.30 / 2021-10-26
 
 ## Enhancements:
 
 * Add support to build and sign certificates with multiple key algorithms.
-  Pull request #4991 by doodzik
-* Avoid loading the `digest` gem unnecessarily. Pull request #4979 by
+  Pull request [#4991](https://github.com/rubygems/rubygems/pull/4991) by doodzik
+* Avoid loading the `digest` gem unnecessarily. Pull request [#4979](https://github.com/rubygems/rubygems/pull/4979) by
   deivid-rodriguez
-* Prefer `require_relative` for all internal requires. Pull request #4978
+* Prefer `require_relative` for all internal requires. Pull request [#4978](https://github.com/rubygems/rubygems/pull/4978)
   by deivid-rodriguez
 * Add missing `require` of `time` within
-  `Gem::Request.verify_certificate_message`. Pull request #4975 by nobu
+  `Gem::Request.verify_certificate_message`. Pull request [#4975](https://github.com/rubygems/rubygems/pull/4975) by nobu
 * Install bundler 2.2.30 as a default gem.
 
 ## Performance:
 
-* Speed up `gem install`, specially under Windows. Pull request #4960 by
+* Speed up `gem install`, specially under Windows. Pull request [#4960](https://github.com/rubygems/rubygems/pull/4960) by
   deivid-rodriguez
 
 # 3.2.29 / 2021-10-08
@@ -537,44 +537,44 @@
 ## Enhancements:
 
 * Only disallow FIXME/TODO for first word of gemspec description. Pull
-  request #4937 by duckinator
+  request [#4937](https://github.com/rubygems/rubygems/pull/4937) by duckinator
 * Install bundler 2.2.29 as a default gem.
 
 ## Bug fixes:
 
 * Fix `wordy` method in `SourceFetchProblem` changing the password of
-  source. Pull request #4910 by Huangxiaodui
+  source. Pull request [#4910](https://github.com/rubygems/rubygems/pull/4910) by Huangxiaodui
 
 ## Performance:
 
 * Improve `require` performance, particularly on systems with a lot of
-  gems installed. Pull request #4951 by pocke
+  gems installed. Pull request [#4951](https://github.com/rubygems/rubygems/pull/4951) by pocke
 
 # 3.2.28 / 2021-09-23
 
 ## Enhancements:
 
-* Support MINGW-UCRT. Pull request #4925 by hsbt
-* Only check if descriptions *start with* FIXME/TODO. Pull request #4841
+* Support MINGW-UCRT. Pull request [#4925](https://github.com/rubygems/rubygems/pull/4925) by hsbt
+* Only check if descriptions *start with* FIXME/TODO. Pull request [#4841](https://github.com/rubygems/rubygems/pull/4841)
   by duckinator
 * Avoid loading `uri` unnecessarily when activating gems. Pull request
-  #4897 by deivid-rodriguez
+  [#4897](https://github.com/rubygems/rubygems/pull/4897) by deivid-rodriguez
 * Install bundler 2.2.28 as a default gem.
 
 ## Bug fixes:
 
-* Fix redacted credentials being sent to gemserver. Pull request #4919 by
+* Fix redacted credentials being sent to gemserver. Pull request [#4919](https://github.com/rubygems/rubygems/pull/4919) by
   jdliss
 
 # 3.2.27 / 2021-09-03
 
 ## Enhancements:
 
-* Redact credentails when printing URI. Pull request #4868 by intuxicated
+* Redact credentails when printing URI. Pull request [#4868](https://github.com/rubygems/rubygems/pull/4868) by intuxicated
 * Prefer `require_relative` to `require` for internal requires. Pull
-  request #4858 by deivid-rodriguez
+  request [#4858](https://github.com/rubygems/rubygems/pull/4858) by deivid-rodriguez
 * Prioritise gems with higher version for fetching metadata, and stop
-  fetching once we find a valid candidate. Pull request #4843 by intuxicated
+  fetching once we find a valid candidate. Pull request [#4843](https://github.com/rubygems/rubygems/pull/4843) by intuxicated
 * Install bundler 2.2.27 as a default gem.
 
 # 3.2.26 / 2021-08-17
@@ -582,34 +582,34 @@
 ## Enhancements:
 
 * Enhance the error handling for loading the
-  `rubygems/defaults/operating_system` file. Pull request #4824 by
+  `rubygems/defaults/operating_system` file. Pull request [#4824](https://github.com/rubygems/rubygems/pull/4824) by
   intuxicated
-* Ignore `RUBYGEMS_GEMDEPS` for the bundler gem. Pull request #4532 by
+* Ignore `RUBYGEMS_GEMDEPS` for the bundler gem. Pull request [#4532](https://github.com/rubygems/rubygems/pull/4532) by
   deivid-rodriguez
 * Install bundler 2.2.26 as a default gem.
 
 ## Bug fixes:
 
-* Also load user installed rubygems plugins. Pull request #4829 by
+* Also load user installed rubygems plugins. Pull request [#4829](https://github.com/rubygems/rubygems/pull/4829) by
   deivid-rodriguez
 
 # 3.2.25 / 2021-07-30
 
 ## Enhancements:
 
-* Don't load the `base64` library since it's not used. Pull request #4785
+* Don't load the `base64` library since it's not used. Pull request [#4785](https://github.com/rubygems/rubygems/pull/4785)
   by deivid-rodriguez
-* Don't load the `resolv` library since it's not used. Pull request #4784
+* Don't load the `resolv` library since it's not used. Pull request [#4784](https://github.com/rubygems/rubygems/pull/4784)
   by deivid-rodriguez
-* Lazily load `shellwords` library. Pull request #4783 by deivid-rodriguez
+* Lazily load `shellwords` library. Pull request [#4783](https://github.com/rubygems/rubygems/pull/4783) by deivid-rodriguez
 * Check requirements class before loading marshalled requirements. Pull
-  request #4651 by nobu
+  request [#4651](https://github.com/rubygems/rubygems/pull/4651) by nobu
 * Install bundler 2.2.25 as a default gem.
 
 ## Bug fixes:
 
 * Add missing `require 'fileutils'` in `Gem::ConfigFile`. Pull request
-  #4768 by ybiquitous
+  [#4768](https://github.com/rubygems/rubygems/pull/4768) by ybiquitous
 
 # 3.2.24 / 2021-07-15
 
@@ -620,56 +620,56 @@
 ## Bug fixes:
 
 * Fix contradictory message about deletion of default gem. Pull request
-  #4739 by jaredbeck
+  [#4739](https://github.com/rubygems/rubygems/pull/4739) by jaredbeck
 
 ## Documentation:
 
 * Add a description about `GEM_HOST_OTP_CODE` to help text. Pull request
-  #4742 by ybiquitous
+  [#4742](https://github.com/rubygems/rubygems/pull/4742) by ybiquitous
 
 # 3.2.23 / 2021-07-09
 
 ## Enhancements:
 
 * Rewind IO source to allow working with contents in memory. Pull request
-  #4729 by drcapulet
+  [#4729](https://github.com/rubygems/rubygems/pull/4729) by drcapulet
 * Install bundler 2.2.23 as a default gem.
 
 # 3.2.22 / 2021-07-06
 
 ## Enhancements:
 
-* Allow setting `--otp` via `GEM_HOST_OTP_CODE`. Pull request #4697 by
+* Allow setting `--otp` via `GEM_HOST_OTP_CODE`. Pull request [#4697](https://github.com/rubygems/rubygems/pull/4697) by
   CGA1123
 * Fixes for the edge case when openssl library is missing. Pull request
-  #4695 by rhenium
+  [#4695](https://github.com/rubygems/rubygems/pull/4695) by rhenium
 * Install bundler 2.2.22 as a default gem.
 
 # 3.2.21 / 2021-06-23
 
 ## Enhancements:
 
-* Fix typo in OpenSSL detection. Pull request #4679 by osyoyu
-* Add the most recent licenses from spdx.org. Pull request #4662 by nobu
+* Fix typo in OpenSSL detection. Pull request [#4679](https://github.com/rubygems/rubygems/pull/4679) by osyoyu
+* Add the most recent licenses from spdx.org. Pull request [#4662](https://github.com/rubygems/rubygems/pull/4662) by nobu
 * Simplify setup.rb code to allow installing rubygems from source on
-  truffleruby 21.0 and 21.1. Pull request #4624 by deivid-rodriguez
+  truffleruby 21.0 and 21.1. Pull request [#4624](https://github.com/rubygems/rubygems/pull/4624) by deivid-rodriguez
 * Install bundler 2.2.21 as a default gem.
 
 ## Bug fixes:
 
 * Create credentials folder when setting API keys if not there yet. Pull
-  request #4665 by deivid-rodriguez
+  request [#4665](https://github.com/rubygems/rubygems/pull/4665) by deivid-rodriguez
 
 # 3.2.20 / 2021-06-11
 
 ## Security fixes:
 
 * Verify platform before installing to avoid potential remote code
-  execution. Pull request #4667 by sonalkr132
+  execution. Pull request [#4667](https://github.com/rubygems/rubygems/pull/4667) by sonalkr132
 
 ## Enhancements:
 
-* Add better specification policy error description. Pull request #4658 by
+* Add better specification policy error description. Pull request [#4658](https://github.com/rubygems/rubygems/pull/4658) by
   ceritium
 * Install bundler 2.2.20 as a default gem.
 
@@ -677,7 +677,7 @@
 
 ## Enhancements:
 
-* Fix `gem help build` output format. Pull request #4613 by tnir
+* Fix `gem help build` output format. Pull request [#4613](https://github.com/rubygems/rubygems/pull/4613) by tnir
 * Install bundler 2.2.19 as a default gem.
 
 # 3.2.18 / 2021-05-25
@@ -685,25 +685,25 @@
 ## Enhancements:
 
 * Don't leave temporary directory around when building extensions to
-  improve build reproducibility. Pull request #4610 by baloo
+  improve build reproducibility. Pull request [#4610](https://github.com/rubygems/rubygems/pull/4610) by baloo
 * Install bundler 2.2.18 as a default gem.
 
 # 3.2.17 / 2021-05-05
 
 ## Enhancements:
 
-* Only print month & year in deprecation messages. Pull request #3085 by
+* Only print month & year in deprecation messages. Pull request [#3085](https://github.com/rubygems/rubygems/pull/3085) by
   Schwad
 * Make deprecate method support ruby3's keyword arguments. Pull request
-  #4558 by mame
-* Update the default bindir on macOS. Pull request #4524 by nobu
-* Prefer File.open instead of Kernel#open. Pull request #4529 by mame
+  [#4558](https://github.com/rubygems/rubygems/pull/4558) by mame
+* Update the default bindir on macOS. Pull request [#4524](https://github.com/rubygems/rubygems/pull/4524) by nobu
+* Prefer File.open instead of Kernel#open. Pull request [#4529](https://github.com/rubygems/rubygems/pull/4529) by mame
 * Install bundler 2.2.17 as a default gem.
 
 ## Documentation:
 
 * Fix usage messages to reflect the current POSIX-compatible behaviour.
-  Pull request #4551 by graywolf-at-work
+  Pull request [#4551](https://github.com/rubygems/rubygems/pull/4551) by graywolf-at-work
 
 # 3.2.16 / 2021-04-08
 
@@ -713,31 +713,31 @@
 
 ## Bug fixes:
 
-* Correctly handle symlinks. Pull request #2836 by voxik
+* Correctly handle symlinks. Pull request [#2836](https://github.com/rubygems/rubygems/pull/2836) by voxik
 
 # 3.2.15 / 2021-03-19
 
 ## Enhancements:
 
-* Prevent downgrades to untested rubygems versions. Pull request #4460 by
+* Prevent downgrades to untested rubygems versions. Pull request [#4460](https://github.com/rubygems/rubygems/pull/4460) by
   deivid-rodriguez
 * Install bundler 2.2.15 as a default gem.
 
 ## Bug fixes:
 
-* Fix missing require breaking `gem cert`. Pull request #4464 by lukehinds
+* Fix missing require breaking `gem cert`. Pull request [#4464](https://github.com/rubygems/rubygems/pull/4464) by lukehinds
 
 # 3.2.14 / 2021-03-08
 
 ## Enhancements:
 
-* Less wrapping of network errors. Pull request #4064 by deivid-rodriguez
+* Less wrapping of network errors. Pull request [#4064](https://github.com/rubygems/rubygems/pull/4064) by deivid-rodriguez
 * Install bundler 2.2.14 as a default gem.
 
 ## Bug fixes:
 
 * Revert addition of support for `musl` variants to restore graceful
-  fallback on Alpine. Pull request #4434 by deivid-rodriguez
+  fallback on Alpine. Pull request [#4434](https://github.com/rubygems/rubygems/pull/4434) by deivid-rodriguez
 
 # 3.2.13 / 2021-03-03
 
@@ -747,7 +747,7 @@
 
 ## Bug fixes:
 
-* Support non-gnu libc linux platforms. Pull request #4082 by lloeki
+* Support non-gnu libc linux platforms. Pull request [#4082](https://github.com/rubygems/rubygems/pull/4082) by lloeki
 
 # 3.2.12 / 2021-03-01
 
@@ -758,13 +758,13 @@
 ## Bug fixes:
 
 * Restore the ability to manually install extension gems. Pull request
-  #4384 by cfis
+  [#4384](https://github.com/rubygems/rubygems/pull/4384) by cfis
 
 # 3.2.11 / 2021-02-17
 
 ## Enhancements:
 
-* Optionally fallback to IPv4 when IPv6 is unreachable. Pull request #2662
+* Optionally fallback to IPv4 when IPv6 is unreachable. Pull request [#2662](https://github.com/rubygems/rubygems/pull/2662)
   by sonalkr132
 * Install bundler 2.2.11 as a default gem.
 
@@ -776,9 +776,9 @@
 
 ## Documentation:
 
-* Add a `gem push` example to `gem help`. Pull request #4373 by
+* Add a `gem push` example to `gem help`. Pull request [#4373](https://github.com/rubygems/rubygems/pull/4373) by
   deivid-rodriguez
-* Improve documentation for `required_ruby_version`. Pull request #4343 by
+* Improve documentation for `required_ruby_version`. Pull request [#4343](https://github.com/rubygems/rubygems/pull/4343) by
   AlexWayfer
 
 # 3.2.9 / 2021-02-08
@@ -790,13 +790,13 @@
 ## Bug fixes:
 
 * Fix error message when underscore selection can't find bundler. Pull
-  request #4363 by deivid-rodriguez
+  request [#4363](https://github.com/rubygems/rubygems/pull/4363) by deivid-rodriguez
 * Fix `Gem::Specification.stubs_for` returning wrong named specs. Pull
-  request #4356 by tompng
+  request [#4356](https://github.com/rubygems/rubygems/pull/4356) by tompng
 * Don't error out when activating a binstub unless necessary. Pull request
-  #4351 by deivid-rodriguez
+  [#4351](https://github.com/rubygems/rubygems/pull/4351) by deivid-rodriguez
 * Fix `gem outdated` incorrectly handling platform specific gems. Pull
-  request #4248 by deivid-rodriguez
+  request [#4248](https://github.com/rubygems/rubygems/pull/4248) by deivid-rodriguez
 
 # 3.2.8 / 2021-02-02
 
@@ -807,7 +807,7 @@
 ## Bug fixes:
 
 * Fix `gem install` crashing on gemspec with nil required_ruby_version.
-  Pull request #4334 by pbernays
+  Pull request [#4334](https://github.com/rubygems/rubygems/pull/4334) by pbernays
 
 # 3.2.7 / 2021-01-26
 
@@ -817,7 +817,7 @@
 
 ## Bug fixes:
 
-* Generate plugin wrappers with relative requires. Pull request #4317 by
+* Generate plugin wrappers with relative requires. Pull request [#4317](https://github.com/rubygems/rubygems/pull/4317) by
   deivid-rodriguez
 
 # 3.2.6 / 2021-01-18
@@ -825,15 +825,15 @@
 ## Enhancements:
 
 * Fix `Gem::Platform#inspect` showing duplicate information. Pull request
-  #4276 by deivid-rodriguez
+  [#4276](https://github.com/rubygems/rubygems/pull/4276) by deivid-rodriguez
 * Install bundler 2.2.6 as a default gem.
 
 ## Bug fixes:
 
 * Swallow any system call error in `ensure_gem_subdirs` to support jruby
-  embedded paths. Pull request #4291 by kares
+  embedded paths. Pull request [#4291](https://github.com/rubygems/rubygems/pull/4291) by kares
 * Restore accepting custom make command with extra options as the `make`
-  env variable. Pull request #4271 by terceiro
+  env variable. Pull request [#4271](https://github.com/rubygems/rubygems/pull/4271) by terceiro
 
 # 3.2.5 / 2021-01-11
 
@@ -844,38 +844,38 @@
 ## Bug fixes:
 
 * Don't load more specs after the whole set of specs has been setup. Pull
-  request #4262 by deivid-rodriguez
+  request [#4262](https://github.com/rubygems/rubygems/pull/4262) by deivid-rodriguez
 * Fix broken `bundler` executable after `gem update --system`. Pull
-  request #4221 by deivid-rodriguez
+  request [#4221](https://github.com/rubygems/rubygems/pull/4221) by deivid-rodriguez
 
 # 3.2.4 / 2020-12-31
 
 ## Enhancements:
 
-* Use a CHANGELOG in markdown for rubygems. Pull request #4168 by
+* Use a CHANGELOG in markdown for rubygems. Pull request [#4168](https://github.com/rubygems/rubygems/pull/4168) by
   deivid-rodriguez
-* Never spawn subshells when building extensions. Pull request #4190 by
+* Never spawn subshells when building extensions. Pull request [#4190](https://github.com/rubygems/rubygems/pull/4190) by
   deivid-rodriguez
 * Install bundler 2.2.4 as a default gem.
 
 ## Bug fixes:
 
 * Fix fallback to the old index and installation from it not working. Pull
-  request #4213 by deivid-rodriguez
-* Fix installing from source on truffleruby. Pull request #4201 by
+  request [#4213](https://github.com/rubygems/rubygems/pull/4213) by deivid-rodriguez
+* Fix installing from source on truffleruby. Pull request [#4201](https://github.com/rubygems/rubygems/pull/4201) by
   deivid-rodriguez
 
 # 3.2.3 / 2020-12-22
 
 ## Enhancements:
 
-* Fix misspellings in default API key name. Pull request #4177 by hsbt
+* Fix misspellings in default API key name. Pull request [#4177](https://github.com/rubygems/rubygems/pull/4177) by hsbt
 * Install bundler 2.2.3 as a default gem.
 
 ## Bug fixes:
 
 * Respect `required_ruby_version` and `required_rubygems_version`
-  constraints when looking for `gem install` candidates. Pull request #4110
+  constraints when looking for `gem install` candidates. Pull request [#4110](https://github.com/rubygems/rubygems/pull/4110)
   by deivid-rodriguez
 
 # 3.2.2 / 2020-12-17
@@ -888,560 +888,560 @@
 
 * Fix issue where CLI commands making more than one request to
   rubygems.org needing an OTP code would crash or ask for the code twice.
-  Pull request #4162 by sonalkr132
-* Fix building rake extensions that require openssl. Pull request #4165 by
+  Pull request [#4162](https://github.com/rubygems/rubygems/pull/4162) by sonalkr132
+* Fix building rake extensions that require openssl. Pull request [#4165](https://github.com/rubygems/rubygems/pull/4165) by
   deivid-rodriguez
 * Fix `gem update --system` displaying too many changelog entries. Pull
-  request #4145 by deivid-rodriguez
+  request [#4145](https://github.com/rubygems/rubygems/pull/4145) by deivid-rodriguez
 
 # 3.2.1 / 2020-12-14
 
 ## Enhancements:
 
 * Added help message for gem i webrick in gem server command. Pull request
-  #4117 by hsbt
+  [#4117](https://github.com/rubygems/rubygems/pull/4117) by hsbt
 * Install bundler 2.2.1 as a default gem.
 
 ## Bug fixes:
 
 * Added the missing loading of fileutils same as load_specs. Pull request
-  #4124 by hsbt
+  [#4124](https://github.com/rubygems/rubygems/pull/4124) by hsbt
 * Fix Resolver::APISet to always include prereleases when necessary. Pull
-  request #4113 by deivid-rodriguez
+  request [#4113](https://github.com/rubygems/rubygems/pull/4113) by deivid-rodriguez
 
 # 3.2.0 / 2020-12-07
 
 ## Enhancements:
 
-* Do not override Kernel#warn when there is no need. Pull request #4075 by
+* Do not override Kernel#warn when there is no need. Pull request [#4075](https://github.com/rubygems/rubygems/pull/4075) by
   eregon
-* Update endpoint of gem signin command. Pull request #3840 by sonalkr132
-* Omit deprecated commands from command help output. Pull request #4023 by
+* Update endpoint of gem signin command. Pull request [#3840](https://github.com/rubygems/rubygems/pull/3840) by sonalkr132
+* Omit deprecated commands from command help output. Pull request [#4023](https://github.com/rubygems/rubygems/pull/4023) by
   landongrindheim
-* Suggest alternatives in `gem query` deprecation. Pull request #4021 by
+* Suggest alternatives in `gem query` deprecation. Pull request [#4021](https://github.com/rubygems/rubygems/pull/4021) by
   landongrindheim
-* Lazily load `time`, `cgi`, and `zlib`. Pull request #4010 by
+* Lazily load `time`, `cgi`, and `zlib`. Pull request [#4010](https://github.com/rubygems/rubygems/pull/4010) by
   deivid-rodriguez
 * Don't hit the network when installing dependencyless local gemspec. Pull
-  request #3968 by deivid-rodriguez
-* Add `--force` option to `gem sources` command. Pull request #3956 by
+  request [#3968](https://github.com/rubygems/rubygems/pull/3968) by deivid-rodriguez
+* Add `--force` option to `gem sources` command. Pull request [#3956](https://github.com/rubygems/rubygems/pull/3956) by
   andy-smith-msm
-* Lazily load `openssl`. Pull request #3850 by deivid-rodriguez
-* Pass more information when comparing platforms. Pull request #3817 by
+* Lazily load `openssl`. Pull request [#3850](https://github.com/rubygems/rubygems/pull/3850) by deivid-rodriguez
+* Pass more information when comparing platforms. Pull request [#3817](https://github.com/rubygems/rubygems/pull/3817) by
   eregon
 * Install bundler 2.2.0 as a default gem.
 
 ## Bug fixes:
 
 * Use better owner & group for files in rubygems package. Pull request
-  #4065 by deivid-rodriguez
-* Improve gem build -C flag. Pull request #3983 by bronzdoc
+  [#4065](https://github.com/rubygems/rubygems/pull/4065) by deivid-rodriguez
+* Improve gem build -C flag. Pull request [#3983](https://github.com/rubygems/rubygems/pull/3983) by bronzdoc
 * Handle unexpected behavior with URI#merge and subpaths missing trailing
-  slashes. Pull request #3123 by drcapulet
+  slashes. Pull request [#3123](https://github.com/rubygems/rubygems/pull/3123) by drcapulet
 * Add missing `fileutils` require in rubygems installer. Pull request
-  #4036 by deivid-rodriguez
+  [#4036](https://github.com/rubygems/rubygems/pull/4036) by deivid-rodriguez
 * Fix `--platform` option to `gem specification` being ignored. Pull
-  request #4043 by deivid-rodriguez
+  request [#4043](https://github.com/rubygems/rubygems/pull/4043) by deivid-rodriguez
 * Expose `--no-minimal-deps` flag to install the latest version of
-  dependencies. Pull request #4030 by deivid-rodriguez
+  dependencies. Pull request [#4030](https://github.com/rubygems/rubygems/pull/4030) by deivid-rodriguez
 * Fix "stack level too deep" error when overriding `Warning.warn`. Pull
-  request #3987 by eregon
+  request [#3987](https://github.com/rubygems/rubygems/pull/3987) by eregon
 * Append '.gemspec' extension only when it is not present. Pull request
-  #3988 by voxik
+  [#3988](https://github.com/rubygems/rubygems/pull/3988) by voxik
 * Install to correct plugins dir when using `--build-root`. Pull request
-  #3972 by deivid-rodriguez
-* Fix `--build-root` flag under Windows. Pull request #3975 by
+  [#3972](https://github.com/rubygems/rubygems/pull/3972) by deivid-rodriguez
+* Fix `--build-root` flag under Windows. Pull request [#3975](https://github.com/rubygems/rubygems/pull/3975) by
   deivid-rodriguez
 * Fix `typo_squatting?` false positive for `rubygems.org` itself. Pull
-  request #3951 by andy-smith-msm
+  request [#3951](https://github.com/rubygems/rubygems/pull/3951) by andy-smith-msm
 * Make `--default` and `--install-dir` options to `gem install` play nice
-  together. Pull request #3906 by deivid-rodriguez
+  together. Pull request [#3906](https://github.com/rubygems/rubygems/pull/3906) by deivid-rodriguez
 
 ## Deprecations:
 
-* Deprecate server command. Pull request #3868 by bronzdoc
+* Deprecate server command. Pull request [#3868](https://github.com/rubygems/rubygems/pull/3868) by bronzdoc
 
 ## Performance:
 
 * Don't change ruby process CWD when building extensions. Pull request
-  #3498 by deivid-rodriguez
+  [#3498](https://github.com/rubygems/rubygems/pull/3498) by deivid-rodriguez
 
 # 3.2.0.rc.2 / 2020-10-08
 
 ## Enhancements:
 
 * Make --dry-run flag consistent across rubygems commands. Pull request
-  #3867 by bronzdoc
-* Disallow downgrades to too old versions. Pull request #3566 by
+  [#3867](https://github.com/rubygems/rubygems/pull/3867) by bronzdoc
+* Disallow downgrades to too old versions. Pull request [#3566](https://github.com/rubygems/rubygems/pull/3566) by
   deivid-rodriguez
-* Added `--platform` option to `build` command. Pull request #3079 by nobu
+* Added `--platform` option to `build` command. Pull request [#3079](https://github.com/rubygems/rubygems/pull/3079) by nobu
 * Have "gem update --system" pass through the `--silent` flag. Pull
-  request #3789 by duckinator
-* Add writable check for cache dir. Pull request #3876 by xndcn
-* Warn on duplicate dependency in a specification. Pull request #3864 by
+  request [#3789](https://github.com/rubygems/rubygems/pull/3789) by duckinator
+* Add writable check for cache dir. Pull request [#3876](https://github.com/rubygems/rubygems/pull/3876) by xndcn
+* Warn on duplicate dependency in a specification. Pull request [#3864](https://github.com/rubygems/rubygems/pull/3864) by
   bronzdoc
-* Fix indentation in `gem env`. Pull request #3861 by colby-swandale
-* Let more exceptions flow. Pull request #3819 by deivid-rodriguez
-* Ignore internal frames in RubyGems' Kernel#warn. Pull request #3810 by
+* Fix indentation in `gem env`. Pull request [#3861](https://github.com/rubygems/rubygems/pull/3861) by colby-swandale
+* Let more exceptions flow. Pull request [#3819](https://github.com/rubygems/rubygems/pull/3819) by deivid-rodriguez
+* Ignore internal frames in RubyGems' Kernel#warn. Pull request [#3810](https://github.com/rubygems/rubygems/pull/3810) by
   eregon
 
 ## Bug fixes:
 
-* Add missing fileutils require. Pull request #3911 by deivid-rodriguez
+* Add missing fileutils require. Pull request [#3911](https://github.com/rubygems/rubygems/pull/3911) by deivid-rodriguez
 * Fix false positive warning on Windows when PATH has
-  `File::ALT_SEPARATOR`. Pull request #3829 by deivid-rodriguez
+  `File::ALT_SEPARATOR`. Pull request [#3829](https://github.com/rubygems/rubygems/pull/3829) by deivid-rodriguez
 * Fix Kernel#warn override to handle backtrace location with nil path.
-  Pull request #3852 by jeremyevans
-* Don't format executables on `gem update --system`. Pull request #3811 by
+  Pull request [#3852](https://github.com/rubygems/rubygems/pull/3852) by jeremyevans
+* Don't format executables on `gem update --system`. Pull request [#3811](https://github.com/rubygems/rubygems/pull/3811) by
   deivid-rodriguez
 * `gem install --user` fails with `Gem::FilePermissionError` on the system
-  plugins directory. Pull request #3804 by nobu
+  plugins directory. Pull request [#3804](https://github.com/rubygems/rubygems/pull/3804) by nobu
 
 ## Performance:
 
 * Avoid duplicated generation of APISpecification objects. Pull request
-  #3940 by mame
-* Eval defaults with frozen_string_literal: true. Pull request #3847 by
+  [#3940](https://github.com/rubygems/rubygems/pull/3940) by mame
+* Eval defaults with frozen_string_literal: true. Pull request [#3847](https://github.com/rubygems/rubygems/pull/3847) by
   casperisfine
-* Deduplicate the requirement operators in memory. Pull request #3846 by
+* Deduplicate the requirement operators in memory. Pull request [#3846](https://github.com/rubygems/rubygems/pull/3846) by
   casperisfine
-* Optimize Gem.already_loaded?. Pull request #3793 by casperisfine
+* Optimize Gem.already_loaded?. Pull request [#3793](https://github.com/rubygems/rubygems/pull/3793) by casperisfine
 
 # 3.2.0.rc.1 / 2020-07-04
 
 ## Enhancements:
 
-* Test TruffleRuby in CI. Pull request #2797 by Benoit Daloze.
-* Rework plugins system and speed up rubygems. Pull request #3108 by David
+* Test TruffleRuby in CI. Pull request [#2797](https://github.com/rubygems/rubygems/pull/2797) by Benoit Daloze.
+* Rework plugins system and speed up rubygems. Pull request [#3108](https://github.com/rubygems/rubygems/pull/3108) by David
   Rodríguez.
-* Specify explicit separator not to be affected by $;. Pull request #3424
+* Specify explicit separator not to be affected by $;. Pull request [#3424](https://github.com/rubygems/rubygems/pull/3424)
   by Nobuyoshi Nakada.
-* Enable `Layout/ExtraSpacing` cop. Pull request #3449 by David Rodríguez.
-* Rollback gem deprecate. Pull request #3530 by Luis Sagastume.
-* Normalize heredoc delimiters. Pull request #3533 by David Rodríguez.
-* Log messages to stdout in `rake package`. Pull request #3632 by David
+* Enable `Layout/ExtraSpacing` cop. Pull request [#3449](https://github.com/rubygems/rubygems/pull/3449) by David Rodríguez.
+* Rollback gem deprecate. Pull request [#3530](https://github.com/rubygems/rubygems/pull/3530) by Luis Sagastume.
+* Normalize heredoc delimiters. Pull request [#3533](https://github.com/rubygems/rubygems/pull/3533) by David Rodríguez.
+* Log messages to stdout in `rake package`. Pull request [#3632](https://github.com/rubygems/rubygems/pull/3632) by David
   Rodríguez.
-* Remove explicit `psych` activation. Pull request #3636 by David
+* Remove explicit `psych` activation. Pull request [#3636](https://github.com/rubygems/rubygems/pull/3636) by David
   Rodríguez.
-* Delay `fileutils` loading to fix some warnings. Pull request #3637 by
+* Delay `fileutils` loading to fix some warnings. Pull request [#3637](https://github.com/rubygems/rubygems/pull/3637) by
   David Rodríguez.
 * Make sure rubygems/package can be directly required reliably. Pull
-  request #3670 by Luis Sagastume.
+  request [#3670](https://github.com/rubygems/rubygems/pull/3670) by Luis Sagastume.
 * Make sure `tmp` folder exists before calling `Dir.tmpdir`. Pull request
-  #3711 by David Rodríguez.
+  [#3711](https://github.com/rubygems/rubygems/pull/3711) by David Rodríguez.
 * Add Gem.disable_system_update_message to disable gem update --system if
-  needed. Pull request #3720 by Josef Šimánek.
-* Tweaks to play nice with ruby-core setup. Pull request #3733 by David
+  needed. Pull request [#3720](https://github.com/rubygems/rubygems/pull/3720) by Josef Šimánek.
+* Tweaks to play nice with ruby-core setup. Pull request [#3733](https://github.com/rubygems/rubygems/pull/3733) by David
   Rodríguez.
-* Remove explicit require for auto-loaded constant. Pull request #3751 by
+* Remove explicit require for auto-loaded constant. Pull request [#3751](https://github.com/rubygems/rubygems/pull/3751) by
   Karol Bucek.
-* Test files should not be included in spec.files. Pull request #3758 by
+* Test files should not be included in spec.files. Pull request [#3758](https://github.com/rubygems/rubygems/pull/3758) by
   Marc-André Lafortune.
 * Remove TODO comment about warning on setting instead of pushing. Pull
-  request #2823 by Luis Sagastume.
-* Add deprecate command method. Pull request #2935 by Luis Sagastume.
-* Simplify deprecate command method. Pull request #2974 by Luis Sagastume.
+  request [#2823](https://github.com/rubygems/rubygems/pull/2823) by Luis Sagastume.
+* Add deprecate command method. Pull request [#2935](https://github.com/rubygems/rubygems/pull/2935) by Luis Sagastume.
+* Simplify deprecate command method. Pull request [#2974](https://github.com/rubygems/rubygems/pull/2974) by Luis Sagastume.
 * Fix Gem::LOADED_SPECS_MUTEX handling for recursive locking. Pull request
-  #2985 by MSP-Greg.
-* Add `funding_uri ` metadata field to gemspec. Pull request #3060 by
+  [#2985](https://github.com/rubygems/rubygems/pull/2985) by MSP-Greg.
+* Add `funding_uri ` metadata field to gemspec. Pull request [#3060](https://github.com/rubygems/rubygems/pull/3060) by
   Colby Swandale.
-* Updates to some old gem-signing docs. Pull request #3063 by Tieg
+* Updates to some old gem-signing docs. Pull request [#3063](https://github.com/rubygems/rubygems/pull/3063) by Tieg
   Zaharia.
-* Update the gem method for Gem::Installer. Pull request #3137 by Daniel
+* Update the gem method for Gem::Installer. Pull request [#3137](https://github.com/rubygems/rubygems/pull/3137) by Daniel
   Berger.
-* Simplify initial gem help output. Pull request #3148 by Olivier Lacan.
-* Resolve latest version via `gem contents`. Pull request #3149 by Dan
+* Simplify initial gem help output. Pull request [#3148](https://github.com/rubygems/rubygems/pull/3148) by Olivier Lacan.
+* Resolve latest version via `gem contents`. Pull request [#3149](https://github.com/rubygems/rubygems/pull/3149) by Dan
   Rice.
-* Install suggestions. Pull request #3151 by Sophia Castellarin.
-* Only rescue the errors we actually want to rescue. Pull request #3156 by
+* Install suggestions. Pull request [#3151](https://github.com/rubygems/rubygems/pull/3151) by Sophia Castellarin.
+* Only rescue the errors we actually want to rescue. Pull request [#3156](https://github.com/rubygems/rubygems/pull/3156) by
   David Rodríguez.
 
 ## Bug fixes:
 
 * Accept not only /usr/bin/env but also /bin/env in some tests. Pull
-  request #3422 by Yusuke Endoh.
+  request [#3422](https://github.com/rubygems/rubygems/pull/3422) by Yusuke Endoh.
 * Skip a test that attempts to remove the current directory on Solaris.
-  Pull request #3423 by Yusuke Endoh.
-* Fix race condition on bundler's parallel installer. Pull request #3440
+  Pull request [#3423](https://github.com/rubygems/rubygems/pull/3423) by Yusuke Endoh.
+* Fix race condition on bundler's parallel installer. Pull request [#3440](https://github.com/rubygems/rubygems/pull/3440)
   by David Rodríguez.
 * Fix platform comparison check in #contains_requirable_file?. Pull
-  request #3495 by Benoit Daloze.
-* Improve missing spec error. Pull request #3559 by Luis Sagastume.
+  request [#3495](https://github.com/rubygems/rubygems/pull/3495) by Benoit Daloze.
+* Improve missing spec error. Pull request [#3559](https://github.com/rubygems/rubygems/pull/3559) by Luis Sagastume.
 * Fix hidden bundler template installation from rubygems updater. Pull
-  request #3674 by David Rodríguez.
-* Fix gem update --user-install. Pull request #2901 by Luis Sagastume.
+  request [#3674](https://github.com/rubygems/rubygems/pull/3674) by David Rodríguez.
+* Fix gem update --user-install. Pull request [#2901](https://github.com/rubygems/rubygems/pull/2901) by Luis Sagastume.
 * Correct conflict list when uninstallation is prevented. Pull request
-  #2973 by David Rodríguez.
+  [#2973](https://github.com/rubygems/rubygems/pull/2973) by David Rodríguez.
 * Fix error when trying to find bundler with a deleted "working directo….
-  Pull request #3090 by Luis Sagastume.
-* Fix -I require priority. Pull request #3124 by David Rodríguez.
-* Fix `ruby setup.rb` for new plugins layout. Pull request #3144 by David
+  Pull request [#3090](https://github.com/rubygems/rubygems/pull/3090) by Luis Sagastume.
+* Fix -I require priority. Pull request [#3124](https://github.com/rubygems/rubygems/pull/3124) by David Rodríguez.
+* Fix `ruby setup.rb` for new plugins layout. Pull request [#3144](https://github.com/rubygems/rubygems/pull/3144) by David
   Rodríguez.
 
 ## Deprecations:
 
-* Set deprecation warning on query command. Pull request #2967 by Luis
+* Set deprecation warning on query command. Pull request [#2967](https://github.com/rubygems/rubygems/pull/2967) by Luis
   Sagastume.
 
 ## Breaking changes:
 
-* Remove ruby 1.8 leftovers. Pull request #3442 by David Rodríguez.
-* Minitest cleanup. Pull request #3445 by David Rodríguez.
+* Remove ruby 1.8 leftovers. Pull request [#3442](https://github.com/rubygems/rubygems/pull/3442) by David Rodríguez.
+* Minitest cleanup. Pull request [#3445](https://github.com/rubygems/rubygems/pull/3445) by David Rodríguez.
 * Remove `builder` gem requirement for `gem regenerate_index`. Pull
-  request #3552 by David Rodríguez.
-* Remove modelines for consistency. Pull request #3714 by David Rodríguez.
-* Stop using deprecated OpenSSL::Digest constants. Pull request #3763 by
+  request [#3552](https://github.com/rubygems/rubygems/pull/3552) by David Rodríguez.
+* Remove modelines for consistency. Pull request [#3714](https://github.com/rubygems/rubygems/pull/3714) by David Rodríguez.
+* Stop using deprecated OpenSSL::Digest constants. Pull request [#3763](https://github.com/rubygems/rubygems/pull/3763) by
   Bart de Water.
-* Remove Gem module deprecated methods. Pull request #3101 by Luis
+* Remove Gem module deprecated methods. Pull request [#3101](https://github.com/rubygems/rubygems/pull/3101) by Luis
   Sagastume.
-* Remove ubygems.rb. Pull request #3102 by Luis Sagastume.
-* Remove Gem::Commands::QueryCommand. Pull request #3104 by Luis
+* Remove ubygems.rb. Pull request [#3102](https://github.com/rubygems/rubygems/pull/3102) by Luis Sagastume.
+* Remove Gem::Commands::QueryCommand. Pull request [#3104](https://github.com/rubygems/rubygems/pull/3104) by Luis
   Sagastume.
-* Remove dependency installer deprecated methods. Pull request #3106 by
+* Remove dependency installer deprecated methods. Pull request [#3106](https://github.com/rubygems/rubygems/pull/3106) by
   Luis Sagastume.
-* Remove Gem::UserInteraction#debug method. Pull request #3107 by Luis
+* Remove Gem::UserInteraction#debug method. Pull request [#3107](https://github.com/rubygems/rubygems/pull/3107) by Luis
   Sagastume.
-* Remove options from Gem::GemRunner.new. Pull request #3110 by Luis
+* Remove options from Gem::GemRunner.new. Pull request [#3110](https://github.com/rubygems/rubygems/pull/3110) by Luis
   Sagastume.
-* Remove deprecated Gem::RemoteFetcher#fetch_size. Pull request #3111 by
+* Remove deprecated Gem::RemoteFetcher#fetch_size. Pull request [#3111](https://github.com/rubygems/rubygems/pull/3111) by
   Luis Sagastume.
-* Remove source_exception from Gem::Exception. Pull request #3112 by Luis
+* Remove source_exception from Gem::Exception. Pull request [#3112](https://github.com/rubygems/rubygems/pull/3112) by Luis
   Sagastume.
 * Requiring rubygems/source_specific_file is deprecated, remove it. Pull
-  request #3114 by Luis Sagastume.
+  request [#3114](https://github.com/rubygems/rubygems/pull/3114) by Luis Sagastume.
 
 # 3.1.4 / 2020-06-03
 
 ## Enhancements:
 
 * Deprecate rubyforge_project attribute only during build
-  time. Pull request #3609 by Josef Šimánek.
-* Update links. Pull request #3610 by Josef Šimánek.
-* Run CI at 3.1 branch head as well. Pull request #3677 by Josef Šimánek.
-* Remove failing ubuntu-rvm CI flow. Pull request #3611 by
+  time. Pull request [#3609](https://github.com/rubygems/rubygems/pull/3609) by Josef Šimánek.
+* Update links. Pull request [#3610](https://github.com/rubygems/rubygems/pull/3610) by Josef Šimánek.
+* Run CI at 3.1 branch head as well. Pull request [#3677](https://github.com/rubygems/rubygems/pull/3677) by Josef Šimánek.
+* Remove failing ubuntu-rvm CI flow. Pull request [#3611](https://github.com/rubygems/rubygems/pull/3611) by
   Josef Šimánek.
 
 # 3.1.3 / 2020-05-05
 
 ## Enhancements:
 
-* Resolver: require NameTuple before use. Pull request #3171 by Olle
+* Resolver: require NameTuple before use. Pull request [#3171](https://github.com/rubygems/rubygems/pull/3171) by Olle
   Jonsson.
-* Use absolute paths with autoload. Pull request #3100 by David Rodríguez.
-* Avoid changing $SOURCE_DATE_EPOCH. Pull request #3088 by Ellen Marie
+* Use absolute paths with autoload. Pull request [#3100](https://github.com/rubygems/rubygems/pull/3100) by David Rodríguez.
+* Avoid changing $SOURCE_DATE_EPOCH. Pull request [#3088](https://github.com/rubygems/rubygems/pull/3088) by Ellen Marie
   Dash.
-* Use Bundler 2.1.4. Pull request #3072 by Hiroshi SHIBATA.
+* Use Bundler 2.1.4. Pull request [#3072](https://github.com/rubygems/rubygems/pull/3072) by Hiroshi SHIBATA.
 * Add tests to check if Gem.ruby_version works with ruby git master.
-  Pull request #3049 by Yusuke Endoh.
+  Pull request [#3049](https://github.com/rubygems/rubygems/pull/3049) by Yusuke Endoh.
 
 ## Bug fixes:
 
 * Fix platform comparison check in #contains_requirable_file?. Pull
-  request #3495 by Benoit Daloze.
-* Improve gzip errors logging. Pull request #3485 by David Rodríguez.
-* Fix incorrect `gem uninstall --all` message. Pull request #3483 by David
+  request [#3495](https://github.com/rubygems/rubygems/pull/3495) by Benoit Daloze.
+* Improve gzip errors logging. Pull request [#3485](https://github.com/rubygems/rubygems/pull/3485) by David Rodríguez.
+* Fix incorrect `gem uninstall --all` message. Pull request [#3483](https://github.com/rubygems/rubygems/pull/3483) by David
   Rodríguez.
-* Fix incorrect bundler version being required. Pull request #3458 by
+* Fix incorrect bundler version being required. Pull request [#3458](https://github.com/rubygems/rubygems/pull/3458) by
   David Rodríguez.
 * Fix gem install from a gemdeps file with complex dependencies.
-  Pull request #3054 by Luis Sagastume.
+  Pull request [#3054](https://github.com/rubygems/rubygems/pull/3054) by Luis Sagastume.
 
 # 3.1.2 / 2019-12-20
 
 ## Enhancements:
 
-* Restore non prompting `gem update --system` behavior. Pull request #3040
+* Restore non prompting `gem update --system` behavior. Pull request [#3040](https://github.com/rubygems/rubygems/pull/3040)
   by David Rodríguez.
-* Show only release notes for new code installed. Pull request #3041 by
+* Show only release notes for new code installed. Pull request [#3041](https://github.com/rubygems/rubygems/pull/3041) by
   David Rodríguez.
 * Inform about installed `bundle` executable after `gem update --system`.
-  Pull request #3042 by David Rodríguez.
-* Use Bundler 2.1.2. Pull request #3043 by SHIBATA Hiroshi.
+  Pull request [#3042](https://github.com/rubygems/rubygems/pull/3042) by David Rodríguez.
+* Use Bundler 2.1.2. Pull request [#3043](https://github.com/rubygems/rubygems/pull/3043) by SHIBATA Hiroshi.
 
 ## Bug fixes:
 
-* Require `uri` in source.rb. Pull request #3034 by mihaibuzgau.
-* Fix `gem update --system --force`. Pull request #3035 by David
+* Require `uri` in source.rb. Pull request [#3034](https://github.com/rubygems/rubygems/pull/3034) by mihaibuzgau.
+* Fix `gem update --system --force`. Pull request [#3035](https://github.com/rubygems/rubygems/pull/3035) by David
   Rodríguez.
-* Move `require uri` to source_list. Pull request #3038 by mihaibuzgau.
+* Move `require uri` to source_list. Pull request [#3038](https://github.com/rubygems/rubygems/pull/3038) by mihaibuzgau.
 
 # 3.1.1 / 2019-12-16
 
 ## Bug fixes:
 
 * Vendor Bundler 2.1.0 again. The version of Bundler with
-  RubyGems 3.1.0 was Bundler 2.1.0.pre.3. Pull request #3029 by
+  RubyGems 3.1.0 was Bundler 2.1.0.pre.3. Pull request [#3029](https://github.com/rubygems/rubygems/pull/3029) by
   SHIBATA Hiroshi.
 
 # 3.1.0 / 2019-12-16
 
 ## Enhancements:
 
-* Vendor bundler 2.1. Pull request #3028 by David Rodríguez.
-* Check for rubygems.org typo squatting sources. Pull request #2999 by
+* Vendor bundler 2.1. Pull request [#3028](https://github.com/rubygems/rubygems/pull/3028) by David Rodríguez.
+* Check for rubygems.org typo squatting sources. Pull request [#2999](https://github.com/rubygems/rubygems/pull/2999) by
   Luis Sagastume.
-* Refactor remote fetcher. Pull request #3017 by David Rodríguez.
-* Lazily load `open3`. Pull request #3001 by David Rodríguez.
-* Remove `delegate` dependency. Pull request #3002 by David Rodríguez.
-* Lazily load `uri`. Pull request #3005 by David Rodríguez.
-* Lazily load `rubygems/gem_runner` during tests. Pull request #3009 by
+* Refactor remote fetcher. Pull request [#3017](https://github.com/rubygems/rubygems/pull/3017) by David Rodríguez.
+* Lazily load `open3`. Pull request [#3001](https://github.com/rubygems/rubygems/pull/3001) by David Rodríguez.
+* Remove `delegate` dependency. Pull request [#3002](https://github.com/rubygems/rubygems/pull/3002) by David Rodríguez.
+* Lazily load `uri`. Pull request [#3005](https://github.com/rubygems/rubygems/pull/3005) by David Rodríguez.
+* Lazily load `rubygems/gem_runner` during tests. Pull request [#3009](https://github.com/rubygems/rubygems/pull/3009) by
   David Rodríguez.
-* Use bundler to manage development dependencies. Pull request #3012 by
+* Use bundler to manage development dependencies. Pull request [#3012](https://github.com/rubygems/rubygems/pull/3012) by
   David Rodríguez.
 
 ## Bug fixes:
 
-* Remove unnecessary executable flags. Pull request #2982 by David
+* Remove unnecessary executable flags. Pull request [#2982](https://github.com/rubygems/rubygems/pull/2982) by David
   Rodríguez.
-* Remove configuration that contained a typo. Pull request #2989 by David
+* Remove configuration that contained a typo. Pull request [#2989](https://github.com/rubygems/rubygems/pull/2989) by David
   Rodríguez.
 
 ## Deprecations:
 
 * Deprecate `gem generate_index --modern` and `gem generate_index
-  --no-modern`. Pull request #2992 by David Rodríguez.
+  --no-modern`. Pull request [#2992](https://github.com/rubygems/rubygems/pull/2992) by David Rodríguez.
 
 ## Breaking changes:
 
-* Remove 1.8.7 leftovers. Pull request #2972 by David Rodríguez.
+* Remove 1.8.7 leftovers. Pull request [#2972](https://github.com/rubygems/rubygems/pull/2972) by David Rodríguez.
 
 # 3.1.0.pre3 / 2019-11-11
 
 ## Enhancements:
 
 * Fix gem pristine not accounting for user installed gems. Pull request
-  #2914 by Luis Sagastume.
-* Refactor keyword argument test for Ruby 2.7. Pull request #2947 by
+  [#2914](https://github.com/rubygems/rubygems/pull/2914) by Luis Sagastume.
+* Refactor keyword argument test for Ruby 2.7. Pull request [#2947](https://github.com/rubygems/rubygems/pull/2947) by
   SHIBATA Hiroshi.
-* Fix errors at frozen Gem::Version. Pull request #2949 by Nobuyoshi
+* Fix errors at frozen Gem::Version. Pull request [#2949](https://github.com/rubygems/rubygems/pull/2949) by Nobuyoshi
   Nakada.
-* Remove taint usage on Ruby 2.7+. Pull request #2951 by Jeremy Evans.
-* Check Manifest.txt is up to date. Pull request #2953 by David Rodríguez.
-* Clarify symlink conditionals in tests. Pull request #2962 by David
+* Remove taint usage on Ruby 2.7+. Pull request [#2951](https://github.com/rubygems/rubygems/pull/2951) by Jeremy Evans.
+* Check Manifest.txt is up to date. Pull request [#2953](https://github.com/rubygems/rubygems/pull/2953) by David Rodríguez.
+* Clarify symlink conditionals in tests. Pull request [#2962](https://github.com/rubygems/rubygems/pull/2962) by David
   Rodríguez.
-* Update command line parsing to work under ps. Pull request #2966 by
+* Update command line parsing to work under ps. Pull request [#2966](https://github.com/rubygems/rubygems/pull/2966) by
   David Rodríguez.
-* Properly test `Gem::Specifications.stub_for`. Pull request #2970 by
+* Properly test `Gem::Specifications.stub_for`. Pull request [#2970](https://github.com/rubygems/rubygems/pull/2970) by
   David Rodríguez.
 * Fix Gem::LOADED_SPECS_MUTEX handling for recursive locking. Pull request
-  #2985 by MSP-Greg.
+  [#2985](https://github.com/rubygems/rubygems/pull/2985) by MSP-Greg.
 
 # 3.1.0.pre2 / 2019-10-15
 
 ## Enhancements:
 
-* Optimize Gem::Package::TarReader#each. Pull request #2941 by Jean byroot
+* Optimize Gem::Package::TarReader#each. Pull request [#2941](https://github.com/rubygems/rubygems/pull/2941) by Jean byroot
   Boussier.
-* Time comparison around date boundary. Pull request #2944 by Nobuyoshi
+* Time comparison around date boundary. Pull request [#2944](https://github.com/rubygems/rubygems/pull/2944) by Nobuyoshi
   Nakada.
 
 # 3.1.0.pre1 / 2019-10-08
 
 ## Enhancements:
 
-* Try to use bundler-2.1.0.pre.2. Pull request #2923 by SHIBATA Hiroshi.
-* [Require] Ensure -I beats a default gem. Pull request #1868 by Samuel
+* Try to use bundler-2.1.0.pre.2. Pull request [#2923](https://github.com/rubygems/rubygems/pull/2923) by SHIBATA Hiroshi.
+* [Require] Ensure -I beats a default gem. Pull request [#1868](https://github.com/rubygems/rubygems/pull/1868) by Samuel
   Giddins.
 * [Specification] Prefer user-installed gems to default gems. Pull request
-  #2112 by Samuel Giddins.
-* Multifactor authentication for yank command. Pull request #2514 by Qiu
+  [#2112](https://github.com/rubygems/rubygems/pull/2112) by Samuel Giddins.
+* Multifactor authentication for yank command. Pull request [#2514](https://github.com/rubygems/rubygems/pull/2514) by Qiu
   Chaofan.
-* Autoswitch to exact bundler version if present. Pull request #2583 by
+* Autoswitch to exact bundler version if present. Pull request [#2583](https://github.com/rubygems/rubygems/pull/2583) by
   David Rodríguez.
 * Fix Gem::Requirement equality comparison when ~> operator is used. Pull
-  request #2554 by Grey Baker.
-* Don't use a proxy if https_proxy env var is empty. Pull request #2567 by
+  request [#2554](https://github.com/rubygems/rubygems/pull/2554) by Grey Baker.
+* Don't use a proxy if https_proxy env var is empty. Pull request [#2567](https://github.com/rubygems/rubygems/pull/2567) by
   Luis Sagastume.
-* Fix typo in specs warning. Pull request #2585 by Rui.
-* Bin/gem: remove initial empty line. Pull request #2602 by Kenyon Ralph.
+* Fix typo in specs warning. Pull request [#2585](https://github.com/rubygems/rubygems/pull/2585) by Rui.
+* Bin/gem: remove initial empty line. Pull request [#2602](https://github.com/rubygems/rubygems/pull/2602) by Kenyon Ralph.
 * Avoid rdoc hook when it's failed to load rdoc library. Pull request
-  #2604 by SHIBATA Hiroshi.
-* Refactor get_proxy_from_env logic. Pull request #2611 by Luis Sagastume.
-* Allow to easily bisect flaky failures. Pull request #2626 by David
+  [#2604](https://github.com/rubygems/rubygems/pull/2604) by SHIBATA Hiroshi.
+* Refactor get_proxy_from_env logic. Pull request [#2611](https://github.com/rubygems/rubygems/pull/2611) by Luis Sagastume.
+* Allow to easily bisect flaky failures. Pull request [#2626](https://github.com/rubygems/rubygems/pull/2626) by David
   Rodríguez.
 * Fix `--ignore-dependencies` flag not installing platform specific gems.
-  Pull request #2631 by David Rodríguez.
-* Make `gem install --explain` list platforms. Pull request #2634 by David
+  Pull request [#2631](https://github.com/rubygems/rubygems/pull/2631) by David Rodríguez.
+* Make `gem install --explain` list platforms. Pull request [#2634](https://github.com/rubygems/rubygems/pull/2634) by David
   Rodríguez.
-* Make `gem update --explain` list platforms. Pull request #2635 by David
+* Make `gem update --explain` list platforms. Pull request [#2635](https://github.com/rubygems/rubygems/pull/2635) by David
   Rodríguez.
-* Refactoring install and update explanations. Pull request #2643 by David
+* Refactoring install and update explanations. Pull request [#2643](https://github.com/rubygems/rubygems/pull/2643) by David
   Rodríguez.
-* Restore transitiveness of version comparison. Pull request #2651 by
+* Restore transitiveness of version comparison. Pull request [#2651](https://github.com/rubygems/rubygems/pull/2651) by
   David Rodríguez.
-* Undo requirement sorting. Pull request #2652 by David Rodríguez.
-* Update dummy version of Bundler for #2581. Pull request #2584 by SHIBATA
+* Undo requirement sorting. Pull request [#2652](https://github.com/rubygems/rubygems/pull/2652) by David Rodríguez.
+* Update dummy version of Bundler for #2581. Pull request [#2584](https://github.com/rubygems/rubygems/pull/2584) by SHIBATA
   Hiroshi.
-* Ignore to handle the different platform. Pull request #2672 by SHIBATA
+* Ignore to handle the different platform. Pull request [#2672](https://github.com/rubygems/rubygems/pull/2672) by SHIBATA
   Hiroshi.
 * Make Gem::Specification.default_stubs to public methods. Pull request
-  #2675 by SHIBATA Hiroshi.
-* Sort files and test_files in specifications. Pull request #2524 by
+  [#2675](https://github.com/rubygems/rubygems/pull/2675) by SHIBATA Hiroshi.
+* Sort files and test_files in specifications. Pull request [#2524](https://github.com/rubygems/rubygems/pull/2524) by
   Christopher Baines.
 * Fix comment of Gem::Specification#required_ruby_version=. Pull request
-  #2732 by Alex Junger.
+  [#2732](https://github.com/rubygems/rubygems/pull/2732) by Alex Junger.
 * Config_file.rb - update path separator in ENV['GEMRC'] logic. Pull
-  request #2735 by MSP-Greg.
-* Fix `ruby setup.rb` warnings. Pull request #2737 by David Rodríguez.
+  request [#2735](https://github.com/rubygems/rubygems/pull/2735) by MSP-Greg.
+* Fix `ruby setup.rb` warnings. Pull request [#2737](https://github.com/rubygems/rubygems/pull/2737) by David Rodríguez.
 * Don't use regex delimiters when searching for a dependency. Pull request
-  #2738 by Luis Sagastume.
-* Refactor query command. Pull request #2739 by Luis Sagastume.
+  [#2738](https://github.com/rubygems/rubygems/pull/2738) by Luis Sagastume.
+* Refactor query command. Pull request [#2739](https://github.com/rubygems/rubygems/pull/2739) by Luis Sagastume.
 * Don't remove default spec files from mapping after require. Pull request
-  #2741 by David Rodríguez.
-* Cleanup base test case. Pull request #2742 by David Rodríguez.
-* Simplify Specification#gems_dir. Pull request #2745 by David Rodríguez.
-* Fix test warning. Pull request #2746 by David Rodríguez.
-* Extract an `add_to_load_path` method. Pull request #2749 by David
+  [#2741](https://github.com/rubygems/rubygems/pull/2741) by David Rodríguez.
+* Cleanup base test case. Pull request [#2742](https://github.com/rubygems/rubygems/pull/2742) by David Rodríguez.
+* Simplify Specification#gems_dir. Pull request [#2745](https://github.com/rubygems/rubygems/pull/2745) by David Rodríguez.
+* Fix test warning. Pull request [#2746](https://github.com/rubygems/rubygems/pull/2746) by David Rodríguez.
+* Extract an `add_to_load_path` method. Pull request [#2749](https://github.com/rubygems/rubygems/pull/2749) by David
   Rodríguez.
 * Fix setup command if format_executable is true by default. Pull request
-  #2766 by Jeremy Evans.
+  [#2766](https://github.com/rubygems/rubygems/pull/2766) by Jeremy Evans.
 * Update the certificate files to make the test pass on Debian 10. Pull
-  request #2777 by Yusuke Endoh.
-* Write to the correct config file(.gemrc). Pull request #2779 by Luis
+  request [#2777](https://github.com/rubygems/rubygems/pull/2777) by Yusuke Endoh.
+* Write to the correct config file(.gemrc). Pull request [#2779](https://github.com/rubygems/rubygems/pull/2779) by Luis
   Sagastume.
 * Fix for large values in UID/GID fields in tar archives. Pull request
-  #2780 by Alexey Shein.
-* Lazy require stringio. Pull request #2781 by Luis Sagastume.
+  [#2780](https://github.com/rubygems/rubygems/pull/2780) by Alexey Shein.
+* Lazy require stringio. Pull request [#2781](https://github.com/rubygems/rubygems/pull/2781) by Luis Sagastume.
 * Make Gem::Specification#ruby_code handle OpenSSL::PKey::RSA objects.
-  Pull request #2782 by Luis Sagastume.
+  Pull request [#2782](https://github.com/rubygems/rubygems/pull/2782) by Luis Sagastume.
 * Fix setup command test for bundler with program_suffix. Pull request
-  #2783 by Sorah Fukumori.
-* Make sure `rake package` works. Pull request #2787 by David Rodríguez.
+  [#2783](https://github.com/rubygems/rubygems/pull/2783) by Sorah Fukumori.
+* Make sure `rake package` works. Pull request [#2787](https://github.com/rubygems/rubygems/pull/2787) by David Rodríguez.
 * Synchronize access to the Gem::Specification::LOAD_CACHE Hash. Pull
-  request #2789 by Benoit Daloze.
-* Task to install rubygems to local system. Pull request #2795 by David
+  request [#2789](https://github.com/rubygems/rubygems/pull/2789) by Benoit Daloze.
+* Task to install rubygems to local system. Pull request [#2795](https://github.com/rubygems/rubygems/pull/2795) by David
   Rodríguez.
 * Add an attr_reader to Gem::Installer for the package instance variable.
-  Pull request #2796 by Daniel Berger.
-* Switch CI script to bash. Pull request #2799 by David Rodríguez.
-* Move gemcutter utilities code to Gem::Command. Pull request #2803 by
+  Pull request [#2796](https://github.com/rubygems/rubygems/pull/2796) by Daniel Berger.
+* Switch CI script to bash. Pull request [#2799](https://github.com/rubygems/rubygems/pull/2799) by David Rodríguez.
+* Move gemcutter utilities code to Gem::Command. Pull request [#2803](https://github.com/rubygems/rubygems/pull/2803) by
   Luis Sagastume.
-* Add raw spec method to gem package. Pull request #2806 by Luis
+* Add raw spec method to gem package. Pull request [#2806](https://github.com/rubygems/rubygems/pull/2806) by Luis
   Sagastume.
-* Improve `rake package` test error message. Pull request #2815 by David
+* Improve `rake package` test error message. Pull request [#2815](https://github.com/rubygems/rubygems/pull/2815) by David
   Rodríguez.
-* Resolve `@@project_dir` from test file paths. Pull request #2843 by
+* Resolve `@@project_dir` from test file paths. Pull request [#2843](https://github.com/rubygems/rubygems/pull/2843) by
   Nobuyoshi Nakada.
-* Remove dead code in Gem::Validator. Pull request #2537 by Ellen Marie
+* Remove dead code in Gem::Validator. Pull request [#2537](https://github.com/rubygems/rubygems/pull/2537) by Ellen Marie
   Dash.
 * The date might have advanced since TODAY has been set. Pull request
-  #2938 by Nobuyoshi Nakada.
-* Remove old ci configurations. Pull request #2917 by SHIBATA Hiroshi.
-* Add Gem::Dependency identity. Pull request #2936 by Luis Sagastume.
-* Filter dependency type and name strictly. Pull request #2930 by SHIBATA
+  [#2938](https://github.com/rubygems/rubygems/pull/2938) by Nobuyoshi Nakada.
+* Remove old ci configurations. Pull request [#2917](https://github.com/rubygems/rubygems/pull/2917) by SHIBATA Hiroshi.
+* Add Gem::Dependency identity. Pull request [#2936](https://github.com/rubygems/rubygems/pull/2936) by Luis Sagastume.
+* Filter dependency type and name strictly. Pull request [#2930](https://github.com/rubygems/rubygems/pull/2930) by SHIBATA
   Hiroshi.
 * Always pass an encoding option to Zlib::GzipReader.wrap. Pull request
-  #2933 by Nobuyoshi Nakada.
-* Introduce default prerelease requirement. Pull request #2925 by David
+  [#2933](https://github.com/rubygems/rubygems/pull/2933) by Nobuyoshi Nakada.
+* Introduce default prerelease requirement. Pull request [#2925](https://github.com/rubygems/rubygems/pull/2925) by David
   Rodríguez.
-* Detect libc version, closes #2918. Pull request #2922 by fauno.
+* Detect libc version, closes #2918. Pull request [#2922](https://github.com/rubygems/rubygems/pull/2922) by fauno.
 * Use IAM role to extract security-credentials for EC2 instance. Pull
-  request #2894 by Alexander Pakulov.
-* Improve `gem uninstall --all`. Pull request #2893 by David Rodríguez.
-* Use `RbConfig::CONFIG['rubylibprefix']`. Pull request #2889 by Nobuyoshi
+  request [#2894](https://github.com/rubygems/rubygems/pull/2894) by Alexander Pakulov.
+* Improve `gem uninstall --all`. Pull request [#2893](https://github.com/rubygems/rubygems/pull/2893) by David Rodríguez.
+* Use `RbConfig::CONFIG['rubylibprefix']`. Pull request [#2889](https://github.com/rubygems/rubygems/pull/2889) by Nobuyoshi
   Nakada.
 * Build the first gemspec we found if no arguments are passed to gem
-  build. Pull request #2887 by Luis Sagastume.
-* $LOAD_PATH elements should be real paths. Pull request #2885 by
+  build. Pull request [#2887](https://github.com/rubygems/rubygems/pull/2887) by Luis Sagastume.
+* $LOAD_PATH elements should be real paths. Pull request [#2885](https://github.com/rubygems/rubygems/pull/2885) by
   Nobuyoshi Nakada.
 * Use the standard RUBY_ENGINE_VERSION instead of JRUBY_VERSION. Pull
-  request #2864 by Benoit Daloze.
-* Cleanup after testing `rake package`. Pull request #2862 by David
+  request [#2864](https://github.com/rubygems/rubygems/pull/2864) by Benoit Daloze.
+* Cleanup after testing `rake package`. Pull request [#2862](https://github.com/rubygems/rubygems/pull/2862) by David
   Rodríguez.
 * Cherry-pick shushing deprecation warnings from ruby-core. Pull request
-  #2861 by David Rodríguez.
-* Ext/builder.rb cleanup. Pull request #2849 by Luis Sagastume.
-* Fix @ran_rake assignment in builder.rb. Pull request #2850 by Luis
+  [#2861](https://github.com/rubygems/rubygems/pull/2861) by David Rodríguez.
+* Ext/builder.rb cleanup. Pull request [#2849](https://github.com/rubygems/rubygems/pull/2849) by Luis Sagastume.
+* Fix @ran_rake assignment in builder.rb. Pull request [#2850](https://github.com/rubygems/rubygems/pull/2850) by Luis
   Sagastume.
-* Remove test suite warnings. Pull request #2845 by Luis Sagastume.
+* Remove test suite warnings. Pull request [#2845](https://github.com/rubygems/rubygems/pull/2845) by Luis Sagastume.
 * Replace domain parameter with a parameter to suppress suggestions. Pull
-  request #2846 by Luis Sagastume.
+  request [#2846](https://github.com/rubygems/rubygems/pull/2846) by Luis Sagastume.
 * Move default specifications dir definition out of BasicSpecification.
-  Pull request #2841 by Vít Ondruch.
+  Pull request [#2841](https://github.com/rubygems/rubygems/pull/2841) by Vít Ondruch.
 * There is no usage of @orig_env_* variables in test suite. Pull request
-  #2838 by SHIBATA Hiroshi.
+  [#2838](https://github.com/rubygems/rubygems/pull/2838) by SHIBATA Hiroshi.
 * Use File#open instead of Kernel#open in stub_specification.rb. Pull
-  request #2834 by Luis Sagastume.
-* Simplify #to_ruby code. Pull request #2825 by Nobuyoshi Nakada.
-* Add a gem attr to the Gem::Package class. Pull request #2828 by Daniel
+  request [#2834](https://github.com/rubygems/rubygems/pull/2834) by Luis Sagastume.
+* Simplify #to_ruby code. Pull request [#2825](https://github.com/rubygems/rubygems/pull/2825) by Nobuyoshi Nakada.
+* Add a gem attr to the Gem::Package class. Pull request [#2828](https://github.com/rubygems/rubygems/pull/2828) by Daniel
   Berger.
-* Remove useless TODO comment. Pull request #2818 by Luis Sagastume.
+* Remove useless TODO comment. Pull request [#2818](https://github.com/rubygems/rubygems/pull/2818) by Luis Sagastume.
 
 ## Bug fixes:
 
-* Fix typos in History.txt. Pull request #2565 by Igor Zubkov.
-* Remove unused empty sources array. Pull request #2598 by Aaron
+* Fix typos in History.txt. Pull request [#2565](https://github.com/rubygems/rubygems/pull/2565) by Igor Zubkov.
+* Remove unused empty sources array. Pull request [#2598](https://github.com/rubygems/rubygems/pull/2598) by Aaron
   Patterson.
 * Fix windows specific executables generated by `gem install`. Pull
-  request #2628 by David Rodríguez.
-* Gem::Specification#to_ruby needs OpenSSL. Pull request #2937 by
+  request [#2628](https://github.com/rubygems/rubygems/pull/2628) by David Rodríguez.
+* Gem::Specification#to_ruby needs OpenSSL. Pull request [#2937](https://github.com/rubygems/rubygems/pull/2937) by
   Nobuyoshi Nakada.
-* Set SOURCE_DATE_EPOCH env var if not provided. Pull request #2882 by
+* Set SOURCE_DATE_EPOCH env var if not provided. Pull request [#2882](https://github.com/rubygems/rubygems/pull/2882) by
   Ellen Marie Dash.
-* Installer.rb - fix #windows_stub_script. Pull request #2876 by MSP-Greg.
-* Fixed deprecation message. Pull request #2867 by Nobuyoshi Nakada.
-* Fix requiring default gems to consider prereleases. Pull request #2728
+* Installer.rb - fix #windows_stub_script. Pull request [#2876](https://github.com/rubygems/rubygems/pull/2876) by MSP-Greg.
+* Fixed deprecation message. Pull request [#2867](https://github.com/rubygems/rubygems/pull/2867) by Nobuyoshi Nakada.
+* Fix requiring default gems to consider prereleases. Pull request [#2728](https://github.com/rubygems/rubygems/pull/2728)
   by David Rodríguez.
-* Forbid `find_spec_for_exe` without an `exec_name`. Pull request #2706 by
+* Forbid `find_spec_for_exe` without an `exec_name`. Pull request [#2706](https://github.com/rubygems/rubygems/pull/2706) by
   David Rodríguez.
 * Do not prompt for passphrase when key can be loaded without it. Pull
-  request #2710 by Luis Sagastume.
-* Add missing wrapper. Pull request #2690 by David Rodríguez.
-* Remove long ago deprecated methods. Pull request #2704 by David
+  request [#2710](https://github.com/rubygems/rubygems/pull/2710) by Luis Sagastume.
+* Add missing wrapper. Pull request [#2690](https://github.com/rubygems/rubygems/pull/2690) by David Rodríguez.
+* Remove long ago deprecated methods. Pull request [#2704](https://github.com/rubygems/rubygems/pull/2704) by David
   Rodríguez.
-* Renamed duplicate test. Pull request #2678 by Nobuyoshi Nakada.
-* File.exists? is deprecated. Pull request #2855 by SHIBATA Hiroshi.
-* Fixed to warn with shadowing outer local variable. Pull request #2856 by
+* Renamed duplicate test. Pull request [#2678](https://github.com/rubygems/rubygems/pull/2678) by Nobuyoshi Nakada.
+* File.exists? is deprecated. Pull request [#2855](https://github.com/rubygems/rubygems/pull/2855) by SHIBATA Hiroshi.
+* Fixed to warn with shadowing outer local variable. Pull request [#2856](https://github.com/rubygems/rubygems/pull/2856) by
   SHIBATA Hiroshi.
-* Fix explain with ignore-dependencies. Pull request #2647 by David
+* Fix explain with ignore-dependencies. Pull request [#2647](https://github.com/rubygems/rubygems/pull/2647) by David
   Rodríguez.
 * Fix default gem executable installation when folder is not `bin/`. Pull
-  request #2649 by David Rodríguez.
+  request [#2649](https://github.com/rubygems/rubygems/pull/2649) by David Rodríguez.
 * Fix cryptic error on local and ignore-dependencies combination. Pull
-  request #2650 by David Rodríguez.
+  request [#2650](https://github.com/rubygems/rubygems/pull/2650) by David Rodríguez.
 
 ## Deprecations:
 
 * Make deprecate Gem::RubyGemsVersion and Gem::ConfigMap. Pull request
-  #2857 by SHIBATA Hiroshi.
-* Deprecate Gem::RemoteFetcher#fetch_size. Pull request #2833 by Luis
+  [#2857](https://github.com/rubygems/rubygems/pull/2857) by SHIBATA Hiroshi.
+* Deprecate Gem::RemoteFetcher#fetch_size. Pull request [#2833](https://github.com/rubygems/rubygems/pull/2833) by Luis
   Sagastume.
-* Explicitly deprecate `rubyforge_project`. Pull request #2798 by David
+* Explicitly deprecate `rubyforge_project`. Pull request [#2798](https://github.com/rubygems/rubygems/pull/2798) by David
   Rodríguez.
-* Deprecate unused Gem::Installer#unpack method. Pull request #2715 by Vít
+* Deprecate unused Gem::Installer#unpack method. Pull request [#2715](https://github.com/rubygems/rubygems/pull/2715) by Vít
   Ondruch.
-* Deprecate a few unused methods. Pull request #2674 by David Rodríguez.
-* Add deprecation warnings for cli options. Pull request #2607 by Luis
+* Deprecate a few unused methods. Pull request [#2674](https://github.com/rubygems/rubygems/pull/2674) by David Rodríguez.
+* Add deprecation warnings for cli options. Pull request [#2607](https://github.com/rubygems/rubygems/pull/2607) by Luis
   Sagastume.
 
 ## Breaking changes:
 
-* Suppress keywords warning. Pull request #2934 by Nobuyoshi Nakada.
-* Suppress Ruby 2.7's real kwargs warning. Pull request #2912 by Koichi
+* Suppress keywords warning. Pull request [#2934](https://github.com/rubygems/rubygems/pull/2934) by Nobuyoshi Nakada.
+* Suppress Ruby 2.7's real kwargs warning. Pull request [#2912](https://github.com/rubygems/rubygems/pull/2912) by Koichi
   ITO.
-* Fix Kernel#warn override. Pull request #2911 by Jeremy Evans.
+* Fix Kernel#warn override. Pull request [#2911](https://github.com/rubygems/rubygems/pull/2911) by Jeremy Evans.
 * Remove conflict.rb code that was supposed to be removed in Rubygems 3.
-  Pull request #2802 by Luis Sagastume.
-* Compatibility cleanups. Pull request #2754 by David Rodríguez.
-* Remove `others_possible` activation request param. Pull request #2747 by
+  Pull request [#2802](https://github.com/rubygems/rubygems/pull/2802) by Luis Sagastume.
+* Compatibility cleanups. Pull request [#2754](https://github.com/rubygems/rubygems/pull/2754) by David Rodríguez.
+* Remove `others_possible` activation request param. Pull request [#2747](https://github.com/rubygems/rubygems/pull/2747) by
   David Rodríguez.
-* Remove dependency installer deprecated code. Pull request #2740 by Luis
+* Remove dependency installer deprecated code. Pull request [#2740](https://github.com/rubygems/rubygems/pull/2740) by Luis
   Sagastume.
-* Removed guard condition with USE_BUNDLER_FOR_GEMDEPS. Pull request #2716
+* Removed guard condition with USE_BUNDLER_FOR_GEMDEPS. Pull request [#2716](https://github.com/rubygems/rubygems/pull/2716)
   by SHIBATA Hiroshi.
-* Skip deprecation warning during specs. Pull request #2718 by David
+* Skip deprecation warning during specs. Pull request [#2718](https://github.com/rubygems/rubygems/pull/2718) by David
   Rodríguez.
-* Remove QuickLoader reference. Pull request #2719 by David Rodríguez.
-* Removed circular require. Pull request #2679 by Nobuyoshi Nakada.
+* Remove QuickLoader reference. Pull request [#2719](https://github.com/rubygems/rubygems/pull/2719) by David Rodríguez.
+* Removed circular require. Pull request [#2679](https://github.com/rubygems/rubygems/pull/2679) by Nobuyoshi Nakada.
 * Removed needless environmental variable for Travis CI. Pull request
-  #2685 by SHIBATA Hiroshi.
-* Removing yaml require. Pull request #2538 by Luciano Sousa.
+  [#2685](https://github.com/rubygems/rubygems/pull/2685) by SHIBATA Hiroshi.
+* Removing yaml require. Pull request [#2538](https://github.com/rubygems/rubygems/pull/2538) by Luciano Sousa.
 
 # 3.0.8 / 2020-02-19
 
 ## Bug fixes:
 
-* Gem::Specification#to_ruby needs OpenSSL. Pull request #2937 by
+* Gem::Specification#to_ruby needs OpenSSL. Pull request [#2937](https://github.com/rubygems/rubygems/pull/2937) by
   Nobuyoshi Nakada.
 
 # 3.0.7 / 2020-02-18
@@ -1449,12 +1449,12 @@
 ## Bug fixes:
 
 * Fix underscore version selection for bundler #2908 by David Rodríguez.
-* Add missing wrapper. Pull request #2690 by David Rodríguez.
+* Add missing wrapper. Pull request [#2690](https://github.com/rubygems/rubygems/pull/2690) by David Rodríguez.
 * Make Gem::Specification#ruby_code handle OpenSSL::PKey::RSA objects.
-  Pull request #2782 by Luis Sagastume.
-* Installer.rb - fix #windows_stub_script. Pull request #2876 by MSP-Greg.
+  Pull request [#2782](https://github.com/rubygems/rubygems/pull/2782) by Luis Sagastume.
+* Installer.rb - fix #windows_stub_script. Pull request [#2876](https://github.com/rubygems/rubygems/pull/2876) by MSP-Greg.
 * Use IAM role to extract security-credentials for EC2 instance. Pull
-  request #2894 by Alexander Pakulov.
+  request [#2894](https://github.com/rubygems/rubygems/pull/2894) by Alexander Pakulov.
 
 # 3.0.6 / 2019-08-17
 
@@ -1466,53 +1466,53 @@
 
 ## Enhancements:
 
-* Use env var to configure api key on push. Pull request #2559 by Luis
+* Use env var to configure api key on push. Pull request [#2559](https://github.com/rubygems/rubygems/pull/2559) by Luis
   Sagastume.
-* Unswallow uninstall error. Pull request #2707 by David Rodríguez.
-* Expose windows path normalization utility. Pull request #2767 by David
+* Unswallow uninstall error. Pull request [#2707](https://github.com/rubygems/rubygems/pull/2707) by David Rodríguez.
+* Expose windows path normalization utility. Pull request [#2767](https://github.com/rubygems/rubygems/pull/2767) by David
   Rodríguez.
-* Clean which command. Pull request #2801 by Luis Sagastume.
-* Upgrading S3 source signature to AWS SigV4. Pull request #2807 by
+* Clean which command. Pull request [#2801](https://github.com/rubygems/rubygems/pull/2801) by Luis Sagastume.
+* Upgrading S3 source signature to AWS SigV4. Pull request [#2807](https://github.com/rubygems/rubygems/pull/2807) by
   Alexander Pakulov.
 * Remove misleading comment, no reason to move Gem.host to Gem::Util.
-  Pull request #2811 by Luis Sagastume.
-* Drop support for 'gem env packageversion'. Pull request #2813 by Luis
+  Pull request [#2811](https://github.com/rubygems/rubygems/pull/2811) by Luis Sagastume.
+* Drop support for 'gem env packageversion'. Pull request [#2813](https://github.com/rubygems/rubygems/pull/2813) by Luis
   Sagastume.
 * Take into account just git tracked files in update_manifest rake task.
-  Pull request #2816 by Luis Sagastume.
-* Remove TODO comment, there's no Gem::Dirs constant. Pull request #2819
+  Pull request [#2816](https://github.com/rubygems/rubygems/pull/2816) by Luis Sagastume.
+* Remove TODO comment, there's no Gem::Dirs constant. Pull request [#2819](https://github.com/rubygems/rubygems/pull/2819)
   by Luis Sagastume.
-* Remove unused 'raise' from test_case. Pull request #2820 by Luis
+* Remove unused 'raise' from test_case. Pull request [#2820](https://github.com/rubygems/rubygems/pull/2820) by Luis
   Sagastume.
-* Move TODO comment to an information comment. Pull request #2821 by Luis
+* Move TODO comment to an information comment. Pull request [#2821](https://github.com/rubygems/rubygems/pull/2821) by Luis
   Sagastume.
 * Use File#open instead of Kernel#open in stub_specification.rb. Pull
-  request #2834 by Luis Sagastume.
-* Make error code a gemcutter_utilities a constant. Pull request #2844 by
+  request [#2834](https://github.com/rubygems/rubygems/pull/2834) by Luis Sagastume.
+* Make error code a gemcutter_utilities a constant. Pull request [#2844](https://github.com/rubygems/rubygems/pull/2844) by
   Luis Sagastume.
-* Remove FIXME comment related to PathSupport. Pull request #2854 by Luis
+* Remove FIXME comment related to PathSupport. Pull request [#2854](https://github.com/rubygems/rubygems/pull/2854) by Luis
   Sagastume.
-* Use gsub with Hash. Pull request #2860 by Kazuhiro NISHIYAMA.
+* Use gsub with Hash. Pull request [#2860](https://github.com/rubygems/rubygems/pull/2860) by Kazuhiro NISHIYAMA.
 * Use the standard RUBY_ENGINE_VERSION instead of JRUBY_VERSION. Pull
-  request #2864 by Benoit Daloze.
-* Do not mutate uri.query during s3 signature creation. Pull request #2874
+  request [#2864](https://github.com/rubygems/rubygems/pull/2864) by Benoit Daloze.
+* Do not mutate uri.query during s3 signature creation. Pull request [#2874](https://github.com/rubygems/rubygems/pull/2874)
   by Alexander Pakulov.
-* Fixup #2844. Pull request #2878 by SHIBATA Hiroshi.
+* Fixup #2844. Pull request [#2878](https://github.com/rubygems/rubygems/pull/2878) by SHIBATA Hiroshi.
 
 ## Bug fixes:
 
-* Fix intermittent test error on Appveyor & Travis. Pull request #2568 by
+* Fix intermittent test error on Appveyor & Travis. Pull request [#2568](https://github.com/rubygems/rubygems/pull/2568) by
   MSP-Greg.
-* Extend timeout on assert_self_install_permissions. Pull request #2605 by
+* Extend timeout on assert_self_install_permissions. Pull request [#2605](https://github.com/rubygems/rubygems/pull/2605) by
   SHIBATA Hiroshi.
-* Better folder assertions. Pull request #2644 by David Rodríguez.
+* Better folder assertions. Pull request [#2644](https://github.com/rubygems/rubygems/pull/2644) by David Rodríguez.
 * Fix default gem executable installation when folder is not `bin/`. Pull
-  request #2649 by David Rodríguez.
-* Fix gem uninstall behavior. Pull request #2663 by Luis Sagastume.
+  request [#2649](https://github.com/rubygems/rubygems/pull/2649) by David Rodríguez.
+* Fix gem uninstall behavior. Pull request [#2663](https://github.com/rubygems/rubygems/pull/2663) by Luis Sagastume.
 * Fix for large values in UID/GID fields in tar archives. Pull request
-  #2780 by Alexey Shein.
-* Fixed task order for release. Pull request #2792 by SHIBATA Hiroshi.
-* Ignore GEMRC variable for test suite. Pull request #2837 by SHIBATA
+  [#2780](https://github.com/rubygems/rubygems/pull/2780) by Alexey Shein.
+* Fixed task order for release. Pull request [#2792](https://github.com/rubygems/rubygems/pull/2792) by SHIBATA Hiroshi.
+* Ignore GEMRC variable for test suite. Pull request [#2837](https://github.com/rubygems/rubygems/pull/2837) by SHIBATA
   Hiroshi.
 
 # 3.0.4 / 2019-06-14
@@ -1522,53 +1522,53 @@
 * Add support for TruffleRuby #2612 by Benoit Daloze
 * Serve a more descriptive error when --no-ri or --no-rdoc are used #2572
   by Grey Baker
-* Improve test compatibility with CMake 2.8. Pull request #2590 by Vít
+* Improve test compatibility with CMake 2.8. Pull request [#2590](https://github.com/rubygems/rubygems/pull/2590) by Vít
   Ondruch.
 * Restore gem build behavior and introduce the "-C" flag to gem build.
-  Pull request #2596 by Luis Sagastume.
-* Enabled block call with util_set_arch. Pull request #2603 by SHIBATA
+  Pull request [#2596](https://github.com/rubygems/rubygems/pull/2596) by Luis Sagastume.
+* Enabled block call with util_set_arch. Pull request [#2603](https://github.com/rubygems/rubygems/pull/2603) by SHIBATA
   Hiroshi.
 * Avoid rdoc hook when it's failed to load rdoc library. Pull request
-  #2604 by SHIBATA Hiroshi.
-* Drop tests for legacy RDoc. Pull request #2608 by Nobuyoshi Nakada.
-* Update TODO comment. Pull request #2658 by Luis Sagastume.
-* Skip malicious extension test with mswin platform. Pull request #2670 by
+  [#2604](https://github.com/rubygems/rubygems/pull/2604) by SHIBATA Hiroshi.
+* Drop tests for legacy RDoc. Pull request [#2608](https://github.com/rubygems/rubygems/pull/2608) by Nobuyoshi Nakada.
+* Update TODO comment. Pull request [#2658](https://github.com/rubygems/rubygems/pull/2658) by Luis Sagastume.
+* Skip malicious extension test with mswin platform. Pull request [#2670](https://github.com/rubygems/rubygems/pull/2670) by
   SHIBATA Hiroshi.
-* Check deprecated methods on release. Pull request #2673 by David
+* Check deprecated methods on release. Pull request [#2673](https://github.com/rubygems/rubygems/pull/2673) by David
   Rodríguez.
-* Add steps to run bundler tests. Pull request #2680 by Aditya Prakash.
-* Skip temporary "No such host is known" error. Pull request #2684 by
+* Add steps to run bundler tests. Pull request [#2680](https://github.com/rubygems/rubygems/pull/2680) by Aditya Prakash.
+* Skip temporary "No such host is known" error. Pull request [#2684](https://github.com/rubygems/rubygems/pull/2684) by
   Takashi Kokubun.
-* Replaced aws-sdk-s3 instead of s3cmd. Pull request #2688 by SHIBATA
+* Replaced aws-sdk-s3 instead of s3cmd. Pull request [#2688](https://github.com/rubygems/rubygems/pull/2688) by SHIBATA
   Hiroshi.
-* Allow uninstall from symlinked GEM_HOME. Pull request #2720 by David
+* Allow uninstall from symlinked GEM_HOME. Pull request [#2720](https://github.com/rubygems/rubygems/pull/2720) by David
   Rodríguez.
 * Use current checkout in CI to uninstall RVM related gems. Pull request
-  #2729 by David Rodríguez.
-* Update Contributor Covenant v1.4.1. Pull request #2751 by SHIBATA
+  [#2729](https://github.com/rubygems/rubygems/pull/2729) by David Rodríguez.
+* Update Contributor Covenant v1.4.1. Pull request [#2751](https://github.com/rubygems/rubygems/pull/2751) by SHIBATA
   Hiroshi.
-* Added supported versions of Ruby. Pull request #2756 by SHIBATA Hiroshi.
-* Fix shadowing outer local variable warning. Pull request #2763 by Luis
+* Added supported versions of Ruby. Pull request [#2756](https://github.com/rubygems/rubygems/pull/2756) by SHIBATA Hiroshi.
+* Fix shadowing outer local variable warning. Pull request [#2763](https://github.com/rubygems/rubygems/pull/2763) by Luis
   Sagastume.
 * Update the certificate files to make the test pass on Debian 10. Pull
-  request #2777 by Yusuke Endoh.
-* Backport ruby core changes. Pull request #2778 by SHIBATA Hiroshi.
+  request [#2777](https://github.com/rubygems/rubygems/pull/2777) by Yusuke Endoh.
+* Backport ruby core changes. Pull request [#2778](https://github.com/rubygems/rubygems/pull/2778) by SHIBATA Hiroshi.
 
 ## Bug fixes:
 
-* Test_gem.rb - intermittent failure fix. Pull request #2613 by MSP-Greg.
-* Fix sporadic CI failures. Pull request #2617 by David Rodríguez.
-* Fix flaky bundler version finder tests. Pull request #2624 by David
+* Test_gem.rb - intermittent failure fix. Pull request [#2613](https://github.com/rubygems/rubygems/pull/2613) by MSP-Greg.
+* Fix sporadic CI failures. Pull request [#2617](https://github.com/rubygems/rubygems/pull/2617) by David Rodríguez.
+* Fix flaky bundler version finder tests. Pull request [#2624](https://github.com/rubygems/rubygems/pull/2624) by David
   Rodríguez.
-* Fix gem indexer tests leaking utility gems. Pull request #2625 by David
+* Fix gem indexer tests leaking utility gems. Pull request [#2625](https://github.com/rubygems/rubygems/pull/2625) by David
   Rodríguez.
-* Clean up default spec dir too. Pull request #2639 by David Rodríguez.
-* Fix 2.6.1 build against vendored bundler. Pull request #2645 by David
+* Clean up default spec dir too. Pull request [#2639](https://github.com/rubygems/rubygems/pull/2639) by David Rodríguez.
+* Fix 2.6.1 build against vendored bundler. Pull request [#2645](https://github.com/rubygems/rubygems/pull/2645) by David
   Rodríguez.
-* Fix comment typo. Pull request #2664 by Luis Sagastume.
+* Fix comment typo. Pull request [#2664](https://github.com/rubygems/rubygems/pull/2664) by Luis Sagastume.
 * Fix comment of Gem::Specification#required_ruby_version=. Pull request
-  #2732 by Alex Junger.
-* Fix TODOs. Pull request #2748 by David Rodríguez.
+  [#2732](https://github.com/rubygems/rubygems/pull/2732) by Alex Junger.
+* Fix TODOs. Pull request [#2748](https://github.com/rubygems/rubygems/pull/2748) by David Rodríguez.
 
 # 3.0.3 / 2019-03-05
 
@@ -1585,312 +1585,312 @@ Security fixes:
 
 ## Enhancements:
 
-* Use Bundler-1.17.3. Pull request #2556 by SHIBATA Hiroshi.
-* Fix document flag description. Pull request #2555 by Luis Sagastume.
+* Use Bundler-1.17.3. Pull request [#2556](https://github.com/rubygems/rubygems/pull/2556) by SHIBATA Hiroshi.
+* Fix document flag description. Pull request [#2555](https://github.com/rubygems/rubygems/pull/2555) by Luis Sagastume.
 
 ## Bug fixes:
 
 * Fix tests when ruby --program-suffix is used without rubygems
-  --format-executable. Pull request #2549 by Jeremy Evans.
+  --format-executable. Pull request [#2549](https://github.com/rubygems/rubygems/pull/2549) by Jeremy Evans.
 * Fix Gem::Requirement equality comparison when ~> operator is used. Pull
-  request #2554 by Grey Baker.
-* Unset SOURCE_DATE_EPOCH in the test cases. Pull request #2558 by Sorah
+  request [#2554](https://github.com/rubygems/rubygems/pull/2554) by Grey Baker.
+* Unset SOURCE_DATE_EPOCH in the test cases. Pull request [#2558](https://github.com/rubygems/rubygems/pull/2558) by Sorah
   Fukumori.
-* Restore SOURCE_DATE_EPOCH. Pull request #2560 by SHIBATA Hiroshi.
+* Restore SOURCE_DATE_EPOCH. Pull request [#2560](https://github.com/rubygems/rubygems/pull/2560) by SHIBATA Hiroshi.
 
 # 3.0.1 / 2018-12-23
 
 ## Bug fixes:
 
-* Ensure globbed files paths are expanded. Pull request #2536 by Tony Ta.
-* Dup the Dir.home string before passing it on. Pull request #2545 by
+* Ensure globbed files paths are expanded. Pull request [#2536](https://github.com/rubygems/rubygems/pull/2536) by Tony Ta.
+* Dup the Dir.home string before passing it on. Pull request [#2545](https://github.com/rubygems/rubygems/pull/2545) by
   Charles Oliver Nutter.
-* Added permissions to installed files for non-owners. Pull request #2546
+* Added permissions to installed files for non-owners. Pull request [#2546](https://github.com/rubygems/rubygems/pull/2546)
   by SHIBATA Hiroshi.
-* Restore release task without hoe. Pull request #2547 by SHIBATA Hiroshi.
+* Restore release task without hoe. Pull request [#2547](https://github.com/rubygems/rubygems/pull/2547) by SHIBATA Hiroshi.
 
 # 3.0.0 / 2018-12-19
 
 ## Enhancements:
 
-* S3 source. Pull request #1690 by Aditya Prakash.
-* Download gems with threads. Pull request #1898 by André Arko.
-* Update to SPDX license list 3.0. Pull request #2152 by Mike Linksvayer.
-* [GSoC] Multi-factor feature for RubyGems. Pull request #2369 by Qiu
+* S3 source. Pull request [#1690](https://github.com/rubygems/rubygems/pull/1690) by Aditya Prakash.
+* Download gems with threads. Pull request [#1898](https://github.com/rubygems/rubygems/pull/1898) by André Arko.
+* Update to SPDX license list 3.0. Pull request [#2152](https://github.com/rubygems/rubygems/pull/2152) by Mike Linksvayer.
+* [GSoC] Multi-factor feature for RubyGems. Pull request [#2369](https://github.com/rubygems/rubygems/pull/2369) by Qiu
   Chaofan.
-* Use bundler 1.17.2. Pull request #2521 by SHIBATA Hiroshi.
+* Use bundler 1.17.2. Pull request [#2521](https://github.com/rubygems/rubygems/pull/2521) by SHIBATA Hiroshi.
 * Don't treat inaccessible working directories as build failures. Pull
-  request #1135 by Pete.
+  request [#1135](https://github.com/rubygems/rubygems/pull/1135) by Pete.
 * Remove useless directory parameter from builders .build methods.
-  [rebased]. Pull request #1433 by Kurtis Rainbolt-Greene.
-* Skipping more than one gem in pristine. Pull request #1592 by Henne
+  [rebased]. Pull request [#1433](https://github.com/rubygems/rubygems/pull/1433) by Kurtis Rainbolt-Greene.
+* Skipping more than one gem in pristine. Pull request [#1592](https://github.com/rubygems/rubygems/pull/1592) by Henne
   Vogelsang.
 * Add info command to print information about an installed gem. Pull
-  request #2023 by Colby Swandale.
+  request [#2023](https://github.com/rubygems/rubygems/pull/2023) by Colby Swandale.
 * Add --[no-]check-development option to cleanup command. Pull request
-  #2061 by Lin Jen-Shin (godfat).
-* Show which gem referenced a missing gem. Pull request #2067 by Artem
+  [#2061](https://github.com/rubygems/rubygems/pull/2061) by Lin Jen-Shin (godfat).
+* Show which gem referenced a missing gem. Pull request [#2067](https://github.com/rubygems/rubygems/pull/2067) by Artem
   Khramov.
 * Prevent to delete to "bundler-" prefix gem like bundler-audit. Pull
-  request #2086 by SHIBATA Hiroshi.
+  request [#2086](https://github.com/rubygems/rubygems/pull/2086) by SHIBATA Hiroshi.
 * Fix rake install_test_deps once the rake clean_env does not exist. Pull
-  request #2090 by Lucas Arantes.
+  request [#2090](https://github.com/rubygems/rubygems/pull/2090) by Lucas Arantes.
 * Workaround common options mutation in Gem::Command test. Pull request
-  #2098 by Thibault Jouan.
-* Extract a SpecificationPolicy validation class. Pull request #2101 by
+  [#2098](https://github.com/rubygems/rubygems/pull/2098) by Thibault Jouan.
+* Extract a SpecificationPolicy validation class. Pull request [#2101](https://github.com/rubygems/rubygems/pull/2101) by
   Olle Jonsson.
 * Handle environment that does not have `flock` system call. Pull request
-  #2107 by SHIBATA Hiroshi.
-* Handle the explain option in gem update. Pull request #2110 by Colby
+  [#2107](https://github.com/rubygems/rubygems/pull/2107) by SHIBATA Hiroshi.
+* Handle the explain option in gem update. Pull request [#2110](https://github.com/rubygems/rubygems/pull/2110) by Colby
   Swandale.
 * Add Gem.operating_system_defaults to allow packagers to override
-  defaults. Pull request #2116 by Vít Ondruch.
-* Update for compatibility with new minitest. Pull request #2118 by
+  defaults. Pull request [#2116](https://github.com/rubygems/rubygems/pull/2116) by Vít Ondruch.
+* Update for compatibility with new minitest. Pull request [#2118](https://github.com/rubygems/rubygems/pull/2118) by
   MSP-Greg.
-* Make Windows bin stubs portable. Pull request #2119 by MSP-Greg.
+* Make Windows bin stubs portable. Pull request [#2119](https://github.com/rubygems/rubygems/pull/2119) by MSP-Greg.
 * Avoid to warnings about gemspec loadings in rubygems tests. Pull request
-  #2125 by SHIBATA Hiroshi.
+  [#2125](https://github.com/rubygems/rubygems/pull/2125) by SHIBATA Hiroshi.
 * Set whether bundler is used for gemdeps with an environmental variable.
-  Pull request #2126 by SHIBATA Hiroshi.
-* Titleize "GETTING HELP" in readme. Pull request #2136 by Colby Swandale.
+  Pull request [#2126](https://github.com/rubygems/rubygems/pull/2126) by SHIBATA Hiroshi.
+* Titleize "GETTING HELP" in readme. Pull request [#2136](https://github.com/rubygems/rubygems/pull/2136) by Colby Swandale.
 * Improve the error message given when using --version with multiple gems
-  in the install command. Pull request #2137 by Colby Swandale.
-* Use `File.open` instead of `open`. Pull request #2142 by SHIBATA
+  in the install command. Pull request [#2137](https://github.com/rubygems/rubygems/pull/2137) by Colby Swandale.
+* Use `File.open` instead of `open`. Pull request [#2142](https://github.com/rubygems/rubygems/pull/2142) by SHIBATA
   Hiroshi.
 * Gem::Util.traverse_parents should not crash on permissions error. Pull
-  request #2147 by Robert Ulejczyk.
-* [Installer] Avoid a #mkdir race condition. Pull request #2148 by Samuel
+  request [#2147](https://github.com/rubygems/rubygems/pull/2147) by Robert Ulejczyk.
+* [Installer] Avoid a #mkdir race condition. Pull request [#2148](https://github.com/rubygems/rubygems/pull/2148) by Samuel
   Giddins.
 * Allow writing gemspecs from gem unpack to location specified by target
-  option. Pull request #2150 by Colby Swandale.
+  option. Pull request [#2150](https://github.com/rubygems/rubygems/pull/2150) by Colby Swandale.
 * Raise errors in `gem uninstall` when a file in a gem could not be
-  removed . Pull request #2154 by Colby Swandale.
-* Remove PID from gem index directory. Pull request #2155 by SHIBATA
+  removed . Pull request [#2154](https://github.com/rubygems/rubygems/pull/2154) by Colby Swandale.
+* Remove PID from gem index directory. Pull request [#2155](https://github.com/rubygems/rubygems/pull/2155) by SHIBATA
   Hiroshi.
-* Nil guard on `Gem::Specification`. Pull request #2164 by SHIBATA
+* Nil guard on `Gem::Specification`. Pull request [#2164](https://github.com/rubygems/rubygems/pull/2164) by SHIBATA
   Hiroshi.
-* Skip broken test with macOS platform. Pull request #2167 by SHIBATA
+* Skip broken test with macOS platform. Pull request [#2167](https://github.com/rubygems/rubygems/pull/2167) by SHIBATA
   Hiroshi.
 * Support option for `--destdir` with upgrade installer. Pull request
-  #2169 by SHIBATA Hiroshi.
-* To use constant instead of hard-coded version. Pull request #2171 by
+  [#2169](https://github.com/rubygems/rubygems/pull/2169) by SHIBATA Hiroshi.
+* To use constant instead of hard-coded version. Pull request [#2171](https://github.com/rubygems/rubygems/pull/2171) by
   SHIBATA Hiroshi.
-* Add Rake task to install dev dependencies. Pull request #2173 by Ellen
+* Add Rake task to install dev dependencies. Pull request [#2173](https://github.com/rubygems/rubygems/pull/2173) by Ellen
   Marie Dash.
 * Add new sections to the README and explanation of what RubyGems is.
-  Pull request #2174 by Colby Swandale.
-* Prefer to use `Numeric#zero?` instead of `== 0`. Pull request #2176 by
+  Pull request [#2174](https://github.com/rubygems/rubygems/pull/2174) by Colby Swandale.
+* Prefer to use `Numeric#zero?` instead of `== 0`. Pull request [#2176](https://github.com/rubygems/rubygems/pull/2176) by
   SHIBATA Hiroshi.
-* Ignore performance test of version regexp pattern. Pull request #2179 by
+* Ignore performance test of version regexp pattern. Pull request [#2179](https://github.com/rubygems/rubygems/pull/2179) by
   SHIBATA Hiroshi.
-* Ignore .DS_Store files in the update_manifest task. Pull request #2199
+* Ignore .DS_Store files in the update_manifest task. Pull request [#2199](https://github.com/rubygems/rubygems/pull/2199)
   by Colby Swandale.
 * Allow building gems without having to be in the gem folder . Pull
-  request #2204 by Colby Swandale.
-* Added coverage ability used by simplecov. Pull request #2207 by SHIBATA
+  request [#2204](https://github.com/rubygems/rubygems/pull/2204) by Colby Swandale.
+* Added coverage ability used by simplecov. Pull request [#2207](https://github.com/rubygems/rubygems/pull/2207) by SHIBATA
   Hiroshi.
-* Improve invalid proxy error message. Pull request #2217 by Luis
+* Improve invalid proxy error message. Pull request [#2217](https://github.com/rubygems/rubygems/pull/2217) by Luis
   Sagastume.
 * Simplify home directory detection and platform condition. Pull request
-  #2218 by SHIBATA Hiroshi.
-* Permission options. Pull request #2219 by Nobuyoshi Nakada.
-* Improve gemspec and package task. Pull request #2220 by SHIBATA Hiroshi.
-* Prefer to use util_spec in `Gem::TestCase`. Pull request #2227 by
+  [#2218](https://github.com/rubygems/rubygems/pull/2218) by SHIBATA Hiroshi.
+* Permission options. Pull request [#2219](https://github.com/rubygems/rubygems/pull/2219) by Nobuyoshi Nakada.
+* Improve gemspec and package task. Pull request [#2220](https://github.com/rubygems/rubygems/pull/2220) by SHIBATA Hiroshi.
+* Prefer to use util_spec in `Gem::TestCase`. Pull request [#2227](https://github.com/rubygems/rubygems/pull/2227) by
   SHIBATA Hiroshi.
 *  [Requirement] Treat requirements with == versions as equal. Pull
-  request #2230 by Samuel Giddins.
-* Add a note for the non-semantically versioned case. Pull request #2242
+  request [#2230](https://github.com/rubygems/rubygems/pull/2230) by Samuel Giddins.
+* Add a note for the non-semantically versioned case. Pull request [#2242](https://github.com/rubygems/rubygems/pull/2242)
   by David Rodríguez.
-* Keep feature names loaded in the block. Pull request #2261 by Nobuyoshi
+* Keep feature names loaded in the block. Pull request [#2261](https://github.com/rubygems/rubygems/pull/2261) by Nobuyoshi
   Nakada.
-* Tweak warning recommendation. Pull request #2266 by David Rodríguez.
-* Show git path in gem env. Pull request #2268 by Luis Sagastume.
-* Add `--env-shebang` flag to setup command. Pull request #2271 by James
+* Tweak warning recommendation. Pull request [#2266](https://github.com/rubygems/rubygems/pull/2266) by David Rodríguez.
+* Show git path in gem env. Pull request [#2268](https://github.com/rubygems/rubygems/pull/2268) by Luis Sagastume.
+* Add `--env-shebang` flag to setup command. Pull request [#2271](https://github.com/rubygems/rubygems/pull/2271) by James
   Myers.
 * Support SOURCE_DATE_EPOCH to make gem spec reproducible. Pull request
-  #2278 by Levente Polyak.
+  [#2278](https://github.com/rubygems/rubygems/pull/2278) by Levente Polyak.
 * Chdir back to original directory when building an extension fails. Pull
-  request #2282 by Samuel Giddins.
-* [Rakefile] Add a default task that runs the tests. Pull request #2283 by
+  request [#2282](https://github.com/rubygems/rubygems/pull/2282) by Samuel Giddins.
+* [Rakefile] Add a default task that runs the tests. Pull request [#2283](https://github.com/rubygems/rubygems/pull/2283) by
   Samuel Giddins.
 * Support SOURCE_DATE_EPOCH to make gem tar reproducible. Pull request
-  #2289 by Levente Polyak.
-* Reset hooks in test cases. Pull request #2297 by Samuel Giddins.
-* Minor typo: nokogiri. Pull request #2298 by Darshan Baid.
-* Ignore vendored molinillo from code coverage. Pull request #2302 by
+  [#2289](https://github.com/rubygems/rubygems/pull/2289) by Levente Polyak.
+* Reset hooks in test cases. Pull request [#2297](https://github.com/rubygems/rubygems/pull/2297) by Samuel Giddins.
+* Minor typo: nokogiri. Pull request [#2298](https://github.com/rubygems/rubygems/pull/2298) by Darshan Baid.
+* Ignore vendored molinillo from code coverage. Pull request [#2302](https://github.com/rubygems/rubygems/pull/2302) by
   SHIBATA Hiroshi.
-* Support IO.copy_stream. Pull request #2303 by okkez.
-* Prepare beta release. Pull request #2304 by SHIBATA Hiroshi.
-* Add error message when trying to open a default gem. Pull request #2307
+* Support IO.copy_stream. Pull request [#2303](https://github.com/rubygems/rubygems/pull/2303) by okkez.
+* Prepare beta release. Pull request [#2304](https://github.com/rubygems/rubygems/pull/2304) by SHIBATA Hiroshi.
+* Add error message when trying to open a default gem. Pull request [#2307](https://github.com/rubygems/rubygems/pull/2307)
   by Luis Sagastume.
-* Add alias command 'i' for 'install' command. Pull request #2308 by
+* Add alias command 'i' for 'install' command. Pull request [#2308](https://github.com/rubygems/rubygems/pull/2308) by
   ota42y.
-* Cleanup rdoc task in Rakefile. Pull request #2318 by SHIBATA Hiroshi.
-* Add testcase to test_gem_text.rb. Pull request #2329 by Oliver.
-* Gem build strict option. Pull request #2332 by David Rodríguez.
-* Make spec reset more informative. Pull request #2333 by Luis Sagastume.
+* Cleanup rdoc task in Rakefile. Pull request [#2318](https://github.com/rubygems/rubygems/pull/2318) by SHIBATA Hiroshi.
+* Add testcase to test_gem_text.rb. Pull request [#2329](https://github.com/rubygems/rubygems/pull/2329) by Oliver.
+* Gem build strict option. Pull request [#2332](https://github.com/rubygems/rubygems/pull/2332) by David Rodríguez.
+* Make spec reset more informative. Pull request [#2333](https://github.com/rubygems/rubygems/pull/2333) by Luis Sagastume.
 * [Rakefile] Set bundler build metadata when doing a release. Pull request
-  #2335 by Samuel Giddins.
-* Speed up globbing relative to given directories. Pull request #2336 by
+  [#2335](https://github.com/rubygems/rubygems/pull/2335) by Samuel Giddins.
+* Speed up globbing relative to given directories. Pull request [#2336](https://github.com/rubygems/rubygems/pull/2336) by
   Samuel Giddins.
-* Remove semver gem build warning. Pull request #2351 by David Rodríguez.
-* Expand symlinks in gem path. Pull request #2352 by Benoit Daloze.
-* Normalize comment indentations. Pull request #2353 by David Rodríguez.
-* Add bindir flag to pristine. Pull request #2361 by Luis Sagastume.
-* Add --user-install behaviour to cleanup command. Pull request #2362 by
+* Remove semver gem build warning. Pull request [#2351](https://github.com/rubygems/rubygems/pull/2351) by David Rodríguez.
+* Expand symlinks in gem path. Pull request [#2352](https://github.com/rubygems/rubygems/pull/2352) by Benoit Daloze.
+* Normalize comment indentations. Pull request [#2353](https://github.com/rubygems/rubygems/pull/2353) by David Rodríguez.
+* Add bindir flag to pristine. Pull request [#2361](https://github.com/rubygems/rubygems/pull/2361) by Luis Sagastume.
+* Add --user-install behaviour to cleanup command. Pull request [#2362](https://github.com/rubygems/rubygems/pull/2362) by
   Luis Sagastume.
-* Allow build options to be passed to Rake. Pull request #2382 by Alyssa
+* Allow build options to be passed to Rake. Pull request [#2382](https://github.com/rubygems/rubygems/pull/2382) by Alyssa
   Ross.
-* Add --re-sign flag to cert command. Pull request #2391 by Luis
+* Add --re-sign flag to cert command. Pull request [#2391](https://github.com/rubygems/rubygems/pull/2391) by Luis
   Sagastume.
-* Fix "interpreted as grouped expression" warning. Pull request #2399 by
+* Fix "interpreted as grouped expression" warning. Pull request [#2399](https://github.com/rubygems/rubygems/pull/2399) by
   Colby Swandale.
 * [Gem::Ext::Builder] Comments to aid future refactoring. Pull request
-  #2405 by Ellen Marie Dash.
+  [#2405](https://github.com/rubygems/rubygems/pull/2405) by Ellen Marie Dash.
 * Move CONTRIBUTING.rdoc and POLICIES.rdoc documents to markdown. Pull
-  request #2412 by Colby Swandale.
-* Improve certificate expiration defaults. Pull request #2420 by Luis
+  request [#2412](https://github.com/rubygems/rubygems/pull/2412) by Colby Swandale.
+* Improve certificate expiration defaults. Pull request [#2420](https://github.com/rubygems/rubygems/pull/2420) by Luis
   Sagastume.
-* Freeze all possible constants. Pull request #2422 by Colby Swandale.
+* Freeze all possible constants. Pull request [#2422](https://github.com/rubygems/rubygems/pull/2422) by Colby Swandale.
 * Fix bundler rubygems binstub not properly looking for bundler. Pull
-  request #2426 by David Rodríguez.
+  request [#2426](https://github.com/rubygems/rubygems/pull/2426) by David Rodríguez.
 * Make sure rubygems never leaks to another installation. Pull request
-  #2427 by David Rodríguez.
-* Update README.md. Pull request #2428 by Marc-André Lafortune.
-* Restrict special chars from prefixing new gem names. Pull request #2432
+  [#2427](https://github.com/rubygems/rubygems/pull/2427) by David Rodríguez.
+* Update README.md. Pull request [#2428](https://github.com/rubygems/rubygems/pull/2428) by Marc-André Lafortune.
+* Restrict special chars from prefixing new gem names. Pull request [#2432](https://github.com/rubygems/rubygems/pull/2432)
   by Luis Sagastume.
 * This removes support for dynamic API backend lookup via DNS SRV records.
-  Pull request #2433 by Arlandis Word.
-* Fix link to CONTRIBUTING.md doc. Pull request #2434 by Arlandis Word.
-* Support Keyword args with Psych. Pull request #2439 by SHIBATA Hiroshi.
-* Bug/kernel#warn uplevel. Pull request #2442 by Nobuyoshi Nakada.
-* Improve certificate error message. Pull request #2454 by Luis Sagastume.
-* Update gem open command help text. Pull request #2458 by Aditya Prakash.
-* Uninstall with versions. Pull request #2466 by David Rodríguez.
-* Add output option to build command. Pull request #2501 by Colby
+  Pull request [#2433](https://github.com/rubygems/rubygems/pull/2433) by Arlandis Word.
+* Fix link to CONTRIBUTING.md doc. Pull request [#2434](https://github.com/rubygems/rubygems/pull/2434) by Arlandis Word.
+* Support Keyword args with Psych. Pull request [#2439](https://github.com/rubygems/rubygems/pull/2439) by SHIBATA Hiroshi.
+* Bug/kernel#warn uplevel. Pull request [#2442](https://github.com/rubygems/rubygems/pull/2442) by Nobuyoshi Nakada.
+* Improve certificate error message. Pull request [#2454](https://github.com/rubygems/rubygems/pull/2454) by Luis Sagastume.
+* Update gem open command help text. Pull request [#2458](https://github.com/rubygems/rubygems/pull/2458) by Aditya Prakash.
+* Uninstall with versions. Pull request [#2466](https://github.com/rubygems/rubygems/pull/2466) by David Rodríguez.
+* Add output option to build command. Pull request [#2501](https://github.com/rubygems/rubygems/pull/2501) by Colby
   Swandale.
-* Move rubocop into a separate stage in travis ci. Pull request #2510 by
+* Move rubocop into a separate stage in travis ci. Pull request [#2510](https://github.com/rubygems/rubygems/pull/2510) by
   Colby Swandale.
-* Ignore warnings with test_gem_specification.rb. Pull request #2523 by
+* Ignore warnings with test_gem_specification.rb. Pull request [#2523](https://github.com/rubygems/rubygems/pull/2523) by
   SHIBATA Hiroshi.
-* Support the environment without OpenSSL. Pull request #2528 by SHIBATA
+* Support the environment without OpenSSL. Pull request [#2528](https://github.com/rubygems/rubygems/pull/2528) by SHIBATA
   Hiroshi.
 
 ## Bug fixes:
 
-* Fix undefined method error when printing alert. Pull request #1884 by
+* Fix undefined method error when printing alert. Pull request [#1884](https://github.com/rubygems/rubygems/pull/1884) by
   Robert Ross.
 * Frozen string fix - lib/rubygems/bundler_version_finder.rb. Pull request
-  #2115 by MSP-Greg.
-* Fixed typos. Pull request #2143 by SHIBATA Hiroshi.
-* Fix regression of destdir on Windows platform. Pull request #2178 by
+  [#2115](https://github.com/rubygems/rubygems/pull/2115) by MSP-Greg.
+* Fixed typos. Pull request [#2143](https://github.com/rubygems/rubygems/pull/2143) by SHIBATA Hiroshi.
+* Fix regression of destdir on Windows platform. Pull request [#2178](https://github.com/rubygems/rubygems/pull/2178) by
   SHIBATA Hiroshi.
 * Fixed no assignment variables about default gems installation. Pull
-  request #2181 by SHIBATA Hiroshi.
-* Fix spelling errors in the README. Pull request #2187 by Colby Swandale.
-* Missing comma creates ambiguous meaning. Pull request #2190 by Clifford
+  request [#2181](https://github.com/rubygems/rubygems/pull/2181) by SHIBATA Hiroshi.
+* Fix spelling errors in the README. Pull request [#2187](https://github.com/rubygems/rubygems/pull/2187) by Colby Swandale.
+* Missing comma creates ambiguous meaning. Pull request [#2190](https://github.com/rubygems/rubygems/pull/2190) by Clifford
   Heath.
-* Fix getting started instructions. Pull request #2198 by Luis Sagastume.
-* Fix rubygems dev env. Pull request #2201 by Luis Sagastume.
+* Fix getting started instructions. Pull request [#2198](https://github.com/rubygems/rubygems/pull/2198) by Luis Sagastume.
+* Fix rubygems dev env. Pull request [#2201](https://github.com/rubygems/rubygems/pull/2201) by Luis Sagastume.
 * Fix #1470: generate documentation when --install-dir is present. Pull
-  request #2229 by Elias Hernandis.
-* Fix activation when multiple platforms installed. Pull request #2339 by
+  request [#2229](https://github.com/rubygems/rubygems/pull/2229) by Elias Hernandis.
+* Fix activation when multiple platforms installed. Pull request [#2339](https://github.com/rubygems/rubygems/pull/2339) by
   MSP-Greg.
 * Fix required_ruby_version with prereleases and improve error message.
-  Pull request #2344 by David Rodríguez.
-* Update tests for 'newer' Windows builds. Pull request #2348 by MSP-Greg.
-* Fix broken rubocop task by upgrading to 0.58.1. Pull request #2356 by
+  Pull request [#2344](https://github.com/rubygems/rubygems/pull/2344) by David Rodríguez.
+* Update tests for 'newer' Windows builds. Pull request [#2348](https://github.com/rubygems/rubygems/pull/2348) by MSP-Greg.
+* Fix broken rubocop task by upgrading to 0.58.1. Pull request [#2356](https://github.com/rubygems/rubygems/pull/2356) by
   David Rodríguez.
 * Gem::Version should handle nil like it used to before. Pull request
-  #2363 by Luis Sagastume.
-* Avoid need of C++ compiler to pass the test suite. Pull request #2367 by
+  [#2363](https://github.com/rubygems/rubygems/pull/2363) by Luis Sagastume.
+* Avoid need of C++ compiler to pass the test suite. Pull request [#2367](https://github.com/rubygems/rubygems/pull/2367) by
   Vít Ondruch.
-* Fix auto resign expired certificate. Pull request #2380 by Luis
+* Fix auto resign expired certificate. Pull request [#2380](https://github.com/rubygems/rubygems/pull/2380) by Luis
   Sagastume.
-* Skip permissions-dependent test when root. Pull request #2386 by Alyssa
+* Skip permissions-dependent test when root. Pull request [#2386](https://github.com/rubygems/rubygems/pull/2386) by Alyssa
   Ross.
-* Fix test that depended on /usr/bin being in PATH. Pull request #2387 by
+* Fix test that depended on /usr/bin being in PATH. Pull request [#2387](https://github.com/rubygems/rubygems/pull/2387) by
   Alyssa Ross.
-* Fixed test fail with mswin environment. Pull request #2390 by SHIBATA
+* Fixed test fail with mswin environment. Pull request [#2390](https://github.com/rubygems/rubygems/pull/2390) by SHIBATA
   Hiroshi.
-* Fix broken builds using the correct rubocop version. Pull request #2396
+* Fix broken builds using the correct rubocop version. Pull request [#2396](https://github.com/rubygems/rubygems/pull/2396)
   by Luis Sagastume.
-* Fix extension builder failure when verbose. Pull request #2457 by Sorah
+* Fix extension builder failure when verbose. Pull request [#2457](https://github.com/rubygems/rubygems/pull/2457) by Sorah
   Fukumori.
-* Fix test warnings. Pull request #2472 by MSP-Greg.
+* Fix test warnings. Pull request [#2472](https://github.com/rubygems/rubygems/pull/2472) by MSP-Greg.
 * The test suite of bundler is not present ruby description. Pull request
-  #2484 by SHIBATA Hiroshi.
-* Fix crash on certain gemspecs. Pull request #2506 by David Rodríguez.
-* Fixed test fails with the newer version of OpenSSL. Pull request #2507
+  [#2484](https://github.com/rubygems/rubygems/pull/2484) by SHIBATA Hiroshi.
+* Fix crash on certain gemspecs. Pull request [#2506](https://github.com/rubygems/rubygems/pull/2506) by David Rodríguez.
+* Fixed test fails with the newer version of OpenSSL. Pull request [#2507](https://github.com/rubygems/rubygems/pull/2507)
   by SHIBATA Hiroshi.
-* Fix broken symlink that points to ../*. Pull request #2516 by Akira
+* Fix broken symlink that points to ../*. Pull request [#2516](https://github.com/rubygems/rubygems/pull/2516) by Akira
   Matsuda.
-* Fix remote fetcher tests. Pull request #2520 by Luis Sagastume.
+* Fix remote fetcher tests. Pull request [#2520](https://github.com/rubygems/rubygems/pull/2520) by Luis Sagastume.
 * Fix tests when --program-suffix and similar ruby configure options are
-  used. Pull request #2529 by Jeremy Evans.
+  used. Pull request [#2529](https://github.com/rubygems/rubygems/pull/2529) by Jeremy Evans.
 
 ## Breaking changes:
 
-* IO.binread is not provided at Ruby 1.8. Pull request #2093 by SHIBATA
+* IO.binread is not provided at Ruby 1.8. Pull request [#2093](https://github.com/rubygems/rubygems/pull/2093) by SHIBATA
   Hiroshi.
 * Ignored to publish rdoc documentation of rubygems for
-  docs.seattlerb.org. Pull request #2105 by SHIBATA Hiroshi.
-* Support pre-release RubyGems. Pull request #2128 by SHIBATA Hiroshi.
-* Relax minitest version for 5. Pull request #2131 by SHIBATA Hiroshi.
-* Remove zentest from dev dependency. Pull request #2132 by SHIBATA
+  docs.seattlerb.org. Pull request [#2105](https://github.com/rubygems/rubygems/pull/2105) by SHIBATA Hiroshi.
+* Support pre-release RubyGems. Pull request [#2128](https://github.com/rubygems/rubygems/pull/2128) by SHIBATA Hiroshi.
+* Relax minitest version for 5. Pull request [#2131](https://github.com/rubygems/rubygems/pull/2131) by SHIBATA Hiroshi.
+* Remove zentest from dev dependency. Pull request [#2132](https://github.com/rubygems/rubygems/pull/2132) by SHIBATA
   Hiroshi.
-* Remove hoe for test suite. Pull request #2160 by SHIBATA Hiroshi.
-* Cleanup deprecated tasks. Pull request #2162 by SHIBATA Hiroshi.
-* Drop to support Ruby < 2.2. Pull request #2182 by SHIBATA Hiroshi.
-* Cleanup deprecated style. Pull request #2193 by SHIBATA Hiroshi.
-* Remove CVEs from the rubygems repo. Pull request #2195 by Colby
+* Remove hoe for test suite. Pull request [#2160](https://github.com/rubygems/rubygems/pull/2160) by SHIBATA Hiroshi.
+* Cleanup deprecated tasks. Pull request [#2162](https://github.com/rubygems/rubygems/pull/2162) by SHIBATA Hiroshi.
+* Drop to support Ruby < 2.2. Pull request [#2182](https://github.com/rubygems/rubygems/pull/2182) by SHIBATA Hiroshi.
+* Cleanup deprecated style. Pull request [#2193](https://github.com/rubygems/rubygems/pull/2193) by SHIBATA Hiroshi.
+* Remove CVEs from the rubygems repo. Pull request [#2195](https://github.com/rubygems/rubygems/pull/2195) by Colby
   Swandale.
-* Removed needless condition for old version of ruby. Pull request #2206
+* Removed needless condition for old version of ruby. Pull request [#2206](https://github.com/rubygems/rubygems/pull/2206)
   by SHIBATA Hiroshi.
-* Removed deprecated methods over the limit day. Pull request #2216 by
+* Removed deprecated methods over the limit day. Pull request [#2216](https://github.com/rubygems/rubygems/pull/2216) by
   SHIBATA Hiroshi.
-* Remove syck support. Pull request #2222 by SHIBATA Hiroshi.
-* Removed needless condition for Encoding. Pull request #2223 by SHIBATA
+* Remove syck support. Pull request [#2222](https://github.com/rubygems/rubygems/pull/2222) by SHIBATA Hiroshi.
+* Removed needless condition for Encoding. Pull request [#2223](https://github.com/rubygems/rubygems/pull/2223) by SHIBATA
   Hiroshi.
-* Removed needless condition for String#force_encoding. Pull request #2225
+* Removed needless condition for String#force_encoding. Pull request [#2225](https://github.com/rubygems/rubygems/pull/2225)
   by SHIBATA Hiroshi.
-* Removed needless OpenSSL patch for Ruby 1.8. Pull request #2243 by
+* Removed needless OpenSSL patch for Ruby 1.8. Pull request [#2243](https://github.com/rubygems/rubygems/pull/2243) by
   SHIBATA Hiroshi.
-* Removed compatibility code for Ruby 1.9.2. Pull request #2244 by SHIBATA
+* Removed compatibility code for Ruby 1.9.2. Pull request [#2244](https://github.com/rubygems/rubygems/pull/2244) by SHIBATA
   Hiroshi.
-* Removed needless version condition for the old ruby. Pull request #2252
+* Removed needless version condition for the old ruby. Pull request [#2252](https://github.com/rubygems/rubygems/pull/2252)
   by SHIBATA Hiroshi.
-* Remove needless define/respond_to condition. Pull request #2255 by
+* Remove needless define/respond_to condition. Pull request [#2255](https://github.com/rubygems/rubygems/pull/2255) by
   SHIBATA Hiroshi.
-* Use File.realpath directly in Gem::Package. Pull request #2284 by
+* Use File.realpath directly in Gem::Package. Pull request [#2284](https://github.com/rubygems/rubygems/pull/2284) by
   SHIBATA Hiroshi.
-* Removed needless condition for old versions of Ruby. Pull request #2286
+* Removed needless condition for old versions of Ruby. Pull request [#2286](https://github.com/rubygems/rubygems/pull/2286)
   by SHIBATA Hiroshi.
 * Remove the --rdoc and --ri options from install/update. Pull request
-  #2354 by Colby Swandale.
+  [#2354](https://github.com/rubygems/rubygems/pull/2354) by Colby Swandale.
 * Move authors assigner to required attributes section of
-  Gem::Specification. Pull request #2406 by Grey Baker.
-* Remove rubyforge_page functionality. Pull request #2436 by Nick
+  Gem::Specification. Pull request [#2406](https://github.com/rubygems/rubygems/pull/2406) by Grey Baker.
+* Remove rubyforge_page functionality. Pull request [#2436](https://github.com/rubygems/rubygems/pull/2436) by Nick
   Schwaderer.
-* Drop ruby 1.8 support and use IO.popen. Pull request #2441 by Nobuyoshi
+* Drop ruby 1.8 support and use IO.popen. Pull request [#2441](https://github.com/rubygems/rubygems/pull/2441) by Nobuyoshi
   Nakada.
-* Drop ruby 2.2 support. Pull request #2487 by David Rodríguez.
-* Remove some old compatibility code. Pull request #2488 by David
+* Drop ruby 2.2 support. Pull request [#2487](https://github.com/rubygems/rubygems/pull/2487) by David Rodríguez.
+* Remove some old compatibility code. Pull request [#2488](https://github.com/rubygems/rubygems/pull/2488) by David
   Rodríguez.
-* Remove .document from src. Pull request #2489 by Colby Swandale.
-* Remove old version support. Pull request #2493 by Nobuyoshi Nakada.
+* Remove .document from src. Pull request [#2489](https://github.com/rubygems/rubygems/pull/2489) by Colby Swandale.
+* Remove old version support. Pull request [#2493](https://github.com/rubygems/rubygems/pull/2493) by Nobuyoshi Nakada.
 * [BudlerVersionFinder] set .filter! and .compatible? to match only on
-  major versions. Pull request #2515 by Colby Swandale.
+  major versions. Pull request [#2515](https://github.com/rubygems/rubygems/pull/2515) by Colby Swandale.
 
 # 2.7.10 / 2019-06-14
 
 ## Enhancements:
 
-* Fix bundler rubygems binstub not properly looking for bundler. Pull request #2426
+* Fix bundler rubygems binstub not properly looking for bundler. Pull request [#2426](https://github.com/rubygems/rubygems/pull/2426)
   by David Rodríguez.
 * [BudlerVersionFinder] set .filter! and .compatible? to match only on major versions.
-  Pull request #2515 by Colby Swandale.
-+ Update for compatibility with new minitest. Pull request #2118 by MSP-Greg.
+  Pull request [#2515](https://github.com/rubygems/rubygems/pull/2515) by Colby Swandale.
++ Update for compatibility with new minitest. Pull request [#2118](https://github.com/rubygems/rubygems/pull/2118) by MSP-Greg.
 
 # 2.7.9 / 2019-03-05
 
@@ -1908,76 +1908,76 @@ Security fixes:
 ## Enhancements:
 
 * [Requirement] Treat requirements with == versions as equal. Pull
-  request #2230 by Samuel Giddins.
-* Fix exec_name documentation. Pull request #2239 by Luis Sagastume.
-* [TarHeader] Extract the empty header into a constant. Pull request #2247
+  request [#2230](https://github.com/rubygems/rubygems/pull/2230) by Samuel Giddins.
+* Fix exec_name documentation. Pull request [#2239](https://github.com/rubygems/rubygems/pull/2239) by Luis Sagastume.
+* [TarHeader] Extract the empty header into a constant. Pull request [#2247](https://github.com/rubygems/rubygems/pull/2247)
   by Samuel Giddins.
 * Simplify the code that lets us call the original, non-monkeypatched
-  Kernel#require. Pull request #2267 by Leon Miller-Out.
-* Add install alias documentation. Pull request #2320 by ota42y.
+  Kernel#require. Pull request [#2267](https://github.com/rubygems/rubygems/pull/2267) by Leon Miller-Out.
+* Add install alias documentation. Pull request [#2320](https://github.com/rubygems/rubygems/pull/2320) by ota42y.
 * [Rakefile] Set bundler build metadata when doing a release. Pull request
-  #2335 by Samuel Giddins.
-* Backport commits from ruby core . Pull request #2347 by SHIBATA Hiroshi.
-* Sign in to the correct host before push. Pull request #2366 by Luis
+  [#2335](https://github.com/rubygems/rubygems/pull/2335) by Samuel Giddins.
+* Backport commits from ruby core . Pull request [#2347](https://github.com/rubygems/rubygems/pull/2347) by SHIBATA Hiroshi.
+* Sign in to the correct host before push. Pull request [#2366](https://github.com/rubygems/rubygems/pull/2366) by Luis
   Sagastume.
-* Bump bundler-1.16.4. Pull request #2381 by SHIBATA Hiroshi.
-* Improve bindir flag description. Pull request #2383 by Luis Sagastume.
-* Update bundler-1.16.6. Pull request #2423 by SHIBATA Hiroshi.
+* Bump bundler-1.16.4. Pull request [#2381](https://github.com/rubygems/rubygems/pull/2381) by SHIBATA Hiroshi.
+* Improve bindir flag description. Pull request [#2383](https://github.com/rubygems/rubygems/pull/2383) by Luis Sagastume.
+* Update bundler-1.16.6. Pull request [#2423](https://github.com/rubygems/rubygems/pull/2423) by SHIBATA Hiroshi.
 
 ## Bug fixes:
 
 * Fix #1470: generate documentation when --install-dir is present. Pull
-  request #2229 by Elias Hernandis.
-* Fix no proxy checking. Pull request #2249 by Luis Sagastume.
-* Validate SPDX license exceptions. Pull request #2257 by Mikit.
-* Retry api specification spec with original platform. Pull request #2275
+  request [#2229](https://github.com/rubygems/rubygems/pull/2229) by Elias Hernandis.
+* Fix no proxy checking. Pull request [#2249](https://github.com/rubygems/rubygems/pull/2249) by Luis Sagastume.
+* Validate SPDX license exceptions. Pull request [#2257](https://github.com/rubygems/rubygems/pull/2257) by Mikit.
+* Retry api specification spec with original platform. Pull request [#2275](https://github.com/rubygems/rubygems/pull/2275)
   by Luis Sagastume.
-* Fix approximate recommendation with prereleases. Pull request #2345 by
+* Fix approximate recommendation with prereleases. Pull request [#2345](https://github.com/rubygems/rubygems/pull/2345) by
   David Rodríguez.
 * Gem::Version should handle nil like it used to before. Pull request
-  #2363 by Luis Sagastume.
+  [#2363](https://github.com/rubygems/rubygems/pull/2363) by Luis Sagastume.
 
 # 2.7.7 / 2018-05-08
 
 ## Enhancements:
 
 * [RequestSet] Only suggest a gem version with an installable platform.
-  Pull request #2175 by Samuel Giddins.
+  Pull request [#2175](https://github.com/rubygems/rubygems/pull/2175) by Samuel Giddins.
 * Fixed no assignment variables about default gems installation. Pull
-  request #2181 by SHIBATA Hiroshi.
-* Backport improvements for test-case from Ruby core. Pull request #2189
+  request [#2181](https://github.com/rubygems/rubygems/pull/2181) by SHIBATA Hiroshi.
+* Backport improvements for test-case from Ruby core. Pull request [#2189](https://github.com/rubygems/rubygems/pull/2189)
   by SHIBATA Hiroshi.
-* Fix ruby warnings in test suite. Pull request #2205 by Colby Swandale.
+* Fix ruby warnings in test suite. Pull request [#2205](https://github.com/rubygems/rubygems/pull/2205) by Colby Swandale.
 * To use Gem::Specification#bindir of bundler instead of hard coded path.
-  Pull request #2208 by SHIBATA Hiroshi.
-* Update gem push --help description. Pull request #2215 by Luis
+  Pull request [#2208](https://github.com/rubygems/rubygems/pull/2208) by SHIBATA Hiroshi.
+* Update gem push --help description. Pull request [#2215](https://github.com/rubygems/rubygems/pull/2215) by Luis
   Sagastume.
-* Backport ruby core commits. Pull request #2264 by SHIBATA Hiroshi.
+* Backport ruby core commits. Pull request [#2264](https://github.com/rubygems/rubygems/pull/2264) by SHIBATA Hiroshi.
 
 ## Bug fixes:
 
 * Frozen string fix - lib/rubygems/bundler_version_finder.rb. Pull request
-  #2115 by MSP-Greg.
-* Fixed tempfile leak for RubyGems 2.7.6. Pull request #2194 by SHIBATA
+  [#2115](https://github.com/rubygems/rubygems/pull/2115) by MSP-Greg.
+* Fixed tempfile leak for RubyGems 2.7.6. Pull request [#2194](https://github.com/rubygems/rubygems/pull/2194) by SHIBATA
   Hiroshi.
-* Add missing requires. Pull request #2196 by David Rodríguez.
-* Fix Gem::Version.correct?. Pull request #2203 by Masato Nakamura.
-* Fix verify_entry regex for metadata. Pull request #2212 by Luis
+* Add missing requires. Pull request [#2196](https://github.com/rubygems/rubygems/pull/2196) by David Rodríguez.
+* Fix Gem::Version.correct?. Pull request [#2203](https://github.com/rubygems/rubygems/pull/2203) by Masato Nakamura.
+* Fix verify_entry regex for metadata. Pull request [#2212](https://github.com/rubygems/rubygems/pull/2212) by Luis
   Sagastume.
-* Fix path checks for case insensitive filesystem. Pull request #2211 by
+* Fix path checks for case insensitive filesystem. Pull request [#2211](https://github.com/rubygems/rubygems/pull/2211) by
   Lars Kanis.
 
 ## Deprecations:
 
-* Deprecate unused code before removing them at #1524. Pull request #2197
+* Deprecate unused code before removing them at #1524. Pull request [#2197](https://github.com/rubygems/rubygems/pull/2197)
   by SHIBATA Hiroshi.
-* Deprecate for rubygems 3. Pull request #2214 by SHIBATA Hiroshi.
-* Mark deprecation to `ubygems.rb` for RubyGems 4. Pull request #2269 by
+* Deprecate for rubygems 3. Pull request [#2214](https://github.com/rubygems/rubygems/pull/2214) by SHIBATA Hiroshi.
+* Mark deprecation to `ubygems.rb` for RubyGems 4. Pull request [#2269](https://github.com/rubygems/rubygems/pull/2269) by
   SHIBATA Hiroshi.
 
 ## Breaking changes:
 
-* Update bundler-1.16.2. Pull request #2291 by SHIBATA Hiroshi.
+* Update bundler-1.16.2. Pull request [#2291](https://github.com/rubygems/rubygems/pull/2291) by SHIBATA Hiroshi.
 
 # 2.7.6 / 2018-02-16
 
@@ -2003,7 +2003,7 @@ Security fixes:
 ## Bug fixes:
 
 * To use bundler-1.16.1 #2121 by SHIBATA Hiroshi.
-* Fixed leaked FDs. Pull request #2127 by Nobuyoshi Nakada.
+* Fixed leaked FDs. Pull request [#2127](https://github.com/rubygems/rubygems/pull/2127) by Nobuyoshi Nakada.
 * Support option for `--destdir` with upgrade installer. #2169 by Thibault Jouan.
 * Remove PID from gem index directory. #2155 by SHIBATA Hiroshi.
 * Avoid a #mkdir race condition #2148 by Samuel Giddins.
@@ -2016,226 +2016,226 @@ Security fixes:
 
 ## Bug fixes:
 
-* Fixed leaked FDs. Pull request #2127 by Nobuyoshi Nakada.
+* Fixed leaked FDs. Pull request [#2127](https://github.com/rubygems/rubygems/pull/2127) by Nobuyoshi Nakada.
 * Avoid to warnings about gemspec loadings in rubygems tests. Pull request
-  #2125 by SHIBATA Hiroshi.
-* Fix updater with rubygems-2.7.3 Pull request #2124 by SHIBATA Hiroshi.
+  [#2125](https://github.com/rubygems/rubygems/pull/2125) by SHIBATA Hiroshi.
+* Fix updater with rubygems-2.7.3 Pull request [#2124](https://github.com/rubygems/rubygems/pull/2124) by SHIBATA Hiroshi.
 * Handle environment that does not have `flock` system call. Pull request
-  #2107 by SHIBATA Hiroshi.
+  [#2107](https://github.com/rubygems/rubygems/pull/2107) by SHIBATA Hiroshi.
 
 # 2.7.3
 
 ## Enhancements:
 
-* Removed needless version lock. Pull request #2074 by SHIBATA Hiroshi.
+* Removed needless version lock. Pull request [#2074](https://github.com/rubygems/rubygems/pull/2074) by SHIBATA Hiroshi.
 * Add --[no-]check-development option to cleanup command. Pull request
-  #2061 by Lin Jen-Shin (godfat).
-* Merge glob pattern using braces. Pull request #2072 by Kazuhiro
+  [#2061](https://github.com/rubygems/rubygems/pull/2061) by Lin Jen-Shin (godfat).
+* Merge glob pattern using braces. Pull request [#2072](https://github.com/rubygems/rubygems/pull/2072) by Kazuhiro
   NISHIYAMA.
-* Removed warnings of unused variables. Pull request #2084 by SHIBATA
+* Removed warnings of unused variables. Pull request [#2084](https://github.com/rubygems/rubygems/pull/2084) by SHIBATA
   Hiroshi.
-* Call SPDX.org using HTTPS. Pull request #2102 by Olle Jonsson.
-* Remove multi load warning from plugins documentation. Pull request #2103
+* Call SPDX.org using HTTPS. Pull request [#2102](https://github.com/rubygems/rubygems/pull/2102) by Olle Jonsson.
+* Remove multi load warning from plugins documentation. Pull request [#2103](https://github.com/rubygems/rubygems/pull/2103)
   by Thibault Jouan.
 
 ## Bug fixes:
 
-* Fix test failure on Alpine Linux. Pull request #2079 by Ellen Marie
+* Fix test failure on Alpine Linux. Pull request [#2079](https://github.com/rubygems/rubygems/pull/2079) by Ellen Marie
   Dash.
-* Avoid encoding issues by using binread in setup. Pull request #2089 by
+* Avoid encoding issues by using binread in setup. Pull request [#2089](https://github.com/rubygems/rubygems/pull/2089) by
   Mauro Morales.
 * Fix rake install_test_deps once the rake clean_env does not exist. Pull
-  request #2090 by Lucas Oliveira.
+  request [#2090](https://github.com/rubygems/rubygems/pull/2090) by Lucas Oliveira.
 * Prevent to delete to "bundler-" prefix gem like bundler-audit. Pull
-  request #2086 by SHIBATA Hiroshi.
-* Generate .bat files on Windows platform. Pull request #2094 by SHIBATA
+  request [#2086](https://github.com/rubygems/rubygems/pull/2086) by SHIBATA Hiroshi.
+* Generate .bat files on Windows platform. Pull request [#2094](https://github.com/rubygems/rubygems/pull/2094) by SHIBATA
   Hiroshi.
 * Workaround common options mutation in Gem::Command test. Pull request
-  #2098 by Thibault Jouan.
-* Check gems dir existence before removing bundler. Pull request #2104 by
+  [#2098](https://github.com/rubygems/rubygems/pull/2098) by Thibault Jouan.
+* Check gems dir existence before removing bundler. Pull request [#2104](https://github.com/rubygems/rubygems/pull/2104) by
   Thibault Jouan.
-* Use setup command --regenerate-binstubs option flag. Pull request #2099
+* Use setup command --regenerate-binstubs option flag. Pull request [#2099](https://github.com/rubygems/rubygems/pull/2099)
   by Thibault Jouan.
 
 # 2.7.2
 
 ## Bug fixes:
 
-* Added template files to vendoerd bundler. Pull request #2065 by SHIBATA
+* Added template files to vendoerd bundler. Pull request [#2065](https://github.com/rubygems/rubygems/pull/2065) by SHIBATA
   Hiroshi.
-* Added workaround for non-git environment. Pull request #2066 by SHIBATA
+* Added workaround for non-git environment. Pull request [#2066](https://github.com/rubygems/rubygems/pull/2066) by SHIBATA
   Hiroshi.
 
 # 2.7.1 (2017-11-03)
 
 ## Bug fixes:
 
-* Fix `gem update --system` with RubyGems 2.7+. Pull request #2054 by
+* Fix `gem update --system` with RubyGems 2.7+. Pull request [#2054](https://github.com/rubygems/rubygems/pull/2054) by
   Samuel Giddins.
 
 # 2.7.0 (2017-11-02)
 
 ## Enhancements:
 
-* Update vendored bundler-1.16.0. Pull request #2051 by Samuel Giddins.
-* Use Bundler for Gem.use_gemdeps. Pull request #1674 by Samuel Giddins.
-* Add command `signin` to `gem` CLI. Pull request #1944 by Shiva Bhusal.
-* Add Logout feature to CLI. Pull request #1938 by Shiva Bhusal.
+* Update vendored bundler-1.16.0. Pull request [#2051](https://github.com/rubygems/rubygems/pull/2051) by Samuel Giddins.
+* Use Bundler for Gem.use_gemdeps. Pull request [#1674](https://github.com/rubygems/rubygems/pull/1674) by Samuel Giddins.
+* Add command `signin` to `gem` CLI. Pull request [#1944](https://github.com/rubygems/rubygems/pull/1944) by Shiva Bhusal.
+* Add Logout feature to CLI. Pull request [#1938](https://github.com/rubygems/rubygems/pull/1938) by Shiva Bhusal.
 * Added message to uninstall command for gem that is not installed. Pull
-  request #1979 by anant anil kolvankar.
-* Add --trust-policy option to unpack command. Pull request #1718 by
+  request [#1979](https://github.com/rubygems/rubygems/pull/1979) by anant anil kolvankar.
+* Add --trust-policy option to unpack command. Pull request [#1718](https://github.com/rubygems/rubygems/pull/1718) by
   Nobuyoshi Nakada.
-* Show default gems for all platforms. Pull request #1685 by Konstantin
+* Show default gems for all platforms. Pull request [#1685](https://github.com/rubygems/rubygems/pull/1685) by Konstantin
   Shabanov.
-* Add Travis and Appveyor build status to README. Pull request #1918 by
+* Add Travis and Appveyor build status to README. Pull request [#1918](https://github.com/rubygems/rubygems/pull/1918) by
   Jun Aruga.
-* Remove warning `no email specified` when no email. Pull request #1675 by
+* Remove warning `no email specified` when no email. Pull request [#1675](https://github.com/rubygems/rubygems/pull/1675) by
   Leigh McCulloch.
-* Improve -rubygems performance. Pull request #1801 by Samuel Giddins.
-* Improve the performance of Kernel#require. Pull request #1678 by Samuel
+* Improve -rubygems performance. Pull request [#1801](https://github.com/rubygems/rubygems/pull/1801) by Samuel Giddins.
+* Improve the performance of Kernel#require. Pull request [#1678](https://github.com/rubygems/rubygems/pull/1678) by Samuel
   Giddins.
 * Improve user-facing messages by consistent casing of Ruby/RubyGems. Pull
-  request #1771 by John Labovitz.
+  request [#1771](https://github.com/rubygems/rubygems/pull/1771) by John Labovitz.
 * Improve error message when Gem::RuntimeRequirementNotMetError is raised.
-  Pull request #1789 by Luis Sagastume.
-* Code Improvement: Inheritance corrected. Pull request #1942 by Shiva
+  Pull request [#1789](https://github.com/rubygems/rubygems/pull/1789) by Luis Sagastume.
+* Code Improvement: Inheritance corrected. Pull request [#1942](https://github.com/rubygems/rubygems/pull/1942) by Shiva
   Bhusal.
-* [Source] Autoload fileutils. Pull request #1906 by Samuel Giddins.
-* Use Hash#fetch instead of if/else in Gem::ConfigFile. Pull request #1824
+* [Source] Autoload fileutils. Pull request [#1906](https://github.com/rubygems/rubygems/pull/1906) by Samuel Giddins.
+* Use Hash#fetch instead of if/else in Gem::ConfigFile. Pull request [#1824](https://github.com/rubygems/rubygems/pull/1824)
   by Daniel Berger.
-* Require digest when it is used. Pull request #2006 by Samuel Giddins.
+* Require digest when it is used. Pull request [#2006](https://github.com/rubygems/rubygems/pull/2006) by Samuel Giddins.
 * Do not index the doc folder in the `update_manifest` task. Pull request
-  #2031 by Colby Swandale.
-* Don't use two postfix conditionals on one line. Pull request #2038 by
+  [#2031](https://github.com/rubygems/rubygems/pull/2031) by Colby Swandale.
+* Don't use two postfix conditionals on one line. Pull request [#2038](https://github.com/rubygems/rubygems/pull/2038) by
   Ellen Marie Dash.
 * [SafeYAML] Avoid warning when Gem::Deprecate.skip is set. Pull request
-  #2034 by Samuel Giddins.
-* Update gem yank description. Pull request #2009 by David Radcliffe.
+  [#2034](https://github.com/rubygems/rubygems/pull/2034) by Samuel Giddins.
+* Update gem yank description. Pull request [#2009](https://github.com/rubygems/rubygems/pull/2009) by David Radcliffe.
 * Fix formatting of installation instructions in README. Pull request
-  #2018 by Jordan Danford.
-* Do not use #quick_spec internally. Pull request #1733 by Jon Moss.
-* Switch from docs to guides reference. Pull request #1886 by Jonathan
+  [#2018](https://github.com/rubygems/rubygems/pull/2018) by Jordan Danford.
+* Do not use #quick_spec internally. Pull request [#1733](https://github.com/rubygems/rubygems/pull/1733) by Jon Moss.
+* Switch from docs to guides reference. Pull request [#1886](https://github.com/rubygems/rubygems/pull/1886) by Jonathan
   Claudius.
 * Happier message when latest version is already installed. Pull request
-  #1956 by Jared Beck.
-* Update specification reference docs. Pull request #1960 by Grey Baker.
+  [#1956](https://github.com/rubygems/rubygems/pull/1956) by Jared Beck.
+* Update specification reference docs. Pull request [#1960](https://github.com/rubygems/rubygems/pull/1960) by Grey Baker.
 * Allow Gem.finish_resolve to respect already-activated specs. Pull
-  request #1910 by Samuel Giddins.
-* Update cryptography for Gem::Security. Pull request #1691 by Sylvain
+  request [#1910](https://github.com/rubygems/rubygems/pull/1910) by Samuel Giddins.
+* Update cryptography for Gem::Security. Pull request [#1691](https://github.com/rubygems/rubygems/pull/1691) by Sylvain
   Daubert.
 * Don't output mkmf.log message if compilation didn't fail. Pull request
-  #1808 by Jeremy Evans.
-* Matches_for_glob - remove root path. Pull request #2010 by ahorek.
+  [#1808](https://github.com/rubygems/rubygems/pull/1808) by Jeremy Evans.
+* Matches_for_glob - remove root path. Pull request [#2010](https://github.com/rubygems/rubygems/pull/2010) by ahorek.
 * Gem::Resolver#search_for update for reliable searching/sorting. Pull
-  request #1993 by MSP-Greg.
+  request [#1993](https://github.com/rubygems/rubygems/pull/1993) by MSP-Greg.
 * Allow local installs with transitive prerelease requirements. Pull
-  request #1990 by Samuel Giddins.
-* Small style fixes to Installer Set. Pull request #1985 by Arthur
+  request [#1990](https://github.com/rubygems/rubygems/pull/1990) by Samuel Giddins.
+* Small style fixes to Installer Set. Pull request [#1985](https://github.com/rubygems/rubygems/pull/1985) by Arthur
   Marzinkovskiy.
-* Setup cmd: Avoid terminating option string w/ dot. Pull request #1825 by
+* Setup cmd: Avoid terminating option string w/ dot. Pull request [#1825](https://github.com/rubygems/rubygems/pull/1825) by
   Olle Jonsson.
-* Warn when no files are set. Pull request #1773 by Aidan Coyle.
-* Ensure `to_spec` falls back on prerelease specs. Pull request #1755 by
+* Warn when no files are set. Pull request [#1773](https://github.com/rubygems/rubygems/pull/1773) by Aidan Coyle.
+* Ensure `to_spec` falls back on prerelease specs. Pull request [#1755](https://github.com/rubygems/rubygems/pull/1755) by
   André Arko.
 * [Specification] Eval setting default attributes in #initialize. Pull
-  request #1739 by Samuel Giddins.
-* Sort ordering of sources is preserved. Pull request #1633 by Nathan
+  request [#1739](https://github.com/rubygems/rubygems/pull/1739) by Samuel Giddins.
+* Sort ordering of sources is preserved. Pull request [#1633](https://github.com/rubygems/rubygems/pull/1633) by Nathan
   Ladd.
-* Retry with :prerelease when no suggestions are found. Pull request #1696
+* Retry with :prerelease when no suggestions are found. Pull request [#1696](https://github.com/rubygems/rubygems/pull/1696)
   by Aditya Prakash.
 * [Rakefile] Run `git submodule update --init` in `rake newb`. Pull
-  request #1694 by Samuel Giddins.
-* [TestCase] Address comments around ui changes. Pull request #1677 by
+  request [#1694](https://github.com/rubygems/rubygems/pull/1694) by Samuel Giddins.
+* [TestCase] Address comments around ui changes. Pull request [#1677](https://github.com/rubygems/rubygems/pull/1677) by
   Samuel Giddins.
-* Eagerly resolve in activate_bin_path. Pull request #1666 by Samuel
+* Eagerly resolve in activate_bin_path. Pull request [#1666](https://github.com/rubygems/rubygems/pull/1666) by Samuel
   Giddins.
-* [Version] Make hash based upon canonical segments. Pull request #1659 by
+* [Version] Make hash based upon canonical segments. Pull request [#1659](https://github.com/rubygems/rubygems/pull/1659) by
   Samuel Giddins.
-* Add Ruby Together CTA, rearrange README a bit. Pull request #1775 by
+* Add Ruby Together CTA, rearrange README a bit. Pull request [#1775](https://github.com/rubygems/rubygems/pull/1775) by
   Michael Bernstein.
-* Update Contributing.rdoc with new label usage. Pull request #1716 by
+* Update Contributing.rdoc with new label usage. Pull request [#1716](https://github.com/rubygems/rubygems/pull/1716) by
   Lynn Cyrin.
-* Add --host sample to help. Pull request #1709 by Code Ahss.
+* Add --host sample to help. Pull request [#1709](https://github.com/rubygems/rubygems/pull/1709) by Code Ahss.
 * Add a helpful suggestion when `gem install` fails due to required_rub….
-  Pull request #1697 by Samuel Giddins.
-* Add cert expiration length flag. Pull request #1725 by Luis Sagastume.
-* Add submodule instructions to manual install. Pull request #1727 by
+  Pull request [#1697](https://github.com/rubygems/rubygems/pull/1697) by Samuel Giddins.
+* Add cert expiration length flag. Pull request [#1725](https://github.com/rubygems/rubygems/pull/1725) by Luis Sagastume.
+* Add submodule instructions to manual install. Pull request [#1727](https://github.com/rubygems/rubygems/pull/1727) by
   Joseph Frazier.
-* Allow usage of multiple `--version` operators. Pull request #1546 by
+* Allow usage of multiple `--version` operators. Pull request [#1546](https://github.com/rubygems/rubygems/pull/1546) by
   James Wen.
-* Warn when requiring deprecated files. Pull request #1939 by Ellen Marie
+* Warn when requiring deprecated files. Pull request [#1939](https://github.com/rubygems/rubygems/pull/1939) by Ellen Marie
   Dash.
 
 ## Deprecations:
 
 * Deprecate Gem::InstallerTestCase#util_gem_bindir and
-  Gem::InstallerTestCase#util_gem_dir. Pull request #1729 by Jon Moss.
-* Deprecate passing options to Gem::GemRunner. Pull request #1730 by Jon
+  Gem::InstallerTestCase#util_gem_dir. Pull request [#1729](https://github.com/rubygems/rubygems/pull/1729) by Jon Moss.
+* Deprecate passing options to Gem::GemRunner. Pull request [#1730](https://github.com/rubygems/rubygems/pull/1730) by Jon
   Moss.
-* Add deprecation for Gem#datadir. Pull request #1732 by Jon Moss.
+* Add deprecation for Gem#datadir. Pull request [#1732](https://github.com/rubygems/rubygems/pull/1732) by Jon Moss.
 * Add deprecation warning for Gem::DependencyInstaller#gems_to_install.
-  Pull request #1731 by Jon Moss.
+  Pull request [#1731](https://github.com/rubygems/rubygems/pull/1731) by Jon Moss.
 
 ## Breaking changes:
 
 * Use `-rrubygems` instead of `-rubygems.rb`. Because ubygems.rb is
-  unavailable on Ruby 2.5. Pull request #2028 #2027 #2029
+  unavailable on Ruby 2.5. Pull request [#2028](https://github.com/rubygems/rubygems/pull/2028) #2027 #2029
   by SHIBATA Hiroshi.
 * Update Code of Conduct to Contributor Covenant v1.4.0. Pull request
-  #1796 by Matej.
+  [#1796](https://github.com/rubygems/rubygems/pull/1796) by Matej.
 
 ## Bug fixes:
 
-* Fix issue for MinGW / MSYS2 builds and testing. Pull request #1876 by
+* Fix issue for MinGW / MSYS2 builds and testing. Pull request [#1876](https://github.com/rubygems/rubygems/pull/1876) by
   MSP-Greg.
 * Fixed broken links and overzealous URL encoding in gem server. Pull
-  request #1809 by Nicole Orchard.
-* Fix a typo. Pull request #1722 by Koichi ITO.
-* Fix error message Gem::Security::Policy. Pull request #1724 by Nobuyoshi
+  request [#1809](https://github.com/rubygems/rubygems/pull/1809) by Nicole Orchard.
+* Fix a typo. Pull request [#1722](https://github.com/rubygems/rubygems/pull/1722) by Koichi ITO.
+* Fix error message Gem::Security::Policy. Pull request [#1724](https://github.com/rubygems/rubygems/pull/1724) by Nobuyoshi
   Nakada.
-* Fixing links markdown formatting in README. Pull request #1791 by Piotr
+* Fixing links markdown formatting in README. Pull request [#1791](https://github.com/rubygems/rubygems/pull/1791) by Piotr
   Kuczynski.
-* Fix failing Bundler 1.8.7 CI builds. Pull request #1820 by Samuel
+* Fix failing Bundler 1.8.7 CI builds. Pull request [#1820](https://github.com/rubygems/rubygems/pull/1820) by Samuel
   Giddins.
-* Fixed test broken on ruby-head . Pull request #1842 by SHIBATA Hiroshi.
-* Fix typos with misspell. Pull request #1846 by SHIBATA Hiroshi.
+* Fixed test broken on ruby-head . Pull request [#1842](https://github.com/rubygems/rubygems/pull/1842) by SHIBATA Hiroshi.
+* Fix typos with misspell. Pull request [#1846](https://github.com/rubygems/rubygems/pull/1846) by SHIBATA Hiroshi.
 * Fix gem open to open highest version number rather than lowest. Pull
-  request #1877 by Tim Pope.
+  request [#1877](https://github.com/rubygems/rubygems/pull/1877) by Tim Pope.
 * Fix test_self_find_files_with_gemfile to sort expected files. Pull
-  request #1878 by Kazuaki Matsuo.
-* Fix typos in CONTRIBUTING.rdoc. Pull request #1909 by Mark Sayson.
-* Fix some small documentation issues in installer. Pull request #1972 by
+  request [#1878](https://github.com/rubygems/rubygems/pull/1878) by Kazuaki Matsuo.
+* Fix typos in CONTRIBUTING.rdoc. Pull request [#1909](https://github.com/rubygems/rubygems/pull/1909) by Mark Sayson.
+* Fix some small documentation issues in installer. Pull request [#1972](https://github.com/rubygems/rubygems/pull/1972) by
   Colby Swandale.
-* Fix links in Policies document. Pull request #1964 by Alyssa Ross.
-* Fix NoMethodError on bundler/inline environment. Pull request #2042 by
+* Fix links in Policies document. Pull request [#1964](https://github.com/rubygems/rubygems/pull/1964) by Alyssa Ross.
+* Fix NoMethodError on bundler/inline environment. Pull request [#2042](https://github.com/rubygems/rubygems/pull/2042) by
   SHIBATA Hiroshi.
-* Correct comments for Gem::InstallerTestCase#setup. Pull request #1741 by
+* Correct comments for Gem::InstallerTestCase#setup. Pull request [#1741](https://github.com/rubygems/rubygems/pull/1741) by
   MSP-Greg.
 * Use File.expand_path for certification and key location. Pull request
-  #1987 by SHIBATA Hiroshi.
-* Rescue EROFS. Pull request #1417 by Nobuyoshi Nakada.
-* Fix spelling of 'vulnerability'. Pull request #2022 by Philip Arndt.
-* Fix metadata link key names. Pull request #1896 by Aditya Prakash.
-* Fix a typo in uninstall_command.rb. Pull request #1934 by Yasuhiro
+  [#1987](https://github.com/rubygems/rubygems/pull/1987) by SHIBATA Hiroshi.
+* Rescue EROFS. Pull request [#1417](https://github.com/rubygems/rubygems/pull/1417) by Nobuyoshi Nakada.
+* Fix spelling of 'vulnerability'. Pull request [#2022](https://github.com/rubygems/rubygems/pull/2022) by Philip Arndt.
+* Fix metadata link key names. Pull request [#1896](https://github.com/rubygems/rubygems/pull/1896) by Aditya Prakash.
+* Fix a typo in uninstall_command.rb. Pull request [#1934](https://github.com/rubygems/rubygems/pull/1934) by Yasuhiro
   Horimoto.
 * Gem::Requirement.create treat arguments as variable-length. Pull request
-  #1830 by Toru YAGI.
+  [#1830](https://github.com/rubygems/rubygems/pull/1830) by Toru YAGI.
 * Display an explanation when rake encounters an ontological problem. Pull
-  request #1982 by Wilson Bilkovich.
-* [Server] Handle gems with names ending in `-\d`. Pull request #1926 by
+  request [#1982](https://github.com/rubygems/rubygems/pull/1982) by Wilson Bilkovich.
+* [Server] Handle gems with names ending in `-\d`. Pull request [#1926](https://github.com/rubygems/rubygems/pull/1926) by
   Samuel Giddins.
 * [InstallerSet] Avoid reloading _all_ local gems multiple times during
-  dependency resolution. Pull request #1925 by Samuel Giddins.
-* Modify the return value of Gem::Version.correct?. Pull request #1916 by
+  dependency resolution. Pull request [#1925](https://github.com/rubygems/rubygems/pull/1925) by Samuel Giddins.
+* Modify the return value of Gem::Version.correct?. Pull request [#1916](https://github.com/rubygems/rubygems/pull/1916) by
   Tsukuru Tanimichi.
-* Validate metadata link keys. Pull request #1834 by Aditya Prakash.
-* Add changelog to metadata validation. Pull request #1885 by Aditya
+* Validate metadata link keys. Pull request [#1834](https://github.com/rubygems/rubygems/pull/1834) by Aditya Prakash.
+* Add changelog to metadata validation. Pull request [#1885](https://github.com/rubygems/rubygems/pull/1885) by Aditya
   Prakash.
-* Replace socket error text message. Pull request #1823 by Daniel Berger.
+* Replace socket error text message. Pull request [#1823](https://github.com/rubygems/rubygems/pull/1823) by Daniel Berger.
 * Raise error if the email is invalid when building cert. Pull request
-  #1779 by Luis Sagastume.
+  [#1779](https://github.com/rubygems/rubygems/pull/1779) by Luis Sagastume.
 * [StubSpecification] Don’t iterate through all loaded specs in #to_spec.
-  Pull request #1738 by Samuel Giddins.
+  Pull request [#1738](https://github.com/rubygems/rubygems/pull/1738) by Samuel Giddins.
 
 # 2.6.14 / 2017-10-09
 
@@ -2264,35 +2264,35 @@ Security fixes:
 ## Bug fixes:
 
 * Fix test_self_find_files_with_gemfile to sort expected files. Pull
-  request #1880 by Kazuaki Matsuo.
-* Fix issue for MinGW / MSYS2 builds and testing. Pull request #1879 by
+  request [#1880](https://github.com/rubygems/rubygems/pull/1880) by Kazuaki Matsuo.
+* Fix issue for MinGW / MSYS2 builds and testing. Pull request [#1879](https://github.com/rubygems/rubygems/pull/1879) by
   MSP-Greg.
 * Fix gem open to open highest version number rather than lowest. Pull
-  request #1877 by Tim Pope.
+  request [#1877](https://github.com/rubygems/rubygems/pull/1877) by Tim Pope.
 * Add a test for requiring a default spec as installed by the ruby
-  installer. Pull request #1899 by Samuel Giddins.
-* Fix broken --exact parameter to gem command. Pull request #1873 by Jason
+  installer. Pull request [#1899](https://github.com/rubygems/rubygems/pull/1899) by Samuel Giddins.
+* Fix broken --exact parameter to gem command. Pull request [#1873](https://github.com/rubygems/rubygems/pull/1873) by Jason
   Frey.
-* [Installer] Generate backwards-compatible binstubs. Pull request #1904
+* [Installer] Generate backwards-compatible binstubs. Pull request [#1904](https://github.com/rubygems/rubygems/pull/1904)
   by Samuel Giddins.
-* Fix pre-existing source recognition on add action. Pull request #1883 by
+* Fix pre-existing source recognition on add action. Pull request [#1883](https://github.com/rubygems/rubygems/pull/1883) by
   Jonathan Claudius.
-* Prevent negative IDs in output of #inspect. Pull request #1908 by Vít
+* Prevent negative IDs in output of #inspect. Pull request [#1908](https://github.com/rubygems/rubygems/pull/1908) by Vít
   Ondruch.
 * Allow Gem.finish_resolve to respect already-activated specs. Pull
-  request #1910 by Samuel Giddins.
+  request [#1910](https://github.com/rubygems/rubygems/pull/1910) by Samuel Giddins.
 
 # 2.6.11 / 2017-03-16
 
 ## Bug fixes:
 
-* Fixed broken tests on ruby-head. Pull request #1841 by
+* Fixed broken tests on ruby-head. Pull request [#1841](https://github.com/rubygems/rubygems/pull/1841) by
   SHIBATA Hiroshi.
-* Update vendored Molinillo to 0.5.7. Pull request #1859 by Samuel
+* Update vendored Molinillo to 0.5.7. Pull request [#1859](https://github.com/rubygems/rubygems/pull/1859) by Samuel
   Giddins.
-* Avoid activating Ruby 2.5 default gems when possible. Pull request #1843
+* Avoid activating Ruby 2.5 default gems when possible. Pull request [#1843](https://github.com/rubygems/rubygems/pull/1843)
   by Samuel Giddins.
-* Use improved resolver sorting algorithm. Pull request #1856 by
+* Use improved resolver sorting algorithm. Pull request [#1856](https://github.com/rubygems/rubygems/pull/1856) by
   Samuel Giddins.
 
 # 2.6.10 / 2017-01-23
@@ -2300,33 +2300,33 @@ Security fixes:
 ## Bug fixes:
 
 * Fix `require` calling the wrong `gem` method when it is overridden.
-  Pull request #1822 by Samuel Giddins.
+  Pull request [#1822](https://github.com/rubygems/rubygems/pull/1822) by Samuel Giddins.
 
 # 2.6.9 / 2017-01-20
 
 ## Bug fixes:
 
-* Allow initializing versions with empty strings. Pull request #1767 by
+* Allow initializing versions with empty strings. Pull request [#1767](https://github.com/rubygems/rubygems/pull/1767) by
   Luis Sagastume.
-* Fix TypeError on 2.4. Pull request #1788 by Nobuyoshi Nakada.
+* Fix TypeError on 2.4. Pull request [#1788](https://github.com/rubygems/rubygems/pull/1788) by Nobuyoshi Nakada.
 * Don't output mkmf.log message if compilation didn't fail. Pull request
-  #1808 by Jeremy Evans.
+  [#1808](https://github.com/rubygems/rubygems/pull/1808) by Jeremy Evans.
 * Fixed broken links and overzealous URL encoding in gem server. Pull
-  request #1809 by Nicole Orchard.
-* Update vendored Molinillo to 0.5.5. Pull request #1812 by Samuel
+  request [#1809](https://github.com/rubygems/rubygems/pull/1809) by Nicole Orchard.
+* Update vendored Molinillo to 0.5.5. Pull request [#1812](https://github.com/rubygems/rubygems/pull/1812) by Samuel
   Giddins.
-* RakeBuilder: avoid frozen string issue. Pull request #1819 by Olle
+* RakeBuilder: avoid frozen string issue. Pull request [#1819](https://github.com/rubygems/rubygems/pull/1819) by Olle
   Jonsson.
 
 # 2.6.8 / 2016-10-29
 
 ## Bug fixes:
 
-* Improve SSL verification failure message. Pull request #1751
+* Improve SSL verification failure message. Pull request [#1751](https://github.com/rubygems/rubygems/pull/1751)
   by Eric Hodel.
 * Ensure `to_spec` falls back on prerelease specs. Pull request
-  #1755 by André Arko.
-* Update vendored Molinillo to 0.5.3. Pull request #1763 by
+  [#1755](https://github.com/rubygems/rubygems/pull/1755) by André Arko.
+* Update vendored Molinillo to 0.5.3. Pull request [#1763](https://github.com/rubygems/rubygems/pull/1763) by
   Samuel Giddins.
 
 # 2.6.7 / 2016-09-26
@@ -2334,13 +2334,13 @@ Security fixes:
 ## Bug fixes:
 
 * Install native extensions in the correct location when using the
-  `--user-install` flag. Pull request #1683 by Noah Kantrowitz.
+  `--user-install` flag. Pull request [#1683](https://github.com/rubygems/rubygems/pull/1683) by Noah Kantrowitz.
 * When calling `Gem.sources`, load sources from `configuration`
-  if present, else use the default sources. Pull request #1699
+  if present, else use the default sources. Pull request [#1699](https://github.com/rubygems/rubygems/pull/1699)
   by Luis Sagastume.
 * Fail gracefully when attempting to redirect without a Location.
-  Pull request #1711 by Samuel Giddins.
-* Update vendored Molinillo to 0.5.1. Pull request #1714 by
+  Pull request [#1711](https://github.com/rubygems/rubygems/pull/1711) by Samuel Giddins.
+* Update vendored Molinillo to 0.5.1. Pull request [#1714](https://github.com/rubygems/rubygems/pull/1714) by
   Samuel Giddins.
 
 # 2.6.6 / 2016-06-22
@@ -2349,51 +2349,51 @@ Security fixes:
 
 * Sort installed versions to make sure we install the latest version when
   running `gem update --system`. As a one-time fix, run
-  `gem update --system=2.6.6`. Pull request #1601 by David Radcliffe.
+  `gem update --system=2.6.6`. Pull request [#1601](https://github.com/rubygems/rubygems/pull/1601) by David Radcliffe.
 
 # 2.6.5 / 2016-06-21
 
 ## Enhancements:
 
-* Support for unified Integer in Ruby 2.4. Pull request #1618
+* Support for unified Integer in Ruby 2.4. Pull request [#1618](https://github.com/rubygems/rubygems/pull/1618)
   by SHIBATA Hiroshi.
 * Update vendored Molinillo to 0.5.0 for performance improvements.
-  Pull request #1638 by Samuel Giddins.
+  Pull request [#1638](https://github.com/rubygems/rubygems/pull/1638) by Samuel Giddins.
 
 ## Bug fixes:
 
 * Raise an explicit error if Signer#sign is called with no certs. Pull
-  request #1605 by Daniel Berger.
+  request [#1605](https://github.com/rubygems/rubygems/pull/1605) by Daniel Berger.
 * Update `update_bundled_ca_certificates` utility script for directory
-  nesting. Pull request #1583 by James Wen.
+  nesting. Pull request [#1583](https://github.com/rubygems/rubygems/pull/1583) by James Wen.
 * Fix broken symlink support in tar writer (+ fix broken test). Pull
-  request #1578 by Cezary Baginski.
-* Remove extension directory before (re-)installing. Pull request #1576
+  request [#1578](https://github.com/rubygems/rubygems/pull/1578) by Cezary Baginski.
+* Remove extension directory before (re-)installing. Pull request [#1576](https://github.com/rubygems/rubygems/pull/1576)
   by Jeremy Hinegardner.
 * Regenerate test CA certificates with appropriate extensions. Pull
-  request #1611 by rhenium.
+  request [#1611](https://github.com/rubygems/rubygems/pull/1611) by rhenium.
 * Rubygems does not terminate on failed file lock when not superuser. Pull
-  request #1582 by Ellen Marie Dash.
-* Fix tar headers with a 101 character name. Pull request #1612 by Paweł
+  request [#1582](https://github.com/rubygems/rubygems/pull/1582) by Ellen Marie Dash.
+* Fix tar headers with a 101 character name. Pull request [#1612](https://github.com/rubygems/rubygems/pull/1612) by Paweł
   Tomulik.
 * Add Gem.platform_defaults to allow implementations to override defaults.
-  Pull request #1644 by Charles Oliver Nutter.
-* Run Bundler tests on TravisCI. Pull request #1650 by Samuel Giddins.
+  Pull request [#1644](https://github.com/rubygems/rubygems/pull/1644) by Charles Oliver Nutter.
+* Run Bundler tests on TravisCI. Pull request [#1650](https://github.com/rubygems/rubygems/pull/1650) by Samuel Giddins.
 
 # 2.6.4 / 2016-04-26
 
 ## Enhancements:
 
-* Use Gem::Util::NULL_DEVICE instead of hard coded strings. Pull request #1588
+* Use Gem::Util::NULL_DEVICE instead of hard coded strings. Pull request [#1588](https://github.com/rubygems/rubygems/pull/1588)
   by Chris Charabaruk.
-* Use File.symlink on MS Windows if supported. Pull request #1418
+* Use File.symlink on MS Windows if supported. Pull request [#1418](https://github.com/rubygems/rubygems/pull/1418)
   by Nobuyoshi Nakada.
 
 ## Bug fixes:
 
 * Redact uri password from error output when gem fetch fails. Pull request
-  #1565 by Brian Fletcher.
-* Suppress warnings. Pull request #1594 by Nobuyoshi Nakada.
+  [#1565](https://github.com/rubygems/rubygems/pull/1565) by Brian Fletcher.
+* Suppress warnings. Pull request [#1594](https://github.com/rubygems/rubygems/pull/1594) by Nobuyoshi Nakada.
 * Escape user-supplied content served on web pages by `gem server` to avoid
   potential XSS vulnerabilities. Samuel Giddins.
 
@@ -2401,136 +2401,136 @@ Security fixes:
 
 ## Enhancements:
 
-* Lazily calculate Gem::LoadError exception messages. Pull request #1550
+* Lazily calculate Gem::LoadError exception messages. Pull request [#1550](https://github.com/rubygems/rubygems/pull/1550)
   by Aaron Patterson.
-* New fastly cert. Pull request #1548 by David Radcliffe.
-* Organize and cleanup SSL certs. Pull request #1555 by James Wen.
+* New fastly cert. Pull request [#1548](https://github.com/rubygems/rubygems/pull/1548) by David Radcliffe.
+* Organize and cleanup SSL certs. Pull request [#1555](https://github.com/rubygems/rubygems/pull/1555) by James Wen.
 * [RubyGems] Make deprecation message for paths= more helpful. Pull
-  request #1562 by Samuel Giddins.
-* Show default gems when using "gem list". Pull request #1570 by Luis
+  request [#1562](https://github.com/rubygems/rubygems/pull/1562) by Samuel Giddins.
+* Show default gems when using "gem list". Pull request [#1570](https://github.com/rubygems/rubygems/pull/1570) by Luis
   Sagastume.
 
 ## Bug fixes:
 
 * Stub ordering should be consistent regardless of how cache is populated.
-  Pull request #1552 by Aaron Patterson.
+  Pull request [#1552](https://github.com/rubygems/rubygems/pull/1552) by Aaron Patterson.
 * Handle cases when the @@stubs variable contains non-stubs. Pull request
-  #1558 by Per Lundberg.
-* Fix test on Windows for inconsistent temp path. Pull request #1554 by
+  [#1558](https://github.com/rubygems/rubygems/pull/1558) by Per Lundberg.
+* Fix test on Windows for inconsistent temp path. Pull request [#1554](https://github.com/rubygems/rubygems/pull/1554) by
   Hiroshi Shirosaki.
-* Fix `Gem.find_spec_for_exe` picks oldest gem. Pull request #1566 by
+* Fix `Gem.find_spec_for_exe` picks oldest gem. Pull request [#1566](https://github.com/rubygems/rubygems/pull/1566) by
   Shinichi Maeshima.
 * [Owner] Fallback to email and userid when owner email is missing. Pull
-  request #1569 by Samuel Giddins.
-* [Installer] Handle nil existing executable. Pull request #1561 by Samuel
+  request [#1569](https://github.com/rubygems/rubygems/pull/1569) by Samuel Giddins.
+* [Installer] Handle nil existing executable. Pull request [#1561](https://github.com/rubygems/rubygems/pull/1561) by Samuel
   Giddins.
-* Allow two digit version numbers in the tests. Pull request #1575 by unak.
+* Allow two digit version numbers in the tests. Pull request [#1575](https://github.com/rubygems/rubygems/pull/1575) by unak.
 
 # 2.6.2 / 2016-03-12
 
 ## Bug fixes:
 
-* Fix wrong version of gem activation for bin stub. Pull request #1527 by
+* Fix wrong version of gem activation for bin stub. Pull request [#1527](https://github.com/rubygems/rubygems/pull/1527) by
   Aaron Patterson.
-* Speed up gem activation failures. Pull request #1539 by Aaron Patterson.
-* Fix platform sorting in the resolver. Pull request #1542 by Samuel E.
+* Speed up gem activation failures. Pull request [#1539](https://github.com/rubygems/rubygems/pull/1539) by Aaron Patterson.
+* Fix platform sorting in the resolver. Pull request [#1542](https://github.com/rubygems/rubygems/pull/1542) by Samuel E.
   Giddins.
 * Ensure we unlock the monitor even if try_activate throws. Pull request
-  #1538 by Charles Oliver Nutter.
+  [#1538](https://github.com/rubygems/rubygems/pull/1538) by Charles Oliver Nutter.
 
 
 # 2.6.1 / 2016-02-28
 
 ## Bug fixes:
 
-* Ensure `default_path` and `home` are set for paths. Pull request #1513
+* Ensure `default_path` and `home` are set for paths. Pull request [#1513](https://github.com/rubygems/rubygems/pull/1513)
   by Aaron Patterson.
 * Restore but deprecate support for Array values on `Gem.paths=`. Pull
-  request #1514 by Aaron Patterson.
+  request [#1514](https://github.com/rubygems/rubygems/pull/1514) by Aaron Patterson.
 * Fix invalid gem file preventing gem install from working. Pull request
-  #1499 by Luis Sagastume.
+  [#1499](https://github.com/rubygems/rubygems/pull/1499) by Luis Sagastume.
 
 # 2.6.0 / 2016-02-26
 
 ## Enhancements:
 
 * RubyGems now defaults the `gem push` to the gem's "allowed_push_host"
-  metadata setting.  Pull request #1486 by Josh Lane.
-* Update bundled Molinillo to 0.4.3. Pull request #1493 by Samuel E. Giddins.
-* Add version option to gem open command. Pull request #1483 by Hrvoje
+  metadata setting.  Pull request [#1486](https://github.com/rubygems/rubygems/pull/1486) by Josh Lane.
+* Update bundled Molinillo to 0.4.3. Pull request [#1493](https://github.com/rubygems/rubygems/pull/1493) by Samuel E. Giddins.
+* Add version option to gem open command. Pull request [#1483](https://github.com/rubygems/rubygems/pull/1483) by Hrvoje
   Šimić.
-* Feature/add silent flag. Pull request #1455 by Luis Sagastume.
-* Allow specifying gem requirements via env variables. Pull request #1472
+* Feature/add silent flag. Pull request [#1455](https://github.com/rubygems/rubygems/pull/1455) by Luis Sagastume.
+* Allow specifying gem requirements via env variables. Pull request [#1472](https://github.com/rubygems/rubygems/pull/1472)
   by Samuel E. Giddins.
 
 ## Bug fixes:
 
 * RubyGems now stores `gem push` credentials under the host you signed-in for.
-  Pull request #1485 by Josh Lane.
-* Move `coding` location to first line. Pull request #1471 by SHIBATA
+  Pull request [#1485](https://github.com/rubygems/rubygems/pull/1485) by Josh Lane.
+* Move `coding` location to first line. Pull request [#1471](https://github.com/rubygems/rubygems/pull/1471) by SHIBATA
   Hiroshi.
-* [PathSupport] Handle a regexp path separator. Pull request #1469 by
+* [PathSupport] Handle a regexp path separator. Pull request [#1469](https://github.com/rubygems/rubygems/pull/1469) by
   Samuel E. Giddins.
-* Clean up the PathSupport object. Pull request #1094 by Aaron Patterson.
-* Join with File::PATH_SEPARATOR in Gem.use_paths. Pull request #1476 by
+* Clean up the PathSupport object. Pull request [#1094](https://github.com/rubygems/rubygems/pull/1094) by Aaron Patterson.
+* Join with File::PATH_SEPARATOR in Gem.use_paths. Pull request [#1476](https://github.com/rubygems/rubygems/pull/1476) by
   Samuel E. Giddins.
 * Handle when the gem home and gem path aren't set in the config file. Pull
-  request #1478 by Samuel E. Giddins.
-* Terminate TimeoutHandler. Pull request #1479 by Nobuyoshi Nakada.
-* Remove redundant cache. Pull request #1482 by Eileen M. Uchitelle.
-* Freeze `Gem::Version@segments` instance variable. Pull request #1487 by
+  request [#1478](https://github.com/rubygems/rubygems/pull/1478) by Samuel E. Giddins.
+* Terminate TimeoutHandler. Pull request [#1479](https://github.com/rubygems/rubygems/pull/1479) by Nobuyoshi Nakada.
+* Remove redundant cache. Pull request [#1482](https://github.com/rubygems/rubygems/pull/1482) by Eileen M. Uchitelle.
+* Freeze `Gem::Version@segments` instance variable. Pull request [#1487](https://github.com/rubygems/rubygems/pull/1487) by
   Ben Dean.
 * Gem cleanup is trying to uninstall gems outside GEM_HOME and reporting
-  an error after it tries. Pull request #1353 by Luis Sagastume.
-* Avoid duplicated sources. Pull request #1489 by Luis Sagastume.
-* Better description for quiet flag. Pull request #1491 by Luis Sagastume.
-* Raise error if find_by_name returns with nil. Pull request #1494 by
+  an error after it tries. Pull request [#1353](https://github.com/rubygems/rubygems/pull/1353) by Luis Sagastume.
+* Avoid duplicated sources. Pull request [#1489](https://github.com/rubygems/rubygems/pull/1489) by Luis Sagastume.
+* Better description for quiet flag. Pull request [#1491](https://github.com/rubygems/rubygems/pull/1491) by Luis Sagastume.
+* Raise error if find_by_name returns with nil. Pull request [#1494](https://github.com/rubygems/rubygems/pull/1494) by
   Zoltán Hegedüs.
-* Find_files only from loaded_gems when using gemdeps. Pull request #1277
+* Find_files only from loaded_gems when using gemdeps. Pull request [#1277](https://github.com/rubygems/rubygems/pull/1277)
   by Michal Papis.
 
 # 2.5.2 / 2016-01-31
 
 ## Bug fixes:
 
-* Fix memoization of Gem::Version#prerelease? Pull request #1125 by Matijs van
+* Fix memoization of Gem::Version#prerelease? Pull request [#1125](https://github.com/rubygems/rubygems/pull/1125) by Matijs van
   Zuijlen.
 * Handle trailing colons in GEM_PATH, by Damien Robert.
 * Improve the Gemfile `gemspec` method, fixing #1204 and #1033. Pull request
-  #1276 by Michael Papis.
-* Warn only once when a gemspec license is invalid. Pull request #1414 by Samuel
+  [#1276](https://github.com/rubygems/rubygems/pull/1276) by Michael Papis.
+* Warn only once when a gemspec license is invalid. Pull request [#1414](https://github.com/rubygems/rubygems/pull/1414) by Samuel
   E. Giddins.
 * Check for exact constants before using them, fixing Ruby bug #11940. Pull
-  request #1438 by Nobuyoshi Nakada.
-* Fix building C extensions on Ruby 1.9.x on Windows. Pull request #1453 by Marie
+  request [#1438](https://github.com/rubygems/rubygems/pull/1438) by Nobuyoshi Nakada.
+* Fix building C extensions on Ruby 1.9.x on Windows. Pull request [#1453](https://github.com/rubygems/rubygems/pull/1453) by Marie
   Markwell.
-* Handle symlinks containing ".." correctly. Pull request #1457 by Samuel E.
+* Handle symlinks containing ".." correctly. Pull request [#1457](https://github.com/rubygems/rubygems/pull/1457) by Samuel E.
   Giddins.
 
 ## Enhancements:
 
-* Add `--no-rc` flag, which skips loading `.gemrc`. Pull request #1329 by Luis
+* Add `--no-rc` flag, which skips loading `.gemrc`. Pull request [#1329](https://github.com/rubygems/rubygems/pull/1329) by Luis
   Sagastume.
 * Allow basic auth to be excluded from `allowed_push_host`. By Josh Lane.
 * Add `gem list --exact`, which finds gems by string match instead of regex. Pull
-  request #1344 by Luis Sagastume.
-* Suggest alternatives when gem license is unknown. Pull request #1443 by Samuel
+  request [#1344](https://github.com/rubygems/rubygems/pull/1344) by Luis Sagastume.
+* Suggest alternatives when gem license is unknown. Pull request [#1443](https://github.com/rubygems/rubygems/pull/1443) by Samuel
   E. Giddins.
 * Print a useful error if a binstub expects a newer version of a gem than is
-  installed. Pull request #1407 by Samuel E. Giddins.
+  installed. Pull request [#1407](https://github.com/rubygems/rubygems/pull/1407) by Samuel E. Giddins.
 * Allow the (supported) s3:// scheme to be used with `--source`. Pull request
-  #1416 by Dave Adams.
-* Add `--[no-]post-install-message` to `install` and `update`. Pull request #1162
+  [#1416](https://github.com/rubygems/rubygems/pull/1416) by Dave Adams.
+* Add `--[no-]post-install-message` to `install` and `update`. Pull request [#1162](https://github.com/rubygems/rubygems/pull/1162)
   by Josef Šimánek.
 * Add `--host` option to `yank`, providing symmetry with `pull`. Pull request
-  #1361 by Mike Virata-Stone.
-* Update bundled Molinillo to 0.4.1. Pull request #1452 by Samuel E. Giddins.
-* Allow calling `build` without '.gemspec'. Pull request #1454 by Stephen
+  [#1361](https://github.com/rubygems/rubygems/pull/1361) by Mike Virata-Stone.
+* Update bundled Molinillo to 0.4.1. Pull request [#1452](https://github.com/rubygems/rubygems/pull/1452) by Samuel E. Giddins.
+* Allow calling `build` without '.gemspec'. Pull request [#1454](https://github.com/rubygems/rubygems/pull/1454) by Stephen
   Blackstone.
-* Add support for `source` option on gems in Gemfile. Pull request #1355 by
+* Add support for `source` option on gems in Gemfile. Pull request [#1355](https://github.com/rubygems/rubygems/pull/1355) by
   Michael Papis.
 * Function correctly when string literals are frozen on Ruby 2.3. Pull request
-  #1408 by Samuel E. Giddins.
+  [#1408](https://github.com/rubygems/rubygems/pull/1408) by Samuel E. Giddins.
 
 # 2.5.1 / 2015-12-10
 
@@ -2538,30 +2538,30 @@ Security fixes:
 
 * Ensure platform sorting only uses strings. Affected binary installs on Windows.
   Issue #1369 reported by Ryan Atball (among others).
-  Pull request #1375 by Samuel E. Giddins.
+  Pull request [#1375](https://github.com/rubygems/rubygems/pull/1375) by Samuel E. Giddins.
 * Revert PR #1332. Unable to reproduce, and nil should be impossible.
 * Gem::Specification#to_fullpath now returns .rb extensions when such a file
-  exists.  Pull request #1114 by y-yagi.
+  exists.  Pull request [#1114](https://github.com/rubygems/rubygems/pull/1114) by y-yagi.
 * RubyGems now handles Net::HTTPFatalError instead of crashing.  Pull
-  request #1314 by Samuel E. Giddins.
-* Updated bundled Molinillo to 0.4.0.  Pull request #1322, #1396 by Samuel E.
+  request [#1314](https://github.com/rubygems/rubygems/pull/1314) by Samuel E. Giddins.
+* Updated bundled Molinillo to 0.4.0.  Pull request [#1322](https://github.com/rubygems/rubygems/pull/1322), #1396 by Samuel E.
   Giddins.
 * Improved performance of spec loading by reducing likelihood of loading the
-  complete specification.  Pull request #1373 by Aaron Patterson.
-* Improved caching of requirable files  Pull request #1377 by Aaron Patterson.
-* Fixed activation of gems with development dependencies.  Pull request #1388
+  complete specification.  Pull request [#1373](https://github.com/rubygems/rubygems/pull/1373) by Aaron Patterson.
+* Improved caching of requirable files  Pull request [#1377](https://github.com/rubygems/rubygems/pull/1377) by Aaron Patterson.
+* Fixed activation of gems with development dependencies.  Pull request [#1388](https://github.com/rubygems/rubygems/pull/1388)
   by Samuel E. Giddins.
 * RubyGems now uses the same Molinillo vendoring strategy as Bundler.  Pull
-  request #1397 by Samuel E. Giddins.
-* Fixed documentation of Gem::Requirement.parse.  Pull request #1398 by
+  request [#1397](https://github.com/rubygems/rubygems/pull/1397) by Samuel E. Giddins.
+* Fixed documentation of Gem::Requirement.parse.  Pull request [#1398](https://github.com/rubygems/rubygems/pull/1398) by
   Juanito Fatas.
 * RubyGems no longer warns when a prerelease gem has prerelease dependencies.
-  Pull request #1399 by Samuel E. Giddins.
-* Fixed Gem::Version documentation example.  Pull request #1401 by Guilherme
+  Pull request [#1399](https://github.com/rubygems/rubygems/pull/1399) by Samuel E. Giddins.
+* Fixed Gem::Version documentation example.  Pull request [#1401](https://github.com/rubygems/rubygems/pull/1401) by Guilherme
   Goettems Schneider.
-* Updated documentation links to https://.  Pull request #1404 by Suriyaa
+* Updated documentation links to https://.  Pull request [#1404](https://github.com/rubygems/rubygems/pull/1404) by Suriyaa
   Kudo.
-* Fixed double word typo.  Pull request #1411 by Jake Worth.
+* Fixed double word typo.  Pull request [#1411](https://github.com/rubygems/rubygems/pull/1411) by Jake Worth.
 
 # 2.5.0 / 2015-11-03
 
@@ -2572,24 +2572,24 @@ Security fixes:
   Gem::Specification#license attribute to try to standardize (though not
   enforce) licenses set by gem authors.
 
-  Pull request #1249 by Kyle Mitchell.
+  Pull request [#1249](https://github.com/rubygems/rubygems/pull/1249) by Kyle Mitchell.
 
 * Use Molinillo as the resolver library.  This is the same resolver as used by
-  Bundler.  Pull request #1189 by Samuel E. Giddins.
-* Add `--skip=gem_name` to Pristine command.  Pull request #1018 by windwiny.
+  Bundler.  Pull request [#1189](https://github.com/rubygems/rubygems/pull/1189) by Samuel E. Giddins.
+* Add `--skip=gem_name` to Pristine command.  Pull request [#1018](https://github.com/rubygems/rubygems/pull/1018) by windwiny.
 * The parsed gem dependencies file is now available via Gem.gemdeps following
-  Gem.use_gemdeps.  Pull request #1224 by Hsing-Hui Hsu, issue #1213 by
+  Gem.use_gemdeps.  Pull request [#1224](https://github.com/rubygems/rubygems/pull/1224) by Hsing-Hui Hsu, issue #1213 by
   Michal Papis.
 * Moved description attribute to recommended for Gem::Specification.
-  Pull request #1046 by Michal Papis
+  Pull request [#1046](https://github.com/rubygems/rubygems/pull/1046) by Michal Papis
 * Moved `Gem::Indexer#abbreviate` and `#sanitize` to `Gem::Specification`.
-  Pull request #1145 by Arthur Nogueira Neves
+  Pull request [#1145](https://github.com/rubygems/rubygems/pull/1145) by Arthur Nogueira Neves
 * Cache Gem::Version segments for `#bump` and `#release`.
-  Pull request #1131 by Matijs van Zuijlen
+  Pull request [#1131](https://github.com/rubygems/rubygems/pull/1131) by Matijs van Zuijlen
 * Fix edge case in `levenshtein_distance` for comparing longer strings.
-  Pull request #1173 by Richard Schneeman
+  Pull request [#1173](https://github.com/rubygems/rubygems/pull/1173) by Richard Schneeman
 * Remove duplication from List#to_a, improving from O(n^2) to O(n) time.
-  Pull request #1200 by Marc Siegel.
+  Pull request [#1200](https://github.com/rubygems/rubygems/pull/1200) by Marc Siegel.
 * Gem::Specification.add_specs is deprecated and will be removed from version
   3.0 with no replacement.  To add specs, install the gem, then reset the
   cache.
@@ -2601,95 +2601,95 @@ Security fixes:
   cache by calling Gem::Specification.reset.
 * Call Array#compact before calling Array#uniq for minor speed improvement in
   the Gem::Specification#files method.
-  Pull request #1253 by Marat Amerov.
+  Pull request [#1253](https://github.com/rubygems/rubygems/pull/1253) by Marat Amerov.
 * Use stringio instead of custom String classes.
-  Pull request #1250 by Petr Skocik.
+  Pull request [#1250](https://github.com/rubygems/rubygems/pull/1250) by Petr Skocik.
 * Use URI#host instead of URI#hostname to retain backwards compatibility with
   Ruby 1.9.2 and earlier in util library.
-  Pull request #1288 by Joe Rafaniello.
+  Pull request [#1288](https://github.com/rubygems/rubygems/pull/1288) by Joe Rafaniello.
 * Documentation update for gem sources.
-  Pull request #1324 by Ilya Vassilevsky.
+  Pull request [#1324](https://github.com/rubygems/rubygems/pull/1324) by Ilya Vassilevsky.
 * Documentation update for required_ruby_version.
-  Pull request #1321 by Matt Patterson.
+  Pull request [#1321](https://github.com/rubygems/rubygems/pull/1321) by Matt Patterson.
 * Documentation update for gem update.
-  Pull request #1306 by Tim Blair.
+  Pull request [#1306](https://github.com/rubygems/rubygems/pull/1306) by Tim Blair.
 * Emit a warning on SRV resolve failure.
-  Pull request #1023 by Ivan Kuchin.
+  Pull request [#1023](https://github.com/rubygems/rubygems/pull/1023) by Ivan Kuchin.
 * Allow duplicate dependencies between runtime and development.
-  Pull request #1032 by Murray Steele.
+  Pull request [#1032](https://github.com/rubygems/rubygems/pull/1032) by Murray Steele.
 * The gem env command now shows the user installation directory.
-  Pull request #1343 by Luis Sagastume.
+  Pull request [#1343](https://github.com/rubygems/rubygems/pull/1343) by Luis Sagastume.
 * The Gem::Platform#=== method now treats a nil cpu arch the same as 'universal'.
-  Pull request #1356 by Daniel Berger.
+  Pull request [#1356](https://github.com/rubygems/rubygems/pull/1356) by Daniel Berger.
 * Improved memory performance in Gem::Specification.traverse.  Pull request
-  #1188 by Aaron Patterson.
-* RubyGems packages now support symlinks.  Pull request #1209 by Samuel E.
+  [#1188](https://github.com/rubygems/rubygems/pull/1188) by Aaron Patterson.
+* RubyGems packages now support symlinks.  Pull request [#1209](https://github.com/rubygems/rubygems/pull/1209) by Samuel E.
   Giddins.
 * RubyGems no longer outputs mkmf.log if it does not exist.  Pull request
-  #1222 by Andrew Hooker.
-* Added Bitrig platform.  Pull request #1233 by John C. Vernaleo.
+  [#1222](https://github.com/rubygems/rubygems/pull/1222) by Andrew Hooker.
+* Added Bitrig platform.  Pull request [#1233](https://github.com/rubygems/rubygems/pull/1233) by John C. Vernaleo.
 * Improved error message for first-time RubyGems developers.  Pull request
-  #1241 by André Arko
+  [#1241](https://github.com/rubygems/rubygems/pull/1241) by André Arko
 * Improved performance of Gem::Specification#load with cached specs.  Pull
-  request #1297 by Samuel E. Giddins.
-* Gem::RemoteFetcher allows users to set HTTP headers.  Pull request #1363 by
+  request [#1297](https://github.com/rubygems/rubygems/pull/1297) by Samuel E. Giddins.
+* Gem::RemoteFetcher allows users to set HTTP headers.  Pull request [#1363](https://github.com/rubygems/rubygems/pull/1363) by
   Agis Anastasopoulos.
 
 ## Bug fixes:
 
 * Fixed Rake homepage url in example for Gem::Specification#homepage.
-  Pull request #1171 by Arthur Nogueira Neves
+  Pull request [#1171](https://github.com/rubygems/rubygems/pull/1171) by Arthur Nogueira Neves
 * Don't crash if partially uninstalled gem can't be found.
-  Pull request #1283 by Cezary Baginski.
+  Pull request [#1283](https://github.com/rubygems/rubygems/pull/1283) by Cezary Baginski.
 * Test warning cleanup.
-  Pull request #1298 by Samuel E. Giddins.
+  Pull request [#1298](https://github.com/rubygems/rubygems/pull/1298) by Samuel E. Giddins.
 * Documentation fix for GemDependencyAPI.
-  Pull request #1308 by Michael Papis.
+  Pull request [#1308](https://github.com/rubygems/rubygems/pull/1308) by Michael Papis.
 * Fetcher now ignores ENOLCK errors in single threaded environments. This
   handles an issue with gem installation on NFS as best we can. Addresses
   issue #1176 by Ryan Moore.
-  Pull request #1327 by Daniel Berger.
+  Pull request [#1327](https://github.com/rubygems/rubygems/pull/1327) by Daniel Berger.
 * Fix some path quoting issues in the test suite.
-  Pull request #1328 by Gavin Miller.
+  Pull request [#1328](https://github.com/rubygems/rubygems/pull/1328) by Gavin Miller.
 * Fix NoMethodError in running ruby processes when gems are uninstalled.
-  Pull request #1332 by Peter Drake.
+  Pull request [#1332](https://github.com/rubygems/rubygems/pull/1332) by Peter Drake.
 * Fixed a potential NoMethodError for gem cleanup.
-  Pull request #1333 by Peter Drake.
+  Pull request [#1333](https://github.com/rubygems/rubygems/pull/1333) by Peter Drake.
 * Fixed gem help bug.
-  Issue #1352 reported by bogem, pull request #1357 by Luis Sagastume.
-* Remove temporary directories after tests finish.  Pull request #1181 by
+  Issue #1352 reported by bogem, pull request [#1357](https://github.com/rubygems/rubygems/pull/1357) by Luis Sagastume.
+* Remove temporary directories after tests finish.  Pull request [#1181](https://github.com/rubygems/rubygems/pull/1181) by
   Nobuyoshi Nokada.
-* Update links in RubyGems documentation.  Pull request #1185 by Darío Hereñú.
-* Prerelease gem executables can now be run.  Pull request #1186 by Samuel E.
+* Update links in RubyGems documentation.  Pull request [#1185](https://github.com/rubygems/rubygems/pull/1185) by Darío Hereñú.
+* Prerelease gem executables can now be run.  Pull request [#1186](https://github.com/rubygems/rubygems/pull/1186) by Samuel E.
   Giddins.
-* Updated RubyGems travis-ci ruby versions.  Pull request #1187 by Samuel E.
+* Updated RubyGems travis-ci ruby versions.  Pull request [#1187](https://github.com/rubygems/rubygems/pull/1187) by Samuel E.
   Giddins.
-* Fixed release date of RubyGems 2.4.6.  Pull request #1190 by Frieder
+* Fixed release date of RubyGems 2.4.6.  Pull request [#1190](https://github.com/rubygems/rubygems/pull/1190) by Frieder
   Bluemle.
-* Fixed bugs in gem activation.  Pull request #1202 by Miklós Fazekas.
-* Fixed documentation for `gem list`.  Pull request #1228 by Godfrey Chan.
-* Fixed #1200 history entry.  Pull request #1234 by Marc Siegel.
+* Fixed bugs in gem activation.  Pull request [#1202](https://github.com/rubygems/rubygems/pull/1202) by Miklós Fazekas.
+* Fixed documentation for `gem list`.  Pull request [#1228](https://github.com/rubygems/rubygems/pull/1228) by Godfrey Chan.
+* Fixed #1200 history entry.  Pull request [#1234](https://github.com/rubygems/rubygems/pull/1234) by Marc Siegel.
 * Fixed synchronization issue when resetting the Gem::Specification gem list.
-  Pull request #1239 by Samuel E. Giddins.
-* Fixed running tests in parallel.  Pull request #1257 by SHIBATA Hiroshi.
+  Pull request [#1239](https://github.com/rubygems/rubygems/pull/1239) by Samuel E. Giddins.
+* Fixed running tests in parallel.  Pull request [#1257](https://github.com/rubygems/rubygems/pull/1257) by SHIBATA Hiroshi.
 * Fixed running tests with `--program-prefix` or `--program-suffix` for ruby.
-  Pull request #1258 by Shane Gibbs.
-* Fixed Gem::Specification#to_yaml.  Pull request #1262 by Hiroaki Izu.
+  Pull request [#1258](https://github.com/rubygems/rubygems/pull/1258) by Shane Gibbs.
+* Fixed Gem::Specification#to_yaml.  Pull request [#1262](https://github.com/rubygems/rubygems/pull/1262) by Hiroaki Izu.
 * Fixed taintedness of Gem::Specification#raw_require_paths.  Pull request
-  #1268 by Sam Ruby.
-* Fixed sorting of platforms when installing gems.  Pull request #1271 by
+  [#1268](https://github.com/rubygems/rubygems/pull/1268) by Sam Ruby.
+* Fixed sorting of platforms when installing gems.  Pull request [#1271](https://github.com/rubygems/rubygems/pull/1271) by
   nonsequitur.
 * Use `--no-document` over deprecated documentation options when installing
-  dependencies on travis.  Pull request #1272 by takiy33.
-* Improved support for IPv6 addresses in URIs.  Pull request #1275 by Joe
+  dependencies on travis.  Pull request [#1272](https://github.com/rubygems/rubygems/pull/1272) by takiy33.
+* Improved support for IPv6 addresses in URIs.  Pull request [#1275](https://github.com/rubygems/rubygems/pull/1275) by Joe
   Rafaniello.
 * Spec validation no longer crashes if a file does not exist.  Pull request
-  #1278 by Samuel E. Giddins.
-* Gems can now be installed within `rescue`.  Pull request #1282 by Samuel E.
+  [#1278](https://github.com/rubygems/rubygems/pull/1278) by Samuel E. Giddins.
+* Gems can now be installed within `rescue`.  Pull request [#1282](https://github.com/rubygems/rubygems/pull/1282) by Samuel E.
   Giddins.
 * Increased Diffie-Hellman key size for tests for modern OpenSSL.  Pull
-  request #1290 by Vít Ondruch.
-* RubyGems handles invalid config files better.  Pull request #1367 by Agis
+  request [#1290](https://github.com/rubygems/rubygems/pull/1290) by Vít Ondruch.
+* RubyGems handles invalid config files better.  Pull request [#1367](https://github.com/rubygems/rubygems/pull/1367) by Agis
   Anastasopoulos.
 
 # 2.4.8 / 2015-06-08
@@ -2713,33 +2713,33 @@ Security fixes:
   Issue #1141 by Jakub Jirutka.
 * Moved extension directory after require_paths to fix missing constant bugs
   in some gems with C extensions.  Issue #784 by André Arko, pull request
-  #1137 by Barry Allard.
+  [#1137](https://github.com/rubygems/rubygems/pull/1137) by Barry Allard.
 * Use Gem::Dependency#requirement when adding a dependency to an existing
-  dependency instance.  Pull request #1101 by Josh Cheek.
+  dependency instance.  Pull request [#1101](https://github.com/rubygems/rubygems/pull/1101) by Josh Cheek.
 * Fixed warning of shadowed local variable in Gem::Specification.  Pull request
-  #1109 by Rohit Arondekar
+  [#1109](https://github.com/rubygems/rubygems/pull/1109) by Rohit Arondekar
 * Gem::Requirement should always sort requirements before coercion to Hash.
-  Pull request #1139 by Eito Katagiri.
+  Pull request [#1139](https://github.com/rubygems/rubygems/pull/1139) by Eito Katagiri.
 * The `gem open` command should change the current working directory before
-  opening the editor.  Pull request #1142 by Alex Wood.
+  opening the editor.  Pull request [#1142](https://github.com/rubygems/rubygems/pull/1142) by Alex Wood.
 * Ensure quotes are stripped from the Windows launcher script used to install
-  gems.  Pull request #1115 by Youngjun Song.
+  gems.  Pull request [#1115](https://github.com/rubygems/rubygems/pull/1115) by Youngjun Song.
 * Fixed errors when writing to NFS to to 0444 files.  Issue #1161 by Emmanuel
   Hadoux.
-* Removed dead code in Gem::StreamUI.  Pull request #1117 by mediaslave24.
-* Fixed typos.  Pull request #1096 by hakeda.
-* Relaxed CMake dependency for RHEL 6 and CentOS 6.  Pull request #1124 by Vít
+* Removed dead code in Gem::StreamUI.  Pull request [#1117](https://github.com/rubygems/rubygems/pull/1117) by mediaslave24.
+* Fixed typos.  Pull request [#1096](https://github.com/rubygems/rubygems/pull/1096) by hakeda.
+* Relaxed CMake dependency for RHEL 6 and CentOS 6.  Pull request [#1124](https://github.com/rubygems/rubygems/pull/1124) by Vít
   Ondruch.
-* Relaxed Psych dependency.  Pull request #1128 by Vít Ondruch.
+* Relaxed Psych dependency.  Pull request [#1128](https://github.com/rubygems/rubygems/pull/1128) by Vít Ondruch.
 
 # 2.4.5 / 2014-12-03
 
 ## Bug fixes:
 
 * Improved speed of requiring gems.  (Around 25% for a 60 gem test).  Pull
-  request #1060 by unak.
+  request [#1060](https://github.com/rubygems/rubygems/pull/1060) by unak.
 * RubyGems no longer attempts to look up gems remotely with the --local flag.
-  Pull request #1084 by Jeremy Evans.
+  Pull request [#1084](https://github.com/rubygems/rubygems/pull/1084) by Jeremy Evans.
 * Executable stubs use the correct gem version when RUBYGEMS_GEMDEPS is
   active.  Issue #1072 by Michael Kaiser-Nyman.
 * Fixed handling of pinned gems in lockfiles with versions.  Issue #1078 by
@@ -2748,30 +2748,30 @@ Security fixes:
 * Fixed handling of platforms retrieved from the dependencies API.  Issue
   #1058 and patch suggestion by tux-mind.
 * RubyGems now suggests a copy-pasteable `gem pristine` command when
-  extensions are missing.  Pull request #1057 by Shannon Skipper.
-* Improved errors for long file names when packaging.  Pull request #1016 by
+  extensions are missing.  Pull request [#1057](https://github.com/rubygems/rubygems/pull/1057) by Shannon Skipper.
+* Improved errors for long file names when packaging.  Pull request [#1016](https://github.com/rubygems/rubygems/pull/1016) by
   Piotrek Bator.
-* `gem pristine` now skips gems cannot be found remotely.  Pull request #1064
+* `gem pristine` now skips gems cannot be found remotely.  Pull request [#1064](https://github.com/rubygems/rubygems/pull/1064)
   by Tuomas Kareinen.
-* `gem pristine` now caches gems to the proper directory.  Pull request #1064
+* `gem pristine` now caches gems to the proper directory.  Pull request [#1064](https://github.com/rubygems/rubygems/pull/1064)
   by Tuomas Kareinen.
-* `gem pristine` now skips bundled gems properly.  Pull request #1064 by
+* `gem pristine` now skips bundled gems properly.  Pull request [#1064](https://github.com/rubygems/rubygems/pull/1064) by
   Tuomas Kareinen.
-* Improved interoperability of Vagrant with RubyGems.  Pull request #1057 by
+* Improved interoperability of Vagrant with RubyGems.  Pull request [#1057](https://github.com/rubygems/rubygems/pull/1057) by
   Vít Ondruch.
 * Renamed CONTRIBUTING to CONTRIBUTING.rdoc to allow markup.  Pull request
-  #1090 by Roberto Miranda.
+  [#1090](https://github.com/rubygems/rubygems/pull/1090) by Roberto Miranda.
 * Switched from #partition to #reject as only one collection is used.  Pull
-  request #1074 by Tuomas Kareinen.
+  request [#1074](https://github.com/rubygems/rubygems/pull/1074) by Tuomas Kareinen.
 * Fixed installation of gems on systems using memory-mapped files.  Pull
-  request #1038 by Justin Li.
-* Fixed bug in Gem::Text#min3 where `a == b < c`.  Pull request #1026 by
+  request [#1038](https://github.com/rubygems/rubygems/pull/1038) by Justin Li.
+* Fixed bug in Gem::Text#min3 where `a == b < c`.  Pull request [#1026](https://github.com/rubygems/rubygems/pull/1026) by
   fortissimo1997.
 * Fixed uninitialized variable warning in BasicSpecification.  Pull request
-  #1019 by Piotr Szotkowski.
+  [#1019](https://github.com/rubygems/rubygems/pull/1019) by Piotr Szotkowski.
 * Removed unneeded exception handling for cyclic dependencies.  Pull request
-  #1043 by Jens Wille.
-* Fixed grouped expression warning.  Pull request #1081 by André Arko.
+  [#1043](https://github.com/rubygems/rubygems/pull/1043) by Jens Wille.
+* Fixed grouped expression warning.  Pull request [#1081](https://github.com/rubygems/rubygems/pull/1081) by André Arko.
 * Fixed handling of platforms when writing lockfiles.
 
 # 2.4.4 / 2014-11-12
@@ -2785,8 +2785,8 @@ Security fixes:
 
 ## Bug fixes:
 
-* Fix redefine MirrorCommand issue. Pull request #1044 by @akr.
-* Fix typo in platform= docs.  Pull request #1048 by @jasonrclark
+* Fix redefine MirrorCommand issue. Pull request [#1044](https://github.com/rubygems/rubygems/pull/1044) by @akr.
+* Fix typo in platform= docs.  Pull request [#1048](https://github.com/rubygems/rubygems/pull/1048) by @jasonrclark
 * Add root SSL certificates for upcoming certificate change.  Fixes #1050 by
   Protosac
 
@@ -2803,16 +2803,16 @@ This release was sponsored by Ruby Central.
 * Lockfiles will no longer be truncated upon resolution errors.
 * Fixed messaging for `gem owner -a`.  Issue #1004 by Aaron Patterson, Ryan
   Davis.
-* Removed meaningless ensure.  Pull request #1003 by gogotanaka.
-* Improved wording of --source option help.  Pull request #989 by Jason Clark.
+* Removed meaningless ensure.  Pull request [#1003](https://github.com/rubygems/rubygems/pull/1003) by gogotanaka.
+* Improved wording of --source option help.  Pull request [#989](https://github.com/rubygems/rubygems/pull/989) by Jason Clark.
 * Empty build_info files are now ignored.  Issue #903 by Adan Alvarado.
 * Gem::Installer ignores dependency checks when installing development
   dependencies.  Issue #994 by Jens Willie.
 * `gem update` now continues after dependency errors.  Issue #993 by aaronchi.
 * RubyGems no longer warns about semantic version dependencies for the 0.x
-  range.  Issue #987 by Jeff Felchner, pull request #1006 by Hsing-Hui Hsu.
+  range.  Issue #987 by Jeff Felchner, pull request [#1006](https://github.com/rubygems/rubygems/pull/1006) by Hsing-Hui Hsu.
 * Added minimal lock to allow multithread installation of gems.  Issue #982
-  and pull request #1005 by Yorick Peterse
+  and pull request [#1005](https://github.com/rubygems/rubygems/pull/1005) by Yorick Peterse
 * RubyGems now considers prerelease dependencies as it did in earlier versions
   when --prerelease is given.  Issue #990 by Jeremy Tryba.
 * Updated capitalization in README.  Issue #1010 by Ben Bodenmiller.
@@ -2820,7 +2820,7 @@ This release was sponsored by Ruby Central.
 * Fixed windows stub script generation for Cygwin.  Issue #1000 by Brett
   DiFrischia.
 * Allow gem bindir and ruby.exe to live in separate directories.  Pull request
-  #942 by Ian Flynn.
+  [#942](https://github.com/rubygems/rubygems/pull/942) by Ian Flynn.
 * Fixed handling of gemspec in gem dependencies files to match Bundler
   behavior.  Issue #1020 by Michal Papis.
 * Fixed `gem update` when updating to prereleases.  Issue #1028 by Santiago
@@ -2840,10 +2840,10 @@ This release was sponsored by Ruby Central.
 ## Enhancements:
 
 * The contents command now supports a --show-install-dir option that shows
-  only the directory the gem is installed in.  Feature request #966 by Akinori
+  only the directory the gem is installed in.  Feature request [#966](https://github.com/rubygems/rubygems/pull/966) by Akinori
   MUSHA.
 * Added a --build-root option to the install command for packagers.  Pull
-  request #965 by Marcus Rückert.
+  request [#965](https://github.com/rubygems/rubygems/pull/965) by Marcus Rückert.
 * Added vendor gem support to RubyGems.  Package managers may now install gems
   in Gem.vendor_dir with the --vendor option to gem install.  Issue #943 by
   Marcus Rückert.
@@ -2862,34 +2862,34 @@ This release was sponsored by Ruby Central.
   Bug #941 by Michael Kaiser-Nyman.
 * Added open to list of builtin commands (`gem open` now works).  Reported by
   Espen Antonsen.
-* `gem open` now works with command-line editors.  Pull request #962 by Tim
+* `gem open` now works with command-line editors.  Pull request [#962](https://github.com/rubygems/rubygems/pull/962) by Tim
   Pope.
-* `gem install -g` now respects `--conservative`.  Pull request #950 by Jeremy
+* `gem install -g` now respects `--conservative`.  Pull request [#950](https://github.com/rubygems/rubygems/pull/950) by Jeremy
   Evans.
 * RubyGems releases announcements now now include checksums.  Bug #939 by
   Alexander E. Fischer.
 * RubyGems now expands ~ in $PATH when checking if installed executables will
-  be runnable.  Pull request #945 by Alex Talker.
+  be runnable.  Pull request [#945](https://github.com/rubygems/rubygems/pull/945) by Alex Talker.
 * Fixed `gem install -g --explain`.  Issue #947 by Luis Lavena.  Patch by
   Hsing-Hui Hsu.
-* RubyGems locks less during gem activation.  Pull request #951 by Aaron
+* RubyGems locks less during gem activation.  Pull request [#951](https://github.com/rubygems/rubygems/pull/951) by Aaron
   Patterson and Justin Searls, #969 by Jeremy Tryba.
-* Kernel#gem is now thread-safe.  Pull request #967 by Aaron Patterson.
+* Kernel#gem is now thread-safe.  Pull request [#967](https://github.com/rubygems/rubygems/pull/967) by Aaron Patterson.
 * RubyGems now handles spaces in directory names for some parts of extension
-  building.  Pull request #949 by Tristan Hill.
+  building.  Pull request [#949](https://github.com/rubygems/rubygems/pull/949) by Tristan Hill.
 * RubyGems no longer defines an empty Date class.  Pull Request #948 by Benoit
   Daloze.
 * RubyGems respects --document options for `gem update` again.  Bug 946 by
   jonforums.  Patch by Hsing-Hui Hsu.
 * RubyGems generates documentation again with --ignore-dependencies.  Bug #961
   by Pulfer.
-* RubyGems can install extensions across partitions now.  Pull request #970 by
+* RubyGems can install extensions across partitions now.  Pull request [#970](https://github.com/rubygems/rubygems/pull/970) by
   Michael Scherer.
 * `-s` is now short for `--source` which resolves an ambiguity with
-  --no-suggestions.  Pull request #955 by Alexander Kahn.
-* Added extra test for ~> for 0.0.X versions.  Pull request #958 by Mark
+  --no-suggestions.  Pull request [#955](https://github.com/rubygems/rubygems/pull/955) by Alexander Kahn.
+* Added extra test for ~> for 0.0.X versions.  Pull request [#958](https://github.com/rubygems/rubygems/pull/958) by Mark
   Lorenz.
-* Fixed typo in gem updated help.  Pull request #952 by Per Modin.
+* Fixed typo in gem updated help.  Pull request [#952](https://github.com/rubygems/rubygems/pull/952) by Per Modin.
 * Clarified that the gem description should not be excessively long.  Part of
   bug #956 by Renier Morales.
 * Hid documentation of outdated test_files related methods in Specification.
@@ -2904,59 +2904,59 @@ This release was sponsored by Ruby Central.
 
 * Added the `open` command which allows you to inspect the source of a gem
   using your editor.
-  Issue #789 by Mike Perham. Pull request #804 by Vitali F.
+  Issue #789 by Mike Perham. Pull request [#804](https://github.com/rubygems/rubygems/pull/804) by Vitali F.
 * The `update` command shows a summary of which gems were and were not
   updated.  Issue #544 by Mark D. Blackwell.
-  Pull request #777 by Tejas Bubane.
-* Improved "could not find 'gem'" error reporting.  Pull request #913 by
+  Pull request [#777](https://github.com/rubygems/rubygems/pull/777) by Tejas Bubane.
+* Improved "could not find 'gem'" error reporting.  Pull request [#913](https://github.com/rubygems/rubygems/pull/913) by
   Richard Schneeman.
 * Gem.use_gemdeps now accepts an argument specifying the path of the gem
   dependencies file.  When the file is not found an ArgumentError is raised.
 * Writing a .lock file for a gem dependencies file is now controlled by the
-  --[no-]lock option.  Pull request #774 by Jeremy Evans.
+  --[no-]lock option.  Pull request [#774](https://github.com/rubygems/rubygems/pull/774) by Jeremy Evans.
 * Suggestion of alternate names and spelling corrections during install can be
   suppressed with the --no-suggestions option.  Issue #867 by Jimmy Cuadra.
-* Added mswin64 support.  Pull request #881 by U. Nakamura.
+* Added mswin64 support.  Pull request [#881](https://github.com/rubygems/rubygems/pull/881) by U. Nakamura.
 * A gem is installable from an IO again (as in RubyGems 1.8.x and older).
-  Pull request #716 by Xavier Shay.
+  Pull request [#716](https://github.com/rubygems/rubygems/pull/716) by Xavier Shay.
 * RubyGems no longer attempts to build extensions during activation.  Instead
   a warning is issued instructing you to run `gem pristine` which will build
   the extensions for the current platform.  Issue #796 by dunric.
 * Added Gem::UserInteraction#verbose which prints when the --verbose option is
-  given.  Pull request #811 by Aaron Patterson.
+  given.  Pull request [#811](https://github.com/rubygems/rubygems/pull/811) by Aaron Patterson.
 * RubyGems can now fetch gems from private repositories using S3.  Pull
-  request #856 by Brian Palmer.
+  request [#856](https://github.com/rubygems/rubygems/pull/856) by Brian Palmer.
 * Added Gem::ConflictError subclass of Gem::LoadError so you can distinguish
-  conflicts from other problems.  Pull request #841 by Aaron Patterson.
-* Cleaned up unneeded load_yaml bootstrapping in Rakefile.  Pull request #815
+  conflicts from other problems.  Pull request [#841](https://github.com/rubygems/rubygems/pull/841) by Aaron Patterson.
+* Cleaned up unneeded load_yaml bootstrapping in Rakefile.  Pull request [#815](https://github.com/rubygems/rubygems/pull/815)
   by Zachary Scott.
-* Improved performance of conflict resolution.  Pull request #842 by Aaron
+* Improved performance of conflict resolution.  Pull request [#842](https://github.com/rubygems/rubygems/pull/842) by Aaron
   Patterson.
 * Add documentation of "~> 0" to Gem::Version.  Issue #896 by Aaron Suggs.
-* Added CONTRIBUTING file.  Pull request #849 by Mark Turner.
+* Added CONTRIBUTING file.  Pull request [#849](https://github.com/rubygems/rubygems/pull/849) by Mark Turner.
 * Allow use of bindir in windows_stub_script in .bat
-  Pull request #818 by @unak and @nobu
+  Pull request [#818](https://github.com/rubygems/rubygems/pull/818) by @unak and @nobu
 * Use native File::PATH_SEPARATOR and remove $ before gem env on
-  Gem::Dependency#to_specs. Pull request #915 by @parkr
-* RubyGems recommends SPDX IDs for licenses now.  Pull request #917 by
+  Gem::Dependency#to_specs. Pull request [#915](https://github.com/rubygems/rubygems/pull/915) by @parkr
+* RubyGems recommends SPDX IDs for licenses now.  Pull request [#917](https://github.com/rubygems/rubygems/pull/917) by
   Benjamin Fleischer.
 
 ## Bug fixes:
 
 * RubyGems now only fetches the latest specs to find misspellings which speeds
-  up gem suggestions.  Pull request #808 by Aaron Patterson.
+  up gem suggestions.  Pull request [#808](https://github.com/rubygems/rubygems/pull/808) by Aaron Patterson.
 * The given .gem is installed again when multiple versions of the same gem
   exist in the current directory.  Bug #875 by Prem Sichanugrist.
 * Local gems are preferred by name over remote gems again.  Bug #834 by
   jonforums.
-* RubyGems can install local prerelease gems again.  Pull request #866 by
+* RubyGems can install local prerelease gems again.  Pull request [#866](https://github.com/rubygems/rubygems/pull/866) by
   Aaron Patterson.  Issue #813 by André Arko.
 * RubyGems installs development dependencies correctly again.  Issue #893 by
   Jens Wille.
 * RubyGems only installs prerelease versions when they are requested again.
   Issue #853 by Seth Vargo, special thanks to Zachary Scott and Ben Moss.
   Issue #884 by Nathaniel Bibler.
-* Fixed RubyGems list and search command help.  Pull request #905 and #928 by
+* Fixed RubyGems list and search command help.  Pull request [#905](https://github.com/rubygems/rubygems/pull/905) and #928 by
   Gabriel Gilder.
 * The list of gems to uninstall is always sorted now.  Bug #918 by postmodern.
 * The update command only updates exactly matching gem names now.  Bug #919 by
@@ -2985,39 +2985,39 @@ This release was sponsored by Ruby Central.
   by Noah Luck Easterly.
 * The environment command now shows the system configuration directory where
   the all-users gemrc lives.  Bug #827 by Ben Langfeld.
-* Improved speed of conflict checking when activating gems.  Pull request #843
+* Improved speed of conflict checking when activating gems.  Pull request [#843](https://github.com/rubygems/rubygems/pull/843)
   by Aaron Patterson.
 * Improved speed of levenshtein distance for gem suggestion misspellings.
   Pull requests #809, #812 by Aaron Patterson.
-* Restored persistent connections.  Pull request #869 by Aaron Patterson.
-* Reduced requests when fetching gems with the bundler API.  Pull request #773
+* Restored persistent connections.  Pull request [#869](https://github.com/rubygems/rubygems/pull/869) by Aaron Patterson.
+* Reduced requests when fetching gems with the bundler API.  Pull request [#773](https://github.com/rubygems/rubygems/pull/773)
   by Charlie Somerville.
 * Reduced dependency prefetching to improve install speed.  Pull requests
   #871, #872 by Matthew Draper.
 * RubyGems now avoids net/http auto-proxy detection.  Issue #824 by HINOHARA
   Hiroshi.
 * Removed conversion of Gem::List (used for debugging installs) to unless
-  necessary.  Pull request #870 by Aaron Patterson.
+  necessary.  Pull request [#870](https://github.com/rubygems/rubygems/pull/870) by Aaron Patterson.
 * RubyGems now prints release notes from the current release.  Bug #814 by
   André Arko.
 * RubyGems allows installation of unsigned gems again with -P MediumSecurity
   and lower.  Bug #859 by Justin S. Collins.
-* Fixed typo in Jim Weirich's name.  Ruby pull request #577 by Mo Khan.
-* Fixed typo in Gem.datadir documentation.  Pull request #868 by Patrick
+* Fixed typo in Jim Weirich's name.  Ruby pull request [#577](https://github.com/rubygems/rubygems/pull/577) by Mo Khan.
+* Fixed typo in Gem.datadir documentation.  Pull request [#868](https://github.com/rubygems/rubygems/pull/868) by Patrick
   Jones.
-* Fixed File.exists? warnings.  Pull request #829 by SHIBATA Hiroshi.
+* Fixed File.exists? warnings.  Pull request [#829](https://github.com/rubygems/rubygems/pull/829) by SHIBATA Hiroshi.
 * Fixed show_release_notes test for LANG=C.  Issue #862 by Luis Lavena.
 * Fixed Gem::Package from IO tests on windows.  Patch from issue #861 by Luis
   Lavena.
 * Check for nil extensions as BasicSpecification does not initialize them.
-  Pull request #882 by André Arko.
+  Pull request [#882](https://github.com/rubygems/rubygems/pull/882) by André Arko.
 * Fixed Gem::BasicSpecification#require_paths receives a String for
-  @require_paths. Pull request #904 by @danielpclark
+  @require_paths. Pull request [#904](https://github.com/rubygems/rubygems/pull/904) by @danielpclark
 * Fixed circular require warnings.  Bug #908 by Zachary Scott.
 * Gem::Specification#require_paths can no longer accidentally be an Array.
   Pull requests #904, #909 by Daniel P. Clark.
 * Don't build extensions if `build_dir/extensions` isn't writable.
-  Pull request #912 by @dunric
+  Pull request [#912](https://github.com/rubygems/rubygems/pull/912) by @dunric
 * Gem::BasicSpecification#require_paths respects default_ext_dir_for now.  Bug
   #852 by Vít Ondruch.
 
@@ -3048,21 +3048,21 @@ This release was sponsored by Ruby Central.
 * Fixed ruby tests when BASERUBY is not set.  Patch for #778 by Nobuyoshi
   Nakada.
 * Removed double requests in RemoteFetcher#cache_update_path to improve remote
-  install speed.  Pull request #772 by Charlie Somerville.
+  install speed.  Pull request [#772](https://github.com/rubygems/rubygems/pull/772) by Charlie Somerville.
 * The mkmf.log is now placed next to gem_make.out when building extensions.
 * `gem install -g --local` no longer accesses the network.  Bug #776 by Jeremy
   Evans.
 * RubyGems now correctly handles URL passwords with encoded characters.  Pull
-  request #781 by Brian Fletcher.
-* RubyGems now correctly escapes URL characters.  Pull request #788 by Brian
+  request [#781](https://github.com/rubygems/rubygems/pull/781) by Brian Fletcher.
+* RubyGems now correctly escapes URL characters.  Pull request [#788](https://github.com/rubygems/rubygems/pull/788) by Brian
   Fletcher.
 * RubyGems can now unpack tar files where the type flag is not given.  Pull
-  request #790 by Cody Russell.
+  request [#790](https://github.com/rubygems/rubygems/pull/790) by Cody Russell.
 * Typo corrections.  Pull request ruby/ruby#506 by windwiny.
 * RubyGems now uses both the default certificates and ssl_ca_cert instead of
-  one or the other.  Pull request #795 by zebardy.
+  one or the other.  Pull request [#795](https://github.com/rubygems/rubygems/pull/795) by zebardy.
 * RubyGems can now use the bundler API against hosted gem servers in a
-  directory.  Pull request #801 by Brian Fletcher.
+  directory.  Pull request [#801](https://github.com/rubygems/rubygems/pull/801) by Brian Fletcher.
 * RubyGems bin stubs now ignore non-versions.  This allows RubyGems bin stubs
   to list file names like "_foo_".  Issue #799 by Postmodern.
 * Restored behavior of Gem::Version::new when subclassed.  Issue #805 by
@@ -3075,12 +3075,12 @@ This release was sponsored by Ruby Central.
 * Platforms in the Gemfile.lock GEM section are now handled correctly.  Bug
   #767 by Diego Viola.
 * RubyGems now displays which gem couldn't be uninstalled from the home
-  directory.  Pull request #757 by Michal Papis.
-* Removed unused method Gem::Resolver#find_conflict_state.  Pull request #759
+  directory.  Pull request [#757](https://github.com/rubygems/rubygems/pull/757) by Michal Papis.
+* Removed unused method Gem::Resolver#find_conflict_state.  Pull request [#759](https://github.com/rubygems/rubygems/pull/759)
   by Smit Shah.
 * Fixed installing gems from local files without dependencies.  Issue #760 by
-  Arash Mousavi, pull request #764 by Tim Moore.
-* Removed TODO about syntax that works in Ruby 1.8.7.  Pull request #765 by
+  Arash Mousavi, pull request [#764](https://github.com/rubygems/rubygems/pull/764) by Tim Moore.
+* Removed TODO about syntax that works in Ruby 1.8.7.  Pull request [#765](https://github.com/rubygems/rubygems/pull/765) by
   Benjamin Fleischer.
 * Switched Gem.ruby_api_version to use RbConfig::CONFIG['ruby_version'] which
   has the same value but is overridable by packagers through
@@ -3094,7 +3094,7 @@ This release was sponsored by Ruby Central.
 * Gem.read_binary can read read-only files again.  This caused file://
   repositories to stop working.  Bug #761 by John Anderson.
 * Fixed specification file sorting for Ruby 1.8.7 compatibility.  Pull
-  request #763 by James Mead
+  request [#763](https://github.com/rubygems/rubygems/pull/763) by James Mead
 
 # 2.2.0 / 2013-12-26
 
@@ -3127,17 +3127,17 @@ RubyGems as it was prepared for the 2.2.0 release.
 * RubyGems checks the 'allowed_push_host' metadata value when pushing a gem to
   prevent an accidental push to a public repository (such as rubygems.org).
   If you have private gems you should set this value in your gem specification
-  metadata.  Pull request #603 by Seamus Abshere.
-* `gem list` now shows results for multiple arguments.  Pull request #604 by
+  metadata.  Pull request [#603](https://github.com/rubygems/rubygems/pull/603) by Seamus Abshere.
+* `gem list` now shows results for multiple arguments.  Pull request [#604](https://github.com/rubygems/rubygems/pull/604) by
   Zach Rabinovich.
 * `gem pristine --extensions` will restore only gems with extensions.  Issue
   #619 by Postmodern.
-* Gem::Specification#files is now sorted.  Pull request #612 by Justin George.
+* Gem::Specification#files is now sorted.  Pull request [#612](https://github.com/rubygems/rubygems/pull/612) by Justin George.
 * For `gem list` and friends, "LOCAL" and "REMOTE" headers are omitted if
   only local or remote gem information is requested with --quiet.  Pull
-  request #615 by Michal Papis.
+  request [#615](https://github.com/rubygems/rubygems/pull/615) by Michal Papis.
 * Added Gem::Specification#full_require_paths which is like require_paths, but
-  returns a fully-qualified results.  Pull request #632 by Vít Ondruch.
+  returns a fully-qualified results.  Pull request [#632](https://github.com/rubygems/rubygems/pull/632) by Vít Ondruch.
 * RubyGems now looks for the https_proxy environment variable for https://
   sources.  RubyGems will fall back to http_proxy if there is no https_proxy.
   Issue #610 by mkristian.
@@ -3155,7 +3155,7 @@ RubyGems as it was prepared for the 2.2.0 release.
 * When using `gem install -g`, RubyGems now detects the presence of an
   Isolate, Gemfile or gem.deps.rb file.
 * Added Gem::StubSpecification#stubbed? to help determine if a user should run
-  `gem pristine` to speed up gem loading.  Pull request #694 and #701 by Jon
+  `gem pristine` to speed up gem loading.  Pull request [#694](https://github.com/rubygems/rubygems/pull/694) and #701 by Jon
   Leighton.
 * RubyGems now warns when a gem has a pessimistic version dependency that may
   be too strict.
@@ -3163,9 +3163,9 @@ RubyGems as it was prepared for the 2.2.0 release.
 * RubyGems now raises an exception when a dependency for a gem is defined
   twice.
 * Marked the license specification attribute as recommended.  Pull request
-  #713 by Benjamin Fleischer.
+  [#713](https://github.com/rubygems/rubygems/pull/713) by Benjamin Fleischer.
 * RubyGems uses io/console instead of `stty` when available.  Pull request
-  #740 by Nobuyoshi Nakada
+  [#740](https://github.com/rubygems/rubygems/pull/740) by Nobuyoshi Nakada
 * Relaxed Gem.ruby tests for platforms that override where ruby lives.  Pull
   Request #755 by strzibny.
 
@@ -3173,14 +3173,14 @@ RubyGems as it was prepared for the 2.2.0 release.
 
 * RubyGems now returns an error status when any file given to `gem which`
   cannot be found.  Ruby bug #9004 by Eugene Vilensky.
-* Fixed command escaping when building rake extensions.  Pull request #721 by
+* Fixed command escaping when building rake extensions.  Pull request [#721](https://github.com/rubygems/rubygems/pull/721) by
   Dmitry Ratnikov.
 * Fixed uninstallation of gems when GEM_HOME is a relative directory.  Issue
   #708 by Ryan Davis.
 * Default gems are now ignored by Gem::Validator#alien.  Issue #717 by David
   Bahar.
 * Fixed typos in RubyGems.  Pull requests #723, #725, #731 by Akira Matsuda,
-  pull request #736 by Leo Gallucci, pull request #746 by DV Suresh.
+  pull request [#736](https://github.com/rubygems/rubygems/pull/736) by Leo Gallucci, pull request [#746](https://github.com/rubygems/rubygems/pull/746) by DV Suresh.
 * RubyGems now holds exclusive locks on cached gem files to prevent incorrect
   updates.  Pull Request #737 by Smit Shah
 * Improved speed of `gem install --ignore-dependencies`.  Patch by Terence
@@ -3242,11 +3242,11 @@ RubyGems as it was prepared for the 2.2.0 release.
 
 ## Bug fixes:
 
-* `gem sources --list` now displays a list of sources.  Pull request #672 by
+* `gem sources --list` now displays a list of sources.  Pull request [#672](https://github.com/rubygems/rubygems/pull/672) by
   Nathan Marley.
 * RubyGems no longer alters Gem::Specification.dirs when installing.  Pull
   Request #670 by Vít Ondruch
-* Use RFC 2616-compatible time in HTTP headers.  Pull request #655 by Larry
+* Use RFC 2616-compatible time in HTTP headers.  Pull request [#655](https://github.com/rubygems/rubygems/pull/655) by Larry
   Marburger.
 * RubyGems now gives a more descriptive message for missing licenses on
   validation.  Issue #656 by Markus Heiler.
@@ -3262,9 +3262,9 @@ RubyGems as it was prepared for the 2.2.0 release.
 * Remove redundant built-in certificates not needed for https://rubygems.org
   Fixes #654 by Vít Ondruch.
 * Added test for missing certificates for https://s3.amazonaws.com or
-  https://rubygems.org.  Pull request #673 by Hannes Georg.
+  https://rubygems.org.  Pull request [#673](https://github.com/rubygems/rubygems/pull/673) by Hannes Georg.
 * RubyGems now allows a Pathname for Kernel#require like the built-in
-  Kernel#require.  Pull request #663 by Aaron Patterson.
+  Kernel#require.  Pull request [#663](https://github.com/rubygems/rubygems/pull/663) by Aaron Patterson.
 * Required rbconfig in Gem::ConfigFile for Ruby 1.9.1 compatibility.  (Ruby
   1.9.1 is no longer receiving security fixes, so please update to a newer
   version.)  Issue #676 by Michal Papis.  Issue wayneeseguin/rvm#2262 by
@@ -3300,7 +3300,7 @@ Security fixes:
 ## Bug fixes:
 
 * Restore concurrent requires following the fix for ruby bug #8374.  Pull
-  request #637 and issue #640 by Charles Nutter.
+  request [#637](https://github.com/rubygems/rubygems/pull/637) and issue #640 by Charles Nutter.
 * Gems with extensions are now installed correctly when the --install-dir
   option is used.  Issue #642 by Lin Jen-Shin.
 * Gem fetch now fetches the newest (not oldest) gem when --version is given.
@@ -3348,7 +3348,7 @@ Security fixes:
   gemcutter API.  Pull Request #462 and issue #461 by Hugo Lopes Tavares
 * Added --abort-on-dependent to `gem uninstall`.  This will abort instead of
   asking to uninstall a gem that is depended upon by another gem.  Pull
-  request #549 by Philip Arndt.
+  request [#549](https://github.com/rubygems/rubygems/pull/549) by Philip Arndt.
 * RubyGems no longer alters Gem::Specification.dirs when installing.  Based on
   Pull Request #452 by Vít Ondruch
 * RubyGems uses ENV['MAKE'] or ENV['make'] over rbconfig.rb's make if present.
@@ -3360,21 +3360,21 @@ Security fixes:
   Klabnik.
 * RubyGems indicates when a .gem's content is corrupt while verifying.  Bug
   #519 by William T Nelson.
-* Refactored common installer setup.  Pull request #520 by Gastón Ramos
-* Moved activation tests to Gem::Specification.  Pull request #521 by Gastón
+* Refactored common installer setup.  Pull request [#520](https://github.com/rubygems/rubygems/pull/520) by Gastón Ramos
+* Moved activation tests to Gem::Specification.  Pull request [#521](https://github.com/rubygems/rubygems/pull/521) by Gastón
   Ramos
 * When a --version option with a prerelease version is given RubyGems
   automatically enables prerelease versions but only the last version is
   used.  If the first version is a prerelease version this is no longer sticky
   unless an explicit --[no-]prerelease was also given.  Fixes part of #531.
-* RubyGems now supports an SSL client certificate.  Pull request #550 by
+* RubyGems now supports an SSL client certificate.  Pull request [#550](https://github.com/rubygems/rubygems/pull/550) by
   Robert Kenny.
-* RubyGems now suggests how to fix permission errors.  Pull request #553 by
+* RubyGems now suggests how to fix permission errors.  Pull request [#553](https://github.com/rubygems/rubygems/pull/553) by
   Odin Dutton.
 * Added support for installing a gem as default gems for alternate ruby
-  implementations.  Pull request #566 by Charles Nutter.
+  implementations.  Pull request [#566](https://github.com/rubygems/rubygems/pull/566) by Charles Nutter.
 * Improved performance of Gem::Specification#load by caching the loaded
-  gemspec.  Pull request #569 by Charlie Somerville.
+  gemspec.  Pull request [#569](https://github.com/rubygems/rubygems/pull/569) by Charlie Somerville.
 * RubyGems now warns when an unsigned gem is verified if -P was given during
   installation even if the security policy allows unsigned gems and warns when
   an untrusted certificate is seen even if the security policy allows
@@ -3384,13 +3384,13 @@ Security fixes:
   --env-[no-]shebang</code>.  Issue #579 by Paul Annesley.
 * RubyGems can now run its tests without OpenSSL.  Ruby Bug #8557 by nobu.
 * Improved performance by caching Gem::Version objects and avoiding
-  method_missing in Gem::Specification.  Pull request #447 by Jon Leighton.
-* Files in a .gem now preserve their modification times.  Pull request #582 by
+  method_missing in Gem::Specification.  Pull request [#447](https://github.com/rubygems/rubygems/pull/447) by Jon Leighton.
+* Files in a .gem now preserve their modification times.  Pull request [#582](https://github.com/rubygems/rubygems/pull/582) by
   Jesse Bowes
 * Improved speed of looking up dependencies in SpecFetcher through
-  Array#bsearch (when present).  Pull request #595 by Andras Suller
+  Array#bsearch (when present).  Pull request [#595](https://github.com/rubygems/rubygems/pull/595) by Andras Suller
 * Added `--all` option to `gem uninstall` which removes all gems in GEM_HOME.
-  Pull request #584 by Shannon Skipper.
+  Pull request [#584](https://github.com/rubygems/rubygems/pull/584) by Shannon Skipper.
 * Added Gem.find_latest_files which is equivalent to Gem.find_files but only
   returns matching files from the latest version of each gem.  Issue #186 by
   Ryan Davis.
@@ -3402,9 +3402,9 @@ Security fixes:
 
 * rubygems_plugin.rb files are now only loaded from the latest installed gem.
 * Fixed Gem.clear_paths when Security is defined at top-level.  Pull request
-  #625 by elarkin
+  [#625](https://github.com/rubygems/rubygems/pull/625) by elarkin
 * Fixed credential creation for `gem push` when `--host` is not given.  Pull
-  request #622 by Arthur Nogueira Neves
+  request [#622](https://github.com/rubygems/rubygems/pull/622) by Arthur Nogueira Neves
 
 # 2.0.17 / 2015-06-08
 
@@ -3465,9 +3465,9 @@ Security fixes:
 * Remove redundant built-in certificates not needed for https://rubygems.org
   Fixes #654 by Vít Ondruch.
 * Added test for missing certificates for https://s3.amazonaws.com or
-  https://rubygems.org.  Pull request #673 by Hannes Georg.
+  https://rubygems.org.  Pull request [#673](https://github.com/rubygems/rubygems/pull/673) by Hannes Georg.
 * RubyGems now allows a Pathname for Kernel#require like the built-in
-  Kernel#require.  Pull request #663 by Aaron Patterson.
+  Kernel#require.  Pull request [#663](https://github.com/rubygems/rubygems/pull/663) by Aaron Patterson.
 * Required rbconfig in Gem::ConfigFile for Ruby 1.9.1 compatibility.  (Ruby
   1.9.1 is no longer receiving security fixes, so please update to a newer
   version.)  Issue #676 by Michal Papis.  Issue wayneeseguin/rvm#2262 by
@@ -3489,7 +3489,7 @@ Security fixes:
 * Gem fetch now fetches the newest (not oldest) gem when --version is given.
   Issue #643 by Brian Shirai.
 * Fixed credential creation for `gem push` when `--host` is not given.  Pull
-  request #622 by Arthur Nogueira Neves
+  request [#622](https://github.com/rubygems/rubygems/pull/622) by Arthur Nogueira Neves
 
 # 2.0.8 / 2013-09-09
 
@@ -3503,7 +3503,7 @@ Security fixes:
 ## Bug fixes:
 
 * Fixed Gem.clear_paths when Security is defined at top-level.  Pull request
-  #625 by elarkin
+  [#625](https://github.com/rubygems/rubygems/pull/625) by elarkin
 
 # 2.0.7 / 2013-08-15
 
@@ -3512,7 +3512,7 @@ Security fixes:
 * Extensions may now be built in parallel (therefore gems may be installed in
   parallel).  Bug #607 by Hemant Kumar.
 * Changed broken link to RubyGems Bookshelf to point to RubyGems guides.  Ruby
-  pull request #369 by 謝致邦.
+  pull request [#369](https://github.com/rubygems/rubygems/pull/369) by 謝致邦.
 * Fixed various test failures due to platform differences or poor tests.
   Patches by Yui Naruse and Koichi Sasada.
 * Fixed documentation for Kernel#require.
@@ -3545,7 +3545,7 @@ Security fixes:
 * Fixed pushing gems with the default host.  Bug #495 by Utkarsh Kukreti
 * Improved unhelpful error message from `gem owner --remove`.  Bug #488 by
   Steve Klabnik
-* Fixed typo in `gem spec` help.  Pull request #563 by oooooooo
+* Fixed typo in `gem spec` help.  Pull request [#563](https://github.com/rubygems/rubygems/pull/563) by oooooooo
 * Fixed creation of build_info with --install-dir.  Bug #457 by Vít Ondruch.
 * RubyGems converts non-string dependency names to strings now.  Bug #505 by
   Terence Lee
@@ -3554,18 +3554,18 @@ Security fixes:
   every file from the gem.  This improves the performance of gem installation
   on some systems.  Pull Request #556 by Grzesiek Kolodziejczyk
 * Removed surprise search term anchoring in `gem search` to restore 1.8-like
-  search behavior while still defaulting to --remote.  Pull request #562 by
+  search behavior while still defaulting to --remote.  Pull request [#562](https://github.com/rubygems/rubygems/pull/562) by
   Ben Bleything
-* Fixed handling of DESTDIR when building extensions.  Pull request #573 by
+* Fixed handling of DESTDIR when building extensions.  Pull request [#573](https://github.com/rubygems/rubygems/pull/573) by
   Akinori MUSHA
 * Fixed documentation of `gem pristine` defaults (--all is not a default).
-  Pull request #577 by Shannon Skipper
-* Fixed a windows extension-building test failure.  Pull request #575 by
+  Pull request [#577](https://github.com/rubygems/rubygems/pull/577) by Shannon Skipper
+* Fixed a windows extension-building test failure.  Pull request [#575](https://github.com/rubygems/rubygems/pull/575) by
   Hiroshi Shirosaki
 * Fixed issue with `gem update` where it would attempt to use a Version
   instead of a Requirement to find the latest gem.  Fixes #570 by Nick Cox.
 * RubyGems now ignores an empty but set RUBYGEMS_HOST environment variable.
-  Based on pull request #558 by Robin Dupret.
+  Based on pull request [#558](https://github.com/rubygems/rubygems/pull/558) by Robin Dupret.
 * Removed duplicate creation of gem subdirectories in
   Gem::DependencyInstaller.  Pull Request #456 by Vít Ondruch
 * RubyGems now works with Ruby built with `--with-ruby-version=''`.  Pull
@@ -3573,7 +3573,7 @@ Security fixes:
 * Fixed race condition when two threads require the same gem.  Ruby bug report
   #8374 by Joel VanderWerf
 * Cleaned up siteconf between extension build and extension install.  Pull
-  request #587 by Dominic Cleal
+  request [#587](https://github.com/rubygems/rubygems/pull/587) by Dominic Cleal
 * Fix deprecation warnings when converting gemspecs to yaml.  Ruby commit
   r41148 by Yui Naruse
 
@@ -3591,7 +3591,7 @@ Security fixes:
   * Use the absolute path to the generated siteconf in case the extension
     changes directories to run extconf.rb (like memcached).  Fixes #498 by
     Chris Morris.
-  * Fixed default gem key and cert locations.  Pull request #511 by Samuel
+  * Fixed default gem key and cert locations.  Pull request [#511](https://github.com/rubygems/rubygems/pull/511) by Samuel
     Cochran.
 
 # 2.0.2 / 2013-03-06
@@ -3614,7 +3614,7 @@ Security fixes:
   * "Done installing documentation" is no longer displayed when documentation
     generation is disabled.  Fixes bug #469 by Jeff Sandberg
   * The existing executable check now respects --format-executable.  Pull
-    request #471 by Jeremy Evans.
+    request [#471](https://github.com/rubygems/rubygems/pull/471) by Jeremy Evans.
   * RubyGems no longer creates gem subdirectories when fetching gems.  Fixes
     #482 by Loren Segal.
   * RubyGems does not require OpenSSL like RubyGems 1.8, but still prefers it.
@@ -3685,7 +3685,7 @@ Changes since RubyGems 1.8.25 (including past pre-releases):
     Skipper.
   * Gem::DependencyInstaller now passes build_args down to the installer.
     Pull Request #412 by Sam Rawlins.
-  * Added a cmake builder.  Pull request #265 by Allan Espinosa.
+  * Added a cmake builder.  Pull request [#265](https://github.com/rubygems/rubygems/pull/265) by Allan Espinosa.
   * Removed rubyforge page from gem list output
   * Added --only-executables option to `gem pristine`.  Fixes #326
   * Added -I flag for 'gem query' to exclude installed items
@@ -3815,7 +3815,7 @@ Changes since RubyGems 2.0.0.rc.2:
 # 2.0.0.preview2.2 / 2012-12-14
 
 ## Enhancements:
-  * Added a cmake builder.  Pull request #265 by Allan Espinosa.
+  * Added a cmake builder.  Pull request [#265](https://github.com/rubygems/rubygems/pull/265) by Allan Espinosa.
   * Removed rubyforge page from gem list output
 
 ## Bug fixes:
@@ -3981,7 +3981,7 @@ $SAFE=1.  There is no functional difference compared to Ruby 2.0.0.preview2
 * Remove redundant built-in certificates not needed for https://rubygems.org
   Fixes #654 by Vít Ondruch.
 * Added test for missing certificates for https://s3.amazonaws.com or
-  https://rubygems.org.  Pull request #673 by Hannes Georg.
+  https://rubygems.org.  Pull request [#673](https://github.com/rubygems/rubygems/pull/673) by Hannes Georg.
 
 # 1.8.27 / 2013-09-24
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

RubyGems changelog does not include links to pull requests, so it is tedious to review the changes included by each entry.

## What is your fix for the problem, implemented in this PR?

Linkify changelog.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
