### PR TITLE
Avoid calling String#dup in Gem::Version#marshal_dump

### DIFF
--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -272,7 +272,7 @@ class Gem::Version
   # string for backwards (RubyGems 1.3.5 and earlier) compatibility.
 
   def marshal_dump
-    [version]
+    [@version]
   end
 
   ##


### PR DESCRIPTION

## What was the end-user or developer problem that led to this PR?

We're doing unnecessary work when marshal dumping versions, since the provided string is never returned directly to the user
Might potentially save a second every time RubyGems.org creates a specs index


## What is your fix for the problem, implemented in this PR?

Use the ivar directly, instead of calling the method that calls `@version.dup`

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
