### PR TITLE
Always use OpenSSL::Digest instead of Digest

### DIFF
--- a/bundler/spec/bundler/digest_spec.rb
+++ b/bundler/spec/bundler/digest_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require "digest"
+require "openssl"
 require "bundler/digest"
 
 RSpec.describe Bundler::Digest do
   context "SHA1" do
     subject { Bundler::Digest }
-    let(:stdlib) { ::Digest::SHA1 }
+    let(:stdlib) { OpenSSL::Digest::SHA1 }
 
     it "is compatible with stdlib" do
       random_strings = ["foo", "skfjsdlkfjsdf", "3924m", "ldskfj"]

--- a/lib/rubygems/security.rb
+++ b/lib/rubygems/security.rb
@@ -461,16 +461,8 @@ module Gem::Security
   # Creates a new digest instance using the specified +algorithm+. The default
   # is SHA256.
 
-  if defined?(OpenSSL::Digest)
-    def self.create_digest(algorithm = DIGEST_NAME)
-      OpenSSL::Digest.new(algorithm)
-    end
-  else
-    require "digest"
-
-    def self.create_digest(algorithm = DIGEST_NAME)
-      Digest.const_get(algorithm).new
-    end
+  def self.create_digest(algorithm = DIGEST_NAME)
+    OpenSSL::Digest.new(algorithm)
   end
 
   ##

--- a/test/rubygems/test_gem_package_tar_writer.rb
+++ b/test/rubygems/test_gem_package_tar_writer.rb
@@ -70,7 +70,7 @@ class TestGemPackageTarWriter < Gem::Package::TarTestCase
   end
 
   def test_add_file_digest
-    digest_algorithms = Digest::SHA1.new, Digest::SHA512.new
+    digest_algorithms = OpenSSL::Digest::SHA1.new, OpenSSL::Digest::SHA512.new
 
     Time.stub :now, Time.at(1458518157) do
       digests = @tar_writer.add_file_digest "x", 0644, digest_algorithms do |io|
@@ -93,7 +93,7 @@ class TestGemPackageTarWriter < Gem::Package::TarTestCase
   end
 
   def test_add_file_digest_multiple
-    digest_algorithms = [Digest::SHA1.new, Digest::SHA512.new]
+    digest_algorithms = [OpenSSL::Digest::SHA1.new, OpenSSL::Digest::SHA512.new]
 
     Time.stub :now, Time.at(1458518157) do
       digests = @tar_writer.add_file_digest "x", 0644, digest_algorithms do |io|

--- a/test/rubygems/test_gem_source_git.rb
+++ b/test/rubygems/test_gem_source_git.rb
@@ -8,7 +8,7 @@ class TestGemSourceGit < Gem::TestCase
 
     @name, @version, @repository, @head = git_gem
 
-    @hash = Digest::SHA1.hexdigest @repository
+    @hash = OpenSSL::Digest::SHA1.hexdigest @repository
 
     @source = Gem::Source::Git.new @name, @repository, nil, false
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Current rubygems and bundler mixed `OpenSSL::Digest` and `Digest` namespaces. `OpenSSL::Digest` is always provided after Ruby 2.4 or later.

## What is your fix for the problem, implemented in this PR?

We should rely to use `OpenSSL`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
