### PR TITLE
Allow configuration for `install_extension_in_lib`

### DIFF
--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -47,6 +47,7 @@ class Gem::ConfigFile
   DEFAULT_CONCURRENT_DOWNLOADS = 8
   DEFAULT_CERT_EXPIRATION_LENGTH_DAYS = 365
   DEFAULT_IPV4_FALLBACK_ENABLED = false
+  DEFAULT_INSTALL_EXTENSION_IN_LIB = false
 
   ##
   # For Ruby packagers to set configuration defaults.  Set in
@@ -59,11 +60,6 @@ class Gem::ConfigFile
   # rubygems/defaults/#{RUBY_ENGINE}.rb
 
   PLATFORM_DEFAULTS = Gem.platform_defaults
-
-  ##
-  # For installation of gems to install build extensions into lib dir
-
-  INSTALL_EXTENSION_IN_LIB = Gem.install_extension_in_lib
 
   # :stopdoc:
 
@@ -148,7 +144,7 @@ class Gem::ConfigFile
   attr_accessor :cert_expiration_length_days
 
   ##
-  #
+  # Install extensions into lib as well as into the extension directory.
 
   attr_accessor :install_extension_in_lib
 
@@ -193,7 +189,7 @@ class Gem::ConfigFile
     @update_sources = DEFAULT_UPDATE_SOURCES
     @concurrent_downloads = DEFAULT_CONCURRENT_DOWNLOADS
     @cert_expiration_length_days = DEFAULT_CERT_EXPIRATION_LENGTH_DAYS
-    @install_extension_in_lib = INSTALL_EXTENSION_IN_LIB
+    @install_extension_in_lib = DEFAULT_INSTALL_EXTENSION_IN_LIB
     @ipv4_fallback_enabled = ENV["IPV4_FALLBACK_ENABLED"] == "true" || DEFAULT_IPV4_FALLBACK_ENABLED
 
     operating_system_config = Marshal.load Marshal.dump(OPERATING_SYSTEM_DEFAULTS)
@@ -477,7 +473,7 @@ if you believe they were disclosed to a third party.
       @hash.fetch(:concurrent_downloads, DEFAULT_CONCURRENT_DOWNLOADS)
 
     yaml_hash[:install_extension_in_lib] =
-      @hash.fetch(:install_extension_in_lib, INSTALL_EXTENSION_IN_LIB)
+      @hash.fetch(:install_extension_in_lib, DEFAULT_INSTALL_EXTENSION_IN_LIB)
 
     yaml_hash[:ssl_verify_mode] =
       @hash[:ssl_verify_mode] if @hash.key? :ssl_verify_mode

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -60,6 +60,11 @@ class Gem::ConfigFile
 
   PLATFORM_DEFAULTS = Gem.platform_defaults
 
+  ##
+  # For installation of gems to install build extensions into lib dir
+
+  INSTALL_EXTENSION_IN_LIB = Gem.install_extension_in_lib
+
   # :stopdoc:
 
   SYSTEM_CONFIG_PATH =
@@ -143,6 +148,11 @@ class Gem::ConfigFile
   attr_accessor :cert_expiration_length_days
 
   ##
+  #
+
+  attr_accessor :install_extension_in_lib
+
+  ##
   # == Experimental ==
   # Fallback to IPv4 when IPv6 is not reachable or slow (default: false)
 
@@ -183,6 +193,7 @@ class Gem::ConfigFile
     @update_sources = DEFAULT_UPDATE_SOURCES
     @concurrent_downloads = DEFAULT_CONCURRENT_DOWNLOADS
     @cert_expiration_length_days = DEFAULT_CERT_EXPIRATION_LENGTH_DAYS
+    @install_extension_in_lib = INSTALL_EXTENSION_IN_LIB
     @ipv4_fallback_enabled = ENV["IPV4_FALLBACK_ENABLED"] == "true" || DEFAULT_IPV4_FALLBACK_ENABLED
 
     operating_system_config = Marshal.load Marshal.dump(OPERATING_SYSTEM_DEFAULTS)
@@ -212,6 +223,7 @@ class Gem::ConfigFile
     @disable_default_gem_server  = @hash[:disable_default_gem_server]  if @hash.key? :disable_default_gem_server
     @sources                     = @hash[:sources]                     if @hash.key? :sources
     @cert_expiration_length_days = @hash[:cert_expiration_length_days] if @hash.key? :cert_expiration_length_days
+    @install_extension_in_lib    = @hash[:install_extension_in_lib]    if @hash.key? :install_extension_in_lib
     @ipv4_fallback_enabled       = @hash[:ipv4_fallback_enabled]       if @hash.key? :ipv4_fallback_enabled
 
     @ssl_verify_mode  = @hash[:ssl_verify_mode]  if @hash.key? :ssl_verify_mode
