### PR TITLE
Fix incorrect removal of ruby platform when auto-healing corrupted lockfiles

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -80,6 +80,7 @@ bundler/lib/bundler/gem_helpers.rb
 bundler/lib/bundler/gem_tasks.rb
 bundler/lib/bundler/gem_version_promoter.rb
 bundler/lib/bundler/graph.rb
+bundler/lib/bundler/incomplete_specification.rb
 bundler/lib/bundler/index.rb
 bundler/lib/bundler/injector.rb
 bundler/lib/bundler/inline.rb

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -62,6 +62,7 @@ module Bundler
   autoload :GemHelpers,             File.expand_path("bundler/gem_helpers", __dir__)
   autoload :GemVersionPromoter,     File.expand_path("bundler/gem_version_promoter", __dir__)
   autoload :Graph,                  File.expand_path("bundler/graph", __dir__)
+  autoload :IncompleteSpecification, File.expand_path("bundler/incomplete_specification", __dir__)
   autoload :Index,                  File.expand_path("bundler/index", __dir__)
   autoload :Injector,               File.expand_path("bundler/injector", __dir__)
   autoload :Installer,              File.expand_path("bundler/installer", __dir__)

--- a/bundler/lib/bundler/incomplete_specification.rb
+++ b/bundler/lib/bundler/incomplete_specification.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Bundler
+  #
+  # Represents a package name that was found to be incomplete when trying to
+  # materialize a fresh resolution or the lockfile.
+  #
+  # Holds the actual partially complete set of specifications for the name.
+  # These are used so that they can be unlocked in a future resolution, and fix
+  # the situation.
+  #
+  class IncompleteSpecification
+    attr_reader :name, :partially_complete_specs
+
+    def initialize(name, partially_complete_specs = [])
+      @name = name
+      @partially_complete_specs = partially_complete_specs
+    end
+
+    def ==(other)
+      partially_complete_specs == other.partially_complete_specs
+    end
+  end
+end

--- a/bundler/lib/bundler/resolver/base.rb
+++ b/bundler/lib/bundler/resolver/base.rb
@@ -34,9 +34,11 @@ module Bundler
         @base[name]
       end
 
-      def delete(specs)
-        specs.each do |spec|
-          @base.delete(spec)
+      def delete(incomplete_specs)
+        incomplete_specs.each do |incomplete_spec|
+          incomplete_spec.partially_complete_specs.each do |spec|
+            @base.delete(spec)
+          end
         end
       end
 

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -78,8 +78,8 @@ module Bundler
       lookup.dup
     end
 
-    def materialize(deps)
-      materialized = self.for(deps, true)
+    def materialize(deps, platforms = [nil])
+      materialized = self.for(deps, true, platforms)
 
       SpecSet.new(materialized)
     end
@@ -100,9 +100,7 @@ module Bundler
     def incomplete_ruby_specs?(deps)
       return false if @specs.empty?
 
-      materialized = self.for(deps, true, [Gem::Platform::RUBY])
-
-      SpecSet.new(materialized).incomplete_specs.any?
+      materialize(deps, [Gem::Platform::RUBY]).incomplete_specs.any?
     end
 
     def missing_specs

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -103,6 +103,8 @@ module Bundler
     def incomplete_ruby_specs?(deps)
       return false if @specs.empty?
 
+      @incomplete_specs = []
+
       self.for(deps, true, [Gem::Platform::RUBY])
 
       @incomplete_specs.any?

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -101,6 +101,8 @@ module Bundler
     end
 
     def incomplete_ruby_specs?(deps)
+      return false if @specs.empty?
+
       self.for(deps, true, [Gem::Platform::RUBY])
 
       @incomplete_specs.any?

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -1262,7 +1262,7 @@ RSpec.describe "the lockfile format" do
           indirect_dependency (1.2.3)
 
       PLATFORMS
-        #{lockfile_platforms}
+        #{formatted_lockfile_platforms(*["ruby", generic_local_platform].uniq)}
 
       DEPENDENCIES
         direct_dependency

--- a/bundler/spec/support/platforms.rb
+++ b/bundler/spec/support/platforms.rb
@@ -96,7 +96,11 @@ module Spec
     end
 
     def lockfile_platforms(*extra)
-      [local_platform, *extra].map(&:to_s).sort.join("\n  ")
+      formatted_lockfile_platforms(local_platform, *extra)
+    end
+
+    def formatted_lockfile_platforms(*platforms)
+      platforms.map(&:to_s).sort.join("\n  ")
     end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In certain situations, when auto-healing a corrupted lockfile we will end up removing the "RUBY" platform from the lockfile, when not necessary.

This is because we sometimes also "heal" the lockfile PLATFORMS section, because some old lockfiles including the "RUBY" platform incorrectly and can't bundle in newer bundler versions, so we remove it for backwards compatibility.

However, our check to detect these corrupt lockfiles that are locked to the RUBY platform but don't work with it, sometimes was triggering incorrectly.

One is for lockfile with empty SPECS section, another one is for lockfile missing dependencies.

I found these bugs while working on #5700, where I plan to generate a "universal lockfile" by default (with more than just the current platform), so this kind of issue surfaces more since we deal with multiple lockfile platforms in more cases.

## What is your fix for the problem, implemented in this PR?

* For the empty SPECS section case, we explicitly avoid the "incomplete ruby check".
* For the missing dependencies case, we need to make sure the pre-existing "incomplete" condition of the lockfile does not trick us when checking for incompleteness with respect to the "RUBY" platform.

Fixing the latter bug made me realize we were relying too much on state (keeping `@incomplete_platforms` and propagating it through `SpecSet`s), making this bug easy to happen. I refactored things by extracting an `IncompleteSpecification` class that makes things easier to follow and more consistent with how we handle missing specifications.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
