### PR TITLE
Merge rubygems and bundler rubocop rules 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -256,6 +256,9 @@ Lint/ParenthesesAsGroupedExpression:
 Lint/Debugger:
   Enabled: true
 
+Lint/RedundantCopEnableDirective:
+  Enabled: true
+
 Layout/EndAlignment:
   Enabled: true
   EnforcedStyleAlignWith: variable

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ require: rubocop-performance
 
 AllCops:
   DisabledByDefault: true
+  TargetRubyVersion: 2.6
   Exclude:
     - 'bundler/**/*'
     - 'lib/rubygems/resolver/molinillo/**/*'
@@ -9,7 +10,6 @@ AllCops:
     - 'lib/rubygems/optparse/**/*'
     - 'pkg/**/*'
     - 'tmp/**/*'
-  TargetRubyVersion: 2.6
 
 Layout/AccessModifierIndentation:
   Enabled: true
@@ -88,6 +88,9 @@ Layout/SpaceBeforeBlockBraces:
 Layout/SpaceInsideBlockBraces:
   Enabled: true
   SpaceBeforeBlockParameters: false
+  Exclude:
+  - bundler/lib/bundler/templates/Gemfile
+  - bundler/lib/bundler/templates/gems.rb
 
 Layout/SpaceInsideHashLiteralBraces:
   Enabled: true
@@ -113,6 +116,7 @@ Lint/Debugger:
 Layout/EndAlignment:
   Enabled: true
   EnforcedStyleAlignWith: variable
+  AutoCorrect: true
 
 Naming/HeredocDelimiterCase:
   Enabled: true
@@ -190,6 +194,7 @@ Style/SafeNavigation:
   MaxChainLength: 1
 
 Style/StringLiterals:
+  Enabled: true
   EnforcedStyle: double_quotes
 
 # Having these make it easier to *not* forget to add one when adding a new

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -390,3 +390,113 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInHashLiteral:
   Enabled: true
   EnforcedStyleForMultiline: comma
+
+Style/ArrayJoin:
+  Enabled: true
+
+Style/Attr:
+  Enabled: true
+
+Style/BeginBlock:
+  Enabled: true
+
+Style/BlockComments:
+  Enabled: true
+
+Style/ClassMethods:
+  Enabled: true
+
+Style/ColonMethodDefinition:
+  Enabled: true
+
+Style/CommandLiteral:
+  Enabled: true
+
+Style/EachForSimpleLoop:
+  Enabled: true
+
+Style/EmptyBlockParameter:
+  Enabled: true
+
+Style/EmptyLambdaParameter:
+  Enabled: true
+
+Style/EndBlock:
+  Enabled: true
+
+Style/EvenOdd:
+  Enabled: true
+
+Style/For:
+  Enabled: true
+
+Style/IfWithSemicolon:
+  Enabled: true
+
+Style/InfiniteLoop:
+  Enabled: true
+
+Style/LambdaCall:
+  Enabled: true
+
+Style/MinMax:
+  Enabled: true
+
+Style/MixinGrouping:
+  Enabled: true
+
+Style/NegatedWhile:
+  Enabled: true
+
+Style/NestedTernaryOperator:
+  Enabled: true
+
+Style/OneLineConditional:
+  Enabled: true
+
+Style/OptionalArguments:
+  Enabled: true
+
+Style/PercentQLiterals:
+  Enabled: true
+
+Style/Proc:
+  Enabled: true
+
+Style/RandomWithOffset:
+  Enabled: true
+
+Style/RedundantConditional:
+  Enabled: true
+
+Style/RedundantException:
+  Enabled: true
+
+Style/Sample:
+  Enabled: true
+
+# We adopted raise instead of fail.
+Style/SignalException:
+  Enabled: true
+  EnforcedStyle: only_raise
+
+Style/Strip:
+  Enabled: true
+
+Style/StructInheritance:
+  Enabled: true
+
+Style/SymbolLiteral:
+  Enabled: true
+
+Style/TrailingBodyOnClass:
+  Enabled: true
+
+Style/TrailingBodyOnMethodDefinition:
+  Enabled: true
+
+Style/TrailingBodyOnModule:
+  Enabled: true
+
+Style/TrailingMethodEndStatement:
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,15 @@ AllCops:
   CacheRootDirectory: tmp/rubocop
   MaxFilesInCache: 5000
 
+Bundler/DuplicatedGem:
+  Enabled: true
+
+Bundler/InsecureProtocolSource:
+  Enabled: true
+
+Bundler/OrderedGems:
+  Enabled: true
+
 Layout/AccessModifierIndentation:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,7 +22,6 @@ Layout/BlockAlignment:
 
 Layout/CaseIndentation:
   Enabled: true
-  EnforcedStyle: end
 
 Layout/ClosingParenthesisIndentation:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -269,6 +269,20 @@ Naming/HeredocDelimiterNaming:
   ForbiddenDelimiters:
     - ^RB$
 
+Naming/AsciiIdentifiers:
+  Enabled: true
+
+Naming/BinaryOperatorParameterName:
+  Enabled: true
+
+Naming/ClassAndModuleCamelCase:
+  Enabled: true
+
+Naming/FileName:
+  Enabled: true
+  Exclude:
+    - 'bundler/spec/realworld/fixtures/warbler/bin/warbler-example.rb'
+
 Performance/StartWith:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -302,6 +302,9 @@ Performance/UriDefaultParser:
 Security/Open:
   Enabled: true
 
+Security/JSONLoad:
+  Enabled: true
+
 Style/AndOr:
   Enabled: true
   EnforcedStyle: always

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,8 @@ AllCops:
     - 'lib/rubygems/optparse/**/*'
     - 'pkg/**/*'
     - 'tmp/**/*'
+  CacheRootDirectory: tmp/rubocop
+  MaxFilesInCache: 5000
 
 Layout/AccessModifierIndentation:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -278,6 +278,27 @@ Performance/StringInclude:
 Performance/StringReplacement:
   Enabled: true
 
+Performance/CompareWithBlock:
+  Enabled: true
+
+Performance/Detect:
+  Enabled: true
+
+Performance/EndWith:
+  Enabled: true
+
+Performance/FixedSize:
+  Enabled: true
+
+Performance/ReverseEach:
+  Enabled: true
+
+Performance/Size:
+  Enabled: true
+
+Performance/UriDefaultParser:
+  Enabled: true
+
 Security/Open:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -264,6 +264,36 @@ Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
   AutoCorrect: true
 
