### PR TITLE
Exclude gemspec file itself from gem (take 2)

### DIFF
--- a/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(__dir__) do
     `git ls-files -z`.split("\x0").reject do |f|
-      (f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features)/|\.(?:git|circleci)|appveyor)})
+      (File.expand_path(f) == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features)/|\.(?:git|circleci)|appveyor)})
     end
   end
   spec.bindir = "exe"

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -633,7 +633,7 @@ RSpec.describe "bundle gem" do
     it "does not include the gemspec file in files" do
       bundle "gem #{gem_name}"
 
-      bundler_gemspec = Bundler::GemHelper.new(gemspec_dir).gemspec
+      bundler_gemspec = Bundler::GemHelper.new(bundled_app(gem_name), gem_name).gemspec
 
       expect(bundler_gemspec.files).not_to include("#{gem_name}.gemspec")
     end


### PR DESCRIPTION
This patch follows up f444478eaccf036fdc46407c5b82e0f3ed5a2ad5 by @nobu 

## What was the end-user or developer problem that led to this PR?

There used to be a commit f444478eaccf036fdc46407c5b82e0f3ed5a2ad5 that intended to exclude the gemspec file from gem package, but the gemspec file is in fact still included in gems that we build today, even though the test included in that commit (that asserts it "does not include the gemspec file in files") is passing.

This was because:
1. The patch was incomplete, and it failed to actually exclude the gemspec file
2. The test code was referencing a wrong gemspec which of course *does not include* the newly generated gemspec file during the test. So the test wasn't really testing anything

## What is your fix for the problem, implemented in this PR?

This patch fixes both broken test and the newgem template. Now the gemspec file should be properly excluded as intended.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)