### PR TITLE
Fix `gems.rb` lockfile for bundler version lookup in template

### DIFF
--- a/bundler/lib/bundler/templates/Executable.bundler
+++ b/bundler/lib/bundler/templates/Executable.bundler
@@ -47,7 +47,7 @@ m = Module.new do
   def lockfile
     lockfile =
       case File.basename(gemfile)
-      when "gems.rb" then gemfile.sub(/\.rb$/, gemfile)
+      when "gems.rb" then gemfile.sub(/\.rb$/, ".locked")
       else "#{gemfile}.lock"
       end
     File.expand_path(lockfile)

--- a/bundler/spec/commands/binstubs_spec.rb
+++ b/bundler/spec/commands/binstubs_spec.rb
@@ -166,6 +166,21 @@ RSpec.describe "bundle binstubs <gem>" do
           end
         end
 
+        context "and the version is newer when given `gems.rb` and `gems.locked`" do
+          before do
+            gemfile bundled_app("gems.rb"), gemfile
+            lockfile bundled_app("gems.locked"), lockfile.gsub(system_bundler_version, "999.999")
+          end
+
+          it "runs the correct version of bundler" do
+            sys_exec "bin/bundle install", :env => { "BUNDLE_GEMFILE" => "gems.rb" }, :raise_on_error => false
+
+            expect(exitstatus).to eq(42)
+            expect(err).to include("Activating bundler (~> 999.999) failed:").
+              and include("To install the version of bundler this project requires, run `gem install bundler -v '~> 999.999'`")
+          end
+        end
+
         context "and the version is older and a different major" do
           let(:system_bundler_version) { "55" }
 
@@ -175,6 +190,22 @@ RSpec.describe "bundle binstubs <gem>" do
 
           it "runs the correct version of bundler" do
             sys_exec "bin/bundle install", :raise_on_error => false
+            expect(exitstatus).to eq(42)
+            expect(err).to include("Activating bundler (~> 44.0) failed:").
+              and include("To install the version of bundler this project requires, run `gem install bundler -v '~> 44.0'`")
+          end
+        end
+
+        context "and the version is older and a different major when given `gems.rb` and `gems.locked`" do
+          let(:system_bundler_version) { "55" }
+
+          before do
+            gemfile bundled_app("gems.rb"), gemfile
+            lockfile bundled_app("gems.locked"), lockfile.gsub(/BUNDLED WITH\n   .*$/m, "BUNDLED WITH\n   44.0")
+          end
+
+          it "runs the correct version of bundler" do
+            sys_exec "bin/bundle install", :env => { "BUNDLE_GEMFILE" => "gems.rb" }, :raise_on_error => false
             expect(exitstatus).to eq(42)
             expect(err).to include("Activating bundler (~> 44.0) failed:").
               and include("To install the version of bundler this project requires, run `gem install bundler -v '~> 44.0'`")


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When I create a rails 7 project with `rails new my_app --minimal` , there are a couple of files under `bin` provided from bundler.  `bin/bundle` caught my attention with 

```
  def lockfile
    lockfile =
      case File.basename(gemfile)
      when "gems.rb" then gemfile.sub(/\.rb$/, gemfile)
      else "#{gemfile}.lock"
      end
    File.expand_path(lockfile)
  end
```
This line: `when "gems.rb" then gemfile.sub(/\.rb$/, gemfile)`

When provided with `gems.rb`, the lockfile ends up become `gemsgems.rb`, which is very likely that the file is missing and this [expression](https://github.com/rubygems/rubygems/blob/master/bundler/lib/bundler/templates/Executable.bundler#L57) is returning `false` and prevent reading bundler version from the lockfile. 

 I noticed that the filename(`Gemfile`/`gems.rb`, `Gemfile.lock`/`gems.locked`) is probably not that important, since the content is the same, but Bundler has a [specific mapping](https://github.com/rubygems/rubygems/blob/master/lib/rubygems/bundler_version_finder.rb#L68) for `gems.rb` to `gems.locked` I think should be respected.

## What is your fix for the problem, implemented in this PR?

The fix changes the lockfile lookup for `gems.rb` during bundler version lookup. Respect the bundler version specified in `gems.locked`. 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
