### PR TITLE
Use indented heredoc

### DIFF
--- a/bundler/lib/bundler/cli/issue.rb
+++ b/bundler/lib/bundler/cli/issue.rb
@@ -5,7 +5,7 @@ require "rbconfig"
 module Bundler
   class CLI::Issue
     def run
-      Bundler.ui.info <<-EOS.gsub(/^ {8}/, "")
+      Bundler.ui.info <<~EOS
         Did you find an issue with Bundler? Before filing a new issue,
         be sure to check out these resources:
 

--- a/bundler/lib/bundler/cli/show.rb
+++ b/bundler/lib/bundler/cli/show.rb
@@ -40,8 +40,8 @@ module Bundler
           desc = "  * #{s.name} (#{s.version}#{s.git_version})"
           if @verbose
             latest = latest_specs.find {|l| l.name == s.name }
-            Bundler.ui.info <<-END.gsub(/^ +/, "")
-              #{desc}
+            Bundler.ui.info <<~END
+              #{desc.lstrip}
               \tSummary:  #{s.summary || "No description available."}
               \tHomepage: #{s.homepage || "No website available."}
               \tStatus:   #{outdated?(s, latest) ? "Outdated - #{s.version} < #{latest.version}" : "Up to date"}

--- a/bundler/lib/bundler/friendly_errors.rb
+++ b/bundler/lib/bundler/friendly_errors.rb
@@ -61,7 +61,7 @@ module Bundler
     end
 
     def request_issue_report_for(e)
