### PR TITLE
Issue 6353: safe load all marshaled data

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -525,12 +525,6 @@ EOF
       load_marshal(data, :marshal_proc => SAFE_MARSHAL_PROC)
     end
 
-    def load_marshal(data, marshal_proc: nil)
-      Marshal.load(data, marshal_proc)
-    rescue TypeError => e
-      raise MarshalError, "#{e.class}: #{e.message}"
-    end
-
     def load_gemspec(file, validate = false)
       @gemspec_cache ||= {}
       key = File.expand_path(file)
@@ -618,6 +612,12 @@ EOF
     end
 
     private
+
+    def load_marshal(data, marshal_proc: nil)
+      Marshal.load(data, marshal_proc)
+    rescue TypeError => e
+      raise MarshalError, "#{e.class}: #{e.message}"
+    end
 
     def eval_yaml_gemspec(path, contents)
       Kernel.require "psych"

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -39,7 +39,7 @@ module Bundler
   environment_preserver.replace_with_backup
   SUDO_MUTEX = Thread::Mutex.new
 
-  SAFE_MARSHAL_CLASSES = [Symbol, TrueClass, String, Array, Hash].freeze
+  SAFE_MARSHAL_CLASSES = [Symbol, TrueClass, String, Array, Hash, Gem::Version].freeze
   SAFE_MARSHAL_ERROR = "Unexpected class %s present in marshaled data. Only %s are allowed."
   SAFE_MARSHAL_PROC = proc do |object|
     object.tap do

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -39,7 +39,7 @@ module Bundler
   environment_preserver.replace_with_backup
   SUDO_MUTEX = Thread::Mutex.new
 
-  SAFE_MARSHAL_CLASSES = [Symbol, TrueClass, String, Array, Hash, Gem::Version].freeze
+  SAFE_MARSHAL_CLASSES = [Symbol, TrueClass, String, Array, Hash, Gem::Version, Gem::Specification].freeze
   SAFE_MARSHAL_ERROR = "Unexpected class %s present in marshaled data. Only %s are allowed."
   SAFE_MARSHAL_PROC = proc do |object|
     object.tap do

--- a/bundler/lib/bundler/fetcher.rb
+++ b/bundler/lib/bundler/fetcher.rb
@@ -102,11 +102,11 @@ module Bundler
       uri = Bundler::URI.parse("#{remote_uri}#{Gem::MARSHAL_SPEC_DIR}#{spec_file_name}.rz")
       if uri.scheme == "file"
         path = Bundler.rubygems.correct_for_windows_path(uri.path)
-        Bundler.load_marshal Bundler.rubygems.inflate(Gem.read_binary(path))
+        Bundler.safe_load_marshal Bundler.rubygems.inflate(Gem.read_binary(path))
       elsif cached_spec_path = gemspec_cached_path(spec_file_name)
         Bundler.load_gemspec(cached_spec_path)
       else
-        Bundler.load_marshal Bundler.rubygems.inflate(downloader.fetch(uri).body)
+        Bundler.safe_load_marshal Bundler.rubygems.inflate(downloader.fetch(uri).body)
       end
     rescue MarshalError
       raise HTTPError, "Gemspec #{spec} contained invalid data.\n" \

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -453,7 +453,7 @@ module Bundler
       fetcher = gem_remote_fetcher
       fetcher.headers = { "X-Gemfile-Source" => remote.original_uri.to_s } if remote.original_uri
       string = fetcher.fetch_path(path)
-      Bundler.load_marshal(string)
+      Bundler.safe_load_marshal(string)
     rescue Gem::RemoteFetcher::FetchError
       # it's okay for prerelease to fail
       raise unless name == "prerelease_specs"

--- a/bundler/spec/bundler/bundler_spec.rb
+++ b/bundler/spec/bundler/bundler_spec.rb
@@ -5,9 +5,9 @@ require "tmpdir"
 
 RSpec.describe Bundler do
   describe "#load_marshal" do
-    it "loads any data" do
+    it "is a private method and raises an error" do
       data = Marshal.dump(Bundler)
