### PR TITLE
Avoid expiring git sources when unnecessary

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -243,6 +243,7 @@ bundler/lib/bundler/ui/rg_proxy.rb
 bundler/lib/bundler/ui/shell.rb
 bundler/lib/bundler/ui/silent.rb
 bundler/lib/bundler/uri_credentials_filter.rb
+bundler/lib/bundler/uri_normalizer.rb
 bundler/lib/bundler/vendor/.document
 bundler/lib/bundler/vendor/connection_pool/LICENSE
 bundler/lib/bundler/vendor/connection_pool/lib/connection_pool.rb

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -85,6 +85,7 @@ module Bundler
   autoload :StubSpecification,      File.expand_path("bundler/stub_specification", __dir__)
   autoload :UI,                     File.expand_path("bundler/ui", __dir__)
   autoload :URICredentialsFilter,   File.expand_path("bundler/uri_credentials_filter", __dir__)
+  autoload :URINormalizer,          File.expand_path("bundler/uri_normalizer", __dir__)
 
   class << self
     def configure

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -495,7 +495,7 @@ module Bundler
         uri = $2
         suffix = $3
       end
-      uri = "#{uri}/" unless uri.end_with?("/")
+      uri = URINormalizer.normalize_suffix(uri)
       require_relative "vendored_uri"
       uri = Bundler::URI(uri)
       unless uri.absolute?

--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -19,7 +19,7 @@ module Bundler
         # Stringify options that could be set as symbols
         %w[ref branch tag revision].each {|k| options[k] = options[k].to_s if options[k] }
 
-        @uri        = options["uri"] || ""
+        @uri        = URINormalizer.normalize_suffix(options["uri"] || "", :trailing_slash => false)
         @safe_uri   = URICredentialsFilter.credential_filtered_uri(@uri)
         @branch     = options["branch"]
         @ref        = options["ref"] || options["branch"] || options["tag"]

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -337,8 +337,7 @@ module Bundler
       end
 
       def normalize_uri(uri)
-        uri = uri.to_s
-        uri = "#{uri}/" unless %r{/$}.match?(uri)
+        uri = URINormalizer.normalize_suffix(uri.to_s)
         require_relative "../vendored_uri"
         uri = Bundler::URI(uri)
         raise ArgumentError, "The source must be an absolute URI. For example:\n" \

--- a/bundler/lib/bundler/uri_normalizer.rb
+++ b/bundler/lib/bundler/uri_normalizer.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Bundler
+  module URINormalizer
+    module_function
+
+    # Normalizes uri to a consistent version, either with or without trailing
+    # slash.
+    #
+    # TODO: Currently gem sources are locked with a trailing slash, while git
+    # sources are locked without a trailing slash. This should be normalized but
+    # the inconsistency is there for now to avoid changing all lockfiles
+    # including GIT sources. We could normalize this on the next major.
+    #
+    def normalize_suffix(uri, trailing_slash: true)
+      if trailing_slash
+        uri.end_with?("/") ? uri : "#{uri}/"
+      else
+        uri.end_with?("/") ? uri.delete_suffix("/") : uri
+      end
+    end
+  end
+end

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -140,6 +140,24 @@ RSpec.describe "bundle lock" do
     expect(read_lockfile).to eq(@lockfile)
   end
 
+  it "does not unlock git sources when only uri shape changes" do
+    build_git("foo")
+
+    install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
+      gem "foo", :git => "#{file_uri_for(lib_path("foo-1.0"))}"
+    G
+
+    # Change uri format to end with "/" and reinstall
+    install_gemfile <<-G, :verbose => true
+      source "#{file_uri_for(gem_repo1)}"
+      gem "foo", :git => "#{file_uri_for(lib_path("foo-1.0"))}/"
+    G
+
+    expect(out).to include("using resolution from the lockfile")
+    expect(out).not_to include("re-resolving dependencies because the list of sources changed")
+  end
+
   it "errors when updating a missing specific gems using --update" do
     lockfile @lockfile
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I was very confused while writing a regression spec for something else, because Bundler kept expiring the GIT source in the dummy test lockfile I was using and I didn't know why.

Turns out I was writing the lockfile GIT source with a trailing slash, and because of this, Bundler was expiring it because the Gemfile source did not have a trailing slash.

A "style change" like this one should not make Bundler expire a source and the same thing is already handled for GEM sources.

## What is your fix for the problem, implemented in this PR?

Properly normalize git sources URIs to not care about trailing slashes.

I initially normalized this to always include a trailing slash in the lockfile, which is what GEM sources do, but that caused a lot of spec failures because currently GIT sources are locked with whatever the Gemfile specifies, and that's usually _without_ a trailing slash.

So for now I'm just making this consistent, but not changing the way most GIT sources are locked.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
