### PR TITLE
Fix duplicated specs in some error messages

### DIFF
--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -49,7 +49,7 @@ module Bundler
         end
       end
 
-      specs
+      specs.uniq
     end
 
     def [](key)

--- a/bundler/spec/bundler/definition_spec.rb
+++ b/bundler/spec/bundler/definition_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe Bundler::Definition do
             only_java (1.1-java)
 
         PLATFORMS
-          #{lockfile_platforms_for(["java", specific_local_platform])}
+          #{lockfile_platforms_for("java", specific_local_platform)}
 
         DEPENDENCIES
           only_java

--- a/bundler/spec/bundler/definition_spec.rb
+++ b/bundler/spec/bundler/definition_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe Bundler::Definition do
             only_java (1.1-java)
 
         PLATFORMS
-          #{lockfile_platforms_for("java", specific_local_platform)}
+          #{lockfile_platforms("java")}
 
         DEPENDENCIES
           only_java

--- a/bundler/spec/commands/check_spec.rb
+++ b/bundler/spec/commands/check_spec.rb
@@ -351,7 +351,7 @@ RSpec.describe "bundle check" do
 
         PLATFORMS
           ruby
-          #{specific_local_platform}
+          #{local_platform}
 
         DEPENDENCIES
           rack

--- a/bundler/spec/commands/check_spec.rb
+++ b/bundler/spec/commands/check_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe "bundle check" do
           rack (1.0.0)
 
       PLATFORMS
-        #{local}
+        #{generic_local_platform}
         #{not_local}
 
       DEPENDENCIES
@@ -203,7 +203,7 @@ RSpec.describe "bundle check" do
           rack (1.0.0)
 
       PLATFORMS
-        #{local}
+        #{generic_local_platform}
         #{not_local}
 
       DEPENDENCIES

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -331,11 +331,11 @@ RSpec.describe "bundle lock" do
         remote: #{file_uri_for(gem_repo1)}/
         specs:
           platform_specific (1.0)
-          platform_specific (1.0-x86-linux)
+          platform_specific (1.0-x86-64_linux)
 
       PLATFORMS
         ruby
-        x86-linux
+        x86_64-linux
 
       DEPENDENCIES
         platform_specific

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -322,7 +322,7 @@ RSpec.describe "bundle lock" do
 
     allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
     lockfile = Bundler::LockfileParser.new(read_lockfile)
-    expect(lockfile.platforms).to match_array([java, x86_mingw32, specific_local_platform].uniq)
+    expect(lockfile.platforms).to match_array([java, x86_mingw32, local_platform].uniq)
   end
 
   it "supports adding new platforms with force_ruby_platform = true" do
@@ -354,7 +354,7 @@ RSpec.describe "bundle lock" do
 
     allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
     lockfile = Bundler::LockfileParser.new(read_lockfile)
-    expect(lockfile.platforms).to match_array(["ruby", specific_local_platform].uniq)
+    expect(lockfile.platforms).to match_array(["ruby", local_platform].uniq)
   end
 
   it "warns when adding an unknown platform" do
@@ -367,12 +367,12 @@ RSpec.describe "bundle lock" do
 
     allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
     lockfile = Bundler::LockfileParser.new(read_lockfile)
-    expect(lockfile.platforms).to match_array([java, x86_mingw32, specific_local_platform].uniq)
+    expect(lockfile.platforms).to match_array([java, x86_mingw32, local_platform].uniq)
 
     bundle "lock --remove-platform java"
 
     lockfile = Bundler::LockfileParser.new(read_lockfile)
-    expect(lockfile.platforms).to match_array([x86_mingw32, specific_local_platform].uniq)
+    expect(lockfile.platforms).to match_array([x86_mingw32, local_platform].uniq)
   end
 
   it "also cleans up redundant platform gems when removing platforms" do
@@ -431,7 +431,7 @@ RSpec.describe "bundle lock" do
   end
 
   it "errors when removing all platforms" do
-    bundle "lock --remove-platform #{specific_local_platform}", :raise_on_error => false
+    bundle "lock --remove-platform #{local_platform}", :raise_on_error => false
     expect(err).to include("Removing all platforms from the bundle is not allowed")
   end
 

--- a/bundler/spec/commands/outdated_spec.rb
+++ b/bundler/spec/commands/outdated_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe "bundle outdated" do
             vcr (6.0.0)
 
         PLATFORMS
-          #{specific_local_platform}
+          #{local_platform}
 
         DEPENDENCIES
           dotenv

