### PR TITLE
Fix method redefinition warning in gem exec specs

### DIFF
--- a/lib/rubygems/commands/exec_command.rb
+++ b/lib/rubygems/commands/exec_command.rb
@@ -235,11 +235,13 @@ to the same gem path as user-installed gems.
     name = :always_install
     cls = ::Gem::Resolver::InstallerSet
     method = cls.instance_method(name)
+    cls.remove_method(name)
     cls.define_method(name) { [] }
 
     begin
       yield
     ensure
+      cls.remove_method(name)
       cls.define_method(name, method)
     end
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Method redefinition warnings when running the gem exec specs

## What is your fix for the problem, implemented in this PR?

Remove the method before defining it.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
