### PR TITLE
Fix changelog generation

### DIFF
--- a/util/release.rb
+++ b/util/release.rb
@@ -51,7 +51,7 @@ class Release
     end
 
     def latest_release
-      @latest_release ||= gh_client.releases("rubygems/rubygems").select {|release| release.tag_name.start_with?(@tag_prefix) }.sort_by(&:created_at).last
+      @latest_release ||= gh_client.releases("rubygems/rubygems").select {|release| release.tag_name.start_with?(@tag_prefix) }.max_by(&:tag_name)
     end
 
     attr_reader :relevant_pull_requests


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since the release of RubyGems 3.2.34 and Bundler 2.2.34, our changelog generation script was no longer working, because it was mistaken RubyGems 3.2.34 and Bundler 2.2.34 as the latest releases.

## What is your fix for the problem, implemented in this PR?

Sort by version, not by release date, when finding the latest release.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
