### PR TITLE
Make custom cop inherit `RuboCop::Cop::Base`

### DIFF
--- a/util/cops/deprecations.rb
+++ b/util/cops/deprecations.rb
@@ -14,19 +14,12 @@ module RuboCop
       #   # good
       #   # the `deprecate` call is fully removed
       #
-      class Deprecations < Cop
+      class Deprecations < Base
+        MSG = "Remove `%<method_name>s` calls for the next major release."
+        RESTRICT_ON_SEND = %i[rubygems_deprecate rubygems_deprecate_command].freeze
+
         def on_send(node)
-          _receiver, method_name, *args = *node
-          return unless method_name == :rubygems_deprecate || method_name == :rubygems_deprecate_command
-
-          add_offense(node)
-        end
-
-        private
-
-        def message(node)
-          msg = "Remove `#{node.method_name}` calls for the next major release "
-          format(msg, method: node.method_name)
+          add_offense(node, message: format(MSG, method_name: node.method_name))
         end
       end
     end


### PR DESCRIPTION
Follow https://github.com/rubocop/rubocop/pull/7868.

## What was the end-user or developer problem that led to this PR?

The legacy `RuboCop::Cop::Cop` API is soft deprecated and will be removed in RuboCop 2.0.

> maintain any RuboCop extensions, as the legacy API will be removed in RuboCop 2.0.

https://metaredux.com/posts/2020/10/21/rubocop-1-0.html

## What is your fix for the problem, implemented in this PR?

This PR makes custom cop inherit `RuboCop::Cop::Base` API instead.

I've confirmed that the following behavior is compatible:

```console
$ bundle exec util/rubocop -r ./util/cops/deprecations --only Rubygems/Deprecations
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