+Layout/ConditionPosition:
+  Enabled: true
+
+Layout/EmptyComment:
+  Enabled: true
+
+Layout/EmptyLinesAroundArguments:
+  Enabled: true
+
+Layout/EmptyLinesAroundBeginBody:
+  Enabled: true
+
+Layout/InitialIndentation:
+  Enabled: true
+
+Layout/MultilineMethodDefinitionBraceLayout:
+  Enabled: true
+
+Layout/SpaceBeforeComment:
+  Enabled: true
+
+Layout/SpaceBeforeFirstArg:
+  Enabled: true
+
+Layout/SpaceInsideReferenceBrackets:
+  Enabled: true
+
+Layout/IndentationStyle:
+  Enabled: true
+
 Naming/HeredocDelimiterCase:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,129 @@ Gemspec/RequiredRubyVersion:
     - test/rubygems/specifications/*.gemspec
     - test/rubygems/test_gem_ext_cargo_builder/**/*.gemspec
 
+Lint/AmbiguousOperator:
+  Enabled: true
+
+Lint/AmbiguousRegexpLiteral:
+  Enabled: true
+
+Lint/BigDecimalNew:
+  Enabled: true
+
+Lint/BooleanSymbol:
+  Enabled: true
+
+Lint/DeprecatedClassMethods:
+  Enabled: true
+
+Lint/DuplicateHashKey:
+  Enabled: true
+
+Lint/EachWithObjectArgument:
+  Enabled: true
+
+Lint/ElseLayout:
+  Enabled: true
+
+Lint/EmptyEnsure:
+  Enabled: true
+
+Lint/EmptyInterpolation:
+  Enabled: true
+
+Lint/EnsureReturn:
+  Enabled: true
+
+Lint/ErbNewArguments:
+  Enabled: true
+
+Lint/FlipFlop:
+  Enabled: true
+
+Lint/FloatOutOfRange:
+  Enabled: true
+
+Lint/FormatParameterMismatch:
+  Enabled: true
+
+Lint/ImplicitStringConcatenation:
+  Enabled: true
+
+Lint/InheritException:
+  Enabled: true
+
+Lint/LiteralAsCondition:
+  Enabled: true
+
+Lint/LiteralInInterpolation:
+  Enabled: true
+
+Lint/Loop:
+  Enabled: true
+
+Lint/MultipleComparison:
+  Enabled: true
+
+Lint/NestedPercentLiteral:
+  Enabled: true
+
+Lint/NextWithoutAccumulator:
+  Enabled: true
+
+Lint/OrderedMagicComments:
+  Enabled: true
+
+Lint/PercentStringArray:
+  Enabled: true
+
+Lint/PercentSymbolArray:
+  Enabled: true
+
+Lint/RandOne:
+  Enabled: true
+
+Lint/RedundantWithIndex:
+  Enabled: true
+
+Lint/RedundantWithObject:
+  Enabled: true
+
+Lint/RegexpAsCondition:
+  Enabled: true
+
+Lint/RescueType:
+  Enabled: true
+
+Lint/SafeNavigationChain:
+  Enabled: true
+
+Lint/SafeNavigationConsistency:
+  Enabled: true
+
+Lint/ScriptPermission:
+  Enabled: true
+  Exclude:
+    - 'bundler/lib/bundler/templates/Executable'
+    - 'bundler/lib/bundler/templates/Executable.*'
+
+Lint/ShadowedArgument:
+  Enabled: true
+
+Lint/Syntax:
+  Enabled: true
+
+Lint/UnifiedInteger:
+  Enabled: true
+
+Lint/UriEscapeUnescape:
+  Enabled: true
+
+Lint/UriRegexp:
+  Enabled: true
+
+Lint/UselessSetterCall:
+  Enabled: true
+
 Layout/AccessModifierIndentation:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,16 @@ Bundler/InsecureProtocolSource:
 Bundler/OrderedGems:
   Enabled: true
 
+Gemspec/OrderedDependencies:
+  Enabled: true
+
+Gemspec/RequiredRubyVersion:
+  Enabled: true
+  Exclude:
+    - bundler/spec/realworld/fixtures/warbler/demo/demo.gemspec
+    - test/rubygems/specifications/*.gemspec
+    - test/rubygems/test_gem_ext_cargo_builder/**/*.gemspec
+
 Layout/AccessModifierIndentation:
   Enabled: true
 

--- a/.rubocop_bundler.yml
+++ b/.rubocop_bundler.yml
@@ -1,8 +1,6 @@
-require: rubocop-performance
+inherit_from: .rubocop.yml
 
 AllCops:
-  DisabledByDefault: true
-  TargetRubyVersion: 2.6
   Include:
     - bundler/**/*.rb
     - bundler/**/*.gemspec
@@ -57,16 +55,10 @@ Lint/BigDecimalNew:
 Lint/BooleanSymbol:
   Enabled: true
 
-Lint/Debugger:
-  Enabled: true
-
 Lint/DeprecatedClassMethods:
   Enabled: true
 
 Lint/DuplicateCaseCondition:
-  Enabled: true
-
-Lint/DuplicateMethods:
   Enabled: true
 
 Lint/DuplicateHashKey:
@@ -130,9 +122,6 @@ Lint/NonLocalExitFromIterator:
   Enabled: true
 
 Lint/OrderedMagicComments:
-  Enabled: true
-
-Lint/ParenthesesAsGroupedExpression:
   Enabled: true
 
 Lint/PercentStringArray:
@@ -221,40 +210,16 @@ Lint/Void:
 
 # Layout
 
-Layout/AccessModifierIndentation:
-  Enabled: true
-
-Layout/ArrayAlignment:
-  Enabled: true
-
 Layout/ParameterAlignment:
   Enabled: true
   EnforcedStyle: with_fixed_indentation
 
-Layout/BlockAlignment:
-  Enabled: true
-
-Layout/CaseIndentation:
-  Enabled: true
-
-Layout/ClosingParenthesisIndentation:
-  Enabled: true
-
-Layout/CommentIndentation:
-  Enabled: true
-
 Layout/ConditionPosition:
-  Enabled: true
-
-Layout/DefEndAlignment:
   Enabled: true
 
 Layout/DotPosition:
   Enabled: true
   EnforcedStyle: trailing
-
-Layout/ElseAlignment:
-  Enabled: true
 
 Layout/EmptyComment:
   Enabled: true
@@ -265,72 +230,25 @@ Layout/EmptyLineAfterMagicComment:
 Layout/EmptyLineBetweenDefs:
   Enabled: true
 
-Layout/EmptyLines:
-  Enabled: true
-
-Layout/EmptyLinesAroundAccessModifier:
-  Enabled: true
-
 Layout/EmptyLinesAroundArguments:
   Enabled: true
 
 Layout/EmptyLinesAroundBeginBody:
   Enabled: true
 