--- a/bundler/spec/commands/platform_spec.rb
+++ b/bundler/spec/commands/platform_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "bundle platform" do
 Your platform is: #{Gem::Platform.local}
 
 Your app has gems that work on these platforms:
-* #{specific_local_platform}
+* #{local_platform}
 
 Your Gemfile specifies a Ruby version requirement:
 * ruby #{Gem.ruby_version}
@@ -39,7 +39,7 @@ G
 Your platform is: #{Gem::Platform.local}
 
 Your app has gems that work on these platforms:
-* #{specific_local_platform}
+* #{local_platform}
 
 Your Gemfile specifies a Ruby version requirement:
 * #{Bundler::RubyVersion.system.single_version_string}
@@ -60,7 +60,7 @@ G
 Your platform is: #{Gem::Platform.local}
 
 Your app has gems that work on these platforms:
-* #{specific_local_platform}
+* #{local_platform}
 
 Your Gemfile does not specify a Ruby version requirement.
 G
@@ -80,7 +80,7 @@ G
 Your platform is: #{Gem::Platform.local}
 
 Your app has gems that work on these platforms:
-* #{specific_local_platform}
+* #{local_platform}
 
 Your Gemfile specifies a Ruby version requirement:
 * ruby #{not_local_ruby_version}

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -284,7 +284,7 @@ RSpec.describe "bundle update" do
               countries (~> 3.0)
 
         PLATFORMS
-          #{specific_local_platform}
+          #{local_platform}
 
         DEPENDENCIES
           countries
@@ -871,7 +871,7 @@ RSpec.describe "bundle update" do
             vcr (6.0.0)
 
         PLATFORMS
-          #{specific_local_platform}
+          #{local_platform}
 
         DEPENDENCIES
           dotenv
@@ -1602,7 +1602,7 @@ RSpec.describe "bundle update conservative" do
               shared_dep (~> 5.0)
 
         PLATFORMS
-          #{specific_local_platform}
+          #{local_platform}
 
         DEPENDENCIES
           isolated_owner
@@ -1655,7 +1655,7 @@ RSpec.describe "bundle update conservative" do
               shared_dep (~> 5.0)
 
         PLATFORMS
-          #{specific_local_platform}
+          #{local_platform}
 
         DEPENDENCIES
           isolated_owner

--- a/bundler/spec/install/deploy_spec.rb
+++ b/bundler/spec/install/deploy_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe "install in deployment or frozen mode" do
             rack (1.0.0)
 
         PLATFORMS
-          #{local}
+          #{generic_local_platform}
 
         DEPENDENCIES
           rack

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -674,7 +674,7 @@ RSpec.describe "bundle install from an existing gemspec" do
             railties (6.1.4)
 
         PLATFORMS
-          #{lockfile_platforms_for("java", specific_local_platform)}
+          #{lockfile_platforms("java")}
 
         DEPENDENCIES
           activeadmin!

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -674,7 +674,7 @@ RSpec.describe "bundle install from an existing gemspec" do
             railties (6.1.4)
 
         PLATFORMS
-          #{lockfile_platforms_for(["java", specific_local_platform])}
+          #{lockfile_platforms_for("java", specific_local_platform)}
 
         DEPENDENCIES
           activeadmin!

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -459,7 +459,7 @@ RSpec.describe "bundle install with platform conditionals" do
           tzinfo (2.0.4)
 
       PLATFORMS
-        #{specific_local_platform}
+        #{local_platform}
 
       DEPENDENCIES
         activesupport

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
                   rack
 
             PLATFORMS
-              #{specific_local_platform}
+              #{local_platform}
 
             DEPENDENCIES
               depends_on_rack!
@@ -640,7 +640,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
               zeitwerk (2.4.2)
 
           PLATFORMS
-            #{specific_local_platform}
+            #{local_platform}
 
           DEPENDENCIES
             activesupport
@@ -696,7 +696,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
                 sidekiq (>= 6.1.0)
 
           PLATFORMS
-            #{specific_local_platform}
+            #{local_platform}
 
           DEPENDENCIES
             activesupport
@@ -780,7 +780,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
                 sidekiq (>= 6.1.0)
 
           PLATFORMS
-            #{specific_local_platform}
+            #{local_platform}
 
           DEPENDENCIES
             activesupport
@@ -836,7 +836,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
                 sidekiq (>= 6.1.0)
 
           PLATFORMS
-            #{specific_local_platform}
+            #{local_platform}
 
           DEPENDENCIES
             activesupport
