### PR TITLE
Restore better error message when locked ref does not exist

### DIFF
--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -139,8 +139,8 @@ module Bundler
             out, err, status = capture(command, path)
             return out if status.success?
 
-            if err.include?("couldn't find remote ref")
-              raise MissingGitRevisionError.new(command_with_no_credentials, path, explicit_ref, credential_filtered_uri)
+            if err.include?("couldn't find remote ref") || err.include?("not our ref")
+              raise MissingGitRevisionError.new(command_with_no_credentials, path, commit || explicit_ref, credential_filtered_uri)
             else
               raise GitCommandError.new(command_with_no_credentials, path, err)
             end
@@ -186,8 +186,6 @@ module Bundler
         end
 
         def refspec
-          commit = pinned_to_full_sha? ? ref : @revision
-
           if commit
             @commit_ref = "refs/#{commit}-sha"
             return "#{commit}:#{@commit_ref}"
@@ -204,6 +202,10 @@ module Bundler
           end
 
           "#{reference}:#{reference}"
+        end
+
+        def commit
+          @commit ||= pinned_to_full_sha? ? ref : @revision
         end
 
         def fully_qualified_ref

--- a/bundler/spec/lock/git_spec.rb
+++ b/bundler/spec/lock/git_spec.rb
@@ -33,6 +33,33 @@ RSpec.describe "bundle lock with git gems" do
     expect(err).to include("Revision bad does not exist in the repository")
   end
 
+  it "prints a proper error when installing a Gemfile with a locked ref that does not exist" do
+    lockfile <<~L
+      GIT
+        remote: #{lib_path("foo-1.0")}
+        revision: #{"a" * 40}
+        specs:
+          foo (1.0)
+
+      GEM
+        remote: #{file_uri_for(gem_repo1)}/
+        specs:
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        foo!
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+    bundle "install", :raise_on_error => false
+
+    expect(err).to include("Revision #{"a" * 40} does not exist in the repository")
+  end
+
   it "locks a git source to the current ref" do
     update_git "foo"
     bundle :install


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When user tries to install a Gemfile.lock file that includes a locked reference that does not exist, it will get a verbose and not too helpful error.

```
$ bundle install
Fetching gem metadata from https://rubygems.org/.
Fetching https://github.com/dependabot-fixtures/prius

Retrying `git fetch --force --quiet --no-tags --unshallow -- https://github.com/dependabot-fixtures/prius cff701b3bfb182afc99a85657d7c9f3d6c1ccce1:refs/cff701b3bfb182afc99a85657d7c9f3d6c1ccce1-sha` at /Users/deivid/Code/dependabot/dependabot-core/bundler/spec/fixtures/projects/bundler2/bad_ref/foo/ruby/3.2.0/cache/bundler/git/prius-17ebc9a1c48915a50268b9922f2901ebf171d281 due to error (2/4): Bundler::Source::Git::GitCommandError Git error: command `git fetch --force --quiet --no-tags --unshallow -- https://github.com/dependabot-fixtures/prius cff701b3bfb182afc99a85657d7c9f3d6c1ccce1:refs/cff701b3bfb182afc99a85657d7c9f3d6c1ccce1-sha` in directory /Users/deivid/Code/dependabot/dependabot-core/bundler/spec/fixtures/projects/bundler2/bad_ref/foo/ruby/3.2.0/cache/bundler/git/prius-17ebc9a1c48915a50268b9922f2901ebf171d281 has failed.
fatal: remote error: upload-pack: not our ref cff701b3bfb182afc99a85657d7c9f3d6c1ccce1

