### PR TITLE
Don't recommend `--full-index` on errors

### DIFF
--- a/bundler/lib/bundler/fetcher/dependency.rb
+++ b/bundler/lib/bundler/fetcher/dependency.rb
@@ -34,13 +34,9 @@ module Bundler
 
         returned_gems = spec_list.map(&:first).uniq
         specs(deps_list, full_dependency_list + returned_gems, spec_list + last_spec_list)
-      rescue MarshalError
+      rescue MarshalError, HTTPError, GemspecError
         Bundler.ui.info "" unless Bundler.ui.debug? # new line now that the dots are over
         Bundler.ui.debug "could not fetch from the dependency API, trying the full index"
-        nil
-      rescue HTTPError, GemspecError
-        Bundler.ui.info "" unless Bundler.ui.debug? # new line now that the dots are over
-        Bundler.ui.debug "could not fetch from the dependency API\nit's suggested to retry using the full index via `bundle install --full-index`"
         nil
       end
 

--- a/bundler/lib/bundler/remote_specification.rb
+++ b/bundler/lib/bundler/remote_specification.rb
@@ -106,7 +106,7 @@ module Bundler
     def _remote_specification
       @_remote_specification ||= @spec_fetcher.fetch_spec([@name, @version, @original_platform])
       @_remote_specification || raise(GemspecError, "Gemspec data for #{full_name} was" \
-        " missing from the server! Try installing with `--full-index` as a workaround.")
+        " missing from the server!")
     end
 
     def method_missing(method, *args, &blk)

--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -160,7 +160,7 @@ module Bundler
         " (was expecting #{old_deps.map(&:to_s)}, but the real spec has #{new_deps.map(&:to_s)})"
       raise APIResponseMismatchError,
         "Downloading #{spec.full_name} revealed dependencies not in the API or the lockfile (#{extra_deps.join(", ")})." \
-        "\nEither installing with `--full-index` or running `bundle update #{spec.name}` should fix the problem."
+        "\nRunning `bundle update #{spec.name}` should fix the problem."
     end
 
     def pretty_dependency(dep)

--- a/bundler/spec/bundler/fetcher/dependency_spec.rb
+++ b/bundler/spec/bundler/fetcher/dependency_spec.rb
@@ -155,9 +155,9 @@ RSpec.describe Bundler::Fetcher::Dependency do
       end
     end
 
-    shared_examples_for "the error suggests retrying with the full index" do
-      it "should log the inability to fetch from API at debug level" do
-        expect(Bundler).to receive_message_chain(:ui, :debug).with("could not fetch from the dependency API\nit's suggested to retry using the full index via `bundle install --full-index`")
+    shared_examples_for "the error is logged" do
+      it "should log the inability to fetch from API at debug level, and mention retrying" do
+        expect(Bundler).to receive_message_chain(:ui, :debug).with("could not fetch from the dependency API, trying the full index")
         subject.specs(gem_names, full_dependency_list, last_spec_list)
       end
     end
@@ -166,25 +166,21 @@ RSpec.describe Bundler::Fetcher::Dependency do
       before { allow(subject).to receive(:dependency_specs) { raise Bundler::HTTPError.new } }
 
       it_behaves_like "the error is properly handled"
-      it_behaves_like "the error suggests retrying with the full index"
+      it_behaves_like "the error is logged"
     end
 
     context "when a GemspecError occurs" do
       before { allow(subject).to receive(:dependency_specs) { raise Bundler::GemspecError.new } }
 
       it_behaves_like "the error is properly handled"
-      it_behaves_like "the error suggests retrying with the full index"
+      it_behaves_like "the error is logged"
     end
 
     context "when a MarshalError occurs" do
       before { allow(subject).to receive(:dependency_specs) { raise Bundler::MarshalError.new } }
 
       it_behaves_like "the error is properly handled"
-
-      it "should log the inability to fetch from API and mention retrying" do
-        expect(Bundler).to receive_message_chain(:ui, :debug).with("could not fetch from the dependency API, trying the full index")
-        subject.specs(gem_names, full_dependency_list, last_spec_list)
-      end
+      it_behaves_like "the error is logged"
     end
   end
 

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -930,7 +930,7 @@ The checksum of /versions does not match the checksum provided by the server! So
     expect(out).to include("rails-2.3.2 from rubygems remote at #{source_uri}/ has either corrupted API or lockfile dependencies")
     expect(err).to include(<<-E.strip)
 Bundler::APIResponseMismatchError: Downloading rails-2.3.2 revealed dependencies not in the API or the lockfile (#{deps.map(&:to_s).join(", ")}).
-Either installing with `--full-index` or running `bundle update rails` should fix the problem.
+Running `bundle update rails` should fix the problem.
     E
   end
 

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -1218,7 +1218,7 @@ RSpec.describe "the lockfile format" do
     G
 
     expect(err).to include("Downloading rack_middleware-1.0 revealed dependencies not in the API or the lockfile (#{Gem::Dependency.new("rack", "= 0.9.1")}).").
-      and include("Either installing with `--full-index` or running `bundle update rack_middleware` should fix the problem.")
+      and include("Running `bundle update rack_middleware` should fix the problem.")
   end
 
   it "regenerates a lockfile with no specs" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The `--full-index` flag is slow since the resolver needs to fetch the remote gemspec every time it needs to figure out dependencies of a gem, which happens a lot during resolution.

Plus it's still potentially vulnerable to dependency [confusion issues](#4694).

Also, some of this recommendations did not even make sense as far as I understand.

Finally these days the dependency APIs are reliable enough, and there are implicit fallbacks in place anyways.

## What is your fix for the problem, implemented in this PR?

Stop recommending `--full-index`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
