### PR TITLE
[CI] Fix mswin daily-rubygems

### DIFF
--- a/.github/workflows/daily-rubygems.yml
+++ b/.github/workflows/daily-rubygems.yml
@@ -3,6 +3,7 @@ name: daily-rubygems
 on:
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -19,7 +20,7 @@ jobs:
         ruby: [ ruby-head, truffleruby-head ]
         cargo: [ stable ]
         include:
-          - { os: windows-2022, ruby: mswin, cargo: stable-x86_64-pc-windows-gnu }
+          - { os: windows-2022, ruby: mswin, cargo: stable-x86_64-pc-windows-msvc }
     env:
       TRUFFLERUBYOPT: "--experimental-options --testing-rubygems"
     steps:


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The daily-rubygems workflow has been failing for quite a while, most often with the `mswin` job..

## What is your fix for the problem, implemented in this PR?

On Windows, many tools have have two or more 'types' available, as several compilers can be used.

Re Rust, when using mingw or ucrt Windows Rubies, `stable-x86_64-pc-windows-gnu` should be used.  These are compiled with the MSYS2 toolchains.

When using a mswin WIndows Ruby, `stable-x86_64-pc-windows-msvc`.  This is compiled with MSVC (Microsoft Visual C).

PR changes to the correct type.  Ran the workflow in my fork, and it passed.  See https://github.com/MSP-Greg/rubygems/actions/runs/4519727860.

Also, I added `workflow_dispatch` to the workflow. Since it's a cron workflow, there is no way to force CI to run...

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
