### PR TITLE
Alias CurrentRuby#mswin?, mswin64?, mingw?, x64_mingw? to #windows?

### DIFF
--- a/bundler/lib/bundler/current_ruby.rb
+++ b/bundler/lib/bundler/current_ruby.rb
@@ -71,10 +71,10 @@ module Bundler
     def windows?
       Gem.win_platform?
     end
-    alias mswin? windows?
-    alias mswin64? windows?
-    alias mingw? windows?
-    alias x64_mingw? windows?
+    alias_method :mswin?, :windows?
+    alias_method :mswin64?, :windows?
+    alias_method :mingw?, :windows?
+    alias_method :x64_mingw?, :windows?
 
     (KNOWN_MINOR_VERSIONS + KNOWN_MAJOR_VERSIONS).each do |version|
       trimmed_version = version.tr(".", "")

--- a/bundler/lib/bundler/current_ruby.rb
+++ b/bundler/lib/bundler/current_ruby.rb
@@ -71,26 +71,10 @@ module Bundler
     def windows?
       Gem.win_platform?
     end
-
-    def mswin?
-      # For backwards compatibility
-      windows?
-
-      # TODO: This should correctly be:
-      # windows? && Bundler.local_platform != Gem::Platform::RUBY && Bundler.local_platform.os == "mswin32" && Bundler.local_platform.cpu == "x86"
-    end
-
-    def mswin64?
-      windows? && Bundler.local_platform != Gem::Platform::RUBY && Bundler.local_platform.os == "mswin64" && Bundler.local_platform.cpu == "x64"
-    end
-
-    def mingw?
-      windows? && Bundler.local_platform != Gem::Platform::RUBY && Bundler.local_platform.os == "mingw32" && Bundler.local_platform.cpu != "x64"
-    end
-
-    def x64_mingw?
-      Gem.win_platform? && Bundler.local_platform != Gem::Platform::RUBY && Bundler.local_platform.os.start_with?("mingw") && Bundler.local_platform.cpu == "x64"
-    end
+    alias mswin? windows?
+    alias mswin64? windows?
+    alias mingw? windows?
+    alias x64_mingw? windows?
 
     (KNOWN_MINOR_VERSIONS + KNOWN_MAJOR_VERSIONS).each do |version|
       trimmed_version = version.tr(".", "")

--- a/bundler/lib/bundler/dependency.rb
+++ b/bundler/lib/bundler/dependency.rb
@@ -17,7 +17,8 @@ module Bundler
       :truffleruby => [Gem::Platform::RUBY],
       :jruby => [Gem::Platform::JAVA, [18, 19]],
       :windows => [Gem::Platform::WINDOWS, ALL_RUBY_VERSIONS],
-      :mswin => [Gem::Platform::MSWIN,     ALL_RUBY_VERSIONS],
+      # deprecated
+      :mswin => [Gem::Platform::MSWIN, ALL_RUBY_VERSIONS],
       :mswin64 => [Gem::Platform::MSWIN64, ALL_RUBY_VERSIONS - [18]],
       :mingw => [Gem::Platform::MINGW, ALL_RUBY_VERSIONS],
       :x64_mingw => [Gem::Platform::X64_MINGW, ALL_RUBY_VERSIONS - [18, 19]],

--- a/bundler/lib/bundler/man/gemfile.5
+++ b/bundler/lib/bundler/man/gemfile.5
@@ -318,6 +318,14 @@ gem "nokogiri",   platforms: [:windows_31, :jruby]
 .P
 All operations involving groups (\fBbundle install\fR \fIbundle\-install\.1\.html\fR, \fBBundler\.setup\fR, \fBBundler\.require\fR) behave exactly the same as if any groups not matching the current platform were explicitly excluded\.
 .
+.P
+The following platform values are deprecated and should be replaced with \fBwindows\fR:
+.
+.IP "\(bu" 4
+\fBmswin\fR, \fBmswin64\fR, \fBmingw32\fR, \fBx64_mingw\fR
+.
+.IP "" 0
+.
 .SS "FORCE_RUBY_PLATFORM"
 If you always want the pure ruby variant of a gem to be chosen over platform specific variants, you can use the \fBforce_ruby_platform\fR option:
 .

