### PR TITLE
Backport commits from ruby-core

### DIFF
--- a/bundler/lib/bundler/vendor/fileutils/lib/fileutils.rb
+++ b/bundler/lib/bundler/vendor/fileutils/lib/fileutils.rb
@@ -3,7 +3,7 @@
 begin
   require 'rbconfig'
 rescue LoadError
-  # for make mjit-headers
+  # for make rjit-headers
 end
 
 # Namespace for file utility methods for copying, moving, removing, etc.

--- a/test/rubygems/test_gem_commands_exec_command.rb
+++ b/test/rubygems/test_gem_commands_exec_command.rb
@@ -215,7 +215,7 @@ class TestGemCommandsExecCommand < Gem::TestCase
 
   def test_gem_with_platform_and_platform_dependencies
     pend "extensions don't quite work on jruby" if Gem.java_platform?
-    pend "terminates on mswin" if Gem.win_platform?
+    pend "terminates on mswin" if Gem.win_platform? && ruby_repo?
 
     spec_fetcher do |fetcher|
       fetcher.download "a", 2 do |s|

--- a/test/rubygems/test_gem_commands_exec_command.rb
+++ b/test/rubygems/test_gem_commands_exec_command.rb
@@ -215,6 +215,7 @@ class TestGemCommandsExecCommand < Gem::TestCase
 
   def test_gem_with_platform_and_platform_dependencies
     pend "extensions don't quite work on jruby" if Gem.java_platform?
+    pend "terminates on mswin" if Gem.win_platform?
 
     spec_fetcher do |fetcher|
       fetcher.download "a", 2 do |s|

--- a/test/rubygems/test_gem_stream_ui.rb
+++ b/test/rubygems/test_gem_stream_ui.rb
@@ -4,9 +4,9 @@ require "rubygems/user_interaction"
 require "timeout"
 
 class TestGemStreamUI < Gem::TestCase
-  # increase timeout with MJIT for --jit-wait testing
-  mjit_enabled = defined?(RubyVM::MJIT) && RubyVM::MJIT.enabled?
-  SHORT_TIMEOUT = RUBY_ENGINE == "ruby" && !mjit_enabled ? 0.1 : 1.0
+  # increase timeout with RJIT for --jit-wait testing
+  rjit_enabled = defined?(RubyVM::RJIT) && RubyVM::RJIT.enabled?
+  SHORT_TIMEOUT = RUBY_ENGINE == "ruby" && !rjit_enabled ? 0.1 : 1.0
 
   module IsTty
     attr_accessor :tty


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

[ruby/ruby](https://github.com/ruby/ruby) have some out-of-sync commits.

## What is your fix for the problem, implemented in this PR?

I picked them and add guard for this repository.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
