### PR TITLE
Removed needless condition about RUBY_PATCHLEVEL

### DIFF
--- a/bundler/lib/bundler/env.rb
+++ b/bundler/lib/bundler/env.rb
@@ -69,9 +69,7 @@ module Bundler
     end
 
     def self.ruby_version
-      str = String.new(RUBY_VERSION)
-      str << "p#{RUBY_PATCHLEVEL}" if defined? RUBY_PATCHLEVEL
-      str << " (#{RUBY_RELEASE_DATE} revision #{RUBY_REVISION}) [#{Gem::Platform.local}]"
+      "#{RUBY_VERSION}p#{RUBY_PATCHLEVEL} (#{RUBY_RELEASE_DATE} revision #{RUBY_REVISION}) [#{Gem::Platform.local}]"
     end
 
     def self.git_version

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -855,7 +855,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     return @ruby_version if defined? @ruby_version
     version = RUBY_VERSION.dup
 
-    unless defined?(RUBY_PATCHLEVEL) && RUBY_PATCHLEVEL != -1
+    if RUBY_PATCHLEVEL == -1
       if RUBY_ENGINE == "ruby"
         desc = RUBY_DESCRIPTION[/\Aruby #{Regexp.quote(RUBY_VERSION)}([^ ]+) /, 1]
       else

--- a/lib/rubygems/commands/environment_command.rb
+++ b/lib/rubygems/commands/environment_command.rb
@@ -107,9 +107,7 @@ lib/rubygems/defaults/operating_system.rb
 
     out << "  - RUBYGEMS VERSION: #{Gem::VERSION}\n"
 
-    out << "  - RUBY VERSION: #{RUBY_VERSION} (#{RUBY_RELEASE_DATE}"
-    out << " patchlevel #{RUBY_PATCHLEVEL}" if defined? RUBY_PATCHLEVEL
-    out << ") [#{RUBY_PLATFORM}]\n"
+    out << "  - RUBY VERSION: #{RUBY_VERSION} (#{RUBY_RELEASE_DATE} patchlevel #{RUBY_PATCHLEVEL}) [#{RUBY_PLATFORM}]\n"
 
     out << "  - INSTALLATION DIRECTORY: #{Gem.dir}\n"
 

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -1097,7 +1097,7 @@ Also, a list:
 
     @RUBY_VERSION        = RUBY_VERSION
     @RUBY_PATCHLEVEL     = RUBY_PATCHLEVEL
-    @RUBY_REVISION       = RUBY_REVISION       if defined?(RUBY_REVISION)
+    @RUBY_REVISION       = RUBY_REVISION if defined?(RUBY_REVISION)
     @RUBY_DESCRIPTION    = RUBY_DESCRIPTION
     @RUBY_ENGINE         = RUBY_ENGINE
     @RUBY_ENGINE_VERSION = RUBY_ENGINE_VERSION if defined?(RUBY_ENGINE_VERSION)
@@ -1117,12 +1117,10 @@ Also, a list:
 
     Object.const_set :RUBY_VERSION,        @RUBY_VERSION
     Object.const_set :RUBY_PATCHLEVEL,     @RUBY_PATCHLEVEL
-    Object.const_set :RUBY_REVISION,       @RUBY_REVISION    if
-      defined?(@RUBY_REVISION)
+    Object.const_set :RUBY_REVISION,       @RUBY_REVISION if defined?(@RUBY_REVISION)
     Object.const_set :RUBY_DESCRIPTION,    @RUBY_DESCRIPTION
     Object.const_set :RUBY_ENGINE,         @RUBY_ENGINE
-    Object.const_set :RUBY_ENGINE_VERSION, @RUBY_ENGINE_VERSION if
-      defined?(@RUBY_ENGINE_VERSION)
+    Object.const_set :RUBY_ENGINE_VERSION, @RUBY_ENGINE_VERSION if defined?(@RUBY_ENGINE_VERSION)
   end
 
   def util_clear_RUBY_VERSION

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -1096,7 +1096,7 @@ Also, a list:
     end
 
     @RUBY_VERSION        = RUBY_VERSION
-    @RUBY_PATCHLEVEL     = RUBY_PATCHLEVEL     if defined?(RUBY_PATCHLEVEL)
+    @RUBY_PATCHLEVEL     = RUBY_PATCHLEVEL
     @RUBY_REVISION       = RUBY_REVISION       if defined?(RUBY_REVISION)
     @RUBY_DESCRIPTION    = RUBY_DESCRIPTION
     @RUBY_ENGINE         = RUBY_ENGINE
@@ -1116,8 +1116,7 @@ Also, a list:
     util_clear_RUBY_VERSION
 
     Object.const_set :RUBY_VERSION,        @RUBY_VERSION
-    Object.const_set :RUBY_PATCHLEVEL,     @RUBY_PATCHLEVEL  if
-      defined?(@RUBY_PATCHLEVEL)
+    Object.const_set :RUBY_PATCHLEVEL,     @RUBY_PATCHLEVEL
     Object.const_set :RUBY_REVISION,       @RUBY_REVISION    if
       defined?(@RUBY_REVISION)
     Object.const_set :RUBY_DESCRIPTION,    @RUBY_DESCRIPTION


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

RUBY_PATCHLEVEL is always provided from Ruby 1.8.5. But RubyGems has a condition about this.

## What is your fix for the problem, implemented in this PR?

Removed needless condition.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