-      expect(Bundler.load_marshal(data)).to eq(Bundler)
+      expect { Bundler.load_marshal(data) }.to raise_error(NoMethodError, /private method `load_marshal' called/)
     end
   end
 

--- a/bundler/spec/bundler/bundler_spec.rb
+++ b/bundler/spec/bundler/bundler_spec.rb
@@ -27,6 +27,18 @@ RSpec.describe Bundler do
       data = Marshal.dump(simple_structure)
       expect(Bundler.safe_load_marshal(data)).to eq(simple_structure)
     end
+
+    it "loads Gem::Version" do
+      gem_version = Gem::Version.new("3.7.2")
+      data = Marshal.dump(gem_version)
+      expect(Bundler.safe_load_marshal(data)).to eq(gem_version)
+    end
+
+    it "loads Gem::Specification" do
+      gem_spec = Gem::Specification.new("name", "3.7.2")
+      data = Marshal.dump(gem_spec)
+      expect(Bundler.safe_load_marshal(data)).to eq(gem_spec)
+    end
   end
 
   describe "#load_gemspec_uncached" do

--- a/bundler/spec/bundler/bundler_spec.rb
+++ b/bundler/spec/bundler/bundler_spec.rb
@@ -9,6 +9,11 @@ RSpec.describe Bundler do
       data = Marshal.dump(Bundler)
       expect { Bundler.load_marshal(data) }.to raise_error(NoMethodError, /private method `load_marshal' called/)
     end
+
+    it "loads any data" do
+      data = Marshal.dump(Bundler)
+      expect(Bundler.send(:load_marshal, data)).to eq(Bundler)
+    end
   end
 
   describe "#safe_load_marshal" do

--- a/bundler/spec/bundler/fetcher_spec.rb
+++ b/bundler/spec/bundler/fetcher_spec.rb
@@ -161,11 +161,11 @@ RSpec.describe Bundler::Fetcher do
   end
 
   describe "#fetch_spec" do
-    let(:name) { 'name' }
-    let(:version) { '1.3.17' }
-    let(:platform) { 'platform' }
-    let(:downloader) { double("downloader")}
-    let(:body) { double(Net::HTTP::Get, body: downloaded_data)}
+    let(:name) { "name" }
+    let(:version) { "1.3.17" }
+    let(:platform) { "platform" }
+    let(:downloader) { double("downloader" )}
+    let(:body) { double(Net::HTTP::Get, :body => downloaded_data) }
 
     context "when attempting to load a Gem::Specification" do
       let(:spec) { Gem::Specification.new(name, version) }
@@ -178,10 +178,10 @@ RSpec.describe Bundler::Fetcher do
         expect(result).to eq(spec)
       end
     end
-    
+
     context "when attempting to load an unexpected class" do
       let(:downloaded_data) { Zlib::Deflate.deflate(Marshal.dump(3)) }
-      
+
       it "raises a HTTPError error" do
         expect(Bundler::Fetcher::Downloader).to receive(:new).and_return(downloader)
         expect(downloader).to receive(:fetch).once.and_return(body)

--- a/bundler/spec/bundler/fetcher_spec.rb
+++ b/bundler/spec/bundler/fetcher_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe Bundler::Fetcher do
     let(:name) { "name" }
     let(:version) { "1.3.17" }
     let(:platform) { "platform" }
-    let(:downloader) { double("downloader" )}
+    let(:downloader) { double("downloader") }
     let(:body) { double(Net::HTTP::Get, :body => downloaded_data) }
 
     context "when attempting to load a Gem::Specification" do

--- a/bundler/spec/bundler/fetcher_spec.rb
+++ b/bundler/spec/bundler/fetcher_spec.rb
@@ -159,4 +159,34 @@ RSpec.describe Bundler::Fetcher do
       end
     end
   end
+
+  describe "#fetch_spec" do
+    let(:name) { 'name' }
+    let(:version) { '1.3.17' }
+    let(:platform) { 'platform' }
+    let(:downloader) { double("downloader")}
+    let(:body) { double(Net::HTTP::Get, body: downloaded_data)}
+
+    context "when attempting to load a Gem::Specification" do
+      let(:spec) { Gem::Specification.new(name, version) }
+      let(:downloaded_data) { Zlib::Deflate.deflate(Marshal.dump(spec)) }
+
+      it "returns the spec" do
+        expect(Bundler::Fetcher::Downloader).to receive(:new).and_return(downloader)
+        expect(downloader).to receive(:fetch).once.and_return(body)
+        result = fetcher.fetch_spec([name, version, platform])
+        expect(result).to eq(spec)
+      end
+    end
+    
+    context "when attempting to load an unexpected class" do
+      let(:downloaded_data) { Zlib::Deflate.deflate(Marshal.dump(3)) }
+      
+      it "raises a HTTPError error" do
+        expect(Bundler::Fetcher::Downloader).to receive(:new).and_return(downloader)
+        expect(downloader).to receive(:fetch).once.and_return(body)
+        expect { fetcher.fetch_spec([name, version, platform]) }.to raise_error(Bundler::HTTPError, /Gemspec .* contained invalid data/i)
+      end
+    end
+  end
 end

--- a/bundler/spec/bundler/rubygems_integration_spec.rb
+++ b/bundler/spec/bundler/rubygems_integration_spec.rb
@@ -89,5 +89,16 @@ RSpec.describe Bundler::RubygemsIntegration do
         expect(result).to eq(%w[specs prerelease_specs])
       end
     end
+
+    context "when loading an unexpected class" do
+      let(:remote_no_mirror) { double("remote", :uri => uri, :original_uri => nil) }
+      let(:unexpected_specs_response) { Marshal.dump(3) }
+
+      it "raises a MarshalError error" do
+        expect(Bundler.rubygems).to receive(:gem_remote_fetcher).once.and_return(fetcher)
+        expect(fetcher).to receive(:fetch_path).with(uri + "specs.4.8.gz").and_return(unexpected_specs_response)
+        expect { Bundler.rubygems.fetch_all_remote_specs(remote_no_mirror) }.to raise_error(Bundler::MarshalError, /unexpected class/i)
+      end
+    end
   end
 end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

Resolves #6353. 

In https://github.com/rubygems/rubygems/pull/6141, we landed a SafeMarshal class to deserialize data returned from the dependency API. We want to expand the use of SafeMarshal to include every place in RubyGems and Bundler where we load marshaled files, to remove the possibility of an attack by a malicious server.

## What is your fix for the problem, implemented in this PR?

Use the `safe_load_marshal` method when fetching Marshal.specs.4.8.gz and when inflating gem specifications.

Made the legacy `Bundler.load_marshal` method private so that others will be less tempted to use it directly.

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