-      Bundler.ui.error <<-EOS.gsub(/^ {8}/, ""), nil, nil
+      Bundler.ui.error <<~EOS, nil, nil
         --- ERROR REPORT TEMPLATE -------------------------------------------------------
 
         ```
@@ -75,7 +75,7 @@ module Bundler
 
       Bundler.ui.error "Unfortunately, an unexpected error occurred, and Bundler cannot continue."
 
-      Bundler.ui.error <<-EOS.gsub(/^ {8}/, ""), nil, :yellow
+      Bundler.ui.error <<~EOS, nil, :yellow
 
         First, try this link to see if there are any existing issue reports for this error:
         #{issues_url(e)}
@@ -93,7 +93,7 @@ module Bundler
     end
 
     def serialized_exception_for(e)
-      <<-EOS.gsub(/^ {8}/, "")
+      <<~EOS
         #{e.class}: #{e.message}
           #{e.backtrace&.join("\n          ")&.chomp}
       EOS

--- a/bundler/spec/bundler/bundler_spec.rb
+++ b/bundler/spec/bundler/bundler_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Bundler do
         $VERBOSE = verbose
 
         File.open(app_gemspec_path, "wb") do |file|
-          file.puts <<-GEMSPEC.gsub(/^\s+/, "")
+          file.puts <<~GEMSPEC
             # -*- encoding: utf-8 -*-
             Gem::Specification.new do |gem|
               gem.author = "André the Giant"

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -697,7 +697,7 @@ RSpec.describe "bundle exec" do
   context "`load`ing a ruby file instead of `exec`ing" do
     let(:path) { bundled_app("ruby_executable") }
     let(:shebang) { "#!/usr/bin/env ruby" }
-    let(:executable) { <<-RUBY.gsub(/^ */, "").strip }
+    let(:executable) { <<~RUBY.strip }
       #{shebang}
 
       require "rack"

--- a/bundler/spec/install/bundler_spec.rb
+++ b/bundler/spec/install/bundler_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "bundle install" do
         gem "bundler", "0.9.1"
       G
 
-      nice_error = <<-E.strip.gsub(/^ {8}/, "")
+      nice_error = <<~E.strip
         Could not find compatible versions
 
         Because the current Bundler version (#{Bundler::VERSION}) does not satisfy bundler = 0.9.1
@@ -56,7 +56,7 @@ RSpec.describe "bundle install" do
         gem "bundler", "~> 0.8"
       G
 
-      nice_error = <<-E.strip.gsub(/^ {8}/, "")
+      nice_error = <<~E.strip
         Could not find compatible versions
 
         Because rails >= 3.0 depends on bundler >= 0.9.0.pre
@@ -79,7 +79,7 @@ RSpec.describe "bundle install" do
         gem "bundler", "0.9.2"
       G
 
-      nice_error = <<-E.strip.gsub(/^ {8}/, "")
+      nice_error = <<~E.strip
         Could not find compatible versions
 
         Because the current Bundler version (#{Bundler::VERSION}) does not satisfy bundler = 0.9.2
@@ -149,7 +149,7 @@ RSpec.describe "bundle install" do
         gem "rails_pinned_to_old_activesupport"
       G
 
-      nice_error = <<-E.strip.gsub(/^ {8}/, "")
+      nice_error = <<~E.strip
         Could not find compatible versions
 
         Because every version of rails_pinned_to_old_activesupport depends on activesupport = 1.2.3
@@ -177,7 +177,7 @@ RSpec.describe "bundle install" do
         gem "activesupport", "2.3.5"
       G
 
-      nice_error = <<-E.strip.gsub(/^ {8}/, "")
+      nice_error = <<~E.strip
         Could not find compatible versions
 
         Because every version of rails_pinned_to_old_activesupport depends on activesupport = 1.2.3

--- a/bundler/spec/install/gems/flex_spec.rb
+++ b/bundler/spec/install/gems/flex_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe "bundle flex_install" do
     it "discards the locked gems when the Gemfile requires different versions than the lock" do
       bundle "config set force_ruby_platform true"
 
-      nice_error = <<-E.strip.gsub(/^ {8}/, "")
+      nice_error = <<~E.strip
         Could not find compatible versions
 
         Because rack-obama >= 2.0 depends on rack = 1.2
@@ -210,7 +210,7 @@ RSpec.describe "bundle flex_install" do
     it "does not include conflicts with a single requirement tree, because that can't possibly be a conflict" do
       bundle "config set force_ruby_platform true"
 
-      bad_error = <<-E.strip.gsub(/^ {8}/, "")
+      bad_error = <<~E.strip
         Bundler could not find compatible versions for gem "rack-obama":
           In Gemfile:
             rack-obama (= 2.0)

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -635,7 +635,7 @@ module Spec
       end
     end
 
-    TEST_CERT = <<-CERT.gsub(/^\s*/, "")
+    TEST_CERT = <<~CERT
       -----BEGIN CERTIFICATE-----
       MIIDMjCCAhqgAwIBAgIBATANBgkqhkiG9w0BAQUFADAnMQwwCgYDVQQDDAN5b3Ux
       FzAVBgoJkiaJk/IsZAEZFgdleGFtcGxlMB4XDTE1MDIwODAwMTIyM1oXDTQyMDYy
@@ -658,7 +658,7 @@ module Spec
       -----END CERTIFICATE-----
     CERT
 
-    TEST_PKEY = <<-PKEY.gsub(/^\s*/, "")
+    TEST_PKEY = <<~PKEY
       -----BEGIN RSA PRIVATE KEY-----
       MIIEowIBAAKCAQEA2W8V2k3jdzgMxL0mjTqbRruTdtDcdZDXKtiFkyLvsXUXvc2k
       GSdgcjMOS1CkafqGz/hAUlPibjM0QEXjtQuMdTmdMrmuORLeeIZhSO+HdkTNV6j3

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -367,7 +367,7 @@ class TestGem < Gem::TestCase
     install_specs bundler_latest, bundler_previous
 
     File.open("Gemfile.lock", "w") do |f|
-      f.write <<-L.gsub(/ {8}/, "")
+      f.write <<~L
         GEM
           remote: https://rubygems.org/
           specs:
@@ -401,7 +401,7 @@ class TestGem < Gem::TestCase
     install_specs bundler_latest, bundler_previous
 
     File.open("Gemfile.lock", "w") do |f|
-      f.write <<-L.gsub(/ {8}/, "")
+      f.write <<~L
         GEM
           remote: https://rubygems.org/
           specs:
@@ -425,7 +425,7 @@ class TestGem < Gem::TestCase
 
   def test_activate_bin_path_gives_proper_error_for_bundler_when_underscore_selection_given
     File.open("Gemfile.lock", "w") do |f|
-      f.write <<-L.gsub(/ {8}/, "")
+      f.write <<~L
         GEM
           remote: https://rubygems.org/
           specs:


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Indented here document is introduced at ruby 2.3, and rubygems now supports ruby 2.6 or later only.

## What is your fix for the problem, implemented in this PR?

Replace `<<-EOS.gsub(/^ {8}/, "")` and so on with `<<~EOS` etc.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
