### PR TITLE
Avoid intermediate array in TarHeader#calculate_checksum

### DIFF
--- a/lib/rubygems/package/tar_header.rb
+++ b/lib/rubygems/package/tar_header.rb
@@ -208,7 +208,7 @@ class Gem::Package::TarHeader
   private
 
   def calculate_checksum(header)
-    header.bytes.sum
+    header.sum(0)
   end
 
   def header(checksum = @checksum)

--- a/test/rubygems/package/tar_test_case.rb
+++ b/test/rubygems/package/tar_test_case.rb
@@ -67,7 +67,7 @@ class Gem::Package::TarTestCase < Gem::TestCase
   end
 
   def calc_checksum(header)
-    sum = header.bytes.sum
+    sum = header.sum(0)
     SP(Z(to_oct(sum, 6)))
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Avoid the call to String#bytes which generates an intermediate array of character values for checksum.

## What is your fix for the problem, implemented in this PR?

String#sum(0) sums the character bytes without a modulo, much faster.
Follow-up of #6476 based on comment from @nobu.

```
old checksum  3.954847   0.000451   3.955298 (  3.957550)
new checksum  0.490703   0.000003   0.490706 (  0.490972) #6476
sum checksum  0.018343   0.000000   0.018343 (  0.018351) #This PR
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes **=> tests already exist**
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
