### PR TITLE
When running `bundle lock --update <name>`, checkout locked revision of unrelated git sources directly

### DIFF
--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -366,6 +366,11 @@ module Bundler
           args += ["--single-branch"]
           args.unshift("--no-tags") if supports_cloning_with_no_tags?
 
+          # If there's a locked revision, no need to clone any specific branch
+          # or tag, since we will end up checking out that locked revision
+          # anyways.
+          return args if @revision
+
           args += ["--branch", branch || tag] if branch || tag
           args
         end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since Bundler 2.4, we will try to checkout any branch specified in the Gemfile, even if there's a locked revision in the `Gemfile.lock` and the lockfile source has not been expired (for example, when running `bundle lock --update <unrelated-gem-from-a-gem-source>`). Until Bundler 2.3 we would directly checkout the locked revision in this situation.
    
This should not make any difference in most situations, but in some edge cases, like if the branch specified in the `Gemfile` has been renamed, but the locked revision still exist, it causes an error now while before it would update the lockfile without issues.
    
## What is your fix for the problem, implemented in this PR?

I debated which behavior was best, since I was not sure. But my conclusion is that if the situation does not require expiring the lockfile source in favor of the Gemfile source, we should use the locked revision directly and proceed happily. So I restored Bundler 2.3 behavior.
    
I think this is consistent with how yanked gems are handled, for example.
    
Of course, if explicitly updating the git source itself, or all gems, we will still get any errors like missing branches related to the git source.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
