### PR TITLE
Onboard Rubocop Naming/MemoizedInstanceVariableName rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -434,6 +434,9 @@ Naming/FileName:
   Exclude:
     - 'bundler/spec/realworld/fixtures/warbler/bin/warbler-example.rb'
 
+Naming/MemoizedInstanceVariableName:
+  Enabled: true
+
 Performance/TimesMap:
   Enabled: true
 

--- a/.rubocop_bundler.yml
+++ b/.rubocop_bundler.yml
@@ -22,6 +22,9 @@ AllCops:
 Naming/ConstantName:
   Enabled: true
 
+Naming/MemoizedInstanceVariableName:
+  Enabled: false
+
 Naming/MethodName:
   Enabled: true
 

--- a/.rubocop_bundler.yml
+++ b/.rubocop_bundler.yml
@@ -22,9 +22,6 @@ AllCops:
 Naming/ConstantName:
   Enabled: true
 
-Naming/MemoizedInstanceVariableName:
-  Enabled: false
-
 Naming/MethodName:
   Enabled: true
 

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -89,7 +89,7 @@ module Bundler
 
   class << self
     def configure
-      @configured ||= configure_gem_home_and_path
+      @configure ||= configure_gem_home_and_path
     end
 
     def ui
@@ -581,7 +581,7 @@ EOF
       @bin_path = nil
       @bundler_major_version = nil
       @bundle_path = nil
-      @configured = nil
+      @configure = nil
       @configured_bundle_path = nil
       @definition = nil
       @load = nil

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -122,7 +122,7 @@ module Bundler
     end
 
     def to_s
-      @__to_s ||= if platform == Gem::Platform::RUBY
+      @to_s ||= if platform == Gem::Platform::RUBY
         "#{name} (#{version})"
       else
         "#{name} (#{version}-#{platform})"

--- a/bundler/lib/bundler/ruby_version.rb
+++ b/bundler/lib/bundler/ruby_version.rb
@@ -107,7 +107,7 @@ module Bundler
       ruby_engine_version = RUBY_ENGINE == "ruby" ? ruby_version : RUBY_ENGINE_VERSION.dup
       patchlevel = RUBY_PATCHLEVEL.to_s
 
-      @ruby_version ||= RubyVersion.new(ruby_version, patchlevel, ruby_engine, ruby_engine_version)
+      @system ||= RubyVersion.new(ruby_version, patchlevel, ruby_engine, ruby_engine_version)
     end
 
     private

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -66,7 +66,9 @@ module Gem
 
     alias_method :rg_extension_dir, :extension_dir
     def extension_dir
-      @bundler_extension_dir ||= if source.respond_to?(:extension_dir_name)
+      # following instance variable is already used in original method
+      # and that is the reason to prefix it with bundler_ and add rubocop exception
+      @bundler_extension_dir ||= if source.respond_to?(:extension_dir_name) # rubocop:disable Naming/MemoizedInstanceVariableName
         unique_extension_dir = [source.extension_dir_name, File.basename(full_gem_path)].uniq.join("-")
         File.expand_path(File.join(extensions_dir, unique_extension_dir))
       else
@@ -221,9 +223,9 @@ module Gem
         protected
 
         def _requirements_sorted?
-          return @_are_requirements_sorted if defined?(@_are_requirements_sorted)
+          return @_requirements_sorted if defined?(@_requirements_sorted)
           strings = as_list
-          @_are_requirements_sorted = strings == strings.sort
+          @_requirements_sorted = strings == strings.sort
         end
 
         def _with_sorted_requirements

--- a/bundler/spec/bundler/ruby_version_spec.rb
+++ b/bundler/spec/bundler/ruby_version_spec.rb
@@ -400,19 +400,19 @@ RSpec.describe "Bundler::RubyVersion and its subclasses" do
       let(:bundler_system_ruby_version) { subject }
 
       around do |example|
-        if Bundler::RubyVersion.instance_variable_defined?("@ruby_version")
+        if Bundler::RubyVersion.instance_variable_defined?("@system")
           begin
-            old_ruby_version = Bundler::RubyVersion.instance_variable_get("@ruby_version")
-            Bundler::RubyVersion.remove_instance_variable("@ruby_version")
+            old_ruby_version = Bundler::RubyVersion.instance_variable_get("@system")
+            Bundler::RubyVersion.remove_instance_variable("@system")
             example.run
           ensure