@@ -924,7 +924,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
                 nokogiri (>= 1.2.3)
 
           PLATFORMS
-            #{specific_local_platform}
+            #{local_platform}
 
           DEPENDENCIES
             handsoap!
@@ -984,7 +984,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
               rack (0.9.1)
 
           PLATFORMS
-            #{specific_local_platform}
+            #{local_platform}
 
           DEPENDENCIES
             rack!
@@ -1014,7 +1014,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
               rack (0.9.1)
 
           PLATFORMS
-            #{specific_local_platform}
+            #{local_platform}
 
           DEPENDENCIES
             rack!
@@ -1036,7 +1036,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
               rack (0.9.1)
 
           PLATFORMS
-            #{specific_local_platform}
+            #{local_platform}
 
           DEPENDENCIES
             rack!
@@ -1448,7 +1448,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
             mime-types (3.3.1)
 
         PLATFORMS
-          #{specific_local_platform}
+          #{local_platform}
 
         DEPENDENCIES
           capybara (~> 2.5.0)
@@ -1472,7 +1472,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
             mime-types (3.0.0)
 
         PLATFORMS
-          #{specific_local_platform}
+          #{local_platform}
 
         DEPENDENCIES
           capybara (~> 2.5.0)
@@ -1526,7 +1526,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
               pdf-writer (= 1.1.8)
 
         PLATFORMS
-          #{specific_local_platform}
+          #{local_platform}
 
         DEPENDENCIES
           ruport (= 1.7.0.3)!
@@ -1579,7 +1579,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
               pdf-writer (= 1.1.8)
 
         PLATFORMS
-          #{specific_local_platform}
+          #{local_platform}
 
         DEPENDENCIES
           ruport (= 1.7.0.3)!
@@ -1620,7 +1620,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
             pdf-writer (1.1.8)
 
         PLATFORMS
-          #{specific_local_platform}
+          #{local_platform}
 
         DEPENDENCIES
           pdf-writer (= 1.1.8)

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -514,7 +514,7 @@ RSpec.describe "bundle install with specific platforms" do
             sorbet-runtime (= 0.5.10160)
 
       PLATFORMS
-        #{lockfile_platforms_for([specific_local_platform, "ruby"])}
+        #{lockfile_platforms("ruby")}
 
       DEPENDENCIES
         sorbet-static-and-runtime
