### PR TITLE
remove test skips/pends on mswin platform

### DIFF
--- a/test/rubygems/test_gem_commands_exec_command.rb
+++ b/test/rubygems/test_gem_commands_exec_command.rb
@@ -216,7 +216,7 @@ class TestGemCommandsExecCommand < Gem::TestCase
 
   def test_gem_with_platform_and_platform_dependencies
     pend "extensions don't quite work on jruby" if Gem.java_platform?
-    pend "terminates on mswin" if Gem.win_platform? && ruby_repo?
+    pend "terminates on mswin" if vc_windows? && ruby_repo?
 
     spec_fetcher do |fetcher|
       fetcher.download "a", 2 do |s|

--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -105,7 +105,7 @@ install:
   end
 
   def test_build_extensions
-    pend if RUBY_PLATFORM.include?("mswin") && ENV.key?("GITHUB_ACTIONS") # not working from the beginning
+    pend "terminates on mswin" if vc_windows? && ruby_repo?
     @spec.extensions << "ext/extconf.rb"
 
     ext_dir = File.join @spec.gem_dir, "ext"
@@ -141,7 +141,7 @@ install:
   end
 
   def test_build_extensions_with_gemhome_with_space
-    pend if RUBY_PLATFORM.include?("mswin") && ENV.key?("GITHUB_ACTIONS") # not working from the beginning
+    pend "terminates on mswin" if vc_windows? && ruby_repo?
     new_gemhome = File.join @tempdir, "gem home"
     File.rename(@gemhome, new_gemhome)
     @gemhome = new_gemhome
@@ -162,7 +162,7 @@ install:
         false
       end
     end
-    pend if RUBY_PLATFORM.include?("mswin") && ENV.key?("GITHUB_ACTIONS") # not working from the beginning
+    pend "terminates on mswin" if vc_windows? && ruby_repo?
 
     @spec.extensions << "ext/extconf.rb"
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1496,7 +1496,7 @@ gem 'other', version
 
   def test_install_extension_and_script
     pend "Makefile creation crashes on jruby" if Gem.java_platform?
-    pend if RUBY_PLATFORM.include?("mswin") && ENV.key?("GITHUB_ACTIONS") # not working from the beginning
+    pend "terminates on mswin" if vc_windows? && ruby_repo?
 
     @spec = setup_base_spec
     @spec.extensions << "extconf.rb"

--- a/test/rubygems/test_gem_resolver_git_specification.rb
+++ b/test/rubygems/test_gem_resolver_git_specification.rb
@@ -65,7 +65,7 @@ class TestGemResolverGitSpecification < Gem::TestCase
 
   def test_install_extension
     pend if Gem.java_platform?
-    pend if RUBY_PLATFORM.include?("mswin") && ENV.key?("GITHUB_ACTIONS") # not working from the beginning
+    pend "terminates on mswin" if vc_windows? && ruby_repo?
     name, _, repository, = git_gem "a", 1 do |s|
       s.extensions << "ext/extconf.rb"
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Three tests in `test/test_gem_ext_builder.rb` are currently skipped on the mswin platform.  A long time ago, Actions did not enable the msvc build tools with mswin builds.  setup-ruby now does this, and ruby/ruby's mswin CI does something similar.

## What is your fix for the problem, implemented in this PR?

remove the `pend if` lines.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] **Enable** [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
