### PR TITLE
Put extension_dir at first on full_require_paths when using C ext gem

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -145,15 +145,17 @@ class Gem::BasicSpecification
   def full_require_paths
     @full_require_paths ||=
     begin
-      full_paths = raw_require_paths.map do |path|
-        File.join full_gem_path, path.tap(&Gem::UNTAINT)
-      end
-
-      full_paths << extension_dir if have_extensions?
+      full_paths = []
 
       # We should search `extension_dir` first. because lib_dir mixed with
       # several architecture and ruby versions is a mess.
-      full_paths.reverse
+      full_paths << extension_dir if have_extensions?
+
+      full_paths = full_paths + raw_require_paths.map do |path|
+        File.join full_gem_path, path.tap(&Gem::UNTAINT)
+      end
+
+      full_paths
     end
   end
 

--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -151,7 +151,9 @@ class Gem::BasicSpecification
 
       full_paths << extension_dir if have_extensions?
 
-      full_paths
+      # We should search `extension_dir` first. because lib_dir mixed with
+      # several archtecture and ruby versions is a mess.
+      full_paths.reverse
     end
   end
 

--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -152,7 +152,7 @@ class Gem::BasicSpecification
       full_paths << extension_dir if have_extensions?
 
       # We should search `extension_dir` first. because lib_dir mixed with
-      # several archtecture and ruby versions is a mess.
+      # several architecture and ruby versions is a mess.
       full_paths.reverse
     end
   end

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1488,7 +1488,8 @@ gem 'other', version
     expected = File.join @spec.full_require_paths.find {|path|
       File.exist? File.join path, "b.rb"
     }, "b.rb"
-    assert_equal expected, @spec.matches_for_glob("b.rb").first
+    actual = File.join @spec.extension_dir, "b.rb"
+    assert_equal expected, actual
   end
 
   def test_install_extension_and_script

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2067,8 +2067,8 @@ dependencies: []
     @ext.require_paths = "lib"
 
     expected = [
-      File.join(@gemhome, "gems", @ext.original_name, "lib"),
       @ext.extension_dir,
+      File.join(@gemhome, "gems", @ext.original_name, "lib"),
     ]
 
     assert_equal expected, @ext.full_require_paths

--- a/test/rubygems/test_gem_stub_specification.rb
+++ b/test/rubygems/test_gem_stub_specification.rb
@@ -82,8 +82,8 @@ class TestStubSpecification < Gem::TestCase
     stub = stub_with_extension
 
     expected = [
-      File.join(stub.full_gem_path, "lib"),
       stub.extension_dir,
+      File.join(stub.full_gem_path, "lib"),
     ]
 
     assert_equal expected, stub.full_require_paths


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When we set `GEM_HOME` environment variable to `~/.gem` and use ruby version manager like `rbenv`, `chruby`, We always run `gem pristine` command for rebuild C extensions.

Because https://github.com/rubygems/rubygems/blob/master/lib/rubygems/ext/ext_conf_builder.rb#L47 install build artifact to `lib_dir` without `arch` and ruby version. 

## What is your fix for the problem, implemented in this PR?

I reverse orer of `Gem::Specification#full_require_paths` with C ext gems. 

before $LOAD_PATH:

```
    [
      "/Users/hsbt/.local/share/gem/gems/oj-3.14.2/lib",
      "/Users/hsbt/.local/share/gem/extensions/arm64-darwin-22/3.3.0+0-static/oj-3.14.2",
      "/Users/hsbt/.local/share/rbenv/versions/3.3.0-dev/lib/ruby/site_ruby/3.3.0+0",
      (snip)
      "/Users/hsbt/.local/share/rbenv/versions/3.3.0-dev/lib/ruby/3.3.0+0/arm64-darwin22"
    ]
```

after $LOAD_PATH:

```
    [
      "/Users/hsbt/.local/share/gem/extensions/arm64-darwin-22/3.3.0+0-static/oj-3.14.2",
      "/Users/hsbt/.local/share/gem/gems/oj-2.14.2/lib",
      "/Users/hsbt/.local/share/rbenv/versions/3.3.0-dev/lib/ruby/site_ruby/3.3.0+0",
      (snip)
      "/Users/hsbt/.local/share/rbenv/versions/3.3.0-dev/lib/ruby/3.3.0+0/arm64-darwin22"
    ]
```

## Further work

I need to more investigate effect of this change. current gem implementation mixed `.rb` and `.so` like https://github.com/ohler55/oj/blob/develop/lib/oj.rb#L12. `oj` case is safe for me. 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
