### PR TITLE
Fix inconsistent behavior of zero byte files in archive

### DIFF
--- a/lib/rubygems/package/tar_reader/entry.rb
+++ b/lib/rubygems/package/tar_reader/entry.rb
@@ -130,9 +130,10 @@ class Gem::Package::TarReader::Entry
   def read(len = nil)
     check_closed
 
-    return nil if @read >= @header.size
-
     len ||= @header.size - @read
+
+    return nil if len > 0 && @read >= @header.size
+
     max_read = [len, @header.size - @read].min
 
     ret = @io.read max_read
@@ -144,9 +145,10 @@ class Gem::Package::TarReader::Entry
   def readpartial(maxlen = nil, outbuf = "".b)
     check_closed
 
-    raise EOFError if @read >= @header.size
-
     maxlen ||= @header.size - @read
+
+    raise EOFError if maxlen > 0 && @read >= @header.size
+
     max_read = [maxlen, @header.size - @read].min
 
     @io.readpartial(max_read, outbuf)

--- a/test/rubygems/test_gem_package_tar_reader_entry.rb
+++ b/test/rubygems/test_gem_package_tar_reader_entry.rb
@@ -125,6 +125,18 @@ class TestGemPackageTarReaderEntry < Gem::Package::TarTestCase
     assert_equal @contents, @entry.read
   end
 
+  def test_consecutive_read
+    expected = StringIO.new(@contents)
+    assert_equal expected.read, @entry.read
+    assert_equal expected.read, @entry.read
+  end
+
+  def test_consecutive_read_bytes_past_eof
+    expected = StringIO.new(@contents)
+    assert_equal expected.read, @entry.read
+    assert_equal expected.read(1), @entry.read(1)
+  end
+
   def test_read_big
     assert_equal @contents, @entry.read(@contents.size * 2)
   end
@@ -133,9 +145,24 @@ class TestGemPackageTarReaderEntry < Gem::Package::TarTestCase
     assert_equal @contents[0...100], @entry.read(100)
   end
 
-  def test_readpartial
+  def test_read_remaining
+    @entry.read(100)
+    assert_equal @contents[100..-1], @entry.read
+  end
+
+  def test_read_partial
+    assert_equal @contents[0...100], @entry.readpartial(100)
+  end
+
+  def test_read_partial_buffer
+    buffer = "".b
+    @entry.readpartial(100, buffer)
+    assert_equal @contents[0...100], buffer
+  end
+
+  def test_readpartial_past_eof
+    @entry.readpartial(@contents.size)
     assert_raise(EOFError) do
-      @entry.read(@contents.size)
       @entry.readpartial(1)
     end
   end
@@ -148,5 +175,36 @@ class TestGemPackageTarReaderEntry < Gem::Package::TarTestCase
     assert_equal 0, @entry.pos
 
     assert_equal char, @entry.getc
+  end
+
+  def test_read_zero
+    expected = StringIO.new("")
+    assert_equal expected.read(0), @entry.read(0)
+  end
+
+  def test_readpartial_zero
+    expected = StringIO.new("")
+    assert_equal expected.readpartial(0), @entry.readpartial(0)
+  end
+
+  def util_zero_byte_entry
+    tar = String.new
+    tar << tar_file_header("lib/empty", "", 0, 0, Time.now)
+    tar << "\0" * (512 - (tar.size % 512))
+    util_entry tar
+  end
+
+  def test_zero_byte_file_read
+    zero_entry = util_zero_byte_entry
+    expected = StringIO.new("")
+
+    assert_equal expected.read, zero_entry.read
+  end
+
+  def test_zero_byte_file_readpartial
+    zero_entry = util_zero_byte_entry
+    expected = StringIO.new("")
+
+    assert_equal expected.readpartial(0), zero_entry.readpartial(0)
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When working on unpacking gems for rubygems/rfcs#44 I found that one of our test `.gem` files has a zero byte file in it. This is perfectly valid, but caused inconsistent behavior when calculating SHA digests or mime types.

The TarReader in the gem can extract the file, but `TarReader::Entry#read` returns `nil` when it should return a blank string.

This required me to make exceptions when the output of read was nil, when the real solution is that `#read` should behave just like any other reference implementation of read.

## What is your fix for the problem, implemented in this PR?

I made a few new tests that verify the behavior of a 0 byte file in a tar archive. I used `StringIO` as a reference for how `Entry` should behave.

I also locally verified that this is how an open `File` object behaves.

I will submit the following fixes:
- `#read` after already reading to the end of the file should return a blank string.
- `#read` and `#readpartial` should return an empty string if 0 bytes are requested. This was true already, except when the `pos` is at the end of the file. Both `File#readpartial(0)` and `StringIO#readpartial(0)` continue to return `""` even if `readpartial(1)` would EOF.
- `#readpartial` only raises EOF if you attempt to read at least 1 byte past EOF when the `pos` is already at EOF.

I did not fix one inconsistency: `StringIO#readpartial()` (no arguments) gives an argument error. You must supply a length. `TarReader::Entry#readpartial` defaults the maxlen to nil and then calculates the remaining length. I didn't change this behavior since I'm not able to check that every usage of `#readpartial` does include an argument.

The changes I did make are unlikely to break anything since anyone working around our behavior to account for its inconsistency would instead receive a blank string as if the file was empty. Given that you already have the file name, the file size, and any other settings like filemode, it's reasonable to send back a blank string if that is the actual contents of the file.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
