### PR TITLE
Enable `Layout/DefEndAlignment`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,6 +30,9 @@ Layout/ClosingParenthesisIndentation:
 Layout/CommentIndentation:
   Enabled: true
 
+Layout/DefEndAlignment:
+  Enabled: true
+
 Layout/ElseAlignment:
   Enabled: true
 

--- a/test/rubygems/test_gem_commands_exec_command.rb
+++ b/test/rubygems/test_gem_commands_exec_command.rb
@@ -78,7 +78,7 @@ class TestGemCommandsExecCommand < Gem::TestCase
       }
     end
     @cmd.invoke "--gem", "cocoapods", "-v", "> 1", "--version", "< 1.3", "--verbose", "--", "pod", "install", "--no-color", "--help", "--verbose"
- end
+  end
 
   def test_single_arg_parsing
     @cmd.when_invoked do |options|


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We introduced an unaligned end recently and we didn't notice. Tests do show a warning though:

```
/Users/deivid/Code/rubygems/rubygems/test/rubygems/test_gem_commands_exec_command.rb:81: warning: mismatched indentations at 'end' with 'def' at 68
```

## What is your fix for the problem, implemented in this PR?

Introduce a cop to enforce this from now on.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