Retrying `git fetch --force --quiet --no-tags --unshallow -- https://github.com/dependabot-fixtures/prius cff701b3bfb182afc99a85657d7c9f3d6c1ccce1:refs/cff701b3bfb182afc99a85657d7c9f3d6c1ccce1-sha` at /Users/deivid/Code/dependabot/dependabot-core/bundler/spec/fixtures/projects/bundler2/bad_ref/foo/ruby/3.2.0/cache/bundler/git/prius-17ebc9a1c48915a50268b9922f2901ebf171d281 due to error (3/4): Bundler::Source::Git::GitCommandError Git error: command `git fetch --force --quiet --no-tags --unshallow -- https://github.com/dependabot-fixtures/prius cff701b3bfb182afc99a85657d7c9f3d6c1ccce1:refs/cff701b3bfb182afc99a85657d7c9f3d6c1ccce1-sha` in directory /Users/deivid/Code/dependabot/dependabot-core/bundler/spec/fixtures/projects/bundler2/bad_ref/foo/ruby/3.2.0/cache/bundler/git/prius-17ebc9a1c48915a50268b9922f2901ebf171d281 has failed.
fatal: remote error: upload-pack: not our ref cff701b3bfb182afc99a85657d7c9f3d6c1ccce1

Retrying `git fetch --force --quiet --no-tags --unshallow -- https://github.com/dependabot-fixtures/prius cff701b3bfb182afc99a85657d7c9f3d6c1ccce1:refs/cff701b3bfb182afc99a85657d7c9f3d6c1ccce1-sha` at /Users/deivid/Code/dependabot/dependabot-core/bundler/spec/fixtures/projects/bundler2/bad_ref/foo/ruby/3.2.0/cache/bundler/git/prius-17ebc9a1c48915a50268b9922f2901ebf171d281 due to error (4/4): Bundler::Source::Git::GitCommandError Git error: command `git fetch --force --quiet --no-tags --unshallow -- https://github.com/dependabot-fixtures/prius cff701b3bfb182afc99a85657d7c9f3d6c1ccce1:refs/cff701b3bfb182afc99a85657d7c9f3d6c1ccce1-sha` in directory /Users/deivid/Code/dependabot/dependabot-core/bundler/spec/fixtures/projects/bundler2/bad_ref/foo/ruby/3.2.0/cache/bundler/git/prius-17ebc9a1c48915a50268b9922f2901ebf171d281 has failed.
fatal: remote error: upload-pack: not our ref cff701b3bfb182afc99a85657d7c9f3d6c1ccce1

Git error: command `git fetch --force --quiet --no-tags --unshallow -- https://github.com/dependabot-fixtures/prius
cff701b3bfb182afc99a85657d7c9f3d6c1ccce1:refs/cff701b3bfb182afc99a85657d7c9f3d6c1ccce1-sha` in directory
/Users/deivid/Code/dependabot/dependabot-core/bundler/spec/fixtures/projects/bundler2/bad_ref/foo/ruby/3.2.0/cache/bundler/git/prius-17ebc9a1c48915a50268b9922f2901ebf171d281
has failed.
fatal: remote error: upload-pack: not our ref cff701b3bfb182afc99a85657d7c9f3d6c1ccce1
```

## What is your fix for the problem, implemented in this PR?

My fix is to restore the kind of error Bundler 2.3 used to give:

```
$ bundle install
Fetching gem metadata from https://rubygems.org/.
Fetching https://github.com/dependabot-fixtures/prius

Git error: command `git fetch --force --quiet --no-tags --unshallow -- https://github.com/dependabot-fixtures/prius
cff701b3bfb182afc99a85657d7c9f3d6c1ccce1:refs/cff701b3bfb182afc99a85657d7c9f3d6c1ccce1-sha` in directory
/Users/deivid/Code/dependabot/dependabot-core/bundler/spec/fixtures/projects/bundler2/bad_ref/foo/ruby/3.2.0/cache/bundler/git/prius-17ebc9a1c48915a50268b9922f2901ebf171d281
has failed.
Revision cff701b3bfb182afc99a85657d7c9f3d6c1ccce1 does not exist in the repository https://github.com/dependabot-fixtures/prius. Maybe you misspelled it?
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
