### PR TITLE
Ensure safe load marshal is also used when loading gemspecs

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "bundler/vendored_fileutils"
+require "date"
 require "pathname"
 require "rbconfig"
 
@@ -39,7 +40,31 @@ module Bundler
   environment_preserver.replace_with_backup
   SUDO_MUTEX = Thread::Mutex.new
 
-  SAFE_MARSHAL_CLASSES = [Symbol, TrueClass, String, Array, Hash, Gem::Version, Gem::Specification].freeze
+  SAFE_MARSHAL_CLASSES = [
+    Array,
+    Date,
+    Float,
+    Hash,
+    Integer,
+    String,
+    Symbol,
+    Time,
+
+    TrueClass,
+    FalseClass,
+
+    NilClass,
+
+    Gem::Dependency,
+    Gem::NameTuple,
+    Gem::Platform,
+    Gem::Requirement,
+    Gem::Specification,
+    Gem::Version,
+
+    Gem::Util::DefaultKey,
+    Gem::Util::PrivateType,
+  ].freeze
   SAFE_MARSHAL_ERROR = "Unexpected class %s present in marshaled data. Only %s are allowed."
   SAFE_MARSHAL_PROC = proc do |object|
     object.tap do
@@ -48,6 +73,8 @@ module Bundler
       end
     end
   end
+
+  private_constant :SAFE_MARSHAL_CLASSES, :SAFE_MARSHAL_ERROR, :SAFE_MARSHAL_PROC
 
   autoload :Definition,             File.expand_path("bundler/definition", __dir__)
   autoload :Dependency,             File.expand_path("bundler/dependency", __dir__)

--- a/bundler/lib/bundler/fetcher.rb
+++ b/bundler/lib/bundler/fetcher.rb
@@ -108,9 +108,9 @@ module Bundler
       else
         Bundler.safe_load_marshal Bundler.rubygems.inflate(downloader.fetch(uri).body)
       end
-    rescue MarshalError
+    rescue MarshalError => e
       raise HTTPError, "Gemspec #{spec} contained invalid data.\n" \
-        "Your network or your gem server is probably having issues right now."
+        "Your network or your gem server is probably having issues right now.\n#{e}"
     end
 
     # return the specs in the bundler format as an index with retries

--- a/lib/rubygems/indexer.rb
+++ b/lib/rubygems/indexer.rb
@@ -410,7 +410,7 @@ class Gem::Indexer
   # +dest+.  For a latest index, does not ensure the new file is minimal.
 
   def update_specs_index(index, source, dest)
-    specs_index = Marshal.load Gem.read_binary(source)
+    specs_index = Gem::Util.safe_load_marshal Gem.read_binary(source)
 
     index.each do |spec|
       platform = spec.original_platform

--- a/lib/rubygems/source.rb
+++ b/lib/rubygems/source.rb
@@ -137,7 +137,7 @@ class Gem::Source
 
     if File.exist? local_spec
       spec = Gem.read_binary local_spec
-      spec = Marshal.load(spec) rescue nil
+      spec = Gem::Util.safe_load_marshal(spec) rescue nil
       return spec if spec
     end
 
@@ -156,7 +156,7 @@ class Gem::Source
     end
 
     # TODO: Investigate setting Gem::Specification#loaded_from to a URI
-    Marshal.load spec
+    Gem::Util.safe_load_marshal spec
   end
 
   ##
@@ -187,7 +187,7 @@ class Gem::Source
     spec_dump = fetcher.cache_update_path spec_path, local_file, update_cache?
 
     begin
-      Gem::NameTuple.from_list Marshal.load(spec_dump)
+      Gem::NameTuple.from_list Gem::Util.safe_load_marshal(spec_dump)
     rescue ArgumentError
       if update_cache? && !retried
         FileUtils.rm local_file

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1294,7 +1294,7 @@ class Gem::Specification < Gem::BasicSpecification
     Gem.load_yaml
 
     array = begin
-      Marshal.load str
+      Gem::Util.safe_load_marshal str
     rescue ArgumentError => e
       #
       # Some very old marshaled specs included references to `YAML::PrivateType`
@@ -1310,9 +1310,9 @@ class Gem::Specification < Gem::BasicSpecification
       if message.include?("YAML::Syck::")
         YAML.const_set "Syck", YAML unless YAML.const_defined?(:Syck)
 
-        YAML::Syck.const_set "DefaultKey", Class.new if message.include?("YAML::Syck::DefaultKey")
+        YAML::Syck.const_set "DefaultKey", Gem::Util::DefaultKey if message.include?("YAML::Syck::DefaultKey")
       elsif message.include?("YAML::PrivateType")
-        YAML.const_set "PrivateType", Class.new
+        YAML.const_set "PrivateType", Gem::Util::PrivateType
       end
 
       retry

--- a/lib/rubygems/util.rb
+++ b/lib/rubygems/util.rb
@@ -112,4 +112,50 @@ module Gem::Util
     end
   end
 
+  class DefaultKey
+  end
+
+  class PrivateType
+  end
+
+  require "date"
+  SAFE_MARSHAL_CLASSES = [
+    Array,
+    Date,
+    Float,
+    Hash,
+    Integer,
+    String,
+    Symbol,
+    Time,
+
+    TrueClass,
+    FalseClass,
+
+    NilClass,
+
+    Gem::Dependency,
+    Gem::NameTuple,
+    Gem::Platform,
+    Gem::Requirement,
+    Gem::Specification,
+    Gem::Version,
+
+    DefaultKey,
+    PrivateType,
+  ].freeze
+  SAFE_MARSHAL_ERROR = "Unexpected class %s present in marshaled data. Only %s are allowed."
+  SAFE_MARSHAL_PROC = proc do |object|
+    object.tap do
+      unless SAFE_MARSHAL_CLASSES.include?(object.class)
+        raise TypeError, format(SAFE_MARSHAL_ERROR, object.class, SAFE_MARSHAL_CLASSES.join(", "))
+      end
+    end
+  end
+
+  private_constant :SAFE_MARSHAL_CLASSES, :SAFE_MARSHAL_ERROR, :SAFE_MARSHAL_PROC
+
+  def self.safe_load_marshal(data)
+    Marshal.load(data, SAFE_MARSHAL_PROC)
+  end
 end

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -648,7 +648,7 @@ class Gem::TestCase < Test::Unit::TestCase
 
   def read_cache(path)
     File.open path.dup.tap(&Gem::UNTAINT), "rb" do |io|
-      Marshal.load io.read
+      Gem::Util.safe_load_marshal io.read
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`Bundler.safe_load_marshal` wasn't catching "unsafe" objects that were loaded from a `Gem::Specification`

## What is your fix for the problem, implemented in this PR?

My fix ensures that the string loaded in `Gem::Specification._load` goes through a safe-load method. In RubyGems, this is done directly, while in Bundler it is monkey-patched in as a preamble to the `_load` method.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