-Layout/EmptyLinesAroundBlockBody:
-  Enabled: true
-
-Layout/EmptyLinesAroundClassBody:
-  Enabled: true
-
 Layout/EmptyLinesAroundExceptionHandlingKeywords:
-  Enabled: true
-
-Layout/EmptyLinesAroundMethodBody:
   Enabled: true
 
 Layout/EmptyLinesAroundModuleBody:
   Enabled: true
 
-Layout/EndAlignment:
-  Enabled: true
-  EnforcedStyleAlignWith: variable
-  AutoCorrect: true
-
-Layout/EndOfLine:
-  Enabled: true
-  EnforcedStyle: lf
-
-Layout/ExtraSpacing:
-  Enabled: true
-
 Layout/AssignmentIndentation:
   Enabled: true
-
-Layout/FirstArrayElementIndentation:
-  Enabled: true
-  EnforcedStyle: consistent
-
-Layout/FirstHashElementIndentation:
-  Enabled: true
-  EnforcedStyle: special_inside_parentheses
 
 Layout/FirstArgumentIndentation:
   Enabled: true
 
-Layout/HashAlignment:
-  Enabled: true
-
-Layout/IndentationConsistency:
-  Enabled: true
-
-Layout/IndentationWidth:
-  Enabled: true
-
 Layout/InitialIndentation:
-  Enabled: true
-
-Layout/LeadingEmptyLines:
   Enabled: true
 
 Layout/LeadingCommentSpace:
@@ -349,9 +267,6 @@ Layout/MultilineMethodCallBraceLayout:
   Enabled: true
 
 Layout/MultilineMethodDefinitionBraceLayout:
-  Enabled: true
-
-Layout/MultilineOperationIndentation:
   Enabled: true
 
 Layout/SpaceBeforeComma:
@@ -375,22 +290,6 @@ Layout/SpaceInsideArrayLiteralBrackets:
 Layout/SpaceInsideArrayPercentLiteral:
   Enabled: true
 
-Layout/SpaceBeforeBlockBraces:
-  Enabled: true
-
-Layout/SpaceInsideBlockBraces:
-  Enabled: true
-  SpaceBeforeBlockParameters: false
-  Exclude:
-  - bundler/lib/bundler/templates/Gemfile
-  - bundler/lib/bundler/templates/gems.rb
-
-Layout/SpaceInsideHashLiteralBraces:
-  Enabled: true
-
-Layout/SpaceInsideParens:
-  Enabled: true
-
 Layout/SpaceInsidePercentLiteralDelimiters:
   Enabled: true
 
@@ -404,12 +303,6 @@ Layout/SpaceInsideStringInterpolation:
   Enabled: true
 
 Layout/IndentationStyle:
-  Enabled: true
-
-Layout/TrailingEmptyLines:
-  Enabled: true
-
-Layout/TrailingWhitespace:
   Enabled: true
 
 # Naming
@@ -430,14 +323,6 @@ Naming/FileName:
   Enabled: true
   Exclude:
     - 'bundler/spec/realworld/fixtures/warbler/bin/warbler-example.rb'
-
-Naming/HeredocDelimiterCase:
-  Enabled: true
-
-Naming/HeredocDelimiterNaming:
-  Enabled: true
-  ForbiddenDelimiters:
-    - ^RB$
 
 Naming/MethodName:
   Enabled: true
@@ -483,15 +368,6 @@ Performance/ReverseEach:
 Performance/Size:
   Enabled: true
 
-Performance/StartWith:
-  Enabled: true
-
-Performance/StringInclude:
-  Enabled: true
-
-Performance/StringReplacement:
-  Enabled: true
-
 Performance/TimesMap:
   Enabled: true
 
@@ -503,18 +379,11 @@ Performance/UriDefaultParser:
 Security/JSONLoad:
   Enabled: true
 
-Security/Open:
-  Enabled: true
-
 # Style
 
 Style/Alias:
   Enabled: true
   EnforcedStyle: prefer_alias_method
-
-Style/AndOr:
-  Enabled: true
-  EnforcedStyle: always
 
 Style/ArrayJoin:
   Enabled: true
@@ -532,9 +401,6 @@ Style/BeginBlock:
   Enabled: true
 
 Style/BlockComments:
-  Enabled: true
-
-Style/BlockDelimiters:
   Enabled: true
 
 Style/CharacterLiteral:
@@ -564,9 +430,6 @@ Style/CommentAnnotation:
 Style/DefWithParentheses:
   Enabled: true
 
-Style/Dir:
-  Enabled: true
-
 Style/DoubleNegation:
   Enabled: true
 
@@ -585,16 +448,7 @@ Style/EmptyElse:
 Style/EmptyLambdaParameter:
   Enabled: true
 
-Style/Encoding:
-  Enabled: true
-
 Style/EndBlock:
-  Enabled: true
-
-Style/ExpandPathArguments:
-  Enabled: true
-
-Style/EvalWithLocation:
   Enabled: true
 
 Style/EvenOdd:
@@ -618,9 +472,6 @@ Style/HashSyntax:
 Style/IdenticalConditionalBranches:
   Enabled: true
 
-Style/IfInsideElse:
-  Enabled: false
-
 Style/IfUnlessModifierOfIfUnless:
   Enabled: true
 
@@ -636,19 +487,10 @@ Style/LambdaCall:
 Style/LineEndConcatenation:
   Enabled: true
 
-Style/MethodCallWithoutArgsParentheses:
-  Enabled: true
-
-Style/MethodDefParentheses:
-  Enabled: true
-
 Style/MinMax:
   Enabled: true
 
 Style/MixinGrouping:
-  Enabled: true
-
-Style/MultilineIfThen:
   Enabled: true
 
 Style/MultilineMemoization:
@@ -658,9 +500,6 @@ Style/MultilineTernaryOperator:
   Enabled: true
 
 Style/MultipleComparison:
-  Enabled: true
-
-Style/MutableConstant:
   Enabled: true
 
 Style/NegatedIf:
@@ -681,13 +520,7 @@ Style/NestedTernaryOperator:
 Style/Next:
   Enabled: true
 
-Style/NilComparison:
-  Enabled: true
-
 Style/NonNilCheck:
-  Enabled: true
-
-Style/Not:
   Enabled: true
 
 Style/NumericLiteralPrefix:
@@ -709,9 +542,6 @@ Style/ParallelAssignment:
   Enabled: true
 
 Style/ParenthesesAroundCondition:
-  Enabled: true
-
-Style/PercentLiteralDelimiters:
   Enabled: true
 
 Style/PercentQLiterals:
@@ -741,9 +571,6 @@ Lint/RedundantCopEnableDirective:
 Style/RedundantException:
   Enabled: true
 
