### PR TITLE
Changelogs for RubyGems 3.4.6 and Bundler 2.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+# 3.4.6 / 2023-01-31
+
+## Enhancements:
+
+* Allow `require` decorations be disabled. Pull request
+  [#6319](https://github.com/rubygems/rubygems/pull/6319) by
+  deivid-rodriguez
+* Installs bundler 2.4.6 as a default gem.
+
+## Bug fixes:
+
+* Include directory in CargoBuilder install path. Pull request
+  [#6298](https://github.com/rubygems/rubygems/pull/6298) by matsadler
+
+## Documentation:
+
+* Include links to pull requests in changelog. Pull request
+  [#6316](https://github.com/rubygems/rubygems/pull/6316) by
+  deivid-rodriguez
+
 # 3.4.5 / 2023-01-21
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 2.4.6 (January 31, 2023)
+
+## Enhancements:
+
+  - Don't warn on `bundle binstubs --standalone --all` [#6312](https://github.com/rubygems/rubygems/pull/6312)
+
+## Bug fixes:
+
+  - Don't undo require decorations made by other gems [#6308](https://github.com/rubygems/rubygems/pull/6308)
+  - Fix `bundler/inline` not properly installing gems with extensions when used more than once [#6306](https://github.com/rubygems/rubygems/pull/6306)
+  - Fix `bundler/inline` not skipping installation when gems already there, when used more than once [#6305](https://github.com/rubygems/rubygems/pull/6305)
+
 # 2.4.5 (January 21, 2023)
 
 ## Bug fixes:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.4.6 and Bundler 2.4.6 into master.