### PR TITLE
Fix incorrect ruby platform removal from lockfile when adding Gemfile dependencies

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -726,6 +726,8 @@ module Bundler
           dep.source = sources.get(dep.source)
         end
 
+        next if unlocking?
+
         unless locked_dep = @locked_deps[dep.name]
           changes = true
           next
@@ -898,6 +900,7 @@ module Bundler
                 Bundler.local_platform == Gem::Platform::RUBY ||
                 !platforms.include?(Gem::Platform::RUBY) ||
                 (@new_platform && platforms.last == Gem::Platform::RUBY) ||
+                @dependency_changes ||
                 !@originally_locked_specs.incomplete_ruby_specs?(dependencies)
 
       remove_platform(Gem::Platform::RUBY)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When adding a new Gemfile dependencies, we're incorrectly replacing the RUBY platform with the locked platform in the lockfile.

## What is your fix for the problem, implemented in this PR?

Skip the removal of the RUBY platform when dependencies have changed.

Fixes #6536.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
