### PR TITLE
Use proper memoized var name for Gem.state_home.

### DIFF
--- a/lib/rubygems/defaults.rb
+++ b/lib/rubygems/defaults.rb
@@ -158,7 +158,7 @@ module Gem
   # The path to standard location of the user's state directory.
 
   def self.state_home
-    @data_home ||= (ENV["XDG_STATE_HOME"] || File.join(Gem.user_home, ".local", "state"))
+    @state_home ||= (ENV["XDG_STATE_HOME"] || File.join(Gem.user_home, ".local", "state"))
   end
 
   ##

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1654,6 +1654,30 @@ class TestGem < Gem::TestCase
     ENV["SOURCE_DATE_EPOCH"] = old_epoch
   end
 
+  def test_data_home_default
+    expected = File.join(@userhome, ".local", "share")
+    assert_equal expected, Gem.data_home
+  end
+
+  def test_data_home_from_env
+    ENV["XDG_DATA_HOME"] = expected = "/test/data/home"
+    assert_equal expected, Gem.data_home
+  end
+
+  def test_state_home_default
+    Gem.instance_variable_set :@state_home, nil
+    Gem.data_home # memoize @data_home, to demonstrate GH-6418
+    expected = File.join(@userhome, ".local", "state")
+    assert_equal expected, Gem.state_home
+  end
+
+  def test_state_home_from_env
+    Gem.instance_variable_set :@state_home, nil
+    Gem.data_home # memoize @data_home, to demonstrate GH-6418
+    ENV["XDG_STATE_HOME"] = expected = "/test/state/home"
+    assert_equal expected, Gem.state_home
+  end
+
   private
 
   def ruby_install_name(name)


### PR DESCRIPTION
~I wasn't able to find any useful way to test this, thus I decided to onboard related RuboCop rule excluding all violations for now (it is just few of them). I can update this PR if needed @deivid-rodriguez to try to update those files or I can do that later in separated PR.~

PR with Rubocop change will follow.

- fixes https://github.com/rubygems/rubygems/issues/6418