### PR TITLE
Switch supporting explanations to all Ruby Central

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
-custom: rubytogether.org
+custom: https://rubycentral.org/#/portal/signup
 github: rubytogether

--- a/POLICIES.md
+++ b/POLICIES.md
@@ -128,8 +128,8 @@ permissions compromised or exposed.
 
 ## Changing These Policies
 
-These policies were set in order to reduce the burden of maintenance and to
-keep committers current with existing development and policies. RubyGems work
-is primarily volunteer-driven which limits the ability to provide long-term
-support. By joining [Ruby Together](https://rubytogether.org) you can help
-extend support for older RubyGems versions.
+These policies were set in order to reduce the burden of maintenance and to keep
+committers current with existing development and policies. RubyGems work is
+primarily volunteer-driven which limits the ability to provide long-term
+support. By joining [Ruby Central](https://rubycentral.org/#/portal/signup) you
+can help extend support for older RubyGems versions.

--- a/README.md
+++ b/README.md
@@ -85,14 +85,11 @@ See https://bundler.io/compatibility for known issues.
 
 ### Supporting
 
-<a href="https://rubytogether.org/"><img src="https://rubytogether.org/images/rubies.svg" width=200></a><br/>
-<a href="https://rubytogether.org/">Ruby Together</a> pays some RubyGems maintainers for their ongoing work. As a grassroots initiative committed to supporting the critical Ruby infrastructure you rely on, Ruby Together is funded entirely by the Ruby community. Contribute today <a href="https://rubytogether.org/developers">as an individual</a> or even better, <a href="https://rubytogether.org/companies">as a company</a>, and ensure that RubyGems, Bundler, and other shared tooling is around for years to come.
+RubyGems is managed by [Ruby Central](https://rubycentral.org), a non-profit organization that supports the Ruby community through projects like this one, as well as [RubyConf](https://rubyconf.org), [RailsConf](https://railsconf.org), and [RubyGems.org](https://rubygems.org). You can support Ruby Central by attending or [sponsoring](sponsors@rubycentral.org) a conference, or by [joining as a supporting member](https://rubycentral.org/#/portal/signup).
 
 ### Contributing
 
 If you'd like to contribute to RubyGems, that's awesome, and we <3 you. Check out our [guide to contributing](CONTRIBUTING.md) for more information.
-
-While some RubyGems contributors are compensated by Ruby Together, the project maintainers make decisions independent of Ruby Together. As a project, we welcome contributions regardless of the author’s affiliation with Ruby Together.
 
 ### Code of Conduct
 

--- a/bundler/README.md
+++ b/bundler/README.md
@@ -46,12 +46,9 @@ If you'd like to contribute to Bundler, that's awesome, and we <3 you. We've put
 
 If you'd like to request a substantial change to Bundler or its documentation, refer to the [Bundler RFC process](https://github.com/rubygems/rfcs) for more information.
 
-While some Bundler contributors are compensated by Ruby Together, the project maintainers make decisions independent of Ruby Together. As a project, we welcome contributions regardless of the author's affiliation with Ruby Together.
-
 ### Supporting
 
-<a href="https://rubytogether.org/"><img src="https://rubytogether.org/images/rubies.svg" width="150"></a><br>
-<a href="https://rubytogether.org/">Ruby Together</a> pays some Bundler maintainers for their ongoing work. As a grassroots initiative committed to supporting the critical Ruby infrastructure you rely on, Ruby Together is funded entirely by the Ruby community. Contribute today <a href="https://rubytogether.org/developers">as an individual</a> or (better yet) <a href="https://rubytogether.org/companies">as a company</a> to ensure that Bundler, RubyGems, and other shared tooling is around for years to come.
+RubyGems is managed by [Ruby Central](https://rubycentral.org), a non-profit organization that supports the Ruby community through projects like this one, as well as [RubyConf](https://rubyconf.org), [RailsConf](https://railsconf.org), and [RubyGems.org](https://rubygems.org). You can support Ruby Central by attending or [sponsoring](sponsors@rubycentral.org) a conference, or by [joining as a supporting member](https://rubycentral.org/#/portal/signup).
 
 ### Code of Conduct
 

--- a/bundler/doc/contributing/README.md
+++ b/bundler/doc/contributing/README.md
@@ -25,4 +25,4 @@ Here are the different ways you can start contributing to the Bundler project:
 
 ## Supporting Bundler
 
-[Ruby Together](https://rubytogether.org/) pays some Bundler maintainers for their work, funded directly by the Ruby community. If you'd like to support Bundler with a financial contribution, [become an individual sponsor](https://rubytogether.org/developers#plans). We also welcome financial [contributions from companies](https://rubytogether.org/companies#plans), too! (You can also support us through [Open Collective](https://opencollective.com/rubytogether).)
+RubyGems is managed by [Ruby Central](https://rubycentral.org), a non-profit organization that supports the Ruby community through projects like this one, as well as [RubyConf](https://rubyconf.org), [RailsConf](https://railsconf.org), and [RubyGems.org](https://rubygems.org). You can support Ruby Central by attending or [sponsoring](sponsors@rubycentral.org) a conference, or by [joining as a supporting member](https://rubycentral.org/#/portal/signup).


### PR DESCRIPTION
Updates sponsor/support information to point to Ruby Central instead of Ruby Together.