### PR TITLE
Auto-heal on corrupted lockfile with missing deps

### DIFF
--- a/bundler/lib/bundler/installer/parallel_installer.rb
+++ b/bundler/lib/bundler/installer/parallel_installer.rb
@@ -47,13 +47,6 @@ module Bundler
         dependencies.all? {|d| installed_specs.include? d.name }
       end
 
-      # Check whether spec's dependencies are missing, which can indicate a
-      # corrupted lockfile
-      def dependencies_missing?(all_specs)
-        spec_names = all_specs.map(&:name)
-        dependencies.any? {|d| !spec_names.include? d.name }
-      end
-
       # Represents only the non-development dependencies, the ones that are
       # itself and are in the total list.
       def dependencies
@@ -123,11 +116,7 @@ module Bundler
       unmet_dependencies.each do |spec, unmet_spec_dependencies|
         unmet_spec_dependencies.each do |unmet_spec_dependency|
           found = @specs.find {|s| s.name == unmet_spec_dependency.name && !unmet_spec_dependency.matches_spec?(s.spec) }
-          if found
-            warning << "* #{unmet_spec_dependency}, dependency of #{spec.full_name}, unsatisfied by #{found.full_name}"
-          else
-            warning << "* #{unmet_spec_dependency}, dependency of #{spec.full_name} but missing from lockfile"
-          end
+          warning << "* #{unmet_spec_dependency}, dependency of #{spec.full_name}, unsatisfied by #{found.full_name}"
         end
       end
 
@@ -224,8 +213,6 @@ module Bundler
         if spec.dependencies_installed? @specs
           spec.state = :enqueued
           worker_pool.enq spec
-        elsif spec.dependencies_missing? @specs
-          spec.state = :failed
         end
       end
     end

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -78,7 +78,7 @@ module Bundler
     def materialize(deps)
       materialized = self.for(deps, true)
 
-      SpecSet.new(materialized, incomplete_specs)
+      SpecSet.new(materialized, incomplete_specs + specs_with_missing_dependencies(materialized))
     end
 
     # Materialize for all the specs in the spec set, regardless of what platform they're for
@@ -201,6 +201,16 @@ module Bundler
         next if d.type == :development
         lookup[d.name].each {|s2| yield s2 }
       end
+    end
+
+    def specs_with_missing_dependencies(materialized)
+      materialized.
+        select {|spec| missing_dependencies?(spec) }.
+        flat_map {|spec| lookup[spec.name] }
+    end
+
+    def missing_dependencies?(spec)
+      spec.dependencies.any? {|dep| lookup[dep.name].empty? }
     end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

See https://github.com/rubygems/rubygems/pull/6355 for the original problem.

## What is your fix for the problem, implemented in this PR?

https://github.com/rubygems/rubygems/pull/6355 turned a crash into a nicer error. This commit auto-heals the corrupt lockfile instead.

Since in this particular case (a corrupt Gemfile.lock with missing dependencies) the LazySpecification will not have accurate dependency information, we have to materialize the SpecSet to determine there are missing dependencies. Since we've already got some incomplete-spec-auto-healing here, I've treated this as another brand of incomplete spec.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
