### PR TITLE
Auto-heal corrupted `Gemfile.lock` with no specs

### DIFF
--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -44,7 +44,9 @@ module Bundler
           incomplete = true
         end
 
-        @incomplete_specs += lookup[name] if incomplete && check
+        if incomplete && check
+          @incomplete_specs += lookup[name].any? ? lookup[name] : [LazySpecification.new(name, nil, nil)]
+        end
       end
 
       specs


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If a Gemfile.lock has a mismatch between `specs:` and `DEPENDENCIES`, printing funding information runs what boils down to `nil.metadata`. This caused a `NoMethodError` to be raised.

## What is your fix for the problem, implemented in this PR?

If the lockfile is malformed, it should be regenerated.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
