### PR TITLE
Fix flaky on Ruby 3.2 + Windows and speed up some specs 

### DIFF
--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -2,11 +2,10 @@
 
 RSpec.describe "bundle exec" do
   let(:system_gems_to_install) { %w[rack-1.0.0 rack-0.9.1] }
-  before :each do
-    system_gems(system_gems_to_install, :path => default_bundle_path)
-  end
 
   it "works with --gemfile flag" do
+    system_gems(system_gems_to_install, :path => default_bundle_path)
+
     create_file "CustomGemfile", <<-G
       source "#{file_uri_for(gem_repo1)}"
       gem "rack", "1.0.0"
@@ -17,6 +16,8 @@ RSpec.describe "bundle exec" do
   end
 
   it "activates the correct gem" do
+    system_gems(system_gems_to_install, :path => default_bundle_path)
+
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
       gem "rack", "0.9.1"
@@ -27,6 +28,8 @@ RSpec.describe "bundle exec" do
   end
 
   it "works and prints no warnings when HOME is not writable" do
+    system_gems(system_gems_to_install, :path => default_bundle_path)
+
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
       gem "rack", "0.9.1"
@@ -209,8 +212,6 @@ RSpec.describe "bundle exec" do
   end
 
   context "with default gems" do
-    let(:system_gems_to_install) { [] }
-
     let(:default_irb_version) { ruby "gem 'irb', '< 999999'; require 'irb'; puts IRB::VERSION", :raise_on_error => false }
 
     context "when not specified in Gemfile" do
@@ -402,6 +403,8 @@ RSpec.describe "bundle exec" do
   end
 
   it "raises a helpful error when exec'ing to something outside of the bundle" do
+    system_gems(system_gems_to_install, :path => default_bundle_path)
+
     bundle "config set clean false" # want to keep the rackup binstub
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -706,6 +709,8 @@ RSpec.describe "bundle exec" do
     RUBY
 
     before do
+      system_gems(system_gems_to_install, :path => default_bundle_path)
+
       bundled_app(path).open("w") {|f| f << executable }
       bundled_app(path).chmod(0o755)
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We've been getting the following sporadic failure on Ruby 3.2 on Windows for a while: https://github.com/rubygems/rubygems/actions/runs/4047133842/jobs/6960798233.

