### PR TITLE
Reduce method call in missing_extensions?

### DIFF
--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -82,9 +82,10 @@ module Gem
       # TODO: Gem::Specification couldn't access extension name from extconf.rb
       #       so we find them with heuristic way. We should improve it.
       if source.respond_to?(:root)
-        return false if (full_require_paths - [extension_dir]).any? do |path|
-          File.exist?(File.join(path, "#{name}.#{RbConfig::CONFIG["DLEXT"]}")) ||
-          !Dir.glob(File.join(path, name, "*.#{RbConfig::CONFIG["DLEXT"]}")).empty?
+        return false if raw_require_paths.any? do |path|
+          ext_dir = File.join(full_gem_path, path)
+          File.exist?(File.join(ext_dir, "#{name}.#{RbConfig::CONFIG["DLEXT"]}")) ||
+          !Dir.glob(File.join(ext_dir, name, "*.#{RbConfig::CONFIG["DLEXT"]}")).empty?
         end
       end
 

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -74,6 +74,23 @@ module Gem
       end
     end
 
+    alias_method :rg_missing_extensions?, :missing_extensions?
+    def missing_extensions?
+      # When we use this methods with local gemspec, we don't handle
+      # build status of extension correctly. So We need to find extension
+      # files in require_paths.
+      # TODO: Gem::Specification couldn't access extension name from extconf.rb
+      #       so we find them with heuristic way. We should improve it.
+      if source.respond_to?(:root)
+        return false if (full_require_paths - [extension_dir]).any? do |path|
+          File.exist?(File.join(path, "#{name}.#{RbConfig::CONFIG['DLEXT']}")) ||
+          !Dir.glob(File.join(path, name, "*.#{RbConfig::CONFIG['DLEXT']}")).empty?
+        end
+      end
+
+      rg_missing_extensions?
+    end
+
     remove_method :gem_dir if instance_methods(false).include?(:gem_dir)
     def gem_dir
       full_gem_path

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -83,8 +83,8 @@ module Gem
       #       so we find them with heuristic way. We should improve it.
       if source.respond_to?(:root)
         return false if (full_require_paths - [extension_dir]).any? do |path|
-          File.exist?(File.join(path, "#{name}.#{RbConfig::CONFIG['DLEXT']}")) ||
-          !Dir.glob(File.join(path, name, "*.#{RbConfig::CONFIG['DLEXT']}")).empty?
+          File.exist?(File.join(path, "#{name}.#{RbConfig::CONFIG["DLEXT"]}")) ||
+          !Dir.glob(File.join(path, name, "*.#{RbConfig::CONFIG["DLEXT"]}")).empty?
         end
       end
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2184,16 +2184,6 @@ class Gem::Specification < Gem::BasicSpecification
     return false if default_gem?
     return false if File.exist? gem_build_complete_path
 
-    # When we use this methods with local gemspec, we don't handle
-    # build status of extension correctly. So We need to find extension
-    # files in require_paths.
-    # TODO: Gem::Specification couldn't access extension name from extconf.rb
-    #       so we find them with heuristic way. We should improve it.
-    return false if (full_require_paths - [extension_dir]).any? do |path|
-      File.exist?(File.join(path, "#{name}.#{RbConfig::CONFIG['DLEXT']}")) ||
-      !Dir.glob(File.join(path, name, "*.#{RbConfig::CONFIG['DLEXT']}")).empty?
-    end
-
     true
   end
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3663,31 +3663,6 @@ end
     refute @a1.missing_extensions?
   end
 
-  def test_missing_extensions_eh_local_gemspec
-    pend "extensions don't quite work on jruby" if Gem.java_platform?
-
-    spec = new_default_spec "default", 1
-    spec.extensions << "extconf.rb"
-
-    ext_spec
-    @ext.name = spec.name
-    FileUtils.mkdir_p File.join(@ext.gem_dir, "lib")
-
-    # ext_spec used empty extconf.rb, so we need to create dummy extension for rake-compiler case.
-    # Ex. lib/gemname.so
-    FileUtils.touch File.join(@ext.gem_dir, "lib", "#{@ext.name}.#{RbConfig::CONFIG['DLEXT']}")
-
-    refute @ext.missing_extensions?
-
-    # Try to another case of extconf.rb
-    # Ex. lib/gemname/parser.so
-    FileUtils.rm File.join(@ext.gem_dir, "lib", "#{@ext.name}.#{RbConfig::CONFIG['DLEXT']}")
-    FileUtils.mkdir_p File.join(@ext.gem_dir, "lib", @ext.name)
-    FileUtils.touch File.join(@ext.gem_dir, "lib", @ext.name, "parser.#{RbConfig::CONFIG['DLEXT']}")
-
-    refute @ext.missing_extensions?
-  end
-
   def test_find_all_by_full_name
     pl = Gem::Platform.new "i386-linux"
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

https://github.com/rubygems/rubygems/pull/6444 is heavily called in RubyGems.

## What is your fix for the problem, implemented in this PR?

I moved search logic to bundler side. This logic called only git source repo.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
