### PR TITLE
Auto-heal on corrupted lockfile with missing deps

### DIFF
--- a/bundler/lib/bundler/installer/parallel_installer.rb
+++ b/bundler/lib/bundler/installer/parallel_installer.rb
@@ -47,13 +47,6 @@ module Bundler
         dependencies.all? {|d| installed_specs.include? d.name }
       end
 
-      # Check whether spec's dependencies are missing, which can indicate a
-      # corrupted lockfile
-      def dependencies_missing?(all_specs)
-        spec_names = all_specs.map(&:name)
-        dependencies.any? {|d| !spec_names.include? d.name }
-      end
-
       # Represents only the non-development dependencies, the ones that are
       # itself and are in the total list.
       def dependencies
@@ -123,11 +116,7 @@ module Bundler
       unmet_dependencies.each do |spec, unmet_spec_dependencies|
         unmet_spec_dependencies.each do |unmet_spec_dependency|
           found = @specs.find {|s| s.name == unmet_spec_dependency.name && !unmet_spec_dependency.matches_spec?(s.spec) }
-          if found
-            warning << "* #{unmet_spec_dependency}, dependency of #{spec.full_name}, unsatisfied by #{found.full_name}"
-          else
-            warning << "* #{unmet_spec_dependency}, dependency of #{spec.full_name} but missing from lockfile"
-          end
+          warning << "* #{unmet_spec_dependency}, dependency of #{spec.full_name}, unsatisfied by #{found.full_name}"
         end
       end
 
@@ -224,8 +213,6 @@ module Bundler
         if spec.dependencies_installed? @specs
           spec.state = :enqueued
           worker_pool.enq spec
-        elsif spec.dependencies_missing? @specs
-          spec.state = :failed
         end
       end
     end

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -24,6 +24,7 @@ module Bundler
 
         name = dep[0].name
         platform = dep[1]
+        incomplete = false
 
         key = [name, platform]
         next if handled.key?(key)
@@ -36,11 +37,14 @@ module Bundler
 
           specs_for_dep.first.dependencies.each do |d|
             next if d.type == :development
+            incomplete = true if d.name != "bundler" && lookup[d.name].empty?
             deps << [d, dep[1]]
           end
-        elsif check
-          @incomplete_specs += lookup[name]
+        else
+          incomplete = true
         end
+
+        @incomplete_specs += lookup[name] if incomplete && check
       end
 
       specs


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

See https://github.com/rubygems/rubygems/pull/6355 for the original problem.

## What is your fix for the problem, implemented in this PR?

https://github.com/rubygems/rubygems/pull/6355 turned a crash into a nicer error. This commit auto-heals the corrupt lockfile instead.

In this particular case (a corrupt Gemfile.lock with missing dependencies) the LazySpecification will not have accurate dependency information, so we have to materialize the SpecSet to determine there are missing dependencies. We've already got a way to handle this, via `SpecSet#incomplete_specs`, but it wasn't quite working for this case because we'd get to `@incomplete_specs += lookup[name]` and `lookup[name]` would be empty for the dependency.

With this commit we catch it a bit earlier, marking the spec containing the missing dependency as incomplete.

(I had originally opened https://github.com/rubygems/rubygems/pull/6399, but misunderstood a few things there. I closed it and then force pushed to the branch, preventing me from reopening it.)

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
