### PR TITLE
Fix plugins uninstallation for user installed gems

### DIFF
--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -50,7 +50,6 @@ class Gem::Uninstaller
     @gem                = gem
     @version            = options[:version] || Gem::Requirement.default
     @gem_home           = File.realpath(options[:install_dir] || Gem.dir)
-    @plugins_dir        = Gem.plugindir(@gem_home)
     @force_executables  = options[:executables]
     @force_all          = options[:all]
     @force_ignore       = options[:ignore]
@@ -284,7 +283,7 @@ class Gem::Uninstaller
   def remove_plugins(spec) # :nodoc:
     return if spec.plugins.empty?
 
-    remove_plugins_for(spec, @plugins_dir)
+    remove_plugins_for(spec, plugin_dir_for(spec))
   end
 
   ##
@@ -294,7 +293,7 @@ class Gem::Uninstaller
     latest = Gem::Specification.latest_spec_for(@spec.name)
     return if latest.nil?
 
-    regenerate_plugins_for(latest, @plugins_dir)
+    regenerate_plugins_for(latest, plugin_dir_for(@spec))
   end
 
   ##
@@ -405,5 +404,9 @@ class Gem::Uninstaller
     specs.each do |spec|
       say "Gem #{spec.full_name} cannot be uninstalled because it is a default gem"
     end
+  end
+
+  def plugin_dir_for(spec)
+    Gem.plugindir(spec.base_dir)
   end
 end

--- a/test/rubygems/test_gem_uninstaller.rb
+++ b/test/rubygems/test_gem_uninstaller.rb
@@ -215,6 +215,25 @@ class TestGemUninstaller < Gem::InstallerTestCase
     assert File.exist?(plugin_path), "plugin unintentionally removed"
   end
 
+  def test_remove_plugins_user_installed
+    write_file File.join(@tempdir, "lib", "rubygems_plugin.rb") do |io|
+      io.write "# do nothing"
+    end
+
+    @spec.files += %w[lib/rubygems_plugin.rb]
+
+    Gem::Installer.at(Gem::Package.build(@spec), force: true, user_install: true).install
+
+    plugin_path = File.join Gem.user_dir, "plugins/a_plugin.rb"
+    assert File.exist?(plugin_path), "plugin not written"
+
+    Gem::Specification.dirs = [Gem.dir, Gem.user_dir]
+
+    Gem::Uninstaller.new(@spec.name, executables: true, force: true, user_install: true).uninstall
+
+    refute File.exist?(plugin_path), "plugin not removed"
+  end
+
   def test_regenerate_plugins_for
     write_file File.join(@tempdir, "lib", "rubygems_plugin.rb") do |io|
       io.write "# do nothing"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Originally, when the plugins system was reworked as part of #3108, the plugin directory was considered global. But that is mistake. The plugins are always related to specific gems and therefore the directories should be handled via `Gem::Specification`. This will prevent issues such as leftovers after gem uninstallation as demonstred by #6452:

~~~
$ gem uni rubygems-server
Successfully uninstalled rubygems-server-0.3.0

$ gem install rubygems-server --document=ri,rdoc
Error loading RubyGems plugin "/builddir/.local/share/gem/ruby/plugins/rubygems-server_plugin.rb": cannot load such file -- /builddir/.local/share/gem/ruby/gems/rubygems-server-0.3.0/lib/rubygems_plugin.rb (LoadError) Fetching rubygems-server-0.3.0.gem
WARNING:  You don't have /builddir/bin in your PATH,
	  gem executables will not run.
Successfully installed rubygems-server-0.3.0
Parsing documentation for rubygems-server-0.3.0
Installing ri documentation for rubygems-server-0.3.0 Installing fedora::darkfish documentation for rubygems-server-0.3.0 Done installing documentation for rubygems-server after 0 seconds 1 gem installed
~~~

## What is your fix for the problem, implemented in this PR?

`Gem.Specification` should be responsible for providing plugins path.

Fixes #6452.