### PR TITLE
Give a better message when Gemfile branch does not exist

### DIFF
--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -1144,6 +1144,17 @@ RSpec.describe "bundle install with git sources" do
       G
       expect(err).to include("Revision deadbeef does not exist in the repository")
     end
+
+    it "gives a helpful error message when the remote branch no longer exists" do
+      build_git "foo"
+
+      install_gemfile <<-G, :raise_on_error => false
+        source "#{file_uri_for(gem_repo1)}"
+        gem "foo", :git => "#{file_uri_for(lib_path("foo-1.0"))}", :branch => "deadbeef"
+      G
+
+      expect(err).to include("Revision deadbeef does not exist in the repository")
+    end
   end
 
   describe "bundle install with deployment mode configured and git sources" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The error message when the branch in the Gemfile does not exist is too verbose, since the command is retried 3 times even if it will never succeed.

## What is your fix for the problem, implemented in this PR?

Restore the good old Bundler 2.3 error.

This PR is analogous to https://github.com/rubygems/rubygems/pull/6356, but for non existent Gemfile branches.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
