### PR TITLE
Generate native gems with `-fvisibility=hidden`

### DIFF
--- a/bundler/lib/bundler/templates/newgem/ext/newgem/extconf-c.rb.tt
+++ b/bundler/lib/bundler/templates/newgem/ext/newgem/extconf-c.rb.tt
@@ -2,4 +2,9 @@
 
 require "mkmf"
 
+# Makes all symbols private by default to avoid unintended conflict
+# with other gems. To explicitly export symbols you can use RUBY_FUNC_EXPORTED
+# selectively, or entirely remove this flag.
+$CFLAGS << " -fvisibility=hidden "
+
 create_makefile(<%= config[:makefile_path].inspect %>)

--- a/bundler/lib/bundler/templates/newgem/ext/newgem/newgem.c.tt
+++ b/bundler/lib/bundler/templates/newgem/ext/newgem/newgem.c.tt
@@ -2,7 +2,7 @@
 
 VALUE rb_m<%= config[:constant_array].join %>;
 
-void
+RUBY_FUNC_EXPORTED void
 Init_<%= config[:underscored_name] %>(void)
 {
   rb_m<%= config[:constant_array].join %> = rb_define_module(<%= config[:constant_name].inspect %>);

--- a/bundler/lib/bundler/templates/newgem/rubocop.yml.tt
+++ b/bundler/lib/bundler/templates/newgem/rubocop.yml.tt
@@ -9,5 +9,9 @@ Style/StringLiteralsInInterpolation:
   Enabled: true
   EnforcedStyle: double_quotes
 
+Style/GlobalVars:
+  Exclude:
+    - ext/**/extconf.rb
+
 Layout/LineLength:
   Max: 120


### PR DESCRIPTION
I recently ran into very nasty issues with dynamic symbols clashing between two native gems.

I believe the overwhelming majority of native gems don't want to export their symbols, so hiding them by default would make sense to me.
