### PR TITLE
Fix `gem uninstall` with `--install-dir`

### DIFF
--- a/lib/rubygems/commands/uninstall_command.rb
+++ b/lib/rubygems/commands/uninstall_command.rb
@@ -125,6 +125,9 @@ that is a dependency of an existing gem.  You can use the
   def execute
     check_version
 
+    # Consider only gem specifications installed at `--install-dir`
+    Gem::Specification.dirs = options[:install_dir] if options[:install_dir]
+
     if options[:all] && !options[:args].empty?
       uninstall_specific
     elsif options[:all]

--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -37,9 +37,6 @@ module Kernel
     return gem_original_require(path) unless Gem.discover_gems_on_require
 
     begin
-      if RUBYGEMS_ACTIVATION_MONITOR.respond_to?(:mon_owned?)
-        monitor_owned = RUBYGEMS_ACTIVATION_MONITOR.mon_owned?
-      end
       RUBYGEMS_ACTIVATION_MONITOR.enter
 
       path = path.to_path if path.respond_to? :to_path
@@ -163,13 +160,6 @@ module Kernel
       end
 
       raise load_error
-    ensure
-      if RUBYGEMS_ACTIVATION_MONITOR.respond_to?(:mon_owned?)
-        if monitor_owned != (ow = RUBYGEMS_ACTIVATION_MONITOR.mon_owned?)
-          STDERR.puts [$$, Thread.current, $!, $!.backtrace].inspect if $!
-          raise "CRITICAL: RUBYGEMS_ACTIVATION_MONITOR.owned?: before #{monitor_owned} -> after #{ow}"
-        end
-      end
     end
   end
 

--- a/test/rubygems/test_gem_commands_uninstall_command.rb
+++ b/test/rubygems/test_gem_commands_uninstall_command.rb
@@ -22,12 +22,7 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
     a_4, = util_gem "a", 4
     install_gem a_4, :install_dir => gemhome2
 
-    Gem::Specification.dirs = [@gemhome, gemhome2]
-
-    assert_includes Gem::Specification.all_names, "a-1"
-    assert_includes Gem::Specification.all_names, "a-4"
-    assert_includes Gem::Specification.all_names, "b-2"
-    assert_includes Gem::Specification.all_names, "default-1"
+    assert_gems_presence "a-1", "a-4", "b-2", "default-1", dirs: [@gemhome, gemhome2]
 
     @cmd.options[:all] = true
     @cmd.options[:args] = %w[a]
@@ -346,11 +341,7 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
     a_4, = util_gem "a", 4
     install_gem a_4
 
-    Gem::Specification.dirs = [@gemhome, gemhome2]
-
-    assert_includes Gem::Specification.all_names, "a-1"
-    assert_includes Gem::Specification.all_names, "a-4"
-    assert_includes Gem::Specification.all_names, "default-1"
+    assert_gems_presence "a-1", "a-4", "default-1", dirs: [@gemhome, gemhome2]
 
     @cmd.options[:all] = true
     @cmd.options[:args] = []
@@ -371,9 +362,7 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
     a_4, = util_gem "a", 4
     install_gem a_4 , :install_dir => gemhome2
 
-    Gem::Specification.dirs = [@gemhome, gemhome2]
-
-    assert_includes Gem::Specification.all_names, "a-4"
+    assert_gems_presence "a-4", dirs: [@gemhome, gemhome2]
 
     @cmd.options[:args] = ["a:4"]
 
@@ -499,6 +488,14 @@ WARNING:  Use your OS package manager to uninstall vendor gems
       use_ui @ui do
         installer.install
       end
+    end
+  end
+
+  def assert_gems_presence(*gems, dirs:)
+    Gem::Specification.dirs = dirs
+
+    gems.each do |full_name|
+      assert_includes Gem::Specification.all_names, full_name
     end
   end
 end

--- a/test/rubygems/test_gem_commands_uninstall_command.rb
+++ b/test/rubygems/test_gem_commands_uninstall_command.rb
@@ -375,6 +375,26 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
     assert_includes e.message, "a is not installed in GEM_HOME"
   end
 
