### PR TITLE
Remove hardcoded "master" branch references

### DIFF
--- a/lib/rubygems/request_set/gem_dependency_api.rb
+++ b/lib/rubygems/request_set/gem_dependency_api.rb
@@ -435,7 +435,6 @@ Gem dependencies file #{@path} requires #{name} more than once.
     reference ||= ref
     reference ||= branch
     reference ||= tag
-    reference ||= "master"
 
     if ref && branch
       warn <<-WARNING

--- a/lib/rubygems/source/git.rb
+++ b/lib/rubygems/source/git.rb
@@ -53,7 +53,7 @@ class Gem::Source::Git < Gem::Source
     @uri = Gem::Uri.parse(repository)
     @name            = name
     @repository      = repository
-    @reference       = reference
+    @reference       = reference || "HEAD"
     @need_submodules = submodules
 
     @remote   = true

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -563,14 +563,13 @@ class Gem::TestCase < Test::Unit::TestCase
     Dir.chdir directory do
       unless File.exist? ".git"
         system @git, "init", "--quiet"
-        system @git, "checkout", "-b", "master", "--quiet"
         system @git, "config", "user.name",  "RubyGems Tests"
         system @git, "config", "user.email", "rubygems@example"
       end
 
       system @git, "add", gemspec
       system @git, "commit", "-a", "-m", "a non-empty commit message", "--quiet"
-      head = Gem::Util.popen(@git, "rev-parse", "master").strip
+      head = Gem::Util.popen(@git, "rev-parse", "HEAD").strip
     end
 
     return name, git_spec.version, directory, head

--- a/test/rubygems/test_gem_request_set_gem_dependency_api.rb
+++ b/test/rubygems/test_gem_request_set_gem_dependency_api.rb
@@ -95,7 +95,7 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
 
     assert_equal [dep("a")], @set.dependencies
 
-    assert_equal %w[git/a master], @git_set.repositories["a"]
+    assert_equal ["git/a", nil], @git_set.repositories["a"]
 
     expected = { "a" => Gem::Requirement.create("!") }
 
@@ -107,7 +107,7 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
 
     assert_equal [dep("a")], @set.dependencies
 
