### PR TITLE
Don't ignore pre-releases when there's only one candidate

### DIFF
--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -299,7 +299,7 @@ module Bundler
     end
 
     def filter_prereleases(specs, package)
-      return specs unless package.ignores_prereleases?
+      return specs unless package.ignores_prereleases? && specs.size > 1
 
       specs.reject {|s| s.version.prerelease? }
     end

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -980,6 +980,31 @@ RSpec.describe "bundle lock" do
     expect(lockfile).to include("autobuild (1.10.1)")
   end
 
+  # Newer rails depends on Bundler, while ancient Rails does not. Bundler tries
+  # a first resolution pass that does not consider pre-releases. However, when
+  # using a pre-release Bundler (like the .dev version), that results in that
+  # pre-release being ignored and resolving to a version that does not depend on
+  # Bundler at all. We should avoid that and still consider .dev Bundler.
+  #
+  it "does not ignore prereleases with there's only one candidate" do
+    build_repo4 do
+      build_gem "rails", "7.4.0.2" do |s|
+        s.add_dependency "bundler", ">= 1.15.0"
+      end
+
+      build_gem "rails", "2.3.18"
+    end
+
+    gemfile <<~G
+      source "#{file_uri_for(gem_repo4)}"
+      gem "rails"
+    G
+
+    bundle "lock"
+    expect(lockfile).to_not include("rails (2.3.18)")
+    expect(lockfile).to include("rails (7.4.0.2)")
+  end
+
   it "deals with platform specific incompatibilities" do
     build_repo4 do
       build_gem "activerecord", "6.0.6"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

While playing around with the latest (master) branch of Bundler, I found a surprising behavior: a simple Gemfile including only "rails" resolves to Rails 2.3.18 (10 years old!) 😮.

## What is your fix for the problem, implemented in this PR?

Turns out the issue was introduced by #6246.

Since Bundler 2.5.0.dev is a pre-release version, Bundler actually ignores it and tries to find a resolution that does not have any dependency on Bundler, and Rails 2.3.18 satisfies that.

I could've special cased this specifically for Bundler, but I think it does make sense for every gem to not ignore prereleases if the resolver is considering a single version of that gem.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