+  def test_execute_outside_gem_home_when_install_dir_given
+    gemhome2 = "#{@gemhome}2"
+
+    a_4, = util_gem "a", 4
+    install_gem a_4 , :install_dir => gemhome2
+
+    assert_gems_presence "a-4", dirs: [@gemhome, gemhome2]
+
+    Gem::Specification.dirs = [@gemhome]
+
+    @cmd.options[:install_dir] = gemhome2
+    @cmd.options[:args] = ["a:4"]
+
+    @cmd.execute
+
+    Gem::Specification.dirs = [gemhome2]
+
+    refute_includes Gem::Specification.all_names.sort, "a-4"
+  end
+
   def test_handle_options
     @cmd.handle_options %w[]
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

You can currently install a gem to a specific home (regardless of current home) using the `--install-dir` option:

```
$ gem install rake --install-dir foo
Fetching rake-13.0.6.gem
Successfully installed rake-13.0.6
1 gem installed

$ ls foo/gems/rake-13.0.6 
History.rdoc MIT-LICENSE  README.rdoc  doc          exe          lib          rake.gemspec
```

However, the same option for `gem uninstall`, documented as the way to reverse this operation:

```
$ gem uninstall --help |grep install-dir    
    -i, --install-dir DIR            Directory to uninstall gem from
```

It does not work

```
$ gem uninstall rake --install-dir foo
ERROR:  While executing gem ... (Gem::InstallError)
    rake is not installed in GEM_HOME, try:
	gem uninstall -i /Users/deivid/.gem/ruby/3.2.0 rake
	/Users/deivid/.asdf/installs/ruby/3.2.1/lib/ruby/site_ruby/3.2.0/rubygems/uninstaller.rb:124:in `uninstall'
	/Users/deivid/.asdf/installs/ruby/3.2.1/lib/ruby/site_ruby/3.2.0/rubygems/commands/uninstall_command.rb:195:in `uninstall'
	/Users/deivid/.asdf/installs/ruby/3.2.1/lib/ruby/site_ruby/3.2.0/rubygems/commands/uninstall_command.rb:181:in `uninstall_gem'
	/Users/deivid/.asdf/installs/ruby/3.2.1/lib/ruby/site_ruby/3.2.0/rubygems/commands/uninstall_command.rb:175:in `block in uninstall_specific'
	/Users/deivid/.asdf/installs/ruby/3.2.1/lib/ruby/site_ruby/3.2.0/rubygems/commands/uninstall_command.rb:167:in `each'
	/Users/deivid/.asdf/installs/ruby/3.2.1/lib/ruby/site_ruby/3.2.0/rubygems/commands/uninstall_command.rb:167:in `uninstall_specific'
	/Users/deivid/.asdf/installs/ruby/3.2.1/lib/ruby/site_ruby/3.2.0/rubygems/commands/uninstall_command.rb:133:in `execute'
	/Users/deivid/.asdf/installs/ruby/3.2.1/lib/ruby/site_ruby/3.2.0/rubygems/command.rb:327:in `invoke_with_build_args'
	/Users/deivid/.asdf/installs/ruby/3.2.1/lib/ruby/site_ruby/3.2.0/rubygems/command_manager.rb:252:in `invoke_command'
	/Users/deivid/.asdf/installs/ruby/3.2.1/lib/ruby/site_ruby/3.2.0/rubygems/command_manager.rb:192:in `process_args'
	/Users/deivid/.asdf/installs/ruby/3.2.1/lib/ruby/site_ruby/3.2.0/rubygems/command_manager.rb:150:in `run'
	/Users/deivid/.asdf/installs/ruby/3.2.1/lib/ruby/site_ruby/3.2.0/rubygems/gem_runner.rb:51:in `run'
	/Users/deivid/.asdf/installs/ruby/3.2.1/bin/gem:10:in `<main>'
```

## What is your fix for the problem, implemented in this PR?

This PR fixes the problem by setting the place to look for gems to uninstall to `--install-dir`:

```
$ ruby -Ilib -S bin/gem uninstall rake --install-dir foo
Remove executables:
	rake

in addition to the gem? [Yn]  Y
Removing rake
Successfully uninstalled rake-13.0.6
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
