### PR TITLE
Better deal with circular dependencies

### DIFF
--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -38,7 +38,7 @@ module Bundler
 
       @all_specs = Hash.new do |specs, name|
         specs[name] = source_for(name).specs.search(name).reject do |s|
-          s.dependencies.any? {|d| d.name == name } # ignore versions that depend on themselves
+          s.dependencies.any? {|d| d.name == name && !d.requirement.satisfied_by?(s.version) } # ignore versions that depend on themselves incorrectly
         end.sort_by {|s| [s.version, s.platform.to_s] }
       end
 
@@ -57,7 +57,7 @@ module Bundler
           { root_version => root_dependencies }
         else
           Hash.new do |versions, version|
-            versions[version] = to_dependency_hash(version.dependencies, @packages)
+            versions[version] = to_dependency_hash(version.dependencies.reject {|d| d.name == package.name }, @packages)
           end
         end
       end

--- a/bundler/lib/bundler/vendor/pub_grub/lib/pub_grub/incompatibility.rb
+++ b/bundler/lib/bundler/vendor/pub_grub/lib/pub_grub/incompatibility.rb
@@ -8,9 +8,6 @@ module Bundler::PubGrub
     InvalidDependency = Struct.new(:package, :constraint) do
     end
 
-    CircularDependency = Struct.new(:package, :constraint) do
-    end
-
     NoVersions = Struct.new(:constraint) do
     end
 
@@ -66,8 +63,6 @@ module Bundler::PubGrub
         "#{terms[0].to_s(allow_every: true)} depends on #{terms[1].invert}"
       when Bundler::PubGrub::Incompatibility::InvalidDependency
         "#{terms[0].to_s(allow_every: true)} depends on unknown package #{cause.package}"
-      when Bundler::PubGrub::Incompatibility::CircularDependency
-        "#{terms[0].to_s(allow_every: true)} depends on itself"
       when Bundler::PubGrub::Incompatibility::NoVersions
         "no versions satisfy #{cause.constraint}"
       when Bundler::PubGrub::Incompatibility::ConflictCause

--- a/bundler/spec/resolver/basic_spec.rb
+++ b/bundler/spec/resolver/basic_spec.rb
@@ -301,4 +301,27 @@ RSpec.describe "Resolving" do
       end
     end
   end
+
+  it "ignores versions that depend on themselves" do
+    @index = build_index do
+      gem "rack", "3.0.0"
+
+      gem "standalone_migrations", "7.1.0" do
+        dep "rack", "~> 2.0"
+      end
+
+      gem "standalone_migrations", "2.0.4" do
+        dep "standalone_migrations", ">= 0"
+      end
+
+      gem "standalone_migrations", "1.0.13" do
+        dep "rack", ">= 0"
+      end
+    end
+
+    dep "rack", "~> 3.0"
+    dep "standalone_migrations"
+
+    should_resolve_as %w[rack-3.0.0 standalone_migrations-1.0.13]
+  end
 end

--- a/bundler/spec/resolver/basic_spec.rb
+++ b/bundler/spec/resolver/basic_spec.rb
@@ -302,7 +302,7 @@ RSpec.describe "Resolving" do
     end
   end
 
-  it "ignores versions that depend on themselves" do
+  it "handles versions that redundantly depend on themselves" do
     @index = build_index do
       gem "rack", "3.0.0"
 
@@ -312,6 +312,29 @@ RSpec.describe "Resolving" do
 
       gem "standalone_migrations", "2.0.4" do
         dep "standalone_migrations", ">= 0"
+      end
+
+      gem "standalone_migrations", "1.0.13" do
+        dep "rack", ">= 0"
+      end
+    end
+
+    dep "rack", "~> 3.0"
+    dep "standalone_migrations"
+
+    should_resolve_as %w[rack-3.0.0 standalone_migrations-2.0.4]
+  end
+
+  it "ignores versions that incorrectly depend on themselves" do
+    @index = build_index do
+      gem "rack", "3.0.0"
+
+      gem "standalone_migrations", "7.1.0" do
+        dep "rack", "~> 2.0"
+      end
+
+      gem "standalone_migrations", "2.0.4" do
+        dep "standalone_migrations", ">= 2.0.5"
       end
 
       gem "standalone_migrations", "1.0.13" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When a dependency includes a version with circular dependencies, and the resolver ends up considering it, it gives up with a confusing error.

## What is your fix for the problem, implemented in this PR?

Ignore these ill-defined versions.

Fixes #6328.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
