### PR TITLE
Tweaked OSS Scorecards job

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -58,12 +58,12 @@ jobs:
 
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
-      - name: "Upload artifact"
-        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
-        with:
-          name: SARIF file
-          path: results.sarif
-          retention-days: 5
+      # - name: "Upload artifact"
+      #   uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
+      #   with:
+      #     name: SARIF file
+      #     path: results.sarif
+      #     retention-days: 5
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -11,8 +11,8 @@ on:
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
   schedule:
     - cron: '22 4 * * 2'
-  push:
-    branches: [ "master" ]
+  # push:
+  #   branches: [ "master" ]
 
 # Declare default permissions as read only.
 permissions: read-all


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We don't need to run https://github.com/rubygems/rubygems/actions/workflows/scorecards.yml each push on master branch. We can reduce CI jobs.

## What is your fix for the problem, implemented in this PR?

I commented-out some jobs in scorecards.yml.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