```
Failures:

  1) [TEST_ENV_NUMBER=2] bundle exec with help flags when e is used shows executable's man page when the executable has a -
     Failure/Error:
               raise <<~ERROR
       
                 Invoking `#{cmd}` failed with output:
                 ----------------------------------------------------------------------
                 #{command_execution.stdboth}
                 ----------------------------------------------------------------------
               ERROR

     RuntimeError:

       Invoking `gem install --no-document --ignore-dependencies 'D:/a/rubygems/rubygems/bundler/tmp/2/gems/remote1/gems/rack-1.0.0.gem'` failed with output:
       ----------------------------------------------------------------------
       ERROR:  While executing gem ... (Errno::ENOENT)
           No such file or directory @ dir_s_mkdir - D:/a/rubygems/rubygems/bundler/tmp/2/home/AppData/Local/Microsoft/WindowsApps
       	D:/a/rubygems/rubygems/lib/rubygems/installer.rb:956:in `mkdir'
       	D:/a/rubygems/rubygems/lib/rubygems/installer.rb:956:in `ensure_writable_dir'
       	D:/a/rubygems/rubygems/lib/rubygems/installer.rb:488:in `generate_bin'
       	D:/a/rubygems/rubygems/lib/rubygems/installer.rb:331:in `install'
       	D:/a/rubygems/rubygems/lib/rubygems/resolver/specification.rb:104:in `install'
       	D:/a/rubygems/rubygems/lib/rubygems/request_set.rb:279:in `block in install_into'
       	D:/a/rubygems/rubygems/lib/rubygems/request_set.rb:271:in `each'
       	D:/a/rubygems/rubygems/lib/rubygems/request_set.rb:271:in `install_into'
       	D:/a/rubygems/rubygems/lib/rubygems/request_set.rb:147:in `install'
       	D:/a/rubygems/rubygems/lib/rubygems/commands/install_command.rb:214:in `install_gem'
       	D:/a/rubygems/rubygems/lib/rubygems/commands/install_command.rb:230:in `block in install_gems'
       	D:/a/rubygems/rubygems/lib/rubygems/commands/install_command.rb:223:in `each'
       	D:/a/rubygems/rubygems/lib/rubygems/commands/install_command.rb:223:in `install_gems'
       	D:/a/rubygems/rubygems/lib/rubygems/commands/install_command.rb:169:in `execute'
       	D:/a/rubygems/rubygems/lib/rubygems/command.rb:323:in `invoke_with_build_args'
       	D:/a/rubygems/rubygems/lib/rubygems/command_manager.rb:251:in `invoke_command'
       	D:/a/rubygems/rubygems/lib/rubygems/command_manager.rb:191:in `process_args'
       	D:/a/rubygems/rubygems/lib/rubygems/command_manager.rb:149:in `run'
       	D:/a/rubygems/rubygems/lib/rubygems/gem_runner.rb:51:in `run'
       	C:/hostedtoolcache/windows/Ruby/3.2.0/x64/bin/gem.cmd:18:in `<main>'
       Using rubygems directory: D:/a/rubygems/rubygems/bundler/tmp/2/home/.local/share/gem/ruby/3.2.0
       ----------------------------------------------------------------------
     # ./spec/support/helpers.rb:202:in `sys_exec'
     # ./spec/support/helpers.rb:165:in `gem_command'
     # ./spec/support/helpers.rb:308:in `install_gem'
     # ./spec/support/helpers.rb:296:in `block (2 levels) in system_gems'
     # ./spec/support/helpers.rb:288:in `each'
     # ./spec/support/helpers.rb:288:in `block in system_gems'
     # ./spec/support/helpers.rb:345:in `block in with_gem_path_as'
     # ./spec/support/helpers.rb:359:in `without_env_side_effects'
     # ./spec/support/helpers.rb:340:in `with_gem_path_as'
     # ./spec/support/helpers.rb:286:in `system_gems'
     # ./spec/commands/exec_spec.rb:6:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:102:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:102:in `block (3 levels) in <top (required)>'
     # ./spec/support/helpers.rb:345:in `block in with_gem_path_as'
     # ./spec/support/helpers.rb:359:in `without_env_side_effects'
     # ./spec/support/helpers.rb:340:in `with_gem_path_as'
     # ./spec/spec_helper.rb:101:in `block (2 levels) in <top (required)>'
     # ./spec/support/rubygems_ext.rb:103:in `load'
     # ./spec/support/rubygems_ext.rb:103:in `gem_load_and_activate'
     # ./spec/support/rubygems_ext.rb:18:in `gem_load'

Finished in 91 minutes 7 seconds (files took 0 seconds to load)
2990 examples, 1 failure, 116 pending
```

## What is your fix for the problem, implemented in this PR?

Turns out this spec is actually skipped on Windows but the spec setup is still being run, and failing.

So the fix it, avoid running the spec unless specs really need it to pass.

This also speeds up a lot tests in this file:

#### Before

```
$ bin/rspec spec/commands/exec_spec.rb
Run options: exclude {:man=>false, :truffleruby_only=>true, :jruby_only=>true, :readline=>false, :permissions=>false, :no_color_tty=>false, :ruby_repo=>false, :rubygems=>"!= 3.5.0.dev", :bundler=>"!= 2", :git=>"!= 2.37.1", :realworld=>true}

Randomized with seed 55928
......................................................................................*...............

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) bundle exec `load`ing a ruby file instead of `exec`ing regarding $0 and __FILE__ when the path is relative with a leading ./ relative paths with ./ have absolute __FILE__
     # Not yet implemented
     # ./spec/commands/exec_spec.rb:984


Finished in 1 minute 21.76 seconds (files took 0.15948 seconds to load)
102 examples, 0 failures, 1 pending

Randomized with seed 55928
```

#### After

```
$ bin/rspec spec/commands/exec_spec.rb
Run options: exclude {:man=>false, :truffleruby_only=>true, :jruby_only=>true, :readline=>false, :permissions=>false, :no_color_tty=>false, :ruby_repo=>false, :rubygems=>"!= 3.5.0.dev", :bundler=>"!= 2", :git=>"!= 2.37.1", :realworld=>true}

Randomized with seed 65415
.........................................................................................*............

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) bundle exec `load`ing a ruby file instead of `exec`ing regarding $0 and __FILE__ when the path is relative with a leading ./ relative paths with ./ have absolute __FILE__
     # Not yet implemented
     # ./spec/commands/exec_spec.rb:989


Finished in 54.06 seconds (files took 0.13646 seconds to load)
102 examples, 0 failures, 1 pending

Randomized with seed 65415
```


## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
