### PR TITLE
Fix installing plugins in frozen mode

### DIFF
--- a/bundler/lib/bundler/plugin/installer.rb
+++ b/bundler/lib/bundler/plugin/installer.rb
@@ -83,8 +83,11 @@ module Bundler
 
         Bundler.configure_gem_home_and_path(Plugin.root)
 
-        definition = Definition.new(nil, deps, source_list, true)
-        install_definition(definition)
+        Bundler.settings.temporary(:deployment => false, :frozen => false) do
+          definition = Definition.new(nil, deps, source_list, true)
+
+          install_definition(definition)
+        end
       end
 
       # Installs the plugins and deps from the provided specs and returns map of

--- a/bundler/spec/plugins/install_spec.rb
+++ b/bundler/spec/plugins/install_spec.rb
@@ -22,6 +22,13 @@ RSpec.describe "bundler plugin install" do
     plugin_should_be_installed("foo")
   end
 
+  it "installs from rubygems source in frozen mode" do
+    bundle "plugin install foo --source #{file_uri_for(gem_repo2)}", :env => { "BUNDLE_DEPLOYMENT" => "true" }
+
+    expect(out).to include("Installed plugin foo")
+    plugin_should_be_installed("foo")
+  end
+
   it "installs from sources configured as Gem.sources without any flags" do
     bundle "plugin install foo", :env => { "BUNDLER_SPEC_GEM_SOURCES" => file_uri_for(gem_repo2).to_s }
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If `frozen` or `deployment` are configured, installing plugins fail.

## What is your fix for the problem, implemented in this PR?

Plugins don't use a lockfile, so ignore frozen related settings.

Fixes #6534.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