-Style/RedundantFreeze:
-  Enabled: true
-
 Style/RedundantInterpolation:
   Enabled: true
 
@@ -768,10 +595,6 @@ Style/RescueModifier:
 Style/RescueStandardError:
   Enabled: true
 
-Style/SafeNavigation:
-  Enabled: true
-  MaxChainLength: 1
-
 Style/Sample:
   Enabled: true
 
@@ -794,10 +617,6 @@ Style/StabbyLambdaParentheses:
 
 Style/StderrPuts:
   Enabled: true
-
-Style/StringLiterals:
-  Enabled: true
-  EnforcedStyle: double_quotes
 
 Style/StringLiteralsInInterpolation:
   Enabled: true
@@ -830,16 +649,6 @@ Style/TrailingBodyOnMethodDefinition:
 
 Style/TrailingBodyOnModule:
   Enabled: true
-
-# Having these make it easier to *not* forget to add one when adding a new
-# value and you can simply copy the previous line.
-Style/TrailingCommaInArrayLiteral:
-  Enabled: true
-  EnforcedStyleForMultiline: comma
-
-Style/TrailingCommaInHashLiteral:
-  Enabled: true
-  EnforcedStyleForMultiline: comma
 
 Style/TrailingMethodEndStatement:
   Enabled: true

--- a/.rubocop_bundler.yml
+++ b/.rubocop_bundler.yml
@@ -16,8 +16,6 @@ AllCops:
     - util/**/*
     - bundler/tmp/**/*
     - bundler/lib/bundler/vendor/**/*
-  CacheRootDirectory: tmp/rubocop
-  MaxFilesInCache: 5000
 
 # Bundler
 

--- a/.rubocop_bundler.yml
+++ b/.rubocop_bundler.yml
@@ -17,16 +17,6 @@ AllCops:
     - bundler/tmp/**/*
     - bundler/lib/bundler/vendor/**/*
 
-# Bundler
-
-Bundler/DuplicatedGem:
-  Enabled: true
-
-Bundler/InsecureProtocolSource:
-  Enabled: true
-
-Bundler/OrderedGems:
-  Enabled: true
 
 # Gemspec
 

--- a/.rubocop_bundler.yml
+++ b/.rubocop_bundler.yml
@@ -16,7 +16,6 @@ AllCops:
     - util/**/*
     - bundler/tmp/**/*
     - bundler/lib/bundler/vendor/**/*
-  DisplayCopNames: true
   CacheRootDirectory: tmp/rubocop
   MaxFilesInCache: 5000
 

--- a/.rubocop_bundler.yml
+++ b/.rubocop_bundler.yml
@@ -18,16 +18,6 @@ AllCops:
     - bundler/lib/bundler/vendor/**/*
 
 
-# Gemspec
-
-Gemspec/OrderedDependencies:
-  Enabled: true
-
-Gemspec/RequiredRubyVersion:
-  Enabled: true
-  Exclude:
-    - bundler/spec/realworld/fixtures/warbler/demo/demo.gemspec
-
 # Lint
 
 Lint/AmbiguousOperator:

--- a/.rubocop_bundler.yml
+++ b/.rubocop_bundler.yml
@@ -205,22 +205,10 @@ Style/Alias:
   Enabled: true
   EnforcedStyle: prefer_alias_method
 
-Style/ArrayJoin:
-  Enabled: true
-
 Style/AsciiComments:
   Enabled: true
 
-Style/Attr:
-  Enabled: true
-
 Style/BarePercentLiterals:
-  Enabled: true
-
-Style/BeginBlock:
-  Enabled: true
-
-Style/BlockComments:
   Enabled: true
 
 Style/CharacterLiteral:
@@ -229,19 +217,10 @@ Style/CharacterLiteral:
 Style/ClassCheck:
   Enabled: true
 
-Style/ClassMethods:
-  Enabled: true
-
 Style/ClassVars:
   Enabled: true
 
 Style/ColonMethodCall:
-  Enabled: true
-
-Style/ColonMethodDefinition:
-  Enabled: true
-
-Style/CommandLiteral:
   Enabled: true
 
 Style/CommentAnnotation:
@@ -253,28 +232,10 @@ Style/DefWithParentheses:
 Style/DoubleNegation:
   Enabled: true
 
-Style/EachForSimpleLoop:
-  Enabled: true
-
-Style/EmptyBlockParameter:
-  Enabled: true
-
 Style/EmptyCaseCondition:
   Enabled: true
 
 Style/EmptyElse:
-  Enabled: true
-
-Style/EmptyLambdaParameter:
-  Enabled: true
-
-Style/EndBlock:
-  Enabled: true
-
-Style/EvenOdd:
-  Enabled: true
-
-Style/For:
   Enabled: true
 
 Style/FormatString:
@@ -295,22 +256,7 @@ Style/IdenticalConditionalBranches:
 Style/IfUnlessModifierOfIfUnless:
   Enabled: true
 
-Style/IfWithSemicolon:
-  Enabled: true
-
-Style/InfiniteLoop:
-  Enabled: true
-
-Style/LambdaCall:
-  Enabled: true
-
 Style/LineEndConcatenation:
-  Enabled: true
-
-Style/MinMax:
-  Enabled: true
-
-Style/MixinGrouping:
   Enabled: true
 
 Style/MultilineMemoization:
@@ -325,16 +271,10 @@ Style/MultipleComparison:
 Style/NegatedIf:
   Enabled: true
 
-Style/NegatedWhile:
-  Enabled: true
-
 Style/NestedModifier:
   Enabled: true
 
 Style/NestedParenthesizedCalls:
-  Enabled: true
-
-Style/NestedTernaryOperator:
   Enabled: true
 
 Style/Next:
@@ -343,16 +283,10 @@ Style/Next:
 Style/NonNilCheck:
   Enabled: true
 
-Style/NumericLiteralPrefix:
-  Enabled: true
-
 Style/NumericLiterals:
   Enabled: true
 
-Style/OneLineConditional:
-  Enabled: true
-
-Style/OptionalArguments:
+Style/NumericLiteralPrefix:
   Enabled: true
 
 Style/OrAssignment:
@@ -364,25 +298,10 @@ Style/ParallelAssignment:
 Style/ParenthesesAroundCondition:
   Enabled: true
 
-Style/PercentQLiterals:
-  Enabled: true
-
 Style/PreferredHashMethods:
   Enabled: true
 
-Style/Proc:
-  Enabled: true
-
-Style/RandomWithOffset:
-  Enabled: true
-
 Style/RedundantBegin:
-  Enabled: true
-
-Style/RedundantConditional:
-  Enabled: true
-
-Style/RedundantException:
   Enabled: true
 
 Style/RedundantInterpolation:
