### PR TITLE
Fix installation error of same version of default gems with local installation

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1612,6 +1612,8 @@ class Gem::Specification < Gem::BasicSpecification
   def build_extensions # :nodoc:
     return if extensions.empty?
     return if default_gem?
+    # we need to fresh build when same name and version of default gems
+    return if self.class.find_by_full_name(full_name)&.default_gem?
     return if File.exist? gem_build_complete_path
     return if !File.writable?(base_dir)
     return if !File.exist?(File.join(base_dir, "extensions"))

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1022,6 +1022,12 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   ##
+  # Find the best specification matching a +full_name+.
+  def self.find_by_full_name(full_name)
+    stubs.find {|s| s.full_name == full_name }&.to_spec
+  end
+
+  ##
   # Return the best specification that contains the file matching +path+.
 
   def self.find_by_path(path)

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3726,6 +3726,23 @@ end
     assert Gem::Specification.find_by_name "b", ">1"
   end
 
+  def test_find_by_full_name
+    pl = Gem::Platform.new "x86_64-linux"
+
+    a = util_spec "a", "1"
+    install_specs a
+
+    a_pl = util_spec("a", "1") {|s| s.platform = pl }
+    install_specs a_pl
+
+    assert_equal a, Gem::Specification.find_by_full_name("a-1")
+    assert_equal a_pl, Gem::Specification.find_by_full_name("a-1-x86_64-linux")
+
+    assert_nil Gem::Specification.find_by_full_name("a-2")
+    assert_nil Gem::Specification.find_by_full_name("b-1")
+    assert_nil Gem::Specification.find_by_full_name("a-1-arm64-linux")
+  end
+
   def test_find_by_path
     a = util_spec "foo", "1", nil, "lib/foo.rb"
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When we try to install local gem like `pkg/bigdecimal-3.1.4.gem` with Ruby 3.3.0-dev(ruby/ruby master version). RubyGems always fail with the following error.

https://github.com/ruby/bigdecimal/actions/runs/4269574995/jobs/7432842358

```
ERROR:  Error installing pkg/bigdecimal-3.1.4.gem:
	ERROR: Failed to build gem native extension.

    No such file or directory @ dir_s_mkdir - /home/runner/.rubies/ruby-head/lib/ruby/gems/3.3.0+0/gems/bigdecimal-3.1.4/ext/bigdecimal/.gem.2023022[5](https://github.com/ruby/bigdecimal/actions/runs/4269574995/jobs/7432842358#step:8:6)-1814-[6](https://github.com/ruby/bigdecimal/actions/runs/4269574995/jobs/7432842358#step:8:7)gtm34

Gem files will remain installed in /home/runner/.rubies/ruby-head/lib/ruby/gems/3.3.0+0/gems/bigdecimal-3.1.4 for inspection.
Results logged to /home/runner/.rubies/ruby-head/lib/ruby/gems/3.3.0+0/extensions/x[8](https://github.com/ruby/bigdecimal/actions/runs/4269574995/jobs/7432842358#step:8:9)6_64-linux/3.3.0+0/bigdecimal-3.1.4/gem_make.out
```

## What is your fix for the problem, implemented in this PR?

This is too complex condition. The assumption is that `json` is default gems(bigdecimal-3.1.4 didn't release yet, I showed same example with json), 
https://github.com/rubygems/rubygems/blob/master/lib/rubygems/request_set.rb#L183 is always true when it's given same name and same version.

When we try to install via rubygems.org like `gem i json -v 2.6.3`, It's working fine. When we use remote installation, gemspec is `APISpecification` in https://github.com/rubygems/rubygems/blob/master/lib/rubygems/request_set.rb#L184 like:

```
[Activation request
  [APISpecification name: json version: 2.6.3 platform: ruby dependencies: [] set uri: https://index.rubygems.org/info/]
   for [Dependency request  json (= 2.6.3)  requested by nil]]
```

This gemspec don't have `Gem::Specificaiton#extensions` like:

```ruby
Gem::Specification.new do |s|
  s.name = "json"
  s.version = Gem::Version.new("2.6.3")
  s.installed_by_version = Gem::Version.new("0")
  s.authors = ["Florian Frank"]
  s.date = Time.utc(2022, 12, 5)
  s.description = "This is a JSON implementation as a Ruby extension in C."
  s.email = "flori@ping.de"
  s.homepage = "http://flori.github.com/json"
  s.metadata = {"bug_tracker_uri"=>"https://github.com/flori/json/issues",
   "changelog_uri"=>"https://github.com/flori/json/blob/master/CHANGES.md",
   "documentation_uri"=>"http://flori.github.io/json/doc/index.html",
   "homepage_uri"=>"http://flori.github.io/json/",
   "source_code_uri"=>"https://github.com/flori/json",
   "wiki_uri"=>"https://github.com/flori/json/wiki"}
  s.require_paths = ["lib"]
  s.required_ruby_version = Gem::Requirement.new([">= 2.3"])
  s.rubygems_version = "3.4.0.dev"
  s.specification_version = 4
  s.summary = "JSON Implementation for Ruby"
  end
```

Because https://github.com/rubygems/rubygems/blob/master/lib/rubygems/specification.rb#L1607 is skip to this `Gem::Specification#build_extensions` and download, build, install after that.

But when we invoke `gem i pkg/json-2.6.3.gem`, we have `LocalSpecification` like:

```
[Activation request
  [LocalSpecification name: json version: 2.6.3 platform: ruby dependencies: [] source: /Users/hsbt/Documents/github.com/flori/json/pkg/json-2.6.3.gem]
   for [Dependency request  json (= 2.6.3)  requested by nil]]
```

This gemspec have full spec of `Gem::Specification`:

```ruby
Gem::Specification.new do |s|
  s.name = "json"
  s.version = Gem::Version.new("2.6.3")
  s.installed_by_version = Gem::Version.new("0")
  s.authors = ["Florian Frank"]
  s.date = Time.utc(2023, 3, 3)
  s.description = "This is a JSON implementation as a Ruby extension in C."
  s.email = "flori@ping.de"
  s.extensions = ["ext/json/ext/generator/extconf.rb", "ext/json/ext/parser/extconf.rb", "ext/json/extconf.rb"]
  s.extra_rdoc_files = ["README.md"]
  s.files = ["CHANGES.md",
   "LICENSE",
  # (snip)
   "lib/json/pure/parser.rb",
   "lib/json/version.rb"]
  s.homepage = "https://flori.github.io/json"
  s.licenses = ["Ruby"]
  s.metadata = {"bug_tracker_uri"=>"https://github.com/flori/json/issues",
   "changelog_uri"=>"https://github.com/flori/json/blob/master/CHANGES.md",
   "documentation_uri"=>"https://flori.github.io/json/doc/index.html",
   "homepage_uri"=>"https://flori.github.io/json",
   "source_code_uri"=>"https://github.com/flori/json",
   "wiki_uri"=>"https://github.com/flori/json/wiki"}
  s.rdoc_options = ["--title", "JSON implementation for Ruby", "--main", "README.md"]
  s.require_paths = ["/Users/hsbt/.local/share/gem/extensions/arm64-darwin-22/3.3.0+0-static/json-2.6.3", "lib"]
  s.required_ruby_version = Gem::Requirement.new([">= 2.3"])
  s.rubygems_version = "3.5.0.dev"
  s.specification_version = 4
  s.summary = "JSON Implementation for Ruby"
end
```

So, `Gem::Specification#build_extensions` try to build this spec despite there is no files of json-2.6.3.

----

I added guard condition to `Gem::Specification#build_extensions` for fullname of default gems. 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
