### PR TITLE
Use `RbSys::ExtensionTask` when creating new rust gems

### DIFF
--- a/bundler/lib/bundler/templates/newgem/Gemfile.tt
+++ b/bundler/lib/bundler/templates/newgem/Gemfile.tt
@@ -10,7 +10,7 @@ gem "rake", "~> 13.0"
 
 gem "rake-compiler"
 <%- if config[:ext] == 'rust' -%>
-gem "rb_sys"
+gem "rb_sys", "~> 0.9.63"
 <%- end -%>
 <%- end -%>
 <%- if config[:test] -%>

--- a/bundler/lib/bundler/templates/newgem/Rakefile.tt
+++ b/bundler/lib/bundler/templates/newgem/Rakefile.tt
@@ -41,6 +41,15 @@ require "standard/rake"
 <% if config[:ext] -%>
 <% default_task_names.unshift(:compile) -%>
 <% default_task_names.unshift(:clobber) unless config[:ext] == 'rust' -%>
+<% if config[:ext] == 'rust' -%>
+require "rb_sys/extensiontask"
+
+task build: :compile
+
+RbSys::ExtensionTask.new(<%= config[:name].inspect %>) do |ext|
+  ext.lib_dir = "lib/<%= config[:namespaced_path] %>"
+end
+<% else -%>
 require "rake/extensiontask"
 
 task build: :compile
@@ -48,6 +57,7 @@ task build: :compile
 Rake::ExtensionTask.new("<%= config[:underscored_name] %>") do |ext|
   ext.lib_dir = "lib/<%= config[:namespaced_path] %>"
 end
+<% end -%>
 
 <% end -%>
 <% if default_task_names.size == 1 -%>

--- a/bundler/lib/bundler/templates/newgem/github/workflows/main.yml.tt
+++ b/bundler/lib/bundler/templates/newgem/github/workflows/main.yml.tt
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v3
 <%- if config[:ext] == 'rust' -%>
     - name: Set up Ruby & Rust
-      uses: oxidize-rb/actions/setup-ruby-and-rust@main
+      uses: oxidize-rb/actions/setup-ruby-and-rust@v1
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -1473,11 +1473,11 @@ RSpec.describe "bundle gem" do
           # frozen_string_literal: true
 
           require "bundler/gem_tasks"
-          require "rake/extensiontask"
+          require "rb_sys/extensiontask"
 
           task build: :compile
 
-          Rake::ExtensionTask.new("#{gem_name}") do |ext|
+          RbSys::ExtensionTask.new("#{gem_name}") do |ext|
             ext.lib_dir = "lib/#{gem_name}"
           end
 

--- a/bundler/tool/bundler/dev_gems.rb.lock
+++ b/bundler/tool/bundler/dev_gems.rb.lock
@@ -10,7 +10,7 @@ GEM
       parallel
     power_assert (2.0.2)
     rake (13.0.6)
-    rb_sys (0.9.52)
+    rb_sys (0.9.63)
     rdiscount (2.2.7)
     ronn (0.7.3)
       hpricot (>= 0.8.2)

--- a/bundler/tool/bundler/rubocop_gems.rb.lock
+++ b/bundler/tool/bundler/rubocop_gems.rb.lock
@@ -14,7 +14,7 @@ GEM
     rake (13.0.6)
     rake-compiler (1.2.0)
       rake
-    rb_sys (0.9.52)
+    rb_sys (0.9.63)
     regexp_parser (2.6.1)
     rexml (3.2.5)
     rspec (3.12.0)

--- a/bundler/tool/bundler/standard_gems.rb.lock
+++ b/bundler/tool/bundler/standard_gems.rb.lock
@@ -15,7 +15,7 @@ GEM
     rake (13.0.6)
     rake-compiler (1.2.0)
       rake
-    rb_sys (0.9.52)
+    rb_sys (0.9.63)
     regexp_parser (2.6.1)
     rexml (3.2.5)
     rspec (3.12.0)

--- a/bundler/tool/bundler/test_gems.rb.lock
+++ b/bundler/tool/bundler/test_gems.rb.lock
@@ -11,7 +11,7 @@ GEM
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rake (13.0.1)
-    rb_sys (0.9.52)
+    rb_sys (0.9.63)
     ruby2_keywords (0.0.5)
     sinatra (2.0.8.1)
       mustermann (~> 1.0)


### PR DESCRIPTION
This PR makes it so `bundle gem --ext=rust` will use [`RbSys::ExtensionTask`](https://www.rubydoc.info/gems/rb_sys/0.9.63/RbSys/ExtensionTask). This is a thin wrapper over `Rake::ExtensionTask`, which is tailored for Rust and addresses a number of shortcomings of using the default configuration. Namely:

- Removes duplicative `target` directories (reducing compilation times and cache bloat)
- Uses `cargo metadata` to find extension dir (similar to @matsadler PR).
- Adds some helpers for compiling debug-friendly builds

### Links

- [See more in the PR here](https://github.com/oxidize-rb/rb-sys/pull/144)
- [PR integrating this into wasmtime-rb](https://github.com/bytecodealliance/wasmtime-rb/pull/132)