@@ -406,19 +325,11 @@ Style/RescueModifier:
 Style/RescueStandardError:
   Enabled: true
 
-Style/Sample:
-  Enabled: true
-
 Style/SelfAssignment:
   Enabled: true
 
 Style/Semicolon:
   Enabled: true
-
-# We adopted raise instead of fail.
-Style/SignalException:
-  Enabled: true
-  EnforcedStyle: only_raise
 
 Style/SingleLineMethods:
   Enabled: true
@@ -433,35 +344,14 @@ Style/StringLiteralsInInterpolation:
   Enabled: true
   EnforcedStyle: double_quotes
 
-Style/Strip:
-  Enabled: true
-
-Style/StructInheritance:
-  Enabled: true
-
 Style/SymbolArray:
   Enabled: true
   EnforcedStyle: brackets
-
-Style/SymbolLiteral:
-  Enabled: true
 
 Style/SymbolProc:
   Enabled: true
 
 Style/TernaryParentheses:
-  Enabled: true
-
-Style/TrailingBodyOnClass:
-  Enabled: true
-
-Style/TrailingBodyOnMethodDefinition:
-  Enabled: true
-
-Style/TrailingBodyOnModule:
-  Enabled: true
-
-Style/TrailingMethodEndStatement:
   Enabled: true
 
 Style/UnlessElse:

--- a/.rubocop_bundler.yml
+++ b/.rubocop_bundler.yml
@@ -41,6 +41,12 @@ Lint/RequireParentheses:
 Lint/RescueException:
   Enabled: true
 
+Lint/RedundantCopDisableDirective:
+  Enabled: true
+
+Lint/RedundantSplatExpansion:
+  Enabled: true
+
 Lint/ReturnInVoidContext:
   Enabled: true
 
@@ -376,12 +382,6 @@ Style/RedundantBegin:
 Style/RedundantConditional:
   Enabled: true
 
-Lint/RedundantCopDisableDirective:
-  Enabled: true
-
-Lint/RedundantCopEnableDirective:
-  Enabled: true
-
 Style/RedundantException:
   Enabled: true
 
@@ -395,9 +395,6 @@ Style/RedundantSelf:
   Enabled: true
 
 Style/RedundantSortBy:
-  Enabled: true
-
-Lint/RedundantSplatExpansion:
   Enabled: true
 
 Style/RegexpLiteral:

--- a/.rubocop_bundler.yml
+++ b/.rubocop_bundler.yml
@@ -207,11 +207,6 @@ Performance/RegexpMatch:
 Performance/TimesMap:
   Enabled: true
 
-# Security
-
-Security/JSONLoad:
-  Enabled: true
-
 # Style
 
 Style/Alias:

--- a/.rubocop_bundler.yml
+++ b/.rubocop_bundler.yml
@@ -70,30 +70,17 @@ Lint/Void:
 
 # Layout
 
-Layout/ParameterAlignment:
-  Enabled: true
-  EnforcedStyle: with_fixed_indentation
-
-Layout/ConditionPosition:
+Layout/AssignmentIndentation:
   Enabled: true
 
 Layout/DotPosition:
   Enabled: true
   EnforcedStyle: trailing
 
-Layout/EmptyComment:
-  Enabled: true
-
 Layout/EmptyLineAfterMagicComment:
   Enabled: true
 
 Layout/EmptyLineBetweenDefs:
-  Enabled: true
-
-Layout/EmptyLinesAroundArguments:
-  Enabled: true
-
-Layout/EmptyLinesAroundBeginBody:
   Enabled: true
 
 Layout/EmptyLinesAroundExceptionHandlingKeywords:
@@ -102,13 +89,7 @@ Layout/EmptyLinesAroundExceptionHandlingKeywords:
 Layout/EmptyLinesAroundModuleBody:
   Enabled: true
 
-Layout/AssignmentIndentation:
-  Enabled: true
-
 Layout/FirstArgumentIndentation:
-  Enabled: true
-
-Layout/InitialIndentation:
   Enabled: true
 
 Layout/LeadingCommentSpace:
@@ -126,16 +107,11 @@ Layout/MultilineHashBraceLayout:
 Layout/MultilineMethodCallBraceLayout:
   Enabled: true
 
-Layout/MultilineMethodDefinitionBraceLayout:
+Layout/ParameterAlignment:
   Enabled: true
+  EnforcedStyle: with_fixed_indentation
 
 Layout/SpaceBeforeComma:
-  Enabled: true
-
-Layout/SpaceBeforeComment:
-  Enabled: true
-
-Layout/SpaceBeforeFirstArg:
   Enabled: true
 
 Layout/SpaceBeforeSemicolon:
@@ -156,13 +132,7 @@ Layout/SpaceInsidePercentLiteralDelimiters:
 Layout/SpaceInsideRangeLiteral:
   Enabled: true
 
-Layout/SpaceInsideReferenceBrackets:
-  Enabled: true
-
 Layout/SpaceInsideStringInterpolation:
-  Enabled: true
-
-Layout/IndentationStyle:
   Enabled: true
 
 # Naming

--- a/.rubocop_bundler.yml
+++ b/.rubocop_bundler.yml
@@ -20,103 +20,19 @@ AllCops:
 
 # Lint
 
-Lint/AmbiguousOperator:
-  Enabled: true
-
-Lint/AmbiguousRegexpLiteral:
-  Enabled: true
-
-Lint/BigDecimalNew:
-  Enabled: true
-
-Lint/BooleanSymbol:
-  Enabled: true
-
-Lint/DeprecatedClassMethods:
+Lint/BinaryOperatorWithIdenticalOperands:
   Enabled: true
 
 Lint/DuplicateCaseCondition:
   Enabled: true
 
-Lint/DuplicateHashKey:
-  Enabled: true
-
-Lint/EachWithObjectArgument:
-  Enabled: true
-
-Lint/ElseLayout:
-  Enabled: true
-
-Lint/EmptyEnsure:
-  Enabled: true
-
 Lint/EmptyExpression:
-  Enabled: true
-
-Lint/EmptyInterpolation:
-  Enabled: true
-
-Lint/EnsureReturn:
-  Enabled: true
-
-Lint/ErbNewArguments:
-  Enabled: true
-
-Lint/FlipFlop:
-  Enabled: true
-
-Lint/FloatOutOfRange:
-  Enabled: true
-
-Lint/FormatParameterMismatch:
-  Enabled: true
-
-Lint/ImplicitStringConcatenation:
-  Enabled: true
-
-Lint/InheritException:
-  Enabled: true
-
-Lint/LiteralAsCondition:
-  Enabled: true
-
-Lint/LiteralInInterpolation:
-  Enabled: true
-
-Lint/Loop:
-  Enabled: true
-
-Lint/MultipleComparison:
-  Enabled: true
-
-Lint/NestedPercentLiteral:
-  Enabled: true
-
-Lint/NextWithoutAccumulator:
   Enabled: true
 
 Lint/NonLocalExitFromIterator:
   Enabled: true
 
