### PR TITLE
Add debug message for `nil` verson gemspec

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -521,6 +521,8 @@ class Gem::Installer
     else
       regenerate_plugins_for(spec, @plugins_dir)
     end
+  rescue ArgumentError => e
+    raise e, "#{latest.name} #{latest.version} #{spec.name} #{spec.version}: #{e.message}"
   end
 
   ##

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1708,6 +1708,8 @@ class Gem::Specification < Gem::BasicSpecification
         false
       end
     end
+  rescue ArgumentError => e
+    raise e, "#{name} #{version}: #{e.message}"
   end
 
   # The date this gem was created.


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When given gemspec that have `nil` version, RubyGems raised the following error.

```
nil versions are discouraged and will be deprecated in Rubygems 4
/usr/home/chkbuild/chkbuild/tmp/build/20230306T023004Z/lib/ruby/3.3.0+0/rubygems/requirement.rb:242:in `satisfied_by?': Need a Gem::Version: nil (ArgumentError)
```

This error message didn't have `Gem::Specification#name`. So, it's hard to investigate what gem has `nil` version.

FYI: We have this situation at http://rubyci.s3.amazonaws.com/freebsd12/ruby-master/log/20230306T023004Z.fail.html.gz#dist

## What is your fix for the problem, implemented in this PR?

Added debug message for `Gem::Specification#name` and `Gem::Specification#version` for related methods.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
