### PR TITLE
Fix warning in cargo builder tests

### DIFF
--- a/test/rubygems/test_gem_ext_cargo_builder.rb
+++ b/test/rubygems/test_gem_ext_cargo_builder.rb
@@ -87,7 +87,7 @@ class TestGemExtCargoBuilder < Gem::TestCase
       end
     end
 
-    assert_match /cargo\s.*\sfailed/, error.message
+    assert_match(/cargo\s.*\sfailed/, error.message)
   end
 
   def test_full_integration


### PR DESCRIPTION

## What was the end-user or developer problem that led to this PR?

None, just fixing a warning that appears during `rake test`:


```
/path/to/test/rubygems/test_gem_ext_cargo_builder.rb:90: warning:
ambiguity between regexp and two divisions: wrap regexp in parentheses
or add a space after `/' operator
```

## What is your fix for the problem, implemented in this PR?

Parenthesize appropriately.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