-Lint/OrderedMagicComments:
-  Enabled: true
-
-Lint/PercentStringArray:
-  Enabled: true
-
-Lint/PercentSymbolArray:
-  Enabled: true
-
-Lint/RandOne:
-  Enabled: true
-
-Lint/RedundantWithIndex:
-  Enabled: true
-
-Lint/RedundantWithObject:
-  Enabled: true
-
-Lint/RegexpAsCondition:
+Lint/RedundantStringCoercion:
   Enabled: true
 
 Lint/RequireParentheses:
@@ -125,40 +41,13 @@ Lint/RequireParentheses:
 Lint/RescueException:
   Enabled: true
 
-Lint/RescueType:
-  Enabled: true
-
 Lint/ReturnInVoidContext:
-  Enabled: true
-
-Lint/SafeNavigationChain:
-  Enabled: true
-
-Lint/SafeNavigationConsistency:
-  Enabled: true
-
-Lint/ScriptPermission:
-  Enabled: true
-  Exclude:
-    - 'bundler/lib/bundler/templates/Executable'
-    - 'bundler/lib/bundler/templates/Executable.*'
-
-Lint/ShadowedArgument:
   Enabled: true
 
 Lint/ShadowingOuterLocalVariable:
   Enabled: true
 
-Lint/RedundantStringCoercion:
-  Enabled: true
-
-Lint/Syntax:
-  Enabled: true
-
 Lint/UnderscorePrefixedVariableName:
-  Enabled: true
-
-Lint/UnifiedInteger:
   Enabled: true
 
 Lint/UnreachableCode:
@@ -167,19 +56,7 @@ Lint/UnreachableCode:
 Lint/UnusedBlockArgument:
   Enabled: true
 
-Lint/UriEscapeUnescape:
-  Enabled: true
-
-Lint/UriRegexp:
-  Enabled: true
-
 Lint/UselessAccessModifier:
-  Enabled: true
-
-Lint/BinaryOperatorWithIdenticalOperands:
-  Enabled: true
-
-Lint/UselessSetterCall:
   Enabled: true
 
 Lint/Void:

--- a/.rubocop_bundler.yml
+++ b/.rubocop_bundler.yml
@@ -195,37 +195,16 @@ Naming/VariableNumber:
 Performance/Casecmp:
   Enabled: true
 
-Performance/CompareWithBlock:
-  Enabled: true
-
 Performance/Count:
-  Enabled: true
-
-Performance/Detect:
   Enabled: true
 
 Performance/DoubleStartEndWith:
   Enabled: true
 
-Performance/EndWith:
-  Enabled: true
-
-Performance/FixedSize:
-  Enabled: true
-
 Performance/RegexpMatch:
   Enabled: true
 
-Performance/ReverseEach:
-  Enabled: true
-
-Performance/Size:
-  Enabled: true
-
 Performance/TimesMap:
-  Enabled: true
-
-Performance/UriDefaultParser:
   Enabled: true
 
 # Security

--- a/.rubocop_bundler.yml
+++ b/.rubocop_bundler.yml
@@ -161,27 +161,13 @@ Layout/IndentationStyle:
 
 # Naming
 
-Naming/AsciiIdentifiers:
-  Enabled: true
-
-Naming/BinaryOperatorParameterName:
-  Enabled: true
-
-Naming/ClassAndModuleCamelCase:
+Naming/BlockParameterName:
   Enabled: true
 
 Naming/ConstantName:
   Enabled: true
 
-Naming/FileName:
-  Enabled: true
-  Exclude:
-    - 'bundler/spec/realworld/fixtures/warbler/bin/warbler-example.rb'
-
 Naming/MethodName:
-  Enabled: true
-
-Naming/BlockParameterName:
   Enabled: true
 
 Naming/VariableName:

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -771,7 +771,7 @@ module Bundler
 
     def self.deprecated_ext_value?(arguments)
       index = arguments.index("--ext")
-      next_argument = arguments[index+1]
+      next_argument = arguments[index + 1]
 
       # it is ok when --ext is followed with valid extension value
       # for example `bundle gem hello --ext c`

--- a/bundler/lib/bundler/digest.rb
+++ b/bundler/lib/bundler/digest.rb
@@ -26,7 +26,7 @@ module Bundler
           end
           a, b, c, d, e = *words
           (16..79).each do |i|
-            w[i] = SHA1_MASK & rotate((w[i-3] ^ w[i-8] ^ w[i-14] ^ w[i-16]), 1)
+            w[i] = SHA1_MASK & rotate((w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16]), 1)
           end
           0.upto(79) do |i|
             case i

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -1074,7 +1074,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
       it "refuses to install the existing lockfile and prints an error", :bundler => "3" do
         bundle "config set --local deployment true"
 
-        bundle "install", :artifice => "compact_index", :raise_on_error =>false
+        bundle "install", :artifice => "compact_index", :raise_on_error => false
 
         expect(lockfile).to eq(aggregate_gem_section_lockfile)
         expect(err).to include("Your lockfile contains a single rubygems source section with multiple remotes, which is insecure.")

--- a/bundler/spec/runtime/self_management_spec.rb
+++ b/bundler/spec/runtime/self_management_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "Self management", :rubygems => ">= 3.3.0.dev", :realworld => tru
     end
 
     it "shows a discrete message if locked bundler does not exist" do
-      missing_minor ="#{Bundler::VERSION[0]}.999.999"
+      missing_minor = "#{Bundler::VERSION[0]}.999.999"
 
       lockfile_bundled_with(missing_minor)
 

--- a/lib/rubygems/bundler_version_finder.rb
+++ b/lib/rubygems/bundler_version_finder.rb
@@ -65,8 +65,8 @@ module Gem::BundlerVersionFinder
     return unless gemfile
 
     lockfile = case gemfile
-    when "gems.rb" then "gems.locked"
-    else "#{gemfile}.lock"
+               when "gems.rb" then "gems.locked"
+               else "#{gemfile}.lock"
     end.dup.tap(&Gem::UNTAINT)
 
     return unless File.file?(lockfile)

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -54,9 +54,9 @@ class Gem::Commands::SetupCommand < Gem::Command
                "List the documentation types you wish to",
                "generate.  For example: rdoc,ri" do |value, options|
       options[:document] = case value
-      when nil   then %w[rdoc ri]
-      when false then []
-      else            value
+                           when nil   then %w[rdoc ri]
+                           when false then []
+                           else value
       end
     end
 

