### PR TITLE
Changelogs for RubyGems 3.4.10 and Bundler 2.4.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.4.10 / 2023-03-27
+
+## Enhancements:
+
+* Installs bundler 2.4.10 as a default gem.
+
 # 3.4.9 / 2023-03-20
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 2.4.10 (March 27, 2023)
+
+## Bug fixes:
+
+  - Fix some unnecessary top level dependency downgrades [#6535](https://github.com/rubygems/rubygems/pull/6535)
+  - Fix incorrect ruby platform removal from lockfile when adding Gemfile dependencies [#6540](https://github.com/rubygems/rubygems/pull/6540)
+  - Fix installing plugins in frozen mode [#6543](https://github.com/rubygems/rubygems/pull/6543)
+  - Restore "enumerability" of `SpecSet` [#6532](https://github.com/rubygems/rubygems/pull/6532)
+
 # 2.4.9 (March 20, 2023)
 
 ## Security:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.4.10 and Bundler 2.4.10 into master.