@@ -463,6 +475,9 @@ if you believe they were disclosed to a third party.
 
     yaml_hash[:concurrent_downloads] =
       @hash.fetch(:concurrent_downloads, DEFAULT_CONCURRENT_DOWNLOADS)
+
+    yaml_hash[:install_extension_in_lib] =
+      @hash.fetch(:install_extension_in_lib, INSTALL_EXTENSION_IN_LIB)
 
     yaml_hash[:ssl_verify_mode] =
       @hash[:ssl_verify_mode] if @hash.key? :ssl_verify_mode

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -47,7 +47,7 @@ class Gem::ConfigFile
   DEFAULT_CONCURRENT_DOWNLOADS = 8
   DEFAULT_CERT_EXPIRATION_LENGTH_DAYS = 365
   DEFAULT_IPV4_FALLBACK_ENABLED = false
-  DEFAULT_INSTALL_EXTENSION_IN_LIB = false
+  DEFAULT_INSTALL_EXTENSION_IN_LIB = true
 
   ##
   # For Ruby packagers to set configuration defaults.  Set in

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -47,6 +47,7 @@ class Gem::ConfigFile
   DEFAULT_CONCURRENT_DOWNLOADS = 8
   DEFAULT_CERT_EXPIRATION_LENGTH_DAYS = 365
   DEFAULT_IPV4_FALLBACK_ENABLED = false
+  # TODO: Use false as default value for this option in RubyGems 4.0
   DEFAULT_INSTALL_EXTENSION_IN_LIB = true
 
   ##

--- a/lib/rubygems/defaults.rb
+++ b/lib/rubygems/defaults.rb
@@ -248,6 +248,13 @@ module Gem
   end
 
   ##
+  # Install extensions into lib as well as into the extension directory.
+
+  def self.install_extension_in_lib # :nodoc:
+    Gem.configuration.install_extension_in_lib
+  end
+
+  ##
   # Directory where vendor gems are installed.
 
   def self.vendor_dir # :nodoc:

--- a/lib/rubygems/defaults.rb
+++ b/lib/rubygems/defaults.rb
@@ -248,13 +248,6 @@ module Gem
   end
 
   ##
-  # Install extensions into lib as well as into the extension directory.
-
-  def self.install_extension_in_lib # :nodoc:
-    true
-  end
-
-  ##
   # Directory where vendor gems are installed.
 
   def self.vendor_dir # :nodoc:

--- a/lib/rubygems/ext/cargo_builder.rb
+++ b/lib/rubygems/ext/cargo_builder.rb
@@ -47,8 +47,7 @@ class Gem::Ext::CargoBuilder < Gem::Ext::Builder
 
       nesting = extension_nesting(extension)
 
-      # TODO: remove in RubyGems 4
-      if Gem.install_extension_in_lib && lib_dir
+      if !Gem.configuration.install_extension_in_lib && lib_dir
         nested_lib_dir = File.join(lib_dir, nesting)
         FileUtils.mkdir_p nested_lib_dir
         FileUtils.cp_r dlext_path, nested_lib_dir, remove_destination: true

--- a/lib/rubygems/ext/cargo_builder.rb
+++ b/lib/rubygems/ext/cargo_builder.rb
@@ -47,7 +47,7 @@ class Gem::Ext::CargoBuilder < Gem::Ext::Builder
 
       nesting = extension_nesting(extension)
 
-      if !Gem.configuration.install_extension_in_lib && lib_dir
+      if Gem.configuration.install_extension_in_lib && lib_dir
         nested_lib_dir = File.join(lib_dir, nesting)
         FileUtils.mkdir_p nested_lib_dir
         FileUtils.cp_r dlext_path, nested_lib_dir, remove_destination: true

--- a/lib/rubygems/ext/cargo_builder.rb
+++ b/lib/rubygems/ext/cargo_builder.rb
@@ -47,7 +47,7 @@ class Gem::Ext::CargoBuilder < Gem::Ext::Builder
 
       nesting = extension_nesting(extension)
 
-      if Gem.configuration.install_extension_in_lib && lib_dir
+      if Gem.install_extension_in_lib && lib_dir
         nested_lib_dir = File.join(lib_dir, nesting)
         FileUtils.mkdir_p nested_lib_dir
         FileUtils.cp_r dlext_path, nested_lib_dir, remove_destination: true

--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -43,8 +43,7 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
 
       full_tmp_dest = File.join(extension_dir, tmp_dest_relative)
 
-      # TODO: remove in RubyGems 4
-      if Gem.install_extension_in_lib && lib_dir
+      if !Gem.configuration.install_extension_in_lib && lib_dir
         FileUtils.mkdir_p lib_dir
         entries = Dir.entries(full_tmp_dest) - %w[. ..]
         entries = entries.map {|entry| File.join full_tmp_dest, entry }

