### PR TITLE
Introduce to specify deprecated version for rubygems_deprecate_command.

### DIFF
--- a/lib/rubygems/deprecate.rb
+++ b/lib/rubygems/deprecate.rb
@@ -143,7 +143,7 @@ module Gem::Deprecate
   end
 
   # Deprecation method to deprecate Rubygems commands
-  def rubygems_deprecate_command
+  def rubygems_deprecate_command(version = Gem::Deprecate.next_rubygems_major_version)
     class_eval do
       define_method "deprecated?" do
         true
@@ -151,7 +151,7 @@ module Gem::Deprecate
 
       define_method "deprecation_warning" do
         msg = [ "#{self.command} command is deprecated",
-                ". It will be removed in Rubygems #{Gem::Deprecate.next_rubygems_major_version}.\n",
+                ". It will be removed in Rubygems #{version}.\n",
         ]
 
         alert_warning "#{msg.join}" unless Gem::Deprecate.skip


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I'll show warning message to remove `gem server` command for RubyGems 3.2.x. But current `rubygems_deprecate_command` only show major version for removing methods.

From: https://github.com/rubygems/rubygems/issues/6044

## What is your fix for the problem, implemented in this PR?

I added to specify version to `rubygems_deprecate_command`. After merging this, I'll backport this to RubyGems 3.2.x and update warning message for `gem server` command like:

```
rubygems_deprecate_command("3.3.0")
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
