### PR TITLE
Detect extension files under full_required_paths

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -12,6 +12,8 @@ require_relative "stub_specification"
 require_relative "platform"
 require_relative "util/list"
 
+require "rbconfig"
+
 ##
 # The Specification class contains the information for a gem.  Typically
 # defined in a .gemspec file or a Rakefile, and looks like this:
@@ -2179,6 +2181,16 @@ class Gem::Specification < Gem::BasicSpecification
     return false if extensions.empty?
     return false if default_gem?
     return false if File.exist? gem_build_complete_path
+
+    # When we use this methods with local gemspec, we don't handle
+    # build status of extension correctly. So We need to find extension
+    # files in require_paths.
+    # TODO: Gem::Specification couldn't access extension name from extconf.rb
+    #       so we find them with heuristic way. We should improve it.
+    return false if (full_require_paths - [extension_dir]).any? do |path|
+      File.exist?(File.join(path, "#{name}.#{RbConfig::CONFIG['DLEXT']}")) ||
+        !Dir.glob(File.join(path, name, "*.#{RbConfig::CONFIG['DLEXT']}")).empty?
+    end
 
     true
   end

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2189,7 +2189,7 @@ class Gem::Specification < Gem::BasicSpecification
     #       so we find them with heuristic way. We should improve it.
     return false if (full_require_paths - [extension_dir]).any? do |path|
       File.exist?(File.join(path, "#{name}.#{RbConfig::CONFIG['DLEXT']}")) ||
-        !Dir.glob(File.join(path, name, "*.#{RbConfig::CONFIG['DLEXT']}")).empty?
+      !Dir.glob(File.join(path, name, "*.#{RbConfig::CONFIG['DLEXT']}")).empty?
     end
 
     true


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When we use this methods with local gemspec, we don't handle build status of extension correctly. So We need to find extension files in require_paths.

Example with ruby/erb repository:

```
$ bundle exec irb
Ignoring erb-4.0.2 because its extensions are not built. Try: gem pristine erb --version 4.0.2
>>
```

## What is your fix for the problem, implemented in this PR?

I added additional detection logic for above situation. `Gem::Specification` find extension files from `full_required_paths`.

But `Gem::Specification` couldn't access extension name from `extconf.rb`. So we find them with heuristic way. We should improve it or implement `gem.build_complete` file feature to `rake-compiler`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
