### PR TITLE
Fix flaky when making materialized specs uniq

### DIFF
--- a/bundler/lib/bundler/endpoint_specification.rb
+++ b/bundler/lib/bundler/endpoint_specification.rb
@@ -26,10 +26,6 @@ module Bundler
       @platform
     end
 
-    def identifier
-      @__identifier ||= [name, version, platform.to_s]
-    end
-
     # needed for standalone, load required_paths from local gemspec
     # after the gem is installed
     def require_paths

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -20,7 +20,7 @@ module Bundler
     end
 
     def full_name
-      if platform == Gem::Platform::RUBY
+      @full_name ||= if platform == Gem::Platform::RUBY
         "#{@name}-#{@version}"
       else
         "#{@name}-#{@version}-#{platform}"
@@ -28,15 +28,15 @@ module Bundler
     end
 
     def ==(other)
-      identifier == other.identifier
+      full_name == other.full_name
     end
 
     def eql?(other)
-      identifier.eql?(other.identifier)
+      full_name.eql?(other.full_name)
     end
 
     def hash
-      identifier.hash
+      full_name.hash
     end
 
     ##
@@ -127,10 +127,6 @@ module Bundler
       else
         "#{name} (#{version}-#{platform})"
       end
-    end
-
-    def identifier
-      @__identifier ||= [name, version, platform.to_s]
     end
 
     def git_version

--- a/bundler/lib/bundler/lockfile_parser.rb
+++ b/bundler/lib/bundler/lockfile_parser.rb
@@ -86,7 +86,7 @@ module Bundler
           send("parse_#{@state}", line)
         end
       end
-      @specs = @specs.values.sort_by(&:identifier)
+      @specs = @specs.values.sort_by(&:full_name)
     rescue ArgumentError => e
       Bundler.ui.debug(e)
       raise LockfileError, "Your lockfile is unreadable. Run `rm #{Bundler.default_lockfile.relative_path_from(SharedHelpers.pwd)}` " \
@@ -199,7 +199,7 @@ module Bundler
         @current_spec.source = @current_source
         @current_source.add_dependency_names(name)
 
-        @specs[@current_spec.identifier] = @current_spec
+        @specs[@current_spec.full_name] = @current_spec
       elsif spaces.size == 6
         version = version.split(",").map(&:strip) if version
         dep = Gem::Dependency.new(name, version)

--- a/bundler/lib/bundler/remote_specification.rb
+++ b/bundler/lib/bundler/remote_specification.rb
@@ -29,12 +29,8 @@ module Bundler
       @platform = _remote_specification.platform
     end
 
-    def identifier
-      @__identifier ||= [name, version, @platform.to_s]
-    end
-
     def full_name
-      if @platform == Gem::Platform::RUBY
+      @full_name ||= if @platform == Gem::Platform::RUBY
         "#{@name}-#{@version}"
       else
         "#{@name}-#{@version}-#{@platform}"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes we'll have an heterogenous array of specs which include `Gem::Specification` objects, which don't define `#identifier`.

This was introduced by #6475 (not yet released), it's causing some flakies and I believe it may also hit end users, so let's fix it.