-    assert_equal %w[https://example@bitbucket.org/example/repository.git master],
+    assert_equal ["https://example@bitbucket.org/example/repository.git", nil],
                  @git_set.repositories["a"]
 
     expected = { "a" => Gem::Requirement.create("!") }
@@ -120,7 +120,7 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
 
     assert_equal [dep("a")], @set.dependencies
 
-    assert_equal %w[https://example@bitbucket.org/example/example.git master],
+    assert_equal ["https://example@bitbucket.org/example/example.git", nil],
                  @git_set.repositories["a"]
 
     expected = { "a" => Gem::Requirement.create("!") }
@@ -145,7 +145,7 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
 
     assert_equal [dep("a")], @set.dependencies
 
-    assert_equal %w[https://gist.github.com/a.git master],
+    assert_equal ["https://gist.github.com/a.git", nil],
                  @git_set.repositories["a"]
   end
 
@@ -166,7 +166,7 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
 
     assert_equal [dep("a")], @set.dependencies
 
-    assert_equal %w[git/a master], @git_set.repositories["a"]
+    assert_equal ["git/a", nil], @git_set.repositories["a"]
     assert_equal %w[git/a], @git_set.need_submodules.keys
   end
 
@@ -183,7 +183,7 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
 
     assert_equal [dep("a")], @set.dependencies
 
-    assert_equal %w[https://github.com/example/repository.git master],
+    assert_equal ["https://github.com/example/repository.git", nil],
                  @git_set.repositories["a"]
 
     expected = { "a" => Gem::Requirement.create("!") }
@@ -196,7 +196,7 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
 
     assert_equal [dep("a")], @set.dependencies
 
-    assert_equal %w[https://github.com/example/example.git master],
+    assert_equal ["https://github.com/example/example.git", nil],
                  @git_set.repositories["a"]
 
     expected = { "a" => Gem::Requirement.create("!") }
@@ -609,8 +609,8 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
 
     assert_equal [dep("a"), dep("b")], @set.dependencies
 
-    assert_equal %w[git://example/repo.git master], @git_set.repositories["a"]
-    assert_equal %w[git://example/repo.git master], @git_set.repositories["b"]
+    assert_equal ["git://example/repo.git", nil], @git_set.repositories["a"]
+    assert_equal ["git://example/repo.git", nil], @git_set.repositories["b"]
   end
 
   def test_git_source
@@ -620,7 +620,7 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
 
     @gda.gem "a", :example => "repo"
 
-    assert_equal %w[git://example/repo.git master], @git_set.repositories["a"]
+    assert_equal ["git://example/repo.git", nil], @git_set.repositories["a"]
   end
 
   def test_group

--- a/test/rubygems/test_gem_request_set_lockfile_parser.rb
+++ b/test/rubygems/test_gem_request_set_lockfile_parser.rb
@@ -257,7 +257,7 @@ DEPENDENCIES
     write_lockfile <<-LOCKFILE
 GIT
   remote: git://example/a.git
-  revision: master
+  revision: abranch
   specs:
     a (2)
       b (>= 3)
@@ -289,7 +289,7 @@ DEPENDENCIES
                  git_set.specs.values.first.dependencies
 
     expected = {
-      "a" => %w[git://example/a.git master],
+      "a" => %w[git://example/a.git abranch],
     }
 
     assert_equal expected, git_set.repositories

--- a/test/rubygems/test_gem_resolver_git_set.rb
+++ b/test/rubygems/test_gem_resolver_git_set.rb
@@ -13,7 +13,7 @@ class TestGemResolverGitSet < Gem::TestCase
   def test_add_git_gem
     name, version, repository, = git_gem
 
-    @set.add_git_gem name, repository, "master", false
+    @set.add_git_gem name, repository, nil, false
 
     dependency = dep "a"
 
@@ -27,7 +27,7 @@ class TestGemResolverGitSet < Gem::TestCase
   def test_add_git_gem_submodules
     name, _, repository, = git_gem
 
-    @set.add_git_gem name, repository, "master", true
+    @set.add_git_gem name, repository, nil, true
 
     dependency = dep "a"
 
@@ -57,7 +57,7 @@ class TestGemResolverGitSet < Gem::TestCase
   def test_find_all
     name, _, repository, = git_gem
 
-    @set.add_git_gem name, repository, "master", false
+    @set.add_git_gem name, repository, nil, false
 
     dependency = dep "a", "~> 1.0"
     req = Gem::Resolver::DependencyRequest.new dependency, nil
@@ -73,7 +73,7 @@ class TestGemResolverGitSet < Gem::TestCase
   def test_find_all_local
     name, _, repository, = git_gem
 
-    @set.add_git_gem name, repository, "master", false
+    @set.add_git_gem name, repository, nil, false
     @set.remote = false
 
     dependency = dep "a", "~> 1.0"
@@ -88,7 +88,7 @@ class TestGemResolverGitSet < Gem::TestCase
   def test_find_all_prerelease
     name, _, repository, = git_gem "a", "1.a"
 
-    @set.add_git_gem name, repository, "master", false
+    @set.add_git_gem name, repository, nil, false
 
     dependency = dep "a", ">= 0"
     req = Gem::Resolver::DependencyRequest.new dependency, nil
@@ -122,7 +122,7 @@ class TestGemResolverGitSet < Gem::TestCase
   def test_prefetch
     name, _, repository, = git_gem
 
-    @set.add_git_gem name, repository, "master", false
+    @set.add_git_gem name, repository, nil, false
 
     dependency = dep name
     req = Gem::Resolver::DependencyRequest.new dependency, nil
@@ -136,7 +136,7 @@ class TestGemResolverGitSet < Gem::TestCase
   def test_prefetch_cache
     name, _, repository, = git_gem
 
-    @set.add_git_gem name, repository, "master", false
+    @set.add_git_gem name, repository, nil, false
 
     dependency = dep name
     req = Gem::Resolver::DependencyRequest.new dependency, nil
@@ -154,7 +154,7 @@ class TestGemResolverGitSet < Gem::TestCase
   def test_prefetch_filter
     name, _, repository, = git_gem
 
-    @set.add_git_gem name, repository, "master", false
+    @set.add_git_gem name, repository, nil, false
 
     dependency = dep "b"
     req = Gem::Resolver::DependencyRequest.new dependency, nil
@@ -168,7 +168,7 @@ class TestGemResolverGitSet < Gem::TestCase
   def test_prefetch_root_dir
     name, _, repository, = git_gem
 
-    @set.add_git_gem name, repository, "master", false
+    @set.add_git_gem name, repository, nil, false
 
     dependency = dep name
     req = Gem::Resolver::DependencyRequest.new dependency, nil

--- a/test/rubygems/test_gem_resolver_git_specification.rb
+++ b/test/rubygems/test_gem_resolver_git_specification.rb
@@ -84,7 +84,7 @@ class TestGemResolverGitSpecification < Gem::TestCase
       system @git, "commit", "--quiet", "-m", "Add extension files"
     end
 
-    source = Gem::Source::Git.new name, repository, "master", true
+    source = Gem::Source::Git.new name, repository, nil, true
 
     spec = source.specs.first
 

--- a/test/rubygems/test_gem_source.rb
+++ b/test/rubygems/test_gem_source.rb
@@ -30,7 +30,7 @@ class TestGemSource < Gem::TestCase
   def test_initialize_git
     repository = "git@example:a.git"
 
-    source = Gem::Source::Git.new "a", repository, "master", false
+    source = Gem::Source::Git.new "a", repository, nil, false
 
     assert_equal repository, source.uri
   end

--- a/test/rubygems/test_gem_source_installed.rb
+++ b/test/rubygems/test_gem_source_installed.rb
@@ -11,7 +11,7 @@ class TestGemSourceInstalled < Gem::TestCase
     specific  = Gem::Source::SpecificFile.new a1.cache_file
     installed = Gem::Source::Installed.new
     local     = Gem::Source::Local.new
-    git       = Gem::Source::Git.new "a", "a", "master"
+    git       = Gem::Source::Git.new "a", "a", nil
     vendor    = Gem::Source::Vendor.new "a"
 
     assert_equal(0, installed.<=>(installed), "installed <=> installed")

--- a/test/rubygems/test_gem_source_lock.rb
+++ b/test/rubygems/test_gem_source_lock.rb
@@ -18,7 +18,7 @@ class TestGemSourceLock < Gem::TestCase
   end
 
   def test_equals2
-    git    = Gem::Source::Git.new "a", "git/a", "master", false
+    git    = Gem::Source::Git.new "a", "git/a", nil, false
     g_lock = Gem::Source::Lock.new git
 
     installed = Gem::Source::Installed.new
@@ -30,7 +30,7 @@ class TestGemSourceLock < Gem::TestCase
   end
 
   def test_spaceship
-    git    = Gem::Source::Git.new "a", "git/a", "master", false
+    git    = Gem::Source::Git.new "a", "git/a", nil, false
     g_lock = Gem::Source::Lock.new git
 
     installed = Gem::Source::Installed.new
@@ -54,7 +54,7 @@ class TestGemSourceLock < Gem::TestCase
   end
 
   def test_spaceship_git
-    git  = Gem::Source::Git.new "a", "git/a", "master", false
+    git  = Gem::Source::Git.new "a", "git/a", nil, false
     lock = Gem::Source::Lock.new git
 
     assert_equal(1, lock.<=>(git),  "lock <=> git")

--- a/test/rubygems/test_gem_source_vendor.rb
+++ b/test/rubygems/test_gem_source_vendor.rb
@@ -12,7 +12,7 @@ class TestGemSourceVendor < Gem::TestCase
   def test_spaceship
     vendor    = Gem::Source::Vendor.new "vendor/foo"
     remote    = Gem::Source.new @gem_repo
-    git       = Gem::Source::Git.new "a", "a", "master"
+    git       = Gem::Source::Git.new "a", "a", nil
     installed = Gem::Source::Installed.new
 
     assert_equal(0, vendor.<=>(vendor),    "vendor <=> vendor")


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We should let repositories choose their own default branch.

## What is your fix for the problem, implemented in this PR?

Make RubyGems code respect the default branch of repositories, just like Bundler does.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
