### PR TITLE
Fix Tempfile leaks

### DIFF
--- a/test/rubygems/test_gem_package_tar_header.rb
+++ b/test/rubygems/test_gem_package_tar_header.rb
@@ -159,6 +159,7 @@ group\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000
       assert_raise ArgumentError do
         Gem::Package::TarHeader.from io
       end
+    ensure
       io.close!
     end
   end

--- a/test/rubygems/test_gem_package_tar_reader_entry.rb
+++ b/test/rubygems/test_gem_package_tar_reader_entry.rb
@@ -199,6 +199,8 @@ class TestGemPackageTarReaderEntry < Gem::Package::TarTestCase
     expected = StringIO.new("")
 
     assert_equal expected.read, zero_entry.read
+  ensure
+    close_util_entry(zero_entry) if zero_entry
   end
 
   def test_zero_byte_file_readpartial
@@ -206,5 +208,7 @@ class TestGemPackageTarReaderEntry < Gem::Package::TarTestCase
     expected = StringIO.new("")
 
     assert_equal expected.readpartial(0), zero_entry.readpartial(0)
+  ensure
+    close_util_entry(zero_entry) if zero_entry
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

[`Tempfile` leaks](https://github.com/ruby/ruby/actions/runs/4076954001/jobs/7025376975#step:16:100) happen.
```
Leaked file descriptor: TestGemPackageTarReaderEntry#test_zero_byte_file_read: 11 : #<File:/tmp/TempIO20230202-19122-5joh8m>
COMMAND   PID   USER   FD   TYPE DEVICE SIZE/OFF NODE NAME
ruby    19122 runner   11u   REG   8,17     1024 2542 /tmp/TempIO20230202-19122-5joh8m
Multiple autoclose IO objects for a file descriptor in: TestGemPackageTarReaderEntry#test_zero_byte_file_read:  #<IO:<STDIN>>(autoclose) #<IO:fd 0>(autoclose)
Leaked tempfile: TestGemPackageTarReaderEntry#test_zero_byte_file_read: #<TempIO:/tmp/TempIO20230202-19122-5joh8m>
.Closed file descriptor: TestGemPackageTarReaderEntry#test_eof_eh: 11
Leaked file descriptor: TestGemPackageTarReaderEntry#test_zero_byte_file_readpartial: 11 : #<File:/tmp/TempIO20230202-19122-vlkx4g>
COMMAND   PID   USER   FD   TYPE DEVICE SIZE/OFF NODE NAME
ruby    19122 runner   11u   REG   8,17     1024 2542 /tmp/TempIO20230202-19122-vlkx4g
Multiple autoclose IO objects for a file descriptor in: TestGemPackageTarReaderEntry#test_zero_byte_file_readpartial:  #<IO:<STDIN>>(autoclose) #<IO:fd 0>(autoclose)
Leaked tempfile: TestGemPackageTarReaderEntry#test_zero_byte_file_readpartial: #<TempIO:/tmp/TempIO20230202-19122-vlkx4g>
Closed file descriptor: TestGemPackageTarReaderEntry#test_directory_eh: 11
```
## What is your fix for the problem, implemented in this PR?

Close `zero_entry`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
