### PR TITLE
Fix crash in pub grub involving empty ranges

### DIFF
--- a/bundler/lib/bundler/vendor/pub_grub/lib/pub_grub/version_range.rb
+++ b/bundler/lib/bundler/vendor/pub_grub/lib/pub_grub/version_range.rb
@@ -19,7 +19,7 @@ module Bundler::PubGrub
         true
       end
 
-      def eql?
+      def eql?(other)
         other.empty?
       end
 

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -483,7 +483,17 @@ module Spec
     end
 
     def next_ruby_minor
-      Gem.ruby_version.segments[0..1].map.with_index {|s, i| i == 1 ? s + 1 : s }.join(".")
+      ruby_major_minor.map.with_index {|s, i| i == 1 ? s + 1 : s }.join(".")
+    end
+
+    def previous_ruby_minor
+      return "2.7" if ruby_major_minor == [3, 0]
+
+      ruby_major_minor.map.with_index {|s, i| i == 1 ? s - 1 : s }.join(".")
+    end
+
+    def ruby_major_minor
+      Gem.ruby_version.segments[0..1]
     end
 
     # versions not including


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This is another edge case surfacing an issue in pub grub upstream.

Some versions publish platform versions with incompatible Ruby support between each other. For example, `unf_ext` or `google-protobuf`. If both are used in the same resolution, we may end up checking hash equality against empty ranges and causing a resolver crash.

## What is your fix for the problem, implemented in this PR?

Add the missing parameter in Pub Grub and get this edge case tested on our side.

Fixes #6326.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