[Error](https://github.com/rubygems/rubygems/actions/runs/4446839312/jobs/7807646983) is below:

```
       Invoking `C:/hostedtoolcache/windows/Ruby/3.2.1/x64/bin/ruby.exe -ID:/a/rubygems/rubygems/bundler/spec -rD:/a/rubygems/rubygems/bundler/spec/support/artifice/fail.rb -rD:/a/rubygems/rubygems/bundler/spec/support/hax.rb D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/bin/bundle install` failed with output:
       ----------------------------------------------------------------------
       --- ERROR REPORT TEMPLATE -------------------------------------------------------

       ```
       NoMethodError: undefined method `identifier' for #<Gem::Specification:0x000001ee4f65d210 @extension_dir=nil, @full_gem_path=nil, @gem_dir=nil, @ignored=nil, @bin_dir=nil, @cache_dir=nil, @cache_file=nil, @doc_dir=nil, @ri_dir=nil, @spec_dir=nil, @spec_file=nil, @gems_dir=nil, @base_dir=nil, @loaded=false, @activated=false, @loaded_from="D:/a/rubygems/rubygems/bundler/tmp/2/bundled_app/foo.gemspec", @original_platform=nil, @installed_by_version=#<Gem::Version "3.5.0.dev">, @autorequire=nil, @date=2023-03-17 00:00:00 UTC, @description="This is a completely fake gem, for testing purposes.", @email="foo@bar.baz", @homepage="http://example.com", @name="foo", @post_install_message=nil, @signing_key=nil, @summary="This is just a fake gem for testing", @version=#<Gem::Version "1.0">, @authors=["no one"], @bindir="bin", @cert_chain=[], @dependencies=[<Gem::Dependency type=:development name="platform_specific" requirements=">= 0">], @executables=[], @extensions=[], @extra_rdoc_files=[], @files=["foo.gemspec", "lib/foo.rb", "lib/foo/source.rb"], @licenses=["MIT"], @metadata={}, @platform="ruby", @rdoc_options=[], @require_paths=["lib"], @required_ruby_version=#<Gem::Requirement:0x000001ee52175fd8 @requirements=[[">=", #<Gem::Version "0">]]>, @required_rubygems_version=#<Gem::Requirement:0x000001ee52175dd0 @requirements=[[">=", #<Gem::Version "0">]]>, @requirements=[], @rubygems_version="3.5.0.dev", @specification_version=4, @test_files=[], @new_platform="ruby", @full_name="foo-1.0", @source=#<Bundler::Source::Gemspec:0x1460 source at `.`> foo-1.0>
         D:/a/rubygems/rubygems/lib/rubygems/specification.rb:2175:in `method_missing'
         D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/gems/bundler-2.5.0.dev/lib/bundler/lazy_specification.rb:35:in `eql?'
         D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/gems/bundler-2.5.0.dev/lib/bundler/spec_set.rb:52:in `uniq'
         D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/gems/bundler-2.5.0.dev/lib/bundler/spec_set.rb:52:in `for'
         D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/gems/bundler-2.5.0.dev/lib/bundler/spec_set.rb:85:in `materialize'
         D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/gems/bundler-2.5.0.dev/lib/bundler/definition.rb:209:in `missing_specs'
         D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/gems/bundler-2.5.0.dev/lib/bundler/definition.rb:213:in `missing_specs?'
         D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/gems/bundler-2.5.0.dev/lib/bundler/installer.rb:255:in `resolve_if_needed'
         D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/gems/bundler-2.5.0.dev/lib/bundler/installer.rb:82:in `block in run'
         D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/gems/bundler-2.5.0.dev/lib/bundler/process_lock.rb:12:in `block in lock'
         D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/gems/bundler-2.5.0.dev/lib/bundler/process_lock.rb:9:in `open'
         D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/gems/bundler-2.5.0.dev/lib/bundler/process_lock.rb:9:in `lock'
         D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/gems/bundler-2.5.0.dev/lib/bundler/installer.rb:71:in `run'
         D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/gems/bundler-2.5.0.dev/lib/bundler/installer.rb:23:in `install'
         D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/gems/bundler-2.5.0.dev/lib/bundler/cli/install.rb:62:in `run'
         D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/gems/bundler-2.5.0.dev/lib/bundler/cli.rb:261:in `block in install'
         D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/gems/bundler-2.5.0.dev/lib/bundler/settings.rb:131:in `temporary'
         D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/gems/bundler-2.5.0.dev/lib/bundler/cli.rb:260:in `install'
         D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/gems/bundler-2.5.0.dev/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
         D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/gems/bundler-2.5.0.dev/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
         D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/gems/bundler-2.5.0.dev/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
         D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/gems/bundler-2.5.0.dev/lib/bundler/cli.rb:34:in `dispatch'
         D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/gems/bundler-2.5.0.dev/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
         D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/gems/bundler-2.5.0.dev/lib/bundler/cli.rb:28:in `start'
         D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/gems/bundler-2.5.0.dev/exe/bundle:45:in `block in <top (required)>'
         D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/gems/bundler-2.5.0.dev/lib/bundler/friendly_errors.rb:117:in `with_friendly_errors'
         D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/gems/bundler-2.5.0.dev/exe/bundle:33:in `<top (required)>'
         D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/bin/bundle:32:in `load'
         D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/bin/bundle:32:in `<main>'

       ```

       ## Environment

       ```
       Bundler       2.5.0.dev
         Platforms   ruby, x64-mingw-ucrt
       Ruby          3.2.1p31 (2023-02-08 revision 31819e82c88c6f8ecfaeb162519bfa26a14b21fd) [x64-mingw-ucrt]
         Full Path   C:/hostedtoolcache/windows/Ruby/3.2.1/x64/bin/ruby.exe
         Config Dir  C:/ProgramData
       RubyGems      3.5.0.dev
         Gem Home    D:/a/rubygems/rubygems/bundler/tmp/2/gems/system
         Gem Path    D:/a/rubygems/rubygems/bundler/tmp/2/gems/system
         User Home   D:/a/rubygems/rubygems/bundler/tmp/2/home
         User Path   D:/a/rubygems/rubygems/bundler/tmp/2/home/.local/share/gem/ruby/3.2.0
         Bin Dir     D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/bin
       OpenSSL       
         Compiled    OpenSSL 3.0.8 7 Feb 2023
         Loaded      OpenSSL 3.0.8 7 Feb 2023
         Cert File   C:/hostedtoolcache/windows/Ruby/3.2.1/x64/etc/ssl/cert.pem
         Cert Dir    C:/hostedtoolcache/windows/Ruby/3.2.1/x64/etc/ssl/certs
       Tools         
         Git         2.40.0.windows.1
         RVM         not installed
         rbenv       not installed
         chruby      not installed
       ```

       ## Bundler Build Metadata

       ```
       Built At          2023-03-17
       Git SHA           eddabd1
       Released Version  true
       ```

       ## Bundler settings

       ```
       force_ruby_platform
         Set for your local app (D:/a/rubygems/rubygems/bundler/tmp/2/bundled_app/.bundle/config): true
       ```

       ## Gemfile

       ### Gemfile

       ```ruby
       source "file:///D:/a/rubygems/rubygems/bundler/tmp/2/gems/remote2"
       gemspec
       ```

       ### Gemfile.lock

       ```
       PATH
         remote: .
         specs:
           foo (1.0)

       GEM
         remote: file:///D:/a/rubygems/rubygems/bundler/tmp/2/gems/remote2/
         specs:
           platform_specific (1.0)
           platform_specific (1.0-java)
           platform_specific (1.0-x64-mingw-ucrt)
           platform_specific (1.0-x64-mingw32)

       PLATFORMS
         java
         ruby
         x64-mingw-ucrt
         x64-mingw32

       DEPENDENCIES
         foo!
         platform_specific

       BUNDLED WITH
          2.5.0.dev
       ```

       ## Gemspecs

       ### foo.gemspec

       ```ruby
       # -*- encoding: utf-8 -*-
       # stub: foo 1.0 ruby lib

       Gem::Specification.new do |s|
         s.name = "foo".freeze
         s.version = "1.0"

         s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
         s.require_paths = ["lib".freeze]
         s.authors = ["no one".freeze]
         s.date = "2023-03-17"
         s.description = "This is a completely fake gem, for testing purposes.".freeze
         s.email = "foo@bar.baz".freeze
         s.files = ["foo.gemspec".freeze, "lib/foo.rb".freeze, "lib/foo/source.rb".freeze]
         s.homepage = "http://example.com".freeze
         s.licenses = ["MIT".freeze]
         s.rubygems_version = "3.5.0.dev".freeze
         s.summary = "This is just a fake gem for testing".freeze

         s.specification_version = 4

         s.add_development_dependency(%q<platform_specific>.freeze, [">= 0"])
       end
       ```

       --- TEMPLATE END ----------------------------------------------------------------

       Unfortunately, an unexpected error occurred, and Bundler cannot continue.

       First, try this link to see if there are any existing issue reports for this error:
       https://github.com/rubygems/rubygems/search?q=undefined+method+%60identifier%27+for+%23%3CGem++Specification+0x000001ee4f65d210+%40extension_dir%3Dnil%2C+%40full_gem_path%3Dnil%2C+%40gem_dir%3Dnil%2C+%40ignored%3Dnil%2C+%40bin_dir%3Dnil%2C+%40cache_dir%3Dnil%2C+%40cache_file%3Dnil%2C+%40doc_dir%3Dnil%2C+%40ri_dir%3Dnil%2C+%40spec_dir%3Dnil%2C+%40spec_file%3Dnil%2C+%40gems_dir%3Dnil%2C+%40base_dir%3Dnil%2C+%40loaded%3Dfalse%2C+%40activated%3Dfalse%2C+%40loaded_from%3D%22D+%2Fa%2Frubygems%2Frubygems%2Fbundler%2Ftmp%2F2%2Fbundled_app%2Ffoo.gemspec%22%2C+%40original_platform%3Dnil%2C+%40installed_by_version%3D%23%3CGem++Version+%223.5.0.dev%22%3E%2C+%40autorequire%3Dnil%2C+%40date%3D2023-03-17+00+00+00+UTC%2C+%40description%3D%22This+is+a+completely+fake+gem%2C+for+testing+purposes.%22%2C+%40email%3D%22foo%40bar.baz%22%2C+%40homepage%3D%22http+%2F%2Fexample.com%22%2C+%40name%3D%22foo%22%2C+%40post_install_message%3Dnil%2C+%40signing_key%3Dnil%2C+%40summary%3D%22This+is+just+a+fake+gem+for+testing%22%2C+%40version%3D%23%3CGem++Version+%221.0%22%3E%2C+%40authors%3D%5B%22no+one%22%5D%2C+%40bindir%3D%22bin%22%2C+%40cert_chain%3D%5B%5D%2C+%40dependencies%3D%5B%3CGem++Dependency+type%3D+development+name%3D%22platform_specific%22+requirements%3D%22%3E%3D+0%22%3E%5D%2C+%40executables%3D%5B%5D%2C+%40extensions%3D%5B%5D%2C+%40extra_rdoc_files%3D%5B%5D%2C+%40files%3D%5B%22foo.gemspec%22%2C+%22lib%2Ffoo.rb%22%2C+%22lib%2Ffoo%2Fsource.rb%22%5D%2C+%40licenses%3D%5B%22MIT%22%5D%2C+%40metadata%3D%7B%7D%2C+%40platform%3D%22ruby%22%2C+%40rdoc_options%3D%5B%5D%2C+%40require_paths%3D%5B%22lib%22%5D%2C+%40required_ruby_version%3D%23%3CGem++Requirement+0x000001ee52175fd8+%40requirements%3D%5B%5B%22%3E%3D%22%2C+%23%3CGem++Version+%220%22%3E%5D%5D%3E%2C+%40required_rubygems_version%3D%23%3CGem++Requirement+0x000001ee52175dd0+%40requirements%3D%5B%5B%22%3E%3D%22%2C+%23%3CGem++Version+%220%22%3E%5D%5D%3E%2C+%40requirements%3D%5B%5D%2C+%40rubygems_version%3D%223.5.0.dev%22%2C+%40specification_version%3D4%2C+%40test_files%3D%5B%5D%2C+%40new_platform%3D%22ruby%22%2C+%40full_name%3D%22foo-1.0%22%2C+%40source%3D%23%3CBundler++Source++Gemspec+0x1460+source+at+%60.%60%3E+foo-1.0%3E&type=Issues

       If there aren't any reports for this error yet, please fill in the new issue form located at https://github.com/rubygems/rubygems/issues/new?labels=Bundler&template=bundler-related-issue.md, and copy and paste the report template above in there.
       ----------------------------------------------------------------------
     # ./spec/support/helpers.rb:202:in `sys_exec'
     # ./spec/support/helpers.rb:121:in `bundle'
     # ./spec/install/gemfile/gemspec_spec.rb:445:in `block (5 levels) in <top (required)>'
     # ./spec/spec_helper.rb:102:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:102:in `block (3 levels) in <top (required)>'
     # ./spec/support/helpers.rb:345:in `block in with_gem_path_as'
     # ./spec/support/helpers.rb:359:in `without_env_side_effects'
     # ./spec/support/helpers.rb:340:in `with_gem_path_as'
     # ./spec/spec_helper.rb:101:in `block (2 levels) in <top (required)>'
     # ./spec/support/rubygems_ext.rb:103:in `load'
     # ./spec/support/rubygems_ext.rb:103:in `gem_load_and_activate'
     # ./spec/support/rubygems_ext.rb:18:in `gem_load'

Finished in 93 minutes 6 seconds (files took 0 seconds to load)
3018 examples, 1 failure, 118 pending

Failed examples:

rspec ./spec/install/gemfile/gemspec_spec.rb:482 # [TEST_ENV_NUMBER=2] bundle install from an existing gemspec with a lockfile and some missing dependencies bundled for multiple platforms on ruby as a development dependency keeps all platform dependencies in the lockfile

```

## What is your fix for the problem, implemented in this PR?

Let's use `#full_name` consistently.

I also removed the `#identifier` methods just to see if something breaks, but I should probably restore them for backwards compatibility.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
