### PR TITLE
Avoid NoMethodError with malformed Gemfile.lock.

### DIFF
--- a/bundler/lib/bundler/cli/common.rb
+++ b/bundler/lib/bundler/cli/common.rb
@@ -20,7 +20,7 @@ module Bundler
       current_dependencies = definition.requested_dependencies
       current_specs = definition.specs
 
-      count = current_dependencies.count {|dep| current_specs[dep.name].first.metadata.key?("funding_uri") }
+      count = current_dependencies.count {|dep| current_specs[dep.name]&.first&.metadata&.key?("funding_uri") }
 
       return if count.zero?
 

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -1103,4 +1103,39 @@ RSpec.describe "bundle install with gem sources" do
       expect(err).to include("Could not find compatible versions")
     end
   end
+
+  context "with a lockfile that has mismatched 'specs:' and 'DEPENDENCIES' sections" do
+    it "does not throw a NoMethodError" do
+      build_repo4 do
+        build_gem "indirect_dependency", "1.2.3" do |s|
+          s.metadata["funding_uri"] = "https://example.com/donate"
+        end
+
+        build_gem "direct_dependency", "4.5.6" do |s|
+          s.add_dependency "indirect_dependency", ">= 0"
+        end
+      end
+
+      lockfile <<-G
+        GEM
+          remote: #{file_uri_for(gem_repo4)}/
+          specs:
+
+        PLATFORMS
+          ruby
+
+        DEPENDENCIES
+          direct_dependency
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      G
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo4)}"
+
+        gem "direct_dependency"
+      G
+    end
+  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If a Gemfile.lock has a mismatch between `specs:` and `DEPENDENCIES`, printing funding information runs what boils down to `nil.metadata`.

## What is your fix for the problem, implemented in this PR?

Before printing funding information, make sure there's something to print.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
