### PR TITLE
Remove reference to `pry` gem from generated `bin/console` file

### DIFF
--- a/bundler/lib/bundler/templates/newgem/bin/console.tt
+++ b/bundler/lib/bundler/templates/newgem/bin/console.tt
@@ -7,9 +7,5 @@ require "<%= config[:namespaced_path] %>"
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
 
-# (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
-
 require "irb"
 IRB.start(__FILE__)


### PR DESCRIPTION
This is just a suggestion, but since recent versions of Ruby have shipped with a `binding.irb` that provides almost all of the features that `pry` pioneered, it may be time to remove this suggestion in the name of simplicity and not confusing newer developers who aren't familiar with what to use.