@@ -769,7 +769,7 @@ RSpec.describe "bundle install with specific platforms" do
           nokogiri (1.13.8-#{Gem::Platform.local})
 
       PLATFORMS
-        #{lockfile_platforms_for([specific_local_platform, "ruby"])}
+        #{lockfile_platforms("ruby")}
 
       DEPENDENCIES
         nokogiri

--- a/bundler/spec/install/global_cache_spec.rb
+++ b/bundler/spec/install/global_cache_spec.rb
@@ -220,9 +220,9 @@ RSpec.describe "global gem caching" do
         gem "very_simple_path_binary", :path => "#{lib_path("very_simple_path_binary-1.0")}"
       G
 
-      gem_binary_cache = home(".bundle", "cache", "extensions", specific_local_platform.to_s, Bundler.ruby_scope,
+      gem_binary_cache = home(".bundle", "cache", "extensions", local_platform.to_s, Bundler.ruby_scope,
         Digest(:MD5).hexdigest("#{gem_repo1}/"), "very_simple_binary-1.0")
-      git_binary_cache = home(".bundle", "cache", "extensions", specific_local_platform.to_s, Bundler.ruby_scope,
+      git_binary_cache = home(".bundle", "cache", "extensions", local_platform.to_s, Bundler.ruby_scope,
         "very_simple_git_binary-1.0-#{revision}", "very_simple_git_binary-1.0")
 
       cached_extensions = Pathname.glob(home(".bundle", "cache", "extensions", "*", "*", "*", "*", "*")).sort

--- a/bundler/spec/install/yanked_spec.rb
+++ b/bundler/spec/install/yanked_spec.rb
@@ -192,6 +192,12 @@ RSpec.context "when using gem before installing" do
     expect(err).to_not include("Your bundle is locked to rack (0.9.1) from")
     expect(err).to_not include("If you haven't changed sources, that means the author of rack (0.9.1) has removed it.")
     expect(err).to_not include("You'll need to update your bundle to a different version of rack (0.9.1) that hasn't been removed in order to install.")
+
+    # Check error message is still correct when multiple platforms are locked
+    lockfile lockfile.gsub(/PLATFORMS\n  #{lockfile_platforms}/m, "PLATFORMS\n  #{lockfile_platforms("ruby")}")
+
+    bundle :list, :raise_on_error => false
+    expect(err).to include("Could not find rack-0.9.1 in locally installed gems")
   end
 
   it "does not suggest the author has yanked the gem when using more than one gem, but shows all gems that couldn't be found in the source" do

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -982,7 +982,7 @@ RSpec.describe "the lockfile format" do
           rack (1.0.0)
 
       PLATFORMS
-        #{lockfile_platforms_for("java", specific_local_platform)}
+        #{lockfile_platforms("java")}
 
       DEPENDENCIES
         rack

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -982,7 +982,7 @@ RSpec.describe "the lockfile format" do
           rack (1.0.0)
 
       PLATFORMS
-        #{lockfile_platforms_for(["java", specific_local_platform])}
+        #{lockfile_platforms_for("java", specific_local_platform)}
 
       DEPENDENCIES
         rack

--- a/bundler/spec/runtime/platform_spec.rb
+++ b/bundler/spec/runtime/platform_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
           racc (1.5.2)
 
       PLATFORMS
-        #{lockfile_platforms_for("ruby", specific_local_platform)}
+        #{lockfile_platforms("ruby")}
 
       DEPENDENCIES
         nokogiri (~> 1.11)

--- a/bundler/spec/runtime/platform_spec.rb
+++ b/bundler/spec/runtime/platform_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
           racc (1.5.2)
 
       PLATFORMS
-        #{lockfile_platforms_for(["ruby", specific_local_platform])}
+        #{lockfile_platforms_for("ruby", specific_local_platform)}
 
       DEPENDENCIES
         nokogiri (~> 1.11)

--- a/bundler/spec/support/platforms.rb
+++ b/bundler/spec/support/platforms.rb
@@ -99,12 +99,8 @@ module Spec
       9999
     end
 
-    def lockfile_platforms
-      lockfile_platforms_for(specific_local_platform)
-    end
-
-    def lockfile_platforms_for(*platforms)
-      platforms.map(&:to_s).sort.join("\n  ")
+    def lockfile_platforms(*extra)
+      [specific_local_platform, *extra].map(&:to_s).sort.join("\n  ")
     end
   end
 end

--- a/bundler/spec/support/platforms.rb
+++ b/bundler/spec/support/platforms.rb
@@ -104,10 +104,10 @@ module Spec
     end
 
     def lockfile_platforms
-      lockfile_platforms_for([specific_local_platform])
+      lockfile_platforms_for(specific_local_platform)
     end
 
-    def lockfile_platforms_for(platforms)
+    def lockfile_platforms_for(*platforms)
       platforms.map(&:to_s).sort.join("\n  ")
     end
   end

--- a/bundler/spec/support/platforms.rb
+++ b/bundler/spec/support/platforms.rb
@@ -52,10 +52,6 @@ module Spec
       [rb, java, linux, windows_platforms].flatten
     end
 
-    def specific_local_platform
-      Bundler.local_platform
-    end
-
     def not_local
       all_platforms.find {|p| p != generic_local_platform }
     end
@@ -100,7 +96,7 @@ module Spec
     end
 
     def lockfile_platforms(*extra)
-      [specific_local_platform, *extra].map(&:to_s).sort.join("\n  ")
+      [local_platform, *extra].map(&:to_s).sort.join("\n  ")
     end
   end
 end

--- a/bundler/spec/support/platforms.rb
+++ b/bundler/spec/support/platforms.rb
@@ -52,10 +52,6 @@ module Spec
       [rb, java, linux, windows_platforms].flatten
     end
 
-    def local
-      generic_local_platform
-    end
-
     def specific_local_platform
       Bundler.local_platform
     end

--- a/bundler/spec/support/platforms.rb
+++ b/bundler/spec/support/platforms.rb
@@ -21,7 +21,7 @@ module Spec
     end
 
     def linux
-      Gem::Platform.new(["x86", "linux", nil])
+      Gem::Platform.new("x86_64-linux")
     end
 
     def x86_mswin32


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes, when using lockfiles with multiple platforms locked, you may end up with an error messages that mentioned duplicated gems, like

```
Could not find rack-0.9.1, rack-0.9.1 in locally installed gems
Install missing gems with `bundle install`.
```
       
## What is your fix for the problem, implemented in this PR?

Fix the issue by deduplicating specs.

I also included some other minor spec improvements.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
