### PR TITLE
Preserve relative path sources in standalone setup

### DIFF
--- a/bundler/lib/bundler/installer/standalone.rb
+++ b/bundler/lib/bundler/installer/standalone.rb
@@ -52,7 +52,7 @@ module Bundler
 
     def gem_path(path, spec)
       full_path = Pathname.new(path).absolute? ? path : File.join(spec.full_gem_path, path)
-      if spec.source.instance_of?(Source::Path)
+      if spec.source.instance_of?(Source::Path) && spec.source.path.absolute?
         full_path
       else
         Pathname.new(full_path).relative_path_from(Bundler.root.join(bundler_path)).to_s


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Fixes https://github.com/rubygems/rubygems/issues/5317

When specifying gems with the `:path` option, `bundler --standalone` generates a `bundler/setup.rb` with absolute paths for those gems.

This makes good sense when the `:path` is absolute (the behavior was explicitly added in https://github.com/rubygems/rubygems/pull/4792 to handle absolute paths).

But when the `:path` option is relative, it is not always desirable to have absolute paths in `bundler/setup.rb`. For example, I work on an application that runs `bundler --standalone` in CI to build a deploy artifact, but because the root directory in CI does not match the root in production we are unable to use the generated bundler/setup.rb directly.

## What is your fix for the problem, implemented in this PR?

As suggested in https://github.com/rubygems/rubygems/issues/5317#issuecomment-1024438825, this commit reverts back to bundler-setup-relative paths in if the `:path` option is relative. It preserves the current behavior of using absolute paths only when the `:path` option is absolute.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