--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -43,7 +43,7 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
 
       full_tmp_dest = File.join(extension_dir, tmp_dest_relative)
 
-      if Gem.configuration.install_extension_in_lib && lib_dir
+      if Gem.install_extension_in_lib && lib_dir
         FileUtils.mkdir_p lib_dir
         entries = Dir.entries(full_tmp_dest) - %w[. ..]
         entries = entries.map {|entry| File.join full_tmp_dest, entry }

--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -43,7 +43,7 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
 
       full_tmp_dest = File.join(extension_dir, tmp_dest_relative)
 
-      if !Gem.configuration.install_extension_in_lib && lib_dir
+      if Gem.configuration.install_extension_in_lib && lib_dir
         FileUtils.mkdir_p lib_dir
         entries = Dir.entries(full_tmp_dest) - %w[. ..]
         entries = entries.map {|entry| File.join full_tmp_dest, entry }

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -58,6 +58,7 @@ class TestGemConfigFile < Gem::TestCase
       fp.puts ":ssl_verify_mode: 0"
       fp.puts ":ssl_ca_cert: /etc/ssl/certs"
       fp.puts ":cert_expiration_length_days: 28"
+      fp.puts ":install_extension_in_lib: true"
       fp.puts ":ipv4_fallback_enabled: true"
     end
 
@@ -73,6 +74,7 @@ class TestGemConfigFile < Gem::TestCase
     assert_equal 0, @cfg.ssl_verify_mode
     assert_equal "/etc/ssl/certs", @cfg.ssl_ca_cert
     assert_equal 28, @cfg.cert_expiration_length_days
+    assert_equal true, @cfg.install_extension_in_lib
     assert_equal true, @cfg.ipv4_fallback_enabled
   end
 
@@ -507,6 +509,14 @@ if you believe they were disclosed to a third party.
     end
     util_config_file
     assert_equal("/home/me/mine.pem", @cfg.ssl_client_cert)
+  end
+
+  def test_load_install_extension_in_lib_from_config
+    File.open @temp_conf, "w" do |fp|
+      fp.puts ":install_extension_in_lib: false"
+    end
+    util_config_file
+    assert_equal(false, @cfg.install_extension_in_lib)
   end
 
   def util_config_file(args = @cfg_args)

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -519,10 +519,6 @@ if you believe they were disclosed to a third party.
     assert_equal(false, @cfg.install_extension_in_lib)
   end
 
-  def util_config_file(args = @cfg_args)
-    @cfg = Gem::ConfigFile.new args
-  end
-
   def test_disable_default_gem_server
     File.open @temp_conf, "w" do |fp|
       fp.puts ":disable_default_gem_server: true"
@@ -567,5 +563,9 @@ if you believe they were disclosed to a third party.
 
     actual = Gem::ConfigFile.load_with_rubygems_config_hash(yaml)
     assert_equal("bar", actual[:foo])
+  end
+
+  def util_config_file(args = @cfg_args)
+    @cfg = Gem::ConfigFile.new args
   end
 end

--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -161,6 +161,9 @@ install:
     pend "terminates on mswin" if vc_windows? && ruby_repo?
 
     extension_in_lib(false) do
+      @orig_install_extension_in_lib = Gem.configuration.install_extension_in_lib
+      Gem.configuration.install_extension_in_lib = true
+
       @spec.extensions << "ext/extconf.rb"
 
       ext_dir = File.join @spec.gem_dir, "ext"
@@ -194,6 +197,8 @@ install:
       assert_path_not_exist File.join @spec.gem_dir, "lib", "a.rb"
       assert_path_not_exist File.join @spec.gem_dir, "lib", "a", "b.rb"
     end
+  ensure
+    Gem.configuration.install_extension_in_lib = @orig_install_extension_in_lib
   end
 
   def test_build_extensions_none

--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -162,7 +162,7 @@ install:
 
     extension_in_lib(false) do
       @orig_install_extension_in_lib = Gem.configuration.install_extension_in_lib
-      Gem.configuration.install_extension_in_lib = true
+      Gem.configuration.install_extension_in_lib = false
 
       @spec.extensions << "ext/extconf.rb"
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This is another approach for https://github.com/rubygems/rubygems/pull/6439

We handle to install build artifact under the `lib` directory by `Gem.install_extension_in_lib` value. This value is by hard-coded. We couldn't change it without RubyGems version up.

## What is your fix for the problem, implemented in this PR?

I make `Gem.install_extension_in_lib` value configurable by `gemrc`. The users included me can avoid to install mixed arch and ruby version artifact under the `lib` directory by this.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
