### PR TITLE
Use append_cflags instead of directly append for CFLAGS

### DIFF
--- a/bundler/lib/bundler/templates/newgem/ext/newgem/extconf-c.rb.tt
+++ b/bundler/lib/bundler/templates/newgem/ext/newgem/extconf-c.rb.tt
@@ -5,6 +5,6 @@ require "mkmf"
 # Makes all symbols private by default to avoid unintended conflict
 # with other gems. To explicitly export symbols you can use RUBY_FUNC_EXPORTED
 # selectively, or entirely remove this flag.
-$CFLAGS << " -fvisibility=hidden "
+append_cflags("-fvisibility=hidden")
 
 create_makefile(<%= config[:makefile_path].inspect %>)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Apply by [nobu's suggestion]( https://github.com/rubygems/rubygems/pull/6541/files/449624aa5498674f1b88a36523f1c2576220ebf3#r1148549073)

## What is your fix for the problem, implemented in this PR?

Use `append_cflags` instead of `$CFLAGS <<`

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
