### PR TITLE
Warn on self referencing gemspec dependency.

### DIFF
--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -173,6 +173,7 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
   end
 
   ##
+  # Checks that the gem does not depend on itself.
   # Checks that dependencies use requirements as we recommend.  Warnings are
   # issued when dependencies are open-ended or overly strict for semantic
   # versioning.
@@ -180,6 +181,10 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
   def validate_dependencies # :nodoc:
     warning_messages = []
     @specification.dependencies.each do |dep|
+      if dep.name == @specification.name # warn on self reference
+        warning_messages << "Self referencing dependency is unnecessary and strongly discouraged."
+      end
+
       prerelease_dep = dep.requirements_list.any? do |req|
         Gem::Requirement.new(req).prerelease?
       end

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2677,6 +2677,23 @@ duplicate dependency on c (>= 1.2.3, development), (~> 1.2) use:
     end
   end
 
+  def test_validate_self_referencing_dependencies
+    util_setup_validate
+
+    Dir.chdir @tempdir do
+      @a1.add_runtime_dependency @a1.name, "1"
+
+      use_ui @ui do
+        @a1.validate
+      end
+
+      assert_equal <<-EXPECTED, @ui.error
+#{w}:  Self referencing dependency is unnecessary and strongly discouraged.
+#{w}:  See https://guides.rubygems.org/specification-reference/ for help
+      EXPECTED
+    end
+  end
+
   def test_validate_rake_extension_have_rake_dependency_warning
     util_setup_validate
 


### PR DESCRIPTION
- it makes no sense and can break resolving

@deivid-rodriguez as promised at https://github.com/rubygems/rubygems/pull/6330#issuecomment-1413891433

It warns only for now. Feel free to ping me if error makes more sense in here, I can quickly update. As usual I would appreciate any suggestion on the warn/error message.