### PR TITLE
Remove side-effect of GEM_HOME configuration for some tests

### DIFF
--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1464,6 +1464,9 @@ class TestGem < Gem::TestCase
   end
 
   def test_load_user_installed_plugins
+    @orig_gem_home = ENV['GEM_HOME']
+    ENV['GEM_HOME'] = @gemhome
+
     plugin_path = File.join "lib", "rubygems_plugin.rb"
 
     Dir.chdir @tempdir do
@@ -1486,6 +1489,8 @@ class TestGem < Gem::TestCase
     Gem.load_plugins
 
     assert_equal %w[plugin], PLUGINS_LOADED
+  ensure
+    ENV['GEM_HOME'] = @orig_gem_home
   end
 
   def test_load_env_plugins

--- a/test/rubygems/test_gem_gem_runner.rb
+++ b/test/rubygems/test_gem_gem_runner.rb
@@ -3,6 +3,9 @@ require_relative "helper"
 
 class TestGemGemRunner < Gem::TestCase
   def setup
+    @orig_gem_home = ENV["GEM_HOME"]
+    ENV["GEM_HOME"] = @gemhome
+
     require "rubygems/command"
     @orig_args = Gem::Command.build_args
     @orig_specific_extra_args = Gem::Command.specific_extra_args_hash.dup
@@ -20,6 +23,8 @@ class TestGemGemRunner < Gem::TestCase
     Gem::Command.build_args = @orig_args
     Gem::Command.specific_extra_args_hash = @orig_specific_extra_args
     Gem::Command.extra_args = @orig_extra_args
+
+    ENV["GEM_HOME"] = @orig_gem_home
   end
 
   def test_do_configuration


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When I set `~/.gem` to `GEM_HOME`, `rake test` always show like:

```
Loaded suite /Users/hsbt/.local/share/rbenv/versions/3.3.0-dev/lib/ruby/gems/3.3.0+0/gems/rake-13.0.6/lib/rake/rake_test_loader
Started
...............................................................................................
.....................................................................................Ignoring RedCloth-4.3.2 because its extensions are not built. Try: gem pristine RedCloth --version 4.3.2
Ignoring aliyun-sdk-0.8.0 because its extensions are not built. Try: gem pristine aliyun-sdk --version 0.8.0
(snip
....
```

## What is your fix for the problem, implemented in this PR?

In my investigation, some tests reuse `GEM_HOME` configuration in there tests. I remove and restore `GEM_HOME` while their test methods.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