--- a/lib/rubygems/commands/specification_command.rb
+++ b/lib/rubygems/commands/specification_command.rb
@@ -140,9 +140,9 @@ Specific fields in the specification can be extracted in YAML format:
       s = s.send field if field
 
       say case options[:format]
-      when :ruby then s.to_ruby
-      when :marshal then Marshal.dump s
-      else s.to_yaml
+          when :ruby then s.to_ruby
+          when :marshal then Marshal.dump s
+          else s.to_yaml
       end
 
       say "\n"

--- a/lib/rubygems/gem_runner.rb
+++ b/lib/rubygems/gem_runner.rb
@@ -40,10 +40,10 @@ class Gem::GemRunner
     cmd.command_names.each do |command_name|
       config_args = Gem.configuration[command_name]
       config_args = case config_args
-      when String
-        config_args.split " "
-      else
-        Array(config_args)
+                    when String
+                      config_args.split " "
+                    else
+                      Array(config_args)
       end
       Gem::Command.add_specific_extra_args command_name, config_args
     end

--- a/lib/rubygems/install_update_options.rb
+++ b/lib/rubygems/install_update_options.rb
@@ -35,9 +35,9 @@ module Gem::InstallUpdateOptions
                "List the documentation types you wish to",
                "generate.  For example: rdoc,ri") do |value, options|
       options[:document] = case value
-      when nil   then %w[ri]
-      when false then []
-      else            value
+                           when nil   then %w[ri]
+                           when false then []
+                           else value
       end
     end
 

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -79,8 +79,8 @@ class Gem::Platform
       cpu = arch.shift
 
       @cpu = case cpu
-      when /i\d86/ then "x86"
-      else cpu
+             when /i\d86/ then "x86"
+             else cpu
       end
 
       if arch.length == 2 && arch.last =~ /^\d+(\.\d+)?$/ # for command-line
@@ -92,29 +92,29 @@ class Gem::Platform
       @cpu, os = nil, cpu if os.nil? # legacy jruby
 
       @os, @version = case os
-      when /aix(\d+)?/ then             [ "aix",       $1  ]
-      when /cygwin/ then                [ "cygwin",    nil ]
-      when /darwin(\d+)?/ then          [ "darwin",    $1  ]
-      when /^macruby$/ then             [ "macruby",   nil ]
-      when /freebsd(\d+)?/ then         [ "freebsd",   $1  ]
-      when /^java$/, /^jruby$/ then     [ "java",      nil ]
-      when /^java([\d.]*)/ then         [ "java",      $1  ]
-      when /^dalvik(\d+)?$/ then        [ "dalvik",    $1  ]
-      when /^dotnet$/ then              [ "dotnet",    nil ]
-      when /^dotnet([\d.]*)/ then       [ "dotnet",    $1  ]
-      when /linux-?(\w+)?/ then         [ "linux",     $1  ]
-      when /mingw32/ then               [ "mingw32",   nil ]
-      when /mingw-?(\w+)?/ then         [ "mingw",     $1  ]
-      when /(mswin\d+)(\_(\d+))?/ then
-        os, version = $1, $3
-        @cpu = "x86" if @cpu.nil? && os =~ /32$/
-        [os, version]
-      when /netbsdelf/ then             [ "netbsdelf", nil ]
-      when /openbsd(\d+\.\d+)?/ then    [ "openbsd",   $1  ]
-      when /solaris(\d+\.\d+)?/ then    [ "solaris",   $1  ]
-      # test
-      when /^(\w+_platform)(\d+)?/ then [ $1,          $2  ]
-      else                              [ "unknown",   nil ]
+                      when /aix(\d+)?/ then             [ "aix",       $1  ]
+                      when /cygwin/ then                [ "cygwin",    nil ]
+                      when /darwin(\d+)?/ then          [ "darwin",    $1  ]
+                      when /^macruby$/ then             [ "macruby",   nil ]
+                      when /freebsd(\d+)?/ then         [ "freebsd",   $1  ]
+                      when /^java$/, /^jruby$/ then     [ "java",      nil ]
+                      when /^java([\d.]*)/ then         [ "java",      $1  ]
+                      when /^dalvik(\d+)?$/ then        [ "dalvik",    $1  ]
+                      when /^dotnet$/ then              [ "dotnet",    nil ]
+                      when /^dotnet([\d.]*)/ then       [ "dotnet",    $1  ]
+                      when /linux-?(\w+)?/ then         [ "linux",     $1  ]
+                      when /mingw32/ then               [ "mingw32",   nil ]
+                      when /mingw-?(\w+)?/ then         [ "mingw",     $1  ]
+                      when /(mswin\d+)(\_(\d+))?/ then
+                        os, version = $1, $3
+                        @cpu = "x86" if @cpu.nil? && os =~ /32$/
+                        [os, version]
+                      when /netbsdelf/ then             [ "netbsdelf", nil ]
+                      when /openbsd(\d+\.\d+)?/ then    [ "openbsd",   $1  ]
+                      when /solaris(\d+\.\d+)?/ then    [ "solaris",   $1  ]
+                      # test
+                      when /^(\w+_platform)(\d+)?/ then [ $1,          $2  ]
+                      else [ "unknown", nil ]
       end
     when Gem::Platform then
       @cpu = arch.cpu
@@ -209,18 +209,18 @@ class Gem::Platform
     when String then
       # This data is from http://gems.rubyforge.org/gems/yaml on 19 Aug 2007
       other = case other
-      when /^i686-darwin(\d)/     then ["x86",       "darwin",  $1    ]
-      when /^i\d86-linux/         then ["x86",       "linux",   nil   ]
-      when "java", "jruby"        then [nil,         "java",    nil   ]
-      when /^dalvik(\d+)?$/       then [nil,         "dalvik",  $1    ]
-      when /dotnet(\-(\d+\.\d+))?/ then ["universal","dotnet",  $2    ]
-      when /mswin32(\_(\d+))?/    then ["x86",       "mswin32", $2    ]
-      when /mswin64(\_(\d+))?/    then ["x64",       "mswin64", $2    ]
-      when "powerpc-darwin"       then ["powerpc",   "darwin",  nil   ]
-      when /powerpc-darwin(\d)/   then ["powerpc",   "darwin",  $1    ]
-      when /sparc-solaris2.8/     then ["sparc",     "solaris", "2.8" ]
-      when /universal-darwin(\d)/ then ["universal", "darwin",  $1    ]
-      else                             other
+              when /^i686-darwin(\d)/     then ["x86",       "darwin",  $1    ]
+              when /^i\d86-linux/         then ["x86",       "linux",   nil   ]
+              when "java", "jruby"        then [nil,         "java",    nil   ]
+              when /^dalvik(\d+)?$/       then [nil,         "dalvik",  $1    ]
+              when /dotnet(\-(\d+\.\d+))?/ then ["universal","dotnet",  $2    ]
+              when /mswin32(\_(\d+))?/    then ["x86",       "mswin32", $2    ]
+              when /mswin64(\_(\d+))?/    then ["x64",       "mswin64", $2    ]
+              when "powerpc-darwin"       then ["powerpc",   "darwin",  nil   ]
+              when /powerpc-darwin(\d)/   then ["powerpc",   "darwin",  $1    ]
+              when /sparc-solaris2.8/     then ["sparc",     "solaris", "2.8" ]
+              when /universal-darwin(\d)/ then ["universal", "darwin",  $1    ]
+              else other
       end
 
       other = Gem::Platform.new other

