### PR TITLE
Changelogs for RubyGems 3.4.9 and Bundler 2.4.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+# 3.4.9 / 2023-03-20
+
+## Enhancements:
+
+* Improve `TarHeader#calculate_checksum` speed and readability. Pull
+  request [#6476](https://github.com/rubygems/rubygems/pull/6476) by
+  Maumagnaguagno
+* Added only missing extensions option into pristine command. Pull request
+  [#6446](https://github.com/rubygems/rubygems/pull/6446) by hsbt
+* Installs bundler 2.4.9 as a default gem.
+
+## Bug fixes:
+
+* Fix `$LOAD_PATH` in rake and ext_conf builder. Pull request
+  [#6490](https://github.com/rubygems/rubygems/pull/6490) by ntkme
+* Fix `gem uninstall` with `--install-dir`. Pull request
+  [#6481](https://github.com/rubygems/rubygems/pull/6481) by
+  deivid-rodriguez
+
+## Documentation:
+
+* Document our current release policy. Pull request
+  [#6450](https://github.com/rubygems/rubygems/pull/6450) by
+  deivid-rodriguez
+
 # 3.4.8 / 2023-03-08
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,28 @@
+# 2.4.9 (March 20, 2023)
+
+## Security:
+
+  - Don't recommend `--full-index` on errors [#6493](https://github.com/rubygems/rubygems/pull/6493)
+
+## Enhancements:
+
+  - Fix duplicated specs in some error messages [#6475](https://github.com/rubygems/rubygems/pull/6475)
+  - When running `bundle lock --update <name>`, checkout locked revision of unrelated git sources directly [#6459](https://github.com/rubygems/rubygems/pull/6459)
+  - Avoid expiring git sources when unnecessary [#6458](https://github.com/rubygems/rubygems/pull/6458)
+  - Use `RbSys::ExtensionTask` when creating new rust gems [#6352](https://github.com/rubygems/rubygems/pull/6352)
+  - Don't ignore pre-releases when there's only one candidate [#6441](https://github.com/rubygems/rubygems/pull/6441)
+
+## Bug fixes:
+
+  - Fix incorrect removal of ruby platform when auto-healing corrupted lockfiles [#6495](https://github.com/rubygems/rubygems/pull/6495)
+  - Don't consider platform specific candidates when `force_ruby_platform` set [#6442](https://github.com/rubygems/rubygems/pull/6442)
+  - Better deal with circular dependencies [#6330](https://github.com/rubygems/rubygems/pull/6330)
+
+## Documentation:
+
+  - Add debugging docs [#6387](https://github.com/rubygems/rubygems/pull/6387)
+  - Document our current release policy [#6450](https://github.com/rubygems/rubygems/pull/6450)
+
 # 2.4.8 (March 8, 2023)
 
 ## Security:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.4.9 and Bundler 2.4.9 into master.