--- a/bundler/lib/bundler/man/gemfile.5.ronn
+++ b/bundler/lib/bundler/man/gemfile.5.ronn
@@ -228,6 +228,10 @@ All operations involving groups ([`bundle install`](bundle-install.1.html), `Bun
 `Bundler.require`) behave exactly the same as if any groups not
 matching the current platform were explicitly excluded.
 
+The following platform values are deprecated and should be replaced with `windows`:
+
+  * `mswin`, `mswin64`, `mingw32`, `x64_mingw`
+
 ### FORCE_RUBY_PLATFORM
 
 If you always want the pure ruby variant of a gem to be chosen over platform

--- a/bundler/spec/bundler/dependency_spec.rb
+++ b/bundler/spec/bundler/dependency_spec.rb
@@ -89,8 +89,11 @@ RSpec.describe Bundler::Dependency do
         :windows_30 => Gem::Platform::WINDOWS,
         :windows_31 => Gem::Platform::WINDOWS,
         :windows_32 => Gem::Platform::WINDOWS,
-        :windows_33 => Gem::Platform::WINDOWS,
-        :mswin => Gem::Platform::MSWIN,
+        :windows_33 => Gem::Platform::WINDOWS }
+    end
+
+    let(:deprecated) do
+      { :mswin => Gem::Platform::MSWIN,
         :mswin_18 => Gem::Platform::MSWIN,
         :mswin_19 => Gem::Platform::MSWIN,
         :mswin_20 => Gem::Platform::MSWIN,
@@ -151,7 +154,7 @@ RSpec.describe Bundler::Dependency do
     # rubocop:enable Naming/VariableNumber
 
     it "includes all platforms" do
-      expect(subject).to eq(platforms)
+      expect(subject).to eq(platforms.merge(deprecated))
     end
   end
 end

--- a/bundler/spec/commands/cache_spec.rb
+++ b/bundler/spec/commands/cache_spec.rb
@@ -211,7 +211,17 @@ RSpec.describe "bundle cache" do
   end
 
   context "with --all-platforms" do
-    it "puts the gems in vendor/cache even for other rubies" do
+    it "puts the gems in vendor/cache even for other rubies", :bundler => ">= 2.4.0" do
+      gemfile <<-D
+        source "#{file_uri_for(gem_repo1)}"
+        gem 'rack', :platforms => [:ruby_20, :windows_20]
+      D
+
+      bundle "cache --all-platforms"
+      expect(bundled_app("vendor/cache/rack-1.0.0.gem")).to exist
+    end
+
+    it "puts the gems in vendor/cache even for legacy windows rubies", :bundler => ">= 2.4.0" do
       gemfile <<-D
         source "#{file_uri_for(gem_repo1)}"
         gem 'rack', :platforms => [:ruby_20, :x64_mingw_20]

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -550,7 +550,7 @@ RSpec.describe "bundle install with platform conditionals" do
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
 
-      gem "rack", :platform => [:windows, :mingw, :mswin, :x64_mingw, :jruby]
+      gem "rack", :platform => [:windows, :mswin, :mswin64, :mingw, :x64_mingw, :jruby]
     G
 
     bundle "install"

--- a/bundler/spec/runtime/platform_spec.rb
+++ b/bundler/spec/runtime/platform_spec.rb
@@ -365,7 +365,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
     simulate_windows do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
-        gem "nokogiri", :platforms => [:mingw, :mswin, :x64_mingw, :jruby]
+        gem "nokogiri", :platforms => [:windows, :mswin, :mswin64, :mingw, :x64_mingw, :jruby]
         gem "platform_specific"
       G
 


### PR DESCRIPTION
This is a redux of https://github.com/rubygems/rubygems/pull/5883. See that PR for discussion thread.

This PR makes Bundler's platform values `:mswin, :mswin64, :mingw, :x64_mingw` equivalent to the recently added `:windows`. In other words, specifying any of these platform values will now bundle the specified gem on **any** Windows system, which is generally the desired behavior.

*(There is no practical use case where I would want to Bundle a gem such as Nokogiri only on `:mswin`, but not on `:mingw`.)*

**This PR does not affect how gems are built.** Binary gems can/should still be built to target specific Windows architectures such as `x64-mingw-ucrt`.

For comparison, this change makes Windows platforms much closer to how other platforms e.g. `:ruby`, `:jruby` behave today, where a catch-all platform is used in the Gemfile rather than specifying different gems for different Mac/Linux versions.

This PR also updates the manpage to indicate that users should be using `windows` in place of the others.

Lastly, this PR does not add any deprecation warnings when bundling.