### PR TITLE
Remove constants condition related ruby releases.

### DIFF
--- a/lib/rubygems/request.rb
+++ b/lib/rubygems/request.rb
@@ -283,7 +283,7 @@ class Gem::Request
     ua << " Ruby/#{ruby_version} (#{RUBY_RELEASE_DATE}"
     if RUBY_PATCHLEVEL >= 0
       ua << " patchlevel #{RUBY_PATCHLEVEL}"
-    elsif defined?(RUBY_REVISION)
+    else
       ua << " revision #{RUBY_REVISION}"
     end
     ua << ")"

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -1126,7 +1126,7 @@ Also, a list:
     Object.send :remove_const, :RUBY_VERSION
     Object.send :remove_const, :RUBY_PATCHLEVEL
     Object.send :remove_const, :RUBY_REVISION       if defined?(RUBY_REVISION)
-    Object.send :remove_const, :RUBY_DESCRIPTION    if defined?(RUBY_DESCRIPTION)
+    Object.send :remove_const, :RUBY_DESCRIPTION
     Object.send :remove_const, :RUBY_ENGINE
     Object.send :remove_const, :RUBY_ENGINE_VERSION if defined?(RUBY_ENGINE_VERSION)
   end

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -1099,7 +1099,7 @@ Also, a list:
     @RUBY_REVISION       = RUBY_REVISION
     @RUBY_DESCRIPTION    = RUBY_DESCRIPTION
     @RUBY_ENGINE         = RUBY_ENGINE
-    @RUBY_ENGINE_VERSION = RUBY_ENGINE_VERSION if defined?(RUBY_ENGINE_VERSION)
+    @RUBY_ENGINE_VERSION = RUBY_ENGINE_VERSION
 
     util_clear_RUBY_VERSION
 
@@ -1108,7 +1108,7 @@ Also, a list:
     Object.const_set :RUBY_REVISION,       revision
     Object.const_set :RUBY_DESCRIPTION,    description
     Object.const_set :RUBY_ENGINE,         engine
-    Object.const_set :RUBY_ENGINE_VERSION, engine_version if engine_version
+    Object.const_set :RUBY_ENGINE_VERSION, engine_version
   end
 
   def util_restore_RUBY_VERSION
@@ -1119,7 +1119,7 @@ Also, a list:
     Object.const_set :RUBY_REVISION,       @RUBY_REVISION
     Object.const_set :RUBY_DESCRIPTION,    @RUBY_DESCRIPTION
     Object.const_set :RUBY_ENGINE,         @RUBY_ENGINE
-    Object.const_set :RUBY_ENGINE_VERSION, @RUBY_ENGINE_VERSION if defined?(@RUBY_ENGINE_VERSION)
+    Object.const_set :RUBY_ENGINE_VERSION, @RUBY_ENGINE_VERSION
   end
 
   def util_clear_RUBY_VERSION
@@ -1128,7 +1128,7 @@ Also, a list:
     Object.send :remove_const, :RUBY_REVISION
     Object.send :remove_const, :RUBY_DESCRIPTION
     Object.send :remove_const, :RUBY_ENGINE
-    Object.send :remove_const, :RUBY_ENGINE_VERSION if defined?(RUBY_ENGINE_VERSION)
+    Object.send :remove_const, :RUBY_ENGINE_VERSION
   end
 
   ##

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -1124,7 +1124,7 @@ Also, a list:
 
   def util_clear_RUBY_VERSION
     Object.send :remove_const, :RUBY_VERSION
-    Object.send :remove_const, :RUBY_PATCHLEVEL     if defined?(RUBY_PATCHLEVEL)
+    Object.send :remove_const, :RUBY_PATCHLEVEL
     Object.send :remove_const, :RUBY_REVISION       if defined?(RUBY_REVISION)
     Object.send :remove_const, :RUBY_DESCRIPTION    if defined?(RUBY_DESCRIPTION)
     Object.send :remove_const, :RUBY_ENGINE

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -1096,7 +1096,7 @@ Also, a list:
 
     @RUBY_VERSION        = RUBY_VERSION
     @RUBY_PATCHLEVEL     = RUBY_PATCHLEVEL
-    @RUBY_REVISION       = RUBY_REVISION if defined?(RUBY_REVISION)
+    @RUBY_REVISION       = RUBY_REVISION
     @RUBY_DESCRIPTION    = RUBY_DESCRIPTION
     @RUBY_ENGINE         = RUBY_ENGINE
     @RUBY_ENGINE_VERSION = RUBY_ENGINE_VERSION if defined?(RUBY_ENGINE_VERSION)
@@ -1116,7 +1116,7 @@ Also, a list:
 
     Object.const_set :RUBY_VERSION,        @RUBY_VERSION
     Object.const_set :RUBY_PATCHLEVEL,     @RUBY_PATCHLEVEL
-    Object.const_set :RUBY_REVISION,       @RUBY_REVISION if defined?(@RUBY_REVISION)
+    Object.const_set :RUBY_REVISION,       @RUBY_REVISION
     Object.const_set :RUBY_DESCRIPTION,    @RUBY_DESCRIPTION
     Object.const_set :RUBY_ENGINE,         @RUBY_ENGINE
     Object.const_set :RUBY_ENGINE_VERSION, @RUBY_ENGINE_VERSION if defined?(@RUBY_ENGINE_VERSION)
@@ -1125,7 +1125,7 @@ Also, a list:
   def util_clear_RUBY_VERSION
     Object.send :remove_const, :RUBY_VERSION
     Object.send :remove_const, :RUBY_PATCHLEVEL
-    Object.send :remove_const, :RUBY_REVISION       if defined?(RUBY_REVISION)
+    Object.send :remove_const, :RUBY_REVISION
     Object.send :remove_const, :RUBY_DESCRIPTION
     Object.send :remove_const, :RUBY_ENGINE
     Object.send :remove_const, :RUBY_ENGINE_VERSION if defined?(RUBY_ENGINE_VERSION)

--- a/test/rubygems/test_gem_request.rb
+++ b/test/rubygems/test_gem_request.rb
@@ -479,8 +479,7 @@ ERROR:  Certificate  is an invalid CA certificate
 
   def util_restore_version
     Object.send :remove_const, :RUBY_ENGINE
-    Object.send :const_set,    :RUBY_ENGINE, @orig_RUBY_ENGINE if
-      defined?(@orig_RUBY_ENGINE)
+    Object.send :const_set,    :RUBY_ENGINE, @orig_RUBY_ENGINE
 
     Object.send :remove_const, :RUBY_PATCHLEVEL
     Object.send :const_set,    :RUBY_PATCHLEVEL, @orig_RUBY_PATCHLEVEL

--- a/test/rubygems/test_gem_request.rb
+++ b/test/rubygems/test_gem_request.rb
@@ -328,7 +328,7 @@ class TestGemRequest < Gem::TestCase
 
     Object.send :remove_const, :RUBY_PATCHLEVEL
     Object.send :const_set,    :RUBY_PATCHLEVEL, -1
-    Object.send :remove_const, :RUBY_REVISION if defined?(RUBY_REVISION)
+    Object.send :remove_const, :RUBY_REVISION
     Object.send :const_set,    :RUBY_REVISION, 6
 
     ua = make_request(@uri, nil, nil, nil).user_agent
@@ -344,7 +344,7 @@ class TestGemRequest < Gem::TestCase
 
     Object.send :remove_const, :RUBY_PATCHLEVEL
     Object.send :const_set,    :RUBY_PATCHLEVEL, -1
-    Object.send :remove_const, :RUBY_REVISION if defined?(RUBY_REVISION)
+    Object.send :remove_const, :RUBY_REVISION
 
     ua = make_request(@uri, nil, nil, nil).user_agent
 
@@ -499,7 +499,7 @@ ERROR:  Certificate  is an invalid CA certificate
     Object.send :remove_const, :RUBY_PATCHLEVEL
     Object.send :const_set,    :RUBY_PATCHLEVEL, @orig_RUBY_PATCHLEVEL
 
-    Object.send :remove_const, :RUBY_REVISION if defined?(RUBY_REVISION)
+    Object.send :remove_const, :RUBY_REVISION
     Object.send :const_set,    :RUBY_REVISION, @orig_RUBY_REVISION if
       defined?(@orig_RUBY_REVISION)
   end
@@ -507,7 +507,7 @@ ERROR:  Certificate  is an invalid CA certificate
   def util_save_version
     @orig_RUBY_ENGINE     = RUBY_ENGINE
     @orig_RUBY_PATCHLEVEL = RUBY_PATCHLEVEL
-    @orig_RUBY_REVISION   = RUBY_REVISION if defined? RUBY_REVISION
+    @orig_RUBY_REVISION   = RUBY_REVISION
   end
 
   def util_stub_net_http(hash)

--- a/test/rubygems/test_gem_request.rb
+++ b/test/rubygems/test_gem_request.rb
@@ -339,20 +339,6 @@ class TestGemRequest < Gem::TestCase
     util_restore_version
   end
 
-  def test_user_agent_revision_missing
-    util_save_version
-
-    Object.send :remove_const, :RUBY_PATCHLEVEL
-    Object.send :const_set,    :RUBY_PATCHLEVEL, -1
-    Object.send :remove_const, :RUBY_REVISION
-
-    ua = make_request(@uri, nil, nil, nil).user_agent
-
-    assert_match %r{\(#{Regexp.escape RUBY_RELEASE_DATE}\)}, ua
-  ensure
-    util_restore_version
-  end
-
   def test_verify_certificate
     pend if Gem.java_platform?
 
@@ -500,8 +486,7 @@ ERROR:  Certificate  is an invalid CA certificate
     Object.send :const_set,    :RUBY_PATCHLEVEL, @orig_RUBY_PATCHLEVEL
 
     Object.send :remove_const, :RUBY_REVISION
-    Object.send :const_set,    :RUBY_REVISION, @orig_RUBY_REVISION if
-      defined?(@orig_RUBY_REVISION)
+    Object.send :const_set,    :RUBY_REVISION, @orig_RUBY_REVISION
   end
 
   def util_save_version


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This is similar with https://github.com/rubygems/rubygems/pull/6486. `RUBY_REVISION` is always provided in modern Ruby versions. We don't need to consider this constant condition in our code.

## What is your fix for the problem, implemented in this PR?

I removed `defined?(RUBY_REVISION)` from `lib/rubygems/request.rb`. And refactor this test code. We have some of needless `defined?` check globally.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
