### PR TITLE
Improve solve failure explanations by using better wording

### DIFF
--- a/bundler/lib/bundler/vendor/pub_grub/lib/pub_grub/incompatibility.rb
+++ b/bundler/lib/bundler/vendor/pub_grub/lib/pub_grub/incompatibility.rb
@@ -71,9 +71,13 @@ module Bundler::PubGrub
         elsif terms.length == 1
           term = terms[0]
           if term.positive?
-            "#{terms[0].to_s(allow_every: true)} is forbidden"
+            if term.constraint.any?
+              "#{term.package} cannot be used"
+            else
+              "#{term.to_s(allow_every: true)} cannot be used"
+            end
           else
-            "#{terms[0].invert} is required"
+            "#{term.invert} is required"
           end
         else
           if terms.all?(&:positive?)

--- a/bundler/lib/bundler/vendor/pub_grub/lib/pub_grub/version_range.rb
+++ b/bundler/lib/bundler/vendor/pub_grub/lib/pub_grub/version_range.rb
@@ -19,7 +19,7 @@ module Bundler::PubGrub
         true
       end
 
-      def eql?
+      def eql?(other)
         other.empty?
       end
 
@@ -65,6 +65,7 @@ module Bundler::PubGrub
     end
 
     EMPTY = Empty.new
+    Empty.singleton_class.undef_method(:new)
 
     def self.empty
       EMPTY
@@ -88,7 +89,8 @@ module Bundler::PubGrub
 
     def eql?(other)
       if other.is_a?(VersionRange)
-        min.eql?(other.min) &&
+        !other.empty? &&
+          min.eql?(other.min) &&
           max.eql?(other.max) &&
           include_min.eql?(other.include_min) &&
           include_max.eql?(other.include_max)

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -880,7 +880,7 @@ RSpec.describe "bundle lock" do
             and rails >= 7.0.2.3, < 7.0.3.1 depends on activesupport = 7.0.2.3,
             every version of activemodel is incompatible with rails >= 7.0.2.3, < 7.0.3.1.
           And because rails >= 7.0.2.3, < 7.0.3.1 depends on activemodel = 7.0.2.3,
-            rails >= 7.0.2.3, < 7.0.3.1 is forbidden.
+            rails >= 7.0.2.3, < 7.0.3.1 cannot be used.
       (1) So, because rails >= 7.0.3.1, < 7.0.4 depends on activemodel = 7.0.3.1
             and rails >= 7.0.4 depends on activemodel = 7.0.4,
             rails >= 7.0.2.3 requires activemodel = 7.0.3.1 OR = 7.0.4.
@@ -892,7 +892,7 @@ RSpec.describe "bundle lock" do
             and every version of activemodel depends on activesupport = 6.0.4,
             activemodel != 7.0.2.3 is incompatible with rails >= 7.0.2.3.
           And because rails >= 7.0.2.3 requires activemodel = 7.0.3.1 OR = 7.0.4 (1),
-            rails >= 7.0.2.3 is forbidden.
+            rails >= 7.0.2.3 cannot be used.
           So, because Gemfile depends on rails >= 7.0.2.3,
             version solving has failed.
     ERR

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -376,7 +376,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
           Because every version of depends_on_missing depends on missing >= 0
             and missing >= 0 could not be found in any of the sources,
-            every version of depends_on_missing is forbidden.
+            depends_on_missing cannot be used.
           So, because Gemfile depends on depends_on_missing >= 0,
             version solving has failed.
         E
@@ -438,7 +438,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
             Because every version of depends_on_rack depends on rack >= 0
               and rack >= 0 could not be found in rubygems repository https://gem.repo2/ or installed locally,
-              every version of depends_on_rack is forbidden.
+              depends_on_rack cannot be used.
             So, because Gemfile depends on depends_on_rack >= 0,
               version solving has failed.
           E

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -432,7 +432,7 @@ RSpec.describe "bundle install with specific platforms" do
 
       Because every version of sorbet depends on sorbet-static = 0.5.6433
         and sorbet-static = 0.5.6433 could not be found in rubygems repository #{file_uri_for(gem_repo4)}/ or installed locally for any resolution platforms (arm64-darwin-21),
-        every version of sorbet is forbidden.
+        sorbet cannot be used.
       So, because Gemfile depends on sorbet = 0.5.6433,
         version solving has failed.
 

--- a/bundler/spec/install/gems/flex_spec.rb
+++ b/bundler/spec/install/gems/flex_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe "bundle flex_install" do
 
         Because rack-obama >= 2.0 depends on rack = 1.2
           and rack = 1.2 could not be found in rubygems repository #{file_uri_for(gem_repo2)}/ or installed locally,
-          rack-obama >= 2.0 is forbidden.
+          rack-obama >= 2.0 cannot be used.
         So, because Gemfile depends on rack-obama = 2.0,
           version solving has failed.
       E


### PR DESCRIPTION
* Replaces the wording of "is forbidden" with "cannot be used" as suggested by @indirect - see https://github.com/jhawthorn/pub_grub/issues/18
* Fixes the method signature of `VersionRange::Empty#eql?` Fixes #6326