### PR TITLE
Fix `$LOAD_PATH` in rake and ext_conf builder

### DIFF
--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -54,16 +54,20 @@ class Gem::Ext::Builder
     end
   end
 
-  def self.rubygems_load_path
+  def self.ruby
+    require "shellwords"
+    # Gem.ruby is quoted if it contains whitespace
+    cmd = Gem.ruby.shellsplit
+
     # This load_path is only needed when running rubygems test without a proper installation.
     # Prepending it in a normal installation will cause problem with order of $LOAD_PATH.
     # Therefore only add load_path if it is not present in the default $LOAD_PATH.
     load_path = File.expand_path("../..", __dir__)
     case load_path
     when RbConfig::CONFIG["sitelibdir"], RbConfig::CONFIG["vendorlibdir"], RbConfig::CONFIG["rubylibdir"]
-      []
+      cmd
     else
-      ["-I#{load_path}"]
+      cmd << "-I#{load_path}"
     end
   end
 

--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -54,6 +54,19 @@ class Gem::Ext::Builder
     end
   end
 
+  def self.rubygems_load_path
+    # This load_path is only needed when running rubygems test without a proper installation.
+    # Prepending it in a normal installation will cause problem with order of $LOAD_PATH.
+    # Therefore only add load_path if it is not present in the default $LOAD_PATH.
+    load_path = File.expand_path("../..", __dir__)
+    case load_path
+    when RbConfig::CONFIG["sitelibdir"], RbConfig::CONFIG["vendorlibdir"], RbConfig::CONFIG["rubylibdir"]
+      []
+    else
+      ["-I#{load_path}"]
+    end
+  end
+
   def self.run(command, results, command_name = nil, dir = Dir.pwd, env = {})
     verbose = Gem.configuration.really_verbose
 

--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -21,22 +21,10 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
 
     destdir = ENV["DESTDIR"]
 
-    # This is only needed when running rubygems test without a proper installation.
-    # Prepending it in a normal installation can cause problem with order of $LOAD_PATH.
-    # Therefore only add rubygems_load_path if it is not present in the default $LOAD_PATH.
-    rubygems_load_path = File.expand_path("../..", __dir__)
-    load_path =
-      case rubygems_load_path
-      when RbConfig::CONFIG["sitelibdir"], RbConfig::CONFIG["vendorlibdir"], RbConfig::CONFIG["rubylibdir"]
-        []
-      else
-        ["-I#{rubygems_load_path}"]
-      end
-
     begin
       require "shellwords"
       cmd = Gem.ruby.shellsplit
-      cmd.push(*load_path)
+      cmd.push(*rubygems_load_path)
       cmd << File.basename(extension)
       cmd.push(*args)
 

--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -21,9 +21,23 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
 
     destdir = ENV["DESTDIR"]
 
+    # This is only needed when running rubygems test without a proper installation.
+    # Prepending it in a normal installation can cause problem with order of $LOAD_PATH.
+    # Therefore only add rubygems_load_path if it is not present in the default $LOAD_PATH.
+    rubygems_load_path = File.expand_path("../..", __dir__)
+    load_path =
+      case rubygems_load_path
+      when RbConfig::CONFIG["sitelibdir"], RbConfig::CONFIG["vendorlibdir"], RbConfig::CONFIG["rubylibdir"]
+        []
+      else
+        ["-I#{rubygems_load_path}"]
+      end
+
     begin
       require "shellwords"
-      cmd = Gem.ruby.shellsplit << "-I" << File.expand_path("../..", __dir__) << File.basename(extension)
+      cmd = Gem.ruby.shellsplit
+      cmd.push(*load_path)
+      cmd << File.basename(extension)
       cmd.push(*args)
 
       run(cmd, results, class_name, extension_dir) do |s, r|

--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -22,10 +22,7 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
     destdir = ENV["DESTDIR"]
 
     begin
-      require "shellwords"
-      cmd = Gem.ruby.shellsplit
-      cmd.push(*rubygems_load_path)
-      cmd << File.basename(extension)
+      cmd = ruby << File.basename(extension)
       cmd.push(*args)
 
       run(cmd, results, class_name, extension_dir) do |s, r|

