### PR TITLE
TarReader::Entry fix for rewind when reading data.tar.gz in a gem

### DIFF
--- a/lib/rubygems/package/tar_reader/entry.rb
+++ b/lib/rubygems/package/tar_reader/entry.rb
@@ -159,8 +159,9 @@ class Gem::Package::TarReader::Entry
 
   ##
   # Rewinds to the beginning of the tar file entry
-  # This doesn't work when reading the inner data.tar.gz because the gzip io
-  # doesn't support `#pos=`.
+  #
+  # When reading the data.tar.gz in a gem, the io from Zlib::GzipReader
+  # does not support `.pos=`, so use rewind/read instead to avoid error.
 
   def rewind
     check_closed

--- a/lib/rubygems/package/tar_reader/entry.rb
+++ b/lib/rubygems/package/tar_reader/entry.rb
@@ -159,11 +159,18 @@ class Gem::Package::TarReader::Entry
 
   ##
   # Rewinds to the beginning of the tar file entry
+  # This doesn't work when reading the inner data.tar.gz because the gzip io
+  # doesn't support `#pos=`.
 
   def rewind
     check_closed
 
-    @io.pos = @orig_pos
+    if @io.respond_to?(:pos=)
+      @io.pos = @orig_pos
+    else
+      @io.rewind
+      @io.read(@orig_pos)
+    end
     @read = 0
   end
 end

--- a/test/rubygems/test_gem_package_tar_reader_entry.rb
+++ b/test/rubygems/test_gem_package_tar_reader_entry.rb
@@ -216,14 +216,12 @@ class TestGemPackageTarReaderEntry < Gem::Package::TarTestCase
     tgz = util_gzip(@tar)
 
     Zlib::GzipReader.wrap StringIO.new(tgz) do |gzio|
-      begin
-        header = Gem::Package::TarHeader.from gzio
-        entry = Gem::Package::TarReader::Entry.new header, gzio
+      header = Gem::Package::TarHeader.from gzio
+      entry = gem::package::tarreader::entry.new header, gzio
 
-        assert_equal @contents, entry.read
-        entry.rewind
-        assert_equal @contents, entry.read, "read after rewind failed"
-      end
+      assert_equal @contents, entry.read
+      entry.rewind
+      assert_equal @contents, entry.read, "read after rewind failed"
     end
   end
 end

--- a/test/rubygems/test_gem_package_tar_reader_entry.rb
+++ b/test/rubygems/test_gem_package_tar_reader_entry.rb
@@ -211,4 +211,19 @@ class TestGemPackageTarReaderEntry < Gem::Package::TarTestCase
   ensure
     close_util_entry(zero_entry) if zero_entry
   end
+
+  def test_read_from_gzip_io
+    tgz = util_gzip(@tar)
+
+    Zlib::GzipReader.wrap StringIO.new(tgz) do |gzio|
+      begin
+        header = Gem::Package::TarHeader.from gzio
+        entry = Gem::Package::TarReader::Entry.new header, gzio
+
+        assert_equal @contents, entry.read
+        entry.rewind
+        assert_equal @contents, entry.read, "read after rewind failed"
+      end
+    end
+  end
 end

--- a/test/rubygems/test_gem_package_tar_reader_entry.rb
+++ b/test/rubygems/test_gem_package_tar_reader_entry.rb
@@ -217,7 +217,7 @@ class TestGemPackageTarReaderEntry < Gem::Package::TarTestCase
 
     Zlib::GzipReader.wrap StringIO.new(tgz) do |gzio|
       header = Gem::Package::TarHeader.from gzio
-      entry = gem::package::tarreader::entry.new header, gzio
+      entry = Gem::Package::TarReader::Entry.new header, gzio
 
       assert_equal @contents, entry.read
       entry.rewind


### PR DESCRIPTION





## What was the end-user or developer problem that led to this PR?

Zlib::GzipReader doesn't support #pos= so you can't rewind a TarReader::Entry that is wrapping a Zlib::GzipReader.

Gem::Package#open_tar_gz is used in many places to read the data.tar.gz contained within a .gem file. This normally works if you never rewind or try to use TarReader#seek. TarReader::Entry wraps the gzio, but attempting to rewind or seek within the gzip fails by `NoMethodError: undefined method 'pos=' for #<Zlib::GzipReader>`.

This would not be encountered during normal extract of a gem, but does happen when someone uses the methods on Gem::Package to try to access individual files within the gem, or to rewind an entry that's already been read.

I don't know if this really needs to be fixed in rubygems, but I'm pushing it upstream because I fixed it when parsing gems in memory. If this is useful, I can push up a few more fixes to the TarReader that help with seeking to individual files in the data.tar.gz, or whatever else I encounter that could be fixed more easily in rubygems itself.

## What is your fix for the problem, implemented in this PR?

The only solution supported by Zlib::GzipReader (that I can find) is to rewind and read back to the @orig_pos. This works correctly as shown in the test. This test fails with the above NoMethodError without this fix.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