--- a/lib/rubygems/source_list.rb
+++ b/lib/rubygems/source_list.rb
@@ -49,10 +49,10 @@ class Gem::SourceList
 
   def <<(obj)
     src = case obj
-    when Gem::Source
-      obj
-    else
-      Gem::Source.new(obj)
+          when Gem::Source
+            obj
+          else
+            Gem::Source.new(obj)
     end
 
     @sources << src unless @sources.include?(src)

--- a/lib/rubygems/spec_fetcher.rb
+++ b/lib/rubygems/spec_fetcher.rb
@@ -216,26 +216,26 @@ class Gem::SpecFetcher
     @sources.each_source do |source|
       begin
         names = case type
-        when :latest
-          tuples_for source, :latest
-        when :released
-          tuples_for source, :released
-        when :complete
-          names =
-            tuples_for(source, :prerelease, true) +
-            tuples_for(source, :released)
+                when :latest
+                  tuples_for source, :latest
+                when :released
+                  tuples_for source, :released
+                when :complete
+                  names =
+                    tuples_for(source, :prerelease, true) +
+                    tuples_for(source, :released)
 
-          names.sort
-        when :abs_latest
-          names =
-            tuples_for(source, :prerelease, true) +
-            tuples_for(source, :latest)
+                  names.sort
+                when :abs_latest
+                  names =
+                    tuples_for(source, :prerelease, true) +
+                    tuples_for(source, :latest)
 
-          names.sort
-        when :prerelease
-          tuples_for(source, :prerelease)
-        else
-          raise Gem::Exception, "Unknown type - :#{type}"
+                  names.sort
+                when :prerelease
+                  tuples_for(source, :prerelease)
+                else
+                  raise Gem::Exception, "Unknown type - :#{type}"
         end
       rescue Gem::RemoteFetcher::FetchError => e
         errors << Gem::SourceFetchProblem.new(source, e)

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -163,14 +163,14 @@ class Gem::Specification < Gem::BasicSpecification
 
   @@default_value.each do |k,v|
     INITIALIZE_CODE_FOR_DEFAULTS[k] = case v
-    when [], {}, true, false, nil, Numeric, Symbol
-      v.inspect
-    when String
-      v.dump
-    when Numeric
-      "default_value(:#{k})"
-    else
-      "default_value(:#{k}).dup"
+                                      when [], {}, true, false, nil, Numeric, Symbol
+                                        v.inspect
+                                      when String
+                                        v.dump
+                                      when Numeric
+                                        "default_value(:#{k})"
+                                      else
+                                        "default_value(:#{k}).dup"
     end
   end
 
@@ -1747,17 +1747,17 @@ class Gem::Specification < Gem::BasicSpecification
     # This is the cleanest, most-readable, faster-than-using-Date
     # way to do it.
     @date = case date
-    when String then
-      if DateTimeFormat =~ date
-        Time.utc($1.to_i, $2.to_i, $3.to_i)
-      else
-        raise(Gem::InvalidSpecificationException,
-              "invalid date format in specification: #{date.inspect}")
-      end
-    when Time, DateLike then
-      Time.utc(date.year, date.month, date.day)
-    else
-      TODAY
+            when String then
+              if DateTimeFormat =~ date
+                Time.utc($1.to_i, $2.to_i, $3.to_i)
+              else
+                raise(Gem::InvalidSpecificationException,
+                      "invalid date format in specification: #{date.inspect}")
+              end
+            when Time, DateLike then
+              Time.utc(date.year, date.month, date.day)
+            else
+              TODAY
     end
   end
 
@@ -1864,12 +1864,12 @@ class Gem::Specification < Gem::BasicSpecification
     coder.add "name", @name
     coder.add "version", @version
     platform = case @original_platform
-    when nil, "" then
-      "ruby"
-    when String then
-      @original_platform
-    else
-      @original_platform.to_s
+               when nil, "" then
+                 "ruby"
+               when String then
+                 @original_platform
+               else
+                 @original_platform.to_s
     end
     coder.add "platform", platform
 
@@ -2708,8 +2708,8 @@ class Gem::Specification < Gem::BasicSpecification
       default = self.default_value attribute
 
       value = case default
-      when Time, Numeric, Symbol, true, false, nil then default
-      else default.dup
+              when Time, Numeric, Symbol, true, false, nil then default
+              else default.dup
       end
 
       instance_variable_set "@#{attribute}", value

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -337,10 +337,10 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
   def validate_array_attribute(field)
     val = @specification.send(field)
     klass = case field
-    when :dependencies then
-      Gem::Dependency
-    else
-      String
+            when :dependencies then
+              Gem::Dependency
+            else
+              String
     end
 
     unless Array === val && val.all? {|x| x.kind_of?(klass) }

--- a/lib/rubygems/user_interaction.rb
+++ b/lib/rubygems/user_interaction.rb
@@ -258,22 +258,22 @@ class Gem::StreamUI
     end
 
     default_answer = case default
-    when nil
-      "yn"
-    when true
-      "Yn"
-    else
-      "yN"
+                     when nil
+                       "yn"
+                     when true
+                       "Yn"
+                     else
+                       "yN"
     end
 
     result = nil
 
     while result.nil? do
       result = case ask "#{question} [#{default_answer}]"
-      when /^y/i then true
-      when /^n/i then false
-      when /^$/  then default
-      else            nil
+               when /^y/i then true
+               when /^n/i then false
+               when /^$/  then default
+               else nil
       end
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We have two rubocop rules between rubygems and bundler. We should move to merge them.

## What is your fix for the problem, implemented in this PR?

I merge `.rubocop_bundler.yml` into `.rubocop.yml` only non-effect cops at first in this PR. After that, I'll triage `rubocop_bundler.yml` cops and modify rubygems or bundler files step by step.

@deivid-rodriguez @simi Do you have any concerns about this merger plan?

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