--- a/lib/rubygems/ext/rake_builder.rb
+++ b/lib/rubygems/ext/rake_builder.rb
@@ -19,7 +19,7 @@ class Gem::Ext::RakeBuilder < Gem::Ext::Builder
       rake = rake.shellsplit
     else
       begin
-        rake = [Gem.ruby, *rubygems_load_path, "-rrubygems", Gem.bin_path("rake", "rake")]
+        rake = ruby << "-rrubygems" << Gem.bin_path("rake", "rake")
       rescue Gem::Exception
         rake = [Gem.default_exec_format % "rake"]
       end

--- a/lib/rubygems/ext/rake_builder.rb
+++ b/lib/rubygems/ext/rake_builder.rb
@@ -18,20 +18,8 @@ class Gem::Ext::RakeBuilder < Gem::Ext::Builder
       require "shellwords"
       rake = rake.shellsplit
     else
-      # This is only needed when running rubygems test without a proper installation.
-      # Prepending it in a normal installation can cause problem with order of $LOAD_PATH.
-      # Therefore only add rubygems_load_path if it is not present in the default $LOAD_PATH.
-      rubygems_load_path = File.expand_path("../..", __dir__)
-      load_path =
-        case rubygems_load_path
-        when RbConfig::CONFIG["sitelibdir"], RbConfig::CONFIG["vendorlibdir"], RbConfig::CONFIG["rubylibdir"]
-          []
-        else
-          ["-I#{rubygems_load_path}"]
-        end
-
       begin
-        rake = [Gem.ruby, *load_path, "-rrubygems", Gem.bin_path("rake", "rake")]
+        rake = [Gem.ruby, *rubygems_load_path, "-rrubygems", Gem.bin_path("rake", "rake")]
       rescue Gem::Exception
         rake = [Gem.default_exec_format % "rake"]
       end

--- a/lib/rubygems/ext/rake_builder.rb
+++ b/lib/rubygems/ext/rake_builder.rb
@@ -18,8 +18,20 @@ class Gem::Ext::RakeBuilder < Gem::Ext::Builder
       require "shellwords"
       rake = rake.shellsplit
     else
+      # This is only needed when running rubygems test without a proper installation.
+      # Prepending it in a normal installation can cause problem with order of $LOAD_PATH.
+      # Therefore only add rubygems_load_path if it is not present in the default $LOAD_PATH.
+      rubygems_load_path = File.expand_path("../..", __dir__)
+      load_path =
+        case rubygems_load_path
+        when RbConfig::CONFIG["sitelibdir"], RbConfig::CONFIG["vendorlibdir"], RbConfig::CONFIG["rubylibdir"]
+          []
+        else
+          ["-I#{rubygems_load_path}"]
+        end
+
       begin
-        rake = [Gem.ruby, "-I#{File.expand_path("../..", __dir__)}", "-rrubygems", Gem.bin_path("rake", "rake")]
+        rake = [Gem.ruby, *load_path, "-rrubygems", Gem.bin_path("rake", "rake")]
       rescue Gem::Exception
         rake = [Gem.default_exec_format % "rake"]
       end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Installing gem with rake based extension which depends on a native gem (e.g. psych) that has more than one copies on the system (one comes default with ruby installation and one user installation) with the system rubygems can fail in a very strange way.

Reproduction: https://github.com/sinatra/sinatra/pull/1911#issuecomment-1471165928
Explanation: https://github.com/sinatra/sinatra/pull/1911#issuecomment-1471182649

## What is your fix for the problem, implemented in this PR?

Per previous PR related to this issue: https://github.com/rubygems/rubygems/pull/4165

> I'm not sure using this -I parameter here is a good idea, so since I'm not sure I'm just keeping things as they are for now and fixing the bug.

Removing this flag caused one of the existing tests to be broken: https://github.com/rubygems/rubygems/actions/runs/4433225457/jobs/7778058872

Therefore, this PR removes it conditionally.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes (existing tests should be enough)
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
