### PR TITLE
Don't consider platform specific candidates when `force_ruby_platform` set

### DIFF
--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -240,7 +240,7 @@ module Bundler
         ruby_specs = select_best_platform_match(specs, Gem::Platform::RUBY)
         groups << Resolver::Candidate.new(version, :specs => ruby_specs) if ruby_specs.any?
 
-        next groups if platform_specs == ruby_specs
+        next groups if platform_specs == ruby_specs || package.force_ruby_platform?
 
         groups << Resolver::Candidate.new(version, :specs => platform_specs)
 

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -1032,4 +1032,52 @@ RSpec.describe "bundle lock" do
       expect(lockfile).not_to include("tzinfo-data (1.2022.7)")
     end
   end
+
+  context "when resolving platform specific gems as indirect dependencies on truffleruby", :truffleruby_only do
+    before do
+      build_lib "foo", :path => bundled_app do |s|
+        s.add_dependency "nokogiri"
+      end
+
+      build_repo4 do
+        build_gem "nokogiri", "1.14.2"
+        build_gem "nokogiri", "1.14.2" do |s|
+          s.platform = "x86_64-linux"
+        end
+      end
+
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo4)}"
+        gemspec
+      G
+    end
+
+    it "locks ruby specs" do
+      simulate_platform "x86_64-linux" do
+        bundle "lock"
+      end
+
+      expect(lockfile).to eq <<~L
+        PATH
+          remote: .
+          specs:
+            foo (1.0)
+              nokogiri
+
+        GEM
+          remote: #{file_uri_for(gem_repo4)}/
+          specs:
+            nokogiri (1.14.2)
+
+        PLATFORMS
+          x86_64-linux
+
+        DEPENDENCIES
+          foo!
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+    end
+  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This was working fine for direct dependencies using `force_ruby_platform` explicitly through Gemfile, but not for indirect dependencies. In general, indirect dependencies do not have this property set, but in truffleruby this is different and the default value is to have it set.

## What is your fix for the problem, implemented in this PR?

Consider `force_ruby_platform` when finding resolution candidates for indirect dependencies.

Fixes #6435.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
