### PR TITLE
Reduce macos-12 jobs on GitHub Actions

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -41,9 +41,9 @@ jobs:
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.6, value: 2.6.10 } }
 
         include:
-          - { os: { name: MacOS, value: macos-12 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.7 }, timeout: 90 }
-          - { os: { name: MacOS, value: macos-12 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.5 }, timeout: 90 }
-          - { os: { name: MacOS, value: macos-12 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.3 }, timeout: 90 }
+          # - { os: { name: MacOS, value: macos-12 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.7 }, timeout: 90 }
+          # - { os: { name: MacOS, value: macos-12 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.5 }, timeout: 90 }
+          # - { os: { name: MacOS, value: macos-12 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.3 }, timeout: 90 }
           - { os: { name: MacOS, value: macos-12 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.2, value: 3.2.1 }, timeout: 90 }
 
           - { os: { name: Windows, value: windows-2022 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.7 }, timeout: 150 }

--- a/.github/workflows/realworld-bundler.yml
+++ b/.github/workflows/realworld-bundler.yml
@@ -36,9 +36,9 @@ jobs:
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.6, value: 2.6.10 } }
 
         include:
-          - { os: { name: MacOS, value: macos-12 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.7 } }
-          - { os: { name: MacOS, value: macos-12 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.5 } }
-          - { os: { name: MacOS, value: macos-12 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.3 } }
+          # - { os: { name: MacOS, value: macos-12 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.7 } }
+          # - { os: { name: MacOS, value: macos-12 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.5 } }
+          # - { os: { name: MacOS, value: macos-12 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.3 } }
           - { os: { name: MacOS, value: macos-12 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.2, value: 3.2.1 } }
     env:
       RGV: ..

--- a/.github/workflows/rubygems.yml
+++ b/.github/workflows/rubygems.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os:
           - { name: Ubuntu, value: ubuntu-22.04 }
-          - { name: MacOS, value: macos-12 }
+          # - { name: MacOS, value: macos-12 }
           - { name: Windows, value: windows-2022 }
 
         ruby:
@@ -31,6 +31,9 @@ jobs:
           - { name: "3.2", value: 3.2.1 }
 
         include:
+          - ruby: { name: "3.2", value: 3.2.1 }
+            os: { name: macOS, value: macos-12 }
+
           - ruby: { name: jruby-9.4, value: jruby-9.4.2.0 }
             os: { name: Ubuntu, value: ubuntu-22.04 }
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Recently, macos-12 runner of GitHub Actions is frequency stuck status.

## What is your fix for the problem, implemented in this PR?

We have following runners under rubygems organization in this time.

* Linux 40
* Windows 15
* macOS 5(limit reached)

Runner number of Linux + Windows + macOS can up to 60. Sometimes We can use 10 macOS jobs with 10 Linux jobs and 10 Windows jobs. Unfortunately, we couldn't test macOS platform same as Linux and Windows. I disabled Ruby 2.7-3.1 jobs in GitHub Actions. 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
