### PR TITLE
Drop to support Psych 3.0 bundled at Ruby 2.5

### DIFF
--- a/lib/rubygems/safe_yaml.rb
+++ b/lib/rubygems/safe_yaml.rb
@@ -24,34 +24,12 @@ module Gem
       runtime
     ].freeze
 
-    if ::Psych.respond_to? :safe_load
-      def self.safe_load(input)
-        if Gem::Version.new(Psych::VERSION) >= Gem::Version.new("3.1.0.pre1")
-          ::Psych.safe_load(input, permitted_classes: PERMITTED_CLASSES, permitted_symbols: PERMITTED_SYMBOLS, aliases: true)
-        else
-          ::Psych.safe_load(input, PERMITTED_CLASSES, PERMITTED_SYMBOLS, true)
-        end
-      end
+    def self.safe_load(input)
+      ::Psych.safe_load(input, permitted_classes: PERMITTED_CLASSES, permitted_symbols: PERMITTED_SYMBOLS, aliases: true)
+    end
 
-      def self.load(input)
-        if Gem::Version.new(Psych::VERSION) >= Gem::Version.new("3.1.0.pre1")
-          ::Psych.safe_load(input, permitted_classes: [::Symbol])
-        else
-          ::Psych.safe_load(input, [::Symbol])
-        end
-      end
-    else
-      unless Gem::Deprecate.skip
-        warn "Psych safe loading is not available. Please upgrade psych to a version that supports safe loading (>= 2.0)."
-      end
-
-      def self.safe_load(input, *args)
-        ::Psych.load input
-      end
-
-      def self.load(input)
-        ::Psych.load input
-      end
+    def self.load(input)
+      ::Psych.safe_load(input, permitted_classes: [::Symbol])
     end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We already drop to support Ruby 2.5, But Psych 3.0 bundled at Ruby 2.5 remains in our code.

## What is your fix for the problem, implemented in this PR?

Removed version check for Psych 3.0.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
