### PR TITLE
Fix "test project sanity" failure with user installed `rake`

### DIFF
--- a/test/rubygems/test_project_sanity.rb
+++ b/test/rubygems/test_project_sanity.rb
@@ -5,16 +5,39 @@ require "open3"
 
 class TestProjectSanity < Gem::TestCase
   def test_manifest_is_up_to_date
-    pend unless File.exist?(File.expand_path("../../Rakefile", __dir__))
+    pend unless File.exist?("#{root}/Rakefile")
 
     _, status = Open3.capture2e("rake check_manifest")
 
-    assert status.success?, "Expected Manifest.txt to be up to date, but it's not. Run `rake update_manifest` to sync it."
+    unless status.success?
+      original_contents = File.read("#{root}/Manifest.txt")
+
+      # Update the manifest to see if it fixes the problem
+      Open3.capture2e("rake update_manifest")
+
+      out, status = Open3.capture2e("rake check_manifest")
+
+      # If `rake update_manifest` fixed the problem, that was the original
+      # issue, otherwise it was an unknown error, so print the error output
+      if status.success?
+        File.write("#{root}/Manifest.txt", original_contents)
+
+        raise "Expected Manifest.txt to be up to date, but it's not. Run `rake update_manifest` to sync it."
+      else
+        raise "There was an error running `rake check_manifest`: #{out}"
+      end
+    end
   end
 
   def test_require_rubygems_package
     err, status = Open3.capture2e(*ruby_with_rubygems_in_load_path, "--disable-gems", "-e", "require \"rubygems/package\"")
 
     assert status.success?, err
+  end
+
+  private
+
+  def root
+    File.expand_path("../..", __dir__)
   end
 end

--- a/test/rubygems/test_project_sanity.rb
+++ b/test/rubygems/test_project_sanity.rb
@@ -4,6 +4,12 @@ require_relative "helper"
 require "open3"
 
 class TestProjectSanity < Gem::TestCase
+  def setup
+  end
+
+  def teardown
+  end
+
   def test_manifest_is_up_to_date
     pend unless File.exist?("#{root}/Rakefile")
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If you have `rake` installed through `gem install rake --user-install`, then `rake TEST=test/rubygems/test_project_sanity.rb` fails.

## What is your fix for the problem, implemented in this PR?

The first commit makes the underlying error properly show up in this case.

The second commit fixes the problem

```shell
$ rake TEST=test/rubygems/test_project_sanity.rb
Loaded suite /Users/deivid/.gem/ruby/3.2.0/gems/rake-13.0.6/lib/rake/rake_test_loader
Started
E
============================================================================================================================================================================================================
Error: test_manifest_is_up_to_date(TestProjectSanity):
  RuntimeError: There was an error running `rake check_manifest`: /Users/deivid/.asdf/installs/ruby/3.2.1/lib/ruby/site_ruby/3.2.0/rubygems.rb:263:in `find_spec_for_exe': can't find gem rake (>= 0.a) with executable rake (Gem::GemNotFoundException)
  	from /Users/deivid/.asdf/installs/ruby/3.2.1/lib/ruby/site_ruby/3.2.0/rubygems.rb:282:in `activate_bin_path'
  	from /Users/deivid/.asdf/installs/ruby/3.2.1/bin/rake:25:in `<main>'
/Users/deivid/Code/rubygems/rubygems/test/rubygems/test_project_sanity.rb:27:in `test_manifest_is_up_to_date'
     24: 
     25:         raise "Expected Manifest.txt to be up to date, but it's not. Run `rake update_manifest` to sync it."
     26:       else
  => 27:         raise "There was an error running `rake check_manifest`: #{out}"
     28:       end
     29:     end
     30:   end
============================================================================================================================================================================================================
.
Finished in 0.188192 seconds.
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
2 tests, 1 assertions, 0 failures, 1 errors, 0 pendings, 0 omissions, 0 notifications
50% passed
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
10.63 tests/s, 5.31 assertions/s
rake aborted!
Command failed with status (1)
/Users/deivid/.gem/ruby/3.2.0/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
Tasks: TOP => default => test
(See full trace by running task with --trace)
```

The second commit fixes the issue by not running global setup/teardown hooks that mess things up in this case.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