-            Bundler::RubyVersion.instance_variable_set("@ruby_version", old_ruby_version)
+            Bundler::RubyVersion.instance_variable_set("@system", old_ruby_version)
           end
         else
           begin
             example.run
           ensure
-            Bundler::RubyVersion.remove_instance_variable("@ruby_version")
+            Bundler::RubyVersion.remove_instance_variable("@system")
           end
         end
       end

--- a/lib/rubygems/command_manager.rb
+++ b/lib/rubygems/command_manager.rb
@@ -84,7 +84,7 @@ class Gem::CommandManager
   # Return the authoritative instance of the command manager.
 
   def self.instance
-    @command_manager ||= new
+    @instance ||= new
   end
 
   ##
@@ -99,7 +99,7 @@ class Gem::CommandManager
   # Reset the authoritative instance of the command manager.
 
   def self.reset
-    @command_manager = nil
+    @instance = nil
   end
 
   ##

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -387,7 +387,7 @@ class Gem::Installer
   # we'll be installing into.
 
   def installed_specs
-    @specs ||= begin
+    @installed_specs ||= begin
       specs = []
 
       Gem::Util.glob_files_in_dir("*.gemspec", File.join(gem_home, "specifications")).each do |path|

--- a/lib/rubygems/request_set.rb
+++ b/lib/rubygems/request_set.rb
@@ -108,7 +108,7 @@ class Gem::RequestSet
     @requests            = []
     @sets                = []
     @soft_missing        = false
-    @sorted              = nil
+    @sorted_requests     = nil
     @specs               = nil
     @vendor_set          = nil
     @source_set          = nil
@@ -426,7 +426,7 @@ class Gem::RequestSet
   end
 
   def sorted_requests
-    @sorted ||= strongly_connected_components.flatten
+    @sorted_requests ||= strongly_connected_components.flatten
   end
 
   def specs

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2236,7 +2236,7 @@ class Gem::Specification < Gem::BasicSpecification
   # The platform this gem runs on.  See Gem::Platform for details.
 
   def platform
-    @new_platform ||= Gem::Platform::RUBY
+    @new_platform ||= Gem::Platform::RUBY # rubocop:disable Naming/MemoizedInstanceVariableName
   end
 
   def pretty_print(q) # :nodoc:
@@ -2711,6 +2711,8 @@ class Gem::Specification < Gem::BasicSpecification
     end
 
     @installed_by_version ||= nil
+
+    nil
   end
 
   def flatten_require_paths # :nodoc:

--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -182,7 +182,7 @@ class Gem::StubSpecification < Gem::BasicSpecification
   ##
   # The full Gem::Specification for this gem, loaded from evalling its gemspec
 
-  def to_spec
+  def spec
     @spec ||= if @data
       loaded = Gem.loaded_specs[name]
       loaded if loaded && loaded.version == version
@@ -190,6 +190,7 @@ class Gem::StubSpecification < Gem::BasicSpecification
 
     @spec ||= Gem::Specification.load(loaded_from)
   end
+  alias_method :to_spec, :spec
 
   ##
   # Is this StubSpecification valid? i.e. have we found a stub line, OR does

--- a/util/changelog.rb
+++ b/util/changelog.rb
@@ -39,14 +39,14 @@ end
 
 class Changelog
   def self.for_rubygems(version)
-    @rubygems ||= new(
+    @for_rubygems ||= new(
       File.expand_path("../CHANGELOG.md", __dir__),
       version,
     )
   end
 
   def self.for_bundler(version)
-    @bundler ||= new(
+    @for_bundler ||= new(
       File.expand_path("../bundler/CHANGELOG.md", __dir__),
       version,
     )

--- a/util/release.rb
+++ b/util/release.rb
@@ -47,7 +47,7 @@ class Release
     end
 
     def previous_version
-      @latest_release ||= latest_release.tag_name.gsub(/^#{@tag_prefix}/, "")
+      @previous_version ||= latest_release.tag_name.gsub(/^#{@tag_prefix}/, "")
     end
 
     def latest_release


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

It is followup of https://github.com/rubygems/rubygems/pull/6420 to make it easier to prevent similar problems in the future.

## What is your fix for the problem, implemented in this PR?

Onboard related Rubocop rule with two exceptions.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)