### PR TITLE
Added only missing extensions option into pristine command

### DIFF
--- a/lib/rubygems/commands/pristine_command.rb
+++ b/lib/rubygems/commands/pristine_command.rb
@@ -36,7 +36,6 @@ class Gem::Commands::PristineCommand < Gem::Command
 
     add_option("--only-missing-extensions",
                "Only restore gems with missing extensions") do |value, options|
-      options[:extensions_set] = true
       options[:only_missing_extensions] = value
     end
 

--- a/lib/rubygems/commands/pristine_command.rb
+++ b/lib/rubygems/commands/pristine_command.rb
@@ -34,6 +34,12 @@ class Gem::Commands::PristineCommand < Gem::Command
       options[:extensions]     = value
     end
 
+    add_option("--only-missing-extensions",
+               "Only restore gems with missing extensions") do |value, options|
+      options[:extensions_set] = true
+      options[:only_missing_extensions] = value
+    end
+
     add_option("--only-executables",
                "Only restore executables") do |value, options|
       options[:only_executables] = value
@@ -106,6 +112,10 @@ extensions will be restored.
           options[:extensions] && options[:args].empty?
       Gem::Specification.select do |spec|
         spec.extensions && !spec.extensions.empty?
+      end
+    elsif options[:only_missing_extensions]
+      Gem::Specification.select do |spec|
+        spec.missing_extensions?
       end
     else
       get_all_gem_names.sort.map do |gem_name|


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The current `gem pristine --extensions` try all of C-ext gems. But I sometimes need to pristine(rebuild) only broken C ext gems.

In background: I have over 100+ C-ext gems each Ruby versions. `gem pristine --extensions` spend while long time.

## What is your fix for the problem, implemented in this PR?

I added `--only-missing-extensions` option into `gem pristine`. It will rebuild only gems that `Gem::Specification#missing_extensions?` returns `true`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
