### PR TITLE
Use daily check and enabled auto-merge feature for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,12 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'daily'
   - package-ecosystem: 'cargo'
     directory: '/test/rubygems/test_gem_ext_cargo_builder/custom_name/'
     schedule:
-      interval: 'weekly'
+      interval: 'daily'
   - package-ecosystem: 'cargo'
     directory: '/test/rubygems/test_gem_ext_cargo_builder/rust_ruby_example/'
     schedule:
-      interval: 'weekly'
+      interval: 'daily'

--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -1,0 +1,26 @@
+# from https://github.com/gofiber/swagger/blob/main/.github/workflows/dependabot_automerge.yml
+name: Dependabot auto-merge
+on:
+  pull_request_target:
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        uses: dependabot/fetch-metadata@v1
+        id: metadata
+      - name: Wait for status checks
+        uses: lewagon/wait-on-check-action@v1.2.0
+        with:
+          repo-token: ${{ secrets.RUBYGEMS_GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          check-regexp: "^rubygems*|^bundler*"
+          wait-interval: 30
+      - name: Auto-merge for Dependabot PRs
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{ secrets.RUBYGEMS_GITHUB_TOKEN }}

--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           repo-token: ${{ secrets.RUBYGEMS_GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          check-regexp: "^rubygems*|^bundler*"
+          check-regexp: "*"
           wait-interval: 30
       - name: Auto-merge for Dependabot PRs
         if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'}}


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We often received [dependabot updates](https://github.com/rubygems/rubygems/pulls/app%2Fdependabot) every week and triage manually.

## What is your fix for the problem, implemented in this PR?

It's important for preventing supply chain attack. But We can merge them with CI status check automatically because it's only effect to github actions workflow, not gem dependencies.

I added auto-merge workflow with GitHub PAT. Currently, I set my PAT to `RUBYGEMS_GITHUB_TOKEN` for organizational secrets. It's good to use https://github.com/bundlerbot instead of my PAT. /cc @indirect 

@deivid-rodriguez @simi How about this?

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
