### PR TITLE
Improve wording of unmet dependencies warning

### DIFF
--- a/bundler/lib/bundler/installer/parallel_installer.rb
+++ b/bundler/lib/bundler/installer/parallel_installer.rb
@@ -110,12 +110,12 @@ module Bundler
 
       warning = []
       warning << "Your lockfile doesn't include a valid resolution."
-      warning << "You can fix this by regenerating your lockfile or trying to manually editing the bad locked gems to a version that satisfies all dependencies."
+      warning << "You can fix this by regenerating your lockfile or manually editing the bad locked gems to a version that satisfies all dependencies."
       warning << "The unmet dependencies are:"
 
       unmet_dependencies.each do |spec, unmet_spec_dependencies|
         unmet_spec_dependencies.each do |unmet_spec_dependency|
-          warning << "* #{unmet_spec_dependency}, depended upon #{spec.full_name}, unsatisfied by #{@specs.find {|s| s.name == unmet_spec_dependency.name && !unmet_spec_dependency.matches_spec?(s.spec) }.full_name}"
+          warning << "* #{unmet_spec_dependency}, dependency of #{spec.full_name}, unsatisfied by #{@specs.find {|s| s.name == unmet_spec_dependency.name && !unmet_spec_dependency.matches_spec?(s.spec) }.full_name}"
         end
       end
 

--- a/bundler/spec/bundler/installer/parallel_installer_spec.rb
+++ b/bundler/spec/bundler/installer/parallel_installer_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe Bundler::ParallelInstaller do
     it "prints a warning" do
       expect(Bundler.ui).to receive(:warn).with(<<-W.strip)
 Your lockfile doesn't include a valid resolution.
-You can fix this by regenerating your lockfile or trying to manually editing the bad locked gems to a version that satisfies all dependencies.
+You can fix this by regenerating your lockfile or manually editing the bad locked gems to a version that satisfies all dependencies.
 The unmet dependencies are:
-* diff-lcs (< 1.4), depended upon cucumber-4.1.0, unsatisfied by diff-lcs-1.4.4
+* diff-lcs (< 1.4), dependency of cucumber-4.1.0, unsatisfied by diff-lcs-1.4.4
       W
       subject.check_for_unmet_dependencies
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I noticed some small grammar problems in the unmet dependencies warning while working on https://github.com/rubygems/rubygems/pull/6355

## What is your fix for the problem, implemented in this PR?

`trying to manually editing` doesn't seem quite grammatically correct. We could change it to `trying to manually edit` (is that a split infinitive?), but I don't think `trying to` adds much here so I've removed it instead so `editing` is the verb.

For the list of dependencies, the wording before this commit seemed to reverse the dependency. "B, depended on A" sounds like B depends on A (or did in the past but doesn't anymore?), but that's not correct. I think there's a missing word: "B, depended on by A", but I find "B, dependency of A" a bit nicer